### PR TITLE
LibAudio: Port to `Core::Stream`

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
@@ -11,7 +11,7 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto flac_data = ByteBuffer::copy(data, size).release_value();
-    auto flac = make<Audio::FlacLoaderPlugin>(flac_data);
+    auto flac = make<Audio::FlacLoaderPlugin>(flac_data.bytes());
 
     if (flac->initialize().is_error())
         return 1;

--- a/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
@@ -11,7 +11,7 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto flac_data = ByteBuffer::copy(data, size).release_value();
-    auto mp3 = make<Audio::MP3LoaderPlugin>(flac_data);
+    auto mp3 = make<Audio::MP3LoaderPlugin>(flac_data.bytes());
 
     if (mp3->initialize().is_error())
         return 1;

--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Player.h"
+#include <LibCore/File.h>
 
 Player::Player(Audio::ConnectionToServer& audio_client_connection)
     : m_audio_client_connection(audio_client_connection)

--- a/Userland/Applications/SoundPlayer/Playlist.cpp
+++ b/Userland/Applications/SoundPlayer/Playlist.cpp
@@ -10,6 +10,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/Random.h>
 #include <LibAudio/Loader.h>
+#include <LibCore/File.h>
 #include <LibGUI/MessageBox.h>
 
 bool Playlist::load(StringView path)

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -26,21 +26,18 @@
 namespace Audio {
 
 FlacLoaderPlugin::FlacLoaderPlugin(StringView path)
-    : m_path(path)
+    : LoaderPlugin(path)
 {
 }
 
-FlacLoaderPlugin::FlacLoaderPlugin(Bytes& buffer)
-    : m_backing_memory(buffer)
+FlacLoaderPlugin::FlacLoaderPlugin(Bytes buffer)
+    : LoaderPlugin(buffer)
 {
 }
 
 MaybeLoaderError FlacLoaderPlugin::initialize()
 {
-    if (m_backing_memory.has_value())
-        m_stream = LOADER_TRY(Core::Stream::MemoryStream::construct(m_backing_memory.value()));
-    else
-        m_stream = LOADER_TRY(Core::Stream::File::open(m_path, Core::Stream::OpenMode::Read));
+    LOADER_TRY(LoaderPlugin::initialize());
 
     TRY(parse_header());
     TRY(reset());

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -26,33 +26,21 @@
 namespace Audio {
 
 FlacLoaderPlugin::FlacLoaderPlugin(StringView path)
-    : m_file(Core::File::construct(path))
+    : m_path(path)
 {
-    if (!m_file->open(Core::OpenMode::ReadOnly)) {
-        m_error = LoaderError { String::formatted("Can't open file: {}", m_file->error_string()) };
-        return;
-    }
-
-    auto maybe_stream = Core::Stream::BufferedFile::create(MUST(Core::Stream::File::open(path, Core::Stream::OpenMode::Read)), FLAC_BUFFER_SIZE);
-    if (maybe_stream.is_error())
-        m_error = LoaderError { "Can't open file stream" };
-    else
-        m_stream = maybe_stream.release_value();
 }
 
 FlacLoaderPlugin::FlacLoaderPlugin(Bytes& buffer)
+    : m_backing_memory(buffer)
 {
-    auto maybe_stream = Core::Stream::MemoryStream::construct(buffer);
-    if (maybe_stream.is_error())
-        m_error = LoaderError { "Can't open memory stream" };
-    else
-        m_stream = maybe_stream.release_value();
 }
 
 MaybeLoaderError FlacLoaderPlugin::initialize()
 {
-    if (m_error.has_value())
-        return m_error.release_value();
+    if (m_backing_memory.has_value())
+        m_stream = LOADER_TRY(Core::Stream::MemoryStream::construct(m_backing_memory.value()));
+    else
+        m_stream = LOADER_TRY(Core::Stream::File::open(m_path, Core::Stream::OpenMode::Read));
 
     TRY(parse_header());
     TRY(reset());

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -48,7 +48,7 @@ ALWAYS_INLINE ErrorOr<i32> decode_unsigned_exp_golomb(u8 order, BigEndianInputBi
 class FlacLoaderPlugin : public LoaderPlugin {
 public:
     explicit FlacLoaderPlugin(StringView path);
-    explicit FlacLoaderPlugin(Bytes& buffer);
+    explicit FlacLoaderPlugin(Bytes buffer);
     ~FlacLoaderPlugin()
     {
     }
@@ -95,8 +95,6 @@ private:
     ALWAYS_INLINE ErrorOr<u32, LoaderError> convert_sample_rate_code(u8 sample_rate_code);
     ALWAYS_INLINE ErrorOr<PcmSampleFormat, LoaderError> convert_bit_depth_code(u8 bit_depth_code);
 
-    StringView m_path;
-
     // Data obtained directly from the FLAC metadata: many values have specific bit counts
     u32 m_sample_rate { 0 };         // 20 bit
     u8 m_num_channels { 0 };         // 3 bit
@@ -113,8 +111,6 @@ private:
 
     // keep track of the start of the data in the FLAC stream to seek back more easily
     u64 m_data_start_location { 0 };
-    OwnPtr<Core::Stream::SeekableStream> m_stream;
-    Optional<Bytes> m_backing_memory;
     Optional<FlacFrameHeader> m_current_frame;
     // Whatever the last get_more_samples() call couldn't return gets stored here.
     Vector<Sample, FLAC_BUFFER_SIZE> m_unread_data;

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -95,8 +95,7 @@ private:
     ALWAYS_INLINE ErrorOr<u32, LoaderError> convert_sample_rate_code(u8 sample_rate_code);
     ALWAYS_INLINE ErrorOr<PcmSampleFormat, LoaderError> convert_bit_depth_code(u8 bit_depth_code);
 
-    RefPtr<Core::File> m_file;
-    Optional<LoaderError> m_error {};
+    StringView m_path;
 
     // Data obtained directly from the FLAC metadata: many values have specific bit counts
     u32 m_sample_rate { 0 };         // 20 bit
@@ -115,6 +114,7 @@ private:
     // keep track of the start of the data in the FLAC stream to seek back more easily
     u64 m_data_start_location { 0 };
     OwnPtr<Core::Stream::SeekableStream> m_stream;
+    Optional<Bytes> m_backing_memory;
     Optional<FlacFrameHeader> m_current_frame;
     // Whatever the last get_more_samples() call couldn't return gets stored here.
     Vector<Sample, FLAC_BUFFER_SIZE> m_unread_data;

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -66,7 +66,6 @@ public:
     virtual u16 num_channels() override { return m_num_channels; }
     virtual String format_name() override { return "FLAC (.flac)"; }
     virtual PcmSampleFormat pcm_format() override { return m_sample_format; }
-    virtual RefPtr<Core::File> file() override { return m_file; }
 
     bool is_fixed_blocksize_stream() const { return m_min_block_size == m_max_block_size; }
     bool sample_count_unknown() const { return m_total_samples == 0; }

--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -11,6 +11,26 @@
 
 namespace Audio {
 
+LoaderPlugin::LoaderPlugin(StringView path)
+    : m_path(path)
+{
+}
+
+LoaderPlugin::LoaderPlugin(Bytes buffer)
+    : m_backing_memory(buffer)
+{
+}
+
+MaybeLoaderError LoaderPlugin::initialize()
+{
+    if (m_backing_memory.has_value())
+        m_stream = LOADER_TRY(Core::Stream::MemoryStream::construct(m_backing_memory.value()));
+    else
+        m_stream = LOADER_TRY(Core::Stream::File::open(m_path, Core::Stream::OpenMode::Read));
+
+    return {};
+}
+
 Loader::Loader(NonnullOwnPtr<LoaderPlugin> plugin)
     : m_plugin(move(plugin))
 {

--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -44,6 +44,9 @@ Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::try_create(Bytes& buffe
     plugin = adopt_own(*new FlacLoaderPlugin(buffer));
     if (auto initstate = plugin->initialize(); !initstate.is_error())
         return plugin;
+    plugin = adopt_own(*new MP3LoaderPlugin(buffer));
+    if (auto initstate = plugin->initialize(); !initstate.is_error())
+        return plugin;
     return LoaderError { "No loader plugin available" };
 }
 

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -18,7 +18,6 @@
 #include <LibAudio/LoaderError.h>
 #include <LibAudio/Sample.h>
 #include <LibAudio/SampleFormats.h>
-#include <LibCore/File.h>
 
 namespace Audio {
 
@@ -54,7 +53,6 @@ public:
     // Human-readable name of the file format, of the form <full abbreviation> (.<ending>)
     virtual String format_name() = 0;
     virtual PcmSampleFormat pcm_format() = 0;
-    virtual RefPtr<Core::File> file() = 0;
 };
 
 class Loader : public RefCounted<Loader> {
@@ -73,7 +71,6 @@ public:
     u16 num_channels() const { return m_plugin->num_channels(); }
     String format_name() const { return m_plugin->format_name(); }
     u16 bits_per_sample() const { return pcm_bits_per_sample(m_plugin->pcm_format()); }
-    RefPtr<Core::File> file() const { return m_plugin->file(); }
 
 private:
     static Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> try_create(StringView path);

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -18,6 +18,7 @@
 #include <LibAudio/LoaderError.h>
 #include <LibAudio/Sample.h>
 #include <LibAudio/SampleFormats.h>
+#include <LibCore/Stream.h>
 
 namespace Audio {
 
@@ -28,6 +29,8 @@ using MaybeLoaderError = Result<void, LoaderError>;
 
 class LoaderPlugin {
 public:
+    explicit LoaderPlugin(StringView path);
+    explicit LoaderPlugin(Bytes buffer);
     virtual ~LoaderPlugin() = default;
 
     virtual MaybeLoaderError initialize() = 0;
@@ -53,6 +56,12 @@ public:
     // Human-readable name of the file format, of the form <full abbreviation> (.<ending>)
     virtual String format_name() = 0;
     virtual PcmSampleFormat pcm_format() = 0;
+
+protected:
+    StringView m_path;
+    OwnPtr<Core::Stream::SeekableStream> m_stream;
+    // The constructor might set this so that we can initialize the data stream later.
+    Optional<Bytes> m_backing_memory;
 };
 
 class Loader : public RefCounted<Loader> {

--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -20,7 +20,7 @@ MP3LoaderPlugin::MP3LoaderPlugin(StringView path)
 }
 
 MP3LoaderPlugin::MP3LoaderPlugin(Bytes buffer)
-    : m_backing_memory(buffer)
+    : LoaderPlugin(buffer)
 {
 }
 

--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -15,13 +15,19 @@ DSP::MDCT<12> MP3LoaderPlugin::s_mdct_12;
 DSP::MDCT<36> MP3LoaderPlugin::s_mdct_36;
 
 MP3LoaderPlugin::MP3LoaderPlugin(StringView path)
-    : m_path(path)
+    : LoaderPlugin(path)
+{
+}
+
+MP3LoaderPlugin::MP3LoaderPlugin(Bytes buffer)
+    : m_backing_memory(buffer)
 {
 }
 
 MaybeLoaderError MP3LoaderPlugin::initialize()
 {
-    m_stream = LOADER_TRY(Core::Stream::File::open(m_path, Core::Stream::OpenMode::Read));
+    LOADER_TRY(LoaderPlugin::initialize());
+
     m_bitstream = LOADER_TRY(Core::Stream::BigEndianInputBitStream::construct(*m_stream));
 
     TRY(synchronize());

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -11,6 +11,7 @@
 #include <AK/MemoryStream.h>
 #include <AK/Tuple.h>
 #include <LibCore/InputBitStream.h>
+#include <LibCore/MemoryStream.h>
 #include <LibCore/Stream.h>
 #include <LibDSP/MDCT.h>
 
@@ -23,6 +24,7 @@ struct ScaleFactorBand;
 class MP3LoaderPlugin : public LoaderPlugin {
 public:
     explicit MP3LoaderPlugin(StringView path);
+    explicit MP3LoaderPlugin(Bytes buffer);
     virtual ~MP3LoaderPlugin() = default;
 
     virtual MaybeLoaderError initialize() override;
@@ -72,6 +74,7 @@ private:
     u32 m_current_frame_read;
     StringView m_path;
     OwnPtr<Core::Stream::SeekableStream> m_stream;
+    Optional<Bytes const&> m_backing_memory;
     OwnPtr<Core::Stream::BigEndianInputBitStream> m_bitstream;
     DuplexMemoryStream m_bit_reservoir;
 };

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -72,9 +72,6 @@ private:
 
     AK::Optional<MP3::MP3Frame> m_current_frame;
     u32 m_current_frame_read;
-    StringView m_path;
-    OwnPtr<Core::Stream::SeekableStream> m_stream;
-    Optional<Bytes const&> m_backing_memory;
     OwnPtr<Core::Stream::BigEndianInputBitStream> m_bitstream;
     DuplexMemoryStream m_bit_reservoir;
 };

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -10,7 +10,8 @@
 #include "MP3Types.h"
 #include <AK/MemoryStream.h>
 #include <AK/Tuple.h>
-#include <LibCore/FileStream.h>
+#include <LibCore/InputBitStream.h>
+#include <LibCore/Stream.h>
 #include <LibDSP/MDCT.h>
 
 namespace Audio {
@@ -22,7 +23,7 @@ struct ScaleFactorBand;
 class MP3LoaderPlugin : public LoaderPlugin {
 public:
     explicit MP3LoaderPlugin(StringView path);
-    ~MP3LoaderPlugin();
+    virtual ~MP3LoaderPlugin() = default;
 
     virtual MaybeLoaderError initialize() override;
     virtual LoaderSamples get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB) override;
@@ -63,18 +64,16 @@ private:
     u32 m_sample_rate { 0 };
     u8 m_num_channels { 0 };
     PcmSampleFormat m_sample_format { PcmSampleFormat::Int16 };
-    size_t m_file_size { 0 };
     int m_total_samples { 0 };
     size_t m_loaded_samples { 0 };
     bool m_is_first_frame { true };
 
     AK::Optional<MP3::MP3Frame> m_current_frame;
     u32 m_current_frame_read;
-    RefPtr<Core::File> m_file;
-    OwnPtr<Core::InputFileStream> m_input_stream;
-    OwnPtr<InputBitStream> m_bitstream;
+    StringView m_path;
+    OwnPtr<Core::Stream::SeekableStream> m_stream;
+    OwnPtr<Core::Stream::BigEndianInputBitStream> m_bitstream;
     DuplexMemoryStream m_bit_reservoir;
-    Optional<LoaderError> m_error {};
 };
 
 }

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -35,7 +35,6 @@ public:
     virtual u32 sample_rate() override { return m_sample_rate; }
     virtual u16 num_channels() override { return m_num_channels; }
     virtual PcmSampleFormat pcm_format() override { return m_sample_format; }
-    virtual RefPtr<Core::File> file() override { return m_file; }
     virtual String format_name() override { return "MP3 (.mp3)"; }
 
 private:

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -19,7 +19,7 @@ namespace Audio {
 static constexpr size_t const maximum_wav_size = 1 * GiB; // FIXME: is there a more appropriate size limit?
 
 WavLoaderPlugin::WavLoaderPlugin(StringView path)
-    : m_file(Core::File::construct(path))
+    : m_path(path)
 {
 }
 
@@ -28,7 +28,7 @@ MaybeLoaderError WavLoaderPlugin::initialize()
     if (m_backing_memory.has_value())
         m_stream = LOADER_TRY(Core::Stream::MemoryStream::construct(m_backing_memory.value()));
     else
-        m_stream = LOADER_TRY(Core::Stream::File::open(m_file->filename(), Core::Stream::OpenMode::Read));
+        m_stream = LOADER_TRY(Core::Stream::File::open(m_path, Core::Stream::OpenMode::Read));
 
     TRY(parse_header());
     return {};

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -19,23 +19,20 @@ namespace Audio {
 static constexpr size_t const maximum_wav_size = 1 * GiB; // FIXME: is there a more appropriate size limit?
 
 WavLoaderPlugin::WavLoaderPlugin(StringView path)
-    : m_path(path)
+    : LoaderPlugin(path)
 {
 }
 
 MaybeLoaderError WavLoaderPlugin::initialize()
 {
-    if (m_backing_memory.has_value())
-        m_stream = LOADER_TRY(Core::Stream::MemoryStream::construct(m_backing_memory.value()));
-    else
-        m_stream = LOADER_TRY(Core::Stream::File::open(m_path, Core::Stream::OpenMode::Read));
+    LOADER_TRY(LoaderPlugin::initialize());
 
     TRY(parse_header());
     return {};
 }
 
-WavLoaderPlugin::WavLoaderPlugin(Bytes const& buffer)
-    : m_backing_memory(buffer)
+WavLoaderPlugin::WavLoaderPlugin(Bytes buffer)
+    : LoaderPlugin(buffer)
 {
 }
 

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -30,7 +30,7 @@ static constexpr unsigned const WAVE_FORMAT_EXTENSIBLE = 0xFFFE; // Determined b
 class WavLoaderPlugin : public LoaderPlugin {
 public:
     explicit WavLoaderPlugin(StringView path);
-    explicit WavLoaderPlugin(Bytes const& buffer);
+    explicit WavLoaderPlugin(Bytes buffer);
 
     virtual MaybeLoaderError initialize() override;
 
@@ -55,11 +55,6 @@ private:
     LoaderSamples samples_from_pcm_data(Bytes const& data, size_t samples_to_read) const;
     template<typename SampleReader>
     MaybeLoaderError read_samples_from_stream(Core::Stream::Stream& stream, SampleReader read_sample, FixedArray<Sample>& samples) const;
-
-    StringView m_path;
-    OwnPtr<Core::Stream::SeekableStream> m_stream;
-    // The constructor might set this so that we can initialize the data stream later.
-    Optional<Bytes const&> m_backing_memory;
 
     u32 m_sample_rate { 0 };
     u16 m_num_channels { 0 };

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -48,7 +48,6 @@ public:
     virtual u16 num_channels() override { return m_num_channels; }
     virtual String format_name() override { return "RIFF WAVE (.wav)"; }
     virtual PcmSampleFormat pcm_format() override { return m_sample_format; }
-    virtual RefPtr<Core::File> file() override { return m_file; }
 
 private:
     MaybeLoaderError parse_header();
@@ -57,8 +56,7 @@ private:
     template<typename SampleReader>
     MaybeLoaderError read_samples_from_stream(Core::Stream::Stream& stream, SampleReader read_sample, FixedArray<Sample>& samples) const;
 
-    // This is only kept around for compatibility for now.
-    RefPtr<Core::File> m_file;
+    StringView m_path;
     OwnPtr<Core::Stream::SeekableStream> m_stream;
     // The constructor might set this so that we can initialize the data stream later.
     Optional<Bytes const&> m_backing_memory;

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -11,6 +11,7 @@
 #include <LibAudio/Resampler.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 #include <math.h>


### PR DESCRIPTION
This will remove any usage of `Core::File` in LibAudio.

First, by deleting the plugin's method that return a `Core::File` object.
Both Wav and Flac plugins kept this only for compatibility.

Second, I ported the MP3 plugin that still used a `Core::File` object.

Finally, I factorized a common pattern, that arise from the common usage of `Core::Stream`, to the base class `LoaderPlugin`.