### PR TITLE
Ports/qemu: Use the coarse monotonic clock for timing CPU ticks

### DIFF
--- a/Ports/qemu/patches/0001-Add-build-system-support-for-SerenityOS.patch
+++ b/Ports/qemu/patches/0001-Add-build-system-support-for-SerenityOS.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Add build system support for SerenityOS
  1 file changed, 6 insertions(+)
 
 diff --git a/configure b/configure
-index 7c08c18..3177605 100755
+index 7c08c18358becf49779c876b0f3d17329df053c6..3177605054876b387cd2b93463025ee3203991e7 100755
 --- a/configure
 +++ b/configure
 @@ -496,6 +496,8 @@ elif check_define __NetBSD__; then

--- a/Ports/qemu/patches/0002-Extend-short-scan-sets-into-the-full-list.patch
+++ b/Ports/qemu/patches/0002-Extend-short-scan-sets-into-the-full-list.patch
@@ -10,7 +10,7 @@ sets, so extend them into a full list manually.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/chardev/char.c b/chardev/char.c
-index 0169d8d..03ce487 100644
+index 0169d8dde4b533c9cf851831b03c8adcac24cff5..03ce487a23c92b70981643bd213930f5d074afdb 100644
 --- a/chardev/char.c
 +++ b/chardev/char.c
 @@ -382,11 +382,11 @@ QemuOpts *qemu_chr_parse_compat(const char *label, const char *filename,

--- a/Ports/qemu/patches/0003-Use-the-coarse-monotonic-clock-for-timing-CPU-ticks.patch
+++ b/Ports/qemu/patches/0003-Use-the-coarse-monotonic-clock-for-timing-CPU-ticks.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sat, 1 Oct 2022 02:46:48 +0200
+Subject: [PATCH] Use the coarse monotonic clock for timing CPU ticks
+
+While this loses quite a bit of accuracy (although to no apparent
+decrease in emulation quality), it helps avoiding the additional
+overhead of the `clock_gettime` syscall (as `CLOCK_MONOTONIC_COARSE`
+is forwarded using the mapped time page) and we don't have to do a
+HPET timer read for each tick.
+---
+ include/qemu/timer.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/qemu/timer.h b/include/qemu/timer.h
+index ee071e07d131641131ed9705e7407f153bbf6c67..97fb9b9ac28bd36cd7200e92c3c0c1e30858aa0d 100644
+--- a/include/qemu/timer.h
++++ b/include/qemu/timer.h
+@@ -833,7 +833,7 @@ static inline int64_t get_clock(void)
+ {
+     if (use_rt_clock) {
+         struct timespec ts;
+-        clock_gettime(CLOCK_MONOTONIC, &ts);
++        clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);
+         return ts.tv_sec * 1000000000LL + ts.tv_nsec;
+     } else {
+         /* XXX: using gettimeofday leads to problems if the date

--- a/Ports/qemu/patches/ReadMe.md
+++ b/Ports/qemu/patches/ReadMe.md
@@ -12,3 +12,13 @@ Extend short scan sets into the full list
 We don't support the (apparently nonstandard) short variant of scan
 sets, so extend them into a full list manually.
 
+## `0003-Use-the-coarse-monotonic-clock-for-timing-CPU-ticks.patch`
+
+Use the coarse monotonic clock for timing CPU ticks
+
+While this loses quite a bit of accuracy (although to no apparent
+decrease in emulation quality), it helps avoiding the additional
+overhead of the `clock_gettime` syscall (as `CLOCK_MONOTONIC_COARSE`
+is forwarded using the mapped time page) and we don't have to do a
+HPET timer read for each tick.
+


### PR DESCRIPTION
While this loses quite a bit of accuracy (although to no apparent decrease in emulation quality), it helps avoiding the additional overhead of the `clock_gettime` syscall (as `CLOCK_MONOTONIC_COARSE` is forwarded using the mapped time page) and we don't have to do a HPET timer read for each tick.

This results in a decrease of Serenity boot time from 1h16m down to 42m when running on Serenity.