### PR TITLE
Base: Replace linear-gradient() pattern demo with cooler one

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -66,10 +66,12 @@
         }
 
         .grad-9 {
-            background: linear-gradient(135deg, #333 25%, transparent 25%) -50px 0,
-                        linear-gradient(225deg, #333 25%, transparent 25%) -50px 0,
-                        linear-gradient(315deg, #333 25%, transparent 25%),
-                        linear-gradient(45deg, #333 25%, transparent 25%);
+            background: linear-gradient(135deg, #f2f2f2 25%, transparent 25%) -20px 0,
+                        linear-gradient(225deg, #f2f2f2 25%, transparent 25%) -20px 0,
+                        linear-gradient(315deg, #f2f2f2 25%, transparent 25%),
+                        linear-gradient(45deg, #f2f2f2 25%, transparent 25%);
+            background-size: 40px 40px;
+            background-color: #50e3c2;
         }
 
         .grad-10 {


### PR DESCRIPTION
The previous demo didn't work that well, not due to any LibWeb issue (same in other browsers), it just was a broken demo.

This demo shows the neat tricks you can do with linear-gradient()s much better.

**Before**
![image](https://user-images.githubusercontent.com/11597044/183535127-af2b550f-b352-454a-b74a-19111c6e3ad8.png)
**After**
![image](https://user-images.githubusercontent.com/11597044/183535190-26fd8102-330c-479a-ac1e-055ebaf9b38c.png)

(This takes advantage of the changes from #14740)