### PR TITLE
AK+LibPthread+Tests: Implement pthread cleanup handlers

### DIFF
--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -160,6 +160,19 @@ public:
         m_tail = node;
     }
 
+    template<typename U = T>
+    void prepend(U&& value)
+    {
+        auto* node = new Node(forward<U>(value));
+        if (!m_head) {
+            m_head = node;
+            m_tail = node;
+            return;
+        }
+        node->next = m_head;
+        m_head = node;
+    }
+
     bool contains_slow(const T& value) const
     {
         return find(value) != end();

--- a/Tests/LibPthread/CMakeLists.txt
+++ b/Tests/LibPthread/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    TestLibPthreadCleanup.cpp
     TestLibPthreadSpinLocks.cpp
     TestLibPthreadRWLocks.cpp
 )

--- a/Tests/LibPthread/TestLibPthreadCleanup.cpp
+++ b/Tests/LibPthread/TestLibPthreadCleanup.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Tim Schumacher <timschumi@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibPthread/pthread.h>
+#include <LibTest/TestCase.h>
+
+static size_t exit_count = 0;
+
+static void exit_count_test_handler(void* data)
+{
+    EXPECT_EQ(exit_count, reinterpret_cast<size_t>(data));
+    exit_count++;
+}
+
+static void immediate_fail_handler(void*)
+{
+    FAIL("Called a cleanup handler");
+}
+
+static void* cleanup_pthread_exit_inner(void*)
+{
+    // Push handlers in reverse order as they are taken from the top of the stack on cleanup.
+    pthread_cleanup_push(exit_count_test_handler, reinterpret_cast<void*>(2));
+    pthread_cleanup_push(exit_count_test_handler, reinterpret_cast<void*>(1));
+    pthread_cleanup_push(exit_count_test_handler, reinterpret_cast<void*>(0));
+
+    pthread_exit(nullptr);
+}
+
+TEST_CASE(cleanup_pthread_exit)
+{
+    pthread_t thread;
+    exit_count = 0;
+
+    pthread_create(&thread, nullptr, cleanup_pthread_exit_inner, nullptr);
+
+    pthread_join(thread, nullptr);
+
+    // Ensure that all exit handlers have been called.
+    EXPECT_EQ(exit_count, 3ul);
+}
+
+static void* cleanup_return_inner(void*)
+{
+    // Returning from the main function should not call any cleanup handlers.
+    pthread_cleanup_push(immediate_fail_handler, nullptr);
+    return nullptr;
+}
+
+TEST_CASE(cleanup_return)
+{
+    pthread_t thread;
+    pthread_create(&thread, nullptr, cleanup_return_inner, nullptr);
+    pthread_join(thread, nullptr);
+}
+
+static void* cleanup_pop_inner(void*)
+{
+    pthread_cleanup_push(exit_count_test_handler, reinterpret_cast<void*>(1));
+    pthread_cleanup_push(immediate_fail_handler, nullptr);
+    pthread_cleanup_push(exit_count_test_handler, reinterpret_cast<void*>(0));
+    pthread_cleanup_push(immediate_fail_handler, nullptr);
+
+    // Popping a cleanup handler shouldn't run the callback unless `execute` is given.
+    pthread_cleanup_pop(0);
+    pthread_cleanup_pop(1);
+    pthread_cleanup_pop(0);
+    pthread_cleanup_pop(1);
+
+    return nullptr;
+}
+
+TEST_CASE(cleanup_pop)
+{
+    pthread_t thread;
+    exit_count = 0;
+
+    pthread_create(&thread, nullptr, cleanup_pop_inner, nullptr);
+    pthread_join(thread, nullptr);
+
+    // Ensure that all exit handlers have been called.
+    EXPECT_EQ(exit_count, 2ul);
+}


### PR DESCRIPTION
I decided to unlink this from the QEMU PR (#13971) as I didn't want it to turn into a changes graveyard (since there are still other pending issues on that one), this might actually be useful for other ports, and since I maybe wanted to take a look at implementing `pthread_cancel` in the meantime.

I additionally added some tests (and fixed a compliance issue that was found through that) while moving it into a separate branch.
I also dropped the tie-in in the `pthread_cancel` function itself, as that would have caused it to run the cleanup handlers of the calling thread, not the target thread.

I still haven't found any issues regarding `thread_local` (neither with the tests added here, nor with a few test programs that ran parallelized), so I guess this is good to go.