### PR TITLE
LibGfx: Unfilter PNG data before unpacking it to RGBA

### DIFF
--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -183,8 +183,13 @@ static void unfilter_scanline(PNG::FilterType filter, Bytes scanline_data, Reado
 
     switch (filter) {
     case PNG::FilterType::Sub:
-        for (size_t i = 0; i < scanline_data.size(); ++i) {
-            u8 left = (i < bytes_per_complete_pixel) ? 0 : scanline_data[i - bytes_per_complete_pixel];
+        // This loop starts at bytes_per_complete_pixel because all bytes before that are
+        // guaranteed to have no valid byte at index (i - bytes_per_complete pixel).
+        // All such invalid byte indexes should be treated as 0, and adding 0 to the current
+        // byte would do nothing, so the first bytes_per_complete_pixel bytes can instead
+        // just be skipped.
+        for (size_t i = bytes_per_complete_pixel; i < scanline_data.size(); ++i) {
+            u8 left = scanline_data[i - bytes_per_complete_pixel];
             scanline_data[i] += left;
         }
         break;


### PR DESCRIPTION
The order of PNG compression is raw pixel data -> filter -> compress.
For decompression, the order is reversed, so that means uncompress ->
unfilter -> raw pixel data. Previously, the PNG decoder was converting
to raw pixel data before unfiltering, which was a problem when using
indexed color palettes, since each pixel's palette index could change
during unfiltering (e.g. it was unfiltering after already choosing
the color from the palette index). This was leading to 'Palette index
out of range' errors on files that both:

- Had scanlines with some sort of filtering
- Didn't use the full range of possible palette indices for their bit
  depth.

Also, because filtering now happens before converting to pixel data,
filtering acts on bytes instead of pixels, meaning that the
implementation of each filter type now maps much more directly to
the specification:

http://www.libpng.org/pub/png/spec/1.2/PNG-Filters.html

---

This fixes 2 emojis that were failing to load due to this problem (and is something of a follow up to https://github.com/SerenityOS/serenity/pull/14894).

Before:
![png-before](https://user-images.githubusercontent.com/2389051/185308132-026d0346-971f-4230-af8f-cfe531618d74.png)
```
16.225 FileManager(44:44): Failed to load thumbnail for /home/anon/U+1F4C8.png: PNGImageDecoderPlugin: Palette index out of range
16.225 FileManager(44:44): Failed to load thumbnail for /home/anon/U+1F926.png: PNGImageDecoderPlugin: Palette index out of range
```

After:
![png-after](https://user-images.githubusercontent.com/2389051/185308226-70599d85-750a-4994-b1ee-b1d7d53bc9d7.png)

Note: This problem would have also caused incorrect decoding on images with indexed color palettes that fill the entire bit depth (i.e. bit depth 2 with 4 colors) and filtered scanlines, but I don't think there are any examples of that within the current emoji set.

---

Suggestions for how to improve the implementation are more than welcome; this is my first non-trivial contribution to Serenity.