### PR TITLE
LibGUI: Fix broken Breadcrumbbar

### DIFF
--- a/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
@@ -84,10 +84,12 @@ void Breadcrumbbar::append_segment(String text, Gfx::Bitmap const* icon, String 
     button.on_click = [this, index = m_segments.size()](auto) {
         if (on_segment_click)
             on_segment_click(index);
+        if (on_segment_change && m_selected_segment != index)
+            on_segment_change(index);
     };
     button.on_focus_change = [this, index = m_segments.size()](auto has_focus, auto) {
-        if (has_focus && on_segment_click)
-            on_segment_click(index);
+        if (has_focus && on_segment_change && m_selected_segment != index)
+            on_segment_change(index);
     };
     button.on_drop = [this, index = m_segments.size()](auto& drop_event) {
         if (on_segment_drop)

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
@@ -136,6 +136,8 @@ Optional<size_t> Breadcrumbbar::find_segment_with_data(String const& data)
 
 void Breadcrumbbar::set_selected_segment(Optional<size_t> index)
 {
+    if (m_selected_segment == index)
+        return;
     m_selected_segment = index;
 
     if (!index.has_value()) {


### PR DESCRIPTION
The changes introduced in #14964 broke clicking on breadcrumbbar buttons or using tab navigation, this pull request fixes this by calling `on_segment_change` in the click and tab navigation handlers.

It also makes `on_segment_change` more predictable by not calling it for no op index changes.