### PR TITLE
HackStudio: Set proper action scope for editor shortcuts

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1265,12 +1265,12 @@ void HackStudioWidget::create_toolbar(GUI::Widget& parent)
     toolbar.add_action(*m_delete_action);
     toolbar.add_separator();
 
-    toolbar.add_action(GUI::CommonActions::make_cut_action([this](auto&) { current_editor().cut_action().activate(); }));
-    toolbar.add_action(GUI::CommonActions::make_copy_action([this](auto&) { current_editor().copy_action().activate(); }));
-    toolbar.add_action(GUI::CommonActions::make_paste_action([this](auto&) { current_editor().paste_action().activate(); }));
+    toolbar.add_action(GUI::CommonActions::make_cut_action([this](auto&) { current_editor().cut_action().activate(); }, m_editors_splitter));
+    toolbar.add_action(GUI::CommonActions::make_copy_action([this](auto&) { current_editor().copy_action().activate(); }, m_editors_splitter));
+    toolbar.add_action(GUI::CommonActions::make_paste_action([this](auto&) { current_editor().paste_action().activate(); }, m_editors_splitter));
     toolbar.add_separator();
-    toolbar.add_action(GUI::CommonActions::make_undo_action([this](auto&) { current_editor().undo_action().activate(); }));
-    toolbar.add_action(GUI::CommonActions::make_redo_action([this](auto&) { current_editor().redo_action().activate(); }));
+    toolbar.add_action(GUI::CommonActions::make_undo_action([this](auto&) { current_editor().undo_action().activate(); }, m_editors_splitter));
+    toolbar.add_action(GUI::CommonActions::make_redo_action([this](auto&) { current_editor().redo_action().activate(); }, m_editors_splitter));
     toolbar.add_separator();
 
     toolbar.add_action(*m_build_action);


### PR DESCRIPTION
This fixes issue #14429. The editor actions were not given a parent as scope so defaulted to global. Because HackStudio can have multiple editors and even multiple editor tab widgets, I chose the VerticalSplitter that all editor tab widgets get added to as the parent. With a Widget set as the parent, the action gets WidgetLocal scope and allows the embedded terminals to receive shortcuts.