### PR TITLE
LibMarkdown: Make images shrink-to-fit, which you can toggle by clicking on them

### DIFF
--- a/Userland/Applications/Welcome/WelcomeWidget.cpp
+++ b/Userland/Applications/Welcome/WelcomeWidget.cpp
@@ -17,9 +17,7 @@
 #include <LibGUI/Process.h>
 #include <LibGfx/Font/BitmapFont.h>
 #include <LibGfx/Palette.h>
-#include <LibMarkdown/Document.h>
 #include <LibWebView/OutOfProcessWebView.h>
-#include <serenity.h>
 
 WelcomeWidget::WelcomeWidget()
 {
@@ -104,15 +102,7 @@ void WelcomeWidget::open_and_parse_tips_file()
 
 void WelcomeWidget::open_and_parse_readme_file()
 {
-    auto file = Core::File::construct("/home/anon/README.md");
-    if (!file->open(Core::OpenMode::ReadOnly))
-        return;
-
-    auto document = Markdown::Document::parse(file->read_all());
-    if (document) {
-        auto html = document->render_to_html();
-        m_web_view->load_html(html, URL::create_with_file_protocol("/home/anon/README.md"));
-    }
+    m_web_view->load(URL::create_with_file_scheme("/home/anon/README.md"));
 }
 
 void WelcomeWidget::set_random_tip()

--- a/Userland/Applications/Welcome/main.cpp
+++ b/Userland/Applications/Welcome/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers.
+ * Copyright (c) 2021-2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,7 +11,6 @@
 #include <LibGUI/Icon.h>
 #include <LibGUI/Window.h>
 #include <LibMain/Main.h>
-#include <unistd.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -22,6 +21,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/home", "r"));
+    TRY(Core::System::unveil("/tmp/user/%uid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/user/%uid/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/bin/Help", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -218,14 +218,7 @@ void Editor::show_documentation_tooltip_if_available(String const& hovered_token
         return;
     }
 
-    StringBuilder html;
-    // FIXME: With the InProcessWebView we used to manipulate the document body directly,
-    // With OutOfProcessWebView this isn't possible (at the moment). The ideal solution
-    // is probably to tweak Markdown::Document::render_to_html() so we can inject styles
-    // into the rendered HTML easily.
-    html.append(man_document->render_to_html());
-    html.append("<style>body { background-color: #dac7b5; }</style>"sv);
-    m_documentation_page_view->load_html(html.build(), {});
+    m_documentation_page_view->load_html(man_document->render_to_html("<style>body { background-color: #dac7b5; }</style>"sv), {});
 
     m_documentation_tooltip_window->move_to(screen_location.translated(4, 4));
     m_documentation_tooltip_window->show();

--- a/Userland/Libraries/LibMarkdown/Document.cpp
+++ b/Userland/Libraries/LibMarkdown/Document.cpp
@@ -12,23 +12,29 @@
 
 namespace Markdown {
 
-String Document::render_to_html() const
+String Document::render_to_html(StringView extra_head_contents) const
 {
     StringBuilder builder;
-
-    builder.append("<!DOCTYPE html>\n"sv);
-    builder.append("<html>\n"sv);
-    builder.append("<head>\n"sv);
-    builder.append("<style>\n"sv);
-    builder.append("code { white-space: pre; }\n"sv);
-    builder.append("</style>\n"sv);
-    builder.append("</head>\n"sv);
-    builder.append("<body>\n"sv);
+    builder.append(R"~~~(<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        code { white-space: pre; }
+    </style>
+)~~~"sv);
+    if (!extra_head_contents.is_empty())
+        builder.append(extra_head_contents);
+    builder.append(R"~~~(
+</head>
+<body>
+)~~~"sv);
 
     builder.append(render_to_inline_html());
 
-    builder.append("</body>\n"sv);
-    builder.append("</html>\n"sv);
+    builder.append(R"~~~(
+</body>
+</html>)~~~"sv);
+
     return builder.build();
 }
 

--- a/Userland/Libraries/LibMarkdown/Document.h
+++ b/Userland/Libraries/LibMarkdown/Document.h
@@ -19,7 +19,7 @@ public:
         : m_container(move(container))
     {
     }
-    String render_to_html() const;
+    String render_to_html(StringView extra_head_contents = ""sv) const;
     String render_to_inline_html() const;
     String render_for_terminal(size_t view_width = 0) const;
 

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -52,7 +52,50 @@ static bool build_markdown_document(DOM::Document& document, ByteBuffer const& d
     if (!markdown_document)
         return false;
 
-    auto parser = HTML::HTMLParser::create(document, markdown_document->render_to_html(), "utf-8");
+    auto extra_head_contents = R"~~~(
+<style>
+    .zoomable {
+        cursor: zoom-in;
+        max-width: 100%;
+    }
+    .zoomable.zoomed-in {
+        cursor: zoom-out;
+        max-width: none;
+    }
+</style>
+<script>
+    function imageClickEventListener(event) {
+        let image = event.target;
+        if (image.classList.contains("zoomable")) {
+            image.classList.toggle("zoomed-in");
+        }
+    }
+    function processImages() {
+        let images = document.querySelectorAll("img");
+        let windowWidth = window.innerWidth;
+        images.forEach((image) => {
+            if (image.naturalWidth > windowWidth) {
+                image.classList.add("zoomable");
+            } else {
+                image.classList.remove("zoomable");
+                image.classList.remove("zoomed-in");
+            }
+
+            image.addEventListener("click", imageClickEventListener);
+        });
+    }
+
+    document.addEventListener("load", () => {
+        processImages();
+    });
+
+    window.addEventListener("resize", () => {
+        processImages();
+    });
+</script>
+)~~~"sv;
+
+    auto parser = HTML::HTMLParser::create(document, markdown_document->render_to_html(extra_head_contents), "utf-8");
     parser->run(document.url());
     return true;
 }

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -50,31 +50,29 @@ static Gfx::StandardCursor cursor_css_to_gfx(Optional<CSS::Cursor> cursor)
     case CSS::Cursor::Progress:
     case CSS::Cursor::Wait:
         return Gfx::StandardCursor::Wait;
-
     case CSS::Cursor::ColResize:
         return Gfx::StandardCursor::ResizeColumn;
     case CSS::Cursor::EResize:
     case CSS::Cursor::WResize:
     case CSS::Cursor::EwResize:
         return Gfx::StandardCursor::ResizeHorizontal;
-
     case CSS::Cursor::RowResize:
         return Gfx::StandardCursor::ResizeRow;
     case CSS::Cursor::NResize:
     case CSS::Cursor::SResize:
     case CSS::Cursor::NsResize:
         return Gfx::StandardCursor::ResizeVertical;
-
     case CSS::Cursor::NeResize:
     case CSS::Cursor::SwResize:
     case CSS::Cursor::NeswResize:
         return Gfx::StandardCursor::ResizeDiagonalBLTR;
-
     case CSS::Cursor::NwResize:
     case CSS::Cursor::SeResize:
     case CSS::Cursor::NwseResize:
         return Gfx::StandardCursor::ResizeDiagonalTLBR;
-
+    case CSS::Cursor::ZoomIn:
+    case CSS::Cursor::ZoomOut:
+        return Gfx::StandardCursor::Zoom;
     default:
         return Gfx::StandardCursor::None;
     }


### PR DESCRIPTION
Previously, they always showed at 100% size, which made viewing certain manual pages quite awkward. So, this PR makes them a bit smarter: If they are too wide, they shrink to fit the viewport width, with a "zoom" cursor. Clicking the image then toggles them being 100% size, or back to shrink-to-fit.

### Before clicking
![image](https://user-images.githubusercontent.com/222642/192291513-b8e46a1d-3afe-4ac0-ab12-0f691e99d464.png)

### After clicking
![image](https://user-images.githubusercontent.com/222642/192291675-7a45f95e-5f46-4a40-a178-d8a557862f17.png)