### PR TITLE
Build: Generate emoji.txt without requiring Bash 4

### DIFF
--- a/Meta/generate-emoji-txt.sh
+++ b/Meta/generate-emoji-txt.sh
@@ -71,7 +71,8 @@ do
             qualification="${qualification%"${qualification##*[![:space:]]}"}"
 
             IFS=" "
-            echo "$emoji - ${codepoints[*]} ${name^^} ($qualification)" >> "$OUTPUT_PATH"
+            uppercased_name="$(echo -n "${name}" | tr '[:lower:]' '[:upper:]')"
+            echo "$emoji - ${codepoints[*]} ${uppercased_name} ($qualification)" >> "$OUTPUT_PATH"
         fi
     fi
 done < "$INPUT_FILE"


### PR DESCRIPTION
Previously, the {name^^} transformation was used which is Bash 4
exclusive. On macOS, this causes a problem since macOS does not have
Bash >= 4.0 without the user's intervention.

This was switched to `tr` which is available on all
POSIX-compliant systems and therefore also works on macOS and WSL.