### PR TITLE
LibJS: Guard `IntegerIndexedElementSet` with receiver check

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -331,11 +331,18 @@ public:
             auto numeric_index = canonical_numeric_index_string(property_key, CanonicalIndexMode::DetectNumericRoundtrip);
             // b. If numericIndex is not undefined, then
             if (!numeric_index.is_undefined()) {
-                // i. Perform ? IntegerIndexedElementSet(O, numericIndex, V).
-                TRY(integer_indexed_element_set<T>(*this, numeric_index, value));
+                // i. If SameValue(O, Receiver) is true, then
+                if (same_value(this, receiver)) {
+                    // 1. Perform ? IntegerIndexedElementSet(O, numericIndex, V).
+                    TRY(integer_indexed_element_set<T>(*this, numeric_index, value));
 
-                // ii. Return true.
-                return true;
+                    // 2. Return true.
+                    return true;
+                }
+
+                // ii. If IsValidIntegerIndex(O, numericIndex) is false, return true.
+                if (!is_valid_integer_index(*this, numeric_index))
+                    return true;
             }
         }
 

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.js
@@ -359,3 +359,34 @@ TYPED_ARRAYS.forEach(T => {
         expectValueNotSet("1e-10");
     });
 });
+
+test("source is the same value as the receiver", () => {
+    TYPED_ARRAYS.forEach(T => {
+        let target = new T([1, 2]);
+        target[0] = 3;
+
+        expect(target[0]).toBe(3);
+    });
+});
+
+test("source is not the same value as the receiver", () => {
+    TYPED_ARRAYS.forEach(T => {
+        let target = new T([1, 2]);
+        let receiver = Object.create(target);
+        receiver[0] = 3;
+
+        expect(target[0]).toBe(1);
+        expect(receiver[0]).toBe(3);
+    });
+});
+
+test("source is not the same value as the receiver, and the index is invalid", () => {
+    TYPED_ARRAYS.forEach(T => {
+        let target = new T([1, 2]);
+        let receiver = Object.create(target);
+        receiver[2] = 3;
+
+        expect(target[2]).toBeUndefined();
+        expect(receiver[2]).toBeUndefined();
+    });
+});


### PR DESCRIPTION
This is a normative change in the ECMA-262 spec. See:
https://github.com/tc39/ecma262/commit/3620f11