### PR TITLE
Kernel: Make sys$open not need the big lock

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -123,7 +123,7 @@ enum class NeedsBigProcessLock {
     S(msync, NeedsBigProcessLock::Yes)                      \
     S(msyscall, NeedsBigProcessLock::Yes)                   \
     S(munmap, NeedsBigProcessLock::Yes)                     \
-    S(open, NeedsBigProcessLock::Yes)                       \
+    S(open, NeedsBigProcessLock::No)                        \
     S(perf_event, NeedsBigProcessLock::Yes)                 \
     S(perf_register_string, NeedsBigProcessLock::Yes)       \
     S(pipe, NeedsBigProcessLock::No)                        \

--- a/Kernel/Syscalls/open.cpp
+++ b/Kernel/Syscalls/open.cpp
@@ -16,7 +16,7 @@ namespace Kernel {
 
 ErrorOr<FlatPtr> Process::sys$open(Userspace<Syscall::SC_open_params const*> user_params)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     auto params = TRY(copy_typed_from_user(user_params));
 
     int dirfd = params.dirfd;

--- a/Kernel/Syscalls/open.cpp
+++ b/Kernel/Syscalls/open.cpp
@@ -54,7 +54,6 @@ ErrorOr<FlatPtr> Process::sys$open(Userspace<Syscall::SC_open_params const*> use
 
     dbgln_if(IO_DEBUG, "sys$open(dirfd={}, path='{}', options={}, mode={})", dirfd, path->view(), options, mode);
 
-    auto fd_allocation = TRY(allocate_fd());
     RefPtr<Custody> base;
     if (dirfd == AT_FDCWD) {
         base = current_directory();
@@ -74,6 +73,7 @@ ErrorOr<FlatPtr> Process::sys$open(Userspace<Syscall::SC_open_params const*> use
 
     return m_fds.with_exclusive([&](auto& fds) -> ErrorOr<FlatPtr> {
         u32 fd_flags = (options & O_CLOEXEC) ? FD_CLOEXEC : 0;
+        auto fd_allocation = TRY(allocate_fd());
         fds[fd_allocation.fd].set(move(description), fd_flags);
         return fd_allocation.fd;
     });


### PR DESCRIPTION
This pull request lightly modifies the syscall to make it safer and removes the big lock from it.