### PR TITLE
LibWeb: Ignore "pointer-events: none" elements in hit_test

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -280,7 +280,6 @@ bool EventHandler::handle_mousedown(Gfx::IntPoint const& position, unsigned butt
     JS::GCPtr<DOM::Node> node;
 
     {
-        // TODO: Allow selecting element behind if one on top has pointer-events set to none.
         RefPtr<Painting::Paintable> paintable;
         if (m_mouse_event_tracking_layout_node) {
             paintable = m_mouse_event_tracking_layout_node->paintable();
@@ -293,8 +292,7 @@ bool EventHandler::handle_mousedown(Gfx::IntPoint const& position, unsigned butt
 
         auto pointer_events = paintable->computed_values().pointer_events();
         // FIXME: Handle other values for pointer-events.
-        if (pointer_events == CSS::PointerEvents::None)
-            return false;
+        VERIFY(pointer_events != CSS::PointerEvents::None);
 
         node = paintable->mouse_event_target();
         if (!node)
@@ -414,8 +412,7 @@ bool EventHandler::handle_mousemove(Gfx::IntPoint const& position, unsigned butt
 
         auto pointer_events = paintable->computed_values().pointer_events();
         // FIXME: Handle other values for pointer-events.
-        if (pointer_events == CSS::PointerEvents::None)
-            return false;
+        VERIFY(pointer_events != CSS::PointerEvents::None);
 
         hovered_node_changed = node.ptr() != document.hovered_node();
         document.set_hovered_node(node);
@@ -497,7 +494,6 @@ bool EventHandler::handle_doubleclick(Gfx::IntPoint const& position, unsigned bu
     if (!paint_root())
         return false;
 
-    // TODO: Allow selecting element behind if one on top has pointer-events set to none.
     RefPtr<Painting::Paintable> paintable;
     if (m_mouse_event_tracking_layout_node) {
         paintable = m_mouse_event_tracking_layout_node->paintable();

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -379,6 +379,10 @@ Optional<HitTestResult> StackingContext::hit_test(Gfx::FloatPoint const& positio
             return {};
     }
 
+    if (paintable().computed_values().pointer_events() == CSS::PointerEvents::None) {
+        return {};
+    }
+
     // NOTE: Hit testing basically happens in reverse painting order.
     // https://www.w3.org/TR/CSS22/visuren.html#z-index
 


### PR DESCRIPTION
I stumbled on the problem that map on https://www.openstreetmap.org/ is not draggable. Turned out it's because tile images are returned by hit_test in `mousedown` handler and these tiles are <img> with `pointer-events: none`. I solved that by making `StackingContext::hit_test` to ignore elements with `pointer-events: none`. I might be solving it in wrong way but also can't come up with scenario when hit_test should not ignore `pointer-events: none` elements.