### PR TITLE
PixelPaint: Use Sqrt1_2 constant in EllipseTool instead of 1/1.41

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -42,8 +42,9 @@ void EllipseTool::draw_using(GUI::Painter& painter, Gfx::IntPoint const& start_p
         } else {
             // For some reason for non-AA draw_ellipse() the ellipse is outside of the rect (unlike all other ellipse drawing functions).
             // Scale the ellipse rect by sqrt(2) to get an ellipse arc that appears as if it was inside of the rect.
-            auto shrink_width = ellipse_intersecting_rect.width() * (1 - 1 / 1.41);
-            auto shrink_height = ellipse_intersecting_rect.height() * (1 - 1 / 1.41);
+            // Ie. reduce the size by a factor of 1 - sqrt(1/2)
+            auto shrink_width = ellipse_intersecting_rect.width() * (1 - AK::Sqrt1_2<float>);
+            auto shrink_height = ellipse_intersecting_rect.height() * (1 - AK::Sqrt1_2<float>);
             ellipse_intersecting_rect.shrink(shrink_width, shrink_height);
             painter.draw_ellipse_intersecting(ellipse_intersecting_rect, m_editor->color_for(m_drawing_button), thickness);
         }


### PR DESCRIPTION
This also demotes the constant to floats instead of doubles, because we
truncate it to int anyways and don't need the extra accuracy.

---

CC: @MacDue