### PR TITLE
 Kernel/Memory: Split big VMObject spinlock to SpinlockProtected members

### DIFF
--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -76,6 +76,11 @@ public:
         return create(span());
     }
 
+    static void move_elements_to_new_array_from_old_array(FixedArray<T>& new_array, FixedArray<T>&& old_array)
+    {
+        new_array.m_storage = exchange(old_array.m_storage, nullptr);
+    }
+
     static size_t storage_allocation_size(size_t size)
     {
         return sizeof(Storage) + size * sizeof(T);

--- a/Kernel/Memory/AddressSpace.cpp
+++ b/Kernel/Memory/AddressSpace.cpp
@@ -397,9 +397,12 @@ size_t AddressSpace::amount_purgeable_volatile() const
     for (auto const& region : m_region_tree.regions()) {
         if (!region.vmobject().is_anonymous())
             continue;
+
         auto const& vmobject = static_cast<AnonymousVMObject const&>(region.vmobject());
-        if (vmobject.is_purgeable() && vmobject.is_volatile())
-            amount += region.amount_resident();
+        vmobject.attributes().with([&](auto& attributes) {
+            if (attributes.is_purgeable && attributes.is_volatile)
+                amount += region.amount_resident();
+        });
     }
     return amount;
 }
@@ -411,8 +414,10 @@ size_t AddressSpace::amount_purgeable_nonvolatile() const
         if (!region.vmobject().is_anonymous())
             continue;
         auto const& vmobject = static_cast<AnonymousVMObject const&>(region.vmobject());
-        if (vmobject.is_purgeable() && !vmobject.is_volatile())
-            amount += region.amount_resident();
+        vmobject.attributes().with([&](auto& attributes) {
+            if (attributes.is_purgeable && !attributes.is_volatile)
+                amount += region.amount_resident();
+        });
     }
     return amount;
 }

--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -16,63 +16,71 @@ namespace Kernel::Memory {
 
 ErrorOr<NonnullLockRefPtr<VMObject>> AnonymousVMObject::try_clone()
 {
-    // We need to acquire our lock so we copy a sane state
-    SpinlockLocker lock(m_lock);
-
-    if (is_purgeable() && is_volatile()) {
-        // If this object is purgeable+volatile, create a new zero-filled purgeable+volatile
-        // object, effectively "pre-purging" it in the child process.
-        auto clone = TRY(try_create_purgeable_with_size(size(), AllocationStrategy::None));
-        clone->m_volatile = true;
-        return clone;
-    }
-
-    // We're the parent. Since we're about to become COW we need to
-    // commit the number of pages that we need to potentially allocate
-    // so that the parent is still guaranteed to be able to have all
-    // non-volatile memory available.
-    size_t new_cow_pages_needed = 0;
-    for (auto const& page : m_physical_pages) {
-        if (!page->is_shared_zero_page())
-            ++new_cow_pages_needed;
-    }
-
-    if (new_cow_pages_needed == 0)
-        return TRY(try_create_with_size(size(), AllocationStrategy::None));
-
-    dbgln_if(COMMIT_DEBUG, "Cloning {:p}, need {} committed cow pages", this, new_cow_pages_needed);
-
-    auto committed_pages = TRY(MM.commit_physical_pages(new_cow_pages_needed));
-
-    // Create or replace the committed cow pages. When cloning a previously
-    // cloned vmobject, we want to essentially "fork", leaving us and the
-    // new clone with one set of shared committed cow pages, and the original
-    // one would keep the one it still has. This ensures that the original
-    // one and this one, as well as the clone have sufficient resources
-    // to cow all pages as needed
-    auto new_shared_committed_cow_pages = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) SharedCommittedCowPages(move(committed_pages))));
-    auto new_physical_pages = TRY(this->try_clone_physical_pages());
-    auto clone = TRY(try_create_with_shared_cow(*this, *new_shared_committed_cow_pages, move(new_physical_pages)));
-
-    // Both original and clone become COW. So create a COW map for ourselves
-    // or reset all pages to be copied again if we were previously cloned
-    TRY(ensure_or_reset_cow_map());
-
-    m_shared_committed_cow_pages = move(new_shared_committed_cow_pages);
-
-    if (m_unused_committed_pages.has_value() && !m_unused_committed_pages->is_empty()) {
-        // The parent vmobject didn't use up all committed pages. When
-        // cloning (fork) we will overcommit. For this purpose we drop all
-        // lazy-commit references and replace them with shared zero pages.
-        for (size_t i = 0; i < page_count(); i++) {
-            auto& page = clone->m_physical_pages[i];
-            if (page && page->is_lazy_committed_page()) {
-                page = MM.shared_zero_page();
-            }
+    // We need to acquire our m_attributes being locked so we copy a sane state
+    return m_attributes.with([&](auto& attributes) -> ErrorOr<NonnullLockRefPtr<VMObject>> {
+        if (attributes.is_purgeable && attributes.is_volatile) {
+            // If this object is purgeable+volatile, create a new zero-filled purgeable+volatile
+            // object, effectively "pre-purging" it in the child process.
+            auto clone = TRY(try_create_purgeable_with_size(size(), AllocationStrategy::None));
+            clone->m_attributes.with([&](auto& attributes) {
+                attributes.is_volatile = true;
+            });
+            return clone;
         }
-    }
 
-    return clone;
+        // We're the parent. Since we're about to become COW we need to
+        // commit the number of pages that we need to potentially allocate
+        // so that the parent is still guaranteed to be able to have all
+        // non-volatile memory available.
+        size_t new_cow_pages_needed = 0;
+        m_physical_pages.with([&](auto& array) {
+            for (auto const& page : array) {
+                if (!page->is_shared_zero_page())
+                    ++new_cow_pages_needed;
+            }
+        });
+
+        if (new_cow_pages_needed == 0)
+            return TRY(try_create_with_size(size(), AllocationStrategy::None));
+
+        dbgln_if(COMMIT_DEBUG, "Cloning {:p}, need {} committed cow pages", this, new_cow_pages_needed);
+
+        auto committed_pages = TRY(MM.commit_physical_pages(new_cow_pages_needed));
+
+        // Create or replace the committed cow pages. When cloning a previously
+        // cloned vmobject, we want to essentially "fork", leaving us and the
+        // new clone with one set of shared committed cow pages, and the original
+        // one would keep the one it still has. This ensures that the original
+        // one and this one, as well as the clone have sufficient resources
+        // to cow all pages as needed
+        auto new_shared_committed_cow_pages = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) SharedCommittedCowPages(move(committed_pages))));
+        auto new_physical_pages = TRY(this->try_clone_physical_pages());
+        auto clone = TRY(try_create_with_shared_cow(*this, *new_shared_committed_cow_pages, move(new_physical_pages)));
+
+        // Both original and clone become COW. So create a COW map for ourselves
+        // or reset all pages to be copied again if we were previously cloned
+        TRY(ensure_or_reset_cow_map());
+
+        m_shared_committed_cow_pages.with([&](auto& shared_committed_cow_pages) {
+            shared_committed_cow_pages = *new_shared_committed_cow_pages;
+        });
+
+        if (m_unused_committed_pages.has_value() && !m_unused_committed_pages->is_empty()) {
+            // The parent vmobject didn't use up all committed pages. When
+            // cloning (fork) we will overcommit. For this purpose we drop all
+            // lazy-commit references and replace them with shared zero pages.
+            clone->m_physical_pages.with([&](auto& array) {
+                for (size_t i = 0; i < page_count(); i++) {
+                    auto& page = array[i];
+                    if (page && page->is_lazy_committed_page()) {
+                        page = MM.shared_zero_page();
+                    }
+                }
+            });
+        }
+
+        return clone;
+    });
 }
 
 ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_with_size(size_t size, AllocationStrategy strategy)
@@ -106,7 +114,9 @@ ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_purg
     auto new_physical_pages = TRY(VMObject::try_create_physical_pages(size));
 
     auto vmobject = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) AnonymousVMObject(move(new_physical_pages), strategy, move(committed_pages))));
-    vmobject->m_purgeable = true;
+    vmobject->m_attributes.with([&](auto& attributes) {
+        attributes.is_purgeable = true;
+    });
     return vmobject;
 }
 
@@ -143,23 +153,27 @@ AnonymousVMObject::AnonymousVMObject(FixedArray<RefPtr<PhysicalPage>>&& new_phys
     : VMObject(move(new_physical_pages))
     , m_unused_committed_pages(move(committed_pages))
 {
-    if (strategy == AllocationStrategy::AllocateNow) {
-        // Allocate all pages right now. We know we can get all because we committed the amount needed
-        for (size_t i = 0; i < page_count(); ++i)
-            physical_pages()[i] = m_unused_committed_pages->take_one();
-    } else {
-        auto& initial_page = (strategy == AllocationStrategy::Reserve) ? MM.lazy_committed_page() : MM.shared_zero_page();
-        for (size_t i = 0; i < page_count(); ++i)
-            physical_pages()[i] = initial_page;
-    }
+    physical_pages().with([&](auto& array) {
+        if (strategy == AllocationStrategy::AllocateNow) {
+            // Allocate all pages right now. We know we can get all because we committed the amount needed
+            for (size_t i = 0; i < page_count(); ++i)
+                array[i] = m_unused_committed_pages->take_one();
+        } else {
+            auto& initial_page = (strategy == AllocationStrategy::Reserve) ? MM.lazy_committed_page() : MM.shared_zero_page();
+            for (size_t i = 0; i < page_count(); ++i)
+                array[i] = initial_page;
+        }
+    });
 }
 
 AnonymousVMObject::AnonymousVMObject(PhysicalAddress paddr, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
     : VMObject(move(new_physical_pages))
 {
     VERIFY(paddr.page_base() == paddr);
-    for (size_t i = 0; i < page_count(); ++i)
-        physical_pages()[i] = PhysicalPage::create(paddr.offset(i * PAGE_SIZE), MayReturnToFreeList::No);
+    physical_pages().with([&](auto& array) {
+        for (size_t i = 0; i < page_count(); ++i)
+            array[i] = PhysicalPage::create(paddr.offset(i * PAGE_SIZE), MayReturnToFreeList::No);
+    });
 }
 
 AnonymousVMObject::AnonymousVMObject(FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
@@ -167,107 +181,134 @@ AnonymousVMObject::AnonymousVMObject(FixedArray<RefPtr<PhysicalPage>>&& new_phys
 {
 }
 
-AnonymousVMObject::AnonymousVMObject(LockWeakPtr<AnonymousVMObject> other, NonnullLockRefPtr<SharedCommittedCowPages> shared_committed_cow_pages, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+AnonymousVMObject::AnonymousVMObject(LockWeakPtr<AnonymousVMObject> other, NonnullLockRefPtr<SharedCommittedCowPages> preset_shared_committed_cow_pages, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
     : VMObject(move(new_physical_pages))
     , m_cow_parent(move(other))
-    , m_shared_committed_cow_pages(move(shared_committed_cow_pages))
-    , m_purgeable(m_cow_parent.strong_ref()->m_purgeable)
 {
+    m_shared_committed_cow_pages.with([&](auto& shared_committed_cow_pages) {
+        shared_committed_cow_pages = *preset_shared_committed_cow_pages;
+    });
+
+    m_attributes.with([&](auto& attributes) {
+        m_cow_parent.strong_ref()->attributes().with([&](auto& other_attributes) {
+            attributes.is_purgeable = other_attributes.is_purgeable;
+        });
+    });
+}
+
+void AnonymousVMObject::will_be_destroyed()
+{
+    m_shared_committed_cow_pages.with([&](auto& shared_committed_cow_pages) {
+        if (!shared_committed_cow_pages || shared_committed_cow_pages->is_empty())
+            return;
+
+        auto cow_parent = m_cow_parent.strong_ref();
+        if (!cow_parent)
+            return;
+        cow_parent->m_shared_committed_cow_pages.with([&](auto& cow_parent_shared_committed_cow_pages) {
+            if (cow_parent_shared_committed_cow_pages == shared_committed_cow_pages)
+                cow_parent_shared_committed_cow_pages.clear();
+        });
+    });
 }
 
 AnonymousVMObject::~AnonymousVMObject()
 {
-    if (!m_shared_committed_cow_pages || m_shared_committed_cow_pages->is_empty())
-        return;
-    auto cow_parent = m_cow_parent.strong_ref();
-    if (!cow_parent)
-        return;
-    SpinlockLocker lock(cow_parent->m_lock);
-    if (cow_parent->m_shared_committed_cow_pages == m_shared_committed_cow_pages)
-        cow_parent->m_shared_committed_cow_pages.clear();
 }
 
 size_t AnonymousVMObject::purge()
 {
-    SpinlockLocker lock(m_lock);
+    return m_attributes.with([&](auto& attributes) -> size_t {
+        if (!attributes.is_purgeable || !attributes.is_volatile)
+            return 0;
 
-    if (!is_purgeable() || !is_volatile())
-        return 0;
+        size_t total_pages_purged = 0;
 
-    size_t total_pages_purged = 0;
+        m_physical_pages.with([&](auto& array) {
+            for (auto& page : array) {
+                VERIFY(page);
+                if (page->is_shared_zero_page())
+                    continue;
+                page = MM.shared_zero_page();
+                ++total_pages_purged;
+            }
+        });
 
-    for (auto& page : m_physical_pages) {
-        VERIFY(page);
-        if (page->is_shared_zero_page())
-            continue;
-        page = MM.shared_zero_page();
-        ++total_pages_purged;
-    }
+        attributes.was_purged = true;
 
-    m_was_purged = true;
+        for_each_region([](Region& region) {
+            region.remap();
+        });
 
-    for_each_region([](Region& region) {
-        region.remap();
+        return total_pages_purged;
     });
-
-    return total_pages_purged;
 }
 
 ErrorOr<void> AnonymousVMObject::set_volatile(bool is_volatile, bool& was_purged)
 {
-    VERIFY(is_purgeable());
+    return m_attributes.with([&](auto& attributes) -> ErrorOr<void> {
+        if (!attributes.is_purgeable)
+            return Error::from_errno(EINVAL);
 
-    SpinlockLocker locker(m_lock);
+        was_purged = attributes.was_purged;
+        if (attributes.is_volatile == is_volatile)
+            return {};
 
-    was_purged = m_was_purged;
-    if (m_volatile == is_volatile)
-        return {};
+        if (is_volatile) {
+            // When a VMObject is made volatile, it gives up all of its committed memory.
+            // Any physical pages already allocated remain in the VMObject for now, but the kernel is free to take them at any moment.
 
-    if (is_volatile) {
-        // When a VMObject is made volatile, it gives up all of its committed memory.
-        // Any physical pages already allocated remain in the VMObject for now, but the kernel is free to take them at any moment.
-        for (auto& page : m_physical_pages) {
-            if (page && page->is_lazy_committed_page())
-                page = MM.shared_zero_page();
+            m_physical_pages.with([&](auto& array) {
+                for (auto& page : array) {
+                    if (page && page->is_lazy_committed_page())
+                        page = MM.shared_zero_page();
+                }
+            });
+
+            m_unused_committed_pages = {};
+            m_shared_committed_cow_pages.with([&](auto& shared_committed_cow_pages) {
+                shared_committed_cow_pages = nullptr;
+            });
+
+            if (!m_cow_map.is_null())
+                m_cow_map = {};
+
+            attributes.is_volatile = true;
+            attributes.was_purged = false;
+
+            for_each_region([&](auto& region) { region.remap(); });
+            return {};
+        }
+        // When a VMObject is made non-volatile, we try to commit however many pages are not currently available.
+        // If that fails, we return false to indicate that memory allocation failed.
+        size_t committed_pages_needed = 0;
+        m_physical_pages.with([&](auto& array) {
+            for (auto& page : array) {
+                VERIFY(page);
+                if (page->is_shared_zero_page())
+                    ++committed_pages_needed;
+            }
+        });
+
+        if (!committed_pages_needed) {
+            attributes.is_volatile = false;
+            return {};
         }
 
-        m_unused_committed_pages = {};
-        m_shared_committed_cow_pages = nullptr;
+        m_unused_committed_pages = TRY(MM.commit_physical_pages(committed_pages_needed));
 
-        if (!m_cow_map.is_null())
-            m_cow_map = {};
+        m_physical_pages.with([&](auto& array) {
+            for (auto& page : array) {
+                if (page->is_shared_zero_page())
+                    page = MM.lazy_committed_page();
+            }
+        });
 
-        m_volatile = true;
-        m_was_purged = false;
-
+        attributes.is_volatile = false;
+        attributes.was_purged = false;
         for_each_region([&](auto& region) { region.remap(); });
         return {};
-    }
-    // When a VMObject is made non-volatile, we try to commit however many pages are not currently available.
-    // If that fails, we return false to indicate that memory allocation failed.
-    size_t committed_pages_needed = 0;
-    for (auto& page : m_physical_pages) {
-        VERIFY(page);
-        if (page->is_shared_zero_page())
-            ++committed_pages_needed;
-    }
-
-    if (!committed_pages_needed) {
-        m_volatile = false;
-        return {};
-    }
-
-    m_unused_committed_pages = TRY(MM.commit_physical_pages(committed_pages_needed));
-
-    for (auto& page : m_physical_pages) {
-        if (page->is_shared_zero_page())
-            page = MM.lazy_committed_page();
-    }
-
-    m_volatile = false;
-    m_was_purged = false;
-    for_each_region([&](auto& region) { region.remap(); });
-    return {};
+    });
 }
 
 NonnullRefPtr<PhysicalPage> AnonymousVMObject::allocate_committed_page(Badge<Region>)
@@ -293,12 +334,14 @@ ErrorOr<void> AnonymousVMObject::ensure_or_reset_cow_map()
 
 bool AnonymousVMObject::should_cow(size_t page_index, bool is_shared) const
 {
-    auto const& page = physical_pages()[page_index];
-    if (page && (page->is_shared_zero_page() || page->is_lazy_committed_page()))
-        return true;
-    if (is_shared)
-        return false;
-    return !m_cow_map.is_null() && m_cow_map.get(page_index);
+    return m_physical_pages.with([&](auto& array) -> bool {
+        auto const& page = array[page_index];
+        if (page && (page->is_shared_zero_page() || page->is_lazy_committed_page()))
+            return true;
+        if (is_shared)
+            return false;
+        return !m_cow_map.is_null() && m_cow_map.get(page_index);
+    });
 }
 
 ErrorOr<void> AnonymousVMObject::set_should_cow(size_t page_index, bool cow)
@@ -317,67 +360,70 @@ size_t AnonymousVMObject::cow_pages() const
 
 PageFaultResponse AnonymousVMObject::handle_cow_fault(size_t page_index, VirtualAddress vaddr)
 {
-    SpinlockLocker lock(m_lock);
-
-    if (is_volatile()) {
-        // A COW fault in a volatile region? Userspace is writing to volatile memory, this is a bug. Crash.
-        dbgln("COW fault in volatile region, will crash.");
-        return PageFaultResponse::ShouldCrash;
-    }
-
-    auto& page_slot = physical_pages()[page_index];
-
-    // If we were sharing committed COW pages with another process, and the other process
-    // has exhausted the supply, we can stop counting the shared pages.
-    if (m_shared_committed_cow_pages && m_shared_committed_cow_pages->is_empty())
-        m_shared_committed_cow_pages = nullptr;
-
-    if (page_slot->ref_count() == 1) {
-        dbgln_if(PAGE_FAULT_DEBUG, "    >> It's a COW page but nobody is sharing it anymore. Remap r/w");
-        MUST(set_should_cow(page_index, false)); // If we received a COW fault, we already have a cow map allocated, so this is infallible
-
-        if (m_shared_committed_cow_pages) {
-            m_shared_committed_cow_pages->uncommit_one();
-            if (m_shared_committed_cow_pages->is_empty())
-                m_shared_committed_cow_pages = nullptr;
+    return m_attributes.with([&](auto& attributes) -> PageFaultResponse {
+        if (attributes.is_volatile) {
+            // A COW fault in a volatile region? Userspace is writing to volatile memory, this is a bug. Crash.
+            dbgln("COW fault in volatile region, will crash.");
+            return PageFaultResponse::ShouldCrash;
         }
-        return PageFaultResponse::Continue;
-    }
 
-    RefPtr<PhysicalPage> page;
-    if (m_shared_committed_cow_pages) {
-        dbgln_if(PAGE_FAULT_DEBUG, "    >> It's a committed COW page and it's time to COW!");
-        page = m_shared_committed_cow_pages->take_one();
-    } else {
-        dbgln_if(PAGE_FAULT_DEBUG, "    >> It's a COW page and it's time to COW!");
-        auto page_or_error = MM.allocate_physical_page(MemoryManager::ShouldZeroFill::No);
-        if (page_or_error.is_error()) {
-            dmesgln("MM: handle_cow_fault was unable to allocate a physical page");
-            return PageFaultResponse::OutOfMemory;
-        }
-        page = page_or_error.release_value();
-    }
+        return physical_pages().with([&](auto& array) -> PageFaultResponse {
+            auto& page_slot = array[page_index];
 
-    dbgln_if(PAGE_FAULT_DEBUG, "      >> COW {} <- {}", page->paddr(), page_slot->paddr());
-    {
-        u8* dest_ptr = MM.quickmap_page(*page);
-        SmapDisabler disabler;
-        void* fault_at;
-        if (!safe_memcpy(dest_ptr, vaddr.as_ptr(), PAGE_SIZE, fault_at)) {
-            if ((u8*)fault_at >= dest_ptr && (u8*)fault_at <= dest_ptr + PAGE_SIZE)
-                dbgln("      >> COW: error copying page {}/{} to {}/{}: failed to write to page at {}",
-                    page_slot->paddr(), vaddr, page->paddr(), VirtualAddress(dest_ptr), VirtualAddress(fault_at));
-            else if ((u8*)fault_at >= vaddr.as_ptr() && (u8*)fault_at <= vaddr.as_ptr() + PAGE_SIZE)
-                dbgln("      >> COW: error copying page {}/{} to {}/{}: failed to read from page at {}",
-                    page_slot->paddr(), vaddr, page->paddr(), VirtualAddress(dest_ptr), VirtualAddress(fault_at));
-            else
-                VERIFY_NOT_REACHED();
-        }
-        MM.unquickmap_page();
-    }
-    page_slot = move(page);
-    MUST(set_should_cow(page_index, false)); // If we received a COW fault, we already have a cow map allocated, so this is infallible
-    return PageFaultResponse::Continue;
+            // If we were sharing committed COW pages with another process, and the other process
+            // has exhausted the supply, we can stop counting the shared pages.
+            return m_shared_committed_cow_pages.with([&](auto& shared_committed_cow_pages) -> PageFaultResponse {
+                if (shared_committed_cow_pages && shared_committed_cow_pages->is_empty())
+                    shared_committed_cow_pages = nullptr;
+                if (page_slot->ref_count() == 1) {
+                    dbgln_if(PAGE_FAULT_DEBUG, "    >> It's a COW page but nobody is sharing it anymore. Remap r/w");
+                    MUST(set_should_cow(page_index, false)); // If we received a COW fault, we already have a cow map allocated, so this is infallible
+
+                    if (shared_committed_cow_pages) {
+                        shared_committed_cow_pages->uncommit_one();
+                        if (shared_committed_cow_pages->is_empty())
+                            shared_committed_cow_pages = nullptr;
+                    }
+                    return PageFaultResponse::Continue;
+                }
+
+                RefPtr<PhysicalPage> page;
+                if (shared_committed_cow_pages) {
+                    dbgln_if(PAGE_FAULT_DEBUG, "    >> It's a committed COW page and it's time to COW!");
+                    page = shared_committed_cow_pages->take_one();
+                } else {
+                    dbgln_if(PAGE_FAULT_DEBUG, "    >> It's a COW page and it's time to COW!");
+                    auto page_or_error = MM.allocate_physical_page(MemoryManager::ShouldZeroFill::No);
+                    if (page_or_error.is_error()) {
+                        dmesgln("MM: handle_cow_fault was unable to allocate a physical page");
+                        return PageFaultResponse::OutOfMemory;
+                    }
+                    page = page_or_error.release_value();
+                }
+
+                dbgln_if(PAGE_FAULT_DEBUG, "      >> COW {} <- {}", page->paddr(), page_slot->paddr());
+                {
+                    u8* dest_ptr = MM.quickmap_page(*page);
+                    SmapDisabler disabler;
+                    void* fault_at;
+                    if (!safe_memcpy(dest_ptr, vaddr.as_ptr(), PAGE_SIZE, fault_at)) {
+                        if ((u8*)fault_at >= dest_ptr && (u8*)fault_at <= dest_ptr + PAGE_SIZE)
+                            dbgln("      >> COW: error copying page {}/{} to {}/{}: failed to write to page at {}",
+                                page_slot->paddr(), vaddr, page->paddr(), VirtualAddress(dest_ptr), VirtualAddress(fault_at));
+                        else if ((u8*)fault_at >= vaddr.as_ptr() && (u8*)fault_at <= vaddr.as_ptr() + PAGE_SIZE)
+                            dbgln("      >> COW: error copying page {}/{} to {}/{}: failed to read from page at {}",
+                                page_slot->paddr(), vaddr, page->paddr(), VirtualAddress(dest_ptr), VirtualAddress(fault_at));
+                        else
+                            VERIFY_NOT_REACHED();
+                    }
+                    MM.unquickmap_page();
+                }
+                page_slot = move(page);
+                MUST(set_should_cow(page_index, false)); // If we received a COW fault, we already have a cow map allocated, so this is infallible
+                return PageFaultResponse::Continue;
+            });
+        });
+    });
 }
 
 AnonymousVMObject::SharedCommittedCowPages::SharedCommittedCowPages(CommittedPhysicalPageSet&& committed_pages)

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -1004,8 +1004,6 @@ ErrorOr<NonnullRefPtr<PhysicalPage>> MemoryManager::allocate_physical_page(Shoul
                 if (!vmobject.is_anonymous())
                     return IterationDecision::Continue;
                 auto& anonymous_vmobject = static_cast<AnonymousVMObject&>(vmobject);
-                if (!anonymous_vmobject.is_purgeable() || !anonymous_vmobject.is_volatile())
-                    return IterationDecision::Continue;
                 if (auto purged_page_count = anonymous_vmobject.purge()) {
                     dbgln("MM: Purge saved the day! Purged {} pages from AnonymousVMObject", purged_page_count);
                     page = find_free_physical_page(false);

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -14,6 +14,7 @@
 #include <Kernel/KString.h>
 #include <Kernel/Library/LockWeakable.h>
 #include <Kernel/Locking/LockRank.h>
+#include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/PageFaultResponse.h>
 #include <Kernel/Memory/VirtualRange.h>
 #include <Kernel/Sections.h>
@@ -163,7 +164,6 @@ public:
     }
 
     RefPtr<PhysicalPage> physical_page(size_t index) const;
-    RefPtr<PhysicalPage>& physical_page_slot(size_t index);
 
     [[nodiscard]] size_t offset_in_vmobject() const
     {

--- a/Kernel/Memory/ScatterGatherList.h
+++ b/Kernel/Memory/ScatterGatherList.h
@@ -22,7 +22,7 @@ public:
     static LockRefPtr<ScatterGatherList> try_create(AsyncBlockDeviceRequest&, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size);
     VMObject const& vmobject() const { return m_vm_object; }
     VirtualAddress dma_region() const { return m_dma_region->vaddr(); }
-    size_t scatters_count() const { return m_vm_object->physical_pages().size(); }
+    size_t scatters_count() const { return m_vm_object->page_count(); }
 
 private:
     ScatterGatherList(NonnullLockRefPtr<AnonymousVMObject>, AsyncBlockDeviceRequest&, size_t device_block_size);

--- a/Kernel/Memory/SharedFramebufferVMObject.h
+++ b/Kernel/Memory/SharedFramebufferVMObject.h
@@ -29,8 +29,8 @@ public:
         }
         virtual StringView class_name() const override { return "FakeWritesFramebufferVMObject"sv; }
         virtual ErrorOr<NonnullLockRefPtr<VMObject>> try_clone() override { return Error::from_errno(ENOTIMPL); }
-        virtual ReadonlySpan<RefPtr<PhysicalPage>> physical_pages() const override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
-        virtual Span<RefPtr<PhysicalPage>> physical_pages() override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
+        SpinlockProtected<FixedArray<RefPtr<PhysicalPage>>, LockRank::None> const& physical_pages() const override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
+        SpinlockProtected<FixedArray<RefPtr<PhysicalPage>>, LockRank::None>& physical_pages() override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
         NonnullLockRefPtr<SharedFramebufferVMObject> m_parent_object;
     };
 
@@ -46,8 +46,8 @@ public:
         }
         virtual StringView class_name() const override { return "RealWritesFramebufferVMObject"sv; }
         virtual ErrorOr<NonnullLockRefPtr<VMObject>> try_clone() override { return Error::from_errno(ENOTIMPL); }
-        virtual ReadonlySpan<RefPtr<PhysicalPage>> physical_pages() const override { return m_parent_object->real_framebuffer_physical_pages(); }
-        virtual Span<RefPtr<PhysicalPage>> physical_pages() override { return m_parent_object->real_framebuffer_physical_pages(); }
+        virtual SpinlockProtected<FixedArray<RefPtr<PhysicalPage>>, LockRank::None> const& physical_pages() const override { return m_parent_object->real_framebuffer_physical_pages(); }
+        virtual SpinlockProtected<FixedArray<RefPtr<PhysicalPage>>, LockRank::None>& physical_pages() override { return m_parent_object->real_framebuffer_physical_pages(); }
         NonnullLockRefPtr<SharedFramebufferVMObject> m_parent_object;
     };
 
@@ -60,14 +60,14 @@ public:
     void switch_to_fake_sink_framebuffer_writes(Badge<Kernel::DisplayConnector>);
     void switch_to_real_framebuffer_writes(Badge<Kernel::DisplayConnector>);
 
-    virtual ReadonlySpan<RefPtr<PhysicalPage>> physical_pages() const override;
-    virtual Span<RefPtr<PhysicalPage>> physical_pages() override;
+    virtual SpinlockProtected<FixedArray<RefPtr<PhysicalPage>>, LockRank::None>& physical_pages() override;
+    virtual SpinlockProtected<FixedArray<RefPtr<PhysicalPage>>, LockRank::None> const& physical_pages() const override;
 
-    Span<RefPtr<PhysicalPage>> fake_sink_framebuffer_physical_pages();
-    ReadonlySpan<RefPtr<PhysicalPage>> fake_sink_framebuffer_physical_pages() const;
+    SpinlockProtected<FixedArray<RefPtr<PhysicalPage>>, LockRank::None>& fake_sink_framebuffer_physical_pages();
+    SpinlockProtected<FixedArray<RefPtr<PhysicalPage>>, LockRank::None> const& fake_sink_framebuffer_physical_pages() const;
 
-    Span<RefPtr<PhysicalPage>> real_framebuffer_physical_pages();
-    ReadonlySpan<RefPtr<PhysicalPage>> real_framebuffer_physical_pages() const;
+    SpinlockProtected<FixedArray<RefPtr<PhysicalPage>>, LockRank::None>& real_framebuffer_physical_pages();
+    SpinlockProtected<FixedArray<RefPtr<PhysicalPage>>, LockRank::None> const& real_framebuffer_physical_pages() const;
 
     FakeWritesFramebufferVMObject const& fake_writes_framebuffer_vmobject() const { return *m_fake_writes_framebuffer_vmobject; }
     FakeWritesFramebufferVMObject& fake_writes_framebuffer_vmobject() { return *m_fake_writes_framebuffer_vmobject; }

--- a/Kernel/Memory/SharedInodeVMObject.h
+++ b/Kernel/Memory/SharedInodeVMObject.h
@@ -30,6 +30,8 @@ private:
     virtual StringView class_name() const override { return "SharedInodeVMObject"sv; }
 
     SharedInodeVMObject& operator=(SharedInodeVMObject const&) = delete;
+
+    Mutex m_sync_lock;
 };
 
 }

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -429,8 +429,6 @@ ErrorOr<FlatPtr> Process::sys$madvise(Userspace<void*> address, size_t size, int
             if (!region->vmobject().is_anonymous())
                 return EINVAL;
             auto& vmobject = static_cast<Memory::AnonymousVMObject&>(region->vmobject());
-            if (!vmobject.is_purgeable())
-                return EINVAL;
             bool was_purged = false;
             TRY(vmobject.set_volatile(advice == MADV_SET_VOLATILE, was_purged));
             return was_purged ? 1 : 0;

--- a/Tests/AK/TestFixedArray.cpp
+++ b/Tests/AK/TestFixedArray.cpp
@@ -48,6 +48,23 @@ TEST_CASE(move)
     EXPECT_EQ(moved_from_array.size(), 0u);
 }
 
+TEST_CASE(move_from_old_to_new)
+{
+    FixedArray<int> old_array = FixedArray<int>::must_create_but_fixme_should_propagate_errors(4);
+    FixedArray<int> new_array;
+    old_array[0] = 0;
+    old_array[1] = 1;
+    old_array[2] = 2;
+    old_array[3] = 2;
+    FixedArray<int>::move_elements_to_new_array_from_old_array(new_array, move(old_array));
+    EXPECT_EQ(old_array.size(), 0u);
+    EXPECT_EQ(new_array.size(), 4u);
+    EXPECT_EQ(new_array[0], 0);
+    EXPECT_EQ(new_array[1], 1);
+    EXPECT_EQ(new_array[2], 2);
+    EXPECT_EQ(new_array[3], 2);
+}
+
 TEST_CASE(no_allocation)
 {
     FixedArray<int> array = FixedArray<int>::must_create_but_fixme_should_propagate_errors(5);


### PR DESCRIPTION
Relies on #15338.