### PR TITLE
HackStudio: Fix bugs around the unsaved files warning

### DIFF
--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -10,6 +10,7 @@
 #include "HackStudio.h"
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
+#include <LibGUI/FilePicker.h>
 #include <LibGUI/Label.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
@@ -72,6 +73,13 @@ void EditorWrapper::set_filename(String const& filename)
 
 void EditorWrapper::save()
 {
+    if (filename().is_empty()) {
+        auto file_picker_action = GUI::CommonActions::make_save_as_action([&](auto&) {
+            Optional<String> save_path = GUI::FilePicker::get_save_filepath(window(), "file"sv, "txt"sv, project_root().value());
+            set_filename(save_path.value());
+        });
+        file_picker_action->activate();
+    }
     editor().write_to_file(filename());
     update_diff();
     editor().update();

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -703,6 +703,12 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_delete_action()
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_new_project_action()
 {
     return GUI::Action::create("&Project...", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/hackstudio-project.png"sv).release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
+        if (warn_unsaved_changes("There are unsaved changes. Would you like to save before creating a new project?") == ContinueDecision::No)
+            return;
+        // If the user wishes to save the changes, this occurs in warn_unsaved_changes. If they do not,
+        // we need to mark the documents as clean so open_project works properly without asking again.
+        for (auto& editor_wrapper : m_all_editor_wrappers)
+            editor_wrapper.editor().document().set_unmodified();
         auto dialog = NewProjectDialog::construct(window());
         dialog->set_icon(window()->icon());
         auto result = dialog->exec();


### PR DESCRIPTION
This PR is intended to fix two related bugs that occurred when using the dialog that warns of unsaved files. The first issue is that when this dialog was spawned while NewProjectDialog was open, the two windows would fight and neither would be clickable. 
The second issue was that when saving all files through said dialog, any files that had never been saved and thus had no filename would crash HackStudio. This was fixed by adding a "Save as" dialog to the save() function of EditorWrapper.