### PR TITLE
LibJS+Browser+WebContent: Implement formatting for Console.log() and friends

### DIFF
--- a/Userland/Applications/Browser/ConsoleWidget.cpp
+++ b/Userland/Applications/Browser/ConsoleWidget.cpp
@@ -45,8 +45,7 @@ ConsoleWidget::ConsoleWidget()
     m_input->on_return_pressed = [this] {
         auto js_source = m_input->text();
 
-        // FIXME: An is_blank check to check if there is only whitespace would probably be preferable.
-        if (js_source.is_empty())
+        if (js_source.is_whitespace())
             return;
 
         m_input->add_current_text_to_history();

--- a/Userland/Applications/Browser/ConsoleWidget.cpp
+++ b/Userland/Applications/Browser/ConsoleWidget.cpp
@@ -199,7 +199,7 @@ void ConsoleWidget::begin_group(StringView label, bool start_expanded)
         var group = document.createElement("details");
         group.id = "group_{}";
         var label = document.createElement("summary");
-        label.innerText = ")~~~",
+        label.innerHTML = ")~~~",
         group.id);
     builder.append_escaped_for_json(label);
     builder.append(R"~~~(";

--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -615,8 +615,7 @@ ThrowCompletionOr<MarkedVector<Value>> ConsoleClient::formatter(MarkedVector<Val
         // 6. TODO: process %c
         else if (specifier == "%c"sv) {
             // NOTE: This has no spec yet. `%c` specifiers treat the argument as CSS styling for the log message.
-            //       For now, we'll just consume the specifier and the argument.
-            // FIXME: Actually style the message somehow.
+            add_css_style_to_current_message(TRY(current.to_string(vm)));
             converted = js_string(vm, "");
         }
 

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -53,11 +53,11 @@ public:
         Vector<String> stack;
     };
 
-    explicit Console(VM&);
+    explicit Console(Realm&);
 
     void set_client(ConsoleClient& client) { m_client = &client; }
 
-    VM& vm() const { return m_vm; }
+    Realm& realm() const { return m_realm; }
 
     MarkedVector<Value> vm_arguments();
 
@@ -87,7 +87,7 @@ private:
     ThrowCompletionOr<String> value_vector_to_string(MarkedVector<Value> const&);
     ThrowCompletionOr<String> format_time_since(Core::ElapsedTimer timer);
 
-    VM& m_vm;
+    Realm& m_realm;
     ConsoleClient* m_client { nullptr };
 
     HashMap<String, unsigned> m_counters;

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -108,6 +108,8 @@ public:
     ThrowCompletionOr<MarkedVector<Value>> formatter(MarkedVector<Value> const& args);
     virtual ThrowCompletionOr<Value> printer(Console::LogLevel log_level, PrinterArguments) = 0;
 
+    virtual void add_css_style_to_current_message(StringView) {};
+
     virtual void clear() = 0;
     virtual void end_group() = 0;
 

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
@@ -14,7 +14,7 @@ namespace JS {
 
 ConsoleObject::ConsoleObject(Realm& realm)
     : Object(*realm.intrinsics().object_prototype())
-    , m_console(make<Console>(realm.vm()))
+    , m_console(make<Console>(realm))
 {
 }
 

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -27,6 +27,12 @@ private:
     virtual void clear() override;
     virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, PrinterArguments) override;
 
+    virtual void add_css_style_to_current_message(StringView style) override
+    {
+        m_current_message_style.append(style);
+        m_current_message_style.append(';');
+    }
+
     ConnectionFromClient& m_client;
     WeakPtr<JS::Realm> m_realm;
     JS::Handle<ConsoleGlobalObject> m_console_global_object;
@@ -48,6 +54,8 @@ private:
         String data;
     };
     Vector<ConsoleOutput> m_message_log;
+
+    StringBuilder m_current_message_style;
 };
 
 }


### PR DESCRIPTION
Now that https://github.com/whatwg/console/pull/205 is merged, we can implement `Formatter` which is `Console.log()`'s version of `printf()`.

`%o` and `%O` really stumped me, so those are not implemented yet. But we do have `%c`!

![image](https://user-images.githubusercontent.com/222642/191491797-604b3eb0-722b-4c50-934e-4e3d9b347892.png)