### PR TITLE
LibIPC: Make noise when shutting down because of an error

### DIFF
--- a/Userland/Libraries/LibIPC/Connection.cpp
+++ b/Userland/Libraries/LibIPC/Connection.cpp
@@ -39,8 +39,7 @@ ErrorOr<void> ConnectionBase::post_message(MessageBuffer buffer)
 #ifdef __serenity__
     for (auto& fd : buffer.fds) {
         if (auto result = m_socket->send_fd(fd.value()); result.is_error()) {
-            dbgln("{}", result.error());
-            shutdown();
+            shutdown_with_error(result.error());
             return result;
         }
     }
@@ -55,15 +54,13 @@ ErrorOr<void> ConnectionBase::post_message(MessageBuffer buffer)
         if (maybe_nwritten.is_error()) {
             auto error = maybe_nwritten.release_error();
             if (error.is_errno()) {
+                shutdown_with_error(error);
                 switch (error.code()) {
                 case EPIPE:
-                    shutdown();
                     return Error::from_string_literal("IPC::Connection::post_message: Disconnected from peer"sv);
                 case EAGAIN:
-                    shutdown();
                     return Error::from_string_literal("IPC::Connection::post_message: Peer buffer overflowed"sv);
                 default:
-                    shutdown();
                     return Error::from_syscall("IPC::Connection::post_message write"sv, -error.code());
                 }
             } else {
@@ -82,6 +79,12 @@ void ConnectionBase::shutdown()
 {
     m_socket->close();
     die();
+}
+
+void ConnectionBase::shutdown_with_error(Error const& error)
+{
+    dbgln("IPC::ConnectionBase ({:p}) had an error ({}), disconnecting.", this, error);
+    shutdown();
 }
 
 void ConnectionBase::handle_messages()

--- a/Userland/Libraries/LibIPC/Connection.h
+++ b/Userland/Libraries/LibIPC/Connection.h
@@ -47,6 +47,7 @@ protected:
     virtual void may_have_become_unresponsive() { }
     virtual void did_become_responsive() { }
     virtual void try_parse_messages(Vector<u8> const& bytes, size_t& index) = 0;
+    virtual void shutdown_with_error(Error const&);
 
     OwnPtr<IPC::Message> wait_for_specific_endpoint_message_impl(u32 endpoint_magic, int message_id);
     void wait_for_socket_to_become_readable();

--- a/Userland/Libraries/LibIPC/ConnectionFromClient.h
+++ b/Userland/Libraries/LibIPC/ConnectionFromClient.h
@@ -52,9 +52,9 @@ public:
         this->shutdown();
     }
 
-    void shutdown_with_error(Error const& error)
+    virtual void shutdown_with_error(Error const& error) override
     {
-        dbgln("{} (id={}) had error ({}), disconnecting.", *this, m_client_id, error);
+        dbgln("{} (id={}) had an error ({}), disconnecting.", *this, m_client_id, error);
         this->shutdown();
     }
 


### PR DESCRIPTION
Previously, an IPC connection error could shut down the entire process without giving a hint as to what's wrong. Now, we report that error to the debug console.