### PR TITLE
WebContent: Fix `$0` in the browser console, and add some additional goodies

### DIFF
--- a/Userland/Services/WebContent/ConsoleGlobalObject.cpp
+++ b/Userland/Services/WebContent/ConsoleGlobalObject.cpp
@@ -5,8 +5,11 @@
  */
 
 #include "ConsoleGlobalObject.h"
+#include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/Completion.h>
+#include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/NodeList.h>
 #include <LibWeb/HTML/Window.h>
 
 namespace WebContent {
@@ -23,6 +26,8 @@ void ConsoleGlobalObject::initialize(JS::Realm& realm)
 
     define_native_accessor(realm, "$0", $0_getter, nullptr, 0);
     define_native_accessor(realm, "$_", $__getter, nullptr, 0);
+    define_native_function(realm, "$", $_function, 2, JS::default_attributes);
+    define_native_function(realm, "$$", $$_function, 2, JS::default_attributes);
 }
 
 void ConsoleGlobalObject::visit_edges(Visitor& visitor)
@@ -115,6 +120,60 @@ JS_DEFINE_NATIVE_FUNCTION(ConsoleGlobalObject::$__getter)
 {
     auto* console_global_object = TRY(get_console(vm));
     return console_global_object->m_most_recent_result;
+}
+
+JS_DEFINE_NATIVE_FUNCTION(ConsoleGlobalObject::$_function)
+{
+    auto* console_global_object = TRY(get_console(vm));
+    auto& window = *console_global_object->m_window_object;
+
+    auto selector = TRY(vm.argument(0).to_string(vm));
+
+    if (vm.argument_count() > 1) {
+        auto element_value = vm.argument(1);
+        if (!(element_value.is_object() && is<Web::DOM::ParentNode>(element_value.as_object()))) {
+            return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "Node");
+        }
+
+        auto& element = static_cast<Web::DOM::ParentNode&>(element_value.as_object());
+        return TRY(Web::Bindings::throw_dom_exception_if_needed(vm, [&]() {
+            return element.query_selector(selector);
+        }));
+    }
+
+    return TRY(Web::Bindings::throw_dom_exception_if_needed(vm, [&]() {
+        return window.associated_document().query_selector(selector);
+    }));
+}
+
+JS_DEFINE_NATIVE_FUNCTION(ConsoleGlobalObject::$$_function)
+{
+    auto* console_global_object = TRY(get_console(vm));
+    auto& window = *console_global_object->m_window_object;
+
+    auto selector = TRY(vm.argument(0).to_string(vm));
+
+    Web::DOM::ParentNode* element = &window.associated_document();
+
+    if (vm.argument_count() > 1) {
+        auto element_value = vm.argument(1);
+        if (!(element_value.is_object() && is<Web::DOM::ParentNode>(element_value.as_object()))) {
+            return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "Node");
+        }
+
+        element = static_cast<Web::DOM::ParentNode*>(&element_value.as_object());
+    }
+
+    auto node_list = TRY(Web::Bindings::throw_dom_exception_if_needed(vm, [&]() {
+        return element->query_selector_all(selector);
+    }));
+
+    auto* array = TRY(JS::Array::create(*vm.current_realm(), node_list->length()));
+    for (auto i = 0u; i < node_list->length(); ++i) {
+        TRY(array->create_data_property_or_throw(i, node_list->item_value(i)));
+    }
+
+    return array;
 }
 
 }

--- a/Userland/Services/WebContent/ConsoleGlobalObject.cpp
+++ b/Userland/Services/WebContent/ConsoleGlobalObject.cpp
@@ -22,6 +22,7 @@ void ConsoleGlobalObject::initialize(JS::Realm& realm)
     Base::initialize(realm);
 
     define_native_accessor(realm, "$0", $0_getter, nullptr, 0);
+    define_native_accessor(realm, "$_", $__getter, nullptr, 0);
 }
 
 void ConsoleGlobalObject::visit_edges(Visitor& visitor)
@@ -108,6 +109,12 @@ JS_DEFINE_NATIVE_FUNCTION(ConsoleGlobalObject::$0_getter)
         return JS::js_undefined();
 
     return inspected_node;
+}
+
+JS_DEFINE_NATIVE_FUNCTION(ConsoleGlobalObject::$__getter)
+{
+    auto* console_global_object = TRY(get_console(vm));
+    return console_global_object->m_most_recent_result;
 }
 
 }

--- a/Userland/Services/WebContent/ConsoleGlobalObject.h
+++ b/Userland/Services/WebContent/ConsoleGlobalObject.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -36,8 +36,8 @@ public:
 private:
     virtual void visit_edges(Visitor&) override;
 
-    // Because $0 is not a nice C++ function name
-    JS_DECLARE_NATIVE_FUNCTION(inspected_node_getter);
+    // $0, the DOM node currently selected in the inspector
+    JS_DECLARE_NATIVE_FUNCTION($0_getter);
 
     Web::HTML::Window* m_window_object;
 };

--- a/Userland/Services/WebContent/ConsoleGlobalObject.h
+++ b/Userland/Services/WebContent/ConsoleGlobalObject.h
@@ -33,13 +33,18 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const& name) override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;
 
+    void set_most_recent_result(JS::Value result) { m_most_recent_result = move(result); }
+
 private:
     virtual void visit_edges(Visitor&) override;
 
     // $0, the DOM node currently selected in the inspector
     JS_DECLARE_NATIVE_FUNCTION($0_getter);
+    // $_, the value of the most recent expression entered into the console
+    JS_DECLARE_NATIVE_FUNCTION($__getter);
 
     Web::HTML::Window* m_window_object;
+    JS::Value m_most_recent_result { JS::js_undefined() };
 };
 
 }

--- a/Userland/Services/WebContent/ConsoleGlobalObject.h
+++ b/Userland/Services/WebContent/ConsoleGlobalObject.h
@@ -42,6 +42,10 @@ private:
     JS_DECLARE_NATIVE_FUNCTION($0_getter);
     // $_, the value of the most recent expression entered into the console
     JS_DECLARE_NATIVE_FUNCTION($__getter);
+    // $(selector, element), equivalent to `(element || document).querySelector(selector)`
+    JS_DECLARE_NATIVE_FUNCTION($_function);
+    // $$(selector, element), equivalent to `(element || document).querySelectorAll(selector)`
+    JS_DECLARE_NATIVE_FUNCTION($$_function);
 
     Web::HTML::Window* m_window_object;
     JS::Value m_most_recent_result { JS::js_undefined() };

--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -77,8 +77,10 @@ void WebContentConsoleClient::handle_input(String const& js_source)
 
     auto result = script->run();
 
-    if (result.value().has_value())
+    if (result.value().has_value()) {
+        m_console_global_object->set_most_recent_result(result.value().value());
         print_html(JS::MarkupGenerator::html_from_value(*result.value()));
+    }
 }
 
 void WebContentConsoleClient::report_exception(JS::Error const& exception, bool in_promise)

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021, Brandon Scott <xeon.productions@gmail.com>
  * Copyright (c) 2020, Hunter Salyer <thefalsehonesty@gmail.com>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -36,6 +36,7 @@ private:
 
     ConnectionFromClient& m_client;
     WeakPtr<JS::Realm> m_realm;
+    JS::GCPtr<class ConsoleEnvironmentSettingsObject> m_console_settings;
     JS::Handle<ConsoleGlobalObject> m_console_global_object;
 
     void clear_output();


### PR DESCRIPTION
This fixes `$0` by using the special ConsoleGlobalObject as the global object in the browser console. Then, we add a few more goodies based on [what Firefox supports](https://firefox-source-docs.mozilla.org/devtools-user/web_console/helpers/index.html)
- `$_`, the result of the last thing run in the console
- `$(selector, element)`
- `$$(selector, element)`