### PR TITLE
LibWeb+WebContent: Setup the js console client earlier

### DIFF
--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -41,6 +41,9 @@
             column-width: 250px;
         }
     </style>
+    <script>
+        console.log('Hello from an inline script in the head of welcome.html');
+    </script>
     <script src="welcome.js"></script>
 </head>
 

--- a/Base/res/html/misc/welcome.js
+++ b/Base/res/html/misc/welcome.js
@@ -1,3 +1,6 @@
 document.addEventListener("DOMContentLoaded", function () {
+    console.log(
+        "Hello from DOMContentLoaded! There should be a message before this from an inline script"
+    );
     document.getElementById("ua").innerHTML = navigator.userAgent;
 });

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -398,6 +398,8 @@ void FrameLoader::resource_did_load()
     document->set_content_type(resource()->mime_type());
 
     browsing_context().set_active_document(document);
+    if (auto* page = browsing_context().page())
+        page->client().page_did_create_main_document();
 
     if (!parse_document(*document, resource()->encoded_data())) {
         load_error_page(url, "Failed to parse content.");

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -86,6 +86,7 @@ public:
     virtual CSS::PreferredColorScheme preferred_color_scheme() const = 0;
     virtual void page_did_change_title(String const&) { }
     virtual void page_did_start_loading(const AK::URL&) { }
+    virtual void page_did_create_main_document() { }
     virtual void page_did_finish_loading(const AK::URL&) { }
     virtual void page_did_change_selection() { }
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) { }

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -187,11 +187,13 @@ void PageHost::page_did_start_loading(const URL& url)
     m_client.async_did_start_loading(url);
 }
 
+void PageHost::page_did_create_main_document()
+{
+    m_client.initialize_js_console({});
+}
+
 void PageHost::page_did_finish_loading(const URL& url)
 {
-    // FIXME: This is called after the page has finished loading, which means any log messages
-    //        that happen *while* it is loading (such as inline <script>s) will be lost.
-    m_client.initialize_js_console({});
     m_client.async_did_finish_loading(url);
 }
 

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -57,6 +57,7 @@ private:
     virtual void page_did_request_context_menu(Gfx::IntPoint const&) override;
     virtual void page_did_request_link_context_menu(Gfx::IntPoint const&, const URL&, String const& target, unsigned modifiers) override;
     virtual void page_did_start_loading(const URL&) override;
+    virtual void page_did_create_main_document() override;
     virtual void page_did_finish_loading(const URL&) override;
     virtual void page_did_request_alert(String const&) override;
     virtual bool page_did_request_confirm(String const&) override;


### PR DESCRIPTION
This allows us to print messages in inline scripts. Also add an example of this in the welcome page to test this.

![early-log](https://user-images.githubusercontent.com/3750649/191542806-ab232755-a41a-42a5-b17f-daf9c0e1d169.png)

To fix this for ladybird: https://github.com/SerenityOS/ladybird/issues/70
