### PR TITLE
Lagom: Fix libdl build on non-Linux platforms

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -386,7 +386,7 @@ if (BUILD_LAGOM)
     file(GLOB LIBGPU_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibGPU/*.cpp")
     lagom_lib(GPU gpu
         SOURCES ${LIBGPU_SOURCES}
-        LIBS dl
+        LIBS ${CMAKE_DL_LIBS}
     )
 
     # GL


### PR DESCRIPTION
A tiny change to be able to compile this SerenityOS module on BSD's and other platforms that provide a valid CMAKE_DL_LIBS variable