### PR TITLE
LibJS: Use SortIndexedProperties AO in [Typed]Array.prototype.sort

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Array.cpp
@@ -250,13 +250,13 @@ ThrowCompletionOr<MarkedVector<Value>> sort_indexed_properties(GlobalObject& glo
     }
 
     // 4. Sort items using an implementation-defined sequence of calls to SortCompare. If any such call returns an abrupt completion, stop before performing any further calls to SortCompare or steps in this algorithm and return that Completion Record.
-    // FIXME: Support AK::Function in array_merge_sort() to avoid having to create a NativeFunction.
-    auto* native_comparefn = NativeFunction::create(global_object, "", [&](auto& vm, auto&) -> ThrowCompletionOr<Value> {
-        auto x = vm.argument(0);
-        auto y = vm.argument(1);
-        return TRY(sort_compare(x, y));
-    });
-    TRY(array_merge_sort(global_object, native_comparefn, items));
+
+    // Perform sorting by merge sort. This isn't as efficient compared to quick sort, but
+    // quicksort can't be used in all cases because the spec requires Array.prototype.sort()
+    // to be stable. FIXME: when initially scanning through the array, maintain a flag
+    // for if an unstable sort would be indistinguishable from a stable sort (such as just
+    // just strings or numbers), and in that case use quick sort instead for better performance.
+    TRY(array_merge_sort(global_object, sort_compare, items));
 
     // 5. Return items.
     return items;

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.h
@@ -62,6 +62,6 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(with);
 };
 
-ThrowCompletionOr<void> array_merge_sort(GlobalObject&, FunctionObject* compare_func, MarkedVector<Value>& arr_to_sort);
+ThrowCompletionOr<void> array_merge_sort(GlobalObject&, Function<ThrowCompletionOr<double>(Value, Value)> const& compare_func, MarkedVector<Value>& arr_to_sort);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -412,6 +412,10 @@ ThrowCompletionOr<double> compare_typed_array_elements(GlobalObject& global_obje
             : (x.as_double() > y.as_double()))
         return 1;
 
+    // 8. If x is -0𝔽 and y is +0𝔽, return -1𝔽.
+    if (x.is_negative_zero() && y.is_positive_zero())
+        return -1;
+
     // 9. If x is +0𝔽 and y is -0𝔽, return 1𝔽.
     if (x.is_positive_zero() && y.is_negative_zero())
         return 1;


### PR DESCRIPTION
This started with looking to see if we needed to do anything with https://github.com/tc39/ecma262/commit/70baf25 (we don't), and noticed we can be closer to the spec with these methods. 