### PR TITLE
Meta: Convert build directory path to be completely absolute

### DIFF
--- a/Meta/CMake/Superbuild/CMakeLists.txt
+++ b/Meta/CMake/Superbuild/CMakeLists.txt
@@ -44,6 +44,11 @@ if(NOT SERENITY_TOOLCHAIN STREQUAL "GNU")
 endif()
 set(SERENITY_BUILD_DIR "${PROJECT_BINARY_DIR}/../${SERENITY_ARCH}${SERENITY_BUILD_DIR_SUFFIX}")
 
+# Pkgconf incorrectly discards a sysroot if it doesn't match the start of the path to the
+# library file. To avoid that, resolve our sysroot into an absolute and canonical path
+# that matches pkgconf's result for resolving the library file.
+get_filename_component(SERENITY_BUILD_DIR "${SERENITY_BUILD_DIR}" ABSOLUTE)
+
 # TODO: Figure out if and how we can skip this when building on Serenity.
 configure_file("${SERENITY_SOURCE_DIR}/Toolchain/CMake/${SERENITY_TOOLCHAIN}Toolchain.txt.in" "${SERENITY_BUILD_DIR}/CMakeToolchain.txt" @ONLY)
 set(SERENITY_TOOLCHAIN_FILE "${SERENITY_BUILD_DIR}/CMakeToolchain.txt" CACHE PATH "Toolchain file to use for cross-compilation")


### PR DESCRIPTION
Differences in path stem causes pkgconf to ignore the sysroot completely.

Meson in particular, others build system might do this too, messes with PKG_CONFIG_LIBDIR causing the stem to differ and pkgconf to believe any pc file it finds is outside the sysroot.

This has been fixed in pkgconf since at least pkgconf 1.9.0 ([this commit](https://github.com/pkgconf/pkgconf/commit/a61193c7236f5b240585c4f8eef6f452f1d9a7ee) to be specific), but distros have been painfully slow in moving forwards