### PR TITLE
LibCore: `X` and four-digit octal modes for `FilePermissionsMask` parsing

### DIFF
--- a/Tests/LibCore/TestLibCoreFilePermissionsMask.cpp
+++ b/Tests/LibCore/TestLibCoreFilePermissionsMask.cpp
@@ -72,6 +72,16 @@ TEST_CASE(file_permission_mask_from_symbolic_notation)
     EXPECT_EQ(mask.value().apply(0), 0555);
     EXPECT_EQ(mask.value().apply(0664), 0555);
 
+    mask = Core::FilePermissionsMask::from_symbolic_notation("a+X"sv);
+    EXPECT(!mask.is_error());
+    EXPECT_EQ(mask.value().clear_mask(), 0);
+    EXPECT_EQ(mask.value().write_mask(), 0);
+    EXPECT_EQ(mask.value().directory_or_executable_mask().clear_mask(), 0);
+    EXPECT_EQ(mask.value().directory_or_executable_mask().write_mask(), 0111);
+    EXPECT_EQ(mask.value().apply(0), 0);
+    EXPECT_EQ(mask.value().apply(0100), 0111);
+    EXPECT_EQ(mask.value().apply(S_IFDIR | 0), S_IFDIR | 0111);
+
     mask = Core::FilePermissionsMask::from_symbolic_notation("z+rw"sv);
     EXPECT(mask.is_error());
     EXPECT(mask.error().string_literal().starts_with("invalid class"sv));

--- a/Tests/LibCore/TestLibCoreFilePermissionsMask.cpp
+++ b/Tests/LibCore/TestLibCoreFilePermissionsMask.cpp
@@ -116,3 +116,24 @@ TEST_CASE(file_permission_mask_parse)
     mask = Core::FilePermissionsMask::parse("z+rw"sv);
     EXPECT(mask.is_error());
 }
+
+TEST_CASE(numeric_mask_special_bits)
+{
+    {
+        auto mask = Core::FilePermissionsMask::parse("750"sv);
+        EXPECT(!mask.is_error());
+        EXPECT_EQ(mask.value().apply(07000), 07750);
+    }
+
+    {
+        auto mask = Core::FilePermissionsMask::parse("7750"sv);
+        EXPECT(!mask.is_error());
+        EXPECT_EQ(mask.value().apply(0), 07750);
+    }
+
+    {
+        auto mask = Core::FilePermissionsMask::parse("0750"sv);
+        EXPECT(!mask.is_error());
+        EXPECT_EQ(mask.value().apply(07000), 0750);
+    }
+}

--- a/Userland/Libraries/LibCore/FilePermissionsMask.h
+++ b/Userland/Libraries/LibCore/FilePermissionsMask.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <sys/stat.h>
 
@@ -28,13 +29,30 @@ public:
     FilePermissionsMask& add_permissions(mode_t mode);
     FilePermissionsMask& remove_permissions(mode_t mode);
 
-    mode_t apply(mode_t mode) const { return m_write_mask | (mode & ~m_clear_mask); }
+    mode_t apply(mode_t mode) const
+    {
+        if (m_directory_or_executable_mask && (S_ISDIR(mode) || (mode & 0111) != 0))
+            mode = m_directory_or_executable_mask->apply(mode);
+
+        return m_write_mask | (mode & ~m_clear_mask);
+    }
     mode_t clear_mask() const { return m_clear_mask; }
     mode_t write_mask() const { return m_write_mask; }
+
+    FilePermissionsMask& directory_or_executable_mask()
+    {
+        if (!m_directory_or_executable_mask)
+            m_directory_or_executable_mask = make<FilePermissionsMask>();
+
+        return *m_directory_or_executable_mask;
+    }
 
 private:
     mode_t m_clear_mask; // the bits that will be cleared
     mode_t m_write_mask; // the bits that will be set
+
+    // A separate mask, only for files that already have some executable bit set or directories.
+    OwnPtr<FilePermissionsMask> m_directory_or_executable_mask;
 };
 
 }


### PR DESCRIPTION
Not much remains for a `coreutils`-less self-hosting build.