### PR TITLE
Utilize the credentials object in a few more places across the kernel

### DIFF
--- a/Kernel/Coredump.cpp
+++ b/Kernel/Coredump.cpp
@@ -68,12 +68,13 @@ ErrorOr<NonnullLockRefPtr<OpenFileDescription>> Coredump::try_create_target_file
         dbgln("Refusing to put coredump in sketchy directory '{}'", output_directory);
         return EINVAL;
     }
+    auto credentials = process.credentials();
     return TRY(VirtualFileSystem::the().open(
         KLexicalPath::basename(output_path),
         O_CREAT | O_WRONLY | O_EXCL,
         S_IFREG, // We will enable reading from userspace when we finish generating the coredump file
         *dump_directory,
-        UidAndGid { process.uid(), process.gid() }));
+        UidAndGid { credentials->uid(), credentials->gid() }));
 }
 
 ErrorOr<void> Coredump::write_elf_header()

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -342,6 +342,7 @@ ErrorOr<void> VirtualFileSystem::mknod(StringView path, mode_t mode, dev_t dev, 
         return existing_file_or_error.release_error();
     auto& parent_inode = parent_custody->inode();
     auto& current_process = Process::current();
+    auto current_process_credentials = current_process.credentials();
     if (!parent_inode.metadata().may_write(current_process))
         return EACCES;
     if (parent_custody->is_readonly())
@@ -349,7 +350,7 @@ ErrorOr<void> VirtualFileSystem::mknod(StringView path, mode_t mode, dev_t dev, 
 
     auto basename = KLexicalPath::basename(path);
     dbgln_if(VFS_DEBUG, "VirtualFileSystem::mknod: '{}' mode={} dev={} in {}", basename, mode, dev, parent_inode.identifier());
-    (void)TRY(parent_inode.create_child(basename, mode, dev, current_process.euid(), current_process.egid()));
+    (void)TRY(parent_inode.create_child(basename, mode, dev, current_process_credentials->euid(), current_process_credentials->egid()));
     return {};
 }
 
@@ -367,14 +368,15 @@ ErrorOr<NonnullLockRefPtr<OpenFileDescription>> VirtualFileSystem::create(String
 
     auto& parent_inode = parent_custody.inode();
     auto& current_process = Process::current();
+    auto current_process_credentials = current_process.credentials();
     if (!parent_inode.metadata().may_write(current_process))
         return EACCES;
     if (parent_custody.is_readonly())
         return EROFS;
 
     dbgln_if(VFS_DEBUG, "VirtualFileSystem::create: '{}' in {}", basename, parent_inode.identifier());
-    auto uid = owner.has_value() ? owner.value().uid : current_process.euid();
-    auto gid = owner.has_value() ? owner.value().gid : current_process.egid();
+    auto uid = owner.has_value() ? owner.value().uid : current_process_credentials->euid();
+    auto gid = owner.has_value() ? owner.value().gid : current_process_credentials->egid();
 
     auto inode = TRY(parent_inode.create_child(basename, mode, 0, uid, gid));
     auto custody = TRY(Custody::try_create(&parent_custody, basename, inode, parent_custody.mount_flags()));
@@ -411,6 +413,7 @@ ErrorOr<void> VirtualFileSystem::mkdir(StringView path, mode_t mode, Custody& ba
     TRY(validate_path_against_process_veil(*parent_custody, O_CREAT));
     auto& parent_inode = parent_custody->inode();
     auto& current_process = Process::current();
+    auto current_process_credentials = current_process.credentials();
     if (!parent_inode.metadata().may_write(current_process))
         return EACCES;
     if (parent_custody->is_readonly())
@@ -418,7 +421,7 @@ ErrorOr<void> VirtualFileSystem::mkdir(StringView path, mode_t mode, Custody& ba
 
     auto basename = KLexicalPath::basename(path);
     dbgln_if(VFS_DEBUG, "VirtualFileSystem::mkdir: '{}' in {}", basename, parent_inode.identifier());
-    (void)TRY(parent_inode.create_child(basename, S_IFDIR | mode, 0, current_process.euid(), current_process.egid()));
+    (void)TRY(parent_inode.create_child(basename, S_IFDIR | mode, 0, current_process_credentials->euid(), current_process_credentials->egid()));
     return {};
 }
 
@@ -700,6 +703,7 @@ ErrorOr<void> VirtualFileSystem::symlink(StringView target, StringView linkpath,
         return existing_custody_or_error.release_error();
     auto& parent_inode = parent_custody->inode();
     auto& current_process = Process::current();
+    auto current_process_credentials = current_process.credentials();
     if (!parent_inode.metadata().may_write(current_process))
         return EACCES;
     if (parent_custody->is_readonly())
@@ -708,7 +712,7 @@ ErrorOr<void> VirtualFileSystem::symlink(StringView target, StringView linkpath,
     auto basename = KLexicalPath::basename(linkpath);
     dbgln_if(VFS_DEBUG, "VirtualFileSystem::symlink: '{}' (-> '{}') in {}", basename, target, parent_inode.identifier());
 
-    auto inode = TRY(parent_inode.create_child(basename, S_IFLNK | 0644, 0, current_process.euid(), current_process.egid()));
+    auto inode = TRY(parent_inode.create_child(basename, S_IFLNK | 0644, 0, current_process_credentials->euid(), current_process_credentials->egid()));
 
     auto target_buffer = UserOrKernelBuffer::for_kernel_buffer(const_cast<u8*>((u8 const*)target.characters_without_null_termination()));
     MutexLocker locker(inode->m_inode_lock);

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -73,8 +73,9 @@ LocalSocket::LocalSocket(int type, NonnullOwnPtr<DoubleBuffer> client_buffer, No
     , m_for_server(move(server_buffer))
 {
     auto& current_process = Process::current();
-    m_prebind_uid = current_process.euid();
-    m_prebind_gid = current_process.egid();
+    auto current_process_credentials = current_process.credentials();
+    m_prebind_uid = current_process_credentials->euid();
+    m_prebind_gid = current_process_credentials->egid();
     m_prebind_mode = 0666;
 
     m_for_client->set_unblock_callback([this]() {

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -288,12 +288,14 @@ void Socket::set_connected(bool connected)
 
 void Socket::set_origin(Process const& process)
 {
-    m_origin = { process.pid().value(), process.uid().value(), process.gid().value() };
+    auto credentials = process.credentials();
+    m_origin = { process.pid().value(), credentials->uid().value(), credentials->gid().value() };
 }
 
 void Socket::set_acceptor(Process const& process)
 {
-    m_acceptor = { process.pid().value(), process.uid().value(), process.gid().value() };
+    auto credentials = process.credentials();
+    m_acceptor = { process.pid().value(), credentials->uid().value(), credentials->gid().value() };
 }
 
 }


### PR DESCRIPTION
Following on from 122d7d95336e6ea82e92ddcefe6254d05bcfd194, this pull requests reduces the usage of the process' helpers for getting uid, gid, etc, and instead gets the credentials object from the process and the required ids from there. 