### PR TITLE
LibJS: Implement Intl.NumberFormat V3's [[RoundingMode]] and [[RoundingIncrement]]

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -215,6 +215,8 @@ void NumberFormatBase::set_rounding_mode(StringView rounding_mode)
         m_rounding_mode = RoundingMode::HalfTrunc;
     else if (rounding_mode == "trunc"sv)
         m_rounding_mode = RoundingMode::Trunc;
+    else
+        VERIFY_NOT_REACHED();
 }
 
 StringView NumberFormatBase::trailing_zero_display_string() const

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -41,6 +41,14 @@ public:
         Trunc,
     };
 
+    enum class UnsignedRoundingMode {
+        HalfEven,
+        HalfInfinity,
+        HalfZero,
+        Infinity,
+        Zero,
+    };
+
     enum class TrailingZeroDisplay {
         Invalid,
         Auto,
@@ -264,11 +272,13 @@ Vector<PatternPartition> partition_number_pattern(GlobalObject& global_object, N
 Vector<PatternPartition> partition_notation_sub_pattern(GlobalObject& global_object, NumberFormat& number_format, Value number, String formatted_string, int exponent);
 String format_numeric(GlobalObject& global_object, NumberFormat& number_format, Value number);
 Array* format_numeric_to_parts(GlobalObject& global_object, NumberFormat& number_format, Value number);
-RawFormatResult to_raw_precision(GlobalObject& global_object, Value number, int min_precision, int max_precision);
-RawFormatResult to_raw_fixed(GlobalObject& global_object, Value number, int min_fraction, int max_fraction);
+RawFormatResult to_raw_precision(GlobalObject& global_object, Value number, int min_precision, int max_precision, Optional<NumberFormat::UnsignedRoundingMode> const& unsigned_rounding_mode);
+RawFormatResult to_raw_fixed(GlobalObject& global_object, Value number, int min_fraction, int max_fraction, int rounding_increment, Optional<NumberFormat::UnsignedRoundingMode> const& unsigned_rounding_mode);
 Optional<Variant<StringView, String>> get_number_format_pattern(GlobalObject& global_object, NumberFormat& number_format, Value number, Unicode::NumberFormat& found_pattern);
 Optional<StringView> get_notation_sub_pattern(NumberFormat& number_format, int exponent);
 int compute_exponent(GlobalObject& global_object, NumberFormat& number_format, Value number);
 int compute_exponent_for_magnitude(NumberFormat& number_format, int magnitude);
+NumberFormat::UnsignedRoundingMode get_unsigned_rounding_mode(NumberFormat::RoundingMode rounding_mode, bool is_negative);
+Value apply_unsigned_rounding_mode(GlobalObject& global_object, Value x, Value r1, Value r2, Optional<NumberFormat::UnsignedRoundingMode> const& unsigned_rounding_mode);
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
@@ -784,6 +784,118 @@ describe("style=decimal", () => {
         expect(ar.format(-1.2)).toBe("\u061c-\u0661\u066b\u0662");
     });
 
+    test("roundingIncrement", () => {
+        const nf = (roundingIncrement, fractionDigits) => {
+            return new Intl.NumberFormat([], {
+                roundingIncrement: roundingIncrement,
+                minimumFractionDigits: fractionDigits,
+                maximumFractionDigits: fractionDigits,
+            });
+        };
+
+        const nf1 = nf(1, 2);
+        expect(nf1.format(1.01)).toBe("1.01");
+        expect(nf1.format(1.02)).toBe("1.02");
+        expect(nf1.format(1.03)).toBe("1.03");
+        expect(nf1.format(1.04)).toBe("1.04");
+        expect(nf1.format(1.05)).toBe("1.05");
+
+        const nf2 = nf(2, 2);
+        expect(nf2.format(1.01)).toBe("1.02");
+        expect(nf2.format(1.02)).toBe("1.02");
+        expect(nf2.format(1.03)).toBe("1.04");
+        expect(nf2.format(1.04)).toBe("1.04");
+        expect(nf2.format(1.05)).toBe("1.06");
+
+        const nf5 = nf(5, 2);
+        expect(nf5.format(1.01)).toBe("1.00");
+        expect(nf5.format(1.02)).toBe("1.00");
+        expect(nf5.format(1.03)).toBe("1.05");
+        expect(nf5.format(1.04)).toBe("1.05");
+        expect(nf5.format(1.05)).toBe("1.05");
+
+        const nf10 = nf(10, 2);
+        expect(nf10.format(1.1)).toBe("1.10");
+        expect(nf10.format(1.12)).toBe("1.10");
+        expect(nf10.format(1.15)).toBe("1.20");
+        expect(nf10.format(1.2)).toBe("1.20");
+
+        const nf20 = nf(20, 2);
+        expect(nf20.format(1.05)).toBe("1.00");
+        expect(nf20.format(1.1)).toBe("1.20");
+        expect(nf20.format(1.15)).toBe("1.20");
+        expect(nf20.format(1.2)).toBe("1.20");
+
+        const nf25 = nf(25, 2);
+        expect(nf25.format(1.25)).toBe("1.25");
+        expect(nf25.format(1.3125)).toBe("1.25");
+        expect(nf25.format(1.375)).toBe("1.50");
+        expect(nf25.format(1.5)).toBe("1.50");
+
+        const nf50 = nf(50, 2);
+        expect(nf50.format(1.5)).toBe("1.50");
+        expect(nf50.format(1.625)).toBe("1.50");
+        expect(nf50.format(1.75)).toBe("2.00");
+        expect(nf50.format(1.875)).toBe("2.00");
+        expect(nf50.format(2.0)).toBe("2.00");
+
+        const nf100 = nf(100, 3);
+        expect(nf100.format(1.1)).toBe("1.100");
+        expect(nf100.format(1.125)).toBe("1.100");
+        expect(nf100.format(1.15)).toBe("1.200");
+        expect(nf100.format(1.175)).toBe("1.200");
+        expect(nf100.format(1.2)).toBe("1.200");
+
+        const nf200 = nf(200, 3);
+        expect(nf200.format(1.2)).toBe("1.200");
+        expect(nf200.format(1.25)).toBe("1.200");
+        expect(nf200.format(1.3)).toBe("1.400");
+        expect(nf200.format(1.35)).toBe("1.400");
+        expect(nf200.format(1.4)).toBe("1.400");
+
+        const nf250 = nf(250, 3);
+        expect(nf250.format(1.25)).toBe("1.250");
+        expect(nf250.format(1.3125)).toBe("1.250");
+        expect(nf250.format(1.375)).toBe("1.500");
+        expect(nf250.format(1.4375)).toBe("1.500");
+        expect(nf250.format(1.5)).toBe("1.500");
+
+        const nf500 = nf(500, 3);
+        expect(nf500.format(1.5)).toBe("1.500");
+        expect(nf500.format(1.625)).toBe("1.500");
+        expect(nf500.format(1.75)).toBe("2.000");
+        expect(nf500.format(1.875)).toBe("2.000");
+        expect(nf500.format(2.0)).toBe("2.000");
+
+        const nf1000 = nf(1000, 4);
+        expect(nf1000.format(1.1)).toBe("1.1000");
+        expect(nf1000.format(1.125)).toBe("1.1000");
+        expect(nf1000.format(1.15)).toBe("1.2000");
+        expect(nf1000.format(1.175)).toBe("1.2000");
+        expect(nf1000.format(1.2)).toBe("1.2000");
+
+        const nf2000 = nf(2000, 4);
+        expect(nf2000.format(1.2)).toBe("1.2000");
+        expect(nf2000.format(1.25)).toBe("1.2000");
+        expect(nf2000.format(1.3)).toBe("1.4000");
+        expect(nf2000.format(1.35)).toBe("1.4000");
+        expect(nf2000.format(1.4)).toBe("1.4000");
+
+        const nf2500 = nf(2500, 4);
+        expect(nf2500.format(1.25)).toBe("1.2500");
+        expect(nf2500.format(1.3125)).toBe("1.2500");
+        expect(nf2500.format(1.375)).toBe("1.5000");
+        expect(nf2500.format(1.4375)).toBe("1.5000");
+        expect(nf2500.format(1.5)).toBe("1.5000");
+
+        const nf5000 = nf(5000, 4);
+        expect(nf5000.format(1.5)).toBe("1.5000");
+        expect(nf5000.format(1.625)).toBe("1.5000");
+        expect(nf5000.format(1.75)).toBe("2.0000");
+        expect(nf5000.format(1.875)).toBe("2.0000");
+        expect(nf5000.format(2.0)).toBe("2.0000");
+    });
+
     test("trailingZeroDisplay=auto", () => {
         const en = new Intl.NumberFormat("en", {
             trailingZeroDisplay: "auto",

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
@@ -568,6 +568,222 @@ describe("style=decimal", () => {
         expect(nf("ar", undefined, 3, undefined, 1).format(1.23)).toBe("\u0661\u066b\u0662\u0663");
     });
 
+    test("roundingMode=ceil", () => {
+        const en = new Intl.NumberFormat("en", {
+            maximumSignificantDigits: 2,
+            roundingMode: "ceil",
+        });
+        expect(en.format(1.11)).toBe("1.2");
+        expect(en.format(1.15)).toBe("1.2");
+        expect(en.format(1.2)).toBe("1.2");
+        expect(en.format(-1.11)).toBe("-1.1");
+        expect(en.format(-1.15)).toBe("-1.1");
+        expect(en.format(-1.2)).toBe("-1.2");
+
+        const ar = new Intl.NumberFormat("ar", {
+            maximumSignificantDigits: 2,
+            roundingMode: "ceil",
+        });
+        expect(ar.format(1.11)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(1.15)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(1.2)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(-1.11)).toBe("\u061c-\u0661\u066b\u0661");
+        expect(ar.format(-1.15)).toBe("\u061c-\u0661\u066b\u0661");
+        expect(ar.format(-1.2)).toBe("\u061c-\u0661\u066b\u0662");
+    });
+
+    test("roundingMode=expand", () => {
+        const en = new Intl.NumberFormat("en", {
+            maximumSignificantDigits: 2,
+            roundingMode: "expand",
+        });
+        expect(en.format(1.11)).toBe("1.2");
+        expect(en.format(1.15)).toBe("1.2");
+        expect(en.format(1.2)).toBe("1.2");
+        expect(en.format(-1.11)).toBe("-1.2");
+        expect(en.format(-1.15)).toBe("-1.2");
+        expect(en.format(-1.2)).toBe("-1.2");
+
+        const ar = new Intl.NumberFormat("ar", {
+            maximumSignificantDigits: 2,
+            roundingMode: "expand",
+        });
+        expect(ar.format(1.11)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(1.15)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(1.2)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(-1.11)).toBe("\u061c-\u0661\u066b\u0662");
+        expect(ar.format(-1.15)).toBe("\u061c-\u0661\u066b\u0662");
+        expect(ar.format(-1.2)).toBe("\u061c-\u0661\u066b\u0662");
+    });
+
+    test("roundingMode=floor", () => {
+        const en = new Intl.NumberFormat("en", {
+            maximumSignificantDigits: 2,
+            roundingMode: "floor",
+        });
+        expect(en.format(1.11)).toBe("1.1");
+        expect(en.format(1.15)).toBe("1.1");
+        expect(en.format(1.2)).toBe("1.2");
+        expect(en.format(-1.11)).toBe("-1.2");
+        expect(en.format(-1.15)).toBe("-1.2");
+        expect(en.format(-1.2)).toBe("-1.2");
+
+        const ar = new Intl.NumberFormat("ar", {
+            maximumSignificantDigits: 2,
+            roundingMode: "floor",
+        });
+        expect(ar.format(1.11)).toBe("\u0661\u066b\u0661");
+        expect(ar.format(1.15)).toBe("\u0661\u066b\u0661");
+        expect(ar.format(1.2)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(-1.11)).toBe("\u061c-\u0661\u066b\u0662");
+        expect(ar.format(-1.15)).toBe("\u061c-\u0661\u066b\u0662");
+        expect(ar.format(-1.2)).toBe("\u061c-\u0661\u066b\u0662");
+    });
+
+    test("roundingMode=halfCeil", () => {
+        const en = new Intl.NumberFormat("en", {
+            maximumSignificantDigits: 2,
+            roundingMode: "halfCeil",
+        });
+        expect(en.format(1.11)).toBe("1.1");
+        expect(en.format(1.15)).toBe("1.2");
+        expect(en.format(1.2)).toBe("1.2");
+        expect(en.format(-1.11)).toBe("-1.1");
+        expect(en.format(-1.15)).toBe("-1.1");
+        expect(en.format(-1.2)).toBe("-1.2");
+
+        const ar = new Intl.NumberFormat("ar", {
+            maximumSignificantDigits: 2,
+            roundingMode: "halfCeil",
+        });
+        expect(ar.format(1.11)).toBe("\u0661\u066b\u0661");
+        expect(ar.format(1.15)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(1.2)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(-1.11)).toBe("\u061c-\u0661\u066b\u0661");
+        expect(ar.format(-1.15)).toBe("\u061c-\u0661\u066b\u0661");
+        expect(ar.format(-1.2)).toBe("\u061c-\u0661\u066b\u0662");
+    });
+
+    test("roundingMode=halfEven", () => {
+        const en = new Intl.NumberFormat("en", {
+            maximumSignificantDigits: 2,
+            roundingMode: "halfEven",
+        });
+        expect(en.format(1.11)).toBe("1.1");
+        expect(en.format(1.15)).toBe("1.2");
+        expect(en.format(1.2)).toBe("1.2");
+        expect(en.format(-1.11)).toBe("-1.1");
+        expect(en.format(-1.15)).toBe("-1.2");
+        expect(en.format(-1.2)).toBe("-1.2");
+
+        const ar = new Intl.NumberFormat("ar", {
+            maximumSignificantDigits: 2,
+            roundingMode: "halfEven",
+        });
+        expect(ar.format(1.11)).toBe("\u0661\u066b\u0661");
+        expect(ar.format(1.15)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(1.2)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(-1.11)).toBe("\u061c-\u0661\u066b\u0661");
+        expect(ar.format(-1.15)).toBe("\u061c-\u0661\u066b\u0662");
+        expect(ar.format(-1.2)).toBe("\u061c-\u0661\u066b\u0662");
+    });
+
+    test("roundingMode=halfExpand", () => {
+        const en = new Intl.NumberFormat("en", {
+            maximumSignificantDigits: 2,
+            roundingMode: "halfExpand",
+        });
+        expect(en.format(1.11)).toBe("1.1");
+        expect(en.format(1.15)).toBe("1.2");
+        expect(en.format(1.2)).toBe("1.2");
+        expect(en.format(-1.11)).toBe("-1.1");
+        expect(en.format(-1.15)).toBe("-1.2");
+        expect(en.format(-1.2)).toBe("-1.2");
+
+        const ar = new Intl.NumberFormat("ar", {
+            maximumSignificantDigits: 2,
+            roundingMode: "halfExpand",
+        });
+        expect(ar.format(1.11)).toBe("\u0661\u066b\u0661");
+        expect(ar.format(1.15)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(1.2)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(-1.11)).toBe("\u061c-\u0661\u066b\u0661");
+        expect(ar.format(-1.15)).toBe("\u061c-\u0661\u066b\u0662");
+        expect(ar.format(-1.2)).toBe("\u061c-\u0661\u066b\u0662");
+    });
+
+    test("roundingMode=halfFloor", () => {
+        const en = new Intl.NumberFormat("en", {
+            maximumSignificantDigits: 2,
+            roundingMode: "halfFloor",
+        });
+        expect(en.format(1.11)).toBe("1.1");
+        expect(en.format(1.15)).toBe("1.1");
+        expect(en.format(1.2)).toBe("1.2");
+        expect(en.format(-1.11)).toBe("-1.1");
+        expect(en.format(-1.15)).toBe("-1.2");
+        expect(en.format(-1.2)).toBe("-1.2");
+
+        const ar = new Intl.NumberFormat("ar", {
+            maximumSignificantDigits: 2,
+            roundingMode: "halfFloor",
+        });
+        expect(ar.format(1.11)).toBe("\u0661\u066b\u0661");
+        expect(ar.format(1.15)).toBe("\u0661\u066b\u0661");
+        expect(ar.format(1.2)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(-1.11)).toBe("\u061c-\u0661\u066b\u0661");
+        expect(ar.format(-1.15)).toBe("\u061c-\u0661\u066b\u0662");
+        expect(ar.format(-1.2)).toBe("\u061c-\u0661\u066b\u0662");
+    });
+
+    test("roundingMode=halfTrunc", () => {
+        const en = new Intl.NumberFormat("en", {
+            maximumSignificantDigits: 2,
+            roundingMode: "halfTrunc",
+        });
+        expect(en.format(1.11)).toBe("1.1");
+        expect(en.format(1.15)).toBe("1.1");
+        expect(en.format(1.2)).toBe("1.2");
+        expect(en.format(-1.11)).toBe("-1.1");
+        expect(en.format(-1.15)).toBe("-1.1");
+        expect(en.format(-1.2)).toBe("-1.2");
+
+        const ar = new Intl.NumberFormat("ar", {
+            maximumSignificantDigits: 2,
+            roundingMode: "halfTrunc",
+        });
+        expect(ar.format(1.11)).toBe("\u0661\u066b\u0661");
+        expect(ar.format(1.15)).toBe("\u0661\u066b\u0661");
+        expect(ar.format(1.2)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(-1.11)).toBe("\u061c-\u0661\u066b\u0661");
+        expect(ar.format(-1.15)).toBe("\u061c-\u0661\u066b\u0661");
+        expect(ar.format(-1.2)).toBe("\u061c-\u0661\u066b\u0662");
+    });
+
+    test("roundingMode=trunc", () => {
+        const en = new Intl.NumberFormat("en", {
+            maximumSignificantDigits: 2,
+            roundingMode: "trunc",
+        });
+        expect(en.format(1.11)).toBe("1.1");
+        expect(en.format(1.15)).toBe("1.1");
+        expect(en.format(1.2)).toBe("1.2");
+        expect(en.format(-1.11)).toBe("-1.1");
+        expect(en.format(-1.15)).toBe("-1.1");
+        expect(en.format(-1.2)).toBe("-1.2");
+
+        const ar = new Intl.NumberFormat("ar", {
+            maximumSignificantDigits: 2,
+            roundingMode: "trunc",
+        });
+        expect(ar.format(1.11)).toBe("\u0661\u066b\u0661");
+        expect(ar.format(1.15)).toBe("\u0661\u066b\u0661");
+        expect(ar.format(1.2)).toBe("\u0661\u066b\u0662");
+        expect(ar.format(-1.11)).toBe("\u061c-\u0661\u066b\u0661");
+        expect(ar.format(-1.15)).toBe("\u061c-\u0661\u066b\u0661");
+        expect(ar.format(-1.2)).toBe("\u061c-\u0661\u066b\u0662");
+    });
+
     test("trailingZeroDisplay=auto", () => {
         const en = new Intl.NumberFormat("en", {
             trailingZeroDisplay: "auto",


### PR DESCRIPTION
```
Diff Tests:
    +23 ✅    -23 ❌   

Diff Tests:
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-1.js     ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-10.js    ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-100.js   ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-1000.js  ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-2.js     ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-20.js    ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-200.js   ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-2000.js  ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-25.js    ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-250.js   ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-2500.js  ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-5.js     ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-50.js    ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-500.js   ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-increment-5000.js  ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-mode-ceil.js       ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-mode-expand.js     ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-mode-floor.js      ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-ceil.js  ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-even.js  ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-floor.js ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-trunc.js ❌ -> ✅
    test/intl402/NumberFormat/prototype/format/format-rounding-mode-trunc.js      ❌ -> ✅
```