### PR TITLE
LibJS: Allow out-of-order date & number ranges to be formatted

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -53,7 +53,6 @@
     M(IntlNumberIsNaN, "{} must not be NaN")                                                                                            \
     M(IntlNumberIsNaNOrInfinity, "Number must not be NaN or Infinity")                                                                  \
     M(IntlNumberIsNaNOrOutOfRange, "Value {} is NaN or is not between {} and {}")                                                       \
-    M(IntlNumberRangeIsInvalid, "Numeric range is invalid: {}")                                                                         \
     M(IntlOptionUndefined, "Option {} must be defined when option {} is {}")                                                            \
     M(IntlNonNumericOr2DigitAfterNumericOr2Digit, "Styles other than 'numeric' and '2-digit' may not be used in smaller units after "   \
                                                   "being used in larger units")                                                         \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -48,7 +48,6 @@
     M(IntlInvalidRoundingIncrementForRoundingType, "{} is not a valid rounding increment for rounding type {}")                         \
     M(IntlInvalidTime, "Time value must be between -8.64E15 and 8.64E15")                                                               \
     M(IntlInvalidUnit, "Unit {} is not a valid time unit")                                                                              \
-    M(IntlStartRangeAfterEndRange, "Range start {} is greater than range end {}")                                                       \
     M(IntlMinimumExceedsMaximum, "Minimum value {} is larger than maximum value {}")                                                    \
     M(IntlNumberIsNaN, "{} must not be NaN")                                                                                            \
     M(IntlNumberIsNaNOrInfinity, "Number must not be NaN or Infinity")                                                                  \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -49,7 +49,6 @@
     M(IntlInvalidTime, "Time value must be between -8.64E15 and 8.64E15")                                                               \
     M(IntlInvalidUnit, "Unit {} is not a valid time unit")                                                                              \
     M(IntlStartRangeAfterEndRange, "Range start {} is greater than range end {}")                                                       \
-    M(IntlStartTimeAfterEndTime, "Start time {} is after end time {}")                                                                  \
     M(IntlMinimumExceedsMaximum, "Minimum value {} is larger than maximum value {}")                                                    \
     M(IntlNumberIsNaN, "{} must not be NaN")                                                                                            \
     M(IntlNumberIsNaNOrInfinity, "Number must not be NaN or Infinity")                                                                  \

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -934,29 +934,25 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_date_time_range_
     if (isnan(end))
         return vm.throw_completion<RangeError>(global_object, ErrorType::IntlInvalidTime);
 
-    // 5. If x is greater than y, throw a RangeError exception.
-    if (start > end)
-        return vm.throw_completion<RangeError>(global_object, ErrorType::IntlStartTimeAfterEndTime, start, end);
-
-    // 6. Let tm1 be ToLocalTime(x, dateTimeFormat.[[Calendar]], dateTimeFormat.[[TimeZone]]).
+    // 5. Let tm1 be ToLocalTime(x, dateTimeFormat.[[Calendar]], dateTimeFormat.[[TimeZone]]).
     auto start_local_time = TRY(to_local_time(global_object, start, date_time_format.calendar(), date_time_format.time_zone()));
 
-    // 7. Let tm2 be ToLocalTime(y, dateTimeFormat.[[Calendar]], dateTimeFormat.[[TimeZone]]).
+    // 6. Let tm2 be ToLocalTime(y, dateTimeFormat.[[Calendar]], dateTimeFormat.[[TimeZone]]).
     auto end_local_time = TRY(to_local_time(global_object, end, date_time_format.calendar(), date_time_format.time_zone()));
 
-    // 8. Let rangePatterns be dateTimeFormat.[[RangePatterns]].
+    // 7. Let rangePatterns be dateTimeFormat.[[RangePatterns]].
     auto range_patterns = date_time_format.range_patterns();
 
-    // 9. Let rangePattern be undefined.
+    // 8. Let rangePattern be undefined.
     Optional<Unicode::CalendarRangePattern> range_pattern;
 
-    // 10. Let dateFieldsPracticallyEqual be true.
+    // 9. Let dateFieldsPracticallyEqual be true.
     bool date_fields_practically_equal = true;
 
-    // 11. Let patternContainsLargerDateField be false.
+    // 10. Let patternContainsLargerDateField be false.
     bool pattern_contains_larger_date_field = false;
 
-    // 12. While dateFieldsPracticallyEqual is true and patternContainsLargerDateField is false, repeat for each row of Table 4 in order, except the header row:
+    // 11. While dateFieldsPracticallyEqual is true and patternContainsLargerDateField is false, repeat for each row of Table 4 in order, except the header row:
     for_each_range_pattern_field(start_local_time, end_local_time, [&](auto start_value, auto end_value, auto field_name) {
         // a. Let fieldName be the name given in the Range Pattern Field column of the row.
 
@@ -1061,7 +1057,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_date_time_range_
         return IterationDecision::Break;
     });
 
-    // 13. If dateFieldsPracticallyEqual is true, then
+    // 12. If dateFieldsPracticallyEqual is true, then
     if (date_fields_practically_equal) {
         // a. Let pattern be dateTimeFormat.[[Pattern]].
         auto const& pattern = date_time_format.pattern();
@@ -1083,10 +1079,10 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_date_time_range_
         return result;
     }
 
-    // 14. Let result be a new empty List.
+    // 13. Let result be a new empty List.
     Vector<PatternPartitionWithSource> result;
 
-    // 15. If rangePattern is undefined, then
+    // 14. If rangePattern is undefined, then
     if (!range_pattern.has_value()) {
         // a. Let rangePattern be rangePatterns.[[Default]].
         range_pattern = Unicode::get_calendar_default_range_format(date_time_format.data_locale(), date_time_format.calendar());
@@ -1112,7 +1108,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_date_time_range_
         //        step 3 here: https://unicode.org/reports/tr35/tr35-dates.html#intervalFormats
     }
 
-    // 16. For each Record { [[Pattern]], [[Source]] } rangePatternPart in rangePattern.[[PatternParts]], do
+    // 15. For each Record { [[Pattern]], [[Source]] } rangePatternPart in rangePattern.[[PatternParts]], do
     TRY(for_each_range_pattern_with_source(*range_pattern, [&](auto const& pattern, auto source) -> ThrowCompletionOr<void> {
         // a. Let pattern be rangePatternPart.[[Pattern]].
         // b. Let source be rangePatternPart.[[Source]].
@@ -1141,7 +1137,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_date_time_range_
         return {};
     }));
 
-    // 17. Return result.
+    // 16. Return result.
     return result;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
@@ -152,23 +152,19 @@ ThrowCompletionOr<Unicode::PluralCategory> resolve_plural_range(GlobalObject& gl
     if (end.is_nan())
         return vm.throw_completion<RangeError>(global_object, ErrorType::IntlNumberIsNaN, "end"sv);
 
-    // 6. If x > y, throw a RangeError exception.
-    if (start.as_double() > end.as_double())
-        return vm.throw_completion<RangeError>(global_object, ErrorType::IntlStartRangeAfterEndRange, start, end);
-
-    // 7. Let xp be ! ResolvePlural(pluralRules, x).
+    // 6. Let xp be ! ResolvePlural(pluralRules, x).
     auto start_plurality = resolve_plural(plural_rules, start);
 
-    // 8. Let yp be ! ResolvePlural(pluralRules, y).
+    // 7. Let yp be ! ResolvePlural(pluralRules, y).
     auto end_plurality = resolve_plural(plural_rules, end);
 
-    // 9. Let locale be pluralRules.[[Locale]].
+    // 8. Let locale be pluralRules.[[Locale]].
     auto const& locale = plural_rules.locale();
 
-    // 10. Let type be pluralRules.[[Type]].
+    // 9. Let type be pluralRules.[[Type]].
     auto type = plural_rules.type();
 
-    // 11. Return ! PluralRuleSelectRange(locale, type, xp, yp).
+    // 10. Return ! PluralRuleSelectRange(locale, type, xp, yp).
     return plural_rule_select_range(locale, type, start_plurality, end_plurality);
 }
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRange.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRange.js
@@ -36,12 +36,6 @@ describe("errors", () => {
             }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
         });
     });
-
-    test("called with values in bad order", () => {
-        expect(() => {
-            Intl.DateTimeFormat().formatRange(new Date(2021), new Date(1989));
-        }).toThrowWithMessage(RangeError, "Start time 2021 is after end time 1989");
-    });
 });
 
 const d0 = Date.UTC(1989, 0, 23, 7, 8, 9, 45);
@@ -156,6 +150,14 @@ describe("dateStyle", () => {
             const ja = new Intl.DateTimeFormat("ja", { dateStyle: d.date, timeZone: "UTC" });
             expect(ja.formatRange(d0, d1)).toBe(d.ja);
         });
+    });
+
+    test("dates in reverse order", () => {
+        const en = new Intl.DateTimeFormat("en", { dateStyle: "full", timeZone: "UTC" });
+        expect(en.formatRange(d1, d0)).toBe("Tuesday, December 7, 2021 – Monday, January 23, 1989");
+
+        const ja = new Intl.DateTimeFormat("ja", { dateStyle: "full", timeZone: "UTC" });
+        expect(ja.formatRange(d1, d0)).toBe("2021年12月7日火曜日～1989年1月23日月曜日");
     });
 });
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRangeToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRangeToParts.js
@@ -36,12 +36,6 @@ describe("errors", () => {
             }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
         });
     });
-
-    test("called with values in bad order", () => {
-        expect(() => {
-            Intl.DateTimeFormat().formatRangeToParts(new Date(2021), new Date(1989));
-        }).toThrowWithMessage(RangeError, "Start time 2021 is after end time 1989");
-    });
 });
 
 const d0 = Date.UTC(1989, 0, 23, 7, 8, 9, 45);
@@ -341,6 +335,46 @@ describe("dateStyle", () => {
             { type: "month", value: "12", source: "endRange" },
             { type: "literal", value: "/", source: "endRange" },
             { type: "day", value: "07", source: "endRange" },
+        ]);
+    });
+
+    test("dates in reverse order", () => {
+        const en = new Intl.DateTimeFormat("en", { dateStyle: "full", timeZone: "UTC" });
+        expect(en.formatRangeToParts(d1, d0)).toEqual([
+            { type: "weekday", value: "Tuesday", source: "startRange" },
+            { type: "literal", value: ", ", source: "startRange" },
+            { type: "month", value: "December", source: "startRange" },
+            { type: "literal", value: " ", source: "startRange" },
+            { type: "day", value: "7", source: "startRange" },
+            { type: "literal", value: ", ", source: "startRange" },
+            { type: "year", value: "2021", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "weekday", value: "Monday", source: "endRange" },
+            { type: "literal", value: ", ", source: "endRange" },
+            { type: "month", value: "January", source: "endRange" },
+            { type: "literal", value: " ", source: "endRange" },
+            { type: "day", value: "23", source: "endRange" },
+            { type: "literal", value: ", ", source: "endRange" },
+            { type: "year", value: "1989", source: "endRange" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", { dateStyle: "full", timeZone: "UTC" });
+        expect(ja.formatRangeToParts(d1, d0)).toEqual([
+            { type: "year", value: "2021", source: "startRange" },
+            { type: "literal", value: "年", source: "startRange" },
+            { type: "month", value: "12", source: "startRange" },
+            { type: "literal", value: "月", source: "startRange" },
+            { type: "day", value: "7", source: "startRange" },
+            { type: "literal", value: "日", source: "startRange" },
+            { type: "weekday", value: "火曜日", source: "startRange" },
+            { type: "literal", value: "～", source: "shared" },
+            { type: "year", value: "1989", source: "endRange" },
+            { type: "literal", value: "年", source: "endRange" },
+            { type: "month", value: "1", source: "endRange" },
+            { type: "literal", value: "月", source: "endRange" },
+            { type: "day", value: "23", source: "endRange" },
+            { type: "literal", value: "日", source: "endRange" },
+            { type: "weekday", value: "月曜日", source: "endRange" },
         ]);
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatRange.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatRange.js
@@ -33,41 +33,6 @@ describe("errors", () => {
         expect(() => {
             new Intl.NumberFormat().formatRange(1, NaN);
         }).toThrowWithMessage(RangeError, "end must not be NaN");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRange(1, 0);
-        }).toThrowWithMessage(
-            RangeError,
-            "start is a mathematical value, end is a mathematical value and end < start"
-        );
-
-        expect(() => {
-            new Intl.NumberFormat().formatRange(1, -Infinity);
-        }).toThrowWithMessage(RangeError, "start is a mathematical value, end is -∞");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRange(1, -0);
-        }).toThrowWithMessage(RangeError, "start is a mathematical value, end is -0 and start ≥ 0");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRange(Infinity, 0);
-        }).toThrowWithMessage(RangeError, "start is +∞, end is a mathematical value");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRange(Infinity, -Infinity);
-        }).toThrowWithMessage(RangeError, "start is +∞, end is -∞");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRange(Infinity, -0);
-        }).toThrowWithMessage(RangeError, "start is +∞, end is -0");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRange(-0, -1);
-        }).toThrowWithMessage(RangeError, "start is -0, end is a mathematical value and end < 0");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRange(-0, -Infinity);
-        }).toThrowWithMessage(RangeError, "start is -0, end is -∞");
     });
 });
 
@@ -136,5 +101,27 @@ describe("correct behavior", () => {
             maximumFractionDigits: 0,
         });
         expect(ja2.formatRange(3, 5)).toBe("￥3 ～ ￥5");
+    });
+
+    test("numbers in reverse order", () => {
+        const en = new Intl.NumberFormat("en");
+        expect(en.formatRange(1, 0)).toBe("1–0");
+        expect(en.formatRange(1, -Infinity)).toBe("1 – -∞");
+        expect(en.formatRange(1, -0)).toBe("1 – -0");
+        expect(en.formatRange(Infinity, 0)).toBe("∞ – 0");
+        expect(en.formatRange(Infinity, -Infinity)).toBe("∞ – -∞");
+        expect(en.formatRange(Infinity, -0)).toBe("∞ – -0");
+        expect(en.formatRange(-0, -1)).toBe("-0 – -1");
+        expect(en.formatRange(-0, -Infinity)).toBe("-0 – -∞");
+
+        const ja = new Intl.NumberFormat("ja");
+        expect(ja.formatRange(1, 0)).toBe("1～0");
+        expect(ja.formatRange(1, -Infinity)).toBe("1 ～ -∞");
+        expect(ja.formatRange(1, -0)).toBe("1 ～ -0");
+        expect(ja.formatRange(Infinity, 0)).toBe("∞ ～ 0");
+        expect(ja.formatRange(Infinity, -Infinity)).toBe("∞ ～ -∞");
+        expect(ja.formatRange(Infinity, -0)).toBe("∞ ～ -0");
+        expect(ja.formatRange(-0, -1)).toBe("-0 ～ -1");
+        expect(ja.formatRange(-0, -Infinity)).toBe("-0 ～ -∞");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatRangeToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatRangeToParts.js
@@ -33,41 +33,6 @@ describe("errors", () => {
         expect(() => {
             new Intl.NumberFormat().formatRangeToParts(1, NaN);
         }).toThrowWithMessage(RangeError, "end must not be NaN");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRangeToParts(1, 0);
-        }).toThrowWithMessage(
-            RangeError,
-            "start is a mathematical value, end is a mathematical value and end < start"
-        );
-
-        expect(() => {
-            new Intl.NumberFormat().formatRangeToParts(1, -Infinity);
-        }).toThrowWithMessage(RangeError, "start is a mathematical value, end is -∞");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRangeToParts(1, -0);
-        }).toThrowWithMessage(RangeError, "start is a mathematical value, end is -0 and start ≥ 0");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRangeToParts(Infinity, 0);
-        }).toThrowWithMessage(RangeError, "start is +∞, end is a mathematical value");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRangeToParts(Infinity, -Infinity);
-        }).toThrowWithMessage(RangeError, "start is +∞, end is -∞");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRangeToParts(Infinity, -0);
-        }).toThrowWithMessage(RangeError, "start is +∞, end is -0");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRangeToParts(-0, -1);
-        }).toThrowWithMessage(RangeError, "start is -0, end is a mathematical value and end < 0");
-
-        expect(() => {
-            new Intl.NumberFormat().formatRangeToParts(-0, -Infinity);
-        }).toThrowWithMessage(RangeError, "start is -0, end is -∞");
     });
 });
 
@@ -163,6 +128,50 @@ describe("correct behavior", () => {
             { type: "literal", value: " ～ ", source: "shared" },
             { type: "currency", value: "￥", source: "endRange" },
             { type: "integer", value: "5", source: "endRange" },
+        ]);
+    });
+
+    test("numbers in reverse order", () => {
+        const en = new Intl.NumberFormat("en");
+        expect(en.formatRangeToParts(1, -Infinity)).toEqual([
+            { type: "integer", value: "1", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "minusSign", value: "-", source: "endRange" },
+            { type: "infinity", value: "∞", source: "endRange" },
+        ]);
+        expect(en.formatRangeToParts(Infinity, -Infinity)).toEqual([
+            { type: "infinity", value: "∞", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "minusSign", value: "-", source: "endRange" },
+            { type: "infinity", value: "∞", source: "endRange" },
+        ]);
+        expect(en.formatRangeToParts(-0, -Infinity)).toEqual([
+            { type: "minusSign", value: "-", source: "startRange" },
+            { type: "integer", value: "0", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "minusSign", value: "-", source: "endRange" },
+            { type: "infinity", value: "∞", source: "endRange" },
+        ]);
+
+        const ja = new Intl.NumberFormat("ja");
+        expect(ja.formatRangeToParts(1, -Infinity)).toEqual([
+            { type: "integer", value: "1", source: "startRange" },
+            { type: "literal", value: " ～ ", source: "shared" },
+            { type: "minusSign", value: "-", source: "endRange" },
+            { type: "infinity", value: "∞", source: "endRange" },
+        ]);
+        expect(ja.formatRangeToParts(Infinity, -Infinity)).toEqual([
+            { type: "infinity", value: "∞", source: "startRange" },
+            { type: "literal", value: " ～ ", source: "shared" },
+            { type: "minusSign", value: "-", source: "endRange" },
+            { type: "infinity", value: "∞", source: "endRange" },
+        ]);
+        expect(ja.formatRangeToParts(-0, -Infinity)).toEqual([
+            { type: "minusSign", value: "-", source: "startRange" },
+            { type: "integer", value: "0", source: "startRange" },
+            { type: "literal", value: " ～ ", source: "shared" },
+            { type: "minusSign", value: "-", source: "endRange" },
+            { type: "infinity", value: "∞", source: "endRange" },
         ]);
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/PluralRules/PluralRules.prototype.selectRange.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/PluralRules/PluralRules.prototype.selectRange.js
@@ -33,10 +33,6 @@ describe("errors", () => {
         expect(() => {
             new Intl.PluralRules().selectRange(1, NaN);
         }).toThrowWithMessage(RangeError, "end must not be NaN");
-
-        expect(() => {
-            new Intl.PluralRules().selectRange(1, 0);
-        }).toThrowWithMessage(RangeError, "Range start 1 is greater than range end 0");
     });
 });
 
@@ -69,5 +65,17 @@ describe("correct behavior", () => {
         const so = new Intl.PluralRules("so");
         expect(so.selectRange(0, 1)).toBe("one");
         expect(so.selectRange(1, 2)).toBe("other");
+    });
+
+    test("numbers in reverse order", () => {
+        const en = new Intl.PluralRules("en");
+        expect(en.selectRange(1, -Infinity)).toBe("other");
+        expect(en.selectRange(Infinity, -Infinity)).toBe("other");
+        expect(en.selectRange(-0, -Infinity)).toBe("other");
+
+        const ja = new Intl.PluralRules("ja");
+        expect(ja.selectRange(1, -Infinity)).toBe("other");
+        expect(ja.selectRange(Infinity, -Infinity)).toBe("other");
+        expect(ja.selectRange(-0, -Infinity)).toBe("other");
     });
 });


### PR DESCRIPTION
```
Diff Tests:
    test/intl402/DateTimeFormat/prototype/formatRange/date-x-greater-than-y-not-throws.js        ❌ -> ✅
    test/intl402/DateTimeFormat/prototype/formatRangeToParts/date-x-greater-than-y-not-throws.js ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRange/x-greater-than-y-not-throws.js               ❌ -> ✅
    test/intl402/NumberFormat/prototype/formatRangeToParts/x-greater-than-y-not-throws.js        ❌ -> ✅
    test/intl402/PluralRules/prototype/selectRange/x-greater-than-y-not-throws.js                ❌ -> ✅
```