### PR TITLE
pls: Implement support for `--preserve-env`

### DIFF
--- a/Userland/Utilities/pls.cpp
+++ b/Userland/Utilities/pls.cpp
@@ -45,11 +45,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio rpath exec"));
 
-    Vector<String> exec_environment_strings;
     Vector<StringView> exec_environment;
-    if (auto* term = getenv("TERM")) {
-        exec_environment_strings.append(String::formatted("TERM={}", term));
-        exec_environment.append(exec_environment_strings.last());
+    for (size_t i = 0; environ[i]; ++i) {
+        StringView env_view { environ[i] };
+        auto maybe_needle = env_view.find('=');
+
+        if (!maybe_needle.has_value())
+            continue;
+
+        if (env_view.substring_view(0, maybe_needle.value()) != "TERM"sv)
+            continue;
+
+        exec_environment.append(env_view);
     }
 
     Vector<String> exec_arguments;

--- a/Userland/Utilities/pls.cpp
+++ b/Userland/Utilities/pls.cpp
@@ -17,8 +17,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Vector<StringView> command;
     Core::ArgsParser args_parser;
     uid_t as_user_uid = 0;
+    bool preserve_env = false;
     args_parser.set_stop_on_first_non_option(true);
     args_parser.add_option(as_user_uid, "User to execute as", nullptr, 'u', "UID");
+    args_parser.add_option(preserve_env, "Preserve user environment when running command", "preserve-env", 'E');
     args_parser.add_positional_argument(command, "Command to run at elevated privilege level", "command");
     args_parser.parse(arguments);
 
@@ -53,7 +55,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (!maybe_needle.has_value())
             continue;
 
-        if (env_view.substring_view(0, maybe_needle.value()) != "TERM"sv)
+        // FIXME: Allow a custom selection of variables once ArgsParser supports options with optional parameters.
+        if (!preserve_env && env_view.substring_view(0, maybe_needle.value()) != "TERM"sv)
             continue;
 
         exec_environment.append(env_view);


### PR DESCRIPTION
This allows us to skip storing the actual backing data in a separate `Vector`, as we know that we are working with `environ`-backed storage here.

Also, while the logic is currently very similar to what `getenv` does internally, this allows us to eventually implement custom environment variable filters while remaining linear in run time.