### PR TITLE
Taskbar: Fix quicklaunch entry file deleted event

### DIFF
--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -148,11 +148,18 @@ void QuickLaunchWidget::add_or_adjust_button(String const& button_name, NonnullO
             // FIXME: Propagate errors
             m_watcher = MUST(Core::FileWatcher::create());
             m_watcher->on_change = [this](Core::FileWatcherEvent const& event) {
-                auto name = sanitize_entry_name(event.event_path);
-                dbgln("Removing QuickLaunch entry {}", name);
-                auto button = find_child_of_type_named<GUI::Button>(name);
-                if (button)
-                    remove_child(*button);
+                auto keys = Config::list_keys("Taskbar"sv, quick_launch);
+                for (auto& name : keys) {
+                    auto value = Config::read_string("Taskbar"sv, quick_launch, name);
+                    if (event.event_path == value) {
+                        auto sanitized_name = sanitize_entry_name(name);
+                        dbgln("Removing QuickLaunch entry {}", sanitized_name);
+                        auto button = find_child_of_type_named<GUI::Button>(sanitized_name);
+                        if (button)
+                            remove_child(*button);
+                        Config::remove_key("Taskbar"sv, quick_launch, name);
+                    }
+                }
             };
         }
         // FIXME: Propagate errors


### PR DESCRIPTION
Previously this would only work if the filename was also
the config key, but since you can choose any name for
a config key the correct quicklaunch button could not be found.

Fix this by looping through the taskbar config and
matching them by value instead.

I've also updated the deleted event to remove the deleted file
from the config, which was't done previously so the broken
file entry would come back after a reboot.

For example:
```ini
[QuickLaunch]
Readme=/home/anon/README.md
```
Deleting the `README.md` file would not remove the quicklaunch button because it tried to match the filename to the key name.