### PR TITLE
LibGUI: Delete from current position to end of line in VimEditingEngine

### DIFF
--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -963,6 +963,11 @@ bool VimEditingEngine::on_key_in_normal_mode(KeyEvent const& event)
                 move_to_logical_line_end();
                 switch_to_insert_mode();
                 return true;
+            case (KeyCode::Key_D):
+                m_editor->delete_text_range({ m_editor->cursor(), { m_editor->cursor().line(), m_editor->current_line().length() } });
+                if (m_editor->cursor().column() != 0)
+                    move_one_left();
+                break;
             case (KeyCode::Key_I):
                 move_to_logical_line_beginning();
                 switch_to_insert_mode();


### PR DESCRIPTION
When in normal mode pressing Shift+D will delete from the current cursor position to the end of the line. Leaving the cursor on the character before where the cursor was when the deletion took place.