### PR TITLE
Ports: Install host languages into Local/$lang, not Local/$ARCH

### DIFF
--- a/Ports/python3/package.sh
+++ b/Ports/python3/package.sh
@@ -2,6 +2,8 @@
 
 source version.sh
 
+export PATH="${SERENITY_SOURCE_DIR}/Toolchain/Local/python/bin:${PATH}"
+
 port=python3
 version="${PYTHON_VERSION}"
 workdir="Python-${version}"

--- a/Ports/ruby/package.sh
+++ b/Ports/ruby/package.sh
@@ -2,6 +2,8 @@
 
 source version.sh
 
+export PATH="${SERENITY_SOURCE_DIR}/Toolchain/Local/ruby/bin:${PATH}"
+
 port=ruby
 version=${RUBY_VERSION}
 useconfigure="true"

--- a/Ports/ruby/package.sh
+++ b/Ports/ruby/package.sh
@@ -18,7 +18,21 @@ launcher_command="/usr/local/bin/ruby /usr/local/bin/irb --legacy"
 launcher_run_in_terminal="true"
 icon_file="../ruby-kit/ruby.png"
 
-configopts=("--with-coroutine=x86" "--disable-install-doc")
+configopts=(
+    "--disable-install-doc"
+)
+
+case "${SERENITY_ARCH}" in
+    x86_64)
+        configopts+=("--with-coroutine=amd64")
+        ;;
+    i686)
+        configopts+=("--with-coroutine=x86")
+        ;;
+    *)
+        echo "Error: Architecture ${SERENITY_ARCH} is not supported for this port"
+        exit 1
+esac
 
 export CFLAGS="-DNGROUPS_MAX=65536"
 

--- a/Toolchain/BuildPython.sh
+++ b/Toolchain/BuildPython.sh
@@ -5,9 +5,8 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-ARCH=${ARCH:-"i686"}
-PREFIX_DIR="$DIR/Local/$ARCH"
-BUILD_DIR="$DIR/Build/$ARCH"
+PREFIX_DIR="$DIR/Local/python"
+BUILD_DIR="$DIR/Build/python"
 TARBALLS_DIR="$DIR/Tarballs"
 
 # shellcheck source=/dev/null
@@ -42,9 +41,9 @@ if [ -z "$MAKEJOBS" ]; then
 fi
 
 mkdir -p "${PREFIX_DIR}"
-mkdir -p "${BUILD_DIR}/python"
+mkdir -p "${BUILD_DIR}"
 
-pushd "${BUILD_DIR}/python"
+pushd "${BUILD_DIR}"
     "${TARBALLS_DIR}"/Python-"${PYTHON_VERSION}"/configure --prefix="${PREFIX_DIR}"
     make -j "${MAKEJOBS}"
     make install

--- a/Toolchain/BuildRuby.sh
+++ b/Toolchain/BuildRuby.sh
@@ -5,9 +5,8 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-ARCH=${ARCH:-"i686"}
-PREFIX_DIR="$DIR/Local/$ARCH"
-BUILD_DIR="$DIR/Build/$ARCH"
+PREFIX_DIR="$DIR/Local/ruby"
+BUILD_DIR="$DIR/Build/ruby"
 TARBALLS_DIR="$DIR/Tarballs"
 
 # shellcheck source=/dev/null
@@ -42,9 +41,9 @@ if [ -z "$MAKEJOBS" ]; then
 fi
 
 mkdir -p "${PREFIX_DIR}"
-mkdir -p "${BUILD_DIR}/ruby"
+mkdir -p "${BUILD_DIR}"
 
-pushd "${BUILD_DIR}/ruby"
+pushd "${BUILD_DIR}"
     "${TARBALLS_DIR}"/ruby-"${RUBY_VERSION}"/configure --prefix="${PREFIX_DIR}"
     make -j "${MAKEJOBS}"
     make install


### PR DESCRIPTION
Following the pattern for qemu, mold, and clang, we should install the
host tools required to build the python and ruby ports into their own install trees
rather than forcing them into the GNU compiler's bindir.

This makes it significantly easier to build these ports with Clang :)

Also, fix the x86_64 build for ruby, but not the x86_64 execution of the same.