### PR TITLE
AK: Always check shift amount in LEB128 read functions

### DIFF
--- a/AK/LEB128.h
+++ b/AK/LEB128.h
@@ -36,7 +36,7 @@ struct LEB128 {
                 return false;
 
             ValueType masked_byte = byte & ~(1 << 7);
-            bool const shift_too_large_for_result = (num_bytes * 7 > sizeof(ValueType) * 8) && (masked_byte != 0);
+            bool const shift_too_large_for_result = num_bytes * 7 > sizeof(ValueType) * 8;
             if (shift_too_large_for_result)
                 return false;
 
@@ -83,7 +83,7 @@ struct LEB128 {
 
             // note: 64 bit assumptions!
             u64 masked_byte = byte & ~(1 << 7);
-            bool const shift_too_large_for_result = (num_bytes * 7 >= 64) && (masked_byte != ((temp < 0) ? 0x7Fu : 0u));
+            bool const shift_too_large_for_result = num_bytes * 7 >= 64;
             if (shift_too_large_for_result)
                 return false;
 


### PR DESCRIPTION
Even shifting 0 by more than the value size is UB.

Fixes several UB fuzzer issues found in LibWasm.