### PR TITLE
LibSoftGPU: Return a `const&` texel in `Image` to prevent copying

### DIFF
--- a/Userland/Libraries/LibSoftGPU/Image.cpp
+++ b/Userland/Libraries/LibSoftGPU/Image.cpp
@@ -129,7 +129,7 @@ void Image::copy_texels(GPU::Image const& source, u32 source_level, Vector3<u32>
     for (u32 z = 0; z < size.z(); ++z) {
         for (u32 y = 0; y < size.y(); ++y) {
             for (u32 x = 0; x < size.x(); ++x) {
-                auto color = src_image.texel(source_level, source_offset.x() + x, source_offset.y() + y, source_offset.z() + z);
+                auto const& color = src_image.texel(source_level, source_offset.x() + x, source_offset.y() + y, source_offset.z() + z);
                 set_texel(destination_level, destination_offset.x() + x, destination_offset.y() + y, destination_offset.z() + z, color);
             }
         }

--- a/Userland/Libraries/LibSoftGPU/Image.h
+++ b/Userland/Libraries/LibSoftGPU/Image.h
@@ -33,7 +33,7 @@ public:
     GPU::ImageDataLayout image_data_layout(u32 level, Vector3<i32> offset) const;
     virtual void regenerate_mipmaps() override;
 
-    FloatVector4 texel(u32 level, int x, int y, int z) const
+    FloatVector4 const& texel(u32 level, int x, int y, int z) const
     {
         return *texel_pointer(level, x, y, z);
     }

--- a/Userland/Libraries/LibSoftGPU/Sampler.cpp
+++ b/Userland/Libraries/LibSoftGPU/Sampler.cpp
@@ -73,10 +73,10 @@ static f32x4 wrap(f32x4 value, GPU::TextureWrapMode mode, f32x4 num_texels)
 
 ALWAYS_INLINE static Vector4<f32x4> texel4(Image const& image, u32x4 level, u32x4 x, u32x4 y, u32x4 z)
 {
-    auto t0 = image.texel(level[0], x[0], y[0], z[0]);
-    auto t1 = image.texel(level[1], x[1], y[1], z[1]);
-    auto t2 = image.texel(level[2], x[2], y[2], z[2]);
-    auto t3 = image.texel(level[3], x[3], y[3], z[3]);
+    auto const& t0 = image.texel(level[0], x[0], y[0], z[0]);
+    auto const& t1 = image.texel(level[1], x[1], y[1], z[1]);
+    auto const& t2 = image.texel(level[2], x[2], y[2], z[2]);
+    auto const& t3 = image.texel(level[3], x[3], y[3], z[3]);
 
     return Vector4<f32x4> {
         f32x4 { t0.x(), t1.x(), t2.x(), t3.x() },
@@ -90,10 +90,10 @@ ALWAYS_INLINE static Vector4<f32x4> texel4border(Image const& image, u32x4 level
 {
     auto border_mask = maskbits(x < 0 || x >= w || y < 0 || y >= h);
 
-    auto t0 = border_mask & 1 ? border : image.texel(level[0], x[0], y[0], z[0]);
-    auto t1 = border_mask & 2 ? border : image.texel(level[1], x[1], y[1], z[1]);
-    auto t2 = border_mask & 4 ? border : image.texel(level[2], x[2], y[2], z[2]);
-    auto t3 = border_mask & 8 ? border : image.texel(level[3], x[3], y[3], z[3]);
+    auto const& t0 = (border_mask & 1) > 0 ? border : image.texel(level[0], x[0], y[0], z[0]);
+    auto const& t1 = (border_mask & 2) > 0 ? border : image.texel(level[1], x[1], y[1], z[1]);
+    auto const& t2 = (border_mask & 4) > 0 ? border : image.texel(level[2], x[2], y[2], z[2]);
+    auto const& t3 = (border_mask & 8) > 0 ? border : image.texel(level[3], x[3], y[3], z[3]);
 
     return Vector4<f32x4> {
         f32x4 { t0.x(), t1.x(), t2.x(), t3.x() },


### PR DESCRIPTION
On every texel access, some floating point instructions involved in copying 4 floats popped up. Let `Image::texel() const` return a `FloatVector4 const&` to prevent these operations.

This results in a ~7% FPS increase in GLQuake on my machine.