### PR TITLE
Ports/glib: Add back a missing `DESTDIR`

### DIFF
--- a/Ports/glib/package.sh
+++ b/Ports/glib/package.sh
@@ -21,5 +21,6 @@ build() {
 }
 
 install() {
+    export DESTDIR="${SERENITY_INSTALL_ROOT}"
     run meson install -C _build
 }


### PR DESCRIPTION
Getting less fond of mass-port-updates by the minute...