### PR TITLE
Meta: Fix 'time' invocation for IPCMagicLinter in lint-ci

### DIFF
--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -34,7 +34,7 @@ for cmd in \
         Meta/lint-python.sh \
         Meta/lint-shell-scripts.sh; do
     echo "Running ${cmd}"
-    if "time" "${cmd}" "$@"; then
+    if time "${cmd}" "$@"; then
         echo -e "[${GREEN}OK${NC}]: ${cmd}"
     else
         echo -e "[${RED}FAIL${NC}]: ${cmd}"
@@ -44,7 +44,7 @@ done
 
 if [ -x ./Build/lagom/Tools/IPCMagicLinter/IPCMagicLinter ]; then
     echo "Running IPCMagicLinter"
-    if git ls-files '*.ipc' | time xargs ./Build/lagom/Tools/IPCMagicLinter/IPCMagicLinter; then
+    if time { git ls-files '*.ipc' | xargs ./Build/lagom/Tools/IPCMagicLinter/IPCMagicLinter; }; then
         echo -e "[${GREEN}OK${NC}]: IPCMagicLinter (in Meta/lint-ci.sh)"
     else
         echo -e "[${RED}FAIL${NC}]: IPCMagicLinter (in Meta/lint-ci.sh)"


### PR DESCRIPTION
Some systems don't have /usr/bin/time available, so we need to make sure that the bash built-in is used. This cannot easily happen in the middle of a pipe. Also, measuring the time it takes git ls-files to run is a good thing, so we now just time the entire pipe.

CC @alimpfard @Hendiadyoin1 