### PR TITLE
less: Fix out of bounds StringView indexing

### DIFF
--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -332,7 +332,7 @@ private:
 
     size_t render_status_line(StringView prompt, size_t off = 0, char end = '\0', bool ignored = false)
     {
-        for (; prompt[off] != end && off < prompt.length(); ++off) {
+        for (; off < prompt.length() && prompt[off] != end; ++off) {
             if (ignored)
                 continue;
 


### PR DESCRIPTION
This fixes indexing the StringView before knowing if the index
is valid. This did not crash until the changes from 13406b8
which added runtime checks for StringView indexing.