### PR TITLE
LibWeb: Implement document.domain getter

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1830,4 +1830,24 @@ JS::NonnullGCPtr<HTML::History> Document::history()
     return *m_history;
 }
 
+// https://html.spec.whatwg.org/multipage/origin.html#dom-document-domain
+String Document::domain() const
+{
+    // 1. Let effectiveDomain be this's origin's effective domain.
+    auto effective_domain = origin().effective_domain();
+
+    // 2. If effectiveDomain is null, then return the empty string.
+    if (!effective_domain.has_value())
+        return String::empty();
+
+    // 3. Return effectiveDomain, serialized.
+    // FIXME: Implement host serialization.
+    return effective_domain.release_value();
+}
+
+void Document::set_domain(String const& domain)
+{
+    dbgln("(STUBBED) Document::set_domain(domain='{}')", domain);
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -353,6 +353,9 @@ public:
     bool is_initial_about_blank() const { return m_is_initial_about_blank; }
     void set_is_initial_about_blank(bool b) { m_is_initial_about_blank = b; }
 
+    String domain() const;
+    void set_domain(String const& domain);
+
 protected:
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -27,6 +27,7 @@ interface Document : Node {
 
     // FIXME: These attributes currently don't do anything.
     [PutForwards=href, LegacyUnforgeable] readonly attribute Location? location;
+    attribute USVString domain;
 
     readonly attribute DOMImplementation implementation;
 

--- a/Userland/Libraries/LibWeb/HTML/Origin.h
+++ b/Userland/Libraries/LibWeb/HTML/Origin.h
@@ -92,6 +92,19 @@ public:
         return result.to_string();
     }
 
+    // https://html.spec.whatwg.org/multipage/origin.html#concept-origin-effective-domain
+    Optional<String> effective_domain() const
+    {
+        // 1. If origin is an opaque origin, then return null.
+        if (is_opaque())
+            return Optional<String> {};
+
+        // FIXME: 2. If origin's domain is non-null, then return origin's domain.
+
+        // 3. Return origin's host.
+        return m_host;
+    }
+
     bool operator==(Origin const& other) const { return is_same_origin(other); }
     bool operator!=(Origin const& other) const { return !is_same_origin(other); }
 


### PR DESCRIPTION
The document.domain setter is currently stubbed as that is a doozy to implement, given how much restrictions there are in place to try and prevent use of it and potential multi-process implications.

This was the only thing preventing us from being able to start displaying ads delivered via Google Syndication.

![Screenshot from 2022-09-14 15-31-05](https://user-images.githubusercontent.com/25595356/190183657-ff6806ce-1c04-43db-a834-949d88e15578.png)
![Screenshot from 2022-09-14 15-30-58](https://user-images.githubusercontent.com/25595356/190183692-5cbdf2b2-4a6f-4069-aff1-08dc4fa035a9.png)
