### PR TITLE
LibJS: Update order of parameters in our is_less_than implementation

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Array.cpp
@@ -183,15 +183,14 @@ ThrowCompletionOr<double> compare_array_elements(GlobalObject& global_object, Va
     auto* y_string = js_string(vm, TRY(y.to_string(global_object)));
 
     // 7. Let xSmaller be ! IsLessThan(xString, yString, true).
-    // FIXME: Update order of parameters in our is_less_than() impl.
-    auto x_smaller = MUST(is_less_than(global_object, true, x_string, y_string));
+    auto x_smaller = MUST(is_less_than(global_object, x_string, y_string, true));
 
     // 8. If xSmaller is true, return -1𝔽.
     if (x_smaller == TriState::True)
         return -1;
 
     // 9. Let ySmaller be ! IsLessThan(yString, xString, true).
-    auto y_smaller = MUST(is_less_than(global_object, true, y_string, x_string));
+    auto y_smaller = MUST(is_less_than(global_object, y_string, x_string, true));
 
     // 10. If ySmaller is true, return 1𝔽.
     if (y_smaller == TriState::True)

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -875,7 +875,7 @@ ThrowCompletionOr<Value> greater_than(GlobalObject& global_object, Value lhs, Va
     if (lhs.type() == Value::Type::Int32 && rhs.type() == Value::Type::Int32)
         return lhs.as_i32() > rhs.as_i32();
 
-    TriState relation = TRY(is_less_than(global_object, false, lhs, rhs));
+    TriState relation = TRY(is_less_than(global_object, lhs, rhs, false));
     if (relation == TriState::Unknown)
         return Value(false);
     return Value(relation == TriState::True);
@@ -887,7 +887,7 @@ ThrowCompletionOr<Value> greater_than_equals(GlobalObject& global_object, Value 
     if (lhs.type() == Value::Type::Int32 && rhs.type() == Value::Type::Int32)
         return lhs.as_i32() >= rhs.as_i32();
 
-    TriState relation = TRY(is_less_than(global_object, true, lhs, rhs));
+    TriState relation = TRY(is_less_than(global_object, lhs, rhs, true));
     if (relation == TriState::Unknown || relation == TriState::True)
         return Value(false);
     return Value(true);
@@ -899,7 +899,7 @@ ThrowCompletionOr<Value> less_than(GlobalObject& global_object, Value lhs, Value
     if (lhs.type() == Value::Type::Int32 && rhs.type() == Value::Type::Int32)
         return lhs.as_i32() < rhs.as_i32();
 
-    TriState relation = TRY(is_less_than(global_object, true, lhs, rhs));
+    TriState relation = TRY(is_less_than(global_object, lhs, rhs, true));
     if (relation == TriState::Unknown)
         return Value(false);
     return Value(relation == TriState::True);
@@ -911,7 +911,7 @@ ThrowCompletionOr<Value> less_than_equals(GlobalObject& global_object, Value lhs
     if (lhs.type() == Value::Type::Int32 && rhs.type() == Value::Type::Int32)
         return lhs.as_i32() <= rhs.as_i32();
 
-    TriState relation = TRY(is_less_than(global_object, false, lhs, rhs));
+    TriState relation = TRY(is_less_than(global_object, lhs, rhs, false));
     if (relation == TriState::Unknown || relation == TriState::True)
         return Value(false);
     return Value(true);
@@ -1523,7 +1523,7 @@ ThrowCompletionOr<bool> is_loosely_equal(GlobalObject& global_object, Value lhs,
 }
 
 // 7.2.13 IsLessThan ( x, y, LeftFirst ), https://tc39.es/ecma262/#sec-islessthan
-ThrowCompletionOr<TriState> is_less_than(GlobalObject& global_object, bool left_first, Value lhs, Value rhs)
+ThrowCompletionOr<TriState> is_less_than(GlobalObject& global_object, Value lhs, Value rhs, bool left_first)
 {
     Value x_primitive;
     Value y_primitive;

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -429,7 +429,7 @@ bool is_strictly_equal(Value lhs, Value rhs);
 bool same_value(Value lhs, Value rhs);
 bool same_value_zero(Value lhs, Value rhs);
 bool same_value_non_numeric(Value lhs, Value rhs);
-ThrowCompletionOr<TriState> is_less_than(GlobalObject&, bool left_first, Value lhs, Value rhs);
+ThrowCompletionOr<TriState> is_less_than(GlobalObject&, Value lhs, Value rhs, bool left_first);
 
 double to_integer_or_infinity(double);
 


### PR DESCRIPTION
This change updates the parameter order of the is_less_than function
signature and calls to match accordingly with the spec
(https://tc39.es/ecma262/#sec-islessthan)