### PR TITLE
Kernel: Give the Scheduler thread list dump an overhaul (colors and blockers!)

### DIFF
--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -548,23 +548,26 @@ void dump_thread_list(bool with_stack_traces)
     };
 
     Thread::for_each([&](Thread& thread) {
+        auto color = thread.process().is_kernel_process() ? "\x1b[34;1m"sv : "\x1b[33;1m"sv;
         switch (thread.state()) {
         case Thread::State::Dying:
-            dmesgln("  {:14} {:30} @ {:04x}:{:08x} Finalizable: {}, (nsched: {})",
-                thread.state_string(),
+            dmesgln("  {}{:30}\x1b[0m @ {:04x}:{:08x} is {:14} (Finalizable: {}, nsched: {})",
+                color,
                 thread,
                 get_cs(thread),
                 get_eip(thread),
+                thread.state_string(),
                 thread.is_finalizable(),
                 thread.times_scheduled());
             break;
         default:
-            dmesgln("  {:14} Pr:{:2} {:30} @ {:04x}:{:08x} (nsched: {})",
-                thread.state_string(),
-                thread.priority(),
+            dmesgln("  {}{:30}\x1b[0m @ {:04x}:{:08x} is {:14} (Pr:{:2}, nsched: {})",
+                color,
                 thread,
                 get_cs(thread),
                 get_eip(thread),
+                thread.state_string(),
+                thread.priority(),
                 thread.times_scheduled());
             break;
         }

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -568,6 +568,17 @@ void dump_thread_list(bool with_stack_traces)
                 thread.times_scheduled());
             break;
         }
+        if (thread.state() == Thread::State::Blocked && thread.blocking_mutex()) {
+            dmesgln("    Blocking on Mutex {:#x} ({})", thread.blocking_mutex(), thread.blocking_mutex()->name());
+        }
+        if (thread.state() == Thread::State::Blocked && thread.blocker()) {
+            dmesgln("    Blocking on Blocker {:#x}", thread.blocker());
+        }
+#if LOCK_DEBUG
+        thread.for_each_held_lock([](auto const& entry) {
+            dmesgln("    Holding lock {:#x} ({}) at {}", entry.lock, entry.lock->name(), entry.lock_location);
+        });
+#endif
         if (with_stack_traces) {
             auto trace_or_error = thread.backtrace();
             if (!trace_or_error.is_error()) {


### PR DESCRIPTION
Poking around in process and thread lists inside GDB is hard, so I did some nice improvements to the thread list dump while trying to track down one of my infinite waits. Now it shows process names in color (for the sake of readability), shows additional information about what a thread is blocking on, and (if `LOCK_DEBUG` is enabled) it even shows what locks a thread currently holds (and where).

![Bildschirmfoto_2022-08-25_17-38-39](https://user-images.githubusercontent.com/16820960/186712205-0963cebb-680c-433d-87cf-faea4a2efc0c.png)