### PR TITLE
AK: Let StringView::find_all take a predicate

### DIFF
--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -401,6 +401,18 @@ Vector<size_t> find_all(StringView haystack, StringView needle)
     return positions;
 }
 
+Vector<size_t> find_all(StringView haystack, Function<bool(char)> const& predicate)
+{
+    Vector<size_t> positions;
+    size_t current_position = 0;
+    while (current_position < haystack.length()) {
+        if (predicate(haystack[current_position]))
+            positions.append(current_position);
+        ++current_position;
+    }
+    return positions;
+}
+
 Optional<size_t> find_any_of(StringView haystack, StringView needles, SearchDirection direction)
 {
     if (haystack.is_empty() || needles.is_empty())

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -9,6 +9,7 @@
 
 #include <AK/Concepts.h>
 #include <AK/Forward.h>
+#include <AK/Function.h>
 
 namespace AK {
 
@@ -75,6 +76,7 @@ Optional<size_t> find(StringView haystack, char needle, size_t start = 0);
 Optional<size_t> find(StringView haystack, StringView needle, size_t start = 0);
 Optional<size_t> find_last(StringView haystack, char needle);
 Vector<size_t> find_all(StringView haystack, StringView needle);
+Vector<size_t> find_all(StringView haystack, Function<bool(char)> const& predicate);
 enum class SearchDirection {
     Forward,
     Backward

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -239,6 +239,11 @@ Vector<size_t> StringView::find_all(StringView needle) const
     return StringUtils::find_all(*this, needle);
 }
 
+Vector<size_t> StringView::find_all(Function<bool(char)> const& predicate) const
+{
+    return StringUtils::find_all(*this, predicate);
+}
+
 Vector<StringView> StringView::split_view_if(Function<bool(char)> const& predicate, bool keep_empty) const
 {
     if (is_empty())

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -104,6 +104,7 @@ public:
     // FIXME: Implement find_last(StringView) for API symmetry.
 
     [[nodiscard]] Vector<size_t> find_all(StringView needle) const;
+    [[nodiscard]] Vector<size_t> find_all(Function<bool(char)> const& predicate) const;
 
     using SearchDirection = StringUtils::SearchDirection;
     [[nodiscard]] Optional<size_t> find_any_of(StringView needles, SearchDirection direction = SearchDirection::Forward) const { return StringUtils::find_any_of(*this, needles, direction); }


### PR DESCRIPTION
This allows things like:
```cpp
auto fields = "a b c"sv.find_all([](char c) {
     return c == 'a' || c == 'b';
});
// fields == [ 0, 2 ]
```