### PR TITLE
LibWeb: Resolve some clang-tidy warnings in the CSS Parser

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2740,7 +2740,7 @@ auto Parser::extract_properties(Vector<DeclarationOrAtRule> const& declarations_
     return result;
 }
 
-PropertyOwningCSSStyleDeclaration* Parser::convert_to_style_declaration(Vector<DeclarationOrAtRule> declarations_and_at_rules)
+PropertyOwningCSSStyleDeclaration* Parser::convert_to_style_declaration(Vector<DeclarationOrAtRule> const& declarations_and_at_rules)
 {
     auto [properties, custom_properties] = extract_properties(declarations_and_at_rules);
     return PropertyOwningCSSStyleDeclaration::create(m_context.window_object(), move(properties), move(custom_properties));
@@ -5409,7 +5409,7 @@ RefPtr<StyleValue> Parser::parse_transform_origin_value(Vector<ComponentValue> c
         return {};
     };
 
-    auto make_list = [](NonnullRefPtr<StyleValue> x_value, NonnullRefPtr<StyleValue> y_value) -> NonnullRefPtr<StyleValueList> {
+    auto make_list = [](NonnullRefPtr<StyleValue> const& x_value, NonnullRefPtr<StyleValue> const& y_value) -> NonnullRefPtr<StyleValueList> {
         NonnullRefPtrVector<StyleValue> values;
         values.append(x_value);
         values.append(y_value);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3322,9 +3322,9 @@ Optional<Color> Parser::parse_rgb_or_hsl_color(StringView function_name, Vector<
             && params[1].is(Token::Type::Number)
             && params[2].is(Token::Type::Number)) {
 
-            u8 r_val = clamp(llround(params[0].number_value()), 0, 255);
-            u8 g_val = clamp(llround(params[1].number_value()), 0, 255);
-            u8 b_val = clamp(llround(params[2].number_value()), 0, 255);
+            u8 r_val = clamp(llroundf(params[0].number_value()), 0, 255);
+            u8 g_val = clamp(llroundf(params[1].number_value()), 0, 255);
+            u8 b_val = clamp(llroundf(params[2].number_value()), 0, 255);
 
             return Color(r_val, g_val, b_val, a_val);
         }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -183,7 +183,7 @@ Parser::ParsedStyleSheet Parser::parse_a_stylesheet(TokenStream<T>& tokens, Opti
 
     // 3. Create a new stylesheet, with its location set to location (or null, if location was not passed).
     ParsedStyleSheet style_sheet;
-    style_sheet.location = location;
+    style_sheet.location = move(location);
 
     // 4. Consume a list of rules from input, with the top-level flag set, and set the stylesheet’s value to the result.
     style_sheet.rules = consume_a_list_of_rules(tokens, TopLevel::Yes);
@@ -207,7 +207,7 @@ CSSStyleSheet* Parser::parse_as_css_stylesheet(Optional<AK::URL> location)
             rules.append(rule);
     }
 
-    auto* rule_list = CSSRuleList::create(m_context.window_object(), move(rules));
+    auto* rule_list = CSSRuleList::create(m_context.window_object(), rules);
     return CSSStyleSheet::create(m_context.window_object(), *rule_list, move(location));
 }
 
@@ -509,41 +509,40 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
             };
         };
 
-        if (pseudo_name.equals_ignoring_case("active"sv)) {
+        if (pseudo_name.equals_ignoring_case("active"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Active);
-        } else if (pseudo_name.equals_ignoring_case("checked"sv)) {
+        if (pseudo_name.equals_ignoring_case("checked"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Checked);
-        } else if (pseudo_name.equals_ignoring_case("disabled"sv)) {
+        if (pseudo_name.equals_ignoring_case("disabled"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Disabled);
-        } else if (pseudo_name.equals_ignoring_case("empty"sv)) {
+        if (pseudo_name.equals_ignoring_case("empty"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Empty);
-        } else if (pseudo_name.equals_ignoring_case("enabled"sv)) {
+        if (pseudo_name.equals_ignoring_case("enabled"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Enabled);
-        } else if (pseudo_name.equals_ignoring_case("first-child"sv)) {
+        if (pseudo_name.equals_ignoring_case("first-child"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::FirstChild);
-        } else if (pseudo_name.equals_ignoring_case("first-of-type"sv)) {
+        if (pseudo_name.equals_ignoring_case("first-of-type"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::FirstOfType);
-        } else if (pseudo_name.equals_ignoring_case("focus"sv)) {
+        if (pseudo_name.equals_ignoring_case("focus"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Focus);
-        } else if (pseudo_name.equals_ignoring_case("focus-within"sv)) {
+        if (pseudo_name.equals_ignoring_case("focus-within"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::FocusWithin);
-        } else if (pseudo_name.equals_ignoring_case("hover"sv)) {
+        if (pseudo_name.equals_ignoring_case("hover"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Hover);
-        } else if (pseudo_name.equals_ignoring_case("last-child"sv)) {
+        if (pseudo_name.equals_ignoring_case("last-child"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::LastChild);
-        } else if (pseudo_name.equals_ignoring_case("last-of-type"sv)) {
+        if (pseudo_name.equals_ignoring_case("last-of-type"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::LastOfType);
-        } else if (pseudo_name.equals_ignoring_case("link"sv)) {
+        if (pseudo_name.equals_ignoring_case("link"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Link);
-        } else if (pseudo_name.equals_ignoring_case("only-child"sv)) {
+        if (pseudo_name.equals_ignoring_case("only-child"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::OnlyChild);
-        } else if (pseudo_name.equals_ignoring_case("only-of-type"sv)) {
+        if (pseudo_name.equals_ignoring_case("only-of-type"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::OnlyOfType);
-        } else if (pseudo_name.equals_ignoring_case("root"sv)) {
+        if (pseudo_name.equals_ignoring_case("root"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Root);
-        } else if (pseudo_name.equals_ignoring_case("visited"sv)) {
+        if (pseudo_name.equals_ignoring_case("visited"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Visited);
-        }
 
         // Single-colon syntax allowed for ::after, ::before, ::first-letter and ::first-line for compatibility.
         // https://www.w3.org/TR/selectors/#pseudo-element-syntax
@@ -624,7 +623,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
                         : Selector::SimpleSelector::PseudoClass::Type::Where,
                     .argument_selector_list = move(argument_selector_list) }
             };
-        } else if (pseudo_function.name().equals_ignoring_case("not"sv)) {
+        }
+        if (pseudo_function.name().equals_ignoring_case("not"sv)) {
             auto function_token_stream = TokenStream(pseudo_function.values());
             auto not_selector = TRY(parse_a_selector_list(function_token_stream, SelectorType::Standalone));
 
@@ -634,7 +634,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
                     .type = Selector::SimpleSelector::PseudoClass::Type::Not,
                     .argument_selector_list = move(not_selector) }
             };
-        } else if (pseudo_function.name().equals_ignoring_case("lang"sv)) {
+        }
+        if (pseudo_function.name().equals_ignoring_case("lang"sv)) {
             if (pseudo_function.values().is_empty()) {
                 dbgln_if(CSS_PARSER_DEBUG, "Empty :lang() selector");
                 return ParseError::SyntaxError;
@@ -648,15 +649,15 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
                     .type = Selector::SimpleSelector::PseudoClass::Type::Lang,
                     .languages = move(languages) }
             };
-        } else if (pseudo_function.name().equals_ignoring_case("nth-child"sv)) {
-            return parse_nth_child_selector(Selector::SimpleSelector::PseudoClass::Type::NthChild, pseudo_function.values(), true);
-        } else if (pseudo_function.name().equals_ignoring_case("nth-last-child"sv)) {
-            return parse_nth_child_selector(Selector::SimpleSelector::PseudoClass::Type::NthLastChild, pseudo_function.values(), true);
-        } else if (pseudo_function.name().equals_ignoring_case("nth-of-type"sv)) {
-            return parse_nth_child_selector(Selector::SimpleSelector::PseudoClass::Type::NthOfType, pseudo_function.values(), false);
-        } else if (pseudo_function.name().equals_ignoring_case("nth-last-of-type"sv)) {
-            return parse_nth_child_selector(Selector::SimpleSelector::PseudoClass::Type::NthLastOfType, pseudo_function.values(), false);
         }
+        if (pseudo_function.name().equals_ignoring_case("nth-child"sv))
+            return parse_nth_child_selector(Selector::SimpleSelector::PseudoClass::Type::NthChild, pseudo_function.values(), true);
+        if (pseudo_function.name().equals_ignoring_case("nth-last-child"sv))
+            return parse_nth_child_selector(Selector::SimpleSelector::PseudoClass::Type::NthLastChild, pseudo_function.values(), true);
+        if (pseudo_function.name().equals_ignoring_case("nth-of-type"sv))
+            return parse_nth_child_selector(Selector::SimpleSelector::PseudoClass::Type::NthOfType, pseudo_function.values(), false);
+        if (pseudo_function.name().equals_ignoring_case("nth-last-of-type"sv))
+            return parse_nth_child_selector(Selector::SimpleSelector::PseudoClass::Type::NthLastOfType, pseudo_function.values(), false);
 
         dbgln_if(CSS_PARSER_DEBUG, "Unrecognized pseudo-class function: ':{}'()", pseudo_function.name());
         return ParseError::SyntaxError;
@@ -1216,7 +1217,7 @@ Optional<MediaQuery::MediaType> Parser::parse_media_type(TokenStream<ComponentVa
 {
     auto transaction = tokens.begin_transaction();
     tokens.skip_whitespace();
-    auto& token = tokens.next_token();
+    auto const& token = tokens.next_token();
 
     if (!token.is(Token::Type::Ident))
         return {};
@@ -1238,7 +1239,7 @@ OwnPtr<MediaCondition> Parser::parse_media_in_parens(TokenStream<ComponentValue>
     tokens.skip_whitespace();
 
     // `( <media-condition> ) | ( <media-feature> )`
-    auto& first_token = tokens.peek_token();
+    auto const& first_token = tokens.peek_token();
     if (first_token.is_block() && first_token.block().is_paren()) {
         TokenStream inner_token_stream { first_token.block().values() };
         if (auto maybe_media_condition = parse_media_condition(inner_token_stream, MediaCondition::AllowOr::Yes)) {
@@ -1285,7 +1286,7 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Boolean)) {
         auto transaction = tokens.begin_transaction();
         tokens.skip_whitespace();
-        auto& first = tokens.next_token();
+        auto const& first = tokens.next_token();
         if (first.is(Token::Type::Number) && first.token().number().is_integer()
             && (first.token().number_value() == 0 || first.token().number_value() == 1)) {
             transaction.commit();
@@ -1297,7 +1298,7 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Integer)) {
         auto transaction = tokens.begin_transaction();
         tokens.skip_whitespace();
-        auto& first = tokens.next_token();
+        auto const& first = tokens.next_token();
         if (first.is(Token::Type::Number) && first.token().number().is_integer()) {
             transaction.commit();
             return MediaFeatureValue(first.token().number_value());
@@ -1308,7 +1309,7 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Length)) {
         auto transaction = tokens.begin_transaction();
         tokens.skip_whitespace();
-        auto& first = tokens.next_token();
+        auto const& first = tokens.next_token();
         if (auto length = parse_length(first); length.has_value()) {
             transaction.commit();
             return MediaFeatureValue(length.release_value());
@@ -1329,7 +1330,7 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Resolution)) {
         auto transaction = tokens.begin_transaction();
         tokens.skip_whitespace();
-        auto& first = tokens.next_token();
+        auto const& first = tokens.next_token();
         if (auto resolution = parse_dimension(first); resolution.has_value() && resolution->is_resolution()) {
             transaction.commit();
             return MediaFeatureValue(resolution->resolution());
@@ -1362,7 +1363,7 @@ OwnPtr<Supports::Condition> Parser::parse_supports_condition(TokenStream<Compone
     auto transaction = tokens.begin_transaction();
     tokens.skip_whitespace();
 
-    auto& peeked_token = tokens.peek_token();
+    auto const& peeked_token = tokens.peek_token();
     // `not <supports-in-parens>`
     if (peeked_token.is(Token::Type::Ident) && peeked_token.token().ident().equals_ignoring_case("not"sv)) {
         tokens.next_token();
@@ -1430,7 +1431,7 @@ OwnPtr<Supports::Condition> Parser::parse_supports_condition(TokenStream<Compone
 Optional<Supports::InParens> Parser::parse_supports_in_parens(TokenStream<ComponentValue>& tokens)
 {
     // `( <supports-condition> )`
-    auto& first_token = tokens.peek_token();
+    auto const& first_token = tokens.peek_token();
     if (first_token.is_block() && first_token.block().is_paren()) {
         auto transaction = tokens.begin_transaction();
         tokens.next_token();
@@ -1468,7 +1469,7 @@ Optional<Supports::Feature> Parser::parse_supports_feature(TokenStream<Component
 {
     auto transaction = tokens.begin_transaction();
     tokens.skip_whitespace();
-    auto& first_token = tokens.next_token();
+    auto const& first_token = tokens.next_token();
 
     // `<supports-decl>`
     if (first_token.is_block() && first_token.block().is_paren()) {
@@ -1502,7 +1503,7 @@ Optional<GeneralEnclosed> Parser::parse_general_enclosed(TokenStream<ComponentVa
 {
     auto transaction = tokens.begin_transaction();
     tokens.skip_whitespace();
-    auto& first_token = tokens.next_token();
+    auto const& first_token = tokens.next_token();
 
     // `[ <function-token> <any-value>? ) ]`
     if (first_token.is_function()) {
@@ -2018,7 +2019,7 @@ Optional<Declaration> Parser::consume_a_declaration(TokenStream<T>& tokens)
 
     // 7. Return the declaration.
     transaction.commit();
-    return Declaration { move(declaration_name), move(declaration_values), move(declaration_important) };
+    return Declaration { move(declaration_name), move(declaration_values), declaration_important };
 }
 
 // 5.4.5. Consume a list of declarations
@@ -2360,10 +2361,10 @@ Optional<AK::URL> Parser::parse_url_function(ComponentValue const& component_val
         return convert_string_to_url(url_string);
     }
     if (component_value.is_function() && component_value.function().name().equals_ignoring_case("url"sv)) {
-        auto& function_values = component_value.function().values();
+        auto const& function_values = component_value.function().values();
         // FIXME: Handle url-modifiers. https://www.w3.org/TR/css-values-4/#url-modifiers
         for (size_t i = 0; i < function_values.size(); ++i) {
-            auto& value = function_values[i];
+            auto const& value = function_values[i];
             if (value.is(Token::Type::Whitespace))
                 continue;
             if (value.is(Token::Type::String)) {
@@ -2442,7 +2443,7 @@ RefPtr<StyleValue> Parser::parse_linear_gradient_function(ComponentValue const& 
         return token.token().ident().equals_ignoring_case("to"sv);
     };
 
-    auto& first_param = tokens.peek_token();
+    auto const& first_param = tokens.peek_token();
     if (first_param.is(Token::Type::Dimension)) {
         // <angle>
         tokens.next_token();
@@ -2467,7 +2468,7 @@ RefPtr<StyleValue> Parser::parse_linear_gradient_function(ComponentValue const& 
         }
 
         // [left | right] || [top | bottom]
-        auto& first_side = tokens.next_token();
+        auto const& first_side = tokens.next_token();
         if (!first_side.is(Token::Type::Ident))
             return {};
 
@@ -2524,7 +2525,7 @@ RefPtr<StyleValue> Parser::parse_linear_gradient_function(ComponentValue const& 
         tokens.skip_whitespace();
         if (!tokens.has_next_token())
             return ElementType::Garbage;
-        auto& token = tokens.next_token();
+        auto const& token = tokens.next_token();
 
         Gfx::Color color;
         Optional<LengthPercentage> position;
@@ -2605,19 +2606,19 @@ RefPtr<StyleValue> Parser::parse_linear_gradient_function(ComponentValue const& 
 CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
 {
     if (rule->is_at_rule()) {
-        if (has_ignored_vendor_prefix(rule->at_rule_name())) {
+        if (has_ignored_vendor_prefix(rule->at_rule_name()))
             return {};
-        } else if (rule->at_rule_name().equals_ignoring_case("font-face"sv)) {
+        if (rule->at_rule_name().equals_ignoring_case("font-face"sv)) {
             if (!rule->block() || !rule->block()->is_curly()) {
                 dbgln_if(CSS_PARSER_DEBUG, "@font-face rule is malformed.");
                 return {};
             }
             TokenStream tokens { rule->block()->values() };
             return parse_font_face_rule(tokens);
-        } else if (rule->at_rule_name().equals_ignoring_case("import"sv) && !rule->prelude().is_empty()) {
-
+        }
+        if (rule->at_rule_name().equals_ignoring_case("import"sv) && !rule->prelude().is_empty()) {
             Optional<AK::URL> url;
-            for (auto& token : rule->prelude()) {
+            for (auto const& token : rule->prelude()) {
                 if (token.is(Token::Type::Whitespace))
                     continue;
 
@@ -2635,9 +2636,9 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
             if (url.has_value())
                 return CSSImportRule::create(url.value(), const_cast<DOM::Document&>(*m_context.document()));
             dbgln_if(CSS_PARSER_DEBUG, "Unable to parse url from @import rule");
-
-        } else if (rule->at_rule_name().equals_ignoring_case("media"sv)) {
-
+            return {};
+        }
+        if (rule->at_rule_name().equals_ignoring_case("media"sv)) {
             auto media_query_tokens = TokenStream { rule->prelude() };
             auto media_query_list = parse_a_media_query_list(media_query_tokens);
             if (media_query_list.is_empty() || !rule->block())
@@ -2647,14 +2648,13 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
             auto parser_rules = parse_a_list_of_rules(child_tokens);
             JS::MarkedVector<CSSRule*> child_rules(m_context.window_object().heap());
             for (auto& raw_rule : parser_rules) {
-                if (auto child_rule = convert_to_rule(raw_rule))
+                if (auto* child_rule = convert_to_rule(raw_rule))
                     child_rules.append(child_rule);
             }
-            auto* rule_list = CSSRuleList::create(m_context.window_object(), move(child_rules));
+            auto* rule_list = CSSRuleList::create(m_context.window_object(), child_rules);
             return CSSMediaRule::create(m_context.window_object(), *MediaList::create(m_context.window_object(), move(media_query_list)), *rule_list);
-
-        } else if (rule->at_rule_name().equals_ignoring_case("supports"sv)) {
-
+        }
+        if (rule->at_rule_name().equals_ignoring_case("supports"sv)) {
             auto supports_tokens = TokenStream { rule->prelude() };
             auto supports = parse_a_supports(supports_tokens);
             if (!supports) {
@@ -2671,60 +2671,56 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
             auto parser_rules = parse_a_list_of_rules(child_tokens);
             JS::MarkedVector<CSSRule*> child_rules(m_context.window_object().heap());
             for (auto& raw_rule : parser_rules) {
-                if (auto child_rule = convert_to_rule(raw_rule))
+                if (auto* child_rule = convert_to_rule(raw_rule))
                     child_rules.append(child_rule);
             }
 
-            auto* rule_list = CSSRuleList::create(m_context.window_object(), move(child_rules));
+            auto* rule_list = CSSRuleList::create(m_context.window_object(), child_rules);
             return CSSSupportsRule::create(m_context.window_object(), supports.release_nonnull(), *rule_list);
-
-        } else {
-            dbgln_if(CSS_PARSER_DEBUG, "Unrecognized CSS at-rule: @{}", rule->at_rule_name());
         }
 
         // FIXME: More at rules!
-
-    } else {
-        auto prelude_stream = TokenStream(rule->prelude());
-        auto selectors = parse_a_selector_list(prelude_stream, SelectorType::Standalone);
-
-        if (selectors.is_error()) {
-            if (selectors.error() != ParseError::IncludesIgnoredVendorPrefix) {
-                dbgln_if(CSS_PARSER_DEBUG, "CSSParser: style rule selectors invalid; discarding.");
-                if constexpr (CSS_PARSER_DEBUG) {
-                    prelude_stream.dump_all_tokens();
-                }
-            }
-            return {};
-        }
-
-        if (selectors.value().is_empty()) {
-            dbgln_if(CSS_PARSER_DEBUG, "CSSParser: empty selector; discarding.");
-            return {};
-        }
-
-        if (!rule->block()->is_curly())
-            return {};
-
-        auto stream = TokenStream(rule->block()->values());
-        auto declarations_and_at_rules = parse_a_style_blocks_contents(stream);
-
-        auto* declaration = convert_to_style_declaration(declarations_and_at_rules);
-        if (!declaration) {
-            dbgln_if(CSS_PARSER_DEBUG, "CSSParser: style rule declaration invalid; discarding.");
-            return {};
-        }
-
-        return CSSStyleRule::create(m_context.window_object(), move(selectors.value()), *declaration);
+        dbgln_if(CSS_PARSER_DEBUG, "Unrecognized CSS at-rule: @{}", rule->at_rule_name());
+        return {};
     }
 
-    return {};
+    auto prelude_stream = TokenStream(rule->prelude());
+    auto selectors = parse_a_selector_list(prelude_stream, SelectorType::Standalone);
+
+    if (selectors.is_error()) {
+        if (selectors.error() != ParseError::IncludesIgnoredVendorPrefix) {
+            dbgln_if(CSS_PARSER_DEBUG, "CSSParser: style rule selectors invalid; discarding.");
+            if constexpr (CSS_PARSER_DEBUG) {
+                prelude_stream.dump_all_tokens();
+            }
+        }
+        return {};
+    }
+
+    if (selectors.value().is_empty()) {
+        dbgln_if(CSS_PARSER_DEBUG, "CSSParser: empty selector; discarding.");
+        return {};
+    }
+
+    if (!rule->block()->is_curly())
+        return {};
+
+    auto stream = TokenStream(rule->block()->values());
+    auto declarations_and_at_rules = parse_a_style_blocks_contents(stream);
+
+    auto* declaration = convert_to_style_declaration(declarations_and_at_rules);
+    if (!declaration) {
+        dbgln_if(CSS_PARSER_DEBUG, "CSSParser: style rule declaration invalid; discarding.");
+        return {};
+    }
+
+    return CSSStyleRule::create(m_context.window_object(), move(selectors.value()), *declaration);
 }
 
 auto Parser::extract_properties(Vector<DeclarationOrAtRule> const& declarations_and_at_rules) -> PropertiesAndCustomProperties
 {
     PropertiesAndCustomProperties result;
-    for (auto& declaration_or_at_rule : declarations_and_at_rules) {
+    for (auto const& declaration_or_at_rule : declarations_and_at_rules) {
         if (declaration_or_at_rule.is_at_rule()) {
             dbgln_if(CSS_PARSER_DEBUG, "!!! CSS at-rule is not allowed here!");
             continue;
@@ -2778,11 +2774,10 @@ Optional<StyleProperty> Parser::convert_to_style_property(Declaration const& dec
         return {};
     }
 
-    if (property_id == PropertyID::Custom) {
+    if (property_id == PropertyID::Custom)
         return StyleProperty { declaration.importance(), property_id, value.release_value(), declaration.name() };
-    } else {
-        return StyleProperty { declaration.importance(), property_id, value.release_value(), {} };
-    }
+
+    return StyleProperty { declaration.importance(), property_id, value.release_value(), {} };
 }
 
 RefPtr<StyleValue> Parser::parse_builtin_value(ComponentValue const& component_value)
@@ -2840,7 +2835,7 @@ RefPtr<StyleValue> Parser::parse_calculated_value(Vector<ComponentValue> const& 
 RefPtr<StyleValue> Parser::parse_dynamic_value(ComponentValue const& component_value)
 {
     if (component_value.is_function()) {
-        auto& function = component_value.function();
+        auto const& function = component_value.function();
 
         if (function.name().equals_ignoring_case("calc"sv))
             return parse_calculated_value(function.values());
@@ -2997,13 +2992,13 @@ Optional<UnicodeRange> Parser::parse_unicode_range(TokenStream<ComponentValue>& 
     };
 
     // All options start with 'u'/'U'.
-    auto& u = tokens.next_token();
+    auto const& u = tokens.next_token();
     if (!(u.is(Token::Type::Ident) && u.token().ident().equals_ignoring_case("u"sv))) {
         dbgln_if(CSS_PARSER_DEBUG, "CSSParser: <urange> does not start with 'u'");
         return {};
     }
 
-    auto& second_token = tokens.next_token();
+    auto const& second_token = tokens.next_token();
 
     //  u '+' <ident-token> '?'* |
     //  u '+' '?'+
@@ -3012,7 +3007,7 @@ Optional<UnicodeRange> Parser::parse_unicode_range(TokenStream<ComponentValue>& 
         StringBuilder string_builder;
         string_builder.append(representation_of(second_token));
 
-        auto& third_token = tokens.next_token();
+        auto const& third_token = tokens.next_token();
         if (third_token.is(Token::Type::Ident) || is_question_mark(third_token)) {
             string_builder.append(representation_of(third_token));
             while (is_question_mark(tokens.peek_token()))
@@ -3044,7 +3039,7 @@ Optional<UnicodeRange> Parser::parse_unicode_range(TokenStream<ComponentValue>& 
         if (is_ending_token(tokens.peek_token()))
             return create_unicode_range(string_builder.string_view(), local_transaction);
 
-        auto& third_token = tokens.next_token();
+        auto const& third_token = tokens.next_token();
         string_builder.append(representation_of(third_token));
         if (is_question_mark(third_token)) {
             while (is_question_mark(tokens.peek_token()))
@@ -3237,12 +3232,10 @@ RefPtr<StyleValue> Parser::parse_dimension_value(ComponentValue const& component
 RefPtr<StyleValue> Parser::parse_numeric_value(ComponentValue const& component_value)
 {
     if (component_value.is(Token::Type::Number)) {
-        auto number = component_value.token();
-        if (number.number().is_integer()) {
+        auto const& number = component_value.token();
+        if (number.number().is_integer())
             return NumericStyleValue::create_integer(number.to_integer());
-        } else {
-            return NumericStyleValue::create_float(number.number_value());
-        }
+        return NumericStyleValue::create_float(number.number_value());
     }
 
     return {};
@@ -3266,7 +3259,7 @@ Optional<Color> Parser::parse_rgb_or_hsl_color(StringView function_name, Vector<
     auto tokens = TokenStream { component_values };
 
     tokens.skip_whitespace();
-    auto& component1 = tokens.next_token();
+    auto const& component1 = tokens.next_token();
 
     if (!component1.is(Token::Type::Number)
         && !component1.is(Token::Type::Percentage)
@@ -3281,7 +3274,7 @@ Optional<Color> Parser::parse_rgb_or_hsl_color(StringView function_name, Vector<
     }
 
     tokens.skip_whitespace();
-    auto& component2 = tokens.next_token();
+    auto const& component2 = tokens.next_token();
     if (!component2.is(Token::Type::Number) && !component2.is(Token::Type::Percentage))
         return {};
     params[1] = component2.token();
@@ -3291,20 +3284,20 @@ Optional<Color> Parser::parse_rgb_or_hsl_color(StringView function_name, Vector<
         return {};
 
     tokens.skip_whitespace();
-    auto& component3 = tokens.next_token();
+    auto const& component3 = tokens.next_token();
     if (!component3.is(Token::Type::Number) && !component3.is(Token::Type::Percentage))
         return {};
     params[2] = component3.token();
 
     tokens.skip_whitespace();
-    auto& alpha_separator = tokens.peek_token();
+    auto const& alpha_separator = tokens.peek_token();
     bool has_comma = alpha_separator.is(Token::Type::Comma);
     bool has_slash = alpha_separator.is(Token::Type::Delim) && alpha_separator.token().delim() == '/';
     if (legacy_syntax ? has_comma : has_slash) {
         tokens.next_token();
 
         tokens.skip_whitespace();
-        auto& component4 = tokens.next_token();
+        auto const& component4 = tokens.next_token();
         if (!component4.is(Token::Type::Number) && !component4.is(Token::Type::Percentage))
             return {};
         params[3] = component4.token();
@@ -3397,7 +3390,7 @@ RefPtr<StyleValue> Parser::parse_rect_value(ComponentValue const& component_valu
 {
     if (!component_value.is_function())
         return {};
-    auto& function = component_value.function();
+    auto const& function = component_value.function();
     if (!function.name().equals_ignoring_case("rect"sv))
         return {};
 
@@ -3486,8 +3479,8 @@ Optional<Color> Parser::parse_color(ComponentValue const& component_value)
         return {};
 
     } else if (component_value.is_function()) {
-        auto& function = component_value.function();
-        auto& values = function.values();
+        auto const& function = component_value.function();
+        auto const& values = function.values();
 
         return parse_rgb_or_hsl_color(function.name(), values);
     }
@@ -3498,7 +3491,7 @@ Optional<Color> Parser::parse_color(ComponentValue const& component_value)
         // aborting on the first step that returns a value:
 
         // 1. Let cv be the component value.
-        auto& cv = component_value;
+        auto const& cv = component_value;
         String serialization;
         // 2. If cv is a <number-token> or a <dimension-token>, follow these substeps:
         if (cv.is(Token::Type::Number) || cv.is(Token::Type::Dimension)) {
@@ -3677,7 +3670,7 @@ RefPtr<StyleValue> Parser::parse_background_value(Vector<ComponentValue> const& 
 
     auto tokens = TokenStream { component_values };
     while (tokens.has_next_token()) {
-        auto& part = tokens.next_token();
+        auto const& part = tokens.next_token();
 
         if (part.is(Token::Type::Comma)) {
             has_multiple_layers = true;
@@ -3878,7 +3871,7 @@ RefPtr<StyleValue> Parser::parse_single_background_position_value(TokenStream<Co
         if (seen_items == 2)
             break;
 
-        auto& token = tokens.peek_token();
+        auto const& token = tokens.peek_token();
         auto maybe_value = parse_css_value(token);
         if (!maybe_value || !property_accepts_value(PropertyID::BackgroundPosition, *maybe_value))
             break;
@@ -4008,7 +4001,7 @@ RefPtr<StyleValue> Parser::parse_single_background_repeat_value(TokenStream<Comp
         }
     };
 
-    auto& token = tokens.next_token();
+    auto const& token = tokens.next_token();
     auto maybe_x_value = parse_css_value(token);
     if (!maybe_x_value || !property_accepts_value(PropertyID::BackgroundRepeat, *maybe_x_value))
         return nullptr;
@@ -4027,7 +4020,7 @@ RefPtr<StyleValue> Parser::parse_single_background_repeat_value(TokenStream<Comp
         return nullptr;
 
     // See if we have a second value for Y
-    auto& second_token = tokens.peek_token();
+    auto const& second_token = tokens.peek_token();
     auto maybe_y_value = parse_css_value(second_token);
     if (!maybe_y_value || !property_accepts_value(PropertyID::BackgroundRepeat, *maybe_y_value)) {
         // We don't have a second value, so use x for both
@@ -4100,7 +4093,7 @@ RefPtr<StyleValue> Parser::parse_border_value(Vector<ComponentValue> const& comp
     RefPtr<StyleValue> border_color;
     RefPtr<StyleValue> border_style;
 
-    for (auto& part : component_values) {
+    for (auto const& part : component_values) {
         auto value = parse_css_value(part);
         if (!value)
             return nullptr;
@@ -4203,7 +4196,7 @@ RefPtr<StyleValue> Parser::parse_border_radius_shorthand_value(Vector<ComponentV
     Vector<LengthPercentage> vertical_radii;
     bool reading_vertical = false;
 
-    for (auto& value : component_values) {
+    for (auto const& value : component_values) {
         if (value.is(Token::Type::Delim) && value.token().delim() == '/') {
             if (reading_vertical || horizontal_radii.is_empty())
                 return nullptr;
@@ -4265,7 +4258,7 @@ RefPtr<StyleValue> Parser::parse_single_shadow_value(TokenStream<ComponentValue>
     Optional<ShadowPlacement> placement;
 
     while (tokens.has_next_token()) {
-        auto& token = tokens.peek_token();
+        auto const& token = tokens.peek_token();
 
         if (auto maybe_color = parse_color(token); maybe_color.has_value()) {
             if (color.has_value())
@@ -4673,7 +4666,7 @@ RefPtr<StyleValue> Parser::parse_flex_flow_value(Vector<ComponentValue> const& c
     RefPtr<StyleValue> flex_direction;
     RefPtr<StyleValue> flex_wrap;
 
-    for (auto& part : component_values) {
+    for (auto const& part : component_values) {
         auto value = parse_css_value(part);
         if (!value)
             return nullptr;
@@ -4768,7 +4761,7 @@ RefPtr<StyleValue> Parser::parse_font_value(Vector<ComponentValue> const& compon
 
             // Consume `/ line-height` if present
             if (i + 2 < component_values.size()) {
-                auto maybe_solidus = component_values[i + 1];
+                auto const& maybe_solidus = component_values[i + 1];
                 if (maybe_solidus.is(Token::Type::Delim) && maybe_solidus.token().delim() == '/') {
                     auto maybe_line_height = parse_css_value(component_values[i + 2]);
                     if (!(maybe_line_height && property_accepts_value(PropertyID::LineHeight, *maybe_line_height)))
@@ -4812,7 +4805,7 @@ RefPtr<StyleValue> Parser::parse_font_family_value(Vector<ComponentValue> const&
 {
     auto is_comma_or_eof = [&](size_t i) -> bool {
         if (i < component_values.size()) {
-            auto& maybe_comma = component_values[i];
+            auto const& maybe_comma = component_values[i];
             if (!maybe_comma.is(Token::Type::Comma))
                 return false;
         }
@@ -4826,7 +4819,7 @@ RefPtr<StyleValue> Parser::parse_font_family_value(Vector<ComponentValue> const&
     NonnullRefPtrVector<StyleValue> font_families;
     Vector<String> current_name_parts;
     for (size_t i = start_index; i < component_values.size(); ++i) {
-        auto& part = component_values[i];
+        auto const& part = component_values[i];
 
         if (part.is(Token::Type::String)) {
             // `font-family: my cool "font";` is invalid.
@@ -4895,14 +4888,14 @@ CSSRule* Parser::parse_font_face_rule(TokenStream<ComponentValue>& tokens)
             continue;
         }
 
-        auto& declaration = declaration_or_at_rule.declaration();
+        auto const& declaration = declaration_or_at_rule.declaration();
         if (declaration.name().equals_ignoring_case("font-family"sv)) {
             // FIXME: This is very similar to, but different from, the logic in parse_font_family_value().
             //        Ideally they could share code.
             Vector<String> font_family_parts;
             bool had_syntax_error = false;
             for (size_t i = 0; i < declaration.values().size(); ++i) {
-                auto& part = declaration.values()[i];
+                auto const& part = declaration.values()[i];
                 if (part.is(Token::Type::Whitespace))
                     continue;
                 if (part.is(Token::Type::String)) {
@@ -5002,7 +4995,7 @@ Vector<FontFace::Source> Parser::parse_font_face_src(TokenStream<ComponentValue>
     for (auto const& source_token_list : list_of_source_token_lists) {
         TokenStream source_tokens { source_token_list };
         source_tokens.skip_whitespace();
-        auto& first = source_tokens.next_token();
+        auto const& first = source_tokens.next_token();
 
         // <url> [ format(<font-format>)]?
         // FIXME: Implement optional tech() function from CSS-Fonts-4.
@@ -5022,11 +5015,11 @@ Vector<FontFace::Source> Parser::parse_font_face_src(TokenStream<ComponentValue>
                 return {};
             }
 
-            auto& function = maybe_function.function();
+            auto const& function = maybe_function.function();
             if (function.name().equals_ignoring_case("format"sv)) {
                 TokenStream format_tokens { function.values() };
                 format_tokens.skip_whitespace();
-                auto& format_name_token = format_tokens.next_token();
+                auto const& format_name_token = format_tokens.next_token();
                 StringView format_name;
                 if (format_name_token.is(Token::Type::Ident)) {
                     format_name = format_name_token.token().ident();
@@ -5056,12 +5049,11 @@ Vector<FontFace::Source> Parser::parse_font_face_src(TokenStream<ComponentValue>
 
             supported_sources.empend(move(url), format);
             continue;
-
-        } else {
-            // FIXME: Implement `local()`.
-            dbgln_if(CSS_PARSER_DEBUG, "CSSParser: @font-face src invalid (failed to parse url from: {}); discarding.", first.to_debug_string());
-            return {};
         }
+
+        // FIXME: Implement `local()`.
+        dbgln_if(CSS_PARSER_DEBUG, "CSSParser: @font-face src invalid (failed to parse url from: {}); discarding.", first.to_debug_string());
+        return {};
     }
 
     return supported_sources;
@@ -5077,7 +5069,7 @@ RefPtr<StyleValue> Parser::parse_list_style_value(Vector<ComponentValue> const& 
     RefPtr<StyleValue> list_type;
     int found_nones = 0;
 
-    for (auto& part : component_values) {
+    for (auto const& part : component_values) {
         auto value = parse_css_value(part);
         if (!value)
             return nullptr;
@@ -5176,7 +5168,7 @@ RefPtr<StyleValue> Parser::parse_text_decoration_value(Vector<ComponentValue> co
     auto tokens = TokenStream { component_values };
 
     while (tokens.has_next_token()) {
-        auto& part = tokens.next_token();
+        auto const& part = tokens.next_token();
         auto value = parse_css_value(part);
         if (!value)
             return nullptr;
@@ -5230,7 +5222,7 @@ RefPtr<StyleValue> Parser::parse_text_decoration_line_value(TokenStream<Componen
     NonnullRefPtrVector<StyleValue> style_values;
 
     while (tokens.has_next_token()) {
-        auto& token = tokens.next_token();
+        auto const& token = tokens.next_token();
         auto maybe_value = parse_css_value(token);
         if (!maybe_value || !property_accepts_value(PropertyID::TextDecorationLine, *maybe_value)) {
             tokens.reconsume_current_input_token();
@@ -5272,7 +5264,7 @@ RefPtr<StyleValue> Parser::parse_transform_value(Vector<ComponentValue> const& c
 
     while (tokens.has_next_token()) {
         tokens.skip_whitespace();
-        auto& part = tokens.next_token();
+        auto const& part = tokens.next_token();
 
         if (part.is(Token::Type::Ident) && part.token().ident().equals_ignoring_case("none"sv)) {
             if (!transformations.is_empty())
@@ -5295,7 +5287,7 @@ RefPtr<StyleValue> Parser::parse_transform_value(Vector<ComponentValue> const& c
         auto argument_tokens = TokenStream { part.function().values() };
         argument_tokens.skip_whitespace();
         while (argument_tokens.has_next_token()) {
-            auto& value = argument_tokens.next_token();
+            auto const& value = argument_tokens.next_token();
             RefPtr<CalculatedStyleValue> maybe_calc_value;
             if (auto maybe_dynamic_value = parse_dynamic_value(value)) {
                 // TODO: calc() is the only dynamic value we support for now, but more will come later.
@@ -5503,7 +5495,7 @@ RefPtr<StyleValue> Parser::parse_as_css_value(PropertyID property_id)
 RefPtr<StyleValue> Parser::parse_grid_track_sizes(Vector<ComponentValue> const& component_values)
 {
     Vector<CSS::GridTrackSize> params;
-    for (auto& component_value : component_values) {
+    for (auto const& component_value : component_values) {
         // FIXME: Incomplete as a GridTrackSize can be a function like minmax(min, max), etc.
         if (component_value.is_function()) {
             params.append(Length::make_auto());
@@ -5636,7 +5628,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
     bool contains_var_or_attr = false;
 
     while (tokens.has_next_token()) {
-        auto& token = tokens.next_token();
+        auto const& token = tokens.next_token();
 
         if (token.is(Token::Type::Semicolon)) {
             tokens.reconsume_current_input_token();
@@ -5969,7 +5961,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     // Unfortunately these can't be in the same order as in the spec.
 
     values.skip_whitespace();
-    auto& first_value = values.next_token();
+    auto const& first_value = values.next_token();
 
     // odd | even
     if (first_value.is(Token::Type::Ident)) {
@@ -6006,9 +5998,9 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
         // <n-dimension> ['+' | '-'] <signless-integer>
         {
             auto child_transaction = transaction.create_child();
-            auto& second_value = values.next_token();
+            auto const& second_value = values.next_token();
             values.skip_whitespace();
-            auto& third_value = values.next_token();
+            auto const& third_value = values.next_token();
 
             if (is_sign(second_value) && is_signless_integer(third_value)) {
                 int b = third_value.token().to_integer() * (is_delim(second_value, '+') ? 1 : -1);
@@ -6024,7 +6016,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     // <ndash-dimension> <signless-integer>
     if (is_ndash_dimension(first_value)) {
         values.skip_whitespace();
-        auto& second_value = values.next_token();
+        auto const& second_value = values.next_token();
         if (is_signless_integer(second_value)) {
             int a = first_value.token().dimension_value_int();
             int b = -second_value.token().to_integer();
@@ -6036,7 +6028,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     }
     // <ndashdigit-dimension>
     if (is_ndashdigit_dimension(first_value)) {
-        auto& dimension = first_value.token();
+        auto const& dimension = first_value.token();
         int a = dimension.dimension_value_int();
         auto maybe_b = dimension.dimension_unit().substring_view(1).to_int();
         if (maybe_b.has_value()) {
@@ -6072,9 +6064,9 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
         // -n ['+' | '-'] <signless-integer>
         {
             auto child_transaction = transaction.create_child();
-            auto& second_value = values.next_token();
+            auto const& second_value = values.next_token();
             values.skip_whitespace();
-            auto& third_value = values.next_token();
+            auto const& third_value = values.next_token();
 
             if (is_sign(second_value) && is_signless_integer(third_value)) {
                 int b = third_value.token().to_integer() * (is_delim(second_value, '+') ? 1 : -1);
@@ -6090,7 +6082,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     // -n- <signless-integer>
     if (is_dashndash(first_value)) {
         values.skip_whitespace();
-        auto& second_value = values.next_token();
+        auto const& second_value = values.next_token();
         if (is_signless_integer(second_value)) {
             int b = -second_value.token().to_integer();
             transaction.commit();
@@ -6113,7 +6105,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
         // We do *not* skip whitespace here.
     }
 
-    auto& first_after_plus = values.next_token();
+    auto const& first_after_plus = values.next_token();
     // '+'?† n
     // '+'?† n <signed-integer>
     // '+'?† n ['+' | '-'] <signless-integer>
@@ -6130,9 +6122,9 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
         // '+'?† n ['+' | '-'] <signless-integer>
         {
             auto child_transaction = transaction.create_child();
-            auto& second_value = values.next_token();
+            auto const& second_value = values.next_token();
             values.skip_whitespace();
-            auto& third_value = values.next_token();
+            auto const& third_value = values.next_token();
 
             if (is_sign(second_value) && is_signless_integer(third_value)) {
                 int b = third_value.token().to_integer() * (is_delim(second_value, '+') ? 1 : -1);
@@ -6149,7 +6141,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     // '+'?† n- <signless-integer>
     if (is_ndash(first_after_plus)) {
         values.skip_whitespace();
-        auto& second_value = values.next_token();
+        auto const& second_value = values.next_token();
         if (is_signless_integer(second_value)) {
             int b = -second_value.token().to_integer();
             transaction.commit();
@@ -6229,7 +6221,7 @@ OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> Parser::parse_calc_pro
 
     tokens.skip_whitespace();
 
-    auto& op_token = tokens.peek_token();
+    auto const& op_token = tokens.peek_token();
     if (!op_token.is(Token::Type::Delim))
         return nullptr;
 
@@ -6268,7 +6260,7 @@ OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> Parser::parse_ca
 
     tokens.skip_whitespace();
 
-    auto& op_token = tokens.peek_token();
+    auto const& op_token = tokens.peek_token();
     if (!op_token.is(Token::Type::Delim))
         return nullptr;
 
@@ -6322,7 +6314,7 @@ OwnPtr<CalculatedStyleValue::CalcNumberSumPartWithOperator> Parser::parse_calc_n
             && tokens.peek_token(1).is(Token::Type::Whitespace)))
         return nullptr;
 
-    auto& token = tokens.next_token();
+    auto const& token = tokens.next_token();
     tokens.skip_whitespace();
 
     CalculatedStyleValue::SumOperation op;
@@ -6362,7 +6354,7 @@ OwnPtr<CalculatedStyleValue::CalcNumberSum> Parser::parse_calc_number_sum(TokenS
 
 Optional<CalculatedStyleValue::CalcNumberValue> Parser::parse_calc_number_value(TokenStream<ComponentValue>& tokens)
 {
-    auto& first = tokens.peek_token();
+    auto const& first = tokens.peek_token();
     if (first.is_block() && first.block().is_paren()) {
         tokens.next_token();
         auto block_values = TokenStream(first.block().values());
@@ -6408,7 +6400,7 @@ OwnPtr<CalculatedStyleValue::CalcSumPartWithOperator> Parser::parse_calc_sum_par
             && tokens.peek_token(1).is(Token::Type::Whitespace)))
         return nullptr;
 
-    auto& token = tokens.next_token();
+    auto const& token = tokens.next_token();
     tokens.skip_whitespace();
 
     CalculatedStyleValue::SumOperation op;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -240,7 +240,7 @@ private:
     Vector<FontFace::Source> parse_font_face_src(TokenStream<ComponentValue>&);
 
     CSSRule* convert_to_rule(NonnullRefPtr<Rule>);
-    PropertyOwningCSSStyleDeclaration* convert_to_style_declaration(Vector<DeclarationOrAtRule> declarations);
+    PropertyOwningCSSStyleDeclaration* convert_to_style_declaration(Vector<DeclarationOrAtRule> const& declarations);
     Optional<StyleProperty> convert_to_style_property(Declaration const&);
 
     class Dimension {


### PR DESCRIPTION
Finally remembered I wanted to get clang-tidy set up. I'm trying very hard not to go ham on the whole codebase. :sweat_smile: 