### PR TITLE
SystemServer: Propagate more errors

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -26,6 +26,11 @@ public:
     static Error from_syscall(StringView syscall_name, int rc) { return Error(syscall_name, rc); }
     static Error from_string_literal(StringView string_literal) { return Error(string_literal); }
 
+    bool operator==(Error const& other) const
+    {
+        return m_code == other.m_code && m_string_literal == other.m_string_literal && m_syscall == other.m_syscall;
+    }
+
     bool is_errno() const { return m_code != 0; }
     bool is_syscall() const { return m_syscall; }
 

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -687,6 +687,17 @@ ErrorOr<off_t> lseek(int fd, off_t offset, int whence)
     return rc;
 }
 
+ErrorOr<void> endgrent()
+{
+    int old_errno = 0;
+    swap(old_errno, errno);
+    ::endgrent();
+    if (errno != 0)
+        return Error::from_syscall("endgrent", -errno);
+    errno = old_errno;
+    return {};
+}
+
 ErrorOr<WaitPidResult> waitpid(pid_t waitee, int options)
 {
     int wstatus;

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -100,6 +100,7 @@ ErrorOr<void> clock_settime(clockid_t clock_id, struct timespec* ts);
 ErrorOr<pid_t> posix_spawn(StringView path, posix_spawn_file_actions_t const* file_actions, posix_spawnattr_t const* attr, char* const arguments[], char* const envp[]);
 ErrorOr<pid_t> posix_spawnp(StringView path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[]);
 ErrorOr<off_t> lseek(int fd, off_t, int whence);
+ErrorOr<void> endgrent();
 
 struct WaitPidResult {
     pid_t pid;

--- a/Userland/Services/SystemServer/Service.h
+++ b/Userland/Services/SystemServer/Service.h
@@ -14,9 +14,11 @@
 #include <LibCore/Object.h>
 
 class Service final : public Core::Object {
-    C_OBJECT(Service)
+    C_OBJECT_ABSTRACT(Service)
 
 public:
+    static ErrorOr<NonnullRefPtr<Service>> try_create(Core::ConfigFile const& config, StringView name);
+
     bool is_enabled() const;
     void activate();
     void did_exit(int exit_code);
@@ -83,8 +85,8 @@ private:
     // times where it has exited unsuccessfully and too quickly.
     int m_restart_attempts { 0 };
 
-    void setup_socket(SocketDescriptor&);
-    void setup_sockets();
+    ErrorOr<void> setup_socket(SocketDescriptor&);
+    ErrorOr<void> setup_sockets();
     void setup_notifier();
     void handle_socket_connection();
 };

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -487,8 +487,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto config = (user)
         ? TRY(Core::ConfigFile::open_for_app("SystemServer"))
         : TRY(Core::ConfigFile::open_for_system("SystemServer"));
-    for (auto name : config->groups()) {
-        auto service = Service::construct(*config, name);
+    for (auto const& name : config->groups()) {
+        auto service = TRY(Service::try_create(*config, name));
         if (service->is_enabled())
             services.append(service);
     }


### PR DESCRIPTION
New propagated errors comes from an endgrent call, and all chown+chmod calls all over the file. For the two last functions, custom C++ wrappers were used.

Those wrappers were discarding `ENOENT` errors and naively crashing on other errors, this change introduced in 76e12a48 was used to prevent a crash if a mouse wasn't detected. There are no reasons to discard and to not propagate other errors.