### PR TITLE
PixelPaint: Fix Tool ImageEditor sync

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -490,8 +490,11 @@ ErrorOr<void> ImageEditor::add_new_layer_from_selection()
 
 void ImageEditor::set_active_tool(Tool* tool)
 {
-    if (m_active_tool == tool)
+    if (m_active_tool == tool) {
+        if (m_active_tool)
+            m_active_tool->setup(*this);
         return;
+    }
 
     if (m_active_tool)
         m_active_tool->clear();


### PR DESCRIPTION
This fixes a scenario in which the active tool can get out of sync in regards to what it believes it the current ImageEditor. In the case where multiple images are open, switching between the editor tabs with a tool selected can lead to this unsynchronized state due to a check that the ImageEditor's active tool matches the current tool, if this check matches the method returns early before we properly set the new editor pointer on the active tool.