### PR TITLE
PixelPaint: Make scopes hideable

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -509,6 +509,17 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     m_show_active_layer_boundary_action->set_checked(Config::read_bool("PixelPaint"sv, "ImageEditor"sv, "ShowActiveLayerBoundary"sv, true));
     m_view_menu->add_action(*m_show_active_layer_boundary_action);
 
+    m_view_menu->add_separator();
+    auto& scopes_menu = m_view_menu->add_submenu("&Scopes");
+
+    scopes_menu.add_action(GUI::Action::create_checkable("&Histogram", [&](auto& action) {
+        m_histogram_widget->parent_widget()->set_visible(action.is_checked());
+    }));
+
+    scopes_menu.add_action(GUI::Action::create_checkable("&Vectorscope", [&](auto& action) {
+        m_vectorscope_widget->parent_widget()->set_visible(action.is_checked());
+    }));
+
     m_tool_menu = window.add_menu("&Tool");
     m_toolbox->for_each_tool([&](auto& tool) {
         if (tool.action())

--- a/Userland/Applications/PixelPaint/PixelPaintWindow.gml
+++ b/Userland/Applications/PixelPaint/PixelPaintWindow.gml
@@ -67,6 +67,7 @@
             @GUI::GroupBox {
                 title: "Histogram"
                 preferred_height: "shrink"
+                visible: false
                 layout: @GUI::VerticalBoxLayout {
                     margins: [6]
                 }
@@ -80,6 +81,7 @@
             @GUI::GroupBox {
                 title: "Vectorscope"
                 min_height: 80
+                visible: false
                 layout: @GUI::VerticalBoxLayout {
                     margins: [6]
                 }


### PR DESCRIPTION
Vectorscope and Histogram are now hidden by default. New menu "Scopes" allows for them to be toggled on/off.

![image](https://user-images.githubusercontent.com/1731714/198031335-d73bde04-a2fa-4f38-af7c-44fcf9f499af.png)
