### PR TITLE
Ports: Select right config tools for SDL_mixer

### DIFF
--- a/Ports/SDL_mixer/package.sh
+++ b/Ports/SDL_mixer/package.sh
@@ -8,3 +8,8 @@ config_sub_paths=("build-scripts/config.sub")
 files="https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-${version}.tar.gz SDL_mixer-${version}.tar.gz 1644308279a975799049e4826af2cfc787cad2abb11aa14562e402521f86992a"
 auth_type=sha256
 depends=("libmikmod" "libvorbis" "sdl12-compat")
+
+# Explicitly point to the config binaries installed by our ports. Otherwise, it will
+# only work if by chance your host machine has those binaries in $PATH.
+export LIBMIKMOD_CONFIG="${SERENITY_INSTALL_ROOT}/usr/local/bin/libmikmod-config"
+export SDL_CONFIG="${SERENITY_INSTALL_ROOT}/usr/local/bin/sdl-config"


### PR DESCRIPTION
Previously, you would need `sdl-config` and `libmikmod-config` on your host machine to get SDL_mixer to build. With this patch, it always works :^)