### PR TITLE
GamesSettings: Always ensure last card back selected is saved

### DIFF
--- a/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
@@ -43,12 +43,16 @@ CardSettingsWidget::CardSettingsWidget()
     if (!set_card_back_image_path(Config::read_string("Games"sv, "Cards"sv, "CardBackImage"sv)))
         set_card_back_image_path(default_card_back_image_path);
     m_card_back_image_view->on_selection_change = [&]() {
-        if (m_card_back_image_view->selection().is_empty())
+        auto& card_back_selection = m_card_back_image_view->selection();
+        if (card_back_selection.is_empty())
             return;
+        m_last_selected_card_back = card_back_selection.first();
         set_modified(true);
         Cards::CardPainter::the().set_background_image_path(card_back_image_path());
         m_preview_card_back->update();
     };
+
+    m_last_selected_card_back = m_card_back_image_view->selection().first();
 }
 
 void CardSettingsWidget::apply_settings()
@@ -84,6 +88,9 @@ bool CardSettingsWidget::set_card_back_image_path(String const& path)
 
 String CardSettingsWidget::card_back_image_path() const
 {
-    auto card_back_image_index = m_card_back_image_view->selection().first();
+    auto& card_back_selection = m_card_back_image_view->selection();
+    GUI::ModelIndex card_back_image_index = m_last_selected_card_back;
+    if (!card_back_selection.is_empty())
+        card_back_image_index = card_back_selection.first();
     return static_cast<GUI::FileSystemModel const*>(m_card_back_image_view->model())->full_path(card_back_image_index);
 }

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.h
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.h
@@ -10,6 +10,7 @@
 #include <LibGUI/Frame.h>
 #include <LibGUI/IconView.h>
 #include <LibGUI/ImageWidget.h>
+#include <LibGUI/ModelIndex.h>
 #include <LibGUI/SettingsWindow.h>
 
 class CardSettingsWidget final : public GUI::SettingsWindow::Tab {
@@ -34,4 +35,6 @@ private:
 
     RefPtr<GUI::ColorInput> m_background_color_input;
     RefPtr<GUI::IconView> m_card_back_image_view;
+
+    GUI::ModelIndex m_last_selected_card_back;
 };


### PR DESCRIPTION
This is my first contribution to SerenityOS. This fixes a small issue in GamesSettings where deselecting a card back and saving will cause the card back setting to save without a filename. The dialogue box will use the last card back selected by the user (and visible as the selection) when either Apply or OK is selected.