### PR TITLE
mount: Allow extending `fstab` via drop-in files in `fstab.d`

### DIFF
--- a/Base/usr/share/man/man8/mount.md
+++ b/Base/usr/share/man/man8/mount.md
@@ -16,7 +16,7 @@ If invoked without any arguments, `mount` prints a list of all currently mounted
 filesystems.
 
 If invoked as `mount -a`, `mount` mounts all the filesystems configured in
-`/etc/fstab`. This is normally done on system startup by
+`/etc/fstab` and `/etc/fstab.d/*`. This is normally done on system startup by
 [`SystemServer`(7)](help://man/7/SystemServer).
 
 Otherwise, `mount` performs a single filesystem mount. Source should be a path
@@ -36,6 +36,7 @@ Additionally, the name `defaults` is accepted and ignored.
 ## Files
 
 * `/etc/fstab` - read by `mount -a` on startup to find out which filesystems to mount.
+* `/etc/fstab.d` - directory with drop-in additions to the normal `fstab` file, also read by `mount -a`.
 * `/proc/df` - read by `mount` to get information about mounted filesystems.
 
 ## Examples


### PR DESCRIPTION
This will be used by QEMU and (presumably) other JIT-able ports that need to declare that they need their restrictions writable or anonymous executable memory lifted, but where specifying the respective mount flags on `/usr/local` as a whole would be too lax.

This is not included in the QEMU PR as that one is generally considered ready for a final review, while this feature may require some iteration.