### PR TITLE
LibWeb: Add & use TRY_OR_RETURN_OOM macro

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/DOMException.h
+++ b/Userland/Libraries/LibWeb/DOM/DOMException.h
@@ -13,6 +13,16 @@
 
 namespace Web::DOM {
 
+#define TRY_OR_RETURN_OOM(expression)                             \
+    ({                                                            \
+        auto _temporary_result = (expression);                    \
+        if (_temporary_result.is_error()) {                       \
+            VERIFY(_temporary_result.error().code() == ENOMEM);   \
+            return DOM::UnknownError::create("Out of memory."sv); \
+        }                                                         \
+        _temporary_result.release_value();                        \
+    })
+
 // The following have a legacy code value but *don't* produce it as
 // DOMException.code value when used as name (and are therefore omitted here):
 // - DOMStringSizeError (DOMSTRING_SIZE_ERR = 2)

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -50,7 +50,7 @@ public:
 
 private:
     Blob() = default;
-    static DOM::ExceptionOr<ByteBuffer> process_blob_parts(Vector<BlobPart> const& blob_parts);
+    static ErrorOr<ByteBuffer> process_blob_parts(Vector<BlobPart> const& blob_parts);
 
     ByteBuffer m_byte_buffer {};
     String m_type {};

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -118,10 +118,8 @@ DOM::ExceptionOr<JS::Value> XMLHttpRequest::response()
     }
     // 6. Otherwise, if this’s response type is "blob", set this’s response object to a new Blob object representing this’s received bytes with type set to the result of get a final MIME type for this.
     else if (m_response_type == Bindings::XMLHttpRequestResponseType::Blob) {
-        auto blob_part_or_error = try_make_ref_counted<FileAPI::Blob>(m_received_bytes, get_final_mime_type().type());
-        if (blob_part_or_error.is_error())
-            return DOM::UnknownError::create("Out of memory."sv);
-        auto blob = TRY(FileAPI::Blob::create(Vector<FileAPI::BlobPart> { blob_part_or_error.release_value() }));
+        auto blob_part = TRY_OR_RETURN_OOM(try_make_ref_counted<FileAPI::Blob>(m_received_bytes, get_final_mime_type().type()));
+        auto blob = TRY(FileAPI::Blob::create(Vector<FileAPI::BlobPart> { move(blob_part) }));
         m_response_object = JS::make_handle(JS::Value(blob->create_wrapper(global_object)));
     }
     // 7. Otherwise, if this’s response type is "document", set a document response for this.


### PR DESCRIPTION
This is a convenient way to return a DOM exception for operations that return ErrorOr and only have an OOM failure path.