### PR TITLE
Kernel: Add formal Processor::verify_no_spinlocks_held() API

### DIFF
--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -147,6 +147,11 @@ public:
         return current().m_in_critical;
     }
 
+    ALWAYS_INLINE static void verify_no_spinlocks_held()
+    {
+        VERIFY(!Processor::in_critical());
+    }
+
     // FIXME: Actually return the idle thread once aarch64 supports threading.
     ALWAYS_INLINE static Thread* idle_thread()
     {

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -370,6 +370,11 @@ public:
         return read_gs_ptr(__builtin_offsetof(Processor, m_in_critical));
     }
 
+    ALWAYS_INLINE static void verify_no_spinlocks_held()
+    {
+        VERIFY(!Processor::in_critical());
+    }
+
     ALWAYS_INLINE static FPUState const& clean_fpu_state() { return s_clean_fpu_state; }
 
     static void smp_enable();


### PR DESCRIPTION
In a few places we check `!Processor::in_critical()` to validate that the current processor doesn't hold any kernel spinlocks.

Instead lets provide it a first class name for readability. I'll also be adding more of these, so I would rather add more usages of a nice API instead of this implicit/assumed logic.