### PR TITLE
Meta: Only include headings for populated groups/subgroups in emoji.txt

### DIFF
--- a/Meta/generate-emoji-txt.sh
+++ b/Meta/generate-emoji-txt.sh
@@ -15,14 +15,16 @@ OUTPUT_PATH="$3"
 :>| "$OUTPUT_PATH"
 
 first_heading=true
+printed_group_header=false
+printed_subgroup_header=false
 while IFS= read -r line
 do
-    if [[ $line == \#\ subgroup:\ * || $line == \#\ group:\ * ]]; then
-        if [ $first_heading = false ]; then
-            echo "" >> "$OUTPUT_PATH"
-        fi
-        echo "$line" >> "$OUTPUT_PATH"
-        first_heading=false
+    if [[ $line == \#\ group:\ * ]]; then
+        current_group="$line"
+        printed_group_header=false
+    elif [[ $line == \#\ subgroup:\ * ]]; then
+        current_subgroup="$line"
+        printed_subgroup_header=false
     elif [[ ${#line} -ne 0 && $line != \#* ]]; then
         codepoints_string=${line%%;*}
         IFS=" " read -r -a codepoints <<< "$codepoints_string"
@@ -45,6 +47,20 @@ do
         lookup_filename="${lookup_filename_parts[*]}.png"
 
         if [ -f "$EMOJI_DIR/$lookup_filename" ]; then
+            if [ $printed_group_header = false ]; then
+                if [ $first_heading = false ]; then
+                    echo "" >> "$OUTPUT_PATH"
+                fi
+                echo "$current_group" >> "$OUTPUT_PATH"
+                first_heading=false
+                printed_group_header=true
+            fi
+            if [ $printed_subgroup_header = false ]; then
+                echo "" >> "$OUTPUT_PATH"
+                echo "$current_subgroup" >> "$OUTPUT_PATH"
+                printed_subgroup_header=true
+            fi
+
             emoji_and_name=${line#*# }
             emoji=${emoji_and_name%% E*}
             name_with_version=${emoji_and_name#* }


### PR DESCRIPTION
The primary motivation for this is to make `generate-emoji-txt.sh` more
useful for generating a compact list of new emoji being added (e.g.
for use in commit messages / PRs) if it's run with an emoji image
directory that contains only the new emojis.

Example for a directory containing the emojis added in https://github.com/SerenityOS/serenity/pull/14931:

```
Meta/generate-emoji-txt.sh Build/i686/UCD/emoji-test.txt ~/Pictures/serenity-emojis/weather-and-misc new-emoji.txt
```

Now produces a file like this (instead of a file with tons and tons of empty group/subgroup headings):

```
# group: Smileys & Emotion

# subgroup: emotion
💯 - U+1F4AF HUNDRED POINTS (fully-qualified)

# group: Travel & Places

# subgroup: sky & weather
☀️ - U+2600 U+FE0F SUN (fully-qualified)
☀ - U+2600 SUN (unqualified)
☁️ - U+2601 U+FE0F CLOUD (fully-qualified)
☁ - U+2601 CLOUD (unqualified)
🌤️ - U+1F324 U+FE0F SUN BEHIND SMALL CLOUD (fully-qualified)
🌤 - U+1F324 SUN BEHIND SMALL CLOUD (unqualified)
🌥️ - U+1F325 U+FE0F SUN BEHIND LARGE CLOUD (fully-qualified)
🌥 - U+1F325 SUN BEHIND LARGE CLOUD (unqualified)
🌦️ - U+1F326 U+FE0F SUN BEHIND RAIN CLOUD (fully-qualified)
🌦 - U+1F326 SUN BEHIND RAIN CLOUD (unqualified)
🌧️ - U+1F327 U+FE0F CLOUD WITH RAIN (fully-qualified)
🌧 - U+1F327 CLOUD WITH RAIN (unqualified)
🌨️ - U+1F328 U+FE0F CLOUD WITH SNOW (fully-qualified)
🌨 - U+1F328 CLOUD WITH SNOW (unqualified)
🌩️ - U+1F329 U+FE0F CLOUD WITH LIGHTNING (fully-qualified)
🌩 - U+1F329 CLOUD WITH LIGHTNING (unqualified)

# group: Objects

# subgroup: household
🫧 - U+1FAE7 BUBBLES (fully-qualified)
```