### PR TITLE
Ports/dosfstools: Small fixups

### DIFF
--- a/Ports/dosfstools/package.sh
+++ b/Ports/dosfstools/package.sh
@@ -7,10 +7,6 @@ config_sub_paths=('config.sub')
 files="https://github.com/dosfstools/dosfstools/releases/download/v${version}/dosfstools-${version}.tar.gz dosfstools-${version}.tar.gz 64926eebf90092dca21b14259a5301b7b98e7b1943e8a201c7d726084809b527"
 auth_type='sha256'
 
-pre_configure() {
-    run ./autogen.sh 
-}
-
 post_install() {
     ln -sf /usr/local/sbin/mkfs.fat "${SERENITY_INSTALL_ROOT}/usr/local/sbin/mkfs.vfat"
     ln -sf /usr/local/sbin/mkfs.fat "${SERENITY_INSTALL_ROOT}/usr/local/sbin/mkfs.msdos"

--- a/Ports/dosfstools/package.sh
+++ b/Ports/dosfstools/package.sh
@@ -6,8 +6,6 @@ use_fresh_config_sub='true'
 config_sub_paths=('config.sub')
 files="https://github.com/dosfstools/dosfstools/releases/download/v${version}/dosfstools-${version}.tar.gz dosfstools-${version}.tar.gz 64926eebf90092dca21b14259a5301b7b98e7b1943e8a201c7d726084809b527"
 auth_type='sha256'
-
-post_install() {
-    ln -sf /usr/local/sbin/mkfs.fat "${SERENITY_INSTALL_ROOT}/usr/local/sbin/mkfs.vfat"
-    ln -sf /usr/local/sbin/mkfs.fat "${SERENITY_INSTALL_ROOT}/usr/local/sbin/mkfs.msdos"
-}
+configopts=(
+    "--enable-compat-symlinks"
+)


### PR DESCRIPTION
I meant to mention this on the original PR, but then it got :ninjamerge:d while I was having lunch.

The release tarball arrives preconfigured, so there is no need for us to run autogen manually.

Also, replace the manual creation of symlinks with the `--enable-compat-symlinks` configure option, which automatically creates the symlinks that we want and more.