### PR TITLE
LibWeb: Fix Serenity logo vanishing after scrolling on the 4th birthday post

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/CanvasPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CanvasPaintable.cpp
@@ -34,8 +34,8 @@ void CanvasPaintable::paint(PaintContext& context, PaintPhase phase) const
         auto canvas_rect = absolute_rect().to_rounded<int>();
         ScopedCornerRadiusClip corner_clip { context.painter(), canvas_rect, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };
 
-        // FIXME: This should be done at a different level. Also rect() does not include padding etc!
-        if (!context.viewport_rect().intersects(canvas_rect))
+        // FIXME: This should be done at a different level.
+        if (is_out_of_view(context))
             return;
 
         if (layout_box().dom_node().bitmap()) {

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -33,8 +33,8 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
     if (!is_visible())
         return;
 
-    // FIXME: This should be done at a different level. Also rect() does not include padding etc!
-    if (!context.viewport_rect().intersects(enclosing_int_rect(absolute_rect())))
+    // FIXME: This should be done at a different level.
+    if (is_out_of_view(context))
         return;
 
     PaintableBox::paint(context, phase);

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -37,6 +37,13 @@ void PaintableBox::invalidate_stacking_context()
     m_stacking_context = nullptr;
 }
 
+bool PaintableBox::is_out_of_view(PaintContext& context) const
+{
+    return !enclosing_int_rect(absolute_paint_rect())
+                .translated(context.painter().translation())
+                .intersects(context.painter().clip_rect());
+}
+
 PaintableWithLines::PaintableWithLines(Layout::BlockContainer const& layout_box)
     : PaintableBox(layout_box)
 {

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -117,6 +117,8 @@ public:
 
     void invalidate_stacking_context();
 
+    bool is_out_of_view(PaintContext&) const;
+
 protected:
     explicit PaintableBox(Layout::Box const&);
 


### PR DESCRIPTION

**Before**

[screen-capture - 2022-10-10T213510.156.webm](https://user-images.githubusercontent.com/11597044/194948654-68e99d12-df5f-44ef-9157-c7271aeee964.webm)

**After**

[screen-capture - 2022-10-10T213625.851.webm](https://user-images.githubusercontent.com/11597044/194948669-681efe11-6d72-4258-8e1f-b3478daeb012.webm)

P.s. I think there's a few other spots that probably have a similar issue, but you're going to have to go hunting for them :^)
