### PR TITLE
LibGUI: Draw scrollbar buttons as triangles, and make the draw_triangle function symmetric

### DIFF
--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -19,56 +19,28 @@ REGISTER_WIDGET(GUI, Scrollbar)
 
 namespace GUI {
 
-static constexpr Gfx::CharacterBitmap s_up_arrow_bitmap {
-    "         "
-    "         "
-    "         "
-    "    #    "
-    "   ###   "
-    "  #####  "
-    " ####### "
-    "         "
-    "         ",
-    9, 9
+static constexpr AK::Array<Gfx::IntPoint, 3> s_up_arrow_coords = {
+    Gfx::IntPoint { 4, 2 },
+    Gfx::IntPoint { 1, 5 },
+    Gfx::IntPoint { 7, 5 },
 };
 
-static constexpr Gfx::CharacterBitmap s_down_arrow_bitmap {
-    "         "
-    "         "
-    "         "
-    " ####### "
-    "  #####  "
-    "   ###   "
-    "    #    "
-    "         "
-    "         ",
-    9, 9
+static constexpr AK::Array<Gfx::IntPoint, 3> s_down_arrow_coords = {
+    Gfx::IntPoint { 1, 3 },
+    Gfx::IntPoint { 7, 3 },
+    Gfx::IntPoint { 4, 6 },
 };
 
-static constexpr Gfx::CharacterBitmap s_left_arrow_bitmap {
-    "         "
-    "     #   "
-    "    ##   "
-    "   ###   "
-    "  ####   "
-    "   ###   "
-    "    ##   "
-    "     #   "
-    "         ",
-    9, 9
+static constexpr AK::Array<Gfx::IntPoint, 3> s_left_arrow_coords = {
+    Gfx::IntPoint { 5, 1 },
+    Gfx::IntPoint { 2, 4 },
+    Gfx::IntPoint { 5, 7 },
 };
 
-static constexpr Gfx::CharacterBitmap s_right_arrow_bitmap {
-    "         "
-    "   #     "
-    "   ##    "
-    "   ###   "
-    "   ####  "
-    "   ###   "
-    "   ##    "
-    "   #     "
-    "         ",
-    9, 9
+static constexpr AK::Array<Gfx::IntPoint, 3> s_right_arrow_coords = {
+    Gfx::IntPoint { 3, 1 },
+    Gfx::IntPoint { 6, 4 },
+    Gfx::IntPoint { 3, 7 },
 };
 
 Scrollbar::Scrollbar(Orientation orientation)
@@ -241,15 +213,15 @@ void Scrollbar::paint_event(PaintEvent& event)
         if (decrement_pressed)
             decrement_location.translate_by(1, 1);
         if (!has_scrubber() || !is_enabled())
-            painter.draw_bitmap(decrement_location.translated(1, 1), orientation() == Orientation::Vertical ? s_up_arrow_bitmap : s_left_arrow_bitmap, palette().threed_highlight());
-        painter.draw_bitmap(decrement_location, orientation() == Orientation::Vertical ? s_up_arrow_bitmap : s_left_arrow_bitmap, (has_scrubber() && is_enabled()) ? palette().button_text() : palette().threed_shadow1());
+            painter.draw_triangle(decrement_location + Gfx::IntPoint { 1, 1 }, orientation() == Orientation::Vertical ? s_up_arrow_coords : s_left_arrow_coords, palette().threed_highlight());
+        painter.draw_triangle(decrement_location, orientation() == Orientation::Vertical ? s_up_arrow_coords : s_left_arrow_coords, (has_scrubber() && is_enabled()) ? palette().button_text() : palette().threed_shadow1());
 
         auto increment_location = increment_button_rect().location().translated(3, 3);
         if (increment_pressed)
             increment_location.translate_by(1, 1);
         if (!has_scrubber() || !is_enabled())
-            painter.draw_bitmap(increment_location.translated(1, 1), orientation() == Orientation::Vertical ? s_down_arrow_bitmap : s_right_arrow_bitmap, palette().threed_highlight());
-        painter.draw_bitmap(increment_location, orientation() == Orientation::Vertical ? s_down_arrow_bitmap : s_right_arrow_bitmap, (has_scrubber() && is_enabled()) ? palette().button_text() : palette().threed_shadow1());
+            painter.draw_triangle(increment_location + Gfx::IntPoint { 1, 1 }, orientation() == Orientation::Vertical ? s_down_arrow_coords : s_right_arrow_coords, palette().threed_highlight());
+        painter.draw_triangle(increment_location, orientation() == Orientation::Vertical ? s_down_arrow_coords : s_right_arrow_coords, (has_scrubber() && is_enabled()) ? palette().button_text() : palette().threed_shadow1());
     }
 
     if (has_scrubber() && !scrubber_rect().is_null())

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -671,6 +671,12 @@ void Painter::draw_bitmap(IntPoint const& p, GlyphBitmap const& bitmap, Color co
     }
 }
 
+void Painter::draw_triangle(IntPoint const& offset, Span<IntPoint const> control_points, Color color)
+{
+    VERIFY(control_points.size() == 3);
+    draw_triangle(control_points[0] + offset, control_points[1] + offset, control_points[2] + offset, color);
+}
+
 void Painter::draw_triangle(IntPoint const& a, IntPoint const& b, IntPoint const& c, Color color)
 {
     IntPoint p0(to_physical(a));

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -695,6 +695,10 @@ void Painter::draw_triangle(IntPoint const& a, IntPoint const& b, IntPoint const
     if (p0.y() == p2.y())
         return;
 
+    // return if all points are on the same line vertically
+    if (p0.x() == p1.x() && p1.x() == p2.x())
+        return;
+
     // return if top is below clip rect or bottom is above clip rect
     auto clip = clip_rect();
     if (p0.y() >= clip.bottom())
@@ -702,56 +706,78 @@ void Painter::draw_triangle(IntPoint const& a, IntPoint const& b, IntPoint const
     if (p2.y() < clip.top())
         return;
 
+    class BoundaryLine {
+    private:
+        IntPoint m_base {};
+        IntPoint m_path {};
+
+    public:
+        BoundaryLine(IntPoint a, IntPoint b)
+        {
+            VERIFY(a.y() <= b.y());
+            m_base = a;
+            m_path = b - a;
+        }
+
+        int top_y() const { return m_base.y(); }
+
+        int bottom_y() const { return m_base.y() + m_path.y(); }
+
+        bool is_vertical() const { return m_path.x() == 0; }
+
+        bool is_horizontal() const { return m_path.y() == 0; }
+
+        bool in_y_range(int y) const { return y >= top_y() && y <= bottom_y(); }
+
+        Optional<int> intersection_on_x(int y) const
+        {
+            if (!in_y_range(y))
+                return {};
+            if (is_horizontal())
+                return {};
+            if (is_vertical())
+                return m_base.x();
+
+            int y_diff = y - top_y();
+            int x_d = m_path.x() * y_diff, y_d = m_path.y();
+
+            return (x_d / y_d) + m_base.x();
+        }
+    };
+
+    BoundaryLine l0(p0, p1), l1(p0, p2), l2(p1, p2);
+
     int rgba = color.value();
 
-    float dx02 = (float)(p2.x() - p0.x()) / (p2.y() - p0.y());
-    float x01 = p0.x();
-    float x02 = p0.x();
+    for (int y = max(p0.y(), clip.top()); y <= min(p2.y(), clip.bottom()); y++) {
+        Optional<int>
+            x0 = l0.intersection_on_x(y),
+            x1 = l1.intersection_on_x(y),
+            x2 = l2.intersection_on_x(y);
 
-    if (p0.y() != p1.y()) { // p0 and p1 are on different lines
-        float dx01 = (float)(p1.x() - p0.x()) / (p1.y() - p0.y());
+        int result_a = 0, result_b = 0;
 
-        int top = p0.y();
-        if (top < clip.top()) {
-            x01 += dx01 * (clip.top() - top);
-            x02 += dx02 * (clip.top() - top);
-            top = clip.top();
-        }
-
-        for (int y = top; y < p1.y() && y < clip.bottom(); ++y) { // XXX <=?
-            int start = x01 > x02 ? max((int)x02, clip.left()) : max((int)x01, clip.left());
-            int end = x01 > x02 ? min((int)x01, clip.right()) : min((int)x02, clip.right());
-            auto* scanline = m_target->scanline(y);
-            for (int x = start; x < end; x++) {
-                scanline[x] = rgba;
+        if (x0.has_value()) {
+            result_a = x0.value();
+            if (x1.has_value() && ((!x2.has_value()) || (result_a != x1.value()))) {
+                result_b = x1.value();
+            } else {
+                result_b = x2.value();
             }
-            x01 += dx01;
-            x02 += dx02;
+        } else if (x1.has_value()) {
+            result_a = x1.value();
+            result_b = x2.value();
         }
-    }
 
-    // return if middle point and bottom point are on same line
-    if (p1.y() == p2.y())
-        return;
+        if (result_a > result_b)
+            swap(result_a, result_b);
 
-    float x12 = p1.x();
-    float dx12 = (float)(p2.x() - p1.x()) / (p2.y() - p1.y());
-    int top = p1.y();
-    if (top < clip.top()) {
-        x02 += dx02 * (clip.top() - top);
-        x12 += dx12 * (clip.top() - top);
-        top = clip.top();
-    }
+        int left_bound = result_a, right_bound = result_b;
 
-    for (int y = top; y < p2.y() && y < clip.bottom(); ++y) { // XXX <=?
-        int start = x12 > x02 ? max((int)x02, clip.left()) : max((int)x12, clip.left());
-        int end = x12 > x02 ? min((int)x12, clip.right()) : min((int)x02, clip.right());
-        auto* scanline = m_target->scanline(y);
-        for (int x = start; x < end; x++) {
+        ARGB32* scanline = m_target->scanline(y);
+        for (int x = max(left_bound, clip.left()); x <= min(right_bound, clip.right()); x++) {
             scanline[x] = rgba;
         }
-        x02 += dx02;
-        x12 += dx12;
     }
 }
 

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -57,6 +57,7 @@ public:
     void draw_scaled_bitmap(IntRect const& dst_rect, Gfx::Bitmap const&, IntRect const& src_rect, float opacity = 1.0f, ScalingMode = ScalingMode::NearestNeighbor);
     void draw_scaled_bitmap(IntRect const& dst_rect, Gfx::Bitmap const&, FloatRect const& src_rect, float opacity = 1.0f, ScalingMode = ScalingMode::NearestNeighbor);
     void draw_triangle(IntPoint const&, IntPoint const&, IntPoint const&, Color);
+    void draw_triangle(IntPoint const& offset, Span<IntPoint const>, Color);
     void draw_ellipse_intersecting(IntRect const&, Color, int thickness = 1);
     void set_pixel(IntPoint const&, Color, bool blend = false);
     void set_pixel(int x, int y, Color color, bool blend = false) { set_pixel({ x, y }, color, blend); }

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -22,14 +22,14 @@ class Point {
 public:
     Point() = default;
 
-    Point(T x, T y)
+    constexpr Point(T x, T y)
         : m_x(x)
         , m_y(y)
     {
     }
 
     template<typename U>
-    Point(U x, U y)
+    constexpr Point(U x, U y)
         : m_x(x)
         , m_y(y)
     {


### PR DESCRIPTION
This changes the arrows on the scrollbar buttons from hard coded bitmaps to being drawn as triangles.
Apart from arguably being more elegant (although less simple), this lays the groundwork to have them scaled for HIDPI once the necessary changes to the painter and window back store are done.

To enable this, I had to rewrite the draw_triangle function to be symmetrical. Because prior to this, the same triangle would be rendered differently depending on the direction it faced. You can simply have a look at this by compiling this at the commit before the re implementation of draw_triangle, you will see that triangles on the scrollbar buttons all look slightly different.