### PR TITLE
Kernel: Do not mark `.ro_after_init` as `NOLOAD`

### DIFF
--- a/Kernel/Arch/x86/linker.ld
+++ b/Kernel/Arch/x86/linker.ld
@@ -71,7 +71,7 @@ SECTIONS
         end_of_kernel_data = .;
     } :data
 
-    .ro_after_init ALIGN(4K) (NOLOAD) : AT(ADDR(.ro_after_init))
+    .ro_after_init ALIGN(4K) : AT(ADDR(.ro_after_init))
     {
         start_of_ro_after_init = .;
         *(.ro_after_init);


### PR DESCRIPTION
There is no particular reason why this section should be marked as `NOBITS` (as it might very well include initialized values), and it resolves 90% of the mismatches between the input and output sections, which LLD now warns about when linking.