### PR TITLE
LibWeb: Update visibility when Node was invisible before

### DIFF
--- a/Base/res/html/misc/opacity.html
+++ b/Base/res/html/misc/opacity.html
@@ -24,6 +24,13 @@
             .red {
             background: red;
             }
+            .hover-visible {
+                display: inline-block;
+                opacity: 0;
+            }
+            .hover:hover .hover-visible {
+                opacity: 1;
+            }
         </style>
     </head>
     <body>
@@ -64,6 +71,14 @@
             70% opacity
             <div class=op-50>
                 50% opacity inside 70% opacity
+            </div>
+        </div>
+
+        <div class="red hover">
+            Visible on hover
+
+            <div class="hover-visible">
+                I'm visible!
             </div>
         </div>
     </body>

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -490,8 +490,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     if (auto maybe_visibility = computed_style.visibility(); maybe_visibility.has_value())
         computed_values.set_visibility(maybe_visibility.release_value());
 
-    if (computed_values.opacity() == 0 || computed_values.visibility() != CSS::Visibility::Visible)
-        m_visible = false;
+    m_visible = computed_values.opacity() != 0 && computed_values.visibility() == CSS::Visibility::Visible;
 
     if (auto maybe_length_percentage = computed_style.length_percentage(CSS::PropertyID::Width); maybe_length_percentage.has_value())
         computed_values.set_width(maybe_length_percentage.release_value());


### PR DESCRIPTION
Currently, the visibility of a node is only updated to "false", but there's no re-evaluation if it should be visible.
Because of that, if an element has the style `opacity: 0` at first and `opacity: 1` e.g. on hover, it stays invisible.

After the PR:

![opacity_0](https://user-images.githubusercontent.com/7694808/190491719-b30e77c8-d95f-41ff-a2cd-101521b359f6.png)

![opacity_1_hover](https://user-images.githubusercontent.com/7694808/190491735-6cf462dd-3562-45df-9205-ce3fd9771f1e.png)
