### PR TITLE
LibWeb: Set prototype for both TextDecoder and AbortSignal

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -19,6 +19,7 @@ JS::NonnullGCPtr<AbortSignal> AbortSignal::create_with_global_object(HTML::Windo
 AbortSignal::AbortSignal(HTML::Window& window)
     : EventTarget(window.realm())
 {
+    set_prototype(&window.cached_web_prototype("AbortSignal"));
 }
 
 // https://dom.spec.whatwg.org/#abortsignal-add

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -29,6 +29,7 @@ TextDecoder::TextDecoder(HTML::Window& window, TextCodec::Decoder& decoder, FlyS
     , m_fatal(fatal)
     , m_ignore_bom(ignore_bom)
 {
+    set_prototype(&window.cached_web_prototype("TextDecoder"));
 }
 
 TextDecoder::~TextDecoder() = default;


### PR DESCRIPTION
These were forgotten to be set during the GC heap conversion.