### PR TITLE
Spreadsheet: Stuff and things

### DIFF
--- a/AK/CheckedFormatString.h
+++ b/AK/CheckedFormatString.h
@@ -15,7 +15,7 @@
 #ifdef ENABLE_COMPILETIME_FORMAT_CHECK
 // FIXME: Seems like clang doesn't like calling 'consteval' functions inside 'consteval' functions quite the same way as GCC does,
 //        it seems to entirely forget that it accepted that parameters to a 'consteval' function to begin with.
-#    if defined(__clang__) || defined(__CLION_IDE_)
+#    if defined(__clang__) || defined(__CLION_IDE__) || defined(__CLION_IDE_)
 #        undef ENABLE_COMPILETIME_FORMAT_CHECK
 #    endif
 #endif

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -35,7 +35,7 @@
 #    define VALIDATE_IS_X86() static_assert(false, "Trying to include x86 only header on non x86 platform");
 #endif
 
-#if !defined(__clang__) && !defined(__CLION_IDE_)
+#if !defined(__clang__) && !defined(__CLION_IDE_) && !defined(__CLION_IDE__)
 #    define AK_HAS_CONDITIONALLY_TRIVIAL
 #endif
 

--- a/Base/res/js/Spreadsheet/runtime.js
+++ b/Base/res/js/Spreadsheet/runtime.js
@@ -635,6 +635,12 @@ function internal_lookup(
     reference
 ) {
     if_missing = if_missing ?? undefined;
+    const missing = () => {
+        if (if_missing !== undefined) return if_missing;
+
+        throw new Error(`Failed to find ${req_lookup_value} in ${lookup_inputs}`);
+    };
+
     mode = mode ?? "exact";
     const lookup_value = req_lookup_value;
     let matches = null;
@@ -661,7 +667,7 @@ function internal_lookup(
         ++i;
     });
 
-    if (found_input == null) return if_missing;
+    if (found_input == null) return missing();
 
     if (lookup_outputs === undefined) {
         if (reference) return found_input;
@@ -691,14 +697,7 @@ function lookup(req_lookup_value, lookup_inputs, lookup_outputs, if_missing, mod
 }
 
 function reflookup(req_lookup_value, lookup_inputs, lookup_outputs, if_missing, mode) {
-    return internal_lookup(
-        req_lookup_value,
-        lookup_inputs,
-        lookup_outputs,
-        if_missing ?? here(),
-        mode,
-        true
-    );
+    return internal_lookup(req_lookup_value, lookup_inputs, lookup_outputs, if_missing, mode, true);
 }
 
 // Cheat the system and add documentation
@@ -1223,8 +1222,8 @@ lookup.__documentation = JSON.stringify({
         "Allows for finding things in a table or tabular data, by looking for matches in one range, and " +
         "grabbing the corresponding output value from another range.\n" +
         "if `lookup target` is not specified or is nullish, it is assumed to be the same as the `lookup source`\n." +
-        "if nothing matches, the value `value if no match`" +
-        " is returned, which is `undefined` by default.\nBy setting the `match method`, the function can be altered to return " +
+        "if nothing matches, either the value `value if no match` (if not `undefined`) is returned, or " +
+        "an error is thrown.\nBy setting the `match method`, the function can be altered to return " +
         "the closest ordered value (above or below) instead of an exact match. The valid choices for `match method` are:\n" +
         "- `'exact'`: The default method. Uses strict equality to match values.\n" +
         "- `'nextlargest'`: Uses the greater-or-equal operator to match values.\n" +
@@ -1251,8 +1250,8 @@ reflookup.__documentation = JSON.stringify({
         "Allows for finding references to things in a table or tabular data, by looking for matches in one range, and " +
         "grabbing the corresponding output value from another range.\n" +
         "if `lookup target` is not specified or is nullish, it is assumed to be the same as the `lookup source`\n." +
-        "if nothing matches, the value `value if no match`" +
-        " is returned, which is `undefined` by default.\nBy setting the `match method`, the function can be altered to return " +
+        "if nothing matches, either the value `value if no match` (if not `undefined`) is returned, or " +
+        "an error is thrown.\nBy setting the `match method`, the function can be altered to return " +
         "the closest ordered value (above or below) instead of an exact match. The valid choices for `match method` are:\n" +
         "- `'exact'`: The default method. Uses strict equality to match values.\n" +
         "- `'nextlargest'`: Uses the greater-or-equal operator to match values.\n" +

--- a/Userland/Applications/Spreadsheet/Cell.h
+++ b/Userland/Applications/Spreadsheet/Cell.h
@@ -50,6 +50,15 @@ struct Cell : public Weakable<Cell> {
     bool dirty() const { return m_dirty; }
     void clear_dirty() { m_dirty = false; }
 
+    StringView name_for_javascript(Sheet const& sheet) const
+    {
+        if (!m_name_for_javascript.is_empty())
+            return m_name_for_javascript;
+
+        m_name_for_javascript = String::formatted("cell {}", m_position.to_cell_identifier(sheet));
+        return m_name_for_javascript;
+    }
+
     void set_thrown_value(JS::Value value) { m_thrown_value = value; }
     Optional<JS::Value> thrown_value() const
     {
@@ -116,6 +125,7 @@ private:
     CellType const* m_type { nullptr };
     CellTypeMetadata m_type_metadata;
     Position m_position;
+    mutable String m_name_for_javascript;
 
     Vector<ConditionalFormat> m_conditional_formats;
     Format m_evaluated_formats;

--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -154,6 +154,7 @@ void SheetGlobalObject::initialize_global_object()
     define_native_function("column_arithmetic", column_arithmetic, 2, attr);
     define_native_function("column_index", column_index, 1, attr);
     define_native_function("get_column_bound", get_column_bound, 1, attr);
+    define_native_accessor("name", get_name, nullptr, attr);
 }
 
 void SheetGlobalObject::visit_edges(Visitor& visitor)
@@ -165,6 +166,17 @@ void SheetGlobalObject::visit_edges(Visitor& visitor)
 
         visitor.visit(it.value->evaluated_data());
     }
+}
+
+JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::get_name)
+{
+    auto* this_object = TRY(vm.this_value(global_object).to_object(global_object));
+
+    if (!is<SheetGlobalObject>(this_object))
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::NotAnObjectOfType, "SheetGlobalObject");
+
+    auto sheet_object = static_cast<SheetGlobalObject*>(this_object);
+    return JS::js_string(global_object.heap(), sheet_object->m_sheet.name());
 }
 
 JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::get_real_cell_contents)

--- a/Userland/Applications/Spreadsheet/JSIntegration.h
+++ b/Userland/Applications/Spreadsheet/JSIntegration.h
@@ -39,6 +39,7 @@ public:
     JS_DECLARE_NATIVE_FUNCTION(column_index);
     JS_DECLARE_NATIVE_FUNCTION(column_arithmetic);
     JS_DECLARE_NATIVE_FUNCTION(get_column_bound);
+    JS_DECLARE_NATIVE_FUNCTION(get_name);
 
 private:
     virtual void visit_edges(Visitor&) override;

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -165,8 +165,12 @@ void Sheet::update(Cell& cell)
 JS::ThrowCompletionOr<JS::Value> Sheet::evaluate(StringView source, Cell* on_behalf_of)
 {
     TemporaryChange cell_change { m_current_cell_being_evaluated, on_behalf_of };
+    auto name = on_behalf_of ? on_behalf_of->name_for_javascript(*this) : "cell <unknown>"sv;
+    auto script_or_error = JS::Script::parse(
+        source,
+        interpreter().realm(),
+        name);
 
-    auto script_or_error = JS::Script::parse(source, interpreter().realm());
     if (script_or_error.is_error())
         return interpreter().vm().throw_completion<JS::SyntaxError>(interpreter().global_object(), script_or_error.error().first().to_string());
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -103,6 +103,36 @@ GUI::Variant SheetModel::data(const GUI::ModelIndex& index, GUI::ModelRole role)
         return {};
     }
 
+    if (to_underlying(role) == to_underlying(Role::Tooltip)) {
+        auto const* cell = m_sheet->at({ (size_t)index.column(), (size_t)index.row() });
+        if (!cell || !cell->thrown_value().has_value())
+            return {};
+
+        auto value = cell->thrown_value().value();
+        if (!value.is_object())
+            return {};
+
+        auto& object = value.as_object();
+        if (!is<JS::Error>(object))
+            return {};
+
+        auto& error = static_cast<JS::Error&>(object);
+        auto const& trace = error.traceback();
+        StringBuilder builder;
+        builder.appendff("{}\n", error.get_without_side_effects(object.vm().names.message).to_string_without_side_effects());
+        for (auto const& frame : trace.in_reverse()) {
+            if (frame.source_range.filename.contains("runtime.js")) {
+                if (frame.function_name == "<unknown>")
+                    builder.appendff("  in a builtin function at line {}, column {}\n", frame.source_range.start.line, frame.source_range.start.column);
+                else
+                    builder.appendff("  while evaluating builtin '{}'\n", frame.function_name);
+            } else if (frame.source_range.filename.starts_with("cell ")) {
+                builder.appendff("  in cell '{}', at line {}, column {}\n", frame.source_range.filename.substring_view(5), frame.source_range.start.line, frame.source_range.start.column);
+            }
+        }
+        return builder.to_string();
+    }
+
     return {};
 }
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.h
@@ -13,6 +13,11 @@ namespace Spreadsheet {
 
 class SheetModel final : public GUI::Model {
 public:
+    enum class Role : UnderlyingType<GUI::ModelRole> {
+        _Custom = to_underlying(GUI::ModelRole::Custom),
+        Tooltip,
+    };
+
     static NonnullRefPtr<SheetModel> create(Sheet& sheet) { return adopt_ref(*new SheetModel(sheet)); }
     virtual ~SheetModel() override = default;
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -77,6 +77,16 @@ void InfinitelyScrollableTableView::mousemove_event(GUI::MouseEvent& event)
         sheet.disable_updates();
         ScopeGuard sheet_update_enabler { [&] { sheet.enable_updates(); } };
 
+        if (!is_dragging()) {
+            auto tooltip = model->data(index, static_cast<GUI::ModelRole>(SheetModel::Role::Tooltip));
+            if (tooltip.is_string()) {
+                set_tooltip(tooltip.as_string());
+                show_or_hide_tooltip();
+            } else {
+                set_tooltip({});
+            }
+        }
+
         m_is_hovering_cut_zone = false;
         m_is_hovering_extend_zone = false;
         if (selection().size() > 0 && !m_is_dragging_for_select) {

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -78,6 +78,8 @@ private:
     virtual void mouseup_event(GUI::MouseEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
+    bool is_dragging() const { return m_is_dragging_for_cut || m_is_dragging_for_extend || m_is_dragging_for_select; }
+
     bool m_is_hovering_extend_zone { false };
     bool m_is_hovering_cut_zone { false };
     bool m_is_dragging_for_select { false };

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -383,6 +383,7 @@ void SpreadsheetWidget::try_generate_tip_for_input_expression(StringView source,
         m_inline_documentation_window->hide();
         return;
     }
+    cursor_offset = min(cursor_offset, source.length());
     auto maybe_function_and_argument = get_function_and_argument_index(source.substring_view(0, cursor_offset));
     if (!maybe_function_and_argument.has_value()) {
         m_inline_documentation_window->hide();

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -25,6 +25,7 @@ public:
 
     void save(Core::File&);
     void load_file(Core::File&);
+    void import_sheets(Core::File&);
     bool request_close();
     void add_sheet();
     void add_sheet(NonnullRefPtr<Sheet>&&);
@@ -82,6 +83,8 @@ private:
     RefPtr<GUI::Action> m_save_action;
     RefPtr<GUI::Action> m_save_as_action;
     RefPtr<GUI::Action> m_quit_action;
+
+    RefPtr<GUI::Action> m_import_action;
 
     RefPtr<GUI::Action> m_cut_action;
     RefPtr<GUI::Action> m_copy_action;

--- a/Userland/Applications/Spreadsheet/Tests/basic.js
+++ b/Userland/Applications/Spreadsheet/Tests/basic.js
@@ -78,6 +78,28 @@ describe("Range", () => {
         expect(cellsVisited).toEqual(6);
     });
 
+    test("multiple sheets", () => {
+        const workbook = createWorkbook();
+        const sheet1 = createSheet(workbook, "Sheet 1");
+        const sheet2 = createSheet(workbook, "Sheet 2");
+        sheet1.makeCurrent();
+
+        sheet1.setCell("A", 0, "0");
+        sheet1.focusCell("A", 0);
+
+        sheet2.setCell("A", 0, "0");
+        sheet2.setCell("A", 10, "0");
+        sheet2.setCell("B", 1, "0");
+        sheet2.focusCell("A", 0);
+
+        expect(R).toBeDefined();
+        let cellsVisited = 0;
+        R`sheet("Sheet 2"):A0:A10`.forEach(name => {
+            ++cellsVisited;
+        });
+        expect(cellsVisited).toEqual(11);
+    });
+
     test("Ranges", () => {
         const workbook = createWorkbook();
         const sheet = createSheet(workbook, "Sheet 1");

--- a/Userland/Applications/Spreadsheet/Tests/free-functions.js
+++ b/Userland/Applications/Spreadsheet/Tests/free-functions.js
@@ -191,7 +191,7 @@ describe("Lookup", () => {
         expect(lookup).toBeDefined();
         // Note: String ordering.
         expect(lookup("2", R`A0:A9`, R`B0:B9`)).toEqual("B2");
-        expect(lookup("20", R`A0:A9`, R`B0:B9`)).toBeUndefined();
+        expect(() => lookup("20", R`A0:A9`, R`B0:B9`)).toThrow();
         expect(lookup("80", R`A0:A9`, R`B0:B9`, undefined, "nextlargest")).toEqual("B9");
     });
 
@@ -199,7 +199,7 @@ describe("Lookup", () => {
         expect(reflookup).toBeDefined();
         // Note: String ordering.
         expect(reflookup("2", R`A0:A9`, R`B0:B9`).name).toEqual("B2");
-        expect(reflookup("20", R`A0:A9`, R`B0:B9`)).toEqual(here());
+        expect(() => reflookup("20", R`A0:A9`, R`B0:B9`)).toThrow();
         expect(reflookup("80", R`A0:A9`, R`B0:B9`, undefined, "nextlargest").name).toEqual("B9");
     });
 });

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -76,4 +76,15 @@ Result<bool, String> Workbook::write_to_file(Core::File& file)
     return true;
 }
 
+Result<bool, String> Workbook::import_file(Core::File& file)
+{
+    auto mime = Core::guess_mime_type_based_on_filename(file.filename());
+
+    auto sheets = TRY(ImportDialog::make_and_run_for(m_parent_window, mime, file, *this));
+    auto has_any_changes = !sheets.is_empty();
+    m_sheets.extend(move(sheets));
+
+    return has_any_changes;
+}
+
 }

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -20,6 +20,8 @@ public:
     Result<bool, String> open_file(Core::File&);
     Result<bool, String> write_to_file(Core::File&);
 
+    Result<bool, String> import_file(Core::File&);
+
     String const& current_filename() const { return m_current_filename; }
     bool set_filename(String const& filename);
     bool dirty() { return m_dirty; }


### PR DESCRIPTION
- Don't crash when deleting chars from the formula editor (works around the main issue in #14043)
- `` R`sheet("foo"):A0:A69` ``
- Make `lookup` throw instead of returning `undefined` when it fails to find something (even returning `undefined` is better than what Excel and friends do - returning the wrong thing!)
- "Import sheets from..." option for all your multiple CSV importing needs
- Error stack traces!

I meant to do more with this, but some weird HashMap problem got me bored and I stopped here ^^'
