### PR TITLE
LibGfx+LibWeb: Use new 2d rasterizer for painting SVG paths in LibWeb.

### DIFF
--- a/Userland/Libraries/LibGfx/AffineTransform.cpp
+++ b/Userland/Libraries/LibGfx/AffineTransform.cpp
@@ -51,6 +51,11 @@ FloatPoint AffineTransform::translation() const
     return { x_translation(), y_translation() };
 }
 
+AffineTransform& AffineTransform::scale(float s)
+{
+    return scale(s, s);
+}
+
 AffineTransform& AffineTransform::scale(float sx, float sy)
 {
     m_values[0] *= sx;

--- a/Userland/Libraries/LibGfx/AffineTransform.h
+++ b/Userland/Libraries/LibGfx/AffineTransform.h
@@ -55,6 +55,7 @@ public:
     [[nodiscard]] float y_translation() const;
     [[nodiscard]] FloatPoint translation() const;
 
+    AffineTransform& scale(float s);
     AffineTransform& scale(float sx, float sy);
     AffineTransform& scale(FloatPoint const& s);
     AffineTransform& set_scale(float sx, float sy);

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -47,6 +47,8 @@ set(SOURCES
     TextLayout.cpp
     Triangle.cpp
     WindowTheme.cpp
+    Rasterizer.cpp
+    PathPainter.cpp
 )
 
 serenity_lib(LibGfx gfx)

--- a/Userland/Libraries/LibGfx/FillPainter.h
+++ b/Userland/Libraries/LibGfx/FillPainter.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, Daniel Oberhoff <daniel@danieloberhoff.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Rasterizer.h>
+
+namespace Gfx {
+
+class FillPainter {
+public:
+    FillPainter(Gfx::Bitmap& image)
+        : m_rasterizer { image }
+    {
+    }
+
+    void begin(Point<float> p)
+    {
+        m_first_point = m_current_point = p;
+    }
+
+    void edge_to(Point<float> p)
+    {
+        m_rasterizer.add_edge({ m_current_point, p });
+        m_current_point = p;
+    }
+
+    void end()
+    {
+        m_rasterizer.add_edge({ m_current_point, m_first_point });
+    }
+
+    void end_path(Rasterizer::Paint const& paint)
+    {
+        m_rasterizer.rasterize_edges(Rasterizer::FillRule::evenodd, paint);
+    }
+
+    void set_transform(AffineTransform const& transform)
+    {
+        m_rasterizer.set_transform(transform);
+    }
+
+    void set_clip_rect(const IntRect clip_rect)
+    {
+        m_rasterizer.set_clip_rect(clip_rect);
+    }
+
+private:
+    Rasterizer m_rasterizer;
+    Point<float> m_first_point;
+    Point<float> m_current_point;
+};
+
+}

--- a/Userland/Libraries/LibGfx/Gradients.h
+++ b/Userland/Libraries/LibGfx/Gradients.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Daniel Oberhoff <daniel@danieloberhoff.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <LibGfx/Color.h>
+#include <LibGfx/Point.h>
+
+namespace Gfx {
+
+struct GradientStop {
+    Color color;
+    float percentage;
+};
+
+struct LinearGradient {
+    AK::Vector<GradientStop> stops;
+    Point<float> p1;
+    Point<float> p2;
+
+    Color operator()(Point<float> p) const
+    {
+        auto d = p2 - p1;
+        auto o = p - p1;
+        auto percentage = o.dot(d) / d.dot(d);
+        auto i_next = stops.find_if([percentage](auto&& stop) { return stop.percentage >= percentage; });
+        if (i_next == stops.end()) {
+            return stops.last().color;
+        } else if (i_next == stops.begin()) {
+            return stops.first().color;
+        } else {
+            auto& left = *(i_next - 1);
+            auto& right = *i_next;
+            auto weight = (percentage - left.percentage) / (right.percentage - left.percentage);
+            return left.color.interpolate(right.color, weight);
+        }
+    }
+};
+
+}

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2041,10 +2041,8 @@ void Painter::draw_triangle_wave(IntPoint const& a_p1, IntPoint const& a_p2, Col
     }
 }
 
-static bool can_approximate_bezier_curve(FloatPoint const& p1, FloatPoint const& p2, FloatPoint const& control)
+bool Painter::can_approximate_bezier_curve(FloatPoint const& p1, FloatPoint const& p2, FloatPoint const& control, float tolerance)
 {
-    constexpr float tolerance = 0.0015f;
-
     auto p1x = 3 * control.x() - 2 * p1.x() - p2.x();
     auto p1y = 3 * control.y() - 2 * p1.y() - p2.y();
     auto p2x = 3 * control.x() - 2 * p2.x() - p1.x();
@@ -2115,10 +2113,8 @@ void Painter::for_each_line_segment_on_cubic_bezier_curve(FloatPoint const& cont
     for_each_line_segment_on_cubic_bezier_curve(control_point_0, control_point_1, p1, p2, callback);
 }
 
-static bool can_approximate_cubic_bezier_curve(FloatPoint const& p1, FloatPoint const& p2, FloatPoint const& control_0, FloatPoint const& control_1)
+bool Painter::can_approximate_cubic_bezier_curve(FloatPoint const& p1, FloatPoint const& p2, FloatPoint const& control_0, FloatPoint const& control_1, float tolerance)
 {
-    constexpr float tolerance = 0.0015f;
-
     auto ax = 3 * control_0.x() - 2 * p1.x() - p2.x();
     auto ay = 3 * control_0.y() - 2 * p1.y() - p2.y();
     auto bx = 3 * control_1.x() - p1.x() - 2 * p2.x();

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -106,9 +106,11 @@ public:
 
     static void for_each_line_segment_on_bezier_curve(FloatPoint const& control_point, FloatPoint const& p1, FloatPoint const& p2, Function<void(FloatPoint const&, FloatPoint const&)>&);
     static void for_each_line_segment_on_bezier_curve(FloatPoint const& control_point, FloatPoint const& p1, FloatPoint const& p2, Function<void(FloatPoint const&, FloatPoint const&)>&&);
+    static bool can_approximate_bezier_curve(FloatPoint const& p1, FloatPoint const& p2, FloatPoint const& control, float tolerance = 0.0015f);
 
     static void for_each_line_segment_on_cubic_bezier_curve(FloatPoint const& control_point_0, FloatPoint const& control_point_1, FloatPoint const& p1, FloatPoint const& p2, Function<void(FloatPoint const&, FloatPoint const&)>&);
     static void for_each_line_segment_on_cubic_bezier_curve(FloatPoint const& control_point_0, FloatPoint const& control_point_1, FloatPoint const& p1, FloatPoint const& p2, Function<void(FloatPoint const&, FloatPoint const&)>&&);
+    static bool can_approximate_cubic_bezier_curve(FloatPoint const& p1, FloatPoint const& p2, FloatPoint const& control_0, FloatPoint const& control_1, float tolerance = 0.0015f);
 
     static void for_each_line_segment_on_elliptical_arc(FloatPoint const& p1, FloatPoint const& p2, FloatPoint const& center, FloatPoint const radii, float x_axis_rotation, float theta_1, float theta_delta, Function<void(FloatPoint const&, FloatPoint const&)>&);
     static void for_each_line_segment_on_elliptical_arc(FloatPoint const& p1, FloatPoint const& p2, FloatPoint const& center, FloatPoint const radii, float x_axis_rotation, float theta_1, float theta_delta, Function<void(FloatPoint const&, FloatPoint const&)>&&);

--- a/Userland/Libraries/LibGfx/PathPainter.cpp
+++ b/Userland/Libraries/LibGfx/PathPainter.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2022, Daniel Oberhoff <daniel@danieloberhoff.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Painter.h>
+#include <LibGfx/PathPainter.h>
+
+namespace Gfx {
+
+PathPainter::PathPainter(Gfx::Bitmap& image)
+    : m_stroke_painter { image }
+    , m_fill_painter { image }
+{
+}
+
+void PathPainter::check_begin()
+{
+    if (!m_in_path) {
+        begin_paint(m_position);
+        m_in_path = true;
+    }
+}
+
+void PathPainter::check_end()
+{
+    if (m_in_path) {
+        end();
+        m_in_path = false;
+    }
+}
+
+void PathPainter::begin_path(StrokeKind stroke_kind, FillKind fill_kind, float thickness)
+{
+    m_stroke_kind = stroke_kind;
+    m_fill_kind = fill_kind;
+    m_thickness = thickness;
+}
+
+void PathPainter::move_to(Point<float> p)
+{
+    check_end();
+    m_position = p;
+}
+
+void PathPainter::line_to(
+    Point<float> to)
+{
+    check_begin();
+    edge_to(to);
+    m_position = to;
+}
+
+void PathPainter::quadratic_bezier_curve_to(
+    Point<float> control,
+    Point<float> to)
+{
+    check_begin();
+    tesselate_quadratic_bezier_curve(m_position, control, to);
+    m_position = to;
+}
+
+void PathPainter::cubic_bezier_curve_to(
+    Point<float> control1,
+    Point<float> control2,
+    Point<float> to)
+{
+    check_begin();
+    tesslate_cubic_bezier_curve(m_position, control1, control2, to);
+    m_position = to;
+}
+
+void PathPainter::elliptical_arc_to(FloatPoint to, FloatPoint center, FloatPoint radii, float x_axis_rotation, float theta_1, float theta_delta)
+{
+    check_begin();
+    Painter::for_each_line_segment_on_elliptical_arc(
+        m_position,
+        to,
+        center,
+        radii,
+        x_axis_rotation,
+        theta_1,
+        theta_delta,
+        [&](FloatPoint /*from*/, FloatPoint to) {
+            edge_to(to);
+        });
+}
+
+void PathPainter::end()
+{
+    if (m_fill_kind == FillKind::Filled)
+        m_fill_painter.end();
+    switch (m_stroke_kind) {
+    case StrokeKind::OpenStroke:
+    case StrokeKind::ClosedStroke:
+        m_stroke_painter.end();
+        break;
+    case StrokeKind::NoStroke:
+        break;
+    }
+    m_in_path = false;
+}
+
+void PathPainter::end_path(Rasterizer::Paint const& stroke_paint, Rasterizer::Paint const& fill_paint)
+{
+    check_end();
+    switch (m_stroke_kind) {
+    case StrokeKind::OpenStroke:
+    case StrokeKind::ClosedStroke:
+        m_stroke_painter.end_path(stroke_paint);
+        break;
+    case StrokeKind::NoStroke:
+        break;
+    }
+    if (m_fill_kind == FillKind::Filled)
+        m_fill_painter.end_path(fill_paint);
+}
+
+void PathPainter::tesslate_cubic_bezier_curve(
+    Point<float> from,
+    Point<float> control1,
+    Point<float> control2,
+    Point<float> to,
+    int recursion_depth)
+{
+    if (recursion_depth > 10 || Painter::can_approximate_cubic_bezier_curve(from, to, control1, control2, m_max_tesselation_error)) {
+        edge_to(to);
+    } else {
+        Array level_1_midpoints {
+            (from + control1) / 2,
+            (control1 + control2) / 2,
+            (control2 + to) / 2,
+        };
+        Array level_2_midpoints {
+            (level_1_midpoints[0] + level_1_midpoints[1]) / 2,
+            (level_1_midpoints[1] + level_1_midpoints[2]) / 2,
+        };
+        auto level_3_midpoint = (level_2_midpoints[0] + level_2_midpoints[1]) / 2;
+        tesslate_cubic_bezier_curve(from, level_1_midpoints[0], level_2_midpoints[0], level_3_midpoint, recursion_depth + 1);
+        tesslate_cubic_bezier_curve(level_3_midpoint, level_2_midpoints[1], level_1_midpoints[2], to, recursion_depth + 1);
+    }
+}
+
+void PathPainter::tesselate_quadratic_bezier_curve(
+    Point<float> from,
+    Point<float> control,
+    Point<float> to,
+    int recursion_depth)
+{
+    if (recursion_depth > 10 || Painter::can_approximate_bezier_curve(from, to, control, m_max_tesselation_error)) {
+        edge_to(to);
+    } else {
+        auto po1_midpoint = control + from;
+        po1_midpoint /= 2;
+        auto po2_midpoint = control + to;
+        po2_midpoint /= 2;
+        auto new_segment = po1_midpoint + po2_midpoint;
+        new_segment /= 2;
+        tesselate_quadratic_bezier_curve(from, po1_midpoint, new_segment, recursion_depth + 1);
+        tesselate_quadratic_bezier_curve(new_segment, po2_midpoint, to, recursion_depth + 1);
+    }
+}
+
+void PathPainter::begin_paint(Point<float> p)
+{
+    switch (m_stroke_kind) {
+    case StrokeKind::OpenStroke:
+        m_stroke_painter.begin(p, false, m_thickness);
+        break;
+    case StrokeKind::ClosedStroke:
+        m_stroke_painter.begin(p, true, m_thickness);
+        break;
+    case StrokeKind::NoStroke:
+        break;
+    }
+    if (m_fill_kind == FillKind::Filled)
+        m_fill_painter.begin(p);
+}
+
+void PathPainter::edge_to(Point<float> p)
+{
+    switch (m_stroke_kind) {
+    case StrokeKind::OpenStroke:
+    case StrokeKind::ClosedStroke:
+        m_stroke_painter.stroke_to(p);
+        break;
+    case StrokeKind::NoStroke:
+        break;
+    }
+    if (m_fill_kind == FillKind::Filled)
+        m_fill_painter.edge_to(p);
+}
+
+void PathPainter::set_transform(AffineTransform const& transform)
+{
+    m_fill_painter.set_transform(transform);
+    m_stroke_painter.set_transform(transform);
+}
+
+void PathPainter::set_clip_rect(const IntRect clip_rect)
+{
+    m_fill_painter.set_clip_rect(clip_rect);
+    m_stroke_painter.set_clip_rect(clip_rect);
+}
+
+}

--- a/Userland/Libraries/LibGfx/PathPainter.h
+++ b/Userland/Libraries/LibGfx/PathPainter.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022, Daniel Oberhoff <daniel@danieloberhoff.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/FillPainter.h>
+#include <LibGfx/Rasterizer.h>
+#include <LibGfx/StrokePainter.h>
+
+namespace Gfx {
+
+class PathPainter {
+public:
+    enum class StrokeKind {
+        OpenStroke,
+        ClosedStroke,
+        NoStroke
+    };
+    enum class FillKind {
+        Filled,
+        NotFilled
+    };
+    PathPainter(Gfx::Bitmap& image);
+    void begin_path(StrokeKind stroke_kind, FillKind fill_kind, float thickness);
+    void move_to(Point<float> p);
+    void line_to(
+        Point<float> to);
+    void quadratic_bezier_curve_to(
+        Point<float> control,
+        Point<float> to);
+    void cubic_bezier_curve_to(
+        Point<float> control1,
+        Point<float> control2,
+        Point<float> to);
+    void elliptical_arc_to(FloatPoint to, FloatPoint center, FloatPoint radii, float x_axis_rotation, float theta_1, float theta_delta);
+    void end_path(Rasterizer::Paint const& stroke_paint, Rasterizer::Paint const& fill_paint);
+    void set_transform(AffineTransform const& transform);
+    void set_clip_rect(const IntRect clip_rect);
+
+private:
+    enum class Phase { Idle,
+        Begun,
+        Painting };
+
+    void check_begin();
+    void check_end();
+    void end();
+    void tesslate_cubic_bezier_curve(
+        Point<float> from,
+        Point<float> control1,
+        Point<float> control2,
+        Point<float> to,
+        int recursion_depth = 0);
+    void tesselate_quadratic_bezier_curve(
+        Point<float> from,
+        Point<float> control,
+        Point<float> to,
+        int recursion_depth = 0);
+    void begin_paint(Point<float> p);
+    void edge_to(Point<float> p);
+
+    constexpr static float m_max_tesselation_error = 0.05f;
+    bool m_in_path = false;
+    StrokePainter m_stroke_painter;
+    FillPainter m_fill_painter;
+    StrokeKind m_stroke_kind { StrokeKind::NoStroke };
+    FillKind m_fill_kind { FillKind::NotFilled };
+    float m_thickness = 0;
+    Point<float> m_position { 0, 0 };
+};
+
+}

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -255,6 +255,16 @@ public:
 
     [[nodiscard]] String to_string() const;
 
+    [[nodiscard]] T cross(Point<T> const& other) const
+    {
+        return x() * other.y() - y() * other.x();
+    }
+
+    [[nodiscard]] T dot(Point<T> const& other) const
+    {
+        return x() * other.x() + y() * other.y();
+    }
+
 private:
     T m_x { 0 };
     T m_y { 0 };

--- a/Userland/Libraries/LibGfx/Rasterizer.cpp
+++ b/Userland/Libraries/LibGfx/Rasterizer.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2022, Daniel Oberhoff <daniel@danieloberhoff.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/QuickSort.h>
+#include <LibGfx/Color.h>
+#include <LibGfx/Rasterizer.h>
+
+namespace Gfx {
+
+Rasterizer::Rasterizer(Bitmap& image)
+    : m_image { image }
+    , m_clip_rect { m_image.rect() }
+{
+    m_coverage.resize(m_image.width());
+}
+
+void Rasterizer::set_transform(AffineTransform const& transform)
+{
+    m_transform = transform;
+}
+
+void Rasterizer::set_clip_rect(const IntRect clip_rect)
+{
+    m_clip_rect = m_image.rect().intersected(clip_rect);
+}
+
+void Rasterizer::rasterize_edges(FillRule fill_rule, Paint const& paint)
+{
+    AK::quick_sort(m_edges, [](auto a, auto b) { return a.top() < b.top(); });
+    auto next_edge = m_edges.begin();
+    for (int i = m_clip_rect.top(); i <= m_clip_rect.bottom(); ++i) {
+        m_min_col = m_clip_rect.right();
+        m_max_col = m_clip_rect.left();
+        memset(m_coverage.data(), 0, m_coverage.size());
+        if (m_active_edges.is_empty()) {
+            if (m_edges.is_empty())
+                break;
+            i = AK::max<int>(i, m_edges.first().top());
+        }
+        for (size_t s = 0; s < m_oversampling; ++s) {
+            auto scany = i + float(s) / m_oversampling;
+            m_active_edges.remove_all_matching([scany](auto& e) { return e.end <= scany; });
+            for (auto& edge : m_active_edges)
+                edge.x += edge.dx / m_oversampling;
+            for (; next_edge != m_edges.end() && next_edge->top() <= scany; ++next_edge) {
+                if (next_edge->bottom() > scany)
+                    m_active_edges.append(ActiveEdge { *next_edge, scany });
+            }
+            AK::quick_sort(m_active_edges, [](auto a, auto b) { return a.x < b.x; });
+            rasterize_scanline(fill_rule);
+        }
+        if (m_min_col <= m_max_col) {
+            paint.coloring.visit(
+                [&](Color color) {
+                    fill_scanline_solid(i, color);
+                },
+                [&](LinearGradient const& gradient) {
+                    fill_scanline_linear_gradient(i, gradient);
+                });
+        }
+    }
+    m_edges.clear();
+    m_active_edges.clear();
+}
+
+Rasterizer::ActiveEdge::ActiveEdge(Rasterizer::Edge const& edge, float y)
+{
+    auto from = edge.from;
+    auto to = edge.to;
+    if (from.y() > to.y()) {
+        swap(from, to);
+        winding = -1;
+    } else {
+        winding = 1;
+    }
+    auto d = to - from;
+    dx = d.x() / d.y();
+    x = from.x() + dx * (y - from.y());
+    end = to.y();
+}
+
+void Rasterizer::rasterize_scanline(FillRule fill_rule)
+{
+    float x = 0;
+    int winding = 0;
+    switch (fill_rule) {
+    case FillRule::nonzero:
+        for (auto& edge : m_active_edges) {
+            if (winding == 0) {
+                x = edge.x;
+                winding = edge.winding;
+            } else {
+                winding += edge.winding;
+                if (winding == 0)
+                    update_coverage(x, edge.x);
+            }
+        }
+        break;
+    case FillRule::evenodd:
+        for (auto& edge : m_active_edges) {
+            if (winding == 0) {
+                x = edge.x;
+                winding = 1;
+            } else {
+                winding = 0;
+                update_coverage(x, edge.x);
+            }
+        }
+        break;
+    }
+}
+
+void Rasterizer::update_coverage(float x0, float x1)
+{
+    size_t first_index = AK::clamp<size_t>(x0, m_clip_rect.left(), m_clip_rect.right());
+    size_t last_index = AK::clamp<size_t>(x1, m_clip_rect.left(), m_clip_rect.right());
+    m_min_col = AK::min(m_min_col, first_index);
+    m_max_col = AK::max(m_max_col, last_index);
+    auto start_coverage = AK::clamp(first_index + 1 - x0, 0, 1);
+    auto end_coverage = AK::clamp(x1 - last_index, 0, 1);
+    if (first_index == last_index) {
+        m_coverage[first_index] += (AK::clamp(start_coverage * end_coverage, 0, 1) * 255) / m_oversampling;
+    } else {
+        m_coverage[first_index] += (AK::clamp(start_coverage, 0, 1) * 255) / m_oversampling;
+        for (size_t i = first_index + 1; i < last_index; ++i) {
+            m_coverage[i] += 255 / m_oversampling;
+        }
+        m_coverage[last_index] += (AK::clamp(end_coverage, 0, 1) * 255) / m_oversampling;
+    }
+}
+
+void Rasterizer::fill_scanline_solid(size_t i, Color in_color)
+{
+    auto row = m_image.scanline(i);
+    for (size_t j = m_min_col; j <= m_max_col; ++j) {
+        auto color = in_color.with_alpha((uint16_t(in_color.alpha()) * m_coverage[j]) >> 8);
+        row[j] = Color::from_argb(row[j]).blend(color).value();
+    }
+}
+
+void Rasterizer::fill_scanline_linear_gradient(size_t i, LinearGradient const& gradient)
+{
+    auto row = m_image.scanline(i);
+    for (size_t j = m_min_col; j <= m_max_col; ++j) {
+        auto in_color = gradient({ j, i });
+        auto color = in_color.with_alpha((uint16_t(in_color.alpha()) * m_coverage[j]) >> 8);
+        row[j] = Color::from_argb(row[j]).blend(color).value();
+    }
+}
+
+}

--- a/Userland/Libraries/LibGfx/Rasterizer.h
+++ b/Userland/Libraries/LibGfx/Rasterizer.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022, Daniel Oberhoff <daniel@danieloberhoff.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Math.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibGfx/AffineTransform.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Color.h>
+#include <LibGfx/Gradients.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
+
+namespace Gfx {
+
+class Rasterizer {
+public:
+    struct Paint {
+        AK::Variant<Color, LinearGradient> coloring;
+    };
+    struct Edge {
+        Point<float> from, to;
+        float top() const { return AK::min(from.y(), to.y()); }
+        float bottom() const { return AK::max(from.y(), to.y()); }
+    };
+    enum class FillRule {
+        nonzero,
+        evenodd
+    };
+    Rasterizer(Bitmap& image);
+    void set_transform(AffineTransform const& transform);
+    void set_clip_rect(const IntRect clip_rect);
+    void rasterize_edges(FillRule fill_rule, Paint const& paint);
+
+    void add_edge(Edge edge)
+    {
+        edge = {
+            edge.from.transformed(m_transform),
+            edge.to.transformed(m_transform),
+        };
+        if (edge.from.y() != edge.to.y())
+            m_edges.append(edge);
+    }
+
+private:
+    struct ActiveEdge {
+        float x, dx, end;
+        int winding;
+        ActiveEdge(Edge const& edge, float y);
+    };
+    void rasterize_scanline(FillRule fill_rule);
+    void update_coverage(float x0, float x1);
+    void fill_scanline_solid(size_t i, Color in_color);
+    void fill_scanline_linear_gradient(size_t i, LinearGradient const& gradient);
+    static constexpr uint8_t m_oversampling = 5;
+    size_t m_min_col, m_max_col;
+    Bitmap& m_image;
+    IntRect m_clip_rect;
+    IntRect m_effective_clip_rect;
+    AffineTransform m_transform;
+    AK::Vector<uint8_t> m_coverage;
+    AK::Vector<Edge> m_edges;
+    AK::Vector<ActiveEdge> m_active_edges;
+};
+
+}

--- a/Userland/Libraries/LibGfx/StrokePainter.h
+++ b/Userland/Libraries/LibGfx/StrokePainter.h
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2022, Daniel Oberhoff <daniel@danieloberhoff.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Rasterizer.h>
+
+namespace Gfx {
+
+class StrokePainter {
+public:
+    enum class LineEnd {
+        Start,
+        End
+    };
+    enum class CapType {
+        Butt,
+        Square,
+        Round
+    };
+    enum class JoinType {
+        Bevel,
+        Miter,
+        Round
+    };
+    enum class EndType {
+        CloseWithCorner,
+        CloseWihoutCorner,
+        Open
+    };
+    StrokePainter(Bitmap& image)
+        : m_rasterizer { image }
+    {
+    }
+
+    void begin(Point<float> p, bool closed, float thickness)
+    {
+        m_thickness = thickness;
+        m_closed = closed;
+        m_first_point = m_current_point = p;
+        m_first = true;
+        m_first_join = true;
+    }
+
+    void stroke_to(Point<float> p)
+    {
+        if (m_current_point.distance_from(p) == 0)
+            return;
+        if (m_first) {
+            m_second_point = p;
+            if (!m_closed)
+                add_cap(p);
+            m_first = false;
+        } else {
+            add_join(p);
+        }
+        m_last_point = m_current_point;
+        m_current_point = p;
+    }
+
+    void end()
+    {
+        if (m_first)
+            return;
+        else if (m_closed)
+            close();
+        else
+            add_cap(m_last_point);
+    }
+
+    void end_path(Rasterizer::Paint const& paint)
+    {
+        m_rasterizer.rasterize_edges(Rasterizer::FillRule::nonzero, paint);
+    }
+
+    void set_transform(AffineTransform const& transform)
+    {
+        m_rasterizer.set_transform(transform);
+    }
+
+    void set_clip_rect(const IntRect clip_rect)
+    {
+        m_rasterizer.set_clip_rect(clip_rect);
+    }
+
+private:
+    static Point<float> intersect(
+        Point<float> p1,
+        Point<float> d1,
+        Point<float> p2,
+        Point<float> d2)
+    {
+        return intersect(p1, d1, p2, d2, d1.cross(d2));
+    }
+
+    static Point<float> intersect(
+        Point<float> p1,
+        Point<float> d1,
+        Point<float> p2,
+        Point<float> d2,
+        float c)
+    {
+        return -(
+                   d2 * p1.cross(p1 + d1) - d1 * p2.cross(p2 + d2))
+            / c;
+    }
+
+    static float norm(Point<float> p)
+    {
+        return AK::sqrt(p.dot(p));
+    }
+
+    static Point<float> normalized(Point<float> p)
+    {
+        return p / norm(p);
+    }
+
+    static Point<float> left(Point<float> p)
+    {
+        return Point<float> { -p.y(), p.x() };
+    }
+
+    Point<float> offset(Point<float> d) const
+    {
+        return left(d) * (m_thickness / 2);
+    }
+
+    void add_edge(Rasterizer::Edge edge)
+    {
+        m_rasterizer.add_edge(edge);
+    }
+
+    void add_join(Point<float> p)
+    {
+        auto d1 = direction();
+        auto o1 = offset(d1);
+        auto l1 = m_current_point - o1;
+        auto r1 = m_current_point + o1;
+
+        auto d2 = direction(p);
+        auto o2 = offset(d2);
+        auto l2 = p - o2;
+        auto r2 = p + o2;
+
+        auto c = d1.cross(d2);
+
+        auto join_start = [this](auto left, auto right) {
+            if (m_first_join) {
+                m_close_left = left;
+                m_close_right = right;
+                m_first_join = false;
+            } else {
+                add_edge({ m_left, left });
+                add_edge({ right, m_right });
+            }
+        };
+
+        if (AK::abs(c) < 0.0001f) {
+            join_start(l2, r2);
+            m_left = l2;
+            m_right = r2;
+            return;
+        }
+
+        switch (m_join_type) {
+        case JoinType::Bevel: {
+            if (c > 0) {
+                auto right = intersect(r1, d1, r2, d2, c);
+                join_start(l1, right);
+                add_edge({ l1, l2 });
+                m_left = l2;
+                m_right = right;
+            } else {
+                auto left = intersect(l1, d1, l2, d2, c);
+                join_start(left, r1);
+                add_edge({ r2, r1 });
+                m_left = left;
+                m_right = r2;
+            }
+            break;
+        }
+        case JoinType::Miter: {
+            auto left = intersect(l1, d1, l2, d2, c);
+            auto right = intersect(r1, d1, r2, d2, c);
+            join_start(left, right);
+            m_left = left;
+            m_right = right;
+            break;
+        }
+        case JoinType::Round: {
+            if (c > 0) {
+                auto right = intersect(r1, d1, r2, d2, c);
+                join_start(l1, right);
+                add_circle_segment(m_current_point, l1, l2);
+                m_left = l2;
+                m_right = right;
+            } else {
+                auto left = intersect(l1, d1, l2, d2, c);
+                join_start(left, r1);
+                add_circle_segment(m_current_point, r2, r1);
+                m_left = left;
+                m_right = r2;
+            }
+        }
+        }
+    }
+
+    void add_cap(Point<float> towards)
+    {
+        auto d = direction(towards);
+        auto o = offset(d);
+        auto l = m_current_point - o;
+        auto r = m_current_point + o;
+        switch (m_cap_type) {
+        case CapType::Butt: {
+            add_edge({ r, l });
+            break;
+        }
+        case CapType::Square: {
+            auto backoff = normalized(d) * (m_thickness / 2);
+            l -= backoff;
+            r -= backoff;
+            add_edge({ r, l });
+            break;
+        }
+        case CapType::Round: {
+            add_circle_segment(m_current_point, r, l);
+            break;
+        }
+        }
+    }
+
+    void close()
+    {
+        stroke_to(m_first_point);
+        add_join(m_second_point);
+        add_edge({ m_left, m_close_left });
+        add_edge({ m_close_right, m_right });
+    }
+
+    void add_circle_segment(
+        Point<float> center,
+        Point<float> from,
+        Point<float> to)
+    {
+        auto r = from.distance_from(center);
+        auto r1 = from - center;
+        auto r2 = to - center;
+        auto a1 = AK::atan2(r1.x(), r1.y());
+        auto a2 = AK::atan2(r2.x(), r2.y());
+        if (r1.cross(r2) < 0) {
+            if (a1 > a2)
+                a1 -= 2 * float(M_PI);
+        } else {
+            if (a1 < a2)
+                a2 -= 2 * float(M_PI);
+        }
+        size_t n_steps = AK::max(1, to.distance_from(from));
+        Point<float> last = from;
+        for (size_t i = 0; i < n_steps; ++i) {
+            auto a = a1 + float(i + 1) / float(n_steps + 1) * (a2 - a1);
+            float s, c;
+            AK::sincos(a, s, c);
+            auto p = m_current_point + Point<float> { s, c } * r;
+            add_edge({ last, p });
+            last = p;
+        }
+        add_edge({ last, to });
+    }
+
+    Point<float> direction() const
+    {
+        return normalized(m_current_point - m_last_point);
+    }
+
+    Point<float> direction(Point<float> next) const
+    {
+        return normalized(next - m_current_point);
+    }
+
+    Rasterizer m_rasterizer;
+    float m_thickness = 1;
+    bool m_closed;
+    bool m_first = true;
+    bool m_first_join = true;
+    CapType m_cap_type = CapType::Butt;
+    JoinType m_join_type = JoinType::Miter;
+    Point<float> m_left;
+    Point<float> m_right;
+    Point<float> m_close_left;
+    Point<float> m_close_right;
+    Point<float> m_first_point;
+    Point<float> m_second_point;
+    Point<float> m_last_point;
+    Point<float> m_current_point;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGfx/AntiAliasingPainter.h>
+#include "LibGfx/AffineTransform.h"
+#include "LibGfx/Rasterizer.h"
+#include <LibGfx/PathPainter.h>
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Painting/SVGGeometryPaintable.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
+#include <cstdio>
 
 namespace Web::Painting {
 
@@ -37,86 +40,80 @@ void SVGGeometryPaintable::paint(PaintContext& context, PaintPhase phase) const
         return;
 
     auto& geometry_element = layout_box().dom_node();
-
-    Gfx::AntiAliasingPainter painter { context.painter() };
-    auto& svg_context = context.svg_context();
-
-    auto offset = svg_context.svg_element_position();
-    painter.translate(offset);
-
     auto const* svg_element = geometry_element.first_ancestor_of_type<SVG::SVGSVGElement>();
+    auto& svg_context = context.svg_context();
+    auto offset = svg_context.svg_element_position();
     auto maybe_view_box = svg_element->view_box();
-
-    context.painter().add_clip_rect(enclosing_int_rect(absolute_rect()));
-
+    Gfx::AffineTransform transform;
+    transform.translate(Gfx::Point<float>(context.painter().translation()));
+    transform.scale(context.painter().scale());
+    transform.translate(offset);
+    if (maybe_view_box.has_value()) {
+        transform.scale(layout_box().viewbox_scaling(), layout_box().viewbox_scaling());
+        transform.translate(-layout_box().viewbox_origin());
+    }
+    auto fill_color = geometry_element.fill_color().value_or(svg_context.fill_color());
+    auto stroke_color = geometry_element.stroke_color().value_or(svg_context.stroke_color());
+    auto stroke_width = geometry_element.stroke_width().value_or(svg_context.stroke_width()) * 2;
+    auto clip_rect = context.painter().clip_rect().intersected(
+        enclosing_int_rect(absolute_rect()).translated(context.painter().translation()));
     Gfx::Path path = const_cast<SVG::SVGGeometryElement&>(geometry_element).get_path();
 
-    if (maybe_view_box.has_value()) {
-        Gfx::Path new_path;
-        auto scaling = layout_box().viewbox_scaling();
-        auto origin = layout_box().viewbox_origin();
+    paint_internal(
+        fill_color,
+        stroke_color,
+        stroke_width,
+        transform,
+        clip_rect,
+        path,
+        *context.painter().target());
+}
 
-        auto transform_point = [&scaling, &origin](Gfx::FloatPoint const& point) -> Gfx::FloatPoint {
-            auto new_point = point;
-            new_point.translate_by({ -origin.x(), -origin.y() });
-            new_point.scale_by(scaling);
-            return new_point;
-        };
-
-        for (auto& segment : path.segments()) {
-            switch (segment.type()) {
-            case Gfx::Segment::Type::Invalid:
-                break;
-            case Gfx::Segment::Type::MoveTo:
-                new_path.move_to(transform_point(segment.point()));
-                break;
-            case Gfx::Segment::Type::LineTo:
-                new_path.line_to(transform_point(segment.point()));
-                break;
-            case Gfx::Segment::Type::QuadraticBezierCurveTo: {
-                auto& quadratic_bezier_segment = static_cast<Gfx::QuadraticBezierCurveSegment const&>(segment);
-                new_path.quadratic_bezier_curve_to(transform_point(quadratic_bezier_segment.through()), transform_point(quadratic_bezier_segment.point()));
-                break;
-            }
-            case Gfx::Segment::Type::CubicBezierCurveTo: {
-                auto& cubic_bezier_segment = static_cast<Gfx::CubicBezierCurveSegment const&>(segment);
-                new_path.cubic_bezier_curve_to(transform_point(cubic_bezier_segment.through_0()), transform_point(cubic_bezier_segment.through_1()), transform_point(cubic_bezier_segment.point()));
-                break;
-            }
-            case Gfx::Segment::Type::EllipticalArcTo: {
-                auto& elliptical_arc_segment = static_cast<Gfx::EllipticalArcSegment const&>(segment);
-                new_path.elliptical_arc_to(transform_point(elliptical_arc_segment.point()), elliptical_arc_segment.radii().scaled(scaling, scaling), elliptical_arc_segment.x_axis_rotation(), elliptical_arc_segment.large_arc(), elliptical_arc_segment.sweep());
-                break;
-            }
-            }
+void SVGGeometryPaintable::paint_internal(
+    Gfx::Color fill_color,
+    Gfx::Color stroke_color,
+    float stroke_width,
+    Gfx::AffineTransform const& transform,
+    Gfx::IntRect clip_rect,
+    Gfx::Path const& path,
+    Gfx::Bitmap& bitmap) const
+{
+    Gfx::PathPainter painter { bitmap };
+    painter.set_clip_rect(clip_rect);
+    painter.set_transform(transform);
+    // painter.begin_path(StrokeKind stroke_kind, FillKind fill_kind, float thickness)
+    painter.begin_path(
+        stroke_color.alpha() > 0 ? Gfx::PathPainter::StrokeKind::ClosedStroke : Gfx::PathPainter::StrokeKind::NoStroke,
+        fill_color.alpha() > 0 ? Gfx::PathPainter::FillKind::Filled : Gfx::PathPainter::FillKind::NotFilled,
+        stroke_width);
+    for (auto& segment : path.segments()) {
+        switch (segment.type()) {
+        case Gfx::Segment::Type::Invalid:
+            break;
+        case Gfx::Segment::Type::MoveTo:
+            painter.move_to(segment.point());
+            break;
+        case Gfx::Segment::Type::LineTo:
+            painter.line_to(segment.point());
+            break;
+        case Gfx::Segment::Type::QuadraticBezierCurveTo: {
+            auto& curve = static_cast<Gfx::QuadraticBezierCurveSegment const&>(segment);
+            painter.quadratic_bezier_curve_to(curve.through(), curve.point());
+            break;
         }
-
-        path = new_path;
+        case Gfx::Segment::Type::CubicBezierCurveTo: {
+            auto& curve = static_cast<Gfx::CubicBezierCurveSegment const&>(segment);
+            painter.cubic_bezier_curve_to(curve.through_0(), curve.through_1(), curve.point());
+            break;
+        }
+        case Gfx::Segment::Type::EllipticalArcTo: {
+            auto& arc = static_cast<Gfx::EllipticalArcSegment const&>(segment);
+            painter.elliptical_arc_to(arc.point(), arc.center(), arc.radii(), arc.x_axis_rotation(), arc.theta_1(), arc.theta_delta());
+            break;
+        }
+        }
     }
-
-    if (auto fill_color = geometry_element.fill_color().value_or(svg_context.fill_color()); fill_color.alpha() > 0) {
-        // We need to fill the path before applying the stroke, however the filled
-        // path must be closed, whereas the stroke path may not necessary be closed.
-        // Copy the path and close it for filling, but use the previous path for stroke
-        auto closed_path = path;
-        closed_path.close();
-
-        // Fills are computed as though all paths are closed (https://svgwg.org/svg2-draft/painting.html#FillProperties)
-        painter.fill_path(
-            closed_path,
-            fill_color,
-            Gfx::Painter::WindingRule::EvenOdd);
-    }
-
-    if (auto stroke_color = geometry_element.stroke_color().value_or(svg_context.stroke_color()); stroke_color.alpha() > 0) {
-        painter.stroke_path(
-            path,
-            stroke_color,
-            geometry_element.stroke_width().value_or(svg_context.stroke_width()));
-    }
-
-    painter.translate(-offset);
-    context.painter().clear_clip_rect();
+    painter.end_path(Gfx::Rasterizer::Paint { stroke_color }, Gfx::Rasterizer::Paint { fill_color });
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.h
@@ -21,6 +21,16 @@ public:
 
 protected:
     SVGGeometryPaintable(Layout::SVGGeometryBox const&);
+
+private:
+    void paint_internal(
+        Gfx::Color fill_color,
+        Gfx::Color stroke_color,
+        float stroke_width,
+        Gfx::AffineTransform const& transform,
+        Gfx::IntRect clip_rect,
+        Gfx::Path const& path,
+        Gfx::Bitmap& bitmap) const;
 };
 
 }


### PR DESCRIPTION
This introduces a new 2d rasterizer and uses it to render SVG in LibWeb with nice antialiasing and properly joined strokes. It is constructed to be easily changeable and extensible.

After this I would like to merge AntialiasedPainter and Painter and implement those in terms of the new rasterizer (with antialiasing simply being optional). This should make for much more compact code and make it much easier to fix painting bugs.