### PR TITLE
LibJS: Make Function.prototype a callable function object

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -21,14 +21,14 @@
 namespace JS {
 
 FunctionPrototype::FunctionPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : FunctionObject(*global_object.object_prototype())
 {
 }
 
 void FunctionPrototype::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
-    Object::initialize(global_object);
+    Base::initialize(global_object);
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.apply, apply, 2, attr);
     define_native_function(vm.names.bind, bind, 1, attr);
@@ -37,6 +37,13 @@ void FunctionPrototype::initialize(GlobalObject& global_object)
     define_native_function(*vm.well_known_symbol_has_instance(), symbol_has_instance, 1, 0);
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
     define_direct_property(vm.names.name, js_string(heap(), ""), Attribute::Configurable);
+}
+
+ThrowCompletionOr<Value> FunctionPrototype::internal_call(Value, MarkedVector<Value>)
+{
+    // The Function prototype object:
+    // - accepts any arguments and returns undefined when invoked.
+    return js_undefined();
 }
 
 // 20.2.3.1 Function.prototype.apply ( thisArg, argArray ), https://tc39.es/ecma262/#sec-function.prototype.apply

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2020-2022, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,13 +10,16 @@
 
 namespace JS {
 
-class FunctionPrototype final : public Object {
-    JS_OBJECT(FunctionPrototype, Object);
+class FunctionPrototype final : public FunctionObject {
+    JS_OBJECT(FunctionPrototype, FunctionObject);
 
 public:
     explicit FunctionPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
     virtual ~FunctionPrototype() override = default;
+
+    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
+    virtual FlyString const& name() const override { return m_name; }
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(apply);
@@ -24,6 +27,10 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(call);
     JS_DECLARE_NATIVE_FUNCTION(to_string);
     JS_DECLARE_NATIVE_FUNCTION(symbol_has_instance);
+
+    // Totally unnecessary, but sadly still necessary.
+    // TODO: Get rid of the pointless name() method.
+    FlyString m_name { "FunctionPrototype" };
 };
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/Function/Function.prototype.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Function/Function.prototype.js
@@ -1,0 +1,26 @@
+describe("correct behavior", () => {
+    test("length is 0", () => {
+        expect(Function.prototype).toHaveLength(0);
+    });
+
+    test("name is empty string", () => {
+        expect(Function.prototype.name).toBe("");
+    });
+
+    test("basic functionality", () => {
+        function fn() {}
+        expect(Object.getPrototypeOf(fn)).toBe(Function.prototype);
+        expect(Object.getPrototypeOf(Function.prototype)).toBe(Object.prototype);
+    });
+
+    test("is callable", () => {
+        expect(Function.prototype()).toBeUndefined();
+    });
+
+    test("is not constructable", () => {
+        expect(() => new Function.prototype()).toThrowWithMessage(
+            TypeError,
+            "[object FunctionPrototype] is not a constructor (evaluated from 'Function.prototype')"
+        );
+    });
+});


### PR DESCRIPTION
This has been wrong since forever:

![image](https://user-images.githubusercontent.com/19366641/184516080-49d032d0-4c7d-4fd1-b7e9-e27fc783df89.png)

```
Diff Tests:
    test/built-ins/Function/prototype/S15.3.3.1_A1.js  ❌ -> ✅
    test/built-ins/Function/prototype/S15.3.4_A1.js    ❌ -> ✅
    test/built-ins/Function/prototype/S15.3.4_A2_T1.js ❌ -> ✅
    test/built-ins/Function/prototype/S15.3.4_A2_T2.js ❌ -> ✅
    test/built-ins/Function/prototype/S15.3.4_A2_T3.js ❌ -> ✅
```

(only ran `test/built-ins/Function/**/*`)