### PR TITLE
LibGUI: Calculate minimum sizes for more scrollable widgets

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -331,4 +331,12 @@ Gfx::IntPoint AbstractScrollableWidget::to_widget_position(Gfx::IntPoint const& 
     widget_position.translate_by(frame_thickness(), frame_thickness());
     return widget_position;
 }
+
+Optional<UISize> AbstractScrollableWidget::calculated_min_size() const
+{
+    auto vertical_scrollbar = m_vertical_scrollbar->effective_min_size().height().as_int();
+    auto horizontal_scrollbar = m_horizontal_scrollbar->effective_min_size().width().as_int();
+    return { { horizontal_scrollbar + corner_widget().width() + frame_thickness() * 2, vertical_scrollbar + corner_widget().height() + frame_thickness() * 2 } };
+}
+
 }

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
@@ -70,6 +70,8 @@ public:
     Gfx::IntRect to_content_rect(Gfx::IntRect const& widget_rect) const { return { to_content_position(widget_rect.location()), widget_rect.size() }; }
     Gfx::IntRect to_widget_rect(Gfx::IntRect const& content_rect) const { return { to_widget_position(content_rect.location()), content_rect.size() }; }
 
+    virtual Optional<UISize> calculated_min_size() const override;
+
 protected:
     AbstractScrollableWidget();
     virtual void custom_layout() override;

--- a/Userland/Libraries/LibGUI/ListView.cpp
+++ b/Userland/Libraries/LibGUI/ListView.cpp
@@ -44,7 +44,7 @@ void ListView::update_content_size()
         auto text = model()->index(row, m_model_column).data();
         content_width = max(content_width, font().width(text.to_string()) + horizontal_padding() * 2);
     }
-
+    m_max_item_width = content_width;
     content_width = max(content_width, widget_inner_rect().width());
 
     int content_height = item_count() * item_height();
@@ -266,6 +266,17 @@ void ListView::scroll_into_view(ModelIndex const& index, bool scroll_horizontall
     if (!model())
         return;
     AbstractScrollableWidget::scroll_into_view(content_rect(index.row()), scroll_horizontally, scroll_vertically);
+}
+
+Optional<UISize> ListView::calculated_min_size() const
+{
+    auto min_width = horizontal_scrollbar().effective_min_size().width().as_int() + vertical_scrollbar().width() + frame_thickness() * 2;
+    auto min_height = vertical_scrollbar().effective_min_size().height().as_int() + horizontal_scrollbar().height() + frame_thickness() * 2;
+    auto content_exceeds_minimums = content_width() > min_width && content_height() > min_height;
+    auto scrollbars_are_visible = horizontal_scrollbar().is_visible() && vertical_scrollbar().is_visible();
+    if (content_exceeds_minimums || scrollbars_are_visible)
+        return AbstractScrollableWidget::calculated_min_size();
+    return { { m_max_item_width + frame_thickness() * 2, content_height() + frame_thickness() * 2 } };
 }
 
 }

--- a/Userland/Libraries/LibGUI/ListView.h
+++ b/Userland/Libraries/LibGUI/ListView.h
@@ -56,12 +56,15 @@ private:
     virtual void mousemove_event(MouseEvent&) override;
     virtual void layout_relevant_change_occured() override;
 
+    virtual Optional<UISize> calculated_min_size() const override;
+
     Gfx::IntRect content_rect(int row) const;
     void update_content_size();
 
     int m_horizontal_padding { 2 };
     int m_vertical_padding { 2 };
     int m_model_column { 0 };
+    int m_max_item_width { 0 };
     bool m_alternating_row_colors { true };
     bool m_hover_highlighting { false };
 };

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -205,7 +205,7 @@ void Scrollbar::paint_event(PaintEvent& event)
     Gfx::StylePainter::paint_button(painter, decrement_button_rect(), palette(), Gfx::ButtonStyle::ThickCap, decrement_pressed, hovered_component_for_painting == Component::DecrementButton);
     Gfx::StylePainter::paint_button(painter, increment_button_rect(), palette(), Gfx::ButtonStyle::ThickCap, increment_pressed, hovered_component_for_painting == Component::IncrementButton);
 
-    if (length(orientation()) > default_button_size()) {
+    if (length(orientation()) >= default_button_size() * 2) {
         auto decrement_location = decrement_button_rect().location().translated(3, 3);
         if (decrement_pressed)
             decrement_location.translate_by(1, 1);

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -420,10 +420,11 @@ void Scrollbar::update_animated_scroll()
 
 Optional<UISize> Scrollbar::calculated_min_size() const
 {
+    auto scrubber_and_gutter = default_button_size() + 1;
     if (orientation() == Gfx::Orientation::Vertical)
-        return { { default_button_size(), 2 * default_button_size() } };
+        return { { default_button_size(), 2 * default_button_size() + scrubber_and_gutter } };
     else
-        return { { 2 * default_button_size(), default_button_size() } };
+        return { { 2 * default_button_size() + scrubber_and_gutter, default_button_size() } };
 }
 
 Optional<UISize> Scrollbar::calculated_preferred_size() const

--- a/Userland/Libraries/LibGUI/StackWidget.cpp
+++ b/Userland/Libraries/LibGUI/StackWidget.cpp
@@ -66,4 +66,9 @@ void StackWidget::child_event(Core::ChildEvent& event)
     Widget::child_event(event);
 }
 
+Optional<UISize> StackWidget::calculated_min_size() const
+{
+    return m_active_widget->calculated_min_size();
+}
+
 }

--- a/Userland/Libraries/LibGUI/StackWidget.h
+++ b/Userland/Libraries/LibGUI/StackWidget.h
@@ -22,6 +22,8 @@ public:
 
     Function<void(Widget*)> on_active_widget_change;
 
+    virtual Optional<UISize> calculated_min_size() const override;
+
 protected:
     StackWidget() = default;
     virtual void child_event(Core::ChildEvent&) override;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -754,13 +754,10 @@ void TextEditor::paint_event(PaintEvent& event)
 
 Optional<UISize> TextEditor::calculated_min_size() const
 {
-    auto margins = content_margins();
-    int horizontal = margins.left() + margins.right(),
-        vertical = margins.top() + margins.bottom();
-    int vertical_content_size = font().glyph_height() + 4;
-    if (!is_multi_line() && m_icon)
-        vertical_content_size = max(vertical_content_size, icon_size() + 2);
-    return UISize(horizontal, vertical);
+    if (is_multi_line())
+        return AbstractScrollableWidget::calculated_min_size();
+    auto m = content_margins();
+    return UISize { m.left() + m.right(), m.top() + m.bottom() };
 }
 
 void TextEditor::select_all()


### PR DESCRIPTION
These widgets were falling back on their content margins for minimum sizing which made them a little awkward and sometimes unusable
![min-calc](https://user-images.githubusercontent.com/66646555/192104797-3a660d92-315b-4637-9eb6-eb8f0de6b8aa.png)
