### PR TITLE
Kernel/Graphics: Handle correctly unknown ioctls on a DisplayConnector

### DIFF
--- a/Kernel/Graphics/DisplayConnector.h
+++ b/Kernel/Graphics/DisplayConnector.h
@@ -148,7 +148,7 @@ private:
     virtual void will_be_destroyed() override;
     virtual void after_inserting() override;
 
-    bool ioctl_requires_ownership(unsigned request) const;
+    ErrorOr<bool> ioctl_requires_ownership(unsigned request) const;
 
     OwnPtr<Memory::Region> m_framebuffer_region;
     OwnPtr<Memory::Region> m_fake_writes_framebuffer_region;


### PR DESCRIPTION
In such case, we should not assert but instead just return EINVAL.