### PR TITLE
LibWeb: Implement `linear-gradient()` transition hints 

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -102,6 +102,22 @@
             background-image: linear-gradient(to top left, red, green, blue);
             background-size: 30px 30px;
         }
+
+        .grad-hints {
+            background-image: linear-gradient(to right, hotpink, 50%, rebeccapurple);
+        }
+
+        .grad-rainbow {
+            background-image: linear-gradient(
+                to right,
+                tomato,
+                25%,
+                orange 0,
+                50%,
+                yellowgreen 0,
+                75%,
+                dodgerblue 0)
+        }
     </style>
   </head>
   <body>
@@ -112,13 +128,17 @@
     <div class="box grad-2"></div>
     <div class="box grad-3"></div>
     <div class="box grad-4"></div>
-    <b>Funky color hints:</b><br>
+    <b>Funky transition hints:</b><br>
     <div class="box grad-5"></div>
     <div class="box grad-6"></div>
+    <div class="box grad-rainbow"></div>
+    <b>Transition hint test (click to animate):</b><br>
+    <div id="gradient-hints" class="box grad-hints"></div>
     <b>Multiple color stops + arbitrary angles (click to spin!):</b><br>
     <div id="gradient-spin" class="rect grad-7"></div>
     <b>Default color stops:</b><br>
     <div class="box grad-8"></div>
+    <b>Cool pattern demo</b><br>
     <div class="box grad-9"></div>
     <b>Pre-multiplied alpha mixing test:</b><br>
     <div class="box grad-10"></div>
@@ -156,22 +176,29 @@
         })
     }
 
-    // Spinning gradient demo/test
-    let angle = 0;
-    let spinIntervalId = -1;
-    const gradientSpin = document.getElementById("gradient-spin");
-    gradientSpin.onclick = () => {
-        if (spinIntervalId <= -1) {
-            spinIntervalId = setInterval(() => {
-                gradientSpin.style.backgroundImage = `linear-gradient(${angle}deg, red 0%, black 20%, yellow 60%, cyan 100%)`;
-                angle += 1;
-                updateLabels();
-            }, 100)
-        }  else {
-            clearInterval(spinIntervalId);
-            spinIntervalId = -1;
+    const backgroundAnimateDemo = (id, newBackgroundCallback) => {
+        const el = document.getElementById(id);
+        let t = 0;
+        let demoIntervalId = -1;
+        el.onclick = () => {
+            if (demoIntervalId <= -1) {
+                demoIntervalId = setInterval(() => {
+                    el.style.backgroundImage = newBackgroundCallback(t);
+                    t += 1;
+                    updateLabels();
+                }, 100)
+            }  else {
+                clearInterval(demoIntervalId);
+                demoIntervalId = -1;
+            }
         }
     }
+
+    // Spinning gradient demo/test
+    backgroundAnimateDemo("gradient-spin", angle => `linear-gradient(${angle}deg, red 0%, black 20%, yellow 60%, cyan 100%)`)
+
+    // Transistion hints demo
+    backgroundAnimateDemo("gradient-hints", t => `linear-gradient(to right, hotpink, ${((Math.sin(t/4)+1)*50)|0}%, rebeccapurple)`)
 
     updateLabels();
   </script>

--- a/Base/res/html/misc/progressbar.html
+++ b/Base/res/html/misc/progressbar.html
@@ -69,15 +69,14 @@
 
         #really-fancy-progress[value] {
             appearance: none;
-            width: 500px;
-            height: 40px;
+            width: 250px;
+            height: 20px;
         }
 
         #really-fancy-progress[value]::-webkit-progress-bar {
             background-color: #eee;
             border-radius: 2px;
-            /* FIXME: Should be an inset shadow (not supported yet) */
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25);
+            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25) inset;
         }
 
         #really-fancy-progress[value]::-webkit-progress-value {
@@ -89,8 +88,9 @@
                                         rgba(255, 255, 255, .25),
                                         rgba(0, 0, 0, .25)),
                 -webkit-linear-gradient(left, #09c, #f44);
+
             border-radius: 2px;
-            background-size: 70px 40px, 100% 100%, 100% 100%;
+            background-size: 35px 20px, 100% 100%, 100% 100%;
         }
     </style>
 

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -58,28 +58,37 @@ LinearGradientData resolve_linear_gradient_data(Layout::Node const& node, Gfx::F
         ? last_stop.length->resolved(node, gradient_length).to_px(node)
         : gradient_length_px;
 
-    // FIXME: Handle transition hints
     // 2. If a color stop or transition hint has a position that is less than the
     //    specified position of any color stop or transition hint before it in the list,
     //    set its position to be equal to the largest specified position of any color stop
     //    or transition hint before it.
-    auto max_previous_color_stop = resolved_color_stops[0].position;
+    auto max_previous_color_stop_or_hint = resolved_color_stops[0].position;
     for (size_t i = 1; i < color_stop_list.size(); i++) {
         auto& stop = color_stop_list[i];
+        if (stop.transition_hint.has_value()) {
+            float value = stop.transition_hint->value.resolved(node, gradient_length).to_px(node);
+            value = max(value, max_previous_color_stop_or_hint);
+            resolved_color_stops[i].transition_hint = value;
+            max_previous_color_stop_or_hint = value;
+        }
         if (stop.color_stop.length.has_value()) {
             float value = stop.color_stop.length->resolved(node, gradient_length).to_px(node);
-            value = max(value, max_previous_color_stop);
+            value = max(value, max_previous_color_stop_or_hint);
             resolved_color_stops[i].position = value;
-            max_previous_color_stop = value;
+            max_previous_color_stop_or_hint = value;
         }
     }
 
     // 3. If any color stop still does not have a position, then, for each run of adjacent color stops
     //    without positions, set their positions so that they are evenly spaced between the preceding
     //    and following color stops with positions.
+    // Note: Though not mentioned anywhere in the specification transition hints are counted as "color stops with positions".
     size_t i = 1;
     auto find_run_end = [&] {
-        while (i < color_stop_list.size() - 1 && !color_stop_list[i].color_stop.length.has_value()) {
+        auto color_stop_has_position = [](auto& color_stop) {
+            return color_stop.transition_hint.has_value() || color_stop.color_stop.length.has_value();
+        };
+        while (i < color_stop_list.size() - 1 && !color_stop_has_position(color_stop_list[i])) {
             i++;
         }
         return i;
@@ -88,15 +97,27 @@ LinearGradientData resolve_linear_gradient_data(Layout::Node const& node, Gfx::F
         auto& stop = color_stop_list[i];
         if (!stop.color_stop.length.has_value()) {
             auto run_start = i - 1;
+            auto start_position = resolved_color_stops[i++].transition_hint.value_or(resolved_color_stops[run_start].position);
             auto run_end = find_run_end();
-            auto start_position = resolved_color_stops[run_start].position;
-            auto end_position = resolved_color_stops[run_end].position;
+            auto end_position = resolved_color_stops[run_end].transition_hint.value_or(resolved_color_stops[run_end].position);
             auto spacing = (end_position - start_position) / (run_end - run_start);
             for (auto j = run_start + 1; j < run_end; j++) {
                 resolved_color_stops[j].position = start_position + (j - run_start) * spacing;
             }
         }
         i++;
+    }
+
+    // Determine the location of the transition hint as a percentage of the distance between the two color stops,
+    // denoted as a number between 0 and 1, where 0 indicates the hint is placed right on the first color stop,
+    // and 1 indicates the hint is placed right on the second color stop.
+    for (size_t i = 1; i < resolved_color_stops.size(); i++) {
+        auto& color_stop = resolved_color_stops[i];
+        auto& previous_color_stop = resolved_color_stops[i - 1];
+        if (color_stop.transition_hint.has_value()) {
+            auto stop_length = color_stop.position - previous_color_stop.position;
+            color_stop.transition_hint = stop_length > 0 ? (*color_stop.transition_hint - previous_color_stop.position) / stop_length : 0;
+        }
     }
 
     return { gradient_angle, resolved_color_stops };
@@ -148,13 +169,26 @@ void paint_linear_gradient(PaintContext& context, Gfx::IntRect const& gradient_r
     // Rotate gradient line to be horizontal
     auto rotated_start_point_x = start_point.x() * cos_angle - start_point.y() * -sin_angle;
 
-    // FIXME: Handle transition hint interpolation
-    auto linear_step = [](float min, float max, float value) -> float {
-        if (value < min)
-            return 0.;
-        if (value > max)
-            return 1.;
-        return (value - min) / (max - min);
+    auto color_stop_step = [&](auto& previous_stop, auto& next_stop, float position) -> float {
+        if (position < previous_stop.position)
+            return 0;
+        if (position > next_stop.position)
+            return 1;
+        // For any given point between the two color stops,
+        // determine the point’s location as a percentage of the distance between the two color stops.
+        // Let this percentage be P.
+        auto p = (position - previous_stop.position) / (next_stop.position - previous_stop.position);
+        if (!next_stop.transition_hint.has_value())
+            return p;
+        if (*next_stop.transition_hint >= 1)
+            return 0;
+        if (*next_stop.transition_hint <= 0)
+            return 1;
+        // Let C, the color weighting at that point, be equal to P^(logH(.5)).
+        auto c = AK::pow(p, AK::log<float>(0.5) / AK::log(*next_stop.transition_hint));
+        // The color at that point is then a linear blend between the colors of the two color stops,
+        // blending (1 - C) of the first stop and C of the second stop.
+        return c;
     };
 
     Vector<Gfx::Color, 1024> gradient_line_colors;
@@ -165,17 +199,17 @@ void paint_linear_gradient(PaintContext& context, Gfx::IntRect const& gradient_r
         Gfx::Color gradient_color = color_mix(
             color_stops[0].color,
             color_stops[1].color,
-            linear_step(
-                color_stops[0].position,
-                color_stops[1].position,
+            color_stop_step(
+                color_stops[0],
+                color_stops[1],
                 loc));
         for (size_t i = 1; i < color_stops.size() - 1; i++) {
             gradient_color = color_mix(
                 gradient_color,
                 color_stops[i + 1].color,
-                linear_step(
-                    color_stops[i].position,
-                    color_stops[i + 1].position,
+                color_stop_step(
+                    color_stops[i],
+                    color_stops[i + 1],
                     loc));
         }
         gradient_line_colors[loc] = gradient_color;

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.h
@@ -17,6 +17,7 @@ namespace Web::Painting {
 struct ColorStop {
     Gfx::Color color;
     float position = 0;
+    Optional<float> transition_hint = {};
 };
 
 using ColorStopList = Vector<ColorStop, 4>;


### PR DESCRIPTION
**Demo:**
![vokoscreenNG-2022-08-11_19-42-23](https://user-images.githubusercontent.com/11597044/184215646-19f91695-56a9-4ab7-a826-6db4bbfc1eef.gif)

**Top:** Some stripes made using transition hints. 
**Bottom:** An animation of moving the the transition hint between two colour stops. 

With this all of the gradient demos in `gradients.html` are rendering correctly (+/- a few pixels, which I think is due to the style value changes).

**P.s.** I had to wiggle my mouse over the `div` to keep the animation going (seems like some missing invalidation somewhere).