### PR TITLE
Everywhere: Enable building userspace and test binaries on AARCH64

### DIFF
--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -24,4 +24,5 @@ extern "C" __attribute__((noreturn)) void ak_verification_failed(char const*);
 #    define VERIFY_NOT_REACHED() VERIFY(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 static constexpr bool TODO = false;
 #    define TODO() VERIFY(TODO)                /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#    define TODO_AARCH64() VERIFY(TODO)        /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 #endif

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -123,7 +123,11 @@
 #ifdef NAKED
 #    undef NAKED
 #endif
-#define NAKED __attribute__((naked))
+#ifndef AK_ARCH_AARCH64
+#    define NAKED __attribute__((naked))
+#else
+#    define NAKED
+#endif
 
 #ifdef DISALLOW
 #    undef DISALLOW

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -274,6 +274,12 @@ template<>
 struct __MakeUnsigned<bool> {
     using Type = bool;
 };
+#ifdef AK_ARCH_AARCH64
+template<>
+struct __MakeUnsigned<wchar_t> {
+    using Type = wchar_t;
+};
+#endif
 
 template<typename T>
 using MakeUnsigned = typename __MakeUnsigned<T>::Type;
@@ -326,6 +332,12 @@ template<>
 struct __MakeSigned<char> {
     using Type = char;
 };
+#ifdef AK_ARCH_AARCH64
+template<>
+struct __MakeSigned<wchar_t> {
+    using Type = void;
+};
+#endif
 
 template<typename T>
 using MakeSigned = typename __MakeSigned<T>::Type;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,20 +228,22 @@ endif()
 
 add_subdirectory(AK)
 add_subdirectory(Kernel)
-if(NOT "${SERENITY_ARCH}" STREQUAL "aarch64")
-    if (ENABLE_MOLD_LINKER)
-        add_link_options(-fuse-ld=mold)
-    endif()
 
+if (ENABLE_MOLD_LINKER)
+    add_link_options(-fuse-ld=mold)
+endif()
+
+if(NOT "${SERENITY_ARCH}" STREQUAL "aarch64")
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$" OR ENABLE_MOLD_LINKER)
         add_link_options(LINKER:--pack-dyn-relocs=relr)
     else()
         add_link_options(LINKER:-z,pack-relative-relocs)
     endif()
-
-    add_subdirectory(Userland)
-    add_subdirectory(Tests)
 endif()
+
+add_subdirectory(Userland)
+add_subdirectory(Tests)
+
 if (ENABLE_COMPILETIME_HEADER_CHECK)
     add_subdirectory(Meta/HeaderCheck)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,11 @@ if (ENABLE_COMPILETIME_FORMAT_CHECK)
     add_compile_definitions(ENABLE_COMPILETIME_FORMAT_CHECK)
 endif()
 
+if("${SERENITY_ARCH}" STREQUAL "aarch64")
+    # FIXME: re-enable this warning
+    add_compile_options(-Wno-type-limits)
+endif()
+
 add_link_options(-Wno-unused-command-line-argument)
 
 include_directories(.)

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -483,7 +483,7 @@ struct SC_chmod_params {
 void initialize();
 int sync();
 
-#    if ARCH(I386) || ARCH(X86_64)
+#    if ARCH(I386) || ARCH(X86_64) || ARCH(AARCH64)
 inline uintptr_t invoke(Function function)
 {
     uintptr_t result;
@@ -492,11 +492,19 @@ inline uintptr_t invoke(Function function)
                  : "=a"(result)
                  : "a"(function)
                  : "memory");
-#        else
+#        elif ARCH(X86_64)
     asm volatile("syscall"
                  : "=a"(result)
                  : "a"(function)
                  : "rcx", "r11", "memory");
+#        elif ARCH(AARCH64)
+    register uintptr_t x0 asm("x0");
+    register uintptr_t x8 asm("x8") = function;
+    asm volatile("svc #0"
+                 : "=r"(x0)
+                 : "r"(x8)
+                 : "memory");
+    result = x0;
 #        endif
     return result;
 }
@@ -510,11 +518,20 @@ inline uintptr_t invoke(Function function, T1 arg1)
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1)
                  : "memory");
-#        else
+#        elif ARCH(X86_64)
     asm volatile("syscall"
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1)
                  : "rcx", "r11", "memory");
+#        else
+    register uintptr_t x0 asm("x0");
+    register uintptr_t x1 asm("x1") = arg1;
+    register uintptr_t x8 asm("x8") = function;
+    asm volatile("svc #0"
+                 : "=r"(x0)
+                 : "r"(x1), "r"(x8)
+                 : "memory");
+    result = x0;
 #        endif
     return result;
 }
@@ -528,11 +545,21 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2)
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1), "c"((uintptr_t)arg2)
                  : "memory");
-#        else
+#        elif ARCH(X86_64)
     asm volatile("syscall"
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2)
                  : "rcx", "r11", "memory");
+#        else
+    register uintptr_t x0 asm("x0");
+    register uintptr_t x1 asm("x1") = arg1;
+    register uintptr_t x2 asm("x2") = arg2;
+    register uintptr_t x8 asm("x8") = function;
+    asm volatile("svc #0"
+                 : "=r"(x0)
+                 : "r"(x1), "r"(x2), "r"(x8)
+                 : "memory");
+    result = x0;
 #        endif
     return result;
 }
@@ -546,11 +573,22 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3)
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1), "c"((uintptr_t)arg2), "b"((uintptr_t)arg3)
                  : "memory");
-#        else
+#        elif ARCH(X86_64)
     asm volatile("syscall"
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2), "b"((uintptr_t)arg3)
                  : "rcx", "r11", "memory");
+#        else
+    register uintptr_t x0 asm("x0");
+    register uintptr_t x1 asm("x1") = arg1;
+    register uintptr_t x2 asm("x2") = arg2;
+    register uintptr_t x3 asm("x3") = arg3;
+    register uintptr_t x8 asm("x8") = function;
+    asm volatile("svc #0"
+                 : "=r"(x0)
+                 : "r"(x1), "r"(x2), "r"(x3), "r"(x8)
+                 : "memory");
+    result = x0;
 #        endif
     return result;
 }
@@ -564,11 +602,23 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1), "c"((uintptr_t)arg2), "b"((uintptr_t)arg3), "S"((uintptr_t)arg4)
                  : "memory");
-#        else
+#        elif ARCH(X86_64)
     asm volatile("syscall"
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2), "b"((uintptr_t)arg3), "S"((uintptr_t)arg4)
                  : "memory");
+#        else
+    register uintptr_t x0 asm("x0");
+    register uintptr_t x1 asm("x1") = arg1;
+    register uintptr_t x2 asm("x2") = arg2;
+    register uintptr_t x3 asm("x3") = arg3;
+    register uintptr_t x4 asm("x4") = arg4;
+    register uintptr_t x8 asm("x8") = function;
+    asm volatile("svc #0"
+                 : "=r"(x0)
+                 : "r"(x1), "r"(x2), "r"(x3), "r"(x4), "r"(x8)
+                 : "memory");
+    result = x0;
 #        endif
     return result;
 }

--- a/Kernel/Arch/aarch64/mcontext.h
+++ b/Kernel/Arch/aarch64/mcontext.h
@@ -13,7 +13,39 @@ extern "C" {
 #endif
 
 struct __attribute__((packed)) __mcontext {
-    int stub;
+    uint64_t r0;
+    uint64_t r1;
+    uint64_t r2;
+    uint64_t r3;
+    uint64_t r4;
+    uint64_t r5;
+    uint64_t r6;
+    uint64_t r7;
+    uint64_t r8;
+    uint64_t r9;
+    uint64_t r10;
+    uint64_t r11;
+    uint64_t r12;
+    uint64_t r13;
+    uint64_t r14;
+    uint64_t r15;
+    uint64_t r16;
+    uint64_t r17;
+    uint64_t r18;
+    uint64_t r19;
+    uint64_t r20;
+    uint64_t r21;
+    uint64_t r22;
+    uint64_t r23;
+    uint64_t r24;
+    uint64_t r25;
+    uint64_t r26;
+    uint64_t r27;
+    uint64_t r28;
+    uint64_t r29;
+    uint64_t r30;
+    uint64_t sp;
+    uint64_t pc;
 };
 
 #ifdef __cplusplus

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -537,8 +537,7 @@ endif()
 add_compile_options(-fno-asynchronous-unwind-tables)
 add_compile_options(-fstack-protector-strong)
 add_compile_options(-fno-exceptions)
-# FIXME: remove -nodefaultlibs after the next toolchain update
-add_compile_options(-nodefaultlibs -nostdlib)
+add_compile_options(-nostdlib)
 
 # Auto initialize trivial types on the stack, we use "pattern" as 
 # it's the only option portable across compilers going forward.

--- a/Tests/Kernel/crash.cpp
+++ b/Tests/Kernel/crash.cpp
@@ -113,7 +113,7 @@ int main(int argc, char** argv)
 
     if (do_illegal_instruction || do_all_crash_types) {
         any_failures |= !Crash("Illegal instruction", []() {
-            asm volatile("ud2");
+            __builtin_trap();
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
     }

--- a/Tests/Kernel/crash.cpp
+++ b/Tests/Kernel/crash.cpp
@@ -200,7 +200,14 @@ int main(int argc, char** argv)
                 return Crash::Failure::UnexpectedError;
 
             u8* makeshift_esp = makeshift_stack + 2048;
+#if ARCH(I386) || ARCH(X86_64)
             asm volatile("mov %%eax, %%esp" ::"a"(makeshift_esp));
+#elif ARCH(AARCH64)
+            (void)makeshift_esp;
+            TODO_AARCH64();
+#else
+#    error Unknown architecture
+#endif
             getuid();
             dbgln("Survived syscall with MAP_STACK stack");
 
@@ -209,7 +216,14 @@ int main(int argc, char** argv)
                 return Crash::Failure::UnexpectedError;
 
             u8* bad_esp = bad_stack + 2048;
+#if ARCH(I386) || ARCH(X86_64)
             asm volatile("mov %%eax, %%esp" ::"a"(bad_esp));
+#elif ARCH(AARCH64)
+            (void)bad_esp;
+            TODO_AARCH64();
+#else
+#    error Unknown architecture
+#endif
             getuid();
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
@@ -228,6 +242,9 @@ int main(int argc, char** argv)
 #elif ARCH(X86_64)
             asm volatile("movq %%rax, %%rsp" ::"a"(bad_esp));
             asm volatile("pushq $0");
+#elif ARCH(AARCH64)
+            (void)bad_esp;
+            TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif
@@ -267,7 +284,13 @@ int main(int argc, char** argv)
 
     if (do_trigger_user_mode_instruction_prevention) {
         any_failures |= !Crash("Trigger x86 User Mode Instruction Prevention", []() {
+#if ARCH(I386) || ARCH(X86_64)
             asm volatile("str %eax");
+#elif ARCH(AARCH64)
+            TODO_AARCH64();
+#else
+#    error Unknown architecture
+#endif
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
     }

--- a/Tests/Kernel/elf-symbolication-kernel-read-exploit.cpp
+++ b/Tests/Kernel/elf-symbolication-kernel-read-exploit.cpp
@@ -11,9 +11,17 @@
 #include <string.h>
 #include <unistd.h>
 
+#if ARCH(I386) || ARCH(X86_64)
 asm("haxcode:\n"
     "1: jmp 1b\n"
     "haxcode_end:\n");
+#elif ARCH(AARCH64)
+asm("haxcode:\n"
+    "1: b 1b\n"
+    "haxcode_end:\n");
+#else
+#    error Unknown architecture
+#endif
 
 extern "C" void haxcode();
 extern "C" void haxcode_end();

--- a/Tests/Kernel/null-deref-crash-during-pthread_join.cpp
+++ b/Tests/Kernel/null-deref-crash-during-pthread_join.cpp
@@ -15,7 +15,7 @@ int main(int, char**)
     pthread_create(
         &tid, nullptr, [](void*) -> void* {
             sleep(1);
-            asm volatile("ud2");
+            __builtin_trap();
             return nullptr;
         },
         nullptr);

--- a/Tests/LibC/TestWchar.cpp
+++ b/Tests/LibC/TestWchar.cpp
@@ -239,17 +239,17 @@ TEST_CASE(mbrtowc)
     // Ensure that we can parse normal ASCII characters.
     ret = mbrtowc(&wc, "Hello", 5, &state);
     EXPECT_EQ(ret, 1ul);
-    EXPECT_EQ(wc, 'H');
+    EXPECT_EQ(wc, static_cast<wchar_t>('H'));
 
     // Try two three-byte codepoints (™™), only one of which should be consumed.
     ret = mbrtowc(&wc, "\xe2\x84\xa2\xe2\x84\xa2", 6, &state);
     EXPECT_EQ(ret, 3ul);
-    EXPECT_EQ(wc, 0x2122);
+    EXPECT_EQ(wc, static_cast<wchar_t>(0x2122));
 
     // Try a null character, which should return 0 and reset the state to the initial state.
     ret = mbrtowc(&wc, "\x00\x00", 2, &state);
     EXPECT_EQ(ret, 0ul);
-    EXPECT_EQ(wc, 0);
+    EXPECT_EQ(wc, static_cast<wchar_t>(0));
     EXPECT_NE(mbsinit(&state), 0);
 
     // Try an incomplete multibyte character.
@@ -262,7 +262,7 @@ TEST_CASE(mbrtowc)
     // Finish the previous multibyte character.
     ret = mbrtowc(&wc, "\xa2", 1, &state);
     EXPECT_EQ(ret, 1ul);
-    EXPECT_EQ(wc, 0x2122);
+    EXPECT_EQ(wc, static_cast<wchar_t>(0x2122));
 
     // Try an invalid multibyte sequence.
     // Reset the state afterwards because the effects are undefined.
@@ -550,17 +550,17 @@ TEST_CASE(mbtowc)
     // Ensure that we can parse normal ASCII characters.
     ret = mbtowc(&wc, "Hello", 5);
     EXPECT_EQ(ret, 1);
-    EXPECT_EQ(wc, 'H');
+    EXPECT_EQ(wc, static_cast<wchar_t>('H'));
 
     // Try two three-byte codepoints (™™), only one of which should be consumed.
     ret = mbtowc(&wc, "\xe2\x84\xa2\xe2\x84\xa2", 6);
     EXPECT_EQ(ret, 3);
-    EXPECT_EQ(wc, 0x2122);
+    EXPECT_EQ(wc, static_cast<wchar_t>(0x2122));
 
     // Try a null character, which should return 0.
     ret = mbtowc(&wc, "\x00\x00", 2);
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(wc, 0);
+    EXPECT_EQ(wc, static_cast<wchar_t>(0));
 
     // Try an incomplete multibyte character.
     ret = mbtowc(&wc, "\xe2\x84", 2);

--- a/Toolchain/Patches/gcc/0001-Add-a-gcc-driver-for-SerenityOS.patch
+++ b/Toolchain/Patches/gcc/0001-Add-a-gcc-driver-for-SerenityOS.patch
@@ -101,11 +101,11 @@ index 0000000000000000000000000000000000000000..17551aaa1a07e6c0b7365f9889937512
 +/* Files that are linked before user code.
 +   The %s tells GCC to look for these files in the library directory. */
 +#undef STARTFILE_SPEC
-+#define STARTFILE_SPEC "%{!shared:crt0.o%s} crti.o%s %{shared: %{!fbuilding-libgcc:crt0_shared.o%s}} %{shared|static-pie|!no-pie:crtbeginS.o%s; :crtbegin.o%s}"
++#define STARTFILE_SPEC "%{!shared:crt0.o%s} crti.o%s %{shared: %{!fbuilding-libgcc:crt0_shared.o%s}} %{shared|static-pie|!no-pie:%:if-exists-else(crtbeginS.o%s crtbegin.o%s); :crtbegin.o%s}"
 +
 +/* Files that are linked after user code. */
 +#undef ENDFILE_SPEC
-+#define ENDFILE_SPEC "%{shared|static-pie|!no-pie:crtendS.o%s; :crtend.o%s} crtn.o%s"
++#define ENDFILE_SPEC "%{shared|static-pie|!no-pie:%:if-exists-else(crtendS.o%s crtend.o%s); :crtend.o%s} crtn.o%s"
 +
 +#undef LINK_SPEC
 +#define LINK_SPEC "%{shared:-shared} %{static:-static} %{!static: %{rdynamic:-export-dynamic} -dynamic-linker /usr/lib/Loader.so}"

--- a/Toolchain/Patches/gcc/0003-libgcc-Build-for-SerenityOS.patch
+++ b/Toolchain/Patches/gcc/0003-libgcc-Build-for-SerenityOS.patch
@@ -53,8 +53,8 @@ index 8c56fcae5d2fdfcc8d1f9b2614f0c41ad44f258f..f5855cfa66d7950c3d7565ad938b4e47
 +	extra_parts="$extra_parts crti.o crtbegin.o crtend.o crtn.o"
 +	extra_parts="$extra_parts crtfastmath.o"
 +	tmake_file="$tmake_file ${cpu_type}/t-aarch64"
-+	tmake_file="$tmake_file ${cpu_type}/t-lse t-slibgcc-libgcc"
-+	tmake_file="$tmake_file ${cpu_type}/t-softfp t-softp t-crtfm"
++	tmake_file="$tmake_file ${cpu_type}/t-lse t-slibgcc t-slibgcc-libgcc"
++	tmake_file="$tmake_file ${cpu_type}/t-softfp t-softfp t-crtfm"
 +	md_unwind_header=aarch64/aarch64-unwind.h
 +	;;
  *)

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -120,6 +120,9 @@ static TitleAndText build_cpu_registers(const ELF::Core::ThreadInfo& thread_info
     builder.appendff(" r8={:p}  r9={:p} r10={:p} r11={:p}\n", regs.r8, regs.r9, regs.r10, regs.r11);
     builder.appendff("r12={:p} r13={:p} r14={:p} r15={:p}\n", regs.r12, regs.r13, regs.r14, regs.r15);
     builder.appendff("rip={:p} rflags={:p}", regs.rip, regs.rflags);
+#elif ARCH(AARCH64)
+    (void)regs;
+    TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -49,6 +49,9 @@ static void handle_print_registers(PtraceRegisters const& regs)
     outln("r8 ={:p} r9 ={:p} r10={:p} r11={:p}", regs.r8, regs.r9, regs.r10, regs.r11);
     outln("r12={:p} r13={:p} r14={:p} r15={:p}", regs.r12, regs.r13, regs.r14, regs.r15);
     outln("rip={:p} rflags={:p}", regs.rip, regs.rflags);
+#elif ARCH(AARCH64)
+    (void)regs;
+    TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif
@@ -250,6 +253,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         const FlatPtr ip = regs.eip;
 #elif ARCH(X86_64)
         const FlatPtr ip = regs.rip;
+#elif ARCH(AARCH64)
+        const FlatPtr ip = 0; // FIXME
+        TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/DevTools/HackStudio/Debugger/RegistersModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/RegistersModel.cpp
@@ -51,6 +51,8 @@ RegistersModel::RegistersModel(PtraceRegisters const& regs)
     m_registers.append({ "es", regs.es });
     m_registers.append({ "fs", regs.fs });
     m_registers.append({ "gs", regs.gs });
+#elif ARCH(AARCH64)
+    TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif
@@ -97,6 +99,9 @@ RegistersModel::RegistersModel(PtraceRegisters const& current_regs, PtraceRegist
     m_registers.append({ "es", current_regs.es, current_regs.es != previous_regs.es });
     m_registers.append({ "fs", current_regs.fs, current_regs.fs != previous_regs.fs });
     m_registers.append({ "gs", current_regs.gs, current_regs.gs != previous_regs.gs });
+#elif ARCH(AARCH64)
+    (void)previous_regs;
+    TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/DynamicLoader/main.cpp
+++ b/Userland/DynamicLoader/main.cpp
@@ -62,9 +62,14 @@ void _entry(int, char**, char**) __attribute__((used));
 
 NAKED void _start(int, char**, char**)
 {
+#ifdef AK_ARCH_AARCH64
+    asm(
+        "bl _entry\n");
+#else
     asm(
         "push $0\n"
         "jmp _entry@plt\n");
+#endif
 }
 
 void _entry(int argc, char** argv, char** envp)

--- a/Userland/Libraries/LibC/arch/aarch64/setjmp.S
+++ b/Userland/Libraries/LibC/arch/aarch64/setjmp.S
@@ -17,3 +17,10 @@ _longjmp:
 longjmp:
     # FIXME: Possibly incomplete.
     ret
+
+.global _sigsetjmp
+.global sigsetjmp
+_sigsetjmp:
+sigsetjmp:
+    # FIXME: Possibly incomplete.
+    ret

--- a/Userland/Libraries/LibC/crt0.cpp
+++ b/Userland/Libraries/LibC/crt0.cpp
@@ -25,9 +25,14 @@ void _start(int, char**, char**) __attribute__((used));
 
 NAKED void _start(int, char**, char**)
 {
+#    ifdef AK_ARCH_AARCH64
+    asm(
+        "bl _entry\n");
+#    else
     asm(
         "push $0\n"
         "jmp _entry@plt\n");
+#    endif
 }
 
 int _entry(int argc, char** argv, char** env)

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -9,7 +9,9 @@
 
 #include <AK/BuiltinWrappers.h>
 #include <AK/ExtraMathConstants.h>
-#include <AK/FPControl.h>
+#ifndef AK_ARCH_AARCH64
+#    include <AK/FPControl.h>
+#endif
 #include <AK/Math.h>
 #include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
@@ -62,7 +64,7 @@ enum class RoundingMode {
 template<typename T>
 union FloatExtractor;
 
-#if ARCH(I386) || ARCH(X86_64)
+#if ARCH(I386) || ARCH(X86_64) || ARCH(AARCH64)
 // This assumes long double is 80 bits, which is true with GCC on Intel platforms
 template<>
 union FloatExtractor<long double> {
@@ -413,6 +415,7 @@ MAKE_AK_BACKED2(remainder);
 
 long double truncl(long double x) NOEXCEPT
 {
+#ifndef AK_ARCH_AARCH64
     if (fabsl(x) < LONG_LONG_MAX) {
         // This is 1.6 times faster than the implementation using the "internal_to_integer"
         // helper (on x86_64)
@@ -425,12 +428,14 @@ long double truncl(long double x) NOEXCEPT
             : [temp] "m"(temp));
         return x;
     }
+#endif
 
     return internal_to_integer(x, RoundingMode::ToZero);
 }
 
 double trunc(double x) NOEXCEPT
 {
+#ifndef AK_ARCH_AARCH64
     if (fabs(x) < LONG_LONG_MAX) {
         u64 temp;
         asm(
@@ -440,12 +445,14 @@ double trunc(double x) NOEXCEPT
             : [temp] "m"(temp));
         return x;
     }
+#endif
 
     return internal_to_integer(x, RoundingMode::ToZero);
 }
 
 float truncf(float x) NOEXCEPT
 {
+#ifndef AK_ARCH_AARCH64
     if (fabsf(x) < LONG_LONG_MAX) {
         u64 temp;
         asm(
@@ -455,40 +462,60 @@ float truncf(float x) NOEXCEPT
             : [temp] "m"(temp));
         return x;
     }
+#endif
 
     return internal_to_integer(x, RoundingMode::ToZero);
 }
 
 long double rintl(long double value)
 {
+#ifdef AK_ARCH_AARCH64
+    (void)value;
+    TODO_AARCH64();
+#else
     long double res;
     asm(
         "frndint\n"
         : "=t"(res)
         : "0"(value));
     return res;
+#endif
 }
 double rint(double value)
 {
+#ifdef AK_ARCH_AARCH64
+    (void)value;
+    TODO_AARCH64();
+#else
     double res;
     asm(
         "frndint\n"
         : "=t"(res)
         : "0"(value));
     return res;
+#endif
 }
 float rintf(float value)
 {
+#ifdef AK_ARCH_AARCH64
+    (void)value;
+    TODO_AARCH64();
+#else
     float res;
     asm(
         "frndint\n"
         : "=t"(res)
         : "0"(value));
     return res;
+#endif
 }
 
 long lrintl(long double value)
 {
+#ifdef AK_ARCH_AARCH64
+    (void)value;
+    TODO_AARCH64();
+#else
     long res;
     asm(
         "fistpl %0\n"
@@ -496,9 +523,14 @@ long lrintl(long double value)
         : "t"(value)
         : "st");
     return res;
+#endif
 }
 long lrint(double value)
 {
+#ifdef AK_ARCH_AARCH64
+    (void)value;
+    TODO_AARCH64();
+#else
     long res;
     asm(
         "fistpl %0\n"
@@ -506,9 +538,14 @@ long lrint(double value)
         : "t"(value)
         : "st");
     return res;
+#endif
 }
 long lrintf(float value)
 {
+#ifdef AK_ARCH_AARCH64
+    (void)value;
+    TODO_AARCH64();
+#else
     long res;
     asm(
         "fistpl %0\n"
@@ -516,10 +553,15 @@ long lrintf(float value)
         : "t"(value)
         : "st");
     return res;
+#endif
 }
 
 long long llrintl(long double value)
 {
+#ifdef AK_ARCH_AARCH64
+    (void)value;
+    TODO_AARCH64();
+#else
     long long res;
     asm(
         "fistpq %0\n"
@@ -527,9 +569,14 @@ long long llrintl(long double value)
         : "t"(value)
         : "st");
     return res;
+#endif
 }
 long long llrint(double value)
 {
+#ifdef AK_ARCH_AARCH64
+    (void)value;
+    TODO_AARCH64();
+#else
     long long res;
     asm(
         "fistpq %0\n"
@@ -537,9 +584,14 @@ long long llrint(double value)
         : "t"(value)
         : "st");
     return res;
+#endif
 }
 long long llrintf(float value)
 {
+#ifdef AK_ARCH_AARCH64
+    (void)value;
+    TODO_AARCH64();
+#else
     long long res;
     asm(
         "fistpq %0\n"
@@ -547,6 +599,7 @@ long long llrintf(float value)
         : "t"(value)
         : "st");
     return res;
+#endif
 }
 
 // On systems where FLT_RADIX == 2, ldexp is equivalent to scalbn

--- a/Userland/Libraries/LibC/pthread.cpp
+++ b/Userland/Libraries/LibC/pthread.cpp
@@ -102,6 +102,10 @@ static int create_thread(pthread_t* thread, void* (*entry)(void*), void* argumen
     thread_params->rsi = (FlatPtr)argument;
     thread_params->rdx = (FlatPtr)thread_params->stack_location;
     thread_params->rcx = thread_params->stack_size;
+#elif ARCH(AARCH64)
+    (void)entry;
+    (void)argument;
+    TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibC/setjmp.h
+++ b/Userland/Libraries/LibC/setjmp.h
@@ -26,7 +26,7 @@ struct __jmp_buf {
     uint32_t ebp;
     uint32_t esp;
     uint32_t eip;
-#elif __x86_64__
+#elif defined(__x86_64__)
     uint64_t rbx;
     uint64_t r12;
     uint64_t r13;
@@ -35,7 +35,7 @@ struct __jmp_buf {
     uint64_t rbp;
     uint64_t rsp;
     uint64_t rip;
-#elif __aarch64__
+#elif defined(__aarch64__)
     // FIXME: This is likely incorrect.
     uint64_t regs[22];
 #else
@@ -54,9 +54,9 @@ typedef struct __jmp_buf sigjmp_buf[1];
 #ifdef __cplusplus
 #    ifdef __i386__
 static_assert(sizeof(struct __jmp_buf) == 32, "struct __jmp_buf unsynchronized with i386/setjmp.S");
-#    elif __x86_64__
+#    elif defined(__x86_64__)
 static_assert(sizeof(struct __jmp_buf) == 72, "struct __jmp_buf unsynchronized with x86_64/setjmp.S");
-#    elif __aarch64__
+#    elif defined(__aarch64__)
 static_assert(sizeof(struct __jmp_buf) == 184, "struct __jmp_buf unsynchronized with aarch64/setjmp.S");
 #    else
 #        error

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -214,8 +214,9 @@ int atexit(void (*handler)())
 
 void _abort()
 {
-    asm volatile("ud2");
-    __builtin_unreachable();
+    // According to the GCC manual __builtin_trap() can call abort() so using it here might not seem safe at first. However,
+    // on all the platforms we support GCC emits an undefined instruction instead of a call.
+    __builtin_trap();
 }
 
 void abort()

--- a/Userland/Libraries/LibC/string.cpp
+++ b/Userland/Libraries/LibC/string.cpp
@@ -136,6 +136,11 @@ void* memcpy(void* dest_ptr, void const* src_ptr, size_t n)
         "rep movsb"
         : "+D"(dest_ptr), "+S"(src_ptr), "+c"(n)::"memory");
     return original_dest;
+#elif ARCH(AARCH64)
+    (void)dest_ptr;
+    (void)src_ptr;
+    (void)n;
+    TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif
@@ -168,6 +173,14 @@ void* memset(void* dest_ptr, int c, size_t n)
 }
 #elif ARCH(X86_64)
 // For x86-64, an optimized ASM implementation is found in ./arch/x86_64/memset.S
+#elif ARCH(AARCH64)
+void* memset(void* dest_ptr, int c, size_t n)
+{
+    (void)dest_ptr;
+    (void)c;
+    (void)n;
+    TODO_AARCH64();
+}
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibC/sys/arch/i386/regs.h
+++ b/Userland/Libraries/LibC/sys/arch/i386/regs.h
@@ -25,8 +25,10 @@ struct [[gnu::packed]] PtraceRegisters : public __mcontext {
         return eip;
 #        elif ARCH(X86_64)
         return rip;
+#        elif ARCH(AARCH64)
+        return pc;
 #        else
-        TODO_AARCH64();
+#            error Unknown architecture
 #        endif
     }
 
@@ -36,9 +38,10 @@ struct [[gnu::packed]] PtraceRegisters : public __mcontext {
         eip = ip;
 #        elif ARCH(X86_64)
         rip = ip;
+#        elif ARCH(AARCH64)
+        pc = ip;
 #        else
-        (void)ip;
-        TODO_AARCH64();
+#            error Unknown architecture
 #        endif
     }
 
@@ -48,8 +51,10 @@ struct [[gnu::packed]] PtraceRegisters : public __mcontext {
         return ebp;
 #        elif ARCH(X86_64)
         return rbp;
+#        elif ARCH(AARCH64)
+        return r29;
 #        else
-        TODO_AARCH64();
+#            error Unknown architecture
 #        endif
     }
 
@@ -59,9 +64,10 @@ struct [[gnu::packed]] PtraceRegisters : public __mcontext {
         ebp = bp;
 #        elif ARCH(X86_64)
         rbp = bp;
+#        elif ARCH(AARCH64)
+        r29 = bp;
 #        else
-        (void)bp;
-        TODO_AARCH64();
+#            error Unknown architecture
 #        endif
     }
 #    endif

--- a/Userland/Libraries/LibC/sys/arch/i386/regs.h
+++ b/Userland/Libraries/LibC/sys/arch/i386/regs.h
@@ -23,8 +23,10 @@ struct [[gnu::packed]] PtraceRegisters : public __mcontext {
     {
 #        if ARCH(I386)
         return eip;
-#        else
+#        elif ARCH(X86_64)
         return rip;
+#        else
+        TODO_AARCH64();
 #        endif
     }
 
@@ -32,8 +34,11 @@ struct [[gnu::packed]] PtraceRegisters : public __mcontext {
     {
 #        if ARCH(I386)
         eip = ip;
-#        else
+#        elif ARCH(X86_64)
         rip = ip;
+#        else
+        (void)ip;
+        TODO_AARCH64();
 #        endif
     }
 
@@ -41,8 +46,10 @@ struct [[gnu::packed]] PtraceRegisters : public __mcontext {
     {
 #        if ARCH(I386)
         return ebp;
-#        else
+#        elif ARCH(X86_64)
         return rbp;
+#        else
+        TODO_AARCH64();
 #        endif
     }
 
@@ -50,8 +57,11 @@ struct [[gnu::packed]] PtraceRegisters : public __mcontext {
     {
 #        if ARCH(I386)
         ebp = bp;
-#        else
+#        elif ARCH(X86_64)
         rbp = bp;
+#        else
+        (void)bp;
+        TODO_AARCH64();
 #        endif
     }
 #    endif

--- a/Userland/Libraries/LibCoredump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoredump/Backtrace.cpp
@@ -50,6 +50,10 @@ Backtrace::Backtrace(Reader const& coredump, const ELF::Core::ThreadInfo& thread
 #elif ARCH(X86_64)
     auto start_bp = m_thread_info.regs.rbp;
     auto start_ip = m_thread_info.regs.rip;
+#elif ARCH(AARCH64)
+    auto start_bp = 0;
+    auto start_ip = 0;
+    TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibDebug/DebugInfo.cpp
+++ b/Userland/Libraries/LibDebug/DebugInfo.cpp
@@ -171,6 +171,8 @@ NonnullOwnPtrVector<DebugInfo::VariableInfo> DebugInfo::get_variables_in_current
         ip = regs.eip;
 #elif ARCH(X86_64)
         ip = regs.rip;
+#elif ARCH(AARCH64)
+        TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -343,11 +343,15 @@ FlatPtr DebugSession::single_step()
     // After the debuggee has stopped, we clear the TRAP flag.
 
     auto regs = get_registers();
+#if ARCH(I386) || ARCH(X86_64)
     constexpr u32 TRAP_FLAG = 0x100;
+#endif
 #if ARCH(I386)
     regs.eflags |= TRAP_FLAG;
 #elif ARCH(X86_64)
     regs.rflags |= TRAP_FLAG;
+#elif ARCH(AARCH64)
+    TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif
@@ -365,6 +369,8 @@ FlatPtr DebugSession::single_step()
     regs.eflags &= ~(TRAP_FLAG);
 #elif ARCH(X86_64)
     regs.rflags &= ~(TRAP_FLAG);
+#elif ARCH(AARCH64)
+    TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibDebug/DebugSession.h
+++ b/Userland/Libraries/LibDebug/DebugSession.h
@@ -188,6 +188,9 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
         FlatPtr current_instruction = regs.eip;
 #elif ARCH(X86_64)
         FlatPtr current_instruction = regs.rip;
+#elif ARCH(AARCH64)
+        FlatPtr current_instruction;
+        TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif
@@ -211,6 +214,9 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
                 FlatPtr current_ebp = regs.ebp;
 #elif ARCH(X86_64)
                 FlatPtr current_ebp = regs.rbp;
+#elif ARCH(AARCH64)
+                FlatPtr current_ebp;
+                TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif
@@ -259,6 +265,9 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
             regs.eip = breakpoint_addr;
 #elif ARCH(X86_64)
             regs.rip = breakpoint_addr;
+#elif ARCH(AARCH64)
+            (void)breakpoint_addr;
+            TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -660,7 +660,11 @@ void ELF::DynamicLinker::linker_main(String&& main_program_name, int main_progra
 
     dbgln_if(DYNAMIC_LOAD_DEBUG, "Jumping to entry point: {:p}", entry_point_function);
     if (s_do_breakpoint_trap_before_entry) {
+#ifdef AK_ARCH_AARCH64
+        asm("brk #0");
+#else
         asm("int3");
+#endif
     }
 
     _invoke_entry(argc, argv, envp, entry_point_function);

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -270,9 +270,11 @@ public:
         return m_view.visit(
             [&](StringView view) -> u32 {
                 auto ch = view[index];
-                if (ch < 0)
-                    return 256u + ch;
-                return ch;
+                if constexpr (IsSigned<char>) {
+                    if (ch < 0)
+                        return 256u + ch;
+                    return ch;
+                }
             },
             [&](Utf32View const& view) -> u32 { return view[index]; },
             [&](Utf16View const& view) -> u32 { return view.code_point_at(index); },

--- a/Userland/Utilities/functrace.cpp
+++ b/Userland/Utilities/functrace.cpp
@@ -66,6 +66,11 @@ static void print_syscall(PtraceRegisters& regs, size_t depth)
         regs.rcx,
         regs.rbx,
         end_color);
+#elif ARCH(AARCH64)
+    (void)regs;
+    (void)begin_color;
+    (void)end_color;
+    TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif
@@ -145,6 +150,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         const FlatPtr ip = regs.value().eip;
 #elif ARCH(X86_64)
         const FlatPtr ip = regs.value().rip;
+#elif ARCH(AARCH64)
+        const FlatPtr ip = 0; // FIXME
+        TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -894,6 +894,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         syscall_arg_t arg1 = regs.rdx;
         syscall_arg_t arg2 = regs.rcx;
         syscall_arg_t arg3 = regs.rbx;
+#elif ARCH(AARCH64)
+        syscall_arg_t syscall_index = 0; // FIXME
+        syscall_arg_t arg1 = 0;          // FIXME
+        syscall_arg_t arg2 = 0;          // FIXME
+        syscall_arg_t arg3 = 0;          // FIXME
+        TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif
@@ -910,6 +916,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         u32 res = regs.eax;
 #elif ARCH(X86_64)
         u64 res = regs.rax;
+#elif ARCH(AARCH64)
+        u64 res = 0; // FIXME
+        TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif


### PR DESCRIPTION
**Toolchain: Fix building libgcc for AARCH64**

There was a typo in one of the spec files which resulted in us not building softfp support for libgcc. Additionally we were missing flags to build libgcc_s. This patch also makes sure we're not trying to link against crtbeginS.o and crtendS.o. This is part of a larger effort to at least get the userland to build at all.

**AK+Userland: Stub out code that isn't currently implemented on AARCH64**

Even though this almost certainly wouldn't run properly even if we had a working kernel for AARCH64 this at least lets us build all the userland binaries.

**AK+Userland: Make char and wchar_t behave on AARCH64**

By default char and wchar_t are unsigned on AARCH64. This fixes a bunch of related compiler errors.

**Kernel: Implement userspace support for syscalls on AARCH64**

There are no guarantees that the final syscall API will look like this but at least for now this lets us compile the userland binaries.

**AK: Stub out the NAKED macro on AARCH64**

This is almost certainly incorrect but we'll see about that once the kernel actually gets to userspace init.

**Tests+Userland: Prefer using __builtin_trap() instead of UD2**

This way we don't have to hard-code per-architecture instructions.

**Tests+Userland: Implement AARCH64 support for some inline assembly blobs**

**LibC: Fix some compiler errors**

__x86_64__ isn't defined at all on AARCH64.

**Everywhere: Enable building userspace and test binaries on AARCH64**

Surely this will just work once the kernel boots, right?