### PR TITLE
Kernel+Userland: Remove ProcFS PCI node, remove Hardware tab from SystemMonitor

### DIFF
--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -96,7 +96,6 @@ UNMAP_AFTER_INIT bool Access::find_and_register_pci_host_bridges_from_acpi_mcfg_
 UNMAP_AFTER_INIT bool Access::initialize_for_multiple_pci_domains(PhysicalAddress mcfg_table)
 {
     VERIFY(!Access::is_initialized());
-    ProcFSComponentRegistry::the().root_directory().add_pci_node({});
     auto* access = new Access();
     if (!access->find_and_register_pci_host_bridges_from_acpi_mcfg_table(mcfg_table))
         return false;
@@ -108,7 +107,6 @@ UNMAP_AFTER_INIT bool Access::initialize_for_multiple_pci_domains(PhysicalAddres
 UNMAP_AFTER_INIT bool Access::initialize_for_one_pci_domain()
 {
     VERIFY(!Access::is_initialized());
-    ProcFSComponentRegistry::the().root_directory().add_pci_node({});
     auto* access = new Access();
     auto host_bridge = HostBridge::must_create_with_io_access();
     access->add_host_controller(move(host_bridge));

--- a/Kernel/ProcessExposed.h
+++ b/Kernel/ProcessExposed.h
@@ -152,7 +152,6 @@ public:
     virtual ErrorOr<NonnullRefPtr<ProcFSExposedComponent>> lookup(StringView name) override;
     static NonnullRefPtr<ProcFSRootDirectory> must_create();
 
-    void add_pci_node(Badge<PCI::Access>);
     virtual ~ProcFSRootDirectory();
 
 private:

--- a/Userland/Applications/SystemMonitor/CMakeLists.txt
+++ b/Userland/Applications/SystemMonitor/CMakeLists.txt
@@ -23,4 +23,4 @@ set(SOURCES
 )
 
 serenity_app(SystemMonitor ICON app-system-monitor)
-target_link_libraries(SystemMonitor LibGUI LibSymbolication LibPCIDB LibMain)
+target_link_libraries(SystemMonitor LibGUI LibSymbolication LibMain)


### PR DESCRIPTION
Still a draft, because I'm not sure if this is the right direction for `SystemMonitor`. What I do know is that we need a separate application, like in Windows, that describes all of the connected hardware, preferably in a tree-based manner, from SysFS and certainly not from the ProcFS. As for Storage data, `SystemMonitor` might still be a better choice than implementing a new application. However, we technically could take `PartitionEditor` and the storage data from `SystemMonitor` and create a `StorageManager` GUI application, similarly to how Windows allows you to view and manage partitions and other storage devices in one place.