### PR TITLE
Kernel/Syscall: Make anon_create to not use Process::allocate_fd method

### DIFF
--- a/Kernel/Syscalls/anon_create.cpp
+++ b/Kernel/Syscalls/anon_create.cpp
@@ -25,7 +25,6 @@ ErrorOr<FlatPtr> Process::sys$anon_create(size_t size, int options)
     if (size > NumericLimits<ssize_t>::max())
         return EINVAL;
 
-    auto new_fd = TRY(allocate_fd());
     auto vmobject = TRY(Memory::AnonymousVMObject::try_create_purgeable_with_size(size, AllocationStrategy::AllocateNow));
     auto anon_file = TRY(AnonymousFile::try_create(move(vmobject)));
     auto description = TRY(OpenFileDescription::try_create(move(anon_file)));
@@ -37,8 +36,11 @@ ErrorOr<FlatPtr> Process::sys$anon_create(size_t size, int options)
     if (options & O_CLOEXEC)
         fd_flags |= FD_CLOEXEC;
 
-    m_fds.with_exclusive([&](auto& fds) { fds[new_fd.fd].set(move(description), fd_flags); });
-    return new_fd.fd;
+    return m_fds.with_exclusive([&](auto& fds) -> ErrorOr<FlatPtr> {
+        auto new_fd = TRY(fds.allocate());
+        fds[new_fd.fd].set(move(description), fd_flags);
+        return new_fd.fd;
+    });
 }
 
 }


### PR DESCRIPTION
Instead, allocate when acquiring the lock on m_fds struct, which is
safer to do in terms of safely mutating the m_fds struct, because we
don't use the big process lock in this syscall.