### PR TITLE
Shell+LibLine: Avoid crashing on a 0x0 terminal

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -201,8 +201,7 @@ Editor::~Editor()
 void Editor::ensure_free_lines_from_origin(size_t count)
 {
     if (count > m_num_lines) {
-        // It's hopeless...
-        TODO();
+        // FIXME: Implement paging
     }
 
     if (m_origin_row + count <= m_num_lines)
@@ -2174,12 +2173,14 @@ size_t StringMetrics::lines_with_addition(StringMetrics const& offset, size_t co
 {
     size_t lines = 0;
 
-    for (size_t i = 0; i < line_metrics.size() - 1; ++i)
-        lines += (line_metrics[i].total_length() + column_width) / column_width;
+    if (!line_metrics.is_empty()) {
+        for (size_t i = 0; i < line_metrics.size() - 1; ++i)
+            lines += (line_metrics[i].total_length() + column_width) / column_width;
 
-    auto last = line_metrics.last().total_length();
-    last += offset.line_metrics.first().total_length();
-    lines += (last + column_width) / column_width;
+        auto last = line_metrics.last().total_length();
+        last += offset.line_metrics.first().total_length();
+        lines += (last + column_width) / column_width;
+    }
 
     for (size_t i = 1; i < offset.line_metrics.size(); ++i)
         lines += (offset.line_metrics[i].total_length() + column_width) / column_width;
@@ -2192,9 +2193,16 @@ size_t StringMetrics::offset_with_addition(StringMetrics const& offset, size_t c
     if (offset.line_metrics.size() > 1)
         return offset.line_metrics.last().total_length() % column_width;
 
-    auto last = line_metrics.last().total_length();
-    last += offset.line_metrics.first().total_length();
-    return last % column_width;
+    if (!line_metrics.is_empty()) {
+        auto last = line_metrics.last().total_length();
+        last += offset.line_metrics.first().total_length();
+        return last % column_width;
+    }
+
+    if (offset.line_metrics.is_empty())
+        return 0;
+
+    return offset.line_metrics.first().total_length() % column_width;
 }
 
 bool Editor::Spans::contains_up_to_offset(Spans const& other, size_t offset) const

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -55,6 +55,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         s_shell->setup_signals();
 
+        sigset_t blocked;
+        sigemptyset(&blocked);
+        sigaddset(&blocked, SIGTTOU);
+        sigaddset(&blocked, SIGTTIN);
+        pthread_sigmask(SIG_BLOCK, &blocked, nullptr);
+
         shell->termios = editor->termios();
         shell->default_termios = editor->default_termios();
 


### PR DESCRIPTION
Some terminals start with a 0x0 buffer, run the shell, then switch to
a normal buffer size; avoid crashing in this case.

Also downgrade the paging TODO to a FIXME, a slightly broken terminal is
okay if all you're doing is using unimplemented features such as putting
too much text into the terminal.