### PR TITLE
LibWeb: Support `calc()` in `transform` functions

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -82,9 +82,11 @@ public:
     float width { 0 };
 };
 
+using TransformValue = Variant<CSS::Angle, CSS::LengthPercentage, float>;
+
 struct Transformation {
     CSS::TransformFunction function;
-    Vector<Variant<CSS::LengthPercentage, float>> values;
+    Vector<TransformValue> values;
 };
 
 struct TransformOrigin {

--- a/Userland/Libraries/LibWeb/CSS/Percentage.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Percentage.cpp
@@ -9,24 +9,24 @@
 
 namespace Web::CSS {
 
-Angle AnglePercentage::resolve_calculated(NonnullRefPtr<CalculatedStyleValue> const& calculated, Layout::Node const& layout_node, Angle const& reference_value) const
+Angle AnglePercentage::resolve_calculated(NonnullRefPtr<CalculatedStyleValue> const& calculated, Layout::Node const&, Angle const& reference_value) const
 {
-    return calculated->resolve_angle_percentage(reference_value)->resolved(layout_node, reference_value);
+    return calculated->resolve_angle_percentage(reference_value).value();
 }
 
-Frequency FrequencyPercentage::resolve_calculated(NonnullRefPtr<CalculatedStyleValue> const& calculated, Layout::Node const& layout_node, Frequency const& reference_value) const
+Frequency FrequencyPercentage::resolve_calculated(NonnullRefPtr<CalculatedStyleValue> const& calculated, Layout::Node const&, Frequency const& reference_value) const
 {
-    return calculated->resolve_frequency_percentage(reference_value)->resolved(layout_node, reference_value);
+    return calculated->resolve_frequency_percentage(reference_value).value();
 }
 
 Length LengthPercentage::resolve_calculated(NonnullRefPtr<CalculatedStyleValue> const& calculated, Layout::Node const& layout_node, Length const& reference_value) const
 {
-    return calculated->resolve_length_percentage(layout_node, reference_value)->resolved(layout_node, reference_value);
+    return calculated->resolve_length_percentage(layout_node, reference_value).value();
 }
 
-Time TimePercentage::resolve_calculated(NonnullRefPtr<CalculatedStyleValue> const& calculated, Layout::Node const& layout_node, Time const& reference_value) const
+Time TimePercentage::resolve_calculated(NonnullRefPtr<CalculatedStyleValue> const& calculated, Layout::Node const&, Time const& reference_value) const
 {
-    return calculated->resolve_time_percentage(reference_value)->resolved(layout_node, reference_value);
+    return calculated->resolve_time_percentage(reference_value).value();
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1218,7 +1218,8 @@
   },
   "transform": {
     "inherited": false,
-    "initial": "none"
+    "initial": "none",
+    "affects-stacking-context": true
   },
   "transform-origin": {
     "affects-layout": false,

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -124,132 +124,62 @@ static NonnullRefPtr<StyleValue> style_value_for_length_percentage(LengthPercent
 RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout::NodeWithStyle const& layout_node, PropertyID property_id) const
 {
     switch (property_id) {
-    case CSS::PropertyID::Float:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().float_()));
-    case CSS::PropertyID::Clear:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().clear()));
-    case CSS::PropertyID::Cursor:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().cursor()));
-    case CSS::PropertyID::Display:
-        return style_value_for_display(layout_node.computed_values().display());
-    case CSS::PropertyID::ZIndex: {
-        auto maybe_z_index = layout_node.computed_values().z_index();
-        if (!maybe_z_index.has_value())
-            return {};
-        return NumericStyleValue::create_integer(maybe_z_index.release_value());
-    }
-    case CSS::PropertyID::TextAlign:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_align()));
-    case CSS::PropertyID::TextDecorationLine: {
-        auto text_decoration_lines = layout_node.computed_values().text_decoration_line();
-        if (text_decoration_lines.is_empty())
-            return IdentifierStyleValue::create(ValueID::None);
-        NonnullRefPtrVector<StyleValue> style_values;
-        for (auto const& line : text_decoration_lines) {
-            style_values.append(IdentifierStyleValue::create(to_value_id(line)));
-        }
-        return StyleValueList::create(move(style_values), StyleValueList::Separator::Space);
-    }
-    case CSS::PropertyID::TextDecorationStyle:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_decoration_style()));
-    case CSS::PropertyID::TextTransform:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_transform()));
-    case CSS::PropertyID::Position:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().position()));
-    case CSS::PropertyID::WhiteSpace:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().white_space()));
-    case CSS::PropertyID::FlexDirection:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_direction()));
-    case CSS::PropertyID::FlexWrap:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_wrap()));
-    case CSS::PropertyID::FlexBasis: {
-        switch (layout_node.computed_values().flex_basis().type) {
-        case FlexBasis::Content:
-            return IdentifierStyleValue::create(CSS::ValueID::Content);
-        case FlexBasis::LengthPercentage:
-            return style_value_for_length_percentage(*layout_node.computed_values().flex_basis().length_percentage);
-        case FlexBasis::Auto:
-            return IdentifierStyleValue::create(CSS::ValueID::Auto);
-        default:
-            VERIFY_NOT_REACHED();
-        }
-        break;
-    case CSS::PropertyID::FlexGrow:
-        return NumericStyleValue::create_float(layout_node.computed_values().flex_grow());
-    case CSS::PropertyID::FlexShrink:
-        return NumericStyleValue::create_float(layout_node.computed_values().flex_shrink());
-    case CSS::PropertyID::Order:
-        return NumericStyleValue::create_integer(layout_node.computed_values().order());
-    case CSS::PropertyID::Opacity:
-        return NumericStyleValue::create_float(layout_node.computed_values().opacity());
-    case CSS::PropertyID::ImageRendering:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().image_rendering()));
-    case CSS::PropertyID::JustifyContent:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().justify_content()));
-    case CSS::PropertyID::BoxShadow: {
-        auto box_shadow_layers = layout_node.computed_values().box_shadow();
-        if (box_shadow_layers.is_empty())
-            return {};
+    case CSS::PropertyID::Background: {
+        auto maybe_background_color = property(CSS::PropertyID::BackgroundColor);
+        auto maybe_background_image = property(CSS::PropertyID::BackgroundImage);
+        auto maybe_background_position = property(CSS::PropertyID::BackgroundPosition);
+        auto maybe_background_size = property(CSS::PropertyID::BackgroundSize);
+        auto maybe_background_repeat = property(CSS::PropertyID::BackgroundRepeat);
+        auto maybe_background_attachment = property(CSS::PropertyID::BackgroundAttachment);
+        auto maybe_background_origin = property(CSS::PropertyID::BackgroundOrigin);
+        auto maybe_background_clip = property(CSS::PropertyID::BackgroundClip);
 
-        auto make_box_shadow_style_value = [](ShadowData const& data) {
-            return ShadowStyleValue::create(data.color, data.offset_x, data.offset_y, data.blur_radius, data.spread_distance, data.placement);
-        };
-
-        if (box_shadow_layers.size() == 1)
-            return make_box_shadow_style_value(box_shadow_layers.first());
-
-        NonnullRefPtrVector<StyleValue> box_shadow;
-        box_shadow.ensure_capacity(box_shadow_layers.size());
-        for (auto const& layer : box_shadow_layers)
-            box_shadow.append(make_box_shadow_style_value(layer));
-        return StyleValueList::create(move(box_shadow), StyleValueList::Separator::Comma);
+        return BackgroundStyleValue::create(
+            value_or_default(maybe_background_color, InitialStyleValue::the()),
+            value_or_default(maybe_background_image, IdentifierStyleValue::create(CSS::ValueID::None)),
+            value_or_default(maybe_background_position, PositionStyleValue::create(PositionEdge::Left, Length::make_px(0), PositionEdge::Top, Length::make_px(0))),
+            value_or_default(maybe_background_size, IdentifierStyleValue::create(CSS::ValueID::Auto)),
+            value_or_default(maybe_background_repeat, BackgroundRepeatStyleValue::create(CSS::Repeat::Repeat, CSS::Repeat::Repeat)),
+            value_or_default(maybe_background_attachment, IdentifierStyleValue::create(CSS::ValueID::Scroll)),
+            value_or_default(maybe_background_origin, IdentifierStyleValue::create(CSS::ValueID::PaddingBox)),
+            value_or_default(maybe_background_clip, IdentifierStyleValue::create(CSS::ValueID::BorderBox)));
     }
-    case CSS::PropertyID::Width:
-        return style_value_for_length_percentage(layout_node.computed_values().width());
-    case CSS::PropertyID::MinWidth:
-        return style_value_for_length_percentage(layout_node.computed_values().min_width());
-    case CSS::PropertyID::MaxWidth:
-        return style_value_for_length_percentage(layout_node.computed_values().max_width());
-    case CSS::PropertyID::Height:
-        return style_value_for_length_percentage(layout_node.computed_values().height());
-    case CSS::PropertyID::MinHeight:
-        return style_value_for_length_percentage(layout_node.computed_values().min_height());
-    case CSS::PropertyID::MaxHeight:
-        return style_value_for_length_percentage(layout_node.computed_values().max_height());
-    case CSS::PropertyID::Margin: {
-        auto margin = layout_node.computed_values().margin();
-        auto values = NonnullRefPtrVector<StyleValue> {};
-        values.append(style_value_for_length_percentage(margin.top));
-        values.append(style_value_for_length_percentage(margin.right));
-        values.append(style_value_for_length_percentage(margin.bottom));
-        values.append(style_value_for_length_percentage(margin.left));
-        return StyleValueList::create(move(values), StyleValueList::Separator::Space);
+    case PropertyID::BackgroundColor:
+        return ColorStyleValue::create(layout_node.computed_values().background_color());
+    case CSS::PropertyID::BorderBottom: {
+        auto border = layout_node.computed_values().border_bottom();
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
+        return BorderStyleValue::create(width, style, color);
     }
-    case CSS::PropertyID::MarginTop:
-        return style_value_for_length_percentage(layout_node.computed_values().margin().top);
-    case CSS::PropertyID::MarginRight:
-        return style_value_for_length_percentage(layout_node.computed_values().margin().right);
-    case CSS::PropertyID::MarginBottom:
-        return style_value_for_length_percentage(layout_node.computed_values().margin().bottom);
-    case CSS::PropertyID::MarginLeft:
-        return style_value_for_length_percentage(layout_node.computed_values().margin().left);
-    case CSS::PropertyID::Padding: {
-        auto padding = layout_node.computed_values().padding();
-        auto values = NonnullRefPtrVector<StyleValue> {};
-        values.append(style_value_for_length_percentage(padding.top));
-        values.append(style_value_for_length_percentage(padding.right));
-        values.append(style_value_for_length_percentage(padding.bottom));
-        values.append(style_value_for_length_percentage(padding.left));
-        return StyleValueList::create(move(values), StyleValueList::Separator::Space);
+    case CSS::PropertyID::BorderBottomColor:
+        return ColorStyleValue::create(layout_node.computed_values().border_bottom().color);
+    case CSS::PropertyID::BorderBottomLeftRadius: {
+        auto const& border_radius = layout_node.computed_values().border_bottom_left_radius();
+        return BorderRadiusStyleValue::create(border_radius.horizontal_radius, border_radius.vertical_radius);
     }
-    case CSS::PropertyID::PaddingTop:
-        return style_value_for_length_percentage(layout_node.computed_values().padding().top);
-    case CSS::PropertyID::PaddingRight:
-        return style_value_for_length_percentage(layout_node.computed_values().padding().right);
-    case CSS::PropertyID::PaddingBottom:
-        return style_value_for_length_percentage(layout_node.computed_values().padding().bottom);
-    case CSS::PropertyID::PaddingLeft:
-        return style_value_for_length_percentage(layout_node.computed_values().padding().left);
+    case CSS::PropertyID::BorderBottomRightRadius: {
+        auto const& border_radius = layout_node.computed_values().border_bottom_right_radius();
+        return BorderRadiusStyleValue::create(border_radius.horizontal_radius, border_radius.vertical_radius);
+    }
+    case CSS::PropertyID::BorderBottomStyle:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_bottom().line_style));
+    case CSS::PropertyID::BorderBottomWidth:
+        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_bottom().width));
+    case CSS::PropertyID::BorderLeft: {
+        auto border = layout_node.computed_values().border_left();
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
+        return BorderStyleValue::create(width, style, color);
+    }
+    case CSS::PropertyID::BorderLeftColor:
+        return ColorStyleValue::create(layout_node.computed_values().border_left().color);
+    case CSS::PropertyID::BorderLeftStyle:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_left().line_style));
+    case CSS::PropertyID::BorderLeftWidth:
+        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_left().width));
     case CSS::PropertyID::BorderRadius: {
         auto maybe_top_left_radius = property(CSS::PropertyID::BorderTopLeftRadius);
         auto maybe_top_right_radius = property(CSS::PropertyID::BorderTopRightRadius);
@@ -275,15 +205,28 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
 
         return BorderRadiusShorthandStyleValue::create(top_left_radius.release_nonnull(), top_right_radius.release_nonnull(), bottom_right_radius.release_nonnull(), bottom_left_radius.release_nonnull());
     }
-    // FIXME: The two radius components are not yet stored, as we currently don't actually render them.
-    case CSS::PropertyID::BorderBottomLeftRadius: {
-        auto const& border_radius = layout_node.computed_values().border_bottom_left_radius();
-        return BorderRadiusStyleValue::create(border_radius.horizontal_radius, border_radius.vertical_radius);
+    case CSS::PropertyID::BorderRight: {
+        auto border = layout_node.computed_values().border_right();
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
+        return BorderStyleValue::create(width, style, color);
     }
-    case CSS::PropertyID::BorderBottomRightRadius: {
-        auto const& border_radius = layout_node.computed_values().border_bottom_right_radius();
-        return BorderRadiusStyleValue::create(border_radius.horizontal_radius, border_radius.vertical_radius);
+    case CSS::PropertyID::BorderRightColor:
+        return ColorStyleValue::create(layout_node.computed_values().border_right().color);
+    case CSS::PropertyID::BorderRightStyle:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_right().line_style));
+    case CSS::PropertyID::BorderRightWidth:
+        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_right().width));
+    case CSS::PropertyID::BorderTop: {
+        auto border = layout_node.computed_values().border_top();
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
+        return BorderStyleValue::create(width, style, color);
     }
+    case CSS::PropertyID::BorderTopColor:
+        return ColorStyleValue::create(layout_node.computed_values().border_top().color);
     case CSS::PropertyID::BorderTopLeftRadius: {
         auto const& border_radius = layout_node.computed_values().border_top_left_radius();
         return BorderRadiusStyleValue::create(border_radius.horizontal_radius, border_radius.vertical_radius);
@@ -292,86 +235,136 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         auto const& border_radius = layout_node.computed_values().border_top_right_radius();
         return BorderRadiusStyleValue::create(border_radius.horizontal_radius, border_radius.vertical_radius);
     }
-    case CSS::PropertyID::BorderTopWidth:
-        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_top().width));
-    case CSS::PropertyID::BorderRightWidth:
-        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_right().width));
-    case CSS::PropertyID::BorderBottomWidth:
-        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_bottom().width));
-    case CSS::PropertyID::BorderLeftWidth:
-        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_left().width));
-    case CSS::PropertyID::BorderTopColor:
-        return ColorStyleValue::create(layout_node.computed_values().border_top().color);
-    case CSS::PropertyID::BorderRightColor:
-        return ColorStyleValue::create(layout_node.computed_values().border_right().color);
-    case CSS::PropertyID::BorderBottomColor:
-        return ColorStyleValue::create(layout_node.computed_values().border_bottom().color);
-    case CSS::PropertyID::BorderLeftColor:
-        return ColorStyleValue::create(layout_node.computed_values().border_left().color);
     case CSS::PropertyID::BorderTopStyle:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_top().line_style));
-    case CSS::PropertyID::BorderRightStyle:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_right().line_style));
-    case CSS::PropertyID::BorderBottomStyle:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_bottom().line_style));
-    case CSS::PropertyID::BorderLeftStyle:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_left().line_style));
-    case CSS::PropertyID::BorderTop: {
-        auto border = layout_node.computed_values().border_top();
-        auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
-        auto color = ColorStyleValue::create(border.color);
-        return BorderStyleValue::create(width, style, color);
+    case CSS::PropertyID::BorderTopWidth:
+        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_top().width));
+    case CSS::PropertyID::BoxShadow: {
+        auto box_shadow_layers = layout_node.computed_values().box_shadow();
+        if (box_shadow_layers.is_empty())
+            return {};
+
+        auto make_box_shadow_style_value = [](ShadowData const& data) {
+            return ShadowStyleValue::create(data.color, data.offset_x, data.offset_y, data.blur_radius, data.spread_distance, data.placement);
+        };
+
+        if (box_shadow_layers.size() == 1)
+            return make_box_shadow_style_value(box_shadow_layers.first());
+
+        NonnullRefPtrVector<StyleValue> box_shadow;
+        box_shadow.ensure_capacity(box_shadow_layers.size());
+        for (auto const& layer : box_shadow_layers)
+            box_shadow.append(make_box_shadow_style_value(layer));
+        return StyleValueList::create(move(box_shadow), StyleValueList::Separator::Comma);
     }
-    case CSS::PropertyID::BorderRight: {
-        auto border = layout_node.computed_values().border_right();
-        auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
-        auto color = ColorStyleValue::create(border.color);
-        return BorderStyleValue::create(width, style, color);
+    case CSS::PropertyID::BoxSizing:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().box_sizing()));
+    case CSS::PropertyID::Clear:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().clear()));
+    case CSS::PropertyID::Color:
+        return ColorStyleValue::create(layout_node.computed_values().color());
+    case CSS::PropertyID::Cursor:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().cursor()));
+    case CSS::PropertyID::Display:
+        return style_value_for_display(layout_node.computed_values().display());
+    case CSS::PropertyID::FlexBasis: {
+        switch (layout_node.computed_values().flex_basis().type) {
+        case FlexBasis::Content:
+            return IdentifierStyleValue::create(CSS::ValueID::Content);
+        case FlexBasis::LengthPercentage:
+            return style_value_for_length_percentage(*layout_node.computed_values().flex_basis().length_percentage);
+        case FlexBasis::Auto:
+            return IdentifierStyleValue::create(CSS::ValueID::Auto);
+        default:
+            VERIFY_NOT_REACHED();
+        }
+        break;
+    case CSS::PropertyID::FlexDirection:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_direction()));
+    case CSS::PropertyID::FlexGrow:
+        return NumericStyleValue::create_float(layout_node.computed_values().flex_grow());
+    case CSS::PropertyID::FlexShrink:
+        return NumericStyleValue::create_float(layout_node.computed_values().flex_shrink());
+    case CSS::PropertyID::FlexWrap:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_wrap()));
+    case CSS::PropertyID::Float:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().float_()));
+    case CSS::PropertyID::Height:
+        return style_value_for_length_percentage(layout_node.computed_values().height());
+    case CSS::PropertyID::ImageRendering:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().image_rendering()));
+    case CSS::PropertyID::JustifyContent:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().justify_content()));
+    case CSS::PropertyID::ListStyleType:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().list_style_type()));
+    case CSS::PropertyID::Margin: {
+        auto margin = layout_node.computed_values().margin();
+        auto values = NonnullRefPtrVector<StyleValue> {};
+        values.append(style_value_for_length_percentage(margin.top));
+        values.append(style_value_for_length_percentage(margin.right));
+        values.append(style_value_for_length_percentage(margin.bottom));
+        values.append(style_value_for_length_percentage(margin.left));
+        return StyleValueList::create(move(values), StyleValueList::Separator::Space);
     }
-    case CSS::PropertyID::BorderBottom: {
-        auto border = layout_node.computed_values().border_bottom();
-        auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
-        auto color = ColorStyleValue::create(border.color);
-        return BorderStyleValue::create(width, style, color);
-    }
-    case CSS::PropertyID::BorderLeft: {
-        auto border = layout_node.computed_values().border_left();
-        auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
-        auto color = ColorStyleValue::create(border.color);
-        return BorderStyleValue::create(width, style, color);
-    }
+    case CSS::PropertyID::MarginBottom:
+        return style_value_for_length_percentage(layout_node.computed_values().margin().bottom);
+    case CSS::PropertyID::MarginLeft:
+        return style_value_for_length_percentage(layout_node.computed_values().margin().left);
+    case CSS::PropertyID::MarginRight:
+        return style_value_for_length_percentage(layout_node.computed_values().margin().right);
+    case CSS::PropertyID::MarginTop:
+        return style_value_for_length_percentage(layout_node.computed_values().margin().top);
+    case CSS::PropertyID::MaxHeight:
+        return style_value_for_length_percentage(layout_node.computed_values().max_height());
+    case CSS::PropertyID::MaxWidth:
+        return style_value_for_length_percentage(layout_node.computed_values().max_width());
+    case CSS::PropertyID::MinHeight:
+        return style_value_for_length_percentage(layout_node.computed_values().min_height());
+    case CSS::PropertyID::MinWidth:
+        return style_value_for_length_percentage(layout_node.computed_values().min_width());
+    case CSS::PropertyID::Opacity:
+        return NumericStyleValue::create_float(layout_node.computed_values().opacity());
+    case CSS::PropertyID::Order:
+        return NumericStyleValue::create_integer(layout_node.computed_values().order());
     case CSS::PropertyID::OverflowX:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().overflow_x()));
     case CSS::PropertyID::OverflowY:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().overflow_y()));
-    case CSS::PropertyID::Color:
-        return ColorStyleValue::create(layout_node.computed_values().color());
-    case PropertyID::BackgroundColor:
-        return ColorStyleValue::create(layout_node.computed_values().background_color());
-    case CSS::PropertyID::Background: {
-        auto maybe_background_color = property(CSS::PropertyID::BackgroundColor);
-        auto maybe_background_image = property(CSS::PropertyID::BackgroundImage);
-        auto maybe_background_position = property(CSS::PropertyID::BackgroundPosition);
-        auto maybe_background_size = property(CSS::PropertyID::BackgroundSize);
-        auto maybe_background_repeat = property(CSS::PropertyID::BackgroundRepeat);
-        auto maybe_background_attachment = property(CSS::PropertyID::BackgroundAttachment);
-        auto maybe_background_origin = property(CSS::PropertyID::BackgroundOrigin);
-        auto maybe_background_clip = property(CSS::PropertyID::BackgroundClip);
-
-        return BackgroundStyleValue::create(
-            value_or_default(maybe_background_color, InitialStyleValue::the()),
-            value_or_default(maybe_background_image, IdentifierStyleValue::create(CSS::ValueID::None)),
-            value_or_default(maybe_background_position, PositionStyleValue::create(PositionEdge::Left, Length::make_px(0), PositionEdge::Top, Length::make_px(0))),
-            value_or_default(maybe_background_size, IdentifierStyleValue::create(CSS::ValueID::Auto)),
-            value_or_default(maybe_background_repeat, BackgroundRepeatStyleValue::create(CSS::Repeat::Repeat, CSS::Repeat::Repeat)),
-            value_or_default(maybe_background_attachment, IdentifierStyleValue::create(CSS::ValueID::Scroll)),
-            value_or_default(maybe_background_origin, IdentifierStyleValue::create(CSS::ValueID::PaddingBox)),
-            value_or_default(maybe_background_clip, IdentifierStyleValue::create(CSS::ValueID::BorderBox)));
+    case CSS::PropertyID::Padding: {
+        auto padding = layout_node.computed_values().padding();
+        auto values = NonnullRefPtrVector<StyleValue> {};
+        values.append(style_value_for_length_percentage(padding.top));
+        values.append(style_value_for_length_percentage(padding.right));
+        values.append(style_value_for_length_percentage(padding.bottom));
+        values.append(style_value_for_length_percentage(padding.left));
+        return StyleValueList::create(move(values), StyleValueList::Separator::Space);
     }
+    case CSS::PropertyID::PaddingBottom:
+    case CSS::PropertyID::PaddingLeft:
+        return style_value_for_length_percentage(layout_node.computed_values().padding().left);
+        return style_value_for_length_percentage(layout_node.computed_values().padding().bottom);
+    case CSS::PropertyID::PaddingRight:
+        return style_value_for_length_percentage(layout_node.computed_values().padding().right);
+    case CSS::PropertyID::PaddingTop:
+        return style_value_for_length_percentage(layout_node.computed_values().padding().top);
+    case CSS::PropertyID::Position:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().position()));
+    case CSS::PropertyID::TextAlign:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_align()));
+    case CSS::PropertyID::TextDecorationLine: {
+        auto text_decoration_lines = layout_node.computed_values().text_decoration_line();
+        if (text_decoration_lines.is_empty())
+            return IdentifierStyleValue::create(ValueID::None);
+        NonnullRefPtrVector<StyleValue> style_values;
+        for (auto const& line : text_decoration_lines) {
+            style_values.append(IdentifierStyleValue::create(to_value_id(line)));
+        }
+        return StyleValueList::create(move(style_values), StyleValueList::Separator::Space);
+    }
+    case CSS::PropertyID::TextDecorationStyle:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_decoration_style()));
+    case CSS::PropertyID::TextTransform:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_transform()));
     case CSS::PropertyID::VerticalAlign:
         if (auto const* length_percentage = layout_node.computed_values().vertical_align().get_pointer<CSS::LengthPercentage>()) {
             if (length_percentage->is_length())
@@ -381,10 +374,16 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
             VERIFY_NOT_REACHED();
         }
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().vertical_align().get<CSS::VerticalAlign>()));
-    case CSS::PropertyID::ListStyleType:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().list_style_type()));
-    case CSS::PropertyID::BoxSizing:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().box_sizing()));
+    case CSS::PropertyID::WhiteSpace:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().white_space()));
+    case CSS::PropertyID::Width:
+        return style_value_for_length_percentage(layout_node.computed_values().width());
+    case CSS::PropertyID::ZIndex: {
+        auto maybe_z_index = layout_node.computed_values().z_index();
+        if (!maybe_z_index.has_value())
+            return {};
+        return NumericStyleValue::create_integer(maybe_z_index.release_value());
+    }
     case CSS::PropertyID::Invalid:
         return IdentifierStyleValue::create(CSS::ValueID::Invalid);
     case CSS::PropertyID::Custom:

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -261,7 +261,7 @@ Vector<CSS::Transformation> StyleProperties::transformations() const
         auto& transformation_style_value = it.as_transformation();
         CSS::Transformation transformation;
         transformation.function = transformation_style_value.transform_function();
-        Vector<Variant<CSS::LengthPercentage, float>> values;
+        Vector<TransformValue> values;
         for (auto& transformation_value : transformation_style_value.values()) {
             if (transformation_value.is_length()) {
                 values.append({ transformation_value.to_length() });
@@ -270,7 +270,7 @@ Vector<CSS::Transformation> StyleProperties::transformations() const
             } else if (transformation_value.is_numeric()) {
                 values.append({ transformation_value.to_number() });
             } else if (transformation_value.is_angle()) {
-                values.append({ transformation_value.as_angle().angle().to_degrees() });
+                values.append({ transformation_value.as_angle().angle() });
             } else {
                 dbgln("FIXME: Unsupported value in transform!");
             }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -661,18 +661,15 @@ Optional<Angle> CalculatedStyleValue::resolve_angle() const
     return {};
 }
 
-Optional<AnglePercentage> CalculatedStyleValue::resolve_angle_percentage(Angle const& percentage_basis) const
+Optional<Angle> CalculatedStyleValue::resolve_angle_percentage(Angle const& percentage_basis) const
 {
     auto result = m_expression->resolve(nullptr, percentage_basis);
 
     return result.value().visit(
-        [&](Angle const& angle) -> Optional<AnglePercentage> {
+        [&](Angle const& angle) -> Optional<Angle> {
             return angle;
         },
-        [&](Percentage const& percentage) -> Optional<AnglePercentage> {
-            return percentage;
-        },
-        [&](auto const&) -> Optional<AnglePercentage> {
+        [&](auto const&) -> Optional<Angle> {
             return {};
         });
 }
@@ -686,18 +683,15 @@ Optional<Frequency> CalculatedStyleValue::resolve_frequency() const
     return {};
 }
 
-Optional<FrequencyPercentage> CalculatedStyleValue::resolve_frequency_percentage(Frequency const& percentage_basis) const
+Optional<Frequency> CalculatedStyleValue::resolve_frequency_percentage(Frequency const& percentage_basis) const
 {
     auto result = m_expression->resolve(nullptr, percentage_basis);
 
     return result.value().visit(
-        [&](Frequency const& frequency) -> Optional<FrequencyPercentage> {
+        [&](Frequency const& frequency) -> Optional<Frequency> {
             return frequency;
         },
-        [&](Percentage const& percentage) -> Optional<FrequencyPercentage> {
-            return percentage;
-        },
-        [&](auto const&) -> Optional<FrequencyPercentage> {
+        [&](auto const&) -> Optional<Frequency> {
             return {};
         });
 }
@@ -711,18 +705,15 @@ Optional<Length> CalculatedStyleValue::resolve_length(Layout::Node const& layout
     return {};
 }
 
-Optional<LengthPercentage> CalculatedStyleValue::resolve_length_percentage(Layout::Node const& layout_node, Length const& percentage_basis) const
+Optional<Length> CalculatedStyleValue::resolve_length_percentage(Layout::Node const& layout_node, Length const& percentage_basis) const
 {
     auto result = m_expression->resolve(&layout_node, percentage_basis);
 
     return result.value().visit(
-        [&](Length const& length) -> Optional<LengthPercentage> {
+        [&](Length const& length) -> Optional<Length> {
             return length;
         },
-        [&](Percentage const& percentage) -> Optional<LengthPercentage> {
-            return percentage;
-        },
-        [&](auto const&) -> Optional<LengthPercentage> {
+        [&](auto const&) -> Optional<Length> {
             return {};
         });
 }
@@ -744,18 +735,15 @@ Optional<Time> CalculatedStyleValue::resolve_time() const
     return {};
 }
 
-Optional<TimePercentage> CalculatedStyleValue::resolve_time_percentage(Time const& percentage_basis) const
+Optional<Time> CalculatedStyleValue::resolve_time_percentage(Time const& percentage_basis) const
 {
     auto result = m_expression->resolve(nullptr, percentage_basis);
 
     return result.value().visit(
-        [&](Time const& time) -> Optional<TimePercentage> {
+        [&](Time const& time) -> Optional<Time> {
             return time;
         },
-        [&](Percentage const& percentage) -> Optional<TimePercentage> {
-            return percentage;
-        },
-        [&](auto const&) -> Optional<TimePercentage> {
+        [&](auto const&) -> Optional<Time> {
             return {};
         });
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -676,15 +676,27 @@ public:
     ResolvedType resolved_type() const { return m_resolved_type; }
     NonnullOwnPtr<CalcSum> const& expression() const { return m_expression; }
 
+    bool resolves_to_angle() const { return m_resolved_type == ResolvedType::Angle; }
     Optional<Angle> resolve_angle() const;
     Optional<Angle> resolve_angle_percentage(Angle const& percentage_basis) const;
+
+    bool resolves_to_frequency() const { return m_resolved_type == ResolvedType::Frequency; }
     Optional<Frequency> resolve_frequency() const;
     Optional<Frequency> resolve_frequency_percentage(Frequency const& percentage_basis) const;
+
+    bool resolves_to_length() const { return m_resolved_type == ResolvedType::Length; }
     Optional<Length> resolve_length(Layout::Node const& layout_node) const;
     Optional<Length> resolve_length_percentage(Layout::Node const&, Length const& percentage_basis) const;
+
+    bool resolves_to_percentage() const { return m_resolved_type == ResolvedType::Percentage; }
     Optional<Percentage> resolve_percentage() const;
+
+    bool resolves_to_time() const { return m_resolved_type == ResolvedType::Time; }
     Optional<Time> resolve_time() const;
     Optional<Time> resolve_time_percentage(Time const& percentage_basis) const;
+
+    bool resolves_to_integer() const { return m_resolved_type == ResolvedType::Integer; }
+    bool resolves_to_number() const { return resolves_to_integer() || m_resolved_type == ResolvedType::Number; }
     Optional<float> resolve_number();
     Optional<i64> resolve_integer();
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -677,14 +677,14 @@ public:
     NonnullOwnPtr<CalcSum> const& expression() const { return m_expression; }
 
     Optional<Angle> resolve_angle() const;
-    Optional<AnglePercentage> resolve_angle_percentage(Angle const& percentage_basis) const;
+    Optional<Angle> resolve_angle_percentage(Angle const& percentage_basis) const;
     Optional<Frequency> resolve_frequency() const;
-    Optional<FrequencyPercentage> resolve_frequency_percentage(Frequency const& percentage_basis) const;
+    Optional<Frequency> resolve_frequency_percentage(Frequency const& percentage_basis) const;
     Optional<Length> resolve_length(Layout::Node const& layout_node) const;
-    Optional<LengthPercentage> resolve_length_percentage(Layout::Node const&, Length const& percentage_basis) const;
+    Optional<Length> resolve_length_percentage(Layout::Node const&, Length const& percentage_basis) const;
     Optional<Percentage> resolve_percentage() const;
     Optional<Time> resolve_time() const;
-    Optional<TimePercentage> resolve_time_percentage(Time const& percentage_basis) const;
+    Optional<Time> resolve_time_percentage(Time const& percentage_basis) const;
     Optional<float> resolve_number();
     Optional<i64> resolve_integer();
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -30,13 +30,6 @@ public:
         Gfx::FloatRect scrollable_overflow_rect;
         Gfx::FloatPoint scroll_offset;
     };
-    Optional<OverflowData> m_overflow_data;
-
-    Gfx::FloatPoint m_offset;
-    Gfx::FloatSize m_content_size;
-
-    // Some boxes hang off of line box fragments. (inline-block, inline-table, replaced, etc)
-    Optional<Layout::LineBoxFragmentCoordinate> m_containing_line_box_fragment;
 
     Gfx::FloatRect absolute_rect() const;
     Gfx::FloatPoint effective_offset() const;
@@ -133,6 +126,14 @@ protected:
     Painting::BorderRadiiData normalized_border_radii_data() const;
 
 private:
+    Optional<OverflowData> m_overflow_data;
+
+    Gfx::FloatPoint m_offset;
+    Gfx::FloatSize m_content_size;
+
+    // Some boxes hang off of line box fragments. (inline-block, inline-table, replaced, etc)
+    Optional<Layout::LineBoxFragmentCoordinate> m_containing_line_box_fragment;
+
     OwnPtr<Painting::StackingContext> m_stacking_context;
 
     Optional<Gfx::FloatRect> mutable m_absolute_rect;

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -247,6 +247,10 @@ Gfx::FloatMatrix4x4 StackingContext::get_transformation_matrix(CSS::Transformati
                 0, 0, 1, 0,
                 0, 0, 0, 1);
         break;
+    case CSS::TransformFunction::Rotate:
+        if (count == 1)
+            return Gfx::rotation_matrix({ 0.0f, 0.0f, 1.0f }, value(0));
+        break;
     default:
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Unhandled transformation function {}", CSS::TransformationStyleValue::create(transformation.function, {})->to_string());
     }

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,6 +29,7 @@ static void paint_node(Layout::Node const& layout_node, PaintContext& context, P
 
 StackingContext::StackingContext(Layout::Box& box, StackingContext* parent)
     : m_box(box)
+    , m_transform(combine_transformations(m_box.computed_values().transformations()))
     , m_parent(parent)
 {
     VERIFY(m_parent != this);
@@ -269,10 +271,9 @@ Gfx::FloatMatrix4x4 StackingContext::combine_transformations(Vector<CSS::Transfo
 
 // FIXME: This extracts the affine 2D part of the full transformation matrix.
 //  Use the whole matrix when we get better transformation support in LibGfx or use LibGL for drawing the bitmap
-Gfx::AffineTransform StackingContext::combine_transformations_2d(Vector<CSS::Transformation> const& transformations) const
+Gfx::AffineTransform StackingContext::affine_transform_matrix() const
 {
-    auto matrix = combine_transformations(transformations);
-    auto* m = matrix.elements();
+    auto* m = m_transform.elements();
     return Gfx::AffineTransform(m[0][0], m[1][0], m[0][1], m[1][1], m[0][3], m[1][3]);
 }
 
@@ -287,7 +288,7 @@ void StackingContext::paint(PaintContext& context) const
     if (opacity == 0.0f)
         return;
 
-    auto affine_transform = combine_transformations_2d(m_box.computed_values().transformations());
+    auto affine_transform = affine_transform_matrix();
 
     if (opacity < 1.0f || !affine_transform.is_identity()) {
         auto bitmap_or_error = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, context.painter().target()->size());
@@ -327,8 +328,7 @@ Optional<HitTestResult> StackingContext::hit_test(Gfx::FloatPoint const& positio
         return {};
 
     auto transform_origin = this->transform_origin();
-    auto affine_transform = combine_transformations_2d(m_box.computed_values().transformations());
-    auto transformed_position = affine_transform.inverse().value_or({}).map(position - transform_origin) + transform_origin;
+    auto transformed_position = affine_transform_matrix().inverse().value_or({}).map(position - transform_origin) + transform_origin;
 
     // FIXME: Support more overflow variations.
     if (paintable().computed_values().overflow_x() == CSS::Overflow::Hidden && paintable().computed_values().overflow_y() == CSS::Overflow::Hidden) {
@@ -441,7 +441,7 @@ void StackingContext::dump(int indent) const
         builder.append("auto"sv);
     builder.append(')');
 
-    auto affine_transform = combine_transformations_2d(m_box.computed_values().transformations());
+    auto affine_transform = affine_transform_matrix();
     if (!affine_transform.is_identity()) {
         builder.appendff(", transform: {}", affine_transform);
     }

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.h
@@ -34,19 +34,22 @@ public:
     void paint(PaintContext&) const;
     Optional<HitTestResult> hit_test(Gfx::FloatPoint const&, HitTestType) const;
 
+    Gfx::FloatMatrix4x4 const& transform_matrix() const { return m_transform; }
+    Gfx::AffineTransform affine_transform_matrix() const;
+
     void dump(int indent = 0) const;
 
     void sort();
 
 private:
     Layout::Box& m_box;
+    Gfx::FloatMatrix4x4 m_transform;
     StackingContext* const m_parent { nullptr };
     Vector<StackingContext*> m_children;
 
     void paint_internal(PaintContext&) const;
     Gfx::FloatMatrix4x4 get_transformation_matrix(CSS::Transformation const& transformation) const;
     Gfx::FloatMatrix4x4 combine_transformations(Vector<CSS::Transformation> const& transformations) const;
-    Gfx::AffineTransform combine_transformations_2d(Vector<CSS::Transformation> const& transformations) const;
     Gfx::FloatPoint transform_origin() const;
 };
 


### PR DESCRIPTION
This takes us from passing *none* of the tests at https://wpt.live/css/css-values/calc-angle-values.html to passing 27/27! :^)

This was quite a yak-shaving safari, and there are a couple of tangential commits here. :sweat_smile: 