### PR TITLE
LibWeb: Parse css and hsl functions according to CSS Module Level 4

### DIFF
--- a/Base/res/html/misc/colors.html
+++ b/Base/res/html/misc/colors.html
@@ -13,6 +13,10 @@
             #h { background-color: hsl(120, 100%, 50%); }
             #i { background-color: hsla(120, 100%, 50%, 1); }
             #j { color: lime; background-color: currentColor; }
+            #k { background-color: rgba(0 255 0 / 100%); }
+            #l { background-color: rgba(0% 100% 0% / 1); }
+            #m { background-color: hsl(120 100% 50%); }
+            #n { background-color: hsla(120 100% 50% / 1); }
         </style>
     </head>
     <body>
@@ -27,5 +31,9 @@
         <div id="h">This is green, using hsl(120, 100%, 50%).</div>
         <div id="i">This is green, using hsla(120, 100%, 50%, 1).</div>
         <div id="j"><span style="color: black;">This is green, using currentcolor.</span></div>
+        <div id="k">This is green, using rgba(0 255 0 / 100%).</div>
+        <div id="l">This is green, using rgba(0% 100% 0% / 1).</div>
+        <div id="m">This is green, using hsl(120 100% 50%).</div>
+        <div id="n">This is green, using hsla(120 100% 50% / 1).</div>
     </body>
 </html>

--- a/Userland/Libraries/LibWeb/CSS/Angle.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Angle.cpp
@@ -58,7 +58,7 @@ float Angle::to_degrees() const
     case Type::Grad:
         return m_value * (360.0f / 400.0f);
     case Type::Rad:
-        return m_value * (360.0f / 2 * AK::Pi<float>);
+        return m_value * (180.0f / AK::Pi<float>);
     case Type::Turn:
         return m_value * 360.0f;
     }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -304,6 +304,7 @@ private:
         Variant<Angle, Frequency, Length, Percentage, Resolution, Time> m_value;
     };
     Optional<Dimension> parse_dimension(ComponentValue const&);
+    Optional<Color> parse_rgb_or_hsl_color(StringView function_name, Vector<ComponentValue> const&);
     Optional<Color> parse_color(ComponentValue const&);
     Optional<Length> parse_length(ComponentValue const&);
     Optional<Ratio> parse_ratio(TokenStream<ComponentValue>&);


### PR DESCRIPTION
Implement parsing of css(..) and hsl(..) in both the modern level 4
syntax without commas, and the legacy syntax with commas.

The parser accepts non-integer numbers but rounds to integer values
for now.

Also fix a bug in Angle::to_degrees for radians.