### PR TITLE
LibWeb: Add deprecated `image-rendering` values

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -89,7 +89,9 @@
         "crisp-edges",
         "high-quality",
         "pixelated",
-        "smooth"
+        "smooth",
+        "optimizespeed=pixelated",
+        "optimizequality=smooth"
     ],
     "justify-content": [
         "flex-start",

--- a/Userland/Libraries/LibWeb/CSS/Identifiers.json
+++ b/Userland/Libraries/LibWeb/CSS/Identifiers.json
@@ -181,6 +181,8 @@
   "nwse-resize",
   "oblique",
   "opaque",
+  "optimizespeed",
+  "optimizequality",
   "outset",
   "outside",
   "overline",


### PR DESCRIPTION
From the spec:

> This property previously accepted the values optimizeSpeed and
  optimizeQuality. These are now deprecated; a user agent must accept
  them as valid values but must treat them as having the same behavior
  as pixelated and smooth respectively, and authors must not use them.

- https://www.w3.org/TR/css-images-3/#the-image-rendering