### PR TITLE
Meta: Define `SUDO` for all the image building scripts (+ a bit of housekeeping)

### DIFF
--- a/Meta/.shell_include.sh
+++ b/Meta/.shell_include.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# shellcheck disable=SC2034
+# SC2034: "Variable appears unused. Verify it or export it."
+#         Those are intentional here, as the file is meant to be included elsewhere.
+
+SUDO="sudo"
+
+if [ "$(uname -s)" = "SerenityOS" ]; then
+    SUDO="pls"
+fi
+
+die() {
+    echo "die: $*"
+    exit 1
+}

--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -2,16 +2,9 @@
 
 set -e
 
-SUDO="sudo"
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
-if [ "$(uname -s)" = "SerenityOS" ]; then
-    SUDO="pls"
-fi
-
-die() {
-    echo "die: $*"
-    exit 1
-}
+. "${script_path}/.shell_include.sh"
 
 if [ "$(id -u)" != 0 ]; then
     set +e
@@ -98,7 +91,6 @@ mkdir -p mnt
 mount "${dev}${partition_number}" mnt/ || die "couldn't mount filesystem"
 echo "done"
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 "$script_path/build-root-filesystem.sh"
 
 if [ -z "$1" ]; then

--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+SUDO="sudo"
+
+if [ "$(uname -s)" = "SerenityOS" ]; then
+    SUDO="pls"
+fi
+
 die() {
     echo "die: $*"
     exit 1

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -2,16 +2,9 @@
 
 set -e
 
-SUDO="sudo"
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
-if [ "$(uname -s)" = "SerenityOS" ]; then
-    SUDO="pls"
-fi
-
-die() {
-    echo "die: $*"
-    exit 1
-}
+. "${script_path}/.shell_include.sh"
 
 if [ "$(id -u)" != 0 ]; then
     set +e
@@ -116,7 +109,6 @@ mkdir -p mnt
 mount "${dev}${partition_number}" mnt/ || die "couldn't mount filesystem"
 echo "done"
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 "$script_path/build-root-filesystem.sh"
 
 if [ -z "$2" ]; then

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+SUDO="sudo"
+
+if [ "$(uname -s)" = "SerenityOS" ]; then
+    SUDO="pls"
+fi
+
 die() {
     echo "die: $*"
     exit 1

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -2,16 +2,9 @@
 
 set -e
 
-SUDO="sudo"
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
-if [ "$(uname -s)" = "SerenityOS" ]; then
-    SUDO="pls"
-fi
-
-die() {
-    echo "die: $*"
-    exit 1
-}
+. "${script_path}/.shell_include.sh"
 
 if [ ! -d "limine" ]; then
     echo "limine not found, the script will now build it"
@@ -102,7 +95,6 @@ mkdir -p mnt
 mount "${dev}p2" mnt || die "couldn't mount root filesystem"
 echo "done"
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 "$script_path/build-root-filesystem.sh"
 
 echo "installing limine"

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+SUDO="sudo"
+
+if [ "$(uname -s)" = "SerenityOS" ]; then
+    SUDO="pls"
+fi
+
 die() {
     echo "die: $*"
     exit 1

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -14,16 +14,9 @@ fi
 
 set -e
 
-SUDO="sudo"
+SCRIPT_DIR="$(dirname "${0}")"
 
-if [ "$(uname -s)" = "SerenityOS" ]; then
-    SUDO="pls"
-fi
-
-die() {
-    echo "die: $*"
-    exit 1
-}
+. "${SCRIPT_DIR}/.shell_include.sh"
 
 USE_FUSE2FS=0
 
@@ -66,7 +59,6 @@ else
     fi
 fi
 
-SCRIPT_DIR="$(dirname "${0}")"
 
 # Prepend the toolchain qemu directory so we pick up QEMU from there
 PATH="$SCRIPT_DIR/../Toolchain/Local/qemu/bin:$PATH"

--- a/Meta/build-native-partition.sh
+++ b/Meta/build-native-partition.sh
@@ -2,16 +2,9 @@
 
 set -e
 
-SUDO="sudo"
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
-if [ "$(uname -s)" = "SerenityOS" ]; then
-    SUDO="pls"
-fi
-
-die() {
-    echo "die: $*"
-    exit 1
-}
+. "${script_path}/.shell_include.sh"
 
 cleanup() {
     if [ -d mnt ]; then
@@ -60,5 +53,4 @@ else
     echo "done"
 fi
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 "$script_path/build-root-filesystem.sh"

--- a/Meta/build-native-partition.sh
+++ b/Meta/build-native-partition.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+SUDO="sudo"
+
+if [ "$(uname -s)" = "SerenityOS" ]; then
+    SUDO="pls"
+fi
+
 die() {
     echo "die: $*"
     exit 1

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -36,7 +36,7 @@ if (( ${#files[@]} )); then
         exit 1
     fi
 
-    shellcheck "${files[@]}"
+    shellcheck --source-path=SCRIPTDIR "${files[@]}"
 
     for file in "${files[@]}"; do
         if (< "$file" grep -qE "grep [^|);]*-[^- ]*P"); then


### PR DESCRIPTION
Back when adding support for `pls` as a `sudo` replacement, `build-image-qemu` dynamically set the `SUDO` variable depending on what system it was running on and used the contents of that variable to call the correct elevation utility.

During recent changes to the elevation error message, that usage of the variable was replicated across all of our scripts, but without also replicating the logic to set that variable in the first place.

Add back the variable setting logic to all the other scripts to keep them from running into unset variables.

While at it, let's also move those definitions into a common file so that we don't have to copy-paste them that often.