### PR TITLE
HackStudio: Open a single editor tab when switching to a different project

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1543,8 +1543,9 @@ void HackStudioWidget::stop_debugger_if_running()
 void HackStudioWidget::close_current_project()
 {
     m_editors_splitter->remove_all_children();
-    add_new_editor_tab_widget(*m_editors_splitter);
+    m_all_editor_tab_widgets.clear();
     m_all_editor_wrappers.clear();
+    add_new_editor_tab_widget(*m_editors_splitter);
     m_open_files.clear();
     m_open_files_vector.clear();
     m_find_in_files_widget->reset();

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1543,10 +1543,10 @@ void HackStudioWidget::stop_debugger_if_running()
 void HackStudioWidget::close_current_project()
 {
     m_editors_splitter->remove_all_children();
+    add_new_editor_tab_widget(*m_editors_splitter);
     m_all_editor_wrappers.clear();
     m_open_files.clear();
     m_open_files_vector.clear();
-    add_new_editor(*m_current_editor_tab_widget);
     m_find_in_files_widget->reset();
     m_todo_entries_widget->clear();
     m_terminal_wrapper->clear_including_history();


### PR DESCRIPTION
When a new project was opened in HackStudio, after the initial one, there was an issue in which the project's files could not be viewed when opened as there were no editor tabs to view them in.
This small fix leaves one tab open to properly allow files to be viewed when clicked, as is the case upon first opening HackStudio.