### PR TITLE
LibCompress: Fix Brotli meta-data block MSKIPLEN calculation

### DIFF
--- a/Userland/Libraries/LibCompress/Brotli.cpp
+++ b/Userland/Libraries/LibCompress/Brotli.cpp
@@ -605,7 +605,10 @@ ErrorOr<Bytes> BrotliDecompressionStream::read(Bytes output_buffer)
                     return Error::from_string_literal("invalid reserved bit");
 
                 size_t skip_bytes = TRY(m_input_stream.read_bits(2));
-                size_t skip_length = 1 + TRY(m_input_stream.read_bits(8 * skip_bytes));
+                size_t skip_length = 0;
+
+                if (skip_bytes > 0)
+                    skip_length = 1 + TRY(m_input_stream.read_bits(8 * skip_bytes));
 
                 u8 remainder = m_input_stream.align_to_byte_boundary();
                 if (remainder != 0)


### PR DESCRIPTION
According to the [Brotli spec section 9.2](https://www.rfc-editor.org/rfc/rfc7932#section-9.2), skip bytes * 8 gives us the skip length - 1, but only in the case where skip bytes is positive, otherwise skip length is 0.

We didn't take this condition into consideration and were simply always adding one to skip length. This caused us to always skip some bytes and fail to decompress valid streams.

This commit fixes the actual root cause of #15283.