### PR TITLE
LibGUI: Move tooltip position up 4 pixels to prevent cursor pop-under

### DIFF
--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -224,7 +224,7 @@ void Application::request_tooltip_show()
     int const margin = 30;
     Gfx::IntPoint adjusted_pos = ConnectionToWindowServer::the().get_global_cursor_position();
 
-    adjusted_pos.translate_by(0, 18);
+    adjusted_pos.translate_by(0, 14);
 
     if (adjusted_pos.x() + m_tooltip_window->width() >= desktop_rect.width() - margin) {
         adjusted_pos = adjusted_pos.translated(-m_tooltip_window->width(), 0);


### PR DESCRIPTION
As seen in the [#ui channel](https://discord.com/channels/830522505605283862/830529037251641374/1000765765043114074) on the Discord