### PR TITLE
LibWeb: Visit internal fields of Crypto in visit_edges

### DIFF
--- a/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
@@ -114,4 +114,10 @@ String Crypto::random_uuid() const
     return builder.to_string();
 }
 
+void Crypto::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_subtle.ptr());
+}
+
 }

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.h
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.h
@@ -25,6 +25,9 @@ public:
     DOM::ExceptionOr<JS::Value> get_random_values(JS::Value array) const;
     String random_uuid() const;
 
+protected:
+    virtual void visit_edges(Cell::Visitor&) override;
+
 private:
     explicit Crypto(HTML::Window&);
     virtual void initialize(JS::Realm&) override;


### PR DESCRIPTION
Not visiting m_subtle caused very (subtle and) crashes all over Value, due to being uaf'ed. Which would only expose themselfs later in Value::to_boolean, Value::typeof, etc.

See the discord in #js for the full debugging experience