### PR TITLE
LibWeb: Skip anonymous layout nodes while finding the event target

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -39,6 +39,8 @@ static bool parent_element_for_event_dispatch(Painting::Paintable const& paintab
     layout_node = &paintable.layout_node();
     while (layout_node && node && !node->is_element() && layout_node->parent()) {
         layout_node = layout_node->parent();
+        if (layout_node->is_anonymous())
+            continue;
         node = layout_node->dom_node();
     }
     return node && layout_node;


### PR DESCRIPTION
**LibWeb: Move code for finding the parent element into a helper function**

This exact same loop is repeated a couple of times.

**LibWeb: Skip anonymous layout nodes while finding the event target**

This makes the links on nitter.net clickable, e.g. "preferences" in the upper right corner.