### PR TITLE
Kernel: Don't assume paths to children PID directories in ProcFS code

### DIFF
--- a/Kernel/ProcessSpecificExposed.cpp
+++ b/Kernel/ProcessSpecificExposed.cpp
@@ -112,7 +112,7 @@ ErrorOr<NonnullLockRefPtr<Inode>> Process::lookup_children_directory(ProcFS cons
 
 ErrorOr<size_t> Process::procfs_get_child_proccess_link(ProcessID child_pid, KBufferBuilder& builder) const
 {
-    TRY(builder.appendff("/proc/{}", child_pid.value()));
+    TRY(builder.appendff("../../{}", child_pid.value()));
     return builder.length();
 }
 


### PR DESCRIPTION
Instead of using absolute paths which is considered an abstraction layer violation between the kernel and userspace, let's not hardcode the path to children PID directories but instead we can use relative path links to them.

With a few rare exceptions to the known rule of "no hardcoded paths at the kernel" - this is certainly not one of them, so let's ensure we fix it for good.