### PR TITLE
Kernel/USB: Add support for async & interrupt transfers

### DIFF
--- a/Kernel/Bus/USB/UHCI/UHCIDescriptorTypes.h
+++ b/Kernel/Bus/USB/UHCI/UHCIDescriptorTypes.h
@@ -356,6 +356,15 @@ struct alignas(16) QueueHead {
         m_bookkeeping->in_use = false;
     }
 
+    void reinitialize()
+    {
+
+        for (TransferDescriptor* iter = get_first_td(); iter != nullptr; iter = iter->next_td()) {
+            iter->set_active();
+        }
+        attach_transfer_descriptor_chain(get_first_td());
+    }
+
 private:
     u32 m_link_ptr { 0 };                  // Pointer to the next horizontal object that the controller will execute after this one
     volatile u32 m_element_link_ptr { 0 }; // Pointer to the first data object in the queue (can be modified by hw)
@@ -366,4 +375,11 @@ private:
 };
 
 static_assert(AssertSize<QueueHead, 32>()); // Queue Head is always 8 Dwords
+
+struct AsyncTransferHandle {
+    NonnullLockRefPtr<Transfer> transfer;
+    QueueHead* qh;
+    u16 ms_poll_interval;
+};
+
 }

--- a/Kernel/Bus/USB/USBController.h
+++ b/Kernel/Bus/USB/USBController.h
@@ -23,8 +23,10 @@ public:
     virtual ErrorOr<void> stop() = 0;
     virtual ErrorOr<void> start() = 0;
 
+    virtual void cancel_async_transfer(NonnullLockRefPtr<Transfer> transfer) = 0;
     virtual ErrorOr<size_t> submit_control_transfer(Transfer&) = 0;
     virtual ErrorOr<size_t> submit_bulk_transfer(Transfer& transfer) = 0;
+    virtual ErrorOr<void> submit_async_interrupt_transfer(NonnullLockRefPtr<Transfer> transfer, u16 ms_interval) = 0;
 
     u8 allocate_address();
 

--- a/Kernel/Bus/USB/USBPipe.cpp
+++ b/Kernel/Bus/USB/USBPipe.cpp
@@ -36,7 +36,7 @@ ControlPipe::ControlPipe(USBController const& controller, u8 endpoint_address, u
 {
 }
 
-ErrorOr<size_t> ControlPipe::control_transfer(u8 request_type, u8 request, u16 value, u16 index, size_t length, void* data)
+ErrorOr<size_t> ControlPipe::submit_control_transfer(u8 request_type, u8 request, u16 value, u16 index, size_t length, void* data)
 {
     VERIFY(length <= m_dma_buffer->size());
 
@@ -76,7 +76,7 @@ BulkInPipe::BulkInPipe(USBController const& controller, u8 endpoint_address, u16
 {
 }
 
-ErrorOr<size_t> BulkInPipe::bulk_in_transfer(size_t length, void* data)
+ErrorOr<size_t> BulkInPipe::submit_bulk_in_transfer(size_t length, void* data)
 {
     VERIFY(length <= m_dma_buffer->size());
 
@@ -107,7 +107,7 @@ BulkOutPipe::BulkOutPipe(USBController const& controller, u8 endpoint_address, u
 {
 }
 
-ErrorOr<size_t> BulkOutPipe::bulk_out_transfer(size_t length, void* data)
+ErrorOr<size_t> BulkOutPipe::submit_bulk_out_transfer(size_t length, void* data)
 {
     VERIFY(length <= m_dma_buffer->size());
 
@@ -137,7 +137,7 @@ InterruptInPipe::InterruptInPipe(USBController const& controller, u8 endpoint_ad
 {
 }
 
-ErrorOr<NonnullLockRefPtr<Transfer>> InterruptInPipe::interrupt_in_transfer(size_t length, u16 ms_interval, USBAsyncCallback callback)
+ErrorOr<NonnullLockRefPtr<Transfer>> InterruptInPipe::submit_interrupt_in_transfer(size_t length, u16 ms_interval, USBAsyncCallback callback)
 {
     VERIFY(length <= m_dma_buffer->size());
 

--- a/Kernel/Bus/USB/USBPipe.h
+++ b/Kernel/Bus/USB/USBPipe.h
@@ -18,6 +18,8 @@ namespace Kernel::USB {
 class USBController;
 class Transfer;
 
+using USBAsyncCallback = Function<void(Transfer* transfer)>;
+
 //
 // A pipe is the logical connection between a memory buffer on the PC (host) and
 // an endpoint on the device. In this implementation, the data buffer the pipe connects
@@ -110,6 +112,8 @@ private:
 class InterruptInPipe : public Pipe {
 public:
     static ErrorOr<NonnullOwnPtr<InterruptInPipe>> create(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, u16 poll_interval, size_t buffer_size = PAGE_SIZE);
+
+    ErrorOr<NonnullLockRefPtr<Transfer>> interrupt_in_transfer(size_t length, u16 ms_interval, USBAsyncCallback callback);
 
     u16 poll_interval() const { return m_poll_interval; }
 

--- a/Kernel/Bus/USB/USBPipe.h
+++ b/Kernel/Bus/USB/USBPipe.h
@@ -83,7 +83,7 @@ class ControlPipe : public Pipe {
 public:
     static ErrorOr<NonnullOwnPtr<ControlPipe>> create(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, size_t buffer_size = PAGE_SIZE);
 
-    ErrorOr<size_t> control_transfer(u8 request_type, u8 request, u16 value, u16 index, size_t length, void* data);
+    ErrorOr<size_t> submit_control_transfer(u8 request_type, u8 request, u16 value, u16 index, size_t length, void* data);
 
 private:
     ControlPipe(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, NonnullOwnPtr<Memory::Region> dma_buffer);
@@ -93,7 +93,7 @@ class BulkInPipe : public Pipe {
 public:
     static ErrorOr<NonnullOwnPtr<BulkInPipe>> create(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, size_t buffer_size = PAGE_SIZE);
 
-    ErrorOr<size_t> bulk_in_transfer(size_t length, void* data);
+    ErrorOr<size_t> submit_bulk_in_transfer(size_t length, void* data);
 
 private:
     BulkInPipe(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, NonnullOwnPtr<Memory::Region> dma_buffer);
@@ -103,7 +103,7 @@ class BulkOutPipe : public Pipe {
 public:
     static ErrorOr<NonnullOwnPtr<BulkOutPipe>> create(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, size_t buffer_size = PAGE_SIZE);
 
-    ErrorOr<size_t> bulk_out_transfer(size_t length, void* data);
+    ErrorOr<size_t> submit_bulk_out_transfer(size_t length, void* data);
 
 private:
     BulkOutPipe(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, NonnullOwnPtr<Memory::Region> dma_buffer);
@@ -113,7 +113,7 @@ class InterruptInPipe : public Pipe {
 public:
     static ErrorOr<NonnullOwnPtr<InterruptInPipe>> create(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, u16 poll_interval, size_t buffer_size = PAGE_SIZE);
 
-    ErrorOr<NonnullLockRefPtr<Transfer>> interrupt_in_transfer(size_t length, u16 ms_interval, USBAsyncCallback callback);
+    ErrorOr<NonnullLockRefPtr<Transfer>> submit_interrupt_in_transfer(size_t length, u16 ms_interval, USBAsyncCallback callback);
 
     u16 poll_interval() const { return m_poll_interval; }
 

--- a/Kernel/Bus/USB/USBTransfer.h
+++ b/Kernel/Bus/USB/USBTransfer.h
@@ -20,7 +20,7 @@ namespace Kernel::USB {
 
 class Transfer final : public AtomicRefCounted<Transfer> {
 public:
-    static ErrorOr<NonnullLockRefPtr<Transfer>> try_create(Pipe&, u16 length, Memory::Region& dma_buffer);
+    static ErrorOr<NonnullLockRefPtr<Transfer>> create(Pipe&, u16 length, Memory::Region& dma_buffer, USBAsyncCallback callback = nullptr);
 
     Transfer() = delete;
     ~Transfer();
@@ -41,14 +41,17 @@ public:
     bool complete() const { return m_complete; }
     bool error_occurred() const { return m_error_occurred; }
 
+    void invoke_async_callback();
+
 private:
-    Transfer(Pipe& pipe, u16 len, Memory::Region& dma_buffer);
+    Transfer(Pipe& pipe, u16 len, Memory::Region& dma_buffer, USBAsyncCallback callback);
     Pipe& m_pipe;                    // Pipe that initiated this transfer
     Memory::Region& m_dma_buffer;    // DMA buffer
     USBRequestData m_request;        // USB request
     u16 m_transfer_data_size { 0 };  // Size of the transfer's data stage
     bool m_complete { false };       // Has this transfer been completed?
     bool m_error_occurred { false }; // Did an error occur during this transfer?
+    USBAsyncCallback m_callback { nullptr };
 };
 
 }


### PR DESCRIPTION
Depends on: https://github.com/SerenityOS/serenity/pull/15631 and https://github.com/SerenityOS/serenity/pull/15529 (their commits are present in this PR for convenience/ease of testing and will be removed once these PRs or their equivalent are merged)

The first commit here adds support for interrupt transfers, as well as async bulk transfers. The implementation here uses a separate polling kernel task to check a list of active async transfers at a set interval of 1ms (the period of a single UHCI frame, chosen specifically because interrupt transfers are only executed by the hardware controller once per frame and don't take advantage of bandwidth reclamation), invoking the user-provided callback on those that are complete as needed. 

A nicer way of implementing this instead of polling (courtesy of @ADKaster) would be to use a binary semaphore that is counted up within an ISR that is invoked when interrupt transfers are complete (possible through the interrupt-on-complete flag within the UHCI transfer data structures), and then having the async task wait on this semaphore repeatedly. It doesn't seem like there is a semaphore type present in the kernel yet though, with the closest being the wait queue, which would also work just as well but would be a bit more clunky and less expressive. Right now the async poll process seems to use around 0.8% CPU consistently (on my system anyway) which is pretty undesirable, so this is probably a good thing to look into.

The second commit isn't meant to be merged, but instead provides an example (and method of testing) of interrupt transfers working in case anyone is interested in taking a look. The actual USB device drivers will be written to target the USB driver probe branch here: https://github.com/Quaker762/serenity/commits/usb_probe

Comments and feedback are appreciated :)