### PR TITLE
LibWeb: Respect width, height and frameborder attributes of <iframe> + some default attributes for other elements

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -623,6 +623,49 @@ video {
     object-fit: contain;
 }
 
+/* 15.4.3 Attributes for embedded content and images
+ * https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images
+ */
+
+iframe[frameborder='0'], iframe[frameborder=no i] { border: none; }
+
+embed[align=left i], iframe[align=left i], img[align=left i],
+input[type=image i][align=left i], object[align=left i] {
+    float: left;
+}
+
+embed[align=right i], iframe[align=right i], img[align=right i],
+input[type=image i][align=right i], object[align=right i] {
+    float: right;
+}
+
+embed[align=top i], iframe[align=top i], img[align=top i],
+input[type=image i][align=top i], object[align=top i] {
+    vertical-align: top;
+}
+
+embed[align=baseline i], iframe[align=baseline i], img[align=baseline i],
+input[type=image i][align=baseline i], object[align=baseline i] {
+    vertical-align: baseline;
+}
+
+embed[align=texttop i], iframe[align=texttop i], img[align=texttop i],
+input[type=image i][align=texttop i], object[align=texttop i] {
+    vertical-align: text-top;
+}
+
+embed[align=absmiddle i], iframe[align=absmiddle i], img[align=absmiddle i],
+input[type=image i][align=absmiddle i], object[align=absmiddle i],
+embed[align=abscenter i], iframe[align=abscenter i], img[align=abscenter i],
+input[type=image i][align=abscenter i], object[align=abscenter i] {
+    vertical-align: middle;
+}
+
+embed[align=bottom i], iframe[align=bottom i], img[align=bottom i],
+input[type=image i][align=bottom i], object[align=bottom i] {
+    vertical-align: bottom;
+}
+
 /* 15.5.4 The details and summary elements
  * https://html.spec.whatwg.org/multipage/rendering.html#the-details-and-summary-elements
  */

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/HTMLIFrameElement.h>
 #include <LibWeb/HTML/Origin.h>
+#include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/Layout/FrameBox.h>
 
 namespace Web::HTML {
@@ -124,6 +125,20 @@ void HTMLIFrameElement::load_src(String const& value)
 
     dbgln("Loading iframe document from {}", value);
     m_nested_browsing_context->loader().load(url, FrameLoader::Type::IFrame);
+}
+
+// https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images
+void HTMLIFrameElement::apply_presentational_hints(CSS::StyleProperties& style) const
+{
+    for_each_attribute([&](auto& name, auto& value) {
+        if (name == HTML::AttributeNames::width) {
+            if (auto parsed_value = parse_dimension_value(value))
+                style.set_property(CSS::PropertyID::Width, parsed_value.release_nonnull());
+        } else if (name == HTML::AttributeNames::height) {
+            if (auto parsed_value = parse_dimension_value(value))
+                style.set_property(CSS::PropertyID::Height, parsed_value.release_nonnull());
+        }
+    });
 }
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#iframe-load-event-steps

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -23,6 +23,8 @@ public:
 
     void set_current_navigation_was_lazy_loaded(bool value) { m_current_navigation_was_lazy_loaded = value; }
 
+    virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
+
 private:
     HTMLIFrameElement(DOM::Document&, DOM::QualifiedName);
 


### PR DESCRIPTION
Serenity 4th birthday post before:
![Screenshot from 2022-10-10 17-26-48](https://user-images.githubusercontent.com/25595356/194912805-ebb0d703-9917-4895-8501-8347f3e4e167.png)

After frameborder fix:
![Screenshot from 2022-10-10 17-25-21](https://user-images.githubusercontent.com/25595356/194912836-ec6004ee-d452-4b3d-a3f6-829c83cebccf.png)

`www.pokemoncenter.com` security check before:
![Screenshot from 2022-10-10 17-09-33](https://user-images.githubusercontent.com/25595356/194912669-50a3fc5e-7a37-429c-bbae-115c0b8f7cfd.png)

After width+height fix:
![Screenshot from 2022-10-10 17-10-07](https://user-images.githubusercontent.com/25595356/194912716-0d65abc2-6ad2-4bb4-a342-abb3372bbd8d.png)

After width+height+frameborder fix:
![Screenshot from 2022-10-10 17-09-14](https://user-images.githubusercontent.com/25595356/194912749-53ca79f9-a55e-4721-a06e-2a839037205f.png)