### PR TITLE
Kernel: Annotate SpinlockProtected<PacketList> in NetworkAdapter class

### DIFF
--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -109,7 +109,7 @@ private:
 
     PacketList m_packet_queue;
     size_t m_packet_queue_size { 0 };
-    SpinlockProtected<PacketList> m_unused_packets;
+    SpinlockProtected<PacketList> m_unused_packets { LockRank::None };
     NonnullOwnPtr<KString> m_name;
     u32 m_packets_in { 0 };
     u32 m_bytes_in { 0 };


### PR DESCRIPTION
Fix broken CI after 4314c25cf2a60f7692821b10a6e759d24ae1a1b6.

cc @bgianfo @kleinesfilmroellchen 