### PR TITLE
LibC: Unblock all threads in pthread_cond_broadcast

### DIFF
--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_SOURCES
     TestMkDir.cpp
     TestPthreadCancel.cpp
     TestPthreadCleanup.cpp
+    TestPthreadConditionVariable.cpp
     TestPthreadSpinLocks.cpp
     TestPthreadRWLocks.cpp
     TestQsort.cpp

--- a/Tests/LibC/TestPthreadConditionVariable.cpp
+++ b/Tests/LibC/TestPthreadConditionVariable.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, Michael Cullen <michael@michaelcullen.name>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <unistd.h>
+
+struct SyncData {
+    pthread_mutex_t mtx;
+    pthread_cond_t cond;
+};
+
+struct ThreadData {
+    SyncData* sd;
+    bool done { false };
+};
+
+void* thread_worker(void* arg);
+
+void* thread_worker(void* arg)
+{
+    printf("Thread with TID %d starting\n", pthread_self());
+    ThreadData* td = (ThreadData*)arg;
+    pthread_mutex_lock(&td->sd->mtx);
+
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    // wait up to 10 seconds, as a safety net to prevent the test from completely hanging
+    ts.tv_sec += 10;
+
+    printf("Thread %d waiting for cond\n", pthread_self());
+    int res = pthread_cond_timedwait(&td->sd->cond, &td->sd->mtx, &ts);
+    if (res == 0) {
+        printf("Thread %d done waiting for cond\n", pthread_self());
+        td->done = true;
+    } else if (res == ETIMEDOUT) {
+        printf("Thread %d failed to wait for condition (timed out)\n", pthread_self());
+    } else {
+        printf("Thread %d failed to wait for condition (unknown error)\n", pthread_self());
+    }
+
+    pthread_mutex_unlock(&td->sd->mtx);
+    printf("Thread %d exiting\n", pthread_self());
+    return nullptr;
+}
+
+TEST_CASE(conditionvar_broadcast)
+{
+    pthread_t threadA, threadB;
+
+    SyncData sd;
+
+    pthread_mutex_init(&sd.mtx, NULL);
+    pthread_cond_init(&sd.cond, NULL);
+
+    ThreadData tdA {
+        .sd = &sd,
+    };
+    ThreadData tdB {
+        .sd = &sd,
+    };
+
+    pthread_create(&threadA, NULL, thread_worker, &tdA);
+    pthread_create(&threadB, NULL, thread_worker, &tdB);
+
+    printf("Waiting 2s for stuff to get going\n");
+    usleep(2000 * 1000);
+
+    printf("Broadcasting condition variable\n");
+    pthread_cond_broadcast(&sd.cond);
+
+    printf("Joining threads\n");
+    pthread_join(threadA, nullptr);
+    pthread_join(threadB, nullptr);
+
+    EXPECT_EQ(true, tdA.done);
+    EXPECT_EQ(true, tdB.done);
+
+    pthread_cond_destroy(&sd.cond);
+    pthread_mutex_destroy(&sd.mtx);
+}

--- a/Userland/Libraries/LibC/pthread_cond.cpp
+++ b/Userland/Libraries/LibC/pthread_cond.cpp
@@ -155,7 +155,7 @@ int pthread_cond_broadcast(pthread_cond_t* cond)
     pthread_mutex_t* mutex = AK::atomic_load(&cond->mutex, AK::memory_order_relaxed);
     VERIFY(mutex);
 
-    int rc = futex(&cond->value, FUTEX_REQUEUE | FUTEX_PRIVATE_FLAG, 1, nullptr, &mutex->lock, INT_MAX);
+    int rc = futex(&cond->value, FUTEX_REQUEUE | FUTEX_PRIVATE_FLAG, 1, (const struct timespec*)INT_MAX, &mutex->lock, 0);
     VERIFY(rc >= 0);
     return 0;
 }

--- a/Userland/Libraries/LibC/serenity.cpp
+++ b/Userland/Libraries/LibC/serenity.cpp
@@ -42,7 +42,9 @@ int futex(uint32_t* userspace_address, int futex_op, uint32_t value, const struc
 {
     int rc;
     switch (futex_op & FUTEX_CMD_MASK) {
-    case FUTEX_WAKE_OP: {
+    case FUTEX_WAKE_OP:
+    case FUTEX_REQUEUE:
+    case FUTEX_CMP_REQUEUE: {
         // These interpret timeout as a u32 value for val2
         Syscall::SC_futex_params params {
             .userspace_address = userspace_address,


### PR DESCRIPTION
pthread_cond_broadcast is like pthread_cond_signal except it wakes ALL
threads waiting on the condition variable.

As detailed in #15020, it appears to only be waking a single thread.
Further investigation of the implementation suggests that it was in fact
set to only wake one thread.

This commit changes the futex call in pthread_cond_broadcast to wake at
most INT_MAX tasks, rather than at most 1 task. It also sets the val3
argument to 0 rather than INT_MAX since it is unused, and 0 feels like a
better "unused" value.