### PR TITLE
Kernel: Handle some allocation failures in IPv4Socket and TCPSocket

### DIFF
--- a/AK/SinglyLinkedListWithCount.h
+++ b/AK/SinglyLinkedListWithCount.h
@@ -60,11 +60,21 @@ public:
     }
 
     template<typename U = T>
+    ErrorOr<void> try_append(U&& value)
+    {
+        auto result = List::try_append(forward<T>(value));
+        if (!result.is_error())
+            m_count++;
+        return result;
+    }
+
+#ifndef KERNEL
+    template<typename U = T>
     void append(U&& value)
     {
-        m_count++;
-        return List::append(forward<T>(value));
+        MUST(try_append(forward<T>(value)));
     }
+#endif
 
     bool contains_slow(const T& value) const
     {

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -449,7 +449,11 @@ bool IPv4Socket::did_receive(IPv4Address const& source_address, u16 source_port,
             dbgln("IPv4Socket: did_receive unable to allocate storage for incoming packet.");
             return false;
         }
-        m_receive_queue.append({ source_address, source_port, packet_timestamp, data_or_error.release_value() });
+        auto result = m_receive_queue.try_append({ source_address, source_port, packet_timestamp, data_or_error.release_value() });
+        if (result.is_error()) {
+            dbgln("IPv4Socket: Dropped incoming packet because appending to the receive queue failed.");
+            return false;
+        }
         set_can_read(true);
     }
     m_bytes_received += packet_size;


### PR DESCRIPTION
This adds `try_*` methods to the `SinglyLinkedList` and `SinglyLinkedListWithCount` classes and uses them to gracefully handle some allocation failures in the network stack.