### PR TITLE
Kernel/USB: Support UHCI full speed bandwidth reclamation

### DIFF
--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -213,8 +213,10 @@ UNMAP_AFTER_INIT void UHCIController::setup_schedule()
     piix4_td_hack->set_max_len(0x7ff); // Null data packet
     piix4_td_hack->set_device_address(0x7f);
     piix4_td_hack->set_packet_id(PacketID::IN);
-    m_dummy_qh->terminate_with_stray_descriptor(piix4_td_hack);
-    m_dummy_qh->terminate_element_link_ptr();
+    m_dummy_qh->attach_transfer_descriptor_chain(piix4_td_hack);
+    // Cyclically link to the full speed control QH to allow for full speed
+    // bandwidth reclamation during frame idle time
+    m_dummy_qh->link_next_queue_head(m_fullspeed_control_qh);
 
     u32* framelist = reinterpret_cast<u32*>(m_framelist->vaddr().as_ptr());
     for (int frame = 0; frame < UHCI_NUMBER_OF_FRAMES; frame++) {

--- a/Kernel/Bus/USB/UHCI/UHCIDescriptorTypes.h
+++ b/Kernel/Bus/USB/UHCI/UHCIDescriptorTypes.h
@@ -296,12 +296,6 @@ struct alignas(16) QueueHead {
         m_element_link_ptr = m_element_link_ptr | static_cast<u32>(LinkPointerBits::QHSelect);
     }
 
-    void terminate_with_stray_descriptor(TransferDescriptor* td)
-    {
-        m_link_ptr = td->paddr();
-        m_link_ptr |= static_cast<u32>(LinkPointerBits::Terminate);
-    }
-
     // TODO: Should we pass in an array or vector of TDs instead????
     void attach_transfer_descriptor_chain(TransferDescriptor* td)
     {


### PR DESCRIPTION
In UHCI, USB transfers are set up on a "schedule", with 1ms frames where queued transfers are sent over the bus in the order the HCD specifies. When the end of this list of queued transfers is reached, the host controller will sit and idle until the end of the frame. This patch adds support for reclaiming that wasted idle time, as (very vaguely) described in the UHCI spec, by looping through the full speed queue heads while there is remaining frame time.