### PR TITLE
LibJS: Make IsHTMLDDA non-constructible

### DIFF
--- a/Userland/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.cpp
+++ b/Userland/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.cpp
@@ -29,12 +29,4 @@ ThrowCompletionOr<Value> IsHTMLDDA::call()
     return js_undefined();
 }
 
-ThrowCompletionOr<Object*> IsHTMLDDA::construct(FunctionObject&)
-{
-    // Not sure if we need to support construction, but ¯\_(ツ)_/¯
-    auto& vm = this->vm();
-    auto& global_object = this->global_object();
-    return vm.throw_completion<TypeError>(global_object, ErrorType::NotAConstructor, "IsHTMLDDA");
-}
-
 }

--- a/Userland/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.h
+++ b/Userland/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.h
@@ -18,10 +18,8 @@ public:
     virtual ~IsHTMLDDA() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
-    virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
-    virtual bool has_constructor() const override { return true; }
     virtual bool is_htmldda() const override { return true; }
 };
 


### PR DESCRIPTION
I have also made a issue for test262 for clarification on this, as initially it wasn't clear to me whether the object was meant to be non-constructible or this was a property of having a [[IsHTMLDDA]] slot.
See https://github.com/tc39/test262/issues/3644

Fixes 1 test262 test