### PR TITLE
WindowServer: Fix animated cursor not starting after cursor theme switch

### DIFF
--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -111,7 +111,7 @@ public:
     void invalidate_cursor(bool = false);
     Gfx::IntRect current_cursor_rect() const;
     Cursor const* current_cursor() const { return m_current_cursor; }
-    void current_cursor_was_reloaded(Cursor const* new_cursor) { m_current_cursor = new_cursor; }
+    void current_cursor_was_reloaded(Cursor const* new_cursor) { change_cursor(new_cursor); }
 
     void increment_display_link_count(Badge<ConnectionFromClient>);
     void decrement_display_link_count(Badge<ConnectionFromClient>);


### PR DESCRIPTION
Simply setting m_current_cursor in `current_cursor_was_reloaded()` does
not setup the cursor animation, that has to be done in `change_cursor()`.

This also fixes the cursor disappearing after switching from an animated
cursor back to a normal one (which was due to it trying to draw a cursor
frame that did not exist).

cc @djwisdom (who found these issues).