### PR TITLE
LibWeb: Set HTMLParser::m_scripting_enabled as according to the spec

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -121,6 +121,7 @@ static bool is_html_integration_point(DOM::Element const& element)
 
 HTMLParser::HTMLParser(DOM::Document& document, StringView input, String const& encoding)
     : m_tokenizer(input, encoding)
+    , m_scripting_enabled(document.is_scripting_enabled())
     , m_document(JS::make_handle(document))
 {
     m_tokenizer.set_parser({}, *this);
@@ -132,7 +133,8 @@ HTMLParser::HTMLParser(DOM::Document& document, StringView input, String const& 
 }
 
 HTMLParser::HTMLParser(DOM::Document& document)
-    : m_document(JS::make_handle(document))
+    : m_scripting_enabled(document.is_scripting_enabled())
+    , m_document(JS::make_handle(document))
 {
     m_document->set_parser({}, *this);
     m_tokenizer.set_parser({}, *this);

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -169,7 +169,11 @@ private:
     bool m_foster_parenting { false };
     bool m_frameset_ok { true };
     bool m_parsing_fragment { false };
+
+    // https://html.spec.whatwg.org/multipage/parsing.html#scripting-flag
+    // The scripting flag is set to "enabled" if scripting was enabled for the Document with which the parser is associated when the parser was created, and "disabled" otherwise.
     bool m_scripting_enabled { true };
+
     bool m_invoked_via_document_write { false };
     bool m_aborted { false };
     bool m_parser_pause_flag { false };


### PR DESCRIPTION
This allows `<noscript>` elements to display their content as proper HTML instead of raw text when scripting is disabled.

Before:
![image](https://user-images.githubusercontent.com/25595356/192045426-b14a2bbe-2445-443b-a713-689a47597d06.png)

After:
![Screenshot from 2022-09-23 20-43-50](https://user-images.githubusercontent.com/25595356/192045512-bbf99ad5-7204-4861-a8d7-86d5697cbd1e.png)
