### PR TITLE
Kernel/SysFS: Fix parent directory hierarchy with symbolic links

### DIFF
--- a/Kernel/FileSystem/SysFS/Component.cpp
+++ b/Kernel/FileSystem/SysFS/Component.cpp
@@ -91,7 +91,8 @@ static ErrorOr<NonnullOwnPtr<KString>> generate_return_path_to_mount_point(Nonnu
 
 ErrorOr<NonnullOwnPtr<KString>> SysFSSymbolicLink::try_generate_return_path_to_mount_point() const
 {
-    auto hops_from_mountpoint = TRY(relative_path_hops_count_from_mountpoint());
+    VERIFY(m_parent_directory);
+    auto hops_from_mountpoint = TRY(m_parent_directory->relative_path_hops_count_from_mountpoint());
     if (hops_from_mountpoint == 0)
         return KString::try_create("./"sv);
     auto start_return_path = TRY(KString::try_create("./"sv));

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/SymbolicLinkDeviceComponent.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/SymbolicLinkDeviceComponent.cpp
@@ -11,17 +11,32 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullRefPtr<SysFSSymbolicLinkDeviceComponent>> SysFSSymbolicLinkDeviceComponent::try_create(SysFSDeviceIdentifiersDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component)
+ErrorOr<NonnullRefPtr<SysFSSymbolicLinkDeviceComponent>> SysFSSymbolicLinkDeviceComponent::try_create(SysFSCharacterDevicesDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component)
 {
     auto device_name = TRY(KString::formatted("{}:{}", device.major(), device.minor()));
     return adopt_nonnull_ref_or_enomem(new (nothrow) SysFSSymbolicLinkDeviceComponent(parent_directory, move(device_name), device, pointed_component));
 }
-SysFSSymbolicLinkDeviceComponent::SysFSSymbolicLinkDeviceComponent(SysFSDeviceIdentifiersDirectory const& parent_directory, NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const& device, SysFSComponent const& pointed_component)
+
+ErrorOr<NonnullRefPtr<SysFSSymbolicLinkDeviceComponent>> SysFSSymbolicLinkDeviceComponent::try_create(SysFSBlockDevicesDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component)
+{
+    auto device_name = TRY(KString::formatted("{}:{}", device.major(), device.minor()));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) SysFSSymbolicLinkDeviceComponent(parent_directory, move(device_name), device, pointed_component));
+}
+
+SysFSSymbolicLinkDeviceComponent::SysFSSymbolicLinkDeviceComponent(SysFSCharacterDevicesDirectory const& parent_directory, NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const& device, SysFSComponent const& pointed_component)
     : SysFSSymbolicLink(parent_directory, pointed_component)
     , m_block_device(device.is_block_device())
     , m_major_minor_formatted_device_name(move(major_minor_formatted_device_name))
 {
-    VERIFY(device.is_block_device() || device.is_character_device());
+    VERIFY(device.is_character_device());
+}
+
+SysFSSymbolicLinkDeviceComponent::SysFSSymbolicLinkDeviceComponent(SysFSBlockDevicesDirectory const& parent_directory, NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const& device, SysFSComponent const& pointed_component)
+    : SysFSSymbolicLink(parent_directory, pointed_component)
+    , m_block_device(device.is_block_device())
+    , m_major_minor_formatted_device_name(move(major_minor_formatted_device_name))
+{
+    VERIFY(device.is_block_device());
 }
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/SymbolicLinkDeviceComponent.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/SymbolicLinkDeviceComponent.h
@@ -8,6 +8,8 @@
 
 #include <AK/IntrusiveList.h>
 #include <Kernel/FileSystem/SysFS/Component.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/BlockDevicesDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/CharacterDevicesDirectory.h>
 #include <Kernel/KString.h>
 
 namespace Kernel {
@@ -19,12 +21,16 @@ class SysFSSymbolicLinkDeviceComponent final
     friend class SysFSComponentRegistry;
 
 public:
-    static ErrorOr<NonnullRefPtr<SysFSSymbolicLinkDeviceComponent>> try_create(SysFSDeviceIdentifiersDirectory const& parent_directory, Device const&, SysFSComponent const& pointed_component);
+    static ErrorOr<NonnullRefPtr<SysFSSymbolicLinkDeviceComponent>> try_create(SysFSCharacterDevicesDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component);
+    static ErrorOr<NonnullRefPtr<SysFSSymbolicLinkDeviceComponent>> try_create(SysFSBlockDevicesDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component);
+
     virtual StringView name() const override { return m_major_minor_formatted_device_name->view(); }
     bool is_block_device() const { return m_block_device; }
 
 private:
-    SysFSSymbolicLinkDeviceComponent(SysFSDeviceIdentifiersDirectory const& parent_directory, NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const&, SysFSComponent const& pointed_component);
+    SysFSSymbolicLinkDeviceComponent(SysFSCharacterDevicesDirectory const& parent_directory, NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const&, SysFSComponent const& pointed_component);
+    SysFSSymbolicLinkDeviceComponent(SysFSBlockDevicesDirectory const& parent_directory, NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const&, SysFSComponent const& pointed_component);
+
     IntrusiveListNode<SysFSSymbolicLinkDeviceComponent, NonnullRefPtr<SysFSSymbolicLinkDeviceComponent>> m_list_node;
     bool const m_block_device { false };
     NonnullOwnPtr<KString> m_major_minor_formatted_device_name;

--- a/Kernel/Graphics/DisplayConnector.cpp
+++ b/Kernel/Graphics/DisplayConnector.cpp
@@ -76,7 +76,7 @@ void DisplayConnector::after_inserting()
     m_sysfs_device_directory = sysfs_display_connector_device_directory;
     SysFSDisplayConnectorsDirectory::the().plug({}, *sysfs_display_connector_device_directory);
     VERIFY(!m_symlink_sysfs_component);
-    auto sys_fs_component = MUST(SysFSSymbolicLinkDeviceComponent::try_create(SysFSDeviceIdentifiersDirectory::the(), *this, *m_sysfs_device_directory));
+    auto sys_fs_component = MUST(SysFSSymbolicLinkDeviceComponent::try_create(SysFSCharacterDevicesDirectory::the(), *this, *m_sysfs_device_directory));
     m_symlink_sysfs_component = sys_fs_component;
     after_inserting_add_symlink_to_device_identifier_directory();
 

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -35,7 +35,7 @@ void StorageDevice::after_inserting()
     m_sysfs_device_directory = sysfs_storage_device_directory;
     SysFSStorageDirectory::the().plug({}, *sysfs_storage_device_directory);
     VERIFY(!m_symlink_sysfs_component);
-    auto sys_fs_component = MUST(SysFSSymbolicLinkDeviceComponent::try_create(SysFSDeviceIdentifiersDirectory::the(), *this, *m_sysfs_device_directory));
+    auto sys_fs_component = MUST(SysFSSymbolicLinkDeviceComponent::try_create(SysFSBlockDevicesDirectory::the(), *this, *m_sysfs_device_directory));
     m_symlink_sysfs_component = sys_fs_component;
     after_inserting_add_symlink_to_device_identifier_directory();
 }


### PR DESCRIPTION
We should actually start counting from the parent directory and not from
the symbolic link as it will represent a wrong count of hops from the
actual mountpoint.

The symlinks in /sys/dev/block and /sys/dev/char worked only by luck,
because I have set it to the wrong parent directory which is the
/sys/dev directory, so with the symlink it was 3 hops to /sys, together
with the root directory, therefore, everything seemed to work.

Now that the device symlinks in /sys/dev/block and /sys/dev/char are set
to the right parent directory and we start measure hops from root
directory with the parent directory of a symlink, everything seem to
work correctly now.

Cherry-picked from #14601.