### PR TITLE
Meta: Revise lint-commit.sh regex for the title

### DIFF
--- a/Meta/lint-commit.sh
+++ b/Meta/lint-commit.sh
@@ -34,7 +34,7 @@ while read -r line; do
     error "Empty line between commit title and body is missing"
   fi
 
-  category_pattern="^\S.*?\S: .+"
+  category_pattern='^(Revert "|\S+: )'
   if [[ $line_number -eq 1 ]] && (echo "$line" | grep -E -v -q "$category_pattern"); then
     error "Missing category in commit title (if this is a fix up of a previous commit, it should be squashed)"
   fi


### PR DESCRIPTION
This mainly changes two aspects:
- The category can now be a single letter, such as 'w' to indicate the file Utilities/w.cpp
- Spaces in the category (or list) are no longer allowed. This follows the lived practice of writing category lists as "Foo+Bar: Quux"

Closes #15243.

Acceptance testing was done with the following script:

<details><summary>A long file with the name <code>run-regex-test.sh</code></summary>

```bash
#!/bin/bash

set +e

INITIAL_REGEX="^\S.*?\S: .+"
NEW_REGEX='^(Revert "|\S+: )'

# Initialize with the following strings:

# bad example
# really bad: example
# good+example: here
# bad:example
#  even worse: example
#  not: good
# w: Port to Core::Stream

# Note the extra leading spaces with some of these.
# Then, append all the existing commits for more positive examples:
# git log --pretty=format:'%s' >> all-commit-msgs.lst

echo "Initial sort ..."
rm -f commits-orig-rej.lst commits-orig-acc.lst
touch commits-orig-rej.lst commits-orig-acc.lst
while IFS= read -r COMMITMSG
do
    if echo "$COMMITMSG" | grep -E -v -q "${INITIAL_REGEX}"
    then
        echo "$COMMITMSG" >> commits-orig-rej.lst
    else
        echo "$COMMITMSG" >> commits-orig-acc.lst
    fi
done < all-commit-msgs.lst

echo "Sorting orig accepted ..."
rm -f commits-orig-acc-now-acc.lst commits-orig-acc-now-rej.lst
touch commits-orig-acc-now-acc.lst commits-orig-acc-now-rej.lst
while IFS= read -r COMMITMSG
do
    if echo "$COMMITMSG" | grep -E -v -q "${NEW_REGEX}"
    then
        echo "$COMMITMSG" >> commits-orig-acc-now-rej.lst
    else
        echo "$COMMITMSG" >> commits-orig-acc-now-acc.lst
    fi
done < commits-orig-acc.lst

echo "Sorting orig rejected ..."
rm -f commits-orig-rej-now-acc.lst commits-orig-rej-now-rej.lst
touch commits-orig-rej-now-acc.lst commits-orig-rej-now-rej.lst
while IFS= read -r COMMITMSG
do
    if echo "$COMMITMSG" | grep -E -v -q "${NEW_REGEX}"
    then
        echo "$COMMITMSG" >> commits-orig-rej-now-rej.lst
    else
        echo "$COMMITMSG" >> commits-orig-rej-now-acc.lst
    fi
done < commits-orig-rej.lst

echo "Accepting previously accepted: $(wc -l commits-orig-acc-now-acc.lst)"
echo "Accepting previously rejected: $(wc -l commits-orig-rej-now-acc.lst) (!!!)"
echo "Rejecting previously accepted: $(wc -l commits-orig-acc-now-rej.lst) (!!!)"
echo "Rejecting previously rejected: $(wc -l commits-orig-rej-now-rej.lst)"
```

</details>

Most importantly, this shows that it barely changes the behavior of the regex:
- Accepting previously accepted: 40095 commits-orig-acc-now-acc.lst
- Accepting previously rejected: 2 commits-orig-rej-now-acc.lst (!!!)
- Rejecting previously accepted: 72 commits-orig-acc-now-rej.lst (!!!)
- Rejecting previously rejected: 859 commits-orig-rej-now-rej.lst

In particular:
```console
$ cat commits-orig-rej-now-acc.lst
w: Port to Core::Stream
w: Port to LibMain :^)
```
… as intended.

And also:
```console
$ head -n15 commits-orig-acc-now-rej.lst
really bad: example
fixup! Base: Add a pseudo-element test page
Keymap Applet: Spawn KeyboardSettings when clicking
LibJS + js: Rethrow exception on the vm after bytecode interpreter run
Kernel + WindowServer: Re-define the interface to framebuffer devices
LibSQL Tests: Add tests for `SELECT ... WHERE ...`
SQL Utility: Implement reading sql files
SQL Utility: Redesigned the input loop
SQL Utility: Implement connection switching
LibJS + test-js: Get results from the global object directly
Keyboard Mapper: Better text color for buttons in dark theme
Config CLI: Handle missing config values correctly
LibGUI, WindowServer: Greatly simplify menubar logic
GML Playground: Add Vim emulation
File Manager: Differentiate between navigation and rename errors
```

This shows that the regex works as intended. Furthermore, the deprecated style really seems unintentional:
- "Keymap Applet": 2022-02: 99e3e42fa552ab34538fa180054f91cbcac2798a
- "LibJS + js": 2021-11: 22e679d8444a2a24ab9d4f48965e72e14e7c16b5
- "LibSQL Tests": 2021-10: 7496f1762018c7db2144a6474f008ee908a06333
- "LibGUI, WindowServer": 2021-07: 611370e7dcf7e2820738036133dafb2b45340780

For reference, even the tenth-most-recent commit in the style `Foo+Bar: Quux` is just a week ago (463aff827e4d47afacd6693a031e8e0d868affc8)

Hmm. I may have over-engineered the hell out of this, but it was a lot of fun :D

CC @AtkinsSJ as the author of #15243.