### PR TITLE
LibJS: Use more accurate number-to-string method in Intl.NumberFormat and Number.prototype.[toExponential,toPrecision]

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/MathematicalValue.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/MathematicalValue.cpp
@@ -296,7 +296,7 @@ bool MathematicalValue::is_zero() const
 String MathematicalValue::to_string() const
 {
     return m_value.visit(
-        [](double value) { return Value(value).to_string_without_side_effects(); },
+        [](double value) { return number_to_string(value, NumberToStringMode::WithoutExponent); },
         [](Crypto::SignedBigInteger const& value) { return value.to_base(10); },
         [](auto) -> String { VERIFY_NOT_REACHED(); });
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -1032,11 +1032,6 @@ RawFormatResult to_raw_precision(MathematicalValue const& number, int min_precis
     }
     // 3. Else,
     else {
-        // FIXME: The result of these steps isn't entirely accurate for large values of 'p' (which
-        //        defaults to 21, resulting in numbers on the order of 10^21). Either AK::format or
-        //        our Number::toString AO (double_to_string in Value.cpp) will need to be improved
-        //        to produce more accurate results.
-
         // a. Let n1 and e1 each be an integer and r1 a mathematical value, with r1 = ToRawPrecisionFn(n1, e1, p), such that r1 ≤ x and r1 is maximized.
         auto [number1, exponent1, rounded1] = to_raw_precision_function(number, precision, PreferredResult::LessThanNumber);
 

--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -386,17 +386,13 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_precision)
     }
     // 10. Else,
     else {
-        // FIXME: The computations below fall apart for large values of 'p'. A double typically has 52 mantissa bits, which gives us
-        //        up to 2^52 before loss of precision. However, the largest value of 'p' may be 100, resulting in numbers on the order
-        //        of 10^100, thus we lose precision in these computations.
-
         // a. Let e and n be integers such that 10^(p-1) ≤ n < 10^p and for which n × 10^(e-p+1) - x is as close to zero as possible.
         //    If there are two such sets of e and n, pick the e and n for which n × 10^(e-p+1) is larger.
         exponent = static_cast<int>(floor(log10(number)));
         number = round(number / pow(10, exponent - precision + 1));
 
         // b. Let m be the String value consisting of the digits of the decimal representation of n (in order, with no leading zeroes).
-        number_string = decimal_digits_to_string(number);
+        number_string = number_to_string(number, NumberToStringMode::WithoutExponent);
 
         // c. If e < -6 or e ≥ p, then
         if ((exponent < -6) || (exponent >= precision)) {

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -564,6 +564,11 @@ ThrowCompletionOr<TriState> is_less_than(VM&, Value lhs, Value rhs, bool left_fi
 
 double to_integer_or_infinity(double);
 
+enum class NumberToStringMode {
+    WithExponent,
+    WithoutExponent,
+};
+String number_to_string(double, NumberToStringMode = NumberToStringMode::WithExponent);
 Optional<Value> string_to_number(StringView);
 
 inline bool Value::operator==(Value const& value) const { return same_value(*this, value); }

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
@@ -135,6 +135,12 @@ describe("style=decimal", () => {
         expect(en.format(1.23456)).toBe("1.23456");
         expect(en.format(1.234567)).toBe("1.23457");
         expect(en.format(1.234561)).toBe("1.23456");
+        expect(en.format("12344501000000000000000000000000000")).toBe(
+            "12,344,501,000,000,000,000,000,000,000,000,000.000"
+        );
+        expect(en.format("-12344501000000000000000000000000000")).toBe(
+            "-12,344,501,000,000,000,000,000,000,000,000,000.000"
+        );
 
         const ar = new Intl.NumberFormat("ar", {
             minimumFractionDigits: 3,
@@ -149,6 +155,13 @@ describe("style=decimal", () => {
         expect(ar.format(1.23456)).toBe("\u0661\u066b\u0662\u0663\u0664\u0665\u0666");
         expect(ar.format(1.234567)).toBe("\u0661\u066b\u0662\u0663\u0664\u0665\u0667");
         expect(ar.format(1.234561)).toBe("\u0661\u066b\u0662\u0663\u0664\u0665\u0666");
+
+        let digits = "\u0661\u0662\u066c\u0663\u0664\u0664\u066c\u0665\u0660\u0661";
+        digits += "\u066c\u0660\u0660\u0660".repeat(9);
+        digits += "\u066b\u0660\u0660\u0660";
+
+        expect(ar.format("12344501000000000000000000000000000")).toBe(digits);
+        expect(ar.format("-12344501000000000000000000000000000")).toBe("\u061c-" + digits);
     });
 
     test("notation=scientific", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Number/Number.prototype.toExponential.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Number/Number.prototype.toExponential.js
@@ -48,6 +48,9 @@ describe("correct behavior", () => {
             [1, 0, "1e+0"],
             [5, 1, "5.0e+0"],
             [9, 3, "9.000e+0"],
+
+            // Disabled for now due to: https://github.com/SerenityOS/serenity/issues/15924
+            // [3, 100, "3." + "0".repeat(100) + "e+0"],
         ].forEach(test => {
             expect(test[0].toExponential(test[1])).toBe(test[2]);
         });
@@ -83,6 +86,8 @@ describe("correct behavior", () => {
             [0.13, "1.3e-1"],
             [0.0345, "3.45e-2"],
             [0.006789, "6.789e-3"],
+            [1.1e-32, "1.1e-32"],
+            [123.456, "1.23456e+2"],
         ].forEach(test => {
             expect(test[0].toExponential()).toBe(test[1]);
         });

--- a/Userland/Libraries/LibJS/Tests/builtins/Number/Number.prototype.toPrecision.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Number/Number.prototype.toPrecision.js
@@ -87,6 +87,9 @@ describe("correct behavior", () => {
             [1, 4, "1.000"],
             [123, 4, "123.0"],
             [123.45, 4, "123.5"],
+
+            // Disabled for now due to: https://github.com/SerenityOS/serenity/issues/15924
+            // [3, 100, "3." + "0".repeat(99)],
         ].forEach(test => {
             expect(test[0].toPrecision(test[1])).toBe(test[2]);
         });


### PR DESCRIPTION
Fixes the following tests:
```
test/built-ins/Number/prototype/toExponential/range.js                         ❌ -> ✅
test/built-ins/Number/prototype/toExponential/undefined-fractiondigits.js      ❌ -> ✅
test/built-ins/Number/prototype/toPrecision/range.js                           ❌ -> ✅
test/intl402/NumberFormat/prototype/format/format-fraction-digits-precision.js ❌ -> ✅
```

This doesn't do the same for `String.prototype.toFixed` because that requires a more accurate conversion than `Number::toString`. See Note 2 here:
https://tc39.es/ecma262/#sec-number.prototype.tofixed

> The output of toFixed may be more precise than toString for some values because toString only prints enough significant digits to distinguish the number from adjacent Number values. For example,
>
>`(1000000000000000128).toString()` returns `"1000000000000000100"`, while
>`(1000000000000000128).toFixed(0)` returns `"1000000000000000128"`.

There are also still some failures for `toExponential` and `toPrecision` that need to be figured out:
```
❌ /home/flynn/workspace/libjs-test262/test262/test/built-ins/Number/prototype/toExponential/return-values.js                                                                                                                                                                                                                                                                                                                                                                     
❌ /home/flynn/workspace/libjs-test262/test262/test/built-ins/Number/prototype/toPrecision/exponential.js
```