### PR TITLE
Kernel+Audio: Make hardware audio buffer size flexible

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -199,6 +199,28 @@ public:
         m_value /= other;
     }
 
+    constexpr void saturating_sub(T other)
+    {
+        sub(other);
+        // Depending on whether other was positive or negative, we have to saturate to min or max.
+        if (m_overflow && other <= 0)
+            m_value = NumericLimits<T>::max();
+        else if (m_overflow)
+            m_value = NumericLimits<T>::min();
+        m_overflow = false;
+    }
+
+    constexpr void saturating_add(T other)
+    {
+        add(other);
+        // Depending on whether other was positive or negative, we have to saturate to max or min.
+        if (m_overflow && other >= 0)
+            m_value = NumericLimits<T>::max();
+        else if (m_overflow)
+            m_value = NumericLimits<T>::min();
+        m_overflow = false;
+    }
+
     constexpr Checked& operator+=(Checked const& other)
     {
         m_overflow |= other.m_overflow;

--- a/Kernel/Devices/Audio/AC97.cpp
+++ b/Kernel/Devices/Audio/AC97.cpp
@@ -207,12 +207,12 @@ ErrorOr<size_t> AC97::write(size_t channel_index, UserOrKernelBuffer const& data
         m_buffer_descriptor_list = TRY(MM.allocate_dma_buffer_pages(buffer_descriptor_list_size, "AC97 Buffer Descriptor List"sv, Memory::Region::Access::Write));
     }
 
-    auto remaining = length;
+    Checked<size_t> remaining = length;
     size_t offset = 0;
-    while (remaining > 0) {
-        TRY(write_single_buffer(data, offset, min(remaining, PAGE_SIZE)));
+    while (remaining > static_cast<size_t>(0)) {
+        TRY(write_single_buffer(data, offset, min(remaining.value(), PAGE_SIZE)));
         offset += PAGE_SIZE;
-        remaining -= PAGE_SIZE;
+        remaining.saturating_sub(PAGE_SIZE);
     }
 
     return length;

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -20,8 +20,6 @@
 
 namespace AudioServer {
 
-u8 Mixer::m_zero_filled_buffer[4096];
-
 Mixer::Mixer(NonnullRefPtr<Core::ConfigFile> config)
     // FIXME: Allow AudioServer to use other audio channels as well
     : m_device(Core::File::construct("/dev/audio/0", this))
@@ -74,8 +72,7 @@ void Mixer::mix()
 
         active_mix_queues.remove_all_matching([&](auto& entry) { return !entry->client(); });
 
-        Audio::Sample mixed_buffer[1024];
-        auto mixed_buffer_length = (int)(sizeof(mixed_buffer) / sizeof(Audio::Sample));
+        Array<Audio::Sample, HARDWARE_BUFFER_SIZE> mixed_buffer;
 
         m_main_volume.advance_time();
 
@@ -89,8 +86,7 @@ void Mixer::mix()
             ++active_queues;
             queue->volume().advance_time();
 
-            for (int i = 0; i < mixed_buffer_length; ++i) {
-                auto& mixed_sample = mixed_buffer[i];
+            for (auto& mixed_sample : mixed_buffer) {
                 Audio::Sample sample;
                 if (!queue->get_next_sample(sample))
                     break;
@@ -103,13 +99,12 @@ void Mixer::mix()
         }
 
         if (m_muted) {
-            m_device->write(m_zero_filled_buffer, sizeof(m_zero_filled_buffer));
+            m_device->write(m_zero_filled_buffer.data(), static_cast<int>(m_zero_filled_buffer.size()));
         } else {
-            Array<u8, 4096> buffer;
+            Array<u8, HARDWARE_BUFFER_SIZE_BYTES> buffer;
             OutputMemoryStream stream { buffer };
 
-            for (int i = 0; i < mixed_buffer_length; ++i) {
-                auto& mixed_sample = mixed_buffer[i];
+            for (auto& mixed_sample : mixed_buffer) {
 
                 // Even though it's not realistic, the user expects no sound at 0%.
                 if (m_main_volume < 0.01)
@@ -128,7 +123,7 @@ void Mixer::mix()
 
             VERIFY(stream.is_end());
             VERIFY(!stream.has_any_error());
-            m_device->write(stream.data(), stream.size());
+            m_device->write(stream.data(), static_cast<int>(stream.size()));
         }
     }
 }

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -97,7 +97,7 @@ void Mixer::mix()
                 if (queue->is_muted())
                     continue;
                 sample.log_multiply(SAMPLE_HEADROOM);
-                sample.log_multiply(queue->volume());
+                sample.log_multiply(static_cast<float>(queue->volume()));
                 mixed_sample += sample;
             }
         }
@@ -115,14 +115,14 @@ void Mixer::mix()
                 if (m_main_volume < 0.01)
                     mixed_sample = Audio::Sample { 0 };
                 else
-                    mixed_sample.log_multiply(m_main_volume);
+                    mixed_sample.log_multiply(static_cast<float>(m_main_volume));
                 mixed_sample.clip();
 
                 LittleEndian<i16> out_sample;
-                out_sample = mixed_sample.left * NumericLimits<i16>::max();
+                out_sample = static_cast<i16>(mixed_sample.left * NumericLimits<i16>::max());
                 stream << out_sample;
 
-                out_sample = mixed_sample.right * NumericLimits<i16>::max();
+                out_sample = static_cast<i16>(mixed_sample.right * NumericLimits<i16>::max());
                 stream << out_sample;
             }
 

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -29,6 +29,10 @@ namespace AudioServer {
 // Headroom, i.e. fixed attenuation for all audio streams.
 // This is to prevent clipping when two streams with low headroom (e.g. normalized & compressed) are playing.
 constexpr double SAMPLE_HEADROOM = 0.95;
+// The size of the buffer in samples that the hardware receives through write() calls to the audio device.
+constexpr size_t HARDWARE_BUFFER_SIZE = 1024;
+// The hardware buffer size in bytes; there's two channels of 16-bit samples.
+constexpr size_t HARDWARE_BUFFER_SIZE_BYTES = HARDWARE_BUFFER_SIZE * 2 * sizeof(i16);
 
 class ConnectionFromClient;
 
@@ -129,7 +133,7 @@ private:
     NonnullRefPtr<Core::ConfigFile> m_config;
     RefPtr<Core::Timer> m_config_write_timer;
 
-    static u8 m_zero_filled_buffer[4096];
+    Array<u8, HARDWARE_BUFFER_SIZE_BYTES> m_zero_filled_buffer;
 
     void mix();
 };

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -30,7 +30,7 @@ namespace AudioServer {
 // This is to prevent clipping when two streams with low headroom (e.g. normalized & compressed) are playing.
 constexpr double SAMPLE_HEADROOM = 0.95;
 // The size of the buffer in samples that the hardware receives through write() calls to the audio device.
-constexpr size_t HARDWARE_BUFFER_SIZE = 1024;
+constexpr size_t HARDWARE_BUFFER_SIZE = 512;
 // The hardware buffer size in bytes; there's two channels of 16-bit samples.
 constexpr size_t HARDWARE_BUFFER_SIZE_BYTES = HARDWARE_BUFFER_SIZE * 2 * sizeof(i16);
 


### PR DESCRIPTION
This is a collection of commits and bugfixes that allow kernel and userland to deal with audio buffers of any size, only restricted by the hardware limits. For now, this also lowers AudioServer's buffer size to 512 samples, reducing the system latency by >10ms!

The limitation is now QEMU's audio polling rate of 10ms, which appears to be a constant at least on Windows with DirectSound. A bug has been filed [here](https://gitlab.com/qemu-project/qemu/-/issues/1076) which includes some of this PR's commits as a bug-exhibiting patch.

**I need confirmational testing that this doesn't glitch out audio under at least pulseaudio.** The last commit, which reduces the queue size, can easily be removed if that is the case.

CC @gmta