### PR TITLE
TextEditor: Change cursor when reaching the ruler area

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -28,6 +28,7 @@
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Palette.h>
+#include <LibGfx/StandardCursor.h>
 #include <LibSyntax/Highlighter.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -309,6 +310,12 @@ void TextEditor::mousemove_event(MouseEvent& event)
         did_update_selection();
         update();
         return;
+    }
+
+    if (m_ruler_visible && (ruler_rect_in_inner_coordinates().contains(event.position()))) {
+        set_override_cursor(Gfx::StandardCursor::None);
+    } else {
+        set_editing_cursor();
     }
 }
 
@@ -1672,6 +1679,11 @@ void TextEditor::set_mode(const Mode mode)
         VERIFY_NOT_REACHED();
     }
 
+    set_editing_cursor();
+}
+
+void TextEditor::set_editing_cursor()
+{
     if (!is_displayonly())
         set_override_cursor(Gfx::StandardCursor::IBeam);
     else

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -95,6 +95,8 @@ public:
     bool is_displayonly() const { return m_mode == DisplayOnly; }
     void set_mode(const Mode);
 
+    void set_editing_cursor();
+
     bool is_ruler_visible() const { return m_ruler_visible; }
     void set_ruler_visible(bool);
 


### PR DESCRIPTION
Noticed that mouse-overing the ruler area in the TextEditor
does not change the cursor to the default cursor, instead, the
beam cursor is used, which does not look nice.

This PR extends the mousemove event and introduces a new
`set_editing_cursor()` function that takes care of setting the
cursor for the editor area.