### PR TITLE
Base+LibWeb: Some miscellaneous tiny tweaks

### DIFF
--- a/Base/res/html/misc/progressbar.html
+++ b/Base/res/html/misc/progressbar.html
@@ -41,15 +41,10 @@
             margin-left: 20px;
         }
 
-        input {
-            color: black;
-        }
-
         #custom-progress {
             appearance: none;
             width: 200px;
             height: 20px;
-            margin-top: 20px;
         }
 
         #custom-progress::-webkit-progress-bar {

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -330,10 +330,10 @@ progress {
 progress::-webkit-progress-bar {
     width: inherit;
     height: inherit;
-    background-color: #808080;
+    background-color: grey;
 }
 
 progress::-webkit-progress-value {
     height: inherit;
-    background: #008000;
+    background-color: green;
 }

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -249,6 +249,7 @@ button, input[type=submit], input[type=button], input[type=reset] {
     padding: 1px 4px;
     background-color: -libweb-palette-button;
     border: 1px solid -libweb-palette-threed-shadow1;
+    color: -libweb-palette-button-text;
 }
 
 button:hover, input[type=submit]:hover, input[type=button]:hover, input[type=reset]:hover {

--- a/Userland/Libraries/LibWeb/Painting/ProgressPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ProgressPaintable.cpp
@@ -30,8 +30,10 @@ void ProgressPaintable::paint(PaintContext& context, PaintPhase phase) const
         return;
 
     if (phase == PaintPhase::Foreground) {
-        // FIXME: This does not support floating point value() and max()
-        Gfx::StylePainter::paint_progressbar(context.painter(), enclosing_int_rect(absolute_rect()), context.palette(), 0, layout_box().dom_node().max(), layout_box().dom_node().value(), ""sv);
+        auto progress_rect = absolute_rect().to_rounded<int>();
+        auto frame_thickness = min(min(progress_rect.width(), progress_rect.height()) / 6, 3);
+        Gfx::StylePainter::paint_progressbar(context.painter(), progress_rect.shrunken(frame_thickness, frame_thickness), context.palette(), 0, round_to<int>(layout_box().dom_node().max()), round_to<int>(layout_box().dom_node().value()), ""sv);
+        Gfx::StylePainter::paint_frame(context.painter(), progress_rect, context.palette(), Gfx::FrameShape::Box, Gfx::FrameShadow::Raised, frame_thickness);
     }
 }
 


### PR DESCRIPTION
This tweaks a few little things that bugged me (mostly stuff added by me in previous PRs :^))

The main change is here is adding a little frame to system `<progress>` elements. 

![image](https://user-images.githubusercontent.com/11597044/180625728-f2416bb5-0876-4674-bfd4-37e4c550afcb.png)
(Without a frame you can't tell the unfilled section of the bar from a white background)