### PR TITLE
Kernel: Require an explicit lock rank for all Spinlocks

### DIFF
--- a/Kernel/Arch/Spinlock.h
+++ b/Kernel/Arch/Spinlock.h
@@ -16,7 +16,7 @@ class Spinlock {
     AK_MAKE_NONMOVABLE(Spinlock);
 
 public:
-    Spinlock(LockRank rank = LockRank::None)
+    Spinlock(LockRank rank)
         : m_rank(rank)
     {
     }
@@ -48,7 +48,7 @@ class RecursiveSpinlock {
     AK_MAKE_NONMOVABLE(RecursiveSpinlock);
 
 public:
-    RecursiveSpinlock(LockRank rank = LockRank::None)
+    RecursiveSpinlock(LockRank rank)
         : m_rank(rank)
     {
     }

--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -53,8 +53,8 @@ private:
     Vector<Capability> get_capabilities(Address);
     Optional<u8> get_capabilities_pointer(Address address);
 
-    mutable RecursiveSpinlock m_access_lock;
-    mutable Spinlock m_scan_lock;
+    mutable RecursiveSpinlock m_access_lock { LockRank::None };
+    mutable Spinlock m_scan_lock { LockRank::None };
 
     HashMap<u32, NonnullOwnPtr<HostController>> m_host_controllers;
     Vector<DeviceIdentifier> m_device_identifiers;

--- a/Kernel/Bus/PCI/Controller/VolumeManagementDevice.h
+++ b/Kernel/Bus/PCI/Controller/VolumeManagementDevice.h
@@ -29,7 +29,7 @@ private:
 
     // Note: All read and writes must be done with a spinlock because
     // Linux says that CPU might deadlock otherwise if access is not serialized.
-    Spinlock m_config_lock;
+    Spinlock m_config_lock { LockRank::None };
 };
 
 }

--- a/Kernel/Bus/USB/UHCI/UHCIDescriptorPool.h
+++ b/Kernel/Bus/USB/UHCI/UHCIDescriptorPool.h
@@ -70,6 +70,7 @@ private:
     UHCIDescriptorPool(NonnullOwnPtr<Memory::Region> pool_memory_block, StringView name)
         : m_pool_name(name)
         , m_pool_region(move(pool_memory_block))
+        , m_pool_lock(LockRank::None)
     {
         // Go through the number of descriptors to create in the pool, and create a virtual/physical address mapping
         for (size_t i = 0; i < PAGE_SIZE / sizeof(T); i++) {

--- a/Kernel/Bus/VirtIO/Queue.h
+++ b/Kernel/Bus/VirtIO/Queue.h
@@ -96,7 +96,7 @@ private:
     QueueDriver* m_driver { nullptr };
     QueueDevice* m_device { nullptr };
     NonnullOwnPtr<Memory::Region> m_queue_region;
-    Spinlock m_lock;
+    Spinlock m_lock { LockRank::None };
 
     friend class QueueChain;
 };

--- a/Kernel/Devices/AsyncDeviceRequest.h
+++ b/Kernel/Devices/AsyncDeviceRequest.h
@@ -151,7 +151,7 @@ private:
     WaitQueue m_queue;
     NonnullRefPtr<Process> m_process;
     void* m_private { nullptr };
-    mutable Spinlock m_lock;
+    mutable Spinlock m_lock { LockRank::None };
 };
 
 }

--- a/Kernel/Devices/Audio/AC97.h
+++ b/Kernel/Devices/Audio/AC97.h
@@ -144,7 +144,7 @@ private:
     private:
         IOAddress m_channel_base;
         AC97& m_device;
-        SpinlockProtected<bool> m_dma_running { false };
+        SpinlockProtected<bool> m_dma_running { LockRank::None, false };
         StringView m_name;
     };
 

--- a/Kernel/Devices/ConsoleDevice.cpp
+++ b/Kernel/Devices/ConsoleDevice.cpp
@@ -14,7 +14,7 @@
 // Output bytes to kernel debug port 0xE9 (Bochs console). It's very handy.
 #define CONSOLE_OUT_TO_BOCHS_DEBUG_PORT
 
-static Kernel::Spinlock g_console_lock;
+static Kernel::Spinlock g_console_lock { LockRank::None };
 
 UNMAP_AFTER_INIT NonnullRefPtr<ConsoleDevice> ConsoleDevice::must_create()
 {

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -88,7 +88,7 @@ private:
 
     State m_state { State::Normal };
 
-    Spinlock m_requests_lock;
+    Spinlock m_requests_lock { LockRank::None };
     DoublyLinkedList<RefPtr<AsyncDeviceRequest>> m_requests;
 
 protected:

--- a/Kernel/Devices/DeviceManagement.h
+++ b/Kernel/Devices/DeviceManagement.h
@@ -74,9 +74,9 @@ private:
     RefPtr<ConsoleDevice> m_console_device;
     RefPtr<DeviceControlDevice> m_device_control_device;
     // FIXME: Once we have a singleton for managing many sound cards, remove this from here
-    SpinlockProtected<HashMap<u64, Device*>> m_devices;
+    SpinlockProtected<HashMap<u64, Device*>> m_devices { LockRank::None };
 
-    mutable Spinlock m_event_queue_lock;
+    mutable Spinlock m_event_queue_lock { LockRank::None };
     CircularQueue<DeviceEvent, 100> m_event_queue;
 };
 

--- a/Kernel/Devices/HID/HIDManagement.h
+++ b/Kernel/Devices/HID/HIDManagement.h
@@ -57,13 +57,13 @@ private:
     size_t generate_minor_device_number_for_mouse();
     size_t generate_minor_device_number_for_keyboard();
 
-    SpinlockProtected<KeymapData> m_keymap_data;
+    SpinlockProtected<KeymapData> m_keymap_data { LockRank::None };
     size_t m_mouse_minor_number { 0 };
     size_t m_keyboard_minor_number { 0 };
     KeyboardClient* m_client { nullptr };
     RefPtr<I8042Controller> m_i8042_controller;
     NonnullRefPtrVector<HIDDevice> m_hid_devices;
-    Spinlock m_client_lock;
+    Spinlock m_client_lock { LockRank::None };
 };
 
 class KeyboardClient {

--- a/Kernel/Devices/HID/I8042Controller.h
+++ b/Kernel/Devices/HID/I8042Controller.h
@@ -153,7 +153,7 @@ private:
     void do_write(u8 port, u8 data);
     u8 do_read(u8 port);
 
-    Spinlock m_lock;
+    Spinlock m_lock { LockRank::None };
     bool m_first_port_available { false };
     bool m_second_port_available { false };
     bool m_is_dual_channel { false };

--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -46,7 +46,7 @@ public:
 
 protected:
     KeyboardDevice();
-    mutable Spinlock m_queue_lock;
+    mutable Spinlock m_queue_lock { LockRank::None };
     CircularQueue<Event, 16> m_queue;
     // ^CharacterDevice
     virtual StringView class_name() const override { return "KeyboardDevice"sv; }

--- a/Kernel/Devices/HID/MouseDevice.h
+++ b/Kernel/Devices/HID/MouseDevice.h
@@ -36,7 +36,7 @@ protected:
     // ^CharacterDevice
     virtual StringView class_name() const override { return "MouseDevice"sv; }
 
-    mutable Spinlock m_queue_lock;
+    mutable Spinlock m_queue_lock { LockRank::None };
     CircularQueue<MousePacket, 100> m_queue;
 };
 

--- a/Kernel/Devices/KCOVInstance.h
+++ b/Kernel/Devices/KCOVInstance.h
@@ -58,7 +58,7 @@ private:
     // Here to ensure it's not garbage collected at the end of open()
     OwnPtr<Memory::Region> m_kernel_region;
 
-    Spinlock m_lock;
+    Spinlock m_lock { LockRank::None };
 };
 
 }

--- a/Kernel/Devices/SerialDevice.h
+++ b/Kernel/Devices/SerialDevice.h
@@ -130,7 +130,7 @@ private:
     bool m_break_enable { false };
     u8 m_modem_control { 0 };
     bool m_last_put_char_was_carriage_return { false };
-    Spinlock m_serial_lock;
+    Spinlock m_serial_lock { LockRank::None };
 };
 
 }

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -127,7 +127,7 @@ private:
     InodeIndex m_index { 0 };
     WeakPtr<Memory::SharedInodeVMObject> m_shared_vmobject;
     RefPtr<LocalSocket> m_bound_socket;
-    SpinlockProtected<HashTable<InodeWatcher*>> m_watchers;
+    SpinlockProtected<HashTable<InodeWatcher*>> m_watchers { LockRank::None };
     bool m_metadata_dirty { false };
     RefPtr<FIFO> m_fifo;
     IntrusiveListNode<Inode> m_inode_list_node;
@@ -141,7 +141,7 @@ private:
     };
 
     Thread::FlockBlockerSet m_flock_blocker_set;
-    SpinlockProtected<Vector<Flock>> m_flocks;
+    SpinlockProtected<Vector<Flock>> m_flocks { LockRank::None };
 
 public:
     using AllInstancesList = IntrusiveList<&Inode::m_inode_list_node>;

--- a/Kernel/FileSystem/OpenFileDescription.h
+++ b/Kernel/FileSystem/OpenFileDescription.h
@@ -155,6 +155,6 @@ private:
         FIFO::Direction fifo_direction : 2 { FIFO::Direction::Neither };
     };
 
-    SpinlockProtected<State> m_state;
+    SpinlockProtected<State> m_state { LockRank::None };
 };
 }

--- a/Kernel/FileSystem/Plan9FileSystem.h
+++ b/Kernel/FileSystem/Plan9FileSystem.h
@@ -66,11 +66,11 @@ private:
 
     private:
         Plan9FS& m_fs;
-        mutable Spinlock m_lock;
+        mutable Spinlock m_lock { LockRank::None };
     };
 
     struct ReceiveCompletion : public RefCounted<ReceiveCompletion> {
-        mutable Spinlock lock;
+        mutable Spinlock lock { LockRank::None };
         bool completed { false };
         const u16 tag;
         OwnPtr<Message> message;
@@ -139,7 +139,7 @@ private:
     Plan9FSBlockerSet m_completion_blocker;
     HashMap<u16, NonnullRefPtr<ReceiveCompletion>> m_completions;
 
-    Spinlock m_thread_lock;
+    Spinlock m_thread_lock { LockRank::None };
     RefPtr<Thread> m_thread;
     Atomic<bool> m_thread_running { false };
     Atomic<bool, AK::MemoryOrder::memory_order_relaxed> m_thread_shutdown { false };

--- a/Kernel/FileSystem/SysFS/Component.cpp
+++ b/Kernel/FileSystem/SysFS/Component.cpp
@@ -11,7 +11,7 @@
 
 namespace Kernel {
 
-static Spinlock s_index_lock;
+static Spinlock s_index_lock { LockRank::None };
 static InodeIndex s_next_inode_index { 0 };
 
 static size_t allocate_inode_index()

--- a/Kernel/FileSystem/SysFS/Component.h
+++ b/Kernel/FileSystem/SysFS/Component.h
@@ -88,7 +88,7 @@ protected:
 
     SysFSDirectory() {};
     explicit SysFSDirectory(SysFSDirectory const& parent_directory);
-    ChildList m_child_components;
+    ChildList m_child_components { LockRank::None };
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Registry.h
+++ b/Kernel/FileSystem/SysFS/Registry.h
@@ -32,7 +32,7 @@ public:
 
 private:
     NonnullRefPtr<SysFSRootDirectory> m_root_directory;
-    Spinlock m_root_directory_lock;
+    Spinlock m_root_directory_lock { LockRank::None };
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/BusDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/BusDirectory.h
@@ -27,7 +27,7 @@ public:
 
 private:
     explicit SysFSUSBBusDirectory(SysFSBusDirectory&);
-    mutable Spinlock m_lock;
+    mutable Spinlock m_lock { LockRank::None };
 };
 
 }

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -98,7 +98,7 @@ private:
     RefPtr<Inode> m_root_inode;
     RefPtr<Custody> m_root_custody;
 
-    SpinlockProtected<Vector<Mount, 16>> m_mounts;
+    SpinlockProtected<Vector<Mount, 16>> m_mounts { LockRank::None };
 };
 
 }

--- a/Kernel/Graphics/Console/BootFramebufferConsole.h
+++ b/Kernel/Graphics/Console/BootFramebufferConsole.h
@@ -42,7 +42,7 @@ protected:
     OwnPtr<Memory::Region> m_framebuffer;
 #endif
     u8* m_framebuffer_data {};
-    mutable Spinlock m_lock;
+    mutable Spinlock m_lock { LockRank::None };
 };
 
 }

--- a/Kernel/Graphics/Console/GenericFramebufferConsole.h
+++ b/Kernel/Graphics/Console/GenericFramebufferConsole.h
@@ -81,7 +81,7 @@ protected:
 
     virtual void clear_glyph(size_t x, size_t y) override;
 
-    mutable Spinlock m_lock;
+    mutable Spinlock m_lock { LockRank::None };
 };
 
 }

--- a/Kernel/Graphics/Console/VGATextModeConsole.h
+++ b/Kernel/Graphics/Console/VGATextModeConsole.h
@@ -38,7 +38,7 @@ private:
 
     explicit VGATextModeConsole(NonnullOwnPtr<Memory::Region>);
 
-    mutable Spinlock m_vga_lock;
+    mutable Spinlock m_vga_lock { LockRank::None };
 
     NonnullOwnPtr<Memory::Region> m_vga_window_region;
     VirtualAddress m_current_vga_window;

--- a/Kernel/Graphics/DisplayConnector.h
+++ b/Kernel/Graphics/DisplayConnector.h
@@ -114,14 +114,14 @@ protected:
 
     ErrorOr<void> initialize_edid_for_generic_monitor(Optional<Array<u8, 3>> manufacturer_id_string);
 
-    mutable Spinlock m_control_lock;
+    mutable Spinlock m_control_lock { LockRank::None };
     mutable Mutex m_flushing_lock;
 
     bool m_console_mode { false };
 
     bool m_vertical_offsetted { false };
 
-    mutable Spinlock m_modeset_lock;
+    mutable Spinlock m_modeset_lock { LockRank::None };
     ModeSetting m_current_mode_setting {};
 
     Optional<EDID::Parser> m_edid_parser;
@@ -165,7 +165,7 @@ private:
     RefPtr<Memory::SharedFramebufferVMObject> m_shared_framebuffer_vmobject;
 
     WeakPtr<Process> m_responsible_process;
-    Spinlock m_responsible_process_lock;
+    Spinlock m_responsible_process_lock { LockRank::None };
 
     IntrusiveListNode<DisplayConnector, RefPtr<DisplayConnector>> m_list_node;
 };

--- a/Kernel/Graphics/GraphicsManagement.h
+++ b/Kernel/Graphics/GraphicsManagement.h
@@ -58,9 +58,9 @@ private:
 
     unsigned m_current_minor_number { 0 };
 
-    SpinlockProtected<IntrusiveList<&DisplayConnector::m_list_node>> m_display_connector_nodes;
+    SpinlockProtected<IntrusiveList<&DisplayConnector::m_list_node>> m_display_connector_nodes { LockRank::None };
 
-    RecursiveSpinlock m_main_vga_lock;
+    RecursiveSpinlock m_main_vga_lock { LockRank::None };
     bool m_vga_access_is_disabled { false };
 };
 

--- a/Kernel/Graphics/Intel/NativeDisplayConnector.h
+++ b/Kernel/Graphics/Intel/NativeDisplayConnector.h
@@ -154,7 +154,7 @@ private:
 
     Optional<IntelGraphics::PLLSettings> create_pll_settings(u64 target_frequency, u64 reference_clock, IntelGraphics::PLLMaxSettings const&);
 
-    mutable Spinlock m_registers_lock;
+    mutable Spinlock m_registers_lock { LockRank::None };
     RefPtr<Graphics::GenericFramebufferConsole> m_framebuffer_console;
 
     const PhysicalAddress m_registers;

--- a/Kernel/Graphics/VMWare/GraphicsAdapter.h
+++ b/Kernel/Graphics/VMWare/GraphicsAdapter.h
@@ -51,8 +51,8 @@ private:
     Memory::TypedMapping<volatile VMWareDisplayFIFORegisters> m_fifo_registers;
     RefPtr<VMWareDisplayConnector> m_display_connector;
     const IOAddress m_io_registers_base;
-    mutable Spinlock m_io_access_lock;
-    mutable RecursiveSpinlock m_operation_lock;
+    mutable Spinlock m_io_access_lock { LockRank::None };
+    mutable RecursiveSpinlock m_operation_lock { LockRank::None };
 };
 
 }

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -124,7 +124,7 @@ private:
 
     // Synchronous commands
     WaitQueue m_outstanding_request;
-    Spinlock m_operation_lock;
+    Spinlock m_operation_lock { LockRank::None };
     NonnullOwnPtr<Memory::Region> m_scratch_space;
 };
 }

--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -36,7 +36,8 @@ namespace std {
 const nothrow_t nothrow;
 }
 
-static RecursiveSpinlock s_lock; // needs to be recursive because of dump_backtrace()
+// FIXME: Figure out whether this can be MemoryManager.
+static RecursiveSpinlock s_lock { LockRank::None }; // needs to be recursive because of dump_backtrace()
 
 struct KmallocSubheap {
     KmallocSubheap(u8* base, size_t size)

--- a/Kernel/Locking/Mutex.h
+++ b/Kernel/Locking/Mutex.h
@@ -116,9 +116,11 @@ private:
             return mode == Mode::Exclusive ? exclusive : shared;
         }
     };
-    SpinlockProtected<BlockedThreadLists> m_blocked_thread_lists;
+    // FIXME: Use a specific lock rank passed by constructor.
+    SpinlockProtected<BlockedThreadLists> m_blocked_thread_lists { LockRank::None };
 
-    mutable Spinlock m_lock;
+    // FIXME: See above.
+    mutable Spinlock m_lock { LockRank::None };
 
 #if LOCK_SHARED_UPGRADE_DEBUG
     HashMap<Thread*, u32> m_shared_holders_map;

--- a/Kernel/Locking/SpinlockProtected.h
+++ b/Kernel/Locking/SpinlockProtected.h
@@ -47,8 +47,9 @@ private:
 
 public:
     template<typename... Args>
-    SpinlockProtected(Args&&... args)
+    SpinlockProtected(LockRank rank, Args&&... args)
         : m_value(forward<Args>(args)...)
+        , m_spinlock(rank)
     {
     }
 

--- a/Kernel/Memory/AddressSpace.h
+++ b/Kernel/Memory/AddressSpace.h
@@ -67,7 +67,7 @@ public:
 private:
     AddressSpace(NonnullRefPtr<PageDirectory>, VirtualRange total_range);
 
-    mutable RecursiveSpinlock m_lock;
+    mutable RecursiveSpinlock m_lock { LockRank::None };
 
     RefPtr<PageDirectory> m_page_directory;
 

--- a/Kernel/Memory/AnonymousVMObject.h
+++ b/Kernel/Memory/AnonymousVMObject.h
@@ -78,7 +78,7 @@ private:
         void uncommit_one();
 
     private:
-        Spinlock m_lock;
+        Spinlock m_lock { LockRank::None };
         CommittedPhysicalPageSet m_committed_pages;
     };
 

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -89,7 +89,7 @@ struct PhysicalMemoryRange {
 struct MemoryManagerData {
     static ProcessorSpecificDataID processor_specific_data_id() { return ProcessorSpecificDataID::MemoryManager; }
 
-    Spinlock m_quickmap_in_use;
+    Spinlock m_quickmap_in_use { LockRank::None };
     u32 m_quickmap_prev_flags;
 
     PhysicalAddress m_last_quickmap_pd;

--- a/Kernel/Memory/PageDirectory.h
+++ b/Kernel/Memory/PageDirectory.h
@@ -72,7 +72,7 @@ private:
 #else
     RefPtr<PhysicalPage> m_directory_pages[4];
 #endif
-    RecursiveSpinlock m_lock;
+    RecursiveSpinlock m_lock { LockRank::None };
 };
 
 void activate_kernel_page_directory(PageDirectory const& pgd);

--- a/Kernel/Memory/RegionTree.h
+++ b/Kernel/Memory/RegionTree.h
@@ -58,7 +58,8 @@ private:
     ErrorOr<VirtualRange> allocate_range_specific(VirtualAddress base, size_t size);
     ErrorOr<VirtualRange> allocate_range_randomized(size_t size, size_t alignment = PAGE_SIZE);
 
-    RecursiveSpinlock mutable m_lock;
+    // FIXME: We need a Region rank, but we don't know where to put it.
+    RecursiveSpinlock mutable m_lock { LockRank::None };
 
     IntrusiveRedBlackTree<&Region::m_tree_node> m_regions;
     VirtualRange const m_total_range;

--- a/Kernel/Memory/RingBuffer.h
+++ b/Kernel/Memory/RingBuffer.h
@@ -32,7 +32,7 @@ private:
     RingBuffer(NonnullOwnPtr<Memory::Region> region, size_t capacity);
 
     NonnullOwnPtr<Memory::Region> m_region;
-    Spinlock m_lock;
+    Spinlock m_lock { LockRank::None };
     size_t m_start_of_used {};
     size_t m_num_used_bytes {};
     size_t m_capacity_in_bytes {};

--- a/Kernel/Memory/SharedFramebufferVMObject.h
+++ b/Kernel/Memory/SharedFramebufferVMObject.h
@@ -87,7 +87,7 @@ private:
     RefPtr<FakeWritesFramebufferVMObject> m_fake_writes_framebuffer_vmobject;
     RefPtr<RealWritesFramebufferVMObject> m_real_writes_framebuffer_vmobject;
     bool m_writes_are_faked { false };
-    mutable RecursiveSpinlock m_writes_state_lock;
+    mutable RecursiveSpinlock m_writes_state_lock { LockRank::None };
     CommittedPhysicalPageSet m_committed_pages;
 };
 

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -65,7 +65,7 @@ protected:
     IntrusiveListNode<VMObject> m_list_node;
     FixedArray<RefPtr<PhysicalPage>> m_physical_pages;
 
-    mutable RecursiveSpinlock m_lock;
+    mutable RecursiveSpinlock m_lock { LockRank::None };
 
 private:
     VMObject& operator=(VMObject const&) = delete;

--- a/Kernel/Net/NetworkingManagement.h
+++ b/Kernel/Net/NetworkingManagement.h
@@ -14,6 +14,7 @@
 #include <Kernel/Bus/PCI/Definitions.h>
 #include <Kernel/Locking/SpinlockProtected.h>
 #include <Kernel/Memory/Region.h>
+#include <Kernel/Net/NetworkAdapter.h>
 
 namespace Kernel {
 
@@ -41,7 +42,7 @@ public:
 private:
     RefPtr<NetworkAdapter> determine_network_device(PCI::DeviceIdentifier const&) const;
 
-    SpinlockProtected<NonnullRefPtrVector<NetworkAdapter>> m_adapters;
+    SpinlockProtected<NonnullRefPtrVector<NetworkAdapter>> m_adapters { LockRank::None };
     RefPtr<NetworkAdapter> m_loopback_adapter;
 };
 

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -45,7 +45,7 @@ static void create_signal_trampoline();
 
 extern ProcessID g_init_pid;
 
-RecursiveSpinlock g_profiling_lock;
+RecursiveSpinlock g_profiling_lock { LockRank::None };
 static Atomic<pid_t> next_pid;
 static Singleton<SpinlockProtected<Process::List>> s_all_instances;
 READONLY_AFTER_INIT Memory::Region* g_signal_trampoline_region;
@@ -233,9 +233,9 @@ Process::Process(NonnullOwnPtr<KString> name, UserID uid, GroupID gid, ProcessID
     : m_name(move(name))
     , m_is_kernel_process(is_kernel_process)
     , m_executable(move(executable))
-    , m_current_directory(move(current_directory))
+    , m_current_directory(LockRank::None, move(current_directory))
     , m_tty(tty)
-    , m_unveil_data(move(unveil_tree))
+    , m_unveil_data(LockRank::None, move(unveil_tree))
     , m_wait_blocker_set(*this)
 {
     // Ensure that we protect the process data when exiting the constructor.

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -815,7 +815,7 @@ private:
     SpinlockProtected<Thread::ListInProcess>& thread_list() { return m_thread_list; }
     SpinlockProtected<Thread::ListInProcess> const& thread_list() const { return m_thread_list; }
 
-    SpinlockProtected<Thread::ListInProcess> m_thread_list;
+    SpinlockProtected<Thread::ListInProcess> m_thread_list { LockRank::None };
 
     MutexProtected<OpenFileDescriptions> m_fds;
 
@@ -859,7 +859,7 @@ private:
         OwnPtr<KString> value;
     };
 
-    SpinlockProtected<Array<CoredumpProperty, 4>> m_coredump_properties;
+    SpinlockProtected<Array<CoredumpProperty, 4>> m_coredump_properties { LockRank::None };
     NonnullRefPtrVector<Thread> m_threads_for_coredump;
 
     mutable RefPtr<ProcessProcFSTraits> m_procfs_traits;

--- a/Kernel/ProcessExposed.cpp
+++ b/Kernel/ProcessExposed.cpp
@@ -15,7 +15,7 @@
 
 namespace Kernel {
 
-static Spinlock s_index_lock;
+static Spinlock s_index_lock { LockRank::None };
 static InodeIndex s_next_inode_index = 0;
 
 namespace SegmentedProcFSIndex {

--- a/Kernel/Random.h
+++ b/Kernel/Random.h
@@ -117,7 +117,7 @@ private:
     size_t m_p0_len { 0 };
     ByteBuffer m_key;
     HashType m_pools[pool_count];
-    Spinlock m_lock;
+    Spinlock m_lock { LockRank::None };
 };
 
 class KernelRng : public FortunaPRNG<Crypto::Cipher::AESCipher, Crypto::Hash::SHA256, 256> {

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -22,7 +22,7 @@
 
 namespace Kernel {
 
-RecursiveSpinlock g_scheduler_lock;
+RecursiveSpinlock g_scheduler_lock { LockRank::None };
 
 static u32 time_slice_for(Thread const& thread)
 {
@@ -49,7 +49,7 @@ struct ThreadReadyQueues {
 
 static Singleton<SpinlockProtected<ThreadReadyQueues>> g_ready_queues;
 
-static SpinlockProtected<TotalTimeScheduled> g_total_time_scheduled;
+static SpinlockProtected<TotalTimeScheduled> g_total_time_scheduled { LockRank::None };
 
 // The Scheduler::current_time function provides a current time for scheduling purposes,
 // which may not necessarily relate to wall time

--- a/Kernel/Storage/ATA/AHCI/Controller.h
+++ b/Kernel/Storage/ATA/AHCI/Controller.h
@@ -60,6 +60,6 @@ private:
     // Note: This lock is intended to be locked when doing changes to HBA registers
     // that affect its core functionality in a manner that controls all attached storage devices
     // to the HBA SATA ports.
-    mutable Spinlock m_hba_control_lock;
+    mutable Spinlock m_hba_control_lock { LockRank::None };
 };
 }

--- a/Kernel/Storage/ATA/AHCI/Port.h
+++ b/Kernel/Storage/ATA/AHCI/Port.h
@@ -106,7 +106,7 @@ private:
 
     EntropySource m_entropy_source;
     RefPtr<AsyncBlockDeviceRequest> m_current_request;
-    Spinlock m_hard_lock;
+    Spinlock m_hard_lock { LockRank::None };
     Mutex m_lock { "AHCIPort"sv };
 
     mutable bool m_wait_for_completion { false };

--- a/Kernel/Storage/ATA/ATAPort.h
+++ b/Kernel/Storage/ATA/ATAPort.h
@@ -135,7 +135,7 @@ protected:
     }
 
     mutable Mutex m_lock;
-    Spinlock m_hard_lock;
+    Spinlock m_hard_lock { LockRank::None };
 
     EntropySource m_entropy_source;
 

--- a/Kernel/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Storage/NVMe/NVMeQueue.h
@@ -58,7 +58,7 @@ protected:
     Spinlock m_cq_lock { LockRank::Interrupts };
     RefPtr<AsyncBlockDeviceRequest> m_current_request;
     NonnullOwnPtr<Memory::Region> m_rw_dma_region;
-    Spinlock m_request_lock;
+    Spinlock m_request_lock { LockRank::None };
 
 private:
     u16 m_qid {};

--- a/Kernel/TTY/ConsoleManagement.h
+++ b/Kernel/TTY/ConsoleManagement.h
@@ -39,8 +39,8 @@ public:
 private:
     NonnullRefPtrVector<VirtualConsole, s_max_virtual_consoles> m_consoles;
     VirtualConsole* m_active_console { nullptr };
-    Spinlock m_lock;
-    RecursiveSpinlock m_tty_write_lock;
+    Spinlock m_lock { LockRank::None };
+    RecursiveSpinlock m_tty_write_lock { LockRank::None };
 };
 
 };

--- a/Kernel/TTY/PTYMultiplexer.h
+++ b/Kernel/TTY/PTYMultiplexer.h
@@ -35,7 +35,7 @@ private:
     virtual StringView class_name() const override { return "PTYMultiplexer"sv; }
 
     static constexpr size_t max_pty_pairs = 64;
-    SpinlockProtected<Vector<unsigned, max_pty_pairs>> m_freelist;
+    SpinlockProtected<Vector<unsigned, max_pty_pairs>> m_freelist { LockRank::None };
 };
 
 }

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -382,7 +382,8 @@ public:
         bool add_to_blocker_set(BlockerSet&, void* = nullptr);
         void set_blocker_set_raw_locked(BlockerSet* blocker_set) { m_blocker_set = blocker_set; }
 
-        mutable RecursiveSpinlock m_lock;
+        // FIXME: Figure out whether this can be Thread.
+        mutable RecursiveSpinlock m_lock { LockRank::None };
 
     private:
         BlockerSet* m_blocker_set { nullptr };
@@ -500,7 +501,8 @@ public:
             blockers_to_append.clear();
         }
 
-        mutable Spinlock m_lock;
+        // FIXME: Check whether this can be Thread.
+        mutable Spinlock m_lock { LockRank::None };
 
     private:
         Vector<BlockerInfo, 4> m_blockers;
@@ -1227,7 +1229,7 @@ private:
     void reset_fpu_state();
 
     mutable RecursiveSpinlock m_lock { LockRank::Thread };
-    mutable RecursiveSpinlock m_block_lock;
+    mutable RecursiveSpinlock m_block_lock { LockRank::None };
     NonnullRefPtr<Process> m_process;
     ThreadID m_tid { -1 };
     ThreadRegisters m_regs {};
@@ -1274,7 +1276,7 @@ private:
         unsigned count;
     };
     Atomic<u32> m_holding_locks { 0 };
-    Spinlock m_holding_locks_lock;
+    Spinlock m_holding_locks_lock { LockRank::None };
     Vector<HoldingLockInfo> m_holding_locks_list;
 #endif
 

--- a/Kernel/TimerQueue.cpp
+++ b/Kernel/TimerQueue.cpp
@@ -14,7 +14,7 @@
 namespace Kernel {
 
 static Singleton<TimerQueue> s_the;
-static Spinlock g_timerqueue_lock;
+static Spinlock g_timerqueue_lock { LockRank::None };
 
 Time Timer::remaining() const
 {

--- a/Kernel/WorkQueue.h
+++ b/Kernel/WorkQueue.h
@@ -63,7 +63,7 @@ private:
 
     RefPtr<Thread> m_thread;
     WaitQueue m_wait_queue;
-    SpinlockProtected<IntrusiveList<&WorkItem::m_node>> m_items;
+    SpinlockProtected<IntrusiveList<&WorkItem::m_node>> m_items { LockRank::None };
 };
 
 }

--- a/Kernel/kprintf.cpp
+++ b/Kernel/kprintf.cpp
@@ -26,7 +26,7 @@ extern Atomic<Graphics::Console*> g_boot_console;
 static bool serial_debug;
 // A recursive spinlock allows us to keep writing in the case where a
 // page fault happens in the middle of a dbgln(), etc
-static RecursiveSpinlock s_log_lock;
+static RecursiveSpinlock s_log_lock { LockRank::None };
 
 void set_serial_debug(bool on_or_off)
 {


### PR DESCRIPTION
All users which relied on the default constructor use a None lock rank for now. This will make it easier to in the future remove LockRank::None and actually annotate the ranks by searching for None.