### PR TITLE
TextEditor: Comment out the current line

### DIFF
--- a/Userland/Libraries/LibCpp/SemanticSyntaxHighlighter.h
+++ b/Userland/Libraries/LibCpp/SemanticSyntaxHighlighter.h
@@ -25,6 +25,9 @@ public:
     virtual bool is_navigatable(u64 token) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::Cpp; }
+    virtual Optional<StringView> comment_prefix() const override { return "//"sv; }
+    virtual Optional<StringView> comment_suffix() const override { return {}; }
+
     virtual void rehighlight(Palette const&) override;
 
     void update_tokens_info(Vector<CodeComprehension::TokenInfo>);

--- a/Userland/Libraries/LibCpp/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibCpp/SyntaxHighlighter.h
@@ -23,6 +23,8 @@ public:
     virtual bool is_navigatable(u64) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::Cpp; }
+    virtual Optional<StringView> comment_prefix() const override { return "//"sv; }
+    virtual Optional<StringView> comment_suffix() const override { return {}; }
     virtual void rehighlight(Palette const&) override;
 
 protected:

--- a/Userland/Libraries/LibGUI/GML/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibGUI/GML/SyntaxHighlighter.h
@@ -19,6 +19,8 @@ public:
     virtual bool is_identifier(u64) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::GML; }
+    virtual Optional<StringView> comment_prefix() const override { return {}; }
+    virtual Optional<StringView> comment_suffix() const override { return {}; }
     virtual void rehighlight(Palette const&) override;
 
 protected:

--- a/Userland/Libraries/LibGUI/GitCommitSyntaxHighlighter.h
+++ b/Userland/Libraries/LibGUI/GitCommitSyntaxHighlighter.h
@@ -17,6 +17,8 @@ public:
     virtual ~GitCommitSyntaxHighlighter() override = default;
 
     virtual Syntax::Language language() const override { return Syntax::Language::GitCommit; }
+    virtual Optional<StringView> comment_prefix() const override { return {}; }
+    virtual Optional<StringView> comment_suffix() const override { return {}; }
     virtual void rehighlight(Palette const&) override;
 
 protected:

--- a/Userland/Libraries/LibGUI/INISyntaxHighlighter.h
+++ b/Userland/Libraries/LibGUI/INISyntaxHighlighter.h
@@ -19,6 +19,8 @@ public:
     virtual bool is_identifier(u64) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::INI; }
+    virtual Optional<StringView> comment_prefix() const override { return ";"sv; }
+    virtual Optional<StringView> comment_suffix() const override { return {}; }
     virtual void rehighlight(Palette const&) override;
 
 protected:

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -246,6 +246,19 @@ void TextDocumentLine::remove_range(TextDocument& document, size_t start, size_t
     document.update_views({});
 }
 
+void TextDocumentLine::keep_range(TextDocument& document, size_t start_index, size_t length)
+{
+    VERIFY(start_index + length < m_text.size());
+
+    Vector<u32> new_data;
+    new_data.ensure_capacity(m_text.size());
+    for (size_t i = start_index; i <= (start_index + length); i++)
+        new_data.append(m_text[i]);
+
+    m_text = move(new_data);
+    document.update_views({});
+}
+
 void TextDocumentLine::truncate(TextDocument& document, size_t length)
 {
     m_text.resize(length);

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -288,4 +288,30 @@ private:
     TextRange m_range;
 };
 
+class CommentSelection : public TextDocumentUndoCommand {
+public:
+    CommentSelection(TextDocument&, StringView, StringView, TextRange const&);
+    virtual void undo() override;
+    virtual void redo() override;
+    TextRange const& range() const { return m_range; }
+
+private:
+    StringView m_prefix;
+    StringView m_suffix;
+    TextRange m_range;
+};
+
+class UncommentSelection : public TextDocumentUndoCommand {
+public:
+    UncommentSelection(TextDocument&, StringView, StringView, TextRange const&);
+    virtual void undo() override;
+    virtual void redo() override;
+    TextRange const& range() const { return m_range; }
+
+private:
+    StringView m_prefix;
+    StringView m_suffix;
+    TextRange m_range;
+};
+
 }

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -179,6 +179,7 @@ public:
     void truncate(TextDocument&, size_t length);
     void clear(TextDocument&);
     void remove_range(TextDocument&, size_t start, size_t length);
+    void keep_range(TextDocument&, size_t start_index, size_t end_index);
 
     size_t first_non_whitespace_column() const;
     Optional<size_t> last_non_whitespace_column() const;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1003,6 +1003,30 @@ void TextEditor::keydown_event(KeyEvent& event)
         return;
     }
 
+    if (event.ctrl() && event.key() == KeyCode::Key_Slash) {
+        if (m_highlighter != nullptr) {
+            auto prefix = m_highlighter->comment_prefix().value_or(""sv);
+            auto suffix = m_highlighter->comment_suffix().value_or(""sv);
+            auto range = has_selection() ? selection() : TextRange { { m_cursor.line(), m_cursor.column() }, { m_cursor.line(), m_cursor.column() } };
+
+            auto is_already_commented = true;
+            for (size_t i = range.start().line(); i <= range.end().line(); i++) {
+                auto text = m_document->line(i).to_utf8().trim_whitespace();
+                if (!(text.starts_with(prefix) && text.ends_with(suffix))) {
+                    is_already_commented = false;
+                    break;
+                }
+            }
+
+            if (is_already_commented)
+                execute<UncommentSelection>(prefix, suffix, range);
+            else
+                execute<CommentSelection>(prefix, suffix, range);
+
+            return;
+        }
+    }
+
     event.ignore();
 }
 

--- a/Userland/Libraries/LibJS/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibJS/SyntaxHighlighter.h
@@ -19,6 +19,8 @@ public:
     virtual bool is_navigatable(u64) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::JavaScript; }
+    virtual Optional<StringView> comment_prefix() const override { return "//"sv; }
+    virtual Optional<StringView> comment_suffix() const override { return {}; }
     virtual void rehighlight(Palette const&) override;
 
 protected:

--- a/Userland/Libraries/LibSQL/AST/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibSQL/AST/SyntaxHighlighter.h
@@ -19,6 +19,9 @@ public:
     virtual bool is_identifier(u64) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::SQL; }
+    virtual Optional<StringView> comment_prefix() const override { return "--"sv; }
+    virtual Optional<StringView> comment_suffix() const override { return {}; }
+
     virtual void rehighlight(Palette const&) override;
 
 protected:

--- a/Userland/Libraries/LibSyntax/Highlighter.h
+++ b/Userland/Libraries/LibSyntax/Highlighter.h
@@ -41,6 +41,8 @@ public:
 
     virtual Language language() const = 0;
     StringView language_string(Language) const;
+    virtual Optional<StringView> comment_prefix() const = 0;
+    virtual Optional<StringView> comment_suffix() const = 0;
     virtual void rehighlight(Palette const&) = 0;
     virtual void highlight_matching_token_pair();
 

--- a/Userland/Libraries/LibWeb/CSS/SyntaxHighlighter/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibWeb/CSS/SyntaxHighlighter/SyntaxHighlighter.h
@@ -19,6 +19,8 @@ public:
     virtual bool is_navigatable(u64) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::CSS; }
+    virtual Optional<StringView> comment_prefix() const override { return "/*"sv; }
+    virtual Optional<StringView> comment_suffix() const override { return "*/"sv; }
     virtual void rehighlight(Palette const&) override;
 
 protected:

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h
@@ -19,6 +19,8 @@ public:
     virtual bool is_navigatable(u64) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::HTML; }
+    virtual Optional<StringView> comment_prefix() const override { return "<!--"sv; }
+    virtual Optional<StringView> comment_suffix() const override { return "-->"sv; }
     virtual void rehighlight(Palette const&) override;
 
 protected:

--- a/Userland/Shell/SyntaxHighlighter.h
+++ b/Userland/Shell/SyntaxHighlighter.h
@@ -19,6 +19,8 @@ public:
     virtual bool is_navigatable(u64) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::Shell; }
+    virtual Optional<StringView> comment_prefix() const override { return "#"sv; }
+    virtual Optional<StringView> comment_suffix() const override { return {}; }
     virtual void rehighlight(Palette const&) override;
 
 protected:


### PR DESCRIPTION
Ctrl+/ is the shortcut and it behaves in the following ways:

* If there is no highlighter, do nothing.
* If there is a selection and any of the lines are uncommented, comment them all according to the given highlighter.
* If there is no selection and the line the cursor is on is uncommentd, comment it according to the given highlighter.
* If there is a selection and all of the lines are commented, uncomment them all according to the given highlighter.
* If there is no selection and the line the cursor is on is commentd, uncomment it according to the given highlighter.

I am a c++ n00b, so please feel free to suggest how to do this better!