### PR TITLE
SoundPlayer: Append songs to playlist on open and add export playlist action

### DIFF
--- a/Userland/Applications/SoundPlayer/CMakeLists.txt
+++ b/Userland/Applications/SoundPlayer/CMakeLists.txt
@@ -19,4 +19,4 @@ set(SOURCES
 )
 
 serenity_app(SoundPlayer ICON app-sound-player)
-target_link_libraries(SoundPlayer LibAudio LibDSP LibGUI LibMain LibThreading)
+target_link_libraries(SoundPlayer LibAudio LibDSP LibFileSystemAccessClient LibGUI LibMain LibThreading)

--- a/Userland/Applications/SoundPlayer/M3UParser.h
+++ b/Userland/Applications/SoundPlayer/M3UParser.h
@@ -11,6 +11,7 @@
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
+#include <LibCore/Forward.h>
 
 // Extended M3U fields (de facto standard)
 struct M3UExtendedInfo {
@@ -46,4 +47,8 @@ private:
     String m_playlist_path;
     bool m_use_utf8;
     Optional<String> m_parsed_playlist_title;
+};
+
+namespace M3UWriter {
+void export_to_file(Core::File&, Vector<M3UEntry> const&);
 };

--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -27,10 +27,10 @@ Player::Player(Audio::ConnectionToServer& audio_client_connection)
 
         switch (loop_mode()) {
         case LoopMode::File:
-            play_file_path(loaded_filename());
+            play_file_path(loaded_filename(), Player::AppendPlaylist::No);
             return;
         case LoopMode::Playlist:
-            play_file_path(m_playlist.next());
+            play_file_path(m_playlist.next(), Player::AppendPlaylist::No);
             return;
         case LoopMode::None:
             return;
@@ -38,7 +38,7 @@ Player::Player(Audio::ConnectionToServer& audio_client_connection)
     };
 }
 
-void Player::play_file_path(String const& path)
+void Player::play_file_path(String const& path, AppendPlaylist append_playlist)
 {
     if (path.is_null())
         return;
@@ -61,6 +61,14 @@ void Player::play_file_path(String const& path)
     auto loader = maybe_loader.value();
 
     m_loaded_filename = path;
+
+    if (append_playlist == AppendPlaylist::Yes) {
+        M3UExtendedInfo current_track_info;
+        current_track_info.track_length_in_seconds = loader->total_samples() / loader->sample_rate();
+
+        M3UEntry entry { path, current_track_info };
+        m_playlist.model()->items().append(entry);
+    }
 
     file_name_changed(path);
     total_samples_changed(loader->total_samples());

--- a/Userland/Applications/SoundPlayer/Player.h
+++ b/Userland/Applications/SoundPlayer/Player.h
@@ -34,7 +34,11 @@ public:
     explicit Player(Audio::ConnectionToServer& audio_client_connection);
     virtual ~Player() = default;
 
-    void play_file_path(String const& path);
+    enum class AppendPlaylist {
+        No,
+        Yes,
+    };
+    void play_file_path(String const& path, AppendPlaylist);
     bool is_playlist(String const& path);
 
     Playlist& playlist() { return m_playlist; }

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
@@ -24,7 +24,8 @@ PlaylistWidget::PlaylistWidget()
         auto index = m_table_view->index_at_event_position(point);
         if (!index.is_valid())
             return;
-        player->play_file_path(m_table_view->model()->data(index, static_cast<GUI::ModelRole>(PlaylistModelCustomRole::FilePath)).as_string());
+        auto path = m_table_view->model()->data(index, static_cast<GUI::ModelRole>(PlaylistModelCustomRole::FilePath)).as_string();
+        player->play_file_path(path, Player::AppendPlaylist::No);
     };
 }
 

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -83,13 +83,13 @@ SoundPlayerWidgetAdvancedView::SoundPlayerWidgetAdvancedView(GUI::Window& window
     menubar.add<GUI::Label>();
 
     m_back_action = GUI::Action::create("Back", m_back_icon, [&](auto&) {
-        play_file_path(playlist().previous());
+        play_file_path(playlist().previous(), AppendPlaylist::No);
     });
     m_back_action->set_enabled(false);
     menubar.add_action(*m_back_action);
 
     m_next_action = GUI::Action::create("Next", m_next_icon, [&](auto&) {
-        play_file_path(playlist().next());
+        play_file_path(playlist().next(), AppendPlaylist::No);
     });
     m_next_action->set_enabled(false);
     menubar.add_action(*m_next_action);
@@ -130,7 +130,7 @@ void SoundPlayerWidgetAdvancedView::drop_event(GUI::DropEvent& event)
             return;
         window()->move_to_front();
         // FIXME: Add all paths from drop event to the playlist
-        play_file_path(urls.first().path());
+        play_file_path(urls.first().path(), Player::AppendPlaylist::Yes);
     }
 }
 
@@ -228,7 +228,7 @@ void SoundPlayerWidgetAdvancedView::playlist_loaded(StringView path, bool loaded
         return;
     }
     set_playlist_visible(true);
-    play_file_path(playlist().next());
+    play_file_path(playlist().next(), AppendPlaylist::No);
 }
 
 void SoundPlayerWidgetAdvancedView::audio_load_error(StringView path, StringView error_string)

--- a/Userland/Applications/SoundPlayer/main.cpp
+++ b/Userland/Applications/SoundPlayer/main.cpp
@@ -42,7 +42,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Player* player = TRY(window->try_set_main_widget<SoundPlayerWidgetAdvancedView>(window, audio_client));
     if (arguments.argc > 1) {
         StringView path = arguments.strings[1];
-        player->play_file_path(path);
+        player->play_file_path(path, Player::AppendPlaylist::Yes);
         if (player->is_playlist(path))
             player->set_loop_mode(Player::LoopMode::Playlist);
     }
@@ -51,7 +51,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(file_menu->try_add_action(GUI::CommonActions::make_open_action([&](auto&) {
         Optional<String> path = GUI::FilePicker::get_open_filepath(window, "Open sound file...");
         if (path.has_value()) {
-            player->play_file_path(path.value());
+            player->play_file_path(path.value(), Player::AppendPlaylist::Yes);
         }
     })));
 


### PR DESCRIPTION
- **SoundPlayer: Append song to playlist while opening it**

  This will add songs to playlist on app launch, file drop and from the ‘Open…’ menu action.

  > I think the proper way to implement this would be to rely on model indexes, rather than blindly opening paths and then deciding if we want to put it in the playlist.
  > i tired to do it, but eh, i’d rather keep changes small now. :p

- **SoundPlayer: Add an action to export current playlist as M3U file**

  ![](https://user-images.githubusercontent.com/16520278/184553200-79c748cd-7c31-4667-892c-5ff5c9f71b9a.png)
