### PR TITLE
SystemServer: Detect spawning user for AcceptSocketConnections services

### DIFF
--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -100,6 +100,8 @@ void Service::handle_socket_connection()
         }
 
         int accepted_fd = maybe_accepted_fd.release_value();
+        // FIXME: Propagate errors
+        MUST(determine_account(accepted_fd));
         spawn(accepted_fd);
         close(accepted_fd);
     } else {
@@ -397,4 +399,17 @@ bool Service::is_enabled() const
 {
     extern String g_system_mode;
     return m_system_modes.contains_slow(g_system_mode);
+}
+
+ErrorOr<void> Service::determine_account(int fd)
+{
+    struct ucred creds = {};
+    socklen_t creds_size = sizeof(creds);
+    TRY(Core::System::getsockopt(fd, SOL_SOCKET, SO_PEERCRED, &creds, &creds_size));
+
+    auto const directory_name = String::formatted("/proc/{}/", creds.pid);
+    auto const stat = TRY(Core::System::stat(directory_name.characters()));
+
+    m_account = TRY(Core::Account::from_uid(stat.st_uid));
+    return {};
 }

--- a/Userland/Services/SystemServer/Service.h
+++ b/Userland/Services/SystemServer/Service.h
@@ -31,6 +31,8 @@ private:
 
     void spawn(int socket_fd = -1);
 
+    ErrorOr<void> determine_account(int fd);
+
     /// SocketDescriptor describes the details of a single socket that was
     /// requested by a service.
     struct SocketDescriptor {


### PR DESCRIPTION
SystemServer now invokes services with the same uid as the process that made the request.
This allows the superuser to have a normal GUI workflow. For example, read and write its own files in TextEditor.

Closes #13475