### PR TITLE
Kernel: Add StdLib.cpp and UserOrKernelBuffer.cpp to aarch64 build

### DIFF
--- a/Kernel/Arch/aarch64/Dummy.cpp
+++ b/Kernel/Arch/aarch64/Dummy.cpp
@@ -111,23 +111,6 @@ ErrorOr<size_t> Inode::write_bytes(off_t, size_t, UserOrKernelBuffer const&, Ope
 
 }
 
-// UserOrKernelBuffer.cpp
-namespace Kernel {
-
-ErrorOr<void> UserOrKernelBuffer::write(void const*, size_t, size_t)
-{
-    VERIFY_NOT_REACHED();
-    return {};
-}
-
-ErrorOr<void> UserOrKernelBuffer::read(void*, size_t, size_t) const
-{
-    VERIFY_NOT_REACHED();
-    return {};
-}
-
-}
-
 // x86 init
 
 multiboot_module_entry_t multiboot_copy_boot_modules_array[16];

--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -65,12 +65,6 @@ extern ctor_func_t end_ctors[];
 // FIXME: Share this with the Intel Prekernel.
 extern size_t __stack_chk_guard;
 size_t __stack_chk_guard;
-extern "C" [[noreturn]] void __stack_chk_fail();
-
-void __stack_chk_fail()
-{
-    Kernel::Processor::halt();
-}
 
 READONLY_AFTER_INIT bool g_in_early_boot;
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -485,7 +485,9 @@ else()
         KString.cpp
         KSyms.cpp
         MiniStdLib.cpp
+        StdLib.cpp
         UBSanitizer.cpp
+        UserOrKernelBuffer.cpp
 
         Devices/DeviceManagement.cpp
 


### PR DESCRIPTION
I've had this patch laying around for quite some time, so thought I just send it upstream.