### PR TITLE
Lagom: Win32 support baby steps

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -33,6 +33,10 @@
 #    define AK_OS_BSD_GENERIC
 #endif
 
+#if defined(_WIN32) || defined(_WIN64)
+#    define AK_OS_WINDOWS
+#endif
+
 // FIXME: Remove clang-format suppression after https://github.com/llvm/llvm-project/issues/56602 resolved
 // clang-format off
 #if defined(__ANDROID__)
@@ -127,7 +131,11 @@ extern "C" {
 #    endif
 #endif
 
-#ifdef AK_OS_BSD_GENERIC
+#if defined(AK_OS_WINDOWS)
+#    define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
+#endif
+
+#if defined(AK_OS_BSD_GENERIC)
 #    define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
 #    define CLOCK_REALTIME_COARSE CLOCK_REALTIME
 #endif

--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -463,7 +463,14 @@ template<typename T, typename V>
 struct VaArgNextArgument {
     ALWAYS_INLINE T operator()(V ap) const
     {
+#ifdef AK_OS_WINDOWS
+        // GCC on msys2 complains about the type of ap,
+        // so let's force the compiler to belive its a
+        // va_list.
+        return va_arg((va_list&)ap, T);
+#else
         return va_arg(ap, T);
+#endif
     }
 };
 

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -21,6 +21,11 @@
 #    include <sys/random.h>
 #endif
 
+#if defined(AK_OS_WINDOWS)
+#    include <random>
+#    include <unistd.h>
+#endif
+
 namespace AK {
 
 inline void fill_with_random([[maybe_unused]] void* buffer, [[maybe_unused]] size_t length)
@@ -30,6 +35,11 @@ inline void fill_with_random([[maybe_unused]] void* buffer, [[maybe_unused]] siz
 #elif defined(OSS_FUZZ)
 #elif defined(__unix__) or defined(AK_OS_MACOS)
     [[maybe_unused]] int rc = getentropy(buffer, length);
+#else
+    char* char_buffer = static_cast<char*>(buffer);
+    for (size_t i = 0; i < length; i++) {
+        char_buffer[i] = std::rand();
+    }
 #endif
 }
 

--- a/AK/Singleton.h
+++ b/AK/Singleton.h
@@ -13,6 +13,12 @@
 #    include <Kernel/Arch/Processor.h>
 #    include <Kernel/Arch/ScopedCritical.h>
 #    include <Kernel/Locking/SpinlockProtected.h>
+#elif defined(AK_OS_WINDOWS)
+// Forward declare to avoid pulling Windows.h into every file in existence.
+extern "C" __declspec(dllimport) void __stdcall Sleep(unsigned long);
+#    ifndef sched_yield
+#        define sched_yield() Sleep(0)
+#    endif
 #else
 #    include <sched.h>
 #endif

--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -179,7 +179,10 @@ timespec Time::to_timespec() const
 timeval Time::to_timeval() const
 {
     VERIFY(m_nanoseconds < 1'000'000'000);
-    return { static_cast<time_t>(m_seconds), static_cast<suseconds_t>(m_nanoseconds) / 1000 };
+    // This is done because winsock defines tv_sec and tv_usec as long, and Linux64 as long int.
+    using sec_type = decltype(declval<timeval>().tv_sec);
+    using usec_type = decltype(declval<timeval>().tv_usec);
+    return { static_cast<sec_type>(m_seconds), static_cast<usec_type>(m_nanoseconds) / 1000 };
 }
 
 Time Time::operator+(Time const& other) const

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -16,6 +16,10 @@
 struct timeval;
 struct timespec;
 
+#if defined(AK_OS_WINDOWS)
+#    include <time.h>
+#endif
+
 namespace AK {
 
 // Concept to detect types which look like timespec without requiring the type.

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -50,6 +50,10 @@ using pid_t = int;
 using __ptrdiff_t = __PTRDIFF_TYPE__;
 #    endif
 
+#    if defined(AK_OS_WINDOWS)
+using ssize_t = MakeSigned<size_t>;
+using mode_t = unsigned short;
+#    endif
 #endif
 
 using FlatPtr = Conditional<sizeof(void*) == 8, u64, u32>;

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -265,6 +265,12 @@ if (ANDROID)
     list(REMOVE_ITEM LIBCORE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/../../Userland/Libraries/LibCore/Account.cpp")
     list(REMOVE_ITEM LIBCORE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/../../Userland/Libraries/LibCore/LocalServer.cpp")
 endif()
+if (WIN32)
+    list(REMOVE_ITEM LIBCORE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/../../Userland/Libraries/LibCore/Account.cpp")
+    list(REMOVE_ITEM LIBCORE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/../../Userland/Libraries/LibCore/FilePermissionsMask.cpp")
+    list(REMOVE_ITEM LIBCORE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/../../Userland/Libraries/LibCore/Group.cpp")
+    list(REMOVE_ITEM LIBCORE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/../../Userland/Libraries/LibCore/GetPassword.cpp")
+endif()
 lagom_lib(Core core
     SOURCES ${AK_SOURCES} ${LIBCORE_SOURCES}
     LIBS Threads::Threads


### PR DESCRIPTION
This is the initial port of Lagom to win32. This will enable developers to use Lagom as an alternative to vanilla STL/StandardC++Library - which gives a much richer environment (think QtCore - but modern).

My main incentive - is to have a native Windows Ladybird working.

I am starting with AK, which does not yet fully compile (on mingw). When AK is compiling (currently fails building StringBuffer.cpp) - I will continue to LibCore and then the rest of the user space libraries (excluding the GUI, which will be another different effort).

Most of the code is happily stollen from Andrew Kaster's and Filiph Sandström forks.

Co-authored-by: Filiph Sandström <filiph.sandstrom@filfatstudios.com>
Co-authored-by: Andrew Kaster <andrewdkaster@gmail.com>

*Notes on "testing"*:
I am currently building this as part of Ladybird. You will need close Serenity's git in another directory, and then configure ladybird using `cmake .. -DSERENITY_SOURCE_DIR=/path/to/serenity`. Then I build as usual from QtCreator and fix problems in lagom as needed. 

I am using mingw64 - the default compiler that comes with Qt. You can also manually install msys2 and install gcc , you will get similar results. Andrew started working on CL.EXE (aka: Visual Studio) - but this is not tested right now. clang will be tested eventually - this is also one of my goals.

As of this PR, I expect all (?) AK/* to compile - and the next target will be libcore. 