### PR TITLE
Kernel/VFS: Check that mount-point is not in use

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -90,6 +90,8 @@ private:
 
     ErrorOr<void> traverse_directory_inode(Inode&, Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)>);
 
+    bool mount_point_exists_at_inode(InodeIdentifier inode);
+
     Mount* find_mount_for_host(InodeIdentifier);
     Mount* find_mount_for_guest(InodeIdentifier);
 


### PR DESCRIPTION
Before committing the mount, verify that this host i-node is not already
a mount-point.