### PR TITLE
LibGUI: Blit brightened icon when try item is hovered

### DIFF
--- a/Userland/Libraries/LibGUI/Tray.cpp
+++ b/Userland/Libraries/LibGUI/Tray.cpp
@@ -94,8 +94,12 @@ void Tray::paint_event(GUI::PaintEvent& event)
             text_rect.translate_by(1, 1);
         }
 
-        if (item.bitmap)
-            painter.blit(icon_rect.location(), *item.bitmap, item.bitmap->rect());
+        if (item.bitmap) {
+            if (is_hovered)
+                painter.blit_brightened(icon_rect.location(), *item.bitmap, item.bitmap->rect());
+            else
+                painter.blit(icon_rect.location(), *item.bitmap, item.bitmap->rect());
+        }
 
         auto const& font = is_checked ? this->font().bold_variant() : this->font();
         painter.draw_text(text_rect, item.text, font, Gfx::TextAlignment::CenterLeft, palette().color(Gfx::ColorRole::TrayText));


### PR DESCRIPTION
Current:

https://user-images.githubusercontent.com/42888162/189497672-bb886c0e-3bcd-48ab-a244-0a0db7ba7f16.mp4

This pull request:

https://user-images.githubusercontent.com/42888162/189497675-680e9454-d42e-43ed-82cf-16f6a0fbf20a.mp4
