### PR TITLE
LibGUI: Close EmojiDialog on active window change

### DIFF
--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -92,6 +92,11 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
             }
         }
     }
+
+    on_active_window_change = [this](bool is_active_window) {
+        if (!is_active_window)
+            close();
+    };
 }
 
 void EmojiInputDialog::event(Core::Event& event)


### PR DESCRIPTION
This patch makes EmojiDialog be closed whenever the focus moves away
from it just like the CommandPalette.