### PR TITLE
LibC: Stop leaking FILE in `getpwuid` and `getpwnam`

### DIFF
--- a/Userland/Libraries/LibC/pwd.cpp
+++ b/Userland/Libraries/LibC/pwd.cpp
@@ -46,14 +46,6 @@ void endpwent()
         fclose(s_stream);
         s_stream = nullptr;
     }
-
-    memset(&s_passwd_entry, 0, sizeof(s_passwd_entry));
-
-    s_name = {};
-    s_passwd = {};
-    s_gecos = {};
-    s_dir = {};
-    s_shell = {};
 }
 
 struct passwd* getpwuid(uid_t uid)

--- a/Userland/Libraries/LibC/pwd.cpp
+++ b/Userland/Libraries/LibC/pwd.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ScopeGuard.h>
 #include <AK/String.h>
 #include <AK/TemporaryChange.h>
 #include <AK/Vector.h>
@@ -51,6 +52,7 @@ void endpwent()
 struct passwd* getpwuid(uid_t uid)
 {
     setpwent();
+    ScopeGuard guard = [] { endpwent(); };
     while (auto* pw = getpwent()) {
         if (pw->pw_uid == uid)
             return pw;
@@ -61,6 +63,7 @@ struct passwd* getpwuid(uid_t uid)
 struct passwd* getpwnam(char const* name)
 {
     setpwent();
+    ScopeGuard guard = [] { endpwent(); };
     while (auto* pw = getpwent()) {
         if (!strcmp(pw->pw_name, name))
             return pw;


### PR DESCRIPTION
Basically what we have been doing in 6eb9ebec5f2c8dcc937ee048dcede2d4a15c1f8f and #14498, but for the `pw` family of functions and in the correct order this time.