### PR TITLE
AK+LibUnicode: Change ErrorOr to contain a Variant rather than inherit from it

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -210,11 +210,6 @@ static CodePointRange parse_code_point_range(StringView list)
     return code_point_range;
 }
 
-// gcc-11, gcc-12 have a codegen bug, see #15449.
-#if defined(AK_COMPILER_GCC)
-#    pragma GCC push_options
-#    pragma GCC optimize("O0")
-#endif
 static ErrorOr<void> parse_special_casing(Core::Stream::BufferedFile& file, UnicodeData& unicode_data)
 {
     Array<u8, 1024> buffer;
@@ -691,9 +686,6 @@ static ErrorOr<void> parse_unicode_data(Core::Stream::BufferedFile& file, Unicod
 
     return {};
 }
-#if defined(AK_COMPILER_GCC)
-#    pragma GCC pop_options
-#endif
 
 static ErrorOr<void> generate_unicode_data_header(Core::Stream::BufferedFile& file, UnicodeData& unicode_data)
 {


### PR DESCRIPTION
GCC seems to get tripped up over this inheritance when converting from
an `ErrorOr<StringView>` to the partially specialized `ErrorOr<void>`. See
the following snippet:

```c++
NEVER_INLINE ErrorOr<StringView> foo()
{
    auto string = "abc"sv;
    outln("{:p}", string.characters_without_null_termination());
    return string;
}

NEVER_INLINE ErrorOr<void> bar()
{
    auto string = TRY(foo());
    outln("{:p}", string.characters_without_null_termination());

    VERIFY(!string.starts_with('#'));
    return {};
}

int main()
{
    MUST(bar());
}
```

On some machines, bar() will contain a StringView whose pointer has had
its upper bits set to 0:

    0x000000010cafd6f8
    0x000000000cafd6f8

I'm not 100% clear on what's happening in the default-generated Variant
destructor that causes this. Probably worth investigating further.

The error would also be alleviated by making the Variant destructor
virtual, but rather than that, let's make ErrorOr simply contain a
Variant rather than inherit from it.

Fixes #15449.