### PR TITLE
LibC: Make recursive pthread mutexes reentrancy-safe

### DIFF
--- a/Kernel/API/POSIX/sys/types.h
+++ b/Kernel/API/POSIX/sys/types.h
@@ -67,7 +67,6 @@ typedef uint32_t pthread_once_t;
 
 typedef struct __pthread_mutex_t {
     uint32_t lock;
-    pthread_t owner;
     int level;
     int type;
 } pthread_mutex_t;

--- a/Userland/Libraries/LibC/bits/pthread_integration.h
+++ b/Userland/Libraries/LibC/bits/pthread_integration.h
@@ -26,14 +26,14 @@ void __pthread_key_destroy_for_current_thread(void);
 
 #define __PTHREAD_MUTEX_NORMAL 0
 #define __PTHREAD_MUTEX_RECURSIVE 1
-#define __PTHREAD_MUTEX_INITIALIZER     \
-    {                                   \
-        0, 0, 0, __PTHREAD_MUTEX_NORMAL \
+#define __PTHREAD_MUTEX_INITIALIZER  \
+    {                                \
+        0, 0, __PTHREAD_MUTEX_NORMAL \
     }
 
 #define __PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP \
     {                                            \
-        0, 0, 0, __PTHREAD_MUTEX_RECURSIVE       \
+        0, 0, __PTHREAD_MUTEX_RECURSIVE          \
     }
 
 __END_DECLS

--- a/Userland/Libraries/LibC/pthread_integration.cpp
+++ b/Userland/Libraries/LibC/pthread_integration.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, the SerenityOS developers.
+ * Copyright (c) 2022, Idan Horowitz <idan.horowitz@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -94,14 +95,15 @@ int pthread_self()
 }
 
 static constexpr u32 MUTEX_UNLOCKED = 0;
-static constexpr u32 MUTEX_LOCKED_NO_NEED_TO_WAKE = 1;
-static constexpr u32 MUTEX_LOCKED_NEED_TO_WAKE = 2;
+static constexpr u32 MUTEX_LOCKED_NO_NEED_TO_WAKE = 0x40000000;
+static constexpr u32 MUTEX_NEED_TO_WAKE = 0x80000000;
+static constexpr u32 MUTEX_LOCKED_NEED_TO_WAKE = MUTEX_LOCKED_NO_NEED_TO_WAKE | MUTEX_NEED_TO_WAKE;
+static constexpr u32 MUTEX_OWNER_MASK = 0x3FFFFFFF;
 
 // https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_mutex_init.html
 int pthread_mutex_init(pthread_mutex_t* mutex, pthread_mutexattr_t const* attributes)
 {
     mutex->lock = 0;
-    mutex->owner = 0;
     mutex->level = 0;
     mutex->type = attributes ? attributes->type : __PTHREAD_MUTEX_NORMAL;
     return 0;
@@ -111,15 +113,16 @@ int pthread_mutex_init(pthread_mutex_t* mutex, pthread_mutexattr_t const* attrib
 int pthread_mutex_trylock(pthread_mutex_t* mutex)
 {
     u32 expected = MUTEX_UNLOCKED;
-    bool exchanged = AK::atomic_compare_exchange_strong(&mutex->lock, expected, MUTEX_LOCKED_NO_NEED_TO_WAKE, AK::memory_order_acquire);
+    u32 desired = MUTEX_LOCKED_NO_NEED_TO_WAKE;
+    if (mutex->type == __PTHREAD_MUTEX_RECURSIVE)
+        desired |= pthread_self();
+    bool exchanged = AK::atomic_compare_exchange_strong(&mutex->lock, expected, desired, AK::memory_order_acquire);
 
     if (exchanged) [[likely]] {
-        if (mutex->type == __PTHREAD_MUTEX_RECURSIVE)
-            AK::atomic_store(&mutex->owner, pthread_self(), AK::memory_order_relaxed);
         mutex->level = 0;
         return 0;
     } else if (mutex->type == __PTHREAD_MUTEX_RECURSIVE) {
-        pthread_t owner = AK::atomic_load(&mutex->owner, AK::memory_order_relaxed);
+        pthread_t owner = expected & MUTEX_OWNER_MASK;
         if (owner == pthread_self()) {
             // We already own the mutex!
             mutex->level++;
@@ -134,14 +137,15 @@ int pthread_mutex_lock(pthread_mutex_t* mutex)
 {
     // Fast path: attempt to claim the mutex without waiting.
     u32 value = MUTEX_UNLOCKED;
-    bool exchanged = AK::atomic_compare_exchange_strong(&mutex->lock, value, MUTEX_LOCKED_NO_NEED_TO_WAKE, AK::memory_order_acquire);
+    u32 desired = MUTEX_LOCKED_NO_NEED_TO_WAKE;
+    if (mutex->type == __PTHREAD_MUTEX_RECURSIVE)
+        desired |= pthread_self();
+    bool exchanged = AK::atomic_compare_exchange_strong(&mutex->lock, value, desired, AK::memory_order_acquire);
     if (exchanged) [[likely]] {
-        if (mutex->type == __PTHREAD_MUTEX_RECURSIVE)
-            AK::atomic_store(&mutex->owner, pthread_self(), AK::memory_order_relaxed);
         mutex->level = 0;
         return 0;
     } else if (mutex->type == __PTHREAD_MUTEX_RECURSIVE) {
-        pthread_t owner = AK::atomic_load(&mutex->owner, AK::memory_order_relaxed);
+        pthread_t owner = value & MUTEX_OWNER_MASK;
         if (owner == pthread_self()) {
             // We already own the mutex!
             mutex->level++;
@@ -151,16 +155,18 @@ int pthread_mutex_lock(pthread_mutex_t* mutex)
 
     // Slow path: wait, record the fact that we're going to wait, and always
     // remember to wake the next thread up once we release the mutex.
-    if (value != MUTEX_LOCKED_NEED_TO_WAKE)
-        value = AK::atomic_exchange(&mutex->lock, MUTEX_LOCKED_NEED_TO_WAKE, AK::memory_order_acquire);
+    value = AK::atomic_fetch_or(&mutex->lock, MUTEX_NEED_TO_WAKE, AK::memory_order_acquire);
 
-    while (value != MUTEX_UNLOCKED) {
-        futex_wait(&mutex->lock, value, nullptr, 0, false);
-        value = AK::atomic_exchange(&mutex->lock, MUTEX_LOCKED_NEED_TO_WAKE, AK::memory_order_acquire);
+    desired |= MUTEX_NEED_TO_WAKE;
+    if (value == MUTEX_UNLOCKED) {
+        AK::atomic_store(&mutex->lock, desired, AK::memory_order_relaxed);
+    } else {
+        do {
+            futex_wait(&mutex->lock, value, nullptr, 0, false);
+            value = MUTEX_UNLOCKED;
+        } while (!AK::atomic_compare_exchange_strong(&mutex->lock, value, desired, AK::memory_order_acquire));
     }
 
-    if (mutex->type == __PTHREAD_MUTEX_RECURSIVE)
-        AK::atomic_store(&mutex->owner, pthread_self(), AK::memory_order_relaxed);
     mutex->level = 0;
     return 0;
 }
@@ -170,14 +176,19 @@ int __pthread_mutex_lock_pessimistic_np(pthread_mutex_t* mutex)
     // Same as pthread_mutex_lock(), but always set MUTEX_LOCKED_NEED_TO_WAKE,
     // and also don't bother checking for already owning the mutex recursively,
     // because we know we don't. Used in the condition variable implementation.
-    u32 value = AK::atomic_exchange(&mutex->lock, MUTEX_LOCKED_NEED_TO_WAKE, AK::memory_order_acquire);
-    while (value != MUTEX_UNLOCKED) {
-        futex_wait(&mutex->lock, value, nullptr, 0, false);
-        value = AK::atomic_exchange(&mutex->lock, MUTEX_LOCKED_NEED_TO_WAKE, AK::memory_order_acquire);
+    u32 value = AK::atomic_fetch_or(&mutex->lock, MUTEX_NEED_TO_WAKE, AK::memory_order_acquire);
+    u32 desired = MUTEX_LOCKED_NEED_TO_WAKE;
+    if (mutex->type == __PTHREAD_MUTEX_RECURSIVE)
+        desired |= pthread_self();
+    if (value == MUTEX_UNLOCKED) {
+        AK::atomic_store(&mutex->lock, desired, AK::memory_order_relaxed);
+    } else {
+        do {
+            futex_wait(&mutex->lock, value, nullptr, 0, false);
+            value = MUTEX_UNLOCKED;
+        } while (!AK::atomic_compare_exchange_strong(&mutex->lock, value, desired, AK::memory_order_acquire));
     }
 
-    if (mutex->type == __PTHREAD_MUTEX_RECURSIVE)
-        AK::atomic_store(&mutex->owner, pthread_self(), AK::memory_order_relaxed);
     mutex->level = 0;
     return 0;
 }
@@ -190,11 +201,8 @@ int pthread_mutex_unlock(pthread_mutex_t* mutex)
         return 0;
     }
 
-    if (mutex->type == __PTHREAD_MUTEX_RECURSIVE)
-        AK::atomic_store(&mutex->owner, 0, AK::memory_order_relaxed);
-
     u32 value = AK::atomic_exchange(&mutex->lock, MUTEX_UNLOCKED, AK::memory_order_release);
-    if (value == MUTEX_LOCKED_NEED_TO_WAKE) [[unlikely]] {
+    if (value & MUTEX_NEED_TO_WAKE) [[unlikely]] {
         int rc = futex_wake(&mutex->lock, 1, false);
         VERIFY(rc >= 0);
     }

--- a/Userland/Utilities/test-pthread.cpp
+++ b/Userland/Utilities/test-pthread.cpp
@@ -99,7 +99,8 @@ static ErrorOr<void> test_semaphore_as_lock()
 
     VERIFY(v.size() == threads_count * num_times);
     VERIFY(sem_trywait(&semaphore) == 0);
-    VERIFY(sem_trywait(&semaphore) == EAGAIN);
+    VERIFY(sem_trywait(&semaphore) == -1);
+    VERIFY(errno == EAGAIN);
 
     return {};
 }
@@ -128,7 +129,8 @@ static ErrorOr<void> test_semaphore_as_event()
     [[maybe_unused]] auto r1 = reader->join();
     [[maybe_unused]] auto r2 = writer->join();
 
-    VERIFY(sem_trywait(&semaphore) == EAGAIN);
+    VERIFY(sem_trywait(&semaphore) == -1);
+    VERIFY(errno == EAGAIN);
 
     return {};
 }
@@ -171,7 +173,8 @@ static ErrorOr<void> test_semaphore_nonbinary()
     for (size_t i = 0; i < num; i++) {
         VERIFY(sem_trywait(&semaphore) == 0);
     }
-    VERIFY(sem_trywait(&semaphore) == EAGAIN);
+    VERIFY(sem_trywait(&semaphore) == -1);
+    VERIFY(errno == EAGAIN);
 
     return {};
 }


### PR DESCRIPTION
This lets us use recursive mutexes in signal handlers, which in turn makes outln work in signal handlers.