### PR TITLE
Profiler: Fix use after free in FlameGraphView

### DIFF
--- a/Userland/DevTools/Profiler/FlameGraphView.cpp
+++ b/Userland/DevTools/Profiler/FlameGraphView.cpp
@@ -165,6 +165,7 @@ String FlameGraphView::bar_label(StackBar const& bar) const
 void FlameGraphView::layout_bars()
 {
     m_bars.clear();
+    m_hovered_bar = nullptr;
 
     // Explicit copy here so the layout can mutate
     Vector<GUI::ModelIndex> selected = m_selected_indexes;


### PR DESCRIPTION
Layout cleared the list of bars in the flame graph, but didn't clear the
reference m_hovered_bar. This could cause a crash in mousedown_event()
when clicking twice: the first click caused layout, the second used
the old reference.