### PR TITLE
DisplaySettings: Capitalize `s` in screen settings

### DIFF
--- a/Userland/Applications/DisplaySettings/MonitorSettings.gml
+++ b/Userland/Applications/DisplaySettings/MonitorSettings.gml
@@ -35,7 +35,7 @@
         layout: @GUI::VerticalBoxLayout {
             margins: [14, 14, 4]
         }
-        title: "Screen settings"
+        title: "Screen Settings"
 
         @GUI::Widget {
             preferred_height: "fit"


### PR DESCRIPTION
This is done to match the capitalization on other tabs.