### PR TITLE
HackStudio: Perform save-as action if build called before file is saved

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1613,7 +1613,7 @@ HackStudioWidget::ContinueDecision HackStudioWidget::warn_unsaved_changes(String
     if (result == GUI::MessageBox::ExecResult::Yes) {
         for (auto& editor_wrapper : m_all_editor_wrappers) {
             if (editor_wrapper.editor().document().is_modified()) {
-                if (active_file().is_empty())
+                if (editor_wrapper.filename().is_null())
                     m_save_as_action->activate();
                 else
                     editor_wrapper.save();

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1613,7 +1613,10 @@ HackStudioWidget::ContinueDecision HackStudioWidget::warn_unsaved_changes(String
     if (result == GUI::MessageBox::ExecResult::Yes) {
         for (auto& editor_wrapper : m_all_editor_wrappers) {
             if (editor_wrapper.editor().document().is_modified()) {
-                editor_wrapper.save();
+                if (active_file().is_empty())
+                    m_save_as_action->activate();
+                else
+                    editor_wrapper.save();
             }
         }
     }


### PR DESCRIPTION
If Build action is called before the file is saved, it leads to Hack studio crashing. This commit calls the save-as flow before the build if file is not saved before