### PR TITLE
Toolchain: serenity.nix: Fix fuse2fs not being installed

### DIFF
--- a/Toolchain/serenity.nix
+++ b/Toolchain/serenity.nix
@@ -25,13 +25,10 @@ stdenv.mkDerivation {
     openssl
     xlibsWrapper
     qemu
-    # e2fsprogs needs some optional parameter to activate fuse2fs with which
-    # the qemu image will be mounted without root access.
-    (e2fsprogs.overrideAttrs (oldAttrs: {
-      buildInputs = oldAttrs.buildInputs ++ [ pkgs.fuse ];
-    }))
+    e2fsprogs
+    fuse2fs
     # glibc
   ];
-  
+
   hardeningDisable = [ "format" "fortify" ];
 }


### PR DESCRIPTION
Nix (nixpkgs) have updated a while back how the e2fsprogs derivation works and now fuse2fs wasnt being installed with it. It is now needed to add a new derivation (package) to the dependency list: "fuse2fs". This fixes the Meta/serenity.sh script not finding the fuse2fs binary for rootless image building :^)