### PR TITLE
Kernel: Remove unused extern defined linker variables

### DIFF
--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -33,13 +33,6 @@
 #include <Kernel/Arch/x86/ISRStubs.h>
 #include <Kernel/Arch/x86/TrapFrame.h>
 
-extern FlatPtr start_of_unmap_after_init;
-extern FlatPtr end_of_unmap_after_init;
-extern FlatPtr start_of_ro_after_init;
-extern FlatPtr end_of_ro_after_init;
-extern FlatPtr start_of_kernel_ksyms;
-extern FlatPtr end_of_kernel_ksyms;
-
 namespace Kernel {
 
 READONLY_AFTER_INIT static DescriptorTablePointer s_idtr;


### PR DESCRIPTION
These are left over of previously used kernel variables that seems to be abstracted somewhere else now.