### PR TITLE
LibWeb: Resolve cyclic declaration/definitions involving Length

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
     CSS/GridTrackPlacement.cpp
     CSS/GridTrackSize.cpp
     CSS/Length.cpp
+    CSS/LengthBox.cpp
     CSS/MediaList.cpp
     CSS/MediaQuery.cpp
     CSS/MediaQueryList.cpp

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -20,15 +20,19 @@ GridTrackSize::GridTrackSize(Length length)
 
 GridTrackSize::GridTrackSize(Percentage percentage)
     : m_type(Type::Percentage)
+    , m_length { Length::make_px(0) }
     , m_percentage(percentage)
 {
 }
 
 GridTrackSize::GridTrackSize(float flexible_length)
     : m_type(Type::FlexibleLength)
+    , m_length { Length::make_px(0) }
     , m_flexible_length(flexible_length)
 {
 }
+
+GridTrackSize::~GridTrackSize() = default;
 
 GridTrackSize GridTrackSize::make_auto()
 {
@@ -46,6 +50,11 @@ String GridTrackSize::to_string() const
         return String::formatted("{}fr", m_flexible_length);
     }
     VERIFY_NOT_REACHED();
+}
+
+Length GridTrackSize::length() const
+{
+    return m_length;
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
@@ -25,6 +25,7 @@ public:
     GridTrackSize(Length);
     GridTrackSize(Percentage);
     GridTrackSize(float);
+    ~GridTrackSize();
 
     static GridTrackSize make_auto();
 
@@ -34,7 +35,7 @@ public:
     bool is_percentage() const { return m_type == Type::Percentage; }
     bool is_flexible_length() const { return m_type == Type::FlexibleLength; }
 
-    Length length() const { return m_length; }
+    Length length() const;
     Percentage percentage() const { return m_percentage; }
     float flexible_length() const { return m_flexible_length; }
 
@@ -57,7 +58,9 @@ public:
 
 private:
     Type m_type;
-    Length m_length { Length::make_px(0) };
+    // Length includes a RefPtr<CalculatedStyleValue> member, but we can't include the header StyleValue.h as it includes
+    // this file already. To break the cyclic dependency, we must initialize m_length in the constructor.
+    Length m_length;
     Percentage m_percentage { Percentage(0) };
     float m_flexible_length { 0 };
 };

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -28,6 +28,7 @@ Length::Length(float value, Type type)
     , m_value(value)
 {
 }
+Length::~Length() = default;
 
 Length Length::make_auto()
 {
@@ -202,6 +203,13 @@ NonnullRefPtr<CalculatedStyleValue> Length::calculated_style_value() const
 {
     VERIFY(!m_calculated_style.is_null());
     return *m_calculated_style;
+}
+
+bool Length::operator==(Length const& other) const
+{
+    if (is_calculated())
+        return m_calculated_style == other.m_calculated_style;
+    return m_type == other.m_type && m_value == other.m_value;
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -40,6 +40,7 @@ public:
     // this file already. To break the cyclic dependency, we must move all method definitions out.
     Length(int value, Type type);
     Length(float value, Type type);
+    ~Length();
 
     static Length make_auto();
     static Length make_px(float value);
@@ -117,13 +118,9 @@ public:
 
     String to_string() const;
 
-    bool operator==(Length const& other) const
-    {
-        if (is_calculated())
-            return m_calculated_style == other.m_calculated_style;
-        return m_type == other.m_type && m_value == other.m_value;
-    }
-
+    // We have a RefPtr<CalculatedStyleValue> member, but can't include the header StyleValue.h as it includes
+    // this file already. To break the cyclic dependency, we must move all method definitions out.
+    bool operator==(Length const& other) const;
     bool operator!=(Length const& other) const
     {
         return !(*this == other);

--- a/Userland/Libraries/LibWeb/CSS/LengthBox.cpp
+++ b/Userland/Libraries/LibWeb/CSS/LengthBox.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "LengthBox.h"
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+LengthBox::LengthBox()
+    : m_top(Length::make_auto())
+    , m_right(Length::make_auto())
+    , m_bottom(Length::make_auto())
+    , m_left(Length::make_auto())
+{
+}
+
+LengthBox::LengthBox(LengthPercentage top, LengthPercentage right, LengthPercentage bottom, LengthPercentage left)
+    : m_top(top)
+    , m_right(right)
+    , m_bottom(bottom)
+    , m_left(left)
+{
+}
+
+LengthBox::~LengthBox() = default;
+
+}

--- a/Userland/Libraries/LibWeb/CSS/LengthBox.h
+++ b/Userland/Libraries/LibWeb/CSS/LengthBox.h
@@ -10,11 +10,28 @@
 
 namespace Web::CSS {
 
-struct LengthBox {
-    LengthPercentage top { Length::make_auto() };
-    LengthPercentage right { Length::make_auto() };
-    LengthPercentage bottom { Length::make_auto() };
-    LengthPercentage left { Length::make_auto() };
+class LengthBox {
+public:
+    LengthBox();
+    LengthBox(LengthPercentage top, LengthPercentage right, LengthPercentage bottom, LengthPercentage left);
+    ~LengthBox();
+
+    // Length (and thus LengthPercentage) includes a RefPtr<CalculatedStyleValue> member, but we can't include the header StyleValue.h as it includes
+    // this file already. To break the cyclic dependency, we must initialize these members in the constructor.
+    LengthPercentage& top() { return m_top; }
+    LengthPercentage& right() { return m_right; }
+    LengthPercentage& bottom() { return m_bottom; }
+    LengthPercentage& left() { return m_left; };
+    LengthPercentage const& top() const { return m_top; }
+    LengthPercentage const& right() const { return m_right; }
+    LengthPercentage const& bottom() const { return m_bottom; }
+    LengthPercentage const& left() const { return m_left; };
+
+private:
+    LengthPercentage m_top;
+    LengthPercentage m_right;
+    LengthPercentage m_bottom;
+    LengthPercentage m_left;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -359,20 +359,20 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
     case CSS::PropertyID::Margin: {
         auto margin = layout_node.computed_values().margin();
         auto values = NonnullRefPtrVector<StyleValue> {};
-        values.append(style_value_for_length_percentage(margin.top));
-        values.append(style_value_for_length_percentage(margin.right));
-        values.append(style_value_for_length_percentage(margin.bottom));
-        values.append(style_value_for_length_percentage(margin.left));
+        values.append(style_value_for_length_percentage(margin.top()));
+        values.append(style_value_for_length_percentage(margin.right()));
+        values.append(style_value_for_length_percentage(margin.bottom()));
+        values.append(style_value_for_length_percentage(margin.left()));
         return StyleValueList::create(move(values), StyleValueList::Separator::Space);
     }
     case CSS::PropertyID::MarginBottom:
-        return style_value_for_length_percentage(layout_node.computed_values().margin().bottom);
+        return style_value_for_length_percentage(layout_node.computed_values().margin().bottom());
     case CSS::PropertyID::MarginLeft:
-        return style_value_for_length_percentage(layout_node.computed_values().margin().left);
+        return style_value_for_length_percentage(layout_node.computed_values().margin().left());
     case CSS::PropertyID::MarginRight:
-        return style_value_for_length_percentage(layout_node.computed_values().margin().right);
+        return style_value_for_length_percentage(layout_node.computed_values().margin().right());
     case CSS::PropertyID::MarginTop:
-        return style_value_for_length_percentage(layout_node.computed_values().margin().top);
+        return style_value_for_length_percentage(layout_node.computed_values().margin().top());
     case CSS::PropertyID::MaxHeight:
         return style_value_for_length_percentage(layout_node.computed_values().max_height());
     case CSS::PropertyID::MaxWidth:
@@ -392,20 +392,20 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
     case CSS::PropertyID::Padding: {
         auto padding = layout_node.computed_values().padding();
         auto values = NonnullRefPtrVector<StyleValue> {};
-        values.append(style_value_for_length_percentage(padding.top));
-        values.append(style_value_for_length_percentage(padding.right));
-        values.append(style_value_for_length_percentage(padding.bottom));
-        values.append(style_value_for_length_percentage(padding.left));
+        values.append(style_value_for_length_percentage(padding.top()));
+        values.append(style_value_for_length_percentage(padding.right()));
+        values.append(style_value_for_length_percentage(padding.bottom()));
+        values.append(style_value_for_length_percentage(padding.left()));
         return StyleValueList::create(move(values), StyleValueList::Separator::Space);
     }
     case CSS::PropertyID::PaddingBottom:
     case CSS::PropertyID::PaddingLeft:
-        return style_value_for_length_percentage(layout_node.computed_values().padding().left);
-        return style_value_for_length_percentage(layout_node.computed_values().padding().bottom);
+        return style_value_for_length_percentage(layout_node.computed_values().padding().left());
+        return style_value_for_length_percentage(layout_node.computed_values().padding().bottom());
     case CSS::PropertyID::PaddingRight:
-        return style_value_for_length_percentage(layout_node.computed_values().padding().right);
+        return style_value_for_length_percentage(layout_node.computed_values().padding().right());
     case CSS::PropertyID::PaddingTop:
-        return style_value_for_length_percentage(layout_node.computed_values().padding().top);
+        return style_value_for_length_percentage(layout_node.computed_values().padding().top());
     case CSS::PropertyID::Position:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().position()));
     case CSS::PropertyID::TextAlign:

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -81,10 +81,10 @@ Optional<LengthPercentage> StyleProperties::length_percentage(CSS::PropertyID id
 LengthBox StyleProperties::length_box(CSS::PropertyID left_id, CSS::PropertyID top_id, CSS::PropertyID right_id, CSS::PropertyID bottom_id, const CSS::Length& default_value) const
 {
     LengthBox box;
-    box.left = length_percentage_or_fallback(left_id, default_value);
-    box.top = length_percentage_or_fallback(top_id, default_value);
-    box.right = length_percentage_or_fallback(right_id, default_value);
-    box.bottom = length_percentage_or_fallback(bottom_id, default_value);
+    box.left() = length_percentage_or_fallback(left_id, default_value);
+    box.top() = length_percentage_or_fallback(top_id, default_value);
+    box.right() = length_percentage_or_fallback(right_id, default_value);
+    box.bottom() = length_percentage_or_fallback(bottom_id, default_value);
     return box;
 }
 

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -67,6 +67,7 @@ class ImageStyleValue;
 class InheritStyleValue;
 class InitialStyleValue;
 class Length;
+class LengthBox;
 class LengthPercentage;
 class LengthStyleValue;
 class LinearGradientStyleValue;

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -103,13 +103,13 @@ void BlockFormattingContext::compute_width(Box const& box, LayoutMode layout_mod
 
     auto margin_left = CSS::Length::make_auto();
     auto margin_right = CSS::Length::make_auto();
-    auto padding_left = computed_values.padding().left.resolved(box, width_of_containing_block_as_length).resolved(box);
-    auto padding_right = computed_values.padding().right.resolved(box, width_of_containing_block_as_length).resolved(box);
+    auto padding_left = computed_values.padding().left().resolved(box, width_of_containing_block_as_length).resolved(box);
+    auto padding_right = computed_values.padding().right().resolved(box, width_of_containing_block_as_length).resolved(box);
 
     auto try_compute_width = [&](auto const& a_width) {
         CSS::Length width = a_width;
-        margin_left = computed_values.margin().left.resolved(box, width_of_containing_block_as_length).resolved(box);
-        margin_right = computed_values.margin().right.resolved(box, width_of_containing_block_as_length).resolved(box);
+        margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length).resolved(box);
+        margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length).resolved(box);
         float total_px = computed_values.border_left().width + computed_values.border_right().width;
         for (auto& value : { margin_left, padding_left, width, padding_right, margin_right }) {
             total_px += value.to_px(box);
@@ -245,10 +245,10 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Layo
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
     auto zero_value = CSS::Length::make_px(0);
 
-    auto margin_left = computed_values.margin().left.resolved(box, width_of_containing_block_as_length).resolved(box);
-    auto margin_right = computed_values.margin().right.resolved(box, width_of_containing_block_as_length).resolved(box);
-    auto const padding_left = computed_values.padding().left.resolved(box, width_of_containing_block_as_length).resolved(box);
-    auto const padding_right = computed_values.padding().right.resolved(box, width_of_containing_block_as_length).resolved(box);
+    auto margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length).resolved(box);
+    auto margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length).resolved(box);
+    auto const padding_left = computed_values.padding().left().resolved(box, width_of_containing_block_as_length).resolved(box);
+    auto const padding_right = computed_values.padding().right().resolved(box, width_of_containing_block_as_length).resolved(box);
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
     if (margin_left.is_auto())
@@ -351,13 +351,13 @@ void BlockFormattingContext::compute_height(Box const& box, LayoutState& state)
 
     auto& box_state = state.get_mutable(box);
 
-    box_state.margin_top = computed_values.margin().top.resolved(box, width_of_containing_block_as_length).to_px(box);
-    box_state.margin_bottom = computed_values.margin().bottom.resolved(box, width_of_containing_block_as_length).to_px(box);
+    box_state.margin_top = computed_values.margin().top().resolved(box, width_of_containing_block_as_length).to_px(box);
+    box_state.margin_bottom = computed_values.margin().bottom().resolved(box, width_of_containing_block_as_length).to_px(box);
 
     box_state.border_top = computed_values.border_top().width;
     box_state.border_bottom = computed_values.border_bottom().width;
-    box_state.padding_top = computed_values.padding().top.resolved(box, width_of_containing_block_as_length).to_px(box);
-    box_state.padding_bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block_as_length).to_px(box);
+    box_state.padding_top = computed_values.padding().top().resolved(box, width_of_containing_block_as_length).to_px(box);
+    box_state.padding_bottom = computed_values.padding().bottom().resolved(box, width_of_containing_block_as_length).to_px(box);
 
     box_state.set_content_height(compute_theoretical_height(state, box));
 }
@@ -499,12 +499,12 @@ void BlockFormattingContext::compute_vertical_box_model_metrics(Box const& box, 
     auto const& computed_values = box.computed_values();
     auto width_of_containing_block = CSS::Length::make_px(containing_block_width_for(box));
 
-    box_state.margin_top = computed_values.margin().top.resolved(box, width_of_containing_block).resolved(containing_block).to_px(box);
-    box_state.margin_bottom = computed_values.margin().bottom.resolved(box, width_of_containing_block).resolved(containing_block).to_px(box);
+    box_state.margin_top = computed_values.margin().top().resolved(box, width_of_containing_block).resolved(containing_block).to_px(box);
+    box_state.margin_bottom = computed_values.margin().bottom().resolved(box, width_of_containing_block).resolved(containing_block).to_px(box);
     box_state.border_top = computed_values.border_top().width;
     box_state.border_bottom = computed_values.border_bottom().width;
-    box_state.padding_top = computed_values.padding().top.resolved(box, width_of_containing_block).resolved(containing_block).to_px(box);
-    box_state.padding_bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block).resolved(containing_block).to_px(box);
+    box_state.padding_top = computed_values.padding().top().resolved(box, width_of_containing_block).resolved(containing_block).to_px(box);
+    box_state.padding_bottom = computed_values.padding().bottom().resolved(box, width_of_containing_block).resolved(containing_block).to_px(box);
 }
 
 void BlockFormattingContext::place_block_level_element_in_normal_flow_vertically(Box const& child_box, BlockContainer const& containing_block)

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -224,40 +224,40 @@ void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::Flex
         item.borders.cross_before = item.box.computed_values().border_top().width;
         item.borders.cross_after = item.box.computed_values().border_bottom().width;
 
-        item.padding.main_before = item.box.computed_values().padding().left.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.padding.main_after = item.box.computed_values().padding().right.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.padding.cross_before = item.box.computed_values().padding().top.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.padding.cross_after = item.box.computed_values().padding().bottom.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.main_before = item.box.computed_values().padding().left().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.main_after = item.box.computed_values().padding().right().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.cross_before = item.box.computed_values().padding().top().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.cross_after = item.box.computed_values().padding().bottom().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
 
-        item.margins.main_before = item.box.computed_values().margin().left.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.margins.main_after = item.box.computed_values().margin().right.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.margins.cross_before = item.box.computed_values().margin().top.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.margins.cross_after = item.box.computed_values().margin().bottom.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.main_before = item.box.computed_values().margin().left().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.main_after = item.box.computed_values().margin().right().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.cross_before = item.box.computed_values().margin().top().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.cross_after = item.box.computed_values().margin().bottom().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
 
-        item.margins.main_before_is_auto = item.box.computed_values().margin().left.is_auto();
-        item.margins.main_after_is_auto = item.box.computed_values().margin().right.is_auto();
-        item.margins.cross_before_is_auto = item.box.computed_values().margin().top.is_auto();
-        item.margins.cross_after_is_auto = item.box.computed_values().margin().bottom.is_auto();
+        item.margins.main_before_is_auto = item.box.computed_values().margin().left().is_auto();
+        item.margins.main_after_is_auto = item.box.computed_values().margin().right().is_auto();
+        item.margins.cross_before_is_auto = item.box.computed_values().margin().top().is_auto();
+        item.margins.cross_after_is_auto = item.box.computed_values().margin().bottom().is_auto();
     } else {
         item.borders.main_before = item.box.computed_values().border_top().width;
         item.borders.main_after = item.box.computed_values().border_bottom().width;
         item.borders.cross_before = item.box.computed_values().border_left().width;
         item.borders.cross_after = item.box.computed_values().border_right().width;
 
-        item.padding.main_before = item.box.computed_values().padding().top.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.padding.main_after = item.box.computed_values().padding().bottom.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.padding.cross_before = item.box.computed_values().padding().left.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.padding.cross_after = item.box.computed_values().padding().right.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.main_before = item.box.computed_values().padding().top().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.main_after = item.box.computed_values().padding().bottom().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.cross_before = item.box.computed_values().padding().left().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.cross_after = item.box.computed_values().padding().right().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
 
-        item.margins.main_before = item.box.computed_values().margin().top.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.margins.main_after = item.box.computed_values().margin().bottom.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.margins.cross_before = item.box.computed_values().margin().left.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.margins.cross_after = item.box.computed_values().margin().right.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.main_before = item.box.computed_values().margin().top().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.main_after = item.box.computed_values().margin().bottom().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.cross_before = item.box.computed_values().margin().left().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.cross_after = item.box.computed_values().margin().right().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
 
-        item.margins.main_before_is_auto = item.box.computed_values().margin().top.is_auto();
-        item.margins.main_after_is_auto = item.box.computed_values().margin().bottom.is_auto();
-        item.margins.cross_before_is_auto = item.box.computed_values().margin().left.is_auto();
-        item.margins.cross_after_is_auto = item.box.computed_values().margin().right.is_auto();
+        item.margins.main_before_is_auto = item.box.computed_values().margin().top().is_auto();
+        item.margins.main_after_is_auto = item.box.computed_values().margin().bottom().is_auto();
+        item.margins.cross_before_is_auto = item.box.computed_values().margin().left().is_auto();
+        item.margins.cross_after_is_auto = item.box.computed_values().margin().right().is_auto();
     }
 };
 
@@ -1394,15 +1394,15 @@ void FlexFormattingContext::copy_dimensions_from_flex_items_to_boxes()
         auto const& box = flex_item.box;
         auto& box_state = m_state.get_mutable(box);
 
-        box_state.padding_left = box.computed_values().padding().left.resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
-        box_state.padding_right = box.computed_values().padding().right.resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
-        box_state.padding_top = box.computed_values().padding().top.resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
-        box_state.padding_bottom = box.computed_values().padding().bottom.resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.padding_left = box.computed_values().padding().left().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.padding_right = box.computed_values().padding().right().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.padding_top = box.computed_values().padding().top().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.padding_bottom = box.computed_values().padding().bottom().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
 
-        box_state.margin_left = box.computed_values().margin().left.resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
-        box_state.margin_right = box.computed_values().margin().right.resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
-        box_state.margin_top = box.computed_values().margin().top.resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
-        box_state.margin_bottom = box.computed_values().margin().bottom.resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.margin_left = box.computed_values().margin().left().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.margin_right = box.computed_values().margin().right().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.margin_top = box.computed_values().margin().top().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.margin_bottom = box.computed_values().margin().bottom().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
 
         box_state.border_left = box.computed_values().border_left().width;
         box_state.border_right = box.computed_values().border_right().width;

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -421,8 +421,8 @@ float FormattingContext::compute_width_for_replaced_element(LayoutState const& s
     auto zero_value = CSS::Length::make_px(0);
     auto width_of_containing_block_as_length = CSS::Length::make_px(containing_block_width_for(box, state));
 
-    auto margin_left = box.computed_values().margin().left.resolved(box, width_of_containing_block_as_length).resolved(box);
-    auto margin_right = box.computed_values().margin().right.resolved(box, width_of_containing_block_as_length).resolved(box);
+    auto margin_left = box.computed_values().margin().left().resolved(box, width_of_containing_block_as_length).resolved(box);
+    auto margin_right = box.computed_values().margin().right().resolved(box, width_of_containing_block_as_length).resolved(box);
 
     // A computed value of 'auto' for 'margin-left' or 'margin-right' becomes a used value of '0'.
     if (margin_left.is_auto())
@@ -518,15 +518,15 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     auto margin_right = CSS::Length::make_auto();
     auto const border_left = computed_values.border_left().width;
     auto const border_right = computed_values.border_right().width;
-    auto const padding_left = computed_values.padding().left.resolved(box, width_of_containing_block_as_length).to_px(box);
-    auto const padding_right = computed_values.padding().right.resolved(box, width_of_containing_block_as_length).to_px(box);
+    auto const padding_left = computed_values.padding().left().resolved(box, width_of_containing_block_as_length).to_px(box);
+    auto const padding_right = computed_values.padding().right().resolved(box, width_of_containing_block_as_length).to_px(box);
 
     auto try_compute_width = [&](auto const& a_width) {
-        margin_left = computed_values.margin().left.resolved(box, width_of_containing_block_as_length).resolved(box);
-        margin_right = computed_values.margin().right.resolved(box, width_of_containing_block_as_length).resolved(box);
+        margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length).resolved(box);
+        margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length).resolved(box);
 
-        auto left = computed_values.inset().left.resolved(box, width_of_containing_block_as_length).resolved(box);
-        auto right = computed_values.inset().right.resolved(box, width_of_containing_block_as_length).resolved(box);
+        auto left = computed_values.inset().left().resolved(box, width_of_containing_block_as_length).resolved(box);
+        auto right = computed_values.inset().right().resolved(box, width_of_containing_block_as_length).resolved(box);
         auto width = a_width;
 
         auto solve_for_left = [&] {
@@ -671,8 +671,8 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
     auto height_of_containing_block_as_length = CSS::Length::make_px(height_of_containing_block);
 
-    auto const& computed_top = computed_values.inset().top;
-    auto const& computed_bottom = computed_values.inset().bottom;
+    auto const& computed_top = computed_values.inset().top();
+    auto const& computed_bottom = computed_values.inset().bottom();
     auto const& computed_height = computed_values.height();
     auto const& computed_min_height = computed_values.min_height();
     auto const& computed_max_height = computed_values.max_height();
@@ -685,12 +685,12 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         tentative_height = computed_values.height().resolved(box, height_of_containing_block_as_length).resolved(box);
 
     auto& box_state = m_state.get_mutable(box);
-    box_state.margin_top = computed_values.margin().top.resolved(box, width_of_containing_block_as_length).to_px(box);
-    box_state.margin_bottom = computed_values.margin().bottom.resolved(box, width_of_containing_block_as_length).to_px(box);
+    box_state.margin_top = computed_values.margin().top().resolved(box, width_of_containing_block_as_length).to_px(box);
+    box_state.margin_bottom = computed_values.margin().bottom().resolved(box, width_of_containing_block_as_length).to_px(box);
     box_state.border_top = computed_values.border_top().width;
     box_state.border_bottom = computed_values.border_bottom().width;
-    box_state.padding_top = computed_values.padding().top.resolved(box, width_of_containing_block_as_length).to_px(box);
-    box_state.padding_bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block_as_length).to_px(box);
+    box_state.padding_top = computed_values.padding().top().resolved(box, width_of_containing_block_as_length).to_px(box);
+    box_state.padding_bottom = computed_values.padding().bottom().resolved(box, width_of_containing_block_as_length).to_px(box);
 
     if (computed_height.is_auto() && computed_top.is_auto() && computed_bottom.is_auto()) {
         tentative_height = CSS::Length(compute_auto_height_for_block_level_element(m_state, box), CSS::Length::Type::Px);
@@ -737,25 +737,25 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box)
     compute_height_for_absolutely_positioned_element(box);
 
     auto& box_state = m_state.get_mutable(box);
-    box_state.margin_left = box.computed_values().margin().left.resolved(box, width_of_containing_block_as_length).to_px(box);
-    box_state.margin_top = box.computed_values().margin().top.resolved(box, height_of_containing_block_as_length).to_px(box);
-    box_state.margin_right = box.computed_values().margin().right.resolved(box, width_of_containing_block_as_length).to_px(box);
-    box_state.margin_bottom = box.computed_values().margin().bottom.resolved(box, height_of_containing_block_as_length).to_px(box);
+    box_state.margin_left = box.computed_values().margin().left().resolved(box, width_of_containing_block_as_length).to_px(box);
+    box_state.margin_top = box.computed_values().margin().top().resolved(box, height_of_containing_block_as_length).to_px(box);
+    box_state.margin_right = box.computed_values().margin().right().resolved(box, width_of_containing_block_as_length).to_px(box);
+    box_state.margin_bottom = box.computed_values().margin().bottom().resolved(box, height_of_containing_block_as_length).to_px(box);
 
     box_state.border_left = box.computed_values().border_left().width;
     box_state.border_right = box.computed_values().border_right().width;
     box_state.border_top = box.computed_values().border_top().width;
     box_state.border_bottom = box.computed_values().border_bottom().width;
 
-    box_state.inset_left = box.computed_values().inset().left.resolved(box, width_of_containing_block_as_length).to_px(box);
-    box_state.inset_top = box.computed_values().inset().top.resolved(box, height_of_containing_block_as_length).to_px(box);
-    box_state.inset_right = box.computed_values().inset().right.resolved(box, width_of_containing_block_as_length).to_px(box);
-    box_state.inset_bottom = box.computed_values().inset().bottom.resolved(box, height_of_containing_block_as_length).to_px(box);
+    box_state.inset_left = box.computed_values().inset().left().resolved(box, width_of_containing_block_as_length).to_px(box);
+    box_state.inset_top = box.computed_values().inset().top().resolved(box, height_of_containing_block_as_length).to_px(box);
+    box_state.inset_right = box.computed_values().inset().right().resolved(box, width_of_containing_block_as_length).to_px(box);
+    box_state.inset_bottom = box.computed_values().inset().bottom().resolved(box, height_of_containing_block_as_length).to_px(box);
 
-    if (box.computed_values().inset().left.is_auto() && specified_width.is_auto() && box.computed_values().inset().right.is_auto()) {
-        if (box.computed_values().margin().left.is_auto())
+    if (box.computed_values().inset().left().is_auto() && specified_width.is_auto() && box.computed_values().inset().right().is_auto()) {
+        if (box.computed_values().margin().left().is_auto())
             box_state.margin_left = 0;
-        if (box.computed_values().margin().right.is_auto())
+        if (box.computed_values().margin().right().is_auto())
             box_state.margin_right = 0;
     }
 
@@ -771,11 +771,11 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box)
     }
     auto parent_location = absolute_content_rect(static_cast<Box const&>(*relevant_parent), m_state);
 
-    if (!box.computed_values().inset().left.is_auto()) {
+    if (!box.computed_values().inset().left().is_auto()) {
         float x_offset = box_state.inset_left
             + box_state.border_box_left();
         used_offset.set_x(x_offset + box_state.margin_left);
-    } else if (!box.computed_values().inset().right.is_auto()) {
+    } else if (!box.computed_values().inset().right().is_auto()) {
         float x_offset = 0
             - box_state.inset_right
             - box_state.border_box_right();
@@ -786,11 +786,11 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box)
         used_offset.set_x(x_offset);
     }
 
-    if (!box.computed_values().inset().top.is_auto()) {
+    if (!box.computed_values().inset().top().is_auto()) {
         float y_offset = box_state.inset_top
             + box_state.border_box_top();
         used_offset.set_y(y_offset + box_state.margin_top);
-    } else if (!box.computed_values().inset().bottom.is_auto()) {
+    } else if (!box.computed_values().inset().bottom().is_auto()) {
         float y_offset = 0
             - box_state.inset_bottom
             - box_state.border_box_bottom();
@@ -851,8 +851,8 @@ void FormattingContext::compute_inset(Box const& box)
     auto const& computed_values = box.computed_values();
 
     // FIXME: Respect the containing block's writing-mode.
-    resolve_two_opposing_insets(computed_values.inset().left, computed_values.inset().right, box_state.inset_left, box_state.inset_right, containing_block_width_for(box));
-    resolve_two_opposing_insets(computed_values.inset().top, computed_values.inset().bottom, box_state.inset_top, box_state.inset_bottom, containing_block_height_for(box));
+    resolve_two_opposing_insets(computed_values.inset().left(), computed_values.inset().right(), box_state.inset_left, box_state.inset_right, containing_block_width_for(box));
+    resolve_two_opposing_insets(computed_values.inset().top(), computed_values.inset().bottom(), box_state.inset_top, box_state.inset_bottom, containing_block_height_for(box));
 }
 
 float FormattingContext::calculate_fit_content_size(float min_content_size, float max_content_size, SizeConstraint constraint, Optional<float> available_space) const

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -90,21 +90,21 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 
-    box_state.margin_left = computed_values.margin().left.resolved(box, width_of_containing_block).to_px(box);
+    box_state.margin_left = computed_values.margin().left().resolved(box, width_of_containing_block).to_px(box);
     box_state.border_left = computed_values.border_left().width;
-    box_state.padding_left = computed_values.padding().left.resolved(box, width_of_containing_block).to_px(box);
+    box_state.padding_left = computed_values.padding().left().resolved(box, width_of_containing_block).to_px(box);
 
-    box_state.margin_right = computed_values.margin().right.resolved(box, width_of_containing_block).to_px(box);
+    box_state.margin_right = computed_values.margin().right().resolved(box, width_of_containing_block).to_px(box);
     box_state.border_right = computed_values.border_right().width;
-    box_state.padding_right = computed_values.padding().right.resolved(box, width_of_containing_block).to_px(box);
+    box_state.padding_right = computed_values.padding().right().resolved(box, width_of_containing_block).to_px(box);
 
-    box_state.margin_top = computed_values.margin().top.resolved(box, width_of_containing_block).to_px(box);
+    box_state.margin_top = computed_values.margin().top().resolved(box, width_of_containing_block).to_px(box);
     box_state.border_top = computed_values.border_top().width;
-    box_state.padding_top = computed_values.padding().top.resolved(box, width_of_containing_block).to_px(box);
+    box_state.padding_top = computed_values.padding().top().resolved(box, width_of_containing_block).to_px(box);
 
-    box_state.padding_bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block).to_px(box);
+    box_state.padding_bottom = computed_values.padding().bottom().resolved(box, width_of_containing_block).to_px(box);
     box_state.border_bottom = computed_values.border_bottom().width;
-    box_state.margin_bottom = computed_values.margin().bottom.resolved(box, width_of_containing_block).to_px(box);
+    box_state.margin_bottom = computed_values.margin().bottom().resolved(box, width_of_containing_block).to_px(box);
 
     if (is<ReplacedBox>(box)) {
         auto& replaced = verify_cast<ReplacedBox>(box);

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -34,9 +34,9 @@ void InlineLevelIterator::enter_node_with_box_model_metrics(Layout::NodeWithStyl
     auto& used_values = m_layout_state.get_mutable(node);
     auto const& computed_values = node.computed_values();
 
-    used_values.margin_left = computed_values.margin().left.resolved(node, CSS::Length::make_px(m_container_state.content_width())).to_px(node);
+    used_values.margin_left = computed_values.margin().left().resolved(node, CSS::Length::make_px(m_container_state.content_width())).to_px(node);
     used_values.border_left = computed_values.border_left().width;
-    used_values.padding_left = computed_values.padding().left.resolved(node, CSS::Length::make_px(m_container_state.content_width())).to_px(node);
+    used_values.padding_left = computed_values.padding().left().resolved(node, CSS::Length::make_px(m_container_state.content_width())).to_px(node);
 
     m_extra_leading_metrics->margin += used_values.margin_left;
     m_extra_leading_metrics->border += used_values.border_left;
@@ -54,9 +54,9 @@ void InlineLevelIterator::exit_node_with_box_model_metrics()
     auto& used_values = m_layout_state.get_mutable(node);
     auto const& computed_values = node.computed_values();
 
-    used_values.margin_right = computed_values.margin().right.resolved(node, CSS::Length::make_px(m_container_state.content_width())).to_px(node);
+    used_values.margin_right = computed_values.margin().right().resolved(node, CSS::Length::make_px(m_container_state.content_width())).to_px(node);
     used_values.border_right = computed_values.border_right().width;
-    used_values.padding_right = computed_values.padding().right.resolved(node, CSS::Length::make_px(m_container_state.content_width())).to_px(node);
+    used_values.padding_right = computed_values.padding().right().resolved(node, CSS::Length::make_px(m_container_state.content_width())).to_px(node);
 
     m_extra_trailing_metrics->margin += used_values.margin_right;
     m_extra_trailing_metrics->border += used_values.border_right;


### PR DESCRIPTION
This remained undetected for a long time as HeaderCheck is disabled by default. This commit makes the following file compile again:

    // file: compile_me.cpp
    #include <LibWeb/CSS/GridTrackSize.h>
    // That's it, this was enough to cause a compilation error.

This used to be part of #15231, but since this commit is so involved, it should be a separate PR.