### PR TITLE
Calendar: Only accept Calendar notifications

### DIFF
--- a/Userland/Libraries/LibGUI/Calendar.cpp
+++ b/Userland/Libraries/LibGUI/Calendar.cpp
@@ -757,8 +757,7 @@ size_t Calendar::day_of_week_index(String const& day_name)
 
 void Calendar::config_string_did_change(String const& domain, String const& group, String const& key, String const& value)
 {
-    VERIFY(domain == "Calendar");
-    if (group == "View" && key == "FirstDayOfWeek") {
+    if (domain == "Calendar" && group == "View" && key == "FirstDayOfWeek") {
         m_first_day_of_week = static_cast<DayOfWeek>(day_of_week_index(value));
         update_tiles(m_view_year, m_view_month);
     }

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -101,11 +101,7 @@ TaskbarWindow::TaskbarWindow(NonnullRefPtr<GUI::Menu> start_menu)
 
 void TaskbarWindow::config_string_did_change(String const& domain, String const& group, String const& key, String const& value)
 {
-    if (domain == "Calendar"sv)
-        return;
-
-    VERIFY(domain == "Taskbar");
-    if (group == "Clock" && key == "TimeFormat") {
+    if (domain == "Taskbar" && group == "Clock" && key == "TimeFormat") {
         m_clock_widget->update_format(value);
         update_applet_area();
     }


### PR DESCRIPTION
Previously, changing the time format caused Taskbar to crash.

This commit also simplifies TaskbarWindow::config_string_did_change() so that it is in line with the changes made to Calendar::config_string_did_change().