### PR TITLE
LibGfx: Fix issue with affine transformations in TrueType composite glyphs

### DIFF
--- a/Userland/Libraries/LibGfx/Font/TrueType/Glyf.h
+++ b/Userland/Libraries/LibGfx/Font/TrueType/Glyf.h
@@ -105,7 +105,7 @@ public:
         RefPtr<Gfx::Bitmap> rasterize_simple(i16 ascender, i16 descender, float x_scale, float y_scale) const;
 
         template<typename GlyphCb>
-        void rasterize_composite_loop(Rasterizer& rasterizer, Gfx::AffineTransform& transform, GlyphCb glyph_callback) const
+        void rasterize_composite_loop(Rasterizer& rasterizer, Gfx::AffineTransform const& transform, GlyphCb glyph_callback) const
         {
             ComponentIterator component_iterator(m_slice);
 
@@ -115,7 +115,8 @@ public:
                     break;
                 }
                 auto item = opt_item.value();
-                auto affine_here = transform.multiply(item.affine);
+                Gfx::AffineTransform affine_here { transform };
+                affine_here.multiply(item.affine);
                 Glyph glyph = glyph_callback(item.glyph_id);
 
                 if (glyph.m_type == Type::Simple) {


### PR DESCRIPTION
This fixes an issue where, when looping over the components of a composite glyph, we used to mutate the affine transformation of the glyph itself when computing the transformations of its components.

It fixes the rendering of glyphs such as ':' in the Ubuntu-Bold font, which is used by default in Ladybird on my machine.

Before:
![before](https://user-images.githubusercontent.com/9247514/192103580-afb15b72-6895-4677-a108-1c1c58cb2bee.png)
After:
![after](https://user-images.githubusercontent.com/9247514/192103588-9e916166-6502-43ac-8952-3620437a7cb1.png)

