### PR TITLE
LibJS: Handle NumberFormat's [[UseGrouping]] option for "true" / "false"

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -633,12 +633,17 @@ ThrowCompletionOr<StringOrBoolean> get_string_or_boolean_option(VM& vm, Object c
     // 6. Let value be ? ToString(value).
     auto value_string = TRY(value.to_string(vm));
 
-    // 7. If values does not contain an element equal to value, return fallback.
-    auto it = find(values.begin(), values.end(), value_string);
-    if (it == values.end())
+    // 7. NOTE: For historical reasons, the strings "true" and "false" are treated the same as the boolean value true.
+    // 8. If value is "true" or "false", return fallback.
+    if (value_string.is_one_of("true"sv, "false"sv))
         return fallback;
 
-    // 8. Return value.
+    // 9. If values does not contain an element equal to value, throw a RangeError exception.
+    auto it = find(values.begin(), values.end(), value_string);
+    if (it == values.end())
+        return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, value_string, property.as_string());
+
+    // 10. Return value.
     return StringOrBoolean { *it };
 }
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.js
@@ -209,6 +209,12 @@ describe("errors", () => {
         }).toThrowWithMessage(RangeError, "hello! is not a valid value for option signDisplay");
     });
 
+    test("useGrouping option is invalid", () => {
+        expect(() => {
+            new Intl.NumberFormat("en", { useGrouping: "hello!" });
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option useGrouping");
+    });
+
     test("roundingPriority option is invalid", () => {
         expect(() => {
             new Intl.NumberFormat("en", { roundingPriority: "hello!" });
@@ -416,7 +422,7 @@ describe("normal behavior", () => {
     });
 
     test("valid useGrouping options", () => {
-        ["min2", "auto", "always", false, true, ""].forEach(useGrouping => {
+        ["min2", "auto", "always", false, true, "false", "true", ""].forEach(useGrouping => {
             expect(() => {
                 new Intl.NumberFormat("en", { useGrouping: useGrouping });
             }).not.toThrow();

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.resolvedOptions.js
@@ -287,9 +287,15 @@ describe("correct behavior", () => {
         const en4 = new Intl.NumberFormat("en", { useGrouping: true });
         expect(en4.resolvedOptions().useGrouping).toBe("always");
 
+        const en5 = new Intl.NumberFormat("en", { useGrouping: "false" });
+        expect(en5.resolvedOptions().useGrouping).toBe("auto");
+
+        const en6 = new Intl.NumberFormat("en", { useGrouping: "true" });
+        expect(en6.resolvedOptions().useGrouping).toBe("auto");
+
         ["auto", "always", "min2"].forEach(useGrouping => {
-            const en5 = new Intl.NumberFormat("en", { useGrouping: useGrouping });
-            expect(en5.resolvedOptions().useGrouping).toBe(useGrouping);
+            const en7 = new Intl.NumberFormat("en", { useGrouping: useGrouping });
+            expect(en7.resolvedOptions().useGrouping).toBe(useGrouping);
         });
     });
 


### PR DESCRIPTION
This is a normative change to the Intl NumberFormat V3 spec. See: 
https://github.com/tc39/proposal-intl-numberformat-v3/commit/4751da5

No test262 change (yet) - they have tests for this, but there's a bug:
https://github.com/tc39/test262/pull/3653/files#r969149152