### PR TITLE
Toolchain: Hardcode the results of LLVM runtime library detection

### DIFF
--- a/Toolchain/CMake/LLVMRuntimesConfig.cmake
+++ b/Toolchain/CMake/LLVMRuntimesConfig.cmake
@@ -60,3 +60,15 @@ set(LIBCXX_ENABLE_STATIC_ABI_LIBRARY ON CACHE BOOL "")
 set(LIBCXX_INCLUDE_BENCHMARKS OFF CACHE BOOL "")
 set(LIBCXXABI_USE_COMPILER_RT ON CACHE BOOL "")
 set(LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
+
+# Hardcode autodetection results for libm, libdl, and libpthread.
+# This keeps us from accidentially detecting those libraries as being present
+# if we build the toolchain with a populated sysroot (which features the
+# compability linker scripts).
+# TODO: Figure out if we can always build against the Stubs directory instead.
+set(LIBCXXABI_HAS_DL_LIB OFF CACHE BOOL "")
+set(LIBCXXABI_HAS_PTHREAD_LIB OFF CACHE BOOL "")
+set(LIBCXX_HAS_M_LIB OFF CACHE BOOL "")
+set(LIBCXX_HAS_PTHREAD_LIB OFF CACHE BOOL "")
+set(LIBUNWIND_HAS_DL_LIB OFF CACHE BOOL "")
+set(LIBUNWIND_HAS_PTHREAD_LIB OFF CACHE BOOL "")


### PR DESCRIPTION
This keeps us from accidentally building toolchains that don't make it through a clean build if we build them using a populated sysroot, as it would otherwise detect libpthread and friends and try to pull them in while LibC is not yet built.