### PR TITLE
LibGUI+WidgetGallery+AK: Fix layout problems, by introducing calculated sizes for TabWidget

### DIFF
--- a/AK/GenericShorthands.h
+++ b/AK/GenericShorthands.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022, Frhun <serenitystuff@frhun.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace AK {
+
+template<typename T, typename... Ts>
+[[nodiscard]] bool first_is_one_of(T const to_compare, Ts const... valid_values)
+{
+    return (... || (to_compare == valid_values));
+}
+
+template<typename T, typename... Ts>
+[[nodiscard]] bool first_is_smaller_than_one_of(T const to_compare, Ts const... valid_values)
+{
+    return (... || (to_compare < valid_values));
+}
+
+template<typename T, typename... Ts>
+[[nodiscard]] bool first_is_smaller_or_equal_than_one_of(T const to_compare, Ts const... valid_values)
+{
+    return (... || (to_compare <= valid_values));
+}
+
+template<typename T, typename... Ts>
+[[nodiscard]] bool first_is_larger_than_one_of(T const to_compare, Ts const... valid_values)
+{
+    return (... || (to_compare > valid_values));
+}
+
+template<typename T, typename... Ts>
+[[nodiscard]] bool first_is_larger_or_equal_than_one_of(T const to_compare, Ts const... valid_values)
+{
+    return (... || (to_compare >= valid_values));
+}
+
+template<typename T, typename... Ts>
+[[nodiscard]] bool first_is_smaller_than_all_of(T const to_compare, Ts const... valid_values)
+{
+    return (... && (to_compare < valid_values));
+}
+
+template<typename T, typename... Ts>
+[[nodiscard]] bool first_is_smaller_or_equal_than_all_of(T const to_compare, Ts const... valid_values)
+{
+    return (... && (to_compare <= valid_values));
+}
+
+template<typename T, typename... Ts>
+[[nodiscard]] bool first_is_larger_than_all_of(T const to_compare, Ts const... valid_values)
+{
+    return (... && (to_compare > valid_values));
+}
+
+template<typename T, typename... Ts>
+[[nodiscard]] bool first_is_larger_or_equal_than_all_of(T const to_compare, Ts const... valid_values)
+{
+    return (... && (to_compare >= valid_values));
+}
+}
+
+using AK::first_is_larger_or_equal_than_all_of;
+using AK::first_is_larger_or_equal_than_one_of;
+using AK::first_is_larger_than_all_of;
+using AK::first_is_larger_than_one_of;
+using AK::first_is_one_of;
+using AK::first_is_smaller_or_equal_than_all_of;
+using AK::first_is_smaller_or_equal_than_one_of;
+using AK::first_is_smaller_than_all_of;
+using AK::first_is_smaller_than_one_of;

--- a/Userland/Demos/WidgetGallery/GalleryGML/BasicsTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/BasicsTab.gml
@@ -5,7 +5,7 @@
     }
 
     @GUI::GroupBox {
-        fixed_height: 95
+        preferred_height: "fit"
         layout: @GUI::VerticalBoxLayout {
             margins: [8]
         }
@@ -27,11 +27,13 @@
                 @GUI::Label {
                     name: "enabled_label"
                     text: "Label"
+                    min_height: 16
                 }
 
                 @GUI::Label {
                     name: "disabled_label"
                     text: "Disabled"
+                    min_height: 16
                     enabled: false
                 }
             }

--- a/Userland/Libraries/LibGUI/Margins.h
+++ b/Userland/Libraries/LibGUI/Margins.h
@@ -95,6 +95,16 @@ public:
             return m_top + m_bottom;
     }
 
+    [[nodiscard]] int horizontal_total() const
+    {
+        return m_left + m_right;
+    }
+
+    [[nodiscard]] int vertical_total() const
+    {
+        return m_top + m_bottom;
+    }
+
 private:
     int m_top { 0 };
     int m_right { 0 };

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -57,6 +57,7 @@ ErrorOr<void> TabWidget::try_add_widget(Widget& widget)
     update_focus_policy();
     if (on_tab_count_change)
         on_tab_count_change(m_tabs.size());
+    layout_relevant_change_occured();
     return {};
 }
 
@@ -82,6 +83,8 @@ void TabWidget::remove_widget(Widget& widget)
     update_focus_policy();
     if (on_tab_count_change)
         on_tab_count_change(m_tabs.size());
+
+    layout_relevant_change_occured();
 }
 
 void TabWidget::remove_all_tabs_except(Widget& widget)
@@ -98,6 +101,8 @@ void TabWidget::remove_all_tabs_except(Widget& widget)
     update_focus_policy();
     if (on_tab_count_change)
         on_tab_count_change(1);
+
+    layout_relevant_change_occured();
 }
 
 void TabWidget::update_focus_policy()
@@ -130,6 +135,8 @@ void TabWidget::set_active_widget(Widget* widget)
                 on_change(*m_active_widget);
         });
     }
+
+    layout_relevant_change_occured();
 
     update_bar();
 }
@@ -688,6 +695,7 @@ void TabWidget::doubleclick_event(MouseEvent& mouse_event)
 void TabWidget::set_container_margins(GUI::Margins const& margins)
 {
     m_container_margins = margins;
+    layout_relevant_change_occured();
     update();
 }
 

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/GenericShorthands.h>
 #include <AK/JsonValue.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Painter.h>
@@ -688,6 +689,34 @@ void TabWidget::set_container_margins(GUI::Margins const& margins)
 {
     m_container_margins = margins;
     update();
+}
+
+Optional<UISize> TabWidget::calculated_min_size() const
+{
+    if (!m_active_widget)
+        return {};
+    auto content_min_size = m_active_widget->effective_min_size();
+    UIDimension width = MUST(content_min_size.width().shrink_value()), height = MUST(content_min_size.height().shrink_value());
+    width.add_if_int(container_margins().vertical_total()
+        + (first_is_one_of(m_tab_position, TabPosition::Left, TabPosition::Right) ? bar_rect().width() : 0));
+    height.add_if_int(container_margins().vertical_total()
+        + (first_is_one_of(m_tab_position, TabPosition::Top, TabPosition::Bottom) ? bar_rect().height() : 0));
+
+    return UISize { width, height };
+}
+
+Optional<UISize> TabWidget::calculated_preferred_size() const
+{
+    if (!m_active_widget)
+        return {};
+    auto content_preferred_size = m_active_widget->effective_preferred_size();
+    UIDimension width = MUST(content_preferred_size.width().shrink_value()), height = MUST(content_preferred_size.height().shrink_value());
+    width.add_if_int(container_margins().vertical_total()
+        + (first_is_one_of(m_tab_position, TabPosition::Left, TabPosition::Right) ? bar_rect().width() : 0));
+    height.add_if_int(
+        container_margins().vertical_total()
+        + (first_is_one_of(m_tab_position, TabPosition::Top, TabPosition::Bottom) ? bar_rect().height() : 0));
+    return UISize { width, height };
 }
 
 void TabWidget::drag_tab(size_t index)

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -47,6 +47,9 @@ public:
     GUI::Margins const& container_margins() const { return m_container_margins; }
     void set_container_margins(GUI::Margins const&);
 
+    Optional<UISize> calculated_min_size() const override;
+    Optional<UISize> calculated_preferred_size() const override;
+
     ErrorOr<void> try_add_widget(Widget&);
 
     void add_widget(Widget&);

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -201,10 +201,12 @@ Widget::~Widget() = default;
 
 void Widget::layout_relevant_change_occured()
 {
-    if (auto* parent = parent_widget())
-        parent->layout_relevant_change_occured();
-    else
-        invalidate_layout();
+    if (is_visible()) {
+        if (auto* parent = parent_widget())
+            parent->layout_relevant_change_occured();
+        else if (window())
+            window()->schedule_relayout();
+    }
 }
 
 void Widget::child_event(Core::ChildEvent& event)

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -407,6 +407,7 @@ void Widget::set_layout(NonnullRefPtr<Layout> layout)
     } else {
         update();
     }
+    layout_relevant_change_occured();
 }
 
 void Widget::do_layout()
@@ -1018,6 +1019,7 @@ void Widget::set_palette(Palette const& palette)
 void Widget::set_title(String title)
 {
     m_title = move(title);
+    layout_relevant_change_occured();
     // For tab widget children, our change in title also affects the parent.
     if (parent_widget())
         parent_widget()->update();
@@ -1060,7 +1062,7 @@ void Widget::set_grabbable_margins(Margins const& margins)
     if (m_grabbable_margins == margins)
         return;
     m_grabbable_margins = margins;
-    invalidate_layout();
+    layout_relevant_change_occured();
 }
 
 Gfx::IntRect Widget::relative_non_grabbable_rect() const

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -231,6 +231,8 @@ protected:
     virtual void leave_event(Core::Event&);
 
 private:
+    void update_min_size();
+
     void update_cursor();
     void focus_a_widget_if_possible(FocusSource);
 


### PR DESCRIPTION
This
fixes https://github.com/SerenityOS/serenity/issues/14420
the last of those layout problems.

You can try it pretty well by playing around with the WidgetGallery.
TabWigets with the tabs on the left or right are also supported.

This also repairs an issue I came across along the way that windows would't initially take on the min_size of their content widget.

I'm not really sure about the `AK/GenericShorthands.h`, I just don't like repeating myself with things like `var == a || var == b`, and those provide an IMHO good way to get rid of this kind of repetition.