### PR TITLE
StdLibExtraDetails: Add noexcept to IsFunction

### DIFF
--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -140,6 +140,54 @@ template<class Ret, class... Args>
 inline constexpr bool IsFunction<Ret(Args...) const volatile&&> = true;
 template<class Ret, class... Args>
 inline constexpr bool IsFunction<Ret(Args..., ...) const volatile&&> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction < Ret(Args...) const noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) const noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) volatile noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) volatile noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) const volatile noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) const volatile noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...)& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...)& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) const& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) const& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) volatile& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) volatile& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) const volatile& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) const volatile& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...)&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...)&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) const&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) const&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) volatile&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) volatile&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args...) const volatile&& noexcept> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsFunction<Ret(Args..., ...) const volatile&& noexcept> = true;
 
 template<class T>
 inline constexpr bool IsRvalueReference = false;


### PR DESCRIPTION
As of c++17, a `noexcept` specifier is part of a `class`/`struct`'s type so if passed a `noexcept` function will result in a false value of `IsFunction`.