### PR TITLE
LibXML+LibWeb: Store the XML document's original source

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -217,7 +217,7 @@ public:
     JS::NonnullGCPtr<HTMLCollection> all();
 
     String const& source() const { return m_source; }
-    void set_source(String const& source) { m_source = source; }
+    void set_source(String source) { m_source = move(source); }
 
     HTML::EnvironmentSettingsObject& relevant_settings_object();
 

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -46,6 +46,11 @@ XMLDocumentBuilder::XMLDocumentBuilder(DOM::Document& document, XMLScriptingSupp
 {
 }
 
+void XMLDocumentBuilder::set_source(String source)
+{
+    m_document.set_source(move(source));
+}
+
 void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name, String> const& attributes)
 {
     if (m_has_error)

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.h
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.h
@@ -29,6 +29,7 @@ public:
     bool has_error() const { return m_has_error; }
 
 private:
+    virtual void set_source(String) override;
     virtual void element_start(XML::Name const& name, HashMap<XML::Name, String> const& attributes) override;
     virtual void element_end(XML::Name const& name) override;
     virtual void text(String const& data) override;

--- a/Userland/Libraries/LibXML/Parser/Parser.cpp
+++ b/Userland/Libraries/LibXML/Parser/Parser.cpp
@@ -174,6 +174,7 @@ ErrorOr<void, ParseError> Parser::parse_with_listener(Listener& listener)
 {
     m_listener = &listener;
     ScopeGuard unset_listener { [this] { m_listener = nullptr; } };
+    m_listener->set_source(m_source);
     m_listener->document_start();
     auto result = parse_internal();
     if (result.is_error())

--- a/Userland/Libraries/LibXML/Parser/Parser.cpp
+++ b/Userland/Libraries/LibXML/Parser/Parser.cpp
@@ -282,9 +282,9 @@ ErrorOr<void, ParseError> Parser::parse_prolog()
     auto rollback = rollback_point();
     auto rule = enter_rule();
 
-    // 	prolog ::= XMLDecl Misc* (doctypedecl Misc*)?
+    // prolog ::= XMLDecl Misc* (doctypedecl Misc*)?
     // The following is valid in XML 1.0.
-    // 	prolog ::= XMLDecl? Misc* (doctypedecl Misc*)?
+    // prolog ::= XMLDecl? Misc* (doctypedecl Misc*)?
     if (auto result = parse_xml_decl(); result.is_error()) {
         m_version = Version::Version10;
         m_in_compatibility_mode = true;
@@ -425,7 +425,7 @@ ErrorOr<void, ParseError> Parser::parse_misc()
     auto rollback = rollback_point();
     auto rule = enter_rule();
 
-    // 	Misc ::= Comment | PI | S
+    // Misc ::= Comment | PI | S
     if (auto result = parse_comment(); !result.is_error()) {
         rollback.disarm();
         return {};
@@ -510,7 +510,7 @@ ErrorOr<Name, ParseError> Parser::parse_processing_instruction_target()
     auto rollback = rollback_point();
     auto rule = enter_rule();
 
-    // PITarget	::= Name - (('X' | 'x') ('M' | 'm') ('L' | 'l'))
+    // PITarget ::= Name - (('X' | 'x') ('M' | 'm') ('L' | 'l'))
     auto target = TRY(parse_name());
     auto accept = accept_rule();
 
@@ -645,7 +645,7 @@ ErrorOr<NonnullOwnPtr<Node>, ParseError> Parser::parse_empty_element_tag()
     auto rollback = rollback_point();
     auto rule = enter_rule();
 
-    // 	EmptyElemTag ::= '<' Name (S Attribute)* S? '/>'
+    // EmptyElemTag ::= '<' Name (S Attribute)* S? '/>'
     TRY(expect("<"sv));
     auto accept = accept_rule();
 
@@ -677,7 +677,7 @@ ErrorOr<Attribute, ParseError> Parser::parse_attribute()
     auto rollback = rollback_point();
     auto rule = enter_rule();
 
-    // 	Attribute ::= Name Eq AttValue
+    // Attribute ::= Name Eq AttValue
     auto name = TRY(parse_name());
     auto accept = accept_rule();
 
@@ -828,7 +828,7 @@ ErrorOr<Name, ParseError> Parser::parse_end_tag()
     auto rollback = rollback_point();
     auto rule = enter_rule();
 
-    // 	ETag ::= '</' Name S? '>'
+    // ETag ::= '</' Name S? '>'
     TRY(expect("</"sv));
     auto accept = accept_rule();
 
@@ -1098,17 +1098,17 @@ ErrorOr<AttributeListDeclaration::Definition, ParseError> Parser::parse_attribut
     TRY(skip_whitespace(Required::Yes));
 
     // AttType ::= StringType | TokenizedType | EnumeratedType
-    // 	StringType ::= 'CDATA'
-    //  TokenizedType ::= 'ID'
+    // StringType ::= 'CDATA'
+    // TokenizedType ::= 'ID'
     //                  | 'IDREF'
     //                  | 'IDREFS'
     //                  | 'ENTITY'
     //                  | 'ENTITIES'
     //                  | 'NMTOKEN'
     //                  | 'NMTOKENS'
-    //  EnumeratedType ::= NotationType | Enumeration
-    //  NotationType ::= 'NOTATION' S '(' S? Name (S? '|' S? Name)* S? ')'
-    //  Enumeration ::= '(' S? Nmtoken (S? '|' S? Nmtoken)* S? ')'
+    // EnumeratedType ::= NotationType | Enumeration
+    // NotationType ::= 'NOTATION' S '(' S? Name (S? '|' S? Name)* S? ')'
+    // Enumeration ::= '(' S? Nmtoken (S? '|' S? Nmtoken)* S? ')'
     if (m_lexer.consume_specific("CDATA")) {
         type = AttributeListDeclaration::StringType::CData;
     } else if (m_lexer.consume_specific("IDREFS")) {

--- a/Userland/Libraries/LibXML/Parser/Parser.h
+++ b/Userland/Libraries/LibXML/Parser/Parser.h
@@ -29,6 +29,7 @@ struct ParseError {
 struct Listener {
     virtual ~Listener() { }
 
+    virtual void set_source(String) { }
     virtual void document_start() { }
     virtual void document_end() { }
     virtual void element_start(Name const&, HashMap<Name, String> const&) { }


### PR DESCRIPTION
Similar to how we store an HTML document's original source. This allows the source to be inspected with "View Source" in the Browser.

![Screenshot from 2022-11-03 09-39-09](https://user-images.githubusercontent.com/5600524/199737309-919485c4-1553-47e4-82de-a9f81eeb1f6f.png)
