### PR TITLE
Profiler+Kernel: Fix erroneous Loader.so "_end" when profiling Profiler

### DIFF
--- a/Userland/DevTools/Profiler/Process.cpp
+++ b/Userland/DevTools/Profiler/Process.cpp
@@ -69,13 +69,9 @@ static MappedObject* get_or_create_mapped_object(String const& path)
 
 void LibraryMetadata::handle_mmap(FlatPtr base, size_t size, String const& name)
 {
-    StringView path;
-    if (name.contains("Loader.so"sv))
-        path = "Loader.so"sv;
-    else if (!name.contains(':'))
+    if (!name.contains(':'))
         return;
-    else
-        path = name.substring_view(0, name.view().find(':').value());
+    auto path = name.substring_view(0, name.view().find(':').value());
 
     // Each loaded object has at least 4 segments associated with it: .rodata, .text, .relro, .data.
     // We only want to create a single LibraryMetadata object for each library, so we need to update the


### PR DESCRIPTION
Profiling Profiler itself gave a large number of "_end" from Loader.so
in the profile instead of the correct symbols.

Profiler mmaps Loader.so to inspect it. It therefore appeared on two
places in memory in the profile, which caused Profiler to believe that
it spanned the whole memory in between and map all adresses to it.

Fix by changing the kernel to map Loader.so as "/usr/bin/Loader.so:
.[section]", and use that in Profiler to skip the second region.

(Loader.so is a special case. Other libraries were already filtered by
skipping mmaps without ':' in the name).