### PR TITLE
LibC+LibTimeZone: Default to UTC if parsing the TZ environment variable fails, consolidate `TZ` parsing to one location

### DIFF
--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -397,12 +397,7 @@ size_t strftime(char* destination, size_t max_size, char const* format, const st
 
 void tzset()
 {
-    // FIXME: Actually parse the TZ environment variable, described here:
-    // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08
-    if (char* tz = getenv("TZ"); tz != nullptr)
-        __tzname = { tz, strlen(tz) };
-    else
-        __tzname = TimeZone::system_time_zone();
+    __tzname = TimeZone::current_time_zone();
 
     auto set_default_values = []() {
         timezone = 0;

--- a/Userland/Libraries/LibTimeZone/TimeZone.cpp
+++ b/Userland/Libraries/LibTimeZone/TimeZone.cpp
@@ -99,6 +99,7 @@ StringView current_time_zone()
             return *maybe_time_zone;
 
         dbgln_if(TIME_ZONE_DEBUG, "Could not determine time zone from TZ environment: {}", time_zone);
+        return "UTC"sv;
     }
 
 #ifdef AK_OS_SERENITY


### PR DESCRIPTION
This fixes `test-js -f Date.parse.js` when the `TZ` environment variable has invalid values.