### PR TITLE
LibWeb: Implement more of the display grid

### DIFF
--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -29,3 +29,58 @@
   <div class="grid-item">3</div>  
   <div class="grid-item">4</div>
 </div>
+
+<!-- Check for a bug where a github page was crashing due to the following code. -->
+<p>If you can see this message then the test passed.</p>
+<div 
+  class="grid-container"
+  style="
+    --Layout-sidebar-width:296px;
+    grid-template-columns: minmax(0, var(--Layout-sidebar-width));">
+  <div class="grid-item">1</div>
+</div>
+
+<!-- Using grid-row and grid-column -->
+<p>Should render a full-width 4x4 grid with:
+<ul>
+  <li>one large column on the left</li>
+  <li>one large column on the right, being split in half vertically, with the number 2 in the top half, and numbers 3, 4, 5, and 6 in the bottom</li>
+</ul>
+<div 
+  class="grid-container"
+  style="
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-template-rows: 50px 50px 50px 50px;
+  ">
+  <div class="grid-item" style="grid-row: 1/-1; grid-column: 1/3;">1</div>
+  <div class="grid-item" style="grid-row: 1/3; grid-column: 3/-1;">2</div>
+  <div class="grid-item">3</div>  
+  <div class="grid-item">4</div>
+  <div class="grid-item">5</div>  
+  <div class="grid-item">6</div>
+</div>
+ 
+<!-- Different column sizes -->
+<p>Should render a 2x2 grid with columns 50px and 50%</p>
+<div 
+  class="grid-container"
+  style="
+    grid-template-columns: 50px 50%; 
+    grid-template-rows: auto auto;">
+  <div class="grid-item"
+    style="
+    grid-column: 1 / 1;
+    grid-row: 1 / 1">1</div>
+  <div class="grid-item"
+    style="
+    grid-column: 2 / 2;
+    grid-row: 1 / 1">2</div>
+  <div class="grid-item"
+    style="
+    grid-column: 1 / 1;
+    grid-row: 2 / 2">3</div>  
+  <div class="grid-item"
+    style="
+    grid-column: 2 / 2;
+    grid-row: 2 / 2">4</div>
+</div>

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
@@ -21,6 +21,7 @@ GridTrackPlacement::GridTrackPlacement(int position)
 }
 
 GridTrackPlacement::GridTrackPlacement()
+    : m_is_auto(true)
 {
 }
 

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
@@ -18,11 +18,21 @@ public:
 
     static GridTrackPlacement make_auto() { return GridTrackPlacement(); };
 
-    void set_position(int position) { m_position = position; }
+    void set_position(int position)
+    {
+        m_is_auto = false;
+        m_position = position;
+    }
     int position() const { return m_position; }
 
-    void set_has_span(bool has_span) { m_has_span = has_span; }
+    void set_has_span(bool has_span)
+    {
+        VERIFY(!m_is_auto);
+        m_has_span = has_span;
+    }
     bool has_span() const { return m_has_span; }
+
+    bool is_auto() const { return m_is_auto; }
 
     String to_string() const;
     bool operator==(GridTrackPlacement const& other) const
@@ -31,6 +41,7 @@ public:
     }
 
 private:
+    bool m_is_auto { false };
     int m_position { 0 };
     bool m_has_span { false };
 };

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -30,6 +30,11 @@ GridTrackSize::GridTrackSize(float flexible_length)
 {
 }
 
+GridTrackSize GridTrackSize::make_auto()
+{
+    return GridTrackSize(CSS::Length::make_auto());
+}
+
 String GridTrackSize::to_string() const
 {
     switch (m_type) {

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -24,7 +24,7 @@ GridTrackSize::GridTrackSize(Percentage percentage)
 {
 }
 
-GridTrackSize::GridTrackSize(int flexible_length)
+GridTrackSize::GridTrackSize(float flexible_length)
     : m_type(Type::FlexibleLength)
     , m_flexible_length(flexible_length)
 {

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
@@ -24,7 +24,7 @@ public:
 
     GridTrackSize(Length);
     GridTrackSize(Percentage);
-    GridTrackSize(int);
+    GridTrackSize(float);
 
     Type type() const { return m_type; }
 
@@ -34,7 +34,7 @@ public:
 
     Length length() const { return m_length; }
     Percentage percentage() const { return m_percentage; }
-    int flexible_length() const { return m_flexible_length; }
+    float flexible_length() const { return m_flexible_length; }
 
     String to_string() const;
     bool operator==(GridTrackSize const& other) const
@@ -49,7 +49,7 @@ private:
     Type m_type;
     Length m_length { Length::make_px(0) };
     Percentage m_percentage { Percentage(0) };
-    int m_flexible_length { 0 };
+    float m_flexible_length { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
@@ -26,6 +26,8 @@ public:
     GridTrackSize(Percentage);
     GridTrackSize(float);
 
+    static GridTrackSize make_auto();
+
     Type type() const { return m_type; }
 
     bool is_length() const { return m_type == Type::Length; }

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
@@ -38,6 +38,14 @@ public:
     Percentage percentage() const { return m_percentage; }
     float flexible_length() const { return m_flexible_length; }
 
+    // https://drafts.csswg.org/css-grid/#layout-algorithm
+    // Intrinsic sizing function - min-content, max-content, auto, fit-content()
+    // FIXME: Add missing properties once implemented.
+    bool is_intrinsic_track_sizing() const
+    {
+        return (m_type == Type::Length && m_length.is_auto());
+    }
+
     String to_string() const;
     bool operator==(GridTrackSize const& other) const
     {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5329,6 +5329,15 @@ RefPtr<StyleValue> Parser::parse_grid_track_sizes(Vector<ComponentValue> const& 
             params.append(Length::make_auto());
             continue;
         }
+        if (component_value.token().type() == Token::Type::Dimension) {
+            float numeric_value = component_value.token().dimension_value();
+            auto unit_string = component_value.token().dimension_unit();
+            if (unit_string.equals_ignoring_case("fr"sv) && numeric_value) {
+                params.append(GridTrackSize(numeric_value));
+                continue;
+            }
+        }
+
         auto dimension = parse_dimension(component_value);
         if (!dimension.has_value())
             return GridTrackSizeStyleValue::create({});

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5363,13 +5363,16 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement(Vector<ComponentValue> con
     }
 
     auto first_grid_track_placement = CSS::GridTrackPlacement();
+    auto has_span = false;
     if (current_token.to_string() == "span"sv) {
-        first_grid_track_placement.set_has_span(true);
+        has_span = true;
         tokens.skip_whitespace();
         current_token = tokens.next_token().token();
     }
-    if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
+    if (current_token.is(Token::Type::Number) && current_token.number().is_integer()) {
         first_grid_track_placement.set_position(static_cast<int>(current_token.number_value()));
+        first_grid_track_placement.set_has_span(has_span);
+    }
 
     if (!tokens.has_next_token())
         return GridTrackPlacementStyleValue::create(first_grid_track_placement);
@@ -5391,13 +5394,16 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement_shorthand_value(Vector<Com
 
     auto calculate_grid_track_placement = [](auto& current_token, auto& tokens) -> CSS::GridTrackPlacement {
         auto grid_track_placement = CSS::GridTrackPlacement();
+        auto has_span = false;
         if (current_token.to_string() == "span"sv) {
-            grid_track_placement.set_has_span(true);
+            has_span = true;
             tokens.skip_whitespace();
             current_token = tokens.next_token().token();
         }
-        if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
+        if (current_token.is(Token::Type::Number) && current_token.number().is_integer()) {
             grid_track_placement.set_position(static_cast<int>(current_token.number_value()));
+            grid_track_placement.set_has_span(has_span);
+        }
         return grid_track_placement;
     };
 

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -256,6 +256,8 @@ float FormattingContext::compute_auto_height_for_block_level_element(LayoutState
     auto display = box.computed_values().display();
     if (display.is_flex_inside())
         return box_state.content_height();
+    if (display.is_grid_inside())
+        return box_state.content_height();
 
     // https://www.w3.org/TR/CSS22/visudet.html#normal-block
     // 10.6.3 Block-level non-replaced elements in normal flow when 'overflow' computes to 'visible'

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -369,8 +369,14 @@ void GridFormattingContext::run(Box const& box, LayoutMode)
         // FIXME: 4.2. For dense packing:
     }
 
+    auto& box_state = m_state.get_mutable(box);
     for (auto& positioned_box : positioned_boxes) {
+        auto& child_box_state = m_state.get_mutable(positioned_box.box);
+        if (child_box_state.content_height() > positioned_box.computed_height)
+            positioned_box.computed_height = child_box_state.content_height();
         (void)layout_inside(positioned_box.box, LayoutMode::Normal);
+        if (child_box_state.content_height() > positioned_box.computed_height)
+            positioned_box.computed_height = child_box_state.content_height();
     }
 
     // https://drafts.csswg.org/css-grid/#overview-sizing
@@ -992,6 +998,11 @@ void GridFormattingContext::run(Box const& box, LayoutMode)
 
     for (auto& positioned_box : positioned_boxes)
         layout_box(positioned_box.row, positioned_box.row + positioned_box.row_span, positioned_box.column, positioned_box.column + positioned_box.column_span, positioned_box.box);
+
+    float total_y = 0;
+    for (auto& grid_row : grid_rows)
+        total_y += grid_row.base_size;
+    box_state.set_content_height(total_y);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -923,6 +923,48 @@ void GridFormattingContext::run(Box const& box, LayoutMode)
     // track’s base size, restart this algorithm treating all such tracks as inflexible.
 
     // 5. Return the hypothetical fr size.
+
+    // https://drafts.csswg.org/css-grid/#algo-stretch
+    // 12.8. Stretch auto Tracks
+
+    // When the content-distribution property of the grid container is normal or stretch in this axis,
+    // this step expands tracks that have an auto max track sizing function by dividing any remaining
+    // positive, definite free space equally amongst them. If the free space is indefinite, but the grid
+    // container has a definite min-width/height, use that size to calculate the free space for this
+    // step instead.
+    float used_horizontal_space = 0;
+    for (auto& grid_column : grid_columns) {
+        if (!(grid_column.max_track_sizing_function.is_length() && grid_column.max_track_sizing_function.length().is_auto()))
+            used_horizontal_space += grid_column.base_size;
+    }
+
+    float remaining_horizontal_space = box_state.content_width() - used_horizontal_space;
+    auto count_of_auto_max_column_tracks = 0;
+    for (auto& grid_column : grid_columns) {
+        if (grid_column.max_track_sizing_function.is_length() && grid_column.max_track_sizing_function.length().is_auto())
+            count_of_auto_max_column_tracks++;
+    }
+    for (auto& grid_column : grid_columns) {
+        if (grid_column.max_track_sizing_function.is_length() && grid_column.max_track_sizing_function.length().is_auto())
+            grid_column.base_size = max(grid_column.base_size, remaining_horizontal_space / count_of_auto_max_column_tracks);
+    }
+
+    float used_vertical_space = 0;
+    for (auto& grid_row : grid_rows) {
+        if (!(grid_row.max_track_sizing_function.is_length() && grid_row.max_track_sizing_function.length().is_auto()))
+            used_vertical_space += grid_row.base_size;
+    }
+
+    float remaining_vertical_space = box_state.content_height() - used_vertical_space;
+    auto count_of_auto_max_row_tracks = 0;
+    for (auto& grid_row : grid_rows) {
+        if (grid_row.max_track_sizing_function.is_length() && grid_row.max_track_sizing_function.length().is_auto())
+            count_of_auto_max_row_tracks++;
+    }
+    for (auto& grid_row : grid_rows) {
+        if (grid_row.max_track_sizing_function.is_length() && grid_row.max_track_sizing_function.length().is_auto())
+            grid_row.base_size = max(grid_row.base_size, remaining_vertical_space / count_of_auto_max_row_tracks);
+    }
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -35,10 +35,53 @@ void GridFormattingContext::run(Box const& box, LayoutMode)
         return false;
     };
 
+    // https://drafts.csswg.org/css-grid/#overview-placement
+    // 2.2. Placing Items
+    // The contents of the grid container are organized into individual grid items (analogous to
+    // flex items), which are then assigned to predefined areas in the grid. They can be explicitly
+    // placed using coordinates through the grid-placement properties or implicitly placed into
+    // empty areas using auto-placement.
+
     Vector<Vector<bool>> occupation_grid;
     Vector<bool> occupation_grid_row;
     for (int column_index = 0; column_index < max((int)box.computed_values().grid_template_columns().size(), 1); column_index++)
         occupation_grid_row.append(false);
     for (int row_index = 0; row_index < max((int)box.computed_values().grid_template_rows().size(), 1); row_index++)
         occupation_grid.append(occupation_grid_row);
+
+    Vector<Box const&> boxes_to_place;
+    box.for_each_child_of_type<Box>([&](Box& child_box) {
+        if (should_skip_is_anonymous_text_run(child_box))
+            return IterationDecision::Continue;
+        boxes_to_place.append(child_box);
+        return IterationDecision::Continue;
+    });
+
+    // https://drafts.csswg.org/css-grid/#auto-placement-algo
+    // 8.5. Grid Item Placement Algorithm
+
+    // 0. Generate anonymous grid items
+
+    // 1. Position anything that's not auto-positioned.
+
+    // 2. Process the items locked to a given row.
+
+    // 3. Determine the columns in the implicit grid.
+
+    // 3.1. Start with the columns from the explicit grid.
+
+    // 3.2. Among all the items with a definite column position (explicitly positioned items, items
+    // positioned in the previous step, and items not yet positioned but with a definite column) add
+    // columns to the beginning and end of the implicit grid as necessary to accommodate those items.
+    // NOTE: "Explicitly positioned items" and "items positioned in the previous step" done in step 1
+    // and 2, respectively. Adding columns for "items not yet positioned but with a definite column"
+    // will be done in step 4.
+
+    // 3.3. If the largest column span among all the items without a definite column position is larger
+    // than the width of the implicit grid, add columns to the end of the implicit grid to accommodate
+    // that column span.
+
+    // 4. Position the remaining grid items.
+    // For each grid item that hasn't been positioned by the previous steps, in order-modified document
+    // order:
 }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -368,6 +368,45 @@ void GridFormattingContext::run(Box const& box, LayoutMode)
 
         // FIXME: 4.2. For dense packing:
     }
+
+    // https://drafts.csswg.org/css-grid/#overview-sizing
+    // 2.3. Sizing the Grid
+    // Once the grid items have been placed, the sizes of the grid tracks (rows and columns) are
+    // calculated, accounting for the sizes of their contents and/or available space as specified in
+    // the grid definition.
+
+    // https://drafts.csswg.org/css-grid/#layout-algorithm
+    // 12. Grid Sizing
+    // This section defines the grid sizing algorithm, which determines the size of all grid tracks and,
+    // by extension, the entire grid.
+
+    // Each track has specified minimum and maximum sizing functions (which may be the same). Each
+    // sizing function is either:
+
+    // - A fixed sizing function (<length> or resolvable <percentage>).
+    // - An intrinsic sizing function (min-content, max-content, auto, fit-content()).
+    // - A flexible sizing function (<flex>).
+
+    // The grid sizing algorithm defines how to resolve these sizing constraints into used track sizes.
+
+    struct GridTrack {
+        CSS::GridTrackSize min_track_sizing_function;
+        CSS::GridTrackSize max_track_sizing_function;
+        float base_size { 0 };
+        float growth_limit { 0 };
+    };
+    Vector<GridTrack> grid_rows;
+    Vector<GridTrack> grid_columns;
+
+    for (auto& column_size : box.computed_values().grid_template_columns())
+        grid_columns.append({ column_size, column_size });
+    for (auto& row_size : box.computed_values().grid_template_rows())
+        grid_rows.append({ row_size, row_size });
+
+    for (int column_index = grid_columns.size(); column_index < static_cast<int>(occupation_grid[0].size()); column_index++)
+        grid_columns.append({ CSS::GridTrackSize::make_auto(), CSS::GridTrackSize::make_auto() });
+    for (int row_index = grid_rows.size(); row_index < static_cast<int>(occupation_grid.size()); row_index++)
+        grid_rows.append({ CSS::GridTrackSize::make_auto(), CSS::GridTrackSize::make_auto() });
 }
 
 }


### PR DESCRIPTION
Continue with the implementation of the `display: grid`.

Adds ability to define cell positions and sizes with greater detail.

![Screenshot from 2022-09-07 16-05-40](https://user-images.githubusercontent.com/45781926/189976537-e44db5b5-de5d-4ec2-a0e6-a11681017e7e.png)
