### PR TITLE
Toolchain: Set '/' as default division character for binutils

### DIFF
--- a/Toolchain/Patches/binutils.patch
+++ b/Toolchain/Patches/binutils.patch
@@ -1,24 +1,20 @@
-From e80a89e9446501bcaf42dc8ade8ff8a1cd0458bb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bertalan <dani@danielbertalan.dev>
 Date: Thu, 10 Feb 2022 17:49:12 +0100
 Subject: [PATCH] Add support for SerenityOS
 
 Teaches the assembler, BFD, and the linker about the SerenityOS target
 triple.
-
-On x86_64, we override the default base address of non-PIE executables,
-because the default (0x400000) is too close to the beginning of the
-address space, and DynamicLoader often ends up allocating internal data
-at that address. See commit 292398b5857d0104f7c33fdb5d79f45fe8b395dd.
 ---
- bfd/config.bfd                       | 15 +++++++++++++++
- gas/configure.tgt                    |  2 ++
- ld/Makefile.am                       |  1 +
- ld/Makefile.in                       |  1 +
- ld/configure.tgt                     |  9 +++++++++
- ld/emulparams/elf_x86_64_serenity.sh |  2 ++
- 6 files changed, 30 insertions(+)
- create mode 100644 ld/emulparams/elf_x86_64_serenity.sh
+ bfd/config.bfd           | 15 +++++++++++++++
+ gas/config/tc-i386.c     |  3 ++-
+ gas/config/te-serenity.h |  3 +++
+ gas/configure.tgt        |  2 ++
+ ld/Makefile.am           |  1 +
+ ld/Makefile.in           |  1 +
+ ld/configure.tgt         |  9 +++++++++
+ 7 files changed, 33 insertions(+), 1 deletion(-)
+ create mode 100644 gas/config/te-serenity.h
 
 diff --git a/bfd/config.bfd b/bfd/config.bfd
 index cfe58247..9a10e011 100644
@@ -60,15 +56,38 @@ index cfe58247..9a10e011 100644
  #endif
    i[3-7]86-*-lynxos*)
      targ_defvec=i386_elf32_vec
+diff --git a/gas/config/tc-i386.c b/gas/config/tc-i386.c
+index e0632681..4e9ba9fd 100644
+--- a/gas/config/tc-i386.c
++++ b/gas/config/tc-i386.c
+@@ -481,7 +481,8 @@ const char extra_symbol_chars[] = "*%-([{}"
+      && !defined (TE_Haiku)				\
+      && !defined (TE_FreeBSD)				\
+      && !defined (TE_DragonFly)				\
+-     && !defined (TE_NetBSD))
++     && !defined (TE_NetBSD)				\
++     && !defined (TE_SerenityOS))
+ /* This array holds the chars that always start a comment.  If the
+    pre-processor is disabled, these aren't very useful.  The option
+    --divide will remove '/' from this list.  */
+diff --git a/gas/config/te-serenity.h b/gas/config/te-serenity.h
+new file mode 100644
+index 00000000..f38faf59
+--- /dev/null
++++ b/gas/config/te-serenity.h
+@@ -0,0 +1,3 @@
++#include "te-generic.h"
++
++#define TE_SerenityOS 1
 diff --git a/gas/configure.tgt b/gas/configure.tgt
-index 62f806bd..cfc93df9 100644
+index 62f806bd..67ca2445 100644
 --- a/gas/configure.tgt
 +++ b/gas/configure.tgt
 @@ -134,6 +134,7 @@ case ${generic_target} in
        aarch64*-linux-gnu_ilp32)		arch=aarch64:32 ;;
      esac ;;
    aarch64*-*-netbsd*)			fmt=elf em=nbsd;;
-+  aarch64*-*-serenity*)			fmt=elf ;;
++  aarch64*-*-serenity*)			fmt=elf em=serenity ;;
  
    alpha-*-*vms*)			fmt=evax ;;
    alpha-*-osf*)				fmt=ecoff ;;
@@ -76,7 +95,7 @@ index 62f806bd..cfc93df9 100644
    i386-*-*nt*)				fmt=coff em=pe ;;
    i386-*-rdos*)				fmt=elf ;;
    i386-*-darwin*)			fmt=macho ;;
-+  i386-*-serenity)			fmt=elf ;;
++  i386-*-serenity)			fmt=elf em=serenity ;;
  
    ia16-*-elf*)				fmt=elf ;;
  
@@ -105,7 +124,7 @@ index 61e93eea..8b9ee2cf 100644
  	ehppa64linux.c \
  	ei386pep.c \
 diff --git a/ld/configure.tgt b/ld/configure.tgt
-index c7acf3f1..19982e51 100644
+index c7acf3f1..d34b9ea3 100644
 --- a/ld/configure.tgt
 +++ b/ld/configure.tgt
 @@ -59,6 +59,9 @@ aarch64-*-freebsd*)	targ_emul=aarch64fbsd


### PR DESCRIPTION
While we are at it, regenerate the patch and remove some outdated parts of the description.

This eliminates two nasty patches from the upcoming QEMU port.