### PR TITLE
Spider: Make the last move undoable

### DIFF
--- a/Userland/Games/Spider/Game.h
+++ b/Userland/Games/Spider/Game.h
@@ -40,12 +40,28 @@ public:
     Mode mode() const { return m_mode; }
     void setup(Mode);
 
+    void perform_undo();
+
     Function<void(uint32_t)> on_score_update;
     Function<void()> on_game_start;
     Function<void(GameOverReason, uint32_t)> on_game_end;
+    Function<void(bool)> on_undo_availability_change;
 
 private:
     Game();
+
+    struct LastMove {
+        enum class Type {
+            Invalid,
+            MoveCards
+        };
+
+        Type type { Type::Invalid };
+        CardStack* from { nullptr };
+        size_t card_count;
+        bool was_visible;
+        CardStack* to { nullptr };
+    };
 
     enum StackLocation {
         Completed,
@@ -68,6 +84,7 @@ private:
     };
 
     void start_timer_if_necessary();
+    void remember_move_for_undo(CardStack&, CardStack&, size_t, bool);
     void update_score(int delta);
     void draw_cards();
     void detect_full_stacks();
@@ -82,6 +99,7 @@ private:
 
     Mode m_mode { Mode::SingleSuit };
 
+    LastMove m_last_move;
     NonnullRefPtrVector<Card> m_new_deck;
     Gfx::IntPoint m_mouse_down_location;
 

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -239,6 +239,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         game.setup(mode);
     })));
     TRY(game_menu->try_add_separator());
+    auto undo_action = GUI::CommonActions::make_undo_action([&](auto&) {
+        game.perform_undo();
+    });
+    undo_action->set_enabled(false);
+    TRY(game_menu->try_add_action(undo_action));
+    TRY(game_menu->try_add_separator());
     TRY(game_menu->try_add_action(single_suit_action));
     TRY(game_menu->try_add_action(two_suit_action));
     TRY(game_menu->try_add_separator());
@@ -273,6 +279,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(Spider::Game::width, Spider::Game::height + statusbar.max_height().as_int());
     window->set_icon(app_icon.bitmap_for_size(16));
     window->show();
+
+    game.on_undo_availability_change = [&](bool undo_available) {
+        undo_action->set_enabled(undo_available);
+    };
 
     game.setup(mode);
 


### PR DESCRIPTION
The lets the user undo the last card move. Card moves which cause cards to be moved to the waste stack cannot be undone.