### PR TITLE
Kernel: Remove big lock from sys$socket

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -174,7 +174,7 @@ enum class NeedsBigProcessLock {
     S(sigreturn, NeedsBigProcessLock::Yes)                  \
     S(sigsuspend, NeedsBigProcessLock::Yes)                 \
     S(sigtimedwait, NeedsBigProcessLock::Yes)               \
-    S(socket, NeedsBigProcessLock::Yes)                     \
+    S(socket, NeedsBigProcessLock::No)                      \
     S(socketpair, NeedsBigProcessLock::No)                  \
     S(stat, NeedsBigProcessLock::No)                        \
     S(statvfs, NeedsBigProcessLock::No)                     \

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -33,7 +33,7 @@ static void setup_socket_fd(Process::OpenFileDescriptions& fds, int fd, NonnullL
 
 ErrorOr<FlatPtr> Process::sys$socket(int domain, int type, int protocol)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     REQUIRE_PROMISE_FOR_SOCKET_DOMAIN(domain);
 
     auto credentials = this->credentials();


### PR DESCRIPTION
As the new credentials object removes the requirement for is_superuser()  to access shared memory, sys$socket does not need the big lock. 