### PR TITLE
Toolchain: Add SerenityOS to the LLVM config.guess

### DIFF
--- a/Toolchain/Patches/llvm/0010-Add-SerenityOS-to-config.guess.patch
+++ b/Toolchain/Patches/llvm/0010-Add-SerenityOS-to-config.guess.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Wed, 10 Nov 2021 03:29:21 +0100
+Subject: [PATCH] Add SerenityOS to config.guess
+
+---
+ llvm/cmake/config.guess | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/llvm/cmake/config.guess b/llvm/cmake/config.guess
+index 60d3f588d6f7e8b341b47b7b379a6b5be299b4b6..bdbd1e323d95a73307cf7f8188ca3c419cd8c0e8 100644
+--- a/llvm/cmake/config.guess
++++ b/llvm/cmake/config.guess
+@@ -816,6 +816,9 @@ EOF
+     i*:PW*:*)
+ 	echo ${UNAME_MACHINE}-pc-pw32
+ 	exit ;;
++    *:SerenityOS:*:*)
++	echo ${UNAME_MACHINE}-pc-serenity
++	exit ;;
+     *:Interix*:*)
+ 	case ${UNAME_MACHINE} in
+ 	    x86)

--- a/Toolchain/Patches/llvm/ReadMe.md
+++ b/Toolchain/Patches/llvm/ReadMe.md
@@ -81,3 +81,8 @@ enough to linux to use the pre-canned InstrProfiling implementation.
 Curiously, enabling profiling for the SerenityOS target changes the ELF
 OS ABI for userspace binaries to 3, or GNU/Linux.
 
+## `0010-Add-SerenityOS-to-config.guess.patch`
+
+Add SerenityOS to config.guess
+
+


### PR DESCRIPTION
LLVM hasn't updated their `config.guess` since 2011, so we'll just have to add this manually until we get around to upstreaming our patches to LLVM.