### PR TITLE
Kernel: Eliminate possible KASLR leak by disabling CR4.FSGSBASE

### DIFF
--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -593,6 +593,12 @@ UNMAP_AFTER_INIT void Processor::cpu_setup()
     constexpr u64 rflags_mask = 0x257fd5u;
     MSR sfmask_msr(MSR_SFMASK);
     sfmask_msr.set(rflags_mask);
+
+    if (has_feature(CPUFeature::FSGSBASE)) {
+        // Turn off CR4.FSGSBASE to ensure the current Processor base kernel address is not leaked via
+        // the RDGSBASE instruction until we implement proper GS swapping at the userspace/kernel boundaries
+        write_cr4(read_cr4() & ~0x10000);
+    }
 #endif
 
     // Query OS-enabled CPUID features again, and set the flags if needed.


### PR DESCRIPTION
The RDGSBASE userspace instruction allows programs to read the contents of the gs segment register which contains a kernel pointer to the base of the current Processor struct.

Since we don't use this instruction in Serenity at the moment, we can simply disable it for now to ensure we don't break KASLR. Support can later be restored once proper swapping of the contents of gs is done on userspace/kernel boundaries.