### PR TITLE
Shell: Immediately resolve value when setting a variable

### DIFF
--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -3414,6 +3414,7 @@ RefPtr<Value> VariableDeclarations::run(RefPtr<Shell> shell)
         auto value = var.value->run(shell);
         if (shell && shell->has_any_error())
             break;
+        value = value->resolve_without_cast(shell);
 
         shell->set_local_variable(name, value.release_nonnull());
     }
@@ -3701,6 +3702,14 @@ Vector<String> SpecialVariableValue::resolve_as_list(RefPtr<Shell> shell)
     default:
         return { resolve_slices(shell, "", m_slices) };
     }
+}
+
+NonnullRefPtr<Value> SpecialVariableValue::resolve_without_cast(RefPtr<Shell> shell)
+{
+    if (!shell)
+        return *this;
+
+    return make_ref_counted<ListValue>(resolve_as_list(shell));
 }
 
 TildeValue::~TildeValue()

--- a/Userland/Shell/AST.h
+++ b/Userland/Shell/AST.h
@@ -381,6 +381,7 @@ class SpecialVariableValue final : public Value {
 public:
     virtual Vector<String> resolve_as_list(RefPtr<Shell>) override;
     virtual String resolve_as_string(RefPtr<Shell>) override;
+    virtual NonnullRefPtr<Value> resolve_without_cast(RefPtr<Shell>) override;
     virtual NonnullRefPtr<Value> clone() const override { return make_ref_counted<SpecialVariableValue>(m_name)->set_slices(m_slices); }
     virtual ~SpecialVariableValue();
     SpecialVariableValue(char name)
@@ -512,9 +513,15 @@ protected:
     RefPtr<SyntaxError> m_syntax_error_node;
 };
 
-#define NODE(name)                                               \
-    virtual String class_name() const override { return #name; } \
-    virtual Kind kind() const override { return Kind::name; }
+#define NODE(name)                             \
+    virtual String class_name() const override \
+    {                                          \
+        return #name;                          \
+    }                                          \
+    virtual Kind kind() const override         \
+    {                                          \
+        return Kind::name;                     \
+    }
 
 class PathRedirectionNode : public Node {
 public:


### PR DESCRIPTION
The lazy resolution mechanism made it so that the variables were linked
together, causing unexpected behaviour:

    true
    x=$? # expected: x=0
    false
    echo $x # expected: 0, actual: 1