### PR TITLE
LibJS: Change default time display options to "always" for digital style

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -244,23 +244,32 @@ ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM& vm, String 
 
     // 3. If style is undefined, then
     if (style_value.is_undefined()) {
-        // a. Set displayDefault to "auto".
-        display_default = "auto"sv;
-
-        // b. If baseStyle is "digital", then
+        // a. If baseStyle is "digital", then
         if (base_style == "digital"sv) {
-            // i. Set style to digitalBase.
+            // i. If unit is not one of "hours", "minutes", or "seconds", then
+            if (!unit.is_one_of("hours"sv, "minutes"sv, "seconds"sv)) {
+                // 1. Set displayDefault to "auto".
+                display_default = "auto"sv;
+            }
+
+            // ii. Set style to digitalBase.
             style = digital_base;
         }
-        // c. Else if prevStyle is "numeric" or "2-digit", then
-        else if (previous_style == "numeric"sv || previous_style == "2-digit"sv) {
-            // i. Set style to "numeric".
-            style = "numeric"sv;
-        }
-        // d. Else,
+        // b. Else,
         else {
-            // i. Set style to baseStyle.
-            style = base_style;
+            // i. Set displayDefault to "auto".
+            display_default = "auto"sv;
+
+            // ii. If prevStyle is "numeric" or "2-digit", then
+            if (previous_style == "numeric"sv || previous_style == "2-digit"sv) {
+                // 1. Set style to "numeric".
+                style = "numeric"sv;
+            }
+            // iii. Else,
+            else {
+                // 1. Set style to baseStyle.
+                style = base_style;
+            }
         }
     } else {
         style = style_value.as_string().string();

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DurationFormat/DurationFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DurationFormat/DurationFormat.prototype.format.js
@@ -62,6 +62,32 @@ describe("correct behavior", () => {
             }).format(duration)
         ).toBe("1 J, 2 M, 3 W, 3 T, 4 Std., 5 Min., 6 Sek., 7 ms und 8,009 μs");
     });
+
+    test("always show time fields for digital style", () => {
+        const duration1 = {
+            years: 1,
+            months: 2,
+            weeks: 3,
+            days: 3,
+        };
+        const duration2 = {
+            years: 1,
+            months: 2,
+            weeks: 3,
+            days: 3,
+            hours: 4,
+            minutes: 5,
+            seconds: 6,
+        };
+
+        const en = new Intl.DurationFormat("en", { style: "digital" });
+        expect(en.format(duration1)).toBe("1 yr 2 mths 3 wks 3 days 0:00:00");
+        expect(en.format(duration2)).toBe("1 yr 2 mths 3 wks 3 days 4:05:06");
+
+        const de = new Intl.DurationFormat("de", { style: "digital" });
+        expect(de.format(duration1)).toBe("1 J, 2 Mon., 3 Wo., 3 Tg. und 0:00:00");
+        expect(de.format(duration2)).toBe("1 J, 2 Mon., 3 Wo., 3 Tg. und 4:05:06");
+    });
 });
 
 describe("errors", () => {


### PR DESCRIPTION
This is a normative change in the Intl.DurationFormat proposal.
See: https://github.com/tc39/proposal-intl-duration-format/commit/d28076b