### PR TITLE
LibWeb: Add an initial implementation of the `filter` CSS property

### DIFF
--- a/Base/res/html/misc/filter.html
+++ b/Base/res/html/misc/filter.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Filter</title>
+    <style>
+        .image-box {
+          background-image: url(old-computer.png);
+          height: 240px;
+          width: 350px;
+          background-size: cover;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          margin: 5px;
+          border-radius: 50%;
+        }
+
+        .backdrop-box {
+          background-color: rgba(255, 255, 255, 0.1);
+          width: 50%;
+          height: 50%;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          position: relative;
+          top: -72%;
+          left: 26%;
+          font-size: 1.2em;
+        }
+
+        code {
+          text-shadow: 1px 1px 2px black;
+          color: white;
+        }
+
+        body {
+          display: flex;
+          flex-wrap: wrap;
+        }
+
+        .blur {
+          filter: blur(5px);
+        }
+
+        .invert {
+          filter: invert();
+        }
+
+        .grayscale {
+          filter: grayscale();
+        }
+
+        .brightness {
+          filter: brightness(200%);
+        }
+
+        .contrast {
+          filter: contrast(200%);
+        }
+
+        .sepia {
+          filter: sepia();
+        }
+
+        .grayscale-invert-blur {
+          filter: grayscale() invert() blur(5px);
+        }
+
+        .mixed {
+          filter: grayscale(50%) invert(70%);
+        }
+
+        .hue-rotate {
+          filter: hue-rotate(60deg);
+        }
+
+        .saturate {
+          filter: saturate(4);
+        }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="image-box grayscale-invert-blur"></div>
+      <div class="backdrop-box"></div>
+    </div>
+    <div class="container">
+      <div class="image-box mixed"></div>
+      <div class="backdrop-box"></div>
+    </div>
+    <div class="container">
+      <div class="image-box blur"></div>
+      <div class="backdrop-box"></div>
+    </div>
+    <div class="container">
+      <div class="image-box invert"></div>
+      <div class="backdrop-box"></div>
+    </div>
+    <div class="container">
+      <div class="image-box grayscale"></div>
+      <div class="backdrop-box"></div>
+    </div>
+    <div class="container">
+      <div class="image-box brightness"></div>
+      <div class="backdrop-box"></div>
+    </div>
+    <div class="container">
+      <div class="image-box contrast"></div>
+      <div class="backdrop-box"></div>
+    </div>
+    <div class="container">
+      <div class="image-box sepia"></div>
+      <div class="backdrop-box"></div>
+    </div>
+    <div class="container">
+      <div class="image-box hue-rotate"></div>
+      <div class="backdrop-box"></div>
+    </div>
+    <div class="container">
+      <div class="image-box saturate"></div>
+      <div class="backdrop-box"></div>
+    </div>
+  <script>
+    const boxes = document.querySelectorAll(".backdrop-box");
+    const filterMap = {};
+    for (const rule of document.styleSheets[0].cssRules) {
+      filterMap[rule.selectorText] = rule.style.filter;
+    }
+
+    updateLabels = () => {
+        boxes.forEach(box => {
+            const filter = box.previousElementSibling.classList[1];
+            const cssText = filterMap['.'+filter];
+            let newEl = document.createElement('code');
+            let text = document.createTextNode(box.previousElementSibling.style.filter || cssText);
+            newEl.appendChild(text);
+            newEl.id = filter;
+            box.appendChild(newEl);
+        })
+    }
+
+    updateLabels();
+  </script>
+</html>

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <AK/Optional.h>
-#include <LibWeb/CSS/BackdropFilter.h>
 #include <LibWeb/CSS/Clip.h>
+#include <LibWeb/CSS/FilterList.h>
 #include <LibWeb/CSS/LengthBox.h>
 #include <LibWeb/CSS/Size.h>
 #include <LibWeb/CSS/StyleValue.h>
@@ -34,7 +34,7 @@ public:
     static CSS::TextTransform text_transform() { return CSS::TextTransform::None; }
     static CSS::Display display() { return CSS::Display { CSS::Display::Outside::Inline, CSS::Display::Inside::Flow }; }
     static Color color() { return Color::Black; }
-    static CSS::BackdropFilter backdrop_filter() { return BackdropFilter::make_none(); }
+    static CSS::FilterList backdrop_filter() { return FilterList::make_none(); }
     static Color background_color() { return Color::Transparent; }
     static CSS::ListStyleType list_style_type() { return CSS::ListStyleType::Disc; }
     static CSS::Visibility visibility() { return CSS::Visibility::Visible; }
@@ -172,7 +172,7 @@ public:
     CSS::Visibility visibility() const { return m_inherited.visibility; }
     CSS::ImageRendering image_rendering() const { return m_inherited.image_rendering; }
     CSS::JustifyContent justify_content() const { return m_noninherited.justify_content; }
-    CSS::BackdropFilter const& backdrop_filter() const { return m_noninherited.backdrop_filter; }
+    CSS::FilterList const& backdrop_filter() const { return m_noninherited.backdrop_filter; }
     Vector<ShadowData> const& box_shadow() const { return m_noninherited.box_shadow; }
     CSS::BoxSizing box_sizing() const { return m_noninherited.box_sizing; }
     CSS::Size const& width() const { return m_noninherited.width; }
@@ -273,7 +273,7 @@ protected:
         CSS::LengthBox inset { InitialValues::inset() };
         CSS::LengthBox margin { InitialValues::margin() };
         CSS::LengthBox padding { InitialValues::padding() };
-        CSS::BackdropFilter backdrop_filter { InitialValues::backdrop_filter() };
+        CSS::FilterList backdrop_filter { InitialValues::backdrop_filter() };
         BorderData border_left;
         BorderData border_top;
         BorderData border_right;
@@ -355,7 +355,7 @@ public:
     void set_overflow_y(CSS::Overflow value) { m_noninherited.overflow_y = value; }
     void set_list_style_type(CSS::ListStyleType value) { m_inherited.list_style_type = value; }
     void set_display(CSS::Display value) { m_noninherited.display = value; }
-    void set_backdrop_filter(CSS::BackdropFilter backdrop_filter) { m_noninherited.backdrop_filter = move(backdrop_filter); }
+    void set_backdrop_filter(CSS::FilterList backdrop_filter) { m_noninherited.backdrop_filter = move(backdrop_filter); }
     void set_border_bottom_left_radius(CSS::BorderRadiusData value) { m_noninherited.border_bottom_left_radius = move(value); }
     void set_border_bottom_right_radius(CSS::BorderRadiusData value) { m_noninherited.border_bottom_right_radius = move(value); }
     void set_border_top_left_radius(CSS::BorderRadiusData value) { m_noninherited.border_top_left_radius = move(value); }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -35,6 +35,7 @@ public:
     static CSS::Display display() { return CSS::Display { CSS::Display::Outside::Inline, CSS::Display::Inside::Flow }; }
     static Color color() { return Color::Black; }
     static CSS::FilterList backdrop_filter() { return FilterList::make_none(); }
+    static CSS::FilterList filter() { return FilterList::make_none(); }
     static Color background_color() { return Color::Transparent; }
     static CSS::ListStyleType list_style_type() { return CSS::ListStyleType::Disc; }
     static CSS::Visibility visibility() { return CSS::Visibility::Visible; }
@@ -173,6 +174,7 @@ public:
     CSS::ImageRendering image_rendering() const { return m_inherited.image_rendering; }
     CSS::JustifyContent justify_content() const { return m_noninherited.justify_content; }
     CSS::FilterList const& backdrop_filter() const { return m_noninherited.backdrop_filter; }
+    CSS::FilterList const& filter() const { return m_noninherited.filter; }
     Vector<ShadowData> const& box_shadow() const { return m_noninherited.box_shadow; }
     CSS::BoxSizing box_sizing() const { return m_noninherited.box_sizing; }
     CSS::Size const& width() const { return m_noninherited.width; }
@@ -274,6 +276,7 @@ protected:
         CSS::LengthBox margin { InitialValues::margin() };
         CSS::LengthBox padding { InitialValues::padding() };
         CSS::FilterList backdrop_filter { InitialValues::backdrop_filter() };
+        CSS::FilterList filter { InitialValues::filter() };
         BorderData border_left;
         BorderData border_top;
         BorderData border_right;
@@ -356,6 +359,7 @@ public:
     void set_list_style_type(CSS::ListStyleType value) { m_inherited.list_style_type = value; }
     void set_display(CSS::Display value) { m_noninherited.display = value; }
     void set_backdrop_filter(CSS::FilterList backdrop_filter) { m_noninherited.backdrop_filter = move(backdrop_filter); }
+    void set_filter(CSS::FilterList filter) { m_noninherited.filter = move(filter); }
     void set_border_bottom_left_radius(CSS::BorderRadiusData value) { m_noninherited.border_bottom_left_radius = move(value); }
     void set_border_bottom_right_radius(CSS::BorderRadiusData value) { m_noninherited.border_bottom_right_radius = move(value); }
     void set_border_top_left_radius(CSS::BorderRadiusData value) { m_noninherited.border_top_left_radius = move(value); }

--- a/Userland/Libraries/LibWeb/CSS/FilterList.h
+++ b/Userland/Libraries/LibWeb/CSS/FilterList.h
@@ -11,15 +11,15 @@
 
 namespace Web::CSS {
 
-class BackdropFilter {
+class FilterList {
 public:
-    BackdropFilter() = default;
-    BackdropFilter(FilterValueListStyleValue const& filter_value_list)
+    FilterList() = default;
+    FilterList(FilterValueListStyleValue const& filter_value_list)
         : m_filter_value_list { filter_value_list } {};
 
-    static inline BackdropFilter make_none()
+    static inline FilterList make_none()
     {
-        return BackdropFilter {};
+        return FilterList {};
     }
 
     bool has_filters() const { return m_filter_value_list; }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5779,6 +5779,10 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
         if (auto parsed_value = parse_content_value(component_values))
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
+    case PropertyID::Filter:
+        if (auto parsed_value = parse_filter_value_list_value(component_values))
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
     case PropertyID::Flex:
         if (auto parsed_value = parse_flex_value(component_values))
             return parsed_value.release_nonnull();

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -576,6 +576,18 @@
       "none"
     ]
   },
+  "filter": {
+    "affects-layout": false,
+    "affects-stacking-context": true,
+    "inherited": false,
+    "initial": "none",
+    "valid-types": [
+      "filter-value-list"
+    ],
+    "valid-identifiers": [
+      "none"
+    ]
+  },
   "flex": {
     "inherited": false,
     "initial": "0 1 auto",

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -397,12 +397,12 @@ Optional<CSS::Appearance> StyleProperties::appearance() const
     return appearance;
 }
 
-CSS::BackdropFilter StyleProperties::backdrop_filter() const
+CSS::FilterList StyleProperties::backdrop_filter() const
 {
     auto value = property(CSS::PropertyID::BackdropFilter);
     if (value->is_filter_value_list())
-        return BackdropFilter(value->as_filter_value_list());
-    return BackdropFilter::make_none();
+        return FilterList(value->as_filter_value_list());
+    return FilterList::make_none();
 }
 
 Optional<CSS::Position> StyleProperties::position() const

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -405,6 +405,14 @@ CSS::FilterList StyleProperties::backdrop_filter() const
     return FilterList::make_none();
 }
 
+CSS::FilterList StyleProperties::filter() const
+{
+    auto value = property(CSS::PropertyID::Filter);
+    if (value->is_filter_value_list())
+        return FilterList(value->as_filter_value_list());
+    return FilterList::make_none();
+}
+
 Optional<CSS::Position> StyleProperties::position() const
 {
     auto value = property(CSS::PropertyID::Position);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -72,7 +72,7 @@ public:
     Optional<CSS::AlignItems> align_items() const;
     Optional<CSS::AlignSelf> align_self() const;
     Optional<CSS::Appearance> appearance() const;
-    CSS::BackdropFilter backdrop_filter() const;
+    CSS::FilterList backdrop_filter() const;
     float opacity() const;
     Optional<CSS::Visibility> visibility() const;
     Optional<CSS::ImageRendering> image_rendering() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -73,6 +73,7 @@ public:
     Optional<CSS::AlignSelf> align_self() const;
     Optional<CSS::Appearance> appearance() const;
     CSS::FilterList backdrop_filter() const;
+    CSS::FilterList filter() const;
     float opacity() const;
     Optional<CSS::Visibility> visibility() const;
     Optional<CSS::ImageRendering> image_rendering() const;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -117,6 +117,11 @@ bool Node::establishes_stacking_context() const
     if (parent() && parent()->display().is_grid_inside() && computed_values().z_index().has_value())
         return true;
 
+    // https://drafts.fxtf.org/filter-effects/#FilterProperty
+    // A computed value of other than none results in the creation of a stacking context [CSS21] the same way that CSS opacity does.
+    if (!computed_values().filter().is_none())
+        return true;
+
     // https://drafts.fxtf.org/filter-effects-2/#backdrop-filter-operation
     // A computed value of other than none results in the creation of both a stacking context [CSS21] and a Containing Block for absolute and fixed position descendants,
     // unless the element it applies to is a document root element in the current browsing context.

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -417,6 +417,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     computed_values.set_order(computed_style.order());
     computed_values.set_clip(computed_style.clip());
     computed_values.set_backdrop_filter(computed_style.backdrop_filter());
+    computed_values.set_filter(computed_style.filter());
 
     auto justify_content = computed_style.justify_content();
     if (justify_content.has_value())

--- a/Userland/Libraries/LibWeb/Painting/FilterPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/FilterPainting.cpp
@@ -98,7 +98,7 @@ void apply_filter_list(Gfx::Bitmap& target_bitmap, Layout::Node const& node, Spa
     }
 }
 
-void apply_backdrop_filter(PaintContext& context, Layout::Node const& node, Gfx::FloatRect const& backdrop_rect, BorderRadiiData const& border_radii_data, CSS::BackdropFilter const& backdrop_filter)
+void apply_backdrop_filter(PaintContext& context, Layout::Node const& node, Gfx::FloatRect const& backdrop_rect, BorderRadiiData const& border_radii_data, CSS::FilterList const& backdrop_filter)
 {
     // This performs the backdrop filter operation: https://drafts.fxtf.org/filter-effects-2/#backdrop-filter-operation
 

--- a/Userland/Libraries/LibWeb/Painting/FilterPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/FilterPainting.h
@@ -15,5 +15,6 @@ namespace Web::Painting {
 void apply_filter_list(Gfx::Bitmap& target_bitmap, Layout::Node const& node, Span<CSS::FilterFunction const> filter_list);
 
 void apply_backdrop_filter(PaintContext&, Layout::Node const&, Gfx::FloatRect const&, BorderRadiiData const&, CSS::FilterList const&);
+void apply_filter(PaintContext&, Layout::Node const&, Gfx::FloatRect const&, BorderRadiiData const&, CSS::FilterList const&);
 
 }

--- a/Userland/Libraries/LibWeb/Painting/FilterPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/FilterPainting.h
@@ -7,13 +7,13 @@
 #pragma once
 
 #include <LibGfx/Forward.h>
-#include <LibWeb/CSS/BackdropFilter.h>
+#include <LibWeb/CSS/FilterList.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Painting {
 
 void apply_filter_list(Gfx::Bitmap& target_bitmap, Layout::Node const& node, Span<CSS::FilterFunction const> filter_list);
 
-void apply_backdrop_filter(PaintContext&, Layout::Node const&, Gfx::FloatRect const&, BorderRadiiData const&, CSS::BackdropFilter const&);
+void apply_backdrop_filter(PaintContext&, Layout::Node const&, Gfx::FloatRect const&, BorderRadiiData const&, CSS::FilterList const&);
 
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -167,6 +167,15 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
         paint_border(context);
     }
 
+    if (phase == PaintPhase::Overlay) {
+        // https://drafts.fxtf.org/filter-effects-1/#FilterProperty
+        // Conceptually, any parts of the drawing are effected by filter operations.
+        // This includes any content, background, borders, text decoration, outline and visible scrolling mechanism of the element to which the filter is applied,
+        // and those of its descendants. The filter operations are applied in the element’s local coordinate system.
+        // The compositing model follows the SVG compositing model [SVG11]: first any filter effect is applied, then any clipping, masking and opacity.
+        paint_filter(context);
+    }
+
     if (phase == PaintPhase::Overlay && should_clip_rect)
         context.painter().restore();
 
@@ -235,6 +244,13 @@ void PaintableBox::paint_backdrop_filter(PaintContext& context) const
     auto& backdrop_filter = computed_values().backdrop_filter();
     if (!backdrop_filter.is_none())
         Painting::apply_backdrop_filter(context, layout_node(), absolute_border_box_rect(), normalized_border_radii_data(), backdrop_filter);
+}
+
+void PaintableBox::paint_filter(PaintContext& context) const
+{
+    auto& filter = computed_values().filter();
+    if (!filter.is_none())
+        Painting::apply_filter(context, layout_node(), absolute_border_box_rect(), normalized_border_radii_data(), filter);
 }
 
 void PaintableBox::paint_background(PaintContext& context) const

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -124,6 +124,7 @@ protected:
 
     virtual void paint_border(PaintContext&) const;
     virtual void paint_backdrop_filter(PaintContext&) const;
+    virtual void paint_filter(PaintContext&) const;
     virtual void paint_background(PaintContext&) const;
     virtual void paint_box_shadow(PaintContext&) const;
 


### PR DESCRIPTION
This is a bit ad-hoc due to the spec not saying how to apply filters.
It's essentially doing the same operation as backdrop-filter, minus the
comments, backdrop root and transform requirements. The main issue
currently is that blur does not correctly draw outside of the box,
which is especially noticeable with border-radius.

Firefox:
![image](https://user-images.githubusercontent.com/25595356/197871451-5a8c44a7-910b-4ddb-920a-bbff2825cc67.png)

Ladybird:
![image](https://user-images.githubusercontent.com/25595356/197871559-d62880d5-bba7-4699-b6cb-04417a7fb7cb.png)
There are some layout issues in this image, but they are unrelated to the filter property.