### PR TITLE
PixelPaint: Improve image tab titles

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -102,7 +102,7 @@ void ImageEditor::set_title(String title)
 void ImageEditor::set_path(String path)
 {
     m_path = move(path);
-    set_title(LexicalPath::basename(m_path));
+    set_title(LexicalPath::title(m_path));
 }
 
 void ImageEditor::paint_event(GUI::PaintEvent& event)

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -597,7 +597,7 @@ void ImageEditor::save_project()
 
 void ImageEditor::save_project_as()
 {
-    auto response = FileSystemAccessClient::Client::the().try_save_file(window(), "untitled", "pp");
+    auto response = FileSystemAccessClient::Client::the().try_save_file(window(), m_title, "pp");
     if (response.is_error())
         return;
     auto file = response.value();


### PR DESCRIPTION
This pull request makes PixelPaint properly take into account the title entered upon creation of a new image when saving that image for the first time. It also omits the ".pp" extension in ImageEditor titles, as this led to duplicating the extension when "save as" was performed on an already saved file. The extension is still present in the actual filename.