### PR TITLE
Everywhere: Remove even more cyclic #include-s, add pre-commit hook to prevent more cycles

### DIFF
--- a/AK/EnumBits.h
+++ b/AK/EnumBits.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "AK/StdLibExtras.h"
+#include <AK/StdLibExtras.h>
 
 // Enables bitwise operators for the specified Enum type.
 //

--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Concepts.h>
-#include <AK/Format.h>
 #include <AK/IntegralMath.h>
 #include <AK/NumericLimits.h>
 #include <AK/Types.h>

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "AK/StringUtils.h"
 #include <AK/String.h>
+#include <AK/StringUtils.h>
 
 namespace AK {
 

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/Array.h>
 #include <AK/Assertions.h>
+#include <AK/Forward.h>
 #include <AK/Iterator.h>
 #include <AK/TypedTransfer.h>
 #include <AK/Types.h>
@@ -30,21 +30,6 @@ public:
     template<size_t size>
     ALWAYS_INLINE constexpr Span(T (&values)[size])
         : m_values(values)
-        , m_size(size)
-    {
-    }
-
-    template<size_t size>
-    ALWAYS_INLINE constexpr Span(Array<T, size>& array)
-        : m_values(array.data())
-        , m_size(size)
-    {
-    }
-
-    template<size_t size>
-    requires(IsConst<T>)
-        ALWAYS_INLINE constexpr Span(Array<T, size> const& array)
-        : m_values(array.data())
         , m_size(size)
     {
     }

--- a/AK/UBSanitizer.h
+++ b/AK/UBSanitizer.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "AK/Noncopyable.h"
-#include "AK/StdLibExtras.h"
 #include <AK/Atomic.h>
+#include <AK/Noncopyable.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
 namespace AK::UBSanitizer {

--- a/Kernel/API/POSIX/sys/types.h
+++ b/Kernel/API/POSIX/sys/types.h
@@ -6,10 +6,9 @@
 
 #pragma once
 
-#ifndef KERNEL
-#    include <sys/cdefs.h>
-#    include <sys/types.h>
-#endif
+#include <bits/stdint.h>
+#include <stddef.h>
+#include <sys/cdefs.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/Kernel/Bus/USB/USBConfiguration.cpp
+++ b/Kernel/Bus/USB/USBConfiguration.cpp
@@ -7,10 +7,18 @@
 #include <AK/FixedArray.h>
 #include <Kernel/Bus/USB/USBClasses.h>
 #include <Kernel/Bus/USB/USBConfiguration.h>
+#include <Kernel/Bus/USB/USBDevice.h>
 #include <Kernel/Bus/USB/USBInterface.h>
 #include <Kernel/Bus/USB/USBRequest.h>
 
 namespace Kernel::USB {
+
+USBConfiguration::USBConfiguration(Device& device, USBConfigurationDescriptor const descriptor)
+    : m_device(device)
+    , m_descriptor(descriptor)
+{
+    m_interfaces.ensure_capacity(descriptor.number_of_interfaces);
+}
 
 ErrorOr<void> USBConfiguration::enumerate_interfaces()
 {

--- a/Kernel/Bus/USB/USBConfiguration.h
+++ b/Kernel/Bus/USB/USBConfiguration.h
@@ -8,7 +8,6 @@
 
 #include <AK/Vector.h>
 #include <Kernel/Bus/USB/USBDescriptors.h>
-#include <Kernel/Bus/USB/USBDevice.h>
 #include <Kernel/Bus/USB/USBInterface.h>
 
 namespace Kernel::USB {
@@ -18,12 +17,7 @@ class Device;
 class USBConfiguration {
 public:
     USBConfiguration() = delete;
-    USBConfiguration(Device& device, USBConfigurationDescriptor const descriptor)
-        : m_device(device)
-        , m_descriptor(descriptor)
-    {
-        m_interfaces.ensure_capacity(descriptor.number_of_interfaces);
-    }
+    USBConfiguration(Device& device, USBConfigurationDescriptor const descriptor);
 
     Device const& device() const { return m_device; }
     USBConfigurationDescriptor const& descriptor() const { return m_descriptor; }

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -7,6 +7,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
+#include <Kernel/Bus/USB/USBConfiguration.h>
 #include <Kernel/Bus/USB/USBController.h>
 #include <Kernel/Bus/USB/USBDescriptors.h>
 #include <Kernel/Bus/USB/USBDevice.h>

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -9,7 +9,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
-#include <Kernel/Bus/USB/USBConfiguration.h>
+#include <Kernel/Bus/USB/USBDescriptors.h>
 #include <Kernel/Bus/USB/USBPipe.h>
 
 namespace Kernel {

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/DeviceInformation.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/DeviceInformation.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/JsonArraySerializer.h>
 #include <AK/JsonObjectSerializer.h>
+#include <Kernel/Bus/USB/USBConfiguration.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/USB/DeviceInformation.h>
 
 namespace Kernel {

--- a/Kernel/Storage/ATA/AHCI/Controller.cpp
+++ b/Kernel/Storage/ATA/AHCI/Controller.cpp
@@ -14,6 +14,7 @@
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Storage/ATA/AHCI/Controller.h>
 #include <Kernel/Storage/ATA/AHCI/InterruptHandler.h>
+#include <Kernel/Storage/ATA/AHCI/Port.h>
 
 namespace Kernel {
 

--- a/Kernel/Storage/ATA/AHCI/InterruptHandler.h
+++ b/Kernel/Storage/ATA/AHCI/InterruptHandler.h
@@ -16,7 +16,6 @@
 #include <Kernel/Random.h>
 #include <Kernel/Sections.h>
 #include <Kernel/Storage/ATA/AHCI/Controller.h>
-#include <Kernel/Storage/ATA/AHCI/Port.h>
 #include <Kernel/Storage/StorageDevice.h>
 #include <Kernel/WaitQueue.h>
 
@@ -25,7 +24,6 @@ namespace Kernel {
 class AsyncBlockDeviceRequest;
 
 class AHCIController;
-class AHCIPort;
 class AHCIInterruptHandler final : public IRQHandler {
     friend class AHCIController;
 

--- a/Kernel/Storage/ATA/AHCI/Port.cpp
+++ b/Kernel/Storage/ATA/AHCI/Port.cpp
@@ -8,6 +8,7 @@
 // please look at Documentation/Kernel/AHCILocking.md
 
 #include <AK/Atomic.h>
+#include <Kernel/Arch/x86/IO.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Memory/ScatterGatherList.h>

--- a/Kernel/Storage/ATA/AHCI/Port.h
+++ b/Kernel/Storage/ATA/AHCI/Port.h
@@ -21,8 +21,8 @@
 #include <Kernel/PhysicalAddress.h>
 #include <Kernel/Random.h>
 #include <Kernel/Sections.h>
+#include <Kernel/Storage/ATA/AHCI/Controller.h>
 #include <Kernel/Storage/ATA/AHCI/Definitions.h>
-#include <Kernel/Storage/ATA/AHCI/InterruptHandler.h>
 #include <Kernel/Storage/ATA/ATADevice.h>
 #include <Kernel/Storage/ATA/Definitions.h>
 #include <Kernel/WaitQueue.h>
@@ -31,7 +31,6 @@ namespace Kernel {
 
 class AsyncBlockDeviceRequest;
 
-class AHCIInterruptHandler;
 class AHCIPort
     : public AtomicRefCounted<AHCIPort>
     , public LockWeakable<AHCIPort> {

--- a/Kernel/Storage/NVMe/NVMeNameSpace.h
+++ b/Kernel/Storage/NVMe/NVMeNameSpace.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "AK/kmalloc.h"
 #include <AK/OwnPtr.h>
 #include <AK/Types.h>
+#include <AK/kmalloc.h>
 #include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Library/NonnullLockRefPtr.h>
 #include <Kernel/Library/NonnullLockRefPtrVector.h>

--- a/Meta/check-headers-acyclic.py
+++ b/Meta/check-headers-acyclic.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import subprocess
+import sys
+
+ANY_INCLUDE_RE = re.compile('^.*#[ \t]*include(?![A-Za-z]).*\n?$')
+SYSTEM_INCLUDE_RE = re.compile('^.*#[ \t]*include *<([^>]+)> *(?:/[*/].*)?\n?$')
+LOCAL_INCLUDE_RE = re.compile('^.*#[ \t]*include *"([^>]+)" *(?:/[*/].*)?\n?$')
+SHOW_TIMING = False
+
+# These are already very extensive. The only thing missing are the Toolchain includes.
+INCLUDE_LOOKUP_PATHS_FORMAT = [
+    '',  # For things that specify the full path, e.g. <AK/String.h>
+    'Userland/Libraries/',
+    'Userland/Libraries/LibC/',
+    'Userland/Libraries/LibCrypt/',
+    'Userland/Libraries/LibSystem/',
+    'Userland/Services/',
+    'Userland/',
+    'Build/{}/',
+    'Build/{}/Userland/Services/',
+    'Build/{}/Userland/Libraries/',
+    'Build/{}/Userland/',
+]
+
+# These system headers are too hard to find, and they're irrelevant for the purposes of this script anyway.
+KNOWN_GOOD_SYSTEM_HEADERS = {
+    'bits/endian.h',
+    'cxxabi.h',
+    'initializer_list',
+    'libkern/OSByteOrder.h',
+    'machine/endian.h',
+    'malloc/malloc.h',
+    'new',
+    'sanitizer/asan_interface.h',
+    'stdbool.h',
+    'sys/random.h',
+    'typeinfo',
+    'utility',
+    'xmmintrin.h',
+}
+
+
+def get_headers_here():
+    # FIXME: Really test *ALL* other headers!
+    result = subprocess.run(['git', 'ls-files', '*.h'], check=True, capture_output=True, text=True)
+    assert result.stderr == ''
+    output = result.stdout.split('\n')
+    assert output[-1] == ''  # Trailing newline
+    assert len(output) > 500, 'There should be well over a thousand headers, not only {}?!'.format(len(output))
+    return output[:-1]
+
+
+def find_system_include(arch, include_filename, magic=[]):
+    if not magic:
+        magic.extend([fmt.format(arch) for fmt in INCLUDE_LOOKUP_PATHS_FORMAT])
+
+    for possible_prefix in magic:
+        possible_full_filename = possible_prefix + include_filename
+        if os.path.exists(possible_full_filename):
+            return possible_full_filename
+    return None
+
+
+def resolve_local_path(filename, relative_path):
+    filename = os.path.dirname(filename)
+
+    # Collapse '..' into the path of `filename`.
+    # Note that this is currently not used, and doesn't work in some edgecases.
+    while relative_path.startswith('../') and filename:
+        relative_path = relative_path[len('../'):]
+        filename = os.path.dirname(filename)
+
+    if not filename:
+        return relative_path
+
+    return os.path.join(filename, relative_path)
+
+
+def get_dependencies(arch, filename):
+    includes = []
+    # FIXME: Use the readlines() iterator, that should do much less copying, and can also adapt to disk speed I guess
+    with open(filename, 'r') as fp:
+        for line_number, line in enumerate(fp):
+            # Ignore any includes after the 80th line.
+            # Scanning for #include preprocessor commands makes up the majority of the running time of this script.
+            # Only two headers have any includes beyond this point:
+            # - AK/Platform.h, which will be irrelevant for the purposes of this script, as it includes system-headers.
+            # - Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h, which is an abomination, but whose includes
+            #   mostly have the same dependencies anyway, so if any cycles ever arise we will catch them anyway.
+            # So by using this shortcut, we don't lose much. And we gain a lot:
+            # - At the time of writing, all headers together have 226236 lines that would need to be checked.
+            #   Running a string test 226236 times takes a bunch of time.
+            # - Ignoring everything after the 80th line cuts this down to 129758 lines
+            # For reference, the #include on the highest-numbered-line except the above files is in StdLibExtras.h,
+            # line 59 at the time of writing, and it is `#include <utility>`, so arguably also not interesting.
+            # Thus, with 80 we have more than sufficient safety margin to catch all cycles that we might introduce,
+            # and can halve the amount of data we even have to consider.
+            if line_number > 80:
+                break
+            # Do a string search first.
+            # This is faster than even a compiled regex. Timing showed that the compiled regex test makes up the
+            # majority of the time of this script on a machine with fast file access. Doing this pre-check speeds up
+            # the parsing step from about 34.54 µs per file on avg to about 25.55 µs per file on avg.
+            if 'include' not in line:
+                continue
+            # So the current line contains the sequence "include", but it could still be in a comment or a function
+            # name or otherwise unrelated. Is this an include at all?
+            if not ANY_INCLUDE_RE.fullmatch(line):
+                continue
+            system_match = SYSTEM_INCLUDE_RE.fullmatch(line)
+            local_match = LOCAL_INCLUDE_RE.fullmatch(line)
+            if system_match:
+                include_string = system_match.groups()[0]
+                if include_string in KNOWN_GOOD_SYSTEM_HEADERS:
+                    # This include line is irrelevant anyway.
+                    # Discard it immediately.
+                    continue
+                include_filename = find_system_include(arch, include_string)
+                if include_filename is None:
+                    print(f'WARNING: Could not find include <{include_string}> from {filename}!', file=sys.stderr)
+                    continue
+            elif local_match:
+                include_string = local_match.groups()[0]
+                include_filename = resolve_local_path(filename, local_match.groups()[0])
+                if not os.path.exists(include_filename):
+                    print(f'WARNING: Local include "{include_string}" from {filename} does not exist as a file!',
+                          file=sys.stderr)
+                    continue
+            else:
+                print(f'WARNING: Could not parse include line in {filename}: >>>{line}<<<', file=sys.stderr)
+                continue
+            includes.append(include_filename)
+
+    return includes
+
+
+class TarjanNode:
+    def __init__(self, filename):
+        self.filename = filename
+        self.index = None
+        self.lowlink = None
+        self.onStack = False
+
+
+class TarjanState:
+    def __init__(self, deps):
+        self.deps = deps
+        self.stack = []
+        self.next_index = 0  # Called 'index' on Wikipedia
+        self.lowlink = None
+        self.on_stack = False
+        self.nodes = dict()  # Filename to TarjanNode
+        self.components = []
+
+    def neighbors(self, node):
+        for neighbor_name in self.deps[node.filename]:
+            neighbor = self.nodes.get(neighbor_name)
+            if neighbor is None:
+                # neighbor_name either:
+                # - doesn't exist (then we already complained),
+                # - exists but was not scanned (then it doesn't matter),
+                # - or was scanned but contains no includes (then it can be safely ignored).
+                continue
+            yield neighbor
+
+    def push(self, node):
+        assert node.index is None
+        node.index = self.next_index
+        node.lowlink = self.next_index
+        self.next_index += 1
+        self.stack.append(node)
+        node.on_stack = True
+
+    def pop(self, node):
+        # If v is a root node, pop the stack and generate an SCC
+        if node.lowlink != node.index:
+            return
+        # Start a new strongly connected component
+        component = set()
+        while True:
+            subnode = self.stack.pop()
+            subnode.on_stack = False
+            component.add(subnode.filename)
+            if subnode == node:
+                break
+        if len(component) > 1:
+            self.components.append(component)
+
+
+# This implements Tarjan's strongly connected components algorithm. Heavily inspired by:
+# https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm#The_algorithm_in_pseudocode
+# Arguably, this code might be licensed under CC-BY-SA-3.0, but this license is therefore satisfied.
+def tarjan_recurse(state, node):
+    state.push(node)
+
+    # Consider successors of node
+    for successor in state.neighbors(node):
+        if successor.index is None:
+            # Successor has not yet been visited; recurse on it
+            # Theoretically, python runs into trouble at pretty much exactly 1000 stack frames.
+            # Practically, if any inclusion chain comes anywhere near this number, we are doomed anyway.
+            tarjan_recurse(state, successor)
+            node.lowlink = min(node.lowlink, successor.lowlink)
+        elif successor.on_stack:
+            # Successor is in stack and hence in the current SCC
+            # Note: The next line may look odd - but is correct.
+            node.lowlink = min(node.lowlink, successor.index)
+
+    state.pop(node)
+
+
+def find_nontrivial_connected_components(deps):
+    state = TarjanState(deps)
+    for key, value_list in deps.items():
+        if not value_list:
+            # This header does not include anything, therefore it cannot be part of a cycle anyway.
+            continue
+        assert key not in state.nodes
+        state.nodes[key] = TarjanNode(key)
+
+    # Tarjan's strongly connected components algorithm starts here.
+    for node in state.nodes.values():
+        if node.index is None:
+            tarjan_recurse(state, node)
+
+    return state.components
+
+
+def print_components(components, deps):
+    print('digraph G {')
+    for component in components:
+        any_filename = list(component)[0]
+        print(f'  // Cycle or component around {any_filename}')
+        for filename in component:
+            for neighbor in deps[filename]:
+                if neighbor not in component:
+                    continue
+                print(f'  "{filename}" -> "{neighbor}";')
+    print('}')
+
+
+def run(arch):
+    if SHOW_TIMING:
+        import time
+        time_begin = time.time_ns()
+    headers_list = get_headers_here()
+    if SHOW_TIMING:
+        time_listed = time.time_ns()
+    deps = {header_name: get_dependencies(arch, header_name) for header_name in headers_list}
+    if SHOW_TIMING:
+        time_deps_read = time.time_ns()
+    nontrivial_connected_components = find_nontrivial_connected_components(deps)
+    if SHOW_TIMING:
+        time_resolved = time.time_ns()
+        print(f'// Took {(time_listed - time_begin) / 1000000} + {(time_deps_read - time_listed) / 1000000} + '
+              f'{(time_resolved - time_deps_read) / 1000000} = {(time_resolved - time_begin) / 1000000} '
+              ' milliseconds to compute everything')
+        print(f'// The second number splits into reading and parsing phases for each of the {len(deps)} headers.')
+
+    if not nontrivial_connected_components:
+        # Intentionally not to stderr
+        num_deps = sum(len(d) for d in deps.values())
+        print(f'// No cycles detected in {len(headers_list)} files ({num_deps} successfully-resolved includes)')
+        return
+
+    num_cyclic_files = sum(len(cc) for cc in nontrivial_connected_components)
+    print(f'WARNING: Found cycles involving {num_cyclic_files} files! (Fewer is better)', file=sys.stderr)
+    print(f'These cycles can be split into {len(nontrivial_connected_components)} components. (More is better.)',
+          file=sys.stderr)
+
+    print_components(nontrivial_connected_components, deps)
+
+    print('// You can generate a fancy diagram like this:')
+    print(f'// {" ".join(sys.argv)} > cycles.gv || dot cycles.gv -Tpng > cycles.png')
+    exit(1)  # Fail pre-commit hook
+
+
+def guess_architecture():
+    matches = []
+    for arch in 'aarch64 i686 x86_64 lagom'.split():
+        # build.ninja is updated on basically any build command.
+        # Hence, use this file to guess which directory is the most recent one:
+        try:
+            mtime = os.path.getmtime('Build/{}/build.ninja'.format(arch))
+        except FileNotFoundError:
+            pass  # Oh well, didn't work
+        else:
+            matches.append((arch, mtime))
+
+    if not matches:
+        return 'UNKNOWN'
+
+    # Choose the most recently used build directory:
+    matches.sort(reverse=True, key=lambda e: e[1])
+    return matches[0][0]
+
+
+if __name__ == '__main__':
+    os.chdir(os.path.dirname(__file__) + "/..")
+    if 'SERENITY_ARCH' in os.environ:
+        run(os.environ['SERENITY_ARCH'])
+    else:
+        # Try to guess the architecture. We need the architecture to find generated headers,
+        # which are unlikely to be included in a cycle, so it is not too bad if we guess wrong.
+        run(guess_architecture())

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -23,6 +23,7 @@ for cmd in \
         Meta/check-ak-test-files.sh \
         Meta/check-debug-flags.sh \
         Meta/check-emoji.py \
+        Meta/check-headers-acyclic.py \
         Meta/check-markdown.sh \
         Meta/check-newlines-at-eof.py \
         Meta/check-png-sizes.sh \

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "LibGUI/CheckBox.h"
 #include <LibGUI/Button.h>
+#include <LibGUI/CheckBox.h>
 #include <LibGUI/ListView.h>
 #include <LibGUI/SettingsWindow.h>
 

--- a/Userland/DevTools/HackStudio/ProjectBuilder.h
+++ b/Userland/DevTools/HackStudio/ProjectBuilder.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "AK/Error.h"
 #include "Project.h"
 #include "TerminalWrapper.h"
+#include <AK/Error.h>
 #include <AK/Noncopyable.h>
 #include <LibCore/TempFile.h>
 

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.h
@@ -6,13 +6,13 @@
 
 #pragma once
 
-#include "AK/Debug.h"
 #include "Emulator.h"
 #include "Region.h"
 #include "SoftFPU.h"
 #include "SoftVPU.h"
 #include "ValueWithShadow.h"
 #include <AK/ByteReader.h>
+#include <AK/Debug.h>
 #include <LibX86/Instruction.h>
 #include <LibX86/Interpreter.h>
 

--- a/Userland/Libraries/LibC/sys/types.h
+++ b/Userland/Libraries/LibC/sys/types.h
@@ -6,8 +6,4 @@
 
 #pragma once
 
-#include <bits/stdint.h>
-#include <stddef.h>
-#include <sys/cdefs.h>
-
 #include <Kernel/API/POSIX/sys/types.h>

--- a/Userland/Libraries/LibLocale/PluralRules.cpp
+++ b/Userland/Libraries/LibLocale/PluralRules.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <LibLocale/PluralRules.h>
 
 namespace Locale {

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/Forward.h>
 #include <AK/StringView.h>
 

--- a/Userland/Services/AudioServer/FadingProperty.h
+++ b/Userland/Services/AudioServer/FadingProperty.h
@@ -6,7 +6,8 @@
 
 #pragma once
 
-#include "Mixer.h"
+#include <AK/StdLibExtras.h>
+
 namespace AudioServer {
 
 // This is in buffer counts.

--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>
+#include <WebContent/ConnectionFromClient.h>
 #include <WebContent/ConsoleGlobalObject.h>
 
 namespace WebContent {

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -8,9 +8,10 @@
 
 #pragma once
 
-#include "ConnectionFromClient.h"
+#include <AK/WeakPtr.h>
 #include <LibJS/Console.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Heap/Handle.h>
 #include <LibWeb/Forward.h>
 #include <WebContent/Forward.h>
 

--- a/Userland/Services/WindowServer/WMConnectionFromClient.h
+++ b/Userland/Services/WindowServer/WMConnectionFromClient.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "AK/NonnullRefPtr.h"
 #include <AK/HashMap.h>
+#include <AK/NonnullRefPtr.h>
 #include <LibIPC/ConnectionFromClient.h>
 #include <WindowServer/WindowManagerClientEndpoint.h>
 #include <WindowServer/WindowManagerServerEndpoint.h>


### PR DESCRIPTION
This continues the removal of cyclic headers, and adds a pre-commit hook to prevent any future cycles. This script does cause and increase of the pre-commit running time, by about 110ms. See #15281 , in which I decrease the pre-commit running time by about 900ms, so clearly this shouldn't be a problem.

In case you're wondering why I care so much about clean header files: The cleaner they get, the easier it becomes to do some analysis and reduce the overall compilation times. This isn't Feng-Shui programming, but rather a small direct reduction of compilation times in theory, and preparation for future PRs that improve compilation times further. Also, cyclic headers are a real beast, and resolving them leads to headaches. In fact, they already did: https://github.com/SerenityOS/serenity/pull/15236

Also, see https://github.com/SerenityOS/serenity/pull/15235 where a bunch of more cycles got removed.