### PR TITLE
WindowServer: Update alt shortcuts for menu items when text changes

### DIFF
--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -692,12 +692,22 @@ void Menu::set_visible(bool visible)
         m_client->async_menu_visibility_did_change(m_menu_id, visible);
 }
 
+void Menu::update_alt_shortcuts_for_items()
+{
+    m_alt_shortcut_character_to_item_indices.clear();
+    int i = 0;
+    for (auto& item : m_items) {
+        if (auto alt_shortcut = find_ampersand_shortcut_character(item.text())) {
+            m_alt_shortcut_character_to_item_indices.ensure(to_ascii_lowercase(alt_shortcut)).append(i);
+        }
+        ++i;
+    }
+}
+
 void Menu::add_item(NonnullOwnPtr<MenuItem> item)
 {
-    if (auto alt_shortcut = find_ampersand_shortcut_character(item->text())) {
-        m_alt_shortcut_character_to_item_indices.ensure(to_ascii_lowercase(alt_shortcut)).append(m_items.size());
-    }
     m_items.append(move(item));
+    update_alt_shortcuts_for_items();
 }
 
 Vector<size_t> const* Menu::items_with_alt_shortcut(u32 alt_shortcut) const

--- a/Userland/Services/WindowServer/Menu.h
+++ b/Userland/Services/WindowServer/Menu.h
@@ -56,6 +56,7 @@ public:
         return found_item;
     }
 
+    void update_alt_shortcuts_for_items();
     void add_item(NonnullOwnPtr<MenuItem>);
 
     String const& name() const { return m_name; }

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -228,6 +228,8 @@ void Window::update_window_menu_items()
     m_window_menu_close_item->set_enabled(m_closeable);
 
     m_window_menu_move_item->set_enabled(m_minimized_state == WindowMinimizedState::None && !is_maximized() && !m_fullscreen);
+
+    m_window_menu->update_alt_shortcuts_for_items();
 }
 
 void Window::set_minimized(bool minimized)


### PR DESCRIPTION
Previously, the alt shortcuts for Maximize, Minimize, Restore, and Unminimize were not being set for the window menu.
This PR adds `Menu::update_alt_shortcuts_for_items()` which implements the desired behavior.