### PR TITLE
WebDriver: Implement `GET /session/{id}/source` endpoint

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -610,6 +610,10 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
         return active_tab().view().get_element_tag_name(element_id);
     };
 
+    new_tab.on_get_page_source = [this]() {
+        return active_tab().view().get_source_sync();
+    };
+
     new_tab.load(url);
 
     dbgln_if(SPAM_DEBUG, "Added new tab {:p}, loading {}", &new_tab, url);

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -69,6 +69,7 @@ public:
     Function<Vector<Web::Cookie::Cookie>()> on_get_cookies_entries;
     Function<OrderedHashMap<String, String>()> on_get_local_storage_entries;
     Function<OrderedHashMap<String, String>()> on_get_session_storage_entries;
+    Function<String()> on_get_page_source;
 
     WebDriverEndpoints& webdriver_endpoints() { return m_webdriver_endpoints; }
 

--- a/Userland/Applications/Browser/WebDriverConnection.cpp
+++ b/Userland/Applications/Browser/WebDriverConnection.cpp
@@ -199,4 +199,15 @@ Messages::WebDriverSessionClient::GetElementTagNameResponse WebDriverConnection:
     return { "" };
 }
 
+Messages::WebDriverSessionClient::GetPageSourceResponse WebDriverConnection::get_page_source()
+{
+    dbgln("WebDriverConnection: get_page_source");
+    if (auto browser_window = m_browser_window.strong_ref()) {
+        auto& tab = browser_window->active_tab();
+        if (tab.on_get_page_source)
+            return { tab.on_get_page_source() };
+    }
+    return { "" };
+}
+
 }

--- a/Userland/Applications/Browser/WebDriverConnection.h
+++ b/Userland/Applications/Browser/WebDriverConnection.h
@@ -54,6 +54,7 @@ public:
     virtual Messages::WebDriverSessionClient::GetActiveDocumentsTypeResponse get_active_documents_type() override;
     virtual Messages::WebDriverSessionClient::GetComputedValueForElementResponse get_computed_value_for_element(i32 element_id, String const& property_name) override;
     virtual Messages::WebDriverSessionClient::GetElementTagNameResponse get_element_tag_name(i32 element_id) override;
+    virtual Messages::WebDriverSessionClient::GetPageSourceResponse get_page_source() override;
 
 private:
     WebDriverConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, NonnullRefPtr<BrowserWindow> browser_window);

--- a/Userland/Applications/Browser/WebDriverSessionClient.ipc
+++ b/Userland/Applications/Browser/WebDriverSessionClient.ipc
@@ -23,5 +23,6 @@ endpoint WebDriverSessionClient {
     get_active_documents_type() => (String type)
     get_computed_value_for_element(i32 element_id, String property_name) => (String computed_value)
     get_element_tag_name(i32 element_id) => (String tag_name)
+    get_page_source() => (String page_source)
 
 }

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -447,6 +447,11 @@ void OutOfProcessWebView::get_source()
     client().async_get_source();
 }
 
+String OutOfProcessWebView::get_source_sync()
+{
+    return client().get_source_sync();
+}
+
 void OutOfProcessWebView::inspect_dom_tree()
 {
     client().async_inspect_dom_tree();

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -33,6 +33,7 @@ public:
 
     void debug_request(String const& request, String const& argument = {});
     void get_source();
+    String get_source_sync();
 
     void inspect_dom_tree();
     struct DOMNodeProperties {

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -256,6 +256,15 @@ void ConnectionFromClient::get_source()
     }
 }
 
+Messages::WebContentServer::GetSourceSyncResponse ConnectionFromClient::get_source_sync()
+{
+    if (auto* doc = page().top_level_browsing_context().active_document()) {
+        return { doc->source() };
+    }
+
+    return { "" };
+}
+
 void ConnectionFromClient::inspect_dom_tree()
 {
     if (auto* doc = page().top_level_browsing_context().active_document()) {

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -62,6 +62,7 @@ private:
     virtual void remove_backing_store(i32) override;
     virtual void debug_request(String const&, String const&) override;
     virtual void get_source() override;
+    virtual Messages::WebContentServer::GetSourceSyncResponse get_source_sync() override;
     virtual void inspect_dom_tree() override;
     virtual Messages::WebContentServer::InspectDomNodeResponse inspect_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> const& pseudo_element) override;
     virtual Messages::WebContentServer::GetHoveredNodeIdResponse get_hovered_node_id() override;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -31,6 +31,7 @@ endpoint WebContentServer
 
     debug_request(String request, String argument) =|
     get_source() =|
+    get_source_sync() => (String page_source)
     inspect_dom_tree() =|
     inspect_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> pseudo_element) => (bool has_style, String specified_style, String computed_style, String custom_properties, String node_box_sizing)
     get_hovered_node_id() => (i32 node_id)

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -44,6 +44,7 @@ Vector<Client::Route> Client::s_routes = {
     { HTTP::HttpRequest::Method::GET, { "session", ":session_id", "element", ":element_id", "property", ":name" }, &Client::handle_get_element_property },
     { HTTP::HttpRequest::Method::GET, { "session", ":session_id", "element", ":element_id", "css", ":property_name" }, &Client::handle_get_element_css_value },
     { HTTP::HttpRequest::Method::GET, { "session", ":session_id", "element", ":element_id", "name" }, &Client::handle_get_element_tag_name },
+    { HTTP::HttpRequest::Method::GET, { "session", ":session_id", "source" }, &Client::handle_get_page_source },
     { HTTP::HttpRequest::Method::GET, { "session", ":session_id", "cookie" }, &Client::handle_get_all_cookies },
     { HTTP::HttpRequest::Method::GET, { "session", ":session_id", "cookie", ":name" }, &Client::handle_get_named_cookie },
     { HTTP::HttpRequest::Method::POST, { "session", ":session_id", "cookie" }, &Client::handle_add_cookie },
@@ -619,6 +620,16 @@ ErrorOr<JsonValue, WebDriverError> Client::handle_get_element_tag_name(Vector<St
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/name");
     auto* session = TRY(find_session_with_id(parameters[0]));
     auto result = TRY(session->get_element_tag_name(payload, parameters[1]));
+    return make_json_value(result);
+}
+
+// 13.1 Get Page Source, https://w3c.github.io/webdriver/#dfn-get-page-source
+// GET /session/{session id}/source
+ErrorOr<JsonValue, WebDriverError> Client::handle_get_page_source(Vector<StringView> const& parameters, JsonValue const&)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/source");
+    auto* session = TRY(find_session_with_id(parameters[0]));
+    auto result = TRY(session->get_page_source());
     return make_json_value(result);
 }
 

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -69,6 +69,7 @@ private:
     ErrorOr<JsonValue, WebDriverError> handle_get_element_property(Vector<StringView> const&, JsonValue const& payload);
     ErrorOr<JsonValue, WebDriverError> handle_get_element_css_value(Vector<StringView> const&, JsonValue const& payload);
     ErrorOr<JsonValue, WebDriverError> handle_get_element_tag_name(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, WebDriverError> handle_get_page_source(Vector<StringView> const&, JsonValue const& payload);
     ErrorOr<JsonValue, WebDriverError> handle_get_all_cookies(Vector<StringView> const&, JsonValue const& payload);
     ErrorOr<JsonValue, WebDriverError> handle_get_named_cookie(Vector<StringView> const&, JsonValue const& payload);
     ErrorOr<JsonValue, WebDriverError> handle_add_cookie(Vector<StringView> const&, JsonValue const& payload);

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -735,6 +735,25 @@ ErrorOr<JsonValue, WebDriverError> Session::get_element_tag_name(JsonValue const
     return JsonValue(qualified_name);
 }
 
+// 13.1 Get Page Source, https://w3c.github.io/webdriver/#dfn-get-page-source
+ErrorOr<JsonValue, WebDriverError> Session::get_page_source()
+{
+    // 1. If the current browsing context is no longer open, return error with error code no such window.
+    TRY(check_for_open_top_level_browsing_context_or_return_error());
+
+    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+
+    // FIXME: 3. Let source be the result of invoking the fragment serializing algorithm on a fictional node
+    //           whose only child is the document element providing true for the require well-formed flag.
+    //           If this causes an exception to be thrown, let source be null.
+
+    // 4. Let source be the result of serializing to string the current browsing context active document, if source is null.
+    auto source = m_browser_connection->get_page_source();
+
+    // 5. Return success with data source.
+    return JsonValue(source);
+}
+
 // https://w3c.github.io/webdriver/#dfn-serialized-cookie
 static JsonObject serialize_cookie(Web::Cookie::Cookie const& cookie)
 {

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -58,6 +58,7 @@ public:
     ErrorOr<JsonValue, WebDriverError> get_element_property(JsonValue const& payload, StringView element_id, StringView name);
     ErrorOr<JsonValue, WebDriverError> get_element_css_value(JsonValue const& payload, StringView element_id, StringView property_name);
     ErrorOr<JsonValue, WebDriverError> get_element_tag_name(JsonValue const& payload, StringView element_id);
+    ErrorOr<JsonValue, WebDriverError> get_page_source();
     ErrorOr<JsonValue, WebDriverError> get_all_cookies();
     ErrorOr<JsonValue, WebDriverError> get_named_cookie(String const& name);
     ErrorOr<JsonValue, WebDriverError> add_cookie(JsonValue const& payload);


### PR DESCRIPTION
This patch introduces the WebDriver endpoint for getting the source of the currently open page. There already is an async IPC call for this between OOPWV and WebContent, however this adds a synchronous version of that.