### PR TITLE
Userland: Accept drag_enter events for widgets supporting file drops

### DIFF
--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -91,6 +91,7 @@ private:
         glEndList();
     }
 
+    virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void resize_event(GUI::ResizeEvent&) override;
@@ -124,6 +125,13 @@ private:
     GLint m_mag_filter = GL_NEAREST;
     float m_zoom = 1;
 };
+
+void GLContextWidget::drag_enter_event(GUI::DragEvent& event)
+{
+    auto const& mime_types = event.mime_types();
+    if (mime_types.contains_slow("text/uri-list"))
+        event.accept();
+}
 
 void GLContextWidget::drop_event(GUI::DropEvent& event)
 {

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -872,6 +872,13 @@ void MainWidget::update_preview()
         m_font_preview_window->update();
 }
 
+void MainWidget::drag_enter_event(GUI::DragEvent& event)
+{
+    auto const& mime_types = event.mime_types();
+    if (mime_types.contains_slow("text/uri-list"))
+        event.accept();
+}
+
 void MainWidget::drop_event(GUI::DropEvent& event)
 {
     event.accept();

--- a/Userland/Applications/FontEditor/MainWidget.h
+++ b/Userland/Applications/FontEditor/MainWidget.h
@@ -62,6 +62,7 @@ private:
     ErrorOr<void> create_undo_stack();
     ErrorOr<RefPtr<GUI::Window>> create_preview_window();
 
+    virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
     void undo();

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -564,6 +564,13 @@ void HexEditorWidget::set_value_inspector_visible(bool visible)
     m_side_panel_container->set_visible(visible || m_search_results_container->is_visible());
 }
 
+void HexEditorWidget::drag_enter_event(GUI::DragEvent& event)
+{
+    auto const& mime_types = event.mime_types();
+    if (mime_types.contains_slow("text/uri-list"))
+        event.accept();
+}
+
 void HexEditorWidget::drop_event(GUI::DropEvent& event)
 {
     event.accept();

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -36,6 +36,8 @@ private:
     void set_search_results_visible(bool visible);
     void set_value_inspector_visible(bool visible);
     void update_inspector_values(size_t position);
+
+    virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
     RefPtr<HexEditor> m_editor;

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -198,6 +198,13 @@ void ViewWidget::load_from_file(String const& path)
     reset_view();
 }
 
+void ViewWidget::drag_enter_event(GUI::DragEvent& event)
+{
+    auto const& mime_types = event.mime_types();
+    if (mime_types.contains_slow("text/uri-list"))
+        event.accept();
+}
+
 void ViewWidget::drop_event(GUI::DropEvent& event)
 {
     event.accept();

--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -58,6 +58,7 @@ private:
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void mouseup_event(GUI::MouseEvent&) override;
+    virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
     void set_bitmap(Gfx::Bitmap const* bitmap);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1133,6 +1133,13 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
     return image_editor;
 }
 
+void MainWidget::drag_enter_event(GUI::DragEvent& event)
+{
+    auto const& mime_types = event.mime_types();
+    if (mime_types.contains_slow("text/uri-list"))
+        event.accept();
+}
+
 void MainWidget::drop_event(GUI::DropEvent& event)
 {
     if (!event.mime_data().has_urls())

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -56,6 +56,7 @@ private:
 
     void set_actions_enabled(bool enabled);
 
+    virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
     ProjectLoader m_loader;

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -119,6 +119,13 @@ void SoundPlayerWidgetAdvancedView::set_nonlinear_volume_slider(bool nonlinear)
     m_nonlinear_volume_slider = nonlinear;
 }
 
+void SoundPlayerWidgetAdvancedView::drag_enter_event(GUI::DragEvent& event)
+{
+    auto const& mime_types = event.mime_types();
+    if (mime_types.contains_slow("text/uri-list"))
+        event.accept();
+}
+
 void SoundPlayerWidgetAdvancedView::drop_event(GUI::DropEvent& event)
 {
     event.accept();

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
@@ -57,6 +57,7 @@ private:
 
     void sync_previous_next_actions();
 
+    void drag_enter_event(GUI::DragEvent& event) override;
     void drop_event(GUI::DropEvent& event) override;
     GUI::Window& m_window;
 

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -748,6 +748,13 @@ bool MainWidget::request_close()
     return false;
 }
 
+void MainWidget::drag_enter_event(GUI::DragEvent& event)
+{
+    auto const& mime_types = event.mime_types();
+    if (mime_types.contains_slow("text/uri-list"))
+        event.accept();
+}
+
 void MainWidget::drop_event(GUI::DropEvent& event)
 {
     event.accept();

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -54,6 +54,7 @@ private:
     WebView::OutOfProcessWebView& ensure_web_view();
     void set_web_view_visible(bool);
 
+    virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
     enum class ShowMessageIfNoResults {

--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -134,6 +134,13 @@ void PreviewWidget::resize_event(GUI::ResizeEvent&)
     update_preview_window_locations();
 }
 
+void PreviewWidget::drag_enter_event(GUI::DragEvent& event)
+{
+    auto const& mime_types = event.mime_types();
+    if (mime_types.contains_slow("text/uri-list"))
+        event.accept();
+}
+
 void PreviewWidget::drop_event(GUI::DropEvent& event)
 {
     event.accept();

--- a/Userland/Applications/ThemeEditor/PreviewWidget.h
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.h
@@ -33,6 +33,7 @@ private:
     virtual void paint_preview(GUI::PaintEvent&) override;
     virtual void second_paint_event(GUI::PaintEvent&) override;
     virtual void resize_event(GUI::ResizeEvent&) override;
+    virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
     virtual void palette_changed() override;
 

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -348,6 +348,13 @@ void Editor::mousedown_event(GUI::MouseEvent& event)
     GUI::TextEditor::mousedown_event(event);
 }
 
+void Editor::drag_enter_event(GUI::DragEvent& event)
+{
+    auto const& mime_types = event.mime_types();
+    if (mime_types.contains_slow("text/uri-list"))
+        event.accept();
+}
+
 void Editor::drop_event(GUI::DropEvent& event)
 {
     event.accept();

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -65,6 +65,7 @@ private:
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
+    virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
     virtual void enter_event(Core::Event&) override;
     virtual void leave_event(Core::Event&) override;

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -397,6 +397,13 @@ void MainWidget::update_editor_actions(ScriptEditor* editor)
     m_redo_action->set_enabled(editor->redo_action().is_enabled());
 }
 
+void MainWidget::drag_enter_event(GUI::DragEvent& event)
+{
+    auto const& mime_types = event.mime_types();
+    if (mime_types.contains_slow("text/uri-list"))
+        event.accept();
+}
+
 void MainWidget::drop_event(GUI::DropEvent& drop_event)
 {
     drop_event.accept();

--- a/Userland/DevTools/SQLStudio/MainWidget.h
+++ b/Userland/DevTools/SQLStudio/MainWidget.h
@@ -36,6 +36,7 @@ private:
     void update_statusbar(ScriptEditor*);
     void update_editor_actions(ScriptEditor*);
 
+    virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
     RefPtr<GUI::Action> m_new_action;

--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -201,6 +201,13 @@ void QuickLaunchWidget::config_string_did_change(String const& domain, String co
     }
 }
 
+void QuickLaunchWidget::drag_enter_event(GUI::DragEvent& event)
+{
+    auto const& mime_types = event.mime_types();
+    if (mime_types.contains_slow("text/uri-list"))
+        event.accept();
+}
+
 void QuickLaunchWidget::drop_event(GUI::DropEvent& event)
 {
     event.accept();

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -83,6 +83,7 @@ public:
     virtual void config_key_was_removed(String const&, String const&, String const&) override;
     virtual void config_string_did_change(String const&, String const&, String const&, String const&) override;
 
+    virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
 private:


### PR DESCRIPTION
(aka #14957 part II)

This patch will switch cursor to DragCopy when a user enters a widget while dragging file(s), giving them a visual clue that it *might* be dropped into this widget.

This is a rather naive approach, as the cursor icon will change for any kind of file, as currently programs don’t know the drag contents before dropping it. But after all I think it's better than nothing. :^)

*demo – cursor changes when dragging to QuickLaunchWidget in Taskbar, Pixel Paint, and other apps (even when they don’t really support that format):*

https://user-images.githubusercontent.com/16520278/200083035-1ef15977-c049-47cf-856c-793b23794aaa.mp4
