### PR TITLE
Meta: Move additional flags into common_compile_options.cmake

### DIFF
--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -10,3 +10,17 @@ if (NOT CMAKE_HOST_SYSTEM_NAME MATCHES SerenityOS)
     #        Disable -Werror for now.
     add_compile_options(-Werror)
 endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+    add_compile_options(-Wno-user-defined-literals)
+    # Clang's default constexpr-steps limit is 1048576(2^20), GCC doesn't have one
+    add_compile_options(-fconstexpr-steps=16777216)
+
+    # FIXME: Re-enable this check when the warning stops triggering, or document why we can't stop it from triggering.
+    # For now, there is a lot of unused private fields in LibWeb that trigger this that could be removed.
+    # See issue #14137 for details
+    add_compile_options(-Wno-unused-private-field)
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # Only ignore expansion-to-defined for g++, clang's implementation doesn't complain about function-like macros
+    add_compile_options(-Wno-expansion-to-defined)
+endif()

--- a/Meta/CMake/serenity_compile_options.cmake
+++ b/Meta/CMake/serenity_compile_options.cmake
@@ -31,17 +31,12 @@ add_compile_options(-g1)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wno-literal-suffix)
     add_compile_options(-Wno-maybe-uninitialized)
-    # Only ignore expansion-to-defined for g++, clang's implementation doesn't complain about function-like macros
-    add_compile_options(-Wno-expansion-to-defined)
     add_compile_options(-Wcast-align)
     add_compile_options(-Wdouble-promotion)
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
-    add_compile_options(-Wno-user-defined-literals)
     add_compile_options(-Wno-atomic-alignment)
     add_compile_options(-Wno-implicit-const-int-float-conversion)
     add_compile_options(-Wno-unused-const-variable)
-    add_compile_options(-Wno-unused-private-field)
-    add_compile_options(-fconstexpr-steps=16777216)
 
     # Clang doesn't add compiler_rt to the search path when compiling with -nostdlib.
     link_directories(${TOOLCHAIN_ROOT}/lib/clang/${CMAKE_CXX_COMPILER_VERSION}/lib/${SERENITY_ARCH}-pc-serenity/)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -100,22 +100,12 @@ if (ENABLE_FUZZERS)
     add_compile_options(-fno-omit-frame-pointer)
 endif()
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
-    # Clang's default constexpr-steps limit is 1048576(2^20), GCC doesn't have one
-    add_compile_options(-Wno-overloaded-virtual -Wno-user-defined-literals -fconstexpr-steps=16777216)
-    # FIXME: Re-enable this check when the warning stops triggering, or document why we can't stop it from triggering.
-    # For now, there is a lot of unused private fields in LibWeb that trigger this that could be removed.
-    # See issue #14137 for details
-    add_compile_options(-Wno-unused-private-field)
 
-    if (ENABLE_FUZZERS_LIBFUZZER)
+if (ENABLE_FUZZERS_LIBFUZZER)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
         add_compile_options(-fsanitize=fuzzer)
         set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=fuzzer")
-    endif()
-
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-Wno-expansion-to-defined)
-    if (ENABLE_FUZZERS_LIBFUZZER)
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         message(FATAL_ERROR
             "Fuzzer Sanitizer (-fsanitize=fuzzer) is only supported for Fuzzer targets with LLVM. "
             "Reconfigure CMake with -DCMAKE_C_COMPILER and -DCMAKE_CXX_COMPILER pointing to a clang-based toolchain "


### PR DESCRIPTION
These flags were specified in both the main CMakeLists.txt file and
Lagom's. Move them to a common place, which also lets Ladybird's build
pick these up.

We may want to evaluate which of the currently Serenity-specific warning
flags would make sense to have for Lagom as well, but that's outside
the scope of this commit.

Please wait for the CI build to pass with this one; I didn't have patience to test all build configurations, so only CI will tell if I screwed up the copy-paste somehow...