### PR TITLE
Kernel+Userland: Add /sys/devices/graphics/adapters directory, add lsgpu utility

### DIFF
--- a/Kernel/Bus/PCI/API.cpp
+++ b/Kernel/Bus/PCI/API.cpp
@@ -22,6 +22,16 @@ ErrorOr<void> enumerate(Function<void(DeviceIdentifier const&)> callback)
     return Access::the().fast_enumerate(callback);
 }
 
+ErrorOr<void> enumerate_locked(Function<void(DeviceIdentifier&)> callback)
+{
+    return Access::the().enumerate_locked(callback);
+}
+
+RefPtr<PCIDeviceSysFSDirectory> get_sysfs_pci_device_directory(Address address)
+{
+    return Access::the().get_sysfs_pci_device_directory(address);
+}
+
 DeviceIdentifier get_device_identifier(Address address)
 {
     return Access::the().get_device_identifier(address);

--- a/Kernel/Bus/PCI/API.h
+++ b/Kernel/Bus/PCI/API.h
@@ -22,6 +22,7 @@ u32 read32(Address address, PCI::RegisterOffset field);
 HardwareID get_hardware_id(PCI::Address);
 bool is_io_space_enabled(Address);
 ErrorOr<void> enumerate(Function<void(DeviceIdentifier const&)> callback);
+ErrorOr<void> enumerate_locked(Function<void(DeviceIdentifier&)> callback);
 void enable_interrupt_line(Address);
 void disable_interrupt_line(Address);
 void raw_access(Address, u32, size_t, u32);
@@ -40,5 +41,7 @@ void disable_io_space(Address);
 void enable_memory_space(Address);
 void disable_memory_space(Address);
 DeviceIdentifier get_device_identifier(Address address);
+
+RefPtr<PCIDeviceSysFSDirectory> get_sysfs_pci_device_directory(Address address);
 
 }

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -174,6 +174,29 @@ UNMAP_AFTER_INIT void Access::rescan_hardware()
     }
 }
 
+RefPtr<PCIDeviceSysFSDirectory> Access::get_sysfs_pci_device_directory(Address address)
+{
+    SpinlockLocker locker(m_access_lock);
+    VERIFY(!m_device_identifiers.is_empty());
+
+    for (auto& device_identifier : m_device_identifiers) {
+        if (device_identifier.address() == address)
+            return device_identifier.sysfs_pci_device_directory();
+    }
+    return {};
+}
+
+ErrorOr<void> Access::enumerate_locked(Function<void(DeviceIdentifier&)>& callback)
+{
+    SpinlockLocker locker(m_access_lock);
+    VERIFY(!m_device_identifiers.is_empty());
+
+    for (auto& device_identifier : m_device_identifiers) {
+        callback(device_identifier);
+    }
+    return {};
+}
+
 ErrorOr<void> Access::fast_enumerate(Function<void(DeviceIdentifier const&)>& callback) const
 {
     // Note: We hold the m_access_lock for a brief moment just to ensure we get

--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -23,6 +23,10 @@ public:
     static bool initialize_for_one_pci_domain();
 
     ErrorOr<void> fast_enumerate(Function<void(DeviceIdentifier const&)>&) const;
+    ErrorOr<void> enumerate_locked(Function<void(DeviceIdentifier&)>&);
+
+    RefPtr<PCIDeviceSysFSDirectory> get_sysfs_pci_device_directory(Address address);
+
     void rescan_hardware();
 
     static Access& the();

--- a/Kernel/Bus/PCI/Address.h
+++ b/Kernel/Bus/PCI/Address.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/Try.h>
+#include <Kernel/Bus/PCI/Definitions.h>
+
+namespace Kernel::PCI {
+
+struct Address {
+public:
+    Address() = default;
+    Address(u32 domain)
+        : m_domain(domain)
+        , m_bus(0)
+        , m_device(0)
+        , m_function(0)
+    {
+    }
+    Address(u32 domain, u8 bus, u8 device, u8 function)
+        : m_domain(domain)
+        , m_bus(bus)
+        , m_device(device)
+        , m_function(function)
+    {
+    }
+
+    Address(Address const& address) = default;
+
+    bool is_null() const { return !m_bus && !m_device && !m_function; }
+    operator bool() const { return !is_null(); }
+
+    // Disable default implementations that would use surprising integer promotion.
+    bool operator<=(Address const&) const = delete;
+    bool operator>=(Address const&) const = delete;
+    bool operator<(Address const&) const = delete;
+    bool operator>(Address const&) const = delete;
+
+    bool operator==(Address const& other) const
+    {
+        if (this == &other)
+            return true;
+        return m_domain == other.m_domain && m_bus == other.m_bus && m_device == other.m_device && m_function == other.m_function;
+    }
+    bool operator!=(Address const& other) const
+    {
+        return !(*this == other);
+    }
+
+    u32 domain() const { return m_domain; }
+    u8 bus() const { return m_bus; }
+    u8 device() const { return m_device; }
+    u8 function() const { return m_function; }
+
+private:
+    u32 m_domain { 0 };
+    u8 m_bus { 0 };
+    u8 m_device { 0 };
+    u8 m_function { 0 };
+};
+
+}

--- a/Kernel/Bus/PCI/DeviceIdentifier.cpp
+++ b/Kernel/Bus/PCI/DeviceIdentifier.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/PCI/Definitions.h>
+
+namespace Kernel::PCI {
+
+RefPtr<PCIDeviceSysFSDirectory> DeviceIdentifier::sysfs_pci_device_directory() const
+{
+    return m_pci_device_directory;
+}
+
+void DeviceIdentifier::set_sysfs_pci_device_directory(Badge<PCIBusSysFSDirectory>, PCIDeviceSysFSDirectory const& pci_device_directory)
+{
+    m_pci_device_directory = pci_device_directory;
+}
+
+}

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -156,6 +156,8 @@ set(KERNEL_SOURCES
     FileSystem/SysFS/Subsystems/Devices/Graphics/Directory.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/Directory.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.cpp
+    FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DisplayConnectorsDirectory.cpp
+    FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedGraphicsDeviceComponent.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/Directory.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceDirectory.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -80,6 +80,7 @@ set(KERNEL_SOURCES
     Graphics/Console/ContiguousFramebufferConsole.cpp
     Graphics/Console/VGATextModeConsole.cpp
     Graphics/DisplayConnector.cpp
+    Graphics/GenericGraphicsAdapter.cpp
     Graphics/Generic/DisplayConnector.cpp
     Graphics/GraphicsManagement.cpp
     Graphics/PCIGraphicsAdapter.cpp
@@ -152,6 +153,8 @@ set(KERNEL_SOURCES
     FileSystem/SysFS/Subsystems/Devices/Storage/DeviceDirectory.cpp
     FileSystem/SysFS/Subsystems/Devices/Storage/Directory.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/Directory.cpp
+    FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/Directory.cpp
+    FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/Directory.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceDirectory.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceAttribute.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -25,6 +25,7 @@ set(KERNEL_SOURCES
     Bus/PCI/Access.cpp
     Bus/PCI/API.cpp
     Bus/PCI/Device.cpp
+    Bus/PCI/DeviceIdentifier.cpp
     Bus/PCI/Initializer.cpp
     Bus/USB/UHCI/UHCIController.cpp
     Bus/USB/UHCI/UHCIRootHub.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -156,6 +156,7 @@ set(KERNEL_SOURCES
     FileSystem/SysFS/Subsystems/Devices/Graphics/Directory.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/Directory.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.cpp
+    FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedGraphicsDeviceComponent.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/Directory.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceDirectory.cpp
     FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceAttribute.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -82,6 +82,7 @@ set(KERNEL_SOURCES
     Graphics/DisplayConnector.cpp
     Graphics/Generic/DisplayConnector.cpp
     Graphics/GraphicsManagement.cpp
+    Graphics/PCIGraphicsAdapter.cpp
     Graphics/Intel/NativeDisplayConnector.cpp
     Graphics/Intel/NativeGraphicsAdapter.cpp
     Graphics/VMWare/Console.cpp

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.cpp
@@ -18,11 +18,16 @@ namespace Kernel {
 UNMAP_AFTER_INIT void PCIBusSysFSDirectory::initialize()
 {
     auto pci_directory = adopt_ref(*new (nothrow) PCIBusSysFSDirectory());
+    pci_directory->enumerate_all_devices_and_add_pci_device_directories();
     SysFSComponentRegistry::the().register_new_bus_directory(pci_directory);
 }
 
 UNMAP_AFTER_INIT PCIBusSysFSDirectory::PCIBusSysFSDirectory()
     : SysFSDirectory(SysFSComponentRegistry::the().buses_directory())
+{
+}
+
+UNMAP_AFTER_INIT void PCIBusSysFSDirectory::enumerate_all_devices_and_add_pci_device_directories()
 {
     MUST(m_child_components.with([&](auto& list) -> ErrorOr<void> {
         MUST(PCI::enumerate_locked([&](PCI::DeviceIdentifier& device_identifier) {

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.h
@@ -16,6 +16,8 @@ public:
     virtual StringView name() const override { return "pci"sv; }
 
 private:
+    void enumerate_all_devices_and_add_pci_device_directories();
+
     PCIBusSysFSDirectory();
 };
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <Kernel/Bus/PCI/Definitions.h>
 #include <Kernel/FileSystem/SysFS/Component.h>
 
 namespace Kernel {

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.cpp
@@ -6,6 +6,7 @@
 
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Access.h>
+#include <Kernel/Bus/PCI/Definitions.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h>

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <Kernel/Bus/PCI/Definitions.h>
+#include <Kernel/Bus/PCI/Address.h>
 #include <Kernel/FileSystem/SysFS/Component.h>
 #include <Kernel/KString.h>
 

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/DeviceComponent.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/DeviceComponent.h
@@ -24,7 +24,7 @@ public:
     bool is_block_device() const { return m_block_device; }
 
 private:
-    SysFSDeviceComponent(NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const&);
+    SysFSDeviceComponent(SysFSDirectory const& parent_directory, NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const&);
     bool m_block_device;
 
     NonnullOwnPtr<KString> m_major_minor_formatted_device_name;

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/PCI/API.h>
+#include <Kernel/Bus/PCI/Access.h>
+#include <Kernel/Debug.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h>
+#include <Kernel/Graphics/DisplayConnector.h>
+#include <Kernel/Sections.h>
+
+namespace Kernel {
+
+UNMAP_AFTER_INIT NonnullRefPtr<GraphicsAdapterSysFSDirectory> GraphicsAdapterSysFSDirectory::create(SysFSDirectory const& parent_directory, u32 adapter_index)
+{
+    // FIXME: Handle allocation failure gracefully
+    auto device_name = MUST(KString::formatted("{}", adapter_index));
+    auto directory = adopt_ref(*new (nothrow) GraphicsAdapterSysFSDirectory(move(device_name), parent_directory));
+    return directory;
+}
+
+UNMAP_AFTER_INIT GraphicsAdapterSysFSDirectory::GraphicsAdapterSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const& parent_directory)
+    : SysFSDirectory(parent_directory)
+    , m_device_directory_name(move(device_directory_name))
+{
+}
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.cpp
@@ -8,6 +8,7 @@
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DisplayConnectorsDirectory.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedGraphicsDeviceComponent.h>
 #include <Kernel/Graphics/DisplayConnector.h>
 #include <Kernel/Sections.h>
@@ -25,9 +26,16 @@ UNMAP_AFTER_INIT NonnullRefPtr<GraphicsAdapterSysFSDirectory> GraphicsAdapterSys
 
     MUST(directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(SysFSSymbolicLinkLinkedGraphicsDeviceComponent::try_create(*directory, *sysfs_pci_device_directory).release_value_but_fixme_should_propagate_errors());
+        directory->m_display_connectors_symlinks_directory = GraphicsAdapterDisplayConnectorsSysFSDirectory::try_create(*directory).release_value_but_fixme_should_propagate_errors();
+        list.append(*directory->m_display_connectors_symlinks_directory);
         return {};
     }));
     return directory;
+}
+
+RefPtr<GraphicsAdapterDisplayConnectorsSysFSDirectory> GraphicsAdapterSysFSDirectory::display_connectors_symlinks_directory() const
+{
+    return m_display_connectors_symlinks_directory;
 }
 
 UNMAP_AFTER_INIT GraphicsAdapterSysFSDirectory::GraphicsAdapterSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const& parent_directory)

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.cpp
@@ -8,16 +8,25 @@
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedGraphicsDeviceComponent.h>
 #include <Kernel/Graphics/DisplayConnector.h>
 #include <Kernel/Sections.h>
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullRefPtr<GraphicsAdapterSysFSDirectory> GraphicsAdapterSysFSDirectory::create(SysFSDirectory const& parent_directory, u32 adapter_index)
+UNMAP_AFTER_INIT NonnullRefPtr<GraphicsAdapterSysFSDirectory> GraphicsAdapterSysFSDirectory::create(SysFSDirectory const& parent_directory, PCI::Address const& linked_device_address, u32 adapter_index)
 {
     // FIXME: Handle allocation failure gracefully
     auto device_name = MUST(KString::formatted("{}", adapter_index));
     auto directory = adopt_ref(*new (nothrow) GraphicsAdapterSysFSDirectory(move(device_name), parent_directory));
+
+    RefPtr<PCIDeviceSysFSDirectory> sysfs_pci_device_directory = PCI::get_sysfs_pci_device_directory(linked_device_address);
+    VERIFY(!sysfs_pci_device_directory.is_null());
+
+    MUST(directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
+        list.append(SysFSSymbolicLinkLinkedGraphicsDeviceComponent::try_create(*directory, *sysfs_pci_device_directory).release_value_but_fixme_should_propagate_errors());
+        return {};
+    }));
     return directory;
 }
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Bus/PCI/Definitions.h>
+#include <Kernel/FileSystem/SysFS/Component.h>
+#include <Kernel/KString.h>
+
+namespace Kernel {
+
+class GraphicsAdapterAttributeSysFSComponent;
+class GraphicsAdapterSysFSDirectory final : public SysFSDirectory {
+public:
+    static NonnullRefPtr<GraphicsAdapterSysFSDirectory> create(SysFSDirectory const& parent_directory, u32 adapter_index);
+
+    virtual StringView name() const override { return m_device_directory_name->view(); }
+
+private:
+    GraphicsAdapterSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const& parent_directory);
+    NonnullOwnPtr<KString> m_device_directory_name;
+};
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h
@@ -8,20 +8,24 @@
 
 #include <Kernel/Bus/PCI/Definitions.h>
 #include <Kernel/FileSystem/SysFS/Component.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DisplayConnectorsDirectory.h>
 #include <Kernel/KString.h>
 
 namespace Kernel {
 
-class GraphicsAdapterAttributeSysFSComponent;
 class GraphicsAdapterSysFSDirectory final : public SysFSDirectory {
 public:
     static NonnullRefPtr<GraphicsAdapterSysFSDirectory> create(SysFSDirectory const& parent_directory, PCI::Address const&, u32 adapter_index);
 
     virtual StringView name() const override { return m_device_directory_name->view(); }
 
+    RefPtr<GraphicsAdapterDisplayConnectorsSysFSDirectory> display_connectors_symlinks_directory() const;
+
 private:
     GraphicsAdapterSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const& parent_directory);
     NonnullOwnPtr<KString> m_device_directory_name;
+
+    RefPtr<GraphicsAdapterDisplayConnectorsSysFSDirectory> m_display_connectors_symlinks_directory;
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h
@@ -15,7 +15,7 @@ namespace Kernel {
 class GraphicsAdapterAttributeSysFSComponent;
 class GraphicsAdapterSysFSDirectory final : public SysFSDirectory {
 public:
-    static NonnullRefPtr<GraphicsAdapterSysFSDirectory> create(SysFSDirectory const& parent_directory, u32 adapter_index);
+    static NonnullRefPtr<GraphicsAdapterSysFSDirectory> create(SysFSDirectory const& parent_directory, PCI::Address const&, u32 adapter_index);
 
     virtual StringView name() const override { return m_device_directory_name->view(); }
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/Directory.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/FileSystem/SysFS/RootDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Directory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/Directory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Directory.h>
+#include <Kernel/Sections.h>
+#include <Kernel/Storage/StorageDevice.h>
+
+namespace Kernel {
+
+static SysFSGraphicsAdaptersDirectory* s_the { nullptr };
+
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSGraphicsAdaptersDirectory> SysFSGraphicsAdaptersDirectory::must_create(SysFSGraphicsDirectory const& parent_directory)
+{
+    auto directory = adopt_ref(*new (nothrow) SysFSGraphicsAdaptersDirectory(parent_directory));
+    s_the = directory;
+    return directory;
+}
+
+SysFSGraphicsAdaptersDirectory& SysFSGraphicsAdaptersDirectory::the()
+{
+    VERIFY(s_the);
+    return *s_the;
+}
+
+void SysFSGraphicsAdaptersDirectory::plug_pci_adapter(Badge<PCIGraphicsAdapter>, GraphicsAdapterSysFSDirectory& new_device_directory)
+{
+    MUST(m_child_components.with([&](auto& list) -> ErrorOr<void> {
+        list.append(new_device_directory);
+        return {};
+    }));
+}
+
+void SysFSGraphicsAdaptersDirectory::unplug_pci_adapter(Badge<PCIGraphicsAdapter>, SysFSDirectory& removed_device_directory)
+{
+    MUST(m_child_components.with([&](auto& list) -> ErrorOr<void> {
+        list.remove(removed_device_directory);
+        return {};
+    }));
+}
+
+void SysFSGraphicsAdaptersDirectory::plug_virtio_adapter(Badge<VirtIOGraphicsAdapter>, GraphicsAdapterSysFSDirectory& new_device_directory)
+{
+    MUST(m_child_components.with([&](auto& list) -> ErrorOr<void> {
+        list.append(new_device_directory);
+        return {};
+    }));
+}
+
+void SysFSGraphicsAdaptersDirectory::unplug_virtio_adapter(Badge<VirtIOGraphicsAdapter>, SysFSDirectory& removed_device_directory)
+{
+    MUST(m_child_components.with([&](auto& list) -> ErrorOr<void> {
+        list.remove(removed_device_directory);
+        return {};
+    }));
+}
+
+UNMAP_AFTER_INIT SysFSGraphicsAdaptersDirectory::SysFSGraphicsAdaptersDirectory(SysFSGraphicsDirectory const& parent_directory)
+    : SysFSDirectory(parent_directory)
+{
+}
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/Directory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/Directory.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/FileSystem/SysFS/Component.h>
+#include <Kernel/Forward.h>
+
+namespace Kernel {
+
+class GraphicsAdapterSysFSDirectory;
+class VirtIOGraphicsAdapter;
+class PCIGraphicsAdapter;
+class SysFSGraphicsDirectory;
+class SysFSGraphicsAdaptersDirectory : public SysFSDirectory {
+    friend class SysFSComponentRegistry;
+
+public:
+    virtual StringView name() const override { return "adapters"sv; }
+    static SysFSGraphicsAdaptersDirectory& the();
+    static NonnullRefPtr<SysFSGraphicsAdaptersDirectory> must_create(SysFSGraphicsDirectory const&);
+
+    void plug_pci_adapter(Badge<PCIGraphicsAdapter>, GraphicsAdapterSysFSDirectory&);
+    void unplug_pci_adapter(Badge<PCIGraphicsAdapter>, SysFSDirectory&);
+
+    // Note: We will need to eventually get rid of these methods once the VirtIO code
+    // uses the right abstractions - inherting from PCIGraphicsAdapter or even better - some
+    // other agnostic Badge (preferably like GenericGraphicsAdapter).
+    void plug_virtio_adapter(Badge<VirtIOGraphicsAdapter>, GraphicsAdapterSysFSDirectory&);
+    void unplug_virtio_adapter(Badge<VirtIOGraphicsAdapter>, SysFSDirectory&);
+
+private:
+    explicit SysFSGraphicsAdaptersDirectory(SysFSGraphicsDirectory const&);
+};
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DisplayConnectorsDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DisplayConnectorsDirectory.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/PCI/API.h>
+#include <Kernel/Bus/PCI/Access.h>
+#include <Kernel/Debug.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DisplayConnectorsDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.h>
+#include <Kernel/Graphics/DisplayConnector.h>
+#include <Kernel/Sections.h>
+
+namespace Kernel {
+
+void GraphicsAdapterDisplayConnectorsSysFSDirectory::plug_symlink_for_device(Badge<GraphicsManagement>, SysFSSymbolicLinkLinkedDisplayConnectorComponent& new_display_connector_symlink)
+{
+    MUST(m_child_components.with([&](auto& list) -> ErrorOr<void> {
+        list.append(new_display_connector_symlink);
+        return {};
+    }));
+}
+void GraphicsAdapterDisplayConnectorsSysFSDirectory::unplug_symlink_for_device(Badge<GraphicsManagement>, SysFSSymbolicLinkLinkedDisplayConnectorComponent& removed_display_connector_symlink)
+{
+    MUST(m_child_components.with([&](auto& list) -> ErrorOr<void> {
+        list.remove(removed_display_connector_symlink);
+        return {};
+    }));
+}
+
+UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<GraphicsAdapterDisplayConnectorsSysFSDirectory>> GraphicsAdapterDisplayConnectorsSysFSDirectory::try_create(SysFSDirectory const& parent_directory)
+{
+    return adopt_nonnull_ref_or_enomem(new (nothrow) GraphicsAdapterDisplayConnectorsSysFSDirectory(parent_directory));
+}
+
+UNMAP_AFTER_INIT GraphicsAdapterDisplayConnectorsSysFSDirectory::GraphicsAdapterDisplayConnectorsSysFSDirectory(SysFSDirectory const& parent_directory)
+    : SysFSDirectory(parent_directory)
+{
+}
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DisplayConnectorsDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DisplayConnectorsDirectory.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/FileSystem/SysFS/Component.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.h>
+#include <Kernel/Graphics/DisplayConnector.h>
+#include <Kernel/KString.h>
+
+namespace Kernel {
+
+class GraphicsManagement;
+class GraphicsAdapterDisplayConnectorsSysFSDirectory final : public SysFSDirectory {
+public:
+    static ErrorOr<NonnullRefPtr<GraphicsAdapterDisplayConnectorsSysFSDirectory>> try_create(SysFSDirectory const&);
+
+    virtual StringView name() const override { return "connectors"sv; }
+
+    void plug_symlink_for_device(Badge<GraphicsManagement>, SysFSSymbolicLinkLinkedDisplayConnectorComponent&);
+    void unplug_symlink_for_device(Badge<GraphicsManagement>, SysFSSymbolicLinkLinkedDisplayConnectorComponent&);
+
+private:
+    explicit GraphicsAdapterDisplayConnectorsSysFSDirectory(SysFSDirectory const&);
+};
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/FileSystem/SysFS/Component.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/Directory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DisplayConnectorsDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.h>
+#include <Kernel/Sections.h>
+
+namespace Kernel {
+
+ErrorOr<NonnullRefPtr<SysFSSymbolicLinkLinkedDisplayConnectorComponent>> SysFSSymbolicLinkLinkedDisplayConnectorComponent::try_create(SysFSDirectory const& parent_directory, MinorNumber display_connector_minor_number, SysFSComponent const& pointed_component)
+{
+    auto node_name = MUST(KString::formatted("{}", display_connector_minor_number.value()));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) SysFSSymbolicLinkLinkedDisplayConnectorComponent(move(node_name), parent_directory, pointed_component));
+}
+
+SysFSSymbolicLinkLinkedDisplayConnectorComponent::SysFSSymbolicLinkLinkedDisplayConnectorComponent(NonnullOwnPtr<KString> node_name, SysFSDirectory const& parent_directory, SysFSComponent const& pointed_component)
+    : SysFSSymbolicLink(parent_directory, pointed_component)
+    , m_symlink_name(move(node_name))
+{
+}
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.cpp
@@ -13,9 +13,9 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullRefPtr<SysFSSymbolicLinkLinkedDisplayConnectorComponent>> SysFSSymbolicLinkLinkedDisplayConnectorComponent::try_create(SysFSDirectory const& parent_directory, MinorNumber display_connector_minor_number, SysFSComponent const& pointed_component)
+ErrorOr<NonnullRefPtr<SysFSSymbolicLinkLinkedDisplayConnectorComponent>> SysFSSymbolicLinkLinkedDisplayConnectorComponent::try_create(SysFSDirectory const& parent_directory, size_t display_connector_index, SysFSComponent const& pointed_component)
 {
-    auto node_name = MUST(KString::formatted("{}", display_connector_minor_number.value()));
+    auto node_name = MUST(KString::formatted("{}", display_connector_index));
     return adopt_nonnull_ref_or_enomem(new (nothrow) SysFSSymbolicLinkLinkedDisplayConnectorComponent(move(node_name), parent_directory, pointed_component));
 }
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.h
@@ -18,7 +18,7 @@ class SysFSSymbolicLinkLinkedDisplayConnectorComponent final
     friend class SysFSComponentRegistry;
 
 public:
-    static ErrorOr<NonnullRefPtr<SysFSSymbolicLinkLinkedDisplayConnectorComponent>> try_create(SysFSDirectory const& parent_directory, MinorNumber display_connector_minor_number, SysFSComponent const& pointed_component);
+    static ErrorOr<NonnullRefPtr<SysFSSymbolicLinkLinkedDisplayConnectorComponent>> try_create(SysFSDirectory const& parent_directory, size_t display_connector_index, SysFSComponent const& pointed_component);
     virtual StringView name() const override { return m_symlink_name->view(); }
 
 private:

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/IntrusiveList.h>
+#include <Kernel/FileSystem/SysFS/Component.h>
+#include <Kernel/KString.h>
+
+namespace Kernel {
+
+class SysFSSymbolicLinkLinkedDisplayConnectorComponent final
+    : public SysFSSymbolicLink
+    , public Weakable<SysFSSymbolicLinkLinkedDisplayConnectorComponent> {
+    friend class SysFSComponentRegistry;
+
+public:
+    static ErrorOr<NonnullRefPtr<SysFSSymbolicLinkLinkedDisplayConnectorComponent>> try_create(SysFSDirectory const& parent_directory, MinorNumber display_connector_minor_number, SysFSComponent const& pointed_component);
+    virtual StringView name() const override { return m_symlink_name->view(); }
+
+private:
+    SysFSSymbolicLinkLinkedDisplayConnectorComponent(NonnullOwnPtr<KString>, SysFSDirectory const& parent_directory, SysFSComponent const& pointed_component);
+    NonnullOwnPtr<KString> m_symlink_name;
+};
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedGraphicsDeviceComponent.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedGraphicsDeviceComponent.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/FileSystem/SysFS/Component.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/Directory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedGraphicsDeviceComponent.h>
+#include <Kernel/Sections.h>
+
+namespace Kernel {
+
+ErrorOr<NonnullRefPtr<SysFSSymbolicLinkLinkedGraphicsDeviceComponent>> SysFSSymbolicLinkLinkedGraphicsDeviceComponent::try_create(GraphicsAdapterSysFSDirectory const& parent_directory, SysFSComponent const& pointed_component)
+{
+    return adopt_nonnull_ref_or_enomem(new (nothrow) SysFSSymbolicLinkLinkedGraphicsDeviceComponent(parent_directory, pointed_component));
+}
+
+SysFSSymbolicLinkLinkedGraphicsDeviceComponent::SysFSSymbolicLinkLinkedGraphicsDeviceComponent(GraphicsAdapterSysFSDirectory const& parent_directory, SysFSComponent const& pointed_component)
+    : SysFSSymbolicLink(parent_directory, pointed_component)
+{
+}
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedGraphicsDeviceComponent.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedGraphicsDeviceComponent.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/IntrusiveList.h>
+#include <Kernel/FileSystem/SysFS/Component.h>
+#include <Kernel/KString.h>
+
+namespace Kernel {
+
+class GraphicsAdapterSysFSDirectory;
+class SysFSSymbolicLinkLinkedGraphicsDeviceComponent final
+    : public SysFSSymbolicLink
+    , public Weakable<SysFSSymbolicLinkLinkedGraphicsDeviceComponent> {
+    friend class SysFSComponentRegistry;
+
+public:
+    static ErrorOr<NonnullRefPtr<SysFSSymbolicLinkLinkedGraphicsDeviceComponent>> try_create(GraphicsAdapterSysFSDirectory const& parent_directory, SysFSComponent const& pointed_component);
+    virtual StringView name() const override { return "linked_device"sv; }
+
+private:
+    SysFSSymbolicLinkLinkedGraphicsDeviceComponent(GraphicsAdapterSysFSDirectory const& parent_directory, SysFSComponent const& pointed_component);
+};
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Directory.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/Directory.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Directory.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/Directory.h>
 #include <Kernel/Sections.h>
@@ -15,6 +16,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<SysFSGraphicsDirectory> SysFSGraphicsDirectory::m
     auto directory = adopt_ref(*new (nothrow) SysFSGraphicsDirectory(parent_directory));
     MUST(directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(SysFSDisplayConnectorsDirectory::must_create(*directory));
+        list.append(SysFSGraphicsAdaptersDirectory::must_create(*directory));
         return {};
     }));
     return directory;

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -56,6 +56,8 @@ class SysFS;
 class SysFSDirectory;
 class SysFSRootDirectory;
 class SysFSBusDirectory;
+class PCIDeviceSysFSDirectory;
+class PCIBusSysFSDirectory;
 class SysFSDevicesDirectory;
 class SysFSDirectoryInode;
 class SysFSInode;

--- a/Kernel/Graphics/Bochs/DisplayConnector.cpp
+++ b/Kernel/Graphics/Bochs/DisplayConnector.cpp
@@ -14,9 +14,9 @@
 
 namespace Kernel {
 
-NonnullRefPtr<BochsDisplayConnector> BochsDisplayConnector::must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool virtual_box_hardware)
+NonnullRefPtr<BochsDisplayConnector> BochsDisplayConnector::must_create(BochsGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool virtual_box_hardware)
 {
-    auto device_or_error = DeviceManagement::try_create_device<BochsDisplayConnector>(framebuffer_address, framebuffer_resource_size);
+    auto device_or_error = DeviceManagement::try_create_device<BochsDisplayConnector>(parent_adapter, framebuffer_address, framebuffer_resource_size);
     VERIFY(!device_or_error.is_error());
     auto connector = device_or_error.release_value();
     MUST(connector->create_attached_framebuffer_console());
@@ -27,8 +27,9 @@ NonnullRefPtr<BochsDisplayConnector> BochsDisplayConnector::must_create(Physical
     return connector;
 }
 
-BochsDisplayConnector::BochsDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
+BochsDisplayConnector::BochsDisplayConnector(BochsGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
     : DisplayConnector(framebuffer_address, framebuffer_resource_size, false)
+    , m_parent_adapter(parent_adapter)
 {
 }
 

--- a/Kernel/Graphics/Bochs/DisplayConnector.cpp
+++ b/Kernel/Graphics/Bochs/DisplayConnector.cpp
@@ -28,7 +28,7 @@ NonnullRefPtr<BochsDisplayConnector> BochsDisplayConnector::must_create(BochsGra
 }
 
 BochsDisplayConnector::BochsDisplayConnector(BochsGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
-    : DisplayConnector(framebuffer_address, framebuffer_resource_size, false)
+    : DisplayConnector(0, framebuffer_address, framebuffer_resource_size, false)
     , m_parent_adapter(parent_adapter)
 {
 }

--- a/Kernel/Graphics/Bochs/DisplayConnector.h
+++ b/Kernel/Graphics/Bochs/DisplayConnector.h
@@ -9,6 +9,7 @@
 #include <AK/RefPtr.h>
 #include <AK/Try.h>
 #include <Kernel/Graphics/Bochs/Definitions.h>
+#include <Kernel/Graphics/Bochs/GraphicsAdapter.h>
 #include <Kernel/Graphics/Console/GenericFramebufferConsole.h>
 #include <Kernel/Graphics/DisplayConnector.h>
 #include <Kernel/Locking/Spinlock.h>
@@ -16,6 +17,7 @@
 
 namespace Kernel {
 
+class BochsGraphicsAdapter;
 class BochsDisplayConnector
     : public DisplayConnector {
     friend class BochsGraphicsAdapter;
@@ -24,14 +26,16 @@ class BochsDisplayConnector
 public:
     AK_TYPEDEF_DISTINCT_ORDERED_ID(u16, IndexID);
 
-    static NonnullRefPtr<BochsDisplayConnector> must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool virtual_box_hardware);
+    static NonnullRefPtr<BochsDisplayConnector> must_create(BochsGraphicsAdapter const&, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool virtual_box_hardware);
 
     virtual IndexID index_id() const;
 
 protected:
     ErrorOr<void> create_attached_framebuffer_console();
 
-    BochsDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size);
+    BochsDisplayConnector(BochsGraphicsAdapter const&, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size);
+
+    virtual RefPtr<GenericGraphicsAdapter> parent_graphics_adapter() const override { return m_parent_adapter; }
 
     virtual bool mutable_mode_setting_capable() const override final { return true; }
     virtual bool double_framebuffering_capable() const override { return false; }
@@ -51,5 +55,6 @@ protected:
     virtual void disable_console() override final;
 
     RefPtr<Graphics::GenericFramebufferConsole> m_framebuffer_console;
+    NonnullRefPtr<BochsGraphicsAdapter> m_parent_adapter;
 };
 }

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -32,7 +32,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<BochsGraphicsAdapter> BochsGraphicsAdapter::initi
 }
 
 UNMAP_AFTER_INIT BochsGraphicsAdapter::BochsGraphicsAdapter(PCI::DeviceIdentifier const& pci_device_identifier)
-    : PCI::Device(pci_device_identifier.address())
+    : PCIGraphicsAdapter(pci_device_identifier)
 {
 }
 

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -44,11 +44,11 @@ UNMAP_AFTER_INIT ErrorOr<void> BochsGraphicsAdapter::initialize_adapter(PCI::Dev
     bool virtual_box_hardware = (pci_device_identifier.hardware_id().vendor_id == 0x80ee && pci_device_identifier.hardware_id().device_id == 0xbeef);
     auto bar0_space_size = PCI::get_BAR_space_size(pci_device_identifier.address(), 0);
     if (pci_device_identifier.revision_id().value() == 0x0 || virtual_box_hardware) {
-        m_display_connector = BochsDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), bar0_space_size, virtual_box_hardware);
+        m_display_connector = BochsDisplayConnector::must_create(*this, PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), bar0_space_size, virtual_box_hardware);
     } else {
         auto registers_mapping = TRY(Memory::map_typed_writable<BochsDisplayMMIORegisters volatile>(PhysicalAddress(PCI::get_BAR2(pci_device_identifier.address()) & 0xfffffff0)));
         VERIFY(registers_mapping.region);
-        m_display_connector = QEMUDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), bar0_space_size, move(registers_mapping));
+        m_display_connector = QEMUDisplayConnector::must_create(*this, PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), bar0_space_size, move(registers_mapping));
     }
 
     // Note: According to Gerd Hoffmann - "The linux driver simply does

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -7,10 +7,10 @@
 #pragma once
 
 #include <AK/Types.h>
-#include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Graphics/Bochs/Definitions.h>
 #include <Kernel/Graphics/Console/GenericFramebufferConsole.h>
 #include <Kernel/Graphics/GenericGraphicsAdapter.h>
+#include <Kernel/Graphics/PCIGraphicsAdapter.h>
 #include <Kernel/Memory/TypedMapping.h>
 #include <Kernel/PhysicalAddress.h>
 
@@ -20,8 +20,7 @@ class GraphicsManagement;
 struct BochsDisplayMMIORegisters;
 
 class BochsDisplayConnector;
-class BochsGraphicsAdapter final : public GenericGraphicsAdapter
-    , public PCI::Device {
+class BochsGraphicsAdapter final : public PCIGraphicsAdapter {
     friend class GraphicsManagement;
 
 public:

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -24,14 +24,18 @@ class BochsGraphicsAdapter final : public PCIGraphicsAdapter {
     friend class GraphicsManagement;
 
 public:
-    static NonnullRefPtr<BochsGraphicsAdapter> initialize(PCI::DeviceIdentifier const&);
+    static NonnullRefPtr<BochsGraphicsAdapter> create_instance(PCI::DeviceIdentifier const&);
     virtual ~BochsGraphicsAdapter() = default;
 
 private:
-    ErrorOr<void> initialize_adapter(PCI::DeviceIdentifier const&);
+    virtual ErrorOr<void> initialize_after_sysfs_directory_creation() override;
+
+    ErrorOr<void> initialize_adapter();
 
     explicit BochsGraphicsAdapter(PCI::DeviceIdentifier const&);
 
+    bool const bochs_hardware { false };
+    bool const virtual_box_hardware { false };
     RefPtr<BochsDisplayConnector> m_display_connector;
 };
 }

--- a/Kernel/Graphics/Bochs/QEMUDisplayConnector.cpp
+++ b/Kernel/Graphics/Bochs/QEMUDisplayConnector.cpp
@@ -12,9 +12,9 @@
 
 namespace Kernel {
 
-NonnullRefPtr<QEMUDisplayConnector> QEMUDisplayConnector::must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile> registers_mapping)
+NonnullRefPtr<QEMUDisplayConnector> QEMUDisplayConnector::must_create(BochsGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile> registers_mapping)
 {
-    auto device_or_error = DeviceManagement::try_create_device<QEMUDisplayConnector>(framebuffer_address, framebuffer_resource_size, move(registers_mapping));
+    auto device_or_error = DeviceManagement::try_create_device<QEMUDisplayConnector>(parent_adapter, framebuffer_address, framebuffer_resource_size, move(registers_mapping));
     VERIFY(!device_or_error.is_error());
     auto connector = device_or_error.release_value();
     MUST(connector->create_attached_framebuffer_console());
@@ -31,8 +31,8 @@ ErrorOr<void> QEMUDisplayConnector::fetch_and_initialize_edid()
     return {};
 }
 
-QEMUDisplayConnector::QEMUDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile> registers_mapping)
-    : BochsDisplayConnector(framebuffer_address, framebuffer_resource_size)
+QEMUDisplayConnector::QEMUDisplayConnector(BochsGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile> registers_mapping)
+    : BochsDisplayConnector(parent_adapter, framebuffer_address, framebuffer_resource_size)
     , m_registers(move(registers_mapping))
 {
 }

--- a/Kernel/Graphics/Bochs/QEMUDisplayConnector.h
+++ b/Kernel/Graphics/Bochs/QEMUDisplayConnector.h
@@ -22,13 +22,13 @@ class QEMUDisplayConnector final
     friend class DeviceManagement;
 
 public:
-    static NonnullRefPtr<QEMUDisplayConnector> must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile>);
+    static NonnullRefPtr<QEMUDisplayConnector> must_create(BochsGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile>);
 
     virtual IndexID index_id() const override;
 
 private:
     ErrorOr<void> fetch_and_initialize_edid();
-    QEMUDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile>);
+    QEMUDisplayConnector(BochsGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile>);
 
     virtual bool double_framebuffering_capable() const override { return true; }
     virtual ErrorOr<void> set_mode_setting(ModeSetting const&) override;

--- a/Kernel/Graphics/DisplayConnector.cpp
+++ b/Kernel/Graphics/DisplayConnector.cpp
@@ -94,6 +94,13 @@ void DisplayConnector::after_inserting()
     m_framebuffer_data = m_framebuffer_region->vaddr().as_ptr();
     m_fake_writes_framebuffer_region = MUST(MM.allocate_kernel_region_with_vmobject(m_shared_framebuffer_vmobject->fake_writes_framebuffer_vmobject(), rounded_size, "Fake Writes Framebuffer"sv, Memory::Region::Access::ReadWrite));
 
+    if (parent_graphics_adapter()) {
+        auto graphics_adapter_display_connector_symlinks_sysfs_directory = parent_graphics_adapter()->graphics_adapter_display_connector_symlinks_sysfs_directory();
+        VERIFY(graphics_adapter_display_connector_symlinks_sysfs_directory);
+        auto symlink_linked_display_connector_component = MUST(SysFSSymbolicLinkLinkedDisplayConnectorComponent::try_create(*graphics_adapter_display_connector_symlinks_sysfs_directory, minor(), *m_symlink_sysfs_component));
+        m_symlink_linked_display_connector_component = symlink_linked_display_connector_component;
+    }
+
     GraphicsManagement::the().attach_new_display_connector({}, *this);
     if (m_enable_write_combine_optimization) {
         [[maybe_unused]] auto result = m_framebuffer_region->set_write_combine(true);

--- a/Kernel/Graphics/DisplayConnector.cpp
+++ b/Kernel/Graphics/DisplayConnector.cpp
@@ -14,21 +14,23 @@
 
 namespace Kernel {
 
-DisplayConnector::DisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool enable_write_combine_optimization)
+DisplayConnector::DisplayConnector(size_t relative_display_connector_index, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool enable_write_combine_optimization)
     : CharacterDevice(226, GraphicsManagement::the().allocate_minor_device_number())
     , m_enable_write_combine_optimization(enable_write_combine_optimization)
     , m_framebuffer_at_arbitrary_physical_range(false)
     , m_framebuffer_address(framebuffer_address)
     , m_framebuffer_resource_size(framebuffer_resource_size)
+    , m_relative_display_connector_index(relative_display_connector_index)
 {
 }
 
-DisplayConnector::DisplayConnector(size_t framebuffer_resource_size, bool enable_write_combine_optimization)
+DisplayConnector::DisplayConnector(size_t relative_display_connector_index, size_t framebuffer_resource_size, bool enable_write_combine_optimization)
     : CharacterDevice(226, GraphicsManagement::the().allocate_minor_device_number())
     , m_enable_write_combine_optimization(enable_write_combine_optimization)
     , m_framebuffer_at_arbitrary_physical_range(true)
     , m_framebuffer_address({})
     , m_framebuffer_resource_size(framebuffer_resource_size)
+    , m_relative_display_connector_index(relative_display_connector_index)
 {
 }
 
@@ -97,7 +99,7 @@ void DisplayConnector::after_inserting()
     if (parent_graphics_adapter()) {
         auto graphics_adapter_display_connector_symlinks_sysfs_directory = parent_graphics_adapter()->graphics_adapter_display_connector_symlinks_sysfs_directory();
         VERIFY(graphics_adapter_display_connector_symlinks_sysfs_directory);
-        auto symlink_linked_display_connector_component = MUST(SysFSSymbolicLinkLinkedDisplayConnectorComponent::try_create(*graphics_adapter_display_connector_symlinks_sysfs_directory, minor(), *m_symlink_sysfs_component));
+        auto symlink_linked_display_connector_component = MUST(SysFSSymbolicLinkLinkedDisplayConnectorComponent::try_create(*graphics_adapter_display_connector_symlinks_sysfs_directory, m_relative_display_connector_index, *m_symlink_sysfs_component));
         m_symlink_linked_display_connector_component = symlink_linked_display_connector_component;
     }
 

--- a/Kernel/Graphics/DisplayConnector.h
+++ b/Kernel/Graphics/DisplayConnector.h
@@ -8,6 +8,7 @@
 
 #include <AK/Types.h>
 #include <Kernel/Devices/CharacterDevice.h>
+#include <Kernel/Graphics/GenericGraphicsAdapter.h>
 #include <Kernel/Memory/SharedFramebufferVMObject.h>
 #include <LibC/sys/ioctl_numbers.h>
 #include <LibEDID/EDID.h>
@@ -101,6 +102,8 @@ public:
     void set_display_mode(Badge<GraphicsManagement>, DisplayMode);
 
     Memory::Region const& framebuffer_region() const { return *m_framebuffer_region; }
+
+    virtual RefPtr<GenericGraphicsAdapter> parent_graphics_adapter() const = 0;
 
 protected:
     void set_edid_bytes(Array<u8, 128> const& edid_bytes);

--- a/Kernel/Graphics/DisplayConnector.h
+++ b/Kernel/Graphics/DisplayConnector.h
@@ -8,7 +8,7 @@
 
 #include <AK/Types.h>
 #include <Kernel/Devices/CharacterDevice.h>
-#include <Kernel/Graphics/GenericGraphicsAdapter.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/SymbolicLinkLinkedDisplayConnectorComponent.h>
 #include <Kernel/Memory/SharedFramebufferVMObject.h>
 #include <LibC/sys/ioctl_numbers.h>
 #include <LibEDID/EDID.h>
@@ -16,6 +16,7 @@
 namespace Kernel {
 
 class GraphicsManagement;
+class GenericGraphicsAdapter;
 class DisplayConnector : public CharacterDevice {
     friend class GraphicsManagement;
     friend class DeviceManagement;
@@ -171,5 +172,7 @@ private:
     Spinlock m_responsible_process_lock;
 
     IntrusiveListNode<DisplayConnector, RefPtr<DisplayConnector>> m_list_node;
+
+    RefPtr<SysFSSymbolicLinkLinkedDisplayConnectorComponent> m_symlink_linked_display_connector_component;
 };
 }

--- a/Kernel/Graphics/DisplayConnector.h
+++ b/Kernel/Graphics/DisplayConnector.h
@@ -109,8 +109,8 @@ public:
 protected:
     void set_edid_bytes(Array<u8, 128> const& edid_bytes);
 
-    DisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool enable_write_combine_optimization);
-    DisplayConnector(size_t framebuffer_resource_size, bool enable_write_combine_optimization);
+    DisplayConnector(size_t relative_display_connector_index, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool enable_write_combine_optimization);
+    DisplayConnector(size_t relative_display_connector_index, size_t framebuffer_resource_size, bool enable_write_combine_optimization);
     virtual void enable_console() = 0;
     virtual void disable_console() = 0;
     virtual ErrorOr<void> flush_first_surface() = 0;
@@ -174,5 +174,9 @@ private:
     IntrusiveListNode<DisplayConnector, RefPtr<DisplayConnector>> m_list_node;
 
     RefPtr<SysFSSymbolicLinkLinkedDisplayConnectorComponent> m_symlink_linked_display_connector_component;
+
+    // Note: This number is relative to a Graphics adapter, so even if the major number is for example 2,
+    // but this is the first "port" on a graphics card, the index here is 0.
+    const size_t m_relative_display_connector_index { 0 };
 };
 }

--- a/Kernel/Graphics/Generic/DisplayConnector.cpp
+++ b/Kernel/Graphics/Generic/DisplayConnector.cpp
@@ -24,7 +24,7 @@ NonnullRefPtr<GenericDisplayConnector> GenericDisplayConnector::must_create_with
 }
 
 GenericDisplayConnector::GenericDisplayConnector(PhysicalAddress framebuffer_address, size_t width, size_t height, size_t pitch)
-    : DisplayConnector(framebuffer_address, height * pitch, true)
+    : DisplayConnector(0, framebuffer_address, height * pitch, true)
 {
     m_current_mode_setting.horizontal_active = width;
     m_current_mode_setting.vertical_active = height;

--- a/Kernel/Graphics/Generic/DisplayConnector.h
+++ b/Kernel/Graphics/Generic/DisplayConnector.h
@@ -23,6 +23,10 @@ public:
     static NonnullRefPtr<GenericDisplayConnector> must_create_with_preset_resolution(PhysicalAddress framebuffer_address, size_t width, size_t height, size_t pitch);
 
 protected:
+    // Note: A GenericDisplayConnector is technically attached to some sort of video hardware,
+    // We might be not supporting it and we definitely don't know which is it, therefore we can't return the parent device.
+    virtual RefPtr<GenericGraphicsAdapter> parent_graphics_adapter() const override { return {}; }
+
     ErrorOr<void> create_attached_framebuffer_console();
 
     GenericDisplayConnector(PhysicalAddress framebuffer_address, size_t width, size_t height, size_t pitch);

--- a/Kernel/Graphics/GenericGraphicsAdapter.cpp
+++ b/Kernel/Graphics/GenericGraphicsAdapter.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Graphics/GenericGraphicsAdapter.h>
+#include <Kernel/Graphics/GraphicsManagement.h>
+
+namespace Kernel {
+
+GenericGraphicsAdapter::GenericGraphicsAdapter()
+    : m_adapter_id(GraphicsManagement::generate_adapter_id())
+{
+}
+
+}

--- a/Kernel/Graphics/GenericGraphicsAdapter.cpp
+++ b/Kernel/Graphics/GenericGraphicsAdapter.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DisplayConnectorsDirectory.h>
 #include <Kernel/Graphics/GenericGraphicsAdapter.h>
 #include <Kernel/Graphics/GraphicsManagement.h>
 
@@ -12,6 +13,12 @@ namespace Kernel {
 GenericGraphicsAdapter::GenericGraphicsAdapter()
     : m_adapter_id(GraphicsManagement::generate_adapter_id())
 {
+}
+
+RefPtr<GraphicsAdapterDisplayConnectorsSysFSDirectory> GenericGraphicsAdapter::graphics_adapter_display_connector_symlinks_sysfs_directory() const
+{
+    VERIFY(m_sysfs_directory);
+    return m_sysfs_directory->display_connectors_symlinks_directory();
 }
 
 }

--- a/Kernel/Graphics/GenericGraphicsAdapter.h
+++ b/Kernel/Graphics/GenericGraphicsAdapter.h
@@ -10,17 +10,30 @@
 #include <AK/Weakable.h>
 #include <Kernel/Bus/PCI/Definitions.h>
 #include <Kernel/Devices/BlockDevice.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h>
 #include <Kernel/PhysicalAddress.h>
 
 namespace Kernel {
 class GenericGraphicsAdapter
     : public RefCounted<GenericGraphicsAdapter>
     , public Weakable<GenericGraphicsAdapter> {
+    friend class GraphicsManagement;
+
 public:
     virtual ~GenericGraphicsAdapter() = default;
 
+    virtual ErrorOr<void> initialize_after_sysfs_directory_creation() = 0;
+
+    u32 adapter_id() const { return m_adapter_id; }
+
 protected:
-    GenericGraphicsAdapter() = default;
+    GenericGraphicsAdapter();
+
+    virtual void after_inserting() = 0;
+    RefPtr<GraphicsAdapterSysFSDirectory> m_sysfs_directory;
+
+private:
+    u32 const m_adapter_id { 0 };
 };
 
 }

--- a/Kernel/Graphics/GenericGraphicsAdapter.h
+++ b/Kernel/Graphics/GenericGraphicsAdapter.h
@@ -11,9 +11,11 @@
 #include <Kernel/Bus/PCI/Definitions.h>
 #include <Kernel/Devices/BlockDevice.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DisplayConnectorsDirectory.h>
 #include <Kernel/PhysicalAddress.h>
 
 namespace Kernel {
+class GraphicsAdapterDisplayConnectorsSysFSDirectory;
 class GenericGraphicsAdapter
     : public RefCounted<GenericGraphicsAdapter>
     , public Weakable<GenericGraphicsAdapter> {
@@ -26,6 +28,8 @@ public:
 
     u32 adapter_id() const { return m_adapter_id; }
 
+    RefPtr<GraphicsAdapterDisplayConnectorsSysFSDirectory> graphics_adapter_display_connector_symlinks_sysfs_directory() const;
+
 protected:
     GenericGraphicsAdapter();
 
@@ -33,6 +37,9 @@ protected:
     RefPtr<GraphicsAdapterSysFSDirectory> m_sysfs_directory;
 
 private:
+    void after_inserting_display_connector_create_sysfs_symlink(DisplayConnector const&);
+    void before_destroying_display_connector_remove_sysfs_symlink(DisplayConnector const&);
+
     u32 const m_adapter_id { 0 };
 };
 

--- a/Kernel/Graphics/GraphicsManagement.h
+++ b/Kernel/Graphics/GraphicsManagement.h
@@ -43,6 +43,8 @@ public:
     void deactivate_graphical_mode();
     void activate_graphical_mode();
 
+    static u32 generate_adapter_id();
+
 private:
     void enable_vga_text_mode_console_cursor();
 

--- a/Kernel/Graphics/Intel/NativeDisplayConnector.cpp
+++ b/Kernel/Graphics/Intel/NativeDisplayConnector.cpp
@@ -175,10 +175,10 @@ Optional<IntelGraphics::PLLSettings> IntelNativeDisplayConnector::create_pll_set
     return {};
 }
 
-NonnullRefPtr<IntelNativeDisplayConnector> IntelNativeDisplayConnector::must_create(IntelNativeGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, PhysicalAddress registers_region_address, size_t registers_region_length)
+NonnullRefPtr<IntelNativeDisplayConnector> IntelNativeDisplayConnector::must_create(size_t display_connector_index, IntelNativeGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, PhysicalAddress registers_region_address, size_t registers_region_length)
 {
     auto registers_region = MUST(MM.allocate_kernel_region(PhysicalAddress(registers_region_address), registers_region_length, "Intel Native Graphics Registers"sv, Memory::Region::Access::ReadWrite));
-    auto device_or_error = DeviceManagement::try_create_device<IntelNativeDisplayConnector>(parent_adapter, framebuffer_address, framebuffer_resource_size, move(registers_region));
+    auto device_or_error = DeviceManagement::try_create_device<IntelNativeDisplayConnector>(display_connector_index, parent_adapter, framebuffer_address, framebuffer_resource_size, move(registers_region));
     VERIFY(!device_or_error.is_error());
     auto connector = device_or_error.release_value();
     MUST(connector->initialize_gmbus_settings_and_read_edid());
@@ -233,8 +233,8 @@ ErrorOr<void> IntelNativeDisplayConnector::create_attached_framebuffer_console()
     return {};
 }
 
-IntelNativeDisplayConnector::IntelNativeDisplayConnector(IntelNativeGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, NonnullOwnPtr<Memory::Region> registers_region)
-    : DisplayConnector(framebuffer_address, framebuffer_resource_size, true)
+IntelNativeDisplayConnector::IntelNativeDisplayConnector(size_t display_connector_index, IntelNativeGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, NonnullOwnPtr<Memory::Region> registers_region)
+    : DisplayConnector(display_connector_index, framebuffer_address, framebuffer_resource_size, true)
     , m_registers_region(move(registers_region))
     , m_parent_graphics_adapter(parent_adapter)
 {

--- a/Kernel/Graphics/Intel/NativeDisplayConnector.h
+++ b/Kernel/Graphics/Intel/NativeDisplayConnector.h
@@ -11,6 +11,7 @@
 #include <Kernel/Graphics/Console/GenericFramebufferConsole.h>
 #include <Kernel/Graphics/Definitions.h>
 #include <Kernel/Graphics/DisplayConnector.h>
+#include <Kernel/Graphics/Intel/NativeGraphicsAdapter.h>
 #include <Kernel/Memory/TypedMapping.h>
 
 namespace Kernel {
@@ -75,16 +76,18 @@ enum GMBusCycle {
 };
 }
 
+class IntelNativeGraphicsAdapter;
 class IntelNativeDisplayConnector final
     : public DisplayConnector {
     friend class IntelNativeGraphicsAdapter;
     friend class DeviceManagement;
 
 public:
-    static NonnullRefPtr<IntelNativeDisplayConnector> must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, PhysicalAddress registers_region_address, size_t registers_region_length);
+    static NonnullRefPtr<IntelNativeDisplayConnector> must_create(IntelNativeGraphicsAdapter const&, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, PhysicalAddress registers_region_address, size_t registers_region_length);
 
 private:
     // ^DisplayConnector
+    virtual RefPtr<GenericGraphicsAdapter> parent_graphics_adapter() const override { return m_parent_graphics_adapter; }
     // FIXME: Implement modesetting capabilities in runtime from userland...
     virtual bool mutable_mode_setting_capable() const override { return false; }
     // FIXME: Implement double buffering capabilities in runtime from userland...
@@ -103,7 +106,7 @@ private:
 
     ErrorOr<void> initialize_gmbus_settings_and_read_edid();
 
-    IntelNativeDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, NonnullOwnPtr<Memory::Region> registers_region);
+    IntelNativeDisplayConnector(IntelNativeGraphicsAdapter const&, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, NonnullOwnPtr<Memory::Region> registers_region);
 
     ErrorOr<void> create_attached_framebuffer_console();
 
@@ -159,5 +162,7 @@ private:
 
     const PhysicalAddress m_registers;
     NonnullOwnPtr<Memory::Region> m_registers_region;
+
+    NonnullRefPtr<IntelNativeGraphicsAdapter> m_parent_graphics_adapter;
 };
 }

--- a/Kernel/Graphics/Intel/NativeDisplayConnector.h
+++ b/Kernel/Graphics/Intel/NativeDisplayConnector.h
@@ -83,7 +83,7 @@ class IntelNativeDisplayConnector final
     friend class DeviceManagement;
 
 public:
-    static NonnullRefPtr<IntelNativeDisplayConnector> must_create(IntelNativeGraphicsAdapter const&, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, PhysicalAddress registers_region_address, size_t registers_region_length);
+    static NonnullRefPtr<IntelNativeDisplayConnector> must_create(size_t display_connector_index, IntelNativeGraphicsAdapter const&, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, PhysicalAddress registers_region_address, size_t registers_region_length);
 
 private:
     // ^DisplayConnector
@@ -106,7 +106,7 @@ private:
 
     ErrorOr<void> initialize_gmbus_settings_and_read_edid();
 
-    IntelNativeDisplayConnector(IntelNativeGraphicsAdapter const&, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, NonnullOwnPtr<Memory::Region> registers_region);
+    IntelNativeDisplayConnector(size_t display_connector_index, IntelNativeGraphicsAdapter const&, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, NonnullOwnPtr<Memory::Region> registers_region);
 
     ErrorOr<void> create_attached_framebuffer_console();
 

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -33,7 +33,7 @@ RefPtr<IntelNativeGraphicsAdapter> IntelNativeGraphicsAdapter::initialize(PCI::D
     VERIFY(pci_device_identifier.hardware_id().vendor_id == 0x8086);
     if (!is_supported_model(pci_device_identifier.hardware_id().device_id))
         return {};
-    auto adapter = adopt_ref(*new IntelNativeGraphicsAdapter(pci_device_identifier.address()));
+    auto adapter = adopt_ref(*new IntelNativeGraphicsAdapter(pci_device_identifier));
     MUST(adapter->initialize_adapter());
     return adapter;
 }
@@ -53,9 +53,8 @@ ErrorOr<void> IntelNativeGraphicsAdapter::initialize_adapter()
     return {};
 }
 
-IntelNativeGraphicsAdapter::IntelNativeGraphicsAdapter(PCI::Address address)
-    : GenericGraphicsAdapter()
-    , PCI::Device(address)
+IntelNativeGraphicsAdapter::IntelNativeGraphicsAdapter(PCI::DeviceIdentifier const& pci_device_identifier)
+    : PCIGraphicsAdapter(pci_device_identifier)
 {
 }
 

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -9,6 +9,7 @@
 #include <Kernel/Graphics/Console/ContiguousFramebufferConsole.h>
 #include <Kernel/Graphics/Definitions.h>
 #include <Kernel/Graphics/GraphicsManagement.h>
+#include <Kernel/Graphics/Intel/NativeDisplayConnector.h>
 #include <Kernel/Graphics/Intel/NativeGraphicsAdapter.h>
 #include <Kernel/PhysicalAddress.h>
 
@@ -48,7 +49,7 @@ ErrorOr<void> IntelNativeGraphicsAdapter::initialize_adapter()
     dmesgln("Intel Native Graphics Adapter @ {}, framebuffer @ {}", address, PhysicalAddress(PCI::get_BAR2(address)));
     PCI::enable_bus_mastering(address);
 
-    m_display_connector = IntelNativeDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR2(address) & 0xfffffff0), bar2_space_size, PhysicalAddress(PCI::get_BAR0(address) & 0xfffffff0), bar0_space_size);
+    m_display_connector = IntelNativeDisplayConnector::must_create(*this, PhysicalAddress(PCI::get_BAR2(address) & 0xfffffff0), bar2_space_size, PhysicalAddress(PCI::get_BAR0(address) & 0xfffffff0), bar0_space_size);
     return {};
 }
 

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -28,14 +28,19 @@ static bool is_supported_model(u16 device_id)
     return false;
 }
 
-RefPtr<IntelNativeGraphicsAdapter> IntelNativeGraphicsAdapter::initialize(PCI::DeviceIdentifier const& pci_device_identifier)
+RefPtr<IntelNativeGraphicsAdapter> IntelNativeGraphicsAdapter::create_instance(PCI::DeviceIdentifier const& pci_device_identifier)
 {
     VERIFY(pci_device_identifier.hardware_id().vendor_id == 0x8086);
     if (!is_supported_model(pci_device_identifier.hardware_id().device_id))
         return {};
-    auto adapter = adopt_ref(*new IntelNativeGraphicsAdapter(pci_device_identifier));
-    MUST(adapter->initialize_adapter());
-    return adapter;
+    return adopt_ref(*new (nothrow) IntelNativeGraphicsAdapter(pci_device_identifier));
+}
+
+ErrorOr<void> IntelNativeGraphicsAdapter::initialize_after_sysfs_directory_creation()
+{
+    VERIFY(m_sysfs_directory);
+    TRY(initialize_adapter());
+    return {};
 }
 
 ErrorOr<void> IntelNativeGraphicsAdapter::initialize_adapter()

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -54,7 +54,7 @@ ErrorOr<void> IntelNativeGraphicsAdapter::initialize_adapter()
     dmesgln("Intel Native Graphics Adapter @ {}, framebuffer @ {}", address, PhysicalAddress(PCI::get_BAR2(address)));
     PCI::enable_bus_mastering(address);
 
-    m_display_connector = IntelNativeDisplayConnector::must_create(*this, PhysicalAddress(PCI::get_BAR2(address) & 0xfffffff0), bar2_space_size, PhysicalAddress(PCI::get_BAR0(address) & 0xfffffff0), bar0_space_size);
+    m_display_connector = IntelNativeDisplayConnector::must_create(0, *this, PhysicalAddress(PCI::get_BAR2(address) & 0xfffffff0), bar2_space_size, PhysicalAddress(PCI::get_BAR0(address) & 0xfffffff0), bar0_space_size);
     return {};
 }
 

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
@@ -9,12 +9,12 @@
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Graphics/Definitions.h>
-#include <Kernel/Graphics/Intel/NativeDisplayConnector.h>
 #include <Kernel/PhysicalAddress.h>
 #include <LibEDID/EDID.h>
 
 namespace Kernel {
 
+class IntelNativeDisplayConnector;
 class IntelNativeGraphicsAdapter final
     : public GenericGraphicsAdapter
     , public PCI::Device {

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
@@ -18,11 +18,13 @@ class IntelNativeDisplayConnector;
 class IntelNativeGraphicsAdapter final : public PCIGraphicsAdapter {
 
 public:
-    static RefPtr<IntelNativeGraphicsAdapter> initialize(PCI::DeviceIdentifier const&);
+    static RefPtr<IntelNativeGraphicsAdapter> create_instance(PCI::DeviceIdentifier const&);
 
     virtual ~IntelNativeGraphicsAdapter() = default;
 
 private:
+    virtual ErrorOr<void> initialize_after_sysfs_directory_creation() override;
+
     ErrorOr<void> initialize_adapter();
 
     explicit IntelNativeGraphicsAdapter(PCI::DeviceIdentifier const&);

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
@@ -7,17 +7,15 @@
 #pragma once
 
 #include <AK/Types.h>
-#include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Graphics/Definitions.h>
+#include <Kernel/Graphics/PCIGraphicsAdapter.h>
 #include <Kernel/PhysicalAddress.h>
 #include <LibEDID/EDID.h>
 
 namespace Kernel {
 
 class IntelNativeDisplayConnector;
-class IntelNativeGraphicsAdapter final
-    : public GenericGraphicsAdapter
-    , public PCI::Device {
+class IntelNativeGraphicsAdapter final : public PCIGraphicsAdapter {
 
 public:
     static RefPtr<IntelNativeGraphicsAdapter> initialize(PCI::DeviceIdentifier const&);
@@ -27,7 +25,7 @@ public:
 private:
     ErrorOr<void> initialize_adapter();
 
-    explicit IntelNativeGraphicsAdapter(PCI::Address);
+    explicit IntelNativeGraphicsAdapter(PCI::DeviceIdentifier const&);
 
     RefPtr<IntelNativeDisplayConnector> m_display_connector;
 };

--- a/Kernel/Graphics/PCIGraphicsAdapter.cpp
+++ b/Kernel/Graphics/PCIGraphicsAdapter.cpp
@@ -17,7 +17,7 @@ PCIGraphicsAdapter::PCIGraphicsAdapter(PCI::DeviceIdentifier const& pci_device_i
 
 void PCIGraphicsAdapter::after_inserting()
 {
-    auto sysfs_graphics_adapter_directory = GraphicsAdapterSysFSDirectory::create(SysFSGraphicsAdaptersDirectory::the(), adapter_id());
+    auto sysfs_graphics_adapter_directory = GraphicsAdapterSysFSDirectory::create(SysFSGraphicsAdaptersDirectory::the(), pci_address(), adapter_id());
     m_sysfs_directory = sysfs_graphics_adapter_directory;
     SysFSGraphicsAdaptersDirectory::the().plug_pci_adapter({}, *sysfs_graphics_adapter_directory);
 }

--- a/Kernel/Graphics/PCIGraphicsAdapter.cpp
+++ b/Kernel/Graphics/PCIGraphicsAdapter.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/DeviceDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Adapter/Directory.h>
 #include <Kernel/Graphics/PCIGraphicsAdapter.h>
 
 namespace Kernel {
@@ -11,6 +13,13 @@ namespace Kernel {
 PCIGraphicsAdapter::PCIGraphicsAdapter(PCI::DeviceIdentifier const& pci_device_identifier)
     : PCI::Device(pci_device_identifier.address())
 {
+}
+
+void PCIGraphicsAdapter::after_inserting()
+{
+    auto sysfs_graphics_adapter_directory = GraphicsAdapterSysFSDirectory::create(SysFSGraphicsAdaptersDirectory::the(), adapter_id());
+    m_sysfs_directory = sysfs_graphics_adapter_directory;
+    SysFSGraphicsAdaptersDirectory::the().plug_pci_adapter({}, *sysfs_graphics_adapter_directory);
 }
 
 }

--- a/Kernel/Graphics/PCIGraphicsAdapter.cpp
+++ b/Kernel/Graphics/PCIGraphicsAdapter.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Graphics/PCIGraphicsAdapter.h>
+
+namespace Kernel {
+
+PCIGraphicsAdapter::PCIGraphicsAdapter(PCI::DeviceIdentifier const& pci_device_identifier)
+    : PCI::Device(pci_device_identifier.address())
+{
+}
+
+}

--- a/Kernel/Graphics/PCIGraphicsAdapter.h
+++ b/Kernel/Graphics/PCIGraphicsAdapter.h
@@ -22,6 +22,8 @@ public:
 
 protected:
     explicit PCIGraphicsAdapter(PCI::DeviceIdentifier const& pci_device_identifier);
+
+    virtual void after_inserting() override final;
 };
 
 }

--- a/Kernel/Graphics/PCIGraphicsAdapter.h
+++ b/Kernel/Graphics/PCIGraphicsAdapter.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/Bus/PCI/Definitions.h>
+#include <Kernel/Bus/PCI/Device.h>
+#include <Kernel/Graphics/GenericGraphicsAdapter.h>
+
+namespace Kernel {
+class PCIGraphicsAdapter
+    : public GenericGraphicsAdapter
+    , public PCI::Device {
+    friend class GraphicsManagement;
+
+public:
+    virtual ~PCIGraphicsAdapter() = default;
+
+protected:
+    explicit PCIGraphicsAdapter(PCI::DeviceIdentifier const& pci_device_identifier);
+};
+
+}

--- a/Kernel/Graphics/VMWare/DisplayConnector.cpp
+++ b/Kernel/Graphics/VMWare/DisplayConnector.cpp
@@ -12,9 +12,9 @@
 
 namespace Kernel {
 
-NonnullRefPtr<VMWareDisplayConnector> VMWareDisplayConnector::must_create(VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
+NonnullRefPtr<VMWareDisplayConnector> VMWareDisplayConnector::must_create(size_t display_connector_index, VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
 {
-    auto connector = MUST(DeviceManagement::try_create_device<VMWareDisplayConnector>(parent_adapter, framebuffer_address, framebuffer_resource_size));
+    auto connector = MUST(DeviceManagement::try_create_device<VMWareDisplayConnector>(display_connector_index, parent_adapter, framebuffer_address, framebuffer_resource_size));
     MUST(connector->create_attached_framebuffer_console());
     MUST(connector->initialize_edid_for_generic_monitor(Array<u8, 3> { 'V', 'M', 'W' }));
     return connector;
@@ -27,8 +27,8 @@ ErrorOr<void> VMWareDisplayConnector::create_attached_framebuffer_console()
     return {};
 }
 
-VMWareDisplayConnector::VMWareDisplayConnector(VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
-    : DisplayConnector(framebuffer_address, framebuffer_resource_size, false)
+VMWareDisplayConnector::VMWareDisplayConnector(size_t display_connector_index, VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
+    : DisplayConnector(display_connector_index, framebuffer_address, framebuffer_resource_size, false)
     , m_parent_adapter(parent_adapter)
 {
 }

--- a/Kernel/Graphics/VMWare/DisplayConnector.h
+++ b/Kernel/Graphics/VMWare/DisplayConnector.h
@@ -23,10 +23,10 @@ class VMWareDisplayConnector : public DisplayConnector {
     friend class DeviceManagement;
 
 public:
-    static NonnullRefPtr<VMWareDisplayConnector> must_create(VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size);
+    static NonnullRefPtr<VMWareDisplayConnector> must_create(size_t display_connector_index, VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size);
 
 private:
-    VMWareDisplayConnector(VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size);
+    VMWareDisplayConnector(size_t display_connector_index, VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size);
     ErrorOr<void> create_attached_framebuffer_console();
 
     virtual bool mutable_mode_setting_capable() const override { return true; }

--- a/Kernel/Graphics/VMWare/DisplayConnector.h
+++ b/Kernel/Graphics/VMWare/DisplayConnector.h
@@ -47,6 +47,8 @@ private:
     virtual void enable_console() override;
     virtual void disable_console() override;
 
+    virtual RefPtr<GenericGraphicsAdapter> parent_graphics_adapter() const override { return m_parent_adapter; }
+
 private:
     NonnullRefPtr<VMWareGraphicsAdapter> m_parent_adapter;
     RefPtr<VMWareFramebufferConsole> m_framebuffer_console;

--- a/Kernel/Graphics/VMWare/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VMWare/GraphicsAdapter.cpp
@@ -189,7 +189,7 @@ UNMAP_AFTER_INIT ErrorOr<void> VMWareGraphicsAdapter::initialize_adapter()
 
     auto bar1_space_size = PCI::get_BAR_space_size(pci_address(), 1);
 
-    m_display_connector = VMWareDisplayConnector::must_create(*this, PhysicalAddress(PCI::get_BAR1(pci_address()) & 0xfffffff0), bar1_space_size);
+    m_display_connector = VMWareDisplayConnector::must_create(0, *this, PhysicalAddress(PCI::get_BAR1(pci_address()) & 0xfffffff0), bar1_space_size);
     TRY(m_display_connector->set_safe_mode_setting());
     return {};
 }

--- a/Kernel/Graphics/VMWare/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VMWare/GraphicsAdapter.cpp
@@ -34,7 +34,7 @@ UNMAP_AFTER_INIT RefPtr<VMWareGraphicsAdapter> VMWareGraphicsAdapter::try_initia
 }
 
 UNMAP_AFTER_INIT VMWareGraphicsAdapter::VMWareGraphicsAdapter(PCI::DeviceIdentifier const& pci_device_identifier)
-    : PCI::Device(pci_device_identifier.address())
+    : PCIGraphicsAdapter(pci_device_identifier)
     , m_io_registers_base(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0)
 {
     dbgln("VMWare SVGA @ {}, {}", pci_device_identifier.address(), m_io_registers_base);

--- a/Kernel/Graphics/VMWare/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VMWare/GraphicsAdapter.cpp
@@ -21,7 +21,7 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT RefPtr<VMWareGraphicsAdapter> VMWareGraphicsAdapter::try_initialize(PCI::DeviceIdentifier const& pci_device_identifier)
+UNMAP_AFTER_INIT RefPtr<VMWareGraphicsAdapter> VMWareGraphicsAdapter::try_create_instance(PCI::DeviceIdentifier const& pci_device_identifier)
 {
     PCI::HardwareID id = pci_device_identifier.hardware_id();
     VERIFY(id.vendor_id == PCI::VendorID::VMWare);
@@ -29,8 +29,14 @@ UNMAP_AFTER_INIT RefPtr<VMWareGraphicsAdapter> VMWareGraphicsAdapter::try_initia
     if (id.device_id != 0x0405)
         return {};
     auto adapter = MUST(adopt_nonnull_ref_or_enomem(new (nothrow) VMWareGraphicsAdapter(pci_device_identifier)));
-    MUST(adapter->initialize_adapter());
     return adapter;
+}
+
+UNMAP_AFTER_INIT ErrorOr<void> VMWareGraphicsAdapter::initialize_after_sysfs_directory_creation()
+{
+    VERIFY(m_sysfs_directory);
+    TRY(initialize_adapter());
+    return {};
 }
 
 UNMAP_AFTER_INIT VMWareGraphicsAdapter::VMWareGraphicsAdapter(PCI::DeviceIdentifier const& pci_device_identifier)

--- a/Kernel/Graphics/VMWare/GraphicsAdapter.h
+++ b/Kernel/Graphics/VMWare/GraphicsAdapter.h
@@ -8,8 +8,8 @@
 
 #include <AK/Types.h>
 #include <Kernel/Arch/x86/IO.h>
-#include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Graphics/GenericGraphicsAdapter.h>
+#include <Kernel/Graphics/PCIGraphicsAdapter.h>
 #include <Kernel/Graphics/VMWare/Definitions.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/TypedMapping.h>
@@ -20,9 +20,7 @@ namespace Kernel {
 class GraphicsManagement;
 
 class VMWareDisplayConnector;
-class VMWareGraphicsAdapter final
-    : public GenericGraphicsAdapter
-    , public PCI::Device {
+class VMWareGraphicsAdapter final : public PCIGraphicsAdapter {
     friend class GraphicsManagement;
 
 public:

--- a/Kernel/Graphics/VMWare/GraphicsAdapter.h
+++ b/Kernel/Graphics/VMWare/GraphicsAdapter.h
@@ -24,7 +24,7 @@ class VMWareGraphicsAdapter final : public PCIGraphicsAdapter {
     friend class GraphicsManagement;
 
 public:
-    static RefPtr<VMWareGraphicsAdapter> try_initialize(PCI::DeviceIdentifier const&);
+    static RefPtr<VMWareGraphicsAdapter> try_create_instance(PCI::DeviceIdentifier const&);
     virtual ~VMWareGraphicsAdapter() = default;
 
     ErrorOr<void> modeset_primary_screen_resolution(Badge<VMWareDisplayConnector>, size_t width, size_t height);
@@ -34,6 +34,8 @@ public:
     void primary_screen_flush(Badge<VMWareDisplayConnector>, size_t current_width, size_t current_height);
 
 private:
+    virtual ErrorOr<void> initialize_after_sysfs_directory_creation() override;
+
     ErrorOr<void> initialize_adapter();
     ErrorOr<void> initialize_fifo_registers();
     ErrorOr<void> negotiate_device_version();

--- a/Kernel/Graphics/VirtIOGPU/DisplayConnector.cpp
+++ b/Kernel/Graphics/VirtIOGPU/DisplayConnector.cpp
@@ -15,9 +15,9 @@
 
 namespace Kernel {
 
-NonnullRefPtr<VirtIODisplayConnector> VirtIODisplayConnector::must_create(VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id)
+NonnullRefPtr<VirtIODisplayConnector> VirtIODisplayConnector::must_create(size_t display_connector_index, VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id)
 {
-    auto device_or_error = DeviceManagement::try_create_device<VirtIODisplayConnector>(graphics_adapter, scanout_id);
+    auto device_or_error = DeviceManagement::try_create_device<VirtIODisplayConnector>(display_connector_index, graphics_adapter, scanout_id);
     VERIFY(!device_or_error.is_error());
     auto connector = device_or_error.release_value();
     connector->initialize_console();
@@ -26,8 +26,8 @@ NonnullRefPtr<VirtIODisplayConnector> VirtIODisplayConnector::must_create(VirtIO
 
 static_assert((MAX_VIRTIOGPU_RESOLUTION_WIDTH * MAX_VIRTIOGPU_RESOLUTION_HEIGHT * sizeof(u32) * 2) % PAGE_SIZE == 0);
 
-VirtIODisplayConnector::VirtIODisplayConnector(VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id)
-    : DisplayConnector((MAX_VIRTIOGPU_RESOLUTION_WIDTH * MAX_VIRTIOGPU_RESOLUTION_HEIGHT * sizeof(u32) * 2), false)
+VirtIODisplayConnector::VirtIODisplayConnector(size_t display_connector_index, VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id)
+    : DisplayConnector(display_connector_index, (MAX_VIRTIOGPU_RESOLUTION_WIDTH * MAX_VIRTIOGPU_RESOLUTION_HEIGHT * sizeof(u32) * 2), false)
     , m_graphics_adapter(graphics_adapter)
     , m_scanout_id(scanout_id)
 {

--- a/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
+++ b/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
@@ -65,6 +65,8 @@ private:
         return buffer_index == 0 || buffer_index == 1;
     }
 
+    virtual RefPtr<GenericGraphicsAdapter> parent_graphics_adapter() const override { return m_graphics_adapter; }
+
 private:
     VirtIODisplayConnector(VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id);
 

--- a/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
+++ b/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
@@ -30,7 +30,7 @@ class VirtIODisplayConnector final : public DisplayConnector {
     friend class DeviceManagement;
 
 public:
-    static NonnullRefPtr<VirtIODisplayConnector> must_create(VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id);
+    static NonnullRefPtr<VirtIODisplayConnector> must_create(size_t display_connector_index, VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id);
 
     void set_edid_bytes(Badge<VirtIOGraphicsAdapter>, Array<u8, 128> const& edid_bytes);
     void set_safe_mode_setting_after_initialization(Badge<VirtIOGraphicsAdapter>);
@@ -68,7 +68,7 @@ private:
     virtual RefPtr<GenericGraphicsAdapter> parent_graphics_adapter() const override { return m_graphics_adapter; }
 
 private:
-    VirtIODisplayConnector(VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id);
+    VirtIODisplayConnector(size_t display_connector_index, VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id);
 
     void flush_displayed_image(Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
     void set_dirty_displayed_rect(Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
@@ -45,7 +45,7 @@ ErrorOr<void> VirtIOGraphicsAdapter::initialize_after_sysfs_directory_creation()
 
 void VirtIOGraphicsAdapter::after_inserting()
 {
-    auto sysfs_graphics_adapter_directory = GraphicsAdapterSysFSDirectory::create(SysFSGraphicsAdaptersDirectory::the(), adapter_id());
+    auto sysfs_graphics_adapter_directory = GraphicsAdapterSysFSDirectory::create(SysFSGraphicsAdaptersDirectory::the(), pci_address(), adapter_id());
     m_sysfs_directory = sysfs_graphics_adapter_directory;
     SysFSGraphicsAdaptersDirectory::the().plug_virtio_adapter({}, *sysfs_graphics_adapter_directory);
 }

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
@@ -54,7 +54,7 @@ ErrorOr<void> VirtIOGraphicsAdapter::initialize_adapter()
 {
     VERIFY(m_num_scanouts <= VIRTIO_GPU_MAX_SCANOUTS);
     for (size_t index = 0; index < m_num_scanouts; index++) {
-        auto display_connector = VirtIODisplayConnector::must_create(*this, index);
+        auto display_connector = VirtIODisplayConnector::must_create(index, *this, index);
         m_scanouts[index].display_connector = display_connector;
         MUST(query_and_set_edid(index, *display_connector));
         display_connector->set_safe_mode_setting_after_initialization({});

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -38,7 +38,7 @@ class VirtIOGraphicsAdapter final
     friend class VirtIOGPU3DDevice;
 
 public:
-    static NonnullRefPtr<VirtIOGraphicsAdapter> initialize(PCI::DeviceIdentifier const&);
+    static NonnullRefPtr<VirtIOGraphicsAdapter> create_instance(PCI::DeviceIdentifier const&);
 
     virtual void initialize() override;
     void initialize_3d_device();
@@ -54,6 +54,10 @@ public:
     void transfer_framebuffer_data_to_host(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, Graphics::VirtIOGPU::Protocol::Rect const& rect, bool main_buffer);
 
 private:
+    virtual ErrorOr<void> initialize_after_sysfs_directory_creation() override;
+
+    virtual void after_inserting() override;
+
     ErrorOr<void> attach_physical_range_to_framebuffer(VirtIODisplayConnector& connector, bool main_buffer, size_t framebuffer_offset, size_t framebuffer_size);
 
     void flush_dirty_rectangle(Graphics::VirtIOGPU::ScanoutID, Graphics::VirtIOGPU::ResourceID, Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect);

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -30,6 +30,7 @@ namespace Kernel {
 
 class VirtIODisplayConnector;
 class VirtIOGPU3DDevice;
+// FIXME: Make this to inherit from PCIGraphicsAdapter eventually.
 class VirtIOGraphicsAdapter final
     : public GenericGraphicsAdapter
     , public VirtIO::Device {


### PR DESCRIPTION
The implementation for /sys/devices/graphics/adapters directory, is actually ready now :)
I just need a bit more time to come up with a new utility called "lsgpu" to show all graphics devices in the system.

This is heavily relying on #14597, but as always, comments and suggestions are always appreciated :)