### PR TITLE
LibJS: Hide all the constructors!

### DIFF
--- a/Userland/Libraries/LibJS/Contrib/Test262/$262Object.h
+++ b/Userland/Libraries/LibJS/Contrib/Test262/$262Object.h
@@ -17,11 +17,12 @@ class $262Object final : public Object {
     JS_OBJECT($262Object, Object);
 
 public:
-    explicit $262Object(Realm&);
     virtual void initialize(JS::Realm&) override;
     virtual ~$262Object() override = default;
 
 private:
+    explicit $262Object(Realm&);
+
     virtual void visit_edges(Visitor&) override;
 
     AgentObject* m_agent { nullptr };

--- a/Userland/Libraries/LibJS/Contrib/Test262/AgentObject.h
+++ b/Userland/Libraries/LibJS/Contrib/Test262/AgentObject.h
@@ -15,11 +15,12 @@ class AgentObject final : public Object {
     JS_OBJECT(AgentObject, Object);
 
 public:
-    explicit AgentObject(Realm&);
     virtual void initialize(JS::Realm&) override;
     virtual ~AgentObject() override = default;
 
 private:
+    explicit AgentObject(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(monotonic_now);
     JS_DECLARE_NATIVE_FUNCTION(sleep);
 };

--- a/Userland/Libraries/LibJS/Contrib/Test262/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Contrib/Test262/GlobalObject.h
@@ -15,16 +15,17 @@ class GlobalObject final : public JS::GlobalObject {
     JS_OBJECT(GlobalObject, JS::GlobalObject);
 
 public:
-    GlobalObject(JS::Realm& realm)
-        : JS::GlobalObject(realm)
-    {
-    }
     virtual void initialize(Realm&) override;
     virtual ~GlobalObject() override = default;
 
     $262Object* $262() const { return m_$262; }
 
 private:
+    GlobalObject(JS::Realm& realm)
+        : JS::GlobalObject(realm)
+    {
+    }
+
     virtual void visit_edges(Visitor&) override;
 
     $262Object* m_$262 { nullptr };

--- a/Userland/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.h
+++ b/Userland/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.h
@@ -14,12 +14,13 @@ class IsHTMLDDA final : public NativeFunction {
     JS_OBJECT(IsHTMLDDA, NativeFunction);
 
 public:
-    explicit IsHTMLDDA(Realm&);
     virtual ~IsHTMLDDA() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
 
 private:
+    explicit IsHTMLDDA(Realm&);
+
     virtual bool is_htmldda() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Heap/Cell.h
+++ b/Userland/Libraries/LibJS/Heap/Cell.h
@@ -20,7 +20,8 @@ public:                                            \
     virtual StringView class_name() const override \
     {                                              \
         return #class_##sv;                        \
-    }
+    }                                              \
+    friend class JS::Heap;
 
 class Cell {
     AK_MAKE_NONCOPYABLE(Cell);

--- a/Userland/Libraries/LibJS/Heap/Cell.h
+++ b/Userland/Libraries/LibJS/Heap/Cell.h
@@ -14,6 +14,14 @@
 
 namespace JS {
 
+#define JS_CELL(class_, base_class)                \
+public:                                            \
+    using Base = base_class;                       \
+    virtual StringView class_name() const override \
+    {                                              \
+        return #class_##sv;                        \
+    }
+
 class Cell {
     AK_MAKE_NONCOPYABLE(Cell);
     AK_MAKE_NONMOVABLE(Cell);

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.h
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.h
@@ -97,9 +97,9 @@ private:
     bool has_lazy_freelist() const { return m_next_lazy_freelist_index < cell_count(); }
 
     struct FreelistEntry final : public Cell {
-        FreelistEntry* next { nullptr };
+        JS_CELL(FreelistEntry, Cell);
 
-        virtual StringView class_name() const override { return "FreelistEntry"sv; }
+        FreelistEntry* next { nullptr };
     };
 
     Cell* cell(size_t index)

--- a/Userland/Libraries/LibJS/Runtime/Accessor.h
+++ b/Userland/Libraries/LibJS/Runtime/Accessor.h
@@ -22,12 +22,6 @@ public:
         return vm.heap().allocate_without_realm<Accessor>(getter, setter);
     }
 
-    Accessor(FunctionObject* getter, FunctionObject* setter)
-        : m_getter(getter)
-        , m_setter(setter)
-    {
-    }
-
     FunctionObject* getter() const { return m_getter; }
     void set_getter(FunctionObject* getter) { m_getter = getter; }
 
@@ -41,6 +35,12 @@ public:
     }
 
 private:
+    Accessor(FunctionObject* getter, FunctionObject* setter)
+        : m_getter(getter)
+        , m_setter(setter)
+    {
+    }
+
     FunctionObject* m_getter { nullptr };
     FunctionObject* m_setter { nullptr };
 };

--- a/Userland/Libraries/LibJS/Runtime/Accessor.h
+++ b/Userland/Libraries/LibJS/Runtime/Accessor.h
@@ -14,6 +14,8 @@
 namespace JS {
 
 class Accessor final : public Cell {
+    JS_CELL(Accessor, Cell);
+
 public:
     static Accessor* create(VM& vm, FunctionObject* getter, FunctionObject* setter)
     {
@@ -39,8 +41,6 @@ public:
     }
 
 private:
-    StringView class_name() const override { return "Accessor"sv; };
-
     FunctionObject* m_getter { nullptr };
     FunctionObject* m_setter { nullptr };
 };

--- a/Userland/Libraries/LibJS/Runtime/AggregateError.h
+++ b/Userland/Libraries/LibJS/Runtime/AggregateError.h
@@ -16,9 +16,10 @@ class AggregateError : public Error {
 
 public:
     static AggregateError* create(Realm&);
-
-    explicit AggregateError(Object& prototype);
     virtual ~AggregateError() override = default;
+
+private:
+    explicit AggregateError(Object& prototype);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/AggregateErrorConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/AggregateErrorConstructor.h
@@ -14,7 +14,6 @@ class AggregateErrorConstructor final : public NativeFunction {
     JS_OBJECT(AggregateErrorConstructor, NativeFunction);
 
 public:
-    explicit AggregateErrorConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~AggregateErrorConstructor() override = default;
 
@@ -22,6 +21,7 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit AggregateErrorConstructor(Realm&);
     virtual bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/AggregateErrorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AggregateErrorPrototype.h
@@ -14,9 +14,11 @@ class AggregateErrorPrototype final : public Object {
     JS_OBJECT(AggregateErrorPrototype, Object);
 
 public:
-    explicit AggregateErrorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~AggregateErrorPrototype() override = default;
+
+private:
+    explicit AggregateErrorPrototype(Realm&);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -16,8 +16,6 @@ class ArgumentsObject final : public Object {
     JS_OBJECT(ArgumentsObject, Object);
 
 public:
-    ArgumentsObject(Realm&, Environment&);
-
     virtual void initialize(Realm&) override;
     virtual ~ArgumentsObject() override = default;
 
@@ -33,6 +31,8 @@ public:
     Object& parameter_map() { return *m_parameter_map; }
 
 private:
+    ArgumentsObject(Realm&, Environment&);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     Environment& m_environment;

--- a/Userland/Libraries/LibJS/Runtime/Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Array.h
@@ -35,7 +35,6 @@ public:
         return Array::create_from(realm, values);
     }
 
-    explicit Array(Object& prototype);
     virtual ~Array() override = default;
 
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;

--- a/Userland/Libraries/LibJS/Runtime/Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Array.h
@@ -44,6 +44,9 @@ public:
 
     [[nodiscard]] bool length_is_writable() const { return m_length_writable; };
 
+protected:
+    explicit Array(Object& prototype);
+
 private:
     ThrowCompletionOr<bool> set_length(PropertyDescriptor const&);
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -29,8 +29,6 @@ public:
     static ArrayBuffer* create(Realm&, ByteBuffer);
     static ArrayBuffer* create(Realm&, ByteBuffer*);
 
-    ArrayBuffer(ByteBuffer buffer, Object& prototype);
-    ArrayBuffer(ByteBuffer* buffer, Object& prototype);
     virtual ~ArrayBuffer() override = default;
 
     size_t byte_length() const { return buffer_impl().size(); }
@@ -58,6 +56,9 @@ public:
     Value get_modify_set_value(size_t byte_index, Value value, ReadWriteModifyFunction operation, bool is_little_endian = true);
 
 private:
+    ArrayBuffer(ByteBuffer buffer, Object& prototype);
+    ArrayBuffer(ByteBuffer* buffer, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     ByteBuffer& buffer_impl()

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.h
@@ -14,7 +14,6 @@ class ArrayBufferConstructor final : public NativeFunction {
     JS_OBJECT(ArrayBufferConstructor, NativeFunction);
 
 public:
-    explicit ArrayBufferConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ArrayBufferConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit ArrayBufferConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(is_view);

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
@@ -15,11 +15,12 @@ class ArrayBufferPrototype final : public PrototypeObject<ArrayBufferPrototype, 
     JS_PROTOTYPE_OBJECT(ArrayBufferPrototype, ArrayBuffer, ArrayBuffer);
 
 public:
-    explicit ArrayBufferPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ArrayBufferPrototype() override = default;
 
 private:
+    explicit ArrayBufferPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(slice);
     JS_DECLARE_NATIVE_FUNCTION(byte_length_getter);
 };

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.h
@@ -14,7 +14,6 @@ class ArrayConstructor final : public NativeFunction {
     JS_OBJECT(ArrayConstructor, NativeFunction);
 
 public:
-    explicit ArrayConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ArrayConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit ArrayConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);

--- a/Userland/Libraries/LibJS/Runtime/ArrayIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIterator.h
@@ -16,7 +16,6 @@ class ArrayIterator final : public Object {
 public:
     static ArrayIterator* create(Realm&, Value array, Object::PropertyKind iteration_kind);
 
-    explicit ArrayIterator(Value array, Object::PropertyKind iteration_kind, Object& prototype);
     virtual ~ArrayIterator() override = default;
 
     Value array() const { return m_array; }
@@ -25,6 +24,8 @@ public:
 
 private:
     friend class ArrayIteratorPrototype;
+
+    ArrayIterator(Value array, Object::PropertyKind iteration_kind, Object& prototype);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.h
@@ -15,11 +15,12 @@ class ArrayIteratorPrototype final : public PrototypeObject<ArrayIteratorPrototy
     JS_PROTOTYPE_OBJECT(ArrayIteratorPrototype, ArrayIterator, ArrayIterator);
 
 public:
-    ArrayIteratorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ArrayIteratorPrototype() override = default;
 
 private:
+    explicit ArrayIteratorPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(next);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.h
@@ -15,11 +15,12 @@ class ArrayPrototype final : public Array {
     JS_OBJECT(ArrayPrototype, Array);
 
 public:
-    ArrayPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ArrayPrototype() override = default;
 
 private:
+    explicit ArrayPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(at);
     JS_DECLARE_NATIVE_FUNCTION(concat);
     JS_DECLARE_NATIVE_FUNCTION(copy_within);

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.h
@@ -19,7 +19,6 @@ class AsyncFromSyncIterator final : public Object {
 public:
     static AsyncFromSyncIterator* create(Realm&, Iterator sync_iterator_record);
 
-    explicit AsyncFromSyncIterator(Realm&, Iterator sync_iterator_record);
     virtual void initialize(Realm&) override;
     virtual ~AsyncFromSyncIterator() override = default;
 
@@ -29,6 +28,8 @@ public:
     Iterator const& sync_iterator_record() const { return m_sync_iterator_record; }
 
 private:
+    AsyncFromSyncIterator(Realm&, Iterator sync_iterator_record);
+
     Iterator m_sync_iterator_record; // [[SyncIteratorRecord]]
 };
 

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.h
@@ -19,11 +19,12 @@ class AsyncFromSyncIteratorPrototype final : public PrototypeObject<AsyncFromSyn
     JS_PROTOTYPE_OBJECT(AsyncFromSyncIteratorPrototype, AsyncFromSyncIterator, AsyncFromSyncIterator);
 
 public:
-    explicit AsyncFromSyncIteratorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~AsyncFromSyncIteratorPrototype() override = default;
 
 private:
+    explicit AsyncFromSyncIteratorPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(next);
     JS_DECLARE_NATIVE_FUNCTION(return_);
     JS_DECLARE_NATIVE_FUNCTION(throw_);

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionConstructor.h
@@ -15,7 +15,6 @@ class AsyncFunctionConstructor final : public NativeFunction {
     JS_OBJECT(AsyncFunctionConstructor, NativeFunction);
 
 public:
-    explicit AsyncFunctionConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~AsyncFunctionConstructor() override = default;
 
@@ -23,6 +22,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit AsyncFunctionConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
@@ -19,7 +19,6 @@ class AsyncFunctionDriverWrapper final : public Promise {
 
 public:
     static ThrowCompletionOr<Value> create(Realm&, GeneratorObject*);
-    explicit AsyncFunctionDriverWrapper(Realm&, GeneratorObject*);
 
     virtual ~AsyncFunctionDriverWrapper() override = default;
     void visit_edges(Cell::Visitor&) override;
@@ -27,6 +26,8 @@ public:
     ThrowCompletionOr<Value> react_to_async_task_completion(VM&, Value, bool is_successful);
 
 private:
+    AsyncFunctionDriverWrapper(Realm&, GeneratorObject*);
+
     GeneratorObject* m_generator_object { nullptr };
     NativeFunction* m_on_fulfillment { nullptr };
     NativeFunction* m_on_rejection { nullptr };

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionPrototype.h
@@ -14,9 +14,11 @@ class AsyncFunctionPrototype final : public Object {
     JS_OBJECT(AsyncFunctionPrototype, Object);
 
 public:
-    explicit AsyncFunctionPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~AsyncFunctionPrototype() override = default;
+
+private:
+    explicit AsyncFunctionPrototype(Realm&);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
@@ -26,10 +26,11 @@ public:
         Completed,
     };
 
-    explicit AsyncGenerator(Object& prototype);
     virtual ~AsyncGenerator() override = default;
 
 private:
+    explicit AsyncGenerator(Object& prototype);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     // At the time of constructing an AsyncGenerator, we still need to point to an

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionConstructor.h
@@ -14,7 +14,6 @@ class AsyncGeneratorFunctionConstructor final : public NativeFunction {
     JS_OBJECT(AsyncGeneratorFunctionConstructor, NativeFunction);
 
 public:
-    explicit AsyncGeneratorFunctionConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~AsyncGeneratorFunctionConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit AsyncGeneratorFunctionConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionPrototype.h
@@ -14,9 +14,11 @@ class AsyncGeneratorFunctionPrototype final : public PrototypeObject<AsyncGenera
     JS_PROTOTYPE_OBJECT(AsyncGeneratorFunctionPrototype, AsyncGeneratorFunction, AsyncGeneratorFunction);
 
 public:
-    explicit AsyncGeneratorFunctionPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~AsyncGeneratorFunctionPrototype() override = default;
+
+private:
+    explicit AsyncGeneratorFunctionPrototype(Realm&);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorPrototype.h
@@ -15,9 +15,11 @@ class AsyncGeneratorPrototype final : public PrototypeObject<AsyncGeneratorProto
     JS_PROTOTYPE_OBJECT(AsyncGeneratorPrototype, AsyncGenerator, AsyncGenerator)
 
 public:
-    explicit AsyncGeneratorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~AsyncGeneratorPrototype() override = default;
+
+private:
+    explicit AsyncGeneratorPrototype(Realm&);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/AsyncIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncIteratorPrototype.h
@@ -14,11 +14,12 @@ class AsyncIteratorPrototype final : public Object {
     JS_OBJECT(AsyncIteratorPrototype, Object)
 
 public:
-    explicit AsyncIteratorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~AsyncIteratorPrototype() override = default;
 
 private:
+    explicit AsyncIteratorPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(symbol_async_iterator);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/AtomicsObject.h
+++ b/Userland/Libraries/LibJS/Runtime/AtomicsObject.h
@@ -14,11 +14,12 @@ class AtomicsObject : public Object {
     JS_OBJECT(AtomicsObject, Object);
 
 public:
-    explicit AtomicsObject(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~AtomicsObject() override = default;
 
 private:
+    explicit AtomicsObject(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(add);
     JS_DECLARE_NATIVE_FUNCTION(and_);
     JS_DECLARE_NATIVE_FUNCTION(compare_exchange);

--- a/Userland/Libraries/LibJS/Runtime/BigInt.h
+++ b/Userland/Libraries/LibJS/Runtime/BigInt.h
@@ -13,6 +13,8 @@
 namespace JS {
 
 class BigInt final : public Cell {
+    JS_CELL(BigInt, Cell);
+
 public:
     explicit BigInt(Crypto::SignedBigInteger);
     virtual ~BigInt() override = default;
@@ -21,8 +23,6 @@ public:
     const String to_string() const { return String::formatted("{}n", m_big_integer.to_base(10)); }
 
 private:
-    virtual StringView class_name() const override { return "BigInt"sv; }
-
     Crypto::SignedBigInteger m_big_integer;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/BigInt.h
+++ b/Userland/Libraries/LibJS/Runtime/BigInt.h
@@ -16,13 +16,14 @@ class BigInt final : public Cell {
     JS_CELL(BigInt, Cell);
 
 public:
-    explicit BigInt(Crypto::SignedBigInteger);
     virtual ~BigInt() override = default;
 
     Crypto::SignedBigInteger const& big_integer() const { return m_big_integer; }
     const String to_string() const { return String::formatted("{}n", m_big_integer.to_base(10)); }
 
 private:
+    explicit BigInt(Crypto::SignedBigInteger);
+
     Crypto::SignedBigInteger m_big_integer;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.h
@@ -14,7 +14,6 @@ class BigIntConstructor final : public NativeFunction {
     JS_OBJECT(BigIntConstructor, NativeFunction);
 
 public:
-    explicit BigIntConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~BigIntConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit BigIntConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(as_int_n);

--- a/Userland/Libraries/LibJS/Runtime/BigIntObject.h
+++ b/Userland/Libraries/LibJS/Runtime/BigIntObject.h
@@ -17,13 +17,14 @@ class BigIntObject final : public Object {
 public:
     static BigIntObject* create(Realm&, BigInt&);
 
-    BigIntObject(BigInt&, Object& prototype);
     virtual ~BigIntObject() override = default;
 
     BigInt const& bigint() const { return m_bigint; }
     BigInt& bigint() { return m_bigint; }
 
 private:
+    BigIntObject(BigInt&, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     BigInt& m_bigint;

--- a/Userland/Libraries/LibJS/Runtime/BigIntPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/BigIntPrototype.h
@@ -14,11 +14,12 @@ class BigIntPrototype final : public Object {
     JS_OBJECT(BigIntPrototype, Object);
 
 public:
-    explicit BigIntPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~BigIntPrototype() override = default;
 
 private:
+    explicit BigIntPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(to_string);
     JS_DECLARE_NATIVE_FUNCTION(to_locale_string);
     JS_DECLARE_NATIVE_FUNCTION(value_of);

--- a/Userland/Libraries/LibJS/Runtime/BooleanConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/BooleanConstructor.h
@@ -14,7 +14,6 @@ class BooleanConstructor final : public NativeFunction {
     JS_OBJECT(BooleanConstructor, NativeFunction);
 
 public:
-    explicit BooleanConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~BooleanConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit BooleanConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/BooleanObject.h
+++ b/Userland/Libraries/LibJS/Runtime/BooleanObject.h
@@ -16,10 +16,12 @@ class BooleanObject : public Object {
 public:
     static BooleanObject* create(Realm&, bool);
 
-    BooleanObject(bool, Object& prototype);
     virtual ~BooleanObject() override = default;
 
     bool boolean() const { return m_value; }
+
+protected:
+    BooleanObject(bool, Object& prototype);
 
 private:
     bool m_value { false };

--- a/Userland/Libraries/LibJS/Runtime/BooleanPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/BooleanPrototype.h
@@ -14,11 +14,12 @@ class BooleanPrototype final : public BooleanObject {
     JS_OBJECT(BooleanPrototype, BooleanObject);
 
 public:
-    explicit BooleanPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~BooleanPrototype() override = default;
 
 private:
+    explicit BooleanPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(to_string);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
 };

--- a/Userland/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/BoundFunction.h
@@ -17,7 +17,6 @@ class BoundFunction final : public FunctionObject {
 public:
     static ThrowCompletionOr<BoundFunction*> create(Realm&, FunctionObject& target_function, Value bound_this, Vector<Value> bound_arguments);
 
-    BoundFunction(Realm&, FunctionObject& target_function, Value bound_this, Vector<Value> bound_arguments, Object* prototype);
     virtual ~BoundFunction() override = default;
 
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
@@ -32,6 +31,8 @@ public:
     Vector<Value> const& bound_arguments() const { return m_bound_arguments; }
 
 private:
+    BoundFunction(Realm&, FunctionObject& target_function, Value bound_this, Vector<Value> bound_arguments, Object* prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     FunctionObject* m_bound_target_function { nullptr }; // [[BoundTargetFunction]]

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.h
@@ -14,13 +14,14 @@ class ConsoleObject final : public Object {
     JS_OBJECT(ConsoleObject, Object);
 
 public:
-    explicit ConsoleObject(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ConsoleObject() override = default;
 
     Console& console() { return *m_console; }
 
 private:
+    explicit ConsoleObject(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(log);
     JS_DECLARE_NATIVE_FUNCTION(debug);
     JS_DECLARE_NATIVE_FUNCTION(info);

--- a/Userland/Libraries/LibJS/Runtime/DataView.h
+++ b/Userland/Libraries/LibJS/Runtime/DataView.h
@@ -18,7 +18,6 @@ class DataView : public Object {
 public:
     static DataView* create(Realm&, ArrayBuffer*, size_t byte_length, size_t byte_offset);
 
-    explicit DataView(ArrayBuffer*, size_t byte_length, size_t byte_offset, Object& prototype);
     virtual ~DataView() override = default;
 
     ArrayBuffer* viewed_array_buffer() const { return m_viewed_array_buffer; }
@@ -26,6 +25,8 @@ public:
     size_t byte_offset() const { return m_byte_offset; }
 
 private:
+    DataView(ArrayBuffer*, size_t byte_length, size_t byte_offset, Object& prototype);
+
     virtual void visit_edges(Visitor& visitor) override;
 
     ArrayBuffer* m_viewed_array_buffer { nullptr };

--- a/Userland/Libraries/LibJS/Runtime/DataViewConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/DataViewConstructor.h
@@ -14,7 +14,6 @@ class DataViewConstructor final : public NativeFunction {
     JS_OBJECT(DataViewConstructor, NativeFunction);
 
 public:
-    explicit DataViewConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~DataViewConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;
 
 private:
+    explicit DataViewConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/DataViewPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/DataViewPrototype.h
@@ -15,11 +15,12 @@ class DataViewPrototype final : public PrototypeObject<DataViewPrototype, DataVi
     JS_PROTOTYPE_OBJECT(DataViewPrototype, DataView, DataView);
 
 public:
-    DataViewPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~DataViewPrototype() override = default;
 
 private:
+    explicit DataViewPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(get_big_int_64);
     JS_DECLARE_NATIVE_FUNCTION(get_big_uint_64);
     JS_DECLARE_NATIVE_FUNCTION(get_float_32);

--- a/Userland/Libraries/LibJS/Runtime/Date.h
+++ b/Userland/Libraries/LibJS/Runtime/Date.h
@@ -18,7 +18,6 @@ public:
     static Date* create(Realm&, double date_value);
     static Date* now(VM&);
 
-    Date(double date_value, Object& prototype);
     virtual ~Date() override = default;
 
     double date_value() const { return m_date_value; }
@@ -27,6 +26,8 @@ public:
     String iso_date_string() const;
 
 private:
+    Date(double date_value, Object& prototype);
+
     double m_date_value { 0 }; // [[DateValue]]
 };
 

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.h
@@ -14,7 +14,6 @@ class DateConstructor final : public NativeFunction {
     JS_OBJECT(DateConstructor, NativeFunction);
 
 public:
-    explicit DateConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~DateConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit DateConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(now);

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.h
@@ -15,11 +15,12 @@ class DatePrototype final : public PrototypeObject<DatePrototype, Date> {
     JS_PROTOTYPE_OBJECT(DatePrototype, Date, Date);
 
 public:
-    explicit DatePrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~DatePrototype() override = default;
 
 private:
+    explicit DatePrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(get_date);
     JS_DECLARE_NATIVE_FUNCTION(get_day);
     JS_DECLARE_NATIVE_FUNCTION(get_full_year);

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -29,9 +29,6 @@ class DeclarativeEnvironment : public Environment {
 public:
     static DeclarativeEnvironment* create_for_per_iteration_bindings(Badge<ForStatement>, DeclarativeEnvironment& other, size_t bindings_size);
 
-    DeclarativeEnvironment();
-    explicit DeclarativeEnvironment(Environment* parent_environment);
-    explicit DeclarativeEnvironment(Environment* parent_environment, Span<Binding const> bindings);
     virtual ~DeclarativeEnvironment() override = default;
 
     virtual ThrowCompletionOr<bool> has_binding(FlyString const& name, Optional<size_t>* = nullptr) const override;
@@ -62,6 +59,10 @@ public:
     ThrowCompletionOr<void> set_mutable_binding_direct(VM&, size_t index, Value, bool strict);
 
 protected:
+    DeclarativeEnvironment();
+    explicit DeclarativeEnvironment(Environment* parent_environment);
+    DeclarativeEnvironment(Environment* parent_environment, Span<Binding const> bindings);
+
     virtual void visit_edges(Visitor&) override;
 
 private:

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -35,7 +35,6 @@ public:
     static ECMAScriptFunctionObject* create(Realm&, FlyString name, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
     static ECMAScriptFunctionObject* create(Realm&, FlyString name, Object& prototype, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
 
-    ECMAScriptFunctionObject(FlyString name, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
     virtual void initialize(Realm&) override;
     virtual ~ECMAScriptFunctionObject() override = default;
 
@@ -94,6 +93,8 @@ protected:
     virtual Completion ordinary_call_evaluate_body();
 
 private:
+    ECMAScriptFunctionObject(FlyString name, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
+
     virtual bool is_ecmascript_function_object() const override { return true; }
     virtual void visit_edges(Visitor&) override;
 

--- a/Userland/Libraries/LibJS/Runtime/Environment.h
+++ b/Userland/Libraries/LibJS/Runtime/Environment.h
@@ -17,10 +17,7 @@ struct Variable {
     DeclarationKind declaration_kind;
 };
 
-#define JS_ENVIRONMENT(class_, base_class) \
-public:                                    \
-    using Base = base_class;               \
-    virtual StringView class_name() const override { return #class_##sv; }
+#define JS_ENVIRONMENT(class_, base_class) JS_CELL(class_, base_class)
 
 class Environment : public Cell {
     JS_CELL(Environment, Cell);

--- a/Userland/Libraries/LibJS/Runtime/Environment.h
+++ b/Userland/Libraries/LibJS/Runtime/Environment.h
@@ -23,6 +23,8 @@ public:                                    \
     virtual StringView class_name() const override { return #class_##sv; }
 
 class Environment : public Cell {
+    JS_CELL(Environment, Cell);
+
 public:
     virtual bool has_this_binding() const { return false; }
     virtual ThrowCompletionOr<Value> get_this_binding(VM&) const { return Value {}; }
@@ -47,8 +49,6 @@ public:
 
     template<typename T>
     bool fast_is() const = delete;
-
-    virtual StringView class_name() const override { return "Environment"sv; }
 
     // This flag is set on the entire variable environment chain when direct eval() is performed.
     // It is used to disable non-local variable access caching.

--- a/Userland/Libraries/LibJS/Runtime/Error.h
+++ b/Userland/Libraries/LibJS/Runtime/Error.h
@@ -26,7 +26,6 @@ public:
     static Error* create(Realm&);
     static Error* create(Realm&, String const& message);
 
-    explicit Error(Object& prototype);
     virtual ~Error() override = default;
 
     [[nodiscard]] String stack_string() const;
@@ -34,6 +33,9 @@ public:
     ThrowCompletionOr<void> install_error_cause(Value options);
 
     Vector<TracebackFrame, 32> const& traceback() const { return m_traceback; }
+
+protected:
+    explicit Error(Object& prototype);
 
 private:
     void populate_stack();

--- a/Userland/Libraries/LibJS/Runtime/ErrorConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorConstructor.h
@@ -15,7 +15,6 @@ class ErrorConstructor final : public NativeFunction {
     JS_OBJECT(ErrorConstructor, NativeFunction);
 
 public:
-    explicit ErrorConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ErrorConstructor() override = default;
 
@@ -23,6 +22,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit ErrorConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 };
 
@@ -31,14 +32,18 @@ private:
         JS_OBJECT(ConstructorName, NativeFunction);                                             \
                                                                                                 \
     public:                                                                                     \
-        explicit ConstructorName(Realm&);                                                       \
         virtual void initialize(Realm&) override;                                               \
         virtual ~ConstructorName() override;                                                    \
         virtual ThrowCompletionOr<Value> call() override;                                       \
         virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;      \
                                                                                                 \
     private:                                                                                    \
-        virtual bool has_constructor() const override { return true; }                          \
+        explicit ConstructorName(Realm&);                                                       \
+                                                                                                \
+        virtual bool has_constructor() const override                                           \
+        {                                                                                       \
+            return true;                                                                        \
+        }                                                                                       \
     };
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \

--- a/Userland/Libraries/LibJS/Runtime/ErrorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorPrototype.h
@@ -16,11 +16,12 @@ class ErrorPrototype final : public PrototypeObject<ErrorPrototype, Error> {
     JS_PROTOTYPE_OBJECT(ErrorPrototype, Error, Error);
 
 public:
-    explicit ErrorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ErrorPrototype() override = default;
 
 private:
+    explicit ErrorPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(to_string);
     JS_DECLARE_NATIVE_FUNCTION(stack_getter);
     JS_DECLARE_NATIVE_FUNCTION(stack_setter);
@@ -31,9 +32,11 @@ private:
         JS_PROTOTYPE_OBJECT(PrototypeName, ClassName, ClassName);                             \
                                                                                               \
     public:                                                                                   \
-        explicit PrototypeName(Realm&);                                                       \
         virtual void initialize(Realm&) override;                                             \
         virtual ~PrototypeName() override = default;                                          \
+                                                                                              \
+    private:                                                                                  \
+        explicit PrototypeName(Realm&);                                                       \
     };
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
@@ -22,7 +22,6 @@ class FinalizationRegistry final
     JS_OBJECT(FinalizationRegistry, Object);
 
 public:
-    explicit FinalizationRegistry(Realm&, JobCallback, Object& prototype);
     virtual ~FinalizationRegistry() override = default;
 
     void add_finalization_record(Cell& target, Value held_value, Cell* unregister_token);
@@ -38,6 +37,8 @@ public:
     JobCallback const& cleanup_callback() const { return m_cleanup_callback; }
 
 private:
+    FinalizationRegistry(Realm&, JobCallback, Object& prototype);
+
     virtual void visit_edges(Visitor& visitor) override;
 
     Handle<Realm> m_realm;

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.h
@@ -14,7 +14,6 @@ class FinalizationRegistryConstructor final : public NativeFunction {
     JS_OBJECT(FinalizationRegistryConstructor, NativeFunction);
 
 public:
-    explicit FinalizationRegistryConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~FinalizationRegistryConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;
 
 private:
+    explicit FinalizationRegistryConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.h
@@ -15,11 +15,12 @@ class FinalizationRegistryPrototype final : public PrototypeObject<FinalizationR
     JS_PROTOTYPE_OBJECT(FinalizationRegistryPrototype, FinalizationRegistry, FinalizationRegistry);
 
 public:
-    FinalizationRegistryPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~FinalizationRegistryPrototype() override = default;
 
 private:
+    explicit FinalizationRegistryPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(cleanup_some);
     JS_DECLARE_NATIVE_FUNCTION(register_);
     JS_DECLARE_NATIVE_FUNCTION(unregister);

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.h
@@ -17,7 +17,6 @@ class FunctionConstructor final : public NativeFunction {
 public:
     static ThrowCompletionOr<ECMAScriptFunctionObject*> create_dynamic_function(VM&, FunctionObject& constructor, FunctionObject* new_target, FunctionKind kind, MarkedVector<Value> const& args);
 
-    explicit FunctionConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~FunctionConstructor() override = default;
 
@@ -25,6 +24,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit FunctionConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.h
@@ -22,7 +22,6 @@ public:
         Uninitialized,
     };
 
-    explicit FunctionEnvironment(Environment* parent_environment);
     virtual ~FunctionEnvironment() override = default;
 
     ThisBindingStatus this_binding_status() const { return m_this_binding_status; }
@@ -47,6 +46,8 @@ public:
     ThrowCompletionOr<Value> bind_this_value(VM&, Value);
 
 private:
+    explicit FunctionEnvironment(Environment* parent_environment);
+
     virtual bool is_function_environment() const override { return true; }
     virtual void visit_edges(Visitor&) override;
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.h
@@ -14,7 +14,6 @@ class FunctionPrototype final : public FunctionObject {
     JS_OBJECT(FunctionPrototype, FunctionObject);
 
 public:
-    explicit FunctionPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~FunctionPrototype() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual FlyString const& name() const override { return m_name; }
 
 private:
+    explicit FunctionPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(apply);
     JS_DECLARE_NATIVE_FUNCTION(bind);
     JS_DECLARE_NATIVE_FUNCTION(call);

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.h
@@ -15,7 +15,6 @@ class GeneratorFunctionConstructor final : public NativeFunction {
     JS_OBJECT(GeneratorFunctionConstructor, NativeFunction);
 
 public:
-    explicit GeneratorFunctionConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~GeneratorFunctionConstructor() override = default;
 
@@ -23,6 +22,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit GeneratorFunctionConstructor(Realm&);
+
     bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.h
@@ -16,9 +16,11 @@ class GeneratorFunctionPrototype final : public Object {
     JS_OBJECT(GeneratorFunctionPrototype, Object);
 
 public:
-    explicit GeneratorFunctionPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~GeneratorFunctionPrototype() override = default;
+
+private:
+    explicit GeneratorFunctionPrototype(Realm&);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -17,7 +17,6 @@ class GeneratorObject final : public Object {
 
 public:
     static ThrowCompletionOr<GeneratorObject*> create(Realm&, Value, ECMAScriptFunctionObject*, ExecutionContext, Bytecode::RegisterWindow);
-    GeneratorObject(Realm&, Object& prototype, ExecutionContext);
     virtual void initialize(Realm&) override;
     virtual ~GeneratorObject() override = default;
     void visit_edges(Cell::Visitor&) override;
@@ -26,6 +25,8 @@ public:
     void set_done() { m_done = true; }
 
 private:
+    GeneratorObject(Realm&, Object& prototype, ExecutionContext);
+
     ExecutionContext m_execution_context;
     ECMAScriptFunctionObject* m_generating_function { nullptr };
     Value m_previous_value;

--- a/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.h
@@ -16,11 +16,12 @@ class GeneratorPrototype final : public PrototypeObject<GeneratorPrototype, Gene
     JS_PROTOTYPE_OBJECT(GeneratorPrototype, GeneratorObject, Generator);
 
 public:
-    explicit GeneratorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~GeneratorPrototype() override = default;
 
 private:
+    explicit GeneratorPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(next);
     JS_DECLARE_NATIVE_FUNCTION(return_);
     JS_DECLARE_NATIVE_FUNCTION(throw_);

--- a/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.h
@@ -14,8 +14,6 @@ class GlobalEnvironment final : public Environment {
     JS_ENVIRONMENT(GlobalEnvironment, Environment);
 
 public:
-    GlobalEnvironment(Object&, Object& this_value);
-
     virtual bool has_this_binding() const final { return true; }
     virtual ThrowCompletionOr<Value> get_this_binding(VM&) const final;
 
@@ -40,6 +38,8 @@ public:
     ThrowCompletionOr<void> create_global_function_binding(FlyString const& name, Value, bool can_be_deleted);
 
 private:
+    GlobalEnvironment(Object&, Object& this_value);
+
     virtual bool is_global_environment() const override { return true; }
     virtual void visit_edges(Visitor&) override;
 

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -19,9 +19,11 @@ class GlobalObject : public Object {
     friend class Intrinsics;
 
 public:
-    explicit GlobalObject(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~GlobalObject() override;
+
+protected:
+    explicit GlobalObject(Realm&);
 
 private:
     virtual bool is_global_object() const final { return true; }

--- a/Userland/Libraries/LibJS/Runtime/Intl/Collator.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Collator.h
@@ -43,7 +43,6 @@ public:
         return AK::Array { "co"sv, "kf"sv, "kn"sv };
     }
 
-    explicit Collator(Object& prototype);
     virtual ~Collator() override = default;
 
     String const& locale() const { return m_locale; }
@@ -74,6 +73,8 @@ public:
     void set_bound_compare(CollatorCompareFunction* bound_compare) { m_bound_compare = bound_compare; }
 
 private:
+    explicit Collator(Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     String m_locale;                                      // [[Locale]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.h
@@ -16,13 +16,14 @@ class CollatorCompareFunction : public NativeFunction {
 public:
     static CollatorCompareFunction* create(Realm&, Collator&);
 
-    CollatorCompareFunction(Realm&, Collator&);
     virtual void initialize(Realm&) override;
     virtual ~CollatorCompareFunction() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
 
 private:
+    CollatorCompareFunction(Realm&, Collator&);
+
     virtual void visit_edges(Visitor&) override;
 
     Collator& m_collator; // [[Collator]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.h
@@ -14,7 +14,6 @@ class CollatorConstructor final : public NativeFunction {
     JS_OBJECT(CollatorConstructor, NativeFunction);
 
 public:
-    explicit CollatorConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~CollatorConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit CollatorConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorPrototype.h
@@ -15,11 +15,12 @@ class CollatorPrototype final : public PrototypeObject<CollatorPrototype, Collat
     JS_PROTOTYPE_OBJECT(CollatorPrototype, Collator, Collator);
 
 public:
-    explicit CollatorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~CollatorPrototype() override = default;
 
 private:
+    explicit CollatorPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(compare_getter);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -41,7 +41,6 @@ public:
         return AK::Array { "ca"sv, "hc"sv, "nu"sv };
     }
 
-    DateTimeFormat(Object& prototype);
     virtual ~DateTimeFormat() override = default;
 
     String const& locale() const { return m_locale; }
@@ -128,6 +127,8 @@ public:
     void set_bound_format(NativeFunction* bound_format) { m_bound_format = bound_format; }
 
 private:
+    DateTimeFormat(Object& prototype);
+
     static Style style_from_string(StringView style);
     static StringView style_to_string(Style style);
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.h
@@ -14,7 +14,6 @@ class DateTimeFormatConstructor final : public NativeFunction {
     JS_OBJECT(DateTimeFormatConstructor, NativeFunction);
 
 public:
-    explicit DateTimeFormatConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~DateTimeFormatConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit DateTimeFormatConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.h
@@ -18,13 +18,14 @@ class DateTimeFormatFunction final : public NativeFunction {
 public:
     static DateTimeFormatFunction* create(Realm&, DateTimeFormat&);
 
-    explicit DateTimeFormatFunction(DateTimeFormat&, Object& prototype);
     virtual ~DateTimeFormatFunction() override = default;
     virtual void initialize(Realm&) override;
 
     virtual ThrowCompletionOr<Value> call() override;
 
 private:
+    explicit DateTimeFormatFunction(DateTimeFormat&, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     DateTimeFormat& m_date_time_format; // [[DateTimeFormat]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.h
@@ -15,11 +15,12 @@ class DateTimeFormatPrototype final : public PrototypeObject<DateTimeFormatProto
     JS_PROTOTYPE_OBJECT(DateTimeFormatPrototype, DateTimeFormat, Intl.DateTimeFormat);
 
 public:
-    explicit DateTimeFormatPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~DateTimeFormatPrototype() override = default;
 
 private:
+    explicit DateTimeFormatPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(format);
     JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
     JS_DECLARE_NATIVE_FUNCTION(format_range);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.h
@@ -39,7 +39,6 @@ class DisplayNames final : public Object {
     };
 
 public:
-    DisplayNames(Object& prototype);
     virtual ~DisplayNames() override = default;
 
     String const& locale() const { return m_locale; }
@@ -63,6 +62,8 @@ public:
     StringView language_display_string() const;
 
 private:
+    DisplayNames(Object& prototype);
+
     String m_locale;                                 // [[Locale]]
     Unicode::Style m_style { Unicode::Style::Long }; // [[Style]]
     Type m_type { Type::Invalid };                   // [[Type]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.h
@@ -14,7 +14,6 @@ class DisplayNamesConstructor final : public NativeFunction {
     JS_OBJECT(DisplayNamesConstructor, NativeFunction);
 
 public:
-    explicit DisplayNamesConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~DisplayNamesConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit DisplayNamesConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.h
@@ -15,11 +15,12 @@ class DisplayNamesPrototype final : public PrototypeObject<DisplayNamesPrototype
     JS_PROTOTYPE_OBJECT(DisplayNamesPrototype, DisplayNames, Intl.DisplayNames);
 
 public:
-    explicit DisplayNamesPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~DisplayNamesPrototype() override = default;
 
 private:
+    explicit DisplayNamesPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(of);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -48,7 +48,6 @@ public:
         return AK::Array { "nu"sv };
     }
 
-    explicit DurationFormat(Object& prototype);
     virtual ~DurationFormat() override = default;
 
     void set_locale(String locale) { m_locale = move(locale); }
@@ -148,6 +147,8 @@ public:
     u8 fractional_digits() const { return m_fractional_digits.value(); }
 
 private:
+    explicit DurationFormat(Object& prototype);
+
     static Style style_from_string(StringView style);
     static StringView style_to_string(Style);
     static ValueStyle date_style_from_string(StringView date_style);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.h
@@ -14,7 +14,6 @@ class DurationFormatConstructor final : public NativeFunction {
     JS_OBJECT(DurationFormatConstructor, NativeFunction);
 
 public:
-    explicit DurationFormatConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~DurationFormatConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit DurationFormatConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.h
@@ -15,11 +15,12 @@ class DurationFormatPrototype final : public PrototypeObject<DurationFormatProto
     JS_PROTOTYPE_OBJECT(DurationFormatPrototype, DurationFormat, Intl.DurationFormat);
 
 public:
-    explicit DurationFormatPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~DurationFormatPrototype() override = default;
 
 private:
+    explicit DurationFormatPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(format);
     JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);

--- a/Userland/Libraries/LibJS/Runtime/Intl/Intl.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Intl.h
@@ -14,11 +14,12 @@ class Intl final : public Object {
     JS_OBJECT(Intl, Object);
 
 public:
-    explicit Intl(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~Intl() override = default;
 
 private:
+    explicit Intl(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(get_canonical_locales);
     JS_DECLARE_NATIVE_FUNCTION(supported_values_of);
 };

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.h
@@ -28,7 +28,6 @@ public:
         Unit,
     };
 
-    ListFormat(Object& prototype);
     virtual ~ListFormat() override = default;
 
     String const& locale() const { return m_locale; }
@@ -43,6 +42,8 @@ public:
     StringView style_string() const { return Unicode::style_to_string(m_style); }
 
 private:
+    explicit ListFormat(Object& prototype);
+
     String m_locale;                                 // [[Locale]]
     Type m_type { Type::Invalid };                   // [[Type]]
     Unicode::Style m_style { Unicode::Style::Long }; // [[Style]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.h
@@ -14,7 +14,6 @@ class ListFormatConstructor final : public NativeFunction {
     JS_OBJECT(ListFormatConstructor, NativeFunction);
 
 public:
-    explicit ListFormatConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ListFormatConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit ListFormatConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
@@ -15,11 +15,12 @@ class ListFormatPrototype final : public PrototypeObject<ListFormatPrototype, Li
     JS_PROTOTYPE_OBJECT(ListFormatPrototype, ListFormat, Intl.ListFormat);
 
 public:
-    explicit ListFormatPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ListFormatPrototype() override = default;
 
 private:
+    explicit ListFormatPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(format);
     JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
@@ -34,8 +34,6 @@ public:
         return AK::Array { "ca"sv, "co"sv, "hc"sv, "kf"sv, "kn"sv, "nu"sv };
     }
 
-    Locale(Object& prototype);
-    Locale(Unicode::LocaleID const&, Object& prototype);
     virtual ~Locale() override = default;
 
     String const& locale() const { return m_locale; }
@@ -65,6 +63,9 @@ public:
     void set_numeric(bool numeric) { m_numeric = numeric; }
 
 private:
+    explicit Locale(Object& prototype);
+    Locale(Unicode::LocaleID const&, Object& prototype);
+
     String m_locale;                     // [[Locale]]
     Optional<String> m_calendar;         // [[Calendar]]
     Optional<String> m_case_first;       // [[CaseFirst]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.h
@@ -14,7 +14,6 @@ class LocaleConstructor final : public NativeFunction {
     JS_OBJECT(LocaleConstructor, NativeFunction);
 
 public:
-    explicit LocaleConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~LocaleConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit LocaleConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -15,11 +15,12 @@ class LocalePrototype final : public PrototypeObject<LocalePrototype, Locale> {
     JS_PROTOTYPE_OBJECT(LocalePrototype, Locale, Intl.Locale);
 
 public:
-    explicit LocalePrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~LocalePrototype() override = default;
 
 private:
+    explicit LocalePrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(maximize);
     JS_DECLARE_NATIVE_FUNCTION(minimize);
     JS_DECLARE_NATIVE_FUNCTION(to_string);

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -56,7 +56,6 @@ public:
         StripIfInteger,
     };
 
-    NumberFormatBase(Object& prototype);
     virtual ~NumberFormatBase() override = default;
 
     String const& locale() const { return m_locale; }
@@ -98,6 +97,9 @@ public:
     TrailingZeroDisplay trailing_zero_display() const { return m_trailing_zero_display; }
     StringView trailing_zero_display_string() const;
     void set_trailing_zero_display(StringView trailing_zero_display);
+
+protected:
+    explicit NumberFormatBase(Object& prototype);
 
 private:
     String m_locale;                                                              // [[Locale]]
@@ -174,7 +176,6 @@ public:
         return AK::Array { "nu"sv };
     }
 
-    NumberFormat(Object& prototype);
     virtual ~NumberFormat() override = default;
 
     String const& numbering_system() const { return m_numbering_system; }
@@ -233,6 +234,8 @@ public:
     Unicode::NumberFormat compact_format() const { return *m_compact_format; }
 
 private:
+    explicit NumberFormat(Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     String m_locale;                                     // [[Locale]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.h
@@ -15,7 +15,6 @@ class NumberFormatConstructor final : public NativeFunction {
     JS_OBJECT(NumberFormatConstructor, NativeFunction);
 
 public:
-    explicit NumberFormatConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~NumberFormatConstructor() override = default;
 
@@ -23,6 +22,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit NumberFormatConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.h
@@ -18,13 +18,14 @@ class NumberFormatFunction final : public NativeFunction {
 public:
     static NumberFormatFunction* create(Realm&, NumberFormat&);
 
-    explicit NumberFormatFunction(NumberFormat&, Object& prototype);
     virtual ~NumberFormatFunction() override = default;
     virtual void initialize(Realm&) override;
 
     virtual ThrowCompletionOr<Value> call() override;
 
 private:
+    explicit NumberFormatFunction(NumberFormat&, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     NumberFormat& m_number_format; // [[NumberFormat]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.h
@@ -15,11 +15,12 @@ class NumberFormatPrototype final : public PrototypeObject<NumberFormatPrototype
     JS_PROTOTYPE_OBJECT(NumberFormatPrototype, NumberFormat, Intl.NumberFormat);
 
 public:
-    explicit NumberFormatPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~NumberFormatPrototype() override = default;
 
 private:
+    explicit NumberFormatPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(format);
     JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
     JS_DECLARE_NATIVE_FUNCTION(format_range);

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.h
@@ -19,7 +19,6 @@ class PluralRules final : public NumberFormatBase {
     JS_OBJECT(PluralRules, NumberFormatBase);
 
 public:
-    PluralRules(Object& prototype);
     virtual ~PluralRules() override = default;
 
     Unicode::PluralForm type() const { return m_type; }
@@ -27,6 +26,8 @@ public:
     void set_type(StringView type) { m_type = Unicode::plural_form_from_string(type); }
 
 private:
+    explicit PluralRules(Object& prototype);
+
     Unicode::PluralForm m_type { Unicode::PluralForm::Cardinal }; // [[Type]]
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.h
@@ -14,7 +14,6 @@ class PluralRulesConstructor final : public NativeFunction {
     JS_OBJECT(PluralRulesConstructor, NativeFunction);
 
 public:
-    explicit PluralRulesConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PluralRulesConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit PluralRulesConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.h
@@ -15,11 +15,12 @@ class PluralRulesPrototype final : public PrototypeObject<PluralRulesPrototype, 
     JS_PROTOTYPE_OBJECT(PluralRulesPrototype, PluralRules, Intl.PluralRules);
 
 public:
-    explicit PluralRulesPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PluralRulesPrototype() override = default;
 
 private:
+    explicit PluralRulesPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(select);
     JS_DECLARE_NATIVE_FUNCTION(select_range);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
@@ -33,7 +33,6 @@ public:
         return AK::Array { "nu"sv };
     }
 
-    RelativeTimeFormat(Object& prototype);
     virtual ~RelativeTimeFormat() override = default;
 
     String const& locale() const { return m_locale; }
@@ -60,6 +59,8 @@ public:
     void set_plural_rules(PluralRules* plural_rules) { m_plural_rules = plural_rules; }
 
 private:
+    explicit RelativeTimeFormat(Object& prototype);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     String m_locale;                                 // [[Locale]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h
@@ -14,7 +14,6 @@ class RelativeTimeFormatConstructor final : public NativeFunction {
     JS_OBJECT(RelativeTimeFormatConstructor, NativeFunction);
 
 public:
-    explicit RelativeTimeFormatConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~RelativeTimeFormatConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit RelativeTimeFormatConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.h
@@ -15,11 +15,12 @@ class RelativeTimeFormatPrototype final : public PrototypeObject<RelativeTimeFor
     JS_PROTOTYPE_OBJECT(RelativeTimeFormatPrototype, RelativeTimeFormat, Intl.RelativeTimeFormat);
 
 public:
-    explicit RelativeTimeFormatPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~RelativeTimeFormatPrototype() override = default;
 
 private:
+    explicit RelativeTimeFormatPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(format);
     JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.h
@@ -18,7 +18,6 @@ class SegmentIterator final : public Object {
 public:
     static SegmentIterator* create(Realm&, Segmenter&, Utf16View const&, Segments const&);
 
-    SegmentIterator(Realm&, Segmenter&, Utf16View const&, Segments const&);
     virtual ~SegmentIterator() override = default;
 
     Segmenter const& iterating_segmenter() const { return m_iterating_segmenter; }
@@ -29,6 +28,8 @@ public:
     Segments const& segments() { return m_segments; }
 
 private:
+    SegmentIterator(Realm&, Segmenter&, Utf16View const&, Segments const&);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     Segmenter& m_iterating_segmenter;                            // [[IteratingSegmenter]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.h
@@ -15,11 +15,12 @@ class SegmentIteratorPrototype final : public PrototypeObject<SegmentIteratorPro
     JS_PROTOTYPE_OBJECT(SegmentIteratorPrototype, SegmentIterator, SegmentIterator);
 
 public:
-    explicit SegmentIteratorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~SegmentIteratorPrototype() override = default;
 
 private:
+    explicit SegmentIteratorPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(next);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segmenter.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segmenter.h
@@ -21,7 +21,6 @@ public:
         Sentence,
     };
 
-    explicit Segmenter(Object& prototype);
     virtual ~Segmenter() override = default;
 
     String const& locale() const { return m_locale; }
@@ -32,6 +31,8 @@ public:
     StringView segmenter_granularity_string() const;
 
 private:
+    explicit Segmenter(Object& prototype);
+
     String m_locale;                                                                 // [[Locale]]
     SegmenterGranularity m_segmenter_granularity { SegmenterGranularity::Grapheme }; // [[SegmenterGranularity]]
 };

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.h
@@ -14,7 +14,6 @@ class SegmenterConstructor final : public NativeFunction {
     JS_OBJECT(SegmenterConstructor, NativeFunction);
 
 public:
-    explicit SegmenterConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~SegmenterConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit SegmenterConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.h
@@ -15,11 +15,12 @@ class SegmenterPrototype final : public PrototypeObject<SegmenterPrototype, Segm
     JS_PROTOTYPE_OBJECT(SegmenterPrototype, Segmenter, Segmenter);
 
 public:
-    explicit SegmenterPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~SegmenterPrototype() override = default;
 
 private:
+    explicit SegmenterPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(segment);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segments.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segments.h
@@ -18,7 +18,6 @@ class Segments final : public Object {
 public:
     static Segments* create(Realm&, Segmenter&, Utf16String);
 
-    Segments(Realm&, Segmenter&, Utf16String);
     virtual ~Segments() override = default;
 
     Segmenter& segments_segmenter() const { return m_segments_segmenter; }
@@ -28,6 +27,8 @@ public:
     Optional<Vector<size_t>>& boundaries_cache() const { return m_boundaries_cache; }
 
 private:
+    Segments(Realm&, Segmenter&, Utf16String);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     Segmenter& m_segments_segmenter; // [[SegmentsSegmenter]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.h
@@ -15,11 +15,12 @@ class SegmentsPrototype final : public PrototypeObject<SegmentsPrototype, Segmen
     JS_PROTOTYPE_OBJECT(SegmentsPrototype, Segments, Segments);
 
 public:
-    explicit SegmentsPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~SegmentsPrototype() override = default;
 
 private:
+    explicit SegmentsPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(containing);
     JS_DECLARE_NATIVE_FUNCTION(symbol_iterator);
 };

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.h
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.h
@@ -13,6 +13,8 @@
 namespace JS {
 
 class Intrinsics final : public Cell {
+    JS_CELL(Intrinsics, Cell);
+
 public:
     static Intrinsics* create(Realm&);
 
@@ -112,7 +114,6 @@ public:
 #undef __JS_ENUMERATE
 
 private:
-    virtual StringView class_name() const override { return "Intrinsics"sv; }
     virtual void visit_edges(Visitor&) override;
 
     void initialize_intrinsics(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.h
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.h
@@ -18,8 +18,6 @@ class Intrinsics final : public Cell {
 public:
     static Intrinsics* create(Realm&);
 
-    Intrinsics() = default;
-
     Shape* empty_object_shape() { return m_empty_object_shape; }
 
     Shape* new_object_shape() { return m_new_object_shape; }
@@ -114,6 +112,8 @@ public:
 #undef __JS_ENUMERATE
 
 private:
+    Intrinsics() = default;
+
     virtual void visit_edges(Visitor&) override;
 
     void initialize_intrinsics(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/IteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorPrototype.h
@@ -14,11 +14,12 @@ class IteratorPrototype : public Object {
     JS_OBJECT(IteratorPrototype, Object)
 
 public:
-    IteratorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~IteratorPrototype() override = default;
 
 private:
+    IteratorPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(symbol_iterator);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.h
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.h
@@ -14,7 +14,6 @@ class JSONObject final : public Object {
     JS_OBJECT(JSONObject, Object);
 
 public:
-    explicit JSONObject(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~JSONObject() override = default;
 
@@ -25,6 +24,8 @@ public:
     static Value parse_json_value(VM&, JsonValue const&);
 
 private:
+    explicit JSONObject(Realm&);
+
     struct StringifyState {
         FunctionObject* replacer_function { nullptr };
         HashTable<Object*> seen_objects;

--- a/Userland/Libraries/LibJS/Runtime/Map.h
+++ b/Userland/Libraries/LibJS/Runtime/Map.h
@@ -19,10 +19,12 @@ namespace JS {
 class Map : public Object {
     JS_OBJECT(Map, Object);
 
+    // NOTE: This awkwardness is due to Set using a Map internally.
+    friend class Set;
+
 public:
     static Map* create(Realm&);
 
-    explicit Map(Object& prototype);
     virtual ~Map() override = default;
 
     void map_clear();
@@ -106,6 +108,7 @@ public:
     EndIterator end() const { return {}; }
 
 private:
+    explicit Map(Object& prototype);
     virtual void visit_edges(Visitor& visitor) override;
 
     size_t m_next_insertion_id { 0 };

--- a/Userland/Libraries/LibJS/Runtime/MapConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/MapConstructor.h
@@ -14,7 +14,6 @@ class MapConstructor final : public NativeFunction {
     JS_OBJECT(MapConstructor, NativeFunction);
 
 public:
-    explicit MapConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~MapConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;
 
 private:
+    explicit MapConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(symbol_species_getter);

--- a/Userland/Libraries/LibJS/Runtime/MapIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/MapIterator.h
@@ -18,7 +18,6 @@ class MapIterator final : public Object {
 public:
     static MapIterator* create(Realm&, Map& map, Object::PropertyKind iteration_kind);
 
-    explicit MapIterator(Map& map, Object::PropertyKind iteration_kind, Object& prototype);
     virtual ~MapIterator() override = default;
 
     Map& map() const { return m_map; }
@@ -27,6 +26,8 @@ public:
 
 private:
     friend class MapIteratorPrototype;
+
+    explicit MapIterator(Map& map, Object::PropertyKind iteration_kind, Object& prototype);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.h
@@ -15,11 +15,12 @@ class MapIteratorPrototype final : public PrototypeObject<MapIteratorPrototype, 
     JS_PROTOTYPE_OBJECT(MapIteratorPrototype, MapIterator, MapIterator);
 
 public:
-    MapIteratorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~MapIteratorPrototype() override = default;
 
 private:
+    MapIteratorPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(next);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/MapPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/MapPrototype.h
@@ -15,11 +15,12 @@ class MapPrototype final : public PrototypeObject<MapPrototype, Map> {
     JS_PROTOTYPE_OBJECT(MapPrototype, Map, Map);
 
 public:
-    MapPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~MapPrototype() override = default;
 
 private:
+    explicit MapPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(clear);
     JS_DECLARE_NATIVE_FUNCTION(delete_);
     JS_DECLARE_NATIVE_FUNCTION(entries);

--- a/Userland/Libraries/LibJS/Runtime/MathObject.h
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.h
@@ -14,11 +14,12 @@ class MathObject final : public Object {
     JS_OBJECT(MathObject, Object);
 
 public:
-    explicit MathObject(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~MathObject() override = default;
 
 private:
+    explicit MathObject(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(abs);
     JS_DECLARE_NATIVE_FUNCTION(random);
     JS_DECLARE_NATIVE_FUNCTION(sqrt);

--- a/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.h
@@ -17,8 +17,6 @@ class ModuleEnvironment final : public DeclarativeEnvironment {
     JS_ENVIRONMENT(ModuleEnvironment, DeclarativeEnvironment);
 
 public:
-    ModuleEnvironment(Environment* outer_environment);
-
     // Note: Module Environment Records support all of the declarative Environment Record methods listed
     //       in Table 18 and share the same specifications for all of those methods except for
     //       GetBindingValue, DeleteBinding, HasThisBinding and GetThisBinding.
@@ -36,6 +34,8 @@ public:
     virtual ThrowCompletionOr<bool> has_binding(FlyString const& name, Optional<size_t>* = nullptr) const override;
 
 private:
+    explicit ModuleEnvironment(Environment* outer_environment);
+
     struct IndirectBinding {
         FlyString name;
         Module* module;

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -16,8 +16,6 @@ class ModuleNamespaceObject final : public Object {
     JS_OBJECT(ModuleNamespaceObject, Object);
 
 public:
-    ModuleNamespaceObject(Realm&, Module* module, Vector<FlyString> exports);
-
     // 10.4.6 Module Namespace Exotic Objects, https://tc39.es/ecma262/#sec-module-namespace-exotic-objects
 
     virtual ThrowCompletionOr<Object*> internal_get_prototype_of() const override;
@@ -34,6 +32,8 @@ public:
     virtual void initialize(Realm&) override;
 
 private:
+    ModuleNamespaceObject(Realm&, Module* module, Vector<FlyString> exports);
+
     // FIXME: UHHH how do we want to store this to avoid cycles but be safe??
     Module* m_module;            // [[Module]]
     Vector<FlyString> m_exports; // [[Exports]]

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.h
@@ -23,8 +23,6 @@ public:
     static NativeFunction* create(Realm&, Function<ThrowCompletionOr<Value>(VM&)> behaviour, i32 length, PropertyKey const& name, Optional<Realm*> = {}, Optional<Object*> prototype = {}, Optional<StringView> const& prefix = {});
     static NativeFunction* create(Realm&, FlyString const& name, Function<ThrowCompletionOr<Value>(VM&)>);
 
-    NativeFunction(Function<ThrowCompletionOr<Value>(VM&)>, Object* prototype, Realm& realm);
-    NativeFunction(FlyString name, Function<ThrowCompletionOr<Value>(VM&)>, Object& prototype);
     virtual void initialize(Realm&) override { }
     virtual ~NativeFunction() override = default;
 
@@ -46,6 +44,8 @@ public:
 
 protected:
     NativeFunction(FlyString name, Object& prototype);
+    NativeFunction(Function<ThrowCompletionOr<Value>(VM&)>, Object* prototype, Realm& realm);
+    NativeFunction(FlyString name, Function<ThrowCompletionOr<Value>(VM&)>, Object& prototype);
     explicit NativeFunction(Object& prototype);
 
 private:

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.h
@@ -14,7 +14,6 @@ class NumberConstructor final : public NativeFunction {
     JS_OBJECT(NumberConstructor, NativeFunction);
 
 public:
-    explicit NumberConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~NumberConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit NumberConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(is_finite);

--- a/Userland/Libraries/LibJS/Runtime/NumberObject.h
+++ b/Userland/Libraries/LibJS/Runtime/NumberObject.h
@@ -16,10 +16,12 @@ class NumberObject : public Object {
 public:
     static NumberObject* create(Realm&, double);
 
-    NumberObject(double, Object& prototype);
     virtual ~NumberObject() override = default;
 
     double number() const { return m_value; }
+
+protected:
+    NumberObject(double, Object& prototype);
 
 private:
     double m_value { 0 };

--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.h
@@ -14,7 +14,6 @@ class NumberPrototype final : public NumberObject {
     JS_OBJECT(NumberPrototype, NumberObject);
 
 public:
-    explicit NumberPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~NumberPrototype() override = default;
 
@@ -24,6 +23,9 @@ public:
     JS_DECLARE_NATIVE_FUNCTION(to_precision);
     JS_DECLARE_NATIVE_FUNCTION(to_string);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
+
+private:
+    explicit NumberPrototype(Realm&);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -46,6 +46,8 @@ struct PrivateElement {
 };
 
 class Object : public Cell {
+    JS_CELL(Object, Cell);
+
 public:
     static Object* create(Realm&, Object* prototype);
 
@@ -174,7 +176,6 @@ public:
     bool has_parameter_map() const { return m_has_parameter_map; }
     void set_has_parameter_map() { m_has_parameter_map = true; }
 
-    virtual StringView class_name() const override { return "Object"sv; }
     virtual void visit_edges(Cell::Visitor&) override;
 
     Value get_direct(size_t index) const { return m_storage[index]; }

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -45,9 +45,6 @@ class Object : public Cell {
 public:
     static Object* create(Realm&, Object* prototype);
 
-    Object(Realm&, Object* prototype);
-    explicit Object(Object& prototype);
-    explicit Object(Shape&);
     virtual void initialize(Realm&) override;
     virtual ~Object() = default;
 
@@ -189,8 +186,12 @@ public:
 protected:
     enum class GlobalObjectTag { Tag };
     enum class ConstructWithoutPrototypeTag { Tag };
+
     Object(GlobalObjectTag, Realm&);
     Object(ConstructWithoutPrototypeTag, Realm&);
+    Object(Realm&, Object* prototype);
+    explicit Object(Object& prototype);
+    explicit Object(Shape&);
 
     void set_prototype(Object*);
 

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -25,13 +25,7 @@
 
 namespace JS {
 
-#define JS_OBJECT(class_, base_class)              \
-public:                                            \
-    using Base = base_class;                       \
-    virtual StringView class_name() const override \
-    {                                              \
-        return #class_##sv;                        \
-    }
+#define JS_OBJECT(class_, base_class) JS_CELL(class_, base_class)
 
 struct PrivateElement {
     enum class Kind {

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.h
@@ -15,7 +15,6 @@ class ObjectConstructor final : public NativeFunction {
     JS_OBJECT(ObjectConstructor, NativeFunction);
 
 public:
-    explicit ObjectConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ObjectConstructor() override = default;
 
@@ -23,6 +22,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit ObjectConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(define_property);

--- a/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
@@ -18,7 +18,6 @@ public:
         No,
         Yes,
     };
-    ObjectEnvironment(Object& binding_object, IsWithEnvironment, Environment* outer_environment);
 
     virtual ThrowCompletionOr<bool> has_binding(FlyString const& name, Optional<size_t>* = nullptr) const override;
     virtual ThrowCompletionOr<void> create_mutable_binding(VM&, FlyString const& name, bool can_be_deleted) override;
@@ -43,6 +42,8 @@ public:
     bool is_with_environment() const { return m_with_environment; }
 
 private:
+    ObjectEnvironment(Object& binding_object, IsWithEnvironment, Environment* outer_environment);
+
     virtual void visit_edges(Visitor&) override;
 
     Object& m_binding_object;

--- a/Userland/Libraries/LibJS/Runtime/ObjectPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectPrototype.h
@@ -15,7 +15,6 @@ class ObjectPrototype final : public Object {
     JS_OBJECT(ObjectPrototype, Object);
 
 public:
-    explicit ObjectPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ObjectPrototype() override = default;
 
@@ -27,6 +26,8 @@ public:
     JS_DECLARE_NATIVE_FUNCTION(to_string);
 
 private:
+    explicit ObjectPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(has_own_property);
     JS_DECLARE_NATIVE_FUNCTION(to_locale_string);
     JS_DECLARE_NATIVE_FUNCTION(value_of);

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -19,9 +19,6 @@ class PrimitiveString final : public Cell {
     JS_CELL(PrimitiveString, Cell);
 
 public:
-    explicit PrimitiveString(PrimitiveString&, PrimitiveString&);
-    explicit PrimitiveString(String);
-    explicit PrimitiveString(Utf16String);
     virtual ~PrimitiveString();
 
     PrimitiveString(PrimitiveString const&) = delete;
@@ -39,6 +36,10 @@ public:
     Optional<Value> get(VM&, PropertyKey const&) const;
 
 private:
+    explicit PrimitiveString(PrimitiveString&, PrimitiveString&);
+    explicit PrimitiveString(String);
+    explicit PrimitiveString(Utf16String);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     void resolve_rope_if_needed() const;

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -16,6 +16,8 @@
 namespace JS {
 
 class PrimitiveString final : public Cell {
+    JS_CELL(PrimitiveString, Cell);
+
 public:
     explicit PrimitiveString(PrimitiveString&, PrimitiveString&);
     explicit PrimitiveString(String);
@@ -37,7 +39,6 @@ public:
     Optional<Value> get(VM&, PropertyKey const&) const;
 
 private:
-    virtual StringView class_name() const override { return "PrimitiveString"sv; }
     virtual void visit_edges(Cell::Visitor&) override;
 
     void resolve_rope_if_needed() const;

--- a/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.h
@@ -28,6 +28,8 @@ struct PrivateName {
 };
 
 class PrivateEnvironment : public Cell {
+    JS_CELL(PrivateEnvironment, Cell);
+
 public:
     explicit PrivateEnvironment(PrivateEnvironment* parent);
 
@@ -36,7 +38,6 @@ public:
     void add_private_name(Badge<ClassExpression>, FlyString description);
 
 private:
-    virtual StringView class_name() const override { return "PrivateEnvironment"sv; }
     virtual void visit_edges(Visitor&) override;
 
     auto find_private_name(FlyString const& description) const

--- a/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.h
@@ -31,13 +31,13 @@ class PrivateEnvironment : public Cell {
     JS_CELL(PrivateEnvironment, Cell);
 
 public:
-    explicit PrivateEnvironment(PrivateEnvironment* parent);
-
     PrivateName resolve_private_identifier(FlyString const& identifier) const;
 
     void add_private_name(Badge<ClassExpression>, FlyString description);
 
 private:
+    explicit PrivateEnvironment(PrivateEnvironment* parent);
+
     virtual void visit_edges(Visitor&) override;
 
     auto find_private_name(FlyString const& description) const

--- a/Userland/Libraries/LibJS/Runtime/Promise.h
+++ b/Userland/Libraries/LibJS/Runtime/Promise.h
@@ -29,7 +29,6 @@ public:
 
     static Promise* create(Realm&);
 
-    explicit Promise(Object& prototype);
     virtual ~Promise() = default;
 
     State state() const { return m_state; }
@@ -48,6 +47,8 @@ public:
     bool is_handled() const { return m_is_handled; }
 
 protected:
+    explicit Promise(Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
 private:

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.h
@@ -14,7 +14,6 @@ class PromiseConstructor final : public NativeFunction {
     JS_OBJECT(PromiseConstructor, NativeFunction);
 
 public:
-    explicit PromiseConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PromiseConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit PromiseConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(all);

--- a/Userland/Libraries/LibJS/Runtime/PromisePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/PromisePrototype.h
@@ -14,11 +14,12 @@ class PromisePrototype final : public PrototypeObject<PromisePrototype, Promise>
     JS_PROTOTYPE_OBJECT(PromisePrototype, Promise, Promise);
 
 public:
-    PromisePrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PromisePrototype() override = default;
 
 private:
+    PromisePrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(then);
     JS_DECLARE_NATIVE_FUNCTION(catch_);
     JS_DECLARE_NATIVE_FUNCTION(finally);

--- a/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
@@ -78,7 +78,6 @@ public:
         return vm.heap().allocate_without_realm<PromiseReaction>(type, capability, move(handler));
     }
 
-    PromiseReaction(Type type, Optional<PromiseCapability> capability, Optional<JobCallback> handler);
     virtual ~PromiseReaction() = default;
 
     Type type() const { return m_type; }
@@ -88,6 +87,8 @@ public:
     Optional<JobCallback> const& handler() const { return m_handler; }
 
 private:
+    PromiseReaction(Type type, Optional<PromiseCapability> capability, Optional<JobCallback> handler);
+
     virtual void visit_edges(Visitor&) override;
 
     Type m_type;

--- a/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
@@ -65,6 +65,8 @@ ThrowCompletionOr<PromiseCapability> new_promise_capability(VM& vm, Value constr
 
 // 27.2.1.2 PromiseReaction Records, https://tc39.es/ecma262/#sec-promisereaction-records
 class PromiseReaction final : public Cell {
+    JS_CELL(PromiseReaction, Cell);
+
 public:
     enum class Type {
         Fulfill,
@@ -86,7 +88,6 @@ public:
     Optional<JobCallback> const& handler() const { return m_handler; }
 
 private:
-    virtual StringView class_name() const override { return "PromiseReaction"sv; }
     virtual void visit_edges(Visitor&) override;
 
     Type m_type;

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
@@ -15,28 +15,27 @@ namespace JS {
 struct RemainingElements final : public Cell {
     JS_CELL(RemainingElements, Cell);
 
+    u64 value { 0 };
+
+private:
     RemainingElements() = default;
 
     explicit RemainingElements(u64 initial_value)
         : value(initial_value)
     {
     }
-
-    u64 value { 0 };
 };
 
 class PromiseValueList final : public Cell {
     JS_CELL(PromiseValueList, Cell);
 
 public:
-    PromiseValueList()
-    {
-    }
-
     Vector<Value>& values() { return m_values; }
     Vector<Value> const& values() const { return m_values; }
 
 private:
+    PromiseValueList() = default;
+
     virtual void visit_edges(Visitor&) override;
 
     Vector<Value> m_values;
@@ -74,10 +73,11 @@ class PromiseAllResolveElementFunction final : public PromiseResolvingElementFun
 public:
     static PromiseAllResolveElementFunction* create(Realm&, size_t, PromiseValueList&, PromiseCapability, RemainingElements&);
 
-    explicit PromiseAllResolveElementFunction(size_t, PromiseValueList&, PromiseCapability, RemainingElements&, Object& prototype);
     virtual ~PromiseAllResolveElementFunction() override = default;
 
 private:
+    explicit PromiseAllResolveElementFunction(size_t, PromiseValueList&, PromiseCapability, RemainingElements&, Object& prototype);
+
     virtual ThrowCompletionOr<Value> resolve_element() override;
 };
 
@@ -88,10 +88,11 @@ class PromiseAllSettledResolveElementFunction final : public PromiseResolvingEle
 public:
     static PromiseAllSettledResolveElementFunction* create(Realm&, size_t, PromiseValueList&, PromiseCapability, RemainingElements&);
 
-    explicit PromiseAllSettledResolveElementFunction(size_t, PromiseValueList&, PromiseCapability, RemainingElements&, Object& prototype);
     virtual ~PromiseAllSettledResolveElementFunction() override = default;
 
 private:
+    explicit PromiseAllSettledResolveElementFunction(size_t, PromiseValueList&, PromiseCapability, RemainingElements&, Object& prototype);
+
     virtual ThrowCompletionOr<Value> resolve_element() override;
 };
 
@@ -102,10 +103,11 @@ class PromiseAllSettledRejectElementFunction final : public PromiseResolvingElem
 public:
     static PromiseAllSettledRejectElementFunction* create(Realm&, size_t, PromiseValueList&, PromiseCapability, RemainingElements&);
 
-    explicit PromiseAllSettledRejectElementFunction(size_t, PromiseValueList&, PromiseCapability, RemainingElements&, Object& prototype);
     virtual ~PromiseAllSettledRejectElementFunction() override = default;
 
 private:
+    explicit PromiseAllSettledRejectElementFunction(size_t, PromiseValueList&, PromiseCapability, RemainingElements&, Object& prototype);
+
     virtual ThrowCompletionOr<Value> resolve_element() override;
 };
 
@@ -116,10 +118,11 @@ class PromiseAnyRejectElementFunction final : public PromiseResolvingElementFunc
 public:
     static PromiseAnyRejectElementFunction* create(Realm&, size_t, PromiseValueList&, PromiseCapability, RemainingElements&);
 
-    explicit PromiseAnyRejectElementFunction(size_t, PromiseValueList&, PromiseCapability, RemainingElements&, Object& prototype);
     virtual ~PromiseAnyRejectElementFunction() override = default;
 
 private:
+    explicit PromiseAnyRejectElementFunction(size_t, PromiseValueList&, PromiseCapability, RemainingElements&, Object& prototype);
+
     virtual ThrowCompletionOr<Value> resolve_element() override;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
@@ -13,6 +13,8 @@
 namespace JS {
 
 struct RemainingElements final : public Cell {
+    JS_CELL(RemainingElements, Cell);
+
     RemainingElements() = default;
 
     explicit RemainingElements(u64 initial_value)
@@ -20,12 +22,12 @@ struct RemainingElements final : public Cell {
     {
     }
 
-    virtual StringView class_name() const override { return "RemainingElements"sv; }
-
     u64 value { 0 };
 };
 
 class PromiseValueList final : public Cell {
+    JS_CELL(PromiseValueList, Cell);
+
 public:
     PromiseValueList()
     {
@@ -35,7 +37,6 @@ public:
     Vector<Value> const& values() const { return m_values; }
 
 private:
-    virtual StringView class_name() const override { return "PromiseValueList"sv; }
     virtual void visit_edges(Visitor&) override;
 
     Vector<Value> m_values;

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
@@ -30,13 +30,14 @@ public:
 
     static PromiseResolvingFunction* create(Realm&, Promise&, AlreadyResolved&, FunctionType);
 
-    explicit PromiseResolvingFunction(Promise&, AlreadyResolved&, FunctionType, Object& prototype);
     virtual void initialize(Realm&) override;
     virtual ~PromiseResolvingFunction() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
 
 private:
+    explicit PromiseResolvingFunction(Promise&, AlreadyResolved&, FunctionType, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     Promise& m_promise;

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
@@ -12,9 +12,9 @@
 namespace JS {
 
 struct AlreadyResolved final : public Cell {
-    bool value { false };
+    JS_CELL(AlreadyResolved, Cell);
 
-    virtual StringView class_name() const override { return "AlreadyResolved"sv; }
+    bool value { false };
 
 protected:
     // Allocated cells must be >= sizeof(FreelistEntry), which is 24 bytes -

--- a/Userland/Libraries/LibJS/Runtime/ProxyConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyConstructor.h
@@ -15,7 +15,6 @@ class ProxyConstructor final : public NativeFunction {
     JS_OBJECT(ProxyConstructor, NativeFunction);
 
 public:
-    explicit ProxyConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ProxyConstructor() override = default;
 
@@ -23,6 +22,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit ProxyConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(revocable);

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.h
@@ -18,7 +18,6 @@ class ProxyObject final : public FunctionObject {
 public:
     static ProxyObject* create(Realm&, Object& target, Object& handler);
 
-    ProxyObject(Object& target, Object& handler, Object& prototype);
     virtual ~ProxyObject() override = default;
 
     virtual FlyString const& name() const override;
@@ -47,6 +46,8 @@ public:
     virtual ThrowCompletionOr<Object*> internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target) override;
 
 private:
+    ProxyObject(Object& target, Object& handler, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     virtual bool is_function() const override { return m_target.is_function(); }

--- a/Userland/Libraries/LibJS/Runtime/Realm.h
+++ b/Userland/Libraries/LibJS/Runtime/Realm.h
@@ -27,8 +27,6 @@ public:
         virtual ~HostDefined() = default;
     };
 
-    Realm() = default;
-
     static Realm* create(VM&);
     static ThrowCompletionOr<NonnullOwnPtr<ExecutionContext>> initialize_host_defined_realm(VM&, Function<Object*(Realm&)> create_global_object, Function<Object*(Realm&)> create_global_this_value);
 
@@ -49,6 +47,8 @@ public:
     void set_host_defined(OwnPtr<HostDefined> host_defined) { m_host_defined = move(host_defined); }
 
 private:
+    Realm() = default;
+
     virtual void visit_edges(Visitor&) override;
 
     Intrinsics* m_intrinsics { nullptr };                // [[Intrinsics]]

--- a/Userland/Libraries/LibJS/Runtime/Realm.h
+++ b/Userland/Libraries/LibJS/Runtime/Realm.h
@@ -20,6 +20,8 @@ namespace JS {
 class Realm final
     : public Cell
     , public Weakable<Realm> {
+    JS_CELL(Realm, Cell);
+
 public:
     struct HostDefined {
         virtual ~HostDefined() = default;
@@ -47,7 +49,6 @@ public:
     void set_host_defined(OwnPtr<HostDefined> host_defined) { m_host_defined = move(host_defined); }
 
 private:
-    virtual StringView class_name() const override { return "Realm"sv; }
     virtual void visit_edges(Visitor&) override;
 
     Intrinsics* m_intrinsics { nullptr };                // [[Intrinsics]]

--- a/Userland/Libraries/LibJS/Runtime/ReflectObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ReflectObject.h
@@ -14,11 +14,12 @@ class ReflectObject final : public Object {
     JS_OBJECT(ReflectObject, Object);
 
 public:
-    explicit ReflectObject(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ReflectObject() override = default;
 
 private:
+    explicit ReflectObject(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(apply);
     JS_DECLARE_NATIVE_FUNCTION(construct);
     JS_DECLARE_NATIVE_FUNCTION(define_property);

--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.h
@@ -14,7 +14,6 @@ class RegExpConstructor final : public NativeFunction {
     JS_OBJECT(RegExpConstructor, NativeFunction);
 
 public:
-    explicit RegExpConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~RegExpConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit RegExpConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(symbol_species_getter);

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.h
@@ -39,9 +39,6 @@ public:
     static RegExpObject* create(Realm&);
     static RegExpObject* create(Realm&, Regex<ECMA262> regex, String pattern, String flags);
 
-    RegExpObject(Object& prototype);
-    RegExpObject(Regex<ECMA262> regex, String pattern, String flags, Object& prototype);
-
     ThrowCompletionOr<RegExpObject*> regexp_initialize(VM&, Value pattern, Value flags);
     String escape_regexp_pattern() const;
 
@@ -54,6 +51,9 @@ public:
     Regex<ECMA262> const& regex() const { return *m_regex; }
 
 private:
+    RegExpObject(Object& prototype);
+    RegExpObject(Regex<ECMA262> regex, String pattern, String flags, Object& prototype);
+
     String m_pattern;
     String m_flags;
     Optional<Regex<ECMA262>> m_regex;

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -19,11 +19,12 @@ class RegExpPrototype final : public PrototypeObject<RegExpPrototype, RegExpObje
     JS_PROTOTYPE_OBJECT(RegExpPrototype, RegExpObject, RegExp);
 
 public:
-    explicit RegExpPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~RegExpPrototype() override = default;
 
 private:
+    explicit RegExpPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(exec);
     JS_DECLARE_NATIVE_FUNCTION(flags);
     JS_DECLARE_NATIVE_FUNCTION(symbol_match);

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
@@ -18,7 +18,6 @@ class RegExpStringIterator final : public Object {
 public:
     static RegExpStringIterator* create(Realm&, Object& regexp_object, Utf16String string, bool global, bool unicode);
 
-    explicit RegExpStringIterator(Object& prototype, Object& regexp_object, Utf16String string, bool global, bool unicode);
     virtual ~RegExpStringIterator() override = default;
 
     Object& regexp_object() { return m_regexp_object; }
@@ -30,6 +29,8 @@ public:
     void set_done() { m_done = true; }
 
 private:
+    explicit RegExpStringIterator(Object& prototype, Object& regexp_object, Utf16String string, bool global, bool unicode);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     Object& m_regexp_object;

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.h
@@ -15,12 +15,13 @@ class RegExpStringIteratorPrototype final : public PrototypeObject<RegExpStringI
     JS_PROTOTYPE_OBJECT(RegExpStringIteratorPrototype, RegExpStringIterator, RegExpStringIterator);
 
 public:
-    explicit RegExpStringIteratorPrototype(Realm&);
     virtual ~RegExpStringIteratorPrototype() override = default;
 
     virtual void initialize(Realm&) override;
 
 private:
+    explicit RegExpStringIteratorPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(next);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Set.h
+++ b/Userland/Libraries/LibJS/Runtime/Set.h
@@ -19,7 +19,6 @@ class Set : public Object {
 public:
     static Set* create(Realm&);
 
-    explicit Set(Object& prototype);
     virtual ~Set() override = default;
 
     // NOTE: Unlike what the spec says, we implement Sets using an underlying map,
@@ -37,6 +36,8 @@ public:
     auto end() const { return m_values.end(); }
 
 private:
+    explicit Set(Object& prototype);
+
     virtual void visit_edges(Visitor& visitor) override;
 
     Map m_values;

--- a/Userland/Libraries/LibJS/Runtime/SetConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/SetConstructor.h
@@ -14,7 +14,6 @@ class SetConstructor final : public NativeFunction {
     JS_OBJECT(SetConstructor, NativeFunction);
 
 public:
-    explicit SetConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~SetConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;
 
 private:
+    explicit SetConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(symbol_species_getter);

--- a/Userland/Libraries/LibJS/Runtime/SetIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/SetIterator.h
@@ -18,7 +18,6 @@ class SetIterator final : public Object {
 public:
     static SetIterator* create(Realm&, Set& set, Object::PropertyKind iteration_kind);
 
-    explicit SetIterator(Set& set, Object::PropertyKind iteration_kind, Object& prototype);
     virtual ~SetIterator() override = default;
 
     Set& set() const { return m_set; }
@@ -27,6 +26,8 @@ public:
 
 private:
     friend class SetIteratorPrototype;
+
+    explicit SetIterator(Set& set, Object::PropertyKind iteration_kind, Object& prototype);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.h
@@ -15,11 +15,12 @@ class SetIteratorPrototype final : public PrototypeObject<SetIteratorPrototype, 
     JS_PROTOTYPE_OBJECT(SetIteratorPrototype, SetIterator, SetIterator);
 
 public:
-    SetIteratorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~SetIteratorPrototype() override = default;
 
 private:
+    explicit SetIteratorPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(next);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.h
@@ -15,11 +15,12 @@ class SetPrototype final : public PrototypeObject<SetPrototype, Set> {
     JS_PROTOTYPE_OBJECT(SetPrototype, Set, Set);
 
 public:
-    SetPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~SetPrototype() override = default;
 
 private:
+    explicit SetPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(add);
     JS_DECLARE_NATIVE_FUNCTION(clear);
     JS_DECLARE_NATIVE_FUNCTION(delete_);

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.h
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.h
@@ -17,7 +17,6 @@ class ShadowRealm final : public Object {
     JS_OBJECT(ShadowRealm, Object);
 
 public:
-    ShadowRealm(Realm&, ExecutionContext, Object& prototype);
     virtual ~ShadowRealm() override = default;
 
     [[nodiscard]] Realm const& shadow_realm() const { return m_shadow_realm; }
@@ -26,6 +25,8 @@ public:
     [[nodiscard]] ExecutionContext& execution_context() { return m_execution_context; }
 
 private:
+    ShadowRealm(Realm&, ExecutionContext, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     // 3.5 Properties of ShadowRealm Instances, https://tc39.es/proposal-shadowrealm/#sec-properties-of-shadowrealm-instances

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealmConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealmConstructor.h
@@ -14,7 +14,6 @@ class ShadowRealmConstructor final : public NativeFunction {
     JS_OBJECT(ShadowRealmConstructor, NativeFunction);
 
 public:
-    explicit ShadowRealmConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ShadowRealmConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit ShadowRealmConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealmPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealmPrototype.h
@@ -15,11 +15,12 @@ class ShadowRealmPrototype final : public PrototypeObject<ShadowRealmPrototype, 
     JS_PROTOTYPE_OBJECT(ShadowRealmPrototype, ShadowRealm, ShadowRealm);
 
 public:
-    explicit ShadowRealmPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ShadowRealmPrototype() override = default;
 
 private:
+    explicit ShadowRealmPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(evaluate);
     JS_DECLARE_NATIVE_FUNCTION(import_value);
 };

--- a/Userland/Libraries/LibJS/Runtime/Shape.h
+++ b/Userland/Libraries/LibJS/Runtime/Shape.h
@@ -49,10 +49,6 @@ public:
         Prototype,
     };
 
-    explicit Shape(Realm&);
-    Shape(Shape& previous_shape, StringOrSymbol const& property_key, PropertyAttributes attributes, TransitionType);
-    Shape(Shape& previous_shape, Object* new_prototype);
-
     Shape* create_put_transition(StringOrSymbol const&, PropertyAttributes attributes);
     Shape* create_configure_transition(StringOrSymbol const&, PropertyAttributes attributes);
     Shape* create_prototype_transition(Object* new_prototype);
@@ -86,6 +82,10 @@ public:
     void reconfigure_property_in_unique_shape(StringOrSymbol const& property_key, PropertyAttributes attributes);
 
 private:
+    explicit Shape(Realm&);
+    Shape(Shape& previous_shape, StringOrSymbol const& property_key, PropertyAttributes attributes, TransitionType);
+    Shape(Shape& previous_shape, Object* new_prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     Shape* get_or_prune_cached_forward_transition(TransitionKey const&);

--- a/Userland/Libraries/LibJS/Runtime/Shape.h
+++ b/Userland/Libraries/LibJS/Runtime/Shape.h
@@ -37,6 +37,8 @@ struct TransitionKey {
 class Shape final
     : public Cell
     , public Weakable<Shape> {
+    JS_CELL(Shape, Cell);
+
 public:
     virtual ~Shape() override = default;
 
@@ -84,7 +86,6 @@ public:
     void reconfigure_property_in_unique_shape(StringOrSymbol const& property_key, PropertyAttributes attributes);
 
 private:
-    virtual StringView class_name() const override { return "Shape"sv; }
     virtual void visit_edges(Visitor&) override;
 
     Shape* get_or_prune_cached_forward_transition(TransitionKey const&);

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.h
@@ -14,7 +14,6 @@ class StringConstructor final : public NativeFunction {
     JS_OBJECT(StringConstructor, NativeFunction);
 
 public:
-    explicit StringConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~StringConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit StringConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(raw);

--- a/Userland/Libraries/LibJS/Runtime/StringIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/StringIterator.h
@@ -17,13 +17,14 @@ class StringIterator final : public Object {
 public:
     static StringIterator* create(Realm&, String string);
 
-    explicit StringIterator(String string, Object& prototype);
     virtual ~StringIterator() override = default;
 
     Utf8CodePointIterator& iterator() { return m_iterator; }
     bool done() const { return m_done; }
 
 private:
+    explicit StringIterator(String string, Object& prototype);
+
     friend class StringIteratorPrototype;
 
     String m_string;

--- a/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.h
@@ -16,11 +16,12 @@ class StringIteratorPrototype final : public PrototypeObject<StringIteratorProto
     JS_PROTOTYPE_OBJECT(StringIteratorPrototype, StringIterator, StringIterator);
 
 public:
-    StringIteratorPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~StringIteratorPrototype() override = default;
 
 private:
+    explicit StringIteratorPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(next);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/StringObject.h
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.h
@@ -16,12 +16,14 @@ class StringObject : public Object {
 public:
     static StringObject* create(Realm&, PrimitiveString&, Object& prototype);
 
-    StringObject(PrimitiveString&, Object& prototype);
     virtual void initialize(Realm&) override;
     virtual ~StringObject() override = default;
 
     PrimitiveString const& primitive_string() const { return m_string; }
     PrimitiveString& primitive_string() { return m_string; }
+
+protected:
+    StringObject(PrimitiveString&, Object& prototype);
 
 private:
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;

--- a/Userland/Libraries/LibJS/Runtime/Symbol.h
+++ b/Userland/Libraries/LibJS/Runtime/Symbol.h
@@ -13,6 +13,7 @@
 namespace JS {
 
 class Symbol final : public Cell {
+    JS_CELL(Symbol, Cell);
     AK_MAKE_NONCOPYABLE(Symbol);
     AK_MAKE_NONMOVABLE(Symbol);
 
@@ -26,8 +27,6 @@ public:
     String to_string() const { return String::formatted("Symbol({})", description()); }
 
 private:
-    virtual StringView class_name() const override { return "Symbol"sv; }
-
     Optional<String> m_description;
     bool m_is_global;
 };

--- a/Userland/Libraries/LibJS/Runtime/Symbol.h
+++ b/Userland/Libraries/LibJS/Runtime/Symbol.h
@@ -18,7 +18,6 @@ class Symbol final : public Cell {
     AK_MAKE_NONMOVABLE(Symbol);
 
 public:
-    Symbol(Optional<String>, bool);
     virtual ~Symbol() = default;
 
     String description() const { return m_description.value_or(""); }
@@ -27,6 +26,8 @@ public:
     String to_string() const { return String::formatted("Symbol({})", description()); }
 
 private:
+    Symbol(Optional<String>, bool);
+
     Optional<String> m_description;
     bool m_is_global;
 };

--- a/Userland/Libraries/LibJS/Runtime/SymbolConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/SymbolConstructor.h
@@ -14,7 +14,6 @@ class SymbolConstructor final : public NativeFunction {
     JS_OBJECT(SymbolConstructor, NativeFunction);
 
 public:
-    explicit SymbolConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~SymbolConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit SymbolConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(for_);

--- a/Userland/Libraries/LibJS/Runtime/SymbolObject.h
+++ b/Userland/Libraries/LibJS/Runtime/SymbolObject.h
@@ -17,7 +17,6 @@ class SymbolObject : public Object {
 public:
     static SymbolObject* create(Realm&, Symbol&);
 
-    SymbolObject(Symbol&, Object& prototype);
     virtual ~SymbolObject() override = default;
 
     Symbol& primitive_symbol() { return m_symbol; }
@@ -27,6 +26,8 @@ public:
     bool is_global() const { return m_symbol.is_global(); }
 
 private:
+    SymbolObject(Symbol&, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     Symbol& m_symbol;

--- a/Userland/Libraries/LibJS/Runtime/SymbolPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SymbolPrototype.h
@@ -14,11 +14,12 @@ class SymbolPrototype final : public Object {
     JS_OBJECT(SymbolPrototype, Object);
 
 public:
-    explicit SymbolPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~SymbolPrototype() override = default;
 
 private:
+    explicit SymbolPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(description_getter);
 
     JS_DECLARE_NATIVE_FUNCTION(to_string);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
@@ -20,12 +20,13 @@ class Calendar final : public Object {
     JS_OBJECT(Calendar, Object);
 
 public:
-    Calendar(String identifier, Object& prototype);
     virtual ~Calendar() override = default;
 
     [[nodiscard]] String const& identifier() const { return m_identifier; }
 
 private:
+    Calendar(String identifier, Object& prototype);
+
     // 12.5 Properties of Temporal.Calendar Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-calendar-instances
     String m_identifier; // [[Identifier]]
 };

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarConstructor.h
@@ -14,7 +14,6 @@ class CalendarConstructor final : public NativeFunction {
     JS_OBJECT(CalendarConstructor, NativeFunction);
 
 public:
-    explicit CalendarConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~CalendarConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit CalendarConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.h
@@ -15,11 +15,12 @@ class CalendarPrototype final : public PrototypeObject<CalendarPrototype, Calend
     JS_PROTOTYPE_OBJECT(CalendarPrototype, Calendar, Temporal.Calendar);
 
 public:
-    explicit CalendarPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~CalendarPrototype() override = default;
 
 private:
+    explicit CalendarPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(id_getter);
     JS_DECLARE_NATIVE_FUNCTION(date_from_fields);
     JS_DECLARE_NATIVE_FUNCTION(year_month_from_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Duration.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Duration.h
@@ -22,7 +22,6 @@ class Duration final : public Object {
     JS_OBJECT(Duration, Object);
 
 public:
-    Duration(double years, double months, double weeks, double days, double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds, Object& prototype);
     virtual ~Duration() override = default;
 
     [[nodiscard]] double years() const { return m_years; }
@@ -37,6 +36,8 @@ public:
     [[nodiscard]] double nanoseconds() const { return m_nanoseconds; }
 
 private:
+    Duration(double years, double months, double weeks, double days, double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds, Object& prototype);
+
     // 7.4 Properties of Temporal.Duration Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-duration-instances
     double m_years;        // [[Years]]
     double m_months;       // [[Months]]

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationConstructor.h
@@ -14,7 +14,6 @@ class DurationConstructor final : public NativeFunction {
     JS_OBJECT(DurationConstructor, NativeFunction);
 
 public:
-    explicit DurationConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~DurationConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit DurationConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.h
@@ -15,11 +15,12 @@ class DurationPrototype final : public PrototypeObject<DurationPrototype, Durati
     JS_PROTOTYPE_OBJECT(DurationPrototype, Duration, Temporal.Duration);
 
 public:
-    explicit DurationPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~DurationPrototype() override = default;
 
 private:
+    explicit DurationPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(years_getter);
     JS_DECLARE_NATIVE_FUNCTION(months_getter);
     JS_DECLARE_NATIVE_FUNCTION(weeks_getter);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
@@ -20,12 +20,13 @@ class Instant final : public Object {
     JS_OBJECT(Instant, Object);
 
 public:
-    Instant(BigInt const& nanoseconds, Object& prototype);
     virtual ~Instant() override = default;
 
     [[nodiscard]] BigInt const& nanoseconds() const { return m_nanoseconds; }
 
 private:
+    Instant(BigInt const& nanoseconds, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     // 8.4 Properties of Temporal.Instant Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-instant-instances

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantConstructor.h
@@ -14,7 +14,6 @@ class InstantConstructor final : public NativeFunction {
     JS_OBJECT(InstantConstructor, NativeFunction);
 
 public:
-    explicit InstantConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~InstantConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit InstantConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.h
@@ -15,11 +15,12 @@ class InstantPrototype final : public PrototypeObject<InstantPrototype, Instant>
     JS_PROTOTYPE_OBJECT(InstantPrototype, Instant, Temporal.Instant);
 
 public:
-    explicit InstantPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~InstantPrototype() override = default;
 
 private:
+    explicit InstantPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(epoch_seconds_getter);
     JS_DECLARE_NATIVE_FUNCTION(epoch_milliseconds_getter);
     JS_DECLARE_NATIVE_FUNCTION(epoch_microseconds_getter);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.h
@@ -15,11 +15,12 @@ class Now final : public Object {
     JS_OBJECT(Now, Object);
 
 public:
-    explicit Now(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~Now() override = default;
 
 private:
+    explicit Now(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(time_zone);
     JS_DECLARE_NATIVE_FUNCTION(instant);
     JS_DECLARE_NATIVE_FUNCTION(plain_date_time);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.h
@@ -18,7 +18,6 @@ class PlainDate final : public Object {
     JS_OBJECT(PlainDate, Object);
 
 public:
-    PlainDate(i32 iso_year, u8 iso_month, u8 iso_day, Object& calendar, Object& prototype);
     virtual ~PlainDate() override = default;
 
     [[nodiscard]] i32 iso_year() const { return m_iso_year; }
@@ -28,6 +27,8 @@ public:
     [[nodiscard]] Object& calendar() { return m_calendar; }
 
 private:
+    PlainDate(i32 iso_year, u8 iso_month, u8 iso_day, Object& calendar, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     // 3.4 Properties of Temporal.PlainDate Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-plaindate-instances

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateConstructor.h
@@ -14,7 +14,6 @@ class PlainDateConstructor final : public NativeFunction {
     JS_OBJECT(PlainDateConstructor, NativeFunction);
 
 public:
-    explicit PlainDateConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PlainDateConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit PlainDateConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.h
@@ -15,11 +15,12 @@ class PlainDatePrototype final : public PrototypeObject<PlainDatePrototype, Plai
     JS_PROTOTYPE_OBJECT(PlainDatePrototype, PlainDate, Temporal.PlainDate);
 
 public:
-    explicit PlainDatePrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PlainDatePrototype() override = default;
 
 private:
+    explicit PlainDatePrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_getter);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
@@ -19,7 +19,6 @@ class PlainDateTime final : public Object {
     JS_OBJECT(PlainDateTime, Object);
 
 public:
-    PlainDateTime(i32 iso_year, u8 iso_month, u8 iso_day, u8 iso_hour, u8 iso_minute, u8 iso_second, u16 iso_millisecond, u16 iso_microsecond, u16 iso_nanosecond, Object& calendar, Object& prototype);
     virtual ~PlainDateTime() override = default;
 
     [[nodiscard]] i32 iso_year() const { return m_iso_year; }
@@ -35,6 +34,8 @@ public:
     [[nodiscard]] Object& calendar() { return m_calendar; }
 
 private:
+    PlainDateTime(i32 iso_year, u8 iso_month, u8 iso_day, u8 iso_hour, u8 iso_minute, u8 iso_second, u16 iso_millisecond, u16 iso_microsecond, u16 iso_nanosecond, Object& calendar, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     // 5.4 Properties of Temporal.PlainDateTime Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-plaindatetime-instances

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimeConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimeConstructor.h
@@ -14,7 +14,6 @@ class PlainDateTimeConstructor final : public NativeFunction {
     JS_OBJECT(PlainDateTimeConstructor, NativeFunction);
 
 public:
-    explicit PlainDateTimeConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PlainDateTimeConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit PlainDateTimeConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -15,11 +15,12 @@ class PlainDateTimePrototype final : public PrototypeObject<PlainDateTimePrototy
     JS_PROTOTYPE_OBJECT(PlainDateTimePrototype, PlainDateTime, Temporal.PlainDateTime);
 
 public:
-    explicit PlainDateTimePrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PlainDateTimePrototype() override = default;
 
 private:
+    explicit PlainDateTimePrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_getter);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.h
@@ -14,7 +14,6 @@ class PlainMonthDay final : public Object {
     JS_OBJECT(PlainMonthDay, Object);
 
 public:
-    PlainMonthDay(u8 iso_month, u8 iso_day, i32 iso_year, Object& calendar, Object& prototype);
     virtual ~PlainMonthDay() override = default;
 
     [[nodiscard]] i32 iso_year() const { return m_iso_year; }
@@ -24,6 +23,8 @@ public:
     [[nodiscard]] Object& calendar() { return m_calendar; }
 
 private:
+    PlainMonthDay(u8 iso_month, u8 iso_day, i32 iso_year, Object& calendar, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     // 10.4 Properties of Temporal.PlainMonthDay Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-plainmonthday-instances

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayConstructor.h
@@ -14,7 +14,6 @@ class PlainMonthDayConstructor final : public NativeFunction {
     JS_OBJECT(PlainMonthDayConstructor, NativeFunction);
 
 public:
-    explicit PlainMonthDayConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PlainMonthDayConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit PlainMonthDayConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.h
@@ -15,11 +15,12 @@ class PlainMonthDayPrototype final : public PrototypeObject<PlainMonthDayPrototy
     JS_PROTOTYPE_OBJECT(PlainMonthDayPrototype, PlainMonthDay, Temporal.PlainMonthDay);
 
 public:
-    explicit PlainMonthDayPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PlainMonthDayPrototype() override = default;
 
 private:
+    explicit PlainMonthDayPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_code_getter);
     JS_DECLARE_NATIVE_FUNCTION(day_getter);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.h
@@ -19,7 +19,6 @@ class PlainTime final : public Object {
     JS_OBJECT(PlainDateTime, Object);
 
 public:
-    PlainTime(u8 iso_hour, u8 iso_minute, u8 iso_second, u16 iso_millisecond, u16 iso_microsecond, u16 iso_nanosecond, Calendar& calendar, Object& prototype);
     virtual ~PlainTime() override = default;
 
     [[nodiscard]] u8 iso_hour() const { return m_iso_hour; }
@@ -32,6 +31,8 @@ public:
     [[nodiscard]] Calendar& calendar() { return m_calendar; }
 
 private:
+    PlainTime(u8 iso_hour, u8 iso_minute, u8 iso_second, u16 iso_millisecond, u16 iso_microsecond, u16 iso_nanosecond, Calendar& calendar, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     // 4.4 Properties of Temporal.PlainTime Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-plaintime-instances

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimeConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimeConstructor.h
@@ -14,7 +14,6 @@ class PlainTimeConstructor final : public NativeFunction {
     JS_OBJECT(PlainTimeConstructor, NativeFunction);
 
 public:
-    explicit PlainTimeConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PlainTimeConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit PlainTimeConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.h
@@ -15,11 +15,12 @@ class PlainTimePrototype final : public PrototypeObject<PlainTimePrototype, Plai
     JS_PROTOTYPE_OBJECT(PlainTimePrototype, PlainTime, Temporal.PlainTime);
 
 public:
-    explicit PlainTimePrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PlainTimePrototype() override = default;
 
 private:
+    explicit PlainTimePrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
     JS_DECLARE_NATIVE_FUNCTION(hour_getter);
     JS_DECLARE_NATIVE_FUNCTION(minute_getter);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.h
@@ -15,7 +15,6 @@ class PlainYearMonth final : public Object {
     JS_OBJECT(PlainYearMonth, Object);
 
 public:
-    PlainYearMonth(i32 iso_year, u8 iso_month, u8 iso_day, Object& calendar, Object& prototype);
     virtual ~PlainYearMonth() override = default;
 
     [[nodiscard]] i32 iso_year() const { return m_iso_year; }
@@ -25,6 +24,8 @@ public:
     [[nodiscard]] Object& calendar() { return m_calendar; }
 
 private:
+    PlainYearMonth(i32 iso_year, u8 iso_month, u8 iso_day, Object& calendar, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     // 9.4 Properties of Temporal.PlainYearMonth Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-plainyearmonth-instances

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.h
@@ -14,7 +14,6 @@ class PlainYearMonthConstructor final : public NativeFunction {
     JS_OBJECT(PlainYearMonthConstructor, NativeFunction);
 
 public:
-    explicit PlainYearMonthConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PlainYearMonthConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit PlainYearMonthConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -15,11 +15,12 @@ class PlainYearMonthPrototype final : public PrototypeObject<PlainYearMonthProto
     JS_PROTOTYPE_OBJECT(PlainYearMonthPrototype, PlainYearMonth, Temporal.PlainYearMonth);
 
 public:
-    explicit PlainYearMonthPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~PlainYearMonthPrototype() override = default;
 
 private:
+    explicit PlainYearMonthPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_getter);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Temporal.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Temporal.h
@@ -14,9 +14,11 @@ class Temporal final : public Object {
     JS_OBJECT(Temporal, Object);
 
 public:
-    explicit Temporal(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~Temporal() override = default;
+
+private:
+    explicit Temporal(Realm&);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -20,7 +20,6 @@ public:
     // Needs to store values in the range -8.64 * 10^13 to 8.64 * 10^13
     using OffsetType = double;
 
-    explicit TimeZone(Object& prototype);
     virtual ~TimeZone() override = default;
 
     [[nodiscard]] String const& identifier() const { return m_identifier; }
@@ -30,6 +29,8 @@ public:
     void set_offset_nanoseconds(OffsetType offset_nanoseconds) { m_offset_nanoseconds = offset_nanoseconds; };
 
 private:
+    explicit TimeZone(Object& prototype);
+
     // 11.5 Properties of Temporal.TimeZone Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-timezone-instances
     String m_identifier;                       // [[Identifier]]
     Optional<OffsetType> m_offset_nanoseconds; // [[OffsetNanoseconds]]

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneConstructor.h
@@ -14,7 +14,6 @@ class TimeZoneConstructor final : public NativeFunction {
     JS_OBJECT(TimeZoneConstructor, NativeFunction);
 
 public:
-    explicit TimeZoneConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~TimeZoneConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit TimeZoneConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.h
@@ -15,11 +15,12 @@ class TimeZonePrototype final : public PrototypeObject<TimeZonePrototype, TimeZo
     JS_PROTOTYPE_OBJECT(TimeZonePrototype, TimeZone, Temporal.TimeZone);
 
 public:
-    explicit TimeZonePrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~TimeZonePrototype() override = default;
 
 private:
+    explicit TimeZonePrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(id_getter);
     JS_DECLARE_NATIVE_FUNCTION(get_offset_nanoseconds_for);
     JS_DECLARE_NATIVE_FUNCTION(get_offset_string_for);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.h
@@ -15,7 +15,6 @@ class ZonedDateTime final : public Object {
     JS_OBJECT(ZonedDateTime, Object);
 
 public:
-    ZonedDateTime(BigInt const& nanoseconds, Object& time_zone, Object& calendar, Object& prototype);
     virtual ~ZonedDateTime() override = default;
 
     [[nodiscard]] BigInt const& nanoseconds() const { return m_nanoseconds; }
@@ -25,6 +24,8 @@ public:
     [[nodiscard]] Object& calendar() { return m_calendar; }
 
 private:
+    ZonedDateTime(BigInt const& nanoseconds, Object& time_zone, Object& calendar, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     // 6.4 Properties of Temporal.ZonedDateTime Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-zoneddatetime-instances

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.h
@@ -14,7 +14,6 @@ class ZonedDateTimeConstructor final : public NativeFunction {
     JS_OBJECT(ZonedDateTimeConstructor, NativeFunction);
 
 public:
-    explicit ZonedDateTimeConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ZonedDateTimeConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
 
 private:
+    explicit ZonedDateTimeConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.h
@@ -15,11 +15,12 @@ class ZonedDateTimePrototype final : public PrototypeObject<ZonedDateTimePrototy
     JS_PROTOTYPE_OBJECT(ZonedDateTimePrototype, ZonedDateTime, Temporal.ZonedDateTime);
 
 public:
-    explicit ZonedDateTimePrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~ZonedDateTimePrototype() override = default;
 
 private:
+    explicit ZonedDateTimePrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
     JS_DECLARE_NATIVE_FUNCTION(time_zone_getter);
     JS_DECLARE_NATIVE_FUNCTION(year_getter);

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -414,7 +414,7 @@ public:
         return { move(keys) };
     }
 
-    Span<const UnderlyingBufferDataType> data() const
+    Span<UnderlyingBufferDataType const> data() const
     {
         return { reinterpret_cast<UnderlyingBufferDataType const*>(m_viewed_array_buffer->buffer().data() + m_byte_offset), m_array_length };
     }
@@ -471,22 +471,25 @@ ThrowCompletionOr<double> compare_typed_array_elements(VM&, Value x, Value y, Fu
             Realm&, u32 length, FunctionObject& new_target);                                \
         static ThrowCompletionOr<ClassName*> create(Realm&, u32 length);                    \
         static ClassName* create(Realm&, u32 length, ArrayBuffer& buffer);                  \
-        ClassName(Object& prototype, u32 length, ArrayBuffer& array_buffer);                \
         virtual FlyString const& element_name() const override;                             \
+                                                                                            \
+    protected:                                                                              \
+        ClassName(Object& prototype, u32 length, ArrayBuffer& array_buffer);                \
     };                                                                                      \
     class PrototypeName final : public Object {                                             \
         JS_OBJECT(PrototypeName, Object);                                                   \
                                                                                             \
     public:                                                                                 \
-        PrototypeName(Realm&);                                                              \
         virtual void initialize(Realm&) override;                                           \
         virtual ~PrototypeName() override;                                                  \
+                                                                                            \
+    private:                                                                                \
+        PrototypeName(Realm&);                                                              \
     };                                                                                      \
     class ConstructorName final : public TypedArrayConstructor {                            \
         JS_OBJECT(ConstructorName, TypedArrayConstructor);                                  \
                                                                                             \
     public:                                                                                 \
-        explicit ConstructorName(Realm&);                                                   \
         virtual void initialize(Realm&) override;                                           \
         virtual ~ConstructorName() override;                                                \
                                                                                             \
@@ -494,6 +497,7 @@ ThrowCompletionOr<double> compare_typed_array_elements(VM&, Value x, Value y, Fu
         virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;  \
                                                                                             \
     private:                                                                                \
+        explicit ConstructorName(Realm&);                                                   \
         virtual bool has_constructor() const override                                       \
         {                                                                                   \
             return true;                                                                    \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.h
@@ -14,13 +14,15 @@ class TypedArrayConstructor : public NativeFunction {
     JS_OBJECT(TypedArrayConstructor, NativeFunction);
 
 public:
-    TypedArrayConstructor(FlyString const& name, Object& prototype);
     explicit TypedArrayConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~TypedArrayConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
+
+protected:
+    TypedArrayConstructor(FlyString const& name, Object& prototype);
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -15,11 +15,12 @@ class TypedArrayPrototype final : public Object {
     JS_OBJECT(TypedArrayPrototype, Object);
 
 public:
-    explicit TypedArrayPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~TypedArrayPrototype() override = default;
 
 private:
+    explicit TypedArrayPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(buffer_getter);
     JS_DECLARE_NATIVE_FUNCTION(byte_length_getter);
     JS_DECLARE_NATIVE_FUNCTION(byte_offset_getter);

--- a/Userland/Libraries/LibJS/Runtime/WeakMap.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMap.h
@@ -21,7 +21,6 @@ class WeakMap final
 public:
     static WeakMap* create(Realm&);
 
-    explicit WeakMap(Object& prototype);
     virtual ~WeakMap() override = default;
 
     HashMap<Cell*, Value> const& values() const { return m_values; };
@@ -30,6 +29,8 @@ public:
     virtual void remove_dead_cells(Badge<Heap>) override;
 
 private:
+    explicit WeakMap(Object& prototype);
+
     void visit_edges(Visitor&) override;
 
     HashMap<Cell*, Value> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping

--- a/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.h
@@ -14,7 +14,6 @@ class WeakMapConstructor final : public NativeFunction {
     JS_OBJECT(WeakMapConstructor, NativeFunction);
 
 public:
-    explicit WeakMapConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~WeakMapConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;
 
 private:
+    explicit WeakMapConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.h
@@ -15,11 +15,12 @@ class WeakMapPrototype final : public PrototypeObject<WeakMapPrototype, WeakMap>
     JS_PROTOTYPE_OBJECT(WeakMapPrototype, WeakMap, WeakMap);
 
 public:
-    WeakMapPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~WeakMapPrototype() override = default;
 
 private:
+    explicit WeakMapPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(delete_);
     JS_DECLARE_NATIVE_FUNCTION(get);
     JS_DECLARE_NATIVE_FUNCTION(has);

--- a/Userland/Libraries/LibJS/Runtime/WeakRef.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRef.h
@@ -21,8 +21,6 @@ public:
     static WeakRef* create(Realm&, Object&);
     static WeakRef* create(Realm&, Symbol&);
 
-    explicit WeakRef(Object&, Object& prototype);
-    explicit WeakRef(Symbol&, Object& prototype);
     virtual ~WeakRef() override = default;
 
     auto const& value() const { return m_value; };
@@ -32,6 +30,9 @@ public:
     virtual void remove_dead_cells(Badge<Heap>) override;
 
 private:
+    explicit WeakRef(Object&, Object& prototype);
+    explicit WeakRef(Symbol&, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     Variant<Object*, Symbol*, Empty> m_value;

--- a/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.h
@@ -14,7 +14,6 @@ class WeakRefConstructor final : public NativeFunction {
     JS_OBJECT(WeakRefConstructor, NativeFunction);
 
 public:
-    explicit WeakRefConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~WeakRefConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;
 
 private:
+    explicit WeakRefConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.h
@@ -15,11 +15,12 @@ class WeakRefPrototype final : public PrototypeObject<WeakRefPrototype, WeakRef>
     JS_PROTOTYPE_OBJECT(WeakRefPrototype, WeakRef, WeakRef);
 
 public:
-    WeakRefPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~WeakRefPrototype() override = default;
 
 private:
+    explicit WeakRefPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(deref);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.h
@@ -21,7 +21,6 @@ class WeakSet final
 public:
     static WeakSet* create(Realm&);
 
-    explicit WeakSet(Object& prototype);
     virtual ~WeakSet() override = default;
 
     HashTable<Cell*> const& values() const { return m_values; };
@@ -30,6 +29,8 @@ public:
     virtual void remove_dead_cells(Badge<Heap>) override;
 
 private:
+    explicit WeakSet(Object& prototype);
+
     HashTable<Cell*> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping
 };
 

--- a/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.h
@@ -14,7 +14,6 @@ class WeakSetConstructor final : public NativeFunction {
     JS_OBJECT(WeakSetConstructor, NativeFunction);
 
 public:
-    explicit WeakSetConstructor(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~WeakSetConstructor() override = default;
 
@@ -22,6 +21,8 @@ public:
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;
 
 private:
+    explicit WeakSetConstructor(Realm&);
+
     virtual bool has_constructor() const override { return true; }
 };
 

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
@@ -15,11 +15,12 @@ class WeakSetPrototype final : public PrototypeObject<WeakSetPrototype, WeakSet>
     JS_PROTOTYPE_OBJECT(WeakSetPrototype, WeakSet, WeakSet);
 
 public:
-    WeakSetPrototype(Realm&);
     virtual void initialize(Realm&) override;
     virtual ~WeakSetPrototype() override = default;
 
 private:
+    explicit WeakSetPrototype(Realm&);
+
     JS_DECLARE_NATIVE_FUNCTION(add);
     JS_DECLARE_NATIVE_FUNCTION(delete_);
     JS_DECLARE_NATIVE_FUNCTION(has);

--- a/Userland/Libraries/LibJS/Runtime/WrappedFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/WrappedFunction.h
@@ -17,7 +17,6 @@ class WrappedFunction final : public FunctionObject {
 public:
     static ThrowCompletionOr<WrappedFunction*> create(Realm&, Realm& caller_realm, FunctionObject& target_function);
 
-    WrappedFunction(Realm&, FunctionObject&, Object& prototype);
     virtual ~WrappedFunction() = default;
 
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
@@ -31,6 +30,8 @@ public:
     FunctionObject& wrapped_target_function() { return m_wrapped_target_function; }
 
 private:
+    WrappedFunction(Realm&, FunctionObject&, Object& prototype);
+
     virtual void visit_edges(Visitor&) override;
 
     // Internal Slots of Wrapped Function Exotic Objects, https://tc39.es/proposal-shadowrealm/#table-internal-slots-of-wrapped-function-exotic-objects


### PR DESCRIPTION
Use the magic of friendship to remove the need for `JS::Cell` subclasses to have public constructors.