### PR TITLE
Ports: Set correct path in `.la` files for libvorbis

### DIFF
--- a/Ports/libvorbis/package.sh
+++ b/Ports/libvorbis/package.sh
@@ -7,3 +7,9 @@ use_fresh_config_sub=true
 files="https://github.com/xiph/vorbis/releases/download/v${version}/libvorbis-${version}.tar.gz libvorbis-${version}.tar.gz 0e982409a9c3fc82ee06e08205b1355e5c6aa4c36bca58146ef399621b0ce5ab"
 auth_type=sha256
 depends=("libogg")
+
+post_install() {
+    # Fix up broken libtool paths
+    # FIXME: apply a proper libtool fix
+    sed -i "s# /usr/local# ${SERENITY_INSTALL_ROOT}/usr/local#g" "${SERENITY_INSTALL_ROOT}"/usr/local/lib/libvorbis*.la
+}


### PR DESCRIPTION
These libtool archives incorrectly pointed to `/usr/local` causing other ports not to be able to find the libvorbis libraries.

We cannot use `configure --prefix=...` since that will add up with our fixed `make DESTDIR=...` logic, causing the path to be duplicated. We can also not change that `DESTDIR` logic without influencing all other port builds. Finally, `configure --with-sysroot=...` doesn't work since not all other ports (such as SDL_mixer) have a recent enough libtool to
understand the sysroot syntax.

So let's `sed` this and be done with it :^)

Thanks to @timschumi for thinking with me on this.