### PR TITLE
LibGfx+LibSoftGPU: Use `memcpy` for blitting

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1066,7 +1066,7 @@ void Painter::blit(IntPoint const& position, Gfx::Bitmap const& source, IntRect 
         ARGB32 const* src = source.scanline(src_rect.top() + first_row) + src_rect.left() + first_column;
         size_t const src_skip = source.pitch() / sizeof(ARGB32);
         for (int row = first_row; row <= last_row; ++row) {
-            fast_u32_copy(dst, src, clipped_rect.width());
+            memcpy(dst, src, sizeof(ARGB32) * clipped_rect.width());
             dst += dst_skip;
             src += src_skip;
         }

--- a/Userland/Libraries/LibSoftGPU/Buffer/Typed2DBuffer.h
+++ b/Userland/Libraries/LibSoftGPU/Buffer/Typed2DBuffer.h
@@ -42,10 +42,7 @@ public:
         for (int y = target.bottom(); y >= target.top(); --y) {
             auto const* buffer_scanline = scanline(source_y++);
             auto* bitmap_scanline = bitmap.scanline(y);
-
-            int source_x = 0;
-            for (int x = target.left(); x <= target.right(); ++x)
-                bitmap_scanline[x] = buffer_scanline[source_x++];
+            memcpy(bitmap_scanline + target.left(), buffer_scanline, sizeof(u32) * target.width());
         }
     }
 


### PR DESCRIPTION
On my machine, blitting the color buffer of `Tubes` to the screen shows ~19% fewer samples in profiles after this patch.

This begs the question, do we need `fast_u32_copy` and `fast_u32_fill` in `AK/Memory.h` at all?