### PR TITLE
Base: Remove period from TerminalSettings description

### DIFF
--- a/Base/res/apps/TerminalSettings.af
+++ b/Base/res/apps/TerminalSettings.af
@@ -2,4 +2,4 @@
 Name=Terminal Settings
 Executable=/bin/TerminalSettings
 Category=Settings
-Description=Configure the Terminal appearance and behavior.
+Description=Configure the Terminal appearance and behavior


### PR DESCRIPTION
Given all of the other descriptions for each setting don't include a period at the end, it won't hurt to have the TerminalSettings description do the same for consistency.