### PR TITLE
LibWeb+Base: Calculate x,y of absolutely positioned divs

### DIFF
--- a/Base/res/html/misc/clip.html
+++ b/Base/res/html/misc/clip.html
@@ -2,51 +2,56 @@
 <html>
 <head>
     <meta charset="UTF-8"/>
-    <title>CSS Clip test</title>
+    <title>CSS Clip Test Page</title>
     <style>
-        .box1 {
-          background-color: red;
-          height: 300px;
-          width: 400px;
-          position: absolute;
-        }
-        .box2 {
-          background-color: blue;
-          height: 300px;
-          width: 400px;
-          position: absolute;
-          clip: rect(auto, 150px, 8em, -5px);
-          color: white;
-        }
-        .box3 {
-          background-color: purple;
-          height: 300px;
-          width: 400px;
-          position: absolute;
-          clip: rect(0em, 0px, 0px, 0px);
-          top: 350px;
-          color: white;
-        }
+      .box {
+        height: 100px;
+        width: 100px;
+        position: absolute;
+        background-color: aquamarine;
+      }
+
+      .separate-tests {
+        height: 125px;
+        border-width: 0px;
+      }
     </style>
 </head>
 <body>
-    <h1>Clip with rect</h1>
+    <h2>This is a normal rect with auto clipping</h2>
+    <div class="separate-tests">
+      <div class="box" style="clip: rect(auto, auto, auto, auto);"></div>
+    </div>
 
-    <h2>Clip should look kind of like the American flag</h2>
-    <div class="box1">
-      <div class="box2">
-        <p>Hello this is some text</p>
-        <p>Hello this is some text</p>
-        <p>Hello this is some text</p>
-        <p>Hello this is some text</p>
+    <h2>This is a div with the left side clipped out</h2>
+    <div class="separate-tests">
+      <div class="box" style="clip: rect(auto, auto, auto, 50px);"></div>
+    </div>
+
+    <h2>One can create a rect with or without commas and the clip works</h2>
+    <div class="separate-tests">
+      <div class="box" style="clip: rect(4em auto auto auto);"></div>
+    </div>
+
+    <h2>Text and borders are clipped too</h2>
+    <div class="separate-tests">
+      <div class="box" style="clip: rect(-5px auto auto 50px); border: 2px solid black;">
+        Lots of text Lots of text
+        Lots of text Lots of text
+        Lots of text Lots of text
+        Lots of text Lots of text
+        Lots of text Lots of text
       </div>
     </div>
 
-    <h2 style="margin-top: 350px;">Clip should not be visible</h2>
-    <div class="box3">
-      <p>Hello this is some text</p>
-      <p>Hello this is some text</p>
-      <p>Hello this is some text</p>
-      <p>Hello this is some text</p>
+    <h2>:yakgone:</h2>
+    <div class="separate-tests">
+      <div class="box" style="clip: rect(0px 0px 0px 0px); border: 2px solid black;">
+        Lots of text Lots of text
+        Lots of text Lots of text
+        Lots of text Lots of text
+        Lots of text Lots of text
+        Lots of text Lots of text
+      </div>
     </div>
 </body>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1089,4 +1089,59 @@ float FormattingContext::containing_block_height_for(Box const& box, LayoutState
     VERIFY_NOT_REACHED();
 }
 
+float FormattingContext::compute_box_y_position_with_respect_to_siblings(Box const& child_box, LayoutState::UsedValues const& box_state)
+{
+    float y = box_state.border_box_top();
+
+    Vector<float> collapsible_margins;
+
+    auto* relevant_sibling = child_box.previous_sibling_of_type<Layout::BlockContainer>();
+    while (relevant_sibling != nullptr) {
+        if (!relevant_sibling->is_absolutely_positioned() && !relevant_sibling->is_floating()) {
+            auto const& relevant_sibling_state = m_state.get(*relevant_sibling);
+            collapsible_margins.append(relevant_sibling_state.margin_bottom);
+            // NOTE: Empty (0-height) preceding siblings have their margins collapsed with *their* preceding sibling, etc.
+            if (relevant_sibling_state.border_box_height() > 0)
+                break;
+            collapsible_margins.append(relevant_sibling_state.margin_top);
+        }
+        relevant_sibling = relevant_sibling->previous_sibling_of_type<Layout::BlockContainer>();
+    }
+
+    if (relevant_sibling) {
+        // Collapse top margin with the collapsed margin(s) of preceding siblings.
+        collapsible_margins.append(box_state.margin_top);
+
+        float smallest_margin = 0;
+        float largest_margin = 0;
+        size_t negative_margin_count = 0;
+        for (auto margin : collapsible_margins) {
+            if (margin < 0)
+                ++negative_margin_count;
+            largest_margin = max(largest_margin, margin);
+            smallest_margin = min(smallest_margin, margin);
+        }
+
+        float collapsed_margin = 0;
+        if (negative_margin_count == collapsible_margins.size()) {
+            // When all margins are negative, the size of the collapsed margin is the smallest (most negative) margin.
+            collapsed_margin = smallest_margin;
+        } else if (negative_margin_count > 0) {
+            // When negative margins are involved, the size of the collapsed margin is the sum of the largest positive margin and the smallest (most negative) negative margin.
+            collapsed_margin = largest_margin + smallest_margin;
+        } else {
+            // Otherwise, collapse all the adjacent margins by using only the largest one.
+            collapsed_margin = largest_margin;
+        }
+
+        auto const& relevant_sibling_state = m_state.get(*relevant_sibling);
+        return y + relevant_sibling_state.offset.y()
+            + relevant_sibling_state.content_height()
+            + relevant_sibling_state.border_box_bottom()
+            + collapsed_margin;
+    } else {
+        return y + box_state.margin_top;
+    }
+}
+
 }

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -63,6 +63,8 @@ public:
 
     virtual void run_intrinsic_sizing(Box const&);
 
+    float compute_box_y_position_with_respect_to_siblings(Box const&, LayoutState::UsedValues const&);
+
 protected:
     FormattingContext(Type, LayoutState&, Box const&, FormattingContext* parent = nullptr);
 


### PR DESCRIPTION
Calculate the x and y position of absolutely positioned divs with 'auto' values for their 'top' and 'left' positions based on their siblings and parents.

I also included a commit to clean up the Clip test page I made in #14730, which was in desperate need of this absolutely positioned divs PR so as to separate the different clip tests rationally.