### PR TITLE
WorkspacePicker: Immediately update active workspace on click or scroll

### DIFF
--- a/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
+++ b/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
@@ -18,18 +18,18 @@ class DesktopStatusWidget : public GUI::Widget {
 public:
     virtual ~DesktopStatusWidget() override = default;
 
-    Gfx::IntRect rect_for_desktop(unsigned row, unsigned col) const
+    Gfx::IntRect rect_for_desktop(unsigned row, unsigned column) const
     {
         auto& desktop = GUI::Desktop::the();
 
-        auto vcols = desktop.workspace_columns();
-        auto vrows = desktop.workspace_rows();
+        auto workspace_columns = desktop.workspace_columns();
+        auto workspace_rows = desktop.workspace_rows();
 
-        auto desktop_width = (width() - gap() * (vcols - 1)) / vcols;
-        auto desktop_height = (height() - gap() * (vrows - 1)) / vrows;
+        auto desktop_width = (width() - gap() * (workspace_columns - 1)) / workspace_columns;
+        auto desktop_height = (height() - gap() * (workspace_rows - 1)) / workspace_rows;
 
         return {
-            col * (desktop_width + gap()), row * (desktop_height + gap()),
+            column * (desktop_width + gap()), row * (desktop_height + gap()),
             desktop_width, desktop_height
         };
     }
@@ -48,9 +48,9 @@ public:
         auto inactive_color = palette().inactive_window_border1();
 
         for (unsigned row = 0; row < desktop.workspace_rows(); ++row) {
-            for (unsigned col = 0; col < desktop.workspace_columns(); ++col) {
-                painter.fill_rect(rect_for_desktop(row, col),
-                    (row == current_row() && col == current_col()) ? active_color : inactive_color);
+            for (unsigned column = 0; column < desktop.workspace_columns(); ++column) {
+                painter.fill_rect(rect_for_desktop(row, column),
+                    (row == current_row() && column == current_column()) ? active_color : inactive_color);
             }
         }
     }
@@ -59,36 +59,36 @@ public:
     {
         auto base_rect = rect_for_desktop(0, 0);
         auto row = event.y() / (base_rect.height() + gap());
-        auto col = event.x() / (base_rect.width() + gap());
+        auto column = event.x() / (base_rect.width() + gap());
 
         // Handle case where divider is clicked.
-        if (rect_for_desktop(row, col).contains(event.position()))
-            GUI::ConnectionToWindowManagerServer::the().async_set_workspace(row, col);
+        if (rect_for_desktop(row, column).contains(event.position()))
+            GUI::ConnectionToWindowManagerServer::the().async_set_workspace(row, column);
     }
 
     virtual void mousewheel_event(GUI::MouseEvent& event) override
     {
         auto& desktop = GUI::Desktop::the();
 
-        auto col = current_col();
+        auto column = current_column();
         auto row = current_row();
 
-        auto vcols = desktop.workspace_columns();
-        auto vrows = desktop.workspace_rows();
+        auto workspace_columns = desktop.workspace_columns();
+        auto workspace_rows = desktop.workspace_rows();
         auto direction = event.wheel_delta_y() < 0 ? 1 : -1;
 
         if (event.modifiers() & Mod_Shift)
-            col = abs((int)col + direction) % vcols;
+            column = abs((int)column + direction) % workspace_columns;
         else
-            row = abs((int)row + direction) % vrows;
+            row = abs((int)row + direction) % workspace_rows;
 
-        GUI::ConnectionToWindowManagerServer::the().async_set_workspace(row, col);
+        GUI::ConnectionToWindowManagerServer::the().async_set_workspace(row, column);
     }
 
     unsigned current_row() const { return m_current_row; }
     void set_current_row(unsigned row) { m_current_row = row; }
-    unsigned current_col() const { return m_current_col; }
-    void set_current_col(unsigned col) { m_current_col = col; }
+    unsigned current_column() const { return m_current_column; }
+    void set_current_column(unsigned column) { m_current_column = column; }
 
     unsigned gap() const { return m_gap; }
 
@@ -98,7 +98,7 @@ private:
     unsigned m_gap { 1 };
 
     unsigned m_current_row { 0 };
-    unsigned m_current_col { 0 };
+    unsigned m_current_column { 0 };
 };
 
 DesktopStatusWindow::DesktopStatusWindow()
@@ -122,7 +122,7 @@ void DesktopStatusWindow::wm_event(GUI::WMEvent& event)
     if (event.type() == GUI::Event::WM_WorkspaceChanged) {
         auto& changed_event = static_cast<GUI::WMWorkspaceChangedEvent&>(event);
         m_widget->set_current_row(changed_event.current_row());
-        m_widget->set_current_col(changed_event.current_column());
+        m_widget->set_current_column(changed_event.current_column());
         update();
     }
 }

--- a/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
+++ b/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Peter Elliott <pelliott@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022, Jakob-Niklas See <git@nwex.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -62,8 +63,13 @@ public:
         auto column = event.x() / (base_rect.width() + gap());
 
         // Handle case where divider is clicked.
-        if (rect_for_desktop(row, column).contains(event.position()))
+        if (rect_for_desktop(row, column).contains(event.position())) {
             GUI::ConnectionToWindowManagerServer::the().async_set_workspace(row, column);
+
+            set_current_row(row);
+            set_current_column(column);
+            update();
+        }
     }
 
     virtual void mousewheel_event(GUI::MouseEvent& event) override
@@ -81,6 +87,10 @@ public:
             column = abs((int)column + direction) % workspace_columns;
         else
             row = abs((int)row + direction) % workspace_rows;
+
+        set_current_row(row);
+        set_current_column(column);
+        update();
 
         GUI::ConnectionToWindowManagerServer::the().async_set_workspace(row, column);
     }


### PR DESCRIPTION
This pull request makes the picker applet react instantly to a click on a workspace or scroll on the widget, instead of waiting for an event from WindowServer and as such until the switching animation has ended. This synchronises the switching with the overlay shown.

Note that WindowServer events will still get handled in case the workspace were to be updated from somewhere else.

I've also cleaned up some variable names that didn't seem to quite fit our coding style

Current master:
https://user-images.githubusercontent.com/42888162/180564951-ba5971ae-11f2-42c2-b7af-3288ffd004a4.mp4

This pr:
https://user-images.githubusercontent.com/42888162/180565023-9253df11-c704-4012-8583-7b7d68462589.mp4



