### PR TITLE
LibGUI: Add DialogButton for consistency

### DIFF
--- a/Userland/Applications/Run/Run.gml
+++ b/Userland/Applications/Run/Run.gml
@@ -44,22 +44,19 @@
         // HACK: using an empty widget as a spacer
         @GUI::Widget {}
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "ok_button"
             text: "OK"
-            fixed_width: 80
         }
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "cancel_button"
             text: "Cancel"
-            fixed_width: 80
         }
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "browse_button"
             text: "Browse..."
-            fixed_width: 80
         }
     }
 }

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -49,18 +49,18 @@ RunWindow::RunWindow()
     m_path_combo_box->set_model(m_path_history_model);
     m_path_combo_box->set_selected_index(0);
 
-    m_ok_button = *main_widget.find_descendant_of_type_named<GUI::Button>("ok_button");
+    m_ok_button = *main_widget.find_descendant_of_type_named<GUI::DialogButton>("ok_button");
     m_ok_button->on_click = [this](auto) {
         do_run();
     };
     m_ok_button->set_default(true);
 
-    m_cancel_button = *main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    m_cancel_button = *main_widget.find_descendant_of_type_named<GUI::DialogButton>("cancel_button");
     m_cancel_button->on_click = [this](auto) {
         close();
     };
 
-    m_browse_button = *find_descendant_of_type_named<GUI::Button>("browse_button");
+    m_browse_button = *find_descendant_of_type_named<GUI::DialogButton>("browse_button");
     m_browse_button->on_click = [this](auto) {
         Optional<String> path = GUI::FilePicker::get_open_filepath(this, {}, Core::StandardPaths::home_directory(), false, GUI::Dialog::ScreenPosition::Center);
         if (path.has_value())

--- a/Userland/Libraries/LibGUI/AboutDialog.cpp
+++ b/Userland/Libraries/LibGUI/AboutDialog.cpp
@@ -79,8 +79,7 @@ AboutDialog::AboutDialog(StringView name, Gfx::Bitmap const* icon, Window* paren
     button_container.set_fixed_height(22);
     button_container.set_layout<HorizontalBoxLayout>();
     button_container.layout()->add_spacer();
-    auto& ok_button = button_container.add<Button>("OK");
-    ok_button.set_fixed_width(80);
+    auto& ok_button = button_container.add<DialogButton>("OK");
     ok_button.on_click = [this](auto) {
         done(ExecResult::OK);
     };

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -16,6 +16,7 @@
 #include <LibGfx/StylePainter.h>
 
 REGISTER_WIDGET(GUI, Button)
+REGISTER_WIDGET(GUI, DialogButton)
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -76,4 +76,16 @@ private:
     bool m_mimic_pressed { false };
 };
 
+class DialogButton final : public Button {
+    C_OBJECT(DialogButton);
+
+public:
+    virtual ~DialogButton() override {};
+    explicit DialogButton(String text = {})
+        : Button(move(text))
+    {
+        set_fixed_width(80);
+    }
+};
+
 }

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -232,16 +232,14 @@ void ColorPicker::build_ui()
     button_container.layout()->set_spacing(4);
     button_container.layout()->add_spacer();
 
-    auto& ok_button = button_container.add<Button>();
-    ok_button.set_fixed_width(80);
+    auto& ok_button = button_container.add<DialogButton>();
     ok_button.set_text("OK");
     ok_button.on_click = [this](auto) {
         done(ExecResult::OK);
     };
     ok_button.set_default(true);
 
-    auto& cancel_button = button_container.add<Button>();
-    cancel_button.set_fixed_width(80);
+    auto& cancel_button = button_container.add<DialogButton>();
     cancel_button.set_text("Cancel");
     cancel_button.on_click = [this](auto) {
         done(ExecResult::Cancel);

--- a/Userland/Libraries/LibGUI/FilePickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FilePickerDialog.gml
@@ -69,10 +69,9 @@
                     fixed_width: 20
                 }
 
-                @GUI::Button {
+                @GUI::DialogButton {
                     name: "ok_button"
                     text: "OK"
-                    fixed_width: 75
                 }
             }
 
@@ -82,10 +81,9 @@
 
                 @GUI::Widget {}
 
-                @GUI::Button {
+                @GUI::DialogButton {
                     name: "cancel_button"
                     text: "Cancel"
-                    fixed_width: 75
                 }
             }
         }

--- a/Userland/Libraries/LibGUI/FontPickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FontPickerDialog.gml
@@ -73,16 +73,14 @@
 
         @GUI::Widget {}
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "ok_button"
             text: "OK"
-            fixed_width: 80
         }
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "cancel_button"
             text: "Cancel"
-            fixed_width: 80
         }
     }
 }

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -23,6 +23,7 @@ class CheckBox;
 class ComboBox;
 class Command;
 class CommandPalette;
+class DialogButton;
 class DragEvent;
 class DropEvent;
 class EditingEngine;

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -82,7 +82,7 @@ void InputBox::build(InputType input_type)
     button_container_inner.layout()->set_margins({ 4, 0, 4, 4 });
     button_container_inner.layout()->add_spacer();
 
-    m_ok_button = button_container_inner.add<Button>();
+    m_ok_button = button_container_inner.add<DialogButton>();
     m_ok_button->set_text("OK");
     m_ok_button->on_click = [this](auto) {
         dbgln("GUI::InputBox: OK button clicked");
@@ -91,7 +91,7 @@ void InputBox::build(InputType input_type)
     };
     m_ok_button->set_default(true);
 
-    m_cancel_button = button_container_inner.add<Button>();
+    m_cancel_button = button_container_inner.add<DialogButton>();
     m_cancel_button->set_text("Cancel");
     m_cancel_button->on_click = [this](auto) {
         dbgln("GUI::InputBox: Cancel button clicked");

--- a/Userland/Libraries/LibGUI/PasswordInputDialog.gml
+++ b/Userland/Libraries/LibGUI/PasswordInputDialog.gml
@@ -78,16 +78,14 @@
 
             @GUI::Widget {}
 
-            @GUI::Button {
+            @GUI::DialogButton {
                 text: "OK"
                 name: "ok_button"
-                fixed_width: 75
             }
 
-            @GUI::Button {
+            @GUI::DialogButton {
                 text: "Cancel"
                 name: "cancel_button"
-                fixed_width: 75
             }
         }
     }

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -46,8 +46,7 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
     button_container->layout()->set_spacing(6);
 
     if (show_defaults_button == ShowDefaultsButton::Yes) {
-        window->m_reset_button = TRY(button_container->try_add<GUI::Button>("Defaults"));
-        window->m_reset_button->set_fixed_width(75);
+        window->m_reset_button = TRY(button_container->try_add<GUI::DialogButton>("Defaults"));
         window->m_reset_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
             window->reset_default_values();
         };
@@ -55,22 +54,19 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
 
     TRY(button_container->layout()->try_add_spacer());
 
-    window->m_ok_button = TRY(button_container->try_add<GUI::Button>("OK"));
-    window->m_ok_button->set_fixed_width(75);
+    window->m_ok_button = TRY(button_container->try_add<GUI::DialogButton>("OK"));
     window->m_ok_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
         window->apply_settings();
         GUI::Application::the()->quit();
     };
 
-    window->m_cancel_button = TRY(button_container->try_add<GUI::Button>("Cancel"));
-    window->m_cancel_button->set_fixed_width(75);
+    window->m_cancel_button = TRY(button_container->try_add<GUI::DialogButton>("Cancel"));
     window->m_cancel_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
         window->cancel_settings();
         GUI::Application::the()->quit();
     };
 
-    window->m_apply_button = TRY(button_container->try_add<GUI::Button>("Apply"));
-    window->m_apply_button->set_fixed_width(75);
+    window->m_apply_button = TRY(button_container->try_add<GUI::DialogButton>("Apply"));
     window->m_apply_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
         window->apply_settings();
     };

--- a/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
@@ -46,14 +46,12 @@ WizardDialog::WizardDialog(Window* parent_window)
     nav_container_widget.layout()->set_spacing(0);
     nav_container_widget.layout()->add_spacer();
 
-    m_back_button = nav_container_widget.add<Button>("< Back");
-    m_back_button->set_fixed_width(75);
+    m_back_button = nav_container_widget.add<DialogButton>("< Back");
     m_back_button->on_click = [&](auto) {
         pop_page();
     };
 
-    m_next_button = nav_container_widget.add<Button>("Next >");
-    m_next_button->set_fixed_width(75);
+    m_next_button = nav_container_widget.add<DialogButton>("Next >");
     m_next_button->on_click = [&](auto) {
         VERIFY(has_pages());
 
@@ -70,8 +68,7 @@ WizardDialog::WizardDialog(Window* parent_window)
     auto& button_spacer = nav_container_widget.add<Widget>();
     button_spacer.set_fixed_width(10);
 
-    m_cancel_button = nav_container_widget.add<Button>("Cancel");
-    m_cancel_button->set_fixed_width(75);
+    m_cancel_button = nav_container_widget.add<DialogButton>("Cancel");
     m_cancel_button->on_click = [&](auto) {
         handle_cancel();
     };


### PR DESCRIPTION
There are a lot of dialog buttons around the system, and no one can quite seem to agree what size they should be, which results in most of them being a slightly different size from dialog to dialog.
This could be fixed by simply changing all their sizes in one go, but that will likely lead to the same problem later on when more dialogs are added.
So lets instead introduce a clearly named convenience class, that just takes the guesswork out of it.