### PR TITLE
Kernel: Silently discard `SO_REUSEADDR`

### DIFF
--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -125,6 +125,9 @@ ErrorOr<void> Socket::setsockopt(int level, int option, Userspace<void const*> u
         m_routing_disabled = TRY(copy_typed_from_user(static_ptr_cast<int const*>(user_value))) != 0;
         return {};
     }
+    case SO_REUSEADDR:
+        dbgln("FIXME: SO_REUSEADDR requested, but not implemented.");
+        return {};
     default:
         dbgln("setsockopt({}) at SOL_SOCKET not implemented.", option);
         return ENOPROTOOPT;


### PR DESCRIPTION
We were previously rejecting `SO_REUSEADDR` with an `ENOPROTOOPT`, but that made QEMU unhappy.

Instead, just silently discard it and print a FIXME message in case anybody wonders what went wrong if the system won't reuse an address.