### PR TITLE
Profiler: Display correctly rounded percentages as '#.##%'

### DIFF
--- a/Userland/DevTools/Profiler/ProfileModel.cpp
+++ b/Userland/DevTools/Profiler/ProfileModel.cpp
@@ -111,10 +111,16 @@ GUI::Variant ProfileModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
         return {};
     }
     if (role == GUI::ModelRole::Display) {
-        auto round_percentages = [this](auto percentage) {
-            return roundf(static_cast<float>(percentage) / static_cast<float>(m_profile.filtered_event_indices().size())
-                       * percent_digits_rounding_constant)
-                * 100.0f / percent_digits_rounding_constant;
+        auto round_percentages = [this](auto value) {
+            auto percentage_full_precision = round_to<int>(
+                static_cast<float>(value)
+                * 100.f
+                / static_cast<float>(m_profile.filtered_event_indices().size())
+                * percent_digits_rounding);
+            return String::formatted(
+                "{}.{:02}",
+                percentage_full_precision / percent_digits_rounding,
+                percentage_full_precision % percent_digits_rounding);
         };
         if (index.column() == Column::SampleCount) {
             if (m_profile.show_percentages())

--- a/Userland/DevTools/Profiler/ProfileModel.h
+++ b/Userland/DevTools/Profiler/ProfileModel.h
@@ -14,8 +14,8 @@ namespace Profiler {
 class Profile;
 
 // Number of digits after the decimal point for sample percentages.
-static constexpr int const number_of_percent_digits = 3;
-static constexpr float const percent_digits_rounding_constant = AK::pow(10, number_of_percent_digits);
+static constexpr int const number_of_percent_digits = 2;
+static constexpr int const percent_digits_rounding = AK::pow(10, number_of_percent_digits);
 
 class ProfileModel final : public GUI::Model {
 public:


### PR DESCRIPTION
Previously, an incorrect number of digits was rounded to, and floating point imprecisions leaked to the UI.

Before:

![image](https://user-images.githubusercontent.com/3210731/187706707-0395a969-c3f4-4d9a-a806-8eb9db75f376.png)

After:

![image](https://user-images.githubusercontent.com/3210731/187706539-a24e7d9c-04d9-4f2d-8b08-2a06ff033744.png)