### PR TITLE
LibJS+LibUnicode: A couple of DateTimeFormat fixes

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -2289,14 +2289,18 @@ Optional<StringView> get_calendar_day_period_symbol_for_hour(StringView locale, 
 
     for (auto day_period_index : day_periods) {
         auto day_period = s_day_periods[day_period_index];
-        auto h = hour;
+        bool hour_falls_within_day_period = false;
 
         if (day_period.begin > day_period.end) {
-            day_period.end += 24;
-            h += 24;
+            if (hour >= day_period.begin)
+                hour_falls_within_day_period = true;
+            else if (hour <= day_period.end)
+                hour_falls_within_day_period = true;
+        } else if ((day_period.begin <= hour) && (hour < day_period.end)) {
+            hour_falls_within_day_period = true;
         }
 
-        if ((day_period.begin <= h) && (h < day_period.end)) {
+        if (hour_falls_within_day_period) {
             auto period = static_cast<DayPeriod>(day_period.day_period);
             return get_calendar_day_period_symbol(locale, calendar, style, period);
         }

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -590,6 +590,8 @@ static Optional<Unicode::DayPeriod> day_period_from_string(StringView day_period
         return Unicode::DayPeriod::AM;
     if (day_period == "pm"sv)
         return Unicode::DayPeriod::PM;
+    if (day_period == "noon"sv)
+        return Unicode::DayPeriod::Noon;
     if (day_period == "morning1"sv)
         return Unicode::DayPeriod::Morning1;
     if (day_period == "morning2"sv)
@@ -1364,7 +1366,7 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
         auto const& narrow_symbols = symbols_object.get("narrow"sv).as_object();
         auto const& short_symbols = symbols_object.get("abbreviated"sv).as_object();
         auto const& long_symbols = symbols_object.get("wide"sv).as_object();
-        auto symbol_lists = create_symbol_lists(10);
+        auto symbol_lists = create_symbol_lists(11);
 
         auto append_symbol = [&](auto& symbols, auto const& key, auto symbol) {
             if (auto day_period = day_period_from_string(key); day_period.has_value())
@@ -1613,6 +1615,9 @@ static ErrorOr<void> parse_day_periods(String core_path, UnicodeLocaleData& loca
     };
 
     auto parse_day_period = [&](auto const& symbol, auto const& ranges) -> Optional<DayPeriod> {
+        if (!ranges.has("_from"sv))
+            return {};
+
         auto day_period = day_period_from_string(symbol);
         if (!day_period.has_value())
             return {};

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -2240,8 +2240,10 @@ Optional<StringView> get_calendar_era_symbol(StringView locale, StringView calen
 {
     auto symbols = find_calendar_symbols(locale, calendar, CalendarSymbol::Era, style);
 
-    if (auto value_index = to_underlying(value); value_index < symbols.size())
-        return s_string_list[symbols.at(value_index)];
+    if (auto value_index = to_underlying(value); value_index < symbols.size()) {
+        if (auto symbol_index = symbols.at(value_index); symbol_index != 0)
+            return s_string_list[symbol_index];
+    }
 
     return {};
 }
@@ -2250,8 +2252,10 @@ Optional<StringView> get_calendar_month_symbol(StringView locale, StringView cal
 {
     auto symbols = find_calendar_symbols(locale, calendar, CalendarSymbol::Month, style);
 
-    if (auto value_index = to_underlying(value); value_index < symbols.size())
-        return s_string_list[symbols.at(value_index)];
+    if (auto value_index = to_underlying(value); value_index < symbols.size()) {
+        if (auto symbol_index = symbols.at(value_index); symbol_index != 0)
+            return s_string_list[symbol_index];
+    }
 
     return {};
 }
@@ -2260,8 +2264,10 @@ Optional<StringView> get_calendar_weekday_symbol(StringView locale, StringView c
 {
     auto symbols = find_calendar_symbols(locale, calendar, CalendarSymbol::Weekday, style);
 
-    if (auto value_index = to_underlying(value); value_index < symbols.size())
-        return s_string_list[symbols.at(value_index)];
+    if (auto value_index = to_underlying(value); value_index < symbols.size()) {
+        if (auto symbol_index = symbols.at(value_index); symbol_index != 0)
+            return s_string_list[symbol_index];
+    }
 
     return {};
 }
@@ -2270,8 +2276,10 @@ Optional<StringView> get_calendar_day_period_symbol(StringView locale, StringVie
 {
     auto symbols = find_calendar_symbols(locale, calendar, CalendarSymbol::DayPeriod, style);
 
-    if (auto value_index = to_underlying(value); value_index < symbols.size())
-        return s_string_list[symbols.at(value_index)];
+    if (auto value_index = to_underlying(value); value_index < symbols.size()) {
+        if (auto symbol_index = symbols.at(value_index); symbol_index != 0)
+            return s_string_list[symbol_index];
+    }
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -273,6 +273,48 @@ describe("dayPeriod", () => {
         expect(en.format(date1)).toBe("5 at night");
         expect(en.format(date2)).toBe("11 at night");
     });
+
+    test("noon", () => {
+        const date0 = Date.UTC(2017, 11, 12, 12, 0, 0, 0);
+        const date1 = Date.UTC(2017, 11, 12, 12, 1, 0, 0);
+        const date2 = Date.UTC(2017, 11, 12, 12, 0, 1, 0);
+        const date3 = Date.UTC(2017, 11, 12, 12, 0, 0, 500);
+
+        // prettier-ignore
+        const data = [
+            { minute: undefined, second: undefined, fractionalSecondDigits: undefined, en0: "12 noon", en1: "12 noon", en2: "12 noon", en3: "12 noon", ar0: "١٢ ظهرًا", ar1: "١٢ ظهرًا", ar2: "١٢ ظهرًا", ar3: "١٢ ظهرًا" },
+            { minute: "numeric", second: undefined, fractionalSecondDigits: undefined, en0: "12:00 noon", en1: "12:01 in the afternoon", en2: "12:00 noon", en3: "12:00 noon", ar0: "١٢:٠٠ ظهرًا", ar1: "١٢:٠١ ظهرًا", ar2: "١٢:٠٠ ظهرًا", ar3: "١٢:٠٠ ظهرًا" },
+            { minute: "numeric", second: "numeric", fractionalSecondDigits: undefined, en0: "12:00:00 noon", en1: "12:01:00 in the afternoon", en2: "12:00:01 in the afternoon", en3: "12:00:00 noon", ar0: "١٢:٠٠:٠٠ ظهرًا", ar1: "١٢:٠١:٠٠ ظهرًا", ar2: "١٢:٠٠:٠١ ظهرًا", ar3: "١٢:٠٠:٠٠ ظهرًا" },
+            { minute: "numeric", second: "numeric", fractionalSecondDigits: 1, en0: "12:00:00.0 noon", en1: "12:01:00.0 in the afternoon", en2: "12:00:01.0 in the afternoon", en3: "12:00:00.5 in the afternoon", ar0: "١٢:٠٠:٠٠٫٠ ظهرًا", ar1: "١٢:٠١:٠٠٫٠ ظهرًا", ar2: "١٢:٠٠:٠١٫٠ ظهرًا", ar3: "١٢:٠٠:٠٠٫٥ ظهرًا" },
+        ];
+
+        // The en locale includes the "noon" fixed day period, whereas the ar locale does not.
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", {
+                dayPeriod: "short",
+                timeZone: "UTC",
+                minute: d.minute,
+                second: d.second,
+                fractionalSecondDigits: d.fractionalSecondDigits,
+            });
+            expect(en.format(date0)).toBe(d.en0);
+            expect(en.format(date1)).toBe(d.en1);
+            expect(en.format(date2)).toBe(d.en2);
+            expect(en.format(date3)).toBe(d.en3);
+
+            const ar = new Intl.DateTimeFormat("ar", {
+                dayPeriod: "short",
+                timeZone: "UTC",
+                minute: d.minute,
+                second: d.second,
+                fractionalSecondDigits: d.fractionalSecondDigits,
+            });
+            expect(ar.format(date0)).toBe(d.ar0);
+            expect(ar.format(date1)).toBe(d.ar1);
+            expect(ar.format(date2)).toBe(d.ar2);
+            expect(ar.format(date3)).toBe(d.ar3);
+        });
+    });
 });
 
 describe("hour", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -263,11 +263,15 @@ describe("dayPeriod", () => {
     });
 
     test("flexible day period rolls over midnight", () => {
-        // For the en locale, this time (05:00) falls in the flexible day period range of [21:00, 06:00).
-        const date = Date.UTC(2017, 11, 12, 5, 0, 0, 0);
-
         const en = new Intl.DateTimeFormat("en", { dayPeriod: "short", timeZone: "UTC" });
-        expect(en.format(date)).toBe("5 at night");
+
+        // For the en locale, these times (05:00 and 23:00) fall in the flexible day period range of
+        // [21:00, 06:00), on either side of midnight.
+        const date1 = Date.UTC(2017, 11, 12, 5, 0, 0, 0);
+        const date2 = Date.UTC(2017, 11, 12, 23, 0, 0, 0);
+
+        expect(en.format(date1)).toBe("5 at night");
+        expect(en.format(date2)).toBe("11 at night");
     });
 });
 

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -50,6 +50,7 @@ enum class Weekday : u8 {
 enum class DayPeriod : u8 {
     AM,
     PM,
+    Noon,
     Morning1,
     Morning2,
     Afternoon1,


### PR DESCRIPTION
Looking through failures on test262, these are a couple of low hanging fruit. No new passes though, the tests that exercise these fail for other reasons.