### PR TITLE
Documentation: Fix VSCodeConfigurations.md c_cpp_properties.json typo

### DIFF
--- a/Documentation/VSCodeConfiguration.md
+++ b/Documentation/VSCodeConfiguration.md
@@ -59,9 +59,9 @@ These extensions can be used as-is, but you need to point them to the custom Ser
             "intelliSenseMode": "linux-gcc-x86",
             "compileCommands": "Build/i686/compile_commands.json",
             "compilerArgs": [
-                "-wall",
-                "-wextra",
-                "-werror"
+                "-Wall",
+                "-Wextra",
+                "-Werror"
             ],
             "browse": {
                 "path": [


### PR DESCRIPTION
Fixes #14750.

The current `compilerArgs` will cause an error when VSCode's C++ extension
queries the compiler for defaults, causing it to revert to the system's
default compiler.