### PR TITLE
LibWeb: Hold a strong ref to old_rule in CSSRuleList::remove_a_css_rule

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
@@ -72,17 +72,16 @@ DOM::ExceptionOr<void> CSSRuleList::remove_a_css_rule(u32 index)
         return DOM::IndexSizeError::create("CSS rule index out of bounds.");
 
     // 3. Set old rule to the indexth item in list.
-    auto& old_rule = m_rules[index];
+    NonnullRefPtr<CSSRule> old_rule = m_rules[index];
 
     // FIXME: 4. If old rule is an @namespace at-rule, and list contains anything other than @import at-rules, and @namespace at-rules, throw an InvalidStateError exception.
-    (void)old_rule;
 
     // 5. Remove rule old rule from list at the zero-indexed position index.
     m_rules.remove(index);
 
     // 6. Set old rule’s parent CSS rule and parent CSS style sheet to null.
-    old_rule.set_parent_rule(nullptr);
-    old_rule.set_parent_style_sheet(nullptr);
+    old_rule->set_parent_rule(nullptr);
+    old_rule->set_parent_style_sheet(nullptr);
 
     return {};
 }


### PR DESCRIPTION
Using auto& when indexing an NNRPVector doesn't cause it to hold a
strong reference and is instead just a plain old reference.

If m_rules was the only storage holding a strong reference to old_rule,
we would remove it in step 4 and subsequently UAF it in step 5.