### PR TITLE
LibGUI: Improve Toolbars and Breadcrumbbars

### DIFF
--- a/Base/usr/share/man/man5/GML-Widget-Toolbar.md
+++ b/Base/usr/share/man/man5/GML-Widget-Toolbar.md
@@ -6,6 +6,10 @@ GML Toolbar Widget
 
 Defines a GUI toolbar widget.
 
+When `collapsible` is set to `true`, the toolbar can be resized below the size of its items.
+Any items that do not fit the current size, will be placed in an overflow menu.
+To keep groups (i.e. Buttons/items separated by Separators) together, and move them to the overflow menu as one, set the `gouped` property.
+
 ## Synopsis
 
 `@GUI::Toolbar`
@@ -15,5 +19,14 @@ Defines a GUI toolbar widget.
 ```gml
 @GUI::Toolbar {
     name: "toolbar"
+    collapsible: true
+    grouped: true
 }
 ```
+
+## Registered Properties
+
+| Property    | Type | Possible values | Description                                                                           |
+|-------------|------|-----------------|---------------------------------------------------------------------------------------|
+| collapsible | bool | true or false   | If items that do not fit should be placed in an overflow menu                         |
+| grouped     | bool | true or false   | If items should be moved to the overflow menu in groups, separated by Separator items |

--- a/Userland/Applications/FileManager/FileManagerWindow.gml
+++ b/Userland/Applications/FileManager/FileManagerWindow.gml
@@ -10,6 +10,7 @@
         @GUI::Toolbar {
             name: "main_toolbar"
             collapsible: true
+            grouped: true
         }
 
         @GUI::Toolbar {

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
@@ -109,7 +109,8 @@ void Breadcrumbbar::append_segment(String text, Gfx::Bitmap const* icon, String 
     auto button_width = min(button_text_width + icon_width + icon_padding + 16, max_button_width);
     auto shrunken_width = icon_width + icon_padding + (icon ? 4 : 16);
 
-    button.set_fixed_size(button_width, 16 + 8);
+    button.set_max_size(button_width, 16 + 8);
+    button.set_min_size(shrunken_width, 16 + 8);
 
     Segment segment { icon, text, data, button_width, shrunken_width, button.make_weak_ptr<GUI::Button>() };
 
@@ -178,11 +179,11 @@ void Breadcrumbbar::relayout()
 
     for (auto& segment : m_segments) {
         if (remaining_width > width() && !segment.button->is_checked()) {
-            segment.button->set_fixed_width(segment.shrunken_width);
+            segment.button->set_preferred_width(segment.shrunken_width);
             remaining_width -= (segment.width - segment.shrunken_width);
             continue;
         }
-        segment.button->set_fixed_width(segment.width);
+        segment.button->set_preferred_width(segment.width);
     }
 }
 

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -27,6 +27,7 @@ Toolbar::Toolbar(Orientation orientation, int button_size)
     , m_button_size(button_size)
 {
     REGISTER_BOOL_PROPERTY("collapsible", is_collapsible, set_collapsible);
+    REGISTER_BOOL_PROPERTY("grouped", is_grouped, set_grouped);
 
     if (m_orientation == Orientation::Horizontal)
         set_fixed_height(button_size);
@@ -200,6 +201,16 @@ ErrorOr<void> Toolbar::update_overflow_menu()
             m_overflow_button->set_visible(false);
         }
         return {};
+    }
+
+    if (m_grouped) {
+        for (size_t i = marginal_index.value(); i > 0; --i) {
+            auto& item = m_items.at(i);
+            if (item.type == Item::Type::Separator)
+                break;
+            item.widget->set_visible(false);
+            marginal_index = i;
+        }
     }
 
     if (!m_overflow_action)

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -181,13 +181,13 @@ ErrorOr<void> Toolbar::update_overflow_menu()
     Optional<size_t> marginal_index {};
     auto position { 0 };
     auto is_horizontal { m_orientation == Gfx::Orientation::Horizontal };
-    auto margin { is_horizontal ? layout()->margins().right() : layout()->margins().bottom() };
+    auto margin { is_horizontal ? layout()->margins().horizontal_total() : layout()->margins().vertical_total() };
     auto toolbar_size { is_horizontal ? width() : height() };
 
     for (size_t i = 0; i < m_items.size() - 1; ++i) {
         auto& item = m_items.at(i);
         auto item_size = is_horizontal ? item.widget->width() : item.widget->height();
-        if (position + item_size + m_button_size + margin > toolbar_size) {
+        if (position + item_size + margin > toolbar_size) {
             marginal_index = i;
             break;
         }
@@ -201,6 +201,18 @@ ErrorOr<void> Toolbar::update_overflow_menu()
             m_overflow_button->set_visible(false);
         }
         return {};
+    }
+
+    if (marginal_index.value() > 0) {
+        for (size_t i = marginal_index.value() - 1; i > 0; --i) {
+            auto& item = m_items.at(i);
+            auto item_size = is_horizontal ? item.widget->width() : item.widget->height();
+            if (position + m_button_size + margin <= toolbar_size)
+                break;
+            item.widget->set_visible(false);
+            position -= item_size;
+            marginal_index = i;
+        }
     }
 
     if (m_grouped) {

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -182,6 +182,7 @@ ErrorOr<void> Toolbar::update_overflow_menu()
     auto position { 0 };
     auto is_horizontal { m_orientation == Gfx::Orientation::Horizontal };
     auto margin { is_horizontal ? layout()->margins().horizontal_total() : layout()->margins().vertical_total() };
+    auto spacing { layout()->spacing() };
     auto toolbar_size { is_horizontal ? width() : height() };
 
     for (size_t i = 0; i < m_items.size() - 1; ++i) {
@@ -192,7 +193,7 @@ ErrorOr<void> Toolbar::update_overflow_menu()
             break;
         }
         item.widget->set_visible(true);
-        position += item_size;
+        position += item_size + spacing;
     }
 
     if (!marginal_index.has_value()) {
@@ -207,10 +208,10 @@ ErrorOr<void> Toolbar::update_overflow_menu()
         for (size_t i = marginal_index.value() - 1; i > 0; --i) {
             auto& item = m_items.at(i);
             auto item_size = is_horizontal ? item.widget->width() : item.widget->height();
-            if (position + m_button_size + margin <= toolbar_size)
+            if (position + m_button_size + spacing + margin <= toolbar_size)
                 break;
             item.widget->set_visible(false);
-            position -= item_size;
+            position -= item_size + spacing;
             marginal_index = i;
         }
     }

--- a/Userland/Libraries/LibGUI/Toolbar.h
+++ b/Userland/Libraries/LibGUI/Toolbar.h
@@ -27,6 +27,8 @@ public:
 
     bool is_collapsible() const { return m_collapsible; }
     void set_collapsible(bool b) { m_collapsible = b; }
+    bool is_grouped() const { return m_grouped; }
+    void set_grouped(bool b) { m_grouped = b; }
 
     virtual Optional<UISize> calculated_preferred_size() const override;
     virtual Optional<UISize> calculated_min_size() const override;
@@ -58,6 +60,7 @@ private:
     const Gfx::Orientation m_orientation;
     int m_button_size { 24 };
     bool m_collapsible { false };
+    bool m_grouped { false };
 };
 
 }


### PR DESCRIPTION
This
a) fixes the bug where breadcrumbbars refused to shrink below their current size. (because they were set to a fixed size, instead of making proper use of min, max, and preferred sizes)
b) adds the possibility for menubar items to be moved to the overflow menu in groups, to avoid disjointed menus (and enables that option for FileManager)