### PR TITLE
Browser: Add ability to delete cookies from Storage Inspector

### DIFF
--- a/Userland/Applications/Browser/CookiesModel.cpp
+++ b/Userland/Applications/Browser/CookiesModel.cpp
@@ -97,4 +97,10 @@ TriState CookiesModel::data_matches(GUI::ModelIndex const& index, GUI::Variant c
     return TriState::False;
 }
 
+Web::Cookie::Cookie const& CookiesModel::get_cookie(GUI::ModelIndex const& index) const
+{
+    VERIFY(index.is_valid());
+    return m_cookies[index.row()];
+}
+
 }

--- a/Userland/Applications/Browser/CookiesModel.h
+++ b/Userland/Applications/Browser/CookiesModel.h
@@ -34,6 +34,8 @@ public:
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role = GUI::ModelRole::Display) const override;
     virtual TriState data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const override;
 
+    Web::Cookie::Cookie const& get_cookie(GUI::ModelIndex const&) const;
+
 private:
     AK::Vector<Web::Cookie::Cookie> m_cookies;
 };

--- a/Userland/Applications/Browser/StorageWidget.cpp
+++ b/Userland/Applications/Browser/StorageWidget.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,8 +8,8 @@
 #include "StorageWidget.h"
 #include "CookiesModel.h"
 #include "StorageModel.h"
-#include <AK/Variant.h>
 #include <Applications/Browser/StorageWidgetGML.h>
+#include <LibGUI/Menu.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGUI/TableView.h>
 #include <LibWeb/Cookie/Cookie.h>
@@ -36,6 +37,32 @@ StorageWidget::StorageWidget()
     m_cookies_table_view->set_model(m_cookies_filtering_model);
     m_cookies_table_view->set_column_headers_visible(true);
     m_cookies_table_view->set_alternating_row_colors(true);
+
+    auto delete_cookie_action = GUI::Action::create(
+        "&Delete Cookie", { Key_Delete }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/delete.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto const&) {
+            auto cookie_index = m_cookies_table_view->selection().first();
+            delete_cookie(m_cookies_model->get_cookie(cookie_index));
+        },
+        m_cookies_table_view);
+
+    auto delete_all_cookies_action = GUI::Action::create(
+        "Delete &All Cookies", [&](auto const&) {
+            auto cookie_count = m_cookies_model->row_count({});
+            for (auto i = 0; i < cookie_count; ++i) {
+                auto cookie_index = m_cookies_model->index(i);
+                if (cookie_index.is_valid())
+                    delete_cookie(m_cookies_model->get_cookie(cookie_index));
+            }
+        },
+        m_cookies_table_view);
+
+    m_cookies_context_menu = GUI::Menu::construct();
+    m_cookies_context_menu->add_action(delete_cookie_action);
+    m_cookies_context_menu->add_action(delete_all_cookies_action);
+    m_cookies_table_view->on_context_menu_request = [&](auto& index, auto& event) {
+        if (index.is_valid())
+            m_cookies_context_menu->popup(event.screen_position());
+    };
 
     m_local_storage_table_view = tab_widget.find_descendant_of_type_named<GUI::TableView>("local_storage_tableview");
     m_local_storage_textbox = tab_widget.find_descendant_of_type_named<GUI::TextBox>("local_storage_filter_textbox");
@@ -100,6 +127,14 @@ void StorageWidget::set_session_storage_entries(OrderedHashMap<String, String> e
 void StorageWidget::clear_session_storage_entries()
 {
     m_session_storage_model->clear_items();
+}
+
+void StorageWidget::delete_cookie(Web::Cookie::Cookie cookie)
+{
+    // Delete cookie by making its expiry time in the past.
+    cookie.expiry_time = Core::DateTime::from_timestamp(0);
+    if (on_update_cookie)
+        on_update_cookie(move(cookie));
 }
 
 }

--- a/Userland/Applications/Browser/StorageWidget.h
+++ b/Userland/Applications/Browser/StorageWidget.h
@@ -24,6 +24,8 @@ public:
     void set_cookies_entries(Vector<Web::Cookie::Cookie> entries);
     void clear_cookies();
 
+    Function<void(Web::Cookie::Cookie)> on_update_cookie;
+
     void set_local_storage_entries(OrderedHashMap<String, String> entries);
     void clear_local_storage_entries();
 
@@ -33,10 +35,13 @@ public:
 private:
     StorageWidget();
 
+    void delete_cookie(Web::Cookie::Cookie);
+
     RefPtr<GUI::TableView> m_cookies_table_view;
     RefPtr<GUI::TextBox> m_cookies_textbox;
     RefPtr<CookiesModel> m_cookies_model;
     RefPtr<GUI::FilteringProxyModel> m_cookies_filtering_model;
+    RefPtr<GUI::Menu> m_cookies_context_menu;
 
     RefPtr<GUI::TableView> m_local_storage_table_view;
     RefPtr<GUI::TextBox> m_local_storage_textbox;

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -614,6 +614,10 @@ void Tab::show_storage_inspector()
         storage_window->set_title("Storage inspector");
         storage_window->set_icon(g_icon_bag.cookie);
         m_storage_widget = storage_window->set_main_widget<StorageWidget>();
+        m_storage_widget->on_update_cookie = [this](Web::Cookie::Cookie cookie) {
+            if (on_update_cookie)
+                on_update_cookie(url(), move(cookie));
+        };
     }
 
     if (on_get_cookies_entries) {


### PR DESCRIPTION
Adds actions to delete either a single cookie, or all of them.

This looks weird, because the GUI doesn't update until you "Inspect > Open Storage Inspector", but it does function. :^)

(I'm piggy-backing off Tobias's WebDriver work here.)