### PR TITLE
WindowServer+LibGUI+ThemeEditor: Allow overriding the system theme temporarily with the one being edited in ThemeEditor

### DIFF
--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
@@ -17,11 +17,6 @@
 
 namespace DisplaySettings {
 
-static inline String current_system_theme()
-{
-    return GUI::ConnectionToWindowServer::the().get_system_theme();
-}
-
 ThemesSettingsWidget::ThemesSettingsWidget(bool& background_settings_changed)
     : m_background_settings_changed { background_settings_changed }
 {
@@ -29,7 +24,7 @@ ThemesSettingsWidget::ThemesSettingsWidget(bool& background_settings_changed)
     m_themes = Gfx::list_installed_system_themes();
 
     size_t current_theme_index;
-    auto current_theme_name = current_system_theme();
+    auto current_theme_name = GUI::ConnectionToWindowServer::the().get_system_theme();
     auto theme_overridden = GUI::ConnectionToWindowServer::the().is_system_theme_overridden();
     m_theme_names.ensure_capacity(m_themes.size());
     for (auto& theme_meta : m_themes) {
@@ -65,7 +60,7 @@ ThemesSettingsWidget::ThemesSettingsWidget(bool& background_settings_changed)
             return;
         }
 
-        auto current_theme_name = current_system_theme();
+        auto current_theme_name = GUI::ConnectionToWindowServer::the().get_system_theme();
 
         size_t index = 0;
         for (auto& theme_meta : m_themes) {
@@ -81,7 +76,7 @@ ThemesSettingsWidget::ThemesSettingsWidget(bool& background_settings_changed)
 
 void ThemesSettingsWidget::apply_settings()
 {
-    if (m_selected_theme && m_selected_theme->name != current_system_theme())
+    if (m_selected_theme && m_selected_theme->name != GUI::ConnectionToWindowServer::the().get_system_theme())
         VERIFY(GUI::ConnectionToWindowServer::the().set_system_theme(m_selected_theme->path, m_selected_theme->name, m_background_settings_changed));
     m_background_settings_changed = false;
 }

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ * Copyright (c) 2022, Jakob-Niklas See <git@nwex.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,6 +10,7 @@
 #include <AK/QuickSort.h>
 #include <Applications/DisplaySettings/ThemesSettingsGML.h>
 #include <LibCore/DirIterator.h>
+#include <LibGUI/Application.h>
 #include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/ItemListModel.h>
 #include <LibGUI/Process.h>
@@ -53,6 +55,20 @@ ThemesSettingsWidget::ThemesSettingsWidget(bool& background_settings_changed)
     m_cursor_themes_button->set_icon(mouse_settings_icon);
     m_cursor_themes_button->on_click = [&](auto) {
         GUI::Process::spawn_or_show_error(window(), "/bin/MouseSettings", Array { "-t", "cursor-theme" });
+    };
+
+    GUI::Application::the()->on_theme_change = [&]() {
+        auto current_theme_name = current_system_theme();
+
+        size_t index = 0;
+        for (auto& theme_meta : m_themes) {
+            if (current_theme_name == theme_meta.name) {
+                m_themes_combo->set_selected_index(index, GUI::AllowCallback::No);
+                m_selected_theme = &m_themes.at(index);
+                m_theme_preview->set_theme(m_selected_theme->path);
+            }
+            ++index;
+        }
     };
 }
 

--- a/Userland/Applications/ThemeEditor/MainWidget.h
+++ b/Userland/Applications/ThemeEditor/MainWidget.h
@@ -91,7 +91,10 @@ private:
     MainWidget();
 
     void save_to_file(Core::File&);
+    ErrorOr<Core::AnonymousBuffer> encode();
     void set_path(String);
+
+    void build_override_controls();
 
     void add_property_tab(PropertyTab const&);
     void set_alignment(Gfx::AlignmentRole, Gfx::TextAlignment);
@@ -111,6 +114,9 @@ private:
     RefPtr<PreviewWidget> m_preview_widget;
     RefPtr<GUI::TabWidget> m_property_tabs;
     RefPtr<GUI::Action> m_save_action;
+
+    RefPtr<GUI::Button> m_theme_override_apply;
+    RefPtr<GUI::Button> m_theme_override_reset;
 
     Optional<String> m_path;
     Gfx::Palette m_current_palette;

--- a/Userland/Applications/ThemeEditor/ThemeEditor.gml
+++ b/Userland/Applications/ThemeEditor/ThemeEditor.gml
@@ -1,13 +1,42 @@
 @GUI::Widget {
-    layout: @GUI::HorizontalBoxLayout {}
+    layout: @GUI::VerticalBoxLayout {}
     fill_with_background_color: true
 
-    @GUI::Frame {
+    @GUI::Widget {
         layout: @GUI::HorizontalBoxLayout {}
-        name: "preview_frame"
+
+        @GUI::Frame {
+            layout: @GUI::HorizontalBoxLayout {}
+            name: "preview_frame"
+        }
+
+        @GUI::TabWidget {
+            name: "property_tabs"
+        }
     }
 
-    @GUI::TabWidget {
-        name: "property_tabs"
+    @GUI::Widget {
+        name: "theme_override_controls"
+        layout: @GUI::HorizontalBoxLayout {
+            margins: [ 0, 4 ]
+        }
+
+        fixed_height: 30
+
+        @GUI::Layout::Spacer {}
+
+        @GUI::Button {
+            name: "reset"
+            text: "Reset to Previous System Theme"
+            enabled: false
+            fixed_width: 190
+        }
+
+        @GUI::Button {
+            name: "apply"
+            text: "Apply as System Theme"
+            enabled: false
+            fixed_width: 140
+        }
     }
 }

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
@@ -78,6 +78,13 @@ void AbstractThemePreview::set_preview_palette(Gfx::Palette const& palette)
     update();
 }
 
+void AbstractThemePreview::set_theme(Core::AnonymousBuffer const& theme_buffer)
+{
+    VERIFY(theme_buffer.is_valid());
+    m_preview_palette = Gfx::Palette(Gfx::PaletteImpl::create_with_anonymous_buffer(theme_buffer));
+    set_preview_palette(m_preview_palette);
+}
+
 void AbstractThemePreview::set_theme_from_file(Core::File& file)
 {
     auto config_file = Core::ConfigFile::open(file.filename(), file.leak_fd()).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.h
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.h
@@ -25,6 +25,7 @@ public:
     Gfx::Palette const& preview_palette() const { return m_preview_palette; }
     void set_preview_palette(Gfx::Palette const&);
     void set_theme_from_file(Core::File&);
+    void set_theme(Core::AnonymousBuffer const&);
 
     void paint_window(StringView title, Gfx::IntRect const& rect, Gfx::WindowTheme::WindowState, Gfx::Bitmap const& icon, int button_count = 3);
 

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -311,6 +311,10 @@ void Application::event(Core::Event& event)
                 on_action_leave(action);
         }
     }
+    if (event.type() == GUI::Event::ThemeChange) {
+        if (on_theme_change)
+            on_theme_change();
+    }
     Object::event(event);
 }
 

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -83,6 +83,7 @@ public:
 
     Function<void(Action&)> on_action_enter;
     Function<void(Action&)> on_action_leave;
+    Function<void()> on_theme_change;
 
     auto const& global_shortcut_actions(Badge<GUI::CommandPalette>) const { return m_global_shortcut_actions; }
 

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -213,7 +213,9 @@ void ComboBox::set_selected_index(size_t index, AllowCallback allow_callback)
         return;
     size_t previous_index = selected_index();
     TemporaryChange change(m_updating_model, true);
-    m_list_view->set_cursor(m_list_view->model()->index(index, 0), AbstractView::SelectionUpdate::Set);
+    auto model_index = m_list_view->model()->index(index, 0);
+    m_list_view->set_cursor(model_index, AbstractView::SelectionUpdate::Set);
+    selection_updated(model_index);
     if (previous_index != selected_index() && on_change && allow_callback == AllowCallback::Yes)
         on_change(m_editor->text(), m_list_view->cursor_index());
 }

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -200,6 +200,13 @@ void ComboBox::set_model(NonnullRefPtr<Model> model)
     m_list_view->set_model(move(model));
 }
 
+void ComboBox::clear_selection()
+{
+    m_selected_index.clear();
+    m_editor->clear_selection();
+    m_editor->clear();
+}
+
 void ComboBox::set_selected_index(size_t index, AllowCallback allow_callback)
 {
     if (!m_list_view->model())

--- a/Userland/Libraries/LibGUI/ComboBox.h
+++ b/Userland/Libraries/LibGUI/ComboBox.h
@@ -33,6 +33,7 @@ public:
 
     size_t selected_index() const;
     void set_selected_index(size_t index, AllowCallback = AllowCallback::Yes);
+    void clear_selection();
 
     bool only_allow_values_from_model() const { return m_only_allow_values_from_model; }
     void set_only_allow_values_from_model(bool);

--- a/Userland/Libraries/LibGUI/ConnectionToWindowServer.cpp
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowServer.cpp
@@ -67,6 +67,8 @@ void ConnectionToWindowServer::update_system_theme(Core::AnonymousBuffer const& 
     Window::for_each_window({}, [](auto& window) {
         Core::EventLoop::current().post_event(window, make<ThemeChangeEvent>());
     });
+
+    Application::the()->dispatch_event(*make<ThemeChangeEvent>());
 }
 
 void ConnectionToWindowServer::update_system_fonts(String const& default_font_query, String const& fixed_width_font_query)

--- a/Userland/Libraries/LibGfx/SystemTheme.cpp
+++ b/Userland/Libraries/LibGfx/SystemTheme.cpp
@@ -131,19 +131,19 @@ Core::AnonymousBuffer load_system_theme(Core::ConfigFile const& file)
     ENUMERATE_METRIC_ROLES(__ENUMERATE_METRIC_ROLE)
 #undef __ENUMERATE_METRIC_ROLE
 
-#define DO_PATH(x, allow_empty)                                                                                  \
+#define ENCODE_PATH(x, allow_empty)                                                                              \
     do {                                                                                                         \
         auto path = get_path(#x, (int)PathRole::x, allow_empty);                                                 \
         memcpy(data->path[(int)PathRole::x], path, min(strlen(path) + 1, sizeof(data->path[(int)PathRole::x]))); \
         data->path[(int)PathRole::x][sizeof(data->path[(int)PathRole::x]) - 1] = '\0';                           \
     } while (0)
 
-    DO_PATH(TitleButtonIcons, false);
-    DO_PATH(ActiveWindowShadow, true);
-    DO_PATH(InactiveWindowShadow, true);
-    DO_PATH(TaskbarShadow, true);
-    DO_PATH(MenuShadow, true);
-    DO_PATH(TooltipShadow, true);
+    ENCODE_PATH(TitleButtonIcons, false);
+    ENCODE_PATH(ActiveWindowShadow, true);
+    ENCODE_PATH(InactiveWindowShadow, true);
+    ENCODE_PATH(TaskbarShadow, true);
+    ENCODE_PATH(MenuShadow, true);
+    ENCODE_PATH(TooltipShadow, true);
 
     return buffer;
 }

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Jakob-Niklas See <git@nwex.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,6 +21,7 @@
 #include <LibGUI/ConnectionToWindowManagerServer.h>
 #include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/Menu.h>
+#include <LibGUI/MenuItem.h>
 #include <LibGUI/Process.h>
 #include <LibGfx/SystemTheme.h>
 #include <LibMain/Main.h>
@@ -240,6 +242,16 @@ ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu(WindowRefence& window_ref)
             ++theme_identifier;
         }
     }
+
+    GUI::Application::the()->on_theme_change = [&]() {
+        if (g_themes_menu->is_visible())
+            return;
+        auto current_theme_name = GUI::ConnectionToWindowServer::the().get_system_theme();
+        for (size_t index = 0; index < g_themes.size(); ++index) {
+            auto* action = g_themes_menu->action_at(index);
+            action->set_checked(action->text() == current_theme_name);
+        }
+    };
 
     system_menu->add_action(GUI::Action::create("&Settings", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-settings.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         GUI::Process::spawn_or_show_error(window_ref.get(), "/bin/Settings"sv);

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -247,9 +247,10 @@ ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu(WindowRefence& window_ref)
         if (g_themes_menu->is_visible())
             return;
         auto current_theme_name = GUI::ConnectionToWindowServer::the().get_system_theme();
+        auto theme_overridden = GUI::ConnectionToWindowServer::the().is_system_theme_overridden();
         for (size_t index = 0; index < g_themes.size(); ++index) {
             auto* action = g_themes_menu->action_at(index);
-            action->set_checked(action->text() == current_theme_name);
+            action->set_checked(!theme_overridden && action->text() == current_theme_name);
         }
     };
 

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -804,6 +804,27 @@ Messages::WindowServer::GetSystemThemeResponse ConnectionFromClient::get_system_
     return name;
 }
 
+Messages::WindowServer::SetSystemThemeOverrideResponse ConnectionFromClient::set_system_theme_override(Core::AnonymousBuffer const& theme_override)
+{
+    bool success = WindowManager::the().set_theme_override(theme_override);
+    return success;
+}
+
+Messages::WindowServer::GetSystemThemeOverrideResponse ConnectionFromClient::get_system_theme_override()
+{
+    return WindowManager::the().get_theme_override();
+}
+
+void ConnectionFromClient::clear_system_theme_override()
+{
+    WindowManager::the().clear_theme_override();
+}
+
+Messages::WindowServer::IsSystemThemeOverriddenResponse ConnectionFromClient::is_system_theme_overridden()
+{
+    return WindowManager::the().is_theme_overridden();
+}
+
 void ConnectionFromClient::apply_cursor_theme(String const& name)
 {
     WindowManager::the().apply_cursor_theme(name);

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -142,6 +142,10 @@ private:
     virtual Messages::WindowServer::StartDragResponse start_drag(String const&, HashMap<String, ByteBuffer> const&, Gfx::ShareableBitmap const&) override;
     virtual Messages::WindowServer::SetSystemThemeResponse set_system_theme(String const&, String const&, bool keep_desktop_background) override;
     virtual Messages::WindowServer::GetSystemThemeResponse get_system_theme() override;
+    virtual Messages::WindowServer::SetSystemThemeOverrideResponse set_system_theme_override(Core::AnonymousBuffer const&) override;
+    virtual Messages::WindowServer::GetSystemThemeOverrideResponse get_system_theme_override() override;
+    virtual void clear_system_theme_override() override;
+    virtual Messages::WindowServer::IsSystemThemeOverriddenResponse is_system_theme_overridden() override;
     virtual void apply_cursor_theme(String const&) override;
     virtual void set_cursor_highlight_radius(int radius) override;
     virtual Messages::WindowServer::GetCursorHighlightRadiusResponse get_cursor_highlight_radius() override;

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -220,6 +220,11 @@ public:
     bool update_theme(String theme_path, String theme_name, bool keep_desktop_background);
     void invalidate_after_theme_or_font_change();
 
+    bool set_theme_override(Core::AnonymousBuffer const& theme_override);
+    Optional<Core::AnonymousBuffer> get_theme_override() const;
+    void clear_theme_override();
+    bool is_theme_overridden() { return m_theme_overridden; }
+
     bool set_hovered_window(Window*);
     void deliver_mouse_event(Window&, MouseEvent const&, bool process_double_click);
 
@@ -431,6 +436,7 @@ private:
     int m_max_distance_for_double_click { 4 };
     bool m_previous_event_was_super_keydown { false };
     bool m_buttons_switched { false };
+    bool m_theme_overridden { false };
 
     WeakPtr<Window> m_hovered_window;
     WeakPtr<Window> m_highlight_window;

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -129,6 +129,11 @@ endpoint WindowServer
     get_system_theme() => ([UTF8] String theme_name)
     refresh_system_theme() =|
 
+    set_system_theme_override(Core::AnonymousBuffer buffer) => (bool success)
+    get_system_theme_override() => (Optional<Core::AnonymousBuffer> buffer)
+    clear_system_theme_override() =|
+    is_system_theme_overridden() => (bool overridden)
+
     apply_cursor_theme(String name) =|
     get_cursor_theme() => (String name)
 


### PR DESCRIPTION
This pull request allows the taskbar theme menu and display settings theme tab to react to global theme changes, adds a new api to temporarily override the system theme and implements ThemeEditor using that api to apply the theme currently being edited to the whole system.

Demo:

https://user-images.githubusercontent.com/42888162/174161557-07d576e1-b9cc-4754-83eb-8d34320f5b96.mp4


