### PR TITLE
Kernel: Remove hardcoded unveil path of /usr/lib/Loader.so

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -886,8 +886,6 @@ ErrorOr<void> VirtualFileSystem::validate_path_against_process_veil(StringView p
 {
     if (Process::current().veil_state() == VeilState::None)
         return {};
-    if (options == O_EXEC && path == "/usr/lib/Loader.so")
-        return {};
 
     VERIFY(path.starts_with('/'));
     VERIFY(!path.contains("/../"sv) && !path.ends_with("/.."sv));


### PR DESCRIPTION
This rule was added in #9894. I don't think it is necessary to allow automatic unveil of the dynamic loader. If a program needs to execute another program, it should unveil the dynamic loader beforehand.

cc @itamar8910 