### PR TITLE
HexEditor: Fix utf16 validation

### DIFF
--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -347,7 +347,7 @@ void HexEditorWidget::update_inspector_values(size_t position)
     if (byte_read_count % 2 == 0) {
         Utf16View utf16_view { Span<u16 const> { reinterpret_cast<u16 const*>(&unsigned_64_bit_int), 4 } };
         size_t valid_code_units;
-        utf8_view.validate(valid_code_units);
+        utf16_view.validate(valid_code_units);
         if (valid_code_units == 0)
             value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::UTF16, "");
         else


### PR DESCRIPTION
Previously the utf8_view was validated for the utf16 valude instead
of the utf16_view. I noticed this while watching the video by Linus of him implementing it. 