### PR TITLE
LibWeb: Use lowercase type selectors to match against html elements

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -420,7 +420,6 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
             .property_id = property_id,
             .value = style->property(property_id),
         };
-        return {};
     }
 
     auto& layout_node = *m_element->layout_node();

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -341,6 +341,9 @@ static inline bool matches(CSS::Selector::SimpleSelector const& component, DOM::
     case CSS::Selector::SimpleSelector::Type::Class:
         return element.has_class(component.name());
     case CSS::Selector::SimpleSelector::Type::TagName:
+        // See https://html.spec.whatwg.org/multipage/semantics-other.html#case-sensitivity-of-selectors
+        if (is<HTML::HTMLElement>(element) && element.document().document_type() != DOM::Document::Type::XML)
+            return component.name().equals_ignoring_case(element.local_name());
         return component.name() == element.local_name();
     case CSS::Selector::SimpleSelector::Type::Attribute:
         return matches_attribute(component.attribute(), element);

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
@@ -53,7 +53,6 @@ ExceptionOr<NonnullRefPtr<Document>> DOMImplementation::create_document(String c
 // https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
 NonnullRefPtr<Document> DOMImplementation::create_html_document(String const& title) const
 {
-    // FIXME: This should specifically be a HTML document.
     auto html_document = Document::create();
 
     html_document->set_content_type("text/html");

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -45,6 +45,11 @@ class Document
 public:
     using WrapperType = Bindings::DocumentWrapper;
 
+    enum class Type {
+        XML,
+        HTML
+    };
+
     static NonnullRefPtr<Document> create(const AK::URL& url = "about:blank")
     {
         return adopt_ref(*new Document(url));
@@ -207,6 +212,12 @@ public:
     QuirksMode mode() const { return m_quirks_mode; }
     bool in_quirks_mode() const { return m_quirks_mode == QuirksMode::Yes; }
     void set_quirks_mode(QuirksMode mode) { m_quirks_mode = mode; }
+
+    Type document_type() const { return m_type; }
+    void set_document_type(Type type) { m_type = type; }
+
+    // https://dom.spec.whatwg.org/#xml-document
+    bool is_xml_document() const { return m_type == Type::XML; }
 
     ExceptionOr<NonnullRefPtr<Node>> import_node(NonnullRefPtr<Node> node, bool deep);
     void adopt_node(Node&);
@@ -411,6 +422,10 @@ private:
     NonnullRefPtrVector<HTML::HTMLScriptElement> m_scripts_to_execute_as_soon_as_possible;
 
     QuirksMode m_quirks_mode { QuirksMode::No };
+
+    // https://dom.spec.whatwg.org/#concept-document-type
+    Type m_type { Type::HTML };
+
     bool m_editable { false };
 
     WeakPtr<Element> m_focused_element;

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -680,7 +680,7 @@ NonnullRefPtr<Node> Node::clone_node(Document* document, bool clone_children)
         document_copy->set_content_type(document_->content_type());
         document_copy->set_url(document_->url());
         document_copy->set_origin(document_->origin());
-        // FIXME: Set type ("xml" or "html")
+        document_copy->set_document_type(document_->document_type());
         document_copy->set_quirks_mode(document_->mode());
         copy = move(document_copy);
     } else if (is<DocumentType>(this)) {

--- a/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
@@ -25,7 +25,8 @@ NonnullRefPtr<DOM::Document> DOMParser::parse_from_string(String const& string, 
     // 2. Switch on type:
     if (type == Bindings::DOMParserSupportedType::Text_Html) {
         // -> "text/html"
-        // FIXME: 1. Set document's type to "html".
+        // 1. Set document's type to "html".
+        document->set_document_type(DOM::Document::Type::HTML);
 
         // 2. Create an HTML parser parser, associated with document.
         // 3. Place string into the input stream for parser. The encoding confidence is irrelevant.

--- a/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
@@ -24,8 +24,7 @@ DOM::Document& HTMLTemplateElement::appropriate_template_contents_owner_document
         if (!document.associated_inert_template_document()) {
             auto new_document = DOM::Document::create();
             new_document->set_created_for_appropriate_template_contents(true);
-
-            // FIXME: If doc is an HTML document, mark new doc as an HTML document also.
+            new_document->set_document_type(document.document_type());
 
             document.set_associated_inert_template_document(new_document);
         }


### PR DESCRIPTION
Previously we would fail to match a selector like `NAV` against a `<nav>` html element.