### PR TITLE
PixelPaint: Introduce a vectorscope

### DIFF
--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SOURCES
     ProjectLoader.cpp
     ResizeImageDialog.cpp
     ResizeImageDialogGML.h
+    ScopeWidget.cpp
     Selection.cpp
     ToolPropertiesWidget.cpp
     ToolboxWidget.cpp

--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SOURCES
     Tools/Tool.cpp
     Tools/WandSelectTool.cpp
     Tools/ZoomTool.cpp
+    VectorscopeWidget.cpp
     main.cpp
     )
 

--- a/Userland/Applications/PixelPaint/HistogramWidget.cpp
+++ b/Userland/Applications/PixelPaint/HistogramWidget.cpp
@@ -16,25 +16,6 @@ REGISTER_WIDGET(PixelPaint, HistogramWidget);
 
 namespace PixelPaint {
 
-HistogramWidget::~HistogramWidget()
-{
-    if (m_image)
-        m_image->remove_client(*this);
-}
-
-void HistogramWidget::set_image(Image* image)
-{
-    if (m_image == image)
-        return;
-    if (m_image)
-        m_image->remove_client(*this);
-    m_image = image;
-    if (m_image)
-        m_image->add_client(*this);
-
-    (void)rebuild_histogram_data();
-}
-
 ErrorOr<void> HistogramWidget::rebuild_histogram_data()
 {
     if (!m_image)
@@ -81,16 +62,15 @@ ErrorOr<void> HistogramWidget::rebuild_histogram_data()
     }
 
     // Scale the frequency values to fit the widgets height.
-    m_widget_height = height();
+    auto widget_height = height();
 
     for (int i = 0; i < 256; i++) {
-        m_data.red[i] = m_data.red[i] != 0 ? (static_cast<float>(m_data.red[i]) / max_color_frequency) * m_widget_height : 0;
-        m_data.green[i] = m_data.green[i] != 0 ? (static_cast<float>(m_data.green[i]) / max_color_frequency) * m_widget_height : 0;
-        m_data.blue[i] = m_data.blue[i] != 0 ? (static_cast<float>(m_data.blue[i]) / max_color_frequency) * m_widget_height : 0;
-        m_data.brightness[i] = m_data.brightness[i] != 0 ? (static_cast<float>(m_data.brightness[i]) / max_brightness_frequency) * m_widget_height : 0;
+        m_data.red[i] = m_data.red[i] != 0 ? (static_cast<float>(m_data.red[i]) / max_color_frequency) * widget_height : 0;
+        m_data.green[i] = m_data.green[i] != 0 ? (static_cast<float>(m_data.green[i]) / max_color_frequency) * widget_height : 0;
+        m_data.blue[i] = m_data.blue[i] != 0 ? (static_cast<float>(m_data.blue[i]) / max_color_frequency) * widget_height : 0;
+        m_data.brightness[i] = m_data.brightness[i] != 0 ? (static_cast<float>(m_data.brightness[i]) / max_brightness_frequency) * widget_height : 0;
     }
 
-    update();
     return {};
 }
 
@@ -102,7 +82,7 @@ void HistogramWidget::paint_event(GUI::PaintEvent& event)
     if (!m_image)
         return;
 
-    int bottom_line = m_widget_height - 1;
+    int bottom_line = height() - 1;
     float step_width = static_cast<float>(width()) / 256;
 
     Gfx::Path brightness_path;
@@ -153,14 +133,6 @@ void HistogramWidget::paint_event(GUI::PaintEvent& event)
 void HistogramWidget::image_changed()
 {
     (void)rebuild_histogram_data();
-}
-
-void HistogramWidget::set_color_at_mouseposition(Color color)
-{
-    if (m_color_at_mouseposition == color)
-        return;
-
-    m_color_at_mouseposition = color;
     update();
 }
 

--- a/Userland/Applications/PixelPaint/HistogramWidget.cpp
+++ b/Userland/Applications/PixelPaint/HistogramWidget.cpp
@@ -16,11 +16,6 @@ REGISTER_WIDGET(PixelPaint, HistogramWidget);
 
 namespace PixelPaint {
 
-HistogramWidget::HistogramWidget()
-{
-    set_height(65);
-}
-
 HistogramWidget::~HistogramWidget()
 {
     if (m_image)

--- a/Userland/Applications/PixelPaint/HistogramWidget.h
+++ b/Userland/Applications/PixelPaint/HistogramWidget.h
@@ -7,21 +7,17 @@
 #pragma once
 
 #include "Image.h"
-#include <LibGUI/AbstractScrollableWidget.h>
+#include "ScopeWidget.h"
 
 namespace PixelPaint {
 
 class HistogramWidget final
-    : public GUI::Frame
-    , ImageClient {
+    : public ScopeWidget {
     C_OBJECT(HistogramWidget);
 
 public:
-    virtual ~HistogramWidget() override;
-
-    void set_image(Image*);
-    void image_changed();
-    void set_color_at_mouseposition(Color);
+    virtual ~HistogramWidget() = default;
+    virtual void image_changed() override;
 
 private:
     HistogramWidget() = default;
@@ -29,9 +25,6 @@ private:
     virtual void paint_event(GUI::PaintEvent&) override;
 
     ErrorOr<void> rebuild_histogram_data();
-    int m_widget_height = 0;
-    Color m_color_at_mouseposition = Color::Transparent;
-    RefPtr<Image> m_image;
 
     struct HistogramData {
         Vector<int> red;

--- a/Userland/Applications/PixelPaint/HistogramWidget.h
+++ b/Userland/Applications/PixelPaint/HistogramWidget.h
@@ -24,7 +24,7 @@ public:
     void set_color_at_mouseposition(Color);
 
 private:
-    HistogramWidget();
+    HistogramWidget() = default;
 
     virtual void paint_event(GUI::PaintEvent&) override;
 

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -488,6 +488,8 @@ void ImageEditor::set_pixel_grid_visibility(bool show_pixel_grid)
 
 void ImageEditor::layers_did_change()
 {
+    if (on_modified_change)
+        on_modified_change(true);
     update();
 }
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -46,6 +46,7 @@ MainWidget::MainWidget()
     m_palette_widget = *find_descendant_of_type_named<PixelPaint::PaletteWidget>("palette_widget");
 
     m_histogram_widget = *find_descendant_of_type_named<PixelPaint::HistogramWidget>("histogram_widget");
+    m_vectorscope_widget = *find_descendant_of_type_named<PixelPaint::VectorscopeWidget>("vectorscope_widget");
     m_layer_list_widget = *find_descendant_of_type_named<PixelPaint::LayerListWidget>("layer_list_widget");
     m_layer_list_widget->on_layer_select = [&](auto* layer) {
         auto* editor = current_image_editor();
@@ -74,6 +75,7 @@ MainWidget::MainWidget()
                 m_tab_widget->remove_tab(image_editor);
                 if (m_tab_widget->children().size() == 0) {
                     m_histogram_widget->set_image(nullptr);
+                    m_vectorscope_widget->set_image(nullptr);
                     m_layer_list_widget->set_image(nullptr);
                     m_layer_properties_widget->set_layer(nullptr);
                     m_palette_widget->set_image_editor(nullptr);
@@ -88,12 +90,14 @@ MainWidget::MainWidget()
         auto& image_editor = verify_cast<PixelPaint::ImageEditor>(widget);
         m_palette_widget->set_image_editor(&image_editor);
         m_histogram_widget->set_image(&image_editor.image());
+        m_vectorscope_widget->set_image(&image_editor.image());
         m_layer_list_widget->set_image(&image_editor.image());
         m_layer_properties_widget->set_layer(image_editor.active_layer());
         window()->set_modified(image_editor.is_modified());
         image_editor.on_modified_change = [this](bool modified) {
             window()->set_modified(modified);
             m_histogram_widget->image_changed();
+            m_vectorscope_widget->image_changed();
         };
         if (auto* active_tool = m_toolbox->active_tool())
             image_editor.set_active_tool(active_tool);
@@ -161,6 +165,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 editor.undo_stack().set_current_unmodified();
 
                 m_histogram_widget->set_image(image);
+                m_vectorscope_widget->set_image(image);
                 m_layer_list_widget->set_image(image);
                 m_layer_list_widget->set_selected_layer(bg_layer);
             }
@@ -978,15 +983,18 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
         if (image_rectangle.contains(mouse_position)) {
             m_statusbar->set_override_text(mouse_position.to_string());
             m_histogram_widget->set_color_at_mouseposition(current_image_editor()->image().color_at(mouse_position));
+            m_vectorscope_widget->set_color_at_mouseposition(current_image_editor()->image().color_at(mouse_position));
         } else {
             m_statusbar->set_override_text({});
             m_histogram_widget->set_color_at_mouseposition(Color::Transparent);
+            m_vectorscope_widget->set_color_at_mouseposition(Color::Transparent);
         }
     };
 
     image_editor.on_leave = [&]() {
         m_statusbar->set_override_text({});
         m_histogram_widget->set_color_at_mouseposition(Color::Transparent);
+        m_vectorscope_widget->set_color_at_mouseposition(Color::Transparent);
     };
 
     image_editor.on_set_guide_visibility = [&](bool show_guides) {

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -19,6 +19,7 @@
 #include "ToolPropertiesWidget.h"
 #include "ToolboxWidget.h"
 #include "Tools/Tool.h"
+#include "VectorscopeWidget.h"
 #include <LibGUI/Action.h>
 #include <LibGUI/ComboBox.h>
 #include <LibGUI/Forward.h>
@@ -62,6 +63,7 @@ private:
     RefPtr<ToolboxWidget> m_toolbox;
     RefPtr<PaletteWidget> m_palette_widget;
     RefPtr<HistogramWidget> m_histogram_widget;
+    RefPtr<VectorscopeWidget> m_vectorscope_widget;
     RefPtr<LayerListWidget> m_layer_list_widget;
     RefPtr<LayerPropertiesWidget> m_layer_properties_widget;
     RefPtr<ToolPropertiesWidget> m_tool_properties_widget;

--- a/Userland/Applications/PixelPaint/PixelPaintWindow.gml
+++ b/Userland/Applications/PixelPaint/PixelPaintWindow.gml
@@ -66,14 +66,14 @@
 
             @GUI::GroupBox {
                 title: "Histogram"
-                max_height: 90
+                preferred_height: "shrink"
                 layout: @GUI::VerticalBoxLayout {
                     margins: [6]
                 }
 
                 @PixelPaint::HistogramWidget {
                     name: "histogram_widget"
-                    max_height: 65
+                    min_height: 65
                 }
             }
 

--- a/Userland/Applications/PixelPaint/PixelPaintWindow.gml
+++ b/Userland/Applications/PixelPaint/PixelPaintWindow.gml
@@ -77,6 +77,19 @@
                 }
             }
 
+            @GUI::GroupBox {
+                title: "Vectorscope"
+                min_height: 80
+                layout: @GUI::VerticalBoxLayout {
+                    margins: [6]
+                }
+
+                @PixelPaint::VectorscopeWidget {
+                    name: "vectorscope_widget"
+                    preferred_height: "fit"
+                }
+            }
+
             @PixelPaint::ToolPropertiesWidget {
                 name: "tool_properties_widget"
                 max_height: 144

--- a/Userland/Applications/PixelPaint/ScopeWidget.cpp
+++ b/Userland/Applications/PixelPaint/ScopeWidget.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ScopeWidget.h"
+#include "Layer.h"
+
+namespace PixelPaint {
+
+ScopeWidget::~ScopeWidget()
+{
+    if (m_image)
+        m_image->remove_client(*this);
+}
+
+void ScopeWidget::set_image(Image* image)
+{
+    if (m_image == image)
+        return;
+    if (m_image)
+        m_image->remove_client(*this);
+    m_image = image;
+    if (m_image)
+        m_image->add_client(*this);
+
+    image_changed();
+    update();
+}
+
+void ScopeWidget::set_color_at_mouseposition(Color color)
+{
+    if (m_color_at_mouseposition == color)
+        return;
+
+    m_color_at_mouseposition = color;
+    update();
+}
+
+}

--- a/Userland/Applications/PixelPaint/ScopeWidget.h
+++ b/Userland/Applications/PixelPaint/ScopeWidget.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Image.h"
+#include <LibCore/Object.h>
+#include <LibGUI/Frame.h>
+
+namespace PixelPaint {
+
+class ScopeWidget
+    : public GUI::Frame
+    , public ImageClient {
+    C_OBJECT_ABSTRACT(ScopeWidget);
+
+public:
+    virtual ~ScopeWidget() override;
+
+    void set_image(Image*);
+    virtual void image_changed() = 0;
+    void set_color_at_mouseposition(Color);
+
+protected:
+    virtual void paint_event(GUI::PaintEvent&) override = 0;
+
+    Color m_color_at_mouseposition = Color::Transparent;
+    RefPtr<Image> m_image;
+};
+
+}

--- a/Userland/Applications/PixelPaint/VectorscopeWidget.cpp
+++ b/Userland/Applications/PixelPaint/VectorscopeWidget.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "VectorscopeWidget.h"
+#include "Layer.h"
+#include <AK/Math.h>
+#include <AK/Types.h>
+#include <LibGUI/Event.h>
+#include <LibGUI/Painter.h>
+#include <LibGUI/Widget.h>
+#include <LibGfx/AntiAliasingPainter.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Palette.h>
+#include <LibGfx/SystemTheme.h>
+#include <LibGfx/TextAlignment.h>
+#include <LibGfx/TextElision.h>
+
+REGISTER_WIDGET(PixelPaint, VectorscopeWidget);
+
+namespace PixelPaint {
+
+void VectorscopeWidget::image_changed()
+{
+    (void)rebuild_vectorscope_data();
+    rebuild_vectorscope_image();
+    update();
+}
+
+ErrorOr<void> VectorscopeWidget::rebuild_vectorscope_data()
+{
+    if (!m_image)
+        return {};
+
+    m_vectorscope_data.fill({});
+    VERIFY(AK::abs(m_vectorscope_data[0][0]) < 0.01f);
+    auto full_bitmap = TRY(m_image->try_compose_bitmap(Gfx::BitmapFormat::BGRA8888));
+
+    for (size_t x = 0; x < static_cast<size_t>(full_bitmap->width()); ++x) {
+        for (size_t y = 0; y < static_cast<size_t>(full_bitmap->height()); ++y) {
+            auto yuv = full_bitmap->get_pixel(x, y).to_yuv();
+            auto u_index = u_v_to_index(yuv.u);
+            auto v_index = u_v_to_index(yuv.v);
+            m_vectorscope_data[u_index][v_index]++;
+        }
+    }
+
+    auto maximum = full_bitmap->width() * full_bitmap->height() * pixel_percentage_for_max_brightness * pixel_percentage_for_max_brightness;
+
+    for (size_t i = 0; i < m_vectorscope_data.size(); ++i) {
+        for (size_t j = 0; j < m_vectorscope_data[i].size(); ++j) {
+            m_vectorscope_data[i][j] = AK::sqrt(m_vectorscope_data[i][j]) / maximum;
+        }
+    }
+
+    return {};
+}
+
+void VectorscopeWidget::rebuild_vectorscope_image()
+{
+    m_vectorscope_image = MUST(Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, size()));
+    m_vectorscope_image->fill(Color::Transparent);
+
+    Gfx::Painter base_painter(*m_vectorscope_image);
+    Gfx::AntiAliasingPainter painter(base_painter);
+
+    auto const scope_size = min(height(), width());
+    auto const min_scope_size = parent_widget()->min_height().as_int();
+    auto const color_vector_scale = scope_size / static_cast<float>(min_scope_size);
+    auto const size_1x1 = Gfx::FloatSize { 2.5f, 2.5f } * static_cast<float>(color_vector_scale);
+
+    base_painter.translate(width() / 2, height() / 2);
+    painter.translate(static_cast<float>(width()) / 2.0f, static_cast<float>(height()) / 2.0f);
+    for (size_t u_index = 0; u_index < u_v_steps; ++u_index) {
+        for (size_t v_index = 0; v_index < u_v_steps; ++v_index) {
+            auto const color_vector = ColorVector::from_indices(u_index, v_index);
+            auto const brightness = m_vectorscope_data[u_index][v_index];
+            if (brightness < 0.0001f)
+                continue;
+            auto const pseudo_rect = Gfx::FloatRect::centered_at(color_vector.to_vector(scope_size) * 2.0f, size_1x1);
+            auto color = Color::from_yuv(0.6f, color_vector.u, color_vector.v);
+            color = color.saturated_to(1.0f - min(brightness, 1.0f));
+            color.set_alpha(static_cast<u8>(min(AK::sqrt(brightness), alpha_range) * NumericLimits<u8>::max() / alpha_range));
+            painter.fill_rect(pseudo_rect, color);
+        }
+    }
+}
+
+void VectorscopeWidget::paint_event(GUI::PaintEvent& event)
+{
+    GUI::Painter base_painter(*this);
+    Gfx::AntiAliasingPainter painter(base_painter);
+    base_painter.add_clip_rect(event.rect());
+    // From this point on we're working with 0,0 as the scope center to make things easier.
+    base_painter.translate(width() / 2, height() / 2);
+    painter.translate(static_cast<float>(width()) / 2.0f, static_cast<float>(height()) / 2.0f);
+
+    auto const graticule_color = Color::White;
+    auto const scope_size = min(height(), width());
+    auto const graticule_size = scope_size / 6;
+    auto const graticule_thickness = graticule_size / 12;
+    auto const entire_scope_rect = Gfx::FloatRect::centered_at({ 0, 0 }, { scope_size, scope_size });
+
+    painter.fill_ellipse(entire_scope_rect.to_rounded<int>().shrunken(graticule_thickness * 2, graticule_thickness * 2), Color::Black);
+
+    // Main scope data
+    if (m_image) {
+        if (m_vectorscope_image->size() != this->size())
+            rebuild_vectorscope_image();
+
+        base_painter.blit({ -width() / 2, -height() / 2 }, *m_vectorscope_image, m_vectorscope_image->rect());
+    }
+
+    // Graticule(s)
+    painter.draw_ellipse(entire_scope_rect.to_rounded<int>(), graticule_color, graticule_thickness);
+
+    // FIXME: Translation calls to the painters don't appear to work correctly, and I figured out a combination of calls through trial and error that do what I want, but I don't know how they do that.
+    //        Translation does work correctly with things like rectangle and text drawing, so it's very strange.
+    painter.translate(-static_cast<float>(width()) / 2.0f, -static_cast<float>(height()) / 2.0f);
+    // We intentionally draw the skin tone line much further than the actual color we're using for it.
+    painter.draw_line({ 0, 0 }, skin_tone_color.to_vector(scope_size) * 2.0, graticule_color);
+    painter.translate(-static_cast<float>(width()) / 2.0f, -static_cast<float>(height()) / 2.0f);
+
+    for (auto const& primary_color : primary_colors) {
+        // FIXME: Only draw the rectangle corners for a more classical oscilloscope look (& less obscuring of color data)
+        auto graticule_rect = Gfx::FloatRect::centered_at(primary_color.to_vector(scope_size), { graticule_size, graticule_size }).to_rounded<int>();
+        base_painter.draw_rect_with_thickness(graticule_rect, graticule_color, graticule_thickness);
+        auto text_rect = graticule_rect.translated(graticule_size / 2, graticule_size / 2);
+        base_painter.draw_text(text_rect, StringView { &primary_color.symbol, 1 }, Gfx::TextAlignment::TopLeft, graticule_color);
+    }
+
+    if (m_color_at_mouseposition != Color::Transparent) {
+        auto color_vector = ColorVector { m_color_at_mouseposition };
+        painter.draw_ellipse(Gfx::FloatRect::centered_at(color_vector.to_vector(scope_size) * 2.0, { graticule_size, graticule_size }).to_rounded<int>(), graticule_color, graticule_thickness);
+    }
+}
+
+}

--- a/Userland/Applications/PixelPaint/VectorscopeWidget.h
+++ b/Userland/Applications/PixelPaint/VectorscopeWidget.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Image.h"
+#include "ScopeWidget.h"
+#include <AK/Array.h>
+
+namespace PixelPaint {
+
+// Gfx::Color can produce 64-bit floating-point HSV.
+// However, as it internally only uses 8 bits for each color channel, the hue can never have a higher usable resolution than 256 steps.
+static constexpr size_t const u_v_steps = 160;
+
+// Convert to and from U or V (-1 to +1) and an index suitable for the vectorscope table.
+constexpr size_t u_v_to_index(float u_v)
+{
+    float normalized_u_v = (u_v + 1.0f) / 2.0f;
+    return static_cast<size_t>(floorf(normalized_u_v * u_v_steps)) % u_v_steps;
+}
+constexpr float u_v_from_index(size_t index)
+{
+    float normalized_u_v = static_cast<float>(index) / u_v_steps;
+    return normalized_u_v * 2.0f - 1.0f;
+}
+
+struct PrimaryColorVector;
+
+struct ColorVector {
+    constexpr ColorVector(float u, float v)
+        : u(u)
+        , v(v)
+    {
+    }
+
+    constexpr explicit ColorVector(Color color)
+        : ColorVector(color.to_yuv().u, color.to_yuv().v)
+    {
+    }
+
+    static constexpr ColorVector from_indices(size_t u_index, size_t v_index)
+    {
+        return ColorVector(u_v_from_index(u_index), u_v_from_index(v_index));
+    }
+
+    constexpr Gfx::FloatPoint to_vector(float scope_size) const
+    {
+        auto x = u * scope_size / 2.0f;
+        // Computer graphics y increases downwards, but mathematical y increases upwards.
+        auto y = -v * scope_size / 2.0f;
+        return { x, y };
+    }
+
+    constexpr operator PrimaryColorVector() const;
+
+    float u;
+    float v;
+};
+
+struct PrimaryColorVector : public ColorVector {
+    constexpr PrimaryColorVector(Color::NamedColor named_color, char symbol)
+        : ColorVector(Color { named_color })
+        , symbol(symbol)
+    {
+    }
+
+    constexpr PrimaryColorVector(Color color, char symbol)
+        : ColorVector(color.to_yuv().u, color.to_yuv().v)
+        , symbol(symbol)
+    {
+    }
+
+    constexpr PrimaryColorVector(float u, float v, char symbol)
+        : ColorVector(u, v)
+        , symbol(symbol)
+    {
+    }
+
+    char symbol;
+};
+
+constexpr ColorVector::operator PrimaryColorVector() const
+{
+    return PrimaryColorVector { u, v, 'X' };
+}
+
+// Color vectors that are found in this percentage of pixels and above are displayed with maximum brightness in the scope.
+static constexpr float const pixel_percentage_for_max_brightness = 0.01f;
+// Which normalized brightness value (and above) gets to be rendered at 100% opacity.
+static constexpr float const alpha_range = 2.5f;
+// Skin tone line. This was determined manually with a couple of common hex skin tone colors.
+static constexpr PrimaryColorVector const skin_tone_color = { Color::from_hsv(18.0, 1.0, 1.0), 'S' };
+// Used for primary color box graticules.
+static constexpr Array<PrimaryColorVector, 6> const primary_colors = { {
+    { Color::Red, 'R' },
+    { Color::Magenta, 'M' },
+    { Color::Blue, 'B' },
+    { Color::Cyan, 'C' },
+    { Color::Green, 'G' },
+    { Color::Yellow, 'Y' },
+} };
+
+// Vectorscopes are a standard tool in professional video/film color grading.
+// The Vectorscope shows image colors along the I and Q axis (from YIQ color space), which, to oversimplify, means that you get a weirdly shifted hue circle with the radius being the saturation.
+// The brightness for each point in the scope is determined by the number of "color vectors" at that point.
+// FIXME: We would want a lot of the scope settings to be user-adjustable. For example: scale, color/bw scope, graticule brightness
+class VectorscopeWidget final
+    : public ScopeWidget {
+    C_OBJECT(VectorscopeWidget);
+
+public:
+    virtual ~VectorscopeWidget() override = default;
+
+    virtual void image_changed() override;
+
+private:
+    virtual void paint_event(GUI::PaintEvent&) override;
+
+    ErrorOr<void> rebuild_vectorscope_data();
+    void rebuild_vectorscope_image();
+
+    // First index is u, second index is v. The value is y.
+    Array<Array<float, u_v_steps + 1>, u_v_steps + 1> m_vectorscope_data;
+    RefPtr<Gfx::Bitmap> m_vectorscope_image;
+};
+
+}

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -35,6 +35,8 @@ public:
         AlphaSubtract
     };
 
+    void fill_rect(FloatRect const&, Color);
+
     void fill_circle(IntPoint const& center, int radius, Color, BlendMode blend_mode = BlendMode::Normal);
     void fill_ellipse(IntRect const& a_rect, Color, BlendMode blend_mode = BlendMode::Normal);
 

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -25,6 +25,12 @@ struct HSV {
     double value { 0 };
 };
 
+struct YUV {
+    float y { 0 };
+    float u { 0 };
+    float v { 0 };
+};
+
 class Color {
 public:
     enum NamedColor {
@@ -73,6 +79,37 @@ public:
         auto b = static_cast<u8>(255.0f * (1.0f - y) * (1.0f - k));
 
         return Color(r, g, b);
+    }
+
+    static constexpr Color from_yuv(YUV const& yuv) { return from_yuv(yuv.y, yuv.u, yuv.v); }
+    static constexpr Color from_yuv(float y, float u, float v)
+    {
+        // https://www.itu.int/rec/R-REC-BT.1700-0-200502-I/en Table 4, Items 8 and 9 arithmetically inverted
+        float r = y + v / 0.877f;
+        float b = y + u / 0.493f;
+        float g = (y - 0.299f * r - 0.114f * b) / 0.587f;
+        r = clamp(r, 0.0f, 1.0f);
+        g = clamp(g, 0.0f, 1.0f);
+        b = clamp(b, 0.0f, 1.0f);
+
+        return { static_cast<u8>(floorf(r * 255.0f)), static_cast<u8>(floorf(g * 255.0f)), static_cast<u8>(floorf(b * 255.0f)) };
+    }
+
+    // https://www.itu.int/rec/R-REC-BT.1700-0-200502-I/en Table 4
+    constexpr YUV to_yuv() const
+    {
+        float r = red() / 255.0f;
+        float g = green() / 255.0f;
+        float b = blue() / 255.0f;
+        // Item 8
+        float y = 0.299f * r + 0.587f * g + 0.114f * b;
+        // Item 9
+        float u = 0.493f * (b - y);
+        float v = 0.877f * (r - y);
+        y = clamp(y, 0.0f, 1.0f);
+        u = clamp(u, -1.0f, 1.0f);
+        v = clamp(v, -1.0f, 1.0f);
+        return { y, u, v };
     }
 
     static constexpr Color from_hsl(float h_degrees, float s, float l) { return from_hsla(h_degrees, s, l, 1.0); }

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -134,7 +134,7 @@ public:
     constexpr u8 blue() const { return m_value & 0xff; }
     constexpr u8 alpha() const { return (m_value >> 24) & 0xff; }
 
-    void set_alpha(u8 value)
+    constexpr void set_alpha(u8 value)
     {
         m_value &= 0x00ffffff;
         m_value |= value << 24;

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -313,6 +313,15 @@ public:
     Vector<Color> shades(u32 steps, float max = 1.f) const;
     Vector<Color> tints(u32 steps, float max = 1.f) const;
 
+    constexpr Color saturated_to(float saturation) const
+    {
+        auto hsv = to_hsv();
+        auto alpha = this->alpha();
+        auto color = Color::from_hsv(hsv.hue, static_cast<double>(saturation), hsv.value);
+        color.set_alpha(alpha);
+        return color;
+    }
+
     constexpr Color inverted() const
     {
         return Color(~red(), ~green(), ~blue(), alpha());


### PR DESCRIPTION
Vectorscopes are a standard tool in professional video/film color grading. The Vectorscope shows image colors in the UV plane (for the YUV color model) which *to massively oversimplify* equates to hue as the angle and saturation as the radius. Brightness for each point in the scope is determined by the number of "color vectors" at that point.

![image](https://user-images.githubusercontent.com/28656157/188271474-b38d0668-820d-4fcc-b49d-1a0d1c820fae.png)

(The PR's implementation is even a bit better than this)