### PR TITLE
LibAudio: Read FLAC Metadata blocks larger than the buffer size & play files from the beginning

### DIFF
--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -201,7 +201,7 @@ ErrorOr<FlacRawMetadataBlock, LoaderError> FlacLoaderPlugin::next_meta_block(Big
 
 MaybeLoaderError FlacLoaderPlugin::reset()
 {
-    TRY(seek(m_data_start_location));
+    TRY(seek(0));
     m_current_frame.clear();
     return {};
 }


### PR DESCRIPTION
- **LibAudio: Read FLAC Metadata blocks larger than the buffer size**

  Out of 40/63 failed tests, this change reduces the number down to four. :^)

  *:star:new:star:* failing tests | error
  :--|---
  22 - 12 bit per sample.flac | FLAC header: Sample bit depth invalid (at 42)
  37 - 20 bit per sample.flac | FLAC header: Sample bit depth invalid (at 42)
  45 - no total number of samples set.flac | FLAC header: Number of samples is zero (at 42)
  62 - predictor overflow check, 20-bit.flac | FLAC header: Sample bit depth invalid (at 42)

  See: #14683

- **LibAudio: Seek to the first frame on reset in FLAC**

  The files weren't starting exactly from the beginning before.
  This happened because the parameter now takes the sample index, instead of a seekpoint.

cc: @kleinesfilmroellchen