### PR TITLE
Base: Skip Shell tests

### DIFF
--- a/Base/home/anon/.config/Tests.ini
+++ b/Base/home/anon/.config/Tests.ini
@@ -1,5 +1,5 @@
 [Global]
-SkipDirectories=Kernel/Legacy
+SkipDirectories=Kernel/Legacy Shell
 SkipRegex=^ue-.*$
 SkipTests=TestCommonmark TestLibCoreStream function.sh
 NotTestsPattern=^.*(txt|frm|inc)$


### PR DESCRIPTION
We have a high random failure rate on Shell tests, even with two of them already manually disabled for being flaky. For now, let's remove them all from automated/CI testing so that "real" failures are more obvious.

Two of the tests have early-exits to disable them, which I wanted to remove, but that makes `Meta/lint-shell-scripts.sh` very cross, so I'll leave them.