### PR TITLE
AK: Check for width of floating point types properly

### DIFF
--- a/AK/FloatingPoint.h
+++ b/AK/FloatingPoint.h
@@ -15,13 +15,9 @@ namespace AK {
 template<typename T>
 union FloatExtractor;
 
-#if ARCH(I386) || ARCH(X86_64) || ARCH(AARCH64)
-// FIXME: There is no straightforward way, I can think of, to check
-// in compile time that long double is really an 80-bit IEEE574 floating point number.
-static_assert(__LDBL_MAX__ == 1.189731495357231765e4932L);
-
+#ifdef AK_HAS_FLOAT_80
 template<>
-union FloatExtractor<long double> {
+union FloatExtractor<f80> {
     static constexpr int mantissa_bits = 64;
     static constexpr unsigned long long mantissa_max = ~0u;
     static constexpr int exponent_bias = 16383;
@@ -32,12 +28,12 @@ union FloatExtractor<long double> {
         unsigned exponent : 15;
         unsigned sign : 1;
     };
-    long double d;
+    f80 d;
 };
 #endif
 
 template<>
-union FloatExtractor<double> {
+union FloatExtractor<f64> {
     static constexpr int mantissa_bits = 52;
     static constexpr unsigned long long mantissa_max = (1ull << 52) - 1;
     static constexpr int exponent_bias = 1023;
@@ -48,11 +44,11 @@ union FloatExtractor<double> {
         unsigned exponent : 11;
         unsigned sign : 1;
     };
-    double d;
+    f64 d;
 };
 
 template<>
-union FloatExtractor<float> {
+union FloatExtractor<f32> {
     static constexpr int mantissa_bits = 23;
     static constexpr unsigned mantissa_max = (1 << 23) - 1;
     static constexpr int exponent_bias = 127;
@@ -63,7 +59,7 @@ union FloatExtractor<float> {
         unsigned exponent : 8;
         unsigned sign : 1;
     };
-    float d;
+    f32 d;
 };
 
 template<size_t S, size_t E, size_t M>

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -19,6 +19,22 @@ using i32 = __INT32_TYPE__;
 using i16 = __INT16_TYPE__;
 using i8 = __INT8_TYPE__;
 
+#ifndef KERNEL
+using f32 = float;
+static_assert(__FLT_MANT_DIG__ == 24 && __FLT_MAX_EXP__ == 128);
+
+using f64 = double;
+static_assert(__DBL_MANT_DIG__ == 53 && __DBL_MAX_EXP__ == 1024);
+
+#    if __LDBL_MANT_DIG__ == 64 && __LDBL_MAX_EXP__ == 16384
+#        define AK_HAS_FLOAT_80 1
+using f80 = long double;
+#    elif __LDBL_MANT_DIG__ == 113 && __LDBL_MAX_EXP__ == 16384
+#        define AK_HAS_FLOAT_128 1
+using f128 = long double;
+#    endif
+#endif
+
 #ifdef AK_OS_SERENITY
 
 using size_t = __SIZE_TYPE__;


### PR DESCRIPTION
This, hopefully, fixes build on Apple arm64. Furthermore, it prevents LibC from silently using wrong FloatExtractor when `long double` width is unexpected (\ne 80 bits).