### PR TITLE
Utilities/lspci: Don't unveil /res/pci.ids if not asked to resolve IDs

### DIFF
--- a/Base/usr/share/man/man8/lspci.md
+++ b/Base/usr/share/man/man8/lspci.md
@@ -13,6 +13,11 @@ $ lspci
 lspci is a utility for displaying information about PCI buses in the system
 and devices connected to them. It shows a brief list of devices.
 
+## Options
+
+* `-n`, `--numerical`: Don't try to resolve numerical PCI IDs. This is useful when
+there is a need to see the actual PCI IDs, or if `/res/pci.ids` file is not available.
+
 ## Files
 
 * `/sys/bus/pci` - source of the PCI devices list.

--- a/Userland/Utilities/lspci.cpp
+++ b/Userland/Utilities/lspci.cpp
@@ -45,15 +45,17 @@ static u32 convert_sysfs_value_to_uint(String const& value)
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath"));
-    TRY(Core::System::unveil("/res/pci.ids", "r"));
-    TRY(Core::System::unveil("/sys/bus/pci", "r"));
-    TRY(Core::System::unveil(nullptr, nullptr));
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("List PCI devices.");
     args_parser.add_option(flag_show_numerical, "Show numerical IDs", "numerical", 'n');
     args_parser.add_option(flag_verbose, "Show verbose info on devices", "verbose", 'v');
     args_parser.parse(arguments);
+
+    if (!flag_show_numerical)
+        TRY(Core::System::unveil("/res/pci.ids", "r"));
+    TRY(Core::System::unveil("/sys/bus/pci", "r"));
+    TRY(Core::System::unveil(nullptr, nullptr));
 
     auto const format = flag_show_numerical ? format_numerical : format_textual;
 


### PR DESCRIPTION
I tested the grub image under VirtualBox and it appeared that the image
didn't have pci.ids file included in the /res directory. In that case it
would be expected that lspci can still function correctly if the -n
parameter is passed, but then the unveil syscall failed because the file
didn't exist.

To cope with this, we should allow lspci to work without the pci.ids
file being present at the filesystem, so let's not unveil this file if
the -n parameter is passed.