### PR TITLE
LibCards+Games: Various improvements

### DIFF
--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -199,20 +199,12 @@ void Game::setup(String player_name, int hand_number)
         m_passing_button->set_focus(false);
     }
 
-    NonnullRefPtrVector<Card> deck;
-    deck.ensure_capacity(Card::card_count * 4);
-
-    for (int i = 0; i < Card::card_count; ++i) {
-        deck.append(Card::construct(Cards::Suit::Clubs, static_cast<Cards::Rank>(i)));
-        deck.append(Card::construct(Cards::Suit::Spades, static_cast<Cards::Rank>(i)));
-        deck.append(Card::construct(Cards::Suit::Hearts, static_cast<Cards::Rank>(i)));
-        deck.append(Card::construct(Cards::Suit::Diamonds, static_cast<Cards::Rank>(i)));
-    }
+    NonnullRefPtrVector<Card> deck = Cards::create_standard_deck(Cards::Shuffle::Yes);
 
     for (auto& player : m_players) {
         player.hand.ensure_capacity(Card::card_count);
         for (uint8_t i = 0; i < Card::card_count; ++i) {
-            auto card = deck.take(get_random_uniform(deck.size()));
+            auto card = deck.take_last();
             if constexpr (!HEARTS_DEBUG) {
                 if (&player != &m_players[0])
                     card->set_upside_down(true);

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -896,21 +896,21 @@ void Game::paint_event(GUI::PaintEvent& event)
         if (!game_ended()) {
             for (auto& card : player.hand)
                 if (!card.is_null())
-                    card->draw(painter);
+                    card->paint(painter);
         } else {
             // FIXME: reposition cards in advance_game() maybe
             auto card_position = player.first_card_position;
             for (auto& card : player.cards_taken) {
                 card->set_upside_down(false);
                 card->set_position(card_position);
-                card->draw(painter);
+                card->paint(painter);
                 card_position.translate_by(player.card_offset);
             }
         }
     }
 
     for (size_t i = 0; i < m_trick.size(); i++)
-        m_trick[i].draw(painter);
+        m_trick[i].paint(painter);
 }
 
 void Game::dump_state() const

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -162,15 +162,7 @@ void Game::setup(Mode mode)
     if (on_undo_availability_change)
         on_undo_availability_change(false);
 
-    for (int i = 0; i < Card::card_count; ++i) {
-        m_new_deck.append(Card::construct(Cards::Suit::Clubs, static_cast<Cards::Rank>(i)));
-        m_new_deck.append(Card::construct(Cards::Suit::Spades, static_cast<Cards::Rank>(i)));
-        m_new_deck.append(Card::construct(Cards::Suit::Hearts, static_cast<Cards::Rank>(i)));
-        m_new_deck.append(Card::construct(Cards::Suit::Diamonds, static_cast<Cards::Rank>(i)));
-    }
-
-    for (uint8_t i = 0; i < 200; ++i)
-        m_new_deck.append(m_new_deck.take(get_random_uniform(m_new_deck.size())));
+    m_new_deck = Cards::create_standard_deck(Cards::Shuffle::Yes);
 
     m_focused_stack = nullptr;
     m_focused_cards.clear();

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -207,14 +207,14 @@ void Game::update_score(int to_add)
 
 void Game::keydown_event(GUI::KeyEvent& event)
 {
-    if (m_new_game_animation || m_game_over_animation)
+    if (is_moving_cards() || m_new_game_animation || m_game_over_animation)
         return;
 
     if (event.shift() && event.key() == KeyCode::Key_F12) {
         start_game_over_animation();
     } else if (event.key() == KeyCode::Key_Tab) {
         auto_move_eligible_cards_to_foundations();
-    } else if (event.key() == KeyCode::Key_Space && m_mouse_down != true) {
+    } else if (event.key() == KeyCode::Key_Space) {
         draw_cards();
     } else if (event.shift() && event.key() == KeyCode::Key_F11) {
         if constexpr (SOLITAIRE_DEBUG) {

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -552,12 +552,12 @@ void Game::paint_event(GUI::PaintEvent& event)
     }
 
     for (auto& stack : stacks()) {
-        stack.draw(painter, background_color);
+        stack.paint(painter, background_color);
     }
 
     if (!m_focused_cards.is_empty()) {
         for (auto& focused_card : m_focused_cards) {
-            focused_card.draw(painter);
+            focused_card.paint(painter);
             focused_card.save_old_position();
         }
     }

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -486,19 +486,19 @@ bool Game::attempt_to_move_card_to_foundations(CardStack& from)
 
 void Game::auto_move_eligible_cards_to_foundations()
 {
-    bool card_was_moved = false;
+    while (true) {
+        bool card_was_moved = false;
+        for (auto& to_check : stacks()) {
+            if (to_check.type() != CardStack::Type::Normal && to_check.type() != CardStack::Type::Play)
+                continue;
 
-    for (auto& to_check : stacks()) {
-        if (to_check.type() != CardStack::Type::Normal && to_check.type() != CardStack::Type::Play)
-            continue;
+            if (attempt_to_move_card_to_foundations(to_check))
+                card_was_moved = true;
+        }
 
-        if (attempt_to_move_card_to_foundations(to_check))
-            card_was_moved = true;
+        if (!card_was_moved)
+            break;
     }
-
-    // If at least one card was moved, check again to see if now any additional cards can now be moved
-    if (card_was_moved)
-        auto_move_eligible_cards_to_foundations();
 }
 
 void Game::paint_event(GUI::PaintEvent& event)

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -521,16 +521,6 @@ void Game::auto_move_eligible_cards_to_foundations()
         auto_move_eligible_cards_to_foundations();
 }
 
-void Game::mark_intersecting_stacks_dirty(Card& intersecting_card)
-{
-    for (auto& stack : stacks()) {
-        if (intersecting_card.rect().intersects(stack.bounding_box()))
-            update(stack.bounding_box());
-    }
-
-    update(intersecting_card.rect());
-}
-
 void Game::paint_event(GUI::PaintEvent& event)
 {
     Gfx::Color background_color = this->background_color();

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -21,20 +21,20 @@ static constexpr int s_timer_interval_ms = 1000 / 60;
 
 Game::Game()
 {
-    m_stacks.append(adopt_ref(*new CardStack({ 10, 10 }, CardStack::Type::Stock)));
-    m_stacks.append(adopt_ref(*new CardStack({ 10 + Card::width + 10, 10 }, CardStack::Type::Waste)));
-    m_stacks.append(adopt_ref(*new CardStack({ 10 + Card::width + 10, 10 }, CardStack::Type::Play, m_stacks.ptr_at(Waste))));
-    m_stacks.append(adopt_ref(*new CardStack({ Game::width - 4 * Card::width - 40, 10 }, CardStack::Type::Foundation)));
-    m_stacks.append(adopt_ref(*new CardStack({ Game::width - 3 * Card::width - 30, 10 }, CardStack::Type::Foundation)));
-    m_stacks.append(adopt_ref(*new CardStack({ Game::width - 2 * Card::width - 20, 10 }, CardStack::Type::Foundation)));
-    m_stacks.append(adopt_ref(*new CardStack({ Game::width - Card::width - 10, 10 }, CardStack::Type::Foundation)));
-    m_stacks.append(adopt_ref(*new CardStack({ 10, 10 + Card::height + 10 }, CardStack::Type::Normal)));
-    m_stacks.append(adopt_ref(*new CardStack({ 10 + Card::width + 10, 10 + Card::height + 10 }, CardStack::Type::Normal)));
-    m_stacks.append(adopt_ref(*new CardStack({ 10 + 2 * Card::width + 20, 10 + Card::height + 10 }, CardStack::Type::Normal)));
-    m_stacks.append(adopt_ref(*new CardStack({ 10 + 3 * Card::width + 30, 10 + Card::height + 10 }, CardStack::Type::Normal)));
-    m_stacks.append(adopt_ref(*new CardStack({ 10 + 4 * Card::width + 40, 10 + Card::height + 10 }, CardStack::Type::Normal)));
-    m_stacks.append(adopt_ref(*new CardStack({ 10 + 5 * Card::width + 50, 10 + Card::height + 10 }, CardStack::Type::Normal)));
-    m_stacks.append(adopt_ref(*new CardStack({ 10 + 6 * Card::width + 60, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    add_stack(adopt_ref(*new CardStack({ 10, 10 }, CardStack::Type::Stock)));
+    add_stack(adopt_ref(*new CardStack({ 10 + Card::width + 10, 10 }, CardStack::Type::Waste)));
+    add_stack(adopt_ref(*new CardStack({ 10 + Card::width + 10, 10 }, CardStack::Type::Play, stack_at_location(Waste))));
+    add_stack(adopt_ref(*new CardStack({ Game::width - 4 * Card::width - 40, 10 }, CardStack::Type::Foundation)));
+    add_stack(adopt_ref(*new CardStack({ Game::width - 3 * Card::width - 30, 10 }, CardStack::Type::Foundation)));
+    add_stack(adopt_ref(*new CardStack({ Game::width - 2 * Card::width - 20, 10 }, CardStack::Type::Foundation)));
+    add_stack(adopt_ref(*new CardStack({ Game::width - Card::width - 10, 10 }, CardStack::Type::Foundation)));
+    add_stack(adopt_ref(*new CardStack({ 10, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    add_stack(adopt_ref(*new CardStack({ 10 + Card::width + 10, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    add_stack(adopt_ref(*new CardStack({ 10 + 2 * Card::width + 20, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    add_stack(adopt_ref(*new CardStack({ 10 + 3 * Card::width + 30, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    add_stack(adopt_ref(*new CardStack({ 10 + 4 * Card::width + 40, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    add_stack(adopt_ref(*new CardStack({ 10 + 5 * Card::width + 50, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    add_stack(adopt_ref(*new CardStack({ 10 + 6 * Card::width + 60, 10 + Card::height + 10 }, CardStack::Type::Normal)));
 }
 
 static float rand_float()
@@ -60,7 +60,7 @@ void Game::timer_event(Core::TimerEvent&)
             ++m_new_game_animation_delay;
         } else {
             m_new_game_animation_delay = 0;
-            auto& current_pile = stack(piles.at(m_new_game_animation_pile));
+            auto& current_pile = stack_at_location(piles.at(m_new_game_animation_pile));
 
             if (current_pile.count() < m_new_game_animation_pile) {
                 auto card = m_new_deck.take_last();
@@ -74,7 +74,7 @@ void Game::timer_event(Core::TimerEvent&)
             update(current_pile.bounding_box());
 
             if (m_new_game_animation_pile == piles.size()) {
-                auto& stock_pile = stack(Stock);
+                auto& stock_pile = stack_at_location(Stock);
                 while (!m_new_deck.is_empty())
                     stock_pile.push(m_new_deck.take_last());
 
@@ -151,7 +151,7 @@ void Game::setup(Mode mode)
     if (on_game_end)
         on_game_end(GameOverReason::NewGame, m_score);
 
-    for (auto& stack : m_stacks)
+    for (auto& stack : stacks())
         stack.clear();
 
     m_new_deck.clear();
@@ -218,7 +218,9 @@ void Game::keydown_event(GUI::KeyEvent& event)
     } else if (event.key() == KeyCode::Key_Space && m_mouse_down != true) {
         draw_cards();
     } else if (event.shift() && event.key() == KeyCode::Key_F11) {
-        dump_layout();
+        if constexpr (SOLITAIRE_DEBUG) {
+            dump_layout();
+        }
     }
 }
 
@@ -230,7 +232,7 @@ void Game::mousedown_event(GUI::MouseEvent& event)
         return;
 
     auto click_location = event.position();
-    for (auto& to_check : m_stacks) {
+    for (auto& to_check : stacks()) {
         if (to_check.type() == CardStack::Type::Waste)
             continue;
 
@@ -273,7 +275,7 @@ void Game::mouseup_event(GUI::MouseEvent& event)
         return;
 
     bool rebound = true;
-    for (auto& stack : m_stacks) {
+    for (auto& stack : stacks()) {
         if (stack.is_focused())
             continue;
 
@@ -348,7 +350,7 @@ void Game::doubleclick_event(GUI::MouseEvent& event)
         return;
 
     auto click_location = event.position();
-    for (auto& to_check : m_stacks) {
+    for (auto& to_check : stacks()) {
         if (to_check.type() != CardStack::Type::Normal && to_check.type() != CardStack::Type::Play)
             continue;
 
@@ -365,7 +367,7 @@ void Game::doubleclick_event(GUI::MouseEvent& event)
 void Game::check_for_game_over()
 {
     for (auto foundationID : foundations) {
-        auto& foundation = stack(foundationID);
+        auto& foundation = stack_at_location(foundationID);
 
         if (foundation.count() != Card::card_count)
             return;
@@ -376,9 +378,9 @@ void Game::check_for_game_over()
 
 void Game::draw_cards()
 {
-    auto& waste = stack(Waste);
-    auto& stock = stack(Stock);
-    auto& play = stack(Play);
+    auto& waste = stack_at_location(Waste);
+    auto& stock = stack_at_location(Stock);
+    auto& play = stack_at_location(Play);
 
     if (stock.is_empty()) {
         if (waste.is_empty() && play.is_empty())
@@ -447,8 +449,8 @@ void Game::draw_cards()
 
 void Game::pop_waste_to_play_stack()
 {
-    auto& waste = this->stack(Waste);
-    auto& play = this->stack(Play);
+    auto& waste = stack_at_location(Waste);
+    auto& play = stack_at_location(Play);
     if (play.is_empty() && !waste.is_empty()) {
         auto card = waste.pop();
         m_focused_cards.append(card);
@@ -468,7 +470,7 @@ bool Game::attempt_to_move_card_to_foundations(CardStack& from)
     bool card_was_moved = false;
 
     for (auto foundationID : foundations) {
-        auto& foundation = stack(foundationID);
+        auto& foundation = stack_at_location(foundationID);
 
         if (foundation.is_allowed_to_push(top_card)) {
             update(from.bounding_box());
@@ -506,7 +508,7 @@ void Game::auto_move_eligible_cards_to_foundations()
 {
     bool card_was_moved = false;
 
-    for (auto& to_check : m_stacks) {
+    for (auto& to_check : stacks()) {
         if (to_check.type() != CardStack::Type::Normal && to_check.type() != CardStack::Type::Play)
             continue;
 
@@ -521,7 +523,7 @@ void Game::auto_move_eligible_cards_to_foundations()
 
 void Game::mark_intersecting_stacks_dirty(Card& intersecting_card)
 {
-    for (auto& stack : m_stacks) {
+    for (auto& stack : stacks()) {
         if (intersecting_card.rect().intersects(stack.bounding_box()))
             update(stack.bounding_box());
     }
@@ -549,7 +551,7 @@ void Game::paint_event(GUI::PaintEvent& event)
             focused_card.clear(painter, background_color);
     }
 
-    for (auto& stack : m_stacks) {
+    for (auto& stack : stacks()) {
         stack.draw(painter, background_color);
     }
 
@@ -610,7 +612,7 @@ void Game::perform_undo()
     }
 
     if (m_last_move.from->type() == CardStack::Type::Play && m_mode == Mode::SingleCardDraw) {
-        auto& waste = stack(Waste);
+        auto& waste = stack_at_location(Waste);
         if (!m_last_move.from->is_empty())
             waste.push(m_last_move.from->pop());
     }
@@ -622,8 +624,8 @@ void Game::perform_undo()
     }
 
     if (m_last_move.from->type() == CardStack::Type::Stock) {
-        auto& waste = this->stack(Waste);
-        auto& play = this->stack(Play);
+        auto& waste = stack_at_location(Waste);
+        auto& play = stack_at_location(Play);
         NonnullRefPtrVector<Card> cards_popped;
         for (size_t i = 0; i < m_last_move.cards.size(); i++) {
             if (!waste.is_empty()) {
@@ -646,15 +648,6 @@ void Game::perform_undo()
     if (on_undo_availability_change)
         on_undo_availability_change(false);
     invalidate_layout();
-}
-
-void Game::dump_layout() const
-{
-    if constexpr (SOLITAIRE_DEBUG) {
-        dbgln("------------------------------");
-        for (auto const& stack : m_stacks)
-            dbgln("{}", stack);
-    }
 }
 
 }

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -175,12 +175,6 @@ private:
     void create_new_animation_card();
     void set_background_fill_enabled(bool);
     void check_for_game_over();
-    void dump_layout() const;
-
-    ALWAYS_INLINE CardStack& stack(StackLocation location)
-    {
-        return m_stacks[location];
-    }
 
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
@@ -195,7 +189,6 @@ private:
     LastMove m_last_move;
     NonnullRefPtrVector<Card> m_focused_cards;
     NonnullRefPtrVector<Card> m_new_deck;
-    NonnullRefPtrVector<CardStack> m_stacks;
     CardStack* m_focused_stack { nullptr };
     Gfx::IntPoint m_mouse_down_location;
 

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -186,9 +186,7 @@ private:
     Mode m_mode { Mode::SingleCardDraw };
 
     LastMove m_last_move;
-    NonnullRefPtrVector<Card> m_focused_cards;
     NonnullRefPtrVector<Card> m_new_deck;
-    CardStack* m_focused_stack { nullptr };
     Gfx::IntPoint m_mouse_down_location;
 
     bool m_mouse_down { false };

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -159,7 +159,6 @@ private:
         }
     }
 
-    void mark_intersecting_stacks_dirty(Card& intersecting_card);
     void score_move(CardStack& from, CardStack& to, bool inverse = false);
     void score_flip(bool inverse = false);
     void remember_move_for_undo(CardStack& from, CardStack& to, NonnullRefPtrVector<Card> moved_cards);

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -70,7 +70,7 @@ private:
         void draw(GUI::Painter& painter)
         {
             VERIFY(!m_animation_card.is_null());
-            m_animation_card->draw(painter);
+            m_animation_card->paint(painter);
             m_dirty = false;
         }
 

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -201,12 +201,12 @@ void Game::paint_event(GUI::PaintEvent& event)
     }
 
     for (auto& stack : stacks()) {
-        stack.draw(painter, background_color);
+        stack.paint(painter, background_color);
     }
 
     if (!m_focused_cards.is_empty()) {
         for (auto& focused_card : m_focused_cards) {
-            focused_card.draw(painter);
+            focused_card.paint(painter);
             focused_card.save_old_position();
         }
     }

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -67,8 +67,7 @@ void Game::setup(Mode mode)
 
     m_new_deck = Cards::create_deck(0, 0, heart_suits, spade_suits, Cards::Shuffle::Yes);
 
-    m_focused_stack = nullptr;
-    m_focused_cards.clear();
+    clear_moving_cards();
 
     m_new_game_animation = true;
     start_timer(s_timer_interval_ms);
@@ -174,33 +173,28 @@ void Game::paint_event(GUI::PaintEvent& event)
     painter.add_clip_rect(frame_inner_rect());
     painter.add_clip_rect(event.rect());
 
-    if (!m_focused_cards.is_empty()) {
-        for (auto& focused_card : m_focused_cards)
-            focused_card.clear(painter, background_color);
+    if (is_moving_cards()) {
+        for (auto& card : moving_cards())
+            card.clear(painter, background_color);
     }
 
     for (auto& stack : stacks()) {
         stack.paint(painter, background_color);
     }
 
-    if (!m_focused_cards.is_empty()) {
-        for (auto& focused_card : m_focused_cards) {
-            focused_card.paint(painter);
-            focused_card.save_old_position();
+    if (is_moving_cards()) {
+        for (auto& card : moving_cards()) {
+            card.paint(painter);
+            card.save_old_position();
         }
     }
 
     if (!m_mouse_down) {
-        if (!m_focused_cards.is_empty()) {
-            for (auto& card : m_focused_cards)
+        if (is_moving_cards()) {
+            for (auto& card : moving_cards())
                 card.set_moving(false);
-            m_focused_cards.clear();
         }
-
-        if (m_focused_stack) {
-            m_focused_stack->set_focused(false);
-            m_focused_stack = nullptr;
-        }
+        clear_moving_cards();
     }
 }
 
@@ -229,13 +223,9 @@ void Game::mousedown_event(GUI::MouseEvent& event)
                         start_timer_if_necessary();
                         update(top_card.rect());
                     }
-                } else if (m_focused_cards.is_empty()) {
-                    to_check.add_all_grabbed_cards(click_location, m_focused_cards, Cards::CardStack::MovementRule::Same);
+                } else if (!is_moving_cards()) {
+                    pick_up_cards_from_stack(to_check, click_location, Cards::CardStack::MovementRule::Same);
                     m_mouse_down_location = click_location;
-                    if (m_focused_stack)
-                        m_focused_stack->set_focused(false);
-                    to_check.set_focused(true);
-                    m_focused_stack = &to_check;
                     // When the user wants to automatically move cards, do not go into the drag mode.
                     if (event.button() != GUI::MouseButton::Secondary)
                         m_mouse_down = true;
@@ -249,28 +239,17 @@ void Game::mousedown_event(GUI::MouseEvent& event)
 
 void Game::move_focused_cards(CardStack& stack)
 {
-    for (auto& to_intersect : m_focused_cards) {
-        mark_intersecting_stacks_dirty(to_intersect);
-        stack.push(to_intersect);
-        (void)m_focused_stack->pop();
-    }
-
+    drop_cards_on_stack(stack, Cards::CardStack::MovementRule::Any);
     update_score(-1);
-
-    update(m_focused_stack->bounding_box());
-    update(stack.bounding_box());
-
+    moving_cards_source_stack()->make_top_card_visible();
     detect_full_stacks();
-
-    if (m_focused_stack->make_top_card_visible())
-        update(m_focused_stack->peek().rect());
 }
 
 void Game::mouseup_event(GUI::MouseEvent& event)
 {
     GUI::Frame::mouseup_event(event);
 
-    if (!m_focused_stack || m_focused_cards.is_empty() || m_new_game_animation || m_draw_animation)
+    if (!is_moving_cards() || m_new_game_animation || m_draw_animation)
         return;
 
     bool rebound = true;
@@ -281,37 +260,25 @@ void Game::mouseup_event(GUI::MouseEvent& event)
             if (stack.is_focused())
                 continue;
 
-            if (stack.is_allowed_to_push(m_focused_cards.at(0), m_focused_cards.size(), Cards::CardStack::MovementRule::Any) && !stack.is_empty()) {
+            if (stack.is_allowed_to_push(moving_cards().at(0), moving_cards().size(), Cards::CardStack::MovementRule::Any) && !stack.is_empty()) {
                 move_focused_cards(stack);
 
                 rebound = false;
                 break;
             }
         }
-    } else {
-        for (auto& stack : stacks()) {
-            if (stack.is_focused())
-                continue;
-
-            for (auto& focused_card : m_focused_cards) {
-                if (stack.bounding_box().intersects(focused_card.rect())) {
-                    if (stack.is_allowed_to_push(m_focused_cards.at(0), m_focused_cards.size(), Cards::CardStack::MovementRule::Any)) {
-                        move_focused_cards(stack);
-
-                        rebound = false;
-                        break;
-                    }
-                }
-            }
-        }
+    } else if (auto target_stack = find_stack_to_drop_on(Cards::CardStack::MovementRule::Any); !target_stack.is_null()) {
+        auto& stack = *target_stack;
+        move_focused_cards(stack);
+        rebound = false;
     }
 
     if (rebound) {
-        for (auto& to_intersect : m_focused_cards)
+        for (auto& to_intersect : moving_cards())
             mark_intersecting_stacks_dirty(to_intersect);
 
-        m_focused_stack->rebound_cards();
-        update(m_focused_stack->bounding_box());
+        moving_cards_source_stack()->rebound_cards();
+        update(moving_cards_source_stack()->bounding_box());
     }
 
     m_mouse_down = false;
@@ -328,7 +295,7 @@ void Game::mousemove_event(GUI::MouseEvent& event)
     int dx = click_location.dx_relative_to(m_mouse_down_location);
     int dy = click_location.dy_relative_to(m_mouse_down_location);
 
-    for (auto& to_intersect : m_focused_cards) {
+    for (auto& to_intersect : moving_cards()) {
         mark_intersecting_stacks_dirty(to_intersect);
         to_intersect.rect().translate_by(dx, dy);
         update(to_intersect.rect());

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -48,32 +48,24 @@ void Game::setup(Mode mode)
     m_score = 500;
     update_score(0);
 
-    NonnullRefPtrVector<Card> deck;
-    deck.ensure_capacity(Card::card_count * 2);
+    unsigned heart_suits = 0;
+    unsigned spade_suits = 0;
 
-    for (int i = 0; i < Card::card_count; ++i) {
-        switch (m_mode) {
-        case Mode::SingleSuit:
-            for (int j = 0; j < 8; j++) {
-                deck.append(Card::construct(Cards::Suit::Spades, static_cast<Cards::Rank>(i)));
-            }
-            break;
-        case Mode::TwoSuit:
-            for (int j = 0; j < 4; j++) {
-                deck.append(Card::construct(Cards::Suit::Spades, static_cast<Cards::Rank>(i)));
-                deck.append(Card::construct(Cards::Suit::Hearts, static_cast<Cards::Rank>(i)));
-            }
-            break;
-        default:
-            VERIFY_NOT_REACHED();
-            break;
-        }
+    switch (m_mode) {
+    case Mode::SingleSuit:
+        spade_suits = 8;
+        heart_suits = 0;
+        break;
+    case Mode::TwoSuit:
+        spade_suits = 4;
+        heart_suits = 4;
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+        break;
     }
 
-    m_new_deck.clear_with_capacity();
-    m_new_deck.ensure_capacity(deck.size());
-    while (!deck.is_empty())
-        m_new_deck.append(deck.take(get_random_uniform(deck.size())));
+    m_new_deck = Cards::create_deck(0, 0, heart_suits, spade_suits, Cards::Shuffle::Yes);
 
     m_focused_stack = nullptr;
     m_focused_cards.clear();

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -105,16 +105,6 @@ void Game::draw_cards()
     start_timer(s_timer_interval_ms);
 }
 
-void Game::mark_intersecting_stacks_dirty(Card& intersecting_card)
-{
-    for (auto& stack : stacks()) {
-        if (intersecting_card.rect().intersects(stack.bounding_box()))
-            update(stack.bounding_box());
-    }
-
-    update(intersecting_card.rect());
-}
-
 void Game::detect_full_stacks()
 {
     auto& completed_stack = stack_at_location(Completed);

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -257,7 +257,7 @@ void Game::mouseup_event(GUI::MouseEvent& event)
         // This enables the game to move the focused cards to the first possible stack excluding empty stacks.
         // NOTE: This ignores empty stacks, as the game has no undo button, and a card, which has been moved to an empty stack without any other possibilities is not reversible.
         for (auto& stack : stacks()) {
-            if (stack.is_focused())
+            if (stack == moving_cards_source_stack())
                 continue;
 
             if (stack.is_allowed_to_push(moving_cards().at(0), moving_cards().size(), Cards::CardStack::MovementRule::Any) && !stack.is_empty()) {

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -115,18 +115,6 @@ void Game::mark_intersecting_stacks_dirty(Card& intersecting_card)
     update(intersecting_card.rect());
 }
 
-void Game::ensure_top_card_is_visible(NonnullRefPtr<CardStack> stack)
-{
-    if (stack->is_empty())
-        return;
-
-    auto& top_card = stack->peek();
-    if (top_card.is_upside_down()) {
-        top_card.set_upside_down(false);
-        update(top_card.rect());
-    }
-}
-
 void Game::detect_full_stacks()
 {
     auto& completed_stack = stack_at_location(Completed);
@@ -160,7 +148,8 @@ void Game::detect_full_stacks()
                 update(original_current_rect);
                 update(completed_stack.bounding_box());
 
-                ensure_top_card_is_visible(current_pile);
+                if (current_pile.make_top_card_visible())
+                    update(current_pile.peek().rect());
 
                 update_score(101);
             }
@@ -283,7 +272,8 @@ void Game::move_focused_cards(CardStack& stack)
 
     detect_full_stacks();
 
-    ensure_top_card_is_visible(*m_focused_stack);
+    if (m_focused_stack->make_top_card_visible())
+        update(m_focused_stack->peek().rect());
 }
 
 void Game::mouseup_event(GUI::MouseEvent& event)

--- a/Userland/Games/Spider/Game.h
+++ b/Userland/Games/Spider/Game.h
@@ -82,9 +82,7 @@ private:
 
     Mode m_mode { Mode::SingleSuit };
 
-    NonnullRefPtrVector<Card> m_focused_cards;
     NonnullRefPtrVector<Card> m_new_deck;
-    CardStack* m_focused_stack { nullptr };
     Gfx::IntPoint m_mouse_down_location;
 
     bool m_mouse_down { false };

--- a/Userland/Games/Spider/Game.h
+++ b/Userland/Games/Spider/Game.h
@@ -70,7 +70,6 @@ private:
     void start_timer_if_necessary();
     void update_score(int delta);
     void draw_cards();
-    void mark_intersecting_stacks_dirty(Card& intersecting_card);
     void detect_full_stacks();
     void detect_victory();
     void move_focused_cards(CardStack& stack);

--- a/Userland/Games/Spider/Game.h
+++ b/Userland/Games/Spider/Game.h
@@ -71,7 +71,6 @@ private:
     void update_score(int delta);
     void draw_cards();
     void mark_intersecting_stacks_dirty(Card& intersecting_card);
-    void ensure_top_card_is_visible(NonnullRefPtr<CardStack> stack);
     void detect_full_stacks();
     void detect_victory();
     void move_focused_cards(CardStack& stack);

--- a/Userland/Games/Spider/Game.h
+++ b/Userland/Games/Spider/Game.h
@@ -76,11 +76,6 @@ private:
     void detect_victory();
     void move_focused_cards(CardStack& stack);
 
-    ALWAYS_INLINE CardStack& stack(StackLocation location)
-    {
-        return m_stacks[location];
-    }
-
     void paint_event(GUI::PaintEvent&) override;
     void mousedown_event(GUI::MouseEvent&) override;
     void mouseup_event(GUI::MouseEvent&) override;
@@ -91,7 +86,6 @@ private:
 
     NonnullRefPtrVector<Card> m_focused_cards;
     NonnullRefPtrVector<Card> m_new_deck;
-    NonnullRefPtrVector<CardStack> m_stacks;
     CardStack* m_focused_stack { nullptr };
     Gfx::IntPoint m_mouse_down_location;
 

--- a/Userland/Libraries/LibCards/Card.cpp
+++ b/Userland/Libraries/LibCards/Card.cpp
@@ -20,7 +20,7 @@ Card::Card(Suit suit, Rank rank)
     VERIFY(to_underlying(rank) < card_count);
 }
 
-void Card::draw(GUI::Painter& painter) const
+void Card::paint(GUI::Painter& painter) const
 {
     auto& card_painter = CardPainter::the();
     auto bitmap = [&]() {
@@ -43,12 +43,12 @@ void Card::save_old_position()
     m_old_position_valid = true;
 }
 
-void Card::clear_and_draw(GUI::Painter& painter, Color const& background_color)
+void Card::clear_and_paint(GUI::Painter& painter, Color const& background_color)
 {
     if (is_old_position_valid())
         clear(painter, background_color);
 
-    draw(painter);
+    paint(painter);
     save_old_position();
 }
 

--- a/Userland/Libraries/LibCards/Card.cpp
+++ b/Userland/Libraries/LibCards/Card.cpp
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2020, Till Mayer <till.mayer@web.de>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "Card.h"
+#include <AK/Random.h>
 #include <LibCards/CardPainter.h>
 
 namespace Cards {
@@ -48,6 +50,42 @@ void Card::clear_and_draw(GUI::Painter& painter, Color const& background_color)
 
     draw(painter);
     save_old_position();
+}
+
+NonnullRefPtrVector<Card> create_standard_deck(Shuffle shuffle)
+{
+    return create_deck(1, 1, 1, 1, shuffle);
+}
+
+NonnullRefPtrVector<Card> create_deck(unsigned full_club_suit_count, unsigned full_diamond_suit_count, unsigned full_heart_suit_count, unsigned full_spade_suit_count, Shuffle shuffle)
+{
+    NonnullRefPtrVector<Card> deck;
+    deck.ensure_capacity(Card::card_count * (full_club_suit_count + full_diamond_suit_count + full_heart_suit_count + full_spade_suit_count));
+
+    auto add_cards_for_suit = [&deck](Cards::Suit suit, unsigned number_of_suits) {
+        for (auto i = 0u; i < number_of_suits; ++i) {
+            for (auto rank = 0; rank < Card::card_count; ++rank) {
+                deck.append(Card::construct(suit, static_cast<Cards::Rank>(rank)));
+            }
+        }
+    };
+
+    add_cards_for_suit(Cards::Suit::Clubs, full_club_suit_count);
+    add_cards_for_suit(Cards::Suit::Diamonds, full_diamond_suit_count);
+    add_cards_for_suit(Cards::Suit::Hearts, full_heart_suit_count);
+    add_cards_for_suit(Cards::Suit::Spades, full_spade_suit_count);
+
+    if (shuffle == Shuffle::Yes)
+        shuffle_deck(deck);
+
+    return deck;
+}
+
+void shuffle_deck(NonnullRefPtrVector<Card>& deck)
+{
+    auto iteration_count = deck.size() * 4;
+    for (auto i = 0u; i < iteration_count; ++i)
+        deck.append(deck.take(get_random_uniform(deck.size())));
 }
 
 }

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -88,6 +88,7 @@ public:
     virtual ~Card() override = default;
 
     Gfx::IntRect& rect() { return m_rect; }
+    Gfx::IntRect const& rect() const { return m_rect; }
     Gfx::IntPoint position() const { return m_rect.location(); }
     Gfx::IntPoint const& old_position() const { return m_old_position; }
     Rank rank() const { return m_rank; };

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -106,9 +106,9 @@ public:
 
     void save_old_position();
 
-    void draw(GUI::Painter&) const;
+    void paint(GUI::Painter&) const;
     void clear(GUI::Painter&, Color const& background_color) const;
-    void clear_and_draw(GUI::Painter&, Color const& background_color);
+    void clear_and_paint(GUI::Painter& painter, Color const& background_color);
 
 private:
     Card(Suit, Rank);

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -123,6 +123,14 @@ private:
     bool m_inverted { false };
 };
 
+enum class Shuffle {
+    No,
+    Yes,
+};
+NonnullRefPtrVector<Card> create_standard_deck(Shuffle);
+NonnullRefPtrVector<Card> create_deck(unsigned full_club_suit_count, unsigned full_diamond_suit_count, unsigned full_heart_suit_count, unsigned full_spade_suit_count, Shuffle);
+void shuffle_deck(NonnullRefPtrVector<Card>&);
+
 }
 
 template<>

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -22,6 +22,16 @@ void CardGame::add_stack(NonnullRefPtr<CardStack> stack)
     m_stacks.append(move(stack));
 }
 
+void CardGame::mark_intersecting_stacks_dirty(Cards::Card const& intersecting_card)
+{
+    for (auto& stack : stacks()) {
+        if (intersecting_card.rect().intersects(stack.bounding_box()))
+            update(stack.bounding_box());
+    }
+
+    update(intersecting_card.rect());
+}
+
 void CardGame::dump_layout() const
 {
     dbgln("------------------------------");

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -17,6 +17,18 @@ CardGame::CardGame()
     set_background_color(background_color.value_or(Color::from_rgb(0x008000)));
 }
 
+void CardGame::add_stack(NonnullRefPtr<CardStack> stack)
+{
+    m_stacks.append(move(stack));
+}
+
+void CardGame::dump_layout() const
+{
+    dbgln("------------------------------");
+    for (auto const& stack : stacks())
+        dbgln("{}", stack);
+}
+
 void CardGame::config_string_did_change(String const& domain, String const& group, String const& key, String const& value)
 {
     if (domain == "Games" && group == "Cards") {

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -45,10 +45,7 @@ Gfx::IntRect CardGame::moving_cards_bounds() const
 
 void CardGame::pick_up_cards_from_stack(Cards::CardStack& stack, Gfx::IntPoint click_location, CardStack::MovementRule movement_rule)
 {
-    if (m_moving_cards_source_stack)
-        m_moving_cards_source_stack->set_focused(false);
     stack.add_all_grabbed_cards(click_location, m_moving_cards, movement_rule);
-    stack.set_focused(true);
     m_moving_cards_source_stack = stack;
 }
 
@@ -60,7 +57,7 @@ RefPtr<CardStack> CardGame::find_stack_to_drop_on(CardStack::MovementRule moveme
     float closest_distance = FLT_MAX;
 
     for (auto const& stack : stacks()) {
-        if (stack.is_focused())
+        if (stack == moving_cards_source_stack())
             continue;
 
         if (stack.bounding_box().intersects(bounds_to_check)
@@ -92,8 +89,6 @@ void CardGame::drop_cards_on_stack(Cards::CardStack& stack, CardStack::MovementR
 
 void CardGame::clear_moving_cards()
 {
-    if (!m_moving_cards_source_stack.is_null())
-        m_moving_cards_source_stack->set_focused(false);
     m_moving_cards_source_stack.clear();
     m_moving_cards.clear();
 }

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -56,20 +56,25 @@ RefPtr<CardStack> CardGame::find_stack_to_drop_on(CardStack::MovementRule moveme
 {
     auto bounds_to_check = moving_cards_bounds();
 
-    // FIXME: This currently returns only the first stack we overlap,
-    //        but what we want is the stack we overlap the most.
+    RefPtr<CardStack> closest_stack;
+    float closest_distance = FLT_MAX;
+
     for (auto const& stack : stacks()) {
         if (stack.is_focused())
             continue;
 
-        if (stack.bounding_box().intersects(bounds_to_check)) {
-            if (stack.is_allowed_to_push(moving_cards().at(0), moving_cards().size(), movement_rule)) {
-                return stack;
+        if (stack.bounding_box().intersects(bounds_to_check)
+            && stack.is_allowed_to_push(moving_cards().at(0), moving_cards().size(), movement_rule)) {
+
+            auto distance = bounds_to_check.center().distance_from(stack.bounding_box().center());
+            if (distance < closest_distance) {
+                closest_stack = stack;
+                closest_distance = distance;
             }
         }
     }
 
-    return nullptr;
+    return closest_stack;
 }
 
 void CardGame::drop_cards_on_stack(Cards::CardStack& stack, CardStack::MovementRule movement_rule)

--- a/Userland/Libraries/LibCards/CardGame.h
+++ b/Userland/Libraries/LibCards/CardGame.h
@@ -25,6 +25,7 @@ public:
     NonnullRefPtrVector<CardStack> const& stacks() const { return m_stacks; }
     CardStack& stack_at_location(int location) { return m_stacks[location]; }
     void add_stack(NonnullRefPtr<CardStack>);
+    void mark_intersecting_stacks_dirty(Card const& intersecting_card);
 
     void dump_layout() const;
 

--- a/Userland/Libraries/LibCards/CardGame.h
+++ b/Userland/Libraries/LibCards/CardGame.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibCards/CardStack.h>
 #include <LibConfig/Listener.h>
 #include <LibGUI/Frame.h>
 
@@ -20,11 +21,20 @@ public:
     Gfx::Color background_color() const;
     void set_background_color(Gfx::Color const&);
 
+    NonnullRefPtrVector<CardStack>& stacks() { return m_stacks; }
+    NonnullRefPtrVector<CardStack> const& stacks() const { return m_stacks; }
+    CardStack& stack_at_location(int location) { return m_stacks[location]; }
+    void add_stack(NonnullRefPtr<CardStack>);
+
+    void dump_layout() const;
+
 protected:
     CardGame();
 
 private:
     virtual void config_string_did_change(String const& domain, String const& group, String const& key, String const& value) override;
+
+    NonnullRefPtrVector<CardStack> m_stacks;
 };
 
 }

--- a/Userland/Libraries/LibCards/CardGame.h
+++ b/Userland/Libraries/LibCards/CardGame.h
@@ -27,6 +27,16 @@ public:
     void add_stack(NonnullRefPtr<CardStack>);
     void mark_intersecting_stacks_dirty(Card const& intersecting_card);
 
+    bool is_moving_cards() const { return !m_moving_cards.is_empty(); }
+    NonnullRefPtrVector<Card>& moving_cards() { return m_moving_cards; }
+    NonnullRefPtrVector<Card> const& moving_cards() const { return m_moving_cards; }
+    Gfx::IntRect moving_cards_bounds() const;
+    RefPtr<CardStack> moving_cards_source_stack() const { return m_moving_cards_source_stack; }
+    void pick_up_cards_from_stack(CardStack&, Gfx::IntPoint click_location, CardStack::MovementRule);
+    RefPtr<CardStack> find_stack_to_drop_on(CardStack::MovementRule) const;
+    void drop_cards_on_stack(CardStack&, CardStack::MovementRule);
+    void clear_moving_cards();
+
     void dump_layout() const;
 
 protected:
@@ -36,6 +46,9 @@ private:
     virtual void config_string_did_change(String const& domain, String const& group, String const& key, String const& value) override;
 
     NonnullRefPtrVector<CardStack> m_stacks;
+
+    NonnullRefPtrVector<Card> m_moving_cards;
+    RefPtr<CardStack> m_moving_cards_source_stack;
 };
 
 }

--- a/Userland/Libraries/LibCards/CardStack.cpp
+++ b/Userland/Libraries/LibCards/CardStack.cpp
@@ -42,7 +42,7 @@ void CardStack::clear()
     m_stack_positions.clear();
 }
 
-void CardStack::draw(GUI::Painter& painter, Gfx::Color const& background_color)
+void CardStack::paint(GUI::Painter& painter, Gfx::Color const& background_color)
 {
     auto draw_background_if_empty = [&]() {
         size_t number_of_moving_cards = 0;
@@ -89,13 +89,13 @@ void CardStack::draw(GUI::Painter& painter, Gfx::Color const& background_color)
 
     if (m_rules.shift_x == 0 && m_rules.shift_y == 0) {
         auto& card = peek();
-        card.draw(painter);
+        card.paint(painter);
         return;
     }
 
     for (auto& card : m_stack) {
         if (!card.is_moving())
-            card.clear_and_draw(painter, Gfx::Color::Transparent);
+            card.clear_and_paint(painter, Gfx::Color::Transparent);
     }
 }
 

--- a/Userland/Libraries/LibCards/CardStack.cpp
+++ b/Userland/Libraries/LibCards/CardStack.cpp
@@ -36,8 +36,8 @@ void CardStack::paint(GUI::Painter& painter, Gfx::Color const& background_color)
 {
     auto draw_background_if_empty = [&]() {
         size_t number_of_moving_cards = 0;
-        for (const auto& card : m_stack)
-            number_of_moving_cards += card.is_moving();
+        for (auto const& card : m_stack)
+            number_of_moving_cards += card.is_moving() ? 1 : 0;
 
         if (m_covered_stack && !m_covered_stack->is_empty())
             return false;
@@ -194,7 +194,7 @@ bool CardStack::is_allowed_to_push(Card const& card, size_t stack_size, Movement
         return card.rank() == Rank::Ace;
 
     if (!is_empty()) {
-        auto& top_card = peek();
+        auto const& top_card = peek();
         if (top_card.is_upside_down())
             return false;
 
@@ -203,7 +203,8 @@ bool CardStack::is_allowed_to_push(Card const& card, size_t stack_size, Movement
             if (stack_size > 1)
                 return false;
             return top_card.suit() == card.suit() && m_stack.size() == to_underlying(card.rank());
-        } else if (m_type == Type::Normal) {
+        }
+        if (m_type == Type::Normal) {
             bool color_match;
             switch (movement_rule) {
             case MovementRule::Alternating:
@@ -228,10 +229,9 @@ bool CardStack::is_allowed_to_push(Card const& card, size_t stack_size, Movement
 
 void CardStack::push(NonnullRefPtr<Card> card)
 {
-    auto size = m_stack.size();
     auto top_most_position = m_stack_positions.is_empty() ? m_position : m_stack_positions.last();
 
-    if (size && size % m_rules.step == 0) {
+    if (!m_stack.is_empty() && m_stack.size() % m_rules.step == 0) {
         if (peek().is_upside_down())
             top_most_position.translate_by(m_rules.shift_x, m_rules.shift_y_upside_down);
         else
@@ -282,7 +282,7 @@ void CardStack::calculate_bounding_box()
     uint16_t height = 0;
     size_t card_position = 0;
     for (auto& card : m_stack) {
-        if (card_position % m_rules.step == 0 && card_position) {
+        if (card_position % m_rules.step == 0 && card_position != 0) {
             if (card.is_upside_down()) {
                 width += m_rules.shift_x;
                 height += m_rules.shift_y_upside_down;

--- a/Userland/Libraries/LibCards/CardStack.cpp
+++ b/Userland/Libraries/LibCards/CardStack.cpp
@@ -227,6 +227,20 @@ bool CardStack::is_allowed_to_push(Card const& card, size_t stack_size, Movement
     return true;
 }
 
+bool CardStack::make_top_card_visible()
+{
+    if (is_empty())
+        return false;
+
+    auto& top_card = peek();
+    if (top_card.is_upside_down()) {
+        top_card.set_upside_down(false);
+        return true;
+    }
+
+    return false;
+}
+
 void CardStack::push(NonnullRefPtr<Card> card)
 {
     auto top_most_position = m_stack_positions.is_empty() ? m_position : m_stack_positions.last();

--- a/Userland/Libraries/LibCards/CardStack.cpp
+++ b/Userland/Libraries/LibCards/CardStack.cpp
@@ -15,18 +15,8 @@ CardStack::CardStack()
 {
 }
 
-CardStack::CardStack(Gfx::IntPoint const& position, Type type)
-    : m_position(position)
-    , m_type(type)
-    , m_rules(rules_for_type(type))
-    , m_base(m_position, { Card::width, Card::height })
-{
-    VERIFY(type != Type::Invalid);
-    calculate_bounding_box();
-}
-
-CardStack::CardStack(Gfx::IntPoint const& position, Type type, NonnullRefPtr<CardStack> associated_stack)
-    : m_associated_stack(move(associated_stack))
+CardStack::CardStack(Gfx::IntPoint const& position, Type type, RefPtr<CardStack> covered_stack)
+    : m_covered_stack(move(covered_stack))
     , m_position(position)
     , m_type(type)
     , m_rules(rules_for_type(type))
@@ -49,7 +39,7 @@ void CardStack::paint(GUI::Painter& painter, Gfx::Color const& background_color)
         for (const auto& card : m_stack)
             number_of_moving_cards += card.is_moving();
 
-        if (m_associated_stack && !m_associated_stack->is_empty())
+        if (m_covered_stack && !m_covered_stack->is_empty())
             return false;
         if (!is_empty() && (m_stack.size() != number_of_moving_cards))
             return false;

--- a/Userland/Libraries/LibCards/CardStack.h
+++ b/Userland/Libraries/LibCards/CardStack.h
@@ -52,7 +52,7 @@ public:
 
     bool is_allowed_to_push(Card const&, size_t stack_size = 1, MovementRule movement_rule = MovementRule::Alternating) const;
     void add_all_grabbed_cards(Gfx::IntPoint const& click_location, NonnullRefPtrVector<Card>& grabbed, MovementRule movement_rule = MovementRule::Alternating);
-    void draw(GUI::Painter&, Gfx::Color const& background_color);
+    void paint(GUI::Painter&, Gfx::Color const& background_color);
     void clear();
 
 private:

--- a/Userland/Libraries/LibCards/CardStack.h
+++ b/Userland/Libraries/LibCards/CardStack.h
@@ -31,8 +31,7 @@ public:
     };
 
     CardStack();
-    CardStack(Gfx::IntPoint const& position, Type type);
-    CardStack(Gfx::IntPoint const& position, Type type, NonnullRefPtr<CardStack> associated_stack);
+    CardStack(Gfx::IntPoint const& position, Type type, RefPtr<CardStack> covered_stack = nullptr);
 
     bool is_empty() const { return m_stack.is_empty(); }
     bool is_focused() const { return m_focused; }
@@ -83,7 +82,10 @@ private:
 
     void calculate_bounding_box();
 
-    RefPtr<CardStack> m_associated_stack;
+    // An optional stack that this stack is painted on top of.
+    // eg, in Solitaire the Play stack is positioned over the Waste stack.
+    RefPtr<CardStack> m_covered_stack;
+
     NonnullRefPtrVector<Card> m_stack;
     Vector<Gfx::IntPoint> m_stack_positions;
     Gfx::IntPoint m_position;

--- a/Userland/Libraries/LibCards/CardStack.h
+++ b/Userland/Libraries/LibCards/CardStack.h
@@ -62,7 +62,7 @@ private:
         uint8_t shift_y_upside_down { 0 };
     };
 
-    constexpr StackRules rules_for_type(Type stack_type)
+    static constexpr StackRules rules_for_type(Type stack_type)
     {
         switch (stack_type) {
         case Type::Foundation:

--- a/Userland/Libraries/LibCards/CardStack.h
+++ b/Userland/Libraries/LibCards/CardStack.h
@@ -43,6 +43,7 @@ public:
     Gfx::IntRect const& bounding_box() const { return m_bounding_box; }
 
     void set_focused(bool focused) { m_focused = focused; }
+    bool make_top_card_visible(); // Returns true if the card was flipped.
 
     void push(NonnullRefPtr<Card> card);
     NonnullRefPtr<Card> pop();

--- a/Userland/Libraries/LibCards/CardStack.h
+++ b/Userland/Libraries/LibCards/CardStack.h
@@ -34,7 +34,6 @@ public:
     CardStack(Gfx::IntPoint const& position, Type type, RefPtr<CardStack> covered_stack = nullptr);
 
     bool is_empty() const { return m_stack.is_empty(); }
-    bool is_focused() const { return m_focused; }
     Type type() const { return m_type; }
     NonnullRefPtrVector<Card> const& stack() const { return m_stack; }
     size_t count() const { return m_stack.size(); }
@@ -42,7 +41,6 @@ public:
     Card& peek() { return m_stack.last(); }
     Gfx::IntRect const& bounding_box() const { return m_bounding_box; }
 
-    void set_focused(bool focused) { m_focused = focused; }
     bool make_top_card_visible(); // Returns true if the card was flipped.
 
     void push(NonnullRefPtr<Card> card);
@@ -93,7 +91,6 @@ private:
     Gfx::IntRect m_bounding_box;
     Type m_type { Type::Invalid };
     StackRules m_rules;
-    bool m_focused { false };
     Gfx::IntRect m_base;
 };
 


### PR DESCRIPTION
The goal here is to reduce some duplicate code between the card games, (especially Solitaire and Spider,) and generally make it clearer.

There are only two behaviour changes:
- If dropping cards over multiple valid stacks, pick the closest
- Don't allow tab-moving cards while dragging them in Solitaire

The first is what actually got me to look into this at all. Getting confused by naming is what motivated the rest of it. I still have a fairly large yak stack here, but this reduces it a little.