### PR TITLE
LibWeb: Fix ::-webkit-progress-bar/value pseudo elements

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -25,9 +25,8 @@ HTMLProgressElement::~HTMLProgressElement() = default;
 
 RefPtr<Layout::Node> HTMLProgressElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
 {
-    if (style->appearance().value_or(CSS::Appearance::Auto) == CSS::Appearance::None) {
-        return adopt_ref(*new Layout::BlockContainer(document(), this, move(style)));
-    }
+    if (style->appearance().value_or(CSS::Appearance::Auto) == CSS::Appearance::None)
+        return HTMLElement::create_layout_node(style);
     return adopt_ref(*new Layout::Progress(document(), *this, move(style)));
 }
 


### PR DESCRIPTION
Recent changes to layout and display broke these pseudo elements leading to crashes on a few websites such as https://rpcs3.net/.