### PR TITLE
CI: Check out PR merge branch instead of source

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,17 @@ jobs:
             arch: 'x86_64'
 
     steps:
+      # Pull requests can trail behind `master` and can cause breakage if merging before running the CI checks on an updated branch.
+      # Luckily, GitHub creates and maintains a merge branch that is updated whenever the target or source branch is modified. By
+      # checking this branch out, we gain a stabler `master` at the cost of reproducibility.
       - uses: actions/checkout@v3
+        if: ${{ github.event_name != 'pull_request' }}
+
+      - uses: actions/checkout@v3
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
       # Set default Python to python 3.x, and set Python path such that pip install works properly
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Rerunning actions in a PR will now result in CI testing against the merged PR branch, hopefully resulting in fewer `master` breakages.

Enabling the "Require branches to be up to date before merging" feature of protected branches allows us to specify specific checks that should succeed before a PR can be merged by a maintainer, optionally bypassing it:

![image](https://user-images.githubusercontent.com/3210731/199706556-5b7cef4d-a1a4-43b5-ad6f-192090bb83a7.png)