### PR TITLE
WebDriver: Some code niceties

### DIFF
--- a/Userland/Applications/Browser/WebDriverConnection.cpp
+++ b/Userland/Applications/Browser/WebDriverConnection.cpp
@@ -22,14 +22,14 @@ WebDriverConnection::WebDriverConnection(NonnullOwnPtr<Core::Stream::LocalSocket
 
 void WebDriverConnection::quit()
 {
-    dbgln("WebDriverConnection: quit");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: quit");
     if (auto browser_window = m_browser_window.strong_ref())
         browser_window->close();
 }
 
 Messages::WebDriverSessionClient::GetUrlResponse WebDriverConnection::get_url()
 {
-    dbgln("WebDriverConnection: get_url");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_url");
     if (auto browser_window = m_browser_window.strong_ref())
         return { browser_window->active_tab().url() };
     return { URL("") };
@@ -37,14 +37,14 @@ Messages::WebDriverSessionClient::GetUrlResponse WebDriverConnection::get_url()
 
 void WebDriverConnection::set_url(AK::URL const& url)
 {
-    dbgln("WebDriverConnection: set_url {}", url);
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: set_url {}", url);
     if (auto browser_window = m_browser_window.strong_ref())
         browser_window->active_tab().load(url);
 }
 
 Messages::WebDriverSessionClient::GetTitleResponse WebDriverConnection::get_title()
 {
-    dbgln("WebDriverConnection: get_title");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_title");
     if (auto browser_window = m_browser_window.strong_ref())
         return { browser_window->active_tab().title() };
     return { "" };
@@ -52,28 +52,28 @@ Messages::WebDriverSessionClient::GetTitleResponse WebDriverConnection::get_titl
 
 void WebDriverConnection::refresh()
 {
-    dbgln("WebDriverConnection: refresh");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: refresh");
     if (auto browser_window = m_browser_window.strong_ref())
         browser_window->active_tab().reload();
 }
 
 void WebDriverConnection::back()
 {
-    dbgln("WebDriverConnection: back");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: back");
     if (auto browser_window = m_browser_window.strong_ref())
         browser_window->active_tab().go_back();
 }
 
 void WebDriverConnection::forward()
 {
-    dbgln("WebDriverConnection: forward");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: forward");
     if (auto browser_window = m_browser_window.strong_ref())
         browser_window->active_tab().go_forward();
 }
 
 Messages::WebDriverSessionClient::GetAllCookiesResponse WebDriverConnection::get_all_cookies()
 {
-    dbgln("WebDriverConnection: get_cookies");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_cookies");
     if (auto browser_window = m_browser_window.strong_ref()) {
         if (browser_window->active_tab().on_get_cookies_entries) {
             return { browser_window->active_tab().on_get_cookies_entries() };
@@ -84,7 +84,7 @@ Messages::WebDriverSessionClient::GetAllCookiesResponse WebDriverConnection::get
 
 Messages::WebDriverSessionClient::GetNamedCookieResponse WebDriverConnection::get_named_cookie(String const& name)
 {
-    dbgln("WebDriverConnection: get_named_cookie {}", name);
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_named_cookie {}", name);
     if (auto browser_window = m_browser_window.strong_ref()) {
         if (browser_window->active_tab().on_get_cookies_entries) {
             for (auto cookie : browser_window->active_tab().on_get_cookies_entries()) {
@@ -99,7 +99,7 @@ Messages::WebDriverSessionClient::GetNamedCookieResponse WebDriverConnection::ge
 
 void WebDriverConnection::add_cookie(Web::Cookie::ParsedCookie const& cookie)
 {
-    dbgln("WebDriverConnection: add_cookie {}", cookie.name);
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: add_cookie {}", cookie.name);
     if (auto browser_window = m_browser_window.strong_ref()) {
         auto& tab = browser_window->active_tab();
         if (tab.on_set_cookie) {
@@ -113,7 +113,7 @@ void WebDriverConnection::add_cookie(Web::Cookie::ParsedCookie const& cookie)
 
 void WebDriverConnection::update_cookie(Web::Cookie::Cookie const& cookie)
 {
-    dbgln("WebDriverConnection: update_cookie {}", cookie.name);
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: update_cookie {}", cookie.name);
     if (auto browser_window = m_browser_window.strong_ref()) {
         auto& tab = browser_window->active_tab();
         if (tab.on_update_cookie) {
@@ -124,7 +124,7 @@ void WebDriverConnection::update_cookie(Web::Cookie::Cookie const& cookie)
 
 Messages::WebDriverSessionClient::GetDocumentElementResponse WebDriverConnection::get_document_element()
 {
-    dbgln("WebDriverConnection: get_document_element");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_document_element");
     if (auto browser_window = m_browser_window.strong_ref()) {
         auto& tab = browser_window->active_tab();
         if (tab.on_get_document_element)
@@ -135,7 +135,7 @@ Messages::WebDriverSessionClient::GetDocumentElementResponse WebDriverConnection
 
 Messages::WebDriverSessionClient::QuerySelectorAllResponse WebDriverConnection::query_selector_all(i32 start_node_id, String const& selector)
 {
-    dbgln("WebDriverConnection: query_selector_all");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: query_selector_all");
     if (auto browser_window = m_browser_window.strong_ref()) {
         auto& tab = browser_window->active_tab();
         if (tab.on_query_selector_all)
@@ -146,7 +146,7 @@ Messages::WebDriverSessionClient::QuerySelectorAllResponse WebDriverConnection::
 
 Messages::WebDriverSessionClient::GetElementAttributeResponse WebDriverConnection::get_element_attribute(i32 element_id, String const& name)
 {
-    dbgln("WebDriverConnection: get_element_attribute");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_element_attribute");
     if (auto browser_window = m_browser_window.strong_ref()) {
         auto& tab = browser_window->active_tab();
         if (tab.on_get_element_attribute)
@@ -157,7 +157,7 @@ Messages::WebDriverSessionClient::GetElementAttributeResponse WebDriverConnectio
 
 Messages::WebDriverSessionClient::GetElementPropertyResponse WebDriverConnection::get_element_property(i32 element_id, String const& name)
 {
-    dbgln("WebDriverConnection: get_element_property");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_element_property");
     if (auto browser_window = m_browser_window.strong_ref()) {
         auto& tab = browser_window->active_tab();
         if (tab.on_get_element_property)
@@ -168,7 +168,7 @@ Messages::WebDriverSessionClient::GetElementPropertyResponse WebDriverConnection
 
 Messages::WebDriverSessionClient::GetActiveDocumentsTypeResponse WebDriverConnection::get_active_documents_type()
 {
-    dbgln("WebDriverConnection: get_active_documents_type");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_active_documents_type");
     if (auto browser_window = m_browser_window.strong_ref()) {
         auto& tab = browser_window->active_tab();
         if (tab.on_get_active_documents_type)
@@ -179,7 +179,7 @@ Messages::WebDriverSessionClient::GetActiveDocumentsTypeResponse WebDriverConnec
 
 Messages::WebDriverSessionClient::GetComputedValueForElementResponse WebDriverConnection::get_computed_value_for_element(i32 element_id, String const& property_name)
 {
-    dbgln("WebDriverConnection: get_computed_value_for_element");
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_computed_value_for_element");
     if (auto browser_window = m_browser_window.strong_ref()) {
         auto& tab = browser_window->active_tab();
         if (tab.on_get_computed_value_for_element)

--- a/Userland/Applications/Browser/WebDriverConnection.h
+++ b/Userland/Applications/Browser/WebDriverConnection.h
@@ -26,9 +26,9 @@ class WebDriverConnection final
 public:
     static ErrorOr<NonnullRefPtr<WebDriverConnection>> connect_to_webdriver(NonnullRefPtr<BrowserWindow> browser_window, String path)
     {
-        dbgln("Trying to connect to {}", path);
+        dbgln_if(WEBDRIVER_DEBUG, "Trying to connect to {}", path);
         auto result = TRY(Core::Stream::LocalSocket::connect(path));
-        dbgln("Connected to WebDriver");
+        dbgln_if(WEBDRIVER_DEBUG, "Connected to WebDriver");
         return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) WebDriverConnection(move(result), browser_window)));
     }
 

--- a/Userland/Services/WebDriver/CMakeLists.txt
+++ b/Userland/Services/WebDriver/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     Client.cpp
     Session.cpp
     TimeoutsConfiguration.cpp
+    WebDriverError.cpp
     main.cpp
     )
 

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -12,8 +12,8 @@
 #include <LibCore/Stream.h>
 #include <LibHTTP/Forward.h>
 #include <LibHTTP/HttpRequest.h>
-#include <WebDriver/HttpError.h>
 #include <WebDriver/Session.h>
+#include <WebDriver/WebDriverError.h>
 
 namespace WebDriver {
 
@@ -30,11 +30,11 @@ private:
     ErrorOr<JsonValue> read_body_as_json(HTTP::HttpRequest const&);
     ErrorOr<bool> handle_request(HTTP::HttpRequest const&, JsonValue const& body);
     ErrorOr<void> send_response(StringView content, HTTP::HttpRequest const&);
-    ErrorOr<void> send_error_response(HttpError const& error, HTTP::HttpRequest const&);
+    ErrorOr<void> send_error_response(WebDriverError const& error, HTTP::HttpRequest const&);
     void die();
     void log_response(unsigned code, HTTP::HttpRequest const&);
 
-    using RouteHandler = ErrorOr<JsonValue, HttpError> (Client::*)(Vector<StringView> const&, JsonValue const&);
+    using RouteHandler = ErrorOr<JsonValue, WebDriverError> (Client::*)(Vector<StringView> const&, JsonValue const&);
     struct Route {
         HTTP::HttpRequest::Method method;
         Vector<String> path;
@@ -46,56 +46,56 @@ private:
         Vector<StringView> parameters;
     };
 
-    ErrorOr<RoutingResult, HttpError> match_route(HTTP::HttpRequest::Method method, String const& resource);
-    ErrorOr<JsonValue, HttpError> handle_new_session(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_delete_session(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_get_status(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_get_timeouts(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_set_timeouts(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_navigate_to(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_get_current_url(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_back(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_forward(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_refresh(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_get_title(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_get_window_handle(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_close_window(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_get_window_handles(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_find_element(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_find_elements(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_find_element_from_element(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_find_elements_from_element(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_get_element_attribute(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_get_element_property(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_get_element_css_value(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_get_all_cookies(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_get_named_cookie(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_add_cookie(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_delete_cookie(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> handle_delete_all_cookies(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<RoutingResult, WebDriverError> match_route(HTTP::HttpRequest::Method method, String const& resource);
+    ErrorOr<JsonValue, WebDriverError> handle_new_session(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_delete_session(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_get_status(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_get_timeouts(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_set_timeouts(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_navigate_to(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_get_current_url(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_back(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_forward(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_refresh(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_get_title(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_get_window_handle(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_close_window(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_get_window_handles(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_find_element(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_find_elements(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_find_element_from_element(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_find_elements_from_element(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_get_element_attribute(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_get_element_property(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_get_element_css_value(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_get_all_cookies(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_get_named_cookie(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_add_cookie(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_delete_cookie(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_delete_all_cookies(Vector<StringView> const&, JsonValue const& payload);
 
-    ErrorOr<Session*, HttpError> find_session_with_id(StringView session_id);
+    ErrorOr<Session*, WebDriverError> find_session_with_id(StringView session_id);
     JsonValue make_json_value(JsonValue const&);
 
     template<typename T>
-    static ErrorOr<T, HttpError> unwrap_result(ErrorOr<T, Variant<HttpError, Error>> result)
+    static ErrorOr<T, WebDriverError> unwrap_result(ErrorOr<T, Variant<WebDriverError, Error>> result)
     {
         if (result.is_error()) {
-            Variant<HttpError, Error> error = result.release_error();
-            if (error.has<HttpError>())
-                return error.get<HttpError>();
-            return HttpError { 500, "unsupported operation", error.get<Error>().string_literal() };
+            Variant<WebDriverError, Error> error = result.release_error();
+            if (error.has<WebDriverError>())
+                return error.get<WebDriverError>();
+            return WebDriverError { 500, "unsupported operation", error.get<Error>().string_literal() };
         }
 
         return result.release_value();
     }
-    static ErrorOr<void, HttpError> unwrap_result(ErrorOr<void, Variant<HttpError, Error>> result)
+    static ErrorOr<void, WebDriverError> unwrap_result(ErrorOr<void, Variant<WebDriverError, Error>> result)
     {
         if (result.is_error()) {
-            Variant<HttpError, Error> error = result.release_error();
-            if (error.has<HttpError>())
-                return error.get<HttpError>();
-            return HttpError { 500, "unsupported operation", error.get<Error>().string_literal() };
+            Variant<WebDriverError, Error> error = result.release_error();
+            if (error.has<WebDriverError>())
+                return error.get<WebDriverError>();
+            return WebDriverError { 500, "unsupported operation", error.get<Error>().string_literal() };
         }
         return {};
     }

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -84,7 +84,7 @@ private:
             Variant<WebDriverError, Error> error = result.release_error();
             if (error.has<WebDriverError>())
                 return error.get<WebDriverError>();
-            return WebDriverError { 500, "unsupported operation", error.get<Error>().string_literal() };
+            return WebDriverError::from_code(ErrorCode::UnsupportedOperation, error.get<Error>().string_literal());
         }
 
         return result.release_value();
@@ -95,7 +95,7 @@ private:
             Variant<WebDriverError, Error> error = result.release_error();
             if (error.has<WebDriverError>())
                 return error.get<WebDriverError>();
-            return WebDriverError { 500, "unsupported operation", error.get<Error>().string_literal() };
+            return WebDriverError::from_code(ErrorCode::UnsupportedOperation, error.get<Error>().string_literal());
         }
         return {};
     }

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -84,7 +84,7 @@ JsonObject Session::get_timeouts()
 }
 
 // 9.2 Set Timeouts, https://w3c.github.io/webdriver/#dfn-set-timeouts
-ErrorOr<JsonValue, HttpError> Session::set_timeouts(JsonValue const& payload)
+ErrorOr<JsonValue, WebDriverError> Session::set_timeouts(JsonValue const& payload)
 {
     // 1. Let timeouts be the result of trying to JSON deserialize as a timeouts configuration the request’s parameters.
     auto timeouts = TRY(json_deserialize_as_a_timeouts_configuration(payload));
@@ -97,18 +97,18 @@ ErrorOr<JsonValue, HttpError> Session::set_timeouts(JsonValue const& payload)
 }
 
 // 10.1 Navigate To, https://w3c.github.io/webdriver/#dfn-navigate-to
-ErrorOr<JsonValue, HttpError> Session::navigate_to(JsonValue const& payload)
+ErrorOr<JsonValue, WebDriverError> Session::navigate_to(JsonValue const& payload)
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME 2. Handle any user prompts and return its value if it is an error.
 
     // 3. If the url property is missing from the parameters argument or it is not a string, return error with error code invalid argument.
     if (!payload.is_object() || !payload.as_object().has_string("url"sv)) {
-        return HttpError { 400, "invalid argument", "Payload doesn't have a string url" };
+        return WebDriverError { 400, "invalid argument", "Payload doesn't have a string url" };
     }
 
     // 4. Let url be the result of getting a property named url from the parameters argument.
@@ -133,12 +133,12 @@ ErrorOr<JsonValue, HttpError> Session::navigate_to(JsonValue const& payload)
 }
 
 // 10.2 Get Current URL, https://w3c.github.io/webdriver/#dfn-get-current-url
-ErrorOr<JsonValue, HttpError> Session::get_current_url()
+ErrorOr<JsonValue, WebDriverError> Session::get_current_url()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 2. Handle any user prompts and return its value if it is an error.
 
@@ -150,12 +150,12 @@ ErrorOr<JsonValue, HttpError> Session::get_current_url()
 }
 
 // 10.3 Back, https://w3c.github.io/webdriver/#dfn-back
-ErrorOr<JsonValue, HttpError> Session::back()
+ErrorOr<JsonValue, WebDriverError> Session::back()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 2. Handle any user prompts and return its value if it is an error.
 
@@ -173,12 +173,12 @@ ErrorOr<JsonValue, HttpError> Session::back()
 }
 
 // 10.4 Forward, https://w3c.github.io/webdriver/#dfn-forward
-ErrorOr<JsonValue, HttpError> Session::forward()
+ErrorOr<JsonValue, WebDriverError> Session::forward()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 2. Handle any user prompts and return its value if it is an error.
 
@@ -196,12 +196,12 @@ ErrorOr<JsonValue, HttpError> Session::forward()
 }
 
 // 10.5 Refresh, https://w3c.github.io/webdriver/#dfn-refresh
-ErrorOr<JsonValue, HttpError> Session::refresh()
+ErrorOr<JsonValue, WebDriverError> Session::refresh()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 2. Handle any user prompts and return its value if it is an error.
 
@@ -221,12 +221,12 @@ ErrorOr<JsonValue, HttpError> Session::refresh()
 }
 
 // 10.6 Get Title, https://w3c.github.io/webdriver/#dfn-get-title
-ErrorOr<JsonValue, HttpError> Session::get_title()
+ErrorOr<JsonValue, WebDriverError> Session::get_title()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 2. Handle any user prompts and return its value if it is an error.
 
@@ -236,24 +236,24 @@ ErrorOr<JsonValue, HttpError> Session::get_title()
 }
 
 // 11.1 Get Window Handle, https://w3c.github.io/webdriver/#get-window-handle
-ErrorOr<JsonValue, HttpError> Session::get_window_handle()
+ErrorOr<JsonValue, WebDriverError> Session::get_window_handle()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // 2. Return success with data being the window handle associated with the current top-level browsing context.
     return m_current_window_handle;
 }
 
 // 11.2 Close Window, https://w3c.github.io/webdriver/#dfn-close-window
-ErrorOr<void, Variant<HttpError, Error>> Session::close_window()
+ErrorOr<void, Variant<WebDriverError, Error>> Session::close_window()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return Variant<HttpError, Error>(HttpError { 404, "no such window", "Window not found" });
+        return Variant<WebDriverError, Error>(WebDriverError { 404, "no such window", "Window not found" });
 
     // 2. Close the current top-level browsing context.
     m_windows.remove(m_current_window_handle);
@@ -262,7 +262,7 @@ ErrorOr<void, Variant<HttpError, Error>> Session::close_window()
     if (m_windows.is_empty()) {
         auto result = stop();
         if (result.is_error()) {
-            return Variant<HttpError, Error>(result.release_error());
+            return Variant<WebDriverError, Error>(result.release_error());
         }
     }
 
@@ -270,7 +270,7 @@ ErrorOr<void, Variant<HttpError, Error>> Session::close_window()
 }
 
 // 11.4 Get Window Handles, https://w3c.github.io/webdriver/#dfn-get-window-handles
-ErrorOr<JsonValue, HttpError> Session::get_window_handles() const
+ErrorOr<JsonValue, WebDriverError> Session::get_window_handles() const
 {
     // 1. Let handles be a JSON List.
     auto handles = JsonArray {};
@@ -312,7 +312,7 @@ static JsonObject web_element_reference_object(Session::LocalElement const& elem
 }
 
 // https://w3c.github.io/webdriver/#dfn-find
-ErrorOr<JsonArray, HttpError> Session::find(Session::LocalElement const& start_node, StringView const& using_, StringView const& value)
+ErrorOr<JsonArray, WebDriverError> Session::find(Session::LocalElement const& start_node, StringView const& using_, StringView const& value)
 {
     // 1. Let end time be the current time plus the session implicit wait timeout.
     auto end_time = Time::now_monotonic() + Time::from_milliseconds(static_cast<i64>(m_timeouts_configuration.implicit_wait_timeout));
@@ -326,13 +326,13 @@ ErrorOr<JsonArray, HttpError> Session::find(Session::LocalElement const& start_n
     // 4. Let elements returned be the result of trying to call the relevant element location strategy with arguments start node, and selector.
     auto location_strategy_handler = s_locator_strategies.first_matching([&](LocatorStrategy const& match) { return match.name == location_strategy; });
     if (!location_strategy_handler.has_value())
-        return HttpError { 400, "invalid argument", "No valid location strategy" };
+        return WebDriverError { 400, "invalid argument", "No valid location strategy" };
 
     auto elements_or_error = (this->*location_strategy_handler.value().handler)(start_node, selector);
 
     // 5. If a DOMException, SyntaxError, XPathException, or other error occurs during the execution of the element location strategy, return error invalid selector.
     if (elements_or_error.is_error())
-        return HttpError { 400, "invalid selector", String::formatted("The location strategy could not finish: {}", elements_or_error.release_error().message) };
+        return WebDriverError { 400, "invalid selector", String::formatted("The location strategy could not finish: {}", elements_or_error.release_error().message) };
 
     auto elements = elements_or_error.release_value();
 
@@ -361,14 +361,14 @@ Vector<Session::LocatorStrategy> Session::s_locator_strategies = {
 };
 
 // https://w3c.github.io/webdriver/#css-selectors
-ErrorOr<Vector<Session::LocalElement>, HttpError> Session::locator_strategy_css_selectors(Session::LocalElement const& start_node, StringView const& selector)
+ErrorOr<Vector<Session::LocalElement>, WebDriverError> Session::locator_strategy_css_selectors(Session::LocalElement const& start_node, StringView const& selector)
 {
     // 1. Let elements be the result of calling querySelectorAll() with start node as this and selector as the argument.
     //    If this causes an exception to be thrown, return error with error code invalid selector.
     auto elements_ids = m_browser_connection->query_selector_all(start_node.id, selector);
 
     if (!elements_ids.has_value())
-        return HttpError { 400, "invalid selector", "query_selector_all returned failed!" };
+        return WebDriverError { 400, "invalid selector", "query_selector_all returned failed!" };
 
     Vector<Session::LocalElement> elements;
     for (auto id : elements_ids.release_value()) {
@@ -380,67 +380,67 @@ ErrorOr<Vector<Session::LocalElement>, HttpError> Session::locator_strategy_css_
 }
 
 // https://w3c.github.io/webdriver/#link-text
-ErrorOr<Vector<Session::LocalElement>, HttpError> Session::locator_strategy_link_text(Session::LocalElement const&, StringView const&)
+ErrorOr<Vector<Session::LocalElement>, WebDriverError> Session::locator_strategy_link_text(Session::LocalElement const&, StringView const&)
 {
     // FIXME: Implement
-    return HttpError { 501, "not implemented", "locator strategy link text" };
+    return WebDriverError { 501, "not implemented", "locator strategy link text" };
 }
 
 // https://w3c.github.io/webdriver/#partial-link-text
-ErrorOr<Vector<Session::LocalElement>, HttpError> Session::locator_strategy_partial_link_text(Session::LocalElement const&, StringView const&)
+ErrorOr<Vector<Session::LocalElement>, WebDriverError> Session::locator_strategy_partial_link_text(Session::LocalElement const&, StringView const&)
 {
     // FIXME: Implement
-    return HttpError { 501, "not implemented", "locator strategy partial link text" };
+    return WebDriverError { 501, "not implemented", "locator strategy partial link text" };
 }
 
 // https://w3c.github.io/webdriver/#tag-name
-ErrorOr<Vector<Session::LocalElement>, HttpError> Session::locator_strategy_tag_name(Session::LocalElement const&, StringView const&)
+ErrorOr<Vector<Session::LocalElement>, WebDriverError> Session::locator_strategy_tag_name(Session::LocalElement const&, StringView const&)
 {
     // FIXME: Implement
-    return HttpError { 501, "not implemented", "locator strategy tag name" };
+    return WebDriverError { 501, "not implemented", "locator strategy tag name" };
 }
 
 // https://w3c.github.io/webdriver/#xpath
-ErrorOr<Vector<Session::LocalElement>, HttpError> Session::locator_strategy_x_path(Session::LocalElement const&, StringView const&)
+ErrorOr<Vector<Session::LocalElement>, WebDriverError> Session::locator_strategy_x_path(Session::LocalElement const&, StringView const&)
 {
     // FIXME: Implement
-    return HttpError { 501, "not implemented", "locator strategy XPath" };
+    return WebDriverError { 501, "not implemented", "locator strategy XPath" };
 }
 
 // 12.3.2 Find Element, https://w3c.github.io/webdriver/#dfn-find-element
-ErrorOr<JsonValue, HttpError> Session::find_element(JsonValue const& payload)
+ErrorOr<JsonValue, WebDriverError> Session::find_element(JsonValue const& payload)
 {
     if (!payload.is_object())
-        return HttpError { 400, "invalid argument", "Payload is not a JSON object" };
+        return WebDriverError { 400, "invalid argument", "Payload is not a JSON object" };
 
     auto const& properties = payload.as_object();
     // 1. Let location strategy be the result of getting a property called "using".
     if (!properties.has("using"sv))
-        return HttpError { 400, "invalid argument", "No property called 'using' present" };
+        return WebDriverError { 400, "invalid argument", "No property called 'using' present" };
     auto const& maybe_location_strategy = properties.get("using"sv);
     if (!maybe_location_strategy.is_string())
-        return HttpError { 400, "invalid argument", "Property 'using' is not a String" };
+        return WebDriverError { 400, "invalid argument", "Property 'using' is not a String" };
 
     auto location_strategy = maybe_location_strategy.to_string();
 
     // 2. If location strategy is not present as a keyword in the table of location strategies, return error with error code invalid argument.
     if (!s_locator_strategies.first_matching([&](LocatorStrategy const& match) { return match.name == location_strategy; }).has_value())
-        return HttpError { 400, "invalid argument", "No valid location strategy" };
+        return WebDriverError { 400, "invalid argument", "No valid location strategy" };
 
     // 3. Let selector be the result of getting a property called "value".
     // 4. If selector is undefined, return error with error code invalid argument.
     if (!properties.has("value"sv))
-        return HttpError { 400, "invalid argument", "No property called 'value' present" };
+        return WebDriverError { 400, "invalid argument", "No property called 'value' present" };
     auto const& maybe_selector = properties.get("value"sv);
     if (!maybe_selector.is_string())
-        return HttpError { 400, "invalid argument", "Property 'value' is not a String" };
+        return WebDriverError { 400, "invalid argument", "Property 'value' is not a String" };
 
     auto selector = maybe_selector.to_string();
 
     // 5. If the current browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 6. Handle any user prompts and return its value if it is an error.
 
@@ -449,7 +449,7 @@ ErrorOr<JsonValue, HttpError> Session::find_element(JsonValue const& payload)
 
     // 8. If start node is null, return error with error code no such element.
     if (!maybe_start_node_id.has_value())
-        return HttpError { 404, "no such element", "document element does not exist" };
+        return WebDriverError { 404, "no such element", "document element does not exist" };
 
     auto start_node_id = maybe_start_node_id.release_value();
     LocalElement start_node = { start_node_id };
@@ -459,45 +459,45 @@ ErrorOr<JsonValue, HttpError> Session::find_element(JsonValue const& payload)
 
     // 10. If result is empty, return error with error code no such element. Otherwise, return the first element of result.
     if (result.is_empty())
-        return HttpError { 404, "no such element", "the requested element does not exist" };
+        return WebDriverError { 404, "no such element", "the requested element does not exist" };
 
     return JsonValue(result.at(0));
 }
 
 // 12.3.3 Find Elements, https://w3c.github.io/webdriver/#dfn-find-elements
-ErrorOr<JsonValue, HttpError> Session::find_elements(JsonValue const& payload)
+ErrorOr<JsonValue, WebDriverError> Session::find_elements(JsonValue const& payload)
 {
     if (!payload.is_object())
-        return HttpError { 400, "invalid argument", "Payload is not a JSON object" };
+        return WebDriverError { 400, "invalid argument", "Payload is not a JSON object" };
 
     auto const& properties = payload.as_object();
     // 1. Let location strategy be the result of getting a property called "using".
     if (!properties.has("using"sv))
-        return HttpError { 400, "invalid argument", "No property called 'using' present" };
+        return WebDriverError { 400, "invalid argument", "No property called 'using' present" };
     auto const& maybe_location_strategy = properties.get("using"sv);
     if (!maybe_location_strategy.is_string())
-        return HttpError { 400, "invalid argument", "Property 'using' is not a String" };
+        return WebDriverError { 400, "invalid argument", "Property 'using' is not a String" };
 
     auto location_strategy = maybe_location_strategy.to_string();
 
     // 2. If location strategy is not present as a keyword in the table of location strategies, return error with error code invalid argument.
     if (!s_locator_strategies.first_matching([&](LocatorStrategy const& match) { return match.name == location_strategy; }).has_value())
-        return HttpError { 400, "invalid argument", "No valid location strategy" };
+        return WebDriverError { 400, "invalid argument", "No valid location strategy" };
 
     // 3. Let selector be the result of getting a property called "value".
     // 4. If selector is undefined, return error with error code invalid argument.
     if (!properties.has("value"sv))
-        return HttpError { 400, "invalid argument", "No property called 'value' present" };
+        return WebDriverError { 400, "invalid argument", "No property called 'value' present" };
     auto const& maybe_selector = properties.get("value"sv);
     if (!maybe_selector.is_string())
-        return HttpError { 400, "invalid argument", "Property 'value' is not a String" };
+        return WebDriverError { 400, "invalid argument", "Property 'value' is not a String" };
 
     auto selector = maybe_selector.to_string();
 
     // 5. If the current browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 6. Handle any user prompts and return its value if it is an error.
 
@@ -506,7 +506,7 @@ ErrorOr<JsonValue, HttpError> Session::find_elements(JsonValue const& payload)
 
     // 8. If start node is null, return error with error code no such element.
     if (!maybe_start_node_id.has_value())
-        return HttpError { 404, "no such element", "document element does not exist" };
+        return WebDriverError { 404, "no such element", "document element does not exist" };
 
     auto start_node_id = maybe_start_node_id.release_value();
     LocalElement start_node = { start_node_id };
@@ -517,39 +517,39 @@ ErrorOr<JsonValue, HttpError> Session::find_elements(JsonValue const& payload)
 }
 
 // 12.3.4 Find Element From Element, https://w3c.github.io/webdriver/#dfn-find-element-from-element
-ErrorOr<JsonValue, HttpError> Session::find_element_from_element(JsonValue const& payload, StringView parameter_element_id)
+ErrorOr<JsonValue, WebDriverError> Session::find_element_from_element(JsonValue const& payload, StringView parameter_element_id)
 {
     if (!payload.is_object())
-        return HttpError { 400, "invalid argument", "Payload is not a JSON object" };
+        return WebDriverError { 400, "invalid argument", "Payload is not a JSON object" };
 
     auto const& properties = payload.as_object();
     // 1. Let location strategy be the result of getting a property called "using".
     if (!properties.has("using"sv))
-        return HttpError { 400, "invalid argument", "No property called 'using' present" };
+        return WebDriverError { 400, "invalid argument", "No property called 'using' present" };
     auto const& maybe_location_strategy = properties.get("using"sv);
     if (!maybe_location_strategy.is_string())
-        return HttpError { 400, "invalid argument", "Property 'using' is not a String" };
+        return WebDriverError { 400, "invalid argument", "Property 'using' is not a String" };
 
     auto location_strategy = maybe_location_strategy.to_string();
 
     // 2. If location strategy is not present as a keyword in the table of location strategies, return error with error code invalid argument.
     if (!s_locator_strategies.first_matching([&](LocatorStrategy const& match) { return match.name == location_strategy; }).has_value())
-        return HttpError { 400, "invalid argument", "No valid location strategy" };
+        return WebDriverError { 400, "invalid argument", "No valid location strategy" };
 
     // 3. Let selector be the result of getting a property called "value".
     // 4. If selector is undefined, return error with error code invalid argument.
     if (!properties.has("value"sv))
-        return HttpError { 400, "invalid argument", "No property called 'value' present" };
+        return WebDriverError { 400, "invalid argument", "No property called 'value' present" };
     auto const& maybe_selector = properties.get("value"sv);
     if (!maybe_selector.is_string())
-        return HttpError { 400, "invalid argument", "Property 'value' is not a String" };
+        return WebDriverError { 400, "invalid argument", "Property 'value' is not a String" };
 
     auto selector = maybe_selector.to_string();
 
     // 5. If the current browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 6. Handle any user prompts and return its value if it is an error.
 
@@ -559,7 +559,7 @@ ErrorOr<JsonValue, HttpError> Session::find_element_from_element(JsonValue const
 
     auto maybe_element_id = parameter_element_id.to_int();
     if (!maybe_element_id.has_value())
-        return HttpError { 400, "invalid argument", "Element ID is not an i32" };
+        return WebDriverError { 400, "invalid argument", "Element ID is not an i32" };
 
     auto element_id = maybe_element_id.release_value();
     LocalElement start_node = { element_id };
@@ -569,45 +569,45 @@ ErrorOr<JsonValue, HttpError> Session::find_element_from_element(JsonValue const
 
     // 9. If result is empty, return error with error code no such element. Otherwise, return the first element of result.
     if (result.is_empty())
-        return HttpError { 404, "no such element", "the requested element does not exist" };
+        return WebDriverError { 404, "no such element", "the requested element does not exist" };
 
     return JsonValue(result.at(0));
 }
 
 // 12.3.5 Find Elements From Element, https://w3c.github.io/webdriver/#dfn-find-elements-from-element
-ErrorOr<JsonValue, HttpError> Session::find_elements_from_element(JsonValue const& payload, StringView parameter_element_id)
+ErrorOr<JsonValue, WebDriverError> Session::find_elements_from_element(JsonValue const& payload, StringView parameter_element_id)
 {
     if (!payload.is_object())
-        return HttpError { 400, "invalid argument", "Payload is not a JSON object" };
+        return WebDriverError { 400, "invalid argument", "Payload is not a JSON object" };
 
     auto const& properties = payload.as_object();
     // 1. Let location strategy be the result of getting a property called "using".
     if (!properties.has("using"sv))
-        return HttpError { 400, "invalid argument", "No property called 'using' present" };
+        return WebDriverError { 400, "invalid argument", "No property called 'using' present" };
     auto const& maybe_location_strategy = properties.get("using"sv);
     if (!maybe_location_strategy.is_string())
-        return HttpError { 400, "invalid argument", "Property 'using' is not a String" };
+        return WebDriverError { 400, "invalid argument", "Property 'using' is not a String" };
 
     auto location_strategy = maybe_location_strategy.to_string();
 
     // 2. If location strategy is not present as a keyword in the table of location strategies, return error with error code invalid argument.
     if (!s_locator_strategies.first_matching([&](LocatorStrategy const& match) { return match.name == location_strategy; }).has_value())
-        return HttpError { 400, "invalid argument", "No valid location strategy" };
+        return WebDriverError { 400, "invalid argument", "No valid location strategy" };
 
     // 3. Let selector be the result of getting a property called "value".
     // 4. If selector is undefined, return error with error code invalid argument.
     if (!properties.has("value"sv))
-        return HttpError { 400, "invalid argument", "No property called 'value' present" };
+        return WebDriverError { 400, "invalid argument", "No property called 'value' present" };
     auto const& maybe_selector = properties.get("value"sv);
     if (!maybe_selector.is_string())
-        return HttpError { 400, "invalid argument", "Property 'value' is not a String" };
+        return WebDriverError { 400, "invalid argument", "Property 'value' is not a String" };
 
     auto selector = maybe_selector.to_string();
 
     // 5. If the current browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 6. Handle any user prompts and return its value if it is an error.
 
@@ -617,7 +617,7 @@ ErrorOr<JsonValue, HttpError> Session::find_elements_from_element(JsonValue cons
 
     auto maybe_element_id = parameter_element_id.to_int();
     if (!maybe_element_id.has_value())
-        return HttpError { 400, "invalid argument", "Element ID is not an i32" };
+        return WebDriverError { 400, "invalid argument", "Element ID is not an i32" };
 
     auto element_id = maybe_element_id.release_value();
     LocalElement start_node = { element_id };
@@ -628,12 +628,12 @@ ErrorOr<JsonValue, HttpError> Session::find_elements_from_element(JsonValue cons
 }
 
 // 12.4.2 Get Element Attribute, https://w3c.github.io/webdriver/#dfn-get-element-attribute
-ErrorOr<JsonValue, HttpError> Session::get_element_attribute(JsonValue const&, StringView parameter_element_id, StringView name)
+ErrorOr<JsonValue, WebDriverError> Session::get_element_attribute(JsonValue const&, StringView parameter_element_id, StringView name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 2. Handle any user prompts and return its value if it is an error.
 
@@ -642,7 +642,7 @@ ErrorOr<JsonValue, HttpError> Session::get_element_attribute(JsonValue const&, S
     //       For now the element is only represented by its ID
     auto maybe_element_id = parameter_element_id.to_int();
     if (!maybe_element_id.has_value())
-        return HttpError { 400, "invalid argument", "Element ID is not an i32" };
+        return WebDriverError { 400, "invalid argument", "Element ID is not an i32" };
 
     auto element_id = maybe_element_id.release_value();
 
@@ -664,12 +664,12 @@ ErrorOr<JsonValue, HttpError> Session::get_element_attribute(JsonValue const&, S
 }
 
 // 12.4.3 Get Element Property, https://w3c.github.io/webdriver/#dfn-get-element-property
-ErrorOr<JsonValue, HttpError> Session::get_element_property(JsonValue const&, StringView parameter_element_id, StringView name)
+ErrorOr<JsonValue, WebDriverError> Session::get_element_property(JsonValue const&, StringView parameter_element_id, StringView name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 2. Handle any user prompts and return its value if it is an error.
 
@@ -678,7 +678,7 @@ ErrorOr<JsonValue, HttpError> Session::get_element_property(JsonValue const&, St
     //       For now the element is only represented by its ID
     auto maybe_element_id = parameter_element_id.to_int();
     if (!maybe_element_id.has_value())
-        return HttpError { 400, "invalid argument", "Element ID is not an i32" };
+        return WebDriverError { 400, "invalid argument", "Element ID is not an i32" };
 
     auto element_id = maybe_element_id.release_value();
 
@@ -694,12 +694,12 @@ ErrorOr<JsonValue, HttpError> Session::get_element_property(JsonValue const&, St
 }
 
 // 12.4.4 Get Element CSS Value, https://w3c.github.io/webdriver/#dfn-get-element-css-value
-ErrorOr<JsonValue, HttpError> Session::get_element_css_value(JsonValue const&, StringView parameter_element_id, StringView property_name)
+ErrorOr<JsonValue, WebDriverError> Session::get_element_css_value(JsonValue const&, StringView parameter_element_id, StringView property_name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 2. Handle any user prompts and return its value if it is an error.
 
@@ -708,7 +708,7 @@ ErrorOr<JsonValue, HttpError> Session::get_element_css_value(JsonValue const&, S
     //       For now the element is only represented by its ID
     auto maybe_element_id = parameter_element_id.to_int();
     if (!maybe_element_id.has_value())
-        return HttpError { 400, "invalid argument", "Element ID is not an i32" };
+        return WebDriverError { 400, "invalid argument", "Element ID is not an i32" };
 
     auto element_id = maybe_element_id.release_value();
 
@@ -744,12 +744,12 @@ static JsonObject serialize_cookie(Web::Cookie::Cookie const& cookie)
 }
 
 // 14.1 Get All Cookies, https://w3c.github.io/webdriver/#dfn-get-all-cookies
-ErrorOr<JsonValue, HttpError> Session::get_all_cookies()
+ErrorOr<JsonValue, WebDriverError> Session::get_all_cookies()
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 2. Handle any user prompts, and return its value if it is an error.
 
@@ -770,12 +770,12 @@ ErrorOr<JsonValue, HttpError> Session::get_all_cookies()
 }
 
 // 14.2 Get Named Cookie, https://w3c.github.io/webdriver/#dfn-get-named-cookie
-ErrorOr<JsonValue, HttpError> Session::get_named_cookie(String const& name)
+ErrorOr<JsonValue, WebDriverError> Session::get_named_cookie(String const& name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 2. Handle any user prompts, and return its value if it is an error.
 
@@ -789,15 +789,15 @@ ErrorOr<JsonValue, HttpError> Session::get_named_cookie(String const& name)
     }
 
     // 4. Otherwise, return error with error code no such cookie.
-    return HttpError { 404, "no such cookie", "Cookie not found" };
+    return WebDriverError { 404, "no such cookie", "Cookie not found" };
 }
 
 // 14.3 Add Cookie, https://w3c.github.io/webdriver/#dfn-adding-a-cookie
-ErrorOr<JsonValue, HttpError> Session::add_cookie(JsonValue const& payload)
+ErrorOr<JsonValue, WebDriverError> Session::add_cookie(JsonValue const& payload)
 {
     // 1. Let data be the result of getting a property named cookie from the parameters argument.
     if (!payload.is_object() || !payload.as_object().has_object("cookie"sv))
-        return HttpError { 400, "invalid argument", "Payload doesn't have a cookie object" };
+        return WebDriverError { 400, "invalid argument", "Payload doesn't have a cookie object" };
 
     auto const& maybe_data = payload.as_object().get("cookie"sv);
 
@@ -805,17 +805,17 @@ ErrorOr<JsonValue, HttpError> Session::add_cookie(JsonValue const& payload)
     //    return error with error code invalid argument.
     // NOTE: Table is here: https://w3c.github.io/webdriver/#dfn-table-for-cookie-conversion
     if (!maybe_data.is_object())
-        return HttpError { 400, "invalid argument", "Value \"cookie\' is not an object" };
+        return WebDriverError { 400, "invalid argument", "Value \"cookie\' is not an object" };
 
     auto const& data = maybe_data.as_object();
 
     if (!data.has("name"sv) || !data.has("value"sv))
-        return HttpError { 400, "invalid argument", "Cookie-Object doesn't contain all required keys" };
+        return WebDriverError { 400, "invalid argument", "Cookie-Object doesn't contain all required keys" };
 
     // 3. If the current browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 4. Handle any user prompts, and return its value if it is an error.
 
@@ -828,17 +828,17 @@ ErrorOr<JsonValue, HttpError> Session::add_cookie(JsonValue const& payload)
     //    or cookie expiry time is not an integer type, or it less than 0 or greater than the maximum safe integer,
     //    return error with error code invalid argument.
     if (data.get("name"sv).is_null() || data.get("value"sv).is_null())
-        return HttpError { 400, "invalid argument", "Cookie-Object is malformed: name or value are null" };
+        return WebDriverError { 400, "invalid argument", "Cookie-Object is malformed: name or value are null" };
     if (data.has("secure"sv) && !data.get("secure"sv).is_bool())
-        return HttpError { 400, "invalid argument", "Cookie-Object is malformed: secure is not bool" };
+        return WebDriverError { 400, "invalid argument", "Cookie-Object is malformed: secure is not bool" };
     if (data.has("httpOnly"sv) && !data.get("httpOnly"sv).is_bool())
-        return HttpError { 400, "invalid argument", "Cookie-Object is malformed: httpOnly is not bool" };
+        return WebDriverError { 400, "invalid argument", "Cookie-Object is malformed: httpOnly is not bool" };
     Optional<Core::DateTime> expiry_time;
     if (data.has("expiry"sv)) {
         auto expiry_argument = data.get("expiry"sv);
         if (!expiry_argument.is_u32()) {
             // NOTE: less than 0 or greater than safe integer are handled by the JSON parser
-            return HttpError { 400, "invalid argument", "Cookie-Object is malformed: expiry is not u32" };
+            return WebDriverError { 400, "invalid argument", "Cookie-Object is malformed: expiry is not u32" };
         }
         expiry_time = Core::DateTime::from_timestamp(expiry_argument.as_u32());
     }
@@ -850,12 +850,12 @@ ErrorOr<JsonValue, HttpError> Session::add_cookie(JsonValue const& payload)
     if (auto name_attribute = data.get("name"sv); name_attribute.is_string())
         cookie.name = name_attribute.as_string();
     else
-        return HttpError { 400, "invalid argument", "Expect name attribute to be string" };
+        return WebDriverError { 400, "invalid argument", "Expect name attribute to be string" };
 
     if (auto value_attribute = data.get("value"sv); value_attribute.is_string())
         cookie.value = value_attribute.as_string();
     else
-        return HttpError { 400, "invalid argument", "Expect value attribute to be string" };
+        return WebDriverError { 400, "invalid argument", "Expect value attribute to be string" };
 
     // Cookie path
     //     The value if the entry exists, otherwise "/".
@@ -863,7 +863,7 @@ ErrorOr<JsonValue, HttpError> Session::add_cookie(JsonValue const& payload)
         if (auto path_attribute = data.get("path"sv); path_attribute.is_string())
             cookie.path = path_attribute.as_string();
         else
-            return HttpError { 400, "invalid argument", "Expect path attribute to be string" };
+            return WebDriverError { 400, "invalid argument", "Expect path attribute to be string" };
     } else {
         cookie.path = "/";
     }
@@ -875,7 +875,7 @@ ErrorOr<JsonValue, HttpError> Session::add_cookie(JsonValue const& payload)
         if (auto domain_attribute = data.get("domain"sv); domain_attribute.is_string())
             cookie.domain = domain_attribute.as_string();
         else
-            return HttpError { 400, "invalid argument", "Expect domain attribute to be string" };
+            return WebDriverError { 400, "invalid argument", "Expect domain attribute to be string" };
     }
 
     // Cookie secure only
@@ -931,12 +931,12 @@ void Session::delete_cookies(Optional<StringView> const& name)
 }
 
 // 14.4 Delete Cookie, https://w3c.github.io/webdriver/#dfn-delete-cookie
-ErrorOr<JsonValue, HttpError> Session::delete_cookie(StringView const& name)
+ErrorOr<JsonValue, WebDriverError> Session::delete_cookie(StringView const& name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 2. Handle any user prompts, and return its value if it is an error.
 
@@ -948,12 +948,12 @@ ErrorOr<JsonValue, HttpError> Session::delete_cookie(StringView const& name)
 }
 
 // 14.5 Delete All Cookies, https://w3c.github.io/webdriver/#dfn-delete-all-cookies
-ErrorOr<JsonValue, HttpError> Session::delete_all_cookies()
+ErrorOr<JsonValue, WebDriverError> Session::delete_all_cookies()
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     auto current_window = this->current_window();
     if (!current_window.has_value())
-        return HttpError { 404, "no such window", "Window not found" };
+        return WebDriverError { 404, "no such window", "Window not found" };
 
     // FIXME: 2. Handle any user prompts, and return its value if it is an error.
 

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -33,7 +33,8 @@ public:
         i32 id;
     };
 
-    Optional<Window*> current_window() { return m_windows.get(m_current_window_handle); }
+    ErrorOr<Window*, WebDriverError> current_window();
+    ErrorOr<void, WebDriverError> check_for_open_top_level_browsing_context_or_return_error();
     String const& current_window_handle() { return m_current_window_handle; }
 
     ErrorOr<void> start();

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -11,8 +11,8 @@
 #include <AK/JsonValue.h>
 #include <AK/RefPtr.h>
 #include <WebDriver/BrowserConnection.h>
-#include <WebDriver/HttpError.h>
 #include <WebDriver/TimeoutsConfiguration.h>
+#include <WebDriver/WebDriverError.h>
 #include <unistd.h>
 
 namespace WebDriver {
@@ -39,34 +39,34 @@ public:
     ErrorOr<void> start();
     ErrorOr<void> stop();
     JsonObject get_timeouts();
-    ErrorOr<JsonValue, HttpError> set_timeouts(JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> navigate_to(JsonValue const& url);
-    ErrorOr<JsonValue, HttpError> get_current_url();
-    ErrorOr<JsonValue, HttpError> back();
-    ErrorOr<JsonValue, HttpError> forward();
-    ErrorOr<JsonValue, HttpError> refresh();
-    ErrorOr<JsonValue, HttpError> get_title();
-    ErrorOr<JsonValue, HttpError> get_window_handle();
-    ErrorOr<void, Variant<HttpError, Error>> close_window();
-    ErrorOr<JsonValue, HttpError> get_window_handles() const;
-    ErrorOr<JsonValue, HttpError> find_element(JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> find_elements(JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> find_element_from_element(JsonValue const& payload, StringView parameter_element_id);
-    ErrorOr<JsonValue, HttpError> find_elements_from_element(JsonValue const& payload, StringView parameter_element_id);
-    ErrorOr<JsonValue, HttpError> get_element_attribute(JsonValue const& payload, StringView element_id, StringView name);
-    ErrorOr<JsonValue, HttpError> get_element_property(JsonValue const& payload, StringView element_id, StringView name);
-    ErrorOr<JsonValue, HttpError> get_element_css_value(JsonValue const& payload, StringView element_id, StringView property_name);
-    ErrorOr<JsonValue, HttpError> get_all_cookies();
-    ErrorOr<JsonValue, HttpError> get_named_cookie(String const& name);
-    ErrorOr<JsonValue, HttpError> add_cookie(JsonValue const& payload);
-    ErrorOr<JsonValue, HttpError> delete_cookie(StringView const& name);
-    ErrorOr<JsonValue, HttpError> delete_all_cookies();
+    ErrorOr<JsonValue, WebDriverError> set_timeouts(JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> navigate_to(JsonValue const& url);
+    ErrorOr<JsonValue, WebDriverError> get_current_url();
+    ErrorOr<JsonValue, WebDriverError> back();
+    ErrorOr<JsonValue, WebDriverError> forward();
+    ErrorOr<JsonValue, WebDriverError> refresh();
+    ErrorOr<JsonValue, WebDriverError> get_title();
+    ErrorOr<JsonValue, WebDriverError> get_window_handle();
+    ErrorOr<void, Variant<WebDriverError, Error>> close_window();
+    ErrorOr<JsonValue, WebDriverError> get_window_handles() const;
+    ErrorOr<JsonValue, WebDriverError> find_element(JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> find_elements(JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> find_element_from_element(JsonValue const& payload, StringView parameter_element_id);
+    ErrorOr<JsonValue, WebDriverError> find_elements_from_element(JsonValue const& payload, StringView parameter_element_id);
+    ErrorOr<JsonValue, WebDriverError> get_element_attribute(JsonValue const& payload, StringView element_id, StringView name);
+    ErrorOr<JsonValue, WebDriverError> get_element_property(JsonValue const& payload, StringView element_id, StringView name);
+    ErrorOr<JsonValue, WebDriverError> get_element_css_value(JsonValue const& payload, StringView element_id, StringView property_name);
+    ErrorOr<JsonValue, WebDriverError> get_all_cookies();
+    ErrorOr<JsonValue, WebDriverError> get_named_cookie(String const& name);
+    ErrorOr<JsonValue, WebDriverError> add_cookie(JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> delete_cookie(StringView const& name);
+    ErrorOr<JsonValue, WebDriverError> delete_all_cookies();
 
 private:
     void delete_cookies(Optional<StringView> const& name = {});
-    ErrorOr<JsonArray, HttpError> find(LocalElement const& start_node, StringView const& location_strategy, StringView const& selector);
+    ErrorOr<JsonArray, WebDriverError> find(LocalElement const& start_node, StringView const& location_strategy, StringView const& selector);
 
-    using ElementLocationStrategyHandler = ErrorOr<Vector<LocalElement>, HttpError> (Session::*)(LocalElement const&, StringView const&);
+    using ElementLocationStrategyHandler = ErrorOr<Vector<LocalElement>, WebDriverError> (Session::*)(LocalElement const&, StringView const&);
     struct LocatorStrategy {
         String name;
         ElementLocationStrategyHandler handler;
@@ -74,11 +74,11 @@ private:
 
     static Vector<LocatorStrategy> s_locator_strategies;
 
-    ErrorOr<Vector<LocalElement>, HttpError> locator_strategy_css_selectors(LocalElement const&, StringView const&);
-    ErrorOr<Vector<LocalElement>, HttpError> locator_strategy_link_text(LocalElement const&, StringView const&);
-    ErrorOr<Vector<LocalElement>, HttpError> locator_strategy_partial_link_text(LocalElement const&, StringView const&);
-    ErrorOr<Vector<LocalElement>, HttpError> locator_strategy_tag_name(LocalElement const&, StringView const&);
-    ErrorOr<Vector<LocalElement>, HttpError> locator_strategy_x_path(LocalElement const&, StringView const&);
+    ErrorOr<Vector<LocalElement>, WebDriverError> locator_strategy_css_selectors(LocalElement const&, StringView const&);
+    ErrorOr<Vector<LocalElement>, WebDriverError> locator_strategy_link_text(LocalElement const&, StringView const&);
+    ErrorOr<Vector<LocalElement>, WebDriverError> locator_strategy_partial_link_text(LocalElement const&, StringView const&);
+    ErrorOr<Vector<LocalElement>, WebDriverError> locator_strategy_tag_name(LocalElement const&, StringView const&);
+    ErrorOr<Vector<LocalElement>, WebDriverError> locator_strategy_x_path(LocalElement const&, StringView const&);
 
     NonnullRefPtr<Client> m_client;
     bool m_started { false };

--- a/Userland/Services/WebDriver/TimeoutsConfiguration.cpp
+++ b/Userland/Services/WebDriver/TimeoutsConfiguration.cpp
@@ -5,8 +5,8 @@
  */
 
 #include <AK/JsonObject.h>
-#include <WebDriver/HttpError.h>
 #include <WebDriver/TimeoutsConfiguration.h>
+#include <WebDriver/WebDriverError.h>
 
 namespace WebDriver {
 
@@ -35,7 +35,7 @@ JsonObject timeouts_object(TimeoutsConfiguration const& timeouts)
 }
 
 // https://w3c.github.io/webdriver/#ref-for-dfn-json-deserialize-3
-ErrorOr<TimeoutsConfiguration, HttpError> json_deserialize_as_a_timeouts_configuration(JsonValue const& value)
+ErrorOr<TimeoutsConfiguration, WebDriverError> json_deserialize_as_a_timeouts_configuration(JsonValue const& value)
 {
     constexpr i64 max_safe_integer = 9007199254740991;
 
@@ -44,7 +44,7 @@ ErrorOr<TimeoutsConfiguration, HttpError> json_deserialize_as_a_timeouts_configu
 
     // 2. If value is not a JSON Object, return error with error code invalid argument.
     if (!value.is_object())
-        return HttpError { 400, "invalid argument", "Payload is not a JSON object" };
+        return WebDriverError { 400, "invalid argument", "Payload is not a JSON object" };
 
     // 3. If value has a property with the key "script":
     if (value.as_object().has("script"sv)) {
@@ -53,7 +53,7 @@ ErrorOr<TimeoutsConfiguration, HttpError> json_deserialize_as_a_timeouts_configu
 
         // 2. If script duration is a number and less than 0 or greater than maximum safe integer, or it is not null, return error with error code invalid argument.
         if ((script_duration.is_number() && (script_duration.to_i64() < 0 || script_duration.to_i64() > max_safe_integer)) || !script_duration.is_null())
-            return HttpError { 400, "invalid argument", "Invalid script duration" };
+            return WebDriverError { 400, "invalid argument", "Invalid script duration" };
 
         // 3. Set timeouts’s script timeout to script duration.
         timeouts.script_timeout = script_duration.is_null() ? Optional<u64> {} : script_duration.to_u64();
@@ -66,7 +66,7 @@ ErrorOr<TimeoutsConfiguration, HttpError> json_deserialize_as_a_timeouts_configu
 
         // 2. If page load duration is less than 0 or greater than maximum safe integer, return error with error code invalid argument.
         if (!page_load_duration.is_number() || page_load_duration.to_i64() < 0 || page_load_duration.to_i64() > max_safe_integer)
-            return HttpError { 400, "invalid argument", "Invalid page load duration" };
+            return WebDriverError { 400, "invalid argument", "Invalid page load duration" };
 
         // 3. Set timeouts’s page load timeout to page load duration.
         timeouts.page_load_timeout = page_load_duration.to_u64();
@@ -79,7 +79,7 @@ ErrorOr<TimeoutsConfiguration, HttpError> json_deserialize_as_a_timeouts_configu
 
         // 2. If implicit duration is less than 0 or greater than maximum safe integer, return error with error code invalid argument.
         if (!implicit_duration.is_number() || implicit_duration.to_i64() < 0 || implicit_duration.to_i64() > max_safe_integer)
-            return HttpError { 400, "invalid argument", "Invalid implicit duration" };
+            return WebDriverError { 400, "invalid argument", "Invalid implicit duration" };
 
         // 3. Set timeouts’s implicit wait timeout to implicit duration.
         timeouts.implicit_wait_timeout = implicit_duration.to_u64();

--- a/Userland/Services/WebDriver/TimeoutsConfiguration.cpp
+++ b/Userland/Services/WebDriver/TimeoutsConfiguration.cpp
@@ -44,7 +44,7 @@ ErrorOr<TimeoutsConfiguration, WebDriverError> json_deserialize_as_a_timeouts_co
 
     // 2. If value is not a JSON Object, return error with error code invalid argument.
     if (!value.is_object())
-        return WebDriverError { 400, "invalid argument", "Payload is not a JSON object" };
+        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object");
 
     // 3. If value has a property with the key "script":
     if (value.as_object().has("script"sv)) {
@@ -53,7 +53,7 @@ ErrorOr<TimeoutsConfiguration, WebDriverError> json_deserialize_as_a_timeouts_co
 
         // 2. If script duration is a number and less than 0 or greater than maximum safe integer, or it is not null, return error with error code invalid argument.
         if ((script_duration.is_number() && (script_duration.to_i64() < 0 || script_duration.to_i64() > max_safe_integer)) || !script_duration.is_null())
-            return WebDriverError { 400, "invalid argument", "Invalid script duration" };
+            return WebDriverError::from_code(ErrorCode::InvalidArgument, "Invalid script duration");
 
         // 3. Set timeouts’s script timeout to script duration.
         timeouts.script_timeout = script_duration.is_null() ? Optional<u64> {} : script_duration.to_u64();
@@ -66,7 +66,7 @@ ErrorOr<TimeoutsConfiguration, WebDriverError> json_deserialize_as_a_timeouts_co
 
         // 2. If page load duration is less than 0 or greater than maximum safe integer, return error with error code invalid argument.
         if (!page_load_duration.is_number() || page_load_duration.to_i64() < 0 || page_load_duration.to_i64() > max_safe_integer)
-            return WebDriverError { 400, "invalid argument", "Invalid page load duration" };
+            return WebDriverError::from_code(ErrorCode::InvalidArgument, "Invalid page load duration");
 
         // 3. Set timeouts’s page load timeout to page load duration.
         timeouts.page_load_timeout = page_load_duration.to_u64();
@@ -79,7 +79,7 @@ ErrorOr<TimeoutsConfiguration, WebDriverError> json_deserialize_as_a_timeouts_co
 
         // 2. If implicit duration is less than 0 or greater than maximum safe integer, return error with error code invalid argument.
         if (!implicit_duration.is_number() || implicit_duration.to_i64() < 0 || implicit_duration.to_i64() > max_safe_integer)
-            return WebDriverError { 400, "invalid argument", "Invalid implicit duration" };
+            return WebDriverError::from_code(ErrorCode::InvalidArgument, "Invalid implicit duration");
 
         // 3. Set timeouts’s implicit wait timeout to implicit duration.
         timeouts.implicit_wait_timeout = implicit_duration.to_u64();

--- a/Userland/Services/WebDriver/TimeoutsConfiguration.h
+++ b/Userland/Services/WebDriver/TimeoutsConfiguration.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "WebDriverError.h"
 #include <AK/Forward.h>
 #include <AK/Optional.h>
 
@@ -19,6 +20,6 @@ struct TimeoutsConfiguration {
 };
 
 JsonObject timeouts_object(TimeoutsConfiguration const&);
-ErrorOr<TimeoutsConfiguration, HttpError> json_deserialize_as_a_timeouts_configuration(JsonValue const&);
+ErrorOr<TimeoutsConfiguration, WebDriverError> json_deserialize_as_a_timeouts_configuration(JsonValue const&);
 
 }

--- a/Userland/Services/WebDriver/WebDriverError.cpp
+++ b/Userland/Services/WebDriver/WebDriverError.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "WebDriverError.h"
+#include <AK/Vector.h>
+
+namespace WebDriver {
+
+struct ErrorCodeData {
+    ErrorCode error_code;
+    unsigned http_status;
+    String json_error_code;
+};
+
+// https://w3c.github.io/webdriver/#dfn-error-code
+static Vector<ErrorCodeData> const s_error_code_data = {
+    { ErrorCode::ElementClickIntercepted, 400, "element click intercepted" },
+    { ErrorCode::ElementNotInteractable, 400, "element not interactable" },
+    { ErrorCode::InsecureCertificate, 400, "insecure certificate" },
+    { ErrorCode::InvalidArgument, 400, "invalid argument" },
+    { ErrorCode::InvalidCookieDomain, 400, "invalid cookie domain" },
+    { ErrorCode::InvalidElementState, 400, "invalid element state" },
+    { ErrorCode::InvalidSelector, 400, "invalid selector" },
+    { ErrorCode::InvalidSessionId, 404, "invalid session id" },
+    { ErrorCode::JavascriptError, 500, "javascript error" },
+    { ErrorCode::MoveTargetOutOfBounds, 500, "move target out of bounds" },
+    { ErrorCode::NoSuchAlert, 404, "no such alert" },
+    { ErrorCode::NoSuchCookie, 404, "no such cookie" },
+    { ErrorCode::NoSuchElement, 404, "no such element" },
+    { ErrorCode::NoSuchFrame, 404, "no such frame" },
+    { ErrorCode::NoSuchWindow, 404, "no such window" },
+    { ErrorCode::NoSuchShadowRoot, 404, "no such shadow root" },
+    { ErrorCode::ScriptTimeoutError, 500, "script timeout" },
+    { ErrorCode::SessionNotCreated, 500, "session not created" },
+    { ErrorCode::StaleElementReference, 404, "stale element reference" },
+    { ErrorCode::DetachedShadowRoot, 404, "detached shadow root" },
+    { ErrorCode::Timeout, 500, "timeout" },
+    { ErrorCode::UnableToSetCookie, 500, "unable to set cookie" },
+    { ErrorCode::UnableToCaptureScreen, 500, "unable to capture screen" },
+    { ErrorCode::UnexpectedAlertOpen, 500, "unexpected alert open" },
+    { ErrorCode::UnknownCommand, 404, "unknown command" },
+    { ErrorCode::UnknownError, 500, "unknown error" },
+    { ErrorCode::UnknownMethod, 405, "unknown method" },
+    { ErrorCode::UnsupportedOperation, 500, "unsupported operation" },
+};
+
+WebDriverError WebDriverError::from_code(ErrorCode code, String message)
+{
+    auto& data = s_error_code_data[to_underlying(code)];
+    return {
+        .http_status = data.http_status,
+        .error = data.json_error_code,
+        .message = move(message)
+    };
+}
+
+}

--- a/Userland/Services/WebDriver/WebDriverError.h
+++ b/Userland/Services/WebDriver/WebDriverError.h
@@ -11,7 +11,7 @@
 
 namespace WebDriver {
 
-struct HttpError {
+struct WebDriverError {
     unsigned http_status;
     String error;
     String message;
@@ -20,8 +20,8 @@ struct HttpError {
 }
 
 template<>
-struct AK::Formatter<WebDriver::HttpError> : Formatter<StringView> {
-    ErrorOr<void> format(FormatBuilder& builder, WebDriver::HttpError const& error)
+struct AK::Formatter<WebDriver::WebDriverError> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, WebDriver::WebDriverError const& error)
     {
         return Formatter<StringView>::format(builder, String::formatted("Error {}, {}: {}", error.http_status, error.error, error.message));
     }

--- a/Userland/Services/WebDriver/WebDriverError.h
+++ b/Userland/Services/WebDriver/WebDriverError.h
@@ -11,10 +11,45 @@
 
 namespace WebDriver {
 
+// https://w3c.github.io/webdriver/#dfn-error-code
+enum class ErrorCode {
+    ElementClickIntercepted,
+    ElementNotInteractable,
+    InsecureCertificate,
+    InvalidArgument,
+    InvalidCookieDomain,
+    InvalidElementState,
+    InvalidSelector,
+    InvalidSessionId,
+    JavascriptError,
+    MoveTargetOutOfBounds,
+    NoSuchAlert,
+    NoSuchCookie,
+    NoSuchElement,
+    NoSuchFrame,
+    NoSuchWindow,
+    NoSuchShadowRoot,
+    ScriptTimeoutError,
+    SessionNotCreated,
+    StaleElementReference,
+    DetachedShadowRoot,
+    Timeout,
+    UnableToSetCookie,
+    UnableToCaptureScreen,
+    UnexpectedAlertOpen,
+    UnknownCommand,
+    UnknownError,
+    UnknownMethod,
+    UnsupportedOperation,
+};
+
+// https://w3c.github.io/webdriver/#errors
 struct WebDriverError {
     unsigned http_status;
     String error;
     String message;
+
+    static WebDriverError from_code(ErrorCode, String message);
 };
 
 }


### PR DESCRIPTION
The main change here is to create errors with an `ErrorCode` enum rather than having to specify the HTTP status and error name every time. `WebDriverError::from_code(ErrorCode::Foo, "Extra info here")` is more verbose than I'd like though.

Also added a helper for the "If the current top-level browsing context is no longer open, return error with error code no such window." spec step which occurs in basically every Session function.