### PR TITLE
Meta: Don't tell to run script as root when that's not the actual error

### DIFF
--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -8,7 +8,19 @@ die() {
 }
 
 if [ "$(id -u)" != 0 ]; then
-    exec sudo -E -- "$0" "$@" || die "this script needs to run as root"
+    set +e
+    ${SUDO} -E -- sh -c "\"$0\" $* || exit 42"
+    case $? in
+        1)
+            die "this script needs to run as root"
+            ;;
+        42)
+            exit 1
+            ;;
+        *)
+            exit 0
+            ;;
+    esac
 else
     : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
 fi

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -8,7 +8,19 @@ die() {
 }
 
 if [ "$(id -u)" != 0 ]; then
-    exec sudo -E -- "$0" "$@" || die "this script needs to run as root"
+    set +e
+    ${SUDO} -E -- sh -c "\"$0\" $* || exit 42"
+    case $? in
+        1)
+            die "this script needs to run as root"
+            ;;
+        42)
+            exit 1
+            ;;
+        *)
+            exit 0
+            ;;
+    esac
 else
     : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
 fi

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -17,7 +17,19 @@ if [ ! -d "limine" ]; then
 fi
 
 if [ "$(id -u)" != 0 ]; then
-    exec sudo -E -- "$0" "$@" || die "this script needs to run as root"
+    set +e
+    ${SUDO} -E -- sh -c "\"$0\" $* || exit 42"
+    case $? in
+        1)
+            die "this script needs to run as root"
+            ;;
+        42)
+            exit 1
+            ;;
+        *)
+            exit 0
+            ;;
+    esac
 else
     : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
 fi

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -31,8 +31,19 @@ if [ "$(id -u)" != 0 ]; then
     if [ -x "$FUSE2FS_PATH" ] && $FUSE2FS_PATH --help 2>&1 |grep fakeroot > /dev/null; then
         USE_FUSE2FS=1
     else
-        ${SUDO} -E -- "$0" "$@" || die "this script needs to run as root"
-        exit 0
+        set +e
+        ${SUDO} -E -- sh -c "\"$0\" $* || exit 42"
+        case $? in
+            1)
+                die "this script needs to run as root"
+                ;;
+            42)
+                exit 1
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
     fi
 else
     : "${SUDO_UID:=0}" "${SUDO_GID:=0}"

--- a/Meta/build-native-partition.sh
+++ b/Meta/build-native-partition.sh
@@ -16,8 +16,19 @@ cleanup() {
 }
 
 if [ "$(id -u)" != 0 ]; then
-    sudo -E -- "$0" "$@" || die "this script needs to run as root"
-    exit 0
+    set +e
+    ${SUDO} -E -- sh -c "\"$0\" $* || exit 42"
+    case $? in
+        1)
+            die "this script needs to run as root"
+            ;;
+        42)
+            exit 1
+            ;;
+        *)
+            exit 0
+            ;;
+    esac
 else
     : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
 fi


### PR DESCRIPTION
Before, and that was the cause of many confusion in #build-problems
on Discord, the Meta/build-image-qemu.sh script would error out with
the message "this script needs to run as root" while the actual error
was unrelated.
![image](https://user-images.githubusercontent.com/40673815/188267406-f4f6e8d8-3741-442b-8759-b716dfe1749b.png)
![image](https://user-images.githubusercontent.com/40673815/188267409-175fa284-49ee-4a32-b088-39e880736820.png)
![image](https://user-images.githubusercontent.com/40673815/188267413-c3f0acfb-e29c-48a0-bf26-d1f1055d76a5.png)
