### PR TITLE
LibWeb/CSS: Fix incorrect `calc(<percentage> - <value>)` computations

### DIFF
--- a/Base/res/html/misc/calc.html
+++ b/Base/res/html/misc/calc.html
@@ -36,7 +36,7 @@
 
     <p>calc(50% + 60px)</p>
     <div class="container">
-        <div class="box" style="width: calc(50% + 50px);"></div>
+        <div class="box" style="width: calc(50% + 60px);"></div>
     </div>
 
     <p>calc(50% + -60px)</p>
@@ -44,7 +44,7 @@
         <div class="box" style="width: calc(50% + -60px);"></div>
     </div>
 
-    <p>calc(50% + 60px - 10px)</p>
+    <p>calc(50% + 50px - 10px)</p>
     <div class="container">
         <div class="box" style="width: calc(50% + 50px - 10px);"></div>
     </div>

--- a/Base/res/html/misc/calc.html
+++ b/Base/res/html/misc/calc.html
@@ -39,6 +39,11 @@
         <div class="box" style="width: calc(50% + 60px);"></div>
     </div>
 
+    <p>calc(50% - 60px)</p>
+    <div class="container">
+        <div class="box" style="width: calc(50% - 60px);"></div>
+    </div>
+
     <p>calc(50% + -60px)</p>
     <div class="container">
         <div class="box" style="width: calc(50% + -60px);"></div>

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -478,10 +478,13 @@ void CalculatedStyleValue::CalculationResult::add_or_subtract_internal(SumOperat
 
             // Other side isn't a percentage, so the easiest way to handle it without duplicating all the logic, is just to swap `this` and `other`.
             CalculationResult new_value = other;
-            if (op == SumOperation::Add)
+            if (op == SumOperation::Add) {
                 new_value.add(*this, layout_node, percentage_basis);
-            else
-                new_value.subtract(*this, layout_node, percentage_basis);
+            } else {
+                // Turn 'this - other' into '-other + this', as 'A + B == B + A', but 'A - B != B - A'
+                new_value.multiply_by({ Number { Number::Type::Integer, -1.0f } }, layout_node);
+                new_value.add(*this, layout_node, percentage_basis);
+            }
 
             *this = new_value;
         });


### PR DESCRIPTION
Previously `100% - 10px` with base width = `200px` would result in... `-190px` :acid2kiss:

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/19366641/176557232-c2381ba7-69c0-4342-bf0f-3e1c1a15cfda.png) | ![image](https://user-images.githubusercontent.com/19366641/176557305-f581a576-9049-44e2-b9d8-399f60acf15d.png) |
