### PR TITLE
LibWeb: Clip property CSS

### DIFF
--- a/Base/res/html/misc/clip.html
+++ b/Base/res/html/misc/clip.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8"/>
+    <title>CSS Clip test</title>
+    <style>
+        .box1 {
+          background-color: red;
+          height: 300px;
+          width: 400px;
+          position: absolute;
+        }
+        .box2 {
+          background-color: blue;
+          height: 300px;
+          width: 400px;
+          position: absolute;
+          clip: rect(auto, 150px, 8em, -5px);
+          color: white;
+        }
+        .box3 {
+          background-color: purple;
+          height: 300px;
+          width: 400px;
+          position: absolute;
+          clip: rect(0em, 0px, 0px, 0px);
+          top: 350px;
+          color: white;
+        }
+    </style>
+</head>
+<body>
+    <h1>Clip with rect</h1>
+
+    <h2>Clip should look kind of like the American flag</h2>
+    <div class="box1">
+      <div class="box2">
+        <p>Hello this is some text</p>
+        <p>Hello this is some text</p>
+        <p>Hello this is some text</p>
+        <p>Hello this is some text</p>
+      </div>
+    </div>
+
+    <h2 style="margin-top: 350px;">Clip should not be visible</h2>
+    <div class="box3">
+      <p>Hello this is some text</p>
+      <p>Hello this is some text</p>
+      <p>Hello this is some text</p>
+      <p>Hello this is some text</p>
+    </div>
+</body>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -131,6 +131,7 @@
             <li><a href="overflow.html">Overflow</a></li>
             <li><a href="image-rendering.html">image-rendering property</a></li>
             <li><a href="transform.html">Transforms</a></li>
+            <li><a href="clip.html">Clip</a></li>
             <li><h3>Features</h3></li>
             <li><a href="css.html">Basic functionality</a></li>
             <li><a href="colors.html">css colors</a></li>

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -501,6 +501,11 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                             output_numeric_value_check(property_generator, "has_number"sv, "to_number()"sv, Array { "Integer"sv, "Number"sv }, min_value, max_value);
                         } else if (type_name == "percentage") {
                             output_numeric_value_check(property_generator, "is_percentage"sv, "as_percentage().percentage().value()"sv, Array { "Percentage"sv }, min_value, max_value);
+                        } else if (type_name == "rect") {
+                            property_generator.append(R"~~~(
+        if (style_value.has_rect())
+            return true;
+)~~~");
                         } else if (type_name == "resolution") {
                             output_numeric_value_check(property_generator, "is_resolution"sv, "as_resolution().resolution().to_dots_per_pixel()"sv, Array<StringView, 0> {}, min_value, max_value);
                         } else if (type_name == "string") {

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES
     Crypto/Crypto.cpp
     Crypto/SubtleCrypto.cpp
     CSS/Angle.cpp
+    CSS/Clip.cpp
     CSS/CSSConditionRule.cpp
     CSS/CSSGroupingRule.cpp
     CSS/CSSImportRule.cpp

--- a/Userland/Libraries/LibWeb/CSS/Clip.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Clip.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Clip.h"
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+Clip::Clip(Type type, EdgeRect edge_rect)
+    : m_type(type)
+    , m_edge_rect(edge_rect)
+{
+}
+
+Clip::Clip(EdgeRect edge_rect)
+    : m_type(Type::Rect)
+    , m_edge_rect(edge_rect)
+{
+}
+
+Clip Clip::make_auto()
+{
+    return Clip(Type::Auto, EdgeRect { Length::make_auto(), Length::make_auto(), Length::make_auto(), Length::make_auto() });
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/Clip.h
+++ b/Userland/Libraries/LibWeb/CSS/Clip.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+class Clip {
+public:
+    enum class Type {
+        Auto,
+        Rect
+    };
+
+    Clip(Type type, EdgeRect edge_rect);
+    Clip(EdgeRect edge_rect);
+
+    static Clip make_auto();
+
+    bool is_auto() const { return m_type == Type::Auto; }
+    bool is_rect() const { return m_type == Type::Rect; }
+
+    EdgeRect to_rect() const { return m_edge_rect; }
+
+private:
+    Type m_type;
+    EdgeRect m_edge_rect;
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Optional.h>
+#include <LibWeb/CSS/Clip.h>
 #include <LibWeb/CSS/LengthBox.h>
 #include <LibWeb/CSS/StyleValue.h>
 
@@ -19,6 +20,7 @@ public:
     static CSS::FontVariant font_variant() { return CSS::FontVariant::Normal; }
     static CSS::Float float_() { return CSS::Float::None; }
     static CSS::Clear clear() { return CSS::Clear::None; }
+    static CSS::Clip clip() { return CSS::Clip::make_auto(); }
     static CSS::Cursor cursor() { return CSS::Cursor::Auto; }
     static CSS::WhiteSpace white_space() { return CSS::WhiteSpace::Normal; }
     static CSS::TextAlign text_align() { return CSS::TextAlign::Left; }
@@ -130,6 +132,7 @@ class ComputedValues {
 public:
     CSS::Float float_() const { return m_noninherited.float_; }
     CSS::Clear clear() const { return m_noninherited.clear; }
+    CSS::Clip clip() const { return m_noninherited.clip; }
     CSS::Cursor cursor() const { return m_inherited.cursor; }
     CSS::ContentData content() const { return m_noninherited.content; }
     CSS::PointerEvents pointer_events() const { return m_inherited.pointer_events; }
@@ -233,6 +236,7 @@ protected:
     struct {
         CSS::Float float_ { InitialValues::float_() };
         CSS::Clear clear { InitialValues::clear() };
+        CSS::Clip clip { InitialValues::clip() };
         CSS::Display display { InitialValues::display() };
         Optional<int> z_index;
         // FIXME: Store this as flags in a u8.
@@ -292,6 +296,7 @@ public:
     void set_font_weight(int font_weight) { m_inherited.font_weight = font_weight; }
     void set_font_variant(CSS::FontVariant font_variant) { m_inherited.font_variant = font_variant; }
     void set_color(Color const& color) { m_inherited.color = color; }
+    void set_clip(CSS::Clip const& clip) { m_noninherited.clip = clip; }
     void set_content(ContentData const& content) { m_noninherited.content = content; }
     void set_cursor(CSS::Cursor cursor) { m_inherited.cursor = cursor; }
     void set_image_rendering(CSS::ImageRendering value) { m_inherited.image_rendering = value; }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -27,6 +27,7 @@
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/Parser/Rule.h>
 #include <LibWeb/CSS/Selector.h>
+#include <LibWeb/CSS/StyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Dump.h>
 
@@ -3329,6 +3330,46 @@ Optional<Color> Parser::parse_rgb_or_hsl_color(StringView function_name, Vector<
     return {};
 }
 
+// https://www.w3.org/TR/CSS2/visufx.html#value-def-shape
+RefPtr<StyleValue> Parser::parse_rect_value(ComponentValue const& component_value)
+{
+    if (!component_value.is_function())
+        return {};
+    auto& function = component_value.function();
+    if (!function.name().equals_ignoring_case("rect"sv))
+        return {};
+
+    Vector<Length, 4> params;
+    auto tokens = TokenStream { function.values() };
+
+    // In CSS 2.1, the only valid <shape> value is: rect(<top>, <right>, <bottom>, <left>) where
+    // <top> and <bottom> specify offsets from the top border edge of the box, and <right>, and
+    //  <left> specify offsets from the left border edge of the box.
+    for (size_t idx = 0; idx < 4; idx++) {
+        tokens.skip_whitespace();
+
+        // <top>, <right>, <bottom>, and <left> may either have a <length> value or 'auto'.
+        // Negative lengths are permitted.
+        auto current_token = tokens.next_token().token();
+        if (current_token.to_string() == "auto") {
+            params.append(Length::make_auto());
+        } else {
+            auto maybe_length = parse_length(current_token);
+            if (!maybe_length.has_value())
+                return {};
+            params.append(maybe_length.value());
+        }
+        tokens.skip_whitespace();
+
+        // Authors should separate offset values with commas. User agents must support separation
+        // with commas, but may also support separation without commas (but not a combination),
+        // because a previous revision of this specification was ambiguous in this respect.
+        if (tokens.peek_token().is(Token::Type::Comma))
+            tokens.next_token();
+    }
+    return RectStyleValue::create(EdgeRect { params[0], params[1], params[2], params[3] });
+}
+
 Optional<Color> Parser::parse_color(ComponentValue const& component_value)
 {
     // https://www.w3.org/TR/css-color-4/
@@ -5394,6 +5435,9 @@ RefPtr<StyleValue> Parser::parse_css_value(ComponentValue const& component_value
 
     if (auto image = parse_image_value(component_value))
         return image;
+
+    if (auto rect = parse_rect_value(component_value))
+        return rect;
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -328,6 +328,7 @@ private:
     RefPtr<StyleValue> parse_numeric_value(ComponentValue const&);
     RefPtr<StyleValue> parse_identifier_value(ComponentValue const&);
     RefPtr<StyleValue> parse_color_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_rect_value(ComponentValue const&);
     RefPtr<StyleValue> parse_string_value(ComponentValue const&);
     RefPtr<StyleValue> parse_image_value(ComponentValue const&);
     template<typename ParseFunction>

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -475,6 +475,9 @@
     "valid-identifiers": [
       "auto"
     ],
+    "valid-types": [
+      "rect"
+    ],
     "quirks": [
       "unitless-length"
     ]

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -265,6 +265,8 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().box_sizing()));
     case CSS::PropertyID::Clear:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().clear()));
+    case CSS::PropertyID::Clip:
+        return RectStyleValue::create(layout_node.computed_values().clip().to_rect());
     case CSS::PropertyID::Color:
         return ColorStyleValue::create(layout_node.computed_values().color());
     case CSS::PropertyID::Cursor:

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -8,6 +8,7 @@
 #include <AK/TypeCasts.h>
 #include <LibCore/DirIterator.h>
 #include <LibGfx/Font/FontDatabase.h>
+#include <LibWeb/CSS/Clip.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/FontCache.h>
 #include <LibWeb/Layout/BlockContainer.h>
@@ -233,6 +234,14 @@ Optional<CSS::ImageRendering> StyleProperties::image_rendering() const
 {
     auto value = property(CSS::PropertyID::ImageRendering);
     return value_id_to_image_rendering(value->to_identifier());
+}
+
+CSS::Clip StyleProperties::clip() const
+{
+    auto value = property(CSS::PropertyID::Clip);
+    if (!value->has_rect())
+        return CSS::Clip::make_auto();
+    return CSS::Clip(value->as_rect().rect());
 }
 
 Optional<CSS::JustifyContent> StyleProperties::justify_content() const

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -48,6 +48,7 @@ public:
     Color color_or_fallback(CSS::PropertyID, Layout::NodeWithStyle const&, Color fallback) const;
     Optional<CSS::TextAlign> text_align() const;
     Optional<CSS::TextJustify> text_justify() const;
+    CSS::Clip clip() const;
     CSS::Display display() const;
     Optional<CSS::Float> float_() const;
     Optional<CSS::Clear> clear() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -836,6 +836,27 @@ Optional<CalculatedStyleValue::ResolvedType> CalculatedStyleValue::CalcSum::reso
     return resolve_sum_type(type, zero_or_more_additional_calc_products);
 }
 
+// https://www.w3.org/TR/CSS2/visufx.html#value-def-shape
+Gfx::FloatRect EdgeRect::resolved(Layout::Node const& layout_node, Gfx::FloatRect border_box) const
+{
+    // In CSS 2.1, the only valid <shape> value is: rect(<top>, <right>, <bottom>, <left>) where
+    // <top> and <bottom> specify offsets from the top border edge of the box, and <right>, and
+    // <left> specify offsets from the left border edge of the box.
+
+    // The value 'auto' means that a given edge of the clipping region will be the same as the edge
+    // of the element's generated border box (i.e., 'auto' means the same as '0' for <top> and
+    // <left>, the same as the used value of the height plus the sum of vertical padding and border
+    // widths for <bottom>, and the same as the used value of the width plus the sum of the
+    // horizontal padding and border widths for <right>, such that four 'auto' values result in the
+    // clipping region being the same as the element's border box).
+    return Gfx::FloatRect {
+        left_edge.is_auto() ? 0 : left_edge.to_px(layout_node),
+        top_edge.is_auto() ? 0 : top_edge.to_px(layout_node),
+        right_edge.is_auto() ? border_box.width() : right_edge.to_px(layout_node) - left_edge.to_px(layout_node),
+        bottom_edge.is_auto() ? border_box.height() : bottom_edge.to_px(layout_node) - top_edge.to_px(layout_node)
+    };
+}
+
 Optional<CalculatedStyleValue::ResolvedType> CalculatedStyleValue::CalcNumberSum::resolved_type() const
 {
     auto maybe_type = first_calc_number_product->resolved_type();

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -179,6 +179,12 @@ PositionStyleValue const& StyleValue::as_position() const
     return static_cast<PositionStyleValue const&>(*this);
 }
 
+RectStyleValue const& StyleValue::as_rect() const
+{
+    VERIFY(is_rect());
+    return static_cast<RectStyleValue const&>(*this);
+}
+
 ResolutionStyleValue const& StyleValue::as_resolution() const
 {
     VERIFY(is_resolution());
@@ -1483,6 +1489,11 @@ static bool operator==(ColorStopListElement a, ColorStopListElement b)
     return a.transition_hint == b.transition_hint && a.color_stop == b.color_stop;
 }
 
+static bool operator==(EdgeRect a, EdgeRect b)
+{
+    return a.top_edge == b.top_edge && a.right_edge == b.right_edge && a.bottom_edge == b.bottom_edge && a.left_edge == b.left_edge;
+}
+
 bool LinearGradientStyleValue::equals(StyleValue const& other_) const
 {
     if (type() != other_.type())
@@ -1640,6 +1651,19 @@ bool PositionStyleValue::equals(StyleValue const& other) const
         && m_offset_x == typed_other.m_offset_x
         && m_edge_y == typed_other.m_edge_y
         && m_offset_y == typed_other.m_offset_y;
+}
+
+String RectStyleValue::to_string() const
+{
+    return String::formatted("top_edge: {}, right_edge: {}, bottom_edge: {}, left_edge: {}", m_rect.top_edge, m_rect.right_edge, m_rect.bottom_edge, m_rect.left_edge);
+}
+
+bool RectStyleValue::equals(StyleValue const& other) const
+{
+    if (type() != other.type())
+        return false;
+    auto const& typed_other = other.as_rect();
+    return m_rect == typed_other.rect();
 }
 
 bool ResolutionStyleValue::equals(StyleValue const& other) const
@@ -1800,6 +1824,11 @@ NonnullRefPtr<ColorStyleValue> ColorStyleValue::create(Color color)
     }
 
     return adopt_ref(*new ColorStyleValue(color));
+}
+
+NonnullRefPtr<RectStyleValue> RectStyleValue::create(EdgeRect rect)
+{
+    return adopt_ref(*new RectStyleValue(rect));
 }
 
 NonnullRefPtr<LengthStyleValue> LengthStyleValue::create(Length const& length)

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -89,6 +89,7 @@ struct EdgeRect {
     Length right_edge;
     Length bottom_edge;
     Length left_edge;
+    Gfx::FloatRect resolved(Layout::Node const&, Gfx::FloatRect) const;
 };
 
 // FIXME: Find a better place for this helper.

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -84,6 +84,13 @@ struct ColorStopListElement {
     GradientColorStop color_stop;
 };
 
+struct EdgeRect {
+    Length top_edge;
+    Length right_edge;
+    Length bottom_edge;
+    Length left_edge;
+};
+
 // FIXME: Find a better place for this helper.
 inline Gfx::Painter::ScalingMode to_gfx_scaling_mode(CSS::ImageRendering css_value)
 {
@@ -131,6 +138,7 @@ public:
         Overflow,
         Percentage,
         Position,
+        Rect,
         Resolution,
         Shadow,
         String,
@@ -169,6 +177,7 @@ public:
     bool is_overflow() const { return type() == Type::Overflow; }
     bool is_percentage() const { return type() == Type::Percentage; }
     bool is_position() const { return type() == Type::Position; }
+    bool is_rect() const { return type() == Type::Rect; }
     bool is_resolution() const { return type() == Type::Resolution; }
     bool is_shadow() const { return type() == Type::Shadow; }
     bool is_string() const { return type() == Type::String; }
@@ -206,6 +215,7 @@ public:
     OverflowStyleValue const& as_overflow() const;
     PercentageStyleValue const& as_percentage() const;
     PositionStyleValue const& as_position() const;
+    RectStyleValue const& as_rect() const;
     ResolutionStyleValue const& as_resolution() const;
     ShadowStyleValue const& as_shadow() const;
     StringStyleValue const& as_string() const;
@@ -241,6 +251,7 @@ public:
     OverflowStyleValue& as_overflow() { return const_cast<OverflowStyleValue&>(const_cast<StyleValue const&>(*this).as_overflow()); }
     PercentageStyleValue& as_percentage() { return const_cast<PercentageStyleValue&>(const_cast<StyleValue const&>(*this).as_percentage()); }
     PositionStyleValue& as_position() { return const_cast<PositionStyleValue&>(const_cast<StyleValue const&>(*this).as_position()); }
+    RectStyleValue& as_rect() { return const_cast<RectStyleValue&>(const_cast<StyleValue const&>(*this).as_rect()); }
     ResolutionStyleValue& as_resolution() { return const_cast<ResolutionStyleValue&>(const_cast<StyleValue const&>(*this).as_resolution()); }
     ShadowStyleValue& as_shadow() { return const_cast<ShadowStyleValue&>(const_cast<StyleValue const&>(*this).as_shadow()); }
     StringStyleValue& as_string() { return const_cast<StringStyleValue&>(const_cast<StyleValue const&>(*this).as_string()); }
@@ -255,12 +266,14 @@ public:
     virtual bool has_color() const { return false; }
     virtual bool has_identifier() const { return false; }
     virtual bool has_length() const { return false; }
+    virtual bool has_rect() const { return false; }
     virtual bool has_number() const { return false; }
     virtual bool has_integer() const { return false; }
 
     virtual NonnullRefPtr<StyleValue> absolutized(Gfx::IntRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, float font_size, float root_font_size) const;
 
     virtual Color to_color(Layout::NodeWithStyle const&) const { return {}; }
+    virtual EdgeRect to_rect() const { VERIFY_NOT_REACHED(); }
     virtual CSS::ValueID to_identifier() const { return ValueID::Invalid; }
     virtual Length to_length() const { VERIFY_NOT_REACHED(); }
     virtual float to_number() const { return 0; }
@@ -1431,6 +1444,27 @@ private:
 
     Separator m_separator;
     NonnullRefPtrVector<StyleValue> m_values;
+};
+
+class RectStyleValue : public StyleValue {
+public:
+    static NonnullRefPtr<RectStyleValue> create(EdgeRect rect);
+    virtual ~RectStyleValue() override = default;
+
+    EdgeRect rect() const { return m_rect; }
+    virtual String to_string() const override;
+    virtual bool has_rect() const override { return true; }
+    virtual EdgeRect to_rect() const override { return m_rect; }
+    virtual bool equals(StyleValue const& other) const override;
+
+private:
+    explicit RectStyleValue(EdgeRect rect)
+        : StyleValue(Type::Rect)
+        , m_rect(rect)
+    {
+    }
+
+    EdgeRect m_rect;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -75,6 +75,7 @@ class Percentage;
 class PercentageStyleValue;
 class PositionStyleValue;
 class PropertyOwningCSSStyleDeclaration;
+class RectStyleValue;
 class Resolution;
 class ResolutionStyleValue;
 class Screen;

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -32,6 +32,7 @@ class BackgroundStyleValue;
 class BorderRadiusStyleValue;
 class BorderRadiusShorthandStyleValue;
 class BorderStyleValue;
+class Clip;
 class CalculatedStyleValue;
 class ColorStyleValue;
 class ContentStyleValue;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -385,6 +385,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     computed_values.set_flex_grow(computed_style.flex_grow());
     computed_values.set_flex_shrink(computed_style.flex_shrink());
     computed_values.set_order(computed_style.order());
+    computed_values.set_clip(computed_style.clip());
 
     auto justify_content = computed_style.justify_content();
     if (justify_content.has_value())

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -113,7 +113,15 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
     if (!is_visible())
         return;
 
+    auto clip_rect = computed_values().clip();
+    auto should_clip_rect = clip_rect.is_rect() && computed_values().position() == CSS::Position::Absolute;
+
     if (phase == PaintPhase::Background) {
+        if (should_clip_rect) {
+            context.painter().save();
+            auto border_box = absolute_border_box_rect();
+            context.painter().add_clip_rect(clip_rect.to_rect().resolved(Paintable::layout_node(), border_box).to_rounded<int>());
+        }
         paint_background(context);
         paint_box_shadow(context);
     }
@@ -121,6 +129,9 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
     if (phase == PaintPhase::Border) {
         paint_border(context);
     }
+
+    if (phase == PaintPhase::Overlay && should_clip_rect)
+        context.painter().restore();
 
     if (phase == PaintPhase::Overlay && layout_box().dom_node() && layout_box().document().inspected_node() == layout_box().dom_node()) {
         auto content_rect = absolute_rect();


### PR DESCRIPTION
Add ability to parse a Rect when it is passed to the Clip property in CSS, and then later implement it when drawing divs (borders, text, backgrounds).

Fixes a bug I found in aljazeera.com where they use a div with clip: rect(0px, 0px, 0px, 0px) that is supposed to be invisible.

before:
![Screenshot from 2022-07-29 16-13-21](https://user-images.githubusercontent.com/45781926/181815835-364fd93c-5da3-4166-a73d-b09f6961952c.png)
after:
![Screenshot from 2022-07-29 19-56-42](https://user-images.githubusercontent.com/45781926/181817535-0cf6eec4-1387-4a0f-af1a-9d592e7aabb3.png)

