### PR TITLE
LibWeb: Add WebIDL to the IDL generator's list of web namespaces

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
@@ -93,6 +93,7 @@ int main(int argc, char** argv)
         "UIEvents"sv,
         "URL"sv,
         "WebGL"sv,
+        "WebIDL"sv,
         "WebSockets"sv,
         "XHR"sv,
     };


### PR DESCRIPTION
Without this, the generated `DOMExceptionConstructor` does not refer to the `WebIDL::DOMException` with its fully qualified name. This caused an ambiguity error on my machine.

Not sure why this doesn't happen on CI / elsewhere :man_shrugging: 
```
Build/i686/Userland/Libraries/LibWeb/Bindings/DOMExceptionConstructor.cpp:120:68: error: reference to 'DOMException' is ambiguous
  120 |     auto impl = TRY(throw_dom_exception_if_needed(vm, [&] { return DOMException::create_with_global_object(window, message, name); }));

Userland/Libraries/LibWeb/WebIDL/DOMException.h:101:7: note: candidates are: 'class Web::WebIDL::DOMException'
  101 | class DOMException final : public Bindings::PlatformObject {
      |       ^~~~~~~~~~~~

Build/i686/Root/usr/include/LibWeb/DOM/DOMException.h:101:7: note:                 'class Web::DOM::DOMException'
  101 | class DOMException final : public Bindings::PlatformObject {

```