### PR TITLE
AK: Add comparison operators to NonnullOwnPtr

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -135,6 +135,12 @@ public:
         return NonnullOwnPtr<U>(NonnullOwnPtr<U>::Adopt, static_cast<U&>(*leak_ptr()));
     }
 
+    bool operator==(NonnullOwnPtr const& other) const { return m_ptr == other.m_ptr; }
+    bool operator!=(NonnullOwnPtr const& other) const { return m_ptr != other.m_ptr; }
+
+    bool operator==(NonnullOwnPtr& other) { return m_ptr == other.m_ptr; }
+    bool operator!=(NonnullOwnPtr& other) { return m_ptr != other.m_ptr; }
+
 private:
     void clear()
     {


### PR DESCRIPTION
This PR adds the == and != operators to NonnullRefPtr 

Fixes: #12779