### PR TITLE
LibGUI: AbstractScrollableWidget and ScrollableContainerWidget improvements

### DIFF
--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -427,7 +427,9 @@ ConditionView::~ConditionView()
 
 ConditionsView::ConditionsView()
 {
-    set_layout<GUI::VerticalBoxLayout>().set_spacing(2);
+    auto& layout = set_layout<GUI::VerticalBoxLayout>();
+    layout.set_spacing(4);
+    layout.set_margins({ 6 });
 }
 
 void ConditionsView::set_formats(Vector<ConditionalFormat>* formats)

--- a/Userland/Applications/Spreadsheet/CondFormatting.gml
+++ b/Userland/Applications/Spreadsheet/CondFormatting.gml
@@ -6,8 +6,11 @@
         spacing: 4
     }
 
-    @Spreadsheet::ConditionsView {
-        name: "conditions_view"
+    @GUI::ScrollableContainerWidget {
+        should_hide_unnecessary_scrollbars: true
+        content_widget: @Spreadsheet::ConditionsView {
+            name: "conditions_view"
+        }
     }
 
     @GUI::Widget {

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -294,6 +294,18 @@ T* Object::find_descendant_of_type_named(String const& name) requires IsBaseOf<O
         [this] { return this->getter(); },                       \
         {});
 
+#define REGISTER_READONLY_SIZE_PROPERTY(property_name, getter) \
+    register_property(                                         \
+        property_name,                                         \
+        [this] {                                               \
+            auto size = this->getter();                        \
+            JsonArray size_array;                              \
+            size_array.append(size.width());                   \
+            size_array.append(size.height());                  \
+            return size_array;                                 \
+        },                                                     \
+        {});
+
 #define REGISTER_RECT_PROPERTY(property_name, getter, setter)          \
     register_property(                                                 \
         property_name,                                                 \

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -13,6 +13,8 @@ namespace GUI {
 
 AbstractScrollableWidget::AbstractScrollableWidget()
 {
+    REGISTER_READONLY_SIZE_PROPERTY("min_content_size", min_content_size);
+
     m_vertical_scrollbar = add<AbstractScrollableWidgetScrollbar>(*this, Orientation::Vertical);
     m_vertical_scrollbar->set_step(4);
     m_vertical_scrollbar->on_change = [this](int) {

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
@@ -21,6 +21,7 @@ public:
     Gfx::IntSize content_size() const { return m_content_size; }
     int content_width() const { return m_content_size.width(); }
     int content_height() const { return m_content_size.height(); }
+    Gfx::IntSize min_content_size() const { return m_min_content_size; }
 
     Gfx::IntRect visible_content_rect() const;
 
@@ -60,7 +61,7 @@ public:
 
     virtual Margins content_margins() const override;
 
-    void set_should_hide_unnecessary_scrollbars(bool b) { m_should_hide_unnecessary_scrollbars = b; }
+    void set_should_hide_unnecessary_scrollbars(bool);
     bool should_hide_unnecessary_scrollbars() const { return m_should_hide_unnecessary_scrollbars; }
 
     Gfx::IntPoint to_content_position(Gfx::IntPoint const& widget_position) const;
@@ -76,9 +77,12 @@ protected:
     virtual void mousewheel_event(MouseEvent&) override;
     virtual void did_scroll() { }
     void set_content_size(Gfx::IntSize const&);
+    void set_min_content_size(Gfx::IntSize const&);
     void set_size_occupied_by_fixed_elements(Gfx::IntSize const&);
     virtual void on_automatic_scrolling_timer_fired() {};
     int autoscroll_threshold() const { return m_autoscroll_threshold; }
+    void update_scrollbar_visibility();
+    void update_scrollbar_ranges();
 
 private:
     class AbstractScrollableWidgetScrollbar final : public Scrollbar {
@@ -100,13 +104,13 @@ private:
     };
     friend class ScrollableWidgetScrollbar;
 
-    void update_scrollbar_ranges();
     void handle_wheel_event(MouseEvent&, Widget&);
 
     RefPtr<AbstractScrollableWidgetScrollbar> m_vertical_scrollbar;
     RefPtr<AbstractScrollableWidgetScrollbar> m_horizontal_scrollbar;
     RefPtr<Widget> m_corner_widget;
     Gfx::IntSize m_content_size;
+    Gfx::IntSize m_min_content_size;
     Gfx::IntSize m_size_occupied_by_fixed_elements;
     bool m_scrollbars_enabled { true };
     bool m_should_hide_unnecessary_scrollbars { false };

--- a/Userland/Libraries/LibGUI/GroupBox.cpp
+++ b/Userland/Libraries/LibGUI/GroupBox.cpp
@@ -52,7 +52,7 @@ void GroupBox::paint_event(PaintEvent& event)
 void GroupBox::fonts_change_event(FontsChangeEvent& event)
 {
     Widget::fonts_change_event(event);
-    invalidate_layout();
+    layout_relevant_change_occured();
 }
 
 void GroupBox::set_title(StringView title)

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -58,11 +58,29 @@ void ScrollableContainerWidget::update_widget_size()
     }
 }
 
+void ScrollableContainerWidget::update_widget_min_size()
+{
+    if (!m_widget)
+        set_min_content_size({});
+    else
+        set_min_content_size(Gfx::IntSize(m_widget->effective_min_size().replace_component_if_matching_with(SpecialDimension::Shrink, UISize { 0, 0 })));
+}
+
 void ScrollableContainerWidget::resize_event(GUI::ResizeEvent& event)
 {
     AbstractScrollableWidget::resize_event(event);
-    update_widget_position();
     update_widget_size();
+    update_widget_position();
+}
+
+void ScrollableContainerWidget::layout_relevant_change_occured()
+{
+    update_widget_min_size();
+    update_scrollbar_visibility();
+    update_scrollbar_ranges();
+    update_widget_size();
+    update_widget_position();
+    update();
 }
 
 void ScrollableContainerWidget::set_widget(GUI::Widget* widget)
@@ -79,6 +97,7 @@ void ScrollableContainerWidget::set_widget(GUI::Widget* widget)
         add_child(*m_widget);
         m_widget->move_to_back();
     }
+    update_widget_min_size();
     update_widget_size();
     update_widget_position();
 }

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
@@ -24,10 +24,12 @@ public:
 protected:
     virtual void did_scroll() override;
     virtual void resize_event(GUI::ResizeEvent&) override;
+    virtual void layout_relevant_change_occured() override;
 
 private:
     void update_widget_size();
     void update_widget_position();
+    void update_widget_min_size();
     virtual bool load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, RefPtr<Core::Object> (*unregistered_child_handler)(String const&)) override;
 
     ScrollableContainerWidget();

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -352,6 +352,7 @@ protected:
     // This is called after children have been painted.
     virtual void second_paint_event(PaintEvent&);
 
+    virtual void layout_relevant_change_occured();
     virtual void custom_layout() { }
     virtual void did_change_font() { }
     virtual void did_layout() { }


### PR DESCRIPTION
The changes that make flicker (as in the Scrollbars don't flicker when downsizing; when `should_hide_unnecessary_scrollbars` is set to true) of ScrollableContainerWidget possible, by telling AbstractScrollableWidget the minimum size of the content in advance. The same could be used to fix the same scrollbar flickering in Browser.

Video examples:

https://user-images.githubusercontent.com/28605587/176464484-76539e54-cdcb-4a8f-a056-209e2d400fd0.mp4

https://user-images.githubusercontent.com/28605587/176464625-2ad68aac-44c5-44e0-88d7-bed94c2429cb.mp4

depends on https://github.com/SerenityOS/serenity/pull/14418 to work properly