### PR TITLE
Lagom: Fix Clang 16 + LTO build

### DIFF
--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -567,20 +567,20 @@ template<template<typename...> typename U, typename... Us>
 inline constexpr bool IsSpecializationOf<U<Us...>, U> = true;
 
 template<typename T>
-struct __decay {
+struct __Decay {
     typedef Detail::RemoveCVReference<T> type;
 };
 template<typename T>
-struct __decay<T[]> {
+struct __Decay<T[]> {
     typedef T* type;
 };
 template<typename T, decltype(sizeof(T)) N>
-struct __decay<T[N]> {
+struct __Decay<T[N]> {
     typedef T* type;
 };
 // FIXME: Function decay
 template<typename T>
-using Decay = typename __decay<T>::type;
+using Decay = typename __Decay<T>::type;
 
 template<typename T, typename U>
 inline constexpr bool IsPointerOfType = IsPointer<Decay<U>>&& IsSame<T, RemoveCV<RemovePointer<Decay<U>>>>;

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -171,9 +171,13 @@ install(
 )
 
 function(lagom_lib library fs_name)
-    cmake_parse_arguments(LAGOM_LIBRARY "" "" "SOURCES;LIBS" ${ARGN})
+    cmake_parse_arguments(LAGOM_LIBRARY "STATIC" "" "SOURCES;LIBS" ${ARGN})
     set(target_name "Lib${library}")
-    add_library(${target_name} ${LAGOM_LIBRARY_SOURCES})
+    if (LAGOM_LIBRARY_STATIC)
+        add_library(${target_name} STATIC ${LAGOM_LIBRARY_SOURCES})
+    else()
+        add_library(${target_name} ${LAGOM_LIBRARY_SOURCES})
+    endif()
 
     # Don't make alias when we're going to import a previous build for Tools
     # FIXME: Is there a better way to write this?
@@ -283,11 +287,8 @@ endif()
 file(GLOB LIBMAIN_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibMain/*.cpp")
 lagom_lib(Main main
     SOURCES ${LIBMAIN_SOURCES}
+    STATIC
 )
-# The macOS linker is not happy about LibMain's main() calling an undefined symbol (serenity_main()).
-if (APPLE)
-    target_link_options(LibMain PRIVATE -undefined dynamic_lookup)
-endif()
 
 # LibTimeZone
 # This is needed even if Lagom is not enabled because it is depended upon by code generators.


### PR DESCRIPTION
**Lagom: Link LibMain statically**

This matches how LibMain is used within Serenity. This commit makes it
possible to build Lagom with LTO. Previously, `serenity_main` functions
would be dead-stripped away, as the linker could prove that nothing from
the executable ever called them.

**AK: Fix naming conflict with compiler builtin**

Clang patch [D116203](https://reviews.llvm.org/D116203) added various builtin functions for type traits,
`__decay` being one of them. This name conflicts with our
`AK::Detail::__decay`, leading to compiler warnings with Clang 16.