### PR TITLE
LibGUI: Add visual line mode to VimEditingEngine

### DIFF
--- a/Userland/Libraries/LibGUI/VimEditingEngine.h
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.h
@@ -152,7 +152,8 @@ private:
     enum VimMode {
         Normal,
         Insert,
-        Visual
+        Visual,
+        VisualLine
     };
 
     enum YankType {
@@ -185,6 +186,7 @@ private:
     void switch_to_normal_mode();
     void switch_to_insert_mode();
     void switch_to_visual_mode();
+    void switch_to_visual_line_mode();
     void move_half_page_up();
     void move_half_page_down();
     void move_to_previous_empty_lines_block();
@@ -193,6 +195,7 @@ private:
     bool on_key_in_insert_mode(KeyEvent const& event);
     bool on_key_in_normal_mode(KeyEvent const& event);
     bool on_key_in_visual_mode(KeyEvent const& event);
+    bool on_key_in_visual_line_mode(KeyEvent const& event);
 
     void casefold_selection(Casing);
 


### PR DESCRIPTION
Applications using the Vim emulation engine now support line-wise text
selection.

We already have support for character-wise text selection, by pressing
`v` from normal mode.

However now can also trigger line-wise text selection by pressing
`shift+v` from normal mode, and then using vertical motion commands
(e.g. `j` or `k`) to expand the selection. This is a standard vim
feature.

In visual line mode the following operations are supported:

  * `escape`: back to normal mode
  * `u`: convert to lowercase
  * `U`: convert to uppercase
  * `~`: toggle case
  * `ctrl+d`: move down by 50% of page height
  * `ctrl+u`: move up by 50% of page height
  * `d` or `x`: delete selection
  * `c`: change selection
  * `y`: copy selection
  * `page up`: move up by 100% of page height
  * `page down`: move down by 100% of page height

Notably I didn't implement pressing `v` to go to regular
(character-wise) visual mode straight from visual line mode. This is
tricky to implement in the current code base, and there's an
alternative, which is to take a detour via normal mode.

https://user-images.githubusercontent.com/567572/186699608-98f493ce-63af-4c00-8246-cd672120bd9a.mov