### PR TITLE
LibRegex: Account for eof after \<x> when 'x' leads to legacy behaviour

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -603,6 +603,7 @@ TEST_CASE(ECMA262_parse)
         { "(?<𝓑𝓻𝓸𝔀𝓷>a)"sv },
         { "((?=lg)?[vl]k\\-?\\d{3}) bui| 3\\.[-\\w; ]{10}lg?-([06cv9]{3,4})"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended }, // #12373, quantifiable assertions.
         { parse_test_case_long_disjunction_chain.view() },                                                                                 // A whole lot of disjunctions, should not overflow the stack.
+        { "(\"|')(?:(?!\\2)[^\\\\\\r\\n]|\\\\.)*\\2"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended },                         // LegacyOctalEscapeSequence should not consume too many chars (and should not crash)
     };
 
     for (auto& test : tests) {

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -1582,7 +1582,7 @@ bool ECMA262Parser::parse_atom_escape(ByteCode& stack, size_t& match_length_mini
         }
 
         // If not, put the characters back.
-        back(escape_str.length());
+        back(escape_str.length() + (done() ? 0 : 1));
     }
 
     Vector<CompareTypeAndValuePair> escape_compares;

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -2701,10 +2701,13 @@ size_t ECMA262Parser::ensure_total_number_of_capturing_parenthesis()
             continue;
         case '[':
             while (!lexer.is_eof()) {
-                if (lexer.consume_specific('\\'))
+                if (lexer.consume_specific('\\')) {
                     lexer.consume();
-                else if (lexer.consume_specific(']'))
+                    continue;
+                }
+                if (lexer.consume_specific(']')) {
                     break;
+                }
                 lexer.consume();
             }
             break;


### PR DESCRIPTION
We were previously consuming an extra char afterwards, which could be
the charclass terminator, leading to possible OOB accesses.