### PR TITLE
Ports/libyaml: Add correct `workdir`

### DIFF
--- a/Ports/libyaml/package.sh
+++ b/Ports/libyaml/package.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port="libyaml"
-version="0.2.5"
+port='libyaml'
+version='0.2.5'
 files="https://github.com/yaml/libyaml/releases/download/${version}/yaml-${version}.tar.gz yaml-${version}.tar.gz c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
-useconfigure="true"
-auth_type="sha256"
-use_fresh_config_sub=true
+auth_type='sha256'
+useconfigure='true'
+use_fresh_config_sub='true'
 config_sub_paths=("config/config.sub")
+workdir="yaml-${version}"


### PR DESCRIPTION
This fixes the `workdir` after fd9125c and uses single quotes for strings.