### PR TITLE
LibJS: Always access RegExp flags by its "flags" property

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -485,7 +485,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::flags)
 }
 
 // 22.2.5.8 RegExp.prototype [ @@match ] ( string ), https://tc39.es/ecma262/#sec-regexp.prototype-@@match
-// With changes from https://arai-a.github.io/ecma262-compare/?pr=2418&id=sec-regexp.prototype-%2540%2540match
+// With changes from https://arai-a.github.io/ecma262-compare/?pr=2418&id=sec-regexp.prototype-%40%40match
 JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match)
 {
     auto& realm = *vm.current_realm();
@@ -589,7 +589,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match_all)
     // 10. Else, let global be false.
     bool global = flags.contains('g');
 
-    // 11. If flags contains "u", let fullUnicode be true.
+    // 11. If flags contains "u" or flags contains "v", let fullUnicode be true.
     // 12. Else, let fullUnicode be false.
     bool full_unicode = flags.contains('u') || flags.contains('v');
 
@@ -608,7 +608,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match_all)
 }
 
 // 22.2.5.11 RegExp.prototype [ @@replace ] ( string, replaceValue ), https://tc39.es/ecma262/#sec-regexp.prototype-@@replace
-// With changes from https://arai-a.github.io/ecma262-compare/?pr=2418&id=sec-regexp.prototype-@@replace
+// With changes from https://arai-a.github.io/ecma262-compare/?pr=2418&id=sec-regexp.prototype-%40%40replace
 JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
 {
     auto string_value = vm.argument(0);
@@ -867,6 +867,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::source)
 }
 
 // 22.2.5.14 RegExp.prototype [ @@split ] ( string, limit ), https://tc39.es/ecma262/#sec-regexp.prototype-@@split
+// With changes from https://arai-a.github.io/ecma262-compare/?pr=2418&id=sec-regexp.prototype-%40%40split
 JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_split)
 {
     auto& realm = *vm.current_realm();
@@ -885,7 +886,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_split)
     auto flags_value = TRY(regexp_object->get(vm.names.flags));
     auto flags = TRY(flags_value.to_string(vm));
 
-    // 6. If flags contains "u", let unicodeMatching be true.
+    // 6. If flags contains "u" or flags contains "v", let unicodeMatching be true.
     // 7. Else, let unicodeMatching be false.
     bool unicode_matching = flags.contains('u') || flags.contains('v');
 

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.@@match.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.@@match.js
@@ -1,0 +1,27 @@
+describe("basic functionality", () => {
+    test("uses flags property instead of individual property lookups", () => {
+        let accessedFlags = false;
+        let accessedGlobal = false;
+        let accessedUnicode = false;
+
+        class RegExp1 extends RegExp {
+            get flags() {
+                accessedFlags = true;
+                return "g";
+            }
+            get global() {
+                accessedGlobal = true;
+                return false;
+            }
+            get unicode() {
+                accessedUnicode = true;
+                return false;
+            }
+        }
+
+        RegExp.prototype[Symbol.match].call(new RegExp1("foo"));
+        expect(accessedFlags).toBeTrue();
+        expect(accessedGlobal).toBeFalse();
+        expect(accessedUnicode).toBeFalse();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.@@replace.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.@@replace.js
@@ -1,0 +1,27 @@
+describe("basic functionality", () => {
+    test("uses flags property instead of individual property lookups", () => {
+        let accessedFlags = false;
+        let accessedGlobal = false;
+        let accessedUnicode = false;
+
+        class RegExp1 extends RegExp {
+            get flags() {
+                accessedFlags = true;
+                return "g";
+            }
+            get global() {
+                accessedGlobal = true;
+                return false;
+            }
+            get unicode() {
+                accessedUnicode = true;
+                return false;
+            }
+        }
+
+        RegExp.prototype[Symbol.replace].call(new RegExp1("foo"));
+        expect(accessedFlags).toBeTrue();
+        expect(accessedGlobal).toBeFalse();
+        expect(accessedUnicode).toBeFalse();
+    });
+});


### PR DESCRIPTION
This is a normative change in the ECMA-262 spec. See:
https://github.com/tc39/ecma262/commit/35b7eb2

Note there is a bit of weirdness between the mainline spec and the set
notation proposal as the latter has not been updated with this change.
For now, this implements what the spec PR and other prototypes indicate
how the proposal will behave.

```
Diff Tests:
    test/built-ins/RegExp/prototype/Symbol.match/flags-tostring-error.js   ❌ -> ✅
    test/built-ins/RegExp/prototype/Symbol.match/get-flags-err.js          ❌ -> ✅
    test/built-ins/RegExp/prototype/Symbol.match/get-unicode-error.js      ❌ -> ✅
    test/built-ins/RegExp/prototype/Symbol.replace/flags-tostring-error.js ❌ -> ✅
    test/built-ins/RegExp/prototype/Symbol.replace/get-flags-err.js        ❌ -> ✅
    test/built-ins/RegExp/prototype/Symbol.replace/get-unicode-error.js    ❌ -> ✅
```