### PR TITLE
LibGUI: CommandPalette: Fix key event capture for actions

### DIFF
--- a/Userland/Libraries/LibGUI/CommandPalette.cpp
+++ b/Userland/Libraries/LibGUI/CommandPalette.cpp
@@ -223,8 +223,8 @@ CommandPalette::CommandPalette(GUI::Window& parent_window, ScreenPosition screen
 
     m_text_box->set_focus(true);
 
-    on_active_window_change = [this](bool is_active_window) {
-        if (!is_active_window)
+    on_active_input_change = [this](bool is_active_input) {
+        if (!is_active_input)
             close();
     };
 }

--- a/Userland/Libraries/LibGUI/ConnectionToWindowServer.cpp
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowServer.cpp
@@ -164,7 +164,7 @@ static Action* action_for_shortcut(Window& window, Shortcut const& shortcut)
     }
 
     // NOTE: Application-global shortcuts are ignored while a blocking modal window is up.
-    if (!window.is_blocking()) {
+    if (!window.is_blocking() && !window.is_capturing_input()) {
         if (auto* action = Application::the()->action_for_shortcut(shortcut)) {
             dbgln_if(KEYBOARD_SHORTCUTS_DEBUG, "  > Asked application, got action: {} {} (enabled: {}, shortcut: {}, alt-shortcut: {})", action, action->text(), action->is_enabled(), action->shortcut().to_string(), action->alternate_shortcut().to_string());
             return action;
@@ -214,7 +214,7 @@ void ConnectionToWindowServer::key_down(i32 window_id, u32 code_point, u32 key, 
     // FIXME: This shortcut should be configurable.
     if (accepts_command_palette && !m_in_command_palette && modifiers == (Mod_Ctrl | Mod_Shift) && key == Key_A) {
         auto command_palette = CommandPalette::construct(*window);
-        command_palette->set_window_mode(GUI::WindowMode::Passive);
+        command_palette->set_window_mode(GUI::WindowMode::CaptureInput);
         TemporaryChange change { m_in_command_palette, true };
         if (command_palette->exec() != GUI::Dialog::ExecResult::OK)
             return;

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -36,6 +36,7 @@ public:
 
     bool is_modal() const { return m_window_mode != WindowMode::Modeless; }
     bool is_blocking() const { return m_window_mode == WindowMode::Blocking; }
+    bool is_capturing_input() const { return m_window_mode == WindowMode::CaptureInput; }
 
     bool is_fullscreen() const { return m_fullscreen; }
     void set_fullscreen(bool);


### PR DESCRIPTION
I encountered the issue when messing around in PixelPaint bringing up the CommandPalette and searching for the Crop To Content feature. The `c` presses were redirected to the main window instead of the CommandPalette. I tried a few different options:

- Making the CommandPalette `Blocking`: This works but it breaks the unfocus to close feature of the CommandPalette
- Making the CommandPalette `CaptureInput`: This does not work, but I am unsure why

I am not sure if this fix is at the right place or if there is an underlying issue with a Dialog set to `WindowMode::CaptureInput` :^).