### PR TITLE
rev: Add support for the '-' filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ output/
 run-local.sh
 sync-local.sh
 .vim/
+.exrc
 
 Userland/Libraries/LibWasm/Tests/Fixtures/SpecTests
 Userland/Libraries/LibWasm/Tests/Spec

--- a/Base/usr/share/man/man1/rev.md
+++ b/Base/usr/share/man/man1/rev.md
@@ -5,14 +5,19 @@ rev - reverse lines
 ## Synopsis
 
 ```*sh
-$ rev [files...]
+$ rev [file...]
 ```
 
 ## Description
 
 `rev` reads the specified files line by line, and prints them to standard
 output with each line being reversed characterwise. If no files are specified,
-then `rev` will read from standard input.
+then `rev` will read from standard input. If the file `-` is specified then
+`rev` also reads from standard input.
+
+## Arguments
+
+* `file`: Files to print
 
 ## Examples
 
@@ -36,6 +41,21 @@ $ ls
 foo
 bar
 $ ls | rev
+oof
+rab
+```
+
+To print a file 'foo' in reverse followed by the output of `ls` in reverse:
+```sh
+$ cat foo
+foo 1
+foo 2
+$ ls
+foo
+bar
+$ ls | rev foo -
+1 oof
+2 oof
 oof
 rab
 ```


### PR DESCRIPTION
- Meta: Ignore vim's .exrc config
- Rev: Read from stdin if the filename '-' is given
- Rev: Document the '-' filename
