### PR TITLE
Kernel: Move linker variables definition to a header file

### DIFF
--- a/Kernel/Arch/linker.h
+++ b/Kernel/Arch/linker.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+extern u8 start_of_kernel_image[];
+extern u8 end_of_kernel_image[];
+extern u8 start_of_kernel_text[];
+extern u8 start_of_kernel_data[];
+extern u8 end_of_kernel_bss[];
+extern u8 start_of_ro_after_init[];
+extern u8 end_of_ro_after_init[];
+extern u8 start_of_unmap_after_init[];
+extern u8 end_of_unmap_after_init[];
+extern u8 start_of_kernel_ksyms[];
+extern u8 end_of_kernel_ksyms[];

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -33,13 +33,6 @@
 #include <Kernel/Arch/x86/ISRStubs.h>
 #include <Kernel/Arch/x86/TrapFrame.h>
 
-extern FlatPtr start_of_unmap_after_init;
-extern FlatPtr end_of_unmap_after_init;
-extern FlatPtr start_of_ro_after_init;
-extern FlatPtr end_of_ro_after_init;
-extern FlatPtr start_of_kernel_ksyms;
-extern FlatPtr end_of_kernel_ksyms;
-
 namespace Kernel {
 
 READONLY_AFTER_INIT static DescriptorTablePointer s_idtr;

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -13,6 +13,7 @@
 #include <Kernel/Arch/PageDirectory.h>
 #include <Kernel/Arch/PageFault.h>
 #include <Kernel/Arch/RegisterState.h>
+#include <Kernel/Arch/linker.h>
 #include <Kernel/BootInfo.h>
 #include <Kernel/FileSystem/Inode.h>
 #include <Kernel/Heap/kmalloc.h>
@@ -28,18 +29,6 @@
 #include <Kernel/Process.h>
 #include <Kernel/Sections.h>
 #include <Kernel/StdLib.h>
-
-extern u8 start_of_kernel_image[];
-extern u8 end_of_kernel_image[];
-extern u8 start_of_kernel_text[];
-extern u8 start_of_kernel_data[];
-extern u8 end_of_kernel_bss[];
-extern u8 start_of_ro_after_init[];
-extern u8 end_of_ro_after_init[];
-extern u8 start_of_unmap_after_init[];
-extern u8 end_of_unmap_after_init[];
-extern u8 start_of_kernel_ksyms[];
-extern u8 end_of_kernel_ksyms[];
 
 extern multiboot_module_entry_t multiboot_copy_boot_modules_array[16];
 extern size_t multiboot_copy_boot_modules_count;

--- a/Kernel/Memory/PageDirectory.cpp
+++ b/Kernel/Memory/PageDirectory.cpp
@@ -16,9 +16,6 @@
 #include <Kernel/Random.h>
 #include <Kernel/Sections.h>
 
-extern u8 start_of_kernel_image[];
-extern u8 end_of_kernel_image[];
-
 namespace Kernel::Memory {
 
 UNMAP_AFTER_INIT NonnullLockRefPtr<PageDirectory> PageDirectory::must_create_kernel_page_directory()


### PR DESCRIPTION
The 'linker.ld' file has to define special external variable to map the memory layout so that memory management works properly.

Move every definitions (and remove the one that seems to be broken) to a single header in an effort to unify definitions.