### PR TITLE
Services: Use per-user portal

### DIFF
--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -39,22 +39,6 @@ Environment=TERM=xterm
 KeepAlive=true
 SystemModes=text
 
-[CppLanguageServer]
-Socket=/tmp/portal/language/cpp
-SocketPermissions=600
-Lazy=true
-User=anon
-MultiInstance=true
-AcceptSocketConnections=true
-
-[ShellLanguageServer]
-Socket=/tmp/portal/language/shell
-SocketPermissions=600
-Lazy=true
-User=anon
-MultiInstance=true
-AcceptSocketConnections=true
-
 [SQLServer]
 Socket=/tmp/portal/sql
 SocketPermissions=600

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -25,14 +25,6 @@ SocketPermissions=600
 Priority=low
 User=anon
 
-[AudioServer]
-# TODO: It would be nice to make this lazy, but Audio.Applet connects to it immediately on startup anyway.
-Socket=/tmp/portal/audio
-Priority=high
-KeepAlive=true
-User=anon
-SystemModes=text,graphical
-
 [Shell@tty0]
 Executable=/bin/Shell
 StdIO=/dev/tty0

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -1,8 +1,3 @@
-[ConfigServer]
-Socket=/tmp/portal/config
-SocketPermissions=600
-User=anon
-
 [RequestServer]
 Socket=/tmp/portal/request
 SocketPermissions=600

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -8,15 +8,6 @@ SystemModes=text,graphical
 MultiInstance=true
 AcceptSocketConnections=true
 
-[WebContent]
-Socket=/tmp/portal/webcontent
-SocketPermissions=600
-Lazy=true
-User=anon
-SystemModes=graphical
-MultiInstance=true
-AcceptSocketConnections=true
-
 [ImageDecoder]
 Socket=/tmp/portal/image
 SocketPermissions=600

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -10,14 +10,6 @@ KeepAlive=true
 User=lookup
 SystemModes=text,graphical,self-test
 
-[NotificationServer]
-Socket=/tmp/portal/notify
-SocketPermissions=600
-Lazy=true
-Priority=low
-KeepAlive=true
-User=anon
-
 [WindowServer]
 Socket=/tmp/portal/window,/tmp/portal/wm
 SocketPermissions=660

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -17,16 +17,6 @@ SystemModes=graphical
 MultiInstance=true
 AcceptSocketConnections=true
 
-[WebSocket]
-Socket=/tmp/portal/websocket
-SocketPermissions=600
-Lazy=true
-Priority=low
-User=anon
-SystemModes=text,graphical
-MultiInstance=true
-AcceptSocketConnections=true
-
 [NetworkServer]
 User=root
 SystemModes=text,graphical,self-test

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -19,12 +19,6 @@ User=window
 # Ensure windowserver has a controlling TTY.
 StdIO=/dev/tty0
 
-[InspectorServer]
-Socket=/tmp/portal/inspector,/tmp/portal/inspectables
-SocketPermissions=600,666
-KeepAlive=true
-User=anon
-
 [Clipboard]
 Socket=/tmp/portal/clipboard
 SocketPermissions=600

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -39,14 +39,6 @@ Environment=TERM=xterm
 KeepAlive=true
 SystemModes=text
 
-[SQLServer]
-Socket=/tmp/portal/sql
-SocketPermissions=600
-Priority=low
-Lazy=true
-KeepAlive=true
-User=anon
-
 [CrashDaemon]
 KeepAlive=true
 User=anon

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -1,13 +1,3 @@
-[RequestServer]
-Socket=/tmp/portal/request
-SocketPermissions=600
-Lazy=true
-Priority=low
-User=anon
-SystemModes=text,graphical
-MultiInstance=true
-AcceptSocketConnections=true
-
 [FileSystemAccessServer]
 Socket=/tmp/portal/filesystemaccess
 SocketPermissions=660

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -1,13 +1,3 @@
-[FileSystemAccessServer]
-Socket=/tmp/portal/filesystemaccess
-SocketPermissions=660
-Lazy=true
-Priority=low
-User=anon
-SystemModes=text,graphical
-MultiInstance=true
-AcceptSocketConnections=true
-
 [ImageDecoder]
 Socket=/tmp/portal/image
 SocketPermissions=600

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -1,12 +1,3 @@
-[ImageDecoder]
-Socket=/tmp/portal/image
-SocketPermissions=600
-Lazy=true
-User=anon
-SystemModes=graphical
-MultiInstance=true
-AcceptSocketConnections=true
-
 [NetworkServer]
 User=root
 SystemModes=text,graphical,self-test

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -1,5 +1,5 @@
 [LaunchServer]
-Socket=/tmp/100/portal/launch
+Socket=/tmp/user/100/portal/launch
 SocketPermissions=600
 Lazy=true
 SystemModes=text,graphical

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -1,3 +1,7 @@
+[ConfigServer]
+Socket=/tmp/user/%uid/portal/config
+SocketPermissions=600
+
 [LaunchServer]
 Socket=/tmp/user/%uid/portal/launch
 SocketPermissions=600

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -2,6 +2,15 @@
 Socket=/tmp/user/%uid/portal/config
 SocketPermissions=600
 
+[RequestServer]
+Socket=/tmp/user/%uid/portal/request
+SocketPermissions=600
+Lazy=true
+Priority=low
+SystemModes=text,graphical
+MultiInstance=true
+AcceptSocketConnections=true
+
 [LaunchServer]
 Socket=/tmp/user/%uid/portal/launch
 SocketPermissions=600

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -52,6 +52,11 @@ Lazy=true
 Priority=low
 KeepAlive=true
 
+[InspectorServer]
+Socket=/tmp/user/%uid/portal/inspector,/tmp/user/%uid/portal/inspectables
+SocketPermissions=600,666
+KeepAlive=true
+
 [LaunchServer]
 Socket=/tmp/user/%uid/portal/launch
 SocketPermissions=600

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -19,6 +19,15 @@ SystemModes=graphical
 MultiInstance=true
 AcceptSocketConnections=true
 
+[WebSocket]
+Socket=/tmp/user/%uid/portal/websocket
+SocketPermissions=600
+Lazy=true
+Priority=low
+SystemModes=text,graphical
+MultiInstance=true
+AcceptSocketConnections=true
+
 [LaunchServer]
 Socket=/tmp/user/%uid/portal/launch
 SocketPermissions=600

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -77,6 +77,13 @@ Lazy=true
 MultiInstance=true
 AcceptSocketConnections=true
 
+[SQLServer]
+Socket=/tmp/user/%uid/portal/sql
+SocketPermissions=600
+Priority=low
+Lazy=true
+KeepAlive=true
+
 [LaunchServer]
 Socket=/tmp/user/%uid/portal/launch
 SocketPermissions=600

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -28,6 +28,15 @@ SystemModes=text,graphical
 MultiInstance=true
 AcceptSocketConnections=true
 
+[FileSystemAccessServer]
+Socket=/tmp/user/%uid/portal/filesystemaccess
+SocketPermissions=660
+Lazy=true
+Priority=low
+SystemModes=text,graphical
+MultiInstance=true
+AcceptSocketConnections=true
+
 [LaunchServer]
 Socket=/tmp/user/%uid/portal/launch
 SocketPermissions=600

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -1,5 +1,5 @@
 [LaunchServer]
-Socket=/tmp/user/100/portal/launch
+Socket=/tmp/user/%uid/portal/launch
 SocketPermissions=600
 Lazy=true
 SystemModes=text,graphical

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -63,6 +63,20 @@ Priority=high
 KeepAlive=true
 SystemModes=text,graphical
 
+[CppLanguageServer]
+Socket=/tmp/user/%uid/portal/language/cpp
+SocketPermissions=600
+Lazy=true
+MultiInstance=true
+AcceptSocketConnections=true
+
+[ShellLanguageServer]
+Socket=/tmp/user/%uid/portal/language/shell
+SocketPermissions=600
+Lazy=true
+MultiInstance=true
+AcceptSocketConnections=true
+
 [LaunchServer]
 Socket=/tmp/user/%uid/portal/launch
 SocketPermissions=600

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -57,6 +57,12 @@ Socket=/tmp/user/%uid/portal/inspector,/tmp/user/%uid/portal/inspectables
 SocketPermissions=600,666
 KeepAlive=true
 
+[AudioServer]
+Socket=/tmp/user/%uid/portal/audio
+Priority=high
+KeepAlive=true
+SystemModes=text,graphical
+
 [LaunchServer]
 Socket=/tmp/user/%uid/portal/launch
 SocketPermissions=600

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -11,6 +11,14 @@ SystemModes=text,graphical
 MultiInstance=true
 AcceptSocketConnections=true
 
+[WebContent]
+Socket=/tmp/user/%uid/portal/webcontent
+SocketPermissions=600
+Lazy=true
+SystemModes=graphical
+MultiInstance=true
+AcceptSocketConnections=true
+
 [LaunchServer]
 Socket=/tmp/user/%uid/portal/launch
 SocketPermissions=600

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -45,6 +45,13 @@ SystemModes=graphical
 MultiInstance=true
 AcceptSocketConnections=true
 
+[NotificationServer]
+Socket=/tmp/user/%uid/portal/notify
+SocketPermissions=600
+Lazy=true
+Priority=low
+KeepAlive=true
+
 [LaunchServer]
 Socket=/tmp/user/%uid/portal/launch
 SocketPermissions=600

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -37,6 +37,14 @@ SystemModes=text,graphical
 MultiInstance=true
 AcceptSocketConnections=true
 
+[ImageDecoder]
+Socket=/tmp/user/%uid/portal/image
+SocketPermissions=600
+Lazy=true
+SystemModes=graphical
+MultiInstance=true
+AcceptSocketConnections=true
+
 [LaunchServer]
 Socket=/tmp/user/%uid/portal/launch
 SocketPermissions=600

--- a/Base/usr/share/man/man7/Audio-subsystem.md
+++ b/Base/usr/share/man/man7/Audio-subsystem.md
@@ -14,11 +14,22 @@ There are two primary sample formats used in SerenityOS. The `Sample` class in L
 
 ### AudioServer
 
-AudioServer is responsible for handling userland audio clients and talking to the hardware. For this reason, no userland application should ever need to write to a device in `/dev/audio` directly, except for special cases in which AudioServer is not present.
+AudioServer is responsible for handling userland audio clients and talking to the hardware. For this reason, no userland
+application should ever need to write to a device in `/dev/audio` directly, except for special cases in which
+AudioServer is not present.
 
-As with all system servers, AudioServer provides an IPC interface on `/tmp/portal/audio`. For specifics on how to talk to AudioServer, the IPC interface specifications are the best source of information. For controlling mixer functionality, clients have the ability to obtain and change their own volume, or the main volume and mute state.
+As with all system servers, AudioServer provides an IPC interface on `/tmp/user/%uid/portal/audio`, with `%uid` being
+the uid
+of the current user. For specifics on how to talk to AudioServer, the IPC interface specifications are the best source
+of information. For controlling mixer functionality, clients have the ability to obtain and change their own volume, or
+the main volume and mute state.
 
-Userland audio transmission happens via the AudioQueue. This is a shared memory circular queue which supports concurrent lock-free writing and reading. The queue is created by the audio client and its shared memory file descriptor sent to the audio server. In order to use this queue, an audio application needs to split up its audio data into atomic chunks that can then be provided to the queue. The application might need to wait around until the queue is empty in order to write to it. For these reasons, there's a utility API in LibAudio's audio server IPC connection which allows audio applications to send off a large chunk of samples which get progressively sent in the background.
+Userland audio transmission happens via the AudioQueue. This is a shared memory circular queue which supports concurrent
+lock-free writing and reading. The queue is created by the audio client and its shared memory file descriptor sent to
+the audio server. In order to use this queue, an audio application needs to split up its audio data into atomic chunks
+that can then be provided to the queue. The application might need to wait around until the queue is empty in order to
+write to it. For these reasons, there's a utility API in LibAudio's audio server IPC connection which allows audio
+applications to send off a large chunk of samples which get progressively sent in the background.
 
 On the server -> client side, AudioServer has "event" calls that the client receives. These are various mixer state changes (main volume, main mute, client volume).
 
@@ -68,7 +79,7 @@ Although the sample rate can change at any time, it is considered a rarely-chang
 
 * [/dev/audio](help://man/4/audio)
 * AudioApplet and AudioServer have settings which are managed by ConfigServer.
-* `/tmp/portal/audio`: AudioServer's IPC socket
+* `/tmp/user/%uid/portal/audio`: AudioServer's IPC socket
 
 ## See also
 

--- a/Documentation/Browser/ProcessArchitecture.md
+++ b/Documentation/Browser/ProcessArchitecture.md
@@ -30,9 +30,13 @@ This process can decode images (PNG, JPEG, BMP, ICO, PBM, etc.) into bitmaps. Ea
 
 ### How processes are spawned
 
-To get a fresh **WebContent** process, anyone with the suitable file system permissions can spawn one by connecting to the socket at `/tmp/portal/webcontent`. This socket is managed by **SystemServer** and will spawn a new instance of **WebContent** for every connection.
+To get a fresh **WebContent** process, anyone with the suitable file system permissions can spawn one by connecting to
+the socket at `/tmp/user/%uid/portal/webcontent`, with `%uid` being the uid of the current user. This socket is managed
+by **
+SystemServer** and will spawn a new instance of **WebContent** for every connection.
 
-The same basic concept applies to **RequestServer** and **ImageDecoder** as well, except that those services are spawned by **WebContent** as needed, not by **Browser**.
+The same basic concept applies to **RequestServer** and **ImageDecoder** as well, except that those services are spawned
+by **WebContent** as needed, not by **Browser**.
 
 ## Class overview
 

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -241,7 +241,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("AudioApplet");
-    TRY(Core::System::unveil("/tmp/portal/audio", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/audio", "rw"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -164,7 +164,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/portal/notify", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/notify", "rw"));
     TRY(Core::System::unveil("/proc/net/adapters", "r"));
     TRY(Core::System::unveil("/bin/SystemMonitor", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -360,7 +360,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix prot_exec"));
 
-    TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/home/anon/Documents/3D Models", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/usr/lib", "r"));

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -84,7 +84,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
-    TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/portal/image", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/request", "rw"));

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -86,7 +86,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/portal/image", "rw"));
-    TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/request", "rw"));
     TRY(Core::System::unveil("/bin/BrowserSettings", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -85,7 +85,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
-    TRY(Core::System::unveil("/tmp/portal/image", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/image", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/request", "rw"));
     TRY(Core::System::unveil("/bin/BrowserSettings", "x"));

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -87,7 +87,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/portal/image", "rw"));
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
-    TRY(Core::System::unveil("/tmp/portal/request", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/request", "rw"));
     TRY(Core::System::unveil("/bin/BrowserSettings", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/usr/share/man", "r"));
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/usr/share/man", "r"));
-    TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -35,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/usr/share/man", "r"));
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
-    TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     String start_page;

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/usr/share/man", "r"));
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -40,7 +40,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     hex_editor_widget->initialize_menubar(*window);

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/etc", "r"));
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     TRY(Desktop::Launcher::add_allowed_url(URL::create_with_file_protocol("/bin/MailSettings")));

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/etc", "r"));
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     TRY(Desktop::Launcher::add_allowed_url(URL::create_with_file_protocol("/bin/MailSettings")));

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -26,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/etc", "r"));
-    TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -35,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto pdf_viewer_widget = TRY(window->try_set_main_widget<PDFViewerWidget>());

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/clipboard", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
-    TRY(Core::System::unveil("/tmp/portal/image", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/image", "rw"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/clipboard", "rw"));
-    TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/portal/image", "rw"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -44,7 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     }
 
-    TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
     // For writing temporary files when exporting.
     TRY(Core::System::unveil("/tmp", "crw"));
     TRY(Core::System::unveil("/etc", "r"));

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -432,7 +432,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/bin/TerminalSettings", "x"));
     TRY(Core::System::unveil("/bin/utmpupdate", "x"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/portal/config", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -433,7 +433,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/bin/utmpupdate", "x"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
-    TRY(Core::System::unveil("/tmp/portal/config", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/config", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto modified_state_check_timer = Core::Timer::create_repeating(500, [&] {

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -432,7 +432,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/bin/TerminalSettings", "x"));
     TRY(Core::System::unveil("/bin/utmpupdate", "x"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/portal/config", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -32,7 +32,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     parser.parse(arguments);
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
-    TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = GUI::Icon::default_icon("app-text-editor"sv);

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -32,7 +32,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     parser.parse(arguments);
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
-    TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         path = Core::File::absolute_path(file_to_edit);
 
     TRY(Core::System::pledge("stdio recvfd sendfd thread rpath unix"));
-    TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/Welcome/main.cpp
+++ b/Userland/Applications/Welcome/main.cpp
@@ -22,7 +22,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/home", "r"));
-    TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/bin/Help", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));
     auto app_icon = GUI::Icon::default_icon("app-welcome"sv);

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -38,7 +38,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     if ((grid_rows > 0) ^ (grid_columns > 0)) {

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -38,7 +38,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     if ((grid_rows > 0) ^ (grid_columns > 0)) {

--- a/Userland/DevTools/HackStudio/LanguageClients/ConnectionsToServer.h
+++ b/Userland/DevTools/HackStudio/LanguageClients/ConnectionsToServer.h
@@ -15,7 +15,7 @@
 #define LANGUAGE_CLIENT(language_name_, socket_name)                                                    \
     namespace language_name_ {                                                                          \
     class ConnectionToServer final : public HackStudio::ConnectionToServer {                            \
-        IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/portal/language/" #socket_name)                 \
+        IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/portal/language/" socket_name)                  \
     public:                                                                                             \
         static char const* language_name() { return #language_name_; }                                  \
                                                                                                         \
@@ -29,8 +29,8 @@
 
 namespace LanguageClients {
 
-LANGUAGE_CLIENT(Cpp, cpp)
-LANGUAGE_CLIENT(Shell, shell)
+LANGUAGE_CLIENT(Cpp, "cpp"sv)
+LANGUAGE_CLIENT(Shell, "shell"sv)
 
 }
 

--- a/Userland/DevTools/HackStudio/LanguageClients/ConnectionsToServer.h
+++ b/Userland/DevTools/HackStudio/LanguageClients/ConnectionsToServer.h
@@ -15,7 +15,7 @@
 #define LANGUAGE_CLIENT(language_name_, socket_name)                                                    \
     namespace language_name_ {                                                                          \
     class ConnectionToServer final : public HackStudio::ConnectionToServer {                            \
-        IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/portal/language/" socket_name)                  \
+        IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/user/%uid/portal/language/" socket_name)        \
     public:                                                                                             \
         static char const* language_name() { return #language_name_; }                                  \
                                                                                                         \

--- a/Userland/DevTools/Inspector/InspectorServerClient.h
+++ b/Userland/DevTools/Inspector/InspectorServerClient.h
@@ -15,7 +15,7 @@ namespace Inspector {
 class InspectorServerClient final
     : public IPC::ConnectionToServer<InspectorClientEndpoint, InspectorServerEndpoint>
     , public InspectorClientEndpoint {
-    IPC_CLIENT_CONNECTION(InspectorServerClient, "/tmp/portal/inspector")
+    IPC_CLIENT_CONNECTION(InspectorServerClient, "/tmp/portal/inspector"sv)
 
 public:
     virtual ~InspectorServerClient() override = default;

--- a/Userland/DevTools/Inspector/InspectorServerClient.h
+++ b/Userland/DevTools/Inspector/InspectorServerClient.h
@@ -15,7 +15,7 @@ namespace Inspector {
 class InspectorServerClient final
     : public IPC::ConnectionToServer<InspectorClientEndpoint, InspectorServerEndpoint>
     , public InspectorClientEndpoint {
-    IPC_CLIENT_CONNECTION(InspectorServerClient, "/tmp/portal/inspector"sv)
+    IPC_CLIENT_CONNECTION(InspectorServerClient, "/tmp/user/%uid/portal/inspector"sv)
 
 public:
     virtual ~InspectorServerClient() override = default;

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -45,7 +45,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     size_t board_size = Config::read_i32("2048"sv, ""sv, "board_size"sv, 4);

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -45,7 +45,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     size_t board_size = Config::read_i32("2048"sv, ""sv, "board_size"sv, 4);

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin/ChessEngine", "x"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -40,7 +40,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/bin/ChessEngine", "x"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
-    TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto size = Config::read_i32("Chess"sv, "Display"sv, "size"sv, 512);

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin/ChessEngine", "x"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Games/FlappyBug/main.cpp
+++ b/Userland/Games/FlappyBug/main.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     u32 high_score = Config::read_i32("FlappyBug"sv, "Game"sv, "HighScore"sv, 0);

--- a/Userland/Games/FlappyBug/main.cpp
+++ b/Userland/Games/FlappyBug/main.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     u32 high_score = Config::read_i32("FlappyBug"sv, "Game"sv, "HighScore"sv, 0);

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -37,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-gameoflife"sv));

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -37,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-gameoflife"sv));

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -41,7 +41,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto window = TRY(GUI::Window::try_create());

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -41,7 +41,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto window = TRY(GUI::Window::try_create());

--- a/Userland/Games/MasterWord/main.cpp
+++ b/Userland/Games/MasterWord/main.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-masterword"sv));

--- a/Userland/Games/MasterWord/main.cpp
+++ b/Userland/Games/MasterWord/main.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-masterword"sv));

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-minesweeper"sv));

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-minesweeper"sv));

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-snake"sv));

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/100/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-snake"sv));

--- a/Userland/Libraries/LibAudio/ConnectionToServer.h
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.h
@@ -26,7 +26,7 @@ namespace Audio {
 class ConnectionToServer final
     : public IPC::ConnectionToServer<AudioClientEndpoint, AudioServerEndpoint>
     , public AudioClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/portal/audio"sv)
+    IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/user/%uid/portal/audio"sv)
 public:
     virtual ~ConnectionToServer() override;
 

--- a/Userland/Libraries/LibAudio/ConnectionToServer.h
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.h
@@ -26,7 +26,7 @@ namespace Audio {
 class ConnectionToServer final
     : public IPC::ConnectionToServer<AudioClientEndpoint, AudioServerEndpoint>
     , public AudioClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/portal/audio")
+    IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/portal/audio"sv)
 public:
     virtual ~ConnectionToServer() override;
 

--- a/Userland/Libraries/LibConfig/Client.h
+++ b/Userland/Libraries/LibConfig/Client.h
@@ -18,7 +18,7 @@ namespace Config {
 class Client final
     : public IPC::ConnectionToServer<ConfigClientEndpoint, ConfigServerEndpoint>
     , public ConfigClientEndpoint {
-    IPC_CLIENT_CONNECTION(Client, "/tmp/portal/config"sv)
+    IPC_CLIENT_CONNECTION(Client, "/tmp/user/%uid/portal/config"sv)
 
 public:
     void pledge_domains(Vector<String> const&);

--- a/Userland/Libraries/LibConfig/Client.h
+++ b/Userland/Libraries/LibConfig/Client.h
@@ -18,7 +18,7 @@ namespace Config {
 class Client final
     : public IPC::ConnectionToServer<ConfigClientEndpoint, ConfigServerEndpoint>
     , public ConfigClientEndpoint {
-    IPC_CLIENT_CONNECTION(Client, "/tmp/portal/config")
+    IPC_CLIENT_CONNECTION(Client, "/tmp/portal/config"sv)
 
 public:
     void pledge_domains(Vector<String> const&);

--- a/Userland/Libraries/LibCore/Account.cpp
+++ b/Userland/Libraries/LibCore/Account.cpp
@@ -68,6 +68,15 @@ ErrorOr<Account> Account::from_passwd(passwd const& pwd, spwd const& spwd)
     return account;
 }
 
+String Account::parse_path_with_uid(StringView general_path, Optional<uid_t> uid)
+{
+    if (general_path.contains("%uid"sv)) {
+        auto const final_uid = uid.has_value() ? uid.value() : getuid();
+        return general_path.replace("%uid"sv, String::number(final_uid), ReplaceMode::All);
+    }
+    return general_path;
+}
+
 ErrorOr<Account> Account::self([[maybe_unused]] Read options)
 {
     Vector<gid_t> extra_gids = TRY(Core::System::getgroups());

--- a/Userland/Libraries/LibCore/Account.h
+++ b/Userland/Libraries/LibCore/Account.h
@@ -34,6 +34,7 @@ public:
 
     // FIXME: Convert the methods below to take StringViews instead.
 
+    static String parse_path_with_uid(StringView general_path, Optional<uid_t> force_uid = {});
     static ErrorOr<Account> self(Read options = Read::All);
     static ErrorOr<Account> from_name(char const* username, Read options = Read::All);
     static ErrorOr<Account> from_uid(uid_t uid, Read options = Read::All);

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -359,7 +359,7 @@ EventLoop::~EventLoop()
 bool connect_to_inspector_server()
 {
 #ifdef __serenity__
-    auto maybe_socket = Core::Stream::LocalSocket::connect("/tmp/portal/inspectables");
+    auto maybe_socket = Core::Stream::LocalSocket::connect("/tmp/user/%uid/portal/inspectables");
     if (maybe_socket.is_error()) {
         dbgln("connect_to_inspector_server: Failed to connect: {}", maybe_socket.error());
         return false;

--- a/Userland/Libraries/LibCore/LocalServer.cpp
+++ b/Userland/Libraries/LibCore/LocalServer.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Account.h>
 #include <LibCore/LocalServer.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/Stream.h>
@@ -37,7 +38,8 @@ ErrorOr<void> LocalServer::take_over_from_system_server(String const& socket_pat
     if (m_listening)
         return Error::from_string_literal("Core::LocalServer: Can't perform socket takeover when already listening");
 
-    auto socket = TRY(take_over_socket_from_system_server(socket_path));
+    auto const parsed_path = Core::Account::parse_path_with_uid(socket_path);
+    auto socket = TRY(take_over_socket_from_system_server(parsed_path));
     m_fd = TRY(socket->release_fd());
 
     m_listening = true;

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -12,6 +12,7 @@
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibCore/Account.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <limits.h>
@@ -81,8 +82,10 @@ ErrorOr<void> pledge(StringView promises, StringView execpromises)
 
 ErrorOr<void> unveil(StringView path, StringView permissions)
 {
+    auto const parsed_path = Core::Account::parse_path_with_uid(path);
+
     Syscall::SC_unveil_params params {
-        { path.characters_without_null_termination(), path.length() },
+        { parsed_path.characters(), parsed_path.length() },
         { permissions.characters_without_null_termination(), permissions.length() },
     };
     int rc = syscall(SC_unveil, &params);

--- a/Userland/Libraries/LibDesktop/Launcher.cpp
+++ b/Userland/Libraries/LibDesktop/Launcher.cpp
@@ -36,7 +36,7 @@ auto Launcher::Details::from_details_str(String const& details_str) -> NonnullRe
 class ConnectionToLaunchServer final
     : public IPC::ConnectionToServer<LaunchClientEndpoint, LaunchServerEndpoint>
     , public LaunchClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToLaunchServer, "/tmp/100/portal/launch")
+    IPC_CLIENT_CONNECTION(ConnectionToLaunchServer, "/tmp/user/100/portal/launch")
 private:
     ConnectionToLaunchServer(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
         : IPC::ConnectionToServer<LaunchClientEndpoint, LaunchServerEndpoint>(*this, move(socket))

--- a/Userland/Libraries/LibDesktop/Launcher.cpp
+++ b/Userland/Libraries/LibDesktop/Launcher.cpp
@@ -36,7 +36,7 @@ auto Launcher::Details::from_details_str(String const& details_str) -> NonnullRe
 class ConnectionToLaunchServer final
     : public IPC::ConnectionToServer<LaunchClientEndpoint, LaunchServerEndpoint>
     , public LaunchClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToLaunchServer, "/tmp/user/100/portal/launch")
+    IPC_CLIENT_CONNECTION(ConnectionToLaunchServer, "/tmp/user/%uid/portal/launch"sv)
 private:
     ConnectionToLaunchServer(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
         : IPC::ConnectionToServer<LaunchClientEndpoint, LaunchServerEndpoint>(*this, move(socket))

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -23,7 +23,7 @@ using Result = ErrorOr<NonnullRefPtr<Core::File>>;
 class Client final
     : public IPC::ConnectionToServer<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint>
     , public FileSystemAccessClientEndpoint {
-    IPC_CLIENT_CONNECTION(Client, "/tmp/portal/filesystemaccess")
+    IPC_CLIENT_CONNECTION(Client, "/tmp/portal/filesystemaccess"sv)
 
 public:
     Result try_request_file_read_only_approved(GUI::Window* parent_window, String const& path);

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -23,7 +23,7 @@ using Result = ErrorOr<NonnullRefPtr<Core::File>>;
 class Client final
     : public IPC::ConnectionToServer<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint>
     , public FileSystemAccessClientEndpoint {
-    IPC_CLIENT_CONNECTION(Client, "/tmp/portal/filesystemaccess"sv)
+    IPC_CLIENT_CONNECTION(Client, "/tmp/user/%uid/portal/filesystemaccess"sv)
 
 public:
     Result try_request_file_read_only_approved(GUI::Window* parent_window, String const& path);

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -16,7 +16,7 @@ namespace GUI {
 class ConnectionToClipboardServer final
     : public IPC::ConnectionToServer<ClipboardClientEndpoint, ClipboardServerEndpoint>
     , public ClipboardClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToClipboardServer, "/tmp/portal/clipboard")
+    IPC_CLIENT_CONNECTION(ConnectionToClipboardServer, "/tmp/portal/clipboard"sv)
 
 private:
     ConnectionToClipboardServer(NonnullOwnPtr<Core::Stream::LocalSocket> socket)

--- a/Userland/Libraries/LibGUI/ConnectionToWindowManagerServer.h
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowManagerServer.h
@@ -16,7 +16,7 @@ namespace GUI {
 class ConnectionToWindowManagerServer final
     : public IPC::ConnectionToServer<WindowManagerClientEndpoint, WindowManagerServerEndpoint>
     , public WindowManagerClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToWindowManagerServer, "/tmp/portal/wm")
+    IPC_CLIENT_CONNECTION(ConnectionToWindowManagerServer, "/tmp/portal/wm"sv)
 
 public:
     static ConnectionToWindowManagerServer& the();

--- a/Userland/Libraries/LibGUI/ConnectionToWindowServer.h
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowServer.h
@@ -16,7 +16,7 @@ namespace GUI {
 class ConnectionToWindowServer final
     : public IPC::ConnectionToServer<WindowClientEndpoint, WindowServerEndpoint>
     , public WindowClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToWindowServer, "/tmp/portal/window")
+    IPC_CLIENT_CONNECTION(ConnectionToWindowServer, "/tmp/portal/window"sv)
 public:
     static ConnectionToWindowServer& the();
     i32 expose_client_id() { return m_client_id; }

--- a/Userland/Libraries/LibGUI/Notification.cpp
+++ b/Userland/Libraries/LibGUI/Notification.cpp
@@ -15,7 +15,7 @@ namespace GUI {
 class ConnectionToNotificationServer final
     : public IPC::ConnectionToServer<NotificationClientEndpoint, NotificationServerEndpoint>
     , public NotificationClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToNotificationServer, "/tmp/portal/notify"sv)
+    IPC_CLIENT_CONNECTION(ConnectionToNotificationServer, "/tmp/user/%uid/portal/notify"sv)
 
     friend class Notification;
 

--- a/Userland/Libraries/LibGUI/Notification.cpp
+++ b/Userland/Libraries/LibGUI/Notification.cpp
@@ -15,7 +15,7 @@ namespace GUI {
 class ConnectionToNotificationServer final
     : public IPC::ConnectionToServer<NotificationClientEndpoint, NotificationServerEndpoint>
     , public NotificationClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToNotificationServer, "/tmp/portal/notify")
+    IPC_CLIENT_CONNECTION(ConnectionToNotificationServer, "/tmp/portal/notify"sv)
 
     friend class Notification;
 

--- a/Userland/Libraries/LibIPC/ConnectionToServer.h
+++ b/Userland/Libraries/LibIPC/ConnectionToServer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibCore/Account.h>
 #include <LibCore/Stream.h>
 #include <LibIPC/Connection.h>
 
@@ -17,7 +18,8 @@ public:                                                                         
     template<typename Klass = klass, class... Args>                                                    \
     static ErrorOr<NonnullRefPtr<klass>> try_create(Args&&... args)                                    \
     {                                                                                                  \
-        auto socket = TRY(Core::Stream::LocalSocket::connect(socket_path));                            \
+        auto parsed_socket_path { Core::Account::parse_path_with_uid(socket_path) };                   \
+        auto socket = TRY(Core::Stream::LocalSocket::connect(move(parsed_socket_path)));               \
         /* We want to rate-limit our clients */                                                        \
         TRY(socket->set_blocking(true));                                                               \
                                                                                                        \

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -27,7 +27,7 @@ struct DecodedImage {
 class Client final
     : public IPC::ConnectionToServer<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>
     , public ImageDecoderClientEndpoint {
-    IPC_CLIENT_CONNECTION(Client, "/tmp/portal/image"sv);
+    IPC_CLIENT_CONNECTION(Client, "/tmp/user/%uid/portal/image"sv);
 
 public:
     Optional<DecodedImage> decode_image(ReadonlyBytes);

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -27,7 +27,7 @@ struct DecodedImage {
 class Client final
     : public IPC::ConnectionToServer<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>
     , public ImageDecoderClientEndpoint {
-    IPC_CLIENT_CONNECTION(Client, "/tmp/portal/image");
+    IPC_CLIENT_CONNECTION(Client, "/tmp/portal/image"sv);
 
 public:
     Optional<DecodedImage> decode_image(ReadonlyBytes);

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -20,7 +20,7 @@ class Request;
 class RequestClient final
     : public IPC::ConnectionToServer<RequestClientEndpoint, RequestServerEndpoint>
     , public RequestClientEndpoint {
-    IPC_CLIENT_CONNECTION(RequestClient, "/tmp/portal/request")
+    IPC_CLIENT_CONNECTION(RequestClient, "/tmp/portal/request"sv)
 
 public:
     template<typename RequestHashMapTraits = Traits<String>>

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -20,7 +20,7 @@ class Request;
 class RequestClient final
     : public IPC::ConnectionToServer<RequestClientEndpoint, RequestServerEndpoint>
     , public RequestClientEndpoint {
-    IPC_CLIENT_CONNECTION(RequestClient, "/tmp/portal/request"sv)
+    IPC_CLIENT_CONNECTION(RequestClient, "/tmp/user/%uid/portal/request"sv)
 
 public:
     template<typename RequestHashMapTraits = Traits<String>>

--- a/Userland/Libraries/LibProtocol/WebSocketClient.h
+++ b/Userland/Libraries/LibProtocol/WebSocketClient.h
@@ -18,7 +18,7 @@ class WebSocket;
 class WebSocketClient final
     : public IPC::ConnectionToServer<WebSocketClientEndpoint, WebSocketServerEndpoint>
     , public WebSocketClientEndpoint {
-    IPC_CLIENT_CONNECTION(WebSocketClient, "/tmp/portal/websocket")
+    IPC_CLIENT_CONNECTION(WebSocketClient, "/tmp/portal/websocket"sv)
 
 public:
     RefPtr<WebSocket> connect(const URL&, String const& origin = {}, Vector<String> const& protocols = {}, Vector<String> const& extensions = {}, HashMap<String, String> const& request_headers = {});

--- a/Userland/Libraries/LibProtocol/WebSocketClient.h
+++ b/Userland/Libraries/LibProtocol/WebSocketClient.h
@@ -18,7 +18,7 @@ class WebSocket;
 class WebSocketClient final
     : public IPC::ConnectionToServer<WebSocketClientEndpoint, WebSocketServerEndpoint>
     , public WebSocketClientEndpoint {
-    IPC_CLIENT_CONNECTION(WebSocketClient, "/tmp/portal/websocket"sv)
+    IPC_CLIENT_CONNECTION(WebSocketClient, "/tmp/user/%uid/portal/websocket"sv)
 
 public:
     RefPtr<WebSocket> connect(const URL&, String const& origin = {}, Vector<String> const& protocols = {}, Vector<String> const& extensions = {}, HashMap<String, String> const& request_headers = {});

--- a/Userland/Libraries/LibSQL/SQLClient.h
+++ b/Userland/Libraries/LibSQL/SQLClient.h
@@ -16,7 +16,7 @@ namespace SQL {
 class SQLClient
     : public IPC::ConnectionToServer<SQLClientEndpoint, SQLServerEndpoint>
     , public SQLClientEndpoint {
-    IPC_CLIENT_CONNECTION(SQLClient, "/tmp/portal/sql")
+    IPC_CLIENT_CONNECTION(SQLClient, "/tmp/portal/sql"sv)
     virtual ~SQLClient() = default;
 
     Function<void(int, String const&)> on_connected;

--- a/Userland/Libraries/LibSQL/SQLClient.h
+++ b/Userland/Libraries/LibSQL/SQLClient.h
@@ -16,7 +16,7 @@ namespace SQL {
 class SQLClient
     : public IPC::ConnectionToServer<SQLClientEndpoint, SQLServerEndpoint>
     , public SQLClientEndpoint {
-    IPC_CLIENT_CONNECTION(SQLClient, "/tmp/portal/sql"sv)
+    IPC_CLIENT_CONNECTION(SQLClient, "/tmp/user/%uid/portal/sql"sv)
     virtual ~SQLClient() = default;
 
     Function<void(int, String const&)> on_connected;

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -19,7 +19,7 @@ class OutOfProcessWebView;
 class WebContentClient final
     : public IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>
     , public WebContentClientEndpoint {
-    IPC_CLIENT_CONNECTION(WebContentClient, "/tmp/portal/webcontent"sv);
+    IPC_CLIENT_CONNECTION(WebContentClient, "/tmp/user/%uid/portal/webcontent"sv);
 
 public:
     Function<void()> on_web_content_process_crash;

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -19,7 +19,7 @@ class OutOfProcessWebView;
 class WebContentClient final
     : public IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>
     , public WebContentClientEndpoint {
-    IPC_CLIENT_CONNECTION(WebContentClient, "/tmp/portal/webcontent");
+    IPC_CLIENT_CONNECTION(WebContentClient, "/tmp/portal/webcontent"sv);
 
 public:
     Function<void()> on_web_content_process_crash;

--- a/Userland/Services/InspectorServer/main.cpp
+++ b/Userland/Services/InspectorServer/main.cpp
@@ -19,10 +19,10 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     TRY(Core::System::pledge("stdio unix accept"));
 
-    auto server = TRY(IPC::MultiServer<InspectorServer::ConnectionFromClient>::try_create("/tmp/portal/inspector"));
+    auto server = TRY(IPC::MultiServer<InspectorServer::ConnectionFromClient>::try_create("/tmp/user/%uid/portal/inspector"));
 
     auto inspectables_server = TRY(Core::LocalServer::try_create());
-    TRY(inspectables_server->take_over_from_system_server("/tmp/portal/inspectables"));
+    TRY(inspectables_server->take_over_from_system_server("/tmp/user/%uid/portal/inspectables"));
 
     inspectables_server->on_accept = [&](auto client_socket) {
         auto pid = client_socket->peer_pid().release_value_but_fixme_should_propagate_errors();

--- a/Userland/Services/LoginServer/main.cpp
+++ b/Userland/Services/LoginServer/main.cpp
@@ -56,7 +56,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd cpath rpath exec proc id"));
+    TRY(Core::System::pledge("stdio recvfd sendfd cpath chown rpath exec proc id"));
     TRY(Core::System::unveil("/home", "r"));
     TRY(Core::System::unveil("/tmp", "c"));
     TRY(Core::System::unveil("/etc/passwd", "r"));

--- a/Userland/Services/SpiceAgent/ConnectionToClipboardServer.h
+++ b/Userland/Services/SpiceAgent/ConnectionToClipboardServer.h
@@ -15,7 +15,7 @@
 class ConnectionToClipboardServer final
     : public IPC::ConnectionToServer<ClipboardClientEndpoint, ClipboardServerEndpoint>
     , public ClipboardClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToClipboardServer, "/tmp/portal/clipboard")
+    IPC_CLIENT_CONNECTION(ConnectionToClipboardServer, "/tmp/portal/clipboard"sv)
 
 public:
     Function<void()> on_data_changed;

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -35,6 +35,10 @@ ErrorOr<void> Service::setup_socket(SocketDescriptor& socket)
 {
     VERIFY(socket.fd == -1);
 
+    // Note: The purpose of this syscall is to remove potential left-over of previous portal.
+    // The return value is discarded as sockets are not always there, and unlinking a non-existent path is considered as a failure.
+    (void)Core::System::unlink(socket.path);
+
     TRY(Core::Directory::create(LexicalPath(socket.path).parent(), Core::Directory::CreateDirectories::Yes));
 
     // Note: we use SOCK_CLOEXEC here to make sure we don't leak every socket to

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -211,7 +211,7 @@ void Service::spawn(int socket_fd)
             setenv("SOCKET_TAKEOVER", builder.to_string().characters(), true);
         }
 
-        if (m_account.has_value()) {
+        if (m_account.has_value() && m_account.value().uid() != getuid()) {
             auto& account = m_account.value();
             if (setgid(account.gid()) < 0 || setgroups(account.extra_gids().size(), account.extra_gids().data()) < 0 || setuid(account.uid()) < 0) {
                 dbgln("Failed to drop privileges (GID={}, UID={})\n", account.gid(), account.uid());

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -322,7 +322,7 @@ Service::Service(Core::ConfigFile const& config, StringView name)
 
         // Need i here to iterate along with all other vectors.
         for (unsigned i = 0; i < socket_paths.size(); i++) {
-            String& path = socket_paths.at(i);
+            auto const path = Core::Account::parse_path_with_uid(socket_paths.at(i), m_account.has_value() ? m_account.value().uid() : Optional<uid_t> {});
 
             // Socket path (plus NUL) must fit into the structs sent to the Kernel.
             VERIFY(path.length() < UNIX_PATH_MAX);

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -299,7 +299,7 @@ Service::Service(Core::ConfigFile const& config, StringView name)
 
     m_user = config.read_entry(name, "User");
     if (!m_user.is_null()) {
-        auto result = Core::Account::from_name(m_user.characters());
+        auto result = Core::Account::from_name(m_user.characters(), Core::Account::Read::PasswdOnly);
         if (result.is_error())
             warnln("Failed to resolve user {}: {}", m_user, result.error());
         else
@@ -417,7 +417,7 @@ ErrorOr<void> Service::determine_account(int fd)
     auto const directory_name = String::formatted("/proc/{}/", creds.pid);
     auto const stat = TRY(Core::System::stat(directory_name));
 
-    m_account = TRY(Core::Account::from_uid(stat.st_uid));
+    m_account = TRY(Core::Account::from_uid(stat.st_uid, Core::Account::Read::PasswdOnly));
     return {};
 }
 

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -23,7 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd accept unix rpath"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
-    TRY(Core::System::unveil("/tmp/portal/request", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/request", "rw"));
     TRY(Core::System::unveil("/tmp/portal/image", "rw"));
     TRY(Core::System::unveil("/tmp/portal/websocket", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/request", "rw"));
     TRY(Core::System::unveil("/tmp/portal/image", "rw"));
-    TRY(Core::System::unveil("/tmp/portal/websocket", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/websocket", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     Web::ImageDecoding::Decoder::initialize(WebView::ImageDecoderClientAdapter::create());

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/request", "rw"));
-    TRY(Core::System::unveil("/tmp/portal/image", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/image", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/websocket", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -35,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.parse(arguments);
 
     TRY(Core::System::unveil(Core::File::absolute_path(path), "r"sv));
-    TRY(Core::System::unveil("/tmp/portal/audio", "rw"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/audio", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     Core::EventLoop loop;


### PR DESCRIPTION
As introduced by #14608, this PR brings per-user portal for (almost) every service.

Two things are needed to bring this :
 - Support for user detection to create and read the socket at the corresponding place.
 - Configuration changes to tell each service that it has been moved.

1. User detection

To ensure a seamless, multi-user agnostic code. I introduced a variable, `%uid`, to indicate that the path is user-dependent.
As an example, `/tmp/user/%uid/portal/notify` will be replaced by `/tmp/user/100/portal/notify` when being logged as `anon`.

The `/tmp/user` directory is created by root when the first user logs in, and can only be accessed by the superuser. Personal (per-uid) directories are also created by root, but their ownership is forwarded to the user.

There are 3 places where portal paths are used:
 - In `IPC_CLIENT_CONNECTION`, where we connect to the socket
 - In `SystemServer` where we create the socket
 - In each process that unveil it

I wanted to introduce those changes without adding too much overhead. So replacement in those three places are automatically done on the callee side.

2. Configuration changes

The second step is done by all "SystemServer: Launch X at session start-up" commits.