### PR TITLE
Ports: Don't create ccache symlinks for tools we don't have

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -29,7 +29,11 @@ enable_ccache() {
         ccache_tooldir="${SERENITY_BUILD_DIR}/ccache"
         mkdir -p "$ccache_tooldir"
         for tool in cc clang gcc c++ clang++ g++; do
-            ln -sf "$(command -v ccache)" "${ccache_tooldir}/${SERENITY_ARCH}-pc-serenity-${tool}"
+            name="${SERENITY_ARCH}-pc-serenity-${tool}"
+            if ! command -v "${name}" >/dev/null; then
+                continue
+            fi
+            ln -sf "$(command -v ccache)" "${ccache_tooldir}/${name}"
         done
         export PATH="${ccache_tooldir}:$PATH"
     fi


### PR DESCRIPTION
This is maintainable more easily than a static list of tools that gets processed no matter what.

Fixes #14344.

Closes #14345.