### PR TITLE
Base: Make `google.com/log?` not match the logos directory in filters

### DIFF
--- a/Base/home/anon/.config/BrowserContentFilters.txt
+++ b/Base/home/anon/.config/BrowserContentFilters.txt
@@ -401,7 +401,7 @@ go-mpulse.net
 go2speed.org
 google-analytics.com
 google.com/gen_204?
-google.com/log?
+google.com/log?format
 googleadservices.com
 googleoptimize.com
 googlesyndication.com


### PR DESCRIPTION
The `?` character means to match any character instead of being a literal match for `?`, due to the use of String::matches. This should be fixed for all the entries, but this one in particular is pretty common with Google Doodles on the Google homepage.

Ref #15978