### PR TITLE
Kernel/FileSystem: Funnel calls to Inode::prepare_to_write_data method

### DIFF
--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -937,14 +937,11 @@ ErrorOr<void> Ext2FSInode::resize(u64 new_size)
 
 ErrorOr<size_t> Ext2FSInode::write_bytes(off_t offset, size_t count, UserOrKernelBuffer const& data, OpenFileDescription* description)
 {
+    VERIFY(m_inode_lock.is_locked());
     VERIFY(offset >= 0);
 
     if (count == 0)
         return 0;
-
-    MutexLocker inode_locker(m_inode_lock);
-
-    TRY(prepare_to_write_data());
 
     if (is_symlink()) {
         VERIFY(offset == 0);

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -253,9 +253,7 @@ void Inode::did_delete_self()
 
 ErrorOr<void> Inode::prepare_to_write_data()
 {
-    // FIXME: It's a poor design that filesystems are expected to call this before writing out data.
-    //        We should funnel everything through an interface at the VirtualFileSystem layer so this can happen from a single place.
-    MutexLocker locker(m_inode_lock);
+    VERIFY(m_inode_lock.is_locked());
     if (fs().is_readonly())
         return EROFS;
     auto metadata = this->metadata();

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -31,6 +31,7 @@ class Inode : public ListedRefCounted<Inode, LockType::Spinlock>
     , public Weakable<Inode> {
     friend class VirtualFileSystem;
     friend class FileSystem;
+    friend class InodeFile;
 
 public:
     virtual ~Inode();

--- a/Kernel/FileSystem/TmpFS.cpp
+++ b/Kernel/FileSystem/TmpFS.cpp
@@ -108,11 +108,9 @@ ErrorOr<size_t> TmpFSInode::read_bytes(off_t offset, size_t size, UserOrKernelBu
 
 ErrorOr<size_t> TmpFSInode::write_bytes(off_t offset, size_t size, UserOrKernelBuffer const& buffer, OpenFileDescription*)
 {
-    MutexLocker locker(m_inode_lock);
+    VERIFY(m_inode_lock.is_locked());
     VERIFY(!is_directory());
     VERIFY(offset >= 0);
-
-    TRY(prepare_to_write_data());
 
     off_t old_size = m_metadata.size;
     off_t new_size = m_metadata.size;

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -693,6 +693,8 @@ ErrorOr<void> VirtualFileSystem::symlink(StringView target, StringView linkpath,
     auto inode = TRY(parent_inode.create_child(basename, S_IFLNK | 0644, 0, current_process.euid(), current_process.egid()));
 
     auto target_buffer = UserOrKernelBuffer::for_kernel_buffer(const_cast<u8*>((u8 const*)target.characters_without_null_termination()));
+    MutexLocker locker(inode->m_inode_lock);
+    TRY(inode->prepare_to_write_data());
     TRY(inode->write_bytes(0, target.length(), target_buffer, nullptr));
     return {};
 }


### PR DESCRIPTION
Instead of requiring each FileSystem implementation to call this method
when trying to write data, do the calls at 2 points to avoid further
calls (or lack of them due to not remembering to use it) at other files
and locations in the codebase.