### PR TITLE
WebDriver: Eat (delete) all the cookies!

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -566,6 +566,10 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
         m_cookie_jar.dump_cookies();
     };
 
+    new_tab.on_update_cookie = [this](auto const& url, auto cookie) {
+        m_cookie_jar.update_cookie(url, move(cookie));
+    };
+
     new_tab.on_get_cookies_entries = [this]() {
         return m_cookie_jar.get_all_cookies();
     };

--- a/Userland/Applications/Browser/CookieJar.h
+++ b/Userland/Applications/Browser/CookieJar.h
@@ -28,6 +28,7 @@ class CookieJar {
 public:
     String get_cookie(const URL& url, Web::Cookie::Source source);
     void set_cookie(const URL& url, Web::Cookie::ParsedCookie const& parsed_cookie, Web::Cookie::Source source);
+    void update_cookie(URL const&, Web::Cookie::Cookie);
     void dump_cookies() const;
     Vector<Web::Cookie::Cookie> get_all_cookies() const;
 

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -64,6 +64,7 @@ public:
     Function<String(const URL&, Web::Cookie::Source source)> on_get_cookie;
     Function<void(const URL&, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source)> on_set_cookie;
     Function<void()> on_dump_cookies;
+    Function<void(URL const&, Web::Cookie::Cookie)> on_update_cookie;
     Function<Vector<Web::Cookie::Cookie>()> on_get_cookies_entries;
     Function<OrderedHashMap<String, String>()> on_get_local_storage_entries;
     Function<OrderedHashMap<String, String>()> on_get_session_storage_entries;

--- a/Userland/Applications/Browser/WebDriverConnection.cpp
+++ b/Userland/Applications/Browser/WebDriverConnection.cpp
@@ -95,4 +95,14 @@ Messages::WebDriverSessionClient::GetNamedCookieResponse WebDriverConnection::ge
     return { {} };
 }
 
+void WebDriverConnection::update_cookie(Web::Cookie::Cookie const& cookie)
+{
+    if (auto browser_window = m_browser_window.strong_ref()) {
+        auto& tab = browser_window->active_tab();
+        if (tab.on_update_cookie) {
+            tab.on_update_cookie(tab.url(), cookie);
+        }
+    }
+}
+
 }

--- a/Userland/Applications/Browser/WebDriverConnection.h
+++ b/Userland/Applications/Browser/WebDriverConnection.h
@@ -45,6 +45,7 @@ public:
     virtual void forward() override;
     virtual Messages::WebDriverSessionClient::GetAllCookiesResponse get_all_cookies() override;
     virtual Messages::WebDriverSessionClient::GetNamedCookieResponse get_named_cookie(String const& name) override;
+    virtual void update_cookie(Web::Cookie::Cookie const&) override;
 
 private:
     WebDriverConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, NonnullRefPtr<BrowserWindow> browser_window);

--- a/Userland/Applications/Browser/WebDriverSessionClient.ipc
+++ b/Userland/Applications/Browser/WebDriverSessionClient.ipc
@@ -13,5 +13,6 @@ endpoint WebDriverSessionClient {
     forward() =|
     get_all_cookies() => (Vector<Web::Cookie::Cookie> cookies)
     get_named_cookie(String name) => (Optional<Web::Cookie::Cookie> cookie)
+    update_cookie(Web::Cookie::Cookie cookie) =|
 
 }

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -32,6 +32,7 @@ Vector<Client::Route> Client::s_routes = {
     { HTTP::HttpRequest::Method::POST, { "session", ":session_id", "forward" }, &Client::handle_forward },
     { HTTP::HttpRequest::Method::GET, { "session", ":session_id", "cookie" }, &Client::handle_get_all_cookies },
     { HTTP::HttpRequest::Method::GET, { "session", ":session_id", "cookie", ":name" }, &Client::handle_get_named_cookie },
+    { HTTP::HttpRequest::Method::DELETE, { "session", ":session_id", "cookie", ":name" }, &Client::handle_delete_cookie },
     { HTTP::HttpRequest::Method::DELETE, { "session", ":session_id", "cookie" }, &Client::handle_delete_all_cookies },
 };
 
@@ -513,6 +514,17 @@ ErrorOr<JsonValue, HttpError> Client::handle_get_named_cookie(Vector<StringView>
     auto cookies = TRY(session->get_named_cookie(parameters[1]));
 
     return make_json_value(cookies);
+}
+
+// DELETE /session/{session id}/cookie/{name} https://w3c.github.io/webdriver/#dfn-delete-cookie
+ErrorOr<JsonValue, HttpError> Client::handle_delete_cookie(Vector<StringView> parameters, JsonValue const&)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling DELETE /session/<session_id>/cookie/<name>");
+    Session* session = TRY(find_session_with_id(parameters[0]));
+
+    // NOTE: Spec steps handled in Session::delete_cookie().
+    auto result = TRY(session->delete_cookie(parameters[1]));
+    return make_json_value(result);
 }
 
 // DELETE /session/{session id}/cookie https://w3c.github.io/webdriver/#dfn-delete-all-cookies

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -32,6 +32,7 @@ Vector<Client::Route> Client::s_routes = {
     { HTTP::HttpRequest::Method::POST, { "session", ":session_id", "forward" }, &Client::handle_forward },
     { HTTP::HttpRequest::Method::GET, { "session", ":session_id", "cookie" }, &Client::handle_get_all_cookies },
     { HTTP::HttpRequest::Method::GET, { "session", ":session_id", "cookie", ":name" }, &Client::handle_get_named_cookie },
+    { HTTP::HttpRequest::Method::DELETE, { "session", ":session_id", "cookie" }, &Client::handle_delete_all_cookies },
 };
 
 Client::Client(NonnullOwnPtr<Core::Stream::BufferedTCPSocket> socket, Core::Object* parent)
@@ -512,6 +513,17 @@ ErrorOr<JsonValue, HttpError> Client::handle_get_named_cookie(Vector<StringView>
     auto cookies = TRY(session->get_named_cookie(parameters[1]));
 
     return make_json_value(cookies);
+}
+
+// DELETE /session/{session id}/cookie https://w3c.github.io/webdriver/#dfn-delete-all-cookies
+ErrorOr<JsonValue, HttpError> Client::handle_delete_all_cookies(Vector<StringView> parameters, JsonValue const&)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling DELETE /session/<session_id>/cookie");
+    Session* session = TRY(find_session_with_id(parameters[0]));
+
+    // NOTE: Spec steps handled in Session::delete_all_cookies().
+    auto result = TRY(session->delete_all_cookies());
+    return make_json_value(result);
 }
 
 }

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -58,6 +58,7 @@ private:
     ErrorOr<JsonValue, HttpError> handle_forward(Vector<StringView>, JsonValue const& payload);
     ErrorOr<JsonValue, HttpError> handle_get_all_cookies(Vector<StringView>, JsonValue const& payload);
     ErrorOr<JsonValue, HttpError> handle_get_named_cookie(Vector<StringView>, JsonValue const& payload);
+    ErrorOr<JsonValue, HttpError> handle_delete_all_cookies(Vector<StringView>, JsonValue const& payload);
 
     ErrorOr<Session*, HttpError> find_session_with_id(StringView session_id);
     JsonValue make_json_value(JsonValue const&);

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -58,6 +58,7 @@ private:
     ErrorOr<JsonValue, HttpError> handle_forward(Vector<StringView>, JsonValue const& payload);
     ErrorOr<JsonValue, HttpError> handle_get_all_cookies(Vector<StringView>, JsonValue const& payload);
     ErrorOr<JsonValue, HttpError> handle_get_named_cookie(Vector<StringView>, JsonValue const& payload);
+    ErrorOr<JsonValue, HttpError> handle_delete_cookie(Vector<StringView>, JsonValue const& payload);
     ErrorOr<JsonValue, HttpError> handle_delete_all_cookies(Vector<StringView>, JsonValue const& payload);
 
     ErrorOr<Session*, HttpError> find_session_with_id(StringView session_id);

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -297,4 +297,39 @@ ErrorOr<JsonValue, HttpError> Session::get_named_cookie(String const& name)
     return HttpError { 404, "no such cookie", "Cookie not found" };
 }
 
+// https://w3c.github.io/webdriver/#dfn-delete-cookies
+void Session::delete_cookies(Optional<StringView> const& name)
+{
+    // For each cookie among all associated cookies of the current browsing context’s active document,
+    // run the substeps of the first matching condition:
+    for (auto& cookie : m_browser_connection->get_all_cookies()) {
+        // -> name is undefined
+        // -> name is equal to cookie name
+        if (!name.has_value() || name.value() == cookie.name) {
+            // Set the cookie expiry time to a Unix timestamp in the past.
+            cookie.expiry_time = Core::DateTime::from_timestamp(0);
+            m_browser_connection->async_update_cookie(cookie);
+        }
+        // -> Otherwise
+        //    Do nothing.
+    }
+}
+
+// DELETE /session/{session id}/cookie https://w3c.github.io/webdriver/#dfn-delete-all-cookies
+ErrorOr<JsonValue, HttpError> Session::delete_all_cookies()
+{
+    // 1. If the current browsing context is no longer open, return error with error code no such window.
+    auto current_window = get_window_object();
+    if (!current_window.has_value())
+        return HttpError { 404, "no such window", "Window not found" };
+
+    // FIXME: 2. Handle any user prompts, and return its value if it is an error.
+
+    // 3. Delete cookies, giving no filtering argument.
+    delete_cookies();
+
+    // 4. Return success with data null.
+    return JsonValue();
+}
+
 }

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -315,6 +315,23 @@ void Session::delete_cookies(Optional<StringView> const& name)
     }
 }
 
+// DELETE /session/{session id}/cookie/{name} https://w3c.github.io/webdriver/#dfn-delete-cookie
+ErrorOr<JsonValue, HttpError> Session::delete_cookie(StringView const& name)
+{
+    // 1. If the current browsing context is no longer open, return error with error code no such window.
+    auto current_window = get_window_object();
+    if (!current_window.has_value())
+        return HttpError { 404, "no such window", "Window not found" };
+
+    // FIXME: 2. Handle any user prompts, and return its value if it is an error.
+
+    // 3. Delete cookies using the url variable name parameter as the filter argument.
+    delete_cookies(name);
+
+    // 4. Return success with data null.
+    return JsonValue();
+}
+
 // DELETE /session/{session id}/cookie https://w3c.github.io/webdriver/#dfn-delete-all-cookies
 ErrorOr<JsonValue, HttpError> Session::delete_all_cookies()
 {

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -42,8 +42,11 @@ public:
     ErrorOr<JsonValue, HttpError> forward();
     ErrorOr<JsonValue, HttpError> get_all_cookies();
     ErrorOr<JsonValue, HttpError> get_named_cookie(String const& name);
+    ErrorOr<JsonValue, HttpError> delete_all_cookies();
 
 private:
+    void delete_cookies(Optional<StringView> const& name = {});
+
     NonnullRefPtr<Client> m_client;
     bool m_started { false };
     unsigned m_id { 0 };

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -42,6 +42,7 @@ public:
     ErrorOr<JsonValue, HttpError> forward();
     ErrorOr<JsonValue, HttpError> get_all_cookies();
     ErrorOr<JsonValue, HttpError> get_named_cookie(String const& name);
+    ErrorOr<JsonValue, HttpError> delete_cookie(StringView const& name);
     ErrorOr<JsonValue, HttpError> delete_all_cookies();
 
 private:


### PR DESCRIPTION
Two more for @AtkinsSJ list in #15551 
This needed some plumbing into the Browser to allow for the changing of Cookies.
What good does it bring if we can only see Cookies, now we can eat them too!