### PR TITLE
tar: Implement support for GNU long name headers

### DIFF
--- a/Userland/Libraries/LibArchive/Tar.h
+++ b/Userland/Libraries/LibArchive/Tar.h
@@ -26,7 +26,10 @@ enum class TarFileType : char {
     FIFO = '6',
     ContiguousFile = '7',
     GlobalExtendedHeader = 'g',
-    ExtendedHeader = 'x'
+    ExtendedHeader = 'x',
+
+    // GNU extensions
+    LongName = 'L',
 };
 
 constexpr size_t block_size = 512;


### PR DESCRIPTION
While Ports patches are in review, time for a bit of old-school `tar` compliance hacking.

And what better to start on than with a GNU-specific option for something that already exists in some other way.

We can now extract the official GCC tarball.