### PR TITLE
Kernel: Remove unused Process::in_group()

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -84,12 +84,6 @@ UNMAP_AFTER_INIT void Process::initialize()
     create_signal_trampoline();
 }
 
-bool Process::in_group(GroupID gid) const
-{
-    auto credentials = this->credentials();
-    return credentials->gid() == gid || credentials->extra_gids().contains_slow(gid);
-}
-
 void Process::kill_threads_except_self()
 {
     InterruptDisabler disabler;

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -246,8 +246,6 @@ public:
         return with_protected_data([](auto& protected_data) { return protected_data.umask; });
     }
 
-    bool in_group(GroupID) const;
-
     // Breakable iteration functions
     template<IteratorFunction<Process&> Callback>
     static void for_each(Callback);


### PR DESCRIPTION
We don't need this anymore since all callers have migrated over to `Credentials::in_group()`