### PR TITLE
Spreadsheet: Display both arguments of maxIf, minIf as required in help

### DIFF
--- a/Base/res/js/Spreadsheet/runtime.js
+++ b/Base/res/js/Spreadsheet/runtime.js
@@ -908,7 +908,7 @@ max.__documentation = JSON.stringify({
 
 maxIf.__documentation = JSON.stringify({
     name: "maxIf",
-    argc: 1,
+    argc: 2,
     argnames: ["condition", "numbers or cell names"],
     doc: "Calculates the largest of all numbers or cell values which evaluate to true when passed to `condition`",
     examples: {
@@ -930,7 +930,7 @@ min.__documentation = JSON.stringify({
 
 minIf.__documentation = JSON.stringify({
     name: "minIf",
-    argc: 1,
+    argc: 2,
     argnames: ["condition", "numbers or cell names"],
     doc: "Calculates the smallest of all numbers or cell values which evaluate to true when passed to `condition`",
     examples: {


### PR DESCRIPTION
Previously `condition` was shown as required and `numbers or cell names` were optional but actually both are required