### PR TITLE
LibGUI: Spin box usability

### DIFF
--- a/Userland/Libraries/LibGUI/SpinBox.cpp
+++ b/Userland/Libraries/LibGUI/SpinBox.cpp
@@ -69,6 +69,10 @@ void SpinBox::set_value(int value, AllowCallback allow_callback)
     if (m_value == value)
         return;
     m_value = value;
+
+    m_increment_button->set_enabled(m_value < m_max);
+    m_decrement_button->set_enabled(m_value > m_min);
+
     m_editor->set_text(String::number(value));
     update();
     if (on_change && allow_callback == AllowCallback::Yes)

--- a/Userland/Libraries/LibGUI/SpinBox.cpp
+++ b/Userland/Libraries/LibGUI/SpinBox.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022, Timothy Slater <tslater2006@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -24,10 +25,15 @@ SpinBox::SpinBox()
             return;
 
         auto value = m_editor->text().to_uint();
+        if (!value.has_value() && m_editor->text().length() > 0)
+            m_editor->do_delete();
+    };
+    m_editor->on_focusout = [this] {
+        auto value = m_editor->text().to_int();
         if (value.has_value())
             set_value(value.value());
         else
-            m_editor->set_text(String::number(m_value));
+            set_value(min());
     };
     m_editor->on_up_pressed = [this] {
         set_value(m_value + 1);


### PR DESCRIPTION
This covers some usability improvements to the SpinBox control. The issues were noticed when working with PixelPaint.

Issues:

- Deleting selection of text doesn't work
- entering a number does not replace the selected text
- contents of the textbox change immediately and unexpectedly when you enter a number that exceeds the maximum value

These issues all stem from parsing and updating the SpinBox value after every character entry. This PR solves these by deferring the update of the SpinBox's internal value until the control loses focus. Allowing the user to type any numbers they want while they are editing the text field, or even blanking the text field out.

On focus loss the text value will be checked, if blank, we set value to min(), if not blank we set value to the parsed value (which will be clamped by min/max)

Also a small UI fix where we disable the increment/decrement buttons as appropriate, when the SpinBox value matches max or min respectively.