### PR TITLE
LibThreading: Set BackgroundAction's thread name correctly

### DIFF
--- a/Userland/Libraries/LibThreading/BackgroundAction.cpp
+++ b/Userland/Libraries/LibThreading/BackgroundAction.cpp
@@ -41,8 +41,7 @@ static intptr_t background_thread_func()
 static void init()
 {
     s_all_actions = new Queue<Function<void()>>;
-    s_background_thread = &Threading::Thread::construct(background_thread_func).leak_ref();
-    s_background_thread->set_name("Background thread");
+    s_background_thread = &Threading::Thread::construct(background_thread_func, "Background Thread"sv).leak_ref();
     s_background_thread->start();
 }
 


### PR DESCRIPTION
This is a very simple fix to an issue I noticed where the background threads do not get named when they're created. Previously, init() in BackgroundAction.cpp was calling Core::Object::set_name, which does not affect the thread name displayed by the system monitor, and this changes it to pass the name to the thread constructor.