### PR TITLE
PixelPaint: Apply filters on another thread

### DIFF
--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCES
     IconBag.cpp
     Image.cpp
     ImageEditor.cpp
+    ImageProcessor.cpp
     Layer.cpp
     LayerListWidget.cpp
     LayerPropertiesWidget.cpp

--- a/Userland/Applications/PixelPaint/FilterTreeModel.cpp
+++ b/Userland/Applications/PixelPaint/FilterTreeModel.cpp
@@ -32,7 +32,7 @@ ErrorOr<NonnullRefPtr<GUI::TreeViewModel>> create_filter_tree_model(ImageEditor*
     auto filter_tree_model = GUI::TreeViewModel::create();
 
     auto add_filter_node = [&]<typename FilterType>(GUI::TreeViewModel::Node& node) {
-        auto filter = adopt_own(*new FilterType(editor));
+        auto filter = make_ref_counted<FilterType>(editor);
         (void)node.add_node<FilterNode>(filter->filter_name(), filter_icon, move(filter));
     };
 

--- a/Userland/Applications/PixelPaint/FilterTreeModel.h
+++ b/Userland/Applications/PixelPaint/FilterTreeModel.h
@@ -16,7 +16,7 @@ namespace PixelPaint {
 
 class FilterNode final : public GUI::TreeViewModel::Node {
 public:
-    FilterNode(String text, Optional<GUI::Icon> icon, Node* parent_node, NonnullOwnPtr<Filter> filter)
+    FilterNode(String text, Optional<GUI::Icon> icon, Node* parent_node, NonnullRefPtr<Filter> filter)
         : Node(move(text), move(icon), parent_node)
         , m_filter(move(filter))
     {
@@ -26,7 +26,7 @@ public:
     Filter& filter() { return *m_filter; }
 
 private:
-    NonnullOwnPtr<Filter> m_filter;
+    NonnullRefPtr<Filter> m_filter;
 };
 
 ErrorOr<NonnullRefPtr<GUI::TreeViewModel>> create_filter_tree_model(ImageEditor*);

--- a/Userland/Applications/PixelPaint/Filters/Filter.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Filter.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Filter.h"
+#include "../ImageProcessor.h"
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Label.h>
 
@@ -40,11 +41,10 @@ void Filter::apply() const
 {
     if (!m_editor)
         return;
-    if (auto* layer = m_editor->active_layer()) {
-        apply(layer->content_bitmap(), layer->content_bitmap());
-        layer->did_modify_bitmap(layer->rect());
-        m_editor->did_complete_action(String::formatted("Filter {}", filter_name()));
-    }
+    // FIXME: I am not thread-safe!
+    // If you try to edit the bitmap while the image processor is still running... :yaksplode:
+    if (auto* layer = m_editor->active_layer())
+        MUST(ImageProcessor::the()->enqueue_command(make_ref_counted<FilterApplicationCommand>(*this, *layer)));
 }
 
 void Filter::update_preview()

--- a/Userland/Applications/PixelPaint/Filters/Filter.h
+++ b/Userland/Applications/PixelPaint/Filters/Filter.h
@@ -13,7 +13,7 @@
 
 namespace PixelPaint {
 
-class Filter {
+class Filter : public RefCounted<Filter> {
 public:
     virtual void apply() const;
     virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const = 0;

--- a/Userland/Applications/PixelPaint/Filters/Filter.h
+++ b/Userland/Applications/PixelPaint/Filters/Filter.h
@@ -13,7 +13,11 @@
 
 namespace PixelPaint {
 
+class FilterApplicationCommand;
+
 class Filter : public RefCounted<Filter> {
+    friend class FilterApplicationCommand;
+
 public:
     virtual void apply() const;
     virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const = 0;

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -30,6 +30,7 @@ constexpr int marching_ant_length = 4;
 ImageEditor::ImageEditor(NonnullRefPtr<Image> image)
     : m_image(move(image))
     , m_title("Untitled")
+    , m_gui_event_loop(Core::EventLoop::current())
 {
     set_focus_policy(GUI::FocusPolicy::StrongFocus);
     m_undo_stack.push(make<ImageUndoCommand>(*m_image, String()));

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -12,6 +12,7 @@
 #include "Image.h"
 #include "Selection.h"
 #include <AK/Variant.h>
+#include <LibCore/EventLoop.h>
 #include <LibGUI/AbstractZoomPanWidget.h>
 #include <LibGUI/Frame.h>
 #include <LibGUI/UndoStack.h>
@@ -114,6 +115,8 @@ public:
     void draw_marching_ants(Gfx::Painter&, Gfx::IntRect const&) const;
     void draw_marching_ants(Gfx::Painter&, Mask const&) const;
 
+    Core::EventLoop& gui_event_loop() { return m_gui_event_loop; }
+
 private:
     explicit ImageEditor(NonnullRefPtr<Image>);
 
@@ -179,6 +182,8 @@ private:
     int m_marching_ants_offset { 0 };
 
     void draw_marching_ants_pixel(Gfx::Painter&, int x, int y) const;
+
+    Core::EventLoop& m_gui_event_loop;
 };
 
 }

--- a/Userland/Applications/PixelPaint/ImageProcessor.cpp
+++ b/Userland/Applications/PixelPaint/ImageProcessor.cpp
@@ -20,7 +20,7 @@ void FilterApplicationCommand::execute()
     m_filter->m_editor->gui_event_loop().deferred_invoke([strong_this = NonnullRefPtr(*this)]() {
         // HACK: we can't tell strong_this to not be const
         (*const_cast<NonnullRefPtr<Layer>*>(&strong_this->m_target_layer))->did_modify_bitmap(strong_this->m_target_layer->rect());
-        strong_this->m_filter->m_editor->did_complete_action();
+        strong_this->m_filter->m_editor->did_complete_action(String::formatted("Filter {}", strong_this->m_filter->filter_name()));
     });
 }
 

--- a/Userland/Applications/PixelPaint/ImageProcessor.cpp
+++ b/Userland/Applications/PixelPaint/ImageProcessor.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ImageProcessor.h"
+
+namespace PixelPaint {
+
+FilterApplicationCommand::FilterApplicationCommand(NonnullRefPtr<Filter> filter, NonnullRefPtr<Layer> target_layer)
+    : m_filter(move(filter))
+    , m_target_layer(move(target_layer))
+{
+}
+
+void FilterApplicationCommand::execute()
+{
+    m_filter->apply(m_target_layer->content_bitmap(), m_target_layer->content_bitmap());
+    m_filter->m_editor->gui_event_loop().deferred_invoke([strong_this = NonnullRefPtr(*this)]() {
+        // HACK: we can't tell strong_this to not be const
+        (*const_cast<NonnullRefPtr<Layer>*>(&strong_this->m_target_layer))->did_modify_bitmap(strong_this->m_target_layer->rect());
+        strong_this->m_filter->m_editor->did_complete_action();
+    });
+}
+
+static Singleton<ImageProcessor> s_image_processor;
+
+ImageProcessor::ImageProcessor()
+    : m_command_queue(MUST(Queue::try_create()))
+    , m_processor_thread(Threading::Thread::construct([this]() {
+        while (true) {
+            if (auto next_command = m_command_queue.try_dequeue(); !next_command.is_error()) {
+                next_command.value()->execute();
+            } else {
+                Threading::MutexLocker locker { m_wakeup_mutex };
+                m_wakeup_variable.wait_while([this]() { return m_command_queue.weak_used() == 0; });
+            }
+        }
+        return 0;
+    },
+          "Image Processor"sv))
+    , m_wakeup_variable(m_wakeup_mutex)
+{
+}
+
+ImageProcessor* ImageProcessor::the()
+{
+    return s_image_processor;
+}
+
+ErrorOr<void> ImageProcessor::enqueue_command(NonnullRefPtr<ImageProcessingCommand> command)
+{
+    if (auto queue_status = m_command_queue.try_enqueue(move(command)); queue_status.is_error())
+        return ENOSPC;
+
+    if (!m_processor_thread->is_started()) {
+        m_processor_thread->start();
+        m_processor_thread->detach();
+    }
+
+    m_wakeup_mutex.lock();
+    m_wakeup_variable.signal();
+    m_wakeup_mutex.unlock();
+
+    return {};
+}
+
+}

--- a/Userland/Applications/PixelPaint/ImageProcessor.h
+++ b/Userland/Applications/PixelPaint/ImageProcessor.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Filters/Filter.h"
+#include <AK/Function.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefCounted.h>
+#include <AK/Singleton.h>
+#include <LibCore/SharedCircularQueue.h>
+#include <LibThreading/ConditionVariable.h>
+#include <LibThreading/Thread.h>
+
+namespace PixelPaint {
+
+class ImageProcessingCommand : public RefCounted<ImageProcessingCommand> {
+public:
+    virtual void execute() = 0;
+    virtual ~ImageProcessingCommand() = default;
+};
+
+// A command applying a filter from a source to a target bitmap.
+class FilterApplicationCommand : public ImageProcessingCommand {
+public:
+    FilterApplicationCommand(NonnullRefPtr<Filter>, NonnullRefPtr<Layer>);
+
+    virtual void execute() override;
+    virtual ~FilterApplicationCommand() = default;
+
+private:
+    NonnullRefPtr<Filter> m_filter;
+    NonnullRefPtr<Layer> m_target_layer;
+};
+
+// A command based on a custom user function.
+class FunctionCommand : public ImageProcessingCommand {
+public:
+    FunctionCommand(Function<void()> function)
+        : m_function(move(function))
+    {
+    }
+
+    virtual void execute() override { m_function(); }
+
+private:
+    Function<void()> m_function;
+};
+
+// A utility class that allows various PixelPaint systems to execute image processing commands asynchronously on another thread.
+class ImageProcessor final {
+    friend struct AK::SingletonInstanceCreator<ImageProcessor>;
+
+public:
+    static ImageProcessor* the();
+
+    ErrorOr<void> enqueue_command(NonnullRefPtr<ImageProcessingCommand> command);
+
+private:
+    ImageProcessor();
+    void processor_main();
+
+    // Only the memory in the queue is in shared memory, i.e. the smart pointers themselves.
+    // The actual data will remain in normal memory, but for this application we're not using multiple processes so it's fine.
+    using Queue = Core::SharedSingleProducerCircularQueue<RefPtr<ImageProcessingCommand>>;
+    Queue m_command_queue;
+
+    NonnullRefPtr<Threading::Thread> m_processor_thread;
+    Threading::Mutex m_wakeup_mutex {};
+    Threading::ConditionVariable m_wakeup_variable;
+};
+
+}


### PR DESCRIPTION
The main advantage of this change is that heavy-weight filters do not lock up the GUI anymore.

This first cut has several flaws:
- We do not account for modification of the referenced images while the   filter is running. Depending on the exact filter behavior this might have all sorts of weird effects. A simple fix would be to show a  progress dialog to the user, preventing them from performing other  modifications in the meantime.
- We do not use the image processor for previews. Preview behavior has a  couple of other considerations that are intentionally not addressed in  this commit or pull request.

CC @Tobyase, this is the first PR that addresses points laid out in #14843.