### PR TITLE
Ports: Remove creation of ccache links to `i686-pc-serenity-{cc,c++}`

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -28,7 +28,7 @@ enable_ccache() {
     if [ "${USE_CCACHE:-true}" = "true" ] && command -v ccache &>/dev/null; then
         ccache_tooldir="${SERENITY_BUILD_DIR}/ccache"
         mkdir -p "$ccache_tooldir"
-        for tool in cc clang gcc c++ clang++ g++; do
+        for tool in clang gcc clang++ g++; do
             ln -sf "$(command -v ccache)" "${ccache_tooldir}/${SERENITY_ARCH}-pc-serenity-${tool}"
         done
         export PATH="${ccache_tooldir}:$PATH"


### PR DESCRIPTION
Removes faulty ccache link creation towards non existing targets `i686-pc-serenity-{cc,c++}`, fixing the build of at least the `gcc` port.

Fixes #14344.