### PR TITLE
LibJS: Fix length of PlainDateTime.withPlainTime

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -59,7 +59,7 @@ void PlainDateTimePrototype::initialize(Realm& realm)
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.with, with, 1, attr);
-    define_native_function(realm, vm.names.withPlainTime, with_plain_time, 1, attr);
+    define_native_function(realm, vm.names.withPlainTime, with_plain_time, 0, attr);
     define_native_function(realm, vm.names.withPlainDate, with_plain_date, 1, attr);
     define_native_function(realm, vm.names.withCalendar, with_calendar, 1, attr);
     define_native_function(realm, vm.names.add, add, 1, attr);

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.withPlainTime.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.withPlainTime.js
@@ -1,6 +1,6 @@
 describe("correct behavior", () => {
-    test("length is 1", () => {
-        expect(Temporal.PlainDateTime.prototype.withPlainTime).toHaveLength(1);
+    test("length is 0", () => {
+        expect(Temporal.PlainDateTime.prototype.withPlainTime).toHaveLength(0);
     });
 
     test("basic functionality", () => {


### PR DESCRIPTION
withPlainTime's argument is optional, so the length of the function is actually 0.