### PR TITLE
Kernel: Do not require 'proc' promise in getsid() and getpgid()

### DIFF
--- a/Kernel/Syscalls/setpgid.cpp
+++ b/Kernel/Syscalls/setpgid.cpp
@@ -13,7 +13,7 @@ namespace Kernel {
 ErrorOr<FlatPtr> Process::sys$getsid(pid_t pid)
 {
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
-    TRY(require_promise(Pledge::proc));
+    TRY(require_promise(Pledge::stdio));
     if (pid == 0)
         return sid().value();
     auto process = Process::from_pid(pid);
@@ -49,7 +49,7 @@ ErrorOr<FlatPtr> Process::sys$setsid()
 ErrorOr<FlatPtr> Process::sys$getpgid(pid_t pid)
 {
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
-    TRY(require_promise(Pledge::proc));
+    TRY(require_promise(Pledge::stdio));
     if (pid == 0)
         return pgid().value();
     auto process = Process::from_pid(pid);


### PR DESCRIPTION
These only require 'stdio' according to:
https://man.openbsd.org/pledge.2