### PR TITLE
LibJS + LibCrypto: Allow comparing doubles and big ints and more big int fixes

### DIFF
--- a/Tests/LibCrypto/TestBigInteger.cpp
+++ b/Tests/LibCrypto/TestBigInteger.cpp
@@ -659,94 +659,175 @@ TEST_CASE(test_negative_zero_is_not_allowed)
     EXPECT(!zero.is_negative());
 }
 
-TEST_CASE(double_comparisons)
-{
+TEST_CASE(double_comparisons) {
 #define EXPECT_LESS_THAN(bigint, double_value) EXPECT_EQ(bigint.compare_to_double(double_value), Crypto::SignedBigInteger::CompareResult::DoubleGreaterThanBigInt)
 #define EXPECT_GREATER_THAN(bigint, double_value) EXPECT_EQ(bigint.compare_to_double(double_value), Crypto::SignedBigInteger::CompareResult::DoubleLessThanBigInt)
 #define EXPECT_EQUAL_TO(bigint, double_value) EXPECT_EQ(bigint.compare_to_double(double_value), Crypto::SignedBigInteger::CompareResult::DoubleEqualsBigInt)
-    {
-        Crypto::SignedBigInteger zero { 0 };
-        EXPECT_EQUAL_TO(zero, 0.0);
-        EXPECT_EQUAL_TO(zero, -0.0);
-    }
+    { Crypto::SignedBigInteger zero { 0 };
+EXPECT_EQUAL_TO(zero, 0.0);
+EXPECT_EQUAL_TO(zero, -0.0);
+}
 
-    {
-        Crypto::SignedBigInteger one { 1 };
-        EXPECT_EQUAL_TO(one, 1.0);
-        EXPECT_GREATER_THAN(one, -1.0);
-        EXPECT_GREATER_THAN(one, 0.5);
-        EXPECT_GREATER_THAN(one, -0.5);
-        EXPECT_LESS_THAN(one, 1.000001);
+{
+    Crypto::SignedBigInteger one { 1 };
+    EXPECT_EQUAL_TO(one, 1.0);
+    EXPECT_GREATER_THAN(one, -1.0);
+    EXPECT_GREATER_THAN(one, 0.5);
+    EXPECT_GREATER_THAN(one, -0.5);
+    EXPECT_LESS_THAN(one, 1.000001);
 
-        one.negate();
-        auto const& negative_one = one;
-        EXPECT_EQUAL_TO(negative_one, -1.0);
-        EXPECT_LESS_THAN(negative_one, 1.0);
-        EXPECT_LESS_THAN(one, 0.5);
-        EXPECT_LESS_THAN(one, -0.5);
-        EXPECT_GREATER_THAN(one, -1.5);
-        EXPECT_LESS_THAN(one, 1.000001);
-        EXPECT_GREATER_THAN(one, -1.000001);
-    }
+    one.negate();
+    auto const& negative_one = one;
+    EXPECT_EQUAL_TO(negative_one, -1.0);
+    EXPECT_LESS_THAN(negative_one, 1.0);
+    EXPECT_LESS_THAN(one, 0.5);
+    EXPECT_LESS_THAN(one, -0.5);
+    EXPECT_GREATER_THAN(one, -1.5);
+    EXPECT_LESS_THAN(one, 1.000001);
+    EXPECT_GREATER_THAN(one, -1.000001);
+}
 
-    {
-        double double_max_value = NumericLimits<double>::max();
-        double double_below_max_value = nextafter(double_max_value, 0.0);
-        VERIFY(double_below_max_value < double_max_value);
-        VERIFY(double_below_max_value < (double_max_value - 1.0));
-        auto max_value_in_bigint = Crypto::SignedBigInteger::from_base(16, "fffffffffffff800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv);
-        auto max_value_plus_one = max_value_in_bigint.plus(Crypto::SignedBigInteger { 1 });
-        auto max_value_minus_one = max_value_in_bigint.minus(Crypto::SignedBigInteger { 1 });
+{
+    double double_max_value = NumericLimits<double>::max();
+    double double_below_max_value = nextafter(double_max_value, 0.0);
+    VERIFY(double_below_max_value < double_max_value);
+    VERIFY(double_below_max_value < (double_max_value - 1.0));
+    auto max_value_in_bigint = Crypto::SignedBigInteger::from_base(16, "fffffffffffff800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv);
+    auto max_value_plus_one = max_value_in_bigint.plus(Crypto::SignedBigInteger { 1 });
+    auto max_value_minus_one = max_value_in_bigint.minus(Crypto::SignedBigInteger { 1 });
 
-        auto below_max_value_in_bigint = Crypto::SignedBigInteger::from_base(16, "fffffffffffff000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv);
+    auto below_max_value_in_bigint = Crypto::SignedBigInteger::from_base(16, "fffffffffffff000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv);
 
-        EXPECT_EQUAL_TO(max_value_in_bigint, double_max_value);
-        EXPECT_LESS_THAN(max_value_minus_one, double_max_value);
-        EXPECT_GREATER_THAN(max_value_plus_one, double_max_value);
-        EXPECT_LESS_THAN(below_max_value_in_bigint, double_max_value);
+    EXPECT_EQUAL_TO(max_value_in_bigint, double_max_value);
+    EXPECT_LESS_THAN(max_value_minus_one, double_max_value);
+    EXPECT_GREATER_THAN(max_value_plus_one, double_max_value);
+    EXPECT_LESS_THAN(below_max_value_in_bigint, double_max_value);
 
-        EXPECT_GREATER_THAN(max_value_in_bigint, double_below_max_value);
-        EXPECT_GREATER_THAN(max_value_minus_one, double_below_max_value);
-        EXPECT_GREATER_THAN(max_value_plus_one, double_below_max_value);
-        EXPECT_EQUAL_TO(below_max_value_in_bigint, double_below_max_value);
-    }
+    EXPECT_GREATER_THAN(max_value_in_bigint, double_below_max_value);
+    EXPECT_GREATER_THAN(max_value_minus_one, double_below_max_value);
+    EXPECT_GREATER_THAN(max_value_plus_one, double_below_max_value);
+    EXPECT_EQUAL_TO(below_max_value_in_bigint, double_below_max_value);
+}
 
-    {
-        double double_min_value = NumericLimits<double>::lowest();
-        double double_above_min_value = nextafter(double_min_value, 0.0);
-        VERIFY(double_above_min_value > double_min_value);
-        VERIFY(double_above_min_value > (double_min_value + 1.0));
-        auto min_value_in_bigint = Crypto::SignedBigInteger::from_base(16, "-fffffffffffff800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv);
-        auto min_value_plus_one = min_value_in_bigint.plus(Crypto::SignedBigInteger { 1 });
-        auto min_value_minus_one = min_value_in_bigint.minus(Crypto::SignedBigInteger { 1 });
+{
+    double double_min_value = NumericLimits<double>::lowest();
+    double double_above_min_value = nextafter(double_min_value, 0.0);
+    VERIFY(double_above_min_value > double_min_value);
+    VERIFY(double_above_min_value > (double_min_value + 1.0));
+    auto min_value_in_bigint = Crypto::SignedBigInteger::from_base(16, "-fffffffffffff800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv);
+    auto min_value_plus_one = min_value_in_bigint.plus(Crypto::SignedBigInteger { 1 });
+    auto min_value_minus_one = min_value_in_bigint.minus(Crypto::SignedBigInteger { 1 });
 
-        auto above_min_value_in_bigint = Crypto::SignedBigInteger::from_base(16, "-fffffffffffff000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv);
+    auto above_min_value_in_bigint = Crypto::SignedBigInteger::from_base(16, "-fffffffffffff000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv);
 
-        EXPECT_EQUAL_TO(min_value_in_bigint, double_min_value);
-        EXPECT_LESS_THAN(min_value_minus_one, double_min_value);
-        EXPECT_GREATER_THAN(min_value_plus_one, double_min_value);
-        EXPECT_GREATER_THAN(above_min_value_in_bigint, double_min_value);
+    EXPECT_EQUAL_TO(min_value_in_bigint, double_min_value);
+    EXPECT_LESS_THAN(min_value_minus_one, double_min_value);
+    EXPECT_GREATER_THAN(min_value_plus_one, double_min_value);
+    EXPECT_GREATER_THAN(above_min_value_in_bigint, double_min_value);
 
-        EXPECT_LESS_THAN(min_value_in_bigint, double_above_min_value);
-        EXPECT_LESS_THAN(min_value_minus_one, double_above_min_value);
-        EXPECT_LESS_THAN(min_value_plus_one, double_above_min_value);
-        EXPECT_EQUAL_TO(above_min_value_in_bigint, double_above_min_value);
-    }
+    EXPECT_LESS_THAN(min_value_in_bigint, double_above_min_value);
+    EXPECT_LESS_THAN(min_value_minus_one, double_above_min_value);
+    EXPECT_LESS_THAN(min_value_plus_one, double_above_min_value);
+    EXPECT_EQUAL_TO(above_min_value_in_bigint, double_above_min_value);
+}
 
-    {
-        double just_above_255 = bit_cast<double>(0x406fe00000000001ULL);
-        double just_below_255 = bit_cast<double>(0x406fdfffffffffffULL);
-        double double_255 = 255.0;
-        Crypto::SignedBigInteger bigint_255 { 255 };
+{
+    double just_above_255 = bit_cast<double>(0x406fe00000000001ULL);
+    double just_below_255 = bit_cast<double>(0x406fdfffffffffffULL);
+    double double_255 = 255.0;
+    Crypto::SignedBigInteger bigint_255 { 255 };
 
-        EXPECT_EQUAL_TO(bigint_255, double_255);
-        EXPECT_GREATER_THAN(bigint_255, just_below_255);
-        EXPECT_LESS_THAN(bigint_255, just_above_255);
-    }
+    EXPECT_EQUAL_TO(bigint_255, double_255);
+    EXPECT_GREATER_THAN(bigint_255, just_below_255);
+    EXPECT_LESS_THAN(bigint_255, just_above_255);
+}
 
 #undef EXPECT_LESS_THAN
 #undef EXPECT_GREATER_THAN
 #undef EXPECT_EQUAL_TO
+}
+
+TEST_CASE(to_double)
+{
+#define EXPECT_TO_EQUAL_DOUBLE(bigint, double_value) \
+    EXPECT_EQ((bigint).to_double(), double_value)
+
+    EXPECT_TO_EQUAL_DOUBLE(Crypto::UnsignedBigInteger(0), 0.0);
+    // Make sure we don't get negative zero!
+    EXPECT_EQ(signbit(Crypto::UnsignedBigInteger(0).to_double()), 0);
+    {
+        Crypto::SignedBigInteger zero { 0 };
+
+        EXPECT(!zero.is_negative());
+        EXPECT_TO_EQUAL_DOUBLE(zero, 0.0);
+        EXPECT_EQ(signbit(zero.to_double()), 0);
+
+        zero.negate();
+
+        EXPECT(!zero.is_negative());
+        EXPECT_TO_EQUAL_DOUBLE(zero, 0.0);
+        EXPECT_EQ(signbit(zero.to_double()), 0);
+    }
+
+    EXPECT_TO_EQUAL_DOUBLE(Crypto::UnsignedBigInteger(9682), 9682.0);
+    EXPECT_TO_EQUAL_DOUBLE(Crypto::SignedBigInteger(-9660), -9660.0);
+
+    double double_max_value = NumericLimits<double>::max();
+    double infinity = INFINITY;
+
+    EXPECT_TO_EQUAL_DOUBLE(
+        Crypto::UnsignedBigInteger::from_base(16, "fffffffffffff800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv),
+        double_max_value);
+
+    EXPECT_TO_EQUAL_DOUBLE(
+        Crypto::UnsignedBigInteger::from_base(16, "ffffffffffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv),
+        double_max_value);
+
+    EXPECT_TO_EQUAL_DOUBLE(
+        Crypto::UnsignedBigInteger::from_base(16, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"sv),
+        double_max_value);
+
+    EXPECT_TO_EQUAL_DOUBLE(
+        Crypto::UnsignedBigInteger::from_base(16, "10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv),
+        infinity);
+
+    EXPECT_TO_EQUAL_DOUBLE(
+        Crypto::SignedBigInteger::from_base(16, "-fffffffffffff800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv),
+        -double_max_value);
+
+    EXPECT_TO_EQUAL_DOUBLE(
+        Crypto::SignedBigInteger::from_base(16, "-ffffffffffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv),
+        -double_max_value);
+
+    EXPECT_TO_EQUAL_DOUBLE(
+        Crypto::SignedBigInteger::from_base(16, "-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"sv),
+        -double_max_value);
+
+    EXPECT_TO_EQUAL_DOUBLE(
+        Crypto::SignedBigInteger::from_base(16, "-10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"sv),
+        -infinity);
+
+    EXPECT_TO_EQUAL_DOUBLE(
+        Crypto::UnsignedBigInteger::from_base(16, "ffffffffffffffff"sv),
+        18446744073709549568.0);
+
+    EXPECT_TO_EQUAL_DOUBLE(
+        Crypto::UnsignedBigInteger::from_base(16, "fffffffffffff800"sv),
+        18446744073709549568.0);
+
+    EXPECT_TO_EQUAL_DOUBLE(
+        Crypto::UnsignedBigInteger::from_base(16, "fffffffffffff8ff"sv),
+        18446744073709549568.0);
+
+    EXPECT_TO_EQUAL_DOUBLE(Crypto::SignedBigInteger::from_base(10, "1234567890123456789"sv),
+        1234567890123456800.0);
+
+    EXPECT_TO_EQUAL_DOUBLE(Crypto::SignedBigInteger::from_base(10, "2345678901234567890"sv),
+        2345678901234567680.0);
+
+    EXPECT_EQ(1234567890123456800.0, 1234567890123456768.0);
+
+#undef EXPECT_TO_EQUAL_DOUBLE
 }
 
 namespace AK {

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
@@ -70,6 +70,8 @@ double SignedBigInteger::to_double() const
     double unsigned_value = m_unsigned_data.to_double();
     if (!m_sign)
         return unsigned_value;
+
+    VERIFY(!is_zero());
     return -unsigned_value;
 }
 

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -139,6 +139,14 @@ public:
     [[nodiscard]] bool operator<(UnsignedBigInteger const& other) const;
     [[nodiscard]] bool operator>(UnsignedBigInteger const& other) const;
 
+    enum class CompareResult {
+        DoubleEqualsBigInt,
+        DoubleLessThanBigInt,
+        DoubleGreaterThanBigInt
+    };
+
+    [[nodiscard]] CompareResult compare_to_double(double) const;
+
 private:
     void ensure_sign_is_valid()
     {

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -104,7 +104,7 @@ String UnsignedBigInteger::to_base(u16 N) const
 
 u64 UnsignedBigInteger::to_u64() const
 {
-    VERIFY(sizeof(Word) == 4);
+    static_assert(sizeof(Word) == 4);
     if (!length())
         return 0;
     u64 value = m_words[0];

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -2762,7 +2762,7 @@ RefPtr<BindingPattern> Parser::parse_binding_pattern(Parser::AllowDuplicates all
                     name = static_ptr_cast<Identifier>(expression);
                 else
                     syntax_error("Invalid destructuring assignment target", expression_position);
-            } else if (match_identifier_name() || match(TokenType::StringLiteral) || match(TokenType::NumericLiteral)) {
+            } else if (match_identifier_name() || match(TokenType::StringLiteral) || match(TokenType::NumericLiteral) || match(TokenType::BigIntLiteral)) {
                 if (match(TokenType::StringLiteral) || match(TokenType::NumericLiteral))
                     needs_alias = true;
 
@@ -2773,6 +2773,12 @@ RefPtr<BindingPattern> Parser::parse_binding_pattern(Parser::AllowDuplicates all
                     name = create_ast_node<Identifier>(
                         { m_state.current_token.filename(), rule_start.position(), position() },
                         string_literal->value());
+                } else if (match(TokenType::BigIntLiteral)) {
+                    auto string_value = consume().flystring_value();
+                    VERIFY(string_value.ends_with("n"sv));
+                    name = create_ast_node<Identifier>(
+                        { m_state.current_token.filename(), rule_start.position(), position() },
+                        FlyString(string_value.view().substring_view(0, string_value.length() - 1)));
                 } else {
                     name = create_ast_node<Identifier>(
                         { m_state.current_token.filename(), rule_start.position(), position() },

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -1448,10 +1448,13 @@ ThrowCompletionOr<bool> is_loosely_equal(VM& vm, Value lhs, Value rhs)
         // b. If ℝ(x) = ℝ(y), return true; otherwise return false.
         if ((lhs.is_number() && !lhs.is_integral_number()) || (rhs.is_number() && !rhs.is_integral_number()))
             return false;
-        if (lhs.is_number())
-            return Crypto::SignedBigInteger { MUST(lhs.to_i32(vm)) } == rhs.as_bigint().big_integer();
-        else
-            return Crypto::SignedBigInteger { MUST(rhs.to_i32(vm)) } == lhs.as_bigint().big_integer();
+
+        VERIFY(!lhs.is_nan() && !rhs.is_nan());
+
+        auto& number_side = lhs.is_number() ? lhs : rhs;
+        auto& bigint_side = lhs.is_number() ? rhs : lhs;
+
+        return bigint_side.as_bigint().big_integer().compare_to_double(number_side.as_double()) == Crypto::SignedBigInteger::CompareResult::DoubleEqualsBigInt;
     }
 
     // 14. Return false.
@@ -1547,14 +1550,13 @@ ThrowCompletionOr<TriState> is_less_than(VM& vm, Value lhs, Value rhs, bool left
     VERIFY((x_numeric.is_number() && y_numeric.is_bigint()) || (x_numeric.is_bigint() && y_numeric.is_number()));
 
     bool x_lower_than_y;
+    VERIFY(!x_numeric.is_nan() && !y_numeric.is_nan());
     if (x_numeric.is_number()) {
-        x_lower_than_y = x_numeric.is_integral_number()
-            ? Crypto::SignedBigInteger { MUST(x_numeric.to_i32(vm)) } < y_numeric.as_bigint().big_integer()
-            : (Crypto::SignedBigInteger { MUST(x_numeric.to_i32(vm)) } < y_numeric.as_bigint().big_integer() || Crypto::SignedBigInteger { MUST(x_numeric.to_i32(vm)) + 1 } < y_numeric.as_bigint().big_integer());
+        x_lower_than_y = y_numeric.as_bigint().big_integer().compare_to_double(x_numeric.as_double())
+            == Crypto::SignedBigInteger::CompareResult::DoubleLessThanBigInt;
     } else {
-        x_lower_than_y = y_numeric.is_integral_number()
-            ? x_numeric.as_bigint().big_integer() < Crypto::SignedBigInteger { MUST(y_numeric.to_i32(vm)) }
-            : (x_numeric.as_bigint().big_integer() < Crypto::SignedBigInteger { MUST(y_numeric.to_i32(vm)) } || x_numeric.as_bigint().big_integer() < Crypto::SignedBigInteger { MUST(y_numeric.to_i32(vm)) + 1 });
+        x_lower_than_y = x_numeric.as_bigint().big_integer().compare_to_double(y_numeric.as_double())
+            == Crypto::SignedBigInteger::CompareResult::DoubleGreaterThanBigInt;
     }
     if (x_lower_than_y)
         return TriState::True;

--- a/Userland/Libraries/LibJS/Tests/object-expression-numeric-property.js
+++ b/Userland/Libraries/LibJS/Tests/object-expression-numeric-property.js
@@ -28,3 +28,26 @@ test("numeric properties", () => {
         "4294967296", // >= 2^32 - 1
     ]);
 });
+
+test("big int properties", () => {
+    const o = {
+        [-1n]: "foo",
+        0n: "foo",
+        1n: "foo",
+        [12345678901n]: "foo",
+        [4294967294n]: "foo",
+        [4294967295n]: "foo",
+    };
+    // Numeric properties come first in Object.getOwnPropertyNames()'s output,
+    // which means we can test what each is treated as internally.
+    expect(Object.getOwnPropertyNames(o)).toEqual([
+        // Numeric properties
+        "0",
+        "1",
+        "4294967294",
+        // Non-numeric properties
+        "-1",
+        "12345678901", // >= 2^32 - 1
+        "4294967295", // >= 2^32 - 1
+    ]);
+});

--- a/Userland/Libraries/LibJS/Tests/operators/binary-bitwise-left-shift.js
+++ b/Userland/Libraries/LibJS/Tests/operators/binary-bitwise-left-shift.js
@@ -63,3 +63,13 @@ test("shifting with non-numeric values", () => {
     expect(Infinity << Infinity).toBe(0);
     expect(-Infinity << Infinity).toBe(0);
 });
+
+describe("logical left shift on big ints", () => {
+    expect(3n << -1n).toBe(1n);
+    expect(3n << -2n).toBe(0n);
+    expect(-3n << -1n).toBe(-2n);
+    expect(-3n << -2n).toBe(-1n);
+    expect(-3n << -128n).toBe(-1n);
+    expect(3n << 6n).toBe(192n);
+    expect(3n << 0n).toBe(3n);
+});

--- a/Userland/Libraries/LibJS/Tests/operators/binary-bitwise-right-shift.js
+++ b/Userland/Libraries/LibJS/Tests/operators/binary-bitwise-right-shift.js
@@ -64,3 +64,13 @@ test("shifting with non-numeric values", () => {
     expect(Infinity >> Infinity).toBe(0);
     expect(-Infinity >> Infinity).toBe(0);
 });
+
+describe("logical right shift on big ints", () => {
+    expect(3n >> 1n).toBe(1n);
+    expect(3n >> 2n).toBe(0n);
+    expect(-3n >> 1n).toBe(-2n);
+    expect(-3n >> 2n).toBe(-1n);
+    expect(-3n >> 128n).toBe(-1n);
+    expect(-3n >> -6n).toBe(-192n);
+    expect(-3n >> 0n).toBe(-3n);
+});

--- a/Userland/Libraries/LibJS/Tests/syntax/destructuring-assignment.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/destructuring-assignment.js
@@ -223,4 +223,11 @@ describe("evaluating", () => {
         expect(x).toBe("foo");
         expect(a).toBe(o.a);
     });
+
+    test("can use big int values as number-like properties", () => {
+        let o = { "99999999999999999": 1 };
+        let { 123n: a = "foo", 99999999999999999n: b = "bar" } = o;
+        expect(a).toBe("foo");
+        expect(b).toBe(1);
+    });
 });


### PR DESCRIPTION
There are a bunch of explanatory comments in the double comparison algorithm mostly for myself to make sure I actually understood, I can remove them if they are a little too informal.