### PR TITLE
Ports: Update RetroArch configuration

### DIFF
--- a/Ports/RetroArch/patches/0006-Set-default-options-for-SerenityOS.patch
+++ b/Ports/RetroArch/patches/0006-Set-default-options-for-SerenityOS.patch
@@ -204,7 +204,7 @@ index 0000000..088e883
 +
 +# Windowed x resolution scale and y resolution scale
 +# (Real x res: base_size * xscale * aspect_ratio, real y res: base_size * yscale)
-+# video_scale = 3.0
++video_scale = 2.0
 +
 +# Percentage of opacity to use for the window (100 is completely opaque).
 +# video_window_opacity = 100

--- a/Ports/RetroArch/patches/ReadMe.md
+++ b/Ports/RetroArch/patches/ReadMe.md
@@ -31,6 +31,7 @@ Set default options for SerenityOS
 
 Set libretro cores path to `/usr/lib/libretro`
 Set video and audio driver to sdl2
+Set video scale to 2
 Disable vsync
 The libretro core won't keep running in the background when we are in the menu.
 Don't pause gameplay when window focus is lost


### PR DESCRIPTION
Set video scale to 2 (instead of 3 by default) which will improve performance.