### PR TITLE
LibRegex+LibJS: Implement the unicodeSets regex proposal

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,7 +49,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang-format-14 ccache e2fsprogs gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build optipng qemu-utils qemu-system-i386 unzip
       - name: Install JS dependencies
-        run: sudo npm install -g prettier@2.5.1
+        run: sudo npm install -g prettier@2.7.1
       - name: Install Python dependencies
         # The setup-python action set default python to python3.x. Note that we are not using system python here.
         run: |

--- a/Userland/Libraries/LibC/regex.h
+++ b/Userland/Libraries/LibC/regex.h
@@ -21,24 +21,25 @@ typedef struct {
 
 enum __Regex_Error {
     __Regex_NoError,
-    __Regex_InvalidPattern,             // Invalid regular expression.
-    __Regex_InvalidCollationElement,    // Invalid collating element referenced.
-    __Regex_InvalidCharacterClass,      // Invalid character class type referenced.
-    __Regex_InvalidTrailingEscape,      // Trailing \ in pattern.
-    __Regex_InvalidNumber,              // Number in \digit invalid or in error.
-    __Regex_MismatchingBracket,         // [ ] imbalance.
-    __Regex_MismatchingParen,           // ( ) imbalance.
-    __Regex_MismatchingBrace,           // { } imbalance.
-    __Regex_InvalidBraceContent,        // Content of {} invalid: not a number, number too large, more than two numbers, first larger than second.
-    __Regex_InvalidBracketContent,      // Content of [] invalid.
-    __Regex_InvalidRange,               // Invalid endpoint in range expression.
-    __Regex_InvalidRepetitionMarker,    // ?, * or + not preceded by valid regular expression.
-    __Regex_ReachedMaxRecursion,        // MaximumRecursion has been reached.
-    __Regex_EmptySubExpression,         // Sub expression has empty content.
-    __Regex_InvalidCaptureGroup,        // Content of capture group is invalid.
-    __Regex_InvalidNameForCaptureGroup, // Name of capture group is invalid.
-    __Regex_InvalidNameForProperty,     // Name of property is invalid.
-    __Regex_DuplicateNamedCapture,      // Duplicate named capture group
+    __Regex_InvalidPattern,              // Invalid regular expression.
+    __Regex_InvalidCollationElement,     // Invalid collating element referenced.
+    __Regex_InvalidCharacterClass,       // Invalid character class type referenced.
+    __Regex_InvalidTrailingEscape,       // Trailing \ in pattern.
+    __Regex_InvalidNumber,               // Number in \digit invalid or in error.
+    __Regex_MismatchingBracket,          // [ ] imbalance.
+    __Regex_MismatchingParen,            // ( ) imbalance.
+    __Regex_MismatchingBrace,            // { } imbalance.
+    __Regex_InvalidBraceContent,         // Content of {} invalid: not a number, number too large, more than two numbers, first larger than second.
+    __Regex_InvalidBracketContent,       // Content of [] invalid.
+    __Regex_InvalidRange,                // Invalid endpoint in range expression.
+    __Regex_InvalidRepetitionMarker,     // ?, * or + not preceded by valid regular expression.
+    __Regex_ReachedMaxRecursion,         // MaximumRecursion has been reached.
+    __Regex_EmptySubExpression,          // Sub expression has empty content.
+    __Regex_InvalidCaptureGroup,         // Content of capture group is invalid.
+    __Regex_InvalidNameForCaptureGroup,  // Name of capture group is invalid.
+    __Regex_InvalidNameForProperty,      // Name of property is invalid.
+    __Regex_DuplicateNamedCapture,       // Duplicate named capture group
+    __Regex_InvalidCharacterClassEscape, // Invalid escaped entity in character class.
 };
 
 enum ReError {
@@ -82,10 +83,11 @@ enum __RegexAllFlags {
     __Regex_Multiline = __Regex_Global << 12,                // Handle newline characters. Match each line, one by one.
     __Regex_SkipTrimEmptyMatches = __Regex_Global << 13,     // Do not remove empty capture group results.
     __Regex_SingleMatch = __Regex_Global << 14,              // Stop after acquiring a single match.
-    __Regex_Internal_Stateful = __Regex_Global << 15,        // Internal flag; enables stateful matches.
-    __Regex_Internal_BrowserExtended = __Regex_Global << 16, // Internal flag; enable browser-specific ECMA262 extensions.
-    __Regex_Internal_ConsiderNewline = __Regex_Global << 17, // Internal flag; allow matchers to consider newlines as line separators.
-    __Regex_Last = __Regex_SingleMatch
+    __Regex_UnicodeSets = __Regex_Global << 15,              // ECMA262 Parser specific: Allow set operations in char classes.
+    __Regex_Internal_Stateful = __Regex_Global << 16,        // Internal flag; enables stateful matches.
+    __Regex_Internal_BrowserExtended = __Regex_Global << 17, // Internal flag; enable browser-specific ECMA262 extensions.
+    __Regex_Internal_ConsiderNewline = __Regex_Global << 18, // Internal flag; allow matchers to consider newlines as line separators.
+    __Regex_Last = __Regex_UnicodeSets,
 };
 
 // Values for the cflags parameter to the regcomp() function:

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -124,13 +124,14 @@
     __JS_ENUMERATE(toPrimitive, to_primitive)                \
     __JS_ENUMERATE(toStringTag, to_string_tag)
 
-#define JS_ENUMERATE_REGEXP_FLAGS              \
-    __JS_ENUMERATE(hasIndices, has_indices, d) \
-    __JS_ENUMERATE(global, global, g)          \
-    __JS_ENUMERATE(ignoreCase, ignore_case, i) \
-    __JS_ENUMERATE(multiline, multiline, m)    \
-    __JS_ENUMERATE(dotAll, dot_all, s)         \
-    __JS_ENUMERATE(unicode, unicode, u)        \
+#define JS_ENUMERATE_REGEXP_FLAGS                \
+    __JS_ENUMERATE(hasIndices, has_indices, d)   \
+    __JS_ENUMERATE(global, global, g)            \
+    __JS_ENUMERATE(ignoreCase, ignore_case, i)   \
+    __JS_ENUMERATE(multiline, multiline, m)      \
+    __JS_ENUMERATE(dotAll, dot_all, s)           \
+    __JS_ENUMERATE(unicodeSets, unicode_sets, v) \
+    __JS_ENUMERATE(unicode, unicode, u)          \
     __JS_ENUMERATE(sticky, sticky, y)
 
 namespace JS {

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1522,7 +1522,14 @@ NonnullRefPtr<RegExpLiteral> Parser::parse_regexp_literal()
             parsed_flags = parsed_flags_or_error.release_value();
     }
 
-    auto parsed_pattern = parse_regex_pattern(pattern, parsed_flags.has_flag_set(ECMAScriptFlags::Unicode));
+    String parsed_pattern;
+    auto parsed_pattern_result = parse_regex_pattern(pattern, parsed_flags.has_flag_set(ECMAScriptFlags::Unicode), parsed_flags.has_flag_set(ECMAScriptFlags::UnicodeSets));
+    if (parsed_pattern_result.is_error()) {
+        syntax_error(parsed_pattern_result.release_error().error, rule_start.position());
+        parsed_pattern = String::empty();
+    } else {
+        parsed_pattern = parsed_pattern_result.release_value();
+    }
     auto parsed_regex = Regex<ECMA262>::parse_pattern(parsed_pattern, parsed_flags);
 
     if (parsed_regex.error != regex::Error::NoError)

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -526,11 +526,12 @@ namespace JS {
     P(undefined)                             \
     P(unescape)                              \
     P(unicode)                               \
+    P(unicodeSets)                           \
     P(unit)                                  \
     P(unitDisplay)                           \
-    P(until)                                 \
     P(unregister)                            \
     P(unshift)                               \
+    P(until)                                 \
     P(usage)                                 \
     P(useGrouping)                           \
     P(value)                                 \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -209,6 +209,7 @@
     M(RegExpCompileError, "RegExp compile error: {}")                                                                                   \
     M(RegExpObjectBadFlag, "Invalid RegExp flag '{}'")                                                                                  \
     M(RegExpObjectRepeatedFlag, "Repeated RegExp flag '{}'")                                                                            \
+    M(RegExpObjectIncompatibleFlags, "RegExp flag '{}' is incompatible with flag '{}'")                                                 \
     M(RestrictedFunctionPropertiesAccess, "Restricted function properties like 'callee', 'caller' and 'arguments' may "                 \
                                           "not be accessed in strict mode")                                                             \
     M(RestrictedGlobalProperty, "Cannot declare global property '{}'")                                                                  \

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -16,7 +16,7 @@ namespace JS {
 
 Result<regex::RegexOptions<ECMAScriptFlags>, String> regex_flags_from_string(StringView flags)
 {
-    bool d = false, g = false, i = false, m = false, s = false, u = false, y = false;
+    bool d = false, g = false, i = false, m = false, s = false, u = false, y = false, v = false;
     auto options = RegExpObject::default_flags;
 
     for (auto ch : flags) {
@@ -68,6 +68,12 @@ Result<regex::RegexOptions<ECMAScriptFlags>, String> regex_flags_from_string(Str
             options |= (regex::ECMAScriptFlags)regex::AllFlags::Internal_Stateful;
             options |= regex::ECMAScriptFlags::Sticky;
             break;
+        case 'v':
+            if (v)
+                return String::formatted(ErrorType::RegExpObjectRepeatedFlag.message(), ch);
+            v = true;
+            options |= regex::ECMAScriptFlags::UnicodeSets;
+            break;
         default:
             return String::formatted(ErrorType::RegExpObjectBadFlag.message(), ch);
         }
@@ -76,8 +82,11 @@ Result<regex::RegexOptions<ECMAScriptFlags>, String> regex_flags_from_string(Str
     return options;
 }
 
-String parse_regex_pattern(StringView pattern, bool unicode)
+ErrorOr<String, ParseRegexPatternError> parse_regex_pattern(StringView pattern, bool unicode, bool unicode_sets)
 {
+    if (unicode && unicode_sets)
+        return ParseRegexPatternError { String::formatted(ErrorType::RegExpObjectIncompatibleFlags.message(), 'u', 'v') };
+
     auto utf16_pattern = AK::utf8_to_utf16(pattern);
     Utf16View utf16_pattern_view { utf16_pattern };
     StringBuilder builder;
@@ -85,7 +94,7 @@ String parse_regex_pattern(StringView pattern, bool unicode)
     // If the Unicode flag is set, append each code point to the pattern. Otherwise, append each
     // code unit. But unlike the spec, multi-byte code units must be escaped for LibRegex to parse.
     for (size_t i = 0; i < utf16_pattern_view.length_in_code_units();) {
-        if (unicode) {
+        if (unicode || unicode_sets) {
             auto code_point = code_point_at(utf16_pattern_view, i);
             builder.append_code_point(code_point.code_point);
             i += code_point.code_unit_count;
@@ -102,6 +111,15 @@ String parse_regex_pattern(StringView pattern, bool unicode)
     }
 
     return builder.build();
+}
+
+ThrowCompletionOr<String> parse_regex_pattern(StringView pattern, VM& vm, GlobalObject& global_object, bool unicode, bool unicode_sets)
+{
+    auto result = parse_regex_pattern(pattern, unicode, unicode_sets);
+    if (result.is_error())
+        return vm.throw_completion<JS::SyntaxError>(global_object, result.release_error().error);
+
+    return result.release_value();
 }
 
 RegExpObject* RegExpObject::create(GlobalObject& global_object)
@@ -156,7 +174,8 @@ ThrowCompletionOr<RegExpObject*> RegExpObject::regexp_initialize(GlobalObject& g
     } else {
         original_pattern = TRY(pattern.to_string(global_object));
         bool unicode = f.find('u').has_value();
-        parsed_pattern = parse_regex_pattern(original_pattern, unicode);
+        bool unicode_sets = f.find('v').has_value();
+        parsed_pattern = TRY(parse_regex_pattern(original_pattern, vm, global_object, unicode, unicode_sets));
     }
 
     auto parsed_flags_or_error = regex_flags_from_string(f);
@@ -181,7 +200,7 @@ String RegExpObject::escape_regexp_pattern() const
 {
     if (m_pattern.is_empty())
         return "(?:)";
-    // FIXME: Check u flag and escape accordingly
+    // FIXME: Check the 'u' and 'v' flags and escape accordingly
     return m_pattern.replace("\n"sv, "\\n"sv, ReplaceMode::All).replace("\r"sv, "\\r"sv, ReplaceMode::All).replace(LINE_SEPARATOR_STRING, "\\u2028"sv, ReplaceMode::All).replace(PARAGRAPH_SEPARATOR_STRING, "\\u2029"sv, ReplaceMode::All).replace("/"sv, "\\/"sv, ReplaceMode::All);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.h
@@ -17,7 +17,11 @@ namespace JS {
 ThrowCompletionOr<RegExpObject*> regexp_create(GlobalObject&, Value pattern, Value flags);
 
 Result<regex::RegexOptions<ECMAScriptFlags>, String> regex_flags_from_string(StringView flags);
-String parse_regex_pattern(StringView pattern, bool unicode);
+struct ParseRegexPatternError {
+    String error;
+};
+ErrorOr<String, ParseRegexPatternError> parse_regex_pattern(StringView pattern, bool unicode, bool unicode_sets);
+ThrowCompletionOr<String> parse_regex_pattern(StringView pattern, VM& vm, GlobalObject& global_object, bool unicode, bool unicode_sets);
 
 class RegExpObject : public Object {
     JS_OBJECT(RegExpObject, Object);

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -410,6 +410,7 @@ size_t advance_string_index(Utf16View const& string, size_t index, bool unicode)
 // 22.2.5.10 get RegExp.prototype.multiline, https://tc39.es/ecma262/#sec-get-regexp.prototype.multiline
 // 22.2.5.15 get RegExp.prototype.sticky, https://tc39.es/ecma262/#sec-get-regexp.prototype.sticky
 // 22.2.5.18 get RegExp.prototype.unicode, https://tc39.es/ecma262/#sec-get-regexp.prototype.unicode
+// 22.2.5.18 get RegExp.prototype.unicodeSets, https://arai-a.github.io/ecma262-compare/?pr=2418&id=sec-get-regexp.prototype.unicodeSets
 #define __JS_ENUMERATE(flagName, flag_name, flag_char)                                                    \
     JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::flag_name)                                                 \
     {                                                                                                     \
@@ -467,10 +468,12 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::flags)
     // 11. If multiline is true, append the code unit 0x006D (LATIN SMALL LETTER M) as the last code unit of result.
     // 12. Let dotAll be ToBoolean(? Get(R, "dotAll")).
     // 13. If dotAll is true, append the code unit 0x0073 (LATIN SMALL LETTER S) as the last code unit of result.
-    // 14. Let unicode be ToBoolean(? Get(R, "unicode")).
-    // 15. If unicode is true, append the code unit 0x0075 (LATIN SMALL LETTER U) as the last code unit of result.
-    // 16. Let sticky be ToBoolean(? Get(R, "sticky")).
-    // 17. If sticky is true, append the code unit 0x0079 (LATIN SMALL LETTER Y) as the last code unit of result.
+    // 14. Let unicodeSets be ! ToBoolean(? Get(R, "unicodeSets")).
+    // 15. If unicodeSets is true, append the code unit 0x0076 (LATIN SMALL LETTER V) as the last code unit of result.
+    // 16. Let unicode be ToBoolean(? Get(R, "unicode")).
+    // 17. If unicode is true, append the code unit 0x0075 (LATIN SMALL LETTER U) as the last code unit of result.
+    // 18. Let sticky be ToBoolean(? Get(R, "sticky")).
+    // 19. If sticky is true, append the code unit 0x0079 (LATIN SMALL LETTER Y) as the last code unit of result.
 #define __JS_ENUMERATE(flagName, flag_name, flag_char)                  \
     auto flag_##flag_name = TRY(regexp_object->get(vm.names.flagName)); \
     if (flag_##flag_name.to_boolean())                                  \
@@ -483,6 +486,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::flags)
 }
 
 // 22.2.5.8 RegExp.prototype [ @@match ] ( string ), https://tc39.es/ecma262/#sec-regexp.prototype-@@match
+// With changes from https://arai-a.github.io/ecma262-compare/?pr=2418&id=sec-regexp.prototype-%2540%2540match
 JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match)
 {
     // 1. Let rx be the this value.
@@ -504,19 +508,23 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match)
     // 6. Else,
     // a. Assert: global is true.
 
-    // b. Let fullUnicode be ToBoolean(? Get(rx, "unicode")).
-    bool full_unicode = TRY(regexp_object->get(vm.names.unicode)).to_boolean();
+    // b. Let fullUnicode be ToBoolean(? Get(rx, "unicodeSets")).
+    bool full_unicode = TRY(regexp_object->get(vm.names.unicodeSets)).to_boolean();
 
-    // c. Perform ? Set(rx, "lastIndex", +0𝔽, true).
+    // c. If fullUnicode is false, set fullUnicode to ! ToBoolean(? Get(rx, "unicode")).
+    if (!full_unicode)
+        full_unicode = TRY(regexp_object->get(vm.names.unicode)).to_boolean();
+
+    // d. Perform ? Set(rx, "lastIndex", +0𝔽, true).
     TRY(regexp_object->set(vm.names.lastIndex, Value(0), Object::ShouldThrowExceptions::Yes));
 
-    // d. Let A be ! ArrayCreate(0).
+    // e. Let A be ! ArrayCreate(0).
     auto* array = MUST(Array::create(global_object, 0));
 
-    // e. Let n be 0.
+    // f. Let n be 0.
     size_t n = 0;
 
-    // f. Repeat,
+    // g. Repeat,
     while (true) {
         // i. Let result be ? RegExpExec(rx, S).
         auto result = TRY(regexp_exec(global_object, *regexp_object, string));
@@ -552,6 +560,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match)
 }
 
 // 22.2.5.9 RegExp.prototype [ @@matchAll ] ( string ), https://tc39.es/ecma262/#sec-regexp-prototype-matchall
+// With changes from https://arai-a.github.io/ecma262-compare/?pr=2418&id=sec-regexp-prototype-matchall
 JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match_all)
 {
     // 1. Let R be the this value.
@@ -576,7 +585,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match_all)
 
     // 11. If flags contains "u", let fullUnicode be true.
     // 12. Else, let fullUnicode be false.
-    bool full_unicode = flags.contains('u');
+    bool full_unicode = flags.contains('u') || flags.contains('v');
 
     // 6. Let matcher be ? Construct(C, « R, flags »).
     auto* matcher = TRY(construct(global_object, *constructor, regexp_object, js_string(vm, move(flags))));
@@ -593,6 +602,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match_all)
 }
 
 // 22.2.5.11 RegExp.prototype [ @@replace ] ( string, replaceValue ), https://tc39.es/ecma262/#sec-regexp.prototype-@@replace
+// With changes from https://arai-a.github.io/ecma262-compare/?pr=2418&id=sec-regexp.prototype-@@replace
 JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
 {
     auto string_value = vm.argument(0);
@@ -621,10 +631,14 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
 
     // 8. If global is true, then
     if (global) {
-        // a. Let fullUnicode be ToBoolean(? Get(rx, "unicode")).
-        full_unicode = TRY(regexp_object->get(vm.names.unicode)).to_boolean();
+        // a. Let fullUnicode be ToBoolean(? Get(rx, "unicodeSets")).
+        full_unicode = TRY(regexp_object->get(vm.names.unicodeSets)).to_boolean();
 
-        // b. Perform ? Set(rx, "lastIndex", +0𝔽, true).
+        // b. If fullUnicode is false, set fullUnicode to ! ToBoolean(? Get(rx, "unicode")).
+        if (!full_unicode)
+            full_unicode = TRY(regexp_object->get(vm.names.unicode)).to_boolean();
+
+        // c. Perform ? Set(rx, "lastIndex", +0𝔽, true).
         TRY(regexp_object->set(vm.names.lastIndex, Value(0), Object::ShouldThrowExceptions::Yes));
     }
 
@@ -863,7 +877,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_split)
 
     // 6. If flags contains "u", let unicodeMatching be true.
     // 7. Else, let unicodeMatching be false.
-    bool unicode_matching = flags.find('u').has_value();
+    bool unicode_matching = flags.contains('u') || flags.contains('v');
 
     // 8. If flags contains "y", let newFlags be flags.
     // 9. Else, let newFlags be the string-concatenation of flags and "y".

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.flags.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.flags.js
@@ -5,8 +5,11 @@ test("basic functionality", () => {
     expect(/foo/i.flags).toBe("i");
     expect(/foo/m.flags).toBe("m");
     expect(/foo/s.flags).toBe("s");
+    expect(/foo/v.flags).toBe("v");
     expect(/foo/u.flags).toBe("u");
     expect(/foo/y.flags).toBe("y");
     // prettier-ignore
     expect(/foo/dsgimyu.flags).toBe("dgimsuy");
+    // prettier-ignore
+    expect(/foo/dgimsvy.flags).toBe("dgimsvy");
 });

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -532,7 +532,7 @@ ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, M
 
         } else if (compare_type == CharacterCompareType::CharClass) {
 
-            if (input.view.length() <= state.string_position)
+            if (input.view.length() <= state.string_position_in_code_units)
                 return ExecutionResult::Failed_ExecuteLowPrioForks;
 
             auto character_class = (CharClass)m_bytecode->at(offset++);

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -76,7 +76,10 @@ enum class OpCodeId : ByteCodeValueType {
     __ENUMERATE_CHARACTER_COMPARE_TYPE(Script)               \
     __ENUMERATE_CHARACTER_COMPARE_TYPE(ScriptExtension)      \
     __ENUMERATE_CHARACTER_COMPARE_TYPE(RangeExpressionDummy) \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(LookupTable)
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(LookupTable)          \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(And)                  \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(Or)                   \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(EndAndOr)
 
 enum class CharacterCompareType : ByteCodeValueType {
 #define __ENUMERATE_CHARACTER_COMPARE_TYPE(x) x,

--- a/Userland/Libraries/LibRegex/RegexError.h
+++ b/Userland/Libraries/LibRegex/RegexError.h
@@ -18,24 +18,25 @@ namespace regex {
 
 enum class Error : u8 {
     NoError = __Regex_NoError,
-    InvalidPattern = __Regex_InvalidPattern,                         // Invalid regular expression.
-    InvalidCollationElement = __Regex_InvalidCollationElement,       // Invalid collating element referenced.
-    InvalidCharacterClass = __Regex_InvalidCharacterClass,           // Invalid character class type referenced.
-    InvalidTrailingEscape = __Regex_InvalidTrailingEscape,           // Trailing \ in pattern.
-    InvalidNumber = __Regex_InvalidNumber,                           // Number in \digit invalid or in error.
-    MismatchingBracket = __Regex_MismatchingBracket,                 // [ ] imbalance.
-    MismatchingParen = __Regex_MismatchingParen,                     // ( ) imbalance.
-    MismatchingBrace = __Regex_MismatchingBrace,                     // { } imbalance.
-    InvalidBraceContent = __Regex_InvalidBraceContent,               // Content of {} invalid: not a number, number too large, more than two numbers, first larger than second.
-    InvalidBracketContent = __Regex_InvalidBracketContent,           // Content of [] invalid.
-    InvalidRange = __Regex_InvalidRange,                             // Invalid endpoint in range expression.
-    InvalidRepetitionMarker = __Regex_InvalidRepetitionMarker,       // ?, * or + not preceded by valid regular expression.
-    ReachedMaxRecursion = __Regex_ReachedMaxRecursion,               // MaximumRecursion has been reached.
-    EmptySubExpression = __Regex_EmptySubExpression,                 // Sub expression has empty content.
-    InvalidCaptureGroup = __Regex_InvalidCaptureGroup,               // Content of capture group is invalid.
-    InvalidNameForCaptureGroup = __Regex_InvalidNameForCaptureGroup, // Name of capture group is invalid.
-    InvalidNameForProperty = __Regex_InvalidNameForProperty,         // Name of property is invalid.
-    DuplicateNamedCapture = __Regex_DuplicateNamedCapture,           // Name of property is invalid.
+    InvalidPattern = __Regex_InvalidPattern,                           // Invalid regular expression.
+    InvalidCollationElement = __Regex_InvalidCollationElement,         // Invalid collating element referenced.
+    InvalidCharacterClass = __Regex_InvalidCharacterClass,             // Invalid character class type referenced.
+    InvalidTrailingEscape = __Regex_InvalidTrailingEscape,             // Trailing \ in pattern.
+    InvalidNumber = __Regex_InvalidNumber,                             // Number in \digit invalid or in error.
+    MismatchingBracket = __Regex_MismatchingBracket,                   // [ ] imbalance.
+    MismatchingParen = __Regex_MismatchingParen,                       // ( ) imbalance.
+    MismatchingBrace = __Regex_MismatchingBrace,                       // { } imbalance.
+    InvalidBraceContent = __Regex_InvalidBraceContent,                 // Content of {} invalid: not a number, number too large, more than two numbers, first larger than second.
+    InvalidBracketContent = __Regex_InvalidBracketContent,             // Content of [] invalid.
+    InvalidRange = __Regex_InvalidRange,                               // Invalid endpoint in range expression.
+    InvalidRepetitionMarker = __Regex_InvalidRepetitionMarker,         // ?, * or + not preceded by valid regular expression.
+    ReachedMaxRecursion = __Regex_ReachedMaxRecursion,                 // MaximumRecursion has been reached.
+    EmptySubExpression = __Regex_EmptySubExpression,                   // Sub expression has empty content.
+    InvalidCaptureGroup = __Regex_InvalidCaptureGroup,                 // Content of capture group is invalid.
+    InvalidNameForCaptureGroup = __Regex_InvalidNameForCaptureGroup,   // Name of capture group is invalid.
+    InvalidNameForProperty = __Regex_InvalidNameForProperty,           // Name of property is invalid.
+    DuplicateNamedCapture = __Regex_DuplicateNamedCapture,             // Name of property is invalid.
+    InvalidCharacterClassEscape = __Regex_InvalidCharacterClassEscape, // Invalid escaped entity in character class.
 };
 
 inline String get_error_string(Error error)
@@ -79,6 +80,8 @@ inline String get_error_string(Error error)
         return "Name of property is invalid.";
     case Error::DuplicateNamedCapture:
         return "Duplicate capture group name";
+    case Error::InvalidCharacterClassEscape:
+        return "Invalid escaped entity in character class.";
     }
     return "Undefined error.";
 }

--- a/Userland/Libraries/LibRegex/RegexOptimizer.cpp
+++ b/Userland/Libraries/LibRegex/RegexOptimizer.cpp
@@ -205,6 +205,9 @@ static bool has_overlap(Vector<CompareTypeAndValuePair> const& lhs, Vector<Compa
         case CharacterCompareType::GeneralCategory:
         case CharacterCompareType::Script:
         case CharacterCompareType::ScriptExtension:
+        case CharacterCompareType::And:
+        case CharacterCompareType::Or:
+        case CharacterCompareType::EndAndOr:
             // FIXME: These are too difficult to handle, so bail out.
             return true;
         case CharacterCompareType::Undefined:
@@ -274,6 +277,9 @@ static bool has_overlap(Vector<CompareTypeAndValuePair> const& lhs, Vector<Compa
         case CharacterCompareType::GeneralCategory:
         case CharacterCompareType::Script:
         case CharacterCompareType::ScriptExtension:
+        case CharacterCompareType::And:
+        case CharacterCompareType::Or:
+        case CharacterCompareType::EndAndOr:
             // FIXME: These are too difficult to handle, so bail out.
             return true;
         case CharacterCompareType::Undefined:
@@ -785,6 +791,8 @@ enum class LookupTableInsertionOutcome {
     ReplaceWithAnyChar,
     TemporaryInversionNeeded,
     PermanentInversionNeeded,
+    FlushOnInsertion,
+    FinishFlushOnInsertion,
     CannotPlaceInTable,
 };
 static LookupTableInsertionOutcome insert_into_lookup_table(RedBlackTree<ByteCodeValueType, CharRange>& table, CompareTypeAndValuePair pair)
@@ -806,11 +814,16 @@ static LookupTableInsertionOutcome insert_into_lookup_table(RedBlackTree<ByteCod
         table.insert(range.from, range);
         break;
     }
+    case CharacterCompareType::EndAndOr:
+        return LookupTableInsertionOutcome::FinishFlushOnInsertion;
+    case CharacterCompareType::And:
+        return LookupTableInsertionOutcome::FlushOnInsertion;
     case CharacterCompareType::Reference:
     case CharacterCompareType::Property:
     case CharacterCompareType::GeneralCategory:
     case CharacterCompareType::Script:
     case CharacterCompareType::ScriptExtension:
+    case CharacterCompareType::Or:
         return LookupTableInsertionOutcome::CannotPlaceInTable;
     case CharacterCompareType::Undefined:
     case CharacterCompareType::RangeExpressionDummy:
@@ -830,7 +843,12 @@ void Optimizer::append_character_class(ByteCode& target, Vector<CompareTypeAndVa
     if (pairs.size() <= 1) {
         for (auto& pair : pairs) {
             arguments.append(to_underlying(pair.type));
-            if (pair.type != CharacterCompareType::AnyChar && pair.type != CharacterCompareType::TemporaryInverse && pair.type != CharacterCompareType::Inverse)
+            if (pair.type != CharacterCompareType::AnyChar
+                && pair.type != CharacterCompareType::TemporaryInverse
+                && pair.type != CharacterCompareType::Inverse
+                && pair.type != CharacterCompareType::And
+                && pair.type != CharacterCompareType::Or
+                && pair.type != CharacterCompareType::EndAndOr)
                 arguments.append(pair.value);
             ++argument_count;
         }
@@ -881,8 +899,12 @@ void Optimizer::append_character_class(ByteCode& target, Vector<CompareTypeAndVa
                 arguments.append(to_underlying(CharacterCompareType::TemporaryInverse));
                 append_table(inverted_table);
             }
+
+            table.clear();
+            inverted_table.clear();
         };
 
+        auto flush_on_every_insertion = false;
         for (auto& value : pairs) {
             auto should_invert_after_this_iteration = invert_for_next_iteration;
             invert_for_next_iteration = false;
@@ -890,6 +912,8 @@ void Optimizer::append_character_class(ByteCode& target, Vector<CompareTypeAndVa
             auto insertion_result = insert_into_lookup_table(*current_table, value);
             switch (insertion_result) {
             case LookupTableInsertionOutcome::Successful:
+                if (flush_on_every_insertion)
+                    flush_tables();
                 break;
             case LookupTableInsertionOutcome::ReplaceWithAnyChar: {
                 table.clear();
@@ -908,13 +932,25 @@ void Optimizer::append_character_class(ByteCode& target, Vector<CompareTypeAndVa
                 arguments.append(to_underlying(CharacterCompareType::Inverse));
                 ++argument_count;
                 break;
+            case LookupTableInsertionOutcome::FlushOnInsertion:
+            case LookupTableInsertionOutcome::FinishFlushOnInsertion:
+                flush_tables();
+                flush_on_every_insertion = insertion_result == LookupTableInsertionOutcome::FlushOnInsertion;
+                [[fallthrough]];
             case LookupTableInsertionOutcome::CannotPlaceInTable:
                 if (is_currently_inverted) {
                     arguments.append(to_underlying(CharacterCompareType::TemporaryInverse));
                     ++argument_count;
                 }
                 arguments.append(to_underlying(value.type));
-                arguments.append(value.value);
+
+                if (value.type != CharacterCompareType::AnyChar
+                    && value.type != CharacterCompareType::TemporaryInverse
+                    && value.type != CharacterCompareType::Inverse
+                    && value.type != CharacterCompareType::And
+                    && value.type != CharacterCompareType::Or
+                    && value.type != CharacterCompareType::EndAndOr)
+                    arguments.append(value.value);
                 ++argument_count;
                 break;
             }

--- a/Userland/Libraries/LibRegex/RegexOptions.h
+++ b/Userland/Libraries/LibRegex/RegexOptions.h
@@ -34,6 +34,7 @@ enum class AllFlags {
     Multiline = __Regex_Multiline,                               // Handle newline characters. Match each line, one by one.
     SkipTrimEmptyMatches = __Regex_SkipTrimEmptyMatches,         // Do not remove empty capture group results.
     SingleMatch = __Regex_SingleMatch,                           // Stop after acquiring a single match.
+    UnicodeSets = __Regex_UnicodeSets,                           // Only for ECMA262, Allow set operations in character classes.
     Internal_Stateful = __Regex_Internal_Stateful,               // Make global matches match one result at a time, and further match() calls on the same instance continue where the previous one left off.
     Internal_BrowserExtended = __Regex_Internal_BrowserExtended, // Only for ECMA262, Enable the behaviors defined in section B.1.4. of the ECMA262 spec.
     Internal_ConsiderNewline = __Regex_Internal_ConsiderNewline, // Only for ECMA262, Allow multiline matches to consider newlines as line boundaries.
@@ -66,6 +67,7 @@ enum class ECMAScriptFlags : FlagsUnderlyingType {
     Sticky = (FlagsUnderlyingType)AllFlags::Sticky,
     Multiline = (FlagsUnderlyingType)AllFlags::Multiline,
     StringCopyMatches = (FlagsUnderlyingType)AllFlags::StringCopyMatches,
+    UnicodeSets = (FlagsUnderlyingType)AllFlags::UnicodeSets,
     BrowserExtended = (FlagsUnderlyingType)AllFlags::Internal_BrowserExtended,
 };
 

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -255,6 +255,8 @@ private:
     bool parse_nonempty_class_ranges(Vector<CompareTypeAndValuePair>&, ParseFlags);
     bool parse_unicode_property_escape(PropertyEscape& property, bool& negated);
 
+    bool parse_character_escape(Vector<CompareTypeAndValuePair>&, size_t&, ParseFlags);
+
     // Used only by B.1.4, Regular Expression Patterns (Extended for use in browsers)
     bool parse_quantifiable_assertion(ByteCode&, size_t&, ParseFlags);
     bool parse_extended_atom(ByteCode&, size_t&, ParseFlags);

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -92,6 +92,8 @@ protected:
     ALWAYS_INLINE bool done() const;
     ALWAYS_INLINE bool set_error(Error error);
 
+    size_t tell() const { return m_parser_state.current_token.position(); }
+
     struct NamedCaptureGroup {
         size_t group_index { 0 };
         size_t minimum_length { 0 };
@@ -223,6 +225,7 @@ private:
     struct ParseFlags {
         bool unicode { false };
         bool named { false };
+        bool unicode_sets { false };
     };
 
     enum class ReadDigitsInitialZeroState {
@@ -256,6 +259,15 @@ private:
     bool parse_unicode_property_escape(PropertyEscape& property, bool& negated);
 
     bool parse_character_escape(Vector<CompareTypeAndValuePair>&, size_t&, ParseFlags);
+
+    bool parse_class_set_expression(Vector<CompareTypeAndValuePair>&);
+    bool parse_class_union(Vector<CompareTypeAndValuePair>&);
+    bool parse_class_intersection(Vector<CompareTypeAndValuePair>&);
+    bool parse_class_subtraction(Vector<CompareTypeAndValuePair>&);
+    bool parse_class_set_range(Vector<CompareTypeAndValuePair>&);
+    bool parse_class_set_operand(Vector<CompareTypeAndValuePair>&);
+    bool parse_nested_class(Vector<CompareTypeAndValuePair>&);
+    Optional<u32> parse_class_set_character();
 
     // Used only by B.1.4, Regular Expression Patterns (Extended for use in browsers)
     bool parse_quantifiable_assertion(ByteCode&, size_t&, ParseFlags);

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -220,6 +220,11 @@ public:
 private:
     bool parse_internal(ByteCode&, size_t&) override;
 
+    struct ParseFlags {
+        bool unicode { false };
+        bool named { false };
+    };
+
     enum class ReadDigitsInitialZeroState {
         Allow,
         Disallow,
@@ -235,25 +240,25 @@ private:
     using PropertyEscape = Variant<Unicode::Property, Unicode::GeneralCategory, Script, Empty>;
     Optional<PropertyEscape> read_unicode_property_escape();
 
-    bool parse_pattern(ByteCode&, size_t&, bool unicode, bool named);
-    bool parse_disjunction(ByteCode&, size_t&, bool unicode, bool named);
-    bool parse_alternative(ByteCode&, size_t&, bool unicode, bool named);
-    bool parse_term(ByteCode&, size_t&, bool unicode, bool named);
-    bool parse_assertion(ByteCode&, size_t&, bool unicode, bool named);
-    bool parse_atom(ByteCode&, size_t&, bool unicode, bool named);
-    bool parse_quantifier(ByteCode&, size_t&, bool unicode, bool named);
+    bool parse_pattern(ByteCode&, size_t&, ParseFlags);
+    bool parse_disjunction(ByteCode&, size_t&, ParseFlags);
+    bool parse_alternative(ByteCode&, size_t&, ParseFlags);
+    bool parse_term(ByteCode&, size_t&, ParseFlags);
+    bool parse_assertion(ByteCode&, size_t&, ParseFlags);
+    bool parse_atom(ByteCode&, size_t&, ParseFlags);
+    bool parse_quantifier(ByteCode&, size_t&, ParseFlags);
     bool parse_interval_quantifier(Optional<u64>& repeat_min, Optional<u64>& repeat_max);
-    bool parse_atom_escape(ByteCode&, size_t&, bool unicode, bool named);
-    bool parse_character_class(ByteCode&, size_t&, bool unicode, bool named);
-    bool parse_capture_group(ByteCode&, size_t&, bool unicode, bool named);
+    bool parse_atom_escape(ByteCode&, size_t&, ParseFlags);
+    bool parse_character_class(ByteCode&, size_t&, ParseFlags);
+    bool parse_capture_group(ByteCode&, size_t&, ParseFlags);
     Optional<CharClass> parse_character_class_escape(bool& out_inverse, bool expect_backslash = false);
-    bool parse_nonempty_class_ranges(Vector<CompareTypeAndValuePair>&, bool unicode);
+    bool parse_nonempty_class_ranges(Vector<CompareTypeAndValuePair>&, ParseFlags);
     bool parse_unicode_property_escape(PropertyEscape& property, bool& negated);
 
     // Used only by B.1.4, Regular Expression Patterns (Extended for use in browsers)
-    bool parse_quantifiable_assertion(ByteCode&, size_t&, bool named);
-    bool parse_extended_atom(ByteCode&, size_t&, bool named);
-    bool parse_inner_disjunction(ByteCode& bytecode_stack, size_t& length, bool unicode, bool named);
+    bool parse_quantifiable_assertion(ByteCode&, size_t&, ParseFlags);
+    bool parse_extended_atom(ByteCode&, size_t&, ParseFlags);
+    bool parse_inner_disjunction(ByteCode& bytecode_stack, size_t& length, ParseFlags);
     bool parse_invalid_braced_quantifier(); // Note: This function either parses and *fails*, or doesn't parse anything and returns false.
     bool parse_legacy_octal_escape_sequence(ByteCode& bytecode_stack, size_t& length);
     Optional<u8> parse_legacy_octal_escape();

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1187,7 +1187,7 @@ static bool parse_and_run(JS::Interpreter& interpreter, StringView source, Strin
             auto hint = error.source_location_hint(source);
             if (!hint.is_empty())
                 outln("{}", hint);
-            outln(error.to_string());
+            outln("{}", error.to_string());
             result = interpreter.vm().throw_completion<JS::SyntaxError>(interpreter.global_object(), error.to_string());
         } else {
             auto return_early = run_script_or_module(script_or_error.value());


### PR DESCRIPTION
why would anyone yakbait some poor soul into doing this? how cruel! how soul-crushing!

TODO:
- ~~nesting nested charclasses is borked~~
- ~~unicode properties are doing who-knows-what because we're ignoring some state~~
- the `\q{}` nonsense is not implemented, probably won't be in this PR
- ~~there are some regressions~~

```
Duration:
     -38.82s

Summary:
    Diff Tests:
        +46 ✅    -46 ❌

Diff Tests:
    test/built-ins/RegExp/unicodeSets/generated/character-class-difference-character-class-escape.js                ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-difference-character-class.js                       ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-difference-character-property-escape.js             ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-difference-character.js                             ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-escape-difference-character-class-escape.js         ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-escape-difference-character-class.js                ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-escape-difference-character-property-escape.js      ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-escape-difference-character.js                      ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-escape-intersection-character-class-escape.js       ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-escape-intersection-character-class.js              ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-escape-intersection-character-property-escape.js    ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-escape-intersection-character.js                    ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-escape-union-character-class-escape.js              ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-escape-union-character-class.js                     ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-escape-union-character-property-escape.js           ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-escape-union-character.js                           ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-intersection-character-class-escape.js              ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-intersection-character-class.js                     ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-intersection-character-property-escape.js           ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-intersection-character.js                           ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-union-character-class-escape.js                     ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-union-character-class.js                            ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-union-character-property-escape.js                  ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-class-union-character.js                                  ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-difference-character-class-escape.js                      ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-difference-character-property-escape.js                   ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-difference-character.js                                   ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-intersection-character-class-escape.js                    ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-intersection-character-class.js                           ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-intersection-character-property-escape.js                 ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-intersection-character.js                                 ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-property-escape-difference-character-class-escape.js      ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-property-escape-difference-character-property-escape.js   ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-property-escape-difference-character.js                   ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-property-escape-intersection-character-class-escape.js    ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-property-escape-intersection-character-class.js           ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-property-escape-intersection-character-property-escape.js ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-property-escape-intersection-character.js                 ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-property-escape-union-character-class-escape.js           ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-property-escape-union-character-class.js                  ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-property-escape-union-character-property-escape.js        ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-property-escape-union-character.js                        ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-union-character-class-escape.js                           ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-union-character-class.js                                  ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-union-character-property-escape.js                        ❌ -> ✅
    test/built-ins/RegExp/unicodeSets/generated/character-union-character.js                                        ❌ -> ✅

```