### PR TITLE
Meta: Install runtime/utility from jakt to make hello-jakt build again

### DIFF
--- a/Meta/CMake/code_generators.cmake
+++ b/Meta/CMake/code_generators.cmake
@@ -78,8 +78,8 @@ function(compile_jakt source)
     )
     get_property(JAKT_INCLUDE_DIR TARGET Lagom::jakt PROPERTY IMPORTED_INCLUDE_DIRECTORIES)
     set_source_files_properties("${output}" PROPERTIES
-        INCLUDE_DIRECTORIES "${JAKT_INCLUDE_DIR};${JAKT_INCLUDE_DIR}/runtime"
-        COMPILE_FLAGS "-Wno-unused-local-typedefs")
+        INCLUDE_DIRECTORIES "${JAKT_INCLUDE_DIR}/runtime"
+        COMPILE_OPTIONS "-Wno-unused-local-typedefs;-Wno-unused-function")
     get_filename_component(output_name ${output} NAME)
     add_custom_target(generate_${output_name} DEPENDS ${output})
     add_dependencies(all_generated generate_${output_name})

--- a/Meta/CMake/jakt.cmake
+++ b/Meta/CMake/jakt.cmake
@@ -35,5 +35,6 @@ if (NOT jakt_POPULATED)
     install(DIRECTORY "${jakt_SOURCE_DIR}/runtime"
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/jakt
             FILES_MATCHING PATTERN "*.h"
-                           PATTERN "*.cpp")
+                           PATTERN "*.cpp"
+                           PATTERN "utility")
 endif()


### PR DESCRIPTION
Also add a compile flag that fixes a warning from including <serenity.h>

Depends on https://github.com/SerenityOS/jakt/pull/688