### PR TITLE
LibWeb: Implement `repeating-linear-gradient()`s

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -118,6 +118,23 @@
                 75%,
                 dodgerblue 0)
         }
+
+        .grad-repeat-0 {
+            background-image: repeating-linear-gradient(#e66465, #e66465 20px, #9198e5 20px, #9198e5 25px);
+        }
+
+        .grad-repeat-1 {
+            background-image: repeating-linear-gradient(45deg, #3f87a6, #ebf8e1 15%, #f69d3c 20%);
+        }
+
+        .grad-repeat-2 {
+            background-image: repeating-linear-gradient(transparent, #4d9f0c 40px),
+                              repeating-linear-gradient(0.25turn, transparent, #3f87a6 20px);
+        }
+
+        .grad-repeat-3 {
+            background-image: -webkit-repeating-linear-gradient(left, red 10%, blue 30%);
+        }
     </style>
   </head>
   <body>
@@ -151,6 +168,11 @@
     <div class="rect grad-15"></div>
     <b>A webkit gradient</b><br>
     <div class="box grad-webkit"></div>
+    <b>Repeating gradients</b><br>
+    <div class="box grad-repeat-0"></div>
+    <div class="box grad-repeat-1"></div>
+    <div class="box grad-repeat-2"></div>
+    <div class="box grad-repeat-3"></div>
   </body>
   <script>
     const boxes = document.querySelectorAll(".box, .rect");

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1491,6 +1491,8 @@ String LinearGradientStyleValue::to_string() const
 
     if (m_gradient_type == GradientType::WebKit)
         builder.append("-webkit-"sv);
+    if (m_repeating == Repeating::Yes)
+        builder.append("repeating-"sv);
     builder.append("linear-gradient("sv);
     m_direction.visit(
         [&](SideOrCorner side_or_corner) {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -978,10 +978,15 @@ public:
         WebKit
     };
 
-    static NonnullRefPtr<LinearGradientStyleValue> create(GradientDirection direction, Vector<ColorStopListElement> color_stop_list, GradientType type)
+    enum class Repeating {
+        Yes,
+        No
+    };
+
+    static NonnullRefPtr<LinearGradientStyleValue> create(GradientDirection direction, Vector<ColorStopListElement> color_stop_list, GradientType type, Repeating repeating)
     {
         VERIFY(color_stop_list.size() >= 2);
-        return adopt_ref(*new LinearGradientStyleValue(direction, move(color_stop_list), type));
+        return adopt_ref(*new LinearGradientStyleValue(direction, move(color_stop_list), type, repeating));
     }
 
     virtual String to_string() const override;
@@ -993,6 +998,8 @@ public:
         return m_color_stop_list;
     }
 
+    bool is_repeating() const { return m_repeating == Repeating::Yes; }
+
     float angle_degrees(Gfx::FloatSize const& gradient_size) const;
 
     void resolve_for_size(Layout::Node const&, Gfx::FloatSize const&) const override;
@@ -1001,17 +1008,19 @@ public:
     void paint(PaintContext& context, Gfx::IntRect const& dest_rect, CSS::ImageRendering image_rendering) const override;
 
 private:
-    LinearGradientStyleValue(GradientDirection direction, Vector<ColorStopListElement> color_stop_list, GradientType type)
+    LinearGradientStyleValue(GradientDirection direction, Vector<ColorStopListElement> color_stop_list, GradientType type, Repeating repeating)
         : AbstractImageStyleValue(Type::LinearGradient)
         , m_direction(direction)
         , m_color_stop_list(move(color_stop_list))
         , m_gradient_type(type)
+        , m_repeating(repeating)
     {
     }
 
     GradientDirection m_direction;
     Vector<ColorStopListElement> m_color_stop_list;
     GradientType m_gradient_type;
+    Repeating m_repeating;
 
     mutable Optional<Painting::LinearGradientData> m_resolved_data;
 };

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -177,7 +177,11 @@ void paint_linear_gradient(PaintContext& context, Gfx::IntRect const& gradient_r
         // For any given point between the two color stops,
         // determine the point’s location as a percentage of the distance between the two color stops.
         // Let this percentage be P.
-        auto p = (position - previous_stop.position) / (next_stop.position - previous_stop.position);
+        auto stop_length = next_stop.position - previous_stop.position;
+        // FIXME: Avoids NaNs... Still not quite correct?
+        if (stop_length <= 0)
+            return 1;
+        auto p = (position - previous_stop.position) / stop_length;
         if (!next_stop.transition_hint.has_value())
             return p;
         if (*next_stop.transition_hint >= 1)

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.h
@@ -25,6 +25,7 @@ using ColorStopList = Vector<ColorStop, 4>;
 struct LinearGradientData {
     float gradient_angle;
     ColorStopList color_stops;
+    Optional<float> repeat_length;
 };
 
 LinearGradientData resolve_linear_gradient_data(Layout::Node const&, Gfx::FloatSize const&, CSS::LinearGradientStyleValue const&);


### PR DESCRIPTION
Final little linear gradient thing (other than multi position colour stops, but those don't exist in the spec :disappointed:)

| LibWeb                                                                                                          | Chrom                                                                                                           |
|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/11597044/184930501-88c6c477-4e98-49d9-96b9-fb845b12b13f.png) | ![image](https://user-images.githubusercontent.com/11597044/184930556-dedce9f4-b21c-41ca-8dc1-9e6882367aa4.png) |