### PR TITLE
HexEditor: Implement undo and redo actions

### DIFF
--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -24,6 +24,7 @@ public:
 
     virtual ~HexDocument() = default;
     virtual Cell get(size_t position) = 0;
+    virtual u8 get_unchanged(size_t position) = 0;
     virtual void set(size_t position, u8 value);
     virtual size_t size() const = 0;
     virtual Type type() const = 0;
@@ -40,6 +41,7 @@ public:
     virtual ~HexDocumentMemory() = default;
 
     Cell get(size_t position) override;
+    u8 get_unchanged(size_t position) override;
     size_t size() const override;
     Type type() const override;
     void clear_changes() override;
@@ -61,11 +63,14 @@ public:
     void write_to_file();
     bool write_to_file(NonnullRefPtr<Core::File> file);
     Cell get(size_t position) override;
+    u8 get_unchanged(size_t position) override;
     size_t size() const override;
     Type type() const override;
     void clear_changes() override;
 
 private:
+    void ensure_position_in_buffer(size_t position);
+
     NonnullRefPtr<Core::File> m_file;
     size_t m_file_size;
 

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -518,7 +518,7 @@ void HexEditor::update_status()
 void HexEditor::did_change()
 {
     if (on_change)
-        on_change();
+        on_change(m_document->is_dirty());
 }
 
 void HexEditor::paint_event(GUI::PaintEvent& event)

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -59,7 +59,7 @@ public:
     Vector<Match> find_all(ByteBuffer& needle, size_t start = 0);
     Vector<Match> find_all_strings(size_t min_length = 4);
     Function<void(size_t, EditMode, size_t, size_t)> on_status_change; // position, edit mode, selection start, selection end
-    Function<void()> on_change;
+    Function<void(bool is_document_dirty)> on_change;
 
 protected:
     HexEditor();

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -19,6 +19,7 @@
 #include <AK/StdLibExtras.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/AbstractScrollableWidget.h>
+#include <LibGUI/UndoStack.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/TextAlignment.h>
 
@@ -39,6 +40,10 @@ public:
     Optional<u8> get_byte(size_t position);
     bool save_as(NonnullRefPtr<Core::File>);
     bool save();
+
+    bool undo();
+    bool redo();
+    GUI::UndoStack& undo_stack();
 
     void select_all();
     bool has_selection() const { return m_selection_start < m_selection_end && m_document->size() > 0; }
@@ -83,6 +88,7 @@ private:
     NonnullRefPtr<Core::Timer> m_blink_timer;
     bool m_cursor_blink_active { false };
     NonnullOwnPtr<HexDocument> m_document;
+    GUI::UndoStack m_undo_stack;
 
     static constexpr int m_address_bar_width = 90;
     static constexpr int m_padding = 5;
@@ -101,6 +107,8 @@ private:
     void set_content_length(size_t); // I might make this public if I add fetching data on demand.
     void update_status();
     void did_change();
+    void did_complete_action(size_t position, u8 old_value, u8 new_value);
+    void did_complete_action(size_t position, ByteBuffer&& old_values, ByteBuffer&& new_values);
 
     void reset_cursor_blink_state();
 };

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -83,6 +83,11 @@ HexEditorWidget::HexEditorWidget()
         window()->set_modified(is_document_dirty);
     };
 
+    m_editor->undo_stack().on_state_change = [this] {
+        m_undo_action->set_enabled(m_editor->undo_stack().can_undo());
+        m_redo_action->set_enabled(m_editor->undo_stack().can_redo());
+    };
+
     m_search_results->set_activates_on_selection(true);
     m_search_results->on_activation = [this](const GUI::ModelIndex& index) {
         if (!index.is_valid())
@@ -150,6 +155,16 @@ HexEditorWidget::HexEditorWidget()
         set_path(file->filename());
         dbgln("Wrote document to {}", file->filename());
     });
+
+    m_undo_action = GUI::CommonActions::make_undo_action([&](auto&) {
+        m_editor->undo();
+    });
+    m_undo_action->set_enabled(false);
+
+    m_redo_action = GUI::CommonActions::make_redo_action([&](auto&) {
+        m_editor->redo();
+    });
+    m_redo_action->set_enabled(false);
 
     m_find_action = GUI::Action::create("&Find", { Mod_Ctrl, Key_F }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/find.png"sv).release_value_but_fixme_should_propagate_errors(), [&](const GUI::Action&) {
         auto old_buffer = m_search_buffer;
@@ -242,6 +257,9 @@ HexEditorWidget::HexEditorWidget()
     m_toolbar->add_action(*m_new_action);
     m_toolbar->add_action(*m_open_action);
     m_toolbar->add_action(*m_save_action);
+    m_toolbar->add_separator();
+    m_toolbar->add_action(*m_undo_action);
+    m_toolbar->add_action(*m_redo_action);
     m_toolbar->add_separator();
     m_toolbar->add_action(*m_find_action);
     m_toolbar->add_action(*m_goto_offset_action);
@@ -378,6 +396,9 @@ void HexEditorWidget::initialize_menubar(GUI::Window& window)
     }));
 
     auto& edit_menu = window.add_menu("&Edit");
+    edit_menu.add_action(*m_undo_action);
+    edit_menu.add_action(*m_redo_action);
+    edit_menu.add_separator();
     edit_menu.add_action(GUI::CommonActions::make_select_all_action([this](auto&) {
         m_editor->select_all();
         m_editor->update();

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -79,8 +79,8 @@ HexEditorWidget::HexEditorWidget()
         m_selecting_from_inspector = false;
     };
 
-    m_editor->on_change = [this] {
-        window()->set_modified(true);
+    m_editor->on_change = [this](bool is_document_dirty) {
+        window()->set_modified(is_document_dirty);
     };
 
     m_search_results->set_activates_on_selection(true);

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -53,6 +53,10 @@ private:
     RefPtr<GUI::Action> m_open_action;
     RefPtr<GUI::Action> m_save_action;
     RefPtr<GUI::Action> m_save_as_action;
+
+    RefPtr<GUI::Action> m_undo_action;
+    RefPtr<GUI::Action> m_redo_action;
+
     RefPtr<GUI::Action> m_find_action;
     RefPtr<GUI::Action> m_goto_offset_action;
     RefPtr<GUI::Action> m_layout_toolbar_action;


### PR DESCRIPTION
This PR adds undo redo functionality to HexEditor and fixes the window being marked dirty even when no bytes are actually modified.