### PR TITLE
LibHTTP+RequestServer: Recognise more HTTP methods

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -21,6 +21,18 @@ String HttpRequest::method_name() const
         return "HEAD";
     case Method::POST:
         return "POST";
+    case Method::DELETE:
+        return "DELETE";
+    case Method::PATCH:
+        return "PATCH";
+    case Method::OPTIONS:
+        return "OPTIONS";
+    case Method::TRACE:
+        return "TRACE";
+    case Method::CONNECT:
+        return "CONNECT";
+    case Method::PUT:
+        return "PUT";
     default:
         VERIFY_NOT_REACHED();
     }
@@ -155,6 +167,18 @@ Optional<HttpRequest> HttpRequest::from_raw_request(ReadonlyBytes raw_request)
         request.m_method = Method::HEAD;
     else if (method == "POST")
         request.m_method = Method::POST;
+    else if (method == "DELETE")
+        request.set_method(HTTP::HttpRequest::Method::DELETE);
+    else if (method == "PATCH")
+        request.set_method(HTTP::HttpRequest::Method::PATCH);
+    else if (method == "OPTIONS")
+        request.set_method(HTTP::HttpRequest::Method::OPTIONS);
+    else if (method == "TRACE")
+        request.set_method(HTTP::HttpRequest::Method::TRACE);
+    else if (method == "CONNECT")
+        request.set_method(HTTP::HttpRequest::Method::CONNECT);
+    else if (method == "PUT")
+        request.set_method(HTTP::HttpRequest::Method::PUT);
     else
         return {};
 

--- a/Userland/Libraries/LibHTTP/HttpRequest.h
+++ b/Userland/Libraries/LibHTTP/HttpRequest.h
@@ -22,7 +22,13 @@ public:
         Invalid,
         HEAD,
         GET,
-        POST
+        POST,
+        DELETE,
+        PATCH,
+        OPTIONS,
+        TRACE,
+        CONNECT,
+        PUT,
     };
 
     struct Header {

--- a/Userland/Services/RequestServer/HttpCommon.h
+++ b/Userland/Services/RequestServer/HttpCommon.h
@@ -73,6 +73,20 @@ OwnPtr<Request> start_request(TBadgedProtocol&& protocol, ConnectionFromClient& 
     HTTP::HttpRequest request;
     if (method.equals_ignoring_case("post"))
         request.set_method(HTTP::HttpRequest::Method::POST);
+    else if (method.equals_ignoring_case("head"))
+        request.set_method(HTTP::HttpRequest::Method::HEAD);
+    else if (method.equals_ignoring_case("delete"))
+        request.set_method(HTTP::HttpRequest::Method::DELETE);
+    else if (method.equals_ignoring_case("patch"))
+        request.set_method(HTTP::HttpRequest::Method::PATCH);
+    else if (method.equals_ignoring_case("options"))
+        request.set_method(HTTP::HttpRequest::Method::OPTIONS);
+    else if (method.equals_ignoring_case("trace"))
+        request.set_method(HTTP::HttpRequest::Method::TRACE);
+    else if (method.equals_ignoring_case("connect"))
+        request.set_method(HTTP::HttpRequest::Method::CONNECT);
+    else if (method.equals_ignoring_case("put"))
+        request.set_method(HTTP::HttpRequest::Method::PUT);
     else
         request.set_method(HTTP::HttpRequest::Method::GET);
     request.set_url(url);


### PR DESCRIPTION
Previously it would default to GET for all of these and cause the
Discord API to return Method Not Allowed errors for certain endpoints.