### PR TITLE
PixelPaint: Two small fixes

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -37,10 +37,16 @@ void EllipseTool::draw_using(GUI::Painter& painter, Gfx::IntPoint const& start_p
 
     switch (m_fill_mode) {
     case FillMode::Outline:
-        if (m_antialias_enabled)
+        if (m_antialias_enabled) {
             aa_painter.draw_ellipse(ellipse_intersecting_rect, m_editor->color_for(m_drawing_button), thickness);
-        else
+        } else {
+            // For some reason for non-AA draw_ellipse() the ellipse is outside of the rect (unlike all other ellipse drawing functions).
+            // Scale the ellipse rect by sqrt(2) to get an ellipse arc that appears as if it was inside of the rect.
+            auto shrink_width = ellipse_intersecting_rect.width() * (1 - 1 / 1.41);
+            auto shrink_height = ellipse_intersecting_rect.height() * (1 - 1 / 1.41);
+            ellipse_intersecting_rect.shrink(shrink_width, shrink_height);
             painter.draw_ellipse_intersecting(ellipse_intersecting_rect, m_editor->color_for(m_drawing_button), thickness);
+        }
         break;
     case FillMode::Fill:
         if (m_antialias_enabled)

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -116,6 +116,7 @@ void EllipseTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
+    painter.translate(editor_layer_location(*layer));
     auto preview_start = m_editor->content_to_frame_position(m_ellipse_start_position).to_type<int>();
     auto preview_end = m_editor->content_to_frame_position(m_ellipse_end_position).to_type<int>();
     draw_using(painter, preview_start, preview_end, AK::max(m_thickness * m_editor->scale(), 1));

--- a/Userland/Applications/PixelPaint/Tools/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LineTool.cpp
@@ -117,6 +117,7 @@ void LineTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
+    painter.translate(editor_layer_location(*layer));
     auto preview_start = editor_stroke_position(m_line_start_position, m_thickness);
     auto preview_end = editor_stroke_position(m_line_end_position, m_thickness);
     draw_using(painter, preview_start, preview_end, m_editor->color_for(m_drawing_button), AK::max(m_thickness * m_editor->scale(), 1));

--- a/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
@@ -123,6 +123,7 @@ void RectangleTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
+    painter.translate(editor_layer_location(*layer));
     auto start_position = editor_stroke_position(m_rectangle_start_position, m_thickness);
     auto end_position = editor_stroke_position(m_rectangle_end_position, m_thickness);
     draw_using(painter, start_position, end_position, AK::max(m_thickness * m_editor->scale(), 1), m_corner_radius * m_editor->scale());

--- a/Userland/Applications/PixelPaint/Tools/Tool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/Tool.cpp
@@ -8,6 +8,7 @@
 
 #include "Tool.h"
 #include "../ImageEditor.h"
+#include "../Layer.h"
 #include <LibGUI/Action.h>
 
 namespace PixelPaint {
@@ -44,6 +45,11 @@ void Tool::on_keydown(GUI::KeyEvent& event)
     default:
         break;
     }
+}
+
+Gfx::IntPoint Tool::editor_layer_location(Layer const& layer) const
+{
+    return (Gfx::FloatPoint { layer.location() } * m_editor->scale()).to_rounded<int>();
 }
 
 Gfx::IntPoint Tool::editor_stroke_position(Gfx::IntPoint const& pixel_coords, int stroke_thickness) const

--- a/Userland/Applications/PixelPaint/Tools/Tool.h
+++ b/Userland/Applications/PixelPaint/Tools/Tool.h
@@ -79,6 +79,8 @@ protected:
     WeakPtr<ImageEditor> m_editor;
     RefPtr<GUI::Action> m_action;
 
+    Gfx::IntPoint editor_layer_location(Layer const& layer) const;
+
     virtual Gfx::IntPoint editor_stroke_position(Gfx::IntPoint const& pixel_coords, int stroke_thickness) const;
 
     void set_primary_slider(GUI::ValueSlider* primary) { m_primary_slider = primary; }


### PR DESCRIPTION
Two little fixes for PixelPaint :^)

- Make the non-AA outline ellipses the same size as all other ellipses (AA, filled, etc)
   -  `draw_ellipse_intersecting()` draws the ellipse around (rather than inside) the bounding rectangle unlike all other ellipse drawing methods, this corrects that by scaling by root(2), making it consistent with the other modes of ellipse tool.
- Fix tool previews positions on moved layers
   - Currently, the preview drawing does not account for the location of the layer for some tools, so the preview is drawn offset from where you're  drawing.   