### PR TITLE
LibGUI: Update buttons' text/tooltips in Action::set_text

### DIFF
--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -241,6 +241,9 @@ void Action::set_text(String text)
     if (m_text == text)
         return;
     m_text = move(text);
+    for_each_toolbar_button([&](auto& button) {
+        button.set_text_from_action();
+    });
     for_each_menu_item([&](auto& menu_item) {
         menu_item.update_from_action({});
     });

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -169,6 +169,25 @@ void Button::set_action(Action& action)
     set_checkable(action.is_checkable());
     if (action.is_checkable())
         set_checked(action.is_checked());
+    set_text_from_action();
+}
+
+static String create_tooltip_for_action(Action const& action)
+{
+    StringBuilder builder;
+    builder.append(action.text());
+    if (action.shortcut().is_valid()) {
+        builder.append(" ("sv);
+        builder.append(action.shortcut().to_string());
+        builder.append(')');
+    }
+    return builder.to_string();
+}
+
+void Button::set_text_from_action()
+{
+    set_text(action()->text());
+    set_tooltip(create_tooltip_for_action(*action()));
 }
 
 void Button::set_icon(RefPtr<Gfx::Bitmap> icon)

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -50,6 +50,7 @@ public:
     Action* action() { return m_action; }
     Action const* action() const { return m_action; }
     void set_action(Action&);
+    void set_text_from_action();
 
     virtual bool is_uncheckable() const override;
 

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -51,24 +51,12 @@ private:
         if (action.group() && action.group()->is_exclusive())
             set_exclusive(true);
         set_action(action);
-        set_tooltip(tooltip(action));
         set_focus_policy(FocusPolicy::NoFocus);
         if (action.icon())
             set_icon(action.icon());
         else
             set_text(action.text());
         set_button_style(Gfx::ButtonStyle::Coolbar);
-    }
-    String tooltip(Action const& action) const
-    {
-        StringBuilder builder;
-        builder.append(action.text());
-        if (action.shortcut().is_valid()) {
-            builder.append(" ("sv);
-            builder.append(action.shortcut().to_string());
-            builder.append(')');
-        }
-        return builder.to_string();
     }
 
     virtual void enter_event(Core::Event& event) override


### PR DESCRIPTION
This allows Actions that change based on some state to update their associated buttons' text and tooltips to match their new text. The play/pause button in SoundPlayer (and VideoPlayer if it's merged) will now change tooltips when the playback changes state, rather than always displaying "Play (Space)".