### PR TITLE
Kernel: Enable -ftrivial-auto-var-init as a security mitigation

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -495,6 +495,18 @@ add_compile_options(-fno-exceptions)
 # FIXME: remove -nodefaultlibs after the next toolchain update
 add_compile_options(-nodefaultlibs -nostdlib)
 
+# Auto initialize trivial types on the stack, we use "pattern" as 
+# it's the only option portable across compilers going forward.
+#
+# This is designed to help avoid uninitialized variables bugs and
+# information disclosures coming from the kernel stack. 
+#
+# FIXME: It appears to conflict with something during the boot of the
+# aarch64 kernel, we should investigate and remove this special case.
+if (NOT "${SERENITY_ARCH}" STREQUAL "aarch64")
+    add_compile_options(-ftrivial-auto-var-init=pattern)
+endif()
+
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # Apply any flags that are only available on >= GCC 11.1
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.1")


### PR DESCRIPTION
The flag will automatically initialize all variables to a pattern based
on it's type. The goal being here is to eradicate an entire bug class of
of issues that can originate from uninitialized stack memory.

Some examples include:
 - Kernel information disclosure, where uninitialized struct members or struct
   padding is copied back to usermode, leaking kernel information such as stack
   or heap addresses, or secret data like stack cookies.

 - Control flow based on uninitialized memory can cause a variety of issues at
   runtime, including stack corruptions like buffer overflows, heap corruptions
   due to deleting stray pointers. Even basic logic bugs can result from control
   flow operating on uninitialized data.

As of GCC 12 this flag is now supported.
https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=a25e0b5e6ac8a77a71c229e0a7b744603365b0e9

Clang has already supported it for a few releases.
https://reviews.llvm.org/D54604