### PR TITLE
LibWeb: Add support for DOM::Document to XHR::send()

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -130,6 +130,9 @@ CppType idl_type_name_to_cpp_type(Type const& type, Interface const& interface)
     if (type.name() == "BufferSource")
         return { .name = "JS::Handle<JS::Object>", .sequence_storage_type = SequenceStorageType::MarkedVector };
 
+    if (type.name() == "XMLHttpRequestBodyInit")
+        return { .name = "Fetch::XMLHttpRequestBodyInit", .sequence_storage_type = SequenceStorageType::MarkedVector };
+
     if (type.name() == "sequence") {
         auto& parameterized_type = verify_cast<ParameterizedType>(type);
         auto& sequence_type = parameterized_type.parameters().first();

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -128,7 +128,7 @@ void HTMLFormElement::submit_form(JS::GCPtr<HTMLElement> submitter, bool from_su
         auto body = url_encode(parameters, AK::URL::PercentEncodeSet::ApplicationXWWWFormUrlencoded).to_byte_buffer();
         request.set_method("POST");
         request.set_header("Content-Type", "application/x-www-form-urlencoded");
-        request.set_body(body);
+        request.set_body(move(body));
     }
 
     if (auto* page = document().page())

--- a/Userland/Libraries/LibWeb/Loader/LoadRequest.h
+++ b/Userland/Libraries/LibWeb/Loader/LoadRequest.h
@@ -33,7 +33,7 @@ public:
     void set_method(String const& method) { m_method = method; }
 
     ByteBuffer const& body() const { return m_body; }
-    void set_body(ByteBuffer const& body) { m_body = body; }
+    void set_body(ByteBuffer body) { m_body = move(body); }
 
     void start_timer() { m_load_timer.start(); };
     Time load_time() const { return m_load_timer.elapsed_time(); }

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -47,7 +47,7 @@ public:
 
     WebIDL::ExceptionOr<void> open(String const& method, String const& url);
     WebIDL::ExceptionOr<void> open(String const& method, String const& url, bool async, String const& username = {}, String const& password = {});
-    WebIDL::ExceptionOr<void> send(Optional<Fetch::XMLHttpRequestBodyInit> body);
+    WebIDL::ExceptionOr<void> send(Optional<Variant<JS::Handle<DOM::Document>, Fetch::XMLHttpRequestBodyInit>> body = {});
 
     WebIDL::ExceptionOr<void> set_request_header(String const& header, String const& value);
     void set_response_type(Bindings::XMLHttpRequestResponseType type) { m_response_type = type; }

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
@@ -1,3 +1,4 @@
+#import <DOM/Document.idl>
 #import <DOM/EventHandler.idl>
 #import <Fetch/BodyInit.idl>
 #import <XHR/XMLHttpRequestEventTarget.idl>
@@ -33,7 +34,7 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
     undefined open(DOMString method, DOMString url);
     undefined open(ByteString method, USVString url, boolean async, optional USVString? username = {}, optional USVString? password = {});
     undefined setRequestHeader(DOMString name, DOMString value);
-    undefined send(optional XMLHttpRequestBodyInit? body = null);
+    undefined send(optional (Document or XMLHttpRequestBodyInit)? body = null);
 
     ByteString? getResponseHeader(ByteString name);
     ByteString getAllResponseHeaders();


### PR DESCRIPTION
This patch adds support for posting a `DOM::Document` using `XHR::send()`.