### PR TITLE
LibGUI: Allow deleting text editor indent selections in non tab cases

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1501,7 +1501,7 @@ void TextEditor::insert_at_cursor_or_replace_selection(StringView text)
 {
     ReflowDeferrer defer(*this);
     VERIFY(is_editable());
-    if (has_selection() && !is_indenting_selection())
+    if (has_selection())
         delete_selection();
 
     // Check if adding a newline leaves the previous line as just whitespace.
@@ -1510,8 +1510,7 @@ void TextEditor::insert_at_cursor_or_replace_selection(StringView text)
         && clear_length > 0
         && current_line().leading_spaces() == clear_length;
 
-    if (!is_indenting_selection())
-        execute<InsertTextCommand>(text, m_cursor);
+    execute<InsertTextCommand>(text, m_cursor);
 
     if (should_clear_last_line) { // If it does leave just whitespace, clear it.
         auto const original_cursor_position = cursor();


### PR DESCRIPTION
Since 00f51d42d2aeb44ec4813ca13be787c2f5ca55ff we would not allow the deletion for a selection by typing if it would match the conditions to indent on pressing tab.

As any single line `TextEditor` would always match the indent conditions, it was impossible to replace selected text by typing in a `TextBox`, `PasswordBox` or `UrlBox`.

A missing return, as pointed out in https://github.com/SerenityOS/serenity/pull/13269#discussion_r900866416 was the cause for the additional checks in `TextEditor::insert_at_cursor_or_replace_selection`, described in https://github.com/SerenityOS/serenity/pull/13269#discussion_r901009457. With the early return in place the additional checks are not aiding with the indented behavior but cause the regression described above.

This pull request removes the unnecessary conditions.

See #13269