### PR TITLE
LibC+Tests(+Kernel): Implement `pthread_cancel` and its helper functions

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -738,7 +738,7 @@ void Process::die()
 void Process::terminate_due_to_signal(u8 signal)
 {
     VERIFY_INTERRUPTS_DISABLED();
-    VERIFY(signal < 32);
+    VERIFY(signal < NSIG);
     VERIFY(&Process::current() == this);
     dbgln("Terminating {} due to signal {}", *this, signal);
     {

--- a/Kernel/Syscalls/sigaction.cpp
+++ b/Kernel/Syscalls/sigaction.cpp
@@ -54,7 +54,7 @@ ErrorOr<FlatPtr> Process::sys$sigaction(int signum, Userspace<sigaction const*> 
 {
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     TRY(require_promise(Pledge::sigaction));
-    if (signum < 1 || signum >= 32 || signum == SIGKILL || signum == SIGSTOP)
+    if (signum < 1 || signum >= NSIG || signum == SIGKILL || signum == SIGSTOP)
         return EINVAL;
 
     InterruptDisabler disabler; // FIXME: This should use a narrower lock. Maybe a way to ignore signals temporarily?

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -156,7 +156,7 @@ ErrorOr<FlatPtr> Process::sys$kill_thread(pid_t tid, int signal)
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     TRY(require_promise(Pledge::thread));
 
-    if (signal < 0 || signal >= 32)
+    if (signal < 0 || signal >= NSIG)
         return EINVAL;
 
     auto thread = Thread::from_tid(tid);

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -871,6 +871,7 @@ static DefaultSignalAction default_signal_action(u8 signal)
     case SIGIO:
     case SIGPROF:
     case SIGTERM:
+    case SIGCANCEL:
         return DefaultSignalAction::Terminate;
     case SIGCHLD:
     case SIGURG:

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -720,7 +720,7 @@ u32 Thread::pending_signals_for_state() const
 
 void Thread::send_signal(u8 signal, [[maybe_unused]] Process* sender)
 {
-    VERIFY(signal < 32);
+    VERIFY(signal < NSIG);
     VERIFY(process().is_user_process());
     SpinlockLocker scheduler_lock(g_scheduler_lock);
 
@@ -827,7 +827,7 @@ DispatchSignalResult Thread::dispatch_one_pending_signal()
         return DispatchSignalResult::Continue;
 
     u8 signal = 1;
-    for (; signal < 32; ++signal) {
+    for (; signal < NSIG; ++signal) {
         if ((signal_candidates & (1 << (signal - 1))) != 0) {
             break;
         }
@@ -902,7 +902,7 @@ static DefaultSignalAction default_signal_action(u8 signal)
 
 bool Thread::should_ignore_signal(u8 signal) const
 {
-    VERIFY(signal < 32);
+    VERIFY(signal < NSIG);
     auto const& action = m_process->m_signal_action_data[signal];
     if (action.handler_or_sigaction.is_null())
         return default_signal_action(signal) == DefaultSignalAction::Ignore;
@@ -911,14 +911,14 @@ bool Thread::should_ignore_signal(u8 signal) const
 
 bool Thread::has_signal_handler(u8 signal) const
 {
-    VERIFY(signal < 32);
+    VERIFY(signal < NSIG);
     auto const& action = m_process->m_signal_action_data[signal];
     return !action.handler_or_sigaction.is_null();
 }
 
 bool Thread::is_signal_masked(u8 signal) const
 {
-    VERIFY(signal < 32);
+    VERIFY(signal < NSIG);
     return (1 << (signal - 1)) & m_signal_mask;
 }
 
@@ -969,7 +969,7 @@ DispatchSignalResult Thread::dispatch_signal(u8 signal)
 {
     VERIFY_INTERRUPTS_DISABLED();
     VERIFY(g_scheduler_lock.is_locked_by_current_processor());
-    VERIFY(signal > 0 && signal <= 32);
+    VERIFY(signal > 0 && signal <= NSIG);
     VERIFY(process().is_user_process());
     VERIFY(this == Thread::current());
 

--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_SOURCES
     TestMemalign.cpp
     TestMemmem.cpp
     TestMkDir.cpp
+    TestPthreadCancel.cpp
     TestPthreadCleanup.cpp
     TestPthreadSpinLocks.cpp
     TestPthreadRWLocks.cpp

--- a/Tests/LibC/TestPthreadCancel.cpp
+++ b/Tests/LibC/TestPthreadCancel.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022, Tim Schumacher <timschumi@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <pthread.h>
+
+#define TEST_CASE_IN_PTHREAD(x)                                                 \
+    static void* __TESTCASE_FUNC(x##__inner)(void*);                            \
+    TEST_CASE(x)                                                                \
+    {                                                                           \
+        pthread_t thread;                                                       \
+        pthread_create(&thread, nullptr, __TESTCASE_FUNC(x##__inner), nullptr); \
+        pthread_join(thread, nullptr);                                          \
+    }                                                                           \
+    static void* __TESTCASE_FUNC(x##__inner)(void*)
+
+TEST_CASE_IN_PTHREAD(cancel_state_valid)
+{
+    int old_state = 0;
+
+    // Ensure that we return the default state correctly.
+    EXPECT_EQ(pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old_state), 0);
+    EXPECT_EQ(old_state, PTHREAD_CANCEL_ENABLE);
+
+    // Make sure that PTHREAD_CANCEL_DISABLE sticks.
+    EXPECT_EQ(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_state), 0);
+    EXPECT_EQ(old_state, PTHREAD_CANCEL_DISABLE);
+
+    return nullptr;
+}
+
+TEST_CASE_IN_PTHREAD(cancel_state_invalid)
+{
+    constexpr int lower_invalid_state = min(PTHREAD_CANCEL_ENABLE, PTHREAD_CANCEL_DISABLE) - 1;
+    constexpr int upper_invalid_state = max(PTHREAD_CANCEL_ENABLE, PTHREAD_CANCEL_DISABLE) + 1;
+
+    int old_state = 0;
+
+    // Check that both invalid states are rejected and don't change the old state.
+    EXPECT_EQ(pthread_setcancelstate(lower_invalid_state, &old_state), EINVAL);
+    EXPECT_EQ(old_state, 0);
+    EXPECT_EQ(pthread_setcancelstate(upper_invalid_state, &old_state), EINVAL);
+    EXPECT_EQ(old_state, 0);
+
+    // Ensure that we are still in the default state afterwards.
+    EXPECT_EQ(pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old_state), 0);
+    EXPECT_EQ(old_state, PTHREAD_CANCEL_ENABLE);
+
+    return nullptr;
+}
+
+TEST_CASE_IN_PTHREAD(cancel_type_valid)
+{
+    int old_type = 0;
+
+    // Ensure that we return the default type correctly.
+    EXPECT_EQ(pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &old_type), 0);
+    EXPECT_EQ(old_type, PTHREAD_CANCEL_DEFERRED);
+
+    // Make sure that PTHREAD_CANCEL_ASYNCHRONOUS sticks (not that it should ever be used).
+    EXPECT_EQ(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, &old_type), 0);
+    EXPECT_EQ(old_type, PTHREAD_CANCEL_ASYNCHRONOUS);
+
+    return nullptr;
+}
+
+TEST_CASE_IN_PTHREAD(cancel_type_invalid)
+{
+    constexpr int lower_invalid_type = min(PTHREAD_CANCEL_DEFERRED, PTHREAD_CANCEL_ASYNCHRONOUS) - 1;
+    constexpr int upper_invalid_type = max(PTHREAD_CANCEL_DEFERRED, PTHREAD_CANCEL_ASYNCHRONOUS) + 1;
+
+    int old_type = 0;
+
+    // Check that both invalid types are rejected and don't change the old type.
+    EXPECT_EQ(pthread_setcanceltype(lower_invalid_type, &old_type), EINVAL);
+    EXPECT_EQ(old_type, 0);
+    EXPECT_EQ(pthread_setcanceltype(upper_invalid_type, &old_type), EINVAL);
+    EXPECT_EQ(old_type, 0);
+
+    // Ensure that we are still in the default state afterwards.
+    EXPECT_EQ(pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &old_type), 0);
+    EXPECT_EQ(old_type, PTHREAD_CANCEL_DEFERRED);
+
+    return nullptr;
+}

--- a/Userland/Libraries/LibC/bits/pthread_cancel.h
+++ b/Userland/Libraries/LibC/bits/pthread_cancel.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+__BEGIN_DECLS
+
+// This is our hook for cancellation points.
+#ifdef _DYNAMIC_LOADER
+inline void __pthread_maybe_cancel(void)
+{
+}
+#else
+void __pthread_maybe_cancel(void);
+#endif
+
+__END_DECLS

--- a/Userland/Libraries/LibC/fcntl.cpp
+++ b/Userland/Libraries/LibC/fcntl.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
@@ -17,6 +18,8 @@ extern "C" {
 
 int fcntl(int fd, int cmd, ...)
 {
+    __pthread_maybe_cancel();
+
     va_list ap;
     va_start(ap, cmd);
     uintptr_t extra_arg = va_arg(ap, uintptr_t);
@@ -46,11 +49,15 @@ int inode_watcher_remove_watch(int fd, int wd)
 
 int creat(char const* path, mode_t mode)
 {
+    __pthread_maybe_cancel();
+
     return open(path, O_CREAT | O_WRONLY | O_TRUNC, mode);
 }
 
 int open(char const* path, int options, ...)
 {
+    __pthread_maybe_cancel();
+
     if (!path) {
         errno = EFAULT;
         return -1;
@@ -71,6 +78,8 @@ int open(char const* path, int options, ...)
 
 int openat(int dirfd, char const* path, int options, ...)
 {
+    __pthread_maybe_cancel();
+
     if (!path) {
         errno = EFAULT;
         return -1;

--- a/Userland/Libraries/LibC/poll.cpp
+++ b/Userland/Libraries/LibC/poll.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <poll.h>
 #include <sys/time.h>
@@ -14,6 +15,8 @@ extern "C" {
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html
 int poll(pollfd* fds, nfds_t nfds, int timeout_ms)
 {
+    __pthread_maybe_cancel();
+
     timespec timeout;
     timespec* timeout_ts = &timeout;
     if (timeout_ms < 0)

--- a/Userland/Libraries/LibC/pthread.cpp
+++ b/Userland/Libraries/LibC/pthread.cpp
@@ -192,6 +192,8 @@ void pthread_cleanup_pop(int execute)
 // https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_join.html
 int pthread_join(pthread_t thread, void** exit_value_ptr)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_join_thread, thread, exit_value_ptr);
     __RETURN_PTHREAD_ERROR(rc);
 }

--- a/Userland/Libraries/LibC/pthread.cpp
+++ b/Userland/Libraries/LibC/pthread.cpp
@@ -38,6 +38,9 @@ static constexpr size_t highest_reasonable_stack_size = 8 * MiB; // That's the d
 __thread void* s_stack_location;
 __thread size_t s_stack_size;
 
+__thread int s_thread_cancel_state = PTHREAD_CANCEL_ENABLE;
+__thread int s_thread_cancel_type = PTHREAD_CANCEL_DEFERRED;
+
 #define __RETURN_PTHREAD_ERROR(rc) \
     return ((rc) < 0 ? -(rc) : 0)
 
@@ -502,22 +505,22 @@ int pthread_getname_np(pthread_t thread, char* buffer, size_t buffer_size)
 // https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_setcancelstate.html
 int pthread_setcancelstate(int state, int* oldstate)
 {
-    if (oldstate)
-        *oldstate = PTHREAD_CANCEL_DISABLE;
-    dbgln("FIXME: Implement pthread_setcancelstate({}, ...)", state);
-    if (state != PTHREAD_CANCEL_DISABLE)
+    if (state != PTHREAD_CANCEL_ENABLE && state != PTHREAD_CANCEL_DISABLE)
         return EINVAL;
+    if (oldstate)
+        *oldstate = s_thread_cancel_state;
+    s_thread_cancel_state = state;
     return 0;
 }
 
 // https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_setcanceltype.html
 int pthread_setcanceltype(int type, int* oldtype)
 {
-    if (oldtype)
-        *oldtype = PTHREAD_CANCEL_DEFERRED;
-    dbgln("FIXME: Implement pthread_setcanceltype({}, ...)", type);
-    if (type != PTHREAD_CANCEL_DEFERRED)
+    if (type != PTHREAD_CANCEL_DEFERRED && type != PTHREAD_CANCEL_ASYNCHRONOUS)
         return EINVAL;
+    if (oldtype)
+        *oldtype = s_thread_cancel_type;
+    s_thread_cancel_type = type;
     return 0;
 }
 

--- a/Userland/Libraries/LibC/pthread.h
+++ b/Userland/Libraries/LibC/pthread.h
@@ -33,7 +33,7 @@ int pthread_attr_destroy(pthread_attr_t*);
 #define PTHREAD_CREATE_JOINABLE 0
 #define PTHREAD_CREATE_DETACHED 1
 
-#define PTHREAD_CANCELED (-1)
+#define PTHREAD_CANCELED ((void*)-1)
 
 int pthread_attr_getdetachstate(pthread_attr_t const*, int*);
 int pthread_attr_setdetachstate(pthread_attr_t*, int);

--- a/Userland/Libraries/LibC/pthread_cond.cpp
+++ b/Userland/Libraries/LibC/pthread_cond.cpp
@@ -8,6 +8,7 @@
 #include <AK/Assertions.h>
 #include <AK/Atomic.h>
 #include <AK/Types.h>
+#include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <pthread.h>
 #include <serenity.h>
@@ -87,6 +88,8 @@ int pthread_cond_wait(pthread_cond_t* cond, pthread_mutex_t* mutex)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_cond_timedwait.html
 int pthread_cond_timedwait(pthread_cond_t* cond, pthread_mutex_t* mutex, const struct timespec* abstime)
 {
+    __pthread_maybe_cancel();
+
     // Save the mutex this condition variable is associated with. We don't (yet)
     // support changing this mutex once set.
     pthread_mutex_t* old_mutex = AK::atomic_exchange(&cond->mutex, mutex, AK::memory_order_relaxed);

--- a/Userland/Libraries/LibC/semaphore.cpp
+++ b/Userland/Libraries/LibC/semaphore.cpp
@@ -12,6 +12,7 @@
 #include <AK/ScopeGuard.h>
 #include <AK/String.h>
 #include <AK/Types.h>
+#include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
@@ -310,6 +311,8 @@ int sem_wait(sem_t* sem)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/sem_timedwait.html
 int sem_timedwait(sem_t* sem, const struct timespec* abstime)
 {
+    __pthread_maybe_cancel();
+
     if (sem->magic != SEM_MAGIC) {
         errno = EINVAL;
         return -1;

--- a/Userland/Libraries/LibC/signal.cpp
+++ b/Userland/Libraries/LibC/signal.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Format.h>
 #include <assert.h>
+#include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <setjmp.h>
 #include <signal.h>
@@ -175,6 +176,8 @@ void siglongjmp(jmp_buf env, int val)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigsuspend.html
 int sigsuspend(sigset_t const* set)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_sigsuspend, set);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
@@ -182,6 +185,8 @@ int sigsuspend(sigset_t const* set)
 // https://pubs.opengroup.org/onlinepubs/009604499/functions/sigwait.html
 int sigwait(sigset_t const* set, int* sig)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(Syscall::SC_sigtimedwait, set, nullptr, nullptr);
     VERIFY(rc != 0);
     if (rc < 0)
@@ -199,6 +204,8 @@ int sigwaitinfo(sigset_t const* set, siginfo_t* info)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigtimedwait.html
 int sigtimedwait(sigset_t const* set, siginfo_t* info, struct timespec const* timeout)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(Syscall::SC_sigtimedwait, set, info, timeout);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }

--- a/Userland/Libraries/LibC/signal_numbers.h
+++ b/Userland/Libraries/LibC/signal_numbers.h
@@ -38,4 +38,5 @@
 #define SIGIO 29
 #define SIGINFO 30
 #define SIGSYS 31
-#define NSIG 32
+#define SIGCANCEL 32
+#define NSIG 33

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -14,6 +14,7 @@
 #include <LibELF/AuxiliaryVector.h>
 #include <alloca.h>
 #include <assert.h>
+#include <bits/pthread_cancel.h>
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -810,6 +811,8 @@ void srandom(unsigned seed)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/system.html
 int system(char const* command)
 {
+    __pthread_maybe_cancel();
+
     if (!command)
         return 1;
 

--- a/Userland/Libraries/LibC/sys/mman.cpp
+++ b/Userland/Libraries/LibC/sys/mman.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Format.h>
+#include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
@@ -110,6 +111,8 @@ int munlock(void const*, size_t)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/msync.html
 int msync(void* address, size_t size, int flags)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_msync, address, size, flags);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }

--- a/Userland/Libraries/LibC/sys/select.cpp
+++ b/Userland/Libraries/LibC/sys/select.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <stdio.h>
 #include <sys/poll.h>
@@ -18,6 +19,8 @@ extern "C" {
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/select.html
 int select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, timeval* timeout_tv)
 {
+    __pthread_maybe_cancel();
+
     timespec* timeout_ts = nullptr;
     timespec timeout;
     if (timeout_tv) {
@@ -30,6 +33,8 @@ int select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, timev
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/pselect.html
 int pselect(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, timespec const* timeout, sigset_t const* sigmask)
 {
+    __pthread_maybe_cancel();
+
     Vector<pollfd, FD_SETSIZE> fds;
 
     if (nfds < 0 || static_cast<size_t>(nfds) >= fds.capacity())

--- a/Userland/Libraries/LibC/sys/socket.cpp
+++ b/Userland/Libraries/LibC/sys/socket.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Assertions.h>
+#include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
@@ -38,6 +39,8 @@ int listen(int sockfd, int backlog)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html
 int accept(int sockfd, sockaddr* addr, socklen_t* addrlen)
 {
+    __pthread_maybe_cancel();
+
     return accept4(sockfd, addr, addrlen, 0);
 }
 
@@ -51,6 +54,8 @@ int accept4(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
 int connect(int sockfd, sockaddr const* addr, socklen_t addrlen)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_connect, sockfd, addr, addrlen);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
@@ -65,6 +70,8 @@ int shutdown(int sockfd, int how)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html
 ssize_t sendmsg(int sockfd, const struct msghdr* msg, int flags)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_sendmsg, sockfd, msg, flags);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
@@ -86,6 +93,8 @@ ssize_t send(int sockfd, void const* data, size_t data_length, int flags)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html
 ssize_t recvmsg(int sockfd, struct msghdr* msg, int flags)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_recvmsg, sockfd, msg, flags);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
@@ -93,6 +102,8 @@ ssize_t recvmsg(int sockfd, struct msghdr* msg, int flags)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html
 ssize_t recvfrom(int sockfd, void* buffer, size_t buffer_length, int flags, struct sockaddr* addr, socklen_t* addr_length)
 {
+    __pthread_maybe_cancel();
+
     if (!addr_length && addr) {
         errno = EINVAL;
         return -1;

--- a/Userland/Libraries/LibC/sys/uio.cpp
+++ b/Userland/Libraries/LibC/sys/uio.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <sys/uio.h>
 #include <syscall.h>
@@ -12,12 +13,16 @@ extern "C" {
 
 ssize_t writev(int fd, const struct iovec* iov, int iov_count)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_writev, fd, iov, iov_count);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
 ssize_t readv(int fd, const struct iovec* iov, int iov_count)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_readv, fd, iov, iov_count);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }

--- a/Userland/Libraries/LibC/sys/wait.cpp
+++ b/Userland/Libraries/LibC/sys/wait.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <assert.h>
+#include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <sys/wait.h>
 #include <syscall.h>
@@ -21,6 +22,8 @@ pid_t wait(int* wstatus)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/waitpid.html
 pid_t waitpid(pid_t waitee, int* wstatus, int options)
 {
+    __pthread_maybe_cancel();
+
     siginfo_t siginfo;
     idtype_t idtype;
     id_t id;
@@ -78,6 +81,8 @@ pid_t waitpid(pid_t waitee, int* wstatus, int options)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/waitid.html
 int waitid(idtype_t idtype, id_t id, siginfo_t* infop, int options)
 {
+    __pthread_maybe_cancel();
+
     Syscall::SC_waitid_params params { idtype, id, infop, options };
     int rc = syscall(SC_waitid, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);

--- a/Userland/Libraries/LibC/termios.cpp
+++ b/Userland/Libraries/LibC/termios.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <assert.h>
+#include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <sys/ioctl.h>
 #include <termios.h>
@@ -51,6 +52,8 @@ int tcflush(int fd, int queue_selector)
 // https://pubs.opengroup.org/onlinepubs/009695399/functions/tcdrain.html
 int tcdrain([[maybe_unused]] int fd)
 {
+    __pthread_maybe_cancel();
+
     // FIXME: Implement this for real.
     return 0;
 }

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -11,6 +11,7 @@
 #include <Kernel/API/TimePage.h>
 #include <LibTimeZone/TimeZone.h>
 #include <assert.h>
+#include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
@@ -458,6 +459,8 @@ int clock_settime(clockid_t clock_id, struct timespec* ts)
 
 int clock_nanosleep(clockid_t clock_id, int flags, const struct timespec* requested_sleep, struct timespec* remaining_sleep)
 {
+    __pthread_maybe_cancel();
+
     Syscall::SC_clock_nanosleep_params params { clock_id, flags, requested_sleep, remaining_sleep };
     int rc = syscall(SC_clock_nanosleep, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -10,6 +10,7 @@
 #include <AK/Vector.h>
 #include <alloca.h>
 #include <assert.h>
+#include <bits/pthread_cancel.h>
 #include <bits/pthread_integration.h>
 #include <dirent.h>
 #include <errno.h>
@@ -374,6 +375,8 @@ pid_t getpgrp()
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html
 ssize_t read(int fd, void* buf, size_t count)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_read, fd, buf, count);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
@@ -381,6 +384,8 @@ ssize_t read(int fd, void* buf, size_t count)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/pread.html
 ssize_t pread(int fd, void* buf, size_t count, off_t offset)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_pread, fd, buf, count, &offset);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
@@ -388,6 +393,8 @@ ssize_t pread(int fd, void* buf, size_t count, off_t offset)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html
 ssize_t write(int fd, void const* buf, size_t count)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_write, fd, buf, count);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
@@ -395,6 +402,8 @@ ssize_t write(int fd, void const* buf, size_t count)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/pwrite.html
 ssize_t pwrite(int fd, void const* buf, size_t count, off_t offset)
 {
+    __pthread_maybe_cancel();
+
     // FIXME: This is not thread safe and should be implemented in the kernel instead.
     off_t old_offset = lseek(fd, 0, SEEK_CUR);
     lseek(fd, offset, SEEK_SET);
@@ -484,6 +493,8 @@ char* ttyname(int fd)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/close.html
 int close(int fd)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_close, fd);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
@@ -891,6 +902,8 @@ int sysbeep()
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/fsync.html
 int fsync(int fd)
 {
+    __pthread_maybe_cancel();
+
     int rc = syscall(SC_fsync, fd);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }


### PR DESCRIPTION
Now that we can use initialized thread-local values and that we can reasonably interop between LibC and the former LibPthread, it's time to implement pthread cancelling!