### PR TITLE
LibCore+TextEditor: Avoid lag spikes when undoing/redoing chunks of HTML/CSS with the preview open

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -11,6 +11,7 @@
 #include <AK/URL.h>
 #include <Applications/TextEditor/TextEditorWindowGML.h>
 #include <LibConfig/Client.h>
+#include <LibCore/Debounce.h>
 #include <LibCore/File.h>
 #include <LibCpp/SyntaxHighlighter.h>
 #include <LibDesktop/Launcher.h>
@@ -63,9 +64,10 @@ MainWidget::MainWidget()
     else
         VERIFY_NOT_REACHED();
 
-    m_editor->on_change = [this] {
+    m_editor->on_change = Core::debounce([this] {
         update_preview();
-    };
+    },
+        100);
 
     m_editor->on_modified_change = [this](bool modified) {
         window()->set_modified(modified);

--- a/Userland/Libraries/LibCore/Debounce.h
+++ b/Userland/Libraries/LibCore/Debounce.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/Timer.h>
+
+namespace Core {
+
+template<typename TFunction>
+auto debounce(TFunction function, int timeout)
+{
+    RefPtr<Core::Timer> timer;
+    return [=]<typename... T>(T... args) mutable {
+        auto apply_function = [=] { function(args...); };
+        if (timer) {
+            timer->stop();
+            timer->on_timeout = move(apply_function);
+        } else {
+            timer = Core::Timer::create_single_shot(timeout, move(apply_function));
+        }
+        timer->start();
+    };
+};
+
+}


### PR DESCRIPTION
This adds a little `Core::debounce(function, timeout)` helper and uses it to debounce the the HTML preview updates in the TextEditor. This fixes lag spikes when undoing/redoing chunks of HTML/CSS with the preview open. 

The timeout is only 100ms, so the delay is not noticeable 

This has been bugging me for a while now while reducing things in the text editor :)