### PR TITLE
 less: Properly stop on eof, and show correct line index 

### DIFF
--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -365,7 +365,7 @@ private:
                     out(m_tty, "{}", m_filename);
                     break;
                 case 'l':
-                    out(m_tty, "{}", m_line);
+                    out(m_tty, "{}", m_line + 1);
                     break;
                 default:
                     out(m_tty, "?");

--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -324,7 +324,7 @@ private:
     void read_enough_for_line(size_t line)
     {
         // This might read a bounded number of extra lines.
-        while (m_lines.size() < line + m_height - 1) {
+        while (m_lines.size() < line + m_height) {
             if (!read_line())
                 break;
         }


### PR DESCRIPTION
Before, when pressing `j` too much, less would just go past the buffer in some cases.
It would also show the same line index in the status line in some lines.
Very odd. Anyway, that's past now, because **I fixed it**.