### PR TITLE
Kernel: Release 1 page instead of all pages when starved for pages

### DIFF
--- a/Kernel/Memory/InodeVMObject.cpp
+++ b/Kernel/Memory/InodeVMObject.cpp
@@ -67,6 +67,25 @@ int InodeVMObject::release_all_clean_pages()
     return count;
 }
 
+int InodeVMObject::try_release_clean_pages(int page_amount)
+{
+    SpinlockLocker locker(m_lock);
+
+    int count = 0;
+    for (size_t i = 0; i < page_count() && count < page_amount; ++i) {
+        if (!m_dirty_pages.get(i) && m_physical_pages[i]) {
+            m_physical_pages[i] = nullptr;
+            ++count;
+        }
+    }
+    if (count) {
+        for_each_region([](auto& region) {
+            region.remap();
+        });
+    }
+    return count;
+}
+
 u32 InodeVMObject::writable_mappings() const
 {
     u32 count = 0;

--- a/Kernel/Memory/InodeVMObject.h
+++ b/Kernel/Memory/InodeVMObject.h
@@ -23,6 +23,7 @@ public:
     size_t amount_clean() const;
 
     int release_all_clean_pages();
+    int try_release_clean_pages(int page_amount);
 
     u32 writable_mappings() const;
     u32 executable_mappings() const;

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -949,8 +949,7 @@ ErrorOr<NonnullRefPtr<PhysicalPage>> MemoryManager::allocate_physical_page(Shoul
             if (!vmobject.is_inode())
                 return IterationDecision::Continue;
             auto& inode_vmobject = static_cast<InodeVMObject&>(vmobject);
-            // FIXME: It seems excessive to release *all* clean pages from the inode when we only need one.
-            if (auto released_page_count = inode_vmobject.release_all_clean_pages()) {
+            if (auto released_page_count = inode_vmobject.try_release_clean_pages(1)) {
                 dbgln("MM: Clean inode release saved the day! Released {} pages from InodeVMObject", released_page_count);
                 page = find_free_physical_page(false);
                 VERIFY(page);


### PR DESCRIPTION
As suggested by @awesomekling, releasing all clean pages when starved for pages is excessive.
This allows us to only release 1 page, as required to satisfy the request to `allocate_physical_page()`

This PR also introduces `try_release_clean_pages()`, which allows us to release a specific amount of clean pages, rather than *all* clean pages.