### PR TITLE
Meta: Enforce no leading zeros for emoji filenames

### DIFF
--- a/Meta/check-emoji.sh
+++ b/Meta/check-emoji.sh
@@ -17,6 +17,10 @@ for fn in "${files[@]}"; do
         echo "$fn contains invalid characters in its filename. Only uppercase letters, numbers, +, and _ should be used."
         found_invalid_filenames=1
     fi
+    if [[ $basename == *U+0* ]] ; then
+        echo "$fn contains codepoint(s) with leading zeros. Leading zeros should be removed from codepoint(s)."
+        found_invalid_filenames=1
+    fi
     if [[ $basename == *+U* ]] ; then
         echo "$fn is incorrectly named. _ should be used as a separator between codepoints, not +."
         found_invalid_filenames=1


### PR DESCRIPTION
The current lookup code and emoji.txt generator expects codepoints to
not include leading zeros. This may change in the future, but it's worth
enforcing the current convention until then.

Example output if there's an emoji with leading zeros:

```
Base/res/emoji/U+0030_U+20E3.png contains codepoint(s) with leading zeros. Leading zeros should be removed from codepoint(s).
```