### PR TITLE
SpiceAgent: Add unveil call on the /proc/all node path

### DIFF
--- a/Userland/Services/SpiceAgent/main.cpp
+++ b/Userland/Services/SpiceAgent/main.cpp
@@ -18,6 +18,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     TRY(Core::System::pledge("unix rpath wpath stdio sendfd recvfd"));
     TRY(Core::System::unveil(SPICE_DEVICE, "rw"sv));
+    TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/clipboard", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 


### PR DESCRIPTION
This is needed later in the program when doing unveil on the path of "/tmp/session/%sid/portal/clipboard", because %sid is translated to the root session ID which therefore relies on access to the `/proc/all` node.

This fixes a regression after [this commit](https://github.com/SerenityOS/serenity/commit/323c403d43f4ceba2d7275cd0d47c8187b07af5b).

cc @ne0ndrag0n 