### PR TITLE
Toolchain: Disable makeinfo for binutils.

### DIFF
--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -376,8 +376,8 @@ pushd "$DIR/Build/$ARCH"
             popd
         fi
         echo "XXX build binutils"
-        buildstep "binutils/build" "$MAKE" -j "$MAKEJOBS" || exit 1
-        buildstep "binutils/install" "$MAKE" install || exit 1
+        buildstep "binutils/build" "$MAKE" MAKEINFO=true -j "$MAKEJOBS" || exit 1
+        buildstep "binutils/install" "$MAKE" MAKEINFO=true install || exit 1
     popd
 
     echo "XXX serenity libc headers"


### PR DESCRIPTION
This is necessary to build on Mac OS. As discussed in #15530, Serenity no longer appears to build on Mac OS Ventura. This attempts to fix that by enforcing it at the command level.