### PR TITLE
LibCore: Make Core::System::{send,recv}fd work on macOS

### DIFF
--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -563,7 +563,7 @@ ErrorOr<int> LocalSocket::receive_fd(int flags)
 {
 #if defined(AK_OS_SERENITY)
     return Core::System::recvfd(m_helper.fd(), flags);
-#elif defined(AK_OS_LINUX)
+#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS)
     union {
         struct cmsghdr cmsghdr;
         char control[CMSG_SPACE(sizeof(int))];
@@ -608,7 +608,7 @@ ErrorOr<void> LocalSocket::send_fd(int fd)
 {
 #if defined(AK_OS_SERENITY)
     return Core::System::sendfd(m_helper.fd(), fd);
-#elif defined(AK_OS_LINUX)
+#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS)
     char c = 'F';
     struct iovec iov {
         .iov_base = &c,


### PR DESCRIPTION
All the required bits were already there. Also, this would probably work on FreeBSD without modification but I don't currently have a system to test this on.

<img width="1680" alt="Screenshot 2022-10-07 at 18 45 02" src="https://user-images.githubusercontent.com/388571/194606325-e3085024-dd2f-4c3c-9394-4414b2ac5269.png">
