### PR TITLE
LibJS: Subtract time zone offsets when converting from local time to UTC

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -342,7 +342,7 @@ Vector<Crypto::SignedBigInteger> get_named_time_zone_epoch_nanoseconds(StringVie
     // Can only fail if the time zone identifier is invalid, which cannot be the case here.
     VERIFY(offset.has_value());
 
-    return { local_nanoseconds.plus(Crypto::SignedBigInteger { offset->seconds }.multiplied_by(s_one_billion_bigint)) };
+    return { local_nanoseconds.minus(Crypto::SignedBigInteger { offset->seconds }.multiplied_by(s_one_billion_bigint)) };
 }
 
 // 21.4.1.9 GetNamedTimeZoneOffsetNanoseconds ( timeZoneIdentifier, epochNanoseconds ), https://tc39.es/ecma262/#sec-getnamedtimezoneoffsetnanoseconds


### PR DESCRIPTION
When converting to UTC, the UTC AO first tries to disambiguate possible time zone offsets for the given local time. When doing so, the GetNamedTimeZoneEpochNanoseconds AO must *subtract* the found time zone offset from the local time to convert to UTC. The same is performed later in the UTC AO when returning the final UTC time (step 5).

Unfortunately adding a test here doesn't quite expose the issue because test-js runs in UTC. So on the side, I'll work on getting test-js to support specifying time zones for testing regressions like this.