### PR TITLE
Meta: Disallow running with QEMU >= 7.0 on aarch64 build

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -121,6 +121,13 @@ if [ "$installed_major_version" -lt "$SERENITY_QEMU_MIN_REQ_MAJOR_VERSION" ] ||
     die
 fi
 
+# FIXME: Remove this once #14856 is resolved.
+if [ "$SERENITY_ARCH" = "aarch64" ] && [ "$installed_major_version" -ge "7" ]; then
+    echo "The aarch64 Kernel currently does not support QEMU >= 7.0."
+    echo "Please install QEMU 6.2 or use the QEMU build script: 'QEMU_VERSION=\"qemu-6.2.0\" QEMU_MD5SUM=\"a077669ce58b6ee07ec355e54aad25be\" ./Toolchain/BuildQemu.sh'."
+    die
+fi
+
 NATIVE_WINDOWS_QEMU="0"
 
 if command -v wslpath >/dev/null; then

--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -11,8 +11,8 @@ PREFIX="$DIR/Local/qemu"
 BUILD=$(realpath "$DIR/../Build")
 SYSROOT="$BUILD/Root"
 
-QEMU_VERSION="qemu-7.0.0"
-QEMU_MD5SUM="bfb5b09a0d1f887c8c42a6d5f26971ab"
+QEMU_VERSION=${QEMU_VERSION:="qemu-7.0.0"}
+QEMU_MD5SUM=${QEMU_MD5SUM:="bfb5b09a0d1f887c8c42a6d5f26971ab"}
 
 echo PREFIX is "$PREFIX"
 echo SYSROOT is "$SYSROOT"


### PR DESCRIPTION
Currently the aarch64 Kernel does not run with QEMU 7.x and only works with QEMU 6.x. See #14856