### PR TITLE
NetworkSettings+SpiceAgent: Update and add required unveil paths

### DIFF
--- a/Userland/Applications/NetworkSettings/main.cpp
+++ b/Userland/Applications/NetworkSettings/main.cpp
@@ -21,9 +21,10 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     TRY(Core::System::unveil("/bin/NetworkServer", "x"));
     TRY(Core::System::unveil("/etc/Network.ini", "rwc"));
+    TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/proc/net/adapters", "r"));
     TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/portal/clipboard", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/clipboard", "rw"));
     TRY(Core::System::unveil("/tmp/portal/window", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Services/SpiceAgent/ConnectionToClipboardServer.h
+++ b/Userland/Services/SpiceAgent/ConnectionToClipboardServer.h
@@ -15,7 +15,7 @@
 class ConnectionToClipboardServer final
     : public IPC::ConnectionToServer<ClipboardClientEndpoint, ClipboardServerEndpoint>
     , public ClipboardClientEndpoint {
-    IPC_CLIENT_CONNECTION(ConnectionToClipboardServer, "/tmp/portal/clipboard"sv)
+    IPC_CLIENT_CONNECTION(ConnectionToClipboardServer, "/tmp/session/%sid/portal/clipboard"sv)
 
 public:
     Function<void()> on_data_changed;

--- a/Userland/Services/SpiceAgent/main.cpp
+++ b/Userland/Services/SpiceAgent/main.cpp
@@ -18,7 +18,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     TRY(Core::System::pledge("unix rpath wpath stdio sendfd recvfd"));
     TRY(Core::System::unveil(SPICE_DEVICE, "rw"sv));
-    TRY(Core::System::unveil("/tmp/portal/clipboard", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/clipboard", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     int serial_port_fd = TRY(Core::System::open(SPICE_DEVICE, O_RDWR));


### PR DESCRIPTION
Regression bugfixes:

* Update some leftover paths to `/tmp/portal/clipboard` to the new path per discussion in discord.
* NetworkSettings cites a missing `/proc/all` when launching - additional unveil added.