### PR TITLE
BindingsGenerator+CMake: Keep track of IDL dependencies

### DIFF
--- a/Meta/CMake/libweb_generators.cmake
+++ b/Meta/CMake/libweb_generators.cmake
@@ -113,7 +113,7 @@ function (generate_js_bindings target)
             list(TRANSFORM include_paths PREPEND -i)
             add_custom_command(
                 OUTPUT "${bindings_src}"
-                COMMAND "$<TARGET_FILE:Lagom::BindingsGenerator>" "--${bindings_type}" ${include_paths} "${LIBWEB_INPUT_FOLDER}/${class}.idl" "${LIBWEB_INPUT_FOLDER}" > "${bindings_src}.tmp"
+                COMMAND "$<TARGET_FILE:Lagom::BindingsGenerator>" "--${bindings_type}" -o "${bindings_src}.tmp" ${include_paths} "${LIBWEB_INPUT_FOLDER}/${class}.idl" "${LIBWEB_INPUT_FOLDER}"
                 COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${bindings_src}.tmp" "${bindings_src}"
                 COMMAND "${CMAKE_COMMAND}" -E remove "${bindings_src}.tmp"
                 VERBATIM

--- a/Meta/CMake/libweb_generators.cmake
+++ b/Meta/CMake/libweb_generators.cmake
@@ -111,14 +111,30 @@ function (generate_js_bindings target)
             list(GET BINDINGS_TYPES ${iter} bindings_type)
             get_property(include_paths DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
             list(TRANSFORM include_paths PREPEND -i)
+
+            # Ninja expects the target name in depfiles to be relative to CMAKE_BINARY_DIR, but ${bindings_src} is
+            # relative to CMAKE_CURRENT_BINARY_DIR. CMake >= 3.20 can do the rewriting transparently (CMP0116).
+            if(CMAKE_GENERATOR MATCHES "^Ninja" AND NOT POLICY CMP0116)
+                # FIXME: Drop this branch for cmake_minimum_required(3.20)
+                get_filename_component(full_path ${bindings_src} ABSOLUTE BASE_DIR ${CMAKE_CURRENT_BINARY_DIR})
+                file(RELATIVE_PATH depfile_target ${CMAKE_BINARY_DIR} ${full_path})
+            else()
+                if (POLICY CMP0116)
+                    cmake_policy(SET CMP0116 NEW)
+                endif()
+                set(depfile_target ${bindings_src})
+            endif()
+
             add_custom_command(
                 OUTPUT "${bindings_src}"
-                COMMAND "$<TARGET_FILE:Lagom::BindingsGenerator>" "--${bindings_type}" -o "${bindings_src}.tmp" ${include_paths} "${LIBWEB_INPUT_FOLDER}/${class}.idl" "${LIBWEB_INPUT_FOLDER}"
+                COMMAND "$<TARGET_FILE:Lagom::BindingsGenerator>" "--${bindings_type}" -o "${bindings_src}.tmp" --depfile "${bindings_src}.d"
+                        --depfile-target "${depfile_target}" ${include_paths} "${LIBWEB_INPUT_FOLDER}/${class}.idl" "${LIBWEB_INPUT_FOLDER}"
                 COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${bindings_src}.tmp" "${bindings_src}"
                 COMMAND "${CMAKE_COMMAND}" -E remove "${bindings_src}.tmp"
                 VERBATIM
                 DEPENDS Lagom::BindingsGenerator
                 MAIN_DEPENDENCY ${class}.idl
+                DEPFILE ${CMAKE_CURRENT_BINARY_DIR}/${bindings_src}.d
             )
         endforeach()
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/CMakeLists.txt
@@ -3,5 +3,5 @@ set(SOURCES
     main.cpp
 )
 
-lagom_tool(BindingsGenerator LIBS LibIDL)
+lagom_tool(BindingsGenerator LIBS LibIDL LibMain)
 target_compile_options(BindingsGenerator PUBLIC -g)

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1970,9 +1970,8 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@function.name:snakecase@)
 )~~~");
 }
 
-void generate_constructor_header(IDL::Interface const& interface)
+void generate_constructor_header(IDL::Interface const& interface, StringBuilder& builder)
 {
-    StringBuilder builder;
     SourceGenerator generator { builder };
 
     generator.set("name", interface.name);
@@ -2022,13 +2021,10 @@ private:
 
 } // namespace Web::Bindings
 )~~~");
-
-    outln("{}", generator.as_string_view());
 }
 
-void generate_constructor_implementation(IDL::Interface const& interface)
+void generate_constructor_implementation(IDL::Interface const& interface, StringBuilder& builder)
 {
-    StringBuilder builder;
     SourceGenerator generator { builder };
 
     generator.set("name", interface.name);
@@ -2226,13 +2222,10 @@ void @constructor_class@::initialize(JS::Realm& realm)
     generator.append(R"~~~(
 } // namespace Web::Bindings
 )~~~");
-
-    outln("{}", generator.as_string_view());
 }
 
-void generate_prototype_header(IDL::Interface const& interface)
+void generate_prototype_header(IDL::Interface const& interface, StringBuilder& builder)
 {
-    StringBuilder builder;
     SourceGenerator generator { builder };
 
     generator.set("name", interface.name);
@@ -2346,13 +2339,10 @@ inline String idl_enum_to_string(@enum.type.name@ value) {
     generator.append(R"~~~(
 } // namespace Web::Bindings
     )~~~");
-
-    outln("{}", generator.as_string_view());
 }
 
-void generate_prototype_implementation(IDL::Interface const& interface)
+void generate_prototype_implementation(IDL::Interface const& interface, StringBuilder& builder)
 {
-    StringBuilder builder;
     SourceGenerator generator { builder };
 
     generator.set("name", interface.name);
@@ -2789,14 +2779,11 @@ JS_DEFINE_NATIVE_FUNCTION(@prototype_class@::values)
     generator.append(R"~~~(
 } // namespace Web::Bindings
 )~~~");
-
-    outln("{}", generator.as_string_view());
 }
 
-void generate_iterator_prototype_header(IDL::Interface const& interface)
+void generate_iterator_prototype_header(IDL::Interface const& interface, StringBuilder& builder)
 {
     VERIFY(interface.pair_iterator_types.has_value());
-    StringBuilder builder;
     SourceGenerator generator { builder };
 
     generator.set("prototype_class", String::formatted("{}IteratorPrototype", interface.name));
@@ -2821,14 +2808,11 @@ private:
 
 } // namespace Web::Bindings
     )~~~");
-
-    outln("{}", generator.as_string_view());
 }
 
-void generate_iterator_prototype_implementation(IDL::Interface const& interface)
+void generate_iterator_prototype_implementation(IDL::Interface const& interface, StringBuilder& builder)
 {
     VERIFY(interface.pair_iterator_types.has_value());
-    StringBuilder builder;
     SourceGenerator generator { builder };
 
     generator.set("name", String::formatted("{}Iterator", interface.name));
@@ -2909,7 +2893,5 @@ JS_DEFINE_NATIVE_FUNCTION(@prototype_class@::next)
 
 } // namespace Web::Bindings
 )~~~");
-
-    outln("{}", generator.as_string_view());
 }
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
@@ -11,25 +11,27 @@
 #include <AK/LexicalPath.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
+#include <LibCore/Stream.h>
 #include <LibIDL/IDLParser.h>
 #include <LibIDL/Types.h>
 
 extern Vector<StringView> s_header_search_paths;
 
 namespace IDL {
-void generate_constructor_header(IDL::Interface const&);
-void generate_constructor_implementation(IDL::Interface const&);
-void generate_prototype_header(IDL::Interface const&);
-void generate_prototype_implementation(IDL::Interface const&);
-void generate_iterator_prototype_header(IDL::Interface const&);
-void generate_iterator_prototype_implementation(IDL::Interface const&);
+void generate_constructor_header(IDL::Interface const&, StringBuilder&);
+void generate_constructor_implementation(IDL::Interface const&, StringBuilder&);
+void generate_prototype_header(IDL::Interface const&, StringBuilder&);
+void generate_prototype_implementation(IDL::Interface const&, StringBuilder&);
+void generate_iterator_prototype_header(IDL::Interface const&, StringBuilder&);
+void generate_iterator_prototype_implementation(IDL::Interface const&, StringBuilder&);
 }
 
-int main(int argc, char** argv)
+ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     Core::ArgsParser args_parser;
     StringView path;
     StringView import_base_path;
+    StringView output_path = "-"sv;
     bool constructor_header_mode = false;
     bool constructor_implementation_mode = false;
     bool prototype_header_mode = false;
@@ -53,23 +55,22 @@ int main(int argc, char** argv)
             return true;
         },
     });
+    args_parser.add_option(output_path, "Path to output generated file into", "output-path", 'o', "output-path");
     args_parser.add_positional_argument(path, "IDL file", "idl-file");
     args_parser.add_positional_argument(import_base_path, "Import base path", "import-base-path", Core::ArgsParser::Required::No);
-    args_parser.parse(argc, argv);
+    args_parser.parse(arguments);
 
-    auto file_or_error = Core::File::open(path, Core::OpenMode::ReadOnly);
-    if (file_or_error.is_error()) {
-        warnln("Failed to open {}: {}", path, file_or_error.error());
-        return 1;
-    }
+    auto file = TRY(Core::Stream::File::open(path, Core::Stream::OpenMode::Read));
 
     LexicalPath lexical_path(path);
     auto& namespace_ = lexical_path.parts_view().at(lexical_path.parts_view().size() - 2);
 
-    auto data = file_or_error.value()->read_all();
+    auto data = TRY(file->read_all());
 
     if (import_base_path.is_null())
         import_base_path = lexical_path.dirname();
+
+    auto output_file = TRY(Core::Stream::File::open_file_or_standard_stream(output_path, Core::Stream::OpenMode::Write));
 
     IDL::Parser parser(path, data, import_base_path);
     auto& interface = parser.parse();
@@ -149,23 +150,25 @@ int main(int argc, char** argv)
         }
     }
 
+    StringBuilder output_builder;
     if (constructor_header_mode)
-        IDL::generate_constructor_header(interface);
+        IDL::generate_constructor_header(interface, output_builder);
 
     if (constructor_implementation_mode)
-        IDL::generate_constructor_implementation(interface);
+        IDL::generate_constructor_implementation(interface, output_builder);
 
     if (prototype_header_mode)
-        IDL::generate_prototype_header(interface);
+        IDL::generate_prototype_header(interface, output_builder);
 
     if (prototype_implementation_mode)
-        IDL::generate_prototype_implementation(interface);
+        IDL::generate_prototype_implementation(interface, output_builder);
 
     if (iterator_prototype_header_mode)
-        IDL::generate_iterator_prototype_header(interface);
+        IDL::generate_iterator_prototype_header(interface, output_builder);
 
     if (iterator_prototype_implementation_mode)
-        IDL::generate_iterator_prototype_implementation(interface);
+        IDL::generate_iterator_prototype_implementation(interface, output_builder);
 
+    TRY(output_file->write(output_builder.string_view().bytes()));
     return 0;
 }

--- a/Userland/Libraries/LibIDL/IDLParser.cpp
+++ b/Userland/Libraries/LibIDL/IDLParser.cpp
@@ -1055,4 +1055,8 @@ HashTable<NonnullOwnPtr<Interface>>& Parser::top_level_interfaces()
     return top_level_parser()->interfaces;
 }
 
+Vector<String> Parser::imported_files() const
+{
+    return const_cast<Parser*>(this)->top_level_resolved_imports().keys();
+}
 }

--- a/Userland/Libraries/LibIDL/IDLParser.h
+++ b/Userland/Libraries/LibIDL/IDLParser.h
@@ -20,6 +20,8 @@ public:
     Parser(String filename, StringView contents, String import_base_path);
     Interface& parse();
 
+    Vector<String> imported_files() const;
+
 private:
     // https://webidl.spec.whatwg.org/#dfn-special-operation
     // A special operation is a getter, setter or deleter.


### PR DESCRIPTION
This commit teaches BindingsGenerator to generate depfiles, which can be
used by CMake to ensure that bindings are properly regenerated when
imported IDL files change.

Two new options, `--depfile` and `--depfile-target` are added.
- `--depfile` sets the path for the dependency file.
- `--depfile-target` lets us set a target name different than the output
  file in the depfile. This option is needed because generated files are
  first written to a temporary file, but depfiles have to refer to the
  final location.
These are analogous to GCC's `-MF` and `-MT` options respectively. The
depfile's syntax matches the ones generated by GCC.

Note: This changes the minimal required CMake version to 3.20 if the
Make generator is used, and to 3.21 for the Xcode generator. Ninja is
not affected.