### PR TITLE
LibGL+LibGPU+LibSoftGPU: Report texture env add extension

### DIFF
--- a/Userland/Libraries/LibGL/GLContext.cpp
+++ b/Userland/Libraries/LibGL/GLContext.cpp
@@ -933,6 +933,11 @@ void GLContext::build_extension_string()
     if (m_device_info.num_texture_units > 1)
         extensions.append("GL_ARB_multitexture"sv);
 
+    if (m_device_info.supports_texture_env_add) {
+        extensions.append("GL_ARB_texture_env_add"sv);
+        extensions.append("GL_EXT_texture_env_add"sv);
+    }
+
     m_extensions = String::join(' ', extensions);
 }
 

--- a/Userland/Libraries/LibGPU/DeviceInfo.h
+++ b/Userland/Libraries/LibGPU/DeviceInfo.h
@@ -18,6 +18,7 @@ struct DeviceInfo final {
     unsigned max_clip_planes;
     u8 stencil_bits;
     bool supports_npot_textures;
+    bool supports_texture_env_add;
 };
 
 }

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -835,6 +835,7 @@ GPU::DeviceInfo Device::info() const
         .max_clip_planes = MAX_CLIP_PLANES,
         .stencil_bits = sizeof(GPU::StencilType) * 8,
         .supports_npot_textures = true,
+        .supports_texture_env_add = true,
     };
 }
 


### PR DESCRIPTION
The Quake 3 port makes use of this extension to determine a more efficient multitexturing strategy. Since LibSoftGPU supports it, let's report the extension in LibGL. :^)