### PR TITLE
headless-browser: Install EventLoop and Font plugins so it doesn't crash

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -356,9 +356,12 @@ set(SOURCES
     Painting/StackingContext.cpp
     Painting/TextPaintable.cpp
     Platform/EventLoopPlugin.cpp
+    Platform/EventLoopPluginSerenity.cpp
     Platform/FontPlugin.cpp
+    Platform/FontPluginSerenity.cpp
     Platform/ImageCodecPlugin.cpp
     Platform/Timer.cpp
+    Platform/TimerSerenity.cpp
     RequestIdleCallback/IdleDeadline.cpp
     ResizeObserver/ResizeObserver.cpp
     SVG/AttributeNames.cpp

--- a/Userland/Libraries/LibWeb/Platform/EventLoopPluginSerenity.cpp
+++ b/Userland/Libraries/LibWeb/Platform/EventLoopPluginSerenity.cpp
@@ -5,12 +5,12 @@
  */
 
 #include "EventLoopPluginSerenity.h"
-#include "TimerSerenity.h"
 #include <AK/Function.h>
 #include <AK/NonnullRefPtr.h>
 #include <LibCore/EventLoop.h>
+#include <LibWeb/Platform/TimerSerenity.h>
 
-namespace WebContent {
+namespace Web::Platform {
 
 EventLoopPluginSerenity::EventLoopPluginSerenity() = default;
 EventLoopPluginSerenity::~EventLoopPluginSerenity() = default;
@@ -26,7 +26,7 @@ void EventLoopPluginSerenity::deferred_invoke(Function<void()> function)
     Core::deferred_invoke(move(function));
 }
 
-NonnullRefPtr<Web::Platform::Timer> EventLoopPluginSerenity::create_timer()
+NonnullRefPtr<Timer> EventLoopPluginSerenity::create_timer()
 {
     return TimerSerenity::create();
 }

--- a/Userland/Libraries/LibWeb/Platform/EventLoopPluginSerenity.h
+++ b/Userland/Libraries/LibWeb/Platform/EventLoopPluginSerenity.h
@@ -8,7 +8,7 @@
 
 #include <LibWeb/Platform/EventLoopPlugin.h>
 
-namespace WebContent {
+namespace Web::Platform {
 
 class EventLoopPluginSerenity final : public Web::Platform::EventLoopPlugin {
 public:
@@ -17,7 +17,7 @@ public:
 
     virtual void spin_until(Function<bool()> goal_condition) override;
     virtual void deferred_invoke(Function<void()>) override;
-    virtual NonnullRefPtr<Web::Platform::Timer> create_timer() override;
+    virtual NonnullRefPtr<Timer> create_timer() override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Platform/FontPluginSerenity.cpp
+++ b/Userland/Libraries/LibWeb/Platform/FontPluginSerenity.cpp
@@ -8,7 +8,7 @@
 #include <AK/String.h>
 #include <LibGfx/Font/FontDatabase.h>
 
-namespace WebContent {
+namespace Web::Platform {
 
 FontPluginSerenity::FontPluginSerenity()
 {
@@ -26,26 +26,26 @@ Gfx::Font& FontPluginSerenity::default_fixed_width_font()
     return Gfx::FontDatabase::default_fixed_width_font();
 }
 
-String FontPluginSerenity::generic_font_name(Web::Platform::GenericFont generic_font)
+String FontPluginSerenity::generic_font_name(GenericFont generic_font)
 {
     // FIXME: Replace hard-coded font names with a relevant call to FontDatabase.
     // Currently, we cannot request the default font's name, or request it at a specific size and weight.
     // So, hard-coded font names it is.
     switch (generic_font) {
-    case Web::Platform::GenericFont::SansSerif:
-    case Web::Platform::GenericFont::UiSansSerif:
-    case Web::Platform::GenericFont::Cursive:
-    case Web::Platform::GenericFont::UiRounded:
+    case GenericFont::SansSerif:
+    case GenericFont::UiSansSerif:
+    case GenericFont::Cursive:
+    case GenericFont::UiRounded:
         return "Katica";
-    case Web::Platform::GenericFont::Monospace:
-    case Web::Platform::GenericFont::UiMonospace:
+    case GenericFont::Monospace:
+    case GenericFont::UiMonospace:
         return "Csilla";
-    case Web::Platform::GenericFont::Serif:
-    case Web::Platform::GenericFont::UiSerif:
+    case GenericFont::Serif:
+    case GenericFont::UiSerif:
         return "Roman";
-    case Web::Platform::GenericFont::Fantasy:
+    case GenericFont::Fantasy:
         return "Comic Book";
-    case Web::Platform::GenericFont::__Count:
+    case GenericFont::__Count:
         VERIFY_NOT_REACHED();
     }
     VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibWeb/Platform/FontPluginSerenity.h
+++ b/Userland/Libraries/LibWeb/Platform/FontPluginSerenity.h
@@ -9,16 +9,16 @@
 #include <AK/Vector.h>
 #include <LibWeb/Platform/FontPlugin.h>
 
-namespace WebContent {
+namespace Web::Platform {
 
-class FontPluginSerenity final : public Web::Platform::FontPlugin {
+class FontPluginSerenity final : public FontPlugin {
 public:
     FontPluginSerenity();
     virtual ~FontPluginSerenity();
 
     virtual Gfx::Font& default_font() override;
     virtual Gfx::Font& default_fixed_width_font() override;
-    virtual String generic_font_name(Web::Platform::GenericFont) override;
+    virtual String generic_font_name(GenericFont) override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Platform/TimerSerenity.cpp
+++ b/Userland/Libraries/LibWeb/Platform/TimerSerenity.cpp
@@ -8,7 +8,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <LibCore/Timer.h>
 
-namespace WebContent {
+namespace Web::Platform {
 
 NonnullRefPtr<TimerSerenity> TimerSerenity::create()
 {

--- a/Userland/Libraries/LibWeb/Platform/TimerSerenity.h
+++ b/Userland/Libraries/LibWeb/Platform/TimerSerenity.h
@@ -10,9 +10,9 @@
 #include <LibCore/Forward.h>
 #include <LibWeb/Platform/Timer.h>
 
-namespace WebContent {
+namespace Web::Platform {
 
-class TimerSerenity final : public Web::Platform::Timer {
+class TimerSerenity final : public Timer {
 public:
     static NonnullRefPtr<TimerSerenity> create();
 

--- a/Userland/Services/WebContent/CMakeLists.txt
+++ b/Userland/Services/WebContent/CMakeLists.txt
@@ -10,11 +10,8 @@ compile_ipc(WebContentClient.ipc WebContentClientEndpoint.h)
 set(SOURCES
     ConnectionFromClient.cpp
     ConsoleGlobalObject.cpp
-    EventLoopPluginSerenity.cpp
-    FontPluginSerenity.cpp
     ImageCodecPluginSerenity.cpp
     PageHost.cpp
-    TimerSerenity.cpp
     WebContentClientEndpoint.h
     WebContentConsoleClient.cpp
     WebContentServerEndpoint.h

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "EventLoopPluginSerenity.h"
-#include "FontPluginSerenity.h"
 #include "ImageCodecPluginSerenity.h"
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
@@ -14,6 +12,8 @@
 #include <LibMain/Main.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
+#include <LibWeb/Platform/EventLoopPluginSerenity.h>
+#include <LibWeb/Platform/FontPluginSerenity.h>
 #include <LibWeb/WebSockets/WebSocket.h>
 #include <LibWebView/RequestServerAdapter.h>
 #include <LibWebView/WebSocketClientAdapter.h>
@@ -30,9 +30,9 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/tmp/user/%uid/portal/websocket", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    Web::Platform::EventLoopPlugin::install(*new WebContent::EventLoopPluginSerenity);
+    Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);
     Web::Platform::ImageCodecPlugin::install(*new WebContent::ImageCodecPluginSerenity);
-    Web::Platform::FontPlugin::install(*new WebContent::FontPluginSerenity);
+    Web::Platform::FontPlugin::install(*new Web::Platform::FontPluginSerenity);
 
     Web::WebSockets::WebSocketClientManager::initialize(TRY(WebView::WebSocketClientManagerAdapter::try_create()));
     Web::ResourceLoader::initialize(TRY(WebView::RequestServerAdapter::try_create()));

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -40,6 +40,8 @@
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/Platform/EventLoopPluginSerenity.h>
+#include <LibWeb/Platform/FontPluginSerenity.h>
 #include <LibWeb/Platform/ImageCodecPlugin.h>
 #include <LibWeb/WebSockets/WebSocket.h>
 #include <LibWebSocket/ConnectionInfo.h>
@@ -668,6 +670,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(url, "URL to open", "url", Core::ArgsParser::Required::Yes);
     args_parser.parse(arguments);
 
+    Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);
+    Web::Platform::FontPlugin::install(*new Web::Platform::FontPluginSerenity);
     Web::Platform::ImageCodecPlugin::install(*new ImageCodecPluginHeadless);
     Web::ResourceLoader::initialize(HeadlessRequestServer::create());
     Web::WebSockets::WebSocketClientManager::initialize(HeadlessWebSocketClientManager::create());


### PR DESCRIPTION
These are copied from WebContent, which isn't great, but the only place they could really go otherwise is LibWeb, which would include them in Ladybird which seems undesirable.

Fixes #15239