### PR TITLE
Kernel: Don't exclude parts of the boot process that already works on aarch64

### DIFF
--- a/Kernel/Arch/Spinlock.h
+++ b/Kernel/Arch/Spinlock.h
@@ -26,6 +26,10 @@ public:
 
     [[nodiscard]] ALWAYS_INLINE bool is_locked() const
     {
+        // FIXME: Implement Spinlock on aarch64
+#if ARCH(AARCH64)
+        return true;
+#endif
         return m_lock.load(AK::memory_order_relaxed) != 0;
     }
 

--- a/Kernel/Arch/aarch64/Dummy.cpp
+++ b/Kernel/Arch/aarch64/Dummy.cpp
@@ -113,26 +113,6 @@ READONLY_AFTER_INIT u8 multiboot_framebuffer_bpp;
 READONLY_AFTER_INIT u8 multiboot_framebuffer_type;
 }
 
-namespace Kernel {
-
-// KString.cpp
-ErrorOr<NonnullOwnPtr<KString>> KString::try_create_uninitialized(size_t, char*&)
-{
-    VERIFY_NOT_REACHED();
-    return ENOMEM;
-}
-ErrorOr<NonnullOwnPtr<KString>> KString::try_create(StringView)
-{
-    VERIFY_NOT_REACHED();
-    return ENOMEM;
-}
-void KString::operator delete(void*)
-{
-    VERIFY_NOT_REACHED();
-}
-
-}
-
 extern "C" {
 FlatPtr kernel_mapping_base;
 }

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -92,6 +92,11 @@ public:
         return 0;
     }
 
+    ALWAYS_INLINE static bool is_bootstrap_processor()
+    {
+        return Processor::current_id() == 0;
+    }
+
     // FIXME: Actually return the current thread once aarch64 supports threading.
     ALWAYS_INLINE static Thread* current_thread()
     {

--- a/Kernel/Arch/aarch64/RPi/Timer.cpp
+++ b/Kernel/Arch/aarch64/RPi/Timer.cpp
@@ -54,7 +54,7 @@ u64 Timer::microseconds_since_boot()
 
 bool Timer::handle_irq(RegisterState const&)
 {
-    dbgln("Timer fired: {} us", m_current_timer_value);
+    dmesgln("Timer fired: {} us", m_current_timer_value);
 
     m_current_timer_value += m_interrupt_interval;
     set_compare(TimerID::Timer1, m_current_timer_value);

--- a/Kernel/Arch/aarch64/TrapFrame.h
+++ b/Kernel/Arch/aarch64/TrapFrame.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+#include <AK/Platform.h>
+
+namespace Kernel {
+
+struct TrapFrame {
+    u64 x[31];     // Saved general purpose registers
+    u64 spsr_el1;  // Save Processor Status Register, EL1
+    u64 elr_el1;   // Exception Link Reigster, EL1
+    u64 tpidr_el1; // EL0 thread ID
+    u64 sp_el0;    // EL0 stack pointer
+};
+
+}

--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -23,6 +23,10 @@
 #include <Kernel/Arch/aarch64/TrapFrame.h>
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+#include <Kernel/Devices/DeviceManagement.h>
+>>>>>>> 3c34ccfbc7 (Kernel: Include `DeviceManagement` as a part of aarch64)
 #include <Kernel/Graphics/Console/BootFramebufferConsole.h>
 =======
 >>>>>>> 8cfad14511 (Kernel: Move TrapFrame into it's own header on aarch64)
@@ -106,9 +110,6 @@ extern "C" [[noreturn]] void init()
         (*ctor)();
     kmalloc_init();
 
-    for (ctor_func_t* ctor = start_ctors; ctor < end_ctors; ctor++)
-        (*ctor)();
-
     load_kernel_symbol_table();
 
     auto& framebuffer = RPi::Framebuffer::the();
@@ -117,6 +118,13 @@ extern "C" [[noreturn]] void init()
         draw_logo();
     }
     dmesgln("Starting SerenityOS...");
+
+    DeviceManagement::initialize();
+
+    // Invoke all static global constructors in the kernel.
+    // Note that we want to do this as early as possible.
+    for (ctor_func_t* ctor = start_ctors; ctor < end_ctors; ctor++)
+        (*ctor)();
 
     initialize_interrupts();
     InterruptManagement::initialize();

--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -21,7 +21,10 @@
 #include <Kernel/Arch/aarch64/RPi/UART.h>
 #include <Kernel/Arch/aarch64/Registers.h>
 #include <Kernel/Arch/aarch64/TrapFrame.h>
+<<<<<<< HEAD
 #include <Kernel/Graphics/Console/BootFramebufferConsole.h>
+=======
+>>>>>>> 8cfad14511 (Kernel: Move TrapFrame into it's own header on aarch64)
 #include <Kernel/KSyms.h>
 #include <Kernel/Panic.h>
 

--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -20,19 +20,13 @@
 #include <Kernel/Arch/aarch64/RPi/Timer.h>
 #include <Kernel/Arch/aarch64/RPi/UART.h>
 #include <Kernel/Arch/aarch64/Registers.h>
+#include <Kernel/Arch/aarch64/TrapFrame.h>
+#include <Kernel/Graphics/Console/BootFramebufferConsole.h>
 #include <Kernel/KSyms.h>
 #include <Kernel/Panic.h>
 
-struct TrapFrame {
-    u64 x[31];     // Saved general purpose registers
-    u64 spsr_el1;  // Save Processor Status Register, EL1
-    u64 elr_el1;   // Exception Link Reigster, EL1
-    u64 tpidr_el1; // EL0 thread ID
-    u64 sp_el0;    // EL0 stack pointer
-};
-
-extern "C" void exception_common(TrapFrame const* const trap_frame);
-extern "C" void exception_common(TrapFrame const* const trap_frame)
+extern "C" void exception_common(Kernel::TrapFrame const* const trap_frame);
+extern "C" void exception_common(Kernel::TrapFrame const* const trap_frame)
 {
     constexpr bool print_stack_frame = true;
 
@@ -86,6 +80,8 @@ ALWAYS_INLINE static Processor& bootstrap_processor()
     return (Processor&)bootstrap_processor_storage;
 }
 
+Atomic<Graphics::Console*> g_boot_console;
+
 extern "C" [[noreturn]] void init()
 {
     dbgln("Welcome to Serenity OS!");
@@ -108,26 +104,28 @@ extern "C" [[noreturn]] void init()
 
     load_kernel_symbol_table();
 
+    auto& framebuffer = RPi::Framebuffer::the();
+    if (framebuffer.initialized()) {
+        g_boot_console = &try_make_ref_counted<Graphics::BootFramebufferConsole>(framebuffer.gpu_buffer(), framebuffer.width(), framebuffer.width(), framebuffer.pitch()).value().leak_ref();
+        draw_logo();
+    }
+    dmesgln("Starting SerenityOS...");
+
     initialize_interrupts();
     InterruptManagement::initialize();
     Processor::enable_interrupts();
 
     auto firmware_version = query_firmware_version();
-    dbgln("Firmware version: {}", firmware_version);
+    dmesgln("Firmware version: {}", firmware_version);
 
-    dbgln("Initialize MMU");
+    dmesgln("Initialize MMU");
     init_prekernel_page_tables();
-
-    auto& framebuffer = RPi::Framebuffer::the();
-    if (framebuffer.initialized()) {
-        draw_logo();
-    }
 
     auto& timer = RPi::Timer::the();
     timer.set_interrupt_interval_usec(1'000'000);
     timer.enable_interrupt_mode();
 
-    dbgln("Enter loop");
+    dmesgln("Enter loop");
 
     // This will not disable interrupts, so the timer will still fire and show that
     // interrupts are working!

--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -24,7 +24,11 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
+=======
+#include <Kernel/CommandLine.h>
+>>>>>>> 90063bc96f (Kernel: Include `CommandLine` as a part of aarch64)
 #include <Kernel/Devices/DeviceManagement.h>
 >>>>>>> 3c34ccfbc7 (Kernel: Include `DeviceManagement` as a part of aarch64)
 #include <Kernel/Graphics/Console/BootFramebufferConsole.h>
@@ -77,6 +81,8 @@ void __stack_chk_fail()
     Kernel::Processor::halt();
 }
 
+READONLY_AFTER_INIT bool g_in_early_boot;
+
 namespace Kernel {
 
 static void draw_logo();
@@ -95,10 +101,14 @@ Atomic<Graphics::Console*> g_boot_console;
 
 extern "C" [[noreturn]] void init()
 {
+    g_in_early_boot = true;
+
     dbgln("Welcome to Serenity OS!");
     dbgln("Imagine this being your ideal operating system.");
     dbgln("Observed deviations from that ideal are shortcomings of your imagination.");
     dbgln();
+
+    CommandLine::early_initialize("");
 
     new (&bootstrap_processor()) Processor();
     bootstrap_processor().initialize(0);
@@ -111,6 +121,8 @@ extern "C" [[noreturn]] void init()
     kmalloc_init();
 
     load_kernel_symbol_table();
+
+    CommandLine::initialize();
 
     auto& framebuffer = RPi::Framebuffer::the();
     if (framebuffer.initialized()) {

--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -22,9 +22,13 @@
 #include <Kernel/Arch/aarch64/Registers.h>
 #include <Kernel/Arch/aarch64/TrapFrame.h>
 <<<<<<< HEAD
+<<<<<<< HEAD
 #include <Kernel/Graphics/Console/BootFramebufferConsole.h>
 =======
 >>>>>>> 8cfad14511 (Kernel: Move TrapFrame into it's own header on aarch64)
+=======
+#include <Kernel/Graphics/Console/BootFramebufferConsole.h>
+>>>>>>> 4ec9647b24 (Kernel: Add aarch64 support to `BootFramebufferConsole`)
 #include <Kernel/KSyms.h>
 #include <Kernel/Panic.h>
 

--- a/Kernel/Arch/aarch64/kprintf.cpp
+++ b/Kernel/Arch/aarch64/kprintf.cpp
@@ -4,10 +4,23 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Types.h>
 #include <Kernel/Arch/aarch64/RPi/UART.h>
+#include <Kernel/Graphics/Console/BootFramebufferConsole.h>
 #include <Kernel/kstdio.h>
 
 // FIXME: Merge the code in this file with Kernel/kprintf.cpp once the proper abstractions are in place.
+
+namespace Kernel {
+extern Atomic<Graphics::Console*> g_boot_console;
+}
+
+static void console_out(char ch)
+{
+    if (auto* boot_console = g_boot_console.load()) {
+        boot_console->write(ch, true);
+    }
+}
 
 void kernelputstr(char const* characters, size_t length)
 {
@@ -16,6 +29,9 @@ void kernelputstr(char const* characters, size_t length)
 
     auto& uart = Kernel::RPi::UART::the();
     uart.print_str(characters, length);
+
+    for (size_t i = 0; i < length; ++i)
+        console_out(characters[i]);
 }
 
 void kernelcriticalputstr(char const* characters, size_t length)

--- a/Kernel/Arch/aarch64/kprintf.cpp
+++ b/Kernel/Arch/aarch64/kprintf.cpp
@@ -22,6 +22,13 @@ static void console_out(char ch)
     }
 }
 
+static void critical_console_out(char ch)
+{
+    if (auto* boot_console = g_boot_console.load()) {
+        boot_console->write(ch, true);
+    }
+}
+
 void kernelputstr(char const* characters, size_t length)
 {
     if (!characters)
@@ -41,6 +48,8 @@ void kernelcriticalputstr(char const* characters, size_t length)
 
     auto& uart = Kernel::RPi::UART::the();
     uart.print_str(characters, length);
+    for (size_t i = 0; i < length; ++i)
+        critical_console_out(characters[i]);
 }
 
 void kernelearlyputstr(char const* characters, size_t length)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -456,7 +456,9 @@ else()
         Arch/aarch64/vector_table.S
 
         # Files from base Kernel
+        CommandLine.cpp
         KSyms.cpp
+        KString.cpp
         MiniStdLib.cpp
         UBSanitizer.cpp
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -460,6 +460,9 @@ else()
         MiniStdLib.cpp
         UBSanitizer.cpp
 
+        Graphics/Console/BootFramebufferConsole.cpp
+        Graphics/Console/GenericFramebufferConsole.cpp
+
         Memory/AddressSpace.cpp
         Memory/AnonymousVMObject.cpp
         Memory/InodeVMObject.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -460,6 +460,8 @@ else()
         MiniStdLib.cpp
         UBSanitizer.cpp
 
+        Devices/DeviceManagement.cpp
+
         Graphics/Console/BootFramebufferConsole.cpp
         Graphics/Console/GenericFramebufferConsole.cpp
 

--- a/Kernel/Graphics/Console/BootFramebufferConsole.h
+++ b/Kernel/Graphics/Console/BootFramebufferConsole.h
@@ -23,14 +23,24 @@ public:
     virtual void flush(size_t, size_t, size_t, size_t) override { }
     virtual void set_resolution(size_t, size_t, size_t) override { }
 
+// FIXME: Port MemoryManager to aarch64
+#if ARCH(AARCH64)
+    BootFramebufferConsole(u8* framebuffer_addr, size_t width, size_t height, size_t pitch);
+#else
     BootFramebufferConsole(PhysicalAddress framebuffer_addr, size_t width, size_t height, size_t pitch);
+#endif
 
 protected:
     virtual void clear_glyph(size_t x, size_t y) override;
 
     virtual u8* framebuffer_data() override;
 
+// FIXME: Port MemoryManager to aarch64
+#if ARCH(AARCH64)
+    u8* m_framebuffer;
+#else
     OwnPtr<Memory::Region> m_framebuffer;
+#endif
     u8* m_framebuffer_data {};
     mutable Spinlock m_lock;
 };


### PR DESCRIPTION
Relies on #14778.

This also restructures `init.cpp` to closer match the `x86` version