### PR TITLE
LibCompress: Write Deflate window size in the Zlib header

### DIFF
--- a/Userland/Libraries/LibCompress/Zlib.cpp
+++ b/Userland/Libraries/LibCompress/Zlib.cpp
@@ -84,9 +84,15 @@ ZlibCompressor::~ZlibCompressor()
 
 void ZlibCompressor::write_header(ZlibCompressionMethod compression_method, ZlibCompressionLevel compression_level)
 {
+    u8 compression_info = 0;
+    if (compression_method == ZlibCompressionMethod::Deflate) {
+        compression_info = AK::log2(DeflateCompressor::window_size) - 8;
+        VERIFY(compression_info <= 7);
+    }
+
     ZlibHeader header {
         .compression_method = compression_method,
-        .compression_info = 0,
+        .compression_info = compression_info,
         .check_bits = 0,
         .present_dictionary = false,
         .compression_level = compression_level,


### PR DESCRIPTION
Previously we said that the window size was always 512 bytes, which caused errors during decompressing in apps outside of Serenity that actually use this information.
Now, the value is always 7 (32 KiB).

Fixes: #14503