### PR TITLE
WindowServer: Buffer key events if automatic cursor tracking window

### DIFF
--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1218,8 +1218,12 @@ bool WindowManager::process_ongoing_active_input_mouse_event(MouseEvent const& e
     // a move in that other unrelated window, and other silly shenanigans.
     deliver_mouse_event(*input_tracking_window, event, true);
 
-    if (event.type() == Event::MouseUp && event.buttons() == 0)
+    if (event.type() == Event::MouseUp && event.buttons() == 0) {
         set_automatic_cursor_tracking_window(nullptr);
+        for (KeyEvent key : m_buffered_keys)
+            process_key_event(key);
+        m_buffered_keys.clear();
+    }
 
     return true;
 }
@@ -1589,6 +1593,11 @@ void WindowManager::did_switch_window_stack(Badge<Compositor>, WindowStack& prev
 
 void WindowManager::process_key_event(KeyEvent& event)
 {
+    if (automatic_cursor_tracking_window()) {
+        m_buffered_keys.append(event);
+        return;
+    }
+
     m_keyboard_modifiers = event.modifiers();
 
     // Escape key cancels an ongoing drag.

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -472,6 +472,7 @@ private:
 
     u8 m_keyboard_modifiers { 0 };
     u8 m_last_processed_buttons { MouseButton::None };
+    Vector<KeyEvent> m_buffered_keys;
 
     NonnullRefPtr<WindowSwitcher> m_switcher;
     NonnullRefPtr<KeymapSwitcher> m_keymap_switcher;


### PR DESCRIPTION
In one of Andreas's recent videos, it was discovered that currently we
accept key events while in an automatic cursor tracking window, but that
in other systems they buffer the key events and then process them on the
mouse up event.

There are a few awkward pieces with adding this:
- TextEditor - if someone is holding mouse button and typing keys,
  instead of replacing the selected text immediately, the input is
  buffered until they release mouse button. Kind of awkward but also
  kind of unlikely to be holding the selection down still while also
  typing.
- FileManager - If moving around with the arrow keys while also holding
  a drag selection, the end result is that the file highlighted is the
  one that the buffered keys brought them to instead of the drag
  selected ones.
- etc. (I'm sure there's a few that I'm not aware of)

Note on the above if the user doesn't press any keys, then it doesn't
affect the drag in any sense. It just proceeds as usual.