### PR TITLE
LibGfx: Compress PNGs with a better compression level

### DIFF
--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -250,7 +250,7 @@ void PNGWriter::add_IDAT_chunk(Gfx::Bitmap const& bitmap)
         uncompressed_block_data.append(best_filter.buffer);
     }
 
-    auto maybe_zlib_buffer = Compress::ZlibCompressor::compress_all(uncompressed_block_data);
+    auto maybe_zlib_buffer = Compress::ZlibCompressor::compress_all(uncompressed_block_data, Compress::ZlibCompressionLevel::Best);
     if (!maybe_zlib_buffer.has_value()) {
         // FIXME: Handle errors.
         VERIFY_NOT_REACHED();


### PR DESCRIPTION
While for a general purpose encoder a good balance between compression speed and size by default is important, in case of PNG it don't matter that much, as it was said in #14594.

Also note that it's not the best we can have. We use zlib's compression level, which has a range of 0-4, while our deflate implementation ranges from 0 to 5.