### PR TITLE
PixelPaint: Improvements for the brush-tool

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -17,6 +17,7 @@
 #include "ResizeImageDialog.h"
 #include <Applications/PixelPaint/PixelPaintWindowGML.h>
 #include <LibConfig/Client.h>
+#include <LibCore/Debounce.h>
 #include <LibCore/File.h>
 #include <LibCore/MimeData.h>
 #include <LibFileSystemAccessClient/Client.h>
@@ -1091,9 +1092,11 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
         m_show_rulers_action->set_checked(show_rulers);
     };
 
-    image_editor.on_scale_change = [this](float scale) {
+    image_editor.on_scale_change = Core::debounce([this](float scale) {
         m_zoom_combobox->set_text(String::formatted("{}%", roundf(scale * 100)));
-    };
+        current_image_editor()->update_tool_cursor();
+    },
+        100);
 
     if (image->layer_count())
         image_editor.set_active_layer(&image->layer(0));

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
@@ -46,10 +46,7 @@ void BrushTool::on_mousedown(Layer* layer, MouseEvent& event)
         return;
     }
 
-    int const first_draw_opacity = 10;
-
-    for (int i = 0; i < first_draw_opacity; ++i)
-        draw_point(layer->get_scratch_edited_bitmap(), color_for(layer_event), layer_event.position());
+    draw_point(layer->get_scratch_edited_bitmap(), color_for(layer_event), layer_event.position());
 
     layer->did_modify_bitmap(Gfx::IntRect::centered_on(layer_event.position(), Gfx::IntSize { m_size * 2, m_size * 2 }));
     m_last_position = layer_event.position();
@@ -89,6 +86,7 @@ Color BrushTool::color_for(GUI::MouseEvent const& event)
 
 void BrushTool::draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point)
 {
+    constexpr auto flow_scale = 10;
     for (int y = point.y() - size(); y < point.y() + size(); y++) {
         for (int x = point.x() - size(); x < point.x() + size(); x++) {
             auto distance = point.distance_from({ x, y });
@@ -97,9 +95,9 @@ void BrushTool::draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::In
             if (distance >= size())
                 continue;
 
-            auto falloff = get_falloff(distance);
+            auto falloff = get_falloff(distance) * flow_scale;
             auto pixel_color = color;
-            pixel_color.set_alpha(falloff * 255);
+            pixel_color.set_alpha(AK::min(falloff * 255, 255));
             bitmap.set_pixel(x, y, bitmap.get_pixel(x, y).blend(pixel_color));
         }
     }

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.h
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.h
@@ -2,12 +2,14 @@
  * Copyright (c) 2020, Ben Jilks <benjyjilks@gmail.com>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022, Torsten Engelmann <engelTorsten@gmx.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include "../ImageEditor.h"
 #include "Tool.h"
 
 namespace PixelPaint {
@@ -21,9 +23,14 @@ public:
     virtual void on_mousemove(Layer*, MouseEvent&) override;
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override
+    {
+        if (m_editor && m_editor->scale() != m_scale_last_created_cursor)
+            refresh_editor_cursor();
+        return m_cursor;
+    }
 
-    void set_size(int size) { m_size = size; }
+    void set_size(int size);
     int size() const { return m_size; }
 
     void set_hardness(int hardness) { m_hardness = hardness; }
@@ -41,6 +48,9 @@ protected:
     virtual Color color_for(GUI::MouseEvent const& event);
     virtual void draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point);
     virtual void draw_line(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& start, Gfx::IntPoint const& end);
+    virtual NonnullRefPtr<Gfx::Bitmap> build_cursor();
+    void refresh_editor_cursor();
+    float m_scale_last_created_cursor = 0;
 
 private:
     RefPtr<GUI::Widget> m_properties_widget;
@@ -49,6 +59,7 @@ private:
     bool m_was_drawing { false };
     bool m_has_clicked { false };
     Gfx::IntPoint m_last_position;
+    NonnullRefPtr<Gfx::Bitmap> m_cursor = build_cursor();
 };
 
 }

--- a/Userland/Applications/PixelPaint/Tools/EraseTool.h
+++ b/Userland/Applications/PixelPaint/Tools/EraseTool.h
@@ -25,6 +25,7 @@ public:
 protected:
     virtual Color color_for(GUI::MouseEvent const& event) override;
     virtual void draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point) override;
+    virtual NonnullRefPtr<Gfx::Bitmap> build_cursor() override;
 
 private:
     virtual StringView tool_name() const override { return "Erase Tool"sv; }
@@ -35,7 +36,7 @@ private:
         Pencil,
         Brush,
     };
-    DrawMode m_draw_mode { DrawMode::Brush };
+    DrawMode m_draw_mode { DrawMode::Pencil };
     bool m_use_secondary_color { false };
 };
 

--- a/Userland/Applications/PixelPaint/Tools/PenTool.h
+++ b/Userland/Applications/PixelPaint/Tools/PenTool.h
@@ -18,7 +18,7 @@ class PenTool final : public BrushTool {
 public:
     PenTool();
     virtual ~PenTool() override = default;
-
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
     virtual GUI::Widget* get_properties_widget() override;
 
 protected:


### PR DESCRIPTION
This patch introduces a new cursor for the brush and eraser tool to indicate the area where changes will be applied. Furthermore the gradient is smoother espacialy for a low hardness of the brush.

![grafik](https://user-images.githubusercontent.com/103676658/194773403-0d9253fb-d625-4964-856d-fe6580c626a0.png)
