### PR TITLE
LibGUI: Correct cursor index during mouseup_event

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -359,8 +359,7 @@ void AbstractView::mouseup_event(MouseEvent& event)
         // Since we're here, it was not that; so fix up the selection now.
         auto index = index_at_event_position(event.position());
         if (index.is_valid()) {
-            set_selection(index);
-            set_selection_start_index(index);
+            set_cursor(index, SelectionUpdate::Set, true);
         } else
             clear_selection();
         m_might_drag = false;


### PR DESCRIPTION
Fixes #10521

Previously, during a `m_might_drag` `mouse_up` event, we were updating the selection directly, which caused the selection to be accurate but the location of the cursor index to be stale/incorrect. The side effect of this is then future events may point to the wrong index.

Instead, call the `set_cursor` function with `SelectionUpdate::Set`, which handles both updating the cursor index as well as the selection index.

### Before
<img width="769" alt="broken-step1" src="https://user-images.githubusercontent.com/955163/183304124-0e15f988-0cb7-4124-ba1b-e8b14bb9d2c1.PNG">
To replicate the issue, first start out by selecting an icon. In the image above, I am selecting `AnalogClock` application.

<img width="769" alt="broken-step2" src="https://user-images.githubusercontent.com/955163/183304148-1d9f6362-a7ec-4604-8bf5-21defac7cd69.PNG">
Then, start rubber banding by dragging across a set of icons. Note how `AnalogClock` is still selected/focused.

<img width="769" alt="broken-step3" src="https://user-images.githubusercontent.com/955163/183304170-4e00b9c9-a4d4-4dd9-9d25-0ab9f6fa4586.PNG">
Finally, select an icon that is within the rubber band. In the image above, I am selecting `2048` application, but notice the discrepancy. The "selected" application is `2048`, but the application that has the focus is still `AnalogClock`. Now when you double-click `2048` to launch it, it actually launches `AnalogClock`, this is because the cursor index is still associated with `AnalogClock`, and _only_ the selection index is correct for pointing to `2048`.

### After
<img width="769" alt="fixed-step1" src="https://user-images.githubusercontent.com/955163/183304204-7a729bca-8af0-4c6d-b8ac-ff457a393489.PNG">
Like before, start out by first selecting `AnalogClock` by itself, then start rubber banding several icons.

<img width="769" alt="fixed-step2" src="https://user-images.githubusercontent.com/955163/183304220-efed9e00-fd43-45ce-a0aa-39d4455b11c1.PNG">
With this fix, now when you single-click `2048`, it has both the selection and the current focus. Double-clicking correctly launches the correct application.
