### PR TITLE
Kernel: Fix boot profiling

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -411,6 +411,7 @@ public:
     ErrorOr<FlatPtr> sys$getkeymap(Userspace<Syscall::SC_getkeymap_params const*>);
     ErrorOr<FlatPtr> sys$setkeymap(Userspace<Syscall::SC_setkeymap_params const*>);
     ErrorOr<FlatPtr> sys$profiling_enable(pid_t, Userspace<u64 const*>);
+    ErrorOr<FlatPtr> profiling_enable(pid_t, u64 event_mask);
     ErrorOr<FlatPtr> sys$profiling_disable(pid_t);
     ErrorOr<FlatPtr> sys$profiling_free_buffer(pid_t);
     ErrorOr<FlatPtr> sys$futex(Userspace<Syscall::SC_futex_params const*>);

--- a/Kernel/Syscalls/profiling.cpp
+++ b/Kernel/Syscalls/profiling.cpp
@@ -24,6 +24,13 @@ ErrorOr<FlatPtr> Process::sys$profiling_enable(pid_t pid, Userspace<u64 const*> 
     TRY(require_no_promises());
 
     auto const event_mask = TRY(copy_typed_from_user(userspace_event_mask));
+    return profiling_enable(pid, event_mask);
+}
+
+// NOTE: This second entrypoint exists to allow the kernel to invoke the syscall to enable boot profiling.
+ErrorOr<FlatPtr> Process::profiling_enable(pid_t pid, u64 event_mask)
+{
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
 
     if (pid == -1) {
         if (!is_superuser())

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -393,7 +393,7 @@ void init_stage2(void*)
         dbgln("Starting full system boot profiling");
         MutexLocker mutex_locker(Process::current().big_lock());
         auto const enable_all = ~(u64)0;
-        auto result = Process::current().sys$profiling_enable(-1, reinterpret_cast<FlatPtr>(&enable_all));
+        auto result = Process::current().profiling_enable(-1, enable_all);
         VERIFY(!result.is_error());
     }
 


### PR DESCRIPTION
Boot profiling was previously broken due to init_stage2() passing the
event mask to sys$profiling_enable() via kernel pointer, but a user
pointer is expected.

To fix this, I added Process::profiling_enable() as an alternative to
Process::sys$profiling_enable which takes a u64 rather than a
Userspace<u64 const*>. It's a bit of a hack, but it works.