### PR TITLE
PixelPaint: Specialize how the mouse position is converted into a pixel position based on the currently selected tool

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -269,9 +269,11 @@ void ImageEditor::second_paint_event(GUI::PaintEvent& event)
 GUI::MouseEvent ImageEditor::event_with_pan_and_scale_applied(GUI::MouseEvent const& event) const
 {
     auto image_position = frame_to_content_position(event.position());
+    auto tool_adjusted_image_position = m_active_tool->point_position_to_preferred_cell(image_position);
+
     return {
         static_cast<GUI::Event::Type>(event.type()),
-        image_position.to_rounded<int>(),
+        tool_adjusted_image_position,
         event.buttons(),
         event.button(),
         event.modifiers(),
@@ -286,9 +288,11 @@ GUI::MouseEvent ImageEditor::event_adjusted_for_layer(GUI::MouseEvent const& eve
 {
     auto image_position = frame_to_content_position(event.position());
     image_position.translate_by(-layer.location().x(), -layer.location().y());
+    auto tool_adjusted_image_position = m_active_tool->point_position_to_preferred_cell(image_position);
+
     return {
         static_cast<GUI::Event::Type>(event.type()),
-        image_position.to_rounded<int>(),
+        tool_adjusted_image_position,
         event.buttons(),
         event.button(),
         event.modifiers(),

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -335,13 +335,13 @@ void ImageEditor::mousemove_event(GUI::MouseEvent& event)
         return;
     }
 
+    if (!m_active_tool)
+        return;
+
     auto image_event = event_with_pan_and_scale_applied(event);
     if (on_image_mouse_position_change) {
         on_image_mouse_position_change(image_event.position());
     }
-
-    if (!m_active_tool)
-        return;
 
     auto layer_event = m_active_layer ? event_adjusted_for_layer(event, *m_active_layer) : event;
     Tool::MouseEvent tool_event(Tool::MouseEvent::Action::MouseDown, layer_event, image_event, event);

--- a/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.cpp
@@ -211,4 +211,9 @@ GUI::Widget* RectangleSelectTool::get_properties_widget()
     return m_properties_widget.ptr();
 }
 
+Gfx::IntPoint RectangleSelectTool::point_position_to_preferred_cell(Gfx::FloatPoint const& position) const
+{
+    return position.to_rounded<int>();
+}
+
 }

--- a/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.h
@@ -28,6 +28,7 @@ public:
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Gfx::IntPoint point_position_to_preferred_cell(Gfx::FloatPoint const& position) const override;
 
 private:
     virtual StringView tool_name() const override { return "Rectangle Select Tool"sv; }

--- a/Userland/Applications/PixelPaint/Tools/Tool.h
+++ b/Userland/Applications/PixelPaint/Tools/Tool.h
@@ -64,6 +64,7 @@ public:
     virtual void on_tool_activation() { }
     virtual GUI::Widget* get_properties_widget() { return nullptr; }
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() { return Gfx::StandardCursor::None; }
+    virtual Gfx::IntPoint point_position_to_preferred_cell(Gfx::FloatPoint const& position) const { return position.to_type<int>(); }
 
     void clear() { m_editor = nullptr; }
     void setup(ImageEditor&);

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -246,13 +246,19 @@ public:
         return Point<U>(roundf(x()), roundf(y()));
     }
 
+    template<typename U>
+    requires FloatingPoint<T>
+    [[nodiscard]] Point<U> to_ceiled() const
+    {
+        return Point<U>(ceil(x()), ceil(y()));
+    }
+
     [[nodiscard]] String to_string() const;
 
 private:
     T m_x { 0 };
     T m_y { 0 };
 };
-
 using IntPoint = Point<int>;
 using FloatPoint = Point<float>;
 


### PR DESCRIPTION
This commit aims to fix the issue #15064, which happens because the `event_with_pan_and_scale_applied` has been modified to improve the feeling of the rectangle tool.
The issue is that now a pixel offset has been applied because all the other tools work best when the input position is floored instead of being rounded: to fix this situation, the `Tool::point_position_to_preferred_cell `virtual method has been added which is used to fetch the pixel that a tool should interact with based on the mouse position.
The `RectangleSelectionTool `specializes this method to improve how the selection is expanded.
