### PR TITLE
LibDSP+Piano: Volume is back, and it's better than ever

### DIFF
--- a/Userland/Applications/Piano/CMakeLists.txt
+++ b/Userland/Applications/Piano/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     SamplerWidget.cpp
     WaveWidget.cpp
     ProcessorParameterWidget/Slider.cpp
+    ProcessorParameterWidget/ParameterWidget.cpp
 )
 
 serenity_app(Piano ICON app-piano)

--- a/Userland/Applications/Piano/KnobsWidget.cpp
+++ b/Userland/Applications/Piano/KnobsWidget.cpp
@@ -104,11 +104,6 @@ KnobsWidget::KnobsWidget(TrackManager& track_manager, MainWidget& main_widget)
     }
 }
 
-void KnobsWidget::cycle_waveform()
-{
-    m_synth_waveform->set_selected_index((m_synth_waveform->selected_index() + 1) % m_synth_waveform->model()->row_count());
-}
-
 void KnobsWidget::update_knobs()
 {
     // FIXME: This is needed because when the slider is changed normally, we

--- a/Userland/Applications/Piano/KnobsWidget.cpp
+++ b/Userland/Applications/Piano/KnobsWidget.cpp
@@ -34,7 +34,7 @@ KnobsWidget::KnobsWidget(TrackManager& track_manager, MainWidget& main_widget)
     m_values_container->set_layout<GUI::HorizontalBoxLayout>();
     m_values_container->set_fixed_height(10);
 
-    m_volume_value = m_values_container->add<GUI::Label>(String::number(m_track_manager.current_track()->volume()));
+    m_volume_value = m_values_container->add<GUI::Label>(String::number(0));
     m_octave_value = m_values_container->add<GUI::Label>(String::number(m_track_manager.keyboard()->virtual_keyboard_octave()));
 
     m_knobs_container = add<GUI::Widget>();
@@ -44,15 +44,7 @@ KnobsWidget::KnobsWidget(TrackManager& track_manager, MainWidget& main_widget)
 
     m_volume_knob = m_knobs_container->add<GUI::VerticalSlider>();
     m_volume_knob->set_range(0, volume_max);
-    m_volume_knob->set_value(volume_max - m_track_manager.current_track()->volume());
     m_volume_knob->set_step(10);
-    m_volume_knob->on_change = [this](int value) {
-        int new_volume = volume_max - value;
-        if (m_change_underlying)
-            m_track_manager.current_track()->set_volume(new_volume);
-        VERIFY(new_volume == m_track_manager.current_track()->volume());
-        m_volume_value->set_text(String::number(new_volume));
-    };
 
     m_octave_knob = m_knobs_container->add<GUI::VerticalSlider>();
     m_octave_knob->set_tooltip("Z: octave down, X: octave up");
@@ -111,7 +103,6 @@ void KnobsWidget::update_knobs()
     // need to change the slider without changing the underlying value.
     m_change_underlying = false;
 
-    m_volume_knob->set_value(volume_max - m_track_manager.current_track()->volume());
     m_octave_knob->set_value(octave_max - m_track_manager.keyboard()->virtual_keyboard_octave());
 
     m_change_underlying = true;

--- a/Userland/Applications/Piano/KnobsWidget.h
+++ b/Userland/Applications/Piano/KnobsWidget.h
@@ -26,7 +26,6 @@ public:
     virtual ~KnobsWidget() override = default;
 
     void update_knobs();
-    void cycle_waveform();
 
 private:
     KnobsWidget(TrackManager&, MainWidget&);

--- a/Userland/Applications/Piano/KnobsWidget.h
+++ b/Userland/Applications/Piano/KnobsWidget.h
@@ -8,8 +8,7 @@
 
 #pragma once
 
-#include "ProcessorParameterWidget/Dropdown.h"
-#include "ProcessorParameterWidget/Slider.h"
+#include "ProcessorParameterWidget/ParameterWidget.h"
 #include <AK/NonnullRefPtrVector.h>
 #include <LibDSP/ProcessorParameter.h>
 #include <LibDSP/Synthesizers.h>
@@ -33,24 +32,11 @@ private:
     TrackManager& m_track_manager;
     MainWidget& m_main_widget;
 
-    RefPtr<GUI::Widget> m_labels_container;
-    RefPtr<GUI::Label> m_volume_label;
-    RefPtr<GUI::Label> m_octave_label;
-    NonnullRefPtrVector<GUI::Label> m_synth_labels;
-    NonnullRefPtrVector<GUI::Label> m_delay_labels;
-
-    RefPtr<GUI::Widget> m_values_container;
-    RefPtr<GUI::Label> m_volume_value;
-    RefPtr<GUI::Label> m_octave_value;
-    NonnullRefPtrVector<GUI::Label> m_synth_values;
-    NonnullRefPtrVector<GUI::Label> m_delay_values;
-
-    RefPtr<GUI::Widget> m_knobs_container;
-    RefPtr<GUI::Slider> m_volume_knob;
+    RefPtr<GUI::Widget> m_octave_container;
     RefPtr<GUI::Slider> m_octave_knob;
-    RefPtr<ProcessorParameterDropdown<DSP::Synthesizers::Waveform>> m_synth_waveform;
-    NonnullRefPtrVector<GUI::Widget> m_synth_knobs;
-    NonnullRefPtrVector<ProcessorParameterSlider> m_delay_knobs;
+    RefPtr<GUI::Label> m_octave_value;
+
+    NonnullRefPtrVector<ProcessorParameterWidget> m_parameter_widgets;
 
     bool m_change_underlying { true };
 };

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -115,9 +115,6 @@ void MainWidget::special_key_action(int key_code)
     case Key_X:
         set_octave_and_ensure_note_change(DSP::Keyboard::Direction::Up);
         break;
-    case Key_C:
-        m_knobs_widget->cycle_waveform();
-        break;
     case Key_Space:
         m_player_widget->toggle_paused();
         break;

--- a/Userland/Applications/Piano/ProcessorParameterWidget/ParameterWidget.cpp
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/ParameterWidget.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ParameterWidget.h"
+#include "Dropdown.h"
+#include "Slider.h"
+#include "Toggle.h"
+#include <LibDSP/Synthesizers.h>
+#include <LibGUI/BoxLayout.h>
+
+ProcessorParameterWidget::ProcessorParameterWidget(DSP::ProcessorParameter& raw_parameter)
+    : m_parameter(raw_parameter)
+{
+    set_layout<GUI::VerticalBoxLayout>();
+    m_label = add<GUI::Label>(raw_parameter.name());
+    switch (raw_parameter.type()) {
+    case DSP::ParameterType::Range: {
+        auto& parameter = static_cast<DSP::ProcessorRangeParameter&>(raw_parameter);
+        m_value_label = add<GUI::Label>(String::number(static_cast<double>(parameter.value())));
+        m_parameter_modifier = add<ProcessorParameterSlider>(Orientation::Vertical, parameter, m_value_label);
+        break;
+    }
+    case DSP::ParameterType::Enum: {
+        // FIXME: We shouldn't do that, but the only user is the synth right now.
+        auto& parameter = static_cast<DSP::ProcessorEnumParameter<DSP::Synthesizers::Waveform>&>(raw_parameter);
+        auto enum_strings = Vector<String> { "Sine", "Triangle", "Square", "Saw", "Noise" };
+        m_parameter_modifier = add<ProcessorParameterDropdown<DSP::Synthesizers::Waveform>>(parameter, move(enum_strings));
+        break;
+    }
+    case DSP::ParameterType::Boolean: {
+        auto& parameter = static_cast<DSP::ProcessorBooleanParameter&>(raw_parameter);
+        m_parameter_modifier = add<ProcessorParameterToggle>(parameter);
+        break;
+    }
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}

--- a/Userland/Applications/Piano/ProcessorParameterWidget/ParameterWidget.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/ParameterWidget.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtr.h>
+#include <AK/StdLibExtraDetails.h>
+#include <LibCore/Object.h>
+#include <LibDSP/ProcessorParameter.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/Widget.h>
+
+class ProcessorParameterWidget : public GUI::Widget {
+    C_OBJECT(ProcessorParameterWidget)
+public:
+    ProcessorParameterWidget(DSP::ProcessorParameter& parameter);
+    virtual ~ProcessorParameterWidget() = default;
+
+private:
+    DSP::ProcessorParameter& m_parameter;
+    RefPtr<GUI::Widget> m_parameter_modifier;
+    RefPtr<GUI::Label> m_label;
+    RefPtr<GUI::Label> m_value_label;
+};

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Toggle.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Toggle.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/Object.h>
+#include <LibDSP/ProcessorParameter.h>
+#include <LibGUI/CheckBox.h>
+#include <LibGUI/Widget.h>
+
+class ProcessorParameterToggle : public GUI::CheckBox {
+    C_OBJECT(ProcessorParameterToggle)
+
+public:
+    ProcessorParameterToggle(DSP::ProcessorBooleanParameter& parameter)
+        : CheckBox("")
+        , m_parameter(parameter)
+    {
+        on_checked = [this](auto checked) {
+            if (m_currently_setting_from_ui)
+                return;
+            m_currently_setting_from_ui = true;
+            m_parameter.set_value(checked);
+            m_currently_setting_from_ui = false;
+        };
+        m_parameter.register_change_listener([this](auto muted) {
+            set_checked(muted, GUI::AllowCallback::No);
+        });
+
+        set_checked(parameter.value());
+    }
+
+private:
+    DSP::ProcessorBooleanParameter& m_parameter;
+    bool m_currently_setting_from_ui { false };
+};

--- a/Userland/Libraries/LibDSP/Effects.h
+++ b/Userland/Libraries/LibDSP/Effects.h
@@ -37,8 +37,16 @@ class Mastering : public EffectProcessor {
 public:
     Mastering(NonnullRefPtr<Transport>);
 
+    // The mastering processor can be used by the track and therefore needs to be able to write to a fixed array directly.
+    // Otherwise, Track needs to do more unnecessary sample data copies.
+    void process_to_fixed_array(Signal const&, FixedArray<Sample>&);
+
 private:
     virtual void process_impl(Signal const&, Signal&) override;
+
+    ProcessorRangeParameter m_pan;
+    ProcessorRangeParameter m_volume;
+    ProcessorBooleanParameter m_muted;
 };
 
 }

--- a/Userland/Libraries/LibDSP/Track.cpp
+++ b/Userland/Libraries/LibDSP/Track.cpp
@@ -43,18 +43,6 @@ bool Track::check_processor_chain_valid_with_initial_type(SignalType initial_typ
     return true;
 }
 
-float Track::volume() const
-{
-    // FIXME: This is a hack until we have a Master processor
-    return 1.0f;
-}
-
-void Track::set_volume(float volume) const
-{
-    // FIXME: This is a hack until we have a Master processor
-    (void)volume;
-}
-
 NonnullRefPtr<Synthesizers::Classic> Track::synth()
 {
     return static_ptr_cast<Synthesizers::Classic>(m_processor_chain.ptr_at(0));

--- a/Userland/Libraries/LibDSP/Track.cpp
+++ b/Userland/Libraries/LibDSP/Track.cpp
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "AK/NonnullRefPtr.h"
-#include "AK/Userspace.h"
 #include <AK/FixedArray.h>
 #include <AK/NoAllocationGuard.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <AK/StdLibExtras.h>
 #include <AK/TypedTransfer.h>
@@ -91,8 +90,8 @@ void Track::current_signal(FixedArray<Sample>& output_signal)
     }
     VERIFY(source_signal->type() == SignalType::Sample);
     VERIFY(output_signal.size() == source_signal->get<FixedArray<Sample>>().size());
-    // This is one final unavoidable memcopy. Otherwise we need to special-case the last processor or
-    AK::TypedTransfer<Sample>::copy(output_signal.data(), source_signal->get<FixedArray<Sample>>().data(), output_signal.size());
+    // The last processor is the fixed mastering processor. This can write directly to the output data. We also just trust this processor that it does the right thing :^)
+    m_track_mastering->process_to_fixed_array(*source_signal, output_signal);
 }
 
 void NoteTrack::compute_current_clips_signal()

--- a/Userland/Libraries/LibDSP/Track.h
+++ b/Userland/Libraries/LibDSP/Track.h
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <AK/DisjointChunks.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/RefCounted.h>
-#include <AK/RefPtr.h>
 #include <LibDSP/Clip.h>
 #include <LibDSP/Effects.h>
 #include <LibDSP/Keyboard.h>
@@ -35,6 +35,7 @@ public:
 
     NonnullRefPtrVector<Processor> const& processor_chain() const { return m_processor_chain; }
     NonnullRefPtr<Transport const> transport() const { return m_transport; }
+    NonnullRefPtr<DSP::Effects::Mastering> track_mastering() { return m_track_mastering; }
 
     // FIXME: These two getters are temporary until we have dynamic processor UI
     NonnullRefPtr<Synthesizers::Classic> synth();
@@ -43,6 +44,7 @@ public:
 protected:
     Track(NonnullRefPtr<Transport> transport, NonnullRefPtr<Keyboard> keyboard)
         : m_transport(move(transport))
+        , m_track_mastering(make_ref_counted<Effects::Mastering>(m_transport))
         , m_keyboard(move(keyboard))
     {
     }
@@ -53,6 +55,7 @@ protected:
 
     NonnullRefPtrVector<Processor> m_processor_chain;
     NonnullRefPtr<Transport> m_transport;
+    NonnullRefPtr<Effects::Mastering> m_track_mastering;
     NonnullRefPtr<Keyboard> m_keyboard;
     // The current signal is stored here, to prevent unnecessary reallocation.
     Signal m_current_signal { FixedArray<Sample> {} };

--- a/Userland/Libraries/LibDSP/Track.h
+++ b/Userland/Libraries/LibDSP/Track.h
@@ -36,9 +36,6 @@ public:
     NonnullRefPtrVector<Processor> const& processor_chain() const { return m_processor_chain; }
     NonnullRefPtr<Transport const> transport() const { return m_transport; }
 
-    float volume() const;
-    void set_volume(float volume) const;
-
     // FIXME: These two getters are temporary until we have dynamic processor UI
     NonnullRefPtr<Synthesizers::Classic> synth();
     NonnullRefPtr<Effects::Delay> delay();

--- a/Userland/Libraries/LibGUI/CheckBox.h
+++ b/Userland/Libraries/LibGUI/CheckBox.h
@@ -29,9 +29,10 @@ public:
     CheckBoxPosition checkbox_position() const { return m_checkbox_position; }
     void set_checkbox_position(CheckBoxPosition value) { m_checkbox_position = value; }
 
-private:
+protected:
     explicit CheckBox(String = {});
 
+private:
     void size_to_fit();
 
     // These don't make sense for a check box, so hide them.


### PR DESCRIPTION
After I broke volume last time, let's bring it back, but properly. #6528 as usual.

Bonus: I got fed up with repetitive parameter UI code and wrote a generic wrapper which will come in very handy for automatic whole processor UI in the future.

Bonus Bonus: actually a feature improvement this time:
- Volume is logarithmic as it is supposed to be
- You can pan tracks now
- You can mute tracks now

![new sliders](https://media.discordapp.net/attachments/834851530946773022/1000395357622124614/unknown.png)