### PR TITLE
DisplaySettings: Use absolute path for loading mouse settings icon

### DIFF
--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
@@ -48,7 +48,7 @@ ThemesSettingsWidget::ThemesSettingsWidget(bool& background_settings_changed)
     };
     m_themes_combo->set_selected_index(current_theme_index, GUI::AllowCallback::No);
 
-    auto mouse_settings_icon = Gfx::Bitmap::try_load_from_file("res/icons/16x16/app-mouse.png").release_value_but_fixme_should_propagate_errors();
+    auto mouse_settings_icon = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-mouse.png").release_value_but_fixme_should_propagate_errors();
     m_cursor_themes_button = *find_descendant_of_type_named<GUI::Button>("cursor_themes_button");
     m_cursor_themes_button->set_icon(mouse_settings_icon);
     m_cursor_themes_button->on_click = [&](auto) {


### PR DESCRIPTION
This pull request fixes `DisplaySettings` crashing when launching it from a non root working directory.