### PR TITLE
LibWeb: Support double-position `linear-gradient()` color stops

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -135,6 +135,10 @@
         .grad-repeat-3 {
             background-image: -webkit-repeating-linear-gradient(left, red 10%, blue 30%);
         }
+
+        .grad-double-position {
+            background-image: linear-gradient(to right,red 20%, orange 20% 40%, yellow 40% 60%, green 60% 80%, blue 80%)
+        }
     </style>
   </head>
   <body>
@@ -173,6 +177,8 @@
     <div class="box grad-repeat-1"></div>
     <div class="box grad-repeat-2"></div>
     <div class="box grad-repeat-3"></div>
+    <b>Double-position color stops</b><br>
+    <div class="box grad-double-position"></div>
   </body>
   <script>
     const boxes = document.querySelectorAll(".box, .rect");

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1512,8 +1512,9 @@ String LinearGradientStyleValue::to_string() const
         }
 
         serialize_a_srgb_value(builder, element.color_stop.color);
-        if (element.color_stop.length.has_value()) {
-            builder.appendff(" {}"sv, element.color_stop.length->to_string());
+        for (auto position : Array { &element.color_stop.position, &element.color_stop.second_position }) {
+            if (position->has_value())
+                builder.appendff(" {}"sv, (*position)->to_string());
         }
         first = false;
     }
@@ -1537,7 +1538,7 @@ static bool operator==(GradientColorHint a, GradientColorHint b)
 
 static bool operator==(GradientColorStop a, GradientColorStop b)
 {
-    return a.color == b.color && a.length == b.length;
+    return a.color == b.color && a.position == b.position && a.second_position == b.second_position;
 }
 
 static bool operator==(ColorStopListElement a, ColorStopListElement b)

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1612,13 +1612,15 @@ float LinearGradientStyleValue::angle_degrees(Gfx::FloatSize const& gradient_siz
 
 void LinearGradientStyleValue::resolve_for_size(Layout::Node const& node, Gfx::FloatSize const& size) const
 {
-    m_resolved_data = Painting::resolve_linear_gradient_data(node, size, *this);
+    if (m_resolved.has_value() && m_resolved->size == size)
+        return;
+    m_resolved = ResolvedData { Painting::resolve_linear_gradient_data(node, size, *this), size };
 }
 
 void LinearGradientStyleValue::paint(PaintContext& context, Gfx::IntRect const& dest_rect, CSS::ImageRendering) const
 {
-    VERIFY(m_resolved_data.has_value());
-    Painting::paint_linear_gradient(context, dest_rect, *m_resolved_data);
+    VERIFY(m_resolved.has_value());
+    Painting::paint_linear_gradient(context, dest_rect, m_resolved->data);
 }
 
 bool InheritStyleValue::equals(StyleValue const& other) const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1557,8 +1557,12 @@ bool LinearGradientStyleValue::equals(StyleValue const& other_) const
         return false;
     auto& other = other_.as_linear_gradient();
 
-    if (m_direction != other.m_direction || m_color_stop_list.size() != other.m_color_stop_list.size())
+    if (m_gradient_type != other.m_gradient_type
+        || m_repeating != other.m_repeating
+        || m_direction != other.m_direction
+        || m_color_stop_list.size() != other.m_color_stop_list.size()) {
         return false;
+    }
 
     for (size_t i = 0; i < m_color_stop_list.size(); i++) {
         if (m_color_stop_list[i] != other.m_color_stop_list[i])

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -1023,7 +1023,12 @@ private:
     GradientType m_gradient_type;
     Repeating m_repeating;
 
-    mutable Optional<Painting::LinearGradientData> m_resolved_data;
+    struct ResolvedData {
+        Painting::LinearGradientData data;
+        Gfx::FloatSize size;
+    };
+
+    mutable Optional<ResolvedData> m_resolved;
 };
 
 class InheritStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -74,7 +74,8 @@ enum class SideOrCorner {
 
 struct GradientColorStop {
     Color color;
-    Optional<LengthPercentage> length;
+    Optional<LengthPercentage> position;
+    Optional<LengthPercentage> second_position = {};
 };
 
 struct GradientColorHint {

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -49,13 +49,13 @@ LinearGradientData resolve_linear_gradient_data(Layout::Node const& node, Gfx::F
 
     // 1. If the first color stop does not have a position, set its position to 0%.
     auto& first_stop = color_stop_list.first().color_stop;
-    resolved_color_stops.first().position = first_stop.length.has_value()
-        ? first_stop.length->resolved(node, gradient_length).to_px(node)
+    resolved_color_stops.first().position = first_stop.position.has_value()
+        ? first_stop.position->resolved(node, gradient_length).to_px(node)
         : 0;
     //    If the last color stop does not have a position, set its position to 100%
     auto& last_stop = color_stop_list.last().color_stop;
-    resolved_color_stops.last().position = last_stop.length.has_value()
-        ? last_stop.length->resolved(node, gradient_length).to_px(node)
+    resolved_color_stops.last().position = last_stop.position.has_value()
+        ? last_stop.position->resolved(node, gradient_length).to_px(node)
         : gradient_length_px;
 
     // 2. If a color stop or transition hint has a position that is less than the
@@ -71,8 +71,8 @@ LinearGradientData resolve_linear_gradient_data(Layout::Node const& node, Gfx::F
             resolved_color_stops[i].transition_hint = value;
             max_previous_color_stop_or_hint = value;
         }
-        if (stop.color_stop.length.has_value()) {
-            float value = stop.color_stop.length->resolved(node, gradient_length).to_px(node);
+        if (stop.color_stop.position.has_value()) {
+            float value = stop.color_stop.position->resolved(node, gradient_length).to_px(node);
             value = max(value, max_previous_color_stop_or_hint);
             resolved_color_stops[i].position = value;
             max_previous_color_stop_or_hint = value;
@@ -86,7 +86,7 @@ LinearGradientData resolve_linear_gradient_data(Layout::Node const& node, Gfx::F
     size_t i = 1;
     auto find_run_end = [&] {
         auto color_stop_has_position = [](auto& color_stop) {
-            return color_stop.transition_hint.has_value() || color_stop.color_stop.length.has_value();
+            return color_stop.transition_hint.has_value() || color_stop.color_stop.position.has_value();
         };
         while (i < color_stop_list.size() - 1 && !color_stop_has_position(color_stop_list[i])) {
             i++;
@@ -95,7 +95,7 @@ LinearGradientData resolve_linear_gradient_data(Layout::Node const& node, Gfx::F
     };
     while (i < color_stop_list.size() - 1) {
         auto& stop = color_stop_list[i];
-        if (!stop.color_stop.length.has_value()) {
+        if (!stop.color_stop.position.has_value()) {
             auto run_start = i - 1;
             auto start_position = resolved_color_stops[i++].transition_hint.value_or(resolved_color_stops[run_start].position);
             auto run_end = find_run_end();

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.h
@@ -16,7 +16,7 @@ namespace Web::Painting {
 
 struct ColorStop {
     Gfx::Color color;
-    float position = 0;
+    float position = AK::NaN<float>;
     Optional<float> transition_hint = {};
 };
 


### PR DESCRIPTION
This PR adds the final missing `linear-gradient()` feature to LibWeb, double-position color stops, and though I can't find them in the specification, all the cool kids have implemented them so ¯\\\_(ツ)_/¯

![image](https://user-images.githubusercontent.com/11597044/186017135-aad8f4c1-9f8e-4b2a-9fb6-68d8039daddd.png)

(Demo from: https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient#gradient_with_multi-position_color_stops)