### PR TITLE
Ports/bzip2: Set AR and RANLIB

### DIFF
--- a/Ports/bzip2/package.sh
+++ b/Ports/bzip2/package.sh
@@ -7,9 +7,9 @@ makeopts=("bzip2")
 installopts=("PREFIX=${SERENITY_INSTALL_ROOT}/usr/local")
 
 build() {
-    run make CC="${CC}" "${makeopts[@]}" bzip2
+    run make CC="${CC}" AR="${AR}" RANLIB="${RANLIB}" "${makeopts[@]}" bzip2
 }
 
 install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} CC="${CC}" "${installopts[@]}" install
+    run make DESTDIR=${SERENITY_INSTALL_ROOT} CC="${CC}" AR="${AR}" RANLIB="${RANLIB}" "${installopts[@]}" install
 }


### PR DESCRIPTION
bzip2's Makefile uses the '=' operator to set these variables so they
cannot be overridden by just the environment variables; we have to pass
them on the command line.

This change ensures that the system ar/ranlib are no longer used, so the
port can be build on macOS or non-x86 Linux.