### PR TITLE
LibJS+LibUnicode: Generate a set of default DateTimeFormat patterns

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -431,7 +431,7 @@ Optional<Unicode::CalendarPattern> basic_format_matcher(Unicode::CalendarPattern
     best_format->for_each_calendar_field_zipped_with(options, [&](auto& best_format_field, auto const& option_field, auto field_type) {
         switch (field_type) {
         case Unicode::CalendarPattern::Field::FractionalSecondDigits:
-            if (best_format->second.has_value() && option_field.has_value())
+            if ((best_format_field.has_value() || best_format->second.has_value()) && option_field.has_value())
                 best_format_field = option_field;
             break;
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -263,7 +263,11 @@ describe("dayPeriod", () => {
     });
 
     test("flexible day period rolls over midnight", () => {
-        const en = new Intl.DateTimeFormat("en", { dayPeriod: "short", timeZone: "UTC" });
+        const en = new Intl.DateTimeFormat("en", {
+            hour: "numeric",
+            dayPeriod: "short",
+            timeZone: "UTC",
+        });
 
         // For the en locale, these times (05:00 and 23:00) fall in the flexible day period range of
         // [21:00, 06:00), on either side of midnight.
@@ -291,6 +295,7 @@ describe("dayPeriod", () => {
         // The en locale includes the "noon" fixed day period, whereas the ar locale does not.
         data.forEach(d => {
             const en = new Intl.DateTimeFormat("en", {
+                hour: "numeric",
                 dayPeriod: "short",
                 timeZone: "UTC",
                 minute: d.minute,
@@ -303,6 +308,7 @@ describe("dayPeriod", () => {
             expect(en.format(date3)).toBe(d.en3);
 
             const ar = new Intl.DateTimeFormat("ar", {
+                hour: "numeric",
                 dayPeriod: "short",
                 timeZone: "UTC",
                 minute: d.minute,
@@ -313,6 +319,38 @@ describe("dayPeriod", () => {
             expect(ar.format(date1)).toBe(d.ar1);
             expect(ar.format(date2)).toBe(d.ar2);
             expect(ar.format(date3)).toBe(d.ar3);
+        });
+    });
+
+    test("dayPeriod without time", () => {
+        // prettier-ignore
+        const data = [
+            { dayPeriod: "narrow", en0: "in the afternoon", en1: "in the morning", ar0: "بعد الظهر", ar1: "صباحًا", as0: "অপৰাহ্ন", as1: "পূৰ্বাহ্ন"},
+            { dayPeriod: "short", en0: "in the afternoon", en1: "in the morning", ar0: "بعد الظهر", ar1: "ص", as0: "অপৰাহ্ন", as1: "পূৰ্বাহ্ন"},
+            { dayPeriod: "long", en0: "in the afternoon", en1: "in the morning", ar0: "بعد الظهر", ar1: "صباحًا", as0: "অপৰাহ্ন", as1: "পূৰ্বাহ্ন"},
+        ];
+
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", {
+                dayPeriod: d.dayPeriod,
+                timeZone: "UTC",
+            });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", {
+                dayPeriod: d.dayPeriod,
+                timeZone: "UTC",
+            });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+
+            const as = new Intl.DateTimeFormat("as", {
+                dayPeriod: d.dayPeriod,
+                timeZone: "UTC",
+            });
+            expect(as.format(d0)).toBe(d.as0);
+            expect(as.format(d1)).toBe(d.as1);
         });
     });
 });


### PR DESCRIPTION
Spent wayyy too long trying to figure out why our `Intl.DateTimeFormat` implementation adds the hour to the formatted time when only `dayPeriod` is specified, like this:
```js
> new Intl.DateTimeFormat([], {dayPeriod: 'long'}).format(1447372800000)
"7 in the evening"
```

While all other implementations do not:
```js
> new Intl.DateTimeFormat([], {dayPeriod: 'long'}).format(1447372800000)
"in the evening"
```

Turns out in the big wide world of "implementation defined", ICU has added a set of default patterns to their DateTimeFormat since they first created the thing in 2006:
https://github.com/unicode-org/icu/commit/1fd212318824dabe04ca8bf8e19782bd01d3ebb7

This adds the same set of patterns to our implementation, since test262 depends on it:
```
Diff Tests:
    test/intl402/DateTimeFormat/prototype/format/dayPeriod-long-en.js          ❌ -> ✅
    test/intl402/DateTimeFormat/prototype/format/dayPeriod-narrow-en.js        ❌ -> ✅
    test/intl402/DateTimeFormat/prototype/format/dayPeriod-short-en.js         ❌ -> ✅
    test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-long-en.js   ❌ -> ✅
    test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-narrow-en.js ❌ -> ✅
    test/intl402/DateTimeFormat/prototype/formatToParts/dayPeriod-short-en.js  ❌ -> ✅
```