### PR TITLE
LibWeb: Fix crash when loading a HTML string that contains an iframe

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -317,10 +317,10 @@ void FrameLoader::load_html(StringView html, const AK::URL& url)
         DOM::Document::Type::HTML,
         "text/html",
         move(navigation_params));
+    browsing_context().set_active_document(document);
 
     auto parser = HTML::HTMLParser::create(document, html, "utf-8");
     parser->run(url);
-    browsing_context().set_active_document(parser->document());
 }
 
 static String s_error_page_url = "file:///res/html/error.html";


### PR DESCRIPTION
The `HTMLIFrameElement` does not create the nested browsing context on insertion if the document does not have browsing context, which is not set unless it's the active document.

Previously, in FrameLoader the document was not set as active until after parsing, which led to iframes without nested browsing contexts, and crashes.

Fixes #14207