### PR TITLE
LibWeb: Make <th> elements bold by default

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -187,6 +187,10 @@ th {
     display: table-cell;
 }
 
+th {
+    font-weight: bold;
+}
+
 col {
     display: table-column;
 }


### PR DESCRIPTION
a separate rule, because putting it together with `<strong>` and `<b>` didn’t seem right.

