### PR TITLE
CI+LibCore: Restore Android build and CI

### DIFF
--- a/Meta/Azure/Caches.yml
+++ b/Meta/Azure/Caches.yml
@@ -10,8 +10,6 @@ parameters:
   toolchain_ccache_path: ''
   toolchain_ccache_size: $(CCACHE_MAXSIZE)
   with_remote_data_caches: true
-  ndk_version: ''
-  with_ndk_cache: false
 
 steps:
   - script: |
@@ -84,13 +82,3 @@ steps:
             "unicode_locale" | Meta/CMake/locale_data.cmake
         path: $(Build.SourcesDirectory)/${{ parameters.build_directory }}/CLDR
       displayName: 'UnicodeLocale Cache'
-
-  - ${{ if eq(parameters.with_ndk_cache, true) }}:
-    - bash: |
-        echo "##vso[task.setvariable variable=ANDROID_SDK_ROOT;]$ANDROID_SDK_ROOT"
-      displayName: 'Set ANDROID_SDK_ROOT'
-    - task: Cache@2
-      inputs:
-        key: '"ndk" | "$(Agent.OS)" | "${{ parameters.ndk_version }}" '
-        path: $(ANDROID_SDK_ROOT)/ndk
-      displayName: 'Android NDK Cache'

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -42,9 +42,6 @@ jobs:
         build_directory: 'Meta/Lagom/Build'
         serenity_ccache_path: '$(SERENITY_CCACHE_DIR)'
         with_remote_data_caches: true
-        ${{ if eq(parameters.os, 'Android') }}:
-          with_ndk_cache: true
-          ndk_version: '$(ndk_version)'
         ${{ if eq(parameters.os, 'macOS') }}:
           ccache_version: 2
           serenity_ccache_size: '2G'

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -263,6 +263,7 @@ file(GLOB AK_SOURCES CONFIGURE_DEPENDS "../../AK/*.cpp")
 file(GLOB LIBCORE_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibCore/*.cpp")
 if (ANDROID)
     list(REMOVE_ITEM LIBCORE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/../../Userland/Libraries/LibCore/Account.cpp")
+    list(REMOVE_ITEM LIBCORE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/../../Userland/Libraries/LibCore/LocalServer.cpp")
 endif()
 lagom_lib(Core core
     SOURCES ${AK_SOURCES} ${LIBCORE_SOURCES}

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -17,7 +17,6 @@
 #include <AK/Singleton.h>
 #include <AK/TemporaryChange.h>
 #include <AK/Time.h>
-#include <LibCore/Account.h>
 #include <LibCore/Event.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
@@ -37,6 +36,8 @@
 #include <unistd.h>
 
 #ifdef __serenity__
+#    include <LibCore/Account.h>
+
 extern bool s_global_initializers_ran;
 #endif
 

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -12,7 +12,6 @@
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
-#include <LibCore/Account.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <limits.h>
@@ -26,6 +25,7 @@
 #include <unistd.h>
 
 #ifdef __serenity__
+#    include <LibCore/Account.h>
 #    include <LibSystem/syscall.h>
 #    include <serenity.h>
 #endif


### PR DESCRIPTION
Fix the Android nightly by removing the broken Android NDK Cache as  it never worked as a cache, the build has failed since it
tried to use it. This should restore the Android nightly build.

Recent changes caused LibCore::Account to be used in more files of LibCore, but Core::Account relies on shadow.h which is not present in android. So shuffle some headers around and don't build another file in Android.

This makes the latest commits of serenity and ladybird work again on android :pinching_hand: 

![image](https://user-images.githubusercontent.com/8388494/191765534-c61ae0e8-7b9b-4a42-b72a-db85682f04b6.png)
