### PR TITLE
Meta: Remove an outdated `MAKE_DIRECTORY` call for pnp IDs

### DIFF
--- a/Meta/CMake/pnp_ids.cmake
+++ b/Meta/CMake/pnp_ids.cmake
@@ -1,12 +1,9 @@
 include(${CMAKE_CURRENT_LIST_DIR}/utils.cmake)
 
-set(PNP_IDS_FILE pnp.ids)
 set(PNP_IDS_URL http://www.uefi.org/uefi-pnp-export)
 set(PNP_IDS_EXPORT_PATH ${CMAKE_BINARY_DIR}/pnp_ids.html)
-set(PNP_IDS_INSTALL_PATH ${CMAKE_INSTALL_DATAROOTDIR}/${PNP_IDS_FILE})
 
 if (ENABLE_PNP_IDS_DOWNLOAD)
-    file(MAKE_DIRECTORY ${CMAKE_INSTALL_DATAROOTDIR})
     download_file("${PNP_IDS_URL}" "${PNP_IDS_EXPORT_PATH}")
 
     set(PNP_IDS_HEADER PnpIDs.h)


### PR DESCRIPTION
We are downloading these directly into the build directory now, and generating the source code from there, so we no longer need the manually created directory.

While we are at it, remove two variables that seem to be no longer in use, and at least one of which is confusing regarding a missing prefix.

This keeps us from accidentally creating `Userland/Libraries/LibEDID/res` during building.