### PR TITLE
Kernel: Fix USB hotplug kernel crash

### DIFF
--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -20,6 +20,8 @@ ErrorOr<NonnullRefPtr<Device>> Device::try_create(USBController const& controlle
 {
     auto pipe = TRY(Pipe::try_create_pipe(controller, Pipe::Type::Control, Pipe::Direction::Bidirectional, 0, 8, 0));
     auto device = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Device(controller, port, speed, move(pipe))));
+    auto sysfs_node = TRY(SysFSUSBDeviceInformation::create(*device));
+    device->m_sysfs_device_info_node = move(sysfs_node);
     TRY(device->enumerate_device());
     return device;
 }

--- a/Kernel/Bus/USB/USBHub.cpp
+++ b/Kernel/Bus/USB/USBHub.cpp
@@ -45,8 +45,6 @@ ErrorOr<void> Hub::enumerate_and_power_on_hub()
     // USBDevice::enumerate_device must be called before this.
     VERIFY(m_address > 0);
 
-    m_sysfs_device_info_node = TRY(SysFSUSBDeviceInformation::create(*this));
-
     if (m_device_descriptor.device_class != USB_CLASS_HUB) {
         dbgln("USB Hub: Trying to enumerate and power on a device that says it isn't a hub.");
         return EINVAL;

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/BusDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/BusDirectory.cpp
@@ -45,10 +45,4 @@ UNMAP_AFTER_INIT void SysFSUSBBusDirectory::initialize()
     s_sysfs_usb_bus_directory = directory;
 }
 
-ErrorOr<NonnullRefPtr<SysFSUSBDeviceInformation>> SysFSUSBDeviceInformation::create(USB::Device& device)
-{
-    auto device_name = TRY(KString::number(device.address()));
-    return adopt_nonnull_ref_or_enomem(new (nothrow) SysFSUSBDeviceInformation(move(device_name), device));
-}
-
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/DeviceInformation.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/DeviceInformation.cpp
@@ -11,6 +11,12 @@
 
 namespace Kernel {
 
+ErrorOr<NonnullRefPtr<SysFSUSBDeviceInformation>> SysFSUSBDeviceInformation::create(USB::Device& device)
+{
+    auto device_name = TRY(KString::number(device.address()));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) SysFSUSBDeviceInformation(move(device_name), device));
+}
+
 SysFSUSBDeviceInformation::SysFSUSBDeviceInformation(NonnullOwnPtr<KString> device_name, USB::Device& device)
     : SysFSComponent()
     , m_device(device)


### PR DESCRIPTION
Fix the USB hotplug kernel crash bug & move/rename the SysFS USB device information node creation method to be in its respective source file and match the "try_create" idiom that seems to be pretty common across the codebase to reflect that it may return an error.