### PR TITLE
LibWeb: Move Web prototypes and constructors to new Intrinsics object

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzCSSParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzCSSParser.cpp
@@ -4,18 +4,21 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibCore/EventLoop.h>
+#include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/Parser/Parser.h>
-#include <LibWeb/DOM/Document.h>
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Platform/EventLoopPluginSerenity.h>
+
+namespace {
+struct Globals {
+    Globals();
+} globals;
+Globals::Globals() { Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity); }
+}
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    Core::EventLoop loop;
-    auto vm = JS::VM::create();
-    auto realm = JS::Realm::create(*vm);
-    auto window = Web::HTML::Window::create(*realm);
-    auto document = Web::DOM::Document::create(*window);
-    (void)Web::parse_css_stylesheet(Web::CSS::Parser::ParsingContext(document), { data, size });
+    // FIXME: There's got to be a better way to do this "correctly"
+    auto& vm = Web::Bindings::main_thread_vm();
+    (void)Web::parse_css_stylesheet(Web::CSS::Parser::ParsingContext(*vm.current_realm()), { data, size });
     return 0;
 }

--- a/Userland/Libraries/LibWeb/Bindings/AudioConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/AudioConstructor.cpp
@@ -21,10 +21,9 @@ AudioConstructor::AudioConstructor(JS::Realm& realm)
 void AudioConstructor::initialize(JS::Realm& realm)
 {
     auto& vm = this->vm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
     NativeFunction::initialize(realm);
 
-    define_direct_property(vm.names.prototype, &window.cached_web_prototype("HTMLAudioElement"), 0);
+    define_direct_property(vm.names.prototype, &cached_web_prototype(realm, "HTMLAudioElement"), 0);
     define_direct_property(vm.names.length, JS::Value(0), JS::Attribute::Configurable);
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/HostDefined.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/HostDefined.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Heap/Cell.h>
+#include <LibJS/Runtime/Realm.h>
+#include <LibWeb/Bindings/HostDefined.h>
+#include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/HTML/Scripting/Environments.h>
+
+namespace Web::Bindings {
+
+void HostDefined::visit_edges(JS::Cell::Visitor& visitor)
+{
+    JS::Realm::HostDefined::visit_edges(visitor);
+    visitor.visit(environment_settings_object);
+    visitor.visit(*intrinsics);
+}
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/HostDefined.h
+++ b/Userland/Libraries/LibWeb/Bindings/HostDefined.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/TypeCasts.h>
+#include <LibJS/Heap/GCPtr.h>
+#include <LibJS/Runtime/Realm.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::Bindings {
+
+struct HostDefined : public JS::Realm::HostDefined {
+    HostDefined(JS::GCPtr<HTML::EnvironmentSettingsObject> eso, JS::NonnullGCPtr<Intrinsics> intrinsics)
+        : environment_settings_object(eso)
+        , intrinsics(intrinsics)
+    {
+    }
+    virtual ~HostDefined() override = default;
+    virtual void visit_edges(JS::Cell::Visitor& visitor) override;
+
+    // NOTE: Only the root execution environment in the main thread VM ever sets this to nullptr
+    JS::GCPtr<HTML::EnvironmentSettingsObject> environment_settings_object;
+    JS::NonnullGCPtr<Intrinsics> intrinsics;
+};
+
+inline HTML::EnvironmentSettingsObject& host_defined_environment_settings_object(JS::Realm& realm)
+{
+    return *verify_cast<HostDefined>(realm.host_defined())->environment_settings_object;
+}
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
@@ -21,10 +21,9 @@ ImageConstructor::ImageConstructor(JS::Realm& realm)
 void ImageConstructor::initialize(JS::Realm& realm)
 {
     auto& vm = this->vm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
-    NativeFunction::initialize(realm);
 
-    define_direct_property(vm.names.prototype, &window.cached_web_prototype("HTMLImageElement"), 0);
+    NativeFunction::initialize(realm);
+    define_direct_property(vm.names.prototype, &cached_web_prototype(realm, "HTMLImageElement"), 0);
     define_direct_property(vm.names.length, JS::Value(0), JS::Attribute::Configurable);
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/Intrinsics.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/Intrinsics.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/HashMap.h>
+#include <AK/String.h>
+#include <LibJS/Forward.h>
+#include <LibJS/Runtime/NativeFunction.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibWeb/Bindings/Intrinsics.h>
+
+namespace Web::Bindings {
+
+JS::Object& Intrinsics::cached_web_prototype(String const& class_name)
+{
+    auto it = m_prototypes.find(class_name);
+    if (it == m_prototypes.end()) {
+        dbgln("Missing prototype: {}", class_name);
+    }
+    VERIFY(it != m_prototypes.end());
+    return *it->value;
+}
+
+void Intrinsics::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+
+    for (auto& it : m_prototypes)
+        visitor.visit(it.value);
+    for (auto& it : m_constructors)
+        visitor.visit(it.value);
+}
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/Intrinsics.h
+++ b/Userland/Libraries/LibWeb/Bindings/Intrinsics.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <AK/HashMap.h>
+#include <LibJS/Forward.h>
+#include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/Heap.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibWeb/Bindings/HostDefined.h>
+
+namespace Web::Bindings {
+
+class Intrinsics final : public JS::Cell {
+    JS_CELL(Intrinsics, JS::Cell);
+
+public:
+    Intrinsics(JS::Realm& realm)
+        : m_realm(realm)
+    {
+    }
+
+    JS::Object& cached_web_prototype(String const& class_name);
+
+    template<typename T>
+    JS::Object& ensure_web_prototype(String const& class_name)
+    {
+        auto it = m_prototypes.find(class_name);
+        if (it != m_prototypes.end())
+            return *it->value;
+        auto& realm = *m_realm;
+        auto* prototype = heap().allocate<T>(realm, realm);
+        m_prototypes.set(class_name, prototype);
+        return *prototype;
+    }
+
+    template<typename T>
+    JS::NativeFunction& ensure_web_constructor(String const& class_name)
+    {
+        auto it = m_constructors.find(class_name);
+        if (it != m_constructors.end())
+            return *it->value;
+        auto& realm = *m_realm;
+        auto* constructor = heap().allocate<T>(realm, realm);
+        m_constructors.set(class_name, constructor);
+        return *constructor;
+    }
+
+private:
+    virtual void visit_edges(JS::Cell::Visitor&) override;
+
+    HashMap<String, JS::Object*> m_prototypes;
+    HashMap<String, JS::NativeFunction*> m_constructors;
+
+    JS::NonnullGCPtr<JS::Realm> m_realm;
+};
+
+inline Intrinsics& host_defined_intrinsics(JS::Realm& realm)
+{
+    return *verify_cast<HostDefined>(realm.host_defined())->intrinsics;
+}
+
+template<typename T>
+JS::Object& ensure_web_prototype(JS::Realm& realm, String const& class_name)
+{
+    return host_defined_intrinsics(realm).ensure_web_prototype<T>(class_name);
+}
+
+template<typename T>
+JS::NativeFunction& ensure_web_constructor(JS::Realm& realm, String const& class_name)
+{
+    return host_defined_intrinsics(realm).ensure_web_constructor<T>(class_name);
+}
+
+inline JS::Object& cached_web_prototype(JS::Realm& realm, String const& class_name)
+{
+    return host_defined_intrinsics(realm).cached_web_prototype(class_name);
+}
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.cpp
@@ -136,7 +136,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> LegacyPlatformObject::le
     // FIXME: Can this throw?
     if (is_supported_property_index(index)) {
 
-        auto value = TRY(throw_dom_exception_if_needed(global_object(), [&] { return item_value(index); }));
+        auto value = TRY(throw_dom_exception_if_needed(vm(), [&] { return item_value(index); }));
 
         // 5. Let desc be a newly created Property Descriptor with no fields.
         JS::PropertyDescriptor descriptor;

--- a/Userland/Libraries/LibWeb/Bindings/LocationConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LocationConstructor.cpp
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibJS/Runtime/GlobalObject.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/LocationConstructor.h>
 #include <LibWeb/Bindings/LocationPrototype.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Bindings {
 
@@ -31,10 +30,9 @@ JS::ThrowCompletionOr<JS::Object*> LocationConstructor::construct(FunctionObject
 void LocationConstructor::initialize(JS::Realm& realm)
 {
     auto& vm = this->vm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
 
     NativeFunction::initialize(realm);
-    define_direct_property(vm.names.prototype, &window.cached_web_prototype("Location"), 0);
+    define_direct_property(vm.names.prototype, &cached_web_prototype(realm, "Location"), 0);
     define_direct_property(vm.names.length, JS::Value(0), JS::Attribute::Configurable);
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
@@ -24,7 +24,7 @@ namespace Web::Bindings {
 LocationObject::LocationObject(JS::Realm& realm)
     : PlatformObject(realm)
 {
-    set_prototype(&verify_cast<HTML::Window>(realm.global_object()).cached_web_prototype("Location"));
+    set_prototype(&cached_web_prototype(realm, "Location"));
 }
 
 LocationObject::~LocationObject() = default;
@@ -315,7 +315,7 @@ JS::ThrowCompletionOr<bool> LocationObject::internal_define_own_property(JS::Pro
     }
 
     // 2. Throw a "SecurityError" DOMException.
-    return throw_completion(WebIDL::SecurityError::create(global_object(), String::formatted("Can't define property '{}' on cross-origin object", property_key)));
+    return throw_completion(WebIDL::SecurityError::create(realm(), String::formatted("Can't define property '{}' on cross-origin object", property_key)));
 }
 
 // 7.10.5.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/history.html#location-get
@@ -352,7 +352,7 @@ JS::ThrowCompletionOr<bool> LocationObject::internal_delete(JS::PropertyKey cons
         return JS::Object::internal_delete(property_key);
 
     // 2. Throw a "SecurityError" DOMException.
-    return throw_completion(WebIDL::SecurityError::create(global_object(), String::formatted("Can't delete property '{}' on cross-origin object", property_key)));
+    return throw_completion(WebIDL::SecurityError::create(realm(), String::formatted("Can't delete property '{}' on cross-origin object", property_key)));
 }
 
 // 7.10.5.10 [[OwnPropertyKeys]] ( ), https://html.spec.whatwg.org/multipage/history.html#location-ownpropertykeys

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/Environment.h>
 #include <LibJS/Runtime/FinalizationRegistry.h>
+#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Bindings/Intrinsics.h>
@@ -306,12 +307,7 @@ JS::VM& main_thread_vm()
         // NOTE: We push a dummy execution context onto the JS execution context stack,
         //       just to make sure that it's never empty.
         auto& custom_data = *verify_cast<WebEngineCustomData>(vm->custom_data());
-        custom_data.root_execution_context = MUST(JS::Realm::initialize_host_defined_realm(
-            *vm, [&](JS::Realm& realm) -> JS::Object* {
-                custom_data.internal_window_object = JS::make_handle(*HTML::Window::create(realm));
-                return custom_data.internal_window_object.cell();
-            },
-            nullptr));
+        custom_data.root_execution_context = MUST(JS::Realm::initialize_host_defined_realm(*vm, nullptr, nullptr));
 
         auto* root_realm = custom_data.root_execution_context->realm;
         auto* intrinsics = root_realm->heap().allocate<Intrinsics>(*root_realm, *root_realm);
@@ -321,13 +317,6 @@ JS::VM& main_thread_vm()
         vm->push_execution_context(*custom_data.root_execution_context);
     }
     return *vm;
-}
-
-HTML::Window& main_thread_internal_window_object()
-{
-    auto& vm = main_thread_vm();
-    auto& custom_data = verify_cast<WebEngineCustomData>(*vm.custom_data());
-    return *custom_data.internal_window_object;
 }
 
 // https://dom.spec.whatwg.org/#queue-a-mutation-observer-compound-microtask

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -134,7 +134,7 @@ JS::VM& main_thread_vm()
                         /* .promise = */ promise,
                         /* .reason = */ promise.result(),
                     };
-                    auto promise_rejection_event = HTML::PromiseRejectionEvent::create(window, HTML::EventNames::rejectionhandled, event_init);
+                    auto promise_rejection_event = HTML::PromiseRejectionEvent::create(HTML::relevant_realm(global), HTML::EventNames::rejectionhandled, event_init);
                     window.dispatch_event(*promise_rejection_event);
                 });
                 break;

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.h
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.h
@@ -13,7 +13,6 @@
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/DOM/MutationObserver.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Bindings {
 
@@ -34,10 +33,6 @@ struct WebEngineCustomData final : public JS::VM::CustomData {
     Vector<JS::Handle<DOM::MutationObserver>> mutation_observers;
 
     OwnPtr<JS::ExecutionContext> root_execution_context;
-
-    // This object is used as the global object for GC-allocated objects that don't
-    // belong to a web-facing global object.
-    JS::Handle<HTML::Window> internal_window_object;
 };
 
 struct WebEngineCustomJobCallbackData final : public JS::JobCallback::CustomData {
@@ -55,7 +50,6 @@ struct WebEngineCustomJobCallbackData final : public JS::JobCallback::CustomData
 
 HTML::ClassicScript* active_script();
 JS::VM& main_thread_vm();
-HTML::Window& main_thread_internal_window_object();
 void queue_mutation_observer_microtask(DOM::Document&);
 NonnullOwnPtr<JS::ExecutionContext> create_a_new_javascript_realm(JS::VM&, Function<JS::Object*(JS::Realm&)> create_global_object, Function<JS::Object*(JS::Realm&)> create_global_this_value);
 

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorConstructor.cpp
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibJS/Runtime/GlobalObject.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/NavigatorConstructor.h>
 #include <LibWeb/Bindings/NavigatorPrototype.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Bindings {
 
@@ -31,10 +30,9 @@ JS::ThrowCompletionOr<JS::Object*> NavigatorConstructor::construct(FunctionObjec
 void NavigatorConstructor::initialize(JS::Realm& realm)
 {
     auto& vm = this->vm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
 
     NativeFunction::initialize(realm);
-    define_direct_property(vm.names.prototype, &window.cached_web_prototype("Navigator"), 0);
+    define_direct_property(vm.names.prototype, &cached_web_prototype(realm, "Navigator"), 0);
     define_direct_property(vm.names.length, JS::Value(0), JS::Attribute::Configurable);
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <LibJS/Runtime/Array.h>
-#include <LibJS/Runtime/GlobalObject.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/NavigatorObject.h>
 #include <LibWeb/Bindings/NavigatorPrototype.h>
 #include <LibWeb/Loader/ResourceLoader.h>
@@ -14,7 +14,7 @@ namespace Web {
 namespace Bindings {
 
 NavigatorObject::NavigatorObject(JS::Realm& realm)
-    : Object(verify_cast<HTML::Window>(realm.global_object()).cached_web_prototype("Navigator"))
+    : Object(cached_web_prototype(realm, "Navigator"))
 {
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorPrototype.h
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorPrototype.h
@@ -6,11 +6,9 @@
 
 #pragma once
 
-#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Bindings {
 

--- a/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
@@ -23,10 +23,9 @@ OptionConstructor::OptionConstructor(JS::Realm& realm)
 void OptionConstructor::initialize(JS::Realm& realm)
 {
     auto& vm = this->vm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
-    NativeFunction::initialize(realm);
 
-    define_direct_property(vm.names.prototype, &window.cached_web_prototype("HTMLOptionElement"), 0);
+    NativeFunction::initialize(realm);
+    define_direct_property(vm.names.prototype, &cached_web_prototype(realm, "HTMLOptionElement"), 0);
     define_direct_property(vm.names.length, JS::Value(0), JS::Attribute::Configurable);
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/PlatformObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/PlatformObject.h
@@ -31,7 +31,7 @@ public:
     HTML::Window& global_object() const;
 
 protected:
-    PlatformObject(JS::Realm&);
+    explicit PlatformObject(JS::Realm&);
     explicit PlatformObject(JS::Object& prototype);
 };
 

--- a/Userland/Libraries/LibWeb/Bindings/WindowConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowConstructor.cpp
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibJS/Runtime/GlobalObject.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/WindowConstructor.h>
 #include <LibWeb/Bindings/WindowPrototype.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Bindings {
 
@@ -31,10 +30,9 @@ JS::ThrowCompletionOr<JS::Object*> WindowConstructor::construct(FunctionObject&)
 void WindowConstructor::initialize(JS::Realm& realm)
 {
     auto& vm = this->vm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
 
     NativeFunction::initialize(realm);
-    define_direct_property(vm.names.prototype, &window.cached_web_prototype("Window"), 0);
+    define_direct_property(vm.names.prototype, &cached_web_prototype(realm, "Window"), 0);
     define_direct_property(vm.names.length, JS::Value(0), JS::Attribute::Configurable);
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
@@ -394,8 +394,9 @@
 
 #define ADD_WINDOW_OBJECT_CONSTRUCTOR_AND_PROTOTYPE(interface_name, constructor_name, prototype_name)                                \
     {                                                                                                                                \
-        auto& prototype = ensure_web_prototype<Bindings::prototype_name>(#interface_name);                                           \
-        auto& constructor = ensure_web_constructor<Bindings::constructor_name>(#interface_name);                                     \
+        auto& prototype = Bindings::ensure_web_prototype<Bindings::prototype_name>(realm, #interface_name);                          \
+        auto& constructor = Bindings::ensure_web_constructor<Bindings::constructor_name>(realm, #interface_name);                    \
+        define_direct_property(#interface_name, &constructor, JS::Attribute::Writable | JS::Attribute::Configurable);                \
         prototype.define_direct_property(vm.names.constructor, &constructor, JS::Attribute::Writable | JS::Attribute::Configurable); \
         constructor.define_direct_property(vm.names.name, js_string(vm, #interface_name), JS::Attribute::Configurable);              \
     }
@@ -405,6 +406,7 @@
 
 #define ADD_WINDOW_OBJECT_INTERFACES                                                                \
     auto& vm = this->vm();                                                                          \
+    auto& realm = this->realm();                                                                    \
     ADD_WINDOW_OBJECT_INTERFACE(AbortController)                                                    \
     ADD_WINDOW_OBJECT_INTERFACE(AbortSignal)                                                        \
     ADD_WINDOW_OBJECT_INTERFACE(AbstractRange)                                                      \

--- a/Userland/Libraries/LibWeb/Bindings/WindowPrototype.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowPrototype.h
@@ -6,12 +6,9 @@
 
 #pragma once
 
-#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Object.h>
-#include <LibJS/Runtime/VM.h>
-#include <LibWeb/Bindings/EventTargetPrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Bindings {
 
@@ -20,7 +17,7 @@ class WindowPrototype final : public JS::Object {
 
 public:
     explicit WindowPrototype(JS::Realm& realm)
-        : JS::Object(verify_cast<HTML::Window>(realm.global_object()).cached_web_prototype("EventTarget"))
+        : JS::Object(cached_web_prototype(realm, "EventTarget"))
     {
     }
 };

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -3,7 +3,9 @@ include(libweb_generators)
 set(SOURCES
     Bindings/AudioConstructor.cpp
     Bindings/CSSNamespace.cpp
+    Bindings/HostDefined.cpp
     Bindings/ImageConstructor.cpp
+    Bindings/Intrinsics.cpp
     Bindings/LegacyPlatformObject.cpp
     Bindings/LocationConstructor.cpp
     Bindings/LocationObject.cpp

--- a/Userland/Libraries/LibWeb/CSS/CSSConditionRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSConditionRule.cpp
@@ -5,15 +5,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/CSSConditionRulePrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSConditionRule.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::CSS {
 
-CSSConditionRule::CSSConditionRule(HTML::Window& window_object, CSSRuleList& rules)
-    : CSSGroupingRule(window_object, rules)
+CSSConditionRule::CSSConditionRule(JS::Realm& realm, CSSRuleList& rules)
+    : CSSGroupingRule(realm, rules)
 {
-    set_prototype(&window_object.cached_web_prototype("CSSConditionRule"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::CSSConditionRulePrototype>(realm, "CSSConditionRule"));
 }
 
 void CSSConditionRule::for_each_effective_style_rule(Function<void(CSSStyleRule const&)> const& callback) const

--- a/Userland/Libraries/LibWeb/CSS/CSSConditionRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSConditionRule.h
@@ -25,7 +25,7 @@ public:
     virtual void for_each_effective_style_rule(Function<void(CSSStyleRule const&)> const& callback) const override;
 
 protected:
-    explicit CSSConditionRule(HTML::Window&, CSSRuleList&);
+    CSSConditionRule(JS::Realm&, CSSRuleList&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -5,22 +5,23 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/CSSFontFaceRulePrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSFontFaceRule.h>
 #include <LibWeb/CSS/Serialize.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::CSS {
 
-CSSFontFaceRule* CSSFontFaceRule::create(HTML::Window& window_object, FontFace&& font_face)
+CSSFontFaceRule* CSSFontFaceRule::create(JS::Realm& realm, FontFace&& font_face)
 {
-    return window_object.heap().allocate<CSSFontFaceRule>(window_object.realm(), window_object, move(font_face));
+    return realm.heap().allocate<CSSFontFaceRule>(realm, realm, move(font_face));
 }
 
-CSSFontFaceRule::CSSFontFaceRule(HTML::Window& window_object, FontFace&& font_face)
-    : CSSRule(window_object)
+CSSFontFaceRule::CSSFontFaceRule(JS::Realm& realm, FontFace&& font_face)
+    : CSSRule(realm)
     , m_font_face(move(font_face))
 {
-    set_prototype(&window_object.cached_web_prototype("CSSFontFaceRule"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::CSSFontFaceRulePrototype>(realm, "CSSFontFaceRule"));
 }
 
 CSSStyleDeclaration* CSSFontFaceRule::style()

--- a/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.h
@@ -16,7 +16,7 @@ class CSSFontFaceRule final : public CSSRule {
     WEB_PLATFORM_OBJECT(CSSFontFaceRule, CSSRule);
 
 public:
-    static CSSFontFaceRule* create(HTML::Window&, FontFace&&);
+    static CSSFontFaceRule* create(JS::Realm&, FontFace&&);
 
     virtual ~CSSFontFaceRule() override = default;
 
@@ -26,7 +26,7 @@ public:
     CSSStyleDeclaration* style();
 
 private:
-    explicit CSSFontFaceRule(HTML::Window&, FontFace&&);
+    CSSFontFaceRule(JS::Realm&, FontFace&&);
 
     virtual String serialized() const override;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSGroupingRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSGroupingRule.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/CSSGroupingRulePrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/CSSGroupingRule.h>
 #include <LibWeb/CSS/CSSRuleList.h>
@@ -12,11 +14,11 @@
 
 namespace Web::CSS {
 
-CSSGroupingRule::CSSGroupingRule(HTML::Window& window_object, CSSRuleList& rules)
-    : CSSRule(window_object)
+CSSGroupingRule::CSSGroupingRule(JS::Realm& realm, CSSRuleList& rules)
+    : CSSRule(realm)
     , m_rules(rules)
 {
-    set_prototype(&window_object.cached_web_prototype("CSSGroupingRule"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::CSSGroupingRulePrototype>(realm, "CSSGroupingRule"));
     for (auto& rule : m_rules)
         rule.set_parent_rule(this);
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSGroupingRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSGroupingRule.h
@@ -31,7 +31,7 @@ public:
     virtual void set_parent_style_sheet(CSSStyleSheet*) override;
 
 protected:
-    explicit CSSGroupingRule(HTML::Window&, CSSRuleList&);
+    CSSGroupingRule(JS::Realm&, CSSRuleList&);
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -8,6 +8,8 @@
 
 #include <AK/Debug.h>
 #include <AK/URL.h>
+#include <LibWeb/Bindings/CSSImportRulePrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
@@ -18,16 +20,16 @@ namespace Web::CSS {
 
 CSSImportRule* CSSImportRule::create(AK::URL url, DOM::Document& document)
 {
-    auto& window_object = document.window();
-    return window_object.heap().allocate<CSSImportRule>(window_object.realm(), move(url), document);
+    auto& realm = document.realm();
+    return realm.heap().allocate<CSSImportRule>(realm, move(url), document);
 }
 
 CSSImportRule::CSSImportRule(AK::URL url, DOM::Document& document)
-    : CSSRule(document.window())
+    : CSSRule(document.realm())
     , m_url(move(url))
     , m_document(document)
 {
-    set_prototype(&document.window().cached_web_prototype("CSSImportRule"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::CSSImportRulePrototype>(document.realm(), "CSSImportRule"));
 
     dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Loading import URL: {}", m_url);
     auto request = LoadRequest::create_for_url_on_page(m_url, document.page());

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <AK/URL.h>
-#include <LibJS/Heap/Handle.h>
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
@@ -5,21 +5,23 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/Realm.h>
+#include <LibWeb/Bindings/CSSMediaRulePrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSMediaRule.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::CSS {
 
-CSSMediaRule* CSSMediaRule::create(HTML::Window& window_object, MediaList& media_queries, CSSRuleList& rules)
+CSSMediaRule* CSSMediaRule::create(JS::Realm& realm, MediaList& media_queries, CSSRuleList& rules)
 {
-    return window_object.heap().allocate<CSSMediaRule>(window_object.realm(), window_object, media_queries, rules);
+    return realm.heap().allocate<CSSMediaRule>(realm, realm, media_queries, rules);
 }
 
-CSSMediaRule::CSSMediaRule(HTML::Window& window_object, MediaList& media, CSSRuleList& rules)
-    : CSSConditionRule(window_object, rules)
+CSSMediaRule::CSSMediaRule(JS::Realm& realm, MediaList& media, CSSRuleList& rules)
+    : CSSConditionRule(realm, rules)
     , m_media(media)
 {
-    set_prototype(&window_object.cached_web_prototype("CSSMediaRule"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::CSSMediaRulePrototype>(realm, "CSSMediaRule"));
 }
 
 void CSSMediaRule::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.h
@@ -18,7 +18,7 @@ class CSSMediaRule final : public CSSConditionRule {
     WEB_PLATFORM_OBJECT(CSSMediaRule, CSSConditionRule);
 
 public:
-    static CSSMediaRule* create(HTML::Window&, MediaList& media_queries, CSSRuleList&);
+    static CSSMediaRule* create(JS::Realm&, MediaList& media_queries, CSSRuleList&);
 
     virtual ~CSSMediaRule() = default;
 
@@ -33,7 +33,7 @@ public:
     bool evaluate(HTML::Window const& window) { return m_media.evaluate(window); }
 
 private:
-    explicit CSSMediaRule(HTML::Window&, MediaList&, CSSRuleList&);
+    CSSMediaRule(JS::Realm&, MediaList&, CSSRuleList&);
 
     virtual void visit_edges(Cell::Visitor&) override;
     virtual String serialized() const override;

--- a/Userland/Libraries/LibWeb/CSS/CSSRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSRule.cpp
@@ -8,12 +8,11 @@
 
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::CSS {
 
-CSSRule::CSSRule(HTML::Window& window_object)
-    : PlatformObject(window_object.cached_web_prototype("CSSRule"))
+CSSRule::CSSRule(JS::Realm& realm)
+    : PlatformObject(realm)
 {
 }
 

--- a/Userland/Libraries/LibWeb/CSS/CSSRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSRule.h
@@ -16,7 +16,7 @@
 namespace Web::CSS {
 
 class CSSRule : public Bindings::PlatformObject {
-    WEB_PLATFORM_OBJECT(CSSRule, JS::Object);
+    WEB_PLATFORM_OBJECT(CSSRule, Bindings::PlatformObject);
 
 public:
     virtual ~CSSRule() = default;
@@ -45,7 +45,7 @@ public:
     bool fast_is() const = delete;
 
 protected:
-    explicit CSSRule(HTML::Window&);
+    explicit CSSRule(JS::Realm&);
 
     virtual String serialized() const = 0;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <AK/TypeCasts.h>
+#include <LibWeb/Bindings/CSSRuleListPrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/CSSMediaRule.h>
 #include <LibWeb/CSS/CSSRule.h>
@@ -15,22 +17,22 @@
 
 namespace Web::CSS {
 
-CSSRuleList* CSSRuleList::create(HTML::Window& window_object, JS::MarkedVector<CSSRule*> const& rules)
+CSSRuleList* CSSRuleList::create(JS::Realm& realm, JS::MarkedVector<CSSRule*> const& rules)
 {
-    auto* rule_list = window_object.heap().allocate<CSSRuleList>(window_object.realm(), window_object);
+    auto* rule_list = realm.heap().allocate<CSSRuleList>(realm, realm);
     for (auto* rule : rules)
         rule_list->m_rules.append(*rule);
     return rule_list;
 }
 
-CSSRuleList::CSSRuleList(HTML::Window& window_object)
-    : Bindings::LegacyPlatformObject(window_object.cached_web_prototype("CSSRuleList"))
+CSSRuleList::CSSRuleList(JS::Realm& realm)
+    : Bindings::LegacyPlatformObject(Bindings::ensure_web_prototype<Bindings::CSSRuleListPrototype>(realm, "CSSRuleList"))
 {
 }
 
-CSSRuleList* CSSRuleList::create_empty(HTML::Window& window_object)
+CSSRuleList* CSSRuleList::create_empty(JS::Realm& realm)
 {
-    return window_object.heap().allocate<CSSRuleList>(window_object.realm(), window_object);
+    return realm.heap().allocate<CSSRuleList>(realm, realm);
 }
 
 void CSSRuleList::visit_edges(Cell::Visitor& visitor)
@@ -55,7 +57,7 @@ WebIDL::ExceptionOr<unsigned> CSSRuleList::insert_a_css_rule(Variant<StringView,
 
     // 2. If index is greater than length, then throw an IndexSizeError exception.
     if (index > length)
-        return WebIDL::IndexSizeError::create(global_object(), "CSS rule index out of bounds.");
+        return WebIDL::IndexSizeError::create(realm(), "CSS rule index out of bounds.");
 
     // 3. Set new rule to the results of performing parse a CSS rule on argument rule.
     // NOTE: The insert-a-css-rule spec expects `rule` to be a string, but the CSSStyleSheet.insertRule()
@@ -64,7 +66,7 @@ WebIDL::ExceptionOr<unsigned> CSSRuleList::insert_a_css_rule(Variant<StringView,
     CSSRule* new_rule = nullptr;
     if (rule.has<StringView>()) {
         new_rule = parse_css_rule(
-            CSS::Parser::ParsingContext { static_cast<HTML::Window&>(global_object()) },
+            CSS::Parser::ParsingContext { realm() },
             rule.get<StringView>());
     } else {
         new_rule = rule.get<CSSRule*>();
@@ -72,7 +74,7 @@ WebIDL::ExceptionOr<unsigned> CSSRuleList::insert_a_css_rule(Variant<StringView,
 
     // 4. If new rule is a syntax error, throw a SyntaxError exception.
     if (!new_rule)
-        return WebIDL::SyntaxError::create(global_object(), "Unable to parse CSS rule.");
+        return WebIDL::SyntaxError::create(realm(), "Unable to parse CSS rule.");
 
     // FIXME: 5. If new rule cannot be inserted into list at the zero-index position index due to constraints specified by CSS, then throw a HierarchyRequestError exception. [CSS21]
 
@@ -93,7 +95,7 @@ WebIDL::ExceptionOr<void> CSSRuleList::remove_a_css_rule(u32 index)
 
     // 2. If index is greater than or equal to length, then throw an IndexSizeError exception.
     if (index >= length)
-        return WebIDL::IndexSizeError::create(global_object(), "CSS rule index out of bounds.");
+        return WebIDL::IndexSizeError::create(realm(), "CSS rule index out of bounds.");
 
     // 3. Set old rule to the indexth item in list.
     CSSRule& old_rule = m_rules[index];

--- a/Userland/Libraries/LibWeb/CSS/CSSRuleList.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSRuleList.h
@@ -23,10 +23,9 @@ class CSSRuleList : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(CSSRuleList, Bindings::LegacyPlatformObject);
 
 public:
-    static CSSRuleList* create(HTML::Window&, JS::MarkedVector<CSSRule*> const&);
-    static CSSRuleList* create_empty(HTML::Window&);
+    static CSSRuleList* create(JS::Realm&, JS::MarkedVector<CSSRule*> const&);
+    static CSSRuleList* create_empty(JS::Realm&);
 
-    explicit CSSRuleList(HTML::Window&);
     ~CSSRuleList() = default;
 
     CSSRule const* item(size_t index) const
@@ -65,6 +64,8 @@ public:
     bool evaluate_media_queries(HTML::Window const&);
 
 private:
+    explicit CSSRuleList(JS::Realm&);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     Vector<CSSRule&> m_rules;

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -4,26 +4,27 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/CSSStyleDeclarationPrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::CSS {
 
-CSSStyleDeclaration::CSSStyleDeclaration(HTML::Window& window_object)
-    : PlatformObject(window_object.cached_web_prototype("CSSStyleDeclaration"))
+CSSStyleDeclaration::CSSStyleDeclaration(JS::Realm& realm)
+    : PlatformObject(Bindings::ensure_web_prototype<Bindings::CSSStyleDeclarationPrototype>(realm, "CSSStyleDeclaration"))
 {
 }
 
-PropertyOwningCSSStyleDeclaration* PropertyOwningCSSStyleDeclaration::create(HTML::Window& window_object, Vector<StyleProperty> properties, HashMap<String, StyleProperty> custom_properties)
+PropertyOwningCSSStyleDeclaration* PropertyOwningCSSStyleDeclaration::create(JS::Realm& realm, Vector<StyleProperty> properties, HashMap<String, StyleProperty> custom_properties)
 {
-    return window_object.heap().allocate<PropertyOwningCSSStyleDeclaration>(window_object.realm(), window_object, move(properties), move(custom_properties));
+    return realm.heap().allocate<PropertyOwningCSSStyleDeclaration>(realm, realm, move(properties), move(custom_properties));
 }
 
-PropertyOwningCSSStyleDeclaration::PropertyOwningCSSStyleDeclaration(HTML::Window& window_object, Vector<StyleProperty> properties, HashMap<String, StyleProperty> custom_properties)
-    : CSSStyleDeclaration(window_object)
+PropertyOwningCSSStyleDeclaration::PropertyOwningCSSStyleDeclaration(JS::Realm& realm, Vector<StyleProperty> properties, HashMap<String, StyleProperty> custom_properties)
+    : CSSStyleDeclaration(realm)
     , m_properties(move(properties))
     , m_custom_properties(move(custom_properties))
 {
@@ -38,12 +39,12 @@ String PropertyOwningCSSStyleDeclaration::item(size_t index) const
 
 ElementInlineCSSStyleDeclaration* ElementInlineCSSStyleDeclaration::create(DOM::Element& element, Vector<StyleProperty> properties, HashMap<String, StyleProperty> custom_properties)
 {
-    auto& window_object = element.document().window();
-    return window_object.heap().allocate<ElementInlineCSSStyleDeclaration>(window_object.realm(), element, move(properties), move(custom_properties));
+    auto& realm = element.realm();
+    return realm.heap().allocate<ElementInlineCSSStyleDeclaration>(realm, element, move(properties), move(custom_properties));
 }
 
 ElementInlineCSSStyleDeclaration::ElementInlineCSSStyleDeclaration(DOM::Element& element, Vector<StyleProperty> properties, HashMap<String, StyleProperty> custom_properties)
-    : PropertyOwningCSSStyleDeclaration(element.document().window(), move(properties), move(custom_properties))
+    : PropertyOwningCSSStyleDeclaration(element.realm(), move(properties), move(custom_properties))
     , m_element(element.make_weak_ptr<DOM::Element>())
 {
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -55,7 +55,7 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver) override;
 
 protected:
-    explicit CSSStyleDeclaration(HTML::Window&);
+    explicit CSSStyleDeclaration(JS::Realm&);
 };
 
 class PropertyOwningCSSStyleDeclaration : public CSSStyleDeclaration {
@@ -63,7 +63,7 @@ class PropertyOwningCSSStyleDeclaration : public CSSStyleDeclaration {
     friend class ElementInlineCSSStyleDeclaration;
 
 public:
-    static PropertyOwningCSSStyleDeclaration* create(HTML::Window&, Vector<StyleProperty>, HashMap<String, StyleProperty> custom_properties);
+    static PropertyOwningCSSStyleDeclaration* create(JS::Realm&, Vector<StyleProperty>, HashMap<String, StyleProperty> custom_properties);
 
     virtual ~PropertyOwningCSSStyleDeclaration() override = default;
 
@@ -83,7 +83,7 @@ public:
     virtual String serialized() const final override;
 
 protected:
-    PropertyOwningCSSStyleDeclaration(HTML::Window&, Vector<StyleProperty>, HashMap<String, StyleProperty>);
+    PropertyOwningCSSStyleDeclaration(JS::Realm&, Vector<StyleProperty>, HashMap<String, StyleProperty>);
 
     virtual void update_style_attribute() { }
 
@@ -108,7 +108,7 @@ public:
     bool is_updating() const { return m_updating; }
 
 private:
-    explicit ElementInlineCSSStyleDeclaration(DOM::Element&, Vector<StyleProperty> properties, HashMap<String, StyleProperty> custom_properties);
+    ElementInlineCSSStyleDeclaration(DOM::Element&, Vector<StyleProperty> properties, HashMap<String, StyleProperty> custom_properties);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
@@ -4,23 +4,24 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/CSSStyleRulePrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/Parser/Parser.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::CSS {
 
-CSSStyleRule* CSSStyleRule::create(HTML::Window& window_object, NonnullRefPtrVector<Web::CSS::Selector>&& selectors, CSSStyleDeclaration& declaration)
+CSSStyleRule* CSSStyleRule::create(JS::Realm& realm, NonnullRefPtrVector<Web::CSS::Selector>&& selectors, CSSStyleDeclaration& declaration)
 {
-    return window_object.heap().allocate<CSSStyleRule>(window_object.realm(), window_object, move(selectors), declaration);
+    return realm.heap().allocate<CSSStyleRule>(realm, realm, move(selectors), declaration);
 }
 
-CSSStyleRule::CSSStyleRule(HTML::Window& window_object, NonnullRefPtrVector<Selector>&& selectors, CSSStyleDeclaration& declaration)
-    : CSSRule(window_object)
+CSSStyleRule::CSSStyleRule(JS::Realm& realm, NonnullRefPtrVector<Selector>&& selectors, CSSStyleDeclaration& declaration)
+    : CSSRule(realm)
     , m_selectors(move(selectors))
     , m_declaration(declaration)
 {
-    set_prototype(&window_object.cached_web_prototype("CSSStyleRule"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::CSSStyleRulePrototype>(realm, "CSSStyleRule"));
 }
 
 void CSSStyleRule::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
@@ -19,7 +19,7 @@ class CSSStyleRule final : public CSSRule {
     WEB_PLATFORM_OBJECT(CSSStyleRule, CSSRule);
 
 public:
-    static CSSStyleRule* create(HTML::Window&, NonnullRefPtrVector<Selector>&&, CSSStyleDeclaration&);
+    static CSSStyleRule* create(JS::Realm&, NonnullRefPtrVector<Selector>&&, CSSStyleDeclaration&);
 
     virtual ~CSSStyleRule() override = default;
 
@@ -34,7 +34,7 @@ public:
     CSSStyleDeclaration* style();
 
 private:
-    CSSStyleRule(HTML::Window&, NonnullRefPtrVector<Selector>&&, CSSStyleDeclaration&);
+    CSSStyleRule(JS::Realm&, NonnullRefPtrVector<Selector>&&, CSSStyleDeclaration&);
 
     virtual void visit_edges(Cell::Visitor&) override;
     virtual String serialized() const override;

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/CSSStyleSheetPrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleSheetList.h>
@@ -12,16 +14,16 @@
 
 namespace Web::CSS {
 
-CSSStyleSheet* CSSStyleSheet::create(HTML::Window& window_object, CSSRuleList& rules, Optional<AK::URL> location)
+CSSStyleSheet* CSSStyleSheet::create(JS::Realm& realm, CSSRuleList& rules, Optional<AK::URL> location)
 {
-    return window_object.heap().allocate<CSSStyleSheet>(window_object.realm(), window_object, rules, move(location));
+    return realm.heap().allocate<CSSStyleSheet>(realm, realm, rules, move(location));
 }
 
-CSSStyleSheet::CSSStyleSheet(HTML::Window& window_object, CSSRuleList& rules, Optional<AK::URL> location)
-    : StyleSheet(window_object)
+CSSStyleSheet::CSSStyleSheet(JS::Realm& realm, CSSRuleList& rules, Optional<AK::URL> location)
+    : StyleSheet(realm)
     , m_rules(&rules)
 {
-    set_prototype(&window_object.cached_web_prototype("CSSStyleSheet"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::CSSStyleSheetPrototype>(realm, "CSSStyleSheet"));
 
     if (location.has_value())
         set_location(location->to_string());
@@ -50,7 +52,7 @@ WebIDL::ExceptionOr<unsigned> CSSStyleSheet::insert_rule(StringView rule, unsign
 
     // 4. If parsed rule is a syntax error, return parsed rule.
     if (!parsed_rule)
-        return WebIDL::SyntaxError::create(global_object(), "Unable to parse CSS rule.");
+        return WebIDL::SyntaxError::create(realm(), "Unable to parse CSS rule.");
 
     // FIXME: 5. If parsed rule is an @import rule, and the constructed flag is set, throw a SyntaxError DOMException.
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -24,9 +24,8 @@ class CSSStyleSheet final
     WEB_PLATFORM_OBJECT(CSSStyleSheet, StyleSheet);
 
 public:
-    static CSSStyleSheet* create(HTML::Window&, CSSRuleList& rules, Optional<AK::URL> location);
+    static CSSStyleSheet* create(JS::Realm&, CSSRuleList& rules, Optional<AK::URL> location);
 
-    explicit CSSStyleSheet(HTML::Window&, CSSRuleList&, Optional<AK::URL> location);
     virtual ~CSSStyleSheet() override = default;
 
     void set_owner_css_rule(CSSRule* rule) { m_owner_css_rule = rule; }
@@ -51,6 +50,8 @@ public:
     void set_style_sheet_list(Badge<StyleSheetList>, StyleSheetList*);
 
 private:
+    CSSStyleSheet(JS::Realm&, CSSRuleList&, Optional<AK::URL> location);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     CSSRuleList* m_rules { nullptr };

--- a/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.cpp
@@ -4,22 +4,23 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/CSSSupportsRulePrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSSupportsRule.h>
 #include <LibWeb/CSS/Parser/Parser.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::CSS {
 
-CSSSupportsRule* CSSSupportsRule::create(HTML::Window& window_object, NonnullRefPtr<Supports>&& supports, CSSRuleList& rules)
+CSSSupportsRule* CSSSupportsRule::create(JS::Realm& realm, NonnullRefPtr<Supports>&& supports, CSSRuleList& rules)
 {
-    return window_object.heap().allocate<CSSSupportsRule>(window_object.realm(), window_object, move(supports), rules);
+    return realm.heap().allocate<CSSSupportsRule>(realm, realm, move(supports), rules);
 }
 
-CSSSupportsRule::CSSSupportsRule(HTML::Window& window_object, NonnullRefPtr<Supports>&& supports, CSSRuleList& rules)
-    : CSSConditionRule(window_object, rules)
+CSSSupportsRule::CSSSupportsRule(JS::Realm& realm, NonnullRefPtr<Supports>&& supports, CSSRuleList& rules)
+    : CSSConditionRule(realm, rules)
     , m_supports(move(supports))
 {
-    set_prototype(&window_object.cached_web_prototype("CSSSupportsRule"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::CSSSupportsRulePrototype>(realm, "CSSSupportsRule"));
 }
 
 String CSSSupportsRule::condition_text() const

--- a/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.h
@@ -20,7 +20,7 @@ class CSSSupportsRule final : public CSSConditionRule {
     WEB_PLATFORM_OBJECT(CSSSupportsRule, CSSConditionRule);
 
 public:
-    static CSSSupportsRule* create(HTML::Window&, NonnullRefPtr<Supports>&&, CSSRuleList&);
+    static CSSSupportsRule* create(JS::Realm&, NonnullRefPtr<Supports>&&, CSSRuleList&);
 
     virtual ~CSSSupportsRule() = default;
 
@@ -31,7 +31,7 @@ public:
     virtual bool condition_matches() const override { return m_supports->matches(); }
 
 private:
-    explicit CSSSupportsRule(HTML::Window&, NonnullRefPtr<Supports>&&, CSSRuleList&);
+    CSSSupportsRule(JS::Realm&, NonnullRefPtr<Supports>&&, CSSRuleList&);
 
     virtual String serialized() const override;
 

--- a/Userland/Libraries/LibWeb/CSS/MediaList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.cpp
@@ -5,19 +5,20 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/MediaListPrototype.h>
 #include <LibWeb/CSS/MediaList.h>
 #include <LibWeb/CSS/Parser/Parser.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::CSS {
 
-MediaList* MediaList::create(HTML::Window& window_object, NonnullRefPtrVector<MediaQuery>&& media)
+MediaList* MediaList::create(JS::Realm& realm, NonnullRefPtrVector<MediaQuery>&& media)
 {
-    return window_object.heap().allocate<MediaList>(window_object.realm(), window_object, move(media));
+    return realm.heap().allocate<MediaList>(realm, realm, move(media));
 }
 
-MediaList::MediaList(HTML::Window& window_object, NonnullRefPtrVector<MediaQuery>&& media)
-    : Bindings::LegacyPlatformObject(window_object.cached_web_prototype("MediaList"))
+MediaList::MediaList(JS::Realm& realm, NonnullRefPtrVector<MediaQuery>&& media)
+    : Bindings::LegacyPlatformObject(Bindings::ensure_web_prototype<Bindings::MediaListPrototype>(realm, "MediaList"))
     , m_media(move(media))
 {
 }

--- a/Userland/Libraries/LibWeb/CSS/MediaList.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.h
@@ -20,7 +20,7 @@ class MediaList final : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(MediaList, Bindings::LegacyPlatformObject);
 
 public:
-    static MediaList* create(HTML::Window&, NonnullRefPtrVector<MediaQuery>&& media);
+    static MediaList* create(JS::Realm&, NonnullRefPtrVector<MediaQuery>&& media);
     ~MediaList() = default;
 
     String media_text() const;
@@ -37,7 +37,7 @@ public:
     bool matches() const;
 
 private:
-    explicit MediaList(HTML::Window&, NonnullRefPtrVector<MediaQuery>&&);
+    MediaList(JS::Realm&, NonnullRefPtrVector<MediaQuery>&&);
 
     NonnullRefPtrVector<MediaQuery> m_media;
 };

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryList.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/MediaQueryListPrototype.h>
 #include <LibWeb/CSS/MediaQueryList.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/EventDispatcher.h>
@@ -23,7 +25,7 @@ MediaQueryList::MediaQueryList(DOM::Document& document, NonnullRefPtrVector<Medi
     , m_document(document)
     , m_media(move(media))
 {
-    set_prototype(&document.window().cached_web_prototype("MediaQueryList"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::MediaQueryListPrototype>(document.realm(), "MediaQueryList"));
     evaluate();
 }
 

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.cpp
@@ -4,28 +4,23 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MediaQueryListEventPrototype.h>
 #include <LibWeb/CSS/MediaQueryListEvent.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::CSS {
 
-MediaQueryListEvent* MediaQueryListEvent::create(HTML::Window& window_object, FlyString const& event_name, MediaQueryListEventInit const& event_init)
+MediaQueryListEvent* MediaQueryListEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, MediaQueryListEventInit const& event_init)
 {
-    return window_object.heap().allocate<MediaQueryListEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<MediaQueryListEvent>(realm, realm, event_name, event_init);
 }
 
-MediaQueryListEvent* MediaQueryListEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, MediaQueryListEventInit const& event_init)
-{
-    return create(window_object, event_name, event_init);
-}
-
-MediaQueryListEvent::MediaQueryListEvent(HTML::Window& window_object, FlyString const& event_name, MediaQueryListEventInit const& event_init)
-    : DOM::Event(window_object, event_name, event_init)
+MediaQueryListEvent::MediaQueryListEvent(JS::Realm& realm, FlyString const& event_name, MediaQueryListEventInit const& event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_media(event_init.media)
     , m_matches(event_init.matches)
 {
-    set_prototype(&window_object.cached_web_prototype("MediaQueryListEvent"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::MediaQueryListEventPrototype>(realm, "MediaQueryListEvent"));
 }
 
 MediaQueryListEvent::~MediaQueryListEvent() = default;

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.h
@@ -19,16 +19,16 @@ class MediaQueryListEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(MediaQueryListEvent, DOM::Event);
 
 public:
-    static MediaQueryListEvent* create(HTML::Window&, FlyString const& event_name, MediaQueryListEventInit const& event_init = {});
-    static MediaQueryListEvent* create_with_global_object(HTML::Window&, FlyString const& event_name, MediaQueryListEventInit const& event_init);
+    static MediaQueryListEvent* construct_impl(JS::Realm&, FlyString const& event_name, MediaQueryListEventInit const& event_init = {});
 
-    MediaQueryListEvent(HTML::Window&, FlyString const& event_name, MediaQueryListEventInit const& event_init);
     virtual ~MediaQueryListEvent() override;
 
     String const& media() const { return m_media; }
     bool matches() const { return m_matches; }
 
 private:
+    MediaQueryListEvent(JS::Realm&, FlyString const& event_name, MediaQueryListEventInit const& event_init);
+
     String m_media;
     bool m_matches;
 };

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -36,7 +36,7 @@ namespace Web::CSS::Parser {
 class ParsingContext {
 public:
     ParsingContext();
-    explicit ParsingContext(HTML::Window&);
+    explicit ParsingContext(JS::Realm&);
     explicit ParsingContext(DOM::Document const&);
     explicit ParsingContext(DOM::Document const&, AK::URL);
     explicit ParsingContext(DOM::ParentNode&);
@@ -48,10 +48,10 @@ public:
     PropertyID current_property_id() const { return m_current_property_id; }
     void set_current_property_id(PropertyID property_id) { m_current_property_id = property_id; }
 
-    HTML::Window& window_object() const { return m_window_object; }
+    JS::Realm& realm() const { return m_realm; }
 
 private:
-    HTML::Window& m_window_object;
+    JS::Realm& m_realm;
     DOM::Document const* m_document { nullptr };
     PropertyID m_current_property_id { PropertyID::Invalid };
     AK::URL m_url;

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -21,12 +21,11 @@ namespace Web::CSS {
 
 ResolvedCSSStyleDeclaration* ResolvedCSSStyleDeclaration::create(DOM::Element& element)
 {
-    auto& window_object = element.document().window();
-    return window_object.heap().allocate<ResolvedCSSStyleDeclaration>(window_object.realm(), element);
+    return element.realm().heap().allocate<ResolvedCSSStyleDeclaration>(element.realm(), element);
 }
 
 ResolvedCSSStyleDeclaration::ResolvedCSSStyleDeclaration(DOM::Element& element)
-    : CSSStyleDeclaration(element.document().window())
+    : CSSStyleDeclaration(element.realm())
     , m_element(element)
 {
 }
@@ -541,14 +540,14 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
 WebIDL::ExceptionOr<void> ResolvedCSSStyleDeclaration::set_property(PropertyID, StringView, StringView)
 {
     // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
-    return WebIDL::NoModificationAllowedError::create(global_object(), "Cannot modify properties in result of getComputedStyle()");
+    return WebIDL::NoModificationAllowedError::create(realm(), "Cannot modify properties in result of getComputedStyle()");
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
 WebIDL::ExceptionOr<String> ResolvedCSSStyleDeclaration::remove_property(PropertyID)
 {
     // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
-    return WebIDL::NoModificationAllowedError::create(global_object(), "Cannot remove properties from result of getComputedStyle()");
+    return WebIDL::NoModificationAllowedError::create(realm(), "Cannot remove properties from result of getComputedStyle()");
 }
 
 String ResolvedCSSStyleDeclaration::serialized() const

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
@@ -15,7 +15,6 @@ class ResolvedCSSStyleDeclaration final : public CSSStyleDeclaration {
 
 public:
     static ResolvedCSSStyleDeclaration* create(DOM::Element& element);
-    explicit ResolvedCSSStyleDeclaration(DOM::Element&);
 
     virtual ~ResolvedCSSStyleDeclaration() override = default;
 
@@ -28,6 +27,8 @@ public:
     virtual String serialized() const override;
 
 private:
+    explicit ResolvedCSSStyleDeclaration(DOM::Element&);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     RefPtr<StyleValue> style_value_for_property(Layout::NodeWithStyle const&, PropertyID) const;

--- a/Userland/Libraries/LibWeb/CSS/Screen.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Screen.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <LibGfx/Rect.h>
+#include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/ScreenPrototype.h>
 #include <LibWeb/CSS/Screen.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Page/Page.h>
@@ -20,7 +22,7 @@ Screen::Screen(HTML::Window& window)
     : PlatformObject(window.realm())
     , m_window(window)
 {
-    set_prototype(&window.cached_web_prototype("Screen"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::ScreenPrototype>(window.realm(), "Screen"));
 }
 
 void Screen::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/CSS/Screen.h
+++ b/Userland/Libraries/LibWeb/CSS/Screen.h
@@ -17,8 +17,6 @@ class Screen final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(Screen, Bindings::PlatformObject);
 
 public:
-    using AllowOwnPtr = TrueType;
-
     static JS::NonnullGCPtr<Screen> create(HTML::Window&);
 
     i32 width() const { return screen_rect().width(); }

--- a/Userland/Libraries/LibWeb/CSS/StyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheet.cpp
@@ -8,12 +8,11 @@
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/StyleSheet.h>
 #include <LibWeb/DOM/Element.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::CSS {
 
-StyleSheet::StyleSheet(HTML::Window& window_object)
-    : PlatformObject(window_object.cached_web_prototype("StyleSheet"))
+StyleSheet::StyleSheet(JS::Realm& realm)
+    : PlatformObject(realm)
 {
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheet.h
@@ -46,7 +46,7 @@ public:
     void set_parent_css_style_sheet(CSSStyleSheet*);
 
 protected:
-    explicit StyleSheet(HTML::Window&);
+    explicit StyleSheet(JS::Realm&);
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:

--- a/Userland/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/QuickSort.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/StyleSheetListPrototype.h>
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/DOM/Document.h>
@@ -36,12 +37,12 @@ void StyleSheetList::remove_sheet(CSSStyleSheet& sheet)
 
 StyleSheetList* StyleSheetList::create(DOM::Document& document)
 {
-    auto& realm = document.window().realm();
+    auto& realm = document.realm();
     return realm.heap().allocate<StyleSheetList>(realm, document);
 }
 
 StyleSheetList::StyleSheetList(DOM::Document& document)
-    : Bindings::LegacyPlatformObject(document.window().cached_web_prototype("StyleSheetList"))
+    : Bindings::LegacyPlatformObject(Bindings::ensure_web_prototype<Bindings::StyleSheetListPrototype>(document.realm(), "StyleSheetList"))
     , m_document(document)
 {
 }

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
@@ -8,21 +8,21 @@
 #include <AK/Random.h>
 #include <AK/StringBuilder.h>
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/Crypto/SubtleCrypto.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Crypto {
 
-JS::NonnullGCPtr<Crypto> Crypto::create(HTML::Window& window)
+JS::NonnullGCPtr<Crypto> Crypto::create(JS::Realm& realm)
 {
-    return *window.heap().allocate<Crypto>(window.realm(), window);
+    return *realm.heap().allocate<Crypto>(realm, realm);
 }
 
-Crypto::Crypto(HTML::Window& window)
-    : PlatformObject(window.realm())
+Crypto::Crypto(JS::Realm& realm)
+    : PlatformObject(realm)
 {
-    set_prototype(&window.cached_web_prototype("Crypto"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "Crypto"));
 }
 
 Crypto::~Crypto() = default;
@@ -30,7 +30,7 @@ Crypto::~Crypto() = default;
 void Crypto::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
-    m_subtle = SubtleCrypto::create(global_object());
+    m_subtle = SubtleCrypto::create(realm);
 }
 
 JS::NonnullGCPtr<SubtleCrypto> Crypto::subtle() const
@@ -43,16 +43,16 @@ WebIDL::ExceptionOr<JS::Value> Crypto::get_random_values(JS::Value array) const
 {
     // 1. If array is not an Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, BigInt64Array, or BigUint64Array, then throw a TypeMismatchError and terminate the algorithm.
     if (!array.is_object() || !(is<JS::Int8Array>(array.as_object()) || is<JS::Uint8Array>(array.as_object()) || is<JS::Uint8ClampedArray>(array.as_object()) || is<JS::Int16Array>(array.as_object()) || is<JS::Uint16Array>(array.as_object()) || is<JS::Int32Array>(array.as_object()) || is<JS::Uint32Array>(array.as_object()) || is<JS::BigInt64Array>(array.as_object()) || is<JS::BigUint64Array>(array.as_object())))
-        return WebIDL::TypeMismatchError::create(global_object(), "array must be one of Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, BigInt64Array, or BigUint64Array");
+        return WebIDL::TypeMismatchError::create(realm(), "array must be one of Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, BigInt64Array, or BigUint64Array");
     auto& typed_array = static_cast<JS::TypedArrayBase&>(array.as_object());
 
     // 2. If the byteLength of array is greater than 65536, throw a QuotaExceededError and terminate the algorithm.
     if (typed_array.byte_length() > 65536)
-        return WebIDL::QuotaExceededError::create(global_object(), "array's byteLength may not be greater than 65536");
+        return WebIDL::QuotaExceededError::create(realm(), "array's byteLength may not be greater than 65536");
 
     // IMPLEMENTATION DEFINED: If the viewed array buffer is detached, throw a InvalidStateError and terminate the algorithm.
     if (typed_array.viewed_array_buffer()->is_detached())
-        return WebIDL::InvalidStateError::create(global_object(), "array is detached");
+        return WebIDL::InvalidStateError::create(realm(), "array is detached");
     // FIXME: Handle SharedArrayBuffers
 
     // 3. Overwrite all elements of array with cryptographically strong random values of the appropriate type.

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.h
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.h
@@ -16,7 +16,7 @@ class Crypto : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(Crypto, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<Crypto> create(HTML::Window&);
+    static JS::NonnullGCPtr<Crypto> create(JS::Realm&);
 
     virtual ~Crypto() override;
 
@@ -29,7 +29,7 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    explicit Crypto(HTML::Window&);
+    explicit Crypto(JS::Realm&);
     virtual void initialize(JS::Realm&) override;
 
     JS::GCPtr<SubtleCrypto> m_subtle;

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.h
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.h
@@ -15,14 +15,14 @@ class SubtleCrypto final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(SubtleCrypto, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<SubtleCrypto> create(HTML::Window&);
+    static JS::NonnullGCPtr<SubtleCrypto> create(JS::Realm&);
 
     virtual ~SubtleCrypto() override;
 
     JS::Promise* digest(String const& algorithm, JS::Handle<JS::Object> const& data);
 
 private:
-    explicit SubtleCrypto(HTML::Window&);
+    explicit SubtleCrypto(JS::Realm&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/AbortController.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortController.cpp
@@ -4,23 +4,24 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/AbortController.h>
 #include <LibWeb/DOM/AbortSignal.h>
 
 namespace Web::DOM {
 
-JS::NonnullGCPtr<AbortController> AbortController::create_with_global_object(HTML::Window& window)
+JS::NonnullGCPtr<AbortController> AbortController::construct_impl(JS::Realm& realm)
 {
-    auto signal = AbortSignal::create_with_global_object(window);
-    return *window.heap().allocate<AbortController>(window.realm(), window, move(signal));
+    auto signal = AbortSignal::construct_impl(realm);
+    return *realm.heap().allocate<AbortController>(realm, realm, move(signal));
 }
 
 // https://dom.spec.whatwg.org/#dom-abortcontroller-abortcontroller
-AbortController::AbortController(HTML::Window& window, JS::NonnullGCPtr<AbortSignal> signal)
-    : PlatformObject(window.realm())
+AbortController::AbortController(JS::Realm& realm, JS::NonnullGCPtr<AbortSignal> signal)
+    : PlatformObject(realm)
     , m_signal(move(signal))
 {
-    set_prototype(&window.cached_web_prototype("AbortController"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "AbortController"));
 }
 
 AbortController::~AbortController() = default;

--- a/Userland/Libraries/LibWeb/DOM/AbortController.h
+++ b/Userland/Libraries/LibWeb/DOM/AbortController.h
@@ -16,7 +16,7 @@ class AbortController final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(AbortController, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<AbortController> create_with_global_object(HTML::Window&);
+    static JS::NonnullGCPtr<AbortController> construct_impl(JS::Realm&);
 
     virtual ~AbortController() override;
 
@@ -26,7 +26,7 @@ public:
     void abort(JS::Value reason);
 
 private:
-    AbortController(HTML::Window&, JS::NonnullGCPtr<AbortSignal>);
+    AbortController(JS::Realm&, JS::NonnullGCPtr<AbortSignal>);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -23,11 +23,6 @@ AbortSignal::AbortSignal(JS::Realm& realm)
     set_prototype(&Bindings::cached_web_prototype(realm, "AbortSignal"));
 }
 
-AbortSignal::AbortSignal(HTML::Window& window)
-    : AbortSignal(window.realm())
-{
-}
-
 // https://dom.spec.whatwg.org/#abortsignal-add
 void AbortSignal::add_abort_algorithm(Function<void()> abort_algorithm)
 {

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.h
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.h
@@ -40,7 +40,6 @@ public:
 
 private:
     explicit AbortSignal(JS::Realm&);
-    explicit AbortSignal(HTML::Window&);
 
     virtual void visit_edges(JS::Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.h
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.h
@@ -10,7 +10,6 @@
 #include <AK/Weakable.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 
@@ -19,7 +18,7 @@ class AbortSignal final : public EventTarget {
     WEB_PLATFORM_OBJECT(AbortSignal, EventTarget);
 
 public:
-    static JS::NonnullGCPtr<AbortSignal> create_with_global_object(HTML::Window&);
+    static JS::NonnullGCPtr<AbortSignal> construct_impl(JS::Realm&);
 
     virtual ~AbortSignal() override = default;
 
@@ -40,6 +39,7 @@ public:
     JS::ThrowCompletionOr<void> throw_if_aborted() const;
 
 private:
+    explicit AbortSignal(JS::Realm&);
     explicit AbortSignal(HTML::Window&);
 
     virtual void visit_edges(JS::Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/DOM/AbstractRange.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbstractRange.cpp
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/AbstractRange.h>
 #include <LibWeb/DOM/Document.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 
 AbstractRange::AbstractRange(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset)
-    : Bindings::PlatformObject(start_container.document().window().cached_web_prototype("AbstractRange"))
+    : Bindings::PlatformObject(Bindings::cached_web_prototype(start_container.realm(), "AbstractRange"))
     , m_start_container(start_container)
     , m_start_offset(start_offset)
     , m_end_container(end_container)

--- a/Userland/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attr.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
@@ -23,7 +24,7 @@ Attr::Attr(Document& document, FlyString local_name, String value, Element const
     , m_value(move(value))
     , m_owner_element(owner_element)
 {
-    set_prototype(&window().cached_web_prototype("Attr"));
+    set_prototype(&Bindings::cached_web_prototype(document.realm(), "Attr"));
 }
 
 void Attr::visit_edges(Cell::Visitor& visitor)
@@ -69,7 +70,7 @@ void Attr::set_value(String value)
 void Attr::handle_attribute_changes(Element& element, String const& old_value, [[maybe_unused]] String const& new_value)
 {
     // 1. Queue a mutation record of "attributes" for element with attribute’s local name, attribute’s namespace, oldValue, « », « », null, and null.
-    element.queue_mutation_record(MutationType::attributes, local_name(), namespace_uri(), old_value, StaticNodeList::create(window(), {}), StaticNodeList::create(window(), {}), nullptr, nullptr);
+    element.queue_mutation_record(MutationType::attributes, local_name(), namespace_uri(), old_value, StaticNodeList::create(realm(), {}), StaticNodeList::create(realm(), {}), nullptr, nullptr);
 
     // FIXME: 2. If element is custom, then enqueue a custom element callback reaction with element, callback name "attributeChangedCallback", and an argument list containing attribute’s local name, oldValue, newValue, and attribute’s namespace.
 

--- a/Userland/Libraries/LibWeb/DOM/CDATASection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CDATASection.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/CDATASection.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 

--- a/Userland/Libraries/LibWeb/DOM/CDATASection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CDATASection.cpp
@@ -12,7 +12,7 @@ namespace Web::DOM {
 CDATASection::CDATASection(Document& document, String const& data)
     : Text(document, NodeType::CDATA_SECTION_NODE, data)
 {
-    set_prototype(&window().cached_web_prototype("CDATASection"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "CDATASection"));
 }
 
 CDATASection::~CDATASection() = default;

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -17,7 +17,7 @@ CharacterData::CharacterData(Document& document, NodeType type, String const& da
     : Node(document, type)
     , m_data(data)
 {
-    set_prototype(&window().ensure_web_prototype<Bindings::CharacterDataPrototype>("CharacterData"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::CharacterDataPrototype>(document.realm(), "CharacterData"));
 }
 
 // https://dom.spec.whatwg.org/#dom-characterdata-data
@@ -38,7 +38,7 @@ WebIDL::ExceptionOr<String> CharacterData::substring_data(size_t offset, size_t 
 
     // 2. If offset is greater than length, then throw an "IndexSizeError" DOMException.
     if (offset > length)
-        return WebIDL::IndexSizeError::create(global_object(), "Substring offset out of range.");
+        return WebIDL::IndexSizeError::create(realm(), "Substring offset out of range.");
 
     // 3. If offset plus count is greater than length, return a string whose value is the code units from the offsetth code unit
     //    to the end of node’s data, and then return.
@@ -57,14 +57,14 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
 
     // 2. If offset is greater than length, then throw an "IndexSizeError" DOMException.
     if (offset > length)
-        return WebIDL::IndexSizeError::create(global_object(), "Replacement offset out of range.");
+        return WebIDL::IndexSizeError::create(realm(), "Replacement offset out of range.");
 
     // 3. If offset plus count is greater than length, then set count to length minus offset.
     if (offset + count > length)
         count = length - offset;
 
     // 4. Queue a mutation record of "characterData" for node with null, null, node’s data, « », « », null, and null.
-    queue_mutation_record(MutationType::characterData, {}, {}, m_data, StaticNodeList::create(window(), {}), StaticNodeList::create(window(), {}), nullptr, nullptr);
+    queue_mutation_record(MutationType::characterData, {}, {}, m_data, StaticNodeList::create(realm(), {}), StaticNodeList::create(realm(), {}), nullptr, nullptr);
 
     // 5. Insert data into node’s data after offset code units.
     // 6. Let delete offset be offset + data’s length.

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.h
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.h
@@ -34,7 +34,7 @@ public:
     WebIDL::ExceptionOr<void> replace_data(size_t offset, size_t count, String const&);
 
 protected:
-    explicit CharacterData(Document&, NodeType, String const&);
+    CharacterData(Document&, NodeType, String const&);
 
 private:
     String m_data;

--- a/Userland/Libraries/LibWeb/DOM/Comment.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Comment.cpp
@@ -16,9 +16,10 @@ Comment::Comment(Document& document, String const& data)
 }
 
 // https://dom.spec.whatwg.org/#dom-comment-comment
-JS::NonnullGCPtr<Comment> Comment::create_with_global_object(HTML::Window& window, String const& data)
+JS::NonnullGCPtr<Comment> Comment::construct_impl(JS::Realm& realm, String const& data)
 {
-    return *window.heap().allocate<Comment>(window.realm(), window.associated_document(), data);
+    auto& window = verify_cast<HTML::Window>(realm.global_object());
+    return *realm.heap().allocate<Comment>(realm, window.associated_document(), data);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Comment.h
+++ b/Userland/Libraries/LibWeb/DOM/Comment.h
@@ -15,13 +15,13 @@ class Comment final : public CharacterData {
     WEB_PLATFORM_OBJECT(Comment, CharacterData);
 
 public:
-    static JS::NonnullGCPtr<Comment> create_with_global_object(HTML::Window&, String const& data);
+    static JS::NonnullGCPtr<Comment> construct_impl(JS::Realm&, String const& data);
     virtual ~Comment() override = default;
 
     virtual FlyString node_name() const override { return "#comment"; }
 
 private:
-    explicit Comment(Document&, String const&);
+    Comment(Document&, String const&);
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/CustomEvent.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CustomEvent.cpp
@@ -5,32 +5,27 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/Realm.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/CustomEvent.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 
-CustomEvent* CustomEvent::create(HTML::Window& window_object, FlyString const& event_name, CustomEventInit const& event_init)
+CustomEvent* CustomEvent::create(JS::Realm& realm, FlyString const& event_name, CustomEventInit const& event_init)
 {
-    return window_object.heap().allocate<CustomEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<CustomEvent>(realm, realm, event_name, event_init);
 }
 
-CustomEvent* CustomEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, CustomEventInit const& event_init)
+CustomEvent* CustomEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, CustomEventInit const& event_init)
 {
-    return create(window_object, event_name, event_init);
+    return create(realm, event_name, event_init);
 }
 
-CustomEvent::CustomEvent(HTML::Window& window_object, FlyString const& event_name)
-    : Event(window_object, event_name)
-{
-    set_prototype(&window_object.cached_web_prototype("CustomEvent"));
-}
-
-CustomEvent::CustomEvent(HTML::Window& window_object, FlyString const& event_name, CustomEventInit const& event_init)
-    : Event(window_object, event_name, event_init)
+CustomEvent::CustomEvent(JS::Realm& realm, FlyString const& event_name, CustomEventInit const& event_init)
+    : Event(realm, event_name, event_init)
     , m_detail(event_init.detail)
 {
-    set_prototype(&window_object.cached_web_prototype("CustomEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "CustomEvent"));
 }
 
 CustomEvent::~CustomEvent() = default;

--- a/Userland/Libraries/LibWeb/DOM/CustomEvent.h
+++ b/Userland/Libraries/LibWeb/DOM/CustomEvent.h
@@ -20,11 +20,8 @@ class CustomEvent : public Event {
     WEB_PLATFORM_OBJECT(CustomEvent, Event);
 
 public:
-    static CustomEvent* create(HTML::Window&, FlyString const& event_name, CustomEventInit const& event_init = {});
-    static CustomEvent* create_with_global_object(HTML::Window&, FlyString const& event_name, CustomEventInit const& event_init);
-
-    CustomEvent(HTML::Window&, FlyString const& event_name);
-    CustomEvent(HTML::Window&, FlyString const& event_name, CustomEventInit const& event_init);
+    static CustomEvent* create(JS::Realm&, FlyString const& event_name, CustomEventInit const& event_init = {});
+    static CustomEvent* construct_impl(JS::Realm&, FlyString const& event_name, CustomEventInit const& event_init);
 
     virtual ~CustomEvent() override;
 
@@ -36,6 +33,8 @@ public:
     void init_custom_event(String const& type, bool bubbles, bool cancelable, JS::Value detail);
 
 private:
+    CustomEvent(JS::Realm&, FlyString const& event_name, CustomEventInit const& event_init);
+
     // https://dom.spec.whatwg.org/#dom-customevent-initcustomevent-type-bubbles-cancelable-detail-detail
     JS::Value m_detail { JS::js_null() };
 };

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/DOM/DOMImplementation.h>
 #include <LibWeb/DOM/Document.h>
@@ -12,19 +13,18 @@
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/Origin.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Namespace.h>
 
 namespace Web::DOM {
 
 JS::NonnullGCPtr<DOMImplementation> DOMImplementation::create(Document& document)
 {
-    auto& window = document.window();
-    return *window.heap().allocate<DOMImplementation>(document.realm(), document);
+    auto& realm = document.realm();
+    return *realm.heap().allocate<DOMImplementation>(realm, document);
 }
 
 DOMImplementation::DOMImplementation(Document& document)
-    : PlatformObject(document.window().cached_web_prototype("DOMImplementation"))
+    : PlatformObject(Bindings::cached_web_prototype(document.realm(), "DOMImplementation"))
     , m_document(document)
 {
 }
@@ -41,7 +41,7 @@ void DOMImplementation::visit_edges(Cell::Visitor& visitor)
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> DOMImplementation::create_document(String const& namespace_, String const& qualified_name, JS::GCPtr<DocumentType> doctype) const
 {
     // FIXME: This should specifically be an XML document.
-    auto xml_document = Document::create(Bindings::main_thread_internal_window_object());
+    auto xml_document = Document::create(realm());
 
     xml_document->set_ready_for_post_load_tasks(true);
 
@@ -71,7 +71,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> DOMImplementation::create_docume
 // https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
 JS::NonnullGCPtr<Document> DOMImplementation::create_html_document(String const& title) const
 {
-    auto html_document = Document::create(Bindings::main_thread_internal_window_object());
+    auto html_document = Document::create(realm());
 
     html_document->set_content_type("text/html");
     html_document->set_ready_for_post_load_tasks(true);
@@ -105,7 +105,7 @@ JS::NonnullGCPtr<Document> DOMImplementation::create_html_document(String const&
 // https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentType>> DOMImplementation::create_document_type(String const& qualified_name, String const& public_id, String const& system_id)
 {
-    TRY(Document::validate_qualified_name(global_object(), qualified_name));
+    TRY(Document::validate_qualified_name(realm(), qualified_name));
     auto document_type = DocumentType::create(document());
     document_type->set_name(qualified_name);
     document_type->set_public_id(public_id);

--- a/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
@@ -61,7 +61,7 @@ DOMTokenList* DOMTokenList::create(Element const& associated_element, FlyString 
 
 // https://dom.spec.whatwg.org/#ref-for-domtokenlist%E2%91%A0%E2%91%A2
 DOMTokenList::DOMTokenList(Element const& associated_element, FlyString associated_attribute)
-    : Bindings::LegacyPlatformObject(associated_element.window().cached_web_prototype("DOMTokenList"))
+    : Bindings::LegacyPlatformObject(Bindings::cached_web_prototype(associated_element.realm(), "DOMTokenList"))
     , m_associated_element(associated_element)
     , m_associated_attribute(move(associated_attribute))
 {
@@ -234,9 +234,9 @@ void DOMTokenList::set_value(String value)
 WebIDL::ExceptionOr<void> DOMTokenList::validate_token(StringView token) const
 {
     if (token.is_empty())
-        return WebIDL::SyntaxError::create(global_object(), "Non-empty DOM tokens are not allowed");
+        return WebIDL::SyntaxError::create(realm(), "Non-empty DOM tokens are not allowed");
     if (any_of(token, is_ascii_space))
-        return WebIDL::InvalidCharacterError::create(global_object(), "DOM tokens containing ASCII whitespace are not allowed");
+        return WebIDL::InvalidCharacterError::create(realm(), "DOM tokens containing ASCII whitespace are not allowed");
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
@@ -10,7 +10,6 @@
 #include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/WebIDL/DOMException.h>
 
 namespace {
@@ -55,7 +54,7 @@ namespace Web::DOM {
 
 DOMTokenList* DOMTokenList::create(Element const& associated_element, FlyString associated_attribute)
 {
-    auto& realm = associated_element.document().window().realm();
+    auto& realm = associated_element.realm();
     return realm.heap().allocate<DOMTokenList>(realm, associated_element, move(associated_attribute));
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -153,6 +153,8 @@ JS::NonnullGCPtr<Document> Document::create_and_initialize(Type type, String con
         && navigation_params.history_handling == HTML::HistoryHandlingBehavior::Replace
         && (browsing_context->active_document() && browsing_context->active_document()->origin().is_same_origin(navigation_params.origin))) {
         // Do nothing.
+        // NOTE: This means that both the initial about:blank Document, and the new Document that is about to be created, will share the same Window object.
+        window = browsing_context->active_window();
     }
 
     // 6. Otherwise:

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1178,7 +1178,6 @@ JS::NonnullGCPtr<Range> Document::create_range()
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(String const& interface)
 {
     auto& realm = this->realm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
 
     // NOTE: This is named event here, since we do step 5 and 6 as soon as possible for each case.
     // 1. Let constructor be null.
@@ -1202,17 +1201,17 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(String const
     } else if (interface_lowercase.is_one_of("event", "events")) {
         event = Event::create(realm, "");
     } else if (interface_lowercase == "focusevent") {
-        event = UIEvents::FocusEvent::create(window, "");
+        event = UIEvents::FocusEvent::create(realm, "");
     } else if (interface_lowercase == "hashchangeevent") {
         event = Event::create(realm, ""); // FIXME: Create HashChangeEvent
     } else if (interface_lowercase == "htmlevents") {
         event = Event::create(realm, "");
     } else if (interface_lowercase == "keyboardevent") {
-        event = UIEvents::KeyboardEvent::create(window, "");
+        event = UIEvents::KeyboardEvent::create(realm, "");
     } else if (interface_lowercase == "messageevent") {
         event = HTML::MessageEvent::create(realm, "");
     } else if (interface_lowercase.is_one_of("mouseevent", "mouseevents")) {
-        event = UIEvents::MouseEvent::create(window, "");
+        event = UIEvents::MouseEvent::create(realm, "");
     } else if (interface_lowercase == "storageevent") {
         event = Event::create(realm, ""); // FIXME: Create StorageEvent
     } else if (interface_lowercase == "svgevents") {
@@ -1222,7 +1221,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(String const
     } else if (interface_lowercase == "touchevent") {
         event = Event::create(realm, ""); // FIXME: Create TouchEvent
     } else if (interface_lowercase.is_one_of("uievent", "uievents")) {
-        event = UIEvents::UIEvent::create(window, "");
+        event = UIEvents::UIEvent::create(realm, "");
     }
 
     // 3. If constructor is null, then throw a "NotSupportedError" DOMException.

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -288,11 +288,6 @@ JS::NonnullGCPtr<Document> Document::create(JS::Realm& realm, AK::URL const& url
     return *realm.heap().allocate<Document>(realm, realm, url);
 }
 
-JS::NonnullGCPtr<Document> Document::create(HTML::Window& window, AK::URL const& url)
-{
-    return create(window.realm(), url);
-}
-
 Document::Document(JS::Realm& realm, const AK::URL& url)
     : ParentNode(realm, *this, NodeType::DOCUMENT_NODE)
     , m_style_computer(make<CSS::StyleComputer>(*this))

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1709,7 +1709,7 @@ void Document::evaluate_media_queries_and_report_changes()
             CSS::MediaQueryListEventInit init;
             init.media = media_query_list->media();
             init.matches = now_matches;
-            auto event = CSS::MediaQueryListEvent::create(window(), HTML::EventNames::change, init);
+            auto event = CSS::MediaQueryListEvent::create(realm(), HTML::EventNames::change, init);
             event->set_is_trusted(true);
             media_query_list->dispatch_event(*event);
         }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1210,7 +1210,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(String const
     } else if (interface_lowercase == "keyboardevent") {
         event = UIEvents::KeyboardEvent::create(window, "");
     } else if (interface_lowercase == "messageevent") {
-        event = HTML::MessageEvent::create(window, "");
+        event = HTML::MessageEvent::create(realm, "");
     } else if (interface_lowercase.is_one_of("mouseevent", "mouseevents")) {
         event = UIEvents::MouseEvent::create(window, "");
     } else if (interface_lowercase == "storageevent") {
@@ -1967,7 +1967,7 @@ CSS::StyleSheetList const& Document::style_sheets() const
 JS::NonnullGCPtr<HTML::History> Document::history()
 {
     if (!m_history)
-        m_history = HTML::History::create(window(), *this);
+        m_history = HTML::History::create(realm(), *this);
     return *m_history;
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1087,7 +1087,7 @@ Color Document::visited_link_color() const
 HTML::EnvironmentSettingsObject& Document::relevant_settings_object()
 {
     // Then, the relevant settings object for a platform object o is the environment settings object of the relevant Realm for o.
-    return verify_cast<HTML::EnvironmentSettingsObject>(*realm().host_defined());
+    return Bindings::host_defined_environment_settings_object(realm());
 }
 
 JS::Value Document::run_javascript(StringView source, StringView filename)

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -23,6 +23,7 @@
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/DOM/NonElementParentNode.h>
 #include <LibWeb/DOM/ParentNode.h>
+#include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicy.h>
 #include <LibWeb/HTML/DocumentReadyState.h>
 #include <LibWeb/HTML/HTMLScriptElement.h>
@@ -82,8 +83,9 @@ public:
 
     static JS::NonnullGCPtr<Document> create_and_initialize(Type, String content_type, HTML::NavigationParams);
 
+    static JS::NonnullGCPtr<Document> create(JS::Realm&, AK::URL const& url = "about:blank"sv);
     static JS::NonnullGCPtr<Document> create(HTML::Window&, AK::URL const& url = "about:blank"sv);
-    static JS::NonnullGCPtr<Document> create_with_global_object(HTML::Window&);
+    static JS::NonnullGCPtr<Document> construct_impl(JS::Realm&);
     virtual ~Document() override;
 
     size_t next_layout_node_serial_id(Badge<Layout::Node>) { return m_next_layout_node_serial_id++; }
@@ -367,7 +369,7 @@ public:
         FlyString prefix;
         FlyString tag_name;
     };
-    static WebIDL::ExceptionOr<PrefixAndTagName> validate_qualified_name(JS::Object& global_object, String const& qualified_name);
+    static WebIDL::ExceptionOr<PrefixAndTagName> validate_qualified_name(JS::Realm&, String const& qualified_name);
 
     JS::NonnullGCPtr<NodeIterator> create_node_iterator(Node& root, unsigned what_to_show, JS::GCPtr<NodeFilter>);
     JS::NonnullGCPtr<TreeWalker> create_tree_walker(Node& root, unsigned what_to_show, JS::GCPtr<NodeFilter>);
@@ -440,7 +442,7 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    Document(HTML::Window&, AK::URL const&);
+    Document(JS::Realm&, AK::URL const&);
 
     // ^HTML::GlobalEventHandlers
     virtual EventTarget& global_event_handlers_to_event_target(FlyString const&) final { return *this; }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -84,7 +84,6 @@ public:
     static JS::NonnullGCPtr<Document> create_and_initialize(Type, String content_type, HTML::NavigationParams);
 
     static JS::NonnullGCPtr<Document> create(JS::Realm&, AK::URL const& url = "about:blank"sv);
-    static JS::NonnullGCPtr<Document> create(HTML::Window&, AK::URL const& url = "about:blank"sv);
     static JS::NonnullGCPtr<Document> construct_impl(JS::Realm&);
     virtual ~Document() override;
 

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.cpp
@@ -12,7 +12,7 @@ namespace Web::DOM {
 DocumentFragment::DocumentFragment(Document& document)
     : ParentNode(document, NodeType::DOCUMENT_FRAGMENT_NODE)
 {
-    set_prototype(&window().cached_web_prototype("DocumentFragment"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "DocumentFragment"));
 }
 
 void DocumentFragment::visit_edges(Cell::Visitor& visitor)
@@ -27,9 +27,10 @@ void DocumentFragment::set_host(Web::DOM::Element* element)
 }
 
 // https://dom.spec.whatwg.org/#dom-documentfragment-documentfragment
-JS::NonnullGCPtr<DocumentFragment> DocumentFragment::create_with_global_object(HTML::Window& window)
+JS::NonnullGCPtr<DocumentFragment> DocumentFragment::construct_impl(JS::Realm& realm)
 {
-    return *window.heap().allocate<DocumentFragment>(window.realm(), window.associated_document());
+    auto& window = verify_cast<HTML::Window>(realm.global_object());
+    return *realm.heap().allocate<DocumentFragment>(realm, window.associated_document());
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.h
@@ -19,7 +19,7 @@ class DocumentFragment
     WEB_PLATFORM_OBJECT(DocumentFragment, ParentNode);
 
 public:
-    static JS::NonnullGCPtr<DocumentFragment> create_with_global_object(HTML::Window& window);
+    static JS::NonnullGCPtr<DocumentFragment> construct_impl(JS::Realm& realm);
 
     virtual ~DocumentFragment() override = default;
 

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.cpp
@@ -17,7 +17,7 @@ JS::NonnullGCPtr<DocumentType> DocumentType::create(Document& document)
 DocumentType::DocumentType(Document& document)
     : Node(document, NodeType::DOCUMENT_TYPE_NODE)
 {
-    set_prototype(&window().cached_web_prototype("DocumentType"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "DocumentType"));
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -587,12 +587,12 @@ JS::NonnullGCPtr<Geometry::DOMRect> Element::get_bounding_client_rect() const
     // FIXME: Support inline layout nodes as well.
     auto* paint_box = this->paint_box();
     if (!paint_box)
-        return Geometry::DOMRect::create_with_global_object(window(), 0, 0, 0, 0);
+        return Geometry::DOMRect::construct_impl(realm(), 0, 0, 0, 0);
 
     VERIFY(document().browsing_context());
     auto viewport_offset = document().browsing_context()->viewport_scroll_offset();
 
-    return Geometry::DOMRect::create(window(), paint_box->absolute_rect().translated(-viewport_offset.x(), -viewport_offset.y()));
+    return Geometry::DOMRect::create(realm(), paint_box->absolute_rect().translated(-viewport_offset.x(), -viewport_offset.y()));
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-getclientrects
@@ -602,7 +602,7 @@ JS::NonnullGCPtr<Geometry::DOMRectList> Element::get_client_rects() const
 
     // 1. If the element on which it was invoked does not have an associated layout box return an empty DOMRectList object and stop this algorithm.
     if (!layout_node() || !layout_node()->is_box())
-        return Geometry::DOMRectList::create(window(), move(rects));
+        return Geometry::DOMRectList::create(realm(), move(rects));
 
     // FIXME: 2. If the element has an associated SVG layout box return a DOMRectList object containing a single DOMRect object that describes
     // the bounding box of the element as defined by the SVG specification, applying the transforms that apply to the element and its ancestors.
@@ -616,7 +616,7 @@ JS::NonnullGCPtr<Geometry::DOMRectList> Element::get_client_rects() const
 
     auto bounding_rect = get_bounding_client_rect();
     rects.append(*bounding_rect);
-    return Geometry::DOMRectList::create(window(), move(rects));
+    return Geometry::DOMRectList::create(realm(), move(rects));
 }
 
 int Element::client_top() const

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -179,6 +179,6 @@ private:
 template<>
 inline bool Node::fast_is<Element>() const { return is_element(); }
 
-WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Object& global_object, FlyString namespace_, FlyString qualified_name);
+WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Realm&, FlyString namespace_, FlyString qualified_name);
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Event.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Event.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/TypeCasts.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/ShadowRoot.h>
@@ -14,30 +15,45 @@
 
 namespace Web::DOM {
 
-JS::NonnullGCPtr<Event> Event::create(HTML::Window& window_object, FlyString const& event_name, EventInit const& event_init)
+JS::NonnullGCPtr<Event> Event::create(JS::Realm& realm, FlyString const& event_name, EventInit const& event_init)
 {
-    return *window_object.heap().allocate<Event>(window_object.realm(), window_object, event_name, event_init);
+    return *realm.heap().allocate<Event>(realm, realm, event_name, event_init);
 }
 
-JS::NonnullGCPtr<Event> Event::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, EventInit const& event_init)
+JS::NonnullGCPtr<Event> Event::create(HTML::Window& window, FlyString const& event_name, EventInit const& event_init)
 {
-    return create(window_object, event_name, event_init);
+    return create(window.realm(), event_name, event_init);
 }
 
-Event::Event(HTML::Window& window, FlyString const& type)
-    : PlatformObject(window.cached_web_prototype("Event"))
+JS::NonnullGCPtr<Event> Event::construct_impl(JS::Realm& realm, FlyString const& event_name, EventInit const& event_init)
+{
+    return create(realm, event_name, event_init);
+}
+
+Event::Event(JS::Realm& realm, FlyString const& type)
+    : PlatformObject(Bindings::cached_web_prototype(realm, "Event"))
     , m_type(type)
     , m_initialized(true)
 {
 }
 
-Event::Event(HTML::Window& window, FlyString const& type, EventInit const& event_init)
-    : PlatformObject(window.cached_web_prototype("Event"))
+Event::Event(JS::Realm& realm, FlyString const& type, EventInit const& event_init)
+    : PlatformObject(Bindings::cached_web_prototype(realm, "Event"))
     , m_type(type)
     , m_bubbles(event_init.bubbles)
     , m_cancelable(event_init.cancelable)
     , m_composed(event_init.composed)
     , m_initialized(true)
+{
+}
+
+Event::Event(HTML::Window& window, FlyString const& type, EventInit const& event_init)
+    : Event(window.realm(), type, event_init)
+{
+}
+
+Event::Event(HTML::Window& window, FlyString const& type)
+    : Event(window.realm(), type)
 {
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Event.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Event.cpp
@@ -11,18 +11,12 @@
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/ShadowRoot.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 
 JS::NonnullGCPtr<Event> Event::create(JS::Realm& realm, FlyString const& event_name, EventInit const& event_init)
 {
     return *realm.heap().allocate<Event>(realm, realm, event_name, event_init);
-}
-
-JS::NonnullGCPtr<Event> Event::create(HTML::Window& window, FlyString const& event_name, EventInit const& event_init)
-{
-    return create(window.realm(), event_name, event_init);
 }
 
 JS::NonnullGCPtr<Event> Event::construct_impl(JS::Realm& realm, FlyString const& event_name, EventInit const& event_init)
@@ -44,16 +38,6 @@ Event::Event(JS::Realm& realm, FlyString const& type, EventInit const& event_ini
     , m_cancelable(event_init.cancelable)
     , m_composed(event_init.composed)
     , m_initialized(true)
-{
-}
-
-Event::Event(HTML::Window& window, FlyString const& type, EventInit const& event_init)
-    : Event(window.realm(), type, event_init)
-{
-}
-
-Event::Event(HTML::Window& window, FlyString const& type)
-    : Event(window.realm(), type)
 {
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Event.h
+++ b/Userland/Libraries/LibWeb/DOM/Event.h
@@ -9,7 +9,6 @@
 #include <AK/FlyString.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/DOM/EventTarget.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 
@@ -46,9 +45,12 @@ public:
 
     using Path = Vector<PathEntry>;
 
+    static JS::NonnullGCPtr<Event> create(JS::Realm&, FlyString const& event_name, EventInit const& event_init = {});
     static JS::NonnullGCPtr<Event> create(HTML::Window&, FlyString const& event_name, EventInit const& event_init = {});
-    static JS::NonnullGCPtr<Event> create_with_global_object(HTML::Window&, FlyString const& event_name, EventInit const& event_init);
+    static JS::NonnullGCPtr<Event> construct_impl(JS::Realm&, FlyString const& event_name, EventInit const& event_init);
 
+    Event(JS::Realm&, FlyString const& type);
+    Event(JS::Realm&, FlyString const& type, EventInit const& event_init);
     Event(HTML::Window&, FlyString const& type);
     Event(HTML::Window&, FlyString const& type, EventInit const& event_init);
 

--- a/Userland/Libraries/LibWeb/DOM/Event.h
+++ b/Userland/Libraries/LibWeb/DOM/Event.h
@@ -46,13 +46,10 @@ public:
     using Path = Vector<PathEntry>;
 
     static JS::NonnullGCPtr<Event> create(JS::Realm&, FlyString const& event_name, EventInit const& event_init = {});
-    static JS::NonnullGCPtr<Event> create(HTML::Window&, FlyString const& event_name, EventInit const& event_init = {});
     static JS::NonnullGCPtr<Event> construct_impl(JS::Realm&, FlyString const& event_name, EventInit const& event_init);
 
     Event(JS::Realm&, FlyString const& type);
     Event(JS::Realm&, FlyString const& type, EventInit const& event_init);
-    Event(HTML::Window&, FlyString const& type);
-    Event(HTML::Window&, FlyString const& type, EventInit const& event_init);
 
     virtual ~Event() = default;
 

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -556,7 +556,7 @@ void EventTarget::activate_event_handler(FlyString const& name, HTML::EventHandl
         0, "", &realm);
 
     // NOTE: As per the spec, the callback context is arbitrary.
-    auto* callback = realm.heap().allocate_without_realm<WebIDL::CallbackType>(*callback_function, verify_cast<HTML::EnvironmentSettingsObject>(*realm.host_defined()));
+    auto* callback = realm.heap().allocate_without_realm<WebIDL::CallbackType>(*callback_function, Bindings::host_defined_environment_settings_object(realm));
 
     // 5. Let listener be a new event listener whose type is the event handler event type corresponding to eventHandler and callback is callback.
     auto* listener = realm.heap().allocate_without_realm<DOMEventListener>();

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -227,10 +227,10 @@ WebIDL::ExceptionOr<bool> EventTarget::dispatch_event_binding(Event& event)
 {
     // 1. If event’s dispatch flag is set, or if its initialized flag is not set, then throw an "InvalidStateError" DOMException.
     if (event.dispatched())
-        return WebIDL::InvalidStateError::create(global_object(), "The event is already being dispatched.");
+        return WebIDL::InvalidStateError::create(realm(), "The event is already being dispatched.");
 
     if (!event.initialized())
-        return WebIDL::InvalidStateError::create(global_object(), "Cannot dispatch an uninitialized event.");
+        return WebIDL::InvalidStateError::create(realm(), "Cannot dispatch an uninitialized event.");
 
     // 2. Initialize event’s isTrusted attribute to false.
     event.set_is_trusted(false);

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.h
@@ -22,7 +22,7 @@ class EventTarget : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(EventTarget, Bindings::PlatformObject);
 
 public:
-    virtual ~EventTarget();
+    virtual ~EventTarget() override;
 
     virtual bool is_focusable() const { return false; }
 

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/DOM/ParentNode.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Namespace.h>
 
 namespace Web::DOM {
@@ -19,7 +19,7 @@ JS::NonnullGCPtr<HTMLCollection> HTMLCollection::create(ParentNode& root, Functi
 }
 
 HTMLCollection::HTMLCollection(ParentNode& root, Function<bool(Element const&)> filter)
-    : LegacyPlatformObject(root.window().cached_web_prototype("HTMLCollection"))
+    : LegacyPlatformObject(Bindings::cached_web_prototype(root.realm(), "HTMLCollection"))
     , m_root(root)
     , m_filter(move(filter))
 {

--- a/Userland/Libraries/LibWeb/DOM/IDLEventListener.cpp
+++ b/Userland/Libraries/LibWeb/DOM/IDLEventListener.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <LibWeb/DOM/IDLEventListener.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 

--- a/Userland/Libraries/LibWeb/DOM/LiveNodeList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/LiveNodeList.cpp
@@ -7,7 +7,6 @@
 
 #include <LibWeb/DOM/LiveNodeList.h>
 #include <LibWeb/DOM/Node.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 

--- a/Userland/Libraries/LibWeb/DOM/LiveNodeList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/LiveNodeList.cpp
@@ -11,13 +11,13 @@
 
 namespace Web::DOM {
 
-JS::NonnullGCPtr<NodeList> LiveNodeList::create(HTML::Window& window, Node& root, Function<bool(Node const&)> filter)
+JS::NonnullGCPtr<NodeList> LiveNodeList::create(JS::Realm& realm, Node& root, Function<bool(Node const&)> filter)
 {
-    return *window.heap().allocate<LiveNodeList>(window.realm(), window, root, move(filter));
+    return *realm.heap().allocate<LiveNodeList>(realm, realm, root, move(filter));
 }
 
-LiveNodeList::LiveNodeList(HTML::Window& window, Node& root, Function<bool(Node const&)> filter)
-    : NodeList(window)
+LiveNodeList::LiveNodeList(JS::Realm& realm, Node& root, Function<bool(Node const&)> filter)
+    : NodeList(realm)
     , m_root(root)
     , m_filter(move(filter))
 {

--- a/Userland/Libraries/LibWeb/DOM/LiveNodeList.h
+++ b/Userland/Libraries/LibWeb/DOM/LiveNodeList.h
@@ -18,7 +18,7 @@ class LiveNodeList final : public NodeList {
     WEB_PLATFORM_OBJECT(LiveNodeList, NodeList);
 
 public:
-    static JS::NonnullGCPtr<NodeList> create(HTML::Window&, Node& root, Function<bool(Node const&)> filter);
+    static JS::NonnullGCPtr<NodeList> create(JS::Realm&, Node& root, Function<bool(Node const&)> filter);
     virtual ~LiveNodeList() override;
 
     virtual u32 length() const override;
@@ -27,7 +27,7 @@ public:
     virtual bool is_supported_property_index(u32) const override;
 
 private:
-    LiveNodeList(HTML::Window&, Node& root, Function<bool(Node const&)> filter);
+    LiveNodeList(JS::Realm&, Node& root, Function<bool(Node const&)> filter);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/DOM/MutationObserver.cpp
+++ b/Userland/Libraries/LibWeb/DOM/MutationObserver.cpp
@@ -4,29 +4,29 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/DOM/MutationObserver.h>
 #include <LibWeb/DOM/Node.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 
-JS::NonnullGCPtr<MutationObserver> MutationObserver::create_with_global_object(HTML::Window& window, JS::GCPtr<WebIDL::CallbackType> callback)
+JS::NonnullGCPtr<MutationObserver> MutationObserver::construct_impl(JS::Realm& realm, JS::GCPtr<WebIDL::CallbackType> callback)
 {
-    return *window.heap().allocate<MutationObserver>(window.realm(), window, callback);
+    return *realm.heap().allocate<MutationObserver>(realm, realm, callback);
 }
 
 // https://dom.spec.whatwg.org/#dom-mutationobserver-mutationobserver
-MutationObserver::MutationObserver(HTML::Window& window, JS::GCPtr<WebIDL::CallbackType> callback)
-    : PlatformObject(window.realm())
+MutationObserver::MutationObserver(JS::Realm& realm, JS::GCPtr<WebIDL::CallbackType> callback)
+    : PlatformObject(realm)
     , m_callback(move(callback))
 {
-    set_prototype(&window.cached_web_prototype("MutationObserver"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "MutationObserver"));
 
     // 1. Set this’s callback to callback.
 
     // 2. Append this to this’s relevant agent’s mutation observers.
-    auto* agent_custom_data = verify_cast<Bindings::WebEngineCustomData>(window.vm().custom_data());
+    auto* agent_custom_data = verify_cast<Bindings::WebEngineCustomData>(realm.vm().custom_data());
     agent_custom_data->mutation_observers.append(*this);
 }
 

--- a/Userland/Libraries/LibWeb/DOM/MutationObserver.h
+++ b/Userland/Libraries/LibWeb/DOM/MutationObserver.h
@@ -32,7 +32,7 @@ class MutationObserver final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(MutationObserver, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<MutationObserver> create_with_global_object(HTML::Window&, JS::GCPtr<WebIDL::CallbackType>);
+    static JS::NonnullGCPtr<MutationObserver> construct_impl(JS::Realm&, JS::GCPtr<WebIDL::CallbackType>);
     virtual ~MutationObserver() override;
 
     WebIDL::ExceptionOr<void> observe(Node& target, MutationObserverInit options = {});
@@ -50,7 +50,7 @@ public:
     }
 
 private:
-    MutationObserver(HTML::Window&, JS::GCPtr<WebIDL::CallbackType>);
+    MutationObserver(JS::Realm&, JS::GCPtr<WebIDL::CallbackType>);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/DOM/MutationRecord.cpp
+++ b/Userland/Libraries/LibWeb/DOM/MutationRecord.cpp
@@ -5,20 +5,20 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/MutationRecord.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/NodeList.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 
-JS::NonnullGCPtr<MutationRecord> MutationRecord::create(HTML::Window& window, FlyString const& type, Node& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, String const& attribute_name, String const& attribute_namespace, String const& old_value)
+JS::NonnullGCPtr<MutationRecord> MutationRecord::create(JS::Realm& realm, FlyString const& type, Node& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, String const& attribute_name, String const& attribute_namespace, String const& old_value)
 {
-    return *window.heap().allocate<MutationRecord>(window.realm(), window, type, target, added_nodes, removed_nodes, previous_sibling, next_sibling, attribute_name, attribute_namespace, old_value);
+    return *realm.heap().allocate<MutationRecord>(realm, realm, type, target, added_nodes, removed_nodes, previous_sibling, next_sibling, attribute_name, attribute_namespace, old_value);
 }
 
-MutationRecord::MutationRecord(HTML::Window& window, FlyString const& type, Node& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, String const& attribute_name, String const& attribute_namespace, String const& old_value)
-    : PlatformObject(window.realm())
+MutationRecord::MutationRecord(JS::Realm& realm, FlyString const& type, Node& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, String const& attribute_name, String const& attribute_namespace, String const& old_value)
+    : PlatformObject(realm)
     , m_type(type)
     , m_target(JS::make_handle(target))
     , m_added_nodes(added_nodes)
@@ -29,7 +29,7 @@ MutationRecord::MutationRecord(HTML::Window& window, FlyString const& type, Node
     , m_attribute_namespace(attribute_namespace)
     , m_old_value(old_value)
 {
-    set_prototype(&window.cached_web_prototype("MutationRecord"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "MutationRecord"));
 }
 
 MutationRecord::~MutationRecord() = default;

--- a/Userland/Libraries/LibWeb/DOM/MutationRecord.h
+++ b/Userland/Libraries/LibWeb/DOM/MutationRecord.h
@@ -15,7 +15,7 @@ class MutationRecord : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(MutationRecord, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<MutationRecord> create(HTML::Window&, FlyString const& type, Node& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, String const& attribute_name, String const& attribute_namespace, String const& old_value);
+    static JS::NonnullGCPtr<MutationRecord> create(JS::Realm&, FlyString const& type, Node& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, String const& attribute_name, String const& attribute_namespace, String const& old_value);
 
     virtual ~MutationRecord() override;
 
@@ -30,7 +30,7 @@ public:
     String const& old_value() const { return m_old_value; }
 
 private:
-    MutationRecord(HTML::Window& window, FlyString const& type, Node& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, String const& attribute_name, String const& attribute_namespace, String const& old_value);
+    MutationRecord(JS::Realm& realm, FlyString const& type, Node& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, String const& attribute_name, String const& attribute_namespace, String const& old_value);
     virtual void visit_edges(Cell::Visitor&) override;
 
     FlyString m_type;

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -19,7 +19,7 @@ JS::NonnullGCPtr<NamedNodeMap> NamedNodeMap::create(Element& element)
 }
 
 NamedNodeMap::NamedNodeMap(Element& element)
-    : Bindings::LegacyPlatformObject(element.window().cached_web_prototype("NamedNodeMap"))
+    : Bindings::LegacyPlatformObject(Bindings::cached_web_prototype(element.realm(), "NamedNodeMap"))
     , m_element(element)
 {
 }
@@ -93,7 +93,7 @@ WebIDL::ExceptionOr<Attr const*> NamedNodeMap::remove_named_item(StringView qual
 
     // 2. If attr is null, then throw a "NotFoundError" DOMException.
     if (!attribute)
-        return WebIDL::NotFoundError::create(global_object(), String::formatted("Attribute with name '{}' not found", qualified_name));
+        return WebIDL::NotFoundError::create(realm(), String::formatted("Attribute with name '{}' not found", qualified_name));
 
     // 3. Return attr.
     return nullptr;
@@ -137,7 +137,7 @@ WebIDL::ExceptionOr<Attr const*> NamedNodeMap::set_attribute(Attr& attribute)
 {
     // 1. If attr’s element is neither null nor element, throw an "InUseAttributeError" DOMException.
     if ((attribute.owner_element() != nullptr) && (attribute.owner_element() != &associated_element()))
-        return WebIDL::InUseAttributeError::create(global_object(), "Attribute must not already be in use"sv);
+        return WebIDL::InUseAttributeError::create(realm(), "Attribute must not already be in use"sv);
 
     // 2. Let oldAttr be the result of getting an attribute given attr’s namespace, attr’s local name, and element.
     // FIXME: When getNamedItemNS is implemented, use that instead.

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1497,9 +1497,4 @@ bool Node::is_following(Node const& other) const
     return false;
 }
 
-HTML::Window& Node::window() const
-{
-    return document().window();
-}
-
 }

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -116,8 +116,6 @@ public:
     Document& document() { return *m_document; }
     Document const& document() const { return *m_document; }
 
-    HTML::Window& window() const;
-
     JS::GCPtr<Document> owner_document() const;
 
     const HTML::HTMLAnchorElement* enclosing_link_element() const;

--- a/Userland/Libraries/LibWeb/DOM/NodeFilter.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeFilter.cpp
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibJS/Runtime/Realm.h>
+#include <LibJS/Runtime/VM.h>
 #include <LibWeb/DOM/NodeFilter.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 

--- a/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
@@ -12,7 +12,7 @@
 namespace Web::DOM {
 
 NodeIterator::NodeIterator(Node& root)
-    : PlatformObject(root.window().cached_web_prototype("NodeIterator"))
+    : PlatformObject(Bindings::cached_web_prototype(root.realm(), "NodeIterator"))
     , m_root(root)
     , m_reference({ root })
 {
@@ -130,7 +130,7 @@ JS::ThrowCompletionOr<NodeFilter::Result> NodeIterator::filter(Node& node)
 {
     // 1. If traverser’s active flag is set, then throw an "InvalidStateError" DOMException.
     if (m_active)
-        return throw_completion(WebIDL::InvalidStateError::create(global_object(), "NodeIterator is already active"));
+        return throw_completion(WebIDL::InvalidStateError::create(realm(), "NodeIterator is already active"));
 
     // 2. Let n be node’s nodeType attribute value − 1.
     auto n = node.node_type() - 1;

--- a/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
@@ -41,8 +41,8 @@ JS::NonnullGCPtr<NodeIterator> NodeIterator::create(Node& root, unsigned what_to
     // 1. Let iterator be a new NodeIterator object.
     // 2. Set iterator’s root and iterator’s reference to root.
     // 3. Set iterator’s pointer before reference to true.
-    auto& window_object = root.document().window();
-    auto* iterator = window_object.heap().allocate<NodeIterator>(window_object.realm(), root);
+    auto& realm = root.realm();
+    auto* iterator = realm.heap().allocate<NodeIterator>(realm, root);
 
     // 4. Set iterator’s whatToShow to whatToShow.
     iterator->m_what_to_show = what_to_show;

--- a/Userland/Libraries/LibWeb/DOM/NodeList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeList.cpp
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/NodeList.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 
-NodeList::NodeList(HTML::Window& window)
-    : LegacyPlatformObject(window.cached_web_prototype("NodeList"))
+NodeList::NodeList(JS::Realm& realm)
+    : LegacyPlatformObject(Bindings::cached_web_prototype(realm, "NodeList"))
 {
 }
 

--- a/Userland/Libraries/LibWeb/DOM/NodeList.h
+++ b/Userland/Libraries/LibWeb/DOM/NodeList.h
@@ -25,7 +25,7 @@ public:
     virtual bool is_supported_property_index(u32) const override;
 
 protected:
-    explicit NodeList(HTML::Window&);
+    explicit NodeList(JS::Realm&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -22,7 +22,7 @@ WebIDL::ExceptionOr<JS::GCPtr<Element>> ParentNode::query_selector(StringView se
 {
     auto maybe_selectors = parse_selector(CSS::Parser::ParsingContext(*this), selector_text);
     if (!maybe_selectors.has_value())
-        return WebIDL::SyntaxError::create(global_object(), "Failed to parse selector");
+        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector");
 
     auto selectors = maybe_selectors.value();
 
@@ -45,7 +45,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeList>> ParentNode::query_selector_all(S
 {
     auto maybe_selectors = parse_selector(CSS::Parser::ParsingContext(*this), selector_text);
     if (!maybe_selectors.has_value())
-        return WebIDL::SyntaxError::create(global_object(), "Failed to parse selector");
+        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector");
 
     auto selectors = maybe_selectors.value();
 
@@ -60,7 +60,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeList>> ParentNode::query_selector_all(S
         return IterationDecision::Continue;
     });
 
-    return StaticNodeList::create(window(), move(elements));
+    return StaticNodeList::create(realm(), move(elements));
 }
 
 JS::GCPtr<Element> ParentNode::first_element_child()

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -13,7 +13,6 @@
 #include <LibWeb/DOM/ParentNode.h>
 #include <LibWeb/DOM/StaticNodeList.h>
 #include <LibWeb/Dump.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Namespace.h>
 
 namespace Web::DOM {

--- a/Userland/Libraries/LibWeb/DOM/Position.h
+++ b/Userland/Libraries/LibWeb/DOM/Position.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/RefPtr.h>
+#include <LibJS/Heap/Handle.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/Forward.h>
 

--- a/Userland/Libraries/LibWeb/DOM/Range.h
+++ b/Userland/Libraries/LibWeb/DOM/Range.h
@@ -19,10 +19,8 @@ public:
     static JS::NonnullGCPtr<Range> create(Document&);
     static JS::NonnullGCPtr<Range> create(HTML::Window&);
     static JS::NonnullGCPtr<Range> create(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset);
-    static JS::NonnullGCPtr<Range> create_with_global_object(HTML::Window&);
+    static JS::NonnullGCPtr<Range> construct_impl(JS::Realm&);
 
-    explicit Range(Document&);
-    Range(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset);
     virtual ~Range() override;
 
     // FIXME: There are a ton of methods missing here.
@@ -76,6 +74,9 @@ public:
     static HashTable<Range*>& live_ranges();
 
 private:
+    explicit Range(Document&);
+    Range(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset);
+
     Node& root();
     Node const& root() const;
 

--- a/Userland/Libraries/LibWeb/DOM/StaticNodeList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StaticNodeList.cpp
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Heap/Heap.h>
 #include <LibWeb/DOM/StaticNodeList.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::DOM {
 
-JS::NonnullGCPtr<NodeList> StaticNodeList::create(HTML::Window& window, Vector<JS::Handle<Node>> static_nodes)
+JS::NonnullGCPtr<NodeList> StaticNodeList::create(JS::Realm& realm, Vector<JS::Handle<Node>> static_nodes)
 {
-    return *window.heap().allocate<StaticNodeList>(window.realm(), window, move(static_nodes));
+    return *realm.heap().allocate<StaticNodeList>(realm, realm, move(static_nodes));
 }
 
-StaticNodeList::StaticNodeList(HTML::Window& window, Vector<JS::Handle<Node>> static_nodes)
-    : NodeList(window)
+StaticNodeList::StaticNodeList(JS::Realm& realm, Vector<JS::Handle<Node>> static_nodes)
+    : NodeList(realm)
 {
     for (auto& node : static_nodes)
         m_static_nodes.append(*node);

--- a/Userland/Libraries/LibWeb/DOM/StaticNodeList.h
+++ b/Userland/Libraries/LibWeb/DOM/StaticNodeList.h
@@ -16,7 +16,7 @@ class StaticNodeList final : public NodeList {
     WEB_PLATFORM_OBJECT(StaticNodeList, NodeList);
 
 public:
-    static JS::NonnullGCPtr<NodeList> create(HTML::Window&, Vector<JS::Handle<Node>>);
+    static JS::NonnullGCPtr<NodeList> create(JS::Realm&, Vector<JS::Handle<Node>>);
 
     virtual ~StaticNodeList() override;
 
@@ -26,7 +26,7 @@ public:
     virtual bool is_supported_property_index(u32) const override;
 
 private:
-    StaticNodeList(HTML::Window&, Vector<JS::Handle<Node>>);
+    StaticNodeList(JS::Realm&, Vector<JS::Handle<Node>>);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/DOM/StaticRange.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StaticRange.cpp
@@ -6,8 +6,8 @@
  */
 
 #include <AK/TypeCasts.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Attr.h>
-#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentType.h>
 #include <LibWeb/DOM/StaticRange.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -17,23 +17,23 @@ namespace Web::DOM {
 StaticRange::StaticRange(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset)
     : AbstractRange(start_container, start_offset, end_container, end_offset)
 {
-    set_prototype(&start_container.document().window().cached_web_prototype("StaticRange"));
+    set_prototype(&Bindings::cached_web_prototype(start_container.realm(), "StaticRange"));
 }
 
 StaticRange::~StaticRange() = default;
 
 // https://dom.spec.whatwg.org/#dom-staticrange-staticrange
-WebIDL::ExceptionOr<StaticRange*> StaticRange::create_with_global_object(HTML::Window& window, StaticRangeInit& init)
+WebIDL::ExceptionOr<StaticRange*> StaticRange::construct_impl(JS::Realm& realm, StaticRangeInit& init)
 {
     // 1. If init["startContainer"] or init["endContainer"] is a DocumentType or Attr node, then throw an "InvalidNodeTypeError" DOMException.
     if (is<DocumentType>(*init.start_container) || is<Attr>(*init.start_container))
-        return WebIDL::InvalidNodeTypeError::create(window, "startContainer cannot be a DocumentType or Attribute node.");
+        return WebIDL::InvalidNodeTypeError::create(realm, "startContainer cannot be a DocumentType or Attribute node.");
 
     if (is<DocumentType>(*init.end_container) || is<Attr>(*init.end_container))
-        return WebIDL::InvalidNodeTypeError::create(window, "endContainer cannot be a DocumentType or Attribute node.");
+        return WebIDL::InvalidNodeTypeError::create(realm, "endContainer cannot be a DocumentType or Attribute node.");
 
     // 2. Set this’s start to (init["startContainer"], init["startOffset"]) and end to (init["endContainer"], init["endOffset"]).
-    return window.heap().allocate<StaticRange>(window.realm(), *init.start_container, init.start_offset, *init.end_container, init.end_offset);
+    return realm.heap().allocate<StaticRange>(realm, *init.start_container, init.start_offset, *init.end_container, init.end_offset);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/StaticRange.h
+++ b/Userland/Libraries/LibWeb/DOM/StaticRange.h
@@ -24,7 +24,7 @@ class StaticRange final : public AbstractRange {
     WEB_PLATFORM_OBJECT(StaticRange, JS::Object);
 
 public:
-    static WebIDL::ExceptionOr<StaticRange*> create_with_global_object(HTML::Window&, StaticRangeInit& init);
+    static WebIDL::ExceptionOr<StaticRange*> construct_impl(JS::Realm&, StaticRangeInit& init);
 
     StaticRange(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset);
     virtual ~StaticRange() override;

--- a/Userland/Libraries/LibWeb/DOM/Text.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Text.cpp
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
+#include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/TextNode.h>
 
@@ -15,13 +17,13 @@ namespace Web::DOM {
 Text::Text(Document& document, String const& data)
     : CharacterData(document, NodeType::TEXT_NODE, data)
 {
-    set_prototype(&window().cached_web_prototype("Text"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "Text"));
 }
 
 Text::Text(Document& document, NodeType type, String const& data)
     : CharacterData(document, type, data)
 {
-    set_prototype(&window().cached_web_prototype("Text"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "Text"));
 }
 
 void Text::visit_edges(Cell::Visitor& visitor)
@@ -31,9 +33,11 @@ void Text::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://dom.spec.whatwg.org/#dom-text-text
-JS::NonnullGCPtr<Text> Text::create_with_global_object(HTML::Window& window, String const& data)
+JS::NonnullGCPtr<Text> Text::construct_impl(JS::Realm& realm, String const& data)
 {
-    return *window.heap().allocate<Text>(window.realm(), window.associated_document(), data);
+    // The new Text(data) constructor steps are to set this’s data to data and this’s node document to current global object’s associated Document.
+    auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
+    return *realm.heap().allocate<Text>(realm, window.associated_document(), data);
 }
 
 void Text::set_owner_input_element(Badge<HTML::HTMLInputElement>, HTML::HTMLInputElement& input_element)
@@ -50,7 +54,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::split_text(size_t offset)
 
     // 2. If offset is greater than length, then throw an "IndexSizeError" DOMException.
     if (offset > length)
-        return WebIDL::IndexSizeError::create(global_object(), "Split offset is greater than length");
+        return WebIDL::IndexSizeError::create(realm(), "Split offset is greater than length");
 
     // 3. Let count be length minus offset.
     auto count = length - offset;

--- a/Userland/Libraries/LibWeb/DOM/Text.h
+++ b/Userland/Libraries/LibWeb/DOM/Text.h
@@ -18,7 +18,7 @@ class Text : public CharacterData {
 public:
     virtual ~Text() override = default;
 
-    static JS::NonnullGCPtr<Text> construct_impl(JS::Realm& window, String const& data);
+    static JS::NonnullGCPtr<Text> construct_impl(JS::Realm& realm, String const& data);
 
     // ^Node
     virtual FlyString node_name() const override { return "#text"; }

--- a/Userland/Libraries/LibWeb/DOM/Text.h
+++ b/Userland/Libraries/LibWeb/DOM/Text.h
@@ -18,7 +18,7 @@ class Text : public CharacterData {
 public:
     virtual ~Text() override = default;
 
-    static JS::NonnullGCPtr<Text> create_with_global_object(HTML::Window& window, String const& data);
+    static JS::NonnullGCPtr<Text> construct_impl(JS::Realm& window, String const& data);
 
     // ^Node
     virtual FlyString node_name() const override { return "#text"; }
@@ -32,7 +32,7 @@ public:
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> split_text(size_t offset);
 
 protected:
-    explicit Text(Document&, String const&);
+    Text(Document&, String const&);
     Text(Document&, NodeType, String const&);
 
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
+++ b/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
@@ -14,7 +14,7 @@
 namespace Web::DOM {
 
 TreeWalker::TreeWalker(Node& root)
-    : PlatformObject(root.window().cached_web_prototype("TreeWalker"))
+    : PlatformObject(Bindings::cached_web_prototype(root.realm(), "TreeWalker"))
     , m_root(root)
     , m_current(root)
 {
@@ -231,7 +231,7 @@ JS::ThrowCompletionOr<NodeFilter::Result> TreeWalker::filter(Node& node)
 {
     // 1. If traverser’s active flag is set, then throw an "InvalidStateError" DOMException.
     if (m_active)
-        return throw_completion(WebIDL::InvalidStateError::create(global_object(), "NodeIterator is already active"));
+        return throw_completion(WebIDL::InvalidStateError::create(realm(), "NodeIterator is already active"));
 
     // 2. Let n be node’s nodeType attribute value − 1.
     auto n = node.node_type() - 1;

--- a/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
+++ b/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/DOM/Document.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/NodeFilter.h>
 #include <LibWeb/DOM/TreeWalker.h>
@@ -35,8 +35,8 @@ JS::NonnullGCPtr<TreeWalker> TreeWalker::create(Node& root, unsigned what_to_sho
 {
     // 1. Let walker be a new TreeWalker object.
     // 2. Set walker’s root and walker’s current to root.
-    auto& window_object = root.document().window();
-    auto* walker = window_object.heap().allocate<TreeWalker>(window_object.realm(), root);
+    auto& realm = root.realm();
+    auto* walker = realm.heap().allocate<TreeWalker>(realm, root);
 
     // 3. Set walker’s whatToShow to whatToShow.
     walker->m_what_to_show = what_to_show;

--- a/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Heap/Heap.h>
 #include <LibWeb/DOM/DocumentFragment.h>
 #include <LibWeb/DOMParsing/InnerHTML.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -20,15 +20,15 @@
 
 namespace Web::DOMParsing {
 
-JS::NonnullGCPtr<XMLSerializer> XMLSerializer::create_with_global_object(HTML::Window& window)
+JS::NonnullGCPtr<XMLSerializer> XMLSerializer::construct_impl(JS::Realm& realm)
 {
-    return *window.heap().allocate<XMLSerializer>(window.realm(), window);
+    return *realm.heap().allocate<XMLSerializer>(realm, realm);
 }
 
-XMLSerializer::XMLSerializer(HTML::Window& window)
-    : PlatformObject(window.realm())
+XMLSerializer::XMLSerializer(JS::Realm& realm)
+    : PlatformObject(realm)
 {
-    set_prototype(&window.cached_web_prototype("XMLSerializer"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "XMLSerializer"));
 }
 
 XMLSerializer::~XMLSerializer() = default;
@@ -308,7 +308,7 @@ struct LocalNameSetEntry {
 // https://w3c.github.io/DOM-Parsing/#dfn-xml-serialization-of-the-attributes
 static WebIDL::ExceptionOr<String> serialize_element_attributes(DOM::Element const& element, HashMap<FlyString, Vector<String>>& namespace_prefix_map, u64& prefix_index, HashMap<String, String> const& local_prefixes_map, bool ignore_namespace_definition_attribute, RequireWellFormed require_well_formed)
 {
-    auto& global_object = element.global_object();
+    auto& realm = element.realm();
 
     // 1. Let result be the empty string.
     StringBuilder result;
@@ -331,7 +331,7 @@ static WebIDL::ExceptionOr<String> serialize_element_attributes(DOM::Element con
             });
 
             if (local_name_set_iterator != local_name_set.end())
-                return WebIDL::InvalidStateError::create(global_object, "Element contains two attributes with identical namespaces and local names");
+                return WebIDL::InvalidStateError::create(realm, "Element contains two attributes with identical namespaces and local names");
         }
 
         // 2. Create a new tuple consisting of attr's namespaceURI attribute and localName attribute, and add it to the localname set.
@@ -384,12 +384,12 @@ static WebIDL::ExceptionOr<String> serialize_element_attributes(DOM::Element con
                 // 2. If the require well-formed flag is set (its value is true), and the value of attr's value attribute matches the XMLNS namespace,
                 //    then throw an exception; the serialization of this attribute would produce invalid XML because the XMLNS namespace is reserved and cannot be applied as an element's namespace via XML parsing.
                 if (require_well_formed == RequireWellFormed::Yes && attribute->value() == Namespace::XMLNS)
-                    return WebIDL::InvalidStateError::create(global_object, "The XMLNS namespace cannot be used as an element's namespace");
+                    return WebIDL::InvalidStateError::create(realm, "The XMLNS namespace cannot be used as an element's namespace");
 
                 // 3. If the require well-formed flag is set (its value is true), and the value of attr's value attribute is the empty string,
                 //    then throw an exception; namespace prefix declarations cannot be used to undeclare a namespace (use a default namespace declaration instead).
                 if (require_well_formed == RequireWellFormed::Yes && attribute->value().is_empty())
-                    return WebIDL::InvalidStateError::create(global_object, "Attribute's value is empty");
+                    return WebIDL::InvalidStateError::create(realm, "Attribute's value is empty");
 
                 // 4. [If] the attr's prefix matches the string "xmlns", then let candidate prefix be the string "xmlns".
                 if (attribute->prefix() == "xmlns"sv)
@@ -432,12 +432,12 @@ static WebIDL::ExceptionOr<String> serialize_element_attributes(DOM::Element con
         //    or does not match the XML Name production or equals "xmlns" and attribute namespace is null, then throw an exception; the serialization of this attr would not be a well-formed attribute.
         if (require_well_formed == RequireWellFormed::Yes) {
             if (attribute->local_name().view().contains(':'))
-                return WebIDL::InvalidStateError::create(global_object, "Attribute's local name contains a colon");
+                return WebIDL::InvalidStateError::create(realm, "Attribute's local name contains a colon");
 
             // FIXME: Check attribute's local name against the XML Name production.
 
             if (attribute->local_name() == "xmlns"sv && attribute_namespace.is_null())
-                return WebIDL::InvalidStateError::create(global_object, "Attribute's local name is 'xmlns' and the attribute has no namespace");
+                return WebIDL::InvalidStateError::create(realm, "Attribute's local name is 'xmlns' and the attribute has no namespace");
         }
 
         // 9. Append the following strings to result, in the order listed:
@@ -461,13 +461,13 @@ static WebIDL::ExceptionOr<String> serialize_element_attributes(DOM::Element con
 // https://w3c.github.io/DOM-Parsing/#xml-serializing-an-element-node
 static WebIDL::ExceptionOr<String> serialize_element(DOM::Element const& element, Optional<FlyString>& namespace_, HashMap<FlyString, Vector<String>>& namespace_prefix_map, u64& prefix_index, RequireWellFormed require_well_formed)
 {
-    auto& global_object = element.global_object();
+    auto& realm = element.realm();
 
     // 1. If the require well-formed flag is set (its value is true), and this node's localName attribute contains the character ":" (U+003A COLON) or does not match the XML Name production,
     //    then throw an exception; the serialization of this node would not be a well-formed element.
     if (require_well_formed == RequireWellFormed::Yes) {
         if (element.local_name().view().contains(':'))
-            return WebIDL::InvalidStateError::create(global_object, "Element's local name contains a colon");
+            return WebIDL::InvalidStateError::create(realm, "Element's local name contains a colon");
 
         // FIXME: Check element's local name against the XML Char production.
     }
@@ -539,7 +539,7 @@ static WebIDL::ExceptionOr<String> serialize_element(DOM::Element const& element
         if (prefix == "xmlns"sv) {
             // 1. If the require well-formed flag is set, then throw an error. An Element with prefix "xmlns" will not legally round-trip in a conforming XML parser.
             if (require_well_formed == RequireWellFormed::Yes)
-                return WebIDL::InvalidStateError::create(global_object, "Elements prefix is 'xmlns'");
+                return WebIDL::InvalidStateError::create(realm, "Elements prefix is 'xmlns'");
 
             // 2. Let candidate prefix be the value of prefix.
             candidate_prefix = prefix;
@@ -706,7 +706,7 @@ static WebIDL::ExceptionOr<String> serialize_document(DOM::Document const& docum
     // If the require well-formed flag is set (its value is true), and this node has no documentElement (the documentElement attribute's value is null),
     // then throw an exception; the serialization of this node would not be a well-formed document.
     if (require_well_formed == RequireWellFormed::Yes && !document.document_element())
-        return WebIDL::InvalidStateError::create(document.global_object(), "Document has no document element");
+        return WebIDL::InvalidStateError::create(document.realm(), "Document has no document element");
 
     // Otherwise, run the following steps:
     // 1. Let serialized document be an empty string.
@@ -730,10 +730,10 @@ static WebIDL::ExceptionOr<String> serialize_comment(DOM::Comment const& comment
         // FIXME: Check comment's data against the XML Char production.
 
         if (comment.data().contains("--"sv))
-            return WebIDL::InvalidStateError::create(comment.global_object(), "Comment data contains two adjacent hyphens");
+            return WebIDL::InvalidStateError::create(comment.realm(), "Comment data contains two adjacent hyphens");
 
         if (comment.data().ends_with('-'))
-            return WebIDL::InvalidStateError::create(comment.global_object(), "Comment data ends with a hyphen");
+            return WebIDL::InvalidStateError::create(comment.realm(), "Comment data ends with a hyphen");
     }
 
     // Otherwise, return the concatenation of "<!--", node's data, and "-->".
@@ -788,7 +788,7 @@ static WebIDL::ExceptionOr<String> serialize_document_type(DOM::DocumentType con
         //    both a """ (U+0022 QUOTATION MARK) and a "'" (U+0027 APOSTROPHE), then throw an exception; the serialization of this node would not be a well-formed document type declaration.
         // FIXME: Check systemId against the XML Char production.
         if (document_type.system_id().contains('"') && document_type.system_id().contains('\''))
-            return WebIDL::InvalidStateError::create(document_type.global_object(), "Document type system ID contains both a quotation mark and an apostrophe");
+            return WebIDL::InvalidStateError::create(document_type.realm(), "Document type system ID contains both a quotation mark and an apostrophe");
     }
 
     // 3. Let markup be an empty string.
@@ -850,16 +850,16 @@ static WebIDL::ExceptionOr<String> serialize_processing_instruction(DOM::Process
         // 1. If the require well-formed flag is set (its value is true), and node's target contains a ":" (U+003A COLON) character
         //    or is an ASCII case-insensitive match for the string "xml", then throw an exception; the serialization of this node's target would not be well-formed.
         if (processing_instruction.target().contains(':'))
-            return WebIDL::InvalidStateError::create(processing_instruction.global_object(), "Processing instruction target contains a colon");
+            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction target contains a colon");
 
         if (processing_instruction.target().equals_ignoring_case("xml"sv))
-            return WebIDL::InvalidStateError::create(processing_instruction.global_object(), "Processing instruction target is equal to 'xml'");
+            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction target is equal to 'xml'");
 
         // 2. If the require well-formed flag is set (its value is true), and node's data contains characters that are not matched by the XML Char production or contains
         //    the string "?>" (U+003F QUESTION MARK, U+003E GREATER-THAN SIGN), then throw an exception; the serialization of this node's data would not be well-formed.
         // FIXME: Check data against the XML Char production.
         if (processing_instruction.data().contains("?>"sv))
-            return WebIDL::InvalidStateError::create(processing_instruction.global_object(), "Processing instruction data contains a terminator");
+            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction data contains a terminator");
     }
 
     // 3. Let markup be the concatenation of the following, in the order listed:

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.h
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.h
@@ -14,14 +14,14 @@ class XMLSerializer final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(XMLSerializer, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<XMLSerializer> create_with_global_object(HTML::Window&);
+    static JS::NonnullGCPtr<XMLSerializer> construct_impl(JS::Realm&);
 
     virtual ~XMLSerializer() override;
 
     WebIDL::ExceptionOr<String> serialize_to_string(JS::NonnullGCPtr<DOM::Node> root);
 
 private:
-    explicit XMLSerializer(HTML::Window&);
+    explicit XMLSerializer(JS::Realm&);
 };
 
 enum class RequireWellFormed {

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -6,30 +6,30 @@
 
 #include <AK/FlyString.h>
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Encoding/TextDecoder.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 
 namespace Web::Encoding {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<TextDecoder>> TextDecoder::create_with_global_object(HTML::Window& window, FlyString encoding)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<TextDecoder>> TextDecoder::construct_impl(JS::Realm& realm, FlyString encoding)
 {
     auto decoder = TextCodec::decoder_for(encoding);
     if (!decoder)
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, String::formatted("Invalid encoding {}", encoding) };
 
-    return JS::NonnullGCPtr(*window.heap().allocate<TextDecoder>(window.realm(), window, *decoder, move(encoding), false, false));
+    return JS::NonnullGCPtr(*realm.heap().allocate<TextDecoder>(realm, realm, *decoder, move(encoding), false, false));
 }
 
 // https://encoding.spec.whatwg.org/#dom-textdecoder
-TextDecoder::TextDecoder(HTML::Window& window, TextCodec::Decoder& decoder, FlyString encoding, bool fatal, bool ignore_bom)
-    : PlatformObject(window.realm())
+TextDecoder::TextDecoder(JS::Realm& realm, TextCodec::Decoder& decoder, FlyString encoding, bool fatal, bool ignore_bom)
+    : PlatformObject(realm)
     , m_decoder(decoder)
     , m_encoding(move(encoding))
     , m_fatal(fatal)
     , m_ignore_bom(ignore_bom)
 {
-    set_prototype(&window.cached_web_prototype("TextDecoder"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "TextDecoder"));
 }
 
 TextDecoder::~TextDecoder() = default;
@@ -41,7 +41,7 @@ WebIDL::ExceptionOr<String> TextDecoder::decode(JS::Handle<JS::Object> const& in
 
     auto data_buffer_or_error = WebIDL::get_buffer_source_copy(*input.cell());
     if (data_buffer_or_error.is_error())
-        return WebIDL::OperationError::create(global_object(), "Failed to copy bytes from ArrayBuffer");
+        return WebIDL::OperationError::create(realm(), "Failed to copy bytes from ArrayBuffer");
     auto& data_buffer = data_buffer_or_error.value();
     return m_decoder.to_utf8({ data_buffer.data(), data_buffer.size() });
 }

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.h
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.h
@@ -21,7 +21,7 @@ class TextDecoder : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(TextDecoder, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<TextDecoder>> create_with_global_object(HTML::Window&, FlyString encoding);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<TextDecoder>> construct_impl(JS::Realm&, FlyString encoding);
 
     virtual ~TextDecoder() override;
 
@@ -33,7 +33,7 @@ public:
 
 private:
     // https://encoding.spec.whatwg.org/#dom-textdecoder
-    TextDecoder(HTML::Window&, TextCodec::Decoder&, FlyString encoding, bool fatal, bool ignore_bom);
+    TextDecoder(JS::Realm&, TextCodec::Decoder&, FlyString encoding, bool fatal, bool ignore_bom);
 
     TextCodec::Decoder& m_decoder;
     FlyString m_encoding;

--- a/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
@@ -6,20 +6,20 @@
 
 #include <AK/FlyString.h>
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Encoding/TextEncoder.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Encoding {
 
-JS::NonnullGCPtr<TextEncoder> TextEncoder::create_with_global_object(HTML::Window& window)
+JS::NonnullGCPtr<TextEncoder> TextEncoder::construct_impl(JS::Realm& realm)
 {
-    return *window.heap().allocate<TextEncoder>(window.realm(), window);
+    return *realm.heap().allocate<TextEncoder>(realm, realm);
 }
 
-TextEncoder::TextEncoder(HTML::Window& window)
-    : PlatformObject(window.realm())
+TextEncoder::TextEncoder(JS::Realm& realm)
+    : PlatformObject(realm)
 {
-    set_prototype(&window.cached_web_prototype("TextEncoder"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "TextEncoder"));
 }
 
 TextEncoder::~TextEncoder() = default;

--- a/Userland/Libraries/LibWeb/Encoding/TextEncoder.h
+++ b/Userland/Libraries/LibWeb/Encoding/TextEncoder.h
@@ -20,7 +20,7 @@ class TextEncoder final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(TextEncoder, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<TextEncoder> create_with_global_object(HTML::Window&);
+    static JS::NonnullGCPtr<TextEncoder> construct_impl(JS::Realm&);
 
     virtual ~TextEncoder() override;
 
@@ -30,7 +30,7 @@ public:
 
 protected:
     // https://encoding.spec.whatwg.org/#dom-textencoder
-    explicit TextEncoder(HTML::Window&);
+    explicit TextEncoder(JS::Realm&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Body.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Body.cpp
@@ -11,7 +11,6 @@
 #include <LibWeb/Fetch/Body.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/FileAPI/Blob.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Infra/JSON.h>
 #include <LibWeb/MimeSniff/MimeType.h>
 #include <LibWeb/Streams/ReadableStream.h>
@@ -99,7 +98,6 @@ JS::NonnullGCPtr<JS::Promise> BodyMixin::text() const
 WebIDL::ExceptionOr<JS::Value> package_data(JS::Realm& realm, ByteBuffer bytes, PackageDataType type, Optional<MimeSniff::MimeType> const& mime_type)
 {
     auto& vm = realm.vm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
 
     switch (type) {
     case PackageDataType::ArrayBuffer:
@@ -109,7 +107,7 @@ WebIDL::ExceptionOr<JS::Value> package_data(JS::Realm& realm, ByteBuffer bytes, 
         // Return a Blob whose contents are bytes and type attribute is mimeType.
         // NOTE: If extracting the mime type returns failure, other browsers set it to an empty string - not sure if that's spec'd.
         auto mime_type_string = mime_type.has_value() ? mime_type->serialized() : String::empty();
-        return FileAPI::Blob::create(window, move(bytes), move(mime_type_string));
+        return FileAPI::Blob::create(realm, move(bytes), move(mime_type_string));
     }
     case PackageDataType::FormData:
         // If mimeType’s essence is "multipart/form-data", then:

--- a/Userland/Libraries/LibWeb/Fetch/Body.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Body.cpp
@@ -161,7 +161,7 @@ JS::NonnullGCPtr<JS::Promise> consume_body(JS::Realm& realm, BodyMixin const& ob
     // 4. Let steps be to return the result of package data with the first argument given, type, and object’s MIME type.
     auto steps = [&realm, &object, type](JS::Value value) -> WebIDL::ExceptionOr<JS::Value> {
         VERIFY(value.is_string());
-        auto bytes = TRY_OR_RETURN_OOM(realm.global_object(), ByteBuffer::copy(value.as_string().string().bytes()));
+        auto bytes = TRY_OR_RETURN_OOM(realm, ByteBuffer::copy(value.as_string().string().bytes()));
         return package_data(realm, move(bytes), type, object.mime_type_impl());
     };
 

--- a/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
@@ -7,7 +7,6 @@
 
 #include <LibWeb/Fetch/BodyInit.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/URL/URLSearchParams.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -22,7 +21,7 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
     if (auto const* handle = object.get_pointer<JS::Handle<Streams::ReadableStream>>()) {
         stream = const_cast<Streams::ReadableStream*>(handle->cell());
     } else {
-        stream = realm.heap().allocate<Streams::ReadableStream>(realm, verify_cast<HTML::Window>(realm.global_object()));
+        stream = realm.heap().allocate<Streams::ReadableStream>(realm, realm);
     }
 
     // FIXME: 2. Let action be null.

--- a/Userland/Libraries/LibWeb/Fetch/Headers.h
+++ b/Userland/Libraries/LibWeb/Fetch/Headers.h
@@ -31,7 +31,7 @@ public:
         None,
     };
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Headers>> create_with_global_object(HTML::Window& window, Optional<HeadersInit> const& init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Headers>> construct_impl(JS::Realm& realm, Optional<HeadersInit> const& init);
 
     virtual ~Headers() override;
 
@@ -58,7 +58,7 @@ public:
 private:
     friend class HeadersIterator;
 
-    explicit Headers(HTML::Window&);
+    explicit Headers(JS::Realm&);
 
     void remove_privileged_no_cors_headers();
 

--- a/Userland/Libraries/LibWeb/Fetch/HeadersIterator.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/HeadersIterator.cpp
@@ -7,8 +7,8 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/IteratorOperations.h>
 #include <LibWeb/Bindings/HeadersIteratorPrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Fetch/HeadersIterator.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Fetch {
 
@@ -22,7 +22,7 @@ HeadersIterator::HeadersIterator(Headers const& headers, JS::Object::PropertyKin
     , m_headers(headers)
     , m_iteration_kind(iteration_kind)
 {
-    set_prototype(&headers.global_object().ensure_web_prototype<Bindings::HeadersIteratorPrototype>("HeadersIterator"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::HeadersIteratorPrototype>(headers.realm(), "HeadersIterator"));
 }
 
 HeadersIterator::~HeadersIterator() = default;

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -30,11 +30,10 @@ WebIDL::ExceptionOr<Body> Body::clone() const
 
     auto& vm = Bindings::main_thread_vm();
     auto& realm = *vm.current_realm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
 
     // FIXME: 1. Let « out1, out2 » be the result of teeing body’s stream.
     // FIXME: 2. Set body’s stream to out1.
-    auto* out2 = vm.heap().allocate<Streams::ReadableStream>(realm, window);
+    auto* out2 = vm.heap().allocate<Streams::ReadableStream>(realm, realm);
 
     // 3. Return a body whose stream is out2 and other members are copied from body.
     return Body { JS::make_handle(out2), m_source, m_length };

--- a/Userland/Libraries/LibWeb/Fetch/Request.h
+++ b/Userland/Libraries/LibWeb/Fetch/Request.h
@@ -64,7 +64,7 @@ class Request final
 
 public:
     static JS::NonnullGCPtr<Request> create(NonnullOwnPtr<Infrastructure::Request>, Headers::Guard, JS::Realm&);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> create_with_global_object(HTML::Window&, RequestInfo const& input, RequestInit const& init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> construct_impl(JS::Realm&, RequestInfo const& input, RequestInit const& init = {});
 
     virtual ~Request() override;
 

--- a/Userland/Libraries/LibWeb/Fetch/Response.h
+++ b/Userland/Libraries/LibWeb/Fetch/Response.h
@@ -31,7 +31,7 @@ class Response final
 
 public:
     static JS::NonnullGCPtr<Response> create(NonnullOwnPtr<Infrastructure::Response>, Headers::Guard, JS::Realm&);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> create_with_global_object(HTML::Window&, Optional<BodyInit> const& body = {}, ResponseInit const& init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> construct_impl(JS::Realm&, Optional<BodyInit> const& body = {}, ResponseInit const& init = {});
 
     virtual ~Response() override;
 

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -8,15 +8,15 @@
 #include <AK/StdLibExtras.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibWeb/Bindings/BlobPrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/FileAPI/Blob.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 
 namespace Web::FileAPI {
 
-JS::NonnullGCPtr<Blob> Blob::create(HTML::Window& window, ByteBuffer byte_buffer, String type)
+JS::NonnullGCPtr<Blob> Blob::create(JS::Realm& realm, ByteBuffer byte_buffer, String type)
 {
-    return JS::NonnullGCPtr(*window.heap().allocate<Blob>(window.realm(), window, move(byte_buffer), move(type)));
+    return JS::NonnullGCPtr(*realm.heap().allocate<Blob>(realm, realm, move(byte_buffer), move(type)));
 }
 
 // https://w3c.github.io/FileAPI/#convert-line-endings-to-native
@@ -111,40 +111,40 @@ bool is_basic_latin(StringView view)
     return true;
 }
 
-Blob::Blob(HTML::Window& window)
-    : PlatformObject(window.realm())
+Blob::Blob(JS::Realm& realm)
+    : PlatformObject(realm)
 {
-    set_prototype(&window.cached_web_prototype("Blob"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "Blob"));
 }
 
-Blob::Blob(HTML::Window& window, ByteBuffer byte_buffer, String type)
-    : PlatformObject(window.realm())
+Blob::Blob(JS::Realm& realm, ByteBuffer byte_buffer, String type)
+    : PlatformObject(realm)
     , m_byte_buffer(move(byte_buffer))
     , m_type(move(type))
 {
-    set_prototype(&window.cached_web_prototype("Blob"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "Blob"));
 }
 
-Blob::Blob(HTML::Window& window, ByteBuffer byte_buffer)
-    : PlatformObject(window.realm())
+Blob::Blob(JS::Realm& realm, ByteBuffer byte_buffer)
+    : PlatformObject(realm)
     , m_byte_buffer(move(byte_buffer))
 {
-    set_prototype(&window.cached_web_prototype("Blob"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "Blob"));
 }
 
 Blob::~Blob() = default;
 
 // https://w3c.github.io/FileAPI/#ref-for-dom-blob-blob
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::create(HTML::Window& window, Optional<Vector<BlobPart>> const& blob_parts, Optional<BlobPropertyBag> const& options)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::create(JS::Realm& realm, Optional<Vector<BlobPart>> const& blob_parts, Optional<BlobPropertyBag> const& options)
 {
     // 1. If invoked with zero parameters, return a new Blob object consisting of 0 bytes, with size set to 0, and with type set to the empty string.
     if (!blob_parts.has_value() && !options.has_value())
-        return JS::NonnullGCPtr(*window.heap().allocate<Blob>(window.realm(), window));
+        return JS::NonnullGCPtr(*realm.heap().allocate<Blob>(realm, realm));
 
     ByteBuffer byte_buffer {};
     // 2. Let bytes be the result of processing blob parts given blobParts and options.
     if (blob_parts.has_value()) {
-        byte_buffer = TRY_OR_RETURN_OOM(window, process_blob_parts(blob_parts.value(), options));
+        byte_buffer = TRY_OR_RETURN_OOM(realm, process_blob_parts(blob_parts.value(), options));
     }
 
     auto type = String::empty();
@@ -164,12 +164,12 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::create(HTML::Window& window, O
     }
 
     // 4. Return a Blob object referring to bytes as its associated byte sequence, with its size set to the length of bytes, and its type set to the value of t from the substeps above.
-    return JS::NonnullGCPtr(*window.heap().allocate<Blob>(window.realm(), window, move(byte_buffer), move(type)));
+    return JS::NonnullGCPtr(*realm.heap().allocate<Blob>(realm, realm, move(byte_buffer), move(type)));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::create_with_global_object(HTML::Window& window, Optional<Vector<BlobPart>> const& blob_parts, Optional<BlobPropertyBag> const& options)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::construct_impl(JS::Realm& realm, Optional<Vector<BlobPart>> const& blob_parts, Optional<BlobPropertyBag> const& options)
 {
-    return Blob::create(window, blob_parts, options);
+    return Blob::create(realm, blob_parts, options);
 }
 
 // https://w3c.github.io/FileAPI/#dfn-slice
@@ -232,8 +232,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::slice(Optional<i64> start, Opt
     // a. S refers to span consecutive bytes from this, beginning with the byte at byte-order position relativeStart.
     // b. S.size = span.
     // c. S.type = relativeContentType.
-    auto byte_buffer = TRY_OR_RETURN_OOM(global_object(), m_byte_buffer.slice(relative_start, span));
-    return JS::NonnullGCPtr(*heap().allocate<Blob>(realm(), global_object(), move(byte_buffer), move(relative_content_type)));
+    auto byte_buffer = TRY_OR_RETURN_OOM(realm(), m_byte_buffer.slice(relative_start, span));
+    return JS::NonnullGCPtr(*heap().allocate<Blob>(realm(), realm(), move(byte_buffer), move(relative_content_type)));
 }
 
 // https://w3c.github.io/FileAPI/#dom-blob-text

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -33,9 +33,9 @@ class Blob : public Bindings::PlatformObject {
 public:
     virtual ~Blob() override;
 
-    static JS::NonnullGCPtr<Blob> create(HTML::Window&, ByteBuffer, String type);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> create(HTML::Window&, Optional<Vector<BlobPart>> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> create_with_global_object(HTML::Window&, Optional<Vector<BlobPart>> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
+    static JS::NonnullGCPtr<Blob> create(JS::Realm&, ByteBuffer, String type);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> create(JS::Realm&, Optional<Vector<BlobPart>> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> construct_impl(JS::Realm&, Optional<Vector<BlobPart>> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
 
     // https://w3c.github.io/FileAPI/#dfn-size
     u64 size() const { return m_byte_buffer.size(); }
@@ -50,11 +50,11 @@ public:
     ReadonlyBytes bytes() const { return m_byte_buffer.bytes(); }
 
 protected:
-    Blob(HTML::Window&, ByteBuffer, String type);
-    Blob(HTML::Window&, ByteBuffer);
+    Blob(JS::Realm&, ByteBuffer, String type);
+    Blob(JS::Realm&, ByteBuffer);
 
 private:
-    explicit Blob(HTML::Window&);
+    explicit Blob(JS::Realm&);
 
     ByteBuffer m_byte_buffer {};
     String m_type {};

--- a/Userland/Libraries/LibWeb/FileAPI/File.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/File.cpp
@@ -4,26 +4,27 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Time.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/FileAPI/File.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::FileAPI {
 
-File::File(HTML::Window& window, ByteBuffer byte_buffer, String file_name, String type, i64 last_modified)
-    : Blob(window, move(byte_buffer), move(type))
+File::File(JS::Realm& realm, ByteBuffer byte_buffer, String file_name, String type, i64 last_modified)
+    : Blob(realm, move(byte_buffer), move(type))
     , m_name(move(file_name))
     , m_last_modified(last_modified)
 {
-    set_prototype(&window.cached_web_prototype("File"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "File"));
 }
 
 File::~File() = default;
 
 // https://w3c.github.io/FileAPI/#ref-for-dom-file-file
-WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> File::create(HTML::Window& window, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> File::create(JS::Realm& realm, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options)
 {
     // 1. Let bytes be the result of processing blob parts given fileBits and options.
-    auto bytes = TRY_OR_RETURN_OOM(window, process_blob_parts(file_bits, static_cast<Optional<BlobPropertyBag> const&>(*options)));
+    auto bytes = TRY_OR_RETURN_OOM(realm, process_blob_parts(file_bits, static_cast<Optional<BlobPropertyBag> const&>(*options)));
 
     // 2. Let n be the fileName argument to the constructor.
     //    NOTE: Underlying OS filesystems use differing conventions for file name; with constructed files, mandating UTF-16 lessens ambiquity when file names are converted to byte sequences.
@@ -57,12 +58,12 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> File::create(HTML::Window& window, V
     //    4. F.name is set to n.
     //    5. F.type is set to t.
     //    6. F.lastModified is set to d.
-    return JS::NonnullGCPtr(*window.heap().allocate<File>(window.realm(), window, move(bytes), move(name), move(type), last_modified));
+    return JS::NonnullGCPtr(*realm.heap().allocate<File>(realm, realm, move(bytes), move(name), move(type), last_modified));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> File::create_with_global_object(HTML::Window& window, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> File::construct_impl(JS::Realm& realm, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options)
 {
-    return create(window, file_bits, file_name, options);
+    return create(realm, file_bits, file_name, options);
 }
 
 }

--- a/Userland/Libraries/LibWeb/FileAPI/File.h
+++ b/Userland/Libraries/LibWeb/FileAPI/File.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Time.h>
 #include <LibWeb/FileAPI/Blob.h>
 
 namespace Web::FileAPI {
@@ -19,8 +18,8 @@ class File : public Blob {
     WEB_PLATFORM_OBJECT(File, Blob);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> create(HTML::Window&, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> create_with_global_object(HTML::Window&, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> create(JS::Realm&, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> construct_impl(JS::Realm&, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options = {});
 
     virtual ~File() override;
 
@@ -30,7 +29,7 @@ public:
     i64 last_modified() const { return m_last_modified; }
 
 private:
-    File(HTML::Window&, ByteBuffer, String file_name, String type, i64 last_modified);
+    File(JS::Realm&, ByteBuffer, String file_name, String type, i64 last_modified);
 
     String m_name;
     i64 m_last_modified { 0 };

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -473,6 +473,7 @@ class URLSearchParamsIterator;
 }
 
 namespace Web::Bindings {
+class Intrinsics;
 class LocationObject;
 class OptionConstructor;
 class RangePrototype;

--- a/Userland/Libraries/LibWeb/Geometry/DOMPoint.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPoint.cpp
@@ -6,7 +6,6 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMPoint.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Geometry {
 

--- a/Userland/Libraries/LibWeb/Geometry/DOMPoint.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPoint.cpp
@@ -15,11 +15,6 @@ JS::NonnullGCPtr<DOMPoint> DOMPoint::construct_impl(JS::Realm& realm, double x, 
     return *realm.heap().allocate<DOMPoint>(realm, realm, x, y, z, w);
 }
 
-JS::NonnullGCPtr<DOMPoint> DOMPoint::create_with_global_object(HTML::Window& window, double x, double y, double z, double w)
-{
-    return construct_impl(window.realm(), x, y, z, w);
-}
-
 DOMPoint::DOMPoint(JS::Realm& realm, double x, double y, double z, double w)
     : DOMPointReadOnly(realm, x, y, z, w)
 {

--- a/Userland/Libraries/LibWeb/Geometry/DOMPoint.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPoint.cpp
@@ -4,20 +4,26 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMPoint.h>
 #include <LibWeb/HTML/Window.h>
 
 namespace Web::Geometry {
 
-JS::NonnullGCPtr<DOMPoint> DOMPoint::create_with_global_object(HTML::Window& window, double x, double y, double z, double w)
+JS::NonnullGCPtr<DOMPoint> DOMPoint::construct_impl(JS::Realm& realm, double x, double y, double z, double w)
 {
-    return *window.heap().allocate<DOMPoint>(window.realm(), window, x, y, z, w);
+    return *realm.heap().allocate<DOMPoint>(realm, realm, x, y, z, w);
 }
 
-DOMPoint::DOMPoint(HTML::Window& window, double x, double y, double z, double w)
-    : DOMPointReadOnly(window, x, y, z, w)
+JS::NonnullGCPtr<DOMPoint> DOMPoint::create_with_global_object(HTML::Window& window, double x, double y, double z, double w)
 {
-    set_prototype(&window.cached_web_prototype("DOMPoint"));
+    return construct_impl(window.realm(), x, y, z, w);
+}
+
+DOMPoint::DOMPoint(JS::Realm& realm, double x, double y, double z, double w)
+    : DOMPointReadOnly(realm, x, y, z, w)
+{
+    set_prototype(&Bindings::cached_web_prototype(realm, "DOMPoint"));
 }
 
 DOMPoint::~DOMPoint() = default;

--- a/Userland/Libraries/LibWeb/Geometry/DOMPoint.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPoint.h
@@ -16,7 +16,6 @@ class DOMPoint final : public DOMPointReadOnly {
 
 public:
     static JS::NonnullGCPtr<DOMPoint> construct_impl(JS::Realm&, double x = 0, double y = 0, double z = 0, double w = 0);
-    static JS::NonnullGCPtr<DOMPoint> create_with_global_object(HTML::Window&, double x = 0, double y = 0, double z = 0, double w = 0);
 
     virtual ~DOMPoint() override;
 

--- a/Userland/Libraries/LibWeb/Geometry/DOMPoint.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPoint.h
@@ -15,6 +15,7 @@ class DOMPoint final : public DOMPointReadOnly {
     WEB_PLATFORM_OBJECT(DOMPoint, DOMPointReadOnly);
 
 public:
+    static JS::NonnullGCPtr<DOMPoint> construct_impl(JS::Realm&, double x = 0, double y = 0, double z = 0, double w = 0);
     static JS::NonnullGCPtr<DOMPoint> create_with_global_object(HTML::Window&, double x = 0, double y = 0, double z = 0, double w = 0);
 
     virtual ~DOMPoint() override;
@@ -30,7 +31,7 @@ public:
     void set_w(double w) { m_w = w; }
 
 private:
-    DOMPoint(HTML::Window&, double x, double y, double z, double w);
+    DOMPoint(JS::Realm&, double x, double y, double z, double w);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.cpp
@@ -4,24 +4,24 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMPointReadOnly.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Geometry {
 
-JS::NonnullGCPtr<DOMPointReadOnly> DOMPointReadOnly::create_with_global_object(HTML::Window& window, double x, double y, double z, double w)
+JS::NonnullGCPtr<DOMPointReadOnly> DOMPointReadOnly::construct_impl(JS::Realm& realm, double x, double y, double z, double w)
 {
-    return *window.heap().allocate<DOMPointReadOnly>(window.realm(), window, x, y, z, w);
+    return *realm.heap().allocate<DOMPointReadOnly>(realm, realm, x, y, z, w);
 }
 
-DOMPointReadOnly::DOMPointReadOnly(HTML::Window& window, double x, double y, double z, double w)
-    : PlatformObject(window.realm())
+DOMPointReadOnly::DOMPointReadOnly(JS::Realm& realm, double x, double y, double z, double w)
+    : PlatformObject(realm)
     , m_x(x)
     , m_y(y)
     , m_z(z)
     , m_w(w)
 {
-    set_prototype(&window.cached_web_prototype("DOMPointReadOnly"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "DOMPointReadOnly"));
 }
 
 DOMPointReadOnly::~DOMPointReadOnly() = default;

--- a/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.h
@@ -17,7 +17,7 @@ class DOMPointReadOnly : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(DOMPointReadOnly, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<DOMPointReadOnly> create_with_global_object(HTML::Window&, double x = 0, double y = 0, double z = 0, double w = 0);
+    static JS::NonnullGCPtr<DOMPointReadOnly> construct_impl(JS::Realm&, double x = 0, double y = 0, double z = 0, double w = 0);
 
     virtual ~DOMPointReadOnly() override;
 
@@ -27,7 +27,7 @@ public:
     double w() const { return m_w; }
 
 protected:
-    DOMPointReadOnly(HTML::Window&, double x, double y, double z, double w);
+    DOMPointReadOnly(JS::Realm&, double x, double y, double z, double w);
 
     double m_x;
     double m_y;

--- a/Userland/Libraries/LibWeb/Geometry/DOMRect.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRect.cpp
@@ -4,25 +4,25 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMRect.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Geometry {
 
-JS::NonnullGCPtr<DOMRect> DOMRect::create_with_global_object(HTML::Window& window, double x, double y, double width, double height)
+JS::NonnullGCPtr<DOMRect> DOMRect::construct_impl(JS::Realm& realm, double x, double y, double width, double height)
 {
-    return *window.heap().allocate<DOMRect>(window.realm(), window, x, y, width, height);
+    return *realm.heap().allocate<DOMRect>(realm, realm, x, y, width, height);
 }
 
-JS::NonnullGCPtr<DOMRect> DOMRect::create(HTML::Window& window, Gfx::FloatRect const& rect)
+JS::NonnullGCPtr<DOMRect> DOMRect::create(JS::Realm& realm, Gfx::FloatRect const& rect)
 {
-    return create_with_global_object(window, rect.x(), rect.y(), rect.width(), rect.height());
+    return construct_impl(realm, rect.x(), rect.y(), rect.width(), rect.height());
 }
 
-DOMRect::DOMRect(HTML::Window& window, double x, double y, double width, double height)
-    : DOMRectReadOnly(window, x, y, width, height)
+DOMRect::DOMRect(JS::Realm& realm, double x, double y, double width, double height)
+    : DOMRectReadOnly(realm, x, y, width, height)
 {
-    set_prototype(&window.cached_web_prototype("DOMRect"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "DOMRect"));
 }
 
 DOMRect::~DOMRect() = default;

--- a/Userland/Libraries/LibWeb/Geometry/DOMRect.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRect.h
@@ -15,8 +15,8 @@ class DOMRect final : public DOMRectReadOnly {
     WEB_PLATFORM_OBJECT(DOMRect, DOMRectReadOnly);
 
 public:
-    static JS::NonnullGCPtr<DOMRect> create_with_global_object(HTML::Window&, double x = 0, double y = 0, double width = 0, double height = 0);
-    static JS::NonnullGCPtr<DOMRect> create(HTML::Window&, Gfx::FloatRect const&);
+    static JS::NonnullGCPtr<DOMRect> construct_impl(JS::Realm&, double x = 0, double y = 0, double width = 0, double height = 0);
+    static JS::NonnullGCPtr<DOMRect> create(JS::Realm&, Gfx::FloatRect const&);
 
     virtual ~DOMRect() override;
 
@@ -31,7 +31,7 @@ public:
     void set_height(double height) { m_rect.set_height(height); }
 
 private:
-    DOMRect(HTML::Window&, double x, double y, double width, double height);
+    DOMRect(JS::Realm&, double x, double y, double width, double height);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectList.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectList.cpp
@@ -5,22 +5,22 @@
  */
 
 #include <LibJS/Heap/Handle.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMRect.h>
 #include <LibWeb/Geometry/DOMRectList.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Geometry {
 
-JS::NonnullGCPtr<DOMRectList> DOMRectList::create(HTML::Window& window, Vector<JS::Handle<DOMRect>> rect_handles)
+JS::NonnullGCPtr<DOMRectList> DOMRectList::create(JS::Realm& realm, Vector<JS::Handle<DOMRect>> rect_handles)
 {
     Vector<JS::NonnullGCPtr<DOMRect>> rects;
     for (auto& rect : rect_handles)
         rects.append(*rect);
-    return *window.heap().allocate<DOMRectList>(window.realm(), window, move(rects));
+    return *realm.heap().allocate<DOMRectList>(realm, realm, move(rects));
 }
 
-DOMRectList::DOMRectList(HTML::Window& window, Vector<JS::NonnullGCPtr<DOMRect>> rects)
-    : Bindings::LegacyPlatformObject(window.cached_web_prototype("DOMRectList"))
+DOMRectList::DOMRectList(JS::Realm& realm, Vector<JS::NonnullGCPtr<DOMRect>> rects)
+    : Bindings::LegacyPlatformObject(Bindings::cached_web_prototype(realm, "DOMRectList"))
     , m_rects(move(rects))
 {
 }

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectList.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectList.h
@@ -17,7 +17,7 @@ class DOMRectList final : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(DOMRectList, Bindings::LegacyPlatformObject);
 
 public:
-    static JS::NonnullGCPtr<DOMRectList> create(HTML::Window&, Vector<JS::Handle<DOMRect>>);
+    static JS::NonnullGCPtr<DOMRectList> create(JS::Realm&, Vector<JS::Handle<DOMRect>>);
 
     virtual ~DOMRectList() override;
 
@@ -28,7 +28,7 @@ public:
     virtual JS::Value item_value(size_t index) const override;
 
 private:
-    DOMRectList(HTML::Window&, Vector<JS::NonnullGCPtr<DOMRect>>);
+    DOMRectList(JS::Realm&, Vector<JS::NonnullGCPtr<DOMRect>>);
 
     Vector<JS::NonnullGCPtr<DOMRect>> m_rects;
 };

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.cpp
@@ -4,21 +4,21 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMRectReadOnly.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Geometry {
 
-JS::NonnullGCPtr<DOMRectReadOnly> DOMRectReadOnly::create_with_global_object(HTML::Window& window, double x, double y, double width, double height)
+JS::NonnullGCPtr<DOMRectReadOnly> DOMRectReadOnly::construct_impl(JS::Realm& realm, double x, double y, double width, double height)
 {
-    return *window.heap().allocate<DOMRectReadOnly>(window.realm(), window, x, y, width, height);
+    return *realm.heap().allocate<DOMRectReadOnly>(realm, realm, x, y, width, height);
 }
 
-DOMRectReadOnly::DOMRectReadOnly(HTML::Window& window, double x, double y, double width, double height)
-    : PlatformObject(window.realm())
+DOMRectReadOnly::DOMRectReadOnly(JS::Realm& realm, double x, double y, double width, double height)
+    : PlatformObject(realm)
     , m_rect(x, y, width, height)
 {
-    set_prototype(&window.cached_web_prototype("DOMRectReadOnly"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "DOMRectReadOnly"));
 }
 
 DOMRectReadOnly::~DOMRectReadOnly() = default;

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.h
@@ -17,7 +17,7 @@ class DOMRectReadOnly : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(DOMRectReadOnly, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<DOMRectReadOnly> create_with_global_object(HTML::Window&, double x = 0, double y = 0, double width = 0, double height = 0);
+    static JS::NonnullGCPtr<DOMRectReadOnly> construct_impl(JS::Realm&, double x = 0, double y = 0, double width = 0, double height = 0);
 
     virtual ~DOMRectReadOnly() override;
 
@@ -32,7 +32,7 @@ public:
     double left() const { return min(x(), x() + width()); }
 
 protected:
-    DOMRectReadOnly(HTML::Window&, double x, double y, double width, double height);
+    DOMRectReadOnly(JS::Realm&, double x, double y, double width, double height);
 
     Gfx::FloatRect m_rect;
 };

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -164,7 +164,7 @@ NonnullRefPtr<BrowsingContext> BrowsingContext::create_a_new_browsing_context(Pa
     auto load_timing_info = DOM::DocumentLoadTimingInfo();
     load_timing_info.navigation_start_time = HighResolutionTime::coarsen_time(
         unsafe_context_creation_time,
-        verify_cast<WindowEnvironmentSettingsObject>(window->realm().host_defined())->cross_origin_isolated_capability() == CanUseCrossOriginIsolatedAPIs::Yes);
+        verify_cast<WindowEnvironmentSettingsObject>(Bindings::host_defined_environment_settings_object(window->realm())).cross_origin_isolated_capability() == CanUseCrossOriginIsolatedAPIs::Yes);
 
     // 13. Let coop be a new cross-origin opener policy.
     auto coop = CrossOriginOpenerPolicy {};

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -187,7 +187,7 @@ NonnullRefPtr<BrowsingContext> BrowsingContext::create_a_new_browsing_context(Pa
     //     load timing info is loadTimingInfo,
     //     FIXME: navigation id is null,
     //     and which is ready for post-load tasks.
-    auto document = DOM::Document::create(*window);
+    auto document = DOM::Document::create(window->realm());
 
     // Non-standard
     document->set_window({}, *window);
@@ -885,7 +885,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::navigate(
         // 1. If exceptionsEnabled is given and is true, then throw a "SecurityError" DOMException.
         if (exceptions_enabled) {
             VERIFY(source_browsing_context.active_document());
-            return WebIDL::SecurityError::create(source_browsing_context.active_document()->global_object(), "Source browsing context not allowed to navigate"sv);
+            return WebIDL::SecurityError::create(source_browsing_context.active_document()->realm(), "Source browsing context not allowed to navigate"sv);
         }
 
         // FIXME: 2. Otherwise, the user agent may instead offer to open resource in a new top-level browsing context
@@ -1184,7 +1184,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::traverse_the_history(size_t entry_ind
             // and the newURL attribute initialized to newURL.
 
             // FIXME: Implement a proper HashChangeEvent class.
-            auto event = DOM::Event::create(verify_cast<HTML::Window>(relevant_global_object(*new_document)), HTML::EventNames::hashchange);
+            auto event = DOM::Event::create(verify_cast<HTML::Window>(relevant_global_object(*new_document)).realm(), HTML::EventNames::hashchange);
             new_document->dispatch_event(event);
         });
     }

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h
@@ -44,20 +44,20 @@ public:
 
     JS::NonnullGCPtr<CanvasGradient> create_radial_gradient(double x0, double y0, double r0, double x1, double y1, double r1)
     {
-        auto& window = static_cast<IncludingClass&>(*this).global_object();
-        return CanvasGradient::create_radial(window, x0, y0, r0, x1, y1, r1);
+        auto& realm = static_cast<IncludingClass&>(*this).realm();
+        return CanvasGradient::create_radial(realm, x0, y0, r0, x1, y1, r1);
     }
 
     JS::NonnullGCPtr<CanvasGradient> create_linear_gradient(double x0, double y0, double x1, double y1)
     {
-        auto& window = static_cast<IncludingClass&>(*this).global_object();
-        return CanvasGradient::create_linear(window, x0, y0, x1, y1);
+        auto& realm = static_cast<IncludingClass&>(*this).realm();
+        return CanvasGradient::create_linear(realm, x0, y0, x1, y1);
     }
 
     JS::NonnullGCPtr<CanvasGradient> create_conic_gradient(double start_angle, double x, double y)
     {
-        auto& window = static_cast<IncludingClass&>(*this).global_object();
-        return CanvasGradient::create_conic(window, start_angle, x, y);
+        auto& realm = static_cast<IncludingClass&>(*this).realm();
+        return CanvasGradient::create_conic(realm, start_angle, x, y);
     }
 
 protected:

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPath.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPath.cpp
@@ -7,7 +7,6 @@
 
 #include <AK/ExtraMathConstants.h>
 #include <LibWeb/HTML/Canvas/CanvasPath.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
@@ -39,17 +38,17 @@ void CanvasPath::bezier_curve_to(double cp1x, double cp1y, double cp2x, double c
 WebIDL::ExceptionOr<void> CanvasPath::arc(float x, float y, float radius, float start_angle, float end_angle, bool counter_clockwise)
 {
     if (radius < 0)
-        return WebIDL::IndexSizeError::create(m_self.global_object(), String::formatted("The radius provided ({}) is negative.", radius));
+        return WebIDL::IndexSizeError::create(m_self.realm(), String::formatted("The radius provided ({}) is negative.", radius));
     return ellipse(x, y, radius, radius, 0, start_angle, end_angle, counter_clockwise);
 }
 
 WebIDL::ExceptionOr<void> CanvasPath::ellipse(float x, float y, float radius_x, float radius_y, float rotation, float start_angle, float end_angle, bool counter_clockwise)
 {
     if (radius_x < 0)
-        return WebIDL::IndexSizeError::create(m_self.global_object(), String::formatted("The major-axis radius provided ({}) is negative.", radius_x));
+        return WebIDL::IndexSizeError::create(m_self.realm(), String::formatted("The major-axis radius provided ({}) is negative.", radius_x));
 
     if (radius_y < 0)
-        return WebIDL::IndexSizeError::create(m_self.global_object(), String::formatted("The minor-axis radius provided ({}) is negative.", radius_y));
+        return WebIDL::IndexSizeError::create(m_self.realm(), String::formatted("The minor-axis radius provided ({}) is negative.", radius_y));
 
     if (constexpr float tau = M_TAU; (!counter_clockwise && (end_angle - start_angle) >= tau)
         || (counter_clockwise && (start_angle - end_angle) >= tau)) {

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
@@ -5,13 +5,13 @@
  */
 
 #include <AK/QuickSort.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/CanvasGradient.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::HTML {
 
-JS::NonnullGCPtr<CanvasGradient> CanvasGradient::create_radial(HTML::Window& window, double x0, double y0, double r0, double x1, double y1, double r1)
+JS::NonnullGCPtr<CanvasGradient> CanvasGradient::create_radial(JS::Realm& realm, double x0, double y0, double r0, double x1, double y1, double r1)
 {
     (void)x0;
     (void)y0;
@@ -19,31 +19,31 @@ JS::NonnullGCPtr<CanvasGradient> CanvasGradient::create_radial(HTML::Window& win
     (void)x1;
     (void)y1;
     (void)r1;
-    return *window.heap().allocate<CanvasGradient>(window.realm(), window, Type::Radial);
+    return *realm.heap().allocate<CanvasGradient>(realm, realm, Type::Radial);
 }
 
-JS::NonnullGCPtr<CanvasGradient> CanvasGradient::create_linear(HTML::Window& window, double x0, double y0, double x1, double y1)
+JS::NonnullGCPtr<CanvasGradient> CanvasGradient::create_linear(JS::Realm& realm, double x0, double y0, double x1, double y1)
 {
     (void)x0;
     (void)y0;
     (void)x1;
     (void)y1;
-    return *window.heap().allocate<CanvasGradient>(window.realm(), window, Type::Linear);
+    return *realm.heap().allocate<CanvasGradient>(realm, realm, Type::Linear);
 }
 
-JS::NonnullGCPtr<CanvasGradient> CanvasGradient::create_conic(HTML::Window& window, double start_angle, double x, double y)
+JS::NonnullGCPtr<CanvasGradient> CanvasGradient::create_conic(JS::Realm& realm, double start_angle, double x, double y)
 {
     (void)start_angle;
     (void)x;
     (void)y;
-    return *window.heap().allocate<CanvasGradient>(window.realm(), window, Type::Conic);
+    return *realm.heap().allocate<CanvasGradient>(realm, realm, Type::Conic);
 }
 
-CanvasGradient::CanvasGradient(HTML::Window& window, Type type)
-    : PlatformObject(window.realm())
+CanvasGradient::CanvasGradient(JS::Realm& realm, Type type)
+    : PlatformObject(realm)
     , m_type(type)
 {
-    set_prototype(&window.cached_web_prototype("CanvasGradient"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "CanvasGradient"));
 }
 
 CanvasGradient::~CanvasGradient() = default;
@@ -53,14 +53,14 @@ WebIDL::ExceptionOr<void> CanvasGradient::add_color_stop(double offset, String c
 {
     // 1. If the offset is less than 0 or greater than 1, then throw an "IndexSizeError" DOMException.
     if (offset < 0 || offset > 1)
-        return WebIDL::IndexSizeError::create(global_object(), "CanvasGradient color stop offset out of bounds");
+        return WebIDL::IndexSizeError::create(realm(), "CanvasGradient color stop offset out of bounds");
 
     // 2. Let parsed color be the result of parsing color.
     auto parsed_color = Color::from_string(color);
 
     // 3. If parsed color is failure, throw a "SyntaxError" DOMException.
     if (!parsed_color.has_value())
-        return WebIDL::SyntaxError::create(global_object(), "Could not parse color for CanvasGradient");
+        return WebIDL::SyntaxError::create(realm(), "Could not parse color for CanvasGradient");
 
     // 4. Place a new stop on the gradient, at offset offset relative to the whole gradient, and with the color parsed color.
     m_color_stops.append(ColorStop { offset, parsed_color.value() });

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.h
@@ -21,16 +21,16 @@ public:
         Conic,
     };
 
-    static JS::NonnullGCPtr<CanvasGradient> create_radial(HTML::Window&, double x0, double y0, double r0, double x1, double y1, double r1);
-    static JS::NonnullGCPtr<CanvasGradient> create_linear(HTML::Window&, double x0, double y0, double x1, double y1);
-    static JS::NonnullGCPtr<CanvasGradient> create_conic(HTML::Window&, double start_angle, double x, double y);
+    static JS::NonnullGCPtr<CanvasGradient> create_radial(JS::Realm&, double x0, double y0, double r0, double x1, double y1, double r1);
+    static JS::NonnullGCPtr<CanvasGradient> create_linear(JS::Realm&, double x0, double y0, double x1, double y1);
+    static JS::NonnullGCPtr<CanvasGradient> create_conic(JS::Realm&, double start_angle, double x, double y);
 
     WebIDL::ExceptionOr<void> add_color_stop(double offset, String const& color);
 
     ~CanvasGradient();
 
 private:
-    CanvasGradient(HTML::Window&, Type);
+    CanvasGradient(JS::Realm&, Type);
 
     Type m_type {};
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -51,7 +51,7 @@ class CanvasRenderingContext2D
     WEB_PLATFORM_OBJECT(CanvasRenderingContext2D, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<CanvasRenderingContext2D> create(HTML::Window&, HTMLCanvasElement&);
+    static JS::NonnullGCPtr<CanvasRenderingContext2D> create(JS::Realm&, HTMLCanvasElement&);
     virtual ~CanvasRenderingContext2D() override;
 
     virtual void fill_rect(float x, float y, float width, float height) override;
@@ -83,7 +83,7 @@ public:
     virtual void clip() override;
 
 private:
-    explicit CanvasRenderingContext2D(HTML::Window&, HTMLCanvasElement&);
+    explicit CanvasRenderingContext2D(JS::Realm&, HTMLCanvasElement&);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/CloseEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CloseEvent.cpp
@@ -4,28 +4,34 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/CloseEvent.h>
 #include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
-CloseEvent* CloseEvent::create(HTML::Window& window_object, FlyString const& event_name, CloseEventInit const& event_init)
+CloseEvent* CloseEvent::create(JS::Realm& realm, FlyString const& event_name, CloseEventInit const& event_init)
 {
-    return window_object.heap().allocate<CloseEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<CloseEvent>(realm, realm, event_name, event_init);
 }
 
-CloseEvent* CloseEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, CloseEventInit const& event_init)
+CloseEvent* CloseEvent::create(HTML::Window& window, FlyString const& event_name, CloseEventInit const& event_init)
 {
-    return create(window_object, event_name, event_init);
+    return create(window.realm(), event_name, event_init);
 }
 
-CloseEvent::CloseEvent(HTML::Window& window_object, FlyString const& event_name, CloseEventInit const& event_init)
-    : DOM::Event(window_object, event_name, event_init)
+CloseEvent* CloseEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, CloseEventInit const& event_init)
+{
+    return create(realm, event_name, event_init);
+}
+
+CloseEvent::CloseEvent(JS::Realm& realm, FlyString const& event_name, CloseEventInit const& event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_was_clean(event_init.was_clean)
     , m_code(event_init.code)
     , m_reason(event_init.reason)
 {
-    set_prototype(&window_object.cached_web_prototype("CloseEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "CloseEvent"));
 }
 
 CloseEvent::~CloseEvent() = default;

--- a/Userland/Libraries/LibWeb/HTML/CloseEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CloseEvent.cpp
@@ -6,18 +6,12 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/CloseEvent.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
 CloseEvent* CloseEvent::create(JS::Realm& realm, FlyString const& event_name, CloseEventInit const& event_init)
 {
     return realm.heap().allocate<CloseEvent>(realm, realm, event_name, event_init);
-}
-
-CloseEvent* CloseEvent::create(HTML::Window& window, FlyString const& event_name, CloseEventInit const& event_init)
-{
-    return create(window.realm(), event_name, event_init);
 }
 
 CloseEvent* CloseEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, CloseEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/HTML/CloseEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/CloseEvent.h
@@ -22,7 +22,6 @@ class CloseEvent : public DOM::Event {
 
 public:
     static CloseEvent* create(JS::Realm&, FlyString const& event_name, CloseEventInit const& event_init = {});
-    static CloseEvent* create(HTML::Window&, FlyString const& event_name, CloseEventInit const& event_init = {});
     static CloseEvent* construct_impl(JS::Realm&, FlyString const& event_name, CloseEventInit const& event_init);
 
     virtual ~CloseEvent() override;

--- a/Userland/Libraries/LibWeb/HTML/CloseEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/CloseEvent.h
@@ -21,10 +21,9 @@ class CloseEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(CloseEvent, DOM::Event);
 
 public:
+    static CloseEvent* create(JS::Realm&, FlyString const& event_name, CloseEventInit const& event_init = {});
     static CloseEvent* create(HTML::Window&, FlyString const& event_name, CloseEventInit const& event_init = {});
-    static CloseEvent* create_with_global_object(HTML::Window&, FlyString const& event_name, CloseEventInit const& event_init);
-
-    CloseEvent(HTML::Window&, FlyString const& event_name, CloseEventInit const& event_init);
+    static CloseEvent* construct_impl(JS::Realm&, FlyString const& event_name, CloseEventInit const& event_init);
 
     virtual ~CloseEvent() override;
 
@@ -33,6 +32,8 @@ public:
     String reason() const { return m_reason; }
 
 private:
+    CloseEvent(JS::Realm&, FlyString const& event_name, CloseEventInit const& event_init);
+
     bool m_was_clean { false };
     u16 m_code { 0 };
     String m_reason;

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
@@ -78,7 +78,7 @@ JS::ThrowCompletionOr<JS::PropertyDescriptor> cross_origin_property_fallback(JS:
         return JS::PropertyDescriptor { .value = JS::js_undefined(), .writable = false, .enumerable = false, .configurable = true };
 
     // 2. Throw a "SecurityError" DOMException.
-    return throw_completion(WebIDL::SecurityError::create(vm.current_realm()->global_object(), String::formatted("Can't access property '{}' on cross-origin object", property_key)));
+    return throw_completion(WebIDL::SecurityError::create(*vm.current_realm(), String::formatted("Can't access property '{}' on cross-origin object", property_key)));
 }
 
 // 7.2.3.3 IsPlatformObjectSameOrigin ( O ), https://html.spec.whatwg.org/multipage/browsers.html#isplatformobjectsameorigin-(-o-)
@@ -196,7 +196,7 @@ JS::ThrowCompletionOr<JS::Value> cross_origin_get(JS::VM& vm, JS::Object const& 
 
     // 6. If getter is undefined, then throw a "SecurityError" DOMException.
     if (!getter.has_value())
-        return throw_completion(WebIDL::SecurityError::create(vm.current_realm()->global_object(), String::formatted("Can't get property '{}' on cross-origin object", property_key)));
+        return throw_completion(WebIDL::SecurityError::create(*vm.current_realm(), String::formatted("Can't get property '{}' on cross-origin object", property_key)));
 
     // 7. Return ? Call(getter, Receiver).
     return JS::call(vm, *getter, receiver);
@@ -222,7 +222,7 @@ JS::ThrowCompletionOr<bool> cross_origin_set(JS::VM& vm, JS::Object& object, JS:
     }
 
     // 4. Throw a "SecurityError" DOMException.
-    return throw_completion(WebIDL::SecurityError::create(vm.current_realm()->global_object(), String::formatted("Can't set property '{}' on cross-origin object", property_key)));
+    return throw_completion(WebIDL::SecurityError::create(*vm.current_realm(), String::formatted("Can't set property '{}' on cross-origin object", property_key)));
 }
 
 // 7.2.3.7 CrossOriginOwnPropertyKeys ( O ), https://html.spec.whatwg.org/multipage/browsers.html#crossoriginownpropertykeys-(-o-)

--- a/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
@@ -13,15 +13,15 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMParser>> DOMParser::create_with_global_object(HTML::Window& window)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMParser>> DOMParser::construct_impl(JS::Realm& realm)
 {
-    return JS::NonnullGCPtr(*window.heap().allocate<DOMParser>(window.realm(), window));
+    return JS::NonnullGCPtr(*realm.heap().allocate<DOMParser>(realm, realm));
 }
 
-DOMParser::DOMParser(HTML::Window& window)
-    : PlatformObject(window.realm())
+DOMParser::DOMParser(JS::Realm& realm)
+    : PlatformObject(realm)
 {
-    set_prototype(&window.cached_web_prototype("DOMParser"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "DOMParser"));
 }
 
 DOMParser::~DOMParser() = default;
@@ -30,7 +30,7 @@ DOMParser::~DOMParser() = default;
 JS::NonnullGCPtr<DOM::Document> DOMParser::parse_from_string(String const& string, Bindings::DOMParserSupportedType type)
 {
     // 1. Let document be a new Document, whose content type is type and url is this's relevant global object's associated Document's URL.
-    auto document = DOM::Document::create(Bindings::main_thread_internal_window_object(), verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document().url());
+    auto document = DOM::Document::create(realm(), verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document().url());
     document->set_content_type(Bindings::idl_enum_to_string(type));
 
     // 2. Switch on type:

--- a/Userland/Libraries/LibWeb/HTML/DOMParser.h
+++ b/Userland/Libraries/LibWeb/HTML/DOMParser.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Forward.h>
@@ -18,14 +19,14 @@ class DOMParser final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(DOMParser, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMParser>> create_with_global_object(HTML::Window&);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMParser>> construct_impl(JS::Realm&);
 
     virtual ~DOMParser() override;
 
     JS::NonnullGCPtr<DOM::Document> parse_from_string(String const&, Bindings::DOMParserSupportedType type);
 
 private:
-    explicit DOMParser(HTML::Window&);
+    explicit DOMParser(JS::Realm&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
@@ -5,21 +5,21 @@
  */
 
 #include <AK/CharacterTypes.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/HTML/DOMStringMap.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
 JS::NonnullGCPtr<DOMStringMap> DOMStringMap::create(DOM::Element& element)
 {
-    auto& realm = element.document().window().realm();
+    auto& realm = element.realm();
     return *realm.heap().allocate<DOMStringMap>(realm, element);
 }
 
 DOMStringMap::DOMStringMap(DOM::Element& element)
-    : PlatformObject(element.window().cached_web_prototype("DOMStringMap"))
+    : PlatformObject(Bindings::cached_web_prototype(element.realm(), "DOMStringMap"))
     , m_associated_element(element)
 {
 }
@@ -126,7 +126,7 @@ WebIDL::ExceptionOr<void> DOMStringMap::set_value_of_new_named_property(String c
         if (current_character == '-' && character_index + 1 < name.length()) {
             auto next_character = name[character_index + 1];
             if (is_ascii_lower_alpha(next_character))
-                return WebIDL::SyntaxError::create(global_object(), "Name cannot contain a '-' followed by a lowercase character.");
+                return WebIDL::SyntaxError::create(realm(), "Name cannot contain a '-' followed by a lowercase character.");
         }
 
         // 2. For each ASCII upper alpha in name, insert a U+002D HYPHEN-MINUS character (-) before the character and replace the character with the same character converted to ASCII lowercase.

--- a/Userland/Libraries/LibWeb/HTML/ErrorEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ErrorEvent.cpp
@@ -4,30 +4,30 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/ErrorEvent.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
-ErrorEvent* ErrorEvent::create(HTML::Window& window_object, FlyString const& event_name, ErrorEventInit const& event_init)
+ErrorEvent* ErrorEvent::create(JS::Realm& realm, FlyString const& event_name, ErrorEventInit const& event_init)
 {
-    return window_object.heap().allocate<ErrorEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<ErrorEvent>(realm, realm, event_name, event_init);
 }
 
-ErrorEvent* ErrorEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, ErrorEventInit const& event_init)
+ErrorEvent* ErrorEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, ErrorEventInit const& event_init)
 {
-    return create(window_object, event_name, event_init);
+    return create(realm, event_name, event_init);
 }
 
-ErrorEvent::ErrorEvent(HTML::Window& window_object, FlyString const& event_name, ErrorEventInit const& event_init)
-    : DOM::Event(window_object, event_name)
+ErrorEvent::ErrorEvent(JS::Realm& realm, FlyString const& event_name, ErrorEventInit const& event_init)
+    : DOM::Event(realm, event_name)
     , m_message(event_init.message)
     , m_filename(event_init.filename)
     , m_lineno(event_init.lineno)
     , m_colno(event_init.colno)
     , m_error(event_init.error)
 {
-    set_prototype(&window_object.cached_web_prototype("ErrorEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "ErrorEvent"));
 }
 
 ErrorEvent::~ErrorEvent() = default;

--- a/Userland/Libraries/LibWeb/HTML/ErrorEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/ErrorEvent.h
@@ -24,10 +24,8 @@ class ErrorEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(ErrorEvent, DOM::Event);
 
 public:
-    static ErrorEvent* create(HTML::Window&, FlyString const& event_name, ErrorEventInit const& event_init = {});
-    static ErrorEvent* create_with_global_object(HTML::Window&, FlyString const& event_name, ErrorEventInit const& event_init);
-
-    ErrorEvent(HTML::Window&, FlyString const& event_name, ErrorEventInit const& event_init);
+    static ErrorEvent* create(JS::Realm&, FlyString const& event_name, ErrorEventInit const& event_init = {});
+    static ErrorEvent* construct_impl(JS::Realm&, FlyString const& event_name, ErrorEventInit const& event_init);
 
     virtual ~ErrorEvent() override;
 
@@ -47,6 +45,8 @@ public:
     JS::Value error() const { return m_error; }
 
 private:
+    ErrorEvent(JS::Realm&, FlyString const& event_name, ErrorEventInit const& event_init);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     String m_message { "" };

--- a/Userland/Libraries/LibWeb/HTML/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventHandler.cpp
@@ -6,7 +6,6 @@
 
 #include <LibWeb/DOM/DOMEventListener.h>
 #include <LibWeb/HTML/EventHandler.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -368,8 +368,10 @@ void EventLoop::unregister_environment_settings_object(Badge<EnvironmentSettings
 Vector<JS::Handle<HTML::Window>> EventLoop::same_loop_windows() const
 {
     Vector<JS::Handle<HTML::Window>> windows;
-    for (auto& document : documents_in_this_event_loop())
-        windows.append(JS::make_handle(document->window()));
+    for (auto& document : documents_in_this_event_loop()) {
+        if (document->is_fully_active())
+            windows.append(JS::make_handle(document->window()));
+    }
     return windows;
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLAnchorElement::HTMLAnchorElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLAnchorElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLAnchorElement"));
 
     activation_behavior = [this](auto const& event) {
         run_activation_behavior(event);

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLAreaElement::HTMLAreaElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLAreaElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLAreaElement"));
 }
 
 HTMLAreaElement::~HTMLAreaElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLAudioElement::HTMLAudioElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLMediaElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLAudioElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLAudioElement"));
 }
 
 HTMLAudioElement::~HTMLAudioElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLBRElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBRElement.cpp
@@ -13,7 +13,7 @@ namespace Web::HTML {
 HTMLBRElement::HTMLBRElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLBRElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLBRElement"));
 }
 
 HTMLBRElement::~HTMLBRElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLBaseElement::HTMLBaseElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLBaseElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLBaseElement"));
 }
 
 HTMLBaseElement::~HTMLBaseElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -15,7 +15,7 @@ namespace Web::HTML {
 HTMLBodyElement::HTMLBodyElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLBodyElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLBodyElement"));
 }
 
 HTMLBodyElement::~HTMLBodyElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -13,7 +13,7 @@ namespace Web::HTML {
 HTMLButtonElement::HTMLButtonElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLButtonElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLButtonElement"));
 
     // https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element:activation-behaviour
     activation_behavior = [this](auto&) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -21,7 +21,7 @@ static constexpr auto max_canvas_area = 16384 * 16384;
 HTMLCanvasElement::HTMLCanvasElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&document.window().cached_web_prototype("HTMLCanvasElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLCanvasElement"));
 }
 
 HTMLCanvasElement::~HTMLCanvasElement() = default;
@@ -88,7 +88,7 @@ HTMLCanvasElement::HasOrCreatedContext HTMLCanvasElement::create_2d_context()
     if (!m_context.has<Empty>())
         return m_context.has<JS::NonnullGCPtr<CanvasRenderingContext2D>>() ? HasOrCreatedContext::Yes : HasOrCreatedContext::No;
 
-    m_context = CanvasRenderingContext2D::create(window(), *this);
+    m_context = CanvasRenderingContext2D::create(realm(), *this);
     return HasOrCreatedContext::Yes;
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -97,7 +97,7 @@ JS::ThrowCompletionOr<HTMLCanvasElement::HasOrCreatedContext> HTMLCanvasElement:
     if (!m_context.has<Empty>())
         return m_context.has<JS::NonnullGCPtr<WebGL::WebGLRenderingContext>>() ? HasOrCreatedContext::Yes : HasOrCreatedContext::No;
 
-    auto maybe_context = TRY(WebGL::WebGLRenderingContext::create(window(), *this, options));
+    auto maybe_context = TRY(WebGL::WebGLRenderingContext::create(realm(), *this, options));
     if (!maybe_context)
         return HasOrCreatedContext::No;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDListElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDListElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLDListElement::HTMLDListElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLDListElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLDListElement"));
 }
 
 HTMLDListElement::~HTMLDListElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLDataElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDataElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLDataElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDataElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDataElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLDataElement::HTMLDataElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLDataElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLDataElement"));
 }
 
 HTMLDataElement::~HTMLDataElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLDataListElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDataListElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLDataListElement::HTMLDataListElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLDataListElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLDataListElement"));
 }
 
 HTMLDataListElement::~HTMLDataListElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLDataListElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDataListElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLDataListElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLDetailsElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLDetailsElement::HTMLDetailsElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLDetailsElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLDetailsElement"));
 }
 
 HTMLDetailsElement::~HTMLDetailsElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLDialogElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLDialogElement::HTMLDialogElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLDialogElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLDialogElement"));
 }
 
 HTMLDialogElement::~HTMLDialogElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLDirectoryElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDirectoryElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLDirectoryElement::HTMLDirectoryElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLDirectoryElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLDirectoryElement"));
 }
 
 HTMLDirectoryElement::~HTMLDirectoryElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLDivElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDivElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLDivElement::HTMLDivElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLDivElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLDivElement"));
 }
 
 HTMLDivElement::~HTMLDivElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLDivElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDivElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLDivElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -31,7 +31,7 @@ namespace Web::HTML {
 HTMLElement::HTMLElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : Element(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLElement"));
 }
 
 HTMLElement::~HTMLElement() = default;
@@ -104,7 +104,7 @@ WebIDL::ExceptionOr<void> HTMLElement::set_content_editable(String const& conten
         set_attribute(HTML::AttributeNames::contenteditable, "false");
         return {};
     }
-    return WebIDL::SyntaxError::create(global_object(), "Invalid contentEditable value, must be 'true', 'false', or 'inherit'");
+    return WebIDL::SyntaxError::create(realm(), "Invalid contentEditable value, must be 'true', 'false', or 'inherit'");
 }
 
 void HTMLElement::set_inner_text(StringView text)
@@ -436,7 +436,7 @@ bool HTMLElement::fire_a_synthetic_pointer_event(FlyString const& type, DOM::Ele
     // 1. Let event be the result of creating an event using PointerEvent.
     // 2. Initialize event's type attribute to e.
     // FIXME: Actually create a PointerEvent!
-    auto event = UIEvents::MouseEvent::create(document().window(), type);
+    auto event = UIEvents::MouseEvent::create(window(), type);
 
     // 3. Initialize event's bubbles and cancelable attributes to true.
     event->set_bubbles(true);

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -272,7 +272,7 @@ static void run_focus_update_steps(Vector<JS::Handle<DOM::Node>> old_chain, Vect
         //    with related blur target as the related target.
         if (blur_event_target) {
             // FIXME: Implement the "fire a focus event" spec operation.
-            auto blur_event = UIEvents::FocusEvent::create(blur_event_target->global_object(), HTML::EventNames::blur);
+            auto blur_event = UIEvents::FocusEvent::create(blur_event_target->realm(), HTML::EventNames::blur);
             blur_event->set_related_target(related_blur_target);
             blur_event_target->dispatch_event(*blur_event);
         }
@@ -315,7 +315,7 @@ static void run_focus_update_steps(Vector<JS::Handle<DOM::Node>> old_chain, Vect
         //    with related focus target as the related target.
         if (focus_event_target) {
             // FIXME: Implement the "fire a focus event" spec operation.
-            auto focus_event = UIEvents::FocusEvent::create(focus_event_target->global_object(), HTML::EventNames::focus);
+            auto focus_event = UIEvents::FocusEvent::create(focus_event_target->realm(), HTML::EventNames::focus);
             focus_event->set_related_target(related_focus_target);
             focus_event_target->dispatch_event(*focus_event);
         }
@@ -436,7 +436,7 @@ bool HTMLElement::fire_a_synthetic_pointer_event(FlyString const& type, DOM::Ele
     // 1. Let event be the result of creating an event using PointerEvent.
     // 2. Initialize event's type attribute to e.
     // FIXME: Actually create a PointerEvent!
-    auto event = UIEvents::MouseEvent::create(window(), type);
+    auto event = UIEvents::MouseEvent::create(realm(), type);
 
     // 3. Initialize event's bubbles and cancelable attributes to true.
     event->set_bubbles(true);

--- a/Userland/Libraries/LibWeb/HTML/HTMLEmbedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLEmbedElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLEmbedElement::HTMLEmbedElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLEmbedElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLEmbedElement"));
 }
 
 HTMLEmbedElement::~HTMLEmbedElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLEmbedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLEmbedElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLEmbedElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
@@ -13,7 +13,7 @@ namespace Web::HTML {
 HTMLFieldSetElement::HTMLFieldSetElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLFieldSetElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLFieldSetElement"));
 }
 
 HTMLFieldSetElement::~HTMLFieldSetElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLFieldSetElement.h>
 #include <LibWeb/HTML/HTMLLegendElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFontElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFontElement.cpp
@@ -14,7 +14,7 @@ namespace Web::HTML {
 HTMLFontElement::HTMLFontElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLFontElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLFontElement"));
 }
 
 HTMLFontElement::~HTMLFontElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLFontElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFontElement.cpp
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValue.h>
 #include <LibWeb/HTML/HTMLFontElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -25,7 +25,7 @@ namespace Web::HTML {
 HTMLFormElement::HTMLFormElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLFormElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLFormElement"));
 }
 
 HTMLFormElement::~HTMLFormElement() = default;
@@ -73,7 +73,7 @@ void HTMLFormElement::submit_form(JS::GCPtr<HTMLElement> submitter, bool from_su
 
         SubmitEventInit event_init {};
         event_init.submitter = submitter_button;
-        auto submit_event = SubmitEvent::create(document().window(), EventNames::submit, event_init);
+        auto submit_event = SubmitEvent::create(realm(), EventNames::submit, event_init);
         submit_event->set_bubbles(true);
         submit_event->set_cancelable(true);
         bool continue_ = dispatch_event(*submit_event);

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLFrameElement::HTMLFrameElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLFrameElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLFrameElement"));
 }
 
 HTMLFrameElement::~HTMLFrameElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLFrameElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -13,7 +13,7 @@ namespace Web::HTML {
 HTMLFrameSetElement::HTMLFrameSetElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLFrameSetElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLFrameSetElement"));
 }
 
 HTMLFrameSetElement::~HTMLFrameSetElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLHRElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHRElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLHRElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLHRElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHRElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLHRElement::HTMLHRElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLHRElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLHRElement"));
 }
 
 HTMLHRElement::~HTMLHRElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLHeadElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHeadElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLHeadElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLHeadElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHeadElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLHeadElement::HTMLHeadElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLHeadElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLHeadElement"));
 }
 
 HTMLHeadElement::~HTMLHeadElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLHeadingElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLHeadingElement::HTMLHeadingElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLHeadingElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLHeadingElement"));
 }
 
 HTMLHeadingElement::~HTMLHeadingElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLHtmlElement::HTMLHtmlElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLHtmlElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLHtmlElement"));
 }
 
 HTMLHtmlElement::~HTMLHtmlElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -16,7 +16,7 @@ namespace Web::HTML {
 HTMLIFrameElement::HTMLIFrameElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : BrowsingContextContainer(document, move(qualified_name))
 {
-    set_prototype(&document.window().cached_web_prototype("HTMLIFrameElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLIFrameElement"));
 }
 
 HTMLIFrameElement::~HTMLIFrameElement() = default;
@@ -144,7 +144,7 @@ void run_iframe_load_event_steps(HTML::HTMLIFrameElement& element)
     // FIXME: 4. Set childDocument's iframe load in progress flag.
 
     // 5. Fire an event named load at element.
-    element.dispatch_event(*DOM::Event::create(element.document().window(), HTML::EventNames::load));
+    element.dispatch_event(*DOM::Event::create(element.realm(), HTML::EventNames::load));
 
     // FIXME: 6. Unset childDocument's iframe load in progress flag.
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -22,13 +22,13 @@ HTMLImageElement::HTMLImageElement(DOM::Document& document, DOM::QualifiedName q
     : HTMLElement(document, move(qualified_name))
     , m_image_loader(*this)
 {
-    set_prototype(&window().cached_web_prototype("HTMLImageElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLImageElement"));
 
     m_image_loader.on_load = [this] {
         set_needs_style_update(true);
         this->document().set_needs_layout();
         queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
-            dispatch_event(*DOM::Event::create(this->document().window(), EventNames::load));
+            dispatch_event(*DOM::Event::create(this->realm(), EventNames::load));
         });
     };
 
@@ -37,7 +37,7 @@ HTMLImageElement::HTMLImageElement(DOM::Document& document, DOM::QualifiedName q
         set_needs_style_update(true);
         this->document().set_needs_layout();
         queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
-            dispatch_event(*DOM::Event::create(this->document().window(), EventNames::error));
+            dispatch_event(*DOM::Event::create(this->realm(), EventNames::error));
         });
     };
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -24,7 +24,7 @@ HTMLInputElement::HTMLInputElement(DOM::Document& document, DOM::QualifiedName q
     : HTMLElement(document, move(qualified_name))
     , m_value(String::empty())
 {
-    set_prototype(&window().cached_web_prototype("HTMLInputElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLInputElement"));
 
     activation_behavior = [this](auto&) {
         // The activation behavior for input elements are these steps:
@@ -99,13 +99,13 @@ void HTMLInputElement::run_input_activation_behavior()
             return;
 
         // 2. Fire an event named input at the element with the bubbles and composed attributes initialized to true.
-        auto input_event = DOM::Event::create(document().window(), HTML::EventNames::input);
+        auto input_event = DOM::Event::create(realm(), HTML::EventNames::input);
         input_event->set_bubbles(true);
         input_event->set_composed(true);
         dispatch_event(*input_event);
 
         // 3. Fire an event named change at the element with the bubbles attribute initialized to true.
-        auto change_event = DOM::Event::create(document().window(), HTML::EventNames::change);
+        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
         change_event->set_bubbles(true);
         dispatch_event(*change_event);
     } else if (type_state() == TypeAttributeState::SubmitButton) {
@@ -121,7 +121,7 @@ void HTMLInputElement::run_input_activation_behavior()
         // 3. Submit the form owner from the element.
         form->submit_form(this);
     } else {
-        dispatch_event(*DOM::Event::create(document().window(), EventNames::change));
+        dispatch_event(*DOM::Event::create(realm(), EventNames::change));
     }
 }
 
@@ -134,13 +134,13 @@ void HTMLInputElement::did_edit_text_node(Badge<BrowsingContext>)
     // NOTE: This is a bit ad-hoc, but basically implements part of "4.10.5.5 Common event behaviors"
     //       https://html.spec.whatwg.org/multipage/input.html#common-input-element-events
     queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
-        auto input_event = DOM::Event::create(document().window(), HTML::EventNames::input);
+        auto input_event = DOM::Event::create(realm(), HTML::EventNames::input);
         input_event->set_bubbles(true);
         input_event->set_composed(true);
         dispatch_event(*input_event);
 
         // FIXME: This should only fire when the input is "committed", whatever that means.
-        auto change_event = DOM::Event::create(document().window(), HTML::EventNames::change);
+        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
         change_event->set_bubbles(true);
         dispatch_event(*change_event);
     });

--- a/Userland/Libraries/LibWeb/HTML/HTMLLIElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLIElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLLIElement::HTMLLIElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLLIElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLLIElement"));
 }
 
 HTMLLIElement::~HTMLLIElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
@@ -13,7 +13,7 @@ namespace Web::HTML {
 HTMLLabelElement::HTMLLabelElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLLabelElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLLabelElement"));
 }
 
 HTMLLabelElement::~HTMLLabelElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/Bindings/HTMLLegendElementPrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLLegendElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
@@ -13,7 +13,7 @@ namespace Web::HTML {
 HTMLLegendElement::HTMLLegendElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLLegendElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLLegendElement"));
 }
 
 HTMLLegendElement::~HTMLLegendElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -21,7 +21,7 @@ namespace Web::HTML {
 HTMLLinkElement::HTMLLinkElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLLinkElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLLinkElement"));
 }
 
 HTMLLinkElement::~HTMLLinkElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMapElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMapElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLMapElement::HTMLMapElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLMapElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLMapElement"));
 }
 
 HTMLMapElement::~HTMLMapElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMapElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMapElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLMapElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLMarqueeElement::HTMLMarqueeElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLMarqueeElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLMarqueeElement"));
 }
 
 HTMLMarqueeElement::~HTMLMarqueeElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLMarqueeElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -5,8 +5,8 @@
  */
 
 #include <LibWeb/Bindings/HTMLMediaElementPrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -13,7 +13,7 @@ namespace Web::HTML {
 HTMLMediaElement::HTMLMediaElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLMediaElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLMediaElement"));
 }
 
 HTMLMediaElement::~HTMLMediaElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMenuElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMenuElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLMenuElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMenuElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMenuElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLMenuElement::HTMLMenuElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLMenuElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLMenuElement"));
 }
 
 HTMLMenuElement::~HTMLMenuElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLMetaElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLMetaElement::HTMLMetaElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLMetaElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLMetaElement"));
 }
 
 HTMLMetaElement::~HTMLMetaElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLMeterElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLMeterElement::HTMLMeterElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLMeterElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLMeterElement"));
 }
 
 HTMLMeterElement::~HTMLMeterElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLModElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLModElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLModElement::HTMLModElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLModElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLModElement"));
 }
 
 HTMLModElement::~HTMLModElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLModElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLModElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLModElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOListElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOListElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLOListElement::HTMLOListElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLOListElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLOListElement"));
 }
 
 HTMLOListElement::~HTMLOListElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLOListElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOListElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLOListElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -19,7 +19,7 @@ namespace Web::HTML {
 HTMLObjectElement::HTMLObjectElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : BrowsingContextContainer(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLObjectElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLObjectElement"));
 }
 
 HTMLObjectElement::~HTMLObjectElement() = default;
@@ -97,7 +97,7 @@ void HTMLObjectElement::queue_element_task_to_run_object_representation_steps()
 
             // 3. If that failed, fire an event named error at the element, then jump to the step below labeled fallback.
             if (!url.is_valid()) {
-                dispatch_event(*DOM::Event::create(document().window(), HTML::EventNames::error));
+                dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error));
                 return run_object_representation_fallback_steps();
             }
 
@@ -124,7 +124,7 @@ void HTMLObjectElement::queue_element_task_to_run_object_representation_steps()
 void HTMLObjectElement::resource_did_fail()
 {
     // 4.7. If the load failed (e.g. there was an HTTP 404 error, there was a DNS error), fire an event named error at the element, then jump to the step below labeled fallback.
-    dispatch_event(*DOM::Event::create(document().window(), HTML::EventNames::error));
+    dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error));
     run_object_representation_fallback_steps();
 }
 
@@ -262,7 +262,7 @@ void HTMLObjectElement::run_object_representation_completed_steps(Representation
     // 4.11. If the object element does not represent its nested browsing context, then once the resource is completely loaded, queue an element task on the DOM manipulation task source given the object element to fire an event named load at the element.
     if (representation != Representation::NestedBrowsingContext) {
         queue_an_element_task(HTML::Task::Source::DOMManipulation, [&]() {
-            dispatch_event(*DOM::Event::create(document().window(), HTML::EventNames::load));
+            dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::load));
         });
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptGroupElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptGroupElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLOptGroupElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptGroupElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptGroupElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLOptGroupElement::HTMLOptGroupElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLOptGroupElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLOptGroupElement"));
 }
 
 HTMLOptGroupElement::~HTMLOptGroupElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -6,13 +6,13 @@
  */
 
 #include <AK/StringBuilder.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/HTMLOptGroupElement.h>
 #include <LibWeb/HTML/HTMLOptionElement.h>
 #include <LibWeb/HTML/HTMLScriptElement.h>
 #include <LibWeb/HTML/HTMLSelectElement.h>
-#include <LibWeb/HTML/Window.h>
 #include <ctype.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -20,7 +20,7 @@ namespace Web::HTML {
 HTMLOptionElement::HTMLOptionElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLOptionElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLOptionElement"));
 }
 
 HTMLOptionElement::~HTMLOptionElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLOptGroupElement.h>
 #include <LibWeb/HTML/HTMLOptionElement.h>
 #include <LibWeb/HTML/HTMLOptionsCollection.h>
 #include <LibWeb/HTML/HTMLSelectElement.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/WebIDL/DOMException.h>
 
 namespace Web::HTML {
@@ -21,7 +21,7 @@ JS::NonnullGCPtr<HTMLOptionsCollection> HTMLOptionsCollection::create(DOM::Paren
 HTMLOptionsCollection::HTMLOptionsCollection(DOM::ParentNode& root, Function<bool(DOM::Element const&)> filter)
     : DOM::HTMLCollection(root, move(filter))
 {
-    set_prototype(&root.window().cached_web_prototype("HTMLOptionsCollection"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLOptionsCollection"));
 }
 
 HTMLOptionsCollection::~HTMLOptionsCollection() = default;
@@ -40,11 +40,11 @@ WebIDL::ExceptionOr<void> HTMLOptionsCollection::add(HTMLOptionOrOptGroupElement
 
     // 1. If element is an ancestor of the select element on which the HTMLOptionsCollection is rooted, then throw a "HierarchyRequestError" DOMException.
     if (resolved_element->is_ancestor_of(root()))
-        return WebIDL::HierarchyRequestError::create(global_object(), "The provided element is an ancestor of the root select element.");
+        return WebIDL::HierarchyRequestError::create(realm(), "The provided element is an ancestor of the root select element.");
 
     // 2. If before is an element, but that element isn't a descendant of the select element on which the HTMLOptionsCollection is rooted, then throw a "NotFoundError" DOMException.
     if (before_element && !before_element->is_descendant_of(root()))
-        return WebIDL::NotFoundError::create(global_object(), "The 'before' element is not a descendant of the root select element.");
+        return WebIDL::NotFoundError::create(realm(), "The 'before' element is not a descendant of the root select element.");
 
     // 3. If element and before are the same element, then return.
     if (before_element && (resolved_element.ptr() == before_element.ptr()))

--- a/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLOutputElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLOutputElement::HTMLOutputElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLOutputElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLOutputElement"));
 }
 
 HTMLOutputElement::~HTMLOutputElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLParagraphElement::HTMLParagraphElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLParagraphElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLParagraphElement"));
 }
 
 HTMLParagraphElement::~HTMLParagraphElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLParagraphElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLParamElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLParamElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLParamElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLParamElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLParamElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLParamElement::HTMLParamElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLParamElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLParamElement"));
 }
 
 HTMLParamElement::~HTMLParamElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLPictureElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLPictureElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLPictureElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLPictureElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLPictureElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLPictureElement::HTMLPictureElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLPictureElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLPictureElement"));
 }
 
 HTMLPictureElement::~HTMLPictureElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLPreElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLPreElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLPreElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLPreElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLPreElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLPreElement::HTMLPreElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLPreElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLPreElement"));
 }
 
 HTMLPreElement::~HTMLPreElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -18,7 +18,7 @@ namespace Web::HTML {
 HTMLProgressElement::HTMLProgressElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLProgressElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLProgressElement"));
 }
 
 HTMLProgressElement::~HTMLProgressElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLQuoteElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLQuoteElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLQuoteElement::HTMLQuoteElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLQuoteElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLQuoteElement"));
 }
 
 HTMLQuoteElement::~HTMLQuoteElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLQuoteElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLQuoteElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLQuoteElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -7,6 +7,7 @@
 #include <AK/Debug.h>
 #include <AK/StringBuilder.h>
 #include <LibTextCodec/Decoder.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/ShadowRoot.h>
@@ -14,7 +15,6 @@
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/HTMLScriptElement.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -22,7 +22,7 @@ namespace Web::HTML {
 HTMLScriptElement::HTMLScriptElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLScriptElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLScriptElement"));
 }
 
 HTMLScriptElement::~HTMLScriptElement() = default;
@@ -57,7 +57,7 @@ void HTMLScriptElement::execute_script()
     // 3. If the script's script is null for scriptElement, then fire an event named error at scriptElement, and return.
     if (!m_script) {
         dbgln("HTMLScriptElement: Refusing to run script because the script's script is null.");
-        dispatch_event(*DOM::Event::create(document().window(), HTML::EventNames::error));
+        dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error));
         return;
     }
 
@@ -104,7 +104,7 @@ void HTMLScriptElement::execute_script()
 
     // 7. If scriptElement is from an external file, then fire an event named load at scriptElement.
     if (m_from_an_external_file)
-        dispatch_event(*DOM::Event::create(document().window(), HTML::EventNames::load));
+        dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::load));
 }
 
 // https://mimesniff.spec.whatwg.org/#javascript-mime-type-essence-match
@@ -268,7 +268,7 @@ void HTMLScriptElement::prepare_script()
         if (src.is_empty()) {
             dbgln("HTMLScriptElement: Refusing to run script because the src attribute is empty.");
             queue_an_element_task(HTML::Task::Source::Unspecified, [this] {
-                dispatch_event(*DOM::Event::create(document().window(), HTML::EventNames::error));
+                dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error));
             });
             return;
         }
@@ -281,7 +281,7 @@ void HTMLScriptElement::prepare_script()
         if (!url.is_valid()) {
             dbgln("HTMLScriptElement: Refusing to run script because the src URL '{}' is invalid.", url);
             queue_an_element_task(HTML::Task::Source::Unspecified, [this] {
-                dispatch_event(*DOM::Event::create(document().window(), HTML::EventNames::error));
+                dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error));
             });
             return;
         }

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -16,7 +16,7 @@ namespace Web::HTML {
 HTMLSelectElement::HTMLSelectElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLSelectElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLSelectElement"));
 }
 
 HTMLSelectElement::~HTMLSelectElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLFormElement.h>
 #include <LibWeb/HTML/HTMLOptGroupElement.h>
 #include <LibWeb/HTML/HTMLOptionElement.h>
 #include <LibWeb/HTML/HTMLSelectElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLSlotElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLSlotElement::HTMLSlotElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLSlotElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLSlotElement"));
 }
 
 HTMLSlotElement::~HTMLSlotElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLSourceElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLSourceElement::HTMLSourceElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLSourceElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLSourceElement"));
 }
 
 HTMLSourceElement::~HTMLSourceElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLSpanElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSpanElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLSpanElement::HTMLSpanElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLSpanElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLSpanElement"));
 }
 
 HTMLSpanElement::~HTMLSpanElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLSpanElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSpanElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLSpanElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -14,7 +14,7 @@ namespace Web::HTML {
 HTMLStyleElement::HTMLStyleElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLStyleElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLStyleElement"));
 }
 
 HTMLStyleElement::~HTMLStyleElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLTableCaptionElement::HTMLTableCaptionElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLTableCaptionElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLTableCaptionElement"));
 }
 
 HTMLTableCaptionElement::~HTMLTableCaptionElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLTableCaptionElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -14,7 +14,7 @@ namespace Web::HTML {
 HTMLTableCellElement::HTMLTableCellElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLTableCellElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLTableCellElement"));
 }
 
 HTMLTableCellElement::~HTMLTableCellElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/HTML/HTMLTableCellElement.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableColElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableColElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLTableColElement::HTMLTableColElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLTableColElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLTableColElement"));
 }
 
 HTMLTableColElement::~HTMLTableColElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableColElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableColElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLTableColElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -20,7 +20,7 @@ namespace Web::HTML {
 HTMLTableElement::HTMLTableElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLTableElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLTableElement"));
 }
 
 HTMLTableElement::~HTMLTableElement() = default;
@@ -103,7 +103,7 @@ WebIDL::ExceptionOr<void> HTMLTableElement::set_t_head(HTMLTableSectionElement* 
     VERIFY(thead);
 
     if (thead->local_name() != TagNames::thead)
-        return WebIDL::HierarchyRequestError::create(global_object(), "Element is not thead");
+        return WebIDL::HierarchyRequestError::create(realm(), "Element is not thead");
 
     // FIXME: The spec requires deleting the current thead if thead is null
     //        Currently the wrapper generator doesn't send us a nullable value
@@ -190,7 +190,7 @@ WebIDL::ExceptionOr<void> HTMLTableElement::set_t_foot(HTMLTableSectionElement* 
     VERIFY(tfoot);
 
     if (tfoot->local_name() != TagNames::tfoot)
-        return WebIDL::HierarchyRequestError::create(global_object(), "Element is not tfoot");
+        return WebIDL::HierarchyRequestError::create(realm(), "Element is not tfoot");
 
     // FIXME: The spec requires deleting the current tfoot if tfoot is null
     //        Currently the wrapper generator doesn't send us a nullable value
@@ -286,7 +286,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableElement::ins
     auto rows_length = rows->length();
 
     if (index < -1 || index > (long)rows_length) {
-        return WebIDL::IndexSizeError::create(global_object(), "Index is negative or greater than the number of rows");
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of rows");
     }
     auto& tr = static_cast<HTMLTableRowElement&>(*DOM::create_element(document(), TagNames::tr, Namespace::HTML));
     if (rows_length == 0 && !has_child_of_type<HTMLTableRowElement>()) {
@@ -313,7 +313,7 @@ WebIDL::ExceptionOr<void> HTMLTableElement::delete_row(long index)
 
     // 1. If index is less than −1 or greater than or equal to the number of elements in the rows collection, then throw an "IndexSizeError" DOMException.
     if (index < -1 || index >= (long)rows_length)
-        return WebIDL::IndexSizeError::create(global_object(), "Index is negative or greater than or equal to the number of rows");
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of rows");
 
     // 2. If index is −1, then remove the last element in the rows collection from its parent, or do nothing if the rows collection is empty.
     if (index == -1) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/HTMLCollection.h>
@@ -12,7 +13,6 @@
 #include <LibWeb/HTML/HTMLTableElement.h>
 #include <LibWeb/HTML/HTMLTableRowElement.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Namespace.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -16,7 +16,7 @@ namespace Web::HTML {
 HTMLTableRowElement::HTMLTableRowElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLTableRowElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLTableRowElement"));
 }
 
 HTMLTableRowElement::~HTMLTableRowElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/HTML/HTMLTableCellElement.h>
 #include <LibWeb/HTML/HTMLTableElement.h>
 #include <LibWeb/HTML/HTMLTableRowElement.h>
 #include <LibWeb/HTML/HTMLTableSectionElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/HTML/HTMLTableRowElement.h>
 #include <LibWeb/HTML/HTMLTableSectionElement.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Namespace.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -17,7 +17,7 @@ namespace Web::HTML {
 HTMLTableSectionElement::HTMLTableSectionElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLTableSectionElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLTableSectionElement"));
 }
 
 HTMLTableSectionElement::~HTMLTableSectionElement() = default;
@@ -43,7 +43,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableSectionEleme
 
     // 1. If index is less than −1 or greater than the number of elements in the rows collection, throw an "IndexSizeError" DOMException.
     if (index < -1 || index > rows_collection_size)
-        return WebIDL::IndexSizeError::create(global_object(), "Index is negative or greater than the number of rows");
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of rows");
 
     // 2. Let table row be the result of creating an element given this element's node document, tr, and the HTML namespace.
     auto& table_row = static_cast<HTMLTableRowElement&>(*DOM::create_element(document(), TagNames::tr, Namespace::HTML));
@@ -67,7 +67,7 @@ WebIDL::ExceptionOr<void> HTMLTableSectionElement::delete_row(long index)
 
     // 1. If index is less than −1 or greater than or equal to the number of elements in the rows collection, then throw an "IndexSizeError" DOMException.
     if (index < -1 || index >= rows_collection_size)
-        return WebIDL::IndexSizeError::create(global_object(), "Index is negative or greater than or equal to the number of rows");
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of rows");
 
     // 2. If index is −1, then remove the last element in the rows collection from this element, or do nothing if the rows collection is empty.
     if (index == -1) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
@@ -13,7 +13,7 @@ namespace Web::HTML {
 HTMLTemplateElement::HTMLTemplateElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLTemplateElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLTemplateElement"));
 
     m_content = heap().allocate<DOM::DocumentFragment>(realm(), appropriate_template_contents_owner_document(document));
     m_content->set_host(this);
@@ -31,7 +31,7 @@ DOM::Document& HTMLTemplateElement::appropriate_template_contents_owner_document
 {
     if (!document.created_for_appropriate_template_contents()) {
         if (!document.associated_inert_template_document()) {
-            auto new_document = DOM::Document::create(Bindings::main_thread_internal_window_object());
+            auto new_document = DOM::Document::create(realm());
             new_document->set_created_for_appropriate_template_contents(true);
             new_document->set_document_type(document.document_type());
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLTextAreaElement::HTMLTextAreaElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLTextAreaElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLTextAreaElement"));
 }
 
 HTMLTextAreaElement::~HTMLTextAreaElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLTextAreaElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTimeElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTimeElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLTimeElement::HTMLTimeElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLTimeElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLTimeElement"));
 }
 
 HTMLTimeElement::~HTMLTimeElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTimeElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTimeElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLTimeElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
@@ -13,7 +13,7 @@ namespace Web::HTML {
 HTMLTitleElement::HTMLTitleElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLTitleElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLTitleElement"));
 }
 
 HTMLTitleElement::~HTMLTitleElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLTrackElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLTrackElement::HTMLTrackElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLTrackElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLTrackElement"));
 }
 
 HTMLTrackElement::~HTMLTrackElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLUListElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLUListElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLUListElement::HTMLUListElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLUListElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLUListElement"));
 }
 
 HTMLUListElement::~HTMLUListElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLUListElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLUListElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLUListElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLUnknownElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLUnknownElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLUnknownElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLUnknownElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLUnknownElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLUnknownElement::HTMLUnknownElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLUnknownElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLUnknownElement"));
 }
 
 HTMLUnknownElement::~HTMLUnknownElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLVideoElement.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 HTMLVideoElement::HTMLVideoElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLMediaElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("HTMLVideoElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "HTMLVideoElement"));
 }
 
 HTMLVideoElement::~HTMLVideoElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -4,21 +4,22 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/History.h>
 
 namespace Web::HTML {
 
-JS::NonnullGCPtr<History> History::create(HTML::Window& window, DOM::Document& document)
+JS::NonnullGCPtr<History> History::create(JS::Realm& realm, DOM::Document& document)
 {
-    return *window.heap().allocate<History>(window.realm(), window, document);
+    return *realm.heap().allocate<History>(realm, realm, document);
 }
 
-History::History(HTML::Window& window, DOM::Document& document)
-    : PlatformObject(window.realm())
+History::History(JS::Realm& realm, DOM::Document& document)
+    : PlatformObject(realm)
     , m_associated_document(document)
 {
-    set_prototype(&window.cached_web_prototype("History"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "History"));
 }
 
 History::~History() = default;
@@ -50,7 +51,7 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value, 
 
     // 2. If document is not fully active, then throw a "SecurityError" DOMException.
     if (!m_associated_document->is_fully_active())
-        return WebIDL::SecurityError::create(global_object(), "Cannot perform pushState or replaceState on a document that isn't fully active.");
+        return WebIDL::SecurityError::create(realm(), "Cannot perform pushState or replaceState on a document that isn't fully active.");
 
     // 3. Optionally, return. (For example, the user agent might disallow calls to these methods that are invoked on a timer,
     //    or from event listeners that are not triggered in response to a clear user action, or that are invoked in rapid succession.)

--- a/Userland/Libraries/LibWeb/HTML/History.h
+++ b/Userland/Libraries/LibWeb/HTML/History.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <LibJS/Heap/Handle.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -17,7 +16,7 @@ class History final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(History, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<History> create(HTML::Window&, DOM::Document&);
+    static JS::NonnullGCPtr<History> create(JS::Realm&, DOM::Document&);
 
     virtual ~History() override;
 
@@ -25,7 +24,7 @@ public:
     WebIDL::ExceptionOr<void> replace_state(JS::Value data, String const& unused, String const& url);
 
 private:
-    explicit History(HTML::Window&, DOM::Document&);
+    History(JS::Realm&, DOM::Document&);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/ImageData.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ImageData.cpp
@@ -6,14 +6,13 @@
 
 #include <LibGfx/Bitmap.h>
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/ImageData.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
-JS::GCPtr<ImageData> ImageData::create_with_size(HTML::Window& window, int width, int height)
+JS::GCPtr<ImageData> ImageData::create_with_size(JS::Realm& realm, int width, int height)
 {
-    auto& realm = window.realm();
 
     if (width <= 0 || height <= 0)
         return nullptr;
@@ -29,15 +28,15 @@ JS::GCPtr<ImageData> ImageData::create_with_size(HTML::Window& window, int width
     auto bitmap_or_error = Gfx::Bitmap::try_create_wrapper(Gfx::BitmapFormat::RGBA8888, Gfx::IntSize(width, height), 1, width * sizeof(u32), data->data().data());
     if (bitmap_or_error.is_error())
         return nullptr;
-    return realm.heap().allocate<ImageData>(realm, window, bitmap_or_error.release_value(), move(data));
+    return realm.heap().allocate<ImageData>(realm, realm, bitmap_or_error.release_value(), move(data));
 }
 
-ImageData::ImageData(HTML::Window& window, NonnullRefPtr<Gfx::Bitmap> bitmap, JS::NonnullGCPtr<JS::Uint8ClampedArray> data)
-    : PlatformObject(window.realm())
+ImageData::ImageData(JS::Realm& realm, NonnullRefPtr<Gfx::Bitmap> bitmap, JS::NonnullGCPtr<JS::Uint8ClampedArray> data)
+    : PlatformObject(realm)
     , m_bitmap(move(bitmap))
     , m_data(move(data))
 {
-    set_prototype(&window.cached_web_prototype("ImageData"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "ImageData"));
 }
 
 ImageData::~ImageData() = default;

--- a/Userland/Libraries/LibWeb/HTML/ImageData.h
+++ b/Userland/Libraries/LibWeb/HTML/ImageData.h
@@ -15,7 +15,7 @@ class ImageData final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(ImageData, Bindings::PlatformObject);
 
 public:
-    static JS::GCPtr<ImageData> create_with_size(HTML::Window&, int width, int height);
+    static JS::GCPtr<ImageData> create_with_size(JS::Realm&, int width, int height);
 
     virtual ~ImageData() override;
 
@@ -29,7 +29,7 @@ public:
     const JS::Uint8ClampedArray* data() const;
 
 private:
-    explicit ImageData(HTML::Window&, NonnullRefPtr<Gfx::Bitmap>, JS::NonnullGCPtr<JS::Uint8ClampedArray>);
+    ImageData(JS::Realm&, NonnullRefPtr<Gfx::Bitmap>, JS::NonnullGCPtr<JS::Uint8ClampedArray>);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/MessageChannel.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageChannel.cpp
@@ -4,28 +4,28 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/MessageChannel.h>
 #include <LibWeb/HTML/MessagePort.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
-JS::NonnullGCPtr<MessageChannel> MessageChannel::create_with_global_object(HTML::Window& window)
+JS::NonnullGCPtr<MessageChannel> MessageChannel::construct_impl(JS::Realm& realm)
 {
-    return *window.heap().allocate<MessageChannel>(window.realm(), window);
+    return *realm.heap().allocate<MessageChannel>(realm, realm);
 }
 
-MessageChannel::MessageChannel(HTML::Window& window)
-    : PlatformObject(window.realm())
+MessageChannel::MessageChannel(JS::Realm& realm)
+    : PlatformObject(realm)
 {
-    set_prototype(&window.cached_web_prototype("MessageChannel"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "MessageChannel"));
 
     // 1. Set this's port 1 to a new MessagePort in this's relevant Realm.
-    m_port1 = MessagePort::create(window);
+    m_port1 = MessagePort::create(realm);
 
     // 2. Set this's port 2 to a new MessagePort in this's relevant Realm.
-    m_port2 = MessagePort::create(window);
+    m_port2 = MessagePort::create(realm);
 
     // 3. Entangle this's port 1 and this's port 2.
     m_port1->entangle_with(*m_port2);

--- a/Userland/Libraries/LibWeb/HTML/MessageChannel.h
+++ b/Userland/Libraries/LibWeb/HTML/MessageChannel.h
@@ -16,7 +16,7 @@ class MessageChannel final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(MessageChannel, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<MessageChannel> create_with_global_object(HTML::Window&);
+    static JS::NonnullGCPtr<MessageChannel> construct_impl(JS::Realm&);
     virtual ~MessageChannel() override;
 
     MessagePort* port1();
@@ -26,7 +26,7 @@ public:
     MessagePort const* port2() const;
 
 private:
-    explicit MessageChannel(HTML::Window&);
+    explicit MessageChannel(JS::Realm&);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
@@ -4,28 +4,34 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/MessageEvent.h>
 #include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
-MessageEvent* MessageEvent::create(HTML::Window& window_object, FlyString const& event_name, MessageEventInit const& event_init)
+MessageEvent* MessageEvent::create(JS::Realm& realm, FlyString const& event_name, MessageEventInit const& event_init)
 {
-    return window_object.heap().allocate<MessageEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<MessageEvent>(realm, realm, event_name, event_init);
 }
 
-MessageEvent* MessageEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, MessageEventInit const& event_init)
+MessageEvent* MessageEvent::create(HTML::Window& window, FlyString const& event_name, MessageEventInit const& event_init)
 {
-    return create(window_object, event_name, event_init);
+    return create(window.realm(), event_name, event_init);
 }
 
-MessageEvent::MessageEvent(HTML::Window& window_object, FlyString const& event_name, MessageEventInit const& event_init)
-    : DOM::Event(window_object, event_name, event_init)
+MessageEvent* MessageEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, MessageEventInit const& event_init)
+{
+    return create(realm, event_name, event_init);
+}
+
+MessageEvent::MessageEvent(JS::Realm& realm, FlyString const& event_name, MessageEventInit const& event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_data(event_init.data)
     , m_origin(event_init.origin)
     , m_last_event_id(event_init.last_event_id)
 {
-    set_prototype(&window_object.cached_web_prototype("MessageEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "MessageEvent"));
 }
 
 MessageEvent::~MessageEvent() = default;

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
@@ -6,18 +6,12 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/MessageEvent.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
 MessageEvent* MessageEvent::create(JS::Realm& realm, FlyString const& event_name, MessageEventInit const& event_init)
 {
     return realm.heap().allocate<MessageEvent>(realm, realm, event_name, event_init);
-}
-
-MessageEvent* MessageEvent::create(HTML::Window& window, FlyString const& event_name, MessageEventInit const& event_init)
-{
-    return create(window.realm(), event_name, event_init);
 }
 
 MessageEvent* MessageEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, MessageEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.h
@@ -21,10 +21,11 @@ class MessageEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(MessageEvent, DOM::Event);
 
 public:
+    static MessageEvent* create(JS::Realm&, FlyString const& event_name, MessageEventInit const& event_init = {});
     static MessageEvent* create(HTML::Window&, FlyString const& event_name, MessageEventInit const& event_init = {});
-    static MessageEvent* create_with_global_object(HTML::Window&, FlyString const& event_name, MessageEventInit const& event_init);
+    static MessageEvent* construct_impl(JS::Realm&, FlyString const& event_name, MessageEventInit const& event_init);
 
-    MessageEvent(HTML::Window&, FlyString const& event_name, MessageEventInit const& event_init);
+    MessageEvent(JS::Realm&, FlyString const& event_name, MessageEventInit const& event_init);
     virtual ~MessageEvent() override;
 
     JS::Value data() const { return m_data; }

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.h
@@ -22,7 +22,6 @@ class MessageEvent : public DOM::Event {
 
 public:
     static MessageEvent* create(JS::Realm&, FlyString const& event_name, MessageEventInit const& event_init = {});
-    static MessageEvent* create(HTML::Window&, FlyString const& event_name, MessageEventInit const& event_init = {});
     static MessageEvent* construct_impl(JS::Realm&, FlyString const& event_name, MessageEventInit const& event_init);
 
     MessageEvent(JS::Realm&, FlyString const& event_name, MessageEventInit const& event_init);

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/MessageEvent.h>
 #include <LibWeb/HTML/MessagePort.h>
+#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -4,25 +4,25 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/EventDispatcher.h>
 #include <LibWeb/HTML/EventHandler.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/MessageEvent.h>
 #include <LibWeb/HTML/MessagePort.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
-JS::NonnullGCPtr<MessagePort> MessagePort::create(HTML::Window& window)
+JS::NonnullGCPtr<MessagePort> MessagePort::create(JS::Realm& realm)
 {
-    return *window.heap().allocate<MessagePort>(window.realm(), window);
+    return *realm.heap().allocate<MessagePort>(realm, realm);
 }
 
-MessagePort::MessagePort(HTML::Window& window)
-    : DOM::EventTarget(window.realm())
+MessagePort::MessagePort(JS::Realm& realm)
+    : DOM::EventTarget(realm)
 {
-    set_prototype(&window.cached_web_prototype("MessagePort"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "MessagePort"));
 }
 
 MessagePort::~MessagePort() = default;
@@ -92,7 +92,7 @@ void MessagePort::post_message(JS::Value message)
         MessageEventInit event_init {};
         event_init.data = message;
         event_init.origin = "<origin>";
-        target_port->dispatch_event(*MessageEvent::create(verify_cast<HTML::Window>(target_port->realm().global_object()), HTML::EventNames::message, event_init));
+        target_port->dispatch_event(*MessageEvent::create(target_port->realm(), HTML::EventNames::message, event_init));
     }));
 }
 

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.h
@@ -22,7 +22,7 @@ class MessagePort final : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(MessagePort, DOM::EventTarget);
 
 public:
-    static JS::NonnullGCPtr<MessagePort> create(HTML::Window&);
+    static JS::NonnullGCPtr<MessagePort> create(JS::Realm&);
 
     virtual ~MessagePort() override;
 
@@ -44,7 +44,7 @@ public:
 #undef __ENUMERATE
 
 private:
-    explicit MessagePort(HTML::Window&);
+    explicit MessagePort(JS::Realm&);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.cpp
@@ -4,26 +4,26 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/PageTransitionEvent.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
-PageTransitionEvent* PageTransitionEvent::create(HTML::Window& window_object, FlyString const& event_name, PageTransitionEventInit const& event_init)
+PageTransitionEvent* PageTransitionEvent::create(JS::Realm& realm, FlyString const& event_name, PageTransitionEventInit const& event_init)
 {
-    return window_object.heap().allocate<PageTransitionEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<PageTransitionEvent>(realm, realm, event_name, event_init);
 }
 
-PageTransitionEvent* PageTransitionEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, PageTransitionEventInit const& event_init)
+PageTransitionEvent* PageTransitionEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, PageTransitionEventInit const& event_init)
 {
-    return create(window_object, event_name, event_init);
+    return create(realm, event_name, event_init);
 }
 
-PageTransitionEvent::PageTransitionEvent(HTML::Window& window_object, FlyString const& event_name, PageTransitionEventInit const& event_init)
-    : DOM::Event(window_object, event_name, event_init)
+PageTransitionEvent::PageTransitionEvent(JS::Realm& realm, FlyString const& event_name, PageTransitionEventInit const& event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_persisted(event_init.persisted)
 {
-    set_prototype(&window_object.cached_web_prototype("PageTransitionEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "PageTransitionEvent"));
 }
 
 PageTransitionEvent::~PageTransitionEvent() = default;

--- a/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.h
@@ -18,10 +18,10 @@ class PageTransitionEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(PageTransitionEvent, DOM::Event);
 
 public:
-    static PageTransitionEvent* create(HTML::Window&, FlyString const& event_name, PageTransitionEventInit const& event_init);
-    static PageTransitionEvent* create_with_global_object(HTML::Window&, FlyString const& event_name, PageTransitionEventInit const& event_init);
+    static PageTransitionEvent* create(JS::Realm&, FlyString const& event_name, PageTransitionEventInit const& event_init);
+    static PageTransitionEvent* construct_impl(JS::Realm&, FlyString const& event_name, PageTransitionEventInit const& event_init);
 
-    PageTransitionEvent(HTML::Window&, FlyString const& event_name, PageTransitionEventInit const& event_init);
+    PageTransitionEvent(JS::Realm&, FlyString const& event_name, PageTransitionEventInit const& event_init);
 
     virtual ~PageTransitionEvent() override;
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -240,7 +240,7 @@ void HTMLParser::the_end()
         document->load_timing_info().dom_content_loaded_event_start_time = main_thread_event_loop().unsafe_shared_current_time();
 
         // 2. Fire an event named DOMContentLoaded at the Document object, with its bubbles attribute initialized to true.
-        auto content_loaded_event = DOM::Event::create(document->window(), HTML::EventNames::DOMContentLoaded);
+        auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded);
         content_loaded_event->set_bubbles(true);
         document->dispatch_event(*content_loaded_event);
 
@@ -281,7 +281,7 @@ void HTMLParser::the_end()
         // 5. Fire an event named load at window, with legacy target override flag set.
         // FIXME: The legacy target override flag is currently set by a virtual override of dispatch_event()
         //        We should reorganize this so that the flag appears explicitly here instead.
-        window->dispatch_event(*DOM::Event::create(document->window(), HTML::EventNames::load));
+        window->dispatch_event(*DOM::Event::create(document->realm(), HTML::EventNames::load));
 
         // FIXME: 6. Invoke WebDriver BiDi load complete with the Document's browsing context, and a new WebDriver BiDi navigation status whose id is the Document object's navigation id, status is "complete", and url is the Document object's URL.
 
@@ -3375,7 +3375,7 @@ DOM::Document& HTMLParser::document()
 
 Vector<JS::Handle<DOM::Node>> HTMLParser::parse_html_fragment(DOM::Element& context_element, StringView markup)
 {
-    auto temp_document = DOM::Document::create(context_element.window());
+    auto temp_document = DOM::Document::create(context_element.realm());
     auto parser = HTMLParser::create(*temp_document, markup, "utf-8");
     parser->m_context_element = JS::make_handle(context_element);
     parser->m_parsing_fragment = true;

--- a/Userland/Libraries/LibWeb/HTML/Path2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Path2D.cpp
@@ -4,22 +4,22 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/Path2D.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
-JS::NonnullGCPtr<Path2D> Path2D::create_with_global_object(HTML::Window& window, Optional<Variant<JS::Handle<Path2D>, String>> const& path)
+JS::NonnullGCPtr<Path2D> Path2D::construct_impl(JS::Realm& realm, Optional<Variant<JS::Handle<Path2D>, String>> const& path)
 {
-    return *window.heap().allocate<Path2D>(window.realm(), window, path);
+    return *realm.heap().allocate<Path2D>(realm, realm, path);
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-path2d
-Path2D::Path2D(HTML::Window& window, Optional<Variant<JS::Handle<Path2D>, String>> const& path)
-    : PlatformObject(window.realm())
+Path2D::Path2D(JS::Realm& realm, Optional<Variant<JS::Handle<Path2D>, String>> const& path)
+    : PlatformObject(realm)
     , CanvasPath(static_cast<Bindings::PlatformObject&>(*this))
 {
-    set_prototype(&window.cached_web_prototype("Path2D"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "Path2D"));
 
     // 1. Let output be a new Path2D object.
     // 2. If path is not given, then return output.

--- a/Userland/Libraries/LibWeb/HTML/Path2D.h
+++ b/Userland/Libraries/LibWeb/HTML/Path2D.h
@@ -21,12 +21,12 @@ class Path2D final
     WEB_PLATFORM_OBJECT(Path2D, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<Path2D> create_with_global_object(HTML::Window&, Optional<Variant<JS::Handle<Path2D>, String>> const& path);
+    static JS::NonnullGCPtr<Path2D> construct_impl(JS::Realm&, Optional<Variant<JS::Handle<Path2D>, String>> const& path);
 
     virtual ~Path2D() override;
 
 private:
-    Path2D(HTML::Window&, Optional<Variant<JS::Handle<Path2D>, String>> const&);
+    Path2D(JS::Realm&, Optional<Variant<JS::Handle<Path2D>, String>> const&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.cpp
@@ -4,27 +4,27 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/PromiseRejectionEvent.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
-PromiseRejectionEvent* PromiseRejectionEvent::create(HTML::Window& window_object, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
+PromiseRejectionEvent* PromiseRejectionEvent::create(JS::Realm& realm, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
 {
-    return window_object.heap().allocate<PromiseRejectionEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<PromiseRejectionEvent>(realm, realm, event_name, event_init);
 }
 
-PromiseRejectionEvent* PromiseRejectionEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
+PromiseRejectionEvent* PromiseRejectionEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
 {
-    return create(window_object, event_name, event_init);
+    return create(realm, event_name, event_init);
 }
 
-PromiseRejectionEvent::PromiseRejectionEvent(HTML::Window& window_object, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
-    : DOM::Event(window_object, event_name, event_init)
+PromiseRejectionEvent::PromiseRejectionEvent(JS::Realm& realm, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_promise(const_cast<JS::Promise*>(event_init.promise.cell()))
     , m_reason(event_init.reason)
 {
-    set_prototype(&window_object.cached_web_prototype("PromiseRejectionEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "PromiseRejectionEvent"));
 }
 
 PromiseRejectionEvent::~PromiseRejectionEvent() = default;

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <LibJS/Heap/Handle.h>
 #include <LibJS/Runtime/Promise.h>
 #include <LibJS/Runtime/Value.h>
 #include <LibWeb/DOM/Event.h>
@@ -22,10 +23,8 @@ class PromiseRejectionEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(PromiseRejectionEvent, DOM::Event);
 
 public:
-    static PromiseRejectionEvent* create(HTML::Window&, FlyString const& event_name, PromiseRejectionEventInit const& event_init = {});
-    static PromiseRejectionEvent* create_with_global_object(HTML::Window&, FlyString const& event_name, PromiseRejectionEventInit const& event_init);
-
-    PromiseRejectionEvent(HTML::Window&, FlyString const& event_name, PromiseRejectionEventInit const& event_init);
+    static PromiseRejectionEvent* create(JS::Realm&, FlyString const& event_name, PromiseRejectionEventInit const& event_init = {});
+    static PromiseRejectionEvent* construct_impl(JS::Realm&, FlyString const& event_name, PromiseRejectionEventInit const& event_init);
 
     virtual ~PromiseRejectionEvent() override;
 
@@ -34,6 +33,8 @@ public:
     JS::Value reason() const { return m_reason; }
 
 private:
+    PromiseRejectionEvent(JS::Realm&, FlyString const& event_name, PromiseRejectionEventInit const& event_init);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     JS::Promise* m_promise { nullptr };

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -124,7 +124,7 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
             dbgln("network error");
 
             // 2. Throw a "NetworkError" DOMException.
-            return throw_completion(WebIDL::NetworkError::create(settings.global_object(), "Script error."));
+            return throw_completion(WebIDL::NetworkError::create(settings.realm(), "Script error."));
         }
 
         // 3. Otherwise, rethrow errors is false. Perform the following steps:

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -286,7 +286,7 @@ EnvironmentSettingsObject& incumbent_settings_object()
     }
 
     // 3. Return context's Realm component's settings object.
-    return verify_cast<EnvironmentSettingsObject>(*context->realm->host_defined());
+    return Bindings::host_defined_environment_settings_object(*context->realm);
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#concept-incumbent-realm
@@ -310,7 +310,7 @@ EnvironmentSettingsObject& current_settings_object()
     auto& vm = event_loop.vm();
 
     // Then, the current settings object is the environment settings object of the current Realm Record.
-    return verify_cast<EnvironmentSettingsObject>(*vm.current_realm()->host_defined());
+    return Bindings::host_defined_environment_settings_object(*vm.current_realm());
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object
@@ -334,7 +334,7 @@ JS::Realm& relevant_realm(JS::Object const& object)
 EnvironmentSettingsObject& relevant_settings_object(JS::Object const& object)
 {
     // Then, the relevant settings object for a platform object o is the environment settings object of the relevant Realm for o.
-    return verify_cast<EnvironmentSettingsObject>(*relevant_realm(object).host_defined());
+    return Bindings::host_defined_environment_settings_object(relevant_realm(object));
 }
 
 EnvironmentSettingsObject& relevant_settings_object(DOM::Node const& node)

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -219,7 +219,7 @@ void EnvironmentSettingsObject::notify_about_rejected_promises(Badge<EventLoop>)
             // FIXME: This currently assumes that global is a WindowObject.
             auto& window = verify_cast<HTML::Window>(global);
 
-            auto promise_rejection_event = PromiseRejectionEvent::create(window, HTML::EventNames::unhandledrejection, event_init);
+            auto promise_rejection_event = PromiseRejectionEvent::create(window.realm(), HTML::EventNames::unhandledrejection, event_init);
 
             bool not_handled = window.dispatch_event(*promise_rejection_event);
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -12,7 +12,6 @@
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/Realm.h>
-#include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/Origin.h>
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -54,7 +54,9 @@ enum class RunScriptDecision {
 // https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object
 struct EnvironmentSettingsObject
     : public Environment
-    , public JS::Realm::HostDefined {
+    , public JS::Cell {
+    JS_CELL(EnvironmentSettingsObject, JS::Cell);
+
     virtual ~EnvironmentSettingsObject() override;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HostDefined.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h>
 #include <LibWeb/HTML/Window.h>
@@ -36,7 +38,7 @@ void WindowEnvironmentSettingsObject::setup(AK::URL const& creation_url, Nonnull
 
     // 3. Let settings object be a new environment settings object whose algorithms are defined as follows:
     // NOTE: See the functions defined for this class.
-    auto settings_object = adopt_own(*new WindowEnvironmentSettingsObject(window, move(execution_context)));
+    auto* settings_object = realm->heap().allocate<WindowEnvironmentSettingsObject>(*realm, window, move(execution_context));
 
     // 4. If reservedEnvironment is non-null, then:
     if (reserved_environment.has_value()) {
@@ -68,7 +70,14 @@ void WindowEnvironmentSettingsObject::setup(AK::URL const& creation_url, Nonnull
     settings_object->top_level_origin = top_level_origin;
 
     // 7. Set realm's [[HostDefined]] field to settings object.
-    realm->set_host_defined(move(settings_object));
+    // Non-Standard: We store the ESO next to the web intrinsics in a custom HostDefined object
+    auto* intrinsics = realm->heap().allocate<Bindings::Intrinsics>(*realm, *realm);
+    auto host_defined = make<Bindings::HostDefined>(*settings_object, *intrinsics);
+    realm->set_host_defined(move(host_defined));
+
+    // Non-Standard: We cannot fully initialize window object until *after* the we set up
+    //    the realm's [[HostDefined]] internal slot as the internal slot contains the web platform intrinsics
+    window.initialize_web_interfaces({});
 }
 
 // https://html.spec.whatwg.org/multipage/window-object.html#script-settings-for-window-objects:responsible-document

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h
@@ -12,6 +12,8 @@
 namespace Web::HTML {
 
 class WindowEnvironmentSettingsObject final : public EnvironmentSettingsObject {
+    JS_CELL(WindowEnvironmentSettingsObject, EnvironmentSettingsObject);
+
 public:
     static void setup(AK::URL const& creation_url, NonnullOwnPtr<JS::ExecutionContext>, Optional<Environment>, AK::URL top_level_creation_url, Origin top_level_origin);
 

--- a/Userland/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Storage.cpp
@@ -5,20 +5,20 @@
  */
 
 #include <AK/String.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/Storage.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
-JS::NonnullGCPtr<Storage> Storage::create(HTML::Window& window)
+JS::NonnullGCPtr<Storage> Storage::create(JS::Realm& realm)
 {
-    return *window.heap().allocate<Storage>(window.realm(), window);
+    return *realm.heap().allocate<Storage>(realm, realm);
 }
 
-Storage::Storage(HTML::Window& window)
-    : PlatformObject(window.realm())
+Storage::Storage(JS::Realm& realm)
+    : PlatformObject(realm)
 {
-    set_prototype(&window.cached_web_prototype("Storage"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "Storage"));
 }
 
 Storage::~Storage() = default;

--- a/Userland/Libraries/LibWeb/HTML/Storage.h
+++ b/Userland/Libraries/LibWeb/HTML/Storage.h
@@ -16,7 +16,7 @@ class Storage : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(Storage, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<Storage> create(HTML::Window&);
+    static JS::NonnullGCPtr<Storage> create(JS::Realm&);
     ~Storage();
 
     size_t length() const;
@@ -33,7 +33,7 @@ public:
     void dump() const;
 
 private:
-    explicit Storage(HTML::Window&);
+    explicit Storage(JS::Realm&);
 
     void reorder();
     void broadcast(String const& key, String const& old_value, String const& new_value);

--- a/Userland/Libraries/LibWeb/HTML/SubmitEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SubmitEvent.cpp
@@ -4,26 +4,26 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/SubmitEvent.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
-SubmitEvent* SubmitEvent::create(HTML::Window& window_object, FlyString const& event_name, SubmitEventInit const& event_init)
+SubmitEvent* SubmitEvent::create(JS::Realm& realm, FlyString const& event_name, SubmitEventInit const& event_init)
 {
-    return window_object.heap().allocate<SubmitEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<SubmitEvent>(realm, realm, event_name, event_init);
 }
 
-SubmitEvent* SubmitEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, SubmitEventInit const& event_init)
+SubmitEvent* SubmitEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, SubmitEventInit const& event_init)
 {
-    return create(window_object, event_name, event_init);
+    return create(realm, event_name, event_init);
 }
 
-SubmitEvent::SubmitEvent(HTML::Window& window_object, FlyString const& event_name, SubmitEventInit const& event_init)
-    : DOM::Event(window_object, event_name, event_init)
+SubmitEvent::SubmitEvent(JS::Realm& realm, FlyString const& event_name, SubmitEventInit const& event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_submitter(event_init.submitter)
 {
-    set_prototype(&window_object.cached_web_prototype("SubmitEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "SubmitEvent"));
 }
 
 SubmitEvent::~SubmitEvent() = default;

--- a/Userland/Libraries/LibWeb/HTML/SubmitEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/SubmitEvent.h
@@ -19,16 +19,16 @@ class SubmitEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(SubmitEvent, DOM::Event);
 
 public:
-    static SubmitEvent* create(HTML::Window&, FlyString const& event_name, SubmitEventInit const& event_init);
-    static SubmitEvent* create_with_global_object(HTML::Window&, FlyString const& event_name, SubmitEventInit const& event_init);
+    static SubmitEvent* create(JS::Realm&, FlyString const& event_name, SubmitEventInit const& event_init);
+    static SubmitEvent* construct_impl(JS::Realm&, FlyString const& event_name, SubmitEventInit const& event_init);
 
     virtual ~SubmitEvent() override;
-
-    SubmitEvent(HTML::Window&, FlyString const& event_name, SubmitEventInit const& event_init);
 
     JS::GCPtr<HTMLElement> submitter() const { return m_submitter; }
 
 private:
+    SubmitEvent(JS::Realm&, FlyString const& event_name, SubmitEventInit const& event_init);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     JS::GCPtr<HTMLElement> m_submitter;

--- a/Userland/Libraries/LibWeb/HTML/TextMetrics.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TextMetrics.cpp
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/TextMetrics.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
-JS::NonnullGCPtr<TextMetrics> TextMetrics::create(HTML::Window& window)
+JS::NonnullGCPtr<TextMetrics> TextMetrics::create(JS::Realm& realm)
 {
-    return *window.heap().allocate<TextMetrics>(window.realm(), window);
+    return *realm.heap().allocate<TextMetrics>(realm, realm);
 }
 
-TextMetrics::TextMetrics(HTML::Window& window)
-    : PlatformObject(window.realm())
+TextMetrics::TextMetrics(JS::Realm& realm)
+    : PlatformObject(realm)
 {
-    set_prototype(&window.cached_web_prototype("TextMetrics"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "TextMetrics"));
 }
 
 TextMetrics::~TextMetrics() = default;

--- a/Userland/Libraries/LibWeb/HTML/TextMetrics.h
+++ b/Userland/Libraries/LibWeb/HTML/TextMetrics.h
@@ -14,7 +14,7 @@ class TextMetrics : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(TextMetrics, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<TextMetrics> create(HTML::Window&);
+    static JS::NonnullGCPtr<TextMetrics> create(JS::Realm&);
 
     virtual ~TextMetrics() override;
 
@@ -45,7 +45,7 @@ public:
     void set_ideographic_baseline(double baseline) { m_ideographic_baseline = baseline; }
 
 private:
-    explicit TextMetrics(HTML::Window&);
+    explicit TextMetrics(JS::Realm&);
 
     double m_width { 0 };
     double m_actual_bounding_box_left { 0 };

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -96,25 +96,11 @@ void Window::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_screen.ptr());
     visitor.visit(m_location_object);
     visitor.visit(m_crypto);
-    for (auto& it : m_prototypes)
-        visitor.visit(it.value);
-    for (auto& it : m_constructors)
-        visitor.visit(it.value);
     for (auto& it : m_timers)
         visitor.visit(it.value.ptr());
 }
 
 Window::~Window() = default;
-
-JS::Object& Window::cached_web_prototype(String const& class_name)
-{
-    auto it = m_prototypes.find(class_name);
-    if (it == m_prototypes.end()) {
-        dbgln("Missing prototype: {}", class_name);
-    }
-    VERIFY(it != m_prototypes.end());
-    return *it->value;
-}
 
 HighResolutionTime::Performance& Window::performance()
 {
@@ -750,7 +736,10 @@ void Window::initialize(JS::Realm& realm)
 
     // FIXME: This is a hack..
     realm.set_global_object(this, this);
+}
 
+void Window::initialize_web_interfaces(Badge<WindowEnvironmentSettingsObject>)
+{
     ADD_WINDOW_OBJECT_INTERFACES;
 
     Object::set_prototype(&ensure_web_prototype<Bindings::WindowPrototype>("Window"));

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -658,7 +658,7 @@ void Window::invoke_idle_callbacks()
         // 1. Pop the top callback from window's list of runnable idle callbacks.
         auto callback = m_runnable_idle_callbacks.take_first();
         // 2. Let deadlineArg be a new IdleDeadline whose [get deadline time algorithm] is getDeadline.
-        auto deadline_arg = RequestIdleCallback::IdleDeadline::create(*this);
+        auto deadline_arg = RequestIdleCallback::IdleDeadline::create(realm());
         // 3. Call callback with deadlineArg as its argument. If an uncaught runtime script error occurs, then report the exception.
         auto result = callback->invoke(deadline_arg);
         if (result.is_error())
@@ -744,7 +744,7 @@ void Window::initialize_web_interfaces(Badge<WindowEnvironmentSettingsObject>)
 
     Object::set_prototype(&Bindings::ensure_web_prototype<Bindings::WindowPrototype>(realm, "Window"));
 
-    m_crypto = Crypto::Crypto::create(*this);
+    m_crypto = Crypto::Crypto::create(realm);
 
     // FIXME: These should be native accessors, not properties
     define_direct_property("window", this, JS::Attribute::Enumerable);

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -479,7 +479,7 @@ void Window::fire_a_page_transition_event(FlyString const& event_name, bool pers
     // with the persisted attribute initialized to persisted,
     HTML::PageTransitionEventInit event_init {};
     event_init.persisted = persisted;
-    auto event = HTML::PageTransitionEvent::create(associated_document().window(), event_name, event_init);
+    auto event = HTML::PageTransitionEvent::create(associated_document().realm(), event_name, event_init);
 
     // ...the cancelable attribute initialized to true,
     event->set_cancelable(true);
@@ -539,7 +539,7 @@ JS::NonnullGCPtr<HTML::Storage> Window::local_storage()
 
     static HashMap<Origin, JS::Handle<HTML::Storage>> local_storage_per_origin;
     auto storage = local_storage_per_origin.ensure(associated_document().origin(), [this]() -> JS::Handle<HTML::Storage> {
-        return *HTML::Storage::create(*this);
+        return *HTML::Storage::create(realm());
     });
     return *storage;
 }
@@ -551,7 +551,7 @@ JS::NonnullGCPtr<HTML::Storage> Window::session_storage()
 
     static HashMap<Origin, JS::Handle<HTML::Storage>> session_storage_per_origin;
     auto storage = session_storage_per_origin.ensure(associated_document().origin(), [this]() -> JS::Handle<HTML::Storage> {
-        return *HTML::Storage::create(*this);
+        return *HTML::Storage::create(realm());
     });
     return *storage;
 }
@@ -590,7 +590,7 @@ WebIDL::ExceptionOr<void> Window::post_message_impl(JS::Value message, String co
         HTML::MessageEventInit event_init {};
         event_init.data = message;
         event_init.origin = "<origin>";
-        dispatch_event(*HTML::MessageEvent::create(*this, HTML::EventNames::message, event_init));
+        dispatch_event(*HTML::MessageEvent::create(realm(), HTML::EventNames::message, event_init));
     });
     return {};
 }
@@ -742,7 +742,7 @@ void Window::initialize_web_interfaces(Badge<WindowEnvironmentSettingsObject>)
 {
     ADD_WINDOW_OBJECT_INTERFACES;
 
-    Object::set_prototype(&ensure_web_prototype<Bindings::WindowPrototype>("Window"));
+    Object::set_prototype(&Bindings::ensure_web_prototype<Bindings::WindowPrototype>(realm, "Window"));
 
     m_crypto = Crypto::Crypto::create(*this);
 
@@ -1064,7 +1064,7 @@ JS_DEFINE_NATIVE_FUNCTION(Window::btoa)
     byte_string.ensure_capacity(string.length());
     for (u32 code_point : Utf8View(string)) {
         if (code_point > 0xff)
-            return throw_completion(WebIDL::InvalidCharacterError::create(vm.current_realm()->global_object(), "Data contains characters outside the range U+0000 and U+00FF"));
+            return throw_completion(WebIDL::InvalidCharacterError::create(*vm.current_realm(), "Data contains characters outside the range U+0000 and U+00FF"));
         byte_string.append(code_point);
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -173,20 +173,6 @@ public:
     Bindings::LocationObject* location_object() { return m_location_object; }
     Bindings::LocationObject const* location_object() const { return m_location_object; }
 
-    JS::Object& cached_web_prototype(String const& class_name) { return Bindings::cached_web_prototype(realm(), class_name); }
-
-    template<typename T>
-    JS::Object& ensure_web_prototype(String const& class_name)
-    {
-        return Bindings::ensure_web_prototype<T>(realm(), class_name);
-    }
-
-    template<typename T>
-    JS::NativeFunction& ensure_web_constructor(String const& class_name)
-    {
-        return Bindings::ensure_web_constructor<T>(realm(), class_name);
-    }
-
     virtual JS::ThrowCompletionOr<bool> internal_set_prototype_of(JS::Object* prototype) override;
 
     CrossOriginPropertyDescriptorMap const& cross_origin_property_descriptor_map() const { return m_cross_origin_property_descriptor_map; }

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -90,7 +90,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> WindowProxy::internal_ge
                 return Optional<JS::PropertyDescriptor> {};
 
             // 2. Throw a "SecurityError" DOMException.
-            return throw_completion(WebIDL::SecurityError::create(window(), String::formatted("Can't access property '{}' on cross-origin object", property_key)));
+            return throw_completion(WebIDL::SecurityError::create(m_window->realm(), String::formatted("Can't access property '{}' on cross-origin object", property_key)));
         }
 
         // 6. Return PropertyDescriptor{ [[Value]]: value, [[Writable]]: false, [[Enumerable]]: true, [[Configurable]]: true }.
@@ -140,7 +140,7 @@ JS::ThrowCompletionOr<bool> WindowProxy::internal_define_own_property(JS::Proper
     }
 
     // 3. Throw a "SecurityError" DOMException.
-    return throw_completion(WebIDL::SecurityError::create(window(), String::formatted("Can't define property '{}' on cross-origin object", property_key)));
+    return throw_completion(WebIDL::SecurityError::create(m_window->realm(), String::formatted("Can't define property '{}' on cross-origin object", property_key)));
 }
 
 // 7.4.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-get
@@ -213,7 +213,7 @@ JS::ThrowCompletionOr<bool> WindowProxy::internal_delete(JS::PropertyKey const& 
     }
 
     // 3. Throw a "SecurityError" DOMException.
-    return throw_completion(WebIDL::SecurityError::create(window(), String::formatted("Can't delete property '{}' on cross-origin object", property_key)));
+    return throw_completion(WebIDL::SecurityError::create(m_window->realm(), String::formatted("Can't delete property '{}' on cross-origin object", property_key)));
 }
 
 // 7.4.10 [[OwnPropertyKeys]] ( ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-ownpropertykeys

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -25,9 +25,9 @@ Worker::Worker(FlyString const& script_url, WorkerOptions const options, DOM::Do
     , m_worker_vm(JS::VM::create(adopt_own(m_custom_data)))
     , m_interpreter(JS::Interpreter::create<JS::GlobalObject>(m_worker_vm))
     , m_interpreter_scope(*m_interpreter)
-    , m_implicit_port(MessagePort::create(document.window()))
+    , m_implicit_port(MessagePort::create(document.realm()))
 {
-    set_prototype(&document.window().cached_web_prototype("Worker"));
+    set_prototype(&Bindings::cached_web_prototype(document.realm(), "Worker"));
 }
 
 void Worker::visit_edges(Cell::Visitor& visitor)
@@ -63,7 +63,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(FlyString const& sc
     // 4. If this fails, throw a "SyntaxError" DOMException.
     if (!url.is_valid()) {
         dbgln_if(WEB_WORKER_DEBUG, "WebWorker: Invalid URL loaded '{}'.", script_url);
-        return WebIDL::SyntaxError::create(document.global_object(), "url is not valid");
+        return WebIDL::SyntaxError::create(document.realm(), "url is not valid");
     }
 
     // 5. Let worker URL be the resulting URL record.
@@ -72,7 +72,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(FlyString const& sc
     auto worker = document.heap().allocate<Worker>(document.realm(), script_url, options, document);
 
     // 7. Let outside port be a new MessagePort in outside settings's Realm.
-    auto outside_port = MessagePort::create(verify_cast<HTML::Window>(outside_settings.realm().global_object()));
+    auto outside_port = MessagePort::create(outside_settings.realm());
 
     // 8. Associate the outside port with worker
     worker->m_outside_port = outside_port;
@@ -86,7 +86,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(FlyString const& sc
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#run-a-worker
-void Worker::run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_settings, MessagePort& outside_port, WorkerOptions const options)
+void Worker::run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_settings, MessagePort& outside_port, WorkerOptions const& options)
 {
     // 1. Let is shared be true if worker is a SharedWorker object, and false otherwise.
     // FIXME: SharedWorker support
@@ -162,7 +162,7 @@ void Worker::run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_setti
                 MessageEventInit event_init {};
                 event_init.data = message;
                 event_init.origin = "<origin>";
-                dispatch_event(*MessageEvent::create(*m_worker_window, HTML::EventNames::message, event_init));
+                dispatch_event(*MessageEvent::create(*m_worker_realm, HTML::EventNames::message, event_init));
             }));
 
             return JS::js_undefined();
@@ -259,7 +259,7 @@ void Worker::run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_setti
             // FIXME: Global scope association
 
             // 16. Let inside port be a new MessagePort object in inside settings's Realm.
-            auto inside_port = MessagePort::create(*m_worker_window);
+            auto inside_port = MessagePort::create(m_inner_settings->realm());
 
             // 17. Associate inside port with worker global scope.
             // FIXME: Global scope association

--- a/Userland/Libraries/LibWeb/HTML/Worker.h
+++ b/Userland/Libraries/LibWeb/HTML/Worker.h
@@ -37,8 +37,9 @@ class Worker : public DOM::EventTarget {
 
 public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> create(FlyString const& script_url, WorkerOptions const options, DOM::Document& document);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> create_with_global_object(HTML::Window& window, FlyString const& script_url, WorkerOptions const options)
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> construct_impl(JS::Realm& realm, FlyString const& script_url, WorkerOptions const options)
     {
+        auto& window = verify_cast<HTML::Window>(realm.global_object());
         return Worker::create(script_url, options, window.associated_document());
     }
 
@@ -92,7 +93,7 @@ private:
     //        There should be *no* Window object in a Worker context.
     JS::GCPtr<HTML::Window> m_worker_window;
 
-    void run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_settings, MessagePort& outside_port, WorkerOptions const options);
+    void run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_settings, MessagePort& outside_port, WorkerOptions const& options);
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Worker.h
+++ b/Userland/Libraries/LibWeb/HTML/Worker.h
@@ -78,7 +78,7 @@ private:
 
     NonnullRefPtr<JS::VM> m_worker_vm;
     NonnullOwnPtr<JS::Interpreter> m_interpreter;
-    WeakPtr<WorkerEnvironmentSettingsObject> m_inner_settings;
+    JS::GCPtr<WorkerEnvironmentSettingsObject> m_inner_settings;
     JS::VM::InterpreterExecutionScope m_interpreter_scope;
     RefPtr<WorkerDebugConsoleClient> m_console;
 

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -131,7 +131,7 @@ WebIDL::ExceptionOr<String> WorkerGlobalScope::btoa(String const& data) const
     byte_string.ensure_capacity(data.length());
     for (u32 code_point : Utf8View(data)) {
         if (code_point > 0xff)
-            return WebIDL::InvalidCharacterError::create(global_object(), "Data contains characters outside the range U+0000 and U+00FF");
+            return WebIDL::InvalidCharacterError::create(realm(), "Data contains characters outside the range U+0000 and U+00FF");
         byte_string.append(code_point);
     }
 
@@ -151,7 +151,7 @@ WebIDL::ExceptionOr<String> WorkerGlobalScope::atob(String const& data) const
 
     // 2. If decodedData is failure, then throw an "InvalidCharacterError" DOMException.
     if (decoded_data.is_error())
-        return WebIDL::InvalidCharacterError::create(global_object(), "Input string is not valid base64 data");
+        return WebIDL::InvalidCharacterError::create(realm(), "Input string is not valid base64 data");
 
     // 3. Return decodedData.
     // decode_base64() returns a byte string. LibJS uses UTF-8 for strings. Use Latin1Decoder to convert bytes 128-255 to UTF-8.

--- a/Userland/Libraries/LibWeb/HTML/WorkerNavigator.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerNavigator.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Heap/Heap.h>
 #include <LibWeb/HTML/WorkerGlobalScope.h>
 #include <LibWeb/HTML/WorkerNavigator.h>
 

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
@@ -17,7 +17,7 @@ Performance::Performance(HTML::Window& window)
     : DOM::EventTarget(window.realm())
     , m_window(window)
 {
-    set_prototype(&window.cached_web_prototype("Performance"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "Performance"));
     m_timer.start();
 }
 

--- a/Userland/Libraries/LibWeb/Infra/JSON.cpp
+++ b/Userland/Libraries/LibWeb/Infra/JSON.cpp
@@ -53,13 +53,12 @@ WebIDL::ExceptionOr<String> serialize_javascript_value_to_json_string(JS::VM& vm
 WebIDL::ExceptionOr<ByteBuffer> serialize_javascript_value_to_json_bytes(JS::VM& vm, JS::Value value)
 {
     auto& realm = *vm.current_realm();
-    auto& global_object = realm.global_object();
 
     // 1. Let string be the result of serializing a JavaScript value to a JSON string given value.
     auto string = TRY(serialize_javascript_value_to_json_string(vm, value));
 
     // 2. Return the result of running UTF-8 encode on string. [ENCODING]
-    return TRY_OR_RETURN_OOM(global_object, ByteBuffer::copy(string.bytes()));
+    return TRY_OR_RETURN_OOM(realm, ByteBuffer::copy(string.bytes()));
 }
 
 }

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -4,26 +4,26 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Element.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/IntersectionObserver/IntersectionObserver.h>
 
 namespace Web::IntersectionObserver {
 
 // https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-intersectionobserver
-JS::NonnullGCPtr<IntersectionObserver> IntersectionObserver::create_with_global_object(HTML::Window& window, WebIDL::CallbackType* callback, IntersectionObserverInit const& options)
+JS::NonnullGCPtr<IntersectionObserver> IntersectionObserver::construct_impl(JS::Realm& realm, WebIDL::CallbackType* callback, IntersectionObserverInit const& options)
 {
     // FIXME: Implement
     (void)callback;
     (void)options;
 
-    return *window.heap().allocate<IntersectionObserver>(window.realm(), window);
+    return *realm.heap().allocate<IntersectionObserver>(realm, realm);
 }
 
-IntersectionObserver::IntersectionObserver(HTML::Window& window)
-    : PlatformObject(window.realm())
+IntersectionObserver::IntersectionObserver(JS::Realm& realm)
+    : PlatformObject(realm)
 {
-    set_prototype(&window.cached_web_prototype("IntersectionObserver"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "IntersectionObserver"));
 }
 
 IntersectionObserver::~IntersectionObserver() = default;

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
@@ -22,7 +22,7 @@ class IntersectionObserver : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(IntersectionObserver, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<IntersectionObserver> create_with_global_object(HTML::Window&, WebIDL::CallbackType* callback, IntersectionObserverInit const& options = {});
+    static JS::NonnullGCPtr<IntersectionObserver> construct_impl(JS::Realm&, WebIDL::CallbackType* callback, IntersectionObserverInit const& options = {});
 
     virtual ~IntersectionObserver() override;
 
@@ -31,7 +31,7 @@ public:
     void disconnect();
 
 private:
-    explicit IntersectionObserver(HTML::Window&);
+    explicit IntersectionObserver(JS::Realm&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/NavigationTiming/PerformanceTiming.cpp
+++ b/Userland/Libraries/LibWeb/NavigationTiming/PerformanceTiming.cpp
@@ -12,7 +12,7 @@ PerformanceTiming::PerformanceTiming(HTML::Window& window)
     : PlatformObject(window.realm())
     , m_window(window)
 {
-    set_prototype(&window.cached_web_prototype("PerformanceTiming"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "PerformanceTiming"));
 }
 
 PerformanceTiming::~PerformanceTiming() = default;

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -12,7 +12,6 @@
 #include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/HTMLIFrameElement.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/InitialContainingBlock.h>
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/Page.h>

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -203,12 +203,12 @@ bool EventHandler::handle_mouseup(Gfx::IntPoint const& position, unsigned button
             }
 
             auto offset = compute_mouse_event_offset(position, *layout_node);
-            node->dispatch_event(*UIEvents::MouseEvent::create_from_platform_event(node->document().window(), UIEvents::EventNames::mouseup, offset.x(), offset.y(), position.x(), position.y(), button));
+            node->dispatch_event(*UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mouseup, offset.x(), offset.y(), position.x(), position.y(), button));
             handled_event = true;
 
             bool run_activation_behavior = true;
             if (node.ptr() == m_mousedown_target && button == GUI::MouseButton::Primary) {
-                run_activation_behavior = node->dispatch_event(*UIEvents::MouseEvent::create_from_platform_event(node->document().window(), UIEvents::EventNames::click, offset.x(), offset.y(), position.x(), position.y(), button));
+                run_activation_behavior = node->dispatch_event(*UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, offset.x(), offset.y(), position.x(), position.y(), button));
             }
 
             if (run_activation_behavior) {
@@ -332,7 +332,7 @@ bool EventHandler::handle_mousedown(Gfx::IntPoint const& position, unsigned butt
 
         m_mousedown_target = node.ptr();
         auto offset = compute_mouse_event_offset(position, *layout_node);
-        node->dispatch_event(*UIEvents::MouseEvent::create_from_platform_event(node->document().window(), UIEvents::EventNames::mousedown, offset.x(), offset.y(), position.x(), position.y(), button));
+        node->dispatch_event(*UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousedown, offset.x(), offset.y(), position.x(), position.y(), button));
     }
 
     // NOTE: Dispatching an event may have disturbed the world.
@@ -453,7 +453,7 @@ bool EventHandler::handle_mousemove(Gfx::IntPoint const& position, unsigned butt
             }
 
             auto offset = compute_mouse_event_offset(position, *layout_node);
-            node->dispatch_event(*UIEvents::MouseEvent::create_from_platform_event(node->document().window(), UIEvents::EventNames::mousemove, offset.x(), offset.y(), position.x(), position.y()));
+            node->dispatch_event(*UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousemove, offset.x(), offset.y(), position.x(), position.y()));
             // NOTE: Dispatching an event may have disturbed the world.
             if (!paint_root() || paint_root() != node->document().paint_box())
                 return true;
@@ -542,7 +542,7 @@ bool EventHandler::handle_doubleclick(Gfx::IntPoint const& position, unsigned bu
         return false;
 
     auto offset = compute_mouse_event_offset(position, *layout_node);
-    node->dispatch_event(*UIEvents::MouseEvent::create_from_platform_event(node->document().window(), UIEvents::EventNames::dblclick, offset.x(), offset.y(), position.x(), position.y(), button));
+    node->dispatch_event(*UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::dblclick, offset.x(), offset.y(), position.x(), position.y(), button));
 
     // NOTE: Dispatching an event may have disturbed the world.
     if (!paint_root() || paint_root() != node->document().paint_box())
@@ -721,7 +721,7 @@ bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_poin
         return true;
     }
 
-    auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->window(), UIEvents::EventNames::keydown, key, modifiers, code_point);
+    auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), UIEvents::EventNames::keydown, key, modifiers, code_point);
 
     if (JS::GCPtr<DOM::Element> focused_element = document->focused_element())
         return focused_element->dispatch_event(*event);
@@ -738,7 +738,7 @@ bool EventHandler::handle_keyup(KeyCode key, unsigned modifiers, u32 code_point)
     if (!document)
         return false;
 
-    auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->window(), UIEvents::EventNames::keyup, key, modifiers, code_point);
+    auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), UIEvents::EventNames::keyup, key, modifiers, code_point);
 
     if (JS::GCPtr<DOM::Element> focused_element = document->focused_element())
         return document->focused_element()->dispatch_event(*event);

--- a/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.cpp
+++ b/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.cpp
@@ -11,16 +11,16 @@
 
 namespace Web::RequestIdleCallback {
 
-JS::NonnullGCPtr<IdleDeadline> IdleDeadline::create(HTML::Window& window, bool did_timeout)
+JS::NonnullGCPtr<IdleDeadline> IdleDeadline::create(JS::Realm& realm, bool did_timeout)
 {
-    return *window.heap().allocate<IdleDeadline>(window.realm(), window, did_timeout);
+    return *realm.heap().allocate<IdleDeadline>(realm, realm, did_timeout);
 }
 
-IdleDeadline::IdleDeadline(HTML::Window& window, bool did_timeout)
-    : PlatformObject(window.realm())
+IdleDeadline::IdleDeadline(JS::Realm& realm, bool did_timeout)
+    : PlatformObject(realm)
     , m_did_timeout(did_timeout)
 {
-    set_prototype(&window.cached_web_prototype("IdleDeadline"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "IdleDeadline"));
 }
 
 IdleDeadline::~IdleDeadline() = default;

--- a/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.h
+++ b/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.h
@@ -16,14 +16,14 @@ class IdleDeadline final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(IdleDeadline, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<IdleDeadline> create(HTML::Window&, bool did_timeout = false);
+    static JS::NonnullGCPtr<IdleDeadline> create(JS::Realm&, bool did_timeout = false);
     virtual ~IdleDeadline() override;
 
     double time_remaining() const;
     bool did_timeout() const { return m_did_timeout; }
 
 private:
-    IdleDeadline(HTML::Window&, bool did_timeout);
+    IdleDeadline(JS::Realm&, bool did_timeout);
 
     bool m_did_timeout { false };
 };

--- a/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
+++ b/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
@@ -4,24 +4,24 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Element.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/ResizeObserver/ResizeObserver.h>
 
 namespace Web::ResizeObserver {
 
 // https://drafts.csswg.org/resize-observer/#dom-resizeobserver-resizeobserver
-JS::NonnullGCPtr<ResizeObserver> ResizeObserver::create_with_global_object(HTML::Window& window, WebIDL::CallbackType* callback)
+JS::NonnullGCPtr<ResizeObserver> ResizeObserver::construct_impl(JS::Realm& realm, WebIDL::CallbackType* callback)
 {
     // FIXME: Implement
     (void)callback;
-    return *window.heap().allocate<ResizeObserver>(window.realm(), window);
+    return *realm.heap().allocate<ResizeObserver>(realm, realm);
 }
 
-ResizeObserver::ResizeObserver(HTML::Window& window)
-    : PlatformObject(window.realm())
+ResizeObserver::ResizeObserver(JS::Realm& realm)
+    : PlatformObject(realm)
 {
-    set_prototype(&window.cached_web_prototype("ResizeObserver"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "ResizeObserver"));
 }
 
 ResizeObserver::~ResizeObserver() = default;

--- a/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.h
+++ b/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.h
@@ -19,7 +19,7 @@ class ResizeObserver : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(ResizeObserver, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<ResizeObserver> create_with_global_object(HTML::Window&, WebIDL::CallbackType* callback);
+    static JS::NonnullGCPtr<ResizeObserver> construct_impl(JS::Realm&, WebIDL::CallbackType* callback);
 
     virtual ~ResizeObserver() override;
 
@@ -28,7 +28,7 @@ public:
     void disconnect();
 
 private:
-    explicit ResizeObserver(HTML::Window&);
+    explicit ResizeObserver(JS::Realm&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedLength.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedLength.cpp
@@ -4,22 +4,22 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/SVG/SVGAnimatedLength.h>
 
 namespace Web::SVG {
 
-JS::NonnullGCPtr<SVGAnimatedLength> SVGAnimatedLength::create(HTML::Window& window, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val)
+JS::NonnullGCPtr<SVGAnimatedLength> SVGAnimatedLength::create(JS::Realm& realm, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val)
 {
-    return *window.heap().allocate<SVGAnimatedLength>(window.realm(), window, move(base_val), move(anim_val));
+    return *realm.heap().allocate<SVGAnimatedLength>(realm, realm, move(base_val), move(anim_val));
 }
 
-SVGAnimatedLength::SVGAnimatedLength(HTML::Window& window, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val)
-    : PlatformObject(window.realm())
+SVGAnimatedLength::SVGAnimatedLength(JS::Realm& realm, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val)
+    : PlatformObject(realm)
     , m_base_val(move(base_val))
     , m_anim_val(move(anim_val))
 {
-    set_prototype(&window.cached_web_prototype("SVGAnimatedLength"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "SVGAnimatedLength"));
 
     // The object referenced by animVal will always be distinct from the one referenced by baseVal, even when the attribute is not animated.
     VERIFY(m_base_val.ptr() != m_anim_val.ptr());

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedLength.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedLength.h
@@ -16,14 +16,14 @@ class SVGAnimatedLength final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(SVGAnimatedLength, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<SVGAnimatedLength> create(HTML::Window&, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val);
+    static JS::NonnullGCPtr<SVGAnimatedLength> create(JS::Realm&, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val);
     virtual ~SVGAnimatedLength() override;
 
     JS::NonnullGCPtr<SVGLength> base_val() const { return m_base_val; }
     JS::NonnullGCPtr<SVGLength> anim_val() const { return m_anim_val; }
 
 private:
-    SVGAnimatedLength(HTML::Window&, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val);
+    SVGAnimatedLength(JS::Realm&, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGCircleElement.h>
@@ -14,7 +14,7 @@ namespace Web::SVG {
 SVGCircleElement::SVGCircleElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGeometryElement(document, qualified_name)
 {
-    set_prototype(&window().cached_web_prototype("SVGCircleElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGCircleElement"));
 }
 
 void SVGCircleElement::parse_attribute(FlyString const& name, String const& value)
@@ -77,9 +77,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGCircleElement::cx() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_center_x.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_center_x.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_center_x.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_center_x.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#CircleElementCYAttribute
@@ -87,9 +87,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGCircleElement::cy() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_center_y.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_center_y.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_center_y.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_center_y.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#CircleElementRAttribute
@@ -97,9 +97,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGCircleElement::r() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_radius.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_radius.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_radius.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_radius.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
@@ -12,7 +12,7 @@ namespace Web::SVG {
 SVGClipPathElement::SVGClipPathElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("SVGClipPathElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGClipPathElement"));
 }
 
 SVGClipPathElement::~SVGClipPathElement()

--- a/Userland/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/SVG/SVGClipPathElement.h>
 
 namespace Web::SVG {

--- a/Userland/Libraries/LibWeb/SVG/SVGDefsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDefsElement.cpp
@@ -12,7 +12,7 @@ namespace Web::SVG {
 SVGDefsElement::SVGDefsElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGraphicsElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("SVGDefsElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGDefsElement"));
 }
 
 SVGDefsElement::~SVGDefsElement()

--- a/Userland/Libraries/LibWeb/SVG/SVGDefsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDefsElement.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/SVG/SVGDefsElement.h>
 
 namespace Web::SVG {

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -13,7 +13,7 @@ SVGElement::SVGElement(DOM::Document& document, DOM::QualifiedName qualified_nam
     : Element(document, move(qualified_name))
     , m_dataset(HTML::DOMStringMap::create(*this))
 {
-    set_prototype(&window().cached_web_prototype("SVGElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGElement"));
 }
 
 void SVGElement::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/SVG/SVGElement.h>
 
 namespace Web::SVG {

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
@@ -14,7 +14,7 @@ namespace Web::SVG {
 SVGEllipseElement::SVGEllipseElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGeometryElement(document, qualified_name)
 {
-    set_prototype(&window().cached_web_prototype("SVGEllipseElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGEllipseElement"));
 }
 
 void SVGEllipseElement::parse_attribute(FlyString const& name, String const& value)
@@ -82,9 +82,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGEllipseElement::cx() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_center_x.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_center_x.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_center_x.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_center_x.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#EllipseElementCYAttribute
@@ -92,9 +92,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGEllipseElement::cy() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_center_y.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_center_y.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_center_y.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_center_y.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#EllipseElementRXAttribute
@@ -102,9 +102,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGEllipseElement::rx() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_radius_x.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_radius_x.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#EllipseElementRYAttribute
@@ -112,9 +112,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGEllipseElement::ry() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_radius_y.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_radius_y.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Layout/SVGGeometryBox.h>
 #include <LibWeb/SVG/SVGGeometryElement.h>
 
@@ -13,7 +13,7 @@ namespace Web::SVG {
 SVGGeometryElement::SVGGeometryElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGraphicsElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("SVGGeometryElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGGeometryElement"));
 }
 
 RefPtr<Layout::Node> SVGGeometryElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
@@ -29,7 +29,7 @@ float SVGGeometryElement::get_total_length()
 JS::NonnullGCPtr<Geometry::DOMPoint> SVGGeometryElement::get_point_at_length(float distance)
 {
     (void)distance;
-    return Geometry::DOMPoint::create_with_global_object(window(), 0, 0, 0, 0);
+    return Geometry::DOMPoint::construct_impl(realm(), 0, 0, 0, 0);
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -16,7 +16,7 @@ namespace Web::SVG {
 SVGGraphicsElement::SVGGraphicsElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("SVGGraphicsElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGGraphicsElement"));
 }
 
 void SVGGraphicsElement::apply_presentational_hints(CSS::StyleProperties& style) const

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Parser/Parser.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/SVG/SVGGraphicsElement.h>
 #include <LibWeb/SVG/SVGSVGElement.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGLength.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLength.cpp
@@ -4,22 +4,22 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/SVG/SVGLength.h>
 
 namespace Web::SVG {
 
-JS::NonnullGCPtr<SVGLength> SVGLength::create(HTML::Window& window, u8 unit_type, float value)
+JS::NonnullGCPtr<SVGLength> SVGLength::create(JS::Realm& realm, u8 unit_type, float value)
 {
-    return *window.heap().allocate<SVGLength>(window.realm(), window, unit_type, value);
+    return *realm.heap().allocate<SVGLength>(realm, realm, unit_type, value);
 }
 
-SVGLength::SVGLength(HTML::Window& window, u8 unit_type, float value)
-    : PlatformObject(window.realm())
+SVGLength::SVGLength(JS::Realm& realm, u8 unit_type, float value)
+    : PlatformObject(realm)
     , m_unit_type(unit_type)
     , m_value(value)
 {
-    set_prototype(&window.cached_web_prototype("SVGLength"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "SVGLength"));
 }
 
 SVGLength::~SVGLength() = default;

--- a/Userland/Libraries/LibWeb/SVG/SVGLength.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLength.h
@@ -16,7 +16,7 @@ class SVGLength : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(SVGLength, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<SVGLength> create(HTML::Window&, u8 unit_type, float value);
+    static JS::NonnullGCPtr<SVGLength> create(JS::Realm&, u8 unit_type, float value);
     virtual ~SVGLength() override;
 
     u8 unit_type() const { return m_unit_type; }
@@ -25,7 +25,7 @@ public:
     WebIDL::ExceptionOr<void> set_value(float value);
 
 private:
-    SVGLength(HTML::Window&, u8 unit_type, float value);
+    SVGLength(JS::Realm&, u8 unit_type, float value);
 
     u8 m_unit_type { 0 };
     float m_value { 0 };

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGLineElement.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
@@ -14,7 +14,7 @@ namespace Web::SVG {
 SVGLineElement::SVGLineElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGeometryElement(document, qualified_name)
 {
-    set_prototype(&window().cached_web_prototype("SVGLineElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGLineElement"));
 }
 
 void SVGLineElement::parse_attribute(FlyString const& name, String const& value)
@@ -62,9 +62,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGLineElement::x1() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_x1.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_x1.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_x1.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_x1.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#LineElementY1Attribute
@@ -72,9 +72,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGLineElement::y1() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_y1.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_y1.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_y1.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_y1.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#LineElementX2Attribute
@@ -82,9 +82,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGLineElement::x2() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_x2.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_x2.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_x2.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_x2.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#LineElementY2Attribute
@@ -92,9 +92,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGLineElement::y2() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_y2.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_y2.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_y2.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_y2.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -86,7 +86,7 @@ namespace Web::SVG {
 SVGPathElement::SVGPathElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGeometryElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("SVGPathElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGPathElement"));
 }
 
 void SVGPathElement::parse_attribute(FlyString const& name, String const& value)

--- a/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGPolygonElement.h>
@@ -14,7 +14,7 @@ namespace Web::SVG {
 SVGPolygonElement::SVGPolygonElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGeometryElement(document, qualified_name)
 {
-    set_prototype(&window().cached_web_prototype("SVGPolygonElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGPolygonElement"));
 }
 
 void SVGPolygonElement::parse_attribute(FlyString const& name, String const& value)

--- a/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGPolylineElement.h>
@@ -14,7 +14,7 @@ namespace Web::SVG {
 SVGPolylineElement::SVGPolylineElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGeometryElement(document, qualified_name)
 {
-    set_prototype(&window().cached_web_prototype("SVGPolylineElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGPolylineElement"));
 }
 
 void SVGPolylineElement::parse_attribute(FlyString const& name, String const& value)

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGAnimatedLength.h>
@@ -16,7 +16,7 @@ namespace Web::SVG {
 SVGRectElement::SVGRectElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGeometryElement(document, qualified_name)
 {
-    set_prototype(&window().cached_web_prototype("SVGRectElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGRectElement"));
 }
 
 void SVGRectElement::parse_attribute(FlyString const& name, String const& value)
@@ -159,9 +159,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGRectElement::x() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_x.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_x.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_x.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_x.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#RectElementYAttribute
@@ -169,9 +169,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGRectElement::y() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_y.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_y.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_y.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_y.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#RectElementWidthAttribute
@@ -179,9 +179,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGRectElement::width() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_width.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_width.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_width.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_width.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#RectElementHeightAttribute
@@ -189,9 +189,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGRectElement::height() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_height.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_height.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_height.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_height.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#RectElementRXAttribute
@@ -199,9 +199,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGRectElement::rx() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_radius_x.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_radius_x.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#RectElementRYAttribute
@@ -209,9 +209,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGRectElement::ry() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(window(), 0, m_radius_y.value_or(0));
-    auto anim_length = SVGLength::create(window(), 0, m_radius_y.value_or(0));
-    return SVGAnimatedLength::create(window(), move(base_length), move(anim_length));
+    auto base_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -20,7 +20,7 @@ namespace Web::SVG {
 SVGSVGElement::SVGSVGElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGraphicsElement(document, qualified_name)
 {
-    set_prototype(&window().cached_web_prototype("SVGSVGElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGSVGElement"));
 }
 
 RefPtr<Layout::Node> SVGSVGElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)

--- a/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
@@ -13,7 +13,7 @@ namespace Web::SVG {
 SVGTextContentElement::SVGTextContentElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGraphicsElement(document, move(qualified_name))
 {
-    set_prototype(&window().cached_web_prototype("SVGTextContentElement"));
+    set_prototype(&Bindings::cached_web_prototype(realm(), "SVGTextContentElement"));
 }
 
 // https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getNumberOfChars

--- a/Userland/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Userland/Libraries/LibWeb/Selection/Selection.cpp
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Selection/Selection.h>
 
 namespace Web::Selection {
 
-JS::NonnullGCPtr<Selection> Selection::create(HTML::Window& window)
+JS::NonnullGCPtr<Selection> Selection::create(JS::Realm& realm)
 {
-    return *window.heap().allocate<Selection>(window.realm(), window);
+    return *realm.heap().allocate<Selection>(realm, realm);
 }
 
-Selection::Selection(HTML::Window& window)
-    : PlatformObject(window.realm())
+Selection::Selection(JS::Realm& realm)
+    : PlatformObject(realm)
 {
-    set_prototype(&window.cached_web_prototype("Selection"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "Selection"));
 }
 
 Selection::~Selection() = default;

--- a/Userland/Libraries/LibWeb/Selection/Selection.h
+++ b/Userland/Libraries/LibWeb/Selection/Selection.h
@@ -14,7 +14,7 @@ class Selection final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(Selection, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<Selection> create(HTML::Window&);
+    static JS::NonnullGCPtr<Selection> create(JS::Realm&);
 
     virtual ~Selection() override;
 
@@ -43,7 +43,7 @@ public:
     String to_string() const;
 
 private:
-    explicit Selection(HTML::Window&);
+    explicit Selection(JS::Realm&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -4,24 +4,25 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/ReadableStream.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::Streams {
 
 // https://streams.spec.whatwg.org/#rs-constructor
-WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> ReadableStream::create_with_global_object(HTML::Window& window)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> ReadableStream::construct_impl(JS::Realm& realm)
 {
-    auto* readable_stream = window.heap().allocate<ReadableStream>(window.realm(), window);
+    auto* readable_stream = realm.heap().allocate<ReadableStream>(realm, realm);
 
     return JS::NonnullGCPtr { *readable_stream };
 }
 
-ReadableStream::ReadableStream(HTML::Window& window)
-    : PlatformObject(window.realm())
+ReadableStream::ReadableStream(JS::Realm& realm)
+    : PlatformObject(realm)
 {
-    set_prototype(&window.cached_web_prototype("ReadableStream"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "ReadableStream"));
 }
 
 ReadableStream::~ReadableStream() = default;

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.h
@@ -24,7 +24,7 @@ public:
         Errored,
     };
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> create_with_global_object(HTML::Window&);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> construct_impl(JS::Realm&);
 
     virtual ~ReadableStream() override;
 
@@ -39,7 +39,7 @@ public:
     bool is_disturbed() const;
 
 private:
-    explicit ReadableStream(HTML::Window&);
+    explicit ReadableStream(JS::Realm&);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/FocusEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/FocusEvent.cpp
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/UIEvents/FocusEvent.h>
 
 namespace Web::UIEvents {
 
-FocusEvent* FocusEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, FocusEventInit const& event_init)
+FocusEvent* FocusEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, FocusEventInit const& event_init)
 {
-    return window_object.heap().allocate<FocusEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<FocusEvent>(realm, realm, event_name, event_init);
 }
 
-FocusEvent::FocusEvent(HTML::Window& window_object, FlyString const& event_name, FocusEventInit const& event_init)
-    : UIEvent(window_object, event_name)
+FocusEvent::FocusEvent(JS::Realm& realm, FlyString const& event_name, FocusEventInit const& event_init)
+    : UIEvent(realm, event_name)
 {
-    set_prototype(&window_object.cached_web_prototype("FocusEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "FocusEvent"));
     set_related_target(const_cast<DOM::EventTarget*>(event_init.related_target.ptr()));
 }
 

--- a/Userland/Libraries/LibWeb/UIEvents/FocusEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/FocusEvent.h
@@ -18,10 +18,12 @@ class FocusEvent final : public UIEvent {
     WEB_PLATFORM_OBJECT(FocusEvent, UIEvent);
 
 public:
-    static FocusEvent* create_with_global_object(HTML::Window&, FlyString const& event_name, FocusEventInit const& event_init);
+    static FocusEvent* construct_impl(JS::Realm&, FlyString const& event_name, FocusEventInit const& event_init);
 
-    FocusEvent(HTML::Window&, FlyString const& event_name, FocusEventInit const&);
     virtual ~FocusEvent() override;
+
+private:
+    FocusEvent(JS::Realm&, FlyString const& event_name, FocusEventInit const&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <AK/CharacterTypes.h>
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/UIEvents/KeyboardEvent.h>
 
 namespace Web::UIEvents {
@@ -66,7 +66,7 @@ static unsigned long determine_key_code(KeyCode platform_key, u32 code_point)
     return platform_key;
 }
 
-KeyboardEvent* KeyboardEvent::create_from_platform_event(HTML::Window& window_object, FlyString const& event_name, KeyCode platform_key, unsigned modifiers, u32 code_point)
+KeyboardEvent* KeyboardEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, KeyCode platform_key, unsigned modifiers, u32 code_point)
 {
     // FIXME: Figure out what these should actually contain.
     String event_key = key_code_to_string(platform_key);
@@ -88,7 +88,12 @@ KeyboardEvent* KeyboardEvent::create_from_platform_event(HTML::Window& window_ob
     event_init.bubbles = true;
     event_init.cancelable = true;
     event_init.composed = true;
-    return KeyboardEvent::create(window_object, event_name, event_init);
+    return KeyboardEvent::create(realm, event_name, event_init);
+}
+
+KeyboardEvent* KeyboardEvent::create_from_platform_event(HTML::Window& window, FlyString const& event_name, KeyCode platform_key, unsigned modifiers, u32 code_point)
+{
+    return create_from_platform_event(window.realm(), event_name, platform_key, modifiers, code_point);
 }
 
 bool KeyboardEvent::get_modifier_state(String const& key_arg)
@@ -104,18 +109,18 @@ bool KeyboardEvent::get_modifier_state(String const& key_arg)
     return false;
 }
 
-KeyboardEvent* KeyboardEvent::create(HTML::Window& window_object, FlyString const& event_name, KeyboardEventInit const& event_init)
+KeyboardEvent* KeyboardEvent::create(JS::Realm& realm, FlyString const& event_name, KeyboardEventInit const& event_init)
 {
-    return window_object.heap().allocate<KeyboardEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<KeyboardEvent>(realm, realm, event_name, event_init);
 }
 
-KeyboardEvent* KeyboardEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, KeyboardEventInit const& event_init)
+KeyboardEvent* KeyboardEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, KeyboardEventInit const& event_init)
 {
-    return create(window_object, event_name, event_init);
+    return create(realm, event_name, event_init);
 }
 
-KeyboardEvent::KeyboardEvent(HTML::Window& window_object, FlyString const& event_name, KeyboardEventInit const& event_init)
-    : UIEvent(window_object, event_name, event_init)
+KeyboardEvent::KeyboardEvent(JS::Realm& realm, FlyString const& event_name, KeyboardEventInit const& event_init)
+    : UIEvent(realm, event_name, event_init)
     , m_key(event_init.key)
     , m_code(event_init.code)
     , m_location(event_init.location)
@@ -128,7 +133,7 @@ KeyboardEvent::KeyboardEvent(HTML::Window& window_object, FlyString const& event
     , m_key_code(event_init.key_code)
     , m_char_code(event_init.char_code)
 {
-    set_prototype(&window_object.cached_web_prototype("KeyboardEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "KeyboardEvent"));
 }
 
 KeyboardEvent::~KeyboardEvent() = default;

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
@@ -91,11 +91,6 @@ KeyboardEvent* KeyboardEvent::create_from_platform_event(JS::Realm& realm, FlySt
     return KeyboardEvent::create(realm, event_name, event_init);
 }
 
-KeyboardEvent* KeyboardEvent::create_from_platform_event(HTML::Window& window, FlyString const& event_name, KeyCode platform_key, unsigned modifiers, u32 code_point)
-{
-    return create_from_platform_event(window.realm(), event_name, platform_key, modifiers, code_point);
-}
-
 bool KeyboardEvent::get_modifier_state(String const& key_arg)
 {
     if (key_arg == "Alt")

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
@@ -31,7 +31,6 @@ public:
     static KeyboardEvent* create(JS::Realm&, FlyString const& event_name, KeyboardEventInit const& event_init = {});
     static KeyboardEvent* construct_impl(JS::Realm&, FlyString const& event_name, KeyboardEventInit const& event_init);
     static KeyboardEvent* create_from_platform_event(JS::Realm&, FlyString const& event_name, KeyCode, unsigned modifiers, u32 code_point);
-    static KeyboardEvent* create_from_platform_event(HTML::Window&, FlyString const& event_name, KeyCode, unsigned modifiers, u32 code_point);
 
     virtual ~KeyboardEvent() override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
@@ -28,11 +28,10 @@ class KeyboardEvent final : public UIEvent {
     WEB_PLATFORM_OBJECT(KeyboardEvent, UIEvent);
 
 public:
-    static KeyboardEvent* create(HTML::Window&, FlyString const& event_name, KeyboardEventInit const& event_init = {});
-    static KeyboardEvent* create_with_global_object(HTML::Window&, FlyString const& event_name, KeyboardEventInit const& event_init);
+    static KeyboardEvent* create(JS::Realm&, FlyString const& event_name, KeyboardEventInit const& event_init = {});
+    static KeyboardEvent* construct_impl(JS::Realm&, FlyString const& event_name, KeyboardEventInit const& event_init);
+    static KeyboardEvent* create_from_platform_event(JS::Realm&, FlyString const& event_name, KeyCode, unsigned modifiers, u32 code_point);
     static KeyboardEvent* create_from_platform_event(HTML::Window&, FlyString const& event_name, KeyCode, unsigned modifiers, u32 code_point);
-
-    KeyboardEvent(HTML::Window&, FlyString const& event_name, KeyboardEventInit const& event_init);
 
     virtual ~KeyboardEvent() override;
 
@@ -56,6 +55,8 @@ public:
     virtual u32 which() const override { return m_key_code; }
 
 private:
+    KeyboardEvent(JS::Realm&, FlyString const& event_name, KeyboardEventInit const& event_init);
+
     String m_key;
     String m_code;
     u32 m_location { 0 };

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -62,11 +62,6 @@ MouseEvent* MouseEvent::create_from_platform_event(JS::Realm& realm, FlyString c
     return MouseEvent::create(realm, event_name, event_init);
 }
 
-MouseEvent* MouseEvent::create_from_platform_event(HTML::Window& window, FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, unsigned mouse_button)
-{
-    return create_from_platform_event(window.realm(), event_name, offset_x, offset_y, client_x, client_y, mouse_button);
-}
-
 void MouseEvent::set_event_characteristics()
 {
     if (type().is_one_of(EventNames::mousedown, EventNames::mousemove, EventNames::mouseout, EventNames::mouseover, EventNames::mouseup, HTML::EventNames::click)) {

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -6,22 +6,22 @@
  */
 
 #include <LibGUI/Event.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/EventNames.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/UIEvents/EventNames.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
 
 namespace Web::UIEvents {
 
-MouseEvent::MouseEvent(HTML::Window& window_object, FlyString const& event_name, MouseEventInit const& event_init)
-    : UIEvent(window_object, event_name, event_init)
+MouseEvent::MouseEvent(JS::Realm& realm, FlyString const& event_name, MouseEventInit const& event_init)
+    : UIEvent(realm, event_name, event_init)
     , m_offset_x(event_init.offset_x)
     , m_offset_y(event_init.offset_y)
     , m_client_x(event_init.client_x)
     , m_client_y(event_init.client_y)
     , m_button(event_init.button)
 {
-    set_prototype(&window_object.cached_web_prototype("MouseEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "MouseEvent"));
     set_event_characteristics();
 }
 
@@ -46,12 +46,12 @@ static i16 determine_button(unsigned mouse_button)
     }
 }
 
-MouseEvent* MouseEvent::create(HTML::Window& window_object, FlyString const& event_name, MouseEventInit const& event_init)
+MouseEvent* MouseEvent::create(JS::Realm& realm, FlyString const& event_name, MouseEventInit const& event_init)
 {
-    return window_object.heap().allocate<MouseEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<MouseEvent>(realm, realm, event_name, event_init);
 }
 
-MouseEvent* MouseEvent::create_from_platform_event(HTML::Window& window_object, FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, unsigned mouse_button)
+MouseEvent* MouseEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, unsigned mouse_button)
 {
     MouseEventInit event_init {};
     event_init.offset_x = offset_x;
@@ -59,7 +59,12 @@ MouseEvent* MouseEvent::create_from_platform_event(HTML::Window& window_object, 
     event_init.client_x = client_x;
     event_init.client_y = client_y;
     event_init.button = determine_button(mouse_button);
-    return MouseEvent::create(window_object, event_name, event_init);
+    return MouseEvent::create(realm, event_name, event_init);
+}
+
+MouseEvent* MouseEvent::create_from_platform_event(HTML::Window& window, FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, unsigned mouse_button)
+{
+    return create_from_platform_event(window.realm(), event_name, offset_x, offset_y, client_x, client_y, mouse_button);
 }
 
 void MouseEvent::set_event_characteristics()

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -25,10 +25,9 @@ class MouseEvent final : public UIEvent {
     WEB_PLATFORM_OBJECT(MouseEvent, UIEvent);
 
 public:
-    static MouseEvent* create(HTML::Window&, FlyString const& event_name, MouseEventInit const& event_init = {});
+    static MouseEvent* create(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init = {});
+    static MouseEvent* create_from_platform_event(JS::Realm&, FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, unsigned mouse_button = 1);
     static MouseEvent* create_from_platform_event(HTML::Window&, FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, unsigned mouse_button = 1);
-
-    MouseEvent(HTML::Window&, FlyString const& event_name, MouseEventInit const& event_init);
 
     virtual ~MouseEvent() override;
 
@@ -46,6 +45,8 @@ public:
     virtual u32 which() const override { return m_button + 1; }
 
 private:
+    MouseEvent(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init);
+
     void set_event_characteristics();
 
     double m_offset_x { 0 };

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -27,7 +27,6 @@ class MouseEvent final : public UIEvent {
 public:
     static MouseEvent* create(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init = {});
     static MouseEvent* create_from_platform_event(JS::Realm&, FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, unsigned mouse_button = 1);
-    static MouseEvent* create_from_platform_event(HTML::Window&, FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, unsigned mouse_button = 1);
 
     virtual ~MouseEvent() override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.cpp
@@ -4,33 +4,33 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/UIEvents/UIEvent.h>
 
 namespace Web::UIEvents {
 
-UIEvent* UIEvent::create(HTML::Window& window_object, FlyString const& event_name)
+UIEvent* UIEvent::create(JS::Realm& realm, FlyString const& event_name)
 {
-    return window_object.heap().allocate<UIEvent>(window_object.realm(), window_object, event_name);
+    return realm.heap().allocate<UIEvent>(realm, realm, event_name);
 }
 
-UIEvent* UIEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, UIEventInit const& event_init)
+UIEvent* UIEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, UIEventInit const& event_init)
 {
-    return window_object.heap().allocate<UIEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<UIEvent>(realm, realm, event_name, event_init);
 }
 
-UIEvent::UIEvent(HTML::Window& window_object, FlyString const& event_name)
-    : Event(window_object, event_name)
+UIEvent::UIEvent(JS::Realm& realm, FlyString const& event_name)
+    : Event(realm, event_name)
 {
-    set_prototype(&window_object.cached_web_prototype("UIEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "UIEvent"));
 }
 
-UIEvent::UIEvent(HTML::Window& window_object, FlyString const& event_name, UIEventInit const& event_init)
-    : Event(window_object, event_name, event_init)
+UIEvent::UIEvent(JS::Realm& realm, FlyString const& event_name, UIEventInit const& event_init)
+    : Event(realm, event_name, event_init)
     , m_view(event_init.view)
     , m_detail(event_init.detail)
 {
-    set_prototype(&window_object.cached_web_prototype("UIEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "UIEvent"));
 }
 
 UIEvent::~UIEvent() = default;

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.h
@@ -21,11 +21,8 @@ class UIEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(UIEvent, DOM::Event);
 
 public:
-    static UIEvent* create(HTML::Window&, FlyString const& type);
-    static UIEvent* create_with_global_object(HTML::Window&, FlyString const& event_name, UIEventInit const& event_init);
-
-    UIEvent(HTML::Window&, FlyString const& event_name);
-    UIEvent(HTML::Window&, FlyString const& event_name, UIEventInit const& event_init);
+    static UIEvent* create(JS::Realm&, FlyString const& type);
+    static UIEvent* construct_impl(JS::Realm&, FlyString const& event_name, UIEventInit const& event_init);
 
     virtual ~UIEvent() override;
 
@@ -41,6 +38,9 @@ public:
     }
 
 protected:
+    UIEvent(JS::Realm&, FlyString const& event_name);
+    UIEvent(JS::Realm&, FlyString const& event_name, UIEventInit const& event_init);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     JS::GCPtr<HTML::Window> m_view;

--- a/Userland/Libraries/LibWeb/URL/URL.cpp
+++ b/Userland/Libraries/LibWeb/URL/URL.cpp
@@ -6,17 +6,17 @@
  */
 
 #include <AK/URLParser.h>
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/URL/URL.h>
 
 namespace Web::URL {
 
-JS::NonnullGCPtr<URL> URL::create(HTML::Window& window, AK::URL url, JS::NonnullGCPtr<URLSearchParams> query)
+JS::NonnullGCPtr<URL> URL::create(JS::Realm& realm, AK::URL url, JS::NonnullGCPtr<URLSearchParams> query)
 {
-    return *window.heap().allocate<URL>(window.realm(), window, move(url), move(query));
+    return *realm.heap().allocate<URL>(realm, realm, move(url), move(query));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<URL>> URL::create_with_global_object(HTML::Window& window, String const& url, String const& base)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<URL>> URL::construct_impl(JS::Realm& realm, String const& url, String const& base)
 {
     // 1. Let parsedBase be null.
     Optional<AK::URL> parsed_base;
@@ -41,21 +41,21 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<URL>> URL::create_with_global_object(HTML::
     auto& query = parsed_url.query().is_null() ? String::empty() : parsed_url.query();
     // 6. Set this’s URL to parsedURL.
     // 7. Set this’s query object to a new URLSearchParams object.
-    auto query_object = MUST(URLSearchParams::create_with_global_object(window, query));
+    auto query_object = MUST(URLSearchParams::construct_impl(realm, query));
     // 8. Initialize this’s query object with query.
-    auto result_url = URL::create(window, move(parsed_url), move(query_object));
+    auto result_url = URL::create(realm, move(parsed_url), move(query_object));
     // 9. Set this’s query object’s URL object to this.
     result_url->m_query->m_url = result_url;
 
     return result_url;
 }
 
-URL::URL(HTML::Window& window, AK::URL url, JS::NonnullGCPtr<URLSearchParams> query)
-    : PlatformObject(window.realm())
+URL::URL(JS::Realm& realm, AK::URL url, JS::NonnullGCPtr<URLSearchParams> query)
+    : PlatformObject(realm)
     , m_url(move(url))
     , m_query(move(query))
 {
-    set_prototype(&window.cached_web_prototype("URL"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "URL"));
 }
 
 URL::~URL() = default;

--- a/Userland/Libraries/LibWeb/URL/URL.h
+++ b/Userland/Libraries/LibWeb/URL/URL.h
@@ -19,8 +19,8 @@ class URL : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(URL, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<URL> create(HTML::Window&, AK::URL url, JS::NonnullGCPtr<URLSearchParams> query);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<URL>> create_with_global_object(HTML::Window&, String const& url, String const& base);
+    static JS::NonnullGCPtr<URL> create(JS::Realm&, AK::URL url, JS::NonnullGCPtr<URLSearchParams> query);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<URL>> construct_impl(JS::Realm&, String const& url, String const& base);
 
     virtual ~URL() override;
 
@@ -63,7 +63,7 @@ public:
     void set_query(Badge<URLSearchParams>, String query) { m_url.set_query(move(query)); }
 
 private:
-    URL(HTML::Window&, AK::URL, JS::NonnullGCPtr<URLSearchParams> query);
+    URL(JS::Realm&, AK::URL, JS::NonnullGCPtr<URLSearchParams> query);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.h
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.h
@@ -23,8 +23,8 @@ class URLSearchParams : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(URLSearchParams, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<URLSearchParams> create(HTML::Window&, Vector<QueryParam> list);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<URLSearchParams>> create_with_global_object(HTML::Window&, Variant<Vector<Vector<String>>, OrderedHashMap<String, String>, String> const& init);
+    static JS::NonnullGCPtr<URLSearchParams> create(JS::Realm&, Vector<QueryParam> list);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<URLSearchParams>> construct_impl(JS::Realm&, Variant<Vector<Vector<String>>, OrderedHashMap<String, String>, String> const& init);
 
     virtual ~URLSearchParams() override;
 
@@ -46,7 +46,7 @@ private:
     friend class URL;
     friend class URLSearchParamsIterator;
 
-    URLSearchParams(HTML::Window&, Vector<QueryParam> list);
+    URLSearchParams(JS::Realm&, Vector<QueryParam> list);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/URL/URLSearchParamsIterator.cpp
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParamsIterator.cpp
@@ -6,8 +6,8 @@
 
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/IteratorOperations.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/URLSearchParamsIteratorPrototype.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/URL/URLSearchParamsIterator.h>
 
 namespace Web::URL {
@@ -22,7 +22,7 @@ URLSearchParamsIterator::URLSearchParamsIterator(URLSearchParams const& url_sear
     , m_url_search_params(url_search_params)
     , m_iteration_kind(iteration_kind)
 {
-    set_prototype(&url_search_params.global_object().ensure_web_prototype<Bindings::URLSearchParamsIteratorPrototype>("URLSearchParamsIterator"));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::URLSearchParamsIteratorPrototype>(url_search_params.realm(), "URLSearchParamsIterator"));
 }
 
 URLSearchParamsIterator::~URLSearchParamsIterator() = default;

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceConstructor.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceConstructor.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <LibJS/Runtime/GlobalObject.h>
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebAssembly/WebAssemblyInstanceConstructor.h>
 #include <LibWeb/WebAssembly/WebAssemblyInstanceObject.h>
 #include <LibWeb/WebAssembly/WebAssemblyInstanceObjectPrototype.h>
@@ -42,10 +42,9 @@ JS::ThrowCompletionOr<JS::Object*> WebAssemblyInstanceConstructor::construct(Fun
 void WebAssemblyInstanceConstructor::initialize(JS::Realm& realm)
 {
     auto& vm = this->vm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
 
     NativeFunction::initialize(realm);
-    define_direct_property(vm.names.prototype, &window.ensure_web_prototype<WebAssemblyInstancePrototype>("WebAssemblyInstancePrototype"), 0);
+    define_direct_property(vm.names.prototype, &Bindings::ensure_web_prototype<WebAssemblyInstancePrototype>(realm, "WebAssemblyInstancePrototype"), 0);
     define_direct_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);
 }
 

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObject.cpp
@@ -10,7 +10,7 @@
 #include <LibJS/Runtime/BigInt.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWasm/AbstractMachine/Interpreter.h>
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebAssembly/WebAssemblyInstanceObject.h>
 #include <LibWeb/WebAssembly/WebAssemblyMemoryPrototype.h>
 #include <LibWeb/WebAssembly/WebAssemblyObject.h>
@@ -18,7 +18,7 @@
 namespace Web::Bindings {
 
 WebAssemblyInstanceObject::WebAssemblyInstanceObject(JS::Realm& realm, size_t index)
-    : Object(static_cast<Web::HTML::Window&>(realm.global_object()).ensure_web_prototype<WebAssemblyInstancePrototype>("WebAssemblyInstancePrototype"))
+    : Object(Bindings::ensure_web_prototype<WebAssemblyInstancePrototype>(realm, "WebAssemblyInstancePrototype"))
     , m_index(index)
 {
 }

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryConstructor.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryConstructor.cpp
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibJS/Runtime/GlobalObject.h>
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebAssembly/WebAssemblyMemoryConstructor.h>
 #include <LibWeb/WebAssembly/WebAssemblyMemoryPrototype.h>
 #include <LibWeb/WebAssembly/WebAssemblyObject.h>
@@ -53,10 +52,9 @@ JS::ThrowCompletionOr<JS::Object*> WebAssemblyMemoryConstructor::construct(Funct
 void WebAssemblyMemoryConstructor::initialize(JS::Realm& realm)
 {
     auto& vm = this->vm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
 
     NativeFunction::initialize(realm);
-    define_direct_property(vm.names.prototype, &window.ensure_web_prototype<WebAssemblyMemoryPrototype>("WebAssemblyMemoryPrototype"), 0);
+    define_direct_property(vm.names.prototype, &Bindings::ensure_web_prototype<WebAssemblyMemoryPrototype>(realm, "WebAssemblyMemoryPrototype"), 0);
     define_direct_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);
 }
 

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryPrototype.h
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryPrototype.h
@@ -7,11 +7,9 @@
 #pragma once
 
 #include "WebAssemblyMemoryConstructor.h"
-#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Bindings {
 

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyModuleConstructor.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyModuleConstructor.cpp
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/TypedArray.h>
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebAssembly/WebAssemblyModuleConstructor.h>
 #include <LibWeb/WebAssembly/WebAssemblyModuleObject.h>
 #include <LibWeb/WebAssembly/WebAssemblyModulePrototype.h>
@@ -40,10 +39,9 @@ JS::ThrowCompletionOr<JS::Object*> WebAssemblyModuleConstructor::construct(Funct
 void WebAssemblyModuleConstructor::initialize(JS::Realm& realm)
 {
     auto& vm = this->vm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
 
     NativeFunction::initialize(realm);
-    define_direct_property(vm.names.prototype, &window.ensure_web_prototype<WebAssemblyModulePrototype>("WebAssemblyModulePrototype"), 0);
+    define_direct_property(vm.names.prototype, &Bindings::ensure_web_prototype<WebAssemblyModulePrototype>(realm, "WebAssemblyModulePrototype"), 0);
     define_direct_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);
 }
 

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyModuleObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyModuleObject.cpp
@@ -10,7 +10,7 @@
 namespace Web::Bindings {
 
 WebAssemblyModuleObject::WebAssemblyModuleObject(JS::Realm& realm, size_t index)
-    : Object(verify_cast<HTML::Window>(realm.global_object()).ensure_web_prototype<WebAssemblyModulePrototype>("WebAssemblyModulePrototype"))
+    : Object(Bindings::ensure_web_prototype<WebAssemblyModulePrototype>(realm, "WebAssemblyModulePrototype"))
     , m_index(index)
 {
 }

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyModuleObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyModuleObject.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "WebAssemblyModulePrototype.h"
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebAssembly/WebAssemblyModuleObject.h>
 
 namespace Web::Bindings {

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyModulePrototype.h
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyModulePrototype.h
@@ -7,11 +7,9 @@
 #pragma once
 
 #include "WebAssemblyModuleConstructor.h"
-#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Bindings {
 

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
@@ -19,7 +19,7 @@
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWasm/AbstractMachine/Interpreter.h>
 #include <LibWasm/AbstractMachine/Validator.h>
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebAssembly/WebAssemblyInstanceConstructor.h>
 #include <LibWeb/WebAssembly/WebAssemblyObject.h>
 
@@ -42,28 +42,27 @@ void WebAssemblyObject::initialize(JS::Realm& realm)
 
     auto& vm = this->vm();
 
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
-    auto& memory_constructor = window.ensure_web_constructor<WebAssemblyMemoryConstructor>("WebAssembly.Memory");
+    auto& memory_constructor = Bindings::ensure_web_constructor<WebAssemblyMemoryConstructor>(realm, "WebAssembly.Memory");
     memory_constructor.define_direct_property(vm.names.name, js_string(vm, "WebAssembly.Memory"), JS::Attribute::Configurable);
-    auto& memory_prototype = window.ensure_web_prototype<WebAssemblyMemoryPrototype>("WebAssemblyMemoryPrototype");
+    auto& memory_prototype = Bindings::ensure_web_prototype<WebAssemblyMemoryPrototype>(realm, "WebAssemblyMemoryPrototype");
     memory_prototype.define_direct_property(vm.names.constructor, &memory_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
     define_direct_property("Memory", &memory_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
 
-    auto& instance_constructor = window.ensure_web_constructor<WebAssemblyInstanceConstructor>("WebAssembly.Instance");
+    auto& instance_constructor = Bindings::ensure_web_constructor<WebAssemblyInstanceConstructor>(realm, "WebAssembly.Instance");
     instance_constructor.define_direct_property(vm.names.name, js_string(vm, "WebAssembly.Instance"), JS::Attribute::Configurable);
-    auto& instance_prototype = window.ensure_web_prototype<WebAssemblyInstancePrototype>("WebAssemblyInstancePrototype");
+    auto& instance_prototype = Bindings::ensure_web_prototype<WebAssemblyInstancePrototype>(realm, "WebAssemblyInstancePrototype");
     instance_prototype.define_direct_property(vm.names.constructor, &instance_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
     define_direct_property("Instance", &instance_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
 
-    auto& module_constructor = window.ensure_web_constructor<WebAssemblyModuleConstructor>("WebAssembly.Module");
+    auto& module_constructor = Bindings::ensure_web_constructor<WebAssemblyModuleConstructor>(realm, "WebAssembly.Module");
     module_constructor.define_direct_property(vm.names.name, js_string(vm, "WebAssembly.Module"), JS::Attribute::Configurable);
-    auto& module_prototype = window.ensure_web_prototype<WebAssemblyModulePrototype>("WebAssemblyModulePrototype");
+    auto& module_prototype = Bindings::ensure_web_prototype<WebAssemblyModulePrototype>(realm, "WebAssemblyModulePrototype");
     module_prototype.define_direct_property(vm.names.constructor, &module_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
     define_direct_property("Module", &module_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
 
-    auto& table_constructor = window.ensure_web_constructor<WebAssemblyTableConstructor>("WebAssembly.Table");
+    auto& table_constructor = Bindings::ensure_web_constructor<WebAssemblyTableConstructor>(realm, "WebAssembly.Table");
     table_constructor.define_direct_property(vm.names.name, js_string(vm, "WebAssembly.Table"), JS::Attribute::Configurable);
-    auto& table_prototype = window.ensure_web_prototype<WebAssemblyTablePrototype>("WebAssemblyTablePrototype");
+    auto& table_prototype = Bindings::ensure_web_prototype<WebAssemblyTablePrototype>(realm, "WebAssemblyTablePrototype");
     table_prototype.define_direct_property(vm.names.constructor, &table_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
     define_direct_property("Table", &table_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
 }
@@ -482,7 +481,7 @@ JS::NativeFunction* create_native_function(JS::VM& vm, Wasm::FunctionAddress add
 }
 
 WebAssemblyMemoryObject::WebAssemblyMemoryObject(JS::Realm& realm, Wasm::MemoryAddress address)
-    : Object(verify_cast<HTML::Window>(realm.global_object()).ensure_web_prototype<WebAssemblyMemoryPrototype>("WebAssemblyMemoryPrototype"))
+    : Object(Bindings::ensure_web_prototype<WebAssemblyMemoryPrototype>(realm, "WebAssemblyMemoryPrototype"))
     , m_address(address)
 {
 }

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyTableConstructor.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyTableConstructor.cpp
@@ -6,7 +6,7 @@
 
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/TypedArray.h>
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebAssembly/WebAssemblyObject.h>
 #include <LibWeb/WebAssembly/WebAssemblyTableConstructor.h>
 #include <LibWeb/WebAssembly/WebAssemblyTableObject.h>
@@ -83,10 +83,9 @@ JS::ThrowCompletionOr<JS::Object*> WebAssemblyTableConstructor::construct(Functi
 void WebAssemblyTableConstructor::initialize(JS::Realm& realm)
 {
     auto& vm = this->vm();
-    auto& window = verify_cast<HTML::Window>(realm.global_object());
 
     NativeFunction::initialize(realm);
-    define_direct_property(vm.names.prototype, &window.ensure_web_prototype<WebAssemblyTablePrototype>("WebAssemblyTablePrototype"), 0);
+    define_direct_property(vm.names.prototype, &Bindings::ensure_web_prototype<WebAssemblyTablePrototype>(realm, "WebAssemblyTablePrototype"), 0);
     define_direct_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);
 }
 

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyTableObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyTableObject.cpp
@@ -10,7 +10,7 @@
 namespace Web::Bindings {
 
 WebAssemblyTableObject::WebAssemblyTableObject(JS::Realm& realm, Wasm::TableAddress address)
-    : Object(verify_cast<HTML::Window>(realm.global_object()).ensure_web_prototype<WebAssemblyTablePrototype>("WebAssemblyTablePrototype"))
+    : Object(Bindings::ensure_web_prototype<WebAssemblyTablePrototype>(realm, "WebAssemblyTablePrototype"))
     , m_address(address)
 {
 }

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyTableObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyTableObject.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "WebAssemblyTablePrototype.h"
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebAssembly/WebAssemblyTableObject.h>
 
 namespace Web::Bindings {

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyTablePrototype.h
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyTablePrototype.h
@@ -7,11 +7,9 @@
 #pragma once
 
 #include "WebAssemblyTableConstructor.h"
-#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/Window.h>
 
 namespace Web::Bindings {
 

--- a/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.cpp
@@ -4,26 +4,26 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebGL/WebGLContextEvent.h>
 
 namespace Web::WebGL {
 
-WebGLContextEvent* WebGLContextEvent::create(HTML::Window& window_object, FlyString const& event_name, WebGLContextEventInit const& event_init)
+WebGLContextEvent* WebGLContextEvent::create(JS::Realm& realm, FlyString const& event_name, WebGLContextEventInit const& event_init)
 {
-    return window_object.heap().allocate<WebGLContextEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<WebGLContextEvent>(realm, realm, event_name, event_init);
 }
 
-WebGLContextEvent* WebGLContextEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, WebGLContextEventInit const& event_init)
+WebGLContextEvent* WebGLContextEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, WebGLContextEventInit const& event_init)
 {
-    return create(window_object, event_name, event_init);
+    return create(realm, event_name, event_init);
 }
 
-WebGLContextEvent::WebGLContextEvent(HTML::Window& window_object, FlyString const& type, WebGLContextEventInit const& event_init)
-    : DOM::Event(window_object, type, event_init)
+WebGLContextEvent::WebGLContextEvent(JS::Realm& realm, FlyString const& type, WebGLContextEventInit const& event_init)
+    : DOM::Event(realm, type, event_init)
     , m_status_message(event_init.status_message)
 {
-    set_prototype(&window_object.cached_web_prototype("WebGLContextEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "WebGLContextEvent"));
 }
 
 WebGLContextEvent::~WebGLContextEvent() = default;

--- a/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.h
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.h
@@ -19,16 +19,16 @@ class WebGLContextEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(WebGLContextEvent, DOM::Event);
 
 public:
-    static WebGLContextEvent* create(HTML::Window&, FlyString const& type, WebGLContextEventInit const& event_init);
-    static WebGLContextEvent* create_with_global_object(HTML::Window&, FlyString const& type, WebGLContextEventInit const& event_init);
-
-    WebGLContextEvent(HTML::Window&, FlyString const& type, WebGLContextEventInit const& event_init);
+    static WebGLContextEvent* create(JS::Realm&, FlyString const& type, WebGLContextEventInit const& event_init);
+    static WebGLContextEvent* construct_impl(JS::Realm&, FlyString const& type, WebGLContextEventInit const& event_init);
 
     virtual ~WebGLContextEvent() override;
 
     String const& status_message() const { return m_status_message; }
 
 private:
+    WebGLContextEvent(JS::Realm&, FlyString const& type, WebGLContextEventInit const& event_init);
+
     String m_status_message { String::empty() };
 };
 

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.h
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.h
@@ -16,12 +16,12 @@ class WebGLRenderingContext final : public WebGLRenderingContextBase {
     WEB_PLATFORM_OBJECT(WebGLRenderingContext, WebGLRenderingContextBase);
 
 public:
-    static JS::ThrowCompletionOr<JS::GCPtr<WebGLRenderingContext>> create(HTML::Window&, HTML::HTMLCanvasElement& canvas_element, JS::Value options);
+    static JS::ThrowCompletionOr<JS::GCPtr<WebGLRenderingContext>> create(JS::Realm&, HTML::HTMLCanvasElement& canvas_element, JS::Value options);
 
     virtual ~WebGLRenderingContext() override;
 
 private:
-    WebGLRenderingContext(HTML::Window&, HTML::HTMLCanvasElement&, NonnullOwnPtr<GL::GLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters);
+    WebGLRenderingContext(JS::Realm&, HTML::HTMLCanvasElement&, NonnullOwnPtr<GL::GLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters);
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -7,13 +7,12 @@
 #include <AK/Debug.h>
 #include <LibGL/GLContext.h>
 #include <LibWeb/HTML/HTMLCanvasElement.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/WebGL/WebGLRenderingContextBase.h>
 
 namespace Web::WebGL {
 
-WebGLRenderingContextBase::WebGLRenderingContextBase(HTML::Window& window, HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<GL::GLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters)
-    : PlatformObject(window.realm())
+WebGLRenderingContextBase::WebGLRenderingContextBase(JS::Realm& realm, HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<GL::GLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters)
+    : PlatformObject(realm)
     , m_canvas_element(canvas_element)
     , m_context(move(context))
     , m_context_creation_parameters(move(context_creation_parameters))

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
@@ -64,7 +64,7 @@ public:
     void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
 
 protected:
-    WebGLRenderingContextBase(HTML::Window&, HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<GL::GLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters);
+    WebGLRenderingContextBase(JS::Realm&, HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<GL::GLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters);
 
 private:
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -108,7 +108,7 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
     auto& realm = function_object.shape().realm();
 
     // 6. Let relevant settings be realm’s settings object.
-    auto& relevant_settings = verify_cast<HTML::EnvironmentSettingsObject>(*realm.host_defined());
+    auto& relevant_settings = Bindings::host_defined_environment_settings_object(realm);
 
     // 7. Let stored settings be value’s callback context.
     auto& stored_settings = callback.callback_context;

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.h
@@ -11,6 +11,7 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/FunctionObject.h>
+#include <LibWeb/Bindings/HostDefined.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/WebIDL/CallbackType.h>
 
@@ -60,7 +61,7 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, String
     auto& realm = object.shape().realm();
 
     // 5. Let relevant settings be realm’s settings object.
-    auto& relevant_settings = verify_cast<HTML::EnvironmentSettingsObject>(*realm.host_defined());
+    auto& relevant_settings = Bindings::host_defined_environment_settings_object(realm);
 
     // 6. Let stored settings be value’s callback context.
     auto& stored_settings = callback.callback_context;

--- a/Userland/Libraries/LibWeb/WebIDL/DOMException.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/DOMException.cpp
@@ -4,29 +4,27 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebIDL/DOMException.h>
 
 namespace Web::WebIDL {
 
-JS::NonnullGCPtr<DOMException> DOMException::create(JS::Object& global_object, FlyString const& name, FlyString const& message)
+JS::NonnullGCPtr<DOMException> DOMException::create(JS::Realm& realm, FlyString const& name, FlyString const& message)
 {
-    auto& window = verify_cast<HTML::Window>(global_object);
-    return *window.heap().allocate<DOMException>(window.realm(), window, name, message);
+    return *realm.heap().allocate<DOMException>(realm, realm, name, message);
 }
 
-JS::NonnullGCPtr<DOMException> DOMException::create_with_global_object(JS::Object& global_object, FlyString const& message, FlyString const& name)
+JS::NonnullGCPtr<DOMException> DOMException::construct_impl(JS::Realm& realm, FlyString const& message, FlyString const& name)
 {
-    auto& window = verify_cast<HTML::Window>(global_object);
-    return *window.heap().allocate<DOMException>(window.realm(), window, name, message);
+    return *realm.heap().allocate<DOMException>(realm, realm, name, message);
 }
 
-DOMException::DOMException(HTML::Window& window, FlyString const& name, FlyString const& message)
-    : PlatformObject(window.realm())
+DOMException::DOMException(JS::Realm& realm, FlyString const& name, FlyString const& message)
+    : PlatformObject(realm)
     , m_name(name)
     , m_message(message)
 {
-    set_prototype(&window.cached_web_prototype("DOMException"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "DOMException"));
 }
 
 DOMException::~DOMException() = default;

--- a/Userland/Libraries/LibWeb/WebIDL/DOMException.h
+++ b/Userland/Libraries/LibWeb/WebIDL/DOMException.h
@@ -123,17 +123,13 @@ private:
     FlyString m_message;
 };
 
-#define __ENUMERATE(ErrorName)                                                                                  \
-    class ErrorName final {                                                                                     \
-    public:                                                                                                     \
-        static JS::NonnullGCPtr<DOMException> create(JS::Realm& realm, FlyString const& message)                \
-        {                                                                                                       \
-            return DOMException::create(realm, #ErrorName, message);                                            \
-        }                                                                                                       \
-        static JS::NonnullGCPtr<DOMException> create(JS::Object const& global_object, FlyString const& message) \
-        {                                                                                                       \
-            return create(HTML::relevant_realm(global_object), message);                                        \
-        }                                                                                                       \
+#define __ENUMERATE(ErrorName)                                                                   \
+    class ErrorName final {                                                                      \
+    public:                                                                                      \
+        static JS::NonnullGCPtr<DOMException> create(JS::Realm& realm, FlyString const& message) \
+        {                                                                                        \
+            return DOMException::create(realm, #ErrorName, message);                             \
+        }                                                                                        \
     };
 ENUMERATE_DOM_EXCEPTION_ERROR_NAMES
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.h
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.h
@@ -37,7 +37,7 @@ public:
         Closed = 3,
     };
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> create_with_global_object(HTML::Window&, String const& url);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> construct_impl(JS::Realm&, String const& url);
 
     virtual ~WebSocket() override;
 
@@ -66,7 +66,7 @@ private:
     void on_error();
     void on_close(u16 code, String reason, bool was_clean);
 
-    explicit WebSocket(HTML::Window&, AK::URL&);
+    WebSocket(HTML::Window&, AK::URL&);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/XHR/ProgressEvent.cpp
+++ b/Userland/Libraries/LibWeb/XHR/ProgressEvent.cpp
@@ -4,28 +4,28 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/XHR/ProgressEvent.h>
 
 namespace Web::XHR {
 
-ProgressEvent* ProgressEvent::create(HTML::Window& window_object, FlyString const& event_name, ProgressEventInit const& event_init)
+ProgressEvent* ProgressEvent::create(JS::Realm& realm, FlyString const& event_name, ProgressEventInit const& event_init)
 {
-    return window_object.heap().allocate<ProgressEvent>(window_object.realm(), window_object, event_name, event_init);
+    return realm.heap().allocate<ProgressEvent>(realm, realm, event_name, event_init);
 }
 
-ProgressEvent* ProgressEvent::create_with_global_object(HTML::Window& window_object, FlyString const& event_name, ProgressEventInit const& event_init)
+ProgressEvent* ProgressEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, ProgressEventInit const& event_init)
 {
-    return create(window_object, event_name, event_init);
+    return create(realm, event_name, event_init);
 }
 
-ProgressEvent::ProgressEvent(HTML::Window& window_object, FlyString const& event_name, ProgressEventInit const& event_init)
-    : Event(window_object, event_name, event_init)
+ProgressEvent::ProgressEvent(JS::Realm& realm, FlyString const& event_name, ProgressEventInit const& event_init)
+    : Event(realm, event_name, event_init)
     , m_length_computable(event_init.length_computable)
     , m_loaded(event_init.loaded)
     , m_total(event_init.total)
 {
-    set_prototype(&window_object.cached_web_prototype("ProgressEvent"));
+    set_prototype(&Bindings::cached_web_prototype(realm, "ProgressEvent"));
 }
 
 ProgressEvent::~ProgressEvent() = default;

--- a/Userland/Libraries/LibWeb/XHR/ProgressEvent.h
+++ b/Userland/Libraries/LibWeb/XHR/ProgressEvent.h
@@ -23,10 +23,8 @@ class ProgressEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(ProgressEvent, DOM::Event);
 
 public:
-    static ProgressEvent* create(HTML::Window&, FlyString const& event_name, ProgressEventInit const& event_init);
-    static ProgressEvent* create_with_global_object(HTML::Window&, FlyString const& event_name, ProgressEventInit const& event_init);
-
-    ProgressEvent(HTML::Window&, FlyString const& event_name, ProgressEventInit const& event_init);
+    static ProgressEvent* create(JS::Realm&, FlyString const& event_name, ProgressEventInit const& event_init);
+    static ProgressEvent* construct_impl(JS::Realm&, FlyString const& event_name, ProgressEventInit const& event_init);
 
     virtual ~ProgressEvent() override;
 
@@ -35,6 +33,8 @@ public:
     u64 total() const { return m_total; }
 
 private:
+    ProgressEvent(JS::Realm&, FlyString const& event_name, ProgressEventInit const& event_init);
+
     bool m_length_computable { false };
     u64 m_loaded { 0 };
     u64 m_total { 0 };

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -35,7 +35,7 @@ public:
         Done = 4,
     };
 
-    static JS::NonnullGCPtr<XMLHttpRequest> create_with_global_object(HTML::Window&);
+    static JS::NonnullGCPtr<XMLHttpRequest> construct_impl(JS::Realm&);
 
     virtual ~XMLHttpRequest() override;
 

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -177,7 +177,7 @@ void XMLDocumentBuilder::document_end()
         document->load_timing_info().dom_content_loaded_event_start_time = HTML::main_thread_event_loop().unsafe_shared_current_time();
 
         // Fire an event named DOMContentLoaded at the Document object, with its bubbles attribute initialized to true.
-        auto content_loaded_event = DOM::Event::create(document->window(), HTML::EventNames::DOMContentLoaded);
+        auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded);
         content_loaded_event->set_bubbles(true);
         document->dispatch_event(*content_loaded_event);
 
@@ -209,7 +209,7 @@ void XMLDocumentBuilder::document_end()
             return;
 
         // Let window be the Document's relevant global object.
-        JS::NonnullGCPtr<HTML::Window> window = document->window();
+        JS::NonnullGCPtr<HTML::Window> window = verify_cast<HTML::Window>(relevant_global_object(*document));
 
         // Set the Document's load timing info's load event start time to the current high resolution time given window.
         document->load_timing_info().load_event_start_time = HTML::main_thread_event_loop().unsafe_shared_current_time();
@@ -217,7 +217,7 @@ void XMLDocumentBuilder::document_end()
         // Fire an event named load at window, with legacy target override flag set.
         // FIXME: The legacy target override flag is currently set by a virtual override of dispatch_event()
         // We should reorganize this so that the flag appears explicitly here instead.
-        window->dispatch_event(*DOM::Event::create(document->window(), HTML::EventNames::load));
+        window->dispatch_event(*DOM::Event::create(document->realm(), HTML::EventNames::load));
 
         // FIXME: Invoke WebDriver BiDi load complete with the Document's browsing context, and a new WebDriver BiDi navigation status whose id is the Document object's navigation id, status is "complete", and url is the Document object's URL.
 

--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -29,7 +29,7 @@ WebContentConsoleClient::WebContentConsoleClient(JS::Console& console, JS::Realm
     auto console_global_object = realm.heap().allocate_without_realm<ConsoleGlobalObject>(realm, window);
 
     // NOTE: We need to push an execution context here for NativeFunction::create() to succeed during global object initialization.
-    auto& eso = verify_cast<Web::HTML::EnvironmentSettingsObject>(*realm.host_defined());
+    auto& eso = Web::Bindings::host_defined_environment_settings_object(realm);
     vm.push_execution_context(eso.realm_execution_context());
     console_global_object->initialize(realm);
     vm.pop_execution_context();
@@ -42,7 +42,7 @@ void WebContentConsoleClient::handle_input(String const& js_source)
     if (!m_realm)
         return;
 
-    auto& settings = verify_cast<Web::HTML::EnvironmentSettingsObject>(*m_realm->host_defined());
+    auto& settings = Web::Bindings::host_defined_environment_settings_object(*m_realm);
     auto script = Web::HTML::ClassicScript::create("(console)", js_source, settings, settings.api_base_url());
 
     // FIXME: Add parse error printouts back once ClassicScript can report parse errors.


### PR DESCRIPTION
This Intrinsics object hangs off of a new HostDefined struct that takes
the place of EnvironmentSettingsObject as the true [[HostDefined]] slot
on JS::Realm objects created by LibWeb.

This gets the intrinsics off of the GlobalObject, Window, similar to the
previous refactor of LibJS to move the intrinsics into the Realm's
[[Intrinics]] internal slot.

A side effect of this change is that we cannot fully initialize a Window
object until the [[HostDefined]] slot has been installed into the realm,
which happens with the creation of the WindowEnvironmentSettingsObject.

As such, any Window usage that has not been funned through a WindowESO
will not have any cached Web prototyped or constructors, and will not
have Window APIs available to javascript code. Currently this seems
limited to usage of Window in the CSS parser, but a subsequent commit
will clean those up to take Realm as well. However, this commit compiles
so let's cut it off here :^)

Ladybird PR: https://github.com/SerenityOS/ladybird/pull/79