### PR TITLE
Kernel: Don't truncate physical memory space PDE pointers

### DIFF
--- a/Kernel/Arch/aarch64/PageDirectory.h
+++ b/Kernel/Arch/aarch64/PageDirectory.h
@@ -38,7 +38,7 @@ constexpr u32 DEVICE_MEMORY = (1 << 2);
 class PageDirectoryEntry {
 public:
     PhysicalPtr page_table_base() const { return PhysicalAddress::physical_page_base(m_raw); }
-    void set_page_table_base(u32 value)
+    void set_page_table_base(PhysicalPtr value)
     {
         m_raw &= 0xffff000000000fffULL;
         m_raw |= PhysicalAddress::physical_page_base(value);

--- a/Kernel/Arch/x86/PageDirectory.h
+++ b/Kernel/Arch/x86/PageDirectory.h
@@ -16,7 +16,7 @@ namespace Kernel {
 class PageDirectoryEntry {
 public:
     PhysicalPtr page_table_base() const { return PhysicalAddress::physical_page_base(m_raw); }
-    void set_page_table_base(u32 value)
+    void set_page_table_base(PhysicalPtr value)
     {
         m_raw &= 0x8000000000000fffULL;
         m_raw |= PhysicalAddress::physical_page_base(value);


### PR DESCRIPTION
For some odd reason we used to return PhysicalPtr for a page_table_base result, but when setting it we accepted only a 32 bit value, so we truncated valid 64 bit addresses into 32 bit addresses by doing that. With this commit being applied, now PageDirectories can be located beyond the 4 GiB barrier.

This was found by sin-ack, therefore he should be credited with this fix appropriately with Co-authored-by sign.

Co-authored-by: sin-ack <sin-ack@users.noreply.github.com>