### PR TITLE
LibCpp: Add .clang-format to disable clang-format for the LibCpp Tests

### DIFF
--- a/Userland/Libraries/LibCpp/Tests/.clang-format
+++ b/Userland/Libraries/LibCpp/Tests/.clang-format
@@ -1,0 +1,4 @@
+# These are all test files, don't format them, as they maybe
+# intentionally miss-formatted.
+DisableFormat: true
+SortIncludes: Never


### PR DESCRIPTION
We don't format these files, as they might have been intentionally formatted differently from the normal serenity style for testing.

So ignore them from our global style, so clang-format doesn't pick them up by accident.