### PR TITLE
Kernel/Graphics: Move GenericDisplayConnector code to a new sub-folder

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -81,10 +81,10 @@ set(KERNEL_SOURCES
     Graphics/Console/TextModeConsole.cpp
     Graphics/Console/VGAConsole.cpp
     Graphics/DisplayConnector.cpp
+    Graphics/Generic/DisplayConnector.cpp
     Graphics/GraphicsManagement.cpp
     Graphics/Intel/NativeDisplayConnector.cpp
     Graphics/Intel/NativeGraphicsAdapter.cpp
-    Graphics/VGA/DisplayConnector.cpp
     Graphics/VGA/ISAAdapter.cpp
     Graphics/VGA/PCIAdapter.cpp
     Graphics/VGA/VGACompatibleAdapter.cpp

--- a/Kernel/Graphics/Generic/DisplayConnector.cpp
+++ b/Kernel/Graphics/Generic/DisplayConnector.cpp
@@ -8,8 +8,8 @@
 #include <Kernel/Debug.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Graphics/Console/ContiguousFramebufferConsole.h>
+#include <Kernel/Graphics/Generic/DisplayConnector.h>
 #include <Kernel/Graphics/GraphicsManagement.h>
-#include <Kernel/Graphics/VGA/DisplayConnector.h>
 
 namespace Kernel {
 

--- a/Kernel/Graphics/Generic/DisplayConnector.h
+++ b/Kernel/Graphics/Generic/DisplayConnector.h
@@ -36,7 +36,10 @@ protected:
 
     virtual bool partial_flush_support() const override final { return false; }
     virtual bool flush_support() const override final { return false; }
-    // Note: This is possibly a paravirtualized hardware, but since we don't know, we assume there's no refresh rate...
+    // Note: This is "possibly" a paravirtualized hardware, but since we don't know, we assume there's no refresh rate...
+    // We rely on the BIOS and/or the bootloader to initialize the hardware for us, so we don't really care about
+    // the specific implementation and settings that were chosen with the given hardware as long as we just
+    // have a dummy framebuffer to work with.
     virtual bool refresh_rate_support() const override final { return false; }
 
     virtual ErrorOr<void> flush_first_surface() override final;

--- a/Kernel/Graphics/VGA/VGACompatibleAdapter.h
+++ b/Kernel/Graphics/VGA/VGACompatibleAdapter.h
@@ -9,8 +9,8 @@
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Graphics/Console/Console.h>
+#include <Kernel/Graphics/Generic/DisplayConnector.h>
 #include <Kernel/Graphics/GenericGraphicsAdapter.h>
-#include <Kernel/Graphics/VGA/DisplayConnector.h>
 #include <Kernel/PhysicalAddress.h>
 
 namespace Kernel {


### PR DESCRIPTION
In the same fashion like in the Linux kernel, we support pre-initialized
framebuffers that were set up by either the BIOS or the bootloader.
These framebuffers can be backed by any kind of video hardware, and are
not tied to VGA hardware at all. Therefore, this code should be in a
separate sub-folder in the Graphics subsystem to indicate this.