### PR TITLE
Kernel: Protect the AsyncDeviceRequest waiting process with a Spinlock

### DIFF
--- a/Kernel/Devices/AsyncDeviceRequest.h
+++ b/Kernel/Devices/AsyncDeviceRequest.h
@@ -152,6 +152,7 @@ private:
     NonnullLockRefPtr<Process> m_process;
     void* m_private { nullptr };
     mutable Spinlock m_lock { LockRank::None };
+    mutable Spinlock m_wait_lock { LockRank::None };
 };
 
 }


### PR DESCRIPTION
This should minimize the opportunity for a `notify_all()` to slip in after we already checked if the request is already done, but before we manage to block the thread, resulting in an infinite wait (as we start blocking after the notification already arrived).

As this does not fix the issue entirely, this is a draft for now. Feedback and better solutions would be greatly appreciated.