### PR TITLE
Kernel: Use more fine-grained content data block granularity in TmpFS 

### DIFF
--- a/Tests/LibC/TestIo.cpp
+++ b/Tests/LibC/TestIo.cpp
@@ -294,8 +294,7 @@ TEST_CASE(tmpfs_massive_file)
     [[maybe_unused]] auto ignored = strlcpy(buffer, "abcdefghijklmno", sizeof(buffer) - 1);
 
     rc = write(fd, buffer, sizeof(buffer));
-    EXPECT_EQ(rc, -1);
-    EXPECT_EQ(errno, ENOMEM);
+    EXPECT_EQ(rc, 16);
 
     // ok now, write something to it, and try again
     rc = lseek(fd, 0, SEEK_SET);
@@ -307,10 +306,9 @@ TEST_CASE(tmpfs_massive_file)
     rc = lseek(fd, INT32_MAX, SEEK_SET);
     EXPECT_EQ(rc, INT32_MAX);
 
-    // FIXME: Should this return EOVERFLOW? Or is a 0 read fine?
     memset(buffer, 0, sizeof(buffer));
     rc = read(fd, buffer, sizeof(buffer));
-    EXPECT_EQ(rc, 0);
+    EXPECT_EQ(rc, 16);
     EXPECT(buffer != "abcdefghijklmno"sv);
 
     rc = close(fd);


### PR DESCRIPTION
Relies on #14785.