### PR TITLE
Browser: Add Brave and Mojeek to search engines

### DIFF
--- a/Base/home/anon/.config/SearchEngines.json
+++ b/Base/home/anon/.config/SearchEngines.json
@@ -4,6 +4,10 @@
         "url_format": "https://www.bing.com/search?q={}"
     },
     {
+        "title": "Brave",
+        "url_format": "https://search.brave.com/search?q={}"
+    },
+    {
         "title": "DuckDuckGo",
         "url_format": "https://duckduckgo.com/?q={}"
     },
@@ -18,6 +22,10 @@
     {
         "title": "Google",
         "url_format": "https://google.com/search?q={}"
+    },
+    {
+        "title": "Mojeek",
+        "url_format": "https://www.mojeek.com/search?q={}"
     },
     {
         "title": "Yandex",


### PR DESCRIPTION
Browsers with own rendering engines is cool, so is search engines with their own indexes.

This PR adds Brave Search and Mojeek for some additional alternatives to Bing (DuckDockGo/FrogFind) and Google.

Both renders good enough in Browser(Gigablast did not so is not included).