### PR TITLE
LibJS: Add noreturn attribute to functions that doesn't return

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -79,6 +79,11 @@
 #endif
 #define NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
 
+#ifdef NORETURN
+#    undef NORETURN
+#endif
+#define NORETURN __attribute__((noreturn))
+
 #ifdef NAKED
 #    undef NAKED
 #endif

--- a/Userland/Libraries/LibJS/CyclicModule.cpp
+++ b/Userland/Libraries/LibJS/CyclicModule.cpp
@@ -416,14 +416,14 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_evaluation(VM& vm, Vector<Modu
     return index;
 }
 
-ThrowCompletionOr<void> CyclicModule::initialize_environment(VM&)
+NORETURN ThrowCompletionOr<void> CyclicModule::initialize_environment(VM&)
 {
     // Note: In ecma262 this is never called on a cyclic module only on SourceTextModules.
     //       So this check is to make sure we don't accidentally call this.
     VERIFY_NOT_REACHED();
 }
 
-ThrowCompletionOr<void> CyclicModule::execute_module(VM&, Optional<PromiseCapability>)
+NORETURN ThrowCompletionOr<void> CyclicModule::execute_module(VM&, Optional<PromiseCapability>)
 {
     // Note: In ecma262 this is never called on a cyclic module only on SourceTextModules.
     //       So this check is to make sure we don't accidentally call this.

--- a/Userland/Libraries/LibJS/CyclicModule.h
+++ b/Userland/Libraries/LibJS/CyclicModule.h
@@ -37,8 +37,8 @@ protected:
     virtual ThrowCompletionOr<u32> inner_module_linking(VM& vm, Vector<Module*>& stack, u32 index) override;
     virtual ThrowCompletionOr<u32> inner_module_evaluation(VM& vm, Vector<Module*>& stack, u32 index) override;
 
-    virtual ThrowCompletionOr<void> initialize_environment(VM& vm);
-    virtual ThrowCompletionOr<void> execute_module(VM& vm, Optional<PromiseCapability> capability = {});
+    NORETURN virtual ThrowCompletionOr<void> initialize_environment(VM& vm);
+    NORETURN virtual ThrowCompletionOr<void> execute_module(VM& vm, Optional<PromiseCapability> capability = {});
 
     void execute_async_module(VM& vm);
     void gather_available_ancestors(Vector<CyclicModule*>& exec_list);

--- a/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.cpp
@@ -60,7 +60,7 @@ ThrowCompletionOr<bool> ModuleEnvironment::has_binding(FlyString const& name, Op
 }
 
 // 9.1.1.5.2 DeleteBinding ( N ), https://tc39.es/ecma262/#sec-module-environment-records-deletebinding-n
-ThrowCompletionOr<bool> ModuleEnvironment::delete_binding(GlobalObject&, FlyString const&)
+NORETURN ThrowCompletionOr<bool> ModuleEnvironment::delete_binding(GlobalObject&, FlyString const&)
 {
     // The DeleteBinding concrete method of a module Environment Record is never used within this specification.
     VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.h
@@ -24,7 +24,7 @@ public:
     //       GetBindingValue, DeleteBinding, HasThisBinding and GetThisBinding.
     //       In addition, module Environment Records support the methods listed in Table 24.
     virtual ThrowCompletionOr<Value> get_binding_value(GlobalObject&, FlyString const& name, bool strict) override;
-    virtual ThrowCompletionOr<bool> delete_binding(GlobalObject&, FlyString const& name) override;
+    virtual NORETURN ThrowCompletionOr<bool> delete_binding(GlobalObject&, FlyString const& name) override;
     virtual bool has_this_binding() const final { return true; }
     virtual ThrowCompletionOr<Value> get_this_binding(GlobalObject&) const final;
     ThrowCompletionOr<void> create_import_binding(FlyString name, Module* module, FlyString binding_name);

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -229,7 +229,7 @@ ThrowCompletionOr<Value> NativeFunction::call()
     return m_native_function(vm(), global_object());
 }
 
-ThrowCompletionOr<Object*> NativeFunction::construct(FunctionObject&)
+NORETURN ThrowCompletionOr<Object*> NativeFunction::construct(FunctionObject&)
 {
     // Needs to be overridden if [[Construct]] is needed.
     VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.h
@@ -34,7 +34,7 @@ public:
     // Used for [[Call]] / [[Construct]]'s "...result of evaluating F in a manner that conforms to the specification of F".
     // Needs to be overridden by all NativeFunctions without an m_native_function.
     virtual ThrowCompletionOr<Value> call();
-    virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target);
+    NORETURN virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target);
 
     virtual FlyString const& name() const override { return m_name; };
     virtual bool is_strict_mode() const override;

--- a/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
@@ -71,7 +71,7 @@ ThrowCompletionOr<void> ObjectEnvironment::create_mutable_binding(GlobalObject&,
 }
 
 // 9.1.1.2.3 CreateImmutableBinding ( N, S ), https://tc39.es/ecma262/#sec-object-environment-records-createimmutablebinding-n-s
-ThrowCompletionOr<void> ObjectEnvironment::create_immutable_binding(GlobalObject&, FlyString const&, bool)
+NORETURN ThrowCompletionOr<void> ObjectEnvironment::create_immutable_binding(GlobalObject&, FlyString const&, bool)
 {
     // "The CreateImmutableBinding concrete method of an object Environment Record is never used within this specification."
     VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
@@ -22,7 +22,7 @@ public:
 
     virtual ThrowCompletionOr<bool> has_binding(FlyString const& name, Optional<size_t>* = nullptr) const override;
     virtual ThrowCompletionOr<void> create_mutable_binding(GlobalObject&, FlyString const& name, bool can_be_deleted) override;
-    virtual ThrowCompletionOr<void> create_immutable_binding(GlobalObject&, FlyString const& name, bool strict) override;
+    NORETURN virtual ThrowCompletionOr<void> create_immutable_binding(GlobalObject&, FlyString const& name, bool strict) override;
     virtual ThrowCompletionOr<void> initialize_binding(GlobalObject&, FlyString const& name, Value) override;
     virtual ThrowCompletionOr<void> set_mutable_binding(GlobalObject&, FlyString const& name, Value, bool strict) override;
     virtual ThrowCompletionOr<Value> get_binding_value(GlobalObject&, FlyString const& name, bool strict) override;


### PR DESCRIPTION
A few LibJS functions doesn't actually return anything which causes
some compilers to error out. This commit adds the gcc noreturn
attribute to them.