### PR TITLE
Kernel: Fix build error on AARCH64

### DIFF
--- a/Kernel/Arch/aarch64/CurrentTime.cpp
+++ b/Kernel/Arch/aarch64/CurrentTime.cpp
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#pragma once
-
 #include <Kernel/Arch/CurrentTime.h>
 
 namespace Kernel {


### PR DESCRIPTION
This currently fails with:

`error: #pragma once in main file [-Werror]`