### PR TITLE
LibWeb+Browser+Base: Parse SameSite cookie attribute

### DIFF
--- a/Base/res/html/misc/cookie.html
+++ b/Base/res/html/misc/cookie.html
@@ -3,6 +3,9 @@
     <br /><input type=button onclick="setCookie(this.value)" value="cookie1=value1; max-age=5; path=/res/html" />
     <br /><input type=button onclick="setCookie(this.value)" value="cookie2=value2; expires=Sat, 23 Jan 2060 08:10:36 GMT" />
     <br /><input type=button onclick="setCookie(this.value)" value="cookie3=value3" />
+    <br /><input type=button onclick="setCookie(this.value)" value="cookie4=value4;SameSite=Lax" />
+    <br /><input type=button onclick="setCookie(this.value)" value="cookie5=value5;SameSite=Strict" />
+    <br /><input type=button onclick="setCookie(this.value)" value="cookie6=value6;SameSite=None" />
     <br />
 
     <h3>Invalid cookies (the browser should reject these):</h3>

--- a/Userland/Applications/Browser/CookieJar.cpp
+++ b/Userland/Applications/Browser/CookieJar.cpp
@@ -99,6 +99,7 @@ void CookieJar::dump_cookies() const
         builder.appendff("\t{}HttpOnly{} = {:s}\n", attribute_color, no_color, cookie.value.http_only);
         builder.appendff("\t{}HostOnly{} = {:s}\n", attribute_color, no_color, cookie.value.host_only);
         builder.appendff("\t{}Persistent{} = {:s}\n", attribute_color, no_color, cookie.value.persistent);
+        builder.appendff("\t{}SameSite{} = {:s}\n", attribute_color, no_color, Web::Cookie::same_site_to_string(cookie.value.same_site));
     }
 
     dbgln("{}", builder.build());
@@ -199,7 +200,7 @@ void CookieJar::store_cookie(Web::Cookie::ParsedCookie const& parsed_cookie, con
     // https://tools.ietf.org/html/rfc6265#section-5.3
 
     // 2. Create a new cookie with name cookie-name, value cookie-value. Set the creation-time and the last-access-time to the current date and time.
-    Web::Cookie::Cookie cookie { parsed_cookie.name, parsed_cookie.value };
+    Web::Cookie::Cookie cookie { parsed_cookie.name, parsed_cookie.value, parsed_cookie.same_site_attribute };
     cookie.creation_time = Core::DateTime::now();
     cookie.last_access_time = cookie.creation_time;
 

--- a/Userland/Applications/Browser/CookiesModel.cpp
+++ b/Userland/Applications/Browser/CookiesModel.cpp
@@ -47,6 +47,8 @@ String CookiesModel::column_name(int column) const
         return "Value";
     case Column::ExpiryTime:
         return "Expiry time";
+    case Column::SameSite:
+        return "SameSite";
     case Column::__Count:
         return {};
     }
@@ -79,6 +81,8 @@ GUI::Variant CookiesModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
         return cookie.value;
     case Column::ExpiryTime:
         return cookie.expiry_time.to_string();
+    case Column::SameSite:
+        return Web::Cookie::same_site_to_string(cookie.same_site);
     }
 
     VERIFY_NOT_REACHED();

--- a/Userland/Applications/Browser/CookiesModel.h
+++ b/Userland/Applications/Browser/CookiesModel.h
@@ -22,6 +22,7 @@ public:
         Name,
         Value,
         ExpiryTime,
+        SameSite,
         __Count,
     };
 

--- a/Userland/Libraries/LibWeb/Cookie/Cookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/Cookie.cpp
@@ -8,6 +8,25 @@
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 
+namespace Web::Cookie {
+
+StringView same_site_to_string(SameSite same_site)
+{
+    switch (same_site) {
+    case SameSite::Default:
+        return "Default"sv;
+    case SameSite::None:
+        return "None"sv;
+    case SameSite::Lax:
+        return "Lax"sv;
+    case SameSite::Strict:
+        return "Strict"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+}
+
 bool IPC::encode(Encoder& encoder, Web::Cookie::Cookie const& cookie)
 {
     encoder << cookie.name;
@@ -21,6 +40,7 @@ bool IPC::encode(Encoder& encoder, Web::Cookie::Cookie const& cookie)
     encoder << cookie.last_access_time;
     encoder << cookie.persistent;
     encoder << cookie.secure;
+    encoder << cookie.same_site;
 
     return true;
 }
@@ -38,5 +58,6 @@ ErrorOr<void> IPC::decode(Decoder& decoder, Web::Cookie::Cookie& cookie)
     TRY(decoder.decode(cookie.last_access_time));
     TRY(decoder.decode(cookie.persistent));
     TRY(decoder.decode(cookie.secure));
+    TRY(decoder.decode(cookie.same_site));
     return {};
 }

--- a/Userland/Libraries/LibWeb/Cookie/Cookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/Cookie.h
@@ -12,6 +12,13 @@
 
 namespace Web::Cookie {
 
+enum class SameSite {
+    Default,
+    None,
+    Strict,
+    Lax
+};
+
 enum class Source {
     NonHttp,
     Http,
@@ -20,6 +27,7 @@ enum class Source {
 struct Cookie {
     String name;
     String value;
+    SameSite same_site;
     Core::DateTime creation_time {};
     Core::DateTime last_access_time {};
     Core::DateTime expiry_time {};
@@ -30,6 +38,8 @@ struct Cookie {
     bool host_only { false };
     bool persistent { false };
 };
+
+StringView same_site_to_string(SameSite same_site_mode);
 
 }
 

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -25,6 +25,7 @@ static void on_domain_attribute(ParsedCookie& parsed_cookie, StringView attribut
 static void on_path_attribute(ParsedCookie& parsed_cookie, StringView attribute_value);
 static void on_secure_attribute(ParsedCookie& parsed_cookie);
 static void on_http_only_attribute(ParsedCookie& parsed_cookie);
+static void on_same_site_attribute(ParsedCookie& parsed_cookie, StringView attribute_value);
 static Optional<Core::DateTime> parse_date_time(StringView date_string);
 
 Optional<ParsedCookie> parse_cookie(String const& cookie_string)
@@ -143,6 +144,8 @@ void process_attribute(ParsedCookie& parsed_cookie, StringView attribute_name, S
         on_secure_attribute(parsed_cookie);
     } else if (attribute_name.equals_ignoring_case("HttpOnly"sv)) {
         on_http_only_attribute(parsed_cookie);
+    } else if (attribute_name.equals_ignoring_case("SameSite"sv)) {
+        on_same_site_attribute(parsed_cookie, attribute_value);
     }
 }
 
@@ -220,6 +223,23 @@ void on_http_only_attribute(ParsedCookie& parsed_cookie)
 {
     // https://tools.ietf.org/html/rfc6265#section-5.2.6
     parsed_cookie.http_only_attribute_present = true;
+}
+
+// https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-the-samesite-attribute-2
+void on_same_site_attribute(ParsedCookie& parsed_cookie, StringView attribute_value)
+{
+    // 1. Let enforcement be "Default"
+    // Note: Set as default value in ParsedCookie.h
+
+    // 2. If cookie-av's attribute-value is a case-insensitive match for "None", set enforcement to "None".
+    if (attribute_value.equals_ignoring_case("None"sv))
+        parsed_cookie.same_site_attribute = SameSite::None;
+    // 3. If cookie-av's attribute-value is a case-insensitive match for "Strict", set enforcement to "Strict".
+    else if (attribute_value.equals_ignoring_case("Strict"sv))
+        parsed_cookie.same_site_attribute = SameSite::Strict;
+    // 4. If cookie-av's attribute-value is a case-insensitive match for "Lax", set enforcement to "Lax".
+    else if (attribute_value.equals_ignoring_case("Lax"sv))
+        parsed_cookie.same_site_attribute = SameSite::Lax;
 }
 
 Optional<Core::DateTime> parse_date_time(StringView date_string)
@@ -343,6 +363,7 @@ bool IPC::encode(Encoder& encoder, Web::Cookie::ParsedCookie const& cookie)
     encoder << cookie.path;
     encoder << cookie.secure_attribute_present;
     encoder << cookie.http_only_attribute_present;
+    encoder << cookie.same_site_attribute;
 
     return true;
 }
@@ -357,5 +378,6 @@ ErrorOr<void> IPC::decode(Decoder& decoder, Web::Cookie::ParsedCookie& cookie)
     TRY(decoder.decode(cookie.path));
     TRY(decoder.decode(cookie.secure_attribute_present));
     TRY(decoder.decode(cookie.http_only_attribute_present));
+    TRY(decoder.decode(cookie.same_site_attribute));
     return {};
 }

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
@@ -10,12 +10,14 @@
 #include <AK/String.h>
 #include <LibCore/DateTime.h>
 #include <LibIPC/Forward.h>
+#include <LibWeb/Cookie/Cookie.h>
 
 namespace Web::Cookie {
 
 struct ParsedCookie {
     String name;
     String value;
+    SameSite same_site_attribute { SameSite::Default };
     Optional<Core::DateTime> expiry_time_from_expires_attribute {};
     Optional<Core::DateTime> expiry_time_from_max_age_attribute {};
     Optional<String> domain {};


### PR DESCRIPTION
This is my first contribution to the SerenityOS. I am not really a c++ dev, so I probably made lots of mistakes, sorry about that.
But I am eager to learn more of c++ and improve while contributing to this repo which I follow for longer time.
For first contribution I took parsing of the `SameSite` cookie attribute.
Taken from the https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-the-samesite-attribute-2.
It is also now shown in the cookie inspector.
![SameSite](https://user-images.githubusercontent.com/31451544/197183198-58fa3560-8ae1-4bf1-9fa6-c3b83e2b4432.png)

For future this attribute should be considered for http requests to decide whether to send third party cookies or not as headers, but is not included in this PR.
