### PR TITLE
AK: Treat empty string as invalid JSON

### DIFF
--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -236,8 +236,6 @@ void JsonValue::clear()
 #ifndef KERNEL
 ErrorOr<JsonValue> JsonValue::from_string(StringView input)
 {
-    if (input.is_empty())
-        return JsonValue();
     return JsonParser(input).parse();
 }
 #endif

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -131,7 +131,7 @@ chmod 1777 mnt/tmp
 echo "done"
 
 printf "creating utmp file... "
-touch mnt/var/run/utmp
+echo "{}" > mnt/var/run/utmp
 chown 0:$utmp_gid mnt/var/run/utmp
 chmod 664 mnt/var/run/utmp
 echo "done"

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -126,7 +126,7 @@ TEST_CASE(json_u64_roundtrip)
 TEST_CASE(json_parse_empty_string)
 {
     auto value = JsonValue::from_string("");
-    EXPECT_EQ(value.value().is_null(), true);
+    EXPECT_EQ(value.is_error(), true);
 }
 
 TEST_CASE(json_parse_long_decimals)

--- a/Userland/Libraries/LibJS/Tests/builtins/JSON/JSON.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/JSON/JSON.parse.js
@@ -29,6 +29,7 @@ test("syntax errors", () => {
         "[1,2,3, ]",
         '{ "foo": "bar",}',
         '{ "foo": "bar", }',
+        "",
     ].forEach(test => {
         expect(() => {
             JSON.parse(test);


### PR DESCRIPTION
Previously we would treat the empty string as `null`. This caused
JavaScript like this to fail:
```js
var object = {};
try {
    object = JSON.parse("");
} catch {}
var array = object.array || [];
```
Since `JSON.parse("")` returned null instead of throwing, it would set
`object` to null and then try and use it instead of using the default
backup value.