### PR TITLE
LibWeb: Fix bug in column spans greater than implicit grid

### DIFF
--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -30,8 +30,8 @@
   <div class="grid-item">4</div>
 </div>
 
+<p>Start of crash tests</p>
 <!-- Check for a bug where a github page was crashing due to the following code. -->
-<p>If you can see this message then the test passed.</p>
 <div 
   class="grid-container"
   style="
@@ -41,7 +41,6 @@
 </div>
 
 <!-- Spans causing positions outside the inherit grid. (span 2 with an end position of 1 causes the start to be -1) -->
-<p>If you can see this message then the test passed.</p>
 <div class="grid-container">
   <div class="grid-item" style="grid-row: span 2 / 1; grid-column: span 2 / 1;">1</div>
   <div class="grid-item" style="grid-row: span 2 / 1;">2</div>
@@ -50,7 +49,6 @@
 </div>
 
 <!-- 0 positioned grid items and similar inputs -->
-<p>If you can see this message then the test passed.</p>
 <div class="grid-container">
   <div class="grid-item" style="grid-row-end: 0;">2</div>
   <div class="grid-item" style="grid-row: 0 / 0;">3</div>
@@ -59,6 +57,25 @@
   <div class="grid-item" style="grid-row-end: 1;">1</div>
   <div class="grid-item" style="grid-column-end: 1;">6</div>
 </div>
+
+<!-- Grid-column-span larger than implicit grid for row-positioned items -->
+<div class="grid-container">
+  <div class="grid-item" style="grid-row: 1 / -1; grid-column: span 4;">1</div>
+</div>
+<!-- Grid-column-span larger than implicit grid for non-positioned items -->
+<div class="grid-container">
+  <div class="grid-item" style="grid-column: span 4;">1</div>
+</div>
+<!-- Grid-row-span larger than implicit grid for column-positioned items -->
+<div class="grid-container">
+  <div class="grid-item" style="grid-column: 1 / -1; grid-row: span 4;">1</div>
+</div>
+<!-- Grid-row-span larger than implicit grid for non-positioned items -->
+<div class="grid-container">
+  <div class="grid-item" style="grid-row: span 4;">1</div>
+</div>
+
+<p>End of crash tests</p>
 
 <!-- Different column sizes -->
 <p>Should render a 2x2 grid with columns 50px and 50%</p>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -267,6 +267,12 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
 
         int column_start = 0;
         auto column_span = child_box.computed_values().grid_column_start().is_span() ? child_box.computed_values().grid_column_start().raw_value() : 1;
+        // https://drafts.csswg.org/css-grid/#auto-placement-algo
+        // 8.5. Grid Item Placement Algorithm
+        // 3.3. If the largest column span among all the items without a definite column position is larger
+        // than the width of the implicit grid, add columns to the end of the implicit grid to accommodate
+        // that column span.
+        occupation_grid.maybe_add_column(column_span);
         bool found_available_column = false;
         for (int column_index = column_start; column_index < occupation_grid.column_count(); column_index++) {
             if (!occupation_grid.is_occupied(column_index, row_start)) {
@@ -298,11 +304,6 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
     // NOTE: "Explicitly positioned items" and "items positioned in the previous step" done in step 1
     // and 2, respectively. Adding columns for "items not yet positioned but with a definite column"
     // will be done in step 4.
-
-    // 3.3. If the largest column span among all the items without a definite column position is larger
-    // than the width of the implicit grid, add columns to the end of the implicit grid to accommodate
-    // that column span.
-    // NOTE: Done in step 1, 2, and will be done in step 4.
 
     // 4. Position the remaining grid items.
     // For each grid item that hasn't been positioned by the previous steps, in order-modified document
@@ -431,6 +432,12 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
             // algorithm.
             auto column_start = 0;
             auto column_span = child_box.computed_values().grid_column_start().is_span() ? child_box.computed_values().grid_column_start().raw_value() : 1;
+            // https://drafts.csswg.org/css-grid/#auto-placement-algo
+            // 8.5. Grid Item Placement Algorithm
+            // 3.3. If the largest column span among all the items without a definite column position is larger
+            // than the width of the implicit grid, add columns to the end of the implicit grid to accommodate
+            // that column span.
+            occupation_grid.maybe_add_column(column_span);
             auto row_start = 0;
             auto row_span = child_box.computed_values().grid_row_start().is_span() ? child_box.computed_values().grid_row_start().raw_value() : 1;
             auto found_unoccupied_area = false;

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1145,8 +1145,9 @@ void OccupationGrid::maybe_add_column(int needed_number_of_columns)
 {
     if (needed_number_of_columns <= column_count())
         return;
+    auto column_count_before_modification = column_count();
     for (auto& occupation_grid_row : m_occupation_grid)
-        for (int idx = 0; idx < (needed_number_of_columns + 1) - column_count(); idx++)
+        for (int idx = 0; idx < needed_number_of_columns - column_count_before_modification; idx++)
             occupation_grid_row.append(false);
 }
 


### PR DESCRIPTION
Fixes bug when a column-span is indicated that is greater than the size of the grid. This can happen for example when a column-span is a certain number, say 2, and the grid has no specified column-count (so it defaults to 1).

Now, it follows spec and adds the necessary columns.