### PR TITLE
Browser: Tab/BookmarkWidget button polishing

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -109,9 +109,12 @@ BookmarksBarWidget::BookmarksBarWidget(String const& bookmarks_file, bool enable
         set_visible(false);
 
     m_additional = GUI::Button::construct();
+    m_additional->set_tooltip("Show hidden bookmarks");
+    auto bitmap_or_error = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/overflow-menu.png"sv);
+    if (!bitmap_or_error.is_error())
+        m_additional->set_icon(bitmap_or_error.release_value());
     m_additional->set_button_style(Gfx::ButtonStyle::Coolbar);
-    m_additional->set_text(">");
-    m_additional->set_fixed_size(14, 20);
+    m_additional->set_fixed_size(22, 20);
     m_additional->set_focus_policy(GUI::FocusPolicy::TabFocus);
     m_additional->on_click = [this](auto) {
         if (m_additional_menu) {

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -111,17 +111,14 @@ BookmarksBarWidget::BookmarksBarWidget(String const& bookmarks_file, bool enable
 
     m_additional = GUI::Button::construct();
     m_additional->set_tooltip("Show hidden bookmarks");
+    m_additional->set_menu(m_additional_menu);
+    m_additional->set_menu_position(GUI::Button::MenuPosition::BottomLeft);
     auto bitmap_or_error = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/overflow-menu.png"sv);
     if (!bitmap_or_error.is_error())
         m_additional->set_icon(bitmap_or_error.release_value());
     m_additional->set_button_style(Gfx::ButtonStyle::Coolbar);
     m_additional->set_fixed_size(22, 20);
     m_additional->set_focus_policy(GUI::FocusPolicy::TabFocus);
-    m_additional->on_click = [this](auto) {
-        if (m_additional_menu) {
-            m_additional_menu->popup(m_additional->relative_position().translated(relative_position().translated(m_additional->window()->position())));
-        }
-    };
 
     m_separator = GUI::Widget::construct();
 
@@ -254,6 +251,7 @@ void BookmarksBarWidget::update_content_size()
         // hide all items > m_last_visible_index and create new bookmarks menu for them
         m_additional->set_visible(true);
         m_additional_menu = GUI::Menu::construct("Additional Bookmarks");
+        m_additional->set_menu(m_additional_menu);
         for (size_t i = m_last_visible_index; i < m_bookmarks.size(); ++i) {
             auto& bookmark = m_bookmarks.at(i);
             bookmark.set_visible(false);

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -102,6 +102,7 @@ BookmarksBarWidget::BookmarksBarWidget(String const& bookmarks_file, bool enable
     s_the = this;
     set_layout<GUI::HorizontalBoxLayout>();
     layout()->set_spacing(0);
+    layout()->set_margins(2);
 
     set_fixed_height(20);
 

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -186,21 +186,18 @@ Tab::Tab(BrowserWindow& window)
         m_location_box->on_return_pressed();
     }));
 
-    m_bookmark_button = toolbar.add<GUI::Button>();
-    m_bookmark_button->set_button_style(Gfx::ButtonStyle::Coolbar);
-    m_bookmark_button->set_focus_policy(GUI::FocusPolicy::TabFocus);
-    m_bookmark_button->set_icon(g_icon_bag.bookmark_contour);
-    m_bookmark_button->set_fixed_size(22, 22);
-
-    m_bookmark_button->on_click = [this](auto) {
-        bookmark_current_url();
-    };
-
     auto bookmark_action = GUI::Action::create(
         "Bookmark current URL", { Mod_Ctrl, Key_D }, [this](auto&) {
             bookmark_current_url();
         },
         this);
+
+    m_bookmark_button = toolbar.add<GUI::Button>();
+    m_bookmark_button->set_action(bookmark_action);
+    m_bookmark_button->set_button_style(Gfx::ButtonStyle::Coolbar);
+    m_bookmark_button->set_focus_policy(GUI::FocusPolicy::TabFocus);
+    m_bookmark_button->set_icon(g_icon_bag.bookmark_contour);
+    m_bookmark_button->set_fixed_size(22, 22);
 
     view().on_load_start = [this](auto& url) {
         m_navigating_url = url;

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -127,7 +127,7 @@ Tab::Tab(BrowserWindow& window)
     m_web_content_view->set_proxy_mappings(g_proxies, g_proxy_mappings);
 
     auto& go_back_button = toolbar.add_action(window.go_back_action());
-    go_back_button.on_context_menu_request = [this](auto& context_menu_event) {
+    go_back_button.on_context_menu_request = [&](auto&) {
         if (!m_history.can_go_back())
             return;
         int i = 0;
@@ -136,11 +136,11 @@ Tab::Tab(BrowserWindow& window)
             i++;
             m_go_back_context_menu->add_action(GUI::Action::create(url.to_string(), g_icon_bag.filetype_html, [this, i](auto&) { go_back(i); }));
         }
-        m_go_back_context_menu->popup(context_menu_event.screen_position());
+        m_go_back_context_menu->popup(go_back_button.screen_relative_rect().bottom_left());
     };
 
     auto& go_forward_button = toolbar.add_action(window.go_forward_action());
-    go_forward_button.on_context_menu_request = [this](auto& context_menu_event) {
+    go_forward_button.on_context_menu_request = [&](auto&) {
         if (!m_history.can_go_forward())
             return;
         int i = 0;
@@ -149,7 +149,7 @@ Tab::Tab(BrowserWindow& window)
             i++;
             m_go_forward_context_menu->add_action(GUI::Action::create(url.to_string(), g_icon_bag.filetype_html, [this, i](auto&) { go_forward(i); }));
         }
-        m_go_forward_context_menu->popup(context_menu_event.screen_position());
+        m_go_forward_context_menu->popup(go_forward_button.screen_relative_rect().bottom_left());
     };
 
     auto& go_home_button = toolbar.add_action(window.go_home_action());

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -377,7 +377,7 @@ Tab::Tab(BrowserWindow& window)
 
     m_tab_context_menu = GUI::Menu::construct();
     m_tab_context_menu->add_action(GUI::CommonActions::make_reload_action([this](auto&) {
-        this->window().reload_action().activate();
+        reload();
     }));
     m_tab_context_menu->add_action(GUI::CommonActions::make_close_tab_action([this](auto&) {
         on_tab_close_request(*this);


### PR DESCRIPTION
- **Browser: Use overflow-menu icon for hidden bookmarks the button**

  97b381652a (from #14706) started using that icon for toolbars. Let’s also use it for here for the sweet system consistency!

- **Browser: Set margins for BookmarkBarWidget**
  It’s just what GUI::Toolbar is using[^1]. Changed this to make the bookmark overflow button align with the bookmark button.

  old | new
  ---|---
  ![](https://user-images.githubusercontent.com/16520278/183269647-19eb1e6a-5b50-42b0-8dbe-da9c79874cb5.png) | ![](https://user-images.githubusercontent.com/16520278/183269232-f61c2920-4cf8-403a-8ae4-9db9672938d3.png)

- **Browser: Show bookmark and history page lists under the their buttons**

  Previously menus were showing right under the cursor.

  ![](https://user-images.githubusercontent.com/16520278/183269274-30fd44fa-354f-4c10-8012-cb33d220e041.png)

- **Browser: Make the bookmark button use an action**

  This merges 2 duplicated definitions (one for button, second just for the keyboard shortcut) which also makes the button ‘react’ on that shortcut. :^)

  ![](https://user-images.githubusercontent.com/16520278/183269949-2fb5fbe6-a9db-4180-a4f9-80b30e0e46c1.gif)

- **Browser: Make Refresh action in tab context menu refresh the chosen tab**

  It was sending refresh requests to the current tab instead.

[^1]: https://github.com/SerenityOS/serenity/blob/c92e68da38dd7892a4afd6e44383cffcc188c46f/Userland/Libraries/LibGUI/Toolbar.cpp#L38