### PR TITLE
LibWeb: Border-Radius: Endgame

### DIFF
--- a/Base/res/html/misc/border-radius.html
+++ b/Base/res/html/misc/border-radius.html
@@ -311,6 +311,27 @@
     <br>
     <br>
 
+    <p>The all have a border-radius +/- overflow: hidden, which clips their child elements<p>
+    <em>Lorem ipsum, <b>without</b> overflow: hidden</em>
+    <div style="width: 200px; height: 200px; border-radius: 30%; background-color: brown">
+        <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</span>
+    </div>
+    <br>
+    <em>Lorem ipsum, <b>with</b> overflow: hidden</em>
+    <div style="width: 200px; height: 200px; border-radius: 30%; background-color: brown; overflow: hidden;">
+        <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</span>
+    </div>
+    <br>
+    <em>An image inside a inline-block <code>&lt;a&gt;</code> tag, with a border-radius of 50% and overflow: hidden</em>
+    <br>
+    (this is commonly used for avatars and occurs GitHub a few times)
+    <br>
+    <a style="display: inline-block; border-radius: 50%; overflow: hidden; width: 100px; height: 100px;">
+        <img src="car.png" style="width: 100px; height: 100px">
+    </a>
+    <br>
+    <br>
+
     <p>The boxes are 50x50px</p>
     <em>All round 10px</em>
     <div class="box box-1"></div>

--- a/Base/res/html/misc/border-radius.html
+++ b/Base/res/html/misc/border-radius.html
@@ -332,6 +332,21 @@
     <br>
     <br>
 
+    <p>All these are non-conventional elements with a border-radius :^)<p>
+    <em>iframe to the welcome page</em>
+    <br>
+    <iframe style="border-radius: 50%; border: none; width: 300px; height: 200px;" src="welcome.html"></iframe>
+    <br>
+    <em>Fun canvas demo</em>
+    <br>
+    <canvas id="fun-canvas" style="border-radius: 30%;" width="200" height="200"></canvas>
+    <script src="fun-canvas.js"></script>
+    <script>
+        makeFunCanvas("fun-canvas")
+    </script>
+    <br/>
+    <br/>
+
     <p>The boxes are 50x50px</p>
     <em>All round 10px</em>
     <div class="box box-1"></div>

--- a/Base/res/html/misc/demo.html
+++ b/Base/res/html/misc/demo.html
@@ -5,50 +5,9 @@
 </head>
 <body>
 <canvas id=c width=400 height=300></canvas>
+<script src="fun-canvas.js"></script>
 <script>
-c = document.getElementById("c");
-ctx = c.getContext("2d");
-ctx.fillStyle = 'black';
-ctx.fillRect(0, 0, c.width, c.height);
-
-pressed = false;
-mouseX = 0;
-mouseY = 0;
-
-c.addEventListener("mousedown", function(e) {
-    // mousedown
-    pressed = true;
-    mouseX = e.offsetX;
-    mouseY = e.offsetY;
-});
-
-c.addEventListener("mouseup", function() {
-    // mouseup
-    pressed = false;
-});
-
-c.addEventListener("mousemove", function(e) {
-    // mousemove
-    mouseX = e.offsetX;
-    mouseY = e.offsetY;
-});
-
-function update() {
-    if (pressed) {
-        var r = Math.random() * 255;
-        var g = Math.random() * 255;
-        var b = Math.random() * 255;
-        var color = "rgb(" + ~~r + "," + ~~g + "," + ~~b + ")";
-        ctx.fillStyle = color;
-        const spread = 35;
-        var x = mouseX + (Math.random() * spread) - (spread / 2);
-        var y = mouseY + (Math.random() * spread) - (spread / 2);
-        var size = Math.random() * 8;
-        ctx.fillRect(x, y, size, size);
-    }
-}
-
-setInterval(update, 20);
+    makeFunCanvas("c")
 </script>
 </body>
 </html>

--- a/Base/res/html/misc/fun-canvas.js
+++ b/Base/res/html/misc/fun-canvas.js
@@ -1,0 +1,46 @@
+const makeFunCanvas = canvasId => {
+    c = document.getElementById(canvasId);
+
+    ctx = c.getContext("2d");
+    ctx.fillStyle = "black";
+    ctx.fillRect(0, 0, c.width, c.height);
+
+    pressed = false;
+    mouseX = 0;
+    mouseY = 0;
+
+    c.addEventListener("mousedown", function (e) {
+        // mousedown
+        pressed = true;
+        mouseX = e.offsetX;
+        mouseY = e.offsetY;
+    });
+
+    c.addEventListener("mouseup", function () {
+        // mouseup
+        pressed = false;
+    });
+
+    c.addEventListener("mousemove", function (e) {
+        // mousemove
+        mouseX = e.offsetX;
+        mouseY = e.offsetY;
+    });
+
+    function update() {
+        if (pressed) {
+            var r = Math.random() * 255;
+            var g = Math.random() * 255;
+            var b = Math.random() * 255;
+            var color = "rgb(" + ~~r + "," + ~~g + "," + ~~b + ")";
+            ctx.fillStyle = color;
+            const spread = 35;
+            var x = mouseX + Math.random() * spread - spread / 2;
+            var y = mouseY + Math.random() * spread - spread / 2;
+            var size = Math.random() * 8;
+            ctx.fillRect(x, y, size, size);
+        }
+    }
+
+    setInterval(update, 20);
+};

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -89,17 +89,10 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
         auto& image = *layer.image->bitmap();
 
         // Clip
-        Optional<BorderRadiusCornerClipper> corner_radius_clipper {};
         auto clip_box = get_box(layer.clip);
         auto clip_rect = clip_box.rect.to_rounded<int>();
-        if (clip_box.radii.has_any_radius()) {
-            auto clipper = BorderRadiusCornerClipper::create(clip_rect, clip_box.radii);
-            if (!clipper.is_error()) {
-                corner_radius_clipper = clipper.release_value();
-                corner_radius_clipper->sample_under_corners(painter);
-            }
-        }
         painter.add_clip_rect(clip_rect);
+        ScopedCornerRadiusClip corner_clip { painter, clip_rect, clip_box.radii };
 
         Gfx::FloatRect background_positioning_area;
 
@@ -292,9 +285,6 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
                 break;
             image_y += y_step;
         }
-
-        if (corner_radius_clipper.has_value())
-            corner_radius_clipper->blit_corner_clipping(painter);
     }
 }
 

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.h
@@ -60,4 +60,32 @@ private:
     }
 };
 
+struct ScopedCornerRadiusClip {
+    ScopedCornerRadiusClip(Gfx::Painter& painter, Gfx::IntRect const& border_rect, BorderRadiiData const& border_radii, CornerClip corner_clip = CornerClip::Outside, BorderRadiusCornerClipper::UseCachedBitmap use_cached_bitmap = BorderRadiusCornerClipper::UseCachedBitmap::Yes)
+        : m_painter(painter)
+    {
+        if (border_radii.has_any_radius()) {
+            auto clipper = BorderRadiusCornerClipper::create(border_rect, border_radii, corner_clip, use_cached_bitmap);
+            if (!clipper.is_error()) {
+                m_corner_clipper = clipper.release_value();
+                m_corner_clipper->sample_under_corners(m_painter);
+            }
+        }
+    }
+
+    ~ScopedCornerRadiusClip()
+    {
+        if (m_corner_clipper.has_value()) {
+            m_corner_clipper->blit_corner_clipping(m_painter);
+        }
+    }
+
+    AK_MAKE_NONMOVABLE(ScopedCornerRadiusClip);
+    AK_MAKE_NONCOPYABLE(ScopedCornerRadiusClip);
+
+private:
+    Gfx::Painter& m_painter;
+    Optional<BorderRadiusCornerClipper> m_corner_clipper;
+};
+
 }

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.h
@@ -18,7 +18,12 @@ enum class CornerClip {
 
 class BorderRadiusCornerClipper {
 public:
-    static ErrorOr<BorderRadiusCornerClipper> create(Gfx::IntRect const& border_rect, BorderRadiiData const& border_radii, CornerClip corner_clip = CornerClip::Outside);
+    enum class UseCachedBitmap {
+        Yes,
+        No
+    };
+
+    static ErrorOr<BorderRadiusCornerClipper> create(Gfx::IntRect const& border_rect, BorderRadiiData const& border_radii, CornerClip corner_clip = CornerClip::Outside, UseCachedBitmap use_cached_bitmap = UseCachedBitmap::Yes);
 
     void sample_under_corners(Gfx::Painter& page_painter);
     void blit_corner_clipping(Gfx::Painter& page_painter);

--- a/Userland/Libraries/LibWeb/Painting/CanvasPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CanvasPaintable.cpp
@@ -31,14 +31,17 @@ void CanvasPaintable::paint(PaintContext& context, PaintPhase phase) const
     PaintableBox::paint(context, phase);
 
     if (phase == PaintPhase::Foreground) {
+        auto canvas_rect = absolute_rect().to_rounded<int>();
+        ScopedCornerRadiusClip corner_clip { context.painter(), canvas_rect, normalized_border_radii_data() };
+
         // FIXME: This should be done at a different level. Also rect() does not include padding etc!
-        if (!context.viewport_rect().intersects(enclosing_int_rect(absolute_rect())))
+        if (!context.viewport_rect().intersects(canvas_rect))
             return;
 
         if (layout_box().dom_node().bitmap()) {
             // FIXME: Remove this const_cast.
             const_cast<HTML::HTMLCanvasElement&>(layout_box().dom_node()).present();
-            context.painter().draw_scaled_bitmap(absolute_rect().to_rounded<int>(), *layout_box().dom_node().bitmap(), layout_box().dom_node().bitmap()->rect(), 1.0f, to_gfx_scaling_mode(computed_values().image_rendering()));
+            context.painter().draw_scaled_bitmap(canvas_rect, *layout_box().dom_node().bitmap(), layout_box().dom_node().bitmap()->rect(), 1.0f, to_gfx_scaling_mode(computed_values().image_rendering()));
         }
     }
 }

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -49,22 +49,8 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
             context.painter().draw_text(enclosing_int_rect(absolute_rect()), alt, Gfx::TextAlignment::Center, computed_values().color(), Gfx::TextElision::Right);
         } else if (auto bitmap = layout_box().image_loader().bitmap(layout_box().image_loader().current_frame_index())) {
             auto image_rect = absolute_rect().to_rounded<int>();
-            auto border_radii_data = normalized_border_radii_data();
-
-            Optional<BorderRadiusCornerClipper> corner_clipper;
-            if (border_radii_data.has_any_radius()) {
-                auto clipper = BorderRadiusCornerClipper::create(image_rect, border_radii_data);
-                if (!clipper.is_error())
-                    corner_clipper = clipper.release_value();
-            }
-
-            if (corner_clipper.has_value())
-                corner_clipper->sample_under_corners(context.painter());
-
+            ScopedCornerRadiusClip corner_clip { context.painter(), image_rect, normalized_border_radii_data() };
             context.painter().draw_scaled_bitmap(image_rect, *bitmap, bitmap->rect(), 1.0f, to_gfx_scaling_mode(computed_values().image_rendering()));
-
-            if (corner_clipper.has_value())
-                corner_clipper->blit_corner_clipping(context.painter());
         }
     }
 }

--- a/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/HTML/BrowsingContextContainer.h>
 #include <LibWeb/Layout/FrameBox.h>
 #include <LibWeb/Layout/InitialContainingBlock.h>
+#include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/NestedBrowsingContextPaintable.h>
 
 namespace Web::Painting {
@@ -32,6 +33,9 @@ void NestedBrowsingContextPaintable::paint(PaintContext& context, PaintPhase pha
     PaintableBox::paint(context, phase);
 
     if (phase == PaintPhase::Foreground) {
+        auto clip_rect = absolute_rect().to_rounded<int>();
+        ScopedCornerRadiusClip corner_clip { context.painter(), clip_rect, normalized_border_radii_data() };
+
         auto* hosted_document = layout_box().dom_node().content_document_without_origin_check();
         if (!hosted_document)
             return;
@@ -42,7 +46,7 @@ void NestedBrowsingContextPaintable::paint(PaintContext& context, PaintPhase pha
         context.painter().save();
         auto old_viewport_rect = context.viewport_rect();
 
-        context.painter().add_clip_rect(enclosing_int_rect(absolute_rect()));
+        context.painter().add_clip_rect(clip_rect);
         context.painter().translate(absolute_x(), absolute_y());
 
         context.set_viewport_rect({ {}, layout_box().dom_node().nested_browsing_context()->size() });

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -245,9 +245,10 @@ BorderRadiiData PaintableBox::normalized_border_radii_data() const
 void PaintableBox::before_children_paint(PaintContext& context, PaintPhase) const
 {
     // FIXME: Support more overflow variations.
+    auto clip_rect = absolute_padding_box_rect().to_rounded<int>();
     if (computed_values().overflow_x() == CSS::Overflow::Hidden && computed_values().overflow_y() == CSS::Overflow::Hidden) {
         context.painter().save();
-        context.painter().add_clip_rect(enclosing_int_rect(absolute_border_box_rect()));
+        context.painter().add_clip_rect(clip_rect);
     }
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibWeb/Painting/BorderPainting.h>
+#include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/Paintable.h>
 
 namespace Web::Painting {
@@ -135,6 +136,9 @@ private:
     OwnPtr<Painting::StackingContext> m_stacking_context;
 
     Optional<Gfx::FloatRect> mutable m_absolute_rect;
+
+    mutable bool m_clipping_overflow { false };
+    Optional<BorderRadiusCornerClipper> mutable m_overflow_corner_radius_clipper;
 };
 
 class PaintableWithLines : public PaintableBox {

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -29,16 +29,7 @@ void paint_box_shadow(PaintContext& context, Gfx::IntRect const& content_rect, B
     auto bottom_right_corner = border_radii.bottom_right.as_corner();
     auto bottom_left_corner = border_radii.bottom_left.as_corner();
 
-    Optional<BorderRadiusCornerClipper> corner_radius_clipper {};
-
-    if (border_radii.has_any_radius()) {
-        auto clipper = BorderRadiusCornerClipper::create(content_rect, border_radii, CornerClip::Inside);
-        if (!clipper.is_error())
-            corner_radius_clipper = clipper.release_value();
-    }
-
-    if (corner_radius_clipper.has_value())
-        corner_radius_clipper->sample_under_corners(painter);
+    ScopedCornerRadiusClip corner_clipper { painter, content_rect, border_radii, CornerClip::Inside };
 
     // Note: Box-shadow layers are ordered front-to-back, so we paint them in reverse
     for (auto& box_shadow_data : box_shadow_layers.in_reverse()) {
@@ -326,9 +317,6 @@ void paint_box_shadow(PaintContext& context, Gfx::IntRect const& content_rect, B
             paint_shadow(bottom_left);
         }
     }
-
-    if (corner_radius_clipper.has_value())
-        corner_radius_clipper->blit_corner_clipping(painter);
 }
 
 void paint_text_shadow(PaintContext& context, Layout::LineBoxFragment const& fragment, Vector<ShadowData> const& shadow_layers)


### PR DESCRIPTION
**Demo:**

[screen-capture (93).webm](https://user-images.githubusercontent.com/11597044/177212920-33b0898d-893d-4dbf-876a-f1c36188f3f1.webm)

Finishes off border-radius support for most things (there may still be a few missing cases, let me know if you find one :^)).
It implements:

- `border-radius` + `overflow: hidden`
- Adding a `border-radius` to a `<canvas>` element
- Adding a `border-radius` to a `<iframe>` element
(most other cases are already covered by previous border-radius work).

This PR also includes a little refactoring of previous work. Now adding border-radius clipping to an element has been encapsulated to:
```c++
{
  ScopedCornerRadiusClip corner_clip { context.painter(), border_rect, normalized_border_radii_data() };
  /* paint element */
} 
```
