### PR TITLE
Run: Trigger on escape key only once

### DIFF
--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -71,7 +71,7 @@ RunWindow::RunWindow()
 
 void RunWindow::event(Core::Event& event)
 {
-    if (event.type() == GUI::Event::KeyUp || event.type() == GUI::Event::KeyDown) {
+    if (event.type() == GUI::Event::KeyDown) {
         auto& key_event = static_cast<GUI::KeyEvent&>(event);
         if (key_event.key() == Key_Escape) {
             // Escape key pressed, close dialog


### PR DESCRIPTION
When you press the escape key in the Browse dialog, the key down event closes the dialog while the key up event then closes the Run window.

Prevent this by only listening to key down events.