### PR TITLE
LibGL: Set correct color material mode for `GL_AMBIENT_AND_DIFFUSE`

### DIFF
--- a/Userland/Libraries/LibGL/Lighting.cpp
+++ b/Userland/Libraries/LibGL/Lighting.cpp
@@ -510,8 +510,7 @@ void GLContext::sync_light_state()
         options.color_material_mode = GPU::ColorMaterialMode::Ambient;
         break;
     case GL_AMBIENT_AND_DIFFUSE:
-        options.color_material_mode = GPU::ColorMaterialMode::Ambient;
-        options.color_material_mode = GPU::ColorMaterialMode::Diffuse;
+        options.color_material_mode = GPU::ColorMaterialMode::AmbientAndDiffuse;
         break;
     case GL_DIFFUSE:
         options.color_material_mode = GPU::ColorMaterialMode::Diffuse;


### PR DESCRIPTION
This was a silly mistake :^)