### PR TITLE
Documentation: Amend comment describing use of "virtual" and "final"

### DIFF
--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -579,7 +579,7 @@ public:
 
 class Student : public Person {
 public:
-    virtual String description() final { ... }; // This is correct because it contains both the "override" and "final" keywords to indicate that the method is overridden and that no subclasses of "Student" can override "description".
+    virtual String description() final { ... }; // This is correct because it contains both the "virtual" and "final" keywords to indicate that the method is overridden and that no subclasses of "Student" can override "description".
 }
 
 ```


### PR DESCRIPTION
This comment in the Coding Style doc has the wrong keyword.