### PR TITLE
LibJS: Rename ToShowTimeZoneNameOption to ToTimeZoneNameOption

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -253,8 +253,8 @@ ThrowCompletionOr<String> to_calendar_name_option(VM& vm, Object const& normaliz
     return option.as_string().string();
 }
 
-// 13.10 ToShowTimeZoneNameOption ( normalizedOptions ), https://tc39.es/proposal-temporal/#sec-temporal-toshowtimezonenameoption
-ThrowCompletionOr<String> to_show_time_zone_name_option(VM& vm, Object const& normalized_options)
+// 13.10 ToTimeZoneNameOption ( normalizedOptions ), https://tc39.es/proposal-temporal/#sec-temporal-totimezonenameoption
+ThrowCompletionOr<String> to_time_zone_name_option(VM& vm, Object const& normalized_options)
 {
     // 1. Return ? GetOption(normalizedOptions, "timeZoneName", "string", « "auto", "never", "critical" », "auto").
     auto option = TRY(get_option(vm, normalized_options, vm.names.timeZoneName, OptionType::String, { "auto"sv, "never"sv, "critical"sv }, "auto"sv));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
@@ -141,7 +141,7 @@ ThrowCompletionOr<String> to_temporal_rounding_mode(VM&, Object const& normalize
 StringView negate_temporal_rounding_mode(String const& rounding_mode);
 ThrowCompletionOr<String> to_temporal_offset(VM&, Object const* options, String const& fallback);
 ThrowCompletionOr<String> to_calendar_name_option(VM&, Object const& normalized_options);
-ThrowCompletionOr<String> to_show_time_zone_name_option(VM&, Object const& normalized_options);
+ThrowCompletionOr<String> to_time_zone_name_option(VM&, Object const& normalized_options);
 ThrowCompletionOr<String> to_show_offset_option(VM&, Object const& normalized_options);
 ThrowCompletionOr<u64> to_temporal_rounding_increment(VM&, Object const& normalized_options, Optional<double> dividend, bool inclusive);
 ThrowCompletionOr<u64> to_temporal_date_time_rounding_increment(VM&, Object const& normalized_options, StringView smallest_unit);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -1086,8 +1086,8 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::to_string)
     // 6. Let showCalendar be ? ToCalendarNameOption(options).
     auto show_calendar = TRY(to_calendar_name_option(vm, *options));
 
-    // 7. Let showTimeZone be ? ToShowTimeZoneNameOption(options).
-    auto show_time_zone = TRY(to_show_time_zone_name_option(vm, *options));
+    // 7. Let showTimeZone be ? ToTimeZoneNameOption(options).
+    auto show_time_zone = TRY(to_time_zone_name_option(vm, *options));
 
     // 8. Let showOffset be ? ToShowOffsetOption(options).
     auto show_offset = TRY(to_show_offset_option(vm, *options));


### PR DESCRIPTION
This is an editorial change in Temporal spec.

See: https://github.com/tc39/proposal-temporal/commit/ab5b1ba91054a921e2ae129e3fe024bd1c6e7f2f

Ticks one box off in #15525