### PR TITLE
LibC: Implement memset_explicit function

### DIFF
--- a/Userland/Libraries/LibC/string.cpp
+++ b/Userland/Libraries/LibC/string.cpp
@@ -479,4 +479,16 @@ void explicit_bzero(void* ptr, size_t size)
 {
     secure_zero(ptr, size);
 }
+
+void* (*volatile memset_ptr)(void*, int, size_t) = memset;
+
+// Not in POSIX yet, this was added in C23.
+// https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2897.htm
+void* memset_explicit(void* dest_ptr, int c, size_t n)
+{
+    // Due to the function pointer being volatile, 
+    // the compiler doesn't optimize away the call.
+    return memset_ptr(dest_ptr, c, n);
+}
+
 }

--- a/Userland/Libraries/LibC/string.cpp
+++ b/Userland/Libraries/LibC/string.cpp
@@ -480,7 +480,7 @@ void explicit_bzero(void* ptr, size_t size)
     secure_zero(ptr, size);
 }
 
-void* (*volatile memset_ptr)(void*, int, size_t) = memset;
+static void* (*volatile memset_ptr)(void*, int, size_t) = memset;
 
 // Not in POSIX yet, this was added in C23.
 // https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2897.htm

--- a/Userland/Libraries/LibC/string.h
+++ b/Userland/Libraries/LibC/string.h
@@ -32,6 +32,7 @@ void const* memmem(void const* haystack, size_t, void const* needle, size_t);
 
 void* memset(void*, int, size_t);
 void explicit_bzero(void*, size_t) __attribute__((nonnull(1)));
+void* memset_explicit(void*, int, size_t);
 
 __attribute__((malloc)) char* strdup(char const*);
 __attribute__((malloc)) char* strndup(char const*, size_t);


### PR DESCRIPTION
This is a function added in C2x, and its purpose is to not let the compiler optimize away a call to `memset`.
The proposal paper can be found [here](https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2897.htm) and the latest draft of the C standard can be found [here](https://www.open-std.org/JTC1/SC22/WG14/www/docs/n3054.pdf) (section 7.26.6.2).