### PR TITLE
MouseSettings: Show highlight toggle shortcut and new layout tweaks

### DIFF
--- a/Userland/Applications/MouseSettings/Highlight.gml
+++ b/Userland/Applications/MouseSettings/Highlight.gml
@@ -11,27 +11,33 @@
         fixed_height: 136
     }
 
+    @GUI::Label {
+        autosize: true
+        text: "Shortcut: Super+H"
+        preferred_height: "shrink"
+    }
+
     @GUI::GroupBox {
         title: "Highlight color"
-        fixed_height: 80
+        preferred_height: "opportunistic_grow"
         layout: @GUI::VerticalBoxLayout {
             margins: [6]
             spacing: 2
         }
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::ColorInput {
             name: "highlight_color_input"
             has_alpha_channel: false
         }
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
     }
 
     @GUI::GroupBox {
         title: "Highlight opacity"
-        fixed_height: 80
+        preferred_height: "opportunistic_grow"
         layout: @GUI::VerticalBoxLayout {
             margins: [6]
             spacing: 2
@@ -65,7 +71,7 @@
 
     @GUI::GroupBox {
         title: "Highlight size"
-        fixed_height: 80
+        preferred_height: "opportunistic_grow"
         layout: @GUI::VerticalBoxLayout {
             margins: [6]
             spacing: 2


### PR DESCRIPTION
![screenshot-2022-07-24-13-49-06](https://user-images.githubusercontent.com/11597044/180650139-51523573-c1f5-4ae4-8499-bbde7a550a05.png)

This now shows the shortcut to enable mouse pointer highlighting below
the preview. The GML has also been updated to take advantage of the new
layout features rather than using fixed heights.