### PR TITLE
AK: Do not append string bytes as code points when title-casing a string

### DIFF
--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -465,9 +465,9 @@ String to_titlecase(StringView str)
 
     for (auto ch : str) {
         if (next_is_upper)
-            builder.append_code_point(to_ascii_uppercase(ch));
+            builder.append(to_ascii_uppercase(ch));
         else
-            builder.append_code_point(to_ascii_lowercase(ch));
+            builder.append(to_ascii_lowercase(ch));
         next_is_upper = ch == ' ';
     }
 

--- a/Tests/AK/TestStringUtils.cpp
+++ b/Tests/AK/TestStringUtils.cpp
@@ -387,4 +387,6 @@ TEST_CASE(to_titlecase)
     EXPECT_EQ(AK::StringUtils::to_titlecase("foo  bar"sv), "Foo  Bar"sv);
     EXPECT_EQ(AK::StringUtils::to_titlecase("foo   bar"sv), "Foo   Bar"sv);
     EXPECT_EQ(AK::StringUtils::to_titlecase("   foo   bar   "sv), "   Foo   Bar   "sv);
+    EXPECT_EQ(AK::StringUtils::to_titlecase("\xc3\xa7"sv), "\xc3\xa7"sv);         // U+00E7 LATIN SMALL LETTER C WITH CEDILLA
+    EXPECT_EQ(AK::StringUtils::to_titlecase("\xe1\x80\x80"sv), "\xe1\x80\x80"sv); // U+1000 MYANMAR LETTER KA
 }


### PR DESCRIPTION
By appending individual bytes as code points, we were "breaking apart" multi-byte UTF-8 code points. This now behaves the same way as the `invert_case` helper in `StringUtils`.

This was quite noticeable in the emoji picker.

Before:
![before](https://user-images.githubusercontent.com/5600524/196952683-5bf261b8-5eef-4f0f-9d74-090ca94ad1d5.png)

After:
![after](https://user-images.githubusercontent.com/5600524/196952711-aa238c22-e1b1-44d6-8a6e-b78055e675cf.png)

