### PR TITLE
LibCore+LibDesktop+Ports: Allow launcher applications to specify working directory

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -76,6 +76,7 @@ auth_opts=()
 launcher_name=
 launcher_category=
 launcher_command=
+launcher_workdir=
 launcher_run_in_terminal=false
 icon_file=
 
@@ -204,18 +205,19 @@ install_icon() {
 
 install_main_launcher() {
     if [ -n "$launcher_name" ] && [ -n "$launcher_category" ] && [ -n "$launcher_command" ]; then
-        install_launcher "$launcher_name" "$launcher_category" "$launcher_command"
+        install_launcher "$launcher_name" "$launcher_category" "$launcher_command" "$launcher_workdir"
     fi
 }
 
 install_launcher() {
-    if [ "$#" -lt 3 ]; then
-        echo "Syntax: install_launcher <name> <category> <command>"
+    if [ "$#" -lt 4 ]; then
+        echo "Syntax: install_launcher <name> <category> <command> <workdir>"
         exit 1
     fi
     local launcher_name="$1"
     local launcher_category="$2"
     local launcher_command="$3"
+    local launcher_workdir="$4"
     local launcher_filename="${launcher_name,,}"
     launcher_filename="${launcher_filename// /}"
     local icon_override=""
@@ -240,6 +242,7 @@ SCRIPT
 Name=$launcher_name
 Executable=$launcher_executable
 Category=$launcher_category
+WorkingDirectory=$launcher_workdir
 RunInTerminal=$launcher_run_in_terminal
 ${icon_override}
 CONFIG

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -22,6 +22,7 @@ namespace Core {
 
 struct ArgvList {
     String m_path;
+    String m_working_directory;
     Vector<char const*, 10> m_argv;
 
     ArgvList(String path, size_t size)
@@ -43,25 +44,38 @@ struct ArgvList {
         return m_argv;
     }
 
+    void set_working_directory(String const& working_directory)
+    {
+        m_working_directory = working_directory;
+    }
+
     ErrorOr<pid_t> spawn()
     {
-        auto pid = TRY(System::posix_spawn(m_path.view(), nullptr, nullptr, const_cast<char**>(get().data()), environ));
 #ifdef AK_OS_SERENITY
+        posix_spawn_file_actions_t spawn_actions;
+        posix_spawn_file_actions_init(&spawn_actions);
+        if (!m_working_directory.is_empty())
+            posix_spawn_file_actions_addchdir(&spawn_actions, m_working_directory.characters());
+
+        auto pid = TRY(System::posix_spawn(m_path.view(), &spawn_actions, nullptr, const_cast<char**>(get().data()), environ));
         TRY(System::disown(pid));
+#else
+        auto pid = TRY(System::posix_spawn(m_path.view(), nullptr, nullptr, const_cast<char**>(get().data()), environ));
 #endif
         return pid;
     }
 };
 
-ErrorOr<pid_t> Process::spawn(StringView path, Span<String const> arguments)
+ErrorOr<pid_t> Process::spawn(StringView path, Span<String const> arguments, String working_directory)
 {
     ArgvList argv { path, arguments.size() };
     for (auto const& arg : arguments)
         argv.append(arg.characters());
+    argv.set_working_directory(working_directory);
     return argv.spawn();
 }
 
-ErrorOr<pid_t> Process::spawn(StringView path, Span<StringView const> arguments)
+ErrorOr<pid_t> Process::spawn(StringView path, Span<StringView const> arguments, String working_directory)
 {
     Vector<String> backing_strings;
     backing_strings.ensure_capacity(arguments.size());
@@ -70,14 +84,16 @@ ErrorOr<pid_t> Process::spawn(StringView path, Span<StringView const> arguments)
         backing_strings.append(arg);
         argv.append(backing_strings.last().characters());
     }
+    argv.set_working_directory(working_directory);
     return argv.spawn();
 }
 
-ErrorOr<pid_t> Process::spawn(StringView path, Span<char const* const> arguments)
+ErrorOr<pid_t> Process::spawn(StringView path, Span<char const* const> arguments, String working_directory)
 {
     ArgvList argv { path, arguments.size() };
     for (auto arg : arguments)
         argv.append(arg);
+    argv.set_working_directory(working_directory);
     return argv.spawn();
 }
 

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -14,9 +14,9 @@ namespace Core {
 
 class Process {
 public:
-    static ErrorOr<pid_t> spawn(StringView path, Span<String const> arguments);
-    static ErrorOr<pid_t> spawn(StringView path, Span<StringView const> arguments);
-    static ErrorOr<pid_t> spawn(StringView path, Span<char const* const> arguments = {});
+    static ErrorOr<pid_t> spawn(StringView path, Span<String const> arguments, String working_directory = {});
+    static ErrorOr<pid_t> spawn(StringView path, Span<StringView const> arguments, String working_directory = {});
+    static ErrorOr<pid_t> spawn(StringView path, Span<char const* const> arguments = {}, String working_directory = {});
 };
 
 }

--- a/Userland/Libraries/LibDesktop/AppFile.cpp
+++ b/Userland/Libraries/LibDesktop/AppFile.cpp
@@ -82,6 +82,11 @@ String AppFile::category() const
     return m_config->read_entry("App", "Category").trim_whitespace();
 }
 
+String AppFile::working_directory() const
+{
+    return m_config->read_entry("App", "WorkingDirectory").trim_whitespace();
+}
+
 String AppFile::icon_path() const
 {
     return m_config->read_entry("App", "IconPath").trim_whitespace();
@@ -145,7 +150,7 @@ bool AppFile::spawn() const
     if (!is_valid())
         return false;
 
-    auto pid = Core::Process::spawn(executable());
+    auto pid = Core::Process::spawn(executable(), Span<String const> {}, working_directory());
     if (pid.is_error())
         return false;
 

--- a/Userland/Libraries/LibDesktop/AppFile.h
+++ b/Userland/Libraries/LibDesktop/AppFile.h
@@ -29,6 +29,7 @@ public:
     String executable() const;
     String category() const;
     String description() const;
+    String working_directory() const;
     String icon_path() const;
     GUI::Icon icon() const;
     bool run_in_terminal() const;


### PR DESCRIPTION
This adds a new `WorkingDirectory` property to .af files that ensures launcher applications will run with a specific working directory. This is needed for the ClassiCube port (PR https://github.com/SerenityOS/serenity/pull/15622) to prevent the game from creating its various resources in `/usr/local/bin/`.