### PR TITLE
SystemMonitor: Opening NetworkSettings from Network tab + some other tweaks

### DIFF
--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
@@ -158,4 +158,10 @@ void NetworkSettingsWidget::apply_settings()
     GUI::Process::spawn_or_show_error(window(), "/bin/NetworkServer"sv);
 }
 
+void NetworkSettingsWidget::switch_adapter(String const& adapter)
+{
+    m_adapters_combobox->set_text(adapter, GUI::AllowCallback::No);
+    on_switch_adapter(adapter);
+}
+
 }

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.h
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.h
@@ -17,6 +17,7 @@ class NetworkSettingsWidget : public GUI::SettingsWindow::Tab {
 
 public:
     virtual void apply_settings() override;
+    void switch_adapter(String const& adapter);
 
 private:
     NetworkSettingsWidget();

--- a/Userland/Applications/NetworkSettings/main.cpp
+++ b/Userland/Applications/NetworkSettings/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "NetworkSettingsWidget.h"
+#include <LibCore/ArgsParser.h>
 #include <LibGUI/MessageBox.h>
 #include <unistd.h>
 
@@ -28,6 +29,12 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     TRY(Core::System::unveil("/tmp/portal/window", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
+    String adapter;
+
+    Core::ArgsParser parser;
+    parser.add_positional_argument(adapter, "Adapter to display settings for", "adapter", Core::ArgsParser::Required::No);
+    parser.parse(args);
+
     auto app = TRY(GUI::Application::try_create(args));
 
     if (getuid() != 0) {
@@ -39,7 +46,10 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     auto app_icon = GUI::Icon::default_icon("network"sv);
     auto window = TRY(GUI::SettingsWindow::create("Network Settings", GUI::SettingsWindow::ShowDefaultsButton::No));
-    (void)TRY(window->add_tab<NetworkSettings::NetworkSettingsWidget>("Network"sv, "network"sv));
+    auto network_settings_widget = TRY(window->add_tab<NetworkSettings::NetworkSettingsWidget>("Network"sv, "network"sv));
+    if (!adapter.is_null()) {
+        network_settings_widget->switch_adapter(adapter);
+    }
     window->set_icon(app_icon.bitmap_for_size(16));
 
     window->show();

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -9,6 +9,8 @@
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/GroupBox.h>
 #include <LibGUI/JsonArrayModel.h>
+#include <LibGUI/Menu.h>
+#include <LibGUI/Process.h>
 #include <LibGUI/SortingProxyModel.h>
 #include <LibGUI/TableView.h>
 #include <LibGfx/Painter.h>
@@ -71,6 +73,25 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         net_adapters_fields.empend("bytes_out", "Bytes Out", Gfx::TextAlignment::CenterRight);
         m_adapter_model = GUI::JsonArrayModel::create("/sys/kernel/net/adapters", move(net_adapters_fields));
         m_adapter_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_adapter_model)));
+        m_adapter_context_menu = MUST(GUI::Menu::try_create());
+        m_adapter_context_menu->add_action(GUI::Action::create(
+            "Open in Network Settings...", MUST(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/network.png"sv)), [this](GUI::Action&) {
+                m_adapter_table_view->selection().for_each_index([this](GUI::ModelIndex const& index) {
+                    auto adapter_name = index.sibling_at_column(1).data().as_string();
+                    GUI::Process::spawn_or_show_error(window(), "/bin/Escalator"sv, Array { "/bin/NetworkSettings", adapter_name.characters() });
+                });
+            },
+            this));
+        m_adapter_table_view->on_context_menu_request = [this](GUI::ModelIndex const& index, GUI::ContextMenuEvent const& event) {
+            if (!index.is_valid()) {
+                return;
+            }
+            auto adapter_name = index.sibling_at_column(1).data().as_string();
+            if (adapter_name == "loop") {
+                return;
+            }
+            m_adapter_context_menu->popup(event.screen_position());
+        };
 
         auto& tcp_sockets_group_box = add<GUI::GroupBox>("TCP Sockets"sv);
         tcp_sockets_group_box.set_layout<GUI::VerticalBoxLayout>();

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.h
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.h
@@ -22,6 +22,7 @@ private:
     void update_models();
 
     RefPtr<GUI::TableView> m_adapter_table_view;
+    RefPtr<GUI::Menu> m_adapter_context_menu;
     RefPtr<GUI::TableView> m_tcp_socket_table_view;
     RefPtr<GUI::TableView> m_udp_socket_table_view;
     RefPtr<GUI::JsonArrayModel> m_adapter_model;

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -52,6 +52,7 @@ public:
         UnixSocketWriteBytes,
         IPv4SocketReadBytes,
         IPv4SocketWriteBytes,
+        Command,
         __Count
     };
 
@@ -105,6 +106,7 @@ private:
         bool kernel { false };
         String executable { "" };
         String name { "" };
+        String command { "" };
         uid_t uid { 0 };
         String state { "" };
         String user { "" };
@@ -149,6 +151,7 @@ private:
             this->kernel = other.kernel;
             this->executable = other.executable;
             this->name = other.name;
+            this->command = other.command;
             this->uid = other.uid;
             this->state = other.state;
             this->user = other.user;

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -246,6 +246,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/sys/kernel", "r"));
     TRY(Core::System::unveil("/dev", "r"));
     TRY(Core::System::unveil("/bin", "r"));
+    TRY(Core::System::unveil("/bin/Escalator", "x"));
     TRY(Core::System::unveil("/usr/lib", "r"));
 
     // This directory only exists if ports are installed


### PR DESCRIPTION
**SystemMonitor: Add Command column to ProcessModel**

This column shows full command line of a process, or empty line if an
error occures when reading it. The command is not escaped for now.

**NetworkSettings: Add command line option for opening a specific adapter**

**SystemMonitor: Add context menu for opening adapter in NetworkSettings**