### PR TITLE
LibJS+LibUnicode: Move some constant arrays to a separate header

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
@@ -26,7 +26,7 @@
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
 #include <LibCore/Stream.h>
-#include <LibJS/Runtime/Intl/AbstractOperations.h>
+#include <LibJS/Runtime/Intl/SingleUnitIdentifiers.h>
 #include <LibUnicode/Locale.h>
 #include <LibUnicode/NumberFormat.h>
 #include <LibUnicode/PluralRules.h>

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -6,13 +6,13 @@
 
 #pragma once
 
-#include <AK/Array.h>
 #include <AK/Span.h>
 #include <AK/String.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Intl/DisplayNames.h>
+#include <LibJS/Runtime/Intl/SingleUnitIdentifiers.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
 #include <LibJS/Runtime/Value.h>
 #include <LibUnicode/Forward.h>
@@ -76,18 +76,6 @@ struct PatternPartitionWithSource : public PatternPartition {
 
     StringView source;
 };
-
-// Table 2: Single units sanctioned for use in ECMAScript, https://tc39.es/ecma402/#table-sanctioned-single-unit-identifiers
-constexpr auto sanctioned_single_unit_identifiers()
-{
-    return AK::Array { "acre"sv, "bit"sv, "byte"sv, "celsius"sv, "centimeter"sv, "day"sv, "degree"sv, "fahrenheit"sv, "fluid-ounce"sv, "foot"sv, "gallon"sv, "gigabit"sv, "gigabyte"sv, "gram"sv, "hectare"sv, "hour"sv, "inch"sv, "kilobit"sv, "kilobyte"sv, "kilogram"sv, "kilometer"sv, "liter"sv, "megabit"sv, "megabyte"sv, "meter"sv, "mile"sv, "mile-scandinavian"sv, "milliliter"sv, "millimeter"sv, "millisecond"sv, "minute"sv, "month"sv, "ounce"sv, "percent"sv, "petabyte"sv, "pound"sv, "second"sv, "stone"sv, "terabit"sv, "terabyte"sv, "week"sv, "yard"sv, "year"sv };
-}
-
-// Additional single units used in ECMAScript required by the Intl.DurationFormat proposal
-constexpr auto extra_sanctioned_single_unit_identifiers()
-{
-    return AK::Array { "microsecond"sv, "nanosecond"sv };
-}
 
 using StringOrBoolean = Variant<StringView, bool>;
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/SingleUnitIdentifiers.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SingleUnitIdentifiers.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/StringView.h>
+
+namespace JS::Intl {
+
+// Table 2: Single units sanctioned for use in ECMAScript, https://tc39.es/ecma402/#table-sanctioned-single-unit-identifiers
+constexpr auto sanctioned_single_unit_identifiers()
+{
+    return AK::Array { "acre"sv, "bit"sv, "byte"sv, "celsius"sv, "centimeter"sv, "day"sv, "degree"sv, "fahrenheit"sv, "fluid-ounce"sv, "foot"sv, "gallon"sv, "gigabit"sv, "gigabyte"sv, "gram"sv, "hectare"sv, "hour"sv, "inch"sv, "kilobit"sv, "kilobyte"sv, "kilogram"sv, "kilometer"sv, "liter"sv, "megabit"sv, "megabyte"sv, "meter"sv, "mile"sv, "mile-scandinavian"sv, "milliliter"sv, "millimeter"sv, "millisecond"sv, "minute"sv, "month"sv, "ounce"sv, "percent"sv, "petabyte"sv, "pound"sv, "second"sv, "stone"sv, "terabit"sv, "terabyte"sv, "week"sv, "yard"sv, "year"sv };
+}
+
+// Additional single units used in ECMAScript required by the Intl.DurationFormat proposal
+constexpr auto extra_sanctioned_single_unit_identifiers()
+{
+    return AK::Array { "microsecond"sv, "nanosecond"sv };
+}
+
+}


### PR DESCRIPTION
Since LibUnicode depends on this data it used to include
Intl/AbstractOperations which in turn includes a number of other LibJS
headers. By moving this to its own header with minimal includes we can
save on rebuilding LibUnicode for unrelated LibJS header changes.

This prevents quite a bit of linking and rebuilding, I'll post some results once I've got them
Before: ~1 minute rebuild after editing VM.h
After: ~50 seconds minute rebuild after editing VM.h