### PR TITLE
CatDog: Make it always on top

### DIFF
--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -50,6 +50,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(context_menu->try_add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); })));
 
     window->show();
+    window->set_always_on_top();
     catdog_widget->start_timer(250, Core::TimerShouldFireWhenNotVisible::Yes);
     catdog_widget->start_the_timer(); // timer for "mouse sleep detection"
 
@@ -74,6 +75,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         catdog_widget->set_roaming(false);
         advice_window->move_to(window->x() - advice_window->width() / 2, window->y() - advice_window->height());
         advice_window->show();
+        advice_window->set_always_on_top();
     };
     advice_timer->start();
 

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -1281,4 +1281,11 @@ void Window::flush_pending_paints_immediately()
     handle_multi_paint_event(paint_event);
 }
 
+void Window::set_always_on_top(bool always_on_top)
+{
+    if (!m_window_id)
+        return;
+    ConnectionToWindowServer::the().set_always_on_top(m_window_id, always_on_top);
+}
+
 }

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -231,6 +231,8 @@ public:
     void set_blocks_emoji_input(bool b) { m_blocks_emoji_input = b; }
     bool blocks_emoji_input() const { return m_blocks_emoji_input; }
 
+    void set_always_on_top(bool always_on_top = true);
+
 protected:
     Window(Core::Object* parent = nullptr);
     virtual void wm_event(WMEvent&);

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -1337,6 +1337,15 @@ void ConnectionFromClient::remove_window_stealing(i32 window_id)
     window->remove_all_stealing();
 }
 
+void ConnectionFromClient::set_always_on_top(i32 window_id, bool always_on_top)
+{
+    auto window = window_from_id(window_id);
+    if (!window)
+        did_misbehave("SetAlwaysOnTop: Bad window ID");
+
+    window->set_always_on_top(always_on_top);
+}
+
 void ConnectionFromClient::notify_about_theme_change()
 {
     // Recalculate minimum size for each window, using the new theme metrics.

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -185,6 +185,7 @@ private:
     virtual void add_window_stealing_for_client(i32, i32) override;
     virtual void remove_window_stealing_for_client(i32, i32) override;
     virtual void remove_window_stealing(i32) override;
+    virtual void set_always_on_top(i32, bool) override;
     virtual Messages::WindowServer::GetColorUnderCursorResponse get_color_under_cursor() override;
 
     Window* window_from_id(i32 window_id);

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -182,4 +182,6 @@ endpoint WindowServer
     add_window_stealing_for_client(i32 client_id, i32 window_id) => ()
     remove_window_stealing_for_client(i32 client_id, i32 window_id) => ()
     remove_window_stealing(i32 window_id) => ()
+
+    set_always_on_top(i32 window_id, bool always_on_top) => ()
 }


### PR DESCRIPTION
I was annoyed to see that CatDog gets hidden by other windows when switching between them.
I added a Window::set_always_on_top() method which asks WindowManager through the IPC system to call the method of the same name (since that logic already existed, but wasn't exposed to LibGUI).
Result:
https://user-images.githubusercontent.com/40673815/194747870-04f9b7aa-79a9-4f2f-9af5-80626ad21c53.mp4

