### PR TITLE
WindowServer+LibGUI: Shrink window edge resize hot-spots

### DIFF
--- a/Userland/Libraries/LibGUI/ResizeCorner.cpp
+++ b/Userland/Libraries/LibGUI/ResizeCorner.cpp
@@ -76,7 +76,7 @@ void ResizeCorner::paint_event(PaintEvent& event)
 void ResizeCorner::mousedown_event(MouseEvent& event)
 {
     if (event.button() == MouseButton::Primary)
-        window()->start_interactive_resize();
+        window()->start_interactive_resize(ResizeDirection::DownRight);
     Widget::mousedown_event(event);
 }
 

--- a/Userland/Libraries/LibGUI/ResizeDirection.h
+++ b/Userland/Libraries/LibGUI/ResizeDirection.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022, Mart G <martg_@hotmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Services/WindowServer/ResizeDirection.h>
+
+namespace GUI {
+
+using ResizeDirection = WindowServer::ResizeDirection;
+
+}

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -938,9 +938,9 @@ void Window::apply_icon()
     ConnectionToWindowServer::the().async_set_window_icon_bitmap(m_window_id, m_icon->to_shareable_bitmap());
 }
 
-void Window::start_interactive_resize()
+void Window::start_interactive_resize(ResizeDirection resize_direction)
 {
-    ConnectionToWindowServer::the().async_start_window_resize(m_window_id);
+    ConnectionToWindowServer::the().async_start_window_resize(m_window_id, (i32)resize_direction);
 }
 
 Vector<Widget&> Window::focusable_widgets(FocusSource source) const

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -14,6 +14,7 @@
 #include <LibCore/Object.h>
 #include <LibGUI/FocusSource.h>
 #include <LibGUI/Forward.h>
+#include <LibGUI/ResizeDirection.h>
 #include <LibGUI/WindowMode.h>
 #include <LibGUI/WindowType.h>
 #include <LibGfx/Forward.h>
@@ -131,7 +132,7 @@ public:
     virtual void close();
     void move_to_front();
 
-    void start_interactive_resize();
+    void start_interactive_resize(ResizeDirection resize_direction);
 
     Widget* main_widget() { return m_main_widget; }
     Widget const* main_widget() const { return m_main_widget; }

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -426,6 +426,9 @@ void Compositor::compose()
                 backing_rect.set_right_without_resize(window_rect.right());
                 backing_rect.set_top(window_rect.top());
                 break;
+            default:
+                VERIFY_NOT_REACHED();
+                break;
             }
 
             Gfx::IntRect dirty_rect_in_backing_coordinates = rect.intersected(window_rect)

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -800,11 +800,15 @@ void ConnectionFromClient::set_window_alpha_hit_threshold(i32 window_id, float t
     it->value->set_alpha_hit_threshold(threshold);
 }
 
-void ConnectionFromClient::start_window_resize(i32 window_id)
+void ConnectionFromClient::start_window_resize(i32 window_id, i32 resize_direction)
 {
     auto it = m_windows.find(window_id);
     if (it == m_windows.end()) {
         did_misbehave("WM_StartWindowResize: Bad window ID");
+        return;
+    }
+    if (resize_direction < 0 || resize_direction >= (i32)ResizeDirection::__Count) {
+        did_misbehave("WM_StartWindowResize: Bad resize direction");
         return;
     }
     auto& window = *(*it).value;
@@ -814,7 +818,7 @@ void ConnectionFromClient::start_window_resize(i32 window_id)
     }
     // FIXME: We are cheating a bit here by using the current cursor location and hard-coding the left button.
     //        Maybe the client should be allowed to specify what initiated this request?
-    WindowManager::the().start_window_resize(window, ScreenInput::the().cursor_location(), MouseButton::Primary);
+    WindowManager::the().start_window_resize(window, ScreenInput::the().cursor_location(), MouseButton::Primary, (ResizeDirection)resize_direction);
 }
 
 Messages::WindowServer::StartDragResponse ConnectionFromClient::start_drag(String const& text, HashMap<String, ByteBuffer> const& mime_data, Gfx::ShareableBitmap const& drag_bitmap)

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -109,7 +109,7 @@ private:
     virtual Messages::WindowServer::GetWindowTitleResponse get_window_title(i32) override;
     virtual Messages::WindowServer::IsMaximizedResponse is_maximized(i32) override;
     virtual void set_maximized(i32, bool) override;
-    virtual void start_window_resize(i32) override;
+    virtual void start_window_resize(i32, i32) override;
     virtual Messages::WindowServer::SetWindowRectResponse set_window_rect(i32, Gfx::IntRect const&) override;
     virtual Messages::WindowServer::GetWindowRectResponse get_window_rect(i32) override;
     virtual void set_window_minimum_size(i32, Gfx::IntSize const&) override;

--- a/Userland/Services/WindowServer/ResizeDirection.h
+++ b/Userland/Services/WindowServer/ResizeDirection.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, Mart G <martg_@hotmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace WindowServer {
+
+enum class ResizeDirection {
+    None,
+    Left,
+    UpLeft,
+    Up,
+    UpRight,
+    Right,
+    DownRight,
+    Down,
+    DownLeft,
+    __Count
+};
+
+}

--- a/Userland/Services/WindowServer/WMConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/WMConnectionFromClient.cpp
@@ -86,7 +86,7 @@ void WMConnectionFromClient::popup_window_menu(i32 client_id, i32 window_id, Gfx
     }
 }
 
-void WMConnectionFromClient::start_window_resize(i32 client_id, i32 window_id)
+void WMConnectionFromClient::start_window_resize(i32 client_id, i32 window_id, i32 resize_direction)
 {
     auto* client = WindowServer::ConnectionFromClient::from_client_id(client_id);
     if (!client) {
@@ -101,7 +101,7 @@ void WMConnectionFromClient::start_window_resize(i32 client_id, i32 window_id)
     auto& window = *(*it).value;
     // FIXME: We are cheating a bit here by using the current cursor location and hard-coding the left button.
     //        Maybe the client should be allowed to specify what initiated this request?
-    WindowManager::the().start_window_resize(window, ScreenInput::the().cursor_location(), MouseButton::Primary);
+    WindowManager::the().start_window_resize(window, ScreenInput::the().cursor_location(), MouseButton::Primary, (ResizeDirection)resize_direction);
 }
 
 void WMConnectionFromClient::set_window_minimized(i32 client_id, i32 window_id, bool minimized)

--- a/Userland/Services/WindowServer/WMConnectionFromClient.h
+++ b/Userland/Services/WindowServer/WMConnectionFromClient.h
@@ -24,7 +24,7 @@ public:
     virtual void set_active_window(i32, i32) override;
     virtual void set_window_minimized(i32, i32, bool) override;
     virtual void toggle_show_desktop() override;
-    virtual void start_window_resize(i32, i32) override;
+    virtual void start_window_resize(i32, i32, i32) override;
     virtual void popup_window_menu(i32, i32, Gfx::IntPoint const&) override;
     virtual void set_window_taskbar_rect(i32, i32, Gfx::IntRect const&) override;
     virtual void set_applet_area_position(Gfx::IntPoint const&) override;

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -21,6 +21,7 @@
 #include <WindowServer/Event.h>
 #include <WindowServer/KeymapSwitcher.h>
 #include <WindowServer/MenuManager.h>
+#include <WindowServer/ResizeDirection.h>
 #include <WindowServer/ScreenLayout.h>
 #include <WindowServer/SystemEffects.h>
 #include <WindowServer/WMConnectionFromClient.h>
@@ -40,18 +41,6 @@ class WindowSwitcher;
 class Button;
 class DndOverlay;
 class WindowGeometryOverlay;
-
-enum class ResizeDirection {
-    None,
-    Left,
-    UpLeft,
-    Up,
-    UpRight,
-    Right,
-    DownRight,
-    Down,
-    DownLeft
-};
 
 class WindowManager : public Core::Object {
     C_OBJECT(WindowManager)
@@ -202,8 +191,8 @@ public:
 
     void check_hide_geometry_overlay(Window&);
 
-    void start_window_resize(Window&, Gfx::IntPoint const&, MouseButton);
-    void start_window_resize(Window&, MouseEvent const&);
+    void start_window_resize(Window&, Gfx::IntPoint const&, MouseButton, ResizeDirection);
+    void start_window_resize(Window&, MouseEvent const&, ResizeDirection);
     void start_window_move(Window&, MouseEvent const&);
     void start_window_move(Window&, Gfx::IntPoint const&);
 

--- a/Userland/Services/WindowServer/WindowManagerServer.ipc
+++ b/Userland/Services/WindowServer/WindowManagerServer.ipc
@@ -8,7 +8,7 @@ endpoint WindowManagerServer
     set_active_window(i32 client_id, i32 window_id) =|
     set_window_minimized(i32 client_id, i32 window_id, bool minimized) =|
     toggle_show_desktop() =|
-    start_window_resize(i32 client_id, i32 window_id) =|
+    start_window_resize(i32 client_id, i32 window_id, i32 resize_direction) =|
     popup_window_menu(i32 client_id, i32 window_id, Gfx::IntPoint screen_position) =|
     set_window_taskbar_rect(i32 client_id, i32 window_id, Gfx::IntRect rect) =|
     set_applet_area_position(Gfx::IntPoint position) =|

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -80,7 +80,7 @@ endpoint WindowServer
 
     get_applet_rect_on_screen(i32 window_id) => (Gfx::IntRect rect)
 
-    start_window_resize(i32 window_id) =|
+    start_window_resize(i32 window_id, i32 resize_direction) =|
 
     is_maximized(i32 window_id) => (bool maximized)
     set_maximized(i32 window_id, bool maximized) =|


### PR DESCRIPTION
The hot-spots for resizing a window by dragging its corner are now limited to a small area around the actual corner instead of an area with 1/3rd the length or width of the window.

The hot-spots to resize a window while holding a modifier key and the right mouse button are unchanged.

This seems to be in line with what other desktop environments do.