### PR TITLE
LibHTTP: Use 'close' as the default value for Connection in HTTP/1.0

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.h
+++ b/Userland/Libraries/LibHTTP/Job.h
@@ -52,6 +52,7 @@ protected:
     HttpRequest m_request;
     State m_state { State::InStatus };
     Core::Stream::BufferedSocketBase* m_socket { nullptr };
+    bool m_legacy_connection { false };
     int m_code { -1 };
     HashMap<String, String, CaseInsensitiveStringTraits> m_headers;
     Vector<String> m_set_cookie_headers;


### PR DESCRIPTION
Unlike HTTP/1.1 and above, the default behaviour for HTTP/1.0 servers is to close the connection after sending the response.
Fixes #14092.