### PR TITLE
LibJS: Store symbols in a Handle inside PropertyKey

### DIFF
--- a/Userland/Libraries/LibJS/Heap/Handle.h
+++ b/Userland/Libraries/LibJS/Heap/Handle.h
@@ -12,7 +12,6 @@
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <LibJS/Forward.h>
-#include <LibJS/Runtime/Environment.h>
 #include <LibJS/Runtime/Value.h>
 
 namespace JS {

--- a/Userland/Libraries/LibJS/Runtime/ClassFieldDefinition.h
+++ b/Userland/Libraries/LibJS/Runtime/ClassFieldDefinition.h
@@ -9,6 +9,7 @@
 #include <AK/Forward.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Handle.h>
+#include <LibJS/Runtime/Environment.h>
 
 namespace JS {
 

--- a/Userland/Libraries/LibJS/Runtime/PropertyKey.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyKey.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <LibJS/Heap/Handle.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/StringOrSymbol.h>
 
@@ -186,7 +187,7 @@ private:
     Type m_type { Type::Invalid };
     u32 m_number { 0 };
     FlyString m_string;
-    Symbol* m_symbol { nullptr };
+    Handle<Symbol> m_symbol;
 };
 
 }


### PR DESCRIPTION
If the stored symbol is custom (non-global), it is allocated on the heap, and may not be visited by anyone else, so we must register it in order to keep it alive. Fixes #14182.