### PR TITLE
less+LibLine: Support escaped contents when computing visible line length

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -1778,6 +1778,7 @@ enum VTState {
     Bracket = 5,
     BracketArgsSemi = 7,
     Title = 9,
+    URL = 11,
 };
 static VTState actual_rendered_string_length_step(StringMetrics& metrics, size_t index, StringMetrics::LineMetrics& current_line, u32 c, u32 next_c, VTState state, Optional<Style::Mask> const& mask, Optional<size_t> const& maximum_line_width = {}, Optional<size_t&> last_return = {});
 
@@ -1966,6 +1967,8 @@ VTState actual_rendered_string_length_step(StringMetrics& metrics, size_t index,
         if (c == ']') {
             if (next_c == '0')
                 state = Title;
+            if (next_c == '8')
+                state = URL;
             return state;
         }
         if (c == '[') {
@@ -1987,6 +1990,10 @@ VTState actual_rendered_string_length_step(StringMetrics& metrics, size_t index,
         return state;
     case Title:
         if (c == 7)
+            state = Free;
+        return state;
+    case URL:
+        if (c == '\\')
             state = Free;
         return state;
     }

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -160,7 +160,7 @@ public:
     void register_key_input_callback(Vector<Key> keys, Function<bool(Editor&)> callback) { m_callback_machine.register_key_input_callback(move(keys), move(callback)); }
     void register_key_input_callback(Key key, Function<bool(Editor&)> callback) { register_key_input_callback(Vector<Key> { key }, move(callback)); }
 
-    static StringMetrics actual_rendered_string_metrics(StringView, RedBlackTree<u32, Optional<Style::Mask>> const& masks = {});
+    static StringMetrics actual_rendered_string_metrics(StringView, RedBlackTree<u32, Optional<Style::Mask>> const& masks = {}, Optional<size_t> maximum_line_width = {});
     static StringMetrics actual_rendered_string_metrics(Utf32View const&, RedBlackTree<u32, Optional<Style::Mask>> const& masks = {});
 
     Function<Vector<CompletionSuggestion>(Editor const&)> on_tab_complete;

--- a/Userland/Libraries/LibLine/StringMetrics.h
+++ b/Userland/Libraries/LibLine/StringMetrics.h
@@ -20,6 +20,8 @@ struct StringMetrics {
     struct LineMetrics {
         Vector<MaskedChar> masked_chars;
         size_t length { 0 };
+        size_t visible_length { 0 };
+        Optional<size_t> bit_length { 0 };
 
         size_t total_length() const { return length; }
     };

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -4,7 +4,7 @@ list(APPEND REQUIRED_TARGETS
     arp base64 basename cat chmod chown clear comm cp cut date dd df diff dirname dmesg du echo env expr false fgrep
     file find grep groups head host hostname id ifconfig kill killall ln logout ls mkdir mount mv nproc
     pgrep pidof ping pkill pmap ps readlink realpath reboot rm rmdir route seq shutdown sleep sort stat stty su tail test
-    touch tr true umount uname uniq uptime w wc which whoami xargs yes less
+    touch tr true umount uname uniq uptime w wc which whoami xargs yes
 )
 list(APPEND RECOMMENDED_TARGETS
     adjtime aplay abench asctl bt checksum chres cksum copy fortune gunzip gzip init install keymap lsirq lsof lspci man mknod mktemp
@@ -93,6 +93,7 @@ target_link_libraries(headless-browser PRIVATE LibCrypto LibGemini LibGfx LibHTT
 target_link_libraries(js PRIVATE LibCrypto LibJS LibLine LibLocale LibTextCodec)
 link_with_locale_data(js)
 target_link_libraries(keymap PRIVATE LibKeyboard)
+target_link_libraries(less PRIVATE LibLine)
 target_link_libraries(lspci PRIVATE LibPCIDB)
 target_link_libraries(lsusb PRIVATE LibUSBDB)
 target_link_libraries(man PRIVATE LibMarkdown)

--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
-#include <AK/HashMap.h>
 #include <AK/LexicalPath.h>
-#include <AK/String.h>
-#include <AK/StringBuilder.h>
-#include <AK/Utf8View.h>
-#include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
+#include <LibLine/Editor.h>
 #include <LibMain/Main.h>
 #include <csignal>
-#include <ctype.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <sys/ioctl.h>
 #include <termios.h>
@@ -59,41 +52,15 @@ static ErrorOr<void> teardown_tty(bool switch_buffer)
 
 static Vector<StringView> wrap_line(String const& string, size_t width)
 {
-    Utf8View utf8(string);
-    Vector<size_t> splits;
-
-    size_t offset = 0;
-
-    bool in_ansi = false;
-    // for (auto codepoint : string) {
-    for (auto it = utf8.begin(); it != utf8.end(); ++it) {
-        if (offset >= width) {
-            splits.append(utf8.byte_offset_of(it));
-            offset = 0;
-        }
-
-        if (*it == '\e')
-            in_ansi = true;
-
-        if (!in_ansi) {
-            if (*it == '\t') {
-                // Tabs are a special case, because their width is variable.
-                offset += (8 - (offset % 8));
-            } else {
-                // FIXME: calculate the printed width of the character.
-                offset++;
-            }
-        }
-
-        if (isalpha(*it))
-            in_ansi = false;
-    }
+    auto const result = Line::Editor::actual_rendered_string_metrics(string, {}, width);
 
     Vector<StringView> spans;
     size_t span_start = 0;
-    for (auto split : splits) {
-        spans.append(string.substring_view(span_start, split - span_start));
-        span_start = split;
+    for (auto const& line_metric : result.line_metrics) {
+        VERIFY(line_metric.bit_length.has_value());
+        auto const bit_length = line_metric.bit_length.value();
+        spans.append(string.substring_view(span_start, bit_length));
+        span_start += bit_length;
     }
     spans.append(string.substring_view(span_start));
 


### PR DESCRIPTION
First draw to fix #15242.

~~Still a draft as I need to add support for masks and to remove a silly `const_cast`.~~ (I gave up on full mask support)

It works by using the LibLine's method `Editor::actual_rendered_string_length()` in `less` to computes the visible length.