### PR TITLE
LibGUI: Hold down Alt when clicking TreeView to expand full subtree

### DIFF
--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -430,6 +430,33 @@ void TreeView::did_update_selection()
         activate(index);
 }
 
+void TreeView::mousedown_event(MouseEvent& event)
+{
+    if (!model())
+        return AbstractView::mousedown_event(event);
+
+    if (event.button() != MouseButton::Primary)
+        return AbstractView::mousedown_event(event);
+
+    bool is_toggle;
+    auto index = index_at_event_position(event.position(), is_toggle);
+
+    if (index.is_valid() && is_toggle && model()->row_count(index)) {
+        if (event.alt()) {
+            if (is_toggled(index)) {
+                collapse_tree(index);
+            } else {
+                expand_tree(index);
+            }
+            return;
+        }
+        toggle_index(index);
+        return;
+    }
+
+    AbstractView::mousedown_event(event);
+}
+
 void TreeView::keydown_event(KeyEvent& event)
 {
     if (!model())

--- a/Userland/Libraries/LibGUI/TreeView.h
+++ b/Userland/Libraries/LibGUI/TreeView.h
@@ -43,6 +43,7 @@ public:
 protected:
     TreeView();
 
+    virtual void mousedown_event(MouseEvent&) override;
     virtual void paint_event(PaintEvent&) override;
     virtual void doubleclick_event(MouseEvent&) override;
     virtual void keydown_event(KeyEvent&) override;


### PR DESCRIPTION
On other operating systems, if you hold down Alt when you click to expand part of a tree, it expands all of the children of the node you clicked. This commit makes our TreeView act the same way :)