### PR TITLE
LibGUI: Properly handle range selections in ColumnsView

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -453,6 +453,23 @@ void AbstractView::set_key_column_and_sort_order(int column, SortOrder sort_orde
     update();
 }
 
+void AbstractView::select_range(ModelIndex const& index)
+{
+    auto min_row = min(selection_start_index().row(), index.row());
+    auto max_row = max(selection_start_index().row(), index.row());
+    auto min_column = min(selection_start_index().column(), index.column());
+    auto max_column = max(selection_start_index().column(), index.column());
+
+    clear_selection();
+    for (auto row = min_row; row <= max_row; ++row) {
+        for (auto column = min_column; column <= max_column; ++column) {
+            auto new_index = model()->index(row, column);
+            if (new_index.is_valid())
+                toggle_selection(new_index);
+        }
+    }
+}
+
 void AbstractView::set_cursor(ModelIndex index, SelectionUpdate selection_update, bool scroll_cursor_into_view)
 {
     if (!model() || !index.is_valid() || selection_mode() == SelectionMode::NoSelection) {
@@ -477,19 +494,7 @@ void AbstractView::set_cursor(ModelIndex index, SelectionUpdate selection_update
             if (!m_selection.contains(index))
                 clear_selection();
         } else if (selection_update == SelectionUpdate::Shift) {
-            auto min_row = min(selection_start_index().row(), index.row());
-            auto max_row = max(selection_start_index().row(), index.row());
-            auto min_column = min(selection_start_index().column(), index.column());
-            auto max_column = max(selection_start_index().column(), index.column());
-
-            clear_selection();
-            for (auto row = min_row; row <= max_row; ++row) {
-                for (auto column = min_column; column <= max_column; ++column) {
-                    auto new_index = model()->index(row, column);
-                    if (new_index.is_valid())
-                        toggle_selection(new_index);
-                }
-            }
+            select_range(index);
         }
 
         // FIXME: Support the other SelectionUpdate types

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -156,6 +156,7 @@ protected:
     virtual void add_selection(ModelIndex const&);
     virtual void remove_selection(ModelIndex const&);
     virtual void toggle_selection(ModelIndex const&);
+    virtual void select_range(ModelIndex const&);
     virtual void did_change_hovered_index([[maybe_unused]] ModelIndex const& old_index, [[maybe_unused]] ModelIndex const& new_index) { }
     virtual void did_change_cursor_index([[maybe_unused]] ModelIndex const& old_index, [[maybe_unused]] ModelIndex const& new_index) { }
     virtual void editing_widget_did_change([[maybe_unused]] ModelIndex const& index) { }

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -8,9 +8,9 @@ set(SOURCES
     AbstractScrollableWidget.cpp
     AbstractSlider.cpp
     AbstractTableView.cpp
+    AbstractThemePreview.cpp
     AbstractView.cpp
     AbstractZoomPanWidget.cpp
-    AbstractThemePreview.cpp
     Action.cpp
     ActionGroup.cpp
     Application.cpp
@@ -24,10 +24,12 @@ set(SOURCES
     ColorInput.cpp
     ColorPicker.cpp
     ColumnsView.cpp
-    CommonActions.cpp
-    CommonLocationsProvider.cpp
     ComboBox.cpp
     CommandPalette.cpp
+    CommonActions.cpp
+    CommonLocationsProvider.cpp
+    ConnectionToWindowManagerServer.cpp
+    ConnectionToWindowServer.cpp
     Desktop.cpp
     Dialog.cpp
     DisplayLink.cpp
@@ -52,11 +54,11 @@ set(SOURCES
     GML/SyntaxHighlighter.cpp
     GroupBox.cpp
     HeaderView.cpp
-    INILexer.cpp
-    INISyntaxHighlighter.cpp
     Icon.cpp
     IconView.cpp
     ImageWidget.cpp
+    INILexer.cpp
+    INISyntaxHighlighter.cpp
     InputBox.cpp
     JsonArrayModel.cpp
     Label.cpp
@@ -65,8 +67,8 @@ set(SOURCES
     LinkLabel.cpp
     ListView.cpp
     Menu.cpp
-    MenuItem.cpp
     Menubar.cpp
+    MenuItem.cpp
     MessageBox.cpp
     Model.cpp
     ModelIndex.cpp
@@ -98,8 +100,8 @@ set(SOURCES
     Splitter.cpp
     StackWidget.cpp
     Statusbar.cpp
-    TabWidget.cpp
     TableView.cpp
+    TabWidget.cpp
     TextBox.cpp
     TextDocument.cpp
     TextEditor.cpp
@@ -114,11 +116,9 @@ set(SOURCES
     VimEditingEngine.cpp
     Widget.cpp
     Window.cpp
-    ConnectionToWindowServer.cpp
-    ConnectionToWindowManagerServer.cpp
-    Wizards/WizardDialog.cpp
     Wizards/AbstractWizardPage.cpp
     Wizards/CoverWizardPage.cpp
+    Wizards/WizardDialog.cpp
     Wizards/WizardPage.cpp
 )
 

--- a/Userland/Libraries/LibGUI/ColumnsView.cpp
+++ b/Userland/Libraries/LibGUI/ColumnsView.cpp
@@ -234,6 +234,20 @@ ModelIndex ColumnsView::index_at_event_position(Gfx::IntPoint const& a_position)
     return {};
 }
 
+void ColumnsView::select_range(ModelIndex const& index)
+{
+    auto min_row = min(selection_start_index().row(), index.row());
+    auto max_row = max(selection_start_index().row(), index.row());
+    auto parent = index.parent();
+
+    clear_selection();
+    for (auto row = min_row; row <= max_row; ++row) {
+        auto new_index = model()->index(row, m_model_column, parent);
+        if (new_index.is_valid())
+            toggle_selection(new_index);
+    }
+}
+
 void ColumnsView::mousedown_event(MouseEvent& event)
 {
     AbstractView::mousedown_event(event);

--- a/Userland/Libraries/LibGUI/ColumnsView.h
+++ b/Userland/Libraries/LibGUI/ColumnsView.h
@@ -37,6 +37,8 @@ private:
     virtual void paint_event(PaintEvent&) override;
     virtual void mousedown_event(MouseEvent& event) override;
 
+    virtual void select_range(ModelIndex const&) override;
+
     void move_cursor(CursorMovement, SelectionUpdate) override;
 
     virtual void select_all() override;


### PR DESCRIPTION
Previously we would always select the left most column when selecting a range of rows.

This pull request fixes this issue by always applying a selection to the column in which the selection ends.

Master:

https://user-images.githubusercontent.com/42888162/180624530-80b1a14b-2dbd-4fc9-8747-502588674755.mp4

This pull request:

https://user-images.githubusercontent.com/42888162/180624557-2c2444f4-d3b1-4ccf-9d2f-9255116c15ba.mp4
