### PR TITLE
LibELF: Add test for dlsym(RTLD_DEFAULT)

### DIFF
--- a/Tests/LibELF/CMakeLists.txt
+++ b/Tests/LibELF/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(CMAKE_SKIP_RPATH FALSE)
 macro(add_dlopen_lib NAME FUNCTION)
     add_library(${NAME} SHARED Dynlib.cpp)
     target_compile_definitions(${NAME} PRIVATE -DFUNCTION=${FUNCTION})
@@ -6,10 +7,16 @@ macro(add_dlopen_lib NAME FUNCTION)
 	 # Avoid execution by the test runner
     install(TARGETS ${NAME}
             DESTINATION usr/Tests/LibELF
-            PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
+            PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE GROUP_WRITE)
 endmacro()
 add_dlopen_lib(DynlibA dynliba_function)
 add_dlopen_lib(DynlibB dynlibb_function)
+
+add_dlopen_lib(DynlibC dynlibc_function)
+set(CMAKE_INSTALL_RPATH $ORIGIN)
+add_dlopen_lib(DynlibD dynlibd_function)
+target_link_libraries(DynlibD DynlibC)
+unset(CMAKE_INSTALL_RPATH)
 
 set(TEST_SOURCES
     test-elf.cpp

--- a/Tests/LibELF/TestDlOpen.cpp
+++ b/Tests/LibELF/TestDlOpen.cpp
@@ -23,3 +23,24 @@ TEST_CASE(test_dlopen)
     EXPECT_NE(func_b, nullptr);
     EXPECT_EQ(0, func_b());
 }
+
+TEST_CASE(test_dlsym_rtld_default)
+{
+    auto libd = dlopen("/usr/Tests/LibELF/libDynlibD.so", 0);
+    EXPECT_NE(libd, nullptr);
+    if (libd == nullptr) {
+        warnln("can't open libDynlibD.so, {}", dlerror());
+        return;
+    }
+
+    typedef int (*dynlib_func_t)();
+    dynlib_func_t func_c = (dynlib_func_t)dlsym(RTLD_DEFAULT, "dynlibc_function");
+    EXPECT_NE(func_c, nullptr);
+    EXPECT_EQ(0, func_c());
+
+    dynlib_func_t func_d = (dynlib_func_t)dlsym(RTLD_DEFAULT, "dynlibd_function");
+    EXPECT_NE(func_d, nullptr);
+    EXPECT_EQ(0, func_d());
+
+    dlclose(libd);
+}

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -299,8 +299,16 @@ static void for_each_unfinished_dependency_of(String const& name, HashTable<Stri
     if (!loader.has_value())
         return;
 
-    if (loader.value()->is_fully_initialized())
+    if (loader.value()->is_fully_relocated()) {
+        if (!loader.value()->is_fully_initialized()) {
+            // If we are ending up here, that possibly means that this library either dlopens itself or a library that depends
+            // on it while running its initializers. Assuming that this is the only funny thing that the library does, there is
+            // a reasonable chance that nothing breaks, so just warn and continue.
+            dbgln("\033[33mWarning:\033[0m Querying for dependencies of '{}' while running its initializers", name);
+        }
+
         return;
+    }
 
     if (seen_names.contains(name))
         return;

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -249,6 +249,8 @@ Result<NonnullRefPtr<DynamicObject>, DlErrorMessage> DynamicLoader::load_stage_3
 void DynamicLoader::load_stage_4()
 {
     call_object_init_functions();
+
+    m_fully_initialized = true;
 }
 
 void DynamicLoader::do_lazy_relocations()

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -243,6 +243,8 @@ Result<NonnullRefPtr<DynamicObject>, DlErrorMessage> DynamicLoader::load_stage_3
 #endif
     }
 
+    m_fully_relocated = true;
+
     return NonnullRefPtr<DynamicObject> { *m_dynamic_object };
 }
 

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -82,6 +82,7 @@ public:
 
     DynamicObject const& dynamic_object() const;
 
+    bool is_fully_relocated() const { return m_fully_relocated; }
     bool is_fully_initialized() const { return m_fully_initialized; }
 
 private:
@@ -161,6 +162,7 @@ private:
 
     mutable RefPtr<DynamicObject> m_cached_dynamic_object;
 
+    bool m_fully_relocated { false };
     bool m_fully_initialized { false };
 };
 

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -82,6 +82,8 @@ public:
 
     DynamicObject const& dynamic_object() const;
 
+    bool is_fully_initialized() const { return m_fully_initialized; }
+
 private:
     DynamicLoader(int fd, String filename, void* file_data, size_t file_size, String filepath);
 
@@ -158,6 +160,8 @@ private:
     Vector<DynamicObject::Relocation> m_unresolved_relocations;
 
     mutable RefPtr<DynamicObject> m_cached_dynamic_object;
+
+    bool m_fully_initialized { false };
 };
 
 template<typename F>


### PR DESCRIPTION
Add test to make sure that we can dlsym symbols from dependencies of dlopen'd libraries.

This was broken by re-organization of when objects are added to s_global_objects in 07208feae78496e516bf7038e9f59f1a285c31ea . The logic for dlopen to figure out if we should recurse objects that may already be loaded to re-load them was depending on the indication for an object being "fully loaded" to be whether it exists in that hash map. 

This is quite fragile, so Tim's fix adds a flag to each DynamicLoader that knows if we've handled its load steps properly when recursing dependencies of libraries that we're trying to load.

This opens up a possibility that we could do weird things when an object dlopens another object which is not fully initialized from within static initializers. So, add a warning for that case. Hopefully no real world programs :tm: are insane enough to do this.


As a side effect, this un-breaks the OpenJDK port :^)