### PR TITLE
LibWeb: Support translate3d parsing in CSS

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
@@ -78,6 +78,7 @@ namespace Web::CSS {
     generator.append(R"~~~(
 enum class TransformFunctionParameterType {
     Angle,
+    Length,
     LengthPercentage,
     Number,
 };
@@ -176,6 +177,8 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
             StringView parameter_type = ""sv;
             if (parameter_type_name == "angle"sv)
                 parameter_type = "Angle"sv;
+            else if (parameter_type_name == "length"sv)
+                parameter_type = "Length"sv;
             else if (parameter_type_name == "length-percentage"sv)
                 parameter_type = "LengthPercentage"sv;
             else if (parameter_type_name == "number"sv)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5233,6 +5233,21 @@ RefPtr<StyleValue> Parser::parse_transform_value(Vector<ComponentValue> const& c
                 }
                 break;
             }
+            case TransformFunctionParameterType::Length: {
+                if (maybe_calc_value && maybe_calc_value->resolves_to_length()) {
+                    values.append(LengthStyleValue::create(Length::make_calculated(maybe_calc_value.release_nonnull())));
+                } else {
+                    auto dimension_value = parse_dimension_value(value);
+                    if (!dimension_value)
+                        return nullptr;
+
+                    if (dimension_value->is_length())
+                        values.append(dimension_value.release_nonnull());
+                    else
+                        return nullptr;
+                }
+                break;
+            }
             case TransformFunctionParameterType::LengthPercentage: {
                 if (maybe_calc_value && maybe_calc_value->resolves_to_length()) {
                     values.append(LengthStyleValue::create(Length::make_calculated(maybe_calc_value.release_nonnull())));

--- a/Userland/Libraries/LibWeb/CSS/TransformFunctions.json
+++ b/Userland/Libraries/LibWeb/CSS/TransformFunctions.json
@@ -35,6 +35,13 @@
             { "type": "<length-percentage>", "required": false }
         ]
     },
+    "translate3d": {
+        "parameters": [
+            { "type": "<length-percentage>", "required": true },
+            { "type": "<length-percentage>", "required": true },
+            { "type": "<length>", "required": true }
+        ]
+    },
     "translateX": {
         "parameters": [{ "type": "<length-percentage>", "required": true }]
     },

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -209,7 +209,11 @@ Gfx::FloatMatrix4x4 StackingContext::get_transformation_matrix(CSS::Transformati
     auto value = [this, transformation](size_t index, Optional<CSS::Length const&> reference_length = {}) -> float {
         return transformation.values[index].visit(
             [this, reference_length](CSS::LengthPercentage const& value) {
-                return value.resolved(m_box, reference_length.value()).to_px(m_box);
+                if (reference_length.has_value()) {
+                    return value.resolved(m_box, reference_length.value()).to_px(m_box);
+                }
+
+                return value.length().to_px(m_box);
             },
             [](CSS::Angle const& value) {
                 return value.to_degrees() * static_cast<float>(M_DEG2RAD);
@@ -249,6 +253,12 @@ Gfx::FloatMatrix4x4 StackingContext::get_transformation_matrix(CSS::Transformati
                 0, 1, 0, value(1, height),
                 0, 0, 1, 0,
                 0, 0, 0, 1);
+        break;
+    case CSS::TransformFunction::Translate3d:
+        return Gfx::FloatMatrix4x4(1, 0, 0, value(0, width),
+            0, 1, 0, value(1, height),
+            0, 0, 1, value(2),
+            0, 0, 0, 1);
         break;
     case CSS::TransformFunction::TranslateX:
         if (count == 1)


### PR DESCRIPTION
Current format of [TransformFunctions.json](https://github.com/SerenityOS/serenity/blob/master/Userland/Libraries/LibWeb/CSS/TransformFunctions.json) doesn't seem to allow to define functions like [translate3d](https://w3c.github.io/csswg-drafts/css-transforms-2/#funcdef-translate3d)  and [rotate3d](https://w3c.github.io/csswg-drafts/css-transforms-2/#funcdef-rotate3d) which doesn't have the same type for all parameters. In this patch I want to make TransformFunctions.json format more verbose to allow to specify type for each parameter position individually.

I am bit not happy that the format I introduced here allows to define optional parameter in the middle of required parameters but maybe it's ok for now.

UPD: added support for translate3d function