### PR TITLE
LibGUI: Don't let widgets hide tooltips they didn't show

### DIFF
--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -466,7 +466,8 @@ void Widget::handle_leave_event(Core::Event& event)
 {
     if (auto* window = this->window())
         window->update_cursor({});
-    Application::the()->hide_tooltip();
+    if (Application::the()->tooltip_source_widget() == this)
+        Application::the()->hide_tooltip();
     leave_event(event);
 }
 


### PR DESCRIPTION
Widget::handle_leave_event() hides the tooltip if one is shown. That's
usually fine and hides the widget's tooltip, but it can happen that
another widget managed to show a tooltip after the Leave event was
triggered and before it's processed.

Thus change handle_leave_event() to only hide the tooltip if it was show
by the widget.

Fixes the case where this could happen in the flame graph in Profiler
when moving the mouse over the tooltip window itself #14852.