### PR TITLE
LibELF: Copy the entire TLS segment instead of each symbol one-by-one (+ "proof of concept" in LibC)

### DIFF
--- a/Userland/Libraries/LibC/malloc.cpp
+++ b/Userland/Libraries/LibC/malloc.cpp
@@ -291,9 +291,7 @@ enum class CallerWillInitializeMemory {
 };
 
 #ifndef NO_TLS
-// HACK: This is a __thread - marked thread-local variable. If we initialize it globally here, VERY weird errors happen.
-// The initialization happens in __malloc_init() and pthread_create_helper().
-__thread bool s_allocation_enabled;
+__thread bool s_allocation_enabled = true;
 #endif
 
 static ErrorOr<void*> malloc_impl(size_t size, size_t align, CallerWillInitializeMemory caller_will_initialize_memory)
@@ -697,12 +695,6 @@ void* realloc(void* ptr, size_t size)
 
 void __malloc_init()
 {
-#ifndef NO_TLS
-    // HACK: This is a __thread - marked thread-local variable. If we initialize it globally, VERY weird errors happen.
-    // Therefore, we need to do the initialization here and in pthread_create_helper().
-    s_allocation_enabled = true;
-#endif
-
     s_in_userspace_emulator = (int)syscall(SC_emuctl, 0) != -ENOSYS;
     if (s_in_userspace_emulator) {
         // Don't bother scrubbing memory if we're running in UE since it

--- a/Userland/Libraries/LibC/pthread.cpp
+++ b/Userland/Libraries/LibC/pthread.cpp
@@ -64,9 +64,6 @@ extern "C" {
 
 static void* pthread_create_helper(void* (*routine)(void*), void* argument, void* stack_location, size_t stack_size)
 {
-    // HACK: This is a __thread - marked thread-local variable. If we initialize it globally, VERY weird errors happen.
-    // Therefore, we need to do the initialization here and in __malloc_init().
-    s_allocation_enabled = true;
     s_stack_location = stack_location;
     s_stack_size = stack_size;
     void* ret_val = routine(argument);

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -350,7 +350,6 @@ void DynamicLoader::load_program_headers()
     Vector<ProgramHeaderRegion, 4> load_regions;
     Vector<ProgramHeaderRegion, 3> map_regions;
     Vector<ProgramHeaderRegion, 1> copy_regions;
-    Optional<ProgramHeaderRegion> tls_region;
     Optional<ProgramHeaderRegion> relro_region;
 
     VirtualAddress dynamic_region_desired_vaddr;
@@ -359,8 +358,7 @@ void DynamicLoader::load_program_headers()
         ProgramHeaderRegion region {};
         region.set_program_header(program_header.raw_header());
         if (region.is_tls_template()) {
-            VERIFY(!tls_region.has_value());
-            tls_region = region;
+            // Skip, this is handled in DynamicLoader::copy_initial_tls_data_into.
         } else if (region.is_load()) {
             if (region.size_in_memory() == 0)
                 return;
@@ -464,8 +462,6 @@ void DynamicLoader::load_program_headers()
 
         memcpy(data_segment_start.as_ptr(), (u8*)m_file_data + region.offset(), region.size_in_image());
     }
-
-    // FIXME: Initialize the values in the TLS section. Currently, it is zeroed.
 }
 
 DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicObject::Relocation& relocation, ShouldInitializeWeak should_initialize_weak)

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -136,7 +136,6 @@ private:
     RelocationResult do_relocation(DynamicObject::Relocation const&, ShouldInitializeWeak should_initialize_weak);
     void do_relr_relocations();
     void find_tls_size_and_alignment();
-    ssize_t negative_offset_from_tls_block_end(ssize_t tls_offset, size_t value_of_symbol) const;
 
     String m_filename;
     String m_filepath;


### PR DESCRIPTION
This fixes an issue where we would previously copy data from the ELF image even for TLS symbols that are uninitialized, which therefore don't have their template data stored in the image. This led to unexplainable errors as soon as an ELF image had at least one initialized TLS value, at which point the TLS size was no longer zero and the copying code ran (as we had now copied garbage data into our uninitialized variables, that are actually meant to be filled with zeroes).

Additionally included is a workaround-removal for the first victim of this issue. The second former victim will soon follow in a separate PR. :^)