### PR TITLE
Meta: serenity.sh typo

### DIFF
--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -259,7 +259,7 @@ build_target() {
         cmake -S "$SERENITY_SOURCE_DIR/Meta/Lagom" -B "$BUILD_DIR" -DBUILD_LAGOM=ON
     fi
 
-    # Get either the environement MAKEJOBS or all processors via CMake
+    # Get either the environment MAKEJOBS or all processors via CMake
     [ -z "$MAKEJOBS" ] && MAKEJOBS=$(cmake -P "$SERENITY_SOURCE_DIR/Meta/CMake/processor-count.cmake" 2>&1)
 
     # With zero args, we are doing a standard "build"


### PR DESCRIPTION
Remove unneeded “e” in “environement”.