### PR TITLE
Ports: Add aclock port

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -6,6 +6,7 @@ This list is also available at [ports.serenityos.net](https://ports.serenityos.n
 
 | Port                                                | Name                                                            | Version                  | Website                                                                        |
 |-----------------------------------------------------|-----------------------------------------------------------------|--------------------------|--------------------------------------------------------------------------------|
+| [`aclock`](aclock/)                                 | aclock                                                          | 2.3                      | https://github.com/tenox7/aclock                                               |
 | [`acpica-tools`](acpica-tools/)                     | ACPI Component Architecture Project Userspace Utilities         | 20220331                 | https://acpica.org/downloads                                                   |
 | [`angband`](angband/)                               | Angband                                                         | 4.2.4                    | https://rephial.org                                                            |
 | [`Another-World`](Another-World/)                   | Another World Bytecode Interpreter                              |                          | https://github.com/fabiensanglard/Another-World-Bytecode-Interpreter           |

--- a/Ports/aclock/package.sh
+++ b/Ports/aclock/package.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port='aclock'
+version='2.3'
+files="https://github.com/tenox7/aclock/raw/f9668617eac365fe8b5416cfbd801b727d8a3746/sources/aclock-unix-curses.c aclock-${version}.c 2b098996409c4740f492fb8fd5a63cb5e3e15283c2f7e3f06c75d6a9ad916669"
+auth_type='sha256'
+depends=("ncurses")
+
+build() {
+    run_nocd ${CC} aclock-${version}.c -o aclock -lcurses -lm
+}
+
+install() {
+    cp aclock "$DESTDIR/usr/local/bin"
+}


### PR DESCRIPTION
Aclock is an ASCII analog clock for the terminal. Since it's already ported to almost everything you could think about might as well port it to Serenity :^)

PR attempt #2 since I suck at Git.