### PR TITLE
AK: Remove redundant hex_encode API

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -225,7 +225,8 @@ public:
     ErrorOr<void> put_hexdump(
         ReadonlyBytes,
         size_t width,
-        char fill = ' ');
+        char fill = ' ',
+        bool upper_case = false);
 
     StringBuilder const& builder() const
     {
@@ -293,6 +294,7 @@ struct StandardFormatter {
         Hexfloat,
         HexfloatUppercase,
         HexDump,
+        HexDumpUppercase
     };
 
     FormatBuilder::Align m_align = FormatBuilder::Align::Default;

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -383,10 +383,8 @@ struct Formatter<ReadonlyBytes> : Formatter<StringView> {
             Formatter<FlatPtr> formatter { *this };
             return formatter.format(builder, reinterpret_cast<FlatPtr>(value.data()));
         }
-        if (m_mode == Mode::Default || m_mode == Mode::HexDump) {
+        if (m_mode == Mode::Default)
             m_mode = Mode::HexDump;
-            return Formatter<StringView>::format(builder, value);
-        }
         return Formatter<StringView>::format(builder, value);
     }
 };

--- a/AK/Hex.cpp
+++ b/AK/Hex.cpp
@@ -35,26 +35,4 @@ ErrorOr<ByteBuffer> decode_hex(StringView input)
     return { move(output) };
 }
 
-#ifdef KERNEL
-ErrorOr<NonnullOwnPtr<Kernel::KString>> encode_hex(const ReadonlyBytes input)
-{
-    StringBuilder output(input.size() * 2);
-
-    for (auto ch : input)
-        TRY(output.try_appendff("{:02x}", ch));
-
-    return Kernel::KString::try_create(output.string_view());
-}
-#else
-String encode_hex(const ReadonlyBytes input)
-{
-    StringBuilder output(input.size() * 2);
-
-    for (auto ch : input)
-        output.appendff("{:02x}", ch);
-
-    return output.build();
-}
-#endif
-
 }

--- a/AK/Hex.h
+++ b/AK/Hex.h
@@ -31,14 +31,7 @@ constexpr u8 decode_hex_digit(char digit)
 
 ErrorOr<ByteBuffer> decode_hex(StringView);
 
-#ifdef KERNEL
-ErrorOr<NonnullOwnPtr<Kernel::KString>> encode_hex(ReadonlyBytes);
-#else
-String encode_hex(ReadonlyBytes);
-#endif
-
 }
 
 using AK::decode_hex;
 using AK::decode_hex_digit;
-using AK::encode_hex;

--- a/AK/UUID.cpp
+++ b/AK/UUID.cpp
@@ -79,37 +79,22 @@ UUID::UUID(StringView uuid_string_view, Endianness endianness)
 #ifdef KERNEL
 ErrorOr<NonnullOwnPtr<Kernel::KString>> UUID::to_string() const
 {
-    StringBuilder builder(36);
-    auto nibble0 = TRY(encode_hex(m_uuid_buffer.span().trim(4)));
-    TRY(builder.try_append(nibble0->view()));
-    TRY(builder.try_append('-'));
-    auto nibble1 = TRY(encode_hex(m_uuid_buffer.span().slice(4).trim(2)));
-    TRY(builder.try_append(nibble1->view()));
-    TRY(builder.try_append('-'));
-    auto nibble2 = TRY(encode_hex(m_uuid_buffer.span().slice(6).trim(2)));
-    TRY(builder.try_append(nibble2->view()));
-    TRY(builder.try_append('-'));
-    auto nibble3 = TRY(encode_hex(m_uuid_buffer.span().slice(8).trim(2)));
-    TRY(builder.try_append(nibble3->view()));
-    TRY(builder.try_append('-'));
-    auto nibble4 = TRY(encode_hex(m_uuid_buffer.span().slice(10).trim(6)));
-    TRY(builder.try_append(nibble4->view()));
-    return Kernel::KString::try_create(builder.string_view());
+    return Kernel::KString::formatted("{}-{}-{}-{}-{}",
+        m_uuid_buffer.span().trim(4),
+        m_uuid_buffer.span().slice(4).trim(2),
+        m_uuid_buffer.span().slice(6).trim(2),
+        m_uuid_buffer.span().slice(8).trim(2),
+        m_uuid_buffer.span().slice(10).trim(6));
 }
 #else
 String UUID::to_string() const
 {
-    StringBuilder builder(36);
-    builder.append(encode_hex(m_uuid_buffer.span().trim(4)).view());
-    builder.append('-');
-    builder.append(encode_hex(m_uuid_buffer.span().slice(4).trim(2)).view());
-    builder.append('-');
-    builder.append(encode_hex(m_uuid_buffer.span().slice(6).trim(2)).view());
-    builder.append('-');
-    builder.append(encode_hex(m_uuid_buffer.span().slice(8).trim(2)).view());
-    builder.append('-');
-    builder.append(encode_hex(m_uuid_buffer.span().slice(10).trim(6)).view());
-    return builder.to_string();
+    return String::formatted("{}-{}-{}-{}-{}",
+        m_uuid_buffer.span().trim(4),
+        m_uuid_buffer.span().slice(4).trim(2),
+        m_uuid_buffer.span().slice(6).trim(2),
+        m_uuid_buffer.span().slice(8).trim(2),
+        m_uuid_buffer.span().slice(10).trim(6));
 }
 #endif
 

--- a/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
+++ b/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
@@ -39,7 +39,7 @@ static void append_indent(StringBuilder& builder, int indent)
 String StringObject::to_string(int) const
 {
     if (is_binary())
-        return String::formatted("<{}>", encode_hex(string().bytes()).to_uppercase());
+        return String::formatted("<{:HEX-DUMP}>", string().bytes());
     return String::formatted("({})", string());
 }
 
@@ -99,16 +99,15 @@ String StreamObject::to_string(int indent) const
     builder.appendff("{}\n", dict()->to_string(indent + 1));
     append_indent(builder, indent + 1);
 
-    auto string = encode_hex(bytes());
+    off_t offset = 0;
     while (true) {
-        if (string.length() > 60) {
-            builder.appendff("{}\n", string.substring(0, 60));
+        if (bytes().size() * 2 - offset > 60) {
+            builder.appendff("{}\n", bytes().slice(offset, 60));
             append_indent(builder, indent);
-            string = string.substring(60);
             continue;
         }
 
-        builder.appendff("{}\n", string);
+        builder.appendff("{}\n", bytes().slice(offset));
         break;
     }
 

--- a/Userland/Libraries/LibTLS/HandshakeClient.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeClient.cpp
@@ -141,11 +141,7 @@ bool TLSv12::compute_master_secret_from_pre_master_secret(size_t length)
 
     if constexpr (TLS_SSL_KEYLOG_DEBUG) {
         auto file = MUST(Core::Stream::File::open("/home/anon/ssl_keylog"sv, Core::Stream::OpenMode::Append | Core::Stream::OpenMode::Write));
-        VERIFY(file->write_or_error("CLIENT_RANDOM "sv.bytes()));
-        VERIFY(file->write_or_error(encode_hex({ m_context.local_random, 32 }).bytes()));
-        VERIFY(file->write_or_error(" "sv.bytes()));
-        VERIFY(file->write_or_error(encode_hex(m_context.master_key).bytes()));
-        VERIFY(file->write_or_error("\n"sv.bytes()));
+        MUST(file->write(String::formatted("CLIENT_RANDOM {} {}\n", ReadonlyBytes { m_context.local_random, 32 }, m_context.master_key.bytes()).bytes()));
     }
 
     expand_key();


### PR DESCRIPTION
This also simplifies some functions previously using that API as well as the `put_hexdump` formatting helper