### PR TITLE
SystemMonitor: Keep selected row in ProcessMemoryMapWidget

### DIFF
--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
@@ -123,7 +123,7 @@ void ProcessMemoryMapWidget::set_pid(pid_t pid)
 void ProcessMemoryMapWidget::refresh()
 {
     if (m_pid != -1)
-        m_json_model->invalidate();
+        m_json_model->update();
 }
 
 }


### PR DESCRIPTION
The process memory view loses the selected row when it's redrawn. Call
update() instead of invalidate() to fix this.