### PR TITLE
LibWeb: Fix some missing overflow: hidden cases

### DIFF
--- a/Base/res/html/misc/border-radius.html
+++ b/Base/res/html/misc/border-radius.html
@@ -223,6 +223,11 @@
             border-radius: 50px;
             padding: 10px;
         }
+
+        .positioned {
+            background-color: red;
+            position: relative;
+        }
     </style>
 </head>
 
@@ -329,6 +334,16 @@
     <a style="display: inline-block; border-radius: 50%; overflow: hidden; width: 100px; height: 100px;">
         <img src="car.png" style="width: 100px; height: 100px">
     </a>
+    <br>
+    <em>A red div with position: relative within a parent with overflow: hidden + a border-radius</em><br>
+    <div class="box" style="border-radius: 10px; overflow: hidden;">
+        <div class="box positioned"></div>
+    </div>
+    <br>
+    <em>A blue (background) div within a parent with overflow: hidden + a border-radius</em><br>
+    <div class="box" style="border-radius: 10px; overflow: hidden;">
+        <div class="box" style="background-color: blue;"></div>
+    </div>
     <br>
     <br>
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/GenericShorthands.h>
 #include <LibUnicode/CharacterTypes.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
@@ -242,8 +243,11 @@ BorderRadiiData PaintableBox::normalized_border_radii_data() const
         computed_values().border_bottom_left_radius());
 }
 
-void PaintableBox::before_children_paint(PaintContext& context, PaintPhase) const
+void PaintableBox::before_children_paint(PaintContext& context, PaintPhase phase) const
 {
+    if (!AK::first_is_one_of(phase, PaintPhase::Background, PaintPhase::Border, PaintPhase::Foreground))
+        return;
+
     // FIXME: Support more overflow variations.
     auto clip_rect = absolute_padding_box_rect().to_rounded<int>();
     auto overflow_x = computed_values().overflow_x();
@@ -277,8 +281,11 @@ void PaintableBox::before_children_paint(PaintContext& context, PaintPhase) cons
     }
 }
 
-void PaintableBox::after_children_paint(PaintContext& context, PaintPhase) const
+void PaintableBox::after_children_paint(PaintContext& context, PaintPhase phase) const
 {
+    if (!AK::first_is_one_of(phase, PaintPhase::Background, PaintPhase::Border, PaintPhase::Foreground))
+        return;
+
     // FIXME: Support more overflow variations.
     if (m_clipping_overflow) {
         context.painter().restore();


### PR DESCRIPTION
**Before**
![Screenshot from 2022-07-19 10-57-52](https://user-images.githubusercontent.com/11597044/179739924-3a788d7c-2189-4bed-a9d5-d748f6a4b93f.png)
**After**
![Screenshot from 2022-07-19 10-58-39](https://user-images.githubusercontent.com/11597044/179739931-f0b1f428-e17c-46eb-86e8-1d3027fb8927.png)

This fixes the `border-radius` on thing thingy on https://rpcs3.net/compatibility
![image](https://user-images.githubusercontent.com/11597044/179740014-dad9af34-4a66-4912-be74-99988b9bd471.png)

If you find any other border-radius issues don't hesitate to call my on my personal number: 0118 999 881 999 119 7253