### PR TITLE
LibJS/Temporal: Fix rounding in DifferenceInstant

### DIFF
--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
@@ -299,6 +299,13 @@ FLATTEN SignedBigInteger SignedBigInteger::negated_value() const
     return result;
 }
 
+FLATTEN SignedBigInteger SignedBigInteger::absolute_value() const
+{
+    auto result { *this };
+    result.m_sign = false;
+    return result;
+}
+
 u32 SignedBigInteger::hash() const
 {
     return m_unsigned_data.hash() * (1 - (2 * m_sign));

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -122,6 +122,7 @@ public:
     [[nodiscard]] SignedDivisionResult divided_by(UnsignedBigInteger const& divisor) const;
 
     [[nodiscard]] SignedBigInteger negated_value() const;
+    [[nodiscard]] SignedBigInteger absolute_value() const;
 
     [[nodiscard]] u32 hash() const;
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
@@ -1080,16 +1080,11 @@ ThrowCompletionOr<DurationRecord> add_duration(VM& vm, double years1, double mon
 
     // 11. If largestUnit is not one of "year", "month", "week", or "day", then
     if (!largest_unit.is_one_of("year"sv, "month"sv, "week"sv, "day"sv)) {
-        // a. Let diffNs be ! DifferenceInstant(relativeTo.[[Nanoseconds]], endNs, 1, "nanosecond", "halfExpand").
-        auto* diff_ns = difference_instant(vm, relative_to.nanoseconds(), *end_ns, 1, "nanosecond"sv, "halfExpand"sv);
+        // a. Let result be ! DifferenceInstant(relativeTo.[[Nanoseconds]], endNs, 1, "nanosecond", largestUnit, "halfExpand").
+        auto result = difference_instant(vm, relative_to.nanoseconds(), *end_ns, 1, "nanosecond"sv, largest_unit, "halfExpand"sv);
 
-        // b. Assert: The following steps cannot fail due to overflow in the Number domain because abs(diffNs) ≤ 2 × nsMaxInstant.
-
-        // c. Let result be ! BalanceDuration(0, 0, 0, 0, 0, 0, diffNs, largestUnit).
-        auto result = MUST(balance_duration(vm, 0, 0, 0, 0, 0, 0, diff_ns->big_integer(), largest_unit));
-
-        // d. Return ? CreateDurationRecord(0, 0, 0, 0, result.[[Hours]], result.[[Minutes]], result.[[Seconds]], result.[[Milliseconds]], result.[[Microseconds]], result.[[Nanoseconds]]).
-        return create_duration_record(vm, 0, 0, 0, 0, result.hours, result.minutes, result.seconds, result.milliseconds, result.microseconds, result.nanoseconds);
+        // b. Return ! CreateDurationRecord(0, 0, 0, 0, result.[[Hours]], result.[[Minutes]], result.[[Seconds]], result.[[Milliseconds]], result.[[Microseconds]], result.[[Nanoseconds]]).
+        return create_duration_record(0, 0, 0, 0, result.hours, result.minutes, result.seconds, result.milliseconds, result.microseconds, result.nanoseconds);
     }
 
     // 12. Return ? DifferenceZonedDateTime(relativeTo.[[Nanoseconds]], endNs, timeZone, calendar, largestUnit, OrdinaryObjectCreate(null)).

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.cpp
@@ -13,6 +13,7 @@
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>
+#include <LibJS/Runtime/Temporal/Duration.h>
 #include <LibJS/Runtime/Temporal/Instant.h>
 #include <LibJS/Runtime/Temporal/InstantConstructor.h>
 #include <LibJS/Runtime/Temporal/PlainDateTime.h>
@@ -183,14 +184,26 @@ ThrowCompletionOr<BigInt*> add_instant(VM& vm, BigInt const& epoch_nanoseconds, 
     return result;
 }
 
-// 8.5.7 DifferenceInstant ( ns1, ns2, roundingIncrement, smallestUnit, roundingMode ), https://tc39.es/proposal-temporal/#sec-temporal-differenceinstant
-BigInt* difference_instant(VM& vm, BigInt const& nanoseconds1, BigInt const& nanoseconds2, u64 rounding_increment, StringView smallest_unit, StringView rounding_mode)
+// 8.5.7 DifferenceInstant ( ns1, ns2, roundingIncrement, smallestUnit, largestUnit, roundingMode ), https://tc39.es/proposal-temporal/#sec-temporal-differenceinstant
+TimeDurationRecord difference_instant(VM& vm, BigInt const& nanoseconds1, BigInt const& nanoseconds2, u64 rounding_increment, StringView smallest_unit, StringView largest_unit, StringView rounding_mode)
 {
+    auto n2_minus_n1 = nanoseconds2.big_integer().minus(nanoseconds1.big_integer());
+
     // 1. Assert: Type(ns1) is BigInt.
     // 2. Assert: Type(ns2) is BigInt.
 
-    // 3. Return ! RoundTemporalInstant(ns2 - ns1, roundingIncrement, smallestUnit, roundingMode).
-    return round_temporal_instant(vm, *js_bigint(vm, nanoseconds2.big_integer().minus(nanoseconds1.big_integer())), rounding_increment, smallest_unit, rounding_mode);
+    // 3. Assert: The following step cannot fail due to overflow in the Number domain because abs(ns2 - ns1) ≤ 2 × nsMaxInstant.
+    VERIFY(n2_minus_n1.absolute_value() <= ns_max_instant.multiplied_by("2"_sbigint));
+
+    // 4. Let roundResult be ! RoundDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, ns2 - ns1, roundingIncrement, smallestUnit, roundingMode).[[DurationRecord]].
+    auto round_result = MUST(round_duration(vm, 0, 0, 0, 0, 0, 0, 0, 0, 0, n2_minus_n1.to_double(), rounding_increment, smallest_unit, rounding_mode, nullptr)).duration_record;
+    auto round_result_nanoseconds = Crypto::SignedBigInteger(round_result.nanoseconds);
+
+    // 5. Assert: roundResult.[[Days]] is 0.
+    VERIFY(round_result.days == 0);
+
+    // 6. Return ! BalanceDuration(0, roundResult.[[Hours]], roundResult.[[Minutes]], roundResult.[[Seconds]], roundResult.[[Milliseconds]], roundResult.[[Microseconds]], roundResult.[[Nanoseconds]], largestUnit).
+    return MUST(balance_duration(vm, 0, round_result.hours, round_result.minutes, round_result.seconds, round_result.milliseconds, round_result.microseconds, round_result_nanoseconds, largest_unit));
 }
 
 // 8.5.8 RoundTemporalInstant ( ns, increment, unit, roundingMode ), https://tc39.es/proposal-temporal/#sec-temporal-roundtemporalinstant
@@ -293,15 +306,10 @@ ThrowCompletionOr<Duration*> difference_temporal_instant(VM& vm, DifferenceOpera
     // 3. Let settings be ? GetDifferenceSettings(operation, options, time, « », "nanosecond", "second").
     auto settings = TRY(get_difference_settings(vm, operation, options_value, UnitGroup::Time, {}, { "nanosecond"sv }, "second"sv));
 
-    // 4. Let roundedNs be ! DifferenceInstant(instant.[[Nanoseconds]], other.[[Nanoseconds]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
-    auto* rounded_ns = difference_instant(vm, instant.nanoseconds(), other->nanoseconds(), settings.rounding_increment, settings.smallest_unit, settings.rounding_mode);
+    // 4. Let result be ! DifferenceInstant(instant.[[Nanoseconds]], other.[[Nanoseconds]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[LargestUnit]], settings.[[RoundingMode]]).
+    auto result = difference_instant(vm, instant.nanoseconds(), other->nanoseconds(), settings.rounding_increment, settings.smallest_unit, settings.largest_unit, settings.rounding_mode);
 
-    // 5. Assert: The following steps cannot fail due to overflow in the Number domain because abs(roundedNs) ≤ 2 × nsMaxInstant.
-
-    // 6. Let result be ! BalanceDuration(0, 0, 0, 0, 0, 0, roundedNs, settings.[[LargestUnit]]).
-    auto result = MUST(balance_duration(vm, 0, 0, 0, 0, 0, 0, rounded_ns->big_integer(), settings.largest_unit));
-
-    // 7. Return ! CreateTemporalDuration(0, 0, 0, 0, sign × result.[[Hours]], sign × result.[[Minutes]], sign × result.[[Seconds]], sign × result.[[Milliseconds]], sign × result.[[Microseconds]], sign × result.[[Nanoseconds]]).
+    // 5. Return ! CreateTemporalDuration(0, 0, 0, 0, sign × result.[[Hours]], sign × result.[[Minutes]], sign × result.[[Seconds]], sign × result.[[Milliseconds]], sign × result.[[Microseconds]], sign × result.[[Nanoseconds]]).
     return MUST(create_temporal_duration(vm, 0, 0, 0, 0, sign * result.hours, sign * result.minutes, sign * result.seconds, sign * result.milliseconds, sign * result.microseconds, sign * result.nanoseconds));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
@@ -48,7 +48,7 @@ ThrowCompletionOr<Instant*> to_temporal_instant(VM&, Value item);
 ThrowCompletionOr<BigInt*> parse_temporal_instant(VM&, String const& iso_string);
 i32 compare_epoch_nanoseconds(BigInt const&, BigInt const&);
 ThrowCompletionOr<BigInt*> add_instant(VM&, BigInt const& epoch_nanoseconds, double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds);
-BigInt* difference_instant(VM&, BigInt const& nanoseconds1, BigInt const& nanoseconds2, u64 rounding_increment, StringView smallest_unit, StringView rounding_mode);
+TimeDurationRecord difference_instant(VM&, BigInt const& nanoseconds1, BigInt const& nanoseconds2, u64 rounding_increment, StringView smallest_unit, StringView largest_unit, StringView rounding_mode);
 BigInt* round_temporal_instant(VM&, BigInt const& nanoseconds, u64 increment, StringView unit, StringView rounding_mode);
 ThrowCompletionOr<String> temporal_instant_to_string(VM&, Instant&, Value time_zone, Variant<StringView, u8> const& precision);
 ThrowCompletionOr<Duration*> difference_temporal_instant(VM&, DifferenceOperation, Instant const&, Value other, Value options);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -562,16 +562,11 @@ ThrowCompletionOr<Duration*> difference_temporal_zoned_date_time(VM& vm, Differe
 
     // 5. If settings.[[LargestUnit]] is not one of "year", "month", "week", or "day", then
     if (!settings.largest_unit.is_one_of("year"sv, "month"sv, "week"sv, "day"sv)) {
-        // a. Let differenceNs be ! DifferenceInstant(zonedDateTime.[[Nanoseconds]], other.[[Nanoseconds]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
-        auto* difference_ns = difference_instant(vm, zoned_date_time.nanoseconds(), other->nanoseconds(), settings.rounding_increment, settings.smallest_unit, settings.rounding_mode);
+        // a. Let result be ! DifferenceInstant(zonedDateTime.[[Nanoseconds]], other.[[Nanoseconds]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[LargestUnit]], settings.[[RoundingMode]]).
+        auto result = difference_instant(vm, zoned_date_time.nanoseconds(), other->nanoseconds(), settings.rounding_increment, settings.smallest_unit, settings.largest_unit, settings.rounding_mode);
 
-        // b. Assert: The following steps cannot fail due to overflow in the Number domain because abs(differenceNs) ≤ 2 × nsMaxInstant.
-
-        // c. Let balanceResult be ! BalanceDuration(0, 0, 0, 0, 0, 0, differenceNs, settings.[[LargestUnit]]).
-        auto balance_result = MUST(balance_duration(vm, 0, 0, 0, 0, 0, 0, difference_ns->big_integer(), settings.largest_unit));
-
-        // d. Return ! CreateTemporalDuration(0, 0, 0, 0, sign × balanceResult.[[Hours]], sign × balanceResult.[[Minutes]], sign × balanceResult.[[Seconds]], sign × balanceResult.[[Milliseconds]], sign × balanceResult.[[Microseconds]], sign × balanceResult.[[Nanoseconds]]).
-        return MUST(create_temporal_duration(vm, 0, 0, 0, 0, sign * balance_result.hours, sign * balance_result.minutes, sign * balance_result.seconds, sign * balance_result.milliseconds, sign * balance_result.microseconds, sign * balance_result.nanoseconds));
+        // b. Return ! CreateTemporalDuration(0, 0, 0, 0, sign × result.[[Hours]], sign × result.[[Minutes]], sign × result.[[Seconds]], sign × result.[[Milliseconds]], sign × result.[[Microseconds]], sign × result.[[Nanoseconds]]).
+        return MUST(create_temporal_duration(vm, 0, 0, 0, 0, sign * result.hours, sign * result.minutes, sign * result.seconds, sign * result.milliseconds, sign * result.microseconds, sign * result.nanoseconds));
     }
 
     // 6. If ? TimeZoneEquals(zonedDateTime.[[TimeZone]], other.[[TimeZone]]) is false, then

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.since.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.since.js
@@ -9,8 +9,8 @@ describe("correct behavior", () => {
             [2345679011n, 123456789n, "PT2.222222222S"],
             [123456789n, 0n, "PT0.123456789S"],
             [0n, 123456789n, "-PT0.123456789S"],
-            [123456789123456789n, 0n, "PT34293H33M9.123456789S"],
-            [0n, 123456789123456789n, "-PT34293H33M9.123456789S"],
+            [123456789123456789n, 0n, "PT34293H33M9.123456784S"],
+            [0n, 123456789123456789n, "-PT34293H33M9.123456784S"],
         ];
         const utc = new Temporal.TimeZone("UTC");
         for (const [arg, argOther, expected] of values) {
@@ -34,7 +34,7 @@ describe("correct behavior", () => {
             ["second", "PT9556H5M6S"],
             ["millisecond", "PT9556H5M6.007S"],
             ["microsecond", "PT9556H5M6.007008S"],
-            ["nanosecond", "PT9556H5M6.007008009S"],
+            ["nanosecond", "PT9556H5M6.007008008S"],
         ];
         for (const [smallestUnit, expected] of values) {
             expect(zonedDateTime.since(other, { smallestUnit }).toString()).toBe(expected);
@@ -50,11 +50,11 @@ describe("correct behavior", () => {
             ["month", "P13M2DT4H5M6.007008009S"],
             ["week", "P56W6DT4H5M6.007008009S"],
             ["day", "P398DT4H5M6.007008009S"],
-            ["hour", "PT9556H5M6.007008009S"],
-            ["minute", "PT573365M6.007008009S"],
-            ["second", "PT34401906.007008009S"],
-            ["millisecond", "PT34401906.007008009S"],
-            ["microsecond", "PT34401906.007008009S"],
+            ["hour", "PT9556H5M6.007008008S"],
+            ["minute", "PT573365M6.007008008S"],
+            ["second", "PT34401906.007008008S"],
+            ["millisecond", "PT34401906.007008008S"],
+            ["microsecond", "PT34401906.007008008S"],
             ["nanosecond", "PT34401906.007008008S"],
         ];
         for (const [largestUnit, expected] of values) {

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.until.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.until.js
@@ -9,8 +9,8 @@ describe("correct behavior", () => {
             [123456789n, 2345679011n, "PT2.222222222S"],
             [0n, 123456789n, "PT0.123456789S"],
             [123456789n, 0n, "-PT0.123456789S"],
-            [0n, 123456789123456789n, "PT34293H33M9.123456789S"],
-            [123456789123456789n, 0n, "-PT34293H33M9.123456789S"],
+            [0n, 123456789123456789n, "PT34293H33M9.123456784S"],
+            [123456789123456789n, 0n, "-PT34293H33M9.123456784S"],
         ];
         const utc = new Temporal.TimeZone("UTC");
         for (const [arg, argOther, expected] of values) {
@@ -34,7 +34,7 @@ describe("correct behavior", () => {
             ["second", "PT9556H5M6S"],
             ["millisecond", "PT9556H5M6.007S"],
             ["microsecond", "PT9556H5M6.007008S"],
-            ["nanosecond", "PT9556H5M6.007008009S"],
+            ["nanosecond", "PT9556H5M6.007008008S"],
         ];
         for (const [smallestUnit, expected] of values) {
             expect(zonedDateTime.until(other, { smallestUnit }).toString()).toBe(expected);
@@ -50,11 +50,11 @@ describe("correct behavior", () => {
             ["month", "P13M2DT4H5M6.007008009S"],
             ["week", "P56W6DT4H5M6.007008009S"],
             ["day", "P398DT4H5M6.007008009S"],
-            ["hour", "PT9556H5M6.007008009S"],
-            ["minute", "PT573365M6.007008009S"],
-            ["second", "PT34401906.007008009S"],
-            ["millisecond", "PT34401906.007008009S"],
-            ["microsecond", "PT34401906.007008009S"],
+            ["hour", "PT9556H5M6.007008008S"],
+            ["minute", "PT573365M6.007008008S"],
+            ["second", "PT34401906.007008008S"],
+            ["millisecond", "PT34401906.007008008S"],
+            ["microsecond", "PT34401906.007008008S"],
             ["nanosecond", "PT34401906.007008008S"],
         ];
         for (const [largestUnit, expected] of values) {


### PR DESCRIPTION
Ticks two boxes in #15525 

- Normative: Fix rounding in DifferenceInstant
- Editorial: Rename balanceResult to result on step 5.2 of DifferenceTemporalZonedDateTime