### PR TITLE
Meta: Make YCM work when the current dir is not the root of the tree

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -67,7 +67,7 @@ if gcc_path:
             continue
         serenity_flags.extend(('-isystem', include_path))
 
-database = ycm_core.CompilationDatabase(f'Build/{serenity_arch}')
+database = ycm_core.CompilationDatabase(os.path.join(DIR_OF_THIS_SCRIPT, f'Build/{serenity_arch}'))
 
 
 def is_header_file(filename):

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -115,10 +115,6 @@ def Settings(**kwargs):
     final_flags = [flag for flag in compilation_info.compiler_flags_ if not startswith_any(flag, ignored_flags)]
     final_flags.extend(serenity_flags)
 
-    with open('/tmp/x', 'w') as fp:
-        import json
-        json.dump(final_flags, fp)
-
     return {
         'flags': final_flags,
         'include_paths_relative_to_dir': DIR_OF_THIS_SCRIPT,


### PR DESCRIPTION
Previously we'd incorrectly use a relative path for the compilation database.