### PR TITLE
pls: Properly set groups when executing a command

### DIFF
--- a/Userland/Utilities/pls.cpp
+++ b/Userland/Utilities/pls.cpp
@@ -42,8 +42,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio rpath exec id"));
 
-    TRY(Core::System::setgid(0));
-    TRY(Core::System::setuid(as_user_uid));
+    TRY(as_user.login());
 
     TRY(Core::System::pledge("stdio rpath exec"));
 


### PR DESCRIPTION
2 deletion, 1 addition and fixes #13437
It simply adds, as it can be expected, a call to `Core::System::setgroups()` using `LibCore::Account::login()`.


The PR is based on #14296 to take advantage of error propagation in `LibCore::Account::login()`.