### PR TITLE
tail: Port to Core::Stream, use Core::FileWatcher

### DIFF
--- a/Base/root/generate_manpages.sh
+++ b/Base/root/generate_manpages.sh
@@ -26,7 +26,6 @@ for i in ( \
             (shot 1) \
             (sql 1) \
             (strace 1) \
-            (tail 1) \
             (tr 1) \
             (traceroute 1) \
             (tree 1) \

--- a/Base/usr/share/man/man1/tail.md
+++ b/Base/usr/share/man/man1/tail.md
@@ -1,24 +1,44 @@
 ## Name
 
-tail
+tail - Print the end of a file
 
 ## Synopsis
 
-```sh
-$ tail [--follow] [--lines number] <file>
+```**sh
+$ tail [-f] [-n number] [file]
 ```
 
 ## Description
 
-Print the end ('tail') of a file.
+`tail` prints the specified `number` (10 by default) of lines at the end of `file`.
 
-## Options:
+## Options
 
 * `-f`, `--follow`: Output data as it is written to the file
-* `-n number`, `--lines number`: Fetch the specified number of lines
+* `-n number`, `--lines number`: Print the specified number of lines
 
-## Arguments:
+## Arguments
 
-* `file`: File path
+* `file`: Target file. If unspecified or `-`, defaults to the standard input.
 
-<!-- Auto-generated through ArgsParser -->
+## Examples
+
+Print the last 10 lines of README.md:
+```sh
+$ tail README.md
+```
+
+Print the last 42 lines of todo.txt:
+```sh
+$ tail -n42 todo.txt
+```
+
+Print the last lines as they are written to logs.log:
+```sh
+$ tail -f logs.log
+```
+
+## See also
+
+* [`head`(1)](help://man/1/head)
+* [`cat`(1)](help://man/1/cat)


### PR DESCRIPTION
`tail` was still using old Core::File, and a loop with a timeout to check for file changes when using `--follow`.
This PR changes that, and also updates the man page (which was previously automatically generated from ArgsParser).