### PR TITLE
Meta: Make file-system resizing work on macOS

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -49,6 +49,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
     export PATH="/opt/homebrew/opt/e2fsprogs/sbin:$PATH"
 
     E2FSCK="e2fsck"
+    RESIZE2FS_PATH="resize2fs"
 elif [ "$(uname -s)" = "SerenityOS" ]; then
     E2FSCK="/usr/local/sbin/e2fsck"
 else


### PR DESCRIPTION
Previously we'd fail to execute the resize2fs tool which then results in us recreating the image from scratch:

```
resizing disk image...
Image resized.
line 132: /usr/sbin/resize2fs: No such file or directory failed, not using existing image
done
```