### PR TITLE
VideoPlayer: Show current open file in the title

### DIFF
--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -77,6 +77,9 @@ void VideoPlayerWidget::open_file(StringView filename)
         return;
     }
 
+    m_path = filename;
+    update_title();
+
     m_playback_manager = load_file_result.release_value();
     resume_playback();
 }
@@ -182,6 +185,19 @@ void VideoPlayerWidget::cycle_sizing_modes()
     sizing_mode = static_cast<VideoSizingMode>((to_underlying(sizing_mode) + 1) % to_underlying(VideoSizingMode::Sentinel));
     m_video_display->set_sizing_mode(sizing_mode);
     m_video_display->update();
+}
+
+void VideoPlayerWidget::update_title()
+{
+    StringBuilder string_builder;
+    if (m_path.is_empty()) {
+        string_builder.append("No video"sv);
+    } else {
+        string_builder.append(m_path.view());
+    }
+
+    string_builder.append("[*] - Video Player"sv);
+    window()->set_title(string_builder.to_string());
 }
 
 }

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
@@ -27,6 +27,8 @@ public:
     void pause_playback();
     void toggle_pause();
 
+    void update_title();
+
 private:
     VideoPlayerWidget(GUI::Window&);
 
@@ -39,6 +41,8 @@ private:
     void event(Core::Event&) override;
 
     GUI::Window& m_window;
+
+    String m_path;
 
     RefPtr<VideoFrameWidget> m_video_display;
     RefPtr<GUI::HorizontalSlider> m_seek_slider;

--- a/Userland/Applications/VideoPlayer/main.cpp
+++ b/Userland/Applications/VideoPlayer/main.cpp
@@ -25,11 +25,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
     auto window = TRY(GUI::Window::try_create());
-    window->set_title("Video Player");
     window->resize(640, 480);
     window->set_resizable(true);
 
     auto main_widget = TRY(window->try_set_main_widget<VideoPlayer::VideoPlayerWidget>(window));
+    main_widget->update_title();
 
     if (!filename.is_empty())
         main_widget->open_file(filename);


### PR DESCRIPTION
Whilst taking a look at TextEditor, I noticed that it follows the following format for the title:
``[file path, or, 'Untitled' if there's no file] - Text Editor``

Video Player doesn't indicate to the user which file is currently open, so I feel like we should follow in the same footsteps as Text Editor :^)

![Screenshot 2022-11-06 131135](https://user-images.githubusercontent.com/117548228/200172824-4bd619d1-8b4f-4664-81bc-21976b0fbd34.png)
![Screenshot 2022-11-06 131117](https://user-images.githubusercontent.com/117548228/200172829-6de76d16-cf69-48ec-bde4-392602e207d1.png)
