### PR TITLE
AK: fix FreeBSD compilation for ladybird

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -166,7 +166,7 @@ extern "C" {
 #    define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
 #endif
 
-#if defined(AK_OS_BSD_GENERIC)
+#if defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_FREEBSD)
 #    define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
 #    define CLOCK_REALTIME_COARSE CLOCK_REALTIME
 #endif


### PR DESCRIPTION
this patch fixes a compilation error that appears when trying to compile ladybird on a FreeBSD host.

FreeBSD introduced CLOCK_MONOTONIC_COARSE and CLOCK_REALTIME_COARSE in more recent editions. checked in a FreeBSD 13.1 jail.

see [clock_gettime(2)](https://www.freebsd.org/cgi/man.cgi?query=clock_gettime&apropos=0&sektion=0&manpath=FreeBSD+13.1-RELEASE&arch=default&format=ascii) 