### PR TITLE
Kernel/USB: Reorganize UHCI schedule structure

### DIFF
--- a/Kernel/Bus/USB/UHCI/UHCIController.h
+++ b/Kernel/Bus/USB/UHCI/UHCIController.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include <AK/Platform.h>
-
+#include <AK/Array.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/Platform.h>
 #include <Kernel/Arch/x86/IO.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Bus/USB/UHCI/UHCIDescriptorPool.h>
@@ -31,6 +31,7 @@ class UHCIController final
 
     static constexpr u8 MAXIMUM_NUMBER_OF_TDS = 128; // Upper pool limit. This consumes the second page we have allocated
     static constexpr u8 MAXIMUM_NUMBER_OF_QHS = 64;
+    static constexpr u8 NUMBER_OF_INTERRUPT_QHS = 11;
 
 public:
     static constexpr u8 NUMBER_OF_ROOT_PORTS = 2;
@@ -102,7 +103,7 @@ private:
     Vector<TransferDescriptor*> m_iso_td_list;
 
     QueueHead* m_schedule_begin_anchor;
-    QueueHead* m_interrupt_qh_anchor;
+    Array<QueueHead*, NUMBER_OF_INTERRUPT_QHS> m_interrupt_qh_anchor_arr;
     QueueHead* m_ls_control_qh_anchor;
     QueueHead* m_fs_control_qh_anchor;
     // Always final queue in the schedule, may loop back to previous QH for bandwidth

--- a/Kernel/Bus/USB/UHCI/UHCIDescriptorTypes.h
+++ b/Kernel/Bus/USB/UHCI/UHCIDescriptorTypes.h
@@ -266,28 +266,24 @@ struct alignas(16) QueueHead {
 
     u32 link_ptr() const { return m_link_ptr; }
     u32 element_link_ptr() const { return m_element_link_ptr; }
+
     u32 paddr() const { return m_paddr; }
     bool in_use() const { return m_in_use; }
-
     void set_in_use(bool in_use) { m_in_use = in_use; }
-    void set_link_ptr(u32 val) { m_link_ptr = val; }
 
     // FIXME: For the love of God, use AK SMART POINTERS PLEASE!!
     QueueHead* next_qh() { return m_next_qh; }
     QueueHead const* next_qh() const { return m_next_qh; }
-    void set_next_qh(QueueHead* qh) { m_next_qh = qh; }
 
     QueueHead* prev_qh() { return m_prev_qh; }
     QueueHead const* prev_qh() const { return m_prev_qh; }
-    void set_previous_qh(QueueHead* qh)
-    {
-        m_prev_qh = qh;
-    }
 
     void link_next_queue_head(QueueHead* qh)
     {
         m_link_ptr = qh->paddr();
         m_link_ptr |= static_cast<u32>(LinkPointerBits::QHSelect);
+        m_next_qh = qh;
+        qh->m_prev_qh = this;
     }
 
     void attach_transfer_queue(QueueHead& qh)


### PR DESCRIPTION
Currently in the UHCI code, when a queued (interrupt/bulk/control) transfer is submitted, it will attach itself to the corresponding queue head which is linked into the schedule for execution by the hardware controller, overwriting any previous transfers that are occupying that memory spot. This means only one transfer of each type can be executed simultaneously, and also opens the door to other problems like memory leaks and transfers that never complete. The first commit fixes this by transforming the schedule as set up by the software into a linked list with sentinel values ("anchors") to insert new transfers in front of as needed, while maintaining the correct transfer type ordering. When a transfer & transfer descriptor chain is created, it is also allocated a queue head to link to it and link into the schedule list. The second commit further prepares the schedule for the implementation of interrupt transfers, which are up next after async transfers. It creates several separate interrupt queue head anchors, each designated a different power-of-two latency between 2^0 and 2^10 milliseconds, to allow for interrupt transfers with different execution periods to be queued up.