### PR TITLE
AK+Everywhere: Add AK_COMPILER_{GCC,CLANG} and use them most places

### DIFF
--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -11,7 +11,7 @@
 template<Unsigned IntType>
 inline constexpr int popcount(IntType value)
 {
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(AK_COMPILER_CLANG) || defined(AK_COMPILER_GCC)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))
         return __builtin_popcount(value);
@@ -39,7 +39,7 @@ inline constexpr int popcount(IntType value)
 template<Unsigned IntType>
 inline constexpr int count_trailing_zeroes(IntType value)
 {
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(AK_COMPILER_CLANG) || defined(AK_COMPILER_GCC)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))
         return __builtin_ctz(value);
@@ -77,7 +77,7 @@ inline constexpr int count_trailing_zeroes_safe(IntType value)
 template<Unsigned IntType>
 inline constexpr int count_leading_zeroes(IntType value)
 {
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(AK_COMPILER_CLANG) || defined(AK_COMPILER_GCC)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))
         return __builtin_clz(value) - (32 - (8 * sizeof(IntType)));
@@ -114,7 +114,7 @@ inline constexpr int count_leading_zeroes_safe(IntType value)
 template<Integral IntType>
 inline constexpr int bit_scan_forward(IntType value)
 {
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(AK_COMPILER_CLANG) || defined(AK_COMPILER_GCC)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))
         return __builtin_ffs(value);

--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -302,7 +302,7 @@ public:
     template<typename U, typename V>
     [[nodiscard]] static constexpr bool addition_would_overflow(U u, V v)
     {
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
         Checked checked;
         checked = u;
         checked += v;
@@ -315,7 +315,7 @@ public:
     template<typename U, typename V>
     [[nodiscard]] static constexpr bool multiplication_would_overflow(U u, V v)
     {
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
         Checked checked;
         checked = u;
         checked *= v;

--- a/AK/CheckedFormatString.h
+++ b/AK/CheckedFormatString.h
@@ -15,7 +15,7 @@
 #ifdef ENABLE_COMPILETIME_FORMAT_CHECK
 // FIXME: Seems like clang doesn't like calling 'consteval' functions inside 'consteval' functions quite the same way as GCC does,
 //        it seems to entirely forget that it accepted that parameters to a 'consteval' function to begin with.
-#    if defined(__clang__) || defined(__CLION_IDE__) || defined(__CLION_IDE_)
+#    if defined(AK_COMPILER_CLANG) || defined(__CLION_IDE__) || defined(__CLION_IDE_)
 #        undef ENABLE_COMPILETIME_FORMAT_CHECK
 #    endif
 #endif

--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -168,7 +168,7 @@ public:
 
     // Note: For some reason, clang does not consider `member` as declared here, and as declared above (`SubstitutedIntrusiveListNode<T, Container> T::*`)
     //       to be of equal types. so for now, just make the members public on clang.
-#ifndef __clang__
+#if !defined(AK_COMPILER_CLANG)
 private:
     template<class T_, typename Container_, SubstitutedIntrusiveListNode<T_, Container_> T_::*member>
     friend class ::AK::Detail::IntrusiveList;

--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -198,7 +198,7 @@ public:
 
     static constexpr bool IsRaw = IsPointer<Container>;
 
-#ifndef __clang__
+#if !defined(AK_COMPILER_CLANG)
 private:
     template<Integral TK, typename TV, typename TContainer, SubstitutedIntrusiveRedBlackTreeNode<TK, TV, TContainer> TV::*member>
     friend class ::AK::Detail::IntrusiveRedBlackTree;

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Nico Weber <thakis@chromium.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -22,6 +23,12 @@
 #    define AK_ARCH_64_BIT
 #else
 #    define AK_ARCH_32_BIT
+#endif
+
+#if defined(__clang__)
+#    define AK_COMPILER_CLANG
+#elif defined(__GNUC__)
+#    define AK_COMPILER_GCC
 #endif
 
 #if defined(__serenity__)
@@ -84,7 +91,7 @@
 #    define VALIDATE_IS_X86() static_assert(false, "Trying to include x86 only header on non x86 platform");
 #endif
 
-#if !defined(__clang__) && !defined(__CLION_IDE_) && !defined(__CLION_IDE__)
+#if !defined(AK_COMPILER_CLANG) && !defined(__CLION_IDE_) && !defined(__CLION_IDE__)
 #    define AK_HAS_CONDITIONALLY_TRIVIAL
 #endif
 
@@ -121,7 +128,7 @@
 #ifdef DISALLOW
 #    undef DISALLOW
 #endif
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    define DISALLOW(message) __attribute__((diagnose_if(1, message, "error")))
 #else
 #    define DISALLOW(message) __attribute__((error(message)))

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+
 namespace AK::Detail {
 
 template<class T, T v>
@@ -530,7 +532,7 @@ template<typename T>
 inline constexpr bool IsDestructible = requires { declval<T>().~T(); };
 
 template<typename T>
-#if defined(__clang__)
+#if defined(AK_COMPILER_CLANG)
 inline constexpr bool IsTriviallyDestructible = __is_trivially_destructible(T);
 #else
 inline constexpr bool IsTriviallyDestructible = __has_trivial_destructor(T) && IsDestructible<T>;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
-#if defined(__clang__) || defined(__CLION_IDE__)
+#include <AK/Platform.h>
+
+#if defined(AK_COMPILER_CLANG) || defined(__CLION_IDE__)
 #    pragma clang diagnostic ignored "-Wunqualified-std-cast-call"
 #endif
 

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -338,7 +338,7 @@ struct CaseInsensitiveStringViewTraits : public Traits<StringView> {
 
 // FIXME: Remove this when clang fully supports consteval (specifically in the context of default parameter initialization).
 // See: https://stackoverflow.com/questions/68789984/immediate-function-as-default-function-argument-initializer-in-clang
-#if defined(__clang__)
+#if defined(AK_COMPILER_CLANG)
 #    define AK_STRING_VIEW_LITERAL_CONSTEVAL constexpr
 #else
 #    define AK_STRING_VIEW_LITERAL_CONSTEVAL consteval

--- a/Kernel/Arch/x86/i386/Atomics.cpp
+++ b/Kernel/Arch/x86/i386/Atomics.cpp
@@ -8,7 +8,7 @@
 
 extern "C" {
 
-#if defined(__GNUC__) && !defined(__clang__) // FIXME: Remove this file once GCC supports 8-byte atomics on i686
+#if defined(AK_COMPILER_GCC) // FIXME: Remove this file once GCC supports 8-byte atomics on i686
 
 u64 kernel__atomic_compare_exchange_8(u64 volatile*, u64*, u64, int, int);
 #    pragma redefine_extname kernel__atomic_compare_exchange_8 __atomic_compare_exchange_8

--- a/Kernel/StdLib.cpp
+++ b/Kernel/StdLib.cpp
@@ -206,7 +206,7 @@ ErrorOr<void> memset_user(void* dest_ptr, int c, size_t n)
     return {};
 }
 
-#if defined(__clang__) && defined(ENABLE_KERNEL_LTO)
+#if defined(AK_COMPILER_CLANG) && defined(ENABLE_KERNEL_LTO)
 // Due to a chicken-and-egg situation, certain linker-defined symbols that are added on-demand (like the GOT)
 // need to be present before LTO bitcode files are compiled. And since we don't link to any native object files,
 // the linker does not know that _GLOBAL_OFFSET_TABLE_ is needed, so it doesn't define it, so linking as a PIE fails.

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -751,7 +751,7 @@ public:
 private:
 };
 
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #pragma clang diagnostic pop
 #endif)~~~");
 }
@@ -781,7 +781,7 @@ void build(StringBuilder& builder, Vector<Endpoint> const& endpoints)
 #include <LibIPC/Message.h>
 #include <LibIPC/Stub.h>
 
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdefaulted-function-deleted"
 #endif)~~~");

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -199,7 +199,7 @@ static CodePointRange parse_code_point_range(StringView list)
 }
 
 // gcc-11, gcc-12 have a codegen bug on (at least) intel macOS 10.15, see #15449.
-#if defined(__GNUC__) && !defined(__clang__) && defined(AK_OS_MACOS)
+#if defined(AK_COMPILER_GCC) && defined(AK_OS_MACOS)
 #    pragma GCC push_options
 #    pragma GCC optimize("O0")
 #endif
@@ -649,7 +649,7 @@ static ErrorOr<void> parse_unicode_data(Core::Stream::BufferedFile& file, Unicod
 
     return {};
 }
-#if defined(__GNUC__) && !defined(__clang__) && defined(AK_OS_MACOS)
+#if defined(AK_COMPILER_GCC) && defined(AK_OS_MACOS)
 #    pragma GCC pop_options
 #endif
 

--- a/Tests/AK/TestRefPtr.cpp
+++ b/Tests/AK/TestRefPtr.cpp
@@ -97,12 +97,12 @@ TEST_CASE(assign_moved_self)
 {
     RefPtr<Object> object = adopt_ref(*new Object);
     EXPECT_EQ(object->ref_count(), 1u);
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wself-move"
 #endif
     object = move(object);
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic pop
 #endif
     EXPECT_EQ(object->ref_count(), 1u);
@@ -113,12 +113,12 @@ TEST_CASE(assign_copy_self)
     RefPtr<Object> object = adopt_ref(*new Object);
     EXPECT_EQ(object->ref_count(), 1u);
 
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wself-assign-overloaded"
 #endif
     object = object;
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic pop
 #endif
 

--- a/Tests/AK/TestWeakPtr.cpp
+++ b/Tests/AK/TestWeakPtr.cpp
@@ -10,7 +10,7 @@
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
 
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wunused-private-field"
 #endif
@@ -24,7 +24,7 @@ private:
     int m_member { 123 };
 };
 
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic pop
 #endif
 

--- a/Tests/Kernel/TestSigAltStack.cpp
+++ b/Tests/Kernel/TestSigAltStack.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#ifdef __clang__
+#include <AK/Platform.h>
+
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang optimize off
 #else
 #    pragma GCC optimize("O0")

--- a/Tests/Kernel/crash.cpp
+++ b/Tests/Kernel/crash.cpp
@@ -23,7 +23,7 @@
 
 using Test::Crash;
 
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang optimize off
 #else
 #    pragma GCC optimize("O0")

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#ifdef __clang__
+#include <AK/Platform.h>
+
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang optimize off
 #else
 #    pragma GCC optimize("O0")

--- a/Tests/LibC/TestMemalign.cpp
+++ b/Tests/LibC/TestMemalign.cpp
@@ -91,13 +91,13 @@ TEST_CASE(aligned_alloc_fuzz)
 
 TEST_CASE(aligned_alloc_not_power2)
 {
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wnon-power-of-two-alignment"
 #endif
     EXPECT_EQ(aligned_alloc(7, 256), nullptr);
     EXPECT_EQ(errno, EINVAL);
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic pop
 #endif
 }

--- a/Userland/Applications/KeyboardMapper/KeyPositions.h
+++ b/Userland/Applications/KeyboardMapper/KeyPositions.h
@@ -21,7 +21,7 @@ struct KeyPosition {
 
 #define KEY_COUNT 63
 
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wc99-designator"
 #endif
@@ -99,6 +99,6 @@ struct KeyPosition keys[KEY_COUNT] = {
     // clang-format on
 };
 
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic pop
 #endif

--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -25,7 +25,7 @@
 #include <syscall.h>
 #include <unistd.h>
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(AK_COMPILER_GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -29,7 +29,7 @@
 #include <syscall.h>
 #include <termios.h>
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(AK_COMPILER_GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(AK_COMPILER_GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
@@ -16,7 +16,7 @@
 
 #include <unistd.h>
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(AK_COMPILER_GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/Libraries/LibC/arch/x86_64/memset.cpp
+++ b/Userland/Libraries/LibC/arch/x86_64/memset.cpp
@@ -41,7 +41,7 @@ namespace {
 }
 }
 
-#if !defined(__clang__) && !defined(_DYNAMIC_LOADER)
+#if !defined(AK_COMPILER_CLANG) && !defined(_DYNAMIC_LOADER)
 [[gnu::ifunc("resolve_memset")]] void* memset(void*, int, size_t);
 #else
 // DynamicLoader can't self-relocate IFUNCs.

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -19,7 +19,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wdouble-promotion"
 #endif
@@ -1148,6 +1148,6 @@ float nearbyintf(float value) NOEXCEPT
 }
 }
 
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic pop
 #endif

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -64,7 +64,7 @@ void DwarfInfo::populate_compilation_units()
         // HACK: Clang generates line programs for embedded resource assembly files, but not compile units.
         // Meaning that for graphical applications, some line info data would be unread, triggering the assertion below.
         // As a fix, we don't create compilation units for line programs that come from resource files.
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
         if (line_program->source_files().size() == 1 && line_program->source_files()[0].name.view().contains("serenity_icon_"sv)) {
             debug_info_stream.seek(unit_offset);
         } else

--- a/Userland/Libraries/LibEDID/EDID.cpp
+++ b/Userland/Libraries/LibEDID/EDID.cpp
@@ -23,7 +23,7 @@ namespace EDID {
 
 // clang doesn't like passing around pointers to members in packed structures,
 // even though we're only using them for arithmetic purposes
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic ignored "-Waddress-of-packed-member"
 #endif
 

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(AK_COMPILER_GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/Libraries/LibGfx/Filters/FastBoxBlurFilter.cpp
+++ b/Userland/Libraries/LibGfx/Filters/FastBoxBlurFilter.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(AK_COMPILER_GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/Libraries/LibGfx/Filters/StackBlurFilter.cpp
+++ b/Userland/Libraries/LibGfx/Filters/StackBlurFilter.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(AK_COMPILER_GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/Libraries/LibGfx/Gamma.h
+++ b/Userland/Libraries/LibGfx/Gamma.h
@@ -42,13 +42,7 @@ using AK::SIMD::f32x4;
 
 // Transform f32x4 from gamma2.2 space to linear space
 // Assumes x is in range [0, 1]
-// FIXME: Remove this hack once clang-11 is available as the default in Github Actions.
-//        This is apparently sometime mid-December. https://github.com/actions/virtual-environments/issues/2130
-#    if !defined(__clang__) || __clang_major__ >= 11
 constexpr f32x4 gamma_to_linear4(f32x4 x)
-#    else
-inline f32x4 gamma_to_linear4(f32x4 x)
-#    endif
 {
     return (0.8f + 0.2f * x) * x * x;
 }

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -36,7 +36,7 @@
 #include <LibGfx/TextLayout.h>
 #include <stdio.h>
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(AK_COMPILER_GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/Libraries/LibGfx/VectorN.h
+++ b/Userland/Libraries/LibGfx/VectorN.h
@@ -21,7 +21,7 @@
 #define STRINGIFY_HELPER(x) #x
 #define STRINGIFY(x) STRINGIFY_HELPER(x)
 
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    define UNROLL_LOOP _Pragma(STRINGIFY(unroll))
 #else
 #    define UNROLL_LOOP _Pragma(STRINGIFY(GCC unroll(LOOP_UNROLL_N)))

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -11,7 +11,7 @@
 #include <LibJS/Runtime/NumberConstructor.h>
 #include <LibJS/Runtime/NumberObject.h>
 
-#ifdef __clang__
+#if defined(AK_COMPILER_CLANG)
 #    define EPSILON_VALUE AK::exp2(-52.)
 #    define MAX_SAFE_INTEGER_VALUE AK::exp2(53.) - 1
 #    define MIN_SAFE_INTEGER_VALUE -(AK::exp2(53.) - 1)

--- a/Userland/Libraries/LibX86/Instruction.cpp
+++ b/Userland/Libraries/LibX86/Instruction.cpp
@@ -8,7 +8,7 @@
 #include <LibX86/Instruction.h>
 #include <LibX86/Interpreter.h>
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(AK_COMPILER_GCC)
 #    pragma GCC optimize("O3")
 #endif
 


### PR DESCRIPTION
As requested here: https://github.com/SerenityOS/serenity/pull/15451#discussion_r985512999