### PR TITLE
Kernel: Explicitly check arch

### DIFF
--- a/Kernel/Arch/x86/mcontext.h
+++ b/Kernel/Arch/x86/mcontext.h
@@ -24,7 +24,7 @@ struct __attribute__((packed)) __mcontext {
     uint32_t edi;
     uint32_t eip;
     uint32_t eflags;
-#else
+#elif __x86_64__
     uint64_t rax;
     uint64_t rcx;
     uint64_t rdx;


### PR DESCRIPTION
Previously we assumed that !defined(__i386__) meant x86_64 which won't
be the case when aarch64 gets brought up.