### PR TITLE
Kernel: Update the ".." inode for directories after a rename

### DIFF
--- a/Kernel/FileSystem/DevPtsFS.cpp
+++ b/Kernel/FileSystem/DevPtsFS.cpp
@@ -158,6 +158,11 @@ ErrorOr<void> DevPtsFSInode::remove_child(StringView)
     return EROFS;
 }
 
+ErrorOr<void> DevPtsFSInode::replace_child(StringView, Inode&)
+{
+    return EROFS;
+}
+
 ErrorOr<void> DevPtsFSInode::chmod(mode_t)
 {
     return EROFS;

--- a/Kernel/FileSystem/DevPtsFS.h
+++ b/Kernel/FileSystem/DevPtsFS.h
@@ -56,6 +56,7 @@ private:
     virtual ErrorOr<NonnullLockRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
+    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
 

--- a/Kernel/FileSystem/DevTmpFS.cpp
+++ b/Kernel/FileSystem/DevTmpFS.cpp
@@ -135,6 +135,11 @@ ErrorOr<void> DevTmpFSInode::remove_child(StringView)
     VERIFY_NOT_REACHED();
 }
 
+ErrorOr<void> DevTmpFSInode::replace_child(StringView, Inode&)
+{
+    VERIFY_NOT_REACHED();
+}
+
 ErrorOr<void> DevTmpFSInode::chmod(mode_t mode)
 {
     MutexLocker locker(m_inode_lock);
@@ -234,6 +239,11 @@ ErrorOr<void> DevTmpFSDirectoryInode::remove_child(StringView name)
         }
     }
     return Error::from_errno(ENOENT);
+}
+
+ErrorOr<void> DevTmpFSDirectoryInode::replace_child(StringView, Inode&)
+{
+    VERIFY_NOT_REACHED();
 }
 
 ErrorOr<NonnullLockRefPtr<Inode>> DevTmpFSDirectoryInode::create_child(StringView name, mode_t mode, dev_t device_mode, UserID, GroupID)

--- a/Kernel/FileSystem/DevTmpFS.h
+++ b/Kernel/FileSystem/DevTmpFS.h
@@ -57,6 +57,7 @@ protected:
     virtual ErrorOr<NonnullLockRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
+    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
     virtual ErrorOr<void> truncate(u64) override;
@@ -137,6 +138,7 @@ protected:
 
     virtual ErrorOr<NonnullLockRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
+    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> traverse_as_directory(Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)>) const override;
     virtual ErrorOr<NonnullLockRefPtr<Inode>> lookup(StringView name) override;
     DevTmpFSDirectoryInode(DevTmpFS&, NonnullOwnPtr<KString> name);

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -44,6 +44,7 @@ private:
     virtual ErrorOr<NonnullLockRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode& child, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
+    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> update_timestamps(Optional<time_t> atime, Optional<time_t> ctime, Optional<time_t> mtime) override;
     virtual ErrorOr<void> increment_link_count() override;
     virtual ErrorOr<void> decrement_link_count() override;

--- a/Kernel/FileSystem/ISO9660FileSystem.cpp
+++ b/Kernel/FileSystem/ISO9660FileSystem.cpp
@@ -513,6 +513,11 @@ ErrorOr<void> ISO9660Inode::remove_child(StringView)
     return EROFS;
 }
 
+ErrorOr<void> ISO9660Inode::replace_child(StringView, Inode&)
+{
+    return EROFS;
+}
+
 ErrorOr<void> ISO9660Inode::chmod(mode_t)
 {
     return EROFS;

--- a/Kernel/FileSystem/ISO9660FileSystem.h
+++ b/Kernel/FileSystem/ISO9660FileSystem.h
@@ -354,6 +354,7 @@ public:
     virtual ErrorOr<NonnullLockRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
+    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
     virtual ErrorOr<void> truncate(u64) override;

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -66,6 +66,9 @@ public:
     virtual ErrorOr<NonnullLockRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) = 0;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) = 0;
     virtual ErrorOr<void> remove_child(StringView name) = 0;
+    /// Replace child atomically, incrementing the link count of the replacement
+    /// inode and decrementing the older inode's.
+    virtual ErrorOr<void> replace_child(StringView name, Inode&) = 0;
     virtual ErrorOr<void> chmod(mode_t) = 0;
     virtual ErrorOr<void> chown(UserID, GroupID) = 0;
     virtual ErrorOr<void> truncate(u64) { return {}; }

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -920,6 +920,12 @@ ErrorOr<void> Plan9FSInode::remove_child(StringView)
     return ENOTIMPL;
 }
 
+ErrorOr<void> Plan9FSInode::replace_child(StringView, Inode&)
+{
+    // TODO
+    return ENOTIMPL;
+}
+
 ErrorOr<void> Plan9FSInode::chmod(mode_t)
 {
     // TODO

--- a/Kernel/FileSystem/Plan9FileSystem.h
+++ b/Kernel/FileSystem/Plan9FileSystem.h
@@ -161,6 +161,7 @@ public:
     virtual ErrorOr<NonnullLockRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
+    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
     virtual ErrorOr<void> truncate(u64) override;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -83,6 +83,11 @@ ErrorOr<void> ProcFSInode::remove_child(StringView)
     return EROFS;
 }
 
+ErrorOr<void> ProcFSInode::replace_child(StringView, Inode&)
+{
+    return EROFS;
+}
+
 ErrorOr<void> ProcFSInode::chmod(mode_t)
 {
     return EPERM;

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -60,6 +60,7 @@ protected:
     virtual ErrorOr<NonnullLockRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override final;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override final;
     virtual ErrorOr<void> remove_child(StringView name) override final;
+    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override final;
     virtual ErrorOr<void> chmod(mode_t) override final;
     virtual ErrorOr<void> chown(UserID, GroupID) override final;
 };

--- a/Kernel/FileSystem/SysFS.cpp
+++ b/Kernel/FileSystem/SysFS.cpp
@@ -111,6 +111,11 @@ ErrorOr<void> SysFSInode::remove_child(StringView)
     return EROFS;
 }
 
+ErrorOr<void> SysFSInode::replace_child(StringView, Inode&)
+{
+    return EROFS;
+}
+
 ErrorOr<void> SysFSInode::chmod(mode_t)
 {
     return EPERM;

--- a/Kernel/FileSystem/SysFS.h
+++ b/Kernel/FileSystem/SysFS.h
@@ -51,6 +51,7 @@ protected:
     virtual ErrorOr<NonnullLockRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
+    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
     virtual ErrorOr<void> truncate(u64) override;

--- a/Kernel/FileSystem/TmpFS.h
+++ b/Kernel/FileSystem/TmpFS.h
@@ -54,6 +54,7 @@ public:
     virtual ErrorOr<NonnullLockRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
+    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
     virtual ErrorOr<void> truncate(u64) override;

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -558,6 +558,14 @@ ErrorOr<void> VirtualFileSystem::rename(Credentials const& credentials, StringVi
 
     TRY(new_parent_inode.add_child(old_inode, new_basename, old_inode.mode()));
     TRY(old_parent_inode.remove_child(old_basename));
+
+    // If the inode that we moved is a directory and we changed parent
+    // directories, then we also have to make .. point to the new parent inode,
+    // because .. is its own inode.
+    if (old_inode.is_directory() && old_parent_inode.index() != new_parent_inode.index()) {
+        TRY(old_inode.replace_child(".."sv, new_parent_inode));
+    }
+
     return {};
 }
 


### PR DESCRIPTION
Because the ".." entry in a directory is a separate inode, if a directory is renamed to a new location, then we should update this entry the point to the new parent directory as well.

Contributed live from SYCL 2022. :^)