### PR TITLE
LibWeb: Add initial implementation of Element.blur()

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -44,6 +44,8 @@ public:
 
     void click();
 
+    void blur();
+
     bool fire_a_synthetic_pointer_event(FlyString const& type, DOM::Element& target, bool not_trusted);
 
     // https://html.spec.whatwg.org/multipage/forms.html#category-label

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -15,6 +15,8 @@ interface HTMLElement : Element {
     // FIXME: Support the optional FocusOptions parameter.
     undefined focus();
 
+    undefined blur();
+
     [LegacyNullToEmptyString] attribute DOMString innerText;
 
     readonly attribute long offsetTop;


### PR DESCRIPTION
This implementation includes a first cut at run the unfocusing steps
from the spec, with many things left unimplemented.

The viewport related spec steps in particular don't seem to map to
LibWeb concepts, which makes figuring out if things are properly focused
much more difficult.

Adding this method makes https://copy.sh/v86 load the page when clicking one of the available OS's to emulate, but the page still chokes on the missing HTMLInputElement `file` type. And fails to update the current origin URL because shared_history_push_replace_state is missing. 

![image](https://user-images.githubusercontent.com/8388494/193476017-09cbcabd-4ec5-4ac3-9fc5-6651f891242f.png)
