### PR TITLE
AK: Warn when trying to set `@foo@` as a SourceGenerator key

### DIFF
--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -37,7 +37,15 @@ public:
 
     SourceGenerator fork() { return SourceGenerator { m_builder, m_mapping, m_opening, m_closing }; }
 
-    void set(StringView key, String value) { m_mapping.set(key, move(value)); }
+    void set(StringView key, String value)
+    {
+        if (key.contains(m_opening) || key.contains(m_closing)) {
+            warnln("SourceGenerator keys cannot contain the opening/closing delimiters `{}` and `{}`. (Keys are only wrapped in these when using them, not when setting them.)", m_opening, m_closing);
+            VERIFY_NOT_REACHED();
+        }
+        m_mapping.set(key, move(value));
+    }
+
     String get(StringView key) const
     {
         auto result = m_mapping.get(key);


### PR DESCRIPTION
I was very confused why I was getting "no key named `foo`" errors, so hopefully this will save someone that confusion in the future. :^)

(It'll probably be me again...)