### PR TITLE
LibWeb: Layout inner floats/abspos boxes after laying out the top float

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -556,8 +556,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     float width_of_containing_block = available_space.width.to_px();
 
     compute_width(box, available_space, layout_mode);
-    if (auto independent_formatting_context = layout_inside(box, layout_mode, box_state.available_inner_space_or_constraints_from(available_space)))
-        independent_formatting_context->parent_context_did_dimension_child_root_box();
+    auto independent_formatting_context = layout_inside(box, layout_mode, box_state.available_inner_space_or_constraints_from(available_space));
     compute_height(box, available_space);
 
     // First we place the box normally (to get the right y coordinate.)
@@ -674,6 +673,9 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
 
     if (line_builder)
         line_builder->recalculate_available_space();
+
+    if (independent_formatting_context)
+        independent_formatting_context->parent_context_did_dimension_child_root_box();
 }
 
 void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_item_box)


### PR DESCRIPTION
Calling parent_context_did_dimension_child_root_box immediately after laying out the inside of the floating box is not correct, as we haven't worked out the dimensions of the floating box yet.

In particular, this caused the icons in the top bar of Cookie Clicker to not hug the top of the viewport. This is because the icons are absolutely positioned elements inside a floating element which has padding applied to it. Since we laid out the abspos element before the floating element, it got padding values of 0 from the parent, the default value, meaning it didn't take away the padding of it's floating parent.

This follows how abspos boxes layout their inside boxes as well.

Before:
![Screenshot from 2022-10-24 19-57-50](https://user-images.githubusercontent.com/25595356/197604169-95533951-18d1-4e4f-8c0f-89804da65e8d.png)

After:
![Screenshot from 2022-10-24 19-34-28](https://user-images.githubusercontent.com/25595356/197603104-dea55a4a-09a0-4b5b-928d-d5bef924f5ed.png)