### PR TITLE
CI: Bust the macOS Lagom ccache and reduce its size

### DIFF
--- a/Meta/Azure/Caches.yml
+++ b/Meta/Azure/Caches.yml
@@ -6,6 +6,7 @@ parameters:
   build_directory: ''
   ccache_version: 1 # Increment this number if CI has trouble with ccache.
   serenity_ccache_path: ''
+  serenity_ccache_size: '5G'
   toolchain_ccache_path: ''
   toolchain_ccache_size: $(CCACHE_MAXSIZE)
   with_remote_data_caches: true
@@ -55,7 +56,7 @@ steps:
       displayName: 'Serenity Compiler Cache'
 
     - script: |
-        CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -M 5G
+        CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -M ${{ parameters.serenity_ccache_size }}
         CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -s
       displayName: 'Configure Serenity ccache'
 

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -45,6 +45,9 @@ jobs:
         ${{ if eq(parameters.os, 'Android') }}:
           with_ndk_cache: true
           ndk_version: '$(ndk_version)'
+        ${{ if eq(parameters.os, 'macOS') }}:
+          ccache_version: 2
+          serenity_ccache_size: '2G'
 
     - ${{ if eq(parameters.os, 'Android') }}:
       - script: |


### PR DESCRIPTION
It currently takes upwards of 40 minutes to download the ccache on macOS
and often errors-out near the end. Change the cache version to bust it
so we can start anew. Reduce its max size to 2 GB (a clean build is ~0.9
GB, so this allows just over 2 clean builds to be cached).