### PR TITLE
LibWeb: Respect media attribute of style tag

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -24,7 +24,7 @@ class CSSStyleSheet final
     WEB_PLATFORM_OBJECT(CSSStyleSheet, StyleSheet);
 
 public:
-    static CSSStyleSheet* create(JS::Realm&, CSSRuleList& rules, Optional<AK::URL> location);
+    static CSSStyleSheet* create(JS::Realm&, CSSRuleList& rules, MediaList& media, Optional<AK::URL> location);
 
     virtual ~CSSStyleSheet() override = default;
 
@@ -50,7 +50,7 @@ public:
     void set_style_sheet_list(Badge<StyleSheetList>, StyleSheetList*);
 
 private:
-    CSSStyleSheet(JS::Realm&, CSSRuleList&, Optional<AK::URL> location);
+    CSSStyleSheet(JS::Realm&, CSSRuleList&, MediaList&, Optional<AK::URL> location);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/CSS/MediaList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.cpp
@@ -85,6 +85,10 @@ bool MediaList::evaluate(HTML::Window const& window)
 
 bool MediaList::matches() const
 {
+    if (m_media.is_empty()) {
+        return true;
+    }
+
     for (auto& media : m_media) {
         if (media.matches())
             return true;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -21,6 +21,7 @@
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/CSSSupportsRule.h>
+#include <LibWeb/CSS/MediaList.h>
 #include <LibWeb/CSS/Parser/Block.h>
 #include <LibWeb/CSS/Parser/ComponentValue.h>
 #include <LibWeb/CSS/Parser/DeclarationOrAtRule.h>
@@ -127,7 +128,7 @@ CSSStyleSheet* Parser::parse_as_css_stylesheet(Optional<AK::URL> location)
     }
 
     auto* rule_list = CSSRuleList::create(m_context.realm(), rules);
-    return CSSStyleSheet::create(m_context.realm(), *rule_list, move(location));
+    return CSSStyleSheet::create(m_context.realm(), *rule_list, *MediaList::create(m_context.realm(), {}), move(location));
 }
 
 Optional<SelectorList> Parser::parse_as_selector(SelectorParsingMode parsing_mode)
@@ -6649,7 +6650,7 @@ namespace Web {
 CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingContext const& context, StringView css, Optional<AK::URL> location)
 {
     if (css.is_empty())
-        return CSS::CSSStyleSheet::create(context.realm(), *CSS::CSSRuleList::create_empty(context.realm()), location);
+        return CSS::CSSStyleSheet::create(context.realm(), *CSS::CSSRuleList::create_empty(context.realm()), *CSS::MediaList::create(context.realm(), {}), location);
     CSS::Parser::Parser parser(context, css);
     return parser.parse_as_css_stylesheet(location);
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheet.cpp
@@ -11,8 +11,9 @@
 
 namespace Web::CSS {
 
-StyleSheet::StyleSheet(JS::Realm& realm)
+StyleSheet::StyleSheet(JS::Realm& realm, MediaList& media)
     : PlatformObject(realm)
+    , m_media(media)
 {
 }
 
@@ -21,6 +22,7 @@ void StyleSheet::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_owner_node);
     visitor.visit(m_parent_style_sheet);
+    visitor.visit(m_media);
 }
 
 void StyleSheet::set_owner_node(DOM::Element* element)

--- a/Userland/Libraries/LibWeb/CSS/StyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheet.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/CSS/MediaList.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -32,7 +33,16 @@ public:
     void set_title(String title) { m_title = move(title); }
 
     void set_type(String type) { m_type_string = move(type); }
-    void set_media(String media) { m_media_string = move(media); }
+
+    MediaList* media() const
+    {
+        return &m_media;
+    }
+
+    void set_media(String media)
+    {
+        m_media.set_media_text(media);
+    }
 
     bool is_alternate() const { return m_alternate; }
     void set_alternate(bool alternate) { m_alternate = alternate; }
@@ -46,8 +56,10 @@ public:
     void set_parent_css_style_sheet(CSSStyleSheet*);
 
 protected:
-    explicit StyleSheet(JS::Realm&);
+    explicit StyleSheet(JS::Realm&, MediaList& media);
     virtual void visit_edges(Cell::Visitor&) override;
+
+    MediaList& m_media;
 
 private:
     JS::GCPtr<DOM::Element> m_owner_node;
@@ -56,7 +68,6 @@ private:
     String m_location;
     String m_title;
     String m_type_string;
-    String m_media_string;
 
     bool m_disabled { false };
     bool m_alternate { false };

--- a/Userland/Libraries/LibWeb/CSS/StyleSheet.idl
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheet.idl
@@ -12,7 +12,7 @@ interface StyleSheet {
     readonly attribute USVString? href;
     readonly attribute CSSStyleSheet? parentStyleSheet;
     readonly attribute DOMString? title;
-    // [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
+    [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
     attribute boolean disabled;
 
 };


### PR DESCRIPTION
I want to address issue when some websites have additional `<style media="print">` styles that hides part of elements with `display: none` which currently not ignored and always applied.