### PR TITLE
Lagom: Skip IMPORTED targets in get_linked_lagom_libraries

### DIFF
--- a/Meta/Lagom/get_linked_lagom_libraries.cmake
+++ b/Meta/Lagom/get_linked_lagom_libraries.cmake
@@ -11,6 +11,11 @@ function(get_linked_lagom_libraries_impl target output)
         return()
     endif()
 
+    get_target_property(target_is_imported "${target}" IMPORTED)
+    if (target_is_imported)
+        return()
+    endif()
+
     get_target_property(target_type "${target}" TYPE)
 
     if ("${target_type}" STREQUAL "SHARED_LIBRARY")


### PR DESCRIPTION
This script is useful when wanting to install lagom libraries for projects using Lagom via FetchContent, but trips over itself if the project links other non-Lagom imported targets to itself. So, let's just skip them.

As a side note, I tried messing with the mentioned CMake 3.21 feature `install(RUNTIME_DEPENDENCIES)`, but I could not get it to behave in a way that only installs Lagom libraries when installing ladybird. It insisted on copying all Qt, Wayland, etc system libraries into the install tree :/

cc @trflynn89 