### PR TITLE
FreeBSD compile support

### DIFF
--- a/AK/StackInfo.cpp
+++ b/AK/StackInfo.cpp
@@ -12,7 +12,7 @@
 
 #ifdef __serenity__
 #    include <serenity.h>
-#elif defined(__linux__) or defined(AK_OS_MACOS)
+#elif defined(__linux__) or defined(AK_OS_MACOS) or defined(AK_OS_BSD_GENERIC)
 #    include <pthread.h>
 #endif
 

--- a/Documentation/BuildInstructionsOther.md
+++ b/Documentation/BuildInstructionsOther.md
@@ -63,6 +63,6 @@ doas pkg_add bash cmake g++ gcc git gmake gmp ninja ccache rsync coreutils qemu 
 ## FreeBSD prerequisites
 
 ```console
-pkg install qemu bash cmake coreutils e2fsprogs fusefs-ext2 gcc11 git gmake ninja sudo gmp mpc mpfr ccache rsync
+pkg install qemu bash cmake coreutils e2fsprogs fusefs-ext2 gcc11 git gmake ninja sudo gmp mpc mpfr ccache rsync texinfo
 ```
 Optional: `fusefs-ext2` for [building images without root](https://github.com/SerenityOS/serenity/pull/11224).

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -182,9 +182,14 @@ cleanup() {
             if [ $USE_FUSE2FS -eq 1 ]; then
                 fusermount -u mnt || (sleep 1 && sync && fusermount -u mnt)
             else
-                umount mnt || ( sleep 1 && sync && umount mnt )
+                if [ ! "$(uname -s)" = "FreeBSD" ]; then
+                    umount mnt || ( sleep 1 && sync && umount mnt )
+                fi
             fi
-            rmdir mnt
+            # disable on freebsd
+            if [ ! "$(uname -s)" = "FreeBSD" ]; then
+               rmdir mnt
+            fi
         else
             rm -rf mnt
         fi

--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -251,7 +251,9 @@ String DateTime::to_string(StringView format) const
                 format_time_zone_offset(true);
                 break;
             case 'Z':
+#if !defined(__FreeBSD__)
                 builder.append(tzname[daylight]);
+#endif
                 break;
             case '%':
                 builder.append('%');

--- a/Userland/Libraries/LibTest/CrashTest.cpp
+++ b/Userland/Libraries/LibTest/CrashTest.cpp
@@ -12,7 +12,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#ifndef AK_OS_MACOS
+#if !defined(AK_OS_MACOS) && !defined(AK_OS_BSD_GENERIC)
 #    include <sys/prctl.h>
 #endif
 
@@ -38,7 +38,7 @@ bool Crash::run(RunType run_type)
             perror("fork");
             VERIFY_NOT_REACHED();
         } else if (pid == 0) {
-#ifndef AK_OS_MACOS
+#if !defined(AK_OS_MACOS) && !defined(AK_OS_BSD_GENERIC)
             if (prctl(PR_SET_DUMPABLE, 0, 0) < 0)
                 perror("prctl(PR_SET_DUMPABLE)");
 #endif


### PR DESCRIPTION
these changesets are for fixing compilation on a freebsd host. tested on a 13.1 freebsd vm.

Results from running test suite
```
$ uname -a
FreeBSD freebsd 13.1-RELEASE FreeBSD 13.1-RELEASE releng/13.1-n250148-fc952ac2212 GENERIC amd64

$ ./Meta/serenity.sh test
...
...
...
Test Suites: 0 total
Tests:       1 failed, 24 skipped, 191 passed, 216 total
Files:       192 total
Time:        308.526s
Failed tests: [ /usr/Tests/LibTLS/TestTLSHandshake ]
```