### PR TITLE
LibGfx: Make formatting of spatial types work with non-int/floats

### DIFF
--- a/Userland/Libraries/LibGfx/Line.h
+++ b/Userland/Libraries/LibGfx/Line.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Format.h>
 #include <AK/Optional.h>
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
@@ -151,5 +152,17 @@ inline String FloatLine::to_string() const
 {
     return String::formatted("[{},{} {}x{}]", m_a.x(), m_a.y(), m_b.x(), m_b.y());
 }
+
+}
+
+namespace AK {
+
+template<typename T>
+struct Formatter<Gfx::Line<T>> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Gfx::Line<T> const& value)
+    {
+        return Formatter<FormatString>::format(builder, "[{},{} -> {},{}]"sv, value.a().x(), value.a().y(), value.b().x(), value.b().y());
+    }
+};
 
 }

--- a/Userland/Libraries/LibGfx/Line.h
+++ b/Userland/Libraries/LibGfx/Line.h
@@ -144,13 +144,13 @@ private:
 template<>
 inline String IntLine::to_string() const
 {
-    return String::formatted("[{},{} -> {}x{}]", m_a.x(), m_a.y(), m_b.x(), m_b.y());
+    return String::formatted("[{},{} -> {},{}]", m_a.x(), m_a.y(), m_b.x(), m_b.y());
 }
 
 template<>
 inline String FloatLine::to_string() const
 {
-    return String::formatted("[{},{} {}x{}]", m_a.x(), m_a.y(), m_b.x(), m_b.y());
+    return String::formatted("[{},{} -> {},{}]", m_a.x(), m_a.y(), m_b.x(), m_b.y());
 }
 
 }

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -285,10 +285,10 @@ inline Point<T> cubic_interpolate(Point<T> const& p1, Point<T> const& p2, Point<
 namespace AK {
 
 template<typename T>
-struct Formatter<Gfx::Point<T>> : Formatter<StringView> {
+struct Formatter<Gfx::Point<T>> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Gfx::Point<T> const& value)
     {
-        return Formatter<StringView>::format(builder, value.to_string());
+        return Formatter<FormatString>::format(builder, "[{},{}]"sv, value.x(), value.y());
     }
 };
 

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -1026,10 +1026,10 @@ using FloatRect = Rect<float>;
 namespace AK {
 
 template<typename T>
-struct Formatter<Gfx::Rect<T>> : Formatter<StringView> {
+struct Formatter<Gfx::Rect<T>> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Gfx::Rect<T> const& value)
     {
-        return Formatter<StringView>::format(builder, value.to_string());
+        return Formatter<FormatString>::format(builder, "[{},{} {}x{}]"sv, value.x(), value.y(), value.width(), value.height());
     }
 };
 

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -183,10 +183,10 @@ using FloatSize = Size<float>;
 namespace AK {
 
 template<typename T>
-struct Formatter<Gfx::Size<T>> : Formatter<StringView> {
+struct Formatter<Gfx::Size<T>> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Gfx::Size<T> const& value)
     {
-        return Formatter<StringView>::format(builder, value.to_string());
+        return Formatter<FormatString>::format(builder, "[{}x{}]"sv, value.width(), value.height());
     }
 };
 


### PR DESCRIPTION
Line, Point, Rect, and Size now all have Formatters that will work with any type that itself has a Formatter.