### PR TITLE
Base: Add dir as alias to shellrc

### DIFF
--- a/Base/etc/shellrc
+++ b/Base/etc/shellrc
@@ -28,6 +28,7 @@ alias ue=UserspaceEmulator
 alias fe=FontEditor
 alias ss=Spreadsheet
 
+alias dir='ls'
 alias ll='ls -l'
 
 if [ "$(id -u)" = "0" ] {


### PR DESCRIPTION
Add `dir` as an alias to `ls`.

Because way to many times `dir: Command not found.` in Terminal. 🤪