### PR TITLE
LibJS: Try to cache function environment bindings after first call

### DIFF
--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -156,6 +156,7 @@ struct ClassFieldDefinition;
 class Completion;
 class Console;
 class DeclarativeEnvironment;
+class DeclarativeEnvironmentBindings;
 class DeferGC;
 class ECMAScriptFunctionObject;
 class Environment;

--- a/Userland/Libraries/LibJS/Heap/Cell.h
+++ b/Userland/Libraries/LibJS/Heap/Cell.h
@@ -30,7 +30,12 @@ class Cell {
     AK_MAKE_NONMOVABLE(Cell);
 
 public:
+    // Post-construction initialization for cells that are part of a realm.
     virtual void initialize(Realm&) { }
+
+    // Post-construction initialization for cells that aren't part of a realm.
+    virtual void initialize_without_realm() { }
+
     virtual ~Cell() = default;
 
     bool is_marked() const { return m_mark; }

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -37,6 +37,8 @@ public:
     {
         auto* memory = allocate_cell(sizeof(T));
         new (memory) T(forward<Args>(args)...);
+        auto* cell = static_cast<T*>(memory);
+        cell->initialize_without_realm();
         return static_cast<T*>(memory);
     }
 

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -396,12 +396,12 @@ ObjectEnvironment* new_object_environment(Object& object, bool is_with_environme
 }
 
 // 9.1.2.4 NewFunctionEnvironment ( F, newTarget ), https://tc39.es/ecma262/#sec-newfunctionenvironment
-FunctionEnvironment* new_function_environment(ECMAScriptFunctionObject& function, Object* new_target)
+FunctionEnvironment* new_function_environment(ECMAScriptFunctionObject& function, Object* new_target, DeclarativeEnvironmentBindings* cached_bindings)
 {
     auto& heap = function.heap();
 
     // 1. Let env be a new function Environment Record containing no bindings.
-    auto* env = heap.allocate_without_realm<FunctionEnvironment>(function.environment());
+    auto* env = heap.allocate_without_realm<FunctionEnvironment>(function.environment(), cached_bindings);
 
     // 2. Set env.[[FunctionObject]] to F.
     env->set_function_object(function);

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -21,7 +21,7 @@ namespace JS {
 
 DeclarativeEnvironment* new_declarative_environment(Environment&);
 ObjectEnvironment* new_object_environment(Object&, bool is_with_environment, Environment*);
-FunctionEnvironment* new_function_environment(ECMAScriptFunctionObject&, Object* new_target);
+FunctionEnvironment* new_function_environment(ECMAScriptFunctionObject&, Object* new_target, DeclarativeEnvironmentBindings* cached_bindings = nullptr);
 PrivateEnvironment* new_private_environment(VM& vm, PrivateEnvironment* outer);
 Environment& get_this_environment(VM&);
 bool can_be_held_weakly(Value);

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -13,12 +13,26 @@
 
 namespace JS {
 
+DeclarativeEnvironmentBindings::~DeclarativeEnvironmentBindings() = default;
+
+JS::NonnullGCPtr<DeclarativeEnvironmentBindings> DeclarativeEnvironmentBindings::make_unshared_copy()
+{
+    auto copy = heap().allocate_without_realm<DeclarativeEnvironmentBindings>();
+    copy->m_shared = false;
+    copy->m_bindings = m_bindings;
+    return *copy;
+}
+
 DeclarativeEnvironment* DeclarativeEnvironment::create_for_per_iteration_bindings(Badge<ForStatement>, DeclarativeEnvironment& other, size_t bindings_size)
 {
-    auto bindings = other.m_bindings.span().slice(0, bindings_size);
     auto* parent_environment = other.outer_environment();
 
-    return parent_environment->heap().allocate_without_realm<DeclarativeEnvironment>(parent_environment, bindings);
+    auto environment = parent_environment->heap().allocate_without_realm<DeclarativeEnvironment>(parent_environment);
+    auto bindings = other.m_bindings->bindings().span().slice(0, bindings_size);
+    auto values = other.m_values.span().slice(0, bindings_size);
+    environment->m_bindings->bindings().append(bindings.data(), bindings.size());
+    environment->m_values.append(values.data(), values.size());
+    return environment;
 }
 
 DeclarativeEnvironment::DeclarativeEnvironment()
@@ -26,22 +40,35 @@ DeclarativeEnvironment::DeclarativeEnvironment()
 {
 }
 
-DeclarativeEnvironment::DeclarativeEnvironment(Environment* parent_environment)
+DeclarativeEnvironment::DeclarativeEnvironment(JS::GCPtr<Environment> parent_environment, JS::GCPtr<DeclarativeEnvironmentBindings> shared_bindings)
     : Environment(parent_environment)
+    , m_bindings(shared_bindings)
 {
 }
 
-DeclarativeEnvironment::DeclarativeEnvironment(Environment* parent_environment, Span<Binding const> bindings)
-    : Environment(parent_environment)
-    , m_bindings(bindings)
+void DeclarativeEnvironment::unshare_bindings_if_needed()
 {
+    if (!m_bindings->is_shared())
+        return;
+    m_bindings = m_bindings->make_unshared_copy();
+}
+
+void DeclarativeEnvironment::initialize_without_realm()
+{
+    Base::initialize_without_realm();
+    if (!m_bindings)
+        m_bindings = heap().allocate_without_realm<DeclarativeEnvironmentBindings>();
+    m_values.resize(m_bindings->bindings().size());
 }
 
 void DeclarativeEnvironment::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    for (auto& binding : m_bindings)
-        visitor.visit(binding.value);
+    visitor.visit(m_bindings);
+    for (auto& value : m_values) {
+        if (value.has_value())
+            visitor.visit(*value);
+    }
 }
 
 // 9.1.1.1.1 HasBinding ( N ), https://tc39.es/ecma262/#sec-declarative-environment-records-hasbinding-n
@@ -58,18 +85,19 @@ ThrowCompletionOr<bool> DeclarativeEnvironment::has_binding(FlyString const& nam
 // 9.1.1.1.2 CreateMutableBinding ( N, D ), https://tc39.es/ecma262/#sec-declarative-environment-records-createmutablebinding-n-d
 ThrowCompletionOr<void> DeclarativeEnvironment::create_mutable_binding(VM&, FlyString const& name, bool can_be_deleted)
 {
+    unshare_bindings_if_needed();
+
     // 1. Assert: envRec does not already have a binding for N.
     // NOTE: We skip this to avoid O(n) traversal of m_bindings.
 
     // 2. Create a mutable binding in envRec for N and record that it is uninitialized. If D is true, record that the newly created binding may be deleted by a subsequent DeleteBinding call.
-    m_bindings.append(Binding {
+    m_bindings->bindings().append(Binding {
         .name = name,
-        .value = {},
         .strict = false,
         .mutable_ = true,
         .can_be_deleted = can_be_deleted,
-        .initialized = false,
     });
+    m_values.append({});
 
     // 3. Return unused.
     return {};
@@ -78,18 +106,19 @@ ThrowCompletionOr<void> DeclarativeEnvironment::create_mutable_binding(VM&, FlyS
 // 9.1.1.1.3 CreateImmutableBinding ( N, S ), https://tc39.es/ecma262/#sec-declarative-environment-records-createimmutablebinding-n-s
 ThrowCompletionOr<void> DeclarativeEnvironment::create_immutable_binding(VM&, FlyString const& name, bool strict)
 {
+    unshare_bindings_if_needed();
+
     // 1. Assert: envRec does not already have a binding for N.
     // NOTE: We skip this to avoid O(n) traversal of m_bindings.
 
     // 2. Create an immutable binding in envRec for N and record that it is uninitialized. If S is true, record that the newly created binding is a strict binding.
-    m_bindings.append(Binding {
+    m_bindings->bindings().append(Binding {
         .name = name,
-        .value = {},
         .strict = strict,
         .mutable_ = false,
         .can_be_deleted = false,
-        .initialized = false,
     });
+    m_values.append({});
 
     // 3. Return unused.
     return {};
@@ -101,19 +130,20 @@ ThrowCompletionOr<void> DeclarativeEnvironment::initialize_binding(VM& vm, FlySt
     auto binding_and_index = find_binding_and_index(name);
     VERIFY(binding_and_index.has_value());
 
-    return initialize_binding_direct(vm, binding_and_index->binding(), value);
+    return initialize_binding_direct(vm, binding_and_index->index().value(), value);
 }
 
-ThrowCompletionOr<void> DeclarativeEnvironment::initialize_binding_direct(VM&, Binding& binding, Value value)
+ThrowCompletionOr<void> DeclarativeEnvironment::initialize_binding_direct(VM&, size_t index, Value value)
 {
     // 1. Assert: envRec must have an uninitialized binding for N.
-    VERIFY(binding.initialized == false);
+    VERIFY(m_values[index].has_value() == false);
+
+    VERIFY(!value.is_empty());
 
     // 2. Set the bound value for N in envRec to V.
-    binding.value = value;
-
     // 3. Record that the binding for N in envRec has been initialized.
-    binding.initialized = true;
+    // NOTE: We use the empty Optional<Value> to indicate uninitialized bindings.
+    m_values[index] = value;
 
     // 4. Return unused.
     return {};
@@ -139,8 +169,18 @@ ThrowCompletionOr<void> DeclarativeEnvironment::set_mutable_binding(VM& vm, FlyS
         return {};
     }
 
+    // AD-HOC: This is here to deal with the awkward fake bindings from ModuleEnvironment.
+    if (!binding_and_index->index().has_value()) {
+        auto const& binding = binding_and_index->binding();
+        if (binding.strict)
+            strict = true;
+        if (strict)
+            return vm.throw_completion<TypeError>(ErrorType::InvalidAssignToConst);
+        return {};
+    }
+
     // 2-5. (extracted into a non-standard function below)
-    TRY(set_mutable_binding_direct(vm, binding_and_index->binding(), value, strict));
+    TRY(set_mutable_binding_direct(vm, binding_and_index->index().value(), value, strict));
 
     // 6. Return unused.
     return {};
@@ -148,19 +188,16 @@ ThrowCompletionOr<void> DeclarativeEnvironment::set_mutable_binding(VM& vm, FlyS
 
 ThrowCompletionOr<void> DeclarativeEnvironment::set_mutable_binding_direct(VM& vm, size_t index, Value value, bool strict)
 {
-    return set_mutable_binding_direct(vm, m_bindings[index], value, strict);
-}
-
-ThrowCompletionOr<void> DeclarativeEnvironment::set_mutable_binding_direct(VM& vm, Binding& binding, Value value, bool strict)
-{
+    auto const& binding = m_bindings->bindings()[index];
     if (binding.strict)
         strict = true;
 
-    if (!binding.initialized)
+    if (!m_values[index].has_value())
         return vm.throw_completion<ReferenceError>(ErrorType::BindingNotInitialized, binding.name);
 
     if (binding.mutable_) {
-        binding.value = value;
+        VERIFY(!value.is_empty());
+        m_values[index] = value;
     } else {
         if (strict)
             return vm.throw_completion<TypeError>(ErrorType::InvalidAssignToConst);
@@ -177,27 +214,26 @@ ThrowCompletionOr<Value> DeclarativeEnvironment::get_binding_value(VM& vm, FlySt
     VERIFY(binding_and_index.has_value());
 
     // 2-3. (extracted into a non-standard function below)
-    return get_binding_value_direct(vm, binding_and_index->binding(), strict);
+    return get_binding_value_direct(vm, binding_and_index->index().value(), strict);
 }
 
-ThrowCompletionOr<Value> DeclarativeEnvironment::get_binding_value_direct(VM& vm, size_t index, bool strict)
+ThrowCompletionOr<Value> DeclarativeEnvironment::get_binding_value_direct(VM&, size_t index, bool)
 {
-    return get_binding_value_direct(vm, m_bindings[index], strict);
-}
+    auto const& binding = m_bindings->bindings()[index];
 
-ThrowCompletionOr<Value> DeclarativeEnvironment::get_binding_value_direct(VM&, Binding& binding, bool)
-{
     // 2. If the binding for N in envRec is an uninitialized binding, throw a ReferenceError exception.
-    if (!binding.initialized)
+    if (!m_values[index].has_value())
         return vm().throw_completion<ReferenceError>(ErrorType::BindingNotInitialized, binding.name);
 
     // 3. Return the value currently bound to N in envRec.
-    return binding.value;
+    return *m_values[index];
 }
 
 // 9.1.1.1.7 DeleteBinding ( N ), https://tc39.es/ecma262/#sec-declarative-environment-records-deletebinding-n
 ThrowCompletionOr<bool> DeclarativeEnvironment::delete_binding(VM&, FlyString const& name)
 {
+    unshare_bindings_if_needed();
+
     // 1. Assert: envRec has a binding for the name that is the value of N.
     auto binding_and_index = find_binding_and_index(name);
     VERIFY(binding_and_index.has_value());
@@ -219,7 +255,7 @@ ThrowCompletionOr<void> DeclarativeEnvironment::initialize_or_set_mutable_bindin
     auto binding_and_index = find_binding_and_index(name);
     VERIFY(binding_and_index.has_value());
 
-    if (!binding_and_index->binding().initialized)
+    if (!m_values[binding_and_index->index().value()].has_value())
         TRY(initialize_binding(vm, name, value));
     else
         TRY(set_mutable_binding(vm, name, value, false));
@@ -229,6 +265,18 @@ ThrowCompletionOr<void> DeclarativeEnvironment::initialize_or_set_mutable_bindin
 void DeclarativeEnvironment::initialize_or_set_mutable_binding(Badge<ScopeNode>, VM& vm, FlyString const& name, Value value)
 {
     MUST(initialize_or_set_mutable_binding(vm, name, value));
+}
+
+Optional<DeclarativeEnvironment::BindingAndIndex> DeclarativeEnvironment::find_binding_and_index(FlyString const& name) const
+{
+    auto it = m_bindings->bindings().find_if([&](auto const& binding) {
+        return binding.name == name;
+    });
+
+    if (it == m_bindings->bindings().end())
+        return {};
+
+    return BindingAndIndex { const_cast<Binding*>(&(*it)), it.index() };
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -132,6 +132,8 @@ private:
     bool m_is_arrow_function : 1 { false };
     bool m_has_simple_parameter_list : 1 { false };
     FunctionKind m_kind : 3 { FunctionKind::Normal };
+
+    JS::GCPtr<DeclarativeEnvironmentBindings> m_cached_var_bindings;
 };
 
 template<>

--- a/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.cpp
@@ -11,8 +11,8 @@
 
 namespace JS {
 
-FunctionEnvironment::FunctionEnvironment(Environment* parent_environment)
-    : DeclarativeEnvironment(parent_environment)
+FunctionEnvironment::FunctionEnvironment(JS::GCPtr<Environment> parent_environment, JS::GCPtr<DeclarativeEnvironmentBindings> shared_bindings)
+    : DeclarativeEnvironment(parent_environment, shared_bindings)
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.h
@@ -46,7 +46,7 @@ public:
     ThrowCompletionOr<Value> bind_this_value(VM&, Value);
 
 private:
-    explicit FunctionEnvironment(Environment* parent_environment);
+    FunctionEnvironment(JS::GCPtr<Environment> parent_environment, JS::GCPtr<DeclarativeEnvironmentBindings> shared_bindings);
 
     virtual bool is_function_environment() const override { return true; }
     virtual void visit_edges(Visitor&) override;

--- a/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.cpp
@@ -119,7 +119,6 @@ Optional<ModuleEnvironment::BindingAndIndex> ModuleEnvironment::find_binding_and
         Binding copy_binding = result->binding();
         copy_binding.mutable_ = false;
         copy_binding.can_be_deleted = false;
-        copy_binding.initialized = true;
         return BindingAndIndex { copy_binding };
     }
 

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1753,9 +1753,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 auto const& variable = interpreter->realm().global_object();
                 list_all_properties(variable.shape(), variable_name);
 
-                for (auto const& name : global_environment.declarative_record().bindings()) {
-                    if (name.starts_with(variable_name)) {
-                        results.empend(name);
+                for (auto const& binding : global_environment.declarative_record().bindings()->bindings()) {
+                    if (binding.name.starts_with(variable_name)) {
+                        results.empend(binding.name);
                         results.last().invariant_offset = variable_name.length();
                     }
                 }


### PR DESCRIPTION
One of the hottest functions in LibJS when burning CPU on real websites        
has been `ECMAScriptFunctionObject::function_declaration_instantiation()`.        
It implements the FunctionDeclarationInstantiation AO from the spec by        
setting up variable and lexical bindings, creating the `arguments`        
object, etc. This AO is invoked on every function call.        
        
A large majority of functions don't do anything to mutate their set of        
bindings after setup (other than assigning to bindings, of course).        
        
This patch adds an optimization that allows us to cache the bindings we        
set up in `function_declaration_instantiation()` after the first call,        
if the function fulfills a set of criteria.        
        
Sharing is achieved by splitting out `DeclarativeEnvironment`'s bindings        
table to a `DeclarativeEnvironmentBindings` object that holds metadata.        
The binding *values* remain on the environment, but now as a simple        
`Vector<Optional<Value>>`.
        
In this first cut of the optimization, we only do this for a very narrow        
set of functions. In the future, it can be loosened to support more        
cases, but this already improves some of the Kraken subtests by ~10%.   