### PR TITLE
Kernel: Don't lock the scheduler in ProcFSOverallProcesses::try_generate

### DIFF
--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -582,23 +582,20 @@ private:
             return {};
         };
 
-        SpinlockLocker lock(g_scheduler_lock);
         {
-            {
-                auto array = TRY(json.add_array("processes"sv));
-                TRY(build_process(array, *Scheduler::colonel()));
-                TRY(Process::all_instances().with([&](auto& processes) -> ErrorOr<void> {
-                    for (auto& process : processes)
-                        TRY(build_process(array, process));
-                    return {};
-                }));
-                TRY(array.finish());
-            }
-
-            auto total_time_scheduled = Scheduler::get_total_time_scheduled();
-            TRY(json.add("total_time"sv, total_time_scheduled.total));
-            TRY(json.add("total_time_kernel"sv, total_time_scheduled.total_kernel));
+            auto array = TRY(json.add_array("processes"sv));
+            TRY(build_process(array, *Scheduler::colonel()));
+            TRY(Process::all_instances().with([&](auto& processes) -> ErrorOr<void> {
+                for (auto& process : processes)
+                    TRY(build_process(array, process));
+                return {};
+            }));
+            TRY(array.finish());
         }
+
+        auto total_time_scheduled = Scheduler::get_total_time_scheduled();
+        TRY(json.add("total_time"sv, total_time_scheduled.total));
+        TRY(json.add("total_time_kernel"sv, total_time_scheduled.total_kernel));
         TRY(json.finish());
         return {};
     }


### PR DESCRIPTION
This used to be needed to protect accesses to Process::all_instances.
That list now has a more granular lock, so we don't need to take the
scheduler lock.

This fixes a crash when we try to access a locked Thread::m_fds in the
loop, which calls Thread::block, which then asserts that the scheduler
lock must not be locked by the current process.

Fixes #13617

cc @supercomputer7  as we talked about this a while back
cc @tomuta because of the scheduler lock 😉 