### PR TITLE
Account for malformed size in read_and_dispatch_one_message()

### DIFF
--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -552,6 +552,9 @@ ErrorOr<void> Plan9FS::read_and_dispatch_one_message()
     TRY(do_read(reinterpret_cast<u8*>(&header), sizeof(header)));
 
     auto buffer = TRY(KBuffer::try_create_with_size(header.size, Memory::Region::Access::ReadWrite));
+    if (header.size < sizeof(header)) {
+        return EIO;
+    }
     // Copy the already read header into the buffer.
     memcpy(buffer->data(), &header, sizeof(header));
     TRY(do_read(buffer->data() + sizeof(header), header.size - sizeof(header)));


### PR DESCRIPTION
read_and_dispatch_one_message() reads a header which contains a size. It assumes the size is at least the size of the header, however, this is never verified. If the size in the header is too small memory corruption will occur.

This fixes the problem by explicitly checking to make sure the size in the header is at least sizeof(header).