### PR TITLE
LibC: Consume all whitespace in `scanf` if present in format

### DIFF
--- a/Tests/LibC/TestScanf.cpp
+++ b/Tests/LibC/TestScanf.cpp
@@ -180,6 +180,7 @@ const TestSuite test_suites[] {
     { "%d %n", "1 a", 1, 2, { intarg0, intarg1 }, { to_value_t(1), to_value_t(2) } },
     { "%*d", "  42", 0, 0, {}, {} },
     { "%d%*1[:/]%d", "24/7", 2, 2, { intarg0, intarg1 }, { to_value_t(24), to_value_t(7) } },
+    { " %[^a]", " b", 1, 1, { charstararg0 }, { str_to_value_t("b") } },
 };
 
 bool g_any_failed = false;


### PR DESCRIPTION
We were consuming all whitespace from the format, but not the input lexer - that was left to the actual format parsing code. It so happened that we did not account for whitespace with the conversion specifier '[', causing whitespace to end up in the output variables.

Fix this by always consuming all whitespace and removing the whitespace logic from the conversion code.

This allows the PrBoom+ port to read its configuration file :^)