### PR TITLE
Base: Final step for multi-user support in GUI

### DIFF
--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -39,10 +39,6 @@ Environment=TERM=xterm
 KeepAlive=true
 SystemModes=text
 
-[CrashDaemon]
-KeepAlive=true
-User=anon
-
 [KeyboardPreferenceLoader]
 KeepAlive=false
 User=anon

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -20,10 +20,10 @@ User=window
 StdIO=/dev/tty0
 
 [Clipboard]
-Socket=/tmp/portal/clipboard
+Socket=/tmp/session/%sid/portal/clipboard
 SocketPermissions=600
 Priority=low
-User=anon
+User=window
 
 [Shell@tty0]
 Executable=/bin/Shell

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -1,3 +1,8 @@
+[Clipboard]
+Socket=/tmp/session/%sid/portal/clipboard
+SocketPermissions=600
+Priority=low
+
 [ConfigServer]
 Socket=/tmp/session/%sid/portal/config
 SocketPermissions=600

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -131,3 +131,6 @@ KeepAlive=true
 
 [Terminal]
 WorkingDirectory=/home/anon
+
+[CrashDaemon]
+KeepAlive=true

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -16,7 +16,7 @@ namespace GUI {
 class ConnectionToClipboardServer final
     : public IPC::ConnectionToServer<ClipboardClientEndpoint, ClipboardServerEndpoint>
     , public ClipboardClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToClipboardServer, "/tmp/portal/clipboard"sv)
+    IPC_CLIENT_CONNECTION(ConnectionToClipboardServer, "/tmp/session/%sid/portal/clipboard"sv)
 
 private:
     ConnectionToClipboardServer(NonnullOwnPtr<Core::Stream::LocalSocket> socket)


### PR DESCRIPTION
The clipboard service hasn't been ported to user-based portals with others services as it is needed at `GUI::Application` creation and thus before the first login, as the `LoginServer` needs one.

This problem as been solved thanks to session-based portals, a clipboard portal is now created at boot for the "login" session and another for each "user" session.

With a user-based portal, the "login" portal would have needed to be created for the `root` user, exposing us to security issues. It now, can be owned by the `window` user.

Edit:
It also now launches `CrashDaemon` at session start-up, solving issues with the `CrashReporter`.