### PR TITLE
LibGUI+Browser: Allow opening bookmarks in a new tab using middle mouse click

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Emanuel Sprung <emanuel.sprung@gmail.com>
+ * Copyright (c) 2022, Jakob-Niklas See <git@nwex.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -200,10 +201,16 @@ void BookmarksBarWidget::model_did_update(unsigned)
         button.set_relative_rect(rect);
         button.set_focus_policy(GUI::FocusPolicy::TabFocus);
         button.set_tooltip(url);
+        button.set_allowed_mouse_buttons_for_pressing(GUI::MouseButton::Primary | GUI::MouseButton::Middle);
 
         button.on_click = [title, url, this](auto) {
             if (on_bookmark_click)
                 on_bookmark_click(url, OpenInNewTab::No);
+        };
+
+        button.on_middle_mouse_click = [title, url, this](auto) {
+            if (on_bookmark_click)
+                on_bookmark_click(url, OpenInNewTab::Yes);
         };
 
         button.on_context_menu_request = [this, url](auto& context_menu_event) {

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -124,7 +124,7 @@ BookmarksBarWidget::BookmarksBarWidget(String const& bookmarks_file, bool enable
     auto default_action = GUI::Action::create(
         "&Open", [this](auto&) {
             if (on_bookmark_click)
-                on_bookmark_click(m_context_menu_url, Mod_None);
+                on_bookmark_click(m_context_menu_url, OpenInNewTab::No);
         },
         this);
     m_context_menu_default_action = default_action;
@@ -132,7 +132,7 @@ BookmarksBarWidget::BookmarksBarWidget(String const& bookmarks_file, bool enable
     m_context_menu->add_action(GUI::Action::create(
         "Open in New &Tab", [this](auto&) {
             if (on_bookmark_click)
-                on_bookmark_click(m_context_menu_url, Mod_Ctrl);
+                on_bookmark_click(m_context_menu_url, OpenInNewTab::Yes);
         },
         this));
     m_context_menu->add_separator();
@@ -201,9 +201,9 @@ void BookmarksBarWidget::model_did_update(unsigned)
         button.set_focus_policy(GUI::FocusPolicy::TabFocus);
         button.set_tooltip(url);
 
-        button.on_click = [title, url, this](auto modifiers) {
+        button.on_click = [title, url, this](auto) {
             if (on_bookmark_click)
-                on_bookmark_click(url, modifiers);
+                on_bookmark_click(url, OpenInNewTab::No);
         };
 
         button.on_context_menu_request = [this, url](auto& context_menu_event) {

--- a/Userland/Applications/Browser/BookmarksBarWidget.h
+++ b/Userland/Applications/Browser/BookmarksBarWidget.h
@@ -26,7 +26,12 @@ public:
     GUI::Model* model() { return m_model.ptr(); }
     const GUI::Model* model() const { return m_model.ptr(); }
 
-    Function<void(String const& url, unsigned modifiers)> on_bookmark_click;
+    enum class OpenInNewTab {
+        Yes,
+        No
+    };
+
+    Function<void(String const& url, OpenInNewTab)> on_bookmark_click;
     Function<void(String const&, String const&)> on_bookmark_hover;
 
     bool contains_bookmark(String const& url);

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -484,8 +484,8 @@ void Tab::update_bookmark_button(String const& url)
 
 void Tab::did_become_active()
 {
-    BookmarksBarWidget::the().on_bookmark_click = [this](auto& url, unsigned modifiers) {
-        if (modifiers & Mod_Ctrl)
+    BookmarksBarWidget::the().on_bookmark_click = [this](auto& url, auto open_in_new_tab) {
+        if (open_in_new_tab == BookmarksBarWidget::OpenInNewTab::Yes)
             on_tab_open_request(url);
         else
             load(url);

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -3,6 +3,7 @@
  * Copyright (c) 2021, Maciej Zygmanowski <sppmacd@pm.me>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022, Jakob-Niklas See <git@nwex.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -146,7 +147,12 @@ Tab::Tab(BrowserWindow& window)
         m_go_forward_context_menu->popup(context_menu_event.screen_position());
     };
 
-    toolbar.add_action(window.go_home_action());
+    auto& go_home_button = toolbar.add_action(window.go_home_action());
+    go_home_button.set_allowed_mouse_buttons_for_pressing(GUI::MouseButton::Primary | GUI::MouseButton::Middle);
+    go_home_button.on_middle_mouse_click = [&](auto) {
+        on_tab_open_request(Browser::url_from_user_input(g_home_url));
+    };
+
     toolbar.add_action(window.reload_action());
 
     m_location_box = toolbar.add<GUI::UrlBox>();

--- a/Userland/Libraries/LibGUI/AbstractButton.cpp
+++ b/Userland/Libraries/LibGUI/AbstractButton.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022, Jakob-Niklas See <git@nwex.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -93,7 +94,7 @@ void AbstractButton::mousemove_event(MouseEvent& event)
 {
     bool is_over = rect().contains(event.position());
     m_hovered = is_over;
-    if (event.buttons() & MouseButton::Primary) {
+    if (event.buttons() & m_pressed_mouse_button) {
         bool being_pressed = is_over;
         if (being_pressed != m_being_pressed) {
             m_being_pressed = being_pressed;
@@ -111,8 +112,9 @@ void AbstractButton::mousemove_event(MouseEvent& event)
 
 void AbstractButton::mousedown_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Primary) {
+    if (event.button() & m_allowed_mouse_buttons_for_pressing) {
         m_being_pressed = true;
+        m_pressed_mouse_button = event.button();
         repaint();
 
         if (m_auto_repeat_interval) {
@@ -126,14 +128,22 @@ void AbstractButton::mousedown_event(MouseEvent& event)
 
 void AbstractButton::mouseup_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Primary && m_being_pressed) {
+    if (event.button() == m_pressed_mouse_button && m_being_pressed) {
         bool was_auto_repeating = m_auto_repeat_timer->is_active();
         m_auto_repeat_timer->stop();
         bool was_being_pressed = m_being_pressed;
         m_being_pressed = false;
+        m_pressed_mouse_button = MouseButton::None;
         repaint();
-        if (was_being_pressed && !was_auto_repeating)
-            click(event.modifiers());
+        if (was_being_pressed && !was_auto_repeating) {
+            switch (event.button()) {
+            case MouseButton::Primary:
+                click(event.modifiers());
+                break;
+            default:
+                VERIFY_NOT_REACHED();
+            }
+        }
     }
     Widget::mouseup_event(event);
 }

--- a/Userland/Libraries/LibGUI/AbstractButton.cpp
+++ b/Userland/Libraries/LibGUI/AbstractButton.cpp
@@ -140,6 +140,9 @@ void AbstractButton::mouseup_event(MouseEvent& event)
             case MouseButton::Primary:
                 click(event.modifiers());
                 break;
+            case MouseButton::Middle:
+                middle_mouse_click(event.modifiers());
+                break;
             default:
                 VERIFY_NOT_REACHED();
             }

--- a/Userland/Libraries/LibGUI/AbstractButton.h
+++ b/Userland/Libraries/LibGUI/AbstractButton.h
@@ -39,6 +39,7 @@ public:
     void set_allowed_mouse_buttons_for_pressing(unsigned allowed_buttons) { m_allowed_mouse_buttons_for_pressing = allowed_buttons; }
 
     virtual void click(unsigned modifiers = 0) = 0;
+    virtual void middle_mouse_click(unsigned) {};
     virtual bool is_uncheckable() const { return true; }
 
     int auto_repeat_interval() const { return m_auto_repeat_interval; }

--- a/Userland/Libraries/LibGUI/AbstractButton.h
+++ b/Userland/Libraries/LibGUI/AbstractButton.h
@@ -35,6 +35,9 @@ public:
     bool is_hovered() const { return m_hovered; }
     bool is_being_pressed() const { return m_being_pressed; }
 
+    unsigned allowed_mouse_buttons_for_pressing() const { return m_allowed_mouse_buttons_for_pressing; }
+    void set_allowed_mouse_buttons_for_pressing(unsigned allowed_buttons) { m_allowed_mouse_buttons_for_pressing = allowed_buttons; }
+
     virtual void click(unsigned modifiers = 0) = 0;
     virtual bool is_uncheckable() const { return true; }
 
@@ -64,6 +67,9 @@ private:
     bool m_being_pressed { false };
     bool m_being_keyboard_pressed { false };
     bool m_exclusive { false };
+
+    MouseButton m_pressed_mouse_button { MouseButton::None };
+    unsigned m_allowed_mouse_buttons_for_pressing { MouseButton::Primary };
 
     int m_auto_repeat_interval { 0 };
     RefPtr<Core::Timer> m_auto_repeat_timer;

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -141,6 +141,17 @@ void Button::click(unsigned modifiers)
         m_action->activate(this);
 }
 
+void Button::middle_mouse_click(unsigned int modifiers)
+{
+    if (!is_enabled())
+        return;
+
+    NonnullRefPtr protector = *this;
+
+    if (on_middle_mouse_click)
+        on_middle_mouse_click(modifiers);
+}
+
 void Button::context_menu_event(ContextMenuEvent& context_menu_event)
 {
     if (!is_enabled())

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -30,12 +30,14 @@ public:
     Gfx::TextAlignment text_alignment() const { return m_text_alignment; }
 
     Function<void(unsigned modifiers)> on_click;
+    Function<void(unsigned modifiers)> on_middle_mouse_click;
     Function<void(ContextMenuEvent&)> on_context_menu_request;
 
     void set_button_style(Gfx::ButtonStyle style) { m_button_style = style; }
     Gfx::ButtonStyle button_style() const { return m_button_style; }
 
     virtual void click(unsigned modifiers = 0) override;
+    virtual void middle_mouse_click(unsigned modifiers = 0) override;
     virtual void context_menu_event(ContextMenuEvent&) override;
 
     Action* action() { return m_action; }


### PR DESCRIPTION
This pull request adds the ability to open browser bookmarks in a new tab by clicking a bookmark button using the middle mouse button.

For that buttons are now able to define which set of mouse buttons they respond to on press.

https://user-images.githubusercontent.com/42888162/178151288-dd7d422b-ecaa-4d1d-8a01-8f9795f00058.mp4

