### PR TITLE
WindowServer+DisplaySettings: Capitalize display mode dropdown

### DIFF
--- a/Base/etc/WindowServer.ini
+++ b/Base/etc/WindowServer.ini
@@ -31,7 +31,7 @@ OverlayRectShadow=/res/graphics/overlay-rect-shadow.png
 DoubleClickSpeed=250
 
 [Background]
-Mode=stretch
+Mode=Stretch
 
 [Applet]
 Order=WorkspacePicker,CPUGraph,MemoryGraph,NetworkGraph,Network,ClipboardHistory,Audio,Keymap

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -34,9 +34,9 @@ namespace DisplaySettings {
 BackgroundSettingsWidget::BackgroundSettingsWidget(bool& background_settings_changed)
     : m_background_settings_changed { background_settings_changed }
 {
-    m_modes.append("tile");
-    m_modes.append("center");
-    m_modes.append("stretch");
+    m_modes.append("Tile");
+    m_modes.append("Center");
+    m_modes.append("Stretch");
 
     create_frame();
     load_current_settings();

--- a/Userland/Applications/DisplaySettings/MonitorWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.cpp
@@ -124,12 +124,12 @@ void MonitorWidget::redraw_desktop_if_needed()
     auto scaled_size = m_wallpaper_bitmap->size().to_type<float>().scaled_by(sw, sh).to_type<int>();
     auto scaled_bitmap = m_wallpaper_bitmap->scaled(sw, sh).release_value_but_fixme_should_propagate_errors();
 
-    if (m_desktop_wallpaper_mode == "center") {
+    if (m_desktop_wallpaper_mode == "Center") {
         auto centered_rect = Gfx::IntRect({}, scaled_size).centered_within(m_desktop_bitmap->rect());
         painter.blit(centered_rect.location(), *scaled_bitmap, scaled_bitmap->rect());
-    } else if (m_desktop_wallpaper_mode == "tile") {
+    } else if (m_desktop_wallpaper_mode == "Tile") {
         painter.draw_tiled_bitmap(m_desktop_bitmap->rect(), *scaled_bitmap);
-    } else if (m_desktop_wallpaper_mode == "stretch") {
+    } else if (m_desktop_wallpaper_mode == "Stretch") {
         painter.draw_scaled_bitmap(m_desktop_bitmap->rect(), *m_wallpaper_bitmap, m_wallpaper_bitmap->rect());
     } else {
         VERIFY_NOT_REACHED();

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -33,11 +33,11 @@ Compositor& Compositor::the()
 
 static WallpaperMode mode_to_enum(String const& name)
 {
-    if (name == "tile")
+    if (name == "Tile")
         return WallpaperMode::Tile;
-    if (name == "stretch")
+    if (name == "Stretch")
         return WallpaperMode::Stretch;
-    if (name == "center")
+    if (name == "Center")
         return WallpaperMode::Center;
     return WallpaperMode::Center;
 }
@@ -139,7 +139,7 @@ void Compositor::did_construct_window_manager(Badge<WindowManager>)
 
     m_current_window_stack = &wm.current_window_stack();
 
-    m_wallpaper_mode = mode_to_enum(wm.config()->read_entry("Background", "Mode", "center"));
+    m_wallpaper_mode = mode_to_enum(wm.config()->read_entry("Background", "Mode", "Center"));
     m_custom_background_color = Color::from_string(wm.config()->read_entry("Background", "Color", ""));
 
     invalidate_screen();


### PR DESCRIPTION
Every other dropdown in settings is capitalized apart from this one.
This commit fixes that.