### PR TITLE
Meta: Make x86-64 target the default

### DIFF
--- a/Meta/CMake/Superbuild/CMakeLists.txt
+++ b/Meta/CMake/Superbuild/CMakeLists.txt
@@ -32,7 +32,7 @@ get_filename_component(
     SERENITY_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../../.."
     ABSOLUTE CACHE
 )
-set(SERENITY_ARCH "i686" CACHE STRING "Target architecture for SerenityOS.")
+set(SERENITY_ARCH "x86_64" CACHE STRING "Target architecture for SerenityOS.")
 set(SERENITY_TOOLCHAIN "GNU" CACHE STRING "Compiler toolchain to use for Serenity (GNU or Clang)")
 
 # FIXME: It is preferred to keep all the sub-build artifacts below the binary directory for the superbuild

--- a/Meta/analyze-qemu-coverage.sh
+++ b/Meta/analyze-qemu-coverage.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 SCRIPT_DIR="$(dirname "${0}")"
 
 if [ -z "$SERENITY_ARCH" ]; then
-    SERENITY_ARCH="i686"
+    SERENITY_ARCH="x86_64"
 fi
 
 toolchain_suffix=

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -41,7 +41,7 @@ else
     chown -R 0:0 mnt/
 fi
 
-SERENITY_ARCH="${SERENITY_ARCH:-i686}"
+SERENITY_ARCH="${SERENITY_ARCH:-x86_64}"
 LLVM_VERSION="${LLVM_VERSION:-14.0.1}"
 
 if [ "$SERENITY_TOOLCHAIN" = "Clang" ]; then

--- a/Meta/check-symbols.sh
+++ b/Meta/check-symbols.sh
@@ -9,7 +9,7 @@ cd "$script_path/.." || exit 1
 # To eliminate the need for these symbols, avoid doing non-trivial construction of local statics in LibC.
 
 FORBIDDEN_SYMBOLS="__cxa_guard_acquire __cxa_guard_release"
-TARGET="${SERENITY_ARCH:-"i686"}"
+TARGET="${SERENITY_ARCH:-"x86_64"}"
 LIBC_PATH="Build/${TARGET}/Userland/Libraries/LibC/libc.a"
 for forbidden_symbol in $FORBIDDEN_SYMBOLS; do
     # check if there's an undefined reference to the symbol & it is not defined anywhere else in the library

--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$(dirname "${0}")"
 
 if [ -z "$SERENITY_ARCH" ]; then
-    SERENITY_ARCH="i686"
+    SERENITY_ARCH="x86_64"
 fi
 
 # Set this environment variable to override the default debugger.
@@ -50,10 +50,10 @@ fi
 
 
 exec $SERENITY_KERNEL_DEBUGGER \
-    -ex "file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}$toolchain_suffix/Kernel/Prekernel/$prekernel_image" \
+    -ex "file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-x86_64}$toolchain_suffix/Kernel/Prekernel/$prekernel_image" \
     -ex "set confirm off" \
-    -ex "directory $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}$toolchain_suffix/" \
-    -ex "add-symbol-file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}$toolchain_suffix/Kernel/Kernel -o $kernel_base" \
+    -ex "directory $SCRIPT_DIR/../Build/${SERENITY_ARCH:-x86_64}$toolchain_suffix/" \
+    -ex "add-symbol-file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-x86_64}$toolchain_suffix/Kernel/Kernel -o $kernel_base" \
     -ex "set confirm on" \
     -ex "set arch $gdb_arch" \
     -ex "set print frame-arguments none" \

--- a/Meta/export-argsparser-manpages.sh
+++ b/Meta/export-argsparser-manpages.sh
@@ -29,7 +29,7 @@ sudo true
 
 if [ -z "$BUILD_DIR" ]; then
     if [ -z "$SERENITY_ARCH" ]; then
-        export SERENITY_ARCH="i686"
+        export SERENITY_ARCH="x86_64"
         echo "SERENITY_ARCH not given. Assuming ${SERENITY_ARCH}."
     fi
     BUILD_DIR=Build/"$SERENITY_ARCH"

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -91,7 +91,7 @@ fi
 if [ -n "$1" ]; then
     TARGET="$1"; shift
 else
-    TARGET="${SERENITY_ARCH:-"i686"}"
+    TARGET="${SERENITY_ARCH:-"x86_64"}"
 fi
 
 CMAKE_ARGS=()

--- a/Ports/.hosted_defs.sh
+++ b/Ports/.hosted_defs.sh
@@ -2,7 +2,7 @@
 
 SCRIPT="$(dirname "${0}")"
 
-export SERENITY_ARCH="${SERENITY_ARCH:-i686}"
+export SERENITY_ARCH="${SERENITY_ARCH:-x86_64}"
 export SERENITY_TOOLCHAIN="${SERENITY_TOOLCHAIN:-GNU}"
 
 if [ -z "${HOST_CC:=}" ]; then

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -9,7 +9,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo "$DIR"
 
-ARCH=${ARCH:-"i686"}
+ARCH=${ARCH:-"x86_64"}
 TARGET="$ARCH-pc-serenity"
 PREFIX="$DIR/Local/$ARCH"
 BUILD="$DIR/../Build/$ARCH"


### PR DESCRIPTION
This is a preparation to check if we people find noticeable bugs in the x86-64 target, before we can decide if we want to remove the i686 target for good.

This is a result of a discussion I had earlier with @sin-ack, @ADKaster, @timschumi and @BertalanD about this. We can start removing i686 by checking if people are noticing any difference at all. Next step is to remove i686 by removing support in both userland and the Kernel. This is still up to discussion but I am convinced this is the right thing to do.
We still have many problems to fix before i686 can be removed, but these are all solvable things.

The Key points for making the x86-64 the default and later on to remove i686 are:
1. One of the strong arguments to keep i686 is for bare metal usage. However, Not many people needed i686 for their bare metal hardware, so this is a very weak point now. I only remember once that a folk in Discord told me that he had a old Pentium 3 machine that he wanted to test Serenity on, but I don't remember if he did actually test it later on. All other folks at `#bare-metal` channel use a machine that supports x86-64 mode.
2. Many features are limited due to small virtual memory space. For example, KASLR is extremely incapable because of the small range we can use to put the kernel into. Also, TmpFS inodes currently rely on allocating Kernel Regions for holding its data. With #15172, TmpFS inodes should allocate physical pages and only when needed, it will allocate a Region to map these pages. This is a shortcoming of i686 because we are limited in virtual memory space, but in x86-64 this is not a problem at all, because the virtual memory space is huge.
3. Testing on both targets (i686 and x86-64) is hard. We had a breakage on i686 because of GCC being not able to handle 64 bit atomics properly (so I had to send a quick patch [#14922], but then @IdanHo suggested a better solution and it got fixed then). I hardly believe this won't happen again. We could probably find a quick fix if it ever happens again, but is just a burden on everyone being involved in the project.
4. We had i686 (and before of that - legacy protected mode, what is commonly known as i586 support) just because Andreas started to write a 32 bit kernel. Many OSDev projects actually start by writing a 64 bit kernel, ditching 32 bit entirely. I hardly believe that if we had 64 bit kernel from day 1 that adding i686 port would be acceptable.
