### PR TITLE
LibWeb: Calculate available space for children of the grid

### DIFF
--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -332,3 +332,23 @@ length value, and as a minimum two lengths with an auto. -->
     <div class="grid-item">3</div>
     <div class="grid-item">4</div>
 </div>
+
+<!-- Sizing of children of grid -->
+<p>Should render a 64px wide image</p>
+<div 
+  class="grid-container"
+  style="
+    grid-template-columns: auto 0 minmax(0, 100%);
+  ">
+  <div class="wrapper" style="width: 100%;">
+    <img style="width: 100%;" src="data:image/jpeg;base64,
+      /9j/4AAQSkZJRgABAQEAYABgAAD/2wBDADIiJSwlHzIsKSw4NTI7S31RS0VFS5ltc1p9tZ++u7Kf
+      r6zI4f/zyNT/16yv+v/9////////wfD/////////////2wBDATU4OEtCS5NRUZP/zq/O////////
+      ////////////////////////////////////////////////////////////wAARCAAYAEADAREA
+      AhEBAxEB/8QAGQAAAgMBAAAAAAAAAAAAAAAAAQMAAgQF/8QAJRABAAIBBAEEAgMAAAAAAAAAAQIR
+      AAMSITEEEyJBgTORUWFx/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAA
+      AAD/2gAMAwEAAhEDEQA/AOgM52xQDrjvAV5Xv0vfKUALlTQfeBm0HThMNHXkL0Lw/swN5qgA8yT4
+      MCS1OEOJV8mBz9Z05yfW8iSx7p4j+jA1aD6Wj7ZMzstsfvAas4UyRHvjrAkC9KhpLMClQntlqFc2
+      X1gUj4viwVObKrddH9YDoHvuujAEuNV+bLwFS8XxdSr+Cq3Vf+4F5RgQl6ZR2p1eAzU/HX80YBYy
+      JLCuexwJCO2O1bwCRidAfWBSctswbI12GAJT3yiwFR7+MBjGK2g/WAJR3FdF84E2rK5VR0YH/9k=">
+</div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -67,7 +67,6 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
         int row_span { 1 };
         int column { 0 };
         int column_span { 1 };
-        float computed_height { 0 };
     };
     Vector<PositionedBox> positioned_boxes;
     Vector<Box const&> boxes_to_place;
@@ -655,16 +654,6 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
         i--;
 
         // FIXME: 4.2. For dense packing:
-    }
-
-    for (auto& positioned_box : positioned_boxes) {
-        auto& child_box_state = m_state.get_mutable(positioned_box.box);
-        if (child_box_state.content_height() > positioned_box.computed_height)
-            positioned_box.computed_height = child_box_state.content_height();
-        if (child_box_state.content_height() > positioned_box.computed_height)
-            positioned_box.computed_height = child_box_state.content_height();
-        if (auto min_content_height = calculate_min_content_height(positioned_box.box, available_space.width); min_content_height > positioned_box.computed_height)
-            positioned_box.computed_height = min_content_height;
     }
 
     // https://drafts.csswg.org/css-grid/#overview-sizing
@@ -1370,7 +1359,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
         // the size of the item’s content, it is considered a type of intrinsic size contribution.
         float grid_row_height = 0;
         for (auto& positioned_box : positioned_boxes_of_row)
-            grid_row_height = max(grid_row_height, positioned_box.computed_height);
+            grid_row_height = max(grid_row_height, calculate_min_content_height(positioned_box.box, AvailableSize::make_definite(m_grid_columns[positioned_box.column].base_size)));
         grid_row.base_size = grid_row_height;
 
         // - For min-content maximums:

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -661,8 +661,6 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
         auto& child_box_state = m_state.get_mutable(positioned_box.box);
         if (child_box_state.content_height() > positioned_box.computed_height)
             positioned_box.computed_height = child_box_state.content_height();
-        if (auto independent_formatting_context = layout_inside(positioned_box.box, LayoutMode::Normal, available_space))
-            independent_formatting_context->parent_context_did_dimension_child_root_box();
         if (child_box_state.content_height() > positioned_box.computed_height)
             positioned_box.computed_height = child_box_state.content_height();
         if (auto min_content_height = calculate_min_content_height(positioned_box.box, available_space.width); min_content_height > positioned_box.computed_height)
@@ -1470,6 +1468,10 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
         child_box_state.set_content_width(x_end - x_start);
         child_box_state.set_content_height(y_end - y_start);
         child_box_state.offset = { x_start, y_start };
+
+        auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(child_box_state.content_width()), AvailableSize::make_definite(child_box_state.content_height()));
+        if (auto independent_formatting_context = layout_inside(child_box, LayoutMode::Normal, available_space_for_children))
+            independent_formatting_context->parent_context_did_dimension_child_root_box();
     };
 
     for (auto& positioned_box : positioned_boxes) {

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -38,7 +38,7 @@ private:
     Vector<GridTrackSizeConstraints> m_grid_rows;
     Vector<GridTrackSizeConstraints> m_grid_columns;
 
-    float get_free_space_x(Box const&);
+    float get_free_space_x(AvailableSpace const& available_space);
     float get_free_space_y(Box const&);
 
     int get_line_index_by_line_name(String const& line_name, CSS::GridTrackSizeList);


### PR DESCRIPTION
This fixes a bug in the CSS Grid where children were not taking into account the constraints of the grid.