### PR TITLE
LibJS: Add a LoadElimination pass to bytecode

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -109,6 +109,7 @@ public:
     String to_string(Bytecode::Executable const&) const;
     ThrowCompletionOr<void> execute(Bytecode::Interpreter&) const;
     void replace_references(BasicBlock const&, BasicBlock const&);
+    void replace_references(Register, Register);
     static void destroy(Instruction&);
 
 protected:

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -232,6 +232,7 @@ Bytecode::PassManager& Interpreter::optimization_pipeline(Interpreter::Optimizat
         pm->add<Passes::MergeBlocks>();
         pm->add<Passes::GenerateCFG>();
         pm->add<Passes::PlaceBlocks>();
+        pm->add<Passes::EliminateLoads>();
     } else {
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -751,6 +751,26 @@ void FinishUnwind::replace_references_impl(BasicBlock const& from, BasicBlock co
         m_next_target = Label { to };
 }
 
+void CopyObjectExcludingProperties::replace_references_impl(Register from, Register to)
+{
+    if (m_from_object == from)
+        m_from_object = to;
+
+    for (size_t i = 0; i < m_excluded_names_count; ++i) {
+        if (m_excluded_names[i] == from)
+            m_excluded_names[i] = to;
+    }
+}
+
+void Call::replace_references_impl(Register from, Register to)
+{
+    if (m_callee == from)
+        m_callee = to;
+
+    if (m_this_value == from)
+        m_this_value = to;
+}
+
 ThrowCompletionOr<void> LeaveEnvironment::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     if (m_mode == EnvironmentMode::Lexical)

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -74,6 +74,8 @@ public:
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
     void replace_references_impl(Register, Register) { }
 
+    Register dst() const { return m_dst; }
+
 private:
     Register m_dst;
 };
@@ -271,6 +273,20 @@ public:
         return sizeof(*this) + sizeof(Register) * (m_element_count == 0 ? 0 : 2);
     }
 
+    Register start() const
+    {
+        VERIFY(m_element_count);
+        return m_elements[0];
+    }
+
+    Register end() const
+    {
+        VERIFY(m_element_count);
+        return m_elements[1];
+    }
+
+    size_t element_count() const { return m_element_count; }
+
 private:
     size_t m_element_count { 0 };
     Register m_elements[];
@@ -406,6 +422,8 @@ public:
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
     void replace_references_impl(Register, Register) { }
 
+    IdentifierTableIndex identifier() const { return m_identifier; }
+
 private:
     IdentifierTableIndex m_identifier;
     EnvironmentMode m_mode;
@@ -425,6 +443,8 @@ public:
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
     void replace_references_impl(Register, Register) { }
 
+    IdentifierTableIndex identifier() const { return m_identifier; }
+
 private:
     IdentifierTableIndex m_identifier;
 
@@ -443,6 +463,8 @@ public:
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
     void replace_references_impl(Register, Register) { }
+
+    IdentifierTableIndex identifier() const { return m_identifier; }
 
 private:
     IdentifierTableIndex m_identifier;

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -34,6 +34,11 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register from, Register to)
+    {
+        if (m_src == from)
+            m_src = to;
+    }
 
 private:
     Register m_src;
@@ -50,6 +55,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     Value m_value;
@@ -66,6 +72,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     Register m_dst;
@@ -107,6 +114,11 @@ private:
         ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;    \
         String to_string_impl(Bytecode::Executable const&) const;              \
         void replace_references_impl(BasicBlock const&, BasicBlock const&) { } \
+        void replace_references_impl(Register from, Register to)               \
+        {                                                                      \
+            if (m_lhs_reg == from)                                             \
+                m_lhs_reg = to;                                                \
+        }                                                                      \
                                                                                \
     private:                                                                   \
         Register m_lhs_reg;                                                    \
@@ -133,6 +145,7 @@ JS_ENUMERATE_COMMON_BINARY_OPS(JS_DECLARE_COMMON_BINARY_OP)
         ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;    \
         String to_string_impl(Bytecode::Executable const&) const;              \
         void replace_references_impl(BasicBlock const&, BasicBlock const&) { } \
+        void replace_references_impl(Register, Register) { }                   \
     };
 
 JS_ENUMERATE_COMMON_UNARY_OPS(JS_DECLARE_COMMON_UNARY_OP)
@@ -149,6 +162,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     StringTableIndex m_string;
@@ -164,6 +178,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class NewRegExp final : public Instruction {
@@ -178,6 +193,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     StringTableIndex m_source_index;
@@ -199,6 +215,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register from, Register to);
 
     size_t length_impl() const { return sizeof(*this) + sizeof(Register) * m_excluded_names_count; }
 
@@ -219,6 +236,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     Crypto::SignedBigInteger m_bigint;
@@ -244,6 +262,9 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    // Note: The underlying element range shall never be changed item, by item
+    //       shifting it may be done in the future
+    void replace_references_impl(Register from, Register) { VERIFY(!m_element_count || from.index() < start().index() || from.index() > end().index()); }
 
     size_t length_impl() const
     {
@@ -268,6 +289,9 @@ public:
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
 
+    // Note: This should never do anything, the lhs should always be an array, that is currently being constructed
+    void replace_references_impl(Register from, Register) { VERIFY(from != m_lhs); }
+
 private:
     Register m_lhs;
     bool m_is_spread = false;
@@ -283,6 +307,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class ConcatString final : public Instruction {
@@ -296,6 +321,8 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    // Note: lhs should always be a string in construction, so this should never do anything
+    void replace_references_impl(Register from, Register) { VERIFY(from != m_lhs); }
 
 private:
     Register m_lhs;
@@ -317,6 +344,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     EnvironmentMode m_mode { EnvironmentMode::Lexical };
@@ -332,6 +360,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class CreateVariable final : public Instruction {
@@ -348,6 +377,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     IdentifierTableIndex m_identifier;
@@ -374,6 +404,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     IdentifierTableIndex m_identifier;
@@ -392,6 +423,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     IdentifierTableIndex m_identifier;
@@ -410,6 +442,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     IdentifierTableIndex m_identifier;
@@ -426,6 +459,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     IdentifierTableIndex m_property;
@@ -452,6 +486,11 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register from, Register to)
+    {
+        if (m_base == from)
+            m_base = to;
+    }
 
 private:
     Register m_base;
@@ -470,6 +509,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     IdentifierTableIndex m_property;
@@ -486,6 +526,11 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register from, Register to)
+    {
+        if (m_base == from)
+            m_base = to;
+    }
 
 private:
     Register m_base;
@@ -504,6 +549,11 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register from, Register to)
+    {
+        if (m_base == from)
+            m_base = to;
+    }
 
 private:
     Register m_base;
@@ -522,6 +572,11 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register from, Register to)
+    {
+        if (m_base == from)
+            m_base = to;
+    }
 
 private:
     Register m_base;
@@ -554,6 +609,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&);
+    void replace_references_impl(Register, Register) { }
 
     auto& true_target() const { return m_true_target; }
     auto& false_target() const { return m_false_target; }
@@ -616,6 +672,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register);
 
     Completion throw_type_error_for_callee(Bytecode::Interpreter&, StringView callee_type) const;
 
@@ -638,6 +695,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     bool m_is_synthetic;
@@ -654,6 +712,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     ClassExpression const& m_class_expression;
@@ -670,6 +729,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     FunctionNode const& m_function_node;
@@ -687,6 +747,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class Increment final : public Instruction {
@@ -699,6 +760,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class Decrement final : public Instruction {
@@ -711,6 +773,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class Throw final : public Instruction {
@@ -725,6 +788,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class EnterUnwindContext final : public Instruction {
@@ -742,6 +806,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&);
+    void replace_references_impl(Register, Register) { }
 
     auto& entry_point() const { return m_entry_point; }
     auto& handler_target() const { return m_handler_target; }
@@ -764,6 +829,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     EnvironmentMode m_mode { EnvironmentMode::Lexical };
@@ -779,6 +845,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class FinishUnwind final : public Instruction {
@@ -792,6 +859,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&);
+    void replace_references_impl(Register, Register) { }
 
 private:
     Label m_next_target;
@@ -810,6 +878,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&);
+    void replace_references_impl(Register, Register) { }
 
     auto& resume_target() const { return m_resume_target; }
 
@@ -835,6 +904,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&);
+    void replace_references_impl(Register, Register) { }
 
     auto& continuation() const { return m_continuation_label; }
 
@@ -853,6 +923,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     HashMap<u32, Variable> m_variables;
@@ -868,6 +939,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class GetObjectPropertyIterator final : public Instruction {
@@ -880,6 +952,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class IteratorNext final : public Instruction {
@@ -892,6 +965,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class IteratorResultDone final : public Instruction {
@@ -904,6 +978,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class IteratorResultValue final : public Instruction {
@@ -916,6 +991,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class ResolveThisBinding final : public Instruction {
@@ -928,6 +1004,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class GetNewTarget final : public Instruction {
@@ -940,6 +1017,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 };
 
 class TypeofVariable final : public Instruction {
@@ -953,6 +1031,7 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     String to_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
 
 private:
     IdentifierTableIndex m_identifier;
@@ -978,6 +1057,21 @@ ALWAYS_INLINE ThrowCompletionOr<void> Instruction::execute(Bytecode::Interpreter
 }
 
 ALWAYS_INLINE void Instruction::replace_references(BasicBlock const& from, BasicBlock const& to)
+{
+#define __BYTECODE_OP(op)       \
+    case Instruction::Type::op: \
+        return static_cast<Bytecode::Op::op&>(*this).replace_references_impl(from, to);
+
+    switch (type()) {
+        ENUMERATE_BYTECODE_OPS(__BYTECODE_OP)
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+#undef __BYTECODE_OP
+}
+
+ALWAYS_INLINE void Instruction::replace_references(Register from, Register to)
 {
 #define __BYTECODE_OP(op)       \
     case Instruction::Type::op: \

--- a/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2022, Leon Albrecht <leon.a@serenityos.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Bitmap.h>
+#include <AK/TypeCasts.h>
+#include <LibJS/Bytecode/Op.h>
+#include <LibJS/Bytecode/PassManager.h>
+
+namespace JS::Bytecode::Passes {
+
+static NonnullOwnPtr<BasicBlock> eliminate_loads(BasicBlock const& block, size_t number_of_registers)
+{
+    auto array_ranges = Bitmap::must_create(number_of_registers, false);
+
+    for (auto it = InstructionStreamIterator(block.instruction_stream()); !it.at_end(); ++it) {
+        if ((*it).type() == Instruction::Type::NewArray) {
+            Op::NewArray const& array_instruction = static_cast<Op::NewArray const&>(*it);
+            if (size_t element_count = array_instruction.element_count())
+                array_ranges.set_range<true, false>(array_instruction.start().index(), element_count);
+        }
+    }
+
+    auto new_block = BasicBlock::create(block.name(), block.size());
+    HashMap<size_t, Register> identifier_table {};
+    HashMap<u32, Register> register_rerouting_table {};
+
+    for (auto it = InstructionStreamIterator(block.instruction_stream()); !it.at_end();) {
+        using enum Instruction::Type;
+
+        // Note: When creating a variable, we technically purge the cache of any
+        //       variables of the same name;
+        //       In practice, we always generate a coinciding SetVariable, which
+        //       does the same
+        switch ((*it).type()) {
+        case GetVariable: {
+            auto const& get_variable = static_cast<Op::GetVariable const&>(*it);
+            ++it;
+            auto const& next_instruction = *it;
+
+            if (auto reg = identifier_table.find(get_variable.identifier().value()); reg != identifier_table.end()) {
+                // If we have already seen a variable, we can replace its GetVariable with a simple Load
+                // knowing that it was already stored in a register
+                new (new_block->next_slot()) Op::Load(reg->value);
+                new_block->grow(sizeof(Op::Load));
+
+                if (next_instruction.type() == Instruction::Type::Store) {
+                    // If the next instruction is a Store, that is not meant to
+                    // construct an array, we can simply elide that store and reroute
+                    // all further references to the stores destination to the cached
+                    // instance of variable.
+                    // FIXME: We might be able to elide the previous load in the non-array case,
+                    //        because we do not yet reuse the accumulator
+                    auto const& store = static_cast<Op::Store const&>(next_instruction);
+
+                    if (array_ranges.get(store.dst().index())) {
+                        // re-emit the store
+                        new (new_block->next_slot()) Op::Store(store);
+                        new_block->grow(sizeof(Op::Store));
+                    } else {
+                        register_rerouting_table.set(store.dst().index(), reg->value);
+                    }
+
+                    ++it;
+                }
+
+                continue;
+            }
+            // Otherwise we need to emit the GetVariable
+            new (new_block->next_slot()) Op::GetVariable(get_variable);
+            new_block->grow(sizeof(Op::GetVariable));
+
+            // And if the next instruction is a Store, we can cache it's destination
+            if (next_instruction.type() == Instruction::Type::Store) {
+                auto const& store = static_cast<Op::Store const&>(next_instruction);
+                identifier_table.set(get_variable.identifier().value(), store.dst());
+
+                new (new_block->next_slot()) Op::Store(store);
+                new_block->grow(sizeof(Op::Store));
+                ++it;
+            }
+
+            continue;
+        }
+        case SetVariable: {
+            // When a variable is set we need to remove it from the cache, because
+            // we don't have an accurate view on it anymore
+            // FIXME: If the previous instruction was a `Load $reg`, we could
+            //        update the cache instead
+            auto const& set_variable = static_cast<Op::SetVariable const&>(*it);
+
+            identifier_table.remove(set_variable.identifier().value());
+
+            break;
+        }
+        case DeleteVariable: {
+            // When a variable is deleted we need to remove it from the cache, it does not
+            // exist anymore, although a variable of the same name may exist in upper scopes
+            auto const& set_variable = static_cast<Op::DeleteVariable const&>(*it);
+
+            identifier_table.remove(set_variable.identifier().value());
+
+            break;
+        }
+        case Store: {
+            // If we store to a position that we have are rerouting from,
+            // we need to remove it from the routeing table
+            // FIXME: This may be redundant due to us assigning to registers only once
+            auto const& store = static_cast<Op::Store const&>(*it);
+            register_rerouting_table.remove(store.dst().index());
+
+            break;
+        }
+        case DeleteById:
+        case DeleteByValue:
+            // These can trigger proxies, which call into user code
+            // So these are treated like calls
+        case GetByValue:
+        case GetById:
+        case PutByValue:
+        case PutById:
+            // Attribute accesses (`a.o` or `a[o]`) may result in calls to getters or setters
+            // or may trigger proxies
+            // So these are treated like calls
+        case Call:
+            // Calls, especially to local functions and eval, may poison visible and
+            // cached variables, hence we need to clear the lookup cache after emitting them
+            // FIXME: In strict mode and with better identifier metrics, we might be able
+            //        to safe some caching with a more fine-grained identifier table
+            // FIXME: We might be able to save some lookups to objects like `this`
+            //        which should not change their pointer
+            memcpy(new_block->next_slot(), &*it, (*it).length());
+            for (auto route : register_rerouting_table)
+                reinterpret_cast<Instruction*>(new_block->next_slot())->replace_references(Register { route.key }, route.value);
+            new_block->grow((*it).length());
+
+            identifier_table.clear_with_capacity();
+
+            ++it;
+            continue;
+        case NewBigInt:
+            // FIXME: This is the only non trivially copyable Instruction,
+            //        so we need to do some extra work here
+            new (new_block->next_slot()) Op::NewBigInt(static_cast<Op::NewBigInt const&>(*it));
+            new_block->grow(sizeof(Op::NewBigInt));
+            ++it;
+            continue;
+        default:
+            break;
+        }
+
+        memcpy(new_block->next_slot(), &*it, (*it).length());
+        for (auto route : register_rerouting_table) {
+            // rerouting from key to value
+            reinterpret_cast<Instruction*>(new_block->next_slot())->replace_references(Register { route.key }, route.value);
+        }
+        // because we are replacing the current block, we need to replace references
+        // to ourselves here
+        reinterpret_cast<Instruction*>(new_block->next_slot())->replace_references(block, *new_block);
+
+        new_block->grow((*it).length());
+
+        ++it;
+    }
+    return new_block;
+}
+
+void EliminateLoads::perform(PassPipelineExecutable& executable)
+{
+    started();
+
+    // FIXME: If we walk the CFG instead of the block list, we might be able to
+    //        save some work between blocks
+    for (auto it = executable.executable.basic_blocks.begin(); it != executable.executable.basic_blocks.end(); ++it) {
+        auto const& old_block = *it;
+        auto new_block = eliminate_loads(old_block, executable.executable.number_of_registers);
+
+        // We will replace the old block, with a new one, so we need to replace all references,
+        // to the old one with the new one
+        for (auto& block : executable.executable.basic_blocks) {
+            InstructionStreamIterator it { block.instruction_stream() };
+            while (!it.at_end()) {
+                auto& instruction = *it;
+                ++it;
+                const_cast<Instruction&>(instruction).replace_references(old_block, *new_block);
+            }
+        }
+
+        executable.executable.basic_blocks.ptr_at(it.index()) = move(new_block);
+    }
+
+    finished();
+}
+
+}

--- a/Userland/Libraries/LibJS/Bytecode/PassManager.h
+++ b/Userland/Libraries/LibJS/Bytecode/PassManager.h
@@ -136,6 +136,15 @@ private:
     FILE* m_file { nullptr };
 };
 
+class EliminateLoads : public Pass {
+public:
+    EliminateLoads() = default;
+    virtual ~EliminateLoads() override = default;
+
+private:
+    virtual void perform(PassPipelineExecutable&) override;
+};
+
 }
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Register.h
+++ b/Userland/Libraries/LibJS/Bytecode/Register.h
@@ -25,6 +25,8 @@ public:
     {
     }
 
+    bool operator==(Register reg) const { return m_index == reg.index(); }
+
     u32 index() const { return m_index; }
 
 private:

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     Bytecode/Op.cpp
     Bytecode/Pass/DumpCFG.cpp
     Bytecode/Pass/GenerateCFG.cpp
+    Bytecode/Pass/LoadElimination.cpp
     Bytecode/Pass/MergeBlocks.cpp
     Bytecode/Pass/PlaceBlocks.cpp
     Bytecode/Pass/UnifySameBlocks.cpp


### PR DESCRIPTION
I know bytecode optimizations are not sought after, as of yet, but this is still a nice thing to have

~~Also includes a free AK fix~~

Working on this also exposed #15753