### PR TITLE
LibWeb: Avoid leaking tasks, elements, and documents every time .innerHTML is set!

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -17,7 +17,7 @@ NonnullRefPtr<NamedNodeMap> NamedNodeMap::create(Element& associated_element)
 }
 
 NamedNodeMap::NamedNodeMap(Element& associated_element)
-    : RefCountForwarder(associated_element)
+    : m_associated_element(associated_element)
 {
 }
 

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -20,7 +20,7 @@ namespace Web::DOM {
 
 // https://dom.spec.whatwg.org/#interface-namednodemap
 class NamedNodeMap final
-    : public RefCountForwarder<Element>
+    : public RefCounted<NamedNodeMap>
     , public Bindings::Wrappable {
 
 public:
@@ -52,11 +52,12 @@ public:
 private:
     explicit NamedNodeMap(Element& associated_element);
 
-    Element& associated_element() { return ref_count_target(); }
-    Element const& associated_element() const { return ref_count_target(); }
+    Element& associated_element() { return m_associated_element; }
+    Element const& associated_element() const { return m_associated_element; }
 
     void remove_attribute_at_index(size_t attribute_index);
 
+    Element& m_associated_element;
     NonnullRefPtrVector<Attribute> m_attributes;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
@@ -26,7 +26,7 @@ Vector<DOMStringMap::NameValuePair> DOMStringMap::get_name_value_pairs() const
     // 2. For each content attribute on the DOMStringMap's associated element whose first five characters are the string "data-" and whose remaining characters (if any) do not include any ASCII upper alphas,
     //    in the order that those attributes are listed in the element's attribute list, add a name-value pair to list whose name is the attribute's name with the first five characters removed and whose value
     //    is the attribute's value.
-    m_associated_element->for_each_attribute([&](auto& name, auto& value) {
+    associated_element().for_each_attribute([&](auto& name, auto& value) {
         if (!name.starts_with("data-"sv))
             return;
 
@@ -129,8 +129,8 @@ DOM::ExceptionOr<void> DOMStringMap::set_value_of_new_named_property(String cons
     // FIXME: 4. If name does not match the XML Name production, throw an "InvalidCharacterError" DOMException.
 
     // 5. Set an attribute value for the DOMStringMap's associated element using name and value.
-    m_associated_element->set_attribute(data_name, value);
 
+    associated_element().set_attribute(data_name, value);
     return {};
 }
 
@@ -162,7 +162,7 @@ bool DOMStringMap::delete_existing_named_property(String const& name)
 
     // Remove an attribute by name given name and the DOMStringMap's associated element.
     auto data_name = builder.to_string();
-    m_associated_element->remove_attribute(data_name);
+    associated_element().remove_attribute(data_name);
 
     // The spec doesn't have the step. This indicates that the deletion was successful.
     return true;

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.h
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/RefCounted.h>
+
 #include <AK/Weakable.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/Forward.h>
@@ -37,18 +38,21 @@ public:
 
     bool delete_existing_named_property(String const&);
 
-private:
+    DOM::Element& associated_element() { return m_associated_element; }
+    DOM::Element const& associated_element() const { return m_associated_element; }
+
     DOMStringMap(DOM::Element&);
 
+private:
     struct NameValuePair {
         String name;
         String value;
     };
 
-    Vector<NameValuePair> get_name_value_pairs() const;
-
     // https://html.spec.whatwg.org/multipage/dom.html#concept-domstringmap-element
-    NonnullRefPtr<DOM::Element> m_associated_element;
+    DOM::Element& m_associated_element;
+
+    Vector<NameValuePair> get_name_value_pairs() const;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/Task.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/Task.h
@@ -48,7 +48,7 @@ private:
 
     Source m_source { Source::Unspecified };
     Function<void()> m_steps;
-    RefPtr<DOM::Document> m_document;
+    WeakPtr<DOM::Document> m_document;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -3400,7 +3400,6 @@ NonnullRefPtrVector<DOM::Node> HTMLParser::parse_html_fragment(DOM::Element& con
     auto root = create_element(context_element.document(), HTML::TagNames::html, Namespace::HTML);
     parser->document().append_child(root);
     parser->m_stack_of_open_elements.push(root);
-
     if (context_element.local_name() == HTML::TagNames::template_) {
         parser->m_stack_of_template_insertion_modes.append(InsertionMode::InTemplate);
     }
@@ -3424,6 +3423,8 @@ NonnullRefPtrVector<DOM::Node> HTMLParser::parse_html_fragment(DOM::Element& con
         context_element.document().adopt_node(*child);
         children.append(*child);
     }
+    parser->document().remove_child(root);
+
     return children;
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -10,7 +10,7 @@ namespace Web::SVG {
 
 SVGElement::SVGElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : Element(document, move(qualified_name))
-    , m_dataset(HTML::DOMStringMap::create(*this))
+    , m_dataset(*this)
 {
 }
 


### PR DESCRIPTION
This was not easy to debug (for me)... 
But now I can finally just use `.innerHTML` in a `setInterval()` without things going boom :^)

There may be some other lifetime implications from this change since the DOMStringMap/NamedNodeMap no-longer keeps the elements alive, but I can't figure out a way to do this without a circular reference and/or a crash. Things seem to be working though.

P.s. Don't review a header, I don't want to rebuild LibWeb again :thousandstareyak:  