### PR TITLE
LibCore+LibIPC: Quick fixes to get Inspector working

### DIFF
--- a/Userland/Demos/WidgetGallery/main.cpp
+++ b/Userland/Demos/WidgetGallery/main.cpp
@@ -15,7 +15,7 @@
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix thread"));
-    auto app = TRY(GUI::Application::try_create(arguments));
+    auto app = TRY(GUI::Application::try_create(arguments, Core::EventLoop::MakeInspectable::Yes));
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath thread"));
     TRY(Core::System::unveil("/res", "r"));


### PR DESCRIPTION
Inspector hung on trying to inspect larger applications like WidgetGallery (which I made inspectable by default because it's the perfect target anyways, and who cares about it's performance or security) because the JSON sent to represent the current state by far exceeded (> 200kB) what's possible to be sent in a single write (the fix in EventLoop) and also hit the socket buffer limit and caused an `EAGAIN` error.
The fix for the latter is really far from ideal, but it gets the Inspector working again. Every time it gets triggered a debug message will be written reminding everyone that this problem needs to be addressed, or simply that ludicrously large things are being sent over IPC.