### PR TITLE
ConfigServer: Do not crash if configuration filesystem is read-only

### DIFF
--- a/Userland/Services/ConfigServer/CMakeLists.txt
+++ b/Userland/Services/ConfigServer/CMakeLists.txt
@@ -15,4 +15,4 @@ set(SOURCES
 )
 
 serenity_bin(ConfigServer)
-target_link_libraries(ConfigServer LibIPC LibMain)
+target_link_libraries(ConfigServer LibIPC LibMain LibGUI)


### PR DESCRIPTION
Instead, inform the user of this fact once and just don't sync to disk.

This *should* make https://github.com/supercomputer7/serenity/commits/require-initramfs-init not crash on desktop bringup. 