### PR TITLE
LibWeb: An initial implementation of `backdrop-filter`

### DIFF
--- a/Base/res/html/misc/backdrop-filter.html
+++ b/Base/res/html/misc/backdrop-filter.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Backdrop Filter</title>
+    <style>
+        .image-box {
+          background-image: url(old-computer.png);
+          height: 240px;
+          width: 350px;
+          background-size: cover;
+          border: 2px solid black;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          margin: 5px;
+        }
+
+
+        .backdrop-box {
+          background-color: rgba(255, 255, 255, 0.1);
+          border-radius: 5px;
+          width: 50%;
+          height: 50%;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+        }
+
+        code {
+          text-shadow: 1px 1px 2px black;
+          color: white;
+        }
+
+        body {
+          display: flex;
+          flex-wrap: wrap;
+        }
+
+        .blur {
+          backdrop-filter: blur(5px);
+        }
+
+        .invert {
+          backdrop-filter: invert();
+        }
+
+        .grayscale {
+          backdrop-filter: grayscale();
+        }
+
+        .brightness {
+          backdrop-filter: brightness(200%);
+        }
+
+        .contrast {
+          backdrop-filter: contrast(200%);
+        }
+
+        .sepia {
+          backdrop-filter: sepia();
+        }
+
+        .grayscale-invert-blur {
+          backdrop-filter: grayscale() invert() blur(5px);
+        }
+
+        .mixed {
+          backdrop-filter: grayscale(50%) invert(70%);
+        }
+    </style>
+  </head>
+  <body>
+    <div class="image-box">
+      <div class="backdrop-box grayscale-invert-blur">
+      </div>
+    </div>
+    <div class="image-box">
+      <div class="backdrop-box mixed">
+      </div>
+    </div>
+    <div class="image-box">
+      <div class="backdrop-box blur">
+      </div>
+    </div>
+    <div class="image-box">
+      <div class="backdrop-box invert">
+      </div>
+    </div>
+    <div class="image-box">
+      <div class="backdrop-box grayscale">
+      </div>
+    </div>
+    <div class="image-box">
+      <div class="backdrop-box brightness">
+      </div>
+    </div>
+    <div class="image-box">
+      <div class="backdrop-box contrast">
+      </div>
+    </div>
+    <div class="image-box">
+      <div class="backdrop-box sepia">
+      </div>
+    </div>
+  <script>
+    const boxes = document.querySelectorAll(".backdrop-box");
+    const filterMap = {};
+    for (const rule of document.styleSheets[0].cssRules) {
+      filterMap[rule.selectorText] = rule.style.backdropFilter;
+    }
+
+    updateLabels = () => {
+        boxes.forEach(box => {
+            const filter = box.classList[1];
+            const cssText = filterMap['.'+filter];
+            let el = document.getElementById(filter);
+            let newEl = document.createElement('code');
+            let text = document.createTextNode(box.style.backdropFilter || cssText);
+            newEl.appendChild(text);
+            newEl.id = filter;
+            if (!el)
+                box.appendChild(newEl)
+            else
+                box.replaceChild(newEl, el);
+        })
+    }
+
+    updateLabels();
+  </script>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -107,6 +107,7 @@
             <li><h3>Properties</h3></li>
             <li><a href="gradients.html">Gradients</a></li>
             <li><a href="vertical-align.html">vertical-align</a></li>
+            <li><a href="backdrop-filter.html">backdrop-filter</a></li>
             <li><a href="backgrounds.html">Backgrounds</a></li>
             <li><a href="background-repeat-test.html">Background-repeat</a></li>
             <li><a href="box-shadow.html">Box-shadow</a></li>

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -486,6 +486,11 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
         if (style_value.has_color())
             return true;
 )~~~");
+                        } else if (type_name == "filter-value-list") {
+                            property_generator.append(R"~~~(
+        if (style_value.is_filter_value_list())
+            return true;
+)~~~");
                         } else if (type_name == "frequency") {
                             output_numeric_value_check(property_generator, "is_frequency"sv, "as_frequency().frequency().to_hertz()"sv, Array { "Frequency"sv }, min_value, max_value);
                         } else if (type_name == "image") {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -490,7 +490,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                             output_numeric_value_check(property_generator, "is_frequency"sv, "as_frequency().frequency().to_hertz()"sv, Array { "Frequency"sv }, min_value, max_value);
                         } else if (type_name == "image") {
                             property_generator.append(R"~~~(
-        if (style_value.is_image() || style_value.is_linear_gradient())
+        if (style_value.is_abstract_image())
             return true;
 )~~~");
                         } else if (type_name == "integer") {

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -449,9 +449,9 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::scaled(float sx, float sy) const
     return new_bitmap;
 }
 
-ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::cropped(Gfx::IntRect crop) const
+ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::cropped(Gfx::IntRect crop, Optional<BitmapFormat> new_bitmap_format) const
 {
-    auto new_bitmap = TRY(Gfx::Bitmap::try_create(format(), { crop.width(), crop.height() }, 1));
+    auto new_bitmap = TRY(Gfx::Bitmap::try_create(new_bitmap_format.value_or(format()), { crop.width(), crop.height() }, 1));
 
     for (int y = 0; y < crop.height(); ++y) {
         for (int x = 0; x < crop.width(); ++x) {

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -115,7 +115,7 @@ public:
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> flipped(Gfx::Orientation) const;
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> scaled(int sx, int sy) const;
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> scaled(float sx, float sy) const;
-    ErrorOr<NonnullRefPtr<Gfx::Bitmap>> cropped(Gfx::IntRect) const;
+    ErrorOr<NonnullRefPtr<Gfx::Bitmap>> cropped(Gfx::IntRect, Optional<BitmapFormat> new_bitmap_format = {}) const;
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> to_bitmap_backed_by_anonymous_buffer() const;
     [[nodiscard]] ByteBuffer serialize_to_byte_buffer() const;
 

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -310,6 +310,30 @@ Optional<Color> Color::from_string(StringView string)
     return Color(r.value(), g.value(), b.value(), a.value());
 }
 
+Color Color::mixed_with(Color const& other, float weight) const
+{
+    if (alpha() == other.alpha() || with_alpha(0) == other.with_alpha(0)) {
+        return Gfx::Color {
+            round_to<u8>(mix<float>(red(), other.red(), weight)),
+            round_to<u8>(mix<float>(green(), other.green(), weight)),
+            round_to<u8>(mix<float>(blue(), other.blue(), weight)),
+            round_to<u8>(mix<float>(alpha(), other.alpha(), weight)),
+        };
+    }
+    // Fallback to slower, but more visually pleasing premultiplied alpha mix.
+    // This is needed for linear-gradient()s in LibWeb.
+    auto mixed_alpha = mix<float>(alpha(), other.alpha(), weight);
+    auto premultiplied_mix_channel = [&](float channel, float other_channel, float weight) {
+        return round_to<u8>(mix<float>(channel * (alpha() / 255.0f), other_channel * (other.alpha() / 255.0f), weight) / (mixed_alpha / 255.0f));
+    };
+    return Gfx::Color {
+        premultiplied_mix_channel(red(), other.red(), weight),
+        premultiplied_mix_channel(green(), other.green(), weight),
+        premultiplied_mix_channel(blue(), other.blue(), weight),
+        round_to<u8>(mixed_alpha),
+    };
+}
+
 Vector<Color> Color::shades(u32 steps, float max) const
 {
     float shade = 1.f;

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -235,6 +235,8 @@ public:
 #endif
     }
 
+    Color mixed_with(Color const& other, float weight) const;
+
     Color interpolate(Color const& other, float weight) const noexcept
     {
         u8 r = red() + round_to<u8>(static_cast<float>(other.red() - red()) * weight);

--- a/Userland/Libraries/LibGfx/Filters/BrightnessFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/BrightnessFilter.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+#include <LibGfx/Filters/ColorFilter.h>
+
+namespace Gfx {
+
+class BrightnessFilter : public ColorFilter {
+public:
+    using ColorFilter::ColorFilter;
+    virtual ~BrightnessFilter() = default;
+
+    virtual StringView class_name() const override { return "BrightnessFilter"sv; }
+
+    virtual bool amount_handled_in_filter() const override
+    {
+        return true;
+    }
+
+protected:
+    Color convert_color(Color original) override
+    {
+        auto convert_channel = [&](u8 channel) {
+            return static_cast<u8>(clamp(round_to<int>(channel * m_amount), 0, 255));
+        };
+        return Gfx::Color {
+            convert_channel(original.red()),
+            convert_channel(original.green()),
+            convert_channel(original.blue()),
+            original.alpha()
+        };
+    };
+};
+
+}

--- a/Userland/Libraries/LibGfx/Filters/ColorFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/ColorFilter.h
@@ -12,7 +12,17 @@ namespace Gfx {
 
 class ColorFilter : public Filter {
 public:
+    ColorFilter(float amount = 1.0f)
+        : m_amount(amount)
+    {
+    }
+
     virtual ~ColorFilter() = default;
+
+    virtual bool amount_handled_in_filter() const
+    {
+        return false;
+    }
 
     virtual void apply(Bitmap& target_bitmap, IntRect const& target_rect, Bitmap const& source_bitmap, IntRect const& source_rect) override
     {
@@ -30,15 +40,14 @@ public:
                 auto source_pixel = source_bitmap.get_pixel(source_x, source_y);
                 auto target_color = convert_color(source_pixel);
 
-                target_bitmap.set_pixel(target_x, target_y, target_color);
+                target_bitmap.set_pixel(target_x, target_y, m_amount < 1.0f && !amount_handled_in_filter() ? source_pixel.mixed_with(target_color, m_amount) : target_color);
             }
         }
     }
 
 protected:
-    ColorFilter() = default;
-
     virtual Color convert_color(Color) = 0;
+    float m_amount { 1.0f };
 };
 
 }

--- a/Userland/Libraries/LibGfx/Filters/ContrastFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/ContrastFilter.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+#include <LibGfx/Filters/ColorFilter.h>
+
+namespace Gfx {
+
+class ContrastFilter : public ColorFilter {
+public:
+    using ColorFilter::ColorFilter;
+    virtual ~ContrastFilter() = default;
+
+    virtual StringView class_name() const override { return "ContrastFilter"sv; }
+
+    virtual bool amount_handled_in_filter() const override
+    {
+        return true;
+    }
+
+protected:
+    Color convert_color(Color original) override
+    {
+        auto convert_channel = [&](u8 channel) {
+            return static_cast<u8>(clamp(round_to<int>(channel * m_amount + (-128 * m_amount) + 128), 0, 255));
+        };
+        return Gfx::Color {
+            convert_channel(original.red()),
+            convert_channel(original.green()),
+            convert_channel(original.blue()),
+            original.alpha()
+        };
+    };
+};
+
+}

--- a/Userland/Libraries/LibGfx/Filters/GrayscaleFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/GrayscaleFilter.h
@@ -13,7 +13,7 @@ namespace Gfx {
 
 class GrayscaleFilter : public ColorFilter {
 public:
-    GrayscaleFilter() = default;
+    using ColorFilter::ColorFilter;
     virtual ~GrayscaleFilter() = default;
 
     virtual StringView class_name() const override { return "GrayscaleFilter"sv; }

--- a/Userland/Libraries/LibGfx/Filters/InvertFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/InvertFilter.h
@@ -13,7 +13,7 @@ namespace Gfx {
 
 class InvertFilter : public ColorFilter {
 public:
-    InvertFilter() = default;
+    using ColorFilter::ColorFilter;
     virtual ~InvertFilter() = default;
 
     virtual StringView class_name() const override { return "InvertFilter"sv; }

--- a/Userland/Libraries/LibGfx/Filters/OpacityFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/OpacityFilter.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+#include <LibGfx/Filters/ColorFilter.h>
+
+namespace Gfx {
+
+class OpacityFilter : public ColorFilter {
+public:
+    using ColorFilter::ColorFilter;
+    virtual ~OpacityFilter() = default;
+
+    virtual StringView class_name() const override { return "OpacityFilter"sv; }
+
+    virtual bool amount_handled_in_filter() const override
+    {
+        return true;
+    }
+
+protected:
+    Color convert_color(Color original) override
+    {
+        return original.with_alpha(m_amount * 255);
+    };
+};
+
+}

--- a/Userland/Libraries/LibGfx/Filters/SepiaFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/SepiaFilter.h
@@ -15,19 +15,18 @@ namespace Gfx {
 
 class SepiaFilter : public ColorFilter {
 public:
-    SepiaFilter(float amount = 1.0f)
-        : m_amount(amount)
-    {
-    }
+    using ColorFilter::ColorFilter;
     virtual ~SepiaFilter() = default;
 
     virtual StringView class_name() const override { return "SepiaFilter"sv; }
 
+    virtual bool amount_handled_in_filter() const override
+    {
+        return true;
+    }
+
 protected:
     Color convert_color(Color original) override { return original.sepia(m_amount); };
-
-private:
-    float m_amount;
 };
 
 }

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1799,6 +1799,15 @@ Optional<Color> Painter::get_pixel(IntPoint const& p)
     return Color::from_argb(m_target->scanline(point.y())[point.x()]);
 }
 
+ErrorOr<NonnullRefPtr<Bitmap>> Painter::get_region_bitmap(IntRect const& region, BitmapFormat format, Optional<IntRect&> actual_region)
+{
+    VERIFY(scale() == 1);
+    auto bitmap_region = region.translated(state().translation).intersected(m_target->rect());
+    if (actual_region.has_value())
+        actual_region.value() = bitmap_region.translated(-state().translation);
+    return m_target->cropped(bitmap_region, format);
+}
+
 ALWAYS_INLINE void Painter::set_physical_pixel_with_draw_op(u32& pixel, Color const& color)
 {
     // This always sets a single physical pixel, independent of scale().

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -62,6 +62,7 @@ public:
     void set_pixel(IntPoint const&, Color, bool blend = false);
     void set_pixel(int x, int y, Color color, bool blend = false) { set_pixel({ x, y }, color, blend); }
     Optional<Color> get_pixel(IntPoint const&);
+    ErrorOr<NonnullRefPtr<Bitmap>> get_region_bitmap(IntRect const&, BitmapFormat format, Optional<IntRect&> actual_region = {});
     void draw_line(IntPoint const&, IntPoint const&, Color, int thickness = 1, LineStyle style = LineStyle::Solid, Color alternate_color = Color::Transparent);
     void draw_triangle_wave(IntPoint const&, IntPoint const&, Color color, int amplitude, int thickness = 1);
     void draw_quadratic_bezier_curve(IntPoint const& control_point, IntPoint const&, IntPoint const&, Color, int thickness = 1, LineStyle style = LineStyle::Solid);

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -334,6 +334,7 @@ set(SOURCES
     Painting/CanvasPaintable.cpp
     Painting/CheckBoxPaintable.cpp
     Painting/GradientPainting.cpp
+    Painting/FilterPainting.cpp
     Painting/ImagePaintable.cpp
     Painting/InlinePaintable.cpp
     Painting/LabelablePaintable.cpp

--- a/Userland/Libraries/LibWeb/CSS/BackdropFilter.h
+++ b/Userland/Libraries/LibWeb/CSS/BackdropFilter.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Variant.h>
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+class BackdropFilter {
+public:
+    BackdropFilter() = default;
+    BackdropFilter(FilterValueListStyleValue const& filter_value_list)
+        : m_filter_value_list { filter_value_list } {};
+
+    static inline BackdropFilter make_none()
+    {
+        return BackdropFilter {};
+    }
+
+    bool has_filters() const { return m_filter_value_list; }
+    bool is_none() const { return !has_filters(); }
+
+    Span<FilterFunction const> filters() const
+    {
+        VERIFY(has_filters());
+        return m_filter_value_list->filter_value_list().span();
+    }
+
+private:
+    RefPtr<FilterValueListStyleValue const> m_filter_value_list { nullptr };
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Optional.h>
+#include <LibWeb/CSS/BackdropFilter.h>
 #include <LibWeb/CSS/Clip.h>
 #include <LibWeb/CSS/LengthBox.h>
 #include <LibWeb/CSS/StyleValue.h>
@@ -32,6 +33,7 @@ public:
     static CSS::TextTransform text_transform() { return CSS::TextTransform::None; }
     static CSS::Display display() { return CSS::Display { CSS::Display::Outside::Inline, CSS::Display::Inside::Flow }; }
     static Color color() { return Color::Black; }
+    static CSS::BackdropFilter backdrop_filter() { return BackdropFilter::make_none(); }
     static Color background_color() { return Color::Transparent; }
     static CSS::ListStyleType list_style_type() { return CSS::ListStyleType::Disc; }
     static CSS::Visibility visibility() { return CSS::Visibility::Visible; }
@@ -167,6 +169,7 @@ public:
     CSS::Visibility visibility() const { return m_inherited.visibility; }
     CSS::ImageRendering image_rendering() const { return m_inherited.image_rendering; }
     CSS::JustifyContent justify_content() const { return m_noninherited.justify_content; }
+    CSS::BackdropFilter const& backdrop_filter() const { return m_noninherited.backdrop_filter; }
     Vector<ShadowData> const& box_shadow() const { return m_noninherited.box_shadow; }
     CSS::BoxSizing box_sizing() const { return m_noninherited.box_sizing; }
     CSS::LengthPercentage const& width() const { return m_noninherited.width; }
@@ -267,6 +270,7 @@ protected:
         CSS::LengthBox inset { InitialValues::inset() };
         CSS::LengthBox margin { InitialValues::margin() };
         CSS::LengthBox padding { InitialValues::padding() };
+        CSS::BackdropFilter backdrop_filter { InitialValues::backdrop_filter() };
         BorderData border_left;
         BorderData border_top;
         BorderData border_right;
@@ -347,6 +351,7 @@ public:
     void set_overflow_y(CSS::Overflow value) { m_noninherited.overflow_y = value; }
     void set_list_style_type(CSS::ListStyleType value) { m_inherited.list_style_type = value; }
     void set_display(CSS::Display value) { m_noninherited.display = value; }
+    void set_backdrop_filter(CSS::BackdropFilter backdrop_filter) { m_noninherited.backdrop_filter = move(backdrop_filter); }
     void set_border_bottom_left_radius(CSS::BorderRadiusData value) { m_noninherited.border_bottom_left_radius = value; }
     void set_border_bottom_right_radius(CSS::BorderRadiusData value) { m_noninherited.border_bottom_right_radius = value; }
     void set_border_top_left_radius(CSS::BorderRadiusData value) { m_noninherited.border_top_left_radius = value; }

--- a/Userland/Libraries/LibWeb/CSS/Number.h
+++ b/Userland/Libraries/LibWeb/CSS/Number.h
@@ -76,6 +76,11 @@ public:
         return String::number(m_value);
     }
 
+    bool operator==(Number const& other) const
+    {
+        return m_type == other.m_type && m_value == other.m_value;
+    }
+
 private:
     float m_value { 0 };
     Type m_type;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4406,6 +4406,188 @@ RefPtr<StyleValue> Parser::parse_content_value(Vector<ComponentValue> const& com
     return ContentStyleValue::create(StyleValueList::create(move(content_values), StyleValueList::Separator::Space), move(alt_text));
 }
 
+RefPtr<StyleValue> Parser::parse_filter_value_list_value(Vector<ComponentValue> const& component_values)
+{
+    if (component_values.size() == 1 && component_values.first().is(Token::Type::Ident)) {
+        auto ident = parse_identifier_value(component_values.first());
+        if (ident && ident->to_identifier() == ValueID::None)
+            return ident;
+    }
+
+    TokenStream tokens { component_values };
+
+    // FIXME: <url>s are ignored for now
+    // <filter-value-list> = [ <filter-function> | <url> ]+
+
+    enum class FilterToken {
+        // Color filters:
+        Brightness,
+        Contrast,
+        Grayscale,
+        Invert,
+        Opacity,
+        Saturate,
+        Sepia,
+        // Special filters:
+        Blur,
+        DropShadow,
+        HueRotate
+    };
+
+    auto filter_token_to_operation = [&](auto filter) {
+        VERIFY(to_underlying(filter) < to_underlying(FilterToken::Blur));
+        return static_cast<Filter::Color::Operation>(filter);
+    };
+
+    auto parse_number_percentage = [&](auto& token) -> Optional<NumberPercentage> {
+        if (token.is(Token::Type::Percentage))
+            return NumberPercentage(Percentage(token.token().percentage()));
+        if (token.is(Token::Type::Number))
+            return NumberPercentage(Number(Number::Type::Number, token.token().number_value()));
+        return {};
+    };
+
+    auto parse_filter_function_name = [&](auto name) -> Optional<FilterToken> {
+        if (name.equals_ignoring_case("blur"sv))
+            return FilterToken::Blur;
+        if (name.equals_ignoring_case("brightness"sv))
+            return FilterToken::Brightness;
+        if (name.equals_ignoring_case("contrast"sv))
+            return FilterToken::Contrast;
+        if (name.equals_ignoring_case("drop-shadow"sv))
+            return FilterToken::DropShadow;
+        if (name.equals_ignoring_case("grayscale"sv))
+            return FilterToken::Grayscale;
+        if (name.equals_ignoring_case("hue-rotate"sv))
+            return FilterToken::HueRotate;
+        if (name.equals_ignoring_case("invert"sv))
+            return FilterToken::Invert;
+        if (name.equals_ignoring_case("opacity"sv))
+            return FilterToken::Opacity;
+        if (name.equals_ignoring_case("saturate"sv))
+            return FilterToken::Saturate;
+        if (name.equals_ignoring_case("sepia"sv))
+            return FilterToken::Sepia;
+        return {};
+    };
+
+    auto parse_filter_function = [&](auto filter_token, auto function_values) -> Optional<FilterFunction> {
+        TokenStream tokens { function_values };
+        tokens.skip_whitespace();
+
+        auto if_no_more_tokens_return = [&](auto filter) -> Optional<FilterFunction> {
+            tokens.skip_whitespace();
+            if (tokens.has_next_token())
+                return {};
+            return filter;
+        };
+
+        if (filter_token == FilterToken::Blur) {
+            // blur( <length>? )
+            if (!tokens.has_next_token())
+                return Filter::Blur {};
+            auto blur_radius = parse_length(tokens.next_token());
+            if (!blur_radius.has_value())
+                return {};
+            return if_no_more_tokens_return(Filter::Blur { *blur_radius });
+        } else if (filter_token == FilterToken::DropShadow) {
+            if (!tokens.has_next_token())
+                return {};
+            auto next_token = [&]() -> auto&
+            {
+                auto& token = tokens.next_token();
+                tokens.skip_whitespace();
+                return token;
+            };
+            // drop-shadow( [ <color>? && <length>{2,3} ] )
+            // Note: The following code is a little awkward to allow the color to be before or after the lengths.
+            auto& first_param = next_token();
+            Optional<Length> maybe_radius = {};
+            auto maybe_color = parse_color(first_param);
+            auto x_offset = parse_length(maybe_color.has_value() ? next_token() : first_param);
+            if (!x_offset.has_value() || !tokens.has_next_token()) {
+                return {};
+            }
+            auto y_offset = parse_length(next_token());
+            if (!y_offset.has_value()) {
+                return {};
+            }
+            if (tokens.has_next_token()) {
+                auto& token = next_token();
+                maybe_radius = parse_length(token);
+                if (!maybe_color.has_value() && (!maybe_radius.has_value() || tokens.has_next_token())) {
+                    maybe_color = parse_color(!maybe_radius.has_value() ? token : next_token());
+                    if (!maybe_color.has_value()) {
+                        return {};
+                    }
+                } else if (!maybe_radius.has_value()) {
+                    return {};
+                }
+            }
+            return if_no_more_tokens_return(Filter::DropShadow { *x_offset, *y_offset, maybe_radius, maybe_color });
+        } else if (filter_token == FilterToken::HueRotate) {
+            // hue-rotate( [ <angle> | <zero> ]? )
+            if (!tokens.has_next_token())
+                return Filter::HueRotate {};
+            auto& token = tokens.next_token();
+            if (token.is(Token::Type::Number)) {
+                // hue-rotate(0)
+                auto number = token.token().number();
+                if (number.is_integer() && number.integer_value() == 0)
+                    return if_no_more_tokens_return(Filter::HueRotate { Filter::HueRotate::Zero {} });
+                return {};
+            }
+            if (!token.is(Token::Type::Dimension))
+                return {};
+            float angle_value = token.token().dimension_value();
+            auto angle_unit_name = token.token().dimension_unit();
+            auto angle_unit = Angle::unit_from_name(angle_unit_name);
+            if (!angle_unit.has_value())
+                return {};
+            Angle angle { angle_value, angle_unit.release_value() };
+            return if_no_more_tokens_return(Filter::HueRotate { angle });
+        } else {
+            // Simple filters:
+            // brightness( <number-percentage>? )
+            // contrast( <number-percentage>? )
+            // grayscale( <number-percentage>? )
+            // invert( <number-percentage>? )
+            // opacity( <number-percentage>? )
+            // sepia( <number-percentage>? )
+            // saturate( <number-percentage>? )
+            if (!tokens.has_next_token())
+                return Filter::Color { filter_token_to_operation(filter_token) };
+            auto amount = parse_number_percentage(tokens.next_token());
+            if (!amount.has_value())
+                return {};
+            return if_no_more_tokens_return(Filter::Color { filter_token_to_operation(filter_token), *amount });
+        }
+    };
+
+    Vector<FilterFunction> filter_value_list {};
+
+    while (tokens.has_next_token()) {
+        tokens.skip_whitespace();
+        if (!tokens.has_next_token())
+            break;
+        auto& token = tokens.next_token();
+        if (!token.is_function())
+            return {};
+        auto filter_token = parse_filter_function_name(token.function().name());
+        if (!filter_token.has_value())
+            return {};
+        auto filter_function = parse_filter_function(*filter_token, token.function().values());
+        if (!filter_function.has_value())
+            return {};
+        filter_value_list.append(*filter_function);
+    }
+
+    if (filter_value_list.is_empty())
+        return {};
+
+    return FilterValueListStyleValue::create(move(filter_value_list));
+}
+
 RefPtr<StyleValue> Parser::parse_flex_value(Vector<ComponentValue> const& component_values)
 {
     if (component_values.size() == 1) {
@@ -5471,6 +5653,10 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
 
     // Special-case property handling
     switch (property_id) {
+    case PropertyID::BackdropFilter:
+        if (auto parsed_value = parse_filter_value_list_value(component_values))
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
     case PropertyID::Background:
         if (auto parsed_value = parse_background_value(component_values))
             return parsed_value.release_nonnull();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -339,6 +339,7 @@ private:
     RefPtr<StyleValue> parse_comma_separated_value_list(Vector<ComponentValue> const&, ParseFunction);
     RefPtr<StyleValue> parse_simple_comma_separated_value_list(Vector<ComponentValue> const&);
 
+    RefPtr<StyleValue> parse_filter_value_list_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_background_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_single_background_position_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_single_background_repeat_value(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Percentage.h
+++ b/Userland/Libraries/LibWeb/CSS/Percentage.h
@@ -11,6 +11,7 @@
 #include <LibWeb/CSS/Angle.h>
 #include <LibWeb/CSS/Frequency.h>
 #include <LibWeb/CSS/Length.h>
+#include <LibWeb/CSS/Number.h>
 #include <LibWeb/CSS/Time.h>
 
 namespace Web::CSS {
@@ -198,6 +199,14 @@ public:
     bool is_time() const { return is_t(); }
     Time const& time() const { return get_t(); }
     virtual Time resolve_calculated(NonnullRefPtr<CalculatedStyleValue> const&, Layout::Node const&, Time const& reference_value) const override;
+};
+
+struct NumberPercentage : public PercentageOr<Number> {
+public:
+    using PercentageOr<Number>::PercentageOr;
+
+    bool is_number() const { return is_t(); }
+    Number const& number() const { return get_t(); }
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -20,6 +20,17 @@
       "appearance"
     ]
   },
+  "backdrop-filter": {
+    "affects-layout": false,
+    "inherited": false,
+    "initial": "none",
+    "valid-types": [
+      "filter-value-list"
+    ],
+    "valid-identifiers": [
+      "none"
+    ]
+  },
   "background": {
     "affects-layout": false,
     "inherited": false,

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -355,6 +355,14 @@ Optional<CSS::Appearance> StyleProperties::appearance() const
     return appearance;
 }
 
+CSS::BackdropFilter StyleProperties::backdrop_filter() const
+{
+    auto value = property(CSS::PropertyID::BackdropFilter);
+    if (value->is_filter_value_list())
+        return BackdropFilter(value->as_filter_value_list());
+    return BackdropFilter::make_none();
+}
+
 Optional<CSS::Position> StyleProperties::position() const
 {
     auto value = property(CSS::PropertyID::Position);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -70,6 +70,7 @@ public:
     Optional<CSS::AlignItems> align_items() const;
     Optional<CSS::AlignSelf> align_self() const;
     Optional<CSS::Appearance> appearance() const;
+    CSS::BackdropFilter backdrop_filter() const;
     float opacity() const;
     Optional<CSS::Visibility> visibility() const;
     Optional<CSS::ImageRendering> image_rendering() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1591,7 +1591,7 @@ String LinearGradientStyleValue::to_string() const
     return builder.to_string();
 }
 
-static bool operator==(LinearGradientStyleValue::GradientDirection a, LinearGradientStyleValue::GradientDirection b)
+static bool operator==(LinearGradientStyleValue::GradientDirection const& a, LinearGradientStyleValue::GradientDirection const& b)
 {
     if (a.has<SideOrCorner>() && b.has<SideOrCorner>())
         return a.get<SideOrCorner>() == b.get<SideOrCorner>();
@@ -1600,22 +1600,22 @@ static bool operator==(LinearGradientStyleValue::GradientDirection a, LinearGrad
     return false;
 }
 
-static bool operator==(GradientColorHint a, GradientColorHint b)
+static bool operator==(GradientColorHint const& a, GradientColorHint const& b)
 {
     return a.value == b.value;
 }
 
-static bool operator==(GradientColorStop a, GradientColorStop b)
+static bool operator==(GradientColorStop const& a, GradientColorStop const& b)
 {
     return a.color == b.color && a.position == b.position && a.second_position == b.second_position;
 }
 
-static bool operator==(ColorStopListElement a, ColorStopListElement b)
+static bool operator==(ColorStopListElement const& a, ColorStopListElement const& b)
 {
     return a.transition_hint == b.transition_hint && a.color_stop == b.color_stop;
 }
 
-static bool operator==(EdgeRect a, EdgeRect b)
+static bool operator==(EdgeRect const& a, EdgeRect const& b)
 {
     return a.top_edge == b.top_edge && a.right_edge == b.right_edge && a.bottom_edge == b.bottom_edge && a.left_edge == b.left_edge;
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -97,6 +97,52 @@ struct EdgeRect {
     Gfx::FloatRect resolved(Layout::Node const&, Gfx::FloatRect) const;
 };
 
+namespace Filter {
+
+struct Blur {
+    Optional<Length> radius {};
+    float resolved_radius(Layout::Node const&) const;
+};
+
+struct DropShadow {
+    Length offset_x;
+    Length offset_y;
+    Optional<Length> radius {};
+    Optional<Color> color {};
+    struct Resolved {
+        float offset_x;
+        float offset_y;
+        float radius;
+        Color color;
+    };
+    Resolved resolved(Layout::Node const&) const;
+};
+
+struct HueRotate {
+    struct Zero { };
+    using AngleOrZero = Variant<Angle, Zero>;
+    Optional<AngleOrZero> angle {};
+    float angle_degrees() const;
+};
+
+struct Color {
+    enum class Operation {
+        Brightness,
+        Contrast,
+        Grayscale,
+        Invert,
+        Opacity,
+        Saturate,
+        Sepia
+    } operation;
+    Optional<NumberPercentage> amount {};
+    float resolved_amount() const;
+};
+
+};
+
+using FilterFunction = Variant<Filter::Blur, Filter::DropShadow, Filter::HueRotate, Filter::Color>;
+
 // FIXME: Find a better place for this helper.
 inline Gfx::Painter::ScalingMode to_gfx_scaling_mode(CSS::ImageRendering css_value)
 {
@@ -128,6 +174,7 @@ public:
         Calculated,
         Color,
         Content,
+        FilterValueList,
         Flex,
         FlexFlow,
         Font,
@@ -172,6 +219,7 @@ public:
     bool is_calculated() const { return type() == Type::Calculated; }
     bool is_color() const { return type() == Type::Color; }
     bool is_content() const { return type() == Type::Content; }
+    bool is_filter_value_list() const { return type() == Type::FilterValueList; }
     bool is_flex() const { return type() == Type::Flex; }
     bool is_flex_flow() const { return type() == Type::FlexFlow; }
     bool is_font() const { return type() == Type::Font; }
@@ -214,6 +262,7 @@ public:
     CalculatedStyleValue const& as_calculated() const;
     ColorStyleValue const& as_color() const;
     ContentStyleValue const& as_content() const;
+    FilterValueListStyleValue const& as_filter_value_list() const;
     FlexFlowStyleValue const& as_flex_flow() const;
     FlexStyleValue const& as_flex() const;
     FontStyleValue const& as_font() const;
@@ -254,6 +303,7 @@ public:
     CalculatedStyleValue& as_calculated() { return const_cast<CalculatedStyleValue&>(const_cast<StyleValue const&>(*this).as_calculated()); }
     ColorStyleValue& as_color() { return const_cast<ColorStyleValue&>(const_cast<StyleValue const&>(*this).as_color()); }
     ContentStyleValue& as_content() { return const_cast<ContentStyleValue&>(const_cast<StyleValue const&>(*this).as_content()); }
+    FilterValueListStyleValue& as_filter_value_list() { return const_cast<FilterValueListStyleValue&>(const_cast<StyleValue const&>(*this).as_filter_value_list()); }
     FlexFlowStyleValue& as_flex_flow() { return const_cast<FlexFlowStyleValue&>(const_cast<StyleValue const&>(*this).as_flex_flow()); }
     FlexStyleValue& as_flex() { return const_cast<FlexStyleValue&>(const_cast<StyleValue const&>(*this).as_flex()); }
     FontStyleValue& as_font() { return const_cast<FontStyleValue&>(const_cast<StyleValue const&>(*this).as_font()); }
@@ -792,6 +842,33 @@ private:
 
     NonnullRefPtr<StyleValueList> m_content;
     RefPtr<StyleValueList> m_alt_text;
+};
+
+class FilterValueListStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<FilterValueListStyleValue> create(
+        Vector<FilterFunction> filter_value_list)
+    {
+        VERIFY(filter_value_list.size() >= 1);
+        return adopt_ref(*new FilterValueListStyleValue(move(filter_value_list)));
+    }
+
+    Vector<FilterFunction> const& filter_value_list() const { return m_filter_value_list; }
+
+    virtual String to_string() const override;
+    virtual bool equals(StyleValue const& other) const override;
+
+    virtual ~FilterValueListStyleValue() override = default;
+
+private:
+    FilterValueListStyleValue(Vector<FilterFunction> filter_value_list)
+        : StyleValue(Type::FilterValueList)
+        , m_filter_value_list(move(filter_value_list))
+    {
+    }
+
+    // FIXME: No support for SVG filters yet
+    Vector<FilterFunction> m_filter_value_list;
 };
 
 class FlexStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -50,6 +50,7 @@ class CSSStyleSheet;
 class CSSSupportsRule;
 class Display;
 class ElementInlineCSSStyleDeclaration;
+class FilterValueListStyleValue;
 class FlexFlowStyleValue;
 class FlexStyleValue;
 class FontFace;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -384,6 +384,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     computed_values.set_flex_shrink(computed_style.flex_shrink());
     computed_values.set_order(computed_style.order());
     computed_values.set_clip(computed_style.clip());
+    computed_values.set_backdrop_filter(computed_style.backdrop_filter());
 
     auto justify_content = computed_style.justify_content();
     if (justify_content.has_value())

--- a/Userland/Libraries/LibWeb/Painting/FilterPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/FilterPainting.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Filters/BrightnessFilter.h>
+#include <LibGfx/Filters/ContrastFilter.h>
+#include <LibGfx/Filters/GrayscaleFilter.h>
+#include <LibGfx/Filters/InvertFilter.h>
+#include <LibGfx/Filters/OpacityFilter.h>
+#include <LibGfx/Filters/SepiaFilter.h>
+#include <LibGfx/Filters/StackBlurFilter.h>
+#include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BorderRadiusCornerClipper.h>
+#include <LibWeb/Painting/FilterPainting.h>
+
+namespace Web::Painting {
+
+void apply_filter_list(Gfx::Bitmap& target_bitmap, Layout::Node const& node, Span<CSS::FilterFunction const> filter_list)
+{
+    for (auto& filter_function : filter_list) {
+        // See: https://drafts.fxtf.org/filter-effects-1/#supported-filter-functions
+        filter_function.visit(
+            [&](CSS::Filter::Blur const& blur) {
+                // Applies a Gaussian blur to the input image.
+                // The passed parameter defines the value of the standard deviation to the Gaussian function.
+                Gfx::StackBlurFilter filter { target_bitmap };
+                filter.process_rgba(blur.resolved_radius(node), Color::Transparent);
+            },
+            [&](CSS::Filter::Color const& color) {
+                auto amount = color.resolved_amount();
+                auto amount_clamped = clamp(amount, 0.0f, 1.0f);
+                auto apply_color_filter = [&](Gfx::ColorFilter const& filter) {
+                    const_cast<Gfx::ColorFilter&>(filter).apply(target_bitmap, target_bitmap.rect(), target_bitmap, target_bitmap.rect());
+                };
+                switch (color.operation) {
+                case CSS::Filter::Color::Operation::Grayscale: {
+                    // Converts the input image to grayscale. The passed parameter defines the proportion of the conversion.
+                    // A value of 100% is completely grayscale. A value of 0% leaves the input unchanged.
+                    apply_color_filter(Gfx::GrayscaleFilter { amount_clamped });
+                    break;
+                }
+                case CSS::Filter::Color::Operation::Brightness: {
+                    // Applies a linear multiplier to input image, making it appear more or less bright.
+                    // A value of 0% will create an image that is completely black. A value of 100% leaves the input unchanged.
+                    // Values of amount over 100% are allowed, providing brighter results.
+                    apply_color_filter(Gfx::BrightnessFilter { amount });
+                    break;
+                }
+                case CSS::Filter::Color::Operation::Contrast: {
+                    // Adjusts the contrast of the input. A value of 0% will create an image that is completely gray.
+                    // A value of 100% leaves the input unchanged. Values of amount over 100% are allowed, providing results with more contrast.
+                    apply_color_filter(Gfx::ContrastFilter { amount });
+                    break;
+                }
+                case CSS::Filter::Color::Operation::Invert: {
+                    // Inverts the samples in the input image. The passed parameter defines the proportion of the conversion.
+                    // A value of 100% is completely inverted. A value of 0% leaves the input unchanged.
+                    apply_color_filter(Gfx::InvertFilter { amount_clamped });
+                    break;
+                }
+                case CSS::Filter::Color::Operation::Opacity: {
+                    // Applies transparency to the samples in the input image. The passed parameter defines the proportion of the conversion.
+                    // A value of 0% is completely transparent. A value of 100% leaves the input unchanged.
+                    apply_color_filter(Gfx::OpacityFilter { amount_clamped });
+                    break;
+                }
+                case CSS::Filter::Color::Operation::Sepia: {
+                    // Converts the input image to sepia. The passed parameter defines the proportion of the conversion.
+                    // A value of 100% is completely sepia. A value of 0% leaves the input unchanged.
+                    apply_color_filter(Gfx::SepiaFilter { amount_clamped });
+                    break;
+                }
+                case CSS::Filter::Color::Operation::Saturate: {
+                    dbgln("TODO: Implement saturate() filter function!");
+                    break;
+                }
+                default:
+                    break;
+                }
+            },
+            [&](CSS::Filter::HueRotate const&) {
+                dbgln("TODO: Implement hue-rotate() filter function!");
+            },
+            [&](CSS::Filter::DropShadow const&) {
+                dbgln("TODO: Implement drop-shadow() filter function!");
+            });
+    }
+}
+
+void apply_backdrop_filter(PaintContext& context, Layout::Node const& node, Gfx::FloatRect const& backdrop_rect, BorderRadiiData const& border_radii_data, CSS::BackdropFilter const& backdrop_filter)
+{
+    // This performs the backdrop filter operation: https://drafts.fxtf.org/filter-effects-2/#backdrop-filter-operation
+
+    auto backdrop_region = backdrop_rect.to_rounded<int>();
+
+    // Note: The region bitmap can be smaller than the backdrop_region if it's at the edge of canvas.
+    Gfx::IntRect actual_region {};
+
+    // FIXME: Go through the steps to find the "Backdrop Root Image"
+    // https://drafts.fxtf.org/filter-effects-2/#BackdropRoot
+
+    // 1. Copy the Backdrop Root Image into a temporary buffer, such as a raster image. Call this buffer T’.
+    auto maybe_backdrop_bitmap = context.painter().get_region_bitmap(backdrop_region, Gfx::BitmapFormat::BGRA8888, actual_region);
+    if (actual_region.is_empty())
+        return;
+    if (maybe_backdrop_bitmap.is_error()) {
+        dbgln("Failed get region bitmap for backdrop-filter");
+        return;
+    }
+    auto backdrop_bitmap = maybe_backdrop_bitmap.release_value();
+    // 2. Apply the backdrop-filter’s filter operations to the entire contents of T'.
+    apply_filter_list(*backdrop_bitmap, node, backdrop_filter.filters());
+
+    // FIXME: 3. If element B has any transforms (between B and the Backdrop Root), apply the inverse of those transforms to the contents of T’.
+
+    // 4. Apply a clip to the contents of T’, using the border box of element B, including border-radius if specified. Note that the children of B are not considered for the sizing or location of this clip.
+    ScopedCornerRadiusClip corner_clipper { context.painter(), backdrop_region, border_radii_data };
+
+    // FIXME: 5. Draw all of element B, including its background, border, and any children elements, into T’.
+
+    // FXIME: 6. If element B has any transforms, effects, or clips, apply those to T’.
+
+    // 7. Composite the contents of T’ into element B’s parent, using source-over compositing.
+    context.painter().blit(actual_region.location(), *backdrop_bitmap, backdrop_bitmap->rect());
+}
+
+}

--- a/Userland/Libraries/LibWeb/Painting/FilterPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/FilterPainting.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Forward.h>
+#include <LibWeb/CSS/BackdropFilter.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::Painting {
+
+void apply_filter_list(Gfx::Bitmap& target_bitmap, Layout::Node const& node, Span<CSS::FilterFunction const> filter_list);
+
+void apply_backdrop_filter(PaintContext&, Layout::Node const&, Gfx::FloatRect const&, BorderRadiiData const&, CSS::BackdropFilter const&);
+
+}

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/InitialContainingBlock.h>
 #include <LibWeb/Painting/BackgroundPainting.h>
+#include <LibWeb/Painting/FilterPainting.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/ShadowPainting.h>
 #include <LibWeb/Painting/StackingContext.h>
@@ -122,6 +123,7 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
             auto border_box = absolute_border_box_rect();
             context.painter().add_clip_rect(clip_rect.to_rect().resolved(Paintable::layout_node(), border_box).to_rounded<int>());
         }
+        paint_backdrop_filter(context);
         paint_background(context);
         paint_box_shadow(context);
     }
@@ -191,6 +193,13 @@ void PaintableBox::paint_border(PaintContext& context) const
         .left = computed_values().border_left(),
     };
     paint_all_borders(context, absolute_border_box_rect(), normalized_border_radii_data(), borders_data);
+}
+
+void PaintableBox::paint_backdrop_filter(PaintContext& context) const
+{
+    auto& backdrop_filter = computed_values().backdrop_filter();
+    if (!backdrop_filter.is_none())
+        Painting::apply_backdrop_filter(context, layout_node(), absolute_border_box_rect(), normalized_border_radii_data(), backdrop_filter);
 }
 
 void PaintableBox::paint_background(PaintContext& context) const

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -118,6 +118,7 @@ protected:
     explicit PaintableBox(Layout::Box const&);
 
     virtual void paint_border(PaintContext&) const;
+    virtual void paint_backdrop_filter(PaintContext&) const;
     virtual void paint_background(PaintContext&) const;
     virtual void paint_box_shadow(PaintContext&) const;
 


### PR DESCRIPTION

This is an initial implementation of the `backdrop-filter` CSS property, there's still a few missing bits and a bunch of new `FIXME`s, but it seems to work fairly well. See commits or the pretty pictures below:



**LibWeb:**
![image](https://user-images.githubusercontent.com/11597044/188284264-576d68a5-fae8-4300-bc87-153a189ae388.png)

**Firefox:**
![image](https://user-images.githubusercontent.com/11597044/188284294-cc17777b-24ea-49ee-b731-d6df16408ef3.png)

---

Performance with a `backdrop-filter` also seems okay for the most part. In the clip below I'm randomly scrolling up/down on a page with a `grayscale() invert() blur(2px)` filter on the header, and it does not feel that slow. In profiling it seems that about 10% of the time is spend doing the filtering (which I don't think is _that_ bad).

[screen-capture - 2022-09-03T155155.178.webm](https://user-images.githubusercontent.com/11597044/188284577-61128a68-f841-49c2-a9e5-2c5b23667c35.webm)

---

_Apologies for the girth of this PR_