### PR TITLE
Toolchain: Add $arch-pc-serenity-clang symlink

### DIFF
--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -321,7 +321,13 @@ pushd "$DIR/Build/clang"
 popd
 
 pushd "$DIR/Local/clang/bin/"
-    buildstep "mold_symlink" ln -s ../../mold/bin/mold ld.mold
+    ln -s ../../mold/bin/mold ld.mold
+
+    for arch in $ARCHS; do
+        ln -s clang "$arch"-pc-serenity-clang
+        ln -s clang++ "$arch"-pc-serenity-clang++
+        echo "--sysroot=$BUILD/${arch}clang/Root" > "$arch"-pc-serenity.cfg
+    done
 popd
 
 # === SAVE TO CACHE ===


### PR DESCRIPTION
This will allow us to build ports that don't allow the --target and
--sysroot compiler arguments to be specified in $CC/$CXX.