### PR TITLE
AK: Clear the previous and next pointers of deleted HashTable buckets

### DIFF
--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -704,11 +704,12 @@ private:
                 bucket.previous->next = bucket.next;
             else
                 m_collection_data.head = bucket.next;
-
+            bucket.previous = nullptr;
             if (bucket.next)
                 bucket.next->previous = bucket.previous;
             else
                 m_collection_data.tail = bucket.previous;
+            bucket.next = nullptr;
         }
     }
 

--- a/Tests/AK/TestHashMap.cpp
+++ b/Tests/AK/TestHashMap.cpp
@@ -201,3 +201,13 @@ TEST_CASE(basic_contains)
     EXPECT_EQ(map.remove(1), true);
     EXPECT_EQ(map.contains(1), false);
 }
+
+TEST_CASE(in_place_rehashing_ordered_loop_bug)
+{
+    OrderedHashMap<String, String> map;
+    map.set("yt.innertube::nextId", "");
+    map.set("yt.innertube::requests", "");
+    map.remove("yt.innertube::nextId");
+    map.set("yt.innertube::nextId", "");
+    VERIFY(map.keys().size() == 2);
+}


### PR DESCRIPTION
Usually the values of the previous and next pointers of deleted buckets are never used, as they're not part of the main ordered bucket chain, but if an in-place rehashing is done, which results in the bucket being turned into a free bucket, the stale pointers will remain, at which point any item that is inserted into said free-bucket will have either a stale previous pointer if the HashTable was empty on insertion, or a stale next pointer, resulting in undefined behaviour.