### PR TITLE
LibC: Add missing sys/cdefs.h include

### DIFF
--- a/Userland/Libraries/LibC/complex.h
+++ b/Userland/Libraries/LibC/complex.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/dirent.h
+++ b/Userland/Libraries/LibC/dirent.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/dirent.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/fcntl.h
+++ b/Userland/Libraries/LibC/fcntl.h
@@ -9,6 +9,7 @@
 
 #include <Kernel/API/POSIX/fcntl.h>
 #include <Kernel/API/POSIX/sys/stat.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/fnmatch.h
+++ b/Userland/Libraries/LibC/fnmatch.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <sys/cdefs.h>
 #include <sys/types.h>
 
 #define FNM_NOMATCH 1

--- a/Userland/Libraries/LibC/glob.h
+++ b/Userland/Libraries/LibC/glob.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <sys/cdefs.h>
 #include <sys/types.h>
 
 __BEGIN_DECLS

--- a/Userland/Libraries/LibC/net/if.h
+++ b/Userland/Libraries/LibC/net/if.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/net/if.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/netinet/in.h
+++ b/Userland/Libraries/LibC/netinet/in.h
@@ -8,6 +8,7 @@
 
 #include <Kernel/API/POSIX/netinet/in.h>
 #include <endian.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/poll.h
+++ b/Userland/Libraries/LibC/poll.h
@@ -8,6 +8,7 @@
 
 #include <Kernel/API/POSIX/poll.h>
 #include <signal.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/regex.h
+++ b/Userland/Libraries/LibC/regex.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <sys/cdefs.h>
 #include <sys/types.h>
 
 __BEGIN_DECLS

--- a/Userland/Libraries/LibC/resolv.h
+++ b/Userland/Libraries/LibC/resolv.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <sys/cdefs.h>
 #include <sys/types.h>
 
 __BEGIN_DECLS

--- a/Userland/Libraries/LibC/serenity.h
+++ b/Userland/Libraries/LibC/serenity.h
@@ -9,6 +9,7 @@
 #include <Kernel/API/POSIX/futex.h>
 #include <Kernel/API/POSIX/serenity.h>
 #include <stdio.h>
+#include <sys/cdefs.h>
 #include <time.h>
 #include <unistd.h>
 

--- a/Userland/Libraries/LibC/signal.h
+++ b/Userland/Libraries/LibC/signal.h
@@ -10,6 +10,7 @@
 #include <Kernel/API/POSIX/ucontext.h>
 #include <bits/sighow.h>
 #include <signal_numbers.h>
+#include <sys/cdefs.h>
 #include <sys/types.h>
 
 __BEGIN_DECLS

--- a/Userland/Libraries/LibC/stdio_ext.h
+++ b/Userland/Libraries/LibC/stdio_ext.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <stdio.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/sys/mman.h
+++ b/Userland/Libraries/LibC/sys/mman.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/sys/mman.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/sys/ptrace.h
+++ b/Userland/Libraries/LibC/sys/ptrace.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/sys/ptrace.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/sys/socket.h
+++ b/Userland/Libraries/LibC/sys/socket.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/sys/socket.h>
+#include <sys/cdefs.h>
 #include <sys/un.h>
 
 __BEGIN_DECLS

--- a/Userland/Libraries/LibC/sys/statvfs.h
+++ b/Userland/Libraries/LibC/sys/statvfs.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/sys/statvfs.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/sys/time.h
+++ b/Userland/Libraries/LibC/sys/time.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/sys/time.h>
+#include <sys/cdefs.h>
 #include <time.h>
 
 __BEGIN_DECLS

--- a/Userland/Libraries/LibC/sys/times.h
+++ b/Userland/Libraries/LibC/sys/times.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/sys/times.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/sys/uio.h
+++ b/Userland/Libraries/LibC/sys/uio.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/sys/uio.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/sys/utsname.h
+++ b/Userland/Libraries/LibC/sys/utsname.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/sys/utsname.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/sys/wait.h
+++ b/Userland/Libraries/LibC/sys/wait.h
@@ -8,6 +8,7 @@
 
 #include <Kernel/API/POSIX/signal.h>
 #include <Kernel/API/POSIX/sys/wait.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/sys/xattr.h
+++ b/Userland/Libraries/LibC/sys/xattr.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <sys/cdefs.h>
 #include <sys/types.h>
 
 __BEGIN_DECLS

--- a/Userland/Libraries/LibC/termios.h
+++ b/Userland/Libraries/LibC/termios.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/termios.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/time.h
+++ b/Userland/Libraries/LibC/time.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/time.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -16,6 +16,7 @@
 #include <Kernel/API/POSIX/unistd.h>
 #include <fd_set.h>
 #include <limits.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/wctype.h
+++ b/Userland/Libraries/LibC/wctype.h
@@ -8,6 +8,7 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <sys/cdefs.h>
 #include <wchar.h>
 
 __BEGIN_DECLS


### PR DESCRIPTION
Some header files use `__BEGIN_DECLS` without including `sys/cdefs.h`. This causes issues for C code that compiles against these headers, which may occur with Ports.

Related https://github.com/NixOS/nixpkgs/pull/186484