### PR TITLE
LibWeb: Implement recent changes to module script fetching 

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -317,53 +317,50 @@ JS::VM& main_thread_vm()
             return { "type"sv };
         };
 
-        // 8.1.5.5.3 HostResolveImportedModule(referencingScriptOrModule, moduleRequest), https://html.spec.whatwg.org/multipage/webappapis.html#hostresolveimportedmodule(referencingscriptormodule,-modulerequest)
+        // 8.1.6.5.3 HostResolveImportedModule(referencingScriptOrModule, moduleRequest), https://html.spec.whatwg.org/multipage/webappapis.html#hostresolveimportedmodule(referencingscriptormodule,-modulerequest)
         vm->host_resolve_imported_module = [](JS::ScriptOrModule const& referencing_string_or_module, JS::ModuleRequest const& module_request) -> JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Module>> {
-            // 1. Let settings object be the current settings object.
-            auto* settings_object = &HTML::current_settings_object();
+            // 1. Let moduleMap and referencingScript be null.
+            Optional<HTML::ModuleMap&> module_map;
+            Optional<HTML::Script&> referencing_script;
 
-            // 2. Let base URL be settings object's API base URL.
-            auto base_url = settings_object->api_base_url();
-
-            // 3. If referencingScriptOrModule is not null, then:
+            // 2. If referencingScriptOrModule is not null, then:
             if (!referencing_string_or_module.has<Empty>()) {
-                // 1. Let referencing script be referencingScriptOrModule.[[HostDefined]].
-                auto const& referencing_script = verify_cast<HTML::Script>(referencing_string_or_module.has<JS::NonnullGCPtr<JS::Script>>() ? referencing_string_or_module.get<JS::NonnullGCPtr<JS::Script>>()->host_defined() : referencing_string_or_module.get<JS::NonnullGCPtr<JS::Module>>()->host_defined());
+                // 1. Set referencingScript to referencingScriptOrModule.[[HostDefined]].
+                referencing_script = verify_cast<HTML::Script>(referencing_string_or_module.has<JS::NonnullGCPtr<JS::Script>>() ? *referencing_string_or_module.get<JS::NonnullGCPtr<JS::Script>>()->host_defined() : *referencing_string_or_module.get<JS::NonnullGCPtr<JS::Module>>()->host_defined());
 
-                // 2. Set settings object to referencing script's settings object.
-                settings_object = &referencing_script->settings_object();
+                // 2. Set moduleMap to referencingScript's settings object's module map.
+                module_map = referencing_script->settings_object().module_map();
+            }
+            // 3. Otherwise:
+            else {
+                // 1. Assert: there is a current settings object.
+                // NOTE: This is handled by the HTML::current_settings_object() accessor.
 
-                // 3. Set base URL to referencing script's base URL.
-                base_url = referencing_script->base_url();
-
-                // 4. Assert: base URL is not null, as referencing script is a classic script or a JavaScript module script.
-                VERIFY(base_url.is_valid());
+                // 2. Set moduleMap to the current settings object's module map.
+                module_map = HTML::current_settings_object().module_map();
             }
 
-            // 4. Let moduleMap be settings object's module map.
-            auto& module_map = settings_object->module_map();
+            // 4. Let url be the result of resolving a module specifier given referencingScript and moduleRequest.[[Specifier]].
+            auto url = MUST(HTML::resolve_module_specifier(referencing_script, module_request.module_specifier));
 
-            // 5. Let url be the result of resolving a module specifier given base URL and moduleRequest.[[Specifier]].
-            auto url = HTML::resolve_module_specifier(module_request, base_url);
-
-            // 6. Assert: url is never failure, because resolving a module specifier must have been previously successful
+            // 5. Assert: the previous step never throws an exception, because resolving a module specifier must have been previously successful
             //    with these same two arguments (either while creating the corresponding module script, or in fetch an import() module script graph).
-            VERIFY(url.is_valid());
+            // NOTE: Handled by MUST above.
 
-            // 7. Let moduleType be the result of running the module type from module request steps given moduleRequest.
+            // 6. Let moduleType be the result of running the module type from module request steps given moduleRequest.
             auto module_type = HTML::module_type_from_module_request(module_request);
 
-            // 8. Let resolved module script be moduleMap[(url, moduleType)]. (This entry must exist for us to have gotten to this point.)
-            auto resolved_module = module_map.get(url, module_type).value();
+            // 7. Let resolvedModuleScript be moduleMap[(url, moduleType)]. (This entry must exist for us to have gotten to this point.)
+            auto resolved_module_script = module_map->get(url, module_type).value();
 
-            // 9. Assert: resolved module script is a module script (i.e., is not null or "fetching").
-            VERIFY(resolved_module.type == HTML::ModuleMap::EntryType::ModuleScript);
+            // 8. Assert: resolvedModuleScript is a module script (i.e., is not null or "fetching").
+            VERIFY(resolved_module_script.type == HTML::ModuleMap::EntryType::ModuleScript);
 
-            // 10. Assert: resolved module script's record is not null.
-            VERIFY(resolved_module.module_script->record());
+            // 9. Assert: resolvedModuleScript's record is not null.
+            VERIFY(resolved_module_script.module_script->record());
 
-            // 11. Return resolved module script's record.
-            return JS::NonnullGCPtr(*resolved_module.module_script->record());
+            // 10. Return resolvedModuleScript's record.
+            return JS::NonnullGCPtr(*resolved_module_script.module_script->record());
         };
 
         // NOTE: We push a dummy execution context onto the JS execution context stack,

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -293,6 +293,20 @@ bool EnvironmentSettingsObject::module_type_allowed(AK::String const& module_typ
     return true;
 }
 
+// https://html.spec.whatwg.org/multipage/webappapis.html#disallow-further-import-maps
+void EnvironmentSettingsObject::disallow_further_import_maps()
+{
+    // 1. Let global be settingsObject's global object.
+    auto& global = global_object();
+
+    // 2. If global does not implement Window, then return.
+    if (!is<Window>(global))
+        return;
+
+    // 3. Set global's import maps allowed to false.
+    verify_cast<Window>(global).set_import_maps_allowed(false);
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object
 EnvironmentSettingsObject& incumbent_settings_object()
 {

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -110,6 +110,8 @@ struct EnvironmentSettingsObject
 
     bool module_type_allowed(String const& module_type) const;
 
+    void disallow_further_import_maps();
+
 protected:
     explicit EnvironmentSettingsObject(NonnullOwnPtr<JS::ExecutionContext>);
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
@@ -6,11 +6,12 @@
 
 #pragma once
 
+#include <LibWeb/HTML/Scripting/ImportMap.h>
 #include <LibWeb/HTML/Scripting/ModuleScript.h>
 
 namespace Web::HTML {
 
-using ModuleCallback = Function<void(JavaScriptModuleScript const*)>;
+using ModuleCallback = Function<void(JavaScriptModuleScript*)>;
 
 class DescendantFetchingContext : public RefCounted<DescendantFetchingContext> {
 public:
@@ -25,7 +26,7 @@ public:
     bool failed() const { return m_failed; }
     void set_failed(bool failed) { m_failed = failed; }
 
-    void on_complete(JavaScriptModuleScript const* module_script) { m_on_complete(module_script); };
+    void on_complete(JavaScriptModuleScript* module_script) { m_on_complete(module_script); };
     void set_on_complete(ModuleCallback on_complete) { m_on_complete = move(on_complete); }
 
 private:
@@ -38,14 +39,16 @@ private:
 };
 
 String module_type_from_module_request(JS::ModuleRequest const&);
-AK::URL resolve_module_specifier(JS::ModuleRequest const&, AK::URL const& base_url);
+WebIDL::ExceptionOr<AK::URL> resolve_module_specifier(Optional<Script&> referring_script, String const& specifier);
+WebIDL::ExceptionOr<Optional<AK::URL>> resolve_imports_match(String const& normalized_specifier, Optional<AK::URL> as_url, ModuleSpecifierMap const&);
+Optional<AK::URL> resolve_url_like_module_specifier(String const& specifier, AK::URL const& base_url);
 
-void fetch_internal_module_script_graph(JS::ModuleRequest const& module_request, EnvironmentSettingsObject& fetch_client_settings_object, StringView destination, EnvironmentSettingsObject& module_script_settings_object, HashTable<ModuleLocationTuple> const& visited_set, AK::URL const& referrer, ModuleCallback on_complete);
+void fetch_internal_module_script_graph(JS::ModuleRequest const& module_request, EnvironmentSettingsObject& fetch_client_settings_object, StringView destination, Script& referring_script, HashTable<ModuleLocationTuple> const& visited_set, ModuleCallback on_complete);
 void fetch_external_module_script_graph(AK::URL const&, EnvironmentSettingsObject& settings_object, ModuleCallback on_complete);
 void fetch_inline_module_script_graph(String const& filename, String const& source_text, AK::URL const& base_url, EnvironmentSettingsObject& settings_object, ModuleCallback on_complete);
 
-void fetch_descendants_of_a_module_script(JavaScriptModuleScript const& module_script, EnvironmentSettingsObject& fetch_client_settings_object, StringView destination, HashTable<ModuleLocationTuple> visited_set, ModuleCallback callback);
-void fetch_descendants_of_and_link_a_module_script(JavaScriptModuleScript const& module_script, EnvironmentSettingsObject& fetch_client_settings_object, StringView destination, HashTable<ModuleLocationTuple> const& visited_set, ModuleCallback on_complete);
+void fetch_descendants_of_a_module_script(JavaScriptModuleScript& module_script, EnvironmentSettingsObject& fetch_client_settings_object, StringView destination, HashTable<ModuleLocationTuple> visited_set, ModuleCallback callback);
+void fetch_descendants_of_and_link_a_module_script(JavaScriptModuleScript& module_script, EnvironmentSettingsObject& fetch_client_settings_object, StringView destination, HashTable<ModuleLocationTuple> const& visited_set, ModuleCallback on_complete);
 
 enum class TopLevelModule {
     Yes,

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ImportMap.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ImportMap.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, networkException <networkexception@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+
+namespace Web::HTML {
+
+using ModuleSpecifierMap = HashMap<String, Optional<AK::URL>>;
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#import-map
+class ImportMap {
+public:
+    ImportMap() = default;
+
+    ModuleSpecifierMap const& imports() const { return m_imports; }
+    ModuleSpecifierMap& imports() { return m_imports; }
+
+    HashMap<AK::URL, ModuleSpecifierMap> const& scopes() const { return m_scopes; }
+    HashMap<AK::URL, ModuleSpecifierMap>& scopes() { return m_scopes; }
+
+private:
+    ModuleSpecifierMap m_imports;
+    HashMap<AK::URL, ModuleSpecifierMap> m_scopes;
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -19,6 +19,7 @@
 #include <LibWeb/HTML/AnimationFrameCallbackDriver.h>
 #include <LibWeb/HTML/CrossOrigin/CrossOriginPropertyDescriptorMap.h>
 #include <LibWeb/HTML/GlobalEventHandlers.h>
+#include <LibWeb/HTML/Scripting/ImportMap.h>
 #include <LibWeb/HTML/WindowEventHandlers.h>
 
 namespace Web::HTML {
@@ -54,6 +55,11 @@ public:
     HTML::BrowsingContext* browsing_context();
 
     JS::ThrowCompletionOr<size_t> document_tree_child_browsing_context_count() const;
+
+    ImportMap const& import_map() const { return m_import_map; }
+
+    bool import_maps_allowed() const { return m_import_maps_allowed; }
+    void set_import_maps_allowed(bool import_maps_allowed) { m_import_maps_allowed = import_maps_allowed; }
 
     void alert_impl(String const&);
     bool confirm_impl(String const&);
@@ -151,6 +157,12 @@ private:
 
     IDAllocator m_timer_id_allocator;
     HashMap<int, JS::NonnullGCPtr<Timer>> m_timers;
+
+    // https://html.spec.whatwg.org/multipage/webappapis.html#concept-window-import-map
+    ImportMap m_import_map;
+
+    // https://html.spec.whatwg.org/multipage/webappapis.html#import-maps-allowed
+    bool m_import_maps_allowed { true };
 
     JS::GCPtr<HighResolutionTime::Performance> m_performance;
     JS::GCPtr<Crypto::Crypto> m_crypto;

--- a/Userland/Libraries/LibWeb/Infra/Strings.cpp
+++ b/Userland/Libraries/LibWeb/Infra/Strings.cpp
@@ -1,10 +1,12 @@
 /*
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, networkException <networkexception@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/String.h>
+#include <AK/Utf16View.h>
 #include <AK/Utf8View.h>
 #include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Infra/Strings.h>
@@ -27,6 +29,40 @@ String strip_and_collapse_whitespace(StringView string)
 
     // ...and then remove any leading and trailing ASCII whitespace from that string.
     return builder.string_view().trim(Infra::ASCII_WHITESPACE);
+}
+
+// https://infra.spec.whatwg.org/#code-unit-prefix
+bool is_code_unit_prefix(StringView potential_prefix, StringView input)
+{
+    auto potential_prefix_utf16 = utf8_to_utf16(potential_prefix);
+    auto input_utf16 = utf8_to_utf16(input);
+
+    // 1. Let i be 0.
+    size_t i = 0;
+
+    // 2. While true:
+    while (true) {
+        // 1. If i is greater than or equal to potentialPrefix’s length, then return true.
+        if (i >= potential_prefix.length())
+            return true;
+
+        // 2. If i is greater than or equal to input’s length, then return false.
+        if (i >= input.length())
+            return false;
+
+        // 3. Let potentialPrefixCodeUnit be the ith code unit of potentialPrefix.
+        auto potential_prefix_code_unit = Utf16View(potential_prefix_utf16).code_unit_at(i);
+
+        // 4. Let inputCodeUnit be the ith code unit of input.
+        auto input_code_unit = Utf16View(input_utf16).code_unit_at(i);
+
+        // 5. Return false if potentialPrefixCodeUnit is not inputCodeUnit.
+        if (potential_prefix_code_unit != input_code_unit)
+            return false;
+
+        // 6. Set i to i + 1.
+        ++i;
+    }
 }
 
 }

--- a/Userland/Libraries/LibWeb/Infra/Strings.h
+++ b/Userland/Libraries/LibWeb/Infra/Strings.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, networkException <networkexception@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,5 +12,6 @@
 namespace Web::Infra {
 
 String strip_and_collapse_whitespace(StringView string);
+bool is_code_unit_prefix(StringView potential_prefix, StringView input);
 
 }


### PR DESCRIPTION
This pull request implements all changes to the specification touching the subset of module script fetching we support.

Notably it adds parts of the specification for supporting import maps.

With this we are also able to get rid of a non standard workaround for a (yet to be resolved) spec issue we discovered while initially implementing module scripts :^)

See https://github.com/whatwg/html/pull/8417