### PR TITLE
LibVideo: Initialize VP9 BitStream's reservoir field

### DIFF
--- a/Userland/Libraries/LibVideo/VP9/BitStream.h
+++ b/Userland/Libraries/LibVideo/VP9/BitStream.h
@@ -47,7 +47,7 @@ private:
 
     u8 const* m_data_ptr { nullptr };
     u8 const* m_end_ptr { nullptr };
-    u64 m_reservoir;
+    u64 m_reservoir { 0 };
     u8 m_reservoir_bits_remaining { 0 };
     size_t m_bits_read { 0 };
 


### PR DESCRIPTION
Leaving it uninitialized could lead to undefined behavior.