### PR TITLE
Kernel/aarch64: Properly initialize T0SZ and T1SZ fields in TCR_EL1

### DIFF
--- a/Kernel/Arch/aarch64/MMU.cpp
+++ b/Kernel/Arch/aarch64/MMU.cpp
@@ -164,10 +164,12 @@ static void activate_mmu()
     tcr_el1.SH1 = Aarch64::TCR_EL1::InnerShareable;
     tcr_el1.ORGN1 = Aarch64::TCR_EL1::NormalMemory_Outer_WriteBack_ReadAllocate_WriteAllocateCacheable;
     tcr_el1.IRGN1 = Aarch64::TCR_EL1::NormalMemory_Inner_WriteBack_ReadAllocate_WriteAllocateCacheable;
+    tcr_el1.T1SZ = 16;
 
     tcr_el1.SH0 = Aarch64::TCR_EL1::InnerShareable;
     tcr_el1.ORGN0 = Aarch64::TCR_EL1::NormalMemory_Outer_WriteBack_ReadAllocate_WriteAllocateCacheable;
     tcr_el1.IRGN0 = Aarch64::TCR_EL1::NormalMemory_Inner_WriteBack_ReadAllocate_WriteAllocateCacheable;
+    tcr_el1.T0SZ = 16;
 
     tcr_el1.TG1 = Aarch64::TCR_EL1::TG1GranuleSize::Size_4KB;
     tcr_el1.TG0 = Aarch64::TCR_EL1::TG0GranuleSize::Size_4KB;

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -121,13 +121,6 @@ if [ "$installed_major_version" -lt "$SERENITY_QEMU_MIN_REQ_MAJOR_VERSION" ] ||
     die
 fi
 
-# FIXME: Remove this once #14856 is resolved.
-if [ "$SERENITY_ARCH" = "aarch64" ] && [ "$installed_major_version" -ge "7" ]; then
-    echo "The aarch64 Kernel currently does not support QEMU >= 7.0."
-    echo "Please install QEMU 6.2 or use the QEMU build script: 'QEMU_VERSION=\"qemu-6.2.0\" QEMU_MD5SUM=\"a077669ce58b6ee07ec355e54aad25be\" ./Toolchain/BuildQemu.sh'."
-    die
-fi
-
 NATIVE_WINDOWS_QEMU="0"
 
 if command -v wslpath >/dev/null; then


### PR DESCRIPTION
Relying on the default values for these fields is implementation defined behavior and caused a translation fault with QEMU 7.x.

Setting these fields to the correct value now makes our aarch64 kernel run with QEMU 7.x :^)

For some more context on the exact issue see: https://gitlab.com/qemu-project/qemu/-/issues/1157

Fixes #14856 