### PR TITLE
Userland: Move HID input device nodes to /dev/input/{mouse,keyboard}, Unveil only subdirectories in /dev directory for WindowServer

### DIFF
--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -21,7 +21,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     TRY(Core::System::unveil("/bin/keymap", "x"));
     TRY(Core::System::unveil("/etc/Keyboard.ini", "r"));
-    TRY(Core::System::unveil("/dev/keyboard0", "r"));
+    TRY(Core::System::unveil("/dev/input/keyboard/0", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
     auto mapper_config = TRY(Core::ConfigFile::open("/etc/Keyboard.ini"));
     auto keymaps = mapper_config->read_entry("Mapping", "Keymaps", "");
@@ -38,7 +38,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     }
 
     bool enable_num_lock = keyboard_settings_config->read_bool_entry("StartupEnable", "NumLock", true);
-    auto keyboard_device = TRY(Core::File::open("/dev/keyboard0", Core::OpenMode::ReadOnly));
+    auto keyboard_device = TRY(Core::File::open("/dev/input/keyboard/0", Core::OpenMode::ReadOnly));
     TRY(Core::System::ioctl(keyboard_device->fd(), KEYBOARD_IOCTL_SET_NUM_LOCK, enable_num_lock));
 
     return 0;

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -218,7 +218,7 @@ static void populate_devtmpfs_devices_based_on_devctl()
             if (!is_block_device) {
                 switch (minor_number) {
                 case 0: {
-                    create_devtmpfs_char_device("/dev/mouse0", 0660, 10, 0);
+                    create_devtmpfs_char_device("/dev/input/mouse/0", 0660, 10, 0);
                     break;
                 }
                 case 183: {
@@ -235,7 +235,7 @@ static void populate_devtmpfs_devices_based_on_devctl()
             if (!is_block_device) {
                 switch (minor_number) {
                 case 0: {
-                    create_devtmpfs_char_device("/dev/keyboard0", 0660, 85, 0);
+                    create_devtmpfs_char_device("/dev/input/keyboard/0", 0660, 85, 0);
                     break;
                 }
                 default:
@@ -375,6 +375,9 @@ static ErrorOr<void> prepare_synthetic_filesystems()
     TRY(Core::System::mount(-1, "/dev"sv, "dev"sv, 0));
 
     TRY(Core::System::mkdir("/dev/audio"sv, 0755));
+    TRY(Core::System::mkdir("/dev/input"sv, 0755));
+    TRY(Core::System::mkdir("/dev/input/keyboard"sv, 0755));
+    TRY(Core::System::mkdir("/dev/input/mouse"sv, 0755));
 
     TRY(Core::System::symlink("/proc/self/fd/0"sv, "/dev/stdin"sv));
     TRY(Core::System::symlink("/proc/self/fd/1"sv, "/dev/stdout"sv));
@@ -406,8 +409,8 @@ static ErrorOr<void> prepare_synthetic_filesystems()
         return result;
     };
 
-    TRY(filter_chown_ENOENT(Core::System::chown("/dev/keyboard0"sv, 0, phys_group.value().gr_gid)));
-    TRY(filter_chown_ENOENT(Core::System::chown("/dev/mouse0"sv, 0, phys_group.value().gr_gid)));
+    TRY(filter_chown_ENOENT(Core::System::chown("/dev/input/keyboard/0"sv, 0, phys_group.value().gr_gid)));
+    TRY(filter_chown_ENOENT(Core::System::chown("/dev/input/mouse/0"sv, 0, phys_group.value().gr_gid)));
 
     auto tty_group = TRY(Core::System::getgrnam("tty"sv));
     VERIFY(tty_group.has_value());

--- a/Userland/Services/WindowServer/EventLoop.cpp
+++ b/Userland/Services/WindowServer/EventLoop.cpp
@@ -20,8 +20,8 @@ namespace WindowServer {
 
 EventLoop::EventLoop()
 {
-    m_keyboard_fd = open("/dev/keyboard0", O_RDONLY | O_NONBLOCK | O_CLOEXEC);
-    m_mouse_fd = open("/dev/mouse0", O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+    m_keyboard_fd = open("/dev/input/keyboard/0", O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+    m_mouse_fd = open("/dev/input/mouse/0", O_RDONLY | O_NONBLOCK | O_CLOEXEC);
 
     m_window_server = MUST(IPC::MultiServer<ConnectionFromClient>::try_create("/tmp/portal/window"));
     m_wm_server = MUST(IPC::MultiServer<WMConnectionFromClient>::try_create("/tmp/portal/wm"));
@@ -30,14 +30,14 @@ EventLoop::EventLoop()
         m_keyboard_notifier = Core::Notifier::construct(m_keyboard_fd, Core::Notifier::Read);
         m_keyboard_notifier->on_ready_to_read = [this] { drain_keyboard(); };
     } else {
-        dbgln("Couldn't open /dev/keyboard0");
+        dbgln("Couldn't open /dev/input/keyboard/0");
     }
 
     if (m_mouse_fd >= 0) {
         m_mouse_notifier = Core::Notifier::construct(m_mouse_fd, Core::Notifier::Read);
         m_mouse_notifier->on_ready_to_read = [this] { drain_mouse(); };
     } else {
-        dbgln("Couldn't open /dev/mouse0");
+        dbgln("Couldn't open /dev/input/mouse/0");
     }
 }
 

--- a/Userland/Services/WindowServer/main.cpp
+++ b/Userland/Services/WindowServer/main.cpp
@@ -27,7 +27,9 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/tmp", "cw"));
     TRY(Core::System::unveil("/etc/WindowServer.ini", "rwc"));
     TRY(Core::System::unveil("/etc/Keyboard.ini", "r"));
-    TRY(Core::System::unveil("/dev", "rw"));
+    TRY(Core::System::unveil("/dev/tty", "rw"));
+    TRY(Core::System::unveil("/dev/gpu/", "rw"));
+    TRY(Core::System::unveil("/dev/input/", "rw"));
     TRY(Core::System::unveil("/bin/keymap", "x"));
     TRY(Core::System::unveil("/proc/keymap", "r"));
 
@@ -135,10 +137,6 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto mm = WindowServer::MenuManager::construct();
 
     TRY(Core::System::unveil("/tmp", ""));
-
-    // NOTE: Because we dynamically need to be able to open new /dev/gpu/connector*
-    // devices we can't really unveil all of /dev unless we have some
-    // other mechanism that can hand us file descriptors for these.
 
     TRY(Core::System::unveil(nullptr, nullptr));
 


### PR DESCRIPTION
Because HID devices are not always present in quantities of one per type it is more elegant and correct to put the representative device nodes in subdirectories for each HID device type.