### PR TITLE
SystemMonitor: Remember column configurations

### DIFF
--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -528,3 +528,19 @@ void ProcessModel::update()
     //        It would be good if GUI::Model had a way to orchestrate removal/insertion while preserving indices.
     did_update(previous_tid_count == m_threads.size() ? GUI::Model::UpdateFlag::DontInvalidateIndices : GUI::Model::UpdateFlag::InvalidateAllIndices);
 }
+
+bool ProcessModel::is_default_column(int index) const
+{
+    switch (index) {
+    case Column::PID:
+    case Column::TID:
+    case Column::Name:
+    case Column::CPU:
+    case Column::User:
+    case Column::Virtual:
+    case Column::DirtyPrivate:
+        return true;
+    default:
+        return false;
+    }
+}

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -71,6 +71,7 @@ public:
     virtual Vector<GUI::ModelIndex> matches(StringView, unsigned = MatchesFlag::AllMatching, GUI::ModelIndex const& = GUI::ModelIndex()) override;
     virtual bool is_column_sortable(int column_index) const override { return column_index != Column::Icon; }
     void update();
+    bool is_default_column(int index) const;
 
     struct CpuInfo {
         u32 id;


### PR DESCRIPTION
Make SytemMonitor remember the last column configurations by save the state of the columns to the program's config file.

This addresses #14951 