### PR TITLE
LibJS: Check for add overflow in `DataViewConstructor`

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Checked.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/DataView.h>
 #include <LibJS/Runtime/DataViewConstructor.h>
@@ -61,7 +62,8 @@ ThrowCompletionOr<Object*> DataViewConstructor::construct(FunctionObject& new_ta
         view_byte_length = buffer_byte_length - offset;
     } else {
         view_byte_length = TRY(vm.argument(2).to_index(global_object));
-        if (offset + view_byte_length > buffer_byte_length)
+        auto const checked_add = AK::make_checked(view_byte_length) + AK::make_checked(offset);
+        if (checked_add.has_overflow() || checked_add.value() > buffer_byte_length)
             return vm.throw_completion<RangeError>(global_object, ErrorType::InvalidLength, vm.names.DataView);
     }
 

--- a/Userland/Libraries/LibJS/Tests/builtins/DataView/DataView-invalid-length-overflow.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/DataView/DataView-invalid-length-overflow.js
@@ -1,0 +1,6 @@
+test("Issue #13451, integer overflow in offset + view_byte_length", () => {
+    const arrayBuffer = new ArrayBuffer(1);
+    expect(() => {
+        new DataView(arrayBuffer, 1, 1024 * 1024 * 1024 * 4 - 1);
+    }).toThrowWithMessage(RangeError, "Invalid DataView length");
+});


### PR DESCRIPTION
Use the Checked type from AK to verify that offset + view\_byte\_length
is buffer\_byte\_length at most.

Fixes #13451, at least the LibJS part.
