### PR TITLE
Kernel: Handle signal handlers correctly on exec and fork

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -273,6 +273,12 @@ ErrorOr<void> Process::attach_resources(NonnullOwnPtr<Memory::AddressSpace>&& pr
 
     auto weak_ptr = TRY(this->try_make_weak_ptr());
     m_procfs_traits = TRY(ProcessProcFSTraits::try_create({}, move(weak_ptr)));
+
+    // This is not actually explicitly verified by any official documentation,
+    // but it's not listed anywhere as being cleared, and rsync expects it to work like this.
+    if (fork_parent)
+        m_signal_action_data = fork_parent->m_signal_action_data;
+
     return {};
 }
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -570,6 +570,7 @@ private:
 
     bool has_tracee_thread(ProcessID tracer_pid);
 
+    void clear_signal_handlers_for_exec();
     void clear_futex_queues_on_exec();
 
     ErrorOr<void> remap_range_as_stack(FlatPtr address, size_t size);

--- a/Tests/Kernel/CMakeLists.txt
+++ b/Tests/Kernel/CMakeLists.txt
@@ -43,6 +43,7 @@ set(LIBTEST_BASED_SOURCES
     TestProcFS.cpp
     TestProcFSWrite.cpp
     TestSigAltStack.cpp
+    TestSigHandler.cpp
     TestSigWait.cpp
 )
 

--- a/Tests/Kernel/TestSigHandler.cpp
+++ b/Tests/Kernel/TestSigHandler.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, Tim Schumacher <timschumi@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void signal_handler(int)
+{
+    VERIFY_NOT_REACHED();
+}
+
+TEST_CASE(default_handlers)
+{
+    struct sigaction current_action { };
+
+    int rc = sigaction(SIGUSR2, nullptr, &current_action);
+
+    EXPECT_EQ(rc, 0);
+    EXPECT_EQ(current_action.sa_handler, SIG_DFL);
+}
+
+TEST_CASE(handlers_after_fork)
+{
+    struct sigaction new_action {
+        { signal_handler }, 0, 0
+    };
+    int rc = sigaction(SIGUSR2, &new_action, nullptr);
+    EXPECT_EQ(rc, 0);
+
+    pid_t pid = fork();
+
+    if (pid == 0) {
+        struct sigaction current_action { };
+        rc = sigaction(SIGUSR2, nullptr, &current_action);
+        EXPECT_EQ(rc, 0);
+        EXPECT_EQ(current_action.sa_handler, signal_handler);
+        exit(rc == 0 && current_action.sa_handler == signal_handler ? EXIT_SUCCESS : EXIT_FAILURE);
+    } else {
+        int exit_status = 0;
+        rc = waitpid(pid, &exit_status, 0);
+        EXPECT_EQ(rc, pid);
+        EXPECT(WIFEXITED(exit_status));
+        EXPECT_EQ(WEXITSTATUS(exit_status), 0);
+    }
+}
+
+TEST_CASE(handlers_after_exec)
+{
+    struct sigaction new_action {
+        { signal_handler }, 0, 0
+    };
+    int rc = sigaction(SIGUSR2, &new_action, nullptr);
+    EXPECT_EQ(rc, 0);
+
+    pid_t pid = fork();
+
+    if (pid == 0) {
+        // Hide the confusing "Running 1 cases out of 3" output.
+        freopen("/dev/null", "w", stdout);
+
+        // This runs the 'default_handlers' test in this binary again, but after exec.
+        execl("/proc/self/exe", "TestSigHandler", "default_handlers", nullptr);
+        FAIL("Failed to exec.");
+    } else {
+        int exit_status = 0;
+        rc = waitpid(pid, &exit_status, 0);
+        EXPECT_EQ(rc, pid);
+        EXPECT(WIFEXITED(exit_status));
+        EXPECT_EQ(WEXITSTATUS(exit_status), 0);
+    }
+}


### PR DESCRIPTION
`rsync` sets up its remote process in a way where it will register its signal handlers first, and then fork. Afterwards, it does the transfer and sends a signal to the remote process that tells it to exit cleanly.

Previously we would just error out when receiving that signal, as we haven't copied the signal handlers while forking. Resolve that by actually copying the signal handlers, which in turn fixes `rsync` transfers.

To make sure that we don't introduce any new issues accidentally, do a POSIX-correct clear of the signal handlers when `exec`ing.