### PR TITLE
pro+LibProtocol+LibHTTP: Fixes and quality-of-life changes and an EXCITING NEW FEATURE

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -12,30 +12,35 @@
 
 namespace HTTP {
 
-String HttpRequest::method_name() const
+String to_string(HttpRequest::Method method)
 {
-    switch (m_method) {
-    case Method::GET:
+    switch (method) {
+    case HttpRequest::Method::GET:
         return "GET";
-    case Method::HEAD:
+    case HttpRequest::Method::HEAD:
         return "HEAD";
-    case Method::POST:
+    case HttpRequest::Method::POST:
         return "POST";
-    case Method::DELETE:
+    case HttpRequest::Method::DELETE:
         return "DELETE";
-    case Method::PATCH:
+    case HttpRequest::Method::PATCH:
         return "PATCH";
-    case Method::OPTIONS:
+    case HttpRequest::Method::OPTIONS:
         return "OPTIONS";
-    case Method::TRACE:
+    case HttpRequest::Method::TRACE:
         return "TRACE";
-    case Method::CONNECT:
+    case HttpRequest::Method::CONNECT:
         return "CONNECT";
-    case Method::PUT:
+    case HttpRequest::Method::PUT:
         return "PUT";
     default:
         VERIFY_NOT_REACHED();
     }
+}
+
+String HttpRequest::method_name() const
+{
+    return to_string(m_method);
 }
 
 ByteBuffer HttpRequest::to_raw_request() const

--- a/Userland/Libraries/LibHTTP/HttpRequest.h
+++ b/Userland/Libraries/LibHTTP/HttpRequest.h
@@ -73,4 +73,6 @@ private:
     ByteBuffer m_body;
 };
 
+String to_string(HttpRequest::Method);
+
 }

--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -40,7 +40,6 @@ RefPtr<Request> RequestClient::start_request(String const& method, URL const& ur
     request->set_request_fd({}, response_fd);
     m_requests.set(request_id, request);
     return request;
-    return nullptr;
 }
 
 bool RequestClient::stop_request(Badge<Request>, Request& request)

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -154,6 +154,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     char const* data = nullptr;
     StringView proxy_spec;
     String method = "GET";
+    StringView method_override;
     HashMap<String, String, CaseInsensitiveStringTraits> request_headers;
 
     Core::ArgsParser args_parser;
@@ -162,6 +163,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         "and thus supports at least http, https, and gemini.");
     args_parser.add_option(save_at_provided_name, "Write to a file named as the remote file", nullptr, 'O');
     args_parser.add_option(data, "(HTTP only) Send the provided data via an HTTP POST request", "data", 'd', "data");
+    args_parser.add_option(method_override, "(HTTP only) HTTP method to use for the request (eg, GET, POST, etc)", "method", 'm', "method");
     args_parser.add_option(should_follow_url, "(HTTP only) Follow the Location header if a 3xx status is encountered", "follow", 'l');
     args_parser.add_option(Core::ArgsParser::Option {
         .argument_mode = Core::ArgsParser::OptionArgumentMode::Required,
@@ -181,7 +183,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(url_str, "URL to download from", "url");
     args_parser.parse(arguments);
 
-    if (data) {
+    if (!method_override.is_empty()) {
+        method = method_override;
+    } else if (data) {
         method = "POST";
         // FIXME: Content-Type?
     }

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -329,7 +329,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     dbgln("started request with id {}", request->id());
 
     auto rc = loop.exec();
-    // FIXME: This shouldn't be needed.
-    fclose(stdout);
+    fflush(stdout);
     return rc;
 }

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -300,6 +300,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             } else {
                 following_url = false;
+
+                if (status_code_value >= 400)
+                    warnln("Request returned error {}", status_code_value);
             }
         };
         request->on_finish = [&](bool success, auto) {


### PR DESCRIPTION
These came up while working on https://github.com/SerenityOS/serenity/pull/15504 but they're not directly connected with it.

The ***EXCITING NEW FEATURE*** is adding a `--method FOO` argument to `pro` so that you can send requests that aren't `GET` or `POST`. Because WebDriver uses `DELETE` too.