### PR TITLE
Documentation: Add more information about MacOS build prerequisites

### DIFF
--- a/Documentation/BuildInstructionsMacOS.md
+++ b/Documentation/BuildInstructionsMacOS.md
@@ -34,3 +34,4 @@ Notes:
 
 - Installing macfuse for the first time requires enabling its system extension in System Preferences and then restarting
   your machine. The output from installing macfuse with brew says this, but it's easy to miss.
+- It's important to make sure that Xcode is not only installed but also accordingly updated, otherwise CMake will run into incompatibilities with GCC.


### PR DESCRIPTION
This PR includes information that highlights the importance of updating Xcode on MacOS.
I ran into problems building serenity on MacOS because I had Xcode installed but not updated in a while. This triggered seemingly unrelated errors that were easily solved by updating Xcode.
So I think this is useful information to add to this documentation.