### PR TITLE
LibJS+LibWeb: Implement WebAssembly Native Errors

### DIFF
--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -47,14 +47,18 @@
     JS_ENUMERATE_NATIVE_OBJECTS_EXCLUDING_TEMPLATES \
     __JS_ENUMERATE(TypedArray, typed_array, TypedArrayPrototype, TypedArrayConstructor, void)
 
-#define JS_ENUMERATE_NATIVE_ERRORS                                                                            \
-    __JS_ENUMERATE(EvalError, eval_error, EvalErrorPrototype, EvalErrorConstructor, void)                     \
-    __JS_ENUMERATE(InternalError, internal_error, InternalErrorPrototype, InternalErrorConstructor, void)     \
-    __JS_ENUMERATE(RangeError, range_error, RangeErrorPrototype, RangeErrorConstructor, void)                 \
-    __JS_ENUMERATE(ReferenceError, reference_error, ReferenceErrorPrototype, ReferenceErrorConstructor, void) \
-    __JS_ENUMERATE(SyntaxError, syntax_error, SyntaxErrorPrototype, SyntaxErrorConstructor, void)             \
-    __JS_ENUMERATE(TypeError, type_error, TypeErrorPrototype, TypeErrorConstructor, void)                     \
-    __JS_ENUMERATE(URIError, uri_error, URIErrorPrototype, URIErrorConstructor, void)
+#define JS_ENUMERATE_NATIVE_ERRORS                                                                                                                  \
+    __JS_ENUMERATE(EvalError, eval_error, EvalErrorPrototype, EvalErrorConstructor, void)                                                           \
+    __JS_ENUMERATE(InternalError, internal_error, InternalErrorPrototype, InternalErrorConstructor, void)                                           \
+    __JS_ENUMERATE(RangeError, range_error, RangeErrorPrototype, RangeErrorConstructor, void)                                                       \
+    __JS_ENUMERATE(ReferenceError, reference_error, ReferenceErrorPrototype, ReferenceErrorConstructor, void)                                       \
+    __JS_ENUMERATE(SyntaxError, syntax_error, SyntaxErrorPrototype, SyntaxErrorConstructor, void)                                                   \
+    __JS_ENUMERATE(TypeError, type_error, TypeErrorPrototype, TypeErrorConstructor, void)                                                           \
+    __JS_ENUMERATE(URIError, uri_error, URIErrorPrototype, URIErrorConstructor, void)                                                               \
+    /* 4.7. Error Objects https://webassembly.github.io/spec/js-api/#error-objects */                                                               \
+    __JS_ENUMERATE(WebAssemblyCompileError, web_assembly_compile_error, WebAssemblyCompileErrorPrototype, WebAssemblyCompileErrorConstructor, void) \
+    __JS_ENUMERATE(WebAssemblyRuntimeError, web_assembly_runtime_error, WebAssemblyRuntimeErrorPrototype, WebAssemblyRuntimeErrorConstructor, void) \
+    __JS_ENUMERATE(WebAssemblyLinkError, web_assembly_link_error, WebAssemblyLinkErrorPrototype, WebAssemblyLinkErrorConstructor, void)
 
 #define JS_ENUMERATE_TYPED_ARRAYS                                                                                               \
     __JS_ENUMERATE(Uint8Array, uint8_array, Uint8ArrayPrototype, Uint8ArrayConstructor, u8)                                     \

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
@@ -16,6 +16,8 @@
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/BigInt.h>
 #include <LibJS/Runtime/DataView.h>
+#include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/ErrorConstructor.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWasm/AbstractMachine/Interpreter.h>
 #include <LibWasm/AbstractMachine/Validator.h>
@@ -66,6 +68,12 @@ void WebAssemblyObject::initialize(JS::Realm& realm)
     auto& table_prototype = window.ensure_web_prototype<WebAssemblyTablePrototype>("WebAssemblyTablePrototype");
     table_prototype.define_direct_property(vm.names.constructor, &table_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
     define_direct_property("Table", &table_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
+
+    auto* runtime_error_constructor = realm.intrinsics().web_assembly_runtime_error_constructor();
+    runtime_error_constructor->define_direct_property(vm.names.name, js_string(vm, "WebAssembly.RuntimeError"), JS::Attribute::Configurable);
+    auto* runtime_error_prototype = realm.intrinsics().web_assembly_runtime_error_prototype();
+    runtime_error_prototype->define_direct_property(vm.names.constructor, runtime_error_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
+    define_direct_property("RuntimeError", runtime_error_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
 }
 
 NonnullOwnPtrVector<WebAssemblyObject::CompiledWebAssemblyModule> WebAssemblyObject::s_compiled_modules;


### PR DESCRIPTION
This pull request adds the CompileError, RuntimeError and LinkError native errors and exposes them on the WebAssembly object.

Initially I tried defining the errors outside LibJS, this however is non trivial as both [we](https://github.com/SerenityOS/serenity/blob/8ff7c52cf43273b9a7e2a63c0c12cf2dd0379d5e/Userland/Libraries/LibJS/Runtime/AbstractOperations.h#L134) and [the spec](https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor) rely (?) on intrinsics knowing about them.