### PR TITLE
LibWeb: Fix not being able to process unhandled Promise rejections + a few other improvements

### DIFF
--- a/Base/res/html/misc/unhandledpromisetest.html
+++ b/Base/res/html/misc/unhandledpromisetest.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Unhandled Promise rejection with no [[ScriptOrModule]] for the current execution context</title>
+</head>
+<body>
+  <button onclick="
+    Promise.reject(new Error('Success!'));
+    window.timer = setTimeout(() => {
+      const element = document.createElement('p');
+      element.innerText = 'Did not receieve unhandledrejection event in 100ms.';
+      element.style.color = 'red';
+      document.body.appendChild(element);
+    }, 100)
+  ">
+    Click me to cause an unhandled promise rejection.
+  </button>
+
+  <script>
+    window.onunhandledrejection = (rejectionEvent) => {
+      clearTimeout(window.timer);
+      const element = document.createElement("p");
+      element.innerText = rejectionEvent.reason.message;
+      element.style.color = "green";
+      document.body.appendChild(element);
+    }
+  </script>
+</body>
+</html>

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLGenerators.cpp
@@ -605,10 +605,18 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
 )~~~");
         }
 
-        enum_generator.append(R"~~~(
+        // NOTE: Attribute setters return undefined instead of throwing when the string doesn't match an enum value.
+        if constexpr (!IsSame<Attribute, RemoveConst<ParameterType>>) {
+            enum_generator.append(R"~~~(
     @else@
         return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::InvalidEnumerationValue, @js_name.as_string@, "@parameter.type.name@");
 )~~~");
+        } else {
+            enum_generator.append(R"~~~(
+    @else@
+        return JS::js_undefined();
+)~~~");
+        }
 
         if (optional) {
             enum_generator.append(R"~~~(

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -137,10 +137,11 @@ void WindowObject::initialize_global_object()
     // WebAssembly "namespace"
     define_direct_property("WebAssembly", heap().allocate<WebAssemblyObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
 
-    // HTML::GlobalEventHandlers
+    // HTML::GlobalEventHandlers and HTML::WindowEventHandlers
 #define __ENUMERATE(attribute, event_name) \
     define_native_accessor(#attribute, attribute##_getter, attribute##_setter, attr);
     ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE);
+    ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE);
 #undef __ENUMERATE
 
     ADD_WINDOW_OBJECT_INTERFACES;
@@ -719,6 +720,7 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::name_setter)
         return JS::js_undefined();                                                                                         \
     }
 ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE)
+ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.h
@@ -17,6 +17,7 @@
 #include <LibWeb/Bindings/CrossOriginAbstractOperations.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/GlobalEventHandlers.h>
+#include <LibWeb/HTML/WindowEventHandlers.h>
 
 namespace Web {
 namespace Bindings {
@@ -140,6 +141,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(attribute##_getter); \
     JS_DECLARE_NATIVE_FUNCTION(attribute##_setter);
     ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE);
+    ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE);
 #undef __ENUMERATE
 
     NonnullRefPtr<HTML::Window> m_impl;

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -226,6 +226,7 @@ set(SOURCES
     HTML/TextMetrics.cpp
     HTML/Timer.cpp
     HTML/Window.cpp
+    HTML/WindowEventHandlers.cpp
     HTML/Worker.cpp
     HTML/WorkerDebugConsoleClient.cpp
     HTML/WorkerGlobalScope.cpp

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -353,7 +353,7 @@ private:
     explicit Document(const AK::URL&);
 
     // ^HTML::GlobalEventHandlers
-    virtual EventTarget& global_event_handlers_to_event_target() final { return *this; }
+    virtual EventTarget& global_event_handlers_to_event_target(FlyString const&) final { return *this; }
 
     void tear_down_layout_tree();
 

--- a/Userland/Libraries/LibWeb/DOM/EventHandler.idl
+++ b/Userland/Libraries/LibWeb/DOM/EventHandler.idl
@@ -6,6 +6,10 @@ typedef EventHandlerNonNull? EventHandler;
 callback OnErrorEventHandlerNonNull = any ((Event or DOMString) event, optional DOMString source, optional unsigned long lineno, optional unsigned long colno, optional any error);
 typedef OnErrorEventHandlerNonNull? OnErrorEventHandler;
 
+[LegacyTreatNonObjectAsNull]
+callback OnBeforeUnloadEventHandlerNonNull = DOMString? (Event event);
+typedef OnBeforeUnloadEventHandlerNonNull? OnBeforeUnloadEventHandler;
+
 interface mixin GlobalEventHandlers {
     attribute EventHandler onabort;
     attribute EventHandler onauxclick;
@@ -76,4 +80,23 @@ interface mixin GlobalEventHandlers {
     attribute EventHandler onwebkitanimationstart;
     attribute EventHandler onwebkittransitionend;
     attribute EventHandler onwheel;
+};
+
+interface mixin WindowEventHandlers {
+    attribute EventHandler onafterprint;
+    attribute EventHandler onbeforeprint;
+    attribute OnBeforeUnloadEventHandler onbeforeunload;
+    attribute EventHandler onhashchange;
+    attribute EventHandler onlanguagechange;
+    attribute EventHandler onmessage;
+    attribute EventHandler onmessageerror;
+    attribute EventHandler onoffline;
+    attribute EventHandler ononline;
+    attribute EventHandler onpagehide;
+    attribute EventHandler onpageshow;
+    attribute EventHandler onpopstate;
+    attribute EventHandler onrejectionhandled;
+    attribute EventHandler onstorage;
+    attribute EventHandler onunhandledrejection;
+    attribute EventHandler onunload;
 };

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -218,7 +218,7 @@ ExceptionOr<bool> EventTarget::dispatch_event_binding(NonnullRefPtr<Event> event
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#window-reflecting-body-element-event-handler-set
-static bool is_window_reflecting_body_element_event_handler(FlyString const& name)
+bool is_window_reflecting_body_element_event_handler(FlyString const& name)
 {
     return name.is_one_of(
         HTML::EventNames::blur,

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.h
@@ -86,4 +86,6 @@ private:
     JS::ThrowCompletionOr<void> process_event_handler_for_event(FlyString const& name, Event& event);
 };
 
+bool is_window_reflecting_body_element_event_handler(FlyString const& name);
+
 }

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -98,7 +98,10 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(novalidate)                 \
     __ENUMERATE_HTML_ATTRIBUTE(nowrap)                     \
     __ENUMERATE_HTML_ATTRIBUTE(onabort)                    \
+    __ENUMERATE_HTML_ATTRIBUTE(onafterprint)               \
     __ENUMERATE_HTML_ATTRIBUTE(onauxclick)                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onbeforeprint)              \
+    __ENUMERATE_HTML_ATTRIBUTE(onbeforeunload)             \
     __ENUMERATE_HTML_ATTRIBUTE(onblur)                     \
     __ENUMERATE_HTML_ATTRIBUTE(oncancel)                   \
     __ENUMERATE_HTML_ATTRIBUTE(oncanplay)                  \
@@ -122,15 +125,19 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(onerror)                    \
     __ENUMERATE_HTML_ATTRIBUTE(onfocus)                    \
     __ENUMERATE_HTML_ATTRIBUTE(onformdata)                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onhashchange)               \
     __ENUMERATE_HTML_ATTRIBUTE(oninput)                    \
     __ENUMERATE_HTML_ATTRIBUTE(oninvalid)                  \
     __ENUMERATE_HTML_ATTRIBUTE(onkeydown)                  \
     __ENUMERATE_HTML_ATTRIBUTE(onkeypress)                 \
     __ENUMERATE_HTML_ATTRIBUTE(onkeyup)                    \
+    __ENUMERATE_HTML_ATTRIBUTE(onlanguagechange)           \
     __ENUMERATE_HTML_ATTRIBUTE(onload)                     \
     __ENUMERATE_HTML_ATTRIBUTE(onloadeddata)               \
     __ENUMERATE_HTML_ATTRIBUTE(onloadedmetadata)           \
     __ENUMERATE_HTML_ATTRIBUTE(onloadstart)                \
+    __ENUMERATE_HTML_ATTRIBUTE(onmessage)                  \
+    __ENUMERATE_HTML_ATTRIBUTE(onmessageerror)             \
     __ENUMERATE_HTML_ATTRIBUTE(onmousedown)                \
     __ENUMERATE_HTML_ATTRIBUTE(onmouseenter)               \
     __ENUMERATE_HTML_ATTRIBUTE(onmouseleave)               \
@@ -138,11 +145,17 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(onmouseout)                 \
     __ENUMERATE_HTML_ATTRIBUTE(onmouseover)                \
     __ENUMERATE_HTML_ATTRIBUTE(onmouseup)                  \
+    __ENUMERATE_HTML_ATTRIBUTE(onoffline)                  \
+    __ENUMERATE_HTML_ATTRIBUTE(ononline)                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onpagehide)                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onpageshow)                 \
     __ENUMERATE_HTML_ATTRIBUTE(onpause)                    \
     __ENUMERATE_HTML_ATTRIBUTE(onplay)                     \
     __ENUMERATE_HTML_ATTRIBUTE(onplaying)                  \
+    __ENUMERATE_HTML_ATTRIBUTE(onpopstate)                 \
     __ENUMERATE_HTML_ATTRIBUTE(onprogress)                 \
     __ENUMERATE_HTML_ATTRIBUTE(onratechange)               \
+    __ENUMERATE_HTML_ATTRIBUTE(onrejectionhandled)         \
     __ENUMERATE_HTML_ATTRIBUTE(onreset)                    \
     __ENUMERATE_HTML_ATTRIBUTE(onresize)                   \
     __ENUMERATE_HTML_ATTRIBUTE(onscroll)                   \
@@ -152,10 +165,13 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(onselect)                   \
     __ENUMERATE_HTML_ATTRIBUTE(onslotchange)               \
     __ENUMERATE_HTML_ATTRIBUTE(onstalled)                  \
+    __ENUMERATE_HTML_ATTRIBUTE(onstorage)                  \
     __ENUMERATE_HTML_ATTRIBUTE(onsubmit)                   \
     __ENUMERATE_HTML_ATTRIBUTE(onsuspend)                  \
     __ENUMERATE_HTML_ATTRIBUTE(ontimeupdate)               \
     __ENUMERATE_HTML_ATTRIBUTE(ontoggle)                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onunhandledrejection)       \
+    __ENUMERATE_HTML_ATTRIBUTE(onunload)                   \
     __ENUMERATE_HTML_ATTRIBUTE(onvolumechange)             \
     __ENUMERATE_HTML_ATTRIBUTE(onwaiting)                  \
     __ENUMERATE_HTML_ATTRIBUTE(onwebkitanimationend)       \

--- a/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.cpp
+++ b/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.cpp
@@ -16,14 +16,14 @@
 namespace Web::HTML {
 
 #undef __ENUMERATE
-#define __ENUMERATE(attribute_name, event_name)                                                       \
-    void GlobalEventHandlers::set_##attribute_name(Optional<Bindings::CallbackType> value)            \
-    {                                                                                                 \
-        global_event_handlers_to_event_target().set_event_handler_attribute(event_name, move(value)); \
-    }                                                                                                 \
-    Bindings::CallbackType* GlobalEventHandlers::attribute_name()                                     \
-    {                                                                                                 \
-        return global_event_handlers_to_event_target().event_handler_attribute(event_name);           \
+#define __ENUMERATE(attribute_name, event_name)                                                                 \
+    void GlobalEventHandlers::set_##attribute_name(Optional<Bindings::CallbackType> value)                      \
+    {                                                                                                           \
+        global_event_handlers_to_event_target(event_name).set_event_handler_attribute(event_name, move(value)); \
+    }                                                                                                           \
+    Bindings::CallbackType* GlobalEventHandlers::attribute_name()                                               \
+    {                                                                                                           \
+        return global_event_handlers_to_event_target(event_name).event_handler_attribute(event_name);           \
     }
 ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.cpp
+++ b/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.cpp
@@ -4,11 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibJS/Interpreter.h>
-#include <LibJS/Parser.h>
-#include <LibWeb/DOM/Document.h>
-#include <LibWeb/DOM/IDLEventListener.h>
-#include <LibWeb/HTML/EventHandler.h>
+#include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/GlobalEventHandlers.h>
 #include <LibWeb/UIEvents/EventNames.h>

--- a/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.h
+++ b/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.h
@@ -91,7 +91,7 @@ public:
 #undef __ENUMERATE
 
 protected:
-    virtual DOM::EventTarget& global_event_handlers_to_event_target() = 0;
+    virtual DOM::EventTarget& global_event_handlers_to_event_target(FlyString const& event_name) = 0;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -57,10 +57,14 @@ void HTMLBodyElement::parse_attribute(FlyString const& name, String const& value
     }
 }
 
-DOM::EventTarget& HTMLBodyElement::global_event_handlers_to_event_target()
+DOM::EventTarget& HTMLBodyElement::global_event_handlers_to_event_target(FlyString const& event_name)
 {
     // NOTE: This is a little weird, but IIUC document.body.onload actually refers to window.onload
-    return document().window();
+    // NOTE: document.body can return either a HTMLBodyElement or HTMLFrameSetElement, so both these elements must support this mapping.
+    if (DOM::is_window_reflecting_body_element_event_handler(event_name))
+        return document().window();
+
+    return *this;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -55,6 +55,14 @@ void HTMLBodyElement::parse_attribute(FlyString const& name, String const& value
     } else if (name.equals_ignoring_case("background")) {
         m_background_style_value = CSS::ImageStyleValue::create(document().parse_url(value));
     }
+
+#undef __ENUMERATE
+#define __ENUMERATE(attribute_name, event_name)                     \
+    if (name == HTML::AttributeNames::attribute_name) {             \
+        element_event_handler_attribute_changed(event_name, value); \
+    }
+    ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE)
+#undef __ENUMERATE
 }
 
 DOM::EventTarget& HTMLBodyElement::global_event_handlers_to_event_target(FlyString const& event_name)
@@ -65,6 +73,13 @@ DOM::EventTarget& HTMLBodyElement::global_event_handlers_to_event_target(FlyStri
         return document().window();
 
     return *this;
+}
+
+DOM::EventTarget& HTMLBodyElement::window_event_handlers_to_event_target()
+{
+    // All WindowEventHandlers on HTMLFrameSetElement (e.g. document.body.onrejectionhandled) are mapped to window.on{event}.
+    // NOTE: document.body can return either a HTMLBodyElement or HTMLFrameSetElement, so both these elements must support this mapping.
+    return document().window();
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
@@ -7,10 +7,13 @@
 #pragma once
 
 #include <LibWeb/HTML/HTMLElement.h>
+#include <LibWeb/HTML/WindowEventHandlers.h>
 
 namespace Web::HTML {
 
-class HTMLBodyElement final : public HTMLElement {
+class HTMLBodyElement final
+    : public HTMLElement
+    , public WindowEventHandlers {
 public:
     using WrapperType = Bindings::HTMLBodyElementWrapper;
 
@@ -23,6 +26,9 @@ public:
 private:
     // ^HTML::GlobalEventHandlers
     virtual EventTarget& global_event_handlers_to_event_target(FlyString const& event_name) override;
+
+    // ^HTML::WindowEventHandlers
+    virtual EventTarget& window_event_handlers_to_event_target() override;
 
     RefPtr<CSS::ImageStyleValue> m_background_style_value;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
@@ -22,7 +22,7 @@ public:
 
 private:
     // ^HTML::GlobalEventHandlers
-    virtual EventTarget& global_event_handlers_to_event_target() override;
+    virtual EventTarget& global_event_handlers_to_event_target(FlyString const& event_name) override;
 
     RefPtr<CSS::ImageStyleValue> m_background_style_value;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.idl
@@ -1,3 +1,4 @@
+#import <DOM/EventHandler.idl>
 #import <HTML/HTMLElement.idl>
 
 interface HTMLBodyElement : HTMLElement {
@@ -10,3 +11,5 @@ interface HTMLBodyElement : HTMLElement {
     [Reflect] attribute DOMString background;
 
 };
+
+HTMLBodyElement includes WindowEventHandlers;

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -54,7 +54,7 @@ protected:
 
 private:
     // ^HTML::GlobalEventHandlers
-    virtual DOM::EventTarget& global_event_handlers_to_event_target() override { return *this; }
+    virtual DOM::EventTarget& global_event_handlers_to_event_target(FlyString const&) override { return *this; }
 
     enum class ContentEditableState {
         True,

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLFrameSetElement.h>
+#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
@@ -15,6 +17,19 @@ HTMLFrameSetElement::HTMLFrameSetElement(DOM::Document& document, DOM::Qualified
 
 HTMLFrameSetElement::~HTMLFrameSetElement() = default;
 
+void HTMLFrameSetElement::parse_attribute(FlyString const& name, String const& value)
+{
+    HTMLElement::parse_attribute(name, value);
+
+#undef __ENUMERATE
+#define __ENUMERATE(attribute_name, event_name)                     \
+    if (name == HTML::AttributeNames::attribute_name) {             \
+        element_event_handler_attribute_changed(event_name, value); \
+    }
+    ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE)
+#undef __ENUMERATE
+}
+
 DOM::EventTarget& HTMLFrameSetElement::global_event_handlers_to_event_target(FlyString const& event_name)
 {
     // NOTE: This is a little weird, but IIUC document.body.onload actually refers to window.onload
@@ -23,6 +38,13 @@ DOM::EventTarget& HTMLFrameSetElement::global_event_handlers_to_event_target(Fly
         return document().window();
 
     return *this;
+}
+
+DOM::EventTarget& HTMLFrameSetElement::window_event_handlers_to_event_target()
+{
+    // All WindowEventHandlers on HTMLFrameSetElement (e.g. document.body.onrejectionhandled) are mapped to window.on{event}.
+    // NOTE: document.body can return either a HTMLBodyElement or HTMLFrameSetElement, so both these elements must support this mapping.
+    return document().window();
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -14,4 +14,15 @@ HTMLFrameSetElement::HTMLFrameSetElement(DOM::Document& document, DOM::Qualified
 }
 
 HTMLFrameSetElement::~HTMLFrameSetElement() = default;
+
+DOM::EventTarget& HTMLFrameSetElement::global_event_handlers_to_event_target(FlyString const& event_name)
+{
+    // NOTE: This is a little weird, but IIUC document.body.onload actually refers to window.onload
+    // NOTE: document.body can return either a HTMLBodyElement or HTMLFrameSetElement, so both these elements must support this mapping.
+    if (DOM::is_window_reflecting_body_element_event_handler(event_name))
+        return document().window();
+
+    return *this;
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
@@ -17,6 +17,10 @@ public:
 
     HTMLFrameSetElement(DOM::Document&, DOM::QualifiedName);
     virtual ~HTMLFrameSetElement() override;
+
+private:
+    // ^HTML::GlobalEventHandlers
+    virtual EventTarget& global_event_handlers_to_event_target(FlyString const& event_name) override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
@@ -7,20 +7,28 @@
 #pragma once
 
 #include <LibWeb/HTML/HTMLElement.h>
+#include <LibWeb/HTML/WindowEventHandlers.h>
 
 namespace Web::HTML {
 
 // NOTE: This element is marked as obsolete, but is still listed as required by the specification.
-class HTMLFrameSetElement final : public HTMLElement {
+class HTMLFrameSetElement final
+    : public HTMLElement
+    , public WindowEventHandlers {
 public:
     using WrapperType = Bindings::HTMLFrameSetElementWrapper;
 
     HTMLFrameSetElement(DOM::Document&, DOM::QualifiedName);
     virtual ~HTMLFrameSetElement() override;
 
+    virtual void parse_attribute(FlyString const&, String const&) override;
+
 private:
     // ^HTML::GlobalEventHandlers
     virtual EventTarget& global_event_handlers_to_event_target(FlyString const& event_name) override;
+
+    // ^HTML::WindowEventHandlers
+    virtual EventTarget& window_event_handlers_to_event_target() override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.idl
@@ -1,3 +1,4 @@
+#import <DOM/EventHandler.idl>
 #import <HTML/HTMLElement.idl>
 
 interface HTMLFrameSetElement : HTMLElement {
@@ -6,3 +7,5 @@ interface HTMLFrameSetElement : HTMLElement {
     [Reflect] attribute DOMString rows;
 
 };
+
+HTMLFrameSetElement includes WindowEventHandlers;

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
@@ -34,19 +34,18 @@ public:
 
     // Needs to return a pointer for the generated JS bindings to work.
     JS::Promise const* promise() const { return m_promise.cell(); }
-    JS::Value reason() const { return m_reason; }
+    JS::Value reason() const { return m_reason.value(); }
 
 protected:
     PromiseRejectionEvent(FlyString const& event_name, PromiseRejectionEventInit const& event_init)
         : DOM::Event(event_name, event_init)
         , m_promise(event_init.promise)
-        , m_reason(event_init.reason)
+        , m_reason(JS::make_handle(event_init.reason))
     {
     }
 
     JS::Handle<JS::Promise> m_promise;
-    // FIXME: Protect this from GC! Currently we have no handle for arbitrary JS::Value.
-    JS::Value m_reason;
+    JS::Handle<JS::Value> m_reason;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
@@ -28,8 +28,6 @@ public:
     JS::Script* script_record() { return m_script_record; }
     JS::Script const* script_record() const { return m_script_record; }
 
-    EnvironmentSettingsObject& settings_object() { return m_settings_object; }
-
     enum class RethrowErrors {
         No,
         Yes,
@@ -41,7 +39,6 @@ public:
 private:
     ClassicScript(AK::URL base_url, String filename, EnvironmentSettingsObject& environment_settings_object);
 
-    EnvironmentSettingsObject& m_settings_object;
     RefPtr<JS::Script> m_script_record;
     MutedErrors m_muted_errors { MutedErrors::No };
     Optional<JS::Parser::Error> m_error_to_rethrow;

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/PromiseRejectionEvent.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/HTML/Scripting/ExceptionReporter.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Page/Page.h>
 
@@ -232,7 +233,7 @@ void EnvironmentSettingsObject::notify_about_rejected_promises(Badge<EventLoop>)
             // This algorithm results in promise rejections being marked as handled or not handled. These concepts parallel handled and not handled script errors.
             // If a rejection is still not handled after this, then the rejection may be reported to a developer console.
             if (not_handled)
-                dbgln("WARNING: A promise was rejected without any handlers. promise={:p}, result={}", &promise, promise.result().to_string_without_side_effects());
+                HTML::print_error_from_value(promise.result(), ErrorInPromise::Yes);
         }
     });
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ExceptionReporter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ExceptionReporter.cpp
@@ -11,24 +11,19 @@
 
 namespace Web::HTML {
 
-// https://html.spec.whatwg.org/#report-the-exception
-void report_exception(JS::Completion const& throw_completion)
+void print_error_from_value(JS::Value value, ErrorInPromise error_in_promise)
 {
-    // FIXME: This is just old code, and does not strictly follow the spec of report an exception.
     // FIXME: We should probably also report these exceptions to the JS console.
-    VERIFY(throw_completion.type() == JS::Completion::Type::Throw);
-    VERIFY(throw_completion.value().has_value());
-    auto thrown_value = *throw_completion.value();
-    if (thrown_value.is_object()) {
-        auto& object = thrown_value.as_object();
+    if (value.is_object()) {
+        auto& object = value.as_object();
         auto& vm = object.vm();
         auto name = object.get_without_side_effects(vm.names.name).value_or(JS::js_undefined());
         auto message = object.get_without_side_effects(vm.names.message).value_or(JS::js_undefined());
         if (name.is_accessor() || message.is_accessor()) {
             // The result is not going to be useful, let's just print the value. This affects DOMExceptions, for example.
-            dbgln("\033[31;1mUnhandled JavaScript exception:\033[0m {}", thrown_value);
+            dbgln("\033[31;1mUnhandled JavaScript exception{}:\033[0m {}", error_in_promise == ErrorInPromise::Yes ? " (in promise)" : "", JS::Value(&object));
         } else {
-            dbgln("\033[31;1mUnhandled JavaScript exception:\033[0m [{}] {}", name, message);
+            dbgln("\033[31;1mUnhandled JavaScript exception{}:\033[0m [{}] {}", error_in_promise == ErrorInPromise::Yes ? " (in promise)" : "", name, message);
         }
         if (is<JS::Error>(object)) {
             auto const& error_value = static_cast<JS::Error const&>(object);
@@ -39,8 +34,17 @@ void report_exception(JS::Completion const& throw_completion)
             }
         }
     } else {
-        dbgln("\033[31;1mUnhandled JavaScript exception:\033[0m {}", thrown_value);
+        dbgln("\033[31;1mUnhandled JavaScript exception:\033[0m {}", value);
     }
+}
+
+// https://html.spec.whatwg.org/#report-the-exception
+void report_exception(JS::Completion const& throw_completion)
+{
+    // FIXME: This is just old code, and does not strictly follow the spec of report an exception.
+    VERIFY(throw_completion.type() == JS::Completion::Type::Throw);
+    VERIFY(throw_completion.value().has_value());
+    print_error_from_value(*throw_completion.value(), ErrorInPromise::No);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ExceptionReporter.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ExceptionReporter.h
@@ -10,6 +10,12 @@
 
 namespace Web::HTML {
 
+enum class ErrorInPromise {
+    No,
+    Yes,
+};
+
+void print_error_from_value(JS::Value, ErrorInPromise);
 void report_exception(JS::Completion const&);
 
 template<typename T>

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Script.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Script.cpp
@@ -8,9 +8,10 @@
 
 namespace Web::HTML {
 
-Script::Script(AK::URL base_url, String filename)
+Script::Script(AK::URL base_url, String filename, EnvironmentSettingsObject& environment_settings_object)
     : m_base_url(move(base_url))
     , m_filename(move(filename))
+    , m_settings_object(environment_settings_object)
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Script.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Script.h
@@ -8,6 +8,7 @@
 
 #include <AK/RefCounted.h>
 #include <AK/URL.h>
+#include <LibWeb/Forward.h>
 
 namespace Web::HTML {
 
@@ -19,12 +20,15 @@ public:
     AK::URL const& base_url() const { return m_base_url; }
     String const& filename() const { return m_filename; }
 
+    EnvironmentSettingsObject& settings_object() { return m_settings_object; }
+
 protected:
-    Script(AK::URL base_url, String filename);
+    Script(AK::URL base_url, String filename, EnvironmentSettingsObject& environment_settings_object);
 
 private:
     AK::URL m_base_url;
     String m_filename;
+    EnvironmentSettingsObject& m_settings_object;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -21,6 +21,7 @@
 #include <LibWeb/HTML/AnimationFrameCallbackDriver.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/GlobalEventHandlers.h>
+#include <LibWeb/HTML/WindowEventHandlers.h>
 
 namespace Web::HTML {
 
@@ -30,7 +31,8 @@ class Window final
     : public RefCounted<Window>
     , public Weakable<Window>
     , public DOM::EventTarget
-    , public HTML::GlobalEventHandlers {
+    , public HTML::GlobalEventHandlers
+    , public HTML::WindowEventHandlers {
 public:
     static NonnullRefPtr<Window> create_with_document(DOM::Document&);
     ~Window();
@@ -129,6 +131,9 @@ private:
 
     // ^HTML::GlobalEventHandlers
     virtual DOM::EventTarget& global_event_handlers_to_event_target(FlyString const&) override { return *this; }
+
+    // ^HTML::WindowEventHandlers
+    virtual DOM::EventTarget& window_event_handlers_to_event_target() override { return *this; }
 
     enum class Repeat {
         Yes,

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -128,7 +128,7 @@ private:
     explicit Window(DOM::Document&);
 
     // ^HTML::GlobalEventHandlers
-    virtual DOM::EventTarget& global_event_handlers_to_event_target() override { return *this; }
+    virtual DOM::EventTarget& global_event_handlers_to_event_target(FlyString const&) override { return *this; }
 
     enum class Repeat {
         Yes,

--- a/Userland/Libraries/LibWeb/HTML/WindowEventHandlers.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowEventHandlers.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/EventTarget.h>
+#include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/HTML/WindowEventHandlers.h>
+
+namespace Web::HTML {
+
+#undef __ENUMERATE
+#define __ENUMERATE(attribute_name, event_name)                                                       \
+    void WindowEventHandlers::set_##attribute_name(Optional<Bindings::CallbackType> value)            \
+    {                                                                                                 \
+        window_event_handlers_to_event_target().set_event_handler_attribute(event_name, move(value)); \
+    }                                                                                                 \
+    Bindings::CallbackType* WindowEventHandlers::attribute_name()                                     \
+    {                                                                                                 \
+        return window_event_handlers_to_event_target().event_handler_attribute(event_name);           \
+    }
+ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE)
+#undef __ENUMERATE
+
+WindowEventHandlers::~WindowEventHandlers() = default;
+
+}

--- a/Userland/Libraries/LibWeb/HTML/WindowEventHandlers.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowEventHandlers.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <LibWeb/Forward.h>
+
+#define ENUMERATE_WINDOW_EVENT_HANDLERS(E)                        \
+    E(onafterprint, HTML::EventNames::afterprint)                 \
+    E(onbeforeprint, HTML::EventNames::beforeprint)               \
+    E(onbeforeunload, HTML::EventNames::beforeunload)             \
+    E(onhashchange, HTML::EventNames::hashchange)                 \
+    E(onlanguagechange, HTML::EventNames::languagechange)         \
+    E(onmessage, HTML::EventNames::message)                       \
+    E(onmessageerror, HTML::EventNames::messageerror)             \
+    E(onoffline, HTML::EventNames::offline)                       \
+    E(ononline, HTML::EventNames::online)                         \
+    E(onpagehide, HTML::EventNames::pagehide)                     \
+    E(onpageshow, HTML::EventNames::pageshow)                     \
+    E(onpopstate, HTML::EventNames::popstate)                     \
+    E(onrejectionhandled, HTML::EventNames::rejectionhandled)     \
+    E(onstorage, HTML::EventNames::storage)                       \
+    E(onunhandledrejection, HTML::EventNames::unhandledrejection) \
+    E(onunload, HTML::EventNames::unload)
+
+namespace Web::HTML {
+
+class WindowEventHandlers {
+public:
+    virtual ~WindowEventHandlers();
+
+#undef __ENUMERATE
+#define __ENUMERATE(attribute_name, event_name)                  \
+    void set_##attribute_name(Optional<Bindings::CallbackType>); \
+    Bindings::CallbackType* attribute_name();
+    ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE)
+#undef __ENUMERATE
+
+protected:
+    virtual DOM::EventTarget& window_event_handlers_to_event_target() = 0;
+};
+
+}


### PR DESCRIPTION
The first 2 commits are when I noticed the test in the PR for fixing unhandled Promise rejections used WindowEventHandlers, specifically `onunhandledrejection`, which we were missing and I noticed the <body> and <frameset> reflection issue on the side.

The third commit is for an issue I found when testing the unhandled Promise rejections fix.

The rest of the commits are a lead up to and implementing https://github.com/whatwg/html/pull/8043