### PR TITLE
LibWeb+LibGfx: Implement the `hue-rotate()` filter effect

### DIFF
--- a/Base/res/html/misc/backdrop-filter.html
+++ b/Base/res/html/misc/backdrop-filter.html
@@ -68,6 +68,10 @@
         .mixed {
           backdrop-filter: grayscale(50%) invert(70%);
         }
+
+        .hue-rotate {
+          backdrop-filter: hue-rotate(60deg);
+        }
     </style>
   </head>
   <body>
@@ -101,6 +105,10 @@
     </div>
     <div class="image-box">
       <div class="backdrop-box sepia">
+      </div>
+    </div>
+    <div class="image-box">
+      <div class="backdrop-box hue-rotate">
       </div>
     </div>
   <script>

--- a/Userland/Libraries/LibGfx/Filters/HueRotateFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/HueRotateFilter.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Math.h>
+#include <LibGfx/Filters/ColorFilter.h>
+#include <LibGfx/Matrix3x3.h>
+
+namespace Gfx {
+
+class HueRotateFilter : public ColorFilter {
+public:
+    HueRotateFilter(float angle_degrees)
+        : ColorFilter(angle_degrees)
+        , m_operation(calculate_operation_matrix(angle_degrees))
+    {
+    }
+
+    virtual bool amount_handled_in_filter() const override
+    {
+        return true;
+    }
+
+    float angle_degrees() const
+    {
+        return m_amount;
+    }
+
+    virtual StringView class_name() const override { return "HueRotateFilter"sv; }
+
+protected:
+    Color convert_color(Color original) override
+    {
+        FloatVector3 rgb = {
+            original.red() / 256.0f,
+            original.green() / 256.0f,
+            original.blue() / 256.0f,
+        };
+        rgb = m_operation * rgb;
+        auto safe_float_to_u8 = [](float value) -> u8 {
+            return static_cast<u8>(AK::clamp(value, 0.0f, 1.0f) * 256);
+        };
+        return Color {
+            safe_float_to_u8(rgb[0]),
+            safe_float_to_u8(rgb[1]),
+            safe_float_to_u8(rgb[2]),
+            original.alpha()
+        };
+    }
+
+private:
+    static FloatMatrix3x3 calculate_operation_matrix(float angle)
+    {
+        float angle_rads = angle * (AK::Pi<float> / 180);
+        float cos_angle = 0;
+        float sin_angle = 0;
+        AK::sincos(angle_rads, sin_angle, cos_angle);
+        // The matrices here are taken directly from the SVG filter specification:
+        // https://drafts.fxtf.org/filter-effects-1/#feColorMatrixElement
+        // clang-format off
+        return FloatMatrix3x3 {
+            +0.213, +0.715, +0.072,
+            +0.213, +0.715, +0.072,
+            +0.213, +0.715, +0.072
+        } + cos_angle * FloatMatrix3x3 {
+            +0.787, -0.715, -0.072,
+            -0.213, +0.285, -0.072,
+            -0.213, -0.715, +0.928
+        } + sin_angle * FloatMatrix3x3 {
+            -0.213, -0.715, +0.928,
+            +0.143, +0.140, -0.283,
+            -0.787, +0.715, +0.072
+        };
+        // clang-format on
+    }
+
+    FloatMatrix3x3 m_operation;
+};
+
+}

--- a/Userland/Libraries/LibGfx/Matrix.h
+++ b/Userland/Libraries/LibGfx/Matrix.h
@@ -50,7 +50,7 @@ public:
     constexpr auto elements() const { return m_elements; }
     constexpr auto elements() { return m_elements; }
 
-    constexpr Matrix operator*(Matrix const& other) const
+    [[nodiscard]] constexpr Matrix operator*(Matrix const& other) const
     {
         Matrix product;
         for (size_t i = 0; i < N; ++i) {
@@ -84,7 +84,7 @@ public:
         return product;
     }
 
-    constexpr Matrix operator+(Matrix const& other) const
+    [[nodiscard]] constexpr Matrix operator+(Matrix const& other) const
     {
         Matrix sum;
         for (size_t i = 0; i < N; ++i) {
@@ -94,7 +94,7 @@ public:
         return sum;
     }
 
-    constexpr Matrix operator/(T divisor) const
+    [[nodiscard]] constexpr Matrix operator/(T divisor) const
     {
         Matrix division;
         for (size_t i = 0; i < N; ++i) {
@@ -104,7 +104,7 @@ public:
         return division;
     }
 
-    friend constexpr Matrix operator*(Matrix const& matrix, T scalar)
+    [[nodiscard]] friend constexpr Matrix operator*(Matrix const& matrix, T scalar)
     {
         Matrix scaled;
         for (size_t i = 0; i < N; ++i) {
@@ -114,7 +114,7 @@ public:
         return scaled;
     }
 
-    friend constexpr Matrix operator*(T scalar, Matrix const& matrix)
+    [[nodiscard]] friend constexpr Matrix operator*(T scalar, Matrix const& matrix)
     {
         return matrix * scalar;
     }

--- a/Userland/Libraries/LibGfx/Matrix.h
+++ b/Userland/Libraries/LibGfx/Matrix.h
@@ -84,6 +84,16 @@ public:
         return product;
     }
 
+    constexpr Matrix operator+(Matrix const& other) const
+    {
+        Matrix sum;
+        for (size_t i = 0; i < N; ++i) {
+            for (size_t j = 0; j < N; ++j)
+                sum.m_elements[i][j] = m_elements[i][j] + other.m_elements[i][j];
+        }
+        return sum;
+    }
+
     constexpr Matrix operator/(T divisor) const
     {
         Matrix division;

--- a/Userland/Libraries/LibGfx/Matrix.h
+++ b/Userland/Libraries/LibGfx/Matrix.h
@@ -104,6 +104,21 @@ public:
         return division;
     }
 
+    friend constexpr Matrix operator*(Matrix const& matrix, T scalar)
+    {
+        Matrix scaled;
+        for (size_t i = 0; i < N; ++i) {
+            for (size_t j = 0; j < N; ++j)
+                scaled.m_elements[i][j] = matrix.m_elements[i][j] * scalar;
+        }
+        return scaled;
+    }
+
+    friend constexpr Matrix operator*(T scalar, Matrix const& matrix)
+    {
+        return matrix * scalar;
+    }
+
     [[nodiscard]] constexpr Matrix adjugate() const
     {
         if constexpr (N == 1)


### PR DESCRIPTION
This PR implements the `hue-rotate()` filter effect as defined in the SVG filter effect specification (minus the SVG part :sweat_smile:)  

| LibWeb                                                                                                          | Chrome                                                                                                          |
|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/11597044/193429546-092133c4-3727-4a1c-84ea-ddab44094ce4.png) | ![image](https://user-images.githubusercontent.com/11597044/193429578-06274483-0023-4fab-98a2-a48fde720c44.png) |