### PR TITLE
LibGUI: Window text entry mode

### DIFF
--- a/Userland/Libraries/LibGUI/ConnectionToWindowServer.cpp
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowServer.cpp
@@ -149,6 +149,10 @@ static Action* action_for_shortcut(Window& window, Shortcut const& shortcut)
     if (!shortcut.is_valid())
         return nullptr;
 
+    if (window.is_in_text_entry() && shortcut.looks_like_text_entry()) {
+        return nullptr;
+    }
+
     dbgln_if(KEYBOARD_SHORTCUTS_DEBUG, "Looking up action for {}", shortcut.to_string());
 
     for (auto* widget = window.focused_widget(); widget; widget = widget->parent_widget()) {

--- a/Userland/Libraries/LibGUI/Shortcut.cpp
+++ b/Userland/Libraries/LibGUI/Shortcut.cpp
@@ -42,4 +42,14 @@ String Shortcut::to_string() const
     return builder.to_string();
 }
 
+bool Shortcut::looks_like_text_entry() const
+{
+    if (m_type != Type::Keyboard)
+        return false;
+    if (m_modifiers & Mod_Alt || m_modifiers & Mod_Ctrl || m_modifiers & Mod_Super)
+        return false;
+
+    return (m_keyboard_key >= Key_Space && m_keyboard_key <= Key_Backtick);
+}
+
 }

--- a/Userland/Libraries/LibGUI/Shortcut.h
+++ b/Userland/Libraries/LibGUI/Shortcut.h
@@ -49,6 +49,7 @@ public:
     String to_string() const;
     Type type() const { return m_type; }
     bool is_valid() const { return m_type == Type::Keyboard ? (m_keyboard_key != Key_Invalid) : (m_mouse_button != MouseButton::None); }
+    bool looks_like_text_entry() const;
     u8 modifiers() const { return m_modifiers; }
 
     KeyCode key() const

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1370,6 +1370,7 @@ void TextEditor::focusin_event(FocusEvent& event)
 {
     if (event.source() == FocusSource::Keyboard)
         select_all();
+    window()->set_in_text_entry(true);
     m_cursor_state = true;
     update_cursor();
     stop_timer();
@@ -1380,6 +1381,7 @@ void TextEditor::focusin_event(FocusEvent& event)
 
 void TextEditor::focusout_event(FocusEvent&)
 {
+    window()->set_in_text_entry(false);
     if (is_displayonly() && has_selection())
         m_selection.clear();
     stop_timer();

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -206,6 +206,9 @@ public:
 
     Action* action_for_shortcut(Shortcut const&);
 
+    void set_in_text_entry(bool in_text_entry) { m_in_text_entry = in_text_entry; }
+    bool is_in_text_entry() { return m_in_text_entry; }
+
     void did_add_widget(Badge<Widget>, Widget&);
     void did_remove_widget(Badge<Widget>, Widget&);
 
@@ -318,6 +321,7 @@ private:
     bool m_moved_by_client { false };
     bool m_blocks_command_palette { false };
     bool m_blocks_emoji_input { false };
+    bool m_in_text_entry { false };
 };
 
 }


### PR DESCRIPTION
This PR allows for an application to tell the Window "I am in some text entry mode", which then causes any single letter/number or Shift + single letter/number shortcuts to be ignored.

This aims to solve a particularly annoying problem in PixelPaint. Many tools/actions in this program are only a single letter, like the Clone Tool has the shortcut "C". When the user is typing a layer name, the letter "C" gets incorrectly sent to the action instead of the textbox. This specific situation could be solved by scoping the actions, but I'm also working on adding a Text Tool where such a scoping would not help. You would need to scope the Tool actions to the ImageEditor for them to be useful, and that's what would have focus while the Text Tool is in use.