### PR TITLE
Toolchain+LibC: Remove unecessary llvm patches, add tests for ctype

### DIFF
--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SOURCES
     TestAbort.cpp
     TestAssert.cpp
+    TestCType.cpp
     TestIo.cpp
     TestLibCExec.cpp
     TestLibCDirEnt.cpp

--- a/Tests/LibC/TestCType.cpp
+++ b/Tests/LibC/TestCType.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2022, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <ctype.h>
+
+// https://open-std.org/JTC1/SC22/WG14/www/docs/n2912.pdf
+// Section 7.4.1 Character classification functions
+
+// 7.4.1.1 The isalnum function
+// The isalnum function tests for any character for which isalpha or isdigit is true.
+TEST_CASE(test_isalnum)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i >= '0' && i <= '9') || (i >= 'A' && i <= 'Z') || (i >= 'a' && i <= 'z'))
+            EXPECT_NE(isalnum(i), 0);
+        else
+            EXPECT_EQ(isalnum(i), 0);
+    }
+}
+
+// 7.4.1.2 The isalpha function
+// The isalpha function tests for any character for which isupper or islower is true, or any character
+// that is one of a locale-specific set of alphabetic characters for which none of iscntrl, isdigit,
+// ispunct, or isspace is true. In the "C" locale, isalpha returns true only for the characters for
+// which isupper or islower is true.
+TEST_CASE(test_isalpha)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i >= 'A' && i <= 'Z') || (i >= 'a' && i <= 'z'))
+            EXPECT_NE(isalpha(i), 0);
+        else
+            EXPECT_EQ(isalpha(i), 0);
+    }
+}
+
+// 7.4.1.3 The isblank function
+// The isblank function tests for any character that is a standard blank character or is one of a locale-
+// specific set of characters for which isspace is true and that is used to separate words within a line
+// of text. The standard blank characters are the following: space (’ ’ ), and horizontal tab (’\t’ ). In
+// the "C" locale, isblank returns true only for the standard blank characters.
+TEST_CASE(test_isblank)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i == ' ') || (i == '\t'))
+            EXPECT_NE(isblank(i), 0);
+        else
+            EXPECT_EQ(isblank(i), 0);
+    }
+}
+
+// 7.4.1.4 The iscntrl function
+// The iscntrl function tests for any control character
+TEST_CASE(test_iscntrl)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i < ' ') || (i == '\x7F')) // 7F is DEL
+            EXPECT_NE(iscntrl(i), 0);
+        else
+            EXPECT_EQ(iscntrl(i), 0);
+    }
+}
+
+// 7.4.1.5 The isdigit function
+// The isdigit function tests for any decimal-digit character (as defined in 5.2.1)
+TEST_CASE(test_isdigit)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i >= '0' && i <= '9'))
+            EXPECT_NE(isdigit(i), 0);
+        else
+            EXPECT_EQ(isdigit(i), 0);
+    }
+}
+
+// 7.4.1.6 The isgraph function
+// The isgraph function tests for any printing character except space (’ ’).
+TEST_CASE(test_isgraph)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i > ' ' && i <= '~'))
+            EXPECT_NE(isgraph(i), 0);
+        else
+            EXPECT_EQ(isgraph(i), 0);
+    }
+}
+
+// 7.4.1.7 The islower function
+// The islower function tests for any character that is a lowercase letter or is one of a locale-specific set
+// of characters for which none of iscntrl, isdigit, ispunct, or isspace is true. In the "C" locale,
+// islower returns true only for the lowercase letters (as defined in 5.2.1
+TEST_CASE(test_islower)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i >= 'a' && i <= 'z'))
+            EXPECT_NE(islower(i), 0);
+        else
+            EXPECT_EQ(islower(i), 0);
+    }
+}
+
+// 7.4.1.8 The isprint function
+// The isprint function tests for any printing character including space (’ ’).
+TEST_CASE(test_isprint)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i >= ' ' && i <= '~'))
+            EXPECT_NE(isprint(i), 0);
+        else
+            EXPECT_EQ(isprint(i), 0);
+    }
+}
+
+// 7.4.1.9 The ispunct function
+// The ispunct function tests for any printing character that is one of a locale-specific set of punctuation
+// characters for which neither isspace nor isalnum is true. In the "C" locale, ispunct returns true
+// for every printing character for which neither isspace nor isalnum is true
+TEST_CASE(test_ispunct)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i > ' ' && i < '0') || (i > '9' && i < 'A') || (i > 'Z' && i < 'a') || (i > 'z' && i < '\x7F'))
+            EXPECT_NE(ispunct(i), 0);
+        else
+            EXPECT_EQ(ispunct(i), 0);
+    }
+}
+
+// 7.4.1.10 The isspace function
+// The isspace function tests for any character that is a standard white-space character or is one of
+// a locale-specific set of characters for which isalnum is false. The standard white-space characters
+// are the following: space (’ ’ ), form feed (’\f’ ), new-line (’\n’ ), carriage return (’\r’ ), horizontal
+// tab (’\t’ ), and vertical tab (’\v’ ). In the "C" locale, isspace returns true only for the standard
+// white-space characters.
+TEST_CASE(test_isspace)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i == ' ') || (i == '\f') || (i == '\n') || (i == '\r') || (i == '\t') || (i == '\v'))
+            EXPECT_NE(isspace(i), 0);
+        else
+            EXPECT_EQ(isspace(i), 0);
+    }
+}
+
+// 7.4.1.11 The isupper function
+// The isupper function tests for any character that is an uppercase letter or is one of a locale-specific
+// set of characters for which none of iscntrl, isdigit, ispunct, or isspace is true. In the "C" locale,
+// isupper returns true only for the uppercase letters (as defined in 5.2.1)
+TEST_CASE(test_isupper)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i >= 'A' && i <= 'Z'))
+            EXPECT_NE(isupper(i), 0);
+        else
+            EXPECT_EQ(isupper(i), 0);
+    }
+}
+
+// 7.4.1.12 The isxdigit function
+// The isxdigit function tests for any hexadecimal-digit character (as defined in 6.4.4.1).
+TEST_CASE(test_isxdigit)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i >= '0' && i <= '9') || (i >= 'A' && i <= 'F') || (i >= 'a' && i <= 'f'))
+            EXPECT_NE(isxdigit(i), 0);
+        else
+            EXPECT_EQ(isxdigit(i), 0);
+    }
+}
+
+// 7.4.2.1 The tolower function
+// The tolower function converts an uppercase letter to a corresponding lowercase letter
+TEST_CASE(test_tolower)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i >= 'A' && i <= 'Z'))
+            EXPECT_EQ(tolower(i), i + 0x20);
+        else
+            EXPECT_EQ(tolower(i), i);
+    }
+}
+
+// 7.4.2.2 The toupper function
+// The toupper function converts an lowercase letter to a corresponding uppercase letter
+TEST_CASE(test_toupper)
+{
+    for (int i = 0; i < 256; ++i) {
+        if ((i >= 'a' && i <= 'z'))
+            EXPECT_EQ(toupper(i), i - 0x20);
+        else
+            EXPECT_EQ(toupper(i), i);
+    }
+}

--- a/Toolchain/Patches/llvm/0001-Support-Add-support-for-building-LLVM-on-SerenityOS.patch
+++ b/Toolchain/Patches/llvm/0001-Support-Add-support-for-building-LLVM-on-SerenityOS.patch
@@ -1,7 +1,7 @@
-From 9ff3d5362c71dfa9b6aba1dd65a33bb6d8971164 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bertalan <dani@danielbertalan.dev>
 Date: Thu, 14 Apr 2022 09:54:22 +0200
-Subject: [PATCH 1/9] [Support] Add support for building LLVM on SerenityOS
+Subject: [PATCH] [Support] Add support for building LLVM on SerenityOS
 
 Adds SerenityOS `#ifdef`s for platform-specific code.
 
@@ -76,6 +76,3 @@ index 089342030..3ffe064e5 100644
  ProcessInfo llvm::sys::Wait(const ProcessInfo &PI, unsigned SecondsToWait,
                              bool WaitUntilTerminates, std::string *ErrMsg,
                              Optional<ProcessStatistics> *ProcStat) {
--- 
-2.35.3
-

--- a/Toolchain/Patches/llvm/0002-Triple-Add-triple-for-SerenityOS.patch
+++ b/Toolchain/Patches/llvm/0002-Triple-Add-triple-for-SerenityOS.patch
@@ -1,7 +1,7 @@
-From 0cf66d1dbcd3b7c0e2ddd65177066955c41352b7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bertalan <dani@danielbertalan.dev>
 Date: Thu, 14 Apr 2022 09:51:24 +0200
-Subject: [PATCH 2/9] [Triple] Add triple for SerenityOS
+Subject: [PATCH] [Triple] Add triple for SerenityOS
 
 ---
  llvm/include/llvm/ADT/Triple.h | 8 +++++++-
@@ -54,6 +54,3 @@ index a9afcc9db..aef8c7549 100644
      .Default(Triple::UnknownOS);
  }
  
--- 
-2.35.3
-

--- a/Toolchain/Patches/llvm/0003-Driver-Add-support-for-SerenityOS.patch
+++ b/Toolchain/Patches/llvm/0003-Driver-Add-support-for-SerenityOS.patch
@@ -1,7 +1,7 @@
-From 70cbf6e9ed46f0d39f43ac4a43b9bd2cc10da6c3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bertalan <dani@danielbertalan.dev>
 Date: Thu, 14 Apr 2022 10:09:50 +0200
-Subject: [PATCH 3/9] [Driver] Add support for SerenityOS
+Subject: [PATCH] [Driver] Add support for SerenityOS
 
 Adds support for the `$arch-pc-serenity` target to the Clang front end.
 This makes the compiler look for libraries and headers in the right
@@ -590,6 +590,3 @@ index 000000000..d414f8366
 +} // end namespace clang
 +
 +#endif // LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_SERENITY_H
--- 
-2.35.3
-

--- a/Toolchain/Patches/llvm/0004-Driver-Default-to-ftls-model-initial-exec-on-Serenit.patch
+++ b/Toolchain/Patches/llvm/0004-Driver-Default-to-ftls-model-initial-exec-on-Serenit.patch
@@ -1,8 +1,7 @@
-From 50e7b15efa5f7e2ff57e998879fee28fff4a5305 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bertalan <dani@danielbertalan.dev>
 Date: Thu, 14 Apr 2022 10:12:54 +0200
-Subject: [PATCH 4/9] [Driver] Default to -ftls-model=initial-exec on
- SerenityOS
+Subject: [PATCH] [Driver] Default to -ftls-model=initial-exec on SerenityOS
 
 This is a hack to make Clang use the initial-exec TLS model instead of
 the default local-exec when building code for Serenity.
@@ -31,6 +30,3 @@ index f2f18e901..39d6c18fe 100644
  
    if (Args.hasFlag(options::OPT_fnew_infallible,
                     options::OPT_fno_new_infallible, false))
--- 
-2.35.3
-

--- a/Toolchain/Patches/llvm/0005-libc-Add-support-for-SerenityOS.patch
+++ b/Toolchain/Patches/llvm/0005-libc-Add-support-for-SerenityOS.patch
@@ -10,24 +10,17 @@ LibC, namely:
 * The number of errno constants defined by us is given by the value of
   the `ELAST` macro.
 * Multithreading is implemented though the pthread library.
-* Aligned memory allocation is provided by the MSVCRT-like
-  `_aligned_{malloc,free}` functions.
-
-Adds a hack for a header not found error when including
-`<initializer_list>` inside the SerenityOS kernel.
-
-Makes libc++ use its builtin character type table instead of the one
-provided by LibC as it is incomplete.
+* Use libc++'s builtin character type table instead of the one provided
+  by LibC as there's a lot of extra porting work to convince the rest of
+  locale.cpp to use our character type table properly.
 ---
  libcxx/include/CMakeLists.txt               |  1 +
  libcxx/include/__config                     |  6 ++++--
  libcxx/include/__locale                     |  2 ++
  libcxx/include/__support/serenity/xlocale.h | 24 +++++++++++++++++++++
- libcxx/include/initializer_list             |  2 ++
  libcxx/include/locale                       |  2 +-
- libcxx/include/new                          |  4 ++--
  libcxx/src/include/config_elast.h           |  2 ++
- 8 files changed, 38 insertions(+), 5 deletions(-)
+ 6 files changed, 34 insertions(+), 3 deletions(-)
  create mode 100644 libcxx/include/__support/serenity/xlocale.h
 
 diff --git a/libcxx/include/CMakeLists.txt b/libcxx/include/CMakeLists.txt
@@ -109,20 +102,6 @@ index 000000000..0f939d2f6
 +#endif // __serenity__
 +
 +#endif
-diff --git a/libcxx/include/initializer_list b/libcxx/include/initializer_list
-index fefaf8cf8..c388bc246 100644
---- a/libcxx/include/initializer_list
-+++ b/libcxx/include/initializer_list
-@@ -43,7 +43,9 @@ template<class E> const E* end(initializer_list<E> il) noexcept; // constexpr in
- */
- 
- #include <__config>
-+#if !defined(__serenity__) || !defined(KERNEL)
- #include <cstddef>
-+#endif
- 
- #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
- #pragma GCC system_header
 diff --git a/libcxx/include/locale b/libcxx/include/locale
 index 7c2d2361f..229ca7258 100644
 --- a/libcxx/include/locale
@@ -136,28 +115,6 @@ index 7c2d2361f..229ca7258 100644
  #    define _LIBCPP_HAS_CATOPEN 1
  #    include <nl_types.h>
  #  endif
-diff --git a/libcxx/include/new b/libcxx/include/new
-index be0d972f4..d212bae46 100644
---- a/libcxx/include/new
-+++ b/libcxx/include/new
-@@ -320,7 +320,7 @@ inline _LIBCPP_INLINE_VISIBILITY void __libcpp_deallocate_unsized(void* __ptr, s
- // Returns the allocated memory, or `nullptr` on failure.
- inline _LIBCPP_INLINE_VISIBILITY
- void* __libcpp_aligned_alloc(std::size_t __alignment, std::size_t __size) {
--#if defined(_LIBCPP_MSVCRT_LIKE)
-+#if defined(_LIBCPP_MSVCRT_LIKE) || (defined(__serenity__) && !defined(KERNEL))
-   return ::_aligned_malloc(__size, __alignment);
- #else
-   void* __result = nullptr;
-@@ -332,7 +332,7 @@ void* __libcpp_aligned_alloc(std::size_t __alignment, std::size_t __size) {
- 
- inline _LIBCPP_INLINE_VISIBILITY
- void __libcpp_aligned_free(void* __ptr) {
--#if defined(_LIBCPP_MSVCRT_LIKE)
-+#if defined(_LIBCPP_MSVCRT_LIKE) || (defined(__serenity__) && !defined(KERNEL))
-   ::_aligned_free(__ptr);
- #else
-   ::free(__ptr);
 diff --git a/libcxx/src/include/config_elast.h b/libcxx/src/include/config_elast.h
 index 0ed53a3b2..7fffd937e 100644
 --- a/libcxx/src/include/config_elast.h

--- a/Toolchain/Patches/llvm/0005-libc-Add-support-for-SerenityOS.patch
+++ b/Toolchain/Patches/llvm/0005-libc-Add-support-for-SerenityOS.patch
@@ -1,7 +1,7 @@
-From fae5030852da34db641d636ad4c599e56b92ccdf Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bertalan <dani@danielbertalan.dev>
 Date: Thu, 14 Apr 2022 10:17:13 +0200
-Subject: [PATCH 5/9] [libc++] Add support for SerenityOS
+Subject: [PATCH] [libc++] Add support for SerenityOS
 
 This commit teaches libc++ about what features are available in our
 LibC, namely:
@@ -148,6 +148,3 @@ index 0ed53a3b2..7fffd937e 100644
  #elif defined(__sun__)
  #define _LIBCPP_ELAST ESTALE
  #elif defined(__MVS__)
--- 
-2.35.3
-

--- a/Toolchain/Patches/llvm/0005-libc-Add-support-for-SerenityOS.patch
+++ b/Toolchain/Patches/llvm/0005-libc-Add-support-for-SerenityOS.patch
@@ -19,15 +19,29 @@ Adds a hack for a header not found error when including
 Makes libc++ use its builtin character type table instead of the one
 provided by LibC as it is incomplete.
 ---
- libcxx/include/__config                   | 6 ++++--
- libcxx/include/__locale                   | 2 +-
- libcxx/include/__support/newlib/xlocale.h | 4 ++--
- libcxx/include/initializer_list           | 2 ++
- libcxx/include/locale                     | 2 +-
- libcxx/include/new                        | 4 ++--
- libcxx/src/include/config_elast.h         | 2 ++
- 7 files changed, 14 insertions(+), 8 deletions(-)
+ libcxx/include/CMakeLists.txt               |  1 +
+ libcxx/include/__config                     |  6 ++++--
+ libcxx/include/__locale                     |  2 ++
+ libcxx/include/__support/serenity/xlocale.h | 24 +++++++++++++++++++++
+ libcxx/include/initializer_list             |  2 ++
+ libcxx/include/locale                       |  2 +-
+ libcxx/include/new                          |  4 ++--
+ libcxx/src/include/config_elast.h           |  2 ++
+ 8 files changed, 38 insertions(+), 5 deletions(-)
+ create mode 100644 libcxx/include/__support/serenity/xlocale.h
 
+diff --git a/libcxx/include/CMakeLists.txt b/libcxx/include/CMakeLists.txt
+index 53700fc9e..67d50bdbc 100644
+--- a/libcxx/include/CMakeLists.txt
++++ b/libcxx/include/CMakeLists.txt
+@@ -365,6 +365,7 @@ set(files
+   __support/musl/xlocale.h
+   __support/newlib/xlocale.h
+   __support/openbsd/xlocale.h
++  __support/serenity/xlocale.h
+   __support/solaris/floatingpoint.h
+   __support/solaris/wchar.h
+   __support/solaris/xlocale.h
 diff --git a/libcxx/include/__config b/libcxx/include/__config
 index 458d0c1b8..69f627294 100644
 --- a/libcxx/include/__config
@@ -53,39 +67,48 @@ index 458d0c1b8..69f627294 100644
  #endif
  
 diff --git a/libcxx/include/__locale b/libcxx/include/__locale
-index 51f35eece..4bc91ecb5 100644
+index 51f35eece..6f25098a2 100644
 --- a/libcxx/include/__locale
 +++ b/libcxx/include/__locale
-@@ -30,7 +30,7 @@
- #elif defined(__sun__)
- # include <xlocale.h>
- # include <__support/solaris/xlocale.h>
--#elif defined(_NEWLIB_VERSION)
-+#elif defined(_NEWLIB_VERSION) || defined(__serenity__)
- # include <__support/newlib/xlocale.h>
- #elif defined(__OpenBSD__)
- # include <__support/openbsd/xlocale.h>
-diff --git a/libcxx/include/__support/newlib/xlocale.h b/libcxx/include/__support/newlib/xlocale.h
-index b75f9263a..f5ffb9003 100644
---- a/libcxx/include/__support/newlib/xlocale.h
-+++ b/libcxx/include/__support/newlib/xlocale.h
-@@ -9,7 +9,7 @@
- #ifndef _LIBCPP_SUPPORT_NEWLIB_XLOCALE_H
- #define _LIBCPP_SUPPORT_NEWLIB_XLOCALE_H
- 
--#if defined(_NEWLIB_VERSION)
-+#if defined(_NEWLIB_VERSION) || defined(__serenity__)
- 
- #include <cstdlib>
- #include <clocale>
-@@ -22,6 +22,6 @@
- #include <__support/xlocale/__strtonum_fallback.h>
+@@ -44,6 +44,8 @@
+ # include <__support/musl/xlocale.h>
+ #elif defined(_LIBCPP_HAS_MUSL_LIBC)
+ # include <__support/musl/xlocale.h>
++#elif defined(__serenity__)
++# include <__support/serenity/xlocale.h>
  #endif
  
--#endif // _NEWLIB_VERSION
-+#endif // _NEWLIB_VERSION || __serenity__
- 
- #endif
+ #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+diff --git a/libcxx/include/__support/serenity/xlocale.h b/libcxx/include/__support/serenity/xlocale.h
+new file mode 100644
+index 000000000..0f939d2f6
+--- /dev/null
++++ b/libcxx/include/__support/serenity/xlocale.h
+@@ -0,0 +1,24 @@
++//===----------------------------------------------------------------------===//
++//
++// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
++// See https://llvm.org/LICENSE.txt for license information.
++// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
++//
++//===----------------------------------------------------------------------===//
++
++#ifndef _LIBCPP_SUPPORT_SERENITY_XLOCALE_H
++#define _LIBCPP_SUPPORT_SERENITY_XLOCALE_H
++
++#if defined(__serenity__)
++
++#include <cstdlib>
++#include <clocale>
++#include <cwctype>
++#include <ctype.h>
++#include <__support/xlocale/__nop_locale_mgmt.h>
++#include <__support/xlocale/__posix_l_fallback.h>
++#include <__support/xlocale/__strtonum_fallback.h>
++
++#endif // __serenity__
++
++#endif
 diff --git a/libcxx/include/initializer_list b/libcxx/include/initializer_list
 index fefaf8cf8..c388bc246 100644
 --- a/libcxx/include/initializer_list

--- a/Toolchain/Patches/llvm/0006-compiler-rt-Build-crtbegin.o-crtend.o-for-SerenityOS.patch
+++ b/Toolchain/Patches/llvm/0006-compiler-rt-Build-crtbegin.o-crtend.o-for-SerenityOS.patch
@@ -1,7 +1,7 @@
-From 1cf9ec98aa817c13b94b42e4df80804a6757aa8a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bertalan <dani@danielbertalan.dev>
 Date: Thu, 14 Apr 2022 10:20:46 +0200
-Subject: [PATCH 6/9] [compiler-rt] Build crtbegin.o/crtend.o for SerenityOS
+Subject: [PATCH] [compiler-rt] Build crtbegin.o/crtend.o for SerenityOS
 
 ---
  compiler-rt/cmake/config-ix.cmake | 2 +-
@@ -20,6 +20,3 @@ index fc62d5ecc..7a47b7f71 100644
    set(COMPILER_RT_HAS_CRT TRUE)
  else()
    set(COMPILER_RT_HAS_CRT FALSE)
--- 
-2.35.3
-

--- a/Toolchain/Patches/llvm/0007-cmake-Allow-undefined-symbols-on-SerenityOS.patch
+++ b/Toolchain/Patches/llvm/0007-cmake-Allow-undefined-symbols-on-SerenityOS.patch
@@ -1,7 +1,7 @@
-From ac91fd973bdf23b24645336a470d5dfb31811aa6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bertalan <dani@danielbertalan.dev>
 Date: Thu, 14 Apr 2022 10:21:19 +0200
-Subject: [PATCH 7/9] [cmake] Allow undefined symbols on SerenityOS
+Subject: [PATCH] [cmake] Allow undefined symbols on SerenityOS
 
 Allow undefined symbols in LLVM libraries, which is needed because only
 stubs are available for SerenityOS libraries when libc++ and libunwind
@@ -23,6 +23,3 @@ index fcaa8f20b..c27209146 100644
          WIN32 OR CYGWIN) AND
     NOT LLVM_USE_SANITIZER)
    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
--- 
-2.35.3
-

--- a/Toolchain/Patches/llvm/0008-cmake-Support-building-shared-libLLVM-and-libClang-f.patch
+++ b/Toolchain/Patches/llvm/0008-cmake-Support-building-shared-libLLVM-and-libClang-f.patch
@@ -1,7 +1,7 @@
-From eb1dbc59eaebdefd9735b738ca30478ce1788dca Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bertalan <dani@danielbertalan.dev>
 Date: Mon, 18 Apr 2022 22:32:29 +0200
-Subject: [PATCH 8/9] [cmake] Support building shared libLLVM and libClang for
+Subject: [PATCH] [cmake] Support building shared libLLVM and libClang for
  SerenityOS
 
 This patch tells CMake that the --whole-archive linker option should be
@@ -49,6 +49,3 @@ index 8e2b78f1b..909018753 100644
        # Solaris ld does not accept global: *; so there is no way to version *all* global symbols
        set(LIB_NAMES -Wl,--version-script,${LLVM_LIBRARY_DIR}/tools/llvm-shlib/simple_version_script.map ${LIB_NAMES})
      endif()
--- 
-2.35.3
-

--- a/Toolchain/Patches/llvm/0009-compiler-rt-llvm-Enable-profile-instrumentation-for-.patch
+++ b/Toolchain/Patches/llvm/0009-compiler-rt-llvm-Enable-profile-instrumentation-for-.patch
@@ -1,8 +1,8 @@
-From 539a12f2955a737f550be655c56a1a993eaa1ae2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Kaster <akaster@serenityos.org>
 Date: Fri, 4 Mar 2022 15:13:42 -0700
-Subject: [PATCH 9/9] [compiler-rt/llvm] Enable profile instrumentation
- for SerenityOS
+Subject: [PATCH] [compiler-rt/llvm] Enable profile instrumentation for
+ SerenityOS
 
 Treat SerenityOS the same as other *NIX platforms that behave close
 enough to linux to use the pre-canned InstrProfiling implementation.
@@ -17,7 +17,7 @@ OS ABI for userspace binaries to 3, or GNU/Linux.
  4 files changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/compiler-rt/cmake/config-ix.cmake b/compiler-rt/cmake/config-ix.cmake
-index 7a47b7f..8d4211d 100644
+index 7a47b7f71..8d4211deb 100644
 --- a/compiler-rt/cmake/config-ix.cmake
 +++ b/compiler-rt/cmake/config-ix.cmake
 @@ -738,7 +738,7 @@ else()
@@ -30,7 +30,7 @@ index 7a47b7f..8d4211d 100644
  else()
    set(COMPILER_RT_HAS_PROFILE FALSE)
 diff --git a/compiler-rt/lib/profile/InstrProfilingPlatformLinux.c b/compiler-rt/lib/profile/InstrProfilingPlatformLinux.c
-index 592c09b..1833682 100644
+index 592c09b49..1833682d7 100644
 --- a/compiler-rt/lib/profile/InstrProfilingPlatformLinux.c
 +++ b/compiler-rt/lib/profile/InstrProfilingPlatformLinux.c
 @@ -7,7 +7,8 @@
@@ -44,7 +44,7 @@ index 592c09b..1833682 100644
  #include <elf.h>
  #include <link.h>
 diff --git a/compiler-rt/lib/profile/InstrProfilingPlatformOther.c b/compiler-rt/lib/profile/InstrProfilingPlatformOther.c
-index 3e9b3ca..d257013 100644
+index 3e9b3ca0a..d257013dd 100644
 --- a/compiler-rt/lib/profile/InstrProfilingPlatformOther.c
 +++ b/compiler-rt/lib/profile/InstrProfilingPlatformOther.c
 @@ -8,7 +8,7 @@
@@ -57,7 +57,7 @@ index 3e9b3ca..d257013 100644
  #include <stdlib.h>
  #include <stdio.h>
 diff --git a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp b/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
-index 6868408..eaa1b64 100644
+index 6868408ef..eaa1b64d2 100644
 --- a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
 +++ b/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
 @@ -857,7 +857,8 @@ static bool needsRuntimeRegistrationOfSectionRange(const Triple &TT) {
@@ -70,6 +70,3 @@ index 6868408..eaa1b64 100644
      return false;
  
    return true;
--- 
-2.32.0
-

--- a/Userland/Libraries/LibC/ctype.cpp
+++ b/Userland/Libraries/LibC/ctype.cpp
@@ -8,7 +8,8 @@
 
 extern "C" {
 
-char const _ctype_[256] = {
+char const _ctype_[1 + 256] = {
+    0,
     _C, _C, _C, _C, _C, _C, _C, _C,
     _C, _C | _S, _C | _S, _C | _S, _C | _S, _C | _S, _C, _C,
     _C, _C, _C, _C, _C, _C, _C, _C,

--- a/Userland/Libraries/LibC/ctype.h
+++ b/Userland/Libraries/LibC/ctype.h
@@ -10,6 +10,10 @@
 
 __BEGIN_DECLS
 
+#ifndef EOF
+#    define EOF (-1)
+#endif
+
 /* Do what newlib does to appease GCC's --with-newlib option. */
 #define _U 01
 #define _L 02
@@ -20,16 +24,21 @@ __BEGIN_DECLS
 #define _X 0100
 #define _B 0200
 
-extern char const _ctype_[256] __attribute__((visibility("default")));
+/**
+ * newlib has a 257 byte _ctype_ array to enable compiler tricks to catch
+ * people passing char instead of int. We don't engage in those tricks,
+ * but still claim to be newlib to the toolchains
+ */
+extern char const _ctype_[1 + 256] __attribute__((visibility("default")));
 
 static inline int __inline_isalnum(int c)
 {
-    return _ctype_[(unsigned char)(c)] & (_U | _L | _N);
+    return _ctype_[(unsigned char)(c) + 1] & (_U | _L | _N);
 }
 
 static inline int __inline_isalpha(int c)
 {
-    return _ctype_[(unsigned char)(c)] & (_U | _L);
+    return _ctype_[(unsigned char)(c) + 1] & (_U | _L);
 }
 
 static inline int __inline_isascii(int c)
@@ -39,52 +48,52 @@ static inline int __inline_isascii(int c)
 
 static inline int __inline_iscntrl(int c)
 {
-    return _ctype_[(unsigned char)(c)] & (_C);
+    return _ctype_[(unsigned char)(c) + 1] & (_C);
 }
 
 static inline int __inline_isdigit(int c)
 {
-    return _ctype_[(unsigned char)(c)] & (_N);
+    return _ctype_[(unsigned char)(c) + 1] & (_N);
 }
 
 static inline int __inline_isxdigit(int c)
 {
-    return _ctype_[(unsigned char)(c)] & (_N | _X);
+    return _ctype_[(unsigned char)(c) + 1] & (_N | _X);
 }
 
 static inline int __inline_isspace(int c)
 {
-    return _ctype_[(unsigned char)(c)] & (_S);
+    return _ctype_[(unsigned char)(c) + 1] & (_S);
 }
 
 static inline int __inline_ispunct(int c)
 {
-    return _ctype_[(unsigned char)(c)] & (_P);
+    return _ctype_[(unsigned char)(c) + 1] & (_P);
 }
 
 static inline int __inline_isprint(int c)
 {
-    return _ctype_[(unsigned char)(c)] & (_P | _U | _L | _N | _B);
+    return _ctype_[(unsigned char)(c) + 1] & (_P | _U | _L | _N | _B);
 }
 
 static inline int __inline_isgraph(int c)
 {
-    return _ctype_[(unsigned char)(c)] & (_P | _U | _L | _N);
+    return _ctype_[(unsigned char)(c) + 1] & (_P | _U | _L | _N);
 }
 
 static inline int __inline_islower(int c)
 {
-    return _ctype_[(unsigned char)(c)] & (_L);
+    return _ctype_[(unsigned char)(c) + 1] & (_L);
 }
 
 static inline int __inline_isupper(int c)
 {
-    return _ctype_[(unsigned char)(c)] & (_U);
+    return _ctype_[(unsigned char)(c) + 1] & (_U);
 }
 
 static inline int __inline_isblank(int c)
 {
-    return _ctype_[(unsigned char)(c)] & (_B) || (c == '\t');
+    return _ctype_[(unsigned char)(c) + 1] & (_B) || (c == '\t');
 }
 
 static inline int __inline_toascii(int c)


### PR DESCRIPTION
newlib has an extra character slot at the beginning to enable some
macro tricks that cause a warning when someone passes a type that's not
"int" into a ctype function. Our deviation from this causes issues for
LLVM.

Add tests as well, for the ones with a C standard ref. The ones defined in POSIX can be tested later :)

Related to #14183

While we're here, go further and refactor llvm patches to remove hacks and make desired behavior more explicit.