### PR TITLE
Meta: Hide WebView behind ENABLE_LAGOM_LIBWEB CMake option

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -585,11 +585,13 @@ if (BUILD_LAGOM)
     )
 
     # WebView
-    list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/DOMTreeModel.cpp")
-    list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/WebContentClient.cpp")
-    lagom_lib(WebView webview
-        SOURCES ${LIBWEBVIEW_SOURCES}
-        LIBS LibGUI LibWeb)
+    if (ENABLE_LAGOM_LIBWEB)
+        list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/DOMTreeModel.cpp")
+        list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/WebContentClient.cpp")
+        lagom_lib(WebView webview
+            SOURCES ${LIBWEBVIEW_SOURCES}
+            LIBS LibGUI LibWeb)
+    endif()
 
     # x86
     # FIXME: Excluding arm64 is a temporary hack to circumvent a build problem


### PR DESCRIPTION
If ENABLE_LAGOM_LIBWEB is OFF, this will fail to build.