### PR TITLE
LibJS: Consolidate sources of system time zone to one location in Date

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -11,10 +11,15 @@
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Temporal/ISO8601.h>
 #include <LibTimeZone/TimeZone.h>
 #include <time.h>
 
 namespace JS {
+
+static Crypto::SignedBigInteger const s_one_billion_bigint { 1'000'000'000 };
+static Crypto::SignedBigInteger const s_one_million_bigint { 1'000'000 };
+static Crypto::SignedBigInteger const s_one_thousand_bigint { 1'000 };
 
 Date* Date::create(Realm& realm, double date_value)
 {
@@ -265,6 +270,7 @@ u8 week_day(double t)
 }
 
 // 21.4.1.7 LocalTZA ( t, isUTC ), https://tc39.es/ecma262/#sec-local-time-zone-adjustment
+// FIXME: Remove this when ECMA-402 is synced with https://github.com/tc39/ecma262/commit/43fd5f25357333d8340bfb486b8f0738e6d0d0cb.
 double local_tza(double time, [[maybe_unused]] bool is_utc, Optional<StringView> time_zone_override)
 {
     // The time_zone_override parameter is non-standard, but allows callers to override the system
@@ -285,21 +291,160 @@ double local_tza(double time, [[maybe_unused]] bool is_utc, Optional<StringView>
     return maybe_offset.has_value() ? static_cast<double>(maybe_offset->seconds) * 1000 : 0;
 }
 
-// 21.4.1.8 LocalTime ( t ), https://tc39.es/ecma262/#sec-localtime
+// 21.4.1.7 GetUTCEpochNanoseconds ( year, month, day, hour, minute, second, millisecond, microsecond, nanosecond ), https://tc39.es/ecma262/#sec-getutcepochnanoseconds
+Crypto::SignedBigInteger get_utc_epoch_nanoseconds(i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond)
+{
+    // 1. Let date be MakeDay(𝔽(year), 𝔽(month - 1), 𝔽(day)).
+    auto date = make_day(year, month - 1, day);
+
+    // 2. Let time be MakeTime(𝔽(hour), 𝔽(minute), 𝔽(second), 𝔽(millisecond)).
+    auto time = make_time(hour, minute, second, millisecond);
+
+    // 3. Let ms be MakeDate(date, time).
+    auto ms = make_date(date, time);
+
+    // 4. Assert: ms is an integral Number.
+    VERIFY(ms == trunc(ms));
+
+    // 5. Return ℤ(ℝ(ms) × 10^6 + microsecond × 10^3 + nanosecond).
+    auto result = Crypto::SignedBigInteger { ms }.multiplied_by(s_one_million_bigint);
+    result = result.plus(Crypto::SignedBigInteger { static_cast<i32>(microsecond) }.multiplied_by(s_one_thousand_bigint));
+    result = result.plus(Crypto::SignedBigInteger { static_cast<i32>(nanosecond) });
+    return result;
+}
+
+static i64 clip_bigint_to_sane_time(Crypto::SignedBigInteger const& value)
+{
+    static Crypto::SignedBigInteger const min_bigint { NumericLimits<i64>::min() };
+    static Crypto::SignedBigInteger const max_bigint { NumericLimits<i64>::max() };
+
+    // The provided epoch (nano)seconds value is potentially out of range for AK::Time and subsequently
+    // get_time_zone_offset(). We can safely assume that the TZDB has no useful information that far
+    // into the past and future anyway, so clamp it to the i64 range.
+    if (value < min_bigint)
+        return NumericLimits<i64>::min();
+    if (value > max_bigint)
+        return NumericLimits<i64>::max();
+
+    // FIXME: Can we do this without string conversion?
+    return value.to_base(10).to_int<i64>().value();
+}
+
+// 21.4.1.8 GetNamedTimeZoneEpochNanoseconds ( timeZoneIdentifier, year, month, day, hour, minute, second, millisecond, microsecond, nanosecond ), https://tc39.es/ecma262/#sec-getnamedtimezoneepochnanoseconds
+Vector<Crypto::SignedBigInteger> get_named_time_zone_epoch_nanoseconds(StringView time_zone_identifier, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond)
+{
+    auto local_nanoseconds = get_utc_epoch_nanoseconds(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    auto local_time = Time::from_nanoseconds(clip_bigint_to_sane_time(local_nanoseconds));
+
+    // FIXME: LibTimeZone does not behave exactly as the spec expects. It does not consider repeated or skipped time points.
+    auto offset = TimeZone::get_time_zone_offset(time_zone_identifier, local_time);
+
+    // Can only fail if the time zone identifier is invalid, which cannot be the case here.
+    VERIFY(offset.has_value());
+
+    return { local_nanoseconds.plus(Crypto::SignedBigInteger { offset->seconds }.multiplied_by(s_one_billion_bigint)) };
+}
+
+// 21.4.1.9 GetNamedTimeZoneOffsetNanoseconds ( timeZoneIdentifier, epochNanoseconds ), https://tc39.es/ecma262/#sec-getnamedtimezoneoffsetnanoseconds
+i64 get_named_time_zone_offset_nanoseconds(StringView time_zone_identifier, Crypto::SignedBigInteger const& epoch_nanoseconds)
+{
+    // Only called with validated time zone identifier as argument.
+    auto time_zone = TimeZone::time_zone_from_string(time_zone_identifier);
+    VERIFY(time_zone.has_value());
+
+    // Since Time::from_seconds() and Time::from_nanoseconds() both take an i64, converting to
+    // seconds first gives us a greater range. The TZDB doesn't have sub-second offsets.
+    auto seconds = epoch_nanoseconds.divided_by(s_one_billion_bigint).quotient;
+    auto time = Time::from_seconds(clip_bigint_to_sane_time(seconds));
+
+    auto offset = TimeZone::get_time_zone_offset(*time_zone, time);
+    VERIFY(offset.has_value());
+
+    return offset->seconds * 1'000'000'000;
+}
+
+// 21.4.1.10 DefaultTimeZone ( ), https://tc39.es/ecma262/#sec-defaulttimezone
+StringView default_time_zone()
+{
+    return TimeZone::current_time_zone();
+}
+
+// 21.4.1.11 LocalTime ( t ), https://tc39.es/ecma262/#sec-localtime
 double local_time(double time)
 {
-    // 1. Return t + LocalTZA(t, true).
-    return time + local_tza(time, true);
+    // 1. Let localTimeZone be DefaultTimeZone().
+    auto local_time_zone = default_time_zone();
+
+    double offset_nanoseconds { 0 };
+
+    // 2. If IsTimeZoneOffsetString(localTimeZone) is true, then
+    if (is_time_zone_offset_string(local_time_zone)) {
+        // a. Let offsetNs be ParseTimeZoneOffsetString(localTimeZone).
+        offset_nanoseconds = parse_time_zone_offset_string(local_time_zone);
+    }
+    // 3. Else,
+    else {
+        // a. Let offsetNs be GetNamedTimeZoneOffsetNanoseconds(localTimeZone, ℤ(ℝ(t) × 10^6)).
+        auto time_bigint = Crypto::SignedBigInteger { time }.multiplied_by(s_one_million_bigint);
+        offset_nanoseconds = get_named_time_zone_offset_nanoseconds(local_time_zone, time_bigint);
+    }
+
+    // 4. Let offsetMs be truncate(offsetNs / 10^6).
+    auto offset_milliseconds = trunc(offset_nanoseconds / 1e6);
+
+    // 5. Return t + 𝔽(offsetMs).
+    return time + offset_milliseconds;
 }
 
-// 21.4.1.9 UTC ( t ), https://tc39.es/ecma262/#sec-utc-t
+// 21.4.1.12 UTC ( t ), https://tc39.es/ecma262/#sec-utc-t
 double utc_time(double time)
 {
-    // 1. Return t - LocalTZA(t, false).
-    return time - local_tza(time, false);
+    // 1. Let localTimeZone be DefaultTimeZone().
+    auto local_time_zone = default_time_zone();
+
+    double offset_nanoseconds { 0 };
+
+    // 2. If IsTimeZoneOffsetString(localTimeZone) is true, then
+    if (is_time_zone_offset_string(local_time_zone)) {
+        // a. Let offsetNs be ParseTimeZoneOffsetString(localTimeZone).
+        offset_nanoseconds = parse_time_zone_offset_string(local_time_zone);
+    }
+    // 3. Else,
+    else {
+        // a. Let possibleInstants be GetNamedTimeZoneEpochNanoseconds(localTimeZone, ℝ(YearFromTime(t)), ℝ(MonthFromTime(t)) + 1, ℝ(DateFromTime(t)), ℝ(HourFromTime(t)), ℝ(MinFromTime(t)), ℝ(SecFromTime(t)), ℝ(msFromTime(t)), 0, 0).
+        auto possible_instants = get_named_time_zone_epoch_nanoseconds(local_time_zone, year_from_time(time), month_from_time(time) + 1, date_from_time(time), hour_from_time(time), min_from_time(time), sec_from_time(time), ms_from_time(time), 0, 0);
+
+        // b. NOTE: The following steps ensure that when t represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), t is interpreted using the time zone offset before the transition.
+        Crypto::SignedBigInteger disambiguated_instant;
+
+        // c. If possibleInstants is not empty, then
+        if (!possible_instants.is_empty()) {
+            // i. Let disambiguatedInstant be possibleInstants[0].
+            disambiguated_instant = move(possible_instants.first());
+        }
+        // d. Else,
+        else {
+            // i. NOTE: t represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
+            // ii. Let possibleInstantsBefore be GetNamedTimeZoneEpochNanoseconds(localTimeZone, ℝ(YearFromTime(tBefore)), ℝ(MonthFromTime(tBefore)) + 1, ℝ(DateFromTime(tBefore)), ℝ(HourFromTime(tBefore)), ℝ(MinFromTime(tBefore)), ℝ(SecFromTime(tBefore)), ℝ(msFromTime(tBefore)), 0, 0), where tBefore is the largest integral Number < t for which possibleInstantsBefore is not empty (i.e., tBefore represents the last local time before the transition).
+            // iii. Let disambiguatedInstant be the last element of possibleInstantsBefore.
+
+            // FIXME: This branch currently cannot be reached with our implementation, because LibTimeZone does not handle skipped time points.
+            //        When GetNamedTimeZoneEpochNanoseconds is updated to use a LibTimeZone API which does handle them, implement these steps.
+            VERIFY_NOT_REACHED();
+        }
+
+        // e. Let offsetNs be GetNamedTimeZoneOffsetNanoseconds(localTimeZone, disambiguatedInstant).
+        offset_nanoseconds = get_named_time_zone_offset_nanoseconds(local_time_zone, disambiguated_instant);
+    }
+
+    // 4. Let offsetMs be truncate(offsetNs / 10^6).
+    auto offset_milliseconds = trunc(offset_nanoseconds / 1e6);
+
+    // 5. Return t - 𝔽(offsetMs).
+    return time - offset_milliseconds;
 }
 
-// 21.4.1.11 MakeTime ( hour, min, sec, ms ), https://tc39.es/ecma262/#sec-maketime
+// 21.4.1.14 MakeTime ( hour, min, sec, ms ), https://tc39.es/ecma262/#sec-maketime
 double make_time(double hour, double min, double sec, double ms)
 {
     // 1. If hour is not finite or min is not finite or sec is not finite or ms is not finite, return NaN.
@@ -334,7 +479,7 @@ double time_within_day(double time)
     return modulo(time, ms_per_day);
 }
 
-// 21.4.1.12 MakeDay ( year, month, date ), https://tc39.es/ecma262/#sec-makeday
+// 21.4.1.15 MakeDay ( year, month, date ), https://tc39.es/ecma262/#sec-makeday
 double make_day(double year, double month, double date)
 {
     // 1. If year is not finite or month is not finite or date is not finite, return NaN.
@@ -367,7 +512,7 @@ double make_day(double year, double month, double date)
     return day(static_cast<double>(t)) + dt - 1;
 }
 
-// 21.4.1.13 MakeDate ( day, time ), https://tc39.es/ecma262/#sec-makedate
+// 21.4.1.16 MakeDate ( day, time ), https://tc39.es/ecma262/#sec-makedate
 double make_date(double day, double time)
 {
     // 1. If day is not finite or time is not finite, return NaN.
@@ -385,7 +530,7 @@ double make_date(double day, double time)
     return tv;
 }
 
-// 21.4.1.14 TimeClip ( time ), https://tc39.es/ecma262/#sec-timeclip
+// 21.4.1.17 TimeClip ( time ), https://tc39.es/ecma262/#sec-timeclip
 double time_clip(double time)
 {
     // 1. If time is not finite, return NaN.
@@ -398,6 +543,113 @@ double time_clip(double time)
 
     // 3. Return 𝔽(! ToIntegerOrInfinity(time)).
     return to_integer_or_infinity(time);
+}
+
+// 21.4.1.19.1 IsTimeZoneOffsetString ( offsetString ), https://tc39.es/ecma262/#sec-istimezoneoffsetstring
+bool is_time_zone_offset_string(StringView offset_string)
+{
+    // 1. Let parseResult be ParseText(StringToCodePoints(offsetString), UTCOffset).
+    auto parse_result = Temporal::parse_iso8601(Temporal::Production::TimeZoneNumericUTCOffset, offset_string);
+
+    // 2. If parseResult is a List of errors, return false.
+    // 3. Return true.
+    return parse_result.has_value();
+}
+
+// 21.4.1.19.2 ParseTimeZoneOffsetString ( offsetString ), https://tc39.es/ecma262/#sec-parsetimezoneoffsetstring
+double parse_time_zone_offset_string(StringView offset_string)
+{
+    // 1. Let parseResult be ParseText(StringToCodePoints(offsetString), UTCOffset).
+    auto parse_result = Temporal::parse_iso8601(Temporal::Production::TimeZoneNumericUTCOffset, offset_string);
+
+    // 2. Assert: parseResult is not a List of errors.
+    VERIFY(parse_result.has_value());
+
+    // 3. Assert: parseResult contains a TemporalSign Parse Node.
+    VERIFY(parse_result->time_zone_utc_offset_sign.has_value());
+
+    // 4. Let parsedSign be the source text matched by the TemporalSign Parse Node contained within parseResult.
+    auto parsed_sign = *parse_result->time_zone_utc_offset_sign;
+    i8 sign { 0 };
+
+    // 5. If parsedSign is the single code point U+002D (HYPHEN-MINUS) or U+2212 (MINUS SIGN), then
+    if (parsed_sign.is_one_of("-"sv, "\xE2\x88\x92"sv)) {
+        // a. Let sign be -1.
+        sign = -1;
+    }
+    // 6. Else,
+    else {
+        // a. Let sign be 1.
+        sign = 1;
+    }
+
+    // 7. NOTE: Applications of StringToNumber below do not lose precision, since each of the parsed values is guaranteed to be a sufficiently short string of decimal digits.
+
+    // 8. Assert: parseResult contains an Hour Parse Node.
+    VERIFY(parse_result->time_zone_utc_offset_hour.has_value());
+
+    // 9. Let parsedHours be the source text matched by the Hour Parse Node contained within parseResult.
+    auto parsed_hours = *parse_result->time_zone_utc_offset_hour;
+
+    // 10. Let hours be ℝ(StringToNumber(CodePointsToString(parsedHours))).
+    auto hours = string_to_number(parsed_hours)->as_double();
+
+    double minutes { 0 };
+    double seconds { 0 };
+    double nanoseconds { 0 };
+
+    // 11. If parseResult does not contain a MinuteSecond Parse Node, then
+    if (!parse_result->time_zone_utc_offset_minute.has_value()) {
+        // a. Let minutes be 0.
+        minutes = 0;
+    }
+    // 12. Else,
+    else {
+        // a. Let parsedMinutes be the source text matched by the first MinuteSecond Parse Node contained within parseResult.
+        auto parsed_minutes = *parse_result->time_zone_utc_offset_minute;
+
+        // b. Let minutes be ℝ(StringToNumber(CodePointsToString(parsedMinutes))).
+        minutes = string_to_number(parsed_minutes)->as_double();
+    }
+
+    // 13. If parseResult does not contain two MinuteSecond Parse Nodes, then
+    if (!parse_result->time_zone_utc_offset_second.has_value()) {
+        // a. Let seconds be 0.
+        seconds = 0;
+    }
+    // 14. Else,
+    else {
+        // a. Let parsedSeconds be the source text matched by the second secondSecond Parse Node contained within parseResult.
+        auto parsed_seconds = *parse_result->time_zone_utc_offset_second;
+
+        // b. Let seconds be ℝ(StringToNumber(CodePointsToString(parsedSeconds))).
+        seconds = string_to_number(parsed_seconds)->as_double();
+    }
+
+    // 15. If parseResult does not contain a TemporalDecimalFraction Parse Node, then
+    if (!parse_result->time_zone_utc_offset_fraction.has_value()) {
+        // a. Let nanoseconds be 0.
+        nanoseconds = 0;
+    }
+    // 16. Else,
+    else {
+        // a. Let parsedFraction be the source text matched by the TemporalDecimalFraction Parse Node contained within parseResult.
+        auto parsed_fraction = *parse_result->time_zone_utc_offset_fraction;
+
+        // b. Let fraction be the string-concatenation of CodePointsToString(parsedFraction) and "000000000".
+        auto fraction = String::formatted("{}000000000", parsed_fraction);
+
+        // c. Let nanosecondsString be the substring of fraction from 1 to 10.
+        auto nanoseconds_string = fraction.substring_view(1, 9);
+
+        // d. Let nanoseconds be ℝ(StringToNumber(nanosecondsString)).
+        nanoseconds = string_to_number(nanoseconds_string)->as_double();
+    }
+
+    // 17. Return sign × (((hours × 60 + minutes) × 60 + seconds) × 10^9 + nanoseconds).
+    // NOTE: Using scientific notation (1e9) ensures the result of this expression is a double,
+    //       which is important - otherwise it's all integers and the result overflows!
+    return sign * (((hours * 60 + minutes) * 60 + seconds) * 1e9 + nanoseconds);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Date.h
+++ b/Userland/Libraries/LibJS/Runtime/Date.h
@@ -63,6 +63,10 @@ u8 sec_from_time(double);
 u16 ms_from_time(double);
 u8 week_day(double);
 double local_tza(double time, bool is_utc, Optional<StringView> time_zone_override = {});
+Crypto::SignedBigInteger get_utc_epoch_nanoseconds(i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond);
+Vector<Crypto::SignedBigInteger> get_named_time_zone_epoch_nanoseconds(StringView time_zone_identifier, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond);
+i64 get_named_time_zone_offset_nanoseconds(StringView time_zone_identifier, Crypto::SignedBigInteger const& epoch_nanoseconds);
+StringView default_time_zone();
 double local_time(double time);
 double utc_time(double time);
 double day(double);
@@ -71,5 +75,7 @@ double make_time(double hour, double min, double sec, double ms);
 double make_day(double year, double month, double date);
 double make_date(double day, double time);
 double time_clip(double time);
+bool is_time_zone_offset_string(StringView offset_string);
+double parse_time_zone_offset_string(StringView offset_string);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -6,6 +6,7 @@
 
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Intl/DateTimeFormat.h>
@@ -216,7 +217,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
     // 30. If timeZone is undefined, then
     if (time_zone_value.is_undefined()) {
         // a. Set timeZone to ! DefaultTimeZone().
-        time_zone = Temporal::default_time_zone();
+        time_zone = default_time_zone();
     }
     // 31. Else,
     else {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -381,7 +381,7 @@ ThrowCompletionOr<SecondsStringPrecision> to_seconds_string_precision(VM& vm, Ob
     if (fractional_digits_value.is_nan() || fractional_digits_value.is_infinity())
         return vm.template throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, fractional_digits_value, "fractionalSecondDigits"sv);
 
-    // 12. Let fractionalDigitCount be RoundTowardsZero(ℝ(fractionalDigitsVal)).
+    // 12. Let fractionalDigitCount be truncate(ℝ(fractionalDigitsVal)).
     auto fractional_digit_count_unchecked = trunc(fractional_digits_value.as_double());
 
     // 13. If fractionalDigitCount < 0 or fractionalDigitCount > 9, throw a RangeError exception.

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
@@ -1582,19 +1582,19 @@ String temporal_duration_to_string(double years, double months, double weeks, do
     // 1. Let sign be ! DurationSign(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds).
     auto sign = duration_sign(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
 
-    // 2. Set microseconds to microseconds + RoundTowardsZero(nanoseconds / 1000).
+    // 2. Set microseconds to microseconds + truncate(nanoseconds / 1000).
     microseconds += trunc(nanoseconds / 1000);
 
     // 3. Set nanoseconds to remainder(nanoseconds, 1000).
     nanoseconds = fmod(nanoseconds, 1000);
 
-    // 4. Set milliseconds to milliseconds + RoundTowardsZero(microseconds / 1000).
+    // 4. Set milliseconds to milliseconds + truncate(microseconds / 1000).
     milliseconds += trunc(microseconds / 1000);
 
     // 5. Set microseconds to remainder(microseconds, 1000).
     microseconds = fmod(microseconds, 1000);
 
-    // 6. Set seconds to seconds + RoundTowardsZero(milliseconds / 1000).
+    // 6. Set seconds to seconds + truncate(milliseconds / 1000).
     seconds += trunc(milliseconds / 1000);
 
     // 7. Set milliseconds to remainder(milliseconds, 1000).

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.cpp
@@ -125,8 +125,12 @@ ThrowCompletionOr<BigInt*> parse_temporal_instant(VM& vm, String const& iso_stri
     // 5. Let utc be GetUTCEpochNanoseconds(result.[[Year]], result.[[Month]], result.[[Day]], result.[[Hour]], result.[[Minute]], result.[[Second]], result.[[Millisecond]], result.[[Microsecond]], result.[[Nanosecond]]).
     auto utc = get_utc_epoch_nanoseconds(result.year, result.month, result.day, result.hour, result.minute, result.second, result.millisecond, result.microsecond, result.nanosecond);
 
-    // 6. Let offsetNanoseconds be ? ParseTimeZoneOffsetString(offsetString).
-    auto offset_nanoseconds = TRY(parse_time_zone_offset_string(vm, *offset_string));
+    // 6. If IsTimeZoneOffsetString(offsetString) is false, throw a RangeError exception.
+    if (!is_time_zone_offset_string(*offset_string))
+        return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidTimeZoneName, *offset_string);
+
+    // 7. Let offsetNanoseconds be ParseTimeZoneOffsetString(offsetString).
+    auto offset_nanoseconds = parse_time_zone_offset_string(*offset_string);
 
     // 7. Let result be utc - ℤ(offsetNanoseconds).
     auto result_ns = utc.minus(Crypto::SignedBigInteger { offset_nanoseconds });

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
@@ -42,6 +42,7 @@ static auto const ns_max_instant = "8640000000000000000000"_sbigint;
 static auto const ns_min_instant = "-8640000000000000000000"_sbigint;
 
 bool is_valid_epoch_nanoseconds(BigInt const& epoch_nanoseconds);
+bool is_valid_epoch_nanoseconds(Crypto::SignedBigInteger const& epoch_nanoseconds);
 ThrowCompletionOr<Instant*> create_temporal_instant(VM&, BigInt const& nanoseconds, FunctionObject const* new_target = nullptr);
 ThrowCompletionOr<Instant*> to_temporal_instant(VM&, Value item);
 ThrowCompletionOr<BigInt*> parse_temporal_instant(VM&, String const& iso_string);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
@@ -63,7 +63,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::epoch_seconds_getter)
     // 3. Let ns be instant.[[Nanoseconds]].
     auto& ns = instant->nanoseconds();
 
-    // 4. Let s be RoundTowardsZero(ℝ(ns) / 10^9).
+    // 4. Let s be truncate(ℝ(ns) / 10^9).
     auto [s, _] = ns.big_integer().divided_by(Crypto::UnsignedBigInteger { 1'000'000'000 });
 
     // 5. Return 𝔽(s).
@@ -80,7 +80,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::epoch_milliseconds_getter)
     // 3. Let ns be instant.[[Nanoseconds]].
     auto& ns = instant->nanoseconds();
 
-    // 4. Let ms be RoundTowardsZero(ℝ(ns) / 10^6).
+    // 4. Let ms be truncate(ℝ(ns) / 10^6).
     auto [ms, _] = ns.big_integer().divided_by(Crypto::UnsignedBigInteger { 1'000'000 });
 
     // 5. Return 𝔽(ms).
@@ -97,7 +97,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::epoch_microseconds_getter)
     // 3. Let ns be instant.[[Nanoseconds]].
     auto& ns = instant->nanoseconds();
 
-    // 4. Let µs be RoundTowardsZero(ℝ(ns) / 10^3).
+    // 4. Let µs be truncate(ℝ(ns) / 10^3).
     auto [us, _] = ns.big_integer().divided_by(Crypto::UnsignedBigInteger { 1'000 });
 
     // 5. Return ℤ(µs).

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
@@ -7,6 +7,7 @@
 #include <AK/Time.h>
 #include <LibCrypto/BigInt/SignedBigInteger.h>
 #include <LibJS/Runtime/Completion.h>
+#include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>
 #include <LibJS/Runtime/Temporal/Instant.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
@@ -295,7 +295,7 @@ DateDurationRecord difference_iso_date(VM& vm, i32 year1, u8 month1, u8 day1, i3
 
         // h. If largestUnit is "week", then
         if (largest_unit == "week"sv) {
-            // i. Set weeks to RoundTowardsZero(days / 7).
+            // i. Set weeks to truncate(days / 7).
             weeks = trunc(days / 7);
 
             // ii. Set days to remainder(days, 7).

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
@@ -62,7 +62,7 @@ ThrowCompletionOr<PlainDate*> create_temporal_date(VM& vm, i32 iso_year, u8 iso_
         return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidPlainDate);
 
     // 6. If ISODateTimeWithinLimits(isoYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0) is false, throw a RangeError exception.
-    if (!iso_date_time_within_limits(vm, iso_year, iso_month, iso_day, 12, 0, 0, 0, 0, 0))
+    if (!iso_date_time_within_limits(iso_year, iso_month, iso_day, 12, 0, 0, 0, 0, 0))
         return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidPlainDate);
 
     // 7. If newTarget is not present, set newTarget to %Temporal.PlainDate%.

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
@@ -64,8 +64,7 @@ struct TemporalPlainDateTime {
     u16 nanosecond;
 };
 
-BigInt* get_epoch_from_iso_parts(VM&, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond);
-bool iso_date_time_within_limits(VM&, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond);
+bool iso_date_time_within_limits(i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond);
 ThrowCompletionOr<ISODateTime> interpret_temporal_date_time_fields(VM&, Object& calendar, Object& fields, Object const& options);
 ThrowCompletionOr<PlainDateTime*> to_temporal_date_time(VM&, Value item, Object const* options = nullptr);
 ISODateTime balance_iso_date_time(i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, i64 nanosecond);
@@ -73,7 +72,7 @@ ThrowCompletionOr<PlainDateTime*> create_temporal_date_time(VM&, i32 iso_year, u
 ThrowCompletionOr<String> temporal_date_time_to_string(VM&, i32 iso_year, u8 iso_month, u8 iso_day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond, Object const* calendar, Variant<StringView, u8> const& precision, StringView show_calendar);
 i8 compare_iso_date_time(i32 year1, u8 month1, u8 day1, u8 hour1, u8 minute1, u8 second1, u16 millisecond1, u16 microsecond1, u16 nanosecond1, i32 year2, u8 month2, u8 day2, u8 hour2, u8 minute2, u8 second2, u16 millisecond2, u16 microsecond2, u16 nanosecond2);
 ThrowCompletionOr<TemporalPlainDateTime> add_date_time(VM&, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond, Object& calendar, double years, double months, double weeks, double days, double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds, Object* options);
-ISODateTime round_iso_date_time(VM&, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond, u64 increment, StringView unit, StringView rounding_mode, Optional<double> day_length = {});
+ISODateTime round_iso_date_time(i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond, u64 increment, StringView unit, StringView rounding_mode, Optional<double> day_length = {});
 ThrowCompletionOr<DurationRecord> difference_iso_date_time(VM&, i32 year1, u8 month1, u8 day1, u8 hour1, u8 minute1, u8 second1, u16 millisecond1, u16 microsecond1, u16 nanosecond1, i32 year2, u8 month2, u8 day2, u8 hour2, u8 minute2, u8 second2, u16 millisecond2, u16 microsecond2, u16 nanosecond2, Object& calendar, StringView largest_unit, Object const& options);
 ThrowCompletionOr<Duration*> difference_temporal_plain_date_time(VM&, DifferenceOperation, PlainDateTime&, Value other, Value options);
 ThrowCompletionOr<PlainDateTime*> add_duration_to_or_subtract_duration_from_plain_date_time(VM&, ArithmeticOperation, PlainDateTime&, Value temporal_duration_like, Value options_value);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -557,7 +557,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::round)
     auto rounding_increment = TRY(to_temporal_date_time_rounding_increment(vm, *round_to, *smallest_unit));
 
     // 9. Let result be ! RoundISODateTime(dateTime.[[ISOYear]], dateTime.[[ISOMonth]], dateTime.[[ISODay]], dateTime.[[ISOHour]], dateTime.[[ISOMinute]], dateTime.[[ISOSecond]], dateTime.[[ISOMillisecond]], dateTime.[[ISOMicrosecond]], dateTime.[[ISONanosecond]], roundingIncrement, smallestUnit, roundingMode).
-    auto result = round_iso_date_time(vm, date_time->iso_year(), date_time->iso_month(), date_time->iso_day(), date_time->iso_hour(), date_time->iso_minute(), date_time->iso_second(), date_time->iso_millisecond(), date_time->iso_microsecond(), date_time->iso_nanosecond(), rounding_increment, *smallest_unit, rounding_mode);
+    auto result = round_iso_date_time(date_time->iso_year(), date_time->iso_month(), date_time->iso_day(), date_time->iso_hour(), date_time->iso_minute(), date_time->iso_second(), date_time->iso_millisecond(), date_time->iso_microsecond(), date_time->iso_nanosecond(), rounding_increment, *smallest_unit, rounding_mode);
 
     // 10. Return ? CreateTemporalDateTime(result.[[Year]], result.[[Month]], result.[[Day]], result.[[Hour]], result.[[Minute]], result.[[Second]], result.[[Millisecond]], result.[[Microsecond]], result.[[Nanosecond]], dateTime.[[Calendar]]).
     return TRY(create_temporal_date_time(vm, result.year, result.month, result.day, result.hour, result.minute, result.second, result.millisecond, result.microsecond, result.nanosecond, date_time->calendar()));
@@ -604,7 +604,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::to_string)
     auto show_calendar = TRY(to_show_calendar_option(vm, *options));
 
     // 7. Let result be ! RoundISODateTime(dateTime.[[ISOYear]], dateTime.[[ISOMonth]], dateTime.[[ISODay]], dateTime.[[ISOHour]], dateTime.[[ISOMinute]], dateTime.[[ISOSecond]], dateTime.[[ISOMillisecond]], dateTime.[[ISOMicrosecond]], dateTime.[[ISONanosecond]], precision.[[Increment]], precision.[[Unit]], roundingMode).
-    auto result = round_iso_date_time(vm, date_time->iso_year(), date_time->iso_month(), date_time->iso_day(), date_time->iso_hour(), date_time->iso_minute(), date_time->iso_second(), date_time->iso_millisecond(), date_time->iso_microsecond(), date_time->iso_nanosecond(), precision.increment, precision.unit, rounding_mode);
+    auto result = round_iso_date_time(date_time->iso_year(), date_time->iso_month(), date_time->iso_day(), date_time->iso_hour(), date_time->iso_minute(), date_time->iso_second(), date_time->iso_millisecond(), date_time->iso_microsecond(), date_time->iso_nanosecond(), precision.increment, precision.unit, rounding_mode);
 
     // 8. Return ? TemporalDateTimeToString(result.[[Year]], result.[[Month]], result.[[Day]], result.[[Hour]], result.[[Minute]], result.[[Second]], result.[[Millisecond]], result.[[Microsecond]], result.[[Nanosecond]], dateTime.[[Calendar]], precision.[[Precision]], showCalendar).
     return js_string(vm, TRY(temporal_date_time_to_string(vm, result.year, result.month, result.day, result.hour, result.minute, result.second, result.millisecond, result.microsecond, result.nanosecond, &date_time->calendar(), precision.precision, show_calendar)));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.cpp
@@ -154,7 +154,7 @@ ThrowCompletionOr<PlainMonthDay*> create_temporal_month_day(VM& vm, u8 iso_month
         return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidPlainMonthDay);
 
     // 4. If ISODateTimeWithinLimits(referenceISOYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0) is false, throw a RangeError exception.
-    if (!iso_date_time_within_limits(vm, reference_iso_year, iso_month, iso_day, 12, 0, 0, 0, 0, 0))
+    if (!iso_date_time_within_limits(reference_iso_year, iso_month, iso_day, 12, 0, 0, 0, 0, 0))
         return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidPlainMonthDay);
 
     // 5. If newTarget is not present, set newTarget to %Temporal.PlainMonthDay%.

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
@@ -149,21 +149,7 @@ ISODateTime get_iso_parts_from_epoch(VM& vm, Crypto::SignedBigInteger const& epo
     return { .year = year, .month = month, .day = day, .hour = hour, .minute = minute, .second = second, .millisecond = millisecond, .microsecond = static_cast<u16>(microsecond), .nanosecond = static_cast<u16>(nanosecond) };
 }
 
-// 11.6.3 GetIANATimeZoneEpochValue ( timeZoneIdentifier, year, month, day, hour, minute, second, millisecond, microsecond, nanosecond ), https://tc39.es/proposal-temporal/#sec-temporal-getianatimezoneepochvalue
-MarkedVector<BigInt*> get_iana_time_zone_epoch_value(VM& vm, [[maybe_unused]] StringView time_zone_identifier, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond)
-{
-    // The implementation-defined abstract operation GetIANATimeZoneEpochValue takes arguments timeZoneIdentifier (a String), year (an integer), month (an integer between 1 and 12 inclusive), day (an integer between 1 and 31 inclusive), hour (an integer between 0 and 23 inclusive), minute (an integer between 0 and 59 inclusive), second (an integer between 0 and 59 inclusive), millisecond (an integer between 0 and 999 inclusive), microsecond (an integer between 0 and 999 inclusive), and nanosecond (an integer between 0 and 999 inclusive) and returns a List of BigInts.
-    // Each value in the returned List represents a number of nanoseconds since the Unix epoch in UTC that corresponds to the given ISO 8601 calendar date and wall-clock time in the IANA time zone identified by timeZoneIdentifier.
-    // When the input represents a local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change), the returned List will have more than one element. The elements are sorted in numerical order. When the input represents a skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), the returned List will be empty. Otherwise, the returned List will have one element.
-    // It is an error to call GetIANATimeZoneEpochValue with arguments such that IsValidISODate(year, month, day) is false.
-
-    // FIXME: Implement this properly for non-UTC timezones.
-    auto list = MarkedVector<BigInt*> { vm.heap() };
-    list.append(js_bigint(vm, get_utc_epoch_nanoseconds(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond)));
-    return list;
-}
-
-// 11.6.4 GetIANATimeZoneOffsetNanoseconds ( epochNanoseconds, timeZoneIdentifier ), https://tc39.es/proposal-temporal/#sec-temporal-getianatimezoneoffsetnanoseconds
+// 11.6.3 GetIANATimeZoneOffsetNanoseconds ( epochNanoseconds, timeZoneIdentifier ), https://tc39.es/proposal-temporal/#sec-temporal-getianatimezoneoffsetnanoseconds
 i64 get_iana_time_zone_offset_nanoseconds(BigInt const& epoch_nanoseconds, String const& time_zone_identifier)
 {
     // The implementation-defined abstract operation GetIANATimeZoneOffsetNanoseconds takes arguments epochNanoseconds (a BigInt) and timeZoneIdentifier (a String) and returns an integer.
@@ -195,7 +181,7 @@ i64 get_iana_time_zone_offset_nanoseconds(BigInt const& epoch_nanoseconds, Strin
     return offset->seconds * 1'000'000'000;
 }
 
-// 11.6.5 GetIANATimeZoneNextTransition ( epochNanoseconds, timeZoneIdentifier ), https://tc39.es/proposal-temporal/#sec-temporal-getianatimezonenexttransition
+// 11.6.4 GetIANATimeZoneNextTransition ( epochNanoseconds, timeZoneIdentifier ), https://tc39.es/proposal-temporal/#sec-temporal-getianatimezonenexttransition
 BigInt* get_iana_time_zone_next_transition(VM&, [[maybe_unused]] BigInt const& epoch_nanoseconds, [[maybe_unused]] StringView time_zone_identifier)
 {
     // The implementation-defined abstract operation GetIANATimeZoneNextTransition takes arguments epochNanoseconds (a BigInt) and timeZoneIdentifier (a String) and returns a BigInt or null.
@@ -206,7 +192,7 @@ BigInt* get_iana_time_zone_next_transition(VM&, [[maybe_unused]] BigInt const& e
     return nullptr;
 }
 
-// 11.6.6 GetIANATimeZonePreviousTransition ( epochNanoseconds, timeZoneIdentifier ), https://tc39.es/proposal-temporal/#sec-temporal-getianatimezoneprevioustransition
+// 11.6.5 GetIANATimeZonePreviousTransition ( epochNanoseconds, timeZoneIdentifier ), https://tc39.es/proposal-temporal/#sec-temporal-getianatimezoneprevioustransition
 BigInt* get_iana_time_zone_previous_transition(VM&, [[maybe_unused]] BigInt const& epoch_nanoseconds, [[maybe_unused]] StringView time_zone_identifier)
 {
     // The implementation-defined abstract operation GetIANATimeZonePreviousTransition takes arguments epochNanoseconds (a BigInt) and timeZoneIdentifier (a String) and returns a BigInt or null.
@@ -260,7 +246,7 @@ bool is_valid_time_zone_numeric_utc_offset_syntax(String const& offset_string)
     return parse_time_zone_numeric_utc_offset_syntax(offset_string, discarded, discarded, optionally_discarded, optionally_discarded, optionally_discarded);
 }
 
-// 11.6.7 ParseTimeZoneOffsetString ( offsetString ), https://tc39.es/proposal-temporal/#sec-temporal-parsetimezoneoffsetstring
+// 11.6.6 ParseTimeZoneOffsetString ( offsetString ), https://tc39.es/proposal-temporal/#sec-temporal-parsetimezoneoffsetstring
 ThrowCompletionOr<double> parse_time_zone_offset_string(VM& vm, String const& offset_string)
 {
     // 1. Let parseResult be ParseText(StringToCodePoints(offsetString), TimeZoneNumericUTCOffset).
@@ -333,7 +319,7 @@ ThrowCompletionOr<double> parse_time_zone_offset_string(VM& vm, String const& of
     return factor * (((hours_mv * 60 + minutes_mv) * 60 + seconds_mv) * 1e9 + nanoseconds_mv);
 }
 
-// 11.6.8 FormatTimeZoneOffsetString ( offsetNanoseconds ), https://tc39.es/proposal-temporal/#sec-temporal-formattimezoneoffsetstring
+// 11.6.7 FormatTimeZoneOffsetString ( offsetNanoseconds ), https://tc39.es/proposal-temporal/#sec-temporal-formattimezoneoffsetstring
 String format_time_zone_offset_string(double offset_nanoseconds)
 {
     auto offset = static_cast<i64>(offset_nanoseconds);
@@ -387,7 +373,7 @@ String format_time_zone_offset_string(double offset_nanoseconds)
     return builder.to_string();
 }
 
-// 11.6.9 FormatISOTimeZoneOffsetString ( offsetNanoseconds ), https://tc39.es/proposal-temporal/#sec-temporal-formatisotimezoneoffsetstring
+// 11.6.8 FormatISOTimeZoneOffsetString ( offsetNanoseconds ), https://tc39.es/proposal-temporal/#sec-temporal-formatisotimezoneoffsetstring
 String format_iso_time_zone_offset_string(double offset_nanoseconds)
 {
     // 1. Assert: offsetNanoseconds is an integer.
@@ -414,7 +400,7 @@ String format_iso_time_zone_offset_string(double offset_nanoseconds)
     return String::formatted("{}{:02}:{:02}", sign, (u32)hours, (u32)minutes);
 }
 
-// 11.6.10 ToTemporalTimeZone ( temporalTimeZoneLike ), https://tc39.es/proposal-temporal/#sec-temporal-totemporaltimezone
+// 11.6.9 ToTemporalTimeZone ( temporalTimeZoneLike ), https://tc39.es/proposal-temporal/#sec-temporal-totemporaltimezone
 ThrowCompletionOr<Object*> to_temporal_time_zone(VM& vm, Value temporal_time_zone_like)
 {
     // 1. If Type(temporalTimeZoneLike) is Object, then
@@ -472,7 +458,7 @@ ThrowCompletionOr<Object*> to_temporal_time_zone(VM& vm, Value temporal_time_zon
     return MUST(create_temporal_time_zone(vm, *parse_result.offset_string));
 }
 
-// 11.6.11 GetOffsetNanosecondsFor ( timeZone, instant ), https://tc39.es/proposal-temporal/#sec-temporal-getoffsetnanosecondsfor
+// 11.6.10 GetOffsetNanosecondsFor ( timeZone, instant ), https://tc39.es/proposal-temporal/#sec-temporal-getoffsetnanosecondsfor
 ThrowCompletionOr<double> get_offset_nanoseconds_for(VM& vm, Value time_zone, Instant& instant)
 {
     // 1. Let getOffsetNanosecondsFor be ? GetMethod(timeZone, "getOffsetNanosecondsFor").
@@ -500,7 +486,7 @@ ThrowCompletionOr<double> get_offset_nanoseconds_for(VM& vm, Value time_zone, In
     return offset_nanoseconds;
 }
 
-// 11.6.12 BuiltinTimeZoneGetOffsetStringFor ( timeZone, instant ), https://tc39.es/proposal-temporal/#sec-temporal-builtintimezonegetoffsetstringfor
+// 11.6.11 BuiltinTimeZoneGetOffsetStringFor ( timeZone, instant ), https://tc39.es/proposal-temporal/#sec-temporal-builtintimezonegetoffsetstringfor
 ThrowCompletionOr<String> builtin_time_zone_get_offset_string_for(VM& vm, Value time_zone, Instant& instant)
 {
     // 1. Let offsetNanoseconds be ? GetOffsetNanosecondsFor(timeZone, instant).
@@ -510,7 +496,7 @@ ThrowCompletionOr<String> builtin_time_zone_get_offset_string_for(VM& vm, Value 
     return format_time_zone_offset_string(offset_nanoseconds);
 }
 
-// 11.6.13 BuiltinTimeZoneGetPlainDateTimeFor ( timeZone, instant, calendar ), https://tc39.es/proposal-temporal/#sec-temporal-builtintimezonegetplaindatetimefor
+// 11.6.12 BuiltinTimeZoneGetPlainDateTimeFor ( timeZone, instant, calendar ), https://tc39.es/proposal-temporal/#sec-temporal-builtintimezonegetplaindatetimefor
 ThrowCompletionOr<PlainDateTime*> builtin_time_zone_get_plain_date_time_for(VM& vm, Value time_zone, Instant& instant, Object& calendar)
 {
     // 1. Assert: instant has an [[InitializedTemporalInstant]] internal slot.
@@ -528,7 +514,7 @@ ThrowCompletionOr<PlainDateTime*> builtin_time_zone_get_plain_date_time_for(VM& 
     return create_temporal_date_time(vm, result.year, result.month, result.day, result.hour, result.minute, result.second, result.millisecond, result.microsecond, result.nanosecond, calendar);
 }
 
-// 11.6.14 BuiltinTimeZoneGetInstantFor ( timeZone, dateTime, disambiguation ), https://tc39.es/proposal-temporal/#sec-temporal-builtintimezonegetinstantfor
+// 11.6.13 BuiltinTimeZoneGetInstantFor ( timeZone, dateTime, disambiguation ), https://tc39.es/proposal-temporal/#sec-temporal-builtintimezonegetinstantfor
 ThrowCompletionOr<Instant*> builtin_time_zone_get_instant_for(VM& vm, Value time_zone, PlainDateTime& date_time, StringView disambiguation)
 {
     // 1. Assert: dateTime has an [[InitializedTemporalDateTime]] internal slot.
@@ -540,7 +526,7 @@ ThrowCompletionOr<Instant*> builtin_time_zone_get_instant_for(VM& vm, Value time
     return disambiguate_possible_instants(vm, possible_instants, time_zone, date_time, disambiguation);
 }
 
-// 11.6.15 DisambiguatePossibleInstants ( possibleInstants, timeZone, dateTime, disambiguation ), https://tc39.es/proposal-temporal/#sec-temporal-disambiguatepossibleinstants
+// 11.6.14 DisambiguatePossibleInstants ( possibleInstants, timeZone, dateTime, disambiguation ), https://tc39.es/proposal-temporal/#sec-temporal-disambiguatepossibleinstants
 ThrowCompletionOr<Instant*> disambiguate_possible_instants(VM& vm, MarkedVector<Instant*> const& possible_instants, Value time_zone, PlainDateTime& date_time, StringView disambiguation)
 {
     // 1. Assert: dateTime has an [[InitializedTemporalDateTime]] internal slot.
@@ -658,7 +644,7 @@ ThrowCompletionOr<Instant*> disambiguate_possible_instants(VM& vm, MarkedVector<
     return possible_instants_[n - 1];
 }
 
-// 11.6.16 GetPossibleInstantsFor ( timeZone, dateTime ), https://tc39.es/proposal-temporal/#sec-temporal-getpossibleinstantsfor
+// 11.6.15 GetPossibleInstantsFor ( timeZone, dateTime ), https://tc39.es/proposal-temporal/#sec-temporal-getpossibleinstantsfor
 ThrowCompletionOr<MarkedVector<Instant*>> get_possible_instants_for(VM& vm, Value time_zone, PlainDateTime& date_time)
 {
     // 1. Assert: dateTime has an [[InitializedTemporalDateTime]] internal slot.
@@ -703,7 +689,7 @@ ThrowCompletionOr<MarkedVector<Instant*>> get_possible_instants_for(VM& vm, Valu
     return { move(list) };
 }
 
-// 11.6.17 TimeZoneEquals ( one, two ), https://tc39.es/proposal-temporal/#sec-temporal-timezoneequals
+// 11.6.16 TimeZoneEquals ( one, two ), https://tc39.es/proposal-temporal/#sec-temporal-timezoneequals
 ThrowCompletionOr<bool> time_zone_equals(VM& vm, Object& one, Object& two)
 {
     // 1. If one and two are the same Object value, return true.

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
@@ -54,14 +54,6 @@ String canonicalize_time_zone_name(String const& time_zone)
     return *iana_time_zone;
 }
 
-// 11.1.3 DefaultTimeZone ( ), https://tc39.es/proposal-temporal/#sec-defaulttimezone
-// 15.1.3 DefaultTimeZone ( ), https://tc39.es/proposal-temporal/#sup-defaulttimezone
-String default_time_zone()
-{
-    // The DefaultTimeZone abstract operation returns a String value representing the valid (11.1.1) and canonicalized (11.1.2) time zone name for the host environment's current time zone.
-    return ::TimeZone::current_time_zone();
-}
-
 // 11.6.1 CreateTemporalTimeZone ( identifier [ , newTarget ] ), https://tc39.es/proposal-temporal/#sec-temporal-createtemporaltimezone
 ThrowCompletionOr<TimeZone*> create_temporal_time_zone(VM& vm, String const& identifier, FunctionObject const* new_target)
 {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -41,7 +41,6 @@ String canonicalize_time_zone_name(String const& time_zone);
 String default_time_zone();
 ThrowCompletionOr<TimeZone*> create_temporal_time_zone(VM&, String const& identifier, FunctionObject const* new_target = nullptr);
 ISODateTime get_iso_parts_from_epoch(VM&, Crypto::SignedBigInteger const& epoch_nanoseconds);
-i64 get_iana_time_zone_offset_nanoseconds(BigInt const& epoch_nanoseconds, String const& time_zone_identifier);
 BigInt* get_iana_time_zone_next_transition(VM&, BigInt const& epoch_nanoseconds, StringView time_zone_identifier);
 BigInt* get_iana_time_zone_previous_transition(VM&, BigInt const& epoch_nanoseconds, StringView time_zone_identifier);
 ThrowCompletionOr<double> parse_time_zone_offset_string(VM&, String const&);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -42,7 +42,6 @@ ThrowCompletionOr<TimeZone*> create_temporal_time_zone(VM&, String const& identi
 ISODateTime get_iso_parts_from_epoch(VM&, Crypto::SignedBigInteger const& epoch_nanoseconds);
 BigInt* get_iana_time_zone_next_transition(VM&, BigInt const& epoch_nanoseconds, StringView time_zone_identifier);
 BigInt* get_iana_time_zone_previous_transition(VM&, BigInt const& epoch_nanoseconds, StringView time_zone_identifier);
-ThrowCompletionOr<double> parse_time_zone_offset_string(VM&, String const&);
 String format_time_zone_offset_string(double offset_nanoseconds);
 String format_iso_time_zone_offset_string(double offset_nanoseconds);
 ThrowCompletionOr<Object*> to_temporal_time_zone(VM&, Value temporal_time_zone_like);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -41,7 +41,6 @@ String canonicalize_time_zone_name(String const& time_zone);
 String default_time_zone();
 ThrowCompletionOr<TimeZone*> create_temporal_time_zone(VM&, String const& identifier, FunctionObject const* new_target = nullptr);
 ISODateTime get_iso_parts_from_epoch(VM&, Crypto::SignedBigInteger const& epoch_nanoseconds);
-MarkedVector<BigInt*> get_iana_time_zone_epoch_value(VM&, StringView time_zone_identifier, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond);
 i64 get_iana_time_zone_offset_nanoseconds(BigInt const& epoch_nanoseconds, String const& time_zone_identifier);
 BigInt* get_iana_time_zone_next_transition(VM&, BigInt const& epoch_nanoseconds, StringView time_zone_identifier);
 BigInt* get_iana_time_zone_previous_transition(VM&, BigInt const& epoch_nanoseconds, StringView time_zone_identifier);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -38,7 +38,6 @@ private:
 
 bool is_valid_time_zone_name(String const& time_zone);
 String canonicalize_time_zone_name(String const& time_zone);
-String default_time_zone();
 ThrowCompletionOr<TimeZone*> create_temporal_time_zone(VM&, String const& identifier, FunctionObject const* new_target = nullptr);
 ISODateTime get_iso_parts_from_epoch(VM&, Crypto::SignedBigInteger const& epoch_nanoseconds);
 BigInt* get_iana_time_zone_next_transition(VM&, BigInt const& epoch_nanoseconds, StringView time_zone_identifier);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneConstructor.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/TimeZone.h>
 #include <LibJS/Runtime/Temporal/TimeZoneConstructor.h>
@@ -49,9 +50,8 @@ ThrowCompletionOr<Object*> TimeZoneConstructor::construct(FunctionObject& new_ta
     // 2. Set identifier to ? ToString(identifier).
     auto identifier = TRY(vm.argument(0).to_string(vm));
 
-    // 3. Let parseResult be ParseText(StringToCodePoints(identifier), TimeZoneNumericUTCOffset).
-    // 4. If parseResult is a List of errors, then
-    if (!is_valid_time_zone_numeric_utc_offset_syntax(identifier)) {
+    // 3. If IsTimeZoneOffsetString(identifier) is false, then
+    if (!is_time_zone_offset_string(identifier)) {
         // a. If IsValidTimeZoneName(identifier) is false, then
         if (!is_valid_time_zone_name(identifier)) {
             // i. Throw a RangeError exception.
@@ -62,7 +62,7 @@ ThrowCompletionOr<Object*> TimeZoneConstructor::construct(FunctionObject& new_ta
         identifier = canonicalize_time_zone_name(identifier);
     }
 
-    // 5. Return ? CreateTemporalTimeZone(identifier, NewTarget).
+    // 4. Return ? CreateTemporalTimeZone(identifier, NewTarget).
     return TRY(create_temporal_time_zone(vm, identifier, &new_target));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>
@@ -141,11 +142,11 @@ JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::get_possible_instants_for)
 
     // 4. If timeZone.[[OffsetNanoseconds]] is not undefined, then
     if (time_zone->offset_nanoseconds().has_value()) {
-        // a. Let epochNanoseconds be GetEpochFromISOParts(dateTime.[[ISOYear]], dateTime.[[ISOMonth]], dateTime.[[ISODay]], dateTime.[[ISOHour]], dateTime.[[ISOMinute]], dateTime.[[ISOSecond]], dateTime.[[ISOMillisecond]], dateTime.[[ISOMicrosecond]], dateTime.[[ISONanosecond]]).
-        auto* epoch_nanoseconds = get_epoch_from_iso_parts(vm, date_time->iso_year(), date_time->iso_month(), date_time->iso_day(), date_time->iso_hour(), date_time->iso_minute(), date_time->iso_second(), date_time->iso_millisecond(), date_time->iso_microsecond(), date_time->iso_nanosecond());
+        // a. Let epochNanoseconds be GetUTCEpochNanoseconds(dateTime.[[ISOYear]], dateTime.[[ISOMonth]], dateTime.[[ISODay]], dateTime.[[ISOHour]], dateTime.[[ISOMinute]], dateTime.[[ISOSecond]], dateTime.[[ISOMillisecond]], dateTime.[[ISOMicrosecond]], dateTime.[[ISONanosecond]]).
+        auto epoch_nanoseconds = get_utc_epoch_nanoseconds(date_time->iso_year(), date_time->iso_month(), date_time->iso_day(), date_time->iso_hour(), date_time->iso_minute(), date_time->iso_second(), date_time->iso_millisecond(), date_time->iso_microsecond(), date_time->iso_nanosecond());
 
         // b. Let possibleEpochNanoseconds be « epochNanoseconds - ℤ(timeZone.[[OffsetNanoseconds]]) ».
-        possible_epoch_nanoseconds.append(js_bigint(vm, epoch_nanoseconds->big_integer().minus(Crypto::SignedBigInteger { *time_zone->offset_nanoseconds() })));
+        possible_epoch_nanoseconds.append(js_bigint(vm, epoch_nanoseconds.minus(Crypto::SignedBigInteger { *time_zone->offset_nanoseconds() })));
     }
     // 5. Else,
     else {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
@@ -138,7 +138,7 @@ JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::get_possible_instants_for)
     // 3. Set dateTime to ? ToTemporalDateTime(dateTime).
     auto* date_time = TRY(to_temporal_date_time(vm, vm.argument(0)));
 
-    auto possible_epoch_nanoseconds = MarkedVector<BigInt*> { vm.heap() };
+    Vector<Crypto::SignedBigInteger> possible_epoch_nanoseconds;
 
     // 4. If timeZone.[[OffsetNanoseconds]] is not undefined, then
     if (time_zone->offset_nanoseconds().has_value()) {
@@ -146,12 +146,12 @@ JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::get_possible_instants_for)
         auto epoch_nanoseconds = get_utc_epoch_nanoseconds(date_time->iso_year(), date_time->iso_month(), date_time->iso_day(), date_time->iso_hour(), date_time->iso_minute(), date_time->iso_second(), date_time->iso_millisecond(), date_time->iso_microsecond(), date_time->iso_nanosecond());
 
         // b. Let possibleEpochNanoseconds be « epochNanoseconds - ℤ(timeZone.[[OffsetNanoseconds]]) ».
-        possible_epoch_nanoseconds.append(js_bigint(vm, epoch_nanoseconds.minus(Crypto::SignedBigInteger { *time_zone->offset_nanoseconds() })));
+        possible_epoch_nanoseconds.append(epoch_nanoseconds.minus(Crypto::SignedBigInteger { *time_zone->offset_nanoseconds() }));
     }
     // 5. Else,
     else {
-        // a. Let possibleEpochNanoseconds be GetIANATimeZoneEpochValue(timeZone.[[Identifier]], dateTime.[[ISOYear]], dateTime.[[ISOMonth]], dateTime.[[ISODay]], dateTime.[[ISOHour]], dateTime.[[ISOMinute]], dateTime.[[ISOSecond]], dateTime.[[ISOMillisecond]], dateTime.[[ISOMicrosecond]], dateTime.[[ISONanosecond]]).
-        possible_epoch_nanoseconds = get_iana_time_zone_epoch_value(vm, time_zone->identifier(), date_time->iso_year(), date_time->iso_month(), date_time->iso_day(), date_time->iso_hour(), date_time->iso_minute(), date_time->iso_second(), date_time->iso_millisecond(), date_time->iso_microsecond(), date_time->iso_nanosecond());
+        // a. Let possibleEpochNanoseconds be GetNamedTimeZoneEpochNanoseconds(timeZone.[[Identifier]], dateTime.[[ISOYear]], dateTime.[[ISOMonth]], dateTime.[[ISODay]], dateTime.[[ISOHour]], dateTime.[[ISOMinute]], dateTime.[[ISOSecond]], dateTime.[[ISOMillisecond]], dateTime.[[ISOMicrosecond]], dateTime.[[ISONanosecond]]).
+        possible_epoch_nanoseconds = get_named_time_zone_epoch_nanoseconds(time_zone->identifier(), date_time->iso_year(), date_time->iso_month(), date_time->iso_day(), date_time->iso_hour(), date_time->iso_minute(), date_time->iso_second(), date_time->iso_millisecond(), date_time->iso_microsecond(), date_time->iso_nanosecond());
     }
 
     // 6. Let possibleInstants be a new empty List.
@@ -160,11 +160,12 @@ JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::get_possible_instants_for)
     // 7. For each value epochNanoseconds in possibleEpochNanoseconds, do
     for (auto& epoch_nanoseconds : possible_epoch_nanoseconds) {
         // a. If ! IsValidEpochNanoseconds(epochNanoseconds) is false, throw a RangeError exception.
-        if (!is_valid_epoch_nanoseconds(*epoch_nanoseconds))
+        if (!is_valid_epoch_nanoseconds(epoch_nanoseconds))
             return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidEpochNanoseconds);
 
         // b. Let instant be ! CreateTemporalInstant(epochNanoseconds).
-        auto* instant = MUST(create_temporal_instant(vm, *epoch_nanoseconds));
+        auto* epoch_nanoseconds_bigint = js_bigint(vm, move(epoch_nanoseconds));
+        auto* instant = MUST(create_temporal_instant(vm, *epoch_nanoseconds_bigint));
 
         // c. Append instant to possibleInstants.
         possible_instants.append(instant);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
@@ -70,8 +70,8 @@ JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::get_offset_nanoseconds_for)
     if (time_zone->offset_nanoseconds().has_value())
         return Value(*time_zone->offset_nanoseconds());
 
-    // 5. Return 𝔽(GetIANATimeZoneOffsetNanoseconds(instant.[[Nanoseconds]], timeZone.[[Identifier]])).
-    return Value((double)get_iana_time_zone_offset_nanoseconds(instant->nanoseconds(), time_zone->identifier()));
+    // 5. Return 𝔽(GetNamedTimeZoneOffsetNanoseconds(timeZone.[[Identifier]], instant.[[Nanoseconds]])).
+    return Value((double)get_named_time_zone_offset_nanoseconds(time_zone->identifier(), instant->nanoseconds().big_integer()));
 }
 
 // 11.4.5 Temporal.TimeZone.prototype.getOffsetStringFor ( instant ), https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getoffsetstringfor

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -450,7 +450,7 @@ ThrowCompletionOr<NanosecondsToDaysResult> nanoseconds_to_days(VM& vm, Crypto::S
 
     // 4. If Type(relativeTo) is not Object or relativeTo does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
     if (!relative_to_value.is_object() || !is<ZonedDateTime>(relative_to_value.as_object())) {
-        // a. Return the Record { [[Days]]: RoundTowardsZero(nanoseconds / dayLengthNs), [[Nanoseconds]]: (abs(nanoseconds) modulo dayLengthNs) × sign, [[DayLength]]: dayLengthNs }.
+        // a. Return the Record { [[Days]]: truncate(nanoseconds / dayLengthNs), [[Nanoseconds]]: (abs(nanoseconds) modulo dayLengthNs) × sign, [[DayLength]]: dayLengthNs }.
         return NanosecondsToDaysResult {
             .days = nanoseconds.divided_by(day_length_ns).quotient.to_double(),
             .nanoseconds = Crypto::SignedBigInteger { nanoseconds.unsigned_value() }.divided_by(day_length_ns).remainder.multiplied_by(Crypto::SignedBigInteger { sign }),

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -197,8 +197,8 @@ ThrowCompletionOr<ZonedDateTime*> to_temporal_zoned_date_time(VM& vm, Value item
         // e. Assert: timeZoneName is not undefined.
         VERIFY(time_zone_name.has_value());
 
-        // f. If ParseText(StringToCodePoints(timeZoneName), TimeZoneNumericUTCOffset) is a List of errors, then
-        if (!is_valid_time_zone_numeric_utc_offset_syntax(*time_zone_name)) {
+        // f. If IsTimeZoneOffsetString(timeZoneName) is false, then
+        if (!is_time_zone_offset_string(*time_zone_name)) {
             // i. If IsValidTimeZoneName(timeZoneName) is false, throw a RangeError exception.
             if (!is_valid_time_zone_name(*time_zone_name))
                 return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidTimeZoneName, *time_zone_name);
@@ -239,8 +239,12 @@ ThrowCompletionOr<ZonedDateTime*> to_temporal_zoned_date_time(VM& vm, Value item
 
     // 8. If offsetBehaviour is option, then
     if (offset_behavior == OffsetBehavior::Option) {
+        // a. If IsTimeZoneOffsetString(offsetString) is false, throw a RangeError exception.
+        if (!is_time_zone_offset_string(*offset_string))
+            return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidTimeZoneName, *offset_string);
+
         // a. Set offsetNanoseconds to ? ParseTimeZoneOffsetString(offsetString).
-        offset_nanoseconds = TRY(parse_time_zone_offset_string(vm, *offset_string));
+        offset_nanoseconds = parse_time_zone_offset_string(*offset_string);
     }
 
     // 9. Let disambiguation be ? ToTemporalDisambiguation(options).

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -1027,7 +1027,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::round)
     }
 
     // 20. Let roundResult be ! RoundISODateTime(temporalDateTime.[[ISOYear]], temporalDateTime.[[ISOMonth]], temporalDateTime.[[ISODay]], temporalDateTime.[[ISOHour]], temporalDateTime.[[ISOMinute]], temporalDateTime.[[ISOSecond]], temporalDateTime.[[ISOMillisecond]], temporalDateTime.[[ISOMicrosecond]], temporalDateTime.[[ISONanosecond]], roundingIncrement, smallestUnit, roundingMode, dayLengthNs).
-    auto round_result = round_iso_date_time(vm, temporal_date_time->iso_year(), temporal_date_time->iso_month(), temporal_date_time->iso_day(), temporal_date_time->iso_hour(), temporal_date_time->iso_minute(), temporal_date_time->iso_second(), temporal_date_time->iso_millisecond(), temporal_date_time->iso_microsecond(), temporal_date_time->iso_nanosecond(), rounding_increment, *smallest_unit, rounding_mode, day_length_ns);
+    auto round_result = round_iso_date_time(temporal_date_time->iso_year(), temporal_date_time->iso_month(), temporal_date_time->iso_day(), temporal_date_time->iso_hour(), temporal_date_time->iso_minute(), temporal_date_time->iso_second(), temporal_date_time->iso_millisecond(), temporal_date_time->iso_microsecond(), temporal_date_time->iso_nanosecond(), rounding_increment, *smallest_unit, rounding_mode, day_length_ns);
 
     // 21. Let offsetNanoseconds be ? GetOffsetNanosecondsFor(timeZone, instant).
     auto offset_nanoseconds = TRY(get_offset_nanoseconds_for(vm, &time_zone, *instant));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -352,7 +352,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::epoch_seconds_getter)
     // 3. Let ns be zonedDateTime.[[Nanoseconds]].
     auto& ns = zoned_date_time->nanoseconds();
 
-    // 4. Let s be RoundTowardsZero(ℝ(ns) / 10^9).
+    // 4. Let s be truncate(ℝ(ns) / 10^9).
     auto s = ns.big_integer().divided_by(Crypto::UnsignedBigInteger { 1'000'000'000 }).quotient;
 
     // 5. Return 𝔽(s).
@@ -369,7 +369,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::epoch_milliseconds_getter)
     // 3. Let ns be zonedDateTime.[[Nanoseconds]].
     auto& ns = zoned_date_time->nanoseconds();
 
-    // 4. Let ms be RoundTowardsZero(ℝ(ns) / 10^6).
+    // 4. Let ms be truncate(ℝ(ns) / 10^6).
     auto ms = ns.big_integer().divided_by(Crypto::UnsignedBigInteger { 1'000'000 }).quotient;
 
     // 5. Return 𝔽(ms).
@@ -386,7 +386,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::epoch_microseconds_getter)
     // 3. Let ns be zonedDateTime.[[Nanoseconds]].
     auto& ns = zoned_date_time->nanoseconds();
 
-    // 4. Let µs be RoundTowardsZero(ℝ(ns) / 10^3).
+    // 4. Let µs be truncate(ℝ(ns) / 10^3).
     auto us = ns.big_integer().divided_by(Crypto::UnsignedBigInteger { 1'000 }).quotient;
 
     // 5. Return ℤ(µs).

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -524,7 +524,7 @@ static Optional<NumberParseResult> parse_number_text(StringView text)
 }
 
 // 7.1.4.1.1 StringToNumber ( str ), https://tc39.es/ecma262/#sec-stringtonumber
-static Optional<Value> string_to_number(StringView string)
+Optional<Value> string_to_number(StringView string)
 {
     // 1. Let text be StringToCodePoints(str).
     String text = Utf8View(string).trim(whitespace_characters, AK::TrimMode::Both).as_string();

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -564,6 +564,8 @@ ThrowCompletionOr<TriState> is_less_than(VM&, Value lhs, Value rhs, bool left_fi
 
 double to_integer_or_infinity(double);
 
+Optional<Value> string_to_number(StringView);
+
 inline bool Value::operator==(Value const& value) const { return same_value(*this, value); }
 
 }


### PR DESCRIPTION
A "normative" ECMA-262 change followed by the editorial fallout in Temporal. Though the ECMA-262 change is normative, there's no behavior change.