### PR TITLE
Ports: A followup to various fixes

### DIFF
--- a/Ports/awk/package.sh
+++ b/Ports/awk/package.sh
@@ -2,7 +2,7 @@
 port=awk
 version=20220122
 useconfigure="false"
-files="https://github.com/onetrueawk/awk/archive/refs/tags/${version}.tar.gz awk-${version}.tar.xz 720a06ff8dcc12686a5176e8a4c74b1295753df816e38468a6cf077562d54042"
+files="https://github.com/onetrueawk/awk/archive/refs/tags/${version}.tar.gz awk-${version}.tar.gz 720a06ff8dcc12686a5176e8a4c74b1295753df816e38468a6cf077562d54042"
 auth_type=sha256
 patchlevel=1
 

--- a/Ports/fontconfig/package.sh
+++ b/Ports/fontconfig/package.sh
@@ -6,7 +6,14 @@ use_fresh_config_sub="true"
 depends=("libxml2" "freetype")
 files="https://www.freedesktop.org/software/fontconfig/release/fontconfig-${version}.tar.xz fontconfig-${version}.tar.xz dcbeb84c9c74bbfdb133d535fe1c7bedc9f2221a8daf3914b984c44c520e9bac"
 auth_type="sha256"
-configopts=("--prefix=/usr/local" "--enable-libxml2" "LDFLAGS=-ldl -lxml2")
+configopts=(
+    "--with-sysroot=${SERENITY_INSTALL_ROOT}"
+    "--prefix=/usr/local"
+    "--disable-static"
+    "--enable-shared"
+    "--enable-libxml2"
+    "LDFLAGS=-ldl -lxml2"
+)
 
 export CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/libxml2"
 export LIBXML2_CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/libxml2/"

--- a/Ports/fontconfig/patches/0003-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/fontconfig/patches/0003-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index cd2e462..23e9943 100755
+--- a/configure
++++ b/configure
+@@ -7525,6 +7525,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -10990,6 +10994,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -12520,6 +12528,10 @@ printf "%s\n" "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -13595,6 +13607,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;

--- a/Ports/fontconfig/patches/ReadMe.md
+++ b/Ports/fontconfig/patches/ReadMe.md
@@ -10,3 +10,17 @@ Stub out FcRandom()
 Manually link against lxml2 and ldl
 
 
+## `0003-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/freetype/package.sh
+++ b/Ports/freetype/package.sh
@@ -6,7 +6,14 @@ auth_type='sha256'
 useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=("builds/unix/config.sub")
-configopts=("--with-brotli=no" "--with-bzip2=no" "--with-zlib=no" "--with-harfbuzz=no" "--with-png=no")
+configopts=(
+    "--with-sysroot=${SERENITY_INSTALL_ROOT}"
+    "--with-brotli=no"
+    "--with-bzip2=no"
+    "--with-zlib=no"
+    "--with-harfbuzz=no"
+    "--with-png=no"
+)
 
 install() {
     run make DESTDIR="${SERENITY_INSTALL_ROOT}" "${installopts[@]}" install

--- a/Ports/gnucobol/package.sh
+++ b/Ports/gnucobol/package.sh
@@ -11,6 +11,7 @@ https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts=("--keyring" "./gnu-keyring.gpg" "gnucobol-${version}.tar.bz2.sig")
 configopts=(
+    "--with-sysroot=${SERENITY_INSTALL_ROOT}"
     "--prefix=/usr/local"
     "--enable-hardening"
     "--disable-rpath"

--- a/Ports/libtiff/package.sh
+++ b/Ports/libtiff/package.sh
@@ -4,6 +4,11 @@ version='4.4.0'
 files="http://download.osgeo.org/libtiff/tiff-${version}.tar.xz tiff-${version}.tar.xz 49307b510048ccc7bc40f2cba6e8439182fe6e654057c1a1683139bf2ecb1dc1"
 auth_type='sha256'
 useconfigure='true'
-configopts=("--disable-static" "--enable-shared")
+configopts=(
+    "--with-sysroot=${SERENITY_INSTALL_ROOT}"
+    "--prefix=/usr/local"
+    "--disable-static"
+    "--enable-shared"
+)
 workdir="tiff-${version}"
 depends=("libjpeg" "zstd" "xz")

--- a/Ports/mrsh/package.sh
+++ b/Ports/mrsh/package.sh
@@ -4,5 +4,8 @@ version=cd3c3a48055ab4085d83f149ff4b4feba40b40cb
 files="https://github.com/emersion/mrsh/archive/${version}.tar.gz ${port}-${version}.tar.gz d26e3fdee71ef168cf3f8ad2912c148b20aab524048e4ea899d6b83fb299ceab"
 auth_type=sha256
 useconfigure=true
+configopts=(
+    "--without-readline"
+)
 
 export CFLAGS=-Wno-deprecated-declarations

--- a/Ports/readline/package.sh
+++ b/Ports/readline/package.sh
@@ -7,3 +7,13 @@ config_sub_paths=("support/config.sub")
 use_fresh_config_sub=true
 files="https://ftpmirror.gnu.org/gnu/readline/readline-${version}.tar.gz readline-${version}.tar.gz 7589a2381a8419e68654a47623ce7dfcb756815c8fee726b98f90bf668af7bc6"
 auth_type=sha256
+configopts=(
+    "--disable-static"
+    "--enable-shared"
+)
+
+post_install() {
+    # readline specifies termcap as a dependency in its pkgconfig file, without checking if it exists.
+    # Remove it manually to keep other ports from discarding readline because termcap is supposedly missing.
+    sed -i -e '/^Requires.private:/s/termcap//' "${SERENITY_INSTALL_ROOT}/usr/local/lib/pkgconfig/readline.pc"
+}

--- a/Ports/readline/patches/0001-Add-SerenityOS-support-to-the-shared-library-scripts.patch
+++ b/Ports/readline/patches/0001-Add-SerenityOS-support-to-the-shared-library-scripts.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Wed, 8 Jun 2022 00:30:22 +0200
+Subject: [PATCH] Add SerenityOS support to the shared library scripts
+
+This allows us to have properly named library symlinks.
+---
+ support/shlib-install | 4 ++--
+ support/shobj-conf    | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/support/shlib-install b/support/shlib-install
+index 661355d..f15ec01 100755
+--- a/support/shlib-install
++++ b/support/shlib-install
+@@ -71,7 +71,7 @@ fi
+ # Cygwin installs both a dll (which must go in $BINDIR) and an implicit
+ # link library (in $libdir)
+ case "$host_os" in
+-hpux*|darwin*|macosx*|linux*|solaris2*)
++hpux*|darwin*|macosx*|linux*|solaris2*|serenity*)
+ 	if [ -z "$uninstall" ]; then
+ 		chmod 755 ${INSTALLDIR}/${LIBNAME}
+ 	fi ;;
+@@ -118,7 +118,7 @@ INSTALL_LINK2='${echo} cd $INSTALLDIR && ${echo} ${LN} $LIBNAME $LINK2'
+ # Create symlinks to the installed library.  This section is incomplete.
+ #
+ case "$host_os-$host_vendor" in
+-*linux*|freebsd*|dragonfly*)
++*linux*|freebsd*|dragonfly*|serenity*)
+ 	# libname.so.M -> libname.so.M.N
+ 	${echo} ${RM} ${INSTALLDIR}/$LINK2
+ 	if [ -z "$uninstall" ]; then
+diff --git a/support/shobj-conf b/support/shobj-conf
+index 5a3f977..f6978ea 100644
+--- a/support/shobj-conf
++++ b/support/shobj-conf
+@@ -123,7 +123,7 @@ sunos5*|solaris2*)
+ 	;;
+ 
+ # All versions of Linux (including Gentoo/FreeBSD) or the semi-mythical GNU Hurd.
+-linux*-*|gnu*-*|k*bsd*-gnu-*|freebsd*|dragonfly*)
++linux*-*|gnu*-*|k*bsd*-gnu-*|freebsd*|dragonfly*|serenity*)
+ 	SHOBJ_CFLAGS=-fPIC
+ 	SHOBJ_LD='${CC}'
+ 	SHOBJ_LDFLAGS='-shared -Wl,-soname,$@'

--- a/Ports/readline/patches/ReadMe.md
+++ b/Ports/readline/patches/ReadMe.md
@@ -1,0 +1,8 @@
+# Patches for readline on SerenityOS
+
+## `0001-Add-SerenityOS-support-to-the-shared-library-scripts.patch`
+
+Add SerenityOS support to the shared library scripts
+
+This allows us to have properly named library symlinks.
+

--- a/Ports/thesilversearcher/package.sh
+++ b/Ports/thesilversearcher/package.sh
@@ -2,7 +2,7 @@
 port=thesilversearcher
 version=2.2.0
 useconfigure="true"
-files="https://geoff.greer.fm/ag/releases/the_silver_searcher-${version}.tar.gz the_silver_searcher-${version}.tar.xz d9621a878542f3733b5c6e71c849b9d1a830ed77cb1a1f6c2ea441d4b0643170"
+files="https://geoff.greer.fm/ag/releases/the_silver_searcher-${version}.tar.gz the_silver_searcher-${version}.tar.gz d9621a878542f3733b5c6e71c849b9d1a830ed77cb1a1f6c2ea441d4b0643170"
 workdir="the_silver_searcher-${version}"
 configopts=("--target=${SERENITY_ARCH}-pc-serenity" "--disable-utf8")
 depends=("pcre" "xz")


### PR DESCRIPTION
This fixes various oversights in my last two Ports-related PRs, which either caused some ports to not be buildable or that were just some nitpicks that have been discovered after the fact.

Now, all ports (except for one) that were buildable before my previous changes are buildable again now. The exception to this is PHP, as they haven't updated their version of `libtool` in 12 years, and they therefore lack support for `--with-sysroot` (so I'll have to spend some more time on backporting that).