### PR TITLE
Clipboard: Add persistent storage for clipboard entries

### DIFF
--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -21,6 +21,7 @@ public:
     static NonnullRefPtr<ClipboardHistoryModel> create();
 
     enum Column {
+        IsPersistent,
         Data,
         Type,
         Size,
@@ -28,15 +29,24 @@ public:
         __Count
     };
 
+    enum ClipboardEntryState {
+        Persistent,
+        Volatile
+    };
+
     struct ClipboardItem {
         GUI::Clipboard::DataAndType data_and_type;
         Core::DateTime time;
+        ClipboardEntryState state;
     };
 
     virtual ~ClipboardHistoryModel() override = default;
 
     ClipboardItem const& item_at(int index) const { return m_history_items[index]; }
     void remove_item(int index);
+    void set_state(int index, ClipboardEntryState state);
+    bool is_persistent(int index);
+    void add_item(const GUI::Clipboard::DataAndType& item, ClipboardEntryState state = ClipboardEntryState::Volatile);
 
     // ^GUI::Model
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
@@ -46,7 +56,6 @@ public:
 
 private:
     ClipboardHistoryModel();
-    void add_item(const GUI::Clipboard::DataAndType& item);
 
     // ^GUI::Model
     virtual int row_count(const GUI::ModelIndex&) const override { return m_history_items.size(); }

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -5,7 +5,9 @@
  */
 
 #include "ClipboardHistoryModel.h"
+#include <AK/LexicalPath.h>
 #include <LibConfig/Client.h>
+#include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
@@ -15,16 +17,61 @@
 #include <LibGUI/Window.h>
 #include <LibMain/Main.h>
 
+static void try_load_clipboard_content(String clipboard_file_path, RefPtr<ClipboardHistoryModel> model)
+{
+    dbgln("Try loading content from persistent clipboard");
+
+    auto clipboard_file_or_error = Core::File::open(clipboard_file_path, Core::OpenMode::ReadOnly);
+    if (clipboard_file_or_error.is_error()) {
+        dbgln("Failed to open persistent clipboard file {} as read-only", clipboard_file_path);
+        return;
+    }
+    auto file_content = clipboard_file_or_error.release_value()->read_all();
+    auto json_or_error = JsonValue::from_string(file_content);
+
+    if (json_or_error.is_error()) {
+        dbgln("Failed to parse persistent clipboard file {}. Abort loading.", clipboard_file_path);
+        return;
+    }
+
+    auto json = json_or_error.release_value();
+    json.as_array().for_each([&model = *model](JsonValue const& entry) {
+        if (!entry.as_object().has("Data"sv) || !entry.as_object().has("Type"sv)) {
+            return IterationDecision::Continue;
+        }
+
+        HashMap<String, String> metadata;
+        auto mime_type = entry.as_object().get("Type"sv).to_string();
+        auto data_bytes = entry.as_object().get("Data"sv).to_string().bytes();
+        auto data = ByteBuffer::copy(data_bytes.data(), data_bytes.size());
+
+        if (data.is_error()) {
+            return IterationDecision::Continue;
+        }
+
+        auto state = ClipboardHistoryModel::ClipboardEntryState::Persistent;
+        GUI::Clipboard::DataAndType item = { data.release_value(), mime_type, metadata };
+        model.add_item(item, state);
+
+        return IterationDecision::Continue;
+    });
+}
+
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix cpath wpath"));
     auto app = TRY(GUI::Application::try_create(arguments));
+    auto clipboard_config = TRY(Core::ConfigFile::open_for_app("KeyboardSettings"));
+    bool persistent_clipboard = clipboard_config->read_bool_entry("Clipboard", "PersistentClipboard", false);
+    auto clipboard_file_path = clipboard_config->read_entry("Clipboard", "ClipboardFilePath");
 
     Config::pledge_domain("ClipboardHistory");
     Config::monitor_domain("ClipboardHistory");
-
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath wpath cpath"));
     TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil(Core::StandardPaths::config_directory(), "r"sv));
+    if (!clipboard_file_path.is_empty())
+        TRY(Core::System::unveil(clipboard_file_path, "cwr"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("edit-copy"sv));
 
@@ -36,6 +83,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto table_view = TRY(main_window->try_set_main_widget<GUI::TableView>());
     auto model = ClipboardHistoryModel::create();
     table_view->set_model(model);
+
+    if (persistent_clipboard && !clipboard_file_path.is_empty())
+        try_load_clipboard_content(clipboard_file_path, model);
 
     table_view->on_activation = [&](GUI::ModelIndex const& index) {
         auto& data_and_type = model->item_at(index.row()).data_and_type;
@@ -52,14 +102,106 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         });
     });
 
+    auto persistent_toggle_action = GUI::Action::create("Toggle persistence", [&](const GUI::Action&) {
+        table_view->selection().for_each_index([&](GUI::ModelIndex& index) {
+            auto clipboard_config = Core::ConfigFile::open_for_app("KeyboardSettings");
+            if (clipboard_config.is_error()) {
+                dbgln("Cannot read config for KeyboardSettings application from Clipboard manager");
+                return;
+            }
+            auto clipboard_file_path = clipboard_config.release_value()->read_entry("Clipboard", "ClipboardFilePath");
+            if (clipboard_file_path.is_empty()) {
+                dbgln("Persistent clipboard path is not defined, cannot write to it");
+                return;
+            }
+
+            auto data_string = String::copy(model->item_at(index.row()).data_and_type.data);
+            auto mime_type = model->item_at(index.row()).data_and_type.mime_type;
+
+            auto clipboard_entry_index = index.row();
+            bool currently_persistent = model->is_persistent(clipboard_entry_index);
+
+            JsonValue clipboard_json_content;
+
+            auto clipboard_file_or_error = Core::File::open(clipboard_file_path, Core::OpenMode::ReadOnly);
+            if (clipboard_file_or_error.is_error()) {
+                // Setting default value as the clipboard file could not exist yet
+                clipboard_json_content = JsonValue::from_string("[]"sv).release_value();
+            } else {
+                auto clipboard_content = clipboard_file_or_error.release_value()->read_all();
+                auto json_or_error = JsonValue::from_string(clipboard_content);
+                if (json_or_error.is_error()) {
+                    dbgln("Failed to parse persistent clipboard file {}", clipboard_file_path);
+                    return;
+                }
+                clipboard_json_content = json_or_error.release_value();
+            }
+
+            JsonArray new_entries;
+
+            if (!currently_persistent) {
+                if (mime_type == "text/plain" && data_string.length() < 128) {
+                    dbgln("Setting clipboard entry persistent: {}", data_string);
+                }
+
+                clipboard_json_content.as_array().for_each([&](auto& entry) {
+                    new_entries.append(entry);
+                });
+
+                JsonObject t;
+                t.set("Data", data_string);
+                t.set("Type", mime_type);
+                JsonValue new_entry_object = JsonValue::from_string(t.to_string()).value();
+
+                new_entries.append(new_entry_object);
+            } else {
+                if (mime_type == "text/plain" && data_string.length() < 128) {
+                    dbgln("Removing clipboard entry from persistent clipboard: {}", data_string);
+                }
+
+                clipboard_json_content.as_array().for_each([&](auto& entry) {
+                    auto mime_type = entry.as_object().get("Type"sv).to_string();
+                    auto data = entry.as_object().get("Data"sv).to_string();
+
+                    if (!((mime_type == mime_type) && (data == data_string))) {
+                        new_entries.append(entry);
+                    }
+                });
+            }
+
+            auto clipboard_file_write_or_error = Core::File::open(clipboard_file_path, Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
+            if (clipboard_file_write_or_error.is_error()) {
+                dbgln("Failed to open persistent clipboard file {} as write only", clipboard_file_path);
+                return;
+            }
+
+            bool clipboard_updated = clipboard_file_write_or_error.release_value()->write(new_entries.to_string());
+            if (clipboard_updated) {
+                auto state = ClipboardHistoryModel::ClipboardEntryState::Persistent;
+                if (currently_persistent) {
+                    state = ClipboardHistoryModel::ClipboardEntryState::Volatile;
+                }
+                model->set_state(clipboard_entry_index, state);
+            }
+        });
+    });
+
     auto entry_context_menu = TRY(GUI::Menu::try_create());
     TRY(entry_context_menu->try_add_action(delete_action));
     TRY(entry_context_menu->try_add_action(debug_dump_action));
+    TRY(entry_context_menu->try_add_action(persistent_toggle_action));
+
     table_view->on_context_menu_request = [&](GUI::ModelIndex const&, GUI::ContextMenuEvent const& event) {
         delete_action->set_enabled(!table_view->selection().is_empty());
         debug_dump_action->set_enabled(!table_view->selection().is_empty());
+        persistent_toggle_action->set_enabled(
+            (!table_view->selection().is_empty()) && (persistent_clipboard));
         entry_context_menu->popup(event.screen_position());
     };
+
+    // Saved x and y positions since their values will be 0 if we hide the window
+    int saved_x = main_window->x();
+    int saved_y = main_window->y();
 
     auto applet_window = TRY(GUI::Window::try_create());
     applet_window->set_title("ClipboardHistory");
@@ -68,9 +210,20 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto icon_widget = TRY(applet_window->try_set_main_widget<GUI::ImageWidget>());
     icon_widget->set_tooltip("Clipboard History");
     icon_widget->load_from_file("/res/icons/16x16/edit-copy.png"sv);
-    icon_widget->on_click = [&main_window = *main_window] {
-        main_window.show();
-        main_window.move_to_front();
+    icon_widget->on_click = [&main_window = *main_window, &saved_x, &saved_y] {
+        if (main_window.is_visible()) {
+            if (main_window.is_active()) {
+                saved_x = main_window.x();
+                saved_y = main_window.y();
+                main_window.hide();
+            } else {
+                main_window.move_to_front();
+            }
+        } else {
+            main_window.set_rect(saved_x, saved_y, main_window.width(), main_window.height());
+            main_window.show();
+            main_window.move_to_front();
+        }
     };
     applet_window->resize(16, 16);
     applet_window->show();

--- a/Userland/Applications/KeyboardSettings/Keyboard.gml
+++ b/Userland/Applications/KeyboardSettings/Keyboard.gml
@@ -124,4 +124,51 @@
             name: "num_lock_checkbox"
         }
     }
+
+    @GUI::GroupBox {
+        title: "Persistent Clipboard"
+        // fixed_height: 80
+        layout: @GUI::VerticalBoxLayout {
+            margins: [6]
+            spacing: 2
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 16
+            }
+
+            @GUI::Label {
+                fixed_width: 32
+                fixed_height: 32
+                icon: "/res/icons/32x32/shutdown.png"
+            }
+
+            @GUI::CheckBox {
+                text: "Preserve clipboard content across reboots"
+                name: "persistent_clipboard"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 16
+            }
+
+            @GUI::Widget {
+                fixed_width: 32
+            }
+
+            @GUI::Label {
+                autosize: true
+                text: "Clipboard path:"
+                fixed_width: 80
+                text_alignment: "CenterLeft"
+            }
+
+            @GUI::TextBox {
+                name: "clipboard_file_path"
+            }
+        }
+    }
 }

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -251,6 +251,18 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
     m_num_lock_checkbox->on_checked = [&](auto) {
         set_modified(true);
     };
+
+    m_persistent_clipboard = find_descendant_of_type_named<GUI::CheckBox>("persistent_clipboard");
+    m_persistent_clipboard->set_checked(Config::read_bool("KeyboardSettings"sv, "Clipboard"sv, "PersistentClipboard"sv, true));
+    m_persistent_clipboard->on_checked = [&](auto) {
+        set_modified(true);
+    };
+
+    m_clipboard_file_path = find_descendant_of_type_named<GUI::TextBox>("clipboard_file_path");
+    m_clipboard_file_path->set_text(Config::read_string("KeyboardSettings"sv, "Clipboard"sv, "ClipboardFilePath"sv, ""sv));
+    m_clipboard_file_path->on_change = [&]() {
+        set_modified(true);
+    };
 }
 
 KeyboardSettingsWidget::~KeyboardSettingsWidget()
@@ -278,6 +290,8 @@ void KeyboardSettingsWidget::apply_settings()
     }
     m_initial_active_keymap = m_keymaps_list_model.active_keymap();
     Config::write_bool("KeyboardSettings"sv, "StartupEnable"sv, "NumLock"sv, m_num_lock_checkbox->is_checked());
+    Config::write_bool("KeyboardSettings"sv, "Clipboard"sv, "PersistentClipboard"sv, m_persistent_clipboard->is_checked());
+    Config::write_string("KeyboardSettings"sv, "Clipboard"sv, "ClipboardFilePath"sv, m_clipboard_file_path->get_text());
 }
 
 void KeyboardSettingsWidget::set_keymaps(Vector<String> const& keymaps, String const& active_keymap)

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.h
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.h
@@ -12,6 +12,7 @@
 #include <LibGUI/ConnectionToWindowManagerServer.h>
 #include <LibGUI/ListView.h>
 #include <LibGUI/SettingsWindow.h>
+#include <LibGUI/TextBox.h>
 #include <LibGUI/TextEditor.h>
 
 class KeyboardSettingsWidget final : public GUI::SettingsWindow::Tab {
@@ -35,6 +36,8 @@ private:
     RefPtr<GUI::ListView> m_selected_keymaps_listview;
     RefPtr<GUI::Label> m_active_keymap_label;
     RefPtr<GUI::CheckBox> m_num_lock_checkbox;
+    RefPtr<GUI::CheckBox> m_persistent_clipboard;
+    RefPtr<GUI::TextBox> m_clipboard_file_path;
     RefPtr<GUI::Button> m_activate_keymap_button;
     RefPtr<GUI::Button> m_add_keymap_button;
     RefPtr<GUI::Button> m_remove_keymap_button;

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -68,6 +68,21 @@ Clipboard::DataAndType Clipboard::fetch_data_and_type() const
     return { data.release_value(), type, metadata };
 }
 
+Clipboard::DataAndTypeAndFavorite Clipboard::fetch_data_and_type_and_favorite() const
+{
+    auto response = connection().get_clipboard_data();
+    if (!response.data().is_valid())
+        return {};
+    auto data = ByteBuffer::copy(response.data().data<void>(), response.data().size());
+    if (data.is_error())
+        return {};
+
+    auto favorite = false;
+    auto type = response.mime_type();
+    auto metadata = response.metadata().entries();
+    return { favorite, data.release_value(), type, metadata };
+}
+
 RefPtr<Gfx::Bitmap> Clipboard::DataAndType::as_bitmap() const
 {
     if (mime_type != "image/x-serenityos")

--- a/Userland/Libraries/LibGUI/Clipboard.h
+++ b/Userland/Libraries/LibGUI/Clipboard.h
@@ -36,10 +36,20 @@ public:
         RefPtr<Gfx::Bitmap> as_bitmap() const;
     };
 
+    struct DataAndTypeAndFavorite {
+        bool favorite;
+        ByteBuffer data;
+        String mime_type;
+        HashMap<String, String> metadata;
+
+        RefPtr<Gfx::Bitmap> as_bitmap() const;
+    };
+
     static void initialize(Badge<Application>);
     static Clipboard& the();
 
     DataAndType fetch_data_and_type() const;
+    DataAndTypeAndFavorite fetch_data_and_type_and_favorite() const;
     String fetch_mime_type() const { return fetch_data_and_type().mime_type; }
 
     void set_data(ReadonlyBytes data, String const& mime_type = "text/plain", HashMap<String, String> const& metadata = {});


### PR DESCRIPTION
A clipboard entry can be set as persistent to survive reboots.
Persistence is configured globally thanks to a setting in the
Settings/Keyboard menu.

Clipboard window can now be toggled by clicking on the icon in the status
bar. If the window is already open but not in front, it will be focused.
This way, one can easily access the clipboard entries.

An entry is defined as (non-)persistent by right clicking on it in the
clipboard window and use "Toggle persistence" action. This action is
available only if clipboard persistence is enabled globally.

If persistence is enabled globally, clipboard content will be loaded
when the ClipboardHistory applet is started. If one change the global
settings, the applet should be restarted to automatically load clipboard
content.

Partially addresses #4051

<hr>

Known limitations:
- If window is minimized, impossible to show it again without calling hide() beforehand
- Rightclick menu label does not change based on persistence status. Here is the expected behaviour eventually:
  - "Set as persistent" when the current entry is not persistent
  - "Unset as persistent" when the current entry is persistent
- Sorting does not work when clicking headers in the clipboard window