### PR TITLE
Kernel/SysFS: Expose file size of ACPI tables in /sys/firmware/acpi

### DIFF
--- a/Kernel/Firmware/ACPI/Parser.h
+++ b/Kernel/Firmware/ACPI/Parser.h
@@ -42,7 +42,7 @@ protected:
     ACPISysFSComponent(NonnullOwnPtr<KString> table_name, PhysicalAddress, size_t table_size);
 
     PhysicalAddress m_paddr;
-    size_t m_length;
+    size_t m_length { 0 };
     NonnullOwnPtr<KString> m_table_name;
 };
 

--- a/Kernel/Firmware/ACPI/Parser.h
+++ b/Kernel/Firmware/ACPI/Parser.h
@@ -37,6 +37,8 @@ public:
     virtual StringView name() const override { return m_table_name->view(); }
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
 
+    virtual size_t size() const override final { return m_length; }
+
 protected:
     ErrorOr<NonnullOwnPtr<KBuffer>> try_to_generate_buffer() const;
     ACPISysFSComponent(NonnullOwnPtr<KString> table_name, PhysicalAddress, size_t table_size);


### PR DESCRIPTION
It costs us nothing, and some utilities (such as the known file utility) rely on the advertised file size (after doing `lstat` on it).