### PR TITLE
Browser: Remove GML formatting errors from BrowserSettingsWidget.gml

### DIFF
--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.gml
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.gml
@@ -25,8 +25,7 @@
             }
 
             @GUI::Widget {
-                layout: @GUI::VerticalBoxLayout {
-                }
+                layout: @GUI::VerticalBoxLayout {}
 
                 @GUI::Widget {
                     layout: @GUI::HorizontalBoxLayout {
@@ -44,21 +43,22 @@
                         placeholder: "https://example.com"
                     }
                 }
+
                 @GUI::Widget {
-                     layout: @GUI::HorizontalBoxLayout {
-                         spacing: 16
-                     }
+                    layout: @GUI::HorizontalBoxLayout {
+                        spacing: 16
+                    }
 
-                     @GUI::Label {
-                         text: "New Tab:"
-                         text_alignment: "CenterLeft"
-                         fixed_width: 45
-                     }
+                    @GUI::Label {
+                        text: "New Tab:"
+                        text_alignment: "CenterLeft"
+                        fixed_width: 45
+                    }
 
-                     @GUI::TextBox {
-                         name: "new_tab_url_textbox"
-                         placeholder: "https://example.com"
-                     }
+                    @GUI::TextBox {
+                        name: "new_tab_url_textbox"
+                        placeholder: "https://example.com"
+                    }
                 }
             }
         }


### PR DESCRIPTION
Regressed in commit 65714554997bacb6fdcc09da0b763defe252b435

This is supposed to be caught by the GML format lint in Azure, but it
looks like a :ninjamerge: occured instead :^)