### PR TITLE
Calender: Add ability to set the time of day for an event

### DIFF
--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -23,7 +23,7 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     : Dialog(parent_window)
     , m_date_time(date_time)
 {
-    resize(158, 100);
+    resize(158, 130);
     set_title("Add Event");
     set_resizable(false);
     set_icon(parent_window->icon());
@@ -50,6 +50,11 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     middle_container.set_fixed_height(25);
     middle_container.layout()->set_margins(4);
 
+    auto& time_container = widget.add<GUI::Widget>();
+    time_container.set_layout<GUI::HorizontalBoxLayout>();
+    time_container.set_fixed_height(25);
+    time_container.layout()->set_margins(4);
+
     auto& starting_month_combo = middle_container.add<GUI::ComboBox>();
     starting_month_combo.set_only_allow_values_from_model(true);
     starting_month_combo.set_fixed_size(50, 20);
@@ -65,6 +70,22 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     starting_year_combo.set_fixed_size(55, 20);
     starting_year_combo.set_range(0, 9999);
     starting_year_combo.set_value(m_date_time.year());
+
+    auto& starting_hour_combo = time_container.add<GUI::SpinBox>();
+    starting_hour_combo.set_fixed_size(50, 20);
+    starting_hour_combo.set_range(1, 12);
+    starting_hour_combo.set_value(12);
+
+    auto& starting_minute_combo = time_container.add<GUI::SpinBox>();
+    starting_minute_combo.set_fixed_size(40, 20);
+    starting_minute_combo.set_range(0, 59);
+    starting_minute_combo.set_value(0);
+
+    auto& starting_meridiem_combo = time_container.add<GUI::ComboBox>();
+    starting_meridiem_combo.set_only_allow_values_from_model(true);
+    starting_meridiem_combo.set_fixed_size(55, 20);
+    starting_meridiem_combo.set_model(MeridiemListModel::create());
+    starting_meridiem_combo.set_selected_index(0);
 
     widget.layout()->add_spacer();
 
@@ -87,11 +108,26 @@ int AddEventDialog::MonthListModel::row_count(const GUI::ModelIndex&) const
     return 12;
 }
 
+int AddEventDialog::MeridiemListModel::row_count(const GUI::ModelIndex&) const
+{
+    return 2;
+}
+
 String AddEventDialog::MonthListModel::column_name(int column) const
 {
     switch (column) {
     case Column::Month:
         return "Month";
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+String AddEventDialog::MeridiemListModel::column_name(int column) const
+{
+    switch (column) {
+    case Column::Meridiem:
+        return "Meridiem";
     default:
         VERIFY_NOT_REACHED();
     }
@@ -109,6 +145,24 @@ GUI::Variant AddEventDialog::MonthListModel::data(const GUI::ModelIndex& index, 
         switch (index.column()) {
         case Column::Month:
             return month;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+    return {};
+}
+
+GUI::Variant AddEventDialog::MeridiemListModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
+{
+    constexpr Array meridiem_names = {
+        "AM", "PM"
+    };
+
+    auto& meridiem = meridiem_names[index.row()];
+    if (role == GUI::ModelRole::Display) {
+        switch (index.column()) {
+        case Column::Meridiem:
+            return meridiem;
         default:
             VERIFY_NOT_REACHED();
         }

--- a/Userland/Applications/Calendar/AddEventDialog.h
+++ b/Userland/Applications/Calendar/AddEventDialog.h
@@ -45,5 +45,24 @@ private:
         MonthListModel() = default;
     };
 
+    class MeridiemListModel final : public GUI::Model {
+    public:
+        enum Column {
+            Meridiem,
+            __Count,
+        };
+
+        static NonnullRefPtr<MeridiemListModel> create() { return adopt_ref(*new MeridiemListModel); }
+        virtual ~MeridiemListModel() override = default;
+
+        virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
+        virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
+        virtual String column_name(int) const override;
+        virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
+
+    private:
+        MeridiemListModel() = default;
+    };
+
     Core::DateTime m_date_time;
 };


### PR DESCRIPTION
When adding an event to Calender application, the only configurable elements of the event is the name of the event and the day of the event. This pull request adds the ability to specify the time during the day the event takes place add for added specificity and customization of the "add-event" function
<img width="1023" alt="Screen Shot 2022-06-11 at 9 16 53 AM" src="https://user-images.githubusercontent.com/62975486/173196160-398c0058-59f8-421c-81b9-880c6662f64a.png">

