### PR TITLE
LibWeb: Fix a bunch of web platform tests for CSS clip

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -849,11 +849,15 @@ Gfx::FloatRect EdgeRect::resolved(Layout::Node const& layout_node, Gfx::FloatRec
     // widths for <bottom>, and the same as the used value of the width plus the sum of the
     // horizontal padding and border widths for <right>, such that four 'auto' values result in the
     // clipping region being the same as the element's border box).
+    auto left = border_box.left() + (left_edge.is_auto() ? 0 : left_edge.to_px(layout_node));
+    auto top = border_box.top() + (top_edge.is_auto() ? 0 : top_edge.to_px(layout_node));
+    auto right = border_box.left() + (right_edge.is_auto() ? border_box.width() : right_edge.to_px(layout_node));
+    auto bottom = border_box.top() + (bottom_edge.is_auto() ? border_box.height() : bottom_edge.to_px(layout_node));
     return Gfx::FloatRect {
-        left_edge.is_auto() ? 0 : left_edge.to_px(layout_node),
-        top_edge.is_auto() ? 0 : top_edge.to_px(layout_node),
-        right_edge.is_auto() ? border_box.width() : right_edge.to_px(layout_node) - left_edge.to_px(layout_node),
-        bottom_edge.is_auto() ? border_box.height() : bottom_edge.to_px(layout_node) - top_edge.to_px(layout_node)
+        left,
+        top,
+        right - left,
+        bottom - top
     };
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -114,7 +114,7 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
         return;
 
     auto clip_rect = computed_values().clip();
-    auto should_clip_rect = clip_rect.is_rect() && computed_values().position() == CSS::Position::Absolute;
+    auto should_clip_rect = clip_rect.is_rect() && layout_box().is_absolutely_positioned();
 
     if (phase == PaintPhase::Background) {
         if (should_clip_rect) {


### PR DESCRIPTION
This PR fixes:
- clip-absolute-positioned-002 
- clip-rect-auto-004 
- clip-rect-auto-005
- clip-rect-comma-002
- clip-rect-comma-003
- clip-rect-comma-004

The only tests failing now are
- clip-no-stacking-context
- clip-rect-scroll
- clip-transform-order-2
- clip-transform-order

Which seem to fail due to reasons unrelated to the actual clipping.

cc @martinfalisse (left out the style value formatting changes since I believe you're working on that)