### PR TITLE
Shell: Add the |& construct for piping stderr along with stdout

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -463,6 +463,8 @@ Editor::CodepointRange Editor::byte_offset_range_to_code_point_offset_range(size
 
 void Editor::stylize(Span const& span, Style const& style)
 {
+    if (!span.is_empty())
+        return;
     if (style.is_empty())
         return;
 

--- a/Userland/Libraries/LibLine/Span.h
+++ b/Userland/Libraries/LibLine/Span.h
@@ -28,6 +28,11 @@ public:
     size_t end() const { return m_end; }
     Mode mode() const { return m_mode; }
 
+    bool is_empty() const
+    {
+        return m_beginning < m_end;
+    }
+
 private:
     size_t m_beginning { 0 };
     size_t m_end { 0 };

--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -510,6 +510,18 @@ RefPtr<AST::Node> Parser::parse_pipe_sequence()
 
     auto before_pipe = save_offset();
     consume();
+    auto also_pipe_stderr = peek() == '&';
+    if (also_pipe_stderr) {
+        consume();
+
+        RefPtr<AST::Node> redirection;
+        {
+            auto redirection_start = push_start();
+            redirection = create<AST::Fd2FdRedirection>(STDERR_FILENO, STDOUT_FILENO);
+        }
+
+        left = create<AST::Join>(left.release_nonnull(), redirection.release_nonnull());
+    }
 
     if (auto pipe_seq = parse_pipe_sequence()) {
         return create<AST::Pipe>(left.release_nonnull(), pipe_seq.release_nonnull()); // Pipe

--- a/Userland/Shell/Parser.h
+++ b/Userland/Shell/Parser.h
@@ -200,9 +200,9 @@ heredoc_entries :: { .*? (heredoc_entry) '\n' } [each heredoc_entries]
 variable_decls :: identifier '=' expression (' '+ variable_decls)? ' '*
                 | identifier '=' '(' pipe_sequence ')' (' '+ variable_decls)? ' '*
 
-pipe_sequence :: command '|' pipe_sequence
+pipe_sequence :: command '|' '&'? pipe_sequence
                | command
-               | control_structure '|' pipe_sequence
+               | control_structure '|' '&'? pipe_sequence
                | control_structure
 
 control_structure[c] :: for_expr


### PR DESCRIPTION
When |& is typed, stderr will be piped to stdout before the actual
piping happens. This behaves basically like a 2>&1 | (and the
underlying implementation transforms it to that anyway).