### PR TITLE
LibELF: Store the full file path in `DynamicObject`

### DIFF
--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -100,7 +100,7 @@ DynamicObject const& DynamicLoader::dynamic_object() const
         });
         VERIFY(!dynamic_section_address.is_null());
 
-        m_cached_dynamic_object = ELF::DynamicObject::create(m_filename, VirtualAddress(image().base_address()), dynamic_section_address);
+        m_cached_dynamic_object = ELF::DynamicObject::create(m_filepath, VirtualAddress(image().base_address()), dynamic_section_address);
     }
     return *m_cached_dynamic_object;
 }
@@ -146,7 +146,7 @@ RefPtr<DynamicObject> DynamicLoader::map()
 
     VERIFY(!m_base_address.is_null());
 
-    m_dynamic_object = DynamicObject::create(m_filename, m_base_address, m_dynamic_section_address);
+    m_dynamic_object = DynamicObject::create(m_filepath, m_base_address, m_dynamic_section_address);
     m_dynamic_object->set_tls_offset(m_tls_offset);
     m_dynamic_object->set_tls_size(m_tls_size_of_current_object);
 
@@ -163,7 +163,7 @@ bool DynamicLoader::load_stage_2(unsigned flags)
     VERIFY(flags & RTLD_GLOBAL);
 
     if (m_dynamic_object->has_text_relocations()) {
-        dbgln("\033[33mWarning:\033[0m Dynamic object {} has text relocations", m_dynamic_object->filename());
+        dbgln("\033[33mWarning:\033[0m Dynamic object {} has text relocations", m_dynamic_object->filepath());
         for (auto& text_segment : m_text_segments) {
             VERIFY(text_segment.address().get() != 0);
 

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -16,8 +16,8 @@
 
 namespace ELF {
 
-DynamicObject::DynamicObject(String const& filename, VirtualAddress base_address, VirtualAddress dynamic_section_address)
-    : m_filename(filename)
+DynamicObject::DynamicObject(String const& filepath, VirtualAddress base_address, VirtualAddress dynamic_section_address)
+    : m_filepath(filepath)
     , m_base_address(base_address)
     , m_dynamic_address(dynamic_section_address)
 {
@@ -474,9 +474,9 @@ auto DynamicObject::lookup_symbol(HashSymbol const& symbol) const -> Optional<Sy
     return SymbolLookupResult { symbol_result.value(), symbol_result.size(), symbol_result.address(), symbol_result.bind(), symbol_result.type(), this };
 }
 
-NonnullRefPtr<DynamicObject> DynamicObject::create(String const& filename, VirtualAddress base_address, VirtualAddress dynamic_section_address)
+NonnullRefPtr<DynamicObject> DynamicObject::create(String const& filepath, VirtualAddress base_address, VirtualAddress dynamic_section_address)
 {
-    return adopt_ref(*new DynamicObject(filename, base_address, dynamic_section_address));
+    return adopt_ref(*new DynamicObject(filepath, base_address, dynamic_section_address));
 }
 
 // offset is in PLT relocation table
@@ -499,7 +499,7 @@ VirtualAddress DynamicObject::patch_plt_entry(u32 relocation_offset)
         if (result.value().type == STT_GNU_IFUNC)
             symbol_location = VirtualAddress { reinterpret_cast<IfuncResolver>(symbol_location.get())() };
     } else if (symbol.bind() != STB_WEAK) {
-        dbgln("did not find symbol while doing relocations for library {}: {}", m_filename, symbol.name());
+        dbgln("did not find symbol while doing relocations for library {}: {}", m_filepath, symbol.name());
         VERIFY_NOT_REACHED();
     }
 

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -20,7 +20,7 @@ namespace ELF {
 
 class DynamicObject : public RefCounted<DynamicObject> {
 public:
-    static NonnullRefPtr<DynamicObject> create(String const& filename, VirtualAddress base_address, VirtualAddress dynamic_section_address);
+    static NonnullRefPtr<DynamicObject> create(String const& filepath, VirtualAddress base_address, VirtualAddress dynamic_section_address);
     static char const* name_for_dtag(ElfW(Sword) d_tag);
 
     ~DynamicObject();
@@ -287,7 +287,7 @@ public:
     VirtualAddress plt_got_base_address() const { return m_base_address.offset(m_procedure_linkage_table_offset.value()); }
     VirtualAddress base_address() const { return m_base_address; }
 
-    String const& filename() const { return m_filename; }
+    String const& filepath() const { return m_filepath; }
 
     StringView rpath() const { return m_has_rpath ? symbol_string_table_string(m_rpath_index) : StringView {}; }
     StringView runpath() const { return m_has_runpath ? symbol_string_table_string(m_runpath_index) : StringView {}; }
@@ -338,13 +338,13 @@ public:
     void* symbol_for_name(StringView name);
 
 private:
-    explicit DynamicObject(String const& filename, VirtualAddress base_address, VirtualAddress dynamic_section_address);
+    explicit DynamicObject(String const& filepath, VirtualAddress base_address, VirtualAddress dynamic_section_address);
 
     StringView symbol_string_table_string(ElfW(Word)) const;
     char const* raw_symbol_string_table_string(ElfW(Word)) const;
     void parse();
 
-    String m_filename;
+    String m_filepath;
 
     VirtualAddress m_base_address;
     VirtualAddress m_dynamic_address;


### PR DESCRIPTION
Otherwise, our `dirname` call on the parent object will always be empty when trying to resolve `$ORIGIN` for dependencies.