### PR TITLE
LibWeb: Add support for multi-stop linear-gradients at arbitrary angles (spec correctly)

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -4,11 +4,19 @@
     <meta charset="UTF-8">
     <title>Gradients</title>
     <style>
+        div {
+            border: 1px solid black;
+            margin: 20px;
+        }
+
         .box {
             width: 200px;
             height: 200px;
-            margin: 20px;
-            border: 1px solid black;
+        }
+
+        .rect {
+            width: 400px;
+            height: 225px;
         }
 
         .grad-0 {
@@ -40,30 +48,116 @@
         .grad-6 {
             background-image: linear-gradient(to top, blue 30%, 30%, orange 20%, 10%, red);
         }
+
+        .grad-7 {
+            width: 400px;
+            height: 225px;
+            background-image: linear-gradient(to right, red 0%, black 20%, yellow 60%, cyan 100%);
+        }
+
+        .grad-8 {
+            background-image: linear-gradient(
+                to right,
+                red,
+                #f06d06,
+                rgb(255, 255, 0),
+                green
+                );
+        }
+
+        .grad-9 {
+            background: linear-gradient(135deg, #333 25%, transparent 25%) -50px 0,
+                        linear-gradient(225deg, #333 25%, transparent 25%) -50px 0,
+                        linear-gradient(315deg, #333 25%, transparent 25%),
+                        linear-gradient(45deg, #333 25%, transparent 25%);
+        }
+
+        .grad-10 {
+            background-image: linear-gradient(90deg, red, transparent, blue);
+        }
+
+        .grad-11 {
+            background-image: linear-gradient(to top right, indigo, white, deeppink);
+        }
+
+        .grad-12 {
+            background-image: linear-gradient(to top left, indigo, white, deeppink);
+        }
+
+        .grad-13 {
+            background-image: linear-gradient(to bottom left, indigo, white, deeppink);
+        }
+
+        .grad-14 {
+            background-image: linear-gradient(to bottom right,  indigo, white, deeppink);
+        }
     </style>
   </head>
   <body>
     <h1>Gradients!</h1>
+    <b>Simple gradients:</b><br/>
     <div class="box grad-0"></div>
     <div class="box grad-1"></div>
     <div class="box grad-2"></div>
     <div class="box grad-3"></div>
     <div class="box grad-4"></div>
+    <b>Funky color hints:</b><br>
     <div class="box grad-5"></div>
     <div class="box grad-6"></div>
+    <b>Multiple color stops + arbitrary angles (click to spin!):</b><br>
+    <div id="gradient-spin" class="rect grad-7"></div>
+    <b>Default color stops:</b><br>
+    <div class="box grad-8"></div>
+    <div class="box grad-9"></div>
+    <b>Pre-multiplied alpha mixing test:</b><br>
+    <div class="box grad-10"></div>
+    <b>To corner:</b><br>
+    <div class="rect grad-11"></div>
+    <div class="rect grad-12"></div>
+    <div class="rect grad-13"></div>
+    <div class="rect grad-14"></div>
   </body>
   <script>
-    const boxes = document.querySelectorAll(".box");
+    const boxes = document.querySelectorAll(".box, .rect");
     const backgroundMap = {};
     for (const rule of document.styleSheets[0].cssRules) {
         backgroundMap[rule.selectorText] = rule.style.backgroundImage;
     }
-    boxes.forEach(box => {
-        const grad = box.classList[1];
-        console.log(grad)
-        const el = document.createElement('code');
-        el.innerText = backgroundMap['.'+grad];
-        box.parentNode.insertBefore(el, box)
-    })
+
+    // Extract backgroundImage CSS and place above each box
+    updateLabels = () => {
+        boxes.forEach(box => {
+            const grad = box.classList[1];
+            const cssText = backgroundMap['.'+grad];
+            let el = document.getElementById(grad);
+            let newEl = document.createElement('code');
+            let text = document.createTextNode(box.style.backgroundImage || cssText);
+            newEl.appendChild(text);
+            newEl.id = grad;
+            if (!el)
+                box.parentNode.insertBefore(newEl, box)
+            else
+                box.parentNode.replaceChild(newEl, el);
+        })
+    }
+
+    // Spinning gradient demo/test
+    let angle = 0;
+    let spinIntervalId = -1;
+    const gradientSpin = document.getElementById("gradient-spin");
+    gradientSpin.onclick = () => {
+        if (spinIntervalId <= -1) {
+            spinIntervalId = setInterval(() => {
+                gradientSpin.style.backgroundImage = `linear-gradient(${angle}deg, red 0%, black 20%, yellow 60%, cyan 100%)`;
+                angle += 1;
+                updateLabels();
+            }, 100)
+        }  else {
+            clearInterval(spinIntervalId);
+            spinIntervalId = -1;
+        }
+    }
+
+    updateLabels();
   </script>
 </html>

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -309,6 +309,7 @@ set(SOURCES
     Painting/ButtonPaintable.cpp
     Painting/CanvasPaintable.cpp
     Painting/CheckBoxPaintable.cpp
+    Painting/GradientPainting.cpp
     Painting/ImagePaintable.cpp
     Painting/InlinePaintable.cpp
     Painting/LabelablePaintable.cpp
@@ -323,9 +324,9 @@ set(SOURCES
     Painting/SVGGraphicsPaintable.cpp
     Painting/SVGPaintable.cpp
     Painting/SVGSVGPaintable.cpp
-    Painting/TextPaintable.cpp
     Painting/ShadowPainting.cpp
     Painting/StackingContext.cpp
+    Painting/TextPaintable.cpp
     RequestIdleCallback/IdleDeadline.cpp
     ResizeObserver/ResizeObserver.cpp
     SVG/AttributeNames.cpp

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1502,9 +1502,11 @@ bool LinearGradientStyleValue::equals(StyleValue const& other_) const
     return true;
 }
 
-float LinearGradientStyleValue::angle(Gfx::FloatRect const& background_box) const
+float LinearGradientStyleValue::angle_degrees(Gfx::FloatRect const& gradient_rect) const
 {
-    (void)background_box;
+    auto corner_angle_degrees = [&] {
+        return static_cast<float>(atan2(gradient_rect.height(), gradient_rect.width())) * 180 / AK::Pi<float>;
+    };
     return m_direction.visit(
         [&](SideOrCorner side_or_corner) {
             switch (side_or_corner) {
@@ -1516,9 +1518,16 @@ float LinearGradientStyleValue::angle(Gfx::FloatRect const& background_box) cons
                 return 270.0f;
             case SideOrCorner::Right:
                 return 90.0f;
+            case SideOrCorner::TopRight:
+                return corner_angle_degrees();
+            case SideOrCorner::BottomLeft:
+                return corner_angle_degrees() + 180.0f;
+            case SideOrCorner::TopLeft:
+                return -corner_angle_degrees();
+            case SideOrCorner::BottomRight:
+                return -(corner_angle_degrees() + 180.0f);
             default:
-                // FIXME: Angle gradients towards corners
-                return 0.0f;
+                VERIFY_NOT_REACHED();
             }
         },
         [&](Angle const& angle) {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -936,7 +936,7 @@ public:
         return m_color_stop_list;
     }
 
-    float angle(Gfx::FloatRect const& background_box) const;
+    float angle_degrees(Gfx::FloatRect const& gradient_rect) const;
 
 private:
     LinearGradientStyleValue(GradientDirection direction, Vector<ColorStopListElement> color_stop_list)

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -12,46 +12,10 @@
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Painting/BackgroundPainting.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
+#include <LibWeb/Painting/GradientPainting.h>
 #include <LibWeb/Painting/PaintContext.h>
 
 namespace Web::Painting {
-
-struct GfxGradient {
-    Gfx::Orientation orientation;
-    Gfx::Color color_a;
-    Gfx::Color color_b;
-};
-
-static Optional<GfxGradient> linear_gradient_to_gfx_gradient(CSS::LinearGradientStyleValue const& linear_gradient, Gfx::FloatRect const& background_rect)
-{
-    if (linear_gradient.color_stop_list().size() != 2)
-        return {};
-
-    auto angle = round_to<int>(linear_gradient.angle_degrees(background_rect));
-    auto color_a = linear_gradient.color_stop_list()[0].color_stop.color;
-    auto color_b = linear_gradient.color_stop_list()[1].color_stop.color;
-    auto orientation = [&]() -> Optional<Gfx::Orientation> {
-        switch (angle) {
-        case 0:
-            swap(color_a, color_b);
-            [[fallthrough]];
-        case 180:
-            return Gfx::Orientation::Vertical;
-        case 270:
-            swap(color_a, color_b);
-            [[fallthrough]];
-        case 90:
-            return Gfx::Orientation::Horizontal;
-        default:
-            return {};
-        }
-    }();
-
-    if (!orientation.has_value())
-        return {};
-
-    return GfxGradient { *orientation, color_a, color_b };
-};
 
 // https://www.w3.org/TR/css-backgrounds-3/#backgrounds
 void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMetrics const& layout_node, Gfx::FloatRect const& border_rect, Color background_color, Vector<CSS::BackgroundLayerData> const* background_layers, BorderRadiiData const& border_radii)
@@ -134,13 +98,10 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
         ScopedCornerRadiusClip corner_clip { painter, clip_rect, clip_box.radii };
 
         if (layer.background_image->is_linear_gradient()) {
-            // FIXME: Paint non-orthogonal gradients, gradients with > 2 color stops, gradients with custom stop positions ...
             // FIXME: Support sizing and positioning rules with gradients.
             auto& linear_gradient = layer.background_image->as_linear_gradient();
-            auto gfx_gradient = linear_gradient_to_gfx_gradient(linear_gradient, border_box.rect);
-            if (gfx_gradient.has_value()) {
-                painter.fill_rect_with_gradient(gfx_gradient->orientation, border_box.rect.to_rounded<int>(), gfx_gradient->color_a, gfx_gradient->color_b);
-            }
+            auto data = resolve_linear_gradient_data(layout_node, border_box.rect, linear_gradient);
+            paint_linear_gradient(context, border_box.rect.to_rounded<int>(), data);
             continue;
         }
 

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -27,7 +27,7 @@ static Optional<GfxGradient> linear_gradient_to_gfx_gradient(CSS::LinearGradient
     if (linear_gradient.color_stop_list().size() != 2)
         return {};
 
-    auto angle = round_to<int>(linear_gradient.angle(background_rect));
+    auto angle = round_to<int>(linear_gradient.angle_degrees(background_rect));
     auto color_a = linear_gradient.color_stop_list()[0].color_stop.color;
     auto color_b = linear_gradient.color_stop_list()[1].color_stop.color;
     auto orientation = [&]() -> Optional<Gfx::Orientation> {

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Checked.h>
+#include <AK/Math.h>
+#include <LibGfx/Gamma.h>
+#include <LibGfx/Line.h>
+#include <LibWeb/Painting/GradientPainting.h>
+
+namespace Web::Painting {
+
+static float normalized_gradient_angle_radians(float gradient_angle)
+{
+    // Adjust angle so 0 degrees is bottom
+    float real_angle = 90 - gradient_angle;
+    return real_angle * (AK::Pi<float> / 180);
+}
+
+static float calulate_gradient_length(Gfx::IntRect const& gradient_rect, float sin_angle, float cos_angle)
+{
+    return AK::fabs(gradient_rect.height() * sin_angle) + AK::fabs(gradient_rect.width() * cos_angle);
+}
+
+static float calulate_gradient_length(Gfx::IntRect const& gradient_rect, float gradient_angle)
+{
+    float angle = normalized_gradient_angle_radians(gradient_angle);
+    float sin_angle, cos_angle;
+    AK::sincos(angle, sin_angle, cos_angle);
+    return calulate_gradient_length(gradient_rect, sin_angle, cos_angle);
+}
+
+LinearGradientData resolve_linear_gradient_data(Layout::Node const& node, Gfx::FloatRect const& gradient_rect, CSS::LinearGradientStyleValue const& linear_gradient)
+{
+    auto& color_stop_list = linear_gradient.color_stop_list();
+
+    VERIFY(color_stop_list.size() >= 2);
+    ColorStopList resolved_color_stops;
+    resolved_color_stops.ensure_capacity(color_stop_list.size());
+    for (auto& stop : color_stop_list)
+        resolved_color_stops.append(ColorStop { .color = stop.color_stop.color });
+
+    auto gradient_angle = linear_gradient.angle_degrees(gradient_rect);
+    auto gradient_length_px = calulate_gradient_length(gradient_rect.to_rounded<int>(), gradient_angle);
+    auto gradient_length = CSS::Length::make_px(gradient_length_px);
+
+    // 1. If the first color stop does not have a position, set its position to 0%.
+    auto& first_stop = color_stop_list.first().color_stop;
+    resolved_color_stops.first().position = first_stop.length.has_value()
+        ? first_stop.length->resolved(node, gradient_length).to_px(node)
+        : 0;
+    //    If the last color stop does not have a position, set its position to 100%
+    auto& last_stop = color_stop_list.last().color_stop;
+    resolved_color_stops.last().position = last_stop.length.has_value()
+        ? last_stop.length->resolved(node, gradient_length).to_px(node)
+        : gradient_length_px;
+
+    // FIXME: Handle transition hints
+    // 2. If a color stop or transition hint has a position that is less than the
+    //    specified position of any color stop or transition hint before it in the list,
+    //    set its position to be equal to the largest specified position of any color stop
+    //    or transition hint before it.
+    auto max_previous_color_stop = resolved_color_stops[0].position;
+    for (size_t i = 1; i < color_stop_list.size(); i++) {
+        auto& stop = color_stop_list[i];
+        if (stop.color_stop.length.has_value()) {
+            float value = stop.color_stop.length->resolved(node, gradient_length).to_px(node);
+            value = max(value, max_previous_color_stop);
+            resolved_color_stops[i].position = value;
+            max_previous_color_stop = value;
+        }
+    }
+
+    // 3. If any color stop still does not have a position, then, for each run of adjacent color stops
+    //    without positions, set their positions so that they are evenly spaced between the preceding
+    //    and following color stops with positions.
+    size_t i = 1;
+    auto find_run_end = [&] {
+        while (i < color_stop_list.size() - 1 && !color_stop_list[i].color_stop.length.has_value()) {
+            i++;
+        }
+        return i;
+    };
+    while (i < color_stop_list.size() - 1) {
+        auto& stop = color_stop_list[i];
+        if (!stop.color_stop.length.has_value()) {
+            auto run_start = i - 1;
+            auto run_end = find_run_end();
+            auto start_position = resolved_color_stops[run_start].position;
+            auto end_position = resolved_color_stops[run_end].position;
+            auto spacing = (end_position - start_position) / (run_end - run_start);
+            for (auto j = run_start + 1; j < run_end; j++) {
+                resolved_color_stops[j].position = start_position + (j - run_start) * spacing;
+            }
+        }
+        i++;
+    }
+
+    return { gradient_angle, resolved_color_stops };
+}
+
+static float mix(float x, float y, float a)
+{
+    return x * (1 - a) + y * a;
+}
+
+// Note: Gfx::gamma_accurate_blend() is NOT correct for linear gradients!
+static Gfx::Color color_mix(Gfx::Color x, Gfx::Color y, float a)
+{
+    if (x.alpha() == y.alpha() || x.with_alpha(0) == y.with_alpha(0)) {
+        return Gfx::Color {
+            round_to<u8>(mix(x.red(), y.red(), a)),
+            round_to<u8>(mix(x.green(), y.green(), a)),
+            round_to<u8>(mix(x.blue(), y.blue(), a)),
+            round_to<u8>(mix(x.alpha(), y.alpha(), a)),
+        };
+    }
+    // Use slower but more visually pleasing premultiplied alpha mixing if both the color and alpha differ.
+    // https://drafts.csswg.org/css-images/#coloring-gradient-line
+    auto mixed_alpha = mix(x.alpha(), y.alpha(), a);
+    auto premultiplied_mix_channel = [&](float channel_x, float channel_y, float a) {
+        return round_to<u8>(mix(channel_x * (x.alpha() / 255.0f), channel_y * (y.alpha() / 255.0f), a) / (mixed_alpha / 255.0f));
+    };
+    return Gfx::Color {
+        premultiplied_mix_channel(x.red(), y.red(), a),
+        premultiplied_mix_channel(x.green(), y.green(), a),
+        premultiplied_mix_channel(x.blue(), y.blue(), a),
+        round_to<u8>(mixed_alpha),
+    };
+}
+
+void paint_linear_gradient(PaintContext& context, Gfx::IntRect const& gradient_rect, LinearGradientData const& data)
+{
+    float angle = normalized_gradient_angle_radians(data.gradient_angle);
+    float sin_angle, cos_angle;
+    AK::sincos(angle, sin_angle, cos_angle);
+
+    auto length = calulate_gradient_length(gradient_rect, sin_angle, cos_angle);
+
+    Gfx::FloatPoint offset { cos_angle * (length / 2), sin_angle * (length / 2) };
+
+    auto center = gradient_rect.translated(-gradient_rect.location()).center();
+    auto start_point = center.to_type<float>() - offset;
+
+    // Rotate gradient line to be horizontal
+    auto rotated_start_point_x = start_point.x() * cos_angle - start_point.y() * -sin_angle;
+
+    // FIXME: Handle transition hint interpolation
+    auto linear_step = [](float min, float max, float value) -> float {
+        if (value < min)
+            return 0.;
+        if (value > max)
+            return 1.;
+        return (value - min) / (max - min);
+    };
+
+    Vector<Gfx::Color, 1024> gradient_line_colors;
+    auto int_length = round_to<int>(length);
+    gradient_line_colors.resize(int_length);
+    auto& color_stops = data.color_stops;
+    for (int loc = 0; loc < int_length; loc++) {
+        Gfx::Color gradient_color = color_mix(
+            color_stops[0].color,
+            color_stops[1].color,
+            linear_step(
+                color_stops[0].position,
+                color_stops[1].position,
+                loc));
+        for (size_t i = 1; i < color_stops.size() - 1; i++) {
+            gradient_color = color_mix(
+                gradient_color,
+                color_stops[i + 1].color,
+                linear_step(
+                    color_stops[i].position,
+                    color_stops[i + 1].position,
+                    loc));
+        }
+        gradient_line_colors[loc] = gradient_color;
+    }
+
+    auto lookup_color = [&](int loc) {
+        return gradient_line_colors[clamp(loc, 0, int_length - 1)];
+    };
+
+    for (int y = 0; y < gradient_rect.height(); y++) {
+        for (int x = 0; x < gradient_rect.width(); x++) {
+            auto loc = (x * cos_angle - (gradient_rect.height() - y) * -sin_angle) - rotated_start_point_x;
+            // Blend between the two neighbouring colors (this fixes some nasty aliasing issues at small angles)
+            auto blend = loc - static_cast<int>(loc);
+            auto gradient_color = color_mix(lookup_color(loc - 1), lookup_color(loc), blend);
+            context.painter().set_pixel(gradient_rect.x() + x, gradient_rect.y() + y, gradient_color, gradient_color.alpha() < 255);
+        }
+    }
+}
+
+}

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Span.h>
+#include <AK/Vector.h>
+#include <LibGfx/Color.h>
+#include <LibWeb/CSS/StyleValue.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/Painting/PaintContext.h>
+
+namespace Web::Painting {
+
+struct ColorStop {
+    Gfx::Color color;
+    float position = 0;
+};
+
+using ColorStopList = Vector<ColorStop, 4>;
+
+struct LinearGradientData {
+    float gradient_angle;
+    ColorStopList color_stops;
+};
+
+LinearGradientData resolve_linear_gradient_data(Layout::Node const&, Gfx::FloatRect const&, CSS::LinearGradientStyleValue const&);
+
+void paint_linear_gradient(PaintContext&, Gfx::IntRect const&, LinearGradientData const&);
+
+}


### PR DESCRIPTION
**Depends on #14564! Please merge that first!**

[screen-capture (95).webm](https://user-images.githubusercontent.com/11597044/179420846-d8bedf08-d706-44e7-b6d0-e9336e02ad01.webm)


This creates some big improvements on real websites as @Lubrsi found :^) (before the top was all white)
![image](https://user-images.githubusercontent.com/11597044/179420876-57b68e10-00d3-40ed-8512-3daadee30499.png)

See commits for more details comments 

