### PR TITLE
Base+Taskbar: Support launching apps that require root like PartitionEditor

### DIFF
--- a/Base/res/apps/PartitionEditor.af
+++ b/Base/res/apps/PartitionEditor.af
@@ -1,4 +1,5 @@
 [App]
 Name=Partition Editor
 Executable=/bin/PartitionEditor
+RequiresRoot=true
 Category=Utilities


### PR DESCRIPTION
Thanks to @ne0ndrag0n, `Settings` supports launching apps like `NetworkSettings` that require root via `Escalator`. This PR simply extends this functionality to `Taskbar` so apps like `PartitionEditor` can benefit too.

The only difference is that in the case that `Taskbar` launches an root requiring executable in `Terminal`, we use `pls` instead of `Escalator`. No apps currently take advantage of both `RunInTerminal` and `RequiresRoot` like this, but it does work if you create such an app file. I tested this by installing the Python port and adding `RequiresRoot=true` to its app file.