### PR TITLE
LibGfx: Make should_wrap flag default as true on convolution filters

### DIFF
--- a/Userland/Libraries/LibGfx/Filters/GenericConvolutionFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/GenericConvolutionFilter.h
@@ -34,7 +34,7 @@ class GenericConvolutionFilter : public Filter {
 public:
     class Parameters : public Filter::Parameters {
     public:
-        Parameters(Gfx::Matrix<N, float> const& kernel, bool should_wrap = false)
+        Parameters(Gfx::Matrix<N, float> const& kernel, bool should_wrap = true)
             : m_kernel(kernel)
             , m_should_wrap(should_wrap)
 


### PR DESCRIPTION
Beginning of the solution of this issue: https://github.com/SerenityOS/serenity/issues/9175

I looked into the code and there really is a wrap around option. I tested it, and the result seems to be better. (see the screenshot)

![screenshot 1](https://user-images.githubusercontent.com/19842670/192122719-498cde12-5558-4cf4-a2c0-ddb0cb1eb658.png)

But as I was testing the other filters I saw that for every convolution based filter currently in the options it seems that the wrap around approach is also better... So this PR changes de default behaviour for convolution filters as `wrap around`.

Then, as it was discussed in the issue as a suggestion, i'm thinking of creating a UI to select the desired approach and add more options of heuristics for this problem, because in my opinion the wrap around isn't even the best one, as you can see in this other screenshot.

![screenshot 2](https://user-images.githubusercontent.com/19842670/192122738-735afb74-0a2e-4bcb-a9b5-6eadacfd4ad7.png)

I'm just thinking of doing the more simple change in this one to try to get my foot out of the door, but if you think it can't be a stand-alone PR I will work more on it.