### PR TITLE
Shot: Add ability to edit in PixelPaint

### DIFF
--- a/Base/usr/share/man/man1/shot.md
+++ b/Base/usr/share/man/man1/shot.md
@@ -5,7 +5,7 @@ shot
 ## Synopsis
 
 ```sh
-$ shot [--clipboard] [--delay seconds] [--screen index] [--region] [output]
+$ shot [--clipboard] [--delay seconds] [--screen index] [--region] [--edit] [output]
 ```
 
 ## Options:
@@ -14,6 +14,7 @@ $ shot [--clipboard] [--delay seconds] [--screen index] [--region] [output]
 * `-d seconds`, `--delay seconds`: Seconds to wait before taking a screenshot
 * `-s index`, `--screen index`: The index of the screen (default: -1 for all screens)
 * `-r`, `--region`: Select a region to capture
+* `-e`, `--edit`: Open in PixelPaint
 
 ## Arguments:
 


### PR DESCRIPTION
Adding the ability to directly edit a screenshot via PixelPaint. This seemed like a good way to allow editing a screenshot without significantly complicating the shot code.