### PR TITLE
LibGL: Prevent segfault due to texture destruction

### DIFF
--- a/Userland/Libraries/LibGL/GLContext.cpp
+++ b/Userland/Libraries/LibGL/GLContext.cpp
@@ -21,11 +21,11 @@ __attribute__((visibility("hidden"))) GL::GLContext* g_gl_context;
 namespace GL {
 
 GLContext::GLContext(RefPtr<GPU::Driver> driver, NonnullOwnPtr<GPU::Device> device, Gfx::Bitmap& frontbuffer)
-    : m_viewport { frontbuffer.rect() }
-    , m_frontbuffer { frontbuffer }
-    , m_driver { driver }
+    : m_driver { driver }
     , m_rasterizer { move(device) }
     , m_device_info { m_rasterizer->info() }
+    , m_viewport { frontbuffer.rect() }
+    , m_frontbuffer { frontbuffer }
 {
     m_texture_units.resize(m_device_info.num_texture_units);
     m_active_texture_unit = &m_texture_units[0];

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -254,6 +254,13 @@ private:
     [[nodiscard]] bool should_append_to_listing() const { return m_current_listing_index.has_value(); }
     [[nodiscard]] bool should_execute_after_appending_to_listing() const { return m_current_listing_index.has_value() && m_current_listing_index->mode == GL_COMPILE_AND_EXECUTE; }
 
+    // FIXME: we store GPU::Texture objects that do not point back to either the driver or device, so we need
+    //        to destruct the latter two at the very end. Fix this by making all GPU objects point back to
+    //        the device that created them, and the device back to the driver.
+    RefPtr<GPU::Driver> m_driver;
+    NonnullOwnPtr<GPU::Device> m_rasterizer;
+    GPU::DeviceInfo const m_device_info;
+
     GLenum m_current_draw_mode;
     GLenum m_current_matrix_mode { GL_MODELVIEW };
 
@@ -374,9 +381,6 @@ private:
         return m_texture_coordinate_generation[texture_unit][capability - GL_TEXTURE_GEN_S];
     }
 
-    RefPtr<GPU::Driver> m_driver;
-    NonnullOwnPtr<GPU::Device> m_rasterizer;
-    GPU::DeviceInfo const m_device_info;
     bool m_sampler_config_is_dirty { true };
     bool m_light_state_is_dirty { true };
 


### PR DESCRIPTION
Destruction of `GL::GLContext` resulted in the destruction of `GPU::Driver` _before_ the destruction of the allocated textures, which in turn point to `GPU::Image` objects. Since the destruction of `GPU::Driver` unloads the shared library, we were trying to invoke non-existing code.

Fix this by moving `m_driver` up in `GLContext` so that it's last in line for destruction.

This problem was exposed when running the LibGL tests in Lagom, which has a functioning implementation of `dlclose()`. Inside Serenity, `dlclose()` is still something of a noop and as such did not expose this problem.

However, we're still unsure on why this problem isn't exposed in CI.

Thanks @sunverwerth and @ADKaster