### PR TITLE
WindowServer+Elsewhere: Streamline modals, remove cruft, fix some windowing quirks

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -79,6 +79,7 @@ void Tab::view_source(const URL& url, String const& source)
     window->resize(640, 480);
     window->set_title(url.to_string());
     window->set_icon(g_icon_bag.filetype_text);
+    window->set_window_mode(GUI::WindowMode::Modeless);
     window->show();
 }
 
@@ -555,6 +556,7 @@ void Tab::show_inspector_window(Browser::Tab::InspectorTarget inspector_target)
 {
     if (!m_dom_inspector_widget) {
         auto window = GUI::Window::construct(&this->window());
+        window->set_window_mode(GUI::WindowMode::Modeless);
         window->resize(300, 500);
         window->set_title("Inspector");
         window->set_icon(g_icon_bag.inspector_object);

--- a/Userland/Applications/Calendar/main.cpp
+++ b/Userland/Applications/Calendar/main.cpp
@@ -35,7 +35,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::Window::try_create());
     window->set_title("Calendar");
     window->resize(600, 480);
-    window->set_minimum_size(171, 141);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());

--- a/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
@@ -94,6 +94,7 @@ CharacterMapWidget::CharacterMapWidget()
             m_find_window->set_icon(GUI::Icon::try_create_default_icon("find"sv).value().bitmap_for_size(16));
             m_find_window->set_title("Find a character");
             m_find_window->resize(300, 400);
+            m_find_window->set_window_mode(GUI::WindowMode::Modeless);
         }
         m_find_window->show();
         m_find_window->move_to_front();

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -60,7 +60,7 @@ static constexpr Array pangrams = {
 ErrorOr<RefPtr<GUI::Window>> MainWidget::create_preview_window()
 {
     auto window = TRY(GUI::Window::try_create(this));
-    window->set_window_type(GUI::WindowType::ToolWindow);
+    window->set_window_mode(GUI::WindowMode::RenderAbove);
     window->set_title("Preview");
     window->resize(400, 150);
     window->center_within(*this->window());

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -29,7 +29,6 @@ SoundPlayerWidgetAdvancedView::SoundPlayerWidgetAdvancedView(GUI::Window& window
     , m_window(window)
 {
     window.resize(455, 350);
-    window.set_minimum_size(600, 130);
     window.set_resizable(true);
     set_fill_with_background_color(true);
 

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -66,7 +66,6 @@ HelpWindow::HelpWindow(GUI::Window* parent)
     resize(530, 365);
     set_title("Spreadsheet Functions Help");
     set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-help.png"sv).release_value_but_fixme_should_propagate_errors());
-    set_accessory(true);
 
     auto& widget = set_main_widget<GUI::Widget>();
     widget.set_layout<GUI::VerticalBoxLayout>();

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -53,6 +53,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, NonnullRefPtrVe
             auto docs = sheet_ptr->gather_documentation();
             auto help_window = HelpWindow::the(window());
             help_window->set_docs(move(docs));
+            help_window->set_window_mode(GUI::WindowMode::Modeless);
             help_window->show();
         }
     };

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -170,8 +170,8 @@ static ErrorOr<void> run_command(String command, bool keep_open)
 
 static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget& terminal)
 {
-    auto window = TRY(GUI::Window::try_create());
-    window->set_window_type(GUI::WindowType::ToolWindow);
+    auto window = TRY(GUI::Window::try_create(&terminal));
+    window->set_window_mode(GUI::WindowMode::RenderAbove);
     window->set_title("Find in Terminal");
     window->set_resizable(false);
     window->resize(300, 90);
@@ -415,10 +415,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/Terminal.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Terminal", app_icon, window)));
-
-    window->on_close = [&]() {
-        find_window->close();
-    };
 
     window->on_close_request = [&]() -> GUI::Window::CloseRequestDecision {
         if (check_terminal_quit() == GUI::MessageBox::ExecResult::OK)

--- a/Userland/Applications/Welcome/main.cpp
+++ b/Userland/Applications/Welcome/main.cpp
@@ -30,9 +30,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::Window::try_create());
     window->resize(480, 250);
     window->center_on_screen();
-
     window->set_title("Welcome");
-    window->set_minimum_size(480, 250);
     window->set_icon(app_icon.bitmap_for_size(16));
     auto welcome_widget = TRY(window->try_set_main_widget<WelcomeWidget>());
 

--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -76,7 +76,7 @@ void Canvas::draw(Gfx::Painter& painter)
 {
     auto active_window_icon = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/window.png"sv).release_value_but_fixme_should_propagate_errors();
 
-    Gfx::WindowTheme::current().paint_normal_frame(painter, Gfx::WindowTheme::WindowState::Active, { 4, 18, WIDTH - 8, HEIGHT - 29 }, "Well hello friends 🐞"sv, *active_window_icon, palette(), { WIDTH - 20, 6, 16, 16 }, 0, false);
+    Gfx::WindowTheme::current().paint_normal_frame(painter, Gfx::WindowTheme::WindowState::Active, Gfx::WindowTheme::WindowMode::Other, { 4, 18, WIDTH - 8, HEIGHT - 29 }, "Well hello friends 🐞"sv, *active_window_icon, palette(), { WIDTH - 20, 6, 16, 16 }, 0, false);
 
     painter.fill_rect({ 4, 25, WIDTH - 8, HEIGHT - 30 }, palette().color(Gfx::ColorRole::Background));
     painter.draw_rect({ 20, 34, WIDTH - 40, HEIGHT - 45 }, palette().color(Gfx::ColorRole::Selection), true);

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -409,6 +409,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::Window::try_create());
     window->set_double_buffering_enabled(false);
     window->set_title("Mandelbrot");
+    window->set_obey_widget_min_size(false);
     window->set_minimum_size(320, 240);
     window->resize(window->minimum_size() * 2);
     auto mandelbrot = TRY(window->try_set_main_widget<Mandelbrot>());

--- a/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.cpp
@@ -14,7 +14,6 @@ GitCommitDialog::GitCommitDialog(GUI::Window* parent)
 {
     resize(400, 260);
     center_within(*parent);
-    set_modal(true);
     set_title("Commit");
     set_icon(parent->icon());
 

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
@@ -47,7 +47,6 @@ NewProjectDialog::NewProjectDialog(GUI::Window* parent)
     resize(500, 385);
     center_on_screen();
     set_resizable(false);
-    set_modal(true);
     set_title("New project");
 
     auto& main_widget = set_main_widget<GUI::Widget>();

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
@@ -108,7 +108,7 @@ void AbstractThemePreview::paint_window(StringView title, Gfx::IntRect const& re
 
     int window_button_width = m_preview_palette.window_title_button_width();
     int window_button_height = m_preview_palette.window_title_button_height();
-    auto titlebar_text_rect = Gfx::WindowTheme::current().titlebar_text_rect(Gfx::WindowTheme::WindowType::Normal, rect, m_preview_palette);
+    auto titlebar_text_rect = Gfx::WindowTheme::current().titlebar_text_rect(Gfx::WindowTheme::WindowType::Normal, Gfx::WindowTheme::WindowMode::Other, rect, m_preview_palette);
     int pos = titlebar_text_rect.right() + 1;
 
     Array possible_buttons {
@@ -126,7 +126,7 @@ void AbstractThemePreview::paint_window(StringView title, Gfx::IntRect const& re
         button.rect = button_rect;
     }
 
-    auto frame_rect = Gfx::WindowTheme::current().frame_rect_for_window(Gfx::WindowTheme::WindowType::Normal, rect, m_preview_palette, 0);
+    auto frame_rect = Gfx::WindowTheme::current().frame_rect_for_window(Gfx::WindowTheme::WindowType::Normal, Gfx::WindowTheme::WindowMode::Other, rect, m_preview_palette, 0);
 
     auto paint_shadow = [](Gfx::Painter& painter, Gfx::IntRect& frame_rect, Gfx::Bitmap const& shadow_bitmap) {
         auto total_shadow_size = shadow_bitmap.height();
@@ -142,7 +142,7 @@ void AbstractThemePreview::paint_window(StringView title, Gfx::IntRect const& re
 
     Gfx::PainterStateSaver saver(painter);
     painter.translate(frame_rect.location());
-    Gfx::WindowTheme::current().paint_normal_frame(painter, state, rect, title, icon, m_preview_palette, buttons.last().rect, 0, false);
+    Gfx::WindowTheme::current().paint_normal_frame(painter, state, Gfx::WindowTheme::WindowMode::Other, rect, title, icon, m_preview_palette, buttons.last().rect, 0, false);
     painter.fill_rect(rect.translated(-frame_rect.location()), m_preview_palette.color(Gfx::ColorRole::Background));
 
     for (auto& button : buttons) {
@@ -171,7 +171,7 @@ void AbstractThemePreview::center_window_group_within(Span<Window> windows, Gfx:
 
     auto to_frame_rect = [&](Gfx::IntRect const& rect) {
         return Gfx::WindowTheme::current().frame_rect_for_window(
-            Gfx::WindowTheme::WindowType::Normal, rect, m_preview_palette, 0);
+            Gfx::WindowTheme::WindowType::Normal, Gfx::WindowTheme::WindowMode::Other, rect, m_preview_palette, 0);
     };
 
     auto leftmost_x_value = windows[0].rect.x();

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -109,7 +109,7 @@ ComboBox::ComboBox()
 
     m_list_window = add<Window>(window());
     m_list_window->set_frameless(true);
-    m_list_window->set_accessory(true);
+    m_list_window->set_window_mode(WindowMode::CaptureInput);
     m_list_window->on_active_input_change = [this](bool is_active_input) {
         if (!is_active_input) {
             m_open_button->set_enabled(false);

--- a/Userland/Libraries/LibGUI/ConnectionToWindowManagerServer.cpp
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowManagerServer.cpp
@@ -19,12 +19,11 @@ ConnectionToWindowManagerServer& ConnectionToWindowManagerServer::the()
 }
 
 void ConnectionToWindowManagerServer::window_state_changed(i32 wm_id, i32 client_id, i32 window_id,
-    i32 parent_client_id, i32 parent_window_id, u32 workspace_row, u32 workspace_column,
-    bool is_active, bool is_minimized, bool is_modal, bool is_frameless, i32 window_type,
-    String const& title, Gfx::IntRect const& rect, Optional<i32> const& progress)
+    u32 workspace_row, u32 workspace_column, bool is_active, bool is_minimized, bool is_frameless,
+    i32 window_type, String const& title, Gfx::IntRect const& rect, Optional<i32> const& progress)
 {
     if (auto* window = Window::from_window_id(wm_id))
-        Core::EventLoop::current().post_event(*window, make<WMWindowStateChangedEvent>(client_id, window_id, parent_client_id, parent_window_id, title, rect, workspace_row, workspace_column, is_active, is_modal, static_cast<WindowType>(window_type), is_minimized, is_frameless, progress));
+        Core::EventLoop::current().post_event(*window, make<WMWindowStateChangedEvent>(client_id, window_id, title, rect, workspace_row, workspace_column, is_active, static_cast<WindowType>(window_type), is_minimized, is_frameless, progress));
 }
 
 void ConnectionToWindowManagerServer::applet_area_size_changed(i32 wm_id, Gfx::IntSize const& size)

--- a/Userland/Libraries/LibGUI/ConnectionToWindowManagerServer.h
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowManagerServer.h
@@ -28,7 +28,7 @@ private:
     }
 
     virtual void window_removed(i32, i32, i32) override;
-    virtual void window_state_changed(i32, i32, i32, i32, i32, u32, u32, bool, bool, bool, bool, i32, String const&, Gfx::IntRect const&, Optional<i32> const&) override;
+    virtual void window_state_changed(i32, i32, i32, u32, u32, bool, bool, bool, i32, String const&, Gfx::IntRect const&, Optional<i32> const&) override;
     virtual void window_icon_bitmap_changed(i32, i32, i32, Gfx::ShareableBitmap const&) override;
     virtual void window_rect_changed(i32, i32, i32, Gfx::IntRect const&) override;
     virtual void applet_area_size_changed(i32, Gfx::IntSize const&) override;

--- a/Userland/Libraries/LibGUI/ConnectionToWindowServer.cpp
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowServer.cpp
@@ -163,8 +163,8 @@ static Action* action_for_shortcut(Window& window, Shortcut const& shortcut)
         return action;
     }
 
-    // NOTE: Application-global shortcuts are ignored while a modal window is up.
-    if (!window.is_modal()) {
+    // NOTE: Application-global shortcuts are ignored while a blocking modal window is up.
+    if (!window.is_blocking()) {
         if (auto* action = Application::the()->action_for_shortcut(shortcut)) {
             dbgln_if(KEYBOARD_SHORTCUTS_DEBUG, "  > Asked application, got action: {} {} (enabled: {}, shortcut: {}, alt-shortcut: {})", action, action->text(), action->is_enabled(), action->shortcut().to_string(), action->alternate_shortcut().to_string());
             return action;

--- a/Userland/Libraries/LibGUI/Dialog.cpp
+++ b/Userland/Libraries/LibGUI/Dialog.cpp
@@ -17,8 +17,7 @@ Dialog::Dialog(Window* parent_window, ScreenPosition screen_position)
     : Window(parent_window)
     , m_screen_position(screen_position)
 {
-    set_modal(true);
-    set_minimizable(false);
+    set_window_mode(WindowMode::Blocking);
 }
 
 Dialog::ExecResult Dialog::exec()

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -62,7 +62,7 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
     int dialog_width = button_size * columns + magic_offset;
     int dialog_height = button_size * rows;
 
-    set_minimum_size(dialog_width, dialog_height);
+    resize(dialog_width, dialog_height);
     set_frameless(true);
 
     for (size_t row = 0; row < rows && index < code_points.size(); ++row) {

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -164,29 +164,23 @@ public:
 
 class WMWindowStateChangedEvent : public WMEvent {
 public:
-    WMWindowStateChangedEvent(int client_id, int window_id, int parent_client_id, int parent_window_id, StringView title, Gfx::IntRect const& rect, unsigned workspace_row, unsigned workspace_column, bool is_active, bool is_modal, WindowType window_type, bool is_minimized, bool is_frameless, Optional<int> progress)
+    WMWindowStateChangedEvent(int client_id, int window_id, StringView title, Gfx::IntRect const& rect, unsigned workspace_row, unsigned workspace_column, bool is_active, WindowType window_type, bool is_minimized, bool is_frameless, Optional<int> progress)
         : WMEvent(Event::Type::WM_WindowStateChanged, client_id, window_id)
-        , m_parent_client_id(parent_client_id)
-        , m_parent_window_id(parent_window_id)
         , m_title(title)
         , m_rect(rect)
         , m_window_type(window_type)
         , m_workspace_row(workspace_row)
         , m_workspace_column(workspace_column)
         , m_active(is_active)
-        , m_modal(is_modal)
         , m_minimized(is_minimized)
         , m_frameless(is_frameless)
         , m_progress(progress)
     {
     }
 
-    int parent_client_id() const { return m_parent_client_id; }
-    int parent_window_id() const { return m_parent_window_id; }
     String const& title() const { return m_title; }
     Gfx::IntRect const& rect() const { return m_rect; }
     bool is_active() const { return m_active; }
-    bool is_modal() const { return m_modal; }
     WindowType window_type() const { return m_window_type; }
     bool is_minimized() const { return m_minimized; }
     bool is_frameless() const { return m_frameless; }
@@ -195,15 +189,12 @@ public:
     unsigned workspace_column() const { return m_workspace_column; }
 
 private:
-    int m_parent_client_id;
-    int m_parent_window_id;
     String m_title;
     Gfx::IntRect m_rect;
     WindowType m_window_type;
     unsigned m_workspace_row;
     unsigned m_workspace_column;
     bool m_active;
-    bool m_modal;
     bool m_minimized;
     bool m_frameless;
     Optional<int> m_progress;

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -731,7 +731,7 @@ bool Widget::is_focused() const
     auto* win = window();
     if (!win)
         return false;
-    // Accessory windows are not active despite being the active
+    // Capturing modals are not active despite being the active
     // input window. So we can have focus if either we're the active
     // input window or we're the active window
     if (win->is_active_input() || win->is_active())

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -69,6 +69,9 @@ Window::Window(Core::Object* parent)
     : Core::Object(parent)
     , m_menubar(Menubar::construct())
 {
+    if (parent)
+        set_window_mode(WindowMode::Passive);
+
     all_windows->set(this);
     m_rect_when_windowless = { -5000, -5000, 0, 0 };
     m_title_when_windowless = "GUI::Window";
@@ -144,7 +147,6 @@ void Window::show()
         m_rect_when_windowless,
         !m_moved_by_client,
         m_has_alpha_channel,
-        m_modal,
         m_minimizable,
         m_closeable,
         m_resizable,
@@ -159,6 +161,7 @@ void Window::show()
         m_minimum_size_when_windowless,
         m_resize_aspect_ratio,
         (i32)m_window_type,
+        (i32)m_window_mode,
         m_title_when_windowless,
         parent_window ? parent_window->window_id() : 0,
         launch_origin_rect);
@@ -314,6 +317,12 @@ void Window::center_within(Window const& other)
 void Window::set_window_type(WindowType window_type)
 {
     m_window_type = window_type;
+}
+
+void Window::set_window_mode(WindowMode mode)
+{
+    VERIFY(!is_visible());
+    m_window_mode = mode;
 }
 
 void Window::make_window_manager(unsigned event_mask)
@@ -888,12 +897,6 @@ OwnPtr<WindowBackingStore> Window::create_backing_store(Gfx::IntSize const& size
         return {};
     }
     return make<WindowBackingStore>(bitmap_or_error.release_value());
-}
-
-void Window::set_modal(bool modal)
-{
-    VERIFY(!is_visible());
-    m_modal = modal;
 }
 
 void Window::wm_event(WMEvent&)

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -208,6 +208,8 @@ void Window::hide()
     if (GUI::Application::in_teardown())
         return;
 
+    m_rect_when_windowless = rect();
+
     auto destroyed_window_ids = ConnectionToWindowServer::the().destroy_window(m_window_id);
     server_did_destroy();
 
@@ -468,7 +470,7 @@ void Window::handle_resize_event(ResizeEvent& event)
         m_pending_paint_event_rects.clear_with_capacity();
         m_pending_paint_event_rects.append({ {}, new_size });
     }
-    m_rect_when_windowless = { {}, new_size };
+    m_rect_when_windowless.set_size(new_size);
     if (m_main_widget)
         m_main_widget->set_relative_rect({ {}, new_size });
 }

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -153,7 +153,6 @@ void Window::show()
         m_fullscreen,
         m_frameless,
         m_forced_shadow,
-        m_accessory,
         m_opacity_when_windowless,
         m_alpha_hit_threshold,
         m_base_size,

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -124,9 +124,6 @@ public:
     bool is_active() const;
     bool is_active_input() const { return m_is_active_input; }
 
-    bool is_accessory() const { return m_accessory; }
-    void set_accessory(bool accessory) { m_accessory = accessory; }
-
     void show();
     void hide();
     virtual void close();
@@ -306,7 +303,6 @@ private:
     bool m_layout_pending { false };
     bool m_visible_for_timer_purposes { true };
     bool m_visible { false };
-    bool m_accessory { false };
     bool m_moved_by_client { false };
 };
 

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -14,6 +14,7 @@
 #include <LibCore/Object.h>
 #include <LibGUI/FocusSource.h>
 #include <LibGUI/Forward.h>
+#include <LibGUI/WindowMode.h>
 #include <LibGUI/WindowType.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
@@ -33,8 +34,8 @@ public:
     bool is_modified() const;
     void set_modified(bool);
 
-    bool is_modal() const { return m_modal; }
-    void set_modal(bool);
+    bool is_modal() const { return m_window_mode != WindowMode::Modeless; }
+    bool is_blocking() const { return m_window_mode == WindowMode::Blocking; }
 
     bool is_fullscreen() const { return m_fullscreen; }
     void set_fullscreen(bool);
@@ -70,6 +71,9 @@ public:
 
     WindowType window_type() const { return m_window_type; }
     void set_window_type(WindowType);
+
+    WindowMode window_mode() const { return m_window_mode; }
+    void set_window_mode(WindowMode);
 
     int window_id() const { return m_window_id; }
 
@@ -284,12 +288,12 @@ private:
     Gfx::IntSize m_size_increment;
     Gfx::IntSize m_base_size;
     WindowType m_window_type { WindowType::Normal };
+    WindowMode m_window_mode { WindowMode::Modeless };
     AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_cursor { Gfx::StandardCursor::None };
     AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_effective_cursor { Gfx::StandardCursor::None };
     bool m_is_active_input { false };
     bool m_has_alpha_channel { false };
     bool m_double_buffering_enabled { true };
-    bool m_modal { false };
     bool m_resizable { true };
     bool m_obey_widget_min_size { true };
     Optional<Gfx::IntSize> m_resize_aspect_ratio {};

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -278,8 +278,7 @@ private:
     WeakPtr<Widget> m_automatic_cursor_tracking_widget;
     WeakPtr<Widget> m_hovered_widget;
     Gfx::IntRect m_rect_when_windowless;
-    Gfx::IntSize m_minimum_size_when_windowless { 50, 50 };
-    bool m_minimum_size_modified { false };
+    Gfx::IntSize m_minimum_size_when_windowless { 0, 0 };
     String m_title_when_windowless;
     Vector<Gfx::IntRect, 32> m_pending_paint_event_rects;
     Gfx::IntSize m_size_increment;

--- a/Userland/Libraries/LibGUI/WindowMode.h
+++ b/Userland/Libraries/LibGUI/WindowMode.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Services/WindowServer/WindowMode.h>
+
+namespace GUI {
+
+using WindowMode = WindowServer::WindowMode;
+
+}

--- a/Userland/Libraries/LibGfx/ClassicWindowTheme.h
+++ b/Userland/Libraries/LibGfx/ClassicWindowTheme.h
@@ -16,20 +16,19 @@ public:
     ClassicWindowTheme() = default;
     virtual ~ClassicWindowTheme() override = default;
 
-    virtual void paint_normal_frame(Painter& painter, WindowState window_state, IntRect const& window_rect, StringView window_title, Bitmap const& icon, Palette const& palette, IntRect const& leftmost_button_rect, int menu_row_count, bool window_modified) const override;
-    virtual void paint_tool_window_frame(Painter&, WindowState, IntRect const& window_rect, StringView title, Palette const&, IntRect const& leftmost_button_rect) const override;
-    virtual void paint_notification_frame(Painter&, IntRect const& window_rect, Palette const&, IntRect const& close_button_rect) const override;
+    virtual void paint_normal_frame(Painter& painter, WindowState window_state, WindowMode window_mode, IntRect const& window_rect, StringView window_title, Bitmap const& icon, Palette const& palette, IntRect const& leftmost_button_rect, int menu_row_count, bool window_modified) const override;
+    virtual void paint_notification_frame(Painter&, WindowMode, IntRect const& window_rect, Palette const&, IntRect const& close_button_rect) const override;
 
-    virtual int titlebar_height(WindowType, Palette const&) const override;
-    virtual IntRect titlebar_rect(WindowType, IntRect const& window_rect, Palette const&) const override;
-    virtual IntRect titlebar_icon_rect(WindowType, IntRect const& window_rect, Palette const&) const override;
-    virtual IntRect titlebar_text_rect(WindowType, IntRect const& window_rect, Palette const&) const override;
+    virtual int titlebar_height(WindowType, WindowMode, Palette const&) const override;
+    virtual IntRect titlebar_rect(WindowType, WindowMode, IntRect const& window_rect, Palette const&) const override;
+    virtual IntRect titlebar_icon_rect(WindowType, WindowMode, IntRect const& window_rect, Palette const&) const override;
+    virtual IntRect titlebar_text_rect(WindowType, WindowMode, IntRect const& window_rect, Palette const&) const override;
 
-    virtual IntRect menubar_rect(WindowType, IntRect const& window_rect, Palette const&, int menu_row_count) const override;
+    virtual IntRect menubar_rect(WindowType, WindowMode, IntRect const& window_rect, Palette const&, int menu_row_count) const override;
 
-    virtual IntRect frame_rect_for_window(WindowType, IntRect const& window_rect, Palette const&, int menu_row_count) const override;
+    virtual IntRect frame_rect_for_window(WindowType, WindowMode, IntRect const& window_rect, Palette const&, int menu_row_count) const override;
 
-    virtual Vector<IntRect> layout_buttons(WindowType, IntRect const& window_rect, Palette const&, size_t buttons) const override;
+    virtual Vector<IntRect> layout_buttons(WindowType, WindowMode, IntRect const& window_rect, Palette const&, size_t buttons) const override;
     virtual bool is_simple_rect_frame() const override { return true; }
     virtual bool frame_uses_alpha(WindowState state, Palette const& palette) const override
     {

--- a/Userland/Libraries/LibGfx/Rect.cpp
+++ b/Userland/Libraries/LibGfx/Rect.cpp
@@ -309,16 +309,6 @@ void Rect<T>::align_within(Rect<T> const& other, TextAlignment alignment)
     }
 }
 
-template<typename T>
-void Rect<T>::set_size_around(Size<T> const& new_size, Point<T> const& fixed_point)
-{
-    const T new_x = fixed_point.x() - (T)(new_size.width() * ((float)(fixed_point.x() - x()) / width()));
-    const T new_y = fixed_point.y() - (T)(new_size.height() * ((float)(fixed_point.y() - y()) / height()));
-
-    set_location({ new_x, new_y });
-    set_size(new_size);
-}
-
 template<>
 String IntRect::to_string() const
 {

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -107,8 +107,6 @@ public:
         m_size = size;
     }
 
-    void set_size_around(Size<T> const&, Point<T> const& fixed_point);
-
     void set_size(T width, T height)
     {
         m_size.set_width(width);

--- a/Userland/Libraries/LibGfx/WindowTheme.h
+++ b/Userland/Libraries/LibGfx/WindowTheme.h
@@ -13,9 +13,13 @@ namespace Gfx {
 
 class WindowTheme {
 public:
+    enum class WindowMode {
+        RenderAbove,
+        Other,
+    };
+
     enum class WindowType {
         Normal,
-        ToolWindow,
         Notification,
         Other,
     };
@@ -31,20 +35,19 @@ public:
 
     static WindowTheme& current();
 
-    virtual void paint_normal_frame(Painter&, WindowState, IntRect const& window_rect, StringView title, Bitmap const& icon, Palette const&, IntRect const& leftmost_button_rect, int menu_row_count, bool window_modified) const = 0;
-    virtual void paint_tool_window_frame(Painter&, WindowState, IntRect const& window_rect, StringView title, Palette const&, IntRect const& leftmost_button_rect) const = 0;
-    virtual void paint_notification_frame(Painter&, IntRect const& window_rect, Palette const&, IntRect const& close_button_rect) const = 0;
+    virtual void paint_normal_frame(Painter&, WindowState, WindowMode, IntRect const& window_rect, StringView title, Bitmap const& icon, Palette const&, IntRect const& leftmost_button_rect, int menu_row_count, bool window_modified) const = 0;
+    virtual void paint_notification_frame(Painter&, WindowMode, IntRect const& window_rect, Palette const&, IntRect const& close_button_rect) const = 0;
 
-    virtual int titlebar_height(WindowType, Palette const&) const = 0;
-    virtual IntRect titlebar_rect(WindowType, IntRect const& window_rect, Palette const&) const = 0;
-    virtual IntRect titlebar_icon_rect(WindowType, IntRect const& window_rect, Palette const&) const = 0;
-    virtual IntRect titlebar_text_rect(WindowType, IntRect const& window_rect, Palette const&) const = 0;
+    virtual int titlebar_height(WindowType, WindowMode, Palette const&) const = 0;
+    virtual IntRect titlebar_rect(WindowType, WindowMode, IntRect const& window_rect, Palette const&) const = 0;
+    virtual IntRect titlebar_icon_rect(WindowType, WindowMode, IntRect const& window_rect, Palette const&) const = 0;
+    virtual IntRect titlebar_text_rect(WindowType, WindowMode, IntRect const& window_rect, Palette const&) const = 0;
 
-    virtual IntRect menubar_rect(WindowType, IntRect const& window_rect, Palette const&, int menu_row_count) const = 0;
+    virtual IntRect menubar_rect(WindowType, WindowMode, IntRect const& window_rect, Palette const&, int menu_row_count) const = 0;
 
-    virtual IntRect frame_rect_for_window(WindowType, IntRect const& window_rect, Palette const&, int menu_row_count) const = 0;
+    virtual IntRect frame_rect_for_window(WindowType, WindowMode, IntRect const& window_rect, Palette const&, int menu_row_count) const = 0;
 
-    virtual Vector<IntRect> layout_buttons(WindowType, IntRect const& window_rect, Palette const&, size_t buttons) const = 0;
+    virtual Vector<IntRect> layout_buttons(WindowType, WindowMode, IntRect const& window_rect, Palette const&, size_t buttons) const = 0;
     virtual bool is_simple_rect_frame() const = 0;
     virtual bool frame_uses_alpha(WindowState, Palette const&) const = 0;
     virtual float frame_alpha_hit_threshold(WindowState) const = 0;

--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -37,7 +37,6 @@ private:
     void add_window_button(::Window&, WindowIdentifier const&);
     void remove_window_button(::Window&, bool);
     void update_window_button(::Window&, bool);
-    ::Window* find_window_owner(::Window&) const;
 
     virtual void event(Core::Event&) override;
     virtual void wm_event(GUI::WMEvent&) override;

--- a/Userland/Services/Taskbar/WindowList.cpp
+++ b/Userland/Services/Taskbar/WindowList.cpp
@@ -12,18 +12,6 @@ WindowList& WindowList::the()
     return s_the;
 }
 
-Window* WindowList::find_parent(Window const& window)
-{
-    if (!window.parent_identifier().is_valid())
-        return nullptr;
-    for (auto& it : m_windows) {
-        auto& w = *it.value;
-        if (w.identifier() == window.parent_identifier())
-            return &w;
-    }
-    return nullptr;
-}
-
 Window* WindowList::window(WindowIdentifier const& identifier)
 {
     auto it = m_windows.find(identifier);

--- a/Userland/Services/Taskbar/WindowList.h
+++ b/Userland/Services/Taskbar/WindowList.h
@@ -27,9 +27,6 @@ public:
 
     WindowIdentifier const& identifier() const { return m_identifier; }
 
-    void set_parent_identifier(WindowIdentifier const& parent_identifier) { m_parent_identifier = parent_identifier; }
-    WindowIdentifier const& parent_identifier() const { return m_parent_identifier; }
-
     String title() const { return m_title; }
     void set_title(String const& title) { m_title = title; }
 
@@ -44,9 +41,6 @@ public:
 
     void set_minimized(bool minimized) { m_minimized = minimized; }
     bool is_minimized() const { return m_minimized; }
-
-    void set_modal(bool modal) { m_modal = modal; }
-    bool is_modal() const { return m_modal; }
 
     void set_workspace(unsigned row, unsigned column)
     {
@@ -71,7 +65,6 @@ public:
 
 private:
     WindowIdentifier m_identifier;
-    WindowIdentifier m_parent_identifier;
     String m_title;
     Gfx::IntRect m_rect;
     RefPtr<GUI::Button> m_button;
@@ -80,7 +73,6 @@ private:
     unsigned m_workspace_column { 0 };
     bool m_active { false };
     bool m_minimized { false };
-    bool m_modal { false };
     Optional<int> m_progress;
 };
 
@@ -95,7 +87,6 @@ public:
             callback(*it.value);
     }
 
-    Window* find_parent(Window const&);
     Window* window(WindowIdentifier const&);
     Window& ensure_window(WindowIdentifier const&);
     void remove_window(WindowIdentifier const&);

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -453,7 +453,6 @@ Messages::WindowServer::SetWindowRectResponse ConnectionFromClient::set_window_r
     auto new_rect = rect;
     window.apply_minimum_size(new_rect);
     window.set_rect(new_rect);
-    window.nudge_into_desktop(nullptr);
     window.request_update(window.rect());
     return window.rect();
 }
@@ -523,7 +522,6 @@ void ConnectionFromClient::set_window_minimum_size(i32 window_id, Gfx::IntSize c
         auto new_rect = window.rect();
         bool did_size_clamp = window.apply_minimum_size(new_rect);
         window.set_rect(new_rect);
-        window.nudge_into_desktop(nullptr);
         window.request_update(window.rect());
 
         if (did_size_clamp)
@@ -610,7 +608,6 @@ void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect
             max(minimum_size.height(), system_window_minimum_size.height()) });
         bool did_size_clamp = window->apply_minimum_size(new_rect);
         window->set_rect(new_rect);
-        window->nudge_into_desktop(nullptr);
 
         if (did_size_clamp)
             window->refresh_client_size();

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -563,10 +563,10 @@ Window* ConnectionFromClient::window_from_id(i32 window_id)
 }
 
 void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect,
-    bool auto_position, bool has_alpha_channel, bool modal, bool minimizable, bool closeable, bool resizable,
+    bool auto_position, bool has_alpha_channel, bool minimizable, bool closeable, bool resizable,
     bool fullscreen, bool frameless, bool forced_shadow, bool accessory, float opacity,
     float alpha_hit_threshold, Gfx::IntSize const& base_size, Gfx::IntSize const& size_increment,
-    Gfx::IntSize const& minimum_size, Optional<Gfx::IntSize> const& resize_aspect_ratio, i32 type,
+    Gfx::IntSize const& minimum_size, Optional<Gfx::IntSize> const& resize_aspect_ratio, i32 type, i32 mode,
     String const& title, i32 parent_window_id, Gfx::IntRect const& launch_origin_rect)
 {
     Window* parent_window = nullptr;
@@ -576,10 +576,19 @@ void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect
             did_misbehave("CreateWindow with bad parent_window_id");
             return;
         }
+        if (parent_window->is_blocking() || (parent_window->is_capturing_input() && mode == (i32)WindowMode::CaptureInput)) {
+            did_misbehave("CreateWindow with forbidden parent mode");
+            return;
+        }
     }
 
     if (type < 0 || type >= (i32)WindowType::_Count) {
         did_misbehave("CreateWindow with a bad type");
+        return;
+    }
+
+    if (mode < 0 || mode >= (i32)WindowMode::_Count) {
+        did_misbehave("CreateWindow with a bad mode");
         return;
     }
 
@@ -588,7 +597,7 @@ void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect
         return;
     }
 
-    auto window = Window::construct(*this, (WindowType)type, window_id, modal, minimizable, closeable, frameless, resizable, fullscreen, accessory, parent_window);
+    auto window = Window::construct(*this, (WindowType)type, (WindowMode)mode, window_id, minimizable, closeable, frameless, resizable, fullscreen, accessory, parent_window);
 
     window->set_forced_shadow(forced_shadow);
 

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -474,7 +474,7 @@ static Gfx::IntSize calculate_minimum_size_for_window(Window const& window)
 
     // NOTE: Windows with a title bar have a minimum size enforced by the system,
     //       because we want to always keep their title buttons accessible.
-    if (window.type() == WindowType::Normal || window.type() == WindowType::ToolWindow) {
+    if (window.type() == WindowType::Normal) {
         auto palette = WindowManager::the().palette();
 
         int required_width = 0;

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -470,6 +470,9 @@ Messages::WindowServer::GetWindowRectResponse ConnectionFromClient::get_window_r
 
 static Gfx::IntSize calculate_minimum_size_for_window(Window const& window)
 {
+    if (window.is_frameless())
+        return { 0, 0 };
+
     // NOTE: Windows with a title bar have a minimum size enforced by the system,
     //       because we want to always keep their title buttons accessible.
     if (window.type() == WindowType::Normal || window.type() == WindowType::ToolWindow) {

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -564,7 +564,7 @@ Window* ConnectionFromClient::window_from_id(i32 window_id)
 
 void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect,
     bool auto_position, bool has_alpha_channel, bool minimizable, bool closeable, bool resizable,
-    bool fullscreen, bool frameless, bool forced_shadow, bool accessory, float opacity,
+    bool fullscreen, bool frameless, bool forced_shadow, float opacity,
     float alpha_hit_threshold, Gfx::IntSize const& base_size, Gfx::IntSize const& size_increment,
     Gfx::IntSize const& minimum_size, Optional<Gfx::IntSize> const& resize_aspect_ratio, i32 type, i32 mode,
     String const& title, i32 parent_window_id, Gfx::IntRect const& launch_origin_rect)
@@ -597,7 +597,7 @@ void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect
         return;
     }
 
-    auto window = Window::construct(*this, (WindowType)type, (WindowMode)mode, window_id, minimizable, closeable, frameless, resizable, fullscreen, accessory, parent_window);
+    auto window = Window::construct(*this, (WindowType)type, (WindowMode)mode, window_id, minimizable, closeable, frameless, resizable, fullscreen, parent_window);
 
     window->set_forced_shadow(forced_shadow);
 
@@ -644,13 +644,6 @@ void ConnectionFromClient::destroy_window(Window& window, Vector<i32>& destroyed
             continue;
         VERIFY(child_window->window_id() != window.window_id());
         destroy_window(*child_window, destroyed_window_ids);
-    }
-
-    for (auto& accessory_window : window.accessory_windows()) {
-        if (!accessory_window)
-            continue;
-        VERIFY(accessory_window->window_id() != window.window_id());
-        destroy_window(*accessory_window, destroyed_window_ids);
     }
 
     destroyed_window_ids.append(window.window_id());

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -101,9 +101,9 @@ private:
     virtual void update_menu_item(i32, i32, i32, String const&, bool, bool, bool, bool, String const&, Gfx::ShareableBitmap const&) override;
     virtual void remove_menu_item(i32 menu_id, i32 identifier) override;
     virtual void flash_menubar_menu(i32, i32) override;
-    virtual void create_window(i32, Gfx::IntRect const&, bool, bool, bool, bool, bool,
+    virtual void create_window(i32, Gfx::IntRect const&, bool, bool, bool, bool,
         bool, bool, bool, bool, bool, float, float, Gfx::IntSize const&, Gfx::IntSize const&, Gfx::IntSize const&,
-        Optional<Gfx::IntSize> const&, i32, String const&, i32, Gfx::IntRect const&) override;
+        Optional<Gfx::IntSize> const&, i32, i32, String const&, i32, Gfx::IntRect const&) override;
     virtual Messages::WindowServer::DestroyWindowResponse destroy_window(i32) override;
     virtual void set_window_title(i32, String const&) override;
     virtual Messages::WindowServer::GetWindowTitleResponse get_window_title(i32) override;

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -101,7 +101,7 @@ private:
     virtual void update_menu_item(i32, i32, i32, String const&, bool, bool, bool, bool, String const&, Gfx::ShareableBitmap const&) override;
     virtual void remove_menu_item(i32 menu_id, i32 identifier) override;
     virtual void flash_menubar_menu(i32, i32) override;
-    virtual void create_window(i32, Gfx::IntRect const&, bool, bool, bool, bool,
+    virtual void create_window(i32, Gfx::IntRect const&, bool, bool, bool,
         bool, bool, bool, bool, bool, float, float, Gfx::IntSize const&, Gfx::IntSize const&, Gfx::IntSize const&,
         Optional<Gfx::IntSize> const&, i32, i32, String const&, i32, Gfx::IntRect const&) override;
     virtual Messages::WindowServer::DestroyWindowResponse destroy_window(i32) override;

--- a/Userland/Services/WindowServer/Menubar.cpp
+++ b/Userland/Services/WindowServer/Menubar.cpp
@@ -16,7 +16,7 @@ void Menubar::layout_menu(Menu& menu, Gfx::IntRect window_rect)
     static constexpr auto menubar_menu_margin = 14;
 
     auto& wm = WindowManager::the();
-    auto menubar_rect = Gfx::WindowTheme::current().menubar_rect(Gfx::WindowTheme::WindowType::Normal, window_rect, wm.palette(), 1);
+    auto menubar_rect = Gfx::WindowTheme::current().menubar_rect(Gfx::WindowTheme::WindowType::Normal, Gfx::WindowTheme::WindowMode::Other, window_rect, wm.palette(), 1);
 
     int text_width = wm.font().width(Gfx::parse_ampersand_string(menu.name()));
     menu.set_rect_in_window_menubar({ m_next_menu_location.x(), 0, text_width + menubar_menu_margin, menubar_rect.height() });

--- a/Userland/Services/WindowServer/WMConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/WMConnectionFromClient.cpp
@@ -63,8 +63,7 @@ void WMConnectionFromClient::set_active_window(i32 client_id, i32 window_id)
         return;
     }
     auto& window = *(*it).value;
-    WindowManager::the().minimize_windows(window, false);
-    WindowManager::the().move_to_front_and_make_active(window);
+    WindowManager::the().restore_modal_chain(window);
 }
 
 void WMConnectionFromClient::popup_window_menu(i32 client_id, i32 window_id, Gfx::IntPoint const& screen_position)

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -190,52 +190,6 @@ bool Window::apply_minimum_size(Gfx::IntRect& rect)
     return did_size_clamp;
 }
 
-void Window::nudge_into_desktop(Screen* target_screen, bool force_titlebar_visible)
-{
-    if (!target_screen) {
-        // If no explicit target screen was supplied,
-        // guess based on the current frame rectangle
-        target_screen = &Screen::closest_to_rect(rect());
-    }
-    Gfx::IntRect arena = WindowManager::the().arena_rect_for_type(*target_screen, type());
-    auto min_visible = 1;
-    switch (type()) {
-    case WindowType::Normal:
-        min_visible = 30;
-        break;
-    case WindowType::Desktop:
-        set_rect(arena);
-        return;
-    default:
-        break;
-    }
-
-    // Push the frame around such that at least `min_visible` pixels of the *frame* are in the desktop rect.
-    auto old_frame_rect = frame().rect();
-    Gfx::IntRect new_frame_rect = {
-        clamp(old_frame_rect.x(), arena.left() + min_visible - width(), arena.right() - min_visible),
-        clamp(old_frame_rect.y(), arena.top() + min_visible - height(), arena.bottom() - min_visible),
-        old_frame_rect.width(),
-        old_frame_rect.height(),
-    };
-
-    // Make sure that at least half of the titlebar is visible.
-    auto min_frame_y = arena.top() - (y() - old_frame_rect.y()) / 2;
-    if (force_titlebar_visible && new_frame_rect.y() < min_frame_y) {
-        new_frame_rect.set_y(min_frame_y);
-    }
-
-    // Deduce new window rect:
-    Gfx::IntRect new_window_rect = {
-        x() + new_frame_rect.x() - old_frame_rect.x(),
-        y() + new_frame_rect.y() - old_frame_rect.y(),
-        width(),
-        height(),
-    };
-
-    set_rect(new_window_rect);
-}
-
 void Window::set_minimum_size(Gfx::IntSize const& size)
 {
     VERIFY(size.width() >= 0 && size.height() >= 0);

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -164,14 +164,6 @@ void Window::set_rect_without_repaint(Gfx::IntRect const& rect)
     auto old_rect = m_rect;
     m_rect = rect;
 
-    if (old_rect.size() == m_rect.size()) {
-        auto delta = m_rect.location() - old_rect.location();
-        for (auto& child_window : m_child_windows) {
-            if (child_window)
-                child_window->move_by(delta);
-        }
-    }
-
     invalidate(true, old_rect.size() != rect.size());
     m_frame.window_rect_changed(old_rect, rect);
     invalidate_last_rendered_screen_rects();

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -423,12 +423,10 @@ void Window::set_maximized(bool maximized)
         return;
     m_tile_type = maximized ? WindowTileType::Maximized : WindowTileType::None;
     update_window_menu_items();
-    if (maximized) {
-        m_unmaximized_rect = m_floating_rect;
+    if (maximized)
         set_rect(WindowManager::the().tiled_window_rect(*this));
-    } else {
-        set_rect(m_unmaximized_rect);
-    }
+    else
+        set_rect(m_floating_rect);
     m_frame.did_set_maximized({}, maximized);
     Core::EventLoop::current().post_event(*this, make<ResizeEvent>(m_rect));
     set_default_positioned(false);

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -19,8 +19,6 @@
 
 namespace WindowServer {
 
-static constexpr Gfx::IntSize s_default_normal_minimum_size = { 50, 50 };
-
 static String default_window_icon_path()
 {
     return "/res/icons/16x16/window.png";
@@ -88,10 +86,6 @@ Window::Window(Core::Object& parent, WindowType type)
     , m_icon(default_window_icon())
     , m_frame(*this)
 {
-    // Set default minimum size for Normal windows
-    if (m_type == WindowType::Normal)
-        m_minimum_size = s_default_normal_minimum_size;
-
     WindowManager::the().add_window(*this);
     frame().window_was_constructed({});
 }
@@ -112,10 +106,6 @@ Window::Window(ConnectionFromClient& client, WindowType window_type, int window_
     , m_icon(default_window_icon())
     , m_frame(*this)
 {
-    // Set default minimum size for Normal windows
-    if (m_type == WindowType::Normal)
-        m_minimum_size = s_default_normal_minimum_size;
-
     if (parent_window)
         set_parent_window(*parent_window);
     WindowManager::the().add_window(*this);
@@ -169,7 +159,7 @@ void Window::set_rect(Gfx::IntRect const& rect)
 
 void Window::set_rect_without_repaint(Gfx::IntRect const& rect)
 {
-    VERIFY(!rect.is_empty());
+    VERIFY(rect.width() >= 0 && rect.height() >= 0);
     if (m_rect == rect)
         return;
     auto old_rect = m_rect;
@@ -248,16 +238,9 @@ void Window::nudge_into_desktop(Screen* target_screen, bool force_titlebar_visib
 
 void Window::set_minimum_size(Gfx::IntSize const& size)
 {
-    if (size.is_null())
-        return;
-
+    VERIFY(size.width() >= 0 && size.height() >= 0);
     if (m_minimum_size == size)
         return;
-
-    // Disallow setting minimum zero widths or heights.
-    if (size.width() == 0 || size.height() == 0)
-        return;
-
     m_minimum_size = size;
 }
 

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -228,7 +228,7 @@ void Window::update_window_menu_items()
         return;
 
     m_window_menu_minimize_item->set_text(m_minimized_state != WindowMinimizedState::None ? "&Unminimize" : "Mi&nimize");
-    m_window_menu_minimize_item->set_enabled(m_minimizable);
+    m_window_menu_minimize_item->set_enabled(m_minimizable && !is_modal());
 
     m_window_menu_maximize_item->set_text(is_maximized() ? "&Restore" : "Ma&ximize");
     m_window_menu_maximize_item->set_enabled(m_resizable);

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -415,7 +415,7 @@ void Window::set_occluded(bool occluded)
     WindowManager::the().notify_occlusion_state_changed(*this);
 }
 
-void Window::set_maximized(bool maximized, Optional<Gfx::IntPoint> fixed_point)
+void Window::set_maximized(bool maximized)
 {
     if (is_maximized() == maximized)
         return;
@@ -427,13 +427,7 @@ void Window::set_maximized(bool maximized, Optional<Gfx::IntPoint> fixed_point)
         m_unmaximized_rect = m_floating_rect;
         set_rect(WindowManager::the().tiled_window_rect(*this));
     } else {
-        if (fixed_point.has_value()) {
-            auto new_rect = Gfx::IntRect(m_rect);
-            new_rect.set_size_around(m_unmaximized_rect.size(), fixed_point.value());
-            set_rect(new_rect);
-        } else {
-            set_rect(m_unmaximized_rect);
-        }
+        set_rect(m_unmaximized_rect);
     }
     m_frame.did_set_maximized({}, maximized);
     Core::EventLoop::current().post_event(*this, make<ResizeEvent>(m_rect));
@@ -920,21 +914,14 @@ void Window::check_untile_due_to_resize(Gfx::IntRect const& new_rect)
     m_tile_type = new_tile_type;
 }
 
-bool Window::set_untiled(Optional<Gfx::IntPoint> fixed_point)
+bool Window::set_untiled()
 {
     if (m_tile_type == WindowTileType::None)
         return false;
     VERIFY(!resize_aspect_ratio().has_value());
 
     m_tile_type = WindowTileType::None;
-
-    if (fixed_point.has_value()) {
-        auto new_rect = Gfx::IntRect(m_rect);
-        new_rect.set_size_around(m_floating_rect.size(), fixed_point.value());
-        set_rect(new_rect);
-    } else {
-        set_rect(m_floating_rect);
-    }
+    set_rect(m_floating_rect);
 
     Core::EventLoop::current().post_event(*this, make<ResizeEvent>(m_rect));
 

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -989,6 +989,17 @@ void Window::set_parent_window(Window& parent_window)
         parent_window.add_child_window(*this);
 }
 
+Window* Window::modeless_ancestor()
+{
+    if (!is_modal())
+        return this;
+    for (auto parent = m_parent_window; parent; parent = parent->parent_window()) {
+        if (!parent->is_modal())
+            return parent;
+    }
+    return nullptr;
+}
+
 bool Window::is_accessory() const
 {
     if (!m_accessory)

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -90,11 +90,11 @@ Window::Window(Core::Object& parent, WindowType type)
     frame().window_was_constructed({});
 }
 
-Window::Window(ConnectionFromClient& client, WindowType window_type, int window_id, bool modal, bool minimizable, bool closeable, bool frameless, bool resizable, bool fullscreen, bool accessory, Window* parent_window)
+Window::Window(ConnectionFromClient& client, WindowType window_type, WindowMode window_mode, int window_id, bool minimizable, bool closeable, bool frameless, bool resizable, bool fullscreen, bool accessory, Window* parent_window)
     : Core::Object(&client)
     , m_client(&client)
     , m_type(window_type)
-    , m_modal(modal)
+    , m_mode(window_mode)
     , m_minimizable(minimizable)
     , m_closeable(closeable)
     , m_frameless(frameless)
@@ -739,7 +739,7 @@ void Window::ensure_window_menu()
 
         m_window_menu->add_item(make<MenuItem>(*m_window_menu, MenuItem::Type::Separator));
 
-        if (!m_modal) {
+        if (!is_modal()) {
             auto pin_item = make<MenuItem>(*m_window_menu, (unsigned)WindowMenuAction::ToggleAlwaysOnTop, "Always on &Top");
             m_window_menu_always_on_top_item = pin_item.ptr();
             m_window_menu_always_on_top_item->set_icon(&pin_icon());
@@ -1017,23 +1017,6 @@ bool Window::is_accessory_of(Window& window) const
     if (!is_accessory())
         return false;
     return parent_window() == &window;
-}
-
-void Window::modal_unparented()
-{
-    m_modal = false;
-    WindowManager::the().notify_modal_unparented(*this);
-}
-
-bool Window::is_modal() const
-{
-    if (!m_modal)
-        return false;
-    if (!m_parent_window) {
-        const_cast<Window*>(this)->modal_unparented();
-        return false;
-    }
-    return true;
 }
 
 void Window::set_progress(Optional<int> progress)

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -134,10 +134,7 @@ public:
     bool is_occluded() const { return m_occluded; }
     void set_occluded(bool);
 
-    bool is_movable() const
-    {
-        return m_type == WindowType::Normal || m_type == WindowType::ToolWindow;
-    }
+    bool is_movable() const { return m_type == WindowType::Normal; }
 
     WindowFrame& frame() { return m_frame; }
     WindowFrame const& frame() const { return m_frame; }
@@ -183,6 +180,7 @@ public:
 
     bool is_modal() const { return m_mode != WindowMode::Modeless; }
     bool is_passive() { return m_mode == WindowMode::Passive; }
+    bool is_rendering_above() { return m_mode == WindowMode::RenderAbove; }
 
     bool is_blocking() const { return m_mode == WindowMode::Blocking; }
     Window* blocking_modal_window();

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -184,6 +184,7 @@ public:
 
     bool is_modal() const;
     bool is_modal_dont_unparent() const { return m_modal && m_parent_window; }
+    Window* modeless_ancestor();
 
     Gfx::IntRect rect() const { return m_rect; }
     void set_rect(Gfx::IntRect const&);

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -182,6 +182,9 @@ public:
     bool is_passive() { return m_mode == WindowMode::Passive; }
     bool is_rendering_above() { return m_mode == WindowMode::RenderAbove; }
 
+    bool is_capturing_input() const { return m_mode == WindowMode::CaptureInput; }
+    bool is_capturing_active_input_from(Window const&) const;
+
     bool is_blocking() const { return m_mode == WindowMode::Blocking; }
     Window* blocking_modal_window();
 
@@ -308,14 +311,7 @@ public:
     Vector<WeakPtr<Window>>& child_windows() { return m_child_windows; }
     Vector<WeakPtr<Window>> const& child_windows() const { return m_child_windows; }
 
-    Vector<WeakPtr<Window>>& accessory_windows() { return m_accessory_windows; }
-    Vector<WeakPtr<Window>> const& accessory_windows() const { return m_accessory_windows; }
-
     bool is_descendant_of(Window&) const;
-
-    void set_accessory(bool accessory) { m_accessory = accessory; }
-    bool is_accessory() const;
-    bool is_accessory_of(Window&) const;
 
     void set_frameless(bool);
     bool is_frameless() const { return m_frameless; }
@@ -383,14 +379,13 @@ public:
     bool is_stealable_by_client(i32 client_id) const { return m_stealable_by_client_ids.contains_slow(client_id); }
 
 private:
-    Window(ConnectionFromClient&, WindowType, WindowMode, int window_id, bool minimizable, bool closeable, bool frameless, bool resizable, bool fullscreen, bool accessory, Window* parent_window = nullptr);
+    Window(ConnectionFromClient&, WindowType, WindowMode, int window_id, bool minimizable, bool closeable, bool frameless, bool resizable, bool fullscreen, Window* parent_window = nullptr);
     Window(Core::Object&, WindowType);
 
     virtual void event(Core::Event&) override;
     void handle_mouse_event(MouseEvent const&);
     void handle_keydown_event(KeyEvent const&);
     void add_child_window(Window&);
-    void add_accessory_window(Window&);
     void ensure_window_menu();
     void update_window_menu_items();
     void modal_unparented();
@@ -399,7 +394,6 @@ private:
 
     WeakPtr<Window> m_parent_window;
     Vector<WeakPtr<Window>> m_child_windows;
-    Vector<WeakPtr<Window>> m_accessory_windows;
 
     Menubar m_menubar;
 
@@ -426,7 +420,6 @@ private:
     Optional<Gfx::IntSize> m_resize_aspect_ratio {};
     WindowMinimizedState m_minimized_state { WindowMinimizedState::None };
     bool m_fullscreen { false };
-    bool m_accessory { false };
     bool m_destroyed { false };
     bool m_default_positioned { false };
     bool m_have_taskbar_rect { false };

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -455,7 +455,6 @@ private:
     RefPtr<Cursor> m_cursor_override;
     WindowFrame m_frame;
     Gfx::DisjointRectSet m_pending_paint_rects;
-    Gfx::IntRect m_unmaximized_rect;
     Gfx::IntRect m_rect_in_applet_area;
     RefPtr<Menu> m_window_menu;
     MenuItem* m_window_menu_minimize_item { nullptr };

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -190,7 +190,6 @@ public:
     void set_rect(int x, int y, int width, int height) { set_rect({ x, y, width, height }); }
     void set_rect_without_repaint(Gfx::IntRect const&);
     bool apply_minimum_size(Gfx::IntRect&);
-    void nudge_into_desktop(Screen*, bool force_titlebar_visible = true);
 
     Gfx::IntSize minimum_size() const { return m_minimum_size; }
     void set_minimum_size(Gfx::IntSize const&);

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -450,7 +450,7 @@ private:
     float m_alpha_hit_threshold { 0.0f };
     Gfx::IntSize m_size_increment;
     Gfx::IntSize m_base_size;
-    Gfx::IntSize m_minimum_size { 1, 1 };
+    Gfx::IntSize m_minimum_size { 0, 0 };
     NonnullRefPtr<Gfx::Bitmap> m_icon;
     RefPtr<Cursor> m_cursor;
     RefPtr<Cursor> m_cursor_override;

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -109,7 +109,7 @@ public:
     void set_resizable(bool);
 
     bool is_maximized() const { return m_tile_type == WindowTileType::Maximized; }
-    void set_maximized(bool, Optional<Gfx::IntPoint> fixed_point = {});
+    void set_maximized(bool);
 
     bool is_always_on_top() const { return m_always_on_top; }
     void set_always_on_top(bool);
@@ -122,7 +122,7 @@ public:
     void set_tiled(WindowTileType);
     WindowTileType tile_type_based_on_rect(Gfx::IntRect const&) const;
     void check_untile_due_to_resize(Gfx::IntRect const&);
-    bool set_untiled(Optional<Gfx::IntPoint> fixed_point = {});
+    bool set_untiled();
 
     Gfx::IntRect floating_rect() const { return m_floating_rect; }
     void set_floating_rect(Gfx::IntRect rect) { m_floating_rect = rect; }
@@ -265,7 +265,7 @@ public:
         // The screen can change, so "tiled" and "fixed aspect ratio" are mutually exclusive.
         // Similarly for "maximized" and "fixed aspect ratio".
         // In order to resolve this, undo those properties first:
-        set_untiled(position());
+        set_untiled();
         set_maximized(false);
         m_resize_aspect_ratio = ratio;
     }

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -292,7 +292,6 @@ public:
     void request_update(Gfx::IntRect const&, bool ignore_occlusion = false);
     Gfx::DisjointRectSet take_pending_paint_rects() { return move(m_pending_paint_rects); }
 
-    bool has_taskbar_rect() const { return m_have_taskbar_rect; };
     void start_minimize_animation();
 
     void start_launch_animation(Gfx::IntRect const&);
@@ -422,7 +421,6 @@ private:
     bool m_fullscreen { false };
     bool m_destroyed { false };
     bool m_default_positioned { false };
-    bool m_have_taskbar_rect { false };
     bool m_invalidated { true };
     bool m_invalidated_all { true };
     bool m_invalidated_frame { true };

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -278,7 +278,7 @@ Gfx::WindowTheme::WindowState WindowFrame::window_state_for_theme() const
         return Gfx::WindowTheme::WindowState::Highlighted;
     if (&m_window == wm.m_move_window)
         return Gfx::WindowTheme::WindowState::Moving;
-    if (wm.is_active_window_or_accessory(m_window))
+    if (wm.is_active_window_or_capturing_modal(m_window))
         return Gfx::WindowTheme::WindowState::Active;
     return Gfx::WindowTheme::WindowState::Inactive;
 }

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -107,7 +107,7 @@ void WindowFrame::window_was_constructed(Badge<Window>)
         m_buttons.append(move(button));
     }
 
-    if (m_window.is_minimizable()) {
+    if (m_window.is_minimizable() && !m_window.is_modal()) {
         auto button = make<Button>(*this, [this](auto&) {
             m_window.handle_window_menu_action(WindowMenuAction::MinimizeOrUnminimize);
         });
@@ -136,7 +136,7 @@ void WindowFrame::set_button_icons()
         m_close_button->set_icon(m_window.is_modified() ? s_close_modified_icon : s_close_icon);
         m_close_button->set_style(button_style);
     }
-    if (m_window.is_minimizable()) {
+    if (m_window.is_minimizable() && !m_window.is_modal()) {
         m_minimize_button->set_icon(s_minimize_icon);
         m_minimize_button->set_style(button_style);
     }

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -26,12 +26,20 @@ static Gfx::WindowTheme::WindowType to_theme_window_type(WindowType type)
     switch (type) {
     case WindowType::Normal:
         return Gfx::WindowTheme::WindowType::Normal;
-    case WindowType::ToolWindow:
-        return Gfx::WindowTheme::WindowType::ToolWindow;
     case WindowType::Notification:
         return Gfx::WindowTheme::WindowType::Notification;
     default:
         return Gfx::WindowTheme::WindowType::Other;
+    }
+}
+
+static Gfx::WindowTheme::WindowMode to_theme_window_mode(WindowMode mode)
+{
+    switch (mode) {
+    case WindowMode::RenderAbove:
+        return Gfx::WindowTheme::WindowMode::RenderAbove;
+    default:
+        return Gfx::WindowTheme::WindowMode::Other;
     }
 }
 
@@ -57,7 +65,7 @@ static Gfx::IntRect frame_rect_for_window(Window& window, Gfx::IntRect const& re
     if (window.is_frameless())
         return rect;
     int menu_row_count = (window.menubar().has_menus() && window.should_show_menubar()) ? 1 : 0;
-    return Gfx::WindowTheme::current().frame_rect_for_window(to_theme_window_type(window.type()), rect, WindowManager::the().palette(), menu_row_count);
+    return Gfx::WindowTheme::current().frame_rect_for_window(to_theme_window_type(window.type()), to_theme_window_mode(window.mode()), rect, WindowManager::the().palette(), menu_row_count);
 }
 
 WindowFrame::WindowFrame(Window& window)
@@ -241,22 +249,22 @@ Gfx::IntRect WindowFrame::menubar_rect() const
 {
     if (!m_window.menubar().has_menus() || !m_window.should_show_menubar())
         return {};
-    return Gfx::WindowTheme::current().menubar_rect(to_theme_window_type(m_window.type()), m_window.rect(), WindowManager::the().palette(), menu_row_count());
+    return Gfx::WindowTheme::current().menubar_rect(to_theme_window_type(m_window.type()), to_theme_window_mode(m_window.mode()), m_window.rect(), WindowManager::the().palette(), menu_row_count());
 }
 
 Gfx::IntRect WindowFrame::titlebar_rect() const
 {
-    return Gfx::WindowTheme::current().titlebar_rect(to_theme_window_type(m_window.type()), m_window.rect(), WindowManager::the().palette());
+    return Gfx::WindowTheme::current().titlebar_rect(to_theme_window_type(m_window.type()), to_theme_window_mode(m_window.mode()), m_window.rect(), WindowManager::the().palette());
 }
 
 Gfx::IntRect WindowFrame::titlebar_icon_rect() const
 {
-    return Gfx::WindowTheme::current().titlebar_icon_rect(to_theme_window_type(m_window.type()), m_window.rect(), WindowManager::the().palette());
+    return Gfx::WindowTheme::current().titlebar_icon_rect(to_theme_window_type(m_window.type()), to_theme_window_mode(m_window.mode()), m_window.rect(), WindowManager::the().palette());
 }
 
 Gfx::IntRect WindowFrame::titlebar_text_rect() const
 {
-    return Gfx::WindowTheme::current().titlebar_text_rect(to_theme_window_type(m_window.type()), m_window.rect(), WindowManager::the().palette());
+    return Gfx::WindowTheme::current().titlebar_text_rect(to_theme_window_type(m_window.type()), to_theme_window_mode(m_window.mode()), m_window.rect(), WindowManager::the().palette());
 }
 
 Gfx::WindowTheme::WindowState WindowFrame::window_state_for_theme() const
@@ -278,13 +286,7 @@ Gfx::WindowTheme::WindowState WindowFrame::window_state_for_theme() const
 void WindowFrame::paint_notification_frame(Gfx::Painter& painter)
 {
     auto palette = WindowManager::the().palette();
-    Gfx::WindowTheme::current().paint_notification_frame(painter, m_window.rect(), palette, m_buttons.last().relative_rect());
-}
-
-void WindowFrame::paint_tool_window_frame(Gfx::Painter& painter)
-{
-    auto palette = WindowManager::the().palette();
-    Gfx::WindowTheme::current().paint_tool_window_frame(painter, window_state_for_theme(), m_window.rect(), m_window.computed_title(), palette, leftmost_titlebar_button_rect());
+    Gfx::WindowTheme::current().paint_notification_frame(painter, to_theme_window_mode(m_window.mode()), m_window.rect(), palette, m_buttons.last().relative_rect());
 }
 
 void WindowFrame::paint_menubar(Gfx::Painter& painter)
@@ -326,7 +328,7 @@ void WindowFrame::paint_menubar(Gfx::Painter& painter)
 void WindowFrame::paint_normal_frame(Gfx::Painter& painter)
 {
     auto palette = WindowManager::the().palette();
-    Gfx::WindowTheme::current().paint_normal_frame(painter, window_state_for_theme(), m_window.rect(), m_window.computed_title(), m_window.icon(), palette, leftmost_titlebar_button_rect(), menu_row_count(), m_window.is_modified());
+    Gfx::WindowTheme::current().paint_normal_frame(painter, window_state_for_theme(), to_theme_window_mode(m_window.mode()), m_window.rect(), m_window.computed_title(), m_window.icon(), palette, leftmost_titlebar_button_rect(), menu_row_count(), m_window.is_modified());
 
     if (m_window.menubar().has_menus() && m_window.should_show_menubar())
         paint_menubar(painter);
@@ -387,8 +389,6 @@ void WindowFrame::render(Screen& screen, Gfx::Painter& painter)
         paint_notification_frame(painter);
     else if (m_window.type() == WindowType::Normal)
         paint_normal_frame(painter);
-    else if (m_window.type() == WindowType::ToolWindow)
-        paint_tool_window_frame(painter);
     else
         return;
 
@@ -667,7 +667,7 @@ void WindowFrame::window_rect_changed(Gfx::IntRect const& old_rect, Gfx::IntRect
 
 void WindowFrame::layout_buttons()
 {
-    auto button_rects = Gfx::WindowTheme::current().layout_buttons(to_theme_window_type(m_window.type()), m_window.rect(), WindowManager::the().palette(), m_buttons.size());
+    auto button_rects = Gfx::WindowTheme::current().layout_buttons(to_theme_window_type(m_window.type()), to_theme_window_mode(m_window.mode()), m_window.rect(), WindowManager::the().palette(), m_buttons.size());
     for (size_t i = 0; i < m_buttons.size(); i++)
         m_buttons[i].set_relative_rect(button_rects[i]);
 }
@@ -792,7 +792,7 @@ void WindowFrame::handle_titlebar_mouse_event(MouseEvent const& event)
     }
 
     if (event.type() == Event::MouseDown) {
-        if ((m_window.type() == WindowType::Normal || m_window.type() == WindowType::ToolWindow) && event.button() == MouseButton::Secondary) {
+        if (m_window.type() == WindowType::Normal && event.button() == MouseButton::Secondary) {
             auto default_action = m_window.is_maximized() ? WindowMenuDefaultAction::Restore : WindowMenuDefaultAction::Maximize;
             m_window.popup_window_menu(event.position().translated(rect().location()), default_action);
             return;
@@ -806,11 +806,11 @@ void WindowFrame::handle_mouse_event(MouseEvent const& event)
 {
     VERIFY(!m_window.is_fullscreen());
 
-    if (m_window.type() != WindowType::Normal && m_window.type() != WindowType::ToolWindow && m_window.type() != WindowType::Notification)
+    if (m_window.type() != WindowType::Normal && m_window.type() != WindowType::Notification)
         return;
 
     auto& wm = WindowManager::the();
-    if (m_window.type() == WindowType::Normal || m_window.type() == WindowType::ToolWindow) {
+    if (m_window.type() == WindowType::Normal) {
         if (event.type() == Event::MouseDown)
             wm.move_to_front_and_make_active(m_window);
     }

--- a/Userland/Services/WindowServer/WindowFrame.h
+++ b/Userland/Services/WindowServer/WindowFrame.h
@@ -122,7 +122,6 @@ public:
 private:
     void paint_notification_frame(Gfx::Painter&);
     void paint_normal_frame(Gfx::Painter&);
-    void paint_tool_window_frame(Gfx::Painter&);
     void paint_menubar(Gfx::Painter&);
     MultiScaleBitmaps const* shadow_bitmap() const;
     Gfx::IntRect inflated_for_shadow(Gfx::IntRect const&) const;

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -835,11 +835,6 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event)
             } else if (!m_move_window->is_tiled()) {
                 Gfx::IntPoint pos = m_move_window_origin.translated(event.position() - m_move_origin);
                 m_move_window->set_position_without_repaint(pos);
-                // "Bounce back" the window if it would end up too far outside the screen.
-                // If the user has let go of Mod_Super, maybe they didn't intentionally press it to begin with.
-                // Therefore, refuse to go into a state where knowledge about super-drags is necessary.
-                bool force_titlebar_visible = !(m_keyboard_modifiers & Mod_Super);
-                m_move_window->nudge_into_desktop(&cursor_screen, force_titlebar_visible);
             } else if (pixels_moved_from_start > 5) {
                 Gfx::IntPoint adjusted_position = event.position().translated(-m_move_window_cursor_position);
                 m_move_window->set_untiled();

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -2124,6 +2124,16 @@ void WindowManager::did_popup_a_menu(Badge<Menu>)
     set_automatic_cursor_tracking_window(nullptr);
 }
 
+void WindowManager::restore_modal_chain(Window& window)
+{
+    for_each_window_in_modal_chain(window, [&](auto& w) {
+        w.set_minimized(false);
+        w.window_stack().move_to_front(w);
+        return IterationDecision::Continue;
+    });
+    move_to_front_and_make_active(window);
+}
+
 void WindowManager::minimize_windows(Window& window, bool minimized)
 {
     for_each_window_in_modal_chain(window, [&](auto& w) {

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -577,7 +577,7 @@ void WindowManager::tell_wms_current_window_stack_changed()
 
 static bool window_type_has_title(WindowType type)
 {
-    return type == WindowType::Normal || type == WindowType::ToolWindow;
+    return type == WindowType::Normal;
 }
 
 void WindowManager::notify_modified_changed(Window& window)
@@ -649,7 +649,7 @@ bool WindowManager::pick_new_active_window(Window* previous_active)
     Window* first_candidate = nullptr;
 
     for_each_visible_window_from_front_to_back([&](Window& candidate) {
-        if (candidate.type() != WindowType::Normal && candidate.type() != WindowType::ToolWindow)
+        if (candidate.type() != WindowType::Normal)
             return IterationDecision::Continue;
         if (candidate.is_destroyed())
             return IterationDecision::Continue;
@@ -1246,7 +1246,7 @@ void WindowManager::process_mouse_event_for_window(HitTestResult& result, MouseE
     }
 
     if (event.type() == Event::MouseDown) {
-        if (window.type() == WindowType::Normal || window.type() == WindowType::ToolWindow)
+        if (window.type() == WindowType::Normal)
             move_to_front_and_make_active(window);
         else if (window.type() == WindowType::Desktop)
             set_active_window(&window);
@@ -1420,7 +1420,6 @@ Gfx::IntRect WindowManager::arena_rect_for_type(Screen& screen, WindowType type)
     case WindowType::Desktop:
         return Screen::bounding_rect();
     case WindowType::Normal:
-    case WindowType::ToolWindow:
         return desktop_rect(screen);
     case WindowType::Menu:
     case WindowType::WindowSwitcher:
@@ -1797,7 +1796,7 @@ bool WindowManager::is_active_window_or_accessory(Window& window) const
 
 static bool window_type_can_become_active(WindowType type)
 {
-    return type == WindowType::Normal || type == WindowType::ToolWindow || type == WindowType::Desktop;
+    return type == WindowType::Normal || type == WindowType::Desktop;
 }
 
 void WindowManager::restore_active_input_window(Window* window)
@@ -2193,7 +2192,7 @@ void WindowManager::set_always_on_top(Window& window, bool always_on_top)
 Gfx::IntPoint WindowManager::get_recommended_window_position(Gfx::IntPoint const& desired)
 {
     // FIXME: Find a  better source for the width and height to shift by.
-    Gfx::IntPoint shift(8, Gfx::WindowTheme::current().titlebar_height(Gfx::WindowTheme::WindowType::Normal, palette()) + 10);
+    Gfx::IntPoint shift(8, Gfx::WindowTheme::current().titlebar_height(Gfx::WindowTheme::WindowType::Normal, Gfx::WindowTheme::WindowMode::Other, palette()) + 10);
 
     Window const* overlap_window = nullptr;
     current_window_stack().for_each_visible_window_of_type_from_front_to_back(WindowType::Normal, [&](Window& window) {
@@ -2209,7 +2208,7 @@ Gfx::IntPoint WindowManager::get_recommended_window_position(Gfx::IntPoint const
         point = overlap_window->position() + shift;
         point = { point.x() % screen.width(),
             (point.y() >= (screen.height() - (screen.is_main_screen() ? TaskbarWindow::taskbar_height() : 0)))
-                ? Gfx::WindowTheme::current().titlebar_height(Gfx::WindowTheme::WindowType::Normal, palette())
+                ? Gfx::WindowTheme::current().titlebar_height(Gfx::WindowTheme::WindowType::Normal, Gfx::WindowTheme::WindowMode::Other, palette())
                 : point.y() };
     } else {
         point = desired;

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -446,7 +446,7 @@ void WindowManager::tell_wm_about_window(WMConnectionFromClient& conn, Window& w
         return;
     auto* parent = window.parent_window();
     auto& window_stack = is_stationary_window_type(window.type()) ? current_window_stack() : window.window_stack();
-    conn.async_window_state_changed(conn.window_id(), window.client_id(), window.window_id(), parent ? parent->client_id() : -1, parent ? parent->window_id() : -1, window_stack.row(), window_stack.column(), window.is_active(), window.is_minimized(), window.is_modal_dont_unparent(), window.is_frameless(), (i32)window.type(), window.computed_title(), window.rect(), window.progress());
+    conn.async_window_state_changed(conn.window_id(), window.client_id(), window.window_id(), parent ? parent->client_id() : -1, parent ? parent->window_id() : -1, window_stack.row(), window_stack.column(), window.is_active(), window.is_minimized(), window.is_modal(), window.is_frameless(), (i32)window.type(), window.computed_title(), window.rect(), window.progress());
 }
 
 void WindowManager::tell_wm_about_window_rect(WMConnectionFromClient& conn, Window& window)
@@ -594,19 +594,6 @@ void WindowManager::notify_title_changed(Window& window)
         return;
 
     dbgln_if(WINDOWMANAGER_DEBUG, "[WM] Window({}) title set to '{}'", &window, window.title());
-
-    if (m_switcher->is_visible())
-        m_switcher->refresh();
-
-    tell_wms_window_state_changed(window);
-}
-
-void WindowManager::notify_modal_unparented(Window& window)
-{
-    if (window.type() != WindowType::Normal)
-        return;
-
-    dbgln_if(WINDOWMANAGER_DEBUG, "[WM] Window({}) was unparented", &window);
 
     if (m_switcher->is_visible())
         m_switcher->refresh();

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -2043,9 +2043,9 @@ Gfx::IntRect WindowManager::tiled_window_rect(Window const& window, WindowTileTy
     if (tile_type == WindowTileType::Bottom
         || tile_type == WindowTileType::BottomLeft
         || tile_type == WindowTileType::BottomRight) {
-        auto half_screen_reminder = rect.height() % 2;
-        rect.set_height(rect.height() / 2 + half_screen_reminder);
-        rect.set_y(rect.height() - half_screen_reminder);
+        auto half_screen_remainder = rect.height() % 2;
+        rect.set_height(rect.height() / 2 + half_screen_remainder);
+        rect.set_y(rect.height() - half_screen_remainder);
     }
 
     Gfx::IntRect window_rect = window.rect();

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1673,7 +1673,7 @@ void WindowManager::process_key_event(KeyEvent& event)
                     maximize_windows(*active_input_window, false);
                     return;
                 }
-                if (active_input_window->is_minimizable())
+                if (active_input_window->is_minimizable() && !active_input_window->is_modal())
                     minimize_windows(*active_input_window, true);
                 return;
             }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1809,11 +1809,15 @@ Window* WindowManager::set_active_input_window(Window* window)
 void WindowManager::notify_new_active_input_window(Window& new_input_window)
 {
     Core::EventLoop::current().post_event(new_input_window, make<Event>(Event::WindowInputEntered));
+    if (new_input_window.is_capturing_input() && !new_input_window.is_frameless())
+        new_input_window.invalidate(true, true);
 }
 
 void WindowManager::notify_previous_active_input_window(Window& previous_input_window)
 {
     Core::EventLoop::current().post_event(previous_input_window, make<Event>(Event::WindowInputLeft));
+    if (previous_input_window.is_capturing_input() && !previous_input_window.is_frameless())
+        previous_input_window.invalidate(true, true);
 }
 
 void WindowManager::set_active_window(Window* new_active_window, bool make_input)

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -371,7 +371,7 @@ private:
     void tell_wm_about_window_icon(WMConnectionFromClient& conn, Window&);
     void tell_wm_about_window_rect(WMConnectionFromClient& conn, Window&);
     void tell_wm_about_current_window_stack(WMConnectionFromClient&);
-    bool pick_new_active_window(Window*);
+    void pick_new_active_window(Window*);
 
     bool sync_config_to_disk();
 

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -233,6 +233,7 @@ public:
     void start_menu_doubleclick(Window& window, MouseEvent const& event);
     bool is_menu_doubleclick(Window& window, MouseEvent const& event) const;
 
+    void restore_modal_chain(Window&);
     void minimize_windows(Window&, bool);
     void hide_windows(Window&, bool);
     void maximize_windows(Window&, bool);

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -194,7 +194,7 @@ public:
     void tell_wms_super_digit_key_pressed(u8);
     void tell_wms_current_window_stack_changed();
 
-    bool is_active_window_or_accessory(Window&) const;
+    bool is_active_window_or_capturing_modal(Window&) const;
 
     void check_hide_geometry_overlay(Window&);
 

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -312,7 +312,6 @@ public:
     {
         switch (window_type) {
         case WindowType::Normal:
-        case WindowType::ToolWindow:
         case WindowType::Tooltip:
             return false;
         default:
@@ -516,8 +515,6 @@ inline IterationDecision WindowManager::for_each_visible_window_from_back_to_fro
         return IterationDecision::Break;
     if (for_each_window.template operator()<WindowType::Normal>() == IterationDecision::Break)
         return IterationDecision::Break;
-    if (for_each_window.template operator()<WindowType::ToolWindow>() == IterationDecision::Break)
-        return IterationDecision::Break;
     if (for_each_window.template operator()<WindowType::Taskbar>() == IterationDecision::Break)
         return IterationDecision::Break;
     if (for_each_window.template operator()<WindowType::AppletArea>() == IterationDecision::Break)
@@ -560,8 +557,6 @@ inline IterationDecision WindowManager::for_each_visible_window_from_front_to_ba
     if (for_each_window.template operator()<WindowType::AppletArea>() == IterationDecision::Break)
         return IterationDecision::Break;
     if (for_each_window.template operator()<WindowType::Taskbar>() == IterationDecision::Break)
-        return IterationDecision::Break;
-    if (for_each_window.template operator()<WindowType::ToolWindow>() == IterationDecision::Break)
         return IterationDecision::Break;
     if (for_each_window.template operator()<WindowType::Normal>() == IterationDecision::Break)
         return IterationDecision::Break;

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -81,7 +81,6 @@ public:
     void remove_window(Window&);
 
     void notify_title_changed(Window&);
-    void notify_modal_unparented(Window&);
     void notify_rect_changed(Window&, Gfx::IntRect const& oldRect, Gfx::IntRect const& newRect);
     void notify_minimization_state_changed(Window&);
     void notify_opacity_changed(Window&);

--- a/Userland/Services/WindowServer/WindowManagerClient.ipc
+++ b/Userland/Services/WindowServer/WindowManagerClient.ipc
@@ -3,7 +3,7 @@
 endpoint WindowManagerClient
 {
     window_removed(i32 wm_id, i32 client_id, i32 window_id) =|
-    window_state_changed(i32 wm_id, i32 client_id, i32 window_id, i32 parent_client_id, i32 parent_window_id, u32 workspace_row, u32 workspace_column, bool is_active, bool is_minimized, bool is_modal, bool is_frameless, i32 window_type, [UTF8] String title, Gfx::IntRect rect, Optional<i32> progress) =|
+    window_state_changed(i32 wm_id, i32 client_id, i32 window_id, u32 workspace_row, u32 workspace_column, bool is_active, bool is_minimized, bool is_frameless, i32 window_type, [UTF8] String title, Gfx::IntRect rect, Optional<i32> progress) =|
     window_icon_bitmap_changed(i32 wm_id, i32 client_id, i32 window_id, Gfx::ShareableBitmap bitmap) =|
     window_rect_changed(i32 wm_id, i32 client_id, i32 window_id, Gfx::IntRect rect) =|
     applet_area_size_changed(i32 wm_id, Gfx::IntSize size) =|

--- a/Userland/Services/WindowServer/WindowMode.h
+++ b/Userland/Services/WindowServer/WindowMode.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace WindowServer {
+
+// WindowMode sets modal behavior for windows in a modal chain
+//
+// - Modeless:      No modal effect (default mode for parentless windows)
+// - Passive:       Joins the modal chain but has no modal effect (default mode for child windows)
+// - RenderAbove:   Renders above its parent
+// - CaptureInput:  Captures input from its parent
+// - Blocking:      Preempts all interaction with its modal chain
+enum class WindowMode {
+    Modeless = 0,
+    Passive,
+    RenderAbove,
+    CaptureInput,
+    Blocking,
+    _Count,
+};
+
+}

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -44,7 +44,6 @@ endpoint WindowServer
         Gfx::IntRect rect,
         bool auto_position,
         bool has_alpha_channel,
-        bool modal,
         bool minimizable,
         bool closeable,
         bool resizable,
@@ -59,6 +58,7 @@ endpoint WindowServer
         Gfx::IntSize minimum_size,
         Optional<Gfx::IntSize> resize_aspect_ratio,
         i32 type,
+        i32 mode,
         [UTF8] String title,
         i32 parent_window_id,
         Gfx::IntRect launch_origin_rect) =|

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -50,7 +50,6 @@ endpoint WindowServer
         bool fullscreen,
         bool frameless,
         bool forced_shadow,
-        bool accessory,
         float opacity,
         float alpha_hit_threshold,
         Gfx::IntSize base_size,

--- a/Userland/Services/WindowServer/WindowSwitcher.cpp
+++ b/Userland/Services/WindowServer/WindowSwitcher.cpp
@@ -90,8 +90,7 @@ void WindowSwitcher::on_key_event(KeyEvent const& event)
     if (event.type() == Event::KeyUp) {
         if (event.key() == (m_mode == Mode::ShowAllWindows ? Key_Super : Key_Alt)) {
             if (auto* window = selected_window()) {
-                window->set_minimized(false);
-                WindowManager::the().move_to_front_and_make_active(*window);
+                WindowManager::the().restore_modal_chain(*window);
             }
             WindowManager::the().set_highlight_window(nullptr);
             hide();
@@ -227,7 +226,7 @@ void WindowSwitcher::refresh()
     auto add_window_stack_windows = [&](WindowStack& window_stack) {
         window_stack.for_each_window_of_type_from_front_to_back(
             WindowType::Normal, [&](Window& window) {
-                if (window.is_frameless())
+                if (window.is_frameless() || window.is_modal())
                     return IterationDecision::Continue;
                 ++window_count;
                 longest_title_width = max(longest_title_width, wm.font().width(window.computed_title()));

--- a/Userland/Services/WindowServer/WindowType.h
+++ b/Userland/Services/WindowServer/WindowType.h
@@ -18,7 +18,6 @@ enum class WindowType {
     Applet,
     Notification,
     Desktop,
-    ToolWindow,
     AppletArea,
     _Count
 };


### PR DESCRIPTION
This tackles a few long-standing oddities in the windowing system, mainly by re-thinking window modality.
Fixes #10970
Fixes #13036
Fixes children resizing/relocating after being hidden and shown again
Fixes children always moving in tandem with their parents
Fixes eligible children failing to be blocked by sibling modals
Fixes eligible children failing to switch workspaces with their parents
Fixes eligible children failing to minimize and restore with their parents
Fixes windows tiling below the taskbar on additional workspaces

https://user-images.githubusercontent.com/66646555/186541545-5bfd87dd-820e-4174-8330-d4490d2dbec0.mp4


