### PR TITLE
LibHTTP+WebServer: Add querystring support

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -182,8 +182,18 @@ Optional<HttpRequest> HttpRequest::from_raw_request(ReadonlyBytes raw_request)
     else
         return {};
 
-    request.m_resource = URL::percent_decode(resource);
     request.m_headers = move(headers);
+    auto url_parts = resource.split_limit('?', 2, true);
+
+    request.m_url.set_cannot_be_a_base_url(true);
+    if (url_parts.size() == 2) {
+        request.m_resource = url_parts[0];
+        request.m_url.set_paths({ url_parts[0] });
+        request.m_url.set_query(url_parts[1]);
+    } else {
+        request.m_resource = resource;
+        request.m_url.set_paths({ resource });
+    }
 
     return request;
 }


### PR DESCRIPTION
When trying to access an HTML page with javascript in it(for example, a script that tries to access `window.location.search`), say `test.html?foo=bar`: the _WebServer_ tries to open a file called `test.html?foo=bar` instead of just `test.html`. This leads to a false-positive 404 error, which prevents loading the HTML page. 

Before the PR/patch:
![image](https://user-images.githubusercontent.com/57250448/181667557-719d0cc4-295d-4c0c-bbc1-df7b09d0aff1.png)

After the patch:
![image](https://user-images.githubusercontent.com/57250448/181667625-9effc5d6-4834-4140-8ef2-30af43233778.png)
