### PR TITLE
Kernel/USB: Move buffer allocation from USB transfer to USB pipe

### DIFF
--- a/Kernel/Bus/USB/USBPipe.h
+++ b/Kernel/Bus/USB/USBPipe.h
@@ -9,6 +9,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/USB/USBDescriptors.h>
+#include <Kernel/Locking/Mutex.h>
 #include <Kernel/Memory/Region.h>
 
 namespace Kernel::USB {
@@ -59,9 +60,9 @@ public:
     ErrorOr<size_t> control_transfer(u8 request_type, u8 request, u16 value, u16 index, u16 length, void* data);
     ErrorOr<size_t> bulk_transfer(u16 length, void* data);
 
-    Pipe(USBController const& controller, Type type, Direction direction, u16 max_packet_size);
-    Pipe(USBController const& controller, Type type, Direction direction, USBEndpointDescriptor& endpoint);
-    Pipe(USBController const& controller, Type type, Direction direction, u8 endpoint_address, u16 max_packet_size, u8 poll_interval, i8 device_address);
+    Pipe(USBController const& controller, Type type, Direction direction, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
+    Pipe(USBController const& controller, Type type, Direction direction, USBEndpointDescriptor& endpoint, NonnullOwnPtr<Memory::Region> dma_buffer);
+    Pipe(USBController const& controller, Type type, Direction direction, u8 endpoint_address, u16 max_packet_size, u8 poll_interval, i8 device_address, NonnullOwnPtr<Memory::Region> dma_buffer);
 
 private:
     friend class Device;
@@ -77,5 +78,9 @@ private:
     u16 m_max_packet_size { 0 };  // Max packet size for this pipe
     u8 m_poll_interval { 0 };     // Polling interval (in frames)
     bool m_data_toggle { false }; // Data toggle for stuffing bit
+
+    Mutex m_dma_buffer_lock { "USB pipe mutex" };
+
+    NonnullOwnPtr<Memory::Region> m_dma_buffer;
 };
 }

--- a/Kernel/Bus/USB/USBTransfer.cpp
+++ b/Kernel/Bus/USB/USBTransfer.cpp
@@ -9,17 +9,14 @@
 
 namespace Kernel::USB {
 
-ErrorOr<NonnullRefPtr<Transfer>> Transfer::try_create(Pipe& pipe, u16 length)
+ErrorOr<NonnullRefPtr<Transfer>> Transfer::try_create(Pipe& pipe, u16 length, Memory::Region& dma_buffer)
 {
-    // Initialize data buffer for transfer
-    // This will definitely need to be refactored in the future, I doubt this will scale well...
-    auto region = TRY(MM.allocate_kernel_region(PAGE_SIZE, "USB Transfer Buffer", Memory::Region::Access::ReadWrite));
-    return adopt_nonnull_ref_or_enomem(new (nothrow) Transfer(pipe, length, move(region)));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) Transfer(pipe, length, dma_buffer));
 }
 
-Transfer::Transfer(Pipe& pipe, u16 len, NonnullOwnPtr<Memory::Region> data_buffer)
+Transfer::Transfer(Pipe& pipe, u16 len, Memory::Region& dma_buffer)
     : m_pipe(pipe)
-    , m_data_buffer(move(data_buffer))
+    , m_dma_buffer(dma_buffer)
     , m_transfer_data_size(len)
 {
 }
@@ -45,7 +42,7 @@ void Transfer::set_setup_packet(USBRequestData const& request)
 
 ErrorOr<void> Transfer::write_buffer(u16 len, void* data)
 {
-    VERIFY(len <= m_data_buffer->size());
+    VERIFY(len <= m_dma_buffer.size());
     m_transfer_data_size = len;
     memcpy(buffer().as_ptr(), data, len);
 

--- a/Kernel/Bus/USB/USBTransfer.h
+++ b/Kernel/Bus/USB/USBTransfer.h
@@ -19,7 +19,7 @@ namespace Kernel::USB {
 
 class Transfer : public RefCounted<Transfer> {
 public:
-    static ErrorOr<NonnullRefPtr<Transfer>> try_create(Pipe&, u16 length);
+    static ErrorOr<NonnullRefPtr<Transfer>> try_create(Pipe&, u16 length, Memory::Region& dma_buffer);
 
     Transfer() = delete;
     ~Transfer();
@@ -34,20 +34,20 @@ public:
     USBRequestData const& request() const { return m_request; }
     Pipe const& pipe() const { return m_pipe; }
     Pipe& pipe() { return m_pipe; }
-    VirtualAddress buffer() const { return m_data_buffer->vaddr(); }
-    PhysicalAddress buffer_physical() const { return m_data_buffer->physical_page(0)->paddr(); }
+    VirtualAddress buffer() const { return m_dma_buffer.vaddr(); }
+    PhysicalAddress buffer_physical() const { return m_dma_buffer.physical_page(0)->paddr(); }
     u16 transfer_data_size() const { return m_transfer_data_size; }
     bool complete() const { return m_complete; }
     bool error_occurred() const { return m_error_occurred; }
 
 private:
-    Transfer(Pipe& pipe, u16 len, NonnullOwnPtr<Memory::Region>);
-    Pipe& m_pipe;                                // Pipe that initiated this transfer
-    USBRequestData m_request;                    // USB request
-    NonnullOwnPtr<Memory::Region> m_data_buffer; // DMA Data buffer for transaction
-    u16 m_transfer_data_size { 0 };              // Size of the transfer's data stage
-    bool m_complete { false };                   // Has this transfer been completed?
-    bool m_error_occurred { false };             // Did an error occur during this transfer?
+    Transfer(Pipe& pipe, u16 len, Memory::Region& dma_buffer);
+    Pipe& m_pipe;                    // Pipe that initiated this transfer
+    Memory::Region& m_dma_buffer;    // DMA buffer
+    USBRequestData m_request;        // USB request
+    u16 m_transfer_data_size { 0 };  // Size of the transfer's data stage
+    bool m_complete { false };       // Has this transfer been completed?
+    bool m_error_occurred { false }; // Did an error occur during this transfer?
 };
 
 }


### PR DESCRIPTION
Currently when allocating buffers for USB transfers, it is done
once for every transfer rather than once upon creation of the
USB device. This commit changes that by moving allocation of buffers
to the USB Pipe class where they can be reused.