### PR TITLE
LibWeb+Base: Begin displaying grid

### DIFF
--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -1,0 +1,31 @@
+<style>
+  .grid-container {
+    display: grid;
+    background-color: lightsalmon;
+  }
+  .grid-item {
+    background-color: lightblue;
+  }
+</style>
+
+<!-- A basic grid -->
+<p>Should render a 2x2 grid</p>
+<div 
+  class="grid-container"
+  style="grid-template-columns: auto auto;">
+  <div class="grid-item">1</div>
+  <div class="grid-item">2</div>
+  <div class="grid-item">3</div>  
+  <div class="grid-item">4</div>
+</div>
+
+<!-- Different row heights -->
+<p>Should render a 2x2 grid with the first row having a height of 50px</p>
+<div 
+  class="grid-container"
+  style="grid-template-columns: auto auto;">
+  <div class="grid-item" style="height: 50px;">1</div>
+  <div class="grid-item">2</div>
+  <div class="grid-item">3</div>  
+  <div class="grid-item">4</div>
+</div>

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCES
     CSS/Display.cpp
     CSS/FontFace.cpp
     CSS/Frequency.cpp
+    CSS/GridTrackPlacement.cpp
     CSS/GridTrackSize.cpp
     CSS/Length.cpp
     CSS/MediaList.cpp

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -266,6 +266,7 @@ set(SOURCES
     Layout/FlexFormattingContext.cpp
     Layout/FormattingContext.cpp
     Layout/FrameBox.cpp
+    Layout/GridFormattingContext.cpp
     Layout/ImageBox.cpp
     Layout/InitialContainingBlock.cpp
     Layout/InlineFormattingContext.cpp

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCES
     CSS/Display.cpp
     CSS/FontFace.cpp
     CSS/Frequency.cpp
+    CSS/GridTrackSize.cpp
     CSS/Length.cpp
     CSS/MediaList.cpp
     CSS/MediaQuery.cpp

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -62,6 +62,10 @@ public:
     static CSS::Length max_height() { return CSS::Length::make_auto(); }
     static Vector<CSS::GridTrackSize> grid_template_columns() { return Vector<CSS::GridTrackSize> {}; }
     static Vector<CSS::GridTrackSize> grid_template_rows() { return Vector<CSS::GridTrackSize> {}; }
+    static CSS::GridTrackPlacement grid_column_end() { return CSS::GridTrackPlacement::make_auto(); }
+    static CSS::GridTrackPlacement grid_column_start() { return CSS::GridTrackPlacement::make_auto(); }
+    static CSS::GridTrackPlacement grid_row_end() { return CSS::GridTrackPlacement::make_auto(); }
+    static CSS::GridTrackPlacement grid_row_start() { return CSS::GridTrackPlacement::make_auto(); }
 };
 
 struct BackgroundLayerData {
@@ -174,6 +178,10 @@ public:
     Variant<CSS::VerticalAlign, CSS::LengthPercentage> const& vertical_align() const { return m_noninherited.vertical_align; }
     Vector<CSS::GridTrackSize> const& grid_template_columns() const { return m_noninherited.grid_template_columns; }
     Vector<CSS::GridTrackSize> const& grid_template_rows() const { return m_noninherited.grid_template_rows; }
+    CSS::GridTrackPlacement const& grid_column_end() const { return m_noninherited.grid_column_end; }
+    CSS::GridTrackPlacement const& grid_column_start() const { return m_noninherited.grid_column_start; }
+    CSS::GridTrackPlacement const& grid_row_end() const { return m_noninherited.grid_row_end; }
+    CSS::GridTrackPlacement const& grid_row_start() const { return m_noninherited.grid_row_start; }
 
     CSS::LengthBox const& inset() const { return m_noninherited.inset; }
     const CSS::LengthBox& margin() const { return m_noninherited.margin; }
@@ -290,6 +298,10 @@ protected:
         Variant<CSS::VerticalAlign, CSS::LengthPercentage> vertical_align { InitialValues::vertical_align() };
         Vector<CSS::GridTrackSize> grid_template_columns;
         Vector<CSS::GridTrackSize> grid_template_rows;
+        CSS::GridTrackPlacement grid_column_end { InitialValues::grid_column_end() };
+        CSS::GridTrackPlacement grid_column_start { InitialValues::grid_column_start() };
+        CSS::GridTrackPlacement grid_row_end { InitialValues::grid_row_end() };
+        CSS::GridTrackPlacement grid_row_start { InitialValues::grid_row_start() };
     } m_noninherited;
 };
 
@@ -362,6 +374,10 @@ public:
     void set_visibility(CSS::Visibility value) { m_inherited.visibility = value; }
     void set_grid_template_columns(Vector<CSS::GridTrackSize> value) { m_noninherited.grid_template_columns = value; }
     void set_grid_template_rows(Vector<CSS::GridTrackSize> value) { m_noninherited.grid_template_rows = value; }
+    void set_grid_column_end(CSS::GridTrackPlacement value) { m_noninherited.grid_column_end = value; }
+    void set_grid_column_start(CSS::GridTrackPlacement value) { m_noninherited.grid_column_start = value; }
+    void set_grid_row_end(CSS::GridTrackPlacement value) { m_noninherited.grid_row_end = value; }
+    void set_grid_row_start(CSS::GridTrackPlacement value) { m_noninherited.grid_row_start = value; }
 
     void set_fill(Color value) { m_inherited.fill = value; }
     void set_stroke(Color value) { m_inherited.stroke = value; }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -60,6 +60,8 @@ public:
     static CSS::Length height() { return CSS::Length::make_auto(); }
     static CSS::Length min_height() { return CSS::Length::make_auto(); }
     static CSS::Length max_height() { return CSS::Length::make_auto(); }
+    static Vector<CSS::GridTrackSize> grid_template_columns() { return Vector<CSS::GridTrackSize> {}; }
+    static Vector<CSS::GridTrackSize> grid_template_rows() { return Vector<CSS::GridTrackSize> {}; }
 };
 
 struct BackgroundLayerData {
@@ -170,6 +172,8 @@ public:
     CSS::LengthPercentage const& min_height() const { return m_noninherited.min_height; }
     CSS::LengthPercentage const& max_height() const { return m_noninherited.max_height; }
     Variant<CSS::VerticalAlign, CSS::LengthPercentage> const& vertical_align() const { return m_noninherited.vertical_align; }
+    Vector<CSS::GridTrackSize> const& grid_template_columns() const { return m_noninherited.grid_template_columns; }
+    Vector<CSS::GridTrackSize> const& grid_template_rows() const { return m_noninherited.grid_template_rows; }
 
     CSS::LengthBox const& inset() const { return m_noninherited.inset; }
     const CSS::LengthBox& margin() const { return m_noninherited.margin; }
@@ -284,6 +288,8 @@ protected:
         CSS::BoxSizing box_sizing { InitialValues::box_sizing() };
         CSS::ContentData content;
         Variant<CSS::VerticalAlign, CSS::LengthPercentage> vertical_align { InitialValues::vertical_align() };
+        Vector<CSS::GridTrackSize> grid_template_columns;
+        Vector<CSS::GridTrackSize> grid_template_rows;
     } m_noninherited;
 };
 
@@ -354,6 +360,8 @@ public:
     void set_box_sizing(CSS::BoxSizing value) { m_noninherited.box_sizing = value; }
     void set_vertical_align(Variant<CSS::VerticalAlign, CSS::LengthPercentage> value) { m_noninherited.vertical_align = value; }
     void set_visibility(CSS::Visibility value) { m_inherited.visibility = value; }
+    void set_grid_template_columns(Vector<CSS::GridTrackSize> value) { m_noninherited.grid_template_columns = value; }
+    void set_grid_template_rows(Vector<CSS::GridTrackSize> value) { m_noninherited.grid_template_rows = value; }
 
     void set_fill(Color value) { m_inherited.fill = value; }
     void set_stroke(Color value) { m_inherited.stroke = value; }

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022, Martin Falisse <mfalisse@outlook.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GridTrackPlacement.h"
+#include <AK/String.h>
+
+namespace Web::CSS {
+
+GridTrackPlacement::GridTrackPlacement(int position, bool has_span)
+    : m_position(position)
+    , m_has_span(has_span)
+{
+}
+
+GridTrackPlacement::GridTrackPlacement(int position)
+    : m_position(position)
+{
+}
+
+GridTrackPlacement::GridTrackPlacement()
+{
+}
+
+String GridTrackPlacement::to_string() const
+{
+    StringBuilder builder;
+    if (m_has_span)
+        builder.append("span "sv);
+    builder.append(String::number(m_position));
+    return builder.to_string();
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, Martin Falisse <mfalisse@outlook.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+
+namespace Web::CSS {
+
+class GridTrackPlacement {
+public:
+    GridTrackPlacement(int, bool);
+    GridTrackPlacement(int);
+    GridTrackPlacement();
+
+    static GridTrackPlacement make_auto() { return GridTrackPlacement(); };
+
+    void set_position(int position) { m_position = position; }
+    int position() const { return m_position; }
+
+    void set_has_span(bool has_span) { m_has_span = has_span; }
+    bool has_span() const { return m_has_span; }
+
+    String to_string() const;
+    bool operator==(GridTrackPlacement const& other) const
+    {
+        return m_position == other.position() && m_has_span == other.has_span();
+    }
+
+private:
+    int m_position { 0 };
+    bool m_has_span { false };
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Martin Falisse <mfalisse@outlook.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GridTrackSize.h"
+#include <AK/String.h>
+#include <LibWeb/CSS/Length.h>
+#include <LibWeb/CSS/Percentage.h>
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+GridTrackSize::GridTrackSize(Length length)
+    : m_type(Type::Length)
+    , m_length(length)
+{
+}
+
+GridTrackSize::GridTrackSize(Percentage percentage)
+    : m_type(Type::Percentage)
+    , m_percentage(percentage)
+{
+}
+
+GridTrackSize::GridTrackSize(int flexible_length)
+    : m_type(Type::FlexibleLength)
+    , m_flexible_length(flexible_length)
+{
+}
+
+String GridTrackSize::to_string() const
+{
+    switch (m_type) {
+    case Type::Length:
+        return m_length.to_string();
+    case Type::Percentage:
+        return m_percentage.to_string();
+    case Type::FlexibleLength:
+        return String::formatted("{}fr", m_flexible_length);
+    }
+    VERIFY_NOT_REACHED();
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, Martin Falisse <mfalisse@outlook.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/Length.h>
+#include <LibWeb/CSS/Percentage.h>
+
+namespace Web::CSS {
+
+class GridTrackSize {
+public:
+    enum class Type {
+        Length,
+        Percentage,
+        FlexibleLength,
+        // TODO: MinMax
+        // TODO: Repeat
+        // TODO: Max-Content
+    };
+
+    GridTrackSize(Length);
+    GridTrackSize(Percentage);
+    GridTrackSize(int);
+
+    Type type() const { return m_type; }
+
+    bool is_length() const { return m_type == Type::Length; }
+    bool is_percentage() const { return m_type == Type::Percentage; }
+    bool is_flexible_length() const { return m_type == Type::FlexibleLength; }
+
+    Length length() const { return m_length; }
+    Percentage percentage() const { return m_percentage; }
+    int flexible_length() const { return m_flexible_length; }
+
+    String to_string() const;
+    bool operator==(GridTrackSize const& other) const
+    {
+        return m_type == other.type()
+            && m_length == other.length()
+            && m_percentage == other.percentage()
+            && m_flexible_length == other.flexible_length();
+    }
+
+private:
+    Type m_type;
+    Length m_length { Length::make_px(0) };
+    Percentage m_percentage { Percentage(0) };
+    int m_flexible_length { 0 };
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5352,6 +5352,46 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement(Vector<ComponentValue> con
     return {};
 }
 
+RefPtr<StyleValue> Parser::parse_grid_track_placement_shorthand_value(Vector<ComponentValue> const& component_values)
+{
+    auto tokens = TokenStream { component_values };
+    auto current_token = tokens.next_token().token();
+
+    if (!tokens.has_next_token()) {
+        if (current_token.to_string() == "auto"sv)
+            return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement::make_auto());
+        if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
+            return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement(current_token.number_value()));
+        return {};
+    }
+
+    auto calculate_grid_track_placement = [](auto& current_token, auto& tokens) -> CSS::GridTrackPlacement {
+        auto grid_track_placement = CSS::GridTrackPlacement();
+        if (current_token.to_string() == "span"sv) {
+            grid_track_placement.set_has_span(true);
+            tokens.skip_whitespace();
+            current_token = tokens.next_token().token();
+        }
+        if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
+            grid_track_placement.set_position(static_cast<int>(current_token.number_value()));
+        return grid_track_placement;
+    };
+
+    auto first_grid_track_placement = calculate_grid_track_placement(current_token, tokens);
+    if (!tokens.has_next_token())
+        return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement(first_grid_track_placement));
+
+    tokens.skip_whitespace();
+    current_token = tokens.next_token().token();
+    tokens.skip_whitespace();
+    current_token = tokens.next_token().token();
+
+    auto second_grid_track_placement = calculate_grid_track_placement(current_token, tokens);
+    if (!tokens.has_next_token())
+        return GridTrackPlacementShorthandStyleValue::create(GridTrackPlacementStyleValue::create(first_grid_track_placement), GridTrackPlacementStyleValue::create(second_grid_track_placement));
+    return {};
+}
+
 Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(PropertyID property_id, TokenStream<ComponentValue>& tokens)
 {
     auto function_contains_var_or_attr = [](Function const& function, auto&& recurse) -> bool {
@@ -5482,12 +5522,20 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
         if (auto parsed_value = parse_font_family_value(component_values))
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
+    case PropertyID::GridColumn:
+        if (auto parsed_value = parse_grid_track_placement_shorthand_value(component_values))
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
     case PropertyID::GridColumnEnd:
         if (auto parsed_value = parse_grid_track_placement(component_values))
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::GridColumnStart:
         if (auto parsed_value = parse_grid_track_placement(component_values))
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
+    case PropertyID::GridRow:
+        if (auto parsed_value = parse_grid_track_placement_shorthand_value(component_values))
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::GridRowEnd:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5325,6 +5325,33 @@ RefPtr<StyleValue> Parser::parse_grid_track_sizes(Vector<ComponentValue> const& 
     return GridTrackSizeStyleValue::create(params);
 }
 
+RefPtr<StyleValue> Parser::parse_grid_track_placement(Vector<ComponentValue> const& component_values)
+{
+    auto tokens = TokenStream { component_values };
+    auto current_token = tokens.next_token().token();
+
+    if (!tokens.has_next_token()) {
+        if (current_token.to_string() == "auto"sv)
+            return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement());
+        if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
+            return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement(static_cast<int>(current_token.number_value())));
+        return {};
+    }
+
+    auto first_grid_track_placement = CSS::GridTrackPlacement();
+    if (current_token.to_string() == "span"sv) {
+        first_grid_track_placement.set_has_span(true);
+        tokens.skip_whitespace();
+        current_token = tokens.next_token().token();
+    }
+    if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
+        first_grid_track_placement.set_position(static_cast<int>(current_token.number_value()));
+
+    if (!tokens.has_next_token())
+        return GridTrackPlacementStyleValue::create(first_grid_track_placement);
+    return {};
+}
+
 Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(PropertyID property_id, TokenStream<ComponentValue>& tokens)
 {
     auto function_contains_var_or_attr = [](Function const& function, auto&& recurse) -> bool {
@@ -5453,6 +5480,22 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
         return ParseError::SyntaxError;
     case PropertyID::FontFamily:
         if (auto parsed_value = parse_font_family_value(component_values))
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
+    case PropertyID::GridColumnEnd:
+        if (auto parsed_value = parse_grid_track_placement(component_values))
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
+    case PropertyID::GridColumnStart:
+        if (auto parsed_value = parse_grid_track_placement(component_values))
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
+    case PropertyID::GridRowEnd:
+        if (auto parsed_value = parse_grid_track_placement(component_values))
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
+    case PropertyID::GridRowStart:
+        if (auto parsed_value = parse_grid_track_placement(component_values))
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::GridTemplateColumns:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -361,6 +361,7 @@ private:
     RefPtr<StyleValue> parse_transform_origin_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_sizes(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_placement(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_track_placement_shorthand_value(Vector<ComponentValue> const&);
 
     // calc() parsing, according to https://www.w3.org/TR/css-values-3/#calc-syntax
     OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -360,6 +360,7 @@ private:
     RefPtr<StyleValue> parse_transform_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_transform_origin_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_sizes(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_track_placement(Vector<ComponentValue> const&);
 
     // calc() parsing, according to https://www.w3.org/TR/css-values-3/#calc-syntax
     OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -359,6 +359,7 @@ private:
     RefPtr<StyleValue> parse_text_decoration_line_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_transform_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_transform_origin_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_track_sizes(Vector<ComponentValue> const&);
 
     // calc() parsing, according to https://www.w3.org/TR/css-values-3/#calc-syntax
     OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -528,6 +528,7 @@
     "valid-identifiers": [
       "block",
       "flex",
+      "grid",
       "inline",
       "inline-block",
       "inline-flex",

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -694,6 +694,20 @@
       "normal"
     ]
   },
+  "grid-column": {
+    "inherited": false,
+    "initial": "auto",
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "string"
+    ],
+    "longhands": [
+      "grid-column-end",
+      "grid-column-start"
+    ]
+  },
   "grid-column-end": {
     "inherited": false,
     "initial": "auto",
@@ -712,6 +726,20 @@
     ],
     "valid-types": [
       "string"
+    ]
+  },
+  "grid-row": {
+    "inherited": false,
+    "initial": "auto",
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "string"
+    ],
+    "longhands": [
+      "grid-row-end",
+      "grid-row-start"
     ]
   },
   "grid-row-end": {

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -694,6 +694,32 @@
       "normal"
     ]
   },
+  "grid-template-columns": {
+    "inherited": false,
+    "initial": "auto",
+    "max-values": 4,
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "length",
+      "percentage",
+      "string"
+    ]
+  },
+  "grid-template-rows": {
+    "inherited": false,
+    "initial": "auto",
+    "max-values": 4,
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "length",
+      "percentage",
+      "string"
+    ]
+  },
   "height": {
     "inherited": false,
     "initial": "auto",

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -694,6 +694,46 @@
       "normal"
     ]
   },
+  "grid-column-end": {
+    "inherited": false,
+    "initial": "auto",
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "string"
+    ]
+  },
+  "grid-column-start": {
+    "inherited": false,
+    "initial": "auto",
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "string"
+    ]
+  },
+  "grid-row-end": {
+    "inherited": false,
+    "initial": "auto",
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "string"
+    ]
+  },
+  "grid-row-start": {
+    "inherited": false,
+    "initial": "auto",
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "string"
+    ]
+  },
   "grid-template-columns": {
     "inherited": false,
     "initial": "auto",

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -295,10 +295,38 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_wrap()));
     case CSS::PropertyID::Float:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().float_()));
+    case CSS::PropertyID::GridColumn: {
+        auto maybe_grid_column_end = property(CSS::PropertyID::GridColumnEnd);
+        auto maybe_grid_column_start = property(CSS::PropertyID::GridColumnStart);
+        RefPtr<GridTrackPlacementStyleValue> grid_column_start, grid_column_end;
+        if (maybe_grid_column_end.has_value()) {
+            VERIFY(maybe_grid_column_end.value().value->is_grid_track_placement());
+            grid_column_end = maybe_grid_column_end.value().value->as_grid_track_placement();
+        }
+        if (maybe_grid_column_start.has_value()) {
+            VERIFY(maybe_grid_column_start.value().value->is_grid_track_placement());
+            grid_column_start = maybe_grid_column_start.value().value->as_grid_track_placement();
+        }
+        return GridTrackPlacementShorthandStyleValue::create(grid_column_end.release_nonnull(), grid_column_start.release_nonnull());
+    }
     case CSS::PropertyID::GridColumnEnd:
         return GridTrackPlacementStyleValue::create(layout_node.computed_values().grid_column_end());
     case CSS::PropertyID::GridColumnStart:
         return GridTrackPlacementStyleValue::create(layout_node.computed_values().grid_column_start());
+    case CSS::PropertyID::GridRow: {
+        auto maybe_grid_row_end = property(CSS::PropertyID::GridRowEnd);
+        auto maybe_grid_row_start = property(CSS::PropertyID::GridRowStart);
+        RefPtr<GridTrackPlacementStyleValue> grid_row_start, grid_row_end;
+        if (maybe_grid_row_end.has_value()) {
+            VERIFY(maybe_grid_row_end.value().value->is_grid_track_placement());
+            grid_row_end = maybe_grid_row_end.value().value->as_grid_track_placement();
+        }
+        if (maybe_grid_row_start.has_value()) {
+            VERIFY(maybe_grid_row_start.value().value->is_grid_track_placement());
+            grid_row_start = maybe_grid_row_start.value().value->as_grid_track_placement();
+        }
+        return GridTrackPlacementShorthandStyleValue::create(grid_row_end.release_nonnull(), grid_row_start.release_nonnull());
+    }
     case CSS::PropertyID::GridRowEnd:
         return GridTrackPlacementStyleValue::create(layout_node.computed_values().grid_row_end());
     case CSS::PropertyID::GridRowStart:

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -295,6 +295,14 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_wrap()));
     case CSS::PropertyID::Float:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().float_()));
+    case CSS::PropertyID::GridColumnEnd:
+        return GridTrackPlacementStyleValue::create(layout_node.computed_values().grid_column_end());
+    case CSS::PropertyID::GridColumnStart:
+        return GridTrackPlacementStyleValue::create(layout_node.computed_values().grid_column_start());
+    case CSS::PropertyID::GridRowEnd:
+        return GridTrackPlacementStyleValue::create(layout_node.computed_values().grid_row_end());
+    case CSS::PropertyID::GridRowStart:
+        return GridTrackPlacementStyleValue::create(layout_node.computed_values().grid_row_start());
     case CSS::PropertyID::GridTemplateColumns:
         return GridTrackSizeStyleValue::create(layout_node.computed_values().grid_template_columns());
     case CSS::PropertyID::GridTemplateRows:

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -295,6 +295,10 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_wrap()));
     case CSS::PropertyID::Float:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().float_()));
+    case CSS::PropertyID::GridTemplateColumns:
+        return GridTrackSizeStyleValue::create(layout_node.computed_values().grid_template_columns());
+    case CSS::PropertyID::GridTemplateRows:
+        return GridTrackSizeStyleValue::create(layout_node.computed_values().grid_template_rows());
     case CSS::PropertyID::Height:
         return style_value_for_length_percentage(layout_node.computed_values().height());
     case CSS::PropertyID::ImageRendering:

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -517,6 +517,32 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         return;
     }
 
+    if (property_id == CSS::PropertyID::GridColumn) {
+        if (value.is_grid_track_placement_shorthand()) {
+            auto const& shorthand = value.as_grid_track_placement_shorthand();
+            style.set_property(CSS::PropertyID::GridColumnStart, shorthand.start());
+            style.set_property(CSS::PropertyID::GridColumnEnd, shorthand.end());
+            return;
+        }
+
+        style.set_property(CSS::PropertyID::GridColumnStart, value);
+        style.set_property(CSS::PropertyID::GridColumnEnd, value);
+        return;
+    }
+
+    if (property_id == CSS::PropertyID::GridRow) {
+        if (value.is_grid_track_placement_shorthand()) {
+            auto const& shorthand = value.as_grid_track_placement_shorthand();
+            style.set_property(CSS::PropertyID::GridRowStart, shorthand.start());
+            style.set_property(CSS::PropertyID::GridRowEnd, shorthand.end());
+            return;
+        }
+
+        style.set_property(CSS::PropertyID::GridRowStart, value);
+        style.set_property(CSS::PropertyID::GridRowEnd, value);
+        return;
+    }
+
     style.set_property(property_id, value);
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -530,6 +530,8 @@ CSS::Display StyleProperties::display() const
         return CSS::Display::from_short(CSS::Display::Short::Flex);
     case CSS::ValueID::InlineFlex:
         return CSS::Display::from_short(CSS::Display::Short::InlineFlex);
+    case CSS::ValueID::Grid:
+        return CSS::Display::from_short(CSS::Display::Short::Grid);
     default:
         return CSS::Display::from_short(CSS::Display::Short::Block);
     }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -667,4 +667,28 @@ Vector<CSS::GridTrackSize> StyleProperties::grid_template_rows() const
     return value->as_grid_track_size().grid_track_size();
 }
 
+CSS::GridTrackPlacement StyleProperties::grid_column_end() const
+{
+    auto value = property(CSS::PropertyID::GridColumnEnd);
+    return value->as_grid_track_placement().grid_track_placement();
+}
+
+CSS::GridTrackPlacement StyleProperties::grid_column_start() const
+{
+    auto value = property(CSS::PropertyID::GridColumnStart);
+    return value->as_grid_track_placement().grid_track_placement();
+}
+
+CSS::GridTrackPlacement StyleProperties::grid_row_end() const
+{
+    auto value = property(CSS::PropertyID::GridRowEnd);
+    return value->as_grid_track_placement().grid_track_placement();
+}
+
+CSS::GridTrackPlacement StyleProperties::grid_row_start() const
+{
+    auto value = property(CSS::PropertyID::GridRowStart);
+    return value->as_grid_track_placement().grid_track_placement();
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -655,4 +655,16 @@ Optional<CSS::FontVariant> StyleProperties::font_variant() const
     return value_id_to_font_variant(value->to_identifier());
 }
 
+Vector<CSS::GridTrackSize> StyleProperties::grid_template_columns() const
+{
+    auto value = property(CSS::PropertyID::GridTemplateColumns);
+    return value->as_grid_track_size().grid_track_size();
+}
+
+Vector<CSS::GridTrackSize> StyleProperties::grid_template_rows() const
+{
+    auto value = property(CSS::PropertyID::GridTemplateRows);
+    return value->as_grid_track_size().grid_track_size();
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -83,6 +83,10 @@ public:
     Optional<CSS::FontVariant> font_variant() const;
     Vector<CSS::GridTrackSize> grid_template_columns() const;
     Vector<CSS::GridTrackSize> grid_template_rows() const;
+    CSS::GridTrackPlacement grid_column_end() const;
+    CSS::GridTrackPlacement grid_column_start() const;
+    CSS::GridTrackPlacement grid_row_end() const;
+    CSS::GridTrackPlacement grid_row_start() const;
 
     Vector<CSS::Transformation> transformations() const;
     CSS::TransformOrigin transform_origin() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -81,6 +81,8 @@ public:
     Optional<CSS::PointerEvents> pointer_events() const;
     Variant<CSS::VerticalAlign, CSS::LengthPercentage> vertical_align() const;
     Optional<CSS::FontVariant> font_variant() const;
+    Vector<CSS::GridTrackSize> grid_template_columns() const;
+    Vector<CSS::GridTrackSize> grid_template_rows() const;
 
     Vector<CSS::Transformation> transformations() const;
     CSS::TransformOrigin transform_origin() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -120,6 +120,12 @@ FrequencyStyleValue const& StyleValue::as_frequency() const
     return static_cast<FrequencyStyleValue const&>(*this);
 }
 
+GridTrackPlacementStyleValue const& StyleValue::as_grid_track_placement() const
+{
+    VERIFY(is_grid_track_placement());
+    return static_cast<GridTrackPlacementStyleValue const&>(*this);
+}
+
 IdentifierStyleValue const& StyleValue::as_identifier() const
 {
     VERIFY(is_identifier());
@@ -1204,6 +1210,19 @@ bool FrequencyStyleValue::equals(StyleValue const& other) const
     return m_frequency == other.as_frequency().m_frequency;
 }
 
+String GridTrackPlacementStyleValue::to_string() const
+{
+    return m_grid_track_placement.to_string();
+}
+
+bool GridTrackPlacementStyleValue::equals(StyleValue const& other) const
+{
+    if (type() != other.type())
+        return false;
+    auto const& typed_other = other.as_grid_track_placement();
+    return m_grid_track_placement == typed_other.grid_track_placement();
+}
+
 String GridTrackSizeStyleValue::to_string() const
 {
     StringBuilder builder;
@@ -1929,6 +1948,11 @@ NonnullRefPtr<ColorStyleValue> ColorStyleValue::create(Color color)
     }
 
     return adopt_ref(*new ColorStyleValue(color));
+}
+
+NonnullRefPtr<GridTrackPlacementStyleValue> GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement grid_track_placement)
+{
+    return adopt_ref(*new GridTrackPlacementStyleValue(grid_track_placement));
 }
 
 NonnullRefPtr<GridTrackSizeStyleValue> GridTrackSizeStyleValue::create(Vector<CSS::GridTrackSize> grid_track_size)

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -120,6 +120,12 @@ FrequencyStyleValue const& StyleValue::as_frequency() const
     return static_cast<FrequencyStyleValue const&>(*this);
 }
 
+GridTrackPlacementShorthandStyleValue const& StyleValue::as_grid_track_placement_shorthand() const
+{
+    VERIFY(is_grid_track_placement_shorthand());
+    return static_cast<GridTrackPlacementShorthandStyleValue const&>(*this);
+}
+
 GridTrackPlacementStyleValue const& StyleValue::as_grid_track_placement() const
 {
     VERIFY(is_grid_track_placement());
@@ -1208,6 +1214,22 @@ bool FrequencyStyleValue::equals(StyleValue const& other) const
     if (type() != other.type())
         return false;
     return m_frequency == other.as_frequency().m_frequency;
+}
+
+String GridTrackPlacementShorthandStyleValue::to_string() const
+{
+    if (m_end->grid_track_placement().position() == 0)
+        return String::formatted("{}", m_start->grid_track_placement().to_string());
+    return String::formatted("{} / {}", m_start->grid_track_placement().to_string(), m_end->grid_track_placement().to_string());
+}
+
+bool GridTrackPlacementShorthandStyleValue::equals(StyleValue const& other) const
+{
+    if (type() != other.type())
+        return false;
+    auto const& typed_other = other.as_grid_track_placement_shorthand();
+    return m_start->equals(typed_other.m_start)
+        && m_end->equals(typed_other.m_end);
 }
 
 String GridTrackPlacementStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -150,6 +150,12 @@ LengthStyleValue const& StyleValue::as_length() const
     return static_cast<LengthStyleValue const&>(*this);
 }
 
+GridTrackSizeStyleValue const& StyleValue::as_grid_track_size() const
+{
+    VERIFY(is_grid_track_size());
+    return static_cast<GridTrackSizeStyleValue const&>(*this);
+}
+
 LinearGradientStyleValue const& StyleValue::as_linear_gradient() const
 {
     VERIFY(is_linear_gradient());
@@ -1198,6 +1204,25 @@ bool FrequencyStyleValue::equals(StyleValue const& other) const
     return m_frequency == other.as_frequency().m_frequency;
 }
 
+String GridTrackSizeStyleValue::to_string() const
+{
+    StringBuilder builder;
+    for (size_t i = 0; i < m_grid_track.size(); i++) {
+        builder.append(m_grid_track[i].to_string());
+        if (i != m_grid_track.size() - 1)
+            builder.append(" "sv);
+    }
+    return builder.to_string();
+}
+
+bool GridTrackSizeStyleValue::equals(StyleValue const& other) const
+{
+    if (type() != other.type())
+        return false;
+    auto const& typed_other = other.as_grid_track_size();
+    return m_grid_track == typed_other.grid_track_size();
+}
+
 String IdentifierStyleValue::to_string() const
 {
     return CSS::string_from_value_id(m_id);
@@ -1904,6 +1929,11 @@ NonnullRefPtr<ColorStyleValue> ColorStyleValue::create(Color color)
     }
 
     return adopt_ref(*new ColorStyleValue(color));
+}
+
+NonnullRefPtr<GridTrackSizeStyleValue> GridTrackSizeStyleValue::create(Vector<CSS::GridTrackSize> grid_track_size)
+{
+    return adopt_ref(*new GridTrackSizeStyleValue(grid_track_size));
 }
 
 NonnullRefPtr<RectStyleValue> RectStyleValue::create(EdgeRect rect)

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -28,6 +28,7 @@
 #include <LibWeb/CSS/Display.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/Frequency.h>
+#include <LibWeb/CSS/GridTrackSize.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/Number.h>
 #include <LibWeb/CSS/Parser/ComponentValue.h>
@@ -130,6 +131,7 @@ public:
         FlexFlow,
         Font,
         Frequency,
+        GridTrackSize,
         Identifier,
         Image,
         Inherit,
@@ -171,6 +173,7 @@ public:
     bool is_flex_flow() const { return type() == Type::FlexFlow; }
     bool is_font() const { return type() == Type::Font; }
     bool is_frequency() const { return type() == Type::Frequency; }
+    bool is_grid_track_size() const { return type() == Type::GridTrackSize; }
     bool is_identifier() const { return type() == Type::Identifier; }
     bool is_image() const { return type() == Type::Image; }
     bool is_inherit() const { return type() == Type::Inherit; }
@@ -210,6 +213,7 @@ public:
     FlexStyleValue const& as_flex() const;
     FontStyleValue const& as_font() const;
     FrequencyStyleValue const& as_frequency() const;
+    GridTrackSizeStyleValue const& as_grid_track_size() const;
     IdentifierStyleValue const& as_identifier() const;
     ImageStyleValue const& as_image() const;
     InheritStyleValue const& as_inherit() const;
@@ -247,6 +251,7 @@ public:
     FlexStyleValue& as_flex() { return const_cast<FlexStyleValue&>(const_cast<StyleValue const&>(*this).as_flex()); }
     FontStyleValue& as_font() { return const_cast<FontStyleValue&>(const_cast<StyleValue const&>(*this).as_font()); }
     FrequencyStyleValue& as_frequency() { return const_cast<FrequencyStyleValue&>(const_cast<StyleValue const&>(*this).as_frequency()); }
+    GridTrackSizeStyleValue& as_grid_track_size() { return const_cast<GridTrackSizeStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_track_size()); }
     IdentifierStyleValue& as_identifier() { return const_cast<IdentifierStyleValue&>(const_cast<StyleValue const&>(*this).as_identifier()); }
     ImageStyleValue& as_image() { return const_cast<ImageStyleValue&>(const_cast<StyleValue const&>(*this).as_image()); }
     InheritStyleValue& as_inherit() { return const_cast<InheritStyleValue&>(const_cast<StyleValue const&>(*this).as_inherit()); }
@@ -895,6 +900,25 @@ private:
     }
 
     Frequency m_frequency;
+};
+
+class GridTrackSizeStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<GridTrackSizeStyleValue> create(Vector<CSS::GridTrackSize> grid_track_size);
+    virtual ~GridTrackSizeStyleValue() override = default;
+
+    Vector<CSS::GridTrackSize> grid_track_size() const { return m_grid_track; }
+    virtual String to_string() const override;
+    virtual bool equals(StyleValue const& other) const override;
+
+private:
+    explicit GridTrackSizeStyleValue(Vector<CSS::GridTrackSize> grid_track_size)
+        : StyleValue(Type::GridTrackSize)
+        , m_grid_track(grid_track_size)
+    {
+    }
+
+    Vector<CSS::GridTrackSize> m_grid_track;
 };
 
 class IdentifierStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -133,6 +133,7 @@ public:
         Font,
         Frequency,
         GridTrackPlacement,
+        GridTrackPlacementShorthand,
         GridTrackSize,
         Identifier,
         Image,
@@ -176,6 +177,7 @@ public:
     bool is_font() const { return type() == Type::Font; }
     bool is_frequency() const { return type() == Type::Frequency; }
     bool is_grid_track_placement() const { return type() == Type::GridTrackPlacement; }
+    bool is_grid_track_placement_shorthand() const { return type() == Type::GridTrackPlacementShorthand; }
     bool is_grid_track_size() const { return type() == Type::GridTrackSize; }
     bool is_identifier() const { return type() == Type::Identifier; }
     bool is_image() const { return type() == Type::Image; }
@@ -216,6 +218,7 @@ public:
     FlexStyleValue const& as_flex() const;
     FontStyleValue const& as_font() const;
     FrequencyStyleValue const& as_frequency() const;
+    GridTrackPlacementShorthandStyleValue const& as_grid_track_placement_shorthand() const;
     GridTrackPlacementStyleValue const& as_grid_track_placement() const;
     GridTrackSizeStyleValue const& as_grid_track_size() const;
     IdentifierStyleValue const& as_identifier() const;
@@ -255,6 +258,7 @@ public:
     FlexStyleValue& as_flex() { return const_cast<FlexStyleValue&>(const_cast<StyleValue const&>(*this).as_flex()); }
     FontStyleValue& as_font() { return const_cast<FontStyleValue&>(const_cast<StyleValue const&>(*this).as_font()); }
     FrequencyStyleValue& as_frequency() { return const_cast<FrequencyStyleValue&>(const_cast<StyleValue const&>(*this).as_frequency()); }
+    GridTrackPlacementShorthandStyleValue& as_grid_track_placement_shorthand() { return const_cast<GridTrackPlacementShorthandStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_track_placement_shorthand()); }
     GridTrackPlacementStyleValue& as_grid_track_placement() { return const_cast<GridTrackPlacementStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_track_placement()); }
     GridTrackSizeStyleValue& as_grid_track_size() { return const_cast<GridTrackSizeStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_track_size()); }
     IdentifierStyleValue& as_identifier() { return const_cast<IdentifierStyleValue&>(const_cast<StyleValue const&>(*this).as_identifier()); }
@@ -924,6 +928,36 @@ private:
     }
 
     CSS::GridTrackPlacement m_grid_track_placement;
+};
+
+class GridTrackPlacementShorthandStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<GridTrackPlacementShorthandStyleValue> create(NonnullRefPtr<GridTrackPlacementStyleValue> start, NonnullRefPtr<GridTrackPlacementStyleValue> end)
+    {
+        return adopt_ref(*new GridTrackPlacementShorthandStyleValue(start, end));
+    }
+    static NonnullRefPtr<GridTrackPlacementShorthandStyleValue> create(GridTrackPlacement start)
+    {
+        return adopt_ref(*new GridTrackPlacementShorthandStyleValue(GridTrackPlacementStyleValue::create(start), GridTrackPlacementStyleValue::create(GridTrackPlacement::make_auto())));
+    }
+    virtual ~GridTrackPlacementShorthandStyleValue() override = default;
+
+    NonnullRefPtr<GridTrackPlacementStyleValue> start() const { return m_start; }
+    NonnullRefPtr<GridTrackPlacementStyleValue> end() const { return m_end; }
+
+    virtual String to_string() const override;
+    virtual bool equals(StyleValue const& other) const override;
+
+private:
+    GridTrackPlacementShorthandStyleValue(NonnullRefPtr<GridTrackPlacementStyleValue> start, NonnullRefPtr<GridTrackPlacementStyleValue> end)
+        : StyleValue(Type::GridTrackPlacementShorthand)
+        , m_start(start)
+        , m_end(end)
+    {
+    }
+
+    NonnullRefPtr<GridTrackPlacementStyleValue> m_start;
+    NonnullRefPtr<GridTrackPlacementStyleValue> m_end;
 };
 
 class GridTrackSizeStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -28,6 +28,7 @@
 #include <LibWeb/CSS/Display.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/Frequency.h>
+#include <LibWeb/CSS/GridTrackPlacement.h>
 #include <LibWeb/CSS/GridTrackSize.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/Number.h>
@@ -131,6 +132,7 @@ public:
         FlexFlow,
         Font,
         Frequency,
+        GridTrackPlacement,
         GridTrackSize,
         Identifier,
         Image,
@@ -173,6 +175,7 @@ public:
     bool is_flex_flow() const { return type() == Type::FlexFlow; }
     bool is_font() const { return type() == Type::Font; }
     bool is_frequency() const { return type() == Type::Frequency; }
+    bool is_grid_track_placement() const { return type() == Type::GridTrackPlacement; }
     bool is_grid_track_size() const { return type() == Type::GridTrackSize; }
     bool is_identifier() const { return type() == Type::Identifier; }
     bool is_image() const { return type() == Type::Image; }
@@ -213,6 +216,7 @@ public:
     FlexStyleValue const& as_flex() const;
     FontStyleValue const& as_font() const;
     FrequencyStyleValue const& as_frequency() const;
+    GridTrackPlacementStyleValue const& as_grid_track_placement() const;
     GridTrackSizeStyleValue const& as_grid_track_size() const;
     IdentifierStyleValue const& as_identifier() const;
     ImageStyleValue const& as_image() const;
@@ -251,6 +255,7 @@ public:
     FlexStyleValue& as_flex() { return const_cast<FlexStyleValue&>(const_cast<StyleValue const&>(*this).as_flex()); }
     FontStyleValue& as_font() { return const_cast<FontStyleValue&>(const_cast<StyleValue const&>(*this).as_font()); }
     FrequencyStyleValue& as_frequency() { return const_cast<FrequencyStyleValue&>(const_cast<StyleValue const&>(*this).as_frequency()); }
+    GridTrackPlacementStyleValue& as_grid_track_placement() { return const_cast<GridTrackPlacementStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_track_placement()); }
     GridTrackSizeStyleValue& as_grid_track_size() { return const_cast<GridTrackSizeStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_track_size()); }
     IdentifierStyleValue& as_identifier() { return const_cast<IdentifierStyleValue&>(const_cast<StyleValue const&>(*this).as_identifier()); }
     ImageStyleValue& as_image() { return const_cast<ImageStyleValue&>(const_cast<StyleValue const&>(*this).as_image()); }
@@ -900,6 +905,25 @@ private:
     }
 
     Frequency m_frequency;
+};
+
+class GridTrackPlacementStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<GridTrackPlacementStyleValue> create(CSS::GridTrackPlacement grid_track_placement);
+    virtual ~GridTrackPlacementStyleValue() override = default;
+
+    CSS::GridTrackPlacement const& grid_track_placement() const { return m_grid_track_placement; }
+    virtual String to_string() const override;
+    virtual bool equals(StyleValue const& other) const override;
+
+private:
+    explicit GridTrackPlacementStyleValue(CSS::GridTrackPlacement grid_track_placement)
+        : StyleValue(Type::GridTrackPlacement)
+        , m_grid_track_placement(grid_track_placement)
+    {
+    }
+
+    CSS::GridTrackPlacement m_grid_track_placement;
 };
 
 class GridTrackSizeStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -287,7 +287,7 @@ RefPtr<Layout::Node> Element::create_layout_node_for_display_type(DOM::Document&
         return adopt_ref(*new Layout::InlineNode(document, element, move(style)));
     }
 
-    if (display.is_flow_inside() || display.is_flow_root_inside() || display.is_flex_inside())
+    if (display.is_flow_inside() || display.is_flow_root_inside() || display.is_flex_inside() || display.is_grid_inside())
         return adopt_ref(*new Layout::BlockContainer(document, element, move(style)));
 
     TODO();

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -57,6 +57,7 @@ class FontStyleValue;
 class Frequency;
 class FrequencyPercentage;
 class FrequencyStyleValue;
+class GridTrackSize;
 class IdentifierStyleValue;
 class ImageStyleValue;
 class InheritStyleValue;

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -58,6 +58,7 @@ class Frequency;
 class FrequencyPercentage;
 class FrequencyStyleValue;
 class GridTrackPlacement;
+class GridTrackPlacementStyleValue;
 class GridTrackSize;
 class GridTrackSizeStyleValue;
 class IdentifierStyleValue;

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -58,6 +58,7 @@ class Frequency;
 class FrequencyPercentage;
 class FrequencyStyleValue;
 class GridTrackPlacement;
+class GridTrackPlacementShorthandStyleValue;
 class GridTrackPlacementStyleValue;
 class GridTrackSize;
 class GridTrackSizeStyleValue;

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -57,6 +57,7 @@ class FontStyleValue;
 class Frequency;
 class FrequencyPercentage;
 class FrequencyStyleValue;
+class GridTrackPlacement;
 class GridTrackSize;
 class IdentifierStyleValue;
 class ImageStyleValue;

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -59,6 +59,7 @@ class FrequencyPercentage;
 class FrequencyStyleValue;
 class GridTrackPlacement;
 class GridTrackSize;
+class GridTrackSizeStyleValue;
 class IdentifierStyleValue;
 class ImageStyleValue;
 class InheritStyleValue;

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/FlexFormattingContext.h>
 #include <LibWeb/Layout/FormattingContext.h>
+#include <LibWeb/Layout/GridFormattingContext.h>
 #include <LibWeb/Layout/ReplacedBox.h>
 #include <LibWeb/Layout/SVGFormattingContext.h>
 #include <LibWeb/Layout/SVGSVGBox.h>
@@ -74,12 +75,16 @@ bool FormattingContext::creates_block_formatting_context(Box const& box)
             if (!display.is_flex_inside())
                 return true;
         }
+        if (parent_display.is_grid_inside()) {
+            if (!display.is_grid_inside()) {
+                return true;
+            }
+        }
     }
 
     // FIXME: table-caption
     // FIXME: anonymous table cells
     // FIXME: Elements with contain: layout, content, or paint.
-    // FIXME: grid
     // FIXME: multicol
     // FIXME: column-span: all
     return false;
@@ -119,6 +124,10 @@ OwnPtr<FormattingContext> FormattingContext::create_independent_formatting_conte
 
     if (child_display.is_table_inside())
         return make<TableFormattingContext>(state, verify_cast<TableBox>(child_box), this);
+
+    if (child_display.is_grid_inside()) {
+        return make<GridFormattingContext>(state, verify_cast<BlockContainer>(child_box), this);
+    }
 
     VERIFY(is_block_formatting_context());
     VERIFY(!child_box.children_are_inline());

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/Node.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/GridFormattingContext.h>
 
@@ -18,9 +19,75 @@ GridFormattingContext::~GridFormattingContext() = default;
 
 void GridFormattingContext::run(Box const& box, LayoutMode)
 {
+    auto should_skip_is_anonymous_text_run = [&](Box& child_box) -> bool {
+        if (child_box.is_anonymous() && !child_box.first_child_of_type<BlockContainer>()) {
+            bool contains_only_white_space = true;
+            child_box.for_each_in_subtree([&](auto const& node) {
+                if (!is<TextNode>(node) || !static_cast<TextNode const&>(node).dom_node().data().is_whitespace()) {
+                    contains_only_white_space = false;
+                    return IterationDecision::Break;
+                }
+                return IterationDecision::Continue;
+            });
+            if (contains_only_white_space)
+                return true;
+        }
+        return false;
+    };
+
+    auto number_of_columns = (int)box.computed_values().grid_template_columns().size();
+    struct GridRow {
+        float height { 0 };
+        Vector<Box&> boxes;
+    };
+    Vector<GridRow> grid_rows;
+
+    auto current_column_count = 0;
     box.for_each_child_of_type<Box>([&](Box& child_box) {
+        if (should_skip_is_anonymous_text_run(child_box))
+            return IterationDecision::Continue;
+
+        if (current_column_count == 0)
+            grid_rows.append(GridRow());
+        GridRow& grid_row = grid_rows.last();
+        grid_row.boxes.append(child_box);
+
+        auto& child_box_state = m_state.get_mutable(child_box);
+        if (child_box_state.content_height() > grid_row.height)
+            grid_row.height = child_box_state.content_height();
         (void)layout_inside(child_box, LayoutMode::Normal);
+        if (child_box_state.content_height() > grid_row.height)
+            grid_row.height = child_box_state.content_height();
+
+        current_column_count++;
+        if (current_column_count == number_of_columns)
+            current_column_count = 0;
+        return IterationDecision::Continue;
     });
+
+    auto& box_state = m_state.get_mutable(box);
+    float current_y_position = 0;
+    current_column_count = 0;
+    for (auto& grid_row : grid_rows) {
+        for (auto& child_box : grid_row.boxes) {
+            if (should_skip_is_anonymous_text_run(child_box))
+                continue;
+            auto& child_box_state = m_state.get_mutable(child_box);
+
+            // FIXME: instead of dividing the parent width equally between the columns, should use
+            // the values in the GridTrackSize objects.
+            child_box_state.set_content_width(box_state.content_width() / number_of_columns);
+            child_box_state.set_content_height(grid_row.height);
+            child_box_state.offset = { current_column_count * (box_state.content_width() / number_of_columns), current_y_position };
+
+            current_column_count++;
+            if (current_column_count == number_of_columns) {
+                current_y_position += grid_row.height;
+                current_column_count = 0;
+            }
+            continue;
+        }
+    }
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, Martin Falisse <mfalisse@outlook.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/GridFormattingContext.h>
+
+namespace Web::Layout {
+
+GridFormattingContext::GridFormattingContext(LayoutState& state, BlockContainer const& block_container, FormattingContext* parent)
+    : BlockFormattingContext(state, block_container, parent)
+{
+}
+
+GridFormattingContext::~GridFormattingContext() = default;
+
+void GridFormattingContext::run(Box const& box, LayoutMode)
+{
+    box.for_each_child_of_type<Box>([&](Box& child_box) {
+        (void)layout_inside(child_box, LayoutMode::Normal);
+    });
+}
+
+}

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022, Martin Falisse <mfalisse@outlook.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Layout/BlockFormattingContext.h>
+#include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/FormattingContext.h>
+
+namespace Web::Layout {
+
+class GridFormattingContext final : public BlockFormattingContext {
+public:
+    explicit GridFormattingContext(LayoutState&, BlockContainer const&, FormattingContext* parent);
+    ~GridFormattingContext();
+
+    virtual void run(Box const&, LayoutMode) override;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -525,6 +525,8 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     do_border_style(computed_values.border_bottom(), CSS::PropertyID::BorderBottomWidth, CSS::PropertyID::BorderBottomColor, CSS::PropertyID::BorderBottomStyle);
 
     computed_values.set_content(computed_style.content());
+    computed_values.set_grid_template_columns(computed_style.grid_template_columns());
+    computed_values.set_grid_template_rows(computed_style.grid_template_rows());
 
     if (auto fill = computed_style.property(CSS::PropertyID::Fill); fill->has_color())
         computed_values.set_fill(fill->to_color(*this));

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -527,6 +527,10 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     computed_values.set_content(computed_style.content());
     computed_values.set_grid_template_columns(computed_style.grid_template_columns());
     computed_values.set_grid_template_rows(computed_style.grid_template_rows());
+    computed_values.set_grid_column_end(computed_style.grid_column_end());
+    computed_values.set_grid_column_start(computed_style.grid_column_start());
+    computed_values.set_grid_row_end(computed_style.grid_row_end());
+    computed_values.set_grid_row_start(computed_style.grid_row_start());
 
     if (auto fill = computed_style.property(CSS::PropertyID::Fill); fill->has_color())
         computed_values.set_fill(fill->to_color(*this));


### PR DESCRIPTION
This is a starter PR for displaying the CSS grid via `display: grid`.

Adds parsing for the CSS properties and the very beginnings of the GridFormattingContext.