### PR TITLE
FontEditor+LibGUI: Highlight modified glyphs

### DIFF
--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -204,6 +204,15 @@ ErrorOr<void> MainWidget::create_actions()
     m_show_unicode_blocks_action->set_checked(show_unicode_blocks);
     m_show_unicode_blocks_action->set_status_tip("Show or hide the Unicode block list");
 
+    bool highlight_modifications = Config::read_bool("FontEditor"sv, "Display"sv, "HighlightModifications"sv, true);
+    set_highlight_modifications(highlight_modifications);
+    m_highlight_modifications_action = GUI::Action::create_checkable("&Highlight Modifications", { Mod_Ctrl, Key_H }, [&](auto& action) {
+        set_highlight_modifications(action.is_checked());
+        Config::write_bool("FontEditor"sv, "Display"sv, "HighlightModifications"sv, action.is_checked());
+    });
+    m_highlight_modifications_action->set_checked(highlight_modifications);
+    m_highlight_modifications_action->set_status_tip("Show or hide highlights on modified glyphs. (Green = New, Blue = Modified, Red = Deleted)");
+
     m_go_to_glyph_action = GUI::Action::create("&Go to Glyph...", { Mod_Ctrl, Key_G }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-to.png"sv)), [&](auto&) {
         String input;
         if (GUI::InputBox::show(window(), input, "Hexadecimal:"sv, "Go to glyph"sv) == GUI::InputBox::ExecResult::OK && !input.is_empty()) {
@@ -652,6 +661,8 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
     TRY(view_menu->try_add_action(*m_show_metadata_action));
     TRY(view_menu->try_add_action(*m_show_unicode_blocks_action));
     TRY(view_menu->try_add_separator());
+    TRY(view_menu->try_add_action(*m_highlight_modifications_action));
+    TRY(view_menu->try_add_separator());
     auto scale_menu = TRY(view_menu->try_add_submenu("&Scale"));
     TRY(scale_menu->try_add_action(*m_scale_five_action));
     TRY(scale_menu->try_add_action(*m_scale_ten_action));
@@ -691,6 +702,11 @@ void MainWidget::set_show_unicode_blocks(bool show)
         return;
     m_unicode_blocks = show;
     m_unicode_block_container->set_visible(m_unicode_blocks);
+}
+
+void MainWidget::set_highlight_modifications(bool highlight_modifications)
+{
+    m_glyph_map_widget->set_highlight_modifications(highlight_modifications);
 }
 
 ErrorOr<void> MainWidget::open_file(String const& path)

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -547,7 +547,7 @@ ErrorOr<void> MainWidget::initialize(String const& path, RefPtr<Gfx::BitmapFont>
         return {};
 
     auto selection = m_glyph_map_widget->selection().normalized();
-    m_undo_selection = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) UndoSelection(selection.start(), selection.size(), m_glyph_map_widget->active_glyph(), *edited_font)));
+    m_undo_selection = TRY(try_make_ref_counted<UndoSelection>(selection.start(), selection.size(), m_glyph_map_widget->active_glyph(), *edited_font, *m_glyph_map_widget));
     m_undo_stack->clear();
 
     m_path = path;

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -960,6 +960,7 @@ void MainWidget::paste_glyphs()
             : min(edited_font().max_glyph_width(), data[bytes_per_copied_glyph * glyph_count + i]);
         memcpy(&rows[i * bytes_per_glyph], &data[i * bytes_per_copied_glyph], copyable_bytes_per_glyph);
         memset(&widths[i], copyable_width, sizeof(u8));
+        m_glyph_map_widget->set_glyph_modified(selection.start() + i, true);
     }
 
     m_glyph_map_widget->set_selection(selection.start() + range_bound_glyph_count - 1, -range_bound_glyph_count + 1);

--- a/Userland/Applications/FontEditor/MainWidget.h
+++ b/Userland/Applications/FontEditor/MainWidget.h
@@ -51,6 +51,8 @@ public:
     bool is_showing_unicode_blocks() { return m_unicode_blocks; }
     void set_show_unicode_blocks(bool);
 
+    void set_highlight_modifications(bool);
+
 private:
     MainWidget();
 
@@ -110,6 +112,7 @@ private:
     RefPtr<GUI::Action> m_open_preview_action;
     RefPtr<GUI::Action> m_show_metadata_action;
     RefPtr<GUI::Action> m_show_unicode_blocks_action;
+    RefPtr<GUI::Action> m_highlight_modifications_action;
 
     GUI::ActionGroup m_glyph_editor_scale_actions;
     RefPtr<GUI::Action> m_scale_five_action;

--- a/Userland/Applications/FontEditor/UndoSelection.h
+++ b/Userland/Applications/FontEditor/UndoSelection.h
@@ -7,26 +7,33 @@
 #pragma once
 
 #include <LibGUI/Command.h>
+#include <LibGUI/GlyphMapWidget.h>
 #include <LibGUI/UndoStack.h>
 #include <LibGfx/Font/BitmapFont.h>
 
 class UndoSelection : public RefCounted<UndoSelection> {
 public:
-    explicit UndoSelection(int const start, int const size, u32 const active_glyph, Gfx::BitmapFont const& font)
+    explicit UndoSelection(int const start, int const size, u32 const active_glyph, Gfx::BitmapFont const& font, NonnullRefPtr<GUI::GlyphMapWidget> glyph_map_widget)
         : m_start(start)
         , m_size(size)
         , m_active_glyph(active_glyph)
         , m_font(font)
+        , m_glyph_map_widget(move(glyph_map_widget))
     {
     }
     ErrorOr<NonnullRefPtr<UndoSelection>> save_state()
     {
-        auto state = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) UndoSelection(m_start, m_size, m_active_glyph, *m_font)));
+        auto state = TRY(try_make_ref_counted<UndoSelection>(m_start, m_size, m_active_glyph, *m_font, m_glyph_map_widget));
         size_t bytes_per_glyph = Gfx::GlyphBitmap::bytes_per_row() * font().glyph_height();
         auto* rows = font().rows() + m_start * bytes_per_glyph;
         auto* widths = font().widths() + m_start;
         TRY(state->m_data.try_append(&rows[0], bytes_per_glyph * m_size));
         TRY(state->m_data.try_append(&widths[0], m_size));
+
+        TRY(state->m_restored_modified_state.try_ensure_capacity(m_size));
+        for (int glyph = m_start; glyph < m_start + m_size; ++glyph)
+            TRY(state->m_restored_modified_state.try_append(m_glyph_map_widget->glyph_is_modified(glyph)));
+
         return state;
     }
     void restore_state(UndoSelection const& state)
@@ -36,6 +43,10 @@ public:
         auto* widths = font().widths() + state.m_start;
         memcpy(rows, &state.m_data[0], bytes_per_glyph * state.m_size);
         memcpy(widths, &state.m_data[bytes_per_glyph * state.m_size], state.m_size);
+
+        for (int i = 0; i < state.m_size; ++i)
+            m_glyph_map_widget->set_glyph_modified(state.m_start + i, state.m_restored_modified_state[i]);
+
         m_restored_active_glyph = state.m_active_glyph;
         m_restored_start = state.m_start;
         m_restored_size = state.m_size;
@@ -55,7 +66,9 @@ private:
     int m_restored_start { 0 };
     int m_restored_size { 0 };
     u32 m_restored_active_glyph { 0 };
+    Vector<bool> m_restored_modified_state;
     RefPtr<Gfx::BitmapFont> m_font;
+    NonnullRefPtr<GUI::GlyphMapWidget> m_glyph_map_widget;
     ByteBuffer m_data;
 };
 

--- a/Userland/Libraries/LibGUI/GlyphMapWidget.h
+++ b/Userland/Libraries/LibGUI/GlyphMapWidget.h
@@ -21,6 +21,8 @@ class GlyphMapWidget final : public AbstractScrollableWidget {
 public:
     virtual ~GlyphMapWidget() override = default;
 
+    void set_font(Gfx::Font const&);
+
     class Selection {
     public:
         Selection() = default;
@@ -60,6 +62,10 @@ public:
     void scroll_to_glyph(int);
     void update_glyph(int);
 
+    void set_highlight_modifications(bool);
+    void set_glyph_modified(u32 glyph, bool modified);
+    bool glyph_is_modified(u32 glyph);
+
     void select_previous_existing_glyph();
     void select_next_existing_glyph();
 
@@ -88,6 +94,7 @@ private:
 
     void recalculate_content_size();
 
+    RefPtr<Gfx::Font> m_original_font;
     int m_glyph_count { 0x110000 };
     int m_columns { 0 };
     int m_rows { 0 };
@@ -97,6 +104,8 @@ private:
     int m_active_glyph { 0 };
     int m_visible_glyphs { 0 };
     bool m_in_drag_select { false };
+    bool m_highlight_modifications { false };
+    HashTable<u32> m_modified_glyphs;
     Unicode::CodePointRange m_active_range { 0x0000, 0x10FFFF };
     RefPtr<Core::Timer> m_automatic_selection_scroll_timer;
     Gfx::IntPoint m_last_mousemove_position;


### PR DESCRIPTION
This makes modifications in FontEditor more visible, both so you know
what you've changed, and for taking a handy "here's what's changed"
screenshot for a font PR. :^)

The background color for new glyphs is green, modified glyphs is blue,
and deleted glyphs is red. The changes persist until you load a new
font file, so you can continue saving your work as you go and still be
able to take a convenient screenshot at the end.

----

Now with dark-mode colours, proper undo support, and an option to turn the highlights on and off! :^)

![image](https://user-images.githubusercontent.com/222642/182388274-9f6d3c75-9ef4-4c9b-b53c-2425ef67a32f.png)

![image](https://user-images.githubusercontent.com/222642/182388354-b3920338-fdd9-41ce-b92d-12aa336b49fc.png)