### PR TITLE
Browser: Update Storage Inspector's cookie model when deleting cookies

### DIFF
--- a/Userland/Applications/Browser/CookiesModel.cpp
+++ b/Userland/Applications/Browser/CookiesModel.cpp
@@ -101,10 +101,22 @@ TriState CookiesModel::data_matches(GUI::ModelIndex const& index, GUI::Variant c
     return TriState::False;
 }
 
-Web::Cookie::Cookie const& CookiesModel::get_cookie(GUI::ModelIndex const& index) const
+Web::Cookie::Cookie CookiesModel::take_cookie(GUI::ModelIndex const& index)
 {
     VERIFY(index.is_valid());
-    return m_cookies[index.row()];
+
+    auto cookie = m_cookies.take(index.row());
+    did_update(InvalidateAllIndices);
+
+    return cookie;
+}
+
+AK::Vector<Web::Cookie::Cookie> CookiesModel::take_all_cookies()
+{
+    auto cookies = move(m_cookies);
+    did_update(InvalidateAllIndices);
+
+    return cookies;
 }
 
 }

--- a/Userland/Applications/Browser/CookiesModel.h
+++ b/Userland/Applications/Browser/CookiesModel.h
@@ -35,7 +35,8 @@ public:
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role = GUI::ModelRole::Display) const override;
     virtual TriState data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const override;
 
-    Web::Cookie::Cookie const& get_cookie(GUI::ModelIndex const&) const;
+    Web::Cookie::Cookie take_cookie(GUI::ModelIndex const&);
+    AK::Vector<Web::Cookie::Cookie> take_all_cookies();
 
 private:
     AK::Vector<Web::Cookie::Cookie> m_cookies;

--- a/Userland/Applications/Browser/StorageWidget.cpp
+++ b/Userland/Applications/Browser/StorageWidget.cpp
@@ -41,18 +41,16 @@ StorageWidget::StorageWidget()
     auto delete_cookie_action = GUI::Action::create(
         "&Delete Cookie", { Key_Delete }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/delete.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto const&) {
             auto cookie_index = m_cookies_table_view->selection().first();
-            delete_cookie(m_cookies_model->get_cookie(cookie_index));
+            delete_cookie(m_cookies_model->take_cookie(cookie_index));
         },
         m_cookies_table_view);
 
     auto delete_all_cookies_action = GUI::Action::create(
         "Delete &All Cookies", [&](auto const&) {
-            auto cookie_count = m_cookies_model->row_count({});
-            for (auto i = 0; i < cookie_count; ++i) {
-                auto cookie_index = m_cookies_model->index(i);
-                if (cookie_index.is_valid())
-                    delete_cookie(m_cookies_model->get_cookie(cookie_index));
-            }
+            auto cookies = m_cookies_model->take_all_cookies();
+
+            for (auto& cookie : cookies)
+                delete_cookie(move(cookie));
         },
         m_cookies_table_view);
 


### PR DESCRIPTION
We currently get a list of cookies when the Storage Inspector is opened and never update that list when deleting cookies. This updates the inspector to actually take cookies out of the model when deleting them, rather than deleting a copy of them.