### PR TITLE
AK+LibWeb: Random web-related fixes

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -402,7 +402,7 @@ bool URL::code_point_is_in_percent_encode_set(u32 code_point, URL::PercentEncode
     case URL::PercentEncodeSet::Component:
         return code_point_is_in_percent_encode_set(code_point, URL::PercentEncodeSet::Userinfo) || "$%&+,"sv.contains(code_point);
     case URL::PercentEncodeSet::ApplicationXWWWFormUrlencoded:
-        return code_point >= 0x7E || !(is_ascii_alphanumeric(code_point) || "!'()~"sv.contains(code_point));
+        return code_point_is_in_percent_encode_set(code_point, URL::PercentEncodeSet::Component) || "!'()~"sv.contains(code_point);
     case URL::PercentEncodeSet::EncodeURI:
         // NOTE: This is the same percent encode set that JS encodeURI() uses.
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI

--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -347,7 +347,7 @@ String URL::serialize_origin() const
     builder.append("://"sv);
     builder.append(m_host);
     if (m_port.has_value())
-        builder.append(":{}", *m_port);
+        builder.appendff(":{}", *m_port);
     return builder.build();
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.cpp
@@ -41,10 +41,10 @@ String ComponentValue::to_debug_string() const
             return String::formatted("Token: {}", token.to_debug_string());
         },
         [](NonnullRefPtr<Block> const& block) {
-            return String::formatted("Function: {}", block->to_string());
+            return String::formatted("Block: {}", block->to_string());
         },
         [](NonnullRefPtr<Function> const& function) {
-            return String::formatted("Block: {}", function->to_string());
+            return String::formatted("Function: {}", function->to_string());
         });
 }
 


### PR DESCRIPTION
- **AK: Append correct number of port characters when serializing a URL**

  Instead of formatting a port string, it put bytes from stack, using the port number as a length (so for port 8000 it appended 8000 bytes).

- **AK: Make URL ApplicationXWWWFormUrlencoded encoding closer to spec**

  It was mostly implemented based on a [spec note], that described only allowed characters, but instead of allowing some special characters not to be escaped, we escaped every special character except those ‘new in this encode set’ disallowed characters from the spec definition.

  [spec note]: https://url.spec.whatwg.org/#ref-for-application-x-www-form-urlencoded-percent-encode-set

  *I really thought this was the issue that made us unable to log-in to ports.serenityos.net, but no. it’s still a mystery :magic_wand:*

- **LibWeb: Print correct value types in ComponentValue debug string**

  Block and Function names were swapped.