### PR TITLE
FileManager+LibGUI: Fixes for removal of current directory in FileManager

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -196,6 +196,19 @@ void DirectoryView::setup_model()
             on_path_change(model().root_path(), true, can_write_in_path);
     };
 
+    m_model->on_root_path_removed = [this] {
+        // Change model root to the first existing parent directory.
+        LexicalPath model_root(model().root_path());
+
+        while (model_root.string() != "/") {
+            model_root = model_root.parent();
+            if (Core::File::is_directory(model_root.string()))
+                break;
+        }
+
+        open(model_root.string());
+    };
+
     m_model->register_client(*this);
 
     m_model->on_thumbnail_progress = [this](int done, int total) {

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -421,6 +421,7 @@ void FileSystemModel::handle_file_event(Core::FileWatcherEvent const& event)
         if (&child.value() == m_root) {
             // Root directory of the filesystem model has been removed. All items became invalid.
             invalidate();
+            on_root_path_removed();
             break;
         }
 

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -418,6 +418,12 @@ void FileSystemModel::handle_file_event(Core::FileWatcherEvent const& event)
             break;
         }
 
+        if (&child.value() == m_root) {
+            // Root directory of the filesystem model has been removed. All items became invalid.
+            invalidate();
+            break;
+        }
+
         auto index = child->index(0);
         begin_delete_rows(index.parent(), index.row(), index.row());
 

--- a/Userland/Libraries/LibGUI/FileSystemModel.h
+++ b/Userland/Libraries/LibGUI/FileSystemModel.h
@@ -120,6 +120,7 @@ public:
     Function<void(int error, char const* error_string)> on_directory_change_error;
     Function<void(int error, char const* error_string)> on_rename_error;
     Function<void(String const& old_name, String const& new_name)> on_rename_successful;
+    Function<void()> on_root_path_removed;
 
     virtual int tree_column() const override { return Column::Name; }
     virtual int row_count(ModelIndex const& = ModelIndex()) const override;


### PR DESCRIPTION
This PR addresses two issues in FileManager:
 1. The application will no longer crash when the current directory is removed by an external process (#13584).
 2. When the current location is removed, FileManager will move to an existing parent directory (as many levels as needed).