### PR TITLE
LibWeb: Restore clipping of positioned descendants

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -135,7 +135,7 @@ void StackingContext::paint_internal(PaintContext& context) const
 
     auto paint_child = [&](auto* child) {
         auto parent = child->m_box.parent();
-        auto should_clip_overflow = child->m_box.is_positioned() ? Paintable::ShouldClipOverflow::No : Paintable::ShouldClipOverflow::Yes;
+        auto should_clip_overflow = child->m_box.is_absolutely_positioned() ? Paintable::ShouldClipOverflow::No : Paintable::ShouldClipOverflow::Yes;
         auto* paintable = parent ? parent->paintable() : nullptr;
         if (paintable)
             paintable->before_children_paint(context, PaintPhase::Foreground, should_clip_overflow);


### PR DESCRIPTION
63c727a was meant to stop clipping absolutely positioned descendants, but used `is_positioned()` rather than `is_absolutely_positioned()`, which meant it disabled clipping in many more cases that it should have.