### PR TITLE
Toolchain: fix nix-shell; fuse2fs is now part of e2fsprogs

### DIFF
--- a/Toolchain/serenity.nix
+++ b/Toolchain/serenity.nix
@@ -26,8 +26,6 @@ stdenv.mkDerivation {
     xlibsWrapper
     qemu
     e2fsprogs
-    fuse2fs
-    # glibc
   ];
 
   hardeningDisable = [ "format" "fortify" ];


### PR DESCRIPTION
the e2fsprogs derivation in supported nixpkgs includes fuse2fs, so running nix-shell fails here as there is no fuse2fs derivation.