### PR TITLE
Kernel/Storage: Check IDE error condition under the correct lock

### DIFF
--- a/Kernel/Storage/ATA/IDEChannel.cpp
+++ b/Kernel/Storage/ATA/IDEChannel.cpp
@@ -159,7 +159,7 @@ static void print_ide_status(u8 status)
 
 void IDEChannel::try_disambiguate_error()
 {
-    VERIFY(m_lock.is_locked());
+    VERIFY(m_request_lock.is_locked());
     dbgln("IDEChannel: Error cause:");
 
     switch (m_device_error) {


### PR DESCRIPTION
This bug was probably around for a very long time, but it is noticeable
only under VirtualBox as it generated an non fatal error which caused a
kernel panic because we VERIFYed the wrong lock to be locked.