### PR TITLE
LibWeb: Abstractify image style values and their painting

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -95,6 +95,11 @@
         .grad-webkit {
             background-image: -webkit-linear-gradient(top right, yellow, black, yellow, black);
         }
+
+        .grad-15 {
+            background-image: linear-gradient(to top left, red, green, blue);
+            background-size: 30px 30px;
+        }
     </style>
   </head>
   <body>
@@ -120,6 +125,8 @@
     <div class="rect grad-12"></div>
     <div class="rect grad-13"></div>
     <div class="rect grad-14"></div>
+    <b>With background size:</b><br>
+    <div class="rect grad-15"></div>
     <b>A webkit gradient</b><br>
     <div class="box grad-webkit"></div>
   </body>

--- a/Base/res/html/misc/lists.html
+++ b/Base/res/html/misc/lists.html
@@ -68,6 +68,12 @@
         <li>Another entry</li>
     </ul>
 
+    <p>list-style: linear-gradient(to top left, red, green)</p>
+    <ul style="list-style: linear-gradient(to top left, red, green);">
+        <li>Entry one</li>
+        <li>Another entry</li>
+    </ul>
+
     <p>list-style: inside url(list-item.png)</p>
     <ul style="list-style: inside disc url(custom-list-item.png);">
         <li>Entry one</li>

--- a/Base/res/html/misc/progressbar.html
+++ b/Base/res/html/misc/progressbar.html
@@ -33,6 +33,12 @@
     <br>
     <progress id="custom-progress" value="25" max="100"></progress>
     <br>
+    <br>
+    <em>A super fancy progress bar done purely in CSS</em>
+    <br>
+    <br>
+    <progress id="really-fancy-progress" value="25" max="100"></progress>
+    <br>
 
     <style>
         body {
@@ -57,6 +63,34 @@
         #custom-progress::-webkit-progress-value {
             border-radius: 10px;
             background-color: #ff3863d2;
+        }
+
+        /* The following example is taken from https://css-tricks.com/html5-progress-element/ */
+
+        #really-fancy-progress[value] {
+            appearance: none;
+            width: 500px;
+            height: 40px;
+        }
+
+        #really-fancy-progress[value]::-webkit-progress-bar {
+            background-color: #eee;
+            border-radius: 2px;
+            /* FIXME: Should be an inset shadow (not supported yet) */
+            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25);
+        }
+
+        #really-fancy-progress[value]::-webkit-progress-value {
+            background-image:
+                -webkit-linear-gradient(-45deg,
+                                        transparent 33%, rgba(0, 0, 0, .1) 33%,
+                                        rgba(0,0, 0, .1) 66%, transparent 66%),
+                -webkit-linear-gradient(top,
+                                        rgba(255, 255, 255, .25),
+                                        rgba(0, 0, 0, .25)),
+                -webkit-linear-gradient(left, #09c, #f44);
+            border-radius: 2px;
+            background-size: 70px 40px, 100% 100%, 100% 100%;
         }
     </style>
 

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -164,6 +164,12 @@ public:
 
     [[nodiscard]] String to_string() const;
 
+    template<Integral I>
+    [[nodiscard]] Size<I> to_rounded() const
+    {
+        return Size<I>(round_to<I>(width()), round_to<I>(height()));
+    }
+
 private:
     T m_width { 0 };
     T m_height { 0 };

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -63,7 +63,7 @@ public:
 };
 
 struct BackgroundLayerData {
-    RefPtr<CSS::StyleValue> background_image { nullptr };
+    RefPtr<CSS::AbstractImageStyleValue> background_image { nullptr };
     CSS::BackgroundAttachment attachment { CSS::BackgroundAttachment::Scroll };
     CSS::BackgroundBox origin { CSS::BackgroundBox::PaddingBox };
     CSS::BackgroundBox clip { CSS::BackgroundBox::BorderBox };

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -15,12 +15,19 @@
 #include <LibWeb/Loader/LoadRequest.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/GradientPainting.h>
 
 namespace Web::CSS {
 
 StyleValue::StyleValue(Type type)
     : m_type(type)
 {
+}
+
+AbstractImageStyleValue const& StyleValue::as_abstract_image() const
+{
+    VERIFY(is_abstract_image());
+    return static_cast<AbstractImageStyleValue const&>(*this);
 }
 
 AngleStyleValue const& StyleValue::as_angle() const
@@ -1395,12 +1402,12 @@ Color IdentifierStyleValue::to_color(Layout::NodeWithStyle const& node) const
 }
 
 ImageStyleValue::ImageStyleValue(AK::URL const& url)
-    : StyleValue(Type::Image)
+    : AbstractImageStyleValue(Type::Image)
     , m_url(url)
 {
 }
 
-void ImageStyleValue::load_bitmap(DOM::Document& document)
+void ImageStyleValue::load_any_resources(DOM::Document& document)
 {
     if (m_bitmap)
         return;
@@ -1430,6 +1437,26 @@ bool ImageStyleValue::equals(StyleValue const& other) const
     if (type() != other.type())
         return false;
     return m_url == other.as_image().m_url;
+}
+
+Optional<int> ImageStyleValue::natural_width() const
+{
+    if (m_bitmap)
+        return m_bitmap->width();
+    return {};
+}
+
+Optional<int> ImageStyleValue::natural_height() const
+{
+    if (m_bitmap)
+        return m_bitmap->height();
+    return {};
+}
+
+void ImageStyleValue::paint(PaintContext& context, Gfx::IntRect const& dest_rect) const
+{
+    if (m_bitmap)
+        context.painter().draw_scaled_bitmap(dest_rect, *m_bitmap, m_bitmap->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
 }
 
 String LinearGradientStyleValue::to_string() const
@@ -1533,10 +1560,10 @@ bool LinearGradientStyleValue::equals(StyleValue const& other_) const
     return true;
 }
 
-float LinearGradientStyleValue::angle_degrees(Gfx::FloatRect const& gradient_rect) const
+float LinearGradientStyleValue::angle_degrees(Gfx::FloatSize const& gradient_size) const
 {
     auto corner_angle_degrees = [&] {
-        return static_cast<float>(atan2(gradient_rect.height(), gradient_rect.width())) * 180 / AK::Pi<float>;
+        return static_cast<float>(atan2(gradient_size.height(), gradient_size.width())) * 180 / AK::Pi<float>;
     };
     return m_direction.visit(
         [&](SideOrCorner side_or_corner) {
@@ -1570,6 +1597,17 @@ float LinearGradientStyleValue::angle_degrees(Gfx::FloatRect const& gradient_rec
         [&](Angle const& angle) {
             return angle.to_degrees();
         });
+}
+
+void LinearGradientStyleValue::resolve_for_size(Layout::Node const& node, Gfx::FloatSize const& size) const
+{
+    m_resolved_data = Painting::resolve_linear_gradient_data(node, size, *this);
+}
+
+void LinearGradientStyleValue::paint(PaintContext& context, Gfx::IntRect const& dest_rect) const
+{
+    VERIFY(m_resolved_data.has_value());
+    Painting::paint_linear_gradient(context, dest_rect, *m_resolved_data);
 }
 
 bool InheritStyleValue::equals(StyleValue const& other) const

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -23,6 +23,7 @@ class SubtleCrypto;
 }
 
 namespace Web::CSS {
+class AbstractImageStyleValue;
 class Angle;
 class AnglePercentage;
 class AngleStyleValue;
@@ -339,6 +340,7 @@ class StackingContext;
 class TextPaintable;
 struct BorderRadiusData;
 struct BorderRadiiData;
+struct LinearGradientData;
 }
 
 namespace Web::RequestIdleCallback {

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -765,9 +765,9 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
 
     int image_width = 0;
     int image_height = 0;
-    if (auto const* list_style_image = marker.list_style_image_bitmap()) {
-        image_width = list_style_image->rect().width();
-        image_height = list_style_image->rect().height();
+    if (auto const* list_style_image = marker.list_style_image()) {
+        image_width = list_style_image->natural_width().value_or(0);
+        image_height = list_style_image->natural_height().value_or(0);
     }
 
     int default_marker_width = max(4, marker.font().glyph_height() - 4);

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -51,11 +51,6 @@ ListItemMarkerBox::ListItemMarkerBox(DOM::Document& document, CSS::ListStyleType
 
 ListItemMarkerBox::~ListItemMarkerBox() = default;
 
-Gfx::Bitmap const* ListItemMarkerBox::list_style_image_bitmap() const
-{
-    return list_style_image() ? list_style_image()->bitmap() : nullptr;
-}
-
 RefPtr<Painting::Paintable> ListItemMarkerBox::create_paintable() const
 {
     return Painting::MarkerPaintable::create(*this);

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.h
@@ -16,7 +16,6 @@ public:
     explicit ListItemMarkerBox(DOM::Document&, CSS::ListStyleType, size_t index, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~ListItemMarkerBox() override;
 
-    Gfx::Bitmap const* list_style_image_bitmap() const;
     String const& text() const { return m_text; }
 
     virtual RefPtr<Painting::Paintable> create_paintable() const override;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -248,11 +248,9 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
             CSS::BackgroundLayerData layer;
 
             if (auto image_value = value_for_layer(images, layer_index); image_value) {
-                if (image_value->is_image()) {
-                    image_value->as_image().load_bitmap(document());
-                    layer.background_image = image_value;
-                } else if (image_value->is_linear_gradient()) {
-                    layer.background_image = image_value;
+                if (image_value->is_abstract_image()) {
+                    layer.background_image = image_value->as_abstract_image();
+                    layer.background_image->load_any_resources(document());
                 }
             }
 
@@ -461,9 +459,9 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
         computed_values.set_list_style_type(list_style_type.value());
 
     auto list_style_image = computed_style.property(CSS::PropertyID::ListStyleImage);
-    if (list_style_image->is_image()) {
-        m_list_style_image = list_style_image->as_image();
-        m_list_style_image->load_bitmap(document());
+    if (list_style_image->is_abstract_image()) {
+        m_list_style_image = list_style_image->as_abstract_image();
+        m_list_style_image->load_any_resources(document());
     }
 
     computed_values.set_color(computed_style.color_or_fallback(CSS::PropertyID::Color, *this, CSS::InitialValues::color()));

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -166,7 +166,7 @@ public:
     Gfx::Font const& font() const { return *m_font; }
     float line_height() const { return m_line_height; }
     Vector<CSS::BackgroundLayerData> const& background_layers() const { return computed_values().background_layers(); }
-    const CSS::ImageStyleValue* list_style_image() const { return m_list_style_image; }
+    const CSS::AbstractImageStyleValue* list_style_image() const { return m_list_style_image; }
 
     NonnullRefPtr<NodeWithStyle> create_anonymous_wrapper() const;
 
@@ -180,7 +180,7 @@ private:
     CSS::ComputedValues m_computed_values;
     RefPtr<Gfx::Font> m_font;
     float m_line_height { 0 };
-    RefPtr<CSS::ImageStyleValue> m_list_style_image;
+    RefPtr<CSS::AbstractImageStyleValue> m_list_style_image;
 };
 
 class NodeWithStyleAndBoxModelMetrics : public NodeWithStyle {

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.h
@@ -9,7 +9,6 @@
 #include <AK/Span.h>
 #include <AK/Vector.h>
 #include <LibGfx/Color.h>
-#include <LibWeb/CSS/StyleValue.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/PaintContext.h>
 
@@ -27,7 +26,7 @@ struct LinearGradientData {
     ColorStopList color_stops;
 };
 
-LinearGradientData resolve_linear_gradient_data(Layout::Node const&, Gfx::FloatRect const&, CSS::LinearGradientStyleValue const&);
+LinearGradientData resolve_linear_gradient_data(Layout::Node const&, Gfx::FloatSize const&, CSS::LinearGradientStyleValue const&);
 
 void paint_linear_gradient(PaintContext&, Gfx::IntRect const&, LinearGradientData const&);
 

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -33,16 +33,24 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
 
     auto enclosing = enclosing_int_rect(absolute_rect());
 
-    if (auto const* list_style_image = layout_box().list_style_image_bitmap()) {
-        context.painter().blit(enclosing.location(), *list_style_image, list_style_image->rect());
+    int marker_width = (int)enclosing.height() / 2;
+
+    if (auto const* list_style_image = layout_box().list_style_image()) {
+        Gfx::IntRect image_rect {
+            0, 0,
+            list_style_image->natural_width().value_or(marker_width),
+            list_style_image->natural_height().value_or(marker_width)
+        };
+        image_rect.center_within(enclosing);
+        list_style_image->resolve_for_size(layout_box(), image_rect.size().to_type<float>());
+        list_style_image->paint(context, image_rect);
         return;
     }
 
-    auto color = computed_values().color();
-
-    int marker_width = (int)enclosing.height() / 2;
     Gfx::IntRect marker_rect { 0, 0, marker_width, marker_width };
     marker_rect.center_within(enclosing);
+
+    auto color = computed_values().color();
 
     Gfx::AntiAliasingPainter aa_painter { context.painter() };
 


### PR DESCRIPTION
This is my attempt at implementing @AtkinsSJ suggestion from #14564 

> One issue I'm not sure about, which doesn't have to be fixed here, is how to deal with gradients being allowed anywhere an image is. As written, you'd have to manually enable gradients for each property with specific painting code for them, which feels awkward. Maybe ImageStyleValue and LinearGradientStyleValue can both implement some interface for getting their inherent dimensions and painting them into a rectangle.

With this change we get `linear-gradient`s working with the various background sizing/positioning properties and even working as list-maker images for _mostly_ free :^).
[It's not quite free since there's a few little rough edges]

Here's a demo of some cool stuff that now works:

This [css-tricks](https://css-tricks.com/html5-progress-element/) progress bar demo (this is all CSS, `background-size` + `linear-gradient` + `background-repeat`, no hardcoded images):
![image](https://user-images.githubusercontent.com/11597044/182004773-77174d0f-ccd5-4656-accb-31dcd05d58bf.png)

`linear-gradient` list markers :partying_face: 
![image](https://user-images.githubusercontent.com/11597044/182004812-85ed5e28-e60e-4e16-862b-0e8cddcf91f5.png)

`linear-gradient`  + `background-size`
![image](https://user-images.githubusercontent.com/11597044/182004822-5ef1b7a5-9abc-4abd-8305-52a8851b756e.png)

