### PR TITLE
WebContent: Capture horizontal overflow in full document screenshots

### DIFF
--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -714,7 +714,16 @@ Messages::WebContentServer::TakeDocumentScreenshotResponse ConnectionFromClient:
     if (!document || !document->document_element())
         return { {} };
 
-    auto rect = calculate_absolute_rect_of_element(page(), *document->document_element());
+    auto bounding_rect = document->document_element()->get_bounding_client_rect();
+    auto position = calculate_absolute_position_of_element(page(), bounding_rect);
+    auto const& content_size = m_page_host->content_size();
+
+    Gfx::IntRect rect {
+        position.x(),
+        position.y(),
+        content_size.width() - position.x(),
+        content_size.height() - position.y(),
+    };
 
     auto bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, rect.size()).release_value_but_fixme_should_propagate_errors();
     m_page_host->paint(rect, *bitmap);

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -141,12 +141,11 @@ void PageHost::page_did_layout()
 {
     auto* layout_root = this->layout_root();
     VERIFY(layout_root);
-    Gfx::IntSize content_size;
     if (layout_root->paint_box()->has_overflow())
-        content_size = enclosing_int_rect(layout_root->paint_box()->scrollable_overflow_rect().value()).size();
+        m_content_size = enclosing_int_rect(layout_root->paint_box()->scrollable_overflow_rect().value()).size();
     else
-        content_size = enclosing_int_rect(layout_root->paint_box()->absolute_rect()).size();
-    m_client.async_did_layout(content_size);
+        m_content_size = enclosing_int_rect(layout_root->paint_box()->absolute_rect()).size();
+    m_client.async_did_layout(m_content_size);
 }
 
 void PageHost::page_did_change_title(String const& title)

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -38,6 +38,8 @@ public:
     void set_window_position(Gfx::IntPoint const&);
     void set_window_size(Gfx::IntSize const&);
 
+    Gfx::IntSize const& content_size() const { return m_content_size; }
+
 private:
     // ^PageClient
     virtual Gfx::Palette palette() const override;
@@ -81,6 +83,7 @@ private:
     NonnullOwnPtr<Web::Page> m_page;
     RefPtr<Gfx::PaletteImpl> m_palette_impl;
     Gfx::IntRect m_screen_rect;
+    Gfx::IntSize m_content_size;
     bool m_should_show_line_box_borders { false };
     bool m_has_focus { false };
 


### PR DESCRIPTION
The full-page screenshot was missing horizontal overflow content on most
web pages. Change the dimensions of the captured screenshot to match the
actual content size.

[Screencast from 2022-11-05 11-31-18.webm](https://user-images.githubusercontent.com/5600524/200127587-0f307536-dfc4-4b0d-b61f-9dd65a0e187e.webm)
