### PR TITLE
tail: Add support for reading from stdin

### DIFF
--- a/Base/usr/share/man/man1/tail.md
+++ b/Base/usr/share/man/man1/tail.md
@@ -4,13 +4,13 @@ tail
 
 ## Synopsis
 
-```sh
-$ tail [--follow] [--lines number] <file>
+```*sh
+$ tail [--follow] [--lines number] [file]
 ```
 
 ## Description
 
-Print the end ('tail') of a file.
+Print the end ('tail') of a file. If no file is specified, or the filename '-' is specified, it defaults to standard input.
 
 ## Options:
 

--- a/Userland/Utilities/tail.cpp
+++ b/Userland/Utilities/tail.cpp
@@ -84,10 +84,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.set_general_help("Print the end ('tail') of a file.");
     args_parser.add_option(follow, "Output data as it is written to the file", "follow", 'f');
     args_parser.add_option(line_count, "Fetch the specified number of lines", "lines", 'n', "number");
-    args_parser.add_positional_argument(file, "File path", "file");
+    args_parser.add_positional_argument(file, "File path", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    auto f = TRY(Core::File::open(file, Core::OpenMode::ReadOnly));
+    auto f = TRY(Core::File::open((file == "-"sv || file == nullptr) ? "/dev/stdin" : file, Core::OpenMode::ReadOnly));
     TRY(Core::System::pledge("stdio"));
 
     auto pos = find_seek_pos(*f, line_count);


### PR DESCRIPTION
- tail: Add support for stdin input
- tail: Update the manual page to new changes

These changes will allow you to use `tail` in the same way as most
command-line utilities where no files provided, or the filename '-' will
cause the process to read from stdin:
