### PR TITLE
LibCore+Userland: Use StringViews when calling Core::System::open

### DIFF
--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -185,7 +185,7 @@ ErrorOr<void> File::open_path(StringView filename, mode_t permissions)
     VERIFY(m_fd == -1);
     auto flags = open_mode_to_options(m_mode);
 
-    m_fd = TRY(System::open(filename.characters_without_null_termination(), flags, permissions));
+    m_fd = TRY(System::open(filename, flags, permissions));
     return {};
 }
 

--- a/Userland/Services/WindowServer/HardwareScreenBackend.cpp
+++ b/Userland/Services/WindowServer/HardwareScreenBackend.cpp
@@ -24,7 +24,7 @@ HardwareScreenBackend::HardwareScreenBackend(String device)
 
 ErrorOr<void> HardwareScreenBackend::open()
 {
-    m_framebuffer_fd = TRY(Core::System::open(m_device.characters(), O_RDWR | O_CLOEXEC));
+    m_framebuffer_fd = TRY(Core::System::open(m_device, O_RDWR | O_CLOEXEC));
 
     GraphicsConnectorProperties properties;
     if (graphics_connector_get_properties(m_framebuffer_fd, &properties) < 0)

--- a/Userland/Utilities/disk_benchmark.cpp
+++ b/Userland/Utilities/disk_benchmark.cpp
@@ -105,7 +105,7 @@ ErrorOr<Result> benchmark(String const& filename, int file_size, ByteBuffer& buf
     if (!allow_cache)
         flags |= O_DIRECT;
 
-    int fd = TRY(Core::System::open(filename.characters(), flags, 0644));
+    int fd = TRY(Core::System::open(filename, flags, 0644));
 
     auto fd_cleanup = ScopeGuard([fd, filename] {
         auto void_or_error = Core::System::close(fd);


### PR DESCRIPTION
For some reason we used raw char pointers sometimes, which caused at least one heap buffer overflow detected in fuzzing.