### PR TITLE
LibRegex: Use proper CharRange constructor instead of bit_casting

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -922,6 +922,7 @@ TEST_CASE(optimizer_atomic_groups)
         Tuple { "a+b"sv, "aaaaa"sv, false },
         Tuple { "\\\\(\\d+)"sv, "\\\\"sv, false }, // Rewrite bug turning a+ to a*, see #10952.
         Tuple { "[a-z.]+\\."sv, "..."sv, true },   // Rewrite bug, incorrect interpretation of Compare.
+        Tuple { "[.-]+\\."sv, ".-."sv, true },
         // Alternative fuse
         Tuple { "(abcfoo|abcbar|abcbaz).*x"sv, "abcbarx"sv, true },
         Tuple { "(a|a)"sv, "a"sv, true },

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -538,9 +538,9 @@ ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, M
                     to = to_ascii_lowercase(to);
                     needle = to_ascii_lowercase(needle);
                 }
-                if (needle > range.to)
+                if (needle > to)
                     return 1;
-                if (needle < range.from)
+                if (needle < from)
                     return -1;
                 return 0;
             });

--- a/Userland/Libraries/LibRegex/RegexOptimizer.cpp
+++ b/Userland/Libraries/LibRegex/RegexOptimizer.cpp
@@ -187,7 +187,7 @@ static bool has_overlap(Vector<CompareTypeAndValuePair> const& lhs, Vector<Compa
                 lhs_negated_char_classes.set(static_cast<CharClass>(pair.value));
             break;
         case CharacterCompareType::CharRange: {
-            auto range = bit_cast<CharRange>(pair.value);
+            auto range = CharRange(pair.value);
             if (!current_lhs_inversion_state())
                 lhs_ranges.insert(range.from, range.to);
             else
@@ -257,7 +257,7 @@ static bool has_overlap(Vector<CompareTypeAndValuePair> const& lhs, Vector<Compa
                 return true;
             break;
         case CharacterCompareType::CharRange: {
-            auto range = bit_cast<CharRange>(pair.value);
+            auto range = CharRange(pair.value);
             if (!current_lhs_inversion_state() && range_contains(range))
                 return true;
             break;


### PR DESCRIPTION
MOAR regex fixes :P 