### PR TITLE
Meta: Look for e2fsck path on build-image-qemu.sh

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -50,13 +50,14 @@ if [ "$(uname -s)" = "Darwin" ]; then
 
     E2FSCK="e2fsck"
     RESIZE2FS_PATH="resize2fs"
-elif [ "$(uname -s)" = "SerenityOS" ]; then
-    E2FSCK="/usr/local/sbin/e2fsck"
-else
-    E2FSCK="/usr/sbin/e2fsck"
+elif [ ! -f "$E2FSCK" ]; then
+    E2FSCK="$(command -v e2fsck)"
 
     if [ ! -f "$E2FSCK" ]; then
-        E2FSCK=/sbin/e2fsck
+        E2FSCK="/usr/sbin/e2fsck"
+        if [ ! -f "$E2FSCK" ]; then
+            E2FSCK="/sbin/e2fsck"
+        fi
     fi
 fi
 


### PR DESCRIPTION
Now we attempt to look for the path of e2fsck before checking if the path
can be found in any of the predefined routes. This fixes e2fsck not
being found on some "special" distros like NixOS.

Related #13754