### PR TITLE
LibWeb: Implement `repeating-conic-gradient()`s

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -165,6 +165,23 @@
         .grad-conic-6 {
             background-image: conic-gradient(red 0deg, red 90deg, yellow 90deg, yellow 180deg, green 180deg, green 270deg, blue 270deg);
         }
+
+        .grad-conic-repeat-1 {
+            background-image: repeating-conic-gradient(
+                red 0%,
+                yellow 15%,
+                red 33%
+            );
+        }
+
+        .grad-conic-repeat-2 {
+            background-image: repeating-conic-gradient(
+                from 45deg at 10% 50%,
+                brown 0deg 10deg,
+                darkgoldenrod 10deg 20deg,
+                chocolate 20deg 30deg
+            );
+        }
     </style>
   </head>
   <body>
@@ -212,6 +229,9 @@
     <div class="box grad-conic-4"></div>
     <div class="box grad-conic-5"></div>
     <div class="box grad-conic-6"></div>
+    <b>Repeating conic gradients</b><br>
+    <div class="box grad-conic-repeat-1"></div>
+    <div class="box grad-conic-repeat-2"></div>
   </body>
   <script>
     const boxes = document.querySelectorAll(".box, .rect");

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1751,7 +1751,7 @@ String LinearGradientStyleValue::to_string() const
 
     if (m_gradient_type == GradientType::WebKit)
         builder.append("-webkit-"sv);
-    if (m_repeating == Repeating::Yes)
+    if (is_repeating())
         builder.append("repeating-"sv);
     builder.append("linear-gradient("sv);
     m_direction.visit(
@@ -1958,6 +1958,8 @@ bool PositionValue::operator==(PositionValue const& other) const
 String ConicGradientStyleValue::to_string() const
 {
     StringBuilder builder;
+    if (is_repeating())
+        builder.append("repeating-"sv);
     builder.append("conic-gradient("sv);
     bool has_from_angle = false;
     bool has_at_position = false;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -1191,12 +1191,17 @@ private:
     RefPtr<Gfx::Bitmap> m_bitmap;
 };
 
+enum class GradientRepeating {
+    Yes,
+    No
+};
+
 class ConicGradientStyleValue final : public AbstractImageStyleValue {
 public:
-    static NonnullRefPtr<ConicGradientStyleValue> create(Angle from_angle, PositionValue position, Vector<AngularColorStopListElement> color_stop_list)
+    static NonnullRefPtr<ConicGradientStyleValue> create(Angle from_angle, PositionValue position, Vector<AngularColorStopListElement> color_stop_list, GradientRepeating repeating)
     {
         VERIFY(color_stop_list.size() >= 2);
-        return adopt_ref(*new ConicGradientStyleValue(from_angle, position, move(color_stop_list)));
+        return adopt_ref(*new ConicGradientStyleValue(from_angle, position, move(color_stop_list), repeating));
     }
 
     virtual String to_string() const override;
@@ -1220,12 +1225,15 @@ public:
 
     Gfx::FloatPoint resolve_position(Layout::Node const&, Gfx::FloatRect const&) const;
 
+    bool is_repeating() const { return m_repeating == GradientRepeating::Yes; }
+
 private:
-    ConicGradientStyleValue(Angle from_angle, PositionValue position, Vector<AngularColorStopListElement> color_stop_list)
+    ConicGradientStyleValue(Angle from_angle, PositionValue position, Vector<AngularColorStopListElement> color_stop_list, GradientRepeating repeating)
         : AbstractImageStyleValue(Type::ConicGradient)
         , m_from_angle(from_angle)
         , m_position(position)
         , m_color_stop_list(move(color_stop_list))
+        , m_repeating(repeating)
     {
     }
 
@@ -1233,6 +1241,7 @@ private:
     Angle m_from_angle;
     PositionValue m_position;
     Vector<AngularColorStopListElement> m_color_stop_list;
+    GradientRepeating m_repeating;
 
     struct ResolvedData {
         Painting::ConicGradientData data;
@@ -1251,12 +1260,7 @@ public:
         WebKit
     };
 
-    enum class Repeating {
-        Yes,
-        No
-    };
-
-    static NonnullRefPtr<LinearGradientStyleValue> create(GradientDirection direction, Vector<LinearColorStopListElement> color_stop_list, GradientType type, Repeating repeating)
+    static NonnullRefPtr<LinearGradientStyleValue> create(GradientDirection direction, Vector<LinearColorStopListElement> color_stop_list, GradientType type, GradientRepeating repeating)
     {
         VERIFY(color_stop_list.size() >= 2);
         return adopt_ref(*new LinearGradientStyleValue(direction, move(color_stop_list), type, repeating));
@@ -1271,7 +1275,7 @@ public:
         return m_color_stop_list;
     }
 
-    bool is_repeating() const { return m_repeating == Repeating::Yes; }
+    bool is_repeating() const { return m_repeating == GradientRepeating::Yes; }
 
     float angle_degrees(Gfx::FloatSize const& gradient_size) const;
 
@@ -1281,7 +1285,7 @@ public:
     void paint(PaintContext& context, Gfx::IntRect const& dest_rect, CSS::ImageRendering image_rendering) const override;
 
 private:
-    LinearGradientStyleValue(GradientDirection direction, Vector<LinearColorStopListElement> color_stop_list, GradientType type, Repeating repeating)
+    LinearGradientStyleValue(GradientDirection direction, Vector<LinearColorStopListElement> color_stop_list, GradientType type, GradientRepeating repeating)
         : AbstractImageStyleValue(Type::LinearGradient)
         , m_direction(direction)
         , m_color_stop_list(move(color_stop_list))
@@ -1293,7 +1297,7 @@ private:
     GradientDirection m_direction;
     Vector<LinearColorStopListElement> m_color_stop_list;
     GradientType m_gradient_type;
-    Repeating m_repeating;
+    GradientRepeating m_repeating;
 
     struct ResolvedData {
         Painting::LinearGradientData data;

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.h
@@ -22,15 +22,19 @@ struct ColorStop {
 
 using ColorStopList = Vector<ColorStop, 4>;
 
+struct ColorStopData {
+    ColorStopList list;
+    Optional<float> repeat_length;
+};
+
 struct LinearGradientData {
     float gradient_angle;
-    ColorStopList color_stops;
-    Optional<float> repeat_length;
+    ColorStopData color_stops;
 };
 
 struct ConicGradientData {
     float start_angle;
-    ColorStopList color_stops;
+    ColorStopData color_stops;
 };
 
 LinearGradientData resolve_linear_gradient_data(Layout::Node const&, Gfx::FloatSize const&, CSS::LinearGradientStyleValue const&);


### PR DESCRIPTION
A gradient a day keeps the boogs away!

|                                                                                                                       | LibWeb                                                                                                          | Chrome                                                                                                          |
|-----------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| `repeating-conic-gradient(red 0%, yellow 15%, red 33%)`                                                               | ![image](https://user-images.githubusercontent.com/11597044/200178054-a5086183-d222-431a-a291-df0856876200.png) | ![image](https://user-images.githubusercontent.com/11597044/200178116-5434ed53-e789-4368-a597-3fde22685ed4.png) |
| `repeating-conic-gradient(from 45deg at 10% 50%, brown 0deg 10deg, darkgoldenrod 10deg 20deg, chocolate 20deg 30deg)` | ![image](https://user-images.githubusercontent.com/11597044/200178074-c699c1e1-80d9-45ae-9d26-28f9b25e6022.png) | ![image](https://user-images.githubusercontent.com/11597044/200178123-beb373b6-a3e3-4a36-9a13-10b213506411.png) |