### PR TITLE
PixelPaint: Make Alt-Clicking with all tool act like the PickerTool

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -118,6 +118,8 @@ public:
 
     Core::EventLoop& gui_event_loop() { return m_gui_event_loop; }
 
+    void set_editor_color_to_color_at_mouse_position(GUI::MouseEvent const& event, bool sample_all_layers);
+
 private:
     explicit ImageEditor(NonnullRefPtr<Image>);
 

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.h
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.h
@@ -18,6 +18,8 @@ public:
     virtual GUI::Widget* get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
 
+    virtual bool is_overriding_alt() override { return true; }
+
 protected:
     virtual void draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point) override;
     virtual void draw_line(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& start, Gfx::IntPoint const& end) override;

--- a/Userland/Applications/PixelPaint/Tools/LineTool.h
+++ b/Userland/Applications/PixelPaint/Tools/LineTool.h
@@ -28,6 +28,8 @@ public:
 
     void draw_using(GUI::Painter&, Gfx::IntPoint const& start_position, Gfx::IntPoint const& end_position, Color color, int thickness);
 
+    virtual bool is_overriding_alt() override { return true; }
+
 private:
     virtual StringView tool_name() const override { return "Line Tool"sv; }
 

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
@@ -16,25 +16,10 @@ namespace PixelPaint {
 
 void PickerTool::on_mousedown(Layer* layer, MouseEvent& event)
 {
-    auto& position = event.layer_event().position();
-
-    Color color;
-    if (m_sample_all_layers) {
-        color = m_editor->image().color_at(position);
-    } else {
-        if (!layer || !layer->rect().contains(position))
-            return;
-        color = layer->currently_edited_bitmap().get_pixel(position);
-    }
-
-    // We picked a transparent pixel, do nothing.
-    if (!color.alpha())
+    if (!layer)
         return;
-
-    if (event.layer_event().button() == GUI::MouseButton::Primary)
-        m_editor->set_primary_color(color);
-    else if (event.layer_event().button() == GUI::MouseButton::Secondary)
-        m_editor->set_secondary_color(color);
+    auto layer_event = event.layer_event();
+    m_editor->set_editor_color_to_color_at_mouse_position(layer_event, m_sample_all_layers);
 }
 
 GUI::Widget* PickerTool::get_properties_widget()

--- a/Userland/Applications/PixelPaint/Tools/Tool.h
+++ b/Userland/Applications/PixelPaint/Tools/Tool.h
@@ -77,6 +77,9 @@ public:
 
     virtual StringView tool_name() const = 0;
 
+    // We only set the override_alt_key flag to true since the override is false by default. If false is desired do not call method.
+    virtual bool is_overriding_alt() { return false; };
+
 protected:
     Tool() = default;
     WeakPtr<ImageEditor> m_editor;


### PR DESCRIPTION
Refactored PickerTool functionality to the ImageEditor level and added a flag to Tool Base Class to allow for tools to override Alt+Click ColorPicker functionality