### PR TITLE
LibGUI: Add an overwrite mode to the TextEditor widget

### DIFF
--- a/Userland/Libraries/LibGUI/RegularEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/RegularEditingEngine.cpp
@@ -12,7 +12,7 @@ namespace GUI {
 
 CursorWidth RegularEditingEngine::cursor_width() const
 {
-    return CursorWidth::NARROW;
+    return m_editor->typing_mode() == TextEditor::TypingMode::Overwrite ? CursorWidth::WIDE : CursorWidth::NARROW;
 }
 
 bool RegularEditingEngine::on_key(KeyEvent const& event)
@@ -23,6 +23,12 @@ bool RegularEditingEngine::on_key(KeyEvent const& event)
     if (event.key() == KeyCode::Key_Escape) {
         if (m_editor->on_escape_pressed)
             m_editor->on_escape_pressed();
+        return true;
+    }
+
+    if (event.key() == KeyCode::Key_Insert) {
+        auto new_typing_mode = m_editor->typing_mode() == TextEditor::TypingMode::Insert ? TextEditor::TypingMode::Overwrite : TextEditor::TypingMode::Insert;
+        m_editor->set_typing_mode(new_typing_mode);
         return true;
     }
 

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -128,6 +128,7 @@ public:
 
     TextPosition insert_at(TextPosition const&, u32, Client const* = nullptr);
     TextPosition insert_at(TextPosition const&, StringView, Client const* = nullptr);
+    TextPosition overwrite_at(TextPosition const&, StringView, Client const* = nullptr);
     void remove(TextRange const&);
 
     virtual bool is_code_document() const { return false; }
@@ -174,6 +175,7 @@ public:
     void append(TextDocument&, u32);
     void prepend(TextDocument&, u32);
     void insert(TextDocument&, size_t index, u32);
+    void replace_or_append(TextDocument&, size_t index, u32);
     void remove(TextDocument&, size_t index);
     void append(TextDocument&, u32 const*, size_t);
     void truncate(TextDocument&, size_t length);
@@ -218,6 +220,22 @@ public:
     InsertTextCommand(TextDocument&, String const&, TextPosition const&);
     virtual ~InsertTextCommand() = default;
     virtual void perform_formatting(TextDocument::Client const&) override;
+    virtual void undo() override;
+    virtual void redo() override;
+    virtual bool merge_with(GUI::Command const&) override;
+    virtual String action_text() const override;
+    String const& text() const { return m_text; }
+    TextRange const& range() const { return m_range; }
+
+private:
+    String m_text;
+    TextRange m_range;
+};
+
+class OverwriteTextCommand : public TextDocumentUndoCommand {
+public:
+    OverwriteTextCommand(TextDocument&, String const&, TextPosition const&);
+    virtual ~OverwriteTextCommand() = default;
     virtual void undo() override;
     virtual void redo() override;
     virtual bool merge_with(GUI::Command const&) override;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1513,7 +1513,10 @@ void TextEditor::insert_at_cursor_or_replace_selection(StringView text)
         && clear_length > 0
         && current_line().leading_spaces() == clear_length;
 
-    execute<InsertTextCommand>(text, m_cursor);
+    if (m_typing_mode == TypingMode::Insert)
+        execute<InsertTextCommand>(text, m_cursor);
+    else
+        execute<OverwriteTextCommand>(text, m_cursor);
 
     if (should_clear_last_line) { // If it does leave just whitespace, clear it.
         auto const original_cursor_position = cursor();
@@ -1724,6 +1727,12 @@ void TextEditor::set_text_alignment(Gfx::TextAlignment alignment)
     if (m_text_alignment == alignment)
         return;
     m_text_alignment = alignment;
+    update();
+}
+
+void TextEditor::set_typing_mode(TypingMode typing_mode)
+{
+    m_typing_mode = typing_mode;
     update();
 }
 

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -43,6 +43,11 @@ public:
         DisplayOnly
     };
 
+    enum TypingMode {
+        Insert,
+        Overwrite
+    };
+
     enum WrappingMode {
         NoWrap,
         WrapAnywhere,
@@ -84,6 +89,9 @@ public:
 
     Gfx::TextAlignment text_alignment() const { return m_text_alignment; }
     void set_text_alignment(Gfx::TextAlignment);
+
+    TypingMode typing_mode() const { return m_typing_mode; }
+    void set_typing_mode(TypingMode);
 
     Type type() const { return m_type; }
     bool is_single_line() const { return m_type == SingleLine; }
@@ -367,6 +375,7 @@ private:
 
     TextPosition m_cursor;
     Gfx::TextAlignment m_text_alignment { Gfx::TextAlignment::CenterLeft };
+    TypingMode m_typing_mode { TypingMode::Insert };
     bool m_cursor_state { true };
     bool m_in_drag_select { false };
     bool m_ruler_visible { false };


### PR DESCRIPTION
This adds an overwrite/overtype mode to the TextEditor widget that can be toggled with the insert key. I couldn't figure out how to implement undo/redo, so for now it's just a FIXME.