### PR TITLE
LibGUI: Fix GML parser command order regression

### DIFF
--- a/Userland/Libraries/LibGUI/GML/Parser.cpp
+++ b/Userland/Libraries/LibGUI/GML/Parser.cpp
@@ -57,14 +57,14 @@ static ErrorOr<NonnullRefPtr<Object>> parse_gml_object(Queue<Token>& tokens)
                 // It's a child object.
 
                 while (!pending_comments.is_empty())
-                    TRY(object->add_sub_object_child(pending_comments.take_last()));
+                    TRY(object->add_sub_object_child(pending_comments.take_first()));
 
                 TRY(object->add_sub_object_child(TRY(parse_gml_object(tokens))));
             } else if (peek() == Token::Type::Identifier) {
                 // It's a property.
 
                 while (!pending_comments.is_empty())
-                    TRY(object->add_property_child(pending_comments.take_last()));
+                    TRY(object->add_property_child(pending_comments.take_first()));
 
                 auto property_name = tokens.dequeue();
 


### PR DESCRIPTION
This was previously fixed in #13572 with
546d338639cc090055d0c416a76fc237d06930c8
but regressed in #14251 with
ec40c93300a2b111129adf1a5badecde8c22889f