### PR TITLE
Kernel(+LibC): Add posix_fallocate + Some Syscall fixmes

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -159,6 +159,8 @@ public:
     using SearchDirection = StringUtils::SearchDirection;
     [[nodiscard]] Optional<size_t> find_any_of(StringView needles, SearchDirection direction) const { return StringUtils::find_any_of(*this, needles, direction); }
 
+    [[nodiscard]] StringView find_last_split_view(char separator) const { return view().find_last_split_view(separator); }
+
     [[nodiscard]] String substring(size_t start, size_t length) const;
     [[nodiscard]] String substring(size_t start) const;
     [[nodiscard]] StringView substring_view(size_t start, size_t length) const;

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -132,6 +132,14 @@ public:
 
     [[nodiscard]] Vector<StringView> split_view_if(Function<bool(char)> const& predicate, bool keep_empty = false) const;
 
+    [[nodiscard]] StringView find_last_split_view(char separator) const
+    {
+        auto begin = find_last(separator);
+        if (!begin.has_value())
+            return *this;
+        return substring_view(begin.release_value() + 1);
+    }
+
     template<VoidFunction<StringView> Callback>
     void for_each_split_view(char separator, bool keep_empty, Callback callback) const
     {

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -128,6 +128,7 @@ enum class NeedsBigProcessLock {
     S(pipe, NeedsBigProcessLock::Yes)                       \
     S(pledge, NeedsBigProcessLock::Yes)                     \
     S(poll, NeedsBigProcessLock::Yes)                       \
+    S(posix_fallocate, NeedsBigProcessLock::No)             \
     S(prctl, NeedsBigProcessLock::Yes)                      \
     S(profiling_disable, NeedsBigProcessLock::Yes)          \
     S(profiling_enable, NeedsBigProcessLock::Yes)           \

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -241,6 +241,7 @@ set(KERNEL_SOURCES
     Syscalls/emuctl.cpp
     Syscalls/execve.cpp
     Syscalls/exit.cpp
+    Syscalls/fallocate.cpp
     Syscalls/fcntl.cpp
     Syscalls/fork.cpp
     Syscalls/fsync.cpp

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -232,6 +232,12 @@ void Inode::did_remove_child(InodeIdentifier, StringView name)
 
 void Inode::did_modify_contents()
 {
+    // FIXME: What happens if this fails?
+    //        ENOTIMPL would be a meaningless error to return here
+    auto time = kgettimeofday().to_truncated_seconds();
+    (void)set_mtime(time);
+    (void)set_ctime(time);
+
     m_watchers.for_each([&](auto& watcher) {
         watcher->notify_inode_event({}, identifier(), InodeWatcherEvent::Type::ContentModified);
     });

--- a/Kernel/Memory/AddressSpace.cpp
+++ b/Kernel/Memory/AddressSpace.cpp
@@ -253,9 +253,9 @@ Region* AddressSpace::find_region_containing(VirtualRange const& range)
     return m_region_tree.find_region_containing(range);
 }
 
-ErrorOr<Vector<Region*>> AddressSpace::find_regions_intersecting(VirtualRange const& range)
+ErrorOr<Vector<Region*, 4>> AddressSpace::find_regions_intersecting(VirtualRange const& range)
 {
-    Vector<Region*> regions = {};
+    Vector<Region*, 4> regions = {};
     size_t total_size_collected = 0;
 
     SpinlockLocker lock(m_lock);

--- a/Kernel/Memory/AddressSpace.h
+++ b/Kernel/Memory/AddressSpace.h
@@ -45,7 +45,7 @@ public:
     Region* find_region_from_range(VirtualRange const&);
     Region* find_region_containing(VirtualRange const&);
 
-    ErrorOr<Vector<Region*>> find_regions_intersecting(VirtualRange const&);
+    ErrorOr<Vector<Region*, 4>> find_regions_intersecting(VirtualRange const&);
 
     bool enforces_syscall_regions() const { return m_enforces_syscall_regions; }
     void set_enforces_syscall_regions(bool b) { m_enforces_syscall_regions = b; }

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -301,6 +301,7 @@ public:
     ErrorOr<FlatPtr> sys$stat(Userspace<Syscall::SC_stat_params const*>);
     ErrorOr<FlatPtr> sys$lseek(int fd, Userspace<off_t*>, int whence);
     ErrorOr<FlatPtr> sys$ftruncate(int fd, Userspace<off_t const*>);
+    ErrorOr<FlatPtr> sys$posix_fallocate(int fd, Userspace<off_t const*>, Userspace<off_t const*>);
     ErrorOr<FlatPtr> sys$kill(pid_t pid_or_pgid, int sig);
     [[noreturn]] void sys$exit(int status);
     ErrorOr<FlatPtr> sys$sigreturn(RegisterState& registers);

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -452,12 +452,9 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
     if (!validate_stack_size(arguments, environment))
         return E2BIG;
 
-    // FIXME: split_view() currently allocates (Vector) without checking for failure.
-    auto parts = path->view().split_view('/');
-    if (parts.is_empty())
-        return ENOENT;
+    auto last_part = path->view().find_last_split_view('/');
 
-    auto new_process_name = TRY(KString::try_create(parts.last()));
+    auto new_process_name = TRY(KString::try_create(last_part));
     auto new_main_thread_name = TRY(new_process_name->try_clone());
 
     auto load_result = TRY(load(main_program_description, interpreter_description, main_program_header));

--- a/Kernel/Syscalls/fallocate.cpp
+++ b/Kernel/Syscalls/fallocate.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Checked.h>
+#include <Kernel/FileSystem/Inode.h>
+#include <Kernel/FileSystem/InodeFile.h>
+#include <Kernel/FileSystem/OpenFileDescription.h>
+#include <Kernel/Process.h>
+
+namespace Kernel {
+
+ErrorOr<FlatPtr> Process::sys$posix_fallocate(int fd, Userspace<off_t const*> userspace_offset, Userspace<off_t const*> userspace_length)
+{
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
+    TRY(require_promise(Pledge::stdio));
+
+    auto offset = TRY(copy_typed_from_user(userspace_offset));
+    if (offset < 0)
+        return EINVAL;
+    auto length = TRY(copy_typed_from_user(userspace_length));
+    if (length <= 0)
+        return EINVAL;
+
+    Checked<size_t> checked_size { length };
+    checked_size += offset;
+    // FIXME: Return EFBIG if offset+length > FileSizeMax
+    if (checked_size.has_overflow())
+        return EFBIG;
+
+    auto description = TRY(open_file_description(fd));
+    if (!description->is_writable())
+        return EBADF;
+
+    if (description->is_fifo())
+        return ESPIPE;
+
+    if (!S_ISREG(TRY(description->file().stat()).st_mode))
+        return ENODEV;
+
+    VERIFY(description->file().is_inode());
+
+    auto& file = static_cast<InodeFile&>(description->file());
+    if (file.inode().size() >= checked_size.value())
+        return 0;
+
+    // Note: truncate essentially calls resize in the inodes implementation
+    //       while resize is not a standard member of an inode, so we just call
+    //       truncate instead
+    TRY(file.inode().truncate(checked_size.value()));
+
+    // FIXME: ENOSPC: There is not enough space left on the device containing the file referred to by fd.
+    // FIXME: EINTR: A signal was caught during execution.
+    return 0;
+}
+
+}

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -571,23 +571,37 @@ ErrorOr<FlatPtr> Process::sys$msync(Userspace<void*> address, size_t size, int f
     // Note: This is not specified
     auto rounded_size = TRY(Memory::page_round_up(size));
 
-    // FIXME: We probably want to sync all mappings in the address+size range.
-    auto* region = address_space().find_region_containing(Memory::VirtualRange { address.vaddr(), rounded_size });
+    auto regions = TRY(address_space().find_regions_intersecting(Memory::VirtualRange { address.vaddr(), rounded_size }));
     // All regions from address upto address+size shall be mapped
-    if (!region)
+    if (regions.is_empty())
         return ENOMEM;
 
-    auto& vmobject = region->vmobject();
-    if (!vmobject.is_shared_inode())
-        return 0;
+    size_t total_intersection_size = 0;
+    Memory::VirtualRange range_to_sync { address.vaddr(), rounded_size };
+    for (auto const* region : regions) {
+        // Region was not mapped
+        if (!region->is_mmap())
+            return ENOMEM;
+        total_intersection_size += region->range().intersect(range_to_sync).size();
+    }
+    // Part of the indicated range was not mapped
+    if (total_intersection_size != size)
+        return ENOMEM;
 
-    off_t offset = region->offset_in_vmobject() + address.ptr() - region->range().base().get();
+    for (auto* region : regions) {
+        auto& vmobject = region->vmobject();
+        if (!vmobject.is_shared_inode())
+            continue;
 
-    auto& inode_vmobject = static_cast<Memory::SharedInodeVMObject&>(vmobject);
-    // FIXME: Handle MS_ASYNC
-    TRY(inode_vmobject.sync(offset / PAGE_SIZE, size / PAGE_SIZE));
-    // FIXME: Handle MS_INVALIDATE
-    // FIXME: If msync() causes any write to a file, the file's st_ctime and st_mtime fields shall be marked for update.
+        off_t offset = region->offset_in_vmobject() + address.ptr() - region->range().base().get();
+
+        auto& inode_vmobject = static_cast<Memory::SharedInodeVMObject&>(vmobject);
+        // FIXME: If multiple regions belong to the same vmobject we might want to coalesce these writes
+        // FIXME: Handle MS_ASYNC
+        TRY(inode_vmobject.sync(offset / PAGE_SIZE, rounded_size / PAGE_SIZE));
+        // FIXME: Handle MS_INVALIDATE
+        // FIXME: If msync() causes any write to a file, the file's st_ctime and st_mtime fields shall be marked for update.
+    }
     return 0;
 }
 

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -600,7 +600,6 @@ ErrorOr<FlatPtr> Process::sys$msync(Userspace<void*> address, size_t size, int f
         // FIXME: Handle MS_ASYNC
         TRY(inode_vmobject.sync(offset / PAGE_SIZE, rounded_size / PAGE_SIZE));
         // FIXME: Handle MS_INVALIDATE
-        // FIXME: If msync() causes any write to a file, the file's st_ctime and st_mtime fields shall be marked for update.
     }
     return 0;
 }

--- a/Userland/Libraries/LibC/fcntl.cpp
+++ b/Userland/Libraries/LibC/fcntl.cpp
@@ -104,6 +104,13 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_fallocate.html
+int posix_fallocate(int fd, off_t offset, off_t len)
+{
+    // posix_fallocate does not set errno.
+    return static_cast<int>(syscall(SC_posix_fallocate, fd, &offset, &len));
+}
+
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/utimensat.html
 int utimensat(int dirfd, char const* path, struct timespec const times[2], int flag)
 {

--- a/Userland/Libraries/LibC/fcntl.h
+++ b/Userland/Libraries/LibC/fcntl.h
@@ -29,6 +29,7 @@ int inode_watcher_add_watch(int fd, char const* path, size_t path_length, unsign
 int inode_watcher_remove_watch(int fd, int wd);
 
 int posix_fadvise(int fd, off_t offset, off_t len, int advice);
+int posix_fallocate(int fd, off_t offset, off_t len);
 
 int utimensat(int dirfd, char const* path, struct timespec const times[2], int flag);
 


### PR DESCRIPTION
#### AK: Add an helper to get the last split-group

#### Kernel: Use find_last_split_view to get the executable name in do_exec

#### Kernel+LibC: Add posix_fallocate syscall

#### Kernel: Handle multiple regions in sys$msync

#### Kernel: Try to set [cm]time on sys$msync

----

Name suggestions for the new AK helper welcome

Fixes #14266