### PR TITLE
LibWeb: Don't trigger page_did_layout() on non-active documents

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -816,7 +816,7 @@ void Document::update_layout()
 
     browsing_context()->set_needs_display();
 
-    if (browsing_context()->is_top_level()) {
+    if (browsing_context()->is_top_level() && browsing_context()->active_document() == this) {
         if (auto* page = this->page())
             page->client().page_did_layout();
     }


### PR DESCRIPTION
PageHost assumes `page_did_layout()` to be called when the layout of the active document changes, however, it seems that sometimes the layout can change on another document before the layout of the active document has been calculated. This leads to a `VERIFY()` being hit.

This commit now makes it so `page_did_layout()` is only called when the document is the active document.

Fixes #15328