### PR TITLE
Browser+WebContent: Fix inspecting non-visible nodes

### DIFF
--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -61,13 +61,6 @@ void InspectorWidget::set_selection(GUI::ModelIndex const index)
         return;
     m_selection = move(selection);
 
-    // Note: Non-visible nodes don't have style data and such, and will hit assertions if inspection is attempted.
-    if (!json->get("visible").to_bool(true)) {
-        clear_style_json();
-        clear_node_box_model();
-        return;
-    }
-
     auto maybe_inspected_node_properties = m_web_view->inspect_dom_node(m_selection.dom_node_id, m_selection.pseudo_element);
     if (maybe_inspected_node_properties.has_value()) {
         auto inspected_node_properties = maybe_inspected_node_properties.value();
@@ -75,6 +68,7 @@ void InspectorWidget::set_selection(GUI::ModelIndex const index)
         update_node_box_model(inspected_node_properties.node_box_sizing_json);
     } else {
         clear_style_json();
+        clear_node_box_model();
     }
 }
 

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -267,7 +267,8 @@ Messages::WebContentServer::InspectDomNodeResponse ConnectionFromClient::inspect
     });
 
     Web::DOM::Node* node = Web::DOM::Node::from_id(node_id);
-    if (!node) {
+    // Note: Nodes without layout (aka non-visible nodes, don't have style computed)
+    if (!node || !node->layout_node()) {
         return { false, "", "", "", "" };
     }
 


### PR DESCRIPTION
I already fixed the crash from this in #14470, but didn't fully fix
the issue. Currently the browser just avoids sending the
`inspect_dom_node()` IPC call for non-visible nodes.

The main problem with this is it means the browser keeps displaying
the overlay for the previously selected node. This commit fixes
the crash in the WebContent side, so the IPC call can still be made
and the selection correctly updated.