### PR TITLE
Kernel: Don't release file-pages if volatile memory purge did it

### DIFF
--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -942,6 +942,8 @@ ErrorOr<NonnullRefPtr<PhysicalPage>> MemoryManager::allocate_physical_page(Shoul
             }
             return IterationDecision::Continue;
         });
+    }
+    if (!page) {
         // Second, we look for a file-backed VMObject with clean pages.
         for_each_vmobject([&](auto& vmobject) {
             if (!vmobject.is_inode())
@@ -956,10 +958,10 @@ ErrorOr<NonnullRefPtr<PhysicalPage>> MemoryManager::allocate_physical_page(Shoul
             }
             return IterationDecision::Continue;
         });
-        if (!page) {
-            dmesgln("MM: no physical pages available");
-            return ENOMEM;
-        }
+    }
+    if (!page) {
+        dmesgln("MM: no physical pages available");
+        return ENOMEM;
     }
 
     if (should_zero_fill == ShouldZeroFill::Yes) {


### PR DESCRIPTION
I've saw this bug while watching the video, I know the true case looks like 3 chained `!page` checks but a good compiler should replace that by the attrocious 3 level deep nested ifs equivalent.