### PR TITLE
SystemServer: Fix race condition in Service::determine_account()

### DIFF
--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -419,10 +419,7 @@ ErrorOr<void> Service::determine_account(int fd)
     socklen_t creds_size = sizeof(creds);
     TRY(Core::System::getsockopt(fd, SOL_SOCKET, SO_PEERCRED, &creds, &creds_size));
 
-    auto const directory_name = String::formatted("/proc/{}/", creds.pid);
-    auto const stat = TRY(Core::System::stat(directory_name));
-
-    m_account = TRY(Core::Account::from_uid(stat.st_uid, Core::Account::Read::PasswdOnly));
+    m_account = TRY(Core::Account::from_uid(creds.uid, Core::Account::Read::PasswdOnly));
     return {};
 }
 


### PR DESCRIPTION
In theory our peer process could die between the call to getsockopt() and Core::system::stat() and another process could end up with the same PID which would result in us incorrectly launching the service as another user (e.g. root).