### PR TITLE
LibJS+Meta: Fix vptr errors found by UBSAN & turn on vptr sanitation by default for Lagom

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -93,8 +93,8 @@ if (ENABLE_MEMORY_SANITIZER)
 endif()
 
 if (ENABLE_UNDEFINED_SANITIZER)
-    add_compile_options(-fsanitize=undefined -fno-sanitize=vptr -fno-omit-frame-pointer)
-    set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=undefined -fno-sanitize=vptr")
+    add_compile_options(-fsanitize=undefined -fno-omit-frame-pointer)
+    set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=undefined")
 endif()
 
 if (ENABLE_FUZZERS)

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -14,7 +14,7 @@
 namespace JS {
 
 ArrayBufferConstructor::ArrayBufferConstructor(Realm& realm)
-    : NativeFunction(vm().names.ArrayBuffer.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.ArrayBuffer.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -17,7 +17,7 @@
 namespace JS {
 
 ArrayConstructor::ArrayConstructor(Realm& realm)
-    : NativeFunction(vm().names.Array.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Array.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionConstructor.cpp
@@ -13,7 +13,7 @@
 namespace JS {
 
 AsyncFunctionConstructor::AsyncFunctionConstructor(Realm& realm)
-    : NativeFunction(vm().names.AsyncFunction.as_string(), *realm.intrinsics().function_constructor())
+    : NativeFunction(realm.vm().names.AsyncFunction.as_string(), *realm.intrinsics().function_constructor())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionConstructor.cpp
@@ -13,7 +13,7 @@
 namespace JS {
 
 AsyncGeneratorFunctionConstructor::AsyncGeneratorFunctionConstructor(Realm& realm)
-    : NativeFunction(vm().names.AsyncGeneratorFunction.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.AsyncGeneratorFunction.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -18,7 +18,7 @@ namespace JS {
 static const Crypto::SignedBigInteger BIGINT_ONE { 1 };
 
 BigIntConstructor::BigIntConstructor(Realm& realm)
-    : NativeFunction(vm().names.BigInt.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.BigInt.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/BooleanConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BooleanConstructor.cpp
@@ -12,7 +12,7 @@
 namespace JS {
 
 BooleanConstructor::BooleanConstructor(Realm& realm)
-    : NativeFunction(vm().names.Boolean.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Boolean.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
@@ -14,7 +14,7 @@
 namespace JS {
 
 DataViewConstructor::DataViewConstructor(Realm& realm)
-    : NativeFunction(vm().names.DataView.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.DataView.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -163,7 +163,7 @@ static double parse_date_string(String const& date_string)
 }
 
 DateConstructor::DateConstructor(Realm& realm)
-    : NativeFunction(vm().names.Date.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Date.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ErrorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ErrorConstructor.cpp
@@ -12,7 +12,7 @@
 namespace JS {
 
 ErrorConstructor::ErrorConstructor(Realm& realm)
-    : NativeFunction(vm().names.Error.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Error.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 
@@ -61,57 +61,57 @@ ThrowCompletionOr<Object*> ErrorConstructor::construct(FunctionObject& new_targe
     return error;
 }
 
-#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)                                     \
-    ConstructorName::ConstructorName(Realm& realm)                                                                           \
-        : NativeFunction(vm().names.ClassName.as_string(), *static_cast<Object*>(realm.intrinsics().error_constructor()))    \
-    {                                                                                                                        \
-    }                                                                                                                        \
-                                                                                                                             \
-    void ConstructorName::initialize(Realm& realm)                                                                           \
-    {                                                                                                                        \
-        auto& vm = this->vm();                                                                                               \
-        NativeFunction::initialize(realm);                                                                                   \
-                                                                                                                             \
-        /* 20.5.6.2.1 NativeError.prototype, https://tc39.es/ecma262/#sec-nativeerror.prototype */                           \
-        define_direct_property(vm.names.prototype, realm.intrinsics().snake_name##_prototype(), 0);                          \
-                                                                                                                             \
-        define_direct_property(vm.names.length, Value(1), Attribute::Configurable);                                          \
-    }                                                                                                                        \
-                                                                                                                             \
-    ConstructorName::~ConstructorName() = default;                                                                           \
-                                                                                                                             \
-    /* 20.5.6.1.1 NativeError ( message [ , options ] ), https://tc39.es/ecma262/#sec-nativeerror */                         \
-    ThrowCompletionOr<Value> ConstructorName::call()                                                                         \
-    {                                                                                                                        \
-        /* 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget. */    \
-        return TRY(construct(*this));                                                                                        \
-    }                                                                                                                        \
-                                                                                                                             \
-    /* 20.5.6.1.1 NativeError ( message [ , options ] ), https://tc39.es/ecma262/#sec-nativeerror */                         \
-    ThrowCompletionOr<Object*> ConstructorName::construct(FunctionObject& new_target)                                        \
-    {                                                                                                                        \
-        auto& vm = this->vm();                                                                                               \
-                                                                                                                             \
-        auto message = vm.argument(0);                                                                                       \
-        auto options = vm.argument(1);                                                                                       \
-                                                                                                                             \
-        /* 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »). */        \
-        auto* error = TRY(ordinary_create_from_constructor<ClassName>(vm, new_target, &Intrinsics::snake_name##_prototype)); \
-                                                                                                                             \
-        /* 3. If message is not undefined, then */                                                                           \
-        if (!message.is_undefined()) {                                                                                       \
-            /* a. Let msg be ? ToString(message). */                                                                         \
-            auto msg = TRY(message.to_string(vm));                                                                           \
-                                                                                                                             \
-            /* b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "message", msg). */                                      \
-            error->create_non_enumerable_data_property_or_throw(vm.names.message, js_string(vm, move(msg)));                 \
-        }                                                                                                                    \
-                                                                                                                             \
-        /* 4. Perform ? InstallErrorCause(O, options). */                                                                    \
-        TRY(error->install_error_cause(options));                                                                            \
-                                                                                                                             \
-        /* 5. Return O. */                                                                                                   \
-        return error;                                                                                                        \
+#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)                                        \
+    ConstructorName::ConstructorName(Realm& realm)                                                                              \
+        : NativeFunction(realm.vm().names.ClassName.as_string(), *static_cast<Object*>(realm.intrinsics().error_constructor())) \
+    {                                                                                                                           \
+    }                                                                                                                           \
+                                                                                                                                \
+    void ConstructorName::initialize(Realm& realm)                                                                              \
+    {                                                                                                                           \
+        auto& vm = this->vm();                                                                                                  \
+        NativeFunction::initialize(realm);                                                                                      \
+                                                                                                                                \
+        /* 20.5.6.2.1 NativeError.prototype, https://tc39.es/ecma262/#sec-nativeerror.prototype */                              \
+        define_direct_property(vm.names.prototype, realm.intrinsics().snake_name##_prototype(), 0);                             \
+                                                                                                                                \
+        define_direct_property(vm.names.length, Value(1), Attribute::Configurable);                                             \
+    }                                                                                                                           \
+                                                                                                                                \
+    ConstructorName::~ConstructorName() = default;                                                                              \
+                                                                                                                                \
+    /* 20.5.6.1.1 NativeError ( message [ , options ] ), https://tc39.es/ecma262/#sec-nativeerror */                            \
+    ThrowCompletionOr<Value> ConstructorName::call()                                                                            \
+    {                                                                                                                           \
+        /* 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget. */       \
+        return TRY(construct(*this));                                                                                           \
+    }                                                                                                                           \
+                                                                                                                                \
+    /* 20.5.6.1.1 NativeError ( message [ , options ] ), https://tc39.es/ecma262/#sec-nativeerror */                            \
+    ThrowCompletionOr<Object*> ConstructorName::construct(FunctionObject& new_target)                                           \
+    {                                                                                                                           \
+        auto& vm = this->vm();                                                                                                  \
+                                                                                                                                \
+        auto message = vm.argument(0);                                                                                          \
+        auto options = vm.argument(1);                                                                                          \
+                                                                                                                                \
+        /* 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »). */           \
+        auto* error = TRY(ordinary_create_from_constructor<ClassName>(vm, new_target, &Intrinsics::snake_name##_prototype));    \
+                                                                                                                                \
+        /* 3. If message is not undefined, then */                                                                              \
+        if (!message.is_undefined()) {                                                                                          \
+            /* a. Let msg be ? ToString(message). */                                                                            \
+            auto msg = TRY(message.to_string(vm));                                                                              \
+                                                                                                                                \
+            /* b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "message", msg). */                                         \
+            error->create_non_enumerable_data_property_or_throw(vm.names.message, js_string(vm, move(msg)));                    \
+        }                                                                                                                       \
+                                                                                                                                \
+        /* 4. Perform ? InstallErrorCause(O, options). */                                                                       \
+        TRY(error->install_error_cause(options));                                                                               \
+                                                                                                                                \
+        /* 5. Return O. */                                                                                                      \
+        return error;                                                                                                           \
     }
 
 JS_ENUMERATE_NATIVE_ERRORS

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.cpp
@@ -14,7 +14,7 @@
 namespace JS {
 
 FinalizationRegistryConstructor::FinalizationRegistryConstructor(Realm& realm)
-    : NativeFunction(vm().names.FinalizationRegistry.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.FinalizationRegistry.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -20,7 +20,7 @@
 namespace JS {
 
 FunctionConstructor::FunctionConstructor(Realm& realm)
-    : NativeFunction(vm().names.Function.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Function.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionObject.h
@@ -16,7 +16,7 @@
 namespace JS {
 
 class FunctionObject : public Object {
-    JS_OBJECT(Function, Object);
+    JS_OBJECT(FunctionObject, Object);
 
 public:
     virtual ~FunctionObject() = default;

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -12,7 +12,6 @@
 #include <LibJS/Runtime/BoundFunction.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
 #include <LibJS/Runtime/Error.h>
-#include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/FunctionPrototype.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/NativeFunction.h>

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/FunctionObject.h>
 
 namespace JS {
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -131,7 +131,7 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
 
 // 10.1 The Intl.Collator Constructor, https://tc39.es/ecma402/#sec-the-intl-collator-constructor
 CollatorConstructor::CollatorConstructor(Realm& realm)
-    : NativeFunction(vm().names.Collator.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Collator.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -18,7 +18,7 @@ namespace JS::Intl {
 
 // 11.1 The Intl.DateTimeFormat Constructor, https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor
 DateTimeFormatConstructor::DateTimeFormatConstructor(Realm& realm)
-    : NativeFunction(vm().names.DateTimeFormat.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.DateTimeFormat.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
@@ -17,7 +17,7 @@ namespace JS::Intl {
 
 // 12.1 The Intl.DisplayNames Constructor, https://tc39.es/ecma402/#sec-intl-displaynames-constructor
 DisplayNamesConstructor::DisplayNamesConstructor(Realm& realm)
-    : NativeFunction(vm().names.DisplayNames.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.DisplayNames.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
@@ -16,7 +16,7 @@ namespace JS::Intl {
 
 // 1.2 The Intl.DurationFormat Constructor, https://tc39.es/proposal-intl-duration-format/#sec-intl-durationformat-constructor
 DurationFormatConstructor::DurationFormatConstructor(Realm& realm)
-    : NativeFunction(vm().names.DurationFormat.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.DurationFormat.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
@@ -16,7 +16,7 @@ namespace JS::Intl {
 
 // 13.1 The Intl.ListFormat Constructor, https://tc39.es/ecma402/#sec-intl-listformat-constructor
 ListFormatConstructor::ListFormatConstructor(Realm& realm)
-    : NativeFunction(vm().names.ListFormat.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.ListFormat.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -217,7 +217,7 @@ static LocaleAndKeys apply_unicode_extension_to_tag(StringView tag, LocaleAndKey
 
 // 14.1 The Intl.Locale Constructor, https://tc39.es/ecma402/#sec-intl-locale-constructor
 LocaleConstructor::LocaleConstructor(Realm& realm)
-    : NativeFunction(vm().names.Locale.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Locale.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
@@ -15,7 +15,7 @@ namespace JS::Intl {
 
 // 15.1 The Intl.NumberFormat Constructor, https://tc39.es/ecma402/#sec-intl-numberformat-constructor
 NumberFormatConstructor::NumberFormatConstructor(Realm& realm)
-    : NativeFunction(vm().names.NumberFormat.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.NumberFormat.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
@@ -17,7 +17,7 @@ namespace JS::Intl {
 
 // 16.1 The Intl.PluralRules Constructor, https://tc39.es/ecma402/#sec-intl-pluralrules-constructor
 PluralRulesConstructor::PluralRulesConstructor(Realm& realm)
-    : NativeFunction(vm().names.PluralRules.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.PluralRules.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -20,7 +20,7 @@ namespace JS::Intl {
 
 // 17.1 The Intl.RelativeTimeFormat Constructor, https://tc39.es/ecma402/#sec-intl-relativetimeformat-constructor
 RelativeTimeFormatConstructor::RelativeTimeFormatConstructor(Realm& realm)
-    : NativeFunction(vm().names.RelativeTimeFormat.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.RelativeTimeFormat.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
@@ -16,7 +16,7 @@ namespace JS::Intl {
 
 // 18.1 The Intl.Segmenter Constructor, https://tc39.es/ecma402/#sec-intl-segmenter-constructor
 SegmenterConstructor::SegmenterConstructor(Realm& realm)
-    : NativeFunction(vm().names.Segmenter.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Segmenter.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -207,7 +207,7 @@ ThrowCompletionOr<String> JSONObject::serialize_json_property(VM& vm, StringifyS
 
         // b. If isArray is true, return ? SerializeJSONArray(state, value).
         if (is_array)
-            return serialize_json_array(vm, state, static_cast<Array&>(value.as_object()));
+            return serialize_json_array(vm, state, value.as_object());
 
         // c. Return ? SerializeJSONObject(state, value).
         return serialize_json_object(vm, state, value.as_object());

--- a/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
@@ -14,7 +14,7 @@
 namespace JS {
 
 MapConstructor::MapConstructor(Realm& realm)
-    : NativeFunction(vm().names.Map.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Map.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -24,7 +24,7 @@ constexpr double const MIN_SAFE_INTEGER_VALUE { -(__builtin_exp2(53) - 1) };
 namespace JS {
 
 NumberConstructor::NumberConstructor(Realm& realm)
-    : NativeFunction(vm().names.Number.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Number.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -18,7 +18,7 @@
 namespace JS {
 
 ObjectConstructor::ObjectConstructor(Realm& realm)
-    : NativeFunction(vm().names.Object.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Object.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -240,7 +240,7 @@ static ThrowCompletionOr<Value> perform_promise_race(VM& vm, Iterator& iterator_
 }
 
 PromiseConstructor::PromiseConstructor(Realm& realm)
-    : NativeFunction(vm().names.Promise.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Promise.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ProxyConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyConstructor.cpp
@@ -25,7 +25,7 @@ static ThrowCompletionOr<ProxyObject*> proxy_create(VM& vm, Value target, Value 
 }
 
 ProxyConstructor::ProxyConstructor(Realm& realm)
-    : NativeFunction(vm().names.Proxy.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Proxy.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -12,7 +12,7 @@
 namespace JS {
 
 RegExpConstructor::RegExpConstructor(Realm& realm)
-    : NativeFunction(vm().names.RegExp.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.RegExp.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
@@ -14,7 +14,7 @@
 namespace JS {
 
 SetConstructor::SetConstructor(Realm& realm)
-    : NativeFunction(vm().names.Set.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Set.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealmConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealmConstructor.cpp
@@ -12,7 +12,7 @@ namespace JS {
 
 // 3.2 The ShadowRealm Constructor, https://tc39.es/proposal-shadowrealm/#sec-shadowrealm-constructor
 ShadowRealmConstructor::ShadowRealmConstructor(Realm& realm)
-    : NativeFunction(vm().names.ShadowRealm.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.ShadowRealm.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -18,7 +18,7 @@
 namespace JS {
 
 StringConstructor::StringConstructor(Realm& realm)
-    : NativeFunction(vm().names.String.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.String.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -11,7 +11,7 @@
 namespace JS {
 
 SymbolConstructor::SymbolConstructor(Realm& realm)
-    : NativeFunction(vm().names.Symbol.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Symbol.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarConstructor.cpp
@@ -12,7 +12,7 @@ namespace JS::Temporal {
 
 // 12.2 The Temporal.Calendar Constructor, https://tc39.es/proposal-temporal/#sec-temporal-calendar-constructor
 CalendarConstructor::CalendarConstructor(Realm& realm)
-    : NativeFunction(vm().names.Calendar.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Calendar.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationConstructor.cpp
@@ -15,7 +15,7 @@ namespace JS::Temporal {
 
 // 7.1 The Temporal.Duration Constructor, https://tc39.es/proposal-temporal/#sec-temporal-duration-constructor
 DurationConstructor::DurationConstructor(Realm& realm)
-    : NativeFunction(vm().names.Duration.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Duration.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantConstructor.cpp
@@ -14,7 +14,7 @@ namespace JS::Temporal {
 
 // 8.1 The Temporal.Instant Constructor, https://tc39.es/proposal-temporal/#sec-temporal-instant-constructor
 InstantConstructor::InstantConstructor(Realm& realm)
-    : NativeFunction(vm().names.Instant.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.Instant.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateConstructor.cpp
@@ -16,7 +16,7 @@ namespace JS::Temporal {
 
 // 3.1 The Temporal.PlainDate Constructor, https://tc39.es/proposal-temporal/#sec-temporal-plaindate-constructor
 PlainDateConstructor::PlainDateConstructor(Realm& realm)
-    : NativeFunction(vm().names.PlainDate.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.PlainDate.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimeConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimeConstructor.cpp
@@ -16,7 +16,7 @@ namespace JS::Temporal {
 
 // 5.1 The Temporal.PlainDateTime Constructor, https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-constructor
 PlainDateTimeConstructor::PlainDateTimeConstructor(Realm& realm)
-    : NativeFunction(vm().names.PlainDateTime.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.PlainDateTime.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayConstructor.cpp
@@ -15,7 +15,7 @@ namespace JS::Temporal {
 
 // 10.1 The Temporal.PlainMonthDay Constructor, https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-constructor
 PlainMonthDayConstructor::PlainMonthDayConstructor(Realm& realm)
-    : NativeFunction(vm().names.PlainMonthDay.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.PlainMonthDay.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimeConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimeConstructor.cpp
@@ -14,7 +14,7 @@ namespace JS::Temporal {
 
 // 4.1 The Temporal.PlainTime Constructor, https://tc39.es/proposal-temporal/#sec-temporal-plaintime-constructor
 PlainTimeConstructor::PlainTimeConstructor(Realm& realm)
-    : NativeFunction(vm().names.PlainTime.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.PlainTime.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.cpp
@@ -16,7 +16,7 @@ namespace JS::Temporal {
 
 // 9.1 The Temporal.PlainYearMonth Constructor, https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-constructor
 PlainYearMonthConstructor::PlainYearMonthConstructor(Realm& realm)
-    : NativeFunction(vm().names.PlainYearMonth.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.PlainYearMonth.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneConstructor.cpp
@@ -12,7 +12,7 @@ namespace JS::Temporal {
 
 // 11.2 The Temporal.TimeZone Constructor, https://tc39.es/proposal-temporal/#sec-temporal-timezone-constructor
 TimeZoneConstructor::TimeZoneConstructor(Realm& realm)
-    : NativeFunction(vm().names.TimeZone.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.TimeZone.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.cpp
@@ -17,7 +17,7 @@ namespace JS::Temporal {
 
 // 6.1 The Temporal.ZonedDateTime Constructor, https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-constructor
 ZonedDateTimeConstructor::ZonedDateTimeConstructor(Realm& realm)
-    : NativeFunction(vm().names.ZonedDateTime.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.ZonedDateTime.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -478,7 +478,7 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
     }                                                                                                                            \
                                                                                                                                  \
     ConstructorName::ConstructorName(Realm& realm)                                                                               \
-        : TypedArrayConstructor(vm().names.ClassName.as_string(), *realm.intrinsics().typed_array_constructor())                 \
+        : TypedArrayConstructor(realm.vm().names.ClassName.as_string(), *realm.intrinsics().typed_array_constructor())           \
     {                                                                                                                            \
     }                                                                                                                            \
                                                                                                                                  \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -17,7 +17,7 @@ TypedArrayConstructor::TypedArrayConstructor(FlyString const& name, Object& prot
 }
 
 TypedArrayConstructor::TypedArrayConstructor(Realm& realm)
-    : NativeFunction(vm().names.TypedArray.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.TypedArray.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.cpp
@@ -14,7 +14,7 @@
 namespace JS {
 
 WeakMapConstructor::WeakMapConstructor(Realm& realm)
-    : NativeFunction(vm().names.WeakMap.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.WeakMap.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.cpp
@@ -13,7 +13,7 @@
 namespace JS {
 
 WeakRefConstructor::WeakRefConstructor(Realm& realm)
-    : NativeFunction(vm().names.WeakRef.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.WeakRef.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.cpp
@@ -14,7 +14,7 @@
 namespace JS {
 
 WeakSetConstructor::WeakSetConstructor(Realm& realm)
-    : NativeFunction(vm().names.WeakSet.as_string(), *realm.intrinsics().function_prototype())
+    : NativeFunction(realm.vm().names.WeakSet.as_string(), *realm.intrinsics().function_prototype())
 {
 }
 


### PR DESCRIPTION
IsArray returns true if the object is an Array *or* if it is a ProxyObject whose target is an Array. Therefore, we cannot downcast to an Array based on IsArray.

Luckily, we don't actually need an Array here; SerializeJSONArray only needs an Object.

This was caught by UBSAN with vptr sanitation enabled, which this PR now enabled by default.