### PR TITLE
Ports: Remove invalid copy action from PrBoom+ build

### DIFF
--- a/Ports/prboom-plus/package.sh
+++ b/Ports/prboom-plus/package.sh
@@ -27,7 +27,6 @@ configure() {
 }
 
 build() {
-    run cp -v ../../prboom-plus.wad build/
     run make -C build "${makeopts[@]}"
 }
 


### PR DESCRIPTION
This was a test that should have been removed in the previous PR.