### PR TITLE
LibGL: Make GL::create_context fallible, and usable in Lagom LibWeb

### DIFF
--- a/Tests/LibGL/TestAPI.cpp
+++ b/Tests/LibGL/TestAPI.cpp
@@ -11,7 +11,7 @@
 static NonnullOwnPtr<GL::GLContext> create_testing_context()
 {
     auto bitmap = MUST(Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { 1, 1 }));
-    auto context = GL::create_context(*bitmap);
+    auto context = MUST(GL::create_context(*bitmap));
     GL::make_context_current(context);
     return context;
 }

--- a/Tests/LibGL/TestRender.cpp
+++ b/Tests/LibGL/TestRender.cpp
@@ -24,7 +24,7 @@
 static NonnullOwnPtr<GL::GLContext> create_testing_context(int width, int height)
 {
     auto bitmap = MUST(Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { width, height }));
-    auto context = GL::create_context(*bitmap);
+    auto context = MUST(GL::create_context(*bitmap));
     GL::make_context_current(context);
 
     // Assume some defaults for our testing contexts

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -59,7 +59,7 @@ private:
         constexpr u16 RENDER_WIDTH = 640;
         constexpr u16 RENDER_HEIGHT = 480;
         m_bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { RENDER_WIDTH, RENDER_HEIGHT }).release_value_but_fixme_should_propagate_errors();
-        m_context = GL::create_context(*m_bitmap);
+        m_context = MUST(GL::create_context(*m_bitmap));
 
         start_timer(20);
 

--- a/Userland/Demos/Tubes/Tubes.cpp
+++ b/Userland/Demos/Tubes/Tubes.cpp
@@ -125,7 +125,7 @@ void Tubes::choose_new_direction_for_tube(Tube& tube)
 ErrorOr<void> Tubes::create_buffer(Gfx::IntSize size)
 {
     m_bitmap = TRY(Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, size));
-    m_gl_context = GL::create_context(*m_bitmap);
+    m_gl_context = TRY(GL::create_context(*m_bitmap));
     return {};
 }
 

--- a/Userland/Libraries/LibGL/GLContext.cpp
+++ b/Userland/Libraries/LibGL/GLContext.cpp
@@ -921,11 +921,11 @@ void GLContext::build_extension_string()
     m_extensions = String::join(' ', extensions);
 }
 
-NonnullOwnPtr<GLContext> create_context(Gfx::Bitmap& bitmap)
+ErrorOr<NonnullOwnPtr<GLContext>> create_context(Gfx::Bitmap& bitmap)
 {
     // FIXME: Make driver selectable. This is currently hardcoded to LibSoftGPU
-    auto driver = MUST(GPU::Driver::try_create("softgpu"sv));
-    auto device = MUST(driver->try_create_device(bitmap.size()));
+    auto driver = TRY(GPU::Driver::try_create("softgpu"sv));
+    auto device = TRY(driver->try_create_device(bitmap.size()));
     auto context = make<GLContext>(driver, move(device), bitmap);
     dbgln_if(GL_DEBUG, "GL::create_context({}) -> {:p}", bitmap.size(), context.ptr());
 

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -532,7 +532,7 @@ private:
     String m_extensions;
 };
 
-NonnullOwnPtr<GLContext> create_context(Gfx::Bitmap&);
+ErrorOr<NonnullOwnPtr<GLContext>> create_context(Gfx::Bitmap&);
 void make_context_current(GLContext*);
 void present_context(GLContext*);
 

--- a/Userland/Libraries/LibGPU/Driver.cpp
+++ b/Userland/Libraries/LibGPU/Driver.cpp
@@ -18,9 +18,9 @@ static HashMap<String, String> const s_driver_path_map
 #if defined(__serenity__)
     { "softgpu", "libsoftgpu.so.serenity" },
 #elif defined(__APPLE__)
-    { "softgpu", "./liblagom-softgpu.dylib" },
+    { "softgpu", "liblagom-softgpu.dylib" },
 #else
-    { "softgpu", "./liblagom-softgpu.so" },
+    { "softgpu", "liblagom-softgpu.so.0" },
 #endif
 };
 


### PR DESCRIPTION
Propagate errors in places that are already set up to handle them, like
WebGLRenderingContext and the Tubes demo, and convert other callers
to using MUST.

Fix up the paths for looking for liblagom-softgpu to not be relative, we should have other ways to handle library search paths outside of $PWD in all cases. *should* being the operative word here.