### PR TITLE
Add build directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.autosave
 Meta/Lagom/build
 Build
+build
 Toolchain/Tarballs
 Toolchain/Build
 Toolchain/Local


### PR DESCRIPTION
This directory has some cmake cache in it, and is already in the .gitignore of ladybird