### PR TITLE
Userland: Ignore super key press when in KeyboardMapper

### DIFF
--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -111,5 +111,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     window->show();
 
+    window->set_ignore_super_key(true);
+
     return app->exec();
 }

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -1062,6 +1062,15 @@ void Window::update_min_size()
     }
 }
 
+void Window::set_ignore_super_key(bool ignore_super_key)
+{
+    if (m_should_ignore_super_key == ignore_super_key)
+        return;
+    m_should_ignore_super_key = ignore_super_key;
+
+    ConnectionToWindowServer::the().async_set_ignore_super_key(m_window_id, ignore_super_key);
+}
+
 void Window::schedule_relayout()
 {
     if (m_layout_pending || !is_visible())

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -56,6 +56,9 @@ public:
     bool is_resizable() const { return m_resizable; }
     void set_resizable(bool resizable) { m_resizable = resizable; }
 
+    bool should_ignore_super_key() const { return m_should_ignore_super_key; }
+    void set_ignore_super_key(bool ignore_super_key = false);
+
     bool is_obeying_widget_min_size() { return m_obey_widget_min_size; }
     void set_obey_widget_min_size(bool);
 
@@ -318,6 +321,7 @@ private:
     bool m_visible { false };
     bool m_moved_by_client { false };
     bool m_blocks_emoji_input { false };
+    bool m_should_ignore_super_key { false };
 };
 
 }

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -1415,4 +1415,15 @@ void ConnectionFromClient::notify_about_theme_change()
     async_update_system_theme(Gfx::current_system_theme_buffer());
 }
 
+void ConnectionFromClient::set_ignore_super_key(i32 window_id, bool ignore_super_key)
+{
+    auto* window = window_from_id(window_id);
+    if (!window) {
+        did_misbehave("SetIgnoreSuperKey:: Bad window ID");
+        return;
+    }
+
+    window->set_ignore_super_key(ignore_super_key);
+}
+
 }

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -188,6 +188,7 @@ private:
     virtual void remove_window_stealing_for_client(i32, i32) override;
     virtual void remove_window_stealing(i32) override;
     virtual void set_always_on_top(i32, bool) override;
+    virtual void set_ignore_super_key(i32, bool) override;
     virtual Messages::WindowServer::GetColorUnderCursorResponse get_color_under_cursor() override;
 
     Window* window_from_id(i32 window_id);

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -554,6 +554,13 @@ void Window::set_frameless(bool frameless)
     }
 }
 
+void Window::set_ignore_super_key(bool ignore_super_key)
+{
+    if (m_should_ignore_super_key == ignore_super_key)
+        return;
+    m_should_ignore_super_key = ignore_super_key;
+}
+
 void Window::invalidate(bool invalidate_frame, bool re_render_frame)
 {
     m_invalidated = true;

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -317,6 +317,9 @@ public:
 
     bool should_show_menubar() const { return m_should_show_menubar; }
 
+    bool should_ignore_super_key() const { return m_should_ignore_super_key; }
+    void set_ignore_super_key(bool);
+
     Optional<int> progress() const { return m_progress; }
     void set_progress(Optional<int>);
 
@@ -461,6 +464,7 @@ private:
     bool m_should_show_menubar { true };
     WindowStack* m_window_stack { nullptr };
     RefPtr<Animation> m_animation;
+    bool m_should_ignore_super_key { false };
 
 public:
     using List = IntrusiveList<&Window::m_list_node>;

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1585,7 +1585,7 @@ void WindowManager::process_key_event(KeyEvent& event)
         return;
     }
 
-    if (event.type() == Event::KeyDown && event.key() == Key_Super) {
+    if (event.type() == Event::KeyDown && event.key() == Key_Super && !m_current_window_stack->active_window()->should_ignore_super_key()) {
         m_previous_event_was_super_keydown = true;
     } else if (m_previous_event_was_super_keydown) {
         m_previous_event_was_super_keydown = false;

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -187,4 +187,6 @@ endpoint WindowServer
     remove_window_stealing(i32 window_id) => ()
 
     set_always_on_top(i32 window_id, bool always_on_top) => ()
+
+    set_ignore_super_key(i32 window_id, bool ignore_super_key) => ()
 }


### PR DESCRIPTION
Stops KeyboardMapper from opening up the pop up when testing keys. This allows the super key to be pressed and show up without un-focusing KeyboardMapper.

To do so, m_should_ignore_super_key has been added as a window property. This allows any window to call window->set_ignore_super_key(true), and the super key will be ignored.