### PR TITLE
LibGUI: Improve or implement rubber band selections for {Icon,Columns,Table}View 

### DIFF
--- a/Userland/Libraries/LibGUI/IconView.cpp
+++ b/Userland/Libraries/LibGUI/IconView.cpp
@@ -246,7 +246,7 @@ void IconView::mouseup_event(MouseEvent& event)
 
 bool IconView::update_rubber_banding(Gfx::IntPoint const& input_position)
 {
-    auto adjusted_position = to_content_position(input_position.constrained(widget_inner_rect()));
+    auto adjusted_position = to_content_position(input_position.constrained(widget_inner_rect().inflated(1, 1)));
     if (m_rubber_band_current != adjusted_position) {
         auto prev_rect = Gfx::IntRect::from_two_points(m_rubber_band_origin, m_rubber_band_current);
         auto prev_rubber_band_fill_rect = prev_rect.shrunken(1, 1);

--- a/Userland/Libraries/LibGUI/TableView.h
+++ b/Userland/Libraries/LibGUI/TableView.h
@@ -41,12 +41,20 @@ protected:
     TableView();
 
     virtual void keydown_event(KeyEvent&) override;
+    virtual void mousedown_event(MouseEvent&) override;
+    virtual void mouseup_event(MouseEvent&) override;
+    virtual void mousemove_event(MouseEvent&) override;
     virtual void paint_event(PaintEvent&) override;
+    virtual void second_paint_event(PaintEvent&) override;
 
 private:
     GridStyle m_grid_style { GridStyle::None };
 
     bool m_highlight_key_column { true };
+
+    bool m_rubber_banding { false };
+    int m_rubber_band_origin { 0 };
+    int m_rubber_band_current { 0 };
 };
 
 }


### PR DESCRIPTION
This pull request improves rubber band selections in IconView and ColumnsView by properly limiting the rubber band rects to the widget inner rect:

Behavior on current master 

https://user-images.githubusercontent.com/42888162/189498764-9c1ada66-5f3f-4207-aa10-a8a4b9605d02.mp4

This pull request

https://user-images.githubusercontent.com/42888162/189498898-87c22b90-53b4-4299-ae72-3a56e394045f.mp4

---

This pull request also implements rubber band selections in TableView (with the same selection limitations as ColumnsView at this point in time, not being able to keep selections using the control modifier key):

https://user-images.githubusercontent.com/42888162/189498642-c20ada82-3b4a-48fc-986d-4a0801fe71c3.mp4