### PR TITLE
LibWeb: Implement HTMLSelectElement length, item() and namedItem()

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -42,6 +42,27 @@ JS::GCPtr<HTMLOptionsCollection> const& HTMLSelectElement::options()
     return m_options;
 }
 
+// https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-length
+size_t HTMLSelectElement::length()
+{
+    // The length IDL attribute must return the number of nodes represented by the options collection. On setting, it must act like the attribute of the same name on the options collection.
+    return const_cast<HTMLOptionsCollection&>(*options()).length();
+}
+
+// https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-item
+DOM::Element* HTMLSelectElement::item(size_t index)
+{
+    // The item(index) method must return the value returned by the method of the same name on the options collection, when invoked with the same argument.
+    return const_cast<HTMLOptionsCollection&>(*options()).item(index);
+}
+
+// https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-nameditem
+DOM::Element* HTMLSelectElement::named_item(FlyString const& name)
+{
+    // The namedItem(name) method must return the value returned by the method of the same name on the options collection, when invoked with the same argument.
+    return const_cast<HTMLOptionsCollection&>(*options()).named_item(name);
+}
+
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-add
 WebIDL::ExceptionOr<void> HTMLSelectElement::add(HTMLOptionOrOptGroupElement element, Optional<HTMLElementOrElementIndex> before)
 {

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -25,6 +25,9 @@ public:
 
     JS::GCPtr<HTMLOptionsCollection> const& options();
 
+    size_t length();
+    DOM::Element* item(size_t index);
+    DOM::Element* named_item(FlyString const& name);
     WebIDL::ExceptionOr<void> add(HTMLOptionOrOptGroupElement element, Optional<HTMLElementOrElementIndex> before = {});
 
     int selected_index() const;

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.idl
@@ -10,6 +10,9 @@ interface HTMLSelectElement : HTMLElement {
     [Reflect] attribute boolean required;
     [SameObject] readonly attribute HTMLOptionsCollection options;
 
+    readonly attribute unsigned long length;
+    getter Element? item(unsigned long index);
+    getter Element? namedItem(DOMString name);
     [CEReactions] undefined add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
 
     attribute long selectedIndex;


### PR DESCRIPTION
These are simple calls through to the HTMLOptionsCollection functions of the same names, as with HTMLSelectElement.add().

This fixes an issue that was preventing a 24-hour clock app my brother and I made a while back from running, so now I can see the broken canvas rendering of it :^)

![image](https://user-images.githubusercontent.com/3149592/196382615-28df0097-22ff-497f-b443-807f9dbcd847.png)
