### PR TITLE
Kernel+SystemServer: Make KCOVDevice a character device

### DIFF
--- a/Kernel/Devices/KCOVDevice.cpp
+++ b/Kernel/Devices/KCOVDevice.cpp
@@ -28,7 +28,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<KCOVDevice> KCOVDevice::must_create()
 }
 
 UNMAP_AFTER_INIT KCOVDevice::KCOVDevice()
-    : BlockDevice(30, 0)
+    : CharacterDevice(30, 0)
 {
     proc_instance = new HashMap<ProcessID, KCOVInstance*>();
     thread_instance = new HashMap<ThreadID, KCOVInstance*>();

--- a/Kernel/Devices/KCOVDevice.h
+++ b/Kernel/Devices/KCOVDevice.h
@@ -6,11 +6,11 @@
 
 #pragma once
 
-#include <Kernel/Devices/BlockDevice.h>
+#include <Kernel/Devices/CharacterDevice.h>
 #include <Kernel/Devices/KCOVInstance.h>
 
 namespace Kernel {
-class KCOVDevice final : public BlockDevice {
+class KCOVDevice final : public CharacterDevice {
     friend class DeviceManagement;
 
 public:
@@ -32,7 +32,6 @@ protected:
 
     virtual bool can_read(OpenFileDescription const&, u64) const override final { return true; }
     virtual bool can_write(OpenFileDescription const&, u64) const override final { return true; }
-    virtual void start_request(AsyncBlockDeviceRequest& request) override final { request.complete(AsyncDeviceRequest::Failure); }
     virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override { return EINVAL; }
     virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) override { return EINVAL; }
     virtual ErrorOr<void> ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg) override;

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -275,8 +275,8 @@ static void populate_devtmpfs_devices_based_on_devctl()
             break;
         }
         case 30: {
-            if (is_block_device) {
-                create_devtmpfs_block_device(String::formatted("/dev/kcov{}", minor_number), 0666, 30, minor_number);
+            if (!is_block_device) {
+                create_devtmpfs_char_device(String::formatted("/dev/kcov{}", minor_number), 0666, 30, minor_number);
             }
             break;
         }


### PR DESCRIPTION
This device should not be a block device, as in Serenity, block devices
represent an interface to either disk partitions or storage devices.

Going forward, we should not see any block devices besides disk partitions and storage devices, so the definition of
block devices in Serenity is anything that stores user data in blocks (or that is emulating user data being accessed in blocks, like a RAM disk). Character devices should represent anything else.