### PR TITLE
LibWeb+Meta: Fix some :catdoggone: web APIs

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLParser.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLParser.cpp
@@ -910,6 +910,9 @@ Interface& Parser::parse()
                 interface.stringifier_attribute = mixin->stringifier_attribute;
                 interface.has_stringifier = true;
             }
+
+            if (mixin->has_unscopable_member)
+                interface.has_unscopable_member = true;
         }
     }
 

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.idl
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.idl
@@ -16,3 +16,5 @@ interface CharacterData : Node {
     readonly attribute Element? nextElementSibling;
     readonly attribute Element? previousElementSibling;
 };
+
+CharacterData includes ChildNode;

--- a/Userland/Libraries/LibWeb/DOM/ChildNode.idl
+++ b/Userland/Libraries/LibWeb/DOM/ChildNode.idl
@@ -1,5 +1,3 @@
-#import <DOM/Node.idl>
-
 // https://dom.spec.whatwg.org/#childnode
 interface mixin ChildNode {
     [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
@@ -7,7 +5,3 @@ interface mixin ChildNode {
     [CEReactions, Unscopable] undefined replaceWith((Node or DOMString)... nodes);
     [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
 };
-
-DocumentType includes ChildNode;
-Element includes ChildNode;
-CharacterData includes ChildNode;

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -100,4 +100,5 @@ interface Document : Node {
     [NewObject] TreeWalker createTreeWalker(Node root, optional unsigned long whatToShow = 0xFFFFFFFF, optional NodeFilter? filter = null);
 };
 
+Document includes ParentNode;
 Document includes GlobalEventHandlers;

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
@@ -10,3 +10,5 @@ interface DocumentFragment : Node {
 
     Element? getElementById(DOMString id);
 };
+
+DocumentFragment includes ParentNode;

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -53,3 +53,7 @@ interface Element : Node {
     readonly attribute long clientWidth;
     readonly attribute long clientHeight;
 };
+
+Element includes ParentNode;
+Element includes ChildNode;
+Element includes InnerHTML;

--- a/Userland/Libraries/LibWeb/DOM/InnerHTML.idl
+++ b/Userland/Libraries/LibWeb/DOM/InnerHTML.idl
@@ -2,6 +2,3 @@
 interface mixin InnerHTML {
     [LegacyNullToEmptyString, CEReactions] attribute DOMString innerHTML;
 };
-
-Element includes InnerHTML;
-ShadowRoot includes InnerHTML;

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.idl
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.idl
@@ -1,4 +1,3 @@
-#import <DOM/Element.idl>
 #import <DOM/HTMLCollection.idl>
 #import <DOM/Node.idl>
 
@@ -16,7 +15,3 @@ interface mixin ParentNode {
     Element? querySelector(DOMString selectors);
     [NewObject] NodeList querySelectorAll(DOMString selectors);
 };
-
-Document includes ParentNode;
-DocumentFragment includes ParentNode;
-Element includes ParentNode;

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
@@ -11,5 +11,7 @@ interface ShadowRoot : DocumentFragment {
     // FIXME: attribute EventHandler onslotchange;
 };
 
+ShadowRoot includes InnerHTML;
+
 enum ShadowRootMode { "open", "closed" };
 enum SlotAssignmentMode { "manual", "named" };


### PR DESCRIPTION
The changes from #14716 inadvertently removed APIs such as `document.querySelectorAll()`. 
This seemed to because the IDL generator will silently fail if it encounters circular `#import`s and just did not add the methods. 

There was also an issue with `has_unscopable_member` not being propagated down from mixins, but this was first masked by the the circular imports.