### PR TITLE
LibGfx+PixelPaint: Bitmap flood fill algorithm

### DIFF
--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Timothy Slater <tslater2006@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,6 +8,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/Function.h>
 #include <AK/RefCounted.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibGfx/Color.h>
@@ -241,6 +243,8 @@ public:
     [[nodiscard]] bool visually_equals(Bitmap const&) const;
 
     [[nodiscard]] Optional<Color> solid_color(u8 alpha_threshold = 0) const;
+
+    void flood_visit_from_point(Gfx::IntPoint const& start_point, int threshold, Function<void(Gfx::IntPoint location)> pixel_reached);
 
 private:
     Bitmap(BitmapFormat, IntSize const&, int, BackingStore const&);

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -255,6 +255,15 @@ public:
             alpha() * other.alpha() / 255);
     }
 
+    constexpr float distance_squared_to(Color const& other) const
+    {
+        int a = other.red() - red();
+        int b = other.green() - green();
+        int c = other.blue() - blue();
+        int d = other.alpha() - alpha();
+        return (a * a + b * b + c * c + d * d) / (4.0f * 255.0f * 255.0f);
+    }
+
     constexpr u8 luminosity() const
     {
         return (red() * 0.2126f + green() * 0.7152f + blue() * 0.0722f);


### PR DESCRIPTION
This set of changes abstract out the flood fill algorithm that was implemented  in both Bucket Tool and Wand Select Tool into a common method of the Bitmap class. This reduces code duplication (especially with a few more selection tools in the works). The method in Bitmap class takes a lambda which allows actions to be performed as each reachable pixel is visited during the flood fill. Bucket Tool's lambda will use set_pixel() to color in the reached areas while Wand Select Tool's lambda will alter a selection mask.