### PR TITLE
LibWeb: Fix parsing of background-size: contain/cover

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3741,8 +3741,10 @@ RefPtr<StyleValue> Parser::parse_single_background_size_value(TokenStream<Compon
         return nullptr;
     auto x_value = maybe_x_value.release_nonnull();
 
-    if (x_value->to_identifier() == ValueID::Cover || x_value->to_identifier() == ValueID::Contain)
+    if (x_value->to_identifier() == ValueID::Cover || x_value->to_identifier() == ValueID::Contain) {
+        transaction.commit();
         return x_value;
+    }
 
     auto maybe_y_value = parse_css_value(tokens.peek_token());
     if (!maybe_y_value || !property_accepts_value(PropertyID::BackgroundSize, *maybe_y_value)) {


### PR DESCRIPTION
The lack of the `commit()` before returning the `x_value` here meant,
that in `parse_background_value()` the token stream would be one token
behind after parsing the `background-size`. This led to it to returning
null, after it sees the unexpected 'second' contain / cover token.

With this change all of backgrounds.html is working again.