### PR TITLE
MouseSettings: Fix crash when opening whist using a custom cursor theme

### DIFF
--- a/Userland/Applications/MouseSettings/HighlightPreviewWidget.cpp
+++ b/Userland/Applications/MouseSettings/HighlightPreviewWidget.cpp
@@ -6,6 +6,7 @@
 
 #include "HighlightPreviewWidget.h"
 #include <AK/String.h>
+#include <LibCore/ConfigFile.h>
 #include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/AntiAliasingPainter.h>
@@ -15,8 +16,25 @@ namespace MouseSettings {
 HighlightPreviewWidget::HighlightPreviewWidget(Gfx::Palette const& palette)
     : GUI::AbstractThemePreview(palette)
 {
+    (void)reload_cursor();
+}
+
+ErrorOr<void> HighlightPreviewWidget::reload_cursor()
+{
     auto cursor_theme = GUI::ConnectionToWindowServer::the().get_cursor_theme();
-    m_cursor_bitmap = Gfx::Bitmap::try_load_from_file(String::formatted("/res/cursor-themes/{}/arrow.x2y2.png", cursor_theme)).release_value_but_fixme_should_propagate_errors();
+    auto theme_path = String::formatted("/res/cursor-themes/{}/{}", cursor_theme, "Config.ini");
+    auto cursor_theme_config = TRY(Core::ConfigFile::open(theme_path));
+    auto load_bitmap = [](StringView path, StringView default_path) {
+        auto maybe_bitmap = Gfx::Bitmap::try_load_from_file(path);
+        if (!maybe_bitmap.is_error())
+            return maybe_bitmap;
+        return Gfx::Bitmap::try_load_from_file(default_path);
+    };
+    constexpr auto default_cursor_path = "/res/cursor-themes/Default/arrow.x2y2.png";
+    auto cursor_path = String::formatted("/res/cursor-themes/{}/{}",
+        cursor_theme, cursor_theme_config->read_entry("Cursor", "Arrow"));
+    m_cursor_bitmap = TRY(load_bitmap(cursor_path, default_cursor_path));
+    return {};
 }
 
 void HighlightPreviewWidget::paint_preview(GUI::PaintEvent&)
@@ -28,7 +46,8 @@ void HighlightPreviewWidget::paint_preview(GUI::PaintEvent&)
         highlight_rect.center_within(frame_inner_rect());
         aa_painter.fill_ellipse(highlight_rect, m_color);
     }
-    painter.blit(m_cursor_bitmap->rect().centered_within(frame_inner_rect()).location(), *m_cursor_bitmap, m_cursor_bitmap->rect());
+    if (m_cursor_bitmap)
+        painter.blit(m_cursor_bitmap->rect().centered_within(frame_inner_rect()).location(), *m_cursor_bitmap, m_cursor_bitmap->rect());
 }
 
 }

--- a/Userland/Applications/MouseSettings/HighlightPreviewWidget.h
+++ b/Userland/Applications/MouseSettings/HighlightPreviewWidget.h
@@ -33,6 +33,8 @@ public:
 private:
     explicit HighlightPreviewWidget(Gfx::Palette const& palette);
 
+    ErrorOr<void> reload_cursor();
+
     RefPtr<Gfx::Bitmap> m_cursor_bitmap;
 
     int m_radius { 0 };


### PR DESCRIPTION
Rather than hard-coding the expected cursor path blindly doing a `release_value_but_fixme_should_propagate_errors()`, this instead now uses the current cursor themes `Config.ini` to figure out where to load the cursor from.


Fixes #14200