### PR TITLE
Meta: Use `exec sudo` when re-executing script as root

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -31,8 +31,7 @@ if [ "$(id -u)" != 0 ]; then
     if [ -x "$FUSE2FS_PATH" ] && $FUSE2FS_PATH --help 2>&1 |grep fakeroot > /dev/null; then
         USE_FUSE2FS=1
     else
-        ${SUDO} -E -- "$0" "$@" || die "this script needs to run as root"
-        exit 0
+        exec ${SUDO} -E -- "$0" "$@" || die "this script needs to run as root"
     fi
 else
     : "${SUDO_UID:=0}" "${SUDO_GID:=0}"

--- a/Meta/build-native-partition.sh
+++ b/Meta/build-native-partition.sh
@@ -16,8 +16,7 @@ cleanup() {
 }
 
 if [ "$(id -u)" != 0 ]; then
-    sudo -E -- "$0" "$@" || die "this script needs to run as root"
-    exit 0
+    exec sudo -E -- "$0" "$@" || die "this script needs to run as root"
 else
     : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
 fi


### PR DESCRIPTION
sudo returns the exit code of the process it executes. If we call sudo
without `exec`,  control flow will return to the original script on
failure, printing "die: this script needs to run as root" even if the
failure was caused by something else.