### PR TITLE
LibGUI: Add MoveLineUpOrDownCommand

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -259,8 +259,11 @@ EditingEngine::DidMoveALine EditingEngine::move_one_up(KeyEvent const& event)
 {
     if (m_editor->cursor().line() > 0 || m_editor->is_wrapping_enabled()) {
         if (event.ctrl() && event.shift()) {
-            move_selected_lines_up();
-            return DidMoveALine::Yes;
+            if (MoveLineUpOrDownCommand::valid_operation(*this, VerticalDirection::Up)) {
+                m_editor->execute<MoveLineUpOrDownCommand>(Badge<EditingEngine> {}, event, *this);
+                return DidMoveALine::Yes;
+            }
+            return DidMoveALine::No;
         }
         TextPosition new_cursor;
         if (m_editor->is_wrapping_enabled()) {
@@ -280,8 +283,11 @@ EditingEngine::DidMoveALine EditingEngine::move_one_down(KeyEvent const& event)
 {
     if (m_editor->cursor().line() < (m_editor->line_count() - 1) || m_editor->is_wrapping_enabled()) {
         if (event.ctrl() && event.shift()) {
-            move_selected_lines_down();
-            return DidMoveALine::Yes;
+            if (MoveLineUpOrDownCommand::valid_operation(*this, VerticalDirection::Down)) {
+                m_editor->execute<MoveLineUpOrDownCommand>(Badge<EditingEngine> {}, event, *this);
+                return DidMoveALine::Yes;
+            }
+            return DidMoveALine::No;
         }
         TextPosition new_cursor;
         if (m_editor->is_wrapping_enabled()) {
@@ -353,6 +359,11 @@ void EditingEngine::move_to_last_line()
     m_editor->set_cursor(m_editor->line_count() - 1, m_editor->lines()[m_editor->line_count() - 1].length());
 };
 
+void EditingEngine::get_selection_line_boundaries(Badge<MoveLineUpOrDownCommand>, size_t& first_line, size_t& last_line)
+{
+    get_selection_line_boundaries(first_line, last_line);
+}
+
 void EditingEngine::get_selection_line_boundaries(size_t& first_line, size_t& last_line)
 {
     auto selection = m_editor->normalized_selection();
@@ -365,55 +376,6 @@ void EditingEngine::get_selection_line_boundaries(size_t& first_line, size_t& la
     last_line = selection.end().line();
     if (first_line != last_line && selection.end().column() == 0)
         last_line -= 1;
-}
-
-void EditingEngine::move_selected_lines_up()
-{
-    if (!m_editor->is_editable())
-        return;
-    size_t first_line;
-    size_t last_line;
-    get_selection_line_boundaries(first_line, last_line);
-
-    if (first_line == 0)
-        return;
-
-    auto& lines = m_editor->document().lines();
-    lines.insert((int)last_line, lines.take((int)first_line - 1));
-    m_editor->set_cursor({ m_editor->cursor().line() - 1, m_editor->cursor().column() });
-
-    if (m_editor->has_selection()) {
-        m_editor->selection().start().set_line(m_editor->selection().start().line() - 1);
-        m_editor->selection().end().set_line(m_editor->selection().end().line() - 1);
-    }
-
-    m_editor->did_change();
-    m_editor->update();
-}
-
-void EditingEngine::move_selected_lines_down()
-{
-    if (!m_editor->is_editable())
-        return;
-    size_t first_line;
-    size_t last_line;
-    get_selection_line_boundaries(first_line, last_line);
-
-    auto& lines = m_editor->document().lines();
-    VERIFY(lines.size() != 0);
-    if (last_line >= lines.size() - 1)
-        return;
-
-    lines.insert((int)first_line, lines.take((int)last_line + 1));
-    m_editor->set_cursor({ m_editor->cursor().line() + 1, m_editor->cursor().column() });
-
-    if (m_editor->has_selection()) {
-        m_editor->selection().start().set_line(m_editor->selection().start().line() + 1);
-        m_editor->selection().end().set_line(m_editor->selection().end().line() + 1);
-    }
-
-    m_editor->did_change();
-    m_editor->update();
 }
 
 void EditingEngine::delete_char()
@@ -429,5 +391,106 @@ void EditingEngine::delete_line()
         return;
     m_editor->delete_current_line();
 };
+
+MoveLineUpOrDownCommand::MoveLineUpOrDownCommand(TextDocument& document, KeyEvent event, EditingEngine& engine)
+    : TextDocumentUndoCommand(document)
+    , m_event(move(event))
+    , m_direction(key_code_to_vertical_direction(m_event.key()))
+    , m_engine(engine)
+    , m_selection(m_engine.editor().selection())
+    , m_cursor(m_engine.editor().cursor())
+{
+}
+
+void MoveLineUpOrDownCommand::redo()
+{
+    move_lines(m_direction);
+}
+
+void MoveLineUpOrDownCommand::undo()
+{
+    move_lines(!m_direction);
+}
+
+bool MoveLineUpOrDownCommand::merge_with(GUI::Command const&)
+{
+    return false;
+}
+
+String MoveLineUpOrDownCommand::action_text() const
+{
+    return "Move a line";
+}
+
+bool MoveLineUpOrDownCommand::valid_operation(EditingEngine& engine, VerticalDirection direction)
+{
+
+    VERIFY(engine.editor().line_count() != 0);
+
+    auto const& selection = engine.editor().selection().normalized();
+    if (selection.is_valid()) {
+        if ((direction == VerticalDirection::Up && selection.start().line() == 0) || (direction == VerticalDirection::Down && selection.end().line() >= engine.editor().line_count() - 1))
+            return false;
+    } else {
+        size_t first_line;
+        size_t last_line;
+        engine.get_selection_line_boundaries(Badge<MoveLineUpOrDownCommand> {}, first_line, last_line);
+
+        if ((direction == VerticalDirection::Up && first_line == 0) || (direction == VerticalDirection::Down && last_line >= engine.editor().line_count() - 1))
+            return false;
+    }
+    return true;
+}
+
+TextRange MoveLineUpOrDownCommand::retrieve_selection(VerticalDirection direction)
+{
+    if (direction == m_direction)
+        return m_selection;
+
+    auto const offset_selection = [this](auto const offset) {
+        auto tmp = m_selection;
+        tmp.start().set_line(tmp.start().line() + offset);
+        tmp.end().set_line(tmp.end().line() + offset);
+
+        return tmp;
+    };
+
+    if (direction == VerticalDirection::Up)
+        return offset_selection(1);
+    if (direction == VerticalDirection::Down)
+        return offset_selection(-1);
+    VERIFY_NOT_REACHED();
+}
+
+void MoveLineUpOrDownCommand::move_lines(VerticalDirection direction)
+{
+    if (m_event.shift() && m_selection.is_valid()) {
+        m_engine.editor().set_selection(retrieve_selection(direction));
+        m_engine.editor().did_update_selection();
+    }
+
+    if (!m_engine.editor().is_editable())
+        return;
+
+    size_t first_line;
+    size_t last_line;
+    m_engine.get_selection_line_boundaries(Badge<MoveLineUpOrDownCommand> {}, first_line, last_line);
+
+    auto const offset = direction == VerticalDirection::Up ? -1 : 1;
+    auto const insertion_index = direction == VerticalDirection::Up ? last_line : first_line;
+    auto const moved_line_index = offset + (direction != VerticalDirection::Up ? last_line : first_line);
+
+    auto moved_line = m_document.take_line(moved_line_index);
+    m_document.insert_line(insertion_index, move(moved_line));
+
+    m_engine.editor().set_cursor({ m_engine.editor().cursor().line() + offset, m_engine.editor().cursor().column() });
+    if (m_engine.editor().has_selection()) {
+        m_engine.editor().selection().start().set_line(m_engine.editor().selection().start().line() + offset);
+        m_engine.editor().selection().end().set_line(m_engine.editor().selection().end().line() + offset);
+    }
+
+    m_engine.editor().did_change();
+    m_engine.editor().update();
+}
 
 }

--- a/Userland/Libraries/LibGUI/EditingEngine.h
+++ b/Userland/Libraries/LibGUI/EditingEngine.h
@@ -22,6 +22,8 @@ enum EngineType {
     Vim,
 };
 
+class MoveLineUpOrDownCommand;
+
 class EditingEngine {
     AK_MAKE_NONCOPYABLE(EditingEngine);
     AK_MAKE_NONMOVABLE(EditingEngine);
@@ -44,6 +46,8 @@ public:
 
     bool is_regular() const { return engine_type() == EngineType::Regular; }
     bool is_vim() const { return engine_type() == EngineType::Vim; }
+
+    void get_selection_line_boundaries(Badge<MoveLineUpOrDownCommand>, size_t& first_line, size_t& last_line);
 
 protected:
     EditingEngine() = default;
@@ -80,10 +84,27 @@ protected:
     void delete_char();
 
     virtual EngineType engine_type() const = 0;
+};
+
+class MoveLineUpOrDownCommand : public TextDocumentUndoCommand {
+public:
+    MoveLineUpOrDownCommand(TextDocument&, KeyEvent event, EditingEngine&);
+    virtual void undo() override;
+    virtual void redo() override;
+    bool merge_with(GUI::Command const&) override;
+    String action_text() const override;
+
+    static bool valid_operation(EditingEngine& engine, VerticalDirection direction);
 
 private:
-    void move_selected_lines_up();
-    void move_selected_lines_down();
+    void move_lines(VerticalDirection);
+    TextRange retrieve_selection(VerticalDirection);
+
+    KeyEvent m_event;
+    VerticalDirection m_direction;
+    EditingEngine& m_engine;
+    TextRange m_selection;
+    TextPosition m_cursor;
 };
 
 }

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -263,7 +263,7 @@ void TextDocument::append_line(NonnullOwnPtr<TextDocumentLine> line)
 
 void TextDocument::insert_line(size_t line_index, NonnullOwnPtr<TextDocumentLine> line)
 {
-    lines().insert((int)line_index, move(line));
+    lines().insert(line_index, move(line));
     if (m_client_notifications_enabled) {
         for (auto* client : m_clients)
             client->document_did_insert_line(line_index);
@@ -282,7 +282,7 @@ NonnullOwnPtr<TextDocumentLine> TextDocument::take_line(size_t line_index)
 
 void TextDocument::remove_line(size_t line_index)
 {
-    lines().remove((int)line_index);
+    lines().remove(line_index);
     if (m_client_notifications_enabled) {
         for (auto* client : m_clients)
             client->document_did_remove_line(line_index);

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -270,6 +270,16 @@ void TextDocument::insert_line(size_t line_index, NonnullOwnPtr<TextDocumentLine
     }
 }
 
+NonnullOwnPtr<TextDocumentLine> TextDocument::take_line(size_t line_index)
+{
+    auto line = lines().take(line_index);
+    if (m_client_notifications_enabled) {
+        for (auto* client : m_clients)
+            client->document_did_remove_line(line_index);
+    }
+    return line;
+}
+
 void TextDocument::remove_line(size_t line_index)
 {
     lines().remove((int)line_index);

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -215,6 +215,7 @@ protected:
 class InsertTextCommand : public TextDocumentUndoCommand {
 public:
     InsertTextCommand(TextDocument&, String const&, TextPosition const&);
+    virtual ~InsertTextCommand() = default;
     virtual void perform_formatting(TextDocument::Client const&) override;
     virtual void undo() override;
     virtual void redo() override;
@@ -231,6 +232,7 @@ private:
 class RemoveTextCommand : public TextDocumentUndoCommand {
 public:
     RemoveTextCommand(TextDocument&, String const&, TextRange const&);
+    virtual ~RemoveTextCommand() = default;
     virtual void undo() override;
     virtual void redo() override;
     TextRange const& range() const { return m_range; }
@@ -246,6 +248,7 @@ class ReplaceAllTextCommand final : public GUI::TextDocumentUndoCommand {
 
 public:
     ReplaceAllTextCommand(GUI::TextDocument& document, String const& text, GUI::TextRange const& range, String const& action_text);
+    virtual ~ReplaceAllTextCommand() = default;
     void redo() override;
     void undo() override;
     bool merge_with(GUI::Command const&) override;

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -80,6 +80,7 @@ public:
     TextDocumentSpan const* span_at(TextPosition const&) const;
 
     void append_line(NonnullOwnPtr<TextDocumentLine>);
+    NonnullOwnPtr<TextDocumentLine> take_line(size_t line_index);
     void remove_line(size_t line_index);
     void remove_all_lines();
     void insert_line(size_t line_index, NonnullOwnPtr<TextDocumentLine>);

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -229,6 +229,12 @@ public:
 
     virtual Optional<UISize> calculated_min_size() const override;
 
+    template<class T, class... Args>
+    inline void execute(Badge<EditingEngine>, Args&&... args)
+    {
+        execute<T>(forward<Args>(args)...);
+    }
+
 protected:
     explicit TextEditor(Type = Type::MultiLine);
 

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -52,6 +52,13 @@ enum class VerticalDirection {
     Down
 };
 
+constexpr VerticalDirection operator!(VerticalDirection const& other)
+{
+    if (other == VerticalDirection::Up)
+        return VerticalDirection::Down;
+    return VerticalDirection::Up;
+}
+
 constexpr VerticalDirection key_code_to_vertical_direction(KeyCode const& key)
 {
     if (key == Key_Up)


### PR DESCRIPTION
This allows lines moved by Ctrl+Shift+[Up, Down] to be registered as a command, i.e. cancellable by Ctrl+Z.

This patch also introduces the usage of TextDocument::[take,insert]_line. Those functions forward changes to the visual lines and
then avoid some data mismatch.

~~Needs #14058 to be merged first (both PR share their 3 first commits)~~, and closes #8071.