### PR TITLE
Magnifier: Add Always on Top

### DIFF
--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -107,6 +107,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             magnifier->pause_capture(action.is_checked());
         });
 
+    auto always_on_top_action = GUI::Action::create_checkable(
+        "&Always on Top", [&](auto& action) {
+            window->set_always_on_top(action.is_checked());
+        });
+
     size_action_group->add_action(two_x_action);
     size_action_group->add_action(four_x_action);
     size_action_group->add_action(eight_x_action);
@@ -119,7 +124,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     two_x_action->set_checked(true);
 
     TRY(view_menu->try_add_separator());
+    TRY(view_menu->try_add_action(always_on_top_action));
     TRY(view_menu->try_add_action(pause_action));
+    always_on_top_action->set_checked(true);
 
     auto timeline_menu = TRY(window->try_add_menu("&Timeline"));
     auto previous_frame_action = GUI::Action::create(

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -48,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-magnifier"sv);
 
     // 4px on each side for padding
-    constexpr int window_dimensions = 200 + 4 + 4;
+    constexpr int window_dimensions = 240 + 4 + 4;
     auto window = GUI::Window::construct();
     window->set_title("Magnifier");
     window->resize(window_dimensions, window_dimensions);


### PR DESCRIPTION
This PR makes Magnifier start as always on top and adds a menu item in View to toggle this. 
It also increases the size of the window as I had noticed that the Help menu was not visible on the old size.