### PR TITLE
SpiceAgent: Unveil /proc/all

### DIFF
--- a/Userland/Services/SpiceAgent/main.cpp
+++ b/Userland/Services/SpiceAgent/main.cpp
@@ -17,6 +17,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     Core::EventLoop loop;
 
     TRY(Core::System::pledge("unix rpath wpath stdio sendfd recvfd"));
+    TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil(SPICE_DEVICE, "rw"sv));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/clipboard", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));


### PR DESCRIPTION
This seems to be needed for the sesion-based unveils. Previously this was erroring on boot.