### PR TITLE
LibGUI: Apply more padding to text on tabs 

### DIFF
--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -263,7 +263,7 @@ void TabWidget::paint_event(PaintEvent& event)
         auto button_rect = this->button_rect(i);
         Gfx::StylePainter::paint_tab_button(painter, button_rect, palette(), false, hovered, m_tabs[i].widget->is_enabled(), m_tab_position, window()->is_active());
 
-        auto tab_button_content_rect = button_rect.shrunken(2, 0);
+        auto tab_button_content_rect = button_rect.shrunken(8, 0);
 
         paint_tab_icon_if_needed(m_tabs[i].icon, button_rect, tab_button_content_rect);
         tab_button_content_rect.set_width(tab_button_content_rect.width() - (m_close_button_enabled ? 16 : 0));
@@ -303,7 +303,7 @@ void TabWidget::paint_event(PaintEvent& event)
                 button_rect.set_x(m_mouse_pos - m_grab_offset);
         }
 
-        auto tab_button_content_rect = button_rect.shrunken(2, 0);
+        auto tab_button_content_rect = button_rect.shrunken(8, 0);
         Gfx::StylePainter::paint_tab_button(painter, button_rect, palette(), true, hovered, m_tabs[i].widget->is_enabled(), m_tab_position, window()->is_active());
 
         paint_tab_icon_if_needed(m_tabs[i].icon, button_rect, tab_button_content_rect);


### PR DESCRIPTION
Previously the text would be up close to the left / right border depending on the alignment.

This pull request increases the padding on either side from one to four pixels.

Old:

![image](https://user-images.githubusercontent.com/42888162/178996805-5e36ed44-c167-43f0-a43e-1fd18f1a0f0e.png)


New:

![image](https://user-images.githubusercontent.com/42888162/179036353-933a8039-d098-4456-9260-32d2f9714b00.png)

