### PR TITLE
LibGUI: Avoid too large tooltip when switching to shorter text

### DIFF
--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -43,6 +43,7 @@ private:
     TooltipWindow()
     {
         set_window_type(WindowType::Tooltip);
+        set_obey_widget_min_size(false);
         m_label = set_main_widget<Label>();
         m_label->set_background_role(Gfx::ColorRole::Tooltip);
         m_label->set_foreground_role(Gfx::ColorRole::TooltipText);


### PR DESCRIPTION
The tooltip window didn't resize when setting a shorter text, or moving
to a widget with shorter text, so it had extra space on the sides.

Fix by allowing the window to resize without obeying the minimum size
of the (previous) tooltip.