### PR TITLE
Calendar: Fix crash when changing event date

### DIFF
--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -107,8 +107,8 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
         starting_day_combo.set_range(1, days_in_month(year, month + 1));
     };
 
-    starting_year_combo.on_change = [&update_starting_day_range](auto) { update_starting_day_range(); };
-    starting_month_combo.on_change = [&update_starting_day_range](auto, auto) { update_starting_day_range(); };
+    starting_year_combo.on_change = [update_starting_day_range](auto) { update_starting_day_range(); };
+    starting_month_combo.on_change = [update_starting_day_range](auto, auto) { update_starting_day_range(); };
 
     event_title_textbox.set_focus(true);
 }


### PR DESCRIPTION
We were capturing by reference which lead to the variables going out of scope even when used in the lambda. Due to this the `update_starting_day_range` lambda crashes when called.