### PR TITLE
Userland: Replace empty `GUI::Widget`s in GML with `GUI::Layout::Spacer`

### DIFF
--- a/Userland/Applications/Browser/EditBookmark.gml
+++ b/Userland/Applications/Browser/EditBookmark.gml
@@ -40,7 +40,7 @@
         fixed_height: 24
         layout: @GUI::HorizontalBoxLayout {}
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::Button {
             name: "ok_button"

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.gml
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.gml
@@ -23,7 +23,7 @@
             fixed_height: 32
             layout: @GUI::HorizontalBoxLayout {}
 
-            @GUI::Widget {}
+            @GUI::Layout::Spacer {}
 
             @GUI::Button {
                 name: "add_new_domain_button"

--- a/Userland/Applications/FileManager/FileOperationProgress.gml
+++ b/Userland/Applications/FileManager/FileOperationProgress.gml
@@ -84,7 +84,7 @@
         shrink_to_fit: true
         layout: @GUI::HorizontalBoxLayout {}
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::Button {
             text: "Cancel"

--- a/Userland/Applications/MouseSettings/Mouse.gml
+++ b/Userland/Applications/MouseSettings/Mouse.gml
@@ -100,7 +100,7 @@
                 fixed_width: 100
             }
 
-            @GUI::Widget {}
+            @GUI::Layout::Spacer {}
         }
     }
 

--- a/Userland/Applications/Spreadsheet/csv_export.gml
+++ b/Userland/Applications/Spreadsheet/csv_export.gml
@@ -92,7 +92,7 @@
                         }
                     }
 
-                    @GUI::Widget {}
+                    @GUI::Layout::Spacer {}
 
                     @GUI::Widget {
                         fixed_height: 25
@@ -109,7 +109,7 @@
                         }
                     }
 
-                    @GUI::Widget {}
+                    @GUI::Layout::Spacer {}
                 }
             }
 

--- a/Userland/Applications/Spreadsheet/csv_import.gml
+++ b/Userland/Applications/Spreadsheet/csv_import.gml
@@ -92,7 +92,7 @@
                         }
                     }
 
-                    @GUI::Widget {}
+                    @GUI::Layout::Spacer {}
 
                     @GUI::Widget {
                         fixed_height: 25
@@ -109,7 +109,7 @@
                         }
                     }
 
-                    @GUI::Widget {}
+                    @GUI::Layout::Spacer {}
                 }
             }
 

--- a/Userland/Applications/Spreadsheet/select_format_page.gml
+++ b/Userland/Applications/Spreadsheet/select_format_page.gml
@@ -25,5 +25,5 @@
         }
     }
 
-    @GUI::Widget {}
+    @GUI::Layout::Spacer {}
 }

--- a/Userland/Applications/Welcome/WelcomeWindow.gml
+++ b/Userland/Applications/Welcome/WelcomeWindow.gml
@@ -29,7 +29,7 @@
                     fixed_height: 60
                 }
 
-                @GUI::Widget {}
+                @GUI::Layout::Spacer {}
             }
 
             @GUI::Widget {

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.gml
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.gml
@@ -86,7 +86,7 @@
         layout: @GUI::HorizontalBoxLayout {}
         max_height: 24
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::Button {
             name: "ok_button"

--- a/Userland/Libraries/LibGUI/FontPickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FontPickerDialog.gml
@@ -71,7 +71,7 @@
         fixed_height: 22
         layout: @GUI::HorizontalBoxLayout {}
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::DialogButton {
             name: "ok_button"

--- a/Userland/Libraries/LibGUI/PasswordInputDialog.gml
+++ b/Userland/Libraries/LibGUI/PasswordInputDialog.gml
@@ -78,7 +78,7 @@
                 spacing: 6
             }
 
-            @GUI::Widget {}
+            @GUI::Layout::Spacer {}
 
             @GUI::DialogButton {
                 text: "OK"


### PR DESCRIPTION
This fixes the "Cancel" button on HackStudio's "New Project" dialog being too small. It's also clearer what these actually are.