### PR TITLE
LibWeb: Fix regression in painting the 'caret' icon on GitHub

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.h
@@ -56,7 +56,7 @@ struct BordersData {
     CSS::BorderData bottom;
     CSS::BorderData left;
 };
-void paint_border(PaintContext& context, BorderEdge edge, Gfx::IntRect const& rect, BordersData const& borders_data);
+void paint_border(PaintContext& context, BorderEdge edge, Gfx::IntRect const& rect, BorderRadiiData const& border_radii_data, BordersData const& borders_data);
 void paint_all_borders(PaintContext& context, Gfx::FloatRect const& bordered_rect, BorderRadiiData const& border_radii_data, BordersData const&);
 
 }


### PR DESCRIPTION
Before (note the missing caret on the code & branch buttons):
![image](https://user-images.githubusercontent.com/11597044/173577853-88d9fc30-df37-4995-9139-29caf994d33c.png)

After:
![image](https://user-images.githubusercontent.com/11597044/173577985-1b7845db-bd4f-45a3-9f6c-479952df970d.png)
