### PR TITLE
LibVT: Remove Vector<Kernel::KString> title stack

### DIFF
--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -435,10 +435,7 @@ protected:
     Attribute m_current_attribute;
     Attribute m_saved_attribute;
 
-#ifdef KERNEL
-    OwnPtr<Kernel::KString> m_current_window_title;
-    NonnullOwnPtrVector<Kernel::KString> m_title_stack;
-#else
+#ifndef KERNEL
     String m_current_window_title;
     Vector<String> m_title_stack;
 #endif


### PR DESCRIPTION
When using the kernel console, there's no such concept of title at all.
Also, this makes vim to crash due to dereferencing a null pointer, so
let's remove this as this is clearly not needed when using the kernel
virtual console.