### PR TITLE
LibWeb: Get painting effects working better with opacity and transforms 

### DIFF
--- a/Base/res/html/misc/effects_with_opacity_and_transforms.html
+++ b/Base/res/html/misc/effects_with_opacity_and_transforms.html
@@ -1,0 +1,90 @@
+<style>
+body {
+  background-image: linear-gradient(to bottom left, rgb(211, 157, 157), rgb(30, 101, 182), blue);
+}
+
+.image-box {
+  background-image: url(old-computer.png);
+  height: 120px;
+  width: 175px;
+  background-size: cover;
+  border: 2px solid black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 5px;
+}
+
+
+.backdrop-box {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 5px;
+  width: 50%;
+  height: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  backdrop-filter: grayscale() invert() blur(5px);
+}
+
+
+.box {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  background-image:  url(old-computer.png);;
+  background-size: contain;
+}
+
+.egg {
+  border: 1px solid black;
+  height: 100px;
+  width: 100px;
+  margin: 50px;
+  border-radius: 80% 15% 55% 50% / 55% 15% 80% 50%;
+  box-shadow: 20px 10px 5px magenta, cyan -20px -10px 5px, yellow 10px -5px 5px 20px;
+}
+
+.op-30 {
+  opacity: 30%;
+}
+
+.scale-up {
+  transform: scale(1.3, 1.4);
+}
+
+.scale-down {
+  transform: scale(0.5, 0.4);
+}
+</style>
+
+<table>
+  <thead>
+    <tr>
+      <th>Normal</th>
+      <th>Opacity: 30%</th>
+      <th>Scaled Up</th>
+      <th>Scaled Down</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><div class="egg"></div></td>
+      <td><div class="op-30 egg"></div></td>
+      <td><div class="scale-up egg"></div></td>
+      <td><div class="scale-down egg"></div></td>
+    </tr>
+    <tr>
+      <td><div class="box"></div></td>
+      <td><div class="op-30 box"></div></td>
+      <td><div class="scale-up box"></div></td>
+      <td><div class="scale-down box"></div></td>
+    </tr>
+    <tr>
+      <td><div class="image-box"><div class="backdrop-box"></div></div></td>
+      <td><div class="image-box"><div class="op-30 backdrop-box"></div></div></td>
+      <td><div class="image-box"><div class="scale-up backdrop-box"></div></div></td>
+      <td><div class="image-box"><div class="scale-down backdrop-box"></div></div></td>
+    </tr>
+  </tbody>
+</table>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -153,6 +153,7 @@
             <li><a href="cascade-keywords.html">Cascade keywords (initial, inherit, unset)</a></li>
             <li><a href="inline-node.html">Styling "inline" elements</a></li>
             <li><a href="pseudo-elements.html">Pseudo-elements (::before, ::after, etc)</a></li>
+            <li><a href="effects_with_opacity_and_transforms.html">Effects with opacity and transforms</a></li>
         </ul>
 
         <h2>JavaScript/Wasm</h2>

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -9,6 +9,7 @@
 #include <LibWeb/Painting/BorderPainting.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/ShadowPainting.h>
 
 namespace Web::Painting {
 
@@ -68,6 +69,8 @@ public:
         return rect;
     }
 
+    Gfx::FloatRect absolute_paint_rect() const;
+
     float border_box_width() const
     {
         auto border_box = box_model().border_box();
@@ -123,6 +126,7 @@ protected:
     virtual void paint_box_shadow(PaintContext&) const;
 
     virtual Gfx::FloatRect compute_absolute_rect() const;
+    virtual Gfx::FloatRect compute_absolute_paint_rect() const;
 
     enum class ShrinkRadiiForBorders {
         Yes,
@@ -130,6 +134,8 @@ protected:
     };
 
     Painting::BorderRadiiData normalized_border_radii_data(ShrinkRadiiForBorders shrink = ShrinkRadiiForBorders::No) const;
+
+    Vector<ShadowData> resolve_box_shadow_data() const;
 
 private:
     Optional<OverflowData> m_overflow_data;
@@ -143,6 +149,7 @@ private:
     OwnPtr<Painting::StackingContext> m_stacking_context;
 
     Optional<Gfx::FloatRect> mutable m_absolute_rect;
+    Optional<Gfx::FloatRect> mutable m_absolute_paint_rect;
 
     mutable bool m_clipping_overflow { false };
     Optional<BorderRadiusCornerClipper> mutable m_overflow_corner_radius_clipper;

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/NumericLimits.h>
 #include <LibGfx/DisjointRectSet.h>
 #include <LibGfx/Filters/StackBlurFilter.h>
 #include <LibGfx/Painter.h>
@@ -281,17 +282,22 @@ void paint_box_shadow(PaintContext& context, Gfx::IntRect const& content_rect, B
 
         // FIXME: Could reduce the shadow paints from 8 to 4 for shadows with all corner radii 50%.
 
+        // FIXME: We use this since we want the clip rect to include everything after a certain x or y.
+        // Note: Using painter.target()->width() or height() does not work, when the painter is a small
+        // translated bitmap rather than full screen, as the clip rect may not intersect.
+        constexpr auto really_large_number = NumericLimits<int>::max() / 2;
+
         // Everything above content_rect, including sides
-        paint_shadow({ 0, 0, painter.target()->width(), content_rect.top() });
+        paint_shadow({ 0, 0, really_large_number, content_rect.top() });
 
         // Everything below content_rect, including sides
-        paint_shadow({ 0, content_rect.bottom() + 1, painter.target()->width(), painter.target()->height() });
+        paint_shadow({ 0, content_rect.bottom() + 1, really_large_number, really_large_number });
 
         // Everything directly to the left of content_rect
         paint_shadow({ 0, content_rect.top(), content_rect.left(), content_rect.height() });
 
         // Everything directly to the right of content_rect
-        paint_shadow({ content_rect.right() + 1, content_rect.top(), painter.target()->width(), content_rect.height() });
+        paint_shadow({ content_rect.right() + 1, content_rect.top(), really_large_number, content_rect.height() });
 
         if (top_left_corner) {
             // Inside the top left corner (the part outside the border radius)


### PR DESCRIPTION
This fixes painting effects on elements with an `opacity` < 1, and is a _partial_ fix for elements with a `transform` such as scale.
(It also totally fixes simple translation transforms, which were quite common for centring things pre-flex) 

See commit messages for details, but I'm not sure there's a better fix while transforms work by simply scaling a bitmap. 

| Before                                                                                                          | After                                                                                                           |
|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/11597044/192149972-dd249f8f-60b7-4d03-b256-7b25764baa7d.png) | ![image](https://user-images.githubusercontent.com/11597044/192149928-d64d951d-c13f-4d7b-ac35-728ed5b91bb9.png) |

As mentioned in the commits this can produce a few scaling artefacts, like this, around elements that have been scaled:
> ![image](https://user-images.githubusercontent.com/11597044/192150246-a5747978-d421-47d3-98fa-3e04765bab6b.png)
> "Scaled D" is slightly blurred 

This is kinda unavoidable with how scaling transforms work right now (and the artefacts already existed before these changes on the scaled element itself). 
