### PR TITLE
LibEDID: Remove head index when retrieving an EDID from DisplayConnector

### DIFF
--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -153,7 +153,7 @@ void MonitorSettingsWidget::load_current_settings()
     for (size_t i = 0; i < m_screen_layout.screens.size(); i++) {
         String screen_display_name;
         if (m_screen_layout.screens[i].mode == WindowServer::ScreenLayout::Screen::Mode::Device) {
-            if (auto edid = EDID::Parser::from_display_connector_device(m_screen_layout.screens[i].device.value(), 0); !edid.is_error()) { // TODO: multihead
+            if (auto edid = EDID::Parser::from_display_connector_device(m_screen_layout.screens[i].device.value()); !edid.is_error()) { // TODO: multihead
                 screen_display_name = display_name_from_edid(edid.value());
                 m_screen_edids.append(edid.release_value());
             } else {

--- a/Userland/Libraries/LibC/sys/ioctl_numbers.h
+++ b/Userland/Libraries/LibC/sys/ioctl_numbers.h
@@ -42,8 +42,6 @@ struct GraphicsHeadModeSetting {
 };
 
 struct GraphicsHeadEDID {
-    int head_index;
-
     unsigned char* bytes;
     unsigned bytes_size;
 };

--- a/Userland/Libraries/LibEDID/EDID.cpp
+++ b/Userland/Libraries/LibEDID/EDID.cpp
@@ -198,11 +198,10 @@ ErrorOr<Parser> Parser::from_bytes(ByteBuffer&& bytes)
 }
 
 #ifndef KERNEL
-ErrorOr<Parser> Parser::from_display_connector_device(int display_connector_fd, size_t head)
+ErrorOr<Parser> Parser::from_display_connector_device(int display_connector_fd)
 {
     RawBytes edid_bytes;
     GraphicsHeadEDID edid_info {};
-    edid_info.head_index = head;
     edid_info.bytes = &edid_bytes[0];
     edid_info.bytes_size = sizeof(edid_bytes);
     if (graphics_connector_get_head_edid(display_connector_fd, &edid_info) < 0) {
@@ -226,7 +225,7 @@ ErrorOr<Parser> Parser::from_display_connector_device(int display_connector_fd, 
     return from_bytes(move(edid_byte_buffer));
 }
 
-ErrorOr<Parser> Parser::from_display_connector_device(String const& display_connector_device, size_t head)
+ErrorOr<Parser> Parser::from_display_connector_device(String const& display_connector_device)
 {
     int display_connector_fd = open(display_connector_device.characters(), O_RDWR | O_CLOEXEC);
     if (display_connector_fd < 0) {
@@ -236,7 +235,7 @@ ErrorOr<Parser> Parser::from_display_connector_device(String const& display_conn
     ScopeGuard fd_guard([&] {
         close(display_connector_fd);
     });
-    return from_display_connector_device(display_connector_fd, head);
+    return from_display_connector_device(display_connector_fd);
 }
 #endif
 

--- a/Userland/Libraries/LibEDID/EDID.h
+++ b/Userland/Libraries/LibEDID/EDID.h
@@ -85,8 +85,8 @@ public:
     static ErrorOr<Parser> from_bytes(ByteBuffer&&);
 
 #ifndef KERNEL
-    static ErrorOr<Parser> from_display_connector_device(int, size_t);
-    static ErrorOr<Parser> from_display_connector_device(String const&, size_t);
+    static ErrorOr<Parser> from_display_connector_device(int);
+    static ErrorOr<Parser> from_display_connector_device(String const&);
 #endif
 
     StringView legacy_manufacturer_id() const;


### PR DESCRIPTION
We simply don't need that field anymore, as it was used when one FramebufferDevice could contain multiple framebuffers within it, each for a connected screen head.