### PR TITLE
LibAudio+LibDSP: Fix two misnomers in the audio subsystem

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -315,7 +315,7 @@ if (BUILD_LAGOM)
 
     # Audio
     file(GLOB LIBAUDIO_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibAudio/*.cpp")
-    list(REMOVE_ITEM LIBAUDIO_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../../Userland/Libraries/LibAudio/ConnectionFromClient.cpp")
+    list(REMOVE_ITEM LIBAUDIO_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../../Userland/Libraries/LibAudio/ConnectionToServer.cpp")
     lagom_lib(Audio audio
         SOURCES ${LIBAUDIO_SOURCES}
     )

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -8,7 +8,7 @@
  */
 
 #include <AK/Array.h>
-#include <LibAudio/ConnectionFromClient.h>
+#include <LibAudio/ConnectionToServer.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
@@ -43,14 +43,14 @@ public:
                 { 0, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-zero.png"sv)) },
                 { 0, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-muted.png"sv)) } }
         };
-        auto audio_client = TRY(Audio::ConnectionFromClient::try_create());
+        auto audio_client = TRY(Audio::ConnectionToServer::try_create());
         NonnullRefPtr<AudioWidget> audio_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) AudioWidget(move(audio_client), move(volume_level_bitmaps))));
         TRY(audio_widget->try_initialize_graphical_elements());
         return audio_widget;
     }
 
 private:
-    AudioWidget(NonnullRefPtr<Audio::ConnectionFromClient> audio_client, Array<VolumeBitmapPair, 5> volume_level_bitmaps)
+    AudioWidget(NonnullRefPtr<Audio::ConnectionToServer> audio_client, Array<VolumeBitmapPair, 5> volume_level_bitmaps)
         : m_audio_client(move(audio_client))
         , m_volume_level_bitmaps(move(volume_level_bitmaps))
         , m_show_percent(Config::read_bool("AudioApplet"sv, "Applet"sv, "ShowPercent"sv, false))
@@ -222,7 +222,7 @@ private:
             height);
     }
 
-    NonnullRefPtr<Audio::ConnectionFromClient> m_audio_client;
+    NonnullRefPtr<Audio::ConnectionToServer> m_audio_client;
     Array<VolumeBitmapPair, 5> m_volume_level_bitmaps;
     bool m_show_percent { false };
     bool m_audio_muted { false };

--- a/Userland/Applications/Piano/AudioPlayerLoop.cpp
+++ b/Userland/Applications/Piano/AudioPlayerLoop.cpp
@@ -10,7 +10,7 @@
 #include "TrackManager.h"
 #include <AK/FixedArray.h>
 #include <AK/NumericLimits.h>
-#include <LibAudio/ConnectionFromClient.h>
+#include <LibAudio/ConnectionToServer.h>
 #include <LibAudio/Resampler.h>
 #include <LibAudio/Sample.h>
 #include <LibCore/EventLoop.h>
@@ -29,7 +29,7 @@ AudioPlayerLoop::AudioPlayerLoop(TrackManager& track_manager, bool& need_to_writ
     , m_need_to_write_wav(need_to_write_wav)
     , m_wav_writer(wav_writer)
 {
-    m_audio_client = Audio::ConnectionFromClient::try_create().release_value_but_fixme_should_propagate_errors();
+    m_audio_client = Audio::ConnectionToServer::try_create().release_value_but_fixme_should_propagate_errors();
 
     auto target_sample_rate = m_audio_client->get_sample_rate();
     if (target_sample_rate == 0)

--- a/Userland/Applications/Piano/AudioPlayerLoop.h
+++ b/Userland/Applications/Piano/AudioPlayerLoop.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "Music.h"
-#include <LibAudio/ConnectionFromClient.h>
+#include <LibAudio/ConnectionToServer.h>
 #include <LibAudio/Resampler.h>
 #include <LibAudio/Sample.h>
 #include <LibAudio/WavWriter.h>
@@ -35,7 +35,7 @@ private:
     TrackManager& m_track_manager;
     Array<Sample, sample_count> m_buffer;
     Optional<Audio::ResampleHelper<Sample>> m_resampler;
-    RefPtr<Audio::ConnectionFromClient> m_audio_client;
+    RefPtr<Audio::ConnectionToServer> m_audio_client;
 
     bool m_should_play_audio = true;
 

--- a/Userland/Applications/Piano/KeysWidget.cpp
+++ b/Userland/Applications/Piano/KeysWidget.cpp
@@ -7,13 +7,13 @@
  */
 
 #include "KeysWidget.h"
-#include "LibDSP/Keyboard.h"
 #include "TrackManager.h"
 #include <AK/Array.h>
 #include <AK/StringView.h>
+#include <LibDSP/Keyboard.h>
 #include <LibGUI/Painter.h>
 
-KeysWidget::KeysWidget(NonnullRefPtr<LibDSP::Keyboard> keyboard)
+KeysWidget::KeysWidget(NonnullRefPtr<DSP::Keyboard> keyboard)
     : m_keyboard(move(keyboard))
 {
     set_fill_with_background_color(true);
@@ -27,7 +27,7 @@ int KeysWidget::mouse_note() const
         return -1;
 }
 
-void KeysWidget::set_key(i8 key, LibDSP::Keyboard::Switch switch_note)
+void KeysWidget::set_key(i8 key, DSP::Keyboard::Switch switch_note)
 {
     m_keyboard->set_keyboard_note_in_active_octave(key, switch_note);
 }
@@ -253,7 +253,7 @@ void KeysWidget::mousedown_event(GUI::MouseEvent& event)
 
     m_mouse_note = note_for_event_position(event.position());
 
-    set_key(m_mouse_note, LibDSP::Keyboard::Switch::On);
+    set_key(m_mouse_note, DSP::Keyboard::Switch::On);
     update();
 }
 
@@ -264,7 +264,7 @@ void KeysWidget::mouseup_event(GUI::MouseEvent& event)
 
     m_mouse_down = false;
 
-    set_key(m_mouse_note, LibDSP::Keyboard::Switch::Off);
+    set_key(m_mouse_note, DSP::Keyboard::Switch::Off);
     update();
 }
 
@@ -278,8 +278,8 @@ void KeysWidget::mousemove_event(GUI::MouseEvent& event)
     if (m_mouse_note == new_mouse_note)
         return;
 
-    set_key(m_mouse_note, LibDSP::Keyboard::Switch::Off);
-    set_key(new_mouse_note, LibDSP::Keyboard::Switch::On);
+    set_key(m_mouse_note, DSP::Keyboard::Switch::Off);
+    set_key(new_mouse_note, DSP::Keyboard::Switch::On);
     update();
 
     m_mouse_note = new_mouse_note;

--- a/Userland/Applications/Piano/KeysWidget.h
+++ b/Userland/Applications/Piano/KeysWidget.h
@@ -24,7 +24,7 @@ public:
     int mouse_note() const;
 
 private:
-    KeysWidget(NonnullRefPtr<LibDSP::Keyboard>);
+    KeysWidget(NonnullRefPtr<DSP::Keyboard>);
 
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
@@ -33,9 +33,9 @@ private:
 
     int note_for_event_position(Gfx::IntPoint const&) const;
 
-    void set_key(i8 key, LibDSP::Keyboard::Switch);
+    void set_key(i8 key, DSP::Keyboard::Switch);
 
-    NonnullRefPtr<LibDSP::Keyboard> m_keyboard;
+    NonnullRefPtr<DSP::Keyboard> m_keyboard;
 
     bool m_mouse_down { false };
     int m_mouse_note { -1 };

--- a/Userland/Applications/Piano/KnobsWidget.cpp
+++ b/Userland/Applications/Piano/KnobsWidget.cpp
@@ -70,23 +70,23 @@ KnobsWidget::KnobsWidget(TrackManager& track_manager, MainWidget& main_widget)
     for (auto& raw_parameter : m_track_manager.current_track().synth()->parameters()) {
         // The synth has range and enum parameters
         switch (raw_parameter.type()) {
-        case LibDSP::ParameterType::Range: {
-            auto& parameter = static_cast<LibDSP::ProcessorRangeParameter&>(raw_parameter);
+        case DSP::ParameterType::Range: {
+            auto& parameter = static_cast<DSP::ProcessorRangeParameter&>(raw_parameter);
             m_synth_values.append(m_values_container->add<GUI::Label>(String::number(static_cast<double>(parameter.value()))));
             auto& parameter_knob_value = m_synth_values.last();
             m_synth_labels.append(m_labels_container->add<GUI::Label>(String::formatted("Synth: {}", parameter.name())));
             m_synth_knobs.append(m_knobs_container->add<ProcessorParameterSlider>(Orientation::Vertical, parameter, parameter_knob_value));
             break;
         }
-        case LibDSP::ParameterType::Enum: {
+        case DSP::ParameterType::Enum: {
             // FIXME: We shouldn't do that, but we know the synth and it is nice
-            auto& parameter = static_cast<LibDSP::ProcessorEnumParameter<LibDSP::Synthesizers::Waveform>&>(raw_parameter);
+            auto& parameter = static_cast<DSP::ProcessorEnumParameter<DSP::Synthesizers::Waveform>&>(raw_parameter);
             // The value is empty for enum parameters
             m_synth_values.append(m_values_container->add<GUI::Label>(String::empty()));
             m_synth_labels.append(m_labels_container->add<GUI::Label>(String::formatted("Synth: {}", parameter.name())));
             auto enum_strings = Vector<String> { "Sine", "Triangle", "Square", "Saw", "Noise" };
-            m_synth_knobs.append(m_knobs_container->add<ProcessorParameterDropdown<LibDSP::Synthesizers::Waveform>>(parameter, move(enum_strings)));
-            m_synth_waveform = static_cast<ProcessorParameterDropdown<LibDSP::Synthesizers::Waveform>&>(m_synth_knobs.last());
+            m_synth_knobs.append(m_knobs_container->add<ProcessorParameterDropdown<DSP::Synthesizers::Waveform>>(parameter, move(enum_strings)));
+            m_synth_waveform = static_cast<ProcessorParameterDropdown<DSP::Synthesizers::Waveform>&>(m_synth_knobs.last());
             break;
         }
         default:
@@ -96,7 +96,7 @@ KnobsWidget::KnobsWidget(TrackManager& track_manager, MainWidget& main_widget)
 
     for (auto& raw_parameter : m_track_manager.current_track().delay()->parameters()) {
         // FIXME: We shouldn't do that, but we know the effect and it's nice.
-        auto& parameter = static_cast<LibDSP::ProcessorRangeParameter&>(raw_parameter);
+        auto& parameter = static_cast<DSP::ProcessorRangeParameter&>(raw_parameter);
         m_delay_values.append(m_values_container->add<GUI::Label>(String::number(static_cast<double>(parameter.value()))));
         auto& parameter_knob_value = m_delay_values.last();
         m_delay_labels.append(m_labels_container->add<GUI::Label>(String::formatted("Delay: {}", parameter.name())));

--- a/Userland/Applications/Piano/KnobsWidget.h
+++ b/Userland/Applications/Piano/KnobsWidget.h
@@ -49,7 +49,7 @@ private:
     RefPtr<GUI::Widget> m_knobs_container;
     RefPtr<GUI::Slider> m_volume_knob;
     RefPtr<GUI::Slider> m_octave_knob;
-    RefPtr<ProcessorParameterDropdown<LibDSP::Synthesizers::Waveform>> m_synth_waveform;
+    RefPtr<ProcessorParameterDropdown<DSP::Synthesizers::Waveform>> m_synth_waveform;
     NonnullRefPtrVector<GUI::Widget> m_synth_knobs;
     NonnullRefPtrVector<ProcessorParameterSlider> m_delay_knobs;
 

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -85,7 +85,7 @@ void MainWidget::keydown_event(GUI::KeyEvent& event)
     else
         m_keys_pressed[event.key()] = true;
 
-    note_key_action(event.key(), LibDSP::Keyboard::Switch::On);
+    note_key_action(event.key(), DSP::Keyboard::Switch::On);
     special_key_action(event.key());
     m_keys_widget->update();
 }
@@ -94,11 +94,11 @@ void MainWidget::keyup_event(GUI::KeyEvent& event)
 {
     m_keys_pressed[event.key()] = false;
 
-    note_key_action(event.key(), LibDSP::Keyboard::Switch::Off);
+    note_key_action(event.key(), DSP::Keyboard::Switch::Off);
     m_keys_widget->update();
 }
 
-void MainWidget::note_key_action(int key_code, LibDSP::Keyboard::Switch switch_note)
+void MainWidget::note_key_action(int key_code, DSP::Keyboard::Switch switch_note)
 {
     auto key = m_keys_widget->key_code_to_key(key_code);
     if (key == -1)
@@ -110,10 +110,10 @@ void MainWidget::special_key_action(int key_code)
 {
     switch (key_code) {
     case Key_Z:
-        set_octave_and_ensure_note_change(LibDSP::Keyboard::Direction::Down);
+        set_octave_and_ensure_note_change(DSP::Keyboard::Direction::Down);
         break;
     case Key_X:
-        set_octave_and_ensure_note_change(LibDSP::Keyboard::Direction::Up);
+        set_octave_and_ensure_note_change(DSP::Keyboard::Direction::Up);
         break;
     case Key_C:
         m_knobs_widget->cycle_waveform();
@@ -127,20 +127,20 @@ void MainWidget::special_key_action(int key_code)
 void MainWidget::turn_off_pressed_keys()
 {
     if (m_keys_widget->mouse_note() != -1)
-        m_track_manager.keyboard()->set_keyboard_note_in_active_octave(m_keys_widget->mouse_note(), LibDSP::Keyboard::Switch::Off);
+        m_track_manager.keyboard()->set_keyboard_note_in_active_octave(m_keys_widget->mouse_note(), DSP::Keyboard::Switch::Off);
     for (int i = 0; i < key_code_count; ++i) {
         if (m_keys_pressed[i])
-            note_key_action(i, LibDSP::Keyboard::Switch::Off);
+            note_key_action(i, DSP::Keyboard::Switch::Off);
     }
 }
 
 void MainWidget::turn_on_pressed_keys()
 {
     if (m_keys_widget->mouse_note() != -1)
-        m_track_manager.keyboard()->set_keyboard_note_in_active_octave(m_keys_widget->mouse_note(), LibDSP::Keyboard::Switch::On);
+        m_track_manager.keyboard()->set_keyboard_note_in_active_octave(m_keys_widget->mouse_note(), DSP::Keyboard::Switch::On);
     for (int i = 0; i < key_code_count; ++i) {
         if (m_keys_pressed[i])
-            note_key_action(i, LibDSP::Keyboard::Switch::On);
+            note_key_action(i, DSP::Keyboard::Switch::On);
     }
 }
 
@@ -154,7 +154,7 @@ void MainWidget::set_octave_and_ensure_note_change(int octave)
     m_keys_widget->update();
 }
 
-void MainWidget::set_octave_and_ensure_note_change(LibDSP::Keyboard::Direction direction)
+void MainWidget::set_octave_and_ensure_note_change(DSP::Keyboard::Direction direction)
 {
     turn_off_pressed_keys();
     m_track_manager.keyboard()->change_virtual_keyboard_octave(direction);

--- a/Userland/Applications/Piano/MainWidget.h
+++ b/Userland/Applications/Piano/MainWidget.h
@@ -29,7 +29,7 @@ public:
 
     void add_track_actions(GUI::Menu&);
 
-    void set_octave_and_ensure_note_change(LibDSP::Keyboard::Direction);
+    void set_octave_and_ensure_note_change(DSP::Keyboard::Direction);
     void set_octave_and_ensure_note_change(int);
 
 private:
@@ -39,7 +39,7 @@ private:
     virtual void keyup_event(GUI::KeyEvent&) override;
     virtual void custom_event(Core::CustomEvent&) override;
 
-    void note_key_action(int key_code, LibDSP::Keyboard::Switch);
+    void note_key_action(int key_code, DSP::Keyboard::Switch);
     void special_key_action(int key_code);
 
     void turn_off_pressed_keys();

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Dropdown.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Dropdown.h
@@ -19,7 +19,7 @@ requires(IsEnum<EnumT>) class ProcessorParameterDropdown : public GUI::ComboBox 
     C_OBJECT(ProcessorParameterDropdown);
 
 public:
-    ProcessorParameterDropdown(LibDSP::ProcessorEnumParameter<EnumT>& parameter, Vector<String> modes)
+    ProcessorParameterDropdown(DSP::ProcessorEnumParameter<EnumT>& parameter, Vector<String> modes)
         : ComboBox()
         , m_parameter(parameter)
         , m_modes(move(modes))
@@ -33,7 +33,7 @@ public:
 
         on_change = [this]([[maybe_unused]] auto name, GUI::ModelIndex model_index) {
             auto value = static_cast<EnumT>(model_index.row());
-            m_parameter.set_value_sneaky(value, LibDSP::Detail::ProcessorParameterSetValueTag {});
+            m_parameter.set_value_sneaky(value, DSP::Detail::ProcessorParameterSetValueTag {});
         };
         m_parameter.did_change_value = [this](auto new_value) {
             set_selected_index(static_cast<int>(new_value));
@@ -53,6 +53,6 @@ public:
     }
 
 private:
-    LibDSP::ProcessorEnumParameter<EnumT>& m_parameter;
+    DSP::ProcessorEnumParameter<EnumT>& m_parameter;
     Vector<String> m_modes;
 };

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
@@ -9,7 +9,7 @@
 #include <AK/FixedPoint.h>
 #include <AK/Math.h>
 
-ProcessorParameterSlider::ProcessorParameterSlider(Orientation orientation, LibDSP::ProcessorRangeParameter& parameter, RefPtr<GUI::Label> value_label)
+ProcessorParameterSlider::ProcessorParameterSlider(Orientation orientation, DSP::ProcessorRangeParameter& parameter, RefPtr<GUI::Label> value_label)
     : Slider(orientation)
     , WidgetWithLabel(move(value_label))
     , m_parameter(parameter)
@@ -30,13 +30,13 @@ ProcessorParameterSlider::ProcessorParameterSlider(Orientation orientation, LibD
     m_value_label->set_text(String::formatted("{:.2f}", static_cast<double>(m_parameter)));
 
     on_change = [this](auto value) {
-        LibDSP::ParameterFixedPoint real_value;
+        DSP::ParameterFixedPoint real_value;
         real_value.raw() = value;
         if (is_logarithmic())
             // FIXME: Implement exponential for fixed point
             real_value = exp(static_cast<double>(real_value));
 
-        m_parameter.set_value_sneaky(real_value, LibDSP::Detail::ProcessorParameterSetValueTag {});
+        m_parameter.set_value_sneaky(real_value, DSP::Detail::ProcessorParameterSetValueTag {});
         if (m_value_label) {
             double value = static_cast<double>(m_parameter);
             String label_text = String::formatted("{:.2f}", value);

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.h
@@ -20,11 +20,11 @@ class ProcessorParameterSlider
     C_OBJECT(ProcessorParameterSlider);
 
 public:
-    ProcessorParameterSlider(Orientation, LibDSP::ProcessorRangeParameter&, RefPtr<GUI::Label>);
-    constexpr bool is_logarithmic() const { return m_parameter.is_logarithmic() == LibDSP::Logarithmic::Yes; }
+    ProcessorParameterSlider(Orientation, DSP::ProcessorRangeParameter&, RefPtr<GUI::Label>);
+    constexpr bool is_logarithmic() const { return m_parameter.is_logarithmic() == DSP::Logarithmic::Yes; }
 
 protected:
-    LibDSP::ProcessorRangeParameter& m_parameter;
+    DSP::ProcessorRangeParameter& m_parameter;
 
 private:
     // Converts based on processor parameter boundaries.

--- a/Userland/Applications/Piano/RollWidget.h
+++ b/Userland/Applications/Piano/RollWidget.h
@@ -15,7 +15,7 @@
 #include <LibGUI/AbstractScrollableWidget.h>
 
 class TrackManager;
-using LibDSP::RollNote;
+using DSP::RollNote;
 
 class RollWidget final : public GUI::AbstractScrollableWidget {
     C_OBJECT(RollWidget)

--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -16,10 +16,10 @@
 #include <LibDSP/Music.h>
 #include <math.h>
 
-Track::Track(NonnullRefPtr<LibDSP::Transport> transport, NonnullRefPtr<LibDSP::Keyboard> keyboard)
+Track::Track(NonnullRefPtr<DSP::Transport> transport, NonnullRefPtr<DSP::Keyboard> keyboard)
     : m_transport(move(transport))
-    , m_delay(make_ref_counted<LibDSP::Effects::Delay>(m_transport))
-    , m_synth(make_ref_counted<LibDSP::Synthesizers::Classic>(m_transport))
+    , m_delay(make_ref_counted<DSP::Effects::Delay>(m_transport))
+    , m_synth(make_ref_counted<DSP::Synthesizers::Classic>(m_transport))
     , m_keyboard(move(keyboard))
 {
     set_volume(volume_max);
@@ -27,7 +27,7 @@ Track::Track(NonnullRefPtr<LibDSP::Transport> transport, NonnullRefPtr<LibDSP::K
 
 void Track::fill_sample(Sample& sample)
 {
-    auto playing_notes = LibDSP::RollNotes {};
+    auto playing_notes = DSP::RollNotes {};
 
     for (size_t i = 0; i < note_count; ++i) {
         bool has_roll_notes = false;
@@ -48,9 +48,9 @@ void Track::fill_sample(Sample& sample)
         }
     }
 
-    auto synthesized_sample = LibDSP::Signal { FixedArray<Audio::Sample>::must_create_but_fixme_should_propagate_errors(1) };
+    auto synthesized_sample = DSP::Signal { FixedArray<Audio::Sample>::must_create_but_fixme_should_propagate_errors(1) };
     m_synth->process(playing_notes, synthesized_sample);
-    auto delayed_signal = LibDSP::Signal { FixedArray<Audio::Sample>::must_create_but_fixme_should_propagate_errors(1) };
+    auto delayed_signal = DSP::Signal { FixedArray<Audio::Sample>::must_create_but_fixme_should_propagate_errors(1) };
     m_delay->process(synthesized_sample, delayed_signal);
     auto delayed_sample = delayed_signal.get<FixedArray<Audio::Sample>>()[0];
 

--- a/Userland/Applications/Piano/Track.h
+++ b/Userland/Applications/Piano/Track.h
@@ -19,7 +19,7 @@
 #include <LibDSP/Synthesizers.h>
 #include <LibDSP/Transport.h>
 
-using LibDSP::RollNote;
+using DSP::RollNote;
 using RollIter = AK::SinglyLinkedListIterator<SinglyLinkedList<RollNote>, RollNote>;
 
 class Track {
@@ -27,14 +27,14 @@ class Track {
     AK_MAKE_NONMOVABLE(Track);
 
 public:
-    Track(NonnullRefPtr<LibDSP::Transport>, NonnullRefPtr<LibDSP::Keyboard>);
+    Track(NonnullRefPtr<DSP::Transport>, NonnullRefPtr<DSP::Keyboard>);
     ~Track() = default;
 
     Vector<Audio::Sample> const& recorded_sample() const { return m_recorded_sample; }
     SinglyLinkedList<RollNote> const& roll_notes(int note) const { return m_roll_notes[note]; }
     int volume() const { return m_volume; }
-    NonnullRefPtr<LibDSP::Synthesizers::Classic> synth() { return m_synth; }
-    NonnullRefPtr<LibDSP::Effects::Delay> delay() { return m_delay; }
+    NonnullRefPtr<DSP::Synthesizers::Classic> synth() { return m_synth; }
+    NonnullRefPtr<DSP::Effects::Delay> delay() { return m_delay; }
 
     void fill_sample(Sample& sample);
     void reset();
@@ -52,12 +52,12 @@ private:
 
     int m_volume;
 
-    NonnullRefPtr<LibDSP::Transport> m_transport;
-    NonnullRefPtr<LibDSP::Effects::Delay> m_delay;
-    NonnullRefPtr<LibDSP::Synthesizers::Classic> m_synth;
+    NonnullRefPtr<DSP::Transport> m_transport;
+    NonnullRefPtr<DSP::Effects::Delay> m_delay;
+    NonnullRefPtr<DSP::Synthesizers::Classic> m_synth;
 
     SinglyLinkedList<RollNote> m_roll_notes[note_count];
     RollIter m_roll_iterators[note_count];
-    NonnullRefPtr<LibDSP::Keyboard> m_keyboard;
+    NonnullRefPtr<DSP::Keyboard> m_keyboard;
     bool m_is_active_track { false };
 };

--- a/Userland/Applications/Piano/TrackManager.cpp
+++ b/Userland/Applications/Piano/TrackManager.cpp
@@ -12,8 +12,8 @@
 #include <AK/NonnullRefPtr.h>
 
 TrackManager::TrackManager()
-    : m_transport(make_ref_counted<LibDSP::Transport>(120, 4))
-    , m_keyboard(make_ref_counted<LibDSP::Keyboard>(m_transport))
+    : m_transport(make_ref_counted<DSP::Transport>(120, 4))
+    , m_keyboard(make_ref_counted<DSP::Keyboard>(m_transport))
 {
     add_track();
     m_tracks[m_current_track]->set_active(true);

--- a/Userland/Applications/Piano/TrackManager.h
+++ b/Userland/Applications/Piano/TrackManager.h
@@ -9,14 +9,14 @@
 
 #pragma once
 
-#include "AK/NonnullRefPtr.h"
-#include "LibDSP/Keyboard.h"
 #include "Music.h"
 #include "Track.h"
 #include <AK/Array.h>
 #include <AK/Noncopyable.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/Vector.h>
+#include <LibDSP/Keyboard.h>
 
 class TrackManager {
     AK_MAKE_NONCOPYABLE(TrackManager);
@@ -38,22 +38,22 @@ public:
         m_tracks[m_current_track]->set_active(true);
     }
 
-    NonnullRefPtr<LibDSP::Transport> transport() const { return m_transport; }
-    NonnullRefPtr<LibDSP::Keyboard> keyboard() const { return m_keyboard; }
+    NonnullRefPtr<DSP::Transport> transport() const { return m_transport; }
+    NonnullRefPtr<DSP::Keyboard> keyboard() const { return m_keyboard; }
     // Legacy API, do not add new users.
     void time_forward(int amount);
 
     void fill_buffer(Span<Sample>);
     void reset();
-    void set_keyboard_note(int note, LibDSP::Keyboard::Switch note_switch);
+    void set_keyboard_note(int note, DSP::Keyboard::Switch note_switch);
     void set_should_loop(bool b) { m_should_loop = b; }
     void add_track();
     int next_track_index() const;
 
 private:
     Vector<NonnullOwnPtr<Track>> m_tracks;
-    NonnullRefPtr<LibDSP::Transport> m_transport;
-    NonnullRefPtr<LibDSP::Keyboard> m_keyboard;
+    NonnullRefPtr<DSP::Transport> m_transport;
+    NonnullRefPtr<DSP::Keyboard> m_keyboard;
     size_t m_current_track { 0 };
 
     Array<Sample, sample_count> m_front_buffer;

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -11,7 +11,7 @@
 #include "MainWidget.h"
 #include "TrackManager.h"
 #include <AK/Queue.h>
-#include <LibAudio/ConnectionFromClient.h>
+#include <LibAudio/ConnectionToServer.h>
 #include <LibAudio/WavWriter.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/System.h>

--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -32,7 +32,7 @@ void BarsVisualizationWidget::render(GUI::PaintEvent& event, FixedArray<float> c
 
     AK::TypedTransfer<float>::copy(m_previous_samples.data(), samples.data(), samples.size());
 
-    LibDSP::fft(m_fft_samples.span(), false);
+    DSP::fft(m_fft_samples.span(), false);
 
     Array<float, bar_count> groups {};
 
@@ -102,7 +102,7 @@ BarsVisualizationWidget::BarsVisualizationWidget()
     logarithmic_spectrum_action->set_checked(true);
     m_context_menu->add_action(logarithmic_spectrum_action);
 
-    m_fft_window = LibDSP::Window<float>::hann<fft_size>();
+    m_fft_window = DSP::Window<float>::hann<fft_size>();
 
     // As we use full-overlapping windows, the passed-in data is only half the size of one FFT operation.
     MUST(set_render_sample_count(fft_size / 2));

--- a/Userland/Applications/SoundPlayer/PlaybackManager.cpp
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.cpp
@@ -7,7 +7,7 @@
 
 #include "PlaybackManager.h"
 
-PlaybackManager::PlaybackManager(NonnullRefPtr<Audio::ConnectionFromClient> connection)
+PlaybackManager::PlaybackManager(NonnullRefPtr<Audio::ConnectionToServer> connection)
     : m_connection(connection)
 {
     // FIXME: The buffer enqueuing should happen on a wholly independent second thread.

--- a/Userland/Applications/SoundPlayer/PlaybackManager.h
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.h
@@ -10,7 +10,7 @@
 #include <AK/FixedArray.h>
 #include <AK/Queue.h>
 #include <AK/Vector.h>
-#include <LibAudio/ConnectionFromClient.h>
+#include <LibAudio/ConnectionToServer.h>
 #include <LibAudio/Loader.h>
 #include <LibAudio/Resampler.h>
 #include <LibAudio/Sample.h>
@@ -18,7 +18,7 @@
 
 class PlaybackManager final {
 public:
-    PlaybackManager(NonnullRefPtr<Audio::ConnectionFromClient>);
+    PlaybackManager(NonnullRefPtr<Audio::ConnectionToServer>);
     ~PlaybackManager() = default;
 
     void play();
@@ -36,7 +36,7 @@ public:
     float total_length() const { return m_total_length; }
     FixedArray<Audio::Sample> const& current_buffer() const { return m_current_buffer; }
 
-    NonnullRefPtr<Audio::ConnectionFromClient> connection() const { return m_connection; }
+    NonnullRefPtr<Audio::ConnectionToServer> connection() const { return m_connection; }
 
     Function<void()> on_update;
     Function<void()> on_finished_playing;
@@ -56,7 +56,7 @@ private:
     size_t m_device_samples_per_buffer { 0 };
     size_t m_samples_to_load_per_buffer { 0 };
     RefPtr<Audio::Loader> m_loader { nullptr };
-    NonnullRefPtr<Audio::ConnectionFromClient> m_connection;
+    NonnullRefPtr<Audio::ConnectionToServer> m_connection;
     FixedArray<Audio::Sample> m_current_buffer;
     Optional<Audio::ResampleHelper<Audio::Sample>> m_resampler;
     RefPtr<Core::Timer> m_timer;

--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -7,7 +7,7 @@
 
 #include "Player.h"
 
-Player::Player(Audio::ConnectionFromClient& audio_client_connection)
+Player::Player(Audio::ConnectionToServer& audio_client_connection)
     : m_audio_client_connection(audio_client_connection)
     , m_playback_manager(audio_client_connection)
 {

--- a/Userland/Applications/SoundPlayer/Player.h
+++ b/Userland/Applications/SoundPlayer/Player.h
@@ -31,7 +31,7 @@ public:
         Shuffling,
     };
 
-    explicit Player(Audio::ConnectionFromClient& audio_client_connection);
+    explicit Player(Audio::ConnectionToServer& audio_client_connection);
     virtual ~Player() = default;
 
     void play_file_path(String const& path);
@@ -91,7 +91,7 @@ private:
     LoopMode m_loop_mode { LoopMode::None };
     ShuffleMode m_shuffle_mode { ShuffleMode::None };
 
-    Audio::ConnectionFromClient& m_audio_client_connection;
+    Audio::ConnectionToServer& m_audio_client_connection;
     PlaybackManager m_playback_manager;
 
     String m_loaded_filename;

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -24,7 +24,7 @@
 #include <LibGUI/Window.h>
 #include <LibGfx/Bitmap.h>
 
-SoundPlayerWidgetAdvancedView::SoundPlayerWidgetAdvancedView(GUI::Window& window, Audio::ConnectionFromClient& connection)
+SoundPlayerWidgetAdvancedView::SoundPlayerWidgetAdvancedView(GUI::Window& window, Audio::ConnectionToServer& connection)
     : Player(connection)
     , m_window(window)
 {

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
@@ -13,7 +13,7 @@
 #include "VisualizationWidget.h"
 #include <AK/FixedArray.h>
 #include <AK/NonnullRefPtr.h>
-#include <LibAudio/ConnectionFromClient.h>
+#include <LibAudio/ConnectionToServer.h>
 #include <LibGUI/Splitter.h>
 #include <LibGUI/Widget.h>
 
@@ -53,7 +53,7 @@ protected:
     void keydown_event(GUI::KeyEvent&) override;
 
 private:
-    SoundPlayerWidgetAdvancedView(GUI::Window&, Audio::ConnectionFromClient&);
+    SoundPlayerWidgetAdvancedView(GUI::Window&, Audio::ConnectionToServer&);
 
     void sync_previous_next_actions();
 

--- a/Userland/Applications/SoundPlayer/main.cpp
+++ b/Userland/Applications/SoundPlayer/main.cpp
@@ -10,7 +10,7 @@
 #include "Player.h"
 #include "SampleWidget.h"
 #include "SoundPlayerWidgetAdvancedView.h"
-#include <LibAudio/ConnectionFromClient.h>
+#include <LibAudio/ConnectionToServer.h>
 #include <LibCore/System.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath thread unix"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
-    auto audio_client = TRY(Audio::ConnectionFromClient::try_create());
+    auto audio_client = TRY(Audio::ConnectionToServer::try_create());
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath thread"));
 

--- a/Userland/Applications/VideoPlayer/main.cpp
+++ b/Userland/Applications/VideoPlayer/main.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibAudio/ConnectionFromClient.h>
+#include <LibAudio/ConnectionToServer.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/ImageWidget.h>

--- a/Userland/Libraries/LibAudio/CMakeLists.txt
+++ b/Userland/Libraries/LibAudio/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(SOURCES
     SampleFormats.cpp
-    ConnectionFromClient.cpp
+    ConnectionToServer.cpp
     Loader.cpp
     WavLoader.cpp
     FlacLoader.cpp

--- a/Userland/Libraries/LibAudio/ConnectionToServer.h
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.h
@@ -23,12 +23,12 @@
 
 namespace Audio {
 
-class ConnectionFromClient final
+class ConnectionToServer final
     : public IPC::ConnectionToServer<AudioClientEndpoint, AudioServerEndpoint>
     , public AudioClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionFromClient, "/tmp/portal/audio")
+    IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/portal/audio")
 public:
-    virtual ~ConnectionFromClient() override;
+    virtual ~ConnectionToServer() override;
 
     // Both of these APIs are for convenience and when you don't care about real-time behavior.
     // They will not work properly in conjunction with realtime_enqueue.
@@ -61,7 +61,7 @@ public:
     Function<void(double volume)> on_client_volume_change;
 
 private:
-    ConnectionFromClient(NonnullOwnPtr<Core::Stream::LocalSocket>);
+    ConnectionToServer(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     virtual void main_mix_muted_state_changed(bool) override;
     virtual void main_mix_volume_changed(double) override;

--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -13,8 +13,8 @@
 
 namespace Audio {
 
-LibDSP::MDCT<12> MP3LoaderPlugin::s_mdct_12;
-LibDSP::MDCT<36> MP3LoaderPlugin::s_mdct_36;
+DSP::MDCT<12> MP3LoaderPlugin::s_mdct_12;
+DSP::MDCT<36> MP3LoaderPlugin::s_mdct_36;
 
 MP3LoaderPlugin::MP3LoaderPlugin(StringView path)
     : m_file(Core::File::construct(path))

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -58,8 +58,8 @@ private:
     AK::Vector<AK::Tuple<size_t, int>> m_seek_table;
     AK::Array<AK::Array<AK::Array<float, 18>, 32>, 2> m_last_values {};
     AK::Array<AK::Array<float, 1024>, 2> m_synthesis_buffer {};
-    static LibDSP::MDCT<36> s_mdct_36;
-    static LibDSP::MDCT<12> s_mdct_12;
+    static DSP::MDCT<36> s_mdct_36;
+    static DSP::MDCT<12> s_mdct_12;
 
     u32 m_sample_rate { 0 };
     u8 m_num_channels { 0 };

--- a/Userland/Libraries/LibDSP/Clip.cpp
+++ b/Userland/Libraries/LibDSP/Clip.cpp
@@ -6,7 +6,7 @@
 
 #include "Clip.h"
 
-namespace LibDSP {
+namespace DSP {
 
 Sample AudioClip::sample_at(u32 time)
 {

--- a/Userland/Libraries/LibDSP/Clip.h
+++ b/Userland/Libraries/LibDSP/Clip.h
@@ -11,7 +11,7 @@
 #include <AK/Types.h>
 #include <LibDSP/Music.h>
 
-namespace LibDSP {
+namespace DSP {
 
 // A clip is a self-contained snippet of notes or audio that can freely move inside and in between tracks.
 class Clip : public RefCounted<Clip> {

--- a/Userland/Libraries/LibDSP/Effects.cpp
+++ b/Userland/Libraries/LibDSP/Effects.cpp
@@ -8,7 +8,7 @@
 #include <AK/FixedArray.h>
 #include <math.h>
 
-namespace LibDSP::Effects {
+namespace DSP::Effects {
 
 Delay::Delay(NonnullRefPtr<Transport> transport)
     : EffectProcessor(move(transport))

--- a/Userland/Libraries/LibDSP/Effects.h
+++ b/Userland/Libraries/LibDSP/Effects.h
@@ -11,7 +11,7 @@
 #include <LibDSP/ProcessorParameter.h>
 #include <LibDSP/Transport.h>
 
-namespace LibDSP::Effects {
+namespace DSP::Effects {
 
 // A simple digital delay effect using a delay buffer.
 // This is based on Piano's old built-in delay.

--- a/Userland/Libraries/LibDSP/Envelope.h
+++ b/Userland/Libraries/LibDSP/Envelope.h
@@ -8,7 +8,7 @@
 
 #include <AK/StdLibExtras.h>
 
-namespace LibDSP {
+namespace DSP {
 
 // For now, this cannot be optimal as clang doesn't know underlying type specifications.
 enum EnvelopeState {

--- a/Userland/Libraries/LibDSP/FFT.h
+++ b/Userland/Libraries/LibDSP/FFT.h
@@ -10,7 +10,7 @@
 #include <AK/Math.h>
 #include <AK/Span.h>
 
-namespace LibDSP {
+namespace DSP {
 
 constexpr void fft(Span<Complex<float>> sample_data, bool invert = false)
 {

--- a/Userland/Libraries/LibDSP/Keyboard.cpp
+++ b/Userland/Libraries/LibDSP/Keyboard.cpp
@@ -9,7 +9,7 @@
 #include <AK/Error.h>
 #include <AK/NumericLimits.h>
 
-namespace LibDSP {
+namespace DSP {
 
 void Keyboard::set_keyboard_note(u8 pitch, Keyboard::Switch note_switch)
 {

--- a/Userland/Libraries/LibDSP/Keyboard.h
+++ b/Userland/Libraries/LibDSP/Keyboard.h
@@ -11,7 +11,7 @@
 #include <LibDSP/Music.h>
 #include <LibDSP/Transport.h>
 
-namespace LibDSP {
+namespace DSP {
 
 class Keyboard : public RefCounted<Keyboard> {
 

--- a/Userland/Libraries/LibDSP/MDCT.h
+++ b/Userland/Libraries/LibDSP/MDCT.h
@@ -10,7 +10,7 @@
 #include <AK/Math.h>
 #include <AK/Span.h>
 
-namespace LibDSP {
+namespace DSP {
 
 template<size_t N>
 requires(N % 2 == 0) class MDCT {

--- a/Userland/Libraries/LibDSP/Music.h
+++ b/Userland/Libraries/LibDSP/Music.h
@@ -15,7 +15,7 @@
 #include <LibAudio/Sample.h>
 #include <LibDSP/Envelope.h>
 
-namespace LibDSP {
+namespace DSP {
 
 using Sample = Audio::Sample;
 

--- a/Userland/Libraries/LibDSP/Processor.h
+++ b/Userland/Libraries/LibDSP/Processor.h
@@ -17,7 +17,7 @@
 #include <LibDSP/ProcessorParameter.h>
 #include <LibDSP/Transport.h>
 
-namespace LibDSP {
+namespace DSP {
 
 // A processor processes notes or audio into notes or audio. Processors are e.g. samplers, synthesizers, effects, arpeggiators etc.
 class Processor : public RefCounted<Processor> {

--- a/Userland/Libraries/LibDSP/ProcessorParameter.h
+++ b/Userland/Libraries/LibDSP/ProcessorParameter.h
@@ -14,7 +14,7 @@
 #include <AK/Types.h>
 #include <LibDSP/Music.h>
 
-namespace LibDSP {
+namespace DSP {
 
 using ParameterFixedPoint = FixedPoint<8, i64>;
 
@@ -78,7 +78,7 @@ public:
     ParameterT value() const { return m_value; };
     void set_value(ParameterT value)
     {
-        set_value_sneaky(value, LibDSP::Detail::ProcessorParameterSetValueTag {});
+        set_value_sneaky(value, DSP::Detail::ProcessorParameterSetValueTag {});
         if (did_change_value)
             did_change_value(value);
     }
@@ -151,14 +151,14 @@ public:
 
 }
 template<>
-struct AK::Formatter<LibDSP::ProcessorRangeParameter> : AK::StandardFormatter {
+struct AK::Formatter<DSP::ProcessorRangeParameter> : AK::StandardFormatter {
 
     Formatter() = default;
     explicit Formatter(StandardFormatter formatter)
         : StandardFormatter(formatter)
     {
     }
-    ErrorOr<void> format(FormatBuilder& builder, LibDSP::ProcessorRangeParameter value)
+    ErrorOr<void> format(FormatBuilder& builder, DSP::ProcessorRangeParameter value)
     {
         if (m_mode == Mode::Pointer) {
             Formatter<FlatPtr> formatter { *this };

--- a/Userland/Libraries/LibDSP/Synthesizers.cpp
+++ b/Userland/Libraries/LibDSP/Synthesizers.cpp
@@ -14,10 +14,10 @@
 #include <LibDSP/Processor.h>
 #include <LibDSP/Synthesizers.h>
 
-namespace LibDSP::Synthesizers {
+namespace DSP::Synthesizers {
 
 Classic::Classic(NonnullRefPtr<Transport> transport)
-    : LibDSP::SynthesizerProcessor(transport)
+    : DSP::SynthesizerProcessor(transport)
     , m_waveform("Waveform"sv, Waveform::Saw)
     , m_attack("Attack"sv, 0.01, 2000, 5, Logarithmic::Yes)
     , m_decay("Decay"sv, 0.01, 20'000, 80, Logarithmic::Yes)

--- a/Userland/Libraries/LibDSP/Synthesizers.h
+++ b/Userland/Libraries/LibDSP/Synthesizers.h
@@ -12,7 +12,7 @@
 #include <LibDSP/ProcessorParameter.h>
 #include <LibDSP/Transport.h>
 
-namespace LibDSP::Synthesizers {
+namespace DSP::Synthesizers {
 
 enum Waveform : u8 {
     Sine,

--- a/Userland/Libraries/LibDSP/Track.cpp
+++ b/Userland/Libraries/LibDSP/Track.cpp
@@ -14,7 +14,7 @@
 #include <LibDSP/Processor.h>
 #include <LibDSP/Track.h>
 
-namespace LibDSP {
+namespace DSP {
 
 bool Track::add_processor(NonnullRefPtr<Processor> new_processor)
 {

--- a/Userland/Libraries/LibDSP/Track.h
+++ b/Userland/Libraries/LibDSP/Track.h
@@ -13,7 +13,7 @@
 #include <LibDSP/Music.h>
 #include <LibDSP/Processor.h>
 
-namespace LibDSP {
+namespace DSP {
 
 // A track is also known as a channel and serves as a container for the audio pipeline: clips -> processors -> mixing & output
 class Track : public RefCounted<Track> {

--- a/Userland/Libraries/LibDSP/Transport.h
+++ b/Userland/Libraries/LibDSP/Transport.h
@@ -10,7 +10,7 @@
 #include <AK/Types.h>
 #include <LibDSP/Music.h>
 
-namespace LibDSP {
+namespace DSP {
 
 // The DAW-wide timekeeper and synchronizer
 class Transport final : public RefCounted<Transport> {

--- a/Userland/Libraries/LibDSP/Window.h
+++ b/Userland/Libraries/LibDSP/Window.h
@@ -9,7 +9,7 @@
 #include <AK/FixedArray.h>
 #include <AK/Math.h>
 
-namespace LibDSP {
+namespace DSP {
 
 template<typename T>
 class Window final {

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <AK/Types.h>
-#include <LibAudio/ConnectionFromClient.h>
+#include <LibAudio/ConnectionToServer.h>
 #include <LibAudio/Loader.h>
 #include <LibAudio/Resampler.h>
 #include <LibCore/ArgsParser.h>
@@ -40,7 +40,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::EventLoop loop;
 
-    auto audio_client = TRY(Audio::ConnectionFromClient::try_create());
+    auto audio_client = TRY(Audio::ConnectionToServer::try_create());
     auto maybe_loader = Audio::Loader::create(path);
     if (maybe_loader.is_error()) {
         warnln("Failed to load audio file: {}", maybe_loader.error().description);

--- a/Userland/Utilities/asctl.cpp
+++ b/Userland/Utilities/asctl.cpp
@@ -8,7 +8,7 @@
 
 #include <AK/Variant.h>
 #include <AK/Vector.h>
-#include <LibAudio/ConnectionFromClient.h>
+#include <LibAudio/ConnectionToServer.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
@@ -28,7 +28,7 @@ enum AudioVariable : u32 {
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     Core::EventLoop loop;
-    auto audio_client = TRY(Audio::ConnectionFromClient::try_create());
+    auto audio_client = TRY(Audio::ConnectionToServer::try_create());
     audio_client->async_pause_playback();
 
     String command = String::empty();


### PR DESCRIPTION
- Rename ConnectionFromClient -> ConnectionToServer
- Rename the `LibDSP` namespace to `DSP`