### PR TITLE
Kernel: Lock the inode before writing in SharedInodeVMObject::Sync

### DIFF
--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -19,6 +19,7 @@
 #include <Kernel/Forward.h>
 #include <Kernel/Library/ListedRefCounted.h>
 #include <Kernel/Locking/Mutex.h>
+#include <Kernel/Memory/SharedInodeVMObject.h>
 
 namespace Kernel {
 
@@ -32,6 +33,7 @@ class Inode : public ListedRefCounted<Inode, LockType::Spinlock>
     friend class VirtualFileSystem;
     friend class FileSystem;
     friend class InodeFile;
+    friend class Kernel::Memory::SharedInodeVMObject; // FIXME: Remove when write_bytes becomes non-virtual
 
 public:
     virtual ~Inode();

--- a/Kernel/Memory/SharedInodeVMObject.cpp
+++ b/Kernel/Memory/SharedInodeVMObject.cpp
@@ -53,6 +53,7 @@ ErrorOr<void> SharedInodeVMObject::sync(off_t offset_in_pages, size_t pages)
         u8 page_buffer[PAGE_SIZE];
         MM.copy_physical_page(*physical_page, page_buffer);
 
+        MutexLocker locker(m_inode->m_inode_lock);
         TRY(m_inode->write_bytes(page_index * PAGE_SIZE, PAGE_SIZE, UserOrKernelBuffer::for_kernel_buffer(page_buffer), nullptr));
     }
 


### PR DESCRIPTION
PR #14713 added a check that expects inodes to already be locked before
calling `Ext2FSInode::write_bytes`. This commit adds a lock from
SharedInodeVMObject::Sync before calling `Ext2FSInode::write_bytes`
directly.

Without this fix the following kernel panic can be reproduced by installing the `llvm` port and trying to use `clang` to build a test program:

```
[lld(50:50)]: ASSERTION FAILED: m_inode_lock.is_locked()
[lld(50:50)]: ./Kernel/FileSystem/Ext2FileSystem.cpp:940 in virtual AK::ErrorOr<unsigned int> Kernel::Ext2FSInode::write_bytes(off_t, size_t, const Kernel::UserOrKernelBuffer&, Kernel::OpenFileDescription*)
[lld(50:50)]: KERNEL PANIC! :^(
[lld(50:50)]: Aborted
[lld(50:50)]: at ./Kernel/Arch/x86/common/CPU.cpp:35 in void abort()
[lld(50:50)]: Kernel + 0x0096fae1  Kernel::__panic(char const*, unsigned int, char const*) +0xf1
[lld(50:50)]: Kernel + 0x00d45760  Kernel::cpu_feature_to_string_view(AK::ArbitrarySizedEnum<AK::DistinctNumeric<AK::UFixedBigInt<AK::UFixedBigInt<unsigned long long> >, Kernel::CPUFeature::__CPUFeatureTag, false, true, false, false, false, false> > const&) +0x0
[lld(50:50)]: Kernel + 0x00d45514  abort.localalias +0x0
[lld(50:50)]: Kernel + 0x0045fa1d  Kernel::Ext2FSInode::write_bytes(long long, unsigned int, Kernel::UserOrKernelBuffer const&, Kernel::OpenFileDescription*) [clone .localalias] +0x14fd
[lld(50:50)]: Kernel + 0x007f4deb  Kernel::Memory::SharedInodeVMObject::sync(long long, unsigned int) +0x56b
[lld(50:50)]: Kernel + 0x007b8b5b  Kernel::Memory::Region::~Region() [clone .localalias] +0xfcb
[lld(50:50)]: Kernel + 0x00701741  Kernel::Memory::AddressSpace::deallocate_region(Kernel::Memory::Region&) [clone .localalias] +0x81
[lld(50:50)]: Kernel + 0x0070e236  Kernel::Memory::AddressSpace::unmap_mmap_range(VirtualAddress, unsigned int) +0x7e6
[lld(50:50)]: Kernel + 0x00b22c84  Kernel::Process::sys$munmap(AK::Userspace<void*>, unsigned int) +0x364
[lld(50:50)]: Kernel + 0x00a552d3  syscall_handler +0x1083
[lld(50:50)]: Kernel + 0x00a54241  syscall_asm_entry +0x31
```