### PR TITLE
LibWeb: Avoid copying viewport rect when converting length to pixels

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -104,7 +104,7 @@ float Length::to_px(Layout::Node const& layout_node) const
 
     if (!layout_node.document().browsing_context())
         return 0;
-    auto viewport_rect = layout_node.document().browsing_context()->viewport_rect();
+    auto const& viewport_rect = layout_node.document().browsing_context()->viewport_rect();
     auto* root_element = layout_node.document().document_element();
     if (!root_element || !root_element->layout_node())
         return 0;


### PR DESCRIPTION
I couldn't believe it myself but its apparently been over two years since I started contributing. Back then I had barely any knowledge of C++ (most of which came from watching Andreas' videos anyways), git and all the fun things that go into an operating system.

Since then I've learnt so much and met so many cool people - I'm incredibly grateful for it!

One of my first contributions was to implement the `v{w,h,min,max}` length units in LibWeb. In the review [linus requested](https://github.com/SerenityOS/serenity/pull/3433#discussion_r484562783) that I don't copy the viewport rect every time to read some simple int values from it. As I didn't know what a const reference was and had no clue about squashing commits Andreas simply let it go through.

This pull request fixes this very minor performance issue. If it doesn't get merged due to being a micro optimization with no measured impact I'll happily contribute another change as my 100th commit, though it will not have any lore attached :^) :^)