### PR TITLE
Ports: Make the quake3 port buildable on ARM64 hosts

### DIFF
--- a/Ports/quake3/patches/0001-Meta-Refactor-Makefile-to-support-Serenity.patch
+++ b/Ports/quake3/patches/0001-Meta-Refactor-Makefile-to-support-Serenity.patch
@@ -4,25 +4,33 @@ Date: Fri, 25 Mar 2022 09:39:21 +1100
 Subject: [PATCH] Meta: Refactor Makefile to support Serenity
 
 ---
- Makefile | 36 ++++++++++++++++--------------------
- 1 file changed, 16 insertions(+), 20 deletions(-)
+ Makefile | 44 ++++++++++++++++----------------------------
+ 1 file changed, 16 insertions(+), 28 deletions(-)
 
 diff --git a/Makefile b/Makefile
 index 9e53555..b26ceb7 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -3,8 +3,8 @@
+@@ -3,16 +3,8 @@
  #
  # GNU Make required
  #
 -COMPILE_PLATFORM=$(shell uname | sed -e 's/_.*//' | tr '[:upper:]' '[:lower:]' | sed -e 's/\//_/g')
 -COMPILE_ARCH=$(shell uname -m | sed -e 's/i.86/x86/' | sed -e 's/^arm.*/arm/')
+-
+-#arm64 hack!
+-ifeq ($(shell uname -m), arm64)
+-  COMPILE_ARCH=arm64
+-endif
+-ifeq ($(shell uname -m), aarch64)
+-  COMPILE_ARCH=arm64
+-endif
 +COMPILE_PLATFORM=serenity
 +COMPILE_ARCH=${SERENITY_ARCH}
  
- #arm64 hack!
- ifeq ($(shell uname -m), arm64)
-@@ -35,13 +35,13 @@ ifndef BUILD_GAME_QVM
+ ifeq ($(COMPILE_PLATFORM),sunos)
+   # Solaris uname and GNU uname differ
+@@ -35,13 +27,13 @@ ifndef BUILD_GAME_QVM
    BUILD_GAME_QVM   =
  endif
  ifndef BUILD_BASEGAME
@@ -39,7 +47,7 @@ index 9e53555..b26ceb7 100644
  endif
  ifndef BUILD_AUTOUPDATER  # DON'T build unless you mean to!
    BUILD_AUTOUPDATER=0
-@@ -164,39 +164,39 @@ GENERATE_DEPENDENCIES=1
+@@ -164,39 +156,39 @@ GENERATE_DEPENDENCIES=1
  endif
  
  ifndef USE_OPENAL
@@ -87,7 +95,7 @@ index 9e53555..b26ceb7 100644
  endif
  
  ifndef USE_FREETYPE
-@@ -505,10 +505,6 @@ ifeq ($(PLATFORM),darwin)
+@@ -505,10 +497,6 @@ ifeq ($(PLATFORM),darwin)
    ifeq ($(CROSS_COMPILING),1)
      # If CC is already set to something generic, we probably want to use
      # something more specific
@@ -98,7 +106,7 @@ index 9e53555..b26ceb7 100644
      ifndef CC
        ifndef DARWIN
          # macOS 10.9 SDK
-@@ -817,11 +813,10 @@ ifeq ($(PLATFORM),freebsd)
+@@ -817,11 +805,10 @@ ifeq ($(PLATFORM),freebsd)
  else # ifeq freebsd
  
  #############################################################################
@@ -112,7 +120,7 @@ index 9e53555..b26ceb7 100644
    BASE_CFLAGS = -Wall -fno-strict-aliasing -Wimplicit -Wstrict-prototypes \
      -pipe -DUSE_ICON -DMAP_ANONYMOUS=MAP_ANON
    CLIENT_CFLAGS += $(SDL_CFLAGS)
-@@ -1000,6 +995,7 @@ ifeq ($(PLATFORM),sunos)
+@@ -1000,6 +987,7 @@ ifeq ($(PLATFORM),sunos)
  
  else # ifeq sunos
  

--- a/Ports/quake3/patches/0004-Meta-Add-ldl-library-for-Serenity-target.patch
+++ b/Ports/quake3/patches/0004-Meta-Add-ldl-library-for-Serenity-target.patch
@@ -11,7 +11,7 @@ diff --git a/Makefile b/Makefile
 index b26ceb7..035fea7 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -868,7 +868,7 @@ ifeq ($(PLATFORM),serenity)
+@@ -860,7 +860,7 @@ ifeq ($(PLATFORM),serenity)
    SHLIBLDFLAGS=-shared $(LDFLAGS)
  
    THREAD_LIBS=-lpthread

--- a/Ports/quake3/patches/0006-Meta-Add-ARCH-to-TOOLS_CFLAGS.patch
+++ b/Ports/quake3/patches/0006-Meta-Add-ARCH-to-TOOLS_CFLAGS.patch
@@ -11,7 +11,7 @@ diff --git a/Makefile b/Makefile
 index 035fea7..c5a27ab 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -821,6 +821,8 @@ ifeq ($(PLATFORM),serenity)
+@@ -813,6 +813,8 @@ ifeq ($(PLATFORM),serenity)
      -pipe -DUSE_ICON -DMAP_ANONYMOUS=MAP_ANON
    CLIENT_CFLAGS += $(SDL_CFLAGS)
  

--- a/Ports/quake3/patches/0007-Meta-Remove-extension-from-main-game-exe.patch
+++ b/Ports/quake3/patches/0007-Meta-Remove-extension-from-main-game-exe.patch
@@ -11,7 +11,7 @@ diff --git a/Makefile b/Makefile
 index c5a27ab..c0e6200 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -1046,12 +1046,12 @@ endif
+@@ -1038,12 +1038,12 @@ endif
  
  ifneq ($(BUILD_CLIENT),0)
    ifneq ($(USE_RENDERER_DLOPEN),0)
@@ -26,7 +26,7 @@ index c5a27ab..c0e6200 100644
      ifneq ($(BUILD_RENDERER_OPENGL2),0)
        TARGETS += $(B)/$(CLIENTBIN)_opengl2$(FULLBINEXT)
      endif
-@@ -2246,7 +2246,7 @@ ifeq ($(USE_MUMBLE),1)
+@@ -2238,7 +2238,7 @@ ifeq ($(USE_MUMBLE),1)
  endif
  
  ifneq ($(USE_RENDERER_DLOPEN),0)
@@ -35,7 +35,7 @@ index c5a27ab..c0e6200 100644
  	$(echo_cmd) "LD $@"
  	$(Q)$(CC) $(CLIENT_CFLAGS) $(CFLAGS) $(CLIENT_LDFLAGS) $(LDFLAGS) $(NOTSHLIBLDFLAGS) \
  		-o $@ $(Q3OBJ) \
-@@ -2262,7 +2262,7 @@ $(B)/renderer_opengl2_$(SHLIBNAME): $(Q3R2OBJ) $(Q3R2STRINGOBJ) $(JPGOBJ)
+@@ -2254,7 +2254,7 @@ $(B)/renderer_opengl2_$(SHLIBNAME): $(Q3R2OBJ) $(Q3R2STRINGOBJ) $(JPGOBJ)
  	$(Q)$(CC) $(CFLAGS) $(SHLIBLDFLAGS) -o $@ $(Q3R2OBJ) $(Q3R2STRINGOBJ) $(JPGOBJ) \
  		$(THREAD_LIBS) $(LIBSDLMAIN) $(RENDERER_LIBS) $(LIBS)
  else
@@ -44,7 +44,7 @@ index c5a27ab..c0e6200 100644
  	$(echo_cmd) "LD $@"
  	$(Q)$(CC) $(CLIENT_CFLAGS) $(CFLAGS) $(CLIENT_LDFLAGS) $(LDFLAGS) $(NOTSHLIBLDFLAGS) \
  		-o $@ $(Q3OBJ) $(Q3ROBJ) $(JPGOBJ) \
-@@ -2945,7 +2945,7 @@ ifneq ($(BUILD_GAME_SO),0)
+@@ -2937,7 +2937,7 @@ ifneq ($(BUILD_GAME_SO),0)
  endif
  
  ifneq ($(BUILD_CLIENT),0)


### PR DESCRIPTION
Previously, on ARM64 hosts we'd try to build ARM64 binaries even when SERENITY_ARCH was set to x86_64. This would cause the build to fail.