### PR TITLE
Lagom: Port LibCore, LibMain & LibTimeZone to Win32

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -25,6 +26,16 @@
 
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 #    define AK_OS_BSD_GENERIC
+#endif
+
+#if defined(__CYGWIN__) || defined(_WIN32)
+#    define AK_OS_WIN32
+#    undef __POSIX_VISIBLE
+#    define __POSIX_VISIBLE 200809
+#    undef __XSI_VISIBLE
+#    define __XSI_VISIBLE 700
+#    undef __GNU_VISIBLE
+#    define __GNU_VISIBLE 1
 #endif
 
 // FIXME: Remove clang-format suppression after https://github.com/llvm/llvm-project/issues/56602 resolved
@@ -121,7 +132,7 @@ extern "C" {
 #    endif
 #endif
 
-#ifdef AK_OS_BSD_GENERIC
+#if defined(AK_OS_BSD_GENERIC) || defined(AK_OS_WIN32)
 #    define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
 #    define CLOCK_REALTIME_COARSE CLOCK_REALTIME
 #endif

--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -463,7 +463,14 @@ template<typename T, typename V>
 struct VaArgNextArgument {
     ALWAYS_INLINE T operator()(V ap) const
     {
+#ifdef AK_OS_WIN32
+        // GCC on msys2 complains about the type of ap,
+        // so let's force the compiler to belive its a
+        // va_list.
+        return va_arg((va_list&)ap, T);
+#else
         return va_arg(ap, T);
+#endif
     }
 };
 

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -17,7 +17,7 @@
 #    include <unistd.h>
 #endif
 
-#if defined(AK_OS_MACOS)
+#if defined(AK_OS_MACOS) || defined(AK_OS_WIN32)
 #    include <sys/random.h>
 #endif
 

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -9,9 +9,9 @@ project(
 )
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11")
-  message(FATAL_ERROR
-      "A GCC version less than 11 was detected (${CMAKE_CXX_COMPILER_VERSION}), this is unsupported.\n"
-      "Please re-read the build instructions documentation, and upgrade your host compiler.\n")
+    message(FATAL_ERROR
+        "A GCC version less than 11 was detected (${CMAKE_CXX_COMPILER_VERSION}), this is unsupported.\n"
+        "Please re-read the build instructions documentation, and upgrade your host compiler.\n")
 endif()
 
 if (CYGWIN)
@@ -125,7 +125,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         message(FATAL_ERROR
             "Fuzzer Sanitizer (-fsanitize=fuzzer) is only supported for Fuzzer targets with LLVM. "
             "Reconfigure CMake with -DCMAKE_C_COMPILER and -DCMAKE_CXX_COMPILER pointing to a clang-based toolchain "
-	    "or build binaries without built-in fuzzing support by setting -DENABLE_FUZZERS instead."
+            "or build binaries without built-in fuzzing support by setting -DENABLE_FUZZERS instead."
         )
     endif()
 endif()
@@ -460,8 +460,8 @@ if (BUILD_LAGOM)
     file(GLOB LIBPDF_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibPDF/*.cpp")
     file(GLOB LIBPDF_SUBDIR_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibPDF/*/*.cpp")
     lagom_lib(PDF pdf
-       SOURCES ${LIBPDF_SOURCES} ${LIBPDF_SUBDIR_SOURCES}
-       LIBS LibGfx LibIPC LibTextCodec
+        SOURCES ${LIBPDF_SOURCES} ${LIBPDF_SUBDIR_SOURCES}
+        LIBS LibGfx LibIPC LibTextCodec
     )
 
     # Regex

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -14,6 +14,12 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_
       "Please re-read the build instructions documentation, and upgrade your host compiler.\n")
 endif()
 
+if (CYGWIN)
+    set(BUILD_SHARED_LIBS OFF)
+    unset(BUILD_LAGOM CACHE)
+    message(STATUS "Disabled unsupported Lagom libraries/apps and shared libraries under cygwin")
+endif()
+
 # This is required for CMake (when invoked for a Lagom-only build) to
 # ignore any files downloading during the build, e.g. UnicodeData.txt.
 # https://cmake.org/cmake/help/latest/policy/CMP0058.html
@@ -256,18 +262,24 @@ if (NOT TARGET all_generated)
     add_custom_target(all_generated)
 endif()
 
+# Only enable gcc extensions for LibCore, LibMain & LibTimeZone under cygwin
+if (CYGWIN)
+    set(CMAKE_CXX_EXTENSIONS ON)
+endif()
+
 # AK/LibCore
 # Note: AK is included in LibCore for the host build instead of LibC per the target build
 file(GLOB AK_SOURCES CONFIGURE_DEPENDS "../../AK/*.cpp")
 file(GLOB LIBCORE_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibCore/*.cpp")
-if (ANDROID)
+if (ANDROID OR CYGWIN)
     list(REMOVE_ITEM LIBCORE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/../../Userland/Libraries/LibCore/Account.cpp")
+    list(REMOVE_ITEM LIBCORE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/../../Userland/Libraries/LibCore/Group.cpp")
 endif()
 lagom_lib(Core core
     SOURCES ${AK_SOURCES} ${LIBCORE_SOURCES}
     LIBS Threads::Threads
 )
-if (NOT APPLE AND NOT ANDROID AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
+if (NOT APPLE AND NOT ANDROID AND NOT CYGWIN AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
     target_link_libraries(LibCore crypt) # LibCore::Account uses crypt() but it's not in libcrypt on macOS
 endif()
 
@@ -289,6 +301,11 @@ lagom_lib(TimeZone timezone
     SOURCES ${LIBTIMEZONE_SOURCES} ${TIME_ZONE_DATA_SOURCES}
 )
 target_compile_definitions(LibTimeZone PRIVATE ENABLE_TIME_ZONE_DATA=$<BOOL:${ENABLE_TIME_ZONE_DATABASE_DOWNLOAD}>)
+
+# Disable previously enabled gcc extensions
+if (CYGWIN)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
 
 # Manually install AK headers
 install(

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -13,7 +13,6 @@ set(SOURCES
     File.cpp
     FilePermissionsMask.cpp
     GetPassword.cpp
-    Group.cpp
     IODevice.cpp
     LocalServer.cpp
     LockFile.cpp
@@ -37,8 +36,9 @@ set(SOURCES
     UDPServer.cpp
     Version.cpp
 )
-if (NOT ANDROID)
+if (NOT ANDROID AND NOT CYGWIN)
     list(APPEND SOURCES Account.cpp)
+    list(APPEND SOURCES Group.cpp)
 endif()
 
 serenity_lib(LibCore core)

--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -94,7 +94,7 @@ String DateTime::to_string(StringView format) const
     auto format_time_zone_offset = [&](bool with_separator) {
 #if defined(__serenity__)
         auto offset_seconds = daylight ? -altzone : -timezone;
-#elif !defined(__FreeBSD__)
+#elif !defined(__FreeBSD__) && !defined(AK_OS_WIN32)
         auto offset_seconds = -timezone;
 #else
         auto offset_seconds = 0;
@@ -251,7 +251,9 @@ String DateTime::to_string(StringView format) const
                 format_time_zone_offset(true);
                 break;
             case 'Z': {
-#ifndef __FreeBSD__
+#if defined(AK_OS_WIN32)
+                auto const* timezone_name = "";
+#elif !defined(__FreeBSD__) && !defined(AK_OS_WIN32)
                 auto const* timezone_name = tzname[daylight];
 #else
                 auto const* timezone_name = tzname[0];

--- a/Userland/Libraries/LibCore/DirIterator.cpp
+++ b/Userland/Libraries/LibCore/DirIterator.cpp
@@ -9,6 +9,10 @@
 #include <errno.h>
 #include <unistd.h>
 
+#if defined(AK_OS_WIN32)
+#    include <dirent.h>
+#endif
+
 namespace Core {
 
 DirIterator::DirIterator(String path, Flags flags)

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -74,7 +74,7 @@ thread_local bool EventLoop::s_wake_pipe_initialized { false };
 void EventLoop::initialize_wake_pipes()
 {
     if (!s_wake_pipe_initialized) {
-#if defined(SOCK_NONBLOCK)
+#if defined(SOCK_NONBLOCK) && !defined(AK_OS_WIN32)
         int rc = pipe2(s_wake_pipe_fds, O_CLOEXEC);
 #else
         int rc = pipe(s_wake_pipe_fds);

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -21,7 +21,7 @@
 #include <utime.h>
 
 // On Linux distros that use glibc `basename` is defined as a macro that expands to `__xpg_basename`, so we undefine it
-#if defined(__linux__) && defined(basename)
+#if defined(AK_OS_WIN32) || defined(__linux__) && defined(basename)
 #    undef basename
 #endif
 

--- a/Userland/Libraries/LibCore/IODevice.cpp
+++ b/Userland/Libraries/LibCore/IODevice.cpp
@@ -15,6 +15,10 @@
 #include <sys/time.h>
 #include <unistd.h>
 
+#if defined(AK_OS_WIN32)
+#    include <sys/unistd.h>
+#endif
+
 namespace Core {
 
 IODevice::IODevice(Object* parent)

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -19,10 +19,13 @@
 #include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
-#include <sys/ptrace.h>
 #include <sys/time.h>
 #include <termios.h>
 #include <unistd.h>
+
+#if !defined(AK_OS_WIN32)
+#    include <sys/ptrace.h>
+#endif
 
 #ifdef __serenity__
 #    include <LibSystem/syscall.h>
@@ -183,7 +186,7 @@ ErrorOr<void> profiling_free_buffer(pid_t pid)
 }
 #endif
 
-#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID)
+#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID) && !defined(AK_OS_WIN32)
 ErrorOr<Optional<struct spwd>> getspent()
 {
     errno = 0;
@@ -918,7 +921,7 @@ ErrorOr<struct utsname> uname()
     return uts;
 }
 
-#ifndef AK_OS_ANDROID
+#if !defined(AK_OS_ANDROID) && !defined(AK_OS_WIN32)
 ErrorOr<void> adjtime(const struct timeval* delta, struct timeval* old_delta)
 {
 #    ifdef __serenity__
@@ -1183,7 +1186,7 @@ ErrorOr<void> socketpair(int domain, int type, int protocol, int sv[2])
 ErrorOr<Array<int, 2>> pipe2([[maybe_unused]] int flags)
 {
     Array<int, 2> fds;
-#if defined(__unix__)
+#if defined(__unix__) && !defined(AK_OS_WIN32)
     if (::pipe2(fds.data(), flags) < 0)
         return Error::from_syscall("pipe2"sv, -errno);
 #else

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -26,8 +26,12 @@
 #include <time.h>
 #include <utime.h>
 
-#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID)
+#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID) && !defined(AK_OS_WIN32)
 #    include <shadow.h>
+#endif
+
+#if defined(AK_OS_WIN32)
+typedef _sig_func_ptr sighandler_t;
 #endif
 
 namespace Core::System {
@@ -78,7 +82,7 @@ ALWAYS_INLINE ErrorOr<void> unveil(std::nullptr_t, std::nullptr_t)
     return unveil(StringView {}, StringView {});
 }
 
-#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID)
+#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID) && !defined(AK_OS_WIN32)
 ErrorOr<Optional<struct spwd>> getspent();
 ErrorOr<Optional<struct spwd>> getspnam(StringView name);
 #endif


### PR DESCRIPTION
This is the first step of many to get Lagom fully compiling
on Windows NT based hosts.

msys2/cygwin with a posix env is required to build this.

**EDIT:** *The CMakeLists.txt fix was for issues prior to this PR eg not caused by it (otherwise the commit would've been squashed into the primary one).*