### PR TITLE
HexEditor: Add strings to the value inspector

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -225,6 +225,15 @@ Optional<u8> HexEditor::get_byte(size_t position)
     return {};
 }
 
+Vector<u8> HexEditor::get_selected_bytes()
+{
+    Vector<u8> byte_vector;
+    for (size_t i = m_selection_start; i < m_selection_end; i++)
+        byte_vector.append(m_document->get(i).value);
+
+    return byte_vector;
+}
+
 void HexEditor::mousedown_event(GUI::MouseEvent& event)
 {
     if (event.button() != GUI::MouseButton::Primary) {

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -37,6 +37,7 @@ public:
     void open_file(NonnullRefPtr<Core::File> file);
     void fill_selection(u8 fill_byte);
     Optional<u8> get_byte(size_t position);
+    Vector<u8> get_selected_bytes();
     bool save_as(NonnullRefPtr<Core::File>);
     bool save();
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "HexEditorWidget.h"
+#include "AK/Forward.h"
 #include "FindDialog.h"
 #include "GoToOffsetDialog.h"
 #include "SearchResultsModel.h"
@@ -348,7 +349,7 @@ void HexEditorWidget::update_inspector_values(size_t position)
     if (byte_read_count % 2 == 0) {
         Utf16View utf16_view { Span<u16 const> { reinterpret_cast<u16 const*>(&unsigned_64_bit_int), 4 } };
         size_t valid_code_units;
-        utf16_view.validate(valid_code_units);
+        utf8_view.validate(valid_code_units);
         if (valid_code_units == 0)
             value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::UTF16, "");
         else

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -367,11 +367,19 @@ void HexEditorWidget::update_inspector_values(size_t position)
         if (!is_ascii_control(byte_char) && is_ascii(byte_char)) {
             ascii_string_builder.append(byte_char);
         } else {
-            ascii_string_builder.append(" ");
+            ascii_string_builder.append(' ');
         }
     }
 
     value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::ASCIIString, ascii_string_builder.to_string());
+
+    Utf8View utf8_string_view { ReadonlyBytes { selected_bytes } };
+    utf8_string_view.validate(valid_bytes);
+    if (valid_bytes == 0)
+        value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::UTF8String, "");
+    else
+        // FIXME: replace control chars with something else - we don't want line breaks here ;)
+        value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::UTF8String, utf8_string_view.as_string());
 
     // FIXME: Parse as other values like Timestamp etc
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -279,6 +279,8 @@ void HexEditorWidget::update_inspector_values(size_t position)
         unsigned_64_bit_int = (unsigned_64_bit_int << (8 * bytes_left_to_read));
     }
 
+    Vector<u8> selected_bytes = m_editor->get_selected_bytes();
+
     // Populate the model
     NonnullRefPtr<ValueInspectorModel> value_inspector_model = make_ref_counted<ValueInspectorModel>(m_value_inspector_little_endian);
     if (byte_read_count >= 1) {
@@ -357,6 +359,19 @@ void HexEditorWidget::update_inspector_values(size_t position)
     } else {
         value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::UTF16, "");
     }
+
+    StringBuilder ascii_string_builder;
+    for (size_t i = 0; i < selected_bytes.size(); i++) {
+        char byte_char = static_cast<char>(selected_bytes[i]);
+
+        if (!is_ascii_control(byte_char) && is_ascii(byte_char)) {
+            ascii_string_builder.append(byte_char);
+        } else {
+            ascii_string_builder.append(" ");
+        }
+    }
+
+    value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::ASCIIString, ascii_string_builder.to_string());
 
     // FIXME: Parse as other values like Timestamp etc
 

--- a/Userland/Applications/HexEditor/ValueInspectorModel.h
+++ b/Userland/Applications/HexEditor/ValueInspectorModel.h
@@ -31,6 +31,7 @@ public:
         UTF8,
         UTF16,
         ASCIIString,
+        UTF8String,
         __Count
     };
 
@@ -103,6 +104,8 @@ public:
             return "UTF-16";
         case ASCIIString:
             return "ASCII String";
+        case UTF8String:
+            return "UTF-8 String";
         default:
             return "";
         }

--- a/Userland/Applications/HexEditor/ValueInspectorModel.h
+++ b/Userland/Applications/HexEditor/ValueInspectorModel.h
@@ -30,6 +30,7 @@ public:
         ASCII,
         UTF8,
         UTF16,
+        ASCIIString,
         __Count
     };
 
@@ -100,6 +101,8 @@ public:
             return "UTF-8";
         case UTF16:
             return "UTF-16";
+        case ASCIIString:
+            return "ASCII String";
         default:
             return "";
         }


### PR DESCRIPTION
This tries to fix #13655 and is based on the work done by @MetallicSquid in #13809.

Currently this is work in progress, so I'll mark this as draft.