### PR TITLE
LibC: Don't clear static storage during `endgrent`

### DIFF
--- a/Userland/Libraries/LibC/grp.cpp
+++ b/Userland/Libraries/LibC/grp.cpp
@@ -47,13 +47,6 @@ void endgrent()
         fclose(s_stream);
         s_stream = nullptr;
     }
-
-    memset(&s_group, 0, sizeof(s_group));
-
-    s_name = {};
-    s_passwd = {};
-    s_members = {};
-    s_members_ptrs = {};
 }
 
 struct group* getgrgid(gid_t gid)


### PR DESCRIPTION
The POSIX documentation for `endgrent` only mentions that it "closes the group database", not that it clears the backing storage for return values. This means that applications might make use of the returned values even after closing the group database itself. This includes our own implementations for `getgrnam` and `getgrgid`.

The specification also states that "the storage areas might be overwritten by a subsequent call to `getgrgid`, `getgrnam`, or `getgrent`". This implies that `getgrgid` and `getgrnam` aren't meant to have their own static storage and instead rely on the storage of `getgrent`.

This fixes our `id` utility and the `rsync` port.

This additionally supersedes #14375, which has stalled and has been using a wrong/incomplete approach anyways.