### PR TITLE
LibWeb: Compute values of shorthand properties from longhands

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -38,10 +38,7 @@ void StyleProperties::set_property(CSS::PropertyID id, NonnullRefPtr<StyleValue>
 
 NonnullRefPtr<StyleValue> StyleProperties::property(CSS::PropertyID property_id) const
 {
-    auto value = m_property_values[to_underlying(property_id)];
-    // By the time we call this method, all properties have values assigned.
-    VERIFY(!value.is_null());
-    return value.release_nonnull();
+    return property_computed_value(property_id, m_property_values);
 }
 
 Length StyleProperties::length_or_fallback(CSS::PropertyID id, Length const& fallback) const


### PR DESCRIPTION
Previously we would crash on shorthand properties for elements without layout nodes, because those properties are not defaulted (which is in line with the CSS specification). However, even though they are not defaulted, they should still have valid computed values. This commit makes it so that valid computed values are returned for shorthand properties by creating a StyleValueList from all longhands the of shorthand.