### PR TITLE
LibJS: Properly initialize the global object for $262.createRealm

### DIFF
--- a/Userland/Libraries/LibJS/Contrib/Test262/$262Object.cpp
+++ b/Userland/Libraries/LibJS/Contrib/Test262/$262Object.cpp
@@ -62,6 +62,7 @@ JS_DEFINE_NATIVE_FUNCTION($262Object::create_realm)
     auto* realm_global_object = vm.heap().allocate_without_realm<GlobalObject>(*realm);
     VERIFY(realm_global_object);
     realm->set_global_object(realm_global_object, nullptr);
+    set_default_global_bindings(*realm);
     realm_global_object->initialize(*realm);
     return Value(realm_global_object->$262());
 }


### PR DESCRIPTION
This fixes the recent regression

~~Weirdly it is just: `+173 ✅    -177 ❌   +4 📝` so I missed something?~~
That's me skipping the regex tests because they take so long.