### PR TITLE
Games: Wrong parent window passed to GUI::MessageBox

### DIFF
--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -112,11 +112,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             Config::write_i32("2048"sv, ""sv, "target_tile"sv, target_tile);
             Config::write_bool("2048"sv, ""sv, "evil_ai"sv, evil_ai);
 
-            GUI::MessageBox::show(window, "New settings have been saved and will be applied on a new game"sv, "Settings Changed Successfully"sv, GUI::MessageBox::Type::Information);
+            GUI::MessageBox::show(size_dialog, "New settings have been saved and will be applied on a new game"sv, "Settings Changed Successfully"sv, GUI::MessageBox::Type::Information);
             return;
         }
 
-        GUI::MessageBox::show(window, "New settings have been set and will be applied on the next game"sv, "Settings Changed Successfully"sv, GUI::MessageBox::Type::Information);
+        GUI::MessageBox::show(size_dialog, "New settings have been set and will be applied on the next game"sv, "Settings Changed Successfully"sv, GUI::MessageBox::Type::Information);
     };
     auto start_a_new_game = [&] {
         // Do not leak game states between games.

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -84,7 +84,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         Config::write_string("Hearts"sv, ""sv, "player_name"sv, player_name);
 
-        GUI::MessageBox::show(window, "Settings have been successfully saved and will take effect in the next game."sv, "Settings Changed Successfully"sv, GUI::MessageBox::Type::Information);
+        GUI::MessageBox::show(settings_dialog, "Settings have been successfully saved and will take effect in the next game."sv, "Settings Changed Successfully"sv, GUI::MessageBox::Type::Information);
     };
 
     auto game_menu = TRY(window->try_add_menu("&Game"));


### PR DESCRIPTION
We were passing the wrong parent window to GUI::MessageBox making it impossible to exit the message window.