### PR TITLE
LibHTTP: Null out on_ready_to_read on socket close.

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -127,6 +127,7 @@ void Job::shutdown(ShutdownMode mode)
         return;
     if (mode == ShutdownMode::CloseSocket) {
         m_socket->close();
+        m_socket->on_ready_to_read = nullptr;
     } else {
         m_socket->on_ready_to_read = nullptr;
         m_socket = nullptr;


### PR DESCRIPTION
This fixes the segfault reported in #15283.

on_ready_to_read gets re-registered on every job start anyways.
I see no reason why this could be bad.