### PR TITLE
Meta: Update cmake for jakt bootstrap compiler and add cmake function for building jakt executables

### DIFF
--- a/Meta/CMake/code_generators.cmake
+++ b/Meta/CMake/code_generators.cmake
@@ -64,7 +64,6 @@ function(generate_state_machine source header)
 endfunction()
 
 function(compile_jakt source)
-    set(source ${CMAKE_CURRENT_SOURCE_DIR}/${source})
     get_filename_component(source_base ${source} NAME_WE)
     set(output "${source_base}.cpp")
     add_custom_command(

--- a/Meta/CMake/code_generators.cmake
+++ b/Meta/CMake/code_generators.cmake
@@ -68,7 +68,8 @@ function(compile_jakt source)
     set(output "${source_base}.cpp")
     add_custom_command(
         OUTPUT ${output}
-        COMMAND $<TARGET_FILE:Lagom::jakt> -S -o "${CMAKE_CURRENT_BINARY_DIR}/jakt_tmp" ${source}
+        COMMAND "${CMAKE_COMMAND}" -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/jakt_tmp
+        COMMAND $<TARGET_FILE:Lagom::jakt> -S -B "${CMAKE_CURRENT_BINARY_DIR}/jakt_tmp" ${source}
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/jakt_tmp/${output}" ${output}
         COMMAND "${CMAKE_COMMAND}" -E remove "${CMAKE_CURRENT_BINARY_DIR}/jakt_tmp/${output}"
         VERBATIM

--- a/Meta/CMake/code_generators.cmake
+++ b/Meta/CMake/code_generators.cmake
@@ -78,7 +78,8 @@ function(compile_jakt source)
     get_property(JAKT_INCLUDE_DIR TARGET Lagom::jakt PROPERTY IMPORTED_INCLUDE_DIRECTORIES)
     set_source_files_properties("${output}" PROPERTIES
         INCLUDE_DIRECTORIES "${JAKT_INCLUDE_DIR}/runtime"
-        COMPILE_OPTIONS "-Wno-unused-local-typedefs;-Wno-unused-function")
+        COMPILE_OPTIONS "-Wno-unused-variable;-Wno-trigraphs;-Wno-parentheses-equality;-Wno-unqualified-std-cast-call;-Wno-user-defined-literals;-Wno-deprecated-declarations;-Wno-unused-parameter;-Wno-unused-but-set-variable;-Wno-unused-function;-Wno-unused-result;-Wno-type-limits")
+
     get_filename_component(output_name ${output} NAME)
     add_custom_target(generate_${output_name} DEPENDS ${output})
     add_dependencies(all_generated generate_${output_name})

--- a/Meta/CMake/jakt.cmake
+++ b/Meta/CMake/jakt.cmake
@@ -4,14 +4,6 @@
 
 include(FetchContent)
 
-FetchContent_Declare(
-  Corrosion
-  GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-  GIT_TAG v0.2.1
-)
-
-FetchContent_MakeAvailable(Corrosion)
-
 FetchContent_Declare(jakt
     GIT_REPOSITORY https://github.com/SerenityOS/jakt.git
     GIT_TAG main
@@ -24,17 +16,69 @@ if (JAKT_SOURCE_DIR)
     message(STATUS "Using pre-existing JAKT_SOURCE_DIR: ${JAKT_SOURCE_DIR}")
 endif()
 
+macro(add_jakt_compiler_flags target)
+  target_compile_options("${target}" PRIVATE
+    -Wno-unused-local-typedefs
+    -Wno-unused-function
+    -Wno-unknown-warning-option
+    -Wno-trigraphs
+    -Wno-parentheses-equality
+    -Wno-unqualified-std-cast-call
+    -Wno-user-defined-literals
+    -Wno-deprecated-declarations
+    -Wno-unused-variable
+    -Wno-unused-result
+    -Wno-unused-parameter
+    -Wno-return-type
+    -Wno-unused-but-set-variable
+  )
+  target_compile_features("${target}" PRIVATE cxx_std_20)
+endmacro()
+
 FetchContent_GetProperties(jakt)
 if (NOT jakt_POPULATED)
     FetchContent_Populate(jakt)
-    corrosion_import_crate(MANIFEST_PATH "${jakt_SOURCE_DIR}/Cargo.toml")
-    corrosion_set_hostbuild(jakt)
-    add_executable(Lagom::jakt ALIAS jakt)
-    corrosion_install(TARGETS jakt RUNTIME COMPONENT Lagom_Runtime)
-    # NOTE: See lagom-install-config.cmake for hax required to get Lagom::jakt to show up on install
-    install(DIRECTORY "${jakt_SOURCE_DIR}/runtime"
+
+    if (NOT JAKT_SOURCE_DIR)
+        set(JAKT_SOURCE_DIR ${jakt_SOURCE_DIR})
+    endif()
+
+    add_executable(jakt ${JAKT_SOURCE_DIR}/bootstrap/stage0/jakt.cpp)
+
+    add_jakt_compiler_flags(jakt)
+    target_include_directories(jakt
+      PUBLIC
+        $<BUILD_INTERFACE:${JAKT_SOURCE_DIR}/bootstrap/stage0/runtime>
+        $<INSTALL_INTERFACE:runtime>
+    )
+    
+    # NOTE: See lagom-install-config.cmake for hax required to get Lagom::jakt to show up on install    
+    install(
+        TARGETS jakt
+        EXPORT JaktTargets
+        RUNTIME #
+            DESTINATION "${CMAKE_INSTALL_BINDIR}"
+            COMPONENT Jakt_Runtime
+        LIBRARY #
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/jakt"
+            COMPONENT Jakt_Runtime
+            NAMELINK_COMPONENT Jakt_Development
+        ARCHIVE #
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/jakt"
+            COMPONENT Jakt_Development
+    )
+
+    install(DIRECTORY "${JAKT_SOURCE_DIR}/runtime"
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/jakt
             FILES_MATCHING PATTERN "*.h"
                            PATTERN "*.cpp"
                            PATTERN "utility")
+
+    install(
+        EXPORT JaktTargets
+        NAMESPACE Jakt::
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/jakt"
+        COMPONENT Jakt_Development
+    )
 endif()
+

--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -221,3 +221,32 @@ function(download_file url path)
         endif()
     endif()
 endfunction()
+
+function(add_jakt_executable exe_name source_file)
+    cmake_parse_arguments(PARSE_ARGV 2 JAKT_COMPONENT "RECOMMENDED;REQUIRED" ""  "")
+    if(${source_file} MATCHES "//*")
+        set(source ${source_file})
+    else()
+        set(source ${CMAKE_CURRENT_SOURCE_DIR}/${source_file})
+    endif()
+    
+    get_filename_component(CMD_NAME_JAKT ${source} NAME_WE)
+    add_executable(${exe_name} "${CMD_NAME_JAKT}.cpp")
+    compile_jakt(${source})
+    target_link_libraries(${exe_name} LibC)
+    set_target_properties(${exe_name} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    install(TARGETS ${exe_name} RUNTIME DESTINATION bin OPTIONAL)
+    if(JAKT_COMPONENT_REQUIRED)
+        serenity_component(
+            ${exe_name}
+            REQUIRED
+            TARGETS ${exe_name}
+        )
+    else()
+        serenity_component(
+            ${exe_name}
+            RECOMMENDED
+            TARGETS ${exe_name}
+        )
+    endif()
+endfunction()

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -13,6 +13,10 @@ list(APPEND RECOMMENDED_TARGETS
 
 # FIXME: Support specifying component dependencies for utilities (e.g. WebSocket for telws)
 
+if (ENABLE_JAKT)
+    add_jakt_executable(hello-jakt hello-world.jakt)
+endif()
+
 foreach(CMD_SRC ${CMD_SOURCES})
     get_filename_component(CMD_NAME ${CMD_SRC} NAME_WE)
     if (CMD_NAME IN_LIST SPECIAL_TARGETS)
@@ -50,19 +54,6 @@ foreach(CMD_SRC ${CMD_SOURCES})
         install(TARGETS ${CMD_NAME} RUNTIME DESTINATION bin OPTIONAL)
     endif()
 endforeach()
-
-if (ENABLE_JAKT)
-    add_executable(hello-jakt hello-world.cpp)
-    compile_jakt(hello-world.jakt)
-    target_link_libraries(hello-jakt LibC)
-    set_target_properties(hello-jakt PROPERTIES EXCLUDE_FROM_ALL TRUE)
-    install(TARGETS hello-jakt RUNTIME DESTINATION bin OPTIONAL)
-    serenity_component(
-        hello-jakt
-        RECOMMENDED
-        TARGETS hello-jakt
-    )
-endif()
 
 install(CODE "file(CREATE_LINK grep ${CMAKE_INSTALL_PREFIX}/bin/egrep SYMBOLIC)")
 install(CODE "file(CREATE_LINK grep ${CMAKE_INSTALL_PREFIX}/bin/rgrep SYMBOLIC)")

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB CMD_SOURCES  CONFIGURE_DEPENDS "*.cpp")
+file(GLOB CMD_SOURCES CONFIGURE_DEPENDS "*.cpp")
 list(APPEND SPECIAL_TARGETS test install)
 list(APPEND REQUIRED_TARGETS
     arp base64 basename cat chmod chown clear comm cp cut date dd df diff dirname dmesg du echo env expr false fgrep
@@ -11,13 +11,20 @@ list(APPEND RECOMMENDED_TARGETS
     nc netstat notify ntpquery open pape passwd pls printf pro shot tar tt unzip zip
 )
 
-# FIXME: Support specifying component dependencies for utilities (e.g. WebSocket for telws)
-
+# when ENABLE_JAKT=ON yakt executables added to the YAKT_TARGETS list won't have the C++ version of the same name built if it exists
+set(JAKT_TARGETS "")
 if (ENABLE_JAKT)
     add_jakt_executable(hello-jakt hello-world.jakt)
+
+    list(APPEND JAKT_TARGETS hello-jakt)
+
+    foreach(JAKT_TARGET IN LISTS JAKT_TARGETS)
+        list(REMOVE_ITEM CMD_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/${JAKT_TARGET}.cpp)
+    endforeach()
 endif()
 
-foreach(CMD_SRC ${CMD_SOURCES})
+# FIXME: Support specifying component dependencies for utilities (e.g. WebSocket for telws)
+foreach(CMD_SRC IN LISTS CMD_SOURCES)
     get_filename_component(CMD_NAME ${CMD_SRC} NAME_WE)
     if (CMD_NAME IN_LIST SPECIAL_TARGETS)
         set(TARGET_NAME "${CMD_NAME}-bin")


### PR DESCRIPTION
- Update cmake to remove rust compiler, current bootstrap cpp will be fetched and built from the jakt repo or local source `JAKT_SOURCE_DIR` if set
- Add `add_jakt_executable` function for building jakt programs
- Add JAKT_TARGETS as a way of specifying cases where a jakt version of an executable should be built in place of a cpp version
