### PR TITLE
LibJS: Only coerce value once in BigInt constructor

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -52,8 +52,8 @@ ThrowCompletionOr<Value> BigIntConstructor::call()
     if (primitive.is_number())
         return TRY(number_to_bigint(global_object, primitive));
 
-    // 4. Otherwise, return ? ToBigInt(value).
-    return TRY(value.to_bigint(global_object));
+    // 4. Otherwise, return ? ToBigInt(prim).
+    return TRY(primitive.to_bigint(global_object));
 }
 
 // 21.2.1.1 BigInt ( value ), https://tc39.es/ecma262/#sec-bigint-constructor-number-value

--- a/Userland/Libraries/LibJS/Tests/builtins/BigInt/BigInt.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/BigInt/BigInt.js
@@ -63,6 +63,20 @@ describe("correct behavior", () => {
         expect(BigInt("0X10")).toBe(16n);
         expect(BigInt(`0x${"f".repeat(25)}`)).toBe(1267650600228229401496703205375n);
     });
+
+    test("only coerces value once", () => {
+        let calls = 0;
+        const value = {
+            [Symbol.toPrimitive]() {
+                expect(calls).toBe(0);
+                ++calls;
+                return "123";
+            },
+        };
+
+        expect(BigInt(value)).toEqual(123n);
+        expect(calls).toBe(1);
+    });
 });
 
 describe("errors", () => {


### PR DESCRIPTION
See https://github.com/tc39/ecma262/pull/2812.

This isn't merged yet but a test262 test was added and it seems reasonable so I assume it has been accepted.