### PR TITLE
Meta+LibUnicode: Avoid relocations for static unicode data

### DIFF
--- a/Userland/Libraries/LibUnicode/Normalize.cpp
+++ b/Userland/Libraries/LibUnicode/Normalize.cpp
@@ -14,8 +14,8 @@
 
 namespace Unicode {
 
-Optional<CodePointDecomposition const&> __attribute__((weak)) code_point_decomposition(u32) { return {}; }
-Span<CodePointDecomposition const> __attribute__((weak)) code_point_decompositions() { return {}; }
+Optional<CodePointDecomposition const> __attribute__((weak)) code_point_decomposition(u32) { return {}; }
+Optional<CodePointDecomposition const> __attribute__((weak)) code_point_decomposition_by_index(size_t) { return {}; }
 
 NormalizationForm normalization_form_from_string(StringView form)
 {
@@ -122,7 +122,11 @@ static u32 combine_code_points(u32 a, u32 b)
 {
     Array<u32, 2> const points { a, b };
     // FIXME: Do something better than linear search to find reverse mappings.
-    for (auto const& mapping : Unicode::code_point_decompositions()) {
+    for (size_t index = 0;; ++index) {
+        auto mapping_maybe = Unicode::code_point_decomposition_by_index(index);
+        if (!mapping_maybe.has_value())
+            break;
+        auto& mapping = mapping_maybe.value();
         if (mapping.tag == CompatibilityFormattingTag::Canonical && mapping.decomposition == points) {
             if (code_point_has_property(mapping.code_point, Property::Full_Composition_Exclusion))
                 continue;

--- a/Userland/Libraries/LibUnicode/Normalize.h
+++ b/Userland/Libraries/LibUnicode/Normalize.h
@@ -15,8 +15,8 @@
 
 namespace Unicode {
 
-Optional<CodePointDecomposition const&> code_point_decomposition(u32 code_point);
-Span<CodePointDecomposition const> code_point_decompositions();
+Optional<CodePointDecomposition const> code_point_decomposition(u32 code_point);
+Optional<CodePointDecomposition const> code_point_decomposition_by_index(size_t index);
 
 enum class NormalizationForm {
     NFD,


### PR DESCRIPTION
**Meta+LibUnicode: Avoid relocations for static unicode data**
    
Previously the s_decomposition_mappings variable would refer to other data in s_decomposition_mappings_data. This would cause thousands of avoidable relocations at load time.

This saves about 128kB RAM for each process which uses LibUnicode.

**Meta+LibUnicode: Avoid relocations for emoji data**

Previously each emoji had its own symbol in the library which was then referred to by another symbol. This caused thousands of avoidable data relocations at load time.

This saves about 122kB RAM for each process which uses LibUnicode.

Before:

![mem-vanilla-relro](https://user-images.githubusercontent.com/388571/200159135-a1ff83f4-48c0-4be0-871c-7e883890ca16.png)

![mem-vanilla](https://user-images.githubusercontent.com/388571/200159137-70c95cd1-1d83-488e-b472-7e729db8f6a6.png)

After:

![mem-opt-relro](https://user-images.githubusercontent.com/388571/200159149-e72bcf4d-8755-428f-ad76-840de46acf71.png)

![mem-opt](https://user-images.githubusercontent.com/388571/200159157-4797ca0e-79b0-43ff-9efc-b1bec1507c97.png)


