### PR TITLE
HackStudio: Add more options to the TreeView context menu

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -473,6 +473,7 @@ NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu
     m_open_selected_in_new_tab_action = create_open_selected_in_new_tab_action();
     m_show_in_file_manager_action = create_show_in_file_manager_action();
     m_copy_relative_path_action = create_copy_relative_path_action();
+    m_copy_full_path_action = create_copy_full_path_action();
 
     m_new_directory_action = create_new_directory_action();
     m_delete_action = create_delete_action();
@@ -494,6 +495,7 @@ NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu
     project_tree_view_context_menu->add_action(*m_open_selected_in_new_tab_action);
     project_tree_view_context_menu->add_action(*m_show_in_file_manager_action);
     project_tree_view_context_menu->add_action(*m_copy_relative_path_action);
+    project_tree_view_context_menu->add_action(*m_copy_full_path_action);
     // TODO: Cut, copy, duplicate with new name...
     project_tree_view_context_menu->add_separator();
     project_tree_view_context_menu->add_action(*m_tree_view_rename_action);
@@ -624,6 +626,23 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_copy_relative_path_action()
     copy_relative_path_action->set_icon(GUI::Icon::default_icon("hard-disk").bitmap_for_size(16));
 
     return copy_relative_path_action;
+}
+
+NonnullRefPtr<GUI::Action> HackStudioWidget::create_copy_full_path_action()
+{
+    auto copy_full_path_action = GUI::Action::create("Copy &Full Path", [this](const GUI::Action&) {
+        auto paths = selected_file_paths();
+        VERIFY(!paths.is_empty());
+        Vector<String> full_paths;
+        for (auto& path : paths)
+            full_paths.append(get_absolute_path(path));
+        auto paths_string = String::join("\n", full_paths);
+        GUI::Clipboard::the().set_plain_text(paths_string);
+    });
+    copy_full_path_action->set_enabled(true);
+    copy_full_path_action->set_icon(GUI::Icon::default_icon("hard-disk").bitmap_for_size(16));
+
+    return copy_full_path_action;
 }
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_delete_action()

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -17,7 +17,6 @@
 #include "Git/DiffViewer.h"
 #include "Git/GitWidget.h"
 #include "HackStudio.h"
-#include "HackStudioWidget.h"
 #include "Locator.h"
 #include "Project.h"
 #include "ProjectDeclarations.h"
@@ -473,6 +472,7 @@ NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu
     m_open_selected_action = create_open_selected_action();
     m_open_selected_in_new_tab_action = create_open_selected_in_new_tab_action();
     m_show_in_file_manager_action = create_show_in_file_manager_action();
+    m_copy_relative_path_action = create_copy_relative_path_action();
 
     m_new_directory_action = create_new_directory_action();
     m_delete_action = create_delete_action();
@@ -493,6 +493,7 @@ NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu
     project_tree_view_context_menu->add_action(*m_open_selected_action);
     project_tree_view_context_menu->add_action(*m_open_selected_in_new_tab_action);
     project_tree_view_context_menu->add_action(*m_show_in_file_manager_action);
+    project_tree_view_context_menu->add_action(*m_copy_relative_path_action);
     // TODO: Cut, copy, duplicate with new name...
     project_tree_view_context_menu->add_separator();
     project_tree_view_context_menu->add_action(*m_tree_view_rename_action);
@@ -609,6 +610,20 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_show_in_file_manager_action(
     show_in_file_manager_action->set_icon(GUI::Icon::default_icon("app-file-manager").bitmap_for_size(16));
 
     return show_in_file_manager_action;
+}
+
+NonnullRefPtr<GUI::Action> HackStudioWidget::create_copy_relative_path_action()
+{
+    auto copy_relative_path_action = GUI::Action::create("Copy &Relative Path", [this](const GUI::Action&) {
+        auto paths = selected_file_paths();
+        VERIFY(!paths.is_empty());
+        auto paths_string = String::join("\n", paths);
+        GUI::Clipboard::the().set_plain_text(paths_string);
+    });
+    copy_relative_path_action->set_enabled(true);
+    copy_relative_path_action->set_icon(GUI::Icon::default_icon("hard-disk").bitmap_for_size(16));
+
+    return copy_relative_path_action;
 }
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_delete_action()

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -112,6 +112,7 @@ private:
     NonnullRefPtr<GUI::Action> create_save_action();
     NonnullRefPtr<GUI::Action> create_save_as_action();
     NonnullRefPtr<GUI::Action> create_show_in_file_manager_action();
+    NonnullRefPtr<GUI::Action> create_copy_relative_path_action();
     NonnullRefPtr<GUI::Action> create_add_editor_tab_widget_action();
     NonnullRefPtr<GUI::Action> create_add_editor_action();
     NonnullRefPtr<GUI::Action> create_add_terminal_action();
@@ -219,6 +220,7 @@ private:
     RefPtr<GUI::Action> m_open_selected_action;
     RefPtr<GUI::Action> m_open_selected_in_new_tab_action;
     RefPtr<GUI::Action> m_show_in_file_manager_action;
+    RefPtr<GUI::Action> m_copy_relative_path_action;
     RefPtr<GUI::Action> m_delete_action;
     RefPtr<GUI::Action> m_tree_view_rename_action;
     RefPtr<GUI::Action> m_new_project_action;

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -113,6 +113,7 @@ private:
     NonnullRefPtr<GUI::Action> create_save_as_action();
     NonnullRefPtr<GUI::Action> create_show_in_file_manager_action();
     NonnullRefPtr<GUI::Action> create_copy_relative_path_action();
+    NonnullRefPtr<GUI::Action> create_copy_full_path_action();
     NonnullRefPtr<GUI::Action> create_add_editor_tab_widget_action();
     NonnullRefPtr<GUI::Action> create_add_editor_action();
     NonnullRefPtr<GUI::Action> create_add_terminal_action();
@@ -221,6 +222,7 @@ private:
     RefPtr<GUI::Action> m_open_selected_in_new_tab_action;
     RefPtr<GUI::Action> m_show_in_file_manager_action;
     RefPtr<GUI::Action> m_copy_relative_path_action;
+    RefPtr<GUI::Action> m_copy_full_path_action;
     RefPtr<GUI::Action> m_delete_action;
     RefPtr<GUI::Action> m_tree_view_rename_action;
     RefPtr<GUI::Action> m_new_project_action;


### PR DESCRIPTION
This commit adds support for the "Copy Relative Path" and the "Copy Full Path" options.

Note: when more than one file/directory is selected, the copied paths are usually not in the right order due to the use of HashMaps to store the file paths in the GUI model.

This is a revival of an [older pull request](https://github.com/SerenityOS/serenity/pull/14410) that was closed because of me being a bad git user.
