### PR TITLE
LibWeb: A first pass at `conic-gradient()`s

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -139,6 +139,24 @@
         .grad-double-position {
             background-image: linear-gradient(to right,red 20%, orange 20% 40%, yellow 40% 60%, green 60% 80%, blue 80%)
         }
+
+        .grad-conic-1 {
+            background-image: conic-gradient(red, orange, yellow, green, blue);
+        }
+
+        .grad-conic-2 {
+            background-image: conic-gradient(from 0.25turn at 50% 30%, #f69d3c, 10deg, #3f87a6, 350deg, #ebf8e1);
+        }
+
+        .grad-conic-3 {
+            background-image: conic-gradient(from 3.1416rad at 10% 50%, #e66465, #9198e5);
+        }
+
+        .grad-conic-4 {
+            background-image: conic-gradient(
+                red 6deg, orange 6deg 18deg, yellow 18deg 45deg,
+                green 45deg 110deg, blue 110deg 200deg, purple 200deg);
+        }
     </style>
   </head>
   <body>
@@ -179,6 +197,11 @@
     <div class="box grad-repeat-3"></div>
     <b>Double-position color stops</b><br>
     <div class="box grad-double-position"></div>
+    <b>Conic gradients</b><br>
+    <div class="box grad-conic-1"></div>
+    <div class="box grad-conic-2"></div>
+    <div class="box grad-conic-3"></div>
+    <div class="box grad-conic-4"></div>
   </body>
   <script>
     const boxes = document.querySelectorAll(".box, .rect");

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -254,6 +254,7 @@ private:
     Optional<GridMinMax> parse_min_max(Vector<ComponentValue> const&);
     Optional<GridRepeat> parse_repeat(Vector<ComponentValue> const&);
     Optional<ExplicitGridTrack> parse_track_sizing_function(ComponentValue const&);
+    Optional<PositionValue> parse_position(TokenStream<ComponentValue>&);
 
     enum class AllowedDataUrlType {
         None,

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -264,6 +264,7 @@ private:
     Optional<AK::URL> parse_url_function(ComponentValue const&, AllowedDataUrlType = AllowedDataUrlType::None);
 
     RefPtr<StyleValue> parse_linear_gradient_function(ComponentValue const&);
+    RefPtr<StyleValue> parse_conic_gradient_function(ComponentValue const&);
 
     ParseErrorOr<NonnullRefPtr<StyleValue>> parse_css_value(PropertyID, TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_css_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1976,12 +1976,17 @@ String ConicGradientStyleValue::to_string() const
     return builder.to_string();
 }
 
-void ConicGradientStyleValue::resolve_for_size(Layout::Node const&, Gfx::FloatSize const&) const
+void ConicGradientStyleValue::resolve_for_size(Layout::Node const& node, Gfx::FloatSize const& size) const
 {
+    if (!m_resolved.has_value())
+        m_resolved = ResolvedData { Painting::resolve_conic_gradient_data(node, *this), {} };
+    m_resolved->position = m_position.resolved(node, Gfx::FloatRect { { 0, 0 }, size });
 }
 
-void ConicGradientStyleValue::paint(PaintContext&, Gfx::IntRect const&, CSS::ImageRendering) const
+void ConicGradientStyleValue::paint(PaintContext& context, Gfx::IntRect const& dest_rect, CSS::ImageRendering) const
 {
+    VERIFY(m_resolved.has_value());
+    Painting::paint_conic_gradient(context, dest_rect, m_resolved->data, m_resolved->position.to_rounded<int>());
 }
 
 bool ConicGradientStyleValue::equals(StyleValue const&) const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1853,6 +1853,108 @@ void LinearGradientStyleValue::paint(PaintContext& context, Gfx::IntRect const& 
     Painting::paint_linear_gradient(context, dest_rect, m_resolved->data);
 }
 
+Gfx::FloatPoint PositionValue::resolved(Layout::Node const& node, Gfx::FloatRect const& rect) const
+{
+    // Note: A preset + a none default x/y_relative_to is impossible in the syntax (and makes little sense)
+    float x = horizontal_position.visit(
+        [&](HorizontalPreset preset) {
+            return rect.width() * [&] {
+                switch (preset) {
+                case HorizontalPreset::Left:
+                    return 0.0f;
+                case HorizontalPreset::Center:
+                    return 0.5f;
+                case HorizontalPreset::Right:
+                    return 1.0f;
+                default:
+                    VERIFY_NOT_REACHED();
+                }
+            }();
+        },
+        [&](LengthPercentage length_percentage) {
+            return length_percentage.resolved(node, Length::make_px(rect.width())).to_px(node);
+        });
+    float y = vertical_position.visit(
+        [&](VerticalPreset preset) {
+            return rect.height() * [&] {
+                switch (preset) {
+                case VerticalPreset::Top:
+                    return 0.0f;
+                case VerticalPreset::Center:
+                    return 0.5f;
+                case VerticalPreset::Bottom:
+                    return 1.0f;
+                default:
+                    VERIFY_NOT_REACHED();
+                }
+            }();
+        },
+        [&](LengthPercentage length_percentage) {
+            return length_percentage.resolved(node, Length::make_px(rect.height())).to_px(node);
+        });
+    if (x_relative_to == HorizontalEdge::Right)
+        x = rect.width() - x;
+    if (y_relative_to == VerticalEdge::Bottom)
+        y = rect.height() - y;
+    return Gfx::FloatPoint { rect.x() + x, rect.y() + y };
+}
+
+void PositionValue::serialize(StringBuilder& builder) const
+{
+    // Note: This means our serialization with simplify any with explicit edges that are just `top left`.
+    bool has_relative_edges = x_relative_to == HorizontalEdge::Right || y_relative_to == VerticalEdge::Bottom;
+    if (has_relative_edges)
+        builder.append(x_relative_to == HorizontalEdge::Left ? "left "sv : "right "sv);
+    horizontal_position.visit(
+        [&](HorizontalPreset preset) {
+            builder.append([&] {
+                switch (preset) {
+                case HorizontalPreset::Left:
+                    return "left"sv;
+                case HorizontalPreset::Center:
+                    return "center"sv;
+                case HorizontalPreset::Right:
+                    return "right"sv;
+                default:
+                    VERIFY_NOT_REACHED();
+                }
+            }());
+        },
+        [&](LengthPercentage length_percentage) {
+            builder.append(length_percentage.to_string());
+        });
+    builder.append(' ');
+    if (has_relative_edges)
+        builder.append(y_relative_to == VerticalEdge::Top ? "top "sv : "bottom "sv);
+    vertical_position.visit(
+        [&](VerticalPreset preset) {
+            builder.append([&] {
+                switch (preset) {
+                case VerticalPreset::Top:
+                    return "top"sv;
+                case VerticalPreset::Center:
+                    return "center"sv;
+                case VerticalPreset::Bottom:
+                    return "bottom"sv;
+                default:
+                    VERIFY_NOT_REACHED();
+                }
+            }());
+        },
+        [&](LengthPercentage length_percentage) {
+            builder.append(length_percentage.to_string());
+        });
+}
+
+bool PositionValue::operator==(PositionValue const& other) const
+{
+    return (
+        x_relative_to == other.x_relative_to
+        && y_relative_to == other.y_relative_to
+        && variant_equals(horizontal_position, other.horizontal_position)
+        && variant_equals(vertical_position, other.vertical_position));
+}
+
 String ConicGradientStyleValue::to_string() const
 {
     StringBuilder builder;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -96,6 +96,45 @@ struct ColorStopListElement {
 using LinearColorStopListElement = ColorStopListElement<LengthPercentage>;
 using AngularColorStopListElement = ColorStopListElement<AnglePercentage>;
 
+// FIXME: Named PositionValue to avoid conflicts with enums, but this represents a <position>
+struct PositionValue {
+    enum class HorizontalPreset {
+        Left,
+        Center,
+        Right
+    };
+
+    enum class VerticalPreset {
+        Top,
+        Center,
+        Bottom
+    };
+
+    enum class HorizontalEdge {
+        Left,
+        Right
+    };
+
+    enum class VerticalEdge {
+        Top,
+        Bottom
+    };
+
+    inline static PositionValue center()
+    {
+        return PositionValue { HorizontalPreset::Center, VerticalPreset::Center };
+    }
+
+    Variant<HorizontalPreset, LengthPercentage> horizontal_position { HorizontalPreset::Left };
+    Variant<VerticalPreset, LengthPercentage> vertical_position { VerticalPreset::Top };
+    HorizontalEdge x_relative_to { HorizontalEdge::Left };
+    VerticalEdge y_relative_to { VerticalEdge::Top };
+
+    Gfx::FloatPoint resolved(Layout::Node const&, Gfx::FloatRect const&) const;
+    void serialize(StringBuilder&) const;
+    bool operator==(PositionValue const&) const;
+};
+
 struct EdgeRect {
     Length top_edge;
     Length right_edge;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -1233,6 +1233,13 @@ private:
     Angle m_from_angle;
     PositionValue m_position;
     Vector<AngularColorStopListElement> m_color_stop_list;
+
+    struct ResolvedData {
+        Painting::ConicGradientData data;
+        Gfx::FloatPoint position;
+    };
+
+    mutable Optional<ResolvedData> m_resolved;
 };
 
 class LinearGradientStyleValue final : public AbstractImageStyleValue {

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -36,6 +36,7 @@ class BorderStyleValue;
 class Clip;
 class CalculatedStyleValue;
 class ColorStyleValue;
+class ConicGradientStyleValue;
 class ContentStyleValue;
 class CSSConditionRule;
 class CSSGroupingRule;

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -33,10 +33,8 @@ static float calulate_gradient_length(Gfx::IntSize const& gradient_size, float g
     return calulate_gradient_length(gradient_size, sin_angle, cos_angle);
 }
 
-LinearGradientData resolve_linear_gradient_data(Layout::Node const& node, Gfx::FloatSize const& gradient_size, CSS::LinearGradientStyleValue const& linear_gradient)
+static ColorStopList resolve_color_stop_positions(auto const& color_stop_list, float gradient_length, auto resolve_position_to_float)
 {
-    auto& color_stop_list = linear_gradient.color_stop_list();
-
     VERIFY(color_stop_list.size() >= 2);
     ColorStopList resolved_color_stops;
 
@@ -55,26 +53,23 @@ LinearGradientData resolve_linear_gradient_data(Layout::Node const& node, Gfx::F
             resolved_color_stops.append(resolved_stop);
     }
 
-    auto gradient_angle = linear_gradient.angle_degrees(gradient_size);
-    auto gradient_length_px = calulate_gradient_length(gradient_size.to_rounded<int>(), gradient_angle);
-    auto gradient_length = CSS::Length::make_px(gradient_length_px);
-
     // 1. If the first color stop does not have a position, set its position to 0%.
     resolved_color_stops.first().position = 0;
     //    If the last color stop does not have a position, set its position to 100%
-    resolved_color_stops.last().position = gradient_length_px;
+    resolved_color_stops.last().position = gradient_length;
 
     // 2. If a color stop or transition hint has a position that is less than the
     //    specified position of any color stop or transition hint before it in the list,
     //    set its position to be equal to the largest specified position of any color stop
     //    or transition hint before it.
     auto max_previous_color_stop_or_hint = resolved_color_stops[0].position;
-    auto resolve_stop_position = [&](auto& length_percentage) {
-        float value = length_percentage.resolved(node, gradient_length).to_px(node);
+    auto resolve_stop_position = [&](auto& position) {
+        float value = resolve_position_to_float(position);
         value = max(value, max_previous_color_stop_or_hint);
         max_previous_color_stop_or_hint = value;
         return value;
     };
+    // Move this step somewhere generic (since I think this code can be mostly reused for conic gradients)
     size_t resolved_index = 0;
     for (auto& stop : color_stop_list) {
         if (stop.transition_hint.has_value())
@@ -127,12 +122,96 @@ LinearGradientData resolve_linear_gradient_data(Layout::Node const& node, Gfx::F
         }
     }
 
+    return resolved_color_stops;
+}
+
+LinearGradientData resolve_linear_gradient_data(Layout::Node const& node, Gfx::FloatSize const& gradient_size, CSS::LinearGradientStyleValue const& linear_gradient)
+{
+    auto gradient_angle = linear_gradient.angle_degrees(gradient_size);
+    auto gradient_length_px = calulate_gradient_length(gradient_size.to_rounded<int>(), gradient_angle);
+    auto gradient_length = CSS::Length::make_px(gradient_length_px);
+
+    auto resolved_color_stops = resolve_color_stop_positions(linear_gradient.color_stop_list(), gradient_length_px, [&](auto const& length_percentage) {
+        return length_percentage.resolved(node, gradient_length).to_px(node);
+    });
+
     Optional<float> repeat_length = {};
     if (linear_gradient.is_repeating())
         repeat_length = resolved_color_stops.last().position - resolved_color_stops.first().position;
 
     return { gradient_angle, resolved_color_stops, repeat_length };
 }
+
+ConicGradientData resolve_conic_gradient_data(Layout::Node const& node, CSS::ConicGradientStyleValue const& conic_gradient)
+{
+    CSS::Angle one_turn(360.0f, CSS::Angle::Type::Deg);
+    auto resolved_color_stops = resolve_color_stop_positions(conic_gradient.color_stop_list(), one_turn.to_degrees(), [&](auto const& angle_percentage) {
+        return angle_percentage.resolved(node, one_turn).to_degrees();
+    });
+    return { conic_gradient.angle_degrees(), resolved_color_stops };
+}
+
+static float color_stop_step(ColorStop const& previous_stop, ColorStop const& next_stop, float position)
+{
+    if (position < previous_stop.position)
+        return 0;
+    if (position > next_stop.position)
+        return 1;
+    // For any given point between the two color stops,
+    // determine the point’s location as a percentage of the distance between the two color stops.
+    // Let this percentage be P.
+    auto stop_length = next_stop.position - previous_stop.position;
+    // FIXME: Avoids NaNs... Still not quite correct?
+    if (stop_length <= 0)
+        return 1;
+    auto p = (position - previous_stop.position) / stop_length;
+    if (!next_stop.transition_hint.has_value())
+        return p;
+    if (*next_stop.transition_hint >= 1)
+        return 0;
+    if (*next_stop.transition_hint <= 0)
+        return 1;
+    // Let C, the color weighting at that point, be equal to P^(logH(.5)).
+    auto c = AK::pow(p, AK::log<float>(0.5) / AK::log(*next_stop.transition_hint));
+    // The color at that point is then a linear blend between the colors of the two color stops,
+    // blending (1 - C) of the first stop and C of the second stop.
+    return c;
+}
+
+class GradientLine {
+public:
+    GradientLine(int length, int start_offset, Span<ColorStop const> color_stops)
+    {
+        m_gradient_line_colors.resize(length);
+        // Note: color.mixed_with() performs premultiplied alpha mixing when necessary as defined in:
+        // https://drafts.csswg.org/css-images/#coloring-gradient-line
+        for (int loc = 0; loc < length; loc++) {
+            Gfx::Color gradient_color = color_stops[0].color.mixed_with(
+                color_stops[1].color,
+                color_stop_step(
+                    color_stops[0],
+                    color_stops[1],
+                    loc + start_offset));
+            for (size_t i = 1; i < color_stops.size() - 1; i++) {
+                gradient_color = gradient_color.mixed_with(
+                    color_stops[i + 1].color,
+                    color_stop_step(
+                        color_stops[i],
+                        color_stops[i + 1],
+                        loc + start_offset));
+            }
+            m_gradient_line_colors[loc] = gradient_color;
+        }
+    }
+
+    Gfx::Color lookup_color(int loc) const
+    {
+        return m_gradient_line_colors[clamp(loc, 0, m_gradient_line_colors.size() - 1)];
+    }
+
+private:
+    Vector<Gfx::Color, 1024> m_gradient_line_colors;
+};
 
 void paint_linear_gradient(PaintContext& context, Gfx::IntRect const& gradient_rect, LinearGradientData const& data)
 {
@@ -151,63 +230,11 @@ void paint_linear_gradient(PaintContext& context, Gfx::IntRect const& gradient_r
     // Rotate gradient line to be horizontal
     auto rotated_start_point_x = start_point.x() * cos_angle - start_point.y() * -sin_angle;
 
-    auto color_stop_step = [&](auto& previous_stop, auto& next_stop, float position) -> float {
-        if (position < previous_stop.position)
-            return 0;
-        if (position > next_stop.position)
-            return 1;
-        // For any given point between the two color stops,
-        // determine the point’s location as a percentage of the distance between the two color stops.
-        // Let this percentage be P.
-        auto stop_length = next_stop.position - previous_stop.position;
-        // FIXME: Avoids NaNs... Still not quite correct?
-        if (stop_length <= 0)
-            return 1;
-        auto p = (position - previous_stop.position) / stop_length;
-        if (!next_stop.transition_hint.has_value())
-            return p;
-        if (*next_stop.transition_hint >= 1)
-            return 0;
-        if (*next_stop.transition_hint <= 0)
-            return 1;
-        // Let C, the color weighting at that point, be equal to P^(logH(.5)).
-        auto c = AK::pow(p, AK::log<float>(0.5) / AK::log(*next_stop.transition_hint));
-        // The color at that point is then a linear blend between the colors of the two color stops,
-        // blending (1 - C) of the first stop and C of the second stop.
-        return c;
-    };
-
-    Vector<Gfx::Color, 1024> gradient_line_colors;
     auto gradient_color_count = round_to<int>(data.repeat_length.value_or(length));
-    gradient_line_colors.resize(gradient_color_count);
     auto& color_stops = data.color_stops;
     auto start_offset = data.repeat_length.has_value() ? color_stops.first().position : 0.0f;
-    auto start_offset_int = round_to<int>(start_offset);
 
-    // Note: color.mixed_with() performs premultiplied alpha mixing when necessary as defined in:
-    // https://drafts.csswg.org/css-images/#coloring-gradient-line
-
-    for (int loc = 0; loc < gradient_color_count; loc++) {
-        Gfx::Color gradient_color = color_stops[0].color.mixed_with(
-            color_stops[1].color,
-            color_stop_step(
-                color_stops[0],
-                color_stops[1],
-                loc + start_offset_int));
-        for (size_t i = 1; i < color_stops.size() - 1; i++) {
-            gradient_color = gradient_color.mixed_with(
-                color_stops[i + 1].color,
-                color_stop_step(
-                    color_stops[i],
-                    color_stops[i + 1],
-                    loc + start_offset_int));
-        }
-        gradient_line_colors[loc] = gradient_color;
-    }
-
-    auto lookup_color = [&](int loc) {
-        return gradient_line_colors[clamp(loc, 0, gradient_color_count - 1)];
-    };
+    GradientLine gradient_line(gradient_color_count, round_to<int>(start_offset), color_stops);
 
     auto repeat_wrap_if_required = [&](float loc) {
         if (data.repeat_length.has_value())
@@ -220,7 +247,24 @@ void paint_linear_gradient(PaintContext& context, Gfx::IntRect const& gradient_r
             auto loc = repeat_wrap_if_required((x * cos_angle - (gradient_rect.height() - y) * -sin_angle) - rotated_start_point_x - start_offset);
             auto blend = loc - static_cast<int>(loc);
             // Blend between the two neighbouring colors (this fixes some nasty aliasing issues at small angles)
-            auto gradient_color = lookup_color(loc).mixed_with(lookup_color(repeat_wrap_if_required(loc + 1)), blend);
+            auto gradient_color = gradient_line.lookup_color(loc).mixed_with(gradient_line.lookup_color(repeat_wrap_if_required(loc + 1)), blend);
+            context.painter().set_pixel(gradient_rect.x() + x, gradient_rect.y() + y, gradient_color, gradient_color.alpha() < 255);
+        }
+    }
+}
+
+void paint_conic_gradient(PaintContext& context, Gfx::IntRect const& gradient_rect, ConicGradientData const& data, Gfx::IntPoint position)
+{
+    // FIXME: Do we need/want sub-degree accuracy for the gradient line?
+    GradientLine gradient_line(360, 0, data.color_stops);
+    float start_angle = (360.0f - data.start_angle) + 90.0f;
+    for (int y = 0; y < gradient_rect.height(); y++) {
+        for (int x = 0; x < gradient_rect.width(); x++) {
+            auto point = Gfx::IntPoint { x, y } - position;
+            // FIXME: We could probably get away with some approximation here:
+            float loc = fmod((AK::atan2(float(point.y()), float(point.x())) * 180.0f / AK::Pi<float> + 360.0f + start_angle), 360.0f);
+            auto blend = loc - static_cast<int>(loc);
+            auto gradient_color = gradient_line.lookup_color(loc).mixed_with(gradient_line.lookup_color(loc + 1), blend);
             context.painter().set_pixel(gradient_rect.x() + x, gradient_rect.y() + y, gradient_color, gradient_color.alpha() < 255);
         }
     }

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.h
@@ -28,8 +28,15 @@ struct LinearGradientData {
     Optional<float> repeat_length;
 };
 
+struct ConicGradientData {
+    float start_angle;
+    ColorStopList color_stops;
+};
+
 LinearGradientData resolve_linear_gradient_data(Layout::Node const&, Gfx::FloatSize const&, CSS::LinearGradientStyleValue const&);
+ConicGradientData resolve_conic_gradient_data(Layout::Node const&, CSS::ConicGradientStyleValue const&);
 
 void paint_linear_gradient(PaintContext&, Gfx::IntRect const&, LinearGradientData const&);
+void paint_conic_gradient(PaintContext&, Gfx::IntRect const&, ConicGradientData const&, Gfx::IntPoint position);
 
 }


### PR DESCRIPTION
Bored of linear gradients? Try new conic gradients! They're like linear gradients, but now in a circle!

This is only a first pass at `conic-gradient()`s, but they're already mostly there thanks to being able to share a lot of the code with `linear-gradient()`s. 

So this adds `conic-gradient()`s, with support for a starting angle, position, along with transition hints, double position (or angle here) color stops, etc, etc. The main missing things right now are the `-webkit-` variant (sadly probably needed somewhere), along with `repeating-conic-gradient()`s.


As you can see from this table we're already getting very good results for the [MDN examples](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/conic-gradient). 
|                                                                                                                          | LibWeb                                                                                                          | Chrome                                                                                                          |
|--------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| `conic-gradient(red, orange, yellow, green, blue)`                                                                       | ![image](https://user-images.githubusercontent.com/11597044/199120796-e8750cbd-f28a-4146-9902-33be4998f32c.png) | ![image](https://user-images.githubusercontent.com/11597044/199121171-d183aa53-f7b8-4d43-bcde-051bba3d23ef.png) |
| `conic-gradient(from 0.25turn at 50% 30%, #f69d3c, 10deg, #3f87a6, 350deg, #ebf8e1)`                                     | ![image](https://user-images.githubusercontent.com/11597044/199120844-a0f3851d-c6ad-405b-93e2-79d4afb79c80.png) | ![image](https://user-images.githubusercontent.com/11597044/199121185-652ab54e-f397-419d-b49c-938d80954f54.png) |
| `conic-gradient(from 3.1416rad at 10% 50%, #e66465, #9198e5)`                                                            | ![image](https://user-images.githubusercontent.com/11597044/199121005-1aa0c9bd-27be-43dc-93d2-808e9b6b0992.png) | ![image](https://user-images.githubusercontent.com/11597044/199121203-0a2715cc-8104-4e30-a1d4-46530aa4b948.png) |
| `conic-gradient(red 6deg, orange 6deg 18deg, yellow 18deg 45deg, green 45deg 110deg, blue 110deg 200deg, purple 200deg)` | ![image](https://user-images.githubusercontent.com/11597044/199121041-b9d31063-a509-4e2b-acff-5df1cb09a9fb.png) | ![image](https://user-images.githubusercontent.com/11597044/199121218-f98a14d1-9643-4d2e-b886-d93d1b1e19de.png) |


> P.s. Parsing code is a :pinching_hand: hairy, I'm not a fan of CSS parsing with all it's allowed re-orderings.  
  