### PR TITLE
Everywhere: Remove cyclic #include-s

### DIFF
--- a/Userland/Libraries/LibCpp/Lexer.h
+++ b/Userland/Libraries/LibCpp/Lexer.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "LibCpp/Token.h"
 #include <AK/StringView.h>
 #include <AK/Vector.h>
+#include <LibCpp/Token.h>
 
 namespace Cpp {
 

--- a/Userland/Libraries/LibCpp/Parser.h
+++ b/Userland/Libraries/LibCpp/Parser.h
@@ -6,12 +6,12 @@
 
 #pragma once
 
-#include "AK/NonnullRefPtr.h"
-#include "AST.h"
-#include "Preprocessor.h"
 #include <AK/Noncopyable.h>
+#include <AK/NonnullRefPtr.h>
 #include <LibCodeComprehension/Types.h>
+#include <LibCpp/AST.h>
 #include <LibCpp/Lexer.h>
+#include <LibCpp/Preprocessor.h>
 
 namespace Cpp {
 

--- a/Userland/Libraries/LibDebug/Dwarf/CompilationUnit.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/CompilationUnit.cpp
@@ -5,8 +5,10 @@
  */
 
 #include "CompilationUnit.h"
-#include "DIE.h"
 #include <AK/ByteReader.h>
+#include <LibDebug/Dwarf/DIE.h>
+#include <LibDebug/Dwarf/DwarfInfo.h>
+#include <LibDebug/Dwarf/LineProgram.h>
 
 namespace Debug::Dwarf {
 
@@ -20,6 +22,8 @@ CompilationUnit::CompilationUnit(DwarfInfo const& dwarf_info, u32 offset, Compil
     VERIFY(header.version() < 5 || header.unit_type() == CompilationUnitType::Full);
 }
 
+CompilationUnit::~CompilationUnit() = default;
+
 DIE CompilationUnit::root_die() const
 {
     return DIE(*this, m_offset + m_header.header_size());
@@ -29,6 +33,11 @@ DIE CompilationUnit::get_die_at_offset(u32 die_offset) const
 {
     VERIFY(die_offset >= offset() && die_offset < offset() + size());
     return DIE(*this, die_offset);
+}
+
+LineProgram const& CompilationUnit::line_program() const
+{
+    return *m_line_program;
 }
 
 Optional<FlatPtr> CompilationUnit::base_address() const

--- a/Userland/Libraries/LibDebug/Dwarf/CompilationUnit.h
+++ b/Userland/Libraries/LibDebug/Dwarf/CompilationUnit.h
@@ -7,9 +7,8 @@
 #pragma once
 
 #include "AbbreviationsMap.h"
-#include "DIE.h"
-#include "LineProgram.h"
 #include <AK/Noncopyable.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Types.h>
 
 namespace Debug::Dwarf {
@@ -24,6 +23,7 @@ class CompilationUnit {
 
 public:
     CompilationUnit(DwarfInfo const& dwarf_info, u32 offset, CompilationUnitHeader const&, NonnullOwnPtr<LineProgram>&& line_program);
+    ~CompilationUnit();
 
     u32 offset() const { return m_offset; }
     u32 size() const { return m_header.length() + sizeof(u32); }
@@ -38,7 +38,7 @@ public:
 
     DwarfInfo const& dwarf_info() const { return m_dwarf_info; }
     AbbreviationsMap const& abbreviations_map() const { return m_abbreviations; }
-    LineProgram const& line_program() const { return *m_line_program; }
+    LineProgram const& line_program() const;
     Optional<FlatPtr> base_address() const;
 
     // DW_AT_addr_base

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -31,6 +31,8 @@ DwarfInfo::DwarfInfo(ELF::Image const& elf)
     populate_compilation_units();
 }
 
+DwarfInfo::~DwarfInfo() = default;
+
 ReadonlyBytes DwarfInfo::section_data(StringView section_name) const
 {
     auto section = m_elf.lookup_section(section_name);

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.h
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "AttributeValue.h"
-#include "CompilationUnit.h"
 #include "DwarfTypes.h"
 #include <AK/ByteBuffer.h>
 #include <AK/NonnullOwnPtrVector.h>
@@ -15,9 +14,12 @@
 #include <AK/RedBlackTree.h>
 #include <AK/RefCounted.h>
 #include <AK/String.h>
+#include <LibDebug/Dwarf/DIE.h>
 #include <LibELF/Image.h>
 
 namespace Debug::Dwarf {
+
+class CompilationUnit;
 
 class DwarfInfo {
     AK_MAKE_NONCOPYABLE(DwarfInfo);
@@ -25,6 +27,7 @@ class DwarfInfo {
 
 public:
     explicit DwarfInfo(ELF::Image const&);
+    ~DwarfInfo();
 
     ReadonlyBytes debug_info_data() const { return m_debug_info_data; }
     ReadonlyBytes abbreviation_data() const { return m_abbreviation_data; }

--- a/Userland/Libraries/LibDebug/Dwarf/Expression.h
+++ b/Userland/Libraries/LibDebug/Dwarf/Expression.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "AK/ByteBuffer.h"
-#include "AK/Types.h"
+#include <AK/ByteBuffer.h>
+#include <AK/Types.h>
 
 struct PtraceRegisters;
 

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -9,6 +9,7 @@
 #include <AK/Function.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
+#include <LibDebug/Dwarf/DwarfInfo.h>
 
 namespace Debug::Dwarf {
 

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
@@ -6,12 +6,14 @@
 
 #pragma once
 
-#include "DwarfInfo.h"
 #include <AK/FlyString.h>
 #include <AK/MemoryStream.h>
 #include <AK/Vector.h>
+#include <LibDebug/Dwarf/DwarfTypes.h>
 
 namespace Debug::Dwarf {
+
+class DwarfInfo;
 
 struct [[gnu::packed]] LineProgramUnitHeader32Common {
     u32 length;

--- a/Userland/Libraries/LibDebug/StackFrameUtils.h
+++ b/Userland/Libraries/LibDebug/StackFrameUtils.h
@@ -8,8 +8,7 @@
 
 #include <AK/Optional.h>
 #include <AK/Types.h>
-
-#include "LibDebug/DebugSession.h"
+#include <LibDebug/DebugSession.h>
 
 namespace Debug::StackFrameUtils {
 

--- a/Userland/Libraries/LibGfx/TextLayout.h
+++ b/Userland/Libraries/LibGfx/TextLayout.h
@@ -7,13 +7,13 @@
 
 #pragma once
 
-#include "AK/Forward.h"
-#include "LibGfx/Forward.h"
+#include <AK/Forward.h>
 #include <AK/String.h>
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
 #include <AK/Vector.h>
 #include <LibGfx/Font/Font.h>
+#include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/TextElision.h>
 #include <LibGfx/TextWrapping.h>

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.h
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.h
@@ -8,7 +8,6 @@
 
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
-#include <LibJS/Runtime/Realm.h>
 
 namespace JS {
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Duration.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Duration.h
@@ -12,7 +12,6 @@
 #include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/Temporal/PlainDate.h>
-#include <LibJS/Runtime/Temporal/PlainDateTime.h>
 #include <LibJS/Runtime/Temporal/ZonedDateTime.h>
 #include <LibJS/Runtime/VM.h>
 

--- a/Userland/Libraries/LibPDF/Object.h
+++ b/Userland/Libraries/LibPDF/Object.h
@@ -13,7 +13,6 @@
 #include <AK/SourceLocation.h>
 #include <LibPDF/Error.h>
 #include <LibPDF/Forward.h>
-#include <LibPDF/Value.h>
 
 #ifdef PDF_DEBUG
 namespace {

--- a/Userland/Libraries/LibRegex/RegexDebug.h
+++ b/Userland/Libraries/LibRegex/RegexDebug.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "AK/StringBuilder.h"
-#include "LibRegex/RegexMatcher.h"
 #include <AK/Debug.h>
+#include <AK/StringBuilder.h>
+#include <LibRegex/RegexMatcher.h>
 
 namespace regex {
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.h
@@ -9,7 +9,6 @@
 
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefPtr.h>
-#include <LibWeb/CSS/Parser/Function.h>
 #include <LibWeb/CSS/Parser/Token.h>
 #include <LibWeb/Forward.h>
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/DeclarationOrAtRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeclarationOrAtRule.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibWeb/CSS/Parser/DeclarationOrAtRule.h>
+#include <LibWeb/CSS/Parser/Function.h>
 
 namespace Web::CSS::Parser {
 

--- a/Userland/Libraries/LibWeb/Layout/InitialContainingBlock.h
+++ b/Userland/Libraries/LibWeb/Layout/InitialContainingBlock.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/BlockContainer.h>
+#include <LibWeb/Layout/LayoutPosition.h>
 
 namespace Web::Layout {
 

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -15,7 +15,6 @@
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Layout/BoxModelMetrics.h>
-#include <LibWeb/Layout/LayoutPosition.h>
 #include <LibWeb/Painting/PaintContext.h>
 #include <LibWeb/TreeNode.h>
 


### PR DESCRIPTION
These happen to be non-problematic thanks to sheer luck, but let's avoid trouble down the road.

A tool for detecting these automatically during pre-commit is coming. :^)