### PR TITLE
LibVideo: Treat BT.601/709/2020 input transfer characteristics as sRGB

### DIFF
--- a/Userland/Libraries/LibVideo/Color/ColorConverter.cpp
+++ b/Userland/Libraries/LibVideo/Color/ColorConverter.cpp
@@ -165,21 +165,6 @@ DecoderErrorOr<ColorConverter> ColorConverter::create(u8 bit_depth, CodingIndepe
     //    should apply tonemapping as well.
     //    Use a lookup table as with step 3.
     TransferCharacteristics output_tc = TransferCharacteristics::SRGB;
-    switch (cicp.transfer_characteristics()) {
-    case TransferCharacteristics::Unspecified:
-        break;
-    case TransferCharacteristics::BT709:
-    case TransferCharacteristics::BT601:
-    case TransferCharacteristics::BT2020BitDepth10:
-    case TransferCharacteristics::BT2020BitDepth12:
-        // BT.601, BT.709 and BT.2020 have a similar transfer function to sRGB, and other applications
-        // (Chromium, VLC) seem to keep video output in those transfer characteristics.
-        output_tc = TransferCharacteristics::BT709;
-        break;
-    default:
-        break;
-    }
-
     auto to_non_linear_lookup_table = InterpolatedLookupTable<to_non_linear_size>::create(
         [&](float value) {
             return TransferCharacteristicsConversion::to_non_linear_luminance(value, output_tc);

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -216,7 +216,22 @@ bool PlaybackManager::decode_and_queue_one_sample()
 
     auto& cicp = decoded_frame->cicp();
     cicp.adopt_specified_values(frame_sample->container_cicp());
-    cicp.default_code_points_if_unspecified({ Video::ColorPrimaries::BT709, Video::TransferCharacteristics::BT709, Video::MatrixCoefficients::BT709, Video::ColorRange::Studio });
+    cicp.default_code_points_if_unspecified({ ColorPrimaries::BT709, TransferCharacteristics::BT709, MatrixCoefficients::BT709, ColorRange::Studio });
+
+    // BT.601, BT.709 and BT.2020 have a similar transfer function to sRGB, so other applications
+    // (Chromium, VLC) forgo transfer characteristics conversion. We will emulate that behavior by
+    // handling those as sRGB instead, which causes no transfer function change in the output,
+    // unless display color management is later implemented.
+    switch (cicp.transfer_characteristics()) {
+    case TransferCharacteristics::BT601:
+    case TransferCharacteristics::BT709:
+    case TransferCharacteristics::BT2020BitDepth10:
+    case TransferCharacteristics::BT2020BitDepth12:
+        cicp.set_transfer_characteristics(TransferCharacteristics::SRGB);
+        break;
+    default:
+        break;
+    }
 
     auto bitmap = TRY_OR_POST_ERROR_AND_RETURN(decoded_frame->to_bitmap(), false);
     m_frame_queue->enqueue(FrameQueueItem { bitmap, frame_sample->timestamp() });


### PR DESCRIPTION
I've realized that it probably makes more sense to change the input transfer characteristics to treat BT.601, BT.709 and BT.2020 as sRGB since color conversion in linear converted from BT.709 doesn't really make sense. If content creation applications expect media players to display BT.709 without conversions, this means they expect applications to treat it as sRGB, since that's what most displays use. That most likely also means they process it as sRGB internally, meaning we should do the same for our color primaries conversion.