### PR TITLE
LibWeb: Dont crash WebContent when trying to create an event

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -186,7 +186,7 @@ public:
     NonnullRefPtr<Text> create_text_node(String const& data);
     NonnullRefPtr<Comment> create_comment(String const& data);
     NonnullRefPtr<Range> create_range();
-    NonnullRefPtr<Event> create_event(String const& interface);
+    ExceptionOr<NonnullRefPtr<Event>> create_event(String const& interface);
 
     void set_pending_parsing_blocking_script(Badge<HTML::HTMLScriptElement>, HTML::HTMLScriptElement*);
     HTML::HTMLScriptElement* pending_parsing_blocking_script() { return m_pending_parsing_blocking_script; }


### PR DESCRIPTION
With this change, it no longer calls TODO() and crashes WebContent

Fixes: #14206 