### PR TITLE
Kernel/FileSystem: Remove the locking of a Inode mutex in InodeVMObjects

### DIFF
--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -33,7 +33,6 @@ class Inode : public ListedRefCounted<Inode, LockType::Spinlock>
     friend class VirtualFileSystem;
     friend class FileSystem;
     friend class InodeFile;
-    friend class Kernel::Memory::SharedInodeVMObject; // FIXME: Remove when write_bytes becomes non-virtual
 
 public:
     virtual ~Inode();

--- a/Kernel/Memory/SharedInodeVMObject.cpp
+++ b/Kernel/Memory/SharedInodeVMObject.cpp
@@ -63,7 +63,6 @@ ErrorOr<void> SharedInodeVMObject::sync(off_t offset_in_pages, size_t pages)
         u8 page_buffer[PAGE_SIZE];
         MM.copy_physical_page(*physical_page, page_buffer);
 
-        MutexLocker locker(m_inode->m_inode_lock);
         TRY(m_inode->write_bytes(page_index * PAGE_SIZE, PAGE_SIZE, UserOrKernelBuffer::for_kernel_buffer(page_buffer), nullptr));
     }
 


### PR DESCRIPTION
We no longer require to lock the m_inode_lock outside of the methods of Inode, because now write_bytes and read_bytes method do this for us.