### PR TITLE
AK+LibWeb: Replace the use of "protocol" with "scheme" for URLs and Origins

### DIFF
--- a/AK/URL.h
+++ b/AK/URL.h
@@ -46,7 +46,6 @@ public:
     bool is_valid() const { return m_valid; }
 
     String const& scheme() const { return m_scheme; }
-    String const& protocol() const { return m_scheme; }
     String const& username() const { return m_username; }
     String const& password() const { return m_password; }
     String const& host() const { return m_host; }
@@ -62,7 +61,6 @@ public:
     bool is_special() const { return is_special_scheme(m_scheme); }
 
     void set_scheme(String);
-    void set_protocol(String protocol) { set_scheme(move(protocol)); }
     void set_username(String);
     void set_password(String);
     void set_host(String);
@@ -93,7 +91,6 @@ public:
 
     static URL create_with_url_or_path(String const&);
     static URL create_with_file_scheme(String const& path, String const& fragment = {}, String const& hostname = {});
-    static URL create_with_file_protocol(String const& path, String const& fragment = {}) { return create_with_file_scheme(path, fragment); }
     static URL create_with_help_scheme(String const& path, String const& fragment = {}, String const& hostname = {});
     static URL create_with_data(String mime_type, String payload, bool is_base64 = false) { return URL(move(mime_type), move(payload), is_base64); };
 

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -136,7 +136,7 @@ void GLContextWidget::drop_event(GUI::DropEvent& event)
         return;
 
     for (auto& url : event.mime_data().urls()) {
-        if (url.protocol() != "file")
+        if (url.scheme() != "file")
             continue;
 
         auto response = FileSystemAccessClient::Client::the().try_request_file(window(), url.path(), Core::OpenMode::ReadOnly);

--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -44,7 +44,7 @@ void CalculatorResult::activate() const
 
 void FileResult::activate() const
 {
-    Desktop::Launcher::open(URL::create_with_file_protocol(title()));
+    Desktop::Launcher::open(URL::create_with_file_scheme(title()));
 }
 
 void TerminalResult::activate() const

--- a/Userland/Applications/Browser/CookieJar.cpp
+++ b/Userland/Applications/Browser/CookieJar.cpp
@@ -273,7 +273,7 @@ Vector<Web::Cookie::Cookie&> CookieJar::get_matching_cookies(const URL& url, Str
             continue;
 
         // If the cookie's secure-only-flag is true, then the request-uri's scheme must denote a "secure" protocol.
-        if (cookie.value.secure && (url.protocol() != "https"))
+        if (cookie.value.secure && (url.scheme() != "https"))
             continue;
 
         // If the cookie's http-only-flag is true, then exclude the cookie if the cookie-string is being generated for a "non-HTTP" API.

--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -155,7 +155,7 @@ void DownloadWidget::did_finish(bool success)
     m_close_button->set_enabled(true);
     m_cancel_button->set_text("Open in Folder");
     m_cancel_button->on_click = [this](auto) {
-        Desktop::Launcher::open(URL::create_with_file_protocol(Core::StandardPaths::downloads_directory(), m_url.basename()));
+        Desktop::Launcher::open(URL::create_with_file_scheme(Core::StandardPaths::downloads_directory(), m_url.basename()));
         window()->close();
     };
     m_cancel_button->update();

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -77,7 +77,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // Connect to LaunchServer immediately and let it know that we won't ask for anything other than opening
     // the user's downloads directory.
     // FIXME: This should go away with a standalone download manager at some point.
-    TRY(Desktop::Launcher::add_allowed_url(URL::create_with_file_protocol(Core::StandardPaths::downloads_directory())));
+    TRY(Desktop::Launcher::add_allowed_url(URL::create_with_file_scheme(Core::StandardPaths::downloads_directory())));
     TRY(Desktop::Launcher::seal_allowlist());
 
     TRY(Core::System::unveil("/home", "rwc"));
@@ -120,7 +120,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto url_from_argument_string = [](String const& string) -> URL {
         if (Core::File::exists(string)) {
-            return URL::create_with_file_protocol(Core::File::real_path_for(string));
+            return URL::create_with_file_scheme(Core::File::real_path_for(string));
         }
         return Browser::url_from_user_input(string);
     };

--- a/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
@@ -158,7 +158,7 @@ void CharacterMapWidget::initialize_menubar(GUI::Window& window)
 
     auto& help_menu = window.add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_help_action([&](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/CharacterMap.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/CharacterMap.md"), "/bin/Help");
     }));
     help_menu.add_action(GUI::CommonActions::make_about_action("Character Map", GUI::Icon::default_icon("app-character-map"sv), &window));
 }

--- a/Userland/Applications/CharacterMap/main.cpp
+++ b/Userland/Applications/CharacterMap/main.cpp
@@ -45,7 +45,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("CharacterMap");
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/CharacterMap.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man1/CharacterMap.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -200,14 +200,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     executable_link_label.set_text(LexicalPath::canonicalized_path(executable_path));
     executable_link_label.on_click = [&] {
         LexicalPath path { executable_path };
-        Desktop::Launcher::open(URL::create_with_file_protocol(path.dirname(), path.basename()));
+        Desktop::Launcher::open(URL::create_with_file_scheme(path.dirname(), path.basename()));
     };
 
     auto& coredump_link_label = *widget->find_descendant_of_type_named<GUI::LinkLabel>("coredump_link");
     coredump_link_label.set_text(LexicalPath::canonicalized_path(coredump_path));
     coredump_link_label.on_click = [&] {
         LexicalPath path { coredump_path };
-        Desktop::Launcher::open(URL::create_with_file_protocol(path.dirname(), path.basename()));
+        Desktop::Launcher::open(URL::create_with_file_scheme(path.dirname(), path.basename()));
     };
 
     auto& arguments_label = *widget->find_descendant_of_type_named<GUI::Label>("arguments_label");

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -67,14 +67,14 @@ void BackgroundSettingsWidget::create_frame()
     m_context_menu = GUI::Menu::construct();
     m_show_in_file_manager_action = GUI::Action::create("Show in File Manager", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-file-manager.png"sv).release_value_but_fixme_should_propagate_errors(), [this](GUI::Action const&) {
         LexicalPath path { m_monitor_widget->wallpaper() };
-        Desktop::Launcher::open(URL::create_with_file_protocol(path.dirname(), path.basename()));
+        Desktop::Launcher::open(URL::create_with_file_scheme(path.dirname(), path.basename()));
     });
     m_context_menu->add_action(*m_show_in_file_manager_action);
 
     m_context_menu->add_separator();
     m_copy_action = GUI::CommonActions::make_copy_action(
         [this](auto&) {
-            auto url = URL::create_with_file_protocol(m_monitor_widget->wallpaper()).to_string();
+            auto url = URL::create_with_file_scheme(m_monitor_widget->wallpaper()).to_string();
             GUI::Clipboard::the().set_data(url.bytes(), "text/uri-list");
         },
         this);

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -88,7 +88,7 @@ NonnullRefPtrVector<LauncherHandler> DirectoryView::get_launch_handlers(URL cons
 
 NonnullRefPtrVector<LauncherHandler> DirectoryView::get_launch_handlers(String const& path)
 {
-    return get_launch_handlers(URL::create_with_file_protocol(path));
+    return get_launch_handlers(URL::create_with_file_scheme(path));
 }
 
 void DirectoryView::handle_activation(GUI::ModelIndex const& index)
@@ -107,14 +107,14 @@ void DirectoryView::handle_activation(GUI::ModelIndex const& index)
 
     if (S_ISDIR(st.st_mode)) {
         if (is_desktop()) {
-            Desktop::Launcher::open(URL::create_with_file_protocol(path));
+            Desktop::Launcher::open(URL::create_with_file_scheme(path));
             return;
         }
         open(path);
         return;
     }
 
-    auto url = URL::create_with_file_protocol(path);
+    auto url = URL::create_with_file_scheme(path);
     auto launcher_handlers = get_launch_handlers(url);
     auto default_launcher = get_default_launch_handler(launcher_handlers);
 

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -91,7 +91,7 @@ PropertiesWindow::PropertiesWindow(String const& path, bool disable_rename, Wind
     auto location = general_tab.find_descendant_of_type_named<GUI::LinkLabel>("location");
     location->set_text(path);
     location->on_click = [this] {
-        Desktop::Launcher::open(URL::create_with_file_protocol(m_parent_path, m_name));
+        Desktop::Launcher::open(URL::create_with_file_scheme(m_parent_path, m_name));
     };
 
     if (S_ISLNK(m_mode)) {
@@ -104,7 +104,7 @@ PropertiesWindow::PropertiesWindow(String const& path, bool disable_rename, Wind
             link_location->set_text(link_destination);
             link_location->on_click = [link_destination] {
                 auto link_directory = LexicalPath(link_destination);
-                Desktop::Launcher::open(URL::create_with_file_protocol(link_directory.dirname(), link_directory.basename()));
+                Desktop::Launcher::open(URL::create_with_file_scheme(link_directory.dirname(), link_directory.basename()));
             };
         }
     } else {

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -139,7 +139,7 @@ void do_copy(Vector<String> const& selected_file_paths, FileOperation file_opera
         copy_text.append("#cut\n"sv); // This exploits the comment lines in the text/uri-list specification, which might be a bit hackish
     }
     for (auto& path : selected_file_paths) {
-        auto url = URL::create_with_file_protocol(path);
+        auto url = URL::create_with_file_scheme(path);
         copy_text.appendff("{}\n", url);
     }
     GUI::Clipboard::the().set_data(copy_text.build().bytes(), "text/uri-list");
@@ -169,7 +169,7 @@ void do_paste(String const& target_directory, GUI::Window* window)
         if (uri_as_string.is_empty())
             continue;
         URL url = uri_as_string;
-        if (!url.is_valid() || url.protocol() != "file") {
+        if (!url.is_valid() || url.scheme() != "file") {
             dbgln("Cannot paste URI {}", uri_as_string);
             continue;
         }
@@ -309,7 +309,7 @@ bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView c
     auto default_file_handler = directory_view.get_default_launch_handler(current_file_launch_handlers);
     if (default_file_handler) {
         auto file_open_action = default_file_handler->create_launch_action([&, full_path = move(full_path)](auto& launcher_handler) {
-            directory_view.launch(URL::create_with_file_protocol(full_path), launcher_handler);
+            directory_view.launch(URL::create_with_file_scheme(full_path), launcher_handler);
         });
         if (default_file_handler->details().launcher_type == Desktop::Launcher::LauncherType::Application)
             file_open_action->set_text(String::formatted("Run {}", file_open_action->text()));
@@ -331,7 +331,7 @@ bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView c
             if (&handler == default_file_handler.ptr())
                 continue;
             file_open_with_menu.add_action(handler.create_launch_action([&, full_path = move(full_path)](auto& launcher_handler) {
-                directory_view.launch(URL::create_with_file_protocol(full_path), launcher_handler);
+                directory_view.launch(URL::create_with_file_scheme(full_path), launcher_handler);
             }));
         }
     }
@@ -444,13 +444,13 @@ ErrorOr<int> run_in_desktop_mode()
     auto file_manager_action = GUI::Action::create("Open in File &Manager", {}, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-file-manager.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         auto paths = directory_view->selected_file_paths();
         if (paths.is_empty()) {
-            Desktop::Launcher::open(URL::create_with_file_protocol(directory_view->path()));
+            Desktop::Launcher::open(URL::create_with_file_scheme(directory_view->path()));
             return;
         }
 
         for (auto& path : paths) {
             if (Core::File::is_directory(path))
-                Desktop::Launcher::open(URL::create_with_file_protocol(path));
+                Desktop::Launcher::open(URL::create_with_file_scheme(path));
         }
     });
 
@@ -469,7 +469,7 @@ ErrorOr<int> run_in_desktop_mode()
     });
 
     auto display_properties_action = GUI::Action::create("&Display Settings", {}, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-display-settings.png"sv).release_value_but_fixme_should_propagate_errors(), [&](GUI::Action const&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/bin/DisplaySettings"));
+        Desktop::Launcher::open(URL::create_with_file_scheme("/bin/DisplaySettings"));
     });
 
     TRY(desktop_view_context_menu->try_add_action(directory_view->mkdir_action()));
@@ -801,7 +801,7 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
 
                 for (auto& path : paths) {
                     if (Core::File::is_directory(path))
-                        Desktop::Launcher::open(URL::create_with_file_protocol(path));
+                        Desktop::Launcher::open(URL::create_with_file_scheme(path));
                 }
             },
             window);

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -670,7 +670,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
 
     auto help_menu = TRY(window.try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/FontEditor.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/FontEditor.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Font Editor", TRY(GUI::Icon::try_create_default_icon("app-font-editor"sv)), &window)));
 

--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/FontEditor.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man1/FontEditor.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     Config::pledge_domain("FontEditor");

--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -92,7 +92,7 @@ MainWidget::MainWidget()
 
     m_web_view = find_descendant_of_type_named<WebView::OutOfProcessWebView>("web_view");
     m_web_view->on_link_click = [this](auto& url, auto&, unsigned) {
-        if (url.protocol() == "file") {
+        if (url.scheme() == "file") {
             auto path = url.path();
             if (!path.starts_with("/usr/share/man/"sv)) {
                 open_external(url);
@@ -106,7 +106,7 @@ MainWidget::MainWidget()
             }
             m_history.push(path);
             open_page(path);
-        } else if (url.protocol() == "help") {
+        } else if (url.scheme() == "help") {
             if (url.host() == "man") {
                 if (url.paths().size() != 2) {
                     dbgln("Bad help page URL '{}'", url);
@@ -272,7 +272,7 @@ void MainWidget::open_url(URL const& url)
     m_go_back_action->set_enabled(m_history.can_go_back());
     m_go_forward_action->set_enabled(m_history.can_go_forward());
 
-    if (url.protocol() == "file") {
+    if (url.scheme() == "file") {
         m_web_view->load(url);
         m_web_view->scroll_to_top();
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -470,7 +470,7 @@ void HexEditorWidget::initialize_menubar(GUI::Window& window)
 
     auto& help_menu = window.add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/HexEditor.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/HexEditor.md"), "/bin/Help");
     }));
     help_menu.add_action(GUI::CommonActions::make_about_action("Hex Editor", GUI::Icon::default_icon("app-hex-editor"sv), &window));
 }

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/HexEditor.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man1/HexEditor.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     Config::pledge_domain("HexEditor");

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -40,7 +40,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Desktop::Launcher::add_allowed_handler_with_any_url("/bin/ImageViewer"));
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/ImageViewer.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man1/ImageViewer.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     auto app_icon = GUI::Icon::default_icon("filetype-image"sv);
@@ -97,7 +97,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         widget->load_from_file(path);
 
         for (size_t i = 1; i < urls.size(); ++i) {
-            Desktop::Launcher::open(URL::create_with_file_protocol(urls[i].path().characters()), "/bin/ImageViewer");
+            Desktop::Launcher::open(URL::create_with_file_scheme(urls[i].path().characters()), "/bin/ImageViewer");
         }
     };
     widget->on_doubleclick = [&] {
@@ -330,7 +330,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/ImageViewer.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/ImageViewer.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Image Viewer", app_icon, window)));
 

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -103,7 +103,7 @@ bool MailWidget::connect_and_login()
     if (server.is_empty()) {
         auto result = GUI::MessageBox::show(window(), "Mail has no servers configured. Do you want configure them now?"sv, "Error"sv, GUI::MessageBox::Type::Error, GUI::MessageBox::InputType::YesNo);
         if (result == GUI::MessageBox::ExecResult::Yes)
-            Desktop::Launcher::open(URL::create_with_file_protocol("/bin/MailSettings"));
+            Desktop::Launcher::open(URL::create_with_file_scheme("/bin/MailSettings"));
         return false;
     }
 

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/tmp/user/%uid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    TRY(Desktop::Launcher::add_allowed_url(URL::create_with_file_protocol("/bin/MailSettings")));
+    TRY(Desktop::Launcher::add_allowed_url(URL::create_with_file_scheme("/bin/MailSettings")));
     TRY(Desktop::Launcher::add_allowed_handler_with_any_url("/bin/MailSettings"));
     TRY(Desktop::Launcher::seal_allowlist());
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1058,7 +1058,7 @@ void MainWidget::drop_event(GUI::DropEvent& event)
         return;
 
     for (auto& url : event.mime_data().urls()) {
-        if (url.protocol() != "file")
+        if (url.scheme() != "file")
             continue;
 
         auto response = FileSystemAccessClient::Client::the().try_request_file(window(), url.path(), Core::OpenMode::ReadOnly);

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -142,7 +142,7 @@ bool RunWindow::run_via_launch(String const& run_input)
 {
     auto url = URL::create_with_url_or_path(run_input);
 
-    if (url.protocol() == "file") {
+    if (url.scheme() == "file") {
         auto real_path = Core::File::real_path_for(url.path());
         if (real_path.is_null()) {
             // errno *should* be preserved from Core::File::real_path_for().

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -337,11 +337,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     // Configure the nodes context menu.
     auto open_folder_action = GUI::Action::create("Open Folder", { Mod_Ctrl, Key_O }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol(get_absolute_path_to_selected_node(treemapwidget)));
+        Desktop::Launcher::open(URL::create_with_file_scheme(get_absolute_path_to_selected_node(treemapwidget)));
     });
     auto open_containing_folder_action = GUI::Action::create("Open Containing Folder", { Mod_Ctrl, Key_O }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         LexicalPath path { get_absolute_path_to_selected_node(treemapwidget) };
-        Desktop::Launcher::open(URL::create_with_file_protocol(path.dirname(), path.basename()));
+        Desktop::Launcher::open(URL::create_with_file_scheme(path.dirname(), path.basename()));
     });
     auto copy_path_action = GUI::Action::create("Copy Path to Clipboard", { Mod_Ctrl, Key_C }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-copy.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         GUI::Clipboard::the().set_plain_text(get_absolute_path_to_selected_node(treemapwidget));

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -81,7 +81,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
 
     m_webview = splitter.add<WebView::OutOfProcessWebView>();
     m_webview->on_link_click = [this](auto& url, auto&, auto&&) {
-        VERIFY(url.protocol() == "spreadsheet");
+        VERIFY(url.scheme() == "spreadsheet");
         if (url.host() == "example") {
             auto entry = LexicalPath::basename(url.path());
             auto doc_option = m_docs.get(entry);

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -264,7 +264,7 @@ Optional<Position> Sheet::position_from_url(const URL& url) const
         return {};
     }
 
-    if (url.protocol() != "spreadsheet" || url.host() != "cell") {
+    if (url.scheme() != "spreadsheet" || url.host() != "cell") {
         dbgln("Bad url: {}", url.to_string());
         return {};
     }
@@ -756,7 +756,7 @@ String Position::to_cell_identifier(Sheet const& sheet) const
 URL Position::to_url(Sheet const& sheet) const
 {
     URL url;
-    url.set_protocol("spreadsheet");
+    url.set_scheme("spreadsheet");
     url.set_host("cell");
     url.set_paths({ String::number(getpid()) });
     url.set_fragment(to_cell_identifier(sheet));

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -412,7 +412,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/Terminal.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/Terminal.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Terminal", app_icon, window)));
 

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -618,7 +618,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
 
     auto& help_menu = window.add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/TextEditor.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/TextEditor.md"), "/bin/Help");
     }));
     help_menu.add_action(GUI::CommonActions::make_about_action("Text Editor", GUI::Icon::default_icon("app-text-editor"sv), &window));
 
@@ -813,7 +813,7 @@ void MainWidget::update_markdown_preview()
     if (document) {
         auto html = document->render_to_html();
         auto current_scroll_pos = m_page_view->visible_content_rect();
-        m_page_view->load_html(html, URL::create_with_file_protocol(m_path));
+        m_page_view->load_html(html, URL::create_with_file_scheme(m_path));
         m_page_view->scroll_into_view(current_scroll_pos, true, true);
     }
 }
@@ -821,7 +821,7 @@ void MainWidget::update_markdown_preview()
 void MainWidget::update_html_preview()
 {
     auto current_scroll_pos = m_page_view->visible_content_rect();
-    m_page_view->load_html(m_editor->text(), URL::create_with_file_protocol(m_path));
+    m_page_view->load_html(m_editor->text(), URL::create_with_file_scheme(m_path));
     m_page_view->scroll_into_view(current_scroll_pos, true, true);
 }
 

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -91,7 +91,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/Eyes.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/Eyes.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Eyes Demo", app_icon, window)));
 

--- a/Userland/DevTools/GMLPlayground/main.cpp
+++ b/Userland/DevTools/GMLPlayground/main.cpp
@@ -67,7 +67,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio thread recvfd sendfd cpath rpath wpath unix"));
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/GMLPlayground.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man1/GMLPlayground.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     TRY(Core::System::pledge("stdio thread recvfd sendfd rpath cpath wpath"));
@@ -248,7 +248,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/GMLPlayground.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/GMLPlayground.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("GML Playground", app_icon, window)));
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -606,7 +606,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_show_in_file_manager_action(
     auto show_in_file_manager_action = GUI::Action::create("Show in File &Manager", [this](const GUI::Action&) {
         auto files = selected_file_paths();
         for (auto& file : files)
-            Desktop::Launcher::open(URL::create_with_file_protocol(m_project->root_path(), file));
+            Desktop::Launcher::open(URL::create_with_file_scheme(m_project->root_path(), file));
     });
     show_in_file_manager_action->set_enabled(true);
     show_in_file_manager_action->set_icon(GUI::Icon::default_icon("app-file-manager"sv).bitmap_for_size(16));

--- a/Userland/DevTools/Inspector/main.cpp
+++ b/Userland/DevTools/Inspector/main.cpp
@@ -79,7 +79,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     }
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/Inspector.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man1/Inspector.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     window->set_title("Inspector");
@@ -91,7 +91,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto& help_menu = window->add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/Inspector.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/Inspector.md"), "/bin/Help");
     }));
     help_menu.add_action(GUI::CommonActions::make_about_action("Inspector", app_icon, window));
 

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -79,7 +79,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::Window::try_create());
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/Profiler.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man1/Profiler.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     window->set_title("Profiler");
@@ -301,7 +301,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/Profiler.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/Profiler.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Profiler", app_icon, window)));
 

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -265,7 +265,7 @@ void MainWidget::initialize_menu(GUI::Window* window)
 
     auto& help_menu = window->add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/SQLStudio.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/SQLStudio.md"), "/bin/Help");
     }));
     help_menu.add_action(GUI::CommonActions::make_about_action("SQL Studio", GUI::Icon::default_icon("app-sql-studio"sv), window));
 }

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("2048");
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/2048.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/2048.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
@@ -203,7 +203,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man6/2048.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man6/2048.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("2048", app_icon, window)));
 

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("Chess");
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Chess.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/Chess.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-chess"sv));
@@ -177,7 +177,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man6/Chess.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man6/Chess.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Chess", app_icon, window)));
 

--- a/Userland/Games/FlappyBug/main.cpp
+++ b/Userland/Games/FlappyBug/main.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("FlappyBug");
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/FlappyBug.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/FlappyBug.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
@@ -62,7 +62,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man6/FlappyBug.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man6/FlappyBug.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Flappy Bug", app_icon, window)));
 

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/GameOfLife.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/GameOfLife.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
@@ -140,7 +140,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man6/GameOfLife.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man6/GameOfLife.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Game Of Life", app_icon, window)));
 

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -37,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Hearts.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/Hearts.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
@@ -101,7 +101,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man6/Hearts.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man6/Hearts.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Hearts", app_icon, window)));
 

--- a/Userland/Games/MasterWord/main.cpp
+++ b/Userland/Games/MasterWord/main.cpp
@@ -27,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("MasterWord");
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/MasterWord.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/MasterWord.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
@@ -133,7 +133,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man6/MasterWord.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man6/MasterWord.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("MasterWord", app_icon, window)));
 

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("Minesweeper");
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Minesweeper.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/Minesweeper.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
@@ -124,7 +124,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man6/Minesweeper.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man6/Minesweeper.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Minesweeper", app_icon, window)));
 

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("Snake");
 
-    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Snake.md") }));
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/Snake.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
@@ -59,7 +59,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man6/Snake.md"), "/bin/Help");
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man6/Snake.md"), "/bin/Help");
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Snake", app_icon, window)));
 

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -1145,7 +1145,7 @@ void TerminalWidget::drop_event(GUI::DropEvent& event)
             if (!first)
                 send_non_user_input(" "sv.bytes());
 
-            if (url.protocol() == "file")
+            if (url.scheme() == "file")
                 send_non_user_input(url.path().bytes());
             else
                 send_non_user_input(url.to_string().bytes());

--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
@@ -204,7 +204,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocationObject::protocol_getter)
     // FIXME: 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
 
     // 2. Return this's url's scheme, followed by ":".
-    return JS::js_string(vm, String::formatted("{}:", location_object->url().protocol()));
+    return JS::js_string(vm, String::formatted("{}:", location_object->url().scheme()));
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-location-port

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1383,7 +1383,7 @@ void StyleComputer::load_fonts_from_sheet(CSSStyleSheet const& sheet)
             if (!source.url.is_valid())
                 continue;
 
-            if (source.url.protocol() != "data") {
+            if (source.url.scheme() != "data") {
                 auto path = source.url.path();
                 if (!path.ends_with(".woff"sv, AK::CaseSensitivity::CaseInsensitive)
                     && !path.ends_with(".ttf"sv, AK::CaseSensitivity::CaseInsensitive)) {

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -56,7 +56,7 @@ static HTML::Origin url_origin(AK::URL const& url)
     if (url.scheme() == "file"sv) {
         // Unfortunate as it is, this is left as an exercise to the reader. When in doubt, return a new opaque origin.
         // Note: We must return an origin with the `file://' protocol for `file://' iframes to work from `file://' pages.
-        return HTML::Origin(url.protocol(), String(), 0);
+        return HTML::Origin(url.scheme(), String(), 0);
     }
 
     return HTML::Origin {};

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.cpp
@@ -168,7 +168,7 @@ void BrowsingContextContainer::shared_attribute_processing_steps_for_iframe_and_
     // FIXME: Set the referrer policy.
 
     // AD-HOC:
-    if (url.protocol() == "file" && document().origin().protocol() != "file") {
+    if (url.scheme() == "file" && document().origin().protocol() != "file") {
         dbgln("iframe failed to load URL: Security violation: {} may not load {}", document().url(), url);
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.cpp
@@ -168,7 +168,7 @@ void BrowsingContextContainer::shared_attribute_processing_steps_for_iframe_and_
     // FIXME: Set the referrer policy.
 
     // AD-HOC:
-    if (url.scheme() == "file" && document().origin().protocol() != "file") {
+    if (url.scheme() == "file" && document().origin().scheme() != "file") {
         dbgln("iframe failed to load URL: Security violation: {} may not load {}", document().url(), url);
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -96,8 +96,8 @@ void HTMLFormElement::submit_form(JS::GCPtr<HTMLElement> submitter, bool from_su
         return;
     }
 
-    if (url.protocol() == "file") {
-        if (document().url().protocol() != "file") {
+    if (url.scheme() == "file") {
+        if (document().url().scheme() != "file") {
             dbgln("Failed to submit form: Security violation: {} may not submit to {}", document().url(), url);
             return;
         }
@@ -105,7 +105,7 @@ void HTMLFormElement::submit_form(JS::GCPtr<HTMLElement> submitter, bool from_su
             dbgln("Failed to submit form: Unsupported form method '{}' for URL: {}", method(), url);
             return;
         }
-    } else if (url.protocol() != "http" && url.protocol() != "https") {
+    } else if (url.scheme() != "http" && url.scheme() != "https") {
         dbgln("Failed to submit form: Unsupported protocol for URL: {}", url);
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -117,7 +117,7 @@ void HTMLIFrameElement::load_src(String const& value)
         dbgln("iframe failed to load URL: Invalid URL: {}", value);
         return;
     }
-    if (url.scheme() == "file" && document().origin().protocol() != "file") {
+    if (url.scheme() == "file" && document().origin().scheme() != "file") {
         dbgln("iframe failed to load URL: Security violation: {} may not load {}", document().url(), url);
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -117,7 +117,7 @@ void HTMLIFrameElement::load_src(String const& value)
         dbgln("iframe failed to load URL: Invalid URL: {}", value);
         return;
     }
-    if (url.protocol() == "file" && document().origin().protocol() != "file") {
+    if (url.scheme() == "file" && document().origin().protocol() != "file") {
         dbgln("iframe failed to load URL: Security violation: {} may not load {}", document().url(), url);
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/Origin.h
+++ b/Userland/Libraries/LibWeb/HTML/Origin.h
@@ -14,17 +14,17 @@ namespace Web::HTML {
 class Origin {
 public:
     Origin() = default;
-    Origin(String const& protocol, String const& host, u16 port)
-        : m_protocol(protocol)
+    Origin(String const& scheme, String const& host, u16 port)
+        : m_scheme(scheme)
         , m_host(host)
         , m_port(port)
     {
     }
 
     // https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque
-    bool is_opaque() const { return m_protocol.is_null() && m_host.is_null() && m_port == 0; }
+    bool is_opaque() const { return m_scheme.is_null() && m_host.is_null() && m_port == 0; }
 
-    String const& protocol() const { return m_protocol; }
+    String const& scheme() const { return m_scheme; }
     String const& host() const { return m_host; }
     u16 port() const { return m_port; }
 
@@ -37,7 +37,7 @@ public:
 
         // 2. If A and B are both tuple origins and their schemes, hosts, and port are identical, then return true.
         // 3. Return false.
-        return protocol() == other.protocol()
+        return scheme() == other.scheme()
             && host() == other.host()
             && port() == other.port();
     }
@@ -53,7 +53,7 @@ public:
         if (!is_opaque() && !other.is_opaque()) {
             // 1. If A and B's schemes are identical, and their domains are identical and non-null, then return true.
             // FIXME: Check domains once supported.
-            if (protocol() == other.protocol())
+            if (scheme() == other.scheme())
                 return true;
 
             // 2. Otherwise, if A and B are same origin and their domains are identical and null, then return true.
@@ -75,7 +75,7 @@ public:
 
         // 2. Otherwise, let result be origin's scheme.
         StringBuilder result;
-        result.append(protocol());
+        result.append(scheme());
 
         // 3. Append "://" to result.
         result.append("://"sv);
@@ -109,7 +109,7 @@ public:
     bool operator!=(Origin const& other) const { return !is_same_origin(other); }
 
 private:
-    String m_protocol;
+    String m_scheme;
     String m_host;
     u16 m_port { 0 };
 };
@@ -121,7 +121,7 @@ template<>
 struct Traits<Web::HTML::Origin> : public GenericTraits<Web::HTML::Origin> {
     static unsigned hash(Web::HTML::Origin const& origin)
     {
-        return pair_int_hash(origin.protocol().hash(), pair_int_hash(int_hash(origin.port()), origin.host().hash()));
+        return pair_int_hash(origin.scheme().hash(), pair_int_hash(int_hash(origin.port()), origin.host().hash()));
     }
 };
 } // namespace AK

--- a/Userland/Libraries/LibWeb/Loader/ContentFilter.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ContentFilter.cpp
@@ -21,7 +21,7 @@ ContentFilter::~ContentFilter() = default;
 
 bool ContentFilter::is_filtered(const AK::URL& url) const
 {
-    if (url.protocol() == "data")
+    if (url.scheme() == "data")
         return false;
 
     auto url_string = url.to_string();

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -242,9 +242,9 @@ bool FrameLoader::load(LoadRequest& request, Type type)
     if (document && document->has_active_favicon())
         return true;
 
-    if (url.protocol() == "http" || url.protocol() == "https") {
+    if (url.scheme() == "http" || url.scheme() == "https") {
         AK::URL favicon_url;
-        favicon_url.set_protocol(url.protocol());
+        favicon_url.set_scheme(url.scheme());
         favicon_url.set_host(url.host());
         favicon_url.set_port(url.port_or_default());
         favicon_url.set_paths({ "favicon.ico" });

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -105,7 +105,7 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, HashMap<Strin
         //        Let's use image/x-qoi for now, which is also what our Core::MimeData uses & would guess.
         if (m_mime_type == "application/octet-stream" && url().path().ends_with(".qoi"sv))
             m_mime_type = "image/x-qoi";
-    } else if (url().protocol() == "data" && !url().data_mime_type().is_empty()) {
+    } else if (url().scheme() == "data" && !url().data_mime_type().is_empty()) {
         dbgln_if(RESOURCE_DEBUG, "This is a data URL with mime-type _{}_", url().data_mime_type());
         m_mime_type = url().data_mime_type();
     } else {

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -87,7 +87,7 @@ RefPtr<Resource> ResourceLoader::load_resource(Resource::Type type, LoadRequest&
     if (!request.is_valid())
         return nullptr;
 
-    bool use_cache = request.url().protocol() != "file";
+    bool use_cache = request.url().scheme() != "file";
 
     if (use_cache) {
         auto it = s_resource_cache.find(request);
@@ -120,7 +120,7 @@ RefPtr<Resource> ResourceLoader::load_resource(Resource::Type type, LoadRequest&
 
 static String sanitized_url_for_logging(AK::URL const& url)
 {
-    if (url.protocol() == "data"sv)
+    if (url.scheme() == "data"sv)
         return String::formatted("[data URL, mime-type={}, size={}]", url.data_mime_type(), url.data_payload().length());
     return url.to_string();
 }
@@ -172,7 +172,7 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
         return;
     }
 
-    if (url.protocol() == "about") {
+    if (url.scheme() == "about") {
         dbgln_if(SPAM_DEBUG, "Loading about: URL {}", url);
         log_success(request);
 
@@ -185,7 +185,7 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
         return;
     }
 
-    if (url.protocol() == "data") {
+    if (url.scheme() == "data") {
         dbgln_if(SPAM_DEBUG, "ResourceLoader loading a data URL with mime-type: '{}', base64={}, payload='{}'",
             url.data_mime_type(),
             url.data_payload_is_base64(),
@@ -212,7 +212,7 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
         return;
     }
 
-    if (url.protocol() == "file") {
+    if (url.scheme() == "file") {
         if (request.page().has_value())
             m_page = request.page().value();
 
@@ -263,7 +263,7 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
         return;
     }
 
-    if (url.protocol() == "http" || url.protocol() == "https" || url.protocol() == "gemini") {
+    if (url.scheme() == "http" || url.scheme() == "https" || url.scheme() == "gemini") {
         auto proxy = ProxyMappings::the().proxy_for_url(url);
 
         HashMap<String, String> headers;
@@ -326,7 +326,7 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
         return;
     }
 
-    auto not_implemented_error = String::formatted("Protocol not implemented: {}", url.protocol());
+    auto not_implemented_error = String::formatted("Protocol not implemented: {}", url.scheme());
     log_failure(request, not_implemented_error);
     if (error_callback)
         error_callback(not_implemented_error, {});

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -52,7 +52,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> WebSocket::create_with_global_o
     AK::URL url_record(url);
     if (!url_record.is_valid())
         return WebIDL::SyntaxError::create(window, "Invalid URL");
-    if (!url_record.protocol().is_one_of("ws", "wss"))
+    if (!url_record.scheme().is_one_of("ws", "wss"))
         return WebIDL::SyntaxError::create(window, "Invalid protocol");
     if (!url_record.fragment().is_empty())
         return WebIDL::SyntaxError::create(window, "Presence of URL fragment is invalid");

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -416,7 +416,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<Fetch::XMLHttpRequestBod
     dbgln("XHR send from {} to {}", m_window->associated_document().url(), request_url);
 
     // TODO: Add support for preflight requests to support CORS requests
-    auto request_url_origin = HTML::Origin(request_url.protocol(), request_url.host(), request_url.port_or_default());
+    auto request_url_origin = HTML::Origin(request_url.scheme(), request_url.host(), request_url.port_or_default());
 
     bool should_enforce_same_origin_policy = true;
     if (auto* page = m_window->page())

--- a/Userland/Libraries/LibWebSocket/ConnectionInfo.cpp
+++ b/Userland/Libraries/LibWebSocket/ConnectionInfo.cpp
@@ -17,7 +17,7 @@ bool ConnectionInfo::is_secure() const
 {
     // RFC 6455 Section 3 :
     // The URI is called "secure" if the scheme component matches "wss" case-insensitively.
-    return m_url.protocol().equals_ignoring_case("wss"sv);
+    return m_url.scheme().equals_ignoring_case("wss"sv);
 }
 
 String ConnectionInfo::resource_name() const

--- a/Userland/Libraries/LibWebView/DumpLayoutTree/main.cpp
+++ b/Userland/Libraries/LibWebView/DumpLayoutTree/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char** argv)
     window->resize(800, 600);
     window->show();
     auto& web_view = window->set_main_widget<WebView::OutOfProcessWebView>();
-    web_view.load(URL::create_with_file_protocol(argv[1]));
+    web_view.load(URL::create_with_file_scheme(argv[1]));
     web_view.on_load_finish = [&](auto&) {
         auto dump = web_view.dump_layout_tree();
         write(STDOUT_FILENO, dump.characters(), dump.length() + 1);

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -140,14 +140,14 @@ bool Launcher::has_mime_handlers(String const& mime_type)
 Vector<String> Launcher::handlers_for_url(const URL& url)
 {
     Vector<String> handlers;
-    if (url.protocol() == "file") {
+    if (url.scheme() == "file") {
         for_each_handler_for_path(url.path(), [&](auto& handler) -> bool {
             handlers.append(handler.executable);
             return true;
         });
     } else {
-        for_each_handler(url.protocol(), m_protocol_handlers, [&](auto const& handler) -> bool {
-            if (handler.handler_type != Handler::Type::Default || handler.protocols.contains(url.protocol())) {
+        for_each_handler(url.scheme(), m_protocol_handlers, [&](auto const& handler) -> bool {
+            if (handler.handler_type != Handler::Type::Default || handler.protocols.contains(url.scheme())) {
                 handlers.append(handler.executable);
                 return true;
             }
@@ -160,14 +160,14 @@ Vector<String> Launcher::handlers_for_url(const URL& url)
 Vector<String> Launcher::handlers_with_details_for_url(const URL& url)
 {
     Vector<String> handlers;
-    if (url.protocol() == "file") {
+    if (url.scheme() == "file") {
         for_each_handler_for_path(url.path(), [&](auto& handler) -> bool {
             handlers.append(handler.to_details_str());
             return true;
         });
     } else {
-        for_each_handler(url.protocol(), m_protocol_handlers, [&](auto const& handler) -> bool {
-            if (handler.handler_type != Handler::Type::Default || handler.protocols.contains(url.protocol())) {
+        for_each_handler(url.scheme(), m_protocol_handlers, [&](auto const& handler) -> bool {
+            if (handler.handler_type != Handler::Type::Default || handler.protocols.contains(url.scheme())) {
                 handlers.append(handler.to_details_str());
                 return true;
             }
@@ -196,10 +196,10 @@ bool Launcher::open_url(const URL& url, String const& handler_name)
     if (!handler_name.is_null())
         return open_with_handler_name(url, handler_name);
 
-    if (url.protocol() == "file")
+    if (url.scheme() == "file")
         return open_file_url(url);
 
-    return open_with_user_preferences(m_protocol_handlers, url.protocol(), { url.to_string() });
+    return open_with_user_preferences(m_protocol_handlers, url.scheme(), { url.to_string() });
 }
 
 bool Launcher::open_with_handler_name(const URL& url, String const& handler_name)
@@ -210,7 +210,7 @@ bool Launcher::open_with_handler_name(const URL& url, String const& handler_name
 
     auto& handler = handler_optional.value();
     String argument;
-    if (url.protocol() == "file")
+    if (url.scheme() == "file")
         argument = url.path();
     else
         argument = url.to_string();

--- a/Userland/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Userland/Services/RequestServer/ConnectionFromClient.cpp
@@ -42,7 +42,7 @@ Messages::RequestServer::StartRequestResponse ConnectionFromClient::start_reques
         dbgln("StartRequest: Invalid URL requested: '{}'", url);
         return { -1, Optional<IPC::File> {} };
     }
-    auto* protocol = Protocol::find_by_name(url.protocol());
+    auto* protocol = Protocol::find_by_name(url.scheme());
     if (!protocol) {
         dbgln("StartRequest: No protocol handler for URL: '{}'", url);
         return { -1, Optional<IPC::File> {} };

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -660,7 +660,7 @@ void BarewordLiteral::highlight_in_editor(Line::Editor& editor, Shell& shell, Hi
     }
     if (Core::File::exists(m_text)) {
         auto realpath = shell.resolve_path(m_text);
-        auto url = URL::create_with_file_protocol(realpath);
+        auto url = URL::create_with_file_scheme(realpath);
         url.set_host(shell.hostname);
         editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Hyperlink(url.to_string()) });
     }
@@ -2496,7 +2496,7 @@ void PathRedirectionNode::highlight_in_editor(Line::Editor& editor, Shell& shell
         auto& path = path_text[0];
         if (!path.starts_with('/'))
             path = String::formatted("{}/{}", shell.cwd, path);
-        auto url = URL::create_with_file_protocol(path);
+        auto url = URL::create_with_file_scheme(path);
         url.set_host(shell.hostname);
         editor.stylize({ position.start_offset, position.end_offset }, { Line::Style::Hyperlink(url.to_string()) });
     }
@@ -3058,7 +3058,7 @@ void Juxtaposition::highlight_in_editor(Line::Editor& editor, Shell& shell, High
 
         if (Core::File::exists(path)) {
             auto realpath = shell.resolve_path(path);
-            auto url = URL::create_with_file_protocol(realpath);
+            auto url = URL::create_with_file_scheme(realpath);
             url.set_host(shell.hostname);
             editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Hyperlink(url.to_string()) });
         }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -515,19 +515,19 @@ public:
     virtual RefPtr<Web::ResourceLoaderConnectorRequest> start_request(String const& method, AK::URL const& url, HashMap<String, String> const& request_headers, ReadonlyBytes request_body, Core::ProxyData const& proxy) override
     {
         RefPtr<Web::ResourceLoaderConnectorRequest> request;
-        if (url.protocol().equals_ignoring_case("http"sv)) {
+        if (url.scheme().equals_ignoring_case("http"sv)) {
             auto request_or_error = HTTPHeadlessRequest::create(method, url, request_headers, request_body, proxy);
             if (request_or_error.is_error())
                 return {};
             request = request_or_error.release_value();
         }
-        if (url.protocol().equals_ignoring_case("https"sv)) {
+        if (url.scheme().equals_ignoring_case("https"sv)) {
             auto request_or_error = HTTPSHeadlessRequest::create(method, url, request_headers, request_body, proxy);
             if (request_or_error.is_error())
                 return {};
             request = request_or_error.release_value();
         }
-        if (url.protocol().equals_ignoring_case("gemini"sv)) {
+        if (url.scheme().equals_ignoring_case("gemini"sv)) {
             auto request_or_error = GeminiHeadlessRequest::create(method, url, request_headers, request_body, proxy);
             if (request_or_error.is_error())
                 return {};


### PR DESCRIPTION
We were keeping "protocol" helpers on URLs for backwards compatibility - which is inconsistent and a bit silly.

Likewise Origin just used the wrong terminology with no correctly named helpers.

This pull request removes all improperly named members from the above mentioned classes and updates all call sites to use the new helpers