### PR TITLE
PixelPaint: Call update after clearing guides

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -512,6 +512,12 @@ void ImageEditor::set_pixel_grid_visibility(bool show_pixel_grid)
     update();
 }
 
+void ImageEditor::clear_guides()
+{
+    m_guides.clear();
+    update();
+}
+
 void ImageEditor::layers_did_change()
 {
     if (on_modified_change)

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -60,7 +60,7 @@ public:
     {
         m_guides.remove_first_matching([&](auto& entry) { return &guide == entry.ptr(); });
     }
-    void clear_guides() { m_guides.clear(); }
+    void clear_guides();
 
     void layers_did_change();
 


### PR DESCRIPTION
A small fix to make sure the guides disappear immediately after clicking the button.