### PR TITLE
Kernel: Make the ACPI DSDT table accessible from ACPI::Parser and in /sys/firmware/acpi

### DIFF
--- a/Kernel/Firmware/ACPI/Definitions.h
+++ b/Kernel/Firmware/ACPI/Definitions.h
@@ -320,6 +320,11 @@ struct [[gnu::packed]] MCFG {
     u64 reserved;
     PCI_MMIO_Descriptor descriptors[];
 };
+
+struct [[gnu::packed]] DSDT {
+    SDTHeader h;
+    unsigned char definition_block[];
+};
 }
 
 class Parser;

--- a/Kernel/Firmware/ACPI/Parser.h
+++ b/Kernel/Firmware/ACPI/Parser.h
@@ -89,6 +89,7 @@ private:
     size_t get_table_size(PhysicalAddress);
     u8 get_table_revision(PhysicalAddress);
     void process_fadt_data();
+    void process_dsdt();
 
     bool validate_reset_register(Memory::TypedMapping<Structures::FADT> const&);
     void access_generic_address(Structures::GenericAddressStructure const&, u32 value);


### PR DESCRIPTION
A first little step toward interpreting the AML bytecode from ACPI.