### PR TITLE
Calendar: Limit the starting day input range to the selected month

### DIFF
--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -63,8 +63,8 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
 
     auto& starting_day_combo = middle_container.add<GUI::SpinBox>();
     starting_day_combo.set_fixed_size(40, 20);
+    starting_day_combo.set_range(1, m_date_time.days_in_month());
     starting_day_combo.set_value(m_date_time.day());
-    starting_day_combo.set_min(1);
 
     auto& starting_year_combo = middle_container.add<GUI::SpinBox>();
     starting_year_combo.set_fixed_size(55, 20);
@@ -99,6 +99,16 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
         dbgln("TODO: Add event icon on specific tile");
         done(ExecResult::OK);
     };
+
+    auto update_starting_day_range = [&starting_day_combo, &starting_year_combo, &starting_month_combo]() {
+        auto year = starting_year_combo.value();
+        auto month = starting_month_combo.selected_index();
+
+        starting_day_combo.set_range(1, days_in_month(year, month + 1));
+    };
+
+    starting_year_combo.on_change = [&update_starting_day_range](auto) { update_starting_day_range(); };
+    starting_month_combo.on_change = [&update_starting_day_range](auto, auto) { update_starting_day_range(); };
 
     event_title_textbox.set_focus(true);
 }

--- a/Userland/Libraries/LibGUI/SpinBox.cpp
+++ b/Userland/Libraries/LibGUI/SpinBox.cpp
@@ -96,6 +96,9 @@ void SpinBox::set_range(int min, int max, AllowCallback allow_callback)
             on_change(m_value);
     }
 
+    m_increment_button->set_enabled(m_value < m_max);
+    m_decrement_button->set_enabled(m_value > m_min);
+
     update();
 }
 


### PR DESCRIPTION
Previously we allowed entering any day value greater than one. With this pull request the maximum input value is dynamic based on the selected month and year.


https://user-images.githubusercontent.com/42888162/188687442-026f2c40-3919-4100-bd07-10193c7f4b69.mp4

