### PR TITLE
CI: Upgrade `actions/checkout` and `actions/setup-python`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,7 +33,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # Set default Python to python 3.x, and set Python path such that pip install works properly
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
 
       # === OS SETUP ===
 

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -19,28 +19,28 @@ jobs:
           rm -rf "${{ github.workspace }}/*"
 
       - name: Checkout SerenityOS/serenity
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout linusg/libjs-test262
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: linusg/libjs-test262
           path: libjs-test262
 
       - name: Checkout linusg/libjs-website
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: linusg/libjs-website
           path: libjs-website
 
       - name: Checkout tc39/test262
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: tc39/test262
           path: test262
 
       - name: Checkout tc39/test262-parser-tests
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: tc39/test262-parser-tests
           path: test262-parser-tests

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -57,7 +57,9 @@ jobs:
           )
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
 
       - name: Install Python dependencies
         # The setup-python action set default python to python3.x. Note that we are not using system python here.

--- a/.github/workflows/manpages.yml
+++ b/.github/workflows/manpages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: always() && github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: r-lib/actions/setup-pandoc@v1
         with:
           pandoc-version: '2.13'

--- a/.github/workflows/pvs-studio-static-analysis.yml
+++ b/.github/workflows/pvs-studio-static-analysis.yml
@@ -12,7 +12,7 @@ jobs:
       PVS_STUDIO_ANALYSIS_ARCH: i686
     if: always() && github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: "Configure PVS-Studio Repository"
         run: |

--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -15,7 +15,7 @@ jobs:
       SONAR_SERVER_URL: "https://sonarcloud.io"
       SONAR_ANALYSIS_ARCH: i686
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/.github/workflows/twitter.yml
+++ b/.github/workflows/twitter.yml
@@ -8,7 +8,7 @@ jobs:
     if: always() && github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: '14'


### PR DESCRIPTION
Both of these were just trivial version bumps compared to say `actions/cache` and `actions/github-script` which are either awaiting a PR to be merged to requires some refactoring.

This PR partially fi_xes (scrambled as to not autoclose) #15547.