### PR TITLE
LibC: Implement getpass()

### DIFF
--- a/Userland/Libraries/LibC/limits.h
+++ b/Userland/Libraries/LibC/limits.h
@@ -93,3 +93,5 @@
 #define LINK_MAX 4096
 
 #define TZNAME_MAX 64
+
+#define PASS_MAX 128


### PR DESCRIPTION
This function is a deprecated POSIX function which prints a prompt and receives a password from the user, not echoing back to the terminal.