### PR TITLE
LibWeb: Add blob to union type for XHR::send() + extract_body() spec compliance and some more stuff

### DIFF
--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -54,6 +54,8 @@ private:
 
     ByteBuffer m_byte_buffer {};
     String m_type {};
+
+    friend class XHR::XMLHttpRequest;
 };
 
 }

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
@@ -234,7 +234,7 @@ void URLSearchParams::sort()
     update();
 }
 
-String URLSearchParams::to_string()
+String URLSearchParams::to_string() const
 {
     // return the serialization of this’s list.
     return url_encode(m_list, AK::URL::PercentEncodeSet::ApplicationXWWWFormUrlencoded);

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.h
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.h
@@ -41,7 +41,7 @@ public:
 
     void sort();
 
-    String to_string();
+    String to_string() const;
 
     using ForEachCallback = Function<JS::ThrowCompletionOr<void>(String const&, String const&)>;
     JS::ThrowCompletionOr<void> for_each(ForEachCallback);

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -313,17 +313,17 @@ Optional<MimeSniff::MimeType> XMLHttpRequest::extract_mime_type(Fetch::HeaderLis
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 static XMLHttpRequest::BodyWithType extract_body(XMLHttpRequestBodyInit const& body)
 {
-    if (body.has<NonnullRefPtr<URL::URLSearchParams>>()) {
-        return {
-            body.get<NonnullRefPtr<URL::URLSearchParams>>()->to_string().to_byte_buffer(),
-            "application/x-www-form-urlencoded;charset=UTF-8"
-        };
-    }
-    VERIFY(body.has<String>());
-    return {
-        body.get<String>().to_byte_buffer(),
-        "text/plain;charset=UTF-8"
-    };
+    XMLHttpRequest::BodyWithType body_with_type {};
+    body.visit(
+        [&](NonnullRefPtr<URL::URLSearchParams> const& url_search_params) {
+            body_with_type.body = url_search_params->to_string().to_byte_buffer();
+            body_with_type.type = "application/x-www-form-urlencoded;charset=UTF-8";
+        },
+        [&](String const& string) {
+            body_with_type.body = string.to_byte_buffer();
+            body_with_type.type = "text/plain;charset=UTF-8";
+        });
+    return body_with_type;
 }
 
 // https://xhr.spec.whatwg.org/#dom-xmlhttprequest-setrequestheader

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -310,7 +310,8 @@ Optional<MimeSniff::MimeType> XMLHttpRequest::extract_mime_type(Fetch::HeaderLis
     return mime_type;
 }
 
-static XMLHttpRequest::BodyWithType safely_extract_body(XMLHttpRequestBodyInit& body)
+// https://fetch.spec.whatwg.org/#concept-bodyinit-extract
+static XMLHttpRequest::BodyWithType extract_body(XMLHttpRequestBodyInit& body)
 {
     if (body.has<NonnullRefPtr<URL::URLSearchParams>>()) {
         return {
@@ -464,7 +465,7 @@ DOM::ExceptionOr<void> XMLHttpRequest::send(Optional<XMLHttpRequestBodyInit> bod
     if (m_method.is_one_of("GET"sv, "HEAD"sv))
         body = {};
 
-    auto body_with_type = body.has_value() ? safely_extract_body(body.value()) : XMLHttpRequest::BodyWithType {};
+    auto body_with_type = body.has_value() ? extract_body(body.value()) : XMLHttpRequest::BodyWithType {};
 
     AK::URL request_url = m_window->associated_document().parse_url(m_url.to_string());
     dbgln("XHR send from {} to {}", m_window->associated_document().url(), request_url);

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -311,7 +311,7 @@ Optional<MimeSniff::MimeType> XMLHttpRequest::extract_mime_type(Fetch::HeaderLis
 }
 
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
-static XMLHttpRequest::BodyWithType extract_body(XMLHttpRequestBodyInit& body)
+static XMLHttpRequest::BodyWithType extract_body(XMLHttpRequestBodyInit const& body)
 {
     if (body.has<NonnullRefPtr<URL::URLSearchParams>>()) {
         return {

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -38,11 +38,6 @@ public:
         Done = 4,
     };
 
-    struct BodyWithType {
-        ByteBuffer body;
-        String type;
-    };
-
     using WrapperType = Bindings::XMLHttpRequestWrapper;
 
     static NonnullRefPtr<XMLHttpRequest> create(HTML::Window& window)

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -23,7 +23,7 @@
 
 namespace Web::XHR {
 
-using XMLHttpRequestBodyInit = Variant<NonnullRefPtr<URL::URLSearchParams>, String>;
+using XMLHttpRequestBodyInit = Variant<NonnullRefPtr<FileAPI::Blob>, NonnullRefPtr<URL::URLSearchParams>, String>;
 
 class XMLHttpRequest final
     : public RefCounted<XMLHttpRequest>

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
@@ -1,8 +1,9 @@
 #import <XHR/XMLHttpRequestEventTarget.idl>
 #import <DOM/EventHandler.idl>
+#import <FileAPI/Blob.idl>
 #import <URL/URLSearchParams.idl>
 
-typedef (URLSearchParams or USVString) XMLHttpRequestBodyInit;
+typedef (Blob or URLSearchParams or USVString) XMLHttpRequestBodyInit;
 
 enum XMLHttpRequestResponseType {
   "",


### PR DESCRIPTION
This PR includes some spec compliance work for the `extract_body()` operation, also renames it from `safely_extract_body()` (NOTE: The `safely_extract_body()` operation relies on `ReadableStream` from the streams specification). Rewrites `extract_body()` to use `Variant::visit()`.

Marking `URLSearchParams::to_string()` as const, which then lets us mark the body parameter of `extract_body()` as const reference + same for all the parameters of the lambda expression in `body.visit()`.

And lastly adds blob as a part of the union type `XMLHttpRequestBodyInit` + implementation in `XHR::send()`.

