### PR TITLE
Browser: Fix calculation of greatest child width

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -107,9 +107,6 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     auto const& computed_values = box.computed_values();
 
-    if (should_treat_width_as_auto(box, available_space) && available_space.width.is_intrinsic_sizing_constraint())
-        return;
-
     float width_of_containing_block = available_space.width.to_px();
     auto width_of_containing_block_as_length_for_resolve = available_space.width.is_definite() ? CSS::Length::make_px(width_of_containing_block) : CSS::Length::make_px(0);
 

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -132,7 +132,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
         if (!box.is_inline()) {
             // 10.3.3 Block-level, non-replaced elements in normal flow
             // If 'width' is not 'auto' and 'border-left-width' + 'padding-left' + 'width' + 'padding-right' + 'border-right-width' (plus any of 'margin-left' or 'margin-right' that are not 'auto') is larger than the width of the containing block, then any 'auto' values for 'margin-left' or 'margin-right' are, for the following rules, treated as zero.
-            if (width.is_auto() && total_px > width_of_containing_block) {
+            if (!width.is_auto() && total_px > width_of_containing_block) {
                 if (margin_left.is_auto())
                     margin_left = zero_value;
                 if (margin_right.is_auto())


### PR DESCRIPTION
The greatest child width in `BlockFormattingContext.cpp` does not account for the `min-width` of a child.

You can reproduce this issue with the following html document:
```html
<!DOCTYPE html>
<html lang="en">

<head>
  <meta charset="UTF-8">
  <meta http-equiv="X-UA-Compatible" content="IE=edge">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>Document</title>
  <style>
    .debug_here {
      display: inline-block;
      border: 1px solid red;
    }

    .AvatarStack {
      min-width: 26px;
      min-height: 50px;
    }

    .AvatarStack .AvatarStack-body {
      position: absolute;
      width: 24px;
      height: 24px;
      opacity: 0.3;
      background: red;
    }

    .text {
      display: inline-block;
    }
  </style>
</head>

<body>
  <div class="debug_here">
    <div class="AvatarStack">
      <div class="AvatarStack-body"></div>
    </div>
  </div>
  <div class="text"><a>awesomekling</a><a>LibJS:Only use 1 bit for Cell boolean flag</a></div>
</body>

</html>
```

If you dump the layout blocks, then you will see that `debug_here` has a width of 0px. `debug_here` should be the greatest width of it's child.