### PR TITLE
HeaderCheck: Let's make sure that our headers actually compile!

### DIFF
--- a/AK/FuzzyMatch.cpp
+++ b/AK/FuzzyMatch.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2021, Spencer Dixon <spencercdixon@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/CharacterTypes.h>
+#include <AK/FuzzyMatch.h>
+
+namespace AK {
+
+static constexpr int const RECURSION_LIMIT = 10;
+static constexpr int const MAX_MATCHES = 256;
+
+// Bonuses and penalties are used to build up a final score for the match.
+static constexpr int const SEQUENTIAL_BONUS = 15;            // bonus for adjacent matches (needle: 'ca', haystack: 'cat')
+static constexpr int const SEPARATOR_BONUS = 30;             // bonus if match occurs after a separator ('_' or ' ')
+static constexpr int const CAMEL_BONUS = 30;                 // bonus if match is uppercase and prev is lower (needle: 'myF' haystack: '/path/to/myFile.txt')
+static constexpr int const FIRST_LETTER_BONUS = 20;          // bonus if the first letter is matched (needle: 'c' haystack: 'cat')
+static constexpr int const LEADING_LETTER_PENALTY = -5;      // penalty applied for every letter in str before the first match
+static constexpr int const MAX_LEADING_LETTER_PENALTY = -15; // maximum penalty for leading letters
+static constexpr int const UNMATCHED_LETTER_PENALTY = -1;    // penalty for every letter that doesn't matter
+
+static int calculate_score(String const& string, u8* index_points, size_t index_points_size)
+{
+    int out_score = 100;
+
+    int penalty = LEADING_LETTER_PENALTY * index_points[0];
+    if (penalty < MAX_LEADING_LETTER_PENALTY)
+        penalty = MAX_LEADING_LETTER_PENALTY;
+    out_score += penalty;
+
+    int unmatched = string.length() - index_points_size;
+    out_score += UNMATCHED_LETTER_PENALTY * unmatched;
+
+    for (size_t i = 0; i < index_points_size; i++) {
+        u8 current_idx = index_points[i];
+
+        if (current_idx == 0)
+            out_score += FIRST_LETTER_BONUS;
+
+        if (i == 0)
+            continue;
+
+        u8 previous_idx = index_points[i - 1];
+        if (current_idx - 1 == previous_idx)
+            out_score += SEQUENTIAL_BONUS;
+
+        u32 current_character = string[current_idx];
+        u32 neighbor_character = string[current_idx - 1];
+
+        if (neighbor_character != to_ascii_uppercase(neighbor_character) && current_character != to_ascii_lowercase(current_character))
+            out_score += CAMEL_BONUS;
+
+        if (neighbor_character == '_' || neighbor_character == ' ')
+            out_score += SEPARATOR_BONUS;
+    }
+
+    return out_score;
+}
+
+FuzzyMatchResult fuzzy_match_recursive(String const& needle, String const& haystack, size_t needle_idx, size_t haystack_idx,
+    u8 const* src_matches, u8* matches, int next_match, int& recursion_count)
+{
+    int out_score = 0;
+
+    ++recursion_count;
+    if (recursion_count >= RECURSION_LIMIT)
+        return { false, out_score };
+
+    if (needle.length() == needle_idx || haystack.length() == haystack_idx)
+        return { false, out_score };
+
+    bool had_recursive_match = false;
+    constexpr size_t recursive_match_limit = 256;
+    u8 best_recursive_matches[recursive_match_limit];
+    int best_recursive_score = 0;
+
+    bool first_match = true;
+    while (needle_idx < needle.length() && haystack_idx < haystack.length()) {
+
+        if (to_ascii_lowercase(needle[needle_idx]) == to_ascii_lowercase(haystack[haystack_idx])) {
+            if (next_match >= MAX_MATCHES)
+                return { false, out_score };
+
+            if (first_match && src_matches) {
+                memcpy(matches, src_matches, next_match);
+                first_match = false;
+            }
+
+            u8 recursive_matches[recursive_match_limit] {};
+            auto result = fuzzy_match_recursive(needle, haystack, needle_idx, haystack_idx + 1, matches, recursive_matches, next_match, recursion_count);
+            if (result.matched) {
+                if (!had_recursive_match || result.score > best_recursive_score) {
+                    memcpy(best_recursive_matches, recursive_matches, recursive_match_limit);
+                    best_recursive_score = result.score;
+                }
+                had_recursive_match = true;
+            }
+            matches[next_match++] = haystack_idx;
+            needle_idx++;
+        }
+        haystack_idx++;
+    }
+
+    bool matched = needle_idx == needle.length();
+    if (!matched)
+        return { false, out_score };
+
+    out_score = calculate_score(haystack, matches, next_match);
+
+    if (had_recursive_match && (best_recursive_score > out_score)) {
+        memcpy(matches, best_recursive_matches, MAX_MATCHES);
+        out_score = best_recursive_score;
+    }
+
+    return { true, out_score };
+}
+
+// This fuzzy_match algorithm is based off a similar algorithm used by Sublime Text. The key insight is that instead
+// of doing a total in the distance between characters (I.E. Levenshtein Distance), we apply some meaningful heuristics
+// related to our dataset that we're trying to match to build up a score. Scores can then be sorted and displayed
+// with the highest at the top.
+//
+// Scores are not normalized between any values and have no particular meaning. The starting value is 100 and when we
+// detect good indicators of a match we add to the score. When we detect bad indicators, we penalize the match and subtract
+// from its score. Therefore, the longer the needle/haystack the greater the range of scores could be.
+FuzzyMatchResult fuzzy_match(String const& needle, String const& haystack)
+{
+    int recursion_count = 0;
+    u8 matches[MAX_MATCHES] {};
+    return fuzzy_match_recursive(needle, haystack, 0, 0, nullptr, matches, 0, recursion_count);
+}
+
+}

--- a/AK/FuzzyMatch.h
+++ b/AK/FuzzyMatch.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/CharacterTypes.h>
 #include <AK/String.h>
 
 namespace AK {
@@ -16,129 +15,12 @@ struct FuzzyMatchResult {
     int score { 0 };
 };
 
-static constexpr int const RECURSION_LIMIT = 10;
-static constexpr int const MAX_MATCHES = 256;
+FuzzyMatchResult fuzzy_match_recursive(String const& needle, String const& haystack, size_t needle_idx, size_t haystack_idx,
+    u8 const* src_matches, u8* matches, int next_match, int& recursion_count);
 
-// Bonuses and penalties are used to build up a final score for the match.
-static constexpr int const SEQUENTIAL_BONUS = 15;            // bonus for adjacent matches (needle: 'ca', haystack: 'cat')
-static constexpr int const SEPARATOR_BONUS = 30;             // bonus if match occurs after a separator ('_' or ' ')
-static constexpr int const CAMEL_BONUS = 30;                 // bonus if match is uppercase and prev is lower (needle: 'myF' haystack: '/path/to/myFile.txt')
-static constexpr int const FIRST_LETTER_BONUS = 20;          // bonus if the first letter is matched (needle: 'c' haystack: 'cat')
-static constexpr int const LEADING_LETTER_PENALTY = -5;      // penalty applied for every letter in str before the first match
-static constexpr int const MAX_LEADING_LETTER_PENALTY = -15; // maximum penalty for leading letters
-static constexpr int const UNMATCHED_LETTER_PENALTY = -1;    // penalty for every letter that doesn't matter
-
-static int calculate_score(String const& string, u8* index_points, size_t index_points_size)
-{
-    int out_score = 100;
-
-    int penalty = LEADING_LETTER_PENALTY * index_points[0];
-    if (penalty < MAX_LEADING_LETTER_PENALTY)
-        penalty = MAX_LEADING_LETTER_PENALTY;
-    out_score += penalty;
-
-    int unmatched = string.length() - index_points_size;
-    out_score += UNMATCHED_LETTER_PENALTY * unmatched;
-
-    for (size_t i = 0; i < index_points_size; i++) {
-        u8 current_idx = index_points[i];
-
-        if (current_idx == 0)
-            out_score += FIRST_LETTER_BONUS;
-
-        if (i == 0)
-            continue;
-
-        u8 previous_idx = index_points[i - 1];
-        if (current_idx - 1 == previous_idx)
-            out_score += SEQUENTIAL_BONUS;
-
-        u32 current_character = string[current_idx];
-        u32 neighbor_character = string[current_idx - 1];
-
-        if (neighbor_character != to_ascii_uppercase(neighbor_character) && current_character != to_ascii_lowercase(current_character))
-            out_score += CAMEL_BONUS;
-
-        if (neighbor_character == '_' || neighbor_character == ' ')
-            out_score += SEPARATOR_BONUS;
-    }
-
-    return out_score;
-}
-
-static FuzzyMatchResult fuzzy_match_recursive(String const& needle, String const& haystack, size_t needle_idx, size_t haystack_idx,
-    u8 const* src_matches, u8* matches, int next_match, int& recursion_count)
-{
-    int out_score = 0;
-
-    ++recursion_count;
-    if (recursion_count >= RECURSION_LIMIT)
-        return { false, out_score };
-
-    if (needle.length() == needle_idx || haystack.length() == haystack_idx)
-        return { false, out_score };
-
-    bool had_recursive_match = false;
-    constexpr size_t recursive_match_limit = 256;
-    u8 best_recursive_matches[recursive_match_limit];
-    int best_recursive_score = 0;
-
-    bool first_match = true;
-    while (needle_idx < needle.length() && haystack_idx < haystack.length()) {
-
-        if (to_ascii_lowercase(needle[needle_idx]) == to_ascii_lowercase(haystack[haystack_idx])) {
-            if (next_match >= MAX_MATCHES)
-                return { false, out_score };
-
-            if (first_match && src_matches) {
-                memcpy(matches, src_matches, next_match);
-                first_match = false;
-            }
-
-            u8 recursive_matches[recursive_match_limit] {};
-            auto result = fuzzy_match_recursive(needle, haystack, needle_idx, haystack_idx + 1, matches, recursive_matches, next_match, recursion_count);
-            if (result.matched) {
-                if (!had_recursive_match || result.score > best_recursive_score) {
-                    memcpy(best_recursive_matches, recursive_matches, recursive_match_limit);
-                    best_recursive_score = result.score;
-                }
-                had_recursive_match = true;
-            }
-            matches[next_match++] = haystack_idx;
-            needle_idx++;
-        }
-        haystack_idx++;
-    }
-
-    bool matched = needle_idx == needle.length();
-    if (!matched)
-        return { false, out_score };
-
-    out_score = calculate_score(haystack, matches, next_match);
-
-    if (had_recursive_match && (best_recursive_score > out_score)) {
-        memcpy(matches, best_recursive_matches, MAX_MATCHES);
-        out_score = best_recursive_score;
-    }
-
-    return { true, out_score };
-}
-
-// This fuzzy_match algorithm is based off a similar algorithm used by Sublime Text. The key insight is that instead
-// of doing a total in the distance between characters (I.E. Levenshtein Distance), we apply some meaningful heuristics
-// related to our dataset that we're trying to match to build up a score. Scores can then be sorted and displayed
-// with the highest at the top.
-//
-// Scores are not normalized between any values and have no particular meaning. The starting value is 100 and when we
-// detect good indicators of a match we add to the score. When we detect bad indicators, we penalize the match and subtract
-// from its score. Therefore, the longer the needle/haystack the greater the range of scores could be.
-static FuzzyMatchResult fuzzy_match(String const& needle, String const& haystack)
-{
-    int recursion_count = 0;
-    u8 matches[MAX_MATCHES] {};
-    return fuzzy_match_recursive(needle, haystack, 0, 0, nullptr, matches, 0, recursion_count);
-}
+FuzzyMatchResult fuzzy_match(String const& needle, String const& haystack);
 
 }
+
 using AK::fuzzy_match;
 using AK::FuzzyMatchResult;

--- a/Kernel/API/POSIX/ucontext.h
+++ b/Kernel/API/POSIX/ucontext.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <Kernel/API/POSIX/signal.h>
 #include <Kernel/API/POSIX/sys/types.h>
 #include <Kernel/Arch/mcontext.h>
 

--- a/Meta/HeaderCheck/CMakeLists.txt
+++ b/Meta/HeaderCheck/CMakeLists.txt
@@ -1,4 +1,12 @@
 execute_process(COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/generate_all.py" "${SERENITY_ARCH}" OUTPUT_VARIABLE SOURCES_STRING)
 string(REPLACE "\n" ";" SOURCES_LIST ${SOURCES_STRING})
 
+# TODO: LibSoftGPU does not compile with this warning enabled, so we disable it here.
+# Once LibSoftGPU drops this disable, HeaderCheck should remove it, too. In particular, the following error would be generated:
+# Userland/Libraries/LibSoftGPU/SIMD.h: In function 'AK::SIMD::f32x4 SoftGPU::ddx(AK::SIMD::f32x4)':
+# Userland/Libraries/LibSoftGPU/SIMD.h:71:59: error: SSE vector return without SSE enabled changes the ABI [-Werror=psabi]
+#    71 | ALWAYS_INLINE static AK::SIMD::f32x4 ddx(AK::SIMD::f32x4 v)
+#       |                                                           ^
+add_compile_options(-Wno-psabi)
+
 add_library(HeaderCheck OBJECT ${SOURCES_LIST})

--- a/Meta/HeaderCheck/generate_all.py
+++ b/Meta/HeaderCheck/generate_all.py
@@ -61,8 +61,6 @@ if __name__ == '__main__':
         print('Must set SERENITY_SOURCE_DIR first!', file=sys.stderr)
         exit(1)
     if len(sys.argv) == 2:
-        with open('/tmp/the_arg', 'w') as fp:
-            fp.write(sys.argv[1])
         run(os.environ['SERENITY_SOURCE_DIR'], sys.argv[1])
     else:
         print('Usage: SERENITY_SOURCE_DIR=/path/to/serenity {} SERENITY_BUILD_ARCH'

--- a/Meta/HeaderCheck/generate_all.py
+++ b/Meta/HeaderCheck/generate_all.py
@@ -12,7 +12,9 @@ TEST_FILE_TEMPLATE = '''\
 
 
 def get_headers_here():
-    result = subprocess.run(['git', 'ls-files', 'Userland/Libraries/*.h'], check=True, capture_output=True, text=True)
+    result = subprocess.run(
+        ['git', 'ls-files', 'AK/*.h', 'Userland/Libraries/*.h'],
+        check=True, capture_output=True, text=True)
     assert result.stderr == ''
     output = result.stdout.split('\n')
     assert output[-1] == ''  # Trailing newline

--- a/Userland/Libraries/LibCodeComprehension/Shell/ConnectionFromClient.h
+++ b/Userland/Libraries/LibCodeComprehension/Shell/ConnectionFromClient.h
@@ -19,7 +19,7 @@ private:
     ConnectionFromClient(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
         : LanguageServers::ConnectionFromClient(move(socket))
     {
-        m_autocomplete_engine = make<ShellComprehensionEngine>(m_filedb);
+        m_autocomplete_engine = make<CodeComprehension::Shell::ShellComprehensionEngine>(m_filedb);
         m_autocomplete_engine->set_declarations_of_document_callback = [this](String const& filename, Vector<CodeComprehension::Declaration>&& declarations) {
             async_declarations_in_document(filename, move(declarations));
         };

--- a/Userland/Libraries/LibDNS/Question.h
+++ b/Userland/Libraries/LibDNS/Question.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "Answer.h"
 #include "Name.h"
 #include <AK/Types.h>
 

--- a/Userland/Libraries/LibGPU/StencilConfiguration.h
+++ b/Userland/Libraries/LibGPU/StencilConfiguration.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGPU/Config.h>
 #include <LibGPU/Enums.h>
 
 namespace GPU {

--- a/Userland/Libraries/LibGfx/Font/VectorFont.h
+++ b/Userland/Libraries/LibGfx/Font/VectorFont.h
@@ -8,6 +8,7 @@
 
 #include <AK/Noncopyable.h>
 #include <AK/RefCounted.h>
+#include <LibGfx/Forward.h>
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/PNGShared.h
+++ b/Userland/Libraries/LibGfx/PNGShared.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <AK/Array.h>
+#include <AK/SIMD.h>
+
 namespace Gfx::PNG {
 
 // https://www.w3.org/TR/PNG/#5PNG-file-signature
@@ -33,9 +36,9 @@ enum class FilterType : u8 {
 ALWAYS_INLINE u8 paeth_predictor(u8 a, u8 b, u8 c)
 {
     int p = a + b - c;
-    int pa = abs(p - a);
-    int pb = abs(p - b);
-    int pc = abs(p - c);
+    int pa = AK::abs(p - a);
+    int pb = AK::abs(p - b);
+    int pc = AK::abs(p - c);
     if (pa <= pb && pa <= pc)
         return a;
     if (pb <= pc)

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Concepts.h>
+#include <AK/HashMap.h>
 #include <AK/StdLibExtras.h>
 #include <LibCore/SharedCircularQueue.h>
 #include <LibIPC/Forward.h>

--- a/Userland/Libraries/LibJS/Runtime/ClassFieldDefinition.h
+++ b/Userland/Libraries/LibJS/Runtime/ClassFieldDefinition.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Heap/Handle.h>
 
 namespace JS {
 

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -8,6 +8,7 @@
 
 #include <AK/FlyString.h>
 #include <AK/HashMap.h>
+#include <LibJS/AST.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Environment.h>
 #include <LibJS/Runtime/Value.h>

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Utf8View.h>
 #include <LibJS/Runtime/StringObject.h>
 
 namespace JS {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.h
@@ -8,6 +8,7 @@
 
 #include <LibJS/Runtime/BigInt.h>
 #include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Temporal/AbstractOperations.h>
 
 namespace JS::Temporal {
 

--- a/Userland/Libraries/LibLine/Style.h
+++ b/Userland/Libraries/LibLine/Style.h
@@ -8,6 +8,7 @@
 
 #include <AK/String.h>
 #include <AK/Types.h>
+#include <AK/Utf8View.h>
 #include <AK/Vector.h>
 #include <stdlib.h>
 

--- a/Userland/Libraries/LibPDF/XRefTable.h
+++ b/Userland/Libraries/LibPDF/XRefTable.h
@@ -10,6 +10,7 @@
 #include <AK/RefCounted.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibPDF/Error.h>
 
 namespace PDF {
 

--- a/Userland/Libraries/LibSoftGPU/SIMD.h
+++ b/Userland/Libraries/LibSoftGPU/SIMD.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/SIMDExtras.h>
+#include <AK/SIMDMath.h>
 #include <LibGfx/Vector2.h>
 #include <LibGfx/Vector3.h>
 #include <LibGfx/Vector4.h>

--- a/Userland/Libraries/LibWeb/CSS/UnicodeRange.h
+++ b/Userland/Libraries/LibWeb/CSS/UnicodeRange.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/String.h>
 
 namespace Web::CSS {
 

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -454,6 +454,7 @@ class URLSearchParamsIterator;
 }
 
 namespace Web::Bindings {
+class CallbackType;
 class LocationObject;
 class OptionConstructor;
 class RangePrototype;

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicy.h
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicy.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/String.h>
+
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policy-value

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicyEnforcementResult.h
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicyEnforcementResult.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/URL.h>
+#include <LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicy.h>
 #include <LibWeb/HTML/Origin.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
@@ -8,6 +8,7 @@
 
 #include <AK/Optional.h>
 #include <AK/String.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/SandboxingFlagSet.h
+++ b/Userland/Libraries/LibWeb/HTML/SandboxingFlagSet.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Types.h>
+
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/origin.html#sandboxing-flag-set

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibJS/Heap/Handle.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 
 namespace Web::IntersectionObserver {

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -9,6 +9,7 @@
 #include <AK/Noncopyable.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/InlineNode.h>
+#include <LibWeb/Layout/LayoutState.h>
 #include <LibWeb/Layout/TextNode.h>
 
 namespace Web::Layout {

--- a/Userland/Libraries/LibXML/DOM/Node.h
+++ b/Userland/Libraries/LibXML/DOM/Node.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/String.h>
 #include <AK/Variant.h>

--- a/Userland/Services/WindowServer/SystemEffects.h
+++ b/Userland/Services/WindowServer/SystemEffects.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <AK/Types.h>
+#include <AK/Vector.h>
 
 namespace WindowServer {
 


### PR DESCRIPTION
Let's say we have a file `compile_me.cpp`, like this:

```c++
// file: compile_me.cpp
#include <LibDNS/Question.h>
// That's all!
```

Before this PR, it didn't compile.

HeaderCheck is a tool that automatically tries to compile all headers this way. (All headers in `Userland/Libraries/`.) However, doing so takes a long time, and it sucks when a CI build fails due to this after a long time. [1](https://discord.com/channels/830522505605283862/830525031720943627/943589070565679155) [2](https://github.com/SerenityOS/serenity/commit/bc98ad9cc1452a3db574eca44b029c2dfca43605) [3](https://discord.com/channels/830522505605283862/830739873119207426/1019298311590645792).

This PR:
- fixes all of the existing problems, including the nasty dependency cycle in LibWeb involving `CSS::Length`
- includes AK into the HeaderCheck scope
- runs HeaderCheck as a weekly cronjob that runs at 2am every morning

Here's a preview how this will look: https://github.com/BenWiederhake/serenity/actions/runs/3048260526/jobs/4913127822

Notice that it only takes 8 minutes (plus 14 minutes to build the toolchain from scratch), so I must once again recommend that HeaderCheck be run on every CI execution, but oh well.

And just to hammer down the point that this problem isn't imaginary: people sometimes have to first fiddle with unrelated headers in order to do their work: https://github.com/SerenityOS/serenity/pull/15228/commits/6089d4e56a5827a12098b168eb9822d26f524ec7