### PR TITLE
Browser: Add preference for new tab

### DIFF
--- a/Base/res/html/misc/new-tab.html
+++ b/Base/res/html/misc/new-tab.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>New Tab</title>
+    <style>
+        body {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        main {
+            text-align: center;
+            display: block;
+            width: 100%;
+            max-width: 400px;
+        }
+
+        img {
+            image-rendering: pixelated;
+        }
+
+        input[type=search] {
+            width: 100%;
+            padding: 5px;
+        }
+
+        #search-buttons {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        button:hover {
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <br>
+        <img src="/res/icons/32x32/app-browser.png" width="64" height="64"><br><br>
+        <form>
+            <input type="search" name="q" id="user_query"><br><br>
+            <div id="search-buttons">
+                <button type="button" onclick="search('bing')">Bing</button>
+                <button type="button" onclick="search('duckduckgo')">DuckDuckGo</button>
+                <button type="button" onclick="search('frogfind')">FrogFind</button>
+                <button type="button" onclick="search('github')">GitHub</button>
+                <button type="button" onclick="search('google')">Google</button>
+                <button type="button" onclick="search('yandex')">Yandex</button>
+            </div>
+        </form>
+        <br><br>
+        <p>Your user agent is: <b><span id="ua"></span></b></p>
+        <p>This page loaded in <b><span id="loadtime"></span></b> ms</p>
+    </main>
+
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            document.getElementById("ua").innerHTML = navigator.userAgent;
+            document.getElementById("loadtime").innerHTML = performance.now();
+        });
+
+        function search(searchEngine) {
+            let query = document.getElementById("user_query").value;
+
+            if (!query) {
+                return;
+            }
+
+            let url;
+            if (searchEngine == "bing") {
+                url = new URL("https://www.bing.com/search");
+                url.searchParams.set("q", query);
+            } else if (searchEngine == "duckduckgo") {
+                url = new URL("https://duckduckgo.com");
+                url.searchParams.set("q", query);
+            } else if (searchEngine == "frogfind") {
+                url = new URL("https://frogfind.com");
+                url.searchParams.set("q", query);
+            } else if (searchEngine == "github") {
+                url = new URL("https://github.com/search");
+                url.searchParams.set("q", query);
+            } else if (searchEngine == "google") {
+                url = new URL("https://google.com/search");
+                url.searchParams.set("q", query);
+            } else if (searchEngine == "yandex") {
+                url = new URL("https://yandex.com/search");
+                url.searchParams.set("text", query);
+            }
+            window.location.href = url.toString();
+        }
+    </script>
+</body>
+</html>

--- a/Userland/Applications/Browser/Browser.h
+++ b/Userland/Applications/Browser/Browser.h
@@ -12,6 +12,7 @@
 namespace Browser {
 
 extern String g_home_url;
+extern String g_new_tab_url;
 extern String g_search_engine;
 extern Vector<String> g_content_filters;
 extern Vector<String> g_proxies;

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -100,7 +100,7 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
     };
 
     m_window_actions.on_create_new_tab = [this] {
-        create_new_tab(Browser::url_from_user_input(Browser::g_home_url), true);
+        create_new_tab(Browser::url_from_user_input(Browser::g_new_tab_url), true);
     };
 
     m_window_actions.on_next_tab = [this] {
@@ -606,6 +606,8 @@ void BrowserWindow::config_string_did_change(String const& domain, String const&
             Browser::g_search_engine = value;
         else if (key == "Home")
             Browser::g_home_url = value;
+        else if (key == "NewTab")
+            Browser::g_new_tab_url = value;
     } else if (group.starts_with("Proxy:")) {
         dbgln("Proxy mapping changed: {}/{} = {}", group, key, value);
         auto proxy_spec = group.substring_view(6);

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -31,6 +31,7 @@ namespace Browser {
 
 String g_search_engine;
 String g_home_url;
+String g_new_tab_url;
 Vector<String> g_content_filters;
 bool g_content_filters_enabled { true };
 Vector<String> g_proxies;
@@ -94,6 +95,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-browser");
 
     Browser::g_home_url = Config::read_string("Browser", "Preferences", "Home", "file:///res/html/misc/welcome.html");
+    Browser::g_new_tab_url = Config::read_string("Browser", "Preferences", "NewTab", "file:///res/html/misc/welcome.html");
     Browser::g_search_engine = Config::read_string("Browser", "Preferences", "SearchEngine", {});
     Browser::g_content_filters_enabled = Config::read_bool("Browser", "Preferences", "EnableContentFilters", true);
 

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -95,7 +95,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-browser");
 
     Browser::g_home_url = Config::read_string("Browser", "Preferences", "Home", "file:///res/html/misc/welcome.html");
-    Browser::g_new_tab_url = Config::read_string("Browser", "Preferences", "NewTab", "file:///res/html/misc/welcome.html");
+    Browser::g_new_tab_url = Config::read_string("Browser", "Preferences", "NewTab", "file:///res/html/misc/new-tab.html");
     Browser::g_search_engine = Config::read_string("Browser", "Preferences", "SearchEngine", {});
     Browser::g_content_filters_enabled = Config::read_bool("Browser", "Preferences", "EnableContentFilters", true);
 

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
@@ -13,6 +13,7 @@
 #include <LibGUI/Model.h>
 
 static String default_homepage_url = "file:///res/html/misc/welcome.html";
+static String default_new_tab_url = "file:///res/html/misc/welcome.html";
 static String default_search_engine = "";
 static String default_color_scheme = "auto";
 static bool default_show_bookmarks_bar = true;
@@ -63,6 +64,10 @@ BrowserSettingsWidget::BrowserSettingsWidget()
     m_homepage_url_textbox = find_descendant_of_type_named<GUI::TextBox>("homepage_url_textbox");
     m_homepage_url_textbox->set_text(Config::read_string("Browser", "Preferences", "Home", default_homepage_url), GUI::AllowCallback::No);
     m_homepage_url_textbox->on_change = [&]() { set_modified(true); };
+
+    m_new_tab_url_textbox = find_descendant_of_type_named<GUI::TextBox>("new_tab_url_textbox");
+    m_new_tab_url_textbox->set_text(Config::read_string("Browser", "Preferences", "NewTab", default_new_tab_url), GUI::AllowCallback::No);
+    m_new_tab_url_textbox->on_change = [&]() { set_modified(true); };
 
     m_color_scheme_combobox = find_descendant_of_type_named<GUI::ComboBox>("color_scheme_combobox");
     m_color_scheme_combobox->set_only_allow_values_from_model(true);
@@ -172,6 +177,15 @@ void BrowserSettingsWidget::apply_settings()
     }
     Config::write_string("Browser", "Preferences", "Home", homepage_url);
 
+    auto new_tab_url = m_new_tab_url_textbox->text();
+    if (!URL(new_tab_url).is_valid()) {
+        GUI::MessageBox::show_error(this->window(), "The new tab URL you have entered is not valid");
+        m_new_tab_url_textbox->select_all();
+        m_new_tab_url_textbox->set_focus(true);
+        return;
+    }
+    Config::write_string("Browser", "Preferences", "NewTab", new_tab_url);
+
     Config::write_bool("Browser", "Preferences", "ShowBookmarksBar", m_show_bookmarks_bar_checkbox->is_checked());
 
     auto color_scheme_index = m_color_scheme_combobox->selected_index();
@@ -194,6 +208,7 @@ void BrowserSettingsWidget::apply_settings()
 void BrowserSettingsWidget::reset_default_values()
 {
     m_homepage_url_textbox->set_text(default_homepage_url);
+    m_new_tab_url_textbox->set_text(default_new_tab_url);
     m_show_bookmarks_bar_checkbox->set_checked(default_show_bookmarks_bar);
     set_color_scheme(default_color_scheme);
     m_auto_close_download_windows_checkbox->set_checked(default_auto_close_download_windows);

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
@@ -13,7 +13,7 @@
 #include <LibGUI/Model.h>
 
 static String default_homepage_url = "file:///res/html/misc/welcome.html";
-static String default_new_tab_url = "file:///res/html/misc/welcome.html";
+static String default_new_tab_url = "file:///res/html/misc/new-tab.html";
 static String default_search_engine = "";
 static String default_color_scheme = "auto";
 static bool default_show_bookmarks_bar = true;

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.gml
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.gml
@@ -9,7 +9,7 @@
         title: "Homepage"
         fixed_height: 70
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 8, 8]
+            margins: [2, 8, 2]
             spacing: 2
         }
 
@@ -24,15 +24,42 @@
                 icon: "/res/icons/32x32/home.png"
             }
 
-            @GUI::Label {
-                text: "URL:"
-                text_alignment: "CenterLeft"
-                fixed_width: 30
-            }
+            @GUI::Widget {
+                layout: @GUI::VerticalBoxLayout {
+                }
 
-            @GUI::TextBox {
-                name: "homepage_url_textbox"
-                placeholder: "https://example.com"
+                @GUI::Widget {
+                    layout: @GUI::HorizontalBoxLayout {
+                        spacing: 16
+                    }
+
+                    @GUI::Label {
+                        text: "URL:"
+                        text_alignment: "CenterLeft"
+                        fixed_width: 45
+                    }
+
+                    @GUI::TextBox {
+                        name: "homepage_url_textbox"
+                        placeholder: "https://example.com"
+                    }
+                }
+                @GUI::Widget {
+                     layout: @GUI::HorizontalBoxLayout {
+                         spacing: 16
+                     }
+
+                     @GUI::Label {
+                         text: "New Tab:"
+                         text_alignment: "CenterLeft"
+                         fixed_width: 45
+                     }
+
+                     @GUI::TextBox {
+                         name: "new_tab_url_textbox"
+                         placeholder: "https://example.com"
+                     }
+                }
             }
         }
     }

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.h
@@ -24,6 +24,7 @@ private:
     BrowserSettingsWidget();
 
     RefPtr<GUI::TextBox> m_homepage_url_textbox;
+    RefPtr<GUI::TextBox> m_new_tab_url_textbox;
     void set_color_scheme(StringView);
     RefPtr<GUI::ComboBox> m_color_scheme_combobox;
     RefPtr<GUI::CheckBox> m_show_bookmarks_bar_checkbox;


### PR DESCRIPTION
Separate the "Homepage" preference to "Homepage" and "New tab" so you can have different values.

Also a new default "new tab"-page heavily inspired by Firefox to make it easier to use the different search engines.

![image](https://user-images.githubusercontent.com/93391300/175794294-36d5b4e3-3760-4286-b5ab-2fa24767ddf7.png)

The settings Homepage-group got a bit crowded. I didn't feel comfortable making any major design decisions on this one.

![image](https://user-images.githubusercontent.com/93391300/175794255-0e850ef0-ec1a-4a46-a44e-19fc8aec04d7.png)

One issue is that new-tab.html takes ~2 sec on my machine to load. It's better then welcome.html for me but still not great. This one I leave to someone that understands profiling and browser rendering engines :^)