### PR TITLE
PixelPaint: Extract selection to layer

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -38,6 +38,7 @@ public:
     Layer* active_layer() { return m_active_layer; }
     void set_active_layer(Layer*);
 
+    ErrorOr<void> add_new_layer_from_selection();
     Tool* active_tool() { return m_active_tool; }
     void set_active_tool(Tool*);
     void update_tool_cursor();

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -101,6 +101,9 @@ private:
     RefPtr<GUI::Action> m_show_guides_action;
     RefPtr<GUI::Action> m_show_rulers_action;
     RefPtr<GUI::Action> m_show_active_layer_boundary_action;
+
+    RefPtr<GUI::Action> m_layer_via_copy;
+    RefPtr<GUI::Action> m_layer_via_cut;
 };
 
 }


### PR DESCRIPTION
This adds 2 new menu options in the Layer menu, both allow you to create a new layer based on the active selection. "Layer via Copy" will leave the selected area in the original layer while "Layer via Cut" will remove it from the original layer.