### PR TITLE
Kernel: Pass `CLOCK_MONOTONIC` through the time page

### DIFF
--- a/Kernel/API/TimePage.h
+++ b/Kernel/API/TimePage.h
@@ -18,7 +18,7 @@ namespace Kernel {
 
 inline bool time_page_supports(clockid_t clock_id)
 {
-    return clock_id == CLOCK_REALTIME_COARSE || clock_id == CLOCK_MONOTONIC_COARSE;
+    return clock_id == CLOCK_REALTIME_COARSE || clock_id == CLOCK_MONOTONIC_COARSE || clock_id == CLOCK_MONOTONIC;
 }
 
 struct TimePage {

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -438,6 +438,7 @@ void TimeManagement::update_time_page()
     auto& page = time_page();
     u32 update_iteration = AK::atomic_fetch_add(&page.update2, 1u, AK::MemoryOrder::memory_order_acquire);
     page.clocks[CLOCK_REALTIME_COARSE] = m_epoch_time;
+    page.clocks[CLOCK_MONOTONIC] = monotonic_time(TimePrecision::Precise).to_timespec();
     page.clocks[CLOCK_MONOTONIC_COARSE] = monotonic_time(TimePrecision::Coarse).to_timespec();
     AK::atomic_store(&page.update1, update_iteration + 1u, AK::MemoryOrder::memory_order_release);
 }


### PR DESCRIPTION
This removes a lot of syscall overhead from the QEMU timing code, resulting in a decrease of Serenity boot time from 1h16m down to 42m when running on Serenity.

However, note that the time page only appears to be updated around 250 times a second, so we are likely losing a bit of accuracy there. We will also be running a HPET query on each tick, which might have a negative performance impact on the system as a whole, but I have neither confirmed nor benchmarked that yet.

The other option (with a similar effect regarding the resulting time) would be to simply patch QEMU to use `CLOCK_MONOTONIC_COARSE`, but I'm unsure if the (as far as I understood) even worse accuracy would cause any problems for the emulation. In case there is any preference for either side, please let me know.