### PR TITLE
LibGUI+Taskbar: Change theme temporarily on hover

### DIFF
--- a/Userland/Libraries/LibGUI/Action.h
+++ b/Userland/Libraries/LibGUI/Action.h
@@ -121,6 +121,9 @@ public:
 
     HashTable<MenuItem*> menu_items() const { return m_menu_items; }
 
+    Function<void(Action&)> on_enter;
+    Function<void(Action&)> on_leave;
+
 private:
     Action(String, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
     Action(String, Shortcut const&, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -12,6 +12,7 @@
 #include <AK/WeakPtr.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Object.h>
+#include <LibGUI/Action.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Shortcut.h>
 #include <LibGUI/Widget.h>
@@ -81,8 +82,8 @@ public:
     }
     void notify_drag_cancelled(Badge<ConnectionToWindowServer>);
 
-    Function<void(Action&)> on_action_enter;
-    Function<void(Action&)> on_action_leave;
+    Function<void(Action&)> on_action_enter { [](auto& action) { if (action.on_enter) action.on_enter(action); } };
+    Function<void(Action&)> on_action_leave { [](auto& action) { if (action.on_leave) action.on_leave(action); } };
     Function<void()> on_theme_change;
 
     auto const& global_shortcut_actions(Badge<GUI::CommandPalette>) const { return m_global_shortcut_actions; }


### PR DESCRIPTION
This patch makes it so that when you're hovering on a theme in the theme
menu, it gets temporarily applied.

This patch also introduces on_enter and on_leave callbacks to GUI::Action.