### PR TITLE
Inspector: Reopen picker UI after selecting Inspector

### DIFF
--- a/Userland/DevTools/Inspector/main.cpp
+++ b/Userland/DevTools/Inspector/main.cpp
@@ -66,7 +66,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (pid == getpid()) {
         GUI::MessageBox::show(window, "Cannot inspect Inspector itself!"sv, "Error"sv, GUI::MessageBox::Type::Error);
-        return 1;
+        if (gui_mode)
+            goto choose_pid;
+        else
+            return 1;
     }
 
     RemoteProcess remote_process(pid);


### PR DESCRIPTION
In my opinion, opening the picker UI again after showing the error message is a better user experience.