### PR TITLE
Shell: Fix 'Command:' output for built-in 'time' command

### DIFF
--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -919,7 +919,7 @@ int Shell::builtin_time(int argc, char const** argv)
 
         warnln("Timing report: {} ms", iteration_times.sum());
         warnln("==============");
-        warnln("Command:         {}", String::join(' ', command.argv));
+        warnln("Command:         {}", String::join(' ', Span<char const*>(argv, argc)));
         warnln("Average time:    {:.2} ms (median: {}, stddev: {:.2}, min: {}, max:{})",
             iteration_times.average(), iteration_times.median(),
             iteration_times.standard_deviation(),


### PR DESCRIPTION
This fixes a silly bug that I noticed while trying to time some other command.

Before:

![Bildschirmfoto_2022-09-16_01-05-18](https://user-images.githubusercontent.com/2690845/190523922-ca5359cb-7261-4c3d-ad35-6de715b1318e.png)

After:

![Bildschirmfoto_2022-09-16_01-04-34](https://user-images.githubusercontent.com/2690845/190523935-25ccfb75-0605-4bef-8440-3bc9d160ac0c.png)

EDIT: The reason for the bug is that the variable `command` was moved-out-of a few lines earlier, when calling to `expand_aliases`. Not sure why the compiler doesn't complain about this.