### PR TITLE
Chess: Import/Export chessboards using LibFileSystemAccessClient

### DIFF
--- a/Userland/Games/Chess/CMakeLists.txt
+++ b/Userland/Games/Chess/CMakeLists.txt
@@ -13,4 +13,4 @@ set(SOURCES
 )
 
 serenity_app(Chess ICON app-chess)
-target_link_libraries(Chess LibChess LibConfig LibGUI LibCore LibMain LibDesktop)
+target_link_libraries(Chess LibChess LibConfig LibFileSystemAccessClient LibGUI LibCore LibMain LibDesktop)

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -518,15 +518,8 @@ String ChessWidget::get_fen() const
     return m_playback ? m_board_playback.to_fen() : m_board.to_fen();
 }
 
-bool ChessWidget::import_pgn(StringView import_path)
+void ChessWidget::import_pgn(Core::File& file)
 {
-    auto file_or_error = Core::File::open(import_path, Core::OpenMode::ReadOnly);
-    if (file_or_error.is_error()) {
-        warnln("Couldn't open '{}': {}", import_path, file_or_error.error());
-        return false;
-    }
-    auto& file = *file_or_error.value();
-
     m_board = Chess::Board();
 
     ByteBuffer bytes = file.read_all();
@@ -618,20 +611,10 @@ bool ChessWidget::import_pgn(StringView import_path)
     m_playback_move_number = m_board_playback.moves().size();
     m_playback = true;
     update();
-
-    file.close();
-    return true;
 }
 
-bool ChessWidget::export_pgn(StringView export_path) const
+void ChessWidget::export_pgn(Core::File& file) const
 {
-    auto file_or_error = Core::File::open(export_path, Core::OpenMode::WriteOnly);
-    if (file_or_error.is_error()) {
-        warnln("Couldn't open '{}': {}", export_path, file_or_error.error());
-        return false;
-    }
-    auto& file = *file_or_error.value();
-
     // Tag Pair Section
     file.write("[Event \"Casual Game\"]\n"sv);
     file.write("[Site \"SerenityOS Chess\"]\n"sv);
@@ -669,9 +652,6 @@ bool ChessWidget::export_pgn(StringView export_path) const
     file.write(" } "sv);
     file.write(Chess::Board::result_to_points(m_board.game_result(), m_board.turn()));
     file.write("\n"sv);
-
-    file.close();
-    return true;
 }
 
 void ChessWidget::flip_board()

--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -48,8 +48,8 @@ public:
     void set_show_available_moves(bool e) { m_show_available_moves = e; }
 
     String get_fen() const;
-    bool import_pgn(StringView import_path);
-    bool export_pgn(StringView export_path) const;
+    void import_pgn(Core::File&);
+    void export_pgn(Core::File&) const;
 
     int resign();
     void flip_board();


### PR DESCRIPTION
With this change, the `wpath` and `cpath` promises as well as unveiling unveiling user’s entire home directory are no longer needed. :^)