### PR TITLE
LibJS/Bytecode: End the for variable scope at the start of its end block

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -897,13 +897,13 @@ Bytecode::CodeGenerationErrorOr<void> ForStatement::generate_labelled_evaluation
             {});
     }
 
+    generator.switch_to_basic_block(end_block);
+    generator.emit<Bytecode::Op::Load>(result_reg);
+
     if (has_lexical_environment)
         generator.end_variable_scope();
 
     generator.end_breakable_scope();
-
-    generator.switch_to_basic_block(end_block);
-    generator.emit<Bytecode::Op::Load>(result_reg);
     return {};
 }
 


### PR DESCRIPTION
If the for loop's body is not block terminated, we will generate a Jump
to the end block which will block terminate the body. Then, we ended
the lexical variable scope if needed. However, since the body is now
block terminated, the "LeaveLexicalEnvironment" instruction that is
generated by end_variable_scope is now dropped on the floor.

This fixes this by moving it to the beginning of the end block.