### PR TITLE
Kernel: Abstract platform-specific current time methods from Scheduler

### DIFF
--- a/Kernel/Arch/CurrentTime.h
+++ b/Kernel/Arch/CurrentTime.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Kernel {
+
+typedef u64 (*fptr)();
+
+fptr optional_current_time();
+
+}

--- a/Kernel/Arch/aarch64/CurrentTime.cpp
+++ b/Kernel/Arch/aarch64/CurrentTime.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Arch/CurrentTime.h>
+
+namespace Kernel {
+
+fptr optional_current_time()
+{
+    return nullptr;
+}
+
+}

--- a/Kernel/Arch/x86/CurrentTime.cpp
+++ b/Kernel/Arch/x86/CurrentTime.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/CurrentTime.h>
+#include <Kernel/Arch/x86/ASM_wrapper.h>
+#include <Kernel/Arch/x86/Processor.h>
+
+namespace Kernel {
+
+static u64 current_time_tsc()
+{
+    return read_tsc();
+}
+
+fptr optional_current_time()
+{
+    VERIFY(Processor::is_initialized()); // sanity check
+    // Figure out a good scheduling time source
+    if (Processor::current().has_feature(CPUFeature::TSC) && Processor::current().has_feature(CPUFeature::CONSTANT_TSC)) {
+        return current_time_tsc;
+    }
+    return nullptr;
+}
+
+}

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -928,7 +928,7 @@ void Processor::enter_trap(TrapFrame& trap, bool raise_irq)
         // The cs register of this trap tells us where we will return back to
         auto new_previous_mode = ((trap.regs->cs & 3) != 0) ? Thread::PreviousMode::UserMode : Thread::PreviousMode::KernelMode;
         if (current_thread->set_previous_mode(new_previous_mode) && trap.prev_irq_level == 0) {
-            current_thread->update_time_scheduled(Scheduler::current_time(), new_previous_mode == Thread::PreviousMode::KernelMode, false);
+            current_thread->update_time_scheduled(TimeManagement::scheduler_current_time(), new_previous_mode == Thread::PreviousMode::KernelMode, false);
         }
     } else {
         trap.next_trap = nullptr;
@@ -975,7 +975,7 @@ void Processor::exit_trap(TrapFrame& trap)
         }
 
         if (current_thread->set_previous_mode(new_previous_mode))
-            current_thread->update_time_scheduled(Scheduler::current_time(), true, false);
+            current_thread->update_time_scheduled(TimeManagement::scheduler_current_time(), true, false);
     }
 
     VERIFY_INTERRUPTS_DISABLED();

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -327,6 +327,8 @@ if ("${SERENITY_ARCH}" STREQUAL "i686" OR "${SERENITY_ARCH}" STREQUAL "x86_64")
         Arch/x86/common/SmapDisabler.cpp
         Arch/x86/common/Shutdown.cpp
 
+        Arch/x86/CurrentTime.cpp
+
         Arch/x86/Hypervisor/BochsDisplayConnector.cpp
         Arch/x86/Hypervisor/VMWareBackdoor.cpp
 
@@ -464,6 +466,7 @@ else()
         Arch/aarch64/boot.S
         Arch/aarch64/BootPPMParser.cpp
         Arch/aarch64/CrashHandler.cpp
+        Arch/aarch64/CurrentTime.cpp
         Arch/aarch64/Dummy.cpp
         Arch/aarch64/Exceptions.cpp
         Arch/aarch64/init.cpp

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -55,7 +55,6 @@ public:
     static bool is_initialized();
     static TotalTimeScheduled get_total_time_scheduled();
     static void add_time_scheduled(u64, bool);
-    static u64 (*current_time)();
 };
 
 }

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -37,6 +37,8 @@ public:
     static bool is_initialized();
     static TimeManagement& the();
 
+    static u64 scheduler_current_time();
+
     static ErrorOr<void> validate_clock_id(clockid_t);
     Time current_time(clockid_t) const;
     Time monotonic_time(TimePrecision = TimePrecision::Coarse) const;


### PR DESCRIPTION
This change ensures that the scheduler doesn't depend on a platform specific or arch-specific code when it initializes itself, but rather we ensure that in compile-time we will generate the appropriate code to find the correct arch-specific current time methods.