### PR TITLE
LibJS: Add new host hook, specify template literals and more

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -3545,6 +3545,11 @@ Completion TaggedTemplateLiteral::execute(Interpreter& interpreter, GlobalObject
         // tag`${foo}`             -> "", foo, ""                -> tag(["", ""], foo)
         // tag`foo${bar}baz${qux}` -> "foo", bar, "baz", qux, "" -> tag(["foo", "baz", ""], bar, qux)
         if (i % 2 == 0) {
+            // If the string contains invalid escapes we get a null expression here, which we then convert
+            // to the expected `undefined` TV.
+            if (value.is_nullish())
+                value = js_undefined();
+
             strings->indexed_properties().append(value);
         } else {
             arguments.append(value);

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -339,9 +339,15 @@ ThrowCompletionOr<CallExpression::ThisAndCallee> CallExpression::compute_this_an
         return ThisAndCallee { this_value, callee };
     }
 
+    Value this_value = js_undefined();
+    if (callee_reference.is_environment_reference()) {
+        if (Object* base_object = callee_reference.base_environment().with_base_object(); base_object != nullptr)
+            this_value = base_object;
+    }
+
     // [[Call]] will handle that in non-strict mode the this value becomes the global object
     return ThisAndCallee {
-        js_undefined(),
+        this_value,
         callee_reference.is_unresolvable()
             ? TRY(m_callee->execute(interpreter, global_object)).release_value()
             : TRY(callee_reference.get_value(global_object))

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1769,9 +1769,12 @@ public:
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
+    ThrowCompletionOr<Value> get_template_object(Interpreter& interpreter, GlobalObject& global_object) const;
+
 private:
     NonnullRefPtr<Expression> const m_tag;
     NonnullRefPtr<TemplateLiteral> const m_template_literal;
+    mutable HashMap<Realm*, Handle<Array>> m_cached_values;
 };
 
 class MemberExpression final : public Expression {

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1811,16 +1811,18 @@ NonnullRefPtr<ArrayExpression> Parser::parse_array_expression()
     return create_ast_node<ArrayExpression>({ m_state.current_token.filename(), rule_start.position(), position() }, move(elements));
 }
 
-NonnullRefPtr<StringLiteral> Parser::parse_string_literal(Token const& token, bool in_template_literal)
+NonnullRefPtr<StringLiteral> Parser::parse_string_literal(Token const& token, StringLiteralType string_literal_type, bool* contains_invalid_escape)
 {
     auto rule_start = push_start();
     auto status = Token::StringValueStatus::Ok;
     auto string = token.string_value(status);
+    // NOTE: Tagged templates should not fail on invalid strings as their raw contents can still be accessed.
     if (status != Token::StringValueStatus::Ok) {
         String message;
         if (status == Token::StringValueStatus::LegacyOctalEscapeSequence) {
             m_state.string_legacy_octal_escape_sequence_in_scope = true;
-            if (in_template_literal)
+            // It is a Syntax Error if the [Tagged] parameter was not set and Template{Head, Middle, Tail} Contains NotEscapeSequence.
+            if (string_literal_type != StringLiteralType::Normal)
                 message = "Octal escape sequence not allowed in template literal";
             else if (m_state.strict_mode)
                 message = "Octal escape sequence in string literal not allowed in strict mode";
@@ -1833,11 +1835,17 @@ NonnullRefPtr<StringLiteral> Parser::parse_string_literal(Token const& token, bo
             VERIFY_NOT_REACHED();
         }
 
-        if (!message.is_empty())
-            syntax_error(message, Position { token.line_number(), token.line_column() });
+        if (!message.is_empty()) {
+            if (contains_invalid_escape != nullptr) {
+                VERIFY(string_literal_type == StringLiteralType::TaggedTemplate);
+                *contains_invalid_escape = true;
+            } else {
+                syntax_error(message, Position { token.line_number(), token.line_column() });
+            }
+        }
     }
 
-    auto is_use_strict_directive = !in_template_literal && (token.value() == "'use strict'" || token.value() == "\"use strict\"");
+    auto is_use_strict_directive = string_literal_type == StringLiteralType::Normal && (token.value() == "'use strict'" || token.value() == "\"use strict\"");
 
     return create_ast_node<StringLiteral>({ m_state.current_token.filename(), rule_start.position(), position() }, string, is_use_strict_directive);
 }
@@ -1863,7 +1871,15 @@ NonnullRefPtr<TemplateLiteral> Parser::parse_template_literal(bool is_tagged)
     while (!done() && !match(TokenType::TemplateLiteralEnd) && !match(TokenType::UnterminatedTemplateLiteral)) {
         if (match(TokenType::TemplateLiteralString)) {
             auto token = consume();
-            expressions.append(parse_string_literal(token, true));
+            bool contains_invalid_escape = false;
+            auto parsed_string_value = parse_string_literal(token,
+                is_tagged ? StringLiteralType::TaggedTemplate : StringLiteralType::NonTaggedTemplate,
+                is_tagged ? &contains_invalid_escape : nullptr);
+            // An invalid string leads to a cooked value of `undefined` but still gives the raw string.
+            if (contains_invalid_escape)
+                expressions.append(create_ast_node<NullLiteral>({ m_state.current_token.filename(), rule_start.position(), position() }));
+            else
+                expressions.append(move(parsed_string_value));
             if (is_tagged)
                 raw_strings.append(create_ast_node<StringLiteral>({ m_state.current_token.filename(), rule_start.position(), position() }, token.raw_template_value()));
         } else if (match(TokenType::TemplateLiteralExprStart)) {
@@ -4011,7 +4027,7 @@ FlyString Parser::consume_string_value()
 {
     VERIFY(match(TokenType::StringLiteral));
     auto string_token = consume();
-    FlyString value = parse_string_literal(string_token, false)->value();
+    FlyString value = parse_string_literal(string_token)->value();
 
     // This also checks IsStringWellFormedUnicode which makes sure there is no unpaired surrogate
     // Surrogates are at least 3 bytes

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -142,7 +142,14 @@ public:
     NonnullRefPtr<RegExpLiteral> parse_regexp_literal();
     NonnullRefPtr<ObjectExpression> parse_object_expression();
     NonnullRefPtr<ArrayExpression> parse_array_expression();
-    NonnullRefPtr<StringLiteral> parse_string_literal(Token const& token, bool in_template_literal = false);
+
+    enum class StringLiteralType {
+        Normal,
+        NonTaggedTemplate,
+        TaggedTemplate
+    };
+
+    NonnullRefPtr<StringLiteral> parse_string_literal(Token const& token, StringLiteralType string_literal_type = StringLiteralType::Normal, bool* contains_invalid_escape = nullptr);
     NonnullRefPtr<TemplateLiteral> parse_template_literal(bool is_tagged);
     ExpressionResult parse_secondary_expression(NonnullRefPtr<Expression>, int min_precedence, Associativity associate = Associativity::Right, ForbiddenTokens forbidden = {});
     NonnullRefPtr<Expression> parse_call_expression(NonnullRefPtr<Expression>);

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -103,7 +103,7 @@ JS_DEFINE_NATIVE_FUNCTION(FunctionPrototype::bind)
     auto* function = TRY(BoundFunction::create(global_object, target, this_argument, move(arguments)));
 
     // 4. Let argCount be the number of elements in args.
-    auto arg_count = vm.argument_count() - 1;
+    auto arg_count = vm.argument_count() > 0 ? vm.argument_count() - 1 : 0;
 
     // 5. Perform ? CopyNameAndLength(F, Target, "bound", argCount).
     TRY(copy_name_and_length(global_object, *function, target, "bound"sv, arg_count));

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -124,6 +124,21 @@ VM::VM(OwnPtr<CustomData> custom_data)
         return {};
     };
 
+    host_ensure_can_add_private_element = [](Object&) -> ThrowCompletionOr<void> {
+        // The host-defined abstract operation HostEnsureCanAddPrivateElement takes argument O (an Object)
+        // and returns either a normal completion containing unused or a throw completion.
+        // It allows host environments to prevent the addition of private elements to particular host-defined exotic objects.
+        // An implementation of HostEnsureCanAddPrivateElement must conform to the following requirements:
+        // - If O is not a host-defined exotic object, this abstract operation must return NormalCompletion(unused) and perform no other steps.
+        // - Any two calls of this abstract operation with the same argument must return the same kind of Completion Record.
+        // The default implementation of HostEnsureCanAddPrivateElement is to return NormalCompletion(unused).
+        return {};
+
+        // This abstract operation is only invoked by ECMAScript hosts that are web browsers.
+        // NOTE: Since LibJS has no way of knowing whether the current environment is a browser we always
+        //       call HostEnsureCanAddPrivateElement when needed.
+    };
+
 #define __JS_ENUMERATE(SymbolName, snake_name) \
     m_well_known_symbol_##snake_name = js_symbol(*this, "Symbol." #SymbolName, false);
     JS_ENUMERATE_WELL_KNOWN_SYMBOLS

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -229,6 +229,7 @@ public:
     Function<void(Function<ThrowCompletionOr<Value>()>, Realm*)> host_enqueue_promise_job;
     Function<JobCallback(FunctionObject&)> host_make_job_callback;
     Function<ThrowCompletionOr<void>(Realm&)> host_ensure_can_compile_strings;
+    Function<ThrowCompletionOr<void>(Object&)> host_ensure_can_add_private_element;
 
 private:
     explicit VM(OwnPtr<CustomData>);

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -500,6 +500,11 @@ ThrowCompletionOr<Value> Value::to_number(GlobalObject& global_object) const
         auto parsed_double = strtod(string.characters(), &endptr);
         if (*endptr)
             return js_nan();
+        // NOTE: Per the spec only exactly [+-]Infinity should result in infinity
+        //       but strtod gives infinity for any case-insensitive 'infinity' or 'inf' string.
+        if (isinf(parsed_double) && string.contains('i', AK::CaseSensitivity::CaseInsensitive))
+            return js_nan();
+
         return Value(parsed_double);
     }
     case SYMBOL_TAG:

--- a/Userland/Libraries/LibJS/Tests/builtins/Function/Function.prototype.bind.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Function/Function.prototype.bind.js
@@ -126,6 +126,19 @@ describe("bound function |this|", () => {
     test("arrow functions cannot be bound", () => {
         expect((() => this).bind("foo")()).toBe(globalThis);
     });
+
+    test("length of original function is used for bound function", () => {
+        [0, 1, 2147483647, 2147483648, 2147483649].forEach(value => {
+            function emptyFunction() {}
+
+            Object.defineProperty(emptyFunction, "length", { value });
+
+            expect(emptyFunction.bind().length).toBe(value);
+            expect(emptyFunction.bind(null).length).toBe(value);
+            expect(emptyFunction.bind(null, 0).length).toBe(Math.max(0, value - 1));
+            expect(emptyFunction.bind(null, 0, 1, 2).length).toBe(Math.max(0, value - 3));
+        });
+    });
 });
 
 describe("bound function constructors", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Number/Number.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Number/Number.js
@@ -17,11 +17,18 @@ test("constructor without new", () => {
     expect(Number("Infinity")).toBe(Infinity);
     expect(Number("+Infinity")).toBe(Infinity);
     expect(Number("-Infinity")).toBe(-Infinity);
+    expect(Number("infinity")).toBeNaN();
+    expect(Number("-infinity")).toBeNaN();
+    expect(Number("INFINITY")).toBeNaN();
+    expect(Number("-INFINITY")).toBeNaN();
+    expect(Number("inf")).toBeNaN();
     expect(Number(undefined)).toBeNaN();
     expect(Number({})).toBeNaN();
     expect(Number({ a: 1 })).toBeNaN();
     expect(Number([1, 2, 3])).toBeNaN();
     expect(Number("foo")).toBeNaN();
+    expect(Number("10e10000")).toBe(Infinity);
+    expect(Number("-10e10000")).toBe(-Infinity);
 });
 
 test("constructor with new", () => {
@@ -38,9 +45,16 @@ test("constructor with new", () => {
     expect(new Number("Infinity").valueOf()).toBe(Infinity);
     expect(new Number("+Infinity").valueOf()).toBe(Infinity);
     expect(new Number("-Infinity").valueOf()).toBe(-Infinity);
+    expect(new Number("infinity").valueOf()).toBeNaN();
+    expect(new Number("-infinity").valueOf()).toBeNaN();
+    expect(new Number("INFINITY").valueOf()).toBeNaN();
+    expect(new Number("-INFINITY").valueOf()).toBeNaN();
+    expect(new Number("inf").valueOf()).toBeNaN();
     expect(new Number(undefined).valueOf()).toBeNaN();
     expect(new Number({}).valueOf()).toBeNaN();
     expect(new Number({ a: 1 }).valueOf()).toBeNaN();
     expect(new Number([1, 2, 3]).valueOf()).toBeNaN();
     expect(new Number("foo").valueOf()).toBeNaN();
+    expect(new Number("10e10000").valueOf()).toBe(Infinity);
+    expect(new Number("-10e10000").valueOf()).toBe(-Infinity);
 });

--- a/Userland/Libraries/LibJS/Tests/tagged-template-literals.js
+++ b/Userland/Libraries/LibJS/Tests/tagged-template-literals.js
@@ -105,4 +105,29 @@ describe("tagged template literal functionality", () => {
         expect(raw[1]).toHaveLength(5);
         expect(raw[1]).toBe("\\nbar");
     });
+
+    test("invalid escapes give undefined cooked values but can be accesed in raw form", () => {
+        let calls = 0;
+        let lastValue = null;
+        function noCookedButRaw(values) {
+            ++calls;
+            expect(values).not.toBeNull();
+            expect(values.raw).toHaveLength(1);
+            expect(values.raw[0].length).toBeGreaterThan(0);
+            expect(values.raw[0].charAt(0)).toBe("\\");
+            expect(values[0]).toBeUndefined();
+            lastValue = values.raw[0];
+        }
+        noCookedButRaw`\u`;
+        expect(calls).toBe(1);
+        expect(lastValue).toBe("\\u");
+
+        noCookedButRaw`\01`;
+        expect(calls).toBe(2);
+        expect(lastValue).toBe("\\01");
+
+        noCookedButRaw`\u{10FFFFF}`;
+        expect(calls).toBe(3);
+        expect(lastValue).toBe("\\u{10FFFFF}");
+    });
 });

--- a/Userland/Libraries/LibJS/Tests/tagged-template-literals.js
+++ b/Userland/Libraries/LibJS/Tests/tagged-template-literals.js
@@ -130,4 +130,37 @@ describe("tagged template literal functionality", () => {
         expect(calls).toBe(3);
         expect(lastValue).toBe("\\u{10FFFFF}");
     });
+
+    test("for multiple values gives undefined only for invalid strings", () => {
+        let restValue = null;
+        let stringsValue = null;
+        let calls = 0;
+
+        function extractArguments(value, ...arguments) {
+            ++calls;
+            restValue = arguments;
+            stringsValue = value;
+        }
+        extractArguments`valid${1}invalid\u`;
+
+        expect(calls).toBe(1);
+        expect(restValue).toHaveLength(1);
+        expect(restValue[0]).toBe(1);
+        expect(stringsValue).toHaveLength(2);
+        expect(stringsValue[0]).toBe("valid");
+        expect(stringsValue[1]).toBeUndefined();
+        expect(stringsValue.raw).toHaveLength(2);
+        expect(stringsValue.raw[0]).toBe("valid");
+        expect(stringsValue.raw[1]).toBe("invalid\\u");
+    });
+
+    test("string value gets cached per AST node", () => {
+        function call(func, val) {
+            return func`template${val}second`;
+        }
+
+        let firstResult = call(value => value, 1);
+        let secondResult = call(value => value, 2);
+        expect(firstResult).toBe(secondResult);
+    });
 });

--- a/Userland/Libraries/LibJS/Tests/template-literals.js
+++ b/Userland/Libraries/LibJS/Tests/template-literals.js
@@ -63,3 +63,9 @@ test("line continuation in literals (not characters)", () => {
 test("reference error from expressions", () => {
     expect(() => `${b}`).toThrowWithMessage(ReferenceError, "'b' is not defined");
 });
+
+test("invalid escapes should give syntax error", () => {
+    expect("`\\u`").not.toEval();
+    expect("`\\01`").not.toEval();
+    expect("`\\u{10FFFFF}`").not.toEval();
+});


### PR DESCRIPTION
I have not implemented the hook in browser yet as the PR is not merged yet:
https://github.com/whatwg/html/pull/8198

I do have a patch ready but it might be more complicated by extending location and or window

The original JS PR has already been merged:
https://github.com/tc39/ecma262/pull/2807