### PR TITLE
LibWeb: Add partial serialization for CSSFontFaceRule

### DIFF
--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -139,6 +139,7 @@
             <li><a href="calc.html">calc()</a></li>
             <li><a href="css-import.html">@import</a></li>
             <li><a href="media-queries.html">@media queries</a></li>
+            <li><a href="font-face.html">@font-face</a></li>
             <li><a href="margin-collapse-1.html">margin collapsing 1</a></li>
             <li><a href="margin-collapse-2.html">margin collapsing 2</a></li>
             <li><a href="position-absolute-from-edges.html">position: absolute, offset from edges</a></li>

--- a/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibWeb/CSS/CSSFontFaceRule.h>
+#include <LibWeb/CSS/Serialize.h>
 #include <LibWeb/HTML/Window.h>
 
 namespace Web::CSS {
@@ -31,8 +32,80 @@ CSSStyleDeclaration* CSSFontFaceRule::style()
 // https://www.w3.org/TR/cssom/#ref-for-cssfontfacerule
 String CSSFontFaceRule::serialized() const
 {
-    // FIXME: Implement this!
-    return "@font-face { /* FIXME: Implement CSSFontFaceRule::serialized()! */ }";
+    StringBuilder builder;
+    // The result of concatenating the following:
+
+    // 1. The string "@font-face {", followed by a single SPACE (U+0020).
+    builder.append("@font-face { "sv);
+
+    // 2. The string "font-family:", followed by a single SPACE (U+0020).
+    builder.append("font-family: "sv);
+
+    // 3. The result of performing serialize a string on the rule’s font family name.
+    serialize_a_string(builder, m_font_face.font_family());
+
+    // 4. The string ";", i.e., SEMICOLON (U+003B).
+    builder.append(';');
+
+    // 5. If the rule’s associated source list is not empty, follow these substeps:
+    if (!m_font_face.sources().is_empty()) {
+        // 1. A single SPACE (U+0020), followed by the string "src:", followed by a single SPACE (U+0020).
+        builder.append(" src: "sv);
+
+        // 2. The result of invoking serialize a comma-separated list on performing serialize a URL or serialize a LOCAL for each source on the source list.
+        serialize_a_comma_separated_list(builder, m_font_face.sources(), [&](FontFace::Source source) {
+            if (source.url.cannot_be_a_base_url()) {
+                serialize_a_url(builder, source.url.to_string());
+            } else {
+                serialize_a_local(builder, source.url.to_string());
+            }
+
+            // NOTE: No spec currently exists for format()
+            if (source.format.has_value()) {
+                builder.append("format(\""sv);
+                serialize_a_string(builder, source.format.value());
+                builder.append("\")"sv);
+            }
+        });
+
+        // 3. The string ";", i.e., SEMICOLON (U+003B).
+        builder.append(';');
+    }
+
+    // 6. If rule’s associated unicode-range descriptor is present, a single SPACE (U+0020), followed by the string "unicode-range:", followed by a single SPACE (U+0020), followed by the result of performing serialize a <'unicode-range'>, followed by the string ";", i.e., SEMICOLON (U+003B).
+    builder.append(" unicode-range: "sv);
+    serialize_unicode_ranges(builder, m_font_face.unicode_ranges());
+    builder.append(';');
+
+    // FIXME: 7. If rule’s associated font-variant descriptor is present, a single SPACE (U+0020),
+    // followed by the string "font-variant:", followed by a single SPACE (U+0020),
+    // followed by the result of performing serialize a <'font-variant'>,
+    // followed by the string ";", i.e., SEMICOLON (U+003B).
+
+    // FIXME: 8. If rule’s associated font-feature-settings descriptor is present, a single SPACE (U+0020),
+    // followed by the string "font-feature-settings:", followed by a single SPACE (U+0020),
+    // followed by the result of performing serialize a <'font-feature-settings'>,
+    // followed by the string ";", i.e., SEMICOLON (U+003B).
+
+    // FIXME: 9. If rule’s associated font-stretch descriptor is present, a single SPACE (U+0020),
+    // followed by the string "font-stretch:", followed by a single SPACE (U+0020),
+    // followed by the result of performing serialize a <'font-stretch'>,
+    // followed by the string ";", i.e., SEMICOLON (U+003B).
+
+    // FIXME: 10. If rule’s associated font-weight descriptor is present, a single SPACE (U+0020),
+    // followed by the string "font-weight:", followed by a single SPACE (U+0020),
+    // followed by the result of performing serialize a <'font-weight'>,
+    // followed by the string ";", i.e., SEMICOLON (U+003B).
+
+    // FIXME: 11. If rule’s associated font-style descriptor is present, a single SPACE (U+0020),
+    // followed by the string "font-style:", followed by a single SPACE (U+0020),
+    // followed by the result of performing serialize a <'font-style'>,
+    // followed by the string ";", i.e., SEMICOLON (U+003B).
+
+    // 12. A single SPACE (U+0020), followed by the string "}", i.e., RIGHT CURLY BRACKET (U+007D).
+    builder.append(" }"sv);
+
+    return builder.to_string();
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Serialize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Serialize.cpp
@@ -117,6 +117,24 @@ void serialize_a_url(StringBuilder& builder, StringView url)
     builder.append(')');
 }
 
+// https://www.w3.org/TR/cssom-1/#serialize-a-local
+void serialize_a_local(StringBuilder& builder, StringView path)
+{
+    // To serialize a LOCAL means to create a string represented by "local(",
+    // followed by the serialization of the LOCAL as a string, followed by ")".
+    builder.append("local("sv);
+    serialize_a_string(builder, path.to_string());
+    builder.append(')');
+}
+
+// NOTE: No spec currently exists for serializing a <'unicode-range'>.
+void serialize_unicode_ranges(StringBuilder& builder, Vector<UnicodeRange> const& unicode_ranges)
+{
+    serialize_a_comma_separated_list(builder, unicode_ranges, [&](UnicodeRange unicode_range) {
+        serialize_a_string(builder, unicode_range.to_string());
+    });
+}
+
 // https://www.w3.org/TR/css-color-4/#serializing-sRGB-values
 void serialize_a_srgb_value(StringBuilder& builder, Color color)
 {

--- a/Userland/Libraries/LibWeb/CSS/Serialize.h
+++ b/Userland/Libraries/LibWeb/CSS/Serialize.h
@@ -9,7 +9,9 @@
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
+#include <AK/Vector.h>
 #include <LibGfx/Color.h>
+#include <LibWeb/CSS/UnicodeRange.h>
 
 namespace Web::CSS {
 
@@ -18,6 +20,8 @@ void escape_a_character_as_code_point(StringBuilder&, u32 character);
 void serialize_an_identifier(StringBuilder&, StringView ident);
 void serialize_a_string(StringBuilder&, StringView string);
 void serialize_a_url(StringBuilder&, StringView url);
+void serialize_a_local(StringBuilder&, StringView path);
+void serialize_unicode_ranges(StringBuilder&, Vector<UnicodeRange> const& unicode_ranges);
 void serialize_a_srgb_value(StringBuilder&, Color color);
 
 String escape_a_character(u32 character);
@@ -26,5 +30,17 @@ String serialize_an_identifier(StringView ident);
 String serialize_a_string(StringView string);
 String serialize_a_url(StringView url);
 String serialize_a_srgb_value(Color color);
+
+template<typename T, typename SerializeItem>
+void serialize_a_comma_separated_list(StringBuilder& builder, Vector<T> const& items, SerializeItem serialize_item)
+{
+    for (size_t i = 0; i < items.size(); i++) {
+        auto& item = items.at(i);
+        serialize_item(item);
+        if ((i + 1) < items.size()) {
+            builder.append(",\n"sv);
+        }
+    }
+}
 
 }


### PR DESCRIPTION
This partially adds serialization code for `CSSFontFaceRule::serialized()` to spec. This is only partially implemented as some parts of the `@font-face` rule are not implemented yet.

This also adds the existing `@font-face` test to the welcome page.