### PR TITLE
Userland: Don't expand miscellanea by default upon opening Help

### DIFF
--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -279,8 +279,6 @@ void MainWidget::open_url(URL const& url)
         GUI::Application::the()->deferred_invoke([&, path = url.path()] {
             auto browse_view_index = m_manual_model->index_from_path(path);
             if (browse_view_index.has_value()) {
-                m_browse_view->expand_tree(browse_view_index.value().parent());
-
                 String page_and_section = m_manual_model->page_and_section(browse_view_index.value());
                 window()->set_title(String::formatted("{} - Help", page_and_section));
             } else {


### PR DESCRIPTION
Keep miscellanea closed upon opening Help. It feels out of place having it open up expanded but if having it open was to demonstrate the tree expansion, please feel free to close this :^).

|  Before |   After |   
|:---:|:---:|
| ![MiscellaneaExpand-min](https://user-images.githubusercontent.com/60057590/183548803-c808672a-435c-4e6e-bd46-4a6c5b2dfa79.png)| ![MiscellaneaNoExpand](https://user-images.githubusercontent.com/60057590/183548892-8e297e03-bbcd-44ee-85e6-c48e1191629a.png) |

 