### PR TITLE
Ports/dmidecode: Remove install and post_install overriden sequences

### DIFF
--- a/Ports/dmidecode/package.sh
+++ b/Ports/dmidecode/package.sh
@@ -1,19 +1,5 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port='dmidecode'
 version='3.4'
-useconfigure='false'
 files="https://download.savannah.gnu.org/releases/dmidecode/dmidecode-${version}.tar.xz dmidecode-${version}.tar.xz 43cba851d8467c9979ccdbeab192eb6638c7d3a697eba5ddb779da8837542212"
 auth_type='sha256'
-
-install() {
-    run make clean
-    run make
-}
-
-post_install() {
-    mkdir -p "${SERENITY_INSTALL_ROOT}/bin"
-    run make install-bin DESTDIR="${SERENITY_INSTALL_ROOT}"
-    ln -sf /usr/local/sbin/dmidecode "${SERENITY_INSTALL_ROOT}/bin/dmidecode"
-    ln -sf /usr/local/sbin/biosdecode "${SERENITY_INSTALL_ROOT}/bin/biosdecode"
-    ln -sf /usr/local/sbin/vpddecode "${SERENITY_INSTALL_ROOT}/bin/vpddecode"
-}


### PR DESCRIPTION
We used to do whole bunch of unnecessary things in the install sequence which the default port_include script sequence can do just fine. The post-install sequence wrongly called "make install-bin" which could be done in the default install sequence, as well as to create the /bin directory which is completely unnecessary to do because the image build script already does that for us.