### PR TITLE
WindowServer+MouseSettings: Toggle cursor highlighting with Super+H (and some fixes)

### DIFF
--- a/Userland/Applications/MouseSettings/Highlight.gml
+++ b/Userland/Applications/MouseSettings/Highlight.gml
@@ -45,20 +45,20 @@
 
             @GUI::Label {
                 autosize: true
-                text: "0%"
+                text: "Low"
             }
 
             @GUI::Slider {
                 name: "highlight_opacity_slider"
                 orientation: "Horizontal"
                 max: 230
-                min: 0
+                min: 30
                 value: 110
             }
 
             @GUI::Label {
                 autosize: true
-                text: "100%"
+                text: "High"
             }
         }
     }
@@ -79,20 +79,20 @@
 
             @GUI::Label {
                 autosize: true
-                text: "Off"
+                text: "Small"
             }
 
             @GUI::Slider {
                 name: "highlight_radius_slider"
                 orientation: "Horizontal"
                 max: 60
-                min: 19
+                min: 20
                 value: 25
             }
 
             @GUI::Label {
                 autosize: true
-                text: "Largest"
+                text: "Large"
             }
         }
     }

--- a/Userland/Applications/MouseSettings/Highlight.gml
+++ b/Userland/Applications/MouseSettings/Highlight.gml
@@ -53,7 +53,7 @@
                 orientation: "Horizontal"
                 max: 230
                 min: 0
-                value: 80
+                value: 110
             }
 
             @GUI::Label {
@@ -87,7 +87,7 @@
                 orientation: "Horizontal"
                 max: 60
                 min: 19
-                value: 30
+                value: 25
             }
 
             @GUI::Label {

--- a/Userland/Applications/MouseSettings/HighlightPreviewWidget.cpp
+++ b/Userland/Applications/MouseSettings/HighlightPreviewWidget.cpp
@@ -51,12 +51,10 @@ ErrorOr<void> HighlightPreviewWidget::reload_cursor()
 void HighlightPreviewWidget::paint_preview(GUI::PaintEvent&)
 {
     GUI::Painter painter(*this);
-    if (m_radius > 0 && m_color.alpha() > 0) {
-        Gfx::AntiAliasingPainter aa_painter { painter };
-        Gfx::IntRect highlight_rect { 0, 0, m_radius * 2, m_radius * 2 };
-        highlight_rect.center_within(frame_inner_rect());
-        aa_painter.fill_ellipse(highlight_rect, m_color);
-    }
+    Gfx::AntiAliasingPainter aa_painter { painter };
+    Gfx::IntRect highlight_rect { 0, 0, m_radius * 2, m_radius * 2 };
+    highlight_rect.center_within(frame_inner_rect());
+    aa_painter.fill_ellipse(highlight_rect, m_color);
     if (m_cursor_bitmap) {
         auto cursor_rect = m_cursor_bitmap->rect();
         if (m_cursor_params.frames() > 1)

--- a/Userland/Applications/MouseSettings/HighlightPreviewWidget.cpp
+++ b/Userland/Applications/MouseSettings/HighlightPreviewWidget.cpp
@@ -34,6 +34,17 @@ ErrorOr<void> HighlightPreviewWidget::reload_cursor()
     auto cursor_path = String::formatted("/res/cursor-themes/{}/{}",
         cursor_theme, cursor_theme_config->read_entry("Cursor", "Arrow"));
     m_cursor_bitmap = TRY(load_bitmap(cursor_path, default_cursor_path));
+    m_cursor_params = Gfx::CursorParams::parse_from_filename(cursor_path, m_cursor_bitmap->rect().center()).constrained(*m_cursor_bitmap);
+    // Setup cursor animation:
+    if (m_cursor_params.frames() > 1 && m_cursor_params.frame_ms() > 0) {
+        m_frame_timer = Core::Timer::create_repeating(m_cursor_params.frame_ms(), [&] {
+            m_cursor_frame = (m_cursor_frame + 1) % m_cursor_params.frames();
+            update();
+        });
+        m_frame_timer->start();
+    } else {
+        m_frame_timer = nullptr;
+    }
     return {};
 }
 
@@ -46,8 +57,12 @@ void HighlightPreviewWidget::paint_preview(GUI::PaintEvent&)
         highlight_rect.center_within(frame_inner_rect());
         aa_painter.fill_ellipse(highlight_rect, m_color);
     }
-    if (m_cursor_bitmap)
-        painter.blit(m_cursor_bitmap->rect().centered_within(frame_inner_rect()).location(), *m_cursor_bitmap, m_cursor_bitmap->rect());
+    if (m_cursor_bitmap) {
+        auto cursor_rect = m_cursor_bitmap->rect();
+        if (m_cursor_params.frames() > 1)
+            cursor_rect.set_width(cursor_rect.width() / m_cursor_params.frames());
+        painter.blit(cursor_rect.centered_within(frame_inner_rect()).location(), *m_cursor_bitmap, cursor_rect.translated(m_cursor_frame * cursor_rect.width(), 0));
+    }
 }
 
 }

--- a/Userland/Applications/MouseSettings/HighlightPreviewWidget.h
+++ b/Userland/Applications/MouseSettings/HighlightPreviewWidget.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
+#include <LibCore/Timer.h>
 #include <LibGUI/AbstractThemePreview.h>
 #include <LibGfx/Color.h>
+#include <LibGfx/CursorParams.h>
 
 namespace MouseSettings {
 
@@ -36,7 +38,10 @@ private:
     ErrorOr<void> reload_cursor();
 
     RefPtr<Gfx::Bitmap> m_cursor_bitmap;
+    Gfx::CursorParams m_cursor_params;
+    RefPtr<Core::Timer> m_frame_timer;
 
+    int m_cursor_frame { 0 };
     int m_radius { 0 };
     Gfx::Color m_color;
 };

--- a/Userland/Applications/MouseSettings/HighlightWidget.cpp
+++ b/Userland/Applications/MouseSettings/HighlightWidget.cpp
@@ -66,13 +66,13 @@ void HighlightWidget::apply_settings()
 
 void HighlightWidget::reset_default_values()
 {
-    constexpr auto default_highlight_color = Gfx::Color::NamedColor::Yellow;
-    constexpr auto default_highlight_opacity = 80; // (in range of 0-255)
+    constexpr auto default_highlight_color = Gfx::Color::NamedColor::Red;
+    constexpr auto default_highlight_opacity = 110; // (in range of 0-255)
     // Disable the highlighting by default.
     // The range of radii you can configure the highlight to is 20 to 60px,
     // anything less than that is treated as 'no highlighting'.
-    constexpr auto default_highlight_radius_length = 19;
-    m_highlight_color_input->set_color(default_highlight_color);
+    constexpr auto default_highlight_radius_length = 25;
     m_highlight_opacity_slider->set_value(default_highlight_opacity);
+    m_highlight_color_input->set_color(default_highlight_color);
     m_highlight_radius_slider->set_value(default_highlight_radius_length);
 }

--- a/Userland/Applications/MouseSettings/HighlightWidget.cpp
+++ b/Userland/Applications/MouseSettings/HighlightWidget.cpp
@@ -75,4 +75,8 @@ void HighlightWidget::reset_default_values()
     m_highlight_opacity_slider->set_value(default_highlight_opacity);
     m_highlight_color_input->set_color(default_highlight_color);
     m_highlight_radius_slider->set_value(default_highlight_radius_length);
+    deferred_invoke([&] {
+        // Avoid artifact due to setting both color and opacity sliders:
+        m_highlight_preview->update();
+    });
 }

--- a/Userland/Applications/MouseSettings/HighlightWidget.cpp
+++ b/Userland/Applications/MouseSettings/HighlightWidget.cpp
@@ -52,10 +52,7 @@ Gfx::Color HighlightWidget::highlight_color()
 
 int HighlightWidget::highlight_radius()
 {
-    auto current_value = m_highlight_radius_slider->value();
-    if (current_value <= m_highlight_radius_slider->min())
-        return 0;
-    return current_value;
+    return m_highlight_radius_slider->value();
 }
 
 void HighlightWidget::apply_settings()

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -846,9 +846,11 @@ Gfx::IntRect Compositor::current_cursor_rect() const
     Gfx::IntRect cursor_rect { ScreenInput::the().cursor_location().translated(-current_cursor.params().hotspot()), current_cursor.size() };
     if (wm.is_cursor_highlight_enabled()) {
         auto highlight_diameter = wm.cursor_highlight_radius() * 2;
-        cursor_rect.inflate(
-            highlight_diameter - cursor_rect.width(),
-            highlight_diameter - cursor_rect.height());
+        auto inflate_w = highlight_diameter - cursor_rect.width();
+        auto inflate_h = highlight_diameter - cursor_rect.height();
+        cursor_rect.inflate(inflate_w, inflate_h);
+        // Ensures cursor stays in the same location when highlighting is enabled.
+        cursor_rect.translate_by(-(inflate_w % 2), -(inflate_h % 2));
     }
     return cursor_rect;
 }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1697,40 +1697,47 @@ void WindowManager::process_key_event(KeyEvent& event)
     if (!active_input_window)
         return;
 
-    if (event.type() == Event::KeyDown && event.modifiers() == Mod_Super && active_input_window->type() != WindowType::Desktop) {
-        if (event.key() == Key_Down) {
-            if (active_input_window->is_resizable() && active_input_window->is_maximized()) {
-                maximize_windows(*active_input_window, false);
-                return;
-            }
-            if (active_input_window->is_minimizable())
-                minimize_windows(*active_input_window, true);
+    if (event.type() == Event::KeyDown && event.modifiers() == Mod_Super) {
+        if (event.key() == Key_H) {
+            m_cursor_highlight_enabled = !m_cursor_highlight_enabled;
+            Compositor::the().invalidate_cursor();
             return;
         }
-        if (active_input_window->is_resizable()) {
-            if (event.key() == Key_Up) {
-                maximize_windows(*active_input_window, !active_input_window->is_maximized());
-                return;
-            }
-            if (event.key() == Key_Left) {
-                if (active_input_window->tile_type() == WindowTileType::Left) {
-                    active_input_window->set_untiled();
+        if (active_input_window->type() != WindowType::Desktop) {
+            if (event.key() == Key_Down) {
+                if (active_input_window->is_resizable() && active_input_window->is_maximized()) {
+                    maximize_windows(*active_input_window, false);
                     return;
                 }
-                if (active_input_window->is_maximized())
-                    maximize_windows(*active_input_window, false);
-                active_input_window->set_tiled(WindowTileType::Left);
+                if (active_input_window->is_minimizable())
+                    minimize_windows(*active_input_window, true);
                 return;
             }
-            if (event.key() == Key_Right) {
-                if (active_input_window->tile_type() == WindowTileType::Right) {
-                    active_input_window->set_untiled();
+            if (active_input_window->is_resizable()) {
+                if (event.key() == Key_Up) {
+                    maximize_windows(*active_input_window, !active_input_window->is_maximized());
                     return;
                 }
-                if (active_input_window->is_maximized())
-                    maximize_windows(*active_input_window, false);
-                active_input_window->set_tiled(WindowTileType::Right);
-                return;
+                if (event.key() == Key_Left) {
+                    if (active_input_window->tile_type() == WindowTileType::Left) {
+                        active_input_window->set_untiled();
+                        return;
+                    }
+                    if (active_input_window->is_maximized())
+                        maximize_windows(*active_input_window, false);
+                    active_input_window->set_tiled(WindowTileType::Left);
+                    return;
+                }
+                if (event.key() == Key_Right) {
+                    if (active_input_window->tile_type() == WindowTileType::Right) {
+                        active_input_window->set_untiled();
+                        return;
+                    }
+                    if (active_input_window->is_maximized())
+                        maximize_windows(*active_input_window, false);
+                    active_input_window->set_tiled(WindowTileType::Right);
+                    return;
+                }
             }
         }
     }
@@ -2292,11 +2299,6 @@ void WindowManager::set_cursor_highlight_color(Gfx::Color const& color)
     Compositor::the().invalidate_cursor();
     m_config->write_entry("Mouse", "CursorHighlightColor", color.to_string());
     sync_config_to_disk();
-}
-
-bool WindowManager::is_cursor_highlight_enabled() const
-{
-    return m_cursor_highlight_radius > 0 && m_cursor_highlight_color.alpha() > 0;
 }
 
 bool WindowManager::sync_config_to_disk()

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -82,9 +82,9 @@ void WindowManager::reload_config()
 
     m_double_click_speed = m_config->read_num_entry("Input", "DoubleClickSpeed", 250);
     m_buttons_switched = m_config->read_bool_entry("Mouse", "ButtonsSwitched", false);
-    m_cursor_highlight_radius = m_config->read_num_entry("Mouse", "CursorHighlightRadius", 0);
-    Color default_highlight_color = Color::NamedColor::Yellow;
-    default_highlight_color.set_alpha(80);
+    m_cursor_highlight_radius = m_config->read_num_entry("Mouse", "CursorHighlightRadius", 25);
+    Color default_highlight_color = Color::NamedColor::Red;
+    default_highlight_color.set_alpha(110);
     m_cursor_highlight_color = Color::from_string(m_config->read_entry("Mouse", "CursorHighlightColor")).value_or(default_highlight_color);
     apply_cursor_theme(m_config->read_entry("Mouse", "CursorTheme", "Default"));
 

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -329,7 +329,7 @@ public:
     void set_cursor_highlight_radius(int radius);
     void set_cursor_highlight_color(Gfx::Color const& color);
 
-    bool is_cursor_highlight_enabled() const;
+    bool is_cursor_highlight_enabled() const { return m_cursor_highlight_radius > 0 && m_cursor_highlight_enabled; }
 
 private:
     explicit WindowManager(Gfx::PaletteImpl const&);
@@ -386,6 +386,7 @@ private:
     RefPtr<Cursor> m_zoom_cursor;
     int m_cursor_highlight_radius { 0 };
     Gfx::Color m_cursor_highlight_color;
+    bool m_cursor_highlight_enabled { false };
 
     RefPtr<MultiScaleBitmaps> m_overlay_rect_shadow;
 


### PR DESCRIPTION
With this PR cursor highlighting can be toggled any time with Super+H. 
Mouse settings is now only used to configure the look of the highlighting. 

I think this change makes makes things a bunch more usable. 



https://user-images.githubusercontent.com/11597044/172722131-2b53896c-6dbf-4429-a776-a01d7e9d5206.mp4


---

I've also bundled a few little tweaks + fixes 