### PR TITLE
LibGUI + PixelPaint: Update TabWidget to include `modified` param for each tab, and apply to PixelPaint

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -120,6 +120,10 @@ public:
 
     void set_editor_color_to_color_at_mouse_position(GUI::MouseEvent const& event, bool sample_all_layers);
 
+    void set_modified(DeprecatedString action_text);
+    void set_unmodified();
+    void update_modified();
+
 private:
     explicit ImageEditor(NonnullRefPtr<Image>);
 

--- a/Userland/Applications/PixelPaint/LevelsDialog.cpp
+++ b/Userland/Applications/PixelPaint/LevelsDialog.cpp
@@ -58,10 +58,8 @@ LevelsDialog::LevelsDialog(GUI::Window* parent_window, ImageEditor* editor)
     };
 
     apply_button->on_click = [this](auto) {
-        if (m_did_change) {
-            m_editor->on_modified_change(true);
+        if (m_did_change)
             m_editor->did_complete_action("Levels"sv);
-        }
 
         cleanup_resources();
         done(ExecResult::OK);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -84,6 +84,7 @@ MainWidget::MainWidget()
                     m_tool_properties_widget->set_enabled(false);
                     set_actions_enabled(false);
                 }
+                update_window_modified();
             });
         }
     };
@@ -117,6 +118,7 @@ void MainWidget::image_editor_did_update_undo_stack()
         m_redo_action->set_enabled(false);
         return;
     }
+    image_editor->update_modified();
 
     auto make_action_text = [](auto prefix, auto suffix) {
         StringBuilder builder;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -95,12 +95,7 @@ MainWidget::MainWidget()
         m_vectorscope_widget->set_image(&image_editor.image());
         m_layer_list_widget->set_image(&image_editor.image());
         m_layer_properties_widget->set_layer(image_editor.active_layer());
-        window()->set_modified(image_editor.is_modified());
-        image_editor.on_modified_change = [this](bool modified) {
-            window()->set_modified(modified);
-            m_histogram_widget->image_changed();
-            m_vectorscope_widget->image_changed();
-        };
+        update_window_modified();
         if (auto* active_tool = m_toolbox->active_tool())
             image_editor.set_active_tool(active_tool);
         m_show_guides_action->set_checked(image_editor.guide_visibility());
@@ -164,7 +159,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 auto& editor = create_new_editor(*image);
                 auto image_title = dialog->image_name().trim_whitespace();
                 editor.set_title(image_title.is_empty() ? "Untitled" : image_title);
-                editor.undo_stack().set_current_unmodified();
+                editor.set_unmodified();
 
                 m_histogram_widget->set_image(image);
                 m_vectorscope_widget->set_image(image);
@@ -1003,7 +998,7 @@ void MainWidget::open_image(Core::File& file)
     auto& editor = create_new_editor(image);
     editor.set_loaded_from_image(m_loader.is_raw_image());
     editor.set_path(file.filename());
-    editor.undo_stack().set_current_unmodified();
+    editor.set_unmodified();
     m_layer_list_widget->set_image(&image);
 }
 
@@ -1020,7 +1015,7 @@ void MainWidget::create_default_image()
     auto& editor = create_new_editor(*image);
     editor.set_title("Untitled");
     editor.set_active_layer(bg_layer);
-    editor.undo_stack().set_current_unmodified();
+    editor.set_unmodified();
 }
 
 void MainWidget::create_image_from_clipboard()
@@ -1074,6 +1069,13 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
 
     image_editor.on_title_change = [&](auto const& title) {
         m_tab_widget->set_tab_title(image_editor, title);
+    };
+
+    image_editor.on_modified_change = [&](auto const modified) {
+        m_tab_widget->set_tab_modified(image_editor, modified);
+        update_window_modified();
+        m_histogram_widget->image_changed();
+        m_vectorscope_widget->image_changed();
     };
 
     image_editor.on_image_mouse_position_change = [&](auto const& mouse_position) {
@@ -1174,5 +1176,10 @@ void MainWidget::drop_event(GUI::DropEvent& event)
             return;
         open_image(response.value());
     }
+}
+
+void MainWidget::update_window_modified()
+{
+    window()->set_modified(m_tab_widget->is_any_tab_modified());
 }
 }

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -59,6 +59,8 @@ private:
     virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
+    void update_window_modified();
+
     ProjectLoader m_loader;
 
     RefPtr<ToolboxWidget> m_toolbox;

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -53,7 +53,7 @@ TabWidget::TabWidget()
 
 ErrorOr<void> TabWidget::try_add_widget(Widget& widget)
 {
-    m_tabs.append({ widget.title(), nullptr, &widget });
+    m_tabs.append({ widget.title(), nullptr, &widget, false });
     add_child(widget);
     update_focus_policy();
     if (on_tab_count_change)
@@ -601,6 +601,32 @@ void TabWidget::set_tab_icon(Widget& tab, Gfx::Bitmap const* icon)
             return;
         }
     }
+}
+
+bool TabWidget::is_tab_modified(Widget& tab_input)
+{
+    auto it = m_tabs.find_if([&](auto t) { return t.widget == &tab_input; });
+    if (it.is_end())
+        return false;
+    auto& tab = *it;
+    return tab.modified;
+}
+
+void TabWidget::set_tab_modified(Widget& tab_input, bool modified)
+{
+    auto it = m_tabs.find_if([&](auto t) { return t.widget == &tab_input; });
+    if (it.is_end())
+        return;
+    auto& tab = *it;
+    if (tab.modified != modified) {
+        tab.modified = modified;
+        update();
+    }
+}
+
+bool TabWidget::is_any_tab_modified()
+{
+    return any_of(m_tabs, [](auto& t) { return t.modified; });
 }
 
 void TabWidget::activate_next_tab()

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -287,8 +287,14 @@ void TabWidget::paint_event(PaintEvent& event)
                 Gfx::StylePainter::paint_frame(painter, close_button_rect, palette(), Gfx::FrameShape::Box, pressed_close_button ? Gfx::FrameShadow::Sunken : Gfx::FrameShadow::Raised, 1);
 
             Gfx::IntRect icon_rect { close_button_rect.x() + 3, close_button_rect.y() + 3, 6, 6 };
-            painter.draw_line(icon_rect.top_left(), icon_rect.bottom_right(), palette().button_text());
-            painter.draw_line(icon_rect.top_right(), icon_rect.bottom_left(), palette().button_text());
+            if (!m_tabs[i].modified) {
+                painter.draw_line(icon_rect.top_left(), icon_rect.bottom_right(), palette().button_text());
+                painter.draw_line(icon_rect.top_right(), icon_rect.bottom_left(), palette().button_text());
+            } else {
+                painter.draw_line(icon_rect.top_left().moved_right(1), icon_rect.bottom_right().translated(-1, -1), palette().button_text());
+                painter.draw_line(icon_rect.top_right().moved_left(1), icon_rect.bottom_left().translated(1, -1), palette().button_text());
+                painter.draw_line(icon_rect.bottom_left().moved_down(1), icon_rect.bottom_right().moved_down(1), palette().button_text(), 1, Painter::LineStyle::Dotted);
+            }
         }
     }
 
@@ -355,8 +361,14 @@ void TabWidget::paint_event(PaintEvent& event)
             Gfx::StylePainter::paint_frame(painter, close_button_rect, palette(), Gfx::FrameShape::Box, pressed_close_button ? Gfx::FrameShadow::Sunken : Gfx::FrameShadow::Raised, 1);
 
         Gfx::IntRect icon_rect { close_button_rect.x() + 3, close_button_rect.y() + 3, 6, 6 };
-        painter.draw_line(icon_rect.top_left(), icon_rect.bottom_right(), palette().button_text());
-        painter.draw_line(icon_rect.top_right(), icon_rect.bottom_left(), palette().button_text());
+        if (!m_tabs[i].modified) {
+            painter.draw_line(icon_rect.top_left(), icon_rect.bottom_right(), palette().button_text());
+            painter.draw_line(icon_rect.top_right(), icon_rect.bottom_left(), palette().button_text());
+        } else {
+            painter.draw_line(icon_rect.top_left().moved_right(1), icon_rect.bottom_right().translated(-1, -1), palette().button_text());
+            painter.draw_line(icon_rect.top_right().moved_left(1), icon_rect.bottom_left().translated(1, -1), palette().button_text());
+            painter.draw_line(icon_rect.bottom_left().moved_down(1), icon_rect.bottom_right().moved_down(1), palette().button_text(), 1, Painter::LineStyle::Dotted);
+        }
     }
 }
 

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -79,6 +79,10 @@ public:
     void set_tab_title(Widget& tab, StringView title);
     void set_tab_icon(Widget& tab, Gfx::Bitmap const*);
 
+    bool is_tab_modified(Widget& tab);
+    void set_tab_modified(Widget& tab, bool modified);
+    bool is_any_tab_modified();
+
     void activate_next_tab();
     void activate_previous_tab();
     void activate_last_tab();
@@ -139,6 +143,7 @@ private:
         DeprecatedString title;
         RefPtr<Gfx::Bitmap> icon;
         Widget* widget { nullptr };
+        bool modified { false };
     };
     Vector<TabData> m_tabs;
     TabPosition m_tab_position { TabPosition::Top };


### PR DESCRIPTION
This makes PixelPaint window look through all tabs for it's own modified flag
undo_stack modification has been consolidated to helper functions, cleaning up inconsistencies