### PR TITLE
Kernel/Graphics: Remove GenericGraphicsAdapter::vga_compatible method

### DIFF
--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -34,8 +34,6 @@ UNMAP_AFTER_INIT NonnullRefPtr<BochsGraphicsAdapter> BochsGraphicsAdapter::initi
 UNMAP_AFTER_INIT BochsGraphicsAdapter::BochsGraphicsAdapter(PCI::DeviceIdentifier const& pci_device_identifier)
     : PCI::Device(pci_device_identifier.address())
 {
-    if (pci_device_identifier.class_code().value() == 0x3 && pci_device_identifier.subclass_code().value() == 0x0)
-        m_is_vga_capable = true;
 }
 
 UNMAP_AFTER_INIT ErrorOr<void> BochsGraphicsAdapter::initialize_adapter(PCI::DeviceIdentifier const& pci_device_identifier)
@@ -65,11 +63,6 @@ UNMAP_AFTER_INIT ErrorOr<void> BochsGraphicsAdapter::initialize_adapter(PCI::Dev
     TRY(m_display_connector->set_safe_mode_setting());
 
     return {};
-}
-
-bool BochsGraphicsAdapter::vga_compatible() const
-{
-    return m_is_vga_capable;
 }
 
 }

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -28,14 +28,11 @@ public:
     static NonnullRefPtr<BochsGraphicsAdapter> initialize(PCI::DeviceIdentifier const&);
     virtual ~BochsGraphicsAdapter() = default;
 
-    virtual bool vga_compatible() const override;
-
 private:
     ErrorOr<void> initialize_adapter(PCI::DeviceIdentifier const&);
 
     explicit BochsGraphicsAdapter(PCI::DeviceIdentifier const&);
 
     RefPtr<BochsDisplayConnector> m_display_connector;
-    bool m_is_vga_capable { false };
 };
 }

--- a/Kernel/Graphics/GenericGraphicsAdapter.h
+++ b/Kernel/Graphics/GenericGraphicsAdapter.h
@@ -19,8 +19,6 @@ class GenericGraphicsAdapter
 public:
     virtual ~GenericGraphicsAdapter() = default;
 
-    virtual bool vga_compatible() const = 0;
-
 protected:
     GenericGraphicsAdapter() = default;
 };

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
@@ -24,8 +24,6 @@ public:
 
     virtual ~IntelNativeGraphicsAdapter() = default;
 
-    virtual bool vga_compatible() const override { return true; }
-
 private:
     ErrorOr<void> initialize_adapter();
 

--- a/Kernel/Graphics/VMWare/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VMWare/GraphicsAdapter.cpp
@@ -188,9 +188,4 @@ UNMAP_AFTER_INIT ErrorOr<void> VMWareGraphicsAdapter::initialize_adapter()
     return {};
 }
 
-bool VMWareGraphicsAdapter::vga_compatible() const
-{
-    return false;
-}
-
 }

--- a/Kernel/Graphics/VMWare/GraphicsAdapter.h
+++ b/Kernel/Graphics/VMWare/GraphicsAdapter.h
@@ -29,8 +29,6 @@ public:
     static RefPtr<VMWareGraphicsAdapter> try_initialize(PCI::DeviceIdentifier const&);
     virtual ~VMWareGraphicsAdapter() = default;
 
-    virtual bool vga_compatible() const override;
-
     ErrorOr<void> modeset_primary_screen_resolution(Badge<VMWareDisplayConnector>, size_t width, size_t height);
     size_t primary_screen_width(Badge<VMWareDisplayConnector>) const;
     size_t primary_screen_height(Badge<VMWareDisplayConnector>) const;
@@ -55,7 +53,6 @@ private:
     const IOAddress m_io_registers_base;
     mutable Spinlock m_io_access_lock;
     mutable RecursiveSpinlock m_operation_lock;
-    bool m_is_vga_capable { false };
 };
 
 }

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -39,9 +39,6 @@ class VirtIOGraphicsAdapter final
 public:
     static NonnullRefPtr<VirtIOGraphicsAdapter> initialize(PCI::DeviceIdentifier const&);
 
-    // FIXME: There's a VirtIO VGA GPU variant, so we should consider that
-    virtual bool vga_compatible() const override { return false; }
-
     virtual void initialize() override;
     void initialize_3d_device();
 


### PR DESCRIPTION
There's no point in keeping this method as we don't really care if a
graphics adapter is VGA compatible or not because we don't use this
method anymore.