### PR TITLE
WindowServer: Drag and drop fixes

### DIFF
--- a/Userland/Libraries/LibGUI/DragOperation.cpp
+++ b/Userland/Libraries/LibGUI/DragOperation.cpp
@@ -48,7 +48,7 @@ DragOperation::Outcome DragOperation::exec()
     m_event_loop = make<Core::EventLoop>();
     auto result = m_event_loop->exec();
     m_event_loop = nullptr;
-    dbgln("{}: event loop returned with result {}", class_name(), result);
+    dbgln_if(DRAG_DEBUG, "{}: event loop returned with result {}", class_name(), result);
     remove_from_parent();
     s_current_drag_operation = nullptr;
     return m_outcome;

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -857,7 +857,7 @@ Gfx::IntRect Compositor::current_cursor_rect() const
 
 void Compositor::invalidate_cursor(bool compose_immediately)
 {
-    if (m_invalidated_cursor)
+    if (m_invalidated_cursor && !compose_immediately)
         return;
     m_invalidated_cursor = true;
     m_invalidated_any = true;

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -817,7 +817,7 @@ void ConnectionFromClient::start_window_resize(i32 window_id)
 Messages::WindowServer::StartDragResponse ConnectionFromClient::start_drag(String const& text, HashMap<String, ByteBuffer> const& mime_data, Gfx::ShareableBitmap const& drag_bitmap)
 {
     auto& wm = WindowManager::the();
-    if (wm.dnd_client())
+    if (wm.dnd_client() || !(wm.last_processed_buttons() & MouseButton::Primary))
         return false;
 
     wm.start_dnd_drag(*this, text, drag_bitmap.bitmap(), Core::MimeData::construct(mime_data));

--- a/Userland/Services/WindowServer/Event.h
+++ b/Userland/Services/WindowServer/Event.h
@@ -48,7 +48,7 @@ public:
     bool is_key_event() const { return type() == KeyUp || type() == KeyDown; }
 };
 
-enum class MouseButton : u8 {
+enum MouseButton : u8 {
     None = 0,
     Primary = 1,
     Secondary = 2,

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1459,6 +1459,7 @@ void WindowManager::event(Core::Event& event)
             m_previous_event_was_super_keydown = false;
 
         process_mouse_event(mouse_event);
+        m_last_processed_buttons = mouse_event.buttons();
         // TODO: handle transitioning between two stacks
         set_hovered_window(current_window_stack().window_at(mouse_event.position(), WindowStack::IncludeWindowFrame::No));
         return;

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -2081,10 +2081,10 @@ void WindowManager::start_dnd_drag(ConnectionFromClient& client, String const& t
     VERIFY(!m_dnd_client);
     m_dnd_client = client;
     m_dnd_text = text;
+    Compositor::the().invalidate_cursor(true);
     m_dnd_overlay = Compositor::the().create_overlay<DndOverlay>(text, bitmap);
     m_dnd_overlay->set_enabled(true);
     m_dnd_mime_data = mime_data;
-    Compositor::the().invalidate_cursor();
     set_automatic_cursor_tracking_window(nullptr);
 }
 

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -347,6 +347,8 @@ public:
     Window const* automatic_cursor_tracking_window() const { return m_automatic_cursor_tracking_window; }
     void set_automatic_cursor_tracking_window(Window* window) { m_automatic_cursor_tracking_window = window; }
 
+    u8 last_processed_buttons() { return m_last_processed_buttons; }
+
 private:
     explicit WindowManager(Gfx::PaletteImpl const&);
 
@@ -469,6 +471,7 @@ private:
     ResizeDirection m_resize_direction { ResizeDirection::None };
 
     u8 m_keyboard_modifiers { 0 };
+    u8 m_last_processed_buttons { MouseButton::None };
 
     NonnullRefPtr<WindowSwitcher> m_switcher;
     NonnullRefPtr<KeymapSwitcher> m_keymap_switcher;


### PR DESCRIPTION
Fixes #12650
And the momentary gap caused by active cursor change:
![datgap](https://user-images.githubusercontent.com/66646555/184901511-94952943-e52e-489a-b2ca-c5c591ca113c.png)
