### PR TITLE
LibWeb: Forward rendering context reference counts to HTMLCanvasElement

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -25,11 +25,26 @@
 namespace Web::HTML {
 
 CanvasRenderingContext2D::CanvasRenderingContext2D(HTMLCanvasElement& element)
-    : m_element(element)
+    : RefCountForwarder(element)
 {
 }
 
 CanvasRenderingContext2D::~CanvasRenderingContext2D() = default;
+
+HTMLCanvasElement& CanvasRenderingContext2D::canvas_element()
+{
+    return ref_count_target();
+}
+
+HTMLCanvasElement const& CanvasRenderingContext2D::canvas_element() const
+{
+    return ref_count_target();
+}
+
+NonnullRefPtr<HTMLCanvasElement> CanvasRenderingContext2D::canvas_for_binding() const
+{
+    return canvas_element();
+}
 
 void CanvasRenderingContext2D::set_fill_style(String style)
 {
@@ -263,24 +278,19 @@ void CanvasRenderingContext2D::rotate(float radians)
 void CanvasRenderingContext2D::did_draw(Gfx::FloatRect const&)
 {
     // FIXME: Make use of the rect to reduce the invalidated area when possible.
-    if (!m_element)
+    if (!canvas_element().layout_node())
         return;
-    if (!m_element->layout_node())
-        return;
-    m_element->layout_node()->set_needs_display();
+    canvas_element().layout_node()->set_needs_display();
 }
 
 OwnPtr<Gfx::Painter> CanvasRenderingContext2D::painter()
 {
-    if (!m_element)
-        return {};
-
-    if (!m_element->bitmap()) {
-        if (!m_element->create_bitmap())
+    if (!canvas_element().bitmap()) {
+        if (!canvas_element().create_bitmap())
             return {};
     }
 
-    return make<Gfx::Painter>(*m_element->bitmap());
+    return make<Gfx::Painter>(*canvas_element().bitmap());
 }
 
 void CanvasRenderingContext2D::fill_text(String const& text, float x, float y, Optional<double> max_width)
@@ -468,9 +478,9 @@ DOM::ExceptionOr<RefPtr<ImageData>> CanvasRenderingContext2D::get_image_data(int
     auto image_data = ImageData::create_with_size(wrapper()->global_object(), width, height);
 
     // NOTE: We don't attempt to create the underlying bitmap here; if it doesn't exist, it's like copying only transparent black pixels (which is a no-op).
-    if (!m_element || !m_element->bitmap())
+    if (!canvas_element().bitmap())
         return image_data;
-    auto const& bitmap = *m_element->bitmap();
+    auto const& bitmap = *canvas_element().bitmap();
 
     // 5. Let the source rectangle be the rectangle whose corners are the four points (sx, sy), (sx+sw, sy), (sx+sw, sy+sh), (sx, sy+sh).
     auto source_rect = Gfx::Rect { x, y, width, height };

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <AK/RefCounted.h>
+#include <AK/RefCountForwarder.h>
 #include <AK/Variant.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Color.h>
@@ -27,7 +27,7 @@ namespace Web::HTML {
 using CanvasImageSource = Variant<NonnullRefPtr<HTMLImageElement>, NonnullRefPtr<HTMLCanvasElement>>;
 
 class CanvasRenderingContext2D
-    : public RefCounted<CanvasRenderingContext2D>
+    : public RefCountForwarder<HTMLCanvasElement>
     , public Bindings::Wrappable {
 
     AK_MAKE_NONCOPYABLE(CanvasRenderingContext2D);
@@ -90,7 +90,7 @@ public:
 
     void reset_to_default_state();
 
-    HTMLCanvasElement* canvas() { return m_element; }
+    NonnullRefPtr<HTMLCanvasElement> canvas_for_binding() const;
 
     RefPtr<TextMetrics> measure_text(String const& text);
 
@@ -122,7 +122,8 @@ private:
 
     OwnPtr<Gfx::Painter> painter();
 
-    WeakPtr<HTMLCanvasElement> m_element;
+    HTMLCanvasElement& canvas_element();
+    HTMLCanvasElement const& canvas_element() const;
 
     // https://html.spec.whatwg.org/multipage/canvas.html#drawing-state
     struct DrawingState {

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -47,7 +47,7 @@ interface CanvasRenderingContext2D {
     undefined reset();
     boolean isContextLost();
 
-    readonly attribute HTMLCanvasElement canvas;
+    [ImplementedAs=canvas_for_binding] readonly attribute HTMLCanvasElement canvas;
 
     TextMetrics measureText(DOMString text);
 

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -12,7 +12,7 @@
 namespace Web::WebGL {
 
 WebGLRenderingContextBase::WebGLRenderingContextBase(HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<GL::GLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters)
-    : m_canvas_element(canvas_element)
+    : RefCountForwarder(canvas_element)
     , m_context(move(context))
     , m_context_creation_parameters(move(context_creation_parameters))
     , m_actual_context_parameters(move(actual_context_parameters))
@@ -67,15 +67,23 @@ void WebGLRenderingContextBase::present()
     }
 }
 
+HTML::HTMLCanvasElement& WebGLRenderingContextBase::canvas_element()
+{
+    return ref_count_target();
+}
+
+HTML::HTMLCanvasElement const& WebGLRenderingContextBase::canvas_element() const
+{
+    return ref_count_target();
+}
+
 void WebGLRenderingContextBase::needs_to_present()
 {
     m_should_present = true;
 
-    if (!m_canvas_element)
+    if (!canvas_element().layout_node())
         return;
-    if (!m_canvas_element->layout_node())
-        return;
-    m_canvas_element->layout_node()->set_needs_display();
+    canvas_element().layout_node()->set_needs_display();
 }
 
 void WebGLRenderingContextBase::set_error(GLenum error)

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -77,6 +77,11 @@ HTML::HTMLCanvasElement const& WebGLRenderingContextBase::canvas_element() const
     return ref_count_target();
 }
 
+NonnullRefPtr<HTML::HTMLCanvasElement> WebGLRenderingContextBase::canvas_for_binding() const
+{
+    return canvas_element();
+}
+
 void WebGLRenderingContextBase::needs_to_present()
 {
     m_should_present = true;

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
@@ -23,6 +23,8 @@ public:
 
     void present();
 
+    NonnullRefPtr<HTML::HTMLCanvasElement> canvas_for_binding() const;
+
     bool is_context_lost() const;
 
     Optional<Vector<String>> get_supported_extensions() const;

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/RefCounted.h>
+#include <AK/RefCountForwarder.h>
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
 #include <LibGL/GLContext.h>
@@ -16,7 +16,7 @@
 namespace Web::WebGL {
 
 class WebGLRenderingContextBase
-    : public RefCounted<WebGLRenderingContextBase>
+    : public RefCountForwarder<HTML::HTMLCanvasElement>
     , public Weakable<WebGLRenderingContextBase> {
 public:
     virtual ~WebGLRenderingContextBase();
@@ -63,8 +63,6 @@ protected:
     WebGLRenderingContextBase(HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<GL::GLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters);
 
 private:
-    WeakPtr<HTML::HTMLCanvasElement> m_canvas_element;
-
     NonnullOwnPtr<GL::GLContext> m_context;
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#context-creation-parameters
@@ -86,6 +84,9 @@ private:
     bool m_should_present { true };
 
     GLenum m_error { GL_NO_ERROR };
+
+    HTML::HTMLCanvasElement& canvas_element();
+    HTML::HTMLCanvasElement const& canvas_element() const;
 
     void needs_to_present();
     void set_error(GLenum error);

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.idl
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.idl
@@ -1,3 +1,4 @@
+#import <HTML/HTMLCanvasElement.idl>
 #import <WebGL/Types.idl>
 
 dictionary WebGLContextAttributes {
@@ -17,6 +18,9 @@ interface mixin WebGLRenderingContextBase {
     //       This is because context loss is handled manually on a function by function basis instead of having to add it to the
     //       IDL code generator. This also allows us to handle the return type ourselves instead of adding the complexity of the
     //       code generator working out the return type and returning the appropriate value to return on context loss.
+
+    // FIXME: The type should be (HTMLCanvasElement or OffscreenCanvas).
+    [ImplementedAs=canvas_for_binding] readonly attribute HTMLCanvasElement canvas;
 
     boolean isContextLost();
 


### PR DESCRIPTION
This allows HTMLCanvasElement and its rendering contexts to share their lifetimes, as JS allows them to arbitrarily access them at any time and the rendering contexts have an IDL back reference to the canvas which expects a non-null return value.