### PR TITLE
Keymap: Rename context menu item "Settings" to "Keyboard Settings"

### DIFF
--- a/Userland/Applets/Keymap/KeymapStatusWidget.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWidget.cpp
@@ -50,7 +50,7 @@ ErrorOr<void> KeymapStatusWidget::refresh_menu()
 
     auto settings_icon = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/settings.png"sv));
 
-    m_context_menu->add_action(GUI::Action::create("&Settings",
+    m_context_menu->add_action(GUI::Action::create("Keyboard &Settings",
         settings_icon,
         [&](auto&) {
             GUI::Process::spawn_or_show_error(window(), "/bin/KeyboardSettings"sv);


### PR DESCRIPTION
This is a very small change to improve consistency between applet context menu item names.