### PR TITLE
Meta: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+charset = utf-8


### PR DESCRIPTION
See https://editorconfig.org/
This makes editors supporting editor config have proper indentation without relying on clang-format to do it 