### PR TITLE
Kernel: Protect the list of unused network packets with a Spinlock

### DIFF
--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -122,7 +122,7 @@ RefPtr<PacketWithTimestamp> NetworkAdapter::acquire_packet_buffer(size_t size)
         if (unused_packet->buffer->capacity() >= size)
             return unused_packet;
 
-        // FIXME: Shouldn't we put existing buffers that are too small back into the list?
+        unused_packets.append(*unused_packet);
         return nullptr;
     });
 

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -109,7 +109,7 @@ private:
 
     PacketList m_packet_queue;
     size_t m_packet_queue_size { 0 };
-    PacketList m_unused_packets;
+    SpinlockProtected<PacketList> m_unused_packets;
     NonnullOwnPtr<KString> m_name;
     u32 m_packets_in { 0 };
     u32 m_bytes_in { 0 };


### PR DESCRIPTION
Managed to clone a shallow copy of the Serenity repository without any crashes (with SMP enabled) using this, although we do deadlock shortly after once it has to unpack files.

While we're at it, fix an issue where we would just drop an empty but already allocated packet buffer if we find that it is too small to hold the requested size.