### PR TITLE
LibWeb: Add missing property and methods for history object

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -126,6 +126,7 @@ public:
 
     Vector<SessionHistoryEntry>& session_history() { return m_session_history; }
     Vector<SessionHistoryEntry> const& session_history() const { return m_session_history; }
+    size_t session_history_index() const { return *m_session_history_index; }
 
     // https://html.spec.whatwg.org/multipage/dom.html#still-on-its-initial-about:blank-document
     bool still_on_its_initial_about_blank_document() const;

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -44,6 +44,66 @@ WebIDL::ExceptionOr<void> History::replace_state(JS::Value data, String const&, 
     return shared_history_push_replace_state(data, url, IsPush::No);
 }
 
+// https://html.spec.whatwg.org/multipage/history.html#dom-history-length
+WebIDL::ExceptionOr<u64> History::length() const
+{
+    // 1. If this's associated Document is not fully active, then throw a "SecurityError" DOMException.
+    if (!m_associated_document->is_fully_active())
+        return WebIDL::SecurityError::create(realm(), "Cannot perform length on a document that isn't fully active."sv);
+
+    // 2. Return the number of entries in the top-level browsing context's joint session history.
+    auto const* browsing_context = m_associated_document->browsing_context();
+
+    // FIXME: We don't have the concept of "joint session history", this is an ad-hoc implementation.
+    //        See: https://html.spec.whatwg.org/multipage/history.html#joint-session-history
+    return browsing_context->session_history().size();
+}
+
+// https://html.spec.whatwg.org/multipage/history.html#dom-history-go
+WebIDL::ExceptionOr<void> History::go(long delta = 0)
+{
+    // 1. Let document be this's associated Document.
+
+    // 2. If document is not fully active, then throw a "SecurityError" DOMException.
+    if (!m_associated_document->is_fully_active())
+        return WebIDL::SecurityError::create(realm(), "Cannot perform go on a document that isn't fully active."sv);
+
+    // 3. If delta is 0, then act as if the location.reload() method was called, and return.
+    auto* browsing_context = m_associated_document->browsing_context();
+    auto current_entry_index = browsing_context->session_history_index();
+    auto next_entry_index = current_entry_index + delta;
+    auto const& sessions = browsing_context->session_history();
+    if (next_entry_index < sessions.size()) {
+        auto const& next_entry = sessions.at(next_entry_index);
+        // FIXME: 4. Traverse the history by a delta with delta and document's browsing context.
+        browsing_context->loader().load(next_entry.url, FrameLoader::Type::Reload);
+    }
+
+    return {};
+}
+
+// https://html.spec.whatwg.org/multipage/history.html#dom-history-back
+WebIDL::ExceptionOr<void> History::back()
+{
+    // 1. Let document be this's associated Document.
+    // 2. If document is not fully active, then throw a "SecurityError" DOMException.
+    // NOTE: We already did this check in `go` method, so skip the fully active check here.
+
+    // 3. Traverse the history by a delta with −1 and document's browsing context.
+    return go(-1);
+}
+
+// https://html.spec.whatwg.org/multipage/history.html#dom-history-forward
+WebIDL::ExceptionOr<void> History::forward()
+{
+    // 1. Let document be this's associated Document.
+    // 2. If document is not fully active, then throw a "SecurityError" DOMException.
+    // NOTE: We already did this check in `go` method, so skip the fully active check here.
+
+    // 3. Traverse the history by a delta with +1 and document's browsing context.
+    return go(1);
+}
+
 // https://html.spec.whatwg.org/multipage/history.html#shared-history-push/replace-state-steps
 WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value, String const&, IsPush)
 {
@@ -51,7 +111,7 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value, 
 
     // 2. If document is not fully active, then throw a "SecurityError" DOMException.
     if (!m_associated_document->is_fully_active())
-        return WebIDL::SecurityError::create(realm(), "Cannot perform pushState or replaceState on a document that isn't fully active.");
+        return WebIDL::SecurityError::create(realm(), "Cannot perform pushState or replaceState on a document that isn't fully active."sv);
 
     // 3. Optionally, return. (For example, the user agent might disallow calls to these methods that are invoked on a timer,
     //    or from event listeners that are not triggered in response to a clear user action, or that are invoked in rapid succession.)

--- a/Userland/Libraries/LibWeb/HTML/History.h
+++ b/Userland/Libraries/LibWeb/HTML/History.h
@@ -22,6 +22,10 @@ public:
 
     WebIDL::ExceptionOr<void> push_state(JS::Value data, String const& unused, String const& url);
     WebIDL::ExceptionOr<void> replace_state(JS::Value data, String const& unused, String const& url);
+    WebIDL::ExceptionOr<void> go(long delta);
+    WebIDL::ExceptionOr<void> back();
+    WebIDL::ExceptionOr<void> forward();
+    WebIDL::ExceptionOr<u64> length() const;
 
 private:
     History(JS::Realm&, DOM::Document&);

--- a/Userland/Libraries/LibWeb/HTML/History.idl
+++ b/Userland/Libraries/LibWeb/HTML/History.idl
@@ -1,5 +1,12 @@
+// https://html.spec.whatwg.org/multipage/history.html#the-history-interface
 [Exposed=Window]
 interface History {
+    readonly attribute unsigned long length;
+    // FIXME: attribute ScrollRestoration scrollRestoration;
+    // FIXME: readonly attribute any state;
+    undefined go(optional long delta = 0);
+    undefined back();
+    undefined forward();
     undefined pushState(any data, DOMString unused, optional USVString? url = null);
     undefined replaceState(any data, DOMString unused, optional USVString? url = null);
 };


### PR DESCRIPTION
We provide `length` property and `go` / `back` / `forward` methods implementation here.