### PR TITLE
LibGfx: Implement PNG filtering on write & some cleanup

### DIFF
--- a/AK/SIMDExtras.h
+++ b/AK/SIMDExtras.h
@@ -37,6 +37,18 @@ ALWAYS_INLINE static constexpr u32x4 expand4(u32 u)
 // Casting
 
 template<typename TSrc>
+ALWAYS_INLINE static u8x4 to_u8x4(TSrc v)
+{
+    return __builtin_convertvector(v, u8x4);
+}
+
+template<typename TSrc>
+ALWAYS_INLINE static u16x4 to_u16x4(TSrc v)
+{
+    return __builtin_convertvector(v, u16x4);
+}
+
+template<typename TSrc>
 ALWAYS_INLINE static u32x4 to_u32x4(TSrc v)
 {
     return __builtin_convertvector(v, u32x4);

--- a/Userland/Libraries/LibGfx/PNGShared.h
+++ b/Userland/Libraries/LibGfx/PNGShared.h
@@ -43,4 +43,14 @@ ALWAYS_INLINE u8 paeth_predictor(u8 a, u8 b, u8 c)
     return c;
 }
 
+ALWAYS_INLINE AK::SIMD::u8x4 paeth_predictor(AK::SIMD::u8x4 a, AK::SIMD::u8x4 b, AK::SIMD::u8x4 c)
+{
+    return AK::SIMD::u8x4 {
+        paeth_predictor(a[0], b[0], c[0]),
+        paeth_predictor(a[1], b[1], c[1]),
+        paeth_predictor(a[2], b[2], c[2]),
+        paeth_predictor(a[3], b[3], c[3]),
+    };
+}
+
 };

--- a/Userland/Libraries/LibGfx/PNGShared.h
+++ b/Userland/Libraries/LibGfx/PNGShared.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Gfx::PNG {
+
+// https://www.w3.org/TR/PNG/#6Colour-values
+enum class ColorType : u8 {
+    Greyscale = 0,
+    Truecolor = 2, // RGB
+    IndexedColor = 3,
+    GreyscaleWithAlpha = 4,
+    TruecolorWithAlpha = 6,
+};
+
+// https://www.w3.org/TR/PNG/#9Filter-types
+enum class FilterType : u8 {
+    None,
+    Sub,
+    Up,
+    Average,
+    Paeth,
+};
+
+};

--- a/Userland/Libraries/LibGfx/PNGShared.h
+++ b/Userland/Libraries/LibGfx/PNGShared.h
@@ -8,6 +8,9 @@
 
 namespace Gfx::PNG {
 
+// https://www.w3.org/TR/PNG/#5PNG-file-signature
+static constexpr Array<u8, 8> header = { 0x89, 'P', 'N', 'G', 13, 10, 26, 10 };
+
 // https://www.w3.org/TR/PNG/#6Colour-values
 enum class ColorType : u8 {
     Greyscale = 0,
@@ -25,5 +28,19 @@ enum class FilterType : u8 {
     Average,
     Paeth,
 };
+
+// https://www.w3.org/TR/PNG/#9Filter-type-4-Paeth
+ALWAYS_INLINE u8 paeth_predictor(u8 a, u8 b, u8 c)
+{
+    int p = a + b - c;
+    int pa = abs(p - a);
+    int pb = abs(p - b);
+    int pc = abs(p - c);
+    if (pa <= pb && pa <= pc)
+        return a;
+    if (pb <= pc)
+        return b;
+    return c;
+}
 
 };

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -116,13 +116,13 @@ void PNGWriter::add_png_header()
     m_data.append(png_header, sizeof(png_header));
 }
 
-void PNGWriter::add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, u8 color_type, u8 compression_method, u8 filter_method, u8 interlace_method)
+void PNGWriter::add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, PNG::ColorType color_type, u8 compression_method, u8 filter_method, u8 interlace_method)
 {
     PNGChunk png_chunk { "IHDR" };
     png_chunk.add_as_big_endian(width);
     png_chunk.add_as_big_endian(height);
     png_chunk.add_u8(bit_depth);
-    png_chunk.add_u8(color_type);
+    png_chunk.add_u8(to_underlying(color_type));
     png_chunk.add_u8(compression_method);
     png_chunk.add_u8(filter_method);
     png_chunk.add_u8(interlace_method);
@@ -170,7 +170,7 @@ ByteBuffer PNGWriter::encode(Gfx::Bitmap const& bitmap)
 {
     PNGWriter writer;
     writer.add_png_header();
-    writer.add_IHDR_chunk(bitmap.width(), bitmap.height(), 8, 6, 0, 0, 0);
+    writer.add_IHDR_chunk(bitmap.width(), bitmap.height(), 8, PNG::ColorType::TruecolorWithAlpha, 0, 0, 0);
     writer.add_IDAT_chunk(bitmap);
     writer.add_IEND_chunk();
     // FIXME: Handle OOM failure.

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -112,8 +112,7 @@ void PNGWriter::add_chunk(PNGChunk& png_chunk)
 
 void PNGWriter::add_png_header()
 {
-    const u8 png_header[8] = { 0x89, 'P', 'N', 'G', 13, 10, 26, 10 };
-    m_data.append(png_header, sizeof(png_header));
+    m_data.append(PNG::header.data(), PNG::header.size());
 }
 
 void PNGWriter::add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, PNG::ColorType color_type, u8 compression_method, u8 filter_method, u8 interlace_method)

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -7,11 +7,14 @@
  */
 
 #include <AK/Concepts.h>
+#include <AK/SIMDExtras.h>
 #include <AK/String.h>
 #include <LibCompress/Zlib.h>
 #include <LibCrypto/Checksum/CRC32.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/PNGWriter.h>
+
+#pragma GCC diagnostic ignored "-Wpsabi"
 
 namespace Gfx {
 
@@ -134,6 +137,24 @@ void PNGWriter::add_IEND_chunk()
     add_chunk(png_chunk);
 }
 
+union [[gnu::packed]] Pixel {
+    ARGB32 rgba { 0 };
+    struct {
+        u8 red;
+        u8 green;
+        u8 blue;
+        u8 alpha;
+    };
+    AK::SIMD::u8x4 simd;
+
+    ALWAYS_INLINE static AK::SIMD::u8x4 gfx_to_png(Pixel pixel)
+    {
+        swap(pixel.red, pixel.blue);
+        return pixel.simd;
+    }
+};
+static_assert(AssertSize<Pixel, 4>());
+
 void PNGWriter::add_IDAT_chunk(Gfx::Bitmap const& bitmap)
 {
     PNGChunk png_chunk { "IDAT" };
@@ -142,16 +163,91 @@ void PNGWriter::add_IDAT_chunk(Gfx::Bitmap const& bitmap)
     ByteBuffer uncompressed_block_data;
     uncompressed_block_data.ensure_capacity(bitmap.size_in_bytes() + bitmap.height());
 
+    Pixel const dummy_scanline[bitmap.width()] {};
+    auto* scanline_minus_1 = dummy_scanline;
+
     for (int y = 0; y < bitmap.height(); ++y) {
-        uncompressed_block_data.append(0);
+        auto* scanline = reinterpret_cast<Pixel const*>(bitmap.scanline(y));
+
+        struct Filter {
+            PNG::FilterType type;
+            ByteBuffer buffer {};
+            int sum = 0;
+
+            void append(u8 byte)
+            {
+                buffer.append(byte);
+                sum += static_cast<i8>(byte);
+            }
+
+            void append(AK::SIMD::u8x4 simd)
+            {
+                append(simd[0]);
+                append(simd[1]);
+                append(simd[2]);
+                append(simd[3]);
+            }
+        };
+
+        Filter none_filter { .type = PNG::FilterType::None };
+        none_filter.buffer.ensure_capacity(sizeof(Pixel) * bitmap.height());
+
+        Filter sub_filter { .type = PNG::FilterType::Sub };
+        sub_filter.buffer.ensure_capacity(sizeof(Pixel) * bitmap.height());
+
+        Filter up_filter { .type = PNG::FilterType::Up };
+        up_filter.buffer.ensure_capacity(sizeof(Pixel) * bitmap.height());
+
+        Filter average_filter { .type = PNG::FilterType::Average };
+        average_filter.buffer.ensure_capacity(sizeof(ARGB32) * bitmap.height());
+
+        Filter paeth_filter { .type = PNG::FilterType::Paeth };
+        paeth_filter.buffer.ensure_capacity(sizeof(ARGB32) * bitmap.height());
+
+        auto pixel_x_minus_1 = Pixel::gfx_to_png(*dummy_scanline);
+        auto pixel_xy_minus_1 = Pixel::gfx_to_png(*dummy_scanline);
 
         for (int x = 0; x < bitmap.width(); ++x) {
-            auto pixel = bitmap.get_pixel(x, y);
-            uncompressed_block_data.append(pixel.red());
-            uncompressed_block_data.append(pixel.green());
-            uncompressed_block_data.append(pixel.blue());
-            uncompressed_block_data.append(pixel.alpha());
+            auto pixel = Pixel::gfx_to_png(scanline[x]);
+            auto pixel_y_minus_1 = Pixel::gfx_to_png(scanline_minus_1[x]);
+
+            none_filter.append(pixel);
+
+            sub_filter.append(pixel - pixel_x_minus_1);
+
+            up_filter.append(pixel - pixel_y_minus_1);
+
+            // The sum Orig(a) + Orig(b) shall be performed without overflow (using at least nine-bit arithmetic).
+            auto sum = AK::SIMD::to_u16x4(pixel_x_minus_1) + AK::SIMD::to_u16x4(pixel_y_minus_1);
+            auto average = AK::SIMD::to_u8x4(sum / 2);
+            average_filter.append(pixel - average);
+
+            paeth_filter.append(pixel - PNG::paeth_predictor(pixel_x_minus_1, pixel_y_minus_1, pixel_xy_minus_1));
+
+            pixel_x_minus_1 = pixel;
+            pixel_xy_minus_1 = pixel_y_minus_1;
         }
+
+        scanline_minus_1 = scanline;
+
+        // 12.8 Filter selection: https://www.w3.org/TR/PNG/#12Filter-selection
+        // For best compression of truecolour and greyscale images, the recommended approach
+        // is adaptive filtering in which a filter is chosen for each scanline.
+        // The following simple heuristic has performed well in early tests:
+        // compute the output scanline using all five filters, and select the filter that gives the smallest sum of absolute values of outputs.
+        // (Consider the output bytes as signed differences for this test.)
+        Filter& best_filter = none_filter;
+        if (abs(best_filter.sum) > abs(sub_filter.sum))
+            best_filter = sub_filter;
+        if (abs(best_filter.sum) > abs(up_filter.sum))
+            best_filter = up_filter;
+        if (abs(best_filter.sum) > abs(average_filter.sum))
+            best_filter = average_filter;
+        if (abs(best_filter.sum) > abs(paeth_filter.sum))
+            best_filter = paeth_filter;
+
+        uncompressed_block_data.append(to_underlying(best_filter.type));
+        uncompressed_block_data.append(best_filter.buffer);
     }
 
     auto maybe_zlib_buffer = Compress::ZlibCompressor::compress_all(uncompressed_block_data);

--- a/Userland/Libraries/LibGfx/PNGWriter.h
+++ b/Userland/Libraries/LibGfx/PNGWriter.h
@@ -9,6 +9,7 @@
 
 #include <AK/Vector.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/PNGShared.h>
 
 namespace Gfx {
 
@@ -24,7 +25,7 @@ private:
     Vector<u8> m_data;
     void add_chunk(PNGChunk&);
     void add_png_header();
-    void add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, u8 color_type, u8 compression_method, u8 filter_method, u8 interlace_method);
+    void add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, PNG::ColorType color_type, u8 compression_method, u8 filter_method, u8 interlace_method);
     void add_IDAT_chunk(Gfx::Bitmap const&);
     void add_IEND_chunk();
 };


### PR DESCRIPTION
Is it another great upgrade to our PNG encoder like in 9aafaec259?
Well, not really – it's not a 2x or 55x improvement like you saw there, but still it saves something:

- a screenshot of a blank Serenity desktop dropped from about 45 KiB to 40 KiB.
- re-encoding [NASA photo of the Earth] to PNG again saves about 25% (16.5 MiB -> 12.3 MiB), compared to not using filters.

---

fyi you'll likely need #14530 if you want to test it outside of serenity. ;^)

[NASA photo of the Earth]: https://commons.wikimedia.org/wiki/File:The_Blue_Marble_(remastered).jpg