### PR TITLE
LibWasm: Calculate the max data segment size correctly

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
@@ -345,7 +345,7 @@ InstantiationResult AbstractMachine::instantiate(Module const& module, Vector<Ex
                     auto address = main_module_instance.memories()[data.index.value()];
                     if (auto instance = m_store.get(address)) {
                         if (auto max = instance->type().limits().max(); max.has_value()) {
-                            if (*max < data.init.size() + offset) {
+                            if (*max * Constants::page_size < data.init.size() + offset) {
                                 instantiation_result = InstantiationError {
                                     String::formatted("Data segment attempted to write to out-of-bounds memory ({}) of max {} bytes",
                                         data.init.size() + offset, instance->type().limits().max().value())

--- a/Userland/Libraries/LibWasm/Constants.h
+++ b/Userland/Libraries/LibWasm/Constants.h
@@ -40,7 +40,7 @@ static constexpr auto page_size = 64 * KiB;
 // These are not concretely defined by the spec, so the values are only defined by us.
 static constexpr auto minimum_stack_space_to_keep_free = 256 * KiB; // Note: Value is arbitrary and chosen by testing with ASAN
 static constexpr auto max_allowed_executed_instructions_per_call = 256 * 1024 * 1024;
-static constexpr auto max_allowed_vector_size = 2 * MiB;
+static constexpr auto max_allowed_vector_size = 500 * MiB;
 static constexpr auto max_allowed_function_locals_per_type = 42069; // Note: VERY arbitrary.
 
 }


### PR DESCRIPTION
This is given in pages, we need to first convert to bytes before
comparing with bytes.