### PR TITLE
LibJS: Fix TemporalCalendarString ambiguity

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -243,6 +243,7 @@
     M(TemporalInvalidEpochNanoseconds, "Invalid epoch nanoseconds value, must be in range -86400 * 10^17 to 86400 * 10^17")             \
     M(TemporalInvalidInstantString, "Invalid instant string '{}'")                                                                      \
     M(TemporalInvalidISODate, "Invalid ISO date")                                                                                       \
+    M(TemporalInvalidISODateTime, "Invalid ISO date time")                                                                              \
     M(TemporalInvalidMonthCode, "Invalid month code")                                                                                   \
     M(TemporalInvalidMonthDayString, "Invalid month day string '{}'")                                                                   \
     M(TemporalInvalidMonthDayStringUTCDesignator, "Invalid month day string '{}': must not contain a UTC designator")                   \

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
@@ -161,6 +161,7 @@ Crypto::SignedBigInteger apply_unsigned_rounding_mode(Crypto::SignedDivisionResu
 double round_number_to_increment(double, u64 increment, StringView rounding_mode);
 Crypto::SignedBigInteger round_number_to_increment(Crypto::SignedBigInteger const&, u64 increment, StringView rounding_mode);
 Crypto::SignedBigInteger round_number_to_increment_as_if_positive(Crypto::SignedBigInteger const&, u64 increment, StringView rounding_mode);
+ThrowCompletionOr<ISODateTime> parse_iso_date_time(VM&, StringView iso_string);
 ThrowCompletionOr<ISODateTime> parse_iso_date_time(VM&, ParseResult const& parse_result);
 ThrowCompletionOr<TemporalInstant> parse_temporal_instant_string(VM&, String const& iso_string);
 ThrowCompletionOr<ISODateTime> parse_temporal_zoned_date_time_string(VM&, String const& iso_string);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -406,17 +406,14 @@ ThrowCompletionOr<Object*> to_temporal_calendar(VM& vm, Value temporal_calendar_
     // 2. Let identifier be ? ToString(temporalCalendarLike).
     auto identifier = TRY(temporal_calendar_like.to_string(vm));
 
-    // 3. If IsBuiltinCalendar(identifier) is false, then
-    if (!is_builtin_calendar(identifier)) {
-        // a. Set identifier to ? ParseTemporalCalendarString(identifier).
-        identifier = TRY(parse_temporal_calendar_string(vm, identifier));
+    // 3. Set identifier to ? ParseTemporalCalendarString(identifier).
+    identifier = TRY(parse_temporal_calendar_string(vm, identifier));
 
-        // b. If IsBuiltinCalendar(identifier) is false, throw a RangeError exception.
-        if (!is_builtin_calendar(identifier))
-            return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidCalendarIdentifier, identifier);
-    }
+    // 4. If IsBuiltinCalendar(identifier) is false, throw a RangeError exception.
+    if (!is_builtin_calendar(identifier))
+        return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidCalendarIdentifier, identifier);
 
-    // 4. Return ! CreateTemporalCalendar(identifier).
+    // 5. Return ! CreateTemporalCalendar(identifier).
     return MUST(create_temporal_calendar(vm, identifier));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ISO8601.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ISO8601.cpp
@@ -1446,24 +1446,6 @@ bool ISO8601Parser::parse_temporal_zoned_date_time_string()
     return true;
 }
 
-// https://tc39.es/proposal-temporal/#prod-TemporalCalendarString
-bool ISO8601Parser::parse_temporal_calendar_string()
-{
-    // TemporalCalendarString :
-    //     CalendarName
-    //     TemporalInstantString
-    //     CalendarDateTime
-    //     CalendarTime
-    //     DateSpecYearMonth
-    //     DateSpecMonthDay
-    return parse_calendar_name()
-        || parse_temporal_instant_string()
-        || parse_calendar_date_time()
-        || parse_date_spec_year_month()
-        || parse_date_spec_month_day()
-        || parse_calendar_time();
-}
-
 }
 
 #define JS_ENUMERATE_ISO8601_PRODUCTION_PARSERS                                        \
@@ -1475,8 +1457,8 @@ bool ISO8601Parser::parse_temporal_calendar_string()
     __JS_ENUMERATE(TemporalTimeZoneString, parse_temporal_time_zone_string)            \
     __JS_ENUMERATE(TemporalYearMonthString, parse_temporal_year_month_string)          \
     __JS_ENUMERATE(TemporalZonedDateTimeString, parse_temporal_zoned_date_time_string) \
-    __JS_ENUMERATE(TemporalCalendarString, parse_temporal_calendar_string)             \
-    __JS_ENUMERATE(TimeZoneNumericUTCOffset, parse_time_zone_numeric_utc_offset)
+    __JS_ENUMERATE(TimeZoneNumericUTCOffset, parse_time_zone_numeric_utc_offset)       \
+    __JS_ENUMERATE(CalendarName, parse_calendar_name)
 
 Optional<ParseResult> parse_iso8601(Production production, StringView input)
 {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ISO8601.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ISO8601.h
@@ -52,8 +52,8 @@ enum class Production {
     TemporalTimeZoneString,
     TemporalYearMonthString,
     TemporalZonedDateTimeString,
-    TemporalCalendarString,
     TimeZoneNumericUTCOffset,
+    CalendarName,
 };
 
 Optional<ParseResult> parse_iso8601(Production, StringView);
@@ -166,7 +166,6 @@ public:
     [[nodiscard]] bool parse_temporal_time_zone_string();
     [[nodiscard]] bool parse_temporal_year_month_string();
     [[nodiscard]] bool parse_temporal_zoned_date_time_string();
-    [[nodiscard]] bool parse_temporal_calendar_string();
 
 private:
     struct State {


### PR DESCRIPTION
```
Diff Tests:
    +62 ✅    -62 ❌
```