### PR TITLE
Kernel: Remove leftover reference to prekernel on aarch64

### DIFF
--- a/Kernel/Arch/aarch64/CPU.h
+++ b/Kernel/Arch/aarch64/CPU.h
@@ -11,6 +11,6 @@
 namespace Kernel {
 
 void drop_to_exception_level_1();
-void init_prekernel_page_tables();
+void init_page_tables();
 
 }

--- a/Kernel/Arch/aarch64/MMU.cpp
+++ b/Kernel/Arch/aarch64/MMU.cpp
@@ -186,7 +186,7 @@ static void activate_mmu()
     Aarch64::Asm::flush();
 }
 
-void init_prekernel_page_tables()
+void init_page_tables()
 {
     PageBumpAllocator allocator((u64*)page_tables_phys_start, (u64*)page_tables_phys_end);
     build_identity_map(allocator);

--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -116,7 +116,7 @@ extern "C" [[noreturn]] void init()
     dbgln("Firmware version: {}", firmware_version);
 
     dbgln("Initialize MMU");
-    init_prekernel_page_tables();
+    init_page_tables();
 
     auto& framebuffer = RPi::Framebuffer::the();
     if (framebuffer.initialized()) {


### PR DESCRIPTION
This commit essentially just renames `init_prekernel_page_tables` to `init_page_tables` :^)