### PR TITLE
CI: Ensure the manpage generation step shuts down the VM on failure

### DIFF
--- a/Base/root/generate_manpages.sh
+++ b/Base/root/generate_manpages.sh
@@ -5,7 +5,20 @@ export ARGSPARSER_EMIT_MARKDOWN=1
 # Qemu likes to start us in the middle of a line, so:
 echo
 
-rm -rf generated_manpages || exit 1
+ERROR_FILE="generate_manpages_error.log"
+rm -f "$ERROR_FILE"
+
+exit_for_error()
+{
+    if test $DO_SHUTDOWN_AFTER_GENERATE {
+        touch "$ERROR_FILE" # Ensure it exists, in case there wasn't any stderr output.
+        shutdown -n
+    } else {
+        exit 1
+    }
+}
+
+rm -rf generated_manpages 2> "$ERROR_FILE" || exit_for_error
 
 for i in ( \
             (UserspaceEmulator 1) \
@@ -36,8 +49,8 @@ for i in ( \
     filename="generated_manpages/man$i[1]/$i[0].md"
     mkdir -p "generated_manpages/man$i[1]"
     echo "Generating for $i[0] in $filename ..."
-    $i[0] --help > "$filename" || exit 1
-    echo -e "\n<!-- Auto-generated through ArgsParser -->"  >> "$filename" || exit 1
+    $i[0] --help > "$filename" 2> "$ERROR_FILE" || exit_for_error
+    echo -e "\n<!-- Auto-generated through ArgsParser -->"  >> "$filename" 2> "$ERROR_FILE" || exit_for_error
 }
 
 echo "Successful."

--- a/Meta/export-argsparser-manpages.sh
+++ b/Meta/export-argsparser-manpages.sh
@@ -54,9 +54,20 @@ export SERENITY_KERNEL_CMDLINE="graphics_subsystem_mode=off panic=shutdown syste
 ninja -C "$BUILD_DIR" -- run | sed -re 's,''c,,'
 echo
 
-echo "Extracting generated manpages ..."
 mkdir fsmount
 sudo mount -t ext2 -o loop,rw "$BUILD_DIR"/_disk_image fsmount
+
+if sudo test -f "fsmount/root/generate_manpages_error.log"; then
+    echo ":^( Generating manpages failed, error log:"
+    sudo cat fsmount/root/generate_manpages_error.log
+
+    sudo umount fsmount
+    rmdir fsmount
+
+    exit 1
+fi
+
+echo "Extracting generated manpages ..."
 # 'cp' would create the new files as root, but we don't want that.
 sudo tar -C fsmount/root/generated_manpages --create . | tar -C Base/usr/share/man/ --extract
 sudo umount fsmount

--- a/Userland/Utilities/ntpquery.cpp
+++ b/Userland/Utilities/ntpquery.cpp
@@ -93,9 +93,6 @@ static String format_ntp_timestamp(NtpTimestamp ntp_timestamp)
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio inet unix settime wpath rpath"));
-    TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
-    TRY(Core::System::unveil("/etc/timezone", "r"));
-    TRY(Core::System::unveil(nullptr, nullptr));
 
     bool adjust_time = false;
     bool set_time = false;
@@ -117,6 +114,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(verbose, "Verbose output", "verbose", 'v');
     args_parser.add_positional_argument(host, "NTP server", "host", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
+
+    TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
+    TRY(Core::System::unveil("/etc/timezone", "r"));
+    TRY(Core::System::unveil(nullptr, nullptr));
 
     if (adjust_time && set_time) {
         warnln("-a and -s are mutually exclusive");


### PR DESCRIPTION
Currently, if the script fails, it simply runs "exit 1". This exits the script, but keeps the VM running, so CI hangs until it times out.

Instead of exiting, write a failure status to an error log and shutdown. CI can then read that error log and fail the run if needed.