### PR TITLE
PixelPaint: Cropping to content with moved layers was broken

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -528,7 +528,14 @@ void Image::rotate(Gfx::RotationDirection direction)
 void Image::crop(Gfx::IntRect const& cropped_rect)
 {
     for (auto& layer : m_layers) {
-        layer.crop(cropped_rect);
+        auto layer_location = layer.location();
+        auto layer_local_crop_rect = layer.relative_rect().intersected(cropped_rect).translated(-layer_location.x(), -layer_location.y());
+        layer.crop(layer_local_crop_rect);
+
+        auto new_layer_x = max(0, layer_location.x() - cropped_rect.x());
+        auto new_layer_y = max(0, layer_location.y() - cropped_rect.y());
+
+        layer.set_location({ new_layer_x, new_layer_y });
     }
 
     m_size = { cropped_rect.width(), cropped_rect.height() };


### PR DESCRIPTION
When cropping to content with a layer not positioned at 0,0 the moved
layers content disappeared and the layers position was not updated
according to the crop offset.

Original image:
![grafik](https://user-images.githubusercontent.com/438976/186777490-b34a5c5f-e5f1-45a8-8761-98d45f130f55.png)

Crop to content - Without fix:
![grafik](https://user-images.githubusercontent.com/438976/186777585-9b25f9a1-11e8-4654-94d6-46b1029e654d.png)


... with fix:
![grafik](https://user-images.githubusercontent.com/438976/186777258-6a4def40-c375-4476-97db-5c0951a84774.png)
