### PR TITLE
AK: Allow creating NonnullPtrVectors from an initializer list

### DIFF
--- a/AK/NonnullPtrVector.h
+++ b/AK/NonnullPtrVector.h
@@ -26,10 +26,14 @@ public:
         : Base(static_cast<Base const&>(other))
     {
     }
+    NonnullPtrVector(std::initializer_list<PtrType> list)
+        : Base(list)
+    {
+    }
 
     using Base::size;
 
-    using ConstIterator = SimpleIterator<const NonnullPtrVector, const T>;
+    using ConstIterator = SimpleIterator<NonnullPtrVector const, T const>;
     using Iterator = SimpleIterator<NonnullPtrVector, T>;
     using ReverseIterator = SimpleReverseIterator<NonnullPtrVector, T>;
     using ReverseConstIterator = SimpleReverseIterator<NonnullPtrVector const, T const>;
@@ -60,13 +64,13 @@ public:
     ALWAYS_INLINE PtrType const& ptr_at(size_t index) const { return Base::at(index); }
 
     ALWAYS_INLINE T& at(size_t index) { return *Base::at(index); }
-    ALWAYS_INLINE const T& at(size_t index) const { return *Base::at(index); }
+    ALWAYS_INLINE T const& at(size_t index) const { return *Base::at(index); }
     ALWAYS_INLINE T& operator[](size_t index) { return at(index); }
-    ALWAYS_INLINE const T& operator[](size_t index) const { return at(index); }
+    ALWAYS_INLINE T const& operator[](size_t index) const { return at(index); }
     ALWAYS_INLINE T& first() { return at(0); }
-    ALWAYS_INLINE const T& first() const { return at(0); }
+    ALWAYS_INLINE T const& first() const { return at(0); }
     ALWAYS_INLINE T& last() { return at(size() - 1); }
-    ALWAYS_INLINE const T& last() const { return at(size() - 1); }
+    ALWAYS_INLINE T const& last() const { return at(size() - 1); }
 
 private:
     // NOTE: You can't use resize() on a NonnullFooPtrVector since making the vector

--- a/Userland/Shell/AST.h
+++ b/Userland/Shell/AST.h
@@ -306,10 +306,6 @@ public:
     virtual bool is_list() const override { return true; }
     virtual bool is_list_without_resolution() const override { return true; }
     ListValue(Vector<String> values);
-    ListValue(Vector<NonnullRefPtr<Value>> values)
-        : m_contained_values(move(static_cast<NonnullRefPtrVector<Value>&>(values)))
-    {
-    }
     ListValue(NonnullRefPtrVector<Value> values)
         : m_contained_values(move(values))
     {


### PR DESCRIPTION
This was present in Vector already. Clang-format fixed some const positions automatically too.

Also removed a now-ambiguous and unnecessary constructor from Shell.