### PR TITLE
LibWeb: Implement BufferSource support for XHR::send()

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/IDLAbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/IDLAbstractOperations.cpp
@@ -17,7 +17,7 @@
 namespace Web::Bindings::IDL {
 
 // https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy
-Optional<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
+ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
 {
     // 1. Let esBufferSource be the result of converting bufferSource to an ECMAScript value.
 
@@ -69,18 +69,16 @@ Optional<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
         return ByteBuffer {};
 
     // 8. Let bytes be a new byte sequence of length equal to length.
-    auto bytes = ByteBuffer::create_zeroed(length);
-    if (bytes.is_error())
-        return {};
+    auto bytes = TRY(ByteBuffer::create_zeroed(length));
 
     // 9. For i in the range offset to offset + length − 1, inclusive, set bytes[i − offset] to ! GetValueFromBuffer(esArrayBuffer, i, Uint8, true, Unordered).
     for (u64 i = offset; i <= offset + length - 1; ++i) {
         auto value = es_array_buffer->get_value<u8>(i, true, JS::ArrayBuffer::Unordered);
-        bytes.value()[i - offset] = (u8)value.as_u32();
+        bytes[i - offset] = (u8)value.as_u32();
     }
 
     // 10. Return bytes.
-    return bytes.release_value();
+    return bytes;
 }
 
 // https://webidl.spec.whatwg.org/#invoke-a-callback-function

--- a/Userland/Libraries/LibWeb/Bindings/IDLAbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Bindings/IDLAbstractOperations.h
@@ -16,7 +16,7 @@
 
 namespace Web::Bindings::IDL {
 
-Optional<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source);
+ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source);
 
 // https://webidl.spec.whatwg.org/#call-user-object-operation-return
 inline JS::Completion clean_up_on_return(HTML::EnvironmentSettingsObject& stored_settings, HTML::EnvironmentSettingsObject& relevant_settings, JS::Completion& completion)

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -17,11 +17,11 @@ DOM::ExceptionOr<String> TextDecoder::decode(JS::Handle<JS::Object> const& input
 {
     // FIXME: Implement the streaming stuff.
 
-    auto data_buffer = Bindings::IDL::get_buffer_source_copy(*input.cell());
-    if (!data_buffer.has_value())
+    auto data_buffer_or_error = Bindings::IDL::get_buffer_source_copy(*input.cell());
+    if (data_buffer_or_error.is_error())
         return DOM::OperationError::create("Failed to copy bytes from ArrayBuffer");
-
-    return m_decoder.to_utf8({ data_buffer->data(), data_buffer->size() });
+    auto& data_buffer = data_buffer_or_error.value();
+    return m_decoder.to_utf8({ data_buffer.data(), data_buffer.size() });
 }
 
 }

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -71,10 +71,8 @@ ErrorOr<ByteBuffer> Blob::process_blob_parts(Vector<BlobPart> const& blob_parts)
             },
             // 2. If element is a BufferSource, get a copy of the bytes held by the buffer source, and append those bytes to bytes.
             [&](JS::Handle<JS::Object> const& buffer_source) -> ErrorOr<void> {
-                auto data_buffer = Bindings::IDL::get_buffer_source_copy(*buffer_source.cell());
-                if (data_buffer.has_value())
-                    return bytes.try_append(data_buffer->bytes());
-                return {};
+                auto data_buffer = TRY(Bindings::IDL::get_buffer_source_copy(*buffer_source.cell()));
+                return bytes.try_append(data_buffer.bytes());
             },
             // 3. If element is a Blob, append the bytes it represents to bytes.
             [&](NonnullRefPtr<Blob> const& blob) -> ErrorOr<void> {

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -17,6 +17,7 @@
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/Bindings/EventWrapper.h>
+#include <LibWeb/Bindings/IDLAbstractOperations.h>
 #include <LibWeb/Bindings/XMLHttpRequestWrapper.h>
 #include <LibWeb/DOM/DOMException.h>
 #include <LibWeb/DOM/Document.h>
@@ -281,6 +282,11 @@ static ErrorOr<Fetch::Infrastructure::BodyWithType> extract_body(XMLHttpRequestB
             // If object’s type attribute is not the empty byte sequence, set type to its value.
             if (!blob->type().is_empty())
                 type = blob->type().to_byte_buffer();
+            return {};
+        },
+        [&](JS::Handle<JS::Object> const& buffer_source) -> ErrorOr<void> {
+            // Set source to a copy of the bytes held by object.
+            source = TRY(Bindings::IDL::get_buffer_source_copy(*buffer_source.cell()));
             return {};
         },
         [&](NonnullRefPtr<URL::URLSearchParams> const& url_search_params) -> ErrorOr<void> {

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -23,6 +23,7 @@
 
 namespace Web::XHR {
 
+// https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit
 using XMLHttpRequestBodyInit = Variant<NonnullRefPtr<FileAPI::Blob>, NonnullRefPtr<URL::URLSearchParams>, String>;
 
 class XMLHttpRequest final

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -24,7 +24,7 @@
 namespace Web::XHR {
 
 // https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit
-using XMLHttpRequestBodyInit = Variant<NonnullRefPtr<FileAPI::Blob>, NonnullRefPtr<URL::URLSearchParams>, String>;
+using XMLHttpRequestBodyInit = Variant<NonnullRefPtr<FileAPI::Blob>, JS::Handle<JS::Object>, NonnullRefPtr<URL::URLSearchParams>, String>;
 
 class XMLHttpRequest final
     : public RefCounted<XMLHttpRequest>

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
@@ -3,7 +3,7 @@
 #import <FileAPI/Blob.idl>
 #import <URL/URLSearchParams.idl>
 
-typedef (Blob or URLSearchParams or USVString) XMLHttpRequestBodyInit;
+typedef (Blob or BufferSource or URLSearchParams or USVString) XMLHttpRequestBodyInit;
 
 enum XMLHttpRequestResponseType {
   "",


### PR DESCRIPTION
This also does some refactors on `IDL::get_buffer_source_copy()` and `XHR::extract_body()` to let them return `ErrorOr<...>`.