### PR TITLE
LibWeb: Handle unrecognized values in grid-template-columns

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5306,22 +5306,22 @@ RefPtr<StyleValue> Parser::parse_grid_track_sizes(Vector<ComponentValue> const& 
     Vector<CSS::GridTrackSize> params;
     for (auto& component_value : component_values) {
         // FIXME: Incomplete as a GridTrackSize can be a function like minmax(min, max), etc.
-        if (component_value.is_function())
-            return {};
+        if (component_value.is_function()) {
+            params.append(Length::make_auto());
+            continue;
+        }
         if (component_value.is(Token::Type::Ident) && component_value.token().ident().equals_ignoring_case("auto"sv)) {
             params.append(Length::make_auto());
             continue;
         }
         auto dimension = parse_dimension(component_value);
         if (!dimension.has_value())
-            return {};
+            return GridTrackSizeStyleValue::create({});
         if (dimension->is_length())
             params.append(dimension->length());
         if (dimension->is_percentage())
             params.append(dimension->percentage());
     }
-    if (params.size() == 0)
-        return {};
     return GridTrackSizeStyleValue::create(params);
 }
 


### PR DESCRIPTION
This commit fixes a bug found when passing exotic values in the grid-template-columns (or grid-template-rows) which are not yet supported.

fixes #15030

Found a solution to the issue, but to be completely honest am not able to build a test case to add to the display-grid.html test page. I'll look to do this, but in the meantime here's the fix.