### PR TITLE
AK: Allow destruction of JsonObjectSerializer objects after errors

### DIFF
--- a/AK/JsonArraySerializer.h
+++ b/AK/JsonArraySerializer.h
@@ -43,11 +43,6 @@ public:
 
     JsonArraySerializer(JsonArraySerializer const&) = delete;
 
-    ~JsonArraySerializer()
-    {
-        VERIFY(m_finished);
-    }
-
 #ifndef KERNEL
     ErrorOr<void> add(JsonValue const& value)
     {

--- a/AK/JsonObjectSerializer.h
+++ b/AK/JsonObjectSerializer.h
@@ -38,11 +38,6 @@ public:
 
     JsonObjectSerializer(JsonObjectSerializer const&) = delete;
 
-    ~JsonObjectSerializer()
-    {
-        VERIFY(m_finished);
-    }
-
 #ifndef KERNEL
     ErrorOr<void> add(StringView key, JsonValue const& value)
     {


### PR DESCRIPTION
Previously we'd VERIFY() that the user had called finish(). This makes the following code incorrect though:

```c++
auto json = TRY(JsonObjectSerializer<>::try_create(builder));
TRY(json.add("total_time"sv, total_time_scheduled.total));
TRY(json.finish());
return ...;
```

If the second TRY() returns early we'd fail at the VERIFY() call in the destructor.

Calling finish() in the destructor - like we had done earlier - is also not helpful because we have no idea whether the builder is still valid. Plus we wouldn't be able to handle any errors for that call.

Verifying that either finish() was called or an error occurred doesn't work either because the caller might have multiple Json*Serializer objects, e.g. when inserting a JSON array into a JSON object. Forcing the user to call finish() on their "main" object when a sub-object caused an error seems unnecessarily tedious.