### PR TITLE
LibJS: Fix Bytecode Optimization flakiness

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -64,6 +64,8 @@ public:
     ThrowCompletionOr<void> continue_pending_unwind(Label const& resume_label);
 
     Executable const& current_executable() { return *m_current_executable; }
+    BasicBlock const& current_block() const { return *m_current_block; }
+    size_t pc() const { return m_pc ? m_pc->offset() : 0; }
 
     enum class OptimizationLevel {
         None,
@@ -99,6 +101,8 @@ private:
     Vector<UnwindInfo> m_unwind_contexts;
     Handle<Value> m_saved_exception;
     OwnPtr<JS::Interpreter> m_ast_interpreter;
+    BasicBlock const* m_current_block { nullptr };
+    InstructionStreamIterator* m_pc { nullptr };
 };
 
 extern bool g_dump_bytecode;

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -71,7 +71,7 @@ public:
         None,
         Optimize,
         __Count,
-        Default = None,
+        Default = Optimize,
     };
     static Bytecode::PassManager& optimization_pipeline(OptimizationLevel = OptimizationLevel::Default);
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -569,6 +569,12 @@ static MarkedVector<Value> argument_list_evaluation(Bytecode::Interpreter& inter
     MarkedVector<Value> argument_values { vm.heap() };
     auto arguments = interpreter.accumulator();
 
+    if (!(arguments.is_object() && is<Array>(arguments.as_object()))) {
+        dbgln("Call arguments are not an array, but: {}", arguments.to_string_without_side_effects());
+        dbgln("PC: {}[{:4x}]", interpreter.current_block().name(), interpreter.pc());
+        interpreter.current_executable().dump();
+        VERIFY_NOT_REACHED();
+    }
     auto& argument_array = arguments.as_array();
     auto array_length = argument_array.indexed_properties().array_like_size();
 

--- a/Userland/Libraries/LibJS/Bytecode/Pass/UnifySameBlocks.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/UnifySameBlocks.cpp
@@ -29,6 +29,8 @@ void UnifySameBlocks::perform(PassPipelineExecutable& executable)
                 continue;
 
             auto candidate_bytes = candidate_block->instruction_stream();
+            // FIXME: NewBigInt's value is not correctly reflected by its encoding in memory,
+            //        this will yield false negatives for blocks containing that
             if (memcmp(candidate_bytes.data(), block_bytes.data(), candidate_block->size()) == 0)
                 equal_blocks.set(&*candidate_block, &block);
         }


### PR DESCRIPTION
With this `test-js -b` seems as broken with optimizations as it is without them

Alternatively making the cfg ordered also seems to fix the issue fixed by `LibJS: Fix MergeBlocks emitting some blocks twice`,
but that seemed to me as only papering over the underlying issue.

also
Fixes #15753 
