### PR TITLE
Kernel: Make sys$unveil() not take the big process lock

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -186,7 +186,7 @@ enum class NeedsBigProcessLock {
     S(umount, NeedsBigProcessLock::Yes)                     \
     S(uname, NeedsBigProcessLock::No)                       \
     S(unlink, NeedsBigProcessLock::No)                      \
-    S(unveil, NeedsBigProcessLock::Yes)                     \
+    S(unveil, NeedsBigProcessLock::No)                      \
     S(utime, NeedsBigProcessLock::Yes)                      \
     S(utimensat, NeedsBigProcessLock::Yes)                  \
     S(waitid, NeedsBigProcessLock::Yes)                     \

--- a/Kernel/Syscalls/unveil.cpp
+++ b/Kernel/Syscalls/unveil.cpp
@@ -26,7 +26,7 @@ static void update_intermediate_node_permissions(UnveilNode& root_node, UnveilAc
 
 ErrorOr<FlatPtr> Process::sys$unveil(Userspace<Syscall::SC_unveil_params const*> user_params)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     auto params = TRY(copy_typed_from_user(user_params));
 
     if (!params.path.characters && !params.permissions.characters) {


### PR DESCRIPTION
Yakbaited by Andreas's video. I semi-randomly chose unveil, and maybe I'm missing something, but it looks to already be safe since UnveilData is already SpinlockProtected.