### PR TITLE
LibWeb(+LibWebView+WebContent): Handle double clicks

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -542,7 +542,8 @@ bool EventHandler::handle_doubleclick(Gfx::IntPoint const& position, unsigned bu
     if (!node || !layout_node)
         return false;
 
-    // FIXME: Dispatch 'dblclick' events.
+    auto offset = compute_mouse_event_offset(position, *layout_node);
+    node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(UIEvents::EventNames::dblclick, offset.x(), offset.y(), position.x(), position.y(), button));
 
     // FIXME: Select word
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -26,6 +26,7 @@ public:
     bool handle_mousedown(Gfx::IntPoint const&, unsigned button, unsigned modifiers);
     bool handle_mousemove(Gfx::IntPoint const&, unsigned buttons, unsigned modifiers);
     bool handle_mousewheel(Gfx::IntPoint const&, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
+    bool handle_doubleclick(Gfx::IntPoint const&, unsigned buttons, unsigned modifiers);
 
     bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);
     bool handle_keyup(KeyCode, unsigned modifiers, u32 code_point);

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -79,6 +79,11 @@ bool Page::handle_mousemove(Gfx::IntPoint const& position, unsigned buttons, uns
     return top_level_browsing_context().event_handler().handle_mousemove(position, buttons, modifiers);
 }
 
+bool Page::handle_doubleclick(Gfx::IntPoint const& position, unsigned button, unsigned modifiers)
+{
+    return top_level_browsing_context().event_handler().handle_doubleclick(position, button, modifiers);
+}
+
 bool Page::handle_keydown(KeyCode key, unsigned modifiers, u32 code_point)
 {
     return focused_context().event_handler().handle_keydown(key, modifiers, code_point);

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -51,6 +51,7 @@ public:
     bool handle_mousedown(Gfx::IntPoint const&, unsigned button, unsigned modifiers);
     bool handle_mousemove(Gfx::IntPoint const&, unsigned buttons, unsigned modifiers);
     bool handle_mousewheel(Gfx::IntPoint const&, unsigned button, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
+    bool handle_doubleclick(Gfx::IntPoint const&, unsigned buttons, unsigned modifiers);
 
     bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);
     bool handle_keyup(KeyCode, unsigned modifiers, u32 code_point);

--- a/Userland/Libraries/LibWeb/UIEvents/EventNames.h
+++ b/Userland/Libraries/LibWeb/UIEvents/EventNames.h
@@ -15,6 +15,7 @@ namespace Web::UIEvents::EventNames {
 
 #define ENUMERATE_UI_EVENTS          \
     __ENUMERATE_UI_EVENT(click)      \
+    __ENUMERATE_UI_EVENT(dblclick)   \
     __ENUMERATE_UI_EVENT(keydown)    \
     __ENUMERATE_UI_EVENT(keyup)      \
     __ENUMERATE_UI_EVENT(mousedown)  \

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -184,6 +184,11 @@ void OutOfProcessWebView::mousewheel_event(GUI::MouseEvent& event)
     client().async_mouse_wheel(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
 }
 
+void OutOfProcessWebView::doubleclick_event(GUI::MouseEvent& event)
+{
+    client().async_doubleclick(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers());
+}
+
 void OutOfProcessWebView::theme_change_event(GUI::ThemeChangeEvent& event)
 {
     GUI::AbstractScrollableWidget::theme_change_event(event);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -123,6 +123,7 @@ private:
     virtual void mouseup_event(GUI::MouseEvent&) override;
     virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void mousewheel_event(GUI::MouseEvent&) override;
+    virtual void doubleclick_event(GUI::MouseEvent&) override;
     virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void keyup_event(GUI::KeyEvent&) override;
     virtual void theme_change_event(GUI::ThemeChangeEvent&) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -163,6 +163,11 @@ void ConnectionFromClient::mouse_wheel(Gfx::IntPoint const& position, unsigned i
     page().handle_mousewheel(position, button, modifiers, wheel_delta_x, wheel_delta_y);
 }
 
+void ConnectionFromClient::doubleclick(Gfx::IntPoint const& position, unsigned int button, [[maybe_unused]] unsigned int buttons, unsigned int modifiers)
+{
+    page().handle_doubleclick(position, button, modifiers);
+}
+
 void ConnectionFromClient::key_down(i32 key, unsigned int modifiers, u32 code_point)
 {
     page().handle_keydown((KeyCode)key, modifiers, code_point);

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -48,6 +48,7 @@ private:
     virtual void mouse_move(Gfx::IntPoint const&, unsigned, unsigned, unsigned) override;
     virtual void mouse_up(Gfx::IntPoint const&, unsigned, unsigned, unsigned) override;
     virtual void mouse_wheel(Gfx::IntPoint const&, unsigned, unsigned, unsigned, i32, i32) override;
+    virtual void doubleclick(Gfx::IntPoint const&, unsigned, unsigned, unsigned) override;
     virtual void key_down(i32, unsigned, u32) override;
     virtual void key_up(i32, unsigned, u32) override;
     virtual void add_backing_store(i32, Gfx::ShareableBitmap const&) override;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -23,6 +23,7 @@ endpoint WebContentServer
     mouse_move(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers) =|
     mouse_up(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers) =|
     mouse_wheel(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
+    doubleclick(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers) =|
 
     key_down(i32 key, unsigned modifiers, u32 code_point) =|
     key_up(i32 key, unsigned modifiers, u32 code_point) =|


### PR DESCRIPTION
- **LibWeb: Add stub implementation for handling doubleclicks**
- **LibWeb+LibWebView+WebContent: Get doubleclick events from LibGUI**
- **LibWeb: Dispatch `dblclick` UI Events on double click**

  https://user-images.githubusercontent.com/16520278/173686406-f0fa1914-e2f2-420b-b757-3a7cafaff6d7.mp4

- **LibWeb: Make doubleclicking select the nearest word**

  https://user-images.githubusercontent.com/16520278/173686389-513d11dc-ab04-4b08-bd88-869eb05146de.mp4
