### PR TITLE
LibWeb: Small media query improvements

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -350,6 +350,8 @@ bool MediaQuery::evaluate(HTML::Window const& window)
         case MediaType::Screen:
             // FIXME: Disable for printing, when we have printing!
             return MatchResult::True;
+        case MediaType::Unknown:
+            return MatchResult::False;
         // Deprecated, must never match:
         case MediaType::TTY:
         case MediaType::TV:
@@ -444,7 +446,7 @@ bool is_media_feature_name(StringView name)
     return false;
 }
 
-Optional<MediaQuery::MediaType> media_type_from_string(StringView name)
+MediaQuery::MediaType media_type_from_string(StringView name)
 {
     if (name.equals_ignoring_case("all"sv))
         return MediaQuery::MediaType::All;
@@ -468,7 +470,7 @@ Optional<MediaQuery::MediaType> media_type_from_string(StringView name)
         return MediaQuery::MediaType::TTY;
     if (name.equals_ignoring_case("tv"sv))
         return MediaQuery::MediaType::TV;
-    return {};
+    return MediaQuery::MediaType::Unknown;
 }
 
 StringView to_string(MediaQuery::MediaType media_type)
@@ -496,6 +498,8 @@ StringView to_string(MediaQuery::MediaType media_type)
         return "tty"sv;
     case MediaQuery::MediaType::TV:
         return "tv"sv;
+    case MediaQuery::MediaType::Unknown:
+        return "unknown"sv;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.h
@@ -223,6 +223,7 @@ public:
         All,
         Print,
         Screen,
+        Unknown,
 
         // Deprecated, must never match:
         TTY,
@@ -258,7 +259,7 @@ String serialize_a_media_query_list(NonnullRefPtrVector<MediaQuery> const&);
 
 bool is_media_feature_name(StringView name);
 
-Optional<MediaQuery::MediaType> media_type_from_string(StringView);
+MediaQuery::MediaType media_type_from_string(StringView);
 StringView to_string(MediaQuery::MediaType);
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1141,13 +1141,10 @@ Optional<MediaQuery::MediaType> Parser::parse_media_type(TokenStream<ComponentVa
     if (!token.is(Token::Type::Ident))
         return {};
 
-    auto ident = token.token().ident();
-    if (auto media_type = media_type_from_string(ident); media_type.has_value()) {
-        transaction.commit();
-        return media_type.release_value();
-    }
+    transaction.commit();
 
-    return {};
+    auto ident = token.token().ident();
+    return media_type_from_string(ident);
 }
 
 // `<media-in-parens>`, https://www.w3.org/TR/mediaqueries-4/#typedef-media-in-parens

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -367,8 +367,16 @@ Optional<CSS::MediaFeatureValue> Window::query_media_feature(CSS::MediaFeatureID
     case CSS::MediaFeatureID::ColorIndex:
         return CSS::MediaFeatureValue(0);
     // FIXME: device-aspect-ratio
-    // FIXME: device-height
-    // FIXME: device-width
+    case CSS::MediaFeatureID::DeviceHeight:
+        if (auto* page = this->page()) {
+            return CSS::MediaFeatureValue(CSS::Length::make_px(page->screen_rect().height()));
+        }
+        return CSS::MediaFeatureValue(0);
+    case CSS::MediaFeatureID::DeviceWidth:
+        if (auto* page = this->page()) {
+            return CSS::MediaFeatureValue(CSS::Length::make_px(page->screen_rect().width()));
+        }
+        return CSS::MediaFeatureValue(0);
     case CSS::MediaFeatureID::DisplayMode:
         // FIXME: Detect if window is fullscreen
         return CSS::MediaFeatureValue(CSS::ValueID::Browser);


### PR DESCRIPTION
Couple of media query related improvements:
1. Support of `device-height` and `device-width` in media queries
2. Change parser to not fallback into `not all` query for unknown media types -- use `MediaType::Unknown` instead. Makes following test work correctly http://wpt.live/css/css-conditional/at-media-001.html