### PR TITLE
LibWeb: Use calculate_min_content_height() for sizing of grid children

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -572,6 +572,8 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
             independent_formatting_context->parent_context_did_dimension_child_root_box();
         if (child_box_state.content_height() > positioned_box.computed_height)
             positioned_box.computed_height = child_box_state.content_height();
+        if (auto min_content_height = calculate_min_content_height(positioned_box.box, available_space.width); min_content_height > positioned_box.computed_height)
+            positioned_box.computed_height = min_content_height;
     }
 
     // https://drafts.csswg.org/css-grid/#overview-sizing


### PR DESCRIPTION
We used LayoutMode::Normal for sizing grid children which resulted in outer block level elements have zero height although their children were sized correctly. By using LayoutMode::IntrinsicSizing this is fixed and the footer of our GitHub page is now at its place.

![Screenshot_20221017_181805](https://user-images.githubusercontent.com/729361/196230478-ab779479-ec7b-45ef-8855-c3f2557a6b65.png)
![Screenshot_20221017_181813](https://user-images.githubusercontent.com/729361/196230519-c209fef7-da66-4d6f-8fe6-5a2526491a6d.png)


