### PR TITLE
CharacterMap: Allow resizing the unicode block list

### DIFF
--- a/Userland/Applications/CharacterMap/CharacterMapWindow.gml
+++ b/Userland/Applications/CharacterMap/CharacterMapWindow.gml
@@ -30,7 +30,7 @@
     }
 
     @GUI::HorizontalSplitter {
-        fixed_resizee: "Second"
+        opportunistic_resizee: "First"
 
         @GUI::Widget {
             layout: @GUI::VerticalBoxLayout {}
@@ -59,7 +59,7 @@
         }
 
         @GUI::ListView {
-            max_width: 175
+            preferred_width: 175
             name: "unicode_block_listview"
         }
     }


### PR DESCRIPTION
Previously we would constrain the unicode block list to a width of 175, causing it to stick to the splitter when manually resizing.

This pull request allows resizing the list properly while retaining the new width when resizing the window.

Current master:

https://user-images.githubusercontent.com/42888162/189551055-004ae057-4faf-4c90-869a-46c46367393a.mp4

This pull request:

https://user-images.githubusercontent.com/42888162/189551122-e15c7b71-fec5-4ca8-b1e1-bd507dfad763.mp4