### PR TITLE
DevTools/HackStudio: Fix possible crash when Make does not exist

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1078,6 +1078,10 @@ void HackStudioWidget::build()
     auto result = m_project_builder->build(active_file());
     if (result.is_error()) {
         GUI::MessageBox::show(window(), String::formatted("{}", result.error()), "Build failed", GUI::MessageBox::Type::Error);
+        m_build_action->set_enabled(true);
+        m_stop_action->set_enabled(false);
+    } else {
+        m_stop_action->set_enabled(true);
     }
 }
 
@@ -1086,6 +1090,10 @@ void HackStudioWidget::run()
     auto result = m_project_builder->run(active_file());
     if (result.is_error()) {
         GUI::MessageBox::show(window(), String::formatted("{}", result.error()), "Run failed", GUI::MessageBox::Type::Error);
+        m_run_action->set_enabled(true);
+        m_stop_action->set_enabled(false);
+    } else {
+        m_stop_action->set_enabled(true);
     }
 }
 
@@ -1227,7 +1235,6 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_build_action()
 
         reveal_action_tab(*m_terminal_wrapper);
         build();
-        m_stop_action->set_enabled(true);
     });
 }
 
@@ -1236,7 +1243,6 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_run_action()
     return GUI::Action::create("&Run", { Mod_Ctrl, Key_R }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/program-run.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
         reveal_action_tab(*m_terminal_wrapper);
         run();
-        m_stop_action->set_enabled(true);
     });
 }
 

--- a/Userland/DevTools/HackStudio/ProjectBuilder.cpp
+++ b/Userland/DevTools/HackStudio/ProjectBuilder.cpp
@@ -40,6 +40,7 @@ ErrorOr<void> ProjectBuilder::build(StringView active_file)
     }
 
     if (m_is_serenity == IsSerenityRepo::No) {
+        TRY(verify_make_is_installed());
         TRY(m_terminal->run_command("make"));
         return {};
     }
@@ -65,6 +66,7 @@ ErrorOr<void> ProjectBuilder::run(StringView active_file)
     }
 
     if (m_is_serenity == IsSerenityRepo::No) {
+        TRY(verify_make_is_installed());
         TRY(m_terminal->run_command("make run"));
         return {};
     }
@@ -102,6 +104,7 @@ ErrorOr<void> ProjectBuilder::update_active_file(StringView active_file)
 
 ErrorOr<void> ProjectBuilder::build_serenity_component()
 {
+    TRY(verify_make_is_installed());
     TRY(m_terminal->run_command(String::formatted("make {}", m_serenity_component_name), build_directory(), TerminalWrapper::WaitForExit::Yes, "Make failed"sv));
     return {};
 }
@@ -253,6 +256,14 @@ ErrorOr<void> ProjectBuilder::verify_cmake_is_installed()
     if (!res.is_error() && res.value().exit_code == 0)
         return {};
     return Error::from_string_literal("CMake port is not installed"sv);
+}
+
+ErrorOr<void> ProjectBuilder::verify_make_is_installed()
+{
+    auto res = Core::command("make --version", {});
+    if (!res.is_error() && res.value().exit_code == 0)
+        return {};
+    return Error::from_string_literal("Make port is not installed"sv);
 }
 
 String ProjectBuilder::build_directory() const

--- a/Userland/DevTools/HackStudio/ProjectBuilder.h
+++ b/Userland/DevTools/HackStudio/ProjectBuilder.h
@@ -47,6 +47,7 @@ private:
     static void for_each_library_dependencies(Function<void(String, Vector<StringView>)>);
     static ErrorOr<String> component_name(StringView cmake_file_path);
     static ErrorOr<void> verify_cmake_is_installed();
+    static ErrorOr<void> verify_make_is_installed();
 
     String m_project_root;
     Project const& m_project;


### PR DESCRIPTION
HackStudio being crashed when have not the Make and CMake ports if we are trying to click build and run buttons and they
do not change the their 'active' field simultaneously after the error message pushed as message box. If there's no any 'make' installed, we are pushing a message when we need 'make'.

After these changes we are not getting crashed for these things we are taking the output of build system.