### PR TITLE
Documentation: Update MacOS build dependencies to gcc-12

### DIFF
--- a/Documentation/BuildInstructionsMacOS.md
+++ b/Documentation/BuildInstructionsMacOS.md
@@ -13,7 +13,7 @@ Make sure you also have all the following dependencies installed:
 
 ```console
 # core
-brew install coreutils e2fsprogs qemu bash gcc@11 imagemagick ninja cmake ccache rsync zstd
+brew install coreutils e2fsprogs qemu bash gcc@12 imagemagick ninja cmake ccache rsync zstd
 
 # (option 1) fuse + ext2
 brew install m4 autoconf automake libtool


### PR DESCRIPTION
Since commit bc2ebcadc serenity requires gcc version 12 or later to build, so let's update the homebrew package version to match that.