### PR TITLE
LibELF: Take TLS segment alignment into account in DynamicLoader

### DIFF
--- a/AK/Types.h
+++ b/AK/Types.h
@@ -84,6 +84,11 @@ constexpr size_t align_up_to(const size_t value, const size_t alignment)
     return (value + (alignment - 1)) & ~(alignment - 1);
 }
 
+constexpr size_t align_down_to(const size_t value, const size_t alignment)
+{
+    return value & ~(alignment - 1);
+}
+
 enum class [[nodiscard]] TriState : u8 {
     False,
     True,

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -67,6 +67,7 @@ public:
 
     void set_tls_offset(size_t offset) { m_tls_offset = offset; };
     size_t tls_size_of_current_object() const { return m_tls_size_of_current_object; }
+    size_t tls_alignment_of_current_object() const { return m_tls_alignment_of_current_object; }
     size_t tls_offset() const { return m_tls_offset; }
     const ELF::Image& image() const { return *m_elf_image; }
 
@@ -134,7 +135,7 @@ private:
     };
     RelocationResult do_relocation(DynamicObject::Relocation const&, ShouldInitializeWeak should_initialize_weak);
     void do_relr_relocations();
-    size_t calculate_tls_size() const;
+    void find_tls_size_and_alignment();
     ssize_t negative_offset_from_tls_block_end(ssize_t tls_offset, size_t value_of_symbol) const;
 
     String m_filename;
@@ -157,6 +158,7 @@ private:
 
     ssize_t m_tls_offset { 0 };
     size_t m_tls_size_of_current_object { 0 };
+    size_t m_tls_alignment_of_current_object { 0 };
 
     Vector<DynamicObject::Relocation> m_unresolved_relocations;
 


### PR DESCRIPTION
Previously we would just tightly pack the different libraries' TLS segments together, but that is incorrect, as they might require some kind of minimum alignment for their TLS base address.

We now plumb the required TLS segment alignment down to the TLS block linear allocator and align the base address down to the appropriate alignment.