### PR TITLE
LibWeb: Keep message alive in postMessage task callback lambda

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -87,9 +87,9 @@ void MessagePort::post_message(JS::Value message)
 
     // FIXME: This is an ad-hoc hack implementation instead, since we don't currently
     //        have serialization and deserialization of messages.
-    main_thread_event_loop().task_queue().add(HTML::Task::create(HTML::Task::Source::PostedMessage, nullptr, [strong_port = JS::make_handle(*target_port), message]() mutable {
+    main_thread_event_loop().task_queue().add(HTML::Task::create(HTML::Task::Source::PostedMessage, nullptr, [strong_port = JS::make_handle(*target_port), strong_message = JS::make_handle(message)]() mutable {
         MessageEventInit event_init {};
-        event_init.data = message;
+        event_init.data = strong_message.value();
         event_init.origin = "<origin>";
         strong_port->dispatch_event(*MessageEvent::create(verify_cast<HTML::Window>(strong_port->realm().global_object()), HTML::EventNames::message, event_init));
     }));

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -600,9 +600,9 @@ DOM::ExceptionOr<void> Window::post_message_impl(JS::Value message, String const
 {
     // FIXME: This is an ad-hoc hack implementation instead, since we don't currently
     //        have serialization and deserialization of messages.
-    HTML::queue_global_task(HTML::Task::Source::PostedMessage, *this, [strong_this = JS::make_handle(*this), message]() mutable {
+    HTML::queue_global_task(HTML::Task::Source::PostedMessage, *this, [strong_this = JS::make_handle(*this), strong_message = JS::make_handle(message)]() mutable {
         HTML::MessageEventInit event_init {};
-        event_init.data = message;
+        event_init.data = strong_message.value();
         event_init.origin = "<origin>";
         strong_this->dispatch_event(*HTML::MessageEvent::create(*strong_this, HTML::EventNames::message, event_init));
     });


### PR DESCRIPTION
Tasks can run at any time in the future and GC can run in the time between postMessage and running the task, meaning the message can be reaped if we don't keep a handle to it.

Fixes Google Syndication ads crashing 100% of the time on rpcs3.net