### PR TITLE
LibGUI: Add beginnings of a Dynamic Layout System

### DIFF
--- a/Base/usr/share/man/man5/GML-Introduction.md
+++ b/Base/usr/share/man/man5/GML-Introduction.md
@@ -30,6 +30,7 @@ Or right clicking on a folder in the TreeView and using
     -   [Define widgets](help://man/5/GML-Define-widget)
 -   GML object and property reference
     -   [Core::Object](help://man/5/GML-CoreObject)
+    -   [UI Dimensions](help://man/5/GML-UI-Dimensions)
     -   Layouts
         -   [HorizontalBoxLayout](help://man/5/GML-Layout-HorizontalBoxLayout)
         -   [VerticalBoxLayout](help://man/5/GML-Layout-VerticalBoxLayout)
@@ -76,3 +77,4 @@ Or right clicking on a folder in the TreeView and using
         -   [VerticalSlider](help://man/5/GML-Widget-VerticalSlider)
         -   [VerticalSplitter](help://man/5/GML-Widget-VerticalSplitter)
         -   [Widget](help://man/5/GML-Widget)
+

--- a/Base/usr/share/man/man5/GML-Syntax.md
+++ b/Base/usr/share/man/man5/GML-Syntax.md
@@ -90,6 +90,7 @@ A property's `value` is required to be either a JSON value or another object. Ob
 Among the supported JSON values, these types can be further distinguished:
 
 -   `int`: Regular JSON integer, note that JSON floats are not currently used.
+-   `ui_dimension`: either positive integers, that work just like `int`, or special meaning values as JSON strings; see [UI Dimensions](help://man/5/GML-UI-Dimensions)
 -   `bool`: Regular JSON boolean, may be enclosed in quotes but this is discouraged.
 -   `string`: JSON string, also used as a basis for other types.
 -   `readonly_string`: String-valued property that cannot be changed from C++ later.
@@ -99,6 +100,7 @@ Among the supported JSON values, these types can be further distinguished:
     -   `text_wrapping`: Special case of `enum` for `Gfx::TextWrapping`. One of `Wrap` or `DontWrap`.
 -   `rect`: A JSON object of four `int`s specifying a rectangle. The keys are `x`, `y`, `width`, `height`.
 -   `size`: A JSON array of two `int`s specifying two sizes in the format `[width, height]`.
+-   `ui_size`: A JSON array of two `ui_dimension`s specifying two sizes in the format `[width, height]`
 -   `margins`: A JSON array or object specifying four-directional margins as `int`s. If this is a JSON object, the four keys `top`, `right`, `bottom`, `left` are used. If this is a JSON array, there can be one to four integers. These have the following meaning (see also `GUI::Margins`):
     -   `[ all_four_margins ]`
     -   `[ top_and_bottom, right_and_left ]`
@@ -232,3 +234,4 @@ GML files can be found in the SerenityOS source tree with the `*.gml` extension.
     }
 }
 ```
+

--- a/Base/usr/share/man/man5/GML-UI-Dimensions.md
+++ b/Base/usr/share/man/man5/GML-UI-Dimensions.md
@@ -1,0 +1,29 @@
+## Name
+
+UI Dimensions
+
+# Description
+
+UI Dimension (or [GUI::UIDimension](file:///usr/src/serenity/Userland/Libraries/LibGUI/UIDimensions.h) in c++) is a special, union — of positive integer and enum — like, type that is used to represent dimensions in a user interface context.
+
+It can either store positive integers ≥0 or special meaning values from a pre determined set.
+
+## Basic Syntax
+
+In GML UI Dimensions that are "regular" values (integer ≥0) are represented by JSON's int type,
+while "special" values are represented by their name as a JSON string type.
+
+# Special Values
+
+Special Values carry size information that would otherwise not be intuitively possible to be transported by an integer (positive or negative) alone.
+
+Importantly, while any "regular" (i.e. int ≥0) UI Dimension values might (by convention) be assigned to any UI Dimension property, many properties only allow a subset of the "special" values to be assigned to them.
+
+| Name              | c++ name                                   | GML/JSON representation | General meaning                                 |
+|-------------------|--------------------------------------------|-------------------------|-------------------------------------------------|
+| Regular           | `GUI::SpecialDimension::Regular` (mock)    | int ≥0                  | This is a regular integer value specifying a specific size |
+| Grow              | `GUI::SpecialDimension::Grow`              | `"grow"`                | Grow to the maximum size the surrounding allows |
+| OpportunisticGrow | `GUI::SpecialDimension::OpportunisticGrow` | `"opportunistic_grow"`  | Grow when the opportunity arises, meaning — only when all other widgets have already grown to their maximum size, and only opportunistically growing widgets are left |
+| Fit               | `GUI::SpecialDimension::Fit`               | `"fit"`                 | Grow exactly to the size of the surrounding as determined by other factors, but do not call for e.g. expansion of the parent container itself |
+| Shrink            | `GUI::SpecialDimension::Shrink`            | `"shrink"`              | Shrink to the smallest size possible |
+

--- a/Base/usr/share/man/man5/GML-Widget-ScrollableContainerWidget.md
+++ b/Base/usr/share/man/man5/GML-Widget-ScrollableContainerWidget.md
@@ -6,21 +6,29 @@ GML Scrollable Container Widget
 
 Defines a GUI scrollable container widget.
 
+Unlike other container widgets, this one does not allow multiple child widgets to be added, and thus also does not support setting a layout.
+
 ## Synopsis
 
 `@GUI::ScrollableContainerWidget`
+
+Content declared as `content_widget` property.
 
 ## Examples
 
 ```gml
 @GUI::ScrollableContainerWidget {
-
+	content_widget: @GUI::Widget {
+		[...]
+	}
 }
 ```
 
 ## Registered Properties
 
-| Property                           | Type | Possible values | Description                                 |
-|------------------------------------|------|-----------------|---------------------------------------------|
-| scrollbars_enabled                 | bool | true or false   | Status of scrollbar                         |
-| should_hide_unnecessary_scrollbars | bool | true or false   | Whether to hide scrollbars when unnecessary |
+| Property                           | Type          | Possible values        | Description                                 |
+|------------------------------------|---------------|------------------------|---------------------------------------------|
+| ~~layout~~                         |               | none                   | Does not take layout                        |
+| scrollbars_enabled                 | bool          | true or false          | Status of scrollbar                         |
+| should_hide_unnecessary_scrollbars | bool          | true or false          | Whether to hide scrollbars when unnecessary |
+| content_widget                     | widget object | Any Subclass of Widget | The Widget to be displayed in the Container |

--- a/Base/usr/share/man/man5/GML-Widget.md
+++ b/Base/usr/share/man/man5/GML-Widget.md
@@ -4,7 +4,8 @@ Defines a GUI widget.
 
 ```gml
 @GUI::Widget {
-  fixed_width: 250
+  min_width: 200
+  preferred_width: "opportunistic_grow"
   fixed_height: 215
   fill_with_background_color: true
   layout: @GUI::VerticalBoxLayout {
@@ -15,35 +16,39 @@ Defines a GUI widget.
 
 ## Registered Properties
 
-| Property                    | Type          | Possible values                                       | Description                                                                                       |
-| --------------------------- | ------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| x                           | int           |                                                       | x offset relative to parent                                                                       |
-| y                           | int           |                                                       | y offset relative to parent                                                                       |
-| visible                     | bool          |                                                       | Whether widget and children are drawn                                                             |
-| focused                     | bool          |                                                       | Whether widget should be tab-focused on start                                                     |
-| focus_policy                | enum          | ClickFocus, NoFocus, TabFocus, StrongFocus            | How the widget can receive focus                                                                  |
-| enabled                     | bool          |                                                       | Whether this widget is enabled for interactive purposes, e.g. can be clicked                      |
-| tooltip                     | string        |                                                       | Mouse tooltip to show when hovering over this widget                                              |
-| min_size                    | size          |                                                       | Minimum size this widget wants to occupy                                                          |
-| max_size                    | size          |                                                       | Maximum size this widget wants to occupy                                                          |
-| width                       | int           |                                                       | Width of the widget, independent of its layout size calculation                                   |
-| height                      | int           |                                                       | Height of the widget, independent of its layout size calculation                                  |
-| min_width                   | int           | smaller than max_width                                | Minimum width this widget wants to occupy                                                         |
-| min_height                  | int           | smaller than max_height                               | Minimum height this widget wants to occupy                                                        |
-| max_width                   | int           | greater than min_width                                | Maximum width this widget wants to occupy                                                         |
-| max_height                  | int           | greater than min_height                               | Maximum height this widget wants to occupy                                                        |
-| fixed_width                 | int           |                                                       | Both maximum and minimum width; widget is fixed-width                                             |
-| fixed_height                | int           |                                                       | Both maximum and minimum height; widget is fixed-height                                           |
-| fixed_size                  | size          |                                                       | Both maximum and minimum size; widget is fixed-size                                               |
-| shrink_to_fit               | bool          |                                                       | Whether the widget shrinks as much as possible while still respecting its childrens minimum sizes |
-| font                        | string        | Any system-known font                                 | Font family                                                                                       |
-| font_size                   | int           | Font size that is available on this family            | Font size                                                                                         |
-| font_weight                 | font_weight   | Font weight that is available on this family and size | Font weight                                                                                       |
-| font_type                   | enum          | FixedWidth, Normal                                    | Font type                                                                                         |
-| foreground_color            | color         |                                                       | Color of foreground elements such as text                                                         |
-| foreground_role             | string        | Any theme palette color role name                     | Palette color role (depends on system theme) for the foreground elements                          |
-| background_color            | color         |                                                       | Color of the widget background                                                                    |
-| background_role             | string        | Any theme palette color role name                     | Palette color role (depends on system theme) for the widget background                            |
-| fill_width_background_color | bool          |                                                       | Whether to fill the widget's background with the background color                                 |
-| layout                      | layout object |                                                       | Layout object for layouting this widget's children                                                |
-| relative_rect               | rect          |                                                       | Rectangle for relatively positioning the widget to the parent                                     |
+| Property                    | Type          | Possible values                                       | Description                                                                                        |
+| --------------------------- | ------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| x                           | int           |                                                       | x offset relative to parent                                                                        |
+| y                           | int           |                                                       | y offset relative to parent                                                                        |
+| visible                     | bool          |                                                       | Whether widget and children are drawn                                                              |
+| focused                     | bool          |                                                       | Whether widget should be tab-focused on start                                                      |
+| focus_policy                | enum          | ClickFocus, NoFocus, TabFocus, StrongFocus            | How the widget can receive focus                                                                   |
+| enabled                     | bool          |                                                       | Whether this widget is enabled for interactive purposes, e.g. can be clicked                       |
+| tooltip                     | string        |                                                       | Mouse tooltip to show when hovering over this widget                                               |
+| min_size                    | ui_size       | {Regular, Shrink}²                                    | Minimum size this widget wants to occupy (Shrink is equivalent to 0)                               |
+| max_size                    | ui_size       | {Regular, Grow}²                                      | Maximum size this widget wants to occupy                                                           |
+| preferred_size              | ui_size       | {Regular, Shrink, Fit, OpportunisticGrow, Grow}²      | Preferred size this widget wants to occupy, if not otherwise constrained (Shrink means min_size)   |
+| width                       | int           |                                                       | Width of the widget, independent of its layout size calculation                                    |
+| height                      | int           |                                                       | Height of the widget, independent of its layout size calculation                                   |
+| min_width                   | ui_dimension  | Regular, Shrink                                       | Minimum width this widget wants to occupy (Shrink is equivalent to 0)                              |
+| min_height                  | ui_dimension  | Regular, Shrink                                       | Minimum height this widget wants to occupy (Shrink is equivalent to 0                              |
+| max_width                   | ui_dimension  | Regular, Grow                                         | Maximum width this widget wants to occupy                                                          |
+| max_height                  | ui_dimension  | Regular, Grow                                         | Maximum height this widget wants to occupy                                                         |
+| preferred_width             | ui_dimension  | Regular, Shrink, Fit, OpportunisticGrow, Grow         | Preferred width this widget wants to occupy, if not otherwise constrained (Shrink means min_size)  |
+| preferred_height            | ui_dimension  | Regular, Shrink, Fit, OpportunisticGrow, Grow         | Preferred height this widget wants to occupy, if not otherwise constrained (Shrink means min_size) |
+| fixed_width                 | ui_dimension  | Regular (currently only integer values ≥0 allowed)    | Both maximum and minimum width; widget is fixed-width                                              |
+| fixed_height                | ui_dimension  | Regular (currently only integer values ≥0 allowed)    | Both maximum and minimum height; widget is fixed-height                                            |
+| fixed_size                  | ui_size       | {Regular}²                                            | Both maximum and minimum size; widget is fixed-size                                                |
+| shrink_to_fit               | bool          |                                                       | Whether the widget shrinks as much as possible while still respecting its childrens minimum sizes  |
+| font                        | string        | Any system-known font                                 | Font family                                                                                        |
+| font_size                   | int           | Font size that is available on this family            | Font size                                                                                          |
+| font_weight                 | font_weight   | Font weight that is available on this family and size | Font weight                                                                                        |
+| font_type                   | enum          | FixedWidth, Normal                                    | Font type                                                                                          |
+| foreground_color            | color         |                                                       | Color of foreground elements such as text                                                          |
+| foreground_role             | string        | Any theme palette color role name                     | Palette color role (depends on system theme) for the foreground elements                           |
+| background_color            | color         |                                                       | Color of the widget background                                                                     |
+| background_role             | string        | Any theme palette color role name                     | Palette color role (depends on system theme) for the widget background                             |
+| fill_width_background_color | bool          |                                                       | Whether to fill the widget's background with the background color                                  |
+| layout                      | layout object |                                                       | Layout object for layouting this widget's children                                                 |
+| relative_rect               | rect          |                                                       | Rectangle for relatively positioning the widget to the parent                                      |
+

--- a/Userland/Applications/DisplaySettings/BackgroundSettings.gml
+++ b/Userland/Applications/DisplaySettings/BackgroundSettings.gml
@@ -28,22 +28,20 @@
 
         @GUI::IconView {
             name: "wallpaper_view"
+            preferred_width: "opportunistic_grow"
         }
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_width: "fit"
             layout: @GUI::VerticalBoxLayout {}
 
             @GUI::Button {
                 name: "wallpaper_open_button"
                 tooltip: "Select wallpaper from file system"
                 text: "Browse..."
-                shrink_to_fit: true
             }
 
-            @GUI::Widget {
-                fixed_height: 12
-            }
+            @GUI::Layout::Spacer {}
 
             @GUI::Label {
                 text: "Mode:"
@@ -55,9 +53,7 @@
                 name: "mode_combo"
             }
 
-            @GUI::Widget {
-                fixed_height: 12
-            }
+            @GUI::Layout::Spacer {}
 
             @GUI::Label {
                 text: "Color:"

--- a/Userland/Applications/DisplaySettings/FontSettings.gml
+++ b/Userland/Applications/DisplaySettings/FontSettings.gml
@@ -6,7 +6,7 @@
     }
 
     @GUI::Widget {
-        shrink_to_fit: true
+        preferred_height: "fit"
         layout: @GUI::HorizontalBoxLayout {
             spacing: 6
         }
@@ -17,14 +17,13 @@
             text_alignment: "CenterLeft"
         }
 
-        @GUI::Frame {
+        @GUI::Label {
             background_role: "Base"
+            shadow: "Sunken"
+            shape: "Container"
+            thickness: 2
             fill_with_background_color: true
-            layout: @GUI::VerticalBoxLayout {}
-
-            @GUI::Label {
-                name: "default_font_label"
-            }
+            name: "default_font_label"
         }
 
         @GUI::Button {
@@ -35,7 +34,7 @@
     }
 
     @GUI::Widget {
-        shrink_to_fit: true
+        preferred_height: "fit"
         layout: @GUI::HorizontalBoxLayout {
             spacing: 6
         }
@@ -46,14 +45,13 @@
             text_alignment: "CenterLeft"
         }
 
-        @GUI::Frame {
+        @GUI::Label {
             background_role: "Base"
+            shadow: "Sunken"
+            shape: "Container"
+            thickness: 2
             fill_with_background_color: true
-            layout: @GUI::VerticalBoxLayout {}
-
-            @GUI::Label {
-                name: "fixed_width_font_label"
-            }
+            name: "fixed_width_font_label"
         }
 
         @GUI::Button {
@@ -63,5 +61,5 @@
         }
     }
 
-    @GUI::Widget {}
+    @GUI::Layout::Spacer {}
 }

--- a/Userland/Applications/DisplaySettings/MonitorSettings.gml
+++ b/Userland/Applications/DisplaySettings/MonitorSettings.gml
@@ -15,7 +15,7 @@
     }
 
     @GUI::Widget {
-        shrink_to_fit: true
+        preferred_height: "fit"
         layout: @GUI::HorizontalBoxLayout {
             margins: [8, 8, 6, 16]
         }
@@ -38,7 +38,7 @@
         title: "Screen settings"
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::HorizontalBoxLayout {}
 
             @GUI::Label {
@@ -64,7 +64,7 @@
         }
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::HorizontalBoxLayout {}
 
             @GUI::Label {
@@ -84,6 +84,8 @@
                 text: "2x"
                 fixed_width: 50
             }
+
+            @GUI::Layout::Spacer {}
         }
     }
 }

--- a/Userland/Applications/DisplaySettings/ThemesSettings.gml
+++ b/Userland/Applications/DisplaySettings/ThemesSettings.gml
@@ -23,13 +23,13 @@
         }
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::HorizontalBoxLayout {}
 
             @GUI::Label {
                 text: "Theme:"
                 text_alignment: "CenterLeft"
-                fixed_width: 95
+                preferred_width: 95
             }
 
             @GUI::ComboBox {

--- a/Userland/Applications/MouseSettings/Theme.gml
+++ b/Userland/Applications/MouseSettings/Theme.gml
@@ -12,7 +12,7 @@
         }
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::HorizontalBoxLayout {
                 spacing: 8
             }

--- a/Userland/Applications/TerminalSettings/TerminalSettingsMain.gml
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsMain.gml
@@ -7,7 +7,7 @@
 
     @GUI::GroupBox {
         title: "Bell Mode"
-        shrink_to_fit: false
+        preferred_height: "fit"
         fixed_height: 160
         layout: @GUI::VerticalBoxLayout {
             margins: [16, 8, 8]
@@ -20,7 +20,7 @@
         }
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::VerticalBoxLayout {
                 spacing: 4
             }
@@ -44,7 +44,7 @@
 
     @GUI::GroupBox {
         title: "Scrollback Size (Lines)"
-        shrink_to_fit: true
+        preferred_height: "fit"
         layout: @GUI::VerticalBoxLayout {
             margins: [16, 8, 8]
         }
@@ -64,7 +64,7 @@
 
     @GUI::GroupBox {
         title: "Exit Behaviour"
-        shrink_to_fit: true
+        preferred_height: "fit"
         layout: @GUI::VerticalBoxLayout {
             margins: [16, 8, 8]
         }

--- a/Userland/Applications/TerminalSettings/TerminalSettingsView.gml
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsView.gml
@@ -7,7 +7,7 @@
 
     @GUI::GroupBox {
         title: "Background Opacity"
-        fixed_height: 70
+        preferred_height: "fit"
         layout: @GUI::VerticalBoxLayout {
             margins: [16, 8, 8]
             spacing: 16
@@ -23,7 +23,7 @@
 
     @GUI::GroupBox {
         title: "Terminal Font"
-        fixed_height: 100
+        preferred_height: "fit"
         layout: @GUI::VerticalBoxLayout {
             margins: [16, 8, 8]
             spacing: 16
@@ -35,13 +35,14 @@
         }
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             name: "terminal_font_selection"
             layout: @GUI::HorizontalBoxLayout {
                 spacing: 6
             }
 
             @GUI::Frame {
+                preferred_height: "fit"
                 background_role: "Base"
                 fill_with_background_color: true
                 layout: @GUI::VerticalBoxLayout {}
@@ -89,7 +90,7 @@
 
     @GUI::GroupBox {
         title: "Color Scheme"
-        fixed_height: 70
+        preferred_height: "fit"
         layout: @GUI::VerticalBoxLayout {
             margins: [16, 8, 8]
             spacing: 16

--- a/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
@@ -61,7 +61,6 @@
         @GUI::Scrollbar {
             name: "enabled_scrollbar"
             fixed_height: 16
-            fixed_width: -1
             min: 0
             max: 100
             value: 50
@@ -76,7 +75,6 @@
         @GUI::Scrollbar {
             name: "disabled_scrollbar"
             fixed_height: 16
-            fixed_width: -1
         }
 
         @GUI::Layout::Spacer {}

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -945,7 +945,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_add_terminal_action()
 
 void HackStudioWidget::reveal_action_tab(GUI::Widget& widget)
 {
-    if (m_action_tab_widget->min_height() < 200)
+    if (m_action_tab_widget->effective_min_size().height().as_int() < 200)
         m_action_tab_widget->set_fixed_height(200);
     m_action_tab_widget->set_active_widget(&widget);
 }

--- a/Userland/DevTools/Profiler/TimelineContainer.cpp
+++ b/Userland/DevTools/Profiler/TimelineContainer.cpp
@@ -23,7 +23,7 @@ TimelineContainer::TimelineContainer(GUI::Widget& header_container, TimelineView
     update_widget_sizes();
     update_widget_positions();
 
-    int initial_height = min(300, timeline_view.height() + horizontal_scrollbar().max_height() + frame_thickness() * 2);
+    int initial_height = min(300, timeline_view.height() + 16 + frame_thickness() * 2);
     set_fixed_height(initial_height);
 
     m_timeline_view->on_scale_change = [this] {
@@ -48,16 +48,16 @@ void TimelineContainer::update_widget_sizes()
 {
     {
         m_timeline_view->do_layout();
-        auto preferred_size = m_timeline_view->layout()->preferred_size();
-        m_timeline_view->resize(preferred_size);
-        set_content_size(preferred_size);
+        auto preferred_size = m_timeline_view->effective_preferred_size();
+        m_timeline_view->resize(Gfx::IntSize(preferred_size));
+        set_content_size(Gfx::IntSize(preferred_size));
     }
 
     {
         m_header_container->do_layout();
-        auto preferred_size = m_header_container->layout()->preferred_size();
-        m_header_container->resize(preferred_size);
-        set_size_occupied_by_fixed_elements({ preferred_size.width(), 0 });
+        auto preferred_size = m_header_container->effective_preferred_size();
+        m_header_container->resize(Gfx::IntSize(preferred_size));
+        set_size_occupied_by_fixed_elements({ preferred_size.width().as_int(), 0 });
     }
 }
 

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -104,7 +104,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Hearts", app_icon, window)));
 
     window->set_resizable(false);
-    window->resize(Hearts::Game::width, Hearts::Game::height + statusbar.max_height());
+    window->resize(Hearts::Game::width, Hearts::Game::height + statusbar.max_height().as_int());
     window->set_icon(app_icon.bitmap_for_size(16));
     window->show();
     game.setup(player_name);

--- a/Userland/Games/Minesweeper/Field.cpp
+++ b/Userland/Games/Minesweeper/Field.cpp
@@ -518,7 +518,7 @@ void Field::set_field_size(Difficulty difficulty, size_t rows, size_t columns, s
     m_mine_count = mine_count;
     set_fixed_size(frame_thickness() * 2 + m_columns * square_size(), frame_thickness() * 2 + m_rows * square_size());
     reset();
-    m_on_size_changed(min_size());
+    m_on_size_changed(Gfx::IntSize(min_size()));
 }
 
 void Field::set_single_chording(bool enabled)

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -90,7 +90,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     container->layout()->add_spacer();
 
     auto field = TRY(widget->try_add<Field>(flag_label, time_label, face_button, [&](auto size) {
-        size.set_height(size.height() + container->min_size().height());
+        size.set_height(size.height() + container->min_size().height().as_int());
         window->resize(size);
     }));
 

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -206,7 +206,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Solitaire", app_icon, window)));
 
     window->set_resizable(false);
-    window->resize(Solitaire::Game::width, Solitaire::Game::height + statusbar.max_height());
+    window->resize(Solitaire::Game::width, Solitaire::Game::height + statusbar.max_height().as_int());
     window->set_icon(app_icon.bitmap_for_size(16));
     window->show();
 

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -268,7 +268,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     help_menu->add_action(GUI::CommonActions::make_about_action("Spider", app_icon, window));
 
     window->set_resizable(false);
-    window->resize(Spider::Game::width, Spider::Game::height + statusbar.max_height());
+    window->resize(Spider::Game::width, Spider::Game::height + statusbar.max_height().as_int());
     window->set_icon(app_icon.bitmap_for_size(16));
     window->show();
 

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -75,8 +75,8 @@ void AbstractScrollableWidget::mousewheel_event(MouseEvent& event)
 void AbstractScrollableWidget::custom_layout()
 {
     auto inner_rect = frame_inner_rect_for_size(size());
-    int height_wanted_by_horizontal_scrollbar = m_horizontal_scrollbar->is_visible() ? m_horizontal_scrollbar->min_height() : 0;
-    int width_wanted_by_vertical_scrollbar = m_vertical_scrollbar->is_visible() ? m_vertical_scrollbar->min_width() : 0;
+    int height_wanted_by_horizontal_scrollbar = m_horizontal_scrollbar->is_visible() ? int(m_horizontal_scrollbar->min_height()) : 0;
+    int width_wanted_by_vertical_scrollbar = m_vertical_scrollbar->is_visible() ? int(m_vertical_scrollbar->min_width()) : 0;
 
     m_vertical_scrollbar->set_relative_rect(
         inner_rect.right() + 1 - m_vertical_scrollbar->min_width(),

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -78,17 +78,23 @@ void AbstractScrollableWidget::custom_layout()
     int height_wanted_by_horizontal_scrollbar = m_horizontal_scrollbar->is_visible() ? int(m_horizontal_scrollbar->min_height()) : 0;
     int width_wanted_by_vertical_scrollbar = m_vertical_scrollbar->is_visible() ? int(m_vertical_scrollbar->min_width()) : 0;
 
-    m_vertical_scrollbar->set_relative_rect(
-        inner_rect.right() + 1 - m_vertical_scrollbar->min_width(),
-        inner_rect.top(),
-        m_vertical_scrollbar->min_width(),
-        inner_rect.height() - height_wanted_by_horizontal_scrollbar);
+    {
+        int vertical_scrollbar_width = m_vertical_scrollbar->effective_min_size().width().as_int();
+        m_vertical_scrollbar->set_relative_rect(
+            inner_rect.right() + 1 - vertical_scrollbar_width,
+            inner_rect.top(),
+            vertical_scrollbar_width,
+            inner_rect.height() - height_wanted_by_horizontal_scrollbar);
+    }
 
-    m_horizontal_scrollbar->set_relative_rect(
-        inner_rect.left(),
-        inner_rect.bottom() + 1 - m_horizontal_scrollbar->min_height(),
-        inner_rect.width() - width_wanted_by_vertical_scrollbar,
-        m_horizontal_scrollbar->min_height());
+    {
+        int horizontal_scrollbar_height = m_horizontal_scrollbar->effective_min_size().height().as_int();
+        m_horizontal_scrollbar->set_relative_rect(
+            inner_rect.left(),
+            inner_rect.bottom() + 1 - horizontal_scrollbar_height,
+            inner_rect.width() - width_wanted_by_vertical_scrollbar,
+            horizontal_scrollbar_height);
+    }
 
     m_corner_widget->set_visible(m_vertical_scrollbar->is_visible() && m_horizontal_scrollbar->is_visible());
     if (m_corner_widget->is_visible()) {
@@ -106,8 +112,8 @@ void AbstractScrollableWidget::resize_event(ResizeEvent& event)
 Gfx::IntSize AbstractScrollableWidget::available_size() const
 {
     auto inner_size = Widget::content_size();
-    unsigned available_width = max(inner_size.width() - m_size_occupied_by_fixed_elements.width(), 0);
-    unsigned available_height = max(inner_size.height() - m_size_occupied_by_fixed_elements.height(), 0);
+    int available_width = max(inner_size.width() - m_size_occupied_by_fixed_elements.width(), 0);
+    int available_height = max(inner_size.height() - m_size_occupied_by_fixed_elements.height(), 0);
     return { available_width, available_height };
 }
 

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -75,8 +75,8 @@ void AbstractScrollableWidget::mousewheel_event(MouseEvent& event)
 void AbstractScrollableWidget::custom_layout()
 {
     auto inner_rect = frame_inner_rect_for_size(size());
-    int height_wanted_by_horizontal_scrollbar = m_horizontal_scrollbar->is_visible() ? int(m_horizontal_scrollbar->min_height()) : 0;
-    int width_wanted_by_vertical_scrollbar = m_vertical_scrollbar->is_visible() ? int(m_vertical_scrollbar->min_width()) : 0;
+    int height_wanted_by_horizontal_scrollbar = m_horizontal_scrollbar->is_visible() ? m_horizontal_scrollbar->effective_min_size().height().as_int() : 0;
+    int width_wanted_by_vertical_scrollbar = m_vertical_scrollbar->is_visible() ? m_vertical_scrollbar->effective_min_size().width().as_int() : 0;
 
     {
         int vertical_scrollbar_width = m_vertical_scrollbar->effective_min_size().width().as_int();

--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -411,7 +411,7 @@ void AbstractTableView::layout_headers()
         int y = frame_thickness();
         int width = max(content_width(), rect().width() - frame_thickness() * 2 - row_header_width - vertical_scrollbar_width);
 
-        column_header().set_relative_rect(x, y, width, column_header().min_size().height());
+        column_header().set_relative_rect(x, y, width, column_header().effective_min_size().height().as_int());
     }
 
     if (row_header().is_visible()) {
@@ -422,7 +422,7 @@ void AbstractTableView::layout_headers()
         int y = frame_thickness() + column_header_height - vertical_scrollbar().value();
         int height = max(content_height(), rect().height() - frame_thickness() * 2 - column_header_height - horizontal_scrollbar_height);
 
-        row_header().set_relative_rect(x, y, row_header().min_size().width(), height);
+        row_header().set_relative_rect(x, y, row_header().effective_min_size().width().as_int(), height);
     }
 
     if (row_header().is_visible() && column_header().is_visible()) {

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -27,7 +27,7 @@ public:
     void set_tooltip(String const& tooltip)
     {
         m_label->set_text(Gfx::parse_ampersand_string(tooltip));
-        int tooltip_width = m_label->min_width() + 10;
+        int tooltip_width = m_label->effective_min_size().width().as_int() + 10;
         int line_count = m_label->text().count("\n");
         int glyph_height = m_label->font().glyph_height();
         int tooltip_height = glyph_height * (1 + line_count) + ((glyph_height + 1) / 2) * line_count + 8;

--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -36,9 +36,9 @@ UISize BoxLayout::preferred_size() const
         if (!entry.widget || !entry.widget->is_visible())
             continue;
 
-        UISize min_size = entry.widget->min_size();
+        UISize min_size = entry.widget->effective_min_size();
         UISize max_size = entry.widget->max_size();
-        UISize preferred_size = entry.widget->preferred_size();
+        UISize preferred_size = entry.widget->effective_preferred_size();
 
         if (result_primary != SpecialDimension::Grow) {
             UIDimension item_primary_size = clamp(
@@ -98,7 +98,7 @@ UISize BoxLayout::min_size() const
         if (!entry.widget || !entry.widget->is_visible())
             continue;
 
-        UISize min_size = entry.widget->min_size();
+        UISize min_size = entry.widget->effective_min_size();
 
         {
             UIDimension primary_min_size = min_size.primary_size_for_orientation(orientation());

--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Frhun <serenitystuff@frhun.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -142,94 +143,211 @@ void BoxLayout::run(Widget& widget)
 
     struct Item {
         Widget* widget { nullptr };
-        int min_size { -1 };
-        int max_size { -1 };
+        UIDimension min_size { SpecialDimension::Shrink };
+        UIDimension max_size { SpecialDimension::Grow };
+        UIDimension preferred_size { SpecialDimension::Shrink };
         int size { 0 };
         bool final { false };
     };
 
     Vector<Item, 32> items;
+    int opportunistic_growth_item_count = 0;
+    int opportunistic_growth_items_base_size_total = 0;
 
     for (size_t i = 0; i < m_entries.size(); ++i) {
         auto& entry = m_entries[i];
         if (entry.type == Entry::Type::Spacer) {
-            items.append(Item { nullptr, -1, -1 });
+            items.append(Item { nullptr, { SpecialDimension::Shrink }, { SpecialDimension::Grow }, { SpecialDimension::Grow } });
             continue;
         }
         if (!entry.widget)
             continue;
         if (!entry.widget->is_visible())
             continue;
-        auto min_size = entry.widget->min_size();
-        auto max_size = entry.widget->max_size();
+        auto min_size = entry.widget->effective_min_size().primary_size_for_orientation(orientation());
+        auto max_size = entry.widget->max_size().primary_size_for_orientation(orientation());
+        auto preferred_size = entry.widget->effective_preferred_size().primary_size_for_orientation(orientation());
 
-        if (entry.widget->is_shrink_to_fit() && entry.widget->layout()) {
-            auto preferred_size = entry.widget->layout()->preferred_size();
-            min_size = max_size = preferred_size;
+        if (preferred_size == SpecialDimension::OpportunisticGrow) {
+            opportunistic_growth_item_count++;
+            opportunistic_growth_items_base_size_total += MUST(min_size.shrink_value());
+        } else {
+            preferred_size = clamp(preferred_size, min_size, max_size);
         }
 
-        items.append(Item { entry.widget.ptr(), min_size.primary_size_for_orientation(orientation()), max_size.primary_size_for_orientation(orientation()) });
+        items.append(
+            Item {
+                entry.widget.ptr(),
+                min_size,
+                max_size,
+                preferred_size });
     }
 
     if (items.is_empty())
         return;
 
     Gfx::IntRect content_rect = widget.content_rect();
-    int available_size = content_rect.size().primary_size_for_orientation(orientation()) - spacing() * (items.size() - 1);
-    int unfinished_items = items.size();
-
-    if (orientation() == Gfx::Orientation::Horizontal)
-        available_size -= margins().left() + margins().right();
-    else
-        available_size -= margins().top() + margins().bottom();
+    int uncommitted_size = content_rect.size().primary_size_for_orientation(orientation())
+        - spacing() * (items.size() - 1)
+        - margins().primary_total_for_orientation(orientation());
+    int unfinished_regular_items = items.size() - opportunistic_growth_item_count;
+    int max_amongst_the_min_sizes = 0;
+    int max_amongst_the_min_sizes_of_opportunistically_growing_items = 0;
+    int regular_items_to_layout = 0;
+    int regular_items_min_size_total = 0;
 
     // Pass 1: Set all items to their minimum size.
     for (auto& item : items) {
-        item.size = 0;
-        if (item.min_size >= 0)
-            item.size = item.min_size;
-        available_size -= item.size;
+        VERIFY(item.min_size.is_one_of(SpecialDimension::Regular, SpecialDimension::Shrink));
+        item.size = MUST(item.min_size.shrink_value());
+        uncommitted_size -= item.size;
 
-        if (item.min_size >= 0 && item.max_size >= 0 && item.min_size == item.max_size) {
+        if (item.min_size.is_int() && item.max_size.is_int() && item.min_size == item.max_size) {
             // Fixed-size items finish immediately in the first pass.
             item.final = true;
-            --unfinished_items;
+            if (item.preferred_size == SpecialDimension::OpportunisticGrow) {
+                opportunistic_growth_item_count--;
+                opportunistic_growth_items_base_size_total -= MUST(item.min_size.shrink_value());
+            } else {
+                --unfinished_regular_items;
+            }
+        } else if (item.preferred_size != SpecialDimension::OpportunisticGrow && item.widget) {
+            max_amongst_the_min_sizes = max(max_amongst_the_min_sizes, MUST(item.min_size.shrink_value()));
+            regular_items_to_layout++;
+            regular_items_min_size_total += item.size;
+        } else if (item.preferred_size == SpecialDimension::OpportunisticGrow) {
+            max_amongst_the_min_sizes_of_opportunistically_growing_items = max(max_amongst_the_min_sizes_of_opportunistically_growing_items, MUST(item.min_size.shrink_value()));
         }
     }
 
-    // Pass 2: Distribute remaining available size evenly, respecting each item's maximum size.
-    while (unfinished_items && available_size > 0) {
-        int slice = available_size / unfinished_items;
-        // If available_size does not divide evenly by unfinished_items,
+    // Pass 2: Set all non final, non spacer items to the previously encountered maximum min_size of these kind of items
+    // This is done to ensure even growth, if the items don't have the same min_size, which most won't have.
+    // If you are unsure what effect this has, try looking at widget gallery with, and without this, it'll be obvious.
+    if (uncommitted_size > 0) {
+        int total_growth_if_not_overcommitted = regular_items_to_layout * max_amongst_the_min_sizes - regular_items_min_size_total;
+        int overcommitment_if_all_same_min_size = total_growth_if_not_overcommitted - uncommitted_size;
+        for (auto& item : items) {
+            if (item.final || item.preferred_size == SpecialDimension::OpportunisticGrow || !item.widget)
+                continue;
+            int extra_needed_space = max_amongst_the_min_sizes - item.size;
+
+            if (overcommitment_if_all_same_min_size > 0) {
+                extra_needed_space -= (overcommitment_if_all_same_min_size * extra_needed_space + (total_growth_if_not_overcommitted - 1)) / (total_growth_if_not_overcommitted);
+            }
+
+            VERIFY(extra_needed_space >= 0);
+            VERIFY(uncommitted_size >= extra_needed_space);
+
+            item.size += extra_needed_space;
+            if (item.max_size.is_int() && item.size > item.max_size.as_int())
+                item.size = item.max_size.as_int();
+            uncommitted_size -= item.size - MUST(item.min_size.shrink_value());
+        }
+    }
+
+    // Pass 3: Determine final item size for non spacers, and non opportunisticially growing widgets
+    int loop_counter = 0; // This doubles as a safeguard for when the loop below doesn't finish for some reason, and as a mechanism to ensure it runs at least once.
+    // This has to run at least once, to handle the case where the loop for evening out the min sizes was in an overcommitted state,
+    // and gave the Widget a larger size than its preferred size.
+    while (unfinished_regular_items && (uncommitted_size > 0 || loop_counter++ == 0)) {
+        VERIFY(loop_counter < 100);
+        int slice = uncommitted_size / unfinished_regular_items;
+        // If uncommitted_size does not divide evenly by unfinished_regular_items,
         // there are some extra pixels that have to be distributed.
-        int pixels = available_size - slice * unfinished_items;
-        available_size = 0;
+        int pixels = uncommitted_size - slice * unfinished_regular_items;
+        uncommitted_size = 0;
 
         for (auto& item : items) {
             if (item.final)
+                continue;
+            if (!item.widget)
+                continue;
+            if (item.preferred_size == SpecialDimension::OpportunisticGrow)
                 continue;
 
             int pixel = pixels ? 1 : 0;
             pixels -= pixel;
             int item_size_with_full_slice = item.size + slice + pixel;
-            item.size = item_size_with_full_slice;
 
-            if (item.max_size >= 0)
-                item.size = min(item.max_size, item_size_with_full_slice);
+            UIDimension resulting_size { 0 };
+            resulting_size = max(item.size, item_size_with_full_slice);
+            resulting_size = min(resulting_size, item.preferred_size);
+            resulting_size = min(resulting_size, item.max_size);
 
-            // If the slice was more than we needed, return remained to available_size.
-            int remainder_to_give_back = item_size_with_full_slice - item.size;
-            available_size += remainder_to_give_back;
-
-            if (item.max_size >= 0 && item.size == item.max_size) {
-                // We've hit the item's max size. Don't give it any more space.
+            if (resulting_size.is_shrink()) {
+                // FIXME: Propagate this error, so it is obvious where the mistake is actually made.
+                if (!item.min_size.is_int())
+                    dbgln("BoxLayout: underconstrained widget set to zero size: {} {}", item.widget->class_name(), item.widget->name());
+                resulting_size = MUST(item.min_size.shrink_value());
                 item.final = true;
-                --unfinished_items;
+            }
+
+            if (resulting_size.is_grow())
+                resulting_size = item_size_with_full_slice;
+
+            item.size = resulting_size.as_int();
+
+            // If the slice was more than we needed, return remainder to available_size.
+            // Note that this will in some cases even return more than the slice size.
+            uncommitted_size += item_size_with_full_slice - item.size;
+
+            if (item.final
+                || (item.max_size.is_int() && item.max_size.as_int() == item.size)
+                || (item.preferred_size.is_int() && item.preferred_size.as_int() == item.size)) {
+                item.final = true;
+                --unfinished_regular_items;
             }
         }
     }
 
-    // Pass 3: Place the widgets.
+    // Pass 4: Even out min_size for opportunistically growing items, analogous to pass 2
+    if (uncommitted_size > 0 && opportunistic_growth_item_count > 0) {
+        int total_growth_if_not_overcommitted = opportunistic_growth_item_count * max_amongst_the_min_sizes_of_opportunistically_growing_items - opportunistic_growth_items_base_size_total;
+        int overcommitment_if_all_same_min_size = total_growth_if_not_overcommitted - uncommitted_size;
+        for (auto& item : items) {
+            if (item.final || item.preferred_size != SpecialDimension::OpportunisticGrow || !item.widget)
+                continue;
+            int extra_needed_space = max_amongst_the_min_sizes_of_opportunistically_growing_items - item.size;
+
+            if (overcommitment_if_all_same_min_size > 0 && total_growth_if_not_overcommitted > 0) {
+                extra_needed_space -= (overcommitment_if_all_same_min_size * extra_needed_space + (total_growth_if_not_overcommitted - 1)) / (total_growth_if_not_overcommitted);
+            }
+
+            VERIFY(extra_needed_space >= 0);
+            VERIFY(uncommitted_size >= extra_needed_space);
+
+            item.size += extra_needed_space;
+            if (item.max_size.is_int() && item.size > item.max_size.as_int())
+                item.size = item.max_size.as_int();
+            uncommitted_size -= item.size - MUST(item.min_size.shrink_value());
+        }
+    }
+
+    loop_counter = 0;
+    // Pass 5: Determine the size for the opportunistically growing items.
+    while (opportunistic_growth_item_count > 0 && uncommitted_size > 0) {
+        VERIFY(loop_counter++ < 200);
+        int opportunistic_growth_item_extra_size = uncommitted_size / opportunistic_growth_item_count;
+        int pixels = uncommitted_size - opportunistic_growth_item_count * opportunistic_growth_item_extra_size;
+        VERIFY(pixels >= 0);
+        for (auto& item : items) {
+            if (item.preferred_size != SpecialDimension::OpportunisticGrow || item.final || !item.widget)
+                continue;
+
+            int pixel = (pixels > 0 ? 1 : 0);
+            pixels -= pixel;
+            int previous_size = item.size;
+            item.size += opportunistic_growth_item_extra_size + pixel;
+            if (item.max_size.is_int() && item.size >= item.max_size.as_int()) {
+                item.size = item.max_size.as_int();
+                item.final = true;
+                opportunistic_growth_item_count--;
+            }
+            uncommitted_size -= item.size - previous_size;
+        }
+    }
+
+    // Pass 6: Place the widgets.
     int current_x = margins().left() + content_rect.x();
     int current_y = margins().top() + content_rect.y();
 
@@ -242,14 +360,17 @@ void BoxLayout::run(Widget& widget)
 
         if (item.widget) {
             int secondary = widget.content_size().secondary_size_for_orientation(orientation());
-
-            int min_secondary = item.widget->min_size().secondary_size_for_orientation(orientation());
-            int max_secondary = item.widget->max_size().secondary_size_for_orientation(orientation());
-            if (min_secondary >= 0)
-                secondary = max(secondary, min_secondary);
-            if (max_secondary >= 0)
-                secondary = min(secondary, max_secondary);
             secondary -= margins().secondary_total_for_orientation(orientation());
+
+            UIDimension min_secondary = item.widget->effective_min_size().secondary_size_for_orientation(orientation());
+            UIDimension max_secondary = item.widget->max_size().secondary_size_for_orientation(orientation());
+            UIDimension preferred_secondary = item.widget->effective_preferred_size().secondary_size_for_orientation(orientation());
+            if (preferred_secondary.is_int())
+                secondary = min(secondary, preferred_secondary.as_int());
+            if (min_secondary.is_int())
+                secondary = max(secondary, min_secondary.as_int());
+            if (max_secondary.is_int())
+                secondary = min(secondary, max_secondary.as_int());
 
             rect.set_secondary_size_for_orientation(orientation(), secondary);
 

--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -191,11 +191,7 @@ void BoxLayout::run(Widget& widget)
     int current_x = margins().left() + content_rect.x();
     int current_y = margins().top() + content_rect.y();
 
-    auto widget_rect_with_margins_subtracted = content_rect;
-    widget_rect_with_margins_subtracted.take_from_left(margins().left());
-    widget_rect_with_margins_subtracted.take_from_top(margins().top());
-    widget_rect_with_margins_subtracted.take_from_right(margins().right());
-    widget_rect_with_margins_subtracted.take_from_bottom(margins().bottom());
+    auto widget_rect_with_margins_subtracted = margins().applied_to(content_rect);
 
     for (auto& item : items) {
         Gfx::IntRect rect { current_x, current_y, 0, 0 };
@@ -204,10 +200,6 @@ void BoxLayout::run(Widget& widget)
 
         if (item.widget) {
             int secondary = widget.content_size().secondary_size_for_orientation(orientation());
-            if (orientation() == Gfx::Orientation::Horizontal)
-                secondary -= margins().top() + margins().bottom();
-            else
-                secondary -= margins().left() + margins().right();
 
             int min_secondary = item.widget->min_size().secondary_size_for_orientation(orientation());
             int max_secondary = item.widget->max_size().secondary_size_for_orientation(orientation());
@@ -215,6 +207,7 @@ void BoxLayout::run(Widget& widget)
                 secondary = max(secondary, min_secondary);
             if (max_secondary >= 0)
                 secondary = min(secondary, max_secondary);
+            secondary -= margins().secondary_total_for_orientation(orientation());
 
             rect.set_secondary_size_for_orientation(orientation(), secondary);
 

--- a/Userland/Libraries/LibGUI/BoxLayout.h
+++ b/Userland/Libraries/LibGUI/BoxLayout.h
@@ -23,6 +23,7 @@ public:
 
     virtual void run(Widget&) override;
     virtual Gfx::IntSize preferred_size() const override;
+    virtual UISize min_size() const override;
 
 protected:
     explicit BoxLayout(Gfx::Orientation);

--- a/Userland/Libraries/LibGUI/BoxLayout.h
+++ b/Userland/Libraries/LibGUI/BoxLayout.h
@@ -22,16 +22,13 @@ public:
     Gfx::Orientation orientation() const { return m_orientation; }
 
     virtual void run(Widget&) override;
-    virtual Gfx::IntSize preferred_size() const override;
+    virtual UISize preferred_size() const override;
     virtual UISize min_size() const override;
 
 protected:
     explicit BoxLayout(Gfx::Orientation);
 
 private:
-    int preferred_primary_size() const;
-    int preferred_secondary_size() const;
-
     Gfx::Orientation m_orientation;
 };
 

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -23,8 +23,8 @@ namespace GUI {
 Button::Button(String text)
     : AbstractButton(move(text))
 {
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 40, 22 });
+    set_preferred_size({ SpecialDimension::OpportunisticGrow, 22 });
     set_focus_policy(GUI::FocusPolicy::StrongFocus);
 
     on_focus_change = [this](bool has_focus, auto) {
@@ -251,6 +251,28 @@ void Button::timer_event(Core::TimerEvent&)
 
         update();
     }
+}
+
+Optional<UISize> Button::calculated_min_size() const
+{
+    int horizontal = 0, vertical = 0;
+
+    if (!text().is_empty()) {
+        auto& font = this->font();
+        horizontal = font.width(text()) + 2;
+        vertical = font.glyph_height() + 4; // FIXME: Use actual maximum total height
+    }
+
+    if (m_icon) {
+        vertical = max(vertical, m_icon->height());
+
+        horizontal += m_icon->width() + icon_spacing();
+    }
+
+    horizontal += 8;
+    vertical += 4;
+
+    return UISize(horizontal, vertical);
 }
 
 }

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -57,6 +57,8 @@ public:
     void set_mimic_pressed(bool mimic_pressed);
     bool is_mimic_pressed() const { return m_mimic_pressed; };
 
+    virtual Optional<UISize> calculated_min_size() const override;
+
 protected:
     explicit Button(String text = {});
     virtual void mousedown_event(MouseEvent&) override;

--- a/Userland/Libraries/LibGUI/CheckBox.cpp
+++ b/Userland/Libraries/LibGUI/CheckBox.cpp
@@ -30,8 +30,8 @@ CheckBox::CheckBox(String text)
         { CheckBoxPosition::Left, "Left" },
         { CheckBoxPosition::Right, "Right" });
 
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 22, 22 });
+    set_preferred_size({ SpecialDimension::OpportunisticGrow, 22 });
 }
 
 void CheckBox::paint_event(PaintEvent& event)

--- a/Userland/Libraries/LibGUI/ColorInput.cpp
+++ b/Userland/Libraries/LibGUI/ColorInput.cpp
@@ -18,8 +18,8 @@ namespace GUI {
 ColorInput::ColorInput()
     : TextEditor(TextEditor::SingleLine)
 {
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 40, 22 });
+    set_preferred_size({ SpecialDimension::OpportunisticGrow, 22 });
     TextEditor::on_change = [this] {
         auto parsed_color = Color::from_string(text());
         if (parsed_color.has_value())

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -56,8 +56,8 @@ ComboBox::ComboBox()
     REGISTER_STRING_PROPERTY("placeholder", editor_placeholder, set_editor_placeholder);
     REGISTER_BOOL_PROPERTY("model_only", only_allow_values_from_model, set_only_allow_values_from_model);
 
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 40, 22 });
+    set_preferred_size({ SpecialDimension::OpportunisticGrow, 22 });
 
     m_editor = add<ComboBoxEditor>();
     m_editor->set_frame_thickness(0);

--- a/Userland/Libraries/LibGUI/FilePickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FilePickerDialog.gml
@@ -6,7 +6,7 @@
     }
 
     @GUI::Widget {
-        shrink_to_fit: true
+        preferred_width: 103
         layout: @GUI::VerticalBoxLayout {
             margins: [0, 4]
         }
@@ -19,7 +19,7 @@
 
         @GUI::Tray {
             name: "common_locations_tray"
-            fixed_width: 95
+            min_width: 60
         }
 
         @GUI::Label {
@@ -37,15 +37,18 @@
         layout: @GUI::VerticalBoxLayout {}
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::HorizontalBoxLayout {}
 
             @GUI::TextBox {
                 name: "location_textbox"
+                preferred_width: "opportunistic_grow"
+                min_width: 80
             }
 
             @GUI::Toolbar {
                 name: "toolbar"
+                preferred_width: "shrink"
             }
         }
 
@@ -54,7 +57,7 @@
         }
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::VerticalBoxLayout {}
 
             @GUI::Widget {

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -44,19 +44,19 @@ void InputBox::build(InputType input_type)
     int title_width = widget.font().width(title()) + 24 /* icon, plus a little padding -- not perfect */;
     int max_width = max(text_width, title_width);
 
-    set_rect(x(), y(), max_width + 140, 66);
-
     widget.set_layout<VerticalBoxLayout>();
     widget.set_fill_with_background_color(true);
+    widget.set_preferred_height(SpecialDimension::Fit);
 
     widget.layout()->set_margins(6);
     widget.layout()->set_spacing(6);
 
     auto& label_editor_container = widget.add<Widget>();
     label_editor_container.set_layout<HorizontalBoxLayout>();
+    label_editor_container.set_preferred_height(SpecialDimension::Fit);
 
     auto& label = label_editor_container.add<Label>(m_prompt);
-    label.set_fixed_size(text_width, 16);
+    label.set_preferred_width(text_width);
 
     switch (input_type) {
     case InputType::Text:
@@ -73,13 +73,13 @@ void InputBox::build(InputType input_type)
         m_text_editor->set_placeholder(m_placeholder);
 
     auto& button_container_outer = widget.add<Widget>();
-    button_container_outer.set_fixed_height(22);
+    button_container_outer.set_preferred_height(SpecialDimension::Fit);
     button_container_outer.set_layout<VerticalBoxLayout>();
 
     auto& button_container_inner = button_container_outer.add<Widget>();
     button_container_inner.set_layout<HorizontalBoxLayout>();
+    button_container_inner.set_preferred_height(SpecialDimension::Fit);
     button_container_inner.layout()->set_spacing(6);
-    button_container_inner.layout()->set_margins({ 4, 0, 4, 4 });
     button_container_inner.layout()->add_spacer();
 
     m_ok_button = button_container_inner.add<DialogButton>();
@@ -102,6 +102,8 @@ void InputBox::build(InputType input_type)
         m_cancel_button->click();
     };
     m_text_editor->set_focus(true);
+
+    set_rect(x(), y(), max_width + 140, widget.effective_preferred_size().height().as_int());
 }
 
 }

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -23,6 +23,8 @@ Label::Label(String text)
     REGISTER_TEXT_ALIGNMENT_PROPERTY("text_alignment", text_alignment, set_text_alignment);
     REGISTER_TEXT_WRAPPING_PROPERTY("text_wrapping", text_wrapping, set_text_wrapping);
 
+    set_preferred_size({ SpecialDimension::OpportunisticGrow, 22 });
+
     set_frame_thickness(0);
     set_frame_shadow(Gfx::FrameShadow::Plain);
     set_frame_shape(Gfx::FrameShape::NoFrame);
@@ -112,10 +114,15 @@ void Label::size_to_fit()
     set_fixed_width(font().width(m_text) + m_autosize_padding * 2);
 }
 
-int Label::preferred_height() const
+int Label::text_calculated_preferred_height() const
 {
     // FIXME: The 4 is taken from Gfx::Painter and should be available as
     //        a constant instead.
     return Gfx::TextLayout(&font(), Utf8View { m_text }, text_rect()).bounding_rect(Gfx::TextWrapping::Wrap, 4).height();
+}
+
+Optional<UISize> Label::calculated_preferred_size() const
+{
+    return GUI::UISize(SpecialDimension::Grow, text_calculated_preferred_height());
 }
 }

--- a/Userland/Libraries/LibGUI/Label.h
+++ b/Userland/Libraries/LibGUI/Label.h
@@ -39,7 +39,8 @@ public:
     bool is_autosize() const { return m_autosize; }
     void set_autosize(bool, size_t padding = 0);
 
-    int preferred_height() const;
+    virtual Optional<UISize> calculated_preferred_size() const override;
+    int text_calculated_preferred_height() const;
 
     Gfx::IntRect text_rect() const;
 

--- a/Userland/Libraries/LibGUI/Layout.h
+++ b/Userland/Libraries/LibGUI/Layout.h
@@ -12,6 +12,7 @@
 #include <LibCore/Object.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Margins.h>
+#include <LibGUI/UIDimensions.h>
 #include <LibGfx/Forward.h>
 
 namespace Core {
@@ -49,6 +50,7 @@ public:
 
     virtual void run(Widget&) = 0;
     virtual Gfx::IntSize preferred_size() const = 0;
+    virtual UISize min_size() const = 0;
 
     void notify_adopted(Badge<Widget>, Widget&);
     void notify_disowned(Badge<Widget>, Widget&);

--- a/Userland/Libraries/LibGUI/Layout.h
+++ b/Userland/Libraries/LibGUI/Layout.h
@@ -49,7 +49,7 @@ public:
     void remove_widget(Widget&);
 
     virtual void run(Widget&) = 0;
-    virtual Gfx::IntSize preferred_size() const = 0;
+    virtual UISize preferred_size() const = 0;
     virtual UISize min_size() const = 0;
 
     void notify_adopted(Badge<Widget>, Widget&);

--- a/Userland/Libraries/LibGUI/Margins.h
+++ b/Userland/Libraries/LibGUI/Margins.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/Orientation.h>
 #include <LibGfx/Rect.h>
 
 namespace GUI {
@@ -76,6 +77,22 @@ public:
     Margins operator+(Margins const& other) const
     {
         return Margins { top() + other.top(), right() + other.right(), bottom() + other.bottom(), left() + other.left() };
+    }
+
+    [[nodiscard]] int primary_total_for_orientation(Gfx::Orientation const orientation) const
+    {
+        if (orientation == Gfx::Orientation::Horizontal)
+            return m_left + m_right;
+        else
+            return m_top + m_bottom;
+    }
+
+    [[nodiscard]] int secondary_total_for_orientation(Gfx::Orientation const orientation) const
+    {
+        if (orientation == Gfx::Orientation::Vertical)
+            return m_left + m_right;
+        else
+            return m_top + m_bottom;
     }
 
 private:

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -176,7 +176,8 @@ void MessageBox::build()
     int width = (button_count * button_width) + ((button_count - 1) * button_container.layout()->spacing()) + 32;
     width = max(width, text_width + icon_width + 56);
 
-    set_rect(x(), y(), width, 80 + label.max_height());
+    // FIXME: Use shrink from new layout system
+    set_rect(x(), y(), width, 80 + label.preferred_height());
     set_resizable(false);
 }
 

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -177,7 +177,7 @@ void MessageBox::build()
     width = max(width, text_width + icon_width + 56);
 
     // FIXME: Use shrink from new layout system
-    set_rect(x(), y(), width, 80 + label.preferred_height());
+    set_rect(x(), y(), width, 80 + label.text_calculated_preferred_height());
     set_resizable(false);
 }
 

--- a/Userland/Libraries/LibGUI/RadioButton.cpp
+++ b/Userland/Libraries/LibGUI/RadioButton.cpp
@@ -21,8 +21,8 @@ RadioButton::RadioButton(String text)
 {
     set_exclusive(true);
     set_checkable(true);
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 22, 22 });
+    set_preferred_size({ SpecialDimension::OpportunisticGrow, 22 });
 }
 
 Gfx::IntSize RadioButton::circle_size()
@@ -59,6 +59,15 @@ void RadioButton::click(unsigned)
     if (!is_enabled())
         return;
     set_checked(true);
+}
+
+Optional<UISize> RadioButton::calculated_min_size() const
+{
+    int horizontal = 2 + 7, vertical = 0;
+    auto& font = this->font();
+    vertical = max(font.glyph_height(), circle_size().height());
+    horizontal += font.width(text());
+    return UISize(horizontal, vertical);
 }
 
 }

--- a/Userland/Libraries/LibGUI/RadioButton.h
+++ b/Userland/Libraries/LibGUI/RadioButton.h
@@ -19,6 +19,8 @@ public:
 
     virtual void click(unsigned modifiers = 0) override;
 
+    virtual Optional<UISize> calculated_min_size() const override;
+
 protected:
     explicit RadioButton(String text = {});
     virtual void paint_event(PaintEvent&) override;

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -48,11 +48,7 @@ Scrollbar::Scrollbar(Orientation orientation)
 {
     m_automatic_scrolling_timer = add<Core::Timer>();
 
-    if (orientation == Orientation::Vertical) {
-        set_fixed_width(16);
-    } else {
-        set_fixed_height(16);
-    }
+    set_preferred_size({ SpecialDimension::Fit });
 
     m_automatic_scrolling_timer->set_interval(100);
     m_automatic_scrolling_timer->on_timeout = [this] {
@@ -419,6 +415,22 @@ void Scrollbar::update_animated_scroll()
     double new_distance = initial_distance * ease_percent;
     int new_value = m_start_value + (int)round(new_distance);
     AbstractSlider::set_value(new_value);
+}
+
+Optional<UISize> Scrollbar::calculated_min_size() const
+{
+    if (orientation() == Gfx::Orientation::Vertical)
+        return { { default_button_size(), 2 * default_button_size() } };
+    else
+        return { { 2 * default_button_size(), default_button_size() } };
+}
+
+Optional<UISize> Scrollbar::calculated_preferred_size() const
+{
+    if (orientation() == Gfx::Orientation::Vertical)
+        return { { SpecialDimension::Shrink, SpecialDimension::Grow } };
+    else
+        return { { SpecialDimension::Grow, SpecialDimension::Shrink } };
 }
 
 }

--- a/Userland/Libraries/LibGUI/Scrollbar.h
+++ b/Userland/Libraries/LibGUI/Scrollbar.h
@@ -40,6 +40,9 @@ public:
     virtual void increase_slider_by_steps(int steps) override { set_target_value(m_target_value + step() * steps); }
     virtual void decrease_slider_by_steps(int steps) override { set_target_value(m_target_value - step() * steps); }
 
+    virtual Optional<UISize> calculated_min_size() const override;
+    virtual Optional<UISize> calculated_preferred_size() const override;
+
     enum Component {
         None,
         DecrementButton,

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -41,7 +41,7 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
     window->m_tab_widget = TRY(main_widget->try_add<GUI::TabWidget>());
 
     auto button_container = TRY(main_widget->try_add<GUI::Widget>());
-    button_container->set_shrink_to_fit(true);
+    button_container->set_preferred_size({ SpecialDimension::Grow, SpecialDimension::Fit });
     (void)TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>());
     button_container->layout()->set_spacing(6);
 

--- a/Userland/Libraries/LibGUI/SpinBox.cpp
+++ b/Userland/Libraries/LibGUI/SpinBox.cpp
@@ -15,8 +15,8 @@ namespace GUI {
 
 SpinBox::SpinBox()
 {
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 40, 22 });
+    set_preferred_size({ SpecialDimension::OpportunisticGrow, 22 });
     m_editor = add<TextBox>();
     m_editor->set_text("0");
     m_editor->on_change = [this, weak_this = make_weak_ptr()] {

--- a/Userland/Libraries/LibGUI/Statusbar.cpp
+++ b/Userland/Libraries/LibGUI/Statusbar.cpp
@@ -62,9 +62,10 @@ void Statusbar::update_segment(size_t index)
             segment.set_fixed_width(width);
         }
     } else if (segment.mode() == Segment::Mode::Fixed) {
-        if (segment.max_width() != -1)
-            segment.set_restored_width(segment.max_width());
-        segment.set_fixed_width(segment.max_width());
+        if (segment.max_width().is_int()) {
+            segment.set_restored_width(segment.max_width().as_int());
+            segment.set_fixed_width(segment.max_width());
+        }
     }
 
     if (segment.override_text().is_null()) {
@@ -84,7 +85,7 @@ void Statusbar::update_segment(size_t index)
         segment.set_text(segment.override_text());
         segment.set_frame_shape(Gfx::FrameShape::NoFrame);
         if (segment.mode() != Segment::Mode::Proportional)
-            segment.set_fixed_width(-1);
+            segment.set_fixed_width(SpecialDimension::Grow);
     }
 }
 

--- a/Userland/Libraries/LibGUI/TextBox.cpp
+++ b/Userland/Libraries/LibGUI/TextBox.cpp
@@ -18,8 +18,8 @@ namespace GUI {
 TextBox::TextBox()
     : TextEditor(TextEditor::SingleLine)
 {
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 40, 22 });
+    set_preferred_size({ SpecialDimension::OpportunisticGrow, 22 });
 }
 
 void TextBox::keydown_event(GUI::KeyEvent& event)

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -743,6 +743,17 @@ void TextEditor::paint_event(PaintEvent& event)
         painter.fill_rect(cursor_content_rect(), palette().text_cursor());
 }
 
+Optional<UISize> TextEditor::calculated_min_size() const
+{
+    auto margins = content_margins();
+    int horizontal = margins.left() + margins.right(),
+        vertical = margins.top() + margins.bottom();
+    int vertical_content_size = font().glyph_height() + 4;
+    if (!is_multi_line() && m_icon)
+        vertical_content_size = max(vertical_content_size, icon_size() + 2);
+    return UISize(horizontal, vertical);
+}
+
 void TextEditor::select_all()
 {
     TextPosition start_of_document { 0, 0 };

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -224,6 +224,8 @@ public:
     Optional<size_t> search_result_index() const { return m_search_result_index; }
     Vector<TextRange> const& search_results() const { return m_search_results; }
 
+    virtual Optional<UISize> calculated_min_size() const override;
+
 protected:
     explicit TextEditor(Type = Type::MultiLine);
 

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -133,4 +133,13 @@ void Toolbar::paint_event(PaintEvent& event)
     painter.fill_rect(event.rect(), palette().button());
 }
 
+Optional<UISize> Toolbar::calculated_preferred_size() const
+{
+    if (m_orientation == Gfx::Orientation::Horizontal)
+        return { { SpecialDimension::Grow, SpecialDimension::Fit } };
+    else
+        return { { SpecialDimension::Fit, SpecialDimension::Grow } };
+    VERIFY_NOT_REACHED();
+}
+
 }

--- a/Userland/Libraries/LibGUI/Toolbar.h
+++ b/Userland/Libraries/LibGUI/Toolbar.h
@@ -27,6 +27,8 @@ public:
     bool has_frame() const { return m_has_frame; }
     void set_has_frame(bool has_frame) { m_has_frame = has_frame; }
 
+    virtual Optional<UISize> calculated_preferred_size() const override;
+
 protected:
     explicit Toolbar(Gfx::Orientation = Gfx::Orientation::Horizontal, int button_size = 16);
 

--- a/Userland/Libraries/LibGUI/UIDimensions.h
+++ b/Userland/Libraries/LibGUI/UIDimensions.h
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2022, Frhun <serenitystuff@frhun.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonValue.h>
+#include <AK/Optional.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/Size.h>
+#include <initializer_list>
+
+namespace GUI {
+
+// The constants used for special values
+// Their order here, also defines their order among each other for min, max; operations, excluding Regular
+enum class SpecialDimension : int {
+    Regular = 0, // only really useful for is_one_of
+    Grow = -1,
+    OpportunisticGrow = -2,
+    Fit = -3,
+    Shrink = -4,
+};
+
+class UIDimension {
+    friend constexpr auto AK::max<GUI::UIDimension>(GUI::UIDimension const&, GUI::UIDimension const&) -> GUI::UIDimension;
+    friend constexpr auto AK::min<GUI::UIDimension>(GUI::UIDimension const&, GUI::UIDimension const&) -> GUI::UIDimension;
+
+public:
+    UIDimension() = delete;
+
+    UIDimension(int value)
+        : m_value(value)
+    {
+        VERIFY(value >= 0);
+    }
+
+    UIDimension(SpecialDimension special)
+        : m_value(to_underlying(special))
+    {
+    }
+
+    // This is a temporary hack to get this compiling
+    operator int() const
+    {
+        return m_value;
+    }
+
+    [[nodiscard]] inline bool is_special_value() const
+    {
+        return m_value < 0;
+    }
+
+    [[nodiscard]] inline bool is_int() const
+    {
+        return m_value >= 0;
+    }
+
+    [[nodiscard]] inline bool is_shrink() const
+    {
+        return m_value == to_underlying(SpecialDimension::Shrink);
+    }
+
+    [[nodiscard]] inline bool is_grow() const
+    {
+        return m_value == to_underlying(SpecialDimension::Grow);
+    }
+
+    [[nodiscard]] inline bool is_opportunistic_grow() const
+    {
+        return m_value == to_underlying(SpecialDimension::OpportunisticGrow);
+    }
+
+    [[nodiscard]] inline bool is_fit() const
+    {
+        return m_value == to_underlying(SpecialDimension::Fit);
+    }
+
+    [[nodiscard]] inline bool is_one_of(std::initializer_list<SpecialDimension> valid_values) const
+    {
+        for (SpecialDimension v : valid_values) {
+            if (m_value == to_underlying(v) || (v == SpecialDimension::Regular && is_int()))
+                return true;
+        }
+        return false;
+    }
+
+    [[nodiscard]] ALWAYS_INLINE constexpr bool is(SpecialDimension special_value) const
+    {
+        return m_value == to_underlying(special_value) || (special_value == SpecialDimension::Regular && is_int());
+    }
+
+    template<typename... Ts>
+    [[nodiscard]] bool is_one_of(Ts... valid_values) const
+    {
+        return (... || (is(forward<Ts>(valid_values))));
+    }
+
+    [[nodiscard]] inline bool operator==(UIDimension other) const
+    {
+        return m_value == other.m_value;
+    }
+
+    [[nodiscard]] inline UIDimension must_sum_with(UIDimension other) const
+    {
+        VERIFY(is_int() && other.is_int());
+        return UIDimension { m_value + other.m_value };
+    }
+
+    inline void must_add(int to_add)
+    {
+        VERIFY(is_int());
+        VERIFY(m_value >= -to_add);
+        m_value += to_add;
+    }
+
+    inline void add_if_int(int to_add)
+    {
+        if (is_int()) {
+            m_value += to_add;
+        }
+    }
+
+    [[nodiscard]] inline ErrorOr<int> shrink_value() const
+    {
+        if (m_value >= 0)
+            return m_value;
+        if (m_value == to_underlying(SpecialDimension::Shrink))
+            return 0;
+        return Error::from_string_literal("value is neither shrink nor an integer ≥0");
+    }
+
+    [[nodiscard]] inline int as_int() const
+    {
+        VERIFY(is_int());
+        return m_value;
+    }
+
+    [[nodiscard]] AK::JsonValue as_json_value() const
+    {
+        if (is_int())
+            return m_value;
+        if (is_shrink())
+            return "shrink";
+        if (is_grow())
+            return "grow";
+        if (is_opportunistic_grow())
+            return "opportunistic_grow";
+        if (is_fit())
+            return "fit";
+
+        VERIFY_NOT_REACHED();
+    }
+
+    operator AK::JsonValue() const
+    {
+        return this->as_json_value();
+    }
+
+    [[nodiscard]] static Optional<UIDimension> construct_from_json_value(AK::JsonValue const value)
+    {
+        if (value.is_string()) {
+            String value_literal = value.as_string();
+            if (value_literal == "shrink")
+                return UIDimension { SpecialDimension::Shrink };
+            else if (value_literal == "grow")
+                return UIDimension { SpecialDimension::Grow };
+            else if (value_literal == "opportunistic_grow")
+                return UIDimension { SpecialDimension::OpportunisticGrow };
+            else if (value_literal == "fit")
+                return UIDimension { SpecialDimension::Fit };
+            else
+                return {};
+        } else {
+            int value_int = value.to_i32();
+            if (value_int < 0)
+                return {};
+            return UIDimension(value_int);
+        }
+    }
+
+    // FIXME: Remove these following methods when the move to the new layout system is completed
+    [[nodiscard]] inline bool operator==(int other) const
+    {
+        return m_value == other;
+    }
+
+private:
+    int m_value;
+};
+
+class UISize : public Gfx::Size<UIDimension> {
+
+public:
+    UISize() = delete;
+
+    UISize(int in_width, int in_height)
+        : Gfx::Size<UIDimension>(in_width, in_height)
+    {
+    }
+
+    UISize(Gfx::IntSize size)
+        : UISize(size.width(), size.height())
+    {
+    }
+
+    UISize(SpecialDimension special)
+        : Gfx::Size<UIDimension>(UIDimension { special }, UIDimension { special })
+    {
+    }
+
+    UISize(UIDimension width, UIDimension height)
+        : Gfx::Size<UIDimension>(width, height)
+    {
+    }
+
+    inline UISize replace_component_if_matching_with(UIDimension to_match, UISize replacement)
+    {
+        if (width() == to_match)
+            set_width(replacement.width());
+        if (height() == to_match)
+            set_height(replacement.height());
+        return *this;
+    }
+
+    [[nodiscard]] inline bool has_only_int_values() const
+    {
+        return width().is_int() && height().is_int();
+    }
+
+    [[nodiscard]] inline bool either_is(UIDimension to_match) const
+    {
+        return (width() == to_match || height() == to_match);
+    }
+
+    operator Gfx::IntSize() const
+    {
+        return Gfx::IntSize(width().as_int(), height().as_int());
+    }
+};
+
+}
+
+namespace AK {
+
+template<>
+inline auto max<GUI::UIDimension>(GUI::UIDimension const& a, GUI::UIDimension const& b) -> GUI::UIDimension
+{
+    if ((a.is_int() && b.is_int()) || (a.is_special_value() && b.is_special_value()))
+        return a.m_value > b.m_value ? a : b;
+    if (a.is_grow() || b.is_grow())
+        return GUI::SpecialDimension::Grow;
+    if (a.is_opportunistic_grow() || b.is_opportunistic_grow())
+        return GUI::SpecialDimension::OpportunisticGrow;
+    if (a.is_fit() || b.is_fit())
+        return GUI::SpecialDimension::Fit;
+    if (a.is_shrink())
+        return b;
+    if (b.is_shrink())
+        return a;
+    VERIFY_NOT_REACHED();
+}
+
+template<>
+inline auto min<GUI::UIDimension>(GUI::UIDimension const& a, GUI::UIDimension const& b) -> GUI::UIDimension
+{
+    if ((a.is_int() && b.is_int()) || (a.is_special_value() && b.is_special_value()))
+        return a.m_value < b.m_value ? a : b;
+    if (a.is_shrink() || b.is_shrink())
+        return GUI::SpecialDimension::Shrink;
+    if (a.is_int())
+        return a;
+    if (b.is_int())
+        return b;
+    if (a.is_fit() || b.is_fit())
+        return GUI::SpecialDimension::Fit;
+    if (a.is_opportunistic_grow() || b.is_opportunistic_grow())
+        return GUI::SpecialDimension::OpportunisticGrow;
+    VERIFY_NOT_REACHED();
+}
+
+template<>
+inline auto clamp<GUI::UIDimension>(GUI::UIDimension const& input, GUI::UIDimension const& lower_bound, GUI::UIDimension const& upper_bound) -> GUI::UIDimension
+{
+    return min(max(input, lower_bound), upper_bound);
+}
+
+}

--- a/Userland/Libraries/LibGUI/UIDimensions.h
+++ b/Userland/Libraries/LibGUI/UIDimensions.h
@@ -42,12 +42,6 @@ public:
     {
     }
 
-    // This is a temporary hack to get this compiling
-    operator int() const
-    {
-        return m_value;
-    }
-
     [[nodiscard]] inline bool is_special_value() const
     {
         return m_value < 0;
@@ -154,11 +148,6 @@ public:
         VERIFY_NOT_REACHED();
     }
 
-    operator AK::JsonValue() const
-    {
-        return this->as_json_value();
-    }
-
     [[nodiscard]] static Optional<UIDimension> construct_from_json_value(AK::JsonValue const value)
     {
         if (value.is_string()) {
@@ -179,12 +168,6 @@ public:
                 return {};
             return UIDimension(value_int);
         }
-    }
-
-    // FIXME: Remove these following methods when the move to the new layout system is completed
-    [[nodiscard]] inline bool operator==(int other) const
-    {
-        return m_value == other;
     }
 
 private:
@@ -235,7 +218,7 @@ public:
         return (width() == to_match || height() == to_match);
     }
 
-    operator Gfx::IntSize() const
+    explicit operator Gfx::IntSize() const
     {
         return Gfx::IntSize(width().as_int(), height().as_int());
     }

--- a/Userland/Libraries/LibGUI/UIDimensions.h
+++ b/Userland/Libraries/LibGUI/UIDimensions.h
@@ -285,6 +285,13 @@ inline auto clamp<GUI::UIDimension>(GUI::UIDimension const& input, GUI::UIDimens
             return result.has_value();                                        \
         });
 
+#define REGISTER_READONLY_UI_DIMENSION_PROPERTY(property_name, getter) \
+    register_property(                                                 \
+        property_name,                                                 \
+        [this] {                                                       \
+            return this->getter().as_json_value();                     \
+        });
+
 #define REGISTER_UI_SIZE_PROPERTY(property_name, getter, setter)               \
     register_property(                                                         \
         property_name,                                                         \
@@ -308,4 +315,15 @@ inline auto clamp<GUI::UIDimension>(GUI::UIDimension const& input, GUI::UIDimens
                 return true;                                                   \
             }                                                                  \
             return false;                                                      \
+        });
+
+#define REGISTER_READONLY_UI_SIZE_PROPERTY(property_name, getter)     \
+    register_property(                                                \
+        property_name,                                                \
+        [this] {                                                      \
+            auto size = this->getter();                               \
+            JsonObject size_object;                                   \
+            size_object.set("width", size.width().as_json_value());   \
+            size_object.set("height", size.height().as_json_value()); \
+            return size_object;                                       \
         });

--- a/Userland/Libraries/LibGUI/UIDimensions.h
+++ b/Userland/Libraries/LibGUI/UIDimensions.h
@@ -288,3 +288,41 @@ inline auto clamp<GUI::UIDimension>(GUI::UIDimension const& input, GUI::UIDimens
 }
 
 }
+
+#define REGISTER_UI_DIMENSION_PROPERTY(property_name, getter, setter)         \
+    register_property(                                                        \
+        property_name,                                                        \
+        [this] {                                                              \
+            return this->getter().as_json_value();                            \
+        },                                                                    \
+        [this](auto& value) {                                                 \
+            auto result = GUI::UIDimension::construct_from_json_value(value); \
+            if (result.has_value())                                           \
+                this->setter(result.value());                                 \
+            return result.has_value();                                        \
+        });
+
+#define REGISTER_UI_SIZE_PROPERTY(property_name, getter, setter)               \
+    register_property(                                                         \
+        property_name,                                                         \
+        [this] {                                                               \
+            auto size = this->getter();                                        \
+            JsonObject size_object;                                            \
+            size_object.set("width", size.width().as_json_value());            \
+            size_object.set("height", size.height().as_json_value());          \
+            return size_object;                                                \
+        },                                                                     \
+        [this](auto& value) {                                                  \
+            if (!value.is_object())                                            \
+                return false;                                                  \
+            auto result_width = GUI::UIDimension::construct_from_json_value(   \
+                value.as_object().get("width"));                               \
+            auto result_height = GUI::UIDimension::construct_from_json_value(  \
+                value.as_object().get("height"));                              \
+            if (result_width.has_value() && result_height.has_value()) {       \
+                GUI::UISize size(result_width.value(), result_height.value()); \
+                setter(size);                                                  \
+                return true;                                                   \
+            }                                                                  \
+            return false;                                                      \
+        });

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -51,12 +51,15 @@ Widget::Widget()
 
     REGISTER_UI_SIZE_PROPERTY("min_size", min_size, set_min_size);
     REGISTER_UI_SIZE_PROPERTY("max_size", max_size, set_max_size);
+    REGISTER_UI_SIZE_PROPERTY("preferred_size", preferred_size, set_preferred_size);
     REGISTER_INT_PROPERTY("width", width, set_width);
     REGISTER_UI_DIMENSION_PROPERTY("min_width", min_width, set_min_width);
     REGISTER_UI_DIMENSION_PROPERTY("max_width", max_width, set_max_width);
+    REGISTER_UI_DIMENSION_PROPERTY("preferred_width", preferred_width, set_preferred_width);
     REGISTER_INT_PROPERTY("height", height, set_height);
     REGISTER_UI_DIMENSION_PROPERTY("min_height", min_height, set_min_height);
     REGISTER_UI_DIMENSION_PROPERTY("max_height", max_height, set_max_height);
+    REGISTER_UI_DIMENSION_PROPERTY("preferred_height", preferred_height, set_preferred_height);
 
     REGISTER_INT_PROPERTY("fixed_width", dummy_fixed_width, set_fixed_width);
     REGISTER_INT_PROPERTY("fixed_height", dummy_fixed_height, set_fixed_height);
@@ -795,6 +798,14 @@ void Widget::set_max_size(UISize const& size)
     if (m_max_size == size)
         return;
     m_max_size = size;
+    invalidate_layout();
+}
+
+void Widget::set_preferred_size(UISize const& size)
+{
+    if (m_preferred_size == size)
+        return;
+    m_preferred_size = size;
     invalidate_layout();
 }
 

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -49,14 +49,14 @@ Widget::Widget()
     REGISTER_BOOL_PROPERTY("enabled", is_enabled, set_enabled);
     REGISTER_STRING_PROPERTY("tooltip", tooltip, set_tooltip);
 
-    REGISTER_SIZE_PROPERTY("min_size", min_size, set_min_size);
-    REGISTER_SIZE_PROPERTY("max_size", max_size, set_max_size);
+    REGISTER_UI_SIZE_PROPERTY("min_size", min_size, set_min_size);
+    REGISTER_UI_SIZE_PROPERTY("max_size", max_size, set_max_size);
     REGISTER_INT_PROPERTY("width", width, set_width);
-    REGISTER_INT_PROPERTY("min_width", min_width, set_min_width);
-    REGISTER_INT_PROPERTY("max_width", max_width, set_max_width);
-    REGISTER_INT_PROPERTY("min_height", min_height, set_min_height);
+    REGISTER_UI_DIMENSION_PROPERTY("min_width", min_width, set_min_width);
+    REGISTER_UI_DIMENSION_PROPERTY("max_width", max_width, set_max_width);
     REGISTER_INT_PROPERTY("height", height, set_height);
-    REGISTER_INT_PROPERTY("max_height", max_height, set_max_height);
+    REGISTER_UI_DIMENSION_PROPERTY("min_height", min_height, set_min_height);
+    REGISTER_UI_DIMENSION_PROPERTY("max_height", max_height, set_max_height);
 
     REGISTER_INT_PROPERTY("fixed_width", dummy_fixed_width, set_fixed_width);
     REGISTER_INT_PROPERTY("fixed_height", dummy_fixed_height, set_fixed_height);

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -809,6 +809,24 @@ void Widget::set_preferred_size(UISize const& size)
     invalidate_layout();
 }
 
+Optional<UISize> Widget::calculated_preferred_size() const
+{
+    if (layout())
+        return { layout()->preferred_size() };
+    return {};
+}
+
+Optional<UISize> Widget::calculated_min_size() const
+{
+    if (layout())
+        return { layout()->min_size() };
+    // Fall back to at least displaying the margins, so the Widget is not 0 size.
+    auto m = content_margins();
+    if (!m.is_null())
+        return UISize { m.left() + m.right(), m.top() + m.bottom() };
+    return {};
+}
+
 void Widget::invalidate_layout()
 {
     if (window())

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -780,16 +780,18 @@ void Widget::set_font_fixed_width(bool fixed_width)
         set_font(Gfx::FontDatabase::the().get(Gfx::FontDatabase::the().default_font().family(), m_font->presentation_size(), m_font->weight(), m_font->slope()));
 }
 
-void Widget::set_min_size(Gfx::IntSize const& size)
+void Widget::set_min_size(UISize const& size)
 {
+    VERIFY(size.width().is_one_of(SpecialDimension::Regular, SpecialDimension::Shrink));
     if (m_min_size == size)
         return;
     m_min_size = size;
     invalidate_layout();
 }
 
-void Widget::set_max_size(Gfx::IntSize const& size)
+void Widget::set_max_size(UISize const& size)
 {
+    VERIFY(size.width().is_one_of(SpecialDimension::Regular, SpecialDimension::Grow));
     if (m_max_size == size)
         return;
     m_max_size = size;

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -50,8 +50,10 @@ Widget::Widget()
     REGISTER_STRING_PROPERTY("tooltip", tooltip, set_tooltip);
 
     REGISTER_UI_SIZE_PROPERTY("min_size", min_size, set_min_size);
+    REGISTER_READONLY_UI_SIZE_PROPERTY("effective_min_size", effective_min_size);
     REGISTER_UI_SIZE_PROPERTY("max_size", max_size, set_max_size);
     REGISTER_UI_SIZE_PROPERTY("preferred_size", preferred_size, set_preferred_size);
+    REGISTER_READONLY_UI_SIZE_PROPERTY("effective_preferred_size", effective_preferred_size);
     REGISTER_INT_PROPERTY("width", width, set_width);
     REGISTER_UI_DIMENSION_PROPERTY("min_width", min_width, set_min_width);
     REGISTER_UI_DIMENSION_PROPERTY("max_width", max_width, set_max_width);

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1193,12 +1193,11 @@ bool Widget::has_focus_within() const
     return window->focused_widget() == &effective_focus_widget || is_ancestor_of(*window->focused_widget());
 }
 
-void Widget::set_shrink_to_fit(bool b)
+void Widget::set_shrink_to_fit(bool shrink_to_fit)
 {
-    if (m_shrink_to_fit == b)
-        return;
-    m_shrink_to_fit = b;
-    invalidate_layout();
+    // This function is deprecated, and soon to be removed, it is only still here to ease the transition to UIDimensions
+    if (shrink_to_fit)
+        set_preferred_size(SpecialDimension::Fit);
 }
 
 bool Widget::has_pending_drop() const

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -312,8 +312,9 @@ public:
     bool load_from_gml(StringView);
     bool load_from_gml(StringView, RefPtr<Core::Object> (*unregistered_child_handler)(String const&));
 
+    // FIXME: remove this when all uses of shrink_to_fit are eliminated
     void set_shrink_to_fit(bool);
-    bool is_shrink_to_fit() const { return m_shrink_to_fit; }
+    bool is_shrink_to_fit() const { return preferred_width().is_shrink() || preferred_height().is_shrink(); }
 
     bool has_pending_drop() const;
 
@@ -402,7 +403,6 @@ private:
     bool m_updates_enabled { true };
     bool m_accepts_emoji_input { false };
     bool m_accepts_command_palette { true };
-    bool m_shrink_to_fit { false };
     bool m_default_font { true };
 
     NonnullRefPtr<Gfx::PaletteImpl> m_palette;

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -18,6 +18,7 @@
 #include <LibGUI/Forward.h>
 #include <LibGUI/GML/AST.h>
 #include <LibGUI/Margins.h>
+#include <LibGUI/UIDimensions.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Orientation.h>
@@ -80,40 +81,43 @@ public:
         return layout;
     }
 
-    Gfx::IntSize min_size() const { return m_min_size; }
-    void set_min_size(Gfx::IntSize const&);
-    void set_min_size(int width, int height) { set_min_size({ width, height }); }
+    UISize min_size() const { return m_min_size; }
+    void set_min_size(UISize const&);
+    void set_min_size(UIDimension width, UIDimension height) { set_min_size({ width, height }); }
 
-    int min_width() const { return m_min_size.width(); }
-    int min_height() const { return m_min_size.height(); }
-    void set_min_width(int width) { set_min_size(width, min_height()); }
-    void set_min_height(int height) { set_min_size(min_width(), height); }
+    UIDimension min_width() const { return m_min_size.width(); }
+    UIDimension min_height() const { return m_min_size.height(); }
+    void set_min_width(UIDimension width) { set_min_size(width, min_height()); }
+    void set_min_height(UIDimension height) { set_min_size(min_width(), height); }
 
-    Gfx::IntSize max_size() const { return m_max_size; }
-    void set_max_size(Gfx::IntSize const&);
-    void set_max_size(int width, int height) { set_max_size({ width, height }); }
+    UISize max_size() const { return m_max_size; }
+    void set_max_size(UISize const&);
+    void set_max_size(UIDimension width, UIDimension height) { set_max_size({ width, height }); }
 
-    int max_width() const { return m_max_size.width(); }
-    int max_height() const { return m_max_size.height(); }
-    void set_max_width(int width) { set_max_size(width, max_height()); }
-    void set_max_height(int height) { set_max_size(max_width(), height); }
+    UIDimension max_width() const { return m_max_size.width(); }
+    UIDimension max_height() const { return m_max_size.height(); }
+    void set_max_width(UIDimension width) { set_max_size(width, max_height()); }
+    void set_max_height(UIDimension height) { set_max_size(max_width(), height); }
 
-    void set_fixed_size(Gfx::IntSize const& size)
+    void set_fixed_size(UISize const& size)
     {
+        VERIFY(size.has_only_int_values());
         set_min_size(size);
         set_max_size(size);
     }
 
-    void set_fixed_size(int width, int height) { set_fixed_size({ width, height }); }
+    void set_fixed_size(UIDimension width, UIDimension height) { set_fixed_size({ width, height }); }
 
-    void set_fixed_width(int width)
+    void set_fixed_width(UIDimension width)
     {
+        VERIFY(width.is_int());
         set_min_width(width);
         set_max_width(width);
     }
 
-    void set_fixed_height(int height)
+    void set_fixed_height(UIDimension height)
     {
+        VERIFY(height.is_int());
         set_min_height(height);
         set_max_height(height);
     }
@@ -377,8 +381,8 @@ private:
     NonnullRefPtr<Gfx::Font> m_font;
     String m_tooltip;
 
-    Gfx::IntSize m_min_size { -1, -1 };
-    Gfx::IntSize m_max_size { -1, -1 };
+    UISize m_min_size { SpecialDimension::Shrink };
+    UISize m_max_size { SpecialDimension::Grow };
     Margins m_grabbable_margins;
 
     bool m_fill_with_background_color { false };

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -99,6 +99,14 @@ public:
     void set_max_width(UIDimension width) { set_max_size(width, max_height()); }
     void set_max_height(UIDimension height) { set_max_size(max_width(), height); }
 
+    UISize preferred_size() const { return m_preferred_size; }
+    void set_preferred_size(UISize const&);
+    void set_preferred_size(UIDimension width, UIDimension height) { set_preferred_size({ width, height }); }
+
+    UIDimension preferred_width() const { return m_preferred_size.width(); }
+    UIDimension preferred_height() const { return m_preferred_size.height(); }
+    void set_preferred_width(UIDimension width) { set_preferred_size(width, preferred_height()); }
+    void set_preferred_height(UIDimension height) { set_preferred_size(preferred_width(), height); }
     void set_fixed_size(UISize const& size)
     {
         VERIFY(size.has_only_int_values());
@@ -383,6 +391,7 @@ private:
 
     UISize m_min_size { SpecialDimension::Shrink };
     UISize m_max_size { SpecialDimension::Grow };
+    UISize m_preferred_size { SpecialDimension::Grow };
     Margins m_grabbable_margins;
 
     bool m_fill_with_background_color { false };

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -723,10 +723,9 @@ void Window::set_main_widget(Widget* widget)
     if (m_main_widget) {
         add_child(*widget);
         auto new_window_rect = rect();
-        if (m_main_widget->min_width() >= 0)
-            new_window_rect.set_width(max(new_window_rect.width(), m_main_widget->min_width()));
-        if (m_main_widget->min_height() >= 0)
-            new_window_rect.set_height(max(new_window_rect.height(), m_main_widget->min_height()));
+        auto new_widget_min_size = m_main_widget->effective_min_size();
+        new_window_rect.set_width(max(new_window_rect.width(), MUST(new_widget_min_size.width().shrink_value())));
+        new_window_rect.set_height(max(new_window_rect.height(), MUST(new_widget_min_size.height().shrink_value())));
         set_rect(new_window_rect);
         m_main_widget->set_relative_rect({ {}, new_window_rect.size() });
         m_main_widget->set_window(this);

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -107,7 +107,7 @@ RefPtr<NotificationWindow> NotificationWindow::get_window_by_id(i32 id)
 void NotificationWindow::resize_to_fit_text()
 {
     auto line_height = m_text_label->font().glyph_height();
-    auto total_height = m_text_label->preferred_height();
+    auto total_height = m_text_label->text_calculated_preferred_height();
 
     m_text_label->set_fixed_height(total_height);
     set_height(40 - line_height + total_height);

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -123,7 +123,7 @@ void NotificationWindow::enter_event(Core::Event&)
 void NotificationWindow::leave_event(Core::Event&)
 {
     m_hovering = false;
-    m_text_label->set_fixed_height(-1);
+    m_text_label->set_preferred_height(GUI::SpecialDimension::Grow);
     set_height(40);
 }
 

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -178,7 +178,7 @@ void ClockWidget::paint_event(GUI::PaintEvent& event)
     Gfx::Font const& font = Gfx::FontDatabase::default_font();
     int const frame_width = frame_thickness();
     int const ideal_width = m_time_width;
-    int const widget_width = max_width();
+    int const widget_width = max_width().as_int();
     int const translation_x = (widget_width - ideal_width) / 2 - frame_width;
 
     painter.draw_text(frame_inner_rect().translated(translation_x, frame_width), time_text, font, Gfx::TextAlignment::CenterLeft, palette().window_text());


### PR DESCRIPTION
This introduces (and already makes use of it in some places) a new dynamic layout system for LibGUI.

It started out as me wanting to have more options than just "shrink_to_fit", like "grow_to_size_of_largest_neighbour", and a preferred size system, and so on and so forth.
After i played around with that for a while i noticed that it had the tendency to get very messy , adding another property to widget for every little layout behavior. (and also needing many of them twice for horizontal and vertical)
This is what i came up with to fix that problem:

Widgets have the following size properties:

- settable sizes: (just normal members of widget)
  - min_size
  - preferred_size
  - max_size
- calculated sizes: (used by subclasses of widget to inform the layout system of custom sizing constraints; e.g. Button text width)
  - calculated_min_size
  - calculated_preferred_size
  - (AFAICT calculated_max_size wouldn't make sense)
- effective sizes: (uses the values of the corresponding settable sizes, or getting a value from the calculated sizes if the settablesizes were set to a special value that indicates that)
  - effective_min_size
  - effective_preferred_size
- UISizes are special tagged union like values, that can either represent int-s ≥0 or special values
  - possible special values:
    - shrink
    - fit
    - opportunistic grow
    - grow
  - implemented as header only, to make the best use of inlining optimizations
  - represented ad strings in GML
  - not every value is permitted for every property (always checked with VERIFY at setter, and point of use, to avoid nastysurprises when more special values are added)

Demos: (some of these features will follow in subsequent PRs, to keep this one small - as requested)

[1](https://cdn.discordapp.com/attachments/830529037251641374/975910055406862336/Bildschirmaufzeichnung_vom_10.05.2022_205320.webm)
[2](https://cdn.discordapp.com/attachments/830529037251641374/975910056094736414/Bildschirmaufzeichnung_vom_17.05.2022_003756.webm)
[3](https://cdn.discordapp.com/attachments/830529037251641374/975910056484798474/file-picker.webm)
[4](https://cdn.discordapp.com/attachments/830529037251641374/981673017174270002/Bildschirmaufzeichnung_vom_01.06.2022_233458.webm)