### PR TITLE
Meta: Print error if cmake does not exist

### DIFF
--- a/Meta/CMake/processor-count.cmake
+++ b/Meta/CMake/processor-count.cmake
@@ -1,3 +1,5 @@
 include(ProcessorCount)
 ProcessorCount(N)
-message("${N}")
+# Executing echo here allows us to print to the standard output,
+# to separate the processor count from potential errors
+execute_process(COMMAND "${CMAKE_COMMAND}" -E echo "${N}")

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -260,7 +260,7 @@ build_target() {
     fi
 
     # Get either the environment MAKEJOBS or all processors via CMake
-    [ -z "$MAKEJOBS" ] && MAKEJOBS=$(cmake -P "$SERENITY_SOURCE_DIR/Meta/CMake/processor-count.cmake" 2>&1)
+    [ -z "$MAKEJOBS" ] && MAKEJOBS=$(cmake -P "$SERENITY_SOURCE_DIR/Meta/CMake/processor-count.cmake")
 
     # With zero args, we are doing a standard "build"
     # With multiple args, we are doing an install/image/run


### PR DESCRIPTION
In case CMake wasn't installed or wasn't found (might happen if it was uninstalled or moved or not in the PATH anymore or something else...), `Meta/serenity.sh` would not print anything:
![image](https://user-images.githubusercontent.com/40673815/188103876-8b68ece4-1ace-4f47-8a65-f8c87e84e602.png)
Now, it tells you:
![image](https://user-images.githubusercontent.com/40673815/188103914-d4094d06-5f5b-4c2b-9389-edf42de70e41.png)
