### PR TITLE
Lagom: Work around gcc codegen bug

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -198,6 +198,11 @@ static CodePointRange parse_code_point_range(StringView list)
     return code_point_range;
 }
 
+// gcc-11, gcc-12 have a codegen bug on (at least) intel macOS 10.15, see #15449.
+#if defined(__GNUC__) && !defined(__clang__) && defined(AK_OS_MACOS)
+#    pragma GCC push_options
+#    pragma GCC optimize("O0")
+#endif
 static ErrorOr<void> parse_special_casing(Core::Stream::BufferedFile& file, UnicodeData& unicode_data)
 {
     Array<u8, 1024> buffer;
@@ -644,6 +649,9 @@ static ErrorOr<void> parse_unicode_data(Core::Stream::BufferedFile& file, Unicod
 
     return {};
 }
+#if defined(__GNUC__) && !defined(__clang__) && defined(AK_OS_MACOS)
+#    pragma GCC pop_options
+#endif
 
 static ErrorOr<void> generate_unicode_data_header(Core::Stream::BufferedFile& file, UnicodeData& unicode_data)
 {


### PR DESCRIPTION
Without this, GenerateUnicodeData crashes when run during the build. With this, `serenity.sh run` brings up a running SerenityOS.

Works around #15449.