### PR TITLE
PixelPaint: Enable color picking for paint tools on Alt key

### DIFF
--- a/Meta/CMake/unicode_data.cmake
+++ b/Meta/CMake/unicode_data.cmake
@@ -59,7 +59,7 @@ set(SENTENCE_BREAK_PROP_SOURCE "auxiliary/SentenceBreakProperty.txt")
 set(SENTENCE_BREAK_PROP_PATH "${UCD_PATH}/${SENTENCE_BREAK_PROP_SOURCE}")
 
 string(REGEX REPLACE "([0-9]+\\.[0-9]+)\\.[0-9]+" "\\1" EMOJI_VERSION "${UCD_VERSION}")
-set(EMOJI_TEST_URL "https://unicode.org/Public/emoji/${EMOJI_VERSION}/emoji-test.txt")
+set(EMOJI_TEST_URL "https://www.unicode.org/Public/emoji/${EMOJI_VERSION}/emoji-test.txt")
 set(EMOJI_TEST_PATH "${UCD_PATH}/emoji-test.txt")
 set(EMOJI_RES_PATH "${SerenityOS_SOURCE_DIR}/Base/res/emoji")
 set(EMOJI_SERENITY_PATH "${SerenityOS_SOURCE_DIR}/Base/home/anon/Documents/emoji-serenity.txt")

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.h
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.h
@@ -22,13 +22,10 @@ public:
     virtual void on_mousedown(Layer*, MouseEvent&) override;
     virtual void on_mousemove(Layer*, MouseEvent&) override;
     virtual void on_mouseup(Layer*, MouseEvent&) override;
+    virtual bool on_keydown(GUI::KeyEvent&) override;
+    virtual void on_keyup(GUI::KeyEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override
-    {
-        if (m_editor && m_editor->scale() != m_scale_last_created_cursor)
-            refresh_editor_cursor();
-        return m_cursor;
-    }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
 
     void set_size(int size);
     int size() const { return m_size; }
@@ -51,6 +48,9 @@ protected:
     virtual NonnullRefPtr<Gfx::Bitmap> build_cursor();
     void refresh_editor_cursor();
     float m_scale_last_created_cursor = 0;
+
+    bool m_is_color_selection_enabled { true };
+    bool m_is_selecting_color { false };
 
 private:
     RefPtr<GUI::Widget> m_properties_widget;

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.h
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.h
@@ -12,7 +12,11 @@ namespace PixelPaint {
 
 class CloneTool : public BrushTool {
 public:
-    CloneTool() = default;
+    CloneTool()
+        : BrushTool()
+    {
+        m_is_color_selection_enabled = false;
+    }
     virtual ~CloneTool() override = default;
 
     virtual GUI::Widget* get_properties_widget() override;

--- a/Userland/Applications/PixelPaint/Tools/EraseTool.h
+++ b/Userland/Applications/PixelPaint/Tools/EraseTool.h
@@ -17,7 +17,11 @@ namespace PixelPaint {
 
 class EraseTool final : public BrushTool {
 public:
-    EraseTool() = default;
+    EraseTool()
+        : BrushTool()
+    {
+        m_is_color_selection_enabled = false;
+    }
     virtual ~EraseTool() override = default;
 
     virtual GUI::Widget* get_properties_widget() override;

--- a/Userland/Applications/PixelPaint/Tools/PenTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PenTool.cpp
@@ -62,4 +62,11 @@ GUI::Widget* PenTool::get_properties_widget()
     return m_properties_widget.ptr();
 }
 
+Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> PenTool::cursor()
+{
+    if (m_is_selecting_color)
+        return Gfx::StandardCursor::Eyedropper;
+    return Gfx::StandardCursor::Crosshair;
+}
+
 }

--- a/Userland/Applications/PixelPaint/Tools/PenTool.h
+++ b/Userland/Applications/PixelPaint/Tools/PenTool.h
@@ -18,7 +18,7 @@ class PenTool final : public BrushTool {
 public:
     PenTool();
     virtual ~PenTool() override = default;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
     virtual GUI::Widget* get_properties_widget() override;
 
 protected:

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.h
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.h
@@ -27,6 +27,7 @@ private:
 
     RefPtr<GUI::Widget> m_properties_widget;
     bool m_sample_all_layers { false };
+    bool m_is_selecting_color { false };
 };
 
 }

--- a/Userland/Applications/PixelPaint/Tools/SprayTool.h
+++ b/Userland/Applications/PixelPaint/Tools/SprayTool.h
@@ -22,8 +22,10 @@ public:
     virtual void on_mousedown(Layer*, MouseEvent&) override;
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual void on_mousemove(Layer*, MouseEvent&) override;
+    virtual void on_keyup(GUI::KeyEvent&) override;
+    virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
 
 private:
     virtual StringView tool_name() const override { return "Spray Tool"sv; }
@@ -36,6 +38,7 @@ private:
     Color m_color;
     int m_thickness { 10 };
     int m_density { 40 };
+    bool m_is_selecting_color { false };
 };
 
 }


### PR DESCRIPTION
 Adds color picker ability to the pen, brush and spray tools, similar to the `PickerTool`.

 Feature is available to any `Tool` that inherits from `BrushTool` but can be turned off for tools that don't require it. It is off for `EraseTool` as it doesn't make sense and also for `CloneTool` so it does not interfere with it's current functionality.

There is some duplication between `BrushTool` and `SprayTool` however it felt cleaner as is than to re-use the code by adding more abstraction. Let me know your thoughts!

Note that It currently hard codes the "Sample all layers" to `false`. Was thinking that ideally it would read the value set from the picker `tool` options but wasn't exactly sure what is the best way to read that value. Alternatively we could add the checkbox to the pen, brush and spray tool properties section.

Resolves #11860