### PR TITLE
Ports/ncurses: Disable mixed-case directory names when building on macOS

### DIFF
--- a/Ports/ncurses/patches/0001-Teach-configure-about-serenity.patch
+++ b/Ports/ncurses/patches/0001-Teach-configure-about-serenity.patch
@@ -1,4 +1,4 @@
-From a83fb5794aba24721bc47d1168e5dfc680bdbebd Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Mon, 9 Aug 2021 19:43:03 +0200
 Subject: [PATCH] Teach configure about serenity
@@ -20,6 +20,3 @@ index 421cf85..31bbb85 100755
  		if test "$DFT_LWR_MODEL" = "shared" && test -n "$LD_RPATH_OPT" ; then
  			LOCAL_LDFLAGS="${LD_RPATH_OPT}\$(LOCAL_LIBDIR)"
  			LOCAL_LDFLAGS2="$LOCAL_LDFLAGS"
--- 
-2.36.1
-

--- a/Ports/ncurses/patches/0002-Disable-mixed-case-directory-names-when-building-on-.patch
+++ b/Ports/ncurses/patches/0002-Disable-mixed-case-directory-names-when-building-on-.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SeekingBlues <seekingblues@gmail.com>
+Date: Sun, 19 Jun 2022 18:36:27 +0800
+Subject: [PATCH] Disable mixed-case directory names when building on macOS
+
+Since macOS's filesystem is case-insensitive, its `tic` only generates
+terminfo directory names that are hex numbers instead of letters, such
+as 78/xterm instead of x/xterm. However, the configure script still
+enables the mixed-case directory name feature by default. As a result,
+ncurses will fail when trying to find terminfo entries like x/xterm if
+they are generated on macOS.
+
+It seems like there is no way to change the behavior of `tic` to create
+alphabetical directories, so we can only disable this option explicitly.
+---
+ configure | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/configure b/configure
+index 31bbb85..478eabd 100755
+--- a/configure
++++ b/configure
+@@ -4361,6 +4361,9 @@ if test "$cross_compiling" = yes ; then
+ 		cf_cv_mixedcase=yes
+ 		;;
+ 	esac
++	if test "$(uname)" = Darwin; then
++		cf_cv_mixedcase=no
++	fi
+ else
+ 	rm -f conftest CONFTEST
+ 	echo test >conftest

--- a/Ports/ncurses/patches/ReadMe.md
+++ b/Ports/ncurses/patches/ReadMe.md
@@ -5,3 +5,17 @@
 Teach configure about serenity
 
 
+## `0002-Disable-mixed-case-directory-names-when-building-on-.patch`
+
+Disable mixed-case directory names when building on macOS
+
+Since macOS's filesystem is case-insensitive, its `tic` only generates
+terminfo directory names that are hex numbers instead of letters, such
+as 78/xterm instead of x/xterm. However, the configure script still
+enables the mixed-case directory name feature by default. As a result,
+ncurses will fail when trying to find terminfo entries like x/xterm if
+they are generated on macOS.
+
+It seems like there is no way to change the behavior of `tic` to create
+alphabetical directories, so we can only disable this option explicitly.
+


### PR DESCRIPTION
Since macOS's filesystem is case-insensitive, its `tic` only generates terminfo directory names that are hex numbers instead of letters, such as 78/xterm instead of x/xterm. However, the configure script still enables the mixed-case directory name feature by default. As a result, ncurses will fail when trying to find terminfo entries like x/xterm if they are generated on macOS.

It seems like there is no way to change the behavior of `tic` to create alphabetical directories, so we can only disable this option explicitly.