### PR TITLE
LibVideo: VP9 Decoder Refactor Part 1: Parameterize binary tree parsing

### DIFF
--- a/Userland/Libraries/LibVideo/DecoderError.h
+++ b/Userland/Libraries/LibVideo/DecoderError.h
@@ -22,6 +22,7 @@ using DecoderErrorOr = ErrorOr<T, DecoderError>;
 enum class DecoderErrorCategory : u32 {
     Unknown,
     IO,
+    NeedsMoreInput,
     EndOfStream,
     Memory,
     // The input is corrupted.

--- a/Userland/Libraries/LibVideo/MatroskaDemuxer.cpp
+++ b/Userland/Libraries/LibVideo/MatroskaDemuxer.cpp
@@ -18,7 +18,7 @@ DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> MatroskaDemuxer::from_file(String
     return make<MatroskaDemuxer>(document);
 }
 
-DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> MatroskaDemuxer::from_data(Span<u8 const> data)
+DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> MatroskaDemuxer::from_data(ReadonlyBytes data)
 {
     // FIXME: MatroskaReader should return errors.
     auto nullable_document = MatroskaReader::parse_matroska_from_data(data.data(), data.size());

--- a/Userland/Libraries/LibVideo/MatroskaDemuxer.h
+++ b/Userland/Libraries/LibVideo/MatroskaDemuxer.h
@@ -18,7 +18,7 @@ public:
     // FIXME: We should instead accept some abstract data streaming type so that the demuxer
     //        can work with non-contiguous data.
     static DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> from_file(StringView filename);
-    static DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> from_data(Span<u8 const> data);
+    static DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> from_data(ReadonlyBytes data);
 
     MatroskaDemuxer(NonnullOwnPtr<MatroskaDocument>& document)
         : m_document(move(document))

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -124,7 +124,8 @@ private:
     bool prepare_next_frame();
     void update_presented_frame();
 
-    // Runs off the main thread
+    // May run off the main thread
+    void post_decoder_error(DecoderError error);
     bool decode_and_queue_one_sample();
     void on_decode_timer();
 

--- a/Userland/Libraries/LibVideo/VP9/Context.h
+++ b/Userland/Libraries/LibVideo/VP9/Context.h
@@ -30,4 +30,12 @@ struct Pair {
 typedef Pair<ReferenceFrameType> ReferenceFramePair;
 typedef Pair<MotionVector> MotionVectorPair;
 
+struct TokensContext {
+    TXSize m_tx_size;
+    bool m_is_uv_plane;
+    bool m_is_inter;
+    u8 m_band;
+    u8 m_context_index;
+};
+
 }

--- a/Userland/Libraries/LibVideo/VP9/Context.h
+++ b/Userland/Libraries/LibVideo/VP9/Context.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Hunter Salyer <thefalsehonesty@gmail.com>
+ * Copyright (c) 2022, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Enums.h"
+#include "MotionVector.h"
+
+namespace Video::VP9 {
+
+template<typename T>
+struct Pair {
+    T a;
+    T b;
+
+    T& operator[](size_t index)
+    {
+        if (index == 0)
+            return a;
+        if (index == 1)
+            return b;
+        VERIFY_NOT_REACHED();
+    }
+};
+
+typedef Pair<ReferenceFrameType> ReferenceFramePair;
+typedef Pair<MotionVector> MotionVectorPair;
+
+}

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -19,7 +19,7 @@ Decoder::Decoder()
 {
 }
 
-DecoderErrorOr<void> Decoder::receive_sample(Span<u8 const> chunk_data)
+DecoderErrorOr<void> Decoder::receive_sample(ReadonlyBytes chunk_data)
 {
     auto superframe_sizes = m_parser->parse_superframe_sizes(chunk_data);
 
@@ -52,7 +52,7 @@ inline size_t index_from_row_and_column(u32 row, u32 column, u32 stride)
     return row * stride + column;
 }
 
-DecoderErrorOr<void> Decoder::decode_frame(Span<u8 const> frame_data)
+DecoderErrorOr<void> Decoder::decode_frame(ReadonlyBytes frame_data)
 {
     // 1. The syntax elements for the coded frame are extracted as specified in sections 6 and 7. The syntax
     // tables include function calls indicating when the block decode processes should be triggered.

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -28,7 +28,7 @@ public:
     Decoder();
     ~Decoder() override { }
     /* (8.1) General */
-    DecoderErrorOr<void> receive_sample(Span<u8 const>) override;
+    DecoderErrorOr<void> receive_sample(ReadonlyBytes) override;
     void dump_frame_info();
 
     DecoderErrorOr<NonnullOwnPtr<VideoFrame>> get_decoded_frame() override;
@@ -36,7 +36,7 @@ public:
 private:
     typedef i32 Intermediate;
 
-    DecoderErrorOr<void> decode_frame(Span<u8 const>);
+    DecoderErrorOr<void> decode_frame(ReadonlyBytes);
     DecoderErrorOr<void> create_video_frame();
 
     DecoderErrorOr<void> allocate_buffers();

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -10,6 +10,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Error.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/Queue.h>
 #include <AK/Span.h>
 #include <LibVideo/Color/CodingIndependentCodePoints.h>
 #include <LibVideo/DecoderError.h>
@@ -36,6 +37,7 @@ private:
     typedef i32 Intermediate;
 
     DecoderErrorOr<void> decode_frame(Span<u8 const>);
+    DecoderErrorOr<void> create_video_frame();
 
     DecoderErrorOr<void> allocate_buffers();
     Vector<Intermediate>& get_temp_buffer(u8 plane);
@@ -167,6 +169,8 @@ private:
         Vector<Intermediate> intermediate[3];
         Vector<u16> output[3];
     } m_buffers;
+
+    Queue<NonnullOwnPtr<VideoFrame>, 1> m_video_frame_queue;
 };
 
 }

--- a/Userland/Libraries/LibVideo/VP9/Enums.h
+++ b/Userland/Libraries/LibVideo/VP9/Enums.h
@@ -89,7 +89,7 @@ enum Partition : u8 {
     PartitionSplit = 3,
 };
 
-enum IntraMode : u8 {
+enum class PredictionMode : u8 {
     DcPred = 0,
     VPred = 1,
     HPred = 2,
@@ -100,9 +100,6 @@ enum IntraMode : u8 {
     D207Pred = 7,
     D63Pred = 8,
     TmPred = 9,
-};
-
-enum InterMode : u8 {
     NearestMv = 10,
     NearMv = 11,
     ZeroMv = 12,

--- a/Userland/Libraries/LibVideo/VP9/Enums.h
+++ b/Userland/Libraries/LibVideo/VP9/Enums.h
@@ -35,7 +35,7 @@ enum InterpolationFilter : u8 {
     Switchable = 4
 };
 
-enum ReferenceFrame : u8 {
+enum ReferenceFrameType : u8 {
     // 0 is both INTRA_FRAME and NONE because the value's meaning changes depending on which index they're in on the ref_frame array
     None = 0,
     IntraFrame = 0,

--- a/Userland/Libraries/LibVideo/VP9/LookupTables.h
+++ b/Userland/Libraries/LibVideo/VP9/LookupTables.h
@@ -107,15 +107,15 @@ static constexpr int partition_tree[6] = {
 static constexpr int cols_partition_tree[2] = { -PartitionHorizontal, -PartitionSplit };
 static constexpr int rows_partition_tree[2] = { -PartitionVertical, -PartitionSplit };
 static constexpr int intra_mode_tree[18] = {
-    -DcPred, 2,
-    -TmPred, 4,
-    -VPred, 6,
+    -to_underlying(PredictionMode::DcPred), 2,
+    -to_underlying(PredictionMode::TmPred), 4,
+    -to_underlying(PredictionMode::VPred), 6,
     8, 12,
-    -HPred, 10,
-    -D135Pred, -D117Pred,
-    -D45Pred, 14,
-    -D63Pred, 16,
-    -D153Pred, -D207Pred
+    -to_underlying(PredictionMode::HPred), 10,
+    -to_underlying(PredictionMode::D135Pred), -to_underlying(PredictionMode::D117Pred),
+    -to_underlying(PredictionMode::D45Pred), 14,
+    -to_underlying(PredictionMode::D63Pred), 16,
+    -to_underlying(PredictionMode::D153Pred), -to_underlying(PredictionMode::D207Pred)
 };
 static constexpr int segment_tree[14] = {
     2, 4, 6, 8, 10, 12,
@@ -133,9 +133,9 @@ static constexpr int tx_size_16_tree[4] = {
 };
 static constexpr int tx_size_8_tree[2] = { -TX_4x4, -TX_8x8 };
 static constexpr int inter_mode_tree[6] = {
-    -(ZeroMv - NearestMv), 2,
-    -(NearestMv - NearestMv), 4,
-    -(NearMv - NearestMv), -(NewMv - NearestMv)
+    -to_underlying(PredictionMode::ZeroMv), 2,
+    -to_underlying(PredictionMode::NearestMv), 4,
+    -to_underlying(PredictionMode::NearMv), -to_underlying(PredictionMode::NewMv)
 };
 static constexpr int interp_filter_tree[4] = {
     -EightTap, 2,

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1200,7 +1200,7 @@ DecoderErrorOr<void> Parser::intra_block_mode_info()
         }
         m_y_mode = sub_intra_mode;
     }
-    m_uv_mode = TRY_READ(m_tree_parser->parse_tree<PredictionMode>(SyntaxElementType::UVMode));
+    m_uv_mode = TRY_READ(TreeParser::parse_uv_mode(*m_bit_stream, *m_probability_tables, *m_syntax_element_counter, m_y_mode));
     return {};
 }
 

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -916,7 +916,7 @@ DecoderErrorOr<void> Parser::decode_partition(u32 row, u32 col, BlockSubsize blo
     m_has_cols = (col + half_block_8x8) < m_mi_cols;
     m_row = row;
     m_col = col;
-    auto partition = TRY_READ(m_tree_parser->parse_tree(SyntaxElementType::Partition));
+    auto partition = TRY_READ(TreeParser::parse_partition(*m_bit_stream, *m_probability_tables, *m_syntax_element_counter, m_has_rows, m_has_cols, m_block_subsize, m_num_8x8, m_above_partition_context, m_left_partition_context, row, col, m_frame_is_intra));
 
     auto subsize = subsize_lookup[partition][block_subsize];
     if (subsize < Block_8x8 || partition == PartitionNone) {

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1072,10 +1072,13 @@ DecoderErrorOr<void> Parser::intra_segment_id()
 
 DecoderErrorOr<void> Parser::read_skip()
 {
-    if (seg_feature_active(SEG_LVL_SKIP))
+    if (seg_feature_active(SEG_LVL_SKIP)) {
         m_skip = true;
-    else
-        m_skip = TRY_READ(m_tree_parser->parse_tree<bool>(SyntaxElementType::Skip));
+    } else {
+        Optional<bool> above_skip = m_available_u ? m_skips[get_image_index(m_mi_row - 1, m_mi_col)] : Optional<bool>();
+        Optional<bool> left_skip = m_available_l ? m_skips[get_image_index(m_mi_row, m_mi_col - 1)] : Optional<bool>();
+        m_skip = TRY_READ(TreeParser::parse_skip(*m_bit_stream, *m_probability_tables, *m_syntax_element_counter, above_skip, left_skip));
+    }
     return {};
 }
 

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1057,7 +1057,7 @@ DecoderErrorOr<void> Parser::intra_frame_mode_info()
         }
         m_y_mode = m_default_intra_mode;
     }
-    m_uv_mode = TRY_READ(m_tree_parser->parse_tree<PredictionMode>(SyntaxElementType::DefaultUVMode));
+    m_uv_mode = TRY_READ(TreeParser::parse_default_uv_mode(*m_bit_stream, *m_probability_tables, m_y_mode));
     return {};
 }
 

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1279,10 +1279,17 @@ DecoderErrorOr<void> Parser::read_ref_frames()
         return {};
     }
     ReferenceMode comp_mode;
-    if (m_reference_mode == ReferenceModeSelect)
-        comp_mode = TRY_READ(m_tree_parser->parse_tree<ReferenceMode>(SyntaxElementType::CompMode));
-    else
+    if (m_reference_mode == ReferenceModeSelect) {
+        Optional<bool> above_single = m_available_u ? m_above_single : Optional<bool>();
+        Optional<bool> left_single = m_available_l ? m_left_single : Optional<bool>();
+        Optional<bool> above_intra = m_available_u ? m_above_intra : Optional<bool>();
+        Optional<bool> left_intra = m_available_l ? m_left_intra : Optional<bool>();
+        Optional<ReferenceFrameType> above_ref_frame_0 = m_available_u ? m_above_ref_frame[0] : Optional<ReferenceFrameType>();
+        Optional<ReferenceFrameType> left_ref_frame_0 = m_available_l ? m_left_ref_frame[0] : Optional<ReferenceFrameType>();
+        comp_mode = TRY_READ(TreeParser::parse_comp_mode(*m_bit_stream, *m_probability_tables, *m_syntax_element_counter, m_comp_fixed_ref, above_single, left_single, above_intra, left_intra, above_ref_frame_0, left_ref_frame_0));
+    } else {
         comp_mode = m_reference_mode;
+    }
     if (comp_mode == CompoundReference) {
         auto idx = m_ref_frame_sign_bias[m_comp_fixed_ref];
         auto comp_ref = TRY_READ(m_tree_parser->parse_tree(SyntaxElementType::CompRef));

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1182,7 +1182,7 @@ DecoderErrorOr<void> Parser::intra_block_mode_info()
     m_ref_frame[0] = IntraFrame;
     m_ref_frame[1] = None;
     if (m_mi_size >= Block_8x8) {
-        m_y_mode = TRY_READ(m_tree_parser->parse_tree<PredictionMode>(SyntaxElementType::IntraMode));
+        m_y_mode = TRY_READ(TreeParser::parse_intra_mode(*m_bit_stream, *m_probability_tables, *m_syntax_element_counter, m_mi_size));
         for (auto& block_sub_mode : m_block_sub_modes)
             block_sub_mode = m_y_mode;
     } else {
@@ -1191,7 +1191,7 @@ DecoderErrorOr<void> Parser::intra_block_mode_info()
         PredictionMode sub_intra_mode;
         for (auto idy = 0; idy < 2; idy += m_num_4x4_h) {
             for (auto idx = 0; idx < 2; idx += m_num_4x4_w) {
-                sub_intra_mode = TRY_READ(m_tree_parser->parse_tree<PredictionMode>(SyntaxElementType::SubIntraMode));
+                sub_intra_mode = TRY_READ(TreeParser::parse_sub_intra_mode(*m_bit_stream, *m_probability_tables, *m_syntax_element_counter));
                 for (auto y = 0; y < m_num_4x4_h; y++) {
                     for (auto x = 0; x < m_num_4x4_w; x++)
                         m_block_sub_modes[(idy + y) * 2 + idx + x] = sub_intra_mode;

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -28,7 +28,7 @@ Parser::~Parser()
 {
 }
 
-Vector<size_t> Parser::parse_superframe_sizes(Span<const u8> frame_data)
+Vector<size_t> Parser::parse_superframe_sizes(ReadonlyBytes frame_data)
 {
     if (frame_data.size() < 1)
         return {};
@@ -76,7 +76,7 @@ Vector<size_t> Parser::parse_superframe_sizes(Span<const u8> frame_data)
 }
 
 /* (6.1) */
-DecoderErrorOr<void> Parser::parse_frame(Span<const u8> frame_data)
+DecoderErrorOr<void> Parser::parse_frame(ReadonlyBytes frame_data)
 {
     m_bit_stream = make<BitStream>(frame_data.data(), frame_data.size());
     m_syntax_element_counter = make<SyntaxElementCounter>();

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1217,7 +1217,7 @@ DecoderErrorOr<void> Parser::inter_block_mode_info()
     if (seg_feature_active(SEG_LVL_SKIP)) {
         m_y_mode = PredictionMode::ZeroMv;
     } else if (m_mi_size >= Block_8x8) {
-        m_y_mode = TRY_READ(m_tree_parser->parse_tree<PredictionMode>(SyntaxElementType::InterMode));
+        m_y_mode = TRY_READ(TreeParser::parse_inter_mode(*m_bit_stream, *m_probability_tables, *m_syntax_element_counter, m_mode_context[m_ref_frame[0]]));
     }
     if (m_interpolation_filter == Switchable)
         m_interp_filter = TRY_READ(m_tree_parser->parse_tree<InterpolationFilter>(SyntaxElementType::InterpFilter));
@@ -1228,7 +1228,7 @@ DecoderErrorOr<void> Parser::inter_block_mode_info()
         m_num_4x4_h = num_4x4_blocks_high_lookup[m_mi_size];
         for (auto idy = 0; idy < 2; idy += m_num_4x4_h) {
             for (auto idx = 0; idx < 2; idx += m_num_4x4_w) {
-                m_y_mode = TRY_READ(m_tree_parser->parse_tree<PredictionMode>(SyntaxElementType::InterMode));
+                m_y_mode = TRY_READ(TreeParser::parse_inter_mode(*m_bit_stream, *m_probability_tables, *m_syntax_element_counter, m_mode_context[m_ref_frame[0]]));
                 if (m_y_mode == PredictionMode::NearestMv || m_y_mode == PredictionMode::NearMv) {
                     for (auto j = 0; j < 1 + is_compound; j++)
                         append_sub8x8_mvs(idy * 2 + idx, j);

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -905,7 +905,7 @@ void Parser::clear_left_context()
     clear_context(m_left_partition_context, m_sb64_rows * 8);
 }
 
-DecoderErrorOr<void> Parser::decode_partition(u32 row, u32 col, u8 block_subsize)
+DecoderErrorOr<void> Parser::decode_partition(u32 row, u32 col, BlockSubsize block_subsize)
 {
     if (row >= m_mi_rows || col >= m_mi_cols)
         return {};

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1252,7 +1252,7 @@ DecoderErrorOr<void> Parser::inter_block_mode_info()
 DecoderErrorOr<void> Parser::read_ref_frames()
 {
     if (seg_feature_active(SEG_LVL_REF_FRAME)) {
-        m_ref_frame[0] = static_cast<ReferenceFrame>(m_feature_data[m_segment_id][SEG_LVL_REF_FRAME]);
+        m_ref_frame[0] = static_cast<ReferenceFrameType>(m_feature_data[m_segment_id][SEG_LVL_REF_FRAME]);
         m_ref_frame[1] = None;
         return {};
     }
@@ -1547,7 +1547,7 @@ void Parser::get_block_mv(u32 candidate_row, u32 candidate_column, u8 ref_list, 
     }
 }
 
-void Parser::if_same_ref_frame_add_mv(u32 candidate_row, u32 candidate_column, ReferenceFrame ref_frame, bool use_prev)
+void Parser::if_same_ref_frame_add_mv(u32 candidate_row, u32 candidate_column, ReferenceFrameType ref_frame, bool use_prev)
 {
     for (auto ref_list = 0u; ref_list < 2; ref_list++) {
         get_block_mv(candidate_row, candidate_column, ref_list, use_prev);
@@ -1558,23 +1558,23 @@ void Parser::if_same_ref_frame_add_mv(u32 candidate_row, u32 candidate_column, R
     }
 }
 
-void Parser::scale_mv(u8 ref_list, ReferenceFrame ref_frame)
+void Parser::scale_mv(u8 ref_list, ReferenceFrameType ref_frame)
 {
     auto candidate_frame = m_candidate_frame[ref_list];
     if (m_ref_frame_sign_bias[candidate_frame] != m_ref_frame_sign_bias[ref_frame])
         m_candidate_mv[ref_list] *= -1;
 }
 
-void Parser::if_diff_ref_frame_add_mv(u32 candidate_row, u32 candidate_column, ReferenceFrame ref_frame, bool use_prev)
+void Parser::if_diff_ref_frame_add_mv(u32 candidate_row, u32 candidate_column, ReferenceFrameType ref_frame, bool use_prev)
 {
     for (auto ref_list = 0u; ref_list < 2; ref_list++)
         get_block_mv(candidate_row, candidate_column, ref_list, use_prev);
     auto mvs_are_same = m_candidate_mv[0] == m_candidate_mv[1];
-    if (m_candidate_frame[0] > ReferenceFrame::IntraFrame && m_candidate_frame[0] != ref_frame) {
+    if (m_candidate_frame[0] > ReferenceFrameType::IntraFrame && m_candidate_frame[0] != ref_frame) {
         scale_mv(0, ref_frame);
         add_mv_ref_list(0);
     }
-    if (m_candidate_frame[1] > ReferenceFrame::IntraFrame && m_candidate_frame[1] != ref_frame && !mvs_are_same) {
+    if (m_candidate_frame[1] > ReferenceFrameType::IntraFrame && m_candidate_frame[1] != ref_frame && !mvs_are_same) {
         scale_mv(1, ref_frame);
         add_mv_ref_list(1);
     }
@@ -1604,7 +1604,7 @@ void Parser::clamp_mv_ref(u8 i)
 }
 
 // 6.5.1 Find MV refs syntax
-void Parser::find_mv_refs(ReferenceFrame reference_frame, i32 block)
+void Parser::find_mv_refs(ReferenceFrameType reference_frame, i32 block)
 {
     m_ref_mv_count = 0;
     bool different_ref_found = false;

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1064,7 +1064,7 @@ DecoderErrorOr<void> Parser::intra_frame_mode_info()
 DecoderErrorOr<void> Parser::intra_segment_id()
 {
     if (m_segmentation_enabled && m_segmentation_update_map)
-        m_segment_id = TRY_READ(m_tree_parser->parse_tree<u8>(SyntaxElementType::SegmentID));
+        m_segment_id = TRY_READ(TreeParser::parse_segment_id(*m_bit_stream, m_segmentation_tree_probs));
     else
         m_segment_id = 0;
     return {};
@@ -1128,15 +1128,15 @@ DecoderErrorOr<void> Parser::inter_segment_id()
         return {};
     }
     if (!m_segmentation_temporal_update) {
-        m_segment_id = TRY_READ(m_tree_parser->parse_tree<u8>(SyntaxElementType::SegmentID));
+        m_segment_id = TRY_READ(TreeParser::parse_segment_id(*m_bit_stream, m_segmentation_tree_probs));
         return {};
     }
 
-    auto seg_id_predicted = TRY_READ(m_tree_parser->parse_tree<bool>(SyntaxElementType::SegIDPredicted));
+    auto seg_id_predicted = TRY_READ(TreeParser::parse_segment_id_predicted(*m_bit_stream, m_segmentation_pred_prob, m_left_seg_pred_context[m_mi_row], m_above_seg_pred_context[m_mi_col]));
     if (seg_id_predicted)
         m_segment_id = predicted_segment_id;
     else
-        m_segment_id = TRY_READ(m_tree_parser->parse_tree<u8>(SyntaxElementType::SegmentID));
+        m_segment_id = TRY_READ(TreeParser::parse_segment_id(*m_bit_stream, m_segmentation_tree_probs));
 
     for (size_t i = 0; i < num_8x8_blocks_wide_lookup[m_mi_size]; i++) {
         auto index = m_mi_col + i;

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1178,10 +1178,13 @@ u8 Parser::get_segment_id()
 
 DecoderErrorOr<void> Parser::read_is_inter()
 {
-    if (seg_feature_active(SEG_LVL_REF_FRAME))
+    if (seg_feature_active(SEG_LVL_REF_FRAME)) {
         m_is_inter = m_feature_data[m_segment_id][SEG_LVL_REF_FRAME] != IntraFrame;
-    else
-        m_is_inter = TRY_READ(m_tree_parser->parse_tree<bool>(SyntaxElementType::IsInter));
+    } else {
+        Optional<bool> above_intra = m_available_u ? m_above_intra : Optional<bool>();
+        Optional<bool> left_intra = m_available_l ? m_left_intra : Optional<bool>();
+        m_is_inter = TRY_READ(TreeParser::parse_is_inter(*m_bit_stream, *m_probability_tables, *m_syntax_element_counter, above_intra, left_intra));
+    }
     return {};
 }
 

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1219,10 +1219,15 @@ DecoderErrorOr<void> Parser::inter_block_mode_info()
     } else if (m_mi_size >= Block_8x8) {
         m_y_mode = TRY_READ(TreeParser::parse_inter_mode(*m_bit_stream, *m_probability_tables, *m_syntax_element_counter, m_mode_context[m_ref_frame[0]]));
     }
-    if (m_interpolation_filter == Switchable)
-        m_interp_filter = TRY_READ(m_tree_parser->parse_tree<InterpolationFilter>(SyntaxElementType::InterpFilter));
-    else
+    if (m_interpolation_filter == Switchable) {
+        Optional<ReferenceFrameType> above_ref_frame = m_available_u ? m_ref_frames[get_image_index(m_mi_row - 1, m_mi_col)][0] : Optional<ReferenceFrameType>();
+        Optional<ReferenceFrameType> left_ref_frame = m_available_l ? m_ref_frames[get_image_index(m_mi_row, m_mi_col - 1)][0] : Optional<ReferenceFrameType>();
+        Optional<InterpolationFilter> above_interpolation_filter = m_available_u ? m_interp_filters[get_image_index(m_mi_row - 1, m_mi_col)] : Optional<InterpolationFilter>();
+        Optional<InterpolationFilter> left_interpolation_filter = m_available_l ? m_interp_filters[get_image_index(m_mi_row, m_mi_col - 1)] : Optional<InterpolationFilter>();
+        m_interp_filter = TRY_READ(TreeParser::parse_interpolation_filter(*m_bit_stream, *m_probability_tables, *m_syntax_element_counter, above_ref_frame, left_ref_frame, above_interpolation_filter, left_interpolation_filter));
+    } else {
         m_interp_filter = m_interpolation_filter;
+    }
     if (m_mi_size < Block_8x8) {
         m_num_4x4_w = num_4x4_blocks_wide_lookup[m_mi_size];
         m_num_4x4_h = num_4x4_blocks_high_lookup[m_mi_size];

--- a/Userland/Libraries/LibVideo/VP9/Parser.h
+++ b/Userland/Libraries/LibVideo/VP9/Parser.h
@@ -103,7 +103,7 @@ private:
     u32 get_tile_offset(u32 tile_num, u32 mis, u32 tile_size_log2);
     DecoderErrorOr<void> decode_tile();
     void clear_left_context();
-    DecoderErrorOr<void> decode_partition(u32 row, u32 col, u8 block_subsize);
+    DecoderErrorOr<void> decode_partition(u32 row, u32 col, BlockSubsize block_subsize);
     DecoderErrorOr<void> decode_block(u32 row, u32 col, BlockSubsize subsize);
     DecoderErrorOr<void> mode_info();
     DecoderErrorOr<void> intra_frame_mode_info();
@@ -227,7 +227,7 @@ private:
     bool m_has_rows { false };
     bool m_has_cols { false };
     TXSize m_max_tx_size { TX_4x4 };
-    u8 m_block_subsize { 0 };
+    BlockSubsize m_block_subsize { BlockSubsize::Block_4x4 };
     // The row to use for getting partition tree probability lookups.
     u32 m_row { 0 };
     // The column to use for getting partition tree probability lookups.

--- a/Userland/Libraries/LibVideo/VP9/Parser.h
+++ b/Userland/Libraries/LibVideo/VP9/Parser.h
@@ -33,13 +33,13 @@ class Parser {
 public:
     explicit Parser(Decoder&);
     ~Parser();
-    DecoderErrorOr<void> parse_frame(Span<const u8>);
+    DecoderErrorOr<void> parse_frame(ReadonlyBytes);
     void dump_info();
 
 private:
     /* Annex B: Superframes are a method of storing multiple coded frames into a single chunk
      * See also section 5.26. */
-    Vector<size_t> parse_superframe_sizes(Span<const u8>);
+    Vector<size_t> parse_superframe_sizes(ReadonlyBytes);
 
     DecoderErrorOr<FrameType> read_frame_type();
     DecoderErrorOr<ColorRange> read_color_range();

--- a/Userland/Libraries/LibVideo/VP9/Parser.h
+++ b/Userland/Libraries/LibVideo/VP9/Parser.h
@@ -301,7 +301,6 @@ private:
     OwnPtr<BitStream> m_bit_stream;
     OwnPtr<ProbabilityTables> m_probability_tables;
     OwnPtr<SyntaxElementCounter> m_syntax_element_counter;
-    NonnullOwnPtr<TreeParser> m_tree_parser;
     Decoder& m_decoder;
 };
 

--- a/Userland/Libraries/LibVideo/VP9/Parser.h
+++ b/Userland/Libraries/LibVideo/VP9/Parser.h
@@ -16,6 +16,7 @@
 #include <LibVideo/DecoderError.h>
 
 #include "BitStream.h"
+#include "Context.h"
 #include "LookupTables.h"
 #include "MotionVector.h"
 #include "ProbabilityTables.h"
@@ -233,7 +234,7 @@ private:
     // The column to use for getting partition tree probability lookups.
     u32 m_col { 0 };
     TXSize m_tx_size { TX_4x4 };
-    ReferenceFrameType m_ref_frame[2];
+    ReferenceFramePair m_ref_frame;
     bool m_is_inter { false };
     bool m_is_compound { false };
     PredictionMode m_default_intra_mode { PredictionMode::DcPred };
@@ -243,18 +244,18 @@ private:
     u8 m_num_4x4_h { 0 };
     PredictionMode m_uv_mode { 0 }; // FIXME: Is u8 the right size?
     Vector<Array<PredictionMode, 4>> m_sub_modes;
-    ReferenceFrameType m_left_ref_frame[2];
-    ReferenceFrameType m_above_ref_frame[2];
+    ReferenceFramePair m_left_ref_frame;
+    ReferenceFramePair m_above_ref_frame;
     bool m_left_intra { false };
     bool m_above_intra { false };
     bool m_left_single { false };
     bool m_above_single { false };
     // The current block's interpolation filter.
     InterpolationFilter m_interp_filter { EightTap };
-    MotionVector m_mv[2];
-    MotionVector m_near_mv[2];
-    MotionVector m_nearest_mv[2];
-    MotionVector m_best_mv[2];
+    MotionVectorPair m_mv;
+    MotionVectorPair m_near_mv;
+    MotionVectorPair m_nearest_mv;
+    MotionVectorPair m_best_mv;
     // FIXME: Move these to a struct to store together in one array.
     Gfx::Size<u32> m_ref_frame_size[NUM_REF_FRAMES];
     bool m_ref_subsampling_x[NUM_REF_FRAMES];
@@ -271,7 +272,7 @@ private:
     TXMode m_tx_mode;
     ReferenceMode m_reference_mode;
     ReferenceFrameType m_comp_fixed_ref;
-    ReferenceFrameType m_comp_var_ref[2];
+    ReferenceFramePair m_comp_var_ref;
     MotionVector m_block_mvs[2][4];
     Vector<u8> m_prev_segment_ids;
 
@@ -280,15 +281,15 @@ private:
     Vector<u32> m_mi_sizes;
     Vector<PredictionMode> m_y_modes;
     Vector<u8> m_segment_ids;
-    Vector<Array<ReferenceFrameType, 2>> m_ref_frames;
-    Vector<Array<ReferenceFrameType, 2>> m_prev_ref_frames;
-    Vector<Array<MotionVector, 2>> m_mvs;
-    Vector<Array<MotionVector, 2>> m_prev_mvs;
-    MotionVector m_candidate_mv[2];
-    ReferenceFrameType m_candidate_frame[2];
+    Vector<ReferenceFramePair> m_ref_frames;
+    Vector<ReferenceFramePair> m_prev_ref_frames;
+    Vector<MotionVectorPair> m_mvs;
+    Vector<MotionVectorPair> m_prev_mvs;
+    MotionVectorPair m_candidate_mv;
+    ReferenceFramePair m_candidate_frame;
     Vector<Array<Array<MotionVector, 4>, 2>> m_sub_mvs;
     u8 m_ref_mv_count { 0 };
-    MotionVector m_ref_list_mv[2];
+    MotionVectorPair m_ref_list_mv;
     bool m_use_prev_frame_mvs;
     Vector<InterpolationFilter> m_interp_filters;
     // Indexed by ReferenceFrame enum.

--- a/Userland/Libraries/LibVideo/VP9/Parser.h
+++ b/Userland/Libraries/LibVideo/VP9/Parser.h
@@ -236,13 +236,13 @@ private:
     ReferenceFrameType m_ref_frame[2];
     bool m_is_inter { false };
     bool m_is_compound { false };
-    IntraMode m_default_intra_mode { DcPred };
-    u8 m_y_mode { 0 };
-    u8 m_block_sub_modes[4];
+    PredictionMode m_default_intra_mode { PredictionMode::DcPred };
+    PredictionMode m_y_mode { 0 };
+    PredictionMode m_block_sub_modes[4];
     u8 m_num_4x4_w { 0 };
     u8 m_num_4x4_h { 0 };
-    u8 m_uv_mode { 0 }; // FIXME: Is u8 the right size?
-    Vector<Array<IntraMode, 4>> m_sub_modes;
+    PredictionMode m_uv_mode { 0 }; // FIXME: Is u8 the right size?
+    Vector<Array<PredictionMode, 4>> m_sub_modes;
     ReferenceFrameType m_left_ref_frame[2];
     ReferenceFrameType m_above_ref_frame[2];
     bool m_left_intra { false };
@@ -278,7 +278,7 @@ private:
     Vector<bool> m_skips;
     Vector<TXSize> m_tx_sizes;
     Vector<u32> m_mi_sizes;
-    Vector<u8> m_y_modes;
+    Vector<PredictionMode> m_y_modes;
     Vector<u8> m_segment_ids;
     Vector<Array<ReferenceFrameType, 2>> m_ref_frames;
     Vector<Array<ReferenceFrameType, 2>> m_prev_ref_frames;

--- a/Userland/Libraries/LibVideo/VP9/Parser.h
+++ b/Userland/Libraries/LibVideo/VP9/Parser.h
@@ -243,6 +243,9 @@ private:
     u8 m_num_4x4_w { 0 };
     u8 m_num_4x4_h { 0 };
     PredictionMode m_uv_mode { 0 }; // FIXME: Is u8 the right size?
+    // FIXME: From spec: NOTE – We are using a 2D array to store the SubModes for clarity. It is possible to reduce memory
+    // consumption by only storing one intra mode for each 8x8 horizontal and vertical position, i.e. to use two 1D
+    // arrays instead.
     Vector<Array<PredictionMode, 4>> m_sub_modes;
     ReferenceFramePair m_left_ref_frame;
     ReferenceFramePair m_above_ref_frame;

--- a/Userland/Libraries/LibVideo/VP9/Parser.h
+++ b/Userland/Libraries/LibVideo/VP9/Parser.h
@@ -11,7 +11,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/Span.h>
 #include <AK/Vector.h>
-#include <LibGfx/Forward.h>
+#include <LibGfx/Size.h>
 #include <LibVideo/Color/CodingIndependentCodePoints.h>
 #include <LibVideo/DecoderError.h>
 
@@ -60,9 +60,10 @@ private:
     DecoderErrorOr<void> uncompressed_header();
     DecoderErrorOr<void> frame_sync_code();
     DecoderErrorOr<void> color_config();
-    DecoderErrorOr<void> frame_size();
-    DecoderErrorOr<void> render_size();
-    DecoderErrorOr<void> frame_size_with_refs();
+    DecoderErrorOr<void> set_frame_size_and_compute_image_size();
+    DecoderErrorOr<Gfx::Size<u32>> frame_size();
+    DecoderErrorOr<Gfx::Size<u32>> frame_size_with_refs();
+    DecoderErrorOr<Gfx::Size<u32>> render_size(Gfx::Size<u32> frame_size);
     void compute_image_size();
     DecoderErrorOr<void> read_interpolation_filter();
     DecoderErrorOr<void> loop_filter_params();
@@ -171,10 +172,8 @@ private:
     ColorRange m_color_range;
     bool m_subsampling_x { false };
     bool m_subsampling_y { false };
-    u32 m_frame_width { 0 };
-    u32 m_frame_height { 0 };
-    u16 m_render_width { 0 };
-    u16 m_render_height { 0 };
+    Gfx::Size<u32> m_frame_size { 0, 0 };
+    Gfx::Size<u32> m_render_size { 0, 0 };
     bool m_render_and_frame_size_different { false };
     u32 m_mi_cols { 0 };
     u32 m_mi_rows { 0 };
@@ -257,8 +256,7 @@ private:
     MotionVector m_nearest_mv[2];
     MotionVector m_best_mv[2];
     // FIXME: Move these to a struct to store together in one array.
-    u32 m_ref_frame_width[NUM_REF_FRAMES];
-    u32 m_ref_frame_height[NUM_REF_FRAMES];
+    Gfx::Size<u32> m_ref_frame_size[NUM_REF_FRAMES];
     bool m_ref_subsampling_x[NUM_REF_FRAMES];
     bool m_ref_subsampling_y[NUM_REF_FRAMES];
     u8 m_ref_bit_depth[NUM_REF_FRAMES];

--- a/Userland/Libraries/LibVideo/VP9/Parser.h
+++ b/Userland/Libraries/LibVideo/VP9/Parser.h
@@ -128,7 +128,7 @@ private:
     DecoderErrorOr<i32> read_coef(Token token);
 
     /* (6.5) Motion Vector Prediction */
-    void find_mv_refs(ReferenceFrame, i32 block);
+    void find_mv_refs(ReferenceFrameType, i32 block);
     void find_best_ref_mvs(u8 ref_list);
     bool use_mv_hp(MotionVector const& delta_mv);
     void append_sub8x8_mvs(i32 block, u8 ref_list);
@@ -137,9 +137,9 @@ private:
     MotionVector clamp_mv(MotionVector mvec, i32 border);
     size_t get_image_index(u32 row, u32 column);
     void get_block_mv(u32 candidate_row, u32 candidate_column, u8 ref_list, bool use_prev);
-    void if_same_ref_frame_add_mv(u32 candidate_row, u32 candidate_column, ReferenceFrame ref_frame, bool use_prev);
-    void if_diff_ref_frame_add_mv(u32 candidate_row, u32 candidate_column, ReferenceFrame ref_frame, bool use_prev);
-    void scale_mv(u8 ref_list, ReferenceFrame ref_frame);
+    void if_same_ref_frame_add_mv(u32 candidate_row, u32 candidate_column, ReferenceFrameType ref_frame, bool use_prev);
+    void if_diff_ref_frame_add_mv(u32 candidate_row, u32 candidate_column, ReferenceFrameType ref_frame, bool use_prev);
+    void scale_mv(u8 ref_list, ReferenceFrameType ref_frame);
     void add_mv_ref_list(u8 ref_list);
 
     Gfx::Point<size_t> get_decoded_point_for_plane(u32 row, u32 column, u8 plane);
@@ -234,7 +234,7 @@ private:
     // The column to use for getting partition tree probability lookups.
     u32 m_col { 0 };
     TXSize m_tx_size { TX_4x4 };
-    ReferenceFrame m_ref_frame[2];
+    ReferenceFrameType m_ref_frame[2];
     bool m_is_inter { false };
     bool m_is_compound { false };
     IntraMode m_default_intra_mode { DcPred };
@@ -244,8 +244,8 @@ private:
     u8 m_num_4x4_h { 0 };
     u8 m_uv_mode { 0 }; // FIXME: Is u8 the right size?
     Vector<Array<IntraMode, 4>> m_sub_modes;
-    ReferenceFrame m_left_ref_frame[2];
-    ReferenceFrame m_above_ref_frame[2];
+    ReferenceFrameType m_left_ref_frame[2];
+    ReferenceFrameType m_above_ref_frame[2];
     bool m_left_intra { false };
     bool m_above_intra { false };
     bool m_left_single { false };
@@ -272,8 +272,8 @@ private:
     bool m_use_hp { false };
     TXMode m_tx_mode;
     ReferenceMode m_reference_mode;
-    ReferenceFrame m_comp_fixed_ref;
-    ReferenceFrame m_comp_var_ref[2];
+    ReferenceFrameType m_comp_fixed_ref;
+    ReferenceFrameType m_comp_var_ref[2];
     MotionVector m_block_mvs[2][4];
     Vector<u8> m_prev_segment_ids;
 
@@ -282,12 +282,12 @@ private:
     Vector<u32> m_mi_sizes;
     Vector<u8> m_y_modes;
     Vector<u8> m_segment_ids;
-    Vector<Array<ReferenceFrame, 2>> m_ref_frames;
-    Vector<Array<ReferenceFrame, 2>> m_prev_ref_frames;
+    Vector<Array<ReferenceFrameType, 2>> m_ref_frames;
+    Vector<Array<ReferenceFrameType, 2>> m_prev_ref_frames;
     Vector<Array<MotionVector, 2>> m_mvs;
     Vector<Array<MotionVector, 2>> m_prev_mvs;
     MotionVector m_candidate_mv[2];
-    ReferenceFrame m_candidate_frame[2];
+    ReferenceFrameType m_candidate_frame[2];
     Vector<Array<Array<MotionVector, 4>, 2>> m_sub_mvs;
     u8 m_ref_mv_count { 0 };
     MotionVector m_ref_list_mv[2];

--- a/Userland/Libraries/LibVideo/VP9/ProbabilityTables.h
+++ b/Userland/Libraries/LibVideo/VP9/ProbabilityTables.h
@@ -53,26 +53,47 @@ public:
     KfUVModeProbs const& kf_uv_mode_prob() const;
 
     PartitionProbs& partition_probs() { return m_current_probability_table.partition_probs; };
+    PartitionProbs const& partition_probs() const { return m_current_probability_table.partition_probs; };
     YModeProbs& y_mode_probs() { return m_current_probability_table.y_mode_probs; };
+    YModeProbs const& y_mode_probs() const { return m_current_probability_table.y_mode_probs; };
     UVModeProbs& uv_mode_probs() { return m_current_probability_table.uv_mode_probs; };
+    UVModeProbs const& uv_mode_probs() const { return m_current_probability_table.uv_mode_probs; };
     SkipProb& skip_prob() { return m_current_probability_table.skip_prob; };
+    SkipProb const& skip_prob() const { return m_current_probability_table.skip_prob; };
     IsInterProb& is_inter_prob() { return m_current_probability_table.is_inter_prob; };
+    IsInterProb const& is_inter_prob() const { return m_current_probability_table.is_inter_prob; };
     CompModeProb& comp_mode_prob() { return m_current_probability_table.comp_mode_prob; };
+    CompModeProb const& comp_mode_prob() const { return m_current_probability_table.comp_mode_prob; };
     CompRefProb& comp_ref_prob() { return m_current_probability_table.comp_ref_prob; };
+    CompRefProb const& comp_ref_prob() const { return m_current_probability_table.comp_ref_prob; };
     SingleRefProb& single_ref_prob() { return m_current_probability_table.single_ref_prob; };
+    SingleRefProb const& single_ref_prob() const { return m_current_probability_table.single_ref_prob; };
     MvSignProb& mv_sign_prob() { return m_current_probability_table.mv_sign_prob; };
+    MvSignProb const& mv_sign_prob() const { return m_current_probability_table.mv_sign_prob; };
     MvBitsProb& mv_bits_prob() { return m_current_probability_table.mv_bits_prob; };
+    MvBitsProb const& mv_bits_prob() const { return m_current_probability_table.mv_bits_prob; };
     MvClass0BitProb& mv_class0_bit_prob() { return m_current_probability_table.mv_class0_bit_prob; };
+    MvClass0BitProb const& mv_class0_bit_prob() const { return m_current_probability_table.mv_class0_bit_prob; };
     TxProbs& tx_probs() { return m_current_probability_table.tx_probs; };
+    TxProbs const& tx_probs() const { return m_current_probability_table.tx_probs; };
     InterModeProbs& inter_mode_probs() { return m_current_probability_table.inter_mode_probs; };
+    InterModeProbs const& inter_mode_probs() const { return m_current_probability_table.inter_mode_probs; };
     InterpFilterProbs& interp_filter_probs() { return m_current_probability_table.interp_filter_probs; };
+    InterpFilterProbs const& interp_filter_probs() const { return m_current_probability_table.interp_filter_probs; };
     MvJointProbs& mv_joint_probs() { return m_current_probability_table.mv_joint_probs; };
+    MvJointProbs const& mv_joint_probs() const { return m_current_probability_table.mv_joint_probs; };
     MvClassProbs& mv_class_probs() { return m_current_probability_table.mv_class_probs; };
+    MvClassProbs const& mv_class_probs() const { return m_current_probability_table.mv_class_probs; };
     MvClass0FrProbs& mv_class0_fr_probs() { return m_current_probability_table.mv_class0_fr_probs; };
+    MvClass0FrProbs const& mv_class0_fr_probs() const { return m_current_probability_table.mv_class0_fr_probs; };
     MvClass0HpProbs& mv_class0_hp_prob() { return m_current_probability_table.mv_class0_hp_prob; };
+    MvClass0HpProbs const& mv_class0_hp_prob() const { return m_current_probability_table.mv_class0_hp_prob; };
     MvFrProbs& mv_fr_probs() { return m_current_probability_table.mv_fr_probs; };
+    MvFrProbs const& mv_fr_probs() const { return m_current_probability_table.mv_fr_probs; };
     MvHpProb& mv_hp_prob() { return m_current_probability_table.mv_hp_prob; };
+    MvHpProb const& mv_hp_prob() const { return m_current_probability_table.mv_hp_prob; };
     CoefProbs& coef_probs() { return m_current_probability_table.coef_probs; };
+    CoefProbs const& coef_probs() const { return m_current_probability_table.coef_probs; };
 
 private:
     struct ProbabilityTable {

--- a/Userland/Libraries/LibVideo/VP9/SyntaxElementCounter.h
+++ b/Userland/Libraries/LibVideo/VP9/SyntaxElementCounter.h
@@ -11,37 +11,6 @@
 
 namespace Video::VP9 {
 
-enum class SyntaxElementType {
-    Partition,
-    DefaultIntraMode,
-    DefaultUVMode,
-    IntraMode,
-    SubIntraMode,
-    UVMode,
-    SegmentID,
-    Skip,
-    SegIDPredicted,
-    IsInter,
-    CompMode,
-    CompRef,
-    SingleRefP1,
-    SingleRefP2,
-    MVSign,
-    MVClass0Bit,
-    MVBit,
-    TXSize,
-    InterMode,
-    InterpFilter,
-    MVJoint,
-    MVClass,
-    MVClass0FR,
-    MVClass0HP,
-    MVFR,
-    MVHP,
-    Token,
-    MoreCoefs,
-};
-
 class SyntaxElementCounter final {
 public:
     /* (8.3) Clear Counts Process */

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
@@ -5,9 +5,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "TreeParser.h"
+#include "Enums.h"
 #include "LookupTables.h"
 #include "Parser.h"
+#include "TreeParser.h"
 
 namespace Video::VP9 {
 
@@ -34,7 +35,7 @@ template ErrorOr<int> TreeParser::parse_tree(SyntaxElementType);
 template ErrorOr<bool> TreeParser::parse_tree(SyntaxElementType);
 template ErrorOr<u8> TreeParser::parse_tree(SyntaxElementType);
 template ErrorOr<u32> TreeParser::parse_tree(SyntaxElementType);
-template ErrorOr<IntraMode> TreeParser::parse_tree(SyntaxElementType);
+template ErrorOr<PredictionMode> TreeParser::parse_tree(SyntaxElementType);
 template ErrorOr<TXSize> TreeParser::parse_tree(SyntaxElementType);
 template ErrorOr<InterpolationFilter> TreeParser::parse_tree(SyntaxElementType);
 template ErrorOr<ReferenceMode> TreeParser::parse_tree(SyntaxElementType);
@@ -214,21 +215,21 @@ u8 TreeParser::calculate_partition_probability(u8 node)
 
 u8 TreeParser::calculate_default_intra_mode_probability(u8 node)
 {
-    u32 above_mode, left_mode;
+    PredictionMode above_mode, left_mode;
     if (m_decoder.m_mi_size >= Block_8x8) {
         above_mode = AVAIL_U
             ? m_decoder.m_sub_modes[m_decoder.get_image_index(m_decoder.m_mi_row - 1, m_decoder.m_mi_col)][2]
-            : DcPred;
+            : PredictionMode::DcPred;
         left_mode = AVAIL_L
             ? m_decoder.m_sub_modes[m_decoder.get_image_index(m_decoder.m_mi_row, m_decoder.m_mi_col - 1)][1]
-            : DcPred;
+            : PredictionMode::DcPred;
     } else {
         if (m_idy) {
             above_mode = m_decoder.m_block_sub_modes[m_idx];
         } else {
             above_mode = AVAIL_U
                 ? m_decoder.m_sub_modes[m_decoder.get_image_index(m_decoder.m_mi_row - 1, m_decoder.m_mi_col)][2 + m_idx]
-                : DcPred;
+                : PredictionMode::DcPred;
         }
 
         if (m_idx) {
@@ -236,15 +237,15 @@ u8 TreeParser::calculate_default_intra_mode_probability(u8 node)
         } else {
             left_mode = AVAIL_L
                 ? m_decoder.m_sub_modes[m_decoder.get_image_index(m_decoder.m_mi_row, m_decoder.m_mi_col - 1)][1 + m_idy * 2]
-                : DcPred;
+                : PredictionMode::DcPred;
         }
     }
-    return m_decoder.m_probability_tables->kf_y_mode_probs()[above_mode][left_mode][node];
+    return m_decoder.m_probability_tables->kf_y_mode_probs()[to_underlying(above_mode)][to_underlying(left_mode)][node];
 }
 
 u8 TreeParser::calculate_default_uv_mode_probability(u8 node)
 {
-    return m_decoder.m_probability_tables->kf_uv_mode_prob()[m_decoder.m_y_mode][node];
+    return m_decoder.m_probability_tables->kf_uv_mode_prob()[to_underlying(m_decoder.m_y_mode)][node];
 }
 
 u8 TreeParser::calculate_intra_mode_probability(u8 node)
@@ -261,7 +262,7 @@ u8 TreeParser::calculate_sub_intra_mode_probability(u8 node)
 
 u8 TreeParser::calculate_uv_mode_probability(u8 node)
 {
-    m_ctx = m_decoder.m_y_mode;
+    m_ctx = to_underlying(m_decoder.m_y_mode);
     return m_decoder.m_probability_tables->uv_mode_probs()[m_ctx][node];
 }
 

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -65,6 +65,8 @@ public:
     static ErrorOr<Partition> parse_partition(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, bool has_rows, bool has_columns, BlockSubsize block_subsize, u8 num_8x8, Vector<u8> const& above_partition_context, Vector<u8> const& left_partition_context, u32 row, u32 column, bool frame_is_intra);
     static ErrorOr<PredictionMode> parse_default_intra_mode(BitStream&, ProbabilityTables const&, BlockSubsize mi_size, Optional<Array<PredictionMode, 4> const&> above_context, Optional<Array<PredictionMode, 4> const&> left_context, PredictionMode block_sub_modes[4], u8 index_x, u8 index_y);
     static ErrorOr<PredictionMode> parse_default_uv_mode(BitStream&, ProbabilityTables const&, PredictionMode y_mode);
+    static ErrorOr<PredictionMode> parse_intra_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, BlockSubsize mi_size);
+    static ErrorOr<PredictionMode> parse_sub_intra_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -98,8 +100,6 @@ public:
     }
 
 private:
-    u8 calculate_intra_mode_probability(u8 node);
-    u8 calculate_sub_intra_mode_probability(u8 node);
     u8 calculate_uv_mode_probability(u8 node);
     u8 calculate_segment_id_probability(u8 node);
     u8 calculate_skip_probability();

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -68,6 +68,7 @@ public:
     static ErrorOr<PredictionMode> parse_intra_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, BlockSubsize mi_size);
     static ErrorOr<PredictionMode> parse_sub_intra_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&);
     static ErrorOr<PredictionMode> parse_uv_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, PredictionMode y_mode);
+    static ErrorOr<PredictionMode> parse_inter_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 mode_context_for_ref_frame_0);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -110,7 +111,6 @@ private:
     u8 calculate_single_ref_p1_probability();
     u8 calculate_single_ref_p2_probability();
     u8 calculate_tx_size_probability(u8 node);
-    u8 calculate_inter_mode_probability(u8 node);
     u8 calculate_interp_filter_probability(u8 node);
     u8 calculate_token_probability(u8 node);
     u8 calculate_more_coefs_probability();

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -23,6 +23,7 @@ public:
     {
     }
 
+    // FIXME: Move or remove this class once it is unused in the header.
     class TreeSelection {
     public:
         union TreeSelectionValue {
@@ -43,8 +44,8 @@ public:
         }
 
         bool is_single_value() const { return m_is_single_value; }
-        int get_single_value() const { return m_value.m_value; }
-        int const* get_tree_value() const { return m_value.m_tree; }
+        int single_value() const { return m_value.m_value; }
+        int const* tree() const { return m_value.m_tree; }
 
     private:
         bool m_is_single_value;
@@ -60,6 +61,8 @@ public:
     u8 select_tree_probability(SyntaxElementType type, u8 node);
     /* (9.3.4) */
     void count_syntax_element(SyntaxElementType type, int value);
+
+    static ErrorOr<Partition> parse_partition(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, bool has_rows, bool has_columns, BlockSubsize block_subsize, u8 num_8x8, Vector<u8> const& above_partition_context, Vector<u8> const& left_partition_context, u32 row, u32 column, bool frame_is_intra);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -93,7 +96,6 @@ public:
     }
 
 private:
-    u8 calculate_partition_probability(u8 node);
     u8 calculate_default_intra_mode_probability(u8 node);
     u8 calculate_default_uv_mode_probability(u8 node);
     u8 calculate_intra_mode_probability(u8 node);
@@ -135,6 +137,18 @@ private:
     // 0xFF indicates the value has not been set.
     // parse_mv_class0_fr should be called to set this.
     u8 m_mv_class0_bit { 0xFF };
+};
+
+struct PartitionTreeContext {
+    bool has_rows;
+    bool has_columns;
+    BlockSubsize block_subsize;
+    u8 num_8x8;
+    Vector<u8> const& above_partition_context;
+    Vector<u8> const& left_partition_context;
+    u32 row;
+    u32 column;
+    bool frame_is_intra;
 };
 
 }

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -81,6 +81,16 @@ public:
     static ErrorOr<bool> parse_single_ref_part_1(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<bool> above_single, Optional<bool> left_single, Optional<bool> above_intra, Optional<bool> left_intra, Optional<ReferenceFramePair> above_ref_frame, Optional<ReferenceFramePair> left_ref_frame);
     static ErrorOr<bool> parse_single_ref_part_2(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<bool> above_single, Optional<bool> left_single, Optional<bool> above_intra, Optional<bool> left_intra, Optional<ReferenceFramePair> above_ref_frame, Optional<ReferenceFramePair> left_ref_frame);
 
+    static ErrorOr<MvJoint> parse_motion_vector_joint(BitStream&, ProbabilityTables const&, SyntaxElementCounter&);
+    static ErrorOr<bool> parse_motion_vector_sign(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 component);
+    static ErrorOr<MvClass> parse_motion_vector_class(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 component);
+    static ErrorOr<bool> parse_motion_vector_class0_bit(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 component);
+    static ErrorOr<u8> parse_motion_vector_class0_fr(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 component, bool class_0_bit);
+    static ErrorOr<bool> parse_motion_vector_class0_hp(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 component, bool use_hp);
+    static ErrorOr<bool> parse_motion_vector_bit(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 component, u8 bit_index);
+    static ErrorOr<u8> parse_motion_vector_fr(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 component);
+    static ErrorOr<bool> parse_motion_vector_hp(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 component, bool use_hp);
+
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
         m_idx = idx;
@@ -93,23 +103,6 @@ public:
     {
         m_start_x = start_x;
         m_start_y = start_y;
-    }
-
-    void set_mv_component(u8 component)
-    {
-        m_mv_component = component;
-    }
-
-    ErrorOr<bool> parse_mv_bit(u8 bit)
-    {
-        m_mv_bit = bit;
-        return parse_tree<bool>(SyntaxElementType::MVBit);
-    }
-
-    ErrorOr<u8> parse_mv_class0_fr(bool mv_class0_bit)
-    {
-        m_mv_class0_bit = mv_class0_bit;
-        return parse_tree<u8>(SyntaxElementType::MVClass0FR);
     }
 
 private:

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -78,6 +78,8 @@ public:
     static ErrorOr<bool> parse_is_inter(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<bool> above_intra, Optional<bool> left_intra);
     static ErrorOr<ReferenceMode> parse_comp_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, ReferenceFrameType comp_fixed_ref, Optional<bool> above_single, Optional<bool> left_single, Optional<bool> above_intra, Optional<bool> left_intra, Optional<ReferenceFrameType> above_ref_frame_0, Optional<ReferenceFrameType> left_ref_frame_0);
     static ErrorOr<bool> parse_comp_ref(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, ReferenceFrameType comp_fixed_ref, ReferenceFramePair comp_var_ref, Optional<bool> above_single, Optional<bool> left_single, Optional<bool> above_intra, Optional<bool> left_intra, Optional<ReferenceFrameType> above_ref_frame_0, Optional<ReferenceFrameType> left_ref_frame_0, Optional<ReferenceFrameType> above_ref_frame_biased, Optional<ReferenceFrameType> left_ref_frame_biased);
+    static ErrorOr<bool> parse_single_ref_part_1(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<bool> above_single, Optional<bool> left_single, Optional<bool> above_intra, Optional<bool> left_intra, Optional<ReferenceFramePair> above_ref_frame, Optional<ReferenceFramePair> left_ref_frame);
+    static ErrorOr<bool> parse_single_ref_part_2(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<bool> above_single, Optional<bool> left_single, Optional<bool> above_intra, Optional<bool> left_intra, Optional<ReferenceFramePair> above_ref_frame, Optional<ReferenceFramePair> left_ref_frame);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -111,8 +113,6 @@ public:
     }
 
 private:
-    u8 calculate_single_ref_p1_probability();
-    u8 calculate_single_ref_p2_probability();
     u8 calculate_token_probability(u8 node);
     u8 calculate_more_coefs_probability();
 

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -63,6 +63,7 @@ public:
     void count_syntax_element(SyntaxElementType type, int value);
 
     static ErrorOr<Partition> parse_partition(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, bool has_rows, bool has_columns, BlockSubsize block_subsize, u8 num_8x8, Vector<u8> const& above_partition_context, Vector<u8> const& left_partition_context, u32 row, u32 column, bool frame_is_intra);
+    static ErrorOr<PredictionMode> parse_default_intra_mode(BitStream&, ProbabilityTables const&, BlockSubsize mi_size, Optional<Array<PredictionMode, 4> const&> above_context, Optional<Array<PredictionMode, 4> const&> left_context, PredictionMode block_sub_modes[4], u8 index_x, u8 index_y);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -96,7 +97,6 @@ public:
     }
 
 private:
-    u8 calculate_default_intra_mode_probability(u8 node);
     u8 calculate_default_uv_mode_probability(u8 node);
     u8 calculate_intra_mode_probability(u8 node);
     u8 calculate_sub_intra_mode_probability(u8 node);

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -75,6 +75,7 @@ public:
     static ErrorOr<bool> parse_skip(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<bool> const& above_skip, Optional<bool> const& left_skip);
     static ErrorOr<TXSize> parse_tx_size(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, TXSize max_tx_size, Optional<bool> above_skip, Optional<bool> left_skip, Optional<TXSize> above_tx_size, Optional<TXSize> left_tx_size);
     static ErrorOr<bool> parse_is_inter(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<bool> above_intra, Optional<bool> left_intra);
+    static ErrorOr<ReferenceMode> parse_comp_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, ReferenceFrameType comp_fixed_ref, Optional<bool> above_single, Optional<bool> left_single, Optional<bool> above_intra, Optional<bool> left_intra, Optional<ReferenceFrameType> above_ref_frame_0, Optional<ReferenceFrameType> left_ref_frame_0);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -108,7 +109,6 @@ public:
     }
 
 private:
-    u8 calculate_comp_mode_probability();
     u8 calculate_comp_ref_probability();
     u8 calculate_single_ref_p1_probability();
     u8 calculate_single_ref_p2_probability();

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -67,6 +67,7 @@ public:
     static ErrorOr<PredictionMode> parse_default_uv_mode(BitStream&, ProbabilityTables const&, PredictionMode y_mode);
     static ErrorOr<PredictionMode> parse_intra_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, BlockSubsize mi_size);
     static ErrorOr<PredictionMode> parse_sub_intra_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&);
+    static ErrorOr<PredictionMode> parse_uv_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, PredictionMode y_mode);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -100,7 +101,6 @@ public:
     }
 
 private:
-    u8 calculate_uv_mode_probability(u8 node);
     u8 calculate_segment_id_probability(u8 node);
     u8 calculate_skip_probability();
     u8 calculate_seg_id_predicted_probability();

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -74,6 +74,7 @@ public:
     static ErrorOr<InterpolationFilter> parse_interpolation_filter(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<ReferenceFrameType> above_ref_frame, Optional<ReferenceFrameType> left_ref_frame, Optional<InterpolationFilter> above_interpolation_filter, Optional<InterpolationFilter> left_interpolation_filter);
     static ErrorOr<bool> parse_skip(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<bool> const& above_skip, Optional<bool> const& left_skip);
     static ErrorOr<TXSize> parse_tx_size(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, TXSize max_tx_size, Optional<bool> above_skip, Optional<bool> left_skip, Optional<TXSize> above_tx_size, Optional<TXSize> left_tx_size);
+    static ErrorOr<bool> parse_is_inter(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<bool> above_intra, Optional<bool> left_intra);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -107,7 +108,6 @@ public:
     }
 
 private:
-    u8 calculate_is_inter_probability();
     u8 calculate_comp_mode_probability();
     u8 calculate_comp_ref_probability();
     u8 calculate_single_ref_p1_probability();

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -64,6 +64,7 @@ public:
 
     static ErrorOr<Partition> parse_partition(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, bool has_rows, bool has_columns, BlockSubsize block_subsize, u8 num_8x8, Vector<u8> const& above_partition_context, Vector<u8> const& left_partition_context, u32 row, u32 column, bool frame_is_intra);
     static ErrorOr<PredictionMode> parse_default_intra_mode(BitStream&, ProbabilityTables const&, BlockSubsize mi_size, Optional<Array<PredictionMode, 4> const&> above_context, Optional<Array<PredictionMode, 4> const&> left_context, PredictionMode block_sub_modes[4], u8 index_x, u8 index_y);
+    static ErrorOr<PredictionMode> parse_default_uv_mode(BitStream&, ProbabilityTables const&, PredictionMode y_mode);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -97,7 +98,6 @@ public:
     }
 
 private:
-    u8 calculate_default_uv_mode_probability(u8 node);
     u8 calculate_intra_mode_probability(u8 node);
     u8 calculate_sub_intra_mode_probability(u8 node);
     u8 calculate_uv_mode_probability(u8 node);

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -68,6 +68,8 @@ public:
     static ErrorOr<PredictionMode> parse_intra_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, BlockSubsize mi_size);
     static ErrorOr<PredictionMode> parse_sub_intra_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&);
     static ErrorOr<PredictionMode> parse_uv_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, PredictionMode y_mode);
+    static ErrorOr<u8> parse_segment_id(BitStream&, u8 const probabilities[7]);
+    static ErrorOr<bool> parse_segment_id_predicted(BitStream&, u8 const probabilities[3], u8 above_seg_pred_context, u8 left_seg_pred_context);
     static ErrorOr<PredictionMode> parse_inter_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 mode_context_for_ref_frame_0);
     static ErrorOr<InterpolationFilter> parse_interpolation_filter(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<ReferenceFrameType> above_ref_frame, Optional<ReferenceFrameType> left_ref_frame, Optional<InterpolationFilter> above_interpolation_filter, Optional<InterpolationFilter> left_interpolation_filter);
 
@@ -103,9 +105,7 @@ public:
     }
 
 private:
-    u8 calculate_segment_id_probability(u8 node);
     u8 calculate_skip_probability();
-    u8 calculate_seg_id_predicted_probability();
     u8 calculate_is_inter_probability();
     u8 calculate_comp_mode_probability();
     u8 calculate_comp_ref_probability();

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "BitStream.h"
+#include "Context.h"
 #include "Enums.h"
 #include "ProbabilityTables.h"
 #include "SyntaxElementCounter.h"
@@ -76,6 +77,7 @@ public:
     static ErrorOr<TXSize> parse_tx_size(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, TXSize max_tx_size, Optional<bool> above_skip, Optional<bool> left_skip, Optional<TXSize> above_tx_size, Optional<TXSize> left_tx_size);
     static ErrorOr<bool> parse_is_inter(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<bool> above_intra, Optional<bool> left_intra);
     static ErrorOr<ReferenceMode> parse_comp_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, ReferenceFrameType comp_fixed_ref, Optional<bool> above_single, Optional<bool> left_single, Optional<bool> above_intra, Optional<bool> left_intra, Optional<ReferenceFrameType> above_ref_frame_0, Optional<ReferenceFrameType> left_ref_frame_0);
+    static ErrorOr<bool> parse_comp_ref(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, ReferenceFrameType comp_fixed_ref, ReferenceFramePair comp_var_ref, Optional<bool> above_single, Optional<bool> left_single, Optional<bool> above_intra, Optional<bool> left_intra, Optional<ReferenceFrameType> above_ref_frame_0, Optional<ReferenceFrameType> left_ref_frame_0, Optional<ReferenceFrameType> above_ref_frame_biased, Optional<ReferenceFrameType> left_ref_frame_biased);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -109,7 +111,6 @@ public:
     }
 
 private:
-    u8 calculate_comp_ref_probability();
     u8 calculate_single_ref_p1_probability();
     u8 calculate_single_ref_p2_probability();
     u8 calculate_token_probability(u8 node);

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -73,6 +73,7 @@ public:
     static ErrorOr<PredictionMode> parse_inter_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 mode_context_for_ref_frame_0);
     static ErrorOr<InterpolationFilter> parse_interpolation_filter(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<ReferenceFrameType> above_ref_frame, Optional<ReferenceFrameType> left_ref_frame, Optional<InterpolationFilter> above_interpolation_filter, Optional<InterpolationFilter> left_interpolation_filter);
     static ErrorOr<bool> parse_skip(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<bool> const& above_skip, Optional<bool> const& left_skip);
+    static ErrorOr<TXSize> parse_tx_size(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, TXSize max_tx_size, Optional<bool> above_skip, Optional<bool> left_skip, Optional<TXSize> above_tx_size, Optional<TXSize> left_tx_size);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -111,7 +112,6 @@ private:
     u8 calculate_comp_ref_probability();
     u8 calculate_single_ref_p1_probability();
     u8 calculate_single_ref_p2_probability();
-    u8 calculate_tx_size_probability(u8 node);
     u8 calculate_token_probability(u8 node);
     u8 calculate_more_coefs_probability();
 

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -69,6 +69,7 @@ public:
     static ErrorOr<PredictionMode> parse_sub_intra_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&);
     static ErrorOr<PredictionMode> parse_uv_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, PredictionMode y_mode);
     static ErrorOr<PredictionMode> parse_inter_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 mode_context_for_ref_frame_0);
+    static ErrorOr<InterpolationFilter> parse_interpolation_filter(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<ReferenceFrameType> above_ref_frame, Optional<ReferenceFrameType> left_ref_frame, Optional<InterpolationFilter> above_interpolation_filter, Optional<InterpolationFilter> left_interpolation_filter);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -111,7 +112,6 @@ private:
     u8 calculate_single_ref_p1_probability();
     u8 calculate_single_ref_p2_probability();
     u8 calculate_tx_size_probability(u8 node);
-    u8 calculate_interp_filter_probability(u8 node);
     u8 calculate_token_probability(u8 node);
     u8 calculate_more_coefs_probability();
 

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -72,6 +72,7 @@ public:
     static ErrorOr<bool> parse_segment_id_predicted(BitStream&, u8 const probabilities[3], u8 above_seg_pred_context, u8 left_seg_pred_context);
     static ErrorOr<PredictionMode> parse_inter_mode(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, u8 mode_context_for_ref_frame_0);
     static ErrorOr<InterpolationFilter> parse_interpolation_filter(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<ReferenceFrameType> above_ref_frame, Optional<ReferenceFrameType> left_ref_frame, Optional<InterpolationFilter> above_interpolation_filter, Optional<InterpolationFilter> left_interpolation_filter);
+    static ErrorOr<bool> parse_skip(BitStream&, ProbabilityTables const&, SyntaxElementCounter&, Optional<bool> const& above_skip, Optional<bool> const& left_skip);
 
     void set_default_intra_mode_variables(u8 idx, u8 idy)
     {
@@ -105,7 +106,6 @@ public:
     }
 
 private:
-    u8 calculate_skip_probability();
     u8 calculate_is_inter_probability();
     u8 calculate_comp_mode_probability();
     u8 calculate_comp_ref_probability();

--- a/Userland/Libraries/LibVideo/VideoDecoder.h
+++ b/Userland/Libraries/LibVideo/VideoDecoder.h
@@ -18,7 +18,7 @@ class VideoDecoder {
 public:
     virtual ~VideoDecoder() {};
 
-    virtual DecoderErrorOr<void> receive_sample(Span<u8 const> sample) = 0;
+    virtual DecoderErrorOr<void> receive_sample(ReadonlyBytes sample) = 0;
     DecoderErrorOr<void> receive_sample(ByteBuffer const& sample) { return receive_sample(sample.span()); }
     virtual DecoderErrorOr<NonnullOwnPtr<VideoFrame>> get_decoded_frame() = 0;
 };


### PR DESCRIPTION
This is the first step in making the VP9 decoder's functions depend less on fields defined in Parser.h and some in Decoder.h.

The largest part of this pull request is incrementally replacing the TreeParser member functions with static functions for parsing each syntax element. Instead of making the probability selection depend on fields defined by Parser, now all those dependencies are passed as parameters, making future changes to depend less on state within Parser itself much easier.

Because I made those changes incrementally, the number of commits is quite high. Each step in the process up to and including the last one compiles and decodes VP9 video the same as before, according to my testing, so each one can be inspected as a self-contained change. However, if it's desired, I can always squash some or all of those commits.

One small functionality change was adding a queue of output frames to the decoder, so that in the rare case that a superframe contains multiple frames, they can all be output rather than only outputting the last one.


Edit: It's worth noting that the above and left context parameters passed to many of the tree parser functions are supposed to be replaced with context structs in the future where reasonable, so that they don't need to take multiple optionals as parameters. This is a temporary solution to allow parameterizing the current separate values.