### PR TITLE
LibWeb: Don't get impl in document_tree_child_browsing_context_count

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1040,10 +1040,8 @@ JS_DEFINE_NATIVE_FUNCTION(Window::btoa)
 // https://html.spec.whatwg.org/multipage/window-object.html#number-of-document-tree-child-browsing-contexts
 JS::ThrowCompletionOr<size_t> Window::document_tree_child_browsing_context_count() const
 {
-    auto* impl = TRY(impl_from(vm()));
-
     // 1. If W's browsing context is null, then return 0.
-    auto* this_browsing_context = impl->associated_document().browsing_context();
+    auto* this_browsing_context = associated_document().browsing_context();
     if (!this_browsing_context)
         return 0;
 


### PR DESCRIPTION
This caused `Object.getOwnPropertyNames(window)` to throw, as the `this` value is `Object`.

All users of document_tree_child_browsing_context_count call it on an existing Window impl, including WP::internal_own_property_keys, so getting the impl from the JS VM is not necessary.