### PR TITLE
LibWeb: Rename Event.srcTarget to Event.srcElement

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Event.h
+++ b/Userland/Libraries/LibWeb/DOM/Event.h
@@ -67,7 +67,7 @@ public:
     void set_target(EventTarget* target) { m_target = target; }
 
     // NOTE: This is intended for the JS bindings.
-    RefPtr<EventTarget> src_target() const { return target(); }
+    RefPtr<EventTarget> src_element() const { return target(); }
 
     RefPtr<EventTarget> related_target() const { return m_related_target; }
     void set_related_target(EventTarget* related_target) { m_related_target = related_target; }

--- a/Userland/Libraries/LibWeb/DOM/Event.idl
+++ b/Userland/Libraries/LibWeb/DOM/Event.idl
@@ -6,7 +6,7 @@ interface Event {
 
     readonly attribute DOMString type;
     readonly attribute EventTarget? target;
-    readonly attribute EventTarget? srcTarget;
+    readonly attribute EventTarget? srcElement;
     readonly attribute EventTarget? currentTarget;
     sequence<EventTarget> composedPath();
 


### PR DESCRIPTION
It's called srcElement instead of srcTarget.
Required by w3school's search focus handler.