### PR TITLE
LibWeb: Fix string whitespace splitting mistake

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
@@ -76,7 +76,7 @@ void DOMTokenList::associated_attribute_changed(StringView value)
     if (value.is_empty())
         return;
 
-    auto split_values = value.split_view(Infra::ASCII_WHITESPACE);
+    auto split_values = value.split_view_if(Infra::is_ascii_whitespace);
     for (auto const& split_value : split_values)
         append_to_ordered_set(m_token_set, split_value);
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -518,7 +518,7 @@ bool Element::is_active() const
 JS::NonnullGCPtr<HTMLCollection> Element::get_elements_by_class_name(FlyString const& class_names)
 {
     Vector<FlyString> list_of_class_names;
-    for (auto& name : class_names.view().split_view(Infra::ASCII_WHITESPACE)) {
+    for (auto& name : class_names.view().split_view_if(Infra::is_ascii_whitespace)) {
         list_of_class_names.append(name);
     }
     return HTMLCollection::create(*this, [list_of_class_names = move(list_of_class_names), quirks_mode = document().in_quirks_mode()](Element const& element) {


### PR DESCRIPTION
`.split_view(Infra::ASCII_WHITESPACE)` tries to split the string view on the string "\t\n\f\r " (not any of the individual characters of that string).

The correct way to split this string views here is `.split_view_if(Infra::is_ascii_whitespace)`, this is a little inconsistent with String, so probably should be addressed.

cc @linusg 

(Noticed this as a few of my test pages broke)