### PR TITLE
LibGUI: Invert button icons only when the contrast ratio improves

### DIFF
--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -80,10 +80,14 @@ void Button::paint_event(PaintEvent& event)
 
     if (m_icon) {
         auto solid_color = m_icon->solid_color(60);
-        // Note: 4.5 is the minimum recommended contrast ratio for text on the web:
-        // (https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)
-        // Reusing that threshold here as it seems to work reasonably well.
-        bool should_invert_icon = solid_color.has_value() && palette().button().contrast_ratio(*solid_color) < 4.5f;
+        bool should_invert_icon = false;
+        if (solid_color.has_value()) {
+            auto contrast_ratio = palette().button().contrast_ratio(*solid_color);
+            // Note: 4.5 is the minimum recommended contrast ratio for text on the web:
+            // (https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)
+            // Reusing that threshold here as it seems to work reasonably well.
+            should_invert_icon = contrast_ratio < 4.5f && contrast_ratio < palette().button().contrast_ratio(solid_color->inverted());
+        }
         if (should_invert_icon)
             m_icon->invert();
         if (is_enabled()) {


### PR DESCRIPTION
Fix the algorithm that automatically inverts solid color button icons
when placed in similarly colored backgrounds. It was meant for fixing
black icons in dark themed buttons.

However, there may be situations where the resulting inverted version
is actually worse than the original. This change prevents those cases.

## Example

When opening **Demos** -> **Model Gallery** we can see the plus and minus icons in yellow (they are originally blue).
This is because the contrast ratio between that blue color and the background (~2.33) is below the threshold (4.5).
However the inverted icon contrast is even worse (~1.19).

## Screenshots

### Current version

![Screenshot from 2022-06-27 14-46-18](https://user-images.githubusercontent.com/2660905/175957549-abda2ed7-2d75-4581-b9fd-63dead458579.png)

### With this fix

![Screenshot from 2022-06-27 14-43-37](https://user-images.githubusercontent.com/2660905/175957563-55f322cc-bc39-483f-b5e8-ba023ffa05c6.png)



