### PR TITLE
LibWeb: Implement the HostEnsureCanAddPrivateElement JS hook

### DIFF
--- a/Base/res/html/misc/private-element-test.html
+++ b/Base/res/html/misc/private-element-test.html
@@ -1,0 +1,63 @@
+<html>
+    <body>
+        <span
+            >If passed, the text below should say: "Passed" And the iframe should have loaded</span
+        >
+        <div id="result">Starting up</div>
+        <script>
+            class Base {
+                constructor(o) {
+                    return o;
+                }
+            }
+
+            class Stamper extends Base {
+                #x = 10;
+                static hasX(o) {
+                    return #x in o;
+                }
+            }
+
+            let failed = false;
+            function status(text, fail = false) {
+                console.log("Status", text, fail, failed);
+                const output = document.getElementById("result");
+                if (fail) {
+                    output.innerHTML += "Fail: " + text + "<br />";
+                    output.style.color = "red";
+                    failed = true;
+                } else if (!failed) {
+                    output.innerHTML = text;
+                    output.style.color = "blue";
+                }
+            }
+
+            function fail(text) {
+                return status(text, true);
+            }
+
+            status("Running");
+
+            const iframe = document.body.appendChild(document.createElement("iframe"));
+            iframe.src = "file:///res/html/misc/welcome.html";
+            iframe.onload = () => {
+                status("Inside onload", false);
+                // FIXME: Also test on contentWindow itself once that is an actual WindowProxy.
+                const locationObject = iframe.contentWindow.location;
+                try {
+                    new Stamper(locationObject);
+                    fail("Should have thrown type error!");
+                } catch (e) {
+                    if (!(e instanceof TypeError))
+                        fail("Should have thrown type error! But threw: " + e);
+                }
+                if (Stamper.hasX(locationObject)) {
+                    fail("Stamped #x on Location");
+                } else {
+                    status("Passed");
+                }
+            };
+            status("Set src and onload, waiting for onload");
+        </script>
+    </body>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -170,6 +170,7 @@
             <li><a href="async-js.html">Basic test for async functions and their integration with the LibWeb event loop</a></li>
             <li><a href="worker_parent.html">Workers</a></li>
             <li><a href="storage.html">Web Storage API</a></li>
+            <li><a href="private-element-test.html">Test for rejecting private elements on special objects</a></li>
             <li><h3>Canvas</h3></li>
             <li><a href="canvas.html">canvas 2D test</a></li>
             <li><a href="canvas-rotate.html">canvas rotate()</a></li>


### PR DESCRIPTION
Also added a local test for ensuring this behavior since it is unique to
browsers. Since we don't actually use WindowProxy anywhere yet we just
test on location for now.

I don't know why they made it the first Host hook in the web spec but I updated all the numbers

Also I couldn't make the test work with any WindowProxy and then found a bunch of
`FIXME: This should return the WindowProxy`, comments so I just test location for now.

See https://github.com/whatwg/html/pull/8198 and https://github.com/web-platform-tests/wpt/pull/35520
