### PR TITLE
Kernel/Graphics+LibEDID: Ensure VMWare and VirtualBox EDIDs have manufacturer ID, use "Unknown" string for generic EDIDs

### DIFF
--- a/Kernel/Graphics/Bochs/DisplayConnector.cpp
+++ b/Kernel/Graphics/Bochs/DisplayConnector.cpp
@@ -14,13 +14,16 @@
 
 namespace Kernel {
 
-NonnullRefPtr<BochsDisplayConnector> BochsDisplayConnector::must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
+NonnullRefPtr<BochsDisplayConnector> BochsDisplayConnector::must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool virtual_box_hardware)
 {
     auto device_or_error = DeviceManagement::try_create_device<BochsDisplayConnector>(framebuffer_address, framebuffer_resource_size);
     VERIFY(!device_or_error.is_error());
     auto connector = device_or_error.release_value();
     MUST(connector->create_attached_framebuffer_console());
-    MUST(connector->initialize_edid_for_generic_monitor());
+    if (virtual_box_hardware)
+        MUST(connector->initialize_edid_for_generic_monitor(Array<u8, 3> { 'V', 'B', 'X' }));
+    else
+        MUST(connector->initialize_edid_for_generic_monitor({}));
     return connector;
 }
 

--- a/Kernel/Graphics/Bochs/DisplayConnector.h
+++ b/Kernel/Graphics/Bochs/DisplayConnector.h
@@ -24,7 +24,7 @@ class BochsDisplayConnector
 public:
     TYPEDEF_DISTINCT_ORDERED_ID(u16, IndexID);
 
-    static NonnullRefPtr<BochsDisplayConnector> must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size);
+    static NonnullRefPtr<BochsDisplayConnector> must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool virtual_box_hardware);
 
     virtual IndexID index_id() const;
 

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -43,10 +43,10 @@ UNMAP_AFTER_INIT ErrorOr<void> BochsGraphicsAdapter::initialize_adapter(PCI::Dev
     // Note: If we use VirtualBox graphics adapter (which is based on Bochs one), we need to use IO ports
     // Note: Bochs (the real bochs graphics adapter in the Bochs emulator) uses revision ID of 0x0
     // and doesn't support memory-mapped IO registers.
+    bool virtual_box_hardware = (pci_device_identifier.hardware_id().vendor_id == 0x80ee && pci_device_identifier.hardware_id().device_id == 0xbeef);
     auto bar0_space_size = PCI::get_BAR_space_size(pci_device_identifier.address(), 0);
-    if (pci_device_identifier.revision_id().value() == 0x0
-        || (pci_device_identifier.hardware_id().vendor_id == 0x80ee && pci_device_identifier.hardware_id().device_id == 0xbeef)) {
-        m_display_connector = BochsDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), bar0_space_size);
+    if (pci_device_identifier.revision_id().value() == 0x0 || virtual_box_hardware) {
+        m_display_connector = BochsDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), bar0_space_size, virtual_box_hardware);
     } else {
         auto registers_mapping = TRY(Memory::map_typed_writable<BochsDisplayMMIORegisters volatile>(PhysicalAddress(PCI::get_BAR2(pci_device_identifier.address()) & 0xfffffff0)));
         VERIFY(registers_mapping.region);

--- a/Kernel/Graphics/DisplayConnector.cpp
+++ b/Kernel/Graphics/DisplayConnector.cpp
@@ -155,6 +155,14 @@ ErrorOr<void> DisplayConnector::initialize_edid_for_generic_monitor()
         0x00, /* number of extensions */
         0x00  /* checksum goes here */
     };
+    // Note: Fix checksum to avoid warnings about checksum mismatch.
+    size_t checksum = 0;
+    // Note: Read all 127 bytes to add them to the checksum. Byte 128 is zeroed so
+    // we could technically add it to the sum result, but it could lead to an error if it contained
+    // a non-zero value, so we are not using it.
+    for (size_t index = 0; index < sizeof(virtual_monitor_edid) - 1; index++)
+        checksum += virtual_monitor_edid[index];
+    virtual_monitor_edid[127] = 0x100 - checksum;
     set_edid_bytes(virtual_monitor_edid);
     return {};
 }

--- a/Kernel/Graphics/DisplayConnector.h
+++ b/Kernel/Graphics/DisplayConnector.h
@@ -112,7 +112,7 @@ protected:
     virtual ErrorOr<void> flush_first_surface() = 0;
     virtual ErrorOr<void> flush_rectangle(size_t buffer_index, FBRect const& rect);
 
-    ErrorOr<void> initialize_edid_for_generic_monitor();
+    ErrorOr<void> initialize_edid_for_generic_monitor(Optional<Array<u8, 3>> manufacturer_id_string);
 
     mutable Spinlock m_control_lock;
     mutable Mutex m_flushing_lock;

--- a/Kernel/Graphics/DisplayConnector.h
+++ b/Kernel/Graphics/DisplayConnector.h
@@ -105,16 +105,6 @@ public:
 protected:
     void set_edid_bytes(Array<u8, 128> const& edid_bytes);
 
-    // ^File
-    virtual bool is_seekable() const override { return true; }
-    virtual bool can_read(OpenFileDescription const&, u64) const final override { return true; }
-    virtual bool can_write(OpenFileDescription const&, u64) const final override { return true; }
-    virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override final;
-    virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) override final;
-    virtual ErrorOr<Memory::Region*> mmap(Process&, OpenFileDescription&, Memory::VirtualRange const&, u64, int, bool) override final;
-    virtual ErrorOr<void> ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg) override final;
-    virtual StringView class_name() const override final { return "DisplayConnector"sv; }
-
     DisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool enable_write_combine_optimization);
     DisplayConnector(size_t framebuffer_resource_size, bool enable_write_combine_optimization);
     virtual void enable_console() = 0;
@@ -141,6 +131,16 @@ protected:
     u8* framebuffer_data() { return m_framebuffer_data; }
 
 private:
+    // ^File
+    virtual bool is_seekable() const override { return true; }
+    virtual bool can_read(OpenFileDescription const&, u64) const final override { return true; }
+    virtual bool can_write(OpenFileDescription const&, u64) const final override { return true; }
+    virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override final;
+    virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) override final;
+    virtual ErrorOr<Memory::Region*> mmap(Process&, OpenFileDescription&, Memory::VirtualRange const&, u64, int, bool) override final;
+    virtual ErrorOr<void> ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg) override final;
+    virtual StringView class_name() const override final { return "DisplayConnector"sv; }
+
     DisplayConnector& operator=(DisplayConnector const&) = delete;
     DisplayConnector& operator=(DisplayConnector&&) = delete;
     DisplayConnector(DisplayConnector&&) = delete;

--- a/Kernel/Graphics/VGA/DisplayConnector.cpp
+++ b/Kernel/Graphics/VGA/DisplayConnector.cpp
@@ -19,7 +19,7 @@ NonnullRefPtr<GenericDisplayConnector> GenericDisplayConnector::must_create_with
     VERIFY(!device_or_error.is_error());
     auto connector = device_or_error.release_value();
     MUST(connector->create_attached_framebuffer_console());
-    MUST(connector->initialize_edid_for_generic_monitor());
+    MUST(connector->initialize_edid_for_generic_monitor({}));
     return connector;
 }
 

--- a/Kernel/Graphics/VMWare/DisplayConnector.cpp
+++ b/Kernel/Graphics/VMWare/DisplayConnector.cpp
@@ -16,7 +16,7 @@ NonnullRefPtr<VMWareDisplayConnector> VMWareDisplayConnector::must_create(VMWare
 {
     auto connector = MUST(DeviceManagement::try_create_device<VMWareDisplayConnector>(parent_adapter, framebuffer_address, framebuffer_resource_size));
     MUST(connector->create_attached_framebuffer_console());
-    MUST(connector->initialize_edid_for_generic_monitor());
+    MUST(connector->initialize_edid_for_generic_monitor(Array<u8, 3> { 'V', 'M', 'W' }));
     return connector;
 }
 

--- a/Userland/Libraries/LibEDID/EDID.cpp
+++ b/Userland/Libraries/LibEDID/EDID.cpp
@@ -332,10 +332,13 @@ ErrorOr<void> Parser::parse()
     }
 
     u16 packed_id = read_be(&raw_edid().vendor.manufacturer_id);
+    if (packed_id == 0x0)
+        return {};
     m_legacy_manufacturer_id[0] = (char)((u16)'A' + ((packed_id >> 10) & 0x1f) - 1);
     m_legacy_manufacturer_id[1] = (char)((u16)'A' + ((packed_id >> 5) & 0x1f) - 1);
     m_legacy_manufacturer_id[2] = (char)((u16)'A' + (packed_id & 0x1f) - 1);
     m_legacy_manufacturer_id[3] = '\0';
+    m_legacy_manufacturer_id_valid = true;
 
     return {};
 }
@@ -420,6 +423,8 @@ StringView Parser::legacy_manufacturer_id() const
 #ifndef KERNEL
 String Parser::manufacturer_name() const
 {
+    if (!m_legacy_manufacturer_id_valid)
+        return "Unknown";
     auto manufacturer_id = legacy_manufacturer_id();
 #    ifdef ENABLE_PNP_IDS_DATA
     if (auto pnp_id_data = PnpIDs::find_by_manufacturer_id(manufacturer_id); pnp_id_data.has_value())

--- a/Userland/Libraries/LibEDID/EDID.h
+++ b/Userland/Libraries/LibEDID/EDID.h
@@ -457,6 +457,7 @@ private:
     String m_version;
 #endif
     char m_legacy_manufacturer_id[4] {};
+    bool m_legacy_manufacturer_id_valid { false };
 };
 
 }


### PR DESCRIPTION
Fixes #14139.