### PR TITLE
LibWeb: Mark page as loaded on error

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -281,6 +281,9 @@ void FrameLoader::load_error_page(const AK::URL& failed_url, String const& error
             generator.set("error", escape_html_entities(error));
             generator.append(data);
             load_html(generator.as_string_view(), failed_url);
+
+            if (auto* page = browsing_context().page())
+                page->client().page_did_finish_loading(s_error_page_url);
         },
         [](auto& error, auto) {
             dbgln("Failed to load error page: {}", error);


### PR DESCRIPTION
When a page fails to load and we show the error page, we now notify the page that loading has completed. This allows the UI to be updated including things such as removing the "loading" message from the bottom bar.

This fixes an issue where navigating to a page such as https://mock.codes/503 could hang on "Loading mock.codes" indefinitely even when the error page has finished loading.

<img width="523" alt="image" src="https://user-images.githubusercontent.com/6097064/182255740-f3d384ad-be9d-4ee3-8927-243ae5d5c374.png">


`page_did_finish_loading` along with the error page URL felt like a good combination here. However, this is my first PR so open to suggestions if there's a better way to handle this.