### PR TITLE
LibWeb: Fix some `calc()` crashes

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Angle.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Angle.cpp
@@ -96,4 +96,10 @@ Optional<Angle::Type> Angle::unit_from_name(StringView name)
     return {};
 }
 
+NonnullRefPtr<CalculatedStyleValue> Angle::calculated_style_value() const
+{
+    VERIFY(!m_calculated_style.is_null());
+    return *m_calculated_style;
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/Angle.h
+++ b/Userland/Libraries/LibWeb/CSS/Angle.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/RefPtr.h>
+#include <AK/String.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -55,3 +56,11 @@ private:
 };
 
 }
+
+template<>
+struct AK::Formatter<Web::CSS::Angle> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::CSS::Angle const& angle)
+    {
+        return Formatter<StringView>::format(builder, angle.to_string());
+    }
+};

--- a/Userland/Libraries/LibWeb/CSS/Angle.h
+++ b/Userland/Libraries/LibWeb/CSS/Angle.h
@@ -31,6 +31,7 @@ public:
     Angle percentage_of(Percentage const&) const;
 
     bool is_calculated() const { return m_type == Type::Calculated; }
+    NonnullRefPtr<CalculatedStyleValue> calculated_style_value() const;
 
     String to_string() const;
     float to_degrees() const;

--- a/Userland/Libraries/LibWeb/CSS/Frequency.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.cpp
@@ -83,4 +83,10 @@ Optional<Frequency::Type> Frequency::unit_from_name(StringView name)
     return {};
 }
 
+NonnullRefPtr<CalculatedStyleValue> Frequency::calculated_style_value() const
+{
+    VERIFY(!m_calculated_style.is_null());
+    return *m_calculated_style;
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/Frequency.h
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.h
@@ -28,6 +28,7 @@ public:
     Frequency percentage_of(Percentage const&) const;
 
     bool is_calculated() const { return m_type == Type::Calculated; }
+    NonnullRefPtr<CalculatedStyleValue> calculated_style_value() const;
 
     String to_string() const;
     float to_hertz() const;

--- a/Userland/Libraries/LibWeb/CSS/Frequency.h
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/RefPtr.h>
+#include <AK/String.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -50,4 +51,13 @@ private:
     float m_value { 0 };
     RefPtr<CalculatedStyleValue> m_calculated_style;
 };
+
 }
+
+template<>
+struct AK::Formatter<Web::CSS::Frequency> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::CSS::Frequency const& frequency)
+    {
+        return Formatter<StringView>::format(builder, frequency.to_string());
+    }
+};

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -198,4 +198,10 @@ Optional<Length::Type> Length::unit_from_name(StringView name)
     return {};
 }
 
+NonnullRefPtr<CalculatedStyleValue> Length::calculated_style_value() const
+{
+    VERIFY(!m_calculated_style.is_null());
+    return *m_calculated_style;
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -76,6 +76,7 @@ public:
     }
 
     float raw_value() const { return m_value; }
+    NonnullRefPtr<CalculatedStyleValue> calculated_style_value() const;
 
     float to_px(Layout::Node const&) const;
 

--- a/Userland/Libraries/LibWeb/CSS/Number.h
+++ b/Userland/Libraries/LibWeb/CSS/Number.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <math.h>
 
@@ -68,8 +69,23 @@ public:
         return { Type::Number, m_value / other.m_value };
     }
 
+    String to_string() const
+    {
+        if (m_type == Type::IntegerWithExplicitSign)
+            return String::formatted("{:+}", m_value);
+        return String::number(m_value);
+    }
+
 private:
     float m_value { 0 };
     Type m_type;
 };
 }
+
+template<>
+struct AK::Formatter<Web::CSS::Number> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::CSS::Number const& number)
+    {
+        return Formatter<StringView>::format(builder, number.to_string());
+    }
+};

--- a/Userland/Libraries/LibWeb/CSS/Percentage.h
+++ b/Userland/Libraries/LibWeb/CSS/Percentage.h
@@ -98,6 +98,8 @@ public:
     {
         return m_value.visit(
             [&](T const& t) {
+                if (t.is_calculated())
+                    return resolve_calculated(t.calculated_style_value(), layout_node, reference_value);
                 return t;
             },
             [&](Percentage const& percentage) {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -669,6 +669,9 @@ Optional<Angle> CalculatedStyleValue::resolve_angle_percentage(Angle const& perc
         [&](Angle const& angle) -> Optional<Angle> {
             return angle;
         },
+        [&](Percentage const& percentage) -> Optional<Angle> {
+            return percentage_basis.percentage_of(percentage);
+        },
         [&](auto const&) -> Optional<Angle> {
             return {};
         });
@@ -691,6 +694,9 @@ Optional<Frequency> CalculatedStyleValue::resolve_frequency_percentage(Frequency
         [&](Frequency const& frequency) -> Optional<Frequency> {
             return frequency;
         },
+        [&](Percentage const& percentage) -> Optional<Frequency> {
+            return percentage_basis.percentage_of(percentage);
+        },
         [&](auto const&) -> Optional<Frequency> {
             return {};
         });
@@ -712,6 +718,9 @@ Optional<Length> CalculatedStyleValue::resolve_length_percentage(Layout::Node co
     return result.value().visit(
         [&](Length const& length) -> Optional<Length> {
             return length;
+        },
+        [&](Percentage const& percentage) -> Optional<Length> {
+            return percentage_basis.percentage_of(percentage);
         },
         [&](auto const&) -> Optional<Length> {
             return {};

--- a/Userland/Libraries/LibWeb/CSS/Time.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Time.cpp
@@ -83,4 +83,10 @@ Optional<Time::Type> Time::unit_from_name(StringView name)
     return {};
 }
 
+NonnullRefPtr<CalculatedStyleValue> Time::calculated_style_value() const
+{
+    VERIFY(!m_calculated_style.is_null());
+    return *m_calculated_style;
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/Time.h
+++ b/Userland/Libraries/LibWeb/CSS/Time.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/RefPtr.h>
+#include <AK/String.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -53,3 +54,11 @@ private:
 };
 
 }
+
+template<>
+struct AK::Formatter<Web::CSS::Time> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::CSS::Time const& time)
+    {
+        return Formatter<StringView>::format(builder, time.to_string());
+    }
+};

--- a/Userland/Libraries/LibWeb/CSS/Time.h
+++ b/Userland/Libraries/LibWeb/CSS/Time.h
@@ -29,6 +29,7 @@ public:
     Time percentage_of(Percentage const&) const;
 
     bool is_calculated() const { return m_type == Type::Calculated; }
+    NonnullRefPtr<CalculatedStyleValue> calculated_style_value() const;
 
     String to_string() const;
     float to_seconds() const;


### PR DESCRIPTION
***2-FOR-1 DEAL ON BUG FIXES! ACT NOW TO AVOID DISAPPOINTMENT!***

---

This fixes the crash in #14697, and another on [https://www.welcometosheffield.co.uk/]().