### PR TITLE
WidgetGallery: Port file picker to use LibFileSystemAccessClient

### DIFF
--- a/Userland/Demos/WidgetGallery/CMakeLists.txt
+++ b/Userland/Demos/WidgetGallery/CMakeLists.txt
@@ -27,4 +27,4 @@ set(SOURCES
 )
 
 serenity_app(WidgetGallery ICON app-widget-gallery)
-target_link_libraries(WidgetGallery LibGUI LibMain)
+target_link_libraries(WidgetGallery LibGUI LibMain LibFileSystemAccessClient)

--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -14,6 +14,7 @@
 #include <Demos/WidgetGallery/SlidersTabGML.h>
 #include <Demos/WidgetGallery/WindowGML.h>
 #include <Demos/WidgetGallery/WizardsTabGML.h>
+#include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/ColorInput.h>
 #include <LibGUI/FilePicker.h>
@@ -107,10 +108,10 @@ GalleryWidget::GalleryWidget()
     m_file_button->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors());
 
     m_file_button->on_click = [&](auto) {
-        Optional<String> open_path = GUI::FilePicker::get_open_filepath(window());
-        if (!open_path.has_value())
+        auto response = FileSystemAccessClient::Client::the().try_open_file(window());
+        if (response.is_error())
             return;
-        m_text_editor->set_text(open_path.value());
+        m_text_editor->set_text(response.release_value()->filename());
     };
 
     m_input_button = basics_tab->find_descendant_of_type_named<GUI::Button>("input_button");

--- a/Userland/Demos/WidgetGallery/main.cpp
+++ b/Userland/Demos/WidgetGallery/main.cpp
@@ -17,9 +17,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix thread"));
     auto app = TRY(GUI::Application::try_create(arguments, Core::EventLoop::MakeInspectable::Yes));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath thread"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/home/anon", "r"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-widget-gallery"sv));


### PR DESCRIPTION
Previously we would unveil the home directory of anon to allow showing anything in the file picker. This pull request removes direct access to the home directory and instead makes WidgetGallery connect to FileSystemAccessServer to open a file, making the application more user agnostic and allowing directories outside /home/anon to be shown.

Current master:

![image](https://user-images.githubusercontent.com/42888162/189497797-50d2f396-a9c1-44ec-ae3c-1d277ea29407.png)

This pull request:

![image](https://user-images.githubusercontent.com/42888162/189497816-49f5aa92-a544-4846-9b02-ac325f4256c9.png)

