### PR TITLE
LibWeb: Use DOM manipulation task source for <script> src parsing errors

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -265,10 +265,10 @@ void HTMLScriptElement::prepare_script()
     if (has_attribute(HTML::AttributeNames::src)) {
         // 1. Let src be the value of the element's src attribute.
         auto src = attribute(HTML::AttributeNames::src);
-        // 2. If src is the empty string, queue a task to fire an event named error at the element, and return.
+        // 2. If src is the empty string, then queue an element task on the DOM manipulation task source given el to fire an event named error at el, and return.
         if (src.is_empty()) {
             dbgln("HTMLScriptElement: Refusing to run script because the src attribute is empty.");
-            queue_an_element_task(HTML::Task::Source::Unspecified, [this] {
+            queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
                 dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error));
             });
             return;
@@ -278,10 +278,10 @@ void HTMLScriptElement::prepare_script()
 
         // 4. Parse src relative to the element's node document.
         auto url = document().parse_url(src);
-        // 5. If the previous step failed, queue a task to fire an event named error at the element, and return. Otherwise, let url be the resulting URL record.
+        // 5. If the previous step failed, then queue an element task on the DOM manipulation task source given el to fire an event named error at el, and return. Otherwise, let url be the resulting URL record.
         if (!url.is_valid()) {
             dbgln("HTMLScriptElement: Refusing to run script because the src URL '{}' is invalid.", url);
-            queue_an_element_task(HTML::Task::Source::Unspecified, [this] {
+            queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
                 dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error));
             });
             return;


### PR DESCRIPTION
See: https://github.com/whatwg/html/commit/5d34cb8

We were already using queue_an_element_task here.