### PR TITLE
AK+LibJS: Handle NaN-boxing pointers on AArch64

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -18,6 +18,12 @@
 #    define AK_ARCH_AARCH64 1
 #endif
 
+#if (defined(__SIZEOF_POINTER__) && __SIZEOF_POINTER__ == 8) || defined(_WIN64)
+#    define AK_ARCH_64_BIT
+#else
+#    define AK_ARCH_32_BIT
+#endif
+
 #if defined(__APPLE__) && defined(__MACH__)
 #    define AK_OS_MACOS
 #    define AK_OS_BSD_GENERIC

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -142,7 +142,7 @@ __attribute__((no_sanitize("address"))) void Heap::gather_conservative_roots(Has
             // match any pointer-backed tag, in that case we have to extract the pointer to its
             // canonical form and add that as a possible pointer.
             if ((data & SHIFTED_IS_CELL_PATTERN) == SHIFTED_IS_CELL_PATTERN)
-                possible_pointers.set((u64)(((i64)data << 16) >> 16));
+                possible_pointers.set(Value::extract_pointer_bits(data));
             else
                 possible_pointers.set(data);
         } else {


### PR DESCRIPTION
JS::Value stores 48 bit pointers to separately allocated objects in its payload. On x86-64, canonical addresses have their top 16 bits set to the same value as bit 47, effectively meaning that the value has to be sign-extended to get the pointer. AArch64, however, expects the topmost bits to be all zeros.

This commit gates sign extension behind `#if ARCH(X86_64)`, and adds an `#error` for unsupported architectures, so that we do not forget to choose the correct behavior when porting to a new architecture.

Fixes #15290
Fixes SerenityOS/ladybird#56

---
~~This is a draft for now, as I haven't  tested this yet on my AArch64 Ubuntu VM.~~

Ladybird runs and `test-js` now passes on AArch64 linux!