### PR TITLE
Kernel/USB: Hotplug multiple USB device crash hotfix

### DIFF
--- a/Kernel/Bus/USB/USBHub.cpp
+++ b/Kernel/Bus/USB/USBHub.cpp
@@ -45,6 +45,8 @@ ErrorOr<void> Hub::enumerate_and_power_on_hub()
     // USBDevice::enumerate_device must be called before this.
     VERIFY(m_address > 0);
 
+    m_sysfs_device_info_node = TRY(SysFSUSBDeviceInformation::create(*this));
+
     if (m_device_descriptor.device_class != USB_CLASS_HUB) {
         dbgln("USB Hub: Trying to enumerate and power on a device that says it isn't a hub.");
         return EINVAL;


### PR DESCRIPTION
There's currently a bug with USB hotplug and SysFS that causes a crash when multiple USB devices are "plugged in" (i.e. emulated as attached to a port via QEMU). Previously this happened when any device at all was attached, a bug fixed in PR https://github.com/SerenityOS/serenity/pull/14703. However, I was a little trigger happy with removing the line in USBHub.cpp, as when it is removed it seems that the bug is still present for multiple USB devices attached simultaneously. So, this commit simply adds this line back. This seems to fix the problem of crashing the system when multiple USB devices are present for the time being. Other than mentioning that lsusb seems to print out as expected with the patch, I can't guarantee it plays 100% nice with SysFS.