### PR TITLE
LibGUI: Fix EditingEngine Shift + Up/Down highlight behavior

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -87,8 +87,23 @@ bool EditingEngine::on_key(KeyEvent const& event)
         bool const condition_for_up = direction == VerticalDirection::Up && m_editor->cursor().line() > 0;
         bool const condition_for_down = direction == VerticalDirection::Down && m_editor->cursor().line() < (m_editor->line_count() - 1);
 
+        bool const condition_for_up_to_beginning = direction == VerticalDirection::Up && m_editor->cursor().line() == 0;
+        bool const condition_for_down_to_end = direction == VerticalDirection::Down && m_editor->cursor().line() == (m_editor->line_count() - 1);
+
         if (condition_for_up || condition_for_down || m_editor->is_wrapping_enabled())
             m_editor->update_selection(event.shift());
+
+        // Shift + Up on the top line (or only line) selects from the cursor to the start of the line.
+        if (condition_for_up_to_beginning) {
+            m_editor->update_selection(event.shift());
+            move_to_line_beginning();
+        }
+
+        // Shift + Down on the bottom line (or only line) selects from the cursor to the end of the line.
+        if (condition_for_down_to_end) {
+            m_editor->update_selection(event.shift());
+            move_to_line_end();
+        }
 
         move_one_helper(event, direction);
     }


### PR DESCRIPTION

This commit fixes the highlight behavior of pressing Shift + Up Arrow and Shift + Down Arrow in the EditingEngine. Previously, pressing Shift + Up with your cursor in the middle of the top line would not respond, likewise with pressing Shift + Down with your cursor in the middle of the bottom row. This behavior is inconsistent with the normal, unselected cursor movement when pressing just the Up Arrow or Down Arrow in the same parts of the same lines, where it would send the cursor to the start or end of the line respectively. This commit carries that behavior over to highlighting, so pressing Shift + Up on the middle of the top line will select (or append to an existing selection) the text between the start of the line and the cursor, while pressing Shift + Down on the bottom line will select text between the cursor and the end of the line. 

This is my first commit - feedback very welcome!