### PR TITLE
BrowserSettings: Some content filtering fixes

### DIFF
--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -114,7 +114,7 @@ ContentFilterSettingsWidget::ContentFilterSettingsWidget()
     m_domain_list_view = find_descendant_of_type_named<GUI::ListView>("domain_list_view");
     m_add_new_domain_button = find_descendant_of_type_named<GUI::Button>("add_new_domain_button");
 
-    m_enable_content_filtering_checkbox->set_checked(Config::read_bool("Browser", "Preferences", "EnableContentFilters"), GUI::AllowCallback::No);
+    m_enable_content_filtering_checkbox->set_checked(Config::read_bool("Browser", "Preferences", "EnableContentFilters", s_default_enable_content_filtering), GUI::AllowCallback::No);
     m_enable_content_filtering_checkbox->on_checked = [&](auto) { set_modified(true); };
 
     m_add_new_domain_button->on_click = [&](unsigned) {

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -18,7 +18,7 @@
 #include <LibGUI/ListView.h>
 #include <LibGUI/Menu.h>
 
-static bool default_enable_content_filtering = true;
+static constexpr bool s_default_enable_content_filtering = true;
 
 static String filter_list_file_path()
 {
@@ -157,5 +157,5 @@ void ContentFilterSettingsWidget::apply_settings()
 void ContentFilterSettingsWidget::reset_default_values()
 {
     m_domain_list_model->reset_default_values();
-    m_enable_content_filtering_checkbox->set_checked(default_enable_content_filtering);
+    m_enable_content_filtering_checkbox->set_checked(s_default_enable_content_filtering);
 }


### PR DESCRIPTION
**[BrowserSettings: Make default content filtering flag const(expr)](https://github.com/SerenityOS/serenity/commit/dba669e206ea93664b3d583e16f5114065c2b3b0)**

And add s_ prefix per contribution guidelines.

**[BrowserSettings: Make content filtering on by default](https://github.com/SerenityOS/serenity/commit/4c15735db7c9b1939ad15a24c2f4b1a6e8737ecc)**

It was default in Browser but not default in settings, so the checkbox
was initially not checked.