### PR TITLE
LibUnicode: Generate code point display names with run-length encoding

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -190,7 +190,7 @@ public:
     // section of the shared library. If StringViews are generated directly, the table will be located
     // in the initialized data section. So instead, we generate run-length encoded (RLE) arrays to
     // represent the strings.
-    void generate(SourceGenerator& generator)
+    void generate(SourceGenerator& generator) const
     {
         constexpr size_t max_values_per_row = 300;
         size_t values_in_current_row = 0;


### PR DESCRIPTION
Similar to commit becec35, our code point display name data was a large
list of StringViews. RLE can be used here as well to remove about 32 MB
from the initialized data section to the read-only section.

Some of the refactoring to store strings as indices into an RLE array
also lets us clean up some of the code point name generators.

Before:
```
$ nm ./Build/lagom/liblagom-unicode.so.0.0.0 | rg "(s_code_point_display_names|s_block_display_names|s_abbreviation_mappings)"

0000000000b1fbe0 d _ZN7UnicodeL21s_block_display_namesE
0000000000b24c40 d _ZN7UnicodeL23s_abbreviation_mappingsE
0000000000a5ff00 d _ZN7UnicodeL26s_code_point_display_namesE
```

After:
```
$ nm ./Build/lagom/liblagom-unicode.so.0.0.0 | rg "(s_code_point_display_names|s_block_display_names|s_abbreviation_mappings)"

00000000000e5b40 r _ZN7UnicodeL21s_block_display_namesE
0000000000138c40 r _ZN7UnicodeL23s_abbreviation_mappingsE
0000000000085cc0 r _ZN7UnicodeL26s_code_point_display_namesE
```