### PR TITLE
Utilities/lsusb: Fix uninitialized variable error

### DIFF
--- a/Userland/Utilities/lsusb.cpp
+++ b/Userland/Utilities/lsusb.cpp
@@ -21,7 +21,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    bool print_verbose;
+    bool print_verbose = false;
     bool flag_show_numerical = false;
     Core::ArgsParser args;
     args.set_general_help("List USB devices.");


### PR DESCRIPTION
The variable `print_verbose` (which prints verbose information about the
USB devices connected to the system) was uninitialized in `lsusb`. This
was causing the verbose information to be printed if `-v` was NOT seen
on the command line.