### PR TITLE
LibGUI: Shift+Tab unindents line

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -918,6 +918,11 @@ void TextEditor::keydown_event(KeyEvent& event)
                 indent_selection();
                 return;
             }
+        } else {
+            if (event.modifiers() == Mod_Shift) {
+                unindent_line();
+                return;
+            }
         }
     }
 
@@ -1047,6 +1052,18 @@ void TextEditor::unindent_selection()
             m_selection.set_end({ selection_end.line(), selection_end.column() - current_line().leading_spaces() });
         }
         execute<UnindentSelection>(m_soft_tab_width, TextRange(selection_start, selection_end));
+    }
+}
+
+void TextEditor::unindent_line()
+{
+    if (current_line().first_non_whitespace_column() != 0) {
+        auto const unindent_size = current_line().leading_spaces() < m_soft_tab_width ? current_line().leading_spaces() : m_soft_tab_width;
+        auto const temp_column = m_cursor.column();
+
+        execute<UnindentSelection>(unindent_size, TextRange({ m_cursor.line(), 0 }, { m_cursor.line(), line(m_cursor.line()).length() }));
+
+        set_cursor({ m_cursor.line(), temp_column <= unindent_size ? 0 : temp_column - unindent_size });
     }
 }
 

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -158,6 +158,7 @@ public:
     bool is_indenting_selection();
     void indent_selection();
     void unindent_selection();
+    void unindent_line();
 
     Function<void()> on_change;
     Function<void(bool modified)> on_modified_change;


### PR DESCRIPTION
Unindent the current line if Shift+Tab is pressed and no selection is made.