### PR TITLE
TextEditor: Set window title before showing the main window

### DIFF
--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -67,6 +67,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     text_widget->initialize_menubar(*window);
+    text_widget->update_title();
 
     window->show();
     window->set_icon(app_icon.bitmap_for_size(16));
@@ -85,8 +86,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 return 1;
             text_widget->editor().set_cursor_and_focus_line(parsed_argument.line().value_or(1) - 1, parsed_argument.column().value_or(0));
         }
+
+        text_widget->update_title();
     }
-    text_widget->update_title();
     text_widget->update_statusbar();
 
     return app->exec();


### PR DESCRIPTION
Previously TextEditor updated its window title after the window was already visible. This causes the default title ("GUI::Window") to be shown for a short period of time which was especially noticeable when opening files.


https://user-images.githubusercontent.com/388571/195344068-42d93202-1d86-4417-8f0d-1a16ad0363aa.mov

