### PR TITLE
PixelPaint: Unveil clipboard using the right path

### DIFF
--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/portal/clipboard", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/clipboard", "rw"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/image", "rw"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));


### PR DESCRIPTION
Commit #3197c17 introduced a session based clipboard portal. This made pixel-paint fail to launch, because it had an unveil that used the old path to the clipboard. This commit fixes that and now unveils the new session based clipboard portal.