### PR TITLE
LibWeb + LibGfx: Optimization for anti-aliased and stroked lines

### DIFF
--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <LibGfx/Painter.h>
+#include <LibGfx/Path.h>
+#include <LibGfx/Quad.h>
 
 namespace Gfx {
 
@@ -81,9 +83,13 @@ private:
     };
     template<AntiAliasPolicy policy>
     void draw_anti_aliased_line(FloatPoint const&, FloatPoint const&, Color, float thickness, Painter::LineStyle style, Color alternate_color);
+    void stroke_segment_intersection(FloatPoint const& current_line_a, FloatPoint const& current_line_b, FloatLine const& previous_line, Color, float thickness);
+    FloatQuad build_rotated_rectangle(FloatPoint const& direction, float width);
 
     Painter& m_underlying_painter;
     AffineTransform m_transform;
+    Path m_intersection_edge_path;
+    Path m_rotated_rectangle_path;
 };
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGContext.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGContext.h
@@ -35,7 +35,7 @@ public:
 
 private:
     struct State {
-        Gfx::Color fill_color { Gfx::Color::Black };
+        Gfx::Color fill_color { Gfx::Color::Transparent };
         Gfx::Color stroke_color { Gfx::Color::Transparent };
         float stroke_width { 1.0 };
     };


### PR DESCRIPTION
This patch address some issues with drawing aa-lines:
- non-straight aa-lines are now drawn with a rotated rectangle to maintain the proper width
- straight aa-lines are now drawn in one go and not plotted for every point on the line
- stroking lines takes care of the intersections between two lines and fills the stroke intil the intersection for those lines

This still does not draw pixel-perfect results but it's at least a better approximation.

SVG-sample page before:

![before](https://user-images.githubusercontent.com/103676658/186229167-0911f038-8eac-45e1-8349-fb916a1a0b5d.PNG)

SVG-sample page now:

![optimized](https://user-images.githubusercontent.com/103676658/186229285-1fbec140-ba9f-425e-8b85-7f2f8212a37a.PNG)

