### PR TITLE
Toolchain+Meta: Add Rust stage 1 cross-compiler port

### DIFF
--- a/Ports/.hosted_defs.sh
+++ b/Ports/.hosted_defs.sh
@@ -18,6 +18,8 @@ if [ -z "${HOST_CC:=}" ]; then
     export HOST_PKG_CONFIG_DIR="${PKG_CONFIG_DIR:=}"
     export HOST_PKG_CONFIG_SYSROOT_DIR="${PKG_CONFIG_SYSROOT_DIR:=}"
     export HOST_PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR:=}"
+    unset CARGO_BUILD_TARGET
+    export HOST_CARGO_HOME="${CARGO_HOME:=}"
 fi
 
 export SERENITY_SOURCE_DIR="$(realpath "${SCRIPT}/../")"
@@ -33,6 +35,9 @@ if [ "$SERENITY_TOOLCHAIN" = "Clang" ]; then
     export OBJCOPY="llvm-objcopy"
     export STRIP="llvm-strip"
     export CXXFILT="llvm-cxxfilt"
+    export SERENITY_RUST_DIR="${SERENITY_SOURCE_DIR}/Toolchain/Local/rust"
+    export CARGO_BUILD_TARGET="${SERENITY_ARCH}-unknown-serenity"
+    export CARGO_HOME="${SERENITY_RUST_DIR}/.cargo"
 else
     export SERENITY_BUILD_DIR="${SERENITY_SOURCE_DIR}/Build/${SERENITY_ARCH}"
     export SERENITY_TOOLCHAIN_BINDIR="${SERENITY_SOURCE_DIR}/Toolchain/Local/${SERENITY_ARCH}/bin"
@@ -47,6 +52,10 @@ else
 fi
 
 export PATH="${SERENITY_TOOLCHAIN_BINDIR}:${HOST_PATH}"
+
+if [ ! -z "${SERENITY_RUST_DIR+x}" ]; then
+    export PATH="${SERENITY_RUST_DIR}/bin:${PATH}"
+fi
 
 export PKG_CONFIG_DIR=""
 export PKG_CONFIG_SYSROOT_DIR="${SERENITY_BUILD_DIR}/Root"

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -73,6 +73,8 @@ host_env() {
     export PKG_CONFIG_DIR="${HOST_PKG_CONFIG_DIR}"
     export PKG_CONFIG_SYSROOT_DIR="${HOST_PKG_CONFIG_SYSROOT_DIR}"
     export PKG_CONFIG_LIBDIR="${HOST_PKG_CONFIG_LIBDIR}"
+    unset CARGO_BUILD_TARGET
+    export CARGO_HOME="${HOST_CARGO_HOME}"
     enable_ccache
 }
 

--- a/Toolchain/BuildRust.sh
+++ b/Toolchain/BuildRust.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# === CONFIGURATION AND SETUP ===
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo "$DIR"
+
+PREFIX="$DIR/Local/rust/"
+BUILD="$DIR/../Build/"
+
+MD5SUM="md5sum"
+SED="sed"
+REALPATH="realpath"
+NPROC="nproc"
+
+SYSTEM_NAME="$(uname -s)"
+
+if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
+    REALPATH="readlink -f"
+    NPROC="sysctl -n hw.ncpuonline"
+    MD5SUM="md5 -q"
+    export CC=egcc
+    export CXX=eg++
+    export LDFLAGS=-Wl,-z,notext
+elif [ "$SYSTEM_NAME" = "FreeBSD" ]; then
+    NPROC="sysctl -n hw.ncpu"
+    MD5SUM="md5 -q"
+elif [ "$SYSTEM_NAME" = "Darwin" ]; then
+    MD5SUM="md5 -q"
+    NPROC="sysctl -n hw.ncpu"
+    REALPATH="grealpath"  # GNU coreutils
+    SED="gsed"            # GNU sed
+fi
+
+if [ -z "$MAKEJOBS" ]; then
+    MAKEJOBS=$($NPROC)
+fi
+
+if [ ! -d "$BUILD" ]; then
+    mkdir -p "$BUILD"
+fi
+BUILD=$($REALPATH "$BUILD")
+
+git_patch=
+while [ "$1" != "" ]; do
+    case $1 in
+        --dev )           git_patch=1
+                          ;;
+    esac
+    shift
+done
+
+echo PREFIX is "$PREFIX"
+
+mkdir -p "$DIR/Tarballs"
+
+RUST_VERSION=1.65.0
+RUST_NAME="rustc-${RUST_VERSION}-src"
+RUST_PACKAGE="${RUST_NAME}.tar.gz"
+RUST_URL="https://static.rust-lang.org/dist/${RUST_PACKAGE}"
+RUST_MD5SUM=a4b7f70abcba3933fe955e3229a0095d
+
+RUST_LIBC_VERSION=0.2.137
+RUST_LIBC_NAME="libc-${RUST_LIBC_VERSION}"
+RUST_LIBC_PACKAGE="${RUST_LIBC_NAME}.tar.gz"
+RUST_LIBC_URL="https://github.com/rust-lang/libc/archive/refs/tags/${RUST_LIBC_VERSION}.tar.gz"
+RUST_LIBC_MD5SUM=58229505df135b4a107dcf9518c74517
+
+buildstep() {
+    NAME=$1
+    shift
+    "$@" 2>&1 | sed $'s|^|\x1b[34m['"${NAME}"$']\x1b[39m |'
+}
+
+### Grab rust and rust/libc
+pushd "$DIR/Tarballs"
+
+    ## Download
+    md5=""
+    if [ -e "$RUST_PACKAGE" ]; then
+        md5="$($MD5SUM ${RUST_PACKAGE} | cut -f1 -d' ')"
+        echo "rust md5='$md5'"
+    fi
+
+    if [ "$md5" != ${RUST_MD5SUM} ] ; then
+        rm -f ${RUST_PACKAGE}
+        curl -LO "${RUST_URL}"
+    else
+        echo "Skipped downloading rust"
+    fi
+
+    md5=""
+    if [ -e "${RUST_LIBC_PACKAGE}" ]; then
+        md5="$($MD5SUM ${RUST_LIBC_PACKAGE} | cut -f1 -d' ')"
+        echo "rust libc md5='$md5'"
+    fi
+    if [ "$md5" != ${RUST_LIBC_MD5SUM} ] ; then
+        rm -f "${RUST_LIBC_PACKAGE}"
+        curl -o "${RUST_LIBC_PACKAGE}" -L "${RUST_LIBC_URL}" 
+    else
+        echo "Skipped downloading rust libc"
+    fi
+
+    ## Extract
+
+    patch_rust_md5="$(${MD5SUM} "${DIR}"/Patches/rust/*.patch)"
+
+    if [ ! -d "${RUST_NAME}" ] || [ "$(cat ${RUST_NAME}/.patch.applied)" != "${patch_rust_md5}" ]; then
+        if [ -d ${RUST_NAME} ]; then
+            rm -rf "${RUST_NAME}"
+            rm -rf "${DIR}/Build/rust/${RUST_NAME}"
+        fi
+        echo "Extracting rust..."
+        tar -xzf ${RUST_PACKAGE}
+
+        pushd ${RUST_NAME}
+            if [ "${git_patch}" = "1" ]; then
+                git init > /dev/null
+                git add . > /dev/null
+                git commit -am "BASE" > /dev/null
+                git am --keep-non-patch "${DIR}"/Patches/rust/*.patch > /dev/null
+            else
+                for patch in "${DIR}"/Patches/rust/*.patch; do
+                    patch -p1 < "${patch}" > /dev/null
+                done
+            fi
+            ${MD5SUM} "${DIR}"/Patches/rust/*.patch > .patch.applied
+        popd
+    else
+        echo "Using existing rust source directory"
+    fi
+
+    patch_libc_md5="$(${MD5SUM} "${DIR}"/Patches/rust-libc/*.patch)"
+
+    if [ ! -d "${RUST_LIBC_NAME}" ] || [ "$(cat ${RUST_LIBC_NAME}/.patch.applied)" != "${patch_libc_md5}" ]; then
+        if [ -d ${RUST_LIBC_NAME} ]; then
+            rm -rf "${RUST_LIBC_NAME}"
+        fi
+        echo "Extracting rust libc..."
+        tar -xzf ${RUST_LIBC_PACKAGE}
+
+        # NOTE: Always create a git repo here, or the rust Cargo.toml will be unhappy with our libc
+        pushd ${RUST_LIBC_NAME}
+            git init > /dev/null
+            git add . > /dev/null
+            git commit -am "BASE" > /dev/null
+            git am --keep-non-patch "${DIR}"/Patches/rust-libc/*.patch > /dev/null
+            git tag -a "${RUST_LIBC_VERSION}" -m ""
+            ${MD5SUM} "${DIR}"/Patches/rust-libc/*.patch > .patch.applied
+        popd
+    else
+        echo "Using existing rust libc source directory"
+    fi
+popd
+
+#### Build rust for serenity
+
+rm -rf "${PREFIX}"
+mkdir -p "$PREFIX"
+
+mkdir -p "$DIR/Build/rust"
+
+export CARGO_HOME="$DIR/Local/rust/.cargo"
+mkdir -p "${CARGO_HOME}"
+
+pushd "$DIR/Tarballs/${RUST_NAME}"
+
+    export DESTDIR="$PREFIX"
+
+    # Generate config.toml for building rust itself with proper absolute paths for the current serenity tree
+    "$SED" "s|@SERENITY_TOOLCHAIN_ROOT@|${DIR}|g" "$DIR/Rust/rust-config.toml.in" > "$DIR/Tarballs/${RUST_NAME}/config.toml"
+
+    # Generate config.toml for use by rust and any rust Ports
+    # @TODO: Consider "cloning" local libc source to Local/rust somewhere
+    "$SED" "s|@SERENITY_TOOLCHAIN_ROOT@|${DIR}|g" "$DIR/Rust/config.toml.in" > "${CARGO_HOME}/config.toml"
+    "$SED" -i "s|@RUST_LIBC_NAME@|${RUST_LIBC_NAME}|g" "${CARGO_HOME}/config.toml"
+
+    cargo update -p libc --precise "${RUST_LIBC_VERSION}"
+
+    buildstep serenity-stage1 python3 ./x.py --color always --build-dir "$DIR/Build/rust" install -i --stage 1 --target x86_64-unknown-serenity compiler/rustc library/std cargo rustfmt
+
+    # Make sure we have proc_macros available for host with a matching version, in case the developer doesn't have
+    # a nightly installed that they keep up to date. If adding more/different hosts here, update config.toml.in [build.target]
+    buildstep host python3 ./x.py --color always --build-dir "$DIR/Build/rust"  install -i --stage 1 --target x86_64-unknown-linux-gnu library/std
+
+popd

--- a/Toolchain/Patches/rust-libc/0001-serenity-Add-initial-SerenityOS-support.patch
+++ b/Toolchain/Patches/rust-libc/0001-serenity-Add-initial-SerenityOS-support.patch
@@ -1,0 +1,1244 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andreas Kling <kling@serenityos.org>
+Date: Wed, 20 Apr 2022 21:32:48 +0200
+Subject: [PATCH] serenity: Add initial SerenityOS support
+
+
+Co-Authored-By: Andrew Kaster <akaster@serenityos.org>
+Co-Authored-By: Daniel Bertalan <dani@danielbertalan.dev>
+---
+ src/unix/mod.rs          |    3 +
+ src/unix/serenity/mod.rs | 1210 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 1213 insertions(+)
+ create mode 100644 src/unix/serenity/mod.rs
+
+diff --git a/src/unix/mod.rs b/src/unix/mod.rs
+index ecc693e3db10531d1621cb872eab51f63a1b8ec0..30b638cf521c06dbce57f579b280cbc8e6e6507e 100644
+--- a/src/unix/mod.rs
++++ b/src/unix/mod.rs
+@@ -1497,6 +1497,9 @@ cfg_if! {
+     } else if #[cfg(target_os = "haiku")] {
+         mod haiku;
+         pub use self::haiku::*;
++    } else if #[cfg(target_os = "serenity")] {
++        mod serenity;
++        pub use self::serenity::*;
+     } else if #[cfg(target_os = "hermit")] {
+         mod hermit;
+         pub use self::hermit::*;
+diff --git a/src/unix/serenity/mod.rs b/src/unix/serenity/mod.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..7f536dfa8802d37bebfa03033f875bd5f142ad72
+--- /dev/null
++++ b/src/unix/serenity/mod.rs
+@@ -0,0 +1,1210 @@
++pub type c_char = i8;
++pub type c_long = i64;
++pub type c_ulong = u64;
++pub type wchar_t = i32;
++
++pub type blkcnt_t = u32;
++pub type blksize_t = u32;
++pub type clock_t = u32;
++pub type clockid_t = ::c_int;
++pub type dev_t = u32;
++pub type fsblkcnt_t = u64;
++pub type fsfilcnt_t = u64;
++pub type ino_t = u64;
++pub type mode_t = u16;
++pub type nfds_t = u32;
++pub type nlink_t = u32;
++pub type off_t = i64;
++pub type pthread_t = ::c_int;
++pub type pthread_attr_t = *mut ::c_void;
++
++pub struct pthread_cond_t {
++    __mutex: *mut ::c_void,
++    __value: u32,
++    __clockid: ::c_int,
++}
++
++pub struct pthread_condattr_t {
++    __clockid: ::c_int,
++}
++
++// Must be usize due to libstd/sys_common/thread_local.rs,
++// should technically be *mut ::c_void
++pub type pthread_key_t = usize;
++
++pub struct pthread_mutex_t {
++    __lock: u32,
++    __owner: pthread_t,
++    __level: i32,
++    __type: i32,
++}
++
++pub struct pthread_mutexattr_t {
++    __type: i32,
++}
++
++pub type pthread_rwlock_t = u64;
++pub type pthread_rwlockattr_t = *mut ::c_void;
++pub type rlim_t = ::size_t;
++pub type sa_family_t = u16;
++pub type sem_t = *mut ::c_void;
++pub type sigset_t = u32;
++pub type socklen_t = u32;
++pub type speed_t = u32;
++pub type suseconds_t = i32;
++pub type tcflag_t = u32;
++pub type time_t = i64;
++
++#[cfg_attr(feature = "extra_traits", derive(Debug))]
++pub enum timezone {}
++
++impl ::Copy for timezone {}
++
++impl ::Clone for timezone {
++    fn clone(&self) -> timezone {
++        *self
++    }
++}
++
++s_no_extra_traits! {
++    #[repr(C)]
++    pub struct utsname {
++        pub sysname: [::c_char; UTSLENGTH],
++        pub nodename: [::c_char; UTSLENGTH],
++        pub release: [::c_char; UTSLENGTH],
++        pub version: [::c_char; UTSLENGTH],
++        pub machine: [::c_char; UTSLENGTH],
++        pub domainname: [::c_char; UTSLENGTH],
++    }
++
++    pub struct dirent {
++        pub d_ino: ::ino_t,
++        pub d_off: ::off_t,
++        pub d_reclen: ::c_ushort,
++        pub d_type: ::c_uchar,
++        pub d_name: [::c_char; 256],
++    }
++
++    pub struct sockaddr_un {
++        pub sun_family: ::sa_family_t,
++        pub sun_path: [::c_char; 108]
++    }
++
++    pub struct sockaddr_storage {
++        pub ss_family: ::sa_family_t,
++        __ss_padding: [
++            u8;
++            128 -
++            ::core::mem::size_of::<sa_family_t>() -
++            ::core::mem::size_of::<c_ulong>()
++        ],
++        __ss_align: ::c_ulong,
++    }
++}
++
++s! {
++    pub struct addrinfo {
++        pub ai_flags: ::c_int,
++        pub ai_family: ::c_int,
++        pub ai_socktype: ::c_int,
++        pub ai_protocol: ::c_int,
++        pub ai_addrlen: ::size_t,
++        pub ai_canonname: *mut ::c_char,
++        pub ai_addr: *mut ::sockaddr,
++        pub ai_next: *mut ::addrinfo,
++    }
++
++    pub struct Dl_info {
++        pub dli_fname: *const ::c_char,
++        pub dli_fbase: *mut ::c_void,
++        pub dli_sname: *const ::c_char,
++        pub dli_saddr: *mut ::c_void,
++    }
++
++    pub struct epoll_event {
++        pub events: u32,
++        pub u64: u64,
++        pub _pad: u64,
++    }
++
++    pub struct fd_set {
++        fds_bits: [::c_ulong; ::FD_SETSIZE / ULONG_SIZE],
++    }
++
++    pub struct in_addr {
++        pub s_addr: ::in_addr_t,
++    }
++
++    pub struct ip_mreq {
++        pub imr_multiaddr: ::in_addr,
++        pub imr_interface: ::in_addr,
++    }
++
++    pub struct lconv {
++        pub decimal_point: *const ::c_char,
++        pub thousands_sep: *const ::c_char,
++        pub grouping: *const ::c_char,
++        pub int_curr_symbol: *const ::c_char,
++        pub currency_symbol: *const ::c_char,
++        pub mon_decimal_point: *const ::c_char,
++        pub mon_thousands_sep: *const ::c_char,
++        pub mon_grouping: *const ::c_char,
++        pub negative_sign: *const ::c_char,
++        pub positive_sign: *const ::c_char,
++        pub int_frac_digits: ::c_char,
++        pub frac_digits: ::c_char,
++        pub p_cs_precedes: ::c_char,
++        pub p_sep_by_space: ::c_char,
++        pub n_cs_precedes: ::c_char,
++        pub n_sep_by_space: ::c_char,
++        pub p_sign_posn: ::c_char,
++        pub n_sign_posn: ::c_char,
++    }
++
++    pub struct passwd {
++        pub pw_name: *mut ::c_char,
++        pub pw_passwd: *mut ::c_char,
++        pub pw_uid: ::uid_t,
++        pub pw_gid: ::gid_t,
++        pub pw_gecos: *mut ::c_char,
++        pub pw_dir: *mut ::c_char,
++        pub pw_shell: *mut ::c_char,
++    }
++
++    pub struct sigaction {
++        pub sa_sigaction: ::sighandler_t,
++        pub sa_mask: ::sigset_t,
++        pub sa_flags: ::c_int,
++    }
++
++    pub struct siginfo_t {
++        pub si_signo: ::c_int,
++        pub si_code: ::c_int,
++        pub si_errno: ::c_int,
++        pub si_pid: ::c_int,
++        pub si_uid: ::uid_t,
++        pub si_addr: *mut ::c_void,
++        pub si_status: ::c_int,
++        pub si_band: ::c_int,
++        pub si_value: *mut ::c_void,
++    }
++
++    pub struct sockaddr {
++        pub sa_family: ::sa_family_t,
++        pub sa_data: [::c_char; 14],
++    }
++
++    pub struct sockaddr_in {
++        pub sin_family: ::sa_family_t,
++        pub sin_port: ::in_port_t,
++        pub sin_addr: ::in_addr,
++        pub sin_zero: [::c_char; 8],
++    }
++
++    pub struct sockaddr_in6 {
++        pub sin6_family: ::sa_family_t,
++        pub sin6_port: ::in_port_t,
++        pub sin6_flowinfo: u32,
++        pub sin6_addr: ::in6_addr,
++        pub sin6_scope_id: u32,
++    }
++
++    pub struct stat {
++        pub st_dev: ::dev_t,
++        pub st_ino: ::ino_t,
++        pub st_mode: ::mode_t,
++        pub st_nlink: ::nlink_t,
++        pub st_uid: ::uid_t,
++        pub st_gid: ::gid_t,
++        pub st_rdev: ::dev_t,
++        pub st_size: ::off_t,
++        pub st_blksize: ::blksize_t,
++        pub st_blocks: ::blkcnt_t,
++        pub st_atime: ::time_t,
++        pub st_atime_nsec: ::c_long,
++        pub st_mtime: ::time_t,
++        pub st_mtime_nsec: ::c_long,
++        pub st_ctime: ::time_t,
++        pub st_ctime_nsec: ::c_long,
++    }
++
++    pub struct statvfs {
++        pub f_bsize: ::c_ulong,
++        pub f_frsize: ::c_ulong,
++        pub f_blocks: ::fsblkcnt_t,
++        pub f_bfree: ::fsblkcnt_t,
++        pub f_bavail: ::fsblkcnt_t,
++        pub f_files: ::fsfilcnt_t,
++        pub f_ffree: ::fsfilcnt_t,
++        pub f_favail: ::fsfilcnt_t,
++        pub f_fsid: ::c_ulong,
++        pub f_flag: ::c_ulong,
++        pub f_namemax: ::c_ulong,
++    }
++
++    pub struct termios {
++        pub c_iflag: ::tcflag_t,
++        pub c_oflag: ::tcflag_t,
++        pub c_cflag: ::tcflag_t,
++        pub c_lflag: ::tcflag_t,
++        pub c_line: ::cc_t,
++        pub c_cc: [::cc_t; ::NCCS],
++        pub c_ispeed: ::speed_t,
++        pub c_ospeed: ::speed_t,
++    }
++
++    pub struct tm {
++        pub tm_sec: ::c_int,
++        pub tm_min: ::c_int,
++        pub tm_hour: ::c_int,
++        pub tm_mday: ::c_int,
++        pub tm_mon: ::c_int,
++        pub tm_year: ::c_int,
++        pub tm_wday: ::c_int,
++        pub tm_yday: ::c_int,
++        pub tm_isdst: ::c_int,
++        pub tm_gmtoff: ::c_long,
++        pub tm_zone: *const ::c_char,
++    }
++}
++
++pub const UTSLENGTH: usize = 65;
++
++// intentionally not public, only used for fd_set
++cfg_if! {
++    if #[cfg(target_pointer_width = "32")] {
++        const ULONG_SIZE: usize = 32;
++    } else if #[cfg(target_pointer_width = "64")] {
++        const ULONG_SIZE: usize = 64;
++    } else {
++        // Unknown target_pointer_width
++    }
++}
++
++// limits.h
++pub const PATH_MAX: ::c_int = 4096;
++
++// fcntl.h
++pub const F_GETLK: ::c_int = 5;
++pub const F_SETLK: ::c_int = 6;
++pub const F_SETLKW: ::c_int = 7;
++
++pub const AT_FDCWD: ::c_int = -100;
++pub const AT_SYMLINK_NOFOLLOW: ::c_int = 0x100;
++pub const AT_REMOVEDIR: ::c_int = 0x200;
++
++pub const RTLD_DEFAULT: *mut ::c_void = 0i64 as *mut ::c_void;
++
++// dlfcn.h
++pub const RTLD_LAZY: ::c_int = 0x0001;
++pub const RTLD_NOW: ::c_int = 0x0002;
++pub const RTLD_GLOBAL: ::c_int = 0x0100;
++pub const RTLD_LOCAL: ::c_int = 0x0000;
++
++// errno.h
++pub const EPERM: ::c_int = 1; /* Operation not permitted */
++pub const ENOENT: ::c_int = 2; /* No such file or directory */
++pub const ESRCH: ::c_int = 3; /* No such process */
++pub const EINTR: ::c_int = 4; /* Interrupted syscall */
++pub const EIO: ::c_int = 5; /* I/O error */
++pub const ENXIO: ::c_int = 6; /* No such device or address */
++pub const E2BIG: ::c_int = 7; /* Argument list too long */
++pub const ENOEXEC: ::c_int = 8; /* Exec format error */
++pub const EBADF: ::c_int = 9; /* Bad fd number */
++pub const ECHILD: ::c_int = 10; /* No child processes */
++pub const EAGAIN: ::c_int = 11; /* Try again */
++pub const EWOULDBLOCK: ::c_int = 11; /* Try again */
++pub const ENOMEM: ::c_int = 12; /* Out of memory */
++pub const EACCES: ::c_int = 13; /* Permission denied */
++pub const EFAULT: ::c_int = 14; /* Bad address */
++pub const ENOTBLK: ::c_int = 15; /* Block device required */
++pub const EBUSY: ::c_int = 16; /* Device or resource busy */
++pub const EEXIST: ::c_int = 17; /* File already exists */
++pub const EXDEV: ::c_int = 18; /* Cross-device link */
++pub const ENODEV: ::c_int = 19; /* No such device */
++pub const ENOTDIR: ::c_int = 20; /* Not a directory */
++pub const EISDIR: ::c_int = 21; /* Is a directory */
++pub const EINVAL: ::c_int = 22; /* Invalid argument */
++pub const ENFILE: ::c_int = 23; /* File table overflow */
++pub const EMFILE: ::c_int = 24; /* Too many open files */
++pub const ENOTTY: ::c_int = 25; /* Not a TTY */
++pub const ETXTBSY: ::c_int = 26; /* Text file busy */
++pub const EFBIG: ::c_int = 27; /* File too large */
++pub const ENOSPC: ::c_int = 28; /* No space left on device */
++pub const ESPIPE: ::c_int = 29; /* Illegal seek */
++pub const EROFS: ::c_int = 30; /* Read-only filesystem */
++pub const EMLINK: ::c_int = 31; /* Too many links */
++pub const EPIPE: ::c_int = 32; /* Broken pipe */
++pub const ERANGE: ::c_int = 33; /* Range error */
++pub const ENAMETOOLONG: ::c_int = 34; /* Name too long */
++pub const ELOOP: ::c_int = 35; /* Too many symlinks */
++pub const EOVERFLOW: ::c_int = 36; /* Overflow */
++pub const EOPNOTSUPP: ::c_int = 37; /* Operation not supported */
++pub const ENOSYS: ::c_int = 38; /* No such syscall */
++pub const ENOTIMPL: ::c_int = 39; /* Not implemented */
++pub const EAFNOSUPPORT: ::c_int = 40; /* Address family not supported */
++pub const ENOTSOCK: ::c_int = 41; /* Not a socket */
++pub const EADDRINUSE: ::c_int = 42; /* Address in use */
++pub const ENOTEMPTY: ::c_int = 43; /* Directory not empty */
++pub const EDOM: ::c_int = 44; /* Math argument out of domain */
++pub const ECONNREFUSED: ::c_int = 45; /* Connection refused */
++pub const EHOSTDOWN: ::c_int = 46; /* Host is down */
++pub const EADDRNOTAVAIL: ::c_int = 47; /* Address not available */
++pub const EISCONN: ::c_int = 48; /* Already connected */
++pub const ECONNABORTED: ::c_int = 49; /* Connection aborted */
++pub const EALREADY: ::c_int = 50; /* Connection already in progress */
++pub const ECONNRESET: ::c_int = 51; /* Connection reset */
++pub const EDESTADDRREQ: ::c_int = 52; /* Destination address required */
++pub const EHOSTUNREACH: ::c_int = 53; /* Host unreachable */
++pub const EILSEQ: ::c_int = 54; /* Illegal byte sequence */
++pub const EMSGSIZE: ::c_int = 55; /* Message size */
++pub const ENETDOWN: ::c_int = 56; /* Network down */
++pub const ENETUNREACH: ::c_int = 57; /* Network unreachable */
++pub const ENETRESET: ::c_int = 58; /* Network reset */
++pub const ENOBUFS: ::c_int = 59; /* No buffer space */
++pub const ENOLCK: ::c_int = 60; /* No lock available */
++pub const ENOMSG: ::c_int = 61; /* No message */
++pub const ENOPROTOOPT: ::c_int = 62; /* No protocol option */
++pub const ENOTCONN: ::c_int = 63; /* Not connected */
++pub const ESHUTDOWN: ::c_int = 64; /* Transport endpoint has shutdown */
++pub const ETOOMANYREFS: ::c_int = 65; /* Too many references */
++pub const ESOCKTNOSUPPORT: ::c_int = 66; /* Socket type not supported */
++pub const EPROTONOSUPPORT: ::c_int = 67; /* Protocol not supported */
++pub const EDEADLK: ::c_int = 68; /* Resource deadlock would occur */
++pub const ETIMEDOUT: ::c_int = 69; /* Timed out */
++pub const EPROTOTYPE: ::c_int = 70; /* Wrong protocol type */
++pub const EINPROGRESS: ::c_int = 71; /* Operation in progress */
++pub const ENOTHREAD: ::c_int = 72; /* No such thread */
++pub const EPROTO: ::c_int = 73; /* Protocol error */
++pub const ENOTSUP: ::c_int = 74; /* Not supported */
++pub const EPFNOSUPPORT: ::c_int = 75; /* Protocol family not supported */
++pub const EDIRINTOSELF: ::c_int = 76; /* Cannot make directory a subdirectory of itself */
++pub const EDQUOT: ::c_int = 77; /* Quota exceeded */
++pub const ENOTRECOVERABLE: ::c_int = 78; /* State not recoverable */
++pub const ECANCELED: ::c_int = 79; /* Operation cancelled */
++pub const EPROMISEVIOLATION: ::c_int = 80; /* The process has a promise violation */
++pub const ESTALE: ::c_int = 81; /* Stale network file handle */
++
++// fcntl.h
++pub const F_DUPFD: ::c_int = 0;
++pub const F_GETFD: ::c_int = 1;
++pub const F_SETFD: ::c_int = 2;
++pub const F_GETFL: ::c_int = 3;
++pub const F_SETFL: ::c_int = 4;
++pub const F_DUPFD_CLOEXEC: ::c_int = ::F_DUPFD;
++
++pub const FD_CLOEXEC: ::c_int = 1;
++pub const O_RDONLY: ::c_int = (1 << 0);
++pub const O_WRONLY: ::c_int = (1 << 2);
++pub const O_RDWR: ::c_int = (O_RDONLY | O_WRONLY);
++pub const O_CREAT: ::c_int = (1 << 3);
++pub const O_EXCL: ::c_int = (1 << 4);
++pub const O_TRUNC: ::c_int = (1 << 6);
++pub const O_APPEND: ::c_int = (1 << 7);
++pub const O_NONBLOCK: ::c_int = (1 << 8);
++pub const O_DIRECTORY: ::c_int = (1 << 9);
++pub const O_NOFOLLOW: ::c_int = (1 << 10);
++pub const O_CLOEXEC: ::c_int = (1 << 11);
++
++// FIXME: These don't exist in SerenityOS at the moment:
++pub const O_ACCMODE: ::c_int = 0x0003_0000;
++pub const O_SHLOCK: ::c_int = 0x0010_0000;
++pub const O_EXLOCK: ::c_int = 0x0020_0000;
++pub const O_ASYNC: ::c_int = 0x0040_0000;
++pub const O_FSYNC: ::c_int = 0x0080_0000;
++pub const O_PATH: ::c_int = 0x2000_0000;
++pub const O_SYMLINK: ::c_int = 0x4000_0000;
++
++// netdb.h
++pub const AI_PASSIVE: ::c_int = 0x0001;
++pub const AI_CANONNAME: ::c_int = 0x0002;
++pub const AI_NUMERICHOST: ::c_int = 0x0004;
++pub const AI_NUMERICSERV: ::c_int = 0x0008;
++pub const AI_V4MAPPED: ::c_int = 0x0010;
++pub const AI_ALL: ::c_int = 0x0020;
++pub const AI_ADDRCONFIG: ::c_int = 0x0040;
++
++pub const EAI_ADDRFAMILY: ::c_int = 1;
++pub const EAI_AGAIN: ::c_int = 2;
++pub const EAI_BADFLAGS: ::c_int = 3;
++pub const EAI_FAIL: ::c_int = 4;
++pub const EAI_FAMILY: ::c_int = 5;
++pub const EAI_MEMORY: ::c_int = 6;
++pub const EAI_NODATA: ::c_int = 7;
++pub const EAI_NONAME: ::c_int = 8;
++pub const EAI_SERVICE: ::c_int = 9;
++pub const EAI_SOCKTYPE: ::c_int = 10;
++pub const EAI_SYSTEM: ::c_int = 11;
++pub const EAI_OVERFLOW: ::c_int = 12;
++
++pub const NI_MAXHOST: ::c_int = 1025;
++pub const NI_MAXSERV: ::c_int = 32;
++pub const NI_NUMERICHOST: ::c_int = 1;
++pub const NI_NUMERICSERV: ::c_int = 2;
++pub const NI_NAMEREQD: ::c_int = 0x0008;
++pub const NI_NOFQDN: ::c_int = 0x0004;
++pub const NI_DGRAM: ::c_int = 0x0010;
++
++// netinet/in.h
++pub const IP_TTL: ::c_int = 2;
++pub const IPV6_UNICAST_HOPS: ::c_int = 16;
++pub const IPV6_MULTICAST_IF: ::c_int = 17;
++pub const IPV6_MULTICAST_HOPS: ::c_int = 18;
++pub const IPV6_MULTICAST_LOOP: ::c_int = 19;
++pub const IPV6_ADD_MEMBERSHIP: ::c_int = 20;
++pub const IPV6_DROP_MEMBERSHIP: ::c_int = 21;
++pub const IPV6_V6ONLY: ::c_int = 26;
++pub const IP_MULTICAST_IF: ::c_int = 32;
++pub const IP_MULTICAST_TTL: ::c_int = 33;
++pub const IP_MULTICAST_LOOP: ::c_int = 34;
++pub const IP_ADD_MEMBERSHIP: ::c_int = 35;
++pub const IP_DROP_MEMBERSHIP: ::c_int = 36;
++
++// netinet/tcp.h
++pub const TCP_NODELAY: ::c_int = 1;
++pub const TCP_KEEPIDLE: ::c_int = 1;
++
++// poll.h
++pub const POLLIN: ::c_short = 0x001;
++pub const POLLPRI: ::c_short = 0x002;
++pub const POLLOUT: ::c_short = 0x004;
++pub const POLLERR: ::c_short = 0x008;
++pub const POLLHUP: ::c_short = 0x010;
++pub const POLLNVAL: ::c_short = 0x020;
++
++// pthread.h
++pub const PTHREAD_MUTEX_NORMAL: ::c_int = 0;
++pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 1;
++pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t {
++    __mutex: 0 as *mut ::c_void,
++    __value: 0,
++    __clockid: CLOCK_MONOTONIC_COARSE,
++};
++pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
++    __lock: 0,
++    __owner: 0,
++    __level: 0,
++    __type: 1,
++};
++pub const PTHREAD_RWLOCK_INITIALIZER: ::pthread_rwlock_t = 0;
++pub const PTHREAD_STACK_MIN: ::size_t = 4096;
++
++// signal.h
++pub const SIG_BLOCK: ::c_int = 0;
++pub const SIG_UNBLOCK: ::c_int = 1;
++pub const SIG_SETMASK: ::c_int = 2;
++pub const SIGHUP: ::c_int = 1;
++pub const SIGINT: ::c_int = 2;
++pub const SIGQUIT: ::c_int = 3;
++pub const SIGILL: ::c_int = 4;
++pub const SIGTRAP: ::c_int = 5;
++pub const SIGABRT: ::c_int = 6;
++pub const SIGBUS: ::c_int = 7;
++pub const SIGFPE: ::c_int = 8;
++pub const SIGKILL: ::c_int = 9;
++pub const SIGUSR1: ::c_int = 10;
++pub const SIGSEGV: ::c_int = 11;
++pub const SIGUSR2: ::c_int = 12;
++pub const SIGPIPE: ::c_int = 13;
++pub const SIGALRM: ::c_int = 14;
++pub const SIGTERM: ::c_int = 15;
++pub const SIGSTKFLT: ::c_int = 16;
++pub const SIGCHLD: ::c_int = 17;
++pub const SIGCONT: ::c_int = 18;
++pub const SIGSTOP: ::c_int = 19;
++pub const SIGTSTP: ::c_int = 20;
++pub const SIGTTIN: ::c_int = 21;
++pub const SIGTTOU: ::c_int = 22;
++pub const SIGURG: ::c_int = 23;
++pub const SIGXCPU: ::c_int = 24;
++pub const SIGXFSZ: ::c_int = 25;
++pub const SIGVTALRM: ::c_int = 26;
++pub const SIGPROF: ::c_int = 27;
++pub const SIGWINCH: ::c_int = 28;
++pub const SIGIO: ::c_int = 29;
++pub const SIGPWR: ::c_int = 30;
++pub const SIGSYS: ::c_int = 31;
++pub const NSIG: ::c_int = 32;
++
++pub const SA_NOCLDSTOP: ::c_ulong = 0x00000001;
++pub const SA_NOCLDWAIT: ::c_ulong = 0x00000002;
++pub const SA_SIGINFO: ::c_ulong = 0x00000004;
++pub const SA_RESTORER: ::c_ulong = 0x04000000;
++pub const SA_ONSTACK: ::c_ulong = 0x08000000;
++pub const SA_RESTART: ::c_ulong = 0x10000000;
++pub const SA_NODEFER: ::c_ulong = 0x40000000;
++pub const SA_RESETHAND: ::c_ulong = 0x80000000;
++
++// sys/file.h
++pub const LOCK_SH: ::c_int = 1;
++pub const LOCK_EX: ::c_int = 2;
++pub const LOCK_NB: ::c_int = 4;
++pub const LOCK_UN: ::c_int = 8;
++
++// sys/epoll.h
++pub const EPOLL_CLOEXEC: ::c_int = 0x0100_0000;
++pub const EPOLL_CTL_ADD: ::c_int = 1;
++pub const EPOLL_CTL_DEL: ::c_int = 2;
++pub const EPOLL_CTL_MOD: ::c_int = 3;
++pub const EPOLLIN: ::c_int = 1;
++pub const EPOLLPRI: ::c_int = 0;
++pub const EPOLLOUT: ::c_int = 2;
++pub const EPOLLRDNORM: ::c_int = 0;
++pub const EPOLLNVAL: ::c_int = 0;
++pub const EPOLLRDBAND: ::c_int = 0;
++pub const EPOLLWRNORM: ::c_int = 0;
++pub const EPOLLWRBAND: ::c_int = 0;
++pub const EPOLLMSG: ::c_int = 0;
++pub const EPOLLERR: ::c_int = 0;
++pub const EPOLLHUP: ::c_int = 0;
++pub const EPOLLRDHUP: ::c_int = 0;
++pub const EPOLLEXCLUSIVE: ::c_int = 0;
++pub const EPOLLWAKEUP: ::c_int = 0;
++pub const EPOLLONESHOT: ::c_int = 0;
++pub const EPOLLET: ::c_int = 0;
++
++// sys/stat.h
++pub const S_IFMT: u16 = 0o0_170_000;
++pub const S_IFDIR: u16 = 0o040_000;
++pub const S_IFCHR: u16 = 0o020_000;
++pub const S_IFBLK: u16 = 0o060_000;
++pub const S_IFREG: u16 = 0o100_000;
++pub const S_IFIFO: u16 = 0o010_000;
++pub const S_IFLNK: u16 = 0o120_000;
++pub const S_IFSOCK: u16 = 0o140_000;
++pub const S_IRWXU: u16 = 0o0_700;
++pub const S_IRUSR: u16 = 0o0_400;
++pub const S_IWUSR: u16 = 0o0_200;
++pub const S_IXUSR: u16 = 0o0_100;
++pub const S_IRWXG: u16 = 0o0_070;
++pub const S_IRGRP: u16 = 0o0_040;
++pub const S_IWGRP: u16 = 0o0_020;
++pub const S_IXGRP: u16 = 0o0_010;
++pub const S_IRWXO: u16 = 0o0_007;
++pub const S_IROTH: u16 = 0o0_004;
++pub const S_IWOTH: u16 = 0o0_002;
++pub const S_IXOTH: u16 = 0o0_001;
++
++// stdlib.h
++pub const EXIT_SUCCESS: ::c_int = 0;
++pub const EXIT_FAILURE: ::c_int = 1;
++
++// sys/ioctl.h
++pub const FIONBIO: ::c_ulong = 40;
++pub const FIOCLEX: ::c_ulong = 0x5451;
++pub const TCGETS: ::c_ulong = 2;
++pub const TCSETS: ::c_ulong = 3;
++pub const TCFLSH: ::c_ulong = 4;
++pub const TIOCGPGRP: ::c_ulong = 0;
++pub const TIOCSPGRP: ::c_ulong = 1;
++pub const TIOCGWINSZ: ::c_ulong = 7;
++pub const TIOCSWINSZ: ::c_ulong = 11;
++
++// sys/mman.h
++pub const PROT_NONE: ::c_int = 0x0000;
++pub const PROT_READ: ::c_int = 0x0001;
++pub const PROT_WRITE: ::c_int = 0x0002;
++pub const PROT_EXEC: ::c_int = 0x0004;
++
++pub const MAP_SHARED: ::c_int = 0x0001;
++pub const MAP_PRIVATE: ::c_int = 0x0002;
++pub const MAP_ANON: ::c_int = 0x0020;
++pub const MAP_ANONYMOUS: ::c_int = MAP_ANON;
++pub const MAP_FIXED: ::c_int = 0x0010;
++pub const MAP_FAILED: *mut ::c_void = !0 as _;
++
++pub const MS_ASYNC: ::c_int = 0x0001;
++pub const MS_INVALIDATE: ::c_int = 0x0002;
++pub const MS_SYNC: ::c_int = 0x0004;
++
++// sys/select.h
++pub const FD_SETSIZE: usize = 1024;
++
++// sys/socket.h
++pub const AF_INET: ::c_int = 2;
++pub const AF_INET6: ::c_int = 3;
++pub const AF_UNIX: ::c_int = 1;
++pub const AF_UNSPEC: ::c_int = 0;
++pub const PF_INET: ::c_int = AF_INET;
++pub const PF_INET6: ::c_int = AF_INET6;
++pub const PF_UNIX: ::c_int = AF_UNIX;
++pub const PF_UNSPEC: ::c_int = AF_UNSPEC;
++pub const MSG_TRUNC: ::c_int = 0x1;
++pub const MSG_CTRUNC: ::c_int = 0x2;
++pub const MSG_PEEK: ::c_int = 0x4;
++pub const MSG_OOB: ::c_int = 0x8;
++pub const MSG_DONTROUTE: ::c_int = 0x10;
++pub const MSG_WAITALL: ::c_int = 0x20;
++
++// FIXME: Not implemented on SerenityOS
++pub const MSG_EOR: ::c_int = 128;
++
++pub const SHUT_RD: ::c_int = 1;
++pub const SHUT_WR: ::c_int = 2;
++pub const SHUT_RDWR: ::c_int = 3;
++
++pub const SO_DEBUG: ::c_int = 1;
++pub const SO_REUSEADDR: ::c_int = 2;
++pub const SO_TYPE: ::c_int = 3;
++pub const SO_ERROR: ::c_int = 4;
++pub const SO_DONTROUTE: ::c_int = 5;
++pub const SO_BROADCAST: ::c_int = 6;
++pub const SO_SNDBUF: ::c_int = 7;
++pub const SO_RCVBUF: ::c_int = 8;
++pub const SO_KEEPALIVE: ::c_int = 9;
++pub const SO_OOBINLINE: ::c_int = 10;
++pub const SO_NO_CHECK: ::c_int = 11;
++pub const SO_PRIORITY: ::c_int = 12;
++pub const SO_LINGER: ::c_int = 13;
++pub const SO_BSDCOMPAT: ::c_int = 14;
++pub const SO_REUSEPORT: ::c_int = 15;
++pub const SO_PASSCRED: ::c_int = 16;
++pub const SO_PEERCRED: ::c_int = 17;
++pub const SO_RCVLOWAT: ::c_int = 18;
++pub const SO_SNDLOWAT: ::c_int = 19;
++pub const SO_RCVTIMEO: ::c_int = 20;
++pub const SO_SNDTIMEO: ::c_int = 21;
++pub const SO_ACCEPTCONN: ::c_int = 30;
++pub const SO_PEERSEC: ::c_int = 31;
++pub const SO_SNDBUFFORCE: ::c_int = 32;
++pub const SO_RCVBUFFORCE: ::c_int = 33;
++pub const SO_PROTOCOL: ::c_int = 38;
++pub const SO_DOMAIN: ::c_int = 39;
++
++pub const SOCK_STREAM: ::c_int = 1;
++pub const SOCK_DGRAM: ::c_int = 2;
++pub const SOCK_NONBLOCK: ::c_int = 0o4_000;
++pub const SOCK_CLOEXEC: ::c_int = 0o2_000_000;
++pub const SOCK_SEQPACKET: ::c_int = 5;
++pub const SOL_SOCKET: ::c_int = 1;
++
++// sys/termios.h
++pub const VEOF: usize = 0;
++pub const VEOL: usize = 1;
++pub const VEOL2: usize = 2;
++pub const VERASE: usize = 3;
++pub const VWERASE: usize = 4;
++pub const VKILL: usize = 5;
++pub const VREPRINT: usize = 6;
++pub const VSWTC: usize = 7;
++pub const VINTR: usize = 8;
++pub const VQUIT: usize = 9;
++pub const VSUSP: usize = 10;
++pub const VSTART: usize = 12;
++pub const VSTOP: usize = 13;
++pub const VLNEXT: usize = 14;
++pub const VDISCARD: usize = 15;
++pub const VMIN: usize = 16;
++pub const VTIME: usize = 17;
++pub const NCCS: usize = 32;
++
++pub const IGNBRK: ::tcflag_t = 0o000_001;
++pub const BRKINT: ::tcflag_t = 0o000_002;
++pub const IGNPAR: ::tcflag_t = 0o000_004;
++pub const PARMRK: ::tcflag_t = 0o000_010;
++pub const INPCK: ::tcflag_t = 0o000_020;
++pub const ISTRIP: ::tcflag_t = 0o000_040;
++pub const INLCR: ::tcflag_t = 0o000_100;
++pub const IGNCR: ::tcflag_t = 0o000_200;
++pub const ICRNL: ::tcflag_t = 0o000_400;
++pub const IXON: ::tcflag_t = 0o001_000;
++pub const IXOFF: ::tcflag_t = 0o002_000;
++
++pub const OPOST: ::tcflag_t = 0o000_001;
++pub const ONLCR: ::tcflag_t = 0o000_002;
++pub const OLCUC: ::tcflag_t = 0o000_004;
++pub const OCRNL: ::tcflag_t = 0o000_010;
++pub const ONOCR: ::tcflag_t = 0o000_020;
++pub const ONLRET: ::tcflag_t = 0o000_040;
++pub const OFILL: ::tcflag_t = 0o0000_100;
++pub const OFDEL: ::tcflag_t = 0o0000_200;
++
++pub const B0: speed_t = 0o000_000;
++pub const B50: speed_t = 0o000_001;
++pub const B75: speed_t = 0o000_002;
++pub const B110: speed_t = 0o000_003;
++pub const B134: speed_t = 0o000_004;
++pub const B150: speed_t = 0o000_005;
++pub const B200: speed_t = 0o000_006;
++pub const B300: speed_t = 0o000_007;
++pub const B600: speed_t = 0o000_010;
++pub const B1200: speed_t = 0o000_011;
++pub const B1800: speed_t = 0o000_012;
++pub const B2400: speed_t = 0o000_013;
++pub const B4800: speed_t = 0o000_014;
++pub const B9600: speed_t = 0o000_015;
++pub const B19200: speed_t = 0o000_016;
++pub const B38400: speed_t = 0o000_017;
++
++pub const B57600: speed_t = 0o0_020;
++pub const B115200: speed_t = 0o0_021;
++pub const B230400: speed_t = 0o0_022;
++pub const B460800: speed_t = 0o0_023;
++pub const B500000: speed_t = 0o0_024;
++pub const B576000: speed_t = 0o0_025;
++pub const B921600: speed_t = 0o0_026;
++pub const B1000000: speed_t = 0o0_027;
++pub const B1152000: speed_t = 0o0_030;
++pub const B1500000: speed_t = 0o0_031;
++pub const B2000000: speed_t = 0o0_032;
++pub const B2500000: speed_t = 0o0_033;
++pub const B3000000: speed_t = 0o0_034;
++pub const B3500000: speed_t = 0o0_035;
++pub const B4000000: speed_t = 0o0_036;
++
++pub const CSIZE: ::tcflag_t = 0o001_400;
++pub const CS5: ::tcflag_t = 0o000_000;
++pub const CS6: ::tcflag_t = 0o000_400;
++pub const CS7: ::tcflag_t = 0o001_000;
++pub const CS8: ::tcflag_t = 0o001_400;
++
++pub const CSTOPB: ::tcflag_t = 0o002_000;
++pub const CREAD: ::tcflag_t = 0o004_000;
++pub const PARENB: ::tcflag_t = 0o010_000;
++pub const PARODD: ::tcflag_t = 0o020_000;
++pub const HUPCL: ::tcflag_t = 0o040_000;
++
++pub const CLOCAL: ::tcflag_t = 0o0100000;
++
++pub const ISIG: ::tcflag_t = 0x0000_0080;
++pub const ICANON: ::tcflag_t = 0x0000_0100;
++pub const ECHO: ::tcflag_t = 0x0000_0008;
++pub const ECHOE: ::tcflag_t = 0x0000_0002;
++pub const ECHOK: ::tcflag_t = 0x0000_0004;
++pub const ECHONL: ::tcflag_t = 0x0000_0010;
++pub const NOFLSH: ::tcflag_t = 0x8000_0000;
++pub const TOSTOP: ::tcflag_t = 0x0040_0000;
++pub const IEXTEN: ::tcflag_t = 0x0000_0400;
++
++pub const TCOOFF: ::c_int = 0;
++pub const TCOON: ::c_int = 1;
++pub const TCIOFF: ::c_int = 2;
++pub const TCION: ::c_int = 3;
++
++pub const TCIFLUSH: ::c_int = 0;
++pub const TCOFLUSH: ::c_int = 1;
++pub const TCIOFLUSH: ::c_int = 2;
++
++pub const TCSANOW: ::c_int = 0;
++pub const TCSADRAIN: ::c_int = 1;
++pub const TCSAFLUSH: ::c_int = 2;
++
++// sys/wait.h
++pub const WNOHANG: ::c_int = 1;
++pub const WUNTRACED: ::c_int = 2;
++
++pub const WSTOPPED: ::c_int = 2;
++pub const WEXITED: ::c_int = 4;
++pub const WCONTINUED: ::c_int = 8;
++pub const WNOWAIT: ::c_int = 0x0100_0000;
++
++pub const __WNOTHREAD: ::c_int = 0x2000_0000;
++pub const __WALL: ::c_int = 0x4000_0000;
++#[allow(overflowing_literals)]
++pub const __WCLONE: ::c_int = 0x8000_0000;
++
++// time.h
++pub const CLOCK_REALTIME: ::c_int = 0;
++pub const CLOCK_MONOTONIC: ::c_int = 1;
++pub const CLOCK_MONOTONIC_COARSE: ::c_int = 4;
++pub const CLOCK_PROCESS_CPUTIME_ID: ::clockid_t = 2;
++pub const CLOCKS_PER_SEC: ::clock_t = 1_000;
++
++// unistd.h
++// POSIX.1 {
++pub const _SC_ARG_MAX: ::c_int = 0;
++pub const _SC_CHILD_MAX: ::c_int = 1;
++pub const _SC_CLK_TCK: ::c_int = 2;
++pub const _SC_NGROUPS_MAX: ::c_int = 3;
++pub const _SC_OPEN_MAX: ::c_int = 4;
++pub const _SC_STREAM_MAX: ::c_int = 5;
++pub const _SC_TZNAME_MAX: ::c_int = 6;
++// ...
++pub const _SC_VERSION: ::c_int = 29;
++pub const _SC_PAGESIZE: ::c_int = 30;
++pub const _SC_PAGE_SIZE: ::c_int = 30;
++// ...
++pub const _SC_RE_DUP_MAX: ::c_int = 44;
++// ...
++pub const _SC_LOGIN_NAME_MAX: ::c_int = 71;
++pub const _SC_TTY_NAME_MAX: ::c_int = 72;
++// ...
++pub const _SC_SYMLOOP_MAX: ::c_int = 173;
++// ...
++pub const _SC_HOST_NAME_MAX: ::c_int = 180;
++// } POSIX.1
++
++pub const F_OK: ::c_int = 0;
++pub const R_OK: ::c_int = 4;
++pub const W_OK: ::c_int = 2;
++pub const X_OK: ::c_int = 1;
++
++pub const SEEK_SET: ::c_int = 0;
++pub const SEEK_CUR: ::c_int = 1;
++pub const SEEK_END: ::c_int = 2;
++pub const STDIN_FILENO: ::c_int = 0;
++pub const STDOUT_FILENO: ::c_int = 1;
++pub const STDERR_FILENO: ::c_int = 2;
++
++pub const _PC_LINK_MAX: ::c_int = 0;
++pub const _PC_MAX_CANON: ::c_int = 1;
++pub const _PC_MAX_INPUT: ::c_int = 2;
++pub const _PC_NAME_MAX: ::c_int = 3;
++pub const _PC_PATH_MAX: ::c_int = 4;
++pub const _PC_PIPE_BUF: ::c_int = 5;
++pub const _PC_CHOWN_RESTRICTED: ::c_int = 6;
++pub const _PC_NO_TRUNC: ::c_int = 7;
++pub const _PC_VDISABLE: ::c_int = 8;
++pub const _PC_SYNC_IO: ::c_int = 9;
++pub const _PC_ASYNC_IO: ::c_int = 10;
++pub const _PC_PRIO_IO: ::c_int = 11;
++pub const _PC_SOCK_MAXBUF: ::c_int = 12;
++pub const _PC_FILESIZEBITS: ::c_int = 13;
++pub const _PC_REC_INCR_XFER_SIZE: ::c_int = 14;
++pub const _PC_REC_MAX_XFER_SIZE: ::c_int = 15;
++pub const _PC_REC_MIN_XFER_SIZE: ::c_int = 16;
++pub const _PC_REC_XFER_ALIGN: ::c_int = 17;
++pub const _PC_ALLOC_SIZE_MIN: ::c_int = 18;
++pub const _PC_SYMLINK_MAX: ::c_int = 19;
++pub const _PC_2_SYMLINKS: ::c_int = 20;
++
++pub const PRIO_PROCESS: ::c_int = 0;
++pub const PRIO_PGRP: ::c_int = 1;
++pub const PRIO_USER: ::c_int = 2;
++
++// wait.h
++f! {
++    pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {
++        let fd = fd as usize;
++        let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
++        (*set).fds_bits[fd / size] &= !(1 << (fd % size));
++        return
++    }
++
++    pub fn FD_ISSET(fd: ::c_int, set: *const fd_set) -> bool {
++        let fd = fd as usize;
++        let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
++        return ((*set).fds_bits[fd / size] & (1 << (fd % size))) != 0
++    }
++
++    pub fn FD_SET(fd: ::c_int, set: *mut fd_set) -> () {
++        let fd = fd as usize;
++        let size = ::mem::size_of_val(&(*set).fds_bits[0]) * 8;
++        (*set).fds_bits[fd / size] |= 1 << (fd % size);
++        return
++    }
++
++    pub fn FD_ZERO(set: *mut fd_set) -> () {
++        for slot in (*set).fds_bits.iter_mut() {
++            *slot = 0;
++        }
++    }
++}
++
++safe_f! {
++    pub {const} fn WIFSTOPPED(status: ::c_int) -> bool {
++        (status & 0xff) == 0x7f
++    }
++
++    pub {const} fn WSTOPSIG(status: ::c_int) -> ::c_int {
++        (status >> 8) & 0xff
++    }
++
++    pub {const} fn WIFCONTINUED(status: ::c_int) -> bool {
++        status == 0xffff
++    }
++
++    pub {const} fn WIFSIGNALED(status: ::c_int) -> bool {
++        ((status & 0x7f) + 1) as i8 >= 2
++    }
++
++    pub {const} fn WTERMSIG(status: ::c_int) -> ::c_int {
++        status & 0x7f
++    }
++
++    pub {const} fn WIFEXITED(status: ::c_int) -> bool {
++        (status & 0x7f) == 0
++    }
++
++    pub {const} fn WEXITSTATUS(status: ::c_int) -> ::c_int {
++        (status >> 8) & 0xff
++    }
++
++    pub {const} fn WCOREDUMP(status: ::c_int) -> bool {
++        (status & 0x80) != 0
++    }
++}
++
++extern "C" {
++    // errno.h
++    pub fn __errno_location() -> *mut ::c_int;
++    pub fn strerror_r(errnum: ::c_int, buf: *mut c_char, buflen: ::size_t) -> ::c_int;
++
++    // unistd.h
++    pub fn pipe2(fds: *mut ::c_int, flags: ::c_int) -> ::c_int;
++
++    // malloc.h
++    pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;
++
++    pub fn setgroups(ngroups: ::c_int, ptr: *const ::gid_t) -> ::c_int;
++
++    // netdb.h
++    pub fn getnameinfo(
++        addr: *const ::sockaddr,
++        addrlen: ::socklen_t,
++        host: *mut ::c_char,
++        hostlen: ::socklen_t,
++        serv: *mut ::c_char,
++        servlen: ::socklen_t,
++        flags: ::c_int,
++    ) -> ::c_int;
++
++    // pthread.h
++    pub fn pthread_atfork(
++        prepare: ::Option<unsafe extern "C" fn()>,
++        parent: ::Option<unsafe extern "C" fn()>,
++        child: ::Option<unsafe extern "C" fn()>,
++    ) -> ::c_int;
++    pub fn pthread_create(
++        tid: *mut ::pthread_t,
++        attr: *const ::pthread_attr_t,
++        start: extern "C" fn(*mut ::c_void) -> *mut ::c_void,
++        arg: *mut ::c_void,
++    ) -> ::c_int;
++    pub fn pthread_condattr_setclock(
++        attr: *mut pthread_condattr_t,
++        clock_id: ::clockid_t,
++    ) -> ::c_int;
++    pub fn pthread_setname_np(thread: ::pthread_t, name: *const ::c_char) -> ::c_int;
++
++    // pwd.h
++    pub fn getpwuid_r(
++        uid: ::uid_t,
++        pwd: *mut passwd,
++        buf: *mut ::c_char,
++        buflen: ::size_t,
++        result: *mut *mut passwd,
++    ) -> ::c_int;
++
++    // signal.h
++    pub fn pthread_sigmask(
++        how: ::c_int,
++        set: *const ::sigset_t,
++        oldset: *mut ::sigset_t,
++    ) -> ::c_int;
++    pub fn pthread_cancel(thread: ::pthread_t) -> ::c_int;
++    pub fn pthread_kill(thread: ::pthread_t, sig: ::c_int) -> ::c_int;
++
++    // sys/epoll.h
++    pub fn epoll_create(size: ::c_int) -> ::c_int;
++    pub fn epoll_create1(flags: ::c_int) -> ::c_int;
++    pub fn epoll_wait(
++        epfd: ::c_int,
++        events: *mut ::epoll_event,
++        maxevents: ::c_int,
++        timeout: ::c_int,
++    ) -> ::c_int;
++    pub fn epoll_ctl(epfd: ::c_int, op: ::c_int, fd: ::c_int, event: *mut ::epoll_event)
++        -> ::c_int;
++
++    // sys/ioctl.h
++    pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
++
++    // sys/mman.h
++    pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
++    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
++    pub fn shm_open(name: *const c_char, oflag: ::c_int, mode: mode_t) -> ::c_int;
++    pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
++
++    // sys/resource.h
++    pub fn getrlimit(resource: ::c_int, rlim: *mut ::rlimit) -> ::c_int;
++    pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
++
++    // sys/socket.h
++    pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
++    pub fn recvfrom(
++        socket: ::c_int,
++        buf: *mut ::c_void,
++        len: ::size_t,
++        flags: ::c_int,
++        addr: *mut ::sockaddr,
++        addrlen: *mut ::socklen_t,
++    ) -> ::ssize_t;
++
++    // sys/stat.h
++    pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
++
++    // sys/uio.h
++    pub fn readv(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
++    pub fn writev(fd: ::c_int, iov: *const ::iovec, iovcnt: ::c_int) -> ::ssize_t;
++
++    // sys/utsname.h
++    pub fn uname(utsname: *mut utsname) -> ::c_int;
++
++    // time.h
++    pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::timezone) -> ::c_int;
++    pub fn clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
++}
++
++cfg_if! {
++    if #[cfg(feature = "extra_traits")] {
++        impl PartialEq for dirent {
++            fn eq(&self, other: &dirent) -> bool {
++                self.d_ino == other.d_ino
++                    && self.d_off == other.d_off
++                    && self.d_reclen == other.d_reclen
++                    && self.d_type == other.d_type
++                    && self
++                    .d_name
++                    .iter()
++                    .zip(other.d_name.iter())
++                    .all(|(a,b)| a == b)
++            }
++        }
++
++        impl Eq for dirent {}
++
++        impl ::fmt::Debug for dirent {
++            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
++                f.debug_struct("dirent")
++                    .field("d_ino", &self.d_ino)
++                    .field("d_off", &self.d_off)
++                    .field("d_reclen", &self.d_reclen)
++                    .field("d_type", &self.d_type)
++                // FIXME: .field("d_name", &self.d_name)
++                    .finish()
++            }
++        }
++
++        impl ::hash::Hash for dirent {
++            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
++                self.d_ino.hash(state);
++                self.d_off.hash(state);
++                self.d_reclen.hash(state);
++                self.d_type.hash(state);
++                self.d_name.hash(state);
++            }
++        }
++
++        impl PartialEq for sockaddr_un {
++            fn eq(&self, other: &sockaddr_un) -> bool {
++                self.sun_family == other.sun_family
++                    && self
++                    .sun_path
++                    .iter()
++                    .zip(other.sun_path.iter())
++                    .all(|(a,b)| a == b)
++            }
++        }
++
++        impl Eq for sockaddr_un {}
++
++        impl ::fmt::Debug for sockaddr_un {
++            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
++                f.debug_struct("sockaddr_un")
++                    .field("sun_family", &self.sun_family)
++                // FIXME: .field("sun_path", &self.sun_path)
++                    .finish()
++            }
++        }
++
++        impl ::hash::Hash for sockaddr_un {
++            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
++                self.sun_family.hash(state);
++                self.sun_path.hash(state);
++            }
++        }
++
++        impl PartialEq for sockaddr_storage {
++            fn eq(&self, other: &sockaddr_storage) -> bool {
++                self.ss_family == other.ss_family
++                    && self.__ss_align == self.__ss_align
++                    && self
++                    .__ss_padding
++                    .iter()
++                    .zip(other.__ss_padding.iter())
++                    .all(|(a,b)| a == b)
++            }
++        }
++
++        impl Eq for sockaddr_storage {}
++
++        impl ::fmt::Debug for sockaddr_storage {
++            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
++                f.debug_struct("sockaddr_storage")
++                    .field("ss_family", &self.ss_family)
++                    .field("__ss_align", &self.__ss_align)
++                // FIXME: .field("__ss_padding", &self.__ss_padding)
++                    .finish()
++            }
++        }
++
++        impl ::hash::Hash for sockaddr_storage {
++            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
++                self.ss_family.hash(state);
++                self.__ss_padding.hash(state);
++                self.__ss_align.hash(state);
++            }
++        }
++
++        impl PartialEq for utsname {
++            fn eq(&self, other: &utsname) -> bool {
++                self.sysname
++                    .iter()
++                    .zip(other.sysname.iter())
++                    .all(|(a, b)| a == b)
++                    && self
++                    .nodename
++                    .iter()
++                    .zip(other.nodename.iter())
++                    .all(|(a, b)| a == b)
++                    && self
++                    .release
++                    .iter()
++                    .zip(other.release.iter())
++                    .all(|(a, b)| a == b)
++                    && self
++                    .version
++                    .iter()
++                    .zip(other.version.iter())
++                    .all(|(a, b)| a == b)
++                    && self
++                    .machine
++                    .iter()
++                    .zip(other.machine.iter())
++                    .all(|(a, b)| a == b)
++                    && self
++                    .domainname
++                    .iter()
++                    .zip(other.domainname.iter())
++                    .all(|(a, b)| a == b)
++            }
++        }
++
++        impl Eq for utsname {}
++
++        impl ::fmt::Debug for utsname {
++            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
++                f.debug_struct("utsname")
++                // FIXME: .field("sysname", &self.sysname)
++                // FIXME: .field("nodename", &self.nodename)
++                // FIXME: .field("release", &self.release)
++                // FIXME: .field("version", &self.version)
++                // FIXME: .field("machine", &self.machine)
++                // FIXME: .field("domainname", &self.domainname)
++                    .finish()
++            }
++        }
++
++        impl ::hash::Hash for utsname {
++            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
++                self.sysname.hash(state);
++                self.nodename.hash(state);
++                self.release.hash(state);
++                self.version.hash(state);
++                self.machine.hash(state);
++                self.domainname.hash(state);
++            }
++        }
++    }
++}

--- a/Toolchain/Patches/rust-libc/0002-serenity-Add-wrappers-for-sendfd-recvfd-and-anon_cre.patch
+++ b/Toolchain/Patches/rust-libc/0002-serenity-Add-wrappers-for-sendfd-recvfd-and-anon_cre.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andreas Kling <kling@serenityos.org>
+Date: Thu, 21 Apr 2022 13:18:39 +0200
+Subject: [PATCH] serenity: Add wrappers for sendfd(), recvfd() and
+ anon_create()
+
+---
+ src/unix/serenity/mod.rs | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/unix/serenity/mod.rs b/src/unix/serenity/mod.rs
+index 7f536dfa8802d37bebfa03033f875bd5f142ad72..e573b1f47d754322a469c907da357452a50a2d86 100644
+--- a/src/unix/serenity/mod.rs
++++ b/src/unix/serenity/mod.rs
+@@ -986,6 +986,9 @@ extern "C" {
+         result: *mut *mut passwd,
+     ) -> ::c_int;
+ 
++    // serenity.h
++    pub fn anon_create(size: ::size_t, options: ::c_int) -> ::c_int;
++
+     // signal.h
+     pub fn pthread_sigmask(
+         how: ::c_int,
+@@ -1030,6 +1033,8 @@ extern "C" {
+         addr: *mut ::sockaddr,
+         addrlen: *mut ::socklen_t,
+     ) -> ::ssize_t;
++    pub fn sendfd(sockfd: ::c_int, fd: ::c_int) -> ::c_int;
++    pub fn recvfd(sockfd: ::c_int, options: ::c_int) -> ::c_int;
+ 
+     // sys/stat.h
+     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;

--- a/Toolchain/Patches/rust-libc/0003-serenity-Add-library-dependencies.patch
+++ b/Toolchain/Patches/rust-libc/0003-serenity-Add-library-dependencies.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Bertalan <dani@danielbertalan.dev>
+Date: Sun, 24 Apr 2022 20:16:56 +0200
+Subject: [PATCH] serenity: Add library dependencies
+
+---
+ src/unix/mod.rs | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/unix/mod.rs b/src/unix/mod.rs
+index 30b638cf521c06dbce57f579b280cbc8e6e6507e..64df24638a41a6c6295555495874d369acfc822c 100644
+--- a/src/unix/mod.rs
++++ b/src/unix/mod.rs
+@@ -386,6 +386,10 @@ cfg_if! {
+         #[cfg_attr(feature = "rustc-dep-of-std",
+                    link(name = "c", cfg(not(target_feature = "crt-static"))))]
+         extern {}
++    } else if #[cfg(target_os = "serenity")] {
++        #[link(name = "c")]
++        #[link(name = "unwind")]
++        extern {}
+     } else {
+         #[link(name = "c")]
+         #[link(name = "m")]

--- a/Toolchain/Patches/rust-libc/0004-serenity-Add-dl_iterate_phdr.patch
+++ b/Toolchain/Patches/rust-libc/0004-serenity-Add-dl_iterate_phdr.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Bertalan <dani@danielbertalan.dev>
+Date: Mon, 25 Apr 2022 17:37:00 +0200
+Subject: [PATCH] serenity: Add dl_iterate_phdr
+
+---
+ src/unix/serenity/mod.rs | 68 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 68 insertions(+)
+
+diff --git a/src/unix/serenity/mod.rs b/src/unix/serenity/mod.rs
+index e573b1f47d754322a469c907da357452a50a2d86..2a2ddd6d90e54a8c32908e09f8c19d2cc4fd1db3 100644
+--- a/src/unix/serenity/mod.rs
++++ b/src/unix/serenity/mod.rs
+@@ -18,6 +18,32 @@ pub type off_t = i64;
+ pub type pthread_t = ::c_int;
+ pub type pthread_attr_t = *mut ::c_void;
+ 
++pub type Elf32_Addr = u32;
++pub type Elf32_Half = u16;
++pub type Elf32_Off = u32;
++pub type Elf32_Sword = i32;
++pub type Elf32_Word = u32;
++
++pub type Elf64_Addr = u64;
++pub type Elf64_Half = u16;
++pub type Elf64_Off = u64;
++pub type Elf64_Sword = i32;
++pub type Elf64_Sxword = i64;
++pub type Elf64_Word = u32;
++pub type Elf64_Xword = u64;
++
++cfg_if! {
++    if #[cfg(target_pointer_width = "64")] {
++        type Elf_Addr = Elf64_Addr;
++        type Elf_Half = Elf64_Half;
++        type Elf_Phdr = Elf64_Phdr;
++    } else if #[cfg(target_pointer_width = "32")] {
++        type Elf_Addr = Elf32_Addr;
++        type Elf_Half = Elf32_Half;
++        type Elf_Phdr = Elf32_Phdr;
++    }
++}
++
+ pub struct pthread_cond_t {
+     __mutex: *mut ::c_void,
+     __value: u32,
+@@ -266,6 +292,35 @@ s! {
+         pub tm_gmtoff: ::c_long,
+         pub tm_zone: *const ::c_char,
+     }
++
++    pub struct Elf32_Phdr {
++        pub p_type: Elf32_Word,
++        pub p_offset: Elf32_Off,
++        pub p_vaddr: Elf32_Addr,
++        pub p_paddr: Elf32_Addr,
++        pub p_filesz: Elf32_Word,
++        pub p_memsz: Elf32_Word,
++        pub p_flags: Elf32_Word,
++        pub p_align: Elf32_Word,
++    }
++
++    pub struct Elf64_Phdr {
++        pub p_type: Elf64_Word,
++        pub p_flags: Elf64_Word,
++        pub p_offset: Elf64_Off,
++        pub p_vaddr: Elf64_Addr,
++        pub p_paddr: Elf64_Addr,
++        pub p_filesz: Elf64_Xword,
++        pub p_memsz: Elf64_Xword,
++        pub p_align: Elf64_Xword,
++    }
++
++    pub struct dl_phdr_info {
++        pub dlpi_addr: Elf_Addr,
++        pub dlpi_name: *const ::c_char,
++        pub dlpi_phdr: *const Elf_Phdr,
++        pub dlpi_phnum: Elf_Half,
++    }
+ }
+ 
+ pub const UTSLENGTH: usize = 65;
+@@ -1049,6 +1104,19 @@ extern "C" {
+     // time.h
+     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::timezone) -> ::c_int;
+     pub fn clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
++
++    // link.h
++    pub fn dl_iterate_phdr(
++        callback: ::Option<
++            unsafe extern "C" fn(
++                info: *mut dl_phdr_info,
++                size: usize,
++                data: *mut ::c_void,
++            ) -> ::c_int,
++        >,
++        data: *mut ::c_void,
++    ) -> ::c_int;
++
+ }
+ 
+ cfg_if! {

--- a/Toolchain/Patches/rust-libc/0005-serenity-Add-libc-declarations-for-pledge-and-unveil.patch
+++ b/Toolchain/Patches/rust-libc/0005-serenity-Add-libc-declarations-for-pledge-and-unveil.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andreas Kling <kling@serenityos.org>
+Date: Mon, 25 Apr 2022 22:18:31 +0200
+Subject: [PATCH] serenity: Add libc declarations for pledge() and unveil()
+
+---
+ src/unix/serenity/mod.rs | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/unix/serenity/mod.rs b/src/unix/serenity/mod.rs
+index 2a2ddd6d90e54a8c32908e09f8c19d2cc4fd1db3..5dcbd77b668a392e9c5dba0626d1ffd213821ce0 100644
+--- a/src/unix/serenity/mod.rs
++++ b/src/unix/serenity/mod.rs
+@@ -997,6 +997,8 @@ extern "C" {
+ 
+     // unistd.h
+     pub fn pipe2(fds: *mut ::c_int, flags: ::c_int) -> ::c_int;
++    pub fn pledge(promises: *const ::c_char, execpromises: *const ::c_char) -> ::c_int;
++    pub fn unveil(path: *const ::c_char, permissions: *const ::c_char) -> ::c_int;
+ 
+     // malloc.h
+     pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;

--- a/Toolchain/Patches/rust-libc/0006-serenity-Add-declaration-for-arc4random_buf.patch
+++ b/Toolchain/Patches/rust-libc/0006-serenity-Add-declaration-for-arc4random_buf.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andreas Kling <kling@serenityos.org>
+Date: Mon, 25 Apr 2022 23:43:37 +0200
+Subject: [PATCH] serenity: Add declaration for arc4random_buf()
+
+---
+ src/unix/serenity/mod.rs | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/unix/serenity/mod.rs b/src/unix/serenity/mod.rs
+index 5dcbd77b668a392e9c5dba0626d1ffd213821ce0..2cdf82e1c55c0fd44080ed03640e3f4767b20f0b 100644
+--- a/src/unix/serenity/mod.rs
++++ b/src/unix/serenity/mod.rs
+@@ -1000,6 +1000,9 @@ extern "C" {
+     pub fn pledge(promises: *const ::c_char, execpromises: *const ::c_char) -> ::c_int;
+     pub fn unveil(path: *const ::c_char, permissions: *const ::c_char) -> ::c_int;
+ 
++    // stdlib.h
++    pub fn arc4random_buf(buffer: *mut ::c_void, size: ::size_t);
++
+     // malloc.h
+     pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;
+ 

--- a/Toolchain/Patches/rust-libc/0007-serenity-Add-definitions-for-futimens-constants.patch
+++ b/Toolchain/Patches/rust-libc/0007-serenity-Add-definitions-for-futimens-constants.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Kaster <akaster@serenityos.org>
+Date: Fri, 4 Nov 2022 18:35:01 -0600
+Subject: [PATCH] serenity: Add definitions for futimens constants
+
+---
+ src/unix/serenity/mod.rs | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/unix/serenity/mod.rs b/src/unix/serenity/mod.rs
+index 2cdf82e1c55c0fd44080ed03640e3f4767b20f0b..bc8de204abd91bdb61f1eae8bcd41ba854efe491 100644
+--- a/src/unix/serenity/mod.rs
++++ b/src/unix/serenity/mod.rs
+@@ -640,6 +640,9 @@ pub const S_IROTH: u16 = 0o0_004;
+ pub const S_IWOTH: u16 = 0o0_002;
+ pub const S_IXOTH: u16 = 0o0_001;
+ 
++pub const UTIME_OMIT: c_long = -1;
++pub const UTIME_NOW: c_long = -2;
++
+ // stdlib.h
+ pub const EXIT_SUCCESS: ::c_int = 0;
+ pub const EXIT_FAILURE: ::c_int = 1;

--- a/Toolchain/Patches/rust-libc/0008-serenity-Add-declarations-from-sys-mman.h.patch
+++ b/Toolchain/Patches/rust-libc/0008-serenity-Add-declarations-from-sys-mman.h.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Kaster <akaster@serenityos.org>
+Date: Fri, 4 Nov 2022 20:50:13 -0600
+Subject: [PATCH] serenity: Add declarations from sys/mman.h
+
+---
+ src/unix/serenity/mod.rs | 23 ++++++++++++++++++++---
+ 1 file changed, 20 insertions(+), 3 deletions(-)
+
+diff --git a/src/unix/serenity/mod.rs b/src/unix/serenity/mod.rs
+index bc8de204abd91bdb61f1eae8bcd41ba854efe491..266361226b192dbabc31688b1be2e99074cb6fdf 100644
+--- a/src/unix/serenity/mod.rs
++++ b/src/unix/serenity/mod.rs
+@@ -664,16 +664,30 @@ pub const PROT_READ: ::c_int = 0x0001;
+ pub const PROT_WRITE: ::c_int = 0x0002;
+ pub const PROT_EXEC: ::c_int = 0x0004;
+ 
++pub const MAP_FILE: ::c_int = 0x0000;
+ pub const MAP_SHARED: ::c_int = 0x0001;
+ pub const MAP_PRIVATE: ::c_int = 0x0002;
+ pub const MAP_ANON: ::c_int = 0x0020;
+ pub const MAP_ANONYMOUS: ::c_int = MAP_ANON;
+ pub const MAP_FIXED: ::c_int = 0x0010;
++pub const MAP_STACK: ::c_int = 0x0040;
++pub const MAP_NORESERVE: ::c_int = 0x0080;
++pub const MAP_RANDOMIZED: ::c_int = 0x0100;
++pub const MAP_PURGEABLE: ::c_int = 0x0200;
++pub const MAP_FIXED_NOREPLACE: ::c_int = 0x0400;
+ pub const MAP_FAILED: *mut ::c_void = !0 as _;
+ 
+-pub const MS_ASYNC: ::c_int = 0x0001;
+-pub const MS_INVALIDATE: ::c_int = 0x0002;
+-pub const MS_SYNC: ::c_int = 0x0004;
++pub const MADV_NORMAL: ::c_int = 0x0000;
++pub const MADV_SET_VOLATILE: ::c_int = 0x0001;
++pub const MADV_SET_NONVOLATILE: ::c_int = 0x0002;
++pub const MADV_DONTNEED: ::c_int = 0x0003;
++pub const MADV_WILLNEED: ::c_int = 0x0004;
++pub const MADV_SEQUENTIAL: ::c_int = 0x0005;
++pub const MADV_RANDOM: ::c_int = 0x0006;
++
++pub const MS_SYNC: ::c_int = 0x0001;
++pub const MS_ASYNC: ::c_int = 0x0002;
++pub const MS_INVALIDATE: ::c_int = 0x0004;
+ 
+ // sys/select.h
+ pub const FD_SETSIZE: usize = 1024;
+@@ -1077,8 +1091,11 @@ extern "C" {
+     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
+ 
+     // sys/mman.h
++    pub fn mremap(old_addr: *mut ::c_void, old_size: ::size_t, new_size: ::size_t, flags: ::c_int) -> ::c_int;
+     pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
+     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
++    pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
++    pub fn posix_madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
+     pub fn shm_open(name: *const c_char, oflag: ::c_int, mode: mode_t) -> ::c_int;
+     pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
+ 

--- a/Toolchain/Patches/rust/0001-serenity-Initial-SerenityOS-support.patch
+++ b/Toolchain/Patches/rust/0001-serenity-Initial-SerenityOS-support.patch
@@ -1,0 +1,527 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Kaster <akaster@serenityos.org>
+Date: Fri, 4 Nov 2022 14:41:37 -0600
+Subject: [PATCH] serenity: Initial SerenityOS support
+
+Co-Authored-By: Andreas Kling <kling@serenityos.org>
+Co-Authored-By: Daniel Bertalan <dani@danielbertalan.dev>
+---
+ compiler/rustc_target/src/spec/mod.rs         |   3 +
+ .../rustc_target/src/spec/serenity_base.rs    |  16 +++
+ .../src/spec/x86_64_unknown_serenity.rs       |  20 +++
+ library/std/build.rs                          |   1 +
+ library/std/src/os/mod.rs                     |   2 +
+ library/std/src/os/serenity/fs.rs             | 117 ++++++++++++++++++
+ library/std/src/os/serenity/mod.rs            |   6 +
+ library/std/src/os/serenity/raw.rs            |  73 +++++++++++
+ library/std/src/os/unix/mod.rs                |   2 +
+ library/std/src/sys/unix/args.rs              |   3 +-
+ library/std/src/sys/unix/env.rs               |  11 ++
+ library/std/src/sys/unix/fd.rs                |   2 +
+ library/std/src/sys/unix/fs.rs                |   3 +-
+ library/std/src/sys/unix/os.rs                |   9 +-
+ library/std/src/sys/unix/rand.rs              |  10 ++
+ library/std/src/sys/unix/thread.rs            |   7 ++
+ src/bootstrap/lib.rs                          |   2 +-
+ 17 files changed, 281 insertions(+), 6 deletions(-)
+ create mode 100644 compiler/rustc_target/src/spec/serenity_base.rs
+ create mode 100644 compiler/rustc_target/src/spec/x86_64_unknown_serenity.rs
+ create mode 100644 library/std/src/os/serenity/fs.rs
+ create mode 100644 library/std/src/os/serenity/mod.rs
+ create mode 100644 library/std/src/os/serenity/raw.rs
+
+diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
+index dc16739bd560c7d78b9352969f25552a8d3ad8ed..a474642a6d67c146b8594a537a2f84decff2f29a 100644
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -78,6 +78,7 @@
+ mod netbsd_base;
+ mod openbsd_base;
+ mod redox_base;
++mod serenity_base;
+ mod solaris_base;
+ mod solid_base;
+ mod thumb_base;
+@@ -1138,6 +1139,8 @@ fn $module() {
+     ("x86_64-unknown-none", x86_64_unknown_none),
+ 
+     ("mips64-openwrt-linux-musl", mips64_openwrt_linux_musl),
++
++    ("x86_64-unknown-serenity", x86_64_unknown_serenity),
+ }
+ 
+ /// Cow-Vec-Str: Cow<'static, [Cow<'static, str>]>
+diff --git a/compiler/rustc_target/src/spec/serenity_base.rs b/compiler/rustc_target/src/spec/serenity_base.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..9ab7a45cf164164d12efd076f25b7c625d016340
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/serenity_base.rs
+@@ -0,0 +1,16 @@
++use crate::spec::{cvs, FramePointer, PanicStrategy, RelroLevel, TargetOptions, TlsModel};
++
++pub fn opts() -> TargetOptions {
++    TargetOptions {
++        os: "serenity".into(),
++        dynamic_linking: true,
++        executables: true,
++        tls_model: TlsModel::InitialExec,
++        position_independent_executables: true,
++        panic_strategy: PanicStrategy::Abort,
++        families: cvs!["unix"],
++        relro_level: RelroLevel::Full,
++        frame_pointer: FramePointer::Always,
++        ..Default::default()
++    }
++}
+diff --git a/compiler/rustc_target/src/spec/x86_64_unknown_serenity.rs b/compiler/rustc_target/src/spec/x86_64_unknown_serenity.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..e9d9d6a09195ea2ccaf6a2a7201509359e919824
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/x86_64_unknown_serenity.rs
+@@ -0,0 +1,20 @@
++use crate::spec::{LinkerFlavor, StackProbeType, Target};
++
++pub fn target() -> Target {
++    let mut base = super::serenity_base::opts();
++    base.cpu = "x86-64".into();
++    base.max_atomic_width = Some(64);
++    base.pre_link_args.insert(LinkerFlavor::Gcc, vec!["-m64".into()]);
++    // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved
++    base.stack_probes = StackProbeType::Call;
++    base.position_independent_executables = true;
++
++    Target {
++        llvm_target: "x86_64-unknown-serenity".into(),
++        pointer_width: 64,
++        data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
++            .into(),
++        arch: "x86_64".into(),
++        options: base,
++    }
++}
+diff --git a/library/std/build.rs b/library/std/build.rs
+index 8b1a06ee750fb0e84316d1452e682cdafb5c90f6..91419e00539ea52523d01b16bee1e8a6048e051c 100644
+--- a/library/std/build.rs
++++ b/library/std/build.rs
+@@ -31,6 +31,7 @@ fn main() {
+         || target.contains("espidf")
+         || target.contains("solid")
+         || target.contains("nintendo-3ds")
++        || target.contains("serenity")
+     {
+         // These platforms don't have any special requirements.
+     } else {
+diff --git a/library/std/src/os/mod.rs b/library/std/src/os/mod.rs
+index 18c64b51007647b3d2683147f204af06db49ff65..e578d299c0a66b757fcf2d4835661ad500c78959 100644
+--- a/library/std/src/os/mod.rs
++++ b/library/std/src/os/mod.rs
+@@ -139,6 +139,8 @@ pub mod windows {}
+ pub mod openbsd;
+ #[cfg(target_os = "redox")]
+ pub mod redox;
++#[cfg(target_os = "serenity")]
++pub mod serenity;
+ #[cfg(target_os = "solaris")]
+ pub mod solaris;
+ #[cfg(target_os = "solid_asp3")]
+diff --git a/library/std/src/os/serenity/fs.rs b/library/std/src/os/serenity/fs.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..50206195dd901f0bc594cf63e42df59fbde4114b
+--- /dev/null
++++ b/library/std/src/os/serenity/fs.rs
+@@ -0,0 +1,117 @@
++#![stable(feature = "metadata_ext", since = "1.1.0")]
++
++use crate::fs::Metadata;
++use crate::sys_common::AsInner;
++
++#[allow(deprecated)]
++use crate::os::serenity::raw;
++
++/// OS-specific extensions to [`fs::Metadata`].
++///
++/// [`fs::Metadata`]: crate::fs::Metadata
++#[stable(feature = "metadata_ext", since = "1.1.0")]
++pub trait MetadataExt {
++    /// Gain a reference to the underlying `stat` structure which contains
++    /// the raw information returned by the OS.
++    ///
++    /// The contents of the returned `stat` are **not** consistent across
++    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
++    /// cross-Unix abstractions contained within the raw stat.
++    #[stable(feature = "metadata_ext", since = "1.1.0")]
++    #[deprecated(
++        since = "1.8.0",
++        note = "deprecated in favor of the accessor \
++                  methods of this trait"
++    )]
++    #[allow(deprecated)]
++    fn as_raw_stat(&self) -> &raw::stat;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_dev(&self) -> u64;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_ino(&self) -> u64;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_mode(&self) -> u32;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_nlink(&self) -> u64;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_uid(&self) -> u32;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_gid(&self) -> u32;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_rdev(&self) -> u64;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_size(&self) -> u64;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_atime(&self) -> i64;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_atime_nsec(&self) -> i64;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_mtime(&self) -> i64;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_mtime_nsec(&self) -> i64;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_ctime(&self) -> i64;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_ctime_nsec(&self) -> i64;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_blksize(&self) -> u64;
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_blocks(&self) -> u64;
++}
++
++#[stable(feature = "metadata_ext", since = "1.1.0")]
++impl MetadataExt for Metadata {
++    #[allow(deprecated)]
++    fn as_raw_stat(&self) -> &raw::stat {
++        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
++    }
++    fn st_dev(&self) -> u64 {
++        self.as_inner().as_inner().st_dev as u64
++    }
++    fn st_ino(&self) -> u64 {
++        self.as_inner().as_inner().st_ino as u64
++    }
++    fn st_mode(&self) -> u32 {
++        self.as_inner().as_inner().st_mode as u32
++    }
++    fn st_nlink(&self) -> u64 {
++        self.as_inner().as_inner().st_nlink as u64
++    }
++    fn st_uid(&self) -> u32 {
++        self.as_inner().as_inner().st_uid as u32
++    }
++    fn st_gid(&self) -> u32 {
++        self.as_inner().as_inner().st_gid as u32
++    }
++    fn st_rdev(&self) -> u64 {
++        self.as_inner().as_inner().st_rdev as u64
++    }
++    fn st_size(&self) -> u64 {
++        self.as_inner().as_inner().st_size as u64
++    }
++    fn st_atime(&self) -> i64 {
++        self.as_inner().as_inner().st_atime as i64
++    }
++    fn st_atime_nsec(&self) -> i64 {
++        self.as_inner().as_inner().st_atime_nsec as i64
++    }
++    fn st_mtime(&self) -> i64 {
++        self.as_inner().as_inner().st_mtime as i64
++    }
++    fn st_mtime_nsec(&self) -> i64 {
++        self.as_inner().as_inner().st_mtime_nsec as i64
++    }
++    fn st_ctime(&self) -> i64 {
++        self.as_inner().as_inner().st_ctime as i64
++    }
++    fn st_ctime_nsec(&self) -> i64 {
++        self.as_inner().as_inner().st_ctime_nsec as i64
++    }
++    fn st_blksize(&self) -> u64 {
++        self.as_inner().as_inner().st_blksize as u64
++    }
++    fn st_blocks(&self) -> u64 {
++        self.as_inner().as_inner().st_blocks as u64
++    }
++}
+diff --git a/library/std/src/os/serenity/mod.rs b/library/std/src/os/serenity/mod.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..be4c4b3a18c8bf89cd5c2ee01ab6c93490409520
+--- /dev/null
++++ b/library/std/src/os/serenity/mod.rs
+@@ -0,0 +1,6 @@
++//! SerenityOS-specific definitions
++
++#![stable(feature = "raw_ext", since = "1.1.0")]
++
++pub mod fs;
++pub mod raw;
+diff --git a/library/std/src/os/serenity/raw.rs b/library/std/src/os/serenity/raw.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..96dac78726ad4f84c91f52bf81d39c34d87730b1
+--- /dev/null
++++ b/library/std/src/os/serenity/raw.rs
+@@ -0,0 +1,73 @@
++//! SerenityOS-specific raw type definitions
++
++#![stable(feature = "raw_ext", since = "1.1.0")]
++#![deprecated(
++    since = "1.8.0",
++    note = "these type aliases are no longer supported by \
++              the standard library, the `libc` crate on \
++              crates.io should be used instead for the correct \
++              definitions"
++)]
++#![allow(deprecated)]
++
++use crate::os::raw::c_long;
++
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type blkcnt_t = u32;
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type blksize_t = u32;
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type dev_t = u64;
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type fflags_t = u32;
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type ino_t = u64;
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type mode_t = u16;
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type nlink_t = u32;
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type off_t = i64;
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type time_t = i64;
++
++#[stable(feature = "pthread_t", since = "1.8.0")]
++pub type pthread_t = i32;
++
++#[repr(C)]
++#[derive(Clone)]
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub struct stat {
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_dev: i32,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_ino: u64,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_mode: u16,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_nlink: u32,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_uid: u32,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_gid: u32,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_rdev: i32,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_size: i64,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_blocks: i64,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_blksize: i32,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_atime: i64,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_atime_nsec: c_long,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_mtime: i64,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_mtime_nsec: c_long,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_ctime: i64,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_ctime_nsec: c_long,
++}
+diff --git a/library/std/src/os/unix/mod.rs b/library/std/src/os/unix/mod.rs
+index 411cc0925c4b0869d0a303c95a7876cad872d8ac..eb05e4f856d6f789bf170a36ff796756996dda21 100644
+--- a/library/std/src/os/unix/mod.rs
++++ b/library/std/src/os/unix/mod.rs
+@@ -69,6 +69,8 @@ mod platform {
+     pub use crate::os::openbsd::*;
+     #[cfg(target_os = "redox")]
+     pub use crate::os::redox::*;
++    #[cfg(target_os = "serenity")]
++    pub use crate::os::serenity::*;
+     #[cfg(target_os = "solaris")]
+     pub use crate::os::solaris::*;
+     #[cfg(target_os = "vxworks")]
+diff --git a/library/std/src/sys/unix/args.rs b/library/std/src/sys/unix/args.rs
+index a342f0f5e8597848fc6a2998bce3d62ba391842d..68e8f0c799442cd784f5a01f9b91c7f3d5cce5bd 100644
+--- a/library/std/src/sys/unix/args.rs
++++ b/library/std/src/sys/unix/args.rs
+@@ -69,7 +69,8 @@ fn next_back(&mut self) -> Option<OsString> {
+     target_os = "fuchsia",
+     target_os = "redox",
+     target_os = "vxworks",
+-    target_os = "horizon"
++    target_os = "horizon",
++    target_os = "serenity",
+ ))]
+ mod imp {
+     use super::Args;
+diff --git a/library/std/src/sys/unix/env.rs b/library/std/src/sys/unix/env.rs
+index c9ba661c829fabe03506124a6f8ef522a40f9965..debf387794445c6f10f139d4a81df4049affcc21 100644
+--- a/library/std/src/sys/unix/env.rs
++++ b/library/std/src/sys/unix/env.rs
+@@ -217,3 +217,14 @@ pub mod os {
+     pub const EXE_SUFFIX: &str = "";
+     pub const EXE_EXTENSION: &str = "";
+ }
++
++#[cfg(target_os = "serenity")]
++pub mod os {
++    pub const FAMILY: &str = "unix";
++    pub const OS: &str = "serenity";
++    pub const DLL_PREFIX: &str = "lib";
++    pub const DLL_SUFFIX: &str = ".so";
++    pub const DLL_EXTENSION: &str = "so";
++    pub const EXE_SUFFIX: &str = "";
++    pub const EXE_EXTENSION: &str = "";
++}
+diff --git a/library/std/src/sys/unix/fd.rs b/library/std/src/sys/unix/fd.rs
+index dbaa3c33e2e577f13afb6c98181648bef6e7cf54..37612e4f9b1bca6274631248bb354de0b3ff1d80 100644
+--- a/library/std/src/sys/unix/fd.rs
++++ b/library/std/src/sys/unix/fd.rs
+@@ -212,6 +212,7 @@ pub fn get_cloexec(&self) -> io::Result<bool> {
+         target_os = "linux",
+         target_os = "haiku",
+         target_os = "redox",
++        target_os = "serenity",
+         target_os = "vxworks"
+     )))]
+     pub fn set_cloexec(&self) -> io::Result<()> {
+@@ -230,6 +231,7 @@ pub fn set_cloexec(&self) -> io::Result<()> {
+         target_os = "linux",
+         target_os = "haiku",
+         target_os = "redox",
++        target_os = "serenity",
+         target_os = "vxworks"
+     ))]
+     pub fn set_cloexec(&self) -> io::Result<()> {
+diff --git a/library/std/src/sys/unix/fs.rs b/library/std/src/sys/unix/fs.rs
+index cc347e3586ae337fdcd6d45592f39f1e261e17c8..8ada84292dbd3df4f722d2b4a0b7c248cc69a751 100644
+--- a/library/std/src/sys/unix/fs.rs
++++ b/library/std/src/sys/unix/fs.rs
+@@ -772,6 +772,7 @@ pub fn file_type(&self) -> io::Result<FileType> {
+         target_os = "l4re",
+         target_os = "fuchsia",
+         target_os = "redox",
++        target_os = "serenity",
+         target_os = "vxworks",
+         target_os = "espidf",
+         target_os = "horizon"
+@@ -1381,7 +1382,7 @@ pub fn link(original: &Path, link: &Path) -> io::Result<()> {
+     let original = cstr(original)?;
+     let link = cstr(link)?;
+     cfg_if::cfg_if! {
+-        if #[cfg(any(target_os = "vxworks", target_os = "redox", target_os = "android", target_os = "espidf", target_os = "horizon"))] {
++        if #[cfg(any(target_os = "vxworks", target_os = "redox", target_os = "android", target_os = "espidf", target_os = "horizon", target_os = "serenity"))] {
+             // VxWorks, Redox and ESP-IDF lack `linkat`, so use `link` instead. POSIX leaves
+             // it implementation-defined whether `link` follows symlinks, so rely on the
+             // `symlink_hard_link` test in library/std/src/fs/tests.rs to check the behavior.
+diff --git a/library/std/src/sys/unix/os.rs b/library/std/src/sys/unix/os.rs
+index 46545a0839fe8b416a7cd17a8f57058d34f0f360..4f97c796a2d5cf1d6fe8df574bf80004f22f76e9 100644
+--- a/library/std/src/sys/unix/os.rs
++++ b/library/std/src/sys/unix/os.rs
+@@ -45,6 +45,7 @@
+             target_os = "linux",
+             target_os = "emscripten",
+             target_os = "fuchsia",
++            target_os = "serenity",
+             target_os = "l4re"
+         ),
+         link_name = "__errno_location"
+@@ -350,7 +351,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
+     }
+ }
+ 
+-#[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
++#[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten", target_os = "serenity"))]
+ pub fn current_exe() -> io::Result<PathBuf> {
+     match crate::fs::read_link("/proc/self/exe") {
+         Err(ref e) if e.kind() == io::ErrorKind::NotFound => Err(io::const_io_error!(
+@@ -603,7 +604,8 @@ pub fn home_dir() -> Option<PathBuf> {
+         target_os = "redox",
+         target_os = "vxworks",
+         target_os = "espidf",
+-        target_os = "horizon"
++        target_os = "horizon",
++        target_os = "serenity"
+     ))]
+     unsafe fn fallback() -> Option<OsString> {
+         None
+@@ -616,7 +618,8 @@ unsafe fn fallback() -> Option<OsString> {
+         target_os = "redox",
+         target_os = "vxworks",
+         target_os = "espidf",
+-        target_os = "horizon"
++        target_os = "horizon",
++        target_os = "serenity"
+     )))]
+     unsafe fn fallback() -> Option<OsString> {
+         let amt = match libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) {
+diff --git a/library/std/src/sys/unix/rand.rs b/library/std/src/sys/unix/rand.rs
+index a6fe07873d7ee4263b9362d9a5dda75c35916582..a37d9ad15088cfc6f2a56b971e635d10faddb4d4 100644
+--- a/library/std/src/sys/unix/rand.rs
++++ b/library/std/src/sys/unix/rand.rs
+@@ -20,6 +20,7 @@ pub fn hashmap_random_keys() -> (u64, u64) {
+     not(target_os = "netbsd"),
+     not(target_os = "fuchsia"),
+     not(target_os = "redox"),
++    not(target_os = "serenity"),
+     not(target_os = "vxworks")
+ ))]
+ mod imp {
+@@ -174,6 +175,15 @@ pub fn fill_bytes(v: &mut [u8]) {
+     }
+ }
+ 
++#[cfg(target_os = "serenity")]
++mod imp {
++    pub fn fill_bytes(v: &mut [u8]) {
++        for s in v.chunks_mut(4096) {
++            unsafe { libc::arc4random_buf(s.as_mut_ptr() as *mut libc::c_void, s.len()) };
++        }
++    }
++}
++
+ #[cfg(target_os = "openbsd")]
+ mod imp {
+     use crate::sys::os::errno;
+diff --git a/library/std/src/sys/unix/thread.rs b/library/std/src/sys/unix/thread.rs
+index f6b627afc1223fd408dbb48f7701c79dbdcdafd3..2de46fb109b64564a3897ae4881735c6d87be861 100644
+--- a/library/std/src/sys/unix/thread.rs
++++ b/library/std/src/sys/unix/thread.rs
+@@ -148,6 +148,13 @@ pub fn set_name(name: &CStr) {
+         }
+     }
+ 
++    #[cfg(target_os = "serenity")]
++    pub fn set_name(name: &CStr) {
++        unsafe {
++            libc::pthread_setname_np(libc::pthread_self(), name.as_ptr());
++        }
++    }
++
+     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "watchos"))]
+     pub fn set_name(name: &CStr) {
+         unsafe {
+diff --git a/src/bootstrap/lib.rs b/src/bootstrap/lib.rs
+index cc0cf12bd187a7fc48ed6c06bfa09a9af5e064b0..d54c114e24f779fe8177f184de916110b8d07055 100644
+--- a/src/bootstrap/lib.rs
++++ b/src/bootstrap/lib.rs
+@@ -205,7 +205,7 @@ pub unsafe fn setup(_build: &mut crate::Build) {}
+     (Some(Mode::Std), "backtrace_in_libstd", None),
+     /* Extra values not defined in the built-in targets yet, but used in std */
+     (Some(Mode::Std), "target_env", Some(&["libnx"])),
+-    (Some(Mode::Std), "target_os", Some(&["watchos"])),
++    (Some(Mode::Std), "target_os", Some(&["watchos", "serenity"])),
+     (
+         Some(Mode::Std),
+         "target_arch",

--- a/Toolchain/Patches/rust/0002-Add-support-for-SerenityOS.patch
+++ b/Toolchain/Patches/rust/0002-Add-support-for-SerenityOS.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Bertalan <dani@danielbertalan.dev>
+Date: Mon, 25 Apr 2022 22:11:14 +0200
+Subject: [PATCH] Add support for SerenityOS
+
+---
+ library/backtrace/src/symbolize/gimli.rs | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/library/backtrace/src/symbolize/gimli.rs b/library/backtrace/src/symbolize/gimli.rs
+index 5f10122ddce9d995e37dee5972d208ea8cd305b8..cd6ced3e3bc77784a3ebfb360083d91bd1a797e8 100644
+--- a/library/backtrace/src/symbolize/gimli.rs
++++ b/library/backtrace/src/symbolize/gimli.rs
+@@ -39,6 +39,7 @@ cfg_if::cfg_if! {
+         target_os = "linux",
+         target_os = "macos",
+         target_os = "openbsd",
++        target_os = "serenity",
+         target_os = "solaris",
+         target_os = "illumos",
+     ))] {
+@@ -178,6 +179,7 @@ cfg_if::cfg_if! {
+             target_os = "fuchsia",
+             target_os = "freebsd",
+             target_os = "openbsd",
++            target_os = "serenity",
+             all(target_os = "android", feature = "dl_iterate_phdr"),
+         ),
+         not(target_env = "uclibc"),

--- a/Toolchain/Rust/config.toml.in
+++ b/Toolchain/Rust/config.toml.in
@@ -1,0 +1,2 @@
+[patch.crates-io]
+libc = { git = 'file://@SERENITY_TOOLCHAIN_ROOT@/Tarballs/@RUST_LIBC_NAME@', branch = 'master' }

--- a/Toolchain/Rust/rust-config.toml.in
+++ b/Toolchain/Rust/rust-config.toml.in
@@ -1,0 +1,753 @@
+# Sample TOML configuration file for building Rust.
+#
+# To configure rustbuild, copy this file to the directory from which you will be
+# running the build, and name it config.toml.
+#
+# All options are commented out by default in this file, and they're commented
+# out with their default values. The build system by default looks for
+# `config.toml` in the current directory of a build for build configuration, but
+# a custom configuration file can also be specified with `--config` to the build
+# system.
+
+# Keeps track of the last version of `x.py` used.
+# If it does not match the version that is currently running,
+# `x.py` will prompt you to update it and read the changelog.
+# See `src/bootstrap/CHANGELOG.md` for more information.
+changelog-seen = 2
+
+# =============================================================================
+# Global Settings
+# =============================================================================
+
+# Use different pre-set defaults than the global defaults.
+#
+# See `src/bootstrap/defaults` for more information.
+# Note that this has no default value (x.py uses the defaults in `config.toml.example`).
+#profile = <none>
+
+# =============================================================================
+# Tweaking how LLVM is compiled
+# =============================================================================
+[llvm]
+
+# Whether to use Rust CI built LLVM instead of locally building it.
+#
+# Unless you're developing for a target where Rust CI doesn't build a compiler
+# toolchain or changing LLVM locally, you probably want to set this to true.
+#
+# This is false by default so that distributions don't unexpectedly download
+# LLVM from the internet.
+#
+# All tier 1 targets are currently supported; set this to `"if-available"` if
+# you are not sure whether you're on a tier 1 target.
+#
+# We also currently only support this when building LLVM for the build triple.
+#
+# Note that many of the LLVM options are not currently supported for
+# downloading. Currently only the "assertions" option can be toggled.
+#download-ci-llvm = false
+
+# Indicates whether LLVM rebuild should be skipped when running bootstrap. If
+# this is `false` then the compiler's LLVM will be rebuilt whenever the built
+# version doesn't have the correct hash. If it is `true` then LLVM will never
+# be rebuilt. The default value is `false`.
+#skip-rebuild = false
+
+# Indicates whether the LLVM build is a Release or Debug build
+#optimize = true
+
+# Indicates whether LLVM should be built with ThinLTO. Note that this will
+# only succeed if you use clang, lld, llvm-ar, and llvm-ranlib in your C/C++
+# toolchain (see the `cc`, `cxx`, `linker`, `ar`, and `ranlib` options below).
+# More info at: https://clang.llvm.org/docs/ThinLTO.html#clang-bootstrap
+#thin-lto = false
+
+# Indicates whether an LLVM Release build should include debug info
+#release-debuginfo = false
+
+# Indicates whether the LLVM assertions are enabled or not
+#assertions = false
+
+# Indicates whether the LLVM testsuite is enabled in the build or not. Does
+# not execute the tests as part of the build as part of x.py build et al,
+# just makes it possible to do `ninja check-llvm` in the staged LLVM build
+# directory when doing LLVM development as part of Rust development.
+#tests = false
+
+# Indicates whether the LLVM plugin is enabled or not
+#plugins = false
+
+# Indicates whether ccache is used when building LLVM
+ccache = true
+# or alternatively ...
+#ccache = "/path/to/ccache"
+
+# If an external LLVM root is specified, we automatically check the version by
+# default to make sure it's within the range that we're expecting, but setting
+# this flag will indicate that this version check should not be done.
+#version-check = true
+
+# Link libstdc++ statically into the rustc_llvm instead of relying on a
+# dynamic version to be available.
+#static-libstdcpp = true
+
+# Whether to use Ninja to build LLVM. This runs much faster than make.
+#ninja = true
+
+# LLVM targets to build support for.
+# Note: this is NOT related to Rust compilation targets. However, as Rust is
+# dependent on LLVM for code generation, turning targets off here WILL lead to
+# the resulting rustc being unable to compile for the disabled architectures.
+# Also worth pointing out is that, in case support for new targets are added to
+# LLVM, enabling them here doesn't mean Rust is automatically gaining said
+# support. You'll need to write a target specification at least, and most
+# likely, teach rustc about the C ABI of the target. Get in touch with the
+# Rust team and file an issue if you need assistance in porting!
+#targets = "AArch64;ARM;BPF;Hexagon;MSP430;Mips;NVPTX;PowerPC;RISCV;Sparc;SystemZ;WebAssembly;X86"
+
+# LLVM experimental targets to build support for. These targets are specified in
+# the same format as above, but since these targets are experimental, they are
+# not built by default and the experimental Rust compilation targets that depend
+# on them will not work unless the user opts in to building them.
+#experimental-targets = "AVR;M68k"
+
+# Cap the number of parallel linker invocations when compiling LLVM.
+# This can be useful when building LLVM with debug info, which significantly
+# increases the size of binaries and consequently the memory required by
+# each linker process.
+# If absent or 0, linker invocations are treated like any other job and
+# controlled by rustbuild's -j parameter.
+#link-jobs = 0
+
+# When invoking `llvm-config` this configures whether the `--shared` argument is
+# passed to prefer linking to shared libraries.
+# NOTE: `thin-lto = true` requires this to be `true` and will give an error otherwise.
+#link-shared = false
+
+# When building llvm, this configures what is being appended to the version.
+# The default is "-rust-$version-$channel", except for dev channel where rustc
+# version number is omitted. To use LLVM version as is, provide an empty string.
+#version-suffix = "-rust-dev"
+
+# On MSVC you can compile LLVM with clang-cl, but the test suite doesn't pass
+# with clang-cl, so this is special in that it only compiles LLVM with clang-cl.
+# Note that this takes a /path/to/clang-cl, not a boolean.
+#clang-cl = cc
+
+# Pass extra compiler and linker flags to the LLVM CMake build.
+#cflags = ""
+#cxxflags = ""
+#ldflags = ""
+
+# Use libc++ when building LLVM instead of libstdc++. This is the default on
+# platforms already use libc++ as the default C++ library, but this option
+# allows you to use libc++ even on platforms when it's not. You need to ensure
+# that your host compiler ships with libc++.
+#use-libcxx = false
+
+# The value specified here will be passed as `-DLLVM_USE_LINKER` to CMake.
+#use-linker = <none> (path)
+
+# Whether or not to specify `-DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=YES`
+#allow-old-toolchain = false
+
+# Whether to include the Polly optimizer.
+#polly = false
+
+# Whether to build the clang compiler.
+#clang = false
+
+# Custom CMake defines to set when building LLVM.
+#build-config = {}
+
+# =============================================================================
+# General build configuration options
+# =============================================================================
+[build]
+# The default stage to use for the `check` subcommand
+#check-stage = 0
+
+# The default stage to use for the `doc` subcommand
+#doc-stage = 0
+
+# The default stage to use for the `build` subcommand
+#build-stage = 1
+
+# The default stage to use for the `test` subcommand
+#test-stage = 1
+
+# The default stage to use for the `dist` subcommand
+#dist-stage = 2
+
+# The default stage to use for the `install` subcommand
+#install-stage = 2
+
+# The default stage to use for the `bench` subcommand
+#bench-stage = 2
+
+# Build triple for the original snapshot compiler. This must be a compiler that
+# nightlies are already produced for. The current platform must be able to run
+# binaries of this build triple and the nightly will be used to bootstrap the
+# first compiler.
+#
+# Defaults to platform where `x.py` is run.
+#build = "x86_64-unknown-linux-gnu" (as an example)
+
+# Which triples to produce a compiler toolchain for. Each of these triples will
+# be bootstrapped from the build triple themselves.
+#
+# Defaults to just the build triple.
+#host = ["x86_64-unknown-linux-gnu"] (as an example)
+
+# Which triples to build libraries (core/alloc/std/test/proc_macro) for. Each of
+# these triples will be bootstrapped from the build triple themselves.
+#
+# Defaults to `host`. If you set this explicitly, you likely want to add all
+# host triples to this list as well in order for those host toolchains to be
+# able to compile programs for their native target.
+target = ["x86_64-unknown-linux-gnu", "x86_64-unknown-serenity"]
+
+# Use this directory to store build artifacts.
+# You can use "$ROOT" to indicate the root of the git repository.
+build-dir = "@SERENITY_TOOLCHAIN_ROOT@/Build/rust"
+
+# Instead of downloading the src/stage0.json version of Cargo specified, use
+# this Cargo binary instead to build all Rust code
+#cargo = "/path/to/cargo"
+
+# Instead of downloading the src/stage0.json version of the compiler
+# specified, use this rustc binary instead as the stage0 snapshot compiler.
+#rustc = "/path/to/rustc"
+
+# Instead of download the src/stage0.json version of rustfmt specified,
+# use this rustfmt binary instead as the stage0 snapshot rustfmt.
+#rustfmt = "/path/to/rustfmt"
+
+# Flag to specify whether any documentation is built. If false, rustdoc and
+# friends will still be compiled but they will not be used to generate any
+# documentation.
+#docs = true
+
+# Flag to specify whether CSS, JavaScript, and HTML are minified when
+# docs are generated. JSON is always minified, because it's enormous,
+# and generated in already-minified form from the beginning.
+#docs-minification = true
+
+# Indicate whether the compiler should be documented in addition to the standard
+# library and facade crates.
+#compiler-docs = false
+
+# Indicate whether git submodules are managed and updated automatically.
+#submodules = true
+
+# Update git submodules only when the checked out commit in the submodules differs
+# from what is committed in the main rustc repo.
+#fast-submodules = true
+
+# The path to (or name of) the GDB executable to use. This is only used for
+# executing the debuginfo test suite.
+#gdb = "gdb"
+
+# The node.js executable to use. Note that this is only used for the emscripten
+# target when running tests, otherwise this can be omitted.
+#nodejs = "node"
+
+# Python interpreter to use for various tasks throughout the build, notably
+# rustdoc tests, the lldb python interpreter, and some dist bits and pieces.
+#
+# Defaults to the Python interpreter used to execute x.py
+#python = "python"
+
+# Force Cargo to check that Cargo.lock describes the precise dependency
+# set that all the Cargo.toml files create, instead of updating it.
+#locked-deps = false
+
+# Indicate whether the vendored sources are used for Rust dependencies or not
+#vendor = false
+
+# Typically the build system will build the Rust compiler twice. The second
+# compiler, however, will simply use its own libraries to link against. If you
+# would rather to perform a full bootstrap, compiling the compiler three times,
+# then you can set this option to true. You shouldn't ever need to set this
+# option to true.
+#full-bootstrap = false
+
+# Enable a build of the extended Rust tool set which is not only the compiler
+# but also tools such as Cargo. This will also produce "combined installers"
+# which are used to install Rust and Cargo together. This is disabled by
+# default. The `tools` option (immediately below) specifies which tools should
+# be built if `extended = true`.
+#extended = false
+
+# Installs chosen set of extended tools if `extended = true`. By default builds
+# all extended tools except `rust-demangler`, unless the target is also being
+# built with `profiler = true`. If chosen tool failed to build the installation
+# fails. If `extended = false`, this option is ignored.
+#tools = ["cargo", "rls", "clippy", "rustfmt", "analysis", "src"] # + "rust-demangler" if `profiler`
+
+# Verbosity level: 0 == not verbose, 1 == verbose, 2 == very verbose
+#verbose = 0
+
+# Build the sanitizer runtimes
+#sanitizers = false
+
+# Build the profiler runtime (required when compiling with options that depend
+# on this runtime, such as `-C profile-generate` or `-C instrument-coverage`).
+#profiler = false
+
+# Indicates whether the native libraries linked into Cargo will be statically
+# linked or not.
+#cargo-native-static = false
+
+# Run the build with low priority, by setting the process group's "nice" value
+# to +10 on Unix platforms, and by using a "low priority" job object on Windows.
+#low-priority = false
+
+# Arguments passed to the `./configure` script, used during distcheck. You
+# probably won't fill this in but rather it's filled in by the `./configure`
+# script.
+configure-args = ['--llvm-config=@SERENITY_TOOLCHAIN_ROOT@/Local/clang/bin/llvm-config', '--llvm-root=@SERENITY_TOOLCHAIN_ROOT@/Local/clang']
+
+# Indicates that a local rebuild is occurring instead of a full bootstrap,
+# essentially skipping stage0 as the local compiler is recompiling itself again.
+#local-rebuild = false
+
+# Print out how long each rustbuild step took (mostly intended for CI and
+# tracking over time)
+#print-step-timings = false
+
+# Print out resource usage data for each rustbuild step, as defined by the Unix
+# struct rusage. (Note that this setting is completely unstable: the data it
+# captures, what platforms it supports, the format of its associated output, and
+# this setting's very existence, are all subject to change.)
+#print-step-rusage = false
+
+# Always patch binaries for usage with Nix toolchains. If `true` then binaries
+# will be patched unconditionally. If `false` or unset, binaries will be patched
+# only if the current distribution is NixOS. This option is useful when using
+# a Nix toolchain on non-NixOS distributions.
+#patch-binaries-for-nix = false
+
+# =============================================================================
+# General install configuration options
+# =============================================================================
+[install]
+
+# Instead of installing to /usr/local, install to this path instead.
+prefix = "/"
+
+# Where to install system configuration files
+# If this is a relative path, it will get installed in `prefix` above
+#sysconfdir = "/etc"
+
+# Where to install documentation in `prefix` above
+#docdir = "share/doc/rust"
+
+# Where to install binaries in `prefix` above
+#bindir = "bin"
+
+# Where to install libraries in `prefix` above
+#libdir = "lib"
+
+# Where to install man pages in `prefix` above
+#mandir = "share/man"
+
+# Where to install data in `prefix` above
+#datadir = "share"
+
+# =============================================================================
+# Options for compiling Rust code itself
+# =============================================================================
+[rust]
+
+# Whether or not to optimize the compiler and standard library.
+# WARNING: Building with optimize = false is NOT SUPPORTED. Due to bootstrapping,
+# building without optimizations takes much longer than optimizing. Further, some platforms
+# fail to build without this optimization (c.f. #65352).
+#optimize = true
+
+# Indicates that the build should be configured for debugging Rust. A
+# `debug`-enabled compiler and standard library will be somewhat
+# slower (due to e.g. checking of debug assertions) but should remain
+# usable.
+#
+# Note: If this value is set to `true`, it will affect a number of
+#       configuration options below as well, if they have been left
+#       unconfigured in this file.
+#
+# Note: changes to the `debug` setting do *not* affect `optimize`
+#       above. In theory, a "maximally debuggable" environment would
+#       set `optimize` to `false` above to assist the introspection
+#       facilities of debuggers like lldb and gdb. To recreate such an
+#       environment, explicitly set `optimize` to `false` and `debug`
+#       to `true`. In practice, everyone leaves `optimize` set to
+#       `true`, because an unoptimized rustc with debugging
+#       enabled becomes *unusably slow* (e.g. rust-lang/rust#24840
+#       reported a 25x slowdown) and bootstrapping the supposed
+#       "maximally debuggable" environment (notably libstd) takes
+#       hours to build.
+#
+#debug = false
+
+# Whether to download the stage 1 and 2 compilers from CI.
+# This is mostly useful for tools; if you have changes to `compiler/` they will be ignored.
+#
+# You can set this to "if-unchanged" to only download if `compiler/` has not been modified.
+#download-rustc = false
+
+# Number of codegen units to use for each compiler invocation. A value of 0
+# means "the number of cores on this machine", and 1+ is passed through to the
+# compiler.
+#
+# Uses the rustc defaults: https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
+#codegen-units = if incremental { 256 } else { 16 }
+
+# Sets the number of codegen units to build the standard library with,
+# regardless of what the codegen-unit setting for the rest of the compiler is.
+# NOTE: building with anything other than 1 is known to occasionally have bugs.
+# See https://github.com/rust-lang/rust/issues/83600.
+#codegen-units-std = codegen-units
+
+# Whether or not debug assertions are enabled for the compiler and standard
+# library. Debug assertions control the maximum log level used by rustc. When
+# enabled calls to `trace!` and `debug!` macros are preserved in the compiled
+# binary, otherwise they are omitted.
+#
+# Defaults to rust.debug value
+#debug-assertions = rust.debug (boolean)
+
+# Whether or not debug assertions are enabled for the standard library.
+# Overrides the `debug-assertions` option, if defined.
+#
+# Defaults to rust.debug-assertions value
+#debug-assertions-std = rust.debug-assertions (boolean)
+
+# Whether or not to leave debug! and trace! calls in the rust binary.
+# Overrides the `debug-assertions` option, if defined.
+#
+# Defaults to rust.debug-assertions value
+#
+# If you see a message from `tracing` saying
+# `max_level_info` is enabled and means logging won't be shown,
+# set this value to `true`.
+#debug-logging = rust.debug-assertions (boolean)
+
+# Whether or not overflow checks are enabled for the compiler and standard
+# library.
+#
+# Defaults to rust.debug value
+#overflow-checks = rust.debug (boolean)
+
+# Whether or not overflow checks are enabled for the standard library.
+# Overrides the `overflow-checks` option, if defined.
+#
+# Defaults to rust.overflow-checks value
+#overflow-checks-std = rust.overflow-checks (boolean)
+
+# Debuginfo level for most of Rust code, corresponds to the `-C debuginfo=N` option of `rustc`.
+# `0` - no debug info
+# `1` - line tables only - sufficient to generate backtraces that include line
+#       information and inlined functions, set breakpoints at source code
+#       locations, and step through execution in a debugger.
+# `2` - full debug info with variable and type information
+# Can be overridden for specific subsets of Rust code (rustc, std or tools).
+# Debuginfo for tests run with compiletest is not controlled by this option
+# and needs to be enabled separately with `debuginfo-level-tests`.
+#
+# Note that debuginfo-level = 2 generates several gigabytes of debuginfo
+# and will slow down the linking process significantly.
+#
+# Defaults to 1 if debug is true
+#debuginfo-level = 0
+
+# Debuginfo level for the compiler.
+#debuginfo-level-rustc = debuginfo-level
+
+# Debuginfo level for the standard library.
+#debuginfo-level-std = debuginfo-level
+
+# Debuginfo level for the tools.
+#debuginfo-level-tools = debuginfo-level
+
+# Debuginfo level for the test suites run with compiletest.
+# FIXME(#61117): Some tests fail when this option is enabled.
+#debuginfo-level-tests = 0
+
+# Whether to run `dsymutil` on Apple platforms to gather debug info into .dSYM
+# bundles. `dsymutil` adds time to builds for no clear benefit, and also makes
+# it more difficult for debuggers to find debug info. The compiler currently
+# defaults to running `dsymutil` to preserve its historical default, but when
+# compiling the compiler itself, we skip it by default since we know it's safe
+# to do so in that case.
+#run-dsymutil = false
+
+# Whether or not `panic!`s generate backtraces (RUST_BACKTRACE)
+#backtrace = true
+
+# Whether to always use incremental compilation when building rustc
+incremental = true
+
+# Build a multi-threaded rustc
+# FIXME(#75760): Some UI tests fail when this option is enabled.
+#parallel-compiler = false
+
+# The default linker that will be hard-coded into the generated
+# compiler for targets that don't specify a default linker explicitly
+# in their target specifications.  Note that this is not the linker
+# used to link said compiler. It can also be set per-target (via the
+# `[target.<triple>]` block), which may be useful in a cross-compilation
+# setting.
+#
+# See https://doc.rust-lang.org/rustc/codegen-options/index.html#linker for more information.
+#default-linker = <none> (path)
+
+# The "channel" for the Rust build to produce. The stable/beta channels only
+# allow using stable features, whereas the nightly and dev channels allow using
+# nightly features
+#channel = "dev"
+
+# A descriptive string to be appended to `rustc --version` output, which is
+# also used in places like debuginfo `DW_AT_producer`. This may be useful for
+# supplementary build information, like distro-specific package versions.
+#description = <none> (string)
+
+# The root location of the musl installation directory. The library directory
+# will also need to contain libunwind.a for an unwinding implementation. Note
+# that this option only makes sense for musl targets that produce statically
+# linked binaries.
+#
+# Defaults to /usr on musl hosts. Has no default otherwise.
+#musl-root = <platform specific> (path)
+
+# By default the `rustc` executable is built with `-Wl,-rpath` flags on Unix
+# platforms to ensure that the compiler is usable by default from the build
+# directory (as it links to a number of dynamic libraries). This may not be
+# desired in distributions, for example.
+#rpath = true
+
+# Prints each test name as it is executed, to help debug issues in the test harness itself.
+#verbose-tests = false
+
+# Flag indicating whether tests are compiled with optimizations (the -O flag).
+#optimize-tests = true
+
+# Flag indicating whether codegen tests will be run or not. If you get an error
+# saying that the FileCheck executable is missing, you may want to disable this.
+# Also see the target's llvm-filecheck option.
+#codegen-tests = true
+
+# Flag indicating whether git info will be retrieved from .git automatically.
+# Having the git information can cause a lot of rebuilds during development.
+# Note: If this attribute is not explicitly set (e.g. if left commented out) it
+# will default to true if channel = "dev", but will default to false otherwise.
+#ignore-git = if channel == "dev" { true } else { false }
+
+# When creating source tarballs whether or not to create a source tarball.
+#dist-src = true
+
+# After building or testing extended tools (e.g. clippy and rustfmt), append the
+# result (broken, compiling, testing) into this JSON file.
+#save-toolstates = <none> (path)
+
+# This is an array of the codegen backends that will be compiled for the rustc
+# that's being compiled. The default is to only build the LLVM codegen backend,
+# and currently the only standard options supported are `"llvm"`, `"cranelift"`
+# and `"gcc"`. The first backend in this list will be used as default by rustc
+# when no explicit backend is specified.
+#codegen-backends = ["llvm"]
+
+# Indicates whether LLD will be compiled and made available in the sysroot for
+# rustc to execute.
+#lld = false
+
+# Indicates whether LLD will be used to link Rust crates during bootstrap on
+# supported platforms. The LLD from the bootstrap distribution will be used
+# and not the LLD compiled during the bootstrap.
+#
+# LLD will not be used if we're cross linking.
+#
+# Explicitly setting the linker for a target will override this option when targeting MSVC.
+#use-lld = true
+
+# Indicates whether some LLVM tools, like llvm-objdump, will be made available in the
+# sysroot.
+#llvm-tools = false
+
+# Whether to deny warnings in crates
+#deny-warnings = true
+
+# Print backtrace on internal compiler errors during bootstrap
+#backtrace-on-ice = false
+
+# Whether to verify generated LLVM IR
+#verify-llvm-ir = false
+
+# Compile the compiler with a non-default ThinLTO import limit. This import
+# limit controls the maximum size of functions imported by ThinLTO. Decreasing
+# will make code compile faster at the expense of lower runtime performance.
+#thin-lto-import-instr-limit = if incremental { 10 } else { LLVM default (currently 100) }
+
+# Map debuginfo paths to `/rust/$sha/...`, generally only set for releases
+#remap-debuginfo = false
+
+# Link the compiler against `jemalloc`, where on Linux and OSX it should
+# override the default allocator for rustc and LLVM.
+#jemalloc = false
+
+# Run tests in various test suites with the "nll compare mode" in addition to
+# running the tests in normal mode. Largely only used on CI and during local
+# development of NLL
+#test-compare-mode = false
+
+# Use LLVM libunwind as the implementation for Rust's unwinder.
+# Accepted values are 'in-tree' (formerly true), 'system' or 'no' (formerly false).
+# This option only applies for Linux and Fuchsia targets.
+# On Linux target, if crt-static is not enabled, 'no' means dynamic link to
+# `libgcc_s.so`, 'in-tree' means static link to the in-tree build of llvm libunwind
+# and 'system' means dynamic link to `libunwind.so`. If crt-static is enabled,
+# the behavior is depend on the libc. On musl target, 'no' and 'in-tree' both
+# means static link to the in-tree build of llvm libunwind, and 'system' means
+# static link to `libunwind.a` provided by system. Due to the limitation of glibc,
+# it must link to `libgcc_eh.a` to get a working output, and this option have no effect.
+#llvm-libunwind = 'no'
+
+# Enable Windows Control Flow Guard checks in the standard library.
+# This only applies from stage 1 onwards, and only for Windows targets.
+#control-flow-guard = false
+
+# Enable symbol-mangling-version v0. This can be helpful when profiling rustc,
+# as generics will be preserved in symbols (rather than erased into opaque T).
+# When no setting is given, the new scheme will be used when compiling the
+# compiler and its tools and the legacy scheme will be used when compiling the
+# standard library.
+# If an explicit setting is given, it will be used for all parts of the codebase.
+#new-symbol-mangling = true|false (see comment)
+
+# =============================================================================
+# Options for specific targets
+#
+# Each of the following options is scoped to the specific target triple in
+# question and is used for determining how to compile each target.
+# =============================================================================
+
+[target.x86_64-unknown-linux-gnu]
+# Path to the `llvm-config` binary of the installation of a custom LLVM to link
+# against. Note that if this is specified we don't compile LLVM at all for this
+# target.
+llvm-config = '@SERENITY_TOOLCHAIN_ROOT@/Local/clang/bin/llvm-config'
+
+[target.x86_64-unknown-serenity]
+
+# C compiler to be used to compile C code. Note that the
+# default value is platform specific, and if not specified it may also depend on
+# what platform is crossing to what platform.
+# See `src/bootstrap/cc_detect.rs` for details.
+cc = "@SERENITY_TOOLCHAIN_ROOT@/Local/clang/bin/clang"
+
+# C++ compiler to be used to compile C++ code (e.g. LLVM and our LLVM shims).
+# This is only used for host targets.
+# See `src/bootstrap/cc_detect.rs` for details.
+cxx = "@SERENITY_TOOLCHAIN_ROOT@/Local/clang/bin/clang"
+
+# Archiver to be used to assemble static libraries compiled from C/C++ code.
+# Note: an absolute path should be used, otherwise LLVM build will break.
+ar = "@SERENITY_TOOLCHAIN_ROOT@/Local/clang/bin/llvm-ar"
+
+# Ranlib to be used to assemble static libraries compiled from C/C++ code.
+# Note: an absolute path should be used, otherwise LLVM build will break.
+ranlib = "@SERENITY_TOOLCHAIN_ROOT@/Local/clang/bin/llvm-ranlib"
+
+# Linker to be used to bootstrap Rust code. Note that the
+# default value is platform specific, and if not specified it may also depend on
+# what platform is crossing to what platform.
+# Setting this will override the `use-lld` option for Rust code when targeting MSVC.
+linker = "@SERENITY_TOOLCHAIN_ROOT@/Local/clang/bin/clang"
+
+# Path to the `llvm-config` binary of the installation of a custom LLVM to link
+# against. Note that if this is specified we don't compile LLVM at all for this
+# target.
+llvm-config = '@SERENITY_TOOLCHAIN_ROOT@/Local/clang/bin/llvm-config'
+
+# Normally the build system can find LLVM's FileCheck utility, but if
+# not, you can specify an explicit file name for it.
+llvm-filecheck = "@SERENITY_TOOLCHAIN_ROOT@/Local/clang/bin/FileCheck"
+
+# If this target is for Android, this option will be required to specify where
+# the NDK for the target lives. This is used to find the C compiler to link and
+# build native code.
+# See `src/bootstrap/cc_detect.rs` for details.
+#android-ndk = <none> (path)
+
+# Build the sanitizer runtimes for this target.
+# This option will override the same option under [build] section.
+#sanitizers = build.sanitizers (bool)
+
+# Build the profiler runtime for this target(required when compiling with options that depend
+# on this runtime, such as `-C profile-generate` or `-C instrument-coverage`).
+# This option will override the same option under [build] section.
+#profiler = build.profiler (bool)
+
+# Force static or dynamic linkage of the standard library for this target. If
+# this target is a host for rustc, this will also affect the linkage of the
+# compiler itself. This is useful for building rustc on targets that normally
+# only use static libraries. If unset, the target's default linkage is used.
+#crt-static = <platform-specific> (bool)
+
+# The root location of the musl installation directory. The library directory
+# will also need to contain libunwind.a for an unwinding implementation. Note
+# that this option only makes sense for musl targets that produce statically
+# linked binaries.
+#musl-root = build.musl-root (path)
+
+# The full path to the musl libdir.
+#musl-libdir = musl-root/lib
+
+# The root location of the `wasm32-wasi` sysroot. Only used for the
+# `wasm32-wasi` target. If you are building wasm32-wasi target, make sure to
+# create a `[target.wasm32-wasi]` section and move this field there.
+#wasi-root = <none> (path)
+
+# Used in testing for configuring where the QEMU images are located, you
+# probably don't want to use this.
+#qemu-rootfs = <none> (path)
+
+# =============================================================================
+# Distribution options
+#
+# These options are related to distribution, mostly for the Rust project itself.
+# You probably won't need to concern yourself with any of these options
+# =============================================================================
+[dist]
+
+# This is the folder of artifacts that the build system will sign. All files in
+# this directory will be signed with the default gpg key using the system `gpg`
+# binary. The `asc` and `sha256` files will all be output into the standard dist
+# output folder (currently `build/dist`)
+#
+# This folder should be populated ahead of time before the build system is
+# invoked.
+#sign-folder = <none> (path)
+
+# The remote address that all artifacts will eventually be uploaded to. The
+# build system generates manifests which will point to these urls, and for the
+# manifests to be correct they'll have to have the right URLs encoded.
+#
+# Note that this address should not contain a trailing slash as file names will
+# be appended to it.
+#upload-addr = <none> (URL)
+
+# Whether to build a plain source tarball to upload
+# We disable that on Windows not to override the one already uploaded on S3
+# as the one built on Windows will contain backslashes in paths causing problems
+# on linux
+#src-tarball = true
+
+# Whether to allow failures when building tools
+#missing-tools = false
+
+# List of compression formats to use when generating dist tarballs. The list of
+# formats is provided to rust-installer, which must support all of them.
+#
+# This list must be non-empty.
+#compression-formats = ["gz", "xz"]
+


### PR DESCRIPTION
Building off the work from the spring during the exploratory times, here's an updated BuildRust.sh + patches for rust, libc, and backtrace to build a stage 1 cross compiler based on the clang toolchain.

It's technically possible to create a Port package.sh file from this cross-compiler as installed in Local/rust, but I haven't been able to find an interesting application package that doesn't depend on core OS abstraction packages with very hardcoded  and strict #cfg checks for target_os that make a "I'm sure a Unix platform will do X" implementation impossible.

Given how much of a pain it was to patch libc enough for rustc and any ports I tried to work, I assume that trying to maintain a set of patched rust packages is an exercise in futility.

Regardless, the pattern would look something like this:

```sh
useconfigure='true'

configure()
{
    run cargo update -p libc
}

build()
{
    run cargo --color always build
}

install()
{
    run cargo --color always install
}
```

With the global override for libc pointing to our patched version living in `$CARGO_HOME/config.toml`, which is set to `Toolchain/Local/rust/.cargo`