### PR TITLE
AK: Reintroduce AtomicWeakable and friends

### DIFF
--- a/AK/AtomicWeakable.h
+++ b/AK/AtomicWeakable.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/Atomic.h>
+#include <AK/AtomicRefCounted.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <AK/StdLibExtras.h>
+#include <sched.h>
+
+namespace AK {
+
+template<typename T>
+class AtomicWeakable;
+template<typename T, typename WeakLinkType>
+class WeakPtr;
+
+class AtomicWeakLink : public AtomicRefCounted<AtomicWeakLink> {
+    template<typename T>
+    friend class AtomicWeakable;
+    template<typename T, typename WeakLinkType>
+    friend class WeakPtr;
+
+public:
+    template<typename T>
+    RefPtr<T> strong_ref() const
+        requires(IsBaseOf<RefCountedBase, T>)
+    {
+        RefPtr<T> ref;
+
+        {
+            if ((m_consumers.fetch_add(1u << 1, AK::MemoryOrder::memory_order_acquire) & 1u) == 0) {
+                T* ptr = (T*)m_ptr.load(AK::MemoryOrder::memory_order_acquire);
+                if (ptr && ptr->try_ref())
+                    ref = adopt_ref(*ptr);
+            }
+            m_consumers.fetch_sub(1u << 1, AK::MemoryOrder::memory_order_release);
+        }
+
+        return ref;
+    }
+
+    template<typename T>
+    T* unsafe_ptr() const
+    {
+        if (m_consumers.load(AK::MemoryOrder::memory_order_relaxed) & 1u)
+            return nullptr;
+        // NOTE: This may return a non-null pointer even if revocation
+        // has been triggered as there is a possible race! But it's "unsafe"
+        // anyway because we return a raw pointer without ensuring a
+        // reference...
+        return (T*)m_ptr.load(AK::MemoryOrder::memory_order_acquire);
+    }
+
+    bool is_null() const
+    {
+        return unsafe_ptr<void>() == nullptr;
+    }
+
+    void revoke()
+    {
+        auto current_consumers = m_consumers.fetch_or(1u, AK::MemoryOrder::memory_order_relaxed);
+        VERIFY((current_consumers & 1u) == 0);
+        // We flagged revocation, now wait until everyone trying to obtain
+        // a strong reference is done
+        while (current_consumers > 0) {
+            sched_yield();
+            current_consumers = m_consumers.load(AK::MemoryOrder::memory_order_acquire) & ~1u;
+        }
+        // No one is trying to use it (anymore)
+        m_ptr.store(nullptr, AK::MemoryOrder::memory_order_release);
+    }
+
+private:
+    template<typename T>
+    explicit AtomicWeakLink(T& weakable)
+        : m_ptr(&weakable)
+    {
+    }
+    mutable Atomic<void*> m_ptr;
+    mutable Atomic<unsigned> m_consumers; // LSB indicates revocation in progress
+};
+
+template<typename T>
+class AtomicWeakable {
+private:
+    class Link;
+
+public:
+    template<typename U = T>
+    WeakPtr<U, AtomicWeakLink> make_weak_ptr() const
+    {
+        return MUST(try_make_weak_ptr<U>());
+    }
+
+    template<typename U = T>
+    ErrorOr<WeakPtr<U, AtomicWeakLink>> try_make_weak_ptr() const;
+
+protected:
+    AtomicWeakable() = default;
+
+    ~AtomicWeakable()
+    {
+        revoke_weak_ptrs();
+    }
+
+    void revoke_weak_ptrs()
+    {
+        if (auto link = move(m_link))
+            link->revoke();
+    }
+
+private:
+    mutable RefPtr<AtomicWeakLink> m_link;
+};
+
+}
+
+using AK::AtomicWeakable;

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -135,7 +135,9 @@ class RefPtr;
 template<typename T>
 class OwnPtr;
 
-template<typename T>
+class WeakLink;
+
+template<typename T, typename WeakLinkType = WeakLink>
 class WeakPtr;
 
 template<typename T, size_t inline_capacity = 0>

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -17,7 +17,7 @@
 
 namespace AK {
 
-template<typename T>
+template<typename T, typename WeakLinkType>
 class WeakPtr;
 
 template<typename T>

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -41,7 +41,7 @@ class [[nodiscard]] NonnullRefPtr {
     friend class RefPtr;
     template<typename U>
     friend class NonnullRefPtr;
-    template<typename U>
+    template<typename U, typename WeakLinkType>
     friend class WeakPtr;
 
 public:

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -26,7 +26,7 @@ template<typename T>
 class [[nodiscard]] RefPtr {
     template<typename U>
     friend class RefPtr;
-    template<typename U>
+    template<typename U, typename WeakLinkType>
     friend class WeakPtr;
     template<typename U>
     friend class NonnullRefPtr;

--- a/AK/Weakable.h
+++ b/AK/Weakable.h
@@ -15,13 +15,13 @@ namespace AK {
 
 template<typename T>
 class Weakable;
-template<typename T>
+template<typename T, typename WeakLinkType>
 class WeakPtr;
 
 class WeakLink : public RefCounted<WeakLink> {
     template<typename T>
     friend class Weakable;
-    template<typename T>
+    template<typename T, typename WeakLinkType>
     friend class WeakPtr;
 
 public:

--- a/Userland/Libraries/LibWeb/TreeNode.h
+++ b/Userland/Libraries/LibWeb/TreeNode.h
@@ -27,6 +27,18 @@ public:
         ++m_ref_count;
     }
 
+    bool try_ref()
+    {
+        if (m_in_removed_last_ref)
+            return false;
+        if constexpr (!IsBaseOf<DOM::Node, T>) {
+            if (m_ref_count == 0)
+                return false;
+        }
+        ++m_ref_count;
+        return true;
+    }
+
     void unref()
     {
         VERIFY(!m_in_removed_last_ref);


### PR DESCRIPTION
This is rather useful, so let's bring it back. WeakPtr can now take an additional template parameter for the weak link type.