### PR TITLE
LibWeb: Fix a few `conic-gradient()` bugs

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -157,6 +157,14 @@
                 red 6deg, orange 6deg 18deg, yellow 18deg 45deg,
                 green 45deg 110deg, blue 110deg 200deg, purple 200deg);
         }
+
+        .grad-conic-5 {
+            background-image: conic-gradient(at 60% 45%, red, yellow, green);
+        }
+
+        .grad-conic-6 {
+            background-image: conic-gradient(red 0deg, red 90deg, yellow 90deg, yellow 180deg, green 180deg, green 270deg, blue 270deg);
+        }
     </style>
   </head>
   <body>
@@ -202,6 +210,8 @@
     <div class="box grad-conic-2"></div>
     <div class="box grad-conic-3"></div>
     <div class="box grad-conic-4"></div>
+    <div class="box grad-conic-5"></div>
+    <div class="box grad-conic-6"></div>
   </body>
   <script>
     const boxes = document.querySelectorAll(".box, .rect");

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2617,7 +2617,7 @@ RefPtr<StyleValue> Parser::parse_conic_gradient_function(ComponentValue const& c
     tokens.skip_whitespace();
     if (!tokens.has_next_token())
         return {};
-    if ((got_from_angle || got_color_interpolation_method) && !tokens.next_token().is(Token::Type::Comma))
+    if ((got_from_angle || got_at_position || got_color_interpolation_method) && !tokens.next_token().is(Token::Type::Comma))
         return {};
 
     // <angular-color-stop-list> =

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -273,10 +273,13 @@ void paint_conic_gradient(PaintContext& context, Gfx::IntRect const& gradient_re
     // FIXME: Do we need/want sub-degree accuracy for the gradient line?
     GradientLine gradient_line(360, data.color_stops);
     float start_angle = (360.0f - data.start_angle) + 90.0f;
+    // Translate position/center to the center of the pixel (avoids some funky painting)
+    auto center_point = Gfx::FloatPoint { position }.translated(0.5, 0.5);
     gradient_line.paint_into_rect(context.painter(), gradient_rect, [&](int x, int y) {
-        auto point = Gfx::IntPoint { x, y } - position;
+        auto point = Gfx::FloatPoint { x, y } - center_point;
         // FIXME: We could probably get away with some approximation here:
-        return fmod((AK::atan2(float(point.y()), float(point.x())) * 180.0f / AK::Pi<float> + 360.0f + start_angle), 360.0f);
+        // Note: We need too floor the angle here or the colors will start to diverge as you get further from the center.
+        return floor(fmod((AK::atan2(point.y(), point.x()) * 180.0f / AK::Pi<float> + 360.0f + start_angle), 360.0f));
     });
 }
 


### PR DESCRIPTION
This fixes several small bugs I noticed while browsing a few sites. 

|                                                                                                               | Before                                                                                                          | After                                                                                                           |
|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| Gradient sensitive to correct center position                                                                 | ![image](https://user-images.githubusercontent.com/11597044/200142969-386de252-fc12-41dd-8757-523a8b327385.png) | ![image](https://user-images.githubusercontent.com/11597044/200142886-847b3712-f0bc-459e-88f5-304804e845a8.png) |
| Gradient without starting angle, but with center position<br>`conic-gradient(at 60% 45%, red, yellow, green)` | Parser error :^(                                                                                                | ![image](https://user-images.githubusercontent.com/11597044/200142895-d7347941-56fb-43ce-a5dc-436f81cbf392.png) |
| Hard-edge gradient far from center                                                                            | ![image](https://user-images.githubusercontent.com/11597044/200143005-a74680e7-16ef-4660-9db5-90850d10e5b0.png) | ![image](https://user-images.githubusercontent.com/11597044/200142928-718817b2-681b-4409-a3f4-9ca494183805.png) |es.githubusercontent.com/11597044/200142928-718817b2-681b-4409-a3f4-9ca494183805.png)
