### PR TITLE
LibJS: Shrink Value (and related types)

### DIFF
--- a/AK/BitCast.h
+++ b/AK/BitCast.h
@@ -9,7 +9,7 @@
 namespace AK {
 
 template<typename T, typename U>
-[[nodiscard]] inline T bit_cast(const U& a)
+[[nodiscard]] constexpr inline T bit_cast(const U& a)
 {
 #if (__has_builtin(__builtin_bit_cast))
     return __builtin_bit_cast(T, a);

--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -324,7 +324,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::column_arithmetic)
     auto& column_name_str = column_name.as_string().string();
 
     auto offset = TRY(vm.argument(1).to_number(global_object));
-    auto offset_number = offset.as_i32();
+    auto offset_number = static_cast<i32>(offset.as_double());
 
     auto* this_object = TRY(vm.this_value(global_object).to_object(global_object));
 

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -356,7 +356,7 @@ static ThrowCompletionOr<void> argument_list_evaluation(Interpreter& interpreter
     for (auto& argument : arguments) {
         auto value = TRY(argument.value->execute(interpreter, global_object)).release_value();
         if (argument.is_spread) {
-            auto result = TRY(get_iterator_values(global_object, value, [&](Value iterator_value) -> Optional<Completion> {
+            TRY(get_iterator_values(global_object, value, [&](Value iterator_value) -> Optional<Completion> {
                 list.append(iterator_value);
                 return {};
             }));

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -183,27 +183,53 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::trunc)
 // 21.3.2.30 Math.sin ( x ), https://tc39.es/ecma262/#sec-math.sin
 JS_DEFINE_NATIVE_FUNCTION(MathObject::sin)
 {
+    // 1. Let n be ? ToNumber(x).
     auto number = TRY(vm.argument(0).to_number(global_object));
-    if (number.is_nan())
+    // 2. If n is NaN, n is +0𝔽, or n is -0𝔽, return n.
+    if (number.is_nan() || number.is_positive_zero() || number.is_negative_zero())
+        return number;
+
+    // 3. If n is +∞𝔽 or n is -∞𝔽, return NaN.
+    if (number.is_infinity())
         return js_nan();
+
+    // 4. Return an implementation-approximated Number value representing the result of the sine of ℝ(n).
     return Value(::sin(number.as_double()));
 }
 
 // 21.3.2.12 Math.cos ( x ), https://tc39.es/ecma262/#sec-math.cos
 JS_DEFINE_NATIVE_FUNCTION(MathObject::cos)
 {
+    // 1. Let n be ? ToNumber(x).
     auto number = TRY(vm.argument(0).to_number(global_object));
-    if (number.is_nan())
+
+    // 2. If n is NaN, n is +∞𝔽, or n is -∞𝔽, return NaN.
+    if (number.is_nan() || number.is_infinity())
         return js_nan();
+
+    // 3. If n is +0𝔽 or n is -0𝔽, return 1𝔽.
+    if (number.is_positive_zero() || number.is_negative_zero())
+        return Value(1);
+
+    // 4. Return an implementation-approximated Number value representing the result of the cosine of ℝ(n).
     return Value(::cos(number.as_double()));
 }
 
 // 21.3.2.33 Math.tan ( x ), https://tc39.es/ecma262/#sec-math.tan
 JS_DEFINE_NATIVE_FUNCTION(MathObject::tan)
 {
+    // Let n be ? ToNumber(x).
     auto number = TRY(vm.argument(0).to_number(global_object));
-    if (number.is_nan())
+
+    // 2. If n is NaN, n is +0𝔽, or n is -0𝔽, return n.
+    if (number.is_nan() || number.is_positive_zero() || number.is_negative_zero())
+        return number;
+
+    // 3. If n is +∞𝔽, or n is -∞𝔽, return NaN.
+    if (number.is_infinity())
         return js_nan();
+
+    // 4. Return an implementation-approximated Number value representing the result of the tangent of ℝ(n).
     return Value(::tan(number.as_double()));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/PropertyKey.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyKey.h
@@ -33,7 +33,7 @@ public:
         if (value.is_symbol())
             return PropertyKey { value.as_symbol() };
         if (value.is_integral_number() && value.as_double() >= 0 && value.as_double() < NumericLimits<u32>::max())
-            return value.as_u32();
+            return static_cast<u32>(value.as_double());
         return TRY(value.to_string(global_object));
     }
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.cos.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.cos.js
@@ -11,4 +11,6 @@ test("basic functionality", () => {
     expect(Math.cos([1, 2, 3])).toBeNaN();
     expect(Math.cos({})).toBeNaN();
     expect(Math.cos("foo")).toBeNaN();
+    expect(Math.cos(-Infinity)).toBeNaN();
+    expect(Math.cos(Infinity)).toBeNaN();
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.sin.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.sin.js
@@ -12,4 +12,6 @@ test("basic functionality", () => {
     expect(Math.sin([1, 2, 3])).toBeNaN();
     expect(Math.sin({})).toBeNaN();
     expect(Math.sin("foo")).toBeNaN();
+    expect(Math.sin(Infinity)).toBeNaN();
+    expect(Math.sin(-Infinity)).toBeNaN();
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.tan.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.tan.js
@@ -11,4 +11,6 @@ test("basic functionality", () => {
     expect(Math.tan([1, 2, 3])).toBeNaN();
     expect(Math.tan({})).toBeNaN();
     expect(Math.tan("foo")).toBeNaN();
+    expect(Math.tan(Infinity)).toBeNaN();
+    expect(Math.tan(-Infinity)).toBeNaN();
 });

--- a/Userland/Libraries/LibWeb/Bindings/IDLAbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/IDLAbstractOperations.cpp
@@ -74,7 +74,7 @@ ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
     // 9. For i in the range offset to offset + length − 1, inclusive, set bytes[i − offset] to ! GetValueFromBuffer(esArrayBuffer, i, Uint8, true, Unordered).
     for (u64 i = offset; i <= offset + length - 1; ++i) {
         auto value = es_array_buffer->get_value<u8>(i, true, JS::ArrayBuffer::Unordered);
-        bytes[i - offset] = (u8)value.as_u32();
+        bytes[i - offset] = static_cast<u8>(value.as_double());
     }
 
     // 10. Return bytes.


### PR DESCRIPTION
This is a general optimization of the LibJS Value type. 
And related types and their optional specializations.
This is really just a proof of concept and I would love some more benchmarks and tests to verify this.

It seems to be on par with the current implementation in terms of performance check for example the sunspider comparison in ladybird
![Screenshot from 2022-08-05 22-22-47](https://user-images.githubusercontent.com/3750649/183157209-83cbbe2c-e57b-44c6-83db-9726431a84dd.png)

(Unfortunately does not seem to decrease the memory usage of ladybird running sunspider in any significant way)

Where it really shines is on serenity itself when allocating large arrays as their sizes are halved.
This tests builds a `1000` arrays of size `100000` (with some computation)
```
serenity: master:       51s (or 45s??)
          with changes: 40s

linux:    master:       4.8s (top memory usage 367948 kb)
          with changes: 4.8s (top memory usage 203608 kb)
```

Also we have a bit more stack space left:
```js
var callcount = 0;
function recurse() {
    ++callcount;

    recurse();
}
try {
    recurse();
} catch (e) {
    console.log('crash with ', e);
}
console.log('max recursive call:', callcount);
```

Gives just `1109` on master but with these changes `1714`.

There is still a number of things I want to check / some feedback on.

- [x] Do we want this optimization?
- [x] General bit cast / reinterpret cast nastiness
- [x] Run test262, no changes
- [x] Check if we can fit tuples and records with this schema (see https://github.com/tc39/proposal-record-tuple)
- [x] Add a long explanation comment to Value
- [x] Make sure we can use the upper bits in serenity, sign extend the top 16 bits
- [x] Refactor the code and commits