### PR TITLE
LibWeb: Implement `window.location.origin` and `HTMLElement.dir`

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
@@ -50,6 +50,7 @@ void LocationObject::initialize(JS::Realm& realm)
     define_native_accessor(realm, "search", search_getter, {}, attr);
     define_native_accessor(realm, "protocol", protocol_getter, {}, attr);
     define_native_accessor(realm, "port", port_getter, {}, attr);
+    define_native_accessor(realm, "origin", origin_getter, {}, attr);
 
     define_native_function(realm, "reload", reload, 0, JS::Attribute::Enumerable);
     define_native_function(realm, "replace", replace, 1, JS::Attribute::Enumerable);
@@ -220,6 +221,17 @@ JS_DEFINE_NATIVE_FUNCTION(LocationObject::port_getter)
 
     // 3. Return this's url's port, serialized.
     return JS::js_string(vm, String::number(*location_object->url().port()));
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-origin
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::origin_getter)
+{
+    auto* location_object = TRY(typed_this_value(vm));
+
+    // FIXME: 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
+
+    // 2. Return the serialization of this's url's origin.
+    return JS::js_string(vm, location_object->url().serialize_origin());
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-location-reload

--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.h
@@ -59,6 +59,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(search_getter);
     JS_DECLARE_NATIVE_FUNCTION(protocol_getter);
     JS_DECLARE_NATIVE_FUNCTION(port_getter);
+    JS_DECLARE_NATIVE_FUNCTION(origin_getter);
 
     // [[CrossOriginPropertyDescriptorMap]], https://html.spec.whatwg.org/multipage/browsers.html#crossoriginpropertydescriptormap
     HTML::CrossOriginPropertyDescriptorMap m_cross_origin_property_descriptor_map;

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -54,6 +54,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(declare)                    \
     __ENUMERATE_HTML_ATTRIBUTE(default_)                   \
     __ENUMERATE_HTML_ATTRIBUTE(defer)                      \
+    __ENUMERATE_HTML_ATTRIBUTE(dir)                        \
     __ENUMERATE_HTML_ATTRIBUTE(direction)                  \
     __ENUMERATE_HTML_ATTRIBUTE(dirname)                    \
     __ENUMERATE_HTML_ATTRIBUTE(disabled)                   \

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -52,6 +52,24 @@ void HTMLElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_dataset.ptr());
 }
 
+// https://html.spec.whatwg.org/multipage/dom.html#dom-dir
+String HTMLElement::dir() const
+{
+    auto dir = attribute(HTML::AttributeNames::dir);
+#define __ENUMERATE_HTML_ELEMENT_DIR_ATTRIBUTE(keyword) \
+    if (dir.equals_ignoring_case(#keyword##sv))         \
+        return #keyword##sv;
+    ENUMERATE_HTML_ELEMENT_DIR_ATTRIBUTES
+#undef __ENUMERATE_HTML_ELEMENT_DIR_ATTRIBUTE
+
+    return {};
+}
+
+void HTMLElement::set_dir(String const& dir)
+{
+    MUST(set_attribute(HTML::AttributeNames::dir, dir));
+}
+
 HTMLElement::ContentEditableState HTMLElement::content_editable_state() const
 {
     auto contenteditable = attribute(HTML::AttributeNames::contenteditable);

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -12,6 +12,12 @@
 
 namespace Web::HTML {
 
+// https://html.spec.whatwg.org/multipage/dom.html#attr-dir
+#define ENUMERATE_HTML_ELEMENT_DIR_ATTRIBUTES   \
+    __ENUMERATE_HTML_ELEMENT_DIR_ATTRIBUTE(ltr) \
+    __ENUMERATE_HTML_ELEMENT_DIR_ATTRIBUTE(rtl) \
+    __ENUMERATE_HTML_ELEMENT_DIR_ATTRIBUTE(auto)
+
 class HTMLElement
     : public DOM::Element
     , public HTML::GlobalEventHandlers {
@@ -21,6 +27,9 @@ public:
     virtual ~HTMLElement() override;
 
     String title() const { return attribute(HTML::AttributeNames::title); }
+
+    String dir() const;
+    void set_dir(String const&);
 
     virtual bool is_editable() const final;
     String content_editable() const;

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -7,6 +7,7 @@ interface HTMLElement : Element {
 
     [Reflect] attribute DOMString title;
     [Reflect] attribute DOMString lang;
+    attribute DOMString dir;
 
     [Reflect] attribute boolean hidden;
 


### PR DESCRIPTION
This PR implements `window.location.origin` and  `HTMLElement.dir` (but doesn't implement the algorithm described at https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute)