### PR TITLE
LibGUI: Fix layout bug for the Progess bar in the FileManager Statusbar

### DIFF
--- a/Userland/Libraries/LibGUI/Statusbar.cpp
+++ b/Userland/Libraries/LibGUI/Statusbar.cpp
@@ -38,6 +38,19 @@ NonnullRefPtr<Statusbar::Segment> Statusbar::create_segment()
     return widget;
 }
 
+void Statusbar::child_event(Core::ChildEvent& event)
+{
+    auto& event_to_forward = event;
+    // To ensure that the ResizeCorner is always the last widget, and thus stays in the corner,
+    // we replace ChildAdded events that do not request specific placement with events that request placement before the corner
+    if (event.type() == Event::ChildAdded && is<Widget>(*event.child()) && !event.insertion_before_child()) {
+        Core::ChildEvent new_event(Event::ChildAdded, *event.child(), m_corner.ptr());
+        event_to_forward = new_event;
+    }
+
+    return Widget::child_event(event_to_forward);
+}
+
 void Statusbar::set_segment_count(size_t count)
 {
     if (count <= 1)

--- a/Userland/Libraries/LibGUI/Statusbar.h
+++ b/Userland/Libraries/LibGUI/Statusbar.h
@@ -76,6 +76,8 @@ private:
     void update_segment(size_t);
     NonnullRefPtr<Segment> create_segment();
 
+    virtual void child_event(Core::ChildEvent&) override;
+
     NonnullRefPtrVector<Segment> m_segments;
     RefPtr<ResizeCorner> m_corner;
 };


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/28605587/184496570-e67e9aea-709f-42a8-bb83-ac239926ae2e.mp4

After:

https://user-images.githubusercontent.com/28605587/184496586-4b5b3b70-bdb5-45e5-aa4a-7e681189b802.mp4

(Note: the problem with the status text on the left being squished too small, will be fixed when calculated_min_size is implemented for Button, so doesn't fit here)

Also 🎉💯🎉
