### PR TITLE
CI: Use macOS 12 for Lagom builds

### DIFF
--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -15,7 +15,7 @@ jobs:
       ${{ if or(eq(parameters.os, 'Linux'), eq(parameters.os, 'Android')) }}:
         value: ubuntu-22.04
       ${{ if eq(parameters.os, 'macOS') }}:
-        value: macos-11
+        value: macos-12
 
     - name: toolchain
       ${{ if eq(parameters.fuzzer, 'Fuzz') }}:


### PR DESCRIPTION
An attempt to avoid the "Chunks are not arriving in order or sizes are
not matched up" error we've been seeing.