### PR TITLE
LibWeb: Implement "convert line endings to native" algorithm

### DIFF
--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -27,7 +27,7 @@ struct BlobPropertyBag {
 };
 
 [[nodiscard]] ErrorOr<String> convert_line_endings_to_native(String const& string);
-[[nodiscard]] ErrorOr<ByteBuffer> process_blob_parts(Vector<BlobPart> const& blob_parts);
+[[nodiscard]] ErrorOr<ByteBuffer> process_blob_parts(Vector<BlobPart> const& blob_parts, Optional<BlobPropertyBag> const& options = {});
 
 class Blob
     : public RefCounted<Blob>

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -26,6 +26,7 @@ struct BlobPropertyBag {
     Bindings::EndingType endings;
 };
 
+[[nodiscard]] ErrorOr<String> convert_line_endings_to_native(String const& string);
 [[nodiscard]] ErrorOr<ByteBuffer> process_blob_parts(Vector<BlobPart> const& blob_parts);
 
 class Blob

--- a/Userland/Libraries/LibWeb/FileAPI/File.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/File.cpp
@@ -28,7 +28,7 @@ File::File(ByteBuffer byte_buffer, String file_name, String type, i64 last_modif
 DOM::ExceptionOr<NonnullRefPtr<File>> File::create(Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options)
 {
     // 1. Let bytes be the result of processing blob parts given fileBits and options.
-    auto bytes = TRY_OR_RETURN_OOM(process_blob_parts(file_bits));
+    auto bytes = TRY_OR_RETURN_OOM(process_blob_parts(file_bits, static_cast<Optional<BlobPropertyBag> const&>(*options)));
 
     // 2. Let n be the fileName argument to the constructor.
     //    NOTE: Underlying OS filesystems use differing conventions for file name; with constructed files, mandating UTF-16 lessens ambiquity when file names are converted to byte sequences.


### PR DESCRIPTION
This implements the "convert line endings to native" routine from the FileAPI spec.

---

Another option to this routine is the following two lines:
```cpp
string = string.replace("\r\n"sv, "\n"sv, ReplaceMode::All);
string = string.replace("\r"sv, "\n"sv, ReplaceMode::All);
```
I'll let the maintainers decide on that.