### PR TITLE
SystemMonitor: Ignore processes with no threads

### DIFF
--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -505,16 +505,16 @@ void ProcessModel::update()
         }
     }
 
-    // FIXME: Also remove dead threads from processes
-    for (auto tid : tids_to_remove) {
-        m_threads.remove(tid);
-        for (size_t i = 0; i < m_processes.size(); ++i) {
-            auto& process = m_processes[i];
+    // Remove dead threads from processes and "zombie" processes without active thread
+    for (size_t i = 0; i < m_processes.size(); ++i) {
+        auto& process = m_processes[i];
+        for (auto tid : tids_to_remove) {
+            m_threads.remove(tid);
             process.threads.remove_all_matching([&](auto const& thread) { return thread->current_state.tid == tid; });
-            if (process.threads.size() == 0) {
-                m_processes.remove(i);
-                --i;
-            }
+        }
+        if (m_processes[i].threads.is_empty()) {
+            m_processes.remove(i);
+            --i;
         }
     }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3363,25 +3363,10 @@ RefPtr<StyleValue> Parser::parse_rect_value(ComponentValue const& component_valu
     Vector<Length, 4> params;
     auto tokens = TokenStream { function.values() };
 
-    enum class CommaRequirement {
-        Unknown,
-        RequiresCommas,
-        RequiresNoCommas
-    };
-
-    enum class Side {
-        Top = 0,
-        Right = 1,
-        Bottom = 2,
-        Left = 3
-    };
-
-    auto comma_requirement = CommaRequirement::Unknown;
-
     // In CSS 2.1, the only valid <shape> value is: rect(<top>, <right>, <bottom>, <left>) where
     // <top> and <bottom> specify offsets from the top border edge of the box, and <right>, and
     //  <left> specify offsets from the left border edge of the box.
-    for (size_t side = 0; side < 4; side++) {
+    for (size_t idx = 0; idx < 4; idx++) {
         tokens.skip_whitespace();
 
         // <top>, <right>, <bottom>, and <left> may either have a <length> value or 'auto'.
@@ -3397,34 +3382,12 @@ RefPtr<StyleValue> Parser::parse_rect_value(ComponentValue const& component_valu
         }
         tokens.skip_whitespace();
 
-        // The last side, should be no more tokens following it.
-        if (static_cast<Side>(side) == Side::Left) {
-            if (tokens.has_next_token())
-                return {};
-            break;
-        }
-
-        bool next_is_comma = tokens.peek_token().is(Token::Type::Comma);
-
         // Authors should separate offset values with commas. User agents must support separation
         // with commas, but may also support separation without commas (but not a combination),
         // because a previous revision of this specification was ambiguous in this respect.
-        if (comma_requirement == CommaRequirement::Unknown)
-            comma_requirement = next_is_comma ? CommaRequirement::RequiresCommas : CommaRequirement::RequiresNoCommas;
-
-        if (comma_requirement == CommaRequirement::RequiresCommas) {
-            if (next_is_comma)
-                tokens.next_token();
-            else
-                return {};
-        } else if (comma_requirement == CommaRequirement::RequiresNoCommas) {
-            if (next_is_comma)
-                return {};
-        } else {
-            VERIFY_NOT_REACHED();
-        }
+        if (tokens.peek_token().is(Token::Type::Comma))
+            tokens.next_token();
     }
-
     return RectStyleValue::create(EdgeRect { params[0], params[1], params[2], params[3] });
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -849,15 +849,11 @@ Gfx::FloatRect EdgeRect::resolved(Layout::Node const& layout_node, Gfx::FloatRec
     // widths for <bottom>, and the same as the used value of the width plus the sum of the
     // horizontal padding and border widths for <right>, such that four 'auto' values result in the
     // clipping region being the same as the element's border box).
-    auto left = border_box.left() + (left_edge.is_auto() ? 0 : left_edge.to_px(layout_node));
-    auto top = border_box.top() + (top_edge.is_auto() ? 0 : top_edge.to_px(layout_node));
-    auto right = border_box.left() + (right_edge.is_auto() ? border_box.width() : right_edge.to_px(layout_node));
-    auto bottom = border_box.top() + (bottom_edge.is_auto() ? border_box.height() : bottom_edge.to_px(layout_node));
     return Gfx::FloatRect {
-        left,
-        top,
-        right - left,
-        bottom - top
+        left_edge.is_auto() ? 0 : left_edge.to_px(layout_node),
+        top_edge.is_auto() ? 0 : top_edge.to_px(layout_node),
+        right_edge.is_auto() ? border_box.width() : right_edge.to_px(layout_node) - left_edge.to_px(layout_node),
+        bottom_edge.is_auto() ? border_box.height() : bottom_edge.to_px(layout_node) - top_edge.to_px(layout_node)
     };
 }
 
@@ -1688,7 +1684,7 @@ bool PositionStyleValue::equals(StyleValue const& other) const
 
 String RectStyleValue::to_string() const
 {
-    return String::formatted("rect({} {} {} {})", m_rect.top_edge, m_rect.right_edge, m_rect.bottom_edge, m_rect.left_edge);
+    return String::formatted("top_edge: {}, right_edge: {}, bottom_edge: {}, left_edge: {}", m_rect.top_edge, m_rect.right_edge, m_rect.bottom_edge, m_rect.left_edge);
 }
 
 bool RectStyleValue::equals(StyleValue const& other) const

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -114,7 +114,7 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
         return;
 
     auto clip_rect = computed_values().clip();
-    auto should_clip_rect = clip_rect.is_rect() && layout_box().is_absolutely_positioned();
+    auto should_clip_rect = clip_rect.is_rect() && computed_values().position() == CSS::Position::Absolute;
 
     if (phase == PaintPhase::Background) {
         if (should_clip_rect) {


### PR DESCRIPTION
"Zombie" processes with no live threads can trip up
the refresh of the process list.
This patch checks for such processes and removes them
from the list of shown processes.

This resolves issue #13982 .