### PR TITLE
LibJS: Avoid expensive UTF-8/16 conversion in legacy RegExp properties

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.h
@@ -9,6 +9,7 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Runtime/Utf16String.h>
 
 namespace JS {
 
@@ -22,57 +23,57 @@ namespace JS {
 // [[RegExpParen1]] ... [[RegExpParen9]]
 class RegExpLegacyStaticProperties {
 public:
-    Optional<String> const& input() const { return m_input; }
-    Optional<String> const& last_match() const { return m_last_match; }
-    Optional<String> const& last_paren() const { return m_last_paren; }
-    Optional<String> const& left_context() const { return m_left_context; }
-    Optional<String> const& right_context() const { return m_right_context; }
-    Optional<String> const& $1() const { return m_$1; }
-    Optional<String> const& $2() const { return m_$2; }
-    Optional<String> const& $3() const { return m_$3; }
-    Optional<String> const& $4() const { return m_$4; }
-    Optional<String> const& $5() const { return m_$5; }
-    Optional<String> const& $6() const { return m_$6; }
-    Optional<String> const& $7() const { return m_$7; }
-    Optional<String> const& $8() const { return m_$8; }
-    Optional<String> const& $9() const { return m_$9; }
+    Optional<Utf16String> const& input() const { return m_input; }
+    Optional<Utf16String> const& last_match() const { return m_last_match; }
+    Optional<Utf16String> const& last_paren() const { return m_last_paren; }
+    Optional<Utf16String> const& left_context() const { return m_left_context; }
+    Optional<Utf16String> const& right_context() const { return m_right_context; }
+    Optional<Utf16String> const& $1() const { return m_$1; }
+    Optional<Utf16String> const& $2() const { return m_$2; }
+    Optional<Utf16String> const& $3() const { return m_$3; }
+    Optional<Utf16String> const& $4() const { return m_$4; }
+    Optional<Utf16String> const& $5() const { return m_$5; }
+    Optional<Utf16String> const& $6() const { return m_$6; }
+    Optional<Utf16String> const& $7() const { return m_$7; }
+    Optional<Utf16String> const& $8() const { return m_$8; }
+    Optional<Utf16String> const& $9() const { return m_$9; }
 
-    void set_input(String input) { m_input = move(input); }
-    void set_last_match(String last_match) { m_last_match = move(last_match); }
-    void set_last_paren(String last_paren) { m_last_paren = move(last_paren); }
-    void set_left_context(String left_context) { m_left_context = move(left_context); }
-    void set_right_context(String right_context) { m_right_context = move(right_context); }
-    void set_$1(String value) { m_$1 = move(value); }
-    void set_$2(String value) { m_$2 = move(value); }
-    void set_$3(String value) { m_$3 = move(value); }
-    void set_$4(String value) { m_$4 = move(value); }
-    void set_$5(String value) { m_$5 = move(value); }
-    void set_$6(String value) { m_$6 = move(value); }
-    void set_$7(String value) { m_$7 = move(value); }
-    void set_$8(String value) { m_$8 = move(value); }
-    void set_$9(String value) { m_$9 = move(value); }
+    void set_input(Utf16String input) { m_input = move(input); }
+    void set_last_match(Utf16String last_match) { m_last_match = move(last_match); }
+    void set_last_paren(Utf16String last_paren) { m_last_paren = move(last_paren); }
+    void set_left_context(Utf16String left_context) { m_left_context = move(left_context); }
+    void set_right_context(Utf16String right_context) { m_right_context = move(right_context); }
+    void set_$1(Utf16String value) { m_$1 = move(value); }
+    void set_$2(Utf16String value) { m_$2 = move(value); }
+    void set_$3(Utf16String value) { m_$3 = move(value); }
+    void set_$4(Utf16String value) { m_$4 = move(value); }
+    void set_$5(Utf16String value) { m_$5 = move(value); }
+    void set_$6(Utf16String value) { m_$6 = move(value); }
+    void set_$7(Utf16String value) { m_$7 = move(value); }
+    void set_$8(Utf16String value) { m_$8 = move(value); }
+    void set_$9(Utf16String value) { m_$9 = move(value); }
     void invalidate();
 
 private:
-    Optional<String> m_input;
-    Optional<String> m_last_match;
-    Optional<String> m_last_paren;
-    Optional<String> m_left_context;
-    Optional<String> m_right_context;
-    Optional<String> m_$1;
-    Optional<String> m_$2;
-    Optional<String> m_$3;
-    Optional<String> m_$4;
-    Optional<String> m_$5;
-    Optional<String> m_$6;
-    Optional<String> m_$7;
-    Optional<String> m_$8;
-    Optional<String> m_$9;
+    Optional<Utf16String> m_input;
+    Optional<Utf16String> m_last_match;
+    Optional<Utf16String> m_last_paren;
+    Optional<Utf16String> m_left_context;
+    Optional<Utf16String> m_right_context;
+    Optional<Utf16String> m_$1;
+    Optional<Utf16String> m_$2;
+    Optional<Utf16String> m_$3;
+    Optional<Utf16String> m_$4;
+    Optional<Utf16String> m_$5;
+    Optional<Utf16String> m_$6;
+    Optional<Utf16String> m_$7;
+    Optional<Utf16String> m_$8;
+    Optional<Utf16String> m_$9;
 };
 
-ThrowCompletionOr<void> set_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, void (RegExpLegacyStaticProperties::*property_setter)(String), Value value);
-ThrowCompletionOr<Value> get_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, Optional<String> const& (RegExpLegacyStaticProperties::*property_getter)() const);
-void update_legacy_regexp_static_properties(RegExpConstructor& constructor, Utf16String const& string, size_t start_index, size_t end_index, Vector<String> const& captured_values);
+ThrowCompletionOr<void> set_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, void (RegExpLegacyStaticProperties::*property_setter)(Utf16String), Value value);
+ThrowCompletionOr<Value> get_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, Optional<Utf16String> const& (RegExpLegacyStaticProperties::*property_getter)() const);
+void update_legacy_regexp_static_properties(RegExpConstructor& constructor, Utf16String const& string, size_t start_index, size_t end_index, Vector<Utf16String> const& captured_values);
 void invalidate_legacy_regexp_static_properties(RegExpConstructor& constructor);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -265,7 +265,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
 
     // 24. Let indices be a new empty List.
     Vector<Optional<Match>> indices;
-    Vector<String> captured_values;
+    Vector<Utf16String> captured_values;
 
     // 25. Let groupNames be a new empty List.
     HashMap<FlyString, Match> group_names;
@@ -300,7 +300,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
             // ii. Append undefined to indices.
             indices.append({});
             // iii. Append capture to indices.
-            captured_values.append(String::empty());
+            captured_values.append(Utf16String(""sv));
         }
         // c. Else,
         else {
@@ -311,11 +311,12 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
             //     2. Set captureEnd to ! GetStringIndex(S, Input, captureEnd).
             // iv. Let capture be the Match { [[StartIndex]]: captureStart, [[EndIndex]: captureEnd }.
             // v. Let capturedValue be ! GetMatchString(S, capture).
-            captured_value = js_string(vm, capture.view.u16_view());
+            auto capture_as_utf16_string = Utf16String(capture.view.u16_view());
+            captured_value = js_string(vm, capture_as_utf16_string);
             // vi. Append capture to indices.
             indices.append(Match::create(capture));
             // vii. Append capturedValue to the end of capturedValues.
-            captured_values.append(capture.view.to_string());
+            captured_values.append(capture_as_utf16_string);
         }
 
         // d. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(i)), capturedValue).


### PR DESCRIPTION
Let's not incur the cost of a synchronous conversion to UTF-8 for all the legacy static properties after running a regular expression.

The SunSpider subtest regexp-dna goes from taking ~25 sec to ~0.7 sec on my machine.