### PR TITLE
LibC: Add `ctermid`

### DIFF
--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -1299,6 +1299,15 @@ FILE* tmpfile()
     return fdopen(fd, "rw");
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/ctermid.html
+char* ctermid(char* s)
+{
+    static char tty_path[L_ctermid] = "/dev/tty";
+    if (s)
+        return strcpy(s, tty_path);
+    return tty_path;
+}
+
 size_t __fpending(FILE* stream)
 {
     ScopedFileLock lock(stream);

--- a/Userland/Libraries/LibC/stdio.h
+++ b/Userland/Libraries/LibC/stdio.h
@@ -27,6 +27,7 @@ __BEGIN_DECLS
 #define _IOLBF 1
 #define _IONBF 2
 
+#define L_ctermid 9
 #define L_tmpnam 256
 #define P_tmpdir "/tmp"
 
@@ -99,5 +100,6 @@ FILE* tmpfile(void);
 char* tmpnam(char*);
 FILE* popen(char const* command, char const* type);
 int pclose(FILE*);
+char* ctermid(char* s);
 
 __END_DECLS


### PR DESCRIPTION
We simply return "/dev/tty", since it always refers to the controlling terminal of the calling process.