### PR TITLE
WebContent: Invalidate document style when changing the page's palette

### DIFF
--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -53,6 +53,8 @@ Gfx::Palette PageHost::palette() const
 void PageHost::set_palette_impl(Gfx::PaletteImpl const& impl)
 {
     m_palette_impl = impl;
+    if (auto* document = page().top_level_browsing_context().active_document())
+        document->invalidate_style();
 }
 
 void PageHost::set_preferred_color_scheme(Web::CSS::PreferredColorScheme color_scheme)


### PR DESCRIPTION
This makes the page automatically update to reflect the system theme
when in "Color Scheme > Follow System Theme" mode without having to
manually cause a style update.

![Peek 2022-07-05 17-15](https://user-images.githubusercontent.com/25595356/177372356-49a5f799-25f8-45ee-82a4-4def72b19036.gif)