### PR TITLE
Userland: Make uniq(1) POSIX compliant

### DIFF
--- a/Base/usr/share/man/man1/uniq.md
+++ b/Base/usr/share/man/man1/uniq.md
@@ -1,28 +1,49 @@
 ## Name
 
-uniq - filter out repeated lines
+uniq - filter out repeated adjacent lines
 
 ## Synopsis
 
 ```**sh
-$ uniq [--version] [INPUT] [OUTPUT]
+$ uniq [-c] [-d|-u] [-f skip-fields] [-s skip-chars] [--version] [INPUT] [OUTPUT]
 ```
 
 ## Description
 
-Filter out repeated lines from INPUT (or standard input) and write to OUTPUT (or standard output).
+Filter out repeated adjacent lines from INPUT (or standard input) and write to OUTPUT (or standard output). It is recommended to sort out the input using [`sort(1)`](help://man/1/sort) beforehand.
 
 ## Options
 
-* `--help`: Display help message and exit
-* `--version`: Print version
+* `-c`, `--count`: Precede each line with its number of occurrences.
+* `-d`, `--repeated`: Only print repeated lines.
+* `-u`, `--unique`: Only print unique lines (default).
+* `-f N`, `--skip-fields N`: Skip first N fields of each line before comparing.
+* `-c N`, `--skip-chars N`: Skip first N chars of each line before comparing.
+* `--help`: Display help message and exit.
+* `--version`: Print version.
 
 ## Examples
 
+Filter out repeated lines from README.md and write to standard output:
 ```sh
-# Filter out repeated lines from README.md and write to standard output
 $ uniq README.md
+```
 
-# Filter out repeated lines from README.md and write to UNIQUE.md
+Filter out repeated lines from README.md and write to UNIQUE.md:
+```sh
 $ uniq README.md UNIQUE.md
 ```
+
+Filter out repeated lines from standard input with their occurrence count:
+```sh
+$ echo "Well\nWell\nWell\nHello Friends!" | uniq -c
+3 Well
+1 Hello Friends!
+```
+
+Filter out repeated lines, ignoring the first field ("XXXX" and "ZZZZ") and the four chars after it (" ABC" and " BCA", thus comparing only the "D"s — which are equal indeed):
+```sh
+$ echo "XXXX ABCD\nZZZZ BCAD" | uniq -f1 -s4
+ZZZZ BCAD
+```
+

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -153,6 +153,21 @@ bool File::exists(StringView filename)
     return !Core::System::stat(filename).is_error();
 }
 
+ErrorOr<NonnullOwnPtr<File>> File::open_file_or_standard_stream(StringView filename, OpenMode mode)
+{
+    if (!filename.is_empty() && filename != "-"sv)
+        return File::open(filename, mode);
+
+    switch (mode) {
+    case OpenMode::Read:
+        return File::adopt_fd(STDIN_FILENO, mode);
+    case OpenMode::Write:
+        return File::adopt_fd(STDOUT_FILENO, mode);
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
 int File::open_mode_to_options(OpenMode mode)
 {
     int flags = 0;

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -185,6 +185,8 @@ public:
     static ErrorOr<NonnullOwnPtr<File>> adopt_fd(int fd, OpenMode);
     static bool exists(StringView filename);
 
+    static ErrorOr<NonnullOwnPtr<File>> open_file_or_standard_stream(StringView filename, OpenMode mode);
+
     File(File&& other) { operator=(move(other)); }
 
     File& operator=(File&& other)

--- a/Userland/Utilities/uniq.cpp
+++ b/Userland/Utilities/uniq.cpp
@@ -4,76 +4,111 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CharacterTypes.h>
 #include <AK/RefPtr.h>
+#include <AK/StringView.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/Stream.h>
 #include <LibCore/System.h>
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
-struct linebuf {
-    char* buf = NULL;
-    size_t len = 0;
-};
-
-static FILE* get_stream(char const* filepath, char const* perms)
+static ErrorOr<void> write_line_content(StringView line, size_t count, bool duplicates_only, bool print_count, Core::Stream::File& outfile)
 {
-    FILE* ret;
+    if (duplicates_only && count <= 1)
+        return {};
 
-    if (filepath == nullptr) {
-        if (perms[0] == 'r')
-            return stdin;
-        return stdout;
+    if (print_count)
+        TRY(outfile.write(String::formatted("{} {}\n", count, line).bytes()));
+    else
+        TRY(outfile.write(String::formatted("{}\n", line).bytes()));
+    return {};
+}
+
+static StringView skip(StringView line, unsigned char_skip_count, unsigned field_skip_count)
+{
+    line = line.trim("\n"sv);
+    if (field_skip_count) {
+        bool in_field = false;
+        int field_index = 0;
+        unsigned current_field = 0;
+        for (size_t i = 0; i < line.length(); i++) {
+            char c = line[i];
+            if (is_ascii_space(c)) {
+                in_field = false;
+                field_index = i;
+                if (++current_field > field_skip_count)
+                    break;
+            } else if (!in_field) {
+                in_field = true;
+            }
+        }
+        line = line.substring_view(field_index);
     }
-
-    ret = fopen(filepath, perms);
-    if (ret == nullptr) {
-        perror("fopen");
-        exit(1);
-    }
-
-    return ret;
+    char_skip_count = min(char_skip_count, line.length());
+    return line.substring_view(char_skip_count);
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath wpath cpath"));
 
-    char const* inpath = nullptr;
-    char const* outpath = nullptr;
+    StringView inpath;
+    StringView outpath;
+    bool duplicates_only = false;
+    bool unique_only = false;
+    bool ignore_case = false;
+    bool print_count = false;
+    unsigned skip_chars = 0;
+    unsigned skip_fields = 0;
+
     Core::ArgsParser args_parser;
+    args_parser.add_option(duplicates_only, "Only print duplicated lines", "repeated", 'd');
+    args_parser.add_option(unique_only, "Only print unique lines (default)", "unique", 'u');
+    args_parser.add_option(ignore_case, "Ignore case when comparing lines", "ignore-case", 'i');
+    args_parser.add_option(print_count, "Prefix each line by its number of occurrences", "count", 'c');
+    args_parser.add_option(skip_chars, "Skip N chars", "skip-chars", 's', "N");
+    args_parser.add_option(skip_fields, "Skip N fields", "skip-fields", 'f', "N");
     args_parser.add_positional_argument(inpath, "Input file", "input", Core::ArgsParser::Required::No);
     args_parser.add_positional_argument(outpath, "Output file", "output", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    FILE* infile = get_stream(inpath, "r");
-    FILE* outfile = get_stream(outpath, "w");
-
-    struct linebuf buffers[2];
-    struct linebuf* previous = &(buffers[0]);
-    struct linebuf* current = &(buffers[1]);
-    bool first_run = true;
-    for (;;) {
-        errno = 0;
-        ssize_t rc = getline(&(current->buf), &(current->len), infile);
-        if (rc < 0 && errno != 0) {
-            perror("getline");
-            exit(1);
-        }
-        if (rc < 0)
-            break;
-        if (!first_run && strcmp(current->buf, previous->buf) == 0)
-            continue;
-
-        fputs(current->buf, outfile);
-        swap(current, previous);
-        first_run = false;
+    if (!unique_only && !duplicates_only) {
+        unique_only = true;
+    } else if (unique_only && duplicates_only) {
+        // Printing duplicated and unique lines shouldn't print anything
+        return 0;
     }
 
-    fclose(infile);
-    fclose(outfile);
+    auto infile = TRY(Core::Stream::BufferedFile::create(TRY(Core::Stream::File::open_file_or_standard_stream(inpath, Core::Stream::OpenMode::Read))));
+    auto outfile = TRY(Core::Stream::File::open_file_or_standard_stream(outpath, Core::Stream::OpenMode::Write));
+
+    size_t count = 0;
+    ByteBuffer previous_buf = TRY(ByteBuffer::create_uninitialized(1024));
+    ByteBuffer current_buf = TRY(ByteBuffer::create_uninitialized(1024));
+
+    StringView previous = TRY(infile->read_line(previous_buf));
+    StringView previous_to_compare = skip(previous, skip_chars, skip_fields);
+
+    while (TRY(infile->can_read_line())) {
+        // FIXME: The buffer does not automatically resize,
+        // and this will return EMSGSIZE if the read line
+        // is more than 1024 bytes.
+        StringView current = TRY(infile->read_line(current_buf));
+
+        StringView current_to_compare = skip(current, skip_chars, skip_fields);
+        bool lines_equal = ignore_case ? current_to_compare.equals_ignoring_case(previous_to_compare) : current_to_compare == previous_to_compare;
+        if (!lines_equal) {
+            TRY(write_line_content(previous, count, duplicates_only, print_count, *outfile));
+            count = 1;
+        } else {
+            count++;
+        }
+        swap(current_to_compare, previous_to_compare);
+        swap(current_buf, previous_buf);
+        swap(current, previous);
+    }
+
+    TRY(write_line_content(previous, count, duplicates_only, print_count, *outfile));
 
     return 0;
 }


### PR DESCRIPTION
My second contribution to SerenityOS!

I added -d, -c, -i, -f and -s flags.
The -i flags is a POSIX extension present on many systems.
They're probably not the wellest written, nor the fastest, but they work.
Improvement suggestions welcome.

I tested the command with a few inputs, but probably not all, so this needs more testing.

Working:
```
{ echo hello; echo world } | uniq
# output: hello
world
```
```
{ echo hello; echo world; echo world } | uniq
# output: hello
world
```
```
{ echo hello; echo hello; echo world; echo world } | uniq
# output: hello
world
```
```
{ echo hello; echo hello; echo world } | uniq -d
# output: hello
```
```
{ echo hello; echo HELLO; echo world } | uniq -di
# output: HELLO
```
(I'm not sure about this one, GNU coreutils' uniq echoes the first 'hello')
```
{ echo hello; echo HELLO; echo world } | uniq -dic
# output: 2 HELLO
```
```
{ echo hello; echo HELLO; echo world; echo WORLD; echo WoRlD } | uniq -dic
# output: 2 HELLO
3 WoRlD
```
```
{ echo fieldtoignore hello; echo otherfieldtoignore hello } | uniq -f1
# output: otherfieldtoignore hello
```
```
{ echo hello; echo ehllo } | uniq -s2
# output: ehllo
```
```
{ echo "hello hi"; echo "ehllo ii" } | uniq -f1 -s2
# output: ehllo ii
```