### PR TITLE
LibWeb: Fix regexes for XHR

### DIFF
--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -391,14 +391,14 @@ static bool is_forbidden_method(String const& method)
 // https://fetch.spec.whatwg.org/#concept-method
 static bool is_method(String const& method)
 {
-    Regex<ECMA262Parser> regex { R"~~~(^[A-Za-z0-9!#$%&'*+-.^_`|~]+$)~~~" };
+    Regex<ECMA262Parser> regex { R"~~~(^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$)~~~" };
     return regex.has_match(method);
 }
 
 // https://fetch.spec.whatwg.org/#header-name
 static bool is_header_name(String const& header_name)
 {
-    Regex<ECMA262Parser> regex { R"~~~(^[A-Za-z0-9!#$%&'*+-.^_`|~]+$)~~~" };
+    Regex<ECMA262Parser> regex { R"~~~(^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$)~~~" };
     return regex.has_match(header_name);
 }
 


### PR DESCRIPTION
Regexes for is_method and is_header_name did not escape `-` and unintentionally allowed for `,` to be part of a method/header name, not following the spec.