### PR TITLE
CI: Enable downloading the Azure remote data cache for Fuzzer builds

### DIFF
--- a/Meta/Azure/Caches.yml
+++ b/Meta/Azure/Caches.yml
@@ -62,19 +62,25 @@ steps:
   - ${{ if eq(parameters.with_remote_data_caches, true) }}:
     - task: Cache@2
       inputs:
-        key: '"time_zone_data" | Meta/CMake/time_zone_data.cmake'
+        key: '"time_zone_data" | Meta/CMake/time_zone_data.cmake | "$(timestamp)"'
+        restoreKeys: |
+            "time_zone_data" | Meta/CMake/time_zone_data.cmake
         path: $(Build.SourcesDirectory)/${{ parameters.build_directory }}/TZDB
       displayName: 'TimeZoneData Cache'
 
     - task: Cache@2
       inputs:
-        key: '"unicode_data" | Meta/CMake/unicode_data.cmake'
+        key: '"unicode_data" | Meta/CMake/unicode_data.cmake | "$(timestamp)"'
+        restoreKeys: |
+            "unicode_data" | Meta/CMake/unicode_data.cmake
         path: $(Build.SourcesDirectory)/${{ parameters.build_directory }}/UCD
       displayName: 'UnicodeData Cache'
 
     - task: Cache@2
       inputs:
-        key: '"unicode_locale" | Meta/CMake/unicode_data.cmake'
+        key: '"unicode_locale" | Meta/CMake/unicode_data.cmake | "$(timestamp)"'
+        restoreKeys: |
+            "unicode_locale" | Meta/CMake/unicode_data.cmake
         path: $(Build.SourcesDirectory)/${{ parameters.build_directory }}/CLDR
       displayName: 'UnicodeLocale Cache'
 

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -41,10 +41,7 @@ jobs:
         toolchain: '$(toolchain)'
         build_directory: 'Meta/Lagom/Build'
         serenity_ccache_path: '$(SERENITY_CCACHE_DIR)'
-        ${{ if eq(parameters.fuzzer, 'Fuzz') }}:
-          with_remote_data_caches: false
-        ${{ if eq(parameters.fuzzer, 'NoFuzz') }}:
-          with_remote_data_caches: true
+        with_remote_data_caches: true
         ${{ if eq(parameters.os, 'Android') }}:
           with_ndk_cache: true
           ndk_version: '$(ndk_version)'


### PR DESCRIPTION
This cache was disabled in 3127454 because it wasn't needed and there
was a race between the builders for this cache. Then commit 0c95d99
started fuzzing the generated Unicode / TZDB data. Since then, we've
been pulling this data from the live servers instead of Azure's cache.