### PR TITLE
Userland: Consolidate most PATH resolving into a single implementation

### DIFF
--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -11,6 +11,7 @@
 #include <LibConfig/Listener.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DirIterator.h>
+#include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
@@ -162,7 +163,7 @@ static ErrorOr<void> run_command(String command, bool keep_open)
         arguments.append("-c"sv);
         arguments.append(command);
     }
-    auto env = TRY(FixedArray<StringView>::try_create({ "TERM=xterm"sv, "PAGER=more"sv, "PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"sv }));
+    auto env = TRY(FixedArray<StringView>::try_create({ "TERM=xterm"sv, "PAGER=more"sv, "PATH="sv DEFAULT_PATH_SV }));
     TRY(Core::System::exec(shell, arguments, Core::System::SearchInPath::No, env.span()));
     VERIFY_NOT_REACHED();
 }

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -128,7 +128,7 @@ static void update_path_environment_variable()
 
     if (path.length())
         path.append(':');
-    path.append("/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"sv);
+    path.append(DEFAULT_PATH_SV);
     setenv("PATH", path.to_string().characters(), true);
 }
 

--- a/Userland/DevTools/UserspaceEmulator/main.cpp
+++ b/Userland/DevTools/UserspaceEmulator/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv, char** env)
     if (arguments[0].contains("/"sv))
         executable_path = Core::File::real_path_for(arguments[0]);
     else
-        executable_path = Core::find_executable_in_path(arguments[0]);
+        executable_path = Core::File::resolve_executable_from_environment(arguments[0]).value_or({});
     if (executable_path.is_empty()) {
         reportln("Cannot find executable for '{}'."sv, arguments[0]);
         return 1;

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -8,6 +8,7 @@
 #include <AK/ScopedValueRollback.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibCore/File.h>
 #include <alloca.h>
 #include <assert.h>
 #include <bits/pthread_cancel.h>
@@ -186,7 +187,7 @@ int execvpe(char const* filename, char* const argv[], char* const envp[])
     ScopedValueRollback errno_rollback(errno);
     String path = getenv("PATH");
     if (path.is_empty())
-        path = "/bin:/usr/bin";
+        path = DEFAULT_PATH;
     auto parts = path.split(':');
     for (auto& part : parts) {
         auto candidate = String::formatted("{}/{}", part, filename);

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -179,12 +179,15 @@ int execve(char const* filename, char* const argv[], char* const envp[])
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://linux.die.net/man/3/execvpe (GNU extension)
 int execvpe(char const* filename, char* const argv[], char* const envp[])
 {
     if (strchr(filename, '/'))
         return execve(filename, argv, envp);
 
     ScopedValueRollback errno_rollback(errno);
+
+    // TODO: Make this use the PATH search implementation from Core::File.
     String path = getenv("PATH");
     if (path.is_empty())
         path = DEFAULT_PATH;

--- a/Userland/Libraries/LibCore/DirIterator.cpp
+++ b/Userland/Libraries/LibCore/DirIterator.cpp
@@ -95,28 +95,6 @@ String DirIterator::next_full_path()
     return builder.to_string();
 }
 
-String find_executable_in_path(String filename)
-{
-    if (filename.is_empty())
-        return {};
-
-    if (filename.starts_with('/')) {
-        if (access(filename.characters(), X_OK) == 0)
-            return filename;
-
-        return {};
-    }
-
-    for (auto directory : String { getenv("PATH") }.split(':')) {
-        auto fullpath = String::formatted("{}/{}", directory, filename);
-
-        if (access(fullpath.characters(), X_OK) == 0)
-            return fullpath;
-    }
-
-    return {};
-}
-
 int DirIterator::fd() const
 {
     if (!m_dir)

--- a/Userland/Libraries/LibCore/DirIterator.h
+++ b/Userland/Libraries/LibCore/DirIterator.h
@@ -44,6 +44,4 @@ private:
     bool advance_next();
 };
 
-String find_executable_in_path(String filename);
-
 }

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -110,6 +110,8 @@ public:
     static NonnullRefPtr<File> standard_output();
     static NonnullRefPtr<File> standard_error();
 
+    static Optional<String> resolve_executable_from_environment(StringView filename);
+
 private:
     File(Object* parent = nullptr)
         : IODevice(parent)

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -11,6 +11,10 @@
 #include <LibCore/IODevice.h>
 #include <sys/stat.h>
 
+// FIXME: Make this a bit prettier.
+#define DEFAULT_PATH "/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
+#define DEFAULT_PATH_SV "/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"sv
+
 namespace Core {
 
 class File final : public IODevice {

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -958,7 +958,7 @@ ErrorOr<String> find_file_in_path(StringView filename)
     auto const* path_ptr = getenv("PATH");
     StringView path { path_ptr, strlen(path_ptr) };
     if (path.is_empty())
-        path = "/bin:/usr/bin"sv;
+        path = DEFAULT_PATH_SV;
     auto parts = path.split_view(':');
     for (auto& part : parts) {
         auto candidate = String::formatted("{}/{}", part, filename);
@@ -1043,7 +1043,7 @@ ErrorOr<void> exec(StringView filename, Span<StringView> arguments, SearchInPath
             ScopedValueRollback errno_rollback(errno);
             String path = getenv("PATH");
             if (path.is_empty())
-                path = "/bin:/usr/bin";
+                path = DEFAULT_PATH;
             auto parts = path.split(':');
             for (auto& part : parts) {
                 auto candidate = String::formatted("{}/{}", part, filename);

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -161,7 +161,6 @@ ErrorOr<Array<int, 2>> pipe2(int flags);
 #ifndef AK_OS_ANDROID
 ErrorOr<void> adjtime(const struct timeval* delta, struct timeval* old_delta);
 #endif
-ErrorOr<String> find_file_in_path(StringView filename);
 enum class SearchInPath {
     No,
     Yes,

--- a/Userland/Services/TelnetServer/main.cpp
+++ b/Userland/Services/TelnetServer/main.cpp
@@ -10,6 +10,7 @@
 #include <AK/Types.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/File.h>
 #include <LibCore/TCPServer.h>
 #include <LibMain/Main.h>
 #include <fcntl.h>
@@ -71,7 +72,7 @@ static void run_command(int ptm_fd, String command)
             args[1] = "-c";
             args[2] = command.characters();
         }
-        char const* envs[] = { "TERM=xterm", "PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/bin", nullptr };
+        char const* envs[] = { "TERM=xterm", "PATH=" DEFAULT_PATH, nullptr };
         rc = execve("/bin/Shell", const_cast<char**>(args), const_cast<char**>(envs));
         if (rc < 0) {
             perror("execve");

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -2189,7 +2189,7 @@ Shell::Shell()
             path.append({ path_env_ptr, strlen(path_env_ptr) });
         if (path.length())
             path.append(":"sv);
-        path.append("/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"sv);
+        path.append(DEFAULT_PATH_SV);
         setenv("PATH", path.to_string().characters(), true);
     }
 

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1338,27 +1338,6 @@ String Shell::unescape_token(StringView token)
     return builder.build();
 }
 
-String Shell::find_in_path(StringView program_name)
-{
-    String path = getenv("PATH");
-    if (!path.is_empty()) {
-        auto directories = path.split(':');
-        for (auto const& directory : directories) {
-            Core::DirIterator programs(directory.characters(), Core::DirIterator::SkipDots);
-            while (programs.has_next()) {
-                auto program = programs.next_path();
-                auto program_path = String::formatted("{}/{}", directory, program);
-                if (access(program_path.characters(), X_OK) != 0)
-                    continue;
-                if (program == program_name)
-                    return program_path;
-            }
-        }
-    }
-
-    return {};
-}
-
 void Shell::cache_path()
 {
     if (!m_is_interactive)
@@ -1387,6 +1366,7 @@ void Shell::cache_path()
         cached_path.append({ RunnablePath::Kind::Alias, name });
     }
 
+    // TODO: Can we make this rely on Core::File::resolve_executable_from_environment()?
     String path = getenv("PATH");
     if (!path.is_empty()) {
         auto directories = path.split(':');

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -157,8 +157,6 @@ public:
     String resolve_path(String) const;
     String resolve_alias(StringView) const;
 
-    static String find_in_path(StringView program_name);
-
     static bool has_history_event(StringView);
 
     RefPtr<AST::Value> get_argument(size_t) const;

--- a/Userland/Utilities/which.cpp
+++ b/Userland/Utilities/which.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <LibCore/ArgsParser.h>
-#include <LibCore/DirIterator.h>
+#include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -20,12 +20,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(filename, "Name of executable", "executable");
     args_parser.parse(arguments);
 
-    auto fullpath = Core::find_executable_in_path(filename);
-    if (fullpath.is_empty()) {
+    auto fullpath = Core::File::resolve_executable_from_environment({ filename, strlen(filename) });
+    if (!fullpath.has_value()) {
         warnln("no '{}' in path", filename);
         return 1;
     }
 
-    outln("{}", fullpath);
+    outln("{}", fullpath.release_value());
     return 0;
 }


### PR DESCRIPTION
We previously had at least three different implementations for resolving executables in the PATH, all of which had slightly different characteristics ("file exists" vs. "executable bit set", "search for file names with `/` in them", etc.).

Merge those into a single implementation to keep the behavior consistent, and maybe to make that implementation more configurable in the future.

While we're at it, put all the different variations of the default `PATH` into one place to make sure that we don't have to search around everywhere if we want to change that.