### PR TITLE
Everywhere: Remove redundant inequality comparison operators

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -102,8 +102,6 @@ public:
         return !__builtin_memcmp(data(), other.data(), size());
     }
 
-    bool operator!=(ByteBuffer const& other) const { return !(*this == other); }
-
     [[nodiscard]] u8& operator[](size_t i)
     {
         VERIFY(i < m_size);

--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -211,12 +211,6 @@ public:
         return (this->real() == a.real()) && (this->imag() == a.imag());
     }
 
-    template<AK::Concepts::Arithmetic U>
-    constexpr bool operator!=(Complex<U> const& a) const
-    {
-        return !(*this == a);
-    }
-
     constexpr Complex<T> operator+()
     {
         return *this;

--- a/AK/DistinctNumeric.h
+++ b/AK/DistinctNumeric.h
@@ -67,10 +67,6 @@ public:
     {
         return this->m_value == other.m_value;
     }
-    constexpr bool operator!=(Self const& other) const
-    {
-        return this->m_value != other.m_value;
-    }
 
     // Only implemented when `Incr` is true:
     constexpr Self& operator++()

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -53,16 +53,12 @@ public:
     bool is_null() const { return !m_impl; }
 
     bool operator==(FlyString const& other) const { return m_impl == other.m_impl; }
-    bool operator!=(FlyString const& other) const { return m_impl != other.m_impl; }
 
     bool operator==(String const&) const;
-    bool operator!=(String const& string) const { return !(*this == string); }
 
     bool operator==(StringView) const;
-    bool operator!=(StringView string) const { return !(*this == string); }
 
     bool operator==(char const*) const;
-    bool operator!=(char const* string) const { return !(*this == string); }
 
     StringImpl const* impl() const { return m_impl; }
     char const* characters() const { return m_impl ? m_impl->characters() : nullptr; }

--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -80,7 +80,6 @@ public:
         T& operator*() { return *m_value; }
         auto operator->() { return m_value; }
         bool operator==(Iterator const& other) const { return other.m_value == m_value; }
-        bool operator!=(Iterator const& other) const { return !(*this == other); }
         Iterator& operator++()
         {
             m_value = IntrusiveList<T, Container, member>::next(m_value);
@@ -108,7 +107,6 @@ public:
         T& operator*() { return *m_value; }
         auto operator->() { return m_value; }
         bool operator==(ReverseIterator const& other) const { return other.m_value == m_value; }
-        bool operator!=(ReverseIterator const& other) const { return !(*this == other); }
         ReverseIterator& operator++()
         {
             m_value = IntrusiveList<T, Container, member>::prev(m_value);
@@ -134,7 +132,6 @@ public:
         T const& operator*() const { return *m_value; }
         auto operator->() const { return m_value; }
         bool operator==(ConstIterator const& other) const { return other.m_value == m_value; }
-        bool operator!=(ConstIterator const& other) const { return !(*this == other); }
         ConstIterator& operator++()
         {
             m_value = IntrusiveList<T, Container, member>::next(m_value);

--- a/AK/JsonPath.h
+++ b/AK/JsonPath.h
@@ -75,10 +75,6 @@ public:
         }
         return false;
     }
-    bool operator!=(JsonPathElement const& other) const
-    {
-        return !(*this == other);
-    }
 
 private:
     Kind m_kind;

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -216,10 +216,8 @@ public:
     }
 
     bool operator==(NonnullRefPtr const& other) const { return m_ptr == other.m_ptr; }
-    bool operator!=(NonnullRefPtr const& other) const { return m_ptr != other.m_ptr; }
 
     bool operator==(NonnullRefPtr& other) { return m_ptr == other.m_ptr; }
-    bool operator!=(NonnullRefPtr& other) { return m_ptr != other.m_ptr; }
 
     // clang-format off
 private:

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -260,29 +260,20 @@ public:
     ALWAYS_INLINE operator bool() { return !is_null(); }
 
     bool operator==(std::nullptr_t) const { return is_null(); }
-    bool operator!=(std::nullptr_t) const { return !is_null(); }
 
     bool operator==(RefPtr const& other) const { return as_ptr() == other.as_ptr(); }
-    bool operator!=(RefPtr const& other) const { return as_ptr() != other.as_ptr(); }
 
     bool operator==(RefPtr& other) { return as_ptr() == other.as_ptr(); }
-    bool operator!=(RefPtr& other) { return as_ptr() != other.as_ptr(); }
 
     template<typename U>
     bool operator==(NonnullRefPtr<U> const& other) const { return as_ptr() == other.m_ptr; }
-    template<typename U>
-    bool operator!=(NonnullRefPtr<U> const& other) const { return as_ptr() != other.m_ptr; }
 
     template<typename U>
     bool operator==(NonnullRefPtr<U>& other) { return as_ptr() == other.m_ptr; }
-    template<typename U>
-    bool operator!=(NonnullRefPtr<U>& other) { return as_ptr() != other.m_ptr; }
 
     bool operator==(T const* other) const { return as_ptr() == other; }
-    bool operator!=(T const* other) const { return as_ptr() != other; }
 
     bool operator==(T* other) { return as_ptr() == other; }
-    bool operator!=(T* other) { return as_ptr() != other; }
 
     ALWAYS_INLINE bool is_null() const { return !m_ptr; }
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -203,13 +203,10 @@ public:
     [[nodiscard]] bool ends_with(char) const;
 
     bool operator==(String const&) const;
-    bool operator!=(String const& other) const { return !(*this == other); }
 
     bool operator==(StringView) const;
-    bool operator!=(StringView other) const { return !(*this == other); }
 
     bool operator==(FlyString const&) const;
-    bool operator!=(FlyString const& other) const { return !(*this == other); }
 
     bool operator<(String const&) const;
     bool operator<(char const*) const;
@@ -222,7 +219,6 @@ public:
     bool operator<=(char const* other) const { return !(*this > other); }
 
     bool operator==(char const* cstring) const;
-    bool operator!=(char const* cstring) const { return !(*this == cstring); }
 
     [[nodiscard]] String isolated_copy() const;
 

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -62,10 +62,6 @@ struct MaskSpan {
     {
         return start == other.start && length == other.length;
     }
-    bool operator!=(MaskSpan const& other) const
-    {
-        return !(*this == other);
-    }
 };
 
 namespace StringUtils {

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -245,11 +245,6 @@ public:
         return m_length == 1 && *m_characters == c;
     }
 
-    constexpr bool operator!=(char const* cstring) const
-    {
-        return !(*this == cstring);
-    }
-
 #ifndef KERNEL
     bool operator==(String const&) const;
 #endif

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -223,7 +223,6 @@ public:
     [[nodiscard]] bool is_negative() const { return m_seconds < 0; }
 
     bool operator==(Time const& other) const { return this->m_seconds == other.m_seconds && this->m_nanoseconds == other.m_nanoseconds; }
-    bool operator!=(Time const& other) const { return !(*this == other); }
     Time operator+(Time const& other) const;
     Time& operator+=(Time const& other);
     Time operator-(Time const& other) const;

--- a/AK/UUID.cpp
+++ b/AK/UUID.cpp
@@ -113,15 +113,6 @@ String UUID::to_string() const
 }
 #endif
 
-bool UUID::operator==(const UUID& other) const
-{
-    for (size_t index = 0; index < 16; index++) {
-        if (m_uuid_buffer[index] != other.m_uuid_buffer[index])
-            return false;
-    }
-    return true;
-}
-
 bool UUID::is_zero() const
 {
     return all_of(m_uuid_buffer, [](auto const octet) { return octet == 0; });

--- a/AK/UUID.h
+++ b/AK/UUID.h
@@ -31,12 +31,7 @@ public:
     UUID(StringView, Endianness endianness = Endianness::Little);
     ~UUID() = default;
 
-    bool operator==(const UUID&) const;
-    bool operator!=(const UUID& other) const { return !(*this == other); }
-    bool operator<=(const UUID&) const = delete;
-    bool operator>=(const UUID&) const = delete;
-    bool operator<(const UUID&) const = delete;
-    bool operator>(const UUID&) const = delete;
+    bool operator==(const UUID&) const = default;
 
 #ifdef KERNEL
     ErrorOr<NonnullOwnPtr<Kernel::KString>> to_string() const;

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -35,11 +35,6 @@ public:
         return (m_ptr == other.m_ptr) && (m_remaining_code_units == other.m_remaining_code_units);
     }
 
-    bool operator!=(Utf16CodePointIterator const& other) const
-    {
-        return !(*this == other);
-    }
-
     Utf16CodePointIterator& operator++();
     u32 operator*() const;
 

--- a/AK/Utf32View.h
+++ b/AK/Utf32View.h
@@ -25,10 +25,6 @@ public:
     {
         return m_ptr == other.m_ptr && m_length == other.m_length;
     }
-    bool operator!=(Utf32CodePointIterator const& other) const
-    {
-        return !(*this == other);
-    }
     Utf32CodePointIterator& operator++()
     {
         VERIFY(m_length > 0);

--- a/Userland/Applications/Spreadsheet/Position.h
+++ b/Userland/Applications/Spreadsheet/Position.h
@@ -37,11 +37,6 @@ struct Position {
         return row == other.row && column == other.column;
     }
 
-    bool operator!=(Position const& other) const
-    {
-        return !(other == *this);
-    }
-
     String to_cell_identifier(Sheet const& sheet) const;
     URL to_url(Sheet const& sheet) const;
 

--- a/Userland/Libraries/LibDebug/DebugInfo.h
+++ b/Userland/Libraries/LibDebug/DebugInfo.h
@@ -50,7 +50,6 @@ public:
         }
 
         bool operator==(SourcePosition const& other) const { return file_path == other.file_path && line_number == other.line_number; }
-        bool operator!=(SourcePosition const& other) const { return !(*this == other); }
 
         static SourcePosition from_line_info(Dwarf::LineProgram::LineInfo const&);
     };

--- a/Userland/Libraries/LibDeviceTree/FlattenedDeviceTree.h
+++ b/Userland/Libraries/LibDeviceTree/FlattenedDeviceTree.h
@@ -34,7 +34,6 @@ struct FlattenedDeviceTreeReserveEntry {
     BigEndian<u64> size;
 
     bool operator==(FlattenedDeviceTreeReserveEntry const& other) const { return other.address == address && other.size == size; }
-    bool operator!=(FlattenedDeviceTreeReserveEntry const& other) const { return !(operator==(other)); }
 };
 static_assert(sizeof(FlattenedDeviceTreeReserveEntry) == 16, "FDT Memory Reservation entry size must match specification");
 

--- a/Userland/Libraries/LibGUI/ModelIndex.h
+++ b/Userland/Libraries/LibGUI/ModelIndex.h
@@ -33,11 +33,6 @@ public:
         return m_model == other.m_model && m_row == other.m_row && m_column == other.m_column && m_internal_data == other.m_internal_data;
     }
 
-    bool operator!=(ModelIndex const& other) const
-    {
-        return !(*this == other);
-    }
-
     Model const* model() const { return m_model; }
 
     Variant data(ModelRole = ModelRole::Display) const;

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -350,11 +350,6 @@ public:
         return m_value == other.m_value;
     }
 
-    constexpr bool operator!=(Color const& other) const
-    {
-        return m_value != other.m_value;
-    }
-
     String to_string() const;
     String to_string_without_alpha() const;
     static Optional<Color> from_string(StringView);

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -132,12 +132,6 @@ public:
         return x() == other.x() && y() == other.y();
     }
 
-    template<class U>
-    [[nodiscard]] bool operator!=(Point<U> const& other) const
-    {
-        return !(*this == other);
-    }
-
     [[nodiscard]] Point<T> operator+(Point<T> const& other) const { return { m_x + other.m_x, m_y + other.m_y }; }
 
     Point<T>& operator+=(Point<T> const& other)

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -477,12 +477,6 @@ public:
         return location() == other.location() && size() == other.size();
     }
 
-    template<class U>
-    [[nodiscard]] bool operator!=(Rect<U> const& other) const
-    {
-        return !(*this == other);
-    }
-
     [[nodiscard]] Rect<T> operator*(T factor) const { return { m_location * factor, m_size * factor }; }
 
     Rect<T>& operator*=(T factor)

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -99,12 +99,6 @@ public:
         return width() == other.width() && height() == other.height();
     }
 
-    template<class U>
-    [[nodiscard]] constexpr bool operator!=(Size<U> const& other) const
-    {
-        return !(*this == other);
-    }
-
     constexpr Size<T>& operator-=(Size<T> const& other)
     {
         m_width -= other.m_width;

--- a/Userland/Libraries/LibJS/Runtime/PropertyAttributes.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyAttributes.h
@@ -59,7 +59,6 @@ public:
     }
 
     bool operator==(PropertyAttributes const& other) const { return m_bits == other.m_bits; }
-    bool operator!=(PropertyAttributes const& other) const { return m_bits != other.m_bits; }
 
     [[nodiscard]] u8 bits() const { return m_bits; }
 

--- a/Userland/Libraries/LibLine/KeyCallbackMachine.h
+++ b/Userland/Libraries/LibLine/KeyCallbackMachine.h
@@ -38,11 +38,6 @@ struct Key {
     {
         return other.key == key && other.modifiers == modifiers;
     }
-
-    bool operator!=(Key const& other) const
-    {
-        return !(*this == other);
-    }
 };
 
 struct KeyCallback {

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -310,11 +310,6 @@ public:
             [&](StringView view) { return view == cstring; });
     }
 
-    bool operator!=(char const* cstring) const
-    {
-        return !(*this == cstring);
-    }
-
     bool operator==(String const& string) const
     {
         return m_view.visit(
@@ -333,11 +328,6 @@ public:
             [&](StringView view) { return view == string; });
     }
 
-    bool operator!=(StringView other) const
-    {
-        return !(*this == other);
-    }
-
     bool operator==(Utf32View const& other) const
     {
         return m_view.visit(
@@ -349,11 +339,6 @@ public:
             [&](StringView view) { return view == RegexStringView { other }.to_string(); });
     }
 
-    bool operator!=(Utf32View const& other) const
-    {
-        return !(*this == other);
-    }
-
     bool operator==(Utf16View const& other) const
     {
         return m_view.visit(
@@ -363,11 +348,6 @@ public:
             [&](StringView view) { return view == RegexStringView { other }.to_string(); });
     }
 
-    bool operator!=(Utf16View const& other) const
-    {
-        return !(*this == other);
-    }
-
     bool operator==(Utf8View const& other) const
     {
         return m_view.visit(
@@ -375,11 +355,6 @@ public:
             [&](Utf16View) { return to_string() == other.as_string(); },
             [&](Utf8View const& view) { return view.as_string() == other.as_string(); },
             [&](StringView view) { return other.as_string() == view; });
-    }
-
-    bool operator!=(Utf8View const& other) const
-    {
-        return !(*this == other);
     }
 
     bool equals(RegexStringView other) const

--- a/Userland/Libraries/LibSQL/HashIndex.h
+++ b/Userland/Libraries/LibSQL/HashIndex.h
@@ -118,9 +118,7 @@ public:
     [[nodiscard]] bool is_end() const { return !m_current; }
 
     bool operator==(HashIndexIterator const& other) const;
-    bool operator!=(HashIndexIterator const& other) const { return !(*this == other); }
     bool operator==(Key const& other) const;
-    bool operator!=(Key const& other) const { return !(*this == other); }
 
     HashIndexIterator operator++()
     {

--- a/Userland/Libraries/LibVT/Attribute.h
+++ b/Userland/Libraries/LibVT/Attribute.h
@@ -63,10 +63,6 @@ struct Attribute {
     {
         return foreground_color == other.foreground_color && background_color == other.background_color && flags == other.flags;
     }
-    constexpr bool operator!=(Attribute const& other) const
-    {
-        return !(*this == other);
-    }
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Angle.h
+++ b/Userland/Libraries/LibWeb/CSS/Angle.h
@@ -43,11 +43,6 @@ public:
         return m_type == other.m_type && m_value == other.m_value;
     }
 
-    bool operator!=(Angle const& other) const
-    {
-        return !(*this == other);
-    }
-
 private:
     StringView unit_name() const;
 

--- a/Userland/Libraries/LibWeb/CSS/Display.h
+++ b/Userland/Libraries/LibWeb/CSS/Display.h
@@ -35,8 +35,6 @@ public:
         VERIFY_NOT_REACHED();
     }
 
-    bool operator!=(Display const& other) const { return !(*this == other); }
-
     enum class Outside {
         Block,
         Inline,

--- a/Userland/Libraries/LibWeb/CSS/Frequency.h
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.h
@@ -40,11 +40,6 @@ public:
         return m_type == other.m_type && m_value == other.m_value;
     }
 
-    bool operator!=(Frequency const& other) const
-    {
-        return !(*this == other);
-    }
-
 private:
     StringView unit_name() const;
 

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -121,10 +121,6 @@ public:
     // We have a RefPtr<CalculatedStyleValue> member, but can't include the header StyleValue.h as it includes
     // this file already. To break the cyclic dependency, we must move all method definitions out.
     bool operator==(Length const& other) const;
-    bool operator!=(Length const& other) const
-    {
-        return !(*this == other);
-    }
 
     float relative_length_to_px(Gfx::IntRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, float font_size, float root_font_size) const;
 

--- a/Userland/Libraries/LibWeb/CSS/Percentage.h
+++ b/Userland/Libraries/LibWeb/CSS/Percentage.h
@@ -37,7 +37,6 @@ public:
     }
 
     bool operator==(Percentage const& other) const { return m_value == other.m_value; }
-    bool operator!=(Percentage const& other) const { return !(*this == other); }
 
 private:
     float m_value;
@@ -147,7 +146,6 @@ public:
             return (m_value.template get<Percentage>() == other.m_value.template get<Percentage>());
         return (m_value.template get<T>() == other.m_value.template get<T>());
     }
-    bool operator!=(PercentageOr<T> const& other) const { return !(*this == other); }
 
 protected:
     bool is_t() const { return m_value.template has<T>(); }

--- a/Userland/Libraries/LibWeb/CSS/Resolution.h
+++ b/Userland/Libraries/LibWeb/CSS/Resolution.h
@@ -32,11 +32,6 @@ public:
         return m_type == other.m_type && m_value == other.m_value;
     }
 
-    bool operator!=(Resolution const& other) const
-    {
-        return !(*this == other);
-    }
-
 private:
     StringView unit_name() const;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -108,7 +108,6 @@ public:
     float line_height(Layout::Node const&) const;
 
     bool operator==(StyleProperties const&) const;
-    bool operator!=(StyleProperties const& other) const { return !(*this == other); }
 
     Optional<CSS::Position> position() const;
     Optional<int> z_index() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -352,7 +352,6 @@ public:
     virtual String to_string() const = 0;
 
     bool operator==(StyleValue const& other) const { return equals(other); }
-    bool operator!=(StyleValue const& other) const { return !(*this == other); }
 
     virtual bool equals(StyleValue const& other) const = 0;
 

--- a/Userland/Libraries/LibWeb/CSS/Time.h
+++ b/Userland/Libraries/LibWeb/CSS/Time.h
@@ -41,11 +41,6 @@ public:
         return m_type == other.m_type && m_value == other.m_value;
     }
 
-    bool operator!=(Time const& other) const
-    {
-        return !(*this == other);
-    }
-
 private:
     StringView unit_name() const;
 

--- a/Userland/Libraries/LibWeb/DOM/Position.h
+++ b/Userland/Libraries/LibWeb/DOM/Position.h
@@ -35,11 +35,6 @@ public:
         return m_node.ptr() == other.m_node.ptr() && m_offset == other.m_offset;
     }
 
-    bool operator!=(Position const& other) const
-    {
-        return !(*this == other);
-    }
-
     String to_string() const;
 
 private:

--- a/Userland/Libraries/LibWeb/HTML/Origin.h
+++ b/Userland/Libraries/LibWeb/HTML/Origin.h
@@ -106,7 +106,6 @@ public:
     }
 
     bool operator==(Origin const& other) const { return is_same_origin(other); }
-    bool operator!=(Origin const& other) const { return !is_same_origin(other); }
 
 private:
     String m_scheme;


### PR DESCRIPTION
C++20 can automatically synthesize `operator!=` from `operator==`, so there is no point in writing such functions by hand if all they do is call through to `operator==`.

This fixes a compile error with compilers that implement P2468 (Clang 16 currently). This paper restores the C++17 behavior that if both `T::operator==(U)` and `T::operator!=(U)` exist, `U == T` won't be rewritten in reverse to call `T::operator==(U)`. Removing `!=` operators makes the rewriting possible again.
See https://reviews.llvm.org/D134529#3853062