### PR TITLE
LibWeb: Improve grid-track span

### DIFF
--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -46,15 +46,18 @@
   <div class="grid-item" style="grid-row: span 2 / 1; grid-column: span 2 / 1;">1</div>
   <div class="grid-item" style="grid-row: span 2 / 1;">2</div>
   <div class="grid-item" style="grid-column: span 2 / 1;">3</div>
+  <div class="grid-item" style="grid-column-end: 1; grid-row-end: 1;">6</div>
 </div>
 
-<!-- 0 positioned grid items -->
+<!-- 0 positioned grid items and similar inputs -->
 <p>If you can see this message then the test passed.</p>
 <div class="grid-container">
-  <div class="grid-item" style="grid-row-end: 0;">1</div>
-  <div class="grid-item" style="grid-row: 0 / 0;">2</div>
-  <div class="grid-item" style="grid-column: 0 / 1;">3</div>
-  <div class="grid-item" style="grid-row: 1 / 0;">4</div>
+  <div class="grid-item" style="grid-row-end: 0;">2</div>
+  <div class="grid-item" style="grid-row: 0 / 0;">3</div>
+  <div class="grid-item" style="grid-column: 0 / 1;">4</div>
+  <div class="grid-item" style="grid-row: 1 / 0;">5</div>
+  <div class="grid-item" style="grid-row-end: 1;">1</div>
+  <div class="grid-item" style="grid-column-end: 1;">6</div>
 </div>
 
 <!-- Different column sizes -->

--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -40,26 +40,6 @@
   <div class="grid-item">1</div>
 </div>
 
-<!-- Using grid-row and grid-column -->
-<p>Should render a full-width 4x4 grid with:
-<ul>
-  <li>one large column on the left</li>
-  <li>one large column on the right, being split in half vertically, with the number 2 in the top half, and numbers 3, 4, 5, and 6 in the bottom</li>
-</ul>
-<div 
-  class="grid-container"
-  style="
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-    grid-template-rows: 50px 50px 50px 50px;
-  ">
-  <div class="grid-item" style="grid-row: 1/-1; grid-column: 1/3;">1</div>
-  <div class="grid-item" style="grid-row: 1/3; grid-column: 3/-1;">2</div>
-  <div class="grid-item">3</div>  
-  <div class="grid-item">4</div>
-  <div class="grid-item">5</div>  
-  <div class="grid-item">6</div>
-</div>
- 
 <!-- Different column sizes -->
 <p>Should render a 2x2 grid with columns 50px and 50%</p>
 <div 
@@ -84,3 +64,23 @@
     grid-column: 2 / 2;
     grid-row: 2 / 2">4</div>
 </div>
+
+<!-- Using grid-row and grid-column -->
+<p>Should render a full-width 4x4 grid with:
+  <ul>
+    <li>one large column on the left</li>
+    <li>one large column on the right, being split in half vertically, with the number 2 in the top half, and numbers 3, 4, 5, and 6 in the bottom</li>
+  </ul>
+  <div 
+    class="grid-container"
+    style="
+      grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+      grid-template-rows: 25px 25px 25px 25px 25px 25px 25px 25px;
+    ">
+    <div class="grid-item" style="grid-row: 1 / -1; grid-column: span 4;">1</div>
+    <div class="grid-item" style="grid-row: 1 / 5; grid-column: 5 / -1;">2</div>
+    <div class="grid-item" style="grid-column: span 2; grid-row: span 2;">3</div>
+    <div class="grid-item" style="grid-column: span 2 / -1; grid-row: span 2;">4</div>
+    <div class="grid-item" style="grid-column: span 2; grid-row: 7 / span 100;">5</div>  
+    <div class="grid-item" style="grid-column: 7 / span 2; grid-row: span 2 / -1;">6</div>
+  </div>

--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -48,6 +48,15 @@
   <div class="grid-item" style="grid-column: span 2 / 1;">3</div>
 </div>
 
+<!-- 0 positioned grid items -->
+<p>If you can see this message then the test passed.</p>
+<div class="grid-container">
+  <div class="grid-item" style="grid-row-end: 0;">1</div>
+  <div class="grid-item" style="grid-row: 0 / 0;">2</div>
+  <div class="grid-item" style="grid-column: 0 / 1;">3</div>
+  <div class="grid-item" style="grid-row: 1 / 0;">4</div>
+</div>
+
 <!-- Different column sizes -->
 <p>Should render a 2x2 grid with columns 50px and 50%</p>
 <div 

--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -40,6 +40,14 @@
   <div class="grid-item">1</div>
 </div>
 
+<!-- Spans causing positions outside the inherit grid. (span 2 with an end position of 1 causes the start to be -1) -->
+<p>If you can see this message then the test passed.</p>
+<div class="grid-container">
+  <div class="grid-item" style="grid-row: span 2 / 1; grid-column: span 2 / 1;">1</div>
+  <div class="grid-item" style="grid-row: span 2 / 1;">2</div>
+  <div class="grid-item" style="grid-column: span 2 / 1;">3</div>
+</div>
+
 <!-- Different column sizes -->
 <p>Should render a 2x2 grid with columns 50px and 50%</p>
 <div 

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
@@ -9,28 +9,23 @@
 
 namespace Web::CSS {
 
-GridTrackPlacement::GridTrackPlacement(int position, bool has_span)
-    : m_position(position)
-    , m_has_span(has_span)
-{
-}
-
-GridTrackPlacement::GridTrackPlacement(int position)
-    : m_position(position)
+GridTrackPlacement::GridTrackPlacement(int span_or_position, bool has_span)
+    : m_type(has_span ? Type::Span : Type::Position)
+    , m_value(span_or_position)
 {
 }
 
 GridTrackPlacement::GridTrackPlacement()
-    : m_is_auto(true)
+    : m_type(Type::Auto)
 {
 }
 
 String GridTrackPlacement::to_string() const
 {
     StringBuilder builder;
-    if (m_has_span)
+    if (is_span())
         builder.append("span "sv);
-    builder.append(String::number(m_position));
+    builder.append(String::number(m_value));
     return builder.to_string();
 }
 

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
@@ -12,38 +12,34 @@ namespace Web::CSS {
 
 class GridTrackPlacement {
 public:
-    GridTrackPlacement(int, bool);
-    GridTrackPlacement(int);
+    enum class Type {
+        Span,
+        Position,
+        Auto
+    };
+
+    GridTrackPlacement(int, bool = false);
     GridTrackPlacement();
 
     static GridTrackPlacement make_auto() { return GridTrackPlacement(); };
 
-    void set_position(int position)
-    {
-        m_is_auto = false;
-        m_position = position;
-    }
-    int position() const { return m_position; }
+    bool is_span() const { return m_type == Type::Span; }
+    bool is_position() const { return m_type == Type::Position; }
+    bool is_auto() const { return m_type == Type::Auto; }
+    bool is_auto_positioned() const { return m_type == Type::Auto || m_type == Type::Span; }
 
-    void set_has_span(bool has_span)
-    {
-        VERIFY(!m_is_auto);
-        m_has_span = has_span;
-    }
-    bool has_span() const { return m_has_span; }
-
-    bool is_auto() const { return m_is_auto; }
+    int raw_value() const { return m_value; }
+    Type type() const { return m_type; }
 
     String to_string() const;
     bool operator==(GridTrackPlacement const& other) const
     {
-        return m_position == other.position() && m_has_span == other.has_span();
+        return m_type == other.type() && m_value == other.raw_value();
     }
 
 private:
-    bool m_is_auto { false };
-    int m_position { 0 };
-    bool m_has_span { false };
+    Type m_type;
+    int m_value { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5456,19 +5456,29 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement(Vector<ComponentValue> con
     if (!tokens.has_next_token()) {
         if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("auto"sv))
             return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement());
+        // https://drafts.csswg.org/css-grid/#grid-placement-span-int
+        // If the <integer> is omitted, it defaults to 1.
+        if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("span"sv))
+            return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement(1, true));
         if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
             return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement(static_cast<int>(current_token.number_value())));
         return {};
     }
 
-    auto has_span = false;
+    auto is_span = false;
     if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("span"sv)) {
-        has_span = true;
+        is_span = true;
         tokens.skip_whitespace();
         current_token = tokens.next_token().token();
     }
-    if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && !tokens.has_next_token())
-        return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement(static_cast<int>(current_token.number_value()), has_span));
+
+    if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && !tokens.has_next_token()) {
+        // https://drafts.csswg.org/css-grid/#grid-placement-span-int
+        // Negative integers or zero are invalid.
+        if (is_span && static_cast<int>(current_token.number_value()) < 1)
+            return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement(1, is_span));
+        return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement(static_cast<int>(current_token.number_value()), is_span));
+    }
     return {};
 }
 
@@ -5480,20 +5490,33 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement_shorthand_value(Vector<Com
     if (!tokens.has_next_token()) {
         if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("auto"sv))
             return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement::make_auto());
+        // https://drafts.csswg.org/css-grid/#grid-placement-span-int
+        // If the <integer> is omitted, it defaults to 1.
+        if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("span"sv))
+            return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement(1, true));
         if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
             return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement(current_token.number_value()));
         return {};
     }
 
     auto calculate_grid_track_placement = [](auto& current_token, auto& tokens) -> CSS::GridTrackPlacement {
-        auto has_span = false;
+        auto is_span = false;
         if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("span"sv)) {
-            has_span = true;
+            is_span = true;
             tokens.skip_whitespace();
             current_token = tokens.next_token().token();
         }
-        if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
-            return CSS::GridTrackPlacement(static_cast<int>(current_token.number_value()), has_span);
+        if (current_token.is(Token::Type::Number) && current_token.number().is_integer()) {
+            // https://drafts.csswg.org/css-grid/#grid-placement-span-int
+            // Negative integers or zero are invalid.
+            if (is_span && static_cast<int>(current_token.number_value()) < 1)
+                return CSS::GridTrackPlacement(1, true);
+            return CSS::GridTrackPlacement(static_cast<int>(current_token.number_value()), is_span);
+        }
+        // https://drafts.csswg.org/css-grid/#grid-placement-span-int
+        // If the <integer> is omitted, it defaults to 1.
+        if (is_span && current_token.is(Token::Type::Delim) && current_token.delim() == "/"sv)
+            return CSS::GridTrackPlacement(1, true);
         return CSS::GridTrackPlacement();
     };
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5460,7 +5460,10 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement(Vector<ComponentValue> con
         // If the <integer> is omitted, it defaults to 1.
         if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("span"sv))
             return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement(1, true));
-        if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
+        // https://drafts.csswg.org/css-grid/#grid-placement-int
+        // [ <integer [−∞,−1]> | <integer [1,∞]> ] && <custom-ident>?
+        // An <integer> value of zero makes the declaration invalid.
+        if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && current_token.number_value() != 0)
             return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement(static_cast<int>(current_token.number_value())));
         return {};
     }
@@ -5472,7 +5475,10 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement(Vector<ComponentValue> con
         current_token = tokens.next_token().token();
     }
 
-    if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && !tokens.has_next_token()) {
+    // https://drafts.csswg.org/css-grid/#grid-placement-int
+    // [ <integer [−∞,−1]> | <integer [1,∞]> ] && <custom-ident>?
+    // An <integer> value of zero makes the declaration invalid.
+    if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && current_token.number_value() != 0 && !tokens.has_next_token()) {
         // https://drafts.csswg.org/css-grid/#grid-placement-span-int
         // Negative integers or zero are invalid.
         if (is_span && static_cast<int>(current_token.number_value()) < 1)
@@ -5494,25 +5500,33 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement_shorthand_value(Vector<Com
         // If the <integer> is omitted, it defaults to 1.
         if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("span"sv))
             return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement(1, true));
-        if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
+        // https://drafts.csswg.org/css-grid/#grid-placement-int
+        // [ <integer [−∞,−1]> | <integer [1,∞]> ] && <custom-ident>?
+        // An <integer> value of zero makes the declaration invalid.
+        if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && current_token.number_value() != 0)
             return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement(current_token.number_value()));
         return {};
     }
 
-    auto calculate_grid_track_placement = [](auto& current_token, auto& tokens) -> CSS::GridTrackPlacement {
+    auto calculate_grid_track_placement = [](auto& current_token, auto& tokens) -> Optional<CSS::GridTrackPlacement> {
         auto is_span = false;
         if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("span"sv)) {
             is_span = true;
             tokens.skip_whitespace();
             current_token = tokens.next_token().token();
         }
-        if (current_token.is(Token::Type::Number) && current_token.number().is_integer()) {
+        if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && current_token.number_value() != 0) {
             // https://drafts.csswg.org/css-grid/#grid-placement-span-int
             // Negative integers or zero are invalid.
             if (is_span && static_cast<int>(current_token.number_value()) < 1)
                 return CSS::GridTrackPlacement(1, true);
             return CSS::GridTrackPlacement(static_cast<int>(current_token.number_value()), is_span);
         }
+        // https://drafts.csswg.org/css-grid/#grid-placement-int
+        // [ <integer [−∞,−1]> | <integer [1,∞]> ] && <custom-ident>?
+        // An <integer> value of zero makes the declaration invalid.
+        if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && current_token.number_value() == 0)
+            return {};
         // https://drafts.csswg.org/css-grid/#grid-placement-span-int
         // If the <integer> is omitted, it defaults to 1.
         if (is_span && current_token.is(Token::Type::Delim) && current_token.delim() == "/"sv)
@@ -5521,8 +5535,8 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement_shorthand_value(Vector<Com
     };
 
     auto first_grid_track_placement = calculate_grid_track_placement(current_token, tokens);
-    if (!tokens.has_next_token())
-        return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement(first_grid_track_placement));
+    if (!tokens.has_next_token() && first_grid_track_placement.has_value())
+        return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement(first_grid_track_placement.value()));
 
     tokens.skip_whitespace();
     current_token = tokens.next_token().token();
@@ -5530,8 +5544,8 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement_shorthand_value(Vector<Com
     current_token = tokens.next_token().token();
 
     auto second_grid_track_placement = calculate_grid_track_placement(current_token, tokens);
-    if (!tokens.has_next_token())
-        return GridTrackPlacementShorthandStyleValue::create(GridTrackPlacementStyleValue::create(first_grid_track_placement), GridTrackPlacementStyleValue::create(second_grid_track_placement));
+    if (!tokens.has_next_token() && first_grid_track_placement.has_value() && second_grid_track_placement.has_value())
+        return GridTrackPlacementShorthandStyleValue::create(GridTrackPlacementStyleValue::create(first_grid_track_placement.value()), GridTrackPlacementStyleValue::create(second_grid_track_placement.value()));
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5493,59 +5493,35 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement_shorthand_value(Vector<Com
     auto tokens = TokenStream { component_values };
     auto current_token = tokens.next_token().token();
 
-    if (!tokens.has_next_token()) {
-        if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("auto"sv))
-            return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement::make_auto());
-        // https://drafts.csswg.org/css-grid/#grid-placement-span-int
-        // If the <integer> is omitted, it defaults to 1.
-        if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("span"sv))
-            return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement(1, true));
-        // https://drafts.csswg.org/css-grid/#grid-placement-int
-        // [ <integer [−∞,−1]> | <integer [1,∞]> ] && <custom-ident>?
-        // An <integer> value of zero makes the declaration invalid.
-        if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && current_token.number_value() != 0)
-            return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement(current_token.number_value()));
-        return {};
+    Vector<ComponentValue> track_start_placement_tokens;
+    while (true) {
+        if (current_token.is(Token::Type::Delim) && current_token.delim() == "/"sv)
+            break;
+        track_start_placement_tokens.append(current_token);
+        if (!tokens.has_next_token())
+            break;
+        current_token = tokens.next_token().token();
     }
 
-    auto calculate_grid_track_placement = [](auto& current_token, auto& tokens) -> Optional<CSS::GridTrackPlacement> {
-        auto is_span = false;
-        if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("span"sv)) {
-            is_span = true;
-            tokens.skip_whitespace();
+    Vector<ComponentValue> track_end_placement_tokens;
+    if (tokens.has_next_token()) {
+        current_token = tokens.next_token().token();
+        while (true) {
+            track_end_placement_tokens.append(current_token);
+            if (!tokens.has_next_token())
+                break;
             current_token = tokens.next_token().token();
         }
-        if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && current_token.number_value() != 0) {
-            // https://drafts.csswg.org/css-grid/#grid-placement-span-int
-            // Negative integers or zero are invalid.
-            if (is_span && static_cast<int>(current_token.number_value()) < 1)
-                return CSS::GridTrackPlacement(1, true);
-            return CSS::GridTrackPlacement(static_cast<int>(current_token.number_value()), is_span);
-        }
-        // https://drafts.csswg.org/css-grid/#grid-placement-int
-        // [ <integer [−∞,−1]> | <integer [1,∞]> ] && <custom-ident>?
-        // An <integer> value of zero makes the declaration invalid.
-        if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && current_token.number_value() == 0)
-            return {};
-        // https://drafts.csswg.org/css-grid/#grid-placement-span-int
-        // If the <integer> is omitted, it defaults to 1.
-        if (is_span && current_token.is(Token::Type::Delim) && current_token.delim() == "/"sv)
-            return CSS::GridTrackPlacement(1, true);
-        return CSS::GridTrackPlacement();
-    };
+    }
 
-    auto first_grid_track_placement = calculate_grid_track_placement(current_token, tokens);
-    if (!tokens.has_next_token() && first_grid_track_placement.has_value())
-        return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement(first_grid_track_placement.value()));
+    auto parsed_start_value = parse_grid_track_placement(track_start_placement_tokens);
+    if (parsed_start_value && track_end_placement_tokens.is_empty())
+        return GridTrackPlacementShorthandStyleValue::create(parsed_start_value.release_nonnull()->as_grid_track_placement().grid_track_placement());
 
-    tokens.skip_whitespace();
-    current_token = tokens.next_token().token();
-    tokens.skip_whitespace();
-    current_token = tokens.next_token().token();
+    auto parsed_end_value = parse_grid_track_placement(track_end_placement_tokens);
+    if (parsed_start_value && parsed_end_value)
+        return GridTrackPlacementShorthandStyleValue::create(parsed_start_value.release_nonnull()->as_grid_track_placement(), parsed_end_value.release_nonnull()->as_grid_track_placement());
 
-    auto second_grid_track_placement = calculate_grid_track_placement(current_token, tokens);
-    if (!tokens.has_next_token() && first_grid_track_placement.has_value() && second_grid_track_placement.has_value())
-        return GridTrackPlacementShorthandStyleValue::create(GridTrackPlacementStyleValue::create(first_grid_track_placement.value()), GridTrackPlacementStyleValue::create(second_grid_track_placement.value()));
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3340,7 +3340,7 @@ RefPtr<StyleValue> Parser::parse_rect_value(ComponentValue const& component_valu
         // <top>, <right>, <bottom>, and <left> may either have a <length> value or 'auto'.
         // Negative lengths are permitted.
         auto current_token = tokens.next_token().token();
-        if (current_token.to_string() == "auto") {
+        if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("auto"sv)) {
             params.append(Length::make_auto());
         } else {
             auto maybe_length = parse_length(current_token);
@@ -5454,7 +5454,7 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement(Vector<ComponentValue> con
     auto current_token = tokens.next_token().token();
 
     if (!tokens.has_next_token()) {
-        if (current_token.to_string() == "auto"sv)
+        if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("auto"sv))
             return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement());
         if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
             return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement(static_cast<int>(current_token.number_value())));
@@ -5462,7 +5462,7 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement(Vector<ComponentValue> con
     }
 
     auto has_span = false;
-    if (current_token.to_string() == "span"sv) {
+    if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("span"sv)) {
         has_span = true;
         tokens.skip_whitespace();
         current_token = tokens.next_token().token();
@@ -5478,7 +5478,7 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement_shorthand_value(Vector<Com
     auto current_token = tokens.next_token().token();
 
     if (!tokens.has_next_token()) {
-        if (current_token.to_string() == "auto"sv)
+        if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("auto"sv))
             return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement::make_auto());
         if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
             return GridTrackPlacementShorthandStyleValue::create(CSS::GridTrackPlacement(current_token.number_value()));
@@ -5487,7 +5487,7 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement_shorthand_value(Vector<Com
 
     auto calculate_grid_track_placement = [](auto& current_token, auto& tokens) -> CSS::GridTrackPlacement {
         auto has_span = false;
-        if (current_token.to_string() == "span"sv) {
+        if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_case("span"sv)) {
             has_span = true;
             tokens.skip_whitespace();
             current_token = tokens.next_token().token();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5461,20 +5461,14 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement(Vector<ComponentValue> con
         return {};
     }
 
-    auto first_grid_track_placement = CSS::GridTrackPlacement();
     auto has_span = false;
     if (current_token.to_string() == "span"sv) {
         has_span = true;
         tokens.skip_whitespace();
         current_token = tokens.next_token().token();
     }
-    if (current_token.is(Token::Type::Number) && current_token.number().is_integer()) {
-        first_grid_track_placement.set_position(static_cast<int>(current_token.number_value()));
-        first_grid_track_placement.set_has_span(has_span);
-    }
-
-    if (!tokens.has_next_token())
-        return GridTrackPlacementStyleValue::create(first_grid_track_placement);
+    if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && !tokens.has_next_token())
+        return GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement(static_cast<int>(current_token.number_value()), has_span));
     return {};
 }
 
@@ -5492,18 +5486,15 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement_shorthand_value(Vector<Com
     }
 
     auto calculate_grid_track_placement = [](auto& current_token, auto& tokens) -> CSS::GridTrackPlacement {
-        auto grid_track_placement = CSS::GridTrackPlacement();
         auto has_span = false;
         if (current_token.to_string() == "span"sv) {
             has_span = true;
             tokens.skip_whitespace();
             current_token = tokens.next_token().token();
         }
-        if (current_token.is(Token::Type::Number) && current_token.number().is_integer()) {
-            grid_track_placement.set_position(static_cast<int>(current_token.number_value()));
-            grid_track_placement.set_has_span(has_span);
-        }
-        return grid_track_placement;
+        if (current_token.is(Token::Type::Number) && current_token.number().is_integer())
+            return CSS::GridTrackPlacement(static_cast<int>(current_token.number_value()), has_span);
+        return CSS::GridTrackPlacement();
     };
 
     auto first_grid_track_placement = calculate_grid_track_placement(current_token, tokens);

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1389,7 +1389,7 @@ bool FrequencyStyleValue::equals(StyleValue const& other) const
 
 String GridTrackPlacementShorthandStyleValue::to_string() const
 {
-    if (m_end->grid_track_placement().position() == 0)
+    if (m_end->grid_track_placement().is_auto())
         return String::formatted("{}", m_start->grid_track_placement().to_string());
     return String::formatted("{} / {}", m_start->grid_track_placement().to_string(), m_end->grid_track_placement().to_string());
 }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -35,39 +35,6 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         return false;
     };
 
-    auto maybe_add_column_to_occupation_grid = [](int needed_number_of_columns, Vector<Vector<bool>>& occupation_grid) -> void {
-        int current_column_count = (int)occupation_grid[0].size();
-        if (needed_number_of_columns <= current_column_count)
-            return;
-        for (auto& occupation_grid_row : occupation_grid)
-            for (int idx = 0; idx < (needed_number_of_columns + 1) - current_column_count; idx++)
-                occupation_grid_row.append(false);
-    };
-
-    auto maybe_add_row_to_occupation_grid = [](int needed_number_of_rows, Vector<Vector<bool>>& occupation_grid) -> void {
-        if (needed_number_of_rows <= (int)occupation_grid.size())
-            return;
-
-        Vector<bool> new_occupation_grid_row;
-        for (int idx = 0; idx < (int)occupation_grid[0].size(); idx++)
-            new_occupation_grid_row.append(false);
-
-        for (int idx = 0; idx < needed_number_of_rows - (int)occupation_grid.size(); idx++)
-            occupation_grid.append(new_occupation_grid_row);
-    };
-
-    auto set_occupied_cells = [](int row_start, int row_end, int column_start, int column_end, Vector<Vector<bool>>& occupation_grid) -> void {
-        for (int row_index = 0; row_index < (int)occupation_grid.size(); row_index++) {
-            if (row_index >= row_start && row_index < row_end) {
-                for (int column_index = 0; column_index < (int)occupation_grid[0].size(); column_index++) {
-                    if (column_index >= column_start && column_index < column_end) {
-                        occupation_grid[row_index][column_index] = true;
-                    }
-                }
-            }
-        }
-    };
-
     // https://drafts.csswg.org/css-grid/#overview-placement
     // 2.2. Placing Items
     // The contents of the grid container are organized into individual grid items (analogous to
@@ -83,14 +50,6 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         float computed_height { 0 };
     };
     Vector<PositionedBox> positioned_boxes;
-
-    Vector<Vector<bool>> occupation_grid;
-    Vector<bool> occupation_grid_row;
-    for (int column_index = 0; column_index < max((int)box.computed_values().grid_template_columns().size(), 1); column_index++)
-        occupation_grid_row.append(false);
-    for (int row_index = 0; row_index < max((int)box.computed_values().grid_template_rows().size(), 1); row_index++)
-        occupation_grid.append(occupation_grid_row);
-
     Vector<Box const&> boxes_to_place;
     box.for_each_child_of_type<Box>([&](Box& child_box) {
         if (should_skip_is_anonymous_text_run(child_box))
@@ -98,6 +57,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         boxes_to_place.append(child_box);
         return IterationDecision::Continue;
     });
+    auto occupation_grid = OccupationGrid(static_cast<int>(box.computed_values().grid_template_columns().size()), static_cast<int>(box.computed_values().grid_template_rows().size()));
 
     // https://drafts.csswg.org/css-grid/#auto-placement-algo
     // 8.5. Grid Item Placement Algorithm
@@ -136,9 +96,9 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         // Contributes the Nth grid line to the grid item’s placement. If a negative integer is given, it
         // instead counts in reverse, starting from the end edge of the explicit grid.
         if (row_end < 0)
-            row_end = static_cast<int>(occupation_grid.size()) + row_end + 2;
+            row_end = occupation_grid.row_count() + row_end + 2;
         if (column_end < 0)
-            column_end = static_cast<int>(occupation_grid[0].size()) + column_end + 2;
+            column_end = occupation_grid.column_count() + column_end + 2;
 
         // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
         // lines with that name exist, all implicit grid lines are assumed to have that name for the purpose
@@ -208,9 +168,9 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         column_start -= 1;
         positioned_boxes.append({ child_box, row_start, row_span, column_start, column_span });
 
-        maybe_add_row_to_occupation_grid(row_start + row_span, occupation_grid);
-        maybe_add_column_to_occupation_grid(column_start + column_span, occupation_grid);
-        set_occupied_cells(row_start, row_start + row_span, column_start, column_start + column_span, occupation_grid);
+        occupation_grid.maybe_add_row(row_start + row_span);
+        occupation_grid.maybe_add_column(column_start + column_span);
+        occupation_grid.set_occupied(column_start, column_start + column_span, row_start, row_start + row_span);
         boxes_to_place.remove(i);
         i--;
     }
@@ -245,7 +205,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         // Contributes the Nth grid line to the grid item’s placement. If a negative integer is given, it
         // instead counts in reverse, starting from the end edge of the explicit grid.
         if (row_end < 0)
-            row_end = static_cast<int>(occupation_grid.size()) + row_end + 2;
+            row_end = occupation_grid.row_count() + row_end + 2;
 
         // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
         // lines with that name exist, all implicit grid lines are assumed to have that name for the purpose
@@ -297,23 +257,23 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         // FIXME: If the placement contains only a span for a named line, replace it with a span of 1.
 
         row_start -= 1;
-        maybe_add_row_to_occupation_grid(row_start + row_span, occupation_grid);
+        occupation_grid.maybe_add_row(row_start + row_span);
 
         int column_start = 0;
         auto column_span = child_box.computed_values().grid_column_start().is_span() ? child_box.computed_values().grid_column_start().raw_value() : 1;
         bool found_available_column = false;
-        for (int column_index = column_start; column_index < (int)occupation_grid[0].size(); column_index++) {
-            if (!occupation_grid[row_start][column_index]) {
+        for (int column_index = column_start; column_index < occupation_grid.column_count(); column_index++) {
+            if (!occupation_grid.is_occupied(column_index, row_start)) {
                 found_available_column = true;
                 column_start = column_index;
                 break;
             }
         }
         if (!found_available_column) {
-            column_start = occupation_grid[0].size();
-            maybe_add_column_to_occupation_grid(column_start + column_span, occupation_grid);
+            column_start = occupation_grid.column_count();
+            occupation_grid.maybe_add_column(column_start + column_span);
         }
-        set_occupied_cells(row_start, row_start + row_span, column_start, column_start + column_span, occupation_grid);
+        occupation_grid.set_occupied(column_start, column_start + column_span, row_start, row_start + row_span);
 
         positioned_boxes.append({ child_box, row_start, row_span, column_start, column_span });
         boxes_to_place.remove(i);
@@ -373,7 +333,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             // Contributes the Nth grid line to the grid item’s placement. If a negative integer is given, it
             // instead counts in reverse, starting from the end edge of the explicit grid.
             if (column_end < 0)
-                column_end = static_cast<int>(occupation_grid[0].size()) + column_end + 2;
+                column_end = occupation_grid.column_count() + column_end + 2;
 
             // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
             // lines with that name exist, all implicit grid lines are assumed to have that name for the purpose
@@ -433,21 +393,21 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
                 auto_placement_cursor_y++;
             auto_placement_cursor_x = column_start;
 
-            maybe_add_column_to_occupation_grid(auto_placement_cursor_x + column_span, occupation_grid);
-            maybe_add_row_to_occupation_grid(auto_placement_cursor_y + row_span, occupation_grid);
+            occupation_grid.maybe_add_column(auto_placement_cursor_x + column_span);
+            occupation_grid.maybe_add_row(auto_placement_cursor_y + row_span);
 
             // 4.1.1.2. Increment the cursor's row position until a value is found where the grid item does not
             // overlap any occupied grid cells (creating new rows in the implicit grid as necessary).
             while (true) {
-                if (!occupation_grid[auto_placement_cursor_y][column_start]) {
+                if (!occupation_grid.is_occupied(column_start, auto_placement_cursor_y)) {
                     break;
                 }
                 auto_placement_cursor_y++;
-                maybe_add_row_to_occupation_grid(auto_placement_cursor_y + row_span, occupation_grid);
+                occupation_grid.maybe_add_row(auto_placement_cursor_y + row_span);
             }
             // 4.1.1.3. Set the item's row-start line to the cursor's row position, and set the item's row-end
             // line according to its span from that position.
-            set_occupied_cells(auto_placement_cursor_y, auto_placement_cursor_y + row_span, column_start, column_start + column_span, occupation_grid);
+            occupation_grid.set_occupied(column_start, column_start + column_span, auto_placement_cursor_y, auto_placement_cursor_y + row_span);
 
             positioned_boxes.append({ child_box, auto_placement_cursor_y, row_span, column_start, column_span });
         }
@@ -462,12 +422,12 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             auto row_start = 0;
             auto row_span = child_box.computed_values().grid_row_start().is_span() ? child_box.computed_values().grid_row_start().raw_value() : 1;
             auto found_unoccupied_area = false;
-            for (int row_index = auto_placement_cursor_y; row_index < (int)occupation_grid.size(); row_index++) {
-                for (int column_index = auto_placement_cursor_x; column_index < (int)occupation_grid[0].size(); column_index++) {
-                    if (column_span + column_index <= static_cast<int>(occupation_grid[0].size())) {
+            for (int row_index = auto_placement_cursor_y; row_index < occupation_grid.row_count(); row_index++) {
+                for (int column_index = auto_placement_cursor_x; column_index < occupation_grid.column_count(); column_index++) {
+                    if (column_span + column_index <= occupation_grid.column_count()) {
                         auto found_all_available = true;
                         for (int span_index = 0; span_index < column_span; span_index++) {
-                            if (occupation_grid[row_index][column_index + span_index])
+                            if (occupation_grid.is_occupied(column_index + span_index, row_index))
                                 found_all_available = false;
                         }
                         if (found_all_available) {
@@ -489,11 +449,11 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             // row position (creating new rows in the implicit grid as necessary), set its column position to the
             // start-most column line in the implicit grid, and return to the previous step.
             if (!found_unoccupied_area) {
-                row_start = (int)occupation_grid.size();
-                maybe_add_row_to_occupation_grid((int)occupation_grid.size() + 1, occupation_grid);
+                row_start = occupation_grid.row_count();
+                occupation_grid.maybe_add_row(occupation_grid.row_count() + 1);
             }
 
-            set_occupied_cells(row_start, row_start + row_span, column_start, column_start + column_span, occupation_grid);
+            occupation_grid.set_occupied(column_start, column_start + column_span, row_start, row_start + row_span);
             positioned_boxes.append({ child_box, row_start, row_span, column_start, column_span });
         }
         boxes_to_place.remove(i);
@@ -546,9 +506,9 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
     for (auto& row_size : box.computed_values().grid_template_rows())
         grid_rows.append({ row_size, row_size });
 
-    for (int column_index = grid_columns.size(); column_index < static_cast<int>(occupation_grid[0].size()); column_index++)
+    for (int column_index = grid_columns.size(); column_index < occupation_grid.column_count(); column_index++)
         grid_columns.append({ CSS::GridTrackSize::make_auto(), CSS::GridTrackSize::make_auto() });
-    for (int row_index = grid_rows.size(); row_index < static_cast<int>(occupation_grid.size()); row_index++)
+    for (int row_index = grid_rows.size(); row_index < occupation_grid.row_count(); row_index++)
         grid_rows.append({ CSS::GridTrackSize::make_auto(), CSS::GridTrackSize::make_auto() });
 
     // https://drafts.csswg.org/css-grid/#algo-overview
@@ -1109,7 +1069,6 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             grid_row.base_size = max(grid_row.base_size, remaining_vertical_space / count_of_auto_max_row_tracks);
     }
 
-    // Do layout
     auto layout_box = [&](int row_start, int row_end, int column_start, int column_end, Box const& child_box) -> void {
         auto& child_box_state = m_state.get_mutable(child_box);
         float x_start = 0;
@@ -1158,6 +1117,59 @@ bool GridFormattingContext::is_auto_positioned_column(CSS::GridTrackPlacement co
 bool GridFormattingContext::is_auto_positioned_track(CSS::GridTrackPlacement const& grid_track_start, CSS::GridTrackPlacement const& grid_track_end) const
 {
     return grid_track_start.is_auto_positioned() && grid_track_end.is_auto_positioned();
+}
+
+OccupationGrid::OccupationGrid(int column_count, int row_count)
+{
+    Vector<bool> occupation_grid_row;
+    for (int column_index = 0; column_index < max(column_count, 1); column_index++)
+        occupation_grid_row.append(false);
+    for (int row_index = 0; row_index < max(row_count, 1); row_index++)
+        m_occupation_grid.append(occupation_grid_row);
+}
+
+void OccupationGrid::maybe_add_column(int needed_number_of_columns)
+{
+    if (needed_number_of_columns <= column_count())
+        return;
+    for (auto& occupation_grid_row : m_occupation_grid)
+        for (int idx = 0; idx < (needed_number_of_columns + 1) - column_count(); idx++)
+            occupation_grid_row.append(false);
+}
+
+void OccupationGrid::maybe_add_row(int needed_number_of_rows)
+{
+    if (needed_number_of_rows <= row_count())
+        return;
+
+    Vector<bool> new_occupation_grid_row;
+    for (int idx = 0; idx < column_count(); idx++)
+        new_occupation_grid_row.append(false);
+
+    for (int idx = 0; idx < needed_number_of_rows - row_count(); idx++)
+        m_occupation_grid.append(new_occupation_grid_row);
+}
+
+void OccupationGrid::set_occupied(int column_start, int column_end, int row_start, int row_end)
+{
+    for (int row_index = 0; row_index < row_count(); row_index++) {
+        if (row_index >= row_start && row_index < row_end) {
+            for (int column_index = 0; column_index < column_count(); column_index++) {
+                if (column_index >= column_start && column_index < column_end)
+                    set_occupied(column_index, row_index);
+            }
+        }
+    }
+}
+
+void OccupationGrid::set_occupied(int column_index, int row_index)
+{
+    m_occupation_grid[row_index][column_index] = true;
+}
+
+bool OccupationGrid::is_occupied(int column_index, int row_index)
+{
+    return m_occupation_grid[row_index][column_index];
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -251,6 +251,9 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             if (row_start != row_end)
                 row_span = row_end - row_start;
         }
+        // FIXME: Have yet to find the spec for this.
+        if (!child_box.computed_values().grid_row_start().is_position() && child_box.computed_values().grid_row_end().is_position() && row_end == 1)
+            row_start = 1;
 
         // If the placement contains two spans, remove the one contributed by the end grid-placement
         // property.
@@ -361,6 +364,9 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
                 if (column_start < 0)
                     column_start = 1;
             }
+            // FIXME: Have yet to find the spec for this.
+            if (!child_box.computed_values().grid_column_start().is_position() && child_box.computed_values().grid_column_end().is_position() && column_end == 1)
+                column_start = 1;
 
             // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
             // lines with that name exist, all implicit grid lines on the side of the explicit grid

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -303,7 +303,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         auto column_span = child_box.computed_values().grid_column_start().is_span() ? child_box.computed_values().grid_column_start().raw_value() : 1;
         bool found_available_column = false;
         for (int column_index = column_start; column_index < (int)occupation_grid[0].size(); column_index++) {
-            if (!occupation_grid[0][column_index]) {
+            if (!occupation_grid[row_start][column_index]) {
                 found_available_column = true;
                 column_start = column_index;
                 break;

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1129,8 +1129,10 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         child_box_state.offset = { x_start, y_start };
     };
 
-    for (auto& positioned_box : positioned_boxes)
-        layout_box(positioned_box.row, positioned_box.row + positioned_box.row_span, positioned_box.column, positioned_box.column + positioned_box.column_span, positioned_box.box);
+    for (auto& positioned_box : positioned_boxes) {
+        auto resolved_span = positioned_box.row + positioned_box.row_span > static_cast<int>(grid_rows.size()) ? static_cast<int>(grid_rows.size()) - positioned_box.row : positioned_box.row_span;
+        layout_box(positioned_box.row, positioned_box.row + resolved_span, positioned_box.column, positioned_box.column + positioned_box.column_span, positioned_box.box);
+    }
 
     float total_y = 0;
     for (auto& grid_row : grid_rows)

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -107,18 +107,29 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
     // 1. Position anything that's not auto-positioned.
     for (size_t i = 0; i < boxes_to_place.size(); i++) {
         auto const& child_box = boxes_to_place[i];
-        if (child_box.computed_values().grid_row_start().is_auto()
-            || child_box.computed_values().grid_row_end().is_auto()
-            || child_box.computed_values().grid_column_start().is_auto()
-            || child_box.computed_values().grid_column_end().is_auto())
+        if ((child_box.computed_values().grid_row_start().is_auto_positioned() && child_box.computed_values().grid_row_end().is_auto_positioned())
+            || (child_box.computed_values().grid_column_start().is_auto_positioned() && child_box.computed_values().grid_column_end().is_auto_positioned()))
             continue;
 
-        int row_start = child_box.computed_values().grid_row_start().position();
-        int row_end = child_box.computed_values().grid_row_end().position();
-        int column_start = child_box.computed_values().grid_column_start().position();
-        int column_end = child_box.computed_values().grid_column_end().position();
-        int row_span = 1;
-        int column_span = 1;
+        int row_start = child_box.computed_values().grid_row_start().raw_value();
+        int row_end = child_box.computed_values().grid_row_end().raw_value();
+        int column_start = child_box.computed_values().grid_column_start().raw_value();
+        int column_end = child_box.computed_values().grid_column_end().raw_value();
+
+        // https://drafts.csswg.org/css-grid/#line-placement
+        // 8.3. Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+
+        // https://drafts.csswg.org/css-grid/#grid-placement-slot
+        // FIXME: <custom-ident>
+        // First attempt to match the grid area’s edge to a named grid area: if there is a grid line whose
+        // line name is <custom-ident>-start (for grid-*-start) / <custom-ident>-end (for grid-*-end),
+        // contributes the first such line to the grid item’s placement.
+
+        // Note: Named grid areas automatically generate implicitly-assigned line names of this form, so
+        // specifying grid-row-start: foo will choose the start edge of that named grid area (unless another
+        // line named foo-start was explicitly specified before it).
+
+        // Otherwise, treat this as if the integer 1 had been specified along with the <custom-ident>.
 
         // https://drafts.csswg.org/css-grid/#grid-placement-int
         // [ <integer [−∞,−1]> | <integer [1,∞]> ] && <custom-ident>?
@@ -128,33 +139,68 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             row_end = static_cast<int>(occupation_grid.size()) + row_end + 2;
         if (column_end < 0)
             column_end = static_cast<int>(occupation_grid[0].size()) + column_end + 2;
-        // FIXME: If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
+
+        // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
         // lines with that name exist, all implicit grid lines are assumed to have that name for the purpose
         // of finding this position.
 
-        // FIXME: An <integer> value of zero makes the declaration invalid.
+        // An <integer> value of zero makes the declaration invalid.
+
+        // https://drafts.csswg.org/css-grid/#grid-placement-span-int
+        // span && [ <integer [1,∞]> || <custom-ident> ]
+        // Contributes a grid span to the grid item’s placement such that the corresponding edge of the grid
+        // item’s grid area is N lines from its opposite edge in the corresponding direction. For example,
+        // grid-column-end: span 2 indicates the second grid line in the endward direction from the
+        // grid-column-start line.
+        int row_span = 1;
+        int column_span = 1;
+        if (child_box.computed_values().grid_row_start().is_position() && child_box.computed_values().grid_row_end().is_span())
+            row_span = child_box.computed_values().grid_row_end().raw_value();
+        if (child_box.computed_values().grid_column_start().is_position() && child_box.computed_values().grid_column_end().is_span())
+            column_span = child_box.computed_values().grid_column_end().raw_value();
+        if (child_box.computed_values().grid_row_end().is_position() && child_box.computed_values().grid_row_start().is_span()) {
+            row_span = child_box.computed_values().grid_row_start().raw_value();
+            row_start = row_end - row_span;
+        }
+        if (child_box.computed_values().grid_column_end().is_position() && child_box.computed_values().grid_column_start().is_span()) {
+            column_span = child_box.computed_values().grid_column_start().raw_value();
+            column_start = column_end - column_span;
+        }
+
+        // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
+        // lines with that name exist, all implicit grid lines on the side of the explicit grid
+        // corresponding to the search direction are assumed to have that name for the purpose of counting
+        // this span.
+
+        // https://drafts.csswg.org/css-grid/#grid-placement-auto
+        // auto
+        // The property contributes nothing to the grid item’s placement, indicating auto-placement or a
+        // default span of one. (See § 8 Placing Grid Items, above.)
 
         // https://drafts.csswg.org/css-grid/#grid-placement-errors
         // 8.3.1. Grid Placement Conflict Handling
         // If the placement for a grid item contains two lines, and the start line is further end-ward than
         // the end line, swap the two lines. If the start line is equal to the end line, remove the end
         // line.
-        if (row_start > row_end) {
-            auto temp = row_end;
-            row_end = row_start;
-            row_start = temp;
+        if (child_box.computed_values().grid_row_start().is_position() && child_box.computed_values().grid_row_end().is_position()) {
+            if (row_start > row_end)
+                swap(row_start, row_end);
+            if (row_start != row_end)
+                row_span = row_end - row_start;
         }
-        if (column_start > column_end) {
-            auto temp = column_end;
-            column_end = column_start;
-            column_start = temp;
+        if (child_box.computed_values().grid_column_start().is_position() && child_box.computed_values().grid_column_end().is_position()) {
+            if (column_start > column_end)
+                swap(column_start, column_end);
+            if (column_start != column_end)
+                column_span = column_end - column_start;
         }
-        if (row_start != row_end)
-            row_span = row_end - row_start;
-        if (column_start != column_end)
-            column_span = column_end - column_start;
-        // FIXME: If the placement contains two spans, remove the one contributed by the end grid-placement
+
+        // If the placement contains two spans, remove the one contributed by the end grid-placement
         // property.
+        if (child_box.computed_values().grid_row_start().is_span() && child_box.computed_values().grid_row_end().is_span())
+            row_span = child_box.computed_values().grid_row_start().raw_value();
+        if (child_box.computed_values().grid_column_start().is_span() && child_box.computed_values().grid_column_end().is_span())
+            column_span = child_box.computed_values().grid_column_start().raw_value();
 
         // FIXME: If the placement contains only a span for a named line, replace it with a span of 1.
 
@@ -173,13 +219,26 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
     // FIXME: Do "dense" packing
     for (size_t i = 0; i < boxes_to_place.size(); i++) {
         auto const& child_box = boxes_to_place[i];
-        if (child_box.computed_values().grid_row_start().is_auto()
-            || child_box.computed_values().grid_row_end().is_auto())
+        if (child_box.computed_values().grid_row_start().is_auto_positioned() && child_box.computed_values().grid_row_end().is_auto_positioned())
             continue;
 
-        int row_start = child_box.computed_values().grid_row_start().position();
-        int row_end = child_box.computed_values().grid_row_end().position();
-        int row_span = 1;
+        int row_start = child_box.computed_values().grid_row_start().raw_value();
+        int row_end = child_box.computed_values().grid_row_end().raw_value();
+
+        // https://drafts.csswg.org/css-grid/#line-placement
+        // 8.3. Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+
+        // https://drafts.csswg.org/css-grid/#grid-placement-slot
+        // FIXME: <custom-ident>
+        // First attempt to match the grid area’s edge to a named grid area: if there is a grid line whose
+        // line name is <custom-ident>-start (for grid-*-start) / <custom-ident>-end (for grid-*-end),
+        // contributes the first such line to the grid item’s placement.
+
+        // Note: Named grid areas automatically generate implicitly-assigned line names of this form, so
+        // specifying grid-row-start: foo will choose the start edge of that named grid area (unless another
+        // line named foo-start was explicitly specified before it).
+
+        // Otherwise, treat this as if the integer 1 had been specified along with the <custom-ident>.
 
         // https://drafts.csswg.org/css-grid/#grid-placement-int
         // [ <integer [−∞,−1]> | <integer [1,∞]> ] && <custom-ident>?
@@ -187,26 +246,53 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         // instead counts in reverse, starting from the end edge of the explicit grid.
         if (row_end < 0)
             row_end = static_cast<int>(occupation_grid.size()) + row_end + 2;
-        // FIXME: If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
+
+        // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
         // lines with that name exist, all implicit grid lines are assumed to have that name for the purpose
         // of finding this position.
 
-        // FIXME: An <integer> value of zero makes the declaration invalid.
+        // An <integer> value of zero makes the declaration invalid.
+
+        // https://drafts.csswg.org/css-grid/#grid-placement-span-int
+        // span && [ <integer [1,∞]> || <custom-ident> ]
+        // Contributes a grid span to the grid item’s placement such that the corresponding edge of the grid
+        // item’s grid area is N lines from its opposite edge in the corresponding direction. For example,
+        // grid-column-end: span 2 indicates the second grid line in the endward direction from the
+        // grid-column-start line.
+        int row_span = 1;
+        if (child_box.computed_values().grid_row_start().is_position() && child_box.computed_values().grid_row_end().is_span())
+            row_span = child_box.computed_values().grid_row_end().raw_value();
+        if (child_box.computed_values().grid_row_end().is_position() && child_box.computed_values().grid_row_start().is_span()) {
+            row_span = child_box.computed_values().grid_row_start().raw_value();
+            row_start = row_end - row_span;
+        }
+
+        // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
+        // lines with that name exist, all implicit grid lines on the side of the explicit grid
+        // corresponding to the search direction are assumed to have that name for the purpose of counting
+        // this span.
+
+        // https://drafts.csswg.org/css-grid/#grid-placement-auto
+        // auto
+        // The property contributes nothing to the grid item’s placement, indicating auto-placement or a
+        // default span of one. (See § 8 Placing Grid Items, above.)
 
         // https://drafts.csswg.org/css-grid/#grid-placement-errors
         // 8.3.1. Grid Placement Conflict Handling
         // If the placement for a grid item contains two lines, and the start line is further end-ward than
         // the end line, swap the two lines. If the start line is equal to the end line, remove the end
         // line.
-        if (row_start > row_end) {
-            auto temp = row_end;
-            row_end = row_start;
-            row_start = temp;
+        if (child_box.computed_values().grid_row_start().is_position() && child_box.computed_values().grid_row_end().is_position()) {
+            if (row_start > row_end)
+                swap(row_start, row_end);
+            if (row_start != row_end)
+                row_span = row_end - row_start;
         }
-        if (row_start != row_end)
-            row_span = row_end - row_start;
-        // FIXME: If the placement contains two spans, remove the one contributed by the end grid-placement
+
+        // If the placement contains two spans, remove the one contributed by the end grid-placement
         // property.
+        if (child_box.computed_values().grid_row_start().is_span() && child_box.computed_values().grid_row_end().is_span())
+            row_span = child_box.computed_values().grid_row_start().raw_value();
 
         // FIXME: If the placement contains only a span for a named line, replace it with a span of 1.
 
@@ -263,10 +349,24 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         // FIXME: no distinction made. See #4.2
 
         // 4.1.1. If the item has a definite column position:
-        if (!child_box.computed_values().grid_column_start().is_auto()) {
-            int column_start = child_box.computed_values().grid_column_start().position();
-            int column_end = child_box.computed_values().grid_column_end().position();
-            int column_span = 1;
+        if (!(child_box.computed_values().grid_column_start().is_auto_positioned() && child_box.computed_values().grid_column_end().is_auto_positioned())) {
+            int column_start = child_box.computed_values().grid_column_start().raw_value();
+            int column_end = child_box.computed_values().grid_column_end().raw_value();
+
+            // https://drafts.csswg.org/css-grid/#line-placement
+            // 8.3. Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+
+            // https://drafts.csswg.org/css-grid/#grid-placement-slot
+            // FIXME: <custom-ident>
+            // First attempt to match the grid area’s edge to a named grid area: if there is a grid line whose
+            // line name is <custom-ident>-start (for grid-*-start) / <custom-ident>-end (for grid-*-end),
+            // contributes the first such line to the grid item’s placement.
+
+            // Note: Named grid areas automatically generate implicitly-assigned line names of this form, so
+            // specifying grid-row-start: foo will choose the start edge of that named grid area (unless another
+            // line named foo-start was explicitly specified before it).
+
+            // Otherwise, treat this as if the integer 1 had been specified along with the <custom-ident>.
 
             // https://drafts.csswg.org/css-grid/#grid-placement-int
             // [ <integer [−∞,−1]> | <integer [1,∞]> ] && <custom-ident>?
@@ -274,28 +374,53 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             // instead counts in reverse, starting from the end edge of the explicit grid.
             if (column_end < 0)
                 column_end = static_cast<int>(occupation_grid[0].size()) + column_end + 2;
-            // FIXME: If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
+
+            // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
             // lines with that name exist, all implicit grid lines are assumed to have that name for the purpose
             // of finding this position.
 
-            // FIXME: An <integer> value of zero makes the declaration invalid.
+            // An <integer> value of zero makes the declaration invalid.
+
+            // https://drafts.csswg.org/css-grid/#grid-placement-span-int
+            // span && [ <integer [1,∞]> || <custom-ident> ]
+            // Contributes a grid span to the grid item’s placement such that the corresponding edge of the grid
+            // item’s grid area is N lines from its opposite edge in the corresponding direction. For example,
+            // grid-column-end: span 2 indicates the second grid line in the endward direction from the
+            // grid-column-start line.
+            int column_span = 1;
+            if (child_box.computed_values().grid_column_start().is_position() && child_box.computed_values().grid_column_end().is_span())
+                column_span = child_box.computed_values().grid_column_end().raw_value();
+            if (child_box.computed_values().grid_column_end().is_position() && child_box.computed_values().grid_column_start().is_span()) {
+                column_span = child_box.computed_values().grid_column_start().raw_value();
+                column_start = column_end - column_span;
+            }
+
+            // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
+            // lines with that name exist, all implicit grid lines on the side of the explicit grid
+            // corresponding to the search direction are assumed to have that name for the purpose of counting
+            // this span.
+
+            // https://drafts.csswg.org/css-grid/#grid-placement-auto
+            // auto
+            // The property contributes nothing to the grid item’s placement, indicating auto-placement or a
+            // default span of one. (See § 8 Placing Grid Items, above.)
 
             // https://drafts.csswg.org/css-grid/#grid-placement-errors
             // 8.3.1. Grid Placement Conflict Handling
             // If the placement for a grid item contains two lines, and the start line is further end-ward than
             // the end line, swap the two lines. If the start line is equal to the end line, remove the end
             // line.
-            if (!child_box.computed_values().grid_column_end().is_auto()) {
-                if (column_start > column_end) {
-                    auto temp = column_end;
-                    column_end = column_start;
-                    column_start = temp;
-                }
+            if (child_box.computed_values().grid_column_start().is_position() && child_box.computed_values().grid_column_end().is_position()) {
+                if (column_start > column_end)
+                    swap(column_start, column_end);
                 if (column_start != column_end)
                     column_span = column_end - column_start;
             }
-            // FIXME: If the placement contains two spans, remove the one contributed by the end grid-placement
+
+            // If the placement contains two spans, remove the one contributed by the end grid-placement
             // property.
+            if (child_box.computed_values().grid_column_start().is_span() && child_box.computed_values().grid_column_end().is_span())
+                column_span = child_box.computed_values().grid_column_start().raw_value();
 
             // FIXME: If the placement contains only a span for a named line, replace it with a span of 1.
 

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -107,8 +107,8 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
     // 1. Position anything that's not auto-positioned.
     for (size_t i = 0; i < boxes_to_place.size(); i++) {
         auto const& child_box = boxes_to_place[i];
-        if ((child_box.computed_values().grid_row_start().is_auto_positioned() && child_box.computed_values().grid_row_end().is_auto_positioned())
-            || (child_box.computed_values().grid_column_start().is_auto_positioned() && child_box.computed_values().grid_column_end().is_auto_positioned()))
+        if (is_auto_positioned_row(child_box.computed_values().grid_row_start(), child_box.computed_values().grid_row_end())
+            || is_auto_positioned_column(child_box.computed_values().grid_column_start(), child_box.computed_values().grid_column_end()))
             continue;
 
         int row_start = child_box.computed_values().grid_row_start().raw_value();
@@ -219,7 +219,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
     // FIXME: Do "dense" packing
     for (size_t i = 0; i < boxes_to_place.size(); i++) {
         auto const& child_box = boxes_to_place[i];
-        if (child_box.computed_values().grid_row_start().is_auto_positioned() && child_box.computed_values().grid_row_end().is_auto_positioned())
+        if (is_auto_positioned_row(child_box.computed_values().grid_row_start(), child_box.computed_values().grid_row_end()))
             continue;
 
         int row_start = child_box.computed_values().grid_row_start().raw_value();
@@ -349,7 +349,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         // FIXME: no distinction made. See #4.2
 
         // 4.1.1. If the item has a definite column position:
-        if (!(child_box.computed_values().grid_column_start().is_auto_positioned() && child_box.computed_values().grid_column_end().is_auto_positioned())) {
+        if (!is_auto_positioned_column(child_box.computed_values().grid_column_start(), child_box.computed_values().grid_column_end())) {
             int column_start = child_box.computed_values().grid_column_start().raw_value();
             int column_end = child_box.computed_values().grid_column_end().raw_value();
 
@@ -1133,6 +1133,21 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
 float GridFormattingContext::automatic_content_height() const
 {
     return m_automatic_content_height;
+}
+
+bool GridFormattingContext::is_auto_positioned_row(CSS::GridTrackPlacement const& grid_row_start, CSS::GridTrackPlacement const& grid_row_end) const
+{
+    return is_auto_positioned_track(grid_row_start, grid_row_end);
+}
+
+bool GridFormattingContext::is_auto_positioned_column(CSS::GridTrackPlacement const& grid_column_start, CSS::GridTrackPlacement const& grid_column_end) const
+{
+    return is_auto_positioned_track(grid_column_start, grid_column_end);
+}
+
+bool GridFormattingContext::is_auto_positioned_track(CSS::GridTrackPlacement const& grid_track_start, CSS::GridTrackPlacement const& grid_track_end) const
+{
+    return grid_track_start.is_auto_positioned() && grid_track_end.is_auto_positioned();
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -225,6 +225,9 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         if (child_box.computed_values().grid_row_end().is_position() && child_box.computed_values().grid_row_start().is_span()) {
             row_span = child_box.computed_values().grid_row_start().raw_value();
             row_start = row_end - row_span;
+            // FIXME: Remove me once have implemented spans overflowing into negative indexes, e.g., grid-row: span 2 / 1
+            if (row_start < 0)
+                row_start = 1;
         }
 
         // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
@@ -354,6 +357,9 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             if (child_box.computed_values().grid_column_end().is_position() && child_box.computed_values().grid_column_start().is_span()) {
                 column_span = child_box.computed_values().grid_column_start().raw_value();
                 column_start = column_end - column_span;
+                // FIXME: Remove me once have implemented spans overflowing into negative indexes, e.g., grid-column: span 2 / 1
+                if (column_start < 0)
+                    column_start = 1;
             }
 
             // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -300,7 +300,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
         maybe_add_row_to_occupation_grid(row_start + row_span, occupation_grid);
 
         int column_start = 0;
-        int column_span = 1;
+        auto column_span = child_box.computed_values().grid_column_start().is_span() ? child_box.computed_values().grid_column_start().raw_value() : 1;
         bool found_available_column = false;
         for (int column_index = column_start; column_index < (int)occupation_grid[0].size(); column_index++) {
             if (!occupation_grid[0][column_index]) {
@@ -388,6 +388,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             // grid-column-end: span 2 indicates the second grid line in the endward direction from the
             // grid-column-start line.
             int column_span = 1;
+            auto row_span = child_box.computed_values().grid_row_start().is_span() ? child_box.computed_values().grid_row_start().raw_value() : 1;
             if (child_box.computed_values().grid_column_start().is_position() && child_box.computed_values().grid_column_end().is_span())
                 column_span = child_box.computed_values().grid_column_end().raw_value();
             if (child_box.computed_values().grid_column_end().is_position() && child_box.computed_values().grid_column_start().is_span()) {
@@ -432,8 +433,8 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             if (column_start < auto_placement_cursor_x)
                 auto_placement_cursor_y++;
 
-            maybe_add_column_to_occupation_grid(auto_placement_cursor_x + 1, occupation_grid);
-            maybe_add_row_to_occupation_grid(auto_placement_cursor_y + 1, occupation_grid);
+            maybe_add_column_to_occupation_grid(auto_placement_cursor_x + column_span, occupation_grid);
+            maybe_add_row_to_occupation_grid(auto_placement_cursor_y + row_span, occupation_grid);
 
             // 4.1.1.2. Increment the cursor's row position until a value is found where the grid item does not
             // overlap any occupied grid cells (creating new rows in the implicit grid as necessary).
@@ -442,13 +443,13 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
                     break;
                 }
                 auto_placement_cursor_y++;
-                maybe_add_row_to_occupation_grid(auto_placement_cursor_y + 1, occupation_grid);
+                maybe_add_row_to_occupation_grid(auto_placement_cursor_y + row_span, occupation_grid);
             }
             // 4.1.1.3. Set the item's row-start line to the cursor's row position, and set the item's row-end
             // line according to its span from that position.
-            set_occupied_cells(auto_placement_cursor_y, auto_placement_cursor_y + 1, column_start, column_start + column_span, occupation_grid);
+            set_occupied_cells(auto_placement_cursor_y, auto_placement_cursor_y + row_span, column_start, column_start + column_span, occupation_grid);
 
-            positioned_boxes.append({ child_box, auto_placement_cursor_y, 1, column_start, column_span });
+            positioned_boxes.append({ child_box, auto_placement_cursor_y, row_span, column_start, column_span });
         }
         // 4.1.2. If the item has an automatic grid position in both axes:
         else {
@@ -457,9 +458,9 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             // column span, overflow the number of columns in the implicit grid, as determined earlier in this
             // algorithm.
             auto column_start = 0;
-            auto column_span = 1;
+            auto column_span = child_box.computed_values().grid_column_start().is_span() ? child_box.computed_values().grid_column_start().raw_value() : 1;
             auto row_start = 0;
-            auto row_span = 1;
+            auto row_span = child_box.computed_values().grid_row_start().is_span() ? child_box.computed_values().grid_row_start().raw_value() : 1;
             auto found_unoccupied_cell = false;
             for (int row_index = auto_placement_cursor_y; row_index < (int)occupation_grid.size(); row_index++) {
                 for (int column_index = auto_placement_cursor_x; column_index < (int)occupation_grid[0].size(); column_index++) {

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -429,9 +429,9 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
 
             // 4.1.1.1. Set the column position of the cursor to the grid item's column-start line. If this is
             // less than the previous column position of the cursor, increment the row position by 1.
-            auto_placement_cursor_x = column_start;
             if (column_start < auto_placement_cursor_x)
                 auto_placement_cursor_y++;
+            auto_placement_cursor_x = column_start;
 
             maybe_add_column_to_occupation_grid(auto_placement_cursor_x + column_span, occupation_grid);
             maybe_add_row_to_occupation_grid(auto_placement_cursor_y + row_span, occupation_grid);

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -461,14 +461,21 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             auto column_span = child_box.computed_values().grid_column_start().is_span() ? child_box.computed_values().grid_column_start().raw_value() : 1;
             auto row_start = 0;
             auto row_span = child_box.computed_values().grid_row_start().is_span() ? child_box.computed_values().grid_row_start().raw_value() : 1;
-            auto found_unoccupied_cell = false;
+            auto found_unoccupied_area = false;
             for (int row_index = auto_placement_cursor_y; row_index < (int)occupation_grid.size(); row_index++) {
                 for (int column_index = auto_placement_cursor_x; column_index < (int)occupation_grid[0].size(); column_index++) {
-                    if (!occupation_grid[row_index][column_index]) {
-                        found_unoccupied_cell = true;
-                        column_start = column_index;
-                        row_start = row_index;
-                        goto finish;
+                    if (column_span + column_index <= static_cast<int>(occupation_grid[0].size())) {
+                        auto found_all_available = true;
+                        for (int span_index = 0; span_index < column_span; span_index++) {
+                            if (occupation_grid[row_index][column_index + span_index])
+                                found_all_available = false;
+                        }
+                        if (found_all_available) {
+                            found_unoccupied_area = true;
+                            column_start = column_index;
+                            row_start = row_index;
+                            goto finish;
+                        }
                     }
                     auto_placement_cursor_x = 0;
                 }
@@ -481,7 +488,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Ava
             // and column-start lines to the cursor's position. Otherwise, increment the auto-placement cursor's
             // row position (creating new rows in the implicit grid as necessary), set its column position to the
             // start-most column line in the implicit grid, and return to the previous step.
-            if (!found_unoccupied_cell) {
+            if (!found_unoccupied_area) {
                 row_start = (int)occupation_grid.size();
                 maybe_add_row_to_occupation_grid((int)occupation_grid.size() + 1, occupation_grid);
             }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -27,4 +27,21 @@ private:
     bool is_auto_positioned_track(CSS::GridTrackPlacement const&, CSS::GridTrackPlacement const&) const;
 };
 
+class OccupationGrid {
+public:
+    OccupationGrid(int column_count, int row_count);
+
+    void maybe_add_column(int needed_number_of_columns);
+    void maybe_add_row(int needed_number_of_rows);
+    void set_occupied(int column_start, int column_end, int row_start, int row_end);
+    void set_occupied(int column_index, int row_index);
+
+    int column_count() { return static_cast<int>(m_occupation_grid[0].size()); }
+    int row_count() { return static_cast<int>(m_occupation_grid.size()); }
+    bool is_occupied(int column_index, int row_index);
+
+private:
+    Vector<Vector<bool>> m_occupation_grid;
+};
+
 }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -22,6 +22,9 @@ public:
 
 private:
     float m_automatic_content_height { 0 };
+    bool is_auto_positioned_row(CSS::GridTrackPlacement const&, CSS::GridTrackPlacement const&) const;
+    bool is_auto_positioned_column(CSS::GridTrackPlacement const&, CSS::GridTrackPlacement const&) const;
+    bool is_auto_positioned_track(CSS::GridTrackPlacement const&, CSS::GridTrackPlacement const&) const;
 };
 
 }


### PR DESCRIPTION
This improves (if not fixes) the implementation of grid-track span. I had misunderstood what the CSS value of `grid-column: span 3 / 3;` meant, but now it's fixed.