### PR TITLE
LibCrypto: Add the [[nodiscard]] qualifier in both BigInteger classes

### DIFF
--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -40,15 +40,15 @@ public:
     {
     }
 
-    static SignedBigInteger create_invalid()
+    [[nodiscard]] static SignedBigInteger create_invalid()
     {
         return { UnsignedBigInteger::create_invalid(), false };
     }
 
-    static SignedBigInteger import_data(StringView data) { return import_data((u8 const*)data.characters_without_null_termination(), data.length()); }
-    static SignedBigInteger import_data(u8 const* ptr, size_t length);
+    [[nodiscard]] static SignedBigInteger import_data(StringView data) { return import_data((u8 const*)data.characters_without_null_termination(), data.length()); }
+    [[nodiscard]] static SignedBigInteger import_data(u8 const* ptr, size_t length);
 
-    static SignedBigInteger create_from(i64 value)
+    [[nodiscard]] static SignedBigInteger create_from(i64 value)
     {
         auto sign = false;
         u64 unsigned_value;
@@ -63,15 +63,15 @@ public:
 
     size_t export_data(Bytes, bool remove_leading_zeros = false) const;
 
-    static SignedBigInteger from_base(u16 N, StringView str);
-    String to_base(u16 N) const;
+    [[nodiscard]] static SignedBigInteger from_base(u16 N, StringView str);
+    [[nodiscard]] String to_base(u16 N) const;
 
-    u64 to_u64() const;
-    double to_double() const;
+    [[nodiscard]] u64 to_u64() const;
+    [[nodiscard]] double to_double() const;
 
-    UnsignedBigInteger const& unsigned_value() const { return m_unsigned_data; }
-    Vector<u32, STARTING_WORD_SIZE> const words() const { return m_unsigned_data.words(); }
-    bool is_negative() const { return m_sign; }
+    [[nodiscard]] UnsignedBigInteger const& unsigned_value() const { return m_unsigned_data; }
+    [[nodiscard]] Vector<u32, STARTING_WORD_SIZE> const words() const { return m_unsigned_data.words(); }
+    [[nodiscard]] bool is_negative() const { return m_sign; }
 
     void negate()
     {
@@ -101,42 +101,42 @@ public:
         m_unsigned_data.invalidate();
     }
 
-    bool is_invalid() const { return m_unsigned_data.is_invalid(); }
+    [[nodiscard]] bool is_invalid() const { return m_unsigned_data.is_invalid(); }
 
     // These get + 1 byte for the sign.
-    size_t length() const { return m_unsigned_data.length() + 1; }
-    size_t trimmed_length() const { return m_unsigned_data.trimmed_length() + 1; };
+    [[nodiscard]] size_t length() const { return m_unsigned_data.length() + 1; }
+    [[nodiscard]] size_t trimmed_length() const { return m_unsigned_data.trimmed_length() + 1; };
 
-    SignedBigInteger plus(SignedBigInteger const& other) const;
-    SignedBigInteger minus(SignedBigInteger const& other) const;
-    SignedBigInteger bitwise_or(SignedBigInteger const& other) const;
-    SignedBigInteger bitwise_and(SignedBigInteger const& other) const;
-    SignedBigInteger bitwise_xor(SignedBigInteger const& other) const;
-    SignedBigInteger bitwise_not() const;
-    SignedBigInteger shift_left(size_t num_bits) const;
-    SignedBigInteger multiplied_by(SignedBigInteger const& other) const;
-    SignedDivisionResult divided_by(SignedBigInteger const& divisor) const;
+    [[nodiscard]] SignedBigInteger plus(SignedBigInteger const& other) const;
+    [[nodiscard]] SignedBigInteger minus(SignedBigInteger const& other) const;
+    [[nodiscard]] SignedBigInteger bitwise_or(SignedBigInteger const& other) const;
+    [[nodiscard]] SignedBigInteger bitwise_and(SignedBigInteger const& other) const;
+    [[nodiscard]] SignedBigInteger bitwise_xor(SignedBigInteger const& other) const;
+    [[nodiscard]] SignedBigInteger bitwise_not() const;
+    [[nodiscard]] SignedBigInteger shift_left(size_t num_bits) const;
+    [[nodiscard]] SignedBigInteger multiplied_by(SignedBigInteger const& other) const;
+    [[nodiscard]] SignedDivisionResult divided_by(SignedBigInteger const& divisor) const;
 
-    SignedBigInteger plus(UnsignedBigInteger const& other) const;
-    SignedBigInteger minus(UnsignedBigInteger const& other) const;
-    SignedBigInteger multiplied_by(UnsignedBigInteger const& other) const;
-    SignedDivisionResult divided_by(UnsignedBigInteger const& divisor) const;
+    [[nodiscard]] SignedBigInteger plus(UnsignedBigInteger const& other) const;
+    [[nodiscard]] SignedBigInteger minus(UnsignedBigInteger const& other) const;
+    [[nodiscard]] SignedBigInteger multiplied_by(UnsignedBigInteger const& other) const;
+    [[nodiscard]] SignedDivisionResult divided_by(UnsignedBigInteger const& divisor) const;
 
-    u32 hash() const;
+    [[nodiscard]] u32 hash() const;
 
     void set_bit_inplace(size_t bit_index);
 
-    bool operator==(SignedBigInteger const& other) const;
-    bool operator!=(SignedBigInteger const& other) const;
-    bool operator<(SignedBigInteger const& other) const;
-    bool operator<=(SignedBigInteger const& other) const;
-    bool operator>(SignedBigInteger const& other) const;
-    bool operator>=(SignedBigInteger const& other) const;
+    [[nodiscard]] bool operator==(SignedBigInteger const& other) const;
+    [[nodiscard]] bool operator!=(SignedBigInteger const& other) const;
+    [[nodiscard]] bool operator<(SignedBigInteger const& other) const;
+    [[nodiscard]] bool operator<=(SignedBigInteger const& other) const;
+    [[nodiscard]] bool operator>(SignedBigInteger const& other) const;
+    [[nodiscard]] bool operator>=(SignedBigInteger const& other) const;
 
-    bool operator==(UnsignedBigInteger const& other) const;
-    bool operator!=(UnsignedBigInteger const& other) const;
-    bool operator<(UnsignedBigInteger const& other) const;
-    bool operator>(UnsignedBigInteger const& other) const;
+    [[nodiscard]] bool operator==(UnsignedBigInteger const& other) const;
+    [[nodiscard]] bool operator!=(UnsignedBigInteger const& other) const;
+    [[nodiscard]] bool operator<(UnsignedBigInteger const& other) const;
+    [[nodiscard]] bool operator>(UnsignedBigInteger const& other) const;
 
 private:
     void ensure_sign_is_valid()

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -34,15 +34,15 @@ public:
 
     UnsignedBigInteger() = default;
 
-    static UnsignedBigInteger create_invalid();
+    [[nodiscard]] static UnsignedBigInteger create_invalid();
 
-    static UnsignedBigInteger import_data(StringView data) { return import_data((u8 const*)data.characters_without_null_termination(), data.length()); }
-    static UnsignedBigInteger import_data(u8 const* ptr, size_t length)
+    [[nodiscard]] static UnsignedBigInteger import_data(StringView data) { return import_data((u8 const*)data.characters_without_null_termination(), data.length()); }
+    [[nodiscard]] static UnsignedBigInteger import_data(u8 const* ptr, size_t length)
     {
         return UnsignedBigInteger(ptr, length);
     }
 
-    static UnsignedBigInteger create_from(u64 value)
+    [[nodiscard]] static UnsignedBigInteger create_from(u64 value)
     {
         VERIFY(sizeof(Word) == 4);
         UnsignedBigInteger integer;
@@ -54,13 +54,13 @@ public:
 
     size_t export_data(Bytes, bool remove_leading_zeros = false) const;
 
-    static UnsignedBigInteger from_base(u16 N, StringView str);
-    String to_base(u16 N) const;
+    [[nodiscard]] static UnsignedBigInteger from_base(u16 N, StringView str);
+    [[nodiscard]] String to_base(u16 N) const;
 
-    u64 to_u64() const;
-    double to_double() const;
+    [[nodiscard]] u64 to_u64() const;
+    [[nodiscard]] double to_double() const;
 
-    Vector<Word, STARTING_WORD_SIZE> const& words() const { return m_words; }
+    [[nodiscard]] Vector<Word, STARTING_WORD_SIZE> const& words() const { return m_words; }
 
     void set_to_0();
     void set_to(Word other);
@@ -73,38 +73,38 @@ public:
         m_cached_hash = 0;
     }
 
-    bool is_zero() const;
-    bool is_odd() const { return m_words.size() && (m_words[0] & 1); }
-    bool is_invalid() const { return m_is_invalid; }
+    [[nodiscard]] bool is_zero() const;
+    [[nodiscard]] bool is_odd() const { return m_words.size() && (m_words[0] & 1); }
+    [[nodiscard]] bool is_invalid() const { return m_is_invalid; }
 
-    size_t length() const { return m_words.size(); }
+    [[nodiscard]] size_t length() const { return m_words.size(); }
     // The "trimmed length" is the number of words after trimming leading zeroed words
-    size_t trimmed_length() const;
+    [[nodiscard]] size_t trimmed_length() const;
 
     void clamp_to_trimmed_length();
     void resize_with_leading_zeros(size_t num_words);
 
     size_t one_based_index_of_highest_set_bit() const;
 
-    UnsignedBigInteger plus(UnsignedBigInteger const& other) const;
-    UnsignedBigInteger minus(UnsignedBigInteger const& other) const;
-    UnsignedBigInteger bitwise_or(UnsignedBigInteger const& other) const;
-    UnsignedBigInteger bitwise_and(UnsignedBigInteger const& other) const;
-    UnsignedBigInteger bitwise_xor(UnsignedBigInteger const& other) const;
-    UnsignedBigInteger bitwise_not_fill_to_one_based_index(size_t) const;
-    UnsignedBigInteger shift_left(size_t num_bits) const;
-    UnsignedBigInteger multiplied_by(UnsignedBigInteger const& other) const;
-    UnsignedDivisionResult divided_by(UnsignedBigInteger const& divisor) const;
+    [[nodiscard]] UnsignedBigInteger plus(UnsignedBigInteger const& other) const;
+    [[nodiscard]] UnsignedBigInteger minus(UnsignedBigInteger const& other) const;
+    [[nodiscard]] UnsignedBigInteger bitwise_or(UnsignedBigInteger const& other) const;
+    [[nodiscard]] UnsignedBigInteger bitwise_and(UnsignedBigInteger const& other) const;
+    [[nodiscard]] UnsignedBigInteger bitwise_xor(UnsignedBigInteger const& other) const;
+    [[nodiscard]] UnsignedBigInteger bitwise_not_fill_to_one_based_index(size_t) const;
+    [[nodiscard]] UnsignedBigInteger shift_left(size_t num_bits) const;
+    [[nodiscard]] UnsignedBigInteger multiplied_by(UnsignedBigInteger const& other) const;
+    [[nodiscard]] UnsignedDivisionResult divided_by(UnsignedBigInteger const& divisor) const;
 
-    u32 hash() const;
+    [[nodiscard]] u32 hash() const;
 
     void set_bit_inplace(size_t bit_index);
 
-    bool operator==(UnsignedBigInteger const& other) const;
-    bool operator!=(UnsignedBigInteger const& other) const;
-    bool operator<(UnsignedBigInteger const& other) const;
-    bool operator>(UnsignedBigInteger const& other) const;
-    bool operator>=(UnsignedBigInteger const& other) const;
+    [[nodiscard]] bool operator==(UnsignedBigInteger const& other) const;
+    [[nodiscard]] bool operator!=(UnsignedBigInteger const& other) const;
+    [[nodiscard]] bool operator<(UnsignedBigInteger const& other) const;
+    [[nodiscard]] bool operator>(UnsignedBigInteger const& other) const;
+    [[nodiscard]] bool operator>=(UnsignedBigInteger const& other) const;
 
 private:
     friend class UnsignedBigIntegerAlgorithms;


### PR DESCRIPTION
I'm currently reworking #11623 in multiple PR to ease the review process.
I made this commit standalone as it's quite noisy in terms of changes and not needed for the calculator.

The usage of function instead of operators for mathematical operations is quite misleading, and `[[nodiscard]]` can help you avoid some debugging.