### PR TITLE
LibHTTP: Fix not consuming the last byte of body in from_raw_request

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -175,7 +175,7 @@ Optional<HttpRequest> HttpRequest::from_raw_request(ReadonlyBytes raw_request)
             break;
         case State::InBody:
             buffer.append(consume());
-            if (index + 1 == raw_request.size()) {
+            if (index == raw_request.size()) {
                 // End of data, so store the body
                 auto maybe_body = ByteBuffer::copy(buffer);
                 // FIXME: Propagate this error somehow.


### PR DESCRIPTION
`index + 1` was not correct. For example, if the body has two bytes, we would consume the first byte and increment the index. We then add one to the index and see it's equal to the size, so we take this one byte and set the body result to it. The while loop would still continue and we consume the second byte, adding it to the temporary buffer. We see that the index is above the size, so we don't update the body, dropping the last byte on the floor.