### PR TITLE
Kernel+LibC+LibCore: Pass fcntl extra argument as pointer-sized variable

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -348,7 +348,7 @@ public:
     ErrorOr<FlatPtr> sys$setresgid(GroupID, GroupID, GroupID);
     ErrorOr<FlatPtr> sys$alarm(unsigned seconds);
     ErrorOr<FlatPtr> sys$access(Userspace<char const*> pathname, size_t path_length, int mode);
-    ErrorOr<FlatPtr> sys$fcntl(int fd, int cmd, u32 extra_arg);
+    ErrorOr<FlatPtr> sys$fcntl(int fd, int cmd, uintptr_t extra_arg);
     ErrorOr<FlatPtr> sys$ioctl(int fd, unsigned request, FlatPtr arg);
     ErrorOr<FlatPtr> sys$mkdir(Userspace<char const*> pathname, size_t path_length, mode_t mode);
     ErrorOr<FlatPtr> sys$times(Userspace<tms*>);

--- a/Kernel/Syscalls/fcntl.cpp
+++ b/Kernel/Syscalls/fcntl.cpp
@@ -10,7 +10,7 @@
 
 namespace Kernel {
 
-ErrorOr<FlatPtr> Process::sys$fcntl(int fd, int cmd, u32 arg)
+ErrorOr<FlatPtr> Process::sys$fcntl(int fd, int cmd, uintptr_t arg)
 {
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     TRY(require_promise(Pledge::stdio));

--- a/Userland/Libraries/LibC/fcntl.cpp
+++ b/Userland/Libraries/LibC/fcntl.cpp
@@ -19,7 +19,7 @@ int fcntl(int fd, int cmd, ...)
 {
     va_list ap;
     va_start(ap, cmd);
-    u32 extra_arg = va_arg(ap, u32);
+    uintptr_t extra_arg = va_arg(ap, uintptr_t);
     int rc = syscall(SC_fcntl, fd, cmd, extra_arg);
     va_end(ap);
     __RETURN_WITH_ERRNO(rc, rc, -1);

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -248,7 +248,7 @@ ErrorOr<int> fcntl(int fd, int command, ...)
 {
     va_list ap;
     va_start(ap, command);
-    u32 extra_arg = va_arg(ap, u32);
+    uintptr_t extra_arg = va_arg(ap, uintptr_t);
     int rc = ::fcntl(fd, command, extra_arg);
     va_end(ap);
     if (rc < 0)


### PR DESCRIPTION
The extra argument to `fcntl` is a pointer in the case of `F_GETLK`/`F_SETLK` and we were pulling out a `u32`, leading to pointer truncation on x86_64.
Among other things, this fixes Assistant on x86_64 :^)