### PR TITLE
HackStudio: Make tabs behave more like VSCode/CLion

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -794,15 +794,11 @@ void HackStudioWidget::add_new_editor(GUI::TabWidget& parent)
             set_current_editor_wrapper(tab);
             parent.remove_tab(tab);
             m_all_editor_wrappers.remove_first_matching([&tab](auto& entry) { return entry == &tab; });
-            if (parent.children().is_empty()) {
+            if (parent.children().is_empty() && m_all_editor_tab_widgets.size() > 1) {
                 m_switch_to_next_editor_tab_widget->activate();
                 m_editors_splitter->remove_child(parent);
                 m_all_editor_tab_widgets.remove_first_matching([&parent](auto& entry) { return entry == &parent; });
-                if (m_current_editor_tab_widget->children().size() == 1)
-                    m_current_editor_tab_widget->set_close_button_enabled(false);
             }
-            if (parent.children().size() == 1 && m_all_editor_tab_widgets.size() <= 1)
-                parent.set_close_button_enabled(false);
             update_actions();
         });
     };

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -481,7 +481,6 @@ NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu
     m_new_plain_file_action = create_new_file_action("Plain &File", "/res/icons/16x16/new.png", "");
 
     m_open_selected_action = create_open_selected_action();
-    m_open_selected_in_new_tab_action = create_open_selected_in_new_tab_action();
     m_show_in_file_manager_action = create_show_in_file_manager_action();
     m_copy_relative_path_action = create_copy_relative_path_action();
     m_copy_full_path_action = create_copy_full_path_action();
@@ -503,7 +502,6 @@ NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu
     new_file_submenu.add_action(*m_new_directory_action);
 
     project_tree_view_context_menu->add_action(*m_open_selected_action);
-    project_tree_view_context_menu->add_action(*m_open_selected_in_new_tab_action);
     project_tree_view_context_menu->add_action(*m_show_in_file_manager_action);
     project_tree_view_context_menu->add_action(*m_copy_relative_path_action);
     project_tree_view_context_menu->add_action(*m_copy_full_path_action);
@@ -596,20 +594,6 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_open_selected_action()
     open_selected_action->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors());
     open_selected_action->set_enabled(true);
     return open_selected_action;
-}
-
-NonnullRefPtr<GUI::Action> HackStudioWidget::create_open_selected_in_new_tab_action()
-{
-    auto open_selected_in_new_tab_action = GUI::Action::create("Open in New &Tab", [this](const GUI::Action&) {
-        auto files = selected_file_paths();
-        for (auto& file : files) {
-            add_new_editor(*m_current_editor_tab_widget);
-            open_file(file);
-        }
-    });
-    open_selected_in_new_tab_action->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors());
-    open_selected_in_new_tab_action->set_enabled(true);
-    return open_selected_in_new_tab_action;
 }
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_show_in_file_manager_action()

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -311,6 +311,17 @@ bool HackStudioWidget::open_file(String const& full_filename, size_t line, size_
     if (Core::File::is_directory(filename) || !Core::File::exists(filename))
         return false;
 
+    auto editor_wrapper_or_none = m_all_editor_wrappers.first_matching([&](auto& wrapper) {
+        return wrapper->filename() == filename;
+    });
+
+    if (editor_wrapper_or_none.has_value()) {
+        set_current_editor_wrapper(editor_wrapper_or_none.release_value());
+        return true;
+    } else {
+        add_new_editor(*m_current_editor_tab_widget);
+    }
+
     if (!active_file().is_empty()) {
         // Since the file is previously open, it should always be in m_open_files.
         VERIFY(m_open_files.find(active_file()) != m_open_files.end());
@@ -1175,6 +1186,7 @@ void HackStudioWidget::set_current_editor_wrapper(RefPtr<EditorWrapper> editor_w
     update_current_editor_title();
     update_tree_view();
     set_current_editor_tab_widget(static_cast<GUI::TabWidget*>(m_current_editor_wrapper->parent()));
+    m_current_editor_tab_widget->set_active_widget(editor_wrapper);
     update_statusbar();
 }
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -220,7 +220,6 @@ private:
 
     RefPtr<GUI::Action> m_new_directory_action;
     RefPtr<GUI::Action> m_open_selected_action;
-    RefPtr<GUI::Action> m_open_selected_in_new_tab_action;
     RefPtr<GUI::Action> m_show_in_file_manager_action;
     RefPtr<GUI::Action> m_copy_relative_path_action;
     RefPtr<GUI::Action> m_copy_full_path_action;


### PR DESCRIPTION
Previously opening a file meant that it got opened in the current tab, substituting the file you were viewing before.

These commits change HackStudio to behave more like VSCode or CLion: clicking on a file either opens it in a new tab or, if it's already open in a tab in the current editor group, selects that tab.