### PR TITLE
LibWeb: Fix file:// iframes not loading

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -216,7 +216,7 @@ NonnullRefPtr<Document> Document::create_and_initialize(Type type, String conten
     // 8. Let document be a new Document,
     //    whose type is type,
     //    content type is contentType,
-    //    FIXME: origin is navigationParams's origin,
+    //    origin is navigationParams's origin,
     //    FIXME: policy container is navigationParams's policy container,
     //    FIXME: permissions policy is permissionsPolicy,
     //    FIXME: active sandboxing flag set is navigationParams's final sandboxing flag set,
@@ -226,6 +226,7 @@ NonnullRefPtr<Document> Document::create_and_initialize(Type type, String conten
     auto document = Document::create();
     document->m_type = type;
     document->m_content_type = content_type;
+    document->set_origin(navigation_params.origin);
 
     document->m_window = window;
     window->set_associated_document(*document);

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -59,7 +59,7 @@ static HTML::Origin url_origin(AK::URL const& url)
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#determining-the-origin
-static HTML::Origin determine_the_origin(BrowsingContext const& browsing_context, Optional<AK::URL> url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> invocation_origin)
+HTML::Origin determine_the_origin(BrowsingContext const& browsing_context, Optional<AK::URL> url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> invocation_origin)
 {
     // 1. If sandboxFlags has its sandboxed origin browsing context flag set, then return a new opaque origin.
     if (sandbox_flags.flags & SandboxingFlagSet::SandboxedOrigin) {

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -52,7 +52,8 @@ static HTML::Origin url_origin(AK::URL const& url)
 
     if (url.scheme() == "file"sv) {
         // Unfortunate as it is, this is left as an exercise to the reader. When in doubt, return a new opaque origin.
-        return HTML::Origin {};
+        // Note: We must return an origin with the `file://' protocol for `file://' iframes to work from `file://' pages.
+        return HTML::Origin(url.protocol(), String(), 0);
     }
 
     return HTML::Origin {};

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -157,4 +157,6 @@ private:
     String m_name;
 };
 
+HTML::Origin determine_the_origin(BrowsingContext const& browsing_context, Optional<AK::URL> url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> invocation_origin);
+
 }

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -367,15 +367,22 @@ void FrameLoader::resource_did_load()
         dbgln_if(RESOURCE_DEBUG, "This content has MIME type '{}', encoding unknown", resource()->mime_type());
     }
 
+    auto final_sandboxing_flag_set = HTML::SandboxingFlagSet {};
+
+    // (Part of https://html.spec.whatwg.org/#navigating-across-documents)
+    // 3. Let responseOrigin be the result of determining the origin given browsingContext, resource's url, finalSandboxFlags, and incumbentNavigationOrigin.
+    // FIXME: Pass incumbentNavigationOrigin
+    auto response_origin = HTML::determine_the_origin(browsing_context(), url, final_sandboxing_flag_set, {});
+
     auto response = make<Fetch::Infrastructure::Response>();
     response->url_list().append(url);
     HTML::NavigationParams navigation_params {
         .id = {},
         .request = nullptr,
         .response = move(response),
-        .origin = HTML::Origin {},
+        .origin = move(response_origin),
         .policy_container = HTML::PolicyContainer {},
-        .final_sandboxing_flag_set = HTML::SandboxingFlagSet {},
+        .final_sandboxing_flag_set = move(final_sandboxing_flag_set),
         .cross_origin_opener_policy = HTML::CrossOriginOpenerPolicy {},
         .coop_enforcement_result = HTML::CrossOriginOpenerPolicyEnforcementResult {},
         .reserved_environment = {},


### PR DESCRIPTION

These have been broken since https://github.com/SerenityOS/serenity/commit/6e71e400e696a92bbc2a69e6a59efddc29b926ce, which means the iframe demos from the welcome page have not been working. 

This also now determines the origin when loading pages, this was not done after https://github.com/SerenityOS/serenity/commit/2a7924f96cb20c13897dc3faa8c1b18a79ae3f52, and I think since then all pages have only had opaque origins. 