### PR TITLE
AK: Document the non-standard extensions in TRY

### DIFF
--- a/AK/Try.h
+++ b/AK/Try.h
@@ -8,6 +8,11 @@
 
 // NOTE: This macro works with any result type that has the expected APIs.
 //       It's designed with AK::Result and AK::Error in mind.
+//
+//       It depends on a non-standard C++ extension, specifically
+//       on statement expressions [1]. This is known to be implemented
+//       by at least clang and gcc.
+//       [1] https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html
 
 #define TRY(expression)                                \
     ({                                                 \


### PR DESCRIPTION
I'm not sure there's a material improvement from this patch. However, I've been reading the error handling code from multiple projects and was excited to see Serenity being able to handle assignment  (`auto x = TRY(make_x())`) the same way as actions (`TRY(do_x())`). I think it's worth documenting that this is only possible due to non-standard extensions.