### PR TITLE
AK: VERIFY() the index is in bounds in StringView::operator[]

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -62,7 +62,12 @@ public:
 
     [[nodiscard]] ReadonlyBytes bytes() const { return { m_characters, m_length }; }
 
-    constexpr char const& operator[](size_t index) const { return m_characters[index]; }
+    constexpr char const& operator[](size_t index) const
+    {
+        if (!is_constant_evaluated())
+            VERIFY(index < m_length);
+        return m_characters[index];
+    }
 
     using ConstIterator = SimpleIterator<const StringView, char const>;
 


### PR DESCRIPTION
That this did not already happen took me by surprise, as for
most other similar containers/types in AK (e.g. Span) the index
will be checked. This check not happening could easily let
off-by-one indexing errors slip through the cracks.