### PR TITLE
Ports: Format patches without numbering, commit hash or version number

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -834,7 +834,7 @@ do_dev() {
     if [ "$first_hash" != "$current_hash" ]; then
         >&2 echo "Note: Regenerating patches as there are some commits in the port repo (started at $first_hash, now is $current_hash)"
         rm -fr patches/*.patch
-        git -C "$git_repo" format-patch "$first_hash" -o "$(realpath patches)"
+        git -C "$git_repo" format-patch --no-numbered --zero-commit --no-signature "$first_hash" -o "$(realpath patches)"
         do_generate_patch_readme
     fi
 }

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -824,7 +824,9 @@ do_dev() {
 
     local first_hash="$(git -C "$git_repo" rev-list --max-parents=0 HEAD)"
 
+    pushd "$workdir"
     launch_user_shell
+    popd >/dev/null 2>&1
 
     local current_hash="$(git -C "$git_repo" rev-parse HEAD)"
 

--- a/Ports/Another-World/patches/0001-Skip-using-find_package-for-SDL2.patch
+++ b/Ports/Another-World/patches/0001-Skip-using-find_package-for-SDL2.patch
@@ -1,4 +1,4 @@
-From a85ea6751a9628b9a6ff3caede0a1365490d3cec Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Pavel Safar <safar.pavel@gmail.com>
 Date: Mon, 7 Jun 2021 14:26:26 +0200
 Subject: [PATCH] Skip using find_package() for SDL2
@@ -24,6 +24,3 @@ index 38f6ba8..d0d8463 100644
 +target_link_libraries(raw SDL2)
  target_link_libraries(raw z)
  
--- 
-2.36.1
-

--- a/Ports/RetroArch/patches/0001-Add-SerenityOS-platform.patch
+++ b/Ports/RetroArch/patches/0001-Add-SerenityOS-platform.patch
@@ -1,7 +1,7 @@
-From 53eae76554d4e4629fc1568cec785b644bde1f86 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: gouchi <gouchi@free.fr>
 Date: Sat, 7 May 2022 18:19:42 +0200
-Subject: [PATCH 1/6] Add SerenityOS platform
+Subject: [PATCH] Add SerenityOS platform
 
 ---
  qb/qb.system.sh | 5 +++--
@@ -27,6 +27,3 @@ index c7ac141..f7f198d 100644
  		*) OS="Win32";;
  	esac
  fi
--- 
-2.36.0
-

--- a/Ports/RetroArch/patches/0002-Find-libgl.patch
+++ b/Ports/RetroArch/patches/0002-Find-libgl.patch
@@ -1,7 +1,7 @@
-From d65b301e331c52fd78a1b0205e4b3630a6200950 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: gouchi <gouchi@free.fr>
 Date: Sat, 7 May 2022 18:20:09 +0200
-Subject: [PATCH 2/6] Find libgl
+Subject: [PATCH] Find libgl
 
 ---
  qb/config.libs.sh | 2 +-
@@ -20,6 +20,3 @@ index 19cd2a6..672fb02 100644
     fi
  
     if [ "$HAVE_OPENGL" = 'yes' ]; then
--- 
-2.36.0
-

--- a/Ports/RetroArch/patches/0003-Add-strlcat.patch
+++ b/Ports/RetroArch/patches/0003-Add-strlcat.patch
@@ -1,7 +1,7 @@
-From 05fc282bdbe985fb77d746003ce213012a0292f8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: gouchi <gouchi@free.fr>
 Date: Sat, 7 May 2022 18:20:35 +0200
-Subject: [PATCH 3/6] Add strlcat()
+Subject: [PATCH] Add strlcat()
 
 ---
  Makefile.common | 4 ++++
@@ -22,6 +22,3 @@ index 580beba..dbfbd39 100644
  ifeq ($(HAVE_UNIX), 1)
     OBJ += frontend/drivers/platform_unix.o
  
--- 
-2.36.0
-

--- a/Ports/RetroArch/patches/0004-Disable-pthread_attr_setschedpolicy.patch
+++ b/Ports/RetroArch/patches/0004-Disable-pthread_attr_setschedpolicy.patch
@@ -1,7 +1,7 @@
-From 365f17fb8bb303608d351f3a91219256746cdc60 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: gouchi <gouchi@free.fr>
 Date: Sat, 7 May 2022 18:20:52 +0200
-Subject: [PATCH 4/6] Disable pthread_attr_setschedpolicy()
+Subject: [PATCH] Disable pthread_attr_setschedpolicy()
 
 ---
  libretro-common/rthreads/rthreads.c | 2 +-
@@ -20,6 +20,3 @@ index 30ec6ff..08c8a96 100644
  #define HAVE_THREAD_ATTR
  #endif
  
--- 
-2.36.0
-

--- a/Ports/RetroArch/patches/0005-Use-SDL-software-instead-of-hardware-rendering.patch
+++ b/Ports/RetroArch/patches/0005-Use-SDL-software-instead-of-hardware-rendering.patch
@@ -1,7 +1,7 @@
-From 8494fc6dbd6abc799a2eb02933103361ea0202b0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: gouchi <gouchi@free.fr>
 Date: Sat, 7 May 2022 18:21:50 +0200
-Subject: [PATCH 5/6] Use SDL software instead of hardware rendering
+Subject: [PATCH] Use SDL software instead of hardware rendering
 
 ---
  gfx/drivers/sdl2_gfx.c | 2 +-
@@ -20,6 +20,3 @@ index 4dbe33f..dd67b4a 100644
  
     if (vid->video.vsync)
        flags |= SDL_RENDERER_PRESENTVSYNC;
--- 
-2.36.0
-

--- a/Ports/RetroArch/patches/0006-Set-default-options-for-SerenityOS.patch
+++ b/Ports/RetroArch/patches/0006-Set-default-options-for-SerenityOS.patch
@@ -1,9 +1,9 @@
-From 53b20c98eed2b0ac68ad733c18b45da1bcbc771e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: gouchi <gouchi@free.fr>
 Date: Sat, 7 May 2022 18:26:21 +0200
-Subject: [PATCH 6/6] Set default options for SerenityOS
+Subject: [PATCH] Set default options for SerenityOS
 
-Set Libretro cores path to `/usr/lib/libretro`
+Set libretro cores path to `/usr/lib/libretro`
 Set video and audio driver to sdl2
 Disable vsync
 The libretro core won't keep running in the background when we are in the menu.
@@ -1055,6 +1055,3 @@ index 0000000..088e883
 +content_favorites_path = "~/.config/retroarch/content_favorites.lpl"
 +log_dir = "~/.config/retroarch/logs"
 +video_layout_directory = "~/.config/retroarch/layouts"
--- 
-2.36.0
-

--- a/Ports/SDL2-GNUBoy/patches/0001-Rewrite-the-makefile-for-serenity.patch
+++ b/Ports/SDL2-GNUBoy/patches/0001-Rewrite-the-makefile-for-serenity.patch
@@ -1,4 +1,4 @@
-From 0b3d749c08bada65bc6868befe6c7190c2caf32b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Sun, 15 May 2022 17:39:49 +0430
 Subject: [PATCH] Rewrite the makefile for serenity
@@ -88,6 +88,3 @@ index 8730b6c..bc1fefb 100644
 -	rm -f *gnuboy sdl2gnuboy.exe mac-sdl2gnuboy gmon.out *.o sys/*.o lib/*/*.o sys/*/*.o src/*.o
 \ No newline at end of file
 +	rm -f *gnuboy sdl2gnuboy.exe gmon.out *.o sys/*.o sys/*/*.o $(OBJS)
--- 
-2.36.1
-

--- a/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
+++ b/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
@@ -1,7 +1,7 @@
-From f9447fa6782eef2c4791c963cedf469d9062c792 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andreas Kling <kling@serenityos.org>
 Date: Sat, 27 Mar 2021 22:05:09 +0100
-Subject: [PATCH 1/2] Add SerenityOS platform support
+Subject: [PATCH] Add SerenityOS platform support
 
 Co-Authored-By: Robin Burchell <robin+git@viroteck.net>
 Co-Authored-By: tgsm <doodrabbit@hotmail.com>
@@ -1704,6 +1704,3 @@ index 0000000..b5c6759
 +#endif /* SDL_serenityvideo_h_ */
 +
 +/* vi: set ts=4 sw=4 expandtab: */
--- 
-2.36.1
-

--- a/Ports/SDL2/patches/0002-Make-sdl2-config-prefixes-configurable-again.patch
+++ b/Ports/SDL2/patches/0002-Make-sdl2-config-prefixes-configurable-again.patch
@@ -1,7 +1,7 @@
-From a788810465ed48f0c80494a463a89eec262acd60 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sat, 21 May 2022 23:33:31 +0200
-Subject: [PATCH 2/2] Make sdl2-config prefixes configurable again
+Subject: [PATCH] Make sdl2-config prefixes configurable again
 
 These were accidentally removed in
 6956f4aa1982b66b234026b46f7bb2dd44c67894.
@@ -26,6 +26,3 @@ index 2400d53..7a55d25 100644
    if(SDL_STATIC)
      set(ENABLE_STATIC_TRUE "")
      set(ENABLE_STATIC_FALSE "#")
--- 
-2.36.1
-

--- a/Ports/SDL2_gfx/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/SDL2_gfx/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From 0f827bb1e7e70c292982d68d1be79c0c64317333 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index ddcc961..4767551 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/SDL2_image/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/SDL2_image/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From 1f0f0c7055a0f2556d9094b5d1c13381541c00bd Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index 7eb305d..4299214 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/SDL2_mixer/patches/0001-Skip-building-the-playmus-and-playwav-utilities.patch
+++ b/Ports/SDL2_mixer/patches/0001-Skip-building-the-playmus-and-playwav-utilities.patch
@@ -1,7 +1,7 @@
-From 45c3472482141099e7a14fa67c159b0dcd4164da Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andreas Kling <kling@serenityos.org>
 Date: Mon, 8 Mar 2021 13:15:35 +0100
-Subject: [PATCH 1/2] Skip building the playmus and playwav utilities
+Subject: [PATCH] Skip building the playmus and playwav utilities
 
 ---
  Makefile.in | 14 ++------------
@@ -60,6 +60,3 @@ index 2ff24b2..0e120a1 100644
  
  clean:
  	rm -rf $(objects)
--- 
-2.36.1
-

--- a/Ports/SDL2_mixer/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/SDL2_mixer/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,7 +1,7 @@
-From 2bc8e2c1b321c59ef39c7dbe95871f0f08d1d139 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
-Subject: [PATCH 2/2] libtool: Enable shared library support for SerenityOS
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
 
 For some odd reason, libtool handles the configuration for shared
 libraries entirely statically and in its configure script. If no
@@ -71,6 +71,3 @@ index 4df0be5..9a5f606 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/SDL2_net/patches/0001-Undefine-SIOCGIFCONF-on-serenity.patch
+++ b/Ports/SDL2_net/patches/0001-Undefine-SIOCGIFCONF-on-serenity.patch
@@ -1,7 +1,7 @@
-From 1e79dfd03eeaf33b9249b2a74a9dede5c5da3a59 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Wed, 16 Jun 2021 11:08:32 +0200
-Subject: [PATCH 1/3] Undefine 'SIOCGIFCONF' on serenity
+Subject: [PATCH] Undefine 'SIOCGIFCONF' on serenity
 
 FIXME: We don't know why yet.
 ---
@@ -23,6 +23,3 @@ index 53d125a..87eab4c 100644
  int SDLNet_GetLocalAddresses(IPaddress *addresses, int maxcount)
  {
      int count = 0;
--- 
-2.36.1
-

--- a/Ports/SDL2_net/patches/0002-Include-sys-select.h.patch
+++ b/Ports/SDL2_net/patches/0002-Include-sys-select.h.patch
@@ -1,7 +1,7 @@
-From ef51fb40f756e2d7a7de4d285590305c782ba9b7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Wed, 16 Jun 2021 11:08:32 +0200
-Subject: [PATCH 2/3] Include sys/select.h
+Subject: [PATCH] Include sys/select.h
 
 ---
  SDLnetsys.h | 1 +
@@ -19,6 +19,3 @@ index 6f6dfae..bd9139d 100644
  #ifdef __FreeBSD__
  #include <sys/socket.h>
  #endif
--- 
-2.36.1
-

--- a/Ports/SDL2_net/patches/0003-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/SDL2_net/patches/0003-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,7 +1,7 @@
-From 3986e0cc88c73b1ecb21b831f807333e1c46dad7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
-Subject: [PATCH 3/3] libtool: Enable shared library support for SerenityOS
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
 
 For some odd reason, libtool handles the configuration for shared
 libraries entirely statically and in its configure script. If no
@@ -89,6 +89,3 @@ index 8c1d2d4..8ea327f 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/SDL2_ttf/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/SDL2_ttf/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From 1aec7f15c8d70f249b051a65823215c382fa0498 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -89,6 +89,3 @@ index 02724d0..fec4760 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/SDLPoP/patches/0001-Disable-some-extra-features.patch
+++ b/Ports/SDLPoP/patches/0001-Disable-some-extra-features.patch
@@ -1,7 +1,7 @@
-From 79a5522062cf03b1f7dc878799c66389e689b1d5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Manuel Palenzuela <manuelpalenzuelamerino@gmail.com>
 Date: Sat, 3 Apr 2021 17:53:44 +0200
-Subject: [PATCH 1/4] Disable some extra features
+Subject: [PATCH] Disable some extra features
 
 This just disables some extra features the game has such as screenshots, hardware acceleration, etc.
 ---
@@ -95,6 +95,3 @@ index 698e7ed..0a935ee 100644
  
  // Speed up the sound during fast forward using resampling.
  // If disabled, the sound is sped up by clipping out parts from it.
--- 
-2.36.1
-

--- a/Ports/SDLPoP/patches/0002-Use-the-correct-include-paths-for-SDL.patch
+++ b/Ports/SDLPoP/patches/0002-Use-the-correct-include-paths-for-SDL.patch
@@ -1,7 +1,7 @@
-From d352df3380953ce7acb34aa26dc3b343853c32df Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gunnar@beutner.name>
 Date: Mon, 19 Apr 2021 16:17:10 +0200
-Subject: [PATCH 2/4] Use the correct include paths for SDL
+Subject: [PATCH] Use the correct include paths for SDL
 
 The SDL port is installed into /usr/local, and its headers are
 accessible as <SDL2/...>.
@@ -24,6 +24,3 @@ index 1f696d1..b5ede07 100644
  //#endif
  
  #if SDL_BYTEORDER != SDL_LIL_ENDIAN
--- 
-2.36.1
-

--- a/Ports/SDLPoP/patches/0003-Remove-some-unsupported-scanf-format-specifiers.patch
+++ b/Ports/SDLPoP/patches/0003-Remove-some-unsupported-scanf-format-specifiers.patch
@@ -1,7 +1,7 @@
-From 4776a79fcc39601e79b79909f1fa3c69a42d958c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Manuel Palenzuela <manuelpalenzuelamerino@gmail.com>
 Date: Sat, 3 Apr 2021 17:53:44 +0200
-Subject: [PATCH 3/4] Remove some unsupported scanf format specifiers
+Subject: [PATCH] Remove some unsupported scanf format specifiers
 
 (Note that scanf has been rewritten since and probably supports these
 modifiers now, so this patch might not be necessary)
@@ -47,6 +47,3 @@ index 139c2d8..e2047fb 100644
  			perror(names_path);
  			continue;
  		}
--- 
-2.36.1
-

--- a/Ports/SDLPoP/patches/0004-Fix-SDL2-include-path.patch
+++ b/Ports/SDLPoP/patches/0004-Fix-SDL2-include-path.patch
@@ -1,7 +1,7 @@
-From ddde9196a6a165ff06ac725c567f7e9aebe1d4a8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gunnar@beutner.name>
 Date: Mon, 19 Apr 2021 16:17:10 +0200
-Subject: [PATCH 4/4] Fix SDL2 include path
+Subject: [PATCH] Fix SDL2 include path
 
 SDL2 headers are installed into /usr/local under SDL2, make it so
 they're found.
@@ -26,6 +26,3 @@ index 3558a6c..d074e48 100644
      link_directories(${SDL2}/lib)
  endif()
  
--- 
-2.36.1
-

--- a/Ports/SDL_mixer/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/SDL_mixer/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From bdb6569ba8bcc1332ee220b3128e94c8c69d47f7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -17,7 +17,7 @@ static library into a shared library.
  1 file changed, 23 insertions(+)
 
 diff --git a/configure b/configure
-index e7c8c97..37ef6b5 100755
+index e7c8c97..c8a27a7 100755
 --- a/configure
 +++ b/configure
 @@ -4244,6 +4244,10 @@ sysv4 | sysv4.3*)
@@ -71,6 +71,3 @@ index e7c8c97..37ef6b5 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/SDL_sound/patches/0001-Use-pkgconfig-to-find-SDL2.patch
+++ b/Ports/SDL_sound/patches/0001-Use-pkgconfig-to-find-SDL2.patch
@@ -1,4 +1,4 @@
-From 1a5d08869b8084f5fdc3442c4b4ed237b7c7cf29 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: xSlendiX <gamingxslendix@gmail.com>
 Date: Sun, 19 Sep 2021 22:46:10 +0300
 Subject: [PATCH] Use pkgconfig to find SDL2
@@ -23,6 +23,3 @@ index c1b9241..a659246 100644
  include_directories(${SDL2_INCLUDE_DIRS} ${SDL2_INCLUDE_DIR})
  if(WIN32)
      # -lmingw32: gcc adds it automatically.
--- 
-2.36.1
-

--- a/Ports/Super-Mario/patches/0001-chdir-to-the-installed-directory-before-execution.patch
+++ b/Ports/Super-Mario/patches/0001-chdir-to-the-installed-directory-before-execution.patch
@@ -1,7 +1,7 @@
-From c7869092a313c1550a34675d1c9faebc1468ef1e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Fri, 4 Jun 2021 00:29:36 +0200
-Subject: [PATCH 1/5] chdir() to the installed directory before execution
+Subject: [PATCH] chdir() to the installed directory before execution
 
 The game expects its assets in the current directory, but we install
 those to /opt/Super_Mario, so chdir() there at program startup to avoid
@@ -32,6 +32,3 @@ index 040eb56..ca14d6f 100644
      
      return 0;
  }
--- 
-2.36.1
-

--- a/Ports/Super-Mario/patches/0002-Disable-graphics-acceleration.patch
+++ b/Ports/Super-Mario/patches/0002-Disable-graphics-acceleration.patch
@@ -1,7 +1,7 @@
-From 4a8e24e824e0de7557ae15414d30a1b49d14ce0d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Manuel Palenzuela <manuelpalenzuelamerino@gmail.com>
 Date: Sun, 4 Apr 2021 00:41:48 +0200
-Subject: [PATCH 2/5] Disable graphics acceleration
+Subject: [PATCH] Disable graphics acceleration
 
 Disables SDL2 hardware acceleration as we don't support that.
 ---
@@ -28,6 +28,3 @@ index c04581b..f0c0308 100644
 -}
 \ No newline at end of file
 +}
--- 
-2.36.1
-

--- a/Ports/Super-Mario/patches/0003-Use-pkgconfig-instead-of-find_package-to-look-for-de.patch
+++ b/Ports/Super-Mario/patches/0003-Use-pkgconfig-instead-of-find_package-to-look-for-de.patch
@@ -1,7 +1,7 @@
-From a780c6ee085103b0d3ffa39e0162ddd1848068bb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Manuel Palenzuela <manuelpalenzuelamerino@gmail.com>
 Date: Sun, 4 Apr 2021 00:41:48 +0200
-Subject: [PATCH 3/5] Use pkgconfig instead of find_package() to look for
+Subject: [PATCH] Use pkgconfig instead of find_package() to look for
  dependencies
 
 ---
@@ -38,6 +38,3 @@ index 616d876..d1aa020 100644
 +target_link_libraries(uMario ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES} ${SDL2_MIXER_LIBRARIES}-lSDL2_mixer -lpthread -lm -lgfx -lgui -lipc -lcore)
  
  install(TARGETS uMario RUNTIME DESTINATION ${BIN_DIR})
--- 
-2.36.1
-

--- a/Ports/Super-Mario/patches/0004-Fix-a-header-include-path.patch
+++ b/Ports/Super-Mario/patches/0004-Fix-a-header-include-path.patch
@@ -1,7 +1,7 @@
-From 452f2ace4ba87e7d2e07a46adf4abdfb8970317d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Manuel Palenzuela <manuelpalenzuelamerino@gmail.com>
 Date: Sun, 4 Apr 2021 00:41:48 +0200
-Subject: [PATCH 4/5] Fix a header include path
+Subject: [PATCH] Fix a header include path
 
 ---
  src/FireBall.cpp | 4 ++--
@@ -45,6 +45,3 @@ index b812b49..f6abbb9 100644
 -#endif
 \ No newline at end of file
 +#endif
--- 
-2.36.1
-

--- a/Ports/Super-Mario/patches/0005-Remove-global-static-initializers.patch
+++ b/Ports/Super-Mario/patches/0005-Remove-global-static-initializers.patch
@@ -1,7 +1,7 @@
-From e9d588e7519a15003ded6b68ed7fa10dbe0f8f11 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Thu, 29 Apr 2021 07:36:37 +0200
-Subject: [PATCH 5/5] Remove global static initializers
+Subject: [PATCH] Remove global static initializers
 
 ---
  src/CFG.cpp | 16 ++++++++++++----
@@ -54,6 +54,3 @@ index 90595a5..20dd6ea 100644
  	return tSMBLOGO;
  }
  
--- 
-2.36.1
-

--- a/Ports/acpica-tools/patches/0001-Stop-compiler-warnings-on-dangling-pointer.patch
+++ b/Ports/acpica-tools/patches/0001-Stop-compiler-warnings-on-dangling-pointer.patch
@@ -1,7 +1,7 @@
-From d8b37ad7569de3883ae7d40eb55d3b2fdd763d35 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Liav A <liavalb@gmail.com>
 Date: Fri, 27 May 2022 10:18:35 +0300
-Subject: [PATCH 1/3] Stop compiler warnings on dangling pointer
+Subject: [PATCH] Stop compiler warnings on dangling pointer
 
 Use static variable to prevent using a dangling pointer from a previous
 stack trace.
@@ -22,6 +22,3 @@ index f789e68..fd18f5c 100644
  
  
      AcpiGbl_EntryStackPointer = &CurrentSp;
--- 
-2.36.1
-

--- a/Ports/acpica-tools/patches/0002-Disable-sprintf-debug-message-with-formatting-issues.patch
+++ b/Ports/acpica-tools/patches/0002-Disable-sprintf-debug-message-with-formatting-issues.patch
@@ -1,7 +1,7 @@
-From a8a2509d9e9a0eb293747fa44a63dd899077db98 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Liav A <liavalb@gmail.com>
 Date: Fri, 27 May 2022 10:19:35 +0300
-Subject: [PATCH 2/3] Disable sprintf debug message with formatting issues
+Subject: [PATCH] Disable sprintf debug message with formatting issues
 
 ---
  source/compiler/dtfield.c | 6 +++---
@@ -24,6 +24,3 @@ index f931631..f9fb310 100644
          DtError (ASL_ERROR, ASL_MSG_STRING_LENGTH, Field, AslGbl_MsgBuffer);
          Length = ByteLength;
      }
--- 
-2.36.1
-

--- a/Ports/acpica-tools/patches/0003-Fix-printf-bad-specifier-formatting.patch
+++ b/Ports/acpica-tools/patches/0003-Fix-printf-bad-specifier-formatting.patch
@@ -1,7 +1,7 @@
-From 85ad6c144eb08d3cd94a4b28ac57e46df9f9c497 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Liav A <liavalb@gmail.com>
 Date: Fri, 27 May 2022 22:00:38 +0300
-Subject: [PATCH 3/3] Fix printf bad specifier formatting
+Subject: [PATCH] Fix printf bad specifier formatting
 
 Fix sprintf specifier being written in a bad format leading to iASL to
 crash.
@@ -31,6 +31,3 @@ index 440c5fb..d722e3d 100644
                  Name, Value);
          }
      }
--- 
-2.36.1
-

--- a/Ports/angband/patches/0001-Disable-hardware-acceleration.patch
+++ b/Ports/angband/patches/0001-Disable-hardware-acceleration.patch
@@ -1,7 +1,7 @@
-From 03f7c6e9c77b5084fd5a2b32b3c6f13c152a52b5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 17 Oct 2021 15:44:23 +0200
-Subject: [PATCH 1/2] Disable hardware acceleration
+Subject: [PATCH] Disable hardware acceleration
 
 We don't support this, so disable it.
 ---
@@ -32,6 +32,3 @@ index a678c29..51a343c 100644
  		window->config->renderer_flags = SDL_RENDERER_SOFTWARE;
  	} else {
  		return PARSE_ERROR_INVALID_VALUE;
--- 
-2.36.1
-

--- a/Ports/angband/patches/0002-Fix-up-SDL-path-handling.patch
+++ b/Ports/angband/patches/0002-Fix-up-SDL-path-handling.patch
@@ -1,7 +1,7 @@
-From dce25b95be530cb0d9c650fc93de34ac94161ee3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Wed, 6 Apr 2022 02:25:34 +0200
-Subject: [PATCH 2/2] Fix up SDL path handling
+Subject: [PATCH] Fix up SDL path handling
 
 Fix up some copy-paste and logic mistakes in the configure script that
 prevent us from setting a prefix for the SDL installation.
@@ -69,6 +69,3 @@ index c56ed42..d6e8e85 100755
  		LIBS="${LIBS} ${SDL_LIBS}"
  		if test "$enable_sdl" = "yes"; then
  			{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for IMG_LoadPNG_RW in -lSDL_image" >&5
--- 
-2.36.1
-

--- a/Ports/awk/patches/0001-Make-it-possible-to-override-HOSTCC-and-CC-from-the-.patch
+++ b/Ports/awk/patches/0001-Make-it-possible-to-override-HOSTCC-and-CC-from-the-.patch
@@ -1,7 +1,7 @@
-From 54cc5812382bc7d3b5e2d1ef0c3a18a60fa896b7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mattias Nilsson <mattias.nilsson@nshift.com>
 Date: Mon, 4 Apr 2022 22:05:38 +0200
-Subject: [PATCH 1/2] Make it possible to override HOSTCC and CC from the
+Subject: [PATCH] Make it possible to override HOSTCC and CC from the
  environment
 
 ---
@@ -23,6 +23,3 @@ index 9ceaaad..6b9dff5 100644
  
  # By fiat, to make our lives easier, yacc is now defined to be bison.
  # If you want something else, you're on your own.
--- 
-2.36.1
-

--- a/Ports/awk/patches/0002-Make-the-version-descriptor-match-the-built-tag.patch
+++ b/Ports/awk/patches/0002-Make-the-version-descriptor-match-the-built-tag.patch
@@ -1,7 +1,7 @@
-From 8228e4130e9c373b24f87458bc7248272146bbac Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mattias Nilsson <mattias.nilsson@nshift.com>
 Date: Mon, 4 Apr 2022 22:05:38 +0200
-Subject: [PATCH 2/2] Make the version descriptor match the built tag
+Subject: [PATCH] Make the version descriptor match the built tag
 
 ---
  main.c | 2 +-
@@ -20,6 +20,3 @@ index 986f1a3..e22f097 100644
  
  #define DEBUG
  #include <stdio.h>
--- 
-2.36.1
-

--- a/Ports/bash/patches/0001-accept.c-Include-sys-select.h.patch
+++ b/Ports/bash/patches/0001-accept.c-Include-sys-select.h.patch
@@ -1,4 +1,4 @@
-From 90287ce0f011bb46c082a5e176114c831a6f32e1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke <luke.wilde@live.co.uk>
 Date: Fri, 14 Jan 2022 16:43:10 +0330
 Subject: [PATCH] accept.c: Include sys/select.h
@@ -21,6 +21,3 @@ index 54cf38c..fd8e7ed 100644
  
  #include "loadables.h"
  
--- 
-2.34.1
-

--- a/Ports/bdwgc/patches/0001-Teach-os_dep-and-gcconfig.h-about-serenity.patch
+++ b/Ports/bdwgc/patches/0001-Teach-os_dep-and-gcconfig.h-about-serenity.patch
@@ -1,7 +1,7 @@
-From a866ef2debf6c1639d14e6990be440614dce9a56 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Thu, 24 Feb 2022 01:00:57 +0330
-Subject: [PATCH 1/7] Teach os_dep and gcconfig.h about serenity
+Subject: [PATCH] Teach os_dep and gcconfig.h about serenity
 
 ---
  include/private/gcconfig.h | 48 +++++++++++++++++++++++++++++++++++---
@@ -210,6 +210,3 @@ index b183423..a6d62b9 100644
  #     define CODE_OK TRUE
  #   elif defined(LINUX)
  #     define CODE_OK TRUE
--- 
-2.36.1
-

--- a/Ports/bdwgc/patches/0002-Error-on-unknown-arch.patch
+++ b/Ports/bdwgc/patches/0002-Error-on-unknown-arch.patch
@@ -1,7 +1,7 @@
-From ae7f99f75b0957d62364a19e9a75e74e2ef9bd8d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Thu, 24 Feb 2022 01:50:40 +0330
-Subject: [PATCH 2/7] Error on unknown arch
+Subject: [PATCH] Error on unknown arch
 
 ---
  include/private/gcconfig.h | 2 ++
@@ -20,6 +20,3 @@ index e9d1d42..8e48b66 100644
  #    endif
  #endif
  # if defined(__HAIKU__) && (defined(__amd64__) || defined(__x86_64__))
--- 
-2.36.1
-

--- a/Ports/bdwgc/patches/0003-Teach-dyn_load.c-about-serenity.patch
+++ b/Ports/bdwgc/patches/0003-Teach-dyn_load.c-about-serenity.patch
@@ -1,7 +1,7 @@
-From 1f1a8460083486969fd81d0e1bf74fff4fe18e3d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Thu, 24 Feb 2022 01:54:50 +0330
-Subject: [PATCH 3/7] Teach dyn_load.c about serenity
+Subject: [PATCH] Teach dyn_load.c about serenity
 
 ---
  dyn_load.c | 23 ++++++++++++++++++++---
@@ -62,6 +62,3 @@ index d857246..734643d 100644
      || (defined(__ELF__) && (defined(LINUX) || defined(FREEBSD) \
                               || defined(NACL) || defined(NETBSD) \
                               || defined(OPENBSD)))
--- 
-2.36.1
-

--- a/Ports/bdwgc/patches/0004-Teach-bdwgc-about-serenity-signals.patch
+++ b/Ports/bdwgc/patches/0004-Teach-bdwgc-about-serenity-signals.patch
@@ -1,7 +1,7 @@
-From de33591aec7243f14206913f8188519744714389 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Thu, 24 Feb 2022 03:30:02 +0330
-Subject: [PATCH 4/7] Teach bdwgc about serenity signals
+Subject: [PATCH] Teach bdwgc about serenity signals
 
 Serenity doesn't have the realtime POSIX signals, so use SIGXCPU and
 SIGXFSZ instead.
@@ -61,6 +61,3 @@ index 4b2c429..25eb2a5 100644
       || defined(GC_NETBSD_THREADS) || defined(GC_USESIGRT_SIGNALS)
  #   if defined(_SIGRTMIN) && !defined(CPPCHECK)
  #     define SIG_THR_RESTART _SIGRTMIN + 5
--- 
-2.36.1
-

--- a/Ports/bdwgc/patches/0005-Explicitly-link-with-pthread.patch
+++ b/Ports/bdwgc/patches/0005-Explicitly-link-with-pthread.patch
@@ -1,7 +1,7 @@
-From 55a28f3dbf0ddcf24077281e38ba7bc7904308d6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Thu, 24 Feb 2022 03:47:50 +0330
-Subject: [PATCH 5/7] Explicitly link with pthread
+Subject: [PATCH] Explicitly link with pthread
 
 The cmakelists was using the wrong variable to link against pthread.
 ---
@@ -68,6 +68,3 @@ index 3c84220..5e15727 100644
 -TARGET_LINK_LIBRARIES(smashtest gc-lib)
 +TARGET_LINK_LIBRARIES(smashtest gc-lib ${LIBS})
  ADD_TEST(NAME smashtest COMMAND smashtest)
--- 
-2.36.1
-

--- a/Ports/bdwgc/patches/0006-Make-the-collector-build-with-threads.patch
+++ b/Ports/bdwgc/patches/0006-Make-the-collector-build-with-threads.patch
@@ -1,7 +1,7 @@
-From a9832f6c77e837637544926717061d00951a6321 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 25 Feb 2022 04:53:53 +0330
-Subject: [PATCH 6/7] Make the collector build with threads
+Subject: [PATCH] Make the collector build with threads
 
 In an extremely limited way for now:
 - No extra threads
@@ -47,6 +47,3 @@ index 8e2e3a6..f38fb22 100644
          /* Not respected by PCR test. */
  #endif
  
--- 
-2.36.1
-

--- a/Ports/bdwgc/patches/0007-Add-serenity-to-the-conigure-list-of-pthread-unixes.patch
+++ b/Ports/bdwgc/patches/0007-Add-serenity-to-the-conigure-list-of-pthread-unixes.patch
@@ -1,7 +1,7 @@
-From d55e0b907be765212bdd214c9b0c248646d294e8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Elliott <pelliott@ualberta.ca>
 Date: Mon, 16 May 2022 23:55:41 -0600
-Subject: [PATCH 7/7] Add serenity to the conigure list of pthread unixes
+Subject: [PATCH] Add serenity to the conigure list of pthread unixes
 
 ---
  configure.ac | 2 +-
@@ -20,6 +20,3 @@ index 3b38e6f..5b6daa4 100644
          AC_DEFINE(GC_THREADS)
          AC_DEFINE([_REENTRANT], [1],
                    [Required define if using POSIX threads.])
--- 
-2.36.1
-

--- a/Ports/bochs/patches/0001-Use-pkg-config-for-SDL2.patch
+++ b/Ports/bochs/patches/0001-Use-pkg-config-for-SDL2.patch
@@ -1,4 +1,4 @@
-From cdc23372934196e822175a6ecbd6b06aed2bcea5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Ross <pross@xvid.org>
 Date: Tue, 22 Feb 2022 18:43:09 +1100
 Subject: [PATCH] Use pkg-config for SDL2
@@ -43,6 +43,3 @@ index 5cc4088..d2bff12 100755
    fi
    # The enhanced X debugger depends on GTK2
    if test "$gui_debugger" = 1 -a "$DEFAULT_GUI" != win32; then
--- 
-2.36.1
-

--- a/Ports/brogue/patches/0001-Install-the-game-data-to-usr-local.patch
+++ b/Ports/brogue/patches/0001-Install-the-game-data-to-usr-local.patch
@@ -1,7 +1,7 @@
-From c0fa4cf699ff2f02d9f976deed689d968093313c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: nooga <xnooga@gmail.com>
 Date: Sat, 15 May 2021 01:21:59 +0200
-Subject: [PATCH 1/2] Install the game data to /usr/local
+Subject: [PATCH] Install the game data to /usr/local
 
 ---
  config.mk | 2 +-
@@ -18,6 +18,3 @@ index b33967b..9655958 100644
  
  # Include terminal support. Requires ncurses
  TERMINAL := NO
--- 
-2.36.1
-

--- a/Ports/brogue/patches/0002-Use-pkg-config-for-SDL2.patch
+++ b/Ports/brogue/patches/0002-Use-pkg-config-for-SDL2.patch
@@ -1,7 +1,7 @@
-From f74e17de5c426ae49522008cb5b5d24571345630 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: nooga <xnooga@gmail.com>
 Date: Sat, 15 May 2021 01:21:59 +0200
-Subject: [PATCH 2/2] Use pkg-config for SDL2
+Subject: [PATCH] Use pkg-config for SDL2
 
 ---
  config.mk | 2 +-
@@ -20,6 +20,3 @@ index 9655958..0ce2e55 100644
  
  # Select web brogue mode. Requires POSIX system.
  WEBBROGUE := NO
--- 
-2.36.1
-

--- a/Ports/c-ray/patches/0001-Add-a-dummy-configure-file.patch
+++ b/Ports/c-ray/patches/0001-Add-a-dummy-configure-file.patch
@@ -1,7 +1,7 @@
-From a91deb390a4765985718c4821c0306d433c036f5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Valtteri Koskivuori <vkoskiv@gmail.com>
 Date: Tue, 25 Feb 2020 22:03:47 +0200
-Subject: [PATCH 1/8] Add a dummy configure file
+Subject: [PATCH] Add a dummy configure file
 
 ---
  configure | 1 +
@@ -15,6 +15,3 @@ index 0000000..04bfb39
 +++ b/configure
 @@ -0,0 +1 @@
 +#nop
--- 
-2.36.1
-

--- a/Ports/c-ray/patches/0002-Disable-checkBuf-on-serenity.patch
+++ b/Ports/c-ray/patches/0002-Disable-checkBuf-on-serenity.patch
@@ -1,7 +1,7 @@
-From dc634f4d49c98a7c0243b568631c626cd3da4125 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Linus Groh <mail@linusgroh.de>
 Date: Sat, 13 Mar 2021 22:11:07 +0100
-Subject: [PATCH 2/8] Disable checkBuf() on serenity
+Subject: [PATCH] Disable checkBuf() on serenity
 
 Co-Authored-By: Valtteri Koskivuori <vkoskiv@gmail.com>
 ---
@@ -21,6 +21,3 @@ index 6365973..2edfed8 100644
  	fd_set set;
  	struct timeval timeout;
  	int rv;
--- 
-2.36.1
-

--- a/Ports/c-ray/patches/0003-Let-c-ray-define-its-own-version-of-vasprintf.patch
+++ b/Ports/c-ray/patches/0003-Let-c-ray-define-its-own-version-of-vasprintf.patch
@@ -1,7 +1,7 @@
-From e9b3bd5acd86ffe35b0f4e22bf615b53e0af261c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Linus Groh <mail@linusgroh.de>
 Date: Sat, 13 Mar 2021 22:11:07 +0100
-Subject: [PATCH 3/8] Let c-ray define its own version of vasprintf
+Subject: [PATCH] Let c-ray define its own version of vasprintf
 
 Co-Authored-By: Valtteri Koskivuori <vkoskiv@gmail.com>
 ---
@@ -21,6 +21,3 @@ index 70a95ac..7571e8a 100644
  int cray_vasprintf(char **strp, const char *format, va_list ap) {
  	int len = vscprintf(format, ap);
  	if (len == -1)
--- 
-2.36.1
-

--- a/Ports/c-ray/patches/0004-Link-with-the-needed-serenity-libraries.patch
+++ b/Ports/c-ray/patches/0004-Link-with-the-needed-serenity-libraries.patch
@@ -1,7 +1,7 @@
-From 031255918e1421e343aedaaeb3a71b77a01dbe60 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Linus Groh <mail@linusgroh.de>
 Date: Fri, 1 Apr 2022 01:55:25 +0200
-Subject: [PATCH 4/8] Link with the needed serenity libraries
+Subject: [PATCH] Link with the needed serenity libraries
 
 Co-Authored-By: Valtteri Koskivuori <vkoskiv@gmail.com>
 Co-Authored-By: EWouters <6179932+EWouters@users.noreply.github.com>
@@ -22,6 +22,3 @@ index 20f8440..dc254b5 100644
  endif ()
  
  include(CheckIPOSupported)
--- 
-2.36.1
-

--- a/Ports/c-ray/patches/0005-Use-usleep-on-serenity.patch
+++ b/Ports/c-ray/patches/0005-Use-usleep-on-serenity.patch
@@ -1,7 +1,7 @@
-From 2bbcdcb8ca63d8a9cf475b148f9f11f97df14c35 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Linus Groh <mail@linusgroh.de>
 Date: Sat, 13 Mar 2021 22:11:07 +0100
-Subject: [PATCH 5/8] Use usleep() on serenity
+Subject: [PATCH] Use usleep() on serenity
 
 Co-Authored-By: Valtteri Koskivuori <vkoskiv@gmail.com>
 ---
@@ -30,6 +30,3 @@ index dd83497..3a4357f 100644
  	usleep(ms * 1000);
  #endif
  }
--- 
-2.36.1
-

--- a/Ports/c-ray/patches/0006-Reduce-HDR-scene-settings-a-bit.patch
+++ b/Ports/c-ray/patches/0006-Reduce-HDR-scene-settings-a-bit.patch
@@ -1,7 +1,7 @@
-From 252852219ee147c38a885ea3f1e6118244f7f57d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Valtteri Koskivuori <vkoskiv@gmail.com>
 Date: Sat, 13 Mar 2021 22:11:07 +0100
-Subject: [PATCH 6/8] Reduce HDR scene settings a bit
+Subject: [PATCH] Reduce HDR scene settings a bit
 
 ---
  input/hdr.json | 6 +++---
@@ -31,6 +31,3 @@ index f2f45b1..b7b5b63 100644
  	},
  	"display": {
  		"isFullscreen": false,
--- 
-2.36.1
-

--- a/Ports/c-ray/patches/0007-Replace-the-micro-symbol-with-a-u.patch
+++ b/Ports/c-ray/patches/0007-Replace-the-micro-symbol-with-a-u.patch
@@ -1,7 +1,7 @@
-From bcf1e45d9975ff326d874eb60abaa148b321eb78 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Valtteri Koskivuori <vkoskiv@gmail.com>
 Date: Sat, 17 Apr 2021 08:30:03 +0000
-Subject: [PATCH 7/8] Replace the micro symbol with a 'u'
+Subject: [PATCH] Replace the micro symbol with a 'u'
 
 Co-Authored-By: Linus Groh <mail@linusgroh.de>
 Co-Authored-By: Valtteri Koskivuori <vkoskiv@gmail.com>
@@ -22,6 +22,3 @@ index fe0e44e..6e5e20f 100644
  				 KBLU,
  				 interactive ? ((float)r->state.finishedPasses / (float)r->prefs.sampleCount) * 100.0f :
  							   ((float)r->state.finishedTileCount / (float)r->state.tileCount) * 100.0f,
--- 
-2.36.1
-

--- a/Ports/c-ray/patches/0008-Make-SDL-use-software-rendering.patch
+++ b/Ports/c-ray/patches/0008-Make-SDL-use-software-rendering.patch
@@ -1,7 +1,7 @@
-From e552e1be81f8873930f3a75c051cf1efb2069b64 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Linus Groh <mail@linusgroh.de>
 Date: Sat, 13 Mar 2021 22:11:07 +0100
-Subject: [PATCH 8/8] Make SDL use software rendering
+Subject: [PATCH] Make SDL use software rendering
 
 Serenity does not support accelerated rendering
 
@@ -23,6 +23,3 @@ index 89553c7..4a52e6c 100644
  	if (gdisplay->renderer == NULL) {
  		logr(warning, "Renderer couldn't be created, error: \"%s\"\n", SDL_GetError());
  		destroyDisplay();
--- 
-2.36.1
-

--- a/Ports/ccache/patches/0001-Do-not-define-ESTALE-in-config.h.in.patch
+++ b/Ports/ccache/patches/0001-Do-not-define-ESTALE-in-config.h.in.patch
@@ -1,4 +1,4 @@
-From 0bbcd79078f4d8cb88c1738c6aae1bcc705f3ceb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: SeekingBlues <seekingblues@gmail.com>
 Date: Fri, 3 Jun 2022 16:05:10 -0500
 Subject: [PATCH] Do not define ESTALE in config.h.in
@@ -27,6 +27,3 @@ index 729a1d4..8aa07ca 100644
  #define SYSCONFDIR "@CMAKE_INSTALL_FULL_SYSCONFDIR@"
  
  #cmakedefine INODE_CACHE_SUPPORTED
--- 
-2.36.1
-

--- a/Ports/cfunge/patches/0001-Tell-prng.c-that-we-don-t-have-arc4random_buf.patch
+++ b/Ports/cfunge/patches/0001-Tell-prng.c-that-we-don-t-have-arc4random_buf.patch
@@ -1,7 +1,7 @@
-From 06224692b112908e3cc13dcdb1b2c2037849d30c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tobias Christiansen <tobyase@serenityos.org>
 Date: Thu, 24 Mar 2022 15:41:48 +0100
-Subject: [PATCH 1/4] Tell prng.c that we don't have arc4random_buf
+Subject: [PATCH] Tell prng.c that we don't have arc4random_buf
 
 FIXME: This function does exist, perhaps outdated or some issue -
        explain the issue here if so.
@@ -21,6 +21,3 @@ index 004906d..d73b05c 100644
  #ifdef HAVE_arc4random_buf
  #  define HAVE_ARC4RANDOM
  #  ifndef ARC4RANDOM_IN_BSD
--- 
-2.36.1
-

--- a/Ports/cfunge/patches/0002-Define-MAX-inline-instead-of-using-sys-param.h.patch
+++ b/Ports/cfunge/patches/0002-Define-MAX-inline-instead-of-using-sys-param.h.patch
@@ -1,7 +1,7 @@
-From 8e430a265acf87063fff9b00b18dff91c4a6f073 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tobias Christiansen <tobyase@serenityos.org>
 Date: Thu, 24 Mar 2022 15:41:48 +0100
-Subject: [PATCH 2/4] Define MAX inline instead of using sys/param.h
+Subject: [PATCH] Define MAX inline instead of using sys/param.h
 
 ---
  lib/fungestring/funge_str-two-way.h | 2 +-
@@ -20,6 +20,3 @@ index 70295f4..a3e0888 100644
  
  /* We use the Two-Way string matching algorithm, which guarantees
     linear complexity with constant space.  Additionally, for long
--- 
-2.36.1
-

--- a/Ports/cfunge/patches/0003-define-_POSIX_MAPPED_FILES.patch
+++ b/Ports/cfunge/patches/0003-define-_POSIX_MAPPED_FILES.patch
@@ -1,7 +1,7 @@
-From 2ef179368040355b7a99d3a55c9defdc162baa32 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tobias Christiansen <tobyase@serenityos.org>
 Date: Thu, 24 Mar 2022 15:41:48 +0100
-Subject: [PATCH 3/4] define _POSIX_MAPPED_FILES
+Subject: [PATCH] define _POSIX_MAPPED_FILES
 
 Serenity has a working mmap().
 ---
@@ -20,6 +20,3 @@ index 0b78647..dc1f830 100644
  #if !defined(_POSIX_MAPPED_FILES) || (_POSIX_MAPPED_FILES < 1)
  #  error "cfunge needs a working mmap(), which this system claims it lacks."
  #endif
--- 
-2.36.1
-

--- a/Ports/cfunge/patches/0004-Define-_POSIX_REGEXP.patch
+++ b/Ports/cfunge/patches/0004-Define-_POSIX_REGEXP.patch
@@ -1,7 +1,7 @@
-From 0e1b34946cdc2b4360d9a44f7f44cb5c743a9a78 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tobias Christiansen <tobyase@serenityos.org>
 Date: Thu, 24 Mar 2022 15:41:48 +0100
-Subject: [PATCH 4/4] Define _POSIX_REGEXP
+Subject: [PATCH] Define _POSIX_REGEXP
 
 Serenity's libc does have regex.
 ---
@@ -20,6 +20,3 @@ index c208078..88616b2 100644
  #if !defined(_POSIX_REGEXP) || (_POSIX_REGEXP < 1)
  #  error "cfunge needs POSIX regular expressions, which this system claims it doesn't have."
  #endif
--- 
-2.36.1
-

--- a/Ports/chester/patches/0001-Disable-SDL-accelerated-rendering.patch
+++ b/Ports/chester/patches/0001-Disable-SDL-accelerated-rendering.patch
@@ -1,4 +1,4 @@
-From e04b0fad889f05382a80fd5ac4bd3561afb1c058 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Manuel Palenzuela <manuelpalenzuelamerino@gmail.com>
 Date: Tue, 30 Mar 2021 17:26:39 +0200
 Subject: [PATCH] Disable SDL accelerated rendering
@@ -30,6 +30,3 @@ index cfd46b8..fc47912 100644
  
    if (sdl_graphics_ptr->renderer == NULL)
      {
--- 
-2.36.1
-

--- a/Ports/citron/patches/0001-Get-rid-of-wordexp-on-serenity.patch
+++ b/Ports/citron/patches/0001-Get-rid-of-wordexp-on-serenity.patch
@@ -1,7 +1,7 @@
-From 55c1e96ff844e75a9bf07114e00e27fabb7f54ee Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 11 Feb 2022 16:13:52 +0330
-Subject: [PATCH 1/9] Get rid of wordexp on serenity
+Subject: [PATCH] Get rid of wordexp on serenity
 
 ---
  src/file.c | 15 ++++++++++++++-
@@ -74,6 +74,3 @@ index a3bfd16..720a6e5 100644
  }
  
  /**
--- 
-2.34.1
-

--- a/Ports/citron/patches/0002-Make-fiber-a-noop.patch
+++ b/Ports/citron/patches/0002-Make-fiber-a-noop.patch
@@ -1,7 +1,7 @@
-From 9dd73dc37156e39a03cbf4c2af0d754bf84882ab Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 11 Feb 2022 16:32:42 +0330
-Subject: [PATCH 2/9] Make fiber a noop
+Subject: [PATCH] Make fiber a noop
 
 Serenity doesn't have ucontext.
 ---
@@ -141,6 +141,3 @@ index e8a99f1..23afae6 100644
      CtrStdFiber->info.sticky = 1;
  
      ctr_internal_object_add_property(
--- 
-2.34.1
-

--- a/Ports/citron/patches/0003-Make-coroutines-a-noop.patch
+++ b/Ports/citron/patches/0003-Make-coroutines-a-noop.patch
@@ -1,7 +1,7 @@
-From ee5ca4723aa24d850d13c9a3fcbf7f23250cc4b7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 11 Feb 2022 16:37:54 +0330
-Subject: [PATCH 3/9] Make coroutines a noop
+Subject: [PATCH] Make coroutines a noop
 
 Serenity doesn't have ucontext.
 ---
@@ -172,6 +172,3 @@ index 8497869..8215cfa 100644
 +    return 0;
 +#endif
 +}
--- 
-2.34.1
-

--- a/Ports/citron/patches/0004-Don-t-mess-with-libsocket.patch
+++ b/Ports/citron/patches/0004-Don-t-mess-with-libsocket.patch
@@ -1,7 +1,7 @@
-From 3f73149c75a5755c2b45334abe682dd4b970144b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 11 Feb 2022 16:46:16 +0330
-Subject: [PATCH 4/9] Don't mess with libsocket
+Subject: [PATCH] Don't mess with libsocket
 
 ---
  makefile | 8 +-------
@@ -47,6 +47,3 @@ index ded4d5a..b262cd0 100644
  $(BUILDDIR)/%.o: src/%.c
  	$(CC) -fopenmp $(CFLAGS) -c $< -o $@
  
--- 
-2.34.1
-

--- a/Ports/citron/patches/0005-Disable-inject.patch
+++ b/Ports/citron/patches/0005-Disable-inject.patch
@@ -1,7 +1,7 @@
-From 345758e53e21b23c716c2efccdaccf5434f16f0e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 11 Feb 2022 16:49:59 +0330
-Subject: [PATCH 5/9] Disable inject
+Subject: [PATCH] Disable inject
 
 tcc requires ucontext.
 ---
@@ -21,6 +21,3 @@ index b262cd0..2e05795 100644
  enable_ctypes ?= true
  enable_inline_asm ?= false
  enable_boehm_gc ?= true
--- 
-2.34.1
-

--- a/Ports/citron/patches/0006-Disable-openmp.patch
+++ b/Ports/citron/patches/0006-Disable-openmp.patch
@@ -1,7 +1,7 @@
-From e4b172e0a9db3eaa0c9c14c477e26185a2a596de Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 11 Feb 2022 16:52:51 +0330
-Subject: [PATCH 6/9] Disable openmp
+Subject: [PATCH] Disable openmp
 
 ---
  makefile | 4 ++--
@@ -29,6 +29,3 @@ index 2e05795..d916511 100644
  
  $(BUILDDIR)/%.o: src/%.cpp
  	$(CXX) -g $(CFLAGS) -c $< $(CXXFLAGS) -o $@
--- 
-2.34.1
-

--- a/Ports/citron/patches/0007-Disable-GC-on-serenity.patch
+++ b/Ports/citron/patches/0007-Disable-GC-on-serenity.patch
@@ -1,7 +1,7 @@
-From 88242bebd8381deef7598470ed74c23dbffaacb4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 11 Feb 2022 18:29:07 +0330
-Subject: [PATCH 7/9] Disable GC on serenity
+Subject: [PATCH] Disable GC on serenity
 
 ---
  src/memory.c | 4 ++++
@@ -55,6 +55,3 @@ index e42d09a..a6856b8 100644
      ctr_object* previousObject = NULL;
      ctr_object* currentObject = ctr_first_object;
      ctr_object* nextObject = NULL;
--- 
-2.34.1
-

--- a/Ports/citron/patches/0008-Don-t-use-libbsd-on-serenity.patch
+++ b/Ports/citron/patches/0008-Don-t-use-libbsd-on-serenity.patch
@@ -1,7 +1,7 @@
-From 6e802d3d52c160ca31bc9f7d1b9bb875569e3417 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Sun, 13 Feb 2022 17:03:21 +0330
-Subject: [PATCH 8/9] Don't use libbsd on serenity
+Subject: [PATCH] Don't use libbsd on serenity
 
 arc4random exists on serenity, there's no need to pull libbsd in for
 functionality that already exists.
@@ -22,6 +22,3 @@ index d916511..d1ce70d 100644
  
  CFLAGS += -Wall -Wextra -Wno-unused-parameter\
  		  -D withTermios -D CTR_STD_EXTENSION_PATH=\"$(DATADIR)\"
--- 
-2.34.1
-

--- a/Ports/citron/patches/0009-Disable-boehm-GC-on-serenity.patch
+++ b/Ports/citron/patches/0009-Disable-boehm-GC-on-serenity.patch
@@ -1,7 +1,7 @@
-From adb932228a5b24159d98c53c51281cfae238b57b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Sun, 13 Feb 2022 17:04:46 +0330
-Subject: [PATCH 9/9] Disable boehm GC on serenity
+Subject: [PATCH] Disable boehm GC on serenity
 
 Serenity doesn't have a bdwgc port, so disable it here.
 ---
@@ -21,6 +21,3 @@ index d1ce70d..307bf1c 100644
  use_libbsd ?= false
  
  CFLAGS += -Wall -Wextra -Wno-unused-parameter\
--- 
-2.34.1
-

--- a/Ports/cmake/patches/0001-kwsys-Don-t-use-siginfo.patch
+++ b/Ports/cmake/patches/0001-kwsys-Don-t-use-siginfo.patch
@@ -1,7 +1,7 @@
-From 5e5e6f2f0c25da400093818cbc3c1ae277a1df23 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: AnotherTest <ali.mpfard@gmail.com>
 Date: Fri, 12 Feb 2021 13:42:50 +0330
-Subject: [PATCH 1/6] kwsys: Don't use siginfo
+Subject: [PATCH] kwsys: Don't use siginfo
 
 We don't support SIGINFO. This patch removes uses of SIGINFO.
 
@@ -49,6 +49,3 @@ index e6cc48f2..17fbd547 100644
    static int saOrigValid = 0;
    static struct sigaction saABRTOrig;
    static struct sigaction saSEGVOrig;
--- 
-2.36.1
-

--- a/Ports/cmake/patches/0002-bin-bash.patch
+++ b/Ports/cmake/patches/0002-bin-bash.patch
@@ -1,7 +1,7 @@
-From 75597807e541ebe1ae83345af9250a4113bf1480 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Wed, 12 Jan 2022 22:15:37 +0330
-Subject: [PATCH 2/6] /bin/bash
+Subject: [PATCH] /bin/bash
 
 This patch swaps out /bin/sh for /bin/bash in two scripts that need it.
 
@@ -33,6 +33,3 @@ index 11622160..0e6fc25d 100755
 +#!/bin/bash
  cmake_source_dir=`cd "\`dirname \"$0\"\`";pwd`
  exec "${cmake_source_dir}/bootstrap" "$@"
--- 
-2.36.1
-

--- a/Ports/cmake/patches/0003-Platform-SerenityOS.patch
+++ b/Ports/cmake/patches/0003-Platform-SerenityOS.patch
@@ -1,7 +1,7 @@
-From 049e918181ba913bf992723dd805fb8066aae83b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Wed, 12 Jan 2022 22:17:47 +0330
-Subject: [PATCH 3/6] Platform/SerenityOS
+Subject: [PATCH] Platform/SerenityOS
 
 This patch adds the SerenityOS platform config file to CMake.
 
@@ -45,6 +45,3 @@ index 00000000..952ff61a
 +unset(CMAKE_LIBRARY_ARCHITECTURE_REGEX)
 +
 +include(Platform/UnixPaths)
--- 
-2.36.1
-

--- a/Ports/cmake/patches/0004-cmcurl-Include-unistd.patch
+++ b/Ports/cmake/patches/0004-cmcurl-Include-unistd.patch
@@ -1,7 +1,7 @@
-From a65e8be0dbde0e23fed88f8ebdcdf8668b238b9c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Wed, 12 Jan 2022 22:18:02 +0330
-Subject: [PATCH 4/6] cmcurl: Include unistd
+Subject: [PATCH] cmcurl: Include unistd
 
 Everyone gets this wrong. Most platforms are very lax with these includes, but we're not one of them.
 
@@ -25,6 +25,3 @@ index 91cd95d3..9940748f 100644
  
  #ifdef  __cplusplus
  extern "C" {
--- 
-2.36.1
-

--- a/Ports/cmake/patches/0005-cmcurl-Use-struct-stat-and-include-sys-stat.h.patch
+++ b/Ports/cmake/patches/0005-cmcurl-Use-struct-stat-and-include-sys-stat.h.patch
@@ -1,7 +1,7 @@
-From 8094f0232a6c4c357ec8e2931d44399172123f47 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Wed, 12 Jan 2022 22:18:23 +0330
-Subject: [PATCH 5/6] cmcurl: Use struct stat and include sys/stat.h
+Subject: [PATCH] cmcurl: Use struct stat and include sys/stat.h
 
 For unknown reasons, curl_setup_once.h does not include sys/stat.h. This patch includes sys/stat.h.
 
@@ -25,6 +25,3 @@ index 7421b670..b06c19d8 100644
  #  define struct_stat struct stat
  #endif
  
--- 
-2.36.1
-

--- a/Ports/cmake/patches/0006-CMake-Disable-tests.patch
+++ b/Ports/cmake/patches/0006-CMake-Disable-tests.patch
@@ -1,7 +1,7 @@
-From f0ae38c0f10805a2f4359ee0052766c371ee8d54 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Wed, 12 Jan 2022 22:18:57 +0330
-Subject: [PATCH 6/6] CMake: Disable tests
+Subject: [PATCH] CMake: Disable tests
 
 We don't care about building tests for now, and it makes the compilation much faster.
 
@@ -27,6 +27,3 @@ index b2ab30e1..24127b09 100644
  include (${CMAKE_ROOT}/Modules/Dart.cmake)
  
  # Set up test-time configuration.
--- 
-2.36.1
-

--- a/Ports/cmatrix/patches/0001-Use-manual-include-library-paths-for-ncurses.patch
+++ b/Ports/cmatrix/patches/0001-Use-manual-include-library-paths-for-ncurses.patch
@@ -1,7 +1,7 @@
-From bad2922ad4cbc8c74765d50da61371925b1b80d7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Manuel Palenzuela <manuelpalenzuelamerino@gmail.com>
 Date: Tue, 20 Apr 2021 18:42:04 +0300
-Subject: [PATCH 1/2] Use manual include & library paths for ncurses
+Subject: [PATCH] Use manual include & library paths for ncurses
 
 Co-Authored-By: Panagiotis Vasilopoulos <hello@alwayslivid.com>
 ---
@@ -35,6 +35,3 @@ index 6c50d7b..6ce5f9f 100644
  
  add_executable(cmatrix cmatrix.c)
  
--- 
-2.36.1
-

--- a/Ports/cmatrix/patches/0002-Include-curses.h-from-ncurses-in-serenity.patch
+++ b/Ports/cmatrix/patches/0002-Include-curses.h-from-ncurses-in-serenity.patch
@@ -1,7 +1,7 @@
-From 444b507fab58b76f52fa54abef855a264e8e9e1a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Tue, 17 May 2022 20:58:39 +0430
-Subject: [PATCH 2/2] Include curses.h from <ncurses> in serenity
+Subject: [PATCH] Include curses.h from <ncurses> in serenity
 
 Co-Authored-By: Manuel Palenzuela <manuelpalenzuelamerino@gmail.com>
 ---
@@ -21,6 +21,3 @@ index 7e3fbb9..0d1053f 100644
  #include <ncurses/curses.h>
  #else
  #include <curses.h>
--- 
-2.36.1
-

--- a/Ports/curl/patches/0001-Teach-curl.h-about-serenity-s-sys-select.h-include.patch
+++ b/Ports/curl/patches/0001-Teach-curl.h-about-serenity-s-sys-select.h-include.patch
@@ -1,4 +1,4 @@
-From f3a2d182fe9f6d569db5e6f28e3926ccdce84b1a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke Wilde <lukew@serenityos.org>
 Date: Sun, 13 Mar 2022 16:50:19 +0000
 Subject: [PATCH] Teach curl.h about serenity's <sys/select.h> include
@@ -21,6 +21,3 @@ index 3a2c2ea..2b7c86b 100644
     (defined(__FreeBSD_version) && (__FreeBSD_version < 800000)) || \
     (defined(__MidnightBSD_version) && (__MidnightBSD_version < 100000))
  #include <sys/select.h>
--- 
-2.36.1
-

--- a/Ports/dash/patches/0001-Replace-a-use-of-wait3-with-waitpid-in-the-job-contr.patch
+++ b/Ports/dash/patches/0001-Replace-a-use-of-wait3-with-waitpid-in-the-job-contr.patch
@@ -1,8 +1,7 @@
-From d6d5890a9938ce5bfb6e9a1ee98fb2d692a6efa3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Sun, 10 May 2020 11:50:31 -0400
-Subject: [PATCH 1/2] Replace a use of wait3() with waitpid() in the job
- control
+Subject: [PATCH] Replace a use of wait3() with waitpid() in the job control
 
 wait3() does not exist on serenity.
 ---
@@ -22,6 +21,3 @@ index 606d603..92ac84d 100644
  		if (err || !block)
  			break;
  
--- 
-2.36.1
-

--- a/Ports/dash/patches/0002-Skip-building-helpers-by-default.patch
+++ b/Ports/dash/patches/0002-Skip-building-helpers-by-default.patch
@@ -1,7 +1,7 @@
-From 481993ee4f0908cefcbddb0cca4e6811751d809c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Mon, 12 Apr 2021 09:18:56 +0200
-Subject: [PATCH 2/2] Skip building helpers by default
+Subject: [PATCH] Skip building helpers by default
 
 ---
  configure.ac    | 3 +++
@@ -35,6 +35,3 @@ index 139355e..e95491a 100644
  $(HELPERS): %: %.c
  	$(COMPILE_FOR_BUILD) -o $@ $<
 +endif
--- 
-2.36.1
-

--- a/Ports/dmidecode/patches/0001-Use-serenity-s-firmware-binary-path.patch
+++ b/Ports/dmidecode/patches/0001-Use-serenity-s-firmware-binary-path.patch
@@ -1,4 +1,4 @@
-From 546bd7af0869cb4064d7e29baacfdaa1e174d063 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Liav A <liavalb@gmail.com>
 Date: Fri, 1 Apr 2022 11:01:13 +0300
 Subject: [PATCH] Use serenity's firmware binary path
@@ -20,6 +20,3 @@ index cd2b5c9..49bf30e 100644
  #define SYS_ENTRY_FILE SYS_FIRMWARE_DIR "/smbios_entry_point"
  #define SYS_TABLE_FILE SYS_FIRMWARE_DIR "/DMI"
  
--- 
-2.36.1
-

--- a/Ports/dos2unix/patches/0001-Link-with-lintl.patch
+++ b/Ports/dos2unix/patches/0001-Link-with-lintl.patch
@@ -1,4 +1,4 @@
-From 4a571a9e2bc04dfaeba2e9bee3f495615c7a26fe Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nathan Ell <nathanjamesell@gmail.com>
 Date: Tue, 7 Dec 2021 20:00:58 -0700
 Subject: [PATCH] Link with `-lintl`
@@ -20,6 +20,3 @@ index 2edc74d..4ec93a6 100644
  
  # ............................................................ flags ...
  
--- 
-2.36.1
-

--- a/Ports/dosbox-staging/patches/0001-Skip-use-of-glob-in-serenity.patch
+++ b/Ports/dosbox-staging/patches/0001-Skip-use-of-glob-in-serenity.patch
@@ -1,7 +1,7 @@
-From 6476eefcda05b18de380eca3b772042648107b07 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Fri, 18 Jun 2021 15:06:37 +0200
-Subject: [PATCH 1/4] Skip use of glob() in serenity
+Subject: [PATCH] Skip use of glob() in serenity
 
 We don't have that yet.
 ---
@@ -40,6 +40,3 @@ index fa09872..96002ac 100644
  }
  
  int create_dir(const char *path, uint32_t mode, uint32_t flags) noexcept
--- 
-2.36.1
-

--- a/Ports/dosbox-staging/patches/0002-Replace-some-size_t-Bitu.patch
+++ b/Ports/dosbox-staging/patches/0002-Replace-some-size_t-Bitu.patch
@@ -1,7 +1,7 @@
-From e62df15632c7473f88055973d2e84aec9f7dc3d8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Fri, 18 Jun 2021 15:06:37 +0200
-Subject: [PATCH 2/4] Replace some size_t => Bitu
+Subject: [PATCH] Replace some size_t => Bitu
 
 FIXME: No information as to why this is a thing exists as of yet, fill
        them in when that stuff is known.
@@ -31,6 +31,3 @@ index 355a082..6c20b5c 100644
  	void WriteToRegister();
  
  	// Collections
--- 
-2.36.1
-

--- a/Ports/dosbox-staging/patches/0003-Manually-hardcode-SDL2-library-name.patch
+++ b/Ports/dosbox-staging/patches/0003-Manually-hardcode-SDL2-library-name.patch
@@ -1,7 +1,7 @@
-From 73cb3bfcc987687c1ff1c1de02905b302a98a47a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Fri, 18 Jun 2021 15:06:37 +0200
-Subject: [PATCH 3/4] Manually hardcode SDL2 library name
+Subject: [PATCH] Manually hardcode SDL2 library name
 
 ---
  configure.ac | 6 ++----
@@ -24,6 +24,3 @@ index 28e9281..1cc3691 100644
  PRESDL_LIBS="$LIBS"
  LIBS="$LIBS $SDL_LIBS"
  CPPFLAGS="$CPPFLAGS $SDL_CFLAGS"
--- 
-2.36.1
-

--- a/Ports/dosbox-staging/patches/0004-Disable-SDL-s-accelerated-rendering.patch
+++ b/Ports/dosbox-staging/patches/0004-Disable-SDL-s-accelerated-rendering.patch
@@ -1,7 +1,7 @@
-From 19c66fff43c31010e3cae00c4a4a6898c0a9a30a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Fri, 18 Jun 2021 15:06:37 +0200
-Subject: [PATCH 4/4] Disable SDL's accelerated rendering
+Subject: [PATCH] Disable SDL's accelerated rendering
 
 ---
  src/gui/sdlmain.cpp | 1 -
@@ -19,6 +19,3 @@ index 7039f27..d445ebd 100644
  		                                  (sdl.desktop.vsync ? SDL_RENDERER_PRESENTVSYNC : 0));
  		if (!sdl.renderer) {
  			LOG_MSG("%s\n", SDL_GetError());
--- 
-2.36.1
-

--- a/Ports/dropbear/patches/0001-Disable-some-default-options.patch
+++ b/Ports/dropbear/patches/0001-Disable-some-default-options.patch
@@ -1,7 +1,7 @@
-From 828399ef58c44dfe248c46bd3e7cadfcb904c5cd Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Patrick Meyer <git@the-space.agency>
 Date: Thu, 28 Apr 2022 01:50:11 +0000
-Subject: [PATCH 1/5] Disable some default options
+Subject: [PATCH] Disable some default options
 
 Co-Authored-By: Yonatan Goldschmidt <yon.goldschmidt@gmail.com>
 ---
@@ -32,6 +32,3 @@ index 536f4e7..5073b7c 100644
  
  /* Note: PAM auth is quite simple and only works for PAM modules which just do
   * a simple "Login: " "Password: " (you can edit the strings in svr-authpam.c).
--- 
-2.36.1
-

--- a/Ports/dropbear/patches/0002-Disable-SSP.patch
+++ b/Ports/dropbear/patches/0002-Disable-SSP.patch
@@ -1,7 +1,7 @@
-From 634f30f41971933508832954c142cc6c384d19ed Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Patrick Meyer <git@the-space.agency>
 Date: Thu, 28 Apr 2022 01:50:11 +0000
-Subject: [PATCH 2/5] Disable SSP
+Subject: [PATCH] Disable SSP
 
 Co-Authored-By: Yonatan Goldschmidt <yon.goldschmidt@gmail.com>
 ---
@@ -95,6 +95,3 @@ index 6a19479..28cd987 100644
  	# FORTIFY_SOURCE
  	DB_TRYADDCFLAGS([-D_FORTIFY_SOURCE=2])
  
--- 
-2.36.1
-

--- a/Ports/dropbear/patches/0003-Include-sys-select.h.patch
+++ b/Ports/dropbear/patches/0003-Include-sys-select.h.patch
@@ -1,7 +1,7 @@
-From 6515921fcacaa71f666963a8ef8a8b3c0ad64eb2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Patrick Meyer <git@the-space.agency>
 Date: Thu, 28 Apr 2022 01:50:11 +0000
-Subject: [PATCH 3/5] Include <sys/select.h>
+Subject: [PATCH] Include <sys/select.h>
 
 Co-Authored-By: Yonatan Goldschmidt <yon.goldschmidt@gmail.com>
 ---
@@ -20,6 +20,3 @@ index 1e00002..2208f94 100644
  
  #include <stdio.h>
  #include <errno.h>
--- 
-2.36.1
-

--- a/Ports/dropbear/patches/0004-Install-in-bindir.patch
+++ b/Ports/dropbear/patches/0004-Install-in-bindir.patch
@@ -1,7 +1,7 @@
-From 06371c6e143c43c31070a80d8d717e3213316296 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Patrick Meyer <git@the-space.agency>
 Date: Thu, 28 Apr 2022 01:50:11 +0000
-Subject: [PATCH 4/5] Install in bindir
+Subject: [PATCH] Install in bindir
 
 FIXME: Not sure what this is exactly doing.
 
@@ -23,6 +23,3 @@ index e824491..f30f508 100644
  mandir=@mandir@
  
  .DELETE_ON_ERROR:
--- 
-2.36.1
-

--- a/Ports/dropbear/patches/0005-Remove-some-unsupported-socket-operations.patch
+++ b/Ports/dropbear/patches/0005-Remove-some-unsupported-socket-operations.patch
@@ -1,7 +1,7 @@
-From bc87404dcffad4d0e1577bf407a0bfbacb2d79f2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Patrick Meyer <git@the-space.agency>
 Date: Thu, 28 Apr 2022 01:50:11 +0000
-Subject: [PATCH 5/5] Remove some unsupported socket operations
+Subject: [PATCH] Remove some unsupported socket operations
 
 Co-Authored-By: Yonatan Goldschmidt <yon.goldschmidt@gmail.com>
 ---
@@ -52,6 +52,3 @@ index 2ed9bb1..e0e9962 100644
  
  #if defined(IPPROTO_IPV6) && defined(IPV6_V6ONLY)
  		if (res->ai_family == AF_INET6) {
--- 
-2.36.1
-

--- a/Ports/dungeonrush/patches/0001-chdir-to-the-resource-install-path-at-program-startu.patch
+++ b/Ports/dungeonrush/patches/0001-chdir-to-the-resource-install-path-at-program-startu.patch
@@ -1,7 +1,7 @@
-From 9aeccfdc1257204b18e0c8efa1f18f9a24cdab75 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Wed, 16 Jun 2021 11:23:34 +0200
-Subject: [PATCH 1/2] chdir() to the resource install path at program startup
+Subject: [PATCH] chdir() to the resource install path at program startup
 
 The game tries to open its resource files using relative paths, and we
 install them into /opt, so chdr() there.
@@ -22,6 +22,3 @@ index 8fa842f..e16c35e 100644
    prngSrand(time(NULL));
    // Start up SDL and create window
    if (!init()) {
--- 
-2.36.1
-

--- a/Ports/dungeonrush/patches/0002-Make-it-use-software-rendering.patch
+++ b/Ports/dungeonrush/patches/0002-Make-it-use-software-rendering.patch
@@ -1,7 +1,7 @@
-From 2837d8fc8be4d4bd3d03866cfd139152506f4e31 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Wed, 16 Jun 2021 11:23:34 +0200
-Subject: [PATCH 2/2] Make it use software rendering
+Subject: [PATCH] Make it use software rendering
 
 ---
  src/res.c | 2 ++
@@ -20,6 +20,3 @@ index ef4945a..6c46184 100644
  bool init() {
    // Initialization flag
    bool success = true;
--- 
-2.36.1
-

--- a/Ports/ed/patches/0001-Make-CC-and-friends-overridable-from-the-env.patch
+++ b/Ports/ed/patches/0001-Make-CC-and-friends-overridable-from-the-env.patch
@@ -1,7 +1,7 @@
-From d29259d2ea80767820f69b9b58f9377166440938 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: EWouters <6179932+EWouters@users.noreply.github.com>
 Date: Fri, 1 Apr 2022 02:54:00 +0200
-Subject: [PATCH 1/4] Make CC and friends overridable from the env
+Subject: [PATCH] Make CC and friends overridable from the env
 
 Co-Authored-By: roytam1 <roytam@gmail.com>
 ---
@@ -27,6 +27,3 @@ index 3531bcd..a225c14 100755
  
  # checking whether we are using GNU C.
  /bin/sh -c "${CC} --version" > /dev/null 2>&1 || { CC=cc ; CFLAGS=-O2 ; }
--- 
-2.36.1
-

--- a/Ports/ed/patches/0002-Use-stdbool-instead-of-rolling-a-manual-Bool.patch
+++ b/Ports/ed/patches/0002-Use-stdbool-instead-of-rolling-a-manual-Bool.patch
@@ -1,7 +1,7 @@
-From a61996a48d800229a267d9fef1548b08450997ab Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <ibara@users.noreply.github.com>
 Date: Sat, 1 Feb 2020 14:54:04 -0500
-Subject: [PATCH 2/4] Use stdbool instead of rolling a manual Bool
+Subject: [PATCH] Use stdbool instead of rolling a manual Bool
 
 ---
  ed.h | 3 +--
@@ -21,6 +21,3 @@ index db0b4a6..ef0c134 100644
  #endif
  
  enum Pflags			/* print suffixes */
--- 
-2.36.1
-

--- a/Ports/ed/patches/0003-Manually-link-with-pcre2.patch
+++ b/Ports/ed/patches/0003-Manually-link-with-pcre2.patch
@@ -1,7 +1,7 @@
-From 492088ee0565b8d947d129125ab3518a4da6a7c9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <ibara@users.noreply.github.com>
 Date: Fri, 1 Apr 2022 02:54:00 +0200
-Subject: [PATCH 3/4] Manually link with pcre2
+Subject: [PATCH] Manually link with pcre2
 
 Co-Authored-By: EWouters <6179932+EWouters@users.noreply.github.com>
 ---
@@ -21,6 +21,3 @@ index f716df4..c1a7880 100644
  
  r$(progname) : r$(progname).in
  	cat $(VPATH)/r$(progname).in > $@
--- 
-2.36.1
-

--- a/Ports/ed/patches/0004-Use-pcre2-for-regex-instead-of-libc-s-regex.h.patch
+++ b/Ports/ed/patches/0004-Use-pcre2-for-regex-instead-of-libc-s-regex.h.patch
@@ -1,7 +1,7 @@
-From 5d79ba1193bb0f9813c9650ee36ec416af525a1e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <ibara@users.noreply.github.com>
 Date: Sat, 1 Feb 2020 14:54:04 -0500
-Subject: [PATCH 4/4] Use pcre2 for regex instead of libc's regex.h
+Subject: [PATCH] Use pcre2 for regex instead of libc's regex.h
 
 ---
  regex.c | 2 +-
@@ -20,6 +20,3 @@ index 9b38120..325b2f6 100644
  #include <stdio.h>
  #include <stdlib.h>
  #include <string.h>
--- 
-2.36.1
-

--- a/Ports/emu2/patches/0001-Include-strings.h.patch
+++ b/Ports/emu2/patches/0001-Include-strings.h.patch
@@ -1,7 +1,7 @@
-From 0e8dbc3e4e44760da5817053eb2a9f6f2f55245b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brendan Coles <bcoles@gmail.com>
 Date: Wed, 14 Apr 2021 17:24:58 +0000
-Subject: [PATCH 1/4] Include <strings.h>
+Subject: [PATCH] Include <strings.h>
 
 ---
  src/codepage.c | 1 +
@@ -19,6 +19,3 @@ index 3916b61..9df0bd8 100644
  
  /* List of code-pages */
  struct cp_data
--- 
-2.36.1
-

--- a/Ports/emu2/patches/0002-Replace-a-use-of-rindex-with-strrchr.patch
+++ b/Ports/emu2/patches/0002-Replace-a-use-of-rindex-with-strrchr.patch
@@ -1,7 +1,7 @@
-From 35566f37112c812ab3695e4843ff653792b1d532 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brendan Coles <bcoles@gmail.com>
 Date: Thu, 23 Dec 2021 10:26:29 +0100
-Subject: [PATCH 2/4] Replace a use of rindex() with strrchr()
+Subject: [PATCH] Replace a use of rindex() with strrchr()
 
 Co-Authored-By: Daniel Bertalan <dani@danielbertalan.dev>
 ---
@@ -29,6 +29,3 @@ index b6122a9..582a0e2 100644
      if(!p)
      {
          glob = fspec;
--- 
-2.36.1
-

--- a/Ports/emu2/patches/0003-Install-into-usr-local.patch
+++ b/Ports/emu2/patches/0003-Install-into-usr-local.patch
@@ -1,7 +1,7 @@
-From 83c869b96b9651ff4fc16989cffb9a27d21329b2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Thu, 15 Apr 2021 15:43:18 +0200
-Subject: [PATCH 3/4] Install into /usr/local
+Subject: [PATCH] Install into /usr/local
 
 ---
  Makefile | 2 +-
@@ -20,6 +20,3 @@ index 80dd6ec..7026600 100644
  
  OBJS=\
   cpu.o\
--- 
-2.36.1
-

--- a/Ports/emu2/patches/0004-Don-t-use-setitimer.patch
+++ b/Ports/emu2/patches/0004-Don-t-use-setitimer.patch
@@ -1,7 +1,7 @@
-From 9dec9f5ffc1a75ab15d4ecec19cb03fa4792b31d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brendan Coles <bcoles@gmail.com>
 Date: Fri, 7 Jan 2022 17:26:40 +0100
-Subject: [PATCH 4/4] Don't use setitimer()
+Subject: [PATCH] Don't use setitimer()
 
 Co-Authored-By: Tim Schumacher <timschumi@gmx.de>
 ---
@@ -33,6 +33,3 @@ index d0c0d2f..7e313a0 100644
      init_bios_mem();
      while(1)
      {
--- 
-2.36.1
-

--- a/Ports/epsilon/patches/0001-Add-serenity-toolchain-information-and-makefile-file.patch
+++ b/Ports/epsilon/patches/0001-Add-serenity-toolchain-information-and-makefile-file.patch
@@ -1,7 +1,7 @@
-From baa0491c1ce039d7de092f3f91b6d5b752c3ef24 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Joachim Le Fournis <joachimlf@pm.me>
 Date: Tue, 13 Jul 2021 21:17:44 +0200
-Subject: [PATCH 1/3] Add serenity toolchain information and makefile files
+Subject: [PATCH] Add serenity toolchain information and makefile files
 
 ---
  build/platform.simulator.serenity.mak |  6 ++++
@@ -83,6 +83,3 @@ index 0000000..5d4bb13
 +
 +# The header is refered to as <ion/src/simulator/linux/platform_images.h> so make sure it's findable this way
 +$(call object_for,ion/src/simulator/linux/platform_images.cpp): SFLAGS += -I$(BUILD_DIR)
--- 
-2.36.1
-

--- a/Ports/epsilon/patches/0002-Include-some-missing-headers.patch
+++ b/Ports/epsilon/patches/0002-Include-some-missing-headers.patch
@@ -1,7 +1,7 @@
-From 150a510965a5f673ca1fc3459f0f1766cdfa1217 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Joachim Le Fournis <joachimlf@pm.me>
 Date: Tue, 13 Jul 2021 21:17:44 +0200
-Subject: [PATCH 2/3] Include some missing headers
+Subject: [PATCH] Include some missing headers
 
 ---
  ion/src/simulator/linux/platform_files.cpp  | 1 +
@@ -35,6 +35,3 @@ index 0fb2386..94ed16c 100644
  
  #include <ion/src/simulator/linux/platform_images.h>
  
--- 
-2.36.1
-

--- a/Ports/epsilon/patches/0003-Don-t-use-dynamic-SDL.patch
+++ b/Ports/epsilon/patches/0003-Don-t-use-dynamic-SDL.patch
@@ -1,7 +1,7 @@
-From 5c104400d226a1531145b8e30e2055ef6a24d1e3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Joachim Le Fournis <joachimlf@pm.me>
 Date: Tue, 13 Jul 2021 21:17:44 +0200
-Subject: [PATCH 3/3] Don't use dynamic SDL
+Subject: [PATCH] Don't use dynamic SDL
 
 ---
  build/platform.simulator.mak        | 1 +
@@ -37,6 +37,3 @@ index cf7744b..5157f3c 100644
 +ifeq ($(SHOULD_USE_DYNAMIC_SDL),0)
  ion_src += $(sdl_src)
 +endif
--- 
-2.36.1
-

--- a/Ports/ffmpeg/patches/0001-Assume-that-EDOM-exists.patch
+++ b/Ports/ffmpeg/patches/0001-Assume-that-EDOM-exists.patch
@@ -1,4 +1,4 @@
-From d64d7a469a8524d2ea8121d10844ff73feef3b55 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Ross <pross@xvid.org>
 Date: Tue, 1 Mar 2022 19:50:19 +1100
 Subject: [PATCH] Assume that EDOM exists
@@ -22,6 +22,3 @@ index 0d3269a..a54d80d 100644
  #define AVERROR(e) (-(e))   ///< Returns a negative error code from a POSIX error code, to return from library functions.
  #define AVUNERROR(e) (-(e)) ///< Returns a POSIX error code from a library function error return value.
  #else
--- 
-2.36.1
-

--- a/Ports/fheroes2/patches/0001-Include-endian.h-on-serenity-as-well.patch
+++ b/Ports/fheroes2/patches/0001-Include-endian.h-on-serenity-as-well.patch
@@ -1,7 +1,7 @@
-From eda93d38b7677a38e5027bccfa48d55c94242f4e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Michael Manganiello <adamantike@users.noreply.github.com>
 Date: Sun, 27 Mar 2022 12:52:11 -0300
-Subject: [PATCH 1/3] Include <endian.h> on serenity as well
+Subject: [PATCH] Include <endian.h> on serenity as well
 
 ---
  src/engine/endian_h2.h | 2 +-
@@ -20,6 +20,3 @@ index 7d1fa27..9144a91 100644
  #include <endian.h>
  
  #elif defined( __FreeBSD__ ) || defined( __OpenBSD__ )
--- 
-2.36.1
-

--- a/Ports/fheroes2/patches/0002-Use-pkg-config-for-SDL_-and-SDL2.patch
+++ b/Ports/fheroes2/patches/0002-Use-pkg-config-for-SDL_-and-SDL2.patch
@@ -1,7 +1,7 @@
-From 315d38c29eac54f3db525a7077279c37f1d83b15 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Michael Manganiello <adamantike@users.noreply.github.com>
 Date: Sun, 27 Mar 2022 12:52:11 -0300
-Subject: [PATCH 2/3] Use pkg-config for SDL_* and SDL2
+Subject: [PATCH] Use pkg-config for SDL_* and SDL2
 
 ---
  CMakeLists.txt            |  9 ++++++---
@@ -63,6 +63,3 @@ index 8a1fbeb..b9df312 100644
  	Threads::Threads # To match the build settings of the main app
  	ZLIB::ZLIB
  	)
--- 
-2.36.1
-

--- a/Ports/fheroes2/patches/0003-Disable-SDL-s-accelerated-rendering.patch
+++ b/Ports/fheroes2/patches/0003-Disable-SDL-s-accelerated-rendering.patch
@@ -1,7 +1,7 @@
-From 50f72a8d38355f2d9814cc6f507301b11bcbe02f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Michael Manganiello <adamantike@users.noreply.github.com>
 Date: Sun, 27 Mar 2022 12:52:11 -0300
-Subject: [PATCH 3/3] Disable SDL's accelerated rendering
+Subject: [PATCH] Disable SDL's accelerated rendering
 
 ---
  src/engine/screen.cpp | 4 ++--
@@ -24,6 +24,3 @@ index 9cd9ccb..f4fe315 100644
          }
  
          void _createPalette()
--- 
-2.36.1
-

--- a/Ports/figlet/patches/0001-Disable-toilet-fonts.patch
+++ b/Ports/figlet/patches/0001-Disable-toilet-fonts.patch
@@ -1,4 +1,4 @@
-From a31eefa8225cdf14ac34d57d85cdc27df027b09b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Larkin <45925460+larb0b@users.noreply.github.com>
 Date: Tue, 24 Sep 2019 02:56:39 -0400
 Subject: [PATCH] Disable toilet fonts
@@ -20,6 +20,3 @@ index 5a51d51..5044b4c 100644
  
  # Where to install files
  prefix	= /usr/local
--- 
-2.36.1
-

--- a/Ports/fio/patches/0001-Remove-non-existent-header-sys-ipc.h.patch
+++ b/Ports/fio/patches/0001-Remove-non-existent-header-sys-ipc.h.patch
@@ -1,7 +1,7 @@
-From d59316cb9bc616b4b44d432d1ad363afa69f67eb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Tue, 21 Dec 2021 23:41:47 -0800
-Subject: [PATCH 1/4] Port: fio, remove non existent header sys/ipc.h
+Subject: [PATCH] Remove non existent header sys/ipc.h
 
 Serenity doesn't currently have this header, and
 it doesn't appear to be needed on our platform so
@@ -22,6 +22,3 @@ index 5f069d9..81c4771 100644
  #include <sys/types.h>
  #include <dlfcn.h>
  #ifdef CONFIG_VALGRIND_DEV
--- 
-2.32.0
-

--- a/Ports/fio/patches/0002-Add-SerenityOS-platform-support.patch
+++ b/Ports/fio/patches/0002-Add-SerenityOS-platform-support.patch
@@ -1,7 +1,7 @@
-From 50d3ac3b6faa9d117ec26296067aecee988dbd8c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Tue, 21 Dec 2021 23:47:36 -0800
-Subject: [PATCH 2/4] Port: fio - Add SerenityOS platform support
+Subject: [PATCH] Add SerenityOS platform support
 
 `fio` abstracts individual operating system support out into to an
 `os/os-<name>.h` header where you can select which platform features
@@ -11,14 +11,14 @@ system.
 This patch implements basic OS support for Serenity just to get fio up
 and running.
 ---
- os/os-serenity.h | 87 ++++++++++++++++++++++++++++++++++++++++++++++++
- os/os.h          |  3 ++
- 2 files changed, 90 insertions(+)
+ os/os-serenity.h | 61 ++++++++++++++++++++++++++++++++++++++++++++++++
+ os/os.h          |  3 +++
+ 2 files changed, 64 insertions(+)
  create mode 100644 os/os-serenity.h
 
 diff --git a/os/os-serenity.h b/os/os-serenity.h
 new file mode 100644
-index 0000000..941bf09
+index 0000000..387727a
 --- /dev/null
 +++ b/os/os-serenity.h
 @@ -0,0 +1,61 @@
@@ -104,6 +104,3 @@ index 5965d7b..46604f7 100644
  #else
  #error "unsupported os"
  #endif
--- 
-2.32.0
-

--- a/Ports/fio/patches/0003-Add-SerenityOS-support-to-configure.patch
+++ b/Ports/fio/patches/0003-Add-SerenityOS-support-to-configure.patch
@@ -1,7 +1,7 @@
-From 99f1cf657e539078c7347c3ddc4a1537d5332e15 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Tue, 21 Dec 2021 23:48:09 -0800
-Subject: [PATCH 3/4] Port: Add SerenityOS support to configure
+Subject: [PATCH] Add SerenityOS support to configure
 
 This patch implements targetos detection for serenity, and also
 disables shared memory support automatically for serenity, as it's not
@@ -24,6 +24,3 @@ index 84ccce0..04bac14 100755
  elif check_define _WIN32 ; then
    targetos='CYGWIN'
  else
--- 
-2.32.0
-

--- a/Ports/fio/patches/0004-Disable-rdtsc-support-for-serenity.patch
+++ b/Ports/fio/patches/0004-Disable-rdtsc-support-for-serenity.patch
@@ -1,7 +1,7 @@
-From fdf16439ed5ecb36f762dc2b66102424920e26c1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Tue, 21 Dec 2021 23:48:46 -0800
-Subject: [PATCH 4/4] Port: fio - Disable rdtsc support for serenity
+Subject: [PATCH] Disable rdtsc support for serenity
 
 This patch disables the function which uses `rdtsc` to get the current
 clock time, as that instruction isn't allowed to be called from user
@@ -25,6 +25,3 @@ index c6bcb54..c1005b1 100644
 +// #define ARCH_HAVE_CPU_CLOCK
  
  #endif
--- 
-2.32.0
-

--- a/Ports/fio/patches/ReadMe.md
+++ b/Ports/fio/patches/ReadMe.md
@@ -1,16 +1,16 @@
 # Patches for fio on SerenityOS
 
-## `0001-fio-remove-non-existent-header-sys-ipc.patch`
+## `0001-Remove-non-existent-header-sys-ipc.h.patch`
 
-Port: fio, remove non existent header sys/ipc.h
+Remove non existent header sys/ipc.h
 
 Serenity doesn't currently have this header, and
 it doesn't appear to be needed on our platform so
 remove it for the port.
 
-## `0002-fio-add-serenityos-platform-support.patch`
+## `0002-Add-SerenityOS-platform-support.patch`
 
-Port: fio - Add SerenityOS platform support
+Add SerenityOS platform support
 
 `fio` abstracts individual operating system support out into to an
 `os/os-<name>.h` header where you can select which platform features
@@ -20,17 +20,17 @@ system.
 This patch implements basic OS support for Serenity just to get fio up
 and running.
 
-## `0003-fio-add-serenityos-support-to-configure.patch`
+## `0003-Add-SerenityOS-support-to-configure.patch`
 
-Port: Add SerenityOS support to configure
+Add SerenityOS support to configure
 
 This patch implements targetos detection for serenity, and also
 disables shared memory support automatically for serenity, as it's not
 currently supported.
 
-## `0004-fio-disable-rdtsc-support-for-serenityos.patch`
+## `0004-Disable-rdtsc-support-for-serenity.patch`
 
-Port: fio - Disable rdtsc support for serenity
+Disable rdtsc support for serenity
 
 This patch disables the function which uses `rdtsc` to get the current
 clock time, as that instruction isn't allowed to be called from user

--- a/Ports/flex/patches/0001-Fix-config.h.in.patch
+++ b/Ports/flex/patches/0001-Fix-config.h.in.patch
@@ -1,7 +1,7 @@
-From 622a451c631ed96575c78f68b9df830fe6beedac Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Thu, 23 Jan 2020 23:43:31 -0500
-Subject: [PATCH 1/6] Fix config.h.in
+Subject: [PATCH] Fix config.h.in
 
 FIXME: This patch does not have any accompanying information.
 ---
@@ -28,6 +28,3 @@ index 4756505..96fba7b 100644
  /* Define to `unsigned int' if <sys/types.h> does not define. */
  #undef size_t
  
--- 
-2.36.1
-

--- a/Ports/flex/patches/0002-Don-t-use-libc-s-regex.patch
+++ b/Ports/flex/patches/0002-Don-t-use-libc-s-regex.patch
@@ -1,7 +1,7 @@
-From 1e80ecd820c3a16ffeb99ac0587d996b13784062 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Thu, 23 Jan 2020 23:43:31 -0500
-Subject: [PATCH 2/6] Don't use libc's regex
+Subject: [PATCH] Don't use libc's regex
 
 ---
  configure | 4 ++--
@@ -29,6 +29,3 @@ index d88c47c..90e013f 100755
  do :
    as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
  ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
--- 
-2.36.1
-

--- a/Ports/flex/patches/0003-Replace-libc-s-regex-includes-with-pcre2.patch
+++ b/Ports/flex/patches/0003-Replace-libc-s-regex-includes-with-pcre2.patch
@@ -1,7 +1,7 @@
-From 2aecd57dbc3eb793db2996807f4c17e0c5880d75 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Thu, 23 Jan 2020 23:43:31 -0500
-Subject: [PATCH 3/6] Replace libc's regex includes with pcre2
+Subject: [PATCH] Replace libc's regex includes with pcre2
 
 ---
  src/flexdef.h | 2 +-
@@ -20,6 +20,3 @@ index 9dac654..2bdf9fb 100644
  /* Required: strcasecmp() in <strings.h> */
  #include <strings.h>
  #include "flexint.h"
--- 
-2.36.1
-

--- a/Ports/flex/patches/0004-Link-with-pcre2.patch
+++ b/Ports/flex/patches/0004-Link-with-pcre2.patch
@@ -1,7 +1,7 @@
-From 0e26bc451d724c5666155c9b04f4a010475e66ac Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Thu, 23 Jan 2020 23:43:31 -0500
-Subject: [PATCH 4/6] Link with pcre2
+Subject: [PATCH] Link with pcre2
 
 ---
  src/Makefile.in | 2 +-
@@ -20,6 +20,3 @@ index e570b87..1f8a305 100644
  LIBTOOL = @LIBTOOL@
  LIPO = @LIPO@
  LN_S = @LN_S@
--- 
-2.36.1
-

--- a/Ports/flex/patches/0005-Hardcode-the-m4-include-path.patch
+++ b/Ports/flex/patches/0005-Hardcode-the-m4-include-path.patch
@@ -1,7 +1,7 @@
-From 07a476646c5585444df983b14bd3041d1dae61f1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Thu, 23 Jan 2020 23:43:31 -0500
-Subject: [PATCH 5/6] Hardcode the m4 include path
+Subject: [PATCH] Hardcode the m4 include path
 
 ---
  src/Makefile.in | 4 ++--
@@ -29,6 +29,3 @@ index 1f8a305..a5dd2e2 100644
  @ENABLE_LIBFL_TRUE@lib_LTLIBRARIES = libfl.la
  libfl_la_SOURCES = \
  	libmain.c \
--- 
-2.36.1
-

--- a/Ports/flex/patches/0006-Include-arpa-inet.h.patch
+++ b/Ports/flex/patches/0006-Include-arpa-inet.h.patch
@@ -1,7 +1,7 @@
-From f6d725687a0de5f489b37bf6607795e35be0fd65 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Thu, 23 Jan 2020 23:43:31 -0500
-Subject: [PATCH 6/6] Include <arpa/inet.h>
+Subject: [PATCH] Include <arpa/inet.h>
 
 FIXME: This patch does not have any accompanying information.
 ---
@@ -21,6 +21,3 @@ index 980d2e9..0824a7f 100644
  #include "flexdef.h"
  #include "tables.h"
  
--- 
-2.36.1
-

--- a/Ports/fontconfig/patches/0001-Stub-out-FcRandom.patch
+++ b/Ports/fontconfig/patches/0001-Stub-out-FcRandom.patch
@@ -1,7 +1,7 @@
-From d84d340b3b9b87902011065a1ea4e97c7f3eb095 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brendan Coles <bcoles@gmail.com>
 Date: Tue, 26 Oct 2021 11:34:34 +0000
-Subject: [PATCH 1/2] Stub out FcRandom()
+Subject: [PATCH] Stub out FcRandom()
 
 ---
  src/fccompat.c | 51 --------------------------------------------------
@@ -76,6 +76,3 @@ index 65ac84c..96e4087 100644
  
      return result;
  }
--- 
-2.36.1
-

--- a/Ports/fontconfig/patches/0002-Manually-link-against-lxml2-and-ldl.patch
+++ b/Ports/fontconfig/patches/0002-Manually-link-against-lxml2-and-ldl.patch
@@ -1,7 +1,7 @@
-From f131d47415cb23f90c62c51d1483ea4555bd1a19 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sahan Fernando <sahan.h.fernando@gmail.com>
 Date: Sat, 22 Jan 2022 00:54:01 +1100
-Subject: [PATCH 2/2] Manually link against lxml2 and ldl
+Subject: [PATCH] Manually link against lxml2 and ldl
 
 ---
  fontconfig.pc.in | 2 +-
@@ -19,6 +19,3 @@ index 61b35fb..a3c45eb 100644
 +Libs: -L${libdir} -lfontconfig -lxml2 -ldl
  Libs.private: @ICONV_LIBS@ @PKG_EXPAT_LIBS@
  Cflags: -I${includedir} @ICONV_CFLAGS@ @PKG_EXPAT_CFLAGS@
--- 
-2.36.1
-

--- a/Ports/freeciv/patches/0001-Log-to-dev-null-if-the-log-file-doesn-t-exist.patch
+++ b/Ports/freeciv/patches/0001-Log-to-dev-null-if-the-log-file-doesn-t-exist.patch
@@ -1,4 +1,4 @@
-From cbcb5538e52f9990387d4d79e676d6ef3d03fe46 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Fri, 4 Jun 2021 23:20:55 +0200
 Subject: [PATCH] Log to /dev/null if the log file doesn't exist
@@ -49,6 +49,3 @@ index 0afef96..d931378 100644
          fchmod(1, 0644);
        }
  
--- 
-2.36.1
-

--- a/Ports/freedink/patches/0001-Remove-android-specific-SDL-hint.patch
+++ b/Ports/freedink/patches/0001-Remove-android-specific-SDL-hint.patch
@@ -1,4 +1,4 @@
-From 53958f5cfb0efa2978bb913ffe610f7903e6c69b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brendan Coles <bcoles@gmail.com>
 Date: Thu, 28 Oct 2021 11:27:43 +0000
 Subject: [PATCH] Remove android-specific SDL hint
@@ -22,6 +22,3 @@ index b5ae21e..b6ac494 100644
    /* Touch devices */
    {
      int i;
--- 
-2.36.1
-

--- a/Ports/gdb/patches/0001-gdb-Disable-xmalloc-for-alternate_signal_stack-for-s.patch
+++ b/Ports/gdb/patches/0001-gdb-Disable-xmalloc-for-alternate_signal_stack-for-s.patch
@@ -1,15 +1,14 @@
-From 32bfc7a161e6bf10decbf29b31c7b547cf250d3a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Sat, 19 Feb 2022 19:46:06 -0800
-Subject: [PATCH 1/6] gdb: Disable xmalloc for alternate_signal_stack for
- serenity
+Subject: [PATCH] gdb: Disable xmalloc for alternate_signal_stack for serenity
 
 ---
  gdbsupport/alt-stack.h | 37 ++++++++++++++++++++++++++-----------
  1 file changed, 26 insertions(+), 11 deletions(-)
 
 diff --git a/gdbsupport/alt-stack.h b/gdbsupport/alt-stack.h
-index 056ea41..b638533 100644
+index 8ae229b..6e5b133 100644
 --- a/gdbsupport/alt-stack.h
 +++ b/gdbsupport/alt-stack.h
 @@ -20,7 +20,9 @@
@@ -78,6 +77,3 @@ index 056ea41..b638533 100644
    stack_t m_old_stack;
  #endif
  };
--- 
-2.32.0
-

--- a/Ports/gdb/patches/0002-serenity-Add-basic-ptrace-based-native-target-for-Se.patch
+++ b/Ports/gdb/patches/0002-serenity-Add-basic-ptrace-based-native-target-for-Se.patch
@@ -1,7 +1,7 @@
-From 883a25f5ed8fd8f13b8e30aed3a25001839d892c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Tue, 28 Dec 2021 04:35:47 -0800
-Subject: [PATCH 2/6] serenity: Add basic ptrace based native target for
+Subject: [PATCH] serenity: Add basic ptrace based native target for
  SerenityOS/i386
 
 ---
@@ -55,7 +55,7 @@ index e94a19b..06b87ca 100644
  
  xtensa*-*-linux*)	gdb_host=linux ;;
 diff --git a/gdb/configure.nat b/gdb/configure.nat
-index e34cccf..38b687e 100644
+index f48fbda..6a0115f 100644
 --- a/gdb/configure.nat
 +++ b/gdb/configure.nat
 @@ -86,6 +86,9 @@ case ${gdb_host} in
@@ -269,7 +269,7 @@ index 0000000..4ee3fba
 +
 +#endif /* i386-serenity-tdep.h */
 diff --git a/gdb/osabi.c b/gdb/osabi.c
-index aabf895..28789e8 100644
+index 40c86e7..2f4423c 100644
 --- a/gdb/osabi.c
 +++ b/gdb/osabi.c
 @@ -82,6 +82,7 @@ static const struct osabi_names gdb_osabi_names[] =
@@ -281,7 +281,7 @@ index aabf895..28789e8 100644
    { "<invalid>", NULL }
  };
 diff --git a/gdb/osabi.h b/gdb/osabi.h
-index 1ecbed4..73c5549 100644
+index be01673..36471d8 100644
 --- a/gdb/osabi.h
 +++ b/gdb/osabi.h
 @@ -46,6 +46,7 @@ enum gdb_osabi
@@ -398,6 +398,3 @@ index 0000000..43048c6
 +extern void serenity_init_abi (struct gdbarch_info info, struct gdbarch *gdbarch);
 +
 +#endif /* serenity-tdep.h */
--- 
-2.32.0
-

--- a/Ports/gdb/patches/0003-gdb-Add-build-support-for-SerenityOS.patch
+++ b/Ports/gdb/patches/0003-gdb-Add-build-support-for-SerenityOS.patch
@@ -1,7 +1,7 @@
-From e87fd74df2c7fcb4b146eb09b5b710a45003999a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Sat, 19 Feb 2022 19:47:42 -0800
-Subject: [PATCH 3/6] gdb: Add build support for SerenityOS
+Subject: [PATCH] gdb: Add build support for SerenityOS
 
 ---
  bfd/config.bfd       | 9 +++++++++
@@ -37,10 +37,10 @@ index 30087e3..11dc114 100644
    i[3-7]86-*-lynxos*)
      targ_defvec=i386_elf32_vec
 diff --git a/gdbsupport/configure b/gdbsupport/configure
-index a9dd02c..3c5bcf5 100755
+index aad7469..4c45c27 100755
 --- a/gdbsupport/configure
 +++ b/gdbsupport/configure
-@@ -8934,7 +8934,7 @@ $as_echo "$gdb_cv_cxx_std_thread" >&6; }
+@@ -8958,7 +8958,7 @@ $as_echo "$gdb_cv_cxx_std_thread" >&6; }
  
      # This check must be here, while LIBS includes any necessary
      # threading library.
@@ -64,6 +64,3 @@ index fffb91d..defc239 100755
      ;;
  esac
  
--- 
-2.32.0
-

--- a/Ports/gdb/patches/0004-serenity-Fix-compiler-fpermissive-warnings-from-usin.patch
+++ b/Ports/gdb/patches/0004-serenity-Fix-compiler-fpermissive-warnings-from-usin.patch
@@ -1,7 +1,7 @@
-From 7a5e11d2e9cbe98af96faa4835592686bf261a23 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Tue, 28 Dec 2021 04:39:25 -0800
-Subject: [PATCH 4/6] serenity: Fix compiler -fpermissive warnings from using
+Subject: [PATCH] serenity: Fix compiler -fpermissive warnings from using
  latest GCC
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 4/6] serenity: Fix compiler -fpermissive warnings from using
  1 file changed, 6 insertions(+), 3 deletions(-)
 
 diff --git a/gdb/inf-ptrace.c b/gdb/inf-ptrace.c
-index afa38de..247000a 100644
+index d628886..5f9bba9 100644
 --- a/gdb/inf-ptrace.c
 +++ b/gdb/inf-ptrace.c
 @@ -288,7 +288,7 @@ inf_ptrace_target::resume (ptid_t ptid, int step, enum gdb_signal signal)
@@ -48,6 +48,3 @@ index afa38de..247000a 100644
  	      if (errno != 0)
  		break;
  	    }
--- 
-2.32.0
-

--- a/Ports/gdb/patches/0005-serenity-Implement-custom-wait-override-for-the-sere.patch
+++ b/Ports/gdb/patches/0005-serenity-Implement-custom-wait-override-for-the-sere.patch
@@ -1,7 +1,7 @@
-From a80fc99e8f2e1c5ac1620a8c6c26d65daa98204e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Sun, 20 Feb 2022 00:32:51 -0800
-Subject: [PATCH 5/6] serenity: Implement custom wait override for the
+Subject: [PATCH] serenity: Implement custom wait override for the
  serenity_nat_target
 
 While troubleshooting why gdb wasn't working when attempting to debug
@@ -109,6 +109,3 @@ index dcd24ce..9ae3b87 100644
  };
  
  #endif /* serenity-nat.h */
--- 
-2.32.0
-

--- a/Ports/gdb/patches/0006-serenity-Implement-mourn_inferior-override-for-the-s.patch
+++ b/Ports/gdb/patches/0006-serenity-Implement-mourn_inferior-override-for-the-s.patch
@@ -1,7 +1,7 @@
-From 1285f88fcd5a8eabf5536e5af8015777f2a64117 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Sun, 20 Feb 2022 00:44:08 -0800
-Subject: [PATCH 6/6] serenity: Implement mourn_inferior override for the
+Subject: [PATCH] serenity: Implement mourn_inferior override for the
  serenity_nat_target
 
 We need to pass `WNOHANG` to our `waitpid(..)` call on SerenityOS,
@@ -46,6 +46,3 @@ index 9ae3b87..35d7ffc 100644
  private:
    bool m_attach_before_continue_called { false };
  };
--- 
-2.32.0
-

--- a/Ports/genemu/patches/0001-Manually-link-against-SDL2.patch
+++ b/Ports/genemu/patches/0001-Manually-link-against-SDL2.patch
@@ -1,7 +1,7 @@
-From 056b239a373a1ff7dafd50e75f5c08331d1fcb52 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: aabajyan <arsen.abajyan@pm.me>
 Date: Sun, 7 Mar 2021 22:30:13 +0400
-Subject: [PATCH 1/5] Manually link against SDL2
+Subject: [PATCH] Manually link against SDL2
 
 ---
  CMakeLists.txt | 18 ++++++++++++------
@@ -35,6 +35,3 @@ index 94ae8ef..a9a974c 100644
 +target_link_libraries(genemu PRIVATE ${SDL2_LIBRARIES})
 +
 +install(TARGETS genemu RUNTIME DESTINATION bin)
--- 
-2.36.1
-

--- a/Ports/genemu/patches/0002-Disable-logging.patch
+++ b/Ports/genemu/patches/0002-Disable-logging.patch
@@ -1,7 +1,7 @@
-From bf9d28049d0c69604f968eb23b1a1509f449946a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Mon, 16 May 2022 15:31:45 +0430
-Subject: [PATCH 2/5] Disable logging
+Subject: [PATCH] Disable logging
 
 ---
  mem.h | 2 +-
@@ -20,6 +20,3 @@ index 8c96952..6c39fd6 100644
  
  void mem_init(int romsize);
  int load_bin(const char *fn);
--- 
-2.36.1
-

--- a/Ports/genemu/patches/0003-Add-a-missing-cstdlib-include.patch
+++ b/Ports/genemu/patches/0003-Add-a-missing-cstdlib-include.patch
@@ -1,7 +1,7 @@
-From 0c4abad4174c3b12d5a42b62a47718896961610a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: aabajyan <arsen.abajyan@pm.me>
 Date: Sun, 7 Mar 2021 22:30:13 +0400
-Subject: [PATCH 3/5] Add a missing cstdlib include
+Subject: [PATCH] Add a missing cstdlib include
 
 ---
  mem.cpp | 1 +
@@ -19,6 +19,3 @@ index fd36d68..4cf0b30 100644
  
  uint8_t *ROM;
  uint8_t RAM[0x10000];
--- 
-2.36.1
-

--- a/Ports/genemu/patches/0004-Use-SDL2-for-SDL-includes.patch
+++ b/Ports/genemu/patches/0004-Use-SDL2-for-SDL-includes.patch
@@ -1,7 +1,7 @@
-From 426933aab1632c89ecb75918f23baa9f0c279581 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Mon, 16 May 2022 15:32:01 +0430
-Subject: [PATCH 4/5] Use <SDL2> for SDL includes
+Subject: [PATCH] Use <SDL2> for SDL includes
 
 ---
  gfx.cpp     | 2 +-
@@ -46,6 +46,3 @@ index 38bc547..aa70962 100644
  
  extern "C" {
      #include "m68k/m68k.h"
--- 
-2.36.1
-

--- a/Ports/genemu/patches/0005-Use-software-rendering.patch
+++ b/Ports/genemu/patches/0005-Use-software-rendering.patch
@@ -1,7 +1,7 @@
-From ca395dd67bfc14dcfe769b42f2ec2d3107987cab Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Mon, 16 May 2022 15:32:14 +0430
-Subject: [PATCH 5/5] Use software rendering
+Subject: [PATCH] Use software rendering
 
 ---
  hw.c | 4 ++--
@@ -27,6 +27,3 @@ index 6b864df..1f34423 100644
  
          SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");  // make the scaled rendering look smoother.
          SDL_RenderSetLogicalSize(renderer, 320, 240);
--- 
-2.36.1
-

--- a/Ports/gettext/patches/0001-Stub-out-the-getprogname-implementation.patch
+++ b/Ports/gettext/patches/0001-Stub-out-the-getprogname-implementation.patch
@@ -1,7 +1,7 @@
-From 5eb27ed6f09fb3387c23fb6cd4c39204d4592787 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Mon, 16 May 2022 15:44:53 +0430
-Subject: [PATCH 1/2] Stub out the getprogname() implementation
+Subject: [PATCH] Stub out the getprogname() implementation
 
 ---
  gettext-runtime/gnulib-lib/getprogname.c | 2 ++
@@ -62,6 +62,3 @@ index 5e6f764..e800b89 100644
  # else
  #  error "getprogname module not ported to this OS"
  # endif
--- 
-2.36.1
-

--- a/Ports/gettext/patches/0002-Stub-out-some-wctype-functions.patch
+++ b/Ports/gettext/patches/0002-Stub-out-some-wctype-functions.patch
@@ -1,7 +1,7 @@
-From 83aa314598238bfcbd9d55aa96a3fbe937c45a81 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Mon, 16 May 2022 15:45:32 +0430
-Subject: [PATCH 2/2] Stub out some wctype functions
+Subject: [PATCH] Stub out some wctype functions
 
 ---
  gettext-tools/gnulib-lib/fnmatch.c | 12 ++++++++++++
@@ -30,6 +30,3 @@ index 3937ce3..84aa6e6 100644
  #define IS_CHAR_CLASS(string) wctype (string)
  
  /* Avoid depending on library functions or files
--- 
-2.36.1
-

--- a/Ports/git/patches/0001-Remove-some-unimplemented-function-calls.patch
+++ b/Ports/git/patches/0001-Remove-some-unimplemented-function-calls.patch
@@ -1,7 +1,7 @@
-From 5d3c9d7aafc66abe10e035a7930b0868f73916b5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Federico Guerinoni <41150432+guerinoni@users.noreply.github.com>
 Date: Fri, 16 Apr 2021 17:38:54 +0200
-Subject: [PATCH 1/2] Remove some unimplemented function calls
+Subject: [PATCH] Remove some unimplemented function calls
 
 i.e. f(un)lockfile stubs and setitimer.
 ---
@@ -69,6 +69,3 @@ index 0cdd875..19a2a67 100644
  	signal(SIGALRM, SIG_IGN);
  	progress_update = 0;
  }
--- 
-2.36.1
-

--- a/Ports/git/patches/0002-Remove-uname-detection-in-config.mak.uname.patch
+++ b/Ports/git/patches/0002-Remove-uname-detection-in-config.mak.uname.patch
@@ -1,7 +1,7 @@
-From 1dc6e8b8d7cb459ce209b9f55a69c1f53f277daa Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: TheFightingCatfish <seekingblues@gmail.com>
 Date: Fri, 13 Aug 2021 06:52:59 +0800
-Subject: [PATCH 2/2] Remove uname detection in config.mak.uname
+Subject: [PATCH] Remove uname detection in config.mak.uname
 
 ---
  config.mak.uname | 12 ++++++------
@@ -30,6 +30,3 @@ index 259d151..b072f4c 100644
  
  ifneq ($(findstring MINGW,$(uname_S)),)
  	uname_S := MINGW
--- 
-2.36.1
-

--- a/Ports/glib/patches/0001-poll.h-is-located-at-root-not-sys-poll.h.patch
+++ b/Ports/glib/patches/0001-poll.h-is-located-at-root-not-sys-poll.h.patch
@@ -1,18 +1,17 @@
-From d39946bd24a98fbcee4740f14ccd85ed75f312c6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Thu, 12 Aug 2021 20:29:32 +0200
-Subject: [PATCH 01/12] meson.build: 'poll.h' is located at root, not
- 'sys/poll.h'
+Subject: [PATCH] 'poll.h' is located at root, not 'sys/poll.h'
 
 ---
  meson.build | 18 ++++++++++++++----
  1 file changed, 14 insertions(+), 4 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 1b54fdc..6b22e98 100644
+index a330b7b..0034898 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1717,7 +1717,11 @@ g_have_gnuc_varargs = cc.compiles('''
+@@ -1758,7 +1758,11 @@ g_have_gnuc_varargs = cc.compiles('''
  if cc.has_header('alloca.h')
    glibconfig_conf.set('GLIB_HAVE_ALLOCA_H', true)
  endif
@@ -25,7 +24,7 @@ index 1b54fdc..6b22e98 100644
  has_systypes = cc.has_header('sys/types.h')
  if has_syspoll
    glibconfig_conf.set('GLIB_HAVE_SYS_POLL_H', true)
-@@ -1725,9 +1729,15 @@ endif
+@@ -1766,9 +1770,15 @@ endif
  has_winsock2 = cc.has_header('winsock2.h')
  
  if has_syspoll and has_systypes
@@ -44,6 +43,3 @@ index 1b54fdc..6b22e98 100644
  elif has_winsock2
    poll_includes = '''
        #define _WIN32_WINNT @0@
--- 
-2.25.1
-

--- a/Ports/glib/patches/0002-Use-glib-s-in-built-C_IN.patch
+++ b/Ports/glib/patches/0002-Use-glib-s-in-built-C_IN.patch
@@ -1,7 +1,7 @@
-From a88e13c5461e50ddcad4b8ebeae8d15cee64368b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Thu, 12 Aug 2021 20:22:35 +0200
-Subject: [PATCH 02/12] gio/meson.build: Use glib's in-built C_IN
+Subject: [PATCH] Use glib's in-built C_IN
 
 Since we do not have C_IN and glib has functionality for providing it,
 let glib provide it.
@@ -10,7 +10,7 @@ let glib provide it.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/gio/meson.build b/gio/meson.build
-index 49a37a7..b4ba866 100644
+index 543763e..bbedf47 100644
 --- a/gio/meson.build
 +++ b/gio/meson.build
 @@ -13,7 +13,7 @@ gnetworking_h_conf = configuration_data()
@@ -22,6 +22,3 @@ index 49a37a7..b4ba866 100644
    # Don't check for C_IN on Android since it does not define it in public
    # headers, we define it ourselves wherever necessary
    if not cc.compiles('''#include <sys/types.h>
--- 
-2.25.1
-

--- a/Ports/glib/patches/0003-Let-glib-know-where-our-resolv.h-is-located.patch
+++ b/Ports/glib/patches/0003-Let-glib-know-where-our-resolv.h-is-located.patch
@@ -1,15 +1,14 @@
-From ba252fc514f8efa5af26fba2991caed73e2be771 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Thu, 12 Aug 2021 20:25:48 +0200
-Subject: [PATCH 03/12] gio/meson.build: Let glib know where our 'resolv.h' is
- located
+Subject: [PATCH] Let glib know where our 'resolv.h' is located
 
 ---
  gio/meson.build | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/gio/meson.build b/gio/meson.build
-index b4ba866..849ea80 100644
+index bbedf47..b30cd7c 100644
 --- a/gio/meson.build
 +++ b/gio/meson.build
 @@ -34,7 +34,7 @@ endif
@@ -21,6 +20,3 @@ index b4ba866..849ea80 100644
    # res_query()
    res_query_test = '''#include <resolv.h>
                        int main (int argc, char ** argv) {
--- 
-2.25.1
-

--- a/Ports/glib/patches/0004-Disable-IPV6-support.patch
+++ b/Ports/glib/patches/0004-Disable-IPV6-support.patch
@@ -1,7 +1,7 @@
-From 3bc52eef1086032e2c0379b3f86ce19760db818e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Thu, 12 Aug 2021 20:33:11 +0200
-Subject: [PATCH 04/12] meson.build: Disable IPV6 support
+Subject: [PATCH] Disable IPV6 support
 
 Serenity does not have IPV6 support so disable it
 ---
@@ -9,10 +9,10 @@ Serenity does not have IPV6 support so disable it
  1 file changed, 2 insertions(+)
 
 diff --git a/meson.build b/meson.build
-index f4025d8..d1745de 100644
+index 0034898..26ece5a 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1789,6 +1789,8 @@ endforeach
+@@ -1840,6 +1840,8 @@ endforeach
  
  if host_system == 'windows'
    have_ipv6 = true
@@ -21,6 +21,3 @@ index f4025d8..d1745de 100644
  else
    have_ipv6 = cc.has_type('struct in6_addr', prefix: '#include <netinet/in.h>')
  endif
--- 
-2.25.1
-

--- a/Ports/glib/patches/0005-Serenity-does-not-have-IN_MULTICAST-just-return-0.patch
+++ b/Ports/glib/patches/0005-Serenity-does-not-have-IN_MULTICAST-just-return-0.patch
@@ -1,8 +1,7 @@
-From 192e9481041cb925c6934f51b75f27aaf3421432 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Thu, 12 Aug 2021 20:35:16 +0200
-Subject: [PATCH 05/12] gio/ginetaddress.c: Serenity does not have
- IN_MULTICAST, just return 0
+Subject: [PATCH] Serenity does not have IN_MULTICAST, just return 0
 
 Since Serenity does not have IN_MULTICAST we just return 0
 ---
@@ -26,6 +25,3 @@ index ada32f8..7a0a0c2 100644
      }
    else
  #ifdef HAVE_IPV6
--- 
-2.25.1
-

--- a/Ports/glib/patches/0006-Rename-glib-gio-mount-function-to-gio_mount.patch
+++ b/Ports/glib/patches/0006-Rename-glib-gio-mount-function-to-gio_mount.patch
@@ -1,8 +1,7 @@
-From cadaea8b2c881bf4fcfa75a03fe07ae1addd4f43 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Thu, 12 Aug 2021 20:38:51 +0200
-Subject: [PATCH 06/12] gio/gio-tool-mount.c: Rename glib/gio mount function to
- gio_mount
+Subject: [PATCH] Rename glib/gio mount function to gio_mount
 
 Somehow glib picks up on Serenity's mount function and gets confused
 ---
@@ -34,6 +33,3 @@ index c624268..24723c5 100644
            g_object_unref (file);
          }
      }
--- 
-2.25.1
-

--- a/Ports/glib/patches/0007-Include-arpa-compatibility-definitions.patch
+++ b/Ports/glib/patches/0007-Include-arpa-compatibility-definitions.patch
@@ -1,7 +1,7 @@
-From f4bbbbae7d502766e44c69f6c9286ef9ed0bf485 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Thu, 12 Aug 2021 20:54:46 +0200
-Subject: [PATCH 09/12] gio/gthredresolver.c: Need to include this section
+Subject: [PATCH] Include arpa compatibility definitions
 
 Serenity is missing all that is defined in this section so let's
 include it.
@@ -10,7 +10,7 @@ include it.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/gio/gthreadedresolver.c b/gio/gthreadedresolver.c
-index 93794b5..64c3b2e 100644
+index aeeb40e..3a48b27 100644
 --- a/gio/gthreadedresolver.c
 +++ b/gio/gthreadedresolver.c
 @@ -394,7 +394,7 @@ lookup_by_address_finish (GResolver     *resolver,
@@ -22,6 +22,3 @@ index 93794b5..64c3b2e 100644
  /* Copy from bionic/libc/private/arpa_nameser_compat.h
   * and bionic/libc/private/arpa_nameser.h */
  typedef struct {
--- 
-2.25.1
-

--- a/Ports/glib/patches/0008-Add-stub-for-function-dn_expand.patch
+++ b/Ports/glib/patches/0008-Add-stub-for-function-dn_expand.patch
@@ -1,8 +1,7 @@
-From 1fe4b3e57a1997dac79865b8b9790fae3597f175 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Thu, 12 Aug 2021 20:56:26 +0200
-Subject: [PATCH 10/12] gio/gthreadedresolver.c: Add stub for function
- dn_expand.
+Subject: [PATCH] Add stub for function dn_expand.
 
 Serenity is missing dn_expand so include a stub for it
 ---
@@ -10,7 +9,7 @@ Serenity is missing dn_expand so include a stub for it
  1 file changed, 6 insertions(+)
 
 diff --git a/gio/gthreadedresolver.c b/gio/gthreadedresolver.c
-index 64c3b2e..ef709e0 100644
+index 3a48b27..8d51967 100644
 --- a/gio/gthreadedresolver.c
 +++ b/gio/gthreadedresolver.c
 @@ -462,6 +462,12 @@ typedef struct {
@@ -26,6 +25,3 @@ index 64c3b2e..ef709e0 100644
  #define dn_skipname __dn_skipname
  int dn_skipname(const u_char *, const u_char *);
  
--- 
-2.25.1
-

--- a/Ports/glib/patches/0009-ntohl-ntohs-is-located-in-arpa-inet.h.patch
+++ b/Ports/glib/patches/0009-ntohl-ntohs-is-located-in-arpa-inet.h.patch
@@ -1,8 +1,7 @@
-From 821b33fbb3e93dfd3d43c98146a3399fd8ff1f41 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Thu, 12 Aug 2021 20:59:25 +0200
-Subject: [PATCH 11/12] gio/xdgmime/xdgmimecache.c: ntohl/ntohs is located in
- 'arpa/inet.h'
+Subject: [PATCH] ntohl/ntohs is located in 'arpa/inet.h'
 
 In Serenity ntohl/ntohs is located in arpa/inet.h, other stuff glib
 needs is included in 'netinet/in.h'.
@@ -11,10 +10,10 @@ needs is included in 'netinet/in.h'.
  1 file changed, 5 insertions(+)
 
 diff --git a/gio/xdgmime/xdgmimecache.c b/gio/xdgmime/xdgmimecache.c
-index 769b578..625d8cc 100644
+index f80f122..45220cc 100644
 --- a/gio/xdgmime/xdgmimecache.c
 +++ b/gio/xdgmime/xdgmimecache.c
-@@ -34,7 +34,12 @@
+@@ -38,7 +38,12 @@
  #include <fnmatch.h>
  #include <assert.h>
  
@@ -27,6 +26,3 @@ index 769b578..625d8cc 100644
  
  #ifdef HAVE_MMAP
  #include <sys/mman.h>
--- 
-2.25.1
-

--- a/Ports/glib/patches/0010-Include-strings.h-for-strcasecmp.patch
+++ b/Ports/glib/patches/0010-Include-strings.h-for-strcasecmp.patch
@@ -1,7 +1,7 @@
-From 5029cb921ae1420ef10d5ecb97d07ef9a9b5070a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Thu, 12 Aug 2021 21:03:13 +0200
-Subject: [PATCH 12/12] Include 'strings.h' for strcasecmp
+Subject: [PATCH] Include 'strings.h' for strcasecmp
 
 ---
  glib/glib-init.c | 3 +++
@@ -9,7 +9,7 @@ Subject: [PATCH 12/12] Include 'strings.h' for strcasecmp
  2 files changed, 6 insertions(+)
 
 diff --git a/glib/glib-init.c b/glib/glib-init.c
-index 2958fb5..ef49806 100644
+index e7b4984..340b358 100644
 --- a/glib/glib-init.c
 +++ b/glib/glib-init.c
 @@ -26,6 +26,9 @@
@@ -23,7 +23,7 @@ index 2958fb5..ef49806 100644
  #include <stdlib.h>
  #include <stdio.h>
 diff --git a/glib/gstrfuncs.c b/glib/gstrfuncs.c
-index b6ff60f..670d1aa 100644
+index 9273533..de22330 100644
 --- a/glib/gstrfuncs.c
 +++ b/glib/gstrfuncs.c
 @@ -32,6 +32,9 @@
@@ -36,6 +36,3 @@ index b6ff60f..670d1aa 100644
  #include <string.h>
  #include <locale.h>
  #include <errno.h>
--- 
-2.25.1
-

--- a/Ports/glib/patches/0011-Exclude-arpa-nameser.h-as-it-does-not-exist-on-Seren.patch
+++ b/Ports/glib/patches/0011-Exclude-arpa-nameser.h-as-it-does-not-exist-on-Seren.patch
@@ -1,7 +1,7 @@
-From fb55058ea91d87802c696aa58bcaf97a6ff5b827 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Fri, 13 Aug 2021 22:32:25 +0200
-Subject: [PATCH 13/13] arpa/nameser.h is not needed, and Serenity does not have it at the moment.
+Subject: [PATCH] Exclude arpa/nameser.h as it does not exist on Serenity
 
 ---
  gio/gnetworking.h.in | 2 ++
@@ -21,6 +21,3 @@ index 2fa95ff..1d138cf 100644
  @NAMESER_COMPAT_INCLUDE@
  
  #ifndef T_SRV
--- 
-2.25.1
-

--- a/Ports/glib/patches/ReadMe.md
+++ b/Ports/glib/patches/ReadMe.md
@@ -1,67 +1,67 @@
 # Patches for glib on SerenityOS
 
-## `0001-poll.h-is-located-at-root.patch`
+## `0001-poll.h-is-located-at-root-not-sys-poll.h.patch`
 
-meson.build: 'poll.h' is located at root, not 'sys/poll.h'
+'poll.h' is located at root, not 'sys/poll.h'
 
 
-## `0002-use-glib-in-built-C_IN.patch`
+## `0002-Use-glib-s-in-built-C_IN.patch`
 
-gio/meson.build: Use glib's in-built C_IN
+Use glib's in-built C_IN
 
 Since we do not have C_IN and glib has functionality for providing it,
 let glib provide it.
 
-## `0003-let-glib-know-where-our-resolv.h-is.patch`
+## `0003-Let-glib-know-where-our-resolv.h-is-located.patch`
 
-gio/meson.build: Let glib know where our 'resolv.h' is located
+Let glib know where our 'resolv.h' is located
 
 
-## `0004-disable-IPV6-support.patch`
+## `0004-Disable-IPV6-support.patch`
 
-meson.build: Disable IPV6 support
+Disable IPV6 support
 
 Serenity does not have IPV6 support so disable it
 
-## `0005-serenity-does-not-have-IN_MULTICAST.patch`
+## `0005-Serenity-does-not-have-IN_MULTICAST-just-return-0.patch`
 
-gio/ginetaddress.c: Serenity does not have IN_MULTICAST, just return 0
+Serenity does not have IN_MULTICAST, just return 0
 
 Since Serenity does not have IN_MULTICAST we just return 0
 
-## `0006-conflict-rename-gio-mount-function.patch`
+## `0006-Rename-glib-gio-mount-function-to-gio_mount.patch`
 
-gio/gio-tool-mount.c: Rename glib/gio mount function to gio_mount
+Rename glib/gio mount function to gio_mount
 
 Somehow glib picks up on Serenity's mount function and gets confused
 
-## `0009-include-section-with-missing-functionality.patch`
+## `0007-Include-arpa-compatibility-definitions.patch`
 
-gio/gthredresolver.c: Need to include this section
+Include arpa compatibility definitions
 
 Serenity is missing all that is defined in this section so let's
 include it.
 
-## `0010-stub-for-function-dn_expand.patch`
+## `0008-Add-stub-for-function-dn_expand.patch`
 
-gio/gthreadedresolver.c: Add stub for function dn_expand.
+Add stub for function dn_expand.
 
 Serenity is missing dn_expand so include a stub for it
 
-## `0011-ntohl-ntohs-located-in-arpa-inet.h.patch`
+## `0009-ntohl-ntohs-is-located-in-arpa-inet.h.patch`
 
-gio/xdgmime/xdgmimecache.c: ntohl/ntohs is located in 'arpa/inet.h'
+ntohl/ntohs is located in 'arpa/inet.h'
 
 In Serenity ntohl/ntohs is located in arpa/inet.h, other stuff glib
 needs is included in 'netinet/in.h'.
 
-## `0012-include-strings.h-for-strcasecmp.patch`
+## `0010-Include-strings.h-for-strcasecmp.patch`
 
 Include 'strings.h' for strcasecmp
 
 
-## `0013-nameser.h-is-not-needed.patch`
+## `0011-Exclude-arpa-nameser.h-as-it-does-not-exist-on-Seren.patch`
 
-arpa/nameser.h is not needed, and Serenity does not have it at the moment.
+Exclude arpa/nameser.h as it does not exist on Serenity
 
 

--- a/Ports/gltron/patches/0001-Build-Allow-CFLAGS-env-var-to-be-set.patch
+++ b/Ports/gltron/patches/0001-Build-Allow-CFLAGS-env-var-to-be-set.patch
@@ -1,7 +1,7 @@
-From 94e90c97566a73cb03c4837d53a4cddf452e42bf Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Mon, 9 May 2022 00:29:43 +0200
-Subject: [PATCH 1/7] Build: Allow `CFLAGS` env var to be set
+Subject: [PATCH] Build: Allow `CFLAGS` env var to be set
 
 ---
  configure | 2 +-
@@ -20,6 +20,3 @@ index 226d00e..05ebf5d 100755
  
  # Check whether --enable-warn or --disable-warn was given.
  if test "${enable_warn+set}" = set; then
--- 
-2.34.1
-

--- a/Ports/gltron/patches/0002-Build-Replace-lGL-with-lgl-to-reference-our-LibGL.patch
+++ b/Ports/gltron/patches/0002-Build-Replace-lGL-with-lgl-to-reference-our-LibGL.patch
@@ -1,7 +1,7 @@
-From dd42cfe84e75619676a06b05f8ebe1c1c2e658c9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Mon, 9 May 2022 00:30:04 +0200
-Subject: [PATCH 2/7] Build: Replace `-lGL` with `-lgl` to reference our LibGL
+Subject: [PATCH] Build: Replace `-lGL` with `-lgl` to reference our LibGL
 
 ---
  configure | 4 ++--
@@ -29,6 +29,3 @@ index 05ebf5d..10f771f 100755
  
  else
    { { echo "$as_me:3177: error: OpenGL is not installed" >&5
--- 
-2.34.1
-

--- a/Ports/gltron/patches/0003-Build-Remove-ansi-build-argument.patch
+++ b/Ports/gltron/patches/0003-Build-Remove-ansi-build-argument.patch
@@ -1,7 +1,7 @@
-From b01d5c00dd0dbe9512857e32ffd0822bdfb8a9e3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Mon, 9 May 2022 00:30:54 +0200
-Subject: [PATCH 3/7] Build: Remove `-ansi` build argument
+Subject: [PATCH] Build: Remove `-ansi` build argument
 
 ---
  lua/src/Makefile.in     | 2 +-
@@ -34,6 +34,3 @@ index e2f256f..d2f4040 100644
  LDFLAGS = 
  LIBS = -lm
  
--- 
-2.34.1
-

--- a/Ports/gltron/patches/0004-Build-Fix-char-vs.-const-char-arguments.patch
+++ b/Ports/gltron/patches/0004-Build-Fix-char-vs.-const-char-arguments.patch
@@ -1,7 +1,7 @@
-From 0ec20dfd57ae517d18f06c4c580d346fddd2f926 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Mon, 9 May 2022 00:32:04 +0200
-Subject: [PATCH 4/7] Build: Fix `char*` vs. `const char*` arguments
+Subject: [PATCH] Build: Fix `char*` vs. `const char*` arguments
 
 These arguments are of the wrong constness, which will trip our
 compiler.
@@ -26,6 +26,3 @@ index 867eada..f5d8084 100644
  extern void scripting_RunGC();
  extern void scripting_Register(const char *name, int(*func) (lua_State *L));
  
--- 
-2.34.1
-

--- a/Ports/gltron/patches/0005-Scripting-Fix-default-keybindings.patch
+++ b/Ports/gltron/patches/0005-Scripting-Fix-default-keybindings.patch
@@ -1,7 +1,7 @@
-From d2a56ba682814f2d2451fc0729ada79290de2939 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Mon, 9 May 2022 00:36:08 +0200
-Subject: [PATCH 5/7] Scripting: Fix default keybindings
+Subject: [PATCH] Scripting: Fix default keybindings
 
 These constants referred to the wrong keys.
 ---
@@ -41,6 +41,3 @@ index 3c9e6d2..4755678 100644
     },
     { -- player 3
        left = 276, -- cursor left
--- 
-2.34.1
-

--- a/Ports/gltron/patches/0006-SDL-Convert-SDL1-to-SDL2.patch
+++ b/Ports/gltron/patches/0006-SDL-Convert-SDL1-to-SDL2.patch
@@ -1,7 +1,7 @@
-From bcaa941ae5b682862aacff18e44a8a33294ba716 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Mon, 9 May 2022 00:53:48 +0200
-Subject: [PATCH 6/7] SDL: Convert SDL1 to SDL2
+Subject: [PATCH] SDL: Convert SDL1 to SDL2
 
 ---
  nebu/input/input_system.c |  7 ++++---
@@ -108,6 +108,3 @@ index bb787e5..c35eeca 100644
    
  	/* joystick */
  	if(SDL_Init(SDL_INIT_JOYSTICK) >= 0) {
--- 
-2.34.1
-

--- a/Ports/gltron/patches/0007-SDL-Fix-2x-audio-rate-issue.patch
+++ b/Ports/gltron/patches/0007-SDL-Fix-2x-audio-rate-issue.patch
@@ -1,7 +1,7 @@
-From ad6b92ee167f1241de38da428a01c27f410f3d49 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Mon, 9 May 2022 01:01:47 +0200
-Subject: [PATCH 7/7] SDL: Fix 2x audio rate issue
+Subject: [PATCH] SDL: Fix 2x audio rate issue
 
 By not passing in an `obtained` struct into `SDL_OpenAudio`, we ask SDL
 to perform any sample rate and/or format conversion for us. Previously
@@ -24,6 +24,3 @@ index 9753f09..e08b1b3 100644
        fprintf(stderr, "[error] %s\n", SDL_GetError());
        sound->SetStatus(Sound::eUninitialized);
      } else {
--- 
-2.34.1
-

--- a/Ports/gmp/patches/0001-Teach-configfsf.sub-about-serenity.patch
+++ b/Ports/gmp/patches/0001-Teach-configfsf.sub-about-serenity.patch
@@ -1,4 +1,4 @@
-From 09cd709c6d4b7e180b2ddff01f3f03ac658726b3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brendan Coles <bcoles@gmail.com>
 Date: Thu, 8 Apr 2021 07:11:06 +0000
 Subject: [PATCH] Teach configfsf.sub about serenity
@@ -19,6 +19,3 @@ index 8167d08..ad8066a 100755
  	     | *vms* | esix* | aix* | cnk* | sunos | sunos[34]* \
  	     | hpux* | unos* | osf* | luna* | dgux* | auroraux* | solaris* \
  	     | sym* |  plan9* | psp* | sim* | xray* | os68k* | v88r* \
--- 
-2.36.1
-

--- a/Ports/gnuapl/patches/0001-Include-fcntl-find-fcntl.h.patch
+++ b/Ports/gnuapl/patches/0001-Include-fcntl-find-fcntl.h.patch
@@ -1,7 +1,7 @@
-From 579a391c43b9f0972205d565b3baf908cfd79330 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tobias Christiansen <tobyase@serenityos.org>
 Date: Fri, 11 Mar 2022 19:01:35 +0100
-Subject: [PATCH 1/3] Include fcntl find fcntl.h
+Subject: [PATCH] Include fcntl find fcntl.h
 
 `fcntl.h` was included as `sys/fcntl.h`, which is not where this lives in Serenity.
 
@@ -24,6 +24,3 @@ index 2482a13..6476f11 100644
  
  #ifdef ENABLE_NLS
  #include <libintl.h>
--- 
-2.36.1
-

--- a/Ports/gnuapl/patches/0002-Stub-out-the-performance-report-macro.patch
+++ b/Ports/gnuapl/patches/0002-Stub-out-the-performance-report-macro.patch
@@ -1,7 +1,7 @@
-From 44e3ce1d066e2bcc574081ed828368974e0262a2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tobias Christiansen <tobyase@serenityos.org>
 Date: Fri, 11 Mar 2022 19:01:35 +0100
-Subject: [PATCH 2/3] Stub out the performance report macro
+Subject: [PATCH] Stub out the performance report macro
 
 The Macro for performance reporting was throwing compile errors, so we just stub it out.
 ---
@@ -21,6 +21,3 @@ index e77b6da..1d6ff6e 100644
  #define perfo_4(id, ab, name, thr) perfo_3(id, ab, name, thr)
  
  #include "Performance.def"
--- 
-2.36.1
-

--- a/Ports/gnuapl/patches/0003-Remove-use-of-sbrk.patch
+++ b/Ports/gnuapl/patches/0003-Remove-use-of-sbrk.patch
@@ -1,7 +1,7 @@
-From c7d2b841f46831b159ed715cc5f313129ba6fb10 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tobias Christiansen <tobyase@serenityos.org>
 Date: Fri, 11 Mar 2022 19:01:35 +0100
-Subject: [PATCH 3/3] Remove use of sbrk()
+Subject: [PATCH] Remove use of sbrk()
 
 Again, for performance reporting the function `sbrk` is needed which we don't have. We just stub it out.
 ---
@@ -23,6 +23,3 @@ index 6e5292f..704d75c 100644
 +   return 0xFFFFFFFFULL;
  }
  
--- 
-2.36.1
-

--- a/Ports/gnucobol/patches/0001-Use-bin-bash-instead-of-bin-sh-for-shebang.patch
+++ b/Ports/gnucobol/patches/0001-Use-bin-bash-instead-of-bin-sh-for-shebang.patch
@@ -1,4 +1,4 @@
-From 1cb46c1d7736ebbfe00194e675d29308beb94911 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brendan Coles <bcoles@gmail.com>
 Date: Thu, 8 Apr 2021 12:14:24 +0000
 Subject: [PATCH] Use /bin/bash instead of /bin/sh for shebang
@@ -17,6 +17,3 @@ index 6c07e7d..3086d8c 100644
  #
  # cob-config
  #
--- 
-2.36.1
-

--- a/Ports/gnuplot/patches/0001-Don-t-build-the-docs-and-the-demo.patch
+++ b/Ports/gnuplot/patches/0001-Don-t-build-the-docs-and-the-demo.patch
@@ -1,4 +1,4 @@
-From f05fc83941deb37eac3ac9caa95376d107215f79 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Linus Groh <mail@linusgroh.de>
 Date: Wed, 15 Apr 2020 14:23:25 +0100
 Subject: [PATCH] Don't build the docs and the demo
@@ -25,6 +25,3 @@ index 9241ce5..1e2f6c6 100644
  
  EXTRA_DIST = BUGS Copyright FAQ.pdf GNUmakefile INSTALL INSTALL.gnu \
  Makefile.maint PATCHLEVEL PGPKEYS README RELEASE_NOTES \
--- 
-2.36.1
-

--- a/Ports/gsl/patches/0001-Make-configure-pass-all-dependency-checks-for-sereni.patch
+++ b/Ports/gsl/patches/0001-Make-configure-pass-all-dependency-checks-for-sereni.patch
@@ -1,7 +1,7 @@
-From 4476d98e7c01bf1d5f45fe24a28ceac279949454 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Rodrigo Tobar <rtobarc@gmail.com>
 Date: Wed, 8 Sep 2021 00:13:16 +0800
-Subject: [PATCH 1/1] Make configure pass all dependency checks for serenity
+Subject: [PATCH] Make configure pass all dependency checks for serenity
 
 ---
  configure | 4 ++++
@@ -22,6 +22,3 @@ index b593652..28269b6 100755
  cygwin*)
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
--- 
-2.36.1
-

--- a/Ports/guile/patches/0001-build-When-cross-compiling-get-type-sizes-of-the-tar.patch
+++ b/Ports/guile/patches/0001-build-When-cross-compiling-get-type-sizes-of-the-tar.patch
@@ -1,7 +1,7 @@
-From 2029ec1800c3e9a1d8a50f158c1550523c022cec Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ludovic=20Court=C3=A8s?= <ludo@gnu.org>
 Date: Mon, 28 Feb 2022 22:57:52 +0100
-Subject: [PATCH 1/2] build: When cross-compiling, get type sizes of the target
+Subject: [PATCH] build: When cross-compiling, get type sizes of the target
  system.
 
 Fixes <https://issues.guix.gnu.org/54198>.
@@ -80,6 +80,3 @@ index 01b14f1..691ebd0 100644
  
    pf ("\n");
    pf ("/* same as POSIX \"struct timespec\" -- always defined */\n");
--- 
-2.36.1
-

--- a/Ports/guile/patches/0002-Remove-contents-of-return_unused_stack_to_os.patch
+++ b/Ports/guile/patches/0002-Remove-contents-of-return_unused_stack_to_os.patch
@@ -1,7 +1,7 @@
-From fcd26f263a018d69cf62135f798a04d4c354d5f1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Elliott <pelliott@ualberta.ca>
 Date: Wed, 18 May 2022 01:43:41 -0600
-Subject: [PATCH 2/2] Remove contents of return_unused_stack_to_os
+Subject: [PATCH] Remove contents of return_unused_stack_to_os
 
 guile attempts to madvise(2) away parts of the stack, but serenity only
 supports madvise(2) on entire mmaped regions.
@@ -44,6 +44,3 @@ index 6fd5c55..2eab110 100644
  }
  
  #define SLOT_MAP_CACHE_SIZE 32U
--- 
-2.36.1
-

--- a/Ports/halflife/patches/fwgs-add-serenity.patch
+++ b/Ports/halflife/patches/fwgs-add-serenity.patch
@@ -1,4 +1,4 @@
-From 9b3a3057e154062384b46082d423285f21da28a2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jesse Buhagiar <jooster669@gmail.com>
 Date: Sun, 2 Jan 2022 00:39:02 +1100
 Subject: [PATCH] Build: Add SerenityOS to list of compatible systems

--- a/Ports/halflife/patches/fwgs-dont-format-nan-loop.patch
+++ b/Ports/halflife/patches/fwgs-dont-format-nan-loop.patch
@@ -1,4 +1,4 @@
-From 1bc4a88e6a34b89538f07916479228758dd13155 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Mon, 2 May 2022 01:22:35 +0200
 Subject: [PATCH] Engine: Keep HTTP from endlessly formatting NaN values

--- a/Ports/halflife/patches/hlsdk-add-serenity.patch
+++ b/Ports/halflife/patches/hlsdk-add-serenity.patch
@@ -1,4 +1,4 @@
-From cfeb76389a3f6ad2691a4838c95365f49305f16d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jesse Buhagiar <jooster669@gmail.com>
 Date: Sun, 2 Jan 2022 00:10:53 +1100
 Subject: [PATCH] Build: Add SerenityOS to list of compatible systems

--- a/Ports/halflife/patches/hlsdk-strings-compat.patch
+++ b/Ports/halflife/patches/hlsdk-strings-compat.patch
@@ -1,4 +1,4 @@
-From 673aea20b5917dd7e295f795eb0dd730598c9b0a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jesse Buhagiar <jooster669@gmail.com>
 Date: Sun, 2 Jan 2022 00:27:17 +1100
 Subject: [PATCH] Build: Add `__STRINGS_H_COMPAT_HACK` macro

--- a/Ports/harfbuzz/patches/0001-Mark-a-possibly-unused-variable-as-maybe_unused.patch
+++ b/Ports/harfbuzz/patches/0001-Mark-a-possibly-unused-variable-as-maybe_unused.patch
@@ -1,4 +1,4 @@
-From d9b8ddabdfcd3113fecdbffa8cc3538419f2d2b4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Sat, 8 May 2021 05:23:29 +0200
 Subject: [PATCH] Mark a possibly-unused variable as [[maybe_unused]]
@@ -20,6 +20,3 @@ index 8b432b5..ab18f2e 100644
      assert (bits == (allocated_var_bits & bits));
  #endif
    }
--- 
-2.36.1
-

--- a/Ports/imgcat/patches/0001-Remove-an-include-of-err.h.patch
+++ b/Ports/imgcat/patches/0001-Remove-an-include-of-err.h.patch
@@ -1,4 +1,4 @@
-From 6163cab16b54ccc7301a083f9f3f7c7b6d435713 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 8 May 2022 22:53:34 +0200
 Subject: [PATCH] Remove an include of `err.h`
@@ -21,6 +21,3 @@ index 26a73d7..89fc05d 100644
  #include <limits.h>
  
  #include <getopt.h>
--- 
-2.36.1
-

--- a/Ports/indent/patches/0001-Don-t-build-docs.patch
+++ b/Ports/indent/patches/0001-Don-t-build-docs.patch
@@ -1,4 +1,4 @@
-From e8f990d19324dd80271db8626b72c57aaceb26b9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brendan Coles <bcoles@gmail.com>
 Date: Mon, 9 Nov 2020 10:52:11 +0000
 Subject: [PATCH] Don't build docs
@@ -20,6 +20,3 @@ index cdf7999..ce49203 100644
  BUILT_SOURCES = 
  EXTRA_DIST = README \
  		config/config.rpath config/mkinstalldirs \
--- 
-2.36.1
-

--- a/Ports/ja2/patches/0001-Make-it-build-with-SDL-2-instead-of-1.2.patch
+++ b/Ports/ja2/patches/0001-Make-it-build-with-SDL-2-instead-of-1.2.patch
@@ -1,4 +1,4 @@
-From c818e1fcd3c2e2f5433b20fffd1fda3462b5064f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: safarp <safar.pavel@gmail.com>
 Date: Mon, 21 Mar 2022 21:51:29 +0100
 Subject: [PATCH] Make it build with SDL 2 instead of 1.2
@@ -2476,6 +2476,3 @@ index fbb980b..2158ef3 100644
  void InvalidateRegionEx(INT32 iLeft, INT32 iTop, INT32 iRight, INT32 iBottom);
  
  void RefreshScreen(void);
--- 
-2.36.1
-

--- a/Ports/joe/patches/0001-Define-__USE_MISC-in-checkwidths.c.patch
+++ b/Ports/joe/patches/0001-Define-__USE_MISC-in-checkwidths.c.patch
@@ -1,7 +1,7 @@
-From becc61b31858199a1cff4278bb2239d05ff9d38f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Snow <i@xkun.me>
 Date: Sun, 15 May 2022 11:41:03 +0800
-Subject: [PATCH 1/3] Define __USE_MISC in checkwidths.c
+Subject: [PATCH] Define __USE_MISC in checkwidths.c
 
 Define `__USE_MISC` manually in `checkwidths.c` for `ECHOCTL` and `ECHOKE`,
 see `Kernel/API/POSIX/termios.h`.
@@ -22,6 +22,3 @@ index 509447d..944faef 100644
  #include <stdio.h>
  #include <string.h>
  #include <stdlib.h>
--- 
-2.36.1
-

--- a/Ports/joe/patches/0002-Remove-the-sys-prefix-for-the-fcntl-include.patch
+++ b/Ports/joe/patches/0002-Remove-the-sys-prefix-for-the-fcntl-include.patch
@@ -1,7 +1,7 @@
-From 7136012c016c40b890ae4db5b3e4da4bf9b57caf Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Snow <i@xkun.me>
 Date: Sun, 15 May 2022 11:41:03 +0800
-Subject: [PATCH 2/3] Remove the sys/ prefix for the fcntl include
+Subject: [PATCH] Remove the sys/ prefix for the fcntl include
 
 Serenity does not have the header `fcntl.h` in `/usr/include/sys`.
 ---
@@ -21,6 +21,3 @@ index 944faef..e8e3441 100644
  #include <termios.h>
  
  #define TO_CHAR_OK(c) ((char)(c))
--- 
-2.36.1
-

--- a/Ports/joe/patches/0003-Undefine-TERMINFO-in-termcap.c.patch
+++ b/Ports/joe/patches/0003-Undefine-TERMINFO-in-termcap.c.patch
@@ -1,7 +1,7 @@
-From 07d7111359facb2e8ce95ca28743f3b38d991b25 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Snow <i@xkun.me>
 Date: Sun, 15 May 2022 11:41:03 +0800
-Subject: [PATCH 3/3] Undefine TERMINFO in termcap.c
+Subject: [PATCH] Undefine TERMINFO in termcap.c
 
 Leaving it defined will lead to a crash.
 ---
@@ -21,6 +21,3 @@ index 7f4a459..b6fb6f8 100644
  #ifdef TERMINFO
  
  #ifdef __CYGWIN__
--- 
-2.36.1
-

--- a/Ports/jq/patches/0001-Make-configure-assume-all-dependencies-are-okay.patch
+++ b/Ports/jq/patches/0001-Make-configure-assume-all-dependencies-are-okay.patch
@@ -1,7 +1,7 @@
-From 286ee7f25aefdd17945ba141bb5684857575119a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Mon, 16 May 2022 16:20:52 +0430
-Subject: [PATCH 1/2] Make configure assume all dependencies are okay
+Subject: [PATCH] Make configure assume all dependencies are okay
 
 ---
  configure | 4 ++++
@@ -22,6 +22,3 @@ index de9c48a..1ace244 100755
  cygwin*)
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
--- 
-2.36.1
-

--- a/Ports/jq/patches/0002-Make-jv_mem_alloc-return-a-dummy-allocation-for-zero.patch
+++ b/Ports/jq/patches/0002-Make-jv_mem_alloc-return-a-dummy-allocation-for-zero.patch
@@ -1,8 +1,8 @@
-From 53246ba7b026c92e42aa4c332007f425d297a4ea Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Mon, 16 May 2022 16:21:08 +0430
-Subject: [PATCH 2/2] Make jv_mem_alloc() return a dummy allocation for
- zero-sized allocs
+Subject: [PATCH] Make jv_mem_alloc() return a dummy allocation for zero-sized
+ allocs
 
 And make jv_mem_free() accept it.
 ---
@@ -37,6 +37,3 @@ index fd7b257..9f5ced8 100644
    free(p);
  }
  
--- 
-2.36.1
-

--- a/Ports/klong/patches/0001-Patch-Makefile.patch
+++ b/Ports/klong/patches/0001-Patch-Makefile.patch
@@ -1,4 +1,4 @@
-From 63f3b49119e29d905a66c64895625c702b4827d5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: EWouters <6179932+EWouters@users.noreply.github.com>
 Date: Tue, 5 Apr 2022 14:33:34 +0200
 Subject: [PATCH] Patch Makefile
@@ -39,6 +39,3 @@ index f692ff7..470adcd 100644
 +	install kg ${DESTDIR}/usr/local/bin
 +	mkdir -p ${DESTDIR}/usr/local/lib/klong
 +	install -m 644 lib/* ${DESTDIR}/usr/local/lib/klong
--- 
-2.32.0 (Apple Git-132)
-

--- a/Ports/libassuan/patches/0001-Include-sys-time.h.patch
+++ b/Ports/libassuan/patches/0001-Include-sys-time.h.patch
@@ -1,7 +1,7 @@
-From 4bd9445c203d7d46d40a31c54699681fc6042de7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Wed, 14 Apr 2021 04:32:19 +0200
-Subject: [PATCH 1/2] Include sys/time.h
+Subject: [PATCH] Include sys/time.h
 
 ---
  src/assuan-socket.c | 1 +
@@ -19,6 +19,3 @@ index 97b2312..39079bc 100644
  # include <sys/socket.h>
  # include <netinet/in.h>
  # include <arpa/inet.h>
--- 
-2.36.1
-

--- a/Ports/libassuan/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libassuan/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,7 +1,7 @@
-From 2b1a1933641853db42a37f772efc6d5271e3db16 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
-Subject: [PATCH 2/2] libtool: Enable shared library support for SerenityOS
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
 
 For some odd reason, libtool handles the configuration for shared
 libraries entirely statically and in its configure script. If no
@@ -71,6 +71,3 @@ index 7bee4db..dfbc3ea 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libgcrypt/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libgcrypt/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From dfef4a23509c2f239d0fda51abfd3574147a620d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index 906cbcb..1929b30 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libgpg-error/patches/0001-Include-errno.h.patch
+++ b/Ports/libgpg-error/patches/0001-Include-errno.h.patch
@@ -1,7 +1,7 @@
-From bd7b392f9447112458e9e5cfd89a2b25d544c465 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Wed, 14 Apr 2021 04:32:34 +0200
-Subject: [PATCH 1/3] Include errno.h
+Subject: [PATCH] Include errno.h
 
 ---
  src/mkerrcodes.c | 1 +
@@ -19,6 +19,3 @@ index 29c1cc2..a1cbd52 100644
  
  #include "mkerrcodes.h"
  
--- 
-2.36.1
-

--- a/Ports/libgpg-error/patches/0002-Stub-out-the-gpgrt-lock-impl.patch
+++ b/Ports/libgpg-error/patches/0002-Stub-out-the-gpgrt-lock-impl.patch
@@ -1,7 +1,7 @@
-From 29782147d325747be57381458bc9dffb9bbfaf57 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Wed, 14 Apr 2021 04:32:34 +0200
-Subject: [PATCH 2/3] Stub out the gpgrt lock impl
+Subject: [PATCH] Stub out the gpgrt lock impl
 
 ---
  src/syscfg/lock-obj-pub.i686-pc-serenity.h | 17 +++++++++++++++++
@@ -31,6 +31,3 @@ index 0000000..016f396
 +## buffer-read-only: t
 +## End:
 +##
--- 
-2.36.1
-

--- a/Ports/libgpg-error/patches/0003-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libgpg-error/patches/0003-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,7 +1,7 @@
-From 8c73450cf10645d91bb3fbe4e240184765d2af92 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
-Subject: [PATCH 3/3] libtool: Enable shared library support for SerenityOS
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
 
 For some odd reason, libtool handles the configuration for shared
 libraries entirely statically and in its configure script. If no
@@ -71,6 +71,3 @@ index 24b0799..1838edf 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libiconv/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libiconv/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,7 +1,7 @@
-From bdcb52aa7f451346423c3468ab124c57464b1b5a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
-Subject: [PATCH 2/2] libtool: Enable shared library support for SerenityOS
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
 
 For some odd reason, libtool handles the configuration for shared
 libraries entirely statically and in its configure script. If no
@@ -71,6 +71,3 @@ index 668c3dd..a2857fc 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libicu/patches/0001-Set-host-to-serenity-in-configure.patch
+++ b/Ports/libicu/patches/0001-Set-host-to-serenity-in-configure.patch
@@ -1,7 +1,7 @@
-From 8ab9c30e87cc95f6ad201eaa396c0ea2c62f9a41 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Mon, 16 May 2022 18:03:31 +0430
-Subject: [PATCH 1/2] Set host to serenity in configure
+Subject: [PATCH] Set host to serenity in configure
 
 ---
  configure | 2 ++
@@ -20,6 +20,3 @@ index a2ff7e4..8283dc9 100755
  *-*-mingw*)
  	if test "$GCC" = yes; then
                  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
--- 
-2.36.1
-

--- a/Ports/libicu/patches/0002-Add-a-serenity-specific-makefile.patch
+++ b/Ports/libicu/patches/0002-Add-a-serenity-specific-makefile.patch
@@ -1,7 +1,7 @@
-From 6ff2bd5db3af8d810810f9cd46897f9ab148fb0b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <mpfard@serenityos.org>
 Date: Mon, 16 May 2022 18:03:31 +0430
-Subject: [PATCH 2/2] Add a serenity-specific makefile
+Subject: [PATCH] Add a serenity-specific makefile
 
 ---
  config/mh-serenity | 87 ++++++++++++++++++++++++++++++++++++++++++++++
@@ -101,6 +101,3 @@ index 0000000..53d6780
 +
 +## End Linux-specific setup
 +
--- 
-2.36.1
-

--- a/Ports/libjpeg/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libjpeg/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From 9847675448e5a0169589de8610c0c96463d157b0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index 9e1d1fc..a95ac5d 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libksba/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libksba/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From 253d1b4ca2d00e63cf66fcd04794ff7d85ca4013 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index e9b010b..964315e 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libmad/patches/0001-Remove-fforce-mem-GCC-argument.patch
+++ b/Ports/libmad/patches/0001-Remove-fforce-mem-GCC-argument.patch
@@ -1,4 +1,4 @@
-From dda7e4b915bfa0d1e93e021c2c9ee050e4390b6e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Mon, 17 Jan 2022 17:23:17 +0100
 Subject: [PATCH] Remove `-fforce-mem` GCC argument
@@ -21,6 +21,3 @@ index ee421cc..ccb5928 100755
  	    optimize="$optimize -fforce-addr"
  	    : #x optimize="$optimize -finline-functions"
  	    : #- optimize="$optimize -fstrength-reduce"
--- 
-2.32.0
-

--- a/Ports/libmodplug/patches/0001-Include-strings.h.patch
+++ b/Ports/libmodplug/patches/0001-Include-strings.h.patch
@@ -1,7 +1,7 @@
-From 05bfb2d4b183e7ab23f9c57ccea2022a46178c26 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: xSlendiX <gamingxslendix@gmail.com>
 Date: Sat, 18 Sep 2021 16:19:50 +0300
-Subject: [PATCH 1/2] Include strings.h
+Subject: [PATCH] Include strings.h
 
 ---
  src/libmodplug/stdafx.h | 1 +
@@ -19,6 +19,3 @@ index d45d949..23c66fc 100644
  #ifdef HAVE_MALLOC_H
  #include <malloc.h>
  #endif
--- 
-2.36.1
-

--- a/Ports/libmodplug/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libmodplug/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,7 +1,7 @@
-From 14e9290db59b2a95ea2aa841c4799d1dba648887 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
-Subject: [PATCH 2/2] libtool: Enable shared library support for SerenityOS
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
 
 For some odd reason, libtool handles the configuration for shared
 libraries entirely statically and in its configure script. If no
@@ -89,6 +89,3 @@ index f3d01df..01f0360 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libmpg123/patches/0001-Teach-the-multiple-configure-files-that-serenity-is-.patch
+++ b/Ports/libmpg123/patches/0001-Teach-the-multiple-configure-files-that-serenity-is-.patch
@@ -1,4 +1,4 @@
-From 21ff6032ff3fc0afe704d2363661c2a227911649 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Michael Manganiello <adamantike@users.noreply.github.com>
 Date: Sat, 26 Mar 2022 13:15:31 -0300
 Subject: [PATCH] Teach the multiple configure files that serenity is a thing
@@ -130,6 +130,3 @@ index a6d21ae..44d3c98 100644
          case $cc_basename in
            KCC*)
  	    # Kuck and Associates, Inc. (KAI) C++ Compiler
--- 
-2.36.1
-

--- a/Ports/libogg/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libogg/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From e92cdea5d51443fa7c573cfbc73543d2e78f9a9c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index 3181fb7..b78fdf1 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libpng/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libpng/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From d556fcb6726b513794ab48818e453b8af848d2f1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index 1b2c463..ac2ad0b 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libpuffy/patches/0001-Add-a-definition-for-llabs.patch
+++ b/Ports/libpuffy/patches/0001-Add-a-definition-for-llabs.patch
@@ -1,4 +1,4 @@
-From 806cad445d82dd4facb0759087881dc6d6a0ec70 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Sat, 1 May 2021 22:43:05 +0200
 Subject: [PATCH] Add a definition for llabs
@@ -25,6 +25,3 @@ index 6ad314e..6e68356 100644
  
  /* Format the given "number" into human-readable form in "result".
   * Result must point to an allocated buffer of length FMT_SCALED_STRSIZE.
--- 
-2.36.1
-

--- a/Ports/libsodium/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libsodium/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From 24fdb0b1d714807f338b1a96ae7c30db19e9a7e2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index 6063204..73853e4 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libtheora/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libtheora/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From 8c634afaee47bbf9a3fffc0452b740d040a4df98 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index 9703bcb..548051c 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libtiff/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libtiff/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From 9f36cd059f2ea7ae5233519fd7f486850d623014 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -89,6 +89,3 @@ index 1d9918f..e1e8caa 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libuv/patches/0001-unix-Stub-out-get-set-priority-for-serenity.patch
+++ b/Ports/libuv/patches/0001-unix-Stub-out-get-set-priority-for-serenity.patch
@@ -1,17 +1,17 @@
-From 5ac8ded61c9bcddb7b1df3ad8a23b90a777349bc Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 9 Jul 2021 04:44:26 +0430
-Subject: [PATCH 1/7] unix: Stub out {get,set}priority for serenity
+Subject: [PATCH] unix: Stub out {get,set}priority for serenity
 
 ---
  src/unix/core.c | 6 ++++++
  1 file changed, 6 insertions(+)
 
 diff --git a/src/unix/core.c b/src/unix/core.c
-index 71e9c52..004a589 100644
+index def5b8f..3cdd5fa 100644
 --- a/src/unix/core.c
 +++ b/src/unix/core.c
-@@ -1421,7 +1421,11 @@ int uv_os_getpriority(uv_pid_t pid, int* priority) {
+@@ -1423,7 +1423,11 @@ int uv_os_getpriority(uv_pid_t pid, int* priority) {
      return UV_EINVAL;
  
    errno = 0;
@@ -23,7 +23,7 @@ index 71e9c52..004a589 100644
  
    if (r == -1 && errno != 0)
      return UV__ERR(errno);
-@@ -1435,8 +1439,10 @@ int uv_os_setpriority(uv_pid_t pid, int priority) {
+@@ -1437,8 +1441,10 @@ int uv_os_setpriority(uv_pid_t pid, int priority) {
    if (priority < UV_PRIORITY_HIGHEST || priority > UV_PRIORITY_LOW)
      return UV_EINVAL;
  
@@ -34,6 +34,3 @@ index 71e9c52..004a589 100644
  
    return 0;
  }
--- 
-2.32.0
-

--- a/Ports/libuv/patches/0002-fs-Stub-out-unsupported-syscalls.patch
+++ b/Ports/libuv/patches/0002-fs-Stub-out-unsupported-syscalls.patch
@@ -1,14 +1,14 @@
-From a697c23403039b835526011561bbe4182e4d00fc Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 9 Jul 2021 04:56:55 +0430
-Subject: [PATCH 2/7] fs: Stub out unsupported syscalls
+Subject: [PATCH] fs: Stub out unsupported syscalls
 
 ---
  src/unix/fs.c | 13 ++++++++++---
  1 file changed, 10 insertions(+), 3 deletions(-)
 
 diff --git a/src/unix/fs.c b/src/unix/fs.c
-index eb17fb4..cdc57a7 100644
+index b3211ec..dc149e3 100644
 --- a/src/unix/fs.c
 +++ b/src/unix/fs.c
 @@ -88,7 +88,8 @@
@@ -21,7 +21,7 @@ index eb17fb4..cdc57a7 100644
  # include <sys/statvfs.h>
  #else
  # include <sys/statfs.h>
-@@ -655,7 +656,8 @@ static int uv__fs_statfs(uv_fs_t* req) {
+@@ -656,7 +657,8 @@ static int uv__fs_statfs(uv_fs_t* req) {
      defined(__MVS__)    || \
      defined(__NetBSD__) || \
      defined(__HAIKU__)  || \
@@ -31,7 +31,7 @@ index eb17fb4..cdc57a7 100644
    struct statvfs buf;
  
    if (0 != statvfs(req->path, &buf))
-@@ -677,7 +679,8 @@ static int uv__fs_statfs(uv_fs_t* req) {
+@@ -678,7 +680,8 @@ static int uv__fs_statfs(uv_fs_t* req) {
      defined(__OpenBSD__)  || \
      defined(__NetBSD__)   || \
      defined(__HAIKU__)    || \
@@ -41,7 +41,7 @@ index eb17fb4..cdc57a7 100644
    stat_fs->f_type = 0;  /* f_type is not supported. */
  #else
    stat_fs->f_type = buf.f_type;
-@@ -1666,7 +1669,9 @@ static void uv__fs_work(struct uv__work* w) {
+@@ -1718,7 +1721,9 @@ static void uv__fs_work(struct uv__work* w) {
      X(COPYFILE, uv__fs_copyfile(req));
      X(FCHMOD, fchmod(req->file, req->mode));
      X(FCHOWN, fchown(req->file, req->uid, req->gid));
@@ -51,7 +51,7 @@ index eb17fb4..cdc57a7 100644
      X(FDATASYNC, uv__fs_fdatasync(req));
      X(FSTAT, uv__fs_fstat(req->file, &req->statbuf));
      X(FSYNC, uv__fs_fsync(req));
-@@ -1805,7 +1810,9 @@ int uv_fs_lchown(uv_loop_t* loop,
+@@ -1857,7 +1862,9 @@ int uv_fs_lchown(uv_loop_t* loop,
                   uv_uid_t uid,
                   uv_gid_t gid,
                   uv_fs_cb cb) {
@@ -61,6 +61,3 @@ index eb17fb4..cdc57a7 100644
    PATH;
    req->uid = uid;
    req->gid = gid;
--- 
-2.34.1
-

--- a/Ports/libuv/patches/0003-stream-Don-t-use-AF_INET6.patch
+++ b/Ports/libuv/patches/0003-stream-Don-t-use-AF_INET6.patch
@@ -1,17 +1,17 @@
-From 774eb9413fb32bc3656ddcd9ccb22af3d2083278 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 9 Jul 2021 04:57:31 +0430
-Subject: [PATCH 3/7] stream: Don't use AF_INET6
+Subject: [PATCH] stream: Don't use AF_INET6
 
 ---
  src/unix/stream.c | 8 +++++++-
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/src/unix/stream.c b/src/unix/stream.c
-index f64c01c..96f6417 100644
+index 619b625..10cd4f7 100644
 --- a/src/unix/stream.c
 +++ b/src/unix/stream.c
-@@ -995,13 +995,19 @@ uv_handle_type uv__handle_type(int fd) {
+@@ -994,13 +994,19 @@ uv_handle_type uv__handle_type(int fd) {
        case AF_UNIX:
          return UV_NAMED_PIPE;
        case AF_INET:
@@ -32,6 +32,3 @@ index f64c01c..96f6417 100644
      return UV_UDP;
  
    return UV_UNKNOWN_HANDLE;
--- 
-2.32.0
-

--- a/Ports/libuv/patches/0004-tcp-Don-t-use-SO_LINGER.patch
+++ b/Ports/libuv/patches/0004-tcp-Don-t-use-SO_LINGER.patch
@@ -1,14 +1,14 @@
-From 91c2345d42459232d958eaf0eba5b10786ac3475 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 9 Jul 2021 04:59:05 +0430
-Subject: [PATCH 4/7] tcp: Don't use SO_LINGER
+Subject: [PATCH] tcp: Don't use SO_LINGER
 
 ---
  src/unix/tcp.c | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/src/unix/tcp.c b/src/unix/tcp.c
-index bc0fb66..e78259a 100644
+index 789807f..f92af6b 100644
 --- a/src/unix/tcp.c
 +++ b/src/unix/tcp.c
 @@ -313,15 +313,19 @@ int uv_tcp_getpeername(const uv_tcp_t* handle,
@@ -31,6 +31,3 @@ index bc0fb66..e78259a 100644
  
    uv_close((uv_handle_t*) handle, close_cb);
    return 0;
--- 
-2.32.0
-

--- a/Ports/libuv/patches/0005-build-Add-SerenityOS-platform-definitions.patch
+++ b/Ports/libuv/patches/0005-build-Add-SerenityOS-platform-definitions.patch
@@ -1,17 +1,17 @@
-From 1c95dc0ae7732d4389eac1688d3a13ba942f316d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 9 Jul 2021 05:01:05 +0430
-Subject: [PATCH 5/7] build: Add SerenityOS platform definitions
+Subject: [PATCH] build: Add SerenityOS platform definitions
 
 ---
  CMakeLists.txt | 15 +++++++++++++++
  1 file changed, 15 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index de1272a..f30ec26 100644
+index ac52412..d285ed9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -356,6 +356,21 @@ if(CMAKE_SYSTEM_NAME STREQUAL "QNX")
+@@ -378,6 +378,21 @@ if(CMAKE_SYSTEM_NAME STREQUAL "QNX")
    list(APPEND uv_libraries socket)
  endif()
  
@@ -33,6 +33,3 @@ index de1272a..f30ec26 100644
  if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|Linux|NetBSD|OpenBSD")
    list(APPEND uv_test_libraries util)
  endif()
--- 
-2.32.0
-

--- a/Ports/libuv/patches/0006-include-Teach-the-header-about-serenity.patch
+++ b/Ports/libuv/patches/0006-include-Teach-the-header-about-serenity.patch
@@ -1,25 +1,22 @@
-From b9992fdc37570ae7ca15b50c37ef431289cdc497 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 9 Jul 2021 05:02:01 +0430
-Subject: [PATCH 6/7] include: Teach the header about serenity
+Subject: [PATCH] include: Teach the header about serenity
 
 ---
  include/uv/unix.h | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/include/uv/unix.h b/include/uv/unix.h
-index e3cf7bd..35f1433 100644
+index ea37d78..65e3212 100644
 --- a/include/uv/unix.h
 +++ b/include/uv/unix.h
-@@ -71,6 +71,8 @@
- # include "uv/posix.h"
- #elif defined(__QNX__)
+@@ -69,6 +69,8 @@
+       defined(__QNX__)    || \
+       defined(__GNU__)
  # include "uv/posix.h"
 +#elif defined(__serenity__)
 +# include "uv/posix.h"
  #endif
  
  #ifndef NI_MAXHOST
--- 
-2.32.0
-

--- a/Ports/libuv/patches/0007-build-Add-platform-specific-stubs-and-implementation.patch
+++ b/Ports/libuv/patches/0007-build-Add-platform-specific-stubs-and-implementation.patch
@@ -1,19 +1,19 @@
-From 5c53f32b401baffb4c6dc896ca07beff2add2a42 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 9 Jul 2021 05:32:00 +0430
-Subject: [PATCH 7/7] build: Add platform-specific stubs and implementations
+Subject: [PATCH] build: Add platform-specific stubs and implementations
 
 ---
  CMakeLists.txt           |   2 +
- src/unix/serenity-core.c | 137 +++++++++++++++++++++++++++++++++++++++
- 2 files changed, 139 insertions(+)
+ src/unix/serenity-core.c | 112 +++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 114 insertions(+)
  create mode 100644 src/unix/serenity-core.c
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f30ec26..6f0bf0c 100644
+index d285ed9..10fbd7f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -365,9 +365,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "SerenityOS")
+@@ -387,9 +387,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "SerenityOS")
      src/unix/posix-poll.c
      src/unix/no-fsevents.c
      src/unix/no-proctitle.c
@@ -27,7 +27,7 @@ index f30ec26..6f0bf0c 100644
  
 diff --git a/src/unix/serenity-core.c b/src/unix/serenity-core.c
 new file mode 100644
-index 0000000..821cf37
+index 0000000..4438d15
 --- /dev/null
 +++ b/src/unix/serenity-core.c
 @@ -0,0 +1,112 @@
@@ -143,6 +143,3 @@ index 0000000..821cf37
 +  *rss = 0;
 +  return 0;
 +}
--- 
-2.32.0
-

--- a/Ports/libvorbis/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libvorbis/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From ba4fc4788b1955cbfd2edea3756ad65cbccec395 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index e72b5c7..bfebd8a 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libxml2/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libxml2/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From 897e1d8be1554c6588941574e620a90600b024d0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index 6156015..cfd0935 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/libzip/patches/0001-Disable-some-unneeded-options.patch
+++ b/Ports/libzip/patches/0001-Disable-some-unneeded-options.patch
@@ -1,4 +1,4 @@
-From de9d9f0619d8dbdb42ffa05cd73c50871dc4150e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Edwin Hoksberg <mail@edwinhoksberg.nl>
 Date: Sun, 6 Jun 2021 13:56:15 +0200
 Subject: [PATCH] Disable some unneeded options
@@ -63,6 +63,3 @@ index 93b46a6..6b8d4ed 100644
  
  find_program(MDOCTOOL NAMES mandoc groff)
  if (MDOCTOOL)
--- 
-2.36.1
-

--- a/Ports/lua/patches/0001-Add-a-serenity-target-to-the-makefile.patch
+++ b/Ports/lua/patches/0001-Add-a-serenity-target-to-the-makefile.patch
@@ -1,4 +1,4 @@
-From ffc3fc84ac65d2d1af7faff95e633710aad988ec Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Lemos <xspager@gmail.com>
 Date: Tue, 15 Mar 2022 13:30:11 -0300
 Subject: [PATCH] Add a serenity target to the makefile
@@ -47,6 +47,3 @@ index a13afb9..c54c7bd 100644
  # list targets that do not create files (but not all makes understand .PHONY)
  .PHONY: all $(PLATS) default o a clean depend echo none
  
--- 
-2.36.1
-

--- a/Ports/luajit/patches/0001-Recognize-Serenity-as-POSIX.patch
+++ b/Ports/luajit/patches/0001-Recognize-Serenity-as-POSIX.patch
@@ -1,7 +1,7 @@
-From 514ea84845d1cff0c274ac5e278c0a783d63032f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: circl <circl.lastname@gmail.com>
 Date: Sat, 19 Mar 2022 20:05:26 +0100
-Subject: [PATCH 1/2] Recognize Serenity as POSIX
+Subject: [PATCH] Recognize Serenity as POSIX
 
 ---
  src/lj_arch.h | 2 +-
@@ -20,6 +20,3 @@ index c8d7138..ba7be19 100644
  #define LUAJIT_OS	LUAJIT_OS_POSIX
  #elif defined(__CYGWIN__)
  #define LJ_TARGET_CYGWIN	1
--- 
-2.32.0
-

--- a/Ports/luajit/patches/0002-Serenity-doesn-t-have-setitimer.patch
+++ b/Ports/luajit/patches/0002-Serenity-doesn-t-have-setitimer.patch
@@ -1,7 +1,7 @@
-From a8fd0e7a0e83e768acb4503ba06b19875c2b03ab Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: circl <circl.lastname@gmail.com>
 Date: Sat, 19 Mar 2022 20:07:39 +0100
-Subject: [PATCH 2/2] Serenity doesn't have setitimer
+Subject: [PATCH] Serenity doesn't have setitimer
 
 ---
  src/lj_arch.h | 3 +++
@@ -21,6 +21,3 @@ index ba7be19..0bd7b1b 100644
  #if defined(LUAJIT_DISABLE_PROFILE)
  #define LJ_HASPROFILE		0
  #elif LJ_TARGET_POSIX
--- 
-2.32.0
-

--- a/Ports/luarocks/patches/0001-Setup-the-serenity-platform.patch
+++ b/Ports/luarocks/patches/0001-Setup-the-serenity-platform.patch
@@ -1,7 +1,7 @@
-From 372c6d3d0119e1c0b38f9eed0d7e9b4e45c355a3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Lemos <xspager@gmail.com>
 Date: Tue, 15 Mar 2022 13:48:34 -0300
-Subject: [PATCH 1/2] Setup the serenity platform
+Subject: [PATCH] Setup the serenity platform
 
 Setup serenity as a platform and configure `defaults.variables.UNZIP` to
 work around our `unzip` command not supporting the flag `-n`
@@ -42,6 +42,3 @@ index 926d479..7c2914b 100644
     -- Expose some more values detected by LuaRocks for use by rockspec authors.
     defaults.variables.LIB_EXTENSION = defaults.lib_extension
     defaults.variables.OBJ_EXTENSION = defaults.obj_extension
--- 
-2.36.1
-

--- a/Ports/luarocks/patches/0002-Detect-SerenityOS-using-the-uname-command.patch
+++ b/Ports/luarocks/patches/0002-Detect-SerenityOS-using-the-uname-command.patch
@@ -1,7 +1,7 @@
-From 0b568422cbd06468dad849f836b8de06c3e145e0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Lemos <xspager@gmail.com>
 Date: Tue, 15 Mar 2022 13:48:34 -0300
-Subject: [PATCH 2/2] Detect SerenityOS using the `uname` command
+Subject: [PATCH] Detect SerenityOS using the `uname` command
 
 ---
  src/luarocks/core/sysdetect.lua | 5 +++++
@@ -23,6 +23,3 @@ index 02b8a49..b05f170 100644
     end
  
     return system
--- 
-2.36.1
-

--- a/Ports/m4/patches/0001-Don-t-build-misc-stuff.patch
+++ b/Ports/m4/patches/0001-Don-t-build-misc-stuff.patch
@@ -1,4 +1,4 @@
-From 6e40ded922c482c9e2d96d0101d783174ab7c661 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: AnicJov <contact.andrija@gmail.com>
 Date: Wed, 24 Mar 2021 23:42:01 +0100
 Subject: [PATCH] Don't build misc stuff
@@ -35,6 +35,3 @@ index 746b38c..85cb645 100644
  EXTRA_DIST = bootstrap c-boxes.el cfg.mk maint.mk \
  	.prev-version .version m4/gnulib-cache.m4 ChangeLog-2014
  
--- 
-2.36.1
-

--- a/Ports/make/patches/0001-Include-ar.h-for-serenity-as-well.patch
+++ b/Ports/make/patches/0001-Include-ar.h-for-serenity-as-well.patch
@@ -1,7 +1,7 @@
-From 19fb459471d6242aca08bfc25465eccf05ea767e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andreas Kling <kling@serenityos.org>
 Date: Tue, 15 Dec 2020 01:06:18 +0100
-Subject: [PATCH 1/3] Include ar.h for serenity as well
+Subject: [PATCH] Include ar.h for serenity as well
 
 ---
  src/arscan.c | 2 +-
@@ -20,6 +20,3 @@ index 3ce21db..c48a569 100644
  #  include <ar.h>
  # else
     /* These platforms don't have <ar.h> but have archives in the same format
--- 
-2.36.1
-

--- a/Ports/make/patches/0002-Stub-getdtablesize-for-serenity.patch
+++ b/Ports/make/patches/0002-Stub-getdtablesize-for-serenity.patch
@@ -1,7 +1,7 @@
-From d38968ada9bb551330a127ac37d6d3432f2b4700 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andreas Kling <kling@serenityos.org>
 Date: Tue, 15 Dec 2020 01:06:18 +0100
-Subject: [PATCH 2/3] Stub getdtablesize() for serenity
+Subject: [PATCH] Stub getdtablesize() for serenity
 
 ---
  lib/getdtablesize.c | 8 ++++++++
@@ -40,6 +40,3 @@ index 0fe7092..a14d697 100644
  }
  
  #endif
--- 
-2.36.1
-

--- a/Ports/make/patches/0003-Implement-getprogname.patch
+++ b/Ports/make/patches/0003-Implement-getprogname.patch
@@ -1,7 +1,7 @@
-From 0cb7ee17c3177ca168c7bbd91650fba6616a3f1b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andreas Kling <kling@serenityos.org>
 Date: Tue, 15 Dec 2020 01:06:18 +0100
-Subject: [PATCH 3/3] Implement getprogname()
+Subject: [PATCH] Implement getprogname()
 
 ---
  lib/getprogname.c | 10 ++++++++++
@@ -35,6 +35,3 @@ index 9f69f5a..e5adb23 100644
  # else
  #  error "getprogname module not ported to this OS"
  # endif
--- 
-2.36.1
-

--- a/Ports/mandoc/patches/0001-Add-an-implementation-of-globs.patch
+++ b/Ports/mandoc/patches/0001-Add-an-implementation-of-globs.patch
@@ -1,7 +1,7 @@
-From e922f5ca936776e9c4b7182c73008cf475f8a6ea Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Sat, 25 Jan 2020 21:20:39 -0500
-Subject: [PATCH 1/9] Add an implementation of globs
+Subject: [PATCH] Add an implementation of globs
 
 ---
  compat_glob.c | 1174 +++++++++++++++++++++++++++++++++++++++++++++++++
@@ -1188,6 +1188,3 @@ index 0000000..d155c84
 +	(void)printf("\n");
 +}
 +#endif
--- 
-2.36.1
-

--- a/Ports/mandoc/patches/0002-Add-a-header-describing-the-glob-implementation.patch
+++ b/Ports/mandoc/patches/0002-Add-a-header-describing-the-glob-implementation.patch
@@ -1,7 +1,7 @@
-From 05cf3e8e7e355ec1ae1890cff0ed3a86d7bd5d57 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Sat, 25 Jan 2020 21:20:39 -0500
-Subject: [PATCH 2/9] Add a header describing the glob implementation
+Subject: [PATCH] Add a header describing the glob implementation
 
 ---
  glob.h | 115 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -129,6 +129,3 @@ index 0000000..c304b69
 +__END_DECLS
 +
 +#endif /* !_GLOB_H_ */
--- 
-2.36.1
-

--- a/Ports/mandoc/patches/0003-Make-configure-build-for-serenity.patch
+++ b/Ports/mandoc/patches/0003-Make-configure-build-for-serenity.patch
@@ -1,7 +1,7 @@
-From 75619e06ffe6d4e392bf61ea3cee05706fa6df9a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Sat, 25 Jan 2020 21:20:39 -0500
-Subject: [PATCH 3/9] Make configure build for serenity
+Subject: [PATCH] Make configure build for serenity
 
 ---
  configure | 39 ++++++++++++---------------------------
@@ -101,6 +101,3 @@ index 5507de7..16a074b 100755
  
  [ -z "${HTDOCDIR}"        ] && HTDOCDIR="${WWWPREFIX}/htdocs"
  [ -z "${CGIBINDIR}"       ] && CGIBINDIR="${WWWPREFIX}/cgi-bin"
--- 
-2.36.1
-

--- a/Ports/mandoc/patches/0004-Use-pcre2-for-regex.patch
+++ b/Ports/mandoc/patches/0004-Use-pcre2-for-regex.patch
@@ -1,7 +1,7 @@
-From 173fe2329bb943dba5e0c85c16403e0a4ee61b2f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Sat, 25 Jan 2020 21:20:39 -0500
-Subject: [PATCH 4/9] Use pcre2 for regex
+Subject: [PATCH] Use pcre2 for regex
 
 ---
  dba_read.c | 2 +-
@@ -20,6 +20,3 @@ index e976057..6183dcb 100644
  #include <stdint.h>
  #include <stdlib.h>
  #include <stdio.h>
--- 
-2.36.1
-

--- a/Ports/mandoc/patches/0005-Use-pcre2-for-regex.patch
+++ b/Ports/mandoc/patches/0005-Use-pcre2-for-regex.patch
@@ -1,7 +1,7 @@
-From 7c8e432900e1aafc14d7012cb1456b55c5db860a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Sat, 25 Jan 2020 21:20:39 -0500
-Subject: [PATCH 5/9] Use pcre2 for regex
+Subject: [PATCH] Use pcre2 for regex
 
 ---
  dbm_map.c | 2 +-
@@ -20,6 +20,3 @@ index 87c085d..d5c620e 100644
  #include <stdint.h>
  #include <stdlib.h>
  #include <string.h>
--- 
-2.36.1
-

--- a/Ports/mandoc/patches/0006-Use-pcre2-for-regex.patch
+++ b/Ports/mandoc/patches/0006-Use-pcre2-for-regex.patch
@@ -1,7 +1,7 @@
-From e4b3fb04945980f8546c7437cb345fc0cb67f58d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Sat, 25 Jan 2020 21:20:39 -0500
-Subject: [PATCH 6/9] Use pcre2 for regex
+Subject: [PATCH] Use pcre2 for regex
 
 ---
  dbm.c | 2 +-
@@ -20,6 +20,3 @@ index f6b1259..3dc034a 100644
  #include <stdint.h>
  #include <stdio.h>
  #include <stdlib.h>
--- 
-2.36.1
-

--- a/Ports/mandoc/patches/0007-Use-the-patched-in-version-of-glob.h.patch
+++ b/Ports/mandoc/patches/0007-Use-the-patched-in-version-of-glob.h.patch
@@ -1,7 +1,7 @@
-From e100280860217da8822cb5568db71a8cb1456121 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Thu, 23 Dec 2021 11:13:14 +0100
-Subject: [PATCH 7/9] Use the patched-in version of glob.h
+Subject: [PATCH] Use the patched-in version of glob.h
 
 Co-Authored-By: Daniel Bertalan <dani@danielbertalan.dev>
 ---
@@ -28,6 +28,3 @@ index b91c158..cb785cd 100644
  
  enum	outmode {
  	OUTMODE_DEF = 0,
--- 
-2.36.1
-

--- a/Ports/mandoc/patches/0008-Build-the-patched-in-glob-implementation.patch
+++ b/Ports/mandoc/patches/0008-Build-the-patched-in-glob-implementation.patch
@@ -1,7 +1,7 @@
-From 517695e5b4412d2e1b1f95c0f3cd7c5202968efd Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Sat, 25 Jan 2020 21:20:39 -0500
-Subject: [PATCH 8/9] Build the patched-in glob implementation
+Subject: [PATCH] Build the patched-in glob implementation
 
 ---
  Makefile | 2 ++
@@ -27,6 +27,3 @@ index f4e2954..51a9816 100644
  		   compat_isblank.o \
  		   compat_mkdtemp.o \
  		   compat_ohash.o \
--- 
-2.36.1
-

--- a/Ports/mandoc/patches/0009-Fix-mansearch.c.patch
+++ b/Ports/mandoc/patches/0009-Fix-mansearch.c.patch
@@ -1,7 +1,7 @@
-From f71b62d6e3cc1d31ee46721dd7709f68aaa9b44a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Sat, 25 Jan 2020 21:20:39 -0500
-Subject: [PATCH 9/9] Fix mansearch.c
+Subject: [PATCH] Fix mansearch.c
 
 ---
  mansearch.c | 4 ++--
@@ -23,6 +23,3 @@ index 0c457f9..b036f39 100644
  #include <stdio.h>
  #include <stdint.h>
  #include <stddef.h>
--- 
-2.36.1
-

--- a/Ports/mbedtls/patches/0001-Add-missing-includes.patch
+++ b/Ports/mbedtls/patches/0001-Add-missing-includes.patch
@@ -1,7 +1,7 @@
-From 4f2b20f26ae7ba1f77fa69808f6d4dc926249c0b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Larkin <45925460+larb0b@users.noreply.github.com>
 Date: Tue, 24 Sep 2019 02:56:39 -0400
-Subject: [PATCH 1/2] Add missing includes
+Subject: [PATCH] Add missing includes
 
 ---
  library/ssl_tls.c  | 1 +
@@ -32,6 +32,3 @@ index 97e1d72..9f81247 100644
  #endif /* !_WIN32 || EFIX64 || EFI32 */
  #endif
  
--- 
-2.36.1
-

--- a/Ports/mbedtls/patches/0002-Remove-NET_C-from-config.patch
+++ b/Ports/mbedtls/patches/0002-Remove-NET_C-from-config.patch
@@ -1,7 +1,7 @@
-From e889bf88c3eb76ab6646f2e99fb029b63dac7379 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Larkin <45925460+larb0b@users.noreply.github.com>
 Date: Tue, 24 Sep 2019 02:56:39 -0400
-Subject: [PATCH 2/2] Remove NET_C from config
+Subject: [PATCH] Remove NET_C from config
 
 ---
  include/mbedtls/config.h | 2 +-
@@ -20,6 +20,3 @@ index 654f972..5b37f1f 100644
  
  /**
   * \def MBEDTLS_OID_C
--- 
-2.36.1
-

--- a/Ports/mc/patches/0001-filemanager-ext.c-Include-strings.h-if-SerenityOS.patch
+++ b/Ports/mc/patches/0001-filemanager-ext.c-Include-strings.h-if-SerenityOS.patch
@@ -1,7 +1,7 @@
-From 749c81e5006dea41daf16e99c8a60926236d2373 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Sat, 25 Dec 2021 19:15:35 +0100
-Subject: [PATCH 1/2] filemanager/ext.c: Include strings.h if SerenityOS
+Subject: [PATCH] filemanager/ext.c: Include strings.h if SerenityOS
 
 - [ ] Local?
 - [X] Should be merged to upstream?
@@ -12,7 +12,7 @@ Subject: [PATCH 1/2] filemanager/ext.c: Include strings.h if SerenityOS
  1 file changed, 3 insertions(+)
 
 diff --git a/src/filemanager/ext.c b/src/filemanager/ext.c
-index 781a763..33baf8c 100644
+index a18fda0..12bd8d5 100644
 --- a/src/filemanager/ext.c
 +++ b/src/filemanager/ext.c
 @@ -36,6 +36,9 @@
@@ -25,6 +25,3 @@ index 781a763..33baf8c 100644
  #include <unistd.h>
  
  #include "lib/global.h"
--- 
-2.25.1
-

--- a/Ports/mc/patches/0002-filemanager-ext.c-Use-str_ncasecmp-instead-of-strnca.patch
+++ b/Ports/mc/patches/0002-filemanager-ext.c-Use-str_ncasecmp-instead-of-strnca.patch
@@ -1,8 +1,8 @@
-From 0a5b0b9c2bf5befae8e2e831e75a95f2f0bb26a3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Tue, 11 Jan 2022 19:56:13 +0100
-Subject: [PATCH 2/2] filemanager/ext.c: Use str_ncasecmp instead of
- strncasecmp if SerenityOS
+Subject: [PATCH] filemanager/ext.c: Use str_ncasecmp instead of strncasecmp if
+ SerenityOS
 
 - [ ] Local?
 - [X] Should be merged to upstream?
@@ -13,7 +13,7 @@ Subject: [PATCH 2/2] filemanager/ext.c: Use str_ncasecmp instead of
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/filemanager/ext.c b/src/filemanager/ext.c
-index 33baf8c..a48d6e1 100644
+index 12bd8d5..53cda02 100644
 --- a/src/filemanager/ext.c
 +++ b/src/filemanager/ext.c
 @@ -950,7 +950,7 @@ regex_command_for (void *target, const vfs_path_t * filename_vpath, const char *
@@ -25,6 +25,3 @@ index 33baf8c..a48d6e1 100644
                  }
  
                  if (*p == '.' && file_len >= (size_t) (q - p))
--- 
-2.25.1
-

--- a/Ports/mgba/patches/0001-Remove-use-of-futime-n-s.patch
+++ b/Ports/mgba/patches/0001-Remove-use-of-futime-n-s.patch
@@ -1,7 +1,7 @@
-From 9a3372d695e0374821a0db6275b0b5c57111a341 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke Wilde <lukew@serenityos.org>
 Date: Wed, 13 Apr 2022 17:22:56 +0100
-Subject: [PATCH 1/2] Remove use of futime(n)s
+Subject: [PATCH] Remove use of futime(n)s
 
 We do not currently support futimens or futimes. [futimens is a POSIX function,](https://pubs.opengroup.org/onlinepubs/9699919799/)
 so this is an issue on our side.
@@ -30,6 +30,3 @@ index c15ab5c..8d8d5c8 100644
  	if (buffer && size) {
  		return msync(buffer, size, MS_ASYNC) == 0;
  	}
--- 
-2.36.1
-

--- a/Ports/mgba/patches/0002-Use-SDL-software-renderer-with-no-vsync.patch
+++ b/Ports/mgba/patches/0002-Use-SDL-software-renderer-with-no-vsync.patch
@@ -1,7 +1,7 @@
-From 02fb21126fa6df66dabee40439fab341f2bdd6e8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke Wilde <lukew@serenityos.org>
 Date: Wed, 13 Apr 2022 17:22:56 +0100
-Subject: [PATCH 2/2] Use SDL software renderer with no vsync
+Subject: [PATCH] Use SDL software renderer with no vsync
 
 This makes us use the SDL software renderer with no vsync, as our SDL2 port does not currently support accelerated rendering
 or vsync.
@@ -27,6 +27,3 @@ index 48afc33..11bd58c 100644
  #ifdef COLOR_16_BIT
  #ifdef COLOR_5_6_5
  	renderer->sdlTex = SDL_CreateTexture(renderer->sdlRenderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_STREAMING, width, height);
--- 
-2.36.1
-

--- a/Ports/milkytracker/patches/0001-Include-strings.h.patch
+++ b/Ports/milkytracker/patches/0001-Include-strings.h.patch
@@ -1,7 +1,7 @@
-From c91a634240ee82739c68dc49aad2bd1b6916fedd Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: "jake.westrip" <jake.westrip@lonsec.com.au>
 Date: Tue, 27 Apr 2021 18:34:53 +1000
-Subject: [PATCH 1/5] Include strings.h
+Subject: [PATCH] Include strings.h
 
 ---
  src/ppui/BasicTypes.h | 1 +
@@ -19,6 +19,3 @@ index 20eba8b..e353345 100644
  #include "ScanCodes.h"
  
  #if defined(WIN32) || defined(_WIN32_WCE) 
--- 
-2.36.1
-

--- a/Ports/milkytracker/patches/0002-Remove-OpenGL.patch
+++ b/Ports/milkytracker/patches/0002-Remove-OpenGL.patch
@@ -1,7 +1,7 @@
-From f02afb523d34a56d8da426cee6fb56d3f57b4882 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: "jake.westrip" <jake.westrip@lonsec.com.au>
 Date: Tue, 27 Apr 2021 18:34:53 +1000
-Subject: [PATCH 2/5] Remove OpenGL
+Subject: [PATCH] Remove OpenGL
 
 ---
  src/ppui/sdl/DisplayDevice_SDL.cpp | 42 ++----------------------------
@@ -82,6 +82,3 @@ index a4b966c..7ecedc7 100644
  
  	initMousePointers();
  }
--- 
-2.36.1
-

--- a/Ports/milkytracker/patches/0003-Set-C-standard-to-C-20-and-remove-some-unnecessary-s.patch
+++ b/Ports/milkytracker/patches/0003-Set-C-standard-to-C-20-and-remove-some-unnecessary-s.patch
@@ -1,7 +1,7 @@
-From 5db35a017501fd2e8975d931d77591fdd8d40ed7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: "jake.westrip" <jake.westrip@lonsec.com.au>
 Date: Tue, 27 Apr 2021 18:34:53 +1000
-Subject: [PATCH 3/5] Set C++ standard to C++20 and remove some unnecessary
+Subject: [PATCH] Set C++ standard to C++20 and remove some unnecessary
  subdirectories
 
 ---
@@ -32,6 +32,3 @@ index 4bdecf1..a64b843 100644
  add_subdirectory(src/compression)
  add_subdirectory(src/fx)
  add_subdirectory(src/milkyplay)
--- 
-2.36.1
-

--- a/Ports/milkytracker/patches/0004-Link-against-the-needed-serenity-libraries.patch
+++ b/Ports/milkytracker/patches/0004-Link-against-the-needed-serenity-libraries.patch
@@ -1,7 +1,7 @@
-From 356ec6ffc3184d83e28ba6ad6c4667ac67b6d074 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: "jake.westrip" <jake.westrip@lonsec.com.au>
 Date: Wed, 28 Apr 2021 21:19:03 +1000
-Subject: [PATCH 4/5] Link against the needed serenity libraries
+Subject: [PATCH] Link against the needed serenity libraries
 
 ---
  src/tracker/CMakeLists.txt | 3 +++
@@ -19,6 +19,3 @@ index f4243a0..02f67c0 100644
 +set(INSTALL_DEST bin)
 +
  install(TARGETS tracker DESTINATION ${INSTALL_DEST})
--- 
-2.36.1
-

--- a/Ports/milkytracker/patches/0005-Replace-tmpnam-with-mkstemp.patch
+++ b/Ports/milkytracker/patches/0005-Replace-tmpnam-with-mkstemp.patch
@@ -1,7 +1,7 @@
-From 8938812509ede61e6f50b65ebba94b8809eb0cf5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: "jake.westrip" <jake.westrip@lonsec.com.au>
 Date: Tue, 27 Apr 2021 18:34:53 +1000
-Subject: [PATCH 5/5] Replace tmpnam with mkstemp
+Subject: [PATCH] Replace tmpnam with mkstemp
 
 ---
  src/ppui/osinterface/posix/PPSystem_POSIX.cpp | 2 +-
@@ -20,6 +20,3 @@ index 9b84cfe..03b22b4 100644
  #pragma clang diagnostic pop
  	{
  		// should not be the case, if it is the case, create something that
--- 
-2.36.1
-

--- a/Ports/mold/patches/0001-Disable-mold-wrapper.so-for-Serenity.patch
+++ b/Ports/mold/patches/0001-Disable-mold-wrapper.so-for-Serenity.patch
@@ -1,7 +1,7 @@
-From 70904f38faffd6917593a67326f124251ea03cd3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Kaster <akaster@serenityos.org>
 Date: Sun, 23 Jan 2022 17:47:17 -0700
-Subject: [PATCH 1/6] Disable mold-wrapper.so for Serenity
+Subject: [PATCH] Disable mold-wrapper.so for Serenity
 
 This feature depends on RTLD_NEXT capabilities which are not yet
 implemented in the Serenity DynamicLoader.
@@ -35,6 +35,3 @@ index e2d7cd9..18262a1 100644
  
  	$(INSTALL) -d $D$(LIBEXECDIR)/mold
  	ln -sf $(BINDIR)/mold $D$(LIBEXECDIR)/mold/ld
--- 
-2.25.1
-

--- a/Ports/mold/patches/0002-Disable-mimalloc-for-serenity.patch
+++ b/Ports/mold/patches/0002-Disable-mimalloc-for-serenity.patch
@@ -1,7 +1,7 @@
-From d044a28efff134157154b78c05e881369b512e88 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Kaster <akaster@serenityos.org>
 Date: Sun, 23 Jan 2022 17:55:32 -0700
-Subject: [PATCH 2/6] Disable mimalloc for serenity
+Subject: [PATCH] Disable mimalloc for serenity
 
 mimalloc needs some help to compile and run on serenity.
 That's one yak too far for right now.
@@ -22,6 +22,3 @@ index 18262a1..98c26cc 100644
  else ifeq ($(IS_ANDROID), 1)
    USE_MIMALLOC = 0
  endif
--- 
-2.25.1
-

--- a/Ports/mold/patches/0003-Tell-TBB-that-SerenityOS-does-not-support-weak-symbo.patch
+++ b/Ports/mold/patches/0003-Tell-TBB-that-SerenityOS-does-not-support-weak-symbo.patch
@@ -1,7 +1,7 @@
-From c99783c82b7591768c2b5131c55a55eaa26ca2c1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Kaster <akaster@serenityos.org>
 Date: Tue, 11 Jan 2022 01:04:05 -0700
-Subject: [PATCH 3/6] Tell TBB that SerenityOS does not support weak symbols
+Subject: [PATCH] Tell TBB that SerenityOS does not support weak symbols
 
 Something about the Clang toolchain configuration causes undefined weak
 references to scalable_malloc to remain in the mold executable even
@@ -24,6 +24,3 @@ index cce8ad6..3e07302 100644
  #endif
  
  /** Presence of compiler features **/
--- 
-2.25.1
-

--- a/Ports/mold/patches/0004-Tell-TBB-that-SerenityOS-libraries-are-named-like-BS.patch
+++ b/Ports/mold/patches/0004-Tell-TBB-that-SerenityOS-libraries-are-named-like-BS.patch
@@ -1,8 +1,7 @@
-From 6f67266ca2e7797506273c50b0a0f2adcfaf5173 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Kaster <akaster@serenityos.org>
 Date: Sun, 23 Jan 2022 17:50:52 -0700
-Subject: [PATCH 4/6] Tell TBB that SerenityOS libraries are named like BSD
- ones
+Subject: [PATCH] Tell TBB that SerenityOS libraries are named like BSD ones
 
 We won't be loading these libraries when building TBB as a static
 library for mold, but the OS detection logic still needs updated.
@@ -37,6 +36,3 @@ index d31a77f..fb676bc 100644
  #define RML_SERVER_NAME "libirml" DEBUG_SUFFIX ".so"
  #elif __unix__
  #define RML_SERVER_NAME "libirml" DEBUG_SUFFIX ".so.1"
--- 
-2.25.1
-

--- a/Ports/mold/patches/0005-Stub-out-a-definition-of-RTLD_NOLOAD.patch
+++ b/Ports/mold/patches/0005-Stub-out-a-definition-of-RTLD_NOLOAD.patch
@@ -1,7 +1,7 @@
-From 095c4671242dd8e719c544b97e7b737a553f3d8f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Kaster <akaster@serenityos.org>
 Date: Tue, 11 Jan 2022 01:04:20 -0700
-Subject: [PATCH 5/6] Stub out a definition of RTLD_NOLOAD
+Subject: [PATCH] Stub out a definition of RTLD_NOLOAD
 
 SerenityOS's DynamicLoader doesn't support this flag. However, we won't
 be dynamically loading any tbb extensions for the static library build
@@ -23,6 +23,3 @@ index 3f13425..7dd2169 100644
  
  #define __USE_STATIC_DL_INIT    ( !__ANDROID__ )
  
--- 
-2.25.1
-

--- a/Ports/mold/patches/0006-Disable-__TBB_RESUMABLE_TASKS-for-serenity.patch
+++ b/Ports/mold/patches/0006-Disable-__TBB_RESUMABLE_TASKS-for-serenity.patch
@@ -1,7 +1,7 @@
-From b1c7fb39e002ee60589a731a5908bfc8473760e1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Kaster <akaster@serenityos.org>
 Date: Sun, 23 Jan 2022 17:58:07 -0700
-Subject: [PATCH 6/6] Disable __TBB_RESUMABLE_TASKS for serenity
+Subject: [PATCH] Disable __TBB_RESUMABLE_TASKS for serenity
 
 This feature requires ``<ucontext.h>``, which is not currently
 implemented for any supported SerenityOS targets
@@ -22,6 +22,3 @@ index 3e07302..3b42d9e 100644
  
  /* This macro marks incomplete code or comments describing ideas which are considered for the future.
   * See also for plain comment with TODO and FIXME marks for small improvement opportunities.
--- 
-2.25.1
-

--- a/Ports/mrsh/patches/0001-Add-SerenityOS-to-the-mrsh-build-system.patch
+++ b/Ports/mrsh/patches/0001-Add-SerenityOS-to-the-mrsh-build-system.patch
@@ -1,7 +1,7 @@
-From 4c9a77a1174cdc049d7dc418c43842920bd52f52 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: EWouters <6179932+EWouters@users.noreply.github.com>
 Date: Tue, 12 Apr 2022 17:58:24 +0200
-Subject: [PATCH 1/4] Add SerenityOS to the mrsh build system
+Subject: [PATCH] Add SerenityOS to the mrsh build system
 
 ---
  configure            | 6 ++++--
@@ -41,6 +41,3 @@ index 0000000..33de4a1
 +		*;
 +};
 \ No newline at end of file
--- 
-2.32.0 (Apple Git-132)
-

--- a/Ports/mrsh/patches/0002-Hardcode-default-path-because-confstr-is-missing.patch
+++ b/Ports/mrsh/patches/0002-Hardcode-default-path-because-confstr-is-missing.patch
@@ -1,7 +1,7 @@
-From f254a0f09c9382deb6d2eb7497b453896b9a662f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: EWouters <6179932+EWouters@users.noreply.github.com>
 Date: Tue, 12 Apr 2022 18:00:04 +0200
-Subject: [PATCH 2/4] Hardcode default path because `confstr` is missing
+Subject: [PATCH] Hardcode default path because `confstr` is missing
 
 ---
  shell/path.c | 6 ++++++
@@ -36,6 +36,3 @@ index 3c2bf65..ee2c4e9 100644
  	}
  
  	char *path = NULL;
--- 
-2.32.0 (Apple Git-132)
-

--- a/Ports/mrsh/patches/0003-Workaround-for-redundant-redeclaration-of-environ.patch
+++ b/Ports/mrsh/patches/0003-Workaround-for-redundant-redeclaration-of-environ.patch
@@ -1,7 +1,7 @@
-From fa1d2ddff869430ad17e78755a06475307c49a7f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: EWouters <6179932+EWouters@users.noreply.github.com>
 Date: Tue, 12 Apr 2022 18:01:44 +0200
-Subject: [PATCH 3/4] Workaround for redundant redeclaration of 'environ'
+Subject: [PATCH] Workaround for redundant redeclaration of 'environ'
 
 ---
  main.c | 2 ++
@@ -21,6 +21,3 @@ index 0f433d2..577afde 100644
  
  int main(int argc, char *argv[]) {
  	struct mrsh_state *state = mrsh_state_create();
--- 
-2.32.0 (Apple Git-132)
-

--- a/Ports/mrsh/patches/0004-glob.h-is-missing-so-we-disable-glob.patch
+++ b/Ports/mrsh/patches/0004-glob.h-is-missing-so-we-disable-glob.patch
@@ -1,7 +1,7 @@
-From 7d050176ada352b563e551041999d0783475ad13 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: EWouters <6179932+EWouters@users.noreply.github.com>
 Date: Wed, 4 May 2022 16:50:45 +0200
-Subject: [PATCH 4/4] `glob.h` is missing so we disable glob
+Subject: [PATCH] `glob.h` is missing so we disable glob
 
 ---
  shell/word.c | 6 ++++++
@@ -43,6 +43,3 @@ index df274b7..dd94965 100644
  	}
  
  	return true;
--- 
-2.32.0 (Apple Git-132)
-

--- a/Ports/mruby/patches/0001-Include-sys-select.h.patch
+++ b/Ports/mruby/patches/0001-Include-sys-select.h.patch
@@ -1,7 +1,7 @@
-From 2570626cb58a59e45251dffa409547919dc23df2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Dante Catalfamo <dante.catalfamo@gmail.com>
 Date: Fri, 20 Aug 2021 00:38:31 -0400
-Subject: [PATCH 1/2] Include sys/select.h
+Subject: [PATCH] Include sys/select.h
 
 ---
  mrbgems/mruby-io/src/io.c | 1 +
@@ -19,6 +19,3 @@ index 0469c05..0dae6ca 100644
    typedef size_t fsize_t;
    typedef time_t ftime_t;
    typedef suseconds_t fsuseconds_t;
--- 
-2.36.1
-

--- a/Ports/mruby/patches/0002-Add-a-build-conf-for-serenity.patch
+++ b/Ports/mruby/patches/0002-Add-a-build-conf-for-serenity.patch
@@ -1,7 +1,7 @@
-From 0b19221cc06f6fda8120d1f1bde79ce0a43db8d5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Dante Catalfamo <dante.catalfamo@gmail.com>
 Date: Fri, 20 Aug 2021 00:38:31 -0400
-Subject: [PATCH 2/2] Add a build conf for serenity
+Subject: [PATCH] Add a build conf for serenity
 
 ---
  build_config/serenity.rb | 16 ++++++++++++++++
@@ -30,6 +30,3 @@ index 0000000..b38f5ee
 +
 +  conf.test_runner.command = 'env'
 +end
--- 
-2.36.1
-

--- a/Ports/ncurses/patches/0001-Teach-configure-about-serenity.patch
+++ b/Ports/ncurses/patches/0001-Teach-configure-about-serenity.patch
@@ -1,4 +1,4 @@
-From a83fb5794aba24721bc47d1168e5dfc680bdbebd Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Mon, 9 Aug 2021 19:43:03 +0200
 Subject: [PATCH] Teach configure about serenity
@@ -20,6 +20,3 @@ index 421cf85..31bbb85 100755
  		if test "$DFT_LWR_MODEL" = "shared" && test -n "$LD_RPATH_OPT" ; then
  			LOCAL_LDFLAGS="${LD_RPATH_OPT}\$(LOCAL_LIBDIR)"
  			LOCAL_LDFLAGS2="$LOCAL_LDFLAGS"
--- 
-2.36.1
-

--- a/Ports/neofetch/patches/0001-Add-support-for-serenity.patch
+++ b/Ports/neofetch/patches/0001-Add-support-for-serenity.patch
@@ -1,4 +1,4 @@
-From 155fe5493eafc3a435136ce429052bcc4440d8c6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Linus Groh <mail@linusgroh.de>
 Date: Sat, 14 Aug 2021 13:33:46 -0400
 Subject: [PATCH] Add support for serenity
@@ -258,6 +258,3 @@ index 1e4b564..ea5e351 100755
          "SharkLinux"*)
              set_colors 4 7
              read -rd '' ascii_data <<'EOF'
--- 
-2.36.1
-

--- a/Ports/nesalizer/patches/0001-Add-Serenity-to-Makefile.patch
+++ b/Ports/nesalizer/patches/0001-Add-Serenity-to-Makefile.patch
@@ -1,7 +1,7 @@
-From 9a0103cf47963ff94d97885787993048cc5c4680 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Dan MacDonald <allcoms@gmail.com>
 Date: Sun, 8 Dec 2019 17:30:52 +0000
-Subject: [PATCH 1/2] Add Serenity to Makefile
+Subject: [PATCH] Add Serenity to Makefile
 
 - Add `-lSDL2 -lgui -lipc -lgfx -lcore -lpthread -lregex`
 - Disable RTTI
@@ -37,6 +37,3 @@ index 527a3d0..fa1b849 100644
      link_flags    += $(optimizations) -fuse-linker-plugin
  endif
  
--- 
-2.36.1
-

--- a/Ports/nesalizer/patches/0002-Disable-backtracing.patch
+++ b/Ports/nesalizer/patches/0002-Disable-backtracing.patch
@@ -1,7 +1,7 @@
-From 34b8a26412d6e0880516e881c20ec336e6a450b7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Dan MacDonald <allcoms@gmail.com>
 Date: Sun, 8 Dec 2019 17:25:35 +0000
-Subject: [PATCH 2/2] Disable backtracing
+Subject: [PATCH] Disable backtracing
 
 ---
  src/common.cpp | 6 +++---
@@ -37,6 +37,3 @@ index 33df846..4dd9e9c 100644
      abort();
  }
  
--- 
-2.36.1
-

--- a/Ports/nethack/patches/0001-Don-t-use-fcntl-on-serenity.patch
+++ b/Ports/nethack/patches/0001-Don-t-use-fcntl-on-serenity.patch
@@ -1,7 +1,7 @@
-From 3a91827276d7f4797ba1f8a2f37356ce0985dc7a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Sun, 11 Apr 2021 23:15:42 +0200
-Subject: [PATCH 1/5] Don't use fcntl on serenity
+Subject: [PATCH] Don't use fcntl on serenity
 
 ---
  include/unixconf.h | 2 ++
@@ -22,6 +22,3 @@ index c126d68..cafe766 100644
  
  /*
   * The remainder of the file should not need to be changed.
--- 
-2.36.1
-

--- a/Ports/nethack/patches/0002-Use-explicitly-sized-types.patch
+++ b/Ports/nethack/patches/0002-Use-explicitly-sized-types.patch
@@ -1,7 +1,7 @@
-From 00d5d3dad4bd9410d106bf48b83dbd01943d8db0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Sun, 11 Apr 2021 23:15:42 +0200
-Subject: [PATCH 2/5] Use explicitly sized types
+Subject: [PATCH] Use explicitly sized types
 
 ---
  include/decl.h     |  2 +-
@@ -185,6 +185,3 @@ index cd971bc..de2757e 100644
                    qt_hdr.n_hdr, ofp);
      if (debug) {
          for (i = 0; i < qt_hdr.n_hdr; i++)
--- 
-2.36.1
-

--- a/Ports/nethack/patches/0003-Use-host-tools-where-needed.patch
+++ b/Ports/nethack/patches/0003-Use-host-tools-where-needed.patch
@@ -1,7 +1,7 @@
-From 3d1ff1d1a12a4111b7ef29e8c6bbae05095c1bc1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Sun, 11 Apr 2021 23:15:42 +0200
-Subject: [PATCH 3/5] Use host tools where needed
+Subject: [PATCH] Use host tools where needed
 
 ---
  sys/unix/Makefile.dat | 68 +++++++++++++++++++++----------------------
@@ -163,6 +163,3 @@ index 78e9d72..1a7efca 100644
  # makedefs -z makes both vis_tab.h and vis_tab.c, but writes the .h first
  ../src/vis_tab.c: ../include/vis_tab.h
  
--- 
-2.36.1
-

--- a/Ports/nethack/patches/0004-Set-the-install-path-correctly.patch
+++ b/Ports/nethack/patches/0004-Set-the-install-path-correctly.patch
@@ -1,7 +1,7 @@
-From c8dc69d845ea82c85222882e62af76a11d71695f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Thu, 15 Apr 2021 15:43:18 +0200
-Subject: [PATCH 4/5] Set the install path correctly
+Subject: [PATCH] Set the install path correctly
 
 ---
  sys/unix/Makefile.top | 4 ++--
@@ -43,6 +43,3 @@ index 2c2b62c..70857b6 100755
  
  # Since Nethack.ad is installed in HACKDIR, add it to XUSERFILESEARCHPATH
  case "x$XUSERFILESEARCHPATH" in
--- 
-2.36.1
-

--- a/Ports/nethack/patches/0005-Add-hints-for-serenity.patch
+++ b/Ports/nethack/patches/0005-Add-hints-for-serenity.patch
@@ -1,7 +1,7 @@
-From cac4f570dfb4cb392eaa4f6e8b2845a2875cf17e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Thu, 15 Apr 2021 15:43:18 +0200
-Subject: [PATCH 5/5] Add hints for serenity
+Subject: [PATCH] Add hints for serenity
 
 ---
  sys/unix/hints/serenity | 54 +++++++++++++++++++++++++++++++++++++++++
@@ -68,6 +68,3 @@ index 0000000..1e0ed46
 +VARDIRPERM = 0755
 +VARFILEPERM = 0600
 +GAMEPERM = 0755
--- 
-2.36.1
-

--- a/Ports/ninja/patches/0001-Disable-crossbuild.patch
+++ b/Ports/ninja/patches/0001-Disable-crossbuild.patch
@@ -1,7 +1,7 @@
-From 035b0bf6e03380778803ed7a8703f58906dc41f5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nico Weber <thakis@chromium.org>
 Date: Sun, 21 Jun 2020 18:41:01 -0400
-Subject: [PATCH 1/3] Disable crossbuild
+Subject: [PATCH] Disable crossbuild
 
 (?)
 ---
@@ -21,6 +21,3 @@ index cded265..134db91 100755
      print('bootstrap complete.  rebuilding...')
  
      rebuild_args = []
--- 
-2.36.1
-

--- a/Ports/ninja/patches/0002-Disable-load-average-calculation.patch
+++ b/Ports/ninja/patches/0002-Disable-load-average-calculation.patch
@@ -1,7 +1,7 @@
-From e73cf241735cdc4f0a51b25baa1ee12b3c418ac5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nico Weber <thakis@chromium.org>
 Date: Sun, 21 Jun 2020 18:41:01 -0400
-Subject: [PATCH 2/3] Disable load average calculation
+Subject: [PATCH] Disable load average calculation
 
 ---
  src/util.cc | 3 +++
@@ -26,6 +26,3 @@ index c76f730..5ec2bb8 100644
    return loadavg[0];
  }
  #endif // _WIN32
--- 
-2.36.1
-

--- a/Ports/ninja/patches/0003-Include-unistd.h-for-stat.patch
+++ b/Ports/ninja/patches/0003-Include-unistd.h-for-stat.patch
@@ -1,7 +1,7 @@
-From e692da2de8cbe09141e080499e0d7627d1b69b24 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nico Weber <thakis@chromium.org>
 Date: Sun, 21 Jun 2020 18:41:01 -0400
-Subject: [PATCH 3/3] Include unistd.h for stat()
+Subject: [PATCH] Include unistd.h for stat()
 
 ---
  src/disk_interface.cc | 1 +
@@ -19,6 +19,3 @@ index 49af001..cb1fad5 100644
  
  #ifdef _WIN32
  #include <sstream>
--- 
-2.36.1
-

--- a/Ports/npiet/patches/0001-Don-t-build-the-html-target-by-default.patch
+++ b/Ports/npiet/patches/0001-Don-t-build-the-html-target-by-default.patch
@@ -1,7 +1,7 @@
-From 725d6d5a3abd45a61b863f424fb230f009f4c832 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Noah Rosamilia <ivoahivoah@gmail.com>
 Date: Thu, 6 Jan 2022 18:28:55 -0500
-Subject: [PATCH 1/2] Don't build the html target by default
+Subject: [PATCH] Don't build the html target by default
 
 ---
  Makefile.in | 2 +-
@@ -20,6 +20,3 @@ index e49616a..8d03935 100644
  
  npiet:		npiet.o
  	$(CC) $(LDFLAGS) $(PROF) -o npiet npiet.o $(LIBS)
--- 
-2.36.1
-

--- a/Ports/npiet/patches/0002-Remove-a-malloc.h-include.patch
+++ b/Ports/npiet/patches/0002-Remove-a-malloc.h-include.patch
@@ -1,7 +1,7 @@
-From 105eed290d94b22a172c87e23d518d27c131c5b7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Noah Rosamilia <ivoahivoah@gmail.com>
 Date: Thu, 6 Jan 2022 18:28:55 -0500
-Subject: [PATCH 2/2] Remove a 'malloc.h' include
+Subject: [PATCH] Remove a 'malloc.h' include
 
 ---
  npiet-foogol.c | 2 +-
@@ -20,6 +20,3 @@ index 4d9174a..70fc2cd 100644
  #include <limits.h>
  #include <time.h>
  
--- 
-2.36.1
-

--- a/Ports/npth/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/npth/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From 224a54e5860c10b15fd88a962c509f670f91d311 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index 22ab8e0..51a7571 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/ntbtls/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/ntbtls/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From d4848aa8e5c1783c7d942a45fc2c7780315e4afe Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index 9685eda..6fd2d94 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/nyancat/patches/0001-Install-to-usr-local.patch
+++ b/Ports/nyancat/patches/0001-Install-to-usr-local.patch
@@ -1,7 +1,7 @@
-From 7523e59d058e0455bc03d4c3154d18ffa5fdd92a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Thu, 15 Apr 2021 15:43:18 +0200
-Subject: [PATCH 1/2] Install to /usr/local
+Subject: [PATCH] Install to /usr/local
 
 ---
  Makefile | 6 ++++--
@@ -23,6 +23,3 @@ index 069b06c..34b38d8 100644
 +	gzip -9 -c < nyancat.1 > ${DESTDIR}/usr/local/share/man/man1/nyancat.1.gz
  
  .PHONY: FORCE all clean check dist distcheck install
--- 
-2.36.1
-

--- a/Ports/nyancat/patches/0002-Use-d-for-time-diff-printing.patch
+++ b/Ports/nyancat/patches/0002-Use-d-for-time-diff-printing.patch
@@ -1,7 +1,7 @@
-From e59fb37e9eeae4e68244a29d337047d7eb04c3c2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Thu, 15 Apr 2021 15:43:18 +0200
-Subject: [PATCH 2/2] Use %d for time diff printing
+Subject: [PATCH] Use %d for time diff printing
 
 ---
  src/nyancat.c | 2 +-
@@ -20,6 +20,3 @@ index 537225c..f2965c1 100644
  		}
  		/* Reset the last color so that the escape sequences rewrite */
  		last = 0;
--- 
-2.36.1
-

--- a/Ports/oksh/patches/0001-Add-some-compat-macros-for-serenity.patch
+++ b/Ports/oksh/patches/0001-Add-some-compat-macros-for-serenity.patch
@@ -1,14 +1,14 @@
-From bfc602df4e7eedd1cdc54dc5664ff1ff453fef1b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bertalan <dani@danielbertalan.dev>
 Date: Fri, 5 Nov 2021 22:32:10 +0100
-Subject: [PATCH 1/5] Add some compat macros for serenity
+Subject: [PATCH] Add some compat macros for serenity
 
 ---
- portable.h | 11 ++++++++++-
- 1 file changed, 10 insertions(+), 1 deletion(-)
+ portable.h | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/portable.h b/portable.h
-index 5c86edd..6ccf7f6 100644
+index 5c86edd..c840c69 100644
 --- a/portable.h
 +++ b/portable.h
 @@ -61,7 +61,7 @@
@@ -35,6 +35,3 @@ index 5c86edd..6ccf7f6 100644
  #ifndef HAVE_SETRESGID
  #define setresgid(x, y, z)	setgid(x); setegid(y); setgid(z)
  #endif /* !HAVE_SETRESGID */
--- 
-2.36.1
-

--- a/Ports/oksh/patches/0002-Add-pconfig.h.patch
+++ b/Ports/oksh/patches/0002-Add-pconfig.h.patch
@@ -1,7 +1,7 @@
-From 83b82de3eed21eda75179417c1c234b5a56a52d6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bertalan <dani@danielbertalan.dev>
 Date: Fri, 5 Nov 2021 22:32:10 +0100
-Subject: [PATCH 2/5] Add pconfig.h
+Subject: [PATCH] Add pconfig.h
 
 ---
  pconfig.h | 30 ++++++++++++++++++++++++++++++
@@ -44,6 +44,3 @@ index 0000000..3274014
 +#define HAVE_SIGNAME
 +#define HAVE_TIMERADD
 +#define HAVE_TIMERCLEAR
--- 
-2.36.1
-

--- a/Ports/oksh/patches/0003-Disable-flock.patch
+++ b/Ports/oksh/patches/0003-Disable-flock.patch
@@ -1,7 +1,7 @@
-From eed1007382d7ce6593ec55512bb21ed69343e9cc Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Manuel Palenzuela <manuelpalenzuelamerino@gmail.com>
 Date: Mon, 5 Apr 2021 22:58:01 +0200
-Subject: [PATCH 3/5] Disable flock
+Subject: [PATCH] Disable flock
 
 Serenity does not support flock.
 ---
@@ -36,6 +36,3 @@ index 59876da..b03cc7a 100644
  }
  
  /*
--- 
-2.36.1
-

--- a/Ports/oksh/patches/0004-Disable-rlimit.patch
+++ b/Ports/oksh/patches/0004-Disable-rlimit.patch
@@ -1,7 +1,7 @@
-From 072da9d917bd529cf55973de264c1d288cbf7138 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Manuel Palenzuela <manuelpalenzuelamerino@gmail.com>
 Date: Mon, 5 Apr 2021 22:58:01 +0200
-Subject: [PATCH 4/5] Disable rlimit
+Subject: [PATCH] Disable rlimit
 
 Serenity does not have rlimit support.
 ---
@@ -78,6 +78,3 @@ index 65e0cca..587f08a 100644
 -	}
 +	}*/
  }
--- 
-2.36.1
-

--- a/Ports/oksh/patches/0005-Don-t-emit-the-default-pconfig.h.patch
+++ b/Ports/oksh/patches/0005-Don-t-emit-the-default-pconfig.h.patch
@@ -1,7 +1,7 @@
-From 126df60a9ec402c3a87710500d44b647615c0d8d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bertalan <dani@danielbertalan.dev>
 Date: Fri, 5 Nov 2021 22:32:10 +0100
-Subject: [PATCH 5/5] Don't emit the default pconfig.h
+Subject: [PATCH] Don't emit the default pconfig.h
 
 ---
  configure | 35 -----------------------------------
@@ -54,6 +54,3 @@ index 710dc3b..0625338 100755
    Makefile
  
    exit 0
--- 
-2.36.1
-

--- a/Ports/openssh/patches/0001-ifdef-out-missing-functionality.patch
+++ b/Ports/openssh/patches/0001-ifdef-out-missing-functionality.patch
@@ -1,7 +1,7 @@
-From 0eca70393610857e0a87f157698b295bd727dcae Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Sat, 30 Apr 2022 10:58:10 +0000
-Subject: [PATCH 1/7] ifdef out missing functionality
+Subject: [PATCH] ifdef out missing functionality
 
 Co-Authored-By: Luke <luke.wilde@live.co.uk>
 Co-Authored-By: Patrick Meyer <git@the-space.agency>
@@ -625,6 +625,3 @@ index f1e9200..564ff40 100644
  #ifdef WITH_XMSS
  	case KEY_XMSS:
  	case KEY_XMSS_CERT:
--- 
-2.36.1
-

--- a/Ports/openssh/patches/0002-Add-a-missing-stdio.h-include.patch
+++ b/Ports/openssh/patches/0002-Add-a-missing-stdio.h-include.patch
@@ -1,7 +1,7 @@
-From 352c627e3896ed1305826a1fa2ece85a70e66fd7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke <luke.wilde@live.co.uk>
 Date: Sat, 26 Sep 2020 08:12:27 -0700
-Subject: [PATCH 2/7] Add a missing stdio.h include
+Subject: [PATCH] Add a missing stdio.h include
 
 ---
  openbsd-compat/bsd-flock.c | 4 ++++
@@ -22,6 +22,3 @@ index 9b15d1e..bf57389 100644
  int
  flock(int fd, int op)
  {
--- 
-2.36.1
-

--- a/Ports/openssh/patches/0003-Fix-pledges-to-conform-to-serenity-s-pledge.patch
+++ b/Ports/openssh/patches/0003-Fix-pledges-to-conform-to-serenity-s-pledge.patch
@@ -1,7 +1,7 @@
-From fc2d9a37e6b20ed4544fcb53c25bd34c1c3f2249 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Sat, 30 Apr 2022 10:58:10 +0000
-Subject: [PATCH 3/7] Fix pledges to conform to serenity's pledge()
+Subject: [PATCH] Fix pledges to conform to serenity's pledge()
 
 Co-Authored-By: Patrick Meyer <git@the-space.agency>
 ---
@@ -72,6 +72,3 @@ index c52321e..9ae4dbf 100644
  		fatal("%s: pledge: %s", __progname, strerror(errno));
  
  	for (i = found = 0; i < NUM_KEYTYPES; i++) {
--- 
-2.36.1
-

--- a/Ports/openssh/patches/0004-Remove-inet_aton-redefinition.patch
+++ b/Ports/openssh/patches/0004-Remove-inet_aton-redefinition.patch
@@ -1,7 +1,7 @@
-From 5f5cc486c5de5e03aa2397431e881e356f94724f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke <luke.wilde@live.co.uk>
 Date: Sat, 30 Apr 2022 10:58:10 +0000
-Subject: [PATCH 4/7] Remove inet_aton() redefinition
+Subject: [PATCH] Remove inet_aton() redefinition
 
 Co-Authored-By: Patrick Meyer <git@the-space.agency>
 ---
@@ -217,6 +217,3 @@ index 4316ab8..1c5c338 100644
  int inet_aton(const char *cp, struct in_addr *addr);
  #endif
  
--- 
-2.36.1
-

--- a/Ports/openssh/patches/0005-Assume-SSH-2.0-and-sidestep-some-scanf-issues.patch
+++ b/Ports/openssh/patches/0005-Assume-SSH-2.0-and-sidestep-some-scanf-issues.patch
@@ -1,7 +1,7 @@
-From e7f883a58ee451a086a5f6262cbad323f3af6023 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke <luke.wilde@live.co.uk>
 Date: Sat, 30 Apr 2022 10:58:10 +0000
-Subject: [PATCH 5/7] Assume SSH 2.0 and sidestep some scanf issues
+Subject: [PATCH] Assume SSH 2.0 and sidestep some scanf issues
 
 Co-Authored-By: Patrick Meyer <git@the-space.agency>
 ---
@@ -58,6 +58,3 @@ index 0bcd27d..2539cc2 100644
  	debug("Remote protocol version %d.%d, remote software version %.100s",
  	    remote_major, remote_minor, remote_version);
  	compat_banner(ssh, remote_version);
--- 
-2.36.1
-

--- a/Ports/openssh/patches/0006-Use-sendfd-recvfd-on-serenity.patch
+++ b/Ports/openssh/patches/0006-Use-sendfd-recvfd-on-serenity.patch
@@ -1,7 +1,7 @@
-From 80b391147785edcbf2e1267104e24087ffb420df Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Sat, 30 Apr 2022 10:58:10 +0000
-Subject: [PATCH 6/7] Use sendfd/recvfd on serenity
+Subject: [PATCH] Use sendfd/recvfd on serenity
 
 Co-Authored-By: Patrick Meyer <git@the-space.agency>
 ---
@@ -44,6 +44,3 @@ index a07727a..ad6774e 100644
 +    return recvfd(sock, 0);
 +#endif
  }
--- 
-2.36.1
-

--- a/Ports/openssh/patches/0007-Use-unveil-for-privsep.patch
+++ b/Ports/openssh/patches/0007-Use-unveil-for-privsep.patch
@@ -1,7 +1,7 @@
-From ba3aaa65905f77e6e8bb812ca0ddcdba4f3c0eb3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Patrick Meyer <git@the-space.agency>
 Date: Sat, 30 Apr 2022 10:58:10 +0000
-Subject: [PATCH 7/7] Use unveil for privsep
+Subject: [PATCH] Use unveil for privsep
 
 ---
  sshd.c | 28 +++-------------------------
@@ -53,6 +53,3 @@ index 0ee65b5..e2f84de 100644
  	if (test_flag > 1) {
  		/*
  		 * If no connection info was provided by -C then use
--- 
-2.36.1
-

--- a/Ports/openssl/patches/0001-Add-a-serenity-configuration.patch
+++ b/Ports/openssl/patches/0001-Add-a-serenity-configuration.patch
@@ -1,7 +1,7 @@
-From 924ba86b0ea438a69f0110ccf16cebe24619d3e1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke Wilde <lukew@serenityos.org>
 Date: Wed, 16 Mar 2022 12:52:30 +0000
-Subject: [PATCH 1/2] Add a serenity configuration
+Subject: [PATCH] Add a serenity configuration
 
 Co-Authored-By: Rodrigo Tobar <rtobarc@gmail.com>
 ---
@@ -43,6 +43,3 @@ index 8ca8235..3dea01f 100644
  ####
  #### Variety of LINUX:-)
  ####
--- 
-2.36.1
-

--- a/Ports/openssl/patches/0002-Add-build-configuration-info-for-serenity.patch
+++ b/Ports/openssl/patches/0002-Add-build-configuration-info-for-serenity.patch
@@ -1,7 +1,7 @@
-From 191753ac1b680d24d76558209d9e26fd6d0ce372 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke Wilde <lukew@serenityos.org>
 Date: Wed, 16 Mar 2022 12:52:30 +0000
-Subject: [PATCH 2/2] Add build configuration info for serenity
+Subject: [PATCH] Add build configuration info for serenity
 
 Co-Authored-By: Rodrigo Tobar <rtobarc@gmail.com>
 ---
@@ -26,6 +26,3 @@ index 47eddd6..ab04a19 100644
      'bsd-gcc-shared' => sub { return $shared_info{'linux-shared'}; },
      'bsd-shared' => sub {
          return $shared_info{'gnu-shared'} if detect_gnu_ld();
--- 
-2.36.1
-

--- a/Ports/openttd/patches/0001-All-sorts-of-fixes-for-the-build.patch
+++ b/Ports/openttd/patches/0001-All-sorts-of-fixes-for-the-build.patch
@@ -1,7 +1,7 @@
-From e7cb850da0851c27197f39a2a6593c1c80981a6c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Tue, 5 Apr 2022 23:05:14 +0200
-Subject: [PATCH 1/6] All sorts of fixes for the build
+Subject: [PATCH] All sorts of fixes for the build
 
 Co-Authored-By: Kevin Nobel <kevin@2sk.nl>
 ---
@@ -121,6 +121,3 @@ index effd57c..98800f9 100644
  	typedef unsigned int uint;
  #endif
  
--- 
-2.36.1
-

--- a/Ports/openttd/patches/0002-Memory.patch
+++ b/Ports/openttd/patches/0002-Memory.patch
@@ -1,7 +1,7 @@
-From 1e9569da4e5b1855031495ca2455ed6fa186b3df Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Sat, 17 Apr 2021 15:40:17 +0200
-Subject: [PATCH 2/6] Memory
+Subject: [PATCH] Memory
 
 FIXME: There is no information available about this patch, fill this in.
 ---
@@ -31,6 +31,3 @@ index 6d5ce01..2fda8df 100644
  
  	/* A big free block */
  	_spritecache_ptr->size = (_allocated_sprite_cache_size - sizeof(MemBlock)) | S_FREE_MASK;
--- 
-2.36.1
-

--- a/Ports/openttd/patches/0003-Pass-setsockopt-argument-as-char.patch
+++ b/Ports/openttd/patches/0003-Pass-setsockopt-argument-as-char.patch
@@ -1,7 +1,7 @@
-From 4e0667f3f744b6e7a8ad73581747122d617ea069 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kevin Nobel <kevin@2sk.nl>
 Date: Tue, 5 Apr 2022 23:05:14 +0200
-Subject: [PATCH 3/6] Pass `setsockopt` argument as char*
+Subject: [PATCH] Pass `setsockopt` argument as char*
 
 ---
  src/network/core/os_abstraction.cpp | 2 +-
@@ -20,6 +20,3 @@ index 225c95d..2da1575 100644
  #endif
  }
  
--- 
-2.36.1
-

--- a/Ports/openttd/patches/0004-Stub-GetPerformanceTimer-to-return-0.patch
+++ b/Ports/openttd/patches/0004-Stub-GetPerformanceTimer-to-return-0.patch
@@ -1,7 +1,7 @@
-From 4a6442ab29becbd29418161635930a4d6d5d55e2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Thu, 29 Apr 2021 23:45:51 +0200
-Subject: [PATCH 4/6] Stub GetPerformanceTimer() to return 0
+Subject: [PATCH] Stub GetPerformanceTimer() to return 0
 
 ---
  src/framerate_gui.cpp | 5 +++--
@@ -23,6 +23,3 @@ index 1077629..2d15c5b 100644
  }
  
  
--- 
-2.36.1
-

--- a/Ports/openttd/patches/0005-Don-t-use-the-asm-version-of-rdtsc.patch
+++ b/Ports/openttd/patches/0005-Don-t-use-the-asm-version-of-rdtsc.patch
@@ -1,7 +1,7 @@
-From 4cf117000029c0620085bd273776dc704e6ebc91 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Sat, 17 Apr 2021 15:40:17 +0200
-Subject: [PATCH 5/6] Don't use the asm version of rdtsc
+Subject: [PATCH] Don't use the asm version of rdtsc
 
 ---
  src/cpu.cpp | 2 +-
@@ -20,6 +20,3 @@ index d95c704..762da79 100644
  uint64 ottd_rdtsc()
  {
  	uint32 high, low;
--- 
-2.36.1
-

--- a/Ports/openttd/patches/0006-Don-t-set-any-signal-handlers.patch
+++ b/Ports/openttd/patches/0006-Don-t-set-any-signal-handlers.patch
@@ -1,7 +1,7 @@
-From 42d2fd4d5ab2aa8883f3722c9008e7413980a755 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Sat, 17 Apr 2021 15:40:17 +0200
-Subject: [PATCH 6/6] Don't set any signal handlers
+Subject: [PATCH] Don't set any signal handlers
 
 ---
  src/os/unix/crashlog_unix.cpp | 2 +-
@@ -20,6 +20,3 @@ index fc3682d..32b5f1e 100644
  	}
  }
  
--- 
-2.36.1
-

--- a/Ports/opentyrian/patches/0001-Build-with-CMake.patch
+++ b/Ports/opentyrian/patches/0001-Build-with-CMake.patch
@@ -1,4 +1,4 @@
-From 88cb0766b68056eec4c4f7f39fc188f566037bab Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Oleg Kosenkov <okosenkov@gmail.com>
 Date: Mon, 31 May 2021 14:01:49 -0400
 Subject: [PATCH] Build with CMake
@@ -93,6 +93,3 @@ index 0000000..19d68c0
 +target_link_libraries(tyrian m ${SDL2_LIBRARIES})
 +install(TARGETS tyrian
 +        RUNTIME DESTINATION bin)
--- 
-2.36.1
-

--- a/Ports/opfor/patches/0001-Build-Add-SerenityOS-to-list-of-compatible-systems.patch
+++ b/Ports/opfor/patches/0001-Build-Add-SerenityOS-to-list-of-compatible-systems.patch
@@ -1,4 +1,4 @@
-From 77ad240d87d86e57d0666d45ea6d7b9127d6924b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jesse Buhagiar <jooster669@gmail.com>
 Date: Sun, 2 Jan 2022 00:10:53 +1100
 Subject: [PATCH] Build: Add SerenityOS to list of compatible systems
@@ -11,7 +11,7 @@ the correct name/platform.
  2 files changed, 7 insertions(+)
 
 diff --git a/public/build.h b/public/build.h
-index 6e1f326d6..57a7735f4 100644
+index 6e1f326..57a7735 100644
 --- a/public/build.h
 +++ b/public/build.h
 @@ -74,6 +74,7 @@ For more information, please refer to <http://unlicense.org/>
@@ -33,10 +33,10 @@ index 6e1f326d6..57a7735f4 100644
  #error "Place your operating system name here! If this is a mistake, try to fix conditions above and report a bug"
  #endif
 diff --git a/scripts/waifulib/library_naming.py b/scripts/waifulib/library_naming.py
-index dd8250880..fb46ae604 100644
+index dd82508..fb46ae6 100644
 --- a/scripts/waifulib/library_naming.py
 +++ b/scripts/waifulib/library_naming.py
-@@ -56,6 +56,7 @@
+@@ -56,6 +56,7 @@ DEFINES = [
  'XASH_RISCV_DOUBLEFP',
  'XASH_RISCV_SINGLEFP',
  'XASH_RISCV_SOFTFP',

--- a/Ports/opfor/patches/ReadMe.md
+++ b/Ports/opfor/patches/ReadMe.md
@@ -1,6 +1,6 @@
 # Patches for opfor on SerenityOS
 
-## `hlsdk-add-serenity.patch`
+## `0001-Build-Add-SerenityOS-to-list-of-compatible-systems.patch`
 
 Build: Add SerenityOS to list of compatible systems
 

--- a/Ports/p7zip/patches/0001-Link-with-ldl-liconv-on-serenity.patch
+++ b/Ports/p7zip/patches/0001-Link-with-ldl-liconv-on-serenity.patch
@@ -1,7 +1,7 @@
-From 706b58fb624701b102d18bc60f3d21b9c812c359 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: John Brehm <cooljohnny3@gmail.com>
 Date: Mon, 16 May 2022 22:58:31 +0430
-Subject: [PATCH 1/3] Link with -ldl -liconv on serenity
+Subject: [PATCH] Link with -ldl -liconv on serenity
 
 ---
  7zip/CMAKE/7za/CMakeLists.txt | 4 ++++
@@ -22,6 +22,3 @@ index 7fc1102..9a3511d 100644
  
  IF(APPLE)
     TARGET_LINK_LIBRARIES(7za ${COREFOUNDATION_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
--- 
-2.36.1
-

--- a/Ports/p7zip/patches/0002-Disable-wctype-related-stuff.patch
+++ b/Ports/p7zip/patches/0002-Disable-wctype-related-stuff.patch
@@ -1,7 +1,7 @@
-From faeff47d7dce98869667575f1765fcacbce9da2b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: John Brehm <cooljohnny3@gmail.com>
 Date: Mon, 16 May 2022 22:58:31 +0430
-Subject: [PATCH 2/3] Disable wctype related stuff
+Subject: [PATCH] Disable wctype related stuff
 
 ---
  myWindows/config.h | 2 +-
@@ -20,6 +20,3 @@ index 497d197..fa402c6 100644
    
    #if !defined(ENV_BEOS) && !defined(ANDROID_NDK)
  
--- 
-2.36.1
-

--- a/Ports/p7zip/patches/0003-Add-a-missing-strings.h-include.patch
+++ b/Ports/p7zip/patches/0003-Add-a-missing-strings.h-include.patch
@@ -1,7 +1,7 @@
-From f62c28eb06da77e271e7ad2f2cf7fd09d112f0f1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: John Brehm <cooljohnny3@gmail.com>
 Date: Mon, 16 May 2022 22:58:31 +0430
-Subject: [PATCH 3/3] Add a missing strings.h include
+Subject: [PATCH] Add a missing strings.h include
 
 ---
  7zip/Archive/Zip/ZipItem.cpp | 1 +
@@ -19,6 +19,3 @@ index 353e895..ad0a3da 100644
  
  namespace NArchive {
  namespace NZip {
--- 
-2.36.1
-

--- a/Ports/patch/patches/0001-Remove-oversized-dirfd-cache.patch
+++ b/Ports/patch/patches/0001-Remove-oversized-dirfd-cache.patch
@@ -1,4 +1,4 @@
-From 101002ce462efc69f8511bcb056eba1ca1d89d90 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Wed, 10 Nov 2021 02:07:36 +0100
 Subject: [PATCH] Remove oversized dirfd cache
@@ -22,6 +22,3 @@ index 5a7202f..562a791 100644
  
    cached_dirfds = hash_initialize (max_cached_fds,
  				   NULL,
--- 
-2.36.1
-

--- a/Ports/pcre/patches/0001-test-Disable-S-on-serenity.patch
+++ b/Ports/pcre/patches/0001-test-Disable-S-on-serenity.patch
@@ -1,4 +1,4 @@
-From 853cee5949361930be3a70e7f54941a8fdfabe4f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Fri, 14 Jan 2022 16:13:16 +0330
 Subject: [PATCH] test: Disable '-S' on serenity
@@ -21,6 +21,3 @@ index c1ee128..1ebab82 100644
      printf("PCRE: -S not supported on this OS\n");
      exit(1);
  #else
--- 
-2.34.1
-

--- a/Ports/pcre2/patches/0001-Disable-pcre2test-s-S-flag-on-serenity.patch
+++ b/Ports/pcre2/patches/0001-Disable-pcre2test-s-S-flag-on-serenity.patch
@@ -1,4 +1,4 @@
-From b393ee4471f82747803f0c557d9a7895a4b293b3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Thu, 23 Jan 2020 23:43:31 -0500
 Subject: [PATCH] Disable pcre2test's `-S` flag on serenity
@@ -20,6 +20,3 @@ index ea52a20..e9454c4 100644
      fprintf(stderr, "pcre2test: -S is not supported on this OS\n");
      exit(1);
  #else
--- 
-2.36.1
-

--- a/Ports/pfetch/patches/0001-Use-bin-bash-as-the-shebang.patch
+++ b/Ports/pfetch/patches/0001-Use-bin-bash-as-the-shebang.patch
@@ -1,4 +1,4 @@
-From e748988284621d0f7c03293b93652faefb3b08c9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Liav A <liavalb@gmail.com>
 Date: Fri, 24 Dec 2021 18:38:15 +0200
 Subject: [PATCH] Use /bin/bash as the shebang
@@ -18,6 +18,3 @@ index d47b878..d8f98ba 100755
  #
  # pfetch - Simple POSIX sh fetch script.
  
--- 
-2.36.1
-

--- a/Ports/php/patches/0001-Build-Disable-pharcmd.patch
+++ b/Ports/php/patches/0001-Build-Disable-pharcmd.patch
@@ -1,7 +1,7 @@
-From b77421b9902a06c17e01c6c1dabffbc066a978e8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Tue, 29 Mar 2022 22:41:26 +0200
-Subject: [PATCH 1/2] Build: Disable `pharcmd`
+Subject: [PATCH] Build: Disable `pharcmd`
 
 We do not support running the PHP binary locally after its build, so do
 not try to run phar locally.
@@ -10,7 +10,7 @@ not try to run phar locally.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index b54abe32..d9a8d0b9 100644
+index b54abe3..d9a8d0b 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1567,8 +1567,8 @@ CFLAGS="\$(CFLAGS_CLEAN) $standard_libtool_flag"
@@ -24,6 +24,3 @@ index b54abe32..d9a8d0b9 100644
  else
    pharcmd=
    pharcmd_install=
--- 
-2.32.0
-

--- a/Ports/php/patches/0002-Build-Force-inet_aton-detection.patch
+++ b/Ports/php/patches/0002-Build-Force-inet_aton-detection.patch
@@ -1,7 +1,7 @@
-From 99607c7382d82b955015586c716ab4dc5f747235 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Tue, 29 Mar 2022 22:42:18 +0200
-Subject: [PATCH 2/2] Build: Force `inet_aton` detection
+Subject: [PATCH] Build: Force `inet_aton` detection
 
 For a reason unknown to me, the build system fails to find `inet_aton`
 and tries to redefine it with its own implementation in
@@ -11,7 +11,7 @@ and tries to redefine it with its own implementation in
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index d9a8d0b9..687c2d87 100644
+index d9a8d0b..687c2d8 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -365,8 +365,7 @@ if test "$ac_cv_func_dlopen" = "yes"; then
@@ -24,6 +24,3 @@ index d9a8d0b9..687c2d87 100644
  
  dnl Then headers.
  dnl ----------------------------------------------------------------------------
--- 
-2.32.0
-

--- a/Ports/powdertoy/patches/0001-malloc.h-doesn-t-exist-on-Serenity-but-the-code-only.patch
+++ b/Ports/powdertoy/patches/0001-malloc.h-doesn-t-exist-on-Serenity-but-the-code-only.patch
@@ -1,8 +1,8 @@
-From e02111d802947f23b9424c4e50a76c55288b6fd6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: circl <circl.lastname@gmail.com>
 Date: Sun, 20 Mar 2022 17:13:21 +0100
-Subject: [PATCH 1/2] malloc.h doesn't exist on Serenity, but the code only
- checks for macOS and BSDs
+Subject: [PATCH] malloc.h doesn't exist on Serenity, but the code only checks
+ for macOS and BSDs
 
 ---
  src/Update.cpp | 2 +-
@@ -21,6 +21,3 @@ index 50ef666..5996846 100644
  #include <malloc.h>
  #endif
  #include <cstring>
--- 
-2.32.0
-

--- a/Ports/powdertoy/patches/0002-Open-links-and-directories-using-open-1.patch
+++ b/Ports/powdertoy/patches/0002-Open-links-and-directories-using-open-1.patch
@@ -1,7 +1,7 @@
-From 949ac4d0795be7467f7301f2de0a950767794067 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: circl <circl.lastname@gmail.com>
 Date: Sun, 20 Mar 2022 17:16:16 +0100
-Subject: [PATCH 2/2] Open links and directories using open(1)
+Subject: [PATCH] Open links and directories using open(1)
 
 ---
  src/common/Platform.cpp | 2 +-
@@ -20,6 +20,3 @@ index d341561..d32615c 100644
  	if (system(("open \"" + uri + "\"").c_str()))
  	{
  		fprintf(stderr, "cannot open URI: system(...) failed\n");
--- 
-2.32.0
-

--- a/Ports/pt2-clone/patches/0001-Remove-output-path-from-CMakeLists.patch
+++ b/Ports/pt2-clone/patches/0001-Remove-output-path-from-CMakeLists.patch
@@ -1,7 +1,7 @@
-From cffb5fae8afd6a7272fd71665882b2b41b756d13 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: EWouters <6179932+EWouters@users.noreply.github.com>
 Date: Tue, 5 Apr 2022 14:41:31 +0200
-Subject: [PATCH 1/2] Remove output path from CMakeLists
+Subject: [PATCH] Remove output path from CMakeLists
 
 ---
  CMakeLists.txt | 1 -
@@ -19,6 +19,3 @@ index b391653..0d42019 100644
  
  file(GLOB pt2-clone_SRC
      "${pt2-clone_SOURCE_DIR}/src/*.c"
--- 
-2.32.0 (Apple Git-132)
-

--- a/Ports/pt2-clone/patches/0002-Hacky-Mouse.patch
+++ b/Ports/pt2-clone/patches/0002-Hacky-Mouse.patch
@@ -1,7 +1,7 @@
-From eec08d29c64513c6ebba4af8a367c61aa7bfa1fa Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: EWouters <6179932+EWouters@users.noreply.github.com>
 Date: Tue, 5 Apr 2022 14:55:01 +0200
-Subject: [PATCH 2/2] Hacky Mouse
+Subject: [PATCH] Hacky Mouse
 
 Set video.useDesktopMouseCoords to false.
 ---
@@ -21,6 +21,3 @@ index 40527f5..0b73b9a 100644
  	const char *videoDriver = SDL_GetCurrentVideoDriver();
  	if (videoDriver != NULL && (strcmp("KMSDRM", videoDriver) == 0 || strcmp("wayland", videoDriver) == 0))
  		video.useDesktopMouseCoords = false;
--- 
-2.32.0 (Apple Git-132)
-

--- a/Ports/python3/patches/0001-Enforce-UTF-8-as-the-locale-encoding.patch
+++ b/Ports/python3/patches/0001-Enforce-UTF-8-as-the-locale-encoding.patch
@@ -1,7 +1,7 @@
-From be8a31683b1874d62dc514eb214dfa268ed0a4a4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Linus Groh <mail@linusgroh.de>
 Date: Fri, 14 Jan 2022 23:35:20 +0330
-Subject: [PATCH 1/4] Enforce UTF-8 as the locale encoding
+Subject: [PATCH] Enforce UTF-8 as the locale encoding
 
 By defining `_Py_FORCE_UTF8_LOCALE` as some other platforms already do,
 we can enforce UTF-8 as the encoding.
@@ -22,6 +22,3 @@ index 6ab0ae4..dffd616 100644
     // Use UTF-8 as the locale encoding, ignore the LC_CTYPE locale.
     // See _Py_GetLocaleEncoding(), PyUnicode_DecodeLocale()
     // and PyUnicode_EncodeLocale().
--- 
-2.35.1
-

--- a/Ports/python3/patches/0002-Tweak-configure-and-configure.ac.patch
+++ b/Ports/python3/patches/0002-Tweak-configure-and-configure.ac.patch
@@ -1,7 +1,7 @@
-From 6b7f5908f2d9ca0c3b19fe377feae8f8529e8f4e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Linus Groh <mail@linusgroh.de>
 Date: Fri, 14 Jan 2022 23:35:57 +0330
-Subject: [PATCH 2/4] Tweak configure and configure.ac
+Subject: [PATCH] Tweak configure and configure.ac
 
 As usual, make the `configure` script recognize Serenity. Also set
 `MACHDEP` (which is used for `sys.platform`) to a version-less
@@ -12,7 +12,7 @@ As usual, make the `configure` script recognize Serenity. Also set
  2 files changed, 16 insertions(+), 2 deletions(-)
 
 diff --git a/configure b/configure
-index 0cc86f9..45a4ad6 100755
+index 19f1bd5..340e76e 100755
 --- a/configure
 +++ b/configure
 @@ -3335,6 +3335,9 @@ then
@@ -53,7 +53,7 @@ index 0cc86f9..45a4ad6 100755
  	Darwin/*)
  		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
 diff --git a/configure.ac b/configure.ac
-index 547255f..b352890 100644
+index 763fc69..8d4c0af 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -391,6 +391,9 @@ then
@@ -93,6 +93,3 @@ index 547255f..b352890 100644
  	# -u libsys_s pulls in all symbols in libsys
  	Darwin/*)
  		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
--- 
-2.35.1
-

--- a/Ports/python3/patches/0003-Include-sys-uio.h-in-socketmodule.c.patch
+++ b/Ports/python3/patches/0003-Include-sys-uio.h-in-socketmodule.c.patch
@@ -1,7 +1,7 @@
-From 1805e2be29193655e29355ba9d93b78a654dcaa2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Linus Groh <mail@linusgroh.de>
 Date: Fri, 14 Jan 2022 23:36:28 +0330
-Subject: [PATCH 3/4] Include `sys/uio.h` in `socketmodule.c`
+Subject: [PATCH] Include `sys/uio.h` in `socketmodule.c`
 
 This is to ensure that `struct iovec` is defined, which is required by
 the `socket` module.
@@ -22,6 +22,3 @@ index ab8618b..0109d97 100644
  # include <sys/uio.h>
  #endif
  
--- 
-2.35.1
-

--- a/Ports/python3/patches/0004-Tweak-setup.py.patch
+++ b/Ports/python3/patches/0004-Tweak-setup.py.patch
@@ -1,7 +1,7 @@
-From 1a5f8c57c86964bff49c0d0f61acb18b9223e7d7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Linus Groh <mail@linusgroh.de>
 Date: Fri, 14 Jan 2022 23:36:52 +0330
-Subject: [PATCH 4/4] Tweak `setup.py`
+Subject: [PATCH] Tweak `setup.py`
 
 Make some tweaks to Python's `setup.py`:
 
@@ -45,6 +45,3 @@ index e74a275..acd7b05 100644
          panel_library = 'panel'
          if curses_library == 'ncursesw':
              curses_defines.append(('HAVE_NCURSESW', '1'))
--- 
-2.35.1
-

--- a/Ports/qt6-qtbase/patches/0001-Add-a-SerenityOS-platform-definition.patch
+++ b/Ports/qt6-qtbase/patches/0001-Add-a-SerenityOS-platform-definition.patch
@@ -1,24 +1,24 @@
-From 168040b44c185772fe6d24eb017e6fc6366fadb1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
 Date: Wed, 15 Dec 2021 20:01:43 +0100
-Subject: [PATCH 1/5] Add a SerenityOS platform definition
+Subject: [PATCH] Add a SerenityOS platform definition
 
 ---
  cmake/QtBuild.cmake                   |  2 +
  mkspecs/serenity-g++/qmake.conf       | 25 ++++++++
- mkspecs/serenity-g++/qplatformdefs.h  | 88 +++++++++++++++++++++++++++
+ mkspecs/serenity-g++/qplatformdefs.h  | 87 +++++++++++++++++++++++++++
  src/corelib/global/qsystemdetection.h |  3 +
  src/gui/CMakeLists.txt                |  2 +
  util/cmake/helper.py                  |  1 +
- 6 files changed, 121 insertions(+)
+ 6 files changed, 120 insertions(+)
  create mode 100644 mkspecs/serenity-g++/qmake.conf
  create mode 100644 mkspecs/serenity-g++/qplatformdefs.h
 
 diff --git a/cmake/QtBuild.cmake b/cmake/QtBuild.cmake
-index 7553b681..702ddf6f 100644
+index 6bd255b..ed466b7 100644
 --- a/cmake/QtBuild.cmake
 +++ b/cmake/QtBuild.cmake
-@@ -321,6 +321,8 @@ elseif(APPLE)
+@@ -325,6 +325,8 @@ elseif(APPLE)
      set(QT_DEFAULT_MKSPEC macx-clang)
  elseif(WASM)
      set(QT_DEFAULT_MKSPEC wasm-emscripten)
@@ -29,7 +29,7 @@ index 7553b681..702ddf6f 100644
      set(QT_ENABLE_CXX_EXTENSIONS ON)
 diff --git a/mkspecs/serenity-g++/qmake.conf b/mkspecs/serenity-g++/qmake.conf
 new file mode 100644
-index 00000000..00d5ae2c
+index 0000000..3808b5a
 --- /dev/null
 +++ b/mkspecs/serenity-g++/qmake.conf
 @@ -0,0 +1,25 @@
@@ -60,7 +60,7 @@ index 00000000..00d5ae2c
 +load(qt_config)
 diff --git a/mkspecs/serenity-g++/qplatformdefs.h b/mkspecs/serenity-g++/qplatformdefs.h
 new file mode 100644
-index 00000000..c054ddc5
+index 0000000..1f0dd98
 --- /dev/null
 +++ b/mkspecs/serenity-g++/qplatformdefs.h
 @@ -0,0 +1,87 @@
@@ -152,7 +152,7 @@ index 00000000..c054ddc5
 +
 +#endif // QPLATFORMDEFS_H
 diff --git a/src/corelib/global/qsystemdetection.h b/src/corelib/global/qsystemdetection.h
-index c8f98042..5c534c4a 100644
+index c8f9804..5c534c4 100644
 --- a/src/corelib/global/qsystemdetection.h
 +++ b/src/corelib/global/qsystemdetection.h
 @@ -72,6 +72,7 @@
@@ -173,7 +173,7 @@ index c8f98042..5c534c4a 100644
  #else
  #  error "Qt has not been ported to this OS - see http://www.qt-project.org/"
 diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
-index 1e212b25..b12c8196 100644
+index 1e212b2..b12c819 100644
 --- a/src/gui/CMakeLists.txt
 +++ b/src/gui/CMakeLists.txt
 @@ -29,6 +29,8 @@ if (QT_FEATURE_gui)
@@ -186,7 +186,7 @@ index 1e212b25..b12c8196 100644
          set(_default_platform "xcb")
      endif()
 diff --git a/util/cmake/helper.py b/util/cmake/helper.py
-index e55a9412..87260f36 100644
+index e55a941..87260f3 100644
 --- a/util/cmake/helper.py
 +++ b/util/cmake/helper.py
 @@ -767,6 +767,7 @@ platform_mapping = {
@@ -197,6 +197,3 @@ index e55a9412..87260f36 100644
  }
  
  
--- 
-2.33.1
-

--- a/Ports/qt6-qtbase/patches/0002-Disable-shared-memory-and-semaphores.patch
+++ b/Ports/qt6-qtbase/patches/0002-Disable-shared-memory-and-semaphores.patch
@@ -1,7 +1,7 @@
-From f376d694af85f2f14de87f235d929895baa66fed Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
 Date: Wed, 15 Dec 2021 19:38:27 +0100
-Subject: [PATCH 3/5] Disable shared memory and semaphores
+Subject: [PATCH] Disable shared memory and semaphores
 
 It's probably not done in the cleanest way but it works
 ---
@@ -11,10 +11,10 @@ It's probably not done in the cleanest way but it works
  3 files changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/mkspecs/serenity-g++/qplatformdefs.h b/mkspecs/serenity-g++/qplatformdefs.h
-index c054ddc5..a5a759c0 100644
+index 1f0dd98..65b641e 100644
 --- a/mkspecs/serenity-g++/qplatformdefs.h
 +++ b/mkspecs/serenity-g++/qplatformdefs.h
-@@ -44,6 +44,9 @@
+@@ -43,6 +43,9 @@
  
  #define _GLIBCXX_HAVE_MBSTATE_T 1
  
@@ -25,7 +25,7 @@ index c054ddc5..a5a759c0 100644
  
  // Set any POSIX/XOPEN defines at the top of this file to turn on specific APIs
 diff --git a/src/corelib/kernel/qsharedmemory_p.h b/src/corelib/kernel/qsharedmemory_p.h
-index e06e7e86..7292782d 100644
+index e06e7e8..7292782 100644
 --- a/src/corelib/kernel/qsharedmemory_p.h
 +++ b/src/corelib/kernel/qsharedmemory_p.h
 @@ -51,6 +51,7 @@
@@ -46,7 +46,7 @@ index e06e7e86..7292782d 100644
  #endif
  
 diff --git a/src/corelib/kernel/qsystemsemaphore_p.h b/src/corelib/kernel/qsystemsemaphore_p.h
-index 56619d73..56cf8687 100644
+index 56619d7..56cf868 100644
 --- a/src/corelib/kernel/qsystemsemaphore_p.h
 +++ b/src/corelib/kernel/qsystemsemaphore_p.h
 @@ -51,6 +51,7 @@
@@ -57,6 +57,3 @@ index 56619d73..56cf8687 100644
  #include "qsystemsemaphore.h"
  
  #ifndef QT_NO_SYSTEMSEMAPHORE
--- 
-2.33.1
-

--- a/Ports/qt6-qtbase/patches/0003-Serenity-doesn-t-support-utimensat-and-UTIME_NOW.patch
+++ b/Ports/qt6-qtbase/patches/0003-Serenity-doesn-t-support-utimensat-and-UTIME_NOW.patch
@@ -1,14 +1,14 @@
-From a5935c4f1e954caa33a913cf999a468a02732d21 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
 Date: Wed, 15 Dec 2021 19:49:43 +0100
-Subject: [PATCH 4/5] Serenity doesn't support utimensat and UTIME_NOW
+Subject: [PATCH] Serenity doesn't support utimensat and UTIME_NOW
 
 ---
  qmake/library/ioutils.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/qmake/library/ioutils.cpp b/qmake/library/ioutils.cpp
-index 719d3b51..5490e823 100644
+index 719d3b5..5490e82 100644
 --- a/qmake/library/ioutils.cpp
 +++ b/qmake/library/ioutils.cpp
 @@ -262,7 +262,7 @@ bool IoUtils::touchFile(const QString &targetFileName, const QString &referenceF
@@ -20,6 +20,3 @@ index 719d3b51..5490e823 100644
      const struct timespec times[2] = { { 0, UTIME_NOW }, st.st_mtim };
      const bool utimeError = utimensat(AT_FDCWD, targetFileName.toLocal8Bit().constData(), times, 0) < 0;
  #    else
--- 
-2.33.1
-

--- a/Ports/qt6-qtbase/patches/0004-Hack-Force-searching-for-plugins-in-usr-local.patch
+++ b/Ports/qt6-qtbase/patches/0004-Hack-Force-searching-for-plugins-in-usr-local.patch
@@ -1,7 +1,7 @@
-From c1809bf9fcbf7f4767f750057d08b723d1ad034b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
 Date: Wed, 15 Dec 2021 21:09:35 +0100
-Subject: [PATCH 5/5] Hack: Force searching for plugins in /usr/local
+Subject: [PATCH] Hack: Force searching for plugins in /usr/local
 
 I really don't know how else to do this but I'm sure there is a proper
 way to handle this. But this works and doesn't break the system so
@@ -11,10 +11,10 @@ whatever for now.
  1 file changed, 6 insertions(+)
 
 diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
-index 3bce669b..ca9ca8b9 100644
+index 009aa28..9c0cb52 100644
 --- a/src/corelib/kernel/qcoreapplication.cpp
 +++ b/src/corelib/kernel/qcoreapplication.cpp
-@@ -2751,6 +2751,12 @@ QStringList QCoreApplication::libraryPathsLocked()
+@@ -2760,6 +2760,12 @@ QStringList QCoreApplication::libraryPathsLocked()
          }
  #endif // Q_OS_DARWIN
  
@@ -27,6 +27,3 @@ index 3bce669b..ca9ca8b9 100644
          QString installPathPlugins =  QLibraryInfo::path(QLibraryInfo::PluginsPath);
          if (QFile::exists(installPathPlugins)) {
              // Make sure we convert from backslashes to slashes.
--- 
-2.33.1
-

--- a/Ports/qt6-qtbase/patches/0005-Disable-version-tagging.patch
+++ b/Ports/qt6-qtbase/patches/0005-Disable-version-tagging.patch
@@ -1,4 +1,4 @@
-From 830de469bab98268a328fc982c6d4f938e1547fb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
 Date: Thu, 16 Dec 2021 12:47:31 +0100
 Subject: [PATCH] Disable version tagging
@@ -11,10 +11,10 @@ and other related ELF objects
  2 files changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/cmake/QtBuild.cmake b/cmake/QtBuild.cmake
-index 702ddf6f..ff60a061 100644
+index ed466b7..30668af 100644
 --- a/cmake/QtBuild.cmake
 +++ b/cmake/QtBuild.cmake
-@@ -323,6 +323,8 @@ elseif(WASM)
+@@ -327,6 +327,8 @@ elseif(WASM)
      set(QT_DEFAULT_MKSPEC wasm-emscripten)
  elseif(SERENITYOS)
      set(QT_DEFAULT_MKSPEC serenity-g++)
@@ -24,7 +24,7 @@ index 702ddf6f..ff60a061 100644
      # Certain POSIX defines are not set if we don't compile with -std=gnuXX
      set(QT_ENABLE_CXX_EXTENSIONS ON)
 diff --git a/src/corelib/global/qversiontagging.cpp b/src/corelib/global/qversiontagging.cpp
-index b5e524bf..a7547a3b 100644
+index b5e524b..a7547a3 100644
 --- a/src/corelib/global/qversiontagging.cpp
 +++ b/src/corelib/global/qversiontagging.cpp
 @@ -42,7 +42,7 @@
@@ -36,6 +36,3 @@ index b5e524bf..a7547a3b 100644
  #  define make_versioned_symbol2(sym, m, n, separator)     \
      Q_CORE_EXPORT extern const char sym ## _ ## m ## _ ## n = 0; \
      asm(".symver " QT_STRINGIFY(sym) "_" QT_STRINGIFY(m) "_" QT_STRINGIFY(n) ", " \
--- 
-2.33.1
-

--- a/Ports/quake3/patches/0001-Meta-Refactor-Makefile-to-support-Serenity.patch
+++ b/Ports/quake3/patches/0001-Meta-Refactor-Makefile-to-support-Serenity.patch
@@ -1,14 +1,14 @@
-From 7658f60b1a064ca08da8e71c4f44c4505df6f571 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jesse Buhagiar <jooster669@gmail.com>
 Date: Fri, 25 Mar 2022 09:39:21 +1100
-Subject: [PATCH 1/8] Meta: Refactor Makefile to support Serenity
+Subject: [PATCH] Meta: Refactor Makefile to support Serenity
 
 ---
  Makefile | 36 ++++++++++++++++--------------------
  1 file changed, 16 insertions(+), 20 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 9e535559..b26ceb7f 100644
+index 9e53555..b26ceb7 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -3,8 +3,8 @@
@@ -120,6 +120,3 @@ index 9e535559..b26ceb7f 100644
  #############################################################################
  # SETUP AND BUILD -- GENERIC
  #############################################################################
--- 
-2.35.1
-

--- a/Ports/quake3/patches/0002-Engine-Add-Serenity-so-q_platform.h.patch
+++ b/Ports/quake3/patches/0002-Engine-Add-Serenity-so-q_platform.h.patch
@@ -1,14 +1,14 @@
-From a5f5bd1db818a315cf7da0211a20718f7879791e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jesse Buhagiar <jooster669@gmail.com>
 Date: Fri, 25 Mar 2022 09:39:42 +1100
-Subject: [PATCH 2/8] Engine: Add Serenity so `q_platform.h`
+Subject: [PATCH] Engine: Add Serenity so `q_platform.h`
 
 ---
  code/qcommon/q_platform.h | 29 +++++++++++++++++++++++++++++
  1 file changed, 29 insertions(+)
 
 diff --git a/code/qcommon/q_platform.h b/code/qcommon/q_platform.h
-index 72dbfe1d..3bd829d4 100644
+index 72dbfe1..3bd829d 100644
 --- a/code/qcommon/q_platform.h
 +++ b/code/qcommon/q_platform.h
 @@ -290,6 +290,35 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -47,6 +47,3 @@ index 72dbfe1d..3bd829d4 100644
  //================================================================== Q3VM ===
  
  #ifdef Q3_VM
--- 
-2.35.1
-

--- a/Ports/quake3/patches/0003-Engine-Add-sys-select.h-include-for-Serenity.patch
+++ b/Ports/quake3/patches/0003-Engine-Add-sys-select.h-include-for-Serenity.patch
@@ -1,7 +1,7 @@
-From c7106223c30a896a576c44ce735d4772c283afac Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jesse Buhagiar <jooster669@gmail.com>
 Date: Fri, 25 Mar 2022 09:40:41 +1100
-Subject: [PATCH 3/8] Engine: Add `<sys/select.h>` include for Serenity
+Subject: [PATCH] Engine: Add `<sys/select.h>` include for Serenity
 
 QuakeIII makes extensive use of the `select()` syscall for its' netcode.
 It seems that Linux has this in a header that isn't `<sys/select.h>`
@@ -13,7 +13,7 @@ like us, which results in an implicit declaration error.
  3 files changed, 15 insertions(+)
 
 diff --git a/code/qcommon/net_ip.c b/code/qcommon/net_ip.c
-index bcccda20..ea940f59 100644
+index bcccda2..ea940f5 100644
 --- a/code/qcommon/net_ip.c
 +++ b/code/qcommon/net_ip.c
 @@ -81,6 +81,10 @@ static qboolean	winsockInitialized = qfalse;
@@ -45,7 +45,7 @@ index bcccda20..ea940f59 100644
  ====================
  NET_OpenSocks
 diff --git a/code/sys/con_tty.c b/code/sys/con_tty.c
-index 58f178ad..74e1c60d 100644
+index 58f178a..74e1c60 100644
 --- a/code/sys/con_tty.c
 +++ b/code/sys/con_tty.c
 @@ -34,6 +34,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -60,7 +60,7 @@ index 58f178ad..74e1c60d 100644
  =============================================================
  tty console routines
 diff --git a/code/sys/sys_unix.c b/code/sys/sys_unix.c
-index e0c63238..05f311bb 100644
+index e0c6323..05f311b 100644
 --- a/code/sys/sys_unix.c
 +++ b/code/sys/sys_unix.c
 @@ -39,6 +39,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -74,6 +74,3 @@ index e0c63238..05f311bb 100644
  qboolean stdinIsATTY;
  
  // Used to determine where to store user-specific files
--- 
-2.35.1
-

--- a/Ports/quake3/patches/0004-Meta-Add-ldl-library-for-Serenity-target.patch
+++ b/Ports/quake3/patches/0004-Meta-Add-ldl-library-for-Serenity-target.patch
@@ -1,14 +1,14 @@
-From 5efef55d7dc570bcef21533a952267e6b107d495 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jesse Buhagiar <jooster669@gmail.com>
 Date: Fri, 25 Mar 2022 09:45:12 +1100
-Subject: [PATCH 4/8] Meta: Add `-ldl` library for Serenity target
+Subject: [PATCH] Meta: Add `-ldl` library for Serenity target
 
 ---
  Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index b26ceb7f..035fea77 100644
+index b26ceb7..035fea7 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -868,7 +868,7 @@ ifeq ($(PLATFORM),serenity)
@@ -20,6 +20,3 @@ index b26ceb7f..035fea77 100644
  
    CLIENT_LIBS =
  
--- 
-2.35.1
-

--- a/Ports/quake3/patches/0005-Engine-Move-ifdef-to-more-sensible-location.patch
+++ b/Ports/quake3/patches/0005-Engine-Move-ifdef-to-more-sensible-location.patch
@@ -1,7 +1,7 @@
-From 1d85a563613d3ea2f6cb03c01a4f4bbda2051e79 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jesse Buhagiar <jooster669@gmail.com>
 Date: Fri, 25 Mar 2022 09:45:32 +1100
-Subject: [PATCH 5/8] Engine: Move `#ifdef` to more sensible location
+Subject: [PATCH] Engine: Move `#ifdef` to more sensible location
 
 No linker errors in this dojo!
 ---
@@ -9,7 +9,7 @@ No linker errors in this dojo!
  1 file changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/code/qcommon/net_ip.c b/code/qcommon/net_ip.c
-index ea940f59..aaba8321 100644
+index ea940f5..aaba832 100644
 --- a/code/qcommon/net_ip.c
 +++ b/code/qcommon/net_ip.c
 @@ -1000,9 +1000,9 @@ NET_JoinMulticast
@@ -47,6 +47,3 @@ index ea940f59..aaba8321 100644
  
  /*
  ====================
--- 
-2.35.1
-

--- a/Ports/quake3/patches/0006-Meta-Add-ARCH-to-TOOLS_CFLAGS.patch
+++ b/Ports/quake3/patches/0006-Meta-Add-ARCH-to-TOOLS_CFLAGS.patch
@@ -1,14 +1,14 @@
-From 4c52876ae0217438e97ee9092533bbb29ee1739e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jesse Buhagiar <jooster669@gmail.com>
 Date: Fri, 25 Mar 2022 21:46:14 +1100
-Subject: [PATCH 6/8] Meta: Add ARCH to TOOLS_CFLAGS
+Subject: [PATCH] Meta: Add ARCH to TOOLS_CFLAGS
 
 ---
  Makefile | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/Makefile b/Makefile
-index 035fea77..c5a27abe 100644
+index 035fea7..c5a27ab 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -821,6 +821,8 @@ ifeq ($(PLATFORM),serenity)
@@ -20,6 +20,3 @@ index 035fea77..c5a27abe 100644
    OPTIMIZEVM = -O3
    OPTIMIZE = $(OPTIMIZEVM) -ffast-math
  
--- 
-2.35.1
-

--- a/Ports/quake3/patches/0007-Meta-Remove-extension-from-main-game-exe.patch
+++ b/Ports/quake3/patches/0007-Meta-Remove-extension-from-main-game-exe.patch
@@ -1,14 +1,14 @@
-From 4d5d4cd86c7e94b3f4b2d8cdaf3909a5016aec23 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jesse Buhagiar <jooster669@gmail.com>
 Date: Fri, 25 Mar 2022 22:04:17 +1100
-Subject: [PATCH 7/8] Meta: Remove extension from main game exe
+Subject: [PATCH] Meta: Remove extension from main game exe
 
 ---
  Makefile | 10 +++++-----
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index c5a27abe..c0e62001 100644
+index c5a27ab..c0e6200 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -1046,12 +1046,12 @@ endif
@@ -53,6 +53,3 @@ index c5a27abe..c0e62001 100644
    ifneq ($(USE_RENDERER_DLOPEN),0)
  	$(INSTALL) $(STRIP_FLAG) -m 0755 $(BR)/renderer_opengl1_$(SHLIBNAME) $(COPYBINDIR)/renderer_opengl1_$(SHLIBNAME)
      ifneq ($(BUILD_RENDERER_OPENGL2),0)
--- 
-2.35.1
-

--- a/Ports/quake3/patches/0008-Engine-Use-Serenity-style-PROT_EXEC-mmap.patch
+++ b/Ports/quake3/patches/0008-Engine-Use-Serenity-style-PROT_EXEC-mmap.patch
@@ -1,7 +1,7 @@
-From 488dfbc449db59057afabb92d2843a2ae63741ac Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jesse Buhagiar <jooster669@gmail.com>
 Date: Sat, 26 Mar 2022 00:08:46 +1100
-Subject: [PATCH 8/8] Engine: Use Serenity style PROT_EXEC mmap
+Subject: [PATCH] Engine: Use Serenity style PROT_EXEC mmap
 
 The code for this was really old and crusty, so let's `ifdef` it out and
 use some more friendly Serenity style memory code.
@@ -10,7 +10,7 @@ use some more friendly Serenity style memory code.
  1 file changed, 27 insertions(+), 2 deletions(-)
 
 diff --git a/code/qcommon/vm_x86.c b/code/qcommon/vm_x86.c
-index 8d6321a6..d155efc2 100644
+index 8d6321a..d155efc 100644
 --- a/code/qcommon/vm_x86.c
 +++ b/code/qcommon/vm_x86.c
 @@ -42,6 +42,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -67,6 +67,3 @@ index 8d6321a6..d155efc2 100644
  #elif _WIN32
  	{
  		DWORD oldProtect = 0;
--- 
-2.35.1
-

--- a/Ports/ruby/patches/0001-Teach-configure-about-serenity.patch
+++ b/Ports/ruby/patches/0001-Teach-configure-about-serenity.patch
@@ -1,7 +1,7 @@
-From 9714ad7325f578cb41f8f90496d64888eda8a268 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <mpfard@serenityos.org>
 Date: Sat, 8 Jan 2022 17:02:29 +0330
-Subject: [PATCH 1/4] Teach configure about serenity
+Subject: [PATCH] Teach configure about serenity
 
 Co-Authored-By: Eric Seifert <seiferteric@gmail.com>
 ---
@@ -21,6 +21,3 @@ index a0d9a6c..44ebf54 100755
  
  			: ${LDSHARED='$(CC) -shared'}
  			if test "$rb_cv_binary_elf" = yes; then :
--- 
-2.36.1
-

--- a/Ports/ruby/patches/0002-Remove-locale-defines.patch
+++ b/Ports/ruby/patches/0002-Remove-locale-defines.patch
@@ -1,7 +1,7 @@
-From 30fafa059b5793c3f3638564e00465a4f514f25a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Eric Seifert <seiferteric@gmail.com>
 Date: Tue, 21 Sep 2021 23:09:21 -0700
-Subject: [PATCH 2/4] Remove locale defines
+Subject: [PATCH] Remove locale defines
 
 Serenity does not have any of that.
 ---
@@ -27,6 +27,3 @@ index cd30376..7bafe73 100644
  #endif
  
  #ifdef HAVE_LANGINFO_H
--- 
-2.36.1
-

--- a/Ports/ruby/patches/0003-Remove-the-inline-definitions-of-labs-and-llabs.patch
+++ b/Ports/ruby/patches/0003-Remove-the-inline-definitions-of-labs-and-llabs.patch
@@ -1,7 +1,7 @@
-From 4c770bb497775cfe017df53b002c6dbfda02c5f2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Eric Seifert <seiferteric@gmail.com>
 Date: Tue, 21 Sep 2021 23:09:21 -0700
-Subject: [PATCH 3/4] Remove the inline definitions of labs and llabs
+Subject: [PATCH] Remove the inline definitions of labs and llabs
 
 ---
  ext/bigdecimal/bigdecimal.h | 17 -----------------
@@ -35,6 +35,3 @@ index 28f3363..a2c8c7e 100644
  
  #ifndef HAVE_FINITE
  static int
--- 
-2.36.1
-

--- a/Ports/ruby/patches/0004-Remove-uses-of-rusage.patch
+++ b/Ports/ruby/patches/0004-Remove-uses-of-rusage.patch
@@ -1,7 +1,7 @@
-From de170f190353bb28d0eefacca5087de155948270 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Eric Seifert <seiferteric@gmail.com>
 Date: Tue, 21 Sep 2021 23:09:21 -0700
-Subject: [PATCH 4/4] Remove uses of rusage
+Subject: [PATCH] Remove uses of rusage
 
 ---
  gc.c      | 23 -----------------------
@@ -125,6 +125,3 @@ index 674f05d..b7941aa 100644
  #endif
      id_CLOCK_BASED_CLOCK_PROCESS_CPUTIME_ID = rb_intern_const("CLOCK_BASED_CLOCK_PROCESS_CPUTIME_ID");
  #ifdef __APPLE__
--- 
-2.36.1
-

--- a/Ports/sam/patches/0001-Enable-the-windows-function-stubs-for-serenity.patch
+++ b/Ports/sam/patches/0001-Enable-the-windows-function-stubs-for-serenity.patch
@@ -1,7 +1,7 @@
-From e9875cfafe88de258da81b2b366a534d7f1edfc4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Timothy <timmot@users.noreply.github.com>
 Date: Thu, 3 Jun 2021 14:20:09 -0700
-Subject: [PATCH 1/2] Enable the windows function stubs for serenity
+Subject: [PATCH] Enable the windows function stubs for serenity
 
 ---
  src/main.c | 2 +-
@@ -20,6 +20,3 @@ index 3e8fdde..3432fe8 100644
  static int min(int l, int r) { return l < r ? l : r; }
  static void strcat_s(char * dest, int size, char * str) {
      unsigned int dlen = strlen(dest);
--- 
-2.36.1
-

--- a/Ports/sam/patches/0002-Manually-set-the-SDL2-include-path-and-library-dir.patch
+++ b/Ports/sam/patches/0002-Manually-set-the-SDL2-include-path-and-library-dir.patch
@@ -1,14 +1,14 @@
-From e588447c853b3df909747002985f833a428c8c37 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Timothy <timmot@users.noreply.github.com>
 Date: Mon, 16 May 2022 23:23:21 +0430
-Subject: [PATCH 2/2] Manually set the SDL2 include path and library dir
+Subject: [PATCH] Manually set the SDL2 include path and library dir
 
 ---
  Makefile | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 1153e0c..9c70190 100644
+index 1153e0c..da26e9d 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -3,8 +3,8 @@ OBJS = reciter.o sam.o render.o main.o debug.o processframes.o createtransitions
@@ -22,6 +22,3 @@ index 1153e0c..9c70190 100644
  
  # no libsdl present
  #CFLAGS =  -Wall -O2
--- 
-2.36.1
-

--- a/Ports/scummvm/patches/0001-Prevent-call-to-glGetIntegerv-without-context.patch
+++ b/Ports/scummvm/patches/0001-Prevent-call-to-glGetIntegerv-without-context.patch
@@ -1,7 +1,7 @@
-From 6c64e5bb63f9957ceddb82be5f9aafb73c14375c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Wed, 12 Jan 2022 13:41:39 +0100
-Subject: [PATCH 1/3] Prevent call to `glGetIntegerv` without context
+Subject: [PATCH] Prevent call to `glGetIntegerv` without context
 
 This call to `SDL_GL_GetAttribute` happens when switching from the
 launcher to the game, when no GL context may exist. This caused Grim
@@ -25,6 +25,3 @@ index d5c034f..8a4e3ff 100644
  		#endif
  
  		// When rendering to a framebuffer, MSAA is enabled on that framebuffer, not on the screen
--- 
-2.36.1
-

--- a/Ports/scummvm/patches/0002-Teach-configure-about-serenity.patch
+++ b/Ports/scummvm/patches/0002-Teach-configure-about-serenity.patch
@@ -1,7 +1,7 @@
-From 65f374e0cdc9bb7255ad1aadbad1869d21ac7d82 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Sun, 9 Jan 2022 23:01:32 +0100
-Subject: [PATCH 2/3] Teach configure about serenity
+Subject: [PATCH] Teach configure about serenity
 
 ---
  configure | 5 ++++-
@@ -30,6 +30,3 @@ index 65e4731..39509f3 100755
  		*)
  			OPENGL_LIBS="-lGL"
  			;;
--- 
-2.36.1
-

--- a/Ports/scummvm/patches/0003-Remove-SDL-timer-lock.patch
+++ b/Ports/scummvm/patches/0003-Remove-SDL-timer-lock.patch
@@ -1,7 +1,7 @@
-From ddb49b8e7be62501eeea15941b47b91902f697f8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Sun, 9 Jan 2022 23:18:02 +0100
-Subject: [PATCH 3/3] Remove SDL timer lock
+Subject: [PATCH] Remove SDL timer lock
 
 ---
  backends/timer/sdl/sdl-timer.cpp | 6 ------
@@ -32,6 +32,3 @@ index f9d79ac..ce1af0e 100644
  	// Removes the timer callback
  	SDL_RemoveTimer(_timerID);
  
--- 
-2.36.1
-

--- a/Ports/sdl12-compat/patches/0001-Disable-forced-fullscreen-on-logical-scaling.patch
+++ b/Ports/sdl12-compat/patches/0001-Disable-forced-fullscreen-on-logical-scaling.patch
@@ -1,8 +1,12 @@
-From a2b0791418672dffcfc8baae4d0b8158693a794c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Grigoris Pavlakis <grigpavl@ece.auth.gr>
 Date: Sat, 28 May 2022 17:21:27 +0300
 Subject: [PATCH] Disable forced fullscreen on logical scaling
 
+sdl12-compat forces fullscreen on anything that sets video mode
+and uses OpenGL logical scaling, causing rapid flickering and preventing
+execution. Not sure if this is an upstream bug or intended behavior,
+but disabling fullscreen at this point fixes the flickering.
 ---
  src/SDL12_compat.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
@@ -20,6 +24,3 @@ index b3a411e..4d8001d 100644
                  SDL20_SetWindowFullscreen(VideoWindow20, fullscreen_flags20);
              }
          }
--- 
-2.36.1
-

--- a/Ports/sdl12-compat/patches/ReadMe.md
+++ b/Ports/sdl12-compat/patches/ReadMe.md
@@ -2,6 +2,8 @@
 
 ## `0001-Disable-forced-fullscreen-on-logical-scaling.patch`
 
+Disable forced fullscreen on logical scaling
+
 sdl12-compat forces fullscreen on anything that sets video mode
 and uses OpenGL logical scaling, causing rapid flickering and preventing
 execution. Not sure if this is an upstream bug or intended behavior,

--- a/Ports/sl/patches/0001-Add-an-install-target.patch
+++ b/Ports/sl/patches/0001-Add-an-install-target.patch
@@ -1,4 +1,4 @@
-From 71f2cc48a3e66377763401054c663ca6a2a3f7ca Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Thu, 15 Apr 2021 15:43:18 +0200
 Subject: [PATCH] Add an install target
@@ -22,6 +22,3 @@ index c3005d2..04fcb9d 100644
 +	install sl ${DESTDIR}/usr/local/bin/sl
 +	mkdir -p ${DESTDIR}/usr/local/share/man/man1
 +	gzip -9 -c < sl.1 > ${DESTDIR}/usr/local/share/man/man1/sl.1.gz
--- 
-2.36.1
-

--- a/Ports/sqlite/patches/0001-Teach-configure-about-serenity.patch
+++ b/Ports/sqlite/patches/0001-Teach-configure-about-serenity.patch
@@ -1,7 +1,7 @@
-From 98597b7f104c73a1955eef077097b5dbb372183f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Kaster <akaster@serenityos.org>
 Date: Sat, 8 Jan 2022 05:33:27 -0700
-Subject: [PATCH 1/2] Teach configure about serenity
+Subject: [PATCH] Teach configure about serenity
 
 ---
  configure | 4 ++++
@@ -29,6 +29,3 @@ index 367f505..df6217c 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/sqlite/patches/0002-Disable-vfs-locking.patch
+++ b/Ports/sqlite/patches/0002-Disable-vfs-locking.patch
@@ -1,7 +1,7 @@
-From 574528250f8113f17a1524266114e297417fd3ff Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Sat, 27 Mar 2021 12:38:07 +0100
-Subject: [PATCH 2/2] Disable vfs locking
+Subject: [PATCH] Disable vfs locking
 
 ---
  sqlite3.c | 2 +-
@@ -27,6 +27,3 @@ index 0b227f0..90c38bd 100644
      UNIXVFS("unix-dotfile",  dotlockIoFinder ),
      UNIXVFS("unix-excl",     posixIoFinder ),
  #if OS_VXWORKS
--- 
-2.36.1
-

--- a/Ports/stress-ng/patches/0001-serenity-Disable-linux-scheduler-integration-on-Sere.patch
+++ b/Ports/stress-ng/patches/0001-serenity-Disable-linux-scheduler-integration-on-Sere.patch
@@ -1,8 +1,7 @@
-From bb67e44f840df4b833ea3316cf20dee42d62cdb8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Mon, 27 Dec 2021 20:53:47 -0800
-Subject: [PATCH 01/14] serenity: Disable linux scheduler integration on
- Serenity
+Subject: [PATCH] serenity: Disable linux scheduler integration on Serenity
 
 Follow the path of other platforms, and make this code nop
 when compiling for serenity.
@@ -39,6 +38,3 @@ index 91d1d02..6f172d3 100644
  
  static const int policies[] = {
  #if defined(SCHED_IDLE)
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0002-serenity-Disable-itimer-testing-when-compiling-for-S.patch
+++ b/Ports/stress-ng/patches/0002-serenity-Disable-itimer-testing-when-compiling-for-S.patch
@@ -1,8 +1,7 @@
-From daec883ade0af0b20a4e2f3ef584cde57e22bf3b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Mon, 27 Dec 2021 20:57:05 -0800
-Subject: [PATCH 02/14] serenity: Disable itimer testing when compiling for
- Serenity
+Subject: [PATCH] serenity: Disable itimer testing when compiling for Serenity
 
 The itimer APIs are not implemented in serenity, so just disable
 these tests.
@@ -113,6 +112,3 @@ index 5d9a10a..cacd01c 100644
  
  		ret = bad_syscall(addr);
  		if (ret < 0)
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0003-serenity-Fix-duplicate-definition-of-ALWAYS_INLINE-o.patch
+++ b/Ports/stress-ng/patches/0003-serenity-Fix-duplicate-definition-of-ALWAYS_INLINE-o.patch
@@ -1,7 +1,7 @@
-From 26423a861528dd878910c58af5c13b1d3edb29b1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Mon, 27 Dec 2021 20:58:41 -0800
-Subject: [PATCH 03/14] serenity: Fix duplicate definition of ALWAYS_INLINE on
+Subject: [PATCH] serenity: Fix duplicate definition of ALWAYS_INLINE on
  serenity
 
 ---
@@ -24,6 +24,3 @@ index 84d3bfa..5af02e1 100644
  /* force inlining hint */
  #if (defined(__GNUC__) && NEED_GNUC(3, 4, 0) 					\
       && ((!defined(__s390__) && !defined(__s390x__)) || NEED_GNUC(6, 0, 1))) ||	\
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0004-serenity-ifdef-out-key_t-type-usage-which-serenity-d.patch
+++ b/Ports/stress-ng/patches/0004-serenity-ifdef-out-key_t-type-usage-which-serenity-d.patch
@@ -1,8 +1,8 @@
-From a6387e37e265be01a76d64d2730bcf390a886104 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Mon, 27 Dec 2021 20:59:35 -0800
-Subject: [PATCH 04/14] serenity: ifdef out key_t type usage, which serenity
- does not have
+Subject: [PATCH] serenity: ifdef out key_t type usage, which serenity does not
+ have
 
 ---
  stress-ng.h | 3 +++
@@ -27,6 +27,3 @@ index 5af02e1..dac6113 100644
  #if defined(STRESS_PERF_STATS)
  	struct {
  		bool no_perf;				/* true = Perf not available */
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0005-serenity-Mark-hsearch-stressor-as-not-implemented-on.patch
+++ b/Ports/stress-ng/patches/0005-serenity-Mark-hsearch-stressor-as-not-implemented-on.patch
@@ -1,7 +1,7 @@
-From a2e86111bb205405fdd3066864aaf1000704fe26 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Mon, 27 Dec 2021 21:01:59 -0800
-Subject: [PATCH 05/14] serenity: Mark hsearch stressor as not implemented on
+Subject: [PATCH] serenity: Mark hsearch stressor as not implemented on
  Serenity
 
 ---
@@ -32,6 +32,3 @@ index 90bf3f6..9d97418 100644
 +	.help = help
 +};
 +#endif
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0006-serenity-Disable-signal-code-validation-for-Serenity.patch
+++ b/Ports/stress-ng/patches/0006-serenity-Disable-signal-code-validation-for-Serenity.patch
@@ -1,7 +1,7 @@
-From 955e2e55837b71175a229b0871c57f6b5017f82a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Mon, 27 Dec 2021 23:30:03 -0800
-Subject: [PATCH 06/14] serenity: Disable signal code validation for Serenity
+Subject: [PATCH] serenity: Disable signal code validation for Serenity
 
 We don't currently have a definition for SEGV_ACCERR, so
 this validation is meaningless for SerenityOS.
@@ -27,6 +27,3 @@ index 9930c0e..d6ce99a 100644
  #endif
  			inc_counter(args);
  		} else {
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0007-serenity-Disable-rand48-cpu-stressor-it-s-not-implem.patch
+++ b/Ports/stress-ng/patches/0007-serenity-Disable-rand48-cpu-stressor-it-s-not-implem.patch
@@ -1,8 +1,8 @@
-From 0b17904ec60c45d00a6fca397e86b27b966403b8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Mon, 27 Dec 2021 23:46:44 -0800
-Subject: [PATCH 07/14] serenity: Disable rand48 cpu stressor, it's not
- implemented for Serenity
+Subject: [PATCH] serenity: Disable rand48 cpu stressor, it's not implemented
+ for Serenity
 
 ---
  stress-cpu.c | 4 ++++
@@ -38,6 +38,3 @@ index 0a08f1d..c1f1fc5 100644
  	{ "rgb",		stress_cpu_rgb },
  	{ "sieve",		stress_cpu_sieve },
  	{ "stats",		stress_cpu_stats },
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0008-serenity-Make-lsearch-stressor-a-nop-on-Serenity.patch
+++ b/Ports/stress-ng/patches/0008-serenity-Make-lsearch-stressor-a-nop-on-Serenity.patch
@@ -1,7 +1,7 @@
-From 317481d355bb08bcda3f91b141dba18a2acb8b57 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Mon, 27 Dec 2021 23:47:22 -0800
-Subject: [PATCH 08/14] serenity: Make lsearch stressor a nop on Serenity
+Subject: [PATCH] serenity: Make lsearch stressor a nop on Serenity
 
 ---
  stress-lsearch.c | 9 +++++++++
@@ -31,6 +31,3 @@ index c712112..1072b86 100644
 +	.help = help
 +};
 +#endif
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0009-serenity-Fake-O_SYNC-for-serenity-so-iomix-stressor-.patch
+++ b/Ports/stress-ng/patches/0009-serenity-Fake-O_SYNC-for-serenity-so-iomix-stressor-.patch
@@ -1,8 +1,7 @@
-From f332ec78663a2642c5ff93003dc806575cccfb54 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Mon, 27 Dec 2021 23:47:45 -0800
-Subject: [PATCH 09/14] serenity: Fake O_SYNC for serenity so iomix stressor
- compiles
+Subject: [PATCH] serenity: Fake O_SYNC for serenity so iomix stressor compiles
 
 Serenity doesn't yet support O_SYNC, so just make it compile.
 ---
@@ -25,6 +24,3 @@ index e99d262..8518e39 100644
  typedef void (*stress_iomix_func)(const stress_args_t *args, const int fd, const off_t iomix_bytes);
  
  static const stress_help_t help[] = {
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0010-serenity-Disable-lrand48-zlib-stress-it-is-not-imple.patch
+++ b/Ports/stress-ng/patches/0010-serenity-Disable-lrand48-zlib-stress-it-is-not-imple.patch
@@ -1,8 +1,8 @@
-From 684f3f13ebc61278fd12de7261a759bf8af450a6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Mon, 27 Dec 2021 23:48:49 -0800
-Subject: [PATCH 10/14] serenity: Disable lrand48 zlib stress, it is not
- implemented for Serenity
+Subject: [PATCH] serenity: Disable lrand48 zlib stress, it is not implemented
+ for Serenity
 
 ---
  stress-zlib.c | 6 ++++++
@@ -48,6 +48,3 @@ index 68330bb..90b0c65 100644
  	{ "morse",	stress_rand_data_morse },
  	{ "nybble",	stress_rand_data_nybble },
  	{ "objcode",	stress_rand_data_objcode },
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0011-serenity-Add-bogus-O_NDELAY-just-to-allow-the-port-t.patch
+++ b/Ports/stress-ng/patches/0011-serenity-Add-bogus-O_NDELAY-just-to-allow-the-port-t.patch
@@ -1,7 +1,7 @@
-From 8b2129617d17617124a0cdffd2e4819086ba3473 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Fri, 18 Mar 2022 02:35:30 -0700
-Subject: [PATCH 11/14] serenity: Add bogus O_NDELAY just to allow the port to
+Subject: [PATCH] serenity: Add bogus O_NDELAY just to allow the port to
  compile
 
 ---
@@ -24,6 +24,3 @@ index 7772097..aa98b0a 100644
  /*
   *  Device information is held in a linked list of dev_info_t objects. Each
   *  nth element in the list also points to a unique device state which is
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0012-serenity-Disable-nice-stress-workload-as-we-do-not-i.patch
+++ b/Ports/stress-ng/patches/0012-serenity-Disable-nice-stress-workload-as-we-do-not-i.patch
@@ -1,7 +1,7 @@
-From b874c0fbbb785423ed93ada0e1f7e5e1fe246ce8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Fri, 18 Mar 2022 02:36:17 -0700
-Subject: [PATCH 12/14] serenity: Disable nice() stress workload as we do not
+Subject: [PATCH] serenity: Disable nice() stress workload as we do not
  implement it
 
 ---
@@ -39,6 +39,3 @@ index ca89124..7dd9e52 100644
  	stress_syncload_spinwrite,
  };
  
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0013-serenity-Disable-prctl-stressor-on-serenity.patch
+++ b/Ports/stress-ng/patches/0013-serenity-Disable-prctl-stressor-on-serenity.patch
@@ -1,7 +1,7 @@
-From 94ad2d17986ad9c73efdc9f42a773a217af8ad38 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Fri, 18 Mar 2022 02:36:55 -0700
-Subject: [PATCH 13/14] serenity: Disable prctl stressor on serenity
+Subject: [PATCH] serenity: Disable prctl stressor on serenity
 
 ---
  stress-usersyscall.c | 3 ++-
@@ -21,6 +21,3 @@ index 26732db..a4eb903 100644
  
  #include <sys/prctl.h>
  
--- 
-2.32.0
-

--- a/Ports/stress-ng/patches/0014-Makefile-Install-to-usr-local.patch
+++ b/Ports/stress-ng/patches/0014-Makefile-Install-to-usr-local.patch
@@ -1,7 +1,7 @@
-From 13d34247badfb4adcbf725c04dd6ee2af30e6995 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Thu, 13 Jan 2022 16:13:02 +0330
-Subject: [PATCH 14/14] Makefile: Install to /usr/local
+Subject: [PATCH] Makefile: Install to /usr/local
 
 ---
  Makefile | 8 ++++----
@@ -26,6 +26,3 @@ index f8f71c5..1d90cd0 100644
  
  #
  #  Stressors
--- 
-2.32.0
-

--- a/Ports/tcl/patches/0001-Remove-uses-of-ipv6.patch
+++ b/Ports/tcl/patches/0001-Remove-uses-of-ipv6.patch
@@ -1,4 +1,4 @@
-From 51db9b91674f5ce8709896f1f752bbed7680fe55 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Tue, 27 Apr 2021 14:58:09 +0200
 Subject: [PATCH] Remove uses of ipv6
@@ -35,6 +35,3 @@ index 1a54914..121f8a4 100644
  }
  #if defined (__clang__) || ((__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
  #pragma GCC diagnostic pop
--- 
-2.36.1
-

--- a/Ports/thesilversearcher/patches/0001-Add-the-thread-pledge-to-the-pledge-list.patch
+++ b/Ports/thesilversearcher/patches/0001-Add-the-thread-pledge-to-the-pledge-list.patch
@@ -1,4 +1,4 @@
-From 8fe6ace7f911ecc50ec7e29eb9d3af38869a9905 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Raymond Lucke <ray@raylucke.com>
 Date: Sat, 14 May 2022 13:25:23 -0400
 Subject: [PATCH] Add the thread pledge to the pledge list
@@ -54,6 +54,3 @@ index e63985e..72f88b8 100644
          die("pledge: %s", strerror(errno));
      }
  #endif
--- 
-2.36.1
-

--- a/Ports/tinycc/patches/0001-Disable-backtrace-on-serenity.patch
+++ b/Ports/tinycc/patches/0001-Disable-backtrace-on-serenity.patch
@@ -1,7 +1,7 @@
-From 141841053adcc378af0880381d13db5317182e3b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sergey Bugaev <bugaevc@gmail.com>
 Date: Wed, 2 Oct 2019 22:50:20 +0300
-Subject: [PATCH 1/2] Disable backtrace on serenity
+Subject: [PATCH] Disable backtrace on serenity
 
 ---
  tcc.h | 2 +-
@@ -20,6 +20,3 @@ index ccb3b60..8cd1b19 100644
  # define CONFIG_TCC_BACKTRACE
  # if (defined TCC_TARGET_I386 || defined TCC_TARGET_X86_64 || \
        defined TCC_TARGET_ARM || defined TCC_TARGET_ARM64 || \
--- 
-2.34.1
-

--- a/Ports/tinycc/patches/0002-Manually-set-the-target-os-instead-of-using-uname.patch
+++ b/Ports/tinycc/patches/0002-Manually-set-the-target-os-instead-of-using-uname.patch
@@ -1,7 +1,7 @@
-From 47e11df165dacb5739aea943e548d73ad56818f0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sergey Bugaev <bugaevc@gmail.com>
 Date: Wed, 2 Oct 2019 22:50:20 +0300
-Subject: [PATCH 2/2] Manually set the target os instead of using uname
+Subject: [PATCH] Manually set the target os instead of using uname
 
 ---
  configure | 2 +-
@@ -20,6 +20,3 @@ index 5673d17..9bd864f 100755
  case $targetos in
    Darwin)
      confvars="$confvars OSX"
--- 
-2.34.1
-

--- a/Ports/tr/patches/0001-Add-an-install-target.patch
+++ b/Ports/tr/patches/0001-Add-an-install-target.patch
@@ -1,4 +1,4 @@
-From 1793eeb7c83bcf1cf15684eb2c443bf2ba739bbe Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brian Callahan <bcallah@openbsd.org>
 Date: Sun, 10 May 2020 12:00:03 -0400
 Subject: [PATCH] Add an install target
@@ -21,6 +21,3 @@ index 93cac80..5d68e52 100644
 +
  clean:
  	rm -f ${PROG} ${OBJS}
--- 
-2.36.1
-

--- a/Ports/tuxracer/patches/0001-Fix-config-macro-reference-syntax.patch
+++ b/Ports/tuxracer/patches/0001-Fix-config-macro-reference-syntax.patch
@@ -1,7 +1,7 @@
-From 347946c86f0816ca4a76cfad176db3f7814f53e7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Fri, 24 Dec 2021 15:24:16 +0100
-Subject: [PATCH 1/3] Fix config macro reference syntax
+Subject: [PATCH] Fix config macro reference syntax
 
 ---
  src/game_config.c | 24 ++++++++++++------------
@@ -64,6 +64,3 @@ index f12bb2d..6d1e979 100644
  
  #define FN_PARAM_STRING( name ) \
      FN_PARAM( name, string, char* )
--- 
-2.36.1
-

--- a/Ports/tuxracer/patches/0002-Disable-full-screen.patch
+++ b/Ports/tuxracer/patches/0002-Disable-full-screen.patch
@@ -1,14 +1,14 @@
-From 8b1b102cd2dce045caf8603aa903bc9265c32cc4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jelle Raaijmakers <jelle@gmta.nl>
 Date: Fri, 24 Dec 2021 15:24:16 +0100
-Subject: [PATCH 2/3] Disable full screen
+Subject: [PATCH] Disable full screen
 
 ---
  src/game_config.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/game_config.c b/src/game_config.c
-index 6d1e979..f4c1c0c 100644
+index 6d1e979..35b6036 100644
 --- a/src/game_config.c
 +++ b/src/game_config.c
 @@ -505,7 +505,7 @@ void init_game_configuration()
@@ -20,6 +20,3 @@ index 6d1e979..f4c1c0c 100644
  	"# If true then the game will run in full-screen mode." );
  
      INIT_PARAM_INT( 
--- 
-2.36.1
-

--- a/Ports/tuxracer/patches/0003-Exit-event-loop-on-SDL_QUIT-event.patch
+++ b/Ports/tuxracer/patches/0003-Exit-event-loop-on-SDL_QUIT-event.patch
@@ -1,14 +1,14 @@
-From 99e0390e8974a0f0438fb95665edc910ef176883 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Grigoris Pavlakis <grigpavl@ece.auth.gr>
 Date: Mon, 30 May 2022 01:54:22 +0300
-Subject: [PATCH 3/3] Exit event loop on SDL_QUIT event
+Subject: [PATCH] Exit event loop on SDL_QUIT event
 
 ---
  src/winsys.c | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/src/winsys.c b/src/winsys.c
-index d932a1d..95eeefa 100644
+index d932a1d..5385cb7 100644
 --- a/src/winsys.c
 +++ b/src/winsys.c
 @@ -392,6 +392,10 @@ void winsys_process_events()
@@ -22,6 +22,3 @@ index d932a1d..95eeefa 100644
  	    }
  
  	    SDL_LockAudio();
--- 
-2.36.1
-

--- a/Ports/tuxracer/patches/ReadMe.md
+++ b/Ports/tuxracer/patches/ReadMe.md
@@ -2,13 +2,16 @@
 
 ## `0001-Fix-config-macro-reference-syntax.patch`
 
-Fix macro definitions using old syntax for referring to struct fields
+Fix config macro reference syntax
+
 
 ## `0002-Disable-full-screen.patch`
 
-Disable full screen by default (start in windowed mode)
+Disable full screen
+
 
 ## `0003-Exit-event-loop-on-SDL_QUIT-event.patch`
 
-Check for SDL_QUIT event and exit on its reception
-Allows the game to close from the window button instead from the menu only
+Exit event loop on SDL_QUIT event
+
+

--- a/Ports/vitetris/patches/0001-Add-a-missing-sys-time.h-include.patch
+++ b/Ports/vitetris/patches/0001-Add-a-missing-sys-time.h-include.patch
@@ -1,4 +1,4 @@
-From 8b105bbc4c407b78d264054d74c96db093859c51 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jaan <jaan_veersoo@hotmail.com>
 Date: Sat, 20 Mar 2021 23:34:53 +0200
 Subject: [PATCH] Add a missing sys/time.h include
@@ -17,6 +17,3 @@ index 093bb77..48aad37 100644
  #if HAVE_SYS_SELECT_H
  #include <sys/select.h>
  #elif __DJGPP__
--- 
-2.36.1
-

--- a/Ports/x264/patches/0001-Add-definitions-for-serenity-to-configure.patch
+++ b/Ports/x264/patches/0001-Add-definitions-for-serenity-to-configure.patch
@@ -1,10 +1,10 @@
-From 6f4145f606671d7be8597af7854bda59ef594802 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Hunter Kvalevog <hunterkva@protonmail.com>
 Date: Sat, 2 Apr 2022 19:14:23 -0500
 Subject: [PATCH] Add definitions for serenity to configure
 
 ---
- configure  | 4 ++++
+ configure | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/configure b/configure
@@ -22,6 +22,3 @@ index e242e73..1f60a1a 100755
      *)
          die "Unknown system $host, edit the configure"
          ;;
--- 
-2.36.1
-

--- a/Ports/xz/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/xz/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,4 +1,4 @@
-From 6e8ac02a635810a8be768d6e7bcac786e9e15908 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tim Schumacher <timschumi@gmx.de>
 Date: Sun, 29 May 2022 15:01:28 +0200
 Subject: [PATCH] libtool: Enable shared library support for SerenityOS
@@ -71,6 +71,3 @@ index f103a6b..099c1e4 100755
  *)
    dynamic_linker=no
    ;;
--- 
-2.36.1
-

--- a/Ports/zlib/patches/0001-Fix-configure-issue-that-discarded-provided-CC-defin.patch
+++ b/Ports/zlib/patches/0001-Fix-configure-issue-that-discarded-provided-CC-defin.patch
@@ -1,4 +1,4 @@
-From 05796d3d8d5546cf1b4dfe2cd72ab746afae505d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mark Adler <madler@alumni.caltech.edu>
 Date: Mon, 28 Mar 2022 18:34:10 -0700
 Subject: [PATCH] Fix configure issue that discarded provided CC definition.
@@ -11,7 +11,7 @@ used for linking even though the cross-compiler was specified in the
  1 file changed, 3 insertions(+)
 
 diff --git a/configure b/configure
-index 52ff4a04e..3fa3e8618 100755
+index 52ff4a0..3fa3e86 100755
 --- a/configure
 +++ b/configure
 @@ -174,7 +174,10 @@ if test -z "$CC"; then

--- a/Ports/zlib/patches/ReadMe.md
+++ b/Ports/zlib/patches/ReadMe.md
@@ -1,6 +1,6 @@
 # Patches for zlib on SerenityOS
 
-## `fix-cross-compilation.patch`
+## `0001-Fix-configure-issue-that-discarded-provided-CC-defin.patch`
 
 Fix configure issue that discarded provided CC definition.
 

--- a/Ports/zsh/patches/0001-Let-zsh-define-the-rlimit-constants.patch
+++ b/Ports/zsh/patches/0001-Let-zsh-define-the-rlimit-constants.patch
@@ -1,4 +1,4 @@
-From 8d26e03f10054af3f81bd66b3200efeb91f69c7b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thiago Henrique Hupner <thihup@gmail.com>
 Date: Sat, 5 Jun 2021 08:31:13 -0300
 Subject: [PATCH] Let zsh define the rlimit constants
@@ -21,6 +21,3 @@ index 161b073..00286f2 100644
  /* HPUX does have the BSD rlimits in the kernel.  Officially they are *
   * unsupported but quite a few of them like RLIMIT_CORE seem to work. *
   * All the following are in the <sys/resource.h> but made visible     *
--- 
-2.36.1
-

--- a/Ports/zstd/patches/0001-Fix-linker-soname-flags.patch
+++ b/Ports/zstd/patches/0001-Fix-linker-soname-flags.patch
@@ -1,7 +1,7 @@
-From 119adcddd9faa0485a64c49fb461ed24d26499b6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke Wilde <lukew@serenityos.org>
 Date: Sun, 13 Mar 2022 16:45:19 +0000
-Subject: [PATCH 1/2] Fix linker soname flags
+Subject: [PATCH] Fix linker soname flags
 
 Co-Authored-By: EWouters <6179932+EWouters@users.noreply.github.com>
 ---
@@ -39,6 +39,3 @@ index ef20218..e4766c9 100644
  
  .PHONY: all
  all: lib
--- 
-2.36.1
-

--- a/Ports/zstd/patches/0002-Make-platform.h-understand-that-serenity-is-posix-co.patch
+++ b/Ports/zstd/patches/0002-Make-platform.h-understand-that-serenity-is-posix-co.patch
@@ -1,8 +1,7 @@
-From 71a4bdd121f346d97c398f92a7ff310132de497a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke Wilde <lukew@serenityos.org>
 Date: Sun, 13 Mar 2022 16:45:19 +0000
-Subject: [PATCH 2/2] Make platform.h understand that serenity is
- posix-compliant
+Subject: [PATCH] Make platform.h understand that serenity is posix-compliant
 
 Co-Authored-By: Brian Callahan <bcallah@openbsd.org>
 ---
@@ -26,6 +25,3 @@ index b858e3b..8628c05 100644
  #    else
  #      define PLATFORM_POSIX_VERSION 1
  #    endif
--- 
-2.36.1
-


### PR DESCRIPTION
One giant change to rule them all. Literally. Because there will be no useless changes going forward.

The commit hash is largely irrelevant to us anyways (as most of our patches don't have a corresponding upstream commit, and it would get lost during the next patch change anyways), as are the numbers in the patch title and the Git version at the very end.

The patches that are shared outside of Ports remain unchanged to avoid invalidating peoples toolchain builds.

~~This will be un-drafted once I have scrolled through 8000 lines of diff and cleaned up remaining discrepancies between the patches and their readme.~~

Except for `libuv` (at least from what I have noticed), all changes only affect patch metadata, not patch contents.