### PR TITLE
Base: Set PATH in text mode

### DIFF
--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -28,14 +28,14 @@ User=window
 [Shell@tty0]
 Executable=/bin/Shell
 StdIO=/dev/tty0
-Environment=TERM=xterm
+Environment=TERM=xterm PATH=/bin:/usr/bin:/usr/local/bin
 KeepAlive=true
 SystemModes=text
 
 [Shell@tty1]
 Executable=/bin/Shell
 StdIO=/dev/tty1
-Environment=TERM=xterm
+Environment=TERM=xterm PATH=/bin:/usr/bin:/usr/local/bin
 KeepAlive=true
 SystemModes=text
 


### PR DESCRIPTION
Notably, this fixes tab-completion for program names in the text mode shell.