### PR TITLE
LibWeb: Fix background images not showing till scrolling/repaint

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1393,7 +1393,7 @@ void ImageStyleValue::resource_did_load()
     m_bitmap = resource()->bitmap();
     // FIXME: Do less than a full repaint if possible?
     if (m_document && m_document->browsing_context())
-        m_document->browsing_context()->set_needs_display({});
+        m_document->browsing_context()->set_needs_display();
 }
 
 String ImageStyleValue::to_string() const


### PR DESCRIPTION
Previously, `set_needs_display()` was passed an empty rectangle in
`ImageStyleValue::resource_did_load()`. This led to the browser not
doing a repaint when the image loaded.

Fixes #14435