### PR TITLE
WebServer: Make bound socket a clickable hyperlink

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -831,13 +831,22 @@ void TerminalWidget::mousemove_event(GUI::MouseEvent& event)
 
             auto handlers = Desktop::Launcher::get_handlers_for_url(attribute.href);
             if (!handlers.is_empty()) {
-                auto path = URL(attribute.href).path();
-                auto name = LexicalPath::basename(path);
-                if (path == handlers[0]) {
-                    set_tooltip(String::formatted("Execute {}", name));
+                auto url = URL(attribute.href);
+                auto path = url.path();
+
+                auto app_file = Desktop::AppFile::get_for_app(LexicalPath::basename(handlers[0]));
+                auto app_name = app_file->is_valid() ? app_file->name() : LexicalPath::basename(handlers[0]);
+
+                if (url.scheme() == "file") {
+                    auto file_name = LexicalPath::basename(path);
+
+                    if (path == handlers[0]) {
+                        set_tooltip(String::formatted("Execute {}", app_name));
+                    } else {
+                        set_tooltip(String::formatted("Open {} with {}", file_name, app_name));
+                    }
                 } else {
-                    auto af = Desktop::AppFile::get_for_app(LexicalPath::basename(handlers[0]));
-                    set_tooltip(String::formatted("Open {} with {}", name, af->is_valid() ? af->name() : LexicalPath::basename(handlers[0])));
+                    set_tooltip(String::formatted("Open {} with {}", attribute.href, app_name));
                 }
             }
         } else {

--- a/Userland/Services/WebServer/main.cpp
+++ b/Userland/Services/WebServer/main.cpp
@@ -92,7 +92,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(server->listen(ipv4_address.value(), port));
 
-    outln("Listening on {}:{}", ipv4_address.value(), port);
+    out("Listening on ");
+    out("\033]8;;http://{}:{}\033\\", ipv4_address.value(), port);
+    out("{}:{}", ipv4_address.value(), port);
+    outln("\033]8;;\033\\");
 
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/res/icons", "r"));


### PR DESCRIPTION
This pull request makes it as easy as double clicking to get from WebServer to Browser showing the served directory.

![image](https://user-images.githubusercontent.com/42888162/188332261-ee7e90a2-f7b2-4b4b-b1c2-a898bfddad85.png)
