### PR TITLE
LibJS+js: Disable console debug messages outside Serenity only for js

### DIFF
--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -427,9 +427,8 @@ MarkedVector<Value> Console::vm_arguments()
     return arguments;
 }
 
-void Console::output_debug_message([[maybe_unused]] LogLevel log_level, [[maybe_unused]] String output) const
+void Console::output_debug_message(LogLevel log_level, String const& output) const
 {
-#ifdef AK_OS_SERENITY
     switch (log_level) {
     case Console::LogLevel::Debug:
         dbgln("\033[32;1m(js debug)\033[0m {}", output);
@@ -450,7 +449,6 @@ void Console::output_debug_message([[maybe_unused]] LogLevel log_level, [[maybe_
         dbgln("\033[32;1m(js)\033[0m {}", output);
         break;
     }
-#endif
 }
 
 void Console::report_exception(JS::Error const& exception, bool in_promise) const

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -81,7 +81,7 @@ public:
     ThrowCompletionOr<Value> time_log();
     ThrowCompletionOr<Value> time_end();
 
-    void output_debug_message(LogLevel log_level, String output) const;
+    void output_debug_message(LogLevel log_level, String const& output) const;
     void report_exception(JS::Error const&, bool) const;
 
 private:

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1472,7 +1472,9 @@ public:
         }
 
         auto output = String::join(' ', arguments.get<JS::MarkedVector<JS::Value>>());
+#ifdef AK_OS_SERENITY
         m_console.output_debug_message(log_level, output);
+#endif
 
         switch (log_level) {
         case JS::Console::LogLevel::Debug:


### PR DESCRIPTION
Previously we would disable console debug messages on all non Serenity platforms as it caused double printing on lagom `js`. This pull request limits this to the `js` utility, allowing LibWeb to print debug messages regardless of the operating system :^)

With that we get nice debug messages in ladybird

![image](https://user-images.githubusercontent.com/42888162/196006979-10267d4a-24e5-4e58-8a6a-c5816e28dc46.png)
