### PR TITLE
 Kernel: Send SIGBUS to threads that use after valid Inode mmaped range (attempt #2)

### DIFF
--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -317,11 +317,16 @@ void page_fault_handler(TrapFrame* trap)
     PageFault fault { regs.exception_code, VirtualAddress { fault_address } };
     auto response = MM.handle_page_fault(fault);
 
-    if (response == PageFaultResponse::ShouldCrash || response == PageFaultResponse::OutOfMemory) {
+    if (response == PageFaultResponse::ShouldCrash || response == PageFaultResponse::OutOfMemory || response == PageFaultResponse::BusError) {
         if (faulted_in_kernel && handle_safe_access_fault(regs, fault_address)) {
             // If this would be a ring0 (kernel) fault and the fault was triggered by
             // safe_memcpy, safe_strnlen, or safe_memset then we resume execution at
             // the appropriate _fault label rather than crashing
+            return;
+        }
+
+        if (response == PageFaultResponse::BusError && current_thread->has_signal_handler(SIGBUS)) {
+            current_thread->send_urgent_signal_to_self(SIGBUS);
             return;
         }
 
@@ -341,7 +346,9 @@ void page_fault_handler(TrapFrame* trap)
         constexpr FlatPtr free_scrub_pattern = explode_byte(FREE_SCRUB_BYTE);
         constexpr FlatPtr kmalloc_scrub_pattern = explode_byte(KMALLOC_SCRUB_BYTE);
         constexpr FlatPtr kfree_scrub_pattern = explode_byte(KFREE_SCRUB_BYTE);
-        if ((fault_address & 0xffff0000) == (malloc_scrub_pattern & 0xffff0000)) {
+        if (response == PageFaultResponse::BusError) {
+            dbgln("Note: Address {} is an access to an undefined memory range of an Inode-backed VMObject", VirtualAddress(fault_address));
+        } else if ((fault_address & 0xffff0000) == (malloc_scrub_pattern & 0xffff0000)) {
             dbgln("Note: Address {} looks like it may be uninitialized malloc() memory", VirtualAddress(fault_address));
         } else if ((fault_address & 0xffff0000) == (free_scrub_pattern & 0xffff0000)) {
             dbgln("Note: Address {} looks like it may be recently free()'d memory", VirtualAddress(fault_address));
@@ -390,6 +397,8 @@ void page_fault_handler(TrapFrame* trap)
             }
         }
 
+        if (response == PageFaultResponse::BusError)
+            return handle_crash(regs, "Page Fault (Bus Error)", SIGBUS, false);
         return handle_crash(regs, "Page Fault", SIGSEGV, response == PageFaultResponse::OutOfMemory);
     } else if (response == PageFaultResponse::Continue) {
         dbgln_if(PAGE_FAULT_DEBUG, "Continuing after resolved page fault");

--- a/Kernel/Memory/PageFaultResponse.h
+++ b/Kernel/Memory/PageFaultResponse.h
@@ -10,6 +10,7 @@ namespace Kernel {
 
 enum class PageFaultResponse {
     ShouldCrash,
+    BusError,
     OutOfMemory,
     Continue,
 };

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -501,6 +501,11 @@ PageFaultResponse Region::handle_inode_fault(size_t page_index_in_region)
     }
 
     auto nread = result.value();
+    // Note: If we received 0, it means we are at the end of file or after it,
+    // which means we should return bus error.
+    if (nread == 0)
+        return PageFaultResponse::BusError;
+
     if (nread < PAGE_SIZE) {
         // If we read less than a page, zero out the rest to avoid leaking uninitialized data.
         memset(page_buffer + nread, 0, PAGE_SIZE - nread);

--- a/Tests/Kernel/CMakeLists.txt
+++ b/Tests/Kernel/CMakeLists.txt
@@ -33,7 +33,11 @@ serenity_test("crash.cpp" Kernel MAIN_ALREADY_DEFINED)
 
 set(LIBTEST_BASED_SOURCES
     TestEFault.cpp
+    TestEmptyPrivateInodeVMObject.cpp
+    TestEmptySharedInodeVMObject.cpp
     TestInvalidUIDSet.cpp
+    TestSharedInodeVMObject.cpp
+    TestPrivateInodeVMObject.cpp
     TestKernelAlarm.cpp
     TestKernelFilePermissions.cpp
     TestKernelPledge.cpp

--- a/Tests/Kernel/TestEmptyPrivateInodeVMObject.cpp
+++ b/Tests/Kernel/TestEmptyPrivateInodeVMObject.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/mman.h>
+
+static u8* private_ptr = nullptr;
+
+static void private_zero_length_inode_vmobject_sync_signal_handler(int)
+{
+    auto rc = msync(private_ptr, 0x1000, MS_ASYNC);
+    EXPECT(rc == 0);
+    rc = munmap(private_ptr, 0x1000);
+    EXPECT(rc == 0);
+    exit(0);
+}
+
+TEST_CASE(private_zero_length_inode_vmobject_sync)
+{
+    {
+        struct sigaction new_action {
+            { private_zero_length_inode_vmobject_sync_signal_handler }, 0, 0
+        };
+        int rc = sigaction(SIGBUS, &new_action, nullptr);
+        VERIFY(rc == 0);
+    }
+    int fd = open("/tmp/private_msync_test", O_RDWR | O_CREAT);
+    VERIFY(fd >= 0);
+    private_ptr = (u8*)mmap(nullptr, 0x1000, PROT_READ | PROT_WRITE, MAP_FILE | MAP_PRIVATE, fd, 0);
+    EXPECT(private_ptr != MAP_FAILED);
+    private_ptr[0] = 0x1;
+    VERIFY_NOT_REACHED();
+}

--- a/Tests/Kernel/TestEmptySharedInodeVMObject.cpp
+++ b/Tests/Kernel/TestEmptySharedInodeVMObject.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/mman.h>
+
+static u8* shared_ptr = nullptr;
+
+static void shared_zero_length_inode_vmobject_sync_signal_handler(int)
+{
+    auto rc = msync(shared_ptr, 0x1000, MS_ASYNC);
+    EXPECT(rc == 0);
+    rc = munmap(shared_ptr, 0x1000);
+    EXPECT(rc == 0);
+    exit(0);
+}
+
+TEST_CASE(shared_zero_length_inode_vmobject_sync)
+{
+    {
+        struct sigaction new_action {
+            { shared_zero_length_inode_vmobject_sync_signal_handler }, 0, 0
+        };
+        int rc = sigaction(SIGBUS, &new_action, nullptr);
+        VERIFY(rc == 0);
+    }
+    int fd = open("/tmp/shared_msync_test", O_RDWR | O_CREAT);
+    VERIFY(fd >= 0);
+    shared_ptr = (u8*)mmap(nullptr, 0x1000, PROT_READ | PROT_WRITE, MAP_FILE | MAP_SHARED, fd, 0);
+    EXPECT(shared_ptr != MAP_FAILED);
+    shared_ptr[0] = 0x1;
+    VERIFY_NOT_REACHED();
+}

--- a/Tests/Kernel/TestPrivateInodeVMObject.cpp
+++ b/Tests/Kernel/TestPrivateInodeVMObject.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+static u8* private_ptr = nullptr;
+
+static void private_non_empty_inode_vmobject_sync_signal_handler(int)
+{
+    auto rc = msync(private_ptr, 0x1000, MS_ASYNC);
+    EXPECT(rc == 0);
+    rc = munmap(private_ptr, 0x1000);
+    EXPECT(rc == 0);
+    exit(0);
+}
+
+TEST_CASE(private_non_empty_inode_vmobject_sync)
+{
+    {
+        struct sigaction new_action {
+            { private_non_empty_inode_vmobject_sync_signal_handler }, 0, 0
+        };
+        int rc = sigaction(SIGBUS, &new_action, nullptr);
+        VERIFY(rc == 0);
+    }
+    u8 buf[0x1000];
+    memset(buf, 0, sizeof(buf));
+    int fd = open("/tmp/private_non_empty_msync_test", O_RDWR | O_CREAT);
+    VERIFY(fd >= 0);
+    auto rc = write(fd, buf, sizeof(buf));
+    VERIFY(rc == sizeof(buf));
+    private_ptr = (u8*)mmap(nullptr, 0x2000, PROT_READ | PROT_WRITE, MAP_FILE | MAP_PRIVATE, fd, 0);
+    EXPECT(private_ptr != MAP_FAILED);
+    rc = msync(private_ptr, 0x2000, MS_ASYNC);
+    EXPECT(rc == 0);
+    private_ptr[0x1001] = 0x1;
+    VERIFY_NOT_REACHED();
+}

--- a/Tests/Kernel/TestSharedInodeVMObject.cpp
+++ b/Tests/Kernel/TestSharedInodeVMObject.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+static u8* shared_ptr = nullptr;
+
+static void shared_non_empty_inode_vmobject_sync_signal_handler(int)
+{
+    auto rc = msync(shared_ptr, 0x1000, MS_ASYNC);
+    EXPECT(rc == 0);
+    rc = munmap(shared_ptr, 0x1000);
+    EXPECT(rc == 0);
+    exit(0);
+}
+
+TEST_CASE(shared_non_empty_inode_vmobject_sync)
+{
+    {
+        struct sigaction new_action {
+            { shared_non_empty_inode_vmobject_sync_signal_handler }, 0, 0
+        };
+        int rc = sigaction(SIGBUS, &new_action, nullptr);
+        VERIFY(rc == 0);
+    }
+    u8 buf[0x1000];
+    memset(buf, 0, sizeof(buf));
+    int fd = open("/tmp/shared_non_empty_msync_test", O_RDWR | O_CREAT);
+    VERIFY(fd >= 0);
+    auto rc = write(fd, buf, sizeof(buf));
+    VERIFY(rc == sizeof(buf));
+    shared_ptr = (u8*)mmap(nullptr, 0x2000, PROT_READ | PROT_WRITE, MAP_FILE | MAP_SHARED, fd, 0);
+    EXPECT(shared_ptr != MAP_FAILED);
+    rc = msync(shared_ptr, 0x2000, MS_ASYNC);
+    EXPECT(rc == 0);
+    shared_ptr[0x1001] = 0x1;
+    VERIFY_NOT_REACHED();
+}


### PR DESCRIPTION
I broke SMP with #14785. After a couple of hours of debugging, splitting spinlocks and what not (even reverting my changes in #15336), I managed to find a conclusion what is wrong with my patch - we locked a spinlock and then a Mutex, thus, easily creating a deadlock situation.
I added a paragraph near the lock site to explain why we don't use that subset of my patch under the InodeVMObject spinlock.
Hopefully this will be enough, sorry for the inconvenience and the trouble.

#15336 fixed #15332 by reverting my changes, but this PR fixes #15332 completely.