### PR TITLE
NetworkServer+NetworkSettings: Don't need a reboot when disabling interfaces

### DIFF
--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
@@ -136,12 +136,7 @@ void NetworkSettingsWidget::on_switch_enabled_or_dhcp()
 void NetworkSettingsWidget::apply_settings()
 {
     auto config_file = Core::ConfigFile::open_for_system("Network", Core::ConfigFile::AllowWriting::Yes).release_value_but_fixme_should_propagate_errors();
-    bool may_need_to_reboot = false;
     for (auto const& adapter_data : m_network_adapters) {
-        // FIXME: Setting Enabled=false starts working only after a reboot. Fix this on the NetworkServer side.
-        if (!m_current_adapter_data->enabled)
-            may_need_to_reboot = true;
-
         auto netmask = IPv4Address::netmask_from_cidr(adapter_data.value.cidr).to_string();
         config_file->write_bool_entry(adapter_data.key, "Enabled", adapter_data.value.enabled);
         config_file->write_bool_entry(adapter_data.key, "DHCP", adapter_data.value.dhcp);
@@ -161,9 +156,6 @@ void NetworkSettingsWidget::apply_settings()
     }
 
     GUI::Process::spawn_or_show_error(window(), "/bin/NetworkServer"sv);
-
-    if (may_need_to_reboot)
-        GUI::MessageBox::show(window(), "You may need to reboot for changes to take effect."sv, "Network Settings"sv, GUI::MessageBox::Type::Warning);
 }
 
 }

--- a/Userland/Services/NetworkServer/main.cpp
+++ b/Userland/Services/NetworkServer/main.cpp
@@ -83,8 +83,14 @@ ErrorOr<int> serenity_main(Main::Arguments)
                     MUST(Core::command("route"sv, { "add", "-n", "0.0.0.0", "-m", "0.0.0.0", "-g", config.ipv4_gateway, "-i", ifname }, {}));
                 }
             }
+        } else {
+            // FIXME: Propagate errors
+            dbgln("Disabling interface {}", ifname);
+            MUST(Core::command("route", { "del", "-n", "0.0.0.0", "-m", "0.0.0.0", "-i", ifname }, {}));
+            MUST(Core::command("ifconfig", { "-a", ifname.characters(), "-i", "0.0.0.0", "-m", "0.0.0.0" }, {}));
         }
     });
+
     if (!interfaces_with_dhcp_enabled.is_empty()) {
         dbgln("Running DHCPClient for interfaces: {}", interfaces_with_dhcp_enabled);
         Vector<char*> args;


### PR DESCRIPTION
This PR fixes NetworkServer so that we don't need to reboot / setup interfaces manually when we disable an interface.

* **NetworkServer: Kill DHCPServer as the first thing done**
* **NetworkServer: Disable interface if Enabled = false**
* **NetworkSettings: Remove warning about reboot**
