### PR TITLE
LibArchive: Guard against major() and minor() macros from old glibc

### DIFF
--- a/Userland/Libraries/LibArchive/Tar.h
+++ b/Userland/Libraries/LibArchive/Tar.h
@@ -13,6 +13,16 @@
 #include <string.h>
 #include <sys/types.h>
 
+// glibc before 2.28 defines these from sys/types.h, but we don't want
+// TarFileHeader::major() and TarFileHeader::minor() to use those macros
+#ifdef minor
+#    undef minor
+#endif
+
+#ifdef major
+#    undef major
+#endif
+
 namespace Archive {
 
 enum class TarFileType : char {


### PR DESCRIPTION
glibc before 2.28 defines major() and minor() macros from sys/types.h.

This triggers a Lagom warning for old distros that use versions older
than that, such as Ubuntu 18.04. This fixes a break in the
compiler-explorer Lagom build, which is based off 18.04 docker
containers.