### PR TITLE
LibWeb+LibGfx: A first pass at supporting (linear) gradients!

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Gradients</title>
+    <style>
+        .box {
+            width: 200px;
+            height: 200px;
+            margin: 20px;
+            border: 1px solid black;
+        }
+
+        .grad-0 {
+            background-image: linear-gradient(to top, red, yellow);
+        }
+
+        .grad-1 {
+            background-image: linear-gradient(to bottom, red, yellow);
+        }
+
+        .grad-2 {
+            background-image: linear-gradient(to left, red, yellow);
+        }
+
+        .grad-3 {
+            background-image: linear-gradient(to right, red, yellow);
+        }
+
+        .grad-4 {
+            background-image: linear-gradient(to top, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
+            linear-gradient(to bottom, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
+            linear-gradient(to left, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+        }
+
+        .grad-5 {
+            background-image: linear-gradient(to top, blue, 30%, orange, 10%, red);
+        }
+
+        .grad-6 {
+            background-image: linear-gradient(to top, blue 30%, 30%, orange 20%, 10%, red);
+        }
+    </style>
+  </head>
+  <body>
+    <h1>Gradients!</h1>
+    <div class="box grad-0"></div>
+    <div class="box grad-1"></div>
+    <div class="box grad-2"></div>
+    <div class="box grad-3"></div>
+    <div class="box grad-4"></div>
+    <div class="box grad-5"></div>
+    <div class="box grad-6"></div>
+  </body>
+  <script>
+    const boxes = document.querySelectorAll(".box");
+    const backgroundMap = {};
+    for (const rule of document.styleSheets[0].cssRules) {
+        backgroundMap[rule.selectorText] = rule.style.backgroundImage;
+    }
+    boxes.forEach(box => {
+        const grad = box.classList[1];
+        console.log(grad)
+        const el = document.createElement('code');
+        el.innerText = backgroundMap['.'+grad];
+        box.parentNode.insertBefore(el, box)
+    })
+  </script>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -105,6 +105,7 @@
             <li><a href="hover.html">:hover</a></li>
             <li><a href="focus.html">:focus</a></li>
             <li><h3>Properties</h3></li>
+            <li><a href="gradients.html">Gradients</a></li>
             <li><a href="vertical-align.html">vertical-align</a></li>
             <li><a href="backgrounds.html">Backgrounds</a></li>
             <li><a href="background-repeat-test.html">Background-repeat</a></li>

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -490,7 +490,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                             output_numeric_value_check(property_generator, "is_frequency"sv, "as_frequency().frequency().to_hertz()"sv, Array { "Frequency"sv }, min_value, max_value);
                         } else if (type_name == "image") {
                             property_generator.append(R"~~~(
-        if (style_value.is_image())
+        if (style_value.is_image() || style_value.is_linear_gradient())
             return true;
 )~~~");
                         } else if (type_name == "integer") {

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -255,7 +255,7 @@ void Painter::fill_rect_with_gradient(Orientation orientation, IntRect const& a_
             for (int j = 0; j < clipped_rect.width(); ++j) {
                 auto color = gamma_accurate_blend(gradient_start, gradient_end, c);
                 color.set_alpha(c_alpha);
-                dst[j] = color.value();
+                dst[j] = Color::from_argb(dst[j]).blend(color).value();
                 c_alpha += alpha_increment;
                 c += increment;
             }
@@ -268,7 +268,7 @@ void Painter::fill_rect_with_gradient(Orientation orientation, IntRect const& a_
             auto color = gamma_accurate_blend(gradient_end, gradient_start, c);
             color.set_alpha(c_alpha);
             for (int j = 0; j < clipped_rect.width(); ++j) {
-                dst[j] = color.value();
+                dst[j] = Color::from_argb(dst[j]).blend(color).value();
             }
             c_alpha += alpha_increment;
             c += increment;

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -265,7 +265,7 @@ void Painter::fill_rect_with_gradient(Orientation orientation, IntRect const& a_
         float c = offset * increment;
         float c_alpha = gradient_start.alpha() + offset * alpha_increment;
         for (int i = clipped_rect.height() - 1; i >= 0; --i) {
-            auto color = gamma_accurate_blend(gradient_end, gradient_start, c);
+            auto color = gamma_accurate_blend(gradient_start, gradient_end, c);
             color.set_alpha(c_alpha);
             for (int j = 0; j < clipped_rect.width(); ++j) {
                 dst[j] = Color::from_argb(dst[j]).blend(color).value();

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -60,7 +60,7 @@ public:
 };
 
 struct BackgroundLayerData {
-    RefPtr<CSS::ImageStyleValue> image { nullptr };
+    RefPtr<CSS::StyleValue> background_image { nullptr };
     CSS::BackgroundAttachment attachment { CSS::BackgroundAttachment::Scroll };
     CSS::BackgroundBox origin { CSS::BackgroundBox::PaddingBox };
     CSS::BackgroundBox clip { CSS::BackgroundBox::BorderBox };

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -317,6 +317,8 @@ private:
     };
     Optional<AK::URL> parse_url_function(ComponentValue const&, AllowedDataUrlType = AllowedDataUrlType::None);
 
+    RefPtr<StyleValue> parse_linear_gradient_function(ComponentValue const&);
+
     ParseErrorOr<NonnullRefPtr<StyleValue>> parse_css_value(PropertyID, TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_css_value(ComponentValue const&);
     RefPtr<StyleValue> parse_builtin_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Serialize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Serialize.cpp
@@ -117,6 +117,18 @@ void serialize_a_url(StringBuilder& builder, StringView url)
     builder.append(')');
 }
 
+// https://www.w3.org/TR/css-color-4/#serializing-sRGB-values
+void serialize_a_srgb_value(StringBuilder& builder, Color color)
+{
+    // The serialized form is derived from the computed value and thus, uses either the rgb() or rgba() form
+    // (depending on whether the alpha is exactly 1, or not), with lowercase letters for the function name.
+    // NOTE: Since we use Gfx::Color, having an "alpha of 1" means its value is 255.
+    if (color.alpha() == 255)
+        builder.appendff("rgb({}, {}, {})"sv, color.red(), color.green(), color.blue());
+    else
+        builder.appendff("rgba({}, {}, {}, {})"sv, color.red(), color.green(), color.blue(), (float)(color.alpha()) / 255.0f);
+}
+
 String escape_a_character(u32 character)
 {
     StringBuilder builder;
@@ -149,6 +161,13 @@ String serialize_a_url(StringView url)
 {
     StringBuilder builder;
     serialize_a_url(builder, url);
+    return builder.to_string();
+}
+
+String serialize_a_srgb_value(Color color)
+{
+    StringBuilder builder;
+    serialize_a_srgb_value(builder, color);
     return builder.to_string();
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Serialize.h
+++ b/Userland/Libraries/LibWeb/CSS/Serialize.h
@@ -9,6 +9,7 @@
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
+#include <LibGfx/Color.h>
 
 namespace Web::CSS {
 
@@ -17,11 +18,13 @@ void escape_a_character_as_code_point(StringBuilder&, u32 character);
 void serialize_an_identifier(StringBuilder&, StringView ident);
 void serialize_a_string(StringBuilder&, StringView string);
 void serialize_a_url(StringBuilder&, StringView url);
+void serialize_a_srgb_value(StringBuilder&, Color color);
 
 String escape_a_character(u32 character);
 String escape_a_character_as_code_point(u32 character);
 String serialize_an_identifier(StringView ident);
 String serialize_a_string(StringView string);
 String serialize_a_url(StringView url);
+String serialize_a_srgb_value(Color color);
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1071,15 +1071,9 @@ CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberSumPartW
     return value->resolve(layout_node, percentage_basis);
 }
 
-// https://www.w3.org/TR/css-color-4/#serializing-sRGB-values
 String ColorStyleValue::to_string() const
 {
-    // The serialized form is derived from the computed value and thus, uses either the rgb() or rgba() form
-    // (depending on whether the alpha is exactly 1, or not), with lowercase letters for the function name.
-    // NOTE: Since we use Gfx::Color, having an "alpha of 1" means its value is 255.
-    if (m_color.alpha() == 255)
-        return String::formatted("rgb({}, {}, {})", m_color.red(), m_color.green(), m_color.blue());
-    return String::formatted("rgba({}, {}, {}, {})", m_color.red(), m_color.green(), m_color.blue(), (float)(m_color.alpha()) / 255.0f);
+    return serialize_a_srgb_value(m_color);
 }
 
 bool ColorStyleValue::equals(StyleValue const& other) const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -58,6 +58,7 @@ enum class FlexBasis {
     Auto,
 };
 
+// Note: The sides must be before the corners in this enum (as this order is used in parsing).
 enum class SideOrCorner {
     Top,
     Bottom,

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -62,6 +62,7 @@ class InitialStyleValue;
 class Length;
 class LengthPercentage;
 class LengthStyleValue;
+class LinearGradientStyleValue;
 class ListStyleStyleValue;
 class MediaList;
 class MediaQuery;

--- a/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
@@ -21,7 +21,7 @@ bool HTMLHtmlElement::should_use_body_background_properties() const
     auto const& background_layers = layout_node()->background_layers();
 
     for (auto& layer : background_layers) {
-        if (layer.image)
+        if (layer.background_image)
             return false;
     }
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -280,9 +280,13 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
         for (size_t layer_index = 0; layer_index < layer_count; layer_index++) {
             CSS::BackgroundLayerData layer;
 
-            if (auto image_value = value_for_layer(images, layer_index); image_value && image_value->is_image()) {
-                layer.image = image_value->as_image();
-                layer.image->load_bitmap(document());
+            if (auto image_value = value_for_layer(images, layer_index); image_value) {
+                if (image_value->is_image()) {
+                    image_value->as_image().load_bitmap(document());
+                    layer.background_image = image_value;
+                } else if (image_value->is_linear_gradient()) {
+                    layer.background_image = image_value;
+                }
             }
 
             if (auto attachment_value = value_for_layer(attachments, layer_index); attachment_value && attachment_value->has_identifier()) {

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -60,7 +60,7 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
         color_box = get_box(background_layers->last().clip);
 
     auto layer_is_paintable = [&](auto& layer) {
-        return layer.image && layer.image->bitmap();
+        return layer.background_image && layer.background_image->is_image() && layer.background_image->as_image().bitmap();
     };
 
     bool has_paintable_layers = false;
@@ -86,7 +86,6 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
         if (!layer_is_paintable(layer))
             continue;
         Gfx::PainterStateSaver state { painter };
-        auto& image = *layer.image->bitmap();
 
         // Clip
         auto clip_box = get_box(layer.clip);
@@ -94,6 +93,7 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
         painter.add_clip_rect(clip_rect);
         ScopedCornerRadiusClip corner_clip { painter, clip_rect, clip_box.radii };
 
+        auto& image = *layer.background_image->as_image().bitmap();
         Gfx::FloatRect background_positioning_area;
 
         // Attachment and Origin


### PR DESCRIPTION
Was bored, needed a new yak... Ran out of `border-radius` stuff :cry: 

![image](https://user-images.githubusercontent.com/11597044/178378834-beaff650-807e-4021-ae99-4b0bc62b9dbf.png)

This PR implements parsing for `linear-gradient()`, along with the the necessary plumbing, and some very basic painting.

The parsing is should work for everything defined in the W3 spec https://drafts.csswg.org/css-images/#linear-gradients, though there seems to be some issues there as multi-position stop points are not defined (though are demonstrated on MDN).
Though we can't paint all but the simplest of gradients yet, so this is not a huge issue yet.

P.S. The CSS parsing and style value side of LibWeb is slightly unfamiliar territory for me, so might not be optimal :^).
   
