### PR TITLE
LibWeb: Extract some IDL mixins

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLParser.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLParser.cpp
@@ -761,6 +761,8 @@ void Parser::parse_callback_function(HashMap<String, String>& extended_attribute
 
 void Parser::parse_non_interface_entities(bool allow_interface, Interface& interface)
 {
+    consume_whitespace();
+
     while (!lexer.is_eof()) {
         HashMap<String, String> extended_attributes;
         if (lexer.consume_specific('['))
@@ -794,6 +796,8 @@ void Parser::parse_non_interface_entities(bool allow_interface, Interface& inter
             break;
         }
     }
+
+    consume_whitespace();
 }
 
 void resolve_typedef(Interface& interface, NonnullRefPtr<Type>& type, HashMap<String, String>* extended_attributes = {})

--- a/Userland/Libraries/LibWeb/CSS/LinkStyle.idl
+++ b/Userland/Libraries/LibWeb/CSS/LinkStyle.idl
@@ -1,0 +1,6 @@
+#import <CSS/CSSStyleSheet.idl>
+
+// https://www.w3.org/TR/cssom-1/#ref-for-linkstyle
+interface mixin LinkStyle {
+    readonly attribute CSSStyleSheet? sheet;
+};

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.idl
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.idl
@@ -1,8 +1,9 @@
+#import <DOM/ChildNode.idl>
 #import <DOM/Element.idl>
 #import <DOM/Node.idl>
 
+// https://dom.spec.whatwg.org/#characterdata
 interface CharacterData : Node {
-
     [LegacyNullToEmptyString] attribute DOMString data;
     readonly attribute unsigned long length;
 
@@ -14,11 +15,4 @@ interface CharacterData : Node {
 
     readonly attribute Element? nextElementSibling;
     readonly attribute Element? previousElementSibling;
-
-    // FIXME: These should come from a ChildNode mixin
-    [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined after((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined replaceWith((Node or DOMString)... nodes);
-    [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
-
 };

--- a/Userland/Libraries/LibWeb/DOM/ChildNode.idl
+++ b/Userland/Libraries/LibWeb/DOM/ChildNode.idl
@@ -1,0 +1,13 @@
+#import <DOM/Node.idl>
+
+// https://dom.spec.whatwg.org/#childnode
+interface mixin ChildNode {
+    [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined after((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined replaceWith((Node or DOMString)... nodes);
+    [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
+};
+
+DocumentType includes ChildNode;
+Element includes ChildNode;
+CharacterData includes ChildNode;

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -114,4 +114,4 @@ interface Document : Node {
 
 };
 
-HTMLElement includes GlobalEventHandlers;
+Document includes GlobalEventHandlers;

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -11,6 +11,7 @@
 #import <DOM/NodeFilter.idl>
 #import <DOM/NodeIterator.idl>
 #import <DOM/NodeList.idl>
+#import <DOM/ParentNode.idl>
 #import <DOM/Range.idl>
 #import <DOM/Text.idl>
 #import <DOM/TreeWalker.idl>
@@ -18,8 +19,8 @@
 #import <HTML/HTMLHeadElement.idl>
 #import <HTML/HTMLScriptElement.idl>
 
+// https://dom.spec.whatwg.org/#document
 interface Document : Node {
-
     constructor();
 
     boolean hasFocus();
@@ -92,26 +93,11 @@ interface Document : Node {
 
     attribute DOMString title;
 
-    // FIXME: These should all come from a ParentNode mixin
-    readonly attribute Element? firstElementChild;
-    readonly attribute Element? lastElementChild;
-    readonly attribute unsigned long childElementCount;
-
-    [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined append((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined replaceChildren((Node or DOMString)... nodes);
-
-    Element? querySelector(DOMString selectors);
-    [NewObject] NodeList querySelectorAll(DOMString selectors);
-
-    [SameObject] readonly attribute HTMLCollection children;
-
     readonly boolean hidden;
     readonly DOMString visibilityState;
 
     [NewObject] NodeIterator createNodeIterator(Node root, optional unsigned long whatToShow = 0xFFFFFFFF, optional NodeFilter? filter = null);
     [NewObject] TreeWalker createTreeWalker(Node root, optional unsigned long whatToShow = 0xFFFFFFFF, optional NodeFilter? filter = null);
-
 };
 
 Document includes GlobalEventHandlers;

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
@@ -2,25 +2,11 @@
 #import <DOM/HTMLCollection.idl>
 #import <DOM/Node.idl>
 #import <DOM/NodeList.idl>
+#import <DOM/ParentNode.idl>
 
+// https://dom.spec.whatwg.org/#documentfragment
 interface DocumentFragment : Node {
-
     constructor();
 
     Element? getElementById(DOMString id);
-
-    // FIXME: These should all come from a ParentNode mixin
-    readonly attribute Element? firstElementChild;
-    readonly attribute Element? lastElementChild;
-    readonly attribute unsigned long childElementCount;
-
-    [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined append((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined replaceChildren((Node or DOMString)... nodes);
-
-    Element? querySelector(DOMString selectors);
-    [NewObject] NodeList querySelectorAll(DOMString selectors);
-
-    [SameObject] readonly attribute HTMLCollection children;
-
 };

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.idl
@@ -1,15 +1,9 @@
+#import <DOM/ChildNode.idl>
 #import <DOM/Node.idl>
 
+// https://dom.spec.whatwg.org/#documenttype
 interface DocumentType : Node {
-
     readonly attribute DOMString name;
     readonly attribute DOMString publicId;
     readonly attribute DOMString systemId;
-
-    // FIXME: These should come from a ChildNode mixin
-    [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined after((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined replaceWith((Node or DOMString)... nodes);
-    [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
-
 };

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -1,6 +1,7 @@
 #import <CSS/CSSStyleDeclaration.idl>
 #import <DOM/ChildNode.idl>
 #import <DOM/DOMTokenList.idl>
+#import <DOM/InnerHTML.idl>
 #import <DOM/NamedNodeMap.idl>
 #import <DOM/Node.idl>
 #import <DOM/NodeList.idl>
@@ -28,9 +29,6 @@ interface Element : Node {
     HTMLCollection getElementsByTagName(DOMString tagName);
     HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);
     HTMLCollection getElementsByClassName(DOMString className);
-
-    // FIXME: This should come from a InnerHTML mixin.
-    [LegacyNullToEmptyString, CEReactions] attribute DOMString innerHTML;
 
     [Reflect] attribute DOMString id;
     [Reflect=class] attribute DOMString className;

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -1,11 +1,13 @@
+#import <CSS/CSSStyleDeclaration.idl>
+#import <DOM/ChildNode.idl>
 #import <DOM/DOMTokenList.idl>
 #import <DOM/NamedNodeMap.idl>
 #import <DOM/Node.idl>
 #import <DOM/NodeList.idl>
 #import <Geometry/DOMRect.idl>
 #import <Geometry/DOMRectList.idl>
-#import <CSS/CSSStyleDeclaration.idl>
 
+// https://dom.spec.whatwg.org/#element
 interface Element : Node {
     readonly attribute DOMString? namespaceURI;
     readonly attribute DOMString? prefix;
@@ -65,11 +67,4 @@ interface Element : Node {
     readonly attribute long clientLeft;
     readonly attribute long clientWidth;
     readonly attribute long clientHeight;
-
-    // FIXME: These should come from a ChildNode mixin
-    [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined after((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined replaceWith((Node or DOMString)... nodes);
-    [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
-
 };

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -4,6 +4,7 @@
 #import <DOM/NamedNodeMap.idl>
 #import <DOM/Node.idl>
 #import <DOM/NodeList.idl>
+#import <DOM/ParentNode.idl>
 #import <Geometry/DOMRect.idl>
 #import <Geometry/DOMRectList.idl>
 
@@ -45,20 +46,6 @@ interface Element : Node {
     readonly attribute Element? previousElementSibling;
 
     [ImplementedAs=style_for_bindings] readonly attribute CSSStyleDeclaration style;
-
-    // FIXME: These should all come from a ParentNode mixin (up to and including children)
-    readonly attribute Element? firstElementChild;
-    readonly attribute Element? lastElementChild;
-    readonly attribute unsigned long childElementCount;
-
-    [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined append((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined replaceChildren((Node or DOMString)... nodes);
-
-    Element? querySelector(DOMString selectors);
-    [NewObject] NodeList querySelectorAll(DOMString selectors);
-
-    [SameObject] readonly attribute HTMLCollection children;
 
     DOMRect getBoundingClientRect();
     DOMRectList getClientRects();

--- a/Userland/Libraries/LibWeb/DOM/InnerHTML.idl
+++ b/Userland/Libraries/LibWeb/DOM/InnerHTML.idl
@@ -1,0 +1,7 @@
+// https://w3c.github.io/DOM-Parsing/#the-innerhtml-mixin
+interface mixin InnerHTML {
+    [LegacyNullToEmptyString, CEReactions] attribute DOMString innerHTML;
+};
+
+Element includes InnerHTML;
+ShadowRoot includes InnerHTML;

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.idl
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.idl
@@ -1,0 +1,22 @@
+#import <DOM/Element.idl>
+#import <DOM/HTMLCollection.idl>
+#import <DOM/Node.idl>
+
+// https://dom.spec.whatwg.org/#parentnode
+interface mixin ParentNode {
+    [SameObject] readonly attribute HTMLCollection children;
+    readonly attribute Element? firstElementChild;
+    readonly attribute Element? lastElementChild;
+    readonly attribute unsigned long childElementCount;
+
+    [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined append((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined replaceChildren((Node or DOMString)... nodes);
+
+    Element? querySelector(DOMString selectors);
+    [NewObject] NodeList querySelectorAll(DOMString selectors);
+};
+
+Document includes ParentNode;
+DocumentFragment includes ParentNode;
+Element includes ParentNode;

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
@@ -1,11 +1,15 @@
 #import <DOM/DocumentFragment.idl>
+#import <DOM/InnerHTML.idl>
 
+// https://dom.spec.whatwg.org/#shadowroot
 interface ShadowRoot : DocumentFragment {
-
+    // FIXME: mode should return a ShadowRootMode
     readonly attribute DOMString mode;
+    // FIXME: readonly attribute boolean delegatesFocus;
+    // FIXME: readonly attribute SlotAssignmentMode slotAssignment;
     readonly attribute Element host;
-
-    // FIXME: This should come from a InnerHTML mixin.
-    [LegacyNullToEmptyString] attribute DOMString innerHTML;
-
+    // FIXME: attribute EventHandler onslotchange;
 };
+
+enum ShadowRootMode { "open", "closed" };
+enum SlotAssignmentMode { "manual", "named" };

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
@@ -1,31 +1,24 @@
 #import <HTML/HTMLElement.idl>
+#import <HTML/HTMLHyperlinkElementUtils.idl>
 
+// https://html.spec.whatwg.org/multipage/text-level-semantics.html#htmlanchorelement
 interface HTMLAnchorElement : HTMLElement {
+    // FIXME: [HTMLConstructor] constructor();
 
     [Reflect] attribute DOMString target;
     [Reflect] attribute DOMString download;
     [Reflect] attribute DOMString ping;
     [Reflect] attribute DOMString rel;
+    // FIXME: [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
     [Reflect] attribute DOMString hreflang;
     [Reflect] attribute DOMString type;
 
+    // Obsolete
     [Reflect] attribute DOMString coords;
     [Reflect] attribute DOMString charset;
     [Reflect] attribute DOMString name;
     [Reflect] attribute DOMString rev;
     [Reflect] attribute DOMString shape;
-
-    // FIXME: This should come from a HTMLHyperlinkElementUtils mixin
-    [CEReactions] stringifier attribute USVString href;
-    readonly attribute USVString origin;
-    [CEReactions] attribute USVString protocol;
-    [CEReactions] attribute USVString username;
-    [CEReactions] attribute USVString password;
-    [CEReactions] attribute USVString host;
-    [CEReactions] attribute USVString hostname;
-    [CEReactions] attribute USVString port;
-    [CEReactions] attribute USVString pathname;
-    [CEReactions] attribute USVString search;
-    [CEReactions] attribute USVString hash;
-
 };
+
+HTMLAnchorElement includes HTMLHyperlinkElementUtils;

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.idl
@@ -1,20 +1,22 @@
 #import <HTML/HTMLElement.idl>
+#import <HTML/HTMLHyperlinkElementUtils.idl>
 
+// https://html.spec.whatwg.org/multipage/image-maps.html#htmlareaelement
 interface HTMLAreaElement : HTMLElement {
+    // FIXME: [HTMLConstructor] constructor();
 
+    // FIXME: [CEReactions] attribute DOMString alt;
+    // FIXME: [CEReactions] attribute DOMString coords;
+    // FIXME: [CEReactions] attribute DOMString shape;
+    // FIXME: [CEReactions] attribute DOMString target;
+    // FIXME: [CEReactions] attribute DOMString download;
+    // FIXME: [CEReactions] attribute USVString ping;
+    // FIXME: [CEReactions] attribute DOMString rel;
+    // FIXME: [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+    // FIXME: [CEReactions] attribute DOMString referrerPolicy;
+
+    // Obsolete
     [Reflect=nohref] attribute boolean noHref;
-
-    // FIXME: This should come from a HTMLHyperlinkElementUtils mixin
-    [CEReactions] stringifier attribute USVString href;
-    readonly attribute USVString origin;
-    [CEReactions] attribute USVString protocol;
-    [CEReactions] attribute USVString username;
-    [CEReactions] attribute USVString password;
-    [CEReactions] attribute USVString host;
-    [CEReactions] attribute USVString hostname;
-    [CEReactions] attribute USVString port;
-    [CEReactions] attribute USVString pathname;
-    [CEReactions] attribute USVString search;
-    [CEReactions] attribute USVString hash;
-
 };
+
+HTMLAreaElement includes HTMLHyperlinkElementUtils;

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.idl
@@ -1,0 +1,14 @@
+// https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils
+interface mixin HTMLHyperlinkElementUtils {
+    [CEReactions] stringifier attribute USVString href;
+    readonly attribute USVString origin;
+    [CEReactions] attribute USVString protocol;
+    [CEReactions] attribute USVString username;
+    [CEReactions] attribute USVString password;
+    [CEReactions] attribute USVString host;
+    [CEReactions] attribute USVString hostname;
+    [CEReactions] attribute USVString port;
+    [CEReactions] attribute USVString pathname;
+    [CEReactions] attribute USVString search;
+    [CEReactions] attribute USVString hash;
+};

--- a/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.idl
@@ -1,13 +1,17 @@
 #import <CSS/CSSStyleSheet.idl>
+#import <CSS/LinkStyle.idl>
 #import <HTML/HTMLElement.idl>
 
+// https://html.spec.whatwg.org/multipage/semantics.html#htmlstyleelement
 interface HTMLStyleElement : HTMLElement {
+    // FIXME: [HTMLConstructor] constructor();
 
+    // FIXME: attribute boolean disabled;
     [Reflect] attribute DOMString media;
+    // FIXME: [SameObject, PutForwards=value] readonly attribute DOMTokenList blocking;
 
+    // Obsolete
     [Reflect] attribute DOMString type;
-
-    // FIXME: This should come from a LinkStyle mixin
-    readonly attribute CSSStyleSheet? sheet;
-
 };
+
+HTMLStyleElement includes LinkStyle;

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.idl
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.idl
@@ -1,0 +1,28 @@
+// https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope
+interface mixin WindowOrWorkerGlobalScope {
+    [Replaceable] readonly attribute USVString origin;
+    readonly attribute boolean isSecureContext;
+    readonly attribute boolean crossOriginIsolated;
+
+    // FIXME: undefined reportError(any e);
+
+    // base64 utility methods
+    DOMString btoa(DOMString data);
+    ByteString atob(DOMString data);
+
+    // timers
+    // FIXME: long setTimeout(TimerHandler handler, optional long timeout = 0, any... arguments);
+    // FIXME: undefined clearTimeout(optional long id = 0);
+    // FIXME: long setInterval(TimerHandler handler, optional long timeout = 0, any... arguments);
+    // FIXME: undefined clearInterval(optional long id = 0);
+
+    // microtask queuing
+    // FIXME: undefined queueMicrotask(VoidFunction callback);
+
+    // ImageBitmap
+    // FIXME: Promise<ImageBitmap> createImageBitmap(ImageBitmapSource image, optional ImageBitmapOptions options = {});
+    // FIXME: Promise<ImageBitmap> createImageBitmap(ImageBitmapSource image, long sx, long sy, long sw, long sh, optional ImageBitmapOptions options = {});
+
+    // structured cloning
+    // FIXME: any structuredClone(any value, optional StructuredSerializeOptions options = {});
+};

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.idl
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.idl
@@ -1,8 +1,10 @@
 #import <DOM/EventTarget.idl>
 #import <DOM/EventHandler.idl>
+#import <HTML/WindowOrWorkerGlobalScope.idl>
 #import <HTML/WorkerLocation.idl>
 #import <HTML/WorkerNavigator.idl>
 
+// https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope
 [Exposed=Worker]
 interface WorkerGlobalScope : EventTarget {
     readonly attribute WorkerGlobalScope self;
@@ -16,13 +18,6 @@ interface WorkerGlobalScope : EventTarget {
     attribute EventHandler ononline;
     attribute EventHandler onrejectionhandled;
     attribute EventHandler onunhandledrejection;
-
-    // FIXME: These should all come from a WindowOrWorkerGlobalScope mixin
-    [Replaceable] readonly attribute USVString origin;
-    readonly attribute boolean isSecureContext;
-    readonly attribute boolean crossOriginIsolated;
-
-    // base64 utility methods
-    DOMString btoa(DOMString data);
-    ByteString atob(DOMString data);
 };
+
+WorkerGlobalScope includes WindowOrWorkerGlobalScope;


### PR DESCRIPTION
We had a bunch of FIXMEs in IDL files about how things should be mixins, back from before we supported those in the WrapperGenerator. So, now they are all actual mixins instead! :^)

Also added spec URLs and FIXMEs for missing methods/fields as I noticed them.