### PR TITLE
AK: Use the correct data types in bitap_bitwise()

### DIFF
--- a/AK/MemMem.h
+++ b/AK/MemMem.h
@@ -19,10 +19,10 @@ constexpr void const* bitap_bitwise(void const* haystack, size_t haystack_length
 {
     VERIFY(needle_length < 32);
 
-    u64 lookup = 0xfffffffe;
+    u32 lookup = 0xfffffffe;
 
     constexpr size_t mask_length = (size_t)((u8)-1) + 1;
-    u64 needle_mask[mask_length];
+    u32 needle_mask[mask_length];
 
     for (size_t i = 0; i < mask_length; ++i)
         needle_mask[i] = 0xffffffff;

--- a/Tests/AK/TestMemory.cpp
+++ b/Tests/AK/TestMemory.cpp
@@ -27,6 +27,13 @@ TEST_CASE(bitap)
     EXPECT_EQ(result_1, &haystack[2]);
     EXPECT_EQ(result_2, &haystack[4]);
     EXPECT_EQ(result_3, nullptr);
+
+    auto haystack_string = "Main function must return c_int\n"sv;
+    auto needle_string = "Main function must return c_int"sv;
+
+    auto result = AK::Detail::bitap_bitwise(haystack_string.characters_without_null_termination(), haystack_string.length(), needle_string.characters_without_null_termination(), needle_string.length());
+
+    EXPECT_NE(result, nullptr);
 }
 
 TEST_CASE(kmp_one_chunk)


### PR DESCRIPTION
Otherwise the bit twiddling goes all wrong and breaks some boundary
cases.
Fixes `StringView::contains(31-chars)`.