### PR TITLE
Ports: Build Quake in parallel

### DIFF
--- a/Ports/quake/package.sh
+++ b/Ports/quake/package.sh
@@ -4,7 +4,7 @@ version=0.65
 workdir=SerenityQuake-master
 useconfigure=false
 files="https://github.com/SerenityPorts/SerenityQuake/archive/master.tar.gz quake.tar.gz"
-makeopts=("V=1" "SYMBOLS_ON=Y")
+makeopts+=("V=1" "SYMBOLS_ON=Y")
 depends=("SDL2")
 launcher_name=Quake
 launcher_category=Games


### PR DESCRIPTION
Instead of overwriting the existing `-j` makeopt, we only append options. This brings the build time for the Quake port down from 24.3s to 4.4s on my machine.