### PR TITLE
SQLStudio: resets status bar and menu actions when closing a tab

### DIFF
--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -183,6 +183,7 @@ MainWidget::MainWidget()
         if (close_attempt.release_value()) {
             m_tab_widget->remove_tab(widget);
             update_title();
+            on_editor_change();
         }
     };
 
@@ -351,14 +352,18 @@ void MainWidget::update_title()
 void MainWidget::on_editor_change()
 {
     auto editor = dynamic_cast<ScriptEditor*>(m_tab_widget->active_widget());
-    if (editor) {
-        update_statusbar(editor);
-        update_editor_actions(editor);
-    }
+    update_statusbar(editor);
+    update_editor_actions(editor);
 }
 
 void MainWidget::update_statusbar(ScriptEditor* editor)
 {
+    if (!editor) {
+        m_statusbar->set_text(1, "");
+        m_statusbar->set_text(2, "");
+        return;
+    }
+
     if (editor->has_selection()) {
         auto character_count = editor->selected_text().length();
         auto word_count = editor->number_of_selected_words();
@@ -374,6 +379,15 @@ void MainWidget::update_statusbar(ScriptEditor* editor)
 
 void MainWidget::update_editor_actions(ScriptEditor* editor)
 {
+    if (!editor) {
+        m_copy_action->set_enabled(false);
+        m_cut_action->set_enabled(false);
+        m_paste_action->set_enabled(false);
+        m_undo_action->set_enabled(false);
+        m_redo_action->set_enabled(false);
+        return;
+    }
+
     m_copy_action->set_enabled(editor->copy_action().is_enabled());
     m_cut_action->set_enabled(editor->cut_action().is_enabled());
     m_paste_action->set_enabled(editor->paste_action().is_enabled());


### PR DESCRIPTION
Noticed a small "bug" where the status bar in SQL Studio continued to show the character/word count and showed menu actions as enabled after closing the only tab. 

* Fixed issue by updating the status bar and menu actions after closing the tab 

To reproduce:
1. Open SQLStudio and notice tab is automatically created
2. Type something notice the status bar at the bottom is updated to show character count, word count and line/column number
3. Highlight some words and notice that the edit menu now shows available actions
3. Close tab
4. Status bar has info about closed tab and the actions menu (under edit) still show some actions as available



<img src="https://user-images.githubusercontent.com/3820069/184576396-f1ec13d2-0409-46ef-a654-d056d15e4b2d.PNG" width=300/><img src="https://user-images.githubusercontent.com/3820069/184576405-7d4537b3-345c-4c6a-9f93-05cb293d56a1.PNG" width=300/>

After closing

Bug | Fix
<img src="https://user-images.githubusercontent.com/3820069/184576459-019386d4-0e7c-44ad-9ff2-e338ac120455.PNG" width=300/><img src="https://user-images.githubusercontent.com/3820069/184576455-59a490b3-e84f-45e2-a32d-9da1e2cf3ba5.PNG" width=300/>


