### PR TITLE
Toolchain: Use pkg-config instead of pkgconfig in serenity.nix

### DIFF
--- a/Toolchain/serenity.nix
+++ b/Toolchain/serenity.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     unzip
     texinfo
     # Example Build-time Additional Dependencies
-    pkgconfig
+    pkg-config
   ];
   buildInputs = [
     # Example Run-time Additional Dependencies


### PR DESCRIPTION
pkgconfig was renamed to pkg-config in nixpkgs (https://github.com/NixOS/nixpkgs/pull/109595).