### PR TITLE
Browser: Add a context menu item to take a full document screenshot

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -244,13 +244,13 @@ void BrowserWindow::build_menus()
         this);
     m_inspect_dom_node_action->set_status_tip("Open inspector for this element");
 
-    m_take_screenshot_action = GUI::Action::create(
-        "&Take Screenshot"sv, g_icon_bag.filetype_image, [this](auto&) {
+    m_take_visible_screenshot_action = GUI::Action::create(
+        "Take &Visible Screenshot"sv, g_icon_bag.filetype_image, [this](auto&) {
             if (auto result = take_screenshot(); result.is_error())
                 GUI::MessageBox::show_error(this, String::formatted("{}", result.error()));
         },
         this);
-    m_take_screenshot_action->set_status_tip("Save a screenshot of the current tab to the Downloads directory"sv);
+    m_take_visible_screenshot_action->set_status_tip("Save a screenshot of the visible portion of the current tab to the Downloads directory"sv);
 
     auto& inspect_menu = add_menu("&Inspect");
     inspect_menu.add_action(*m_view_source_action);

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -39,7 +39,7 @@ public:
     GUI::Action& view_source_action() { return *m_view_source_action; }
     GUI::Action& inspect_dom_tree_action() { return *m_inspect_dom_tree_action; }
     GUI::Action& inspect_dom_node_action() { return *m_inspect_dom_node_action; }
-    GUI::Action& take_screenshot_action() { return *m_take_screenshot_action; }
+    GUI::Action& take_visible_screenshot_action() { return *m_take_visible_screenshot_action; }
 
     void content_filters_changed();
     void proxy_mappings_changed();
@@ -70,7 +70,7 @@ private:
     RefPtr<GUI::Action> m_view_source_action;
     RefPtr<GUI::Action> m_inspect_dom_tree_action;
     RefPtr<GUI::Action> m_inspect_dom_node_action;
-    RefPtr<GUI::Action> m_take_screenshot_action;
+    RefPtr<GUI::Action> m_take_visible_screenshot_action;
 
     CookieJar& m_cookie_jar;
     WindowActions m_window_actions;

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -40,6 +40,7 @@ public:
     GUI::Action& inspect_dom_tree_action() { return *m_inspect_dom_tree_action; }
     GUI::Action& inspect_dom_node_action() { return *m_inspect_dom_node_action; }
     GUI::Action& take_visible_screenshot_action() { return *m_take_visible_screenshot_action; }
+    GUI::Action& take_full_screenshot_action() { return *m_take_full_screenshot_action; }
 
     void content_filters_changed();
     void proxy_mappings_changed();
@@ -59,7 +60,11 @@ private:
 
     virtual void event(Core::Event&) override;
 
-    ErrorOr<void> take_screenshot();
+    enum class ScreenshotType {
+        Visible,
+        Full,
+    };
+    ErrorOr<void> take_screenshot(ScreenshotType);
 
     RefPtr<GUI::Action> m_go_back_action;
     RefPtr<GUI::Action> m_go_forward_action;
@@ -71,6 +76,7 @@ private:
     RefPtr<GUI::Action> m_inspect_dom_tree_action;
     RefPtr<GUI::Action> m_inspect_dom_node_action;
     RefPtr<GUI::Action> m_take_visible_screenshot_action;
+    RefPtr<GUI::Action> m_take_full_screenshot_action;
 
     CookieJar& m_cookie_jar;
     WindowActions m_window_actions;

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -406,6 +406,7 @@ Tab::Tab(BrowserWindow& window)
     m_page_context_menu->add_action(window.inspect_dom_node_action());
     m_page_context_menu->add_separator();
     m_page_context_menu->add_action(window.take_visible_screenshot_action());
+    m_page_context_menu->add_action(window.take_full_screenshot_action());
     view().on_context_menu_request = [&](auto& screen_position) {
         m_page_context_menu->popup(screen_position);
     };

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -405,7 +405,7 @@ Tab::Tab(BrowserWindow& window)
     m_page_context_menu->add_action(window.inspect_dom_tree_action());
     m_page_context_menu->add_action(window.inspect_dom_node_action());
     m_page_context_menu->add_separator();
-    m_page_context_menu->add_action(window.take_screenshot_action());
+    m_page_context_menu->add_action(window.take_visible_screenshot_action());
     view().on_context_menu_request = [&](auto& screen_position) {
         m_page_context_menu->popup(screen_position);
     };

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -622,6 +622,11 @@ Gfx::ShareableBitmap OutOfProcessWebView::take_element_screenshot(i32 element_id
     return client().take_element_screenshot(element_id);
 }
 
+Gfx::ShareableBitmap OutOfProcessWebView::take_document_screenshot()
+{
+    return client().take_document_screenshot();
+}
+
 Messages::WebContentServer::WebdriverExecuteScriptResponse OutOfProcessWebView::webdriver_execute_script(String const& body, Vector<String> const& json_arguments, Optional<u64> const& timeout, bool async)
 {
     return client().webdriver_execute_script(body, json_arguments, timeout, async);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -86,6 +86,7 @@ public:
 
     Gfx::ShareableBitmap take_screenshot() const;
     Gfx::ShareableBitmap take_element_screenshot(i32 element_id);
+    Gfx::ShareableBitmap take_document_screenshot();
 
     Messages::WebContentServer::WebdriverExecuteScriptResponse webdriver_execute_script(String const& body, Vector<String> const& json_arguments, Optional<u64> const& timeout, bool async);
 

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -708,6 +708,20 @@ Messages::WebContentServer::TakeElementScreenshotResponse ConnectionFromClient::
     return { bitmap->to_shareable_bitmap() };
 }
 
+Messages::WebContentServer::TakeDocumentScreenshotResponse ConnectionFromClient::take_document_screenshot()
+{
+    auto* document = page().top_level_browsing_context().active_document();
+    if (!document || !document->document_element())
+        return { {} };
+
+    auto rect = calculate_absolute_rect_of_element(page(), *document->document_element());
+
+    auto bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, rect.size()).release_value_but_fixme_should_propagate_errors();
+    m_page_host->paint(rect, *bitmap);
+
+    return { bitmap->to_shareable_bitmap() };
+}
+
 Messages::WebContentServer::GetSelectedTextResponse ConnectionFromClient::get_selected_text()
 {
     return page().focused_context().selected_text();

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -96,6 +96,7 @@ private:
     virtual Messages::WebContentServer::GetElementRectResponse get_element_rect(i32 element_id) override;
     virtual Messages::WebContentServer::IsElementEnabledResponse is_element_enabled(i32 element_id) override;
     virtual Messages::WebContentServer::TakeElementScreenshotResponse take_element_screenshot(i32 element_id) override;
+    virtual Messages::WebContentServer::TakeDocumentScreenshotResponse take_document_screenshot() override;
 
     virtual Messages::WebContentServer::GetLocalStorageEntriesResponse get_local_storage_entries() override;
     virtual Messages::WebContentServer::GetSessionStorageEntriesResponse get_session_storage_entries() override;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -53,6 +53,7 @@ endpoint WebContentServer
     get_element_rect(i32 element_id) => (Gfx::IntRect rect)
     is_element_enabled(i32 element_id) => (bool enabled)
     take_element_screenshot(i32 element_id) => (Gfx::ShareableBitmap data)
+    take_document_screenshot() => (Gfx::ShareableBitmap data)
 
     webdriver_execute_script(String body, Vector<String> json_arguments, Optional<u64> timeout, bool async) => (Web::WebDriver::ExecuteScriptResultType result_type, String json_result)
 


### PR DESCRIPTION
[Screencast from 2022-11-05 00-16-31.webm](https://user-images.githubusercontent.com/5600524/200100384-9bc633e1-e777-4b2e-8cd0-f5d7cdb0e651.webm)
