### PR TITLE
WebSocket: Change target name to deconflict with LibWebSocket on Lagom

### DIFF
--- a/Userland/Services/WebSocket/CMakeLists.txt
+++ b/Userland/Services/WebSocket/CMakeLists.txt
@@ -1,6 +1,6 @@
 serenity_component(
     WebSocket
-    TARGETS WebSocket
+    TARGETS WebSocketServer
 )
 
 compile_ipc(WebSocketServer.ipc WebSocketServerEndpoint.h)
@@ -13,5 +13,9 @@ set(SOURCES
     WebSocketServerEndpoint.h
 )
 
-serenity_bin(WebSocket)
-target_link_libraries(WebSocket LibCore LibIPC LibWebSocket LibMain)
+# Note: We use a target name of WebSocketServer here to deconflict with the
+#    Lagom namespaced target name for LibWebSocket, Lagom::WebSocket.
+#    The server binary name is still WebSocket.
+serenity_bin(WebSocketServer)
+set_target_properties(WebSocketServer PROPERTIES OUTPUT_NAME WebSocket)
+target_link_libraries(WebSocketServer LibCore LibIPC LibWebSocket LibMain)


### PR DESCRIPTION
When compiling with Lagom, we give both LibWebSocket and the WebSocket
IPC service the Lagom:: prefix as an alias, but strip the Lib from all
library target names before applying the prefix. This creates a conflict
when external projects used the aliased name between the server and the
library. Give WebSocket a name that deconflicts it, but keep the binary
name the same, /bin/WebSocket.

Fixes https://github.com/awesomekling/ladybird/issues/13