### PR TITLE
LibJS+LibUnicode: Implement Intl.NumberFormat.prototype.formatRange[ToParts]

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -54,6 +54,7 @@
     M(IntlNumberIsNaN, "{} must not be NaN")                                                                                            \
     M(IntlNumberIsNaNOrInfinity, "Number must not be NaN or Infinity")                                                                  \
     M(IntlNumberIsNaNOrOutOfRange, "Value {} is NaN or is not between {} and {}")                                                       \
+    M(IntlNumberRangeIsInvalid, "Numeric range is invalid: {}")                                                                         \
     M(IntlOptionUndefined, "Option {} must be defined when option {} is {}")                                                            \
     M(IntlNonNumericOr2DigitAfterNumericOr2Digit, "Styles other than 'numeric' and '2-digit' may not be used in smaller units after "   \
                                                   "being used in larger units")                                                         \

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -53,6 +53,30 @@ struct PatternPartition {
     String value;
 };
 
+struct PatternPartitionWithSource : public PatternPartition {
+    static Vector<PatternPartitionWithSource> create_from_parent_list(Vector<PatternPartition> partitions)
+    {
+        Vector<PatternPartitionWithSource> result;
+        result.ensure_capacity(partitions.size());
+
+        for (auto& partition : partitions) {
+            PatternPartitionWithSource partition_with_source {};
+            partition_with_source.type = partition.type;
+            partition_with_source.value = move(partition.value);
+            result.append(move(partition_with_source));
+        }
+
+        return result;
+    }
+
+    bool operator==(PatternPartitionWithSource const& other) const
+    {
+        return (type == other.type) && (value == other.value) && (source == other.source);
+    }
+
+    StringView source;
+};
+
 // Table 2: Single units sanctioned for use in ECMAScript, https://tc39.es/ecma402/#table-sanctioned-single-unit-identifiers
 constexpr auto sanctioned_single_unit_identifiers()
 {

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -180,25 +180,6 @@ struct LocalTime {
     u16 millisecond { 0 }; // [[Millisecond]]
 };
 
-struct PatternPartitionWithSource : public PatternPartition {
-    static Vector<PatternPartitionWithSource> create_from_parent_list(Vector<PatternPartition> partitions)
-    {
-        Vector<PatternPartitionWithSource> result;
-        result.ensure_capacity(partitions.size());
-
-        for (auto& partition : partitions) {
-            PatternPartitionWithSource partition_with_source {};
-            partition_with_source.type = partition.type;
-            partition_with_source.value = move(partition.value);
-            result.append(move(partition_with_source));
-        }
-
-        return result;
-    }
-
-    StringView source;
-};
-
 ThrowCompletionOr<Object*> to_date_time_options(GlobalObject& global_object, Value options_value, OptionRequired, OptionDefaults);
 Optional<Unicode::CalendarPattern> date_time_style_format(StringView data_locale, DateTimeFormat& date_time_format);
 Optional<Unicode::CalendarPattern> basic_format_matcher(Unicode::CalendarPattern const& options, Vector<Unicode::CalendarPattern> formats);

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -1862,4 +1862,43 @@ ThrowCompletionOr<String> format_numeric_range(GlobalObject& global_object, Numb
     return result.build();
 }
 
+// 1.1.25 FormatNumericRangeToParts( numberFormat, x, y ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-formatnumericrangetoparts
+ThrowCompletionOr<Array*> format_numeric_range_to_parts(GlobalObject& global_object, NumberFormat& number_format, MathematicalValue start, MathematicalValue end)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Let parts be ? PartitionNumberRangePattern(numberFormat, x, y).
+    auto parts = TRY(partition_number_range_pattern(global_object, number_format, move(start), move(end)));
+
+    // 2. Let result be ! ArrayCreate(0).
+    auto* result = MUST(Array::create(global_object, 0));
+
+    // 3. Let n be 0.
+    size_t n = 0;
+
+    // 4. For each Record { [[Type]], [[Value]] } part in parts, do
+    for (auto& part : parts) {
+        // a. Let O be OrdinaryObjectCreate(%Object.prototype%).
+        auto* object = Object::create(global_object, global_object.object_prototype());
+
+        // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).
+        MUST(object->create_data_property_or_throw(vm.names.type, js_string(vm, part.type)));
+
+        // c. Perform ! CreateDataPropertyOrThrow(O, "value", part.[[Value]]).
+        MUST(object->create_data_property_or_throw(vm.names.value, js_string(vm, move(part.value))));
+
+        // d. Perform ! CreateDataPropertyOrThrow(O, "source", part.[[Source]]).
+        MUST(object->create_data_property_or_throw(vm.names.source, js_string(vm, part.source)));
+
+        // e. Perform ! CreateDataPropertyOrThrow(result, ! ToString(n), O).
+        MUST(result->create_data_property_or_throw(n, object));
+
+        // f. Increment n by 1.
+        ++n;
+    }
+
+    // 5. Return result.
+    return result;
+}
+
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -287,5 +287,9 @@ int compute_exponent_for_magnitude(NumberFormat& number_format, int magnitude);
 ThrowCompletionOr<MathematicalValue> to_intl_mathematical_value(GlobalObject& global_object, Value value);
 NumberFormat::UnsignedRoundingMode get_unsigned_rounding_mode(NumberFormat::RoundingMode rounding_mode, bool is_negative);
 RoundingDecision apply_unsigned_rounding_mode(MathematicalValue const& x, MathematicalValue const& r1, MathematicalValue const& r2, Optional<NumberFormat::UnsignedRoundingMode> const& unsigned_rounding_mode);
+ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_number_range_pattern(GlobalObject& global_object, NumberFormat& number_format, MathematicalValue start, MathematicalValue end);
+Vector<PatternPartitionWithSource> format_approximately(NumberFormat& number_format, Vector<PatternPartitionWithSource> result);
+Vector<PatternPartitionWithSource> collapse_number_range(Vector<PatternPartitionWithSource> result);
+ThrowCompletionOr<String> format_numeric_range(GlobalObject& global_object, NumberFormat& number_format, MathematicalValue start, MathematicalValue end);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -291,5 +291,6 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_number_range_pat
 Vector<PatternPartitionWithSource> format_approximately(NumberFormat& number_format, Vector<PatternPartitionWithSource> result);
 Vector<PatternPartitionWithSource> collapse_number_range(Vector<PatternPartitionWithSource> result);
 ThrowCompletionOr<String> format_numeric_range(GlobalObject& global_object, NumberFormat& number_format, MathematicalValue start, MathematicalValue end);
+ThrowCompletionOr<Array*> format_numeric_range_to_parts(GlobalObject& global_object, NumberFormat& number_format, MathematicalValue start, MathematicalValue end);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
@@ -33,6 +33,7 @@ void NumberFormatPrototype::initialize(GlobalObject& global_object)
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.formatToParts, format_to_parts, 1, attr);
     define_native_function(vm.names.formatRange, format_range, 2, attr);
+    define_native_function(vm.names.formatRangeToParts, format_range_to_parts, 2, attr);
     define_native_function(vm.names.resolvedOptions, resolved_options, 0, attr);
 }
 
@@ -102,6 +103,32 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_range)
     // 6. Return ? FormatNumericRange(nf, x, y).
     auto formatted = TRY(format_numeric_range(global_object, *number_format, move(x), move(y)));
     return js_string(vm, move(formatted));
+}
+
+// 1.4.6 Intl.NumberFormat.prototype.formatRangeToParts ( start, end ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-intl.numberformat.prototype.formatrangetoparts
+JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_range_to_parts)
+{
+    auto start = vm.argument(0);
+    auto end = vm.argument(1);
+
+    // 1. Let nf be the this value.
+    // 2. Perform ? RequireInternalSlot(nf, [[InitializedNumberFormat]]).
+    auto* number_format = TRY(typed_this_object(global_object));
+
+    // 3. If start is undefined or end is undefined, throw a TypeError exception.
+    if (start.is_undefined())
+        return vm.throw_completion<TypeError>(global_object, ErrorType::IsUndefined, "start"sv);
+    if (end.is_undefined())
+        return vm.throw_completion<TypeError>(global_object, ErrorType::IsUndefined, "end"sv);
+
+    // 4. Let x be ? ToIntlMathematicalValue(start).
+    auto x = TRY(to_intl_mathematical_value(global_object, start));
+
+    // 5. Let y be ? ToIntlMathematicalValue(end).
+    auto y = TRY(to_intl_mathematical_value(global_object, end));
+
+    // 6. Return ? FormatNumericRangeToParts(nf, x, y).
+    return TRY(format_numeric_range_to_parts(global_object, *number_format, move(x), move(y)));
 }
 
 // 15.3.5 Intl.NumberFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.numberformat.prototype.resolvedoptions

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
@@ -32,6 +32,7 @@ void NumberFormatPrototype::initialize(GlobalObject& global_object)
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.formatToParts, format_to_parts, 1, attr);
+    define_native_function(vm.names.formatRange, format_range, 2, attr);
     define_native_function(vm.names.resolvedOptions, resolved_options, 0, attr);
 }
 
@@ -74,6 +75,33 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_to_parts)
     // 4. Return ? FormatNumericToParts(nf, x).
     // Note: Our implementation of FormatNumericToParts does not throw.
     return format_numeric_to_parts(global_object, *number_format, move(mathematical_value));
+}
+
+// 1.4.5 Intl.NumberFormat.prototype.formatRange ( start, end ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-intl.numberformat.prototype.formatrange
+JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_range)
+{
+    auto start = vm.argument(0);
+    auto end = vm.argument(1);
+
+    // 1. Let nf be the this value.
+    // 2. Perform ? RequireInternalSlot(nf, [[InitializedNumberFormat]]).
+    auto* number_format = TRY(typed_this_object(global_object));
+
+    // 3. If start is undefined or end is undefined, throw a TypeError exception.
+    if (start.is_undefined())
+        return vm.throw_completion<TypeError>(global_object, ErrorType::IsUndefined, "start"sv);
+    if (end.is_undefined())
+        return vm.throw_completion<TypeError>(global_object, ErrorType::IsUndefined, "end"sv);
+
+    // 4. Let x be ? ToIntlMathematicalValue(start).
+    auto x = TRY(to_intl_mathematical_value(global_object, start));
+
+    // 5. Let y be ? ToIntlMathematicalValue(end).
+    auto y = TRY(to_intl_mathematical_value(global_object, end));
+
+    // 6. Return ? FormatNumericRange(nf, x, y).
+    auto formatted = TRY(format_numeric_range(global_object, *number_format, move(x), move(y)));
+    return js_string(vm, move(formatted));
 }
 
 // 15.3.5 Intl.NumberFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.numberformat.prototype.resolvedoptions

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.h
@@ -22,6 +22,7 @@ public:
 private:
     JS_DECLARE_NATIVE_FUNCTION(format);
     JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
+    JS_DECLARE_NATIVE_FUNCTION(format_range);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.h
@@ -23,6 +23,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(format);
     JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
     JS_DECLARE_NATIVE_FUNCTION(format_range);
+    JS_DECLARE_NATIVE_FUNCTION(format_range_to_parts);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatRange.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatRange.js
@@ -1,0 +1,140 @@
+describe("errors", () => {
+    test("called on non-NumberFormat object", () => {
+        expect(() => {
+            Intl.NumberFormat.prototype.formatRange();
+        }).toThrowWithMessage(TypeError, "Not an object of type Intl.NumberFormat");
+    });
+
+    test("called without enough values", () => {
+        expect(() => {
+            new Intl.NumberFormat().formatRange();
+        }).toThrowWithMessage(TypeError, "start is undefined");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRange(1);
+        }).toThrowWithMessage(TypeError, "end is undefined");
+    });
+
+    test("called with values that cannot be converted to numbers", () => {
+        expect(() => {
+            new Intl.NumberFormat().formatRange(Symbol.hasInstance, 1);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRange(1, Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+    });
+
+    test("called with invalid numbers", () => {
+        expect(() => {
+            new Intl.NumberFormat().formatRange(NaN, 1);
+        }).toThrowWithMessage(RangeError, "start must not be NaN");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRange(1, NaN);
+        }).toThrowWithMessage(RangeError, "end must not be NaN");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRange(1, 0);
+        }).toThrowWithMessage(
+            RangeError,
+            "start is a mathematical value, end is a mathematical value and end < start"
+        );
+
+        expect(() => {
+            new Intl.NumberFormat().formatRange(1, -Infinity);
+        }).toThrowWithMessage(RangeError, "start is a mathematical value, end is -∞");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRange(1, -0);
+        }).toThrowWithMessage(RangeError, "start is a mathematical value, end is -0 and start ≥ 0");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRange(Infinity, 0);
+        }).toThrowWithMessage(RangeError, "start is +∞, end is a mathematical value");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRange(Infinity, -Infinity);
+        }).toThrowWithMessage(RangeError, "start is +∞, end is -∞");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRange(Infinity, -0);
+        }).toThrowWithMessage(RangeError, "start is +∞, end is -0");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRange(-0, -1);
+        }).toThrowWithMessage(RangeError, "start is -0, end is a mathematical value and end < 0");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRange(-0, -Infinity);
+        }).toThrowWithMessage(RangeError, "start is -0, end is -∞");
+    });
+});
+
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const en1 = new Intl.NumberFormat("en");
+        expect(en1.formatRange(100, 101)).toBe("100–101");
+        expect(en1.formatRange(3.14, 6.28)).toBe("3.14–6.28");
+        expect(en1.formatRange(-0, 1)).toBe("-0–1");
+
+        const ja1 = new Intl.NumberFormat("ja");
+        expect(ja1.formatRange(100, 101)).toBe("100～101");
+        expect(ja1.formatRange(3.14, 6.28)).toBe("3.14～6.28");
+        expect(ja1.formatRange(-0, 1)).toBe("-0～1");
+    });
+
+    test("approximately formatting", () => {
+        const en1 = new Intl.NumberFormat("en", { maximumFractionDigits: 0 });
+        expect(en1.formatRange(2.9, 3.1)).toBe("~3");
+        expect(en1.formatRange(-3.1, -2.9)).toBe("~-3");
+
+        const en2 = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            maximumFractionDigits: 0,
+        });
+        expect(en2.formatRange(2.9, 3.1)).toBe("~$3");
+        expect(en2.formatRange(-3.1, -2.9)).toBe("~-$3");
+
+        const ja1 = new Intl.NumberFormat("ja", { maximumFractionDigits: 0 });
+        expect(ja1.formatRange(2.9, 3.1)).toBe("約3");
+        expect(ja1.formatRange(-3.1, -2.9)).toBe("約-3");
+
+        const ja2 = new Intl.NumberFormat("ja", {
+            style: "currency",
+            currency: "JPY",
+            maximumFractionDigits: 0,
+        });
+        expect(ja2.formatRange(2.9, 3.1)).toBe("約￥3");
+        expect(ja2.formatRange(-3.1, -2.9)).toBe("約-￥3");
+    });
+
+    test("range pattern spacing", () => {
+        const en1 = new Intl.NumberFormat("en");
+        expect(en1.formatRange(3, 5)).toBe("3–5");
+        expect(en1.formatRange(-1, -0)).toBe("-1 – -0");
+        expect(en1.formatRange(0, Infinity)).toBe("0 – ∞");
+        expect(en1.formatRange(-Infinity, 0)).toBe("-∞ – 0");
+
+        const en2 = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            maximumFractionDigits: 0,
+        });
+        expect(en2.formatRange(3, 5)).toBe("$3 – $5");
+
+        const ja1 = new Intl.NumberFormat("ja");
+        expect(ja1.formatRange(3, 5)).toBe("3～5");
+        expect(ja1.formatRange(-1, -0)).toBe("-1 ～ -0");
+        expect(ja1.formatRange(0, Infinity)).toBe("0 ～ ∞");
+        expect(ja1.formatRange(-Infinity, 0)).toBe("-∞ ～ 0");
+
+        const ja2 = new Intl.NumberFormat("ja", {
+            style: "currency",
+            currency: "JPY",
+            maximumFractionDigits: 0,
+        });
+        expect(ja2.formatRange(3, 5)).toBe("￥3 ～ ￥5");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatRangeToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatRangeToParts.js
@@ -1,0 +1,168 @@
+describe("errors", () => {
+    test("called on non-NumberFormat object", () => {
+        expect(() => {
+            Intl.NumberFormat.prototype.formatRangeToParts();
+        }).toThrowWithMessage(TypeError, "Not an object of type Intl.NumberFormat");
+    });
+
+    test("called without enough values", () => {
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts();
+        }).toThrowWithMessage(TypeError, "start is undefined");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(1);
+        }).toThrowWithMessage(TypeError, "end is undefined");
+    });
+
+    test("called with values that cannot be converted to numbers", () => {
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(Symbol.hasInstance, 1);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(1, Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+    });
+
+    test("called with invalid numbers", () => {
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(NaN, 1);
+        }).toThrowWithMessage(RangeError, "start must not be NaN");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(1, NaN);
+        }).toThrowWithMessage(RangeError, "end must not be NaN");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(1, 0);
+        }).toThrowWithMessage(
+            RangeError,
+            "start is a mathematical value, end is a mathematical value and end < start"
+        );
+
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(1, -Infinity);
+        }).toThrowWithMessage(RangeError, "start is a mathematical value, end is -∞");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(1, -0);
+        }).toThrowWithMessage(RangeError, "start is a mathematical value, end is -0 and start ≥ 0");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(Infinity, 0);
+        }).toThrowWithMessage(RangeError, "start is +∞, end is a mathematical value");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(Infinity, -Infinity);
+        }).toThrowWithMessage(RangeError, "start is +∞, end is -∞");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(Infinity, -0);
+        }).toThrowWithMessage(RangeError, "start is +∞, end is -0");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(-0, -1);
+        }).toThrowWithMessage(RangeError, "start is -0, end is a mathematical value and end < 0");
+
+        expect(() => {
+            new Intl.NumberFormat().formatRangeToParts(-0, -Infinity);
+        }).toThrowWithMessage(RangeError, "start is -0, end is -∞");
+    });
+});
+
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const en1 = new Intl.NumberFormat("en");
+        expect(en1.formatRangeToParts(100, 101)).toEqual([
+            { type: "integer", value: "100", source: "startRange" },
+            { type: "literal", value: "–", source: "shared" },
+            { type: "integer", value: "101", source: "endRange" },
+        ]);
+
+        const ja1 = new Intl.NumberFormat("ja");
+        expect(ja1.formatRangeToParts(100, 101)).toEqual([
+            { type: "integer", value: "100", source: "startRange" },
+            { type: "literal", value: "～", source: "shared" },
+            { type: "integer", value: "101", source: "endRange" },
+        ]);
+    });
+
+    test("approximately formatting", () => {
+        const en1 = new Intl.NumberFormat("en", { maximumFractionDigits: 0 });
+        expect(en1.formatRangeToParts(2.9, 3.1)).toEqual([
+            { type: "approximatelySign", value: "~", source: "" },
+            { type: "integer", value: "3", source: "" },
+        ]);
+
+        const en2 = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            maximumFractionDigits: 0,
+        });
+        expect(en2.formatRangeToParts(2.9, 3.1)).toEqual([
+            { type: "approximatelySign", value: "~", source: "" },
+            { type: "currency", value: "$", source: "" },
+            { type: "integer", value: "3", source: "" },
+        ]);
+
+        const ja1 = new Intl.NumberFormat("ja", { maximumFractionDigits: 0 });
+        expect(ja1.formatRangeToParts(2.9, 3.1)).toEqual([
+            { type: "approximatelySign", value: "約", source: "" },
+            { type: "integer", value: "3", source: "" },
+        ]);
+
+        const ja2 = new Intl.NumberFormat("ja", {
+            style: "currency",
+            currency: "JPY",
+            maximumFractionDigits: 0,
+        });
+        expect(ja2.formatRangeToParts(2.9, 3.1)).toEqual([
+            { type: "approximatelySign", value: "約", source: "" },
+            { type: "currency", value: "￥", source: "" },
+            { type: "integer", value: "3", source: "" },
+        ]);
+    });
+
+    test("range pattern spacing", () => {
+        const en1 = new Intl.NumberFormat("en");
+        expect(en1.formatRangeToParts(3, 5)).toEqual([
+            { type: "integer", value: "3", source: "startRange" },
+            { type: "literal", value: "–", source: "shared" },
+            { type: "integer", value: "5", source: "endRange" },
+        ]);
+
+        const en2 = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            maximumFractionDigits: 0,
+        });
+        expect(en2.formatRangeToParts(3, 5)).toEqual([
+            { type: "currency", value: "$", source: "startRange" },
+            { type: "integer", value: "3", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "currency", value: "$", source: "endRange" },
+            { type: "integer", value: "5", source: "endRange" },
+        ]);
+
+        const ja1 = new Intl.NumberFormat("ja");
+        expect(ja1.formatRangeToParts(3, 5)).toEqual([
+            { type: "integer", value: "3", source: "startRange" },
+            { type: "literal", value: "～", source: "shared" },
+            { type: "integer", value: "5", source: "endRange" },
+        ]);
+
+        const ja2 = new Intl.NumberFormat("ja", {
+            style: "currency",
+            currency: "JPY",
+            maximumFractionDigits: 0,
+        });
+        expect(ja2.formatRangeToParts(3, 5)).toEqual([
+            { type: "currency", value: "￥", source: "startRange" },
+            { type: "integer", value: "3", source: "startRange" },
+            { type: "literal", value: " ～ ", source: "shared" },
+            { type: "currency", value: "￥", source: "endRange" },
+            { type: "integer", value: "5", source: "endRange" },
+        ]);
+    });
+});

--- a/Userland/Libraries/LibUnicode/NumberFormat.cpp
+++ b/Userland/Libraries/LibUnicode/NumberFormat.cpp
@@ -50,6 +50,17 @@ String replace_digits_for_number_system(StringView system, StringView number)
     return builder.build();
 }
 
+static u32 last_code_point(StringView string)
+{
+    Utf8View utf8_string { string };
+    u32 code_point = 0;
+
+    for (auto it = utf8_string.begin(); it != utf8_string.end(); ++it)
+        code_point = *it;
+
+    return code_point;
+}
+
 // https://www.unicode.org/reports/tr35/tr35-numbers.html#Currencies
 Optional<String> augment_currency_format_pattern([[maybe_unused]] StringView currency_display, [[maybe_unused]] StringView base_pattern)
 {
@@ -66,16 +77,6 @@ Optional<String> augment_currency_format_pattern([[maybe_unused]] StringView cur
 
     Utf8View utf8_currency_display { currency_display };
     Optional<String> currency_key_with_spacing;
-
-    auto last_code_point = [](StringView string) {
-        Utf8View utf8_string { string };
-        u32 code_point = 0;
-
-        for (auto it = utf8_string.begin(); it != utf8_string.end(); ++it)
-            code_point = *it;
-
-        return code_point;
-    };
 
     if (*number_index < *currency_index) {
         u32 last_pattern_code_point = last_code_point(base_pattern.substring_view(0, *currency_index));
@@ -99,6 +100,39 @@ Optional<String> augment_currency_format_pattern([[maybe_unused]] StringView cur
 
     if (currency_key_with_spacing.has_value())
         return base_pattern.replace(currency_key, *currency_key_with_spacing, ReplaceMode::FirstOnly);
+#endif
+
+    return {};
+}
+
+// https://unicode.org/reports/tr35/tr35-numbers.html#83-range-pattern-processing
+Optional<String> augment_range_pattern(StringView range_separator, StringView lower, StringView upper)
+{
+#if ENABLE_UNICODE_DATA
+    auto range_pattern_with_spacing = [&]() {
+        return String::formatted(" {} ", range_separator);
+    };
+
+    Utf8View utf8_range_separator { range_separator };
+    Utf8View utf8_upper { upper };
+
+    // NOTE: Our implementation does the prescribed checks backwards for simplicity.
+
+    // To determine whether to add spacing, the currently recommended heuristic is:
+    // 2. If the range pattern does not contain a character having the White_Space binary Unicode property after the {0} or before the {1} placeholders.
+    for (auto it = utf8_range_separator.begin(); it != utf8_range_separator.end(); ++it) {
+        if (code_point_has_property(*it, Property::White_Space))
+            return {};
+    }
+
+    // 1. If the lower string ends with a character other than a digit, or if the upper string begins with a character other than a digit.
+    if (auto it = utf8_upper.begin(); it != utf8_upper.end()) {
+        if (!code_point_has_general_category(*it, GeneralCategory::Decimal_Number))
+            return range_pattern_with_spacing();
+    }
+
+    if (!code_point_has_general_category(last_code_point(lower), GeneralCategory::Decimal_Number))
+        return range_pattern_with_spacing();
 #endif
 
     return {};

--- a/Userland/Libraries/LibUnicode/NumberFormat.h
+++ b/Userland/Libraries/LibUnicode/NumberFormat.h
@@ -71,5 +71,6 @@ Vector<NumberFormat> get_compact_number_system_formats(StringView locale, String
 Vector<NumberFormat> get_unit_formats(StringView locale, StringView unit, Style style);
 
 Optional<String> augment_currency_format_pattern(StringView currency_display, StringView base_pattern);
+Optional<String> augment_range_pattern(StringView range_separator, StringView lower, StringView upper);
 
 }

--- a/Userland/Libraries/LibUnicode/NumberFormat.h
+++ b/Userland/Libraries/LibUnicode/NumberFormat.h
@@ -47,6 +47,7 @@ struct NumberFormat {
 };
 
 enum class NumericSymbol : u8 {
+    ApproximatelySign,
     Decimal,
     Exponential,
     Group,
@@ -55,6 +56,7 @@ enum class NumericSymbol : u8 {
     NaN,
     PercentSign,
     PlusSign,
+    RangeSeparator,
     TimeSeparator,
 };
 


### PR DESCRIPTION
```
Diff Tests:
    +14 ✅    -15 ❌   +1 📝   

Diff Tests:
    test/intl402/NumberFormat/prototype/formatRange/builtin.js                        ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRange/invoked-as-func.js                ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRange/length.js                         ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRange/name.js                           ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRange/nan-arguments-throws.js           ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRange/prop-desc.js                      ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRange/x-greater-than-y-throws.js        ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRangeToParts/builtin.js                 ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRangeToParts/en-US.js                   ❌ -> 📝
    test/intl402/NumberFormat/prototype/formatRangeToParts/invoked-as-func.js         ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRangeToParts/length.js                  ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRangeToParts/name.js                    ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRangeToParts/nan-arguments-throws.js    ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRangeToParts/prop-desc.js               ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRangeToParts/x-greater-than-y-throws.js ❌ -> ✅
```

The TODO exception is due to that test using a generator