### PR TITLE
Kernel: Remove support for broken unused `init_args`

### DIFF
--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -299,9 +299,9 @@ NonnullOwnPtrVector<KString> CommandLine::userspace_init_args() const
 
     auto init_args = lookup("init_args"sv).value_or(""sv).split_view(';');
     if (!init_args.is_empty())
-        MUST(args.try_prepend(KString::must_create(userspace_init())));
+        MUST(args.try_prepend(MUST(KString::try_create(userspace_init()))));
     for (auto& init_arg : init_args)
-        args.append(KString::must_create(init_arg));
+        args.append(MUST(KString::try_create(init_arg)));
     return args;
 }
 

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -46,8 +46,10 @@ Usage: $NAME COMMAND [TARGET] [TOOLCHAIN] [ARGS...]
 
 
   Examples:
-    $NAME run i686 smp=on
+    $NAME run i686 GNU smp=on
         Runs the image in QEMU passing "smp=on" to the kernel command line
+    $NAME run i686 GNU 'init=/bin/UserspaceEmulator init_args=/bin/SystemServer'
+        Runs the image in QEMU, and run the entire system through UserspaceEmulator (not fully supported yet)
     $NAME run
         Runs the image for the default TARGET i686 in QEMU
     $NAME run lagom js -A


### PR DESCRIPTION
GUI and text mode, even running tests in CI or auto-generating HTML in Serenity all require SystemServer. Without it, there are no mounts and no services, the system is barely usable without SystemServer. I am not aware of any other program being used as init, but that kernel cmdline option is at least working as intended.

SystemServer only really supports `--help` and `--user` as command-line arguments, so there is no use case for init_args. Fixing this feature would require changing some MUST()s to TRY()s, but the only advantage would be that SystemServer can be made to unexpectedly exit, causing a Kernel panic. Thus, this commit removes `init_args` entirely.

Closes #14927.