### PR TITLE
LibAudio: Fix two PCM rescaling errors

### DIFF
--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -72,10 +72,13 @@ static ErrorOr<double> read_sample_int24(Core::Stream::Stream& stream)
     i32 sample3 = byte;
 
     i32 value = 0;
-    value = sample1 << 8;
-    value |= sample2 << 16;
-    value |= sample3 << 24;
-    return static_cast<double>(value) / static_cast<double>((1 << 24) - 1);
+    value = sample1;
+    value |= sample2 << 8;
+    value |= sample3 << 16;
+    // Sign extend the value, as it can currently not have the correct sign.
+    value = (value << 8) >> 8;
+    // Range of value is now -2^23 to 2^23-1 and we can rescale normally.
+    return static_cast<double>(value) / static_cast<double>((1 << 23) - 1);
 }
 
 template<typename T>


### PR DESCRIPTION
Both 8 bit and 24 bit PCM rescaling should now be correct, at least my ears tell me so.

### LibAudio: Correctly rescale 8-bit PCM samples

8-bit PCM samples are unsigned, at least in WAV, so after rescaling them
to the correct range we also need to center them around 0. This fix
should make 8-bit WAVs have the correct volume of double of what it was
before, and also future-proof for all other unsigned PCM sample formats
we may encounter.

### LibAudio: Fix 24-bit PCM rescaling

This code was so totally wrong I can't even explain it.