### PR TITLE
Everywhere: Move misplaced includes

### DIFF
--- a/Kernel/Arch/SafeMem.h
+++ b/Kernel/Arch/SafeMem.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <AK/Atomic.h>
 #include <AK/Optional.h>
 #include <AK/Types.h>
-
-#pragma once
 
 namespace Kernel {
 

--- a/Kernel/Storage/ATA/Definitions.h
+++ b/Kernel/Storage/ATA/Definitions.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Types.h>
+
 namespace Kernel::ATA {
 
 enum DeviceSignature : u32 {
@@ -88,8 +90,6 @@ enum DeviceSignature : u32 {
 #define ATA_CTL_DEVADDRESS 0x01
 
 #define ATA_CAP_LBA 0x200
-
-#include <AK/Types.h>
 
 namespace Kernel {
 struct [[gnu::packed]] ATAIdentifyBlock {

--- a/Userland/Demos/CatDog/CatDog.h
+++ b/Userland/Demos/CatDog/CatDog.h
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefPtr.h>
 #include <LibCore/ElapsedTimer.h>
@@ -14,8 +16,6 @@
 #include <LibGUI/Widget.h>
 #include <LibGfx/Bitmap.h>
 #include <unistd.h>
-
-#pragma once
 
 class CatDog final : public GUI::Widget
     , GUI::MouseTracker {

--- a/Userland/Libraries/LibC/bits/stdio_file_implementation.h
+++ b/Userland/Libraries/LibC/bits/stdio_file_implementation.h
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <AK/Array.h>
 #include <AK/IntrusiveList.h>
 #include <AK/Types.h>
@@ -12,8 +14,6 @@
 #include <LibC/bits/wchar.h>
 #include <pthread.h>
 #include <sys/types.h>
-
-#pragma once
 
 struct FILE {
 public:

--- a/Userland/Libraries/LibC/byteswap.h
+++ b/Userland/Libraries/LibC/byteswap.h
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <sys/cdefs.h>
-
 #pragma once
+
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/limits.h
+++ b/Userland/Libraries/LibC/limits.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/sys/limits.h>
+#include <bits/posix1_lim.h>
 #include <bits/stdint.h>
 #include <bits/wchar.h>
 
@@ -92,5 +93,3 @@
 #define LINK_MAX 4096
 
 #define TZNAME_MAX 64
-
-#include <bits/posix1_lim.h>

--- a/Userland/Libraries/LibCodeComprehension/Types.h
+++ b/Userland/Libraries/LibCodeComprehension/Types.h
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/String.h>
-
 #pragma once
+
+#include <AK/String.h>
 
 namespace CodeComprehension {
 

--- a/Userland/Libraries/LibCore/UmaskScope.h
+++ b/Userland/Libraries/LibCore/UmaskScope.h
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <sys/stat.h>
 #include <sys/types.h>
-
-#pragma once
 
 namespace Core {
 

--- a/Userland/Libraries/LibGPU/Config.h
+++ b/Userland/Libraries/LibGPU/Config.h
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Types.h>
-
 #pragma once
+
+#include <AK/Types.h>
 
 namespace GPU {
 

--- a/Userland/Services/LoginServer/LoginWindow.h
+++ b/Userland/Services/LoginServer/LoginWindow.h
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <LibGUI/Button.h>
 #include <LibGUI/ImageWidget.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Window.h>
-
-#pragma once
 
 class LoginWindow final : public GUI::Window {
     C_OBJECT(LoginWindow);

--- a/Userland/Services/SpiceAgent/ConnectionToClipboardServer.h
+++ b/Userland/Services/SpiceAgent/ConnectionToClipboardServer.h
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <AK/Function.h>
 #include <Clipboard/ClipboardClientEndpoint.h>
 #include <Clipboard/ClipboardServerEndpoint.h>
 #include <LibGfx/Bitmap.h>
 #include <LibIPC/ConnectionToServer.h>
-
-#pragma once
 
 class ConnectionToClipboardServer final
     : public IPC::ConnectionToServer<ClipboardClientEndpoint, ClipboardServerEndpoint>

--- a/Userland/Services/SpiceAgent/SpiceAgent.h
+++ b/Userland/Services/SpiceAgent/SpiceAgent.h
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include "ConnectionToClipboardServer.h"
 #include <AK/ByteBuffer.h>
 #include <AK/Vector.h>
 #include <LibCore/Notifier.h>
-
-#pragma once
 
 class SpiceAgent {
 public:


### PR DESCRIPTION
In my never-ending quest to clean up our headers, this PR moves some misplaced `#pragma once`s and `#include`s.

In case you're wondering why I care so much about clean header files: The cleaner they get, the easier it becomes to do some analysis and reduce the overall compilation times. This isn't Feng-Shui programming (although arguably a weird #include could indeed lead to some weird problems), but rather preparation for future PRs that improve compilation times. (A PR that removes cycles and automatically prevents them is already in the pipeline; and I have more ideas that I'm actively working on.)