### PR TITLE
LibJS: Bind functions in tree order

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -4721,7 +4721,8 @@ ThrowCompletionOr<void> Program::global_declaration_instantiation(Interpreter& i
     }));
 
     // 16. For each Parse Node f of functionsToInitialize, do
-    for (auto& declaration : functions_to_initialize) {
+    // Note: We used append in place of prepend, so we have to iterate in reverse
+    for (auto const& declaration : functions_to_initialize.in_reverse()) {
         // a. Let fn be the sole element of the BoundNames of f.
         // b. Let fo be InstantiateFunctionObject of f with arguments env and privateEnv.
         auto* function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), &global_environment, private_environment, declaration.kind(), declaration.is_strict_mode(), declaration.might_need_arguments_object(), declaration.contains_direct_call_to_eval());

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -129,7 +129,7 @@ Bytecode::CodeGenerationErrorOr<void> ScopeNode::generate_bytecode(Bytecode::Gen
             // Note: Already done in step iv. above.
 
             // 4. Insert d as the first element of functionsToInitialize.
-            functions_to_initialize.prepend(function);
+            functions_to_initialize.append(function);
             return {};
         });
 
@@ -221,7 +221,8 @@ Bytecode::CodeGenerationErrorOr<void> ScopeNode::generate_bytecode(Bytecode::Gen
         });
 
         // 16. For each Parse Node f of functionsToInitialize, do
-        for (auto& function_declaration : functions_to_initialize) {
+        // Note: We used append in place of prepend, so we have to iterate in reverse
+        for (auto const& function_declaration : functions_to_initialize.in_reverse()) {
             // FIXME: Do this more correctly.
             // a. Let fn be the sole element of the BoundNames of f.
             // b. Let fo be InstantiateFunctionObject of f with arguments env and privateEnv.

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -957,7 +957,8 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
     }));
 
     // 17. For each Parse Node f of functionsToInitialize, do
-    for (auto& declaration : functions_to_initialize) {
+    // Note: We used append in place of prepend, so we have to iterate in reverse
+    for (auto const& declaration : functions_to_initialize.in_reverse()) {
         // a. Let fn be the sole element of the BoundNames of f.
         // b. Let fo be InstantiateFunctionObject of f with arguments lexEnv and privateEnv.
         auto* function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), lexical_environment, private_environment, declaration.kind(), declaration.is_strict_mode(), declaration.might_need_arguments_object());


### PR DESCRIPTION
As discussed on discord, this error is technically observable, but seems not to be tested against

---

Also changes bytecode to be consistent with AST and the eval AO, while saving a good amount of `memmove`s through avoiding preprend