### PR TITLE
Add the noexcept qualifiers to IsFunction

### DIFF
--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -140,6 +140,55 @@ template<class Ret, class... Args>
 inline constexpr bool IsFunction<Ret(Args...) const volatile&&> = true;
 template<class Ret, class... Args>
 inline constexpr bool IsFunction<Ret(Args..., ...) const volatile&&> = true;
+    
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction < Ret(Args...) const noexcept = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) const noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) volatile noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) volatile noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) const volatile noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) const volatile noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...)& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...)& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) const& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) const& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) volatile& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) volatile& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) const volatile& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) const volatile& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...)&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...)&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) const&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) const&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) volatile&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) volatile&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) const volatile&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) const volatile&& noexcept> = true;
 
 template<class T>
 inline constexpr bool IsRvalueReference = false;


### PR DESCRIPTION
As of C++17, the `noexcept` qualifiers were made as part of the type so adding that to `IsFunction`. Functions with `noexcept` will now be able to recognised as a function by IsFunction.