### PR TITLE
LibWeb+Friends: Implement `window.outer{width,height}` and `window.screen{X,Y}`

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -682,4 +682,36 @@ void BrowserWindow::config_bool_did_change(String const& domain, String const& g
     // NOTE: CloseDownloadWidgetOnFinish is read each time in DownloadWindow
 }
 
+void BrowserWindow::broadcast_window_position(Gfx::IntPoint const& position)
+{
+    tab_widget().for_each_child_of_type<Browser::Tab>([&](auto& tab) {
+        tab.window_position_changed(position);
+        return IterationDecision::Continue;
+    });
+}
+
+void BrowserWindow::broadcast_window_size(Gfx::IntSize const& size)
+{
+    tab_widget().for_each_child_of_type<Browser::Tab>([&](auto& tab) {
+        tab.window_size_changed(size);
+        return IterationDecision::Continue;
+    });
+}
+
+void BrowserWindow::event(Core::Event& event)
+{
+    switch (event.type()) {
+    case GUI::Event::Move:
+        broadcast_window_position(static_cast<GUI::MoveEvent&>(event).position());
+        break;
+    case GUI::Event::Resize:
+        broadcast_window_size(static_cast<GUI::ResizeEvent&>(event).size());
+        break;
+    default:
+        break;
+    }
+
+    Window::event(event);
+}
+
 }

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -43,6 +43,9 @@ public:
     void content_filters_changed();
     void proxy_mappings_changed();
 
+    void broadcast_window_position(Gfx::IntPoint const&);
+    void broadcast_window_size(Gfx::IntSize const&);
+
 private:
     explicit BrowserWindow(CookieJar&, URL);
 
@@ -52,6 +55,8 @@ private:
 
     virtual void config_string_did_change(String const& domain, String const& group, String const& key, String const& value) override;
     virtual void config_bool_did_change(String const& domain, String const& group, String const& key, bool value) override;
+
+    virtual void event(Core::Event&) override;
 
     RefPtr<GUI::Action> m_go_back_action;
     RefPtr<GUI::Action> m_go_forward_action;

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -545,6 +545,16 @@ void Tab::action_left(GUI::Action&)
     m_statusbar->set_override_text({});
 }
 
+void Tab::window_position_changed(Gfx::IntPoint const& position)
+{
+    m_web_content_view->set_window_position(position);
+}
+
+void Tab::window_size_changed(Gfx::IntSize const& size)
+{
+    m_web_content_view->set_window_size(size);
+}
+
 BrowserWindow const& Tab::window() const
 {
     return static_cast<BrowserWindow const&>(*Widget::window());

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -57,6 +57,9 @@ public:
     void action_entered(GUI::Action&);
     void action_left(GUI::Action&);
 
+    void window_position_changed(Gfx::IntPoint const&);
+    void window_size_changed(Gfx::IntSize const&);
+
     Function<void(String const&)> on_title_change;
     Function<void(const URL&)> on_tab_open_request;
     Function<void(Tab&)> on_tab_close_request;

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -190,5 +190,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     window->show();
 
+    window->broadcast_window_position(window->position());
+    window->broadcast_window_size(window->size());
+
     return app->exec();
 }

--- a/Userland/Libraries/LibGUI/ConnectionToWindowServer.cpp
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowServer.cpp
@@ -102,6 +102,12 @@ void ConnectionToWindowServer::window_resized(i32 window_id, Gfx::IntRect const&
     }
 }
 
+void ConnectionToWindowServer::window_moved(i32 window_id, Gfx::IntRect const& new_rect)
+{
+    if (auto* window = Window::from_window_id(window_id))
+        Core::EventLoop::current().post_event(*window, make<MoveEvent>(new_rect.location()));
+}
+
 void ConnectionToWindowServer::window_activated(i32 window_id)
 {
     if (auto* window = Window::from_window_id(window_id))

--- a/Userland/Libraries/LibGUI/ConnectionToWindowServer.h
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowServer.h
@@ -41,6 +41,7 @@ private:
     virtual void window_input_left(i32) override;
     virtual void window_close_request(i32) override;
     virtual void window_resized(i32, Gfx::IntRect const&) override;
+    virtual void window_moved(i32, Gfx::IntRect const&) override;
     virtual void menu_item_activated(i32, u32) override;
     virtual void menu_item_entered(i32, u32) override;
     virtual void menu_item_left(i32, u32) override;

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -28,6 +28,7 @@ public:
         Paint,
         MultiPaint,
         Resize,
+        Move,
         MouseMove,
         MouseDown,
         MouseDoubleClick,
@@ -308,6 +309,20 @@ public:
 
 private:
     Gfx::IntSize m_size;
+};
+
+class MoveEvent final : public Event {
+public:
+    explicit MoveEvent(Gfx::IntPoint const& size)
+        : Event(Event::Move)
+        , m_position(size)
+    {
+    }
+
+    Gfx::IntPoint const& position() const { return m_position; }
+
+private:
+    Gfx::IntPoint m_position;
 };
 
 class ContextMenuEvent final : public Event {

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -524,6 +524,24 @@ int Window::screen_y() const
     return 0;
 }
 
+// https://drafts.csswg.org/cssom-view/#dom-window-outerwidth
+int Window::outer_width() const
+{
+    // The outerWidth attribute must return the width of the client window. If there is no client window this attribute must return zero.
+    if (auto* page = this->page())
+        return page->window_size().width();
+    return 0;
+}
+
+// https://drafts.csswg.org/cssom-view/#dom-window-screeny
+int Window::outer_height() const
+{
+    // The outerHeight attribute must return the height of the client window. If there is no client window this attribute must return zero.
+    if (auto* page = this->page())
+        return page->window_size().height();
+    return 0;
+}
+
 // https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage
 JS::NonnullGCPtr<HTML::Storage> Window::local_storage()
 {
@@ -786,6 +804,9 @@ void Window::initialize_web_interfaces(Badge<WindowEnvironmentSettingsObject>)
     define_native_accessor(realm, "screenY", screen_y_getter, {}, attr);
     define_native_accessor(realm, "screenLeft", screen_left_getter, {}, attr);
     define_native_accessor(realm, "screenTop", screen_top_getter, {}, attr);
+
+    define_native_accessor(realm, "outerWidth", outer_width_getter, {}, attr);
+    define_native_accessor(realm, "outerHeight", outer_height_getter, {}, attr);
 
     define_direct_property("CSS", heap().allocate<Bindings::CSSNamespace>(realm, realm), 0);
 
@@ -1421,6 +1442,18 @@ JS_DEFINE_NATIVE_FUNCTION(Window::screen_y_getter)
 {
     auto* impl = TRY(impl_from(vm));
     return JS::Value(impl->screen_y());
+}
+
+JS_DEFINE_NATIVE_FUNCTION(Window::outer_width_getter)
+{
+    auto* impl = TRY(impl_from(vm));
+    return JS::Value(impl->outer_width());
+}
+
+JS_DEFINE_NATIVE_FUNCTION(Window::outer_height_getter)
+{
+    auto* impl = TRY(impl_from(vm));
+    return JS::Value(impl->outer_height());
 }
 
 JS_DEFINE_NATIVE_FUNCTION(Window::post_message)

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -509,6 +509,8 @@ int Window::screen_x() const
 {
     // The screenX and screenLeft attributes must return the x-coordinate, relative to the origin of the Web-exposed screen area,
     // of the left of the client window as number of CSS pixels, or zero if there is no such thing.
+    if (auto* page = this->page())
+        return page->window_position().x();
     return 0;
 }
 
@@ -517,6 +519,8 @@ int Window::screen_y() const
 {
     // The screenY and screenTop attributes must return the y-coordinate, relative to the origin of the screen of the Web-exposed screen area,
     // of the top of the client window as number of CSS pixels, or zero if there is no such thing.
+    if (auto* page = this->page())
+        return page->window_position().y();
     return 0;
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -108,6 +108,9 @@ public:
     int screen_x() const;
     int screen_y() const;
 
+    int outer_width() const;
+    int outer_height() const;
+
     JS::NonnullGCPtr<HTML::Storage> local_storage();
     JS::NonnullGCPtr<HTML::Storage> session_storage();
 
@@ -232,6 +235,9 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(screen_y_getter);
     JS_DECLARE_NATIVE_FUNCTION(screen_left_getter);
     JS_DECLARE_NATIVE_FUNCTION(screen_top_getter);
+
+    JS_DECLARE_NATIVE_FUNCTION(outer_width_getter);
+    JS_DECLARE_NATIVE_FUNCTION(outer_height_getter);
 
     JS_DECLARE_NATIVE_FUNCTION(post_message);
 

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -16,6 +16,8 @@
 #include <Kernel/API/KeyCode.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Palette.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Size.h>
 #include <LibGfx/StandardCursor.h>
 #include <LibJS/Heap/Handle.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
@@ -72,6 +74,12 @@ public:
     bool is_webdriver_active() const { return m_is_webdriver_active; }
     void set_is_webdriver_active(bool b) { m_is_webdriver_active = b; }
 
+    Gfx::IntPoint const& window_position() const { return m_window_position; }
+    void set_window_position(Gfx::IntPoint const& position) { m_window_position = position; }
+
+    Gfx::IntSize const& window_size() const { return m_window_size; }
+    void set_window_size(Gfx::IntSize const& size) { m_window_size = size; }
+
 private:
     PageClient& m_client;
 
@@ -86,6 +94,9 @@ private:
     // https://w3c.github.io/webdriver/#dfn-webdriver-active-flag
     // The webdriver-active flag is set to true when the user agent is under remote control. It is initially false.
     bool m_is_webdriver_active { false };
+
+    Gfx::IntPoint m_window_position {};
+    Gfx::IntSize m_window_size {};
 };
 
 class PageClient {

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -575,6 +575,16 @@ void OutOfProcessWebView::set_is_webdriver_active(bool is_webdriver_enabled)
     client().async_set_is_webdriver_active(is_webdriver_enabled);
 }
 
+void OutOfProcessWebView::set_window_position(Gfx::IntPoint const& position)
+{
+    client().async_set_window_position(position);
+}
+
+void OutOfProcessWebView::set_window_size(Gfx::IntSize const& size)
+{
+    client().async_set_window_size(size);
+}
+
 void OutOfProcessWebView::focusin_event(GUI::FocusEvent&)
 {
     client().async_set_has_focus(true);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -72,6 +72,9 @@ public:
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
     void set_is_webdriver_active(bool);
 
+    void set_window_position(Gfx::IntPoint const&);
+    void set_window_size(Gfx::IntSize const&);
+
     Function<void(Gfx::IntPoint const& screen_position)> on_context_menu_request;
     Function<void(const AK::URL&, String const& target, unsigned modifiers)> on_link_click;
     Function<void(const AK::URL&, Gfx::IntPoint const& screen_position)> on_link_context_menu_request;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -655,6 +655,16 @@ void ConnectionFromClient::set_is_webdriver_active(bool is_webdriver_active)
     m_page_host->set_is_webdriver_active(is_webdriver_active);
 }
 
+void ConnectionFromClient::set_window_position(Gfx::IntPoint const& position)
+{
+    m_page_host->set_window_position(position);
+}
+
+void ConnectionFromClient::set_window_size(Gfx::IntSize const& size)
+{
+    m_page_host->set_window_size(size);
+}
+
 Messages::WebContentServer::GetLocalStorageEntriesResponse ConnectionFromClient::get_local_storage_entries()
 {
     auto* document = page().top_level_browsing_context().active_document();

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -72,6 +72,8 @@ private:
     virtual void set_has_focus(bool) override;
     virtual void set_is_scripting_enabled(bool) override;
     virtual void set_is_webdriver_active(bool) override;
+    virtual void set_window_position(Gfx::IntPoint const&) override;
+    virtual void set_window_size(Gfx::IntSize const&) override;
     virtual void handle_file_return(i32 error, Optional<IPC::File> const& file, i32 request_id) override;
     virtual void set_system_visibility_state(bool visible) override;
 

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -76,6 +76,16 @@ void PageHost::set_is_webdriver_active(bool is_webdriver_active)
     page().set_is_webdriver_active(is_webdriver_active);
 }
 
+void PageHost::set_window_position(Gfx::IntPoint const& position)
+{
+    page().set_window_position(position);
+}
+
+void PageHost::set_window_size(Gfx::IntSize const& size)
+{
+    page().set_window_size(size);
+}
+
 Web::Layout::InitialContainingBlock* PageHost::layout_root()
 {
     auto* document = page().top_level_browsing_context().active_document();

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -35,6 +35,8 @@ public:
     void set_has_focus(bool);
     void set_is_scripting_enabled(bool);
     void set_is_webdriver_active(bool);
+    void set_window_position(Gfx::IntPoint const&);
+    void set_window_size(Gfx::IntSize const&);
 
 private:
     // ^PageClient

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -60,6 +60,9 @@ endpoint WebContentServer
     set_is_scripting_enabled(bool is_scripting_enabled) =|
     set_is_webdriver_active(bool is_webdriver_active) =|
 
+    set_window_position(Gfx::IntPoint position) =|
+    set_window_size(Gfx::IntSize size) =|
+
     get_local_storage_entries() => (OrderedHashMap<String,String> entries)
     get_session_storage_entries() => (OrderedHashMap<String,String> entries)
 

--- a/Userland/Services/WindowServer/Event.h
+++ b/Userland/Services/WindowServer/Event.h
@@ -35,6 +35,7 @@ public:
         WindowInputLeft,
         WindowCloseRequest,
         WindowResized,
+        WindowMoved,
     };
 
     Event() = default;
@@ -147,6 +148,20 @@ class ResizeEvent final : public Event {
 public:
     ResizeEvent(Gfx::IntRect const& rect)
         : Event(Event::WindowResized)
+        , m_rect(rect)
+    {
+    }
+
+    Gfx::IntRect const& rect() const { return m_rect; }
+
+private:
+    Gfx::IntRect m_rect;
+};
+
+class MoveEvent final : public Event {
+public:
+    MoveEvent(Gfx::IntRect const& rect)
+        : Event(Event::WindowMoved)
         , m_rect(rect)
     {
     }

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -408,6 +408,7 @@ void Window::set_maximized(bool maximized)
         set_rect(m_floating_rect);
     m_frame.did_set_maximized({}, maximized);
     Core::EventLoop::current().post_event(*this, make<ResizeEvent>(m_rect));
+    Core::EventLoop::current().post_event(*this, make<MoveEvent>(m_rect));
     set_default_positioned(false);
 
     WindowManager::the().notify_minimization_state_changed(*this);
@@ -485,6 +486,9 @@ void Window::event(Core::Event& event)
         break;
     case Event::WindowResized:
         m_client->async_window_resized(m_window_id, static_cast<ResizeEvent const&>(event).rect());
+        break;
+    case Event::WindowMoved:
+        m_client->async_window_moved(m_window_id, static_cast<MoveEvent const&>(event).rect());
         break;
     default:
         break;
@@ -826,6 +830,7 @@ void Window::set_fullscreen(bool fullscreen)
     }
 
     Core::EventLoop::current().post_event(*this, make<ResizeEvent>(new_window_rect));
+    Core::EventLoop::current().post_event(*this, make<MoveEvent>(new_window_rect));
     set_rect(new_window_rect);
 }
 
@@ -896,6 +901,7 @@ bool Window::set_untiled()
     set_rect(m_floating_rect);
 
     Core::EventLoop::current().post_event(*this, make<ResizeEvent>(m_rect));
+    Core::EventLoop::current().post_event(*this, make<MoveEvent>(m_rect));
 
     return true;
 }
@@ -917,6 +923,7 @@ void Window::set_tiled(WindowTileType tile_type)
 
     set_rect(WindowManager::the().tiled_window_rect(*this, tile_type));
     Core::EventLoop::current().post_event(*this, make<ResizeEvent>(m_rect));
+    Core::EventLoop::current().post_event(*this, make<MoveEvent>(m_rect));
 }
 
 void Window::detach_client(Badge<ConnectionFromClient>)

--- a/Userland/Services/WindowServer/WindowClient.ipc
+++ b/Userland/Services/WindowServer/WindowClient.ipc
@@ -23,6 +23,7 @@ endpoint WindowClient
     window_input_preempted(i32 window_id, i32 preemptor) =|
     window_close_request(i32 window_id) =|
     window_resized(i32 window_id, Gfx::IntRect new_rect) =|
+    window_moved(i32 window_id, Gfx::IntRect new_rect) =|
 
     menu_item_activated(i32 menu_id, u32 identifier) =|
     menu_item_entered(i32 menu_id, u32 identifier) =|

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -742,6 +742,7 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event)
         if (!m_move_window->is_tiled())
             m_move_window->set_floating_rect(m_move_window->rect());
 
+        Core::EventLoop::current().post_event(*m_move_window, make<MoveEvent>(m_move_window->rect()));
         m_move_window->invalidate(true, true);
         if (m_move_window->is_resizable()) {
             process_event_for_doubleclick(*m_move_window, event);
@@ -816,6 +817,7 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event)
             m_geometry_overlay->window_rect_changed();
         }
     }
+    Core::EventLoop::current().post_event(*m_move_window, make<MoveEvent>(m_move_window->rect()));
     return true;
 }
 


### PR DESCRIPTION
These provide the OS-level window size and position to be accessed by JS. Needed for some of the WebDriver APIs.

![Screenshot from 2022-11-01 16-06-59](https://user-images.githubusercontent.com/5600524/199330822-9e81f81a-d7ed-441c-9ee4-e424958027be.png)
