### PR TITLE
LibCore: Add query for all accounts and groups

### DIFF
--- a/Userland/Libraries/LibCore/Account.h
+++ b/Userland/Libraries/LibCore/Account.h
@@ -35,6 +35,7 @@ public:
     static ErrorOr<Account> self(Read options = Read::All);
     static ErrorOr<Account> from_name(StringView username, Read options = Read::All);
     static ErrorOr<Account> from_uid(uid_t uid, Read options = Read::All);
+    static ErrorOr<Vector<Account>> all(Read options = Read::All);
 
     bool authenticate(SecretString const& password) const;
     ErrorOr<void> login() const;

--- a/Userland/Libraries/LibCore/Group.h
+++ b/Userland/Libraries/LibCore/Group.h
@@ -19,6 +19,8 @@ public:
     static ErrorOr<void> add_group(Group& group);
 #endif
 
+    static ErrorOr<Vector<Group>> all();
+
     Group() = default;
     Group(String name, gid_t id = 0, Vector<String> members = {});
 


### PR DESCRIPTION
This adds an API to retrieve a list of all accounts and all groups available on the system via `Core::Account` and `Core::Group`. 

Part 1 of **[Users and Groups.](https://github.com/SerenityOS/serenity/compare/master...ne0ndrag0n:serenity:users-and-groups?expand=1)**
![Screenshot at 2022-11-06 19-19-46](https://user-images.githubusercontent.com/4776559/200203678-00d6403a-1f67-4b9c-9bb9-310ca2d1aee6.png)


