### PR TITLE
LibWeb: Support `-webkit-linear-gradient()` correctly 

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -91,6 +91,10 @@
         .grad-14 {
             background-image: linear-gradient(to bottom right,  indigo, white, deeppink);
         }
+
+        .grad-webkit {
+            background-image: -webkit-linear-gradient(top right, yellow, black, yellow, black);
+        }
     </style>
   </head>
   <body>
@@ -116,6 +120,8 @@
     <div class="rect grad-12"></div>
     <div class="rect grad-13"></div>
     <div class="rect grad-14"></div>
+    <b>A webkit gradient</b><br>
+    <div class="box grad-webkit"></div>
   </body>
   <script>
     const boxes = document.querySelectorAll(".box, .rect");

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -933,10 +933,15 @@ class LinearGradientStyleValue final : public StyleValue {
 public:
     using GradientDirection = Variant<Angle, SideOrCorner>;
 
-    static NonnullRefPtr<LinearGradientStyleValue> create(GradientDirection direction, Vector<ColorStopListElement> color_stop_list)
+    enum class GradientType {
+        Standard,
+        WebKit
+    };
+
+    static NonnullRefPtr<LinearGradientStyleValue> create(GradientDirection direction, Vector<ColorStopListElement> color_stop_list, GradientType type)
     {
         VERIFY(color_stop_list.size() >= 2);
-        return adopt_ref(*new LinearGradientStyleValue(direction, move(color_stop_list)));
+        return adopt_ref(*new LinearGradientStyleValue(direction, move(color_stop_list), type));
     }
 
     virtual String to_string() const override;
@@ -951,15 +956,17 @@ public:
     float angle_degrees(Gfx::FloatRect const& gradient_rect) const;
 
 private:
-    LinearGradientStyleValue(GradientDirection direction, Vector<ColorStopListElement> color_stop_list)
+    LinearGradientStyleValue(GradientDirection direction, Vector<ColorStopListElement> color_stop_list, GradientType type)
         : StyleValue(Type::LinearGradient)
         , m_direction(direction)
         , m_color_stop_list(move(color_stop_list))
+        , m_gradient_type(type)
     {
     }
 
     GradientDirection m_direction;
     Vector<ColorStopListElement> m_color_stop_list;
+    GradientType m_gradient_type;
 };
 
 class InheritStyleValue final : public StyleValue {


### PR DESCRIPTION
Currently `-webkit-linear-gradient()` is treated as an alias for `linear-gradient()`, but that's not correct as there's a few more differences:

- The syntax for specifying a `<side or corner>` differs, on the `-webkit` variant you don't include the `to` (so just `left` not `to left`).
- The direction/angle for a <side or corner> is opposite the the standard one (so `left` is the same as `to right` in a standard gradient). 

So for the standard: `linear-gradient(to left, red, blue)`
The WebKit version is: `-webkit-linear-gradient(right, red, blue)`


This PR implements these webkit quirks, that _unfortunately_ still exist in the wild, and correctly serialises the gradients.