### PR TITLE
Port qt add network concurrent

### DIFF
--- a/Kernel/API/POSIX/netinet/in.h
+++ b/Kernel/API/POSIX/netinet/in.h
@@ -89,12 +89,21 @@ struct ip_mreq_source {
 #define IPV6_V6ONLY 9
 #define IPV6_JOIN_GROUP 5
 #define IPV6_LEAVE_GROUP 6
+#define IPV6_RECVPKTINFO 10
+#define IPV6_PKTINFO 11
+#define IPV6_RECVHOPLIMIT 12
+#define IPV6_HOPLIMIT 13
 
 struct in6_addr {
     union {
         uint8_t s6_addr[16];
         uint32_t s6_addr32[4];
     };
+};
+
+struct in6_pktinfo {
+    struct in6_addr ipi6_addr;
+    uint32_t ipi6_ifindex;
 };
 
 /* clang-format off */

--- a/Ports/qt6-qtbase/package.sh
+++ b/Ports/qt6-qtbase/package.sh
@@ -21,7 +21,7 @@ QT_HOST_CMAKE_PATH=${QT_HOST_PATH}/lib64/cmake
 QT_HOST_TOOLS="HostInfo CoreTools GuiTools WidgetsTools"
 QT_HOST_TOOLS_PATH="${QT_HOST_CMAKE_PATH}/Qt6%s/\n"
 
-QT_DISABLED_FEATURES="sql opengl dbus systemsemaphore sharedmemory thread network"
+QT_DISABLED_FEATURES="sql opengl dbus systemsemaphore sharedmemory dnslookup"
 
 configure() {
     for host_tool in ${QT_HOST_TOOLS}; do

--- a/Ports/qt6-qtbase/package.sh
+++ b/Ports/qt6-qtbase/package.sh
@@ -12,9 +12,11 @@ configopts=(
     "-DQT_BUILD_TOOLS_WHEN_CROSSCOMPILING=ON"
     "-DQT_HOST_PATH=/usr"
     "-DQT_FEATURE_cxx20=ON"
+    "-DQT_FEATURE_ssl=ON"
+    "-DQT_FEATURE_zstd=ON"
     "-DINPUT_opengl=no"
 )
-depends=("md4c")
+depends=("md4c" "zstd" "openssl")
 
 QT_HOST_PATH=/usr
 QT_HOST_CMAKE_PATH=${QT_HOST_PATH}/lib64/cmake

--- a/Userland/Libraries/LibC/pthread.cpp
+++ b/Userland/Libraries/LibC/pthread.cpp
@@ -553,6 +553,12 @@ int pthread_cancel(pthread_t thread)
     return pthread_kill(thread, SIGCANCEL);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_testcancel.html
+void pthread_testcancel(void)
+{
+    __pthread_maybe_cancel();
+}
+
 int pthread_setname_np(pthread_t thread, char const* name)
 {
     if (!name)


### PR DESCRIPTION
This adds some stubs (I hope this is fine fore now?), which allow the compilation of the Network and Concurrent Qt modules.
Once we get something up and running using these Qt modules (I'm currently actively working on this part), and we know that they are needed, we can correctly implement these stubs.