### PR TITLE
Kernel/aarch64: Actually make the MemoryManager work!

### DIFF
--- a/Kernel/Arch/PageDirectory.h
+++ b/Kernel/Arch/PageDirectory.h
@@ -1,156 +1,18 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Timon Kruiper <timonkruiper@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/Badge.h>
-#include <AK/Types.h>
-#include <Kernel/Forward.h>
-#include <Kernel/PhysicalAddress.h>
-
 #include <AK/Platform.h>
 
-namespace Kernel {
-
-class PageDirectoryEntry {
-public:
-    PhysicalPtr page_table_base() const { return PhysicalAddress::physical_page_base(m_raw); }
-    void set_page_table_base(u32 value)
-    {
-        m_raw &= 0x8000000000000fffULL;
-        m_raw |= PhysicalAddress::physical_page_base(value);
-    }
-
-    bool is_null() const { return m_raw == 0; }
-    void clear() { m_raw = 0; }
-
-    u64 raw() const { return m_raw; }
-    void copy_from(Badge<Memory::PageDirectory>, PageDirectoryEntry const& other) { m_raw = other.m_raw; }
-
-    enum Flags {
-        Present = 1 << 0,
-        ReadWrite = 1 << 1,
-        UserSupervisor = 1 << 2,
-        WriteThrough = 1 << 3,
-        CacheDisabled = 1 << 4,
-        Huge = 1 << 7,
-        Global = 1 << 8,
-        NoExecute = 0x8000000000000000ULL,
-    };
-
-    bool is_present() const { return (raw() & Present) == Present; }
-    void set_present(bool b) { set_bit(Present, b); }
-
-    bool is_user_allowed() const { return (raw() & UserSupervisor) == UserSupervisor; }
-    void set_user_allowed(bool b) { set_bit(UserSupervisor, b); }
-
-    bool is_huge() const { return (raw() & Huge) == Huge; }
-    void set_huge(bool b) { set_bit(Huge, b); }
-
-    bool is_writable() const { return (raw() & ReadWrite) == ReadWrite; }
-    void set_writable(bool b) { set_bit(ReadWrite, b); }
-
-    bool is_write_through() const { return (raw() & WriteThrough) == WriteThrough; }
-    void set_write_through(bool b) { set_bit(WriteThrough, b); }
-
-    bool is_cache_disabled() const { return (raw() & CacheDisabled) == CacheDisabled; }
-    void set_cache_disabled(bool b) { set_bit(CacheDisabled, b); }
-
-    bool is_global() const { return (raw() & Global) == Global; }
-    void set_global(bool b) { set_bit(Global, b); }
-
-    bool is_execute_disabled() const { return (raw() & NoExecute) == NoExecute; }
-    void set_execute_disabled(bool b) { set_bit(NoExecute, b); }
-
-private:
-    void set_bit(u64 bit, bool value)
-    {
-        if (value)
-            m_raw |= bit;
-        else
-            m_raw &= ~bit;
-    }
-
-    u64 m_raw;
-};
-
-class PageTableEntry {
-public:
-    PhysicalPtr physical_page_base() const { return PhysicalAddress::physical_page_base(m_raw); }
-    void set_physical_page_base(PhysicalPtr value)
-    {
-        // FIXME: IS THIS PLATFORM SPECIFIC?
-        m_raw &= 0x8000000000000fffULL;
-        m_raw |= PhysicalAddress::physical_page_base(value);
-    }
-
-    u64 raw() const { return m_raw; }
-
-    enum Flags {
-        Present = 1 << 0,
-        ReadWrite = 1 << 1,
-        UserSupervisor = 1 << 2,
-        WriteThrough = 1 << 3,
-        CacheDisabled = 1 << 4,
-        PAT = 1 << 7,
-        Global = 1 << 8,
-        NoExecute = 0x8000000000000000ULL,
-    };
-
-    bool is_present() const { return (raw() & Present) == Present; }
-    void set_present(bool b) { set_bit(Present, b); }
-
-    bool is_user_allowed() const { return (raw() & UserSupervisor) == UserSupervisor; }
-    void set_user_allowed(bool b) { set_bit(UserSupervisor, b); }
-
-    bool is_writable() const { return (raw() & ReadWrite) == ReadWrite; }
-    void set_writable(bool b) { set_bit(ReadWrite, b); }
-
-    bool is_write_through() const { return (raw() & WriteThrough) == WriteThrough; }
-    void set_write_through(bool b) { set_bit(WriteThrough, b); }
-
-    bool is_cache_disabled() const { return (raw() & CacheDisabled) == CacheDisabled; }
-    void set_cache_disabled(bool b) { set_bit(CacheDisabled, b); }
-
-    bool is_global() const { return (raw() & Global) == Global; }
-    void set_global(bool b) { set_bit(Global, b); }
-
-    bool is_execute_disabled() const { return (raw() & NoExecute) == NoExecute; }
-    void set_execute_disabled(bool b) { set_bit(NoExecute, b); }
-
-    bool is_pat() const { return (raw() & PAT) == PAT; }
-    void set_pat(bool b) { set_bit(PAT, b); }
-
-    bool is_null() const { return m_raw == 0; }
-    void clear() { m_raw = 0; }
-
-private:
-    void set_bit(u64 bit, bool value)
-    {
-        if (value)
-            m_raw |= bit;
-        else
-            m_raw &= ~bit;
-    }
-
-    u64 m_raw;
-};
-
-static_assert(AssertSize<PageDirectoryEntry, 8>());
-static_assert(AssertSize<PageTableEntry, 8>());
-
-class PageDirectoryPointerTable {
-public:
-    PageDirectoryEntry* directory(size_t index)
-    {
-        VERIFY(index <= (NumericLimits<size_t>::max() << 30));
-        return (PageDirectoryEntry*)(PhysicalAddress::physical_page_base(raw[index]));
-    }
-
-    u64 raw[512];
-};
-
-}
+#if ARCH(X86_64) || ARCH(I386)
+#    include <Kernel/Arch/x86/PageDirectory.h>
+#elif ARCH(AARCH64)
+#    include <Kernel/Arch/aarch64/PageDirectory.h>
+#else
+#    error "Unknown architecture"
+#endif

--- a/Kernel/Arch/aarch64/Dummy.cpp
+++ b/Kernel/Arch/aarch64/Dummy.cpp
@@ -97,6 +97,18 @@ ErrorOr<void> Inode::set_shared_vmobject(Memory::SharedInodeVMObject&)
     return {};
 }
 
+ErrorOr<size_t> Inode::read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const
+{
+    VERIFY_NOT_REACHED();
+    return 0;
+}
+
+ErrorOr<size_t> Inode::write_bytes(off_t, size_t, UserOrKernelBuffer const&, OpenFileDescription*)
+{
+    VERIFY_NOT_REACHED();
+    return 0;
+}
+
 }
 
 // UserOrKernelBuffer.cpp

--- a/Kernel/Arch/aarch64/MMU.cpp
+++ b/Kernel/Arch/aarch64/MMU.cpp
@@ -8,6 +8,7 @@
 
 #include <Kernel/Arch/aarch64/CPU.h>
 
+#include <Kernel/Arch/PageDirectory.h>
 #include <Kernel/Arch/aarch64/ASM_wrapper.h>
 #include <Kernel/Arch/aarch64/RPi/MMIO.h>
 #include <Kernel/Arch/aarch64/RPi/UART.h>
@@ -26,26 +27,6 @@ namespace Kernel {
 // physical memory
 constexpr u32 START_OF_NORMAL_MEMORY = 0x00000000;
 constexpr u32 END_OF_NORMAL_MEMORY = 0x3EFFFFFF;
-
-// 4KiB page size was chosen for the prekernel to make this code slightly simpler
-constexpr u32 GRANULE_SIZE = 0x1000;
-constexpr u32 PAGE_TABLE_SIZE = 0x1000;
-
-// Documentation for translation table format
-// https://developer.arm.com/documentation/101811/0101/Controlling-address-translation
-constexpr u32 PAGE_DESCRIPTOR = 0b11;
-constexpr u32 TABLE_DESCRIPTOR = 0b11;
-constexpr u32 DESCRIPTOR_MASK = ~0b11;
-
-constexpr u32 ACCESS_FLAG = 1 << 10;
-
-// shareability
-constexpr u32 OUTER_SHAREABLE = (2 << 8);
-constexpr u32 INNER_SHAREABLE = (3 << 8);
-
-// these index into the MAIR attribute table
-constexpr u32 NORMAL_MEMORY = (0 << 2);
-constexpr u32 DEVICE_MEMORY = (1 << 2);
 
 ALWAYS_INLINE static u64* descriptor_to_pointer(FlatPtr descriptor)
 {

--- a/Kernel/Arch/aarch64/PageDirectory.h
+++ b/Kernel/Arch/aarch64/PageDirectory.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Timon Kruiper <timonkruiper@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Badge.h>
+#include <AK/Types.h>
+#include <Kernel/Forward.h>
+#include <Kernel/PhysicalAddress.h>
+
+namespace Kernel {
+
+// 4KiB page size was chosen to make this code slightly simpler
+constexpr u32 GRANULE_SIZE = 0x1000;
+constexpr u32 PAGE_TABLE_SIZE = 0x1000;
+
+// Documentation for translation table format
+// https://developer.arm.com/documentation/101811/0101/Controlling-address-translation
+constexpr u32 PAGE_DESCRIPTOR = 0b11;
+constexpr u32 TABLE_DESCRIPTOR = 0b11;
+constexpr u32 DESCRIPTOR_MASK = ~0b11;
+
+constexpr u32 ACCESS_FLAG = 1 << 10;
+
+// shareability
+constexpr u32 OUTER_SHAREABLE = (2 << 8);
+constexpr u32 INNER_SHAREABLE = (3 << 8);
+
+// these index into the MAIR attribute table
+constexpr u32 NORMAL_MEMORY = (0 << 2);
+constexpr u32 DEVICE_MEMORY = (1 << 2);
+
+// Figure D5-15 of Arm Architecture Reference Manual Armv8 - page D5-2588
+class PageDirectoryEntry {
+public:
+    PhysicalPtr page_table_base() const { return PhysicalAddress::physical_page_base(m_raw); }
+    void set_page_table_base(u32 value)
+    {
+        m_raw &= 0xffff000000000fffULL;
+        m_raw |= PhysicalAddress::physical_page_base(value);
+
+        // FIXME: Do not hardcode this.
+        m_raw |= TABLE_DESCRIPTOR;
+    }
+
+    bool is_null() const { return m_raw == 0; }
+    void clear() { m_raw = 0; }
+
+    u64 raw() const { return m_raw; }
+    void copy_from(Badge<Memory::PageDirectory>, PageDirectoryEntry const& other) { m_raw = other.m_raw; }
+
+    enum Flags {
+        Present = 1 << 0,
+    };
+
+    bool is_present() const { return (raw() & Present) == Present; }
+    void set_present(bool) { }
+
+    bool is_user_allowed() const { VERIFY_NOT_REACHED(); }
+    void set_user_allowed(bool) { }
+
+    bool is_huge() const { VERIFY_NOT_REACHED(); }
+    void set_huge(bool) { }
+
+    bool is_writable() const { VERIFY_NOT_REACHED(); }
+    void set_writable(bool) { }
+
+    bool is_write_through() const { VERIFY_NOT_REACHED(); }
+    void set_write_through(bool) { }
+
+    bool is_cache_disabled() const { VERIFY_NOT_REACHED(); }
+    void set_cache_disabled(bool) { }
+
+    bool is_global() const { VERIFY_NOT_REACHED(); }
+    void set_global(bool) { }
+
+    bool is_execute_disabled() const { VERIFY_NOT_REACHED(); }
+    void set_execute_disabled(bool) { }
+
+private:
+    void set_bit(u64 bit, bool value)
+    {
+        if (value)
+            m_raw |= bit;
+        else
+            m_raw &= ~bit;
+    }
+
+    u64 m_raw;
+};
+
+// Figure D5-17 VMSAv8-64 level 3 descriptor format of Arm Architecture Reference Manual Armv8 - page D5-2592
+class PageTableEntry {
+public:
+    PhysicalPtr physical_page_base() const { return PhysicalAddress::physical_page_base(m_raw); }
+    void set_physical_page_base(PhysicalPtr value)
+    {
+        m_raw &= 0xffff000000000fffULL;
+        m_raw |= PhysicalAddress::physical_page_base(value);
+
+        // FIXME: For now we map everything with the same permissions.
+        u64 normal_memory_flags = ACCESS_FLAG | PAGE_DESCRIPTOR | INNER_SHAREABLE | NORMAL_MEMORY;
+        m_raw |= normal_memory_flags;
+    }
+
+    u64 raw() const { return m_raw; }
+
+    enum Flags {
+        Present = 1 << 0,
+    };
+
+    bool is_present() const { return (raw() & Present) == Present; }
+    void set_present(bool) { }
+
+    bool is_user_allowed() const { VERIFY_NOT_REACHED(); }
+    void set_user_allowed(bool) { }
+
+    bool is_writable() const { VERIFY_NOT_REACHED(); }
+    void set_writable(bool) { }
+
+    bool is_write_through() const { VERIFY_NOT_REACHED(); }
+    void set_write_through(bool) { }
+
+    bool is_cache_disabled() const { VERIFY_NOT_REACHED(); }
+    void set_cache_disabled(bool) { }
+
+    bool is_global() const { VERIFY_NOT_REACHED(); }
+    void set_global(bool) { }
+
+    bool is_execute_disabled() const { VERIFY_NOT_REACHED(); }
+    void set_execute_disabled(bool) { }
+
+    bool is_pat() const { VERIFY_NOT_REACHED(); }
+    void set_pat(bool) { }
+
+    bool is_null() const { return m_raw == 0; }
+    void clear() { m_raw = 0; }
+
+private:
+    void set_bit(u64 bit, bool value)
+    {
+        if (value)
+            m_raw |= bit;
+        else
+            m_raw &= ~bit;
+    }
+
+    u64 m_raw;
+};
+
+static_assert(AssertSize<PageDirectoryEntry, 8>());
+static_assert(AssertSize<PageTableEntry, 8>());
+
+class PageDirectoryPointerTable {
+public:
+    PageDirectoryEntry* directory(size_t index)
+    {
+        VERIFY(index <= (NumericLimits<size_t>::max() << 30));
+        return (PageDirectoryEntry*)(PhysicalAddress::physical_page_base(raw[index]));
+    }
+
+    u64 raw[512];
+};
+
+}

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -41,7 +41,16 @@ void Processor::initialize(u32 cpu)
 
 void Processor::flush_tlb_local(VirtualAddress, size_t)
 {
-    // FIXME: Implement this
+    // FIXME: Figure out how to flush a single page
+    asm volatile("dsb ishst");
+    asm volatile("tlbi vmalle1is");
+    asm volatile("dsb ish");
+    asm volatile("isb");
+}
+
+void Processor::flush_tlb(Memory::PageDirectory const*, VirtualAddress vaddr, size_t page_count)
+{
+    flush_tlb_local(vaddr, page_count);
 }
 
 }

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -77,10 +77,7 @@ public:
     }
 
     static void flush_tlb_local(VirtualAddress vaddr, size_t page_count);
-    ALWAYS_INLINE static void flush_tlb(Memory::PageDirectory const*, VirtualAddress const&, size_t)
-    {
-        VERIFY_NOT_REACHED();
-    }
+    static void flush_tlb(Memory::PageDirectory const*, VirtualAddress, size_t);
 
     // FIXME: When aarch64 supports multiple cores, return the correct core id here.
     ALWAYS_INLINE static u32 current_id()

--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -129,11 +129,6 @@ extern "C" [[noreturn]] void init()
 
     CommandLine::initialize();
 
-    auto& framebuffer = RPi::Framebuffer::the();
-    if (framebuffer.initialized()) {
-        g_boot_console = &try_make_lock_ref_counted<Graphics::BootFramebufferConsole>(framebuffer.gpu_buffer(), framebuffer.width(), framebuffer.width(), framebuffer.pitch()).value().leak_ref();
-        draw_logo();
-    }
     dmesgln("Starting SerenityOS...");
 
     dmesgln("Initialize MMU");
@@ -144,6 +139,12 @@ extern "C" [[noreturn]] void init()
     // Note that we want to do this as early as possible.
     for (ctor_func_t* ctor = start_ctors; ctor < end_ctors; ctor++)
         (*ctor)();
+
+    auto& framebuffer = RPi::Framebuffer::the();
+    if (framebuffer.initialized()) {
+        g_boot_console = &try_make_lock_ref_counted<Graphics::BootFramebufferConsole>(PhysicalAddress((PhysicalPtr)framebuffer.gpu_buffer()), framebuffer.width(), framebuffer.height(), framebuffer.pitch()).value().leak_ref();
+        draw_logo();
+    }
 
     initialize_interrupts();
     InterruptManagement::initialize();

--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -49,6 +49,8 @@ extern "C" void exception_common(Kernel::TrapFrame const* const trap_frame)
 
         auto esr_el1 = Kernel::Aarch64::ESR_EL1::read();
         dbgln("esr_el1: EC({:#b}) IL({:#b}) ISS({:#b}) ISS2({:#b})", esr_el1.EC, esr_el1.IL, esr_el1.ISS, esr_el1.ISS2);
+
+        dump_backtrace_from_base_pointer(trap_frame->x[29]);
     }
 
     Kernel::Processor::halt();

--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -98,7 +98,7 @@ extern "C" [[noreturn]] void init()
     multiboot_memory_map_t mmap[] = {
         { sizeof(struct multiboot_mmap_entry) - sizeof(u32),
             (u64)0x0,
-            (u64)0xA2F000,
+            (u64)0x3F000000,
             MULTIBOOT_MEMORY_AVAILABLE }
     };
 
@@ -114,6 +114,9 @@ extern "C" [[noreturn]] void init()
 
     new (&bootstrap_processor()) Processor();
     bootstrap_processor().initialize(0);
+
+    // We want to enable the MMU as fast as possible to make the boot faster.
+    init_page_tables();
 
     // We call the constructors of kmalloc.cpp separately, because other constructors in the Kernel
     // might rely on being able to call new/kmalloc in the constructor. We do have to run the
@@ -134,7 +137,6 @@ extern "C" [[noreturn]] void init()
     dmesgln("Starting SerenityOS...");
 
     dmesgln("Initialize MMU");
-    init_page_tables();
     Memory::MemoryManager::initialize(0);
     DeviceManagement::initialize();
 

--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -13,6 +13,8 @@ SECTIONS
 {
     . = 0x00080000;
 
+    start_of_kernel_image = .;
+
     .text ALIGN(4K) : AT (ADDR(.text))
     {
         *(.text.first)
@@ -62,8 +64,6 @@ SECTIONS
     /* FIXME: Placeholder to satisfy linker */
     start_of_kernel_text = .;
     end_of_kernel_text = .;
-    start_of_kernel_image = .;
-    end_of_kernel_image = .;
     start_of_unmap_after_init = .;
     end_of_unmap_after_init = .;
     start_of_ro_after_init = .;
@@ -76,6 +76,8 @@ SECTIONS
     
     . += 8M;
     page_tables_phys_end = .;
+
+    end_of_kernel_image = .;
 }
 
 size_of_bss_divided_by_8 = (end_of_bss - start_of_bss + 7) / 8;

--- a/Kernel/Arch/x86/PageDirectory.h
+++ b/Kernel/Arch/x86/PageDirectory.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Badge.h>
+#include <AK/Types.h>
+#include <Kernel/Forward.h>
+#include <Kernel/PhysicalAddress.h>
+
+namespace Kernel {
+
+class PageDirectoryEntry {
+public:
+    PhysicalPtr page_table_base() const { return PhysicalAddress::physical_page_base(m_raw); }
+    void set_page_table_base(u32 value)
+    {
+        m_raw &= 0x8000000000000fffULL;
+        m_raw |= PhysicalAddress::physical_page_base(value);
+    }
+
+    bool is_null() const { return m_raw == 0; }
+    void clear() { m_raw = 0; }
+
+    u64 raw() const { return m_raw; }
+    void copy_from(Badge<Memory::PageDirectory>, PageDirectoryEntry const& other) { m_raw = other.m_raw; }
+
+    enum Flags {
+        Present = 1 << 0,
+        ReadWrite = 1 << 1,
+        UserSupervisor = 1 << 2,
+        WriteThrough = 1 << 3,
+        CacheDisabled = 1 << 4,
+        Huge = 1 << 7,
+        Global = 1 << 8,
+        NoExecute = 0x8000000000000000ULL,
+    };
+
+    bool is_present() const { return (raw() & Present) == Present; }
+    void set_present(bool b) { set_bit(Present, b); }
+
+    bool is_user_allowed() const { return (raw() & UserSupervisor) == UserSupervisor; }
+    void set_user_allowed(bool b) { set_bit(UserSupervisor, b); }
+
+    bool is_huge() const { return (raw() & Huge) == Huge; }
+    void set_huge(bool b) { set_bit(Huge, b); }
+
+    bool is_writable() const { return (raw() & ReadWrite) == ReadWrite; }
+    void set_writable(bool b) { set_bit(ReadWrite, b); }
+
+    bool is_write_through() const { return (raw() & WriteThrough) == WriteThrough; }
+    void set_write_through(bool b) { set_bit(WriteThrough, b); }
+
+    bool is_cache_disabled() const { return (raw() & CacheDisabled) == CacheDisabled; }
+    void set_cache_disabled(bool b) { set_bit(CacheDisabled, b); }
+
+    bool is_global() const { return (raw() & Global) == Global; }
+    void set_global(bool b) { set_bit(Global, b); }
+
+    bool is_execute_disabled() const { return (raw() & NoExecute) == NoExecute; }
+    void set_execute_disabled(bool b) { set_bit(NoExecute, b); }
+
+private:
+    void set_bit(u64 bit, bool value)
+    {
+        if (value)
+            m_raw |= bit;
+        else
+            m_raw &= ~bit;
+    }
+
+    u64 m_raw;
+};
+
+class PageTableEntry {
+public:
+    PhysicalPtr physical_page_base() const { return PhysicalAddress::physical_page_base(m_raw); }
+    void set_physical_page_base(PhysicalPtr value)
+    {
+        // FIXME: IS THIS PLATFORM SPECIFIC?
+        m_raw &= 0x8000000000000fffULL;
+        m_raw |= PhysicalAddress::physical_page_base(value);
+    }
+
+    u64 raw() const { return m_raw; }
+
+    enum Flags {
+        Present = 1 << 0,
+        ReadWrite = 1 << 1,
+        UserSupervisor = 1 << 2,
+        WriteThrough = 1 << 3,
+        CacheDisabled = 1 << 4,
+        PAT = 1 << 7,
+        Global = 1 << 8,
+        NoExecute = 0x8000000000000000ULL,
+    };
+
+    bool is_present() const { return (raw() & Present) == Present; }
+    void set_present(bool b) { set_bit(Present, b); }
+
+    bool is_user_allowed() const { return (raw() & UserSupervisor) == UserSupervisor; }
+    void set_user_allowed(bool b) { set_bit(UserSupervisor, b); }
+
+    bool is_writable() const { return (raw() & ReadWrite) == ReadWrite; }
+    void set_writable(bool b) { set_bit(ReadWrite, b); }
+
+    bool is_write_through() const { return (raw() & WriteThrough) == WriteThrough; }
+    void set_write_through(bool b) { set_bit(WriteThrough, b); }
+
+    bool is_cache_disabled() const { return (raw() & CacheDisabled) == CacheDisabled; }
+    void set_cache_disabled(bool b) { set_bit(CacheDisabled, b); }
+
+    bool is_global() const { return (raw() & Global) == Global; }
+    void set_global(bool b) { set_bit(Global, b); }
+
+    bool is_execute_disabled() const { return (raw() & NoExecute) == NoExecute; }
+    void set_execute_disabled(bool b) { set_bit(NoExecute, b); }
+
+    bool is_pat() const { return (raw() & PAT) == PAT; }
+    void set_pat(bool b) { set_bit(PAT, b); }
+
+    bool is_null() const { return m_raw == 0; }
+    void clear() { m_raw = 0; }
+
+private:
+    void set_bit(u64 bit, bool value)
+    {
+        if (value)
+            m_raw |= bit;
+        else
+            m_raw &= ~bit;
+    }
+
+    u64 m_raw;
+};
+
+static_assert(AssertSize<PageDirectoryEntry, 8>());
+static_assert(AssertSize<PageTableEntry, 8>());
+
+class PageDirectoryPointerTable {
+public:
+    PageDirectoryEntry* directory(size_t index)
+    {
+        VERIFY(index <= (NumericLimits<size_t>::max() << 30));
+        return (PageDirectoryEntry*)(PhysicalAddress::physical_page_base(raw[index]));
+    }
+
+    u64 raw[512];
+};
+
+}

--- a/Kernel/Graphics/Console/BootFramebufferConsole.cpp
+++ b/Kernel/Graphics/Console/BootFramebufferConsole.cpp
@@ -6,34 +6,19 @@
 
 #include <Kernel/Graphics/Console/BootFramebufferConsole.h>
 #include <Kernel/Locking/Spinlock.h>
-// FIXME: Port MemoryManager to aarch64
-#if !ARCH(AARCH64)
-#    include <Kernel/Memory/MemoryManager.h>
-#endif
+#include <Kernel/Memory/MemoryManager.h>
 
 namespace Kernel::Graphics {
 
-// FIXME: Port MemoryManager to aarch64
-#if ARCH(AARCH64)
-BootFramebufferConsole::BootFramebufferConsole(u8* framebuffer_addr, size_t width, size_t height, size_t pitch)
-    : GenericFramebufferConsoleImpl(width, height, pitch)
-    , m_framebuffer(framebuffer_addr)
-#else
 BootFramebufferConsole::BootFramebufferConsole(PhysicalAddress framebuffer_addr, size_t width, size_t height, size_t pitch)
     : GenericFramebufferConsoleImpl(width, height, pitch)
-#endif
 {
-// FIXME: Port MemoryManager to aarch64
-#if ARCH(AARCH64)
-    m_framebuffer_data = framebuffer_addr;
-#else
     // NOTE: We're very early in the boot process, memory allocations shouldn't really fail
     auto framebuffer_end = Memory::page_round_up(framebuffer_addr.offset(height * pitch * sizeof(u32)).get()).release_value();
     m_framebuffer = MM.allocate_kernel_region(framebuffer_addr.page_base(), framebuffer_end - framebuffer_addr.page_base().get(), "Boot Framebuffer"sv, Memory::Region::Access::ReadWrite).release_value();
 
     [[maybe_unused]] auto result = m_framebuffer->set_write_combine(true);
     m_framebuffer_data = m_framebuffer->vaddr().offset(framebuffer_addr.offset_in_page()).as_ptr();
-#endif
     memset(m_framebuffer_data, 0, height * pitch * sizeof(u32));
 }
 

--- a/Kernel/Graphics/Console/BootFramebufferConsole.h
+++ b/Kernel/Graphics/Console/BootFramebufferConsole.h
@@ -23,24 +23,14 @@ public:
     virtual void flush(size_t, size_t, size_t, size_t) override { }
     virtual void set_resolution(size_t, size_t, size_t) override { }
 
-// FIXME: Port MemoryManager to aarch64
-#if ARCH(AARCH64)
-    BootFramebufferConsole(u8* framebuffer_addr, size_t width, size_t height, size_t pitch);
-#else
     BootFramebufferConsole(PhysicalAddress framebuffer_addr, size_t width, size_t height, size_t pitch);
-#endif
 
 protected:
     virtual void clear_glyph(size_t x, size_t y) override;
 
     virtual u8* framebuffer_data() override;
 
-// FIXME: Port MemoryManager to aarch64
-#if ARCH(AARCH64)
-    u8* m_framebuffer;
-#else
     OwnPtr<Memory::Region> m_framebuffer;
-#endif
     u8* m_framebuffer_data {};
     mutable Spinlock m_lock { LockRank::None };
 };

--- a/Kernel/Graphics/Console/BootFramebufferConsole.h
+++ b/Kernel/Graphics/Console/BootFramebufferConsole.h
@@ -23,6 +23,8 @@ public:
     virtual void flush(size_t, size_t, size_t, size_t) override { }
     virtual void set_resolution(size_t, size_t, size_t) override { }
 
+    u8* unsafe_framebuffer_data() { return m_framebuffer_data; }
+
     BootFramebufferConsole(PhysicalAddress framebuffer_addr, size_t width, size_t height, size_t pitch);
 
 protected:

--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -161,6 +161,11 @@ NEVER_INLINE static void dump_backtrace_impl(FlatPtr base_pointer, bool use_ksym
     }
 }
 
+void dump_backtrace_from_base_pointer(FlatPtr base_pointer)
+{
+    dump_backtrace_impl(base_pointer, g_kernel_symbols_available, PrintToScreen::Yes);
+}
+
 void dump_backtrace(PrintToScreen print_to_screen)
 {
     static bool in_dump_backtrace = false;

--- a/Kernel/KSyms.h
+++ b/Kernel/KSyms.h
@@ -29,5 +29,6 @@ extern FlatPtr g_lowest_kernel_symbol_address;
 extern FlatPtr g_highest_kernel_symbol_address;
 
 void dump_backtrace(PrintToScreen print_to_screen = PrintToScreen::No);
+void dump_backtrace_from_base_pointer(FlatPtr base_pointer);
 
 }

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -72,8 +72,14 @@ bool MemoryManager::is_initialized()
 
 static UNMAP_AFTER_INIT VirtualRange kernel_virtual_range()
 {
+#if ARCH(AARCH64)
+    // NOTE: We currently identity map the kernel image for aarch64, so the kernel virtual range
+    //       is the complete memory range.
+    return VirtualRange { VirtualAddress((FlatPtr)0), 0x3F000000 };
+#else
     size_t kernel_range_start = kernel_mapping_base + 2 * MiB; // The first 2 MiB are used for mapping the pre-kernel
     return VirtualRange { VirtualAddress(kernel_range_start), KERNEL_PD_END - kernel_range_start };
+#endif
 }
 
 MemoryManager::GlobalData::GlobalData()

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -243,7 +243,9 @@ UNMAP_AFTER_INIT void MemoryManager::parse_memory_map()
     // Register used memory regions that we know of.
     m_global_data.with([&](auto& global_data) {
         global_data.used_memory_ranges.ensure_capacity(4);
+#if ARCH(I386) || ARCH(X86_64)
         global_data.used_memory_ranges.append(UsedMemoryRange { UsedMemoryRangeType::LowMemory, PhysicalAddress(0x00000000), PhysicalAddress(1 * MiB) });
+#endif
         global_data.used_memory_ranges.append(UsedMemoryRange { UsedMemoryRangeType::Kernel, PhysicalAddress(virtual_to_low_physical((FlatPtr)start_of_kernel_image)), PhysicalAddress(page_round_up(virtual_to_low_physical((FlatPtr)end_of_kernel_image)).release_value_but_fixme_should_propagate_errors()) });
 
         if (multiboot_flags & 0x4) {

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -494,10 +494,8 @@ UNMAP_AFTER_INIT void MemoryManager::initialize_physical_pages()
             auto* pd = reinterpret_cast<PageDirectoryEntry*>(quickmap_page(boot_pd_kernel));
             PageDirectoryEntry& pde = pd[page_directory_index];
 
-            // FIXME: port quickmap_page to aarch64
-#if !ARCH(AARCH64)
             VERIFY(!pde.is_present()); // Nothing should be using this PD yet
-#endif
+
             // We can't use ensure_pte quite yet!
             pde.set_page_table_base(pt_paddr.get());
             pde.set_user_allowed(false);


### PR DESCRIPTION
Previously we were able to compile `MemoryManager`, however it wasn't actually possible to do anything useful with it. This PR implements the quickmap mechanism and fixes the missing bits to actually map memory and create Regions etc.

For now the aarch64 Kernel is identity mapped, but later on we could change this to actually use the same loading addresses as the x86 kernel.

![image](https://user-images.githubusercontent.com/18349222/191560175-b9f8eecc-12e8-4acd-adec-5b7a87596571.png)

