### PR TITLE
Ports: Actually clean port build directory

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -441,11 +441,7 @@ func_defined post_install || post_install() {
     echo
 }
 func_defined clean || clean() {
-    if [ -z "${IN_SERENITY_PORT_DEV:-}" ]; then
-        rm -rf "$workdir" *.out
-    else
-        rm -rf "$nongit_workdir" *.out
-    fi
+    rm -rf "${PORT_BUILD_DIR}"
 }
 func_defined clean_dist || clean_dist() {
     OLDIFS=$IFS
@@ -457,18 +453,8 @@ func_defined clean_dist || clean_dist() {
     done
 }
 func_defined clean_all || clean_all() {
-    if [ -z "${IN_SERENITY_PORT_DEV:-}" ]; then
-        rm -rf "$workdir" *.out
-    else
-        rm -rf "$nongit_workdir" *.out
-    fi
-    OLDIFS=$IFS
-    IFS=$'\n'
-    for f in $files; do
-        IFS=$OLDIFS
-        read url filename hash <<< $(echo "$f")
-        rm -f "${PORT_META_DIR}/${filename}"
-    done
+    clean
+    clean_dist
 }
 addtodb() {
     if [ -n "$(package_install_state $port $version)" ]; then
@@ -574,15 +560,15 @@ do_install() {
     addtodb "${1:-}"
 }
 do_clean() {
-    echo "Cleaning workdir and .out files in $port..."
+    echo "Cleaning build directory for $port..."
     clean
 }
 do_clean_dist() {
-    echo "Cleaning dist in $port..."
+    echo "Cleaning dist files for $port..."
     clean_dist
 }
 do_clean_all() {
-    echo "Cleaning all in $port..."
+    echo "Cleaning all for $port..."
     clean_all
 }
 do_uninstall() {

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -440,10 +440,10 @@ func_defined install || install() {
 func_defined post_install || post_install() {
     echo
 }
-func_defined clean || clean() {
+clean() {
     rm -rf "${PORT_BUILD_DIR}"
 }
-func_defined clean_dist || clean_dist() {
+clean_dist() {
     OLDIFS=$IFS
     IFS=$'\n'
     for f in $files; do
@@ -452,7 +452,7 @@ func_defined clean_dist || clean_dist() {
         rm -f "${PORT_META_DIR}/${filename}"
     done
 }
-func_defined clean_all || clean_all() {
+clean_all() {
     clean
     clean_dist
 }

--- a/Ports/qt6-qtbase/package.sh
+++ b/Ports/qt6-qtbase/package.sh
@@ -57,7 +57,3 @@ install() {
     echo "The development of the Qt Serenity platform plugin is happening here. Fixes for things like input handling, window management and theme integration should go here:"
     echo -e "\t" "https://github.com/SerenityPorts/QSerenityPlatform"
 }
-
-clean() {
-    run ninja clean
-}

--- a/Ports/qt6-serenity/package.sh
+++ b/Ports/qt6-serenity/package.sh
@@ -37,7 +37,3 @@ build() {
 install() {
     run ninja install
 }
-
-clean() {
-    run ninja clean
-}


### PR DESCRIPTION
The functionality for `./package.sh clean` was a bit weird: based on whether you were working in dev mode, it would try to delete either `$workdir` or `$nongit_workdir` and `*.out` from your `pwd`.

The new functionality is pretty clear: `./package.sh clean` deletes the entire build directory for the port regardless of what mode you're in, `./package.sh clean_dist` removes all `$files`, and `./package.sh clean_all` does both.