### PR TITLE
LibWeb: Compute height of absolute before inner layout

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -942,8 +942,8 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box, Ava
     auto specified_width = box.computed_values().width().resolved(box, width_of_containing_block_as_length).resolved(box);
 
     compute_width_for_absolutely_positioned_element(box, available_space);
-    auto independent_formatting_context = layout_inside(box, LayoutMode::Normal, box_state.available_inner_space_or_constraints_from(available_space));
     compute_height_for_absolutely_positioned_element(box, available_space);
+    auto independent_formatting_context = layout_inside(box, LayoutMode::Normal, box_state.available_inner_space_or_constraints_from(available_space));
 
     box_state.margin_left = box.computed_values().margin().left().resolved(box, width_of_containing_block_as_length).to_px(box);
     box_state.margin_top = box.computed_values().margin().top().resolved(box, width_of_containing_block_as_length).to_px(box);


### PR DESCRIPTION
follwing reduced layout has a bug where `#inner` element should take 100% of `#outer` element but it doesn't happen.
```html
<!DOCTYPE html>
<html>
  <head>
    <style>
      #inner {
        position: relative;
        height: 100%;
        background: #ddd;
      }

      #outer {
        position: absolute;
        top: 55px;
        bottom: 0;
        width: 100%;
      }
    </style>
  </head>
  <body>
    <div id="outer"><div id="inner"></div></div>
  </body>
</html>

```
this patch fixes bug in this example but unfortunately I didn't manage to find a place in the spec which describes in what order width and height should be computed for absolute elements.
