### PR TITLE
Meta: Teach pick_host_compiler about Homebrew Clang

### DIFF
--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -199,7 +199,7 @@ pick_host_compiler() {
         return
     fi
 
-    find_newest_compiler clang clang-13 clang-14 clang-15
+    find_newest_compiler clang clang-13 clang-14 clang-15 /opt/homebrew/opt/llvm/bin/clang
     if is_supported_compiler "$HOST_COMPILER"; then
         CMAKE_ARGS+=("-DCMAKE_C_COMPILER=$HOST_COMPILER")
         CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER=${HOST_COMPILER/clang/clang++}")


### PR DESCRIPTION
Homebrew does not add upstream LLVM's install location to $PATH so as
not to conflict with XCode tools, so we should look for it by its
absolute path. LLVM is installed to /opt/homebrew/opt/llvm on ARM Macs,
and is a symlink that points to the latest stable LLVM version.