### PR TITLE
Kernel: Dump OOM debug info after releasing the MM global data lock 

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -915,7 +915,6 @@ extern RecursiveSpinlock g_profiling_lock;
 template<IteratorFunction<Process&> Callback>
 inline void Process::for_each(Callback callback)
 {
-    VERIFY_INTERRUPTS_DISABLED();
     Process::all_instances().with([&](auto const& list) {
         for (auto it = list.begin(); it != list.end();) {
             auto& process = *it;


### PR DESCRIPTION
Otherwise we would be holding the MM global data lock and the Process address space locks in reversed order to the rest of the system, which can lead to deadlocks.