### PR TITLE
Shell: Order CompletionSuggestions for paths lexicographically

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1519,6 +1519,10 @@ Vector<Line::CompletionSuggestion> Shell::complete_path(StringView base, StringV
         }
     }
 
+    // The results of DirIterator are in the order they appear on-disk.
+    // Instead, return suggestions in lexicographical order.
+    quick_sort(suggestions, [](auto& a, auto& b) { return a.text_string < b.text_string; });
+
     return suggestions;
 }
 


### PR DESCRIPTION
This used to be sorted by whatever the order of files in the directory happened to be on-disk, which can be surprising.

Before, a newly created file would appear at the end, which is surprising:
![Bildschirmfoto_2022-09-12_14-26-19](https://user-images.githubusercontent.com/2690845/189653734-dbff8c67-e4fe-471f-ba9e-872cf37188b4.png)

After, the results are "properly" sorted:
![Bildschirmfoto_2022-09-12_14-24-37](https://user-images.githubusercontent.com/2690845/189653941-02cf9c24-e08a-41e9-a05d-6e6fbee63c8b.png)
