### PR TITLE
LibWeb: Don't scale by x, x when a scale x, y is provided as a transform

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -233,7 +233,7 @@ Gfx::FloatMatrix4x4 StackingContext::get_transformation_matrix(CSS::Transformati
                 0, 0, 0, 1);
         if (count == 2)
             return Gfx::FloatMatrix4x4(value(0), 0, 0, 0,
-                0, value(0), 0, 0,
+                0, value(1), 0, 0,
                 0, 0, 1, 0,
                 0, 0, 0, 1);
         break;


### PR DESCRIPTION

Just a small copy-pasta error I have noticed trying to look into why rotation in scuffed