### PR TITLE
LibWeb: Follow `image-rendering` when painting image style values

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1457,10 +1457,10 @@ Optional<int> ImageStyleValue::natural_height() const
     return {};
 }
 
-void ImageStyleValue::paint(PaintContext& context, Gfx::IntRect const& dest_rect) const
+void ImageStyleValue::paint(PaintContext& context, Gfx::IntRect const& dest_rect, CSS::ImageRendering image_rendering) const
 {
     if (m_bitmap)
-        context.painter().draw_scaled_bitmap(dest_rect, *m_bitmap, m_bitmap->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+        context.painter().draw_scaled_bitmap(dest_rect, *m_bitmap, m_bitmap->rect(), 1.0f, to_gfx_scaling_mode(image_rendering));
 }
 
 String LinearGradientStyleValue::to_string() const
@@ -1608,7 +1608,7 @@ void LinearGradientStyleValue::resolve_for_size(Layout::Node const& node, Gfx::F
     m_resolved_data = Painting::resolve_linear_gradient_data(node, size, *this);
 }
 
-void LinearGradientStyleValue::paint(PaintContext& context, Gfx::IntRect const& dest_rect) const
+void LinearGradientStyleValue::paint(PaintContext& context, Gfx::IntRect const& dest_rect, CSS::ImageRendering) const
 {
     VERIFY(m_resolved_data.has_value());
     Painting::paint_linear_gradient(context, dest_rect, *m_resolved_data);

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -935,7 +935,7 @@ public:
     virtual void resolve_for_size(Layout::Node const&, Gfx::FloatSize const&) const {};
 
     virtual bool is_paintable() const = 0;
-    virtual void paint(PaintContext& context, Gfx::IntRect const& dest_rect) const = 0;
+    virtual void paint(PaintContext& context, Gfx::IntRect const& dest_rect, CSS::ImageRendering image_rendering) const = 0;
 };
 
 class ImageStyleValue final
@@ -956,7 +956,7 @@ public:
     Optional<int> natural_height() const override;
 
     bool is_paintable() const override { return !m_bitmap.is_null(); }
-    void paint(PaintContext& context, Gfx::IntRect const& dest_rect) const override;
+    void paint(PaintContext& context, Gfx::IntRect const& dest_rect, CSS::ImageRendering image_rendering) const override;
 
 private:
     ImageStyleValue(AK::URL const&);
@@ -993,12 +993,12 @@ public:
         return m_color_stop_list;
     }
 
-    float angle_degrees(Gfx::FloatSize const& gradient_rect) const;
+    float angle_degrees(Gfx::FloatSize const& gradient_size) const;
 
     void resolve_for_size(Layout::Node const&, Gfx::FloatSize const&) const override;
 
     bool is_paintable() const override { return true; }
-    void paint(PaintContext& context, Gfx::IntRect const& dest_rect) const override;
+    void paint(PaintContext& context, Gfx::IntRect const& dest_rect, CSS::ImageRendering image_rendering) const override;
 
 private:
     LinearGradientStyleValue(GradientDirection direction, Vector<ColorStopListElement> color_stop_list, GradientType type)

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -18,7 +18,7 @@
 namespace Web::Painting {
 
 // https://www.w3.org/TR/css-backgrounds-3/#backgrounds
-void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMetrics const& layout_node, Gfx::FloatRect const& border_rect, Color background_color, Vector<CSS::BackgroundLayerData> const* background_layers, BorderRadiiData const& border_radii)
+void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMetrics const& layout_node, Gfx::FloatRect const& border_rect, Color background_color, CSS::ImageRendering image_rendering, Vector<CSS::BackgroundLayerData> const* background_layers, BorderRadiiData const& border_radii)
 {
     auto& painter = context.painter();
 
@@ -309,7 +309,7 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
                 image_rect.set_x(image_x);
                 auto int_image_rect = image_rect.to_rounded<int>();
                 if (int_image_rect != last_int_image_rect && int_image_rect.intersects(context.viewport_rect()))
-                    image.paint(context, int_image_rect);
+                    image.paint(context, int_image_rect, image_rendering);
                 last_int_image_rect = int_image_rect;
                 if (!repeat_x)
                     break;

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.h
@@ -13,6 +13,6 @@
 
 namespace Web::Painting {
 
-void paint_background(PaintContext&, Layout::NodeWithStyleAndBoxModelMetrics const&, Gfx::FloatRect const&, Color background_color, Vector<CSS::BackgroundLayerData> const*, BorderRadiiData const&);
+void paint_background(PaintContext&, Layout::NodeWithStyleAndBoxModelMetrics const&, Gfx::FloatRect const&, Color background_color, CSS::ImageRendering, Vector<CSS::BackgroundLayerData> const*, BorderRadiiData const&);
 
 }

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -55,7 +55,7 @@ void InlinePaintable::paint(PaintContext& context, Painting::PaintPhase phase) c
             }
 
             auto border_radii_data = Painting::normalized_border_radii_data(layout_node(), absolute_fragment_rect, top_left_border_radius, top_right_border_radius, bottom_right_border_radius, bottom_left_border_radius);
-            Painting::paint_background(context, layout_node(), absolute_fragment_rect, computed_values().background_color(), &computed_values().background_layers(), border_radii_data);
+            Painting::paint_background(context, layout_node(), absolute_fragment_rect, computed_values().background_color(), computed_values().image_rendering(), &computed_values().background_layers(), border_radii_data);
 
             if (auto computed_box_shadow = computed_values().box_shadow(); !computed_box_shadow.is_empty()) {
                 Vector<Painting::ShadowData> resolved_box_shadow_data;

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -43,7 +43,7 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
         };
         image_rect.center_within(enclosing);
         list_style_image->resolve_for_size(layout_box(), image_rect.size().to_type<float>());
-        list_style_image->paint(context, image_rect);
+        list_style_image->paint(context, image_rect, computed_values().image_rendering());
         return;
     }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -222,7 +222,7 @@ void PaintableBox::paint_background(PaintContext& context) const
     if (computed_values().border_top().width || computed_values().border_right().width || computed_values().border_bottom().width || computed_values().border_left().width)
         background_rect = absolute_border_box_rect();
 
-    Painting::paint_background(context, layout_box(), background_rect, background_color, background_layers, normalized_border_radii_data());
+    Painting::paint_background(context, layout_box(), background_rect, background_color, computed_values().image_rendering(), background_layers, normalized_border_radii_data());
 }
 
 void PaintableBox::paint_box_shadow(PaintContext& context) const


### PR DESCRIPTION
This addresses @AtkinsSJ's comment on #14740 :^)