### PR TITLE
AK: Add comparison operators to NonnullRefPtr

### DIFF
--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -218,6 +218,12 @@ public:
         AK::swap(m_ptr, other.m_ptr);
     }
 
+    bool operator==(NonnullRefPtr const& other) const { return m_ptr == other.m_ptr; }
+    bool operator!=(NonnullRefPtr const& other) const { return m_ptr != other.m_ptr; }
+
+    bool operator==(NonnullRefPtr& other) { return m_ptr == other.m_ptr; }
+    bool operator!=(NonnullRefPtr& other) { return m_ptr != other.m_ptr; }
+
     // clang-format off
 private:
     NonnullRefPtr() = delete;

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -32,6 +32,8 @@ class [[nodiscard]] RefPtr {
     friend class RefPtr;
     template<typename U>
     friend class WeakPtr;
+    template<typename U>
+    friend class NonnullRefPtr;
 
 public:
     enum AdoptTag {
@@ -269,6 +271,16 @@ public:
 
     bool operator==(RefPtr& other) { return as_ptr() == other.as_ptr(); }
     bool operator!=(RefPtr& other) { return as_ptr() != other.as_ptr(); }
+
+    template<typename U>
+    bool operator==(NonnullRefPtr<U> const& other) const { return as_ptr() == other.m_ptr; }
+    template<typename U>
+    bool operator!=(NonnullRefPtr<U> const& other) const { return as_ptr() != other.m_ptr; }
+
+    template<typename U>
+    bool operator==(NonnullRefPtr<U>& other) { return as_ptr() == other.m_ptr; }
+    template<typename U>
+    bool operator!=(NonnullRefPtr<U>& other) { return as_ptr() != other.m_ptr; }
 
     bool operator==(const T* other) const { return as_ptr() == other; }
     bool operator!=(const T* other) const { return as_ptr() != other; }


### PR DESCRIPTION
This PR adds the == and != operators to NonnullRefPtr and equality operators to compare RefPtr to NonNullRefPtr

Fixes: #12779