### PR TITLE
Userland: Properly populate GENERATED_SOURCES

### DIFF
--- a/Userland/Applications/Browser/CMakeLists.txt
+++ b/Userland/Applications/Browser/CMakeLists.txt
@@ -13,23 +13,26 @@ compile_gml(Tab.gml TabGML.h tab_gml)
 set(SOURCES
     BookmarksBarWidget.cpp
     BrowserWindow.cpp
-    BrowserWindowGML.h
     ConsoleWidget.cpp
     CookieJar.cpp
     CookiesModel.cpp
     DownloadWidget.cpp
-    EditBookmarkGML.h
     ElementSizePreviewWidget.cpp
     History.cpp
     IconBag.cpp
     InspectorWidget.cpp
     StorageModel.cpp
     StorageWidget.cpp
-    StorageWidgetGML.h
     Tab.cpp
-    TabGML.h
     WindowActions.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
+    BrowserWindowGML.h
+    EditBookmarkGML.h
+    StorageWidgetGML.h
+    TabGML.h
 )
 
 serenity_app(Browser ICON app-browser)

--- a/Userland/Applications/BrowserSettings/CMakeLists.txt
+++ b/Userland/Applications/BrowserSettings/CMakeLists.txt
@@ -8,11 +8,14 @@ compile_gml(BrowserSettingsWidget.gml BrowserSettingsWidgetGML.h browser_setting
 compile_gml(ContentFilterSettingsWidget.gml ContentFilterSettingsWidgetGML.h content_filter_settings_widget_gml)
 
 set(SOURCES
-    main.cpp
-    ContentFilterSettingsWidget.cpp
-    ContentFilterSettingsWidgetGML.h
     BrowserSettingsWidget.cpp
+    ContentFilterSettingsWidget.cpp
+    main.cpp
+)
+
+set(GENERATED_SOURCES
     BrowserSettingsWidgetGML.h
+    ContentFilterSettingsWidgetGML.h
 )
 
 serenity_app(BrowserSettings ICON app-browser)

--- a/Userland/Applications/Calculator/CMakeLists.txt
+++ b/Userland/Applications/Calculator/CMakeLists.txt
@@ -11,6 +11,9 @@ set(SOURCES
     CalculatorWidget.cpp
     RoundingDialog.cpp
     Keypad.cpp
+)
+
+set(GENERATED_SOURCES
     CalculatorGML.h
 )
 

--- a/Userland/Applications/Calendar/CMakeLists.txt
+++ b/Userland/Applications/Calendar/CMakeLists.txt
@@ -7,8 +7,11 @@ compile_gml(CalendarWindow.gml CalendarWindowGML.h calendar_window_gml)
 
 set(SOURCES
     AddEventDialog.cpp
-    CalendarWindowGML.h
     main.cpp
+)
+
+set(GENERATED_SOURCES
+    CalendarWindowGML.h
 )
 
 serenity_app(Calendar ICON app-calendar)

--- a/Userland/Applications/CalendarSettings/CMakeLists.txt
+++ b/Userland/Applications/CalendarSettings/CMakeLists.txt
@@ -9,7 +9,9 @@ compile_gml(CalendarSettingsWidget.gml CalendarSettingsWidgetGML.h calendar_sett
 set(SOURCES
     main.cpp
     CalendarSettingsWidget.cpp
-    CalendarSettingsWidget.h
+)
+
+set(GENERATED_SOURCES
     CalendarSettingsWidgetGML.h
 )
 

--- a/Userland/Applications/CharacterMap/CMakeLists.txt
+++ b/Userland/Applications/CharacterMap/CMakeLists.txt
@@ -9,10 +9,13 @@ compile_gml(CharacterSearchWindow.gml CharacterSearchWindowGML.h character_searc
 
 set(SOURCES
     CharacterMapWidget.cpp
-    CharacterMapWindowGML.h
     CharacterSearchWidget.cpp
-    CharacterSearchWindowGML.h
     main.cpp
+)
+
+set(GENERATED_SOURCES
+    CharacterMapWindowGML.h
+    CharacterSearchWindowGML.h
 )
 
 serenity_app(CharacterMap ICON app-character-map)

--- a/Userland/Applications/ClockSettings/CMakeLists.txt
+++ b/Userland/Applications/ClockSettings/CMakeLists.txt
@@ -10,10 +10,11 @@ compile_gml(TimeZoneSettingsWidget.gml TimeZoneSettingsWidgetGML.h time_zone_set
 set(SOURCES
     main.cpp
     ClockSettingsWidget.cpp
-    ClockSettingsWidget.h
-    ClockSettingsWidgetGML.h
     TimeZoneSettingsWidget.cpp
-    TimeZoneSettingsWidget.h
+)
+
+set(GENERATED_SOURCES
+    ClockSettingsWidgetGML.h
     TimeZoneSettingsWidgetGML.h
 )
 

--- a/Userland/Applications/CrashReporter/CMakeLists.txt
+++ b/Userland/Applications/CrashReporter/CMakeLists.txt
@@ -9,6 +9,9 @@ compile_gml(CrashReporterWindow.gml CrashReporterWindowGML.h crash_reporter_wind
 
 set(SOURCES
     main.cpp
+)
+
+set(GENERATED_SOURCES
     CrashReporterWindowGML.h
 )
 

--- a/Userland/Applications/DisplaySettings/CMakeLists.txt
+++ b/Userland/Applications/DisplaySettings/CMakeLists.txt
@@ -12,23 +12,24 @@ compile_gml(MonitorSettings.gml MonitorSettingsGML.h monitor_settings_window_gml
 compile_gml(ThemesSettings.gml ThemesSettingsGML.h themes_settings_gml)
 
 set(SOURCES
-    BackgroundSettingsGML.h
     BackgroundSettingsWidget.cpp
     DesktopSettingsWidget.cpp
-    DesktopSettingsGML.h
-    EffectsSettingsGML.h
     EffectsSettingsWidget.cpp
-    FontSettingsGML.h
     FontSettingsWidget.cpp
     MonitorSettingsWidget.cpp
-    MonitorSettingsGML.h
     MonitorWidget.cpp
-    ThemePreviewWidget.h
     ThemePreviewWidget.cpp
-    ThemesSettingsWidget.h
     ThemesSettingsWidget.cpp
-    ThemesSettingsGML.h
     main.cpp
+)
+
+set(GENERATED_SOURCES
+    BackgroundSettingsGML.h
+    DesktopSettingsGML.h
+    EffectsSettingsGML.h
+    FontSettingsGML.h
+    MonitorSettingsGML.h
+    ThemesSettingsGML.h
 )
 
 serenity_app(DisplaySettings ICON app-display-settings)

--- a/Userland/Applications/FileManager/CMakeLists.txt
+++ b/Userland/Applications/FileManager/CMakeLists.txt
@@ -12,13 +12,16 @@ compile_gml(PropertiesWindowGeneralTab.gml PropertiesWindowGeneralTabGML.h prope
 set(SOURCES
     DesktopWidget.cpp
     DirectoryView.cpp
-    FileManagerWindowGML.h
-    FileOperationProgress.gml
     FileOperationProgressWidget.cpp
     FileUtils.cpp
     main.cpp
     PropertiesWindow.cpp
-    PropertiesWindowGeneralTab.gml
+)
+
+set(GENERATED_SOURCES
+    FileManagerWindowGML.h
+    FileOperationProgressGML.h
+    PropertiesWindowGeneralTabGML.h
 )
 
 serenity_app(FileManager ICON app-file-manager)

--- a/Userland/Applications/FontEditor/CMakeLists.txt
+++ b/Userland/Applications/FontEditor/CMakeLists.txt
@@ -12,14 +12,16 @@ compile_gml(NewFontDialogPage2.gml NewFontDialogPage2GML.h new_font_dialog_page_
 
 set(SOURCES
     MainWidget.cpp
-    FontEditorWindowGML.h
-    FontPreviewWindowGML.h
     GlyphEditorWidget.cpp
     main.cpp
     NewFontDialog.cpp
+)
+
+set(GENERATED_SOURCES
+    FontEditorWindowGML.h
+    FontPreviewWindowGML.h
     NewFontDialogPage1GML.h
     NewFontDialogPage2GML.h
-    UndoSelection.h
 )
 
 serenity_app(FontEditor ICON app-font-editor)

--- a/Userland/Applications/GamesSettings/CMakeLists.txt
+++ b/Userland/Applications/GamesSettings/CMakeLists.txt
@@ -7,11 +7,13 @@ serenity_component(
 compile_gml(CardSettingsWidget.gml CardSettingsWidgetGML.h card_settings_widget_gml)
 
 set(SOURCES
-        main.cpp
-        CardSettingsWidgetGML.h
-        CardSettingsWidget.cpp
-        CardSettingsWidget.h
-        )
+    main.cpp
+    CardSettingsWidget.cpp
+)
+
+set(GENERATED_SOURCES
+    CardSettingsWidgetGML.h
+)
 
 serenity_app(GamesSettings ICON games)
 target_link_libraries(GamesSettings LibGUI LibMain LibCards)

--- a/Userland/Applications/Help/CMakeLists.txt
+++ b/Userland/Applications/Help/CMakeLists.txt
@@ -8,13 +8,16 @@ serenity_component(
 compile_gml(HelpWindow.gml HelpWindowGML.h help_window_gml)
 
 set(SOURCES
-    HelpWindowGML.h
     History.cpp
     main.cpp
     MainWidget.cpp
     ManualModel.cpp
     ManualPageNode.cpp
     ManualSectionNode.cpp
+)
+
+set(GENERATED_SOURCES
+    HelpWindowGML.h
 )
 
 serenity_app(Help ICON app-help)

--- a/Userland/Applications/HexEditor/CMakeLists.txt
+++ b/Userland/Applications/HexEditor/CMakeLists.txt
@@ -9,12 +9,15 @@ compile_gml(GoToOffsetDialog.gml GoToOffsetDialogGML.h go_to_offset_dialog_gml)
 compile_gml(FindDialog.gml FindDialogGML.h find_dialog_gml)
 
 set(SOURCES
-    HexEditor.cpp
-    HexEditorWidget.cpp
-    HexDocument.cpp
     FindDialog.cpp
     GoToOffsetDialog.cpp
+    HexDocument.cpp
+    HexEditor.cpp
+    HexEditorWidget.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
     FindDialogGML.h
     GoToOffsetDialogGML.h
     HexEditorWindowGML.h

--- a/Userland/Applications/KeyboardSettings/CMakeLists.txt
+++ b/Userland/Applications/KeyboardSettings/CMakeLists.txt
@@ -8,8 +8,11 @@ compile_gml(Keyboard.gml KeyboardWidgetGML.h keyboard_widget_gml)
 compile_gml(KeymapDialog.gml KeymapDialogGML.h keymap_dialog_gml)
 
 set(SOURCES
-    main.cpp
     KeyboardSettingsWidget.cpp
+    main.cpp
+)
+
+set(GENERATED_SOURCES
     KeyboardWidgetGML.h
     KeymapDialogGML.h
 )

--- a/Userland/Applications/Magnifier/CMakeLists.txt
+++ b/Userland/Applications/Magnifier/CMakeLists.txt
@@ -6,7 +6,6 @@ serenity_component(
 
 set(SOURCES
     MagnifierWidget.cpp
-    MagnifierWidget.h
     main.cpp
 )
 

--- a/Userland/Applications/Mail/CMakeLists.txt
+++ b/Userland/Applications/Mail/CMakeLists.txt
@@ -10,10 +10,13 @@ compile_gml(MailWindow.gml MailWindowGML.h mail_window_gml)
 set(SOURCES
     AccountHolder.cpp
     InboxModel.cpp
-    MailboxTreeModel.cpp
     MailWidget.cpp
-    MailWindowGML.h
+    MailboxTreeModel.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
+    MailWindowGML.h
 )
 
 serenity_app(Mail ICON app-mail)

--- a/Userland/Applications/MailSettings/CMakeLists.txt
+++ b/Userland/Applications/MailSettings/CMakeLists.txt
@@ -9,7 +9,9 @@ compile_gml(MailSettingsWidget.gml MailSettingsWidgetGML.h mail_settings_widget_
 set(SOURCES
     main.cpp
     MailSettingsWidget.cpp
-    MailSettingsWidget.h
+)
+
+set(GENERATED_SOURCES
     MailSettingsWidgetGML.h
 )
 

--- a/Userland/Applications/MouseSettings/CMakeLists.txt
+++ b/Userland/Applications/MouseSettings/CMakeLists.txt
@@ -9,16 +9,17 @@ compile_gml(Theme.gml ThemeWidgetGML.h theme_widget_gml)
 compile_gml(Highlight.gml HighlightWidgetGML.h highlight_widget_gml)
 
 set(SOURCES
-    main.cpp
     DoubleClickArrowWidget.cpp
     HighlightPreviewWidget.cpp
     HighlightWidget.cpp
-    HighlightWidgetGML.h
     MouseWidget.cpp
-    MouseWidget.h
-    MouseWidgetGML.h
     ThemeWidget.cpp
-    ThemeWidget.h
+    main.cpp
+)
+
+set(GENERATED_SOURCES
+    HighlightWidgetGML.h
+    MouseWidgetGML.h
     ThemeWidgetGML.h
 )
 

--- a/Userland/Applications/NetworkSettings/CMakeLists.txt
+++ b/Userland/Applications/NetworkSettings/CMakeLists.txt
@@ -7,10 +7,12 @@ serenity_component(
 compile_gml(NetworkSettings.gml NetworkSettingsGML.h network_settings_gml)
 
 set(SOURCES
-    main.cpp
-    NetworkSettingsGML.h
     NetworkSettingsWidget.cpp
-    NetworkSettingsWidget.h
+    main.cpp
+)
+
+set(GENERATED_SOURCES
+    NetworkSettingsGML.h
 )
 
 serenity_app(NetworkSettings ICON network)

--- a/Userland/Applications/PartitionEditor/CMakeLists.txt
+++ b/Userland/Applications/PartitionEditor/CMakeLists.txt
@@ -7,8 +7,11 @@ compile_gml(PartitionEditorWindow.gml PartitionEditorWindowGML.h partition_edito
 
 set(SOURCES
     main.cpp
-    PartitionEditorWindowGML.h
     PartitionModel.cpp
+)
+
+set(GENERATED_SOURCES
+    PartitionEditorWindowGML.h
 )
 
 serenity_app(PartitionEditor ICON app-partition-editor)

--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -16,9 +16,7 @@ set(SOURCES
     CreateNewImageDialog.cpp
     CreateNewLayerDialog.cpp
     EditGuideDialog.cpp
-    EditGuideDialogGML.h
     FilterGallery.cpp
-    FilterGalleryGML.h
     FilterTreeModel.cpp
     FilterPreviewWidget.cpp
     Filters/Bloom.cpp
@@ -34,7 +32,6 @@ set(SOURCES
     Filters/LaplaceCardinal.cpp
     Filters/LaplaceDiagonal.cpp
     Filters/Median.cpp
-    Filters/MedianSettingsGML.h
     Filters/Sepia.cpp
     Filters/Sharpen.cpp
     HistogramWidget.cpp
@@ -45,15 +42,12 @@ set(SOURCES
     Layer.cpp
     LayerListWidget.cpp
     LayerPropertiesWidget.cpp
-    LevelsDialogGML.h
     LevelsDialog.cpp
     MainWidget.cpp
     Mask.cpp
     PaletteWidget.cpp
-    PixelPaintWindowGML.h
     ProjectLoader.cpp
     ResizeImageDialog.cpp
-    ResizeImageDialogGML.h
     ScopeWidget.cpp
     Selection.cpp
     ToolPropertiesWidget.cpp
@@ -76,7 +70,16 @@ set(SOURCES
     Tools/ZoomTool.cpp
     VectorscopeWidget.cpp
     main.cpp
-    )
+)
+
+set(GENERATED_SOURCES
+    EditGuideDialogGML.h
+    FilterGalleryGML.h
+    Filters/MedianSettingsGML.h
+    LevelsDialogGML.h
+    PixelPaintWindowGML.h
+    ResizeImageDialogGML.h
+)
 
 serenity_app(PixelPaint ICON app-pixel-paint)
 target_link_libraries(PixelPaint LibImageDecoderClient LibGUI LibGfx LibFileSystemAccessClient LibConfig LibMain)

--- a/Userland/Applications/Run/CMakeLists.txt
+++ b/Userland/Applications/Run/CMakeLists.txt
@@ -9,7 +9,9 @@ compile_gml(Run.gml RunGML.h run_gml)
 set(SOURCES
     main.cpp
     RunWindow.cpp
-    RunWindow.h
+)
+
+set(GENERATED_SOURCES
     RunGML.h
 )
 

--- a/Userland/Applications/SpaceAnalyzer/CMakeLists.txt
+++ b/Userland/Applications/SpaceAnalyzer/CMakeLists.txt
@@ -6,8 +6,11 @@ serenity_component(
 compile_gml(SpaceAnalyzer.gml SpaceAnalyzerGML.h space_analyzer_gml)
 
 set(SOURCES
-    main.cpp
     TreeMapWidget.cpp
+    main.cpp
+)
+
+set(GENERATED_SOURCES
     SpaceAnalyzerGML.h
 )
 

--- a/Userland/Applications/Spreadsheet/CMakeLists.txt
+++ b/Userland/Applications/Spreadsheet/CMakeLists.txt
@@ -20,8 +20,6 @@ set(SOURCES
     CellType/String.cpp
     CellType/Type.cpp
     CellTypeDialog.cpp
-    CondFormattingGML.h
-    CondFormattingViewGML.h
     ExportDialog.cpp
     HelpWindow.cpp
     ImportDialog.cpp
@@ -38,6 +36,8 @@ set(SOURCES
 set(GENERATED_SOURCES
     CSVExportGML.h
     CSVImportGML.h
+    CondFormattingGML.h
+    CondFormattingViewGML.h
     FormatSelectionPageGML.h
 )
 

--- a/Userland/Applications/SystemMonitor/CMakeLists.txt
+++ b/Userland/Applications/SystemMonitor/CMakeLists.txt
@@ -18,6 +18,9 @@ set(SOURCES
     ProcessUnveiledPathsWidget.cpp
     ProcessStateWidget.cpp
     ThreadStackWidget.cpp
+)
+
+set(GENERATED_SOURCES
     SystemMonitorGML.h
     ProcessWindowGML.h
 )

--- a/Userland/Applications/TerminalSettings/CMakeLists.txt
+++ b/Userland/Applications/TerminalSettings/CMakeLists.txt
@@ -8,8 +8,11 @@ compile_gml(TerminalSettingsMain.gml TerminalSettingsMainGML.h terminal_settings
 compile_gml(TerminalSettingsView.gml TerminalSettingsViewGML.h terminal_settings_view_gml)
 
 set(SOURCES
-    main.cpp
     TerminalSettingsWidget.cpp
+    main.cpp
+)
+
+set(GENERATED_SOURCES
     TerminalSettingsMainGML.h
     TerminalSettingsViewGML.h
 )

--- a/Userland/Applications/TextEditor/CMakeLists.txt
+++ b/Userland/Applications/TextEditor/CMakeLists.txt
@@ -8,9 +8,12 @@ serenity_component(
 compile_gml(TextEditorWindow.gml TextEditorWindowGML.h text_editor_window_gml)
 
 set(SOURCES
-    main.cpp
     FileArgument.cpp
     MainWidget.cpp
+    main.cpp
+)
+
+set(GENERATED_SOURCES
     TextEditorWindowGML.h
 )
 

--- a/Userland/Applications/ThemeEditor/CMakeLists.txt
+++ b/Userland/Applications/ThemeEditor/CMakeLists.txt
@@ -12,9 +12,12 @@ compile_gml(PathProperty.gml PathPropertyGML.h path_property_gml)
 compile_gml(Previews/WindowPreview.gml WindowPreviewGML.h window_preview_gml)
 
 set(SOURCES
-    main.cpp
     MainWidget.cpp
     PreviewWidget.cpp
+    main.cpp
+)
+
+set(GENERATED_SOURCES
     AlignmentPropertyGML.h
     ColorPropertyGML.h
     FlagPropertyGML.h

--- a/Userland/Applications/Welcome/CMakeLists.txt
+++ b/Userland/Applications/Welcome/CMakeLists.txt
@@ -7,10 +7,12 @@ serenity_component(
 compile_gml(WelcomeWindow.gml WelcomeWindowGML.h welcome_window_gml)
 
 set(SOURCES
-    WelcomeWindowGML.h
     WelcomeWidget.cpp
-    WelcomeWidget.h
     main.cpp
+)
+
+set(GENERATED_SOURCES
+    WelcomeWindowGML.h
 )
 
 serenity_app(Welcome ICON app-welcome)

--- a/Userland/Demos/ModelGallery/CMakeLists.txt
+++ b/Userland/Demos/ModelGallery/CMakeLists.txt
@@ -9,6 +9,9 @@ set(SOURCES
     main.cpp
     GalleryWidget.cpp
     BasicModel.cpp
+)
+
+set(GENERATED_SOURCES
     BasicModelTabGML.h
 )
 

--- a/Userland/Demos/WidgetGallery/CMakeLists.txt
+++ b/Userland/Demos/WidgetGallery/CMakeLists.txt
@@ -15,13 +15,16 @@ compile_gml(DemoWizardPage2.gml DemoWizardPage2GML.h demo_wizard_page_2_gml)
 set(SOURCES
     main.cpp
     GalleryWidget.cpp
+    DemoWizardDialog.cpp
+)
+
+set(GENERATED_SOURCES
     WindowGML.h
     BasicsTabGML.h
     SlidersTabGML.h
     CursorsTabGML.h
     IconsTabGML.h
     WizardsTabGML.h
-    DemoWizardDialog.cpp
     DemoWizardPage1GML.h
     DemoWizardPage2GML.h
 )

--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -23,15 +23,12 @@ set(SOURCES
     Debugger/RegistersModel.cpp
     Debugger/VariablesModel.cpp
     Dialogs/Git/GitCommitDialog.cpp
-    Dialogs/Git/GitCommitDialogGML.h
     Dialogs/NewProjectDialog.cpp
-    Dialogs/NewProjectDialogGML.h
     Dialogs/ProjectTemplatesModel.cpp
     Editor.cpp
     EditorWrapper.cpp
     FindInFilesWidget.cpp
     FindWidget.cpp
-    FindWidgetGML.h
     Git/DiffViewer.cpp
     Git/GitFilesModel.cpp
     Git/GitFilesView.cpp
@@ -52,6 +49,12 @@ set(SOURCES
     ToDoEntries.cpp
     ToDoEntriesWidget.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
+    Dialogs/Git/GitCommitDialogGML.h
+    Dialogs/NewProjectDialogGML.h
+    FindWidgetGML.h
 )
 
 serenity_app(HackStudio ICON app-hack-studio)

--- a/Userland/Games/GameOfLife/CMakeLists.txt
+++ b/Userland/Games/GameOfLife/CMakeLists.txt
@@ -10,8 +10,11 @@ set(SOURCES
     main.cpp
     Board.cpp
     BoardWidget.cpp
-    GameOfLifeGML.h
     Pattern.cpp
+)
+
+set(GENERATED_SOURCES
+    GameOfLifeGML.h
 )
 
 serenity_app(GameOfLife ICON app-gameoflife)

--- a/Userland/Games/Hearts/CMakeLists.txt
+++ b/Userland/Games/Hearts/CMakeLists.txt
@@ -13,6 +13,9 @@ set(SOURCES
     Player.cpp
     ScoreCard.cpp
     SettingsDialog.cpp
+)
+
+set(GENERATED_SOURCES
     HeartsGML.h
 )
 

--- a/Userland/Games/Minesweeper/CMakeLists.txt
+++ b/Userland/Games/Minesweeper/CMakeLists.txt
@@ -8,11 +8,14 @@ compile_gml(MinesweeperCustomGameWindow.gml MinesweeperCustomGameWindowGML.h min
 compile_gml(MinesweeperWindow.gml MinesweeperWindowGML.h minesweeper_window_gml)
 
 set(SOURCES
-    MinesweeperCustomGameWindowGML.h
-    MinesweeperWindowGML.h
     CustomGameDialog.cpp
     Field.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
+    MinesweeperCustomGameWindowGML.h
+    MinesweeperWindowGML.h
 )
 
 serenity_app(Minesweeper ICON app-minesweeper)

--- a/Userland/Games/Solitaire/CMakeLists.txt
+++ b/Userland/Games/Solitaire/CMakeLists.txt
@@ -9,6 +9,9 @@ compile_gml(Solitaire.gml SolitaireGML.h solitaire_gml)
 set(SOURCES
     Game.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
     SolitaireGML.h
 )
 

--- a/Userland/Games/Spider/CMakeLists.txt
+++ b/Userland/Games/Spider/CMakeLists.txt
@@ -9,6 +9,9 @@ compile_gml(Spider.gml SpiderGML.h spider_gml)
 set(SOURCES
     Game.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
     SpiderGML.h
 )
 

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -37,15 +37,12 @@ set(SOURCES
     DragOperation.cpp
     EditingEngine.cpp
     EmojiInputDialog.cpp
-    EmojiInputDialogGML.h
     Event.cpp
     FileIconProvider.cpp
     FilePicker.cpp
-    FilePickerDialogGML.h
     FileSystemModel.cpp
     FilteringProxyModel.cpp
     FontPicker.cpp
-    FontPickerDialogGML.h
     Frame.cpp
     GitCommitLexer.cpp
     GitCommitSyntaxHighlighter.cpp
@@ -81,7 +78,6 @@ set(SOURCES
     OpacitySlider.cpp
     Painter.cpp
     PasswordInputDialog.cpp
-    PasswordInputDialogGML.h
     PersistentModelIndex.cpp
     Process.cpp
     ProcessChooser.cpp
@@ -125,14 +121,18 @@ set(SOURCES
 )
 
 set(GENERATED_SOURCES
-    ../../Services/WindowServer/WindowClientEndpoint.h
-    ../../Services/WindowServer/WindowServerEndpoint.h
-    ../../Services/WindowServer/WindowManagerClientEndpoint.h
-    ../../Services/WindowServer/WindowManagerServerEndpoint.h
-    ../../Services/NotificationServer/NotificationClientEndpoint.h
-    ../../Services/NotificationServer/NotificationServerEndpoint.h
     ../../Services/Clipboard/ClipboardClientEndpoint.h
     ../../Services/Clipboard/ClipboardServerEndpoint.h
+    ../../Services/NotificationServer/NotificationClientEndpoint.h
+    ../../Services/NotificationServer/NotificationServerEndpoint.h
+    ../../Services/WindowServer/WindowClientEndpoint.h
+    ../../Services/WindowServer/WindowManagerClientEndpoint.h
+    ../../Services/WindowServer/WindowManagerServerEndpoint.h
+    ../../Services/WindowServer/WindowServerEndpoint.h
+    EmojiInputDialogGML.h
+    FilePickerDialogGML.h
+    FontPickerDialogGML.h
+    PasswordInputDialogGML.h
 )
 
 serenity_lib(LibGUI gui)

--- a/Userland/Services/AudioServer/CMakeLists.txt
+++ b/Userland/Services/AudioServer/CMakeLists.txt
@@ -11,6 +11,9 @@ set(SOURCES
     ConnectionFromClient.cpp
     Mixer.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
     AudioServerEndpoint.h
     AudioClientEndpoint.h
 )

--- a/Userland/Services/Clipboard/CMakeLists.txt
+++ b/Userland/Services/Clipboard/CMakeLists.txt
@@ -9,10 +9,13 @@ compile_ipc(ClipboardClient.ipc ClipboardClientEndpoint.h)
 
 set(SOURCES
     ConnectionFromClient.cpp
-    ClipboardClientEndpoint.h
-    ClipboardServerEndpoint.h
     Storage.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
+    ClipboardClientEndpoint.h
+    ClipboardServerEndpoint.h
 )
 
 serenity_bin(Clipboard)

--- a/Userland/Services/ConfigServer/CMakeLists.txt
+++ b/Userland/Services/ConfigServer/CMakeLists.txt
@@ -10,6 +10,9 @@ compile_ipc(ConfigClient.ipc ConfigClientEndpoint.h)
 set(SOURCES
     ConnectionFromClient.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
     ConfigServerEndpoint.h
     ConfigClientEndpoint.h
 )

--- a/Userland/Services/FileSystemAccessServer/CMakeLists.txt
+++ b/Userland/Services/FileSystemAccessServer/CMakeLists.txt
@@ -10,6 +10,9 @@ compile_ipc(FileSystemAccessClient.ipc FileSystemAccessClientEndpoint.h)
 set(SOURCES
     ConnectionFromClient.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
     FileSystemAccessServerEndpoint.h
     FileSystemAccessClientEndpoint.h
 )

--- a/Userland/Services/ImageDecoder/CMakeLists.txt
+++ b/Userland/Services/ImageDecoder/CMakeLists.txt
@@ -9,6 +9,9 @@ compile_ipc(ImageDecoderClient.ipc ImageDecoderClientEndpoint.h)
 set(SOURCES
     ConnectionFromClient.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
     ImageDecoderServerEndpoint.h
     ImageDecoderClientEndpoint.h
 )

--- a/Userland/Services/InspectorServer/CMakeLists.txt
+++ b/Userland/Services/InspectorServer/CMakeLists.txt
@@ -11,6 +11,9 @@ set(SOURCES
     ConnectionFromClient.cpp
     main.cpp
     InspectableProcess.cpp
+)
+
+set(GENERATED_SOURCES
     InspectorServerEndpoint.h
     InspectorClientEndpoint.h
 )

--- a/Userland/Services/LaunchServer/CMakeLists.txt
+++ b/Userland/Services/LaunchServer/CMakeLists.txt
@@ -11,6 +11,9 @@ set(SOURCES
     ConnectionFromClient.cpp
     Launcher.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
     LaunchClientEndpoint.h
     LaunchServerEndpoint.h
 )

--- a/Userland/Services/LoginServer/CMakeLists.txt
+++ b/Userland/Services/LoginServer/CMakeLists.txt
@@ -7,9 +7,12 @@ serenity_component(
 compile_gml(LoginWindow.gml LoginWindowGML.h login_window_gml)
 
 set(SOURCES
-    LoginWindowGML.h
     LoginWindow.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
+    LoginWindowGML.h
 )
 
 serenity_bin(LoginServer)

--- a/Userland/Services/LookupServer/CMakeLists.txt
+++ b/Userland/Services/LookupServer/CMakeLists.txt
@@ -10,11 +10,14 @@ compile_ipc(LookupClient.ipc LookupClientEndpoint.h)
 set(SOURCES
     DNSServer.cpp
     LookupServer.cpp
-    LookupServerEndpoint.h
-    LookupClientEndpoint.h
     ConnectionFromClient.cpp
     MulticastDNS.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
+    LookupServerEndpoint.h
+    LookupClientEndpoint.h
 )
 
 serenity_bin(LookupServer)

--- a/Userland/Services/NotificationServer/CMakeLists.txt
+++ b/Userland/Services/NotificationServer/CMakeLists.txt
@@ -11,6 +11,9 @@ set(SOURCES
     ConnectionFromClient.cpp
     main.cpp
     NotificationWindow.cpp
+)
+
+set(GENERATED_SOURCES
     NotificationServerEndpoint.h
     NotificationClientEndpoint.h
 )

--- a/Userland/Services/RequestServer/CMakeLists.txt
+++ b/Userland/Services/RequestServer/CMakeLists.txt
@@ -10,8 +10,6 @@ set(SOURCES
     ConnectionFromClient.cpp
     ConnectionCache.cpp
     Request.cpp
-    RequestClientEndpoint.h
-    RequestServerEndpoint.h
     GeminiRequest.cpp
     GeminiProtocol.cpp
     HttpRequest.cpp
@@ -20,6 +18,11 @@ set(SOURCES
     HttpsProtocol.cpp
     main.cpp
     Protocol.cpp
+)
+
+set(GENERATED_SOURCES
+    RequestClientEndpoint.h
+    RequestServerEndpoint.h
 )
 
 serenity_bin(RequestServer)

--- a/Userland/Services/SQLServer/CMakeLists.txt
+++ b/Userland/Services/SQLServer/CMakeLists.txt
@@ -11,10 +11,13 @@ set(SOURCES
     ConnectionFromClient.cpp
     DatabaseConnection.cpp
     main.cpp
+    SQLStatement.cpp
+)
+
+set(GENERATED_SOURCES
     SQLClientEndpoint.h
     SQLServerEndpoint.h
-    SQLStatement.cpp
-    )
+)
 
 serenity_bin(SQLServer)
 target_link_libraries(SQLServer LibCore LibIPC LibSQL LibMain)

--- a/Userland/Services/WebContent/CMakeLists.txt
+++ b/Userland/Services/WebContent/CMakeLists.txt
@@ -12,10 +12,13 @@ set(SOURCES
     ConsoleGlobalObject.cpp
     ImageCodecPluginSerenity.cpp
     PageHost.cpp
-    WebContentClientEndpoint.h
     WebContentConsoleClient.cpp
-    WebContentServerEndpoint.h
     main.cpp
+)
+
+set(GENERATED_SOURCES
+    WebContentClientEndpoint.h
+    WebContentServerEndpoint.h
 )
 
 serenity_bin(WebContent)

--- a/Userland/Services/WebSocket/CMakeLists.txt
+++ b/Userland/Services/WebSocket/CMakeLists.txt
@@ -9,6 +9,9 @@ compile_ipc(WebSocketClient.ipc WebSocketClientEndpoint.h)
 set(SOURCES
     ConnectionFromClient.cpp
     main.cpp
+)
+
+set(GENERATED_SOURCES
     WebSocketClientEndpoint.h
     WebSocketServerEndpoint.h
 )

--- a/Userland/Services/WindowServer/CMakeLists.txt
+++ b/Userland/Services/WindowServer/CMakeLists.txt
@@ -33,12 +33,15 @@ set(SOURCES
     WindowManager.cpp
     WindowStack.cpp
     WindowSwitcher.cpp
+    WMConnectionFromClient.cpp
+    KeymapSwitcher.cpp
+)
+
+set(GENERATED_SOURCES
     WindowServerEndpoint.h
     WindowClientEndpoint.h
     WindowManagerServerEndpoint.h
     WindowManagerClientEndpoint.h
-    WMConnectionFromClient.cpp
-    KeymapSwitcher.cpp
 )
 
 serenity_bin(WindowServer)


### PR DESCRIPTION
We previously put the generated headers in SOURCES, which did not mark them as GENERATED (and did not produce a proper dependency). This commit moves all generated headers into GENERATED_SOURCES, and removes useless header SOURCES.