### PR TITLE
PixelPaint: Make filters apply to a selection if one is present

### DIFF
--- a/Userland/Applications/PixelPaint/FilterGallery.cpp
+++ b/Userland/Applications/PixelPaint/FilterGallery.cpp
@@ -65,6 +65,7 @@ FilterGallery::FilterGallery(GUI::Window* parent_window, ImageEditor* editor)
         m_config_widget->add_child(*m_selected_filter_config_widget);
     };
 
+    m_preview_widget->set_layer(editor->active_layer());
     m_preview_widget->set_bitmap(editor->active_layer()->content_bitmap().clone().release_value());
 
     apply_button->on_click = [this](auto) {

--- a/Userland/Applications/PixelPaint/FilterPreviewWidget.h
+++ b/Userland/Applications/PixelPaint/FilterPreviewWidget.h
@@ -19,6 +19,7 @@ class FilterPreviewWidget final : public GUI::Frame {
 
 public:
     virtual ~FilterPreviewWidget() override;
+    void set_layer(RefPtr<Layer> layer);
     void set_bitmap(RefPtr<Gfx::Bitmap> const& bitmap);
     void set_filter(Filter* filter);
     void clear_filter();
@@ -26,6 +27,7 @@ public:
 private:
     explicit FilterPreviewWidget();
 
+    RefPtr<Layer> m_layer;
     RefPtr<Gfx::Bitmap> m_bitmap;
     RefPtr<Gfx::Bitmap> m_filtered_bitmap;
 

--- a/Userland/Applications/PixelPaint/ImageProcessor.cpp
+++ b/Userland/Applications/PixelPaint/ImageProcessor.cpp
@@ -16,7 +16,7 @@ FilterApplicationCommand::FilterApplicationCommand(NonnullRefPtr<Filter> filter,
 
 void FilterApplicationCommand::execute()
 {
-    m_filter->apply(m_target_layer->content_bitmap(), m_target_layer->content_bitmap());
+    m_filter->apply(m_target_layer->get_scratch_edited_bitmap(), m_target_layer->get_scratch_edited_bitmap());
     m_filter->m_editor->gui_event_loop().deferred_invoke([strong_this = NonnullRefPtr(*this)]() {
         // HACK: we can't tell strong_this to not be const
         (*const_cast<NonnullRefPtr<Layer>*>(&strong_this->m_target_layer))->did_modify_bitmap(strong_this->m_target_layer->rect());


### PR DESCRIPTION
This changes ImageProcessor to use the scratch bitmap of the layer which will cause the changes to only be applied inside the active selection (if there is one). This also updates the FilterPreviewWidget to show the filter preview with active selection taken into account.