### PR TITLE
Ports/python3: Patches to make pip work

### DIFF
--- a/Ports/python3/patches/0005-Tweak-setup.py-sysroot-detection.patch
+++ b/Ports/python3/patches/0005-Tweak-setup.py-sysroot-detection.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Humberto Alves <hjalves@live.com>
+Date: Thu, 1 Sep 2022 20:25:11 +0100
+Subject: [PATCH] Tweak `setup.py` sysroot detection
+
+When crosscompiling, the Python installer expects the C compiler to
+be invoked with a `--sysroot` command line option, which then is used
+to find additional subdirectories containing headers and libraries.
+
+Because there is no such option present, this is a workaround to use
+the environment variable `SERENITY_INSTALL_ROOT` as a fake `--sysroot`
+in the detection code.
+---
+ setup.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/setup.py b/setup.py
+index acd7b05..6554b1c 100644
+--- a/setup.py
++++ b/setup.py
+@@ -163,6 +163,8 @@ def sysroot_paths(make_vars, subdirs):
+     for var_name in make_vars:
+         var = sysconfig.get_config_var(var_name)
+         if var is not None:
++            if serenity_install_root := os.environ.get('SERENITY_INSTALL_ROOT'):
++                var += f' --sysroot={serenity_install_root}'
+             m = re.search(r'--sysroot=([^"]\S*|"[^"]+")', var)
+             if m is not None:
+                 sysroot = m.group(1).strip('"')

--- a/Ports/python3/patches/0006-Workaround-for-unsupported-socket-option.patch
+++ b/Ports/python3/patches/0006-Workaround-for-unsupported-socket-option.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Humberto Alves <hjalves@live.com>
+Date: Fri, 2 Sep 2022 03:31:42 +0100
+Subject: [PATCH] Workaround for unsupported socket option
+
+This is a workaround for ignoring the result of `setsockopt` call when
+given `TCP_NODELAY` as an argument. This TCP socket option is used in
+many applications (like pip and requests) for optimization purposes.
+For now, it can be safely ignored until it's supported in the kernel.
+---
+ Modules/socketmodule.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Modules/socketmodule.c b/Modules/socketmodule.c
+index 0109d97..484e651 100644
+--- a/Modules/socketmodule.c
++++ b/Modules/socketmodule.c
+@@ -3003,6 +3003,8 @@ sock_setsockopt(PySocketSockObject *s, PyObject *args)
+     PyBuffer_Release(&optval);
+ 
+ done:
++    if (res < 0 && level == IPPROTO_TCP && optname == TCP_NODELAY && errno == ENOPROTOOPT)
++        res = 0;
+     if (res < 0) {
+         return s->errorhandler();
+     }

--- a/Ports/python3/patches/ReadMe.md
+++ b/Ports/python3/patches/ReadMe.md
@@ -36,3 +36,24 @@ Make some tweaks to Python's `setup.py`:
   build the `_curses` module. This is by default included for a bunch of
   extensions, but not `_curses`.
 
+## `0005-Tweak-setup.py-sysroot-detection.patch`
+
+Tweak `setup.py` sysroot detection
+
+When crosscompiling, the Python installer expects the C compiler to
+be invoked with a `--sysroot` command line option, which then is used
+to find additional subdirectories containing headers and libraries.
+
+Because there is no such option present, this is a workaround to use
+the environment variable `SERENITY_INSTALL_ROOT` as a fake `--sysroot`
+in the detection code.
+
+## `0006-Workaround-for-unsupported-socket-option.patch`
+
+Workaround for unsupported socket option
+
+This is a workaround for ignoring the result of `setsockopt` call when
+given `TCP_NODELAY` as an argument. This TCP socket option is used in
+many applications (like pip and requests) for optimization purposes.
+For now, it can be safely ignored until it's supported in the kernel.
+


### PR DESCRIPTION
Add two patches to allow Python's package manager to work on Serenity:

- The first one enables zlib module, which is needed for `ensurepip` command;
- The second patch fixes pip downloads, so it's possible to install packages from the PyPI repository.

This may fix #13529

![Screenshot_2022-09-02_04-12-52](https://user-images.githubusercontent.com/2660905/188051601-68ed440b-f366-4659-8e43-f2e8d5f80e1d.png)


