### PR TITLE
NotificationServer: Move notifications down if hovered

### DIFF
--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -118,6 +118,7 @@ void NotificationWindow::enter_event(Core::Event&)
     m_hovering = true;
     resize_to_fit_text();
     move_to_front();
+    update_notification_window_locations(GUI::Desktop::the().rect());
 }
 
 void NotificationWindow::leave_event(Core::Event&)
@@ -125,6 +126,7 @@ void NotificationWindow::leave_event(Core::Event&)
     m_hovering = false;
     m_text_label->set_preferred_height(GUI::SpecialDimension::Grow);
     set_height(40);
+    update_notification_window_locations(GUI::Desktop::the().rect());
 }
 
 void NotificationWindow::set_text(String const& value)


### PR DESCRIPTION
Currently in case of multiple notifications, the notifications are
drawn on top of each other when expanded.
The change moves the notification below other notifications
Fixes [14440](https://github.com/SerenityOS/serenity/issues/14440)
![Notif](https://user-images.githubusercontent.com/4970396/178635676-67a039e3-ba58-4fc3-a9ea-a803234bf854.png)
