### PR TITLE
LibWeb: Trigger a relayout after setting Element.innerHTML

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -468,6 +468,7 @@ ExceptionOr<void> Element::set_inner_html(String const& markup)
 
     // NOTE: Since the DOM has changed, we have to rebuild the layout tree.
     document().invalidate_layout();
+    document().set_needs_layout();
     return {};
 }
 


### PR DESCRIPTION
This fixes the little text animation in serenity's [2nd birthday page](http://serenityos.org/happy/2nd/).