### PR TITLE
LoginServer: Track user sockets by sid instead of uid

### DIFF
--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -1,9 +1,9 @@
 [ConfigServer]
-Socket=/tmp/user/%uid/portal/config
+Socket=/tmp/session/%sid/portal/config
 SocketPermissions=600
 
 [RequestServer]
-Socket=/tmp/user/%uid/portal/request
+Socket=/tmp/session/%sid/portal/request
 SocketPermissions=600
 Lazy=true
 Priority=low
@@ -12,7 +12,7 @@ MultiInstance=true
 AcceptSocketConnections=true
 
 [WebContent]
-Socket=/tmp/user/%uid/portal/webcontent
+Socket=/tmp/session/%sid/portal/webcontent
 SocketPermissions=600
 Lazy=true
 SystemModes=graphical
@@ -20,7 +20,7 @@ MultiInstance=true
 AcceptSocketConnections=true
 
 [WebSocket]
-Socket=/tmp/user/%uid/portal/websocket
+Socket=/tmp/session/%sid/portal/websocket
 SocketPermissions=600
 Lazy=true
 Priority=low
@@ -29,7 +29,7 @@ MultiInstance=true
 AcceptSocketConnections=true
 
 [FileSystemAccessServer]
-Socket=/tmp/user/%uid/portal/filesystemaccess
+Socket=/tmp/session/%sid/portal/filesystemaccess
 SocketPermissions=660
 Lazy=true
 Priority=low
@@ -38,7 +38,7 @@ MultiInstance=true
 AcceptSocketConnections=true
 
 [ImageDecoder]
-Socket=/tmp/user/%uid/portal/image
+Socket=/tmp/session/%sid/portal/image
 SocketPermissions=600
 Lazy=true
 SystemModes=graphical
@@ -46,46 +46,46 @@ MultiInstance=true
 AcceptSocketConnections=true
 
 [NotificationServer]
-Socket=/tmp/user/%uid/portal/notify
+Socket=/tmp/session/%sid/portal/notify
 SocketPermissions=600
 Lazy=true
 Priority=low
 KeepAlive=true
 
 [InspectorServer]
-Socket=/tmp/user/%uid/portal/inspector,/tmp/user/%uid/portal/inspectables
+Socket=/tmp/session/%sid/portal/inspector,/tmp/session/%sid/portal/inspectables
 SocketPermissions=600,666
 KeepAlive=true
 
 [AudioServer]
-Socket=/tmp/user/%uid/portal/audio
+Socket=/tmp/session/%sid/portal/audio
 Priority=high
 KeepAlive=true
 SystemModes=text,graphical
 
 [CppLanguageServer]
-Socket=/tmp/user/%uid/portal/language/cpp
+Socket=/tmp/session/%sid/portal/language/cpp
 SocketPermissions=600
 Lazy=true
 MultiInstance=true
 AcceptSocketConnections=true
 
 [ShellLanguageServer]
-Socket=/tmp/user/%uid/portal/language/shell
+Socket=/tmp/session/%sid/portal/language/shell
 SocketPermissions=600
 Lazy=true
 MultiInstance=true
 AcceptSocketConnections=true
 
 [SQLServer]
-Socket=/tmp/user/%uid/portal/sql
+Socket=/tmp/session/%sid/portal/sql
 SocketPermissions=600
 Priority=low
 Lazy=true
 KeepAlive=true
 
 [LaunchServer]
-Socket=/tmp/user/%uid/portal/launch
+Socket=/tmp/session/%sid/portal/launch
 SocketPermissions=600
 Lazy=true
 SystemModes=text,graphical
@@ -126,4 +126,3 @@ KeepAlive=true
 
 [Terminal]
 WorkingDirectory=/home/anon
-

--- a/Base/usr/share/man/man7/Audio-subsystem.md
+++ b/Base/usr/share/man/man7/Audio-subsystem.md
@@ -1,6 +1,6 @@
 ## Name
 
-Overview of the SerenityOS audio subsystem, including a brief description of [`/dev/audio`](help://man/4/audio), the AudioServer and their interfaces. 
+Overview of the SerenityOS audio subsystem, including a brief description of [`/dev/audio`](help://man/4/audio), the AudioServer and their interfaces.
 
 ## Description
 
@@ -18,9 +18,8 @@ AudioServer is responsible for handling userland audio clients and talking to th
 application should ever need to write to a device in `/dev/audio` directly, except for special cases in which
 AudioServer is not present.
 
-As with all system servers, AudioServer provides an IPC interface on `/tmp/user/%uid/portal/audio`, with `%uid` being
-the uid
-of the current user. For specifics on how to talk to AudioServer, the IPC interface specifications are the best source
+As with all system servers, AudioServer provides an IPC interface on `/tmp/session/%sid/portal/audio`, with `%sid` being
+the current login session id. For specifics on how to talk to AudioServer, the IPC interface specifications are the best source
 of information. For controlling mixer functionality, clients have the ability to obtain and change their own volume, or
 the main volume and mute state.
 

--- a/Documentation/Browser/ProcessArchitecture.md
+++ b/Documentation/Browser/ProcessArchitecture.md
@@ -31,7 +31,7 @@ This process can decode images (PNG, JPEG, BMP, ICO, PBM, etc.) into bitmaps. Ea
 ### How processes are spawned
 
 To get a fresh **WebContent** process, anyone with the suitable file system permissions can spawn one by connecting to
-the socket at `/tmp/user/%uid/portal/webcontent`, with `%uid` being the uid of the current user. This socket is managed
+the socket at `/tmp/user/%sid/portal/webcontent`, with `%sid` being the current login session id. This socket is managed
 by **
 SystemServer** and will spawn a new instance of **WebContent** for every connection.
 

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -237,12 +237,13 @@ private:
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath wpath cpath unix thread"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath wpath cpath unix thread proc"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("AudioApplet");
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/audio", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/audio", "rw"));
     TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto window = TRY(GUI::Window::try_create());

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -17,7 +17,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix proc"));
     auto app = TRY(GUI::Application::try_create(arguments));
 
     Config::pledge_domain("ClipboardHistory");

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -166,8 +166,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix proc exec"));
     auto app = TRY(GUI::Application::try_create(arguments));
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/notify", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/notify", "rw"));
     TRY(Core::System::unveil("/proc/net/adapters", "r"));
     TRY(Core::System::unveil("/bin/SystemMonitor", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -358,9 +358,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix prot_exec"));
+    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix prot_exec proc"));
 
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/home/anon/Documents/3D Models", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/usr/lib", "r"));

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -80,14 +80,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_url(URL::create_with_file_scheme(Core::StandardPaths::downloads_directory())));
     TRY(Desktop::Launcher::seal_allowlist());
 
+    TRY(Core::System::unveil("/proc/all", "r"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/image", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/request", "rw"));
     TRY(Core::System::unveil("/home", "rwc"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/image", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/request", "rw"));
     TRY(Core::System::unveil("/bin/BrowserSettings", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -28,14 +28,15 @@ static String parse_input(StringView input)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix proc"));
     auto app = TRY(GUI::Application::try_create(arguments));
 
+    TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/usr/share/man", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/webcontent", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     String start_page;

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -20,7 +20,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix cpath wpath thread"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix cpath wpath thread proc"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
@@ -43,8 +43,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return GUI::Window::CloseRequestDecision::StayOpen;
     };
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     hex_editor_widget->initialize_menubar(*window);

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -37,11 +37,11 @@ static ErrorOr<ByteBuffer> dump_bitmap(RefPtr<Gfx::Bitmap> bitmap, AK::StringVie
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio cpath rpath recvfd sendfd unix"));
+    TRY(Core::System::pledge("stdio cpath rpath recvfd sendfd unix proc"));
     auto app = TRY(GUI::Application::try_create(arguments));
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = GUI::Icon::default_icon("app-magnifier"sv);

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -18,17 +18,18 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix inet"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix inet proc"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
     Config::pledge_domain("Mail");
 
+    TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/etc", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     TRY(Desktop::Launcher::add_allowed_url(URL::create_with_file_scheme("/bin/MailSettings")));

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -32,10 +32,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("PDF Viewer");
     window->resize(640, 400);
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix proc"));
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto pdf_viewer_widget = TRY(window->try_set_main_widget<PDFViewerWidget>());

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -21,7 +21,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix wpath cpath"));
+    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix wpath cpath proc"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("PixelPaint");
@@ -31,10 +31,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(image_file, "Image file to open", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
+    TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/clipboard", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/image", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/image", "rw"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -26,7 +26,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath fattr unix cpath wpath thread"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath fattr unix cpath wpath thread proc"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
@@ -44,7 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     }
 
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/webcontent", "rw"));
     // For writing temporary files when exporting.
     TRY(Core::System::unveil("/tmp", "crw"));
     TRY(Core::System::unveil("/etc", "r"));

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -422,6 +422,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return GUI::Window::CloseRequestDecision::StayOpen;
     };
 
+    TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin", "r"));
     TRY(Core::System::unveil("/proc", "r"));
@@ -429,8 +430,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/bin/TerminalSettings", "x"));
     TRY(Core::System::unveil("/bin/utmpupdate", "x"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/config", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/config", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto modified_state_check_timer = Core::Timer::create_repeating(500, [&] {

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -18,7 +18,7 @@ using namespace TextEditor;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath unix"));
+    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath unix proc"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
@@ -31,10 +31,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     parser.add_positional_argument(file_to_edit, "File to edit, with optional starting line and column number", "file[:line[:column]]", Core::ArgsParser::Required::No);
     parser.parse(arguments);
 
+    TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = GUI::Icon::default_icon("app-text-editor"sv);

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -38,8 +38,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (!file_to_edit.is_empty())
         path = Core::File::absolute_path(file_to_edit);
 
-    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath unix"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
+    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath unix proc"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/Welcome/main.cpp
+++ b/Userland/Applications/Welcome/main.cpp
@@ -19,10 +19,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("SystemServer");
 
+    TRY(Core::System::unveil("/proc/all", "r"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/home", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/bin/Help", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-welcome"sv));

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -36,12 +36,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(hide_window_frame, "Hide window frame", "hide-window", 'h');
     args_parser.parse(arguments);
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix cpath wpath thread"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix cpath wpath thread proc"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     if ((grid_rows > 0) ^ (grid_columns > 0)) {

--- a/Userland/Demos/WidgetGallery/main.cpp
+++ b/Userland/Demos/WidgetGallery/main.cpp
@@ -14,11 +14,11 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix thread"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix thread proc"));
     auto app = TRY(GUI::Application::try_create(arguments, Core::EventLoop::MakeInspectable::Yes));
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-widget-gallery"sv));

--- a/Userland/DevTools/HackStudio/LanguageClients/ConnectionsToServer.h
+++ b/Userland/DevTools/HackStudio/LanguageClients/ConnectionsToServer.h
@@ -15,7 +15,7 @@
 #define LANGUAGE_CLIENT(language_name_, socket_name)                                                    \
     namespace language_name_ {                                                                          \
     class ConnectionToServer final : public HackStudio::ConnectionToServer {                            \
-        IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/user/%uid/portal/language/" socket_name)        \
+        IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/session/%sid/portal/language/" socket_name)     \
     public:                                                                                             \
         static char const* language_name() { return #language_name_; }                                  \
                                                                                                         \

--- a/Userland/DevTools/Inspector/InspectorServerClient.h
+++ b/Userland/DevTools/Inspector/InspectorServerClient.h
@@ -15,7 +15,7 @@ namespace Inspector {
 class InspectorServerClient final
     : public IPC::ConnectionToServer<InspectorClientEndpoint, InspectorServerEndpoint>
     , public InspectorClientEndpoint {
-    IPC_CLIENT_CONNECTION(InspectorServerClient, "/tmp/user/%uid/portal/inspector"sv)
+    IPC_CLIENT_CONNECTION(InspectorServerClient, "/tmp/session/%sid/portal/inspector"sv)
 
 public:
     virtual ~InspectorServerClient() override = default;

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -28,7 +28,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix"));
+    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix proc"));
 
     srand(time(nullptr));
 
@@ -44,8 +44,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     size_t board_size = Config::read_i32("2048"sv, ""sv, "board_size"sv, 4);

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -36,11 +36,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::Window::try_create());
     auto widget = TRY(window->try_set_main_widget<ChessWidget>());
 
+    TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin/ChessEngine", "x"));
-    TRY(Core::System::unveil("/etc/passwd", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto size = Config::read_i32("Chess"sv, "Display"sv, "size"sv, 512);

--- a/Userland/Games/FlappyBug/main.cpp
+++ b/Userland/Games/FlappyBug/main.cpp
@@ -28,10 +28,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/FlappyBug.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY(Core::System::pledge("stdio rpath recvfd sendfd proc"));
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     u32 high_score = Config::read_i32("FlappyBug"sv, "Game"sv, "HighScore"sv, 0);

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -34,10 +34,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/GameOfLife.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY(Core::System::pledge("stdio rpath recvfd sendfd proc"));
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-gameoflife"sv));

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -40,10 +40,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/Hearts.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath proc"));
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto window = TRY(GUI::Window::try_create());

--- a/Userland/Games/MasterWord/main.cpp
+++ b/Userland/Games/MasterWord/main.cpp
@@ -30,10 +30,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/MasterWord.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY(Core::System::pledge("stdio rpath recvfd sendfd proc"));
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-masterword"sv));

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -36,10 +36,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/Minesweeper.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY(Core::System::pledge("stdio rpath recvfd sendfd proc"));
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-minesweeper"sv));

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -31,10 +31,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/Snake.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY(Core::System::pledge("stdio rpath recvfd sendfd proc"));
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-snake"sv));

--- a/Userland/Libraries/LibAudio/ConnectionToServer.h
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.h
@@ -26,7 +26,7 @@ namespace Audio {
 class ConnectionToServer final
     : public IPC::ConnectionToServer<AudioClientEndpoint, AudioServerEndpoint>
     , public AudioClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/user/%uid/portal/audio"sv)
+    IPC_CLIENT_CONNECTION(ConnectionToServer, "/tmp/session/%sid/portal/audio"sv)
 public:
     virtual ~ConnectionToServer() override;
 

--- a/Userland/Libraries/LibConfig/Client.h
+++ b/Userland/Libraries/LibConfig/Client.h
@@ -18,7 +18,7 @@ namespace Config {
 class Client final
     : public IPC::ConnectionToServer<ConfigClientEndpoint, ConfigServerEndpoint>
     , public ConfigClientEndpoint {
-    IPC_CLIENT_CONNECTION(Client, "/tmp/user/%uid/portal/config"sv)
+    IPC_CLIENT_CONNECTION(Client, "/tmp/session/%sid/portal/config"sv)
 
 public:
     void pledge_domains(Vector<String> const&);

--- a/Userland/Libraries/LibCore/Account.cpp
+++ b/Userland/Libraries/LibCore/Account.cpp
@@ -68,15 +68,6 @@ ErrorOr<Account> Account::from_passwd(passwd const& pwd, spwd const& spwd)
     return account;
 }
 
-String Account::parse_path_with_uid(StringView general_path, Optional<uid_t> uid)
-{
-    if (general_path.contains("%uid"sv)) {
-        auto const final_uid = uid.has_value() ? uid.value() : getuid();
-        return general_path.replace("%uid"sv, String::number(final_uid), ReplaceMode::All);
-    }
-    return general_path;
-}
-
 ErrorOr<Account> Account::self([[maybe_unused]] Read options)
 {
     Vector<gid_t> extra_gids = TRY(Core::System::getgroups());
@@ -147,14 +138,6 @@ bool Account::authenticate(SecretString const& password) const
     // FIXME: Use crypt_r if it can be built in lagom.
     char* hash = crypt(password.characters(), m_password_hash.characters());
     return hash != nullptr && AK::timing_safe_compare(hash, m_password_hash.characters(), m_password_hash.length());
-}
-
-ErrorOr<void> Account::create_user_temporary_directory_if_needed() const
-{
-    auto const temporary_directory = String::formatted("/tmp/user/{}", m_uid);
-    auto directory = TRY(Core::Directory::create(temporary_directory, Core::Directory::CreateDirectories::Yes));
-    TRY(directory.chown(m_uid, m_gid));
-    return {};
 }
 
 ErrorOr<void> Account::login() const

--- a/Userland/Libraries/LibCore/Account.h
+++ b/Userland/Libraries/LibCore/Account.h
@@ -32,15 +32,12 @@ public:
         PasswdOnly
     };
 
-    static String parse_path_with_uid(StringView general_path, Optional<uid_t> force_uid = {});
     static ErrorOr<Account> self(Read options = Read::All);
     static ErrorOr<Account> from_name(StringView username, Read options = Read::All);
     static ErrorOr<Account> from_uid(uid_t uid, Read options = Read::All);
 
     bool authenticate(SecretString const& password) const;
     ErrorOr<void> login() const;
-
-    ErrorOr<void> create_user_temporary_directory_if_needed() const;
 
     String username() const { return m_username; }
     String password_hash() const { return m_password_hash; }

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
     ProcessStatisticsReader.cpp
     Property.cpp
     SecretString.cpp
+    SessionManagement.cpp
     SOCKSProxyClient.cpp
     Stream.cpp
     StandardPaths.cpp

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -22,6 +22,7 @@
 #include <LibCore/LocalServer.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/Object.h>
+#include <LibCore/SessionManagement.h>
 #include <LibThreading/Mutex.h>
 #include <LibThreading/MutexProtected.h>
 #include <errno.h>
@@ -361,7 +362,12 @@ EventLoop::~EventLoop()
 bool connect_to_inspector_server()
 {
 #ifdef __serenity__
-    auto inspector_server_path = Account::parse_path_with_uid("/tmp/user/%uid/portal/inspectables"sv);
+    auto maybe_path = SessionManagement::parse_path_with_sid("/tmp/session/%sid/portal/inspectables"sv);
+    if (maybe_path.is_error()) {
+        dbgln("connect_to_inspector_server: {}", maybe_path.error());
+        return false;
+    }
+    auto inspector_server_path = maybe_path.value();
     auto maybe_socket = Stream::LocalSocket::connect(inspector_server_path);
     if (maybe_socket.is_error()) {
         dbgln("connect_to_inspector_server: Failed to connect: {}", maybe_socket.error());

--- a/Userland/Libraries/LibCore/LocalServer.cpp
+++ b/Userland/Libraries/LibCore/LocalServer.cpp
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibCore/Account.h>
 #include <LibCore/LocalServer.h>
 #include <LibCore/Notifier.h>
+#include <LibCore/SessionManagement.h>
 #include <LibCore/Stream.h>
 #include <LibCore/System.h>
 #include <LibCore/SystemServerTakeover.h>
@@ -38,7 +38,7 @@ ErrorOr<void> LocalServer::take_over_from_system_server(String const& socket_pat
     if (m_listening)
         return Error::from_string_literal("Core::LocalServer: Can't perform socket takeover when already listening");
 
-    auto const parsed_path = Core::Account::parse_path_with_uid(socket_path);
+    auto const parsed_path = TRY(Core::SessionManagement::parse_path_with_sid(socket_path));
     auto socket = TRY(take_over_socket_from_system_server(parsed_path));
     m_fd = TRY(socket->release_fd());
 

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -16,7 +16,7 @@ namespace Core {
 
 HashMap<uid_t, String> ProcessStatisticsReader::s_usernames;
 
-Optional<AllProcessesStatistics> ProcessStatisticsReader::get_all(RefPtr<Core::File>& proc_all_file)
+Optional<AllProcessesStatistics> ProcessStatisticsReader::get_all(RefPtr<Core::File>& proc_all_file, bool include_usernames)
 {
     if (proc_all_file) {
         if (!proc_all_file->seek(0, Core::SeekMode::SetPosition)) {
@@ -93,7 +93,9 @@ Optional<AllProcessesStatistics> ProcessStatisticsReader::get_all(RefPtr<Core::F
         });
 
         // and synthetic data last
-        process.username = username_from_uid(process.uid);
+        if (include_usernames) {
+            process.username = username_from_uid(process.uid);
+        }
         all_processes_statistics.processes.append(move(process));
     });
 
@@ -102,10 +104,10 @@ Optional<AllProcessesStatistics> ProcessStatisticsReader::get_all(RefPtr<Core::F
     return all_processes_statistics;
 }
 
-Optional<AllProcessesStatistics> ProcessStatisticsReader::get_all()
+Optional<AllProcessesStatistics> ProcessStatisticsReader::get_all(bool include_usernames)
 {
     RefPtr<Core::File> proc_all_file;
-    return get_all(proc_all_file);
+    return get_all(proc_all_file, include_usernames);
 }
 
 String ProcessStatisticsReader::username_from_uid(uid_t uid)

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.h
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.h
@@ -72,8 +72,8 @@ struct AllProcessesStatistics {
 
 class ProcessStatisticsReader {
 public:
-    static Optional<AllProcessesStatistics> get_all(RefPtr<Core::File>&);
-    static Optional<AllProcessesStatistics> get_all();
+    static Optional<AllProcessesStatistics> get_all(RefPtr<Core::File>&, bool include_usernames = true);
+    static Optional<AllProcessesStatistics> get_all(bool include_usernames = true);
 
 private:
     static String username_from_uid(uid_t);

--- a/Userland/Libraries/LibCore/SessionManagement.cpp
+++ b/Userland/Libraries/LibCore/SessionManagement.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022, Peter Elliott <pelliott@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/Directory.h>
+#include <LibCore/ProcessStatisticsReader.h>
+#include <LibCore/SessionManagement.h>
+#include <LibCore/System.h>
+
+namespace Core::SessionManagement {
+
+static ErrorOr<Core::ProcessStatistics const*> get_proc(Core::AllProcessesStatistics const& stats, pid_t pid)
+{
+    for (auto& proc : stats.processes) {
+        if (proc.pid == pid)
+            return &proc;
+    }
+    return Error::from_string_literal("Could not find pid in process statistics.");
+}
+
+ErrorOr<pid_t> root_session_id(Optional<pid_t> force_sid)
+{
+    auto stats = Core::ProcessStatisticsReader::get_all(false);
+    if (!stats.has_value())
+        return Error::from_string_literal("Failed to get all process statistics");
+
+    pid_t sid = (force_sid.has_value()) ? force_sid.value() : TRY(System::getsid());
+    while (true) {
+        pid_t parent = TRY(get_proc(stats.value(), sid))->ppid;
+        pid_t parent_sid = TRY(get_proc(stats.value(), parent))->sid;
+
+        if (parent_sid == 0)
+            break;
+
+        sid = parent_sid;
+    }
+
+    return sid;
+}
+
+ErrorOr<void> logout(Optional<pid_t> force_sid)
+{
+    pid_t sid = TRY(root_session_id(force_sid));
+    TRY(System::kill(-sid, SIGTERM));
+    return {};
+}
+
+ErrorOr<String> parse_path_with_sid(StringView general_path, Optional<pid_t> force_sid)
+{
+    if (general_path.contains("%sid"sv)) {
+        pid_t sid = TRY(root_session_id(force_sid));
+        return general_path.replace("%sid"sv, String::number(sid), ReplaceMode::All);
+    }
+    return String(general_path);
+}
+
+ErrorOr<void> create_session_temporary_directory_if_needed(uid_t uid, gid_t gid, Optional<pid_t> force_sid)
+{
+    pid_t sid = TRY(root_session_id(force_sid));
+    auto const temporary_directory = String::formatted("/tmp/session/{}", sid);
+    auto directory = TRY(Core::Directory::create(temporary_directory, Core::Directory::CreateDirectories::Yes));
+    TRY(directory.chown(uid, gid));
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibCore/SessionManagement.h
+++ b/Userland/Libraries/LibCore/SessionManagement.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022, Peter Elliott <pelliott@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/Types.h>
+
+namespace Core::SessionManagement {
+
+ErrorOr<pid_t> root_session_id(Optional<pid_t> force_sid = {});
+ErrorOr<void> logout(Optional<pid_t> force_sid = {});
+
+ErrorOr<String> parse_path_with_sid(StringView general_path, Optional<pid_t> force_sid = {});
+ErrorOr<void> create_session_temporary_directory_if_needed(uid_t uid, gid_t gid, Optional<pid_t> force_sid = {});
+
+}

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -747,6 +747,14 @@ ErrorOr<pid_t> setsid()
     return rc;
 }
 
+ErrorOr<pid_t> getsid(pid_t pid)
+{
+    int rc = ::getsid(pid);
+    if (rc < 0)
+        return Error::from_syscall("getsid"sv, -errno);
+    return rc;
+}
+
 ErrorOr<void> drop_privileges()
 {
     auto gid_result = setgid(getgid());

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -13,6 +13,7 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/File.h>
+#include <LibCore/SessionManagement.h>
 #include <LibCore/System.h>
 #include <limits.h>
 #include <stdarg.h>
@@ -82,7 +83,7 @@ ErrorOr<void> pledge(StringView promises, StringView execpromises)
 
 ErrorOr<void> unveil(StringView path, StringView permissions)
 {
-    auto const parsed_path = Core::Account::parse_path_with_uid(path);
+    auto const parsed_path = TRY(Core::SessionManagement::parse_path_with_sid(path));
 
     Syscall::SC_unveil_params params {
         { parsed_path.characters(), parsed_path.length() },

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -141,6 +141,7 @@ ErrorOr<void> setgid(gid_t);
 ErrorOr<void> setegid(gid_t);
 ErrorOr<void> setpgid(pid_t pid, pid_t pgid);
 ErrorOr<pid_t> setsid();
+ErrorOr<pid_t> getsid(pid_t pid = 0);
 ErrorOr<void> drop_privileges();
 ErrorOr<bool> isatty(int fd);
 ErrorOr<void> link(StringView old_path, StringView new_path);

--- a/Userland/Libraries/LibDesktop/Launcher.cpp
+++ b/Userland/Libraries/LibDesktop/Launcher.cpp
@@ -36,7 +36,7 @@ auto Launcher::Details::from_details_str(String const& details_str) -> NonnullRe
 class ConnectionToLaunchServer final
     : public IPC::ConnectionToServer<LaunchClientEndpoint, LaunchServerEndpoint>
     , public LaunchClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToLaunchServer, "/tmp/user/%uid/portal/launch"sv)
+    IPC_CLIENT_CONNECTION(ConnectionToLaunchServer, "/tmp/session/%sid/portal/launch"sv)
 private:
     ConnectionToLaunchServer(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
         : IPC::ConnectionToServer<LaunchClientEndpoint, LaunchServerEndpoint>(*this, move(socket))

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -23,7 +23,7 @@ using Result = ErrorOr<NonnullRefPtr<Core::File>>;
 class Client final
     : public IPC::ConnectionToServer<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint>
     , public FileSystemAccessClientEndpoint {
-    IPC_CLIENT_CONNECTION(Client, "/tmp/user/%uid/portal/filesystemaccess"sv)
+    IPC_CLIENT_CONNECTION(Client, "/tmp/session/%sid/portal/filesystemaccess"sv)
 
 public:
     Result try_request_file_read_only_approved(GUI::Window* parent_window, String const& path);

--- a/Userland/Libraries/LibGUI/Notification.cpp
+++ b/Userland/Libraries/LibGUI/Notification.cpp
@@ -15,7 +15,7 @@ namespace GUI {
 class ConnectionToNotificationServer final
     : public IPC::ConnectionToServer<NotificationClientEndpoint, NotificationServerEndpoint>
     , public NotificationClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToNotificationServer, "/tmp/user/%uid/portal/notify"sv)
+    IPC_CLIENT_CONNECTION(ConnectionToNotificationServer, "/tmp/session/%sid/portal/notify"sv)
 
     friend class Notification;
 

--- a/Userland/Libraries/LibIPC/ConnectionToServer.h
+++ b/Userland/Libraries/LibIPC/ConnectionToServer.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <LibCore/Account.h>
+#include <LibCore/SessionManagement.h>
 #include <LibCore/Stream.h>
 #include <LibIPC/Connection.h>
 
@@ -18,7 +18,7 @@ public:                                                                         
     template<typename Klass = klass, class... Args>                                                    \
     static ErrorOr<NonnullRefPtr<klass>> try_create(Args&&... args)                                    \
     {                                                                                                  \
-        auto parsed_socket_path { Core::Account::parse_path_with_uid(socket_path) };                   \
+        auto parsed_socket_path = TRY(Core::SessionManagement::parse_path_with_sid(socket_path));      \
         auto socket = TRY(Core::Stream::LocalSocket::connect(move(parsed_socket_path)));               \
         /* We want to rate-limit our clients */                                                        \
         TRY(socket->set_blocking(true));                                                               \

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -27,7 +27,7 @@ struct DecodedImage {
 class Client final
     : public IPC::ConnectionToServer<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>
     , public ImageDecoderClientEndpoint {
-    IPC_CLIENT_CONNECTION(Client, "/tmp/user/%uid/portal/image"sv);
+    IPC_CLIENT_CONNECTION(Client, "/tmp/session/%sid/portal/image"sv);
 
 public:
     Optional<DecodedImage> decode_image(ReadonlyBytes);

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -20,7 +20,7 @@ class Request;
 class RequestClient final
     : public IPC::ConnectionToServer<RequestClientEndpoint, RequestServerEndpoint>
     , public RequestClientEndpoint {
-    IPC_CLIENT_CONNECTION(RequestClient, "/tmp/user/%uid/portal/request"sv)
+    IPC_CLIENT_CONNECTION(RequestClient, "/tmp/session/%sid/portal/request"sv)
 
 public:
     template<typename RequestHashMapTraits = Traits<String>>

--- a/Userland/Libraries/LibProtocol/WebSocketClient.h
+++ b/Userland/Libraries/LibProtocol/WebSocketClient.h
@@ -18,7 +18,7 @@ class WebSocket;
 class WebSocketClient final
     : public IPC::ConnectionToServer<WebSocketClientEndpoint, WebSocketServerEndpoint>
     , public WebSocketClientEndpoint {
-    IPC_CLIENT_CONNECTION(WebSocketClient, "/tmp/user/%uid/portal/websocket"sv)
+    IPC_CLIENT_CONNECTION(WebSocketClient, "/tmp/session/%sid/portal/websocket"sv)
 
 public:
     RefPtr<WebSocket> connect(const URL&, String const& origin = {}, Vector<String> const& protocols = {}, Vector<String> const& extensions = {}, HashMap<String, String> const& request_headers = {});

--- a/Userland/Libraries/LibSQL/SQLClient.h
+++ b/Userland/Libraries/LibSQL/SQLClient.h
@@ -16,7 +16,7 @@ namespace SQL {
 class SQLClient
     : public IPC::ConnectionToServer<SQLClientEndpoint, SQLServerEndpoint>
     , public SQLClientEndpoint {
-    IPC_CLIENT_CONNECTION(SQLClient, "/tmp/user/%uid/portal/sql"sv)
+    IPC_CLIENT_CONNECTION(SQLClient, "/tmp/session/%sid/portal/sql"sv)
     virtual ~SQLClient() = default;
 
     Function<void(int, String const&)> on_connected;

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -19,7 +19,7 @@ class OutOfProcessWebView;
 class WebContentClient final
     : public IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>
     , public WebContentClientEndpoint {
-    IPC_CLIENT_CONNECTION(WebContentClient, "/tmp/user/%uid/portal/webcontent"sv);
+    IPC_CLIENT_CONNECTION(WebContentClient, "/tmp/session/%sid/portal/webcontent"sv);
 
 public:
     Function<void()> on_web_content_process_crash;

--- a/Userland/Services/InspectorServer/main.cpp
+++ b/Userland/Services/InspectorServer/main.cpp
@@ -17,12 +17,12 @@ ErrorOr<int> serenity_main(Main::Arguments)
 {
     Core::EventLoop event_loop;
 
-    TRY(Core::System::pledge("stdio unix accept"));
+    TRY(Core::System::pledge("stdio unix accept rpath proc"));
 
-    auto server = TRY(IPC::MultiServer<InspectorServer::ConnectionFromClient>::try_create("/tmp/user/%uid/portal/inspector"));
+    auto server = TRY(IPC::MultiServer<InspectorServer::ConnectionFromClient>::try_create("/tmp/session/%sid/portal/inspector"));
 
     auto inspectables_server = TRY(Core::LocalServer::try_create());
-    TRY(inspectables_server->take_over_from_system_server("/tmp/user/%uid/portal/inspectables"));
+    TRY(inspectables_server->take_over_from_system_server("/tmp/session/%sid/portal/inspectables"));
 
     inspectables_server->on_accept = [&](auto client_socket) {
         auto pid = client_socket->peer_pid().release_value_but_fixme_should_propagate_errors();

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -22,12 +22,13 @@
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     Core::EventLoop event_loop;
-    TRY(Core::System::pledge("stdio recvfd sendfd accept unix rpath"));
+    TRY(Core::System::pledge("stdio recvfd sendfd accept unix rpath proc"));
+    TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/request", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/image", "rw"));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/websocket", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/request", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/image", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/websocket", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -22,7 +22,7 @@ constexpr size_t LOAD_CHUNK_SIZE = 128 * KiB;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath sendfd unix thread"));
+    TRY(Core::System::pledge("stdio rpath sendfd unix thread proc"));
 
     StringView path {};
     bool should_loop = false;
@@ -34,8 +34,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(show_sample_progress, "Show playback progress in samples", "sample-progress", 's');
     args_parser.parse(arguments);
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/audio", "rw"));
     TRY(Core::System::unveil(Core::File::absolute_path(path), "r"sv));
-    TRY(Core::System::unveil("/tmp/user/%uid/portal/audio", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     Core::EventLoop loop;


### PR DESCRIPTION
This PR moves user sockets to per login session instead of per user id. This has two important advantages:
1. Commands run as root with `pls(1)` will use the correct servers
2. There can be multiple concurrent logged in sessions with the same user each running their own services.
