### PR TITLE
LibWeb: Start to make the Francine CSS oil painting appear 

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -311,33 +311,24 @@ void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_n
 float BlockFormattingContext::compute_theoretical_height(LayoutState const& state, Box const& box)
 {
     auto const& computed_values = box.computed_values();
-    auto const& containing_block = *box.containing_block();
     auto containing_block_height = CSS::Length::make_px(containing_block_height_for(box, state));
-
-    auto is_absolute = [](Optional<CSS::LengthPercentage> const& length_percentage) {
-        return length_percentage.has_value() && length_percentage->is_length() && length_percentage->length().is_absolute();
-    };
 
     // Then work out what the height is, based on box type and CSS properties.
     float height = 0;
     if (is<ReplacedBox>(box)) {
         height = compute_height_for_replaced_element(state, verify_cast<ReplacedBox>(box));
     } else {
-        if (box.computed_values().height().is_auto()
-            || (computed_values.height().is_percentage() && !is_absolute(containing_block.computed_values().height()))) {
+        if (box.computed_values().height().is_auto())
             height = compute_auto_height_for_block_level_element(state, box);
-        } else {
+        else
             height = computed_values.height().resolved(box, containing_block_height).to_px(box);
-        }
     }
 
     auto specified_max_height = computed_values.max_height().resolved(box, containing_block_height).resolved(box);
-    if (!specified_max_height.is_auto()
-        && !(computed_values.max_height().is_percentage() && !is_absolute(containing_block.computed_values().height())))
+    if (!specified_max_height.is_auto())
         height = min(height, specified_max_height.to_px(box));
     auto specified_min_height = computed_values.min_height().resolved(box, containing_block_height).resolved(box);
-    if (!specified_min_height.is_auto()
-        && !(computed_values.min_height().is_percentage() && !is_absolute(containing_block.computed_values().height())))
+    if (!specified_min_height.is_auto())
         height = max(height, specified_min_height.to_px(box));
     return height;
 }

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -658,7 +658,6 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
 
     // FIXME: The section below is partly on-spec, partly ad-hoc.
     auto& computed_values = box.computed_values();
-    auto const& containing_block = *box.containing_block();
 
     auto width_of_containing_block = containing_block_width_for(box);
     auto height_of_containing_block = containing_block_height_for(box);
@@ -675,12 +674,8 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     auto used_bottom = computed_bottom.resolved(box, height_of_containing_block_as_length).resolved(box).to_px(box);
     auto tentative_height = CSS::Length::make_auto();
 
-    if (computed_values.height().is_percentage()
-        && !(containing_block.computed_values().height().is_length() && containing_block.computed_values().height().length().is_absolute())) {
-        // tentative_height is already auto
-    } else {
+    if (!computed_height.is_auto())
         tentative_height = computed_values.height().resolved(box, height_of_containing_block_as_length).resolved(box);
-    }
 
     auto& box_state = m_state.get_mutable(box);
     box_state.margin_top = computed_values.margin().top.resolved(box, width_of_containing_block_as_length).to_px(box);


### PR DESCRIPTION
| Before                                                                                                          | After                                                                                                           |
|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/11597044/183300176-432b54b4-9c64-453d-a90c-c3e942f5d454.png) | ![image](https://user-images.githubusercontent.com/11597044/183307918-8f757a87-0880-4a9a-b37e-38bdfc82d8f0.png) |

This is a start of a little hacking to make https://diana-adrianne.com/purecss-francine/ work (a little more) in LibWeb.

With these changes you can start to make out the figure and the _very cursed_ face :^).

I'm not entirely sure why these restrictions were previously active, but removing them did not seem to regress any sites, and starts to fix Francine.  
