### PR TITLE
PixelPaint: Add scaling function to move tool

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -21,6 +21,7 @@ public:
     virtual void on_mousemove(Layer*, MouseEvent&) override;
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
+    virtual void on_keyup(GUI::KeyEvent&) override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
 
 private:
@@ -29,8 +30,11 @@ private:
     RefPtr<Layer> m_layer_being_moved;
     Gfx::IntPoint m_event_origin;
     Gfx::IntPoint m_layer_origin;
+    Gfx::IntPoint m_new_scaled_layer_location;
+    Gfx::IntSize m_new_layer_size;
     bool m_scaling { false };
     bool m_mouse_in_resize_corner { false };
+    bool m_keep_ascept_ratio { false };
 };
 
 }

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -21,7 +21,7 @@ public:
     virtual void on_mousemove(Layer*, MouseEvent&) override;
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Move; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
 
 private:
     virtual StringView tool_name() const override { return "Move Tool"sv; }
@@ -29,6 +29,8 @@ private:
     RefPtr<Layer> m_layer_being_moved;
     Gfx::IntPoint m_event_origin;
     Gfx::IntPoint m_layer_origin;
+    bool m_scaling { false };
+    bool m_mouse_in_resize_corner { false };
 };
 
 }


### PR DESCRIPTION
This patch adds scaling function to the move tool. When the move tool is selected and the mouse is over the lower right corner of the layer, the cursor changes to signify, that the layer can be scaled by dragging the mouse.
There is currently no preview of the scaling, as doing a resize every time the mouse moves leads to unexpected behaviour, where the image isn't scaled properly and is cut off. The image can also only be scaled from the lower right corner.
Maybe it would be smarter to add a new "scale" tool to do this, or rename the move tool to "translate" tool, to signify these changes.
Here is a YouTube clip demoing the feature: https://youtu.be/Azfsn-YbMyo