### PR TITLE
FileManager: Disable child_directory_action if no child exists

### DIFF
--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -1141,6 +1141,7 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
         go_forward_action->set_enabled(directory_view->path_history_position() < directory_view->path_history_size() - 1);
         go_back_action->set_enabled(directory_view->path_history_position() > 0);
         open_parent_directory_action->set_enabled(new_path != "/");
+        open_child_directory_action->set_enabled(breadcrumbbar.selected_segment().has_value() && *breadcrumbbar.selected_segment() < breadcrumbbar.segment_count() - 1);
         directory_view->view_as_table_action().set_enabled(can_read_in_path);
         directory_view->view_as_icons_action().set_enabled(can_read_in_path);
         directory_view->view_as_columns_action().set_enabled(can_read_in_path);

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -672,8 +672,6 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
         if (!segment_index.has_value() || *segment_index >= breadcrumbbar.segment_count() - 1)
             return;
         breadcrumbbar.set_selected_segment(*segment_index + 1);
-        if (breadcrumbbar.on_segment_click)
-            breadcrumbbar.on_segment_click(*segment_index + 1);
     });
 
     RefPtr<GUI::Action> layout_toolbar_action;
@@ -1073,6 +1071,20 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
     (void)TRY(main_toolbar.try_add_action(directory_view->view_as_table_action()));
     (void)TRY(main_toolbar.try_add_action(directory_view->view_as_columns_action()));
 
+    breadcrumbbar.on_segment_change = [&](auto segment_index) {
+        if (!segment_index.has_value())
+            return;
+        auto selected_path = breadcrumbbar.segment_data(*segment_index);
+        if (Core::File::is_directory(selected_path)) {
+            directory_view->open(selected_path);
+        } else {
+            dbgln("Breadcrumb path '{}' doesn't exist", selected_path);
+            breadcrumbbar.remove_end_segments(*segment_index);
+            auto existing_path_segment = breadcrumbbar.find_segment_with_data(directory_view->path());
+            breadcrumbbar.set_selected_segment(existing_path_segment.value());
+        }
+    };
+
     directory_view->on_path_change = [&](String const& new_path, bool can_read_in_path, bool can_write_in_path) {
         auto icon = GUI::FileIconProvider::icon_for_path(new_path);
         auto* bitmap = icon.bitmap_for_size(16);
@@ -1112,18 +1124,6 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
                 }
 
                 breadcrumbbar.set_selected_segment(breadcrumbbar.segment_count() - 1);
-
-                breadcrumbbar.on_segment_click = [&](size_t segment_index) {
-                    auto selected_path = breadcrumbbar.segment_data(segment_index);
-                    if (Core::File::is_directory(selected_path)) {
-                        directory_view->open(selected_path);
-                    } else {
-                        dbgln("Breadcrumb path '{}' doesn't exist", selected_path);
-                        breadcrumbbar.remove_end_segments(segment_index);
-                        auto existing_path_segment = breadcrumbbar.find_segment_with_data(directory_view->path());
-                        breadcrumbbar.set_selected_segment(existing_path_segment.value());
-                    }
-                };
             }
         }
 

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
@@ -68,6 +68,7 @@ void Breadcrumbbar::clear_segments()
 {
     m_segments.clear();
     remove_all_children();
+    m_selected_segment = {};
 }
 
 void Breadcrumbbar::append_segment(String text, Gfx::Bitmap const* icon, String data, String tooltip)
@@ -120,6 +121,8 @@ void Breadcrumbbar::remove_end_segments(size_t start_segment_index)
         auto segment = m_segments.take_last();
         remove_child(*segment.button);
     }
+    if (m_selected_segment.has_value() && *m_selected_segment >= start_segment_index)
+        m_selected_segment = {};
 }
 
 Optional<size_t> Breadcrumbbar::find_segment_with_data(String const& data)

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
@@ -146,6 +146,8 @@ void Breadcrumbbar::set_selected_segment(Optional<size_t> index)
     auto& segment = m_segments[index.value()];
     VERIFY(segment.button);
     segment.button->set_checked(true);
+    if (on_segment_change)
+        on_segment_change(index);
     relayout();
 }
 

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.h
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.h
@@ -29,6 +29,7 @@ public:
     void set_selected_segment(Optional<size_t> index);
     Optional<size_t> selected_segment() const { return m_selected_segment; }
 
+    Function<void(Optional<size_t> index)> on_segment_change;
     Function<void(size_t index)> on_segment_click;
     Function<void(size_t index, DropEvent&)> on_segment_drop;
     Function<void(size_t index, DragEvent&)> on_segment_drag_enter;


### PR DESCRIPTION
This is already done `open_parent_directory_action`. While the action doesn't do anything if no child segment exists, we should signal to the user that the action won't do anything by disabling it. 
Because Andreas got stumped by it in the video adding said action I have added a new `on_segment_change` handler to the `Breadcrumbbar` class, which is always invoked if the selected segment changes.
The last commit fixes a bug, where the selected index of the breadcrumbbar isn't cleared if the corresponding segment is removed (Though I don't think any existing code was affected by this).

This is my first contribution to the project. Feedback is highly appreciated :)