### PR TITLE
LibC: Improves performance function time_to_tm

### DIFF
--- a/AK/Time.h
+++ b/AK/Time.h
@@ -26,7 +26,7 @@ concept TimeSpecType = requires(T t)
     t.tv_nsec;
 };
 
-constexpr bool is_leap_year(int year)
+constexpr bool is_leap_year(i64 year)
 {
     return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
 }
@@ -35,7 +35,7 @@ constexpr bool is_leap_year(int year)
 // The return value is 0-indexed, that is 0 is Sunday, 1 is Monday, etc.
 // Day may be negative or larger than the number of days
 // in the given month.
-unsigned day_of_week(int year, unsigned month, int day);
+unsigned day_of_week(i64 year, unsigned month, int day);
 
 // Month and day start at 1. Month must be >= 1 and <= 12.
 // The return value is 0-indexed, that is Jan 1 is day 0.
@@ -56,9 +56,9 @@ constexpr int day_of_year(int year, unsigned month, int day)
 }
 
 // Month starts at 1. Month must be >= 1 and <= 12.
-int days_in_month(int year, unsigned month);
+int days_in_month(i64 year, unsigned month);
 
-constexpr int days_in_year(int year)
+constexpr int days_in_year(i64 year)
 {
     return 365 + (is_leap_year(year) ? 1 : 0);
 }

--- a/Tests/AK/TestTime.cpp
+++ b/Tests/AK/TestTime.cpp
@@ -274,3 +274,10 @@ TEST_CASE(is_negative)
     EXPECT_EQ(result.to_nanoseconds(), 5);
     EXPECT(!result.is_negative());
 }
+
+TEST_CASE(day_of_week)
+{
+    EXPECT_EQ(day_of_week(-2147481748, 1, 1), 4u);
+    EXPECT_EQ(day_of_week(1970, 1, 1), 4u);
+    EXPECT_EQ(day_of_week(2147485547, 12, 31), 3u);
+}

--- a/Tests/LibC/TestLibCTime.cpp
+++ b/Tests/LibC/TestLibCTime.cpp
@@ -119,3 +119,34 @@ TEST_CASE(tzset)
     EXPECT_EQ(tzname[0], "CET"sv);
     EXPECT_EQ(tzname[1], "CEST"sv);
 }
+
+TEST_CASE(localtime)
+{
+    TimeZoneGuard guard("UTC");
+
+    // Minimum valid: Thu Jan  1 00:00:00 -2147481748;
+    time_t minimum_possible_epoch = -67768040609740800;
+    auto minimum_tm = localtime(&minimum_possible_epoch);
+
+    EXPECT_EQ(minimum_tm->tm_sec, 0);
+    EXPECT_EQ(minimum_tm->tm_min, 0);
+    EXPECT_EQ(minimum_tm->tm_hour, 0);
+    EXPECT_EQ(minimum_tm->tm_mday, 1);
+    EXPECT_EQ(minimum_tm->tm_mon, 0);
+    EXPECT_EQ(minimum_tm->tm_year, -2147481748 - 1900);
+    EXPECT_EQ(minimum_tm->tm_wday, 4);
+    EXPECT_EQ(minimum_tm->tm_yday, 0);
+
+    // Maximum allowed: Wed Dec 31 23:59:59 2147485547
+    time_t max_possible_epoch = 67768036191676799;
+    auto maximum_tm = localtime(&max_possible_epoch);
+
+    EXPECT_EQ(maximum_tm->tm_sec, 59);
+    EXPECT_EQ(maximum_tm->tm_min, 59);
+    EXPECT_EQ(maximum_tm->tm_hour, 23);
+    EXPECT_EQ(maximum_tm->tm_mday, 31);
+    EXPECT_EQ(maximum_tm->tm_mon, 11);
+    EXPECT_EQ(maximum_tm->tm_year, 2147485547 - 1900);
+    EXPECT_EQ(maximum_tm->tm_wday, 3);
+    EXPECT_EQ(maximum_tm->tm_yday, 364);
+}

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -102,7 +102,12 @@ static struct tm* time_to_tm(struct tm* tm, time_t t)
         return nullptr;
     }
 
-    i64 year = 1970;
+    // In gregorian calendar, there is a 400 years cycle in which there are 97 leap and 303 common years.
+    constexpr time_t seconds_in_400_years = 12622780800;
+    i64 amount_of_400_year_cycles = t / seconds_in_400_years;
+    t %= seconds_in_400_years;
+
+    i64 year = 1970 + 400 * amount_of_400_year_cycles;
     for (; t >= days_in_year(year) * __seconds_per_day; ++year)
         t -= days_in_year(year) * __seconds_per_day;
     for (; t < 0; --year)

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -102,7 +102,7 @@ static struct tm* time_to_tm(struct tm* tm, time_t t)
         return nullptr;
     }
 
-    int year = 1970;
+    i64 year = 1970;
     for (; t >= days_in_year(year) * __seconds_per_day; ++year)
         t -= days_in_year(year) * __seconds_per_day;
     for (; t < 0; --year)


### PR DESCRIPTION

Fixes #12729

This approach makes use of the cyclicity of years in the gregorian calendar. 
Added some basic unit tests too as well as changed some variables to prevent some actual year ( tm->year + 1900) to overflow.