### PR TITLE
LibELF: Eliminate non-absolute file paths from the DynamicLoader

### DIFF
--- a/Userland/DynamicLoader/main.cpp
+++ b/Userland/DynamicLoader/main.cpp
@@ -83,21 +83,21 @@ void _entry(int argc, char** argv, char** envp)
     init_libc();
 
     int main_program_fd = -1;
-    String main_program_name;
+    String main_program_path;
     bool is_secure = false;
     for (; auxvp->a_type != AT_NULL; ++auxvp) {
         if (auxvp->a_type == ELF::AuxiliaryValue::ExecFileDescriptor) {
             main_program_fd = auxvp->a_un.a_val;
         }
         if (auxvp->a_type == ELF::AuxiliaryValue::ExecFilename) {
-            main_program_name = (char const*)auxvp->a_un.a_ptr;
+            main_program_path = (char const*)auxvp->a_un.a_ptr;
         }
         if (auxvp->a_type == ELF::AuxiliaryValue::Secure) {
             is_secure = auxvp->a_un.a_val == 1;
         }
     }
 
-    if (main_program_name == "/usr/lib/Loader.so"sv) {
+    if (main_program_path == "/usr/lib/Loader.so"sv) {
         // We've been invoked directly as an executable rather than as the
         // ELF interpreter for some other binary. In the future we may want
         // to support launching a program directly from the dynamic loader
@@ -107,9 +107,9 @@ void _entry(int argc, char** argv, char** envp)
     }
 
     VERIFY(main_program_fd >= 0);
-    VERIFY(!main_program_name.is_empty());
+    VERIFY(!main_program_path.is_empty());
 
-    ELF::DynamicLinker::linker_main(move(main_program_name), main_program_fd, is_secure, argc, argv, envp);
+    ELF::DynamicLinker::linker_main(move(main_program_path), main_program_fd, is_secure, argc, argv, envp);
     VERIFY_NOT_REACHED();
 }
 }

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -139,7 +139,7 @@ static Optional<String> resolve_library(String const& name, DynamicObject const&
     return {};
 }
 
-static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> map_library(String const& name, DynamicObject const& parent_object)
+static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> resolve_and_map_library(String const& name, DynamicObject const& parent_object)
 {
     if (name.contains("/"sv)) {
         int fd = open(name.characters(), O_RDONLY);
@@ -183,7 +183,7 @@ static Result<void, DlErrorMessage> map_dependencies(String const& name)
         String library_name = get_library_name(needed_name);
 
         if (!s_loaders.contains(library_name) && !s_global_objects.contains(library_name)) {
-            auto result1 = map_library(needed_name, parent_object);
+            auto result1 = resolve_and_map_library(needed_name, parent_object);
             if (result1.is_error()) {
                 return result1.error();
             }
@@ -476,7 +476,7 @@ static Result<void*, DlErrorMessage> __dlopen(char const* filename, int flags)
 
     auto const& parent_object = **s_global_objects.get(get_library_name(s_main_program_path));
 
-    auto result1 = map_library(filename, parent_object);
+    auto result1 = resolve_and_map_library(filename, parent_object);
     if (result1.is_error()) {
         return result1.error();
     }

--- a/Userland/Libraries/LibELF/DynamicLinker.h
+++ b/Userland/Libraries/LibELF/DynamicLinker.h
@@ -15,7 +15,7 @@ namespace ELF {
 class DynamicLinker {
 public:
     static Optional<DynamicObject::SymbolLookupResult> lookup_global_symbol(StringView symbol);
-    [[noreturn]] static void linker_main(String&& main_program_name, int fd, bool is_secure, int argc, char** argv, char** envp);
+    [[noreturn]] static void linker_main(String&& main_program_path, int fd, bool is_secure, int argc, char** argv, char** envp);
 
 private:
     DynamicLinker() = delete;

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -37,7 +37,7 @@ static void* mmap_with_name(void* addr, size_t length, int prot, int flags, int 
 
 namespace ELF {
 
-Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> DynamicLoader::try_create(int fd, String filename, String filepath)
+Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> DynamicLoader::try_create(int fd, String filepath)
 {
     VERIFY(filepath.starts_with('/'));
 
@@ -49,7 +49,7 @@ Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> DynamicLoader::try_create(i
     VERIFY(stat.st_size >= 0);
     auto size = static_cast<size_t>(stat.st_size);
     if (size < sizeof(ElfW(Ehdr)))
-        return DlErrorMessage { String::formatted("File {} has invalid ELF header", filename) };
+        return DlErrorMessage { String::formatted("File {} has invalid ELF header", filepath) };
 
     String file_mmap_name = String::formatted("ELF_DYN: {}", filepath);
     auto* data = mmap_with_name(nullptr, size, PROT_READ, MAP_SHARED, fd, 0, file_mmap_name.characters());
@@ -57,15 +57,14 @@ Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> DynamicLoader::try_create(i
         return DlErrorMessage { "DynamicLoader::try_create mmap" };
     }
 
-    auto loader = adopt_ref(*new DynamicLoader(fd, move(filename), data, size, filepath));
+    auto loader = adopt_ref(*new DynamicLoader(fd, move(filepath), data, size));
     if (!loader->is_valid())
         return DlErrorMessage { "ELF image validation failed" };
     return loader;
 }
 
-DynamicLoader::DynamicLoader(int fd, String filename, void* data, size_t size, String filepath)
-    : m_filename(move(filename))
-    , m_filepath(move(filepath))
+DynamicLoader::DynamicLoader(int fd, String filepath, void* data, size_t size)
+    : m_filepath(move(filepath))
     , m_file_size(size)
     , m_image_fd(fd)
     , m_file_data(data)
@@ -75,7 +74,7 @@ DynamicLoader::DynamicLoader(int fd, String filename, void* data, size_t size, S
     if (m_valid)
         find_tls_size_and_alignment();
     else
-        dbgln("Image validation failed for file {}", m_filename);
+        dbgln("Image validation failed for file {}", m_filepath);
 }
 
 DynamicLoader::~DynamicLoader()
@@ -204,7 +203,7 @@ void DynamicLoader::do_main_relocations()
     auto do_single_relocation = [&](const ELF::DynamicObject::Relocation& relocation) {
         switch (do_relocation(relocation, ShouldInitializeWeak::No)) {
         case RelocationResult::Failed:
-            dbgln("Loader.so: {} unresolved symbol '{}'", m_filename, relocation.symbol().name());
+            dbgln("Loader.so: {} unresolved symbol '{}'", m_filepath, relocation.symbol().name());
             VERIFY_NOT_REACHED();
         case RelocationResult::ResolveLater:
             m_unresolved_relocations.append(relocation);
@@ -264,7 +263,7 @@ void DynamicLoader::do_lazy_relocations()
 {
     for (auto const& relocation : m_unresolved_relocations) {
         if (auto res = do_relocation(relocation, ShouldInitializeWeak::Yes); res != RelocationResult::Success) {
-            dbgln("Loader.so: {} unresolved symbol '{}'", m_filename, relocation.symbol().name());
+            dbgln("Loader.so: {} unresolved symbol '{}'", m_filepath, relocation.symbol().name());
             VERIFY_NOT_REACHED();
         }
     }

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -39,6 +39,8 @@ namespace ELF {
 
 Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> DynamicLoader::try_create(int fd, String filename, String filepath)
 {
+    VERIFY(filepath.starts_with('/'));
+
     struct stat stat;
     if (fstat(fd, &stat) < 0) {
         return DlErrorMessage { "DynamicLoader::try_create fstat" };

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -42,10 +42,10 @@ enum class ShouldInitializeWeak {
 
 class DynamicLoader : public RefCounted<DynamicLoader> {
 public:
-    static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> try_create(int fd, String filename, String filepath);
+    static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> try_create(int fd, String filepath);
     ~DynamicLoader();
 
-    String const& filename() const { return m_filename; }
+    String const& filepath() const { return m_filepath; }
 
     bool is_valid() const { return m_valid; }
 
@@ -87,7 +87,7 @@ public:
     bool is_fully_initialized() const { return m_fully_initialized; }
 
 private:
-    DynamicLoader(int fd, String filename, void* file_data, size_t file_size, String filepath);
+    DynamicLoader(int fd, String filepath, void* file_data, size_t file_size);
 
     class ProgramHeaderRegion {
     public:
@@ -137,7 +137,6 @@ private:
     void do_relr_relocations();
     void find_tls_size_and_alignment();
 
-    String m_filename;
     String m_filepath;
     size_t m_file_size { 0 };
     int m_image_fd { -1 };

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
@@ -232,7 +233,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath"));
 
-    StringView path {};
+    String path {};
     static bool display_all = false;
     static bool display_elf_header = false;
     static bool display_program_headers = false;
@@ -287,6 +288,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         display_symbol_table = true;
         display_hardening = true;
     }
+
+    path = LexicalPath::absolute_path(TRY(Core::System::getcwd()), path);
 
     auto file_or_error = Core::MappedFile::map(path);
 

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -339,7 +339,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         int fd = TRY(Core::System::open(path, O_RDONLY));
-        auto result = ELF::DynamicLoader::try_create(fd, path, path);
+        auto result = ELF::DynamicLoader::try_create(fd, path);
         if (result.is_error()) {
             outln("{}", result.error().text);
             return 1;


### PR DESCRIPTION
We were previously using a funny mix of absolute paths and only file names to keep track of what we have loaded already and where those files are coming from. This did not only lead to confusion and bugs in the past, but it also future-proofs our code in case we ever want to load two similarly named libraries from two different paths.

Now we can be sure that everything that says "path" is actually a path, and an absolute one at that. It also avoids us having to pass redundant information in case we ever have to implement more loader shenanigans (previously we had both `m_filename` and `m_filepath`, the former being the one that this PR gets rid of).

Fixes #14404.