### PR TITLE
Modify VideoPlayer and LibVideo to use ErrorOr and TRY.

### DIFF
--- a/Userland/Applications/VideoPlayer/main.cpp
+++ b/Userland/Applications/VideoPlayer/main.cpp
@@ -43,10 +43,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
             auto const& frame = block.frame(0);
             dbgln("Reading frame 0 from block @ {}", block.timestamp());
-            bool failed = !vp9_decoder.decode_frame(frame);
+            auto result = vp9_decoder.decode_frame(frame);
             vp9_decoder.dump_frame_info();
-            if (failed)
+            if (result.is_error()) {
+                outln("Error: {}", result.error().string_literal());
                 return 1;
+            }
         }
     }
 

--- a/Userland/Libraries/LibVideo/VP9/BitStream.h
+++ b/Userland/Libraries/LibVideo/VP9/BitStream.h
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2021, Hunter Salyer <thefalsehonesty@gmail.com>
+ * Copyright (c) 2022, Gregory Bertilson <zaggy1024@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/Optional.h>
 #include <AK/Types.h>
 
@@ -28,10 +30,10 @@ public:
     u16 read_f16();
 
     /* (9.2) */
-    bool init_bool(size_t bytes);
-    bool read_bool(u8 probability);
-    bool exit_bool();
-    u8 read_literal(size_t n);
+    ErrorOr<void> init_bool(size_t bytes);
+    ErrorOr<bool> read_bool(u8 probability);
+    ErrorOr<void> exit_bool();
+    ErrorOr<u8> read_literal(size_t n);
 
     /* (4.9.2) */
     i8 read_s(size_t n);

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Hunter Salyer <thefalsehonesty@gmail.com>
+ * Copyright (c) 2022, Gregory Bertilson <zaggy1024@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,15 +15,16 @@ Decoder::Decoder()
 {
 }
 
-bool Decoder::decode_frame(ByteBuffer const& frame_data)
+ErrorOr<void> Decoder::decode_frame(ByteBuffer const& frame_data)
 {
-    SAFE_CALL(m_parser->parse_frame(frame_data));
+    TRY(m_parser->parse_frame(frame_data));
     // TODO:
     //  - #2
     //  - #3
     //  - #4
-    SAFE_CALL(update_reference_frames());
-    return true;
+    TRY(update_reference_frames());
+
+    return {};
 }
 
 void Decoder::dump_frame_info()
@@ -49,7 +51,7 @@ u8 Decoder::merge_probs(int const* tree, int index, u8* probs, u8* counts, u8 co
     return left_count + right_count;
 }
 
-bool Decoder::adapt_coef_probs()
+ErrorOr<void> Decoder::adapt_coef_probs()
 {
     u8 update_factor;
     if (m_parser->m_frame_is_intra || m_parser->m_last_frame_type != KeyFrame)
@@ -76,7 +78,7 @@ bool Decoder::adapt_coef_probs()
         }
     }
 
-    return true;
+    return {};
 }
 
 #define ADAPT_PROB_TABLE(name, size)                                     \
@@ -94,7 +96,7 @@ bool Decoder::adapt_coef_probs()
         }                                                                                                  \
     } while (0)
 
-bool Decoder::adapt_non_coef_probs()
+ErrorOr<void> Decoder::adapt_non_coef_probs()
 {
     auto& probs = *m_parser->m_probability_tables;
     auto& counter = *m_parser->m_syntax_element_counter;
@@ -137,7 +139,7 @@ bool Decoder::adapt_non_coef_probs()
             probs.mv_hp_prob()[i] = adapt_prob(probs.mv_hp_prob()[i], counter.m_counts_mv_hp[i]);
         }
     }
-    return true;
+    return {};
 }
 
 void Decoder::adapt_probs(int const* tree, u8* probs, u8* counts)
@@ -150,25 +152,25 @@ u8 Decoder::adapt_prob(u8 prob, u8 counts[2])
     return merge_prob(prob, counts[0], counts[1], COUNT_SAT, MAX_UPDATE_FACTOR);
 }
 
-bool Decoder::predict_intra(size_t, u32, u32, bool, bool, bool, TXSize, u32)
+ErrorOr<void> Decoder::predict_intra(size_t, u32, u32, bool, bool, bool, TXSize, u32)
 {
     // TODO: Implement
-    return true;
+    return Error::from_string_literal("predict_intra not implemented");
 }
 
-bool Decoder::predict_inter(size_t, u32, u32, u32, u32, u32)
+ErrorOr<void> Decoder::predict_inter(size_t, u32, u32, u32, u32, u32)
 {
     // TODO: Implement
-    return true;
+    return Error::from_string_literal("predict_inter not implemented");
 }
 
-bool Decoder::reconstruct(size_t, u32, u32, TXSize)
+ErrorOr<void> Decoder::reconstruct(size_t, u32, u32, TXSize)
 {
     // TODO: Implement
-    return true;
+    return Error::from_string_literal("reconstruct not implemented");
 }
 
-bool Decoder::update_reference_frames()
+ErrorOr<void> Decoder::update_reference_frames()
 {
     for (auto i = 0; i < NUM_REF_FRAMES; i++) {
         dbgln("updating frame {}? {}", i, (m_parser->m_refresh_frame_flags & (1 << i)) == 1);
@@ -179,7 +181,7 @@ bool Decoder::update_reference_frames()
         // TODO: 1.3-1.7
     }
     // TODO: 2.1-2.2
-    return true;
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Hunter Salyer <thefalsehonesty@gmail.com>
+ * Copyright (c) 2022, Gregory Bertilson <zaggy1024@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +9,7 @@
 
 #include "Parser.h"
 #include <AK/ByteBuffer.h>
+#include <AK/Error.h>
 
 namespace Video::VP9 {
 
@@ -16,27 +18,27 @@ class Decoder {
 
 public:
     Decoder();
-    bool decode_frame(ByteBuffer const&);
+    ErrorOr<void> decode_frame(ByteBuffer const&);
     void dump_frame_info();
 
 private:
     /* (8.4) Probability Adaptation Process */
     u8 merge_prob(u8 pre_prob, u8 count_0, u8 count_1, u8 count_sat, u8 max_update_factor);
     u8 merge_probs(int const* tree, int index, u8* probs, u8* counts, u8 count_sat, u8 max_update_factor);
-    bool adapt_coef_probs();
-    bool adapt_non_coef_probs();
+    ErrorOr<void> adapt_coef_probs();
+    ErrorOr<void> adapt_non_coef_probs();
     void adapt_probs(int const* tree, u8* probs, u8* counts);
     u8 adapt_prob(u8 prob, u8 counts[2]);
 
     /* (8.5) Prediction Processes */
-    bool predict_intra(size_t plane, u32 x, u32 y, bool have_left, bool have_above, bool not_on_right, TXSize tx_size, u32 block_index);
-    bool predict_inter(size_t plane, u32 x, u32 y, u32 w, u32 h, u32 block_index);
+    ErrorOr<void> predict_intra(size_t plane, u32 x, u32 y, bool have_left, bool have_above, bool not_on_right, TXSize tx_size, u32 block_index);
+    ErrorOr<void> predict_inter(size_t plane, u32 x, u32 y, u32 w, u32 h, u32 block_index);
 
     /* (8.6) Reconstruction and Dequantization */
-    bool reconstruct(size_t plane, u32 x, u32 y, TXSize size);
+    ErrorOr<void> reconstruct(size_t plane, u32 x, u32 y, TXSize size);
 
     /* (8.10) Reference Frame Update Process */
-    bool update_reference_frames();
+    ErrorOr<void> update_reference_frames();
 
     NonnullOwnPtr<Parser> m_parser;
 };

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Hunter Salyer <thefalsehonesty@gmail.com>
+ * Copyright (c) 2022, Gregory Bertilson <zaggy1024@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,12 +8,9 @@
 #include "Parser.h"
 #include "Decoder.h"
 #include "Utilities.h"
+#include <AK/String.h>
 
 namespace Video::VP9 {
-
-#define RESERVED_ZERO                  \
-    if (m_bit_stream->read_bit() != 0) \
-    return false
 
 Parser::Parser(Decoder& decoder)
     : m_probability_tables(make<ProbabilityTables>())
@@ -42,75 +40,76 @@ void Parser::cleanup_tile_allocations()
 }
 
 /* (6.1) */
-bool Parser::parse_frame(ByteBuffer const& frame_data)
+ErrorOr<void> Parser::parse_frame(ByteBuffer const& frame_data)
 {
     m_bit_stream = make<BitStream>(frame_data.data(), frame_data.size());
     m_syntax_element_counter = make<SyntaxElementCounter>();
 
-    SAFE_CALL(uncompressed_header());
+    TRY(uncompressed_header());
     dbgln("Finished reading uncompressed header");
-    SAFE_CALL(trailing_bits());
-    if (m_header_size_in_bytes == 0) {
-        dbgln("No header");
-        return true;
-    }
+    if (!trailing_bits())
+        return Error::from_string_literal("parse_frame: Trailing bits were non-zero");
+    if (m_header_size_in_bytes == 0)
+        return Error::from_string_literal("parse_frame: Frame header is zero-sized");
     m_probability_tables->load_probs(m_frame_context_idx);
     m_probability_tables->load_probs2(m_frame_context_idx);
     m_syntax_element_counter->clear_counts();
 
-    SAFE_CALL(m_bit_stream->init_bool(m_header_size_in_bytes));
+    TRY(m_bit_stream->init_bool(m_header_size_in_bytes));
     dbgln("Reading compressed header");
-    SAFE_CALL(compressed_header());
+    TRY(compressed_header());
     dbgln("Finished reading compressed header");
-    SAFE_CALL(m_bit_stream->exit_bool());
+    TRY(m_bit_stream->exit_bool());
 
-    SAFE_CALL(decode_tiles());
-    SAFE_CALL(refresh_probs());
+    TRY(decode_tiles());
+    TRY(refresh_probs());
 
     dbgln("Finished reading frame!");
-    return true;
+    return {};
 }
 
 bool Parser::trailing_bits()
 {
-    while (m_bit_stream->get_position() & 7u)
-        RESERVED_ZERO;
+    while (m_bit_stream->get_position() & 7u) {
+        if (m_bit_stream->read_bit())
+            return false;
+    }
     return true;
 }
 
-bool Parser::refresh_probs()
+ErrorOr<void> Parser::refresh_probs()
 {
     if (!m_error_resilient_mode && !m_frame_parallel_decoding_mode) {
         m_probability_tables->load_probs(m_frame_context_idx);
-        SAFE_CALL(m_decoder.adapt_coef_probs());
+        TRY(m_decoder.adapt_coef_probs());
         if (!m_frame_is_intra) {
             m_probability_tables->load_probs2(m_frame_context_idx);
-            SAFE_CALL(m_decoder.adapt_non_coef_probs());
+            TRY(m_decoder.adapt_non_coef_probs());
         }
     }
     if (m_refresh_frame_context)
         m_probability_tables->save_probs(m_frame_context_idx);
-    return true;
+    return {};
 }
 
 /* (6.2) */
-bool Parser::uncompressed_header()
+ErrorOr<void> Parser::uncompressed_header()
 {
     auto frame_marker = m_bit_stream->read_f(2);
     if (frame_marker != 2)
-        return false;
+        return Error::from_string_literal("uncompressed_header: Frame marker must be 2");
     auto profile_low_bit = m_bit_stream->read_bit();
     auto profile_high_bit = m_bit_stream->read_bit();
     m_profile = (profile_high_bit << 1u) + profile_low_bit;
-    if (m_profile == 3)
-        RESERVED_ZERO;
+    if (m_profile == 3 && m_bit_stream->read_bit())
+        return Error::from_string_literal("uncompressed_header: Profile 3 reserved bit was non-zero");
     auto show_existing_frame = m_bit_stream->read_bit();
     if (show_existing_frame) {
         m_frame_to_show_map_index = m_bit_stream->read_f(3);
         m_header_size_in_bytes = 0;
         m_refresh_frame_flags = 0;
         m_loop_filter_level = 0;
-        return true;
+        return {};
     }
 
     m_last_frame_type = m_frame_type;
@@ -119,10 +118,10 @@ bool Parser::uncompressed_header()
     m_error_resilient_mode = m_bit_stream->read_bit();
 
     if (m_frame_type == KeyFrame) {
-        SAFE_CALL(frame_sync_code());
-        SAFE_CALL(color_config());
-        SAFE_CALL(frame_size());
-        SAFE_CALL(render_size());
+        TRY(frame_sync_code());
+        TRY(color_config());
+        frame_size();
+        render_size();
         m_refresh_frame_flags = 0xFF;
         m_frame_is_intra = true;
     } else {
@@ -135,9 +134,9 @@ bool Parser::uncompressed_header()
         }
 
         if (m_frame_is_intra) {
-            SAFE_CALL(frame_sync_code());
+            TRY(frame_sync_code());
             if (m_profile > 0) {
-                SAFE_CALL(color_config());
+                TRY(color_config());
             } else {
                 m_color_space = Bt601;
                 m_subsampling_x = true;
@@ -146,17 +145,17 @@ bool Parser::uncompressed_header()
             }
 
             m_refresh_frame_flags = m_bit_stream->read_f8();
-            SAFE_CALL(frame_size());
-            SAFE_CALL(render_size());
+            frame_size();
+            render_size();
         } else {
             m_refresh_frame_flags = m_bit_stream->read_f8();
             for (auto i = 0; i < 3; i++) {
                 m_ref_frame_idx[i] = m_bit_stream->read_f(3);
                 m_ref_frame_sign_bias[LastFrame + i] = m_bit_stream->read_bit();
             }
-            SAFE_CALL(frame_size_with_refs());
+            frame_size_with_refs();
             m_allow_high_precision_mv = m_bit_stream->read_bit();
-            SAFE_CALL(read_interpolation_filter());
+            read_interpolation_filter();
         }
     }
 
@@ -170,7 +169,7 @@ bool Parser::uncompressed_header()
 
     m_frame_context_idx = m_bit_stream->read_f(2);
     if (m_frame_is_intra || m_error_resilient_mode) {
-        SAFE_CALL(setup_past_independence());
+        setup_past_independence();
         if (m_frame_type == KeyFrame || m_error_resilient_mode || m_reset_frame_context == 3) {
             for (auto i = 0; i < 4; i++) {
                 m_probability_tables->save_probs(i);
@@ -181,26 +180,28 @@ bool Parser::uncompressed_header()
         m_frame_context_idx = 0;
     }
 
-    SAFE_CALL(loop_filter_params());
-    SAFE_CALL(quantization_params());
-    SAFE_CALL(segmentation_params());
-    SAFE_CALL(tile_info());
+    loop_filter_params();
+    quantization_params();
+    segmentation_params();
+    tile_info();
 
     m_header_size_in_bytes = m_bit_stream->read_f16();
 
-    return true;
+    return {};
 }
 
-bool Parser::frame_sync_code()
+ErrorOr<void> Parser::frame_sync_code()
 {
     if (m_bit_stream->read_byte() != 0x49)
-        return false;
+        return Error::from_string_literal("frame_sync_code: Byte 0 was not 0x49.");
     if (m_bit_stream->read_byte() != 0x83)
-        return false;
-    return m_bit_stream->read_byte() == 0x42;
+        return Error::from_string_literal("frame_sync_code: Byte 1 was not 0x83.");
+    if (m_bit_stream->read_byte() != 0x42)
+        return Error::from_string_literal("frame_sync_code: Byte 2 was not 0x42.");
+    return {};
 }
 
-bool Parser::color_config()
+ErrorOr<void> Parser::color_config()
 {
     if (m_profile >= 2) {
         m_bit_depth = m_bit_stream->read_bit() ? 12 : 10;
@@ -209,8 +210,7 @@ bool Parser::color_config()
     }
 
     auto color_space = m_bit_stream->read_f(3);
-    if (color_space > RGB)
-        return false;
+    VERIFY(color_space <= RGB);
     m_color_space = static_cast<ColorSpace>(color_space);
 
     if (color_space != RGB) {
@@ -218,7 +218,8 @@ bool Parser::color_config()
         if (m_profile == 1 || m_profile == 3) {
             m_subsampling_x = m_bit_stream->read_bit();
             m_subsampling_y = m_bit_stream->read_bit();
-            RESERVED_ZERO;
+            if (m_bit_stream->read_bit())
+                return Error::from_string_literal("color_config: Subsampling reserved zero was set");
         } else {
             m_subsampling_x = true;
             m_subsampling_y = true;
@@ -228,21 +229,21 @@ bool Parser::color_config()
         if (m_profile == 1 || m_profile == 3) {
             m_subsampling_x = false;
             m_subsampling_y = false;
-            RESERVED_ZERO;
+            if (m_bit_stream->read_bit())
+                return Error::from_string_literal("color_config: RGB reserved zero was set");
         }
     }
-    return true;
+    return {};
 }
 
-bool Parser::frame_size()
+void Parser::frame_size()
 {
     m_frame_width = m_bit_stream->read_f16() + 1;
     m_frame_height = m_bit_stream->read_f16() + 1;
-    SAFE_CALL(compute_image_size());
-    return true;
+    compute_image_size();
 }
 
-bool Parser::render_size()
+void Parser::render_size()
 {
     if (m_bit_stream->read_bit()) {
         m_render_width = m_bit_stream->read_f16() + 1;
@@ -251,10 +252,9 @@ bool Parser::render_size()
         m_render_width = m_frame_width;
         m_render_height = m_frame_height;
     }
-    return true;
 }
 
-bool Parser::frame_size_with_refs()
+void Parser::frame_size_with_refs()
 {
     bool found_ref;
     for (auto frame_index : m_ref_frame_idx) {
@@ -268,35 +268,32 @@ bool Parser::frame_size_with_refs()
     }
 
     if (!found_ref) {
-        SAFE_CALL(frame_size());
+        frame_size();
     } else {
-        SAFE_CALL(compute_image_size());
+        compute_image_size();
     }
 
-    SAFE_CALL(render_size());
-    return true;
+    render_size();
 }
 
-bool Parser::compute_image_size()
+void Parser::compute_image_size()
 {
     m_mi_cols = (m_frame_width + 7u) >> 3u;
     m_mi_rows = (m_frame_height + 7u) >> 3u;
     m_sb64_cols = (m_mi_cols + 7u) >> 3u;
     m_sb64_rows = (m_mi_rows + 7u) >> 3u;
-    return true;
 }
 
-bool Parser::read_interpolation_filter()
+void Parser::read_interpolation_filter()
 {
     if (m_bit_stream->read_bit()) {
         m_interpolation_filter = Switchable;
     } else {
         m_interpolation_filter = literal_to_type[m_bit_stream->read_f(2)];
     }
-    return true;
 }
 
-bool Parser::loop_filter_params()
+void Parser::loop_filter_params()
 {
     m_loop_filter_level = m_bit_stream->read_f(6);
     m_loop_filter_sharpness = m_bit_stream->read_f(3);
@@ -313,17 +310,15 @@ bool Parser::loop_filter_params()
             }
         }
     }
-    return true;
 }
 
-bool Parser::quantization_params()
+void Parser::quantization_params()
 {
     auto base_q_idx = m_bit_stream->read_byte();
     auto delta_q_y_dc = read_delta_q();
     auto delta_q_uv_dc = read_delta_q();
     auto delta_q_uv_ac = read_delta_q();
     m_lossless = base_q_idx == 0 && delta_q_y_dc == 0 && delta_q_uv_dc == 0 && delta_q_uv_ac == 0;
-    return true;
 }
 
 i8 Parser::read_delta_q()
@@ -333,11 +328,11 @@ i8 Parser::read_delta_q()
     return 0;
 }
 
-bool Parser::segmentation_params()
+void Parser::segmentation_params()
 {
     m_segmentation_enabled = m_bit_stream->read_bit();
     if (!m_segmentation_enabled)
-        return true;
+        return;
 
     m_segmentation_update_map = m_bit_stream->read_bit();
     if (m_segmentation_update_map) {
@@ -348,7 +343,10 @@ bool Parser::segmentation_params()
             segmentation_pred_prob = m_segmentation_temporal_update ? read_prob() : 255;
     }
 
-    SAFE_CALL(m_bit_stream->read_bit());
+    auto segmentation_update_data = (m_bit_stream->read_bit());
+
+    if (!segmentation_update_data)
+        return;
 
     m_segmentation_abs_or_delta_update = m_bit_stream->read_bit();
     for (auto i = 0; i < MAX_SEGMENTS; i++) {
@@ -367,7 +365,6 @@ bool Parser::segmentation_params()
             m_feature_data[i][j] = feature_value;
         }
     }
-    return true;
 }
 
 u8 Parser::read_prob()
@@ -377,7 +374,7 @@ u8 Parser::read_prob()
     return 255;
 }
 
-bool Parser::tile_info()
+void Parser::tile_info()
 {
     auto min_log2_tile_cols = calc_min_log2_tile_cols();
     auto max_log2_tile_cols = calc_max_log2_tile_cols();
@@ -392,7 +389,6 @@ bool Parser::tile_info()
     if (m_tile_rows_log2) {
         m_tile_rows_log2 += m_bit_stream->read_bit();
     }
-    return true;
 }
 
 u16 Parser::calc_min_log2_tile_cols()
@@ -411,7 +407,7 @@ u16 Parser::calc_max_log2_tile_cols()
     return max_log_2 - 1;
 }
 
-bool Parser::setup_past_independence()
+void Parser::setup_past_independence()
 {
     for (auto i = 0; i < 8; i++) {
         for (auto j = 0; j < 4; j++) {
@@ -431,83 +427,82 @@ bool Parser::setup_past_independence()
     for (auto& loop_filter_mode_delta : m_loop_filter_mode_deltas)
         loop_filter_mode_delta = 0;
     m_probability_tables->reset_probs();
-    return true;
 }
 
-bool Parser::compressed_header()
+ErrorOr<void> Parser::compressed_header()
 {
-    SAFE_CALL(read_tx_mode());
+    TRY(read_tx_mode());
     if (m_tx_mode == TXModeSelect)
-        SAFE_CALL(tx_mode_probs());
-    SAFE_CALL(read_coef_probs());
-    SAFE_CALL(read_skip_prob());
+        TRY(tx_mode_probs());
+    TRY(read_coef_probs());
+    TRY(read_skip_prob());
     if (!m_frame_is_intra) {
-        SAFE_CALL(read_inter_mode_probs());
+        TRY(read_inter_mode_probs());
         if (m_interpolation_filter == Switchable)
-            SAFE_CALL(read_interp_filter_probs());
-        SAFE_CALL(read_is_inter_probs());
-        SAFE_CALL(frame_reference_mode());
-        SAFE_CALL(frame_reference_mode_probs());
-        SAFE_CALL(read_y_mode_probs());
-        SAFE_CALL(read_partition_probs());
-        SAFE_CALL(mv_probs());
+            TRY(read_interp_filter_probs());
+        TRY(read_is_inter_probs());
+        TRY(frame_reference_mode());
+        TRY(frame_reference_mode_probs());
+        TRY(read_y_mode_probs());
+        TRY(read_partition_probs());
+        TRY(mv_probs());
     }
-    return true;
+    return {};
 }
 
-bool Parser::read_tx_mode()
+ErrorOr<void> Parser::read_tx_mode()
 {
     if (m_lossless) {
         m_tx_mode = Only_4x4;
     } else {
-        auto tx_mode = m_bit_stream->read_literal(2);
+        auto tx_mode = TRY(m_bit_stream->read_literal(2));
         if (tx_mode == Allow_32x32)
-            tx_mode += m_bit_stream->read_literal(1);
+            tx_mode += TRY(m_bit_stream->read_literal(1));
         m_tx_mode = static_cast<TXMode>(tx_mode);
     }
-    return true;
+    return {};
 }
 
-bool Parser::tx_mode_probs()
+ErrorOr<void> Parser::tx_mode_probs()
 {
     auto& tx_probs = m_probability_tables->tx_probs();
     for (auto i = 0; i < TX_SIZE_CONTEXTS; i++) {
         for (auto j = 0; j < TX_SIZES - 3; j++)
-            tx_probs[TX_8x8][i][j] = diff_update_prob(tx_probs[TX_8x8][i][j]);
+            tx_probs[TX_8x8][i][j] = TRY(diff_update_prob(tx_probs[TX_8x8][i][j]));
     }
     for (auto i = 0; i < TX_SIZE_CONTEXTS; i++) {
         for (auto j = 0; j < TX_SIZES - 2; j++)
-            tx_probs[TX_16x16][i][j] = diff_update_prob(tx_probs[TX_16x16][i][j]);
+            tx_probs[TX_16x16][i][j] = TRY(diff_update_prob(tx_probs[TX_16x16][i][j]));
     }
     for (auto i = 0; i < TX_SIZE_CONTEXTS; i++) {
         for (auto j = 0; j < TX_SIZES - 1; j++)
-            tx_probs[TX_32x32][i][j] = diff_update_prob(tx_probs[TX_32x32][i][j]);
+            tx_probs[TX_32x32][i][j] = TRY(diff_update_prob(tx_probs[TX_32x32][i][j]));
     }
-    return true;
+    return {};
 }
 
-u8 Parser::diff_update_prob(u8 prob)
+ErrorOr<u8> Parser::diff_update_prob(u8 prob)
 {
-    if (m_bit_stream->read_bool(252)) {
-        auto delta_prob = decode_term_subexp();
+    if (TRY(m_bit_stream->read_bool(252))) {
+        auto delta_prob = TRY(decode_term_subexp());
         prob = inv_remap_prob(delta_prob, prob);
     }
     return prob;
 }
 
-u8 Parser::decode_term_subexp()
+ErrorOr<u8> Parser::decode_term_subexp()
 {
-    if (m_bit_stream->read_literal(1) == 0)
-        return m_bit_stream->read_literal(4);
-    if (m_bit_stream->read_literal(1) == 0)
-        return m_bit_stream->read_literal(4) + 16;
-    if (m_bit_stream->read_literal(1) == 0)
-        return m_bit_stream->read_literal(4) + 32;
+    if (TRY(m_bit_stream->read_literal(1)) == 0)
+        return TRY(m_bit_stream->read_literal(4));
+    if (TRY(m_bit_stream->read_literal(1)) == 0)
+        return TRY(m_bit_stream->read_literal(4)) + 16;
+    if (TRY(m_bit_stream->read_literal(1)) == 0)
+        return TRY(m_bit_stream->read_literal(4)) + 32;
 
-    auto v = m_bit_stream->read_literal(7);
+    auto v = TRY(m_bit_stream->read_literal(7));
     if (v < 65)
         return v + 64;
-    return (v << 1u) - 1 + m_bit_stream->read_literal(1);
+    return (v << 1u) - 1 + TRY(m_bit_stream->read_literal(1));
 }
 
 u8 Parser::inv_remap_prob(u8 delta_prob, u8 prob)
@@ -528,11 +523,11 @@ u8 Parser::inv_recenter_nonneg(u8 v, u8 m)
     return m + (v >> 1u);
 }
 
-bool Parser::read_coef_probs()
+ErrorOr<void> Parser::read_coef_probs()
 {
     m_max_tx_size = tx_mode_to_biggest_tx_size[m_tx_mode];
     for (auto tx_size = TX_4x4; tx_size <= m_max_tx_size; tx_size = static_cast<TXSize>(static_cast<int>(tx_size) + 1)) {
-        auto update_probs = m_bit_stream->read_literal(1);
+        auto update_probs = TRY(m_bit_stream->read_literal(1));
         if (update_probs == 1) {
             for (auto i = 0; i < 2; i++) {
                 for (auto j = 0; j < 2; j++) {
@@ -541,7 +536,7 @@ bool Parser::read_coef_probs()
                         for (auto l = 0; l < max_l; l++) {
                             for (auto m = 0; m < 3; m++) {
                                 auto& coef_probs = m_probability_tables->coef_probs()[tx_size];
-                                coef_probs[i][j][k][l][m] = diff_update_prob(coef_probs[i][j][k][l][m]);
+                                coef_probs[i][j][k][l][m] = TRY(diff_update_prob(coef_probs[i][j][k][l][m]));
                             }
                         }
                     }
@@ -549,42 +544,42 @@ bool Parser::read_coef_probs()
             }
         }
     }
-    return true;
+    return {};
 }
 
-bool Parser::read_skip_prob()
+ErrorOr<void> Parser::read_skip_prob()
 {
     for (auto i = 0; i < SKIP_CONTEXTS; i++)
-        m_probability_tables->skip_prob()[i] = diff_update_prob(m_probability_tables->skip_prob()[i]);
-    return true;
+        m_probability_tables->skip_prob()[i] = TRY(diff_update_prob(m_probability_tables->skip_prob()[i]));
+    return {};
 }
 
-bool Parser::read_inter_mode_probs()
+ErrorOr<void> Parser::read_inter_mode_probs()
 {
     for (auto i = 0; i < INTER_MODE_CONTEXTS; i++) {
         for (auto j = 0; j < INTER_MODES - 1; j++)
-            m_probability_tables->inter_mode_probs()[i][j] = diff_update_prob(m_probability_tables->inter_mode_probs()[i][j]);
+            m_probability_tables->inter_mode_probs()[i][j] = TRY(diff_update_prob(m_probability_tables->inter_mode_probs()[i][j]));
     }
-    return true;
+    return {};
 }
 
-bool Parser::read_interp_filter_probs()
+ErrorOr<void> Parser::read_interp_filter_probs()
 {
     for (auto i = 0; i < INTERP_FILTER_CONTEXTS; i++) {
         for (auto j = 0; j < SWITCHABLE_FILTERS - 1; j++)
-            m_probability_tables->interp_filter_probs()[i][j] = diff_update_prob(m_probability_tables->interp_filter_probs()[i][j]);
+            m_probability_tables->interp_filter_probs()[i][j] = TRY(diff_update_prob(m_probability_tables->interp_filter_probs()[i][j]));
     }
-    return true;
+    return {};
 }
 
-bool Parser::read_is_inter_probs()
+ErrorOr<void> Parser::read_is_inter_probs()
 {
     for (auto i = 0; i < IS_INTER_CONTEXTS; i++)
-        m_probability_tables->is_inter_prob()[i] = diff_update_prob(m_probability_tables->is_inter_prob()[i]);
-    return true;
+        m_probability_tables->is_inter_prob()[i] = TRY(diff_update_prob(m_probability_tables->is_inter_prob()[i]));
+    return {};
 }
 
-bool Parser::frame_reference_mode()
+ErrorOr<void> Parser::frame_reference_mode()
 {
     auto compound_reference_allowed = false;
     for (size_t i = 2; i <= REFS_PER_FRAME; i++) {
@@ -592,88 +587,88 @@ bool Parser::frame_reference_mode()
             compound_reference_allowed = true;
     }
     if (compound_reference_allowed) {
-        auto non_single_reference = m_bit_stream->read_literal(1);
+        auto non_single_reference = TRY(m_bit_stream->read_literal(1));
         if (non_single_reference == 0) {
             m_reference_mode = SingleReference;
         } else {
-            auto reference_select = m_bit_stream->read_literal(1);
+            auto reference_select = TRY(m_bit_stream->read_literal(1));
             if (reference_select == 0)
                 m_reference_mode = CompoundReference;
             else
                 m_reference_mode = ReferenceModeSelect;
-            SAFE_CALL(setup_compound_reference_mode());
+            setup_compound_reference_mode();
         }
     } else {
         m_reference_mode = SingleReference;
     }
-    return true;
+    return {};
 }
 
-bool Parser::frame_reference_mode_probs()
+ErrorOr<void> Parser::frame_reference_mode_probs()
 {
     if (m_reference_mode == ReferenceModeSelect) {
         for (auto i = 0; i < COMP_MODE_CONTEXTS; i++) {
             auto& comp_mode_prob = m_probability_tables->comp_mode_prob();
-            comp_mode_prob[i] = diff_update_prob(comp_mode_prob[i]);
+            comp_mode_prob[i] = TRY(diff_update_prob(comp_mode_prob[i]));
         }
     }
     if (m_reference_mode != CompoundReference) {
         for (auto i = 0; i < REF_CONTEXTS; i++) {
             auto& single_ref_prob = m_probability_tables->single_ref_prob();
-            single_ref_prob[i][0] = diff_update_prob(single_ref_prob[i][0]);
-            single_ref_prob[i][1] = diff_update_prob(single_ref_prob[i][1]);
+            single_ref_prob[i][0] = TRY(diff_update_prob(single_ref_prob[i][0]));
+            single_ref_prob[i][1] = TRY(diff_update_prob(single_ref_prob[i][1]));
         }
     }
     if (m_reference_mode != SingleReference) {
         for (auto i = 0; i < REF_CONTEXTS; i++) {
             auto& comp_ref_prob = m_probability_tables->comp_ref_prob();
-            comp_ref_prob[i] = diff_update_prob(comp_ref_prob[i]);
+            comp_ref_prob[i] = TRY(diff_update_prob(comp_ref_prob[i]));
         }
     }
-    return true;
+    return {};
 }
 
-bool Parser::read_y_mode_probs()
+ErrorOr<void> Parser::read_y_mode_probs()
 {
     for (auto i = 0; i < BLOCK_SIZE_GROUPS; i++) {
         for (auto j = 0; j < INTRA_MODES - 1; j++) {
             auto& y_mode_probs = m_probability_tables->y_mode_probs();
-            y_mode_probs[i][j] = diff_update_prob(y_mode_probs[i][j]);
+            y_mode_probs[i][j] = TRY(diff_update_prob(y_mode_probs[i][j]));
         }
     }
-    return true;
+    return {};
 }
 
-bool Parser::read_partition_probs()
+ErrorOr<void> Parser::read_partition_probs()
 {
     for (auto i = 0; i < PARTITION_CONTEXTS; i++) {
         for (auto j = 0; j < PARTITION_TYPES - 1; j++) {
             auto& partition_probs = m_probability_tables->partition_probs();
-            partition_probs[i][j] = diff_update_prob(partition_probs[i][j]);
+            partition_probs[i][j] = TRY(diff_update_prob(partition_probs[i][j]));
         }
     }
-    return true;
+    return {};
 }
 
-bool Parser::mv_probs()
+ErrorOr<void> Parser::mv_probs()
 {
     for (auto j = 0; j < MV_JOINTS - 1; j++) {
         auto& mv_joint_probs = m_probability_tables->mv_joint_probs();
-        mv_joint_probs[j] = update_mv_prob(mv_joint_probs[j]);
+        mv_joint_probs[j] = TRY(update_mv_prob(mv_joint_probs[j]));
     }
 
     for (auto i = 0; i < 2; i++) {
         auto& mv_sign_prob = m_probability_tables->mv_sign_prob();
-        mv_sign_prob[i] = update_mv_prob(mv_sign_prob[i]);
+        mv_sign_prob[i] = TRY(update_mv_prob(mv_sign_prob[i]));
         for (auto j = 0; j < MV_CLASSES - 1; j++) {
             auto& mv_class_probs = m_probability_tables->mv_class_probs();
-            mv_class_probs[i][j] = update_mv_prob(mv_class_probs[i][j]);
+            mv_class_probs[i][j] = TRY(update_mv_prob(mv_class_probs[i][j]));
         }
         auto& mv_class0_bit_prob = m_probability_tables->mv_class0_bit_prob();
-        mv_class0_bit_prob[i] = update_mv_prob(mv_class0_bit_prob[i]);
+        mv_class0_bit_prob[i] = TRY(update_mv_prob(mv_class0_bit_prob[i]));
         for (auto j = 0; j < MV_OFFSET_BITS; j++) {
             auto& mv_bits_prob = m_probability_tables->mv_bits_prob();
-            mv_bits_prob[i][j] = update_mv_prob(mv_bits_prob[i][j]);
+            mv_bits_prob[i][j] = TRY(update_mv_prob(mv_bits_prob[i][j]));
         }
     }
 
@@ -681,12 +676,12 @@ bool Parser::mv_probs()
         for (auto j = 0; j < CLASS0_SIZE; j++) {
             for (auto k = 0; k < MV_FR_SIZE - 1; k++) {
                 auto& mv_class0_fr_probs = m_probability_tables->mv_class0_fr_probs();
-                mv_class0_fr_probs[i][j][k] = update_mv_prob(mv_class0_fr_probs[i][j][k]);
+                mv_class0_fr_probs[i][j][k] = TRY(update_mv_prob(mv_class0_fr_probs[i][j][k]));
             }
         }
         for (auto k = 0; k < MV_FR_SIZE - 1; k++) {
             auto& mv_fr_probs = m_probability_tables->mv_fr_probs();
-            mv_fr_probs[i][k] = update_mv_prob(mv_fr_probs[i][k]);
+            mv_fr_probs[i][k] = TRY(update_mv_prob(mv_fr_probs[i][k]));
         }
     }
 
@@ -694,23 +689,23 @@ bool Parser::mv_probs()
         for (auto i = 0; i < 2; i++) {
             auto& mv_class0_hp_prob = m_probability_tables->mv_class0_hp_prob();
             auto& mv_hp_prob = m_probability_tables->mv_hp_prob();
-            mv_class0_hp_prob[i] = update_mv_prob(mv_class0_hp_prob[i]);
-            mv_hp_prob[i] = update_mv_prob(mv_hp_prob[i]);
+            mv_class0_hp_prob[i] = TRY(update_mv_prob(mv_class0_hp_prob[i]));
+            mv_hp_prob[i] = TRY(update_mv_prob(mv_hp_prob[i]));
         }
     }
 
-    return true;
+    return {};
 }
 
-u8 Parser::update_mv_prob(u8 prob)
+ErrorOr<u8> Parser::update_mv_prob(u8 prob)
 {
-    if (m_bit_stream->read_bool(252)) {
-        return (m_bit_stream->read_literal(7) << 1u) | 1u;
+    if (TRY(m_bit_stream->read_bool(252))) {
+        return (TRY(m_bit_stream->read_literal(7)) << 1u) | 1u;
     }
     return prob;
 }
 
-bool Parser::setup_compound_reference_mode()
+void Parser::setup_compound_reference_mode()
 {
     if (m_ref_frame_sign_bias[LastFrame] == m_ref_frame_sign_bias[GoldenFrame]) {
         m_comp_fixed_ref = AltRefFrame;
@@ -725,7 +720,6 @@ bool Parser::setup_compound_reference_mode()
         m_comp_var_ref[0] = GoldenFrame;
         m_comp_var_ref[1] = AltRefFrame;
     }
-    return true;
 }
 
 void Parser::allocate_tile_data()
@@ -747,12 +741,12 @@ void Parser::allocate_tile_data()
     m_allocated_dimensions = dimensions;
 }
 
-bool Parser::decode_tiles()
+ErrorOr<void> Parser::decode_tiles()
 {
     auto tile_cols = 1 << m_tile_cols_log2;
     auto tile_rows = 1 << m_tile_rows_log2;
     allocate_tile_data();
-    SAFE_CALL(clear_above_context());
+    clear_above_context();
     for (auto tile_row = 0; tile_row < tile_rows; tile_row++) {
         for (auto tile_col = 0; tile_col < tile_cols; tile_col++) {
             auto last_tile = (tile_row == tile_rows - 1) && (tile_col == tile_cols - 1);
@@ -761,12 +755,12 @@ bool Parser::decode_tiles()
             m_mi_row_end = get_tile_offset(tile_row + 1, m_mi_rows, m_tile_rows_log2);
             m_mi_col_start = get_tile_offset(tile_col, m_mi_cols, m_tile_cols_log2);
             m_mi_col_end = get_tile_offset(tile_col + 1, m_mi_cols, m_tile_cols_log2);
-            SAFE_CALL(m_bit_stream->init_bool(tile_size));
-            SAFE_CALL(decode_tile());
-            SAFE_CALL(m_bit_stream->exit_bool());
+            TRY(m_bit_stream->init_bool(tile_size));
+            TRY(decode_tile());
+            TRY(m_bit_stream->exit_bool());
         }
     }
-    return true;
+    return {};
 }
 
 void Parser::clear_context(Vector<u8>& context, size_t size)
@@ -783,12 +777,11 @@ void Parser::clear_context(Vector<Vector<u8>>& context, size_t outer_size, size_
         clear_context(sub_vector, inner_size);
 }
 
-bool Parser::clear_above_context()
+void Parser::clear_above_context()
 {
     clear_context(m_above_nonzero_context, 3, 2 * m_mi_cols);
     clear_context(m_above_seg_pred_context, m_mi_cols);
     clear_context(m_above_partition_context, m_sb64_cols * 8);
-    return true;
 }
 
 u32 Parser::get_tile_offset(u32 tile_num, u32 mis, u32 tile_size_log2)
@@ -798,54 +791,53 @@ u32 Parser::get_tile_offset(u32 tile_num, u32 mis, u32 tile_size_log2)
     return min(offset, mis);
 }
 
-bool Parser::decode_tile()
+ErrorOr<void> Parser::decode_tile()
 {
     for (auto row = m_mi_row_start; row < m_mi_row_end; row += 8) {
-        SAFE_CALL(clear_left_context());
+        clear_left_context();
         m_row = row;
         for (auto col = m_mi_col_start; col < m_mi_col_end; col += 8) {
             m_col = col;
-            SAFE_CALL(decode_partition(row, col, Block_64x64));
+            TRY(decode_partition(row, col, Block_64x64));
         }
     }
-    return true;
+    return {};
 }
 
-bool Parser::clear_left_context()
+void Parser::clear_left_context()
 {
     clear_context(m_left_nonzero_context, 3, 2 * m_mi_rows);
     clear_context(m_left_seg_pred_context, m_mi_rows);
     clear_context(m_left_partition_context, m_sb64_rows * 8);
-    return true;
 }
 
-bool Parser::decode_partition(u32 row, u32 col, u8 block_subsize)
+ErrorOr<void> Parser::decode_partition(u32 row, u32 col, u8 block_subsize)
 {
     if (row >= m_mi_rows || col >= m_mi_cols)
-        return false;
+        return Error::from_string_literal("decode_partition: Row or column were outside valid ranges");
     m_block_subsize = block_subsize;
     m_num_8x8 = num_8x8_blocks_wide_lookup[block_subsize];
     auto half_block_8x8 = m_num_8x8 >> 1;
     m_has_rows = (row + half_block_8x8) < m_mi_rows;
     m_has_cols = (col + half_block_8x8) < m_mi_cols;
 
-    auto partition = m_tree_parser->parse_tree(SyntaxElementType::Partition);
+    auto partition = TRY(m_tree_parser->parse_tree(SyntaxElementType::Partition));
     auto subsize = subsize_lookup[partition][block_subsize];
     if (subsize < Block_8x8 || partition == PartitionNone) {
-        SAFE_CALL(decode_block(row, col, subsize));
+        TRY(decode_block(row, col, subsize));
     } else if (partition == PartitionHorizontal) {
-        SAFE_CALL(decode_block(row, col, subsize));
+        TRY(decode_block(row, col, subsize));
         if (m_has_rows)
-            SAFE_CALL(decode_block(row + half_block_8x8, col, subsize));
+            TRY(decode_block(row + half_block_8x8, col, subsize));
     } else if (partition == PartitionVertical) {
-        SAFE_CALL(decode_block(row, col, subsize));
+        TRY(decode_block(row, col, subsize));
         if (m_has_cols)
-            SAFE_CALL(decode_block(row, col + half_block_8x8, subsize));
+            TRY(decode_block(row, col + half_block_8x8, subsize));
     } else {
-        SAFE_CALL(decode_partition(row, col, subsize));
-        SAFE_CALL(decode_partition(row, col + half_block_8x8, subsize));
-        SAFE_CALL(decode_partition(row + half_block_8x8, col, subsize));
-        SAFE_CALL(decode_partition(row + half_block_8x8, col + half_block_8x8, subsize));
+        TRY(decode_partition(row, col, subsize));
+        TRY(decode_partition(row, col + half_block_8x8, subsize));
+        TRY(decode_partition(row + half_block_8x8, col, subsize));
+        TRY(decode_partition(row + half_block_8x8, col + half_block_8x8, subsize));
     }
     if (block_subsize == Block_8x8 || partition != PartitionSplit) {
         for (size_t i = 0; i < m_num_8x8; i++) {
@@ -853,19 +845,19 @@ bool Parser::decode_partition(u32 row, u32 col, u8 block_subsize)
             m_left_partition_context[row + i] = 15 >> b_width_log2_lookup[subsize];
         }
     }
-    return true;
+    return {};
 }
 
-bool Parser::decode_block(u32 row, u32 col, u8 subsize)
+ErrorOr<void> Parser::decode_block(u32 row, u32 col, u8 subsize)
 {
     m_mi_row = row;
     m_mi_col = col;
     m_mi_size = subsize;
     m_available_u = row > 0;
     m_available_l = col > m_mi_col_start;
-    SAFE_CALL(mode_info());
+    TRY(mode_info());
     m_eob_total = 0;
-    SAFE_CALL(residual());
+    TRY(residual());
     if (m_is_inter && subsize >= Block_8x8 && m_eob_total == 0)
         m_skip = true;
     for (size_t y = 0; y < num_8x8_blocks_high_lookup[subsize]; y++) {
@@ -892,26 +884,28 @@ bool Parser::decode_block(u32 row, u32 col, u8 subsize)
             }
         }
     }
-    return true;
+    return {};
 }
 
-bool Parser::mode_info()
+ErrorOr<void> Parser::mode_info()
 {
     if (m_frame_is_intra)
-        return intra_frame_mode_info();
-    return inter_frame_mode_info();
+        TRY(intra_frame_mode_info());
+    else
+        TRY(inter_frame_mode_info());
+    return {};
 }
 
-bool Parser::intra_frame_mode_info()
+ErrorOr<void> Parser::intra_frame_mode_info()
 {
-    SAFE_CALL(intra_segment_id());
-    SAFE_CALL(read_skip());
-    SAFE_CALL(read_tx_size(true));
+    TRY(intra_segment_id());
+    TRY(read_skip());
+    TRY(read_tx_size(true));
     m_ref_frame[0] = IntraFrame;
     m_ref_frame[1] = None;
     m_is_inter = false;
     if (m_mi_size >= Block_8x8) {
-        m_default_intra_mode = m_tree_parser->parse_tree<IntraMode>(SyntaxElementType::DefaultIntraMode);
+        m_default_intra_mode = TRY(m_tree_parser->parse_tree<IntraMode>(SyntaxElementType::DefaultIntraMode));
         m_y_mode = m_default_intra_mode;
         for (auto& block_sub_mode : m_block_sub_modes)
             block_sub_mode = m_y_mode;
@@ -921,7 +915,7 @@ bool Parser::intra_frame_mode_info()
         for (auto idy = 0; idy < 2; idy += m_num_4x4_h) {
             for (auto idx = 0; idx < 2; idx += m_num_4x4_w) {
                 m_tree_parser->set_default_intra_mode_variables(idx, idy);
-                m_default_intra_mode = m_tree_parser->parse_tree<IntraMode>(SyntaxElementType::DefaultIntraMode);
+                m_default_intra_mode = TRY(m_tree_parser->parse_tree<IntraMode>(SyntaxElementType::DefaultIntraMode));
                 for (auto y = 0; y < m_num_4x4_h; y++) {
                     for (auto x = 0; x < m_num_4x4_w; x++) {
                         auto index = (idy + y) * 2 + idx + x;
@@ -934,26 +928,26 @@ bool Parser::intra_frame_mode_info()
         }
         m_y_mode = m_default_intra_mode;
     }
-    m_uv_mode = m_tree_parser->parse_tree<u8>(SyntaxElementType::DefaultUVMode);
-    return true;
+    m_uv_mode = TRY(m_tree_parser->parse_tree<u8>(SyntaxElementType::DefaultUVMode));
+    return {};
 }
 
-bool Parser::intra_segment_id()
+ErrorOr<void> Parser::intra_segment_id()
 {
     if (m_segmentation_enabled && m_segmentation_update_map)
-        m_segment_id = m_tree_parser->parse_tree<u8>(SyntaxElementType::SegmentID);
+        m_segment_id = TRY(m_tree_parser->parse_tree<u8>(SyntaxElementType::SegmentID));
     else
         m_segment_id = 0;
-    return true;
+    return {};
 }
 
-bool Parser::read_skip()
+ErrorOr<void> Parser::read_skip()
 {
     if (seg_feature_active(SEG_LVL_SKIP))
         m_skip = true;
     else
-        m_skip = m_tree_parser->parse_tree<bool>(SyntaxElementType::Skip);
-    return true;
+        m_skip = TRY(m_tree_parser->parse_tree<bool>(SyntaxElementType::Skip));
+    return {};
 }
 
 bool Parser::seg_feature_active(u8 feature)
@@ -961,17 +955,17 @@ bool Parser::seg_feature_active(u8 feature)
     return m_segmentation_enabled && m_feature_enabled[m_segment_id][feature];
 }
 
-bool Parser::read_tx_size(bool allow_select)
+ErrorOr<void> Parser::read_tx_size(bool allow_select)
 {
     m_max_tx_size = max_txsize_lookup[m_mi_size];
     if (allow_select && m_tx_mode == TXModeSelect && m_mi_size >= Block_8x8)
-        m_tx_size = m_tree_parser->parse_tree<TXSize>(SyntaxElementType::TXSize);
+        m_tx_size = TRY(m_tree_parser->parse_tree<TXSize>(SyntaxElementType::TXSize));
     else
         m_tx_size = min(m_max_tx_size, tx_mode_to_biggest_tx_size[m_tx_mode]);
-    return true;
+    return {};
 }
 
-bool Parser::inter_frame_mode_info()
+ErrorOr<void> Parser::inter_frame_mode_info()
 {
     m_left_ref_frame[0] = m_available_l ? m_ref_frames[m_mi_row * m_mi_cols + (m_mi_col - 1)] : IntraFrame;
     m_above_ref_frame[0] = m_available_u ? m_ref_frames[(m_mi_row - 1) * m_mi_cols + m_mi_col] : IntraFrame;
@@ -981,44 +975,44 @@ bool Parser::inter_frame_mode_info()
     m_above_intra = m_above_ref_frame[0] <= IntraFrame;
     m_left_single = m_left_ref_frame[1] <= None;
     m_above_single = m_above_ref_frame[1] <= None;
-    SAFE_CALL(inter_segment_id());
-    SAFE_CALL(read_skip());
-    SAFE_CALL(read_is_inter());
-    SAFE_CALL(read_tx_size(!m_skip || !m_is_inter));
+    TRY(inter_segment_id());
+    TRY(read_skip());
+    TRY(read_is_inter());
+    TRY(read_tx_size(!m_skip || !m_is_inter));
     if (m_is_inter) {
-        SAFE_CALL(inter_block_mode_info());
+        TRY(inter_block_mode_info());
     } else {
-        SAFE_CALL(intra_block_mode_info());
+        TRY(intra_block_mode_info());
     }
-    return true;
+    return {};
 }
 
-bool Parser::inter_segment_id()
+ErrorOr<void> Parser::inter_segment_id()
 {
     if (!m_segmentation_enabled) {
         m_segment_id = 0;
-        return true;
+        return {};
     }
     auto predicted_segment_id = get_segment_id();
     if (!m_segmentation_update_map) {
         m_segment_id = predicted_segment_id;
-        return true;
+        return {};
     }
     if (!m_segmentation_temporal_update) {
-        m_segment_id = m_tree_parser->parse_tree<u8>(SyntaxElementType::SegmentID);
-        return true;
+        m_segment_id = TRY(m_tree_parser->parse_tree<u8>(SyntaxElementType::SegmentID));
+        return {};
     }
 
-    auto seg_id_predicted = m_tree_parser->parse_tree<bool>(SyntaxElementType::SegIDPredicted);
+    auto seg_id_predicted = TRY(m_tree_parser->parse_tree<bool>(SyntaxElementType::SegIDPredicted));
     if (seg_id_predicted)
         m_segment_id = predicted_segment_id;
     else
-        m_segment_id = m_tree_parser->parse_tree<u8>(SyntaxElementType::SegmentID);
+        m_segment_id = TRY(m_tree_parser->parse_tree<u8>(SyntaxElementType::SegmentID));
     for (size_t i = 0; i < num_8x8_blocks_wide_lookup[m_mi_size]; i++)
         m_above_seg_pred_context[m_mi_col + i] = seg_id_predicted;
     for (size_t i = 0; i < num_8x8_blocks_high_lookup[m_mi_size]; i++)
         m_left_seg_pred_context[m_mi_row + i] = seg_id_predicted;
-    return true;
+    return {};
 }
 
 u8 Parser::get_segment_id()
@@ -1036,21 +1030,21 @@ u8 Parser::get_segment_id()
     return segment;
 }
 
-bool Parser::read_is_inter()
+ErrorOr<void> Parser::read_is_inter()
 {
     if (seg_feature_active(SEG_LVL_REF_FRAME))
         m_is_inter = m_feature_data[m_segment_id][SEG_LVL_REF_FRAME] != IntraFrame;
     else
-        m_is_inter = m_tree_parser->parse_tree<bool>(SyntaxElementType::IsInter);
-    return true;
+        m_is_inter = TRY(m_tree_parser->parse_tree<bool>(SyntaxElementType::IsInter));
+    return {};
 }
 
-bool Parser::intra_block_mode_info()
+ErrorOr<void> Parser::intra_block_mode_info()
 {
     m_ref_frame[0] = IntraFrame;
     m_ref_frame[1] = None;
     if (m_mi_size >= Block_8x8) {
-        m_y_mode = m_tree_parser->parse_tree<u8>(SyntaxElementType::IntraMode);
+        m_y_mode = TRY(m_tree_parser->parse_tree<u8>(SyntaxElementType::IntraMode));
         for (auto& block_sub_mode : m_block_sub_modes)
             block_sub_mode = m_y_mode;
     } else {
@@ -1059,7 +1053,7 @@ bool Parser::intra_block_mode_info()
         u8 sub_intra_mode;
         for (auto idy = 0; idy < 2; idy += m_num_4x4_h) {
             for (auto idx = 0; idx < 2; idx += m_num_4x4_w) {
-                sub_intra_mode = m_tree_parser->parse_tree<u8>(SyntaxElementType::SubIntraMode);
+                sub_intra_mode = TRY(m_tree_parser->parse_tree<u8>(SyntaxElementType::SubIntraMode));
                 for (auto y = 0; y < m_num_4x4_h; y++) {
                     for (auto x = 0; x < m_num_4x4_w; x++)
                         m_block_sub_modes[(idy + y) * 2 + idx + x] = sub_intra_mode;
@@ -1068,28 +1062,28 @@ bool Parser::intra_block_mode_info()
         }
         m_y_mode = sub_intra_mode;
     }
-    m_uv_mode = m_tree_parser->parse_tree<u8>(SyntaxElementType::UVMode);
-    return true;
+    m_uv_mode = TRY(m_tree_parser->parse_tree<u8>(SyntaxElementType::UVMode));
+    return {};
 }
 
-bool Parser::inter_block_mode_info()
+ErrorOr<void> Parser::inter_block_mode_info()
 {
-    SAFE_CALL(read_ref_frames());
+    TRY(read_ref_frames());
     for (auto j = 0; j < 2; j++) {
         if (m_ref_frame[j] > IntraFrame) {
-            SAFE_CALL(find_mv_refs(m_ref_frame[j], -1));
-            SAFE_CALL(find_best_ref_mvs(j));
+            TRY(find_mv_refs(m_ref_frame[j], -1));
+            TRY(find_best_ref_mvs(j));
         }
     }
     auto is_compound = m_ref_frame[1] > IntraFrame;
     if (seg_feature_active(SEG_LVL_SKIP)) {
         m_y_mode = ZeroMv;
     } else if (m_mi_size >= Block_8x8) {
-        auto inter_mode = m_tree_parser->parse_tree(SyntaxElementType::InterMode);
+        auto inter_mode = TRY(m_tree_parser->parse_tree(SyntaxElementType::InterMode));
         m_y_mode = NearestMv + inter_mode;
     }
     if (m_interpolation_filter == Switchable)
-        m_interp_filter = m_tree_parser->parse_tree<InterpolationFilter>(SyntaxElementType::InterpFilter);
+        m_interp_filter = TRY(m_tree_parser->parse_tree<InterpolationFilter>(SyntaxElementType::InterpFilter));
     else
         m_interp_filter = m_interpolation_filter;
     if (m_mi_size < Block_8x8) {
@@ -1097,13 +1091,13 @@ bool Parser::inter_block_mode_info()
         m_num_4x4_h = num_4x4_blocks_high_lookup[m_mi_size];
         for (auto idy = 0; idy < 2; idy += m_num_4x4_h) {
             for (auto idx = 0; idx < 2; idx += m_num_4x4_w) {
-                auto inter_mode = m_tree_parser->parse_tree(SyntaxElementType::InterMode);
+                auto inter_mode = TRY(m_tree_parser->parse_tree(SyntaxElementType::InterMode));
                 m_y_mode = NearestMv + inter_mode;
                 if (m_y_mode == NearestMv || m_y_mode == NearMv) {
                     for (auto j = 0; j < 1 + is_compound; j++)
-                        SAFE_CALL(append_sub8x8_mvs(idy * 2 + idx, j));
+                        TRY(append_sub8x8_mvs(idy * 2 + idx, j));
                 }
-                SAFE_CALL(assign_mv(is_compound));
+                TRY(assign_mv(is_compound));
                 for (auto y = 0; y < m_num_4x4_h; y++) {
                     for (auto x = 0; x < m_num_4x4_w; x++) {
                         auto block = (idy + y) * 2 + idx + x;
@@ -1114,53 +1108,53 @@ bool Parser::inter_block_mode_info()
                 }
             }
         }
-        return true;
+        return {};
     }
-    SAFE_CALL(assign_mv(is_compound));
+    TRY(assign_mv(is_compound));
     for (auto ref_list = 0; ref_list < 1 + is_compound; ref_list++) {
         for (auto block = 0; block < 4; block++) {
             m_block_mvs[ref_list][block] = m_mv[ref_list];
         }
     }
-    return true;
+    return {};
 }
 
-bool Parser::read_ref_frames()
+ErrorOr<void> Parser::read_ref_frames()
 {
     if (seg_feature_active(SEG_LVL_REF_FRAME)) {
         m_ref_frame[0] = static_cast<ReferenceFrame>(m_feature_data[m_segment_id][SEG_LVL_REF_FRAME]);
         m_ref_frame[1] = None;
-        return true;
+        return {};
     }
     ReferenceMode comp_mode;
     if (m_reference_mode == ReferenceModeSelect)
-        comp_mode = m_tree_parser->parse_tree<ReferenceMode>(SyntaxElementType::CompMode);
+        comp_mode = TRY(m_tree_parser->parse_tree<ReferenceMode>(SyntaxElementType::CompMode));
     else
         comp_mode = m_reference_mode;
     if (comp_mode == CompoundReference) {
         auto idx = m_ref_frame_sign_bias[m_comp_fixed_ref];
-        auto comp_ref = m_tree_parser->parse_tree(SyntaxElementType::CompRef);
+        auto comp_ref = TRY(m_tree_parser->parse_tree(SyntaxElementType::CompRef));
         m_ref_frame[idx] = m_comp_fixed_ref;
         m_ref_frame[!idx] = m_comp_var_ref[comp_ref];
-        return true;
+        return {};
     }
-    auto single_ref_p1 = m_tree_parser->parse_tree<bool>(SyntaxElementType::SingleRefP1);
+    auto single_ref_p1 = TRY(m_tree_parser->parse_tree<bool>(SyntaxElementType::SingleRefP1));
     if (single_ref_p1) {
-        auto single_ref_p2 = m_tree_parser->parse_tree<bool>(SyntaxElementType::SingleRefP2);
+        auto single_ref_p2 = TRY(m_tree_parser->parse_tree<bool>(SyntaxElementType::SingleRefP2));
         m_ref_frame[0] = single_ref_p2 ? AltRefFrame : GoldenFrame;
     } else {
         m_ref_frame[0] = LastFrame;
     }
     m_ref_frame[1] = None;
-    return true;
+    return {};
 }
 
-bool Parser::assign_mv(bool is_compound)
+ErrorOr<void> Parser::assign_mv(bool is_compound)
 {
     m_mv[1] = 0;
     for (auto i = 0; i < 1 + is_compound; i++) {
         if (m_y_mode == NewMv) {
-            SAFE_CALL(read_mv(i));
+            TRY(read_mv(i));
         } else if (m_y_mode == NearestMv) {
             m_mv[i] = m_nearest_mv[i];
         } else if (m_y_mode == NearMv) {
@@ -1169,47 +1163,47 @@ bool Parser::assign_mv(bool is_compound)
             m_mv[i] = 0;
         }
     }
-    return true;
+    return {};
 }
 
-bool Parser::read_mv(u8 ref)
+ErrorOr<void> Parser::read_mv(u8 ref)
 {
     m_use_hp = m_allow_high_precision_mv && use_mv_hp(m_best_mv[ref]);
     MV diff_mv;
-    auto mv_joint = m_tree_parser->parse_tree<MvJoint>(SyntaxElementType::MVJoint);
+    auto mv_joint = TRY(m_tree_parser->parse_tree<MvJoint>(SyntaxElementType::MVJoint));
     if (mv_joint == MvJointHzvnz || mv_joint == MvJointHnzvnz)
-        diff_mv.set_row(read_mv_component(0));
+        diff_mv.set_row(TRY(read_mv_component(0)));
     if (mv_joint == MvJointHnzvz || mv_joint == MvJointHnzvnz)
-        diff_mv.set_col(read_mv_component(1));
+        diff_mv.set_col(TRY(read_mv_component(1)));
     m_mv[ref] = m_best_mv[ref] + diff_mv;
-    return true;
+    return {};
 }
 
-i32 Parser::read_mv_component(u8)
+ErrorOr<i32> Parser::read_mv_component(u8)
 {
-    auto mv_sign = m_tree_parser->parse_tree<bool>(SyntaxElementType::MVSign);
-    auto mv_class = m_tree_parser->parse_tree<MvClass>(SyntaxElementType::MVClass);
+    auto mv_sign = TRY(m_tree_parser->parse_tree<bool>(SyntaxElementType::MVSign));
+    auto mv_class = TRY(m_tree_parser->parse_tree<MvClass>(SyntaxElementType::MVClass));
     u32 mag;
     if (mv_class == MvClass0) {
-        auto mv_class0_bit = m_tree_parser->parse_tree<u32>(SyntaxElementType::MVClass0Bit);
-        auto mv_class0_fr = m_tree_parser->parse_tree<u32>(SyntaxElementType::MVClass0FR);
-        auto mv_class0_hp = m_tree_parser->parse_tree<u32>(SyntaxElementType::MVClass0HP);
+        auto mv_class0_bit = TRY(m_tree_parser->parse_tree<u32>(SyntaxElementType::MVClass0Bit));
+        auto mv_class0_fr = TRY(m_tree_parser->parse_tree<u32>(SyntaxElementType::MVClass0FR));
+        auto mv_class0_hp = TRY(m_tree_parser->parse_tree<u32>(SyntaxElementType::MVClass0HP));
         mag = ((mv_class0_bit << 3) | (mv_class0_fr << 1) | mv_class0_hp) + 1;
     } else {
         auto d = 0;
         for (size_t i = 0; i < mv_class; i++) {
-            auto mv_bit = m_tree_parser->parse_tree<bool>(SyntaxElementType::MVBit);
+            auto mv_bit = TRY(m_tree_parser->parse_tree<bool>(SyntaxElementType::MVBit));
             d |= mv_bit << i;
         }
         mag = CLASS0_SIZE << (mv_class + 2);
-        auto mv_fr = m_tree_parser->parse_tree<u32>(SyntaxElementType::MVFR);
-        auto mv_hp = m_tree_parser->parse_tree<u32>(SyntaxElementType::MVHP);
+        auto mv_fr = TRY(m_tree_parser->parse_tree<u32>(SyntaxElementType::MVFR));
+        auto mv_hp = TRY(m_tree_parser->parse_tree<u32>(SyntaxElementType::MVHP));
         mag += ((d << 3) | (mv_fr << 1) | mv_hp) + 1;
     }
     return mv_sign ? -static_cast<i32>(mag) : static_cast<i32>(mag);
 }
 
-bool Parser::residual()
+ErrorOr<void> Parser::residual()
 {
     auto block_size = m_mi_size < Block_8x8 ? Block_8x8 : static_cast<BlockSubsize>(m_mi_size);
     for (size_t plane = 0; plane < 3; plane++) {
@@ -1226,11 +1220,11 @@ bool Parser::residual()
             if (m_mi_size < Block_8x8) {
                 for (auto y = 0; y < num_4x4_h; y++) {
                     for (auto x = 0; x < num_4x4_w; x++) {
-                        SAFE_CALL(m_decoder.predict_inter(plane, base_x + (4 * x), base_y + (4 * y), 4, 4, (y * num_4x4_w) + x));
+                        TRY(m_decoder.predict_inter(plane, base_x + (4 * x), base_y + (4 * y), 4, 4, (y * num_4x4_w) + x));
                     }
                 }
             } else {
-                SAFE_CALL(m_decoder.predict_inter(plane, base_x, base_y, num_4x4_w * 4, num_4x4_h * 4, 0));
+                TRY(m_decoder.predict_inter(plane, base_x, base_y, num_4x4_w * 4, num_4x4_h * 4, 0));
             }
         }
         auto max_x = (m_mi_cols * 8) >> sub_x;
@@ -1243,10 +1237,10 @@ bool Parser::residual()
                 auto non_zero = false;
                 if (start_x < max_x && start_y < max_y) {
                     if (!m_is_inter)
-                        SAFE_CALL(m_decoder.predict_intra(plane, start_x, start_y, m_available_l || x > 0, m_available_u || y > 0, (x + step) < num_4x4_w, tx_size, block_index));
+                        TRY(m_decoder.predict_intra(plane, start_x, start_y, m_available_l || x > 0, m_available_u || y > 0, (x + step) < num_4x4_w, tx_size, block_index));
                     if (!m_skip) {
-                        non_zero = tokens(plane, start_x, start_y, tx_size, block_index);
-                        SAFE_CALL(m_decoder.reconstruct(plane, start_x, start_y, tx_size));
+                        non_zero = TRY(tokens(plane, start_x, start_y, tx_size, block_index));
+                        TRY(m_decoder.reconstruct(plane, start_x, start_y, tx_size));
                     }
                 }
                 auto above_sub_context = m_above_nonzero_context[plane];
@@ -1261,7 +1255,7 @@ bool Parser::residual()
             }
         }
     }
-    return true;
+    return {};
 }
 
 TXSize Parser::get_uv_tx_size()
@@ -1278,7 +1272,7 @@ BlockSubsize Parser::get_plane_block_size(u32 subsize, u8 plane)
     return ss_size_lookup[subsize][sub_x][sub_y];
 }
 
-bool Parser::tokens(size_t plane, u32 start_x, u32 start_y, TXSize tx_size, u32 block_index)
+ErrorOr<bool> Parser::tokens(size_t plane, u32 start_x, u32 start_y, TXSize tx_size, u32 block_index)
 {
     m_tree_parser->set_start_x_and_y(start_x, start_y);
     size_t segment_eob = 16 << (tx_size << 1);
@@ -1290,18 +1284,18 @@ bool Parser::tokens(size_t plane, u32 start_x, u32 start_y, TXSize tx_size, u32 
         auto band = (tx_size == TX_4x4) ? coefband_4x4[c] : coefband_8x8plus[c];
         m_tree_parser->set_tokens_variables(band, c, plane, tx_size, pos);
         if (check_eob) {
-            auto more_coefs = m_tree_parser->parse_tree<bool>(SyntaxElementType::MoreCoefs);
+            auto more_coefs = TRY(m_tree_parser->parse_tree<bool>(SyntaxElementType::MoreCoefs));
             if (!more_coefs)
                 break;
         }
-        auto token = m_tree_parser->parse_tree<Token>(SyntaxElementType::Token);
+        auto token = TRY(m_tree_parser->parse_tree<Token>(SyntaxElementType::Token));
         m_token_cache[pos] = energy_class[token];
         if (token == ZeroToken) {
             m_tokens[pos] = 0;
             check_eob = false;
         } else {
-            i32 coef = static_cast<i32>(read_coef(token));
-            auto sign_bit = m_bit_stream->read_literal(1);
+            i32 coef = static_cast<i32>(TRY(read_coef(token)));
+            auto sign_bit = TRY(m_bit_stream->read_literal(1));
             m_tokens[pos] = sign_bit ? -coef : coef;
             check_eob = true;
         }
@@ -1349,45 +1343,46 @@ u32 const* Parser::get_scan(size_t plane, TXSize tx_size, u32 block_index)
     return default_scan_32x32;
 }
 
-u32 Parser::read_coef(Token token)
+ErrorOr<u32> Parser::read_coef(Token token)
 {
     auto cat = extra_bits[token][0];
     auto num_extra = extra_bits[token][1];
     auto coef = extra_bits[token][2];
     if (token == DctValCat6) {
         for (size_t e = 0; e < (u8)(m_bit_depth - 8); e++) {
-            auto high_bit = m_bit_stream->read_bool(255);
+            auto high_bit = TRY(m_bit_stream->read_bool(255));
             coef += high_bit << (5 + m_bit_depth - e);
         }
     }
     for (size_t e = 0; e < num_extra; e++) {
-        auto coef_bit = m_bit_stream->read_bool(cat_probs[cat][e]);
+        auto coef_bit = TRY(m_bit_stream->read_bool(cat_probs[cat][e]));
         coef += coef_bit << (num_extra - 1 - e);
     }
     return coef;
 }
 
-bool Parser::find_mv_refs(ReferenceFrame, int)
+ErrorOr<void> Parser::find_mv_refs(ReferenceFrame, int)
 {
     // TODO: Implement
-    return true;
+    return Error::from_string_literal("find_mv_refs: Not implemented");
 }
 
-bool Parser::find_best_ref_mvs(int)
+ErrorOr<void> Parser::find_best_ref_mvs(int)
 {
     // TODO: Implement
-    return true;
+    return Error::from_string_literal("find_best_ref_mvs: Not implemented");
 }
 
-bool Parser::append_sub8x8_mvs(u8, u8)
+ErrorOr<void> Parser::append_sub8x8_mvs(u8, u8)
 {
     // TODO: Implement
-    return true;
+    return Error::from_string_literal("append_sub8x8_mvs: Not implemented");
 }
 
 bool Parser::use_mv_hp(const MV&)
 {
     // TODO: Implement
+    VERIFY(false);
     return true;
 }
 
@@ -1398,5 +1393,9 @@ void Parser::dump_info()
     outln("Bit depth: {}", m_bit_depth);
     outln("Interpolation filter: {}", (u8)m_interpolation_filter);
 }
+
+#undef RESERVED_ZERO
+#undef FUNC_ERROR
+#undef WRAP_ERROR
 
 }

--- a/Userland/Libraries/LibVideo/VP9/Parser.h
+++ b/Userland/Libraries/LibVideo/VP9/Parser.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Hunter Salyer <thefalsehonesty@gmail.com>
+ * Copyright (c) 2022, Gregory Bertilson <zaggy1024@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -26,7 +27,7 @@ class Parser {
 public:
     explicit Parser(Decoder&);
     ~Parser();
-    bool parse_frame(ByteBuffer const&);
+    ErrorOr<void> parse_frame(ByteBuffer const&);
     void dump_info();
 
 private:
@@ -52,83 +53,83 @@ private:
 
     /* (6.1) Frame Syntax */
     bool trailing_bits();
-    bool refresh_probs();
+    ErrorOr<void> refresh_probs();
 
     /* (6.2) Uncompressed Header Syntax */
-    bool uncompressed_header();
-    bool frame_sync_code();
-    bool color_config();
-    bool frame_size();
-    bool render_size();
-    bool frame_size_with_refs();
-    bool compute_image_size();
-    bool read_interpolation_filter();
-    bool loop_filter_params();
-    bool quantization_params();
+    ErrorOr<void> uncompressed_header();
+    ErrorOr<void> frame_sync_code();
+    ErrorOr<void> color_config();
+    void frame_size();
+    void render_size();
+    void frame_size_with_refs();
+    void compute_image_size();
+    void read_interpolation_filter();
+    void loop_filter_params();
+    void quantization_params();
     i8 read_delta_q();
-    bool segmentation_params();
+    void segmentation_params();
     u8 read_prob();
-    bool tile_info();
+    void tile_info();
     u16 calc_min_log2_tile_cols();
     u16 calc_max_log2_tile_cols();
-    bool setup_past_independence();
+    void setup_past_independence();
 
     /* (6.3) Compressed Header Syntax */
-    bool compressed_header();
-    bool read_tx_mode();
-    bool tx_mode_probs();
-    u8 diff_update_prob(u8 prob);
-    u8 decode_term_subexp();
+    ErrorOr<void> compressed_header();
+    ErrorOr<void> read_tx_mode();
+    ErrorOr<void> tx_mode_probs();
+    ErrorOr<u8> diff_update_prob(u8 prob);
+    ErrorOr<u8> decode_term_subexp();
     u8 inv_remap_prob(u8 delta_prob, u8 prob);
     u8 inv_recenter_nonneg(u8 v, u8 m);
-    bool read_coef_probs();
-    bool read_skip_prob();
-    bool read_inter_mode_probs();
-    bool read_interp_filter_probs();
-    bool read_is_inter_probs();
-    bool frame_reference_mode();
-    bool frame_reference_mode_probs();
-    bool read_y_mode_probs();
-    bool read_partition_probs();
-    bool mv_probs();
-    u8 update_mv_prob(u8 prob);
-    bool setup_compound_reference_mode();
+    ErrorOr<void> read_coef_probs();
+    ErrorOr<void> read_skip_prob();
+    ErrorOr<void> read_inter_mode_probs();
+    ErrorOr<void> read_interp_filter_probs();
+    ErrorOr<void> read_is_inter_probs();
+    ErrorOr<void> frame_reference_mode();
+    ErrorOr<void> frame_reference_mode_probs();
+    ErrorOr<void> read_y_mode_probs();
+    ErrorOr<void> read_partition_probs();
+    ErrorOr<void> mv_probs();
+    ErrorOr<u8> update_mv_prob(u8 prob);
+    void setup_compound_reference_mode();
 
     /* (6.4) Decode Tiles Syntax */
-    bool decode_tiles();
-    bool clear_above_context();
+    ErrorOr<void> decode_tiles();
+    void clear_above_context();
     u32 get_tile_offset(u32 tile_num, u32 mis, u32 tile_size_log2);
-    bool decode_tile();
-    bool clear_left_context();
-    bool decode_partition(u32 row, u32 col, u8 block_subsize);
-    bool decode_block(u32 row, u32 col, u8 subsize);
-    bool mode_info();
-    bool intra_frame_mode_info();
-    bool intra_segment_id();
-    bool read_skip();
+    ErrorOr<void> decode_tile();
+    void clear_left_context();
+    ErrorOr<void> decode_partition(u32 row, u32 col, u8 block_subsize);
+    ErrorOr<void> decode_block(u32 row, u32 col, u8 subsize);
+    ErrorOr<void> mode_info();
+    ErrorOr<void> intra_frame_mode_info();
+    ErrorOr<void> intra_segment_id();
+    ErrorOr<void> read_skip();
     bool seg_feature_active(u8 feature);
-    bool read_tx_size(bool allow_select);
-    bool inter_frame_mode_info();
-    bool inter_segment_id();
+    ErrorOr<void> read_tx_size(bool allow_select);
+    ErrorOr<void> inter_frame_mode_info();
+    ErrorOr<void> inter_segment_id();
     u8 get_segment_id();
-    bool read_is_inter();
-    bool intra_block_mode_info();
-    bool inter_block_mode_info();
-    bool read_ref_frames();
-    bool assign_mv(bool is_compound);
-    bool read_mv(u8 ref);
-    i32 read_mv_component(u8 component);
-    bool residual();
+    ErrorOr<void> read_is_inter();
+    ErrorOr<void> intra_block_mode_info();
+    ErrorOr<void> inter_block_mode_info();
+    ErrorOr<void> read_ref_frames();
+    ErrorOr<void> assign_mv(bool is_compound);
+    ErrorOr<void> read_mv(u8 ref);
+    ErrorOr<i32> read_mv_component(u8 component);
+    ErrorOr<void> residual();
     TXSize get_uv_tx_size();
     BlockSubsize get_plane_block_size(u32 subsize, u8 plane);
-    bool tokens(size_t plane, u32 x, u32 y, TXSize tx_size, u32 block_index);
+    ErrorOr<bool> tokens(size_t plane, u32 x, u32 y, TXSize tx_size, u32 block_index);
     u32 const* get_scan(size_t plane, TXSize tx_size, u32 block_index);
-    u32 read_coef(Token token);
+    ErrorOr<u32> read_coef(Token token);
 
     /* (6.5) Motion Vector Prediction */
-    bool find_mv_refs(ReferenceFrame, int block);
-    bool find_best_ref_mvs(int ref_list);
-    bool append_sub8x8_mvs(u8 block, u8 ref_list);
+    ErrorOr<void> find_mv_refs(ReferenceFrame, int block);
+    ErrorOr<void> find_best_ref_mvs(int ref_list);
+    ErrorOr<void> append_sub8x8_mvs(u8 block, u8 ref_list);
     bool use_mv_hp(MV const& delta_mv);
 
     u8 m_profile { 0 };

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
@@ -11,7 +11,7 @@
 namespace Video::VP9 {
 
 template<typename T>
-T TreeParser::parse_tree(SyntaxElementType type)
+ErrorOr<T> TreeParser::parse_tree(SyntaxElementType type)
 {
     auto tree_selection = select_tree(type);
     int value;
@@ -21,7 +21,7 @@ T TreeParser::parse_tree(SyntaxElementType type)
         auto tree = tree_selection.get_tree_value();
         int n = 0;
         do {
-            n = tree[n + m_decoder.m_bit_stream->read_bool(select_tree_probability(type, n >> 1))];
+            n = tree[n + TRY(m_decoder.m_bit_stream->read_bool(select_tree_probability(type, n >> 1)))];
         } while (n > 0);
         value = -n;
     }
@@ -29,17 +29,17 @@ T TreeParser::parse_tree(SyntaxElementType type)
     return static_cast<T>(value);
 }
 
-template int TreeParser::parse_tree(SyntaxElementType);
-template bool TreeParser::parse_tree(SyntaxElementType);
-template u8 TreeParser::parse_tree(SyntaxElementType);
-template u32 TreeParser::parse_tree(SyntaxElementType);
-template IntraMode TreeParser::parse_tree(SyntaxElementType);
-template TXSize TreeParser::parse_tree(SyntaxElementType);
-template InterpolationFilter TreeParser::parse_tree(SyntaxElementType);
-template ReferenceMode TreeParser::parse_tree(SyntaxElementType);
-template Token TreeParser::parse_tree(SyntaxElementType);
-template MvClass TreeParser::parse_tree(SyntaxElementType);
-template MvJoint TreeParser::parse_tree(SyntaxElementType);
+template ErrorOr<int> TreeParser::parse_tree(SyntaxElementType);
+template ErrorOr<bool> TreeParser::parse_tree(SyntaxElementType);
+template ErrorOr<u8> TreeParser::parse_tree(SyntaxElementType);
+template ErrorOr<u32> TreeParser::parse_tree(SyntaxElementType);
+template ErrorOr<IntraMode> TreeParser::parse_tree(SyntaxElementType);
+template ErrorOr<TXSize> TreeParser::parse_tree(SyntaxElementType);
+template ErrorOr<InterpolationFilter> TreeParser::parse_tree(SyntaxElementType);
+template ErrorOr<ReferenceMode> TreeParser::parse_tree(SyntaxElementType);
+template ErrorOr<Token> TreeParser::parse_tree(SyntaxElementType);
+template ErrorOr<MvClass> TreeParser::parse_tree(SyntaxElementType);
+template ErrorOr<MvJoint> TreeParser::parse_tree(SyntaxElementType);
 
 /*
  * Select a tree value based on the type of syntax element being parsed, as well as some parser state, as specified in section 9.3.1

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -43,7 +43,7 @@ public:
 
     /* (9.3.3) */
     template<typename T = int>
-    T parse_tree(SyntaxElementType type);
+    ErrorOr<T> parse_tree(SyntaxElementType type);
     /* (9.3.1) */
     TreeSelection select_tree(SyntaxElementType type);
     /* (9.3.2) */

--- a/Userland/Libraries/LibVideo/VP9/Utilities.h
+++ b/Userland/Libraries/LibVideo/VP9/Utilities.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Hunter Salyer <thefalsehonesty@gmail.com>
+ * Copyright (c) 2022, Gregory Bertilson <zaggy1024@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,14 +10,6 @@
 #include <AK/Types.h>
 
 namespace Video::VP9 {
-
-#define SAFE_CALL(call)             \
-    do {                            \
-        if (!(call)) [[unlikely]] { \
-            dbgln("FAILED " #call); \
-            return false;           \
-        }                           \
-    } while (0)
 
 u8 clip_3(u8 x, u8 y, u8 z);
 u8 round_2(u8 x, u8 n);


### PR DESCRIPTION
This should help with tracking down issues preventing videos from being successfully parsed.

All the functions that can't produce errors should now return void rather than bool, but in the future I may take a look to see if there are any that could produce errors to cause the decoder to fail as early as possible to narrow down bad parses.