### PR TITLE
LibGUI: Implement linewise visual mode for VimEditingEngine

### DIFF
--- a/Userland/Libraries/LibGUI/VimEditingEngine.h
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.h
@@ -152,7 +152,8 @@ private:
     enum VimMode {
         Normal,
         Insert,
-        Visual
+        Visual,
+        VisualLine
     };
 
     enum YankType {
@@ -185,6 +186,7 @@ private:
     void switch_to_normal_mode();
     void switch_to_insert_mode();
     void switch_to_visual_mode();
+    void switch_to_visual_line_mode();
     void move_half_page_up();
     void move_half_page_down();
     void move_to_previous_empty_lines_block();
@@ -193,6 +195,7 @@ private:
     bool on_key_in_insert_mode(KeyEvent const& event);
     bool on_key_in_normal_mode(KeyEvent const& event);
     bool on_key_in_visual_mode(KeyEvent const& event);
+    bool on_key_in_visual_line_mode(KeyEvent const& event);
 
     void casefold_selection(Casing);
 


### PR DESCRIPTION
Visual line mode is almost identical to visual mode except for it
operates on whole lines. Movement up/down with k/j selects whole
lines and left/right with l/h has no affect. Shift+V enters visual line
mode.