### PR TITLE
LibWeb: Apply the current transform in CRC2D.stroke()

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -226,7 +226,8 @@ void CanvasRenderingContext2D::stroke_internal(Gfx::Path const& path)
 
 void CanvasRenderingContext2D::stroke()
 {
-    stroke_internal(path());
+    auto transformed_path = path().copy_transformed(drawing_state().transform);
+    stroke_internal(transformed_path);
 }
 
 void CanvasRenderingContext2D::stroke(Path2D const& path)


### PR DESCRIPTION
This makes the Google Docs spelling and grammar squiggles appear in the correct position.

Before:
![image](https://user-images.githubusercontent.com/25595356/200642980-d4265c1f-73b3-4346-90e6-d619bd8caf81.png)


After:
![Screenshot from 2022-11-08 18-09-43](https://user-images.githubusercontent.com/25595356/200642680-e8253178-e589-4b36-a52a-54cd5b78ceba.png)
