### PR TITLE
Toolchain: Force makeinfo to be a no-op

### DIFF
--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -355,6 +355,11 @@ pushd "$DIR/Build/$ARCH"
 
     pushd binutils
         echo "XXX configure binutils"
+
+        # We don't need the documentation that is being built, so
+        # don't force people to install makeinfo just for that.
+        export ac_cv_prog_MAKEINFO=true
+
         buildstep "binutils/configure" "$DIR"/Tarballs/$BINUTILS_NAME/configure --prefix="$PREFIX" \
                                                  --target="$TARGET" \
                                                  --with-sysroot="$SYSROOT" \


### PR DESCRIPTION
Neither are we changing any of our documentation files, nor do we need any of the documentation that is likely being built.

With macOS potentially removing makeinfo from the default Xcode lineup (#15530), SerenityOS not being able to install it at all currently due to a lack of perl (#12303), and it otherwise just being a dependency that has to be installed to make the build system happy, lets just stub it out.