### PR TITLE
LibXML: Fail gracefully on integer overflow in character references

### DIFF
--- a/Tests/LibXML/TestParser.cpp
+++ b/Tests/LibXML/TestParser.cpp
@@ -20,3 +20,12 @@ TEST_CASE(char_data_ending)
         return Test::Crash::Failure::DidNotCrash;
     });
 }
+
+TEST_CASE(character_reference_integer_overflow)
+{
+    EXPECT_NO_CRASH("parsing character references that do not fit in 32 bits should not crash", [] {
+        XML::Parser parser("<G>&#6666666666");
+        (void)parser.parse();
+        return Test::Crash::Failure::DidNotCrash;
+    });
+}

--- a/Userland/Libraries/LibXML/Parser/Parser.cpp
+++ b/Userland/Libraries/LibXML/Parser/Parser.cpp
@@ -758,26 +758,26 @@ ErrorOr<Variant<Parser::EntityReference, String>, ParseError> Parser::parse_refe
     auto name_result = parse_name();
     if (name_result.is_error()) {
         TRY(expect("#"));
-        u32 code_point;
+        Optional<u32> code_point;
         if (m_lexer.consume_specific('x')) {
             auto hex = TRY(expect_many(
                 ranges_for_search<Range('0', '9'), Range('a', 'f'), Range('A', 'F')>(),
                 "any of [0-9a-fA-F]"));
-            code_point = *AK::StringUtils::convert_to_uint_from_hex<u32>(hex);
+            code_point = AK::StringUtils::convert_to_uint_from_hex<u32>(hex);
         } else {
             auto decimal = TRY(expect_many(
                 ranges_for_search<Range('0', '9')>(),
                 "any of [0-9]"));
-            code_point = *decimal.to_uint<u32>();
+            code_point = decimal.to_uint<u32>();
         }
 
-        if (!s_characters.contains(code_point))
+        if (!code_point.has_value() || !s_characters.contains(*code_point))
             return parse_error(reference_start, "Invalid character reference");
 
         TRY(expect(";"));
 
         StringBuilder builder;
-        builder.append_code_point(code_point);
+        builder.append_code_point(*code_point);
 
         rollback.disarm();
         return builder.to_string();


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47738