### PR TITLE
Chess: Highlight piece origin square when dragging piece

### DIFF
--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -157,6 +157,14 @@ void ChessWidget::paint_event(GUI::PaintEvent& event)
             }
         }
 
+        Gfx::IntRect origin_square;
+        if (side() == Chess::Color::White) {
+            origin_square = { m_moving_square.file * tile_width, (7 - m_moving_square.rank) * tile_height, tile_width, tile_height };
+        } else {
+            origin_square = { (7 - m_moving_square.file) * tile_width, m_moving_square.rank * tile_height, tile_width, tile_height };
+        }
+        painter.fill_rect(origin_square, m_move_highlight_color);
+
         auto bmp = m_pieces.get(active_board.get_piece(m_moving_square));
         if (bmp.has_value()) {
             auto center = m_drag_point - Gfx::IntPoint(tile_width / 2, tile_height / 2);


### PR DESCRIPTION
I've used the same highlight color used in marking the last move made.
The highlighting when dragging a piece helps to know where to put the piece back if you change your mind about the move.

Before:
![before](https://user-images.githubusercontent.com/3976857/186797333-a5042f05-160f-4802-af34-d0ae38c2db3d.gif)

After:
![after](https://user-images.githubusercontent.com/3976857/186797345-a38c03fd-d03c-4cab-a0f7-67479e741d2a.gif)

