### PR TITLE
du+LibCore: `--block-size`, `-k`, and other miscellaneous fixes

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -485,7 +485,11 @@ void ArgsParser::add_option(Integral& value, char const* help_string, char const
 }
 
 template void ArgsParser::add_option(int&, char const*, char const*, char, char const*, OptionHideMode);
+template void ArgsParser::add_option(long&, char const*, char const*, char, char const*, OptionHideMode);
+template void ArgsParser::add_option(long long&, char const*, char const*, char, char const*, OptionHideMode);
 template void ArgsParser::add_option(unsigned&, char const*, char const*, char, char const*, OptionHideMode);
+template void ArgsParser::add_option(unsigned long&, char const*, char const*, char, char const*, OptionHideMode);
+template void ArgsParser::add_option(unsigned long long&, char const*, char const*, char, char const*, OptionHideMode);
 
 void ArgsParser::add_option(double& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode)
 {

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -89,8 +89,8 @@ public:
     void add_option(char const*& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(String& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(StringView& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
-    void add_option(int& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
-    void add_option(unsigned& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
+    template<typename Integral>
+    void add_option(Integral& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None) requires(IsIntegral<Integral>);
     void add_option(double& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(Optional<double>& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(Optional<size_t>& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -146,7 +146,7 @@ ErrorOr<off_t> print_space_usage(String const& path, DuOption const& du_option, 
     }
 
     size_t size = path_stat.st_size;
-    if (du_option.apparent_size) {
+    if (!du_option.apparent_size) {
         constexpr auto block_size = 512;
         size = path_stat.st_blocks * block_size;
     }

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -162,7 +162,7 @@ ErrorOr<off_t> print_space_usage(String const& path, DuOption const& du_option, 
         out("{}", human_readable_size(size));
     } else {
         constexpr long long block_size = 1024;
-        size = size / block_size + (size % block_size != 0);
+        size = ceil_div(size, block_size);
         out("{}", size);
     }
 

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -81,6 +81,18 @@ ErrorOr<void> parse_args(Main::Arguments arguments, Vector<String>& files, DuOpt
         }
     };
 
+    Core::ArgsParser::Option block_size_1k_option {
+        Core::ArgsParser::OptionArgumentMode::None,
+        "Equivalent to `--block-size 1024`",
+        nullptr,
+        'k',
+        nullptr,
+        [&du_option](auto const*) {
+            du_option.block_size = 1024;
+            return true;
+        }
+    };
+
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Display actual or apparent disk usage of files or directories.");
     args_parser.add_option(du_option.all, "Write counts for all files, not just directories", "all", 'a');
@@ -93,6 +105,7 @@ ErrorOr<void> parse_args(Main::Arguments arguments, Vector<String>& files, DuOpt
     args_parser.add_option(pattern, "Exclude files that match pattern", "exclude", 0, "pattern");
     args_parser.add_option(exclude_from, "Exclude files that match any pattern in file", "exclude_from", 'X', "file");
     args_parser.add_option(du_option.block_size, "Outputs file sizes as the required blocks with the given size (defaults to 1024)", "block-size", 'B', "size");
+    args_parser.add_option(move(block_size_1k_option));
     args_parser.add_positional_argument(files_to_process, "File to process", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 


### PR DESCRIPTION
The big "Refactor du and add more options" pull request got stale, so I redid just the changes that I need myself and decided to get those merged separately.

This makes `du` behave a bit more like the one from `coreutils`, and it should be close enough that it allows us to actually run our disk image creation script.