### PR TITLE
LibC: Use proper casting in fgetc and fgetc_unlocked functions

### DIFF
--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -631,12 +631,10 @@ char* fgets(char* buffer, int size, FILE* stream)
 int fgetc(FILE* stream)
 {
     VERIFY(stream);
-    char ch;
-    size_t nread = fread(&ch, sizeof(char), 1, stream);
+    unsigned char ch;
+    size_t nread = fread(&ch, sizeof(unsigned char), 1, stream);
     if (nread == 1) {
-        // Note: We do this static_cast because otherwise when casting a char that contains
-        // 0xFF results in an int containing -1, so an explicit cast is required here.
-        return static_cast<int>(ch & 0xff);
+        return ch;
     }
     return EOF;
 }
@@ -644,8 +642,8 @@ int fgetc(FILE* stream)
 int fgetc_unlocked(FILE* stream)
 {
     VERIFY(stream);
-    char ch;
-    size_t nread = fread_unlocked(&ch, sizeof(char), 1, stream);
+    unsigned char ch;
+    size_t nread = fread_unlocked(&ch, sizeof(unsigned char), 1, stream);
     if (nread == 1)
         return ch;
     return EOF;


### PR DESCRIPTION
In the fgetc function, a fix was already in place but was clunky. A real proper solution is to use an unsigned char instead of a char when returning the value, so an implicit cast is happening based on the assumption that the value is unsigned, so if the variable contained 0xff it won't be treated as -1, but as unsigned 0xff, so the result int will be 0xff and not -1.

The same solution is applied to the fgetc_unlocked function as well.

See https://stackoverflow.com/questions/42701823/c-typecasting-from-a-signed-char-to-int-type#42701881 for further explanation.
I tested this patch with the `potrace` port. See #15653, for more info about the previous solution to this patch.