### PR TITLE
LibMarkdown: Support specifying image sizes

### DIFF
--- a/Tests/LibMarkdown/CMakeLists.txt
+++ b/Tests/LibMarkdown/CMakeLists.txt
@@ -2,6 +2,7 @@ include(commonmark_spec)
 
 set(TEST_SOURCES
     TestCommonmark.cpp
+    TestImageSizeExtension.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibMarkdown/TestImageSizeExtension.cpp
+++ b/Tests/LibMarkdown/TestImageSizeExtension.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Array.h>
+#include <LibMarkdown/Document.h>
+#include <LibTest/TestCase.h>
+
+struct TestCase {
+    StringView markdown;
+    StringView expected_html;
+};
+
+static constexpr Array image_size_tests {
+    // No image size:
+    TestCase { .markdown = "![](foo.png)"sv, .expected_html = R"(<p><img src="foo.png" alt="" ></p>)"sv },
+    // Only width given:
+    TestCase { .markdown = "![](foo.png =100x)"sv, .expected_html = R"(<p><img src="foo.png" style="width: 100px;" alt="" ></p>)"sv },
+    // Only height given:
+    TestCase { .markdown = "![](foo.png =x200)"sv, .expected_html = R"(<p><img src="foo.png" style="height: 200px;" alt="" ></p>)"sv },
+    // Both width and height given
+    TestCase { .markdown = "![](foo.png =50x25)"sv, .expected_html = R"(<p><img src="foo.png" style="width: 50px;height: 25px;" alt="" ></p>)"sv },
+    // Size contains invalid width
+    TestCase { .markdown = "![](foo.png =1oox50)"sv, .expected_html = R"(<p><img src="foo.png =1oox50" alt="" ></p>)"sv },
+    // Size contains invalid height
+    TestCase { .markdown = "![](foo.png =900xfour)"sv, .expected_html = R"(<p><img src="foo.png =900xfour" alt="" ></p>)"sv },
+};
+
+TEST_CASE(test_image_size_markdown_extension)
+{
+    for (auto const& test_case : image_size_tests) {
+        auto document = Markdown::Document::parse(test_case.markdown);
+        auto raw_rendered_html = document->render_to_inline_html();
+        auto rendered_html = StringView(raw_rendered_html).trim_whitespace();
+        EXPECT_EQ(rendered_html, test_case.expected_html);
+    }
+}

--- a/Userland/Libraries/LibMarkdown/Text.h
+++ b/Userland/Libraries/LibMarkdown/Text.h
@@ -97,14 +97,22 @@ public:
         bool is_image;
         NonnullOwnPtr<Node> text;
         String href;
+        Optional<int> image_width;
+        Optional<int> image_height;
 
-        LinkNode(bool is_image, NonnullOwnPtr<Node> text, String href)
+        LinkNode(bool is_image, NonnullOwnPtr<Node> text, String href, Optional<int> image_width, Optional<int> image_height)
             : is_image(is_image)
             , text(move(text))
             , href(move(href))
+            , image_width(image_width)
+            , image_height(image_height)
         {
         }
 
+        bool has_image_dimensions() const
+        {
+            return image_width.has_value() || image_height.has_value();
+        }
         virtual void render_to_html(StringBuilder& builder) const override;
         virtual void render_for_terminal(StringBuilder& builder) const override;
         virtual size_t terminal_length() const override;


### PR DESCRIPTION
This PR implements the CommonMark [image size extension](https://github.com/commonmark/commonmark-spec/wiki/Deployed-Extensions#image-size).

With this you can specify:

- both width and height: `![](foo.png =100x200)`
- the width only: `![](foo.png =100x)`
- the height only: ` ![](foo.png =x200)`

The size is in pixels.

(This was motivated by #14757)



