### PR TITLE
LibJS/Temporal: Implement the rest of the IETF SEDATE conclusions

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -280,6 +280,7 @@
     M(TemporalPropertyMustBeFinite, "Property must not be Infinity")                                                                    \
     M(TemporalPropertyMustBePositiveInteger, "Property must be a positive integer")                                                     \
     M(TemporalTimeZoneOffsetStringMismatch, "Time zone offset string mismatch: '{}' is not equal to '{}'")                              \
+    M(TemporalUnknownCriticalAnnotation, "Unknown annotation key in critical annotation: '{}'")                                         \
     M(TemporalZonedDateTimeRoundZeroOrNegativeLengthDay, "Cannot round a ZonedDateTime in a calendar or time zone that has zero or "    \
                                                          "negative length days")                                                        \
     M(ThisHasNotBeenInitialized, "|this| has not been initialized")                                                                     \

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -246,8 +246,8 @@ ThrowCompletionOr<String> to_temporal_offset(VM& vm, Object const* options, Stri
 // 13.9 ToShowCalendarOption ( normalizedOptions ), https://tc39.es/proposal-temporal/#sec-temporal-toshowcalendaroption
 ThrowCompletionOr<String> to_show_calendar_option(VM& vm, Object const& normalized_options)
 {
-    // 1. Return ? GetOption(normalizedOptions, "calendarName", "string", « "auto", "always", "never" », "auto").
-    auto option = TRY(get_option(vm, normalized_options, vm.names.calendarName, OptionType::String, { "auto"sv, "always"sv, "never"sv }, "auto"sv));
+    // 1. Return ? GetOption(normalizedOptions, "calendarName", "string", « "auto", "always", "never", "critical" », "auto").
+    auto option = TRY(get_option(vm, normalized_options, vm.names.calendarName, OptionType::String, { "auto"sv, "always"sv, "never"sv, "critical"sv }, "auto"sv));
 
     VERIFY(option.is_string());
     return option.as_string().string();

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -256,8 +256,8 @@ ThrowCompletionOr<String> to_show_calendar_option(VM& vm, Object const& normaliz
 // 13.10 ToShowTimeZoneNameOption ( normalizedOptions ), https://tc39.es/proposal-temporal/#sec-temporal-toshowtimezonenameoption
 ThrowCompletionOr<String> to_show_time_zone_name_option(VM& vm, Object const& normalized_options)
 {
-    // 1. Return ? GetOption(normalizedOptions, "timeZoneName", "string, « "auto", "never" », "auto").
-    auto option = TRY(get_option(vm, normalized_options, vm.names.timeZoneName, OptionType::String, { "auto"sv, "never"sv }, "auto"sv));
+    // 1. Return ? GetOption(normalizedOptions, "timeZoneName", "string", « "auto", "never", "critical" », "auto").
+    auto option = TRY(get_option(vm, normalized_options, vm.names.timeZoneName, OptionType::String, { "auto"sv, "never"sv, "critical"sv }, "auto"sv));
 
     VERIFY(option.is_string());
     return option.as_string().string();

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -579,19 +579,21 @@ ThrowCompletionOr<String> maybe_format_calendar_annotation(VM& vm, Object const*
 // 12.2.27 FormatCalendarAnnotation ( id, showCalendar ), https://tc39.es/proposal-temporal/#sec-temporal-formatcalendarannotation
 String format_calendar_annotation(StringView id, StringView show_calendar)
 {
-    // 1. Assert: showCalendar is "auto", "always", or "never".
-    VERIFY(show_calendar == "auto"sv || show_calendar == "always"sv || show_calendar == "never"sv);
+    VERIFY(show_calendar == "auto"sv || show_calendar == "always"sv || show_calendar == "never"sv || show_calendar == "critical"sv);
 
-    // 2. If showCalendar is "never", return the empty String.
+    // 1. If showCalendar is "never", return the empty String.
     if (show_calendar == "never"sv)
         return String::empty();
 
-    // 3. If showCalendar is "auto" and id is "iso8601", return the empty String.
+    // 2. If showCalendar is "auto" and id is "iso8601", return the empty String.
     if (show_calendar == "auto"sv && id == "iso8601"sv)
         return String::empty();
 
-    // 4. Return the string-concatenation of "[u-ca=", id, and "]".
-    return String::formatted("[u-ca={}]", id);
+    // 3. If showCalendar is "critical", let flag be "!"; else, let flag be the empty String.
+    auto flag = show_calendar == "critical"sv ? "!"sv : ""sv;
+
+    // 4. Return the string-concatenation of "[", flag, "u-ca=", id, and "]".
+    return String::formatted("[{}u-ca={}]", flag, id);
 }
 
 // 12.2.28 CalendarEquals ( one, two ), https://tc39.es/proposal-temporal/#sec-temporal-calendarequals

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ISO8601.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ISO8601.h
@@ -13,6 +13,12 @@
 
 namespace JS::Temporal {
 
+struct Annotation {
+    bool critical { false };
+    StringView key;
+    StringView value;
+};
+
 struct ParseResult {
     Optional<StringView> sign;
     Optional<StringView> date_year;
@@ -22,7 +28,6 @@ struct ParseResult {
     Optional<StringView> time_minute;
     Optional<StringView> time_second;
     Optional<StringView> time_fraction;
-    Optional<StringView> calendar_name;
     Optional<StringView> utc_designator;
     Optional<StringView> time_zone_bracketed_annotation;
     Optional<StringView> time_zone_numeric_utc_offset;
@@ -42,6 +47,9 @@ struct ParseResult {
     Optional<StringView> duration_minutes_fraction;
     Optional<StringView> duration_whole_seconds;
     Optional<StringView> duration_seconds_fraction;
+    Optional<StringView> annotation_key;
+    Optional<StringView> annotation_value;
+    Vector<Annotation> annotations;
 };
 
 enum class Production {
@@ -54,7 +62,7 @@ enum class Production {
     TemporalZonedDateTimeString,
     TimeZoneIdentifier,
     TimeZoneNumericUTCOffset,
-    CalendarName,
+    AnnotationValue,
     DateMonth,
 };
 
@@ -97,6 +105,7 @@ public:
     [[nodiscard]] bool parse_weeks_designator();
     [[nodiscard]] bool parse_years_designator();
     [[nodiscard]] bool parse_utc_designator();
+    [[nodiscard]] bool parse_annotation_critical_flag();
     [[nodiscard]] bool parse_date_year();
     [[nodiscard]] bool parse_date_month();
     [[nodiscard]] bool parse_date_month_with_thirty_days();
@@ -131,15 +140,23 @@ public:
     [[nodiscard]] bool parse_time_zone_offset_required();
     [[nodiscard]] bool parse_time_zone_name_required();
     [[nodiscard]] bool parse_time_zone();
-    [[nodiscard]] bool parse_calendar_name();
-    [[nodiscard]] bool parse_calendar();
+    [[nodiscard]] bool parse_a_key_leading_char();
+    [[nodiscard]] bool parse_a_key_char();
+    [[nodiscard]] bool parse_a_val_char();
+    [[nodiscard]] bool parse_annotation_key_tail();
+    [[nodiscard]] bool parse_annotation_key();
+    [[nodiscard]] bool parse_annotation_value_component();
+    [[nodiscard]] bool parse_annotation_value_tail();
+    [[nodiscard]] bool parse_annotation_value();
+    [[nodiscard]] bool parse_annotation();
+    [[nodiscard]] bool parse_annotations();
     [[nodiscard]] bool parse_time_spec();
     [[nodiscard]] bool parse_time_spec_with_optional_time_zone_not_ambiguous();
     [[nodiscard]] bool parse_time_spec_separator();
     [[nodiscard]] bool parse_date_time();
-    [[nodiscard]] bool parse_calendar_time();
-    [[nodiscard]] bool parse_calendar_date_time();
-    [[nodiscard]] bool parse_calendar_date_time_time_required();
+    [[nodiscard]] bool parse_annotated_time();
+    [[nodiscard]] bool parse_annotated_date_time();
+    [[nodiscard]] bool parse_annotated_date_time_time_required();
     [[nodiscard]] bool parse_duration_whole_seconds();
     [[nodiscard]] bool parse_duration_seconds_fraction();
     [[nodiscard]] bool parse_duration_seconds_part();

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.cpp
@@ -186,8 +186,8 @@ ThrowCompletionOr<String> temporal_month_day_to_string(VM& vm, PlainMonthDay& mo
     // 6. Let calendarID be ? ToString(monthDay.[[Calendar]]).
     auto calendar_id = TRY(Value(&month_day.calendar()).to_string(vm));
 
-    // 7. If showCalendar is "always" or if calendarID is not "iso8601", then
-    if (show_calendar == "always"sv || calendar_id != "iso8601"sv) {
+    // 7. If showCalendar is one of "always" or "critical", or if calendarID is not "iso8601", then
+    if (show_calendar.is_one_of("always"sv, "critical"sv) || calendar_id != "iso8601"sv) {
         // a. Let year be ! PadISOYear(monthDay.[[ISOYear]]).
         // b. Set result to the string-concatenation of year, the code unit 0x002D (HYPHEN-MINUS), and result.
         result = String::formatted("{}-{}", pad_iso_year(month_day.iso_year()), result);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
@@ -213,8 +213,8 @@ ThrowCompletionOr<String> temporal_year_month_to_string(VM& vm, PlainYearMonth& 
     // 6. Let calendarID be ? ToString(yearMonth.[[Calendar]]).
     auto calendar_id = TRY(Value(&year_month.calendar()).to_string(vm));
 
-    // 7. If showCalendar is "always" or if calendarID is not "iso8601", then
-    if (show_calendar == "always"sv || calendar_id != "iso8601") {
+    // 7. If showCalendar is one of "always" or "critical", or if calendarID is not "iso8601", then
+    if (show_calendar.is_one_of("always"sv, "critical"sv) || calendar_id != "iso8601") {
         // a. Let day be ToZeroPaddedDecimalString(yearMonth.[[ISODay]], 2).
         // b. Set result to the string-concatenation of result, the code unit 0x002D (HYPHEN-MINUS), and day.
         result = String::formatted("{}-{:02}", result, year_month.iso_day());

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -343,8 +343,11 @@ ThrowCompletionOr<String> temporal_zoned_date_time_to_string(VM& vm, ZonedDateTi
         // a. Let timeZoneID be ? ToString(timeZone).
         auto time_zone_id = TRY(Value(&time_zone).to_string(vm));
 
-        // b. Let timeZoneString be the string-concatenation of the code unit 0x005B (LEFT SQUARE BRACKET), timeZoneID, and the code unit 0x005D (RIGHT SQUARE BRACKET).
-        time_zone_string = String::formatted("[{}]", time_zone_id);
+        // b. If showTimeZone is "critical", let flag be "!"; else let flag be the empty String.
+        auto flag = show_time_zone == "critical"sv ? "!"sv : ""sv;
+
+        // c. Let timeZoneString be the string-concatenation of the code unit 0x005B (LEFT SQUARE BRACKET), flag, timeZoneID, and the code unit 0x005D (RIGHT SQUARE BRACKET).
+        time_zone_string = String::formatted("[{}{}]", flag, time_zone_id);
     }
 
     // 14. Let calendarString be ? MaybeFormatCalendarAnnotation(zonedDateTime.[[Calendar]], showCalendar).

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Instant/Instant.from.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Instant/Instant.from.js
@@ -65,12 +65,12 @@ describe("errors", () => {
         );
     });
 
-    test("calendar annotation must match calendar grammar even though it's ignored", () => {
+    test("annotations must match annotation grammar even though they're ignored", () => {
         expect(() => {
-            Temporal.Instant.from("1970-01-01T00:00Z[u-ca=SerenityOS]");
+            Temporal.Instant.from("1970-01-01T00:00Z[SerenityOS=cool]");
         }).toThrowWithMessage(
             RangeError,
-            "Invalid instant string '1970-01-01T00:00Z[u-ca=SerenityOS]'"
+            "Invalid instant string '1970-01-01T00:00Z[SerenityOS=cool]'"
         );
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDate/PlainDate.prototype.toString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDate/PlainDate.prototype.toString.js
@@ -11,12 +11,14 @@ describe("correct behavior", () => {
         expect(plainDate.toString({ calendarName: "auto" })).toBe("2021-07-06");
         expect(plainDate.toString({ calendarName: "always" })).toBe("2021-07-06[u-ca=iso8601]");
         expect(plainDate.toString({ calendarName: "never" })).toBe("2021-07-06");
+        expect(plainDate.toString({ calendarName: "critical" })).toBe("2021-07-06[!u-ca=iso8601]");
 
         plainDate = new Temporal.PlainDate(2021, 7, 6, { toString: () => "foo" });
         expect(plainDate.toString()).toBe("2021-07-06[u-ca=foo]");
         expect(plainDate.toString({ calendarName: "auto" })).toBe("2021-07-06[u-ca=foo]");
         expect(plainDate.toString({ calendarName: "always" })).toBe("2021-07-06[u-ca=foo]");
         expect(plainDate.toString({ calendarName: "never" })).toBe("2021-07-06");
+        expect(plainDate.toString({ calendarName: "critical" })).toBe("2021-07-06[!u-ca=foo]");
 
         plainDate = new Temporal.PlainDate(0, 1, 1);
         expect(plainDate.toString()).toBe("0000-01-01");
@@ -62,7 +64,7 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "Not an object of type Temporal.PlainDate");
     });
 
-    test("calendarName option must be one of 'auto', 'always', 'never'", () => {
+    test("calendarName option must be one of 'auto', 'always', 'never', 'critical'", () => {
         const plainDate = new Temporal.PlainDate(2021, 7, 6);
         expect(() => {
             plainDate.toString({ calendarName: "foo" });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.toString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.toString.js
@@ -80,6 +80,21 @@ describe("correct behavior", () => {
         expect(plainDateTime.toString(options)).toBe("2022-08-08T14:38:40.1002003");
         expect(calledToString).toBeFalse();
     });
+
+    test("calendarName option", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2022, 11, 2, 19, 4, 35, 100, 200, 300);
+        const values = [
+            ["auto", "2022-11-02T19:04:35.1002003"],
+            ["always", "2022-11-02T19:04:35.1002003[u-ca=iso8601]"],
+            ["never", "2022-11-02T19:04:35.1002003"],
+            ["critical", "2022-11-02T19:04:35.1002003[!u-ca=iso8601]"],
+        ];
+
+        for (const [calendarName, expected] of values) {
+            const options = { calendarName };
+            expect(plainDateTime.toString(options)).toBe(expected);
+        }
+    });
 });
 
 describe("errors", () => {
@@ -87,5 +102,12 @@ describe("errors", () => {
         expect(() => {
             Temporal.PlainDateTime.prototype.toString.call("foo");
         }).toThrowWithMessage(TypeError, "Not an object of type Temporal.PlainDateTime");
+    });
+
+    test("calendarName option must be one of 'auto', 'always', 'never', 'critical'", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2022, 11, 2, 19, 5, 40, 100, 200, 300);
+        expect(() => {
+            plainDateTime.toString({ calendarName: "foo" });
+        }).toThrowWithMessage(RangeError, "foo is not a valid value for option calendarName");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainMonthDay/PlainMonthDay.prototype.toString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainMonthDay/PlainMonthDay.prototype.toString.js
@@ -11,12 +11,16 @@ describe("correct behavior", () => {
         expect(plainMonthDay.toString({ calendarName: "auto" })).toBe("07-06");
         expect(plainMonthDay.toString({ calendarName: "always" })).toBe("1972-07-06[u-ca=iso8601]");
         expect(plainMonthDay.toString({ calendarName: "never" })).toBe("07-06");
+        expect(plainMonthDay.toString({ calendarName: "critical" })).toBe(
+            "1972-07-06[!u-ca=iso8601]"
+        );
 
         plainMonthDay = new Temporal.PlainMonthDay(7, 6, { toString: () => "foo" }, 2021);
         expect(plainMonthDay.toString()).toBe("2021-07-06[u-ca=foo]");
         expect(plainMonthDay.toString({ calendarName: "auto" })).toBe("2021-07-06[u-ca=foo]");
         expect(plainMonthDay.toString({ calendarName: "always" })).toBe("2021-07-06[u-ca=foo]");
         expect(plainMonthDay.toString({ calendarName: "never" })).toBe("2021-07-06");
+        expect(plainMonthDay.toString({ calendarName: "critical" })).toBe("2021-07-06[!u-ca=foo]");
     });
 });
 
@@ -27,7 +31,7 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "Not an object of type Temporal.PlainMonthDay");
     });
 
-    test("calendarName option must be one of 'auto', 'always', 'never'", () => {
+    test("calendarName option must be one of 'auto', 'always', 'never', 'critical'", () => {
         const plainMonthDay = new Temporal.PlainMonthDay(7, 6);
         expect(() => {
             plainMonthDay.toString({ calendarName: "foo" });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.toString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.toString.js
@@ -13,12 +13,16 @@ describe("correct behavior", () => {
             "2021-07-01[u-ca=iso8601]"
         );
         expect(plainYearMonth.toString({ calendarName: "never" })).toBe("2021-07");
+        expect(plainYearMonth.toString({ calendarName: "critical" })).toBe(
+            "2021-07-01[!u-ca=iso8601]"
+        );
 
         plainYearMonth = new Temporal.PlainYearMonth(2021, 7, { toString: () => "foo" }, 6);
         expect(plainYearMonth.toString()).toBe("2021-07-06[u-ca=foo]");
         expect(plainYearMonth.toString({ calendarName: "auto" })).toBe("2021-07-06[u-ca=foo]");
         expect(plainYearMonth.toString({ calendarName: "always" })).toBe("2021-07-06[u-ca=foo]");
         expect(plainYearMonth.toString({ calendarName: "never" })).toBe("2021-07-06");
+        expect(plainYearMonth.toString({ calendarName: "critical" })).toBe("2021-07-06[!u-ca=foo]");
 
         plainYearMonth = new Temporal.PlainYearMonth(0, 1);
         expect(plainYearMonth.toString()).toBe("0000-01");
@@ -47,7 +51,7 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "Not an object of type Temporal.PlainYearMonth");
     });
 
-    test("calendarName option must be one of 'auto', 'always', 'never'", () => {
+    test("calendarName option must be one of 'auto', 'always', 'never', 'critical'", () => {
         const plainYearMonth = new Temporal.PlainYearMonth(2021, 7);
         expect(() => {
             plainYearMonth.toString({ calendarName: "foo" });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.toString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.toString.js
@@ -72,6 +72,7 @@ describe("correct behavior", () => {
         const values = [
             ["auto", "2021-11-03T01:33:05.1002003+00:00[UTC]"],
             ["never", "2021-11-03T01:33:05.1002003+00:00"],
+            ["critical", "2021-11-03T01:33:05.1002003+00:00[!UTC]"],
         ];
 
         for (const [timeZoneName, expected] of values) {

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.toString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.toString.js
@@ -125,6 +125,23 @@ describe("correct behavior", () => {
         expect(zonedDateTime.toString(options)).toBe("2022-08-08T14:38:40.1002003+00:00[UTC]");
         expect(calledToString).toBeFalse();
     });
+
+    test("calendarName option", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2022, 11, 2, 19, 4, 35, 100, 200, 300);
+        const timeZone = new Temporal.TimeZone("UTC");
+        const zonedDateTime = plainDateTime.toZonedDateTime(timeZone);
+        const values = [
+            ["auto", "2022-11-02T19:04:35.1002003+00:00[UTC]"],
+            ["always", "2022-11-02T19:04:35.1002003+00:00[UTC][u-ca=iso8601]"],
+            ["never", "2022-11-02T19:04:35.1002003+00:00[UTC]"],
+            ["critical", "2022-11-02T19:04:35.1002003+00:00[UTC][!u-ca=iso8601]"],
+        ];
+
+        for (const [calendarName, expected] of values) {
+            const options = { calendarName };
+            expect(zonedDateTime.toString(options)).toBe(expected);
+        }
+    });
 });
 
 describe("errors", () => {
@@ -139,5 +156,12 @@ describe("errors", () => {
         expect(() => {
             zonedDateTime.toString();
         }).toThrowWithMessage(TypeError, "null is not a function");
+    });
+
+    test("calendarName option must be one of 'auto', 'always', 'never', 'critical'", () => {
+        const zonedDateTime = new Temporal.ZonedDateTime(0n, "UTC");
+        expect(() => {
+            zonedDateTime.toString({ calendarName: "foo" });
+        }).toThrowWithMessage(RangeError, "foo is not a valid value for option calendarName");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.withCalendar.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.withCalendar.js
@@ -31,11 +31,11 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "Not an object of type Temporal.ZonedDateTime");
     });
 
-    test("from invalid calendar string", () => {
+    test("from invalid calendar identifier", () => {
         const zonedDateTime = new Temporal.ZonedDateTime(1n, {}, {});
 
         expect(() => {
             zonedDateTime.withCalendar("iso8602foobar");
-        }).toThrowWithMessage(RangeError, "Invalid calendar string 'iso8602foobar'");
+        }).toThrowWithMessage(RangeError, "Invalid calendar identifier 'iso8602foobar'");
     });
 });


### PR DESCRIPTION
Ticks off three boxes in #15525.
"The rest" because one of the conclusions was implemented in https://github.com/SerenityOS/serenity/commit/4567ded8e4ccab7ab7677860bd68e54c19ecc71c :^)
This is my first time making significant changes to the ISO8601 parser, so please take extra care when looking at the changes to it.

```
Summary:
    Diff Tests:
        +201 ✅    -201 ❌
```