### PR TITLE
LibJS: Check for previous definition of __TRY_OR_*

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
@@ -21,21 +21,23 @@ struct PromiseCapability {
 };
 
 // 27.2.1.1.1 IfAbruptRejectPromise ( value, capability ), https://tc39.es/ecma262/#sec-ifabruptrejectpromise
-#define __TRY_OR_REJECT(global_object, capability, expression, CALL_CHECK)                                                                     \
-    ({                                                                                                                                         \
-        auto _temporary_try_or_reject_result = (expression);                                                                                   \
-        /* 1. If value is an abrupt completion, then */                                                                                        \
-        if (_temporary_try_or_reject_result.is_error()) {                                                                                      \
-            /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                                  \
-            CALL_CHECK(JS::call(global_object, *capability.reject, js_undefined(), *_temporary_try_or_reject_result.release_error().value())); \
-                                                                                                                                               \
-            /* b. Return capability.[[Promise]]. */                                                                                            \
-            return capability.promise;                                                                                                         \
-        }                                                                                                                                      \
-                                                                                                                                               \
-        /* 2. Else if value is a Completion Record, set value to value.[[Value]]. */                                                           \
-        _temporary_try_or_reject_result.release_value();                                                                                       \
-    })
+#ifndef __TRY_OR_REJECT
+#    define __TRY_OR_REJECT(global_object, capability, expression, CALL_CHECK)                                                                     \
+        ({                                                                                                                                         \
+            auto _temporary_try_or_reject_result = (expression);                                                                                   \
+            /* 1. If value is an abrupt completion, then */                                                                                        \
+            if (_temporary_try_or_reject_result.is_error()) {                                                                                      \
+                /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                                  \
+                CALL_CHECK(JS::call(global_object, *capability.reject, js_undefined(), *_temporary_try_or_reject_result.release_error().value())); \
+                                                                                                                                                   \
+                /* b. Return capability.[[Promise]]. */                                                                                            \
+                return capability.promise;                                                                                                         \
+            }                                                                                                                                      \
+                                                                                                                                                   \
+            /* 2. Else if value is a Completion Record, set value to value.[[Value]]. */                                                           \
+            _temporary_try_or_reject_result.release_value();                                                                                       \
+        })
+#endif
 
 #define TRY_OR_REJECT(global_object, capability, expression) \
     __TRY_OR_REJECT(global_object, capability, expression, TRY)
@@ -44,21 +46,23 @@ struct PromiseCapability {
     __TRY_OR_REJECT(global_object, capability, expression, MUST)
 
 // 27.2.1.1.1 IfAbruptRejectPromise ( value, capability ), https://tc39.es/ecma262/#sec-ifabruptrejectpromise
-#define TRY_OR_REJECT_WITH_VALUE(global_object, capability, expression)                                                                 \
-    ({                                                                                                                                  \
-        auto _temporary_try_or_reject_result = (expression);                                                                            \
-        /* 1. If value is an abrupt completion, then */                                                                                 \
-        if (_temporary_try_or_reject_result.is_error()) {                                                                               \
-            /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                           \
-            TRY(JS::call(global_object, *capability.reject, js_undefined(), *_temporary_try_or_reject_result.release_error().value())); \
-                                                                                                                                        \
-            /* b. Return capability.[[Promise]]. */                                                                                     \
-            return Value { capability.promise };                                                                                        \
-        }                                                                                                                               \
-                                                                                                                                        \
-        /* 2. Else if value is a Completion Record, set value to value.[[Value]]. */                                                    \
-        _temporary_try_or_reject_result.release_value();                                                                                \
-    })
+#ifndef TRY_OR_REJECT_WITH_VALUE
+#    define TRY_OR_REJECT_WITH_VALUE(global_object, capability, expression)                                                                 \
+        ({                                                                                                                                  \
+            auto _temporary_try_or_reject_result = (expression);                                                                            \
+            /* 1. If value is an abrupt completion, then */                                                                                 \
+            if (_temporary_try_or_reject_result.is_error()) {                                                                               \
+                /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                           \
+                TRY(JS::call(global_object, *capability.reject, js_undefined(), *_temporary_try_or_reject_result.release_error().value())); \
+                                                                                                                                            \
+                /* b. Return capability.[[Promise]]. */                                                                                     \
+                return Value { capability.promise };                                                                                        \
+            }                                                                                                                               \
+                                                                                                                                            \
+            /* 2. Else if value is a Completion Record, set value to value.[[Value]]. */                                                    \
+            _temporary_try_or_reject_result.release_value();                                                                                \
+        })
+#endif
 
 // 27.2.1.5 NewPromiseCapability ( C ), https://tc39.es/ecma262/#sec-newpromisecapability
 ThrowCompletionOr<PromiseCapability> new_promise_capability(GlobalObject& global_object, Value constructor);


### PR DESCRIPTION
This commit allows users of this file to define their own _TRY_OR* impl.

This is currently needed to work around the fact that msvc doesn't support statement expressions.
Hopefully two `#ifndef`s aren't too intrusive 😅