### PR TITLE
WebContent+WebDriver: Begin moving WebDriver endpoint implementations to WebContent

### DIFF
--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -35,7 +35,8 @@ public:
 
     static ErrorOr<JsonValue> from_string(StringView);
 
-    explicit JsonValue(Type = Type::Null);
+    JsonValue() = default;
+    explicit JsonValue(Type);
     ~JsonValue() { clear(); }
 
     JsonValue(JsonValue const&);

--- a/Userland/Applications/Browser/Browser.h
+++ b/Userland/Applications/Browser/Browser.h
@@ -21,5 +21,6 @@ extern HashMap<String, size_t> g_proxy_mappings;
 extern bool g_content_filters_enabled;
 extern IconBag g_icon_bag;
 extern RefPtr<Browser::WebDriverConnection> g_web_driver_connection;
+extern String g_webdriver_content_ipc_path;
 
 }

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -126,8 +126,7 @@ Tab::Tab(BrowserWindow& window)
         m_web_content_view->set_content_filters({});
 
     m_web_content_view->set_proxy_mappings(g_proxies, g_proxy_mappings);
-
-    if (!g_web_driver_connection.is_null())
+    if (!g_webdriver_content_ipc_path.is_empty())
         enable_webdriver_mode();
 
     auto& go_back_button = toolbar.add_action(window.go_back_action());
@@ -668,7 +667,7 @@ void Tab::hide_event(GUI::HideEvent&)
 
 void Tab::enable_webdriver_mode()
 {
-    m_web_content_view->set_is_webdriver_active(true);
+    m_web_content_view->connect_to_webdriver(Browser::g_webdriver_content_ipc_path);
     auto& webdriver_banner = *find_descendant_of_type_named<GUI::Widget>("webdriver_banner");
     webdriver_banner.set_visible(true);
 }

--- a/Userland/Applications/Browser/WebDriverSessionClient.ipc
+++ b/Userland/Applications/Browser/WebDriverSessionClient.ipc
@@ -8,6 +8,9 @@
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/WebDriver/ExecuteScript.h>
 
+// FIXME: This isn't used here, but the generated IPC fails to compile without this include.
+#include <LibWeb/WebDriver/Response.h>
+
 endpoint WebDriverSessionClient {
     quit() =|
 

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -41,6 +41,7 @@ Vector<String> g_proxies;
 HashMap<String, size_t> g_proxy_mappings;
 IconBag g_icon_bag;
 RefPtr<Browser::WebDriverConnection> g_web_driver_connection;
+String g_webdriver_content_ipc_path;
 
 }
 
@@ -68,11 +69,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd unix fattr cpath rpath wpath proc exec"));
 
     Vector<String> specified_urls;
-    String webdriver_ipc_path;
+    String webdriver_browser_ipc_path;
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(specified_urls, "URLs to open", "url", Core::ArgsParser::Required::No);
-    args_parser.add_option(webdriver_ipc_path, "Path to WebDriver IPC", "webdriver", 0, "path");
+    args_parser.add_option(webdriver_browser_ipc_path, "Path to WebDriver IPC file for Browser", "webdriver-browser-path", 0, "path");
+    args_parser.add_option(Browser::g_webdriver_content_ipc_path, "Path to WebDriver IPC for WebContent", "webdriver-content-path", 0, "path");
 
     args_parser.parse(arguments);
 
@@ -87,9 +89,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_url(URL::create_with_file_scheme(Core::StandardPaths::downloads_directory())));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    if (!webdriver_ipc_path.is_empty()) {
+    if (!webdriver_browser_ipc_path.is_empty()) {
         specified_urls.empend("about:blank");
-        TRY(Core::System::unveil(webdriver_ipc_path.view(), "rw"sv));
+        TRY(Core::System::unveil(webdriver_browser_ipc_path, "rw"sv));
     }
 
     TRY(Core::System::unveil("/sys/kernel/processes", "r"));
@@ -147,13 +149,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Browser::CookieJar cookie_jar;
     auto window = Browser::BrowserWindow::construct(cookie_jar, first_url);
 
-    if (!webdriver_ipc_path.is_empty()) {
-        Browser::g_web_driver_connection = TRY(Browser::WebDriverConnection::connect_to_webdriver(window, webdriver_ipc_path));
-
-        // The first tab is created with the BrowserWindow above, so we have to do this
-        // manually once after establishing the connection.
-        window->active_tab().enable_webdriver_mode();
-    }
+    if (!webdriver_browser_ipc_path.is_empty())
+        Browser::g_web_driver_connection = TRY(Browser::WebDriverConnection::connect_to_webdriver(window, webdriver_browser_ipc_path));
 
     auto content_filters_watcher = TRY(Core::FileWatcher::create());
     content_filters_watcher->on_change = [&](Core::FileWatcherEvent const&) {

--- a/Userland/Libraries/LibCore/LocalServer.cpp
+++ b/Userland/Libraries/LibCore/LocalServer.cpp
@@ -54,7 +54,9 @@ void LocalServer::setup_notifier()
         if (on_accept) {
             auto maybe_client_socket = accept();
             if (maybe_client_socket.is_error()) {
-                dbgln("LocalServer::on_ready_to_read: Error accepting a connection: {} (FIXME: should propagate!)", maybe_client_socket.error());
+                dbgln("LocalServer::on_ready_to_read: Error accepting a connection: {}", maybe_client_socket.error());
+                if (on_accept_error)
+                    on_accept_error(maybe_client_socket.release_error());
                 return;
             }
 

--- a/Userland/Libraries/LibCore/LocalServer.h
+++ b/Userland/Libraries/LibCore/LocalServer.h
@@ -24,6 +24,7 @@ public:
     ErrorOr<NonnullOwnPtr<Stream::LocalSocket>> accept();
 
     Function<void(NonnullOwnPtr<Stream::LocalSocket>)> on_accept;
+    Function<void(Error)> on_accept_error;
 
 private:
     explicit LocalServer(Object* parent = nullptr);

--- a/Userland/Libraries/LibIPC/Decoder.cpp
+++ b/Userland/Libraries/LibIPC/Decoder.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/JsonValue.h>
 #include <AK/MemoryStream.h>
 #include <AK/URL.h>
 #include <LibCore/AnonymousBuffer.h>
@@ -126,6 +127,14 @@ ErrorOr<void> Decoder::decode(ByteBuffer& value)
 
     m_stream >> value.bytes();
     return m_stream.try_handle_any_error();
+}
+
+ErrorOr<void> Decoder::decode(JsonValue& value)
+{
+    String string;
+    TRY(decode(string));
+    value = TRY(JsonValue::from_string(string));
+    return {};
 }
 
 ErrorOr<void> Decoder::decode(URL& value)

--- a/Userland/Libraries/LibIPC/Decoder.h
+++ b/Userland/Libraries/LibIPC/Decoder.h
@@ -49,6 +49,7 @@ public:
     ErrorOr<void> decode(double&);
     ErrorOr<void> decode(String&);
     ErrorOr<void> decode(ByteBuffer&);
+    ErrorOr<void> decode(JsonValue&);
     ErrorOr<void> decode(URL&);
     ErrorOr<void> decode(Dictionary&);
     ErrorOr<void> decode(File&);

--- a/Userland/Libraries/LibIPC/Encoder.cpp
+++ b/Userland/Libraries/LibIPC/Encoder.cpp
@@ -7,6 +7,8 @@
 
 #include <AK/BitCast.h>
 #include <AK/ByteBuffer.h>
+#include <AK/JsonObject.h>
+#include <AK/JsonValue.h>
 #include <AK/String.h>
 #include <AK/URL.h>
 #include <LibCore/AnonymousBuffer.h>
@@ -156,6 +158,12 @@ Encoder& Encoder::operator<<(ByteBuffer const& value)
 {
     *this << static_cast<i32>(value.size());
     m_buffer.data.append(value.data(), value.size());
+    return *this;
+}
+
+Encoder& Encoder::operator<<(JsonValue const& value)
+{
+    *this << value.serialized<StringBuilder>();
     return *this;
 }
 

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -45,6 +45,7 @@ public:
     Encoder& operator<<(StringView);
     Encoder& operator<<(String const&);
     Encoder& operator<<(ByteBuffer const&);
+    Encoder& operator<<(JsonValue const&);
     Encoder& operator<<(URL const&);
     Encoder& operator<<(Dictionary const&);
     Encoder& operator<<(File const&);

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -440,6 +440,7 @@ set(SOURCES
     WebAssembly/WebAssemblyTablePrototype.cpp
     WebDriver/Error.cpp
     WebDriver/ExecuteScript.cpp
+    WebDriver/Response.cpp
     WebGL/WebGLContextAttributes.cpp
     WebGL/WebGLContextEvent.cpp
     WebGL/WebGLRenderingContext.cpp

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -438,6 +438,7 @@ set(SOURCES
     WebAssembly/WebAssemblyTableConstructor.cpp
     WebAssembly/WebAssemblyTableObject.cpp
     WebAssembly/WebAssemblyTablePrototype.cpp
+    WebDriver/Error.cpp
     WebDriver/ExecuteScript.cpp
     WebGL/WebGLContextAttributes.cpp
     WebGL/WebGLContextEvent.cpp

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -1329,6 +1329,8 @@ void BrowsingContext::set_system_visibility_state(VisibilityState visibility_sta
 // https://html.spec.whatwg.org/multipage/window-object.html#a-browsing-context-is-discarded
 void BrowsingContext::discard()
 {
+    m_has_been_discarded = true;
+
     // 1. Discard all Document objects for all the entries in browsingContext's session history.
     for (auto& entry : m_session_history) {
         if (entry.document)

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -243,6 +243,7 @@ public:
 
     // https://html.spec.whatwg.org/multipage/window-object.html#a-browsing-context-is-discarded
     void discard();
+    bool has_been_discarded() const { return m_has_been_discarded; }
 
     // https://html.spec.whatwg.org/multipage/window-object.html#close-a-browsing-context
     void close();
@@ -305,6 +306,8 @@ private:
     JS::GCPtr<BrowsingContext> m_last_child;
     JS::GCPtr<BrowsingContext> m_next_sibling;
     JS::GCPtr<BrowsingContext> m_previous_sibling;
+
+    bool m_has_been_discarded { false };
 };
 
 HTML::Origin determine_the_origin(BrowsingContext const& browsing_context, Optional<AK::URL> url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> invocation_origin);

--- a/Userland/Libraries/LibWeb/WebDriver/Error.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Error.cpp
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "WebDriverError.h"
 #include <AK/Vector.h>
+#include <LibWeb/WebDriver/Error.h>
 
-namespace WebDriver {
+namespace Web::WebDriver {
 
 struct ErrorCodeData {
     ErrorCode error_code;
@@ -47,7 +47,7 @@ static Vector<ErrorCodeData> const s_error_code_data = {
     { ErrorCode::UnsupportedOperation, 500, "unsupported operation" },
 };
 
-WebDriverError WebDriverError::from_code(ErrorCode code, String message, Optional<JsonValue> data)
+Error Error::from_code(ErrorCode code, String message, Optional<JsonValue> data)
 {
     auto const& error_code_data = s_error_code_data[to_underlying(code)];
     return {

--- a/Userland/Libraries/LibWeb/WebDriver/Error.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Error.h
@@ -10,7 +10,7 @@
 #include <AK/JsonValue.h>
 #include <AK/String.h>
 
-namespace WebDriver {
+namespace Web::WebDriver {
 
 // https://w3c.github.io/webdriver/#dfn-error-code
 enum class ErrorCode {
@@ -45,20 +45,20 @@ enum class ErrorCode {
 };
 
 // https://w3c.github.io/webdriver/#errors
-struct WebDriverError {
+struct Error {
     unsigned http_status;
     String error;
     String message;
     Optional<JsonValue> data;
 
-    static WebDriverError from_code(ErrorCode, String message, Optional<JsonValue> data = {});
+    static Error from_code(ErrorCode, String message, Optional<JsonValue> data = {});
 };
 
 }
 
 template<>
-struct AK::Formatter<WebDriver::WebDriverError> : Formatter<StringView> {
-    ErrorOr<void> format(FormatBuilder& builder, WebDriver::WebDriverError const& error)
+struct AK::Formatter<Web::WebDriver::Error> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::WebDriver::Error const& error)
     {
         return Formatter<StringView>::format(builder, String::formatted("Error {}, {}: {}", error.http_status, error.error, error.message));
     }

--- a/Userland/Libraries/LibWeb/WebDriver/Response.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Response.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/WebDriver/Response.h>
+
+enum class ResponseType : u8 {
+    Success,
+    Error,
+};
+
+namespace Web::WebDriver {
+
+Response::Response(JsonValue&& value)
+    : m_value_or_error(move(value))
+{
+}
+
+Response::Response(Error&& error)
+    : m_value_or_error(move(error))
+{
+}
+
+}
+
+bool IPC::encode(Encoder& encoder, Web::WebDriver::Response const& response)
+{
+    response.visit(
+        [](Empty) { VERIFY_NOT_REACHED(); },
+        [&](JsonValue const& value) {
+            encoder << ResponseType::Success;
+            encoder << value;
+        },
+        [&](Web::WebDriver::Error const& error) {
+            encoder << ResponseType::Error;
+            encoder << error.http_status;
+            encoder << error.error;
+            encoder << error.message;
+            encoder << error.data;
+        });
+
+    return true;
+}
+
+ErrorOr<void> IPC::decode(Decoder& decoder, Web::WebDriver::Response& response)
+{
+    ResponseType type {};
+    TRY(decoder.decode(type));
+
+    switch (type) {
+    case ResponseType::Success: {
+        JsonValue value;
+        TRY(decoder.decode(value));
+
+        response = move(value);
+        break;
+    }
+
+    case ResponseType::Error: {
+        Web::WebDriver::Error error {};
+        TRY(decoder.decode(error.http_status));
+        TRY(decoder.decode(error.error));
+        TRY(decoder.decode(error.message));
+        TRY(decoder.decode(error.data));
+
+        response = move(error);
+        break;
+    }
+    }
+
+    return {};
+}

--- a/Userland/Libraries/LibWeb/WebDriver/Response.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Response.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonValue.h>
+#include <AK/Variant.h>
+#include <LibIPC/Forward.h>
+#include <LibWeb/WebDriver/Error.h>
+
+namespace Web::WebDriver {
+
+// FIXME: Ideally, this could be `using Response = ErrorOr<JsonValue, Error>`, but that won't be
+//        default-constructible, which is a requirement for the generated IPC.
+struct Response {
+    Response() = default;
+    Response(JsonValue&&);
+    Response(Error&&);
+
+    JsonValue& value() { return m_value_or_error.template get<JsonValue>(); }
+    JsonValue const& value() const { return m_value_or_error.template get<JsonValue>(); }
+
+    Error& error() { return m_value_or_error.template get<Error>(); }
+    Error const& error() const { return m_value_or_error.template get<Error>(); }
+
+    bool is_error() const { return m_value_or_error.template has<Error>(); }
+
+    JsonValue release_value() { return move(value()); }
+    Error release_error() { return move(error()); }
+
+    template<typename... Visitors>
+    decltype(auto) visit(Visitors&&... visitors) const
+    {
+        return m_value_or_error.visit(forward<Visitors>(visitors)...);
+    }
+
+private:
+    // Note: Empty is only a possible state until the Response has been decoded by IPC.
+    Variant<Empty, JsonValue, Error> m_value_or_error;
+};
+
+}
+
+namespace IPC {
+
+bool encode(Encoder&, Web::WebDriver::Response const&);
+ErrorOr<void> decode(Decoder&, Web::WebDriver::Response&);
+
+}

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -595,9 +595,9 @@ void OutOfProcessWebView::set_preferred_color_scheme(Web::CSS::PreferredColorSch
     client().async_set_preferred_color_scheme(color_scheme);
 }
 
-void OutOfProcessWebView::set_is_webdriver_active(bool is_webdriver_enabled)
+void OutOfProcessWebView::connect_to_webdriver(String const& webdriver_ipc_path)
 {
-    client().async_set_is_webdriver_active(is_webdriver_enabled);
+    client().async_connect_to_webdriver(webdriver_ipc_path);
 }
 
 void OutOfProcessWebView::set_window_position(Gfx::IntPoint const& position)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -79,7 +79,7 @@ public:
     void set_content_filters(Vector<String>);
     void set_proxy_mappings(Vector<String> proxies, HashMap<String, size_t> mappings);
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
-    void set_is_webdriver_active(bool);
+    void connect_to_webdriver(String const& webdriver_ipc_path);
 
     void set_window_position(Gfx::IntPoint const&);
     void set_window_size(Gfx::IntSize const&);

--- a/Userland/Services/WebContent/CMakeLists.txt
+++ b/Userland/Services/WebContent/CMakeLists.txt
@@ -7,18 +7,24 @@ serenity_component(
 compile_ipc(WebContentServer.ipc WebContentServerEndpoint.h)
 compile_ipc(WebContentClient.ipc WebContentClientEndpoint.h)
 
+compile_ipc(WebDriverClient.ipc WebDriverClientEndpoint.h)
+compile_ipc(WebDriverServer.ipc WebDriverServerEndpoint.h)
+
 set(SOURCES
     ConnectionFromClient.cpp
     ConsoleGlobalObject.cpp
     ImageCodecPluginSerenity.cpp
     PageHost.cpp
     WebContentConsoleClient.cpp
+    WebDriverConnection.cpp
     main.cpp
 )
 
 set(GENERATED_SOURCES
     WebContentClientEndpoint.h
     WebContentServerEndpoint.h
+    WebDriverClientEndpoint.h
+    WebDriverServerEndpoint.h
 )
 
 serenity_bin(WebContent)

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -69,6 +69,15 @@ Web::Page const& ConnectionFromClient::page() const
     return m_page_host->page();
 }
 
+void ConnectionFromClient::connect_to_webdriver(String const& webdriver_ipc_path)
+{
+    // FIXME: Propogate this error back to the browser.
+    if (auto result = m_page_host->connect_to_webdriver(webdriver_ipc_path); result.is_error())
+        dbgln("Unable to connect to the WebDriver process: {}", result.error());
+    else
+        set_is_webdriver_active(true);
+}
+
 void ConnectionFromClient::update_system_theme(Core::AnonymousBuffer const& theme_buffer)
 {
     Gfx::set_system_theme(theme_buffer);

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -74,8 +74,6 @@ void ConnectionFromClient::connect_to_webdriver(String const& webdriver_ipc_path
     // FIXME: Propogate this error back to the browser.
     if (auto result = m_page_host->connect_to_webdriver(webdriver_ipc_path); result.is_error())
         dbgln("Unable to connect to the WebDriver process: {}", result.error());
-    else
-        set_is_webdriver_active(true);
 }
 
 void ConnectionFromClient::update_system_theme(Core::AnonymousBuffer const& theme_buffer)
@@ -799,11 +797,6 @@ void ConnectionFromClient::set_has_focus(bool has_focus)
 void ConnectionFromClient::set_is_scripting_enabled(bool is_scripting_enabled)
 {
     m_page_host->set_is_scripting_enabled(is_scripting_enabled);
-}
-
-void ConnectionFromClient::set_is_webdriver_active(bool is_webdriver_active)
-{
-    m_page_host->set_is_webdriver_active(is_webdriver_active);
 }
 
 void ConnectionFromClient::set_window_position(Gfx::IntPoint const& position)

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -74,7 +74,6 @@ private:
     virtual void set_preferred_color_scheme(Web::CSS::PreferredColorScheme const&) override;
     virtual void set_has_focus(bool) override;
     virtual void set_is_scripting_enabled(bool) override;
-    virtual void set_is_webdriver_active(bool) override;
     virtual void set_window_position(Gfx::IntPoint const&) override;
     virtual void set_window_size(Gfx::IntSize const&) override;
     virtual void handle_file_return(i32 error, Optional<IPC::File> const& file, i32 request_id) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -45,6 +45,7 @@ private:
     Web::Page& page();
     Web::Page const& page() const;
 
+    virtual void connect_to_webdriver(String const& webdriver_ipc_path) override;
     virtual void update_system_theme(Core::AnonymousBuffer const&) override;
     virtual void update_system_fonts(String const&, String const&, String const&) override;
     virtual void update_screen_rects(Vector<Gfx::IntRect> const&, u32) override;

--- a/Userland/Services/WebContent/Forward.h
+++ b/Userland/Services/WebContent/Forward.h
@@ -12,5 +12,6 @@ class ConnectionFromClient;
 class ConsoleGlobalObject;
 class PageHost;
 class WebContentConsoleClient;
+class WebDriverConnection;
 
 }

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Platform/Timer.h>
 #include <WebContent/WebContentClientEndpoint.h>
+#include <WebContent/WebDriverConnection.h>
 
 namespace WebContent {
 
@@ -29,6 +30,8 @@ PageHost::PageHost(ConnectionFromClient& client)
         m_invalidation_rect = {};
     });
 }
+
+PageHost::~PageHost() = default;
 
 void PageHost::set_has_focus(bool has_focus)
 {
@@ -84,6 +87,13 @@ void PageHost::set_window_position(Gfx::IntPoint const& position)
 void PageHost::set_window_size(Gfx::IntSize const& size)
 {
     page().set_window_size(size);
+}
+
+ErrorOr<void> PageHost::connect_to_webdriver(String const& webdriver_ipc_path)
+{
+    VERIFY(!m_webdriver);
+    m_webdriver = TRY(WebDriverConnection::connect(*this, webdriver_ipc_path));
+    return {};
 }
 
 Web::Layout::InitialContainingBlock* PageHost::layout_root()

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -9,6 +9,7 @@
 
 #include <LibGfx/Rect.h>
 #include <LibWeb/Page/Page.h>
+#include <WebContent/Forward.h>
 
 namespace WebContent {
 
@@ -20,7 +21,7 @@ class PageHost final : public Web::PageClient {
 
 public:
     static NonnullOwnPtr<PageHost> create(ConnectionFromClient& client) { return adopt_own(*new PageHost(client)); }
-    virtual ~PageHost() = default;
+    virtual ~PageHost();
 
     Web::Page& page() { return *m_page; }
     Web::Page const& page() const { return *m_page; }
@@ -39,6 +40,8 @@ public:
     void set_window_size(Gfx::IntSize const&);
 
     Gfx::IntSize const& content_size() const { return m_content_size; }
+
+    ErrorOr<void> connect_to_webdriver(String const& webdriver_ipc_path);
 
 private:
     // ^PageClient
@@ -90,6 +93,8 @@ private:
     RefPtr<Web::Platform::Timer> m_invalidation_coalescing_timer;
     Gfx::IntRect m_invalidation_rect;
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
+
+    RefPtr<WebDriverConnection> m_webdriver;
 };
 
 }

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -3,6 +3,9 @@
 #include <LibGfx/ShareableBitmap.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 
+// FIXME: This isn't used here, but the generated IPC fails to compile without this include.
+#include <LibWeb/WebDriver/Response.h>
+
 endpoint WebContentClient
 {
     did_start_loading(URL url) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -9,6 +9,8 @@
 
 endpoint WebContentServer
 {
+    connect_to_webdriver(String webdriver_ipc_path) =|
+
     update_system_theme(Core::AnonymousBuffer theme_buffer) =|
     update_system_fonts(String default_font_query, String fixed_width_font_query, String window_title_font_query) =|
     update_screen_rects(Vector<Gfx::IntRect> rects, u32 main_screen_index) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -71,7 +71,6 @@ endpoint WebContentServer
     set_preferred_color_scheme(Web::CSS::PreferredColorScheme color_scheme) =|
     set_has_focus(bool has_focus) =|
     set_is_scripting_enabled(bool is_scripting_enabled) =|
-    set_is_webdriver_active(bool is_webdriver_active) =|
 
     set_window_position(Gfx::IntPoint position) =|
     set_window_size(Gfx::IntSize size) =|

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -1,2 +1,3 @@
 endpoint WebDriverClient {
+    set_is_webdriver_active(bool active) =|
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -3,4 +3,5 @@
 endpoint WebDriverClient {
     set_is_webdriver_active(bool active) =|
     navigate_to(JsonValue payload) => (Web::WebDriver::Response response)
+    get_current_url() => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -1,3 +1,6 @@
+#include <LibWeb/WebDriver/Response.h>
+
 endpoint WebDriverClient {
     set_is_webdriver_active(bool active) =|
+    navigate_to(JsonValue payload) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -1,0 +1,2 @@
+endpoint WebDriverClient {
+}

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -1,6 +1,7 @@
 #include <LibWeb/WebDriver/Response.h>
 
 endpoint WebDriverClient {
+    close_session() => ()
     set_is_webdriver_active(bool active) =|
     navigate_to(JsonValue payload) => (Web::WebDriver::Response response)
     get_current_url() => (Web::WebDriver::Response response)

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022, Florent Castelli <florent.castelli@gmail.com>
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonObject.h>
+#include <AK/JsonValue.h>
+#include <AK/Vector.h>
+#include <LibWeb/HTML/BrowsingContext.h>
+#include <LibWeb/Page/Page.h>
+#include <LibWeb/Platform/Timer.h>
+#include <WebContent/PageHost.h>
+#include <WebContent/WebDriverConnection.h>
+
+namespace WebContent {
+
+ErrorOr<NonnullRefPtr<WebDriverConnection>> WebDriverConnection::connect(PageHost& page_host, String const& webdriver_ipc_path)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Trying to connect to {}", webdriver_ipc_path);
+    auto socket = TRY(Core::Stream::LocalSocket::connect(webdriver_ipc_path));
+
+    dbgln_if(WEBDRIVER_DEBUG, "Connected to WebDriver");
+    return adopt_nonnull_ref_or_enomem(new (nothrow) WebDriverConnection(move(socket), page_host));
+}
+
+WebDriverConnection::WebDriverConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, PageHost& page_host)
+    : IPC::ConnectionToServer<WebDriverClientEndpoint, WebDriverServerEndpoint>(*this, move(socket))
+    , m_page_host(page_host)
+{
+}
+
+}

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -19,6 +19,21 @@
 
 namespace WebContent {
 
+#define DRIVER_TRY(expression)                            \
+    ({                                                    \
+        auto _temporary_result = (expression);            \
+        if (_temporary_result.is_error()) [[unlikely]]    \
+            return { _temporary_result.release_error() }; \
+        _temporary_result.release_value();                \
+    })
+
+static JsonValue make_success_response(JsonValue value)
+{
+    JsonObject result;
+    result.set("value", move(value));
+    return result;
+}
+
 ErrorOr<NonnullRefPtr<WebDriverConnection>> WebDriverConnection::connect(PageHost& page_host, String const& webdriver_ipc_path)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Trying to connect to {}", webdriver_ipc_path);
@@ -37,6 +52,47 @@ WebDriverConnection::WebDriverConnection(NonnullOwnPtr<Core::Stream::LocalSocket
 void WebDriverConnection::set_is_webdriver_active(bool is_webdriver_active)
 {
     m_page_host.set_is_webdriver_active(is_webdriver_active);
+}
+
+// 10.1 Navigate To, https://w3c.github.io/webdriver/#navigate-to
+Messages::WebDriverClient::NavigateToResponse WebDriverConnection::navigate_to(JsonValue const& payload)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection::navigate_to {}", payload);
+
+    // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
+    DRIVER_TRY(ensure_open_top_level_browsing_context());
+
+    // 2. Let url be the result of getting the property url from the parameters argument.
+    if (!payload.is_object() || !payload.as_object().has_string("url"sv))
+        return { Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload doesn't have a string `url`"sv) };
+    URL url(payload.as_object().get_ptr("url"sv)->as_string());
+
+    // FIXME: 3. If url is not an absolute URL or is not an absolute URL with fragment or not a local scheme, return error with error code invalid argument.
+    // FIXME: 4. Handle any user prompts and return its value if it is an error.
+    // FIXME: 5. Let current URL be the current top-level browsing context’s active document’s URL.
+    // FIXME: 6. If current URL and url do not have the same absolute URL:
+    // FIXME:     a. If timer has not been started, start a timer. If this algorithm has not completed before timer reaches the session’s session page load timeout in milliseconds, return an error with error code timeout.
+
+    // 7. Navigate the current top-level browsing context to url.
+    m_page_host.page().load(url);
+
+    // FIXME: 8. If url is special except for file and current URL and URL do not have the same absolute URL:
+    // FIXME:     a. Try to wait for navigation to complete.
+    // FIXME:     b. Try to run the post-navigation checks.
+    // FIXME: 9. Set the current browsing context with the current top-level browsing context.
+    // FIXME: 10. If the current top-level browsing context contains a refresh state pragma directive of time 1 second or less, wait until the refresh timeout has elapsed, a new navigate has begun, and return to the first step of this algorithm.
+
+    // 11. Return success with data null.
+    return { make_success_response({}) };
+}
+
+// https://w3c.github.io/webdriver/#dfn-no-longer-open
+ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::ensure_open_top_level_browsing_context()
+{
+    // A browsing context is said to be no longer open if it has been discarded.
+    if (m_page_host.page().top_level_browsing_context().has_been_discarded())
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchWindow, "Window not found"sv);
+    return {};
 }
 
 }

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -50,6 +50,16 @@ WebDriverConnection::WebDriverConnection(NonnullOwnPtr<Core::Stream::LocalSocket
 {
 }
 
+// https://w3c.github.io/webdriver/#dfn-close-the-session
+void WebDriverConnection::close_session()
+{
+    // 1. Set the webdriver-active flag to false.
+    set_is_webdriver_active(false);
+
+    // 2. An endpoint node must close any top-level browsing contexts associated with the session, without prompting to unload.
+    m_page_host.page().top_level_browsing_context().close();
+}
+
 void WebDriverConnection::set_is_webdriver_active(bool is_webdriver_active)
 {
     m_page_host.set_is_webdriver_active(is_webdriver_active);

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -34,4 +34,9 @@ WebDriverConnection::WebDriverConnection(NonnullOwnPtr<Core::Stream::LocalSocket
 {
 }
 
+void WebDriverConnection::set_is_webdriver_active(bool is_webdriver_active)
+{
+    m_page_host.set_is_webdriver_active(is_webdriver_active);
+}
+
 }

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -11,6 +11,7 @@
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
 #include <AK/Vector.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Platform/Timer.h>
@@ -84,6 +85,23 @@ Messages::WebDriverClient::NavigateToResponse WebDriverConnection::navigate_to(J
 
     // 11. Return success with data null.
     return { make_success_response({}) };
+}
+
+// 10.2 Get Current URL, https://w3c.github.io/webdriver/#get-current-url
+Messages::WebDriverClient::GetCurrentUrlResponse WebDriverConnection::get_current_url()
+{
+    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection::get_current_url");
+
+    // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
+    DRIVER_TRY(ensure_open_top_level_browsing_context());
+
+    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+
+    // 3. Let url be the serialization of the current top-level browsing context’s active document’s document URL.
+    auto url = m_page_host.page().top_level_browsing_context().active_document()->url().to_string();
+
+    // 4. Return success with data url.
+    return { make_success_response(url) };
 }
 
 // https://w3c.github.io/webdriver/#dfn-no-longer-open

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -28,6 +28,7 @@ private:
     WebDriverConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, PageHost& page_host);
 
     virtual void die() override { }
+    virtual void set_is_webdriver_active(bool) override;
 
     PageHost& m_page_host;
 };

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -30,6 +30,7 @@ private:
     virtual void die() override { }
     virtual void set_is_webdriver_active(bool) override;
     virtual Messages::WebDriverClient::NavigateToResponse navigate_to(JsonValue const& payload) override;
+    virtual Messages::WebDriverClient::GetCurrentUrlResponse get_current_url() override;
 
     ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();
 

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Florent Castelli <florent.castelli@gmail.com>
+ * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibIPC/ConnectionToServer.h>
+#include <LibWeb/WebDriver/Response.h>
+#include <WebContent/Forward.h>
+#include <WebContent/WebDriverClientEndpoint.h>
+#include <WebContent/WebDriverServerEndpoint.h>
+
+namespace WebContent {
+
+class WebDriverConnection final
+    : public IPC::ConnectionToServer<WebDriverClientEndpoint, WebDriverServerEndpoint> {
+    C_OBJECT_ABSTRACT(WebDriverConnection)
+
+public:
+    static ErrorOr<NonnullRefPtr<WebDriverConnection>> connect(PageHost& page_host, String const& webdriver_ipc_path);
+    virtual ~WebDriverConnection() = default;
+
+private:
+    WebDriverConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, PageHost& page_host);
+
+    virtual void die() override { }
+
+    PageHost& m_page_host;
+};
+
+}

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -28,6 +28,8 @@ private:
     WebDriverConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, PageHost& page_host);
 
     virtual void die() override { }
+
+    virtual void close_session() override;
     virtual void set_is_webdriver_active(bool) override;
     virtual Messages::WebDriverClient::NavigateToResponse navigate_to(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::GetCurrentUrlResponse get_current_url() override;

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -29,6 +29,9 @@ private:
 
     virtual void die() override { }
     virtual void set_is_webdriver_active(bool) override;
+    virtual Messages::WebDriverClient::NavigateToResponse navigate_to(JsonValue const& payload) override;
+
+    ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();
 
     PageHost& m_page_host;
 };

--- a/Userland/Services/WebContent/WebDriverServer.ipc
+++ b/Userland/Services/WebContent/WebDriverServer.ipc
@@ -1,0 +1,2 @@
+endpoint WebDriverServer {
+}

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -7,6 +7,7 @@
 #include "ImageCodecPluginSerenity.h"
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
+#include <LibCore/Stream.h>
 #include <LibCore/System.h>
 #include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
@@ -23,6 +24,11 @@ ErrorOr<int> serenity_main(Main::Arguments)
 {
     Core::EventLoop event_loop;
     TRY(Core::System::pledge("stdio recvfd sendfd accept unix rpath"));
+
+    // This must be first; we can't check if /tmp/webdriver exists once we've unveiled other paths.
+    if (Core::Stream::File::exists("/tmp/webdriver"sv))
+        TRY(Core::System::unveil("/tmp/webdriver", "rw"));
+
     TRY(Core::System::unveil("/sys/kernel/processes", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/etc/timezone", "r"));

--- a/Userland/Services/WebDriver/CMakeLists.txt
+++ b/Userland/Services/WebDriver/CMakeLists.txt
@@ -1,6 +1,7 @@
 serenity_component(
     WebDriver
     TARGETS WebDriver
+    DEPENDS WebContent
 )
 
 set(SOURCES
@@ -8,12 +9,15 @@ set(SOURCES
     Client.cpp
     Session.cpp
     TimeoutsConfiguration.cpp
+    WebContentConnection.cpp
     main.cpp
 )
 
 set(GENERATED_SOURCES
     ../../Applications/Browser/WebDriverSessionClientEndpoint.h
     ../../Applications/Browser/WebDriverSessionServerEndpoint.h
+    ../../Services/WebContent/WebDriverClientEndpoint.h
+    ../../Services/WebContent/WebDriverServerEndpoint.h
 )
 
 serenity_bin(WebDriver)

--- a/Userland/Services/WebDriver/CMakeLists.txt
+++ b/Userland/Services/WebDriver/CMakeLists.txt
@@ -8,14 +8,13 @@ set(SOURCES
     Client.cpp
     Session.cpp
     TimeoutsConfiguration.cpp
-    WebDriverError.cpp
     main.cpp
-    )
+)
 
 set(GENERATED_SOURCES
     ../../Applications/Browser/WebDriverSessionClientEndpoint.h
     ../../Applications/Browser/WebDriverSessionServerEndpoint.h
-    )
+)
 
 serenity_bin(WebDriver)
 target_link_libraries(WebDriver PRIVATE LibCore LibHTTP LibMain LibIPC LibWeb LibGfx)

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -385,6 +385,8 @@ Web::WebDriver::Response Client::handle_new_session(Vector<StringView> const&, J
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::SessionNotCreated, String::formatted("Failed to start session: {}", start_result.error().string_literal()));
     }
 
+    auto& web_content_connection = session->web_content_connection();
+
     // FIXME: 8. Set the current session to session.
 
     // FIXME: 9. Run any WebDriver new session algorithm defined in external specifications,
@@ -405,7 +407,8 @@ Web::WebDriver::Response Client::handle_new_session(Vector<StringView> const&, J
     // FIXME: 12. Initialize the following from capabilities:
     //            NOTE: See spec for steps
 
-    // FIXME: 13. Set the webdriver-active flag to true.
+    // 13. Set the webdriver-active flag to true.
+    web_content_connection.async_set_is_webdriver_active(true);
 
     // FIXME: 14. Set the current top-level browsing context for session with the top-level browsing context
     //            of the UA’s current browsing context.

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -352,7 +352,7 @@ JsonValue Client::make_json_value(JsonValue const& value)
 
 // 8.1 New Session, https://w3c.github.io/webdriver/#dfn-new-sessions
 // POST /session
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_new_session(Vector<StringView> const&, JsonValue const&)
+Web::WebDriver::Response Client::handle_new_session(Vector<StringView> const&, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session");
 
@@ -418,7 +418,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_new_session(Vector<Stri
 
 // 8.2 Delete Session, https://w3c.github.io/webdriver/#dfn-delete-session
 // DELETE /session/{session id}
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_delete_session(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_delete_session(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling DELETE /session/<session_id>");
 
@@ -435,7 +435,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_delete_session(Vector<S
 
 // 8.3 Status, https://w3c.github.io/webdriver/#dfn-status
 // GET /status
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_status(Vector<StringView> const&, JsonValue const&)
+Web::WebDriver::Response Client::handle_get_status(Vector<StringView> const&, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /status");
 
@@ -450,12 +450,12 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_status(Vector<Strin
     body.set("message", "Ready to start some sessions!");
 
     // 2. Return success with data body.
-    return body;
+    return JsonValue { body };
 }
 
 // 9.1 Get Timeouts, https://w3c.github.io/webdriver/#dfn-get-timeouts
 // GET /session/{session id}/timeouts
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_timeouts(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_get_timeouts(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session id>/timeouts");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -465,7 +465,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_timeouts(Vector<Str
 
 // 9.2 Set Timeouts, https://w3c.github.io/webdriver/#dfn-set-timeouts
 // POST /session/{session id}/timeouts
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_set_timeouts(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_set_timeouts(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session id>/timeouts");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -475,7 +475,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_set_timeouts(Vector<Str
 
 // 10.1 Navigate To, https://w3c.github.io/webdriver/#dfn-navigate-to
 // POST /session/{session id}/url
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_navigate_to(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_navigate_to(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/url");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -485,7 +485,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_navigate_to(Vector<Stri
 
 // 10.2 Get Current URL, https://w3c.github.io/webdriver/#dfn-get-current-url
 // GET /session/{session id}/url
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_current_url(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_get_current_url(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/url");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -495,7 +495,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_current_url(Vector<
 
 // 10.3 Back, https://w3c.github.io/webdriver/#dfn-back
 // POST /session/{session id}/back
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_back(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_back(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/back");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -505,7 +505,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_back(Vector<StringView>
 
 // 10.4 Forward, https://w3c.github.io/webdriver/#dfn-forward
 // POST /session/{session id}/forward
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_forward(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_forward(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/forward");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -515,7 +515,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_forward(Vector<StringVi
 
 // 10.5 Refresh, https://w3c.github.io/webdriver/#dfn-refresh
 // POST /session/{session id}/refresh
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_refresh(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_refresh(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/refresh");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -525,7 +525,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_refresh(Vector<StringVi
 
 // 10.6 Get Title, https://w3c.github.io/webdriver/#dfn-get-title
 // GET /session/{session id}/title
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_title(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_get_title(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/title");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -535,7 +535,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_title(Vector<String
 
 // 11.1 Get Window Handle, https://w3c.github.io/webdriver/#get-window-handle
 // GET /session/{session id}/window
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_window_handle(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_get_window_handle(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/window");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -545,7 +545,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_window_handle(Vecto
 
 // 11.2 Close Window, https://w3c.github.io/webdriver/#dfn-close-window
 // DELETE /session/{session id}/window
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_close_window(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_close_window(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling DELETE /session/<session_id>/window");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -555,7 +555,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_close_window(Vector<Str
 
 // 11.4 Get Window Handles, https://w3c.github.io/webdriver/#dfn-get-window-handles
 // GET /session/{session id}/window/handles
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_window_handles(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_get_window_handles(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/window/handles");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -565,7 +565,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_window_handles(Vect
 
 // 11.8.1 Get Window Rect, https://w3c.github.io/webdriver/#dfn-get-window-rect
 // GET /session/{session id}/window/rect
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_window_rect(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_get_window_rect(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/window/rect");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -575,7 +575,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_window_rect(Vector<
 
 // 11.8.2 Set Window Rect, https://w3c.github.io/webdriver/#dfn-set-window-rect
 // POST /session/{session id}/window/rect
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_set_window_rect(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_set_window_rect(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/window/rect");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -585,7 +585,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_set_window_rect(Vector<
 
 // 11.8.3 Maximize Window, https://w3c.github.io/webdriver/#dfn-maximize-window
 // POST /session/{session id}/window/maximize
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_maximize_window(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_maximize_window(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/window/maximize");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -595,7 +595,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_maximize_window(Vector<
 
 // 11.8.4 Minimize Window, https://w3c.github.io/webdriver/#minimize-window
 // POST /session/{session id}/window/minimize
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_minimize_window(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_minimize_window(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/window/minimize");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -605,7 +605,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_minimize_window(Vector<
 
 // 12.3.2 Find Element, https://w3c.github.io/webdriver/#dfn-find-element
 // POST /session/{session id}/element
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_find_element(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_find_element(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/element");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -615,7 +615,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_find_element(Vector<Str
 
 // 12.3.3 Find Elements, https://w3c.github.io/webdriver/#dfn-find-elements
 // POST /session/{session id}/elements
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_find_elements(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_find_elements(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/elements");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -625,7 +625,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_find_elements(Vector<St
 
 // 12.3.4 Find Element From Element, https://w3c.github.io/webdriver/#dfn-find-element-from-element
 // POST /session/{session id}/element/{element id}/element
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_find_element_from_element(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_find_element_from_element(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/element/<element_id>/element");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -635,7 +635,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_find_element_from_eleme
 
 // 12.3.5 Find Elements From Element, https://w3c.github.io/webdriver/#dfn-find-elements-from-element
 // POST /session/{session id}/element/{element id}/elements
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_find_elements_from_element(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_find_elements_from_element(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/element/<element_id>/elements");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -645,7 +645,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_find_elements_from_elem
 
 // 12.4.1 Is Element Selected, https://w3c.github.io/webdriver/#dfn-is-element-selected
 // GET /session/{session id}/element/{element id}/selected
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_is_element_selected(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_is_element_selected(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/selected");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -655,7 +655,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_is_element_selected(Vec
 
 // 12.4.2 Get Element Attribute, https://w3c.github.io/webdriver/#dfn-get-element-attribute
 // GET /session/{session id}/element/{element id}/attribute/{name}
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_element_attribute(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_get_element_attribute(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/attribute/<name>");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -665,7 +665,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_element_attribute(V
 
 // 12.4.3 Get Element Property, https://w3c.github.io/webdriver/#dfn-get-element-property
 // GET /session/{session id}/element/{element id}/property/{name}
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_element_property(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_get_element_property(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/property/<name>");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -675,7 +675,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_element_property(Ve
 
 // 12.4.4 Get Element CSS Value, https://w3c.github.io/webdriver/#dfn-get-element-css-value
 // GET /session/{session id}/element/{element id}/css/{property name}
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_element_css_value(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_get_element_css_value(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/css/<property_name>");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -685,7 +685,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_element_css_value(V
 
 // 12.4.5 Get Element Text, https://w3c.github.io/webdriver/#dfn-get-element-text
 // GET /session/{session id}/element/{element id}/text
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_element_text(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_get_element_text(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/text");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -695,7 +695,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_element_text(Vector
 
 // 12.4.6 Get Element Tag Name, https://w3c.github.io/webdriver/#dfn-get-element-tag-name
 // GET /session/{session id}/element/{element id}/name
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_element_tag_name(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_get_element_tag_name(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/name");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -705,7 +705,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_element_tag_name(Ve
 
 // 12.4.7 Get Element Rect, https://w3c.github.io/webdriver/#dfn-get-element-rect
 // GET /session/{session id}/element/{element id}/rect
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_element_rect(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_get_element_rect(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/rect");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -715,7 +715,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_element_rect(Vector
 
 // 12.4.8 Is Element Enabled, https://w3c.github.io/webdriver/#dfn-is-element-enabled
 // GET /session/{session id}/element/{element id}/enabled
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_is_element_enabled(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_is_element_enabled(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/enabled");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -725,7 +725,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_is_element_enabled(Vect
 
 // 13.1 Get Page Source, https://w3c.github.io/webdriver/#dfn-get-page-source
 // GET /session/{session id}/source
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_source(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_get_source(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/source");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -735,7 +735,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_source(Vector<Strin
 
 // 13.2.1 Execute Script, https://w3c.github.io/webdriver/#dfn-execute-script
 // POST /session/{session id}/execute/sync
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_execute_script(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_execute_script(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/execute/sync");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -745,7 +745,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_execute_script(Vector<S
 
 // 13.2.2 Execute Async Script, https://w3c.github.io/webdriver/#dfn-execute-async-script
 // POST /session/{session id}/execute/async
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_execute_async_script(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_execute_async_script(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/execute/async");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -755,7 +755,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_execute_async_script(Ve
 
 // 14.1 Get All Cookies, https://w3c.github.io/webdriver/#dfn-get-all-cookies
 // GET /session/{session id}/cookie
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_all_cookies(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_get_all_cookies(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/cookie");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -765,7 +765,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_all_cookies(Vector<
 
 // 14.2 Get Named Cookie, https://w3c.github.io/webdriver/#dfn-get-named-cookie
 // GET /session/{session id}/cookie/{name}
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_named_cookie(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_get_named_cookie(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/cookie/<name>");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -775,7 +775,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_get_named_cookie(Vector
 
 // 14.3 Add Cookie, https://w3c.github.io/webdriver/#dfn-adding-a-cookie
 // POST /session/{session id}/cookie
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_add_cookie(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_add_cookie(Vector<StringView> const& parameters, JsonValue const& payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/cookie");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -785,7 +785,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_add_cookie(Vector<Strin
 
 // 14.4 Delete Cookie, https://w3c.github.io/webdriver/#dfn-delete-cookie
 // DELETE /session/{session id}/cookie/{name}
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_delete_cookie(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_delete_cookie(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling DELETE /session/<session_id>/cookie/<name>");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -795,7 +795,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_delete_cookie(Vector<St
 
 // 14.5 Delete All Cookies, https://w3c.github.io/webdriver/#dfn-delete-all-cookies
 // DELETE /session/{session id}/cookie
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_delete_all_cookies(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_delete_all_cookies(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling DELETE /session/<session_id>/cookie");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -805,7 +805,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_delete_all_cookies(Vect
 
 // 17.1 Take Screenshot, https://w3c.github.io/webdriver/#take-screenshot
 // GET /session/{session id}/screenshot
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_take_screenshot(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_take_screenshot(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/screenshot");
     auto* session = TRY(find_session_with_id(parameters[0]));
@@ -815,7 +815,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_take_screenshot(Vector<
 
 // 17.2 Take Element Screenshot, https://w3c.github.io/webdriver/#dfn-take-element-screenshot
 // GET /session/{session id}/element/{element id}/screenshot
-ErrorOr<JsonValue, Web::WebDriver::Error> Client::handle_take_element_screenshot(Vector<StringView> const& parameters, JsonValue const&)
+Web::WebDriver::Response Client::handle_take_element_screenshot(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/screenshot");
     auto* session = TRY(find_session_with_id(parameters[0]));

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -482,8 +482,7 @@ Web::WebDriver::Response Client::handle_navigate_to(Vector<StringView> const& pa
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/url");
     auto* session = TRY(find_session_with_id(parameters[0]));
-    auto result = TRY(session->navigate_to(payload));
-    return make_json_value(result);
+    return session->web_content_connection().navigate_to(payload);
 }
 
 // 10.2 Get Current URL, https://w3c.github.io/webdriver/#dfn-get-current-url

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -491,8 +491,7 @@ Web::WebDriver::Response Client::handle_get_current_url(Vector<StringView> const
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/url");
     auto* session = TRY(find_session_with_id(parameters[0]));
-    auto result = TRY(session->get_current_url());
-    return make_json_value(result);
+    return session->web_content_connection().get_current_url();
 }
 
 // 10.3 Back, https://w3c.github.io/webdriver/#dfn-back

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -14,6 +14,7 @@
 #include <LibHTTP/Forward.h>
 #include <LibHTTP/HttpRequest.h>
 #include <LibWeb/WebDriver/Error.h>
+#include <LibWeb/WebDriver/Response.h>
 #include <WebDriver/Session.h>
 
 namespace WebDriver {
@@ -35,7 +36,7 @@ private:
     void die();
     void log_response(unsigned code, HTTP::HttpRequest const&);
 
-    using RouteHandler = ErrorOr<JsonValue, Web::WebDriver::Error> (Client::*)(Vector<StringView> const&, JsonValue const&);
+    using RouteHandler = Web::WebDriver::Response (Client::*)(Vector<StringView> const&, JsonValue const&);
     struct Route {
         HTTP::HttpRequest::Method method;
         Vector<String> path;
@@ -48,46 +49,46 @@ private:
     };
 
     ErrorOr<RoutingResult, Web::WebDriver::Error> match_route(HTTP::HttpRequest::Method method, String const& resource);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_new_session(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_delete_session(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_status(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_timeouts(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_set_timeouts(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_navigate_to(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_current_url(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_back(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_forward(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_refresh(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_title(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_window_handle(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_close_window(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_window_handles(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_window_rect(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_set_window_rect(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_maximize_window(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_minimize_window(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_find_element(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_find_elements(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_find_element_from_element(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_find_elements_from_element(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_is_element_selected(Vector<StringView> const& parameters, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_element_attribute(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_element_property(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_element_css_value(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_element_text(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_element_tag_name(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_element_rect(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_is_element_enabled(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_source(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_execute_script(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_execute_async_script(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_all_cookies(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_named_cookie(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_add_cookie(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_delete_cookie(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_delete_all_cookies(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_take_screenshot(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> handle_take_element_screenshot(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_new_session(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_delete_session(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_status(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_timeouts(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_set_timeouts(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_navigate_to(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_current_url(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_back(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_forward(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_refresh(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_title(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_window_handle(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_close_window(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_window_handles(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_window_rect(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_set_window_rect(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_maximize_window(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_minimize_window(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_find_element(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_find_elements(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_find_element_from_element(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_find_elements_from_element(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_is_element_selected(Vector<StringView> const& parameters, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_element_attribute(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_element_property(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_element_css_value(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_element_text(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_element_tag_name(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_element_rect(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_is_element_enabled(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_source(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_execute_script(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_execute_async_script(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_all_cookies(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_get_named_cookie(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_add_cookie(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_delete_cookie(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_delete_all_cookies(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_take_screenshot(Vector<StringView> const&, JsonValue const& payload);
+    Web::WebDriver::Response handle_take_element_screenshot(Vector<StringView> const&, JsonValue const& payload);
 
     ErrorOr<Session*, Web::WebDriver::Error> find_session_with_id(StringView session_id);
     JsonValue make_json_value(JsonValue const&);

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -13,8 +13,8 @@
 #include <LibCore/Stream.h>
 #include <LibHTTP/Forward.h>
 #include <LibHTTP/HttpRequest.h>
+#include <LibWeb/WebDriver/Error.h>
 #include <WebDriver/Session.h>
-#include <WebDriver/WebDriverError.h>
 
 namespace WebDriver {
 
@@ -31,11 +31,11 @@ private:
     ErrorOr<JsonValue> read_body_as_json(HTTP::HttpRequest const&);
     ErrorOr<bool> handle_request(HTTP::HttpRequest const&, JsonValue const& body);
     ErrorOr<void> send_response(StringView content, HTTP::HttpRequest const&);
-    ErrorOr<void> send_error_response(WebDriverError const& error, HTTP::HttpRequest const&);
+    ErrorOr<void> send_error_response(Web::WebDriver::Error const& error, HTTP::HttpRequest const&);
     void die();
     void log_response(unsigned code, HTTP::HttpRequest const&);
 
-    using RouteHandler = ErrorOr<JsonValue, WebDriverError> (Client::*)(Vector<StringView> const&, JsonValue const&);
+    using RouteHandler = ErrorOr<JsonValue, Web::WebDriver::Error> (Client::*)(Vector<StringView> const&, JsonValue const&);
     struct Route {
         HTTP::HttpRequest::Method method;
         Vector<String> path;
@@ -47,70 +47,70 @@ private:
         Vector<StringView> parameters;
     };
 
-    ErrorOr<RoutingResult, WebDriverError> match_route(HTTP::HttpRequest::Method method, String const& resource);
-    ErrorOr<JsonValue, WebDriverError> handle_new_session(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_delete_session(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_status(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_timeouts(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_set_timeouts(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_navigate_to(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_current_url(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_back(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_forward(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_refresh(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_title(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_window_handle(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_close_window(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_window_handles(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_window_rect(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_set_window_rect(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_maximize_window(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_minimize_window(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_find_element(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_find_elements(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_find_element_from_element(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_find_elements_from_element(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_is_element_selected(Vector<StringView> const& parameters, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_element_attribute(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_element_property(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_element_css_value(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_element_text(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_element_tag_name(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_element_rect(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_is_element_enabled(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_source(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_execute_script(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_execute_async_script(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_all_cookies(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_get_named_cookie(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_add_cookie(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_delete_cookie(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_delete_all_cookies(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_take_screenshot(Vector<StringView> const&, JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> handle_take_element_screenshot(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<RoutingResult, Web::WebDriver::Error> match_route(HTTP::HttpRequest::Method method, String const& resource);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_new_session(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_delete_session(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_status(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_timeouts(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_set_timeouts(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_navigate_to(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_current_url(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_back(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_forward(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_refresh(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_title(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_window_handle(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_close_window(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_window_handles(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_window_rect(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_set_window_rect(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_maximize_window(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_minimize_window(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_find_element(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_find_elements(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_find_element_from_element(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_find_elements_from_element(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_is_element_selected(Vector<StringView> const& parameters, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_element_attribute(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_element_property(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_element_css_value(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_element_text(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_element_tag_name(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_element_rect(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_is_element_enabled(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_source(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_execute_script(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_execute_async_script(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_all_cookies(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_get_named_cookie(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_add_cookie(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_delete_cookie(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_delete_all_cookies(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_take_screenshot(Vector<StringView> const&, JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> handle_take_element_screenshot(Vector<StringView> const&, JsonValue const& payload);
 
-    ErrorOr<Session*, WebDriverError> find_session_with_id(StringView session_id);
+    ErrorOr<Session*, Web::WebDriver::Error> find_session_with_id(StringView session_id);
     JsonValue make_json_value(JsonValue const&);
 
     template<typename T>
-    static ErrorOr<T, WebDriverError> unwrap_result(ErrorOr<T, Variant<WebDriverError, Error>> result)
+    static ErrorOr<T, Web::WebDriver::Error> unwrap_result(ErrorOr<T, Variant<Web::WebDriver::Error, Error>> result)
     {
         if (result.is_error()) {
-            Variant<WebDriverError, Error> error = result.release_error();
-            if (error.has<WebDriverError>())
-                return error.get<WebDriverError>();
-            return WebDriverError::from_code(ErrorCode::UnsupportedOperation, error.get<Error>().string_literal());
+            Variant<Web::WebDriver::Error, Error> error = result.release_error();
+            if (error.has<Web::WebDriver::Error>())
+                return error.get<Web::WebDriver::Error>();
+            return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnsupportedOperation, error.get<Error>().string_literal());
         }
 
         return result.release_value();
     }
-    static ErrorOr<void, WebDriverError> unwrap_result(ErrorOr<void, Variant<WebDriverError, Error>> result)
+    static ErrorOr<void, Web::WebDriver::Error> unwrap_result(ErrorOr<void, Variant<Web::WebDriver::Error, Error>> result)
     {
         if (result.is_error()) {
-            Variant<WebDriverError, Error> error = result.release_error();
-            if (error.has<WebDriverError>())
-                return error.get<WebDriverError>();
-            return WebDriverError::from_code(ErrorCode::UnsupportedOperation, error.get<Error>().string_literal());
+            Variant<Web::WebDriver::Error, Error> error = result.release_error();
+            if (error.has<Web::WebDriver::Error>())
+                return error.get<Web::WebDriver::Error>();
+            return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnsupportedOperation, error.get<Error>().string_literal());
         }
         return {};
     }

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -91,6 +91,7 @@ private:
     Web::WebDriver::Response handle_take_element_screenshot(Vector<StringView> const&, JsonValue const& payload);
 
     ErrorOr<Session*, Web::WebDriver::Error> find_session_with_id(StringView session_id);
+    ErrorOr<NonnullOwnPtr<Session>, Web::WebDriver::Error> take_session_with_id(StringView session_id);
     JsonValue make_json_value(JsonValue const&);
 
     template<typename T>

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -165,21 +165,6 @@ Web::WebDriver::Response Session::set_timeouts(JsonValue const& payload)
     return JsonValue {};
 }
 
-// 10.2 Get Current URL, https://w3c.github.io/webdriver/#dfn-get-current-url
-Web::WebDriver::Response Session::get_current_url()
-{
-    // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
-    TRY(check_for_open_top_level_browsing_context_or_return_error());
-
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
-
-    // 3. Let url be the serialization of the current top-level browsing context’s active document’s document URL.
-    auto url = m_browser_connection->get_url().to_string();
-
-    // 4. Return success with data url.
-    return JsonValue(url);
-}
-
 // 10.3 Back, https://w3c.github.io/webdriver/#dfn-back
 Web::WebDriver::Response Session::back()
 {

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -136,10 +136,23 @@ ErrorOr<void> Session::start()
     return {};
 }
 
-ErrorOr<void> Session::stop()
+// https://w3c.github.io/webdriver/#dfn-close-the-session
+Web::WebDriver::Response Session::stop()
 {
+    // 1. Perform the following substeps based on the remote end’s type:
+    // NOTE: We perform the "Remote end is an endpoint node" steps in the WebContent process.
+    m_web_content_connection->close_session();
+    m_web_content_connection = nullptr;
+
+    // 2. Remove the current session from active sessions.
+    // NOTE: Handled by WebDriver::Client.
+
+    // 3. Perform any implementation-specific cleanup steps.
     m_browser_connection->async_quit();
-    return {};
+    m_started = false;
+
+    // 4. If an error has occurred in any of the steps above, return the error, otherwise return success with data null.
+    return JsonValue {};
 }
 
 // 9.1 Get Timeouts, https://w3c.github.io/webdriver/#dfn-get-timeouts

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -107,7 +107,7 @@ JsonObject Session::get_timeouts()
 }
 
 // 9.2 Set Timeouts, https://w3c.github.io/webdriver/#dfn-set-timeouts
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::set_timeouts(JsonValue const& payload)
+Web::WebDriver::Response Session::set_timeouts(JsonValue const& payload)
 {
     // 1. Let timeouts be the result of trying to JSON deserialize as a timeouts configuration the request’s parameters.
     auto timeouts = TRY(json_deserialize_as_a_timeouts_configuration(payload));
@@ -120,7 +120,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::set_timeouts(JsonValue const&
 }
 
 // 10.1 Navigate To, https://w3c.github.io/webdriver/#dfn-navigate-to
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::navigate_to(JsonValue const& payload)
+Web::WebDriver::Response Session::navigate_to(JsonValue const& payload)
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -154,7 +154,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::navigate_to(JsonValue const& 
 }
 
 // 10.2 Get Current URL, https://w3c.github.io/webdriver/#dfn-get-current-url
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_current_url()
+Web::WebDriver::Response Session::get_current_url()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -169,7 +169,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_current_url()
 }
 
 // 10.3 Back, https://w3c.github.io/webdriver/#dfn-back
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::back()
+Web::WebDriver::Response Session::back()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -190,7 +190,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::back()
 }
 
 // 10.4 Forward, https://w3c.github.io/webdriver/#dfn-forward
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::forward()
+Web::WebDriver::Response Session::forward()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -211,7 +211,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::forward()
 }
 
 // 10.5 Refresh, https://w3c.github.io/webdriver/#dfn-refresh
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::refresh()
+Web::WebDriver::Response Session::refresh()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -234,7 +234,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::refresh()
 }
 
 // 10.6 Get Title, https://w3c.github.io/webdriver/#dfn-get-title
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_title()
+Web::WebDriver::Response Session::get_title()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -247,13 +247,13 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_title()
 }
 
 // 11.1 Get Window Handle, https://w3c.github.io/webdriver/#get-window-handle
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_window_handle()
+Web::WebDriver::Response Session::get_window_handle()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
 
     // 2. Return success with data being the window handle associated with the current top-level browsing context.
-    return m_current_window_handle;
+    return JsonValue { m_current_window_handle };
 }
 
 // 11.2 Close Window, https://w3c.github.io/webdriver/#dfn-close-window
@@ -277,7 +277,7 @@ ErrorOr<void, Variant<Web::WebDriver::Error, Error>> Session::close_window()
 }
 
 // 11.4 Get Window Handles, https://w3c.github.io/webdriver/#dfn-get-window-handles
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_window_handles() const
+Web::WebDriver::Response Session::get_window_handles() const
 {
     // 1. Let handles be a JSON List.
     auto handles = JsonArray {};
@@ -287,10 +287,10 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_window_handles() const
         handles.append(window_handle);
 
     // 3. Return success with data handles.
-    return handles;
+    return JsonValue { handles };
 }
 
-static JsonObject serialize_rect(Gfx::IntRect const& rect)
+static JsonValue serialize_rect(Gfx::IntRect const& rect)
 {
     JsonObject serialized_rect = {};
     serialized_rect.set("x", rect.x());
@@ -302,7 +302,7 @@ static JsonObject serialize_rect(Gfx::IntRect const& rect)
 }
 
 // 11.8.1 Get Window Rect, https://w3c.github.io/webdriver/#dfn-get-window-rect
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_window_rect()
+Web::WebDriver::Response Session::get_window_rect()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -314,7 +314,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_window_rect()
 }
 
 // 11.8.2 Set Window Rect, https://w3c.github.io/webdriver/#dfn-set-window-rect
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::set_window_rect(JsonValue const& payload)
+Web::WebDriver::Response Session::set_window_rect(JsonValue const& payload)
 {
     if (!payload.is_object())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
@@ -386,7 +386,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::set_window_rect(JsonValue con
 }
 
 // 11.8.3 Maximize Window, https://w3c.github.io/webdriver/#dfn-maximize-window
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::maximize_window()
+Web::WebDriver::Response Session::maximize_window()
 {
     // 1. If the remote end does not support the Maximize Window command for the current top-level browsing context for any reason, return error with error code unsupported operation.
 
@@ -407,7 +407,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::maximize_window()
 }
 
 // 11.8.4 Minimize Window, https://w3c.github.io/webdriver/#minimize-window
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::minimize_window()
+Web::WebDriver::Response Session::minimize_window()
 {
     // 1. If the remote end does not support the Minimize Window command for the current top-level browsing context for any reason, return error with error code unsupported operation.
 
@@ -561,7 +561,7 @@ ErrorOr<Vector<Session::LocalElement>, Web::WebDriver::Error> Session::locator_s
 }
 
 // 12.3.2 Find Element, https://w3c.github.io/webdriver/#dfn-find-element
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::find_element(JsonValue const& payload)
+Web::WebDriver::Response Session::find_element(JsonValue const& payload)
 {
     if (!payload.is_object())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
@@ -616,7 +616,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::find_element(JsonValue const&
 }
 
 // 12.3.3 Find Elements, https://w3c.github.io/webdriver/#dfn-find-elements
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::find_elements(JsonValue const& payload)
+Web::WebDriver::Response Session::find_elements(JsonValue const& payload)
 {
     if (!payload.is_object())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
@@ -666,7 +666,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::find_elements(JsonValue const
 }
 
 // 12.3.4 Find Element From Element, https://w3c.github.io/webdriver/#dfn-find-element-from-element
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::find_element_from_element(JsonValue const& payload, StringView parameter_element_id)
+Web::WebDriver::Response Session::find_element_from_element(JsonValue const& payload, StringView parameter_element_id)
 {
     if (!payload.is_object())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
@@ -715,7 +715,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::find_element_from_element(Jso
 }
 
 // 12.3.5 Find Elements From Element, https://w3c.github.io/webdriver/#dfn-find-elements-from-element
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::find_elements_from_element(JsonValue const& payload, StringView parameter_element_id)
+Web::WebDriver::Response Session::find_elements_from_element(JsonValue const& payload, StringView parameter_element_id)
 {
     if (!payload.is_object())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
@@ -759,7 +759,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::find_elements_from_element(Js
 }
 
 // 12.4.1 Is Element Selected, https://w3c.github.io/webdriver/#dfn-is-element-selected
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::is_element_selected(StringView parameter_element_id)
+Web::WebDriver::Response Session::is_element_selected(StringView parameter_element_id)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -779,11 +779,11 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::is_element_selected(StringVie
     auto selected = m_browser_connection->is_element_selected(element_id);
 
     // 5. Return success with data selected.
-    return selected;
+    return JsonValue { selected };
 }
 
 // 12.4.2 Get Element Attribute, https://w3c.github.io/webdriver/#dfn-get-element-attribute
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_attribute(JsonValue const&, StringView parameter_element_id, StringView name)
+Web::WebDriver::Response Session::get_element_attribute(JsonValue const&, StringView parameter_element_id, StringView name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -811,7 +811,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_attribute(JsonVal
 }
 
 // 12.4.3 Get Element Property, https://w3c.github.io/webdriver/#dfn-get-element-property
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_property(JsonValue const&, StringView parameter_element_id, StringView name)
+Web::WebDriver::Response Session::get_element_property(JsonValue const&, StringView parameter_element_id, StringView name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -833,7 +833,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_property(JsonValu
 }
 
 // 12.4.4 Get Element CSS Value, https://w3c.github.io/webdriver/#dfn-get-element-css-value
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_css_value(JsonValue const&, StringView parameter_element_id, StringView property_name)
+Web::WebDriver::Response Session::get_element_css_value(JsonValue const&, StringView parameter_element_id, StringView property_name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -859,7 +859,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_css_value(JsonVal
 }
 
 // 12.4.5 Get Element Text, https://w3c.github.io/webdriver/#dfn-get-element-text
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_text(JsonValue const&, StringView parameter_element_id)
+Web::WebDriver::Response Session::get_element_text(JsonValue const&, StringView parameter_element_id)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -882,7 +882,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_text(JsonValue co
 }
 
 // 12.4.6 Get Element Tag Name, https://w3c.github.io/webdriver/#dfn-get-element-tag-name
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_tag_name(JsonValue const&, StringView parameter_element_id)
+Web::WebDriver::Response Session::get_element_tag_name(JsonValue const&, StringView parameter_element_id)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -900,7 +900,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_tag_name(JsonValu
 }
 
 // 12.4.7 Get Element Rect, https://w3c.github.io/webdriver/#dfn-get-element-rect
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_rect(StringView parameter_element_id)
+Web::WebDriver::Response Session::get_element_rect(StringView parameter_element_id)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -930,7 +930,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_rect(StringView p
 }
 
 // 12.4.8 Is Element Enabled, https://w3c.github.io/webdriver/#dfn-is-element-enabled
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::is_element_enabled(StringView parameter_element_id)
+Web::WebDriver::Response Session::is_element_enabled(StringView parameter_element_id)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -946,11 +946,11 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::is_element_enabled(StringView
     auto enabled = m_browser_connection->is_element_enabled(element_id);
 
     // 7. Return success with data enabled.
-    return enabled;
+    return JsonValue { enabled };
 }
 
 // 13.1 Get Page Source, https://w3c.github.io/webdriver/#dfn-get-page-source
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_source()
+Web::WebDriver::Response Session::get_source()
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -963,7 +963,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_source()
     auto source = m_browser_connection->serialize_source();
 
     // 5. Return success with data source.
-    return source;
+    return JsonValue { source };
 }
 
 struct ScriptArguments {
@@ -999,7 +999,7 @@ static ErrorOr<ScriptArguments, Web::WebDriver::Error> extract_the_script_argume
 }
 
 // 13.2.1 Execute Script, https://w3c.github.io/webdriver/#dfn-execute-script
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::execute_script(JsonValue const& payload)
+Web::WebDriver::Response Session::execute_script(JsonValue const& payload)
 {
     // 1. Let body and arguments be the result of trying to extract the script arguments from a request with argument parameters.
     auto const& [body, arguments] = TRY(extract_the_script_arguments_from_a_request(payload));
@@ -1040,7 +1040,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::execute_script(JsonValue cons
 }
 
 // 13.2.2 Execute Async Script, https://w3c.github.io/webdriver/#dfn-execute-async-script
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::execute_async_script(JsonValue const& parameters)
+Web::WebDriver::Response Session::execute_async_script(JsonValue const& parameters)
 {
     // 1. Let body and arguments by the result of trying to extract the script arguments from a request with argument parameters.
     auto [body, arguments] = TRY(extract_the_script_arguments_from_a_request(parameters));
@@ -1096,7 +1096,7 @@ static JsonObject serialize_cookie(Web::Cookie::Cookie const& cookie)
 }
 
 // 14.1 Get All Cookies, https://w3c.github.io/webdriver/#dfn-get-all-cookies
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_all_cookies()
+Web::WebDriver::Response Session::get_all_cookies()
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1120,7 +1120,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_all_cookies()
 }
 
 // 14.2 Get Named Cookie, https://w3c.github.io/webdriver/#dfn-get-named-cookie
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_named_cookie(String const& name)
+Web::WebDriver::Response Session::get_named_cookie(String const& name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1141,7 +1141,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_named_cookie(String const
 }
 
 // 14.3 Add Cookie, https://w3c.github.io/webdriver/#dfn-adding-a-cookie
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::add_cookie(JsonValue const& payload)
+Web::WebDriver::Response Session::add_cookie(JsonValue const& payload)
 {
     // 1. Let data be the result of getting a property named cookie from the parameters argument.
     if (!payload.is_object() || !payload.as_object().has_object("cookie"sv))
@@ -1277,7 +1277,7 @@ void Session::delete_cookies(Optional<StringView> const& name)
 }
 
 // 14.4 Delete Cookie, https://w3c.github.io/webdriver/#dfn-delete-cookie
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::delete_cookie(StringView name)
+Web::WebDriver::Response Session::delete_cookie(StringView name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1292,7 +1292,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::delete_cookie(StringView name
 }
 
 // 14.5 Delete All Cookies, https://w3c.github.io/webdriver/#dfn-delete-all-cookies
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::delete_all_cookies()
+Web::WebDriver::Response Session::delete_all_cookies()
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1333,7 +1333,7 @@ static ErrorOr<String, Web::WebDriver::Error> encode_bitmap_as_canvas_element(Gf
 }
 
 // 17.1 Take Screenshot, https://w3c.github.io/webdriver/#take-screenshot
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::take_screenshot()
+Web::WebDriver::Response Session::take_screenshot()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1351,11 +1351,11 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::take_screenshot()
     auto encoded_string = TRY(encode_bitmap_as_canvas_element(*screenshot.bitmap()));
 
     // 3. Return success with data encoded string.
-    return encoded_string;
+    return JsonValue { encoded_string };
 }
 
 // 17.2 Take Element Screenshot, https://w3c.github.io/webdriver/#dfn-take-element-screenshot
-ErrorOr<JsonValue, Web::WebDriver::Error> Session::take_element_screenshot(StringView parameter_element_id)
+Web::WebDriver::Response Session::take_element_screenshot(StringView parameter_element_id)
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1381,7 +1381,7 @@ ErrorOr<JsonValue, Web::WebDriver::Error> Session::take_element_screenshot(Strin
     auto encoded_string = TRY(encode_bitmap_as_canvas_element(*screenshot.bitmap()));
 
     // 6. Return success with data encoded string.
-    return encoded_string;
+    return JsonValue { encoded_string };
 }
 
 }

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -45,15 +45,15 @@ Session::~Session()
     }
 }
 
-ErrorOr<Session::Window*, WebDriverError> Session::current_window()
+ErrorOr<Session::Window*, Web::WebDriver::Error> Session::current_window()
 {
     auto window = m_windows.get(m_current_window_handle);
     if (!window.has_value())
-        return WebDriverError::from_code(ErrorCode::NoSuchWindow, "Window not found");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchWindow, "Window not found");
     return window.release_value();
 }
 
-ErrorOr<void, WebDriverError> Session::check_for_open_top_level_browsing_context_or_return_error()
+ErrorOr<void, Web::WebDriver::Error> Session::check_for_open_top_level_browsing_context_or_return_error()
 {
     (void)TRY(current_window());
     return {};
@@ -107,7 +107,7 @@ JsonObject Session::get_timeouts()
 }
 
 // 9.2 Set Timeouts, https://w3c.github.io/webdriver/#dfn-set-timeouts
-ErrorOr<JsonValue, WebDriverError> Session::set_timeouts(JsonValue const& payload)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::set_timeouts(JsonValue const& payload)
 {
     // 1. Let timeouts be the result of trying to JSON deserialize as a timeouts configuration the request’s parameters.
     auto timeouts = TRY(json_deserialize_as_a_timeouts_configuration(payload));
@@ -120,7 +120,7 @@ ErrorOr<JsonValue, WebDriverError> Session::set_timeouts(JsonValue const& payloa
 }
 
 // 10.1 Navigate To, https://w3c.github.io/webdriver/#dfn-navigate-to
-ErrorOr<JsonValue, WebDriverError> Session::navigate_to(JsonValue const& payload)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::navigate_to(JsonValue const& payload)
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -129,7 +129,7 @@ ErrorOr<JsonValue, WebDriverError> Session::navigate_to(JsonValue const& payload
 
     // 3. If the url property is missing from the parameters argument or it is not a string, return error with error code invalid argument.
     if (!payload.is_object() || !payload.as_object().has_string("url"sv)) {
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Payload doesn't have a string url");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload doesn't have a string url");
     }
 
     // 4. Let url be the result of getting a property named url from the parameters argument.
@@ -154,7 +154,7 @@ ErrorOr<JsonValue, WebDriverError> Session::navigate_to(JsonValue const& payload
 }
 
 // 10.2 Get Current URL, https://w3c.github.io/webdriver/#dfn-get-current-url
-ErrorOr<JsonValue, WebDriverError> Session::get_current_url()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_current_url()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -169,7 +169,7 @@ ErrorOr<JsonValue, WebDriverError> Session::get_current_url()
 }
 
 // 10.3 Back, https://w3c.github.io/webdriver/#dfn-back
-ErrorOr<JsonValue, WebDriverError> Session::back()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::back()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -190,7 +190,7 @@ ErrorOr<JsonValue, WebDriverError> Session::back()
 }
 
 // 10.4 Forward, https://w3c.github.io/webdriver/#dfn-forward
-ErrorOr<JsonValue, WebDriverError> Session::forward()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::forward()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -211,7 +211,7 @@ ErrorOr<JsonValue, WebDriverError> Session::forward()
 }
 
 // 10.5 Refresh, https://w3c.github.io/webdriver/#dfn-refresh
-ErrorOr<JsonValue, WebDriverError> Session::refresh()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::refresh()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -234,7 +234,7 @@ ErrorOr<JsonValue, WebDriverError> Session::refresh()
 }
 
 // 10.6 Get Title, https://w3c.github.io/webdriver/#dfn-get-title
-ErrorOr<JsonValue, WebDriverError> Session::get_title()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_title()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -247,7 +247,7 @@ ErrorOr<JsonValue, WebDriverError> Session::get_title()
 }
 
 // 11.1 Get Window Handle, https://w3c.github.io/webdriver/#get-window-handle
-ErrorOr<JsonValue, WebDriverError> Session::get_window_handle()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_window_handle()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -257,7 +257,7 @@ ErrorOr<JsonValue, WebDriverError> Session::get_window_handle()
 }
 
 // 11.2 Close Window, https://w3c.github.io/webdriver/#dfn-close-window
-ErrorOr<void, Variant<WebDriverError, Error>> Session::close_window()
+ErrorOr<void, Variant<Web::WebDriver::Error, Error>> Session::close_window()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -269,7 +269,7 @@ ErrorOr<void, Variant<WebDriverError, Error>> Session::close_window()
     if (m_windows.is_empty()) {
         auto result = stop();
         if (result.is_error()) {
-            return Variant<WebDriverError, Error>(result.release_error());
+            return Variant<Web::WebDriver::Error, Error>(result.release_error());
         }
     }
 
@@ -277,7 +277,7 @@ ErrorOr<void, Variant<WebDriverError, Error>> Session::close_window()
 }
 
 // 11.4 Get Window Handles, https://w3c.github.io/webdriver/#dfn-get-window-handles
-ErrorOr<JsonValue, WebDriverError> Session::get_window_handles() const
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_window_handles() const
 {
     // 1. Let handles be a JSON List.
     auto handles = JsonArray {};
@@ -302,7 +302,7 @@ static JsonObject serialize_rect(Gfx::IntRect const& rect)
 }
 
 // 11.8.1 Get Window Rect, https://w3c.github.io/webdriver/#dfn-get-window-rect
-ErrorOr<JsonValue, WebDriverError> Session::get_window_rect()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_window_rect()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -314,25 +314,25 @@ ErrorOr<JsonValue, WebDriverError> Session::get_window_rect()
 }
 
 // 11.8.2 Set Window Rect, https://w3c.github.io/webdriver/#dfn-set-window-rect
-ErrorOr<JsonValue, WebDriverError> Session::set_window_rect(JsonValue const& payload)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::set_window_rect(JsonValue const& payload)
 {
     if (!payload.is_object())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
 
     auto const& properties = payload.as_object();
 
-    auto resolve_property = [](auto name, auto const* property, auto min, auto max) -> ErrorOr<Optional<i32>, WebDriverError> {
+    auto resolve_property = [](auto name, auto const* property, auto min, auto max) -> ErrorOr<Optional<i32>, Web::WebDriver::Error> {
         if (!property)
             return Optional<i32> {};
         if (!property->is_number())
-            return WebDriverError::from_code(ErrorCode::InvalidArgument, String::formatted("Property '{}' is not a Number", name));
+            return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, String::formatted("Property '{}' is not a Number", name));
 
         auto number = property->template to_number<i64>();
 
         if (number < min)
-            return WebDriverError::from_code(ErrorCode::InvalidArgument, String::formatted("Property '{}' value {} exceeds the minimum allowed value {}", name, number, min));
+            return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, String::formatted("Property '{}' value {} exceeds the minimum allowed value {}", name, number, min));
         if (number > max)
-            return WebDriverError::from_code(ErrorCode::InvalidArgument, String::formatted("Property '{}' value {} exceeds the maximum allowed value {}", name, number, max));
+            return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, String::formatted("Property '{}' value {} exceeds the maximum allowed value {}", name, number, max));
 
         return static_cast<i32>(number);
     };
@@ -386,7 +386,7 @@ ErrorOr<JsonValue, WebDriverError> Session::set_window_rect(JsonValue const& pay
 }
 
 // 11.8.3 Maximize Window, https://w3c.github.io/webdriver/#dfn-maximize-window
-ErrorOr<JsonValue, WebDriverError> Session::maximize_window()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::maximize_window()
 {
     // 1. If the remote end does not support the Maximize Window command for the current top-level browsing context for any reason, return error with error code unsupported operation.
 
@@ -407,7 +407,7 @@ ErrorOr<JsonValue, WebDriverError> Session::maximize_window()
 }
 
 // 11.8.4 Minimize Window, https://w3c.github.io/webdriver/#minimize-window
-ErrorOr<JsonValue, WebDriverError> Session::minimize_window()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::minimize_window()
 {
     // 1. If the remote end does not support the Minimize Window command for the current top-level browsing context for any reason, return error with error code unsupported operation.
 
@@ -453,19 +453,19 @@ static JsonObject web_element_reference_object(Session::LocalElement const& elem
 }
 
 // https://w3c.github.io/webdriver/#dfn-get-a-known-connected-element
-static ErrorOr<i32, WebDriverError> get_known_connected_element(StringView element_id)
+static ErrorOr<i32, Web::WebDriver::Error> get_known_connected_element(StringView element_id)
 {
     // NOTE: The whole concept of "connected elements" is not implemented yet. See get_or_create_a_web_element_reference().
     //       For now the element is only represented by its ID.
     auto maybe_element_id = element_id.to_int();
     if (!maybe_element_id.has_value())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Element ID is not an integer");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Element ID is not an integer");
 
     return maybe_element_id.release_value();
 }
 
 // https://w3c.github.io/webdriver/#dfn-find
-ErrorOr<JsonArray, WebDriverError> Session::find(Session::LocalElement const& start_node, StringView using_, StringView value)
+ErrorOr<JsonArray, Web::WebDriver::Error> Session::find(Session::LocalElement const& start_node, StringView using_, StringView value)
 {
     // 1. Let end time be the current time plus the session implicit wait timeout.
     auto end_time = Time::now_monotonic() + Time::from_milliseconds(static_cast<i64>(m_timeouts_configuration.implicit_wait_timeout));
@@ -479,13 +479,13 @@ ErrorOr<JsonArray, WebDriverError> Session::find(Session::LocalElement const& st
     // 4. Let elements returned be the result of trying to call the relevant element location strategy with arguments start node, and selector.
     auto location_strategy_handler = s_locator_strategies.first_matching([&](LocatorStrategy const& match) { return match.name == location_strategy; });
     if (!location_strategy_handler.has_value())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No valid location strategy");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No valid location strategy");
 
     auto elements_or_error = (this->*location_strategy_handler.value().handler)(start_node, selector);
 
     // 5. If a DOMException, SyntaxError, XPathException, or other error occurs during the execution of the element location strategy, return error invalid selector.
     if (elements_or_error.is_error())
-        return WebDriverError::from_code(ErrorCode::InvalidSelector, String::formatted("The location strategy could not finish: {}", elements_or_error.release_error().message));
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidSelector, String::formatted("The location strategy could not finish: {}", elements_or_error.release_error().message));
 
     auto elements = elements_or_error.release_value();
 
@@ -514,14 +514,14 @@ Vector<Session::LocatorStrategy> Session::s_locator_strategies = {
 };
 
 // https://w3c.github.io/webdriver/#css-selectors
-ErrorOr<Vector<Session::LocalElement>, WebDriverError> Session::locator_strategy_css_selectors(Session::LocalElement const& start_node, StringView selector)
+ErrorOr<Vector<Session::LocalElement>, Web::WebDriver::Error> Session::locator_strategy_css_selectors(Session::LocalElement const& start_node, StringView selector)
 {
     // 1. Let elements be the result of calling querySelectorAll() with start node as this and selector as the argument.
     //    If this causes an exception to be thrown, return error with error code invalid selector.
     auto elements_ids = m_browser_connection->query_selector_all(start_node.id, selector);
 
     if (!elements_ids.has_value())
-        return WebDriverError::from_code(ErrorCode::InvalidSelector, "query_selector_all returned failed!");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidSelector, "query_selector_all returned failed!");
 
     Vector<Session::LocalElement> elements;
     for (auto id : elements_ids.release_value()) {
@@ -533,60 +533,60 @@ ErrorOr<Vector<Session::LocalElement>, WebDriverError> Session::locator_strategy
 }
 
 // https://w3c.github.io/webdriver/#link-text
-ErrorOr<Vector<Session::LocalElement>, WebDriverError> Session::locator_strategy_link_text(Session::LocalElement const&, StringView)
+ErrorOr<Vector<Session::LocalElement>, Web::WebDriver::Error> Session::locator_strategy_link_text(Session::LocalElement const&, StringView)
 {
     // FIXME: Implement
-    return WebDriverError::from_code(ErrorCode::UnsupportedOperation, "Not implemented: locator strategy link text");
+    return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnsupportedOperation, "Not implemented: locator strategy link text");
 }
 
 // https://w3c.github.io/webdriver/#partial-link-text
-ErrorOr<Vector<Session::LocalElement>, WebDriverError> Session::locator_strategy_partial_link_text(Session::LocalElement const&, StringView)
+ErrorOr<Vector<Session::LocalElement>, Web::WebDriver::Error> Session::locator_strategy_partial_link_text(Session::LocalElement const&, StringView)
 {
     // FIXME: Implement
-    return WebDriverError::from_code(ErrorCode::UnsupportedOperation, "Not implemented: locator strategy partial link text");
+    return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnsupportedOperation, "Not implemented: locator strategy partial link text");
 }
 
 // https://w3c.github.io/webdriver/#tag-name
-ErrorOr<Vector<Session::LocalElement>, WebDriverError> Session::locator_strategy_tag_name(Session::LocalElement const&, StringView)
+ErrorOr<Vector<Session::LocalElement>, Web::WebDriver::Error> Session::locator_strategy_tag_name(Session::LocalElement const&, StringView)
 {
     // FIXME: Implement
-    return WebDriverError::from_code(ErrorCode::UnsupportedOperation, "Not implemented: locator strategy tag name");
+    return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnsupportedOperation, "Not implemented: locator strategy tag name");
 }
 
 // https://w3c.github.io/webdriver/#xpath
-ErrorOr<Vector<Session::LocalElement>, WebDriverError> Session::locator_strategy_x_path(Session::LocalElement const&, StringView)
+ErrorOr<Vector<Session::LocalElement>, Web::WebDriver::Error> Session::locator_strategy_x_path(Session::LocalElement const&, StringView)
 {
     // FIXME: Implement
-    return WebDriverError::from_code(ErrorCode::UnsupportedOperation, "Not implemented: locator strategy XPath");
+    return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnsupportedOperation, "Not implemented: locator strategy XPath");
 }
 
 // 12.3.2 Find Element, https://w3c.github.io/webdriver/#dfn-find-element
-ErrorOr<JsonValue, WebDriverError> Session::find_element(JsonValue const& payload)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::find_element(JsonValue const& payload)
 {
     if (!payload.is_object())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
 
     auto const& properties = payload.as_object();
     // 1. Let location strategy be the result of getting a property called "using".
     if (!properties.has("using"sv))
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No property called 'using' present");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No property called 'using' present");
     auto const& maybe_location_strategy = properties.get("using"sv);
     if (!maybe_location_strategy.is_string())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Property 'using' is not a String");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Property 'using' is not a String");
 
     auto location_strategy = maybe_location_strategy.to_string();
 
     // 2. If location strategy is not present as a keyword in the table of location strategies, return error with error code invalid argument.
     if (!s_locator_strategies.first_matching([&](LocatorStrategy const& match) { return match.name == location_strategy; }).has_value())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No valid location strategy");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No valid location strategy");
 
     // 3. Let selector be the result of getting a property called "value".
     // 4. If selector is undefined, return error with error code invalid argument.
     if (!properties.has("value"sv))
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No property called 'value' present");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No property called 'value' present");
     auto const& maybe_selector = properties.get("value"sv);
     if (!maybe_selector.is_string())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Property 'value' is not a String");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Property 'value' is not a String");
 
     auto selector = maybe_selector.to_string();
 
@@ -600,7 +600,7 @@ ErrorOr<JsonValue, WebDriverError> Session::find_element(JsonValue const& payloa
 
     // 8. If start node is null, return error with error code no such element.
     if (!maybe_start_node_id.has_value())
-        return WebDriverError::from_code(ErrorCode::NoSuchElement, "document element does not exist");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchElement, "document element does not exist");
 
     auto start_node_id = maybe_start_node_id.release_value();
     LocalElement start_node = { start_node_id };
@@ -610,38 +610,38 @@ ErrorOr<JsonValue, WebDriverError> Session::find_element(JsonValue const& payloa
 
     // 10. If result is empty, return error with error code no such element. Otherwise, return the first element of result.
     if (result.is_empty())
-        return WebDriverError::from_code(ErrorCode::NoSuchElement, "The requested element does not exist");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchElement, "The requested element does not exist");
 
     return JsonValue(result.at(0));
 }
 
 // 12.3.3 Find Elements, https://w3c.github.io/webdriver/#dfn-find-elements
-ErrorOr<JsonValue, WebDriverError> Session::find_elements(JsonValue const& payload)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::find_elements(JsonValue const& payload)
 {
     if (!payload.is_object())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
 
     auto const& properties = payload.as_object();
     // 1. Let location strategy be the result of getting a property called "using".
     if (!properties.has("using"sv))
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No property called 'using' present");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No property called 'using' present");
     auto const& maybe_location_strategy = properties.get("using"sv);
     if (!maybe_location_strategy.is_string())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Property 'using' is not a String");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Property 'using' is not a String");
 
     auto location_strategy = maybe_location_strategy.to_string();
 
     // 2. If location strategy is not present as a keyword in the table of location strategies, return error with error code invalid argument.
     if (!s_locator_strategies.first_matching([&](LocatorStrategy const& match) { return match.name == location_strategy; }).has_value())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No valid location strategy");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No valid location strategy");
 
     // 3. Let selector be the result of getting a property called "value".
     // 4. If selector is undefined, return error with error code invalid argument.
     if (!properties.has("value"sv))
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No property called 'value' present");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No property called 'value' present");
     auto const& maybe_selector = properties.get("value"sv);
     if (!maybe_selector.is_string())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Property 'value' is not a String");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Property 'value' is not a String");
 
     auto selector = maybe_selector.to_string();
 
@@ -655,7 +655,7 @@ ErrorOr<JsonValue, WebDriverError> Session::find_elements(JsonValue const& paylo
 
     // 8. If start node is null, return error with error code no such element.
     if (!maybe_start_node_id.has_value())
-        return WebDriverError::from_code(ErrorCode::NoSuchElement, "document element does not exist");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchElement, "document element does not exist");
 
     auto start_node_id = maybe_start_node_id.release_value();
     LocalElement start_node = { start_node_id };
@@ -666,32 +666,32 @@ ErrorOr<JsonValue, WebDriverError> Session::find_elements(JsonValue const& paylo
 }
 
 // 12.3.4 Find Element From Element, https://w3c.github.io/webdriver/#dfn-find-element-from-element
-ErrorOr<JsonValue, WebDriverError> Session::find_element_from_element(JsonValue const& payload, StringView parameter_element_id)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::find_element_from_element(JsonValue const& payload, StringView parameter_element_id)
 {
     if (!payload.is_object())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
 
     auto const& properties = payload.as_object();
     // 1. Let location strategy be the result of getting a property called "using".
     if (!properties.has("using"sv))
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No property called 'using' present");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No property called 'using' present");
     auto const& maybe_location_strategy = properties.get("using"sv);
     if (!maybe_location_strategy.is_string())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Property 'using' is not a String");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Property 'using' is not a String");
 
     auto location_strategy = maybe_location_strategy.to_string();
 
     // 2. If location strategy is not present as a keyword in the table of location strategies, return error with error code invalid argument.
     if (!s_locator_strategies.first_matching([&](LocatorStrategy const& match) { return match.name == location_strategy; }).has_value())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No valid location strategy");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No valid location strategy");
 
     // 3. Let selector be the result of getting a property called "value".
     // 4. If selector is undefined, return error with error code invalid argument.
     if (!properties.has("value"sv))
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No property called 'value' present");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No property called 'value' present");
     auto const& maybe_selector = properties.get("value"sv);
     if (!maybe_selector.is_string())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Property 'value' is not a String");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Property 'value' is not a String");
 
     auto selector = maybe_selector.to_string();
 
@@ -709,38 +709,38 @@ ErrorOr<JsonValue, WebDriverError> Session::find_element_from_element(JsonValue 
 
     // 9. If result is empty, return error with error code no such element. Otherwise, return the first element of result.
     if (result.is_empty())
-        return WebDriverError::from_code(ErrorCode::NoSuchElement, "The requested element does not exist");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchElement, "The requested element does not exist");
 
     return JsonValue(result.at(0));
 }
 
 // 12.3.5 Find Elements From Element, https://w3c.github.io/webdriver/#dfn-find-elements-from-element
-ErrorOr<JsonValue, WebDriverError> Session::find_elements_from_element(JsonValue const& payload, StringView parameter_element_id)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::find_elements_from_element(JsonValue const& payload, StringView parameter_element_id)
 {
     if (!payload.is_object())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
 
     auto const& properties = payload.as_object();
     // 1. Let location strategy be the result of getting a property called "using".
     if (!properties.has("using"sv))
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No property called 'using' present");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No property called 'using' present");
     auto const& maybe_location_strategy = properties.get("using"sv);
     if (!maybe_location_strategy.is_string())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Property 'using' is not a String");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Property 'using' is not a String");
 
     auto location_strategy = maybe_location_strategy.to_string();
 
     // 2. If location strategy is not present as a keyword in the table of location strategies, return error with error code invalid argument.
     if (!s_locator_strategies.first_matching([&](LocatorStrategy const& match) { return match.name == location_strategy; }).has_value())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No valid location strategy");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No valid location strategy");
 
     // 3. Let selector be the result of getting a property called "value".
     // 4. If selector is undefined, return error with error code invalid argument.
     if (!properties.has("value"sv))
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "No property called 'value' present");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No property called 'value' present");
     auto const& maybe_selector = properties.get("value"sv);
     if (!maybe_selector.is_string())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Property 'value' is not a String");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Property 'value' is not a String");
 
     auto selector = maybe_selector.to_string();
 
@@ -759,7 +759,7 @@ ErrorOr<JsonValue, WebDriverError> Session::find_elements_from_element(JsonValue
 }
 
 // 12.4.1 Is Element Selected, https://w3c.github.io/webdriver/#dfn-is-element-selected
-ErrorOr<JsonValue, WebDriverError> Session::is_element_selected(StringView parameter_element_id)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::is_element_selected(StringView parameter_element_id)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -783,7 +783,7 @@ ErrorOr<JsonValue, WebDriverError> Session::is_element_selected(StringView param
 }
 
 // 12.4.2 Get Element Attribute, https://w3c.github.io/webdriver/#dfn-get-element-attribute
-ErrorOr<JsonValue, WebDriverError> Session::get_element_attribute(JsonValue const&, StringView parameter_element_id, StringView name)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_attribute(JsonValue const&, StringView parameter_element_id, StringView name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -811,7 +811,7 @@ ErrorOr<JsonValue, WebDriverError> Session::get_element_attribute(JsonValue cons
 }
 
 // 12.4.3 Get Element Property, https://w3c.github.io/webdriver/#dfn-get-element-property
-ErrorOr<JsonValue, WebDriverError> Session::get_element_property(JsonValue const&, StringView parameter_element_id, StringView name)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_property(JsonValue const&, StringView parameter_element_id, StringView name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -833,7 +833,7 @@ ErrorOr<JsonValue, WebDriverError> Session::get_element_property(JsonValue const
 }
 
 // 12.4.4 Get Element CSS Value, https://w3c.github.io/webdriver/#dfn-get-element-css-value
-ErrorOr<JsonValue, WebDriverError> Session::get_element_css_value(JsonValue const&, StringView parameter_element_id, StringView property_name)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_css_value(JsonValue const&, StringView parameter_element_id, StringView property_name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -859,7 +859,7 @@ ErrorOr<JsonValue, WebDriverError> Session::get_element_css_value(JsonValue cons
 }
 
 // 12.4.5 Get Element Text, https://w3c.github.io/webdriver/#dfn-get-element-text
-ErrorOr<JsonValue, WebDriverError> Session::get_element_text(JsonValue const&, StringView parameter_element_id)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_text(JsonValue const&, StringView parameter_element_id)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -869,7 +869,7 @@ ErrorOr<JsonValue, WebDriverError> Session::get_element_text(JsonValue const&, S
     // FIXME: 3. Let element be the result of trying to get a known connected element with url variable element id.
     auto maybe_element_id = parameter_element_id.to_int();
     if (!maybe_element_id.has_value())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Element ID is not an i32");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Element ID is not an i32");
 
     auto element_id = maybe_element_id.release_value();
 
@@ -882,7 +882,7 @@ ErrorOr<JsonValue, WebDriverError> Session::get_element_text(JsonValue const&, S
 }
 
 // 12.4.6 Get Element Tag Name, https://w3c.github.io/webdriver/#dfn-get-element-tag-name
-ErrorOr<JsonValue, WebDriverError> Session::get_element_tag_name(JsonValue const&, StringView parameter_element_id)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_tag_name(JsonValue const&, StringView parameter_element_id)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -900,7 +900,7 @@ ErrorOr<JsonValue, WebDriverError> Session::get_element_tag_name(JsonValue const
 }
 
 // 12.4.7 Get Element Rect, https://w3c.github.io/webdriver/#dfn-get-element-rect
-ErrorOr<JsonValue, WebDriverError> Session::get_element_rect(StringView parameter_element_id)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_element_rect(StringView parameter_element_id)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -930,7 +930,7 @@ ErrorOr<JsonValue, WebDriverError> Session::get_element_rect(StringView paramete
 }
 
 // 12.4.8 Is Element Enabled, https://w3c.github.io/webdriver/#dfn-is-element-enabled
-ErrorOr<JsonValue, WebDriverError> Session::is_element_enabled(StringView parameter_element_id)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::is_element_enabled(StringView parameter_element_id)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -950,7 +950,7 @@ ErrorOr<JsonValue, WebDriverError> Session::is_element_enabled(StringView parame
 }
 
 // 13.1 Get Page Source, https://w3c.github.io/webdriver/#dfn-get-page-source
-ErrorOr<JsonValue, WebDriverError> Session::get_source()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_source()
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -972,23 +972,23 @@ struct ScriptArguments {
 };
 
 // https://w3c.github.io/webdriver/#dfn-extract-the-script-arguments-from-a-request
-static ErrorOr<ScriptArguments, WebDriverError> extract_the_script_arguments_from_a_request(JsonValue const& payload)
+static ErrorOr<ScriptArguments, Web::WebDriver::Error> extract_the_script_arguments_from_a_request(JsonValue const& payload)
 {
     if (!payload.is_object())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
 
     auto const& properties = payload.as_object();
 
     // 1. Let script be the result of getting a property named script from the parameters.
     // 2. If script is not a String, return error with error code invalid argument.
     if (!properties.has_string("script"sv))
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Payload doesn't have a 'script' string property");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload doesn't have a 'script' string property");
     auto script = properties.get("script"sv).as_string();
 
     // 3. Let args be the result of getting a property named args from the parameters.
     // 4. If args is not an Array return error with error code invalid argument.
     if (!properties.has_array("args"sv))
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Payload doesn't have an 'args' string property");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload doesn't have an 'args' string property");
     auto const& args = properties.get("args"sv).as_array();
 
     // 5. Let arguments be the result of calling the JSON deserialize algorithm with arguments args.
@@ -999,7 +999,7 @@ static ErrorOr<ScriptArguments, WebDriverError> extract_the_script_arguments_fro
 }
 
 // 13.2.1 Execute Script, https://w3c.github.io/webdriver/#dfn-execute-script
-ErrorOr<JsonValue, WebDriverError> Session::execute_script(JsonValue const& payload)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::execute_script(JsonValue const& payload)
 {
     // 1. Let body and arguments be the result of trying to extract the script arguments from a request with argument parameters.
     auto const& [body, arguments] = TRY(extract_the_script_arguments_from_a_request(payload));
@@ -1026,21 +1026,21 @@ ErrorOr<JsonValue, WebDriverError> Session::execute_script(JsonValue const& payl
     switch (execute_script_response.result_type()) {
     // 6. If promise is still pending and the session script timeout is reached, return error with error code script timeout.
     case Web::WebDriver::ExecuteScriptResultType::Timeout:
-        return WebDriverError::from_code(ErrorCode::ScriptTimeoutError, "Script timed out");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::ScriptTimeoutError, "Script timed out");
     // 7. Upon fulfillment of promise with value v, let result be a JSON clone of v, and return success with data result.
     case Web::WebDriver::ExecuteScriptResultType::PromiseResolved:
         return result;
     // 8. Upon rejection of promise with reason r, let result be a JSON clone of r, and return error with error code javascript error and data result.
     case Web::WebDriver::ExecuteScriptResultType::PromiseRejected:
     case Web::WebDriver::ExecuteScriptResultType::JavaScriptError:
-        return WebDriverError::from_code(ErrorCode::JavascriptError, "Script returned an error", move(result));
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::JavascriptError, "Script returned an error", move(result));
     default:
         VERIFY_NOT_REACHED();
     }
 }
 
 // 13.2.2 Execute Async Script, https://w3c.github.io/webdriver/#dfn-execute-async-script
-ErrorOr<JsonValue, WebDriverError> Session::execute_async_script(JsonValue const& parameters)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::execute_async_script(JsonValue const& parameters)
 {
     // 1. Let body and arguments by the result of trying to extract the script arguments from a request with argument parameters.
     auto [body, arguments] = TRY(extract_the_script_arguments_from_a_request(parameters));
@@ -1067,13 +1067,13 @@ ErrorOr<JsonValue, WebDriverError> Session::execute_async_script(JsonValue const
     switch (execute_script_response.result_type()) {
     // 6. If promise is still pending and the session script timeout is reached, return error with error code script timeout.
     case Web::WebDriver::ExecuteScriptResultType::Timeout:
-        return WebDriverError::from_code(ErrorCode::ScriptTimeoutError, "Script timed out");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::ScriptTimeoutError, "Script timed out");
     // 7. Upon fulfillment of promise with value v, let result be a JSON clone of v, and return success with data result.
     case Web::WebDriver::ExecuteScriptResultType::PromiseResolved:
         return result;
     // 8. Upon rejection of promise with reason r, let result be a JSON clone of r, and return error with error code javascript error and data result.
     case Web::WebDriver::ExecuteScriptResultType::PromiseRejected:
-        return WebDriverError::from_code(ErrorCode::JavascriptError, "Script returned an error", move(result));
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::JavascriptError, "Script returned an error", move(result));
     default:
         VERIFY_NOT_REACHED();
     }
@@ -1096,7 +1096,7 @@ static JsonObject serialize_cookie(Web::Cookie::Cookie const& cookie)
 }
 
 // 14.1 Get All Cookies, https://w3c.github.io/webdriver/#dfn-get-all-cookies
-ErrorOr<JsonValue, WebDriverError> Session::get_all_cookies()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_all_cookies()
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1120,7 +1120,7 @@ ErrorOr<JsonValue, WebDriverError> Session::get_all_cookies()
 }
 
 // 14.2 Get Named Cookie, https://w3c.github.io/webdriver/#dfn-get-named-cookie
-ErrorOr<JsonValue, WebDriverError> Session::get_named_cookie(String const& name)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::get_named_cookie(String const& name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1137,15 +1137,15 @@ ErrorOr<JsonValue, WebDriverError> Session::get_named_cookie(String const& name)
     }
 
     // 4. Otherwise, return error with error code no such cookie.
-    return WebDriverError::from_code(ErrorCode::NoSuchCookie, "Cookie not found");
+    return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchCookie, "Cookie not found");
 }
 
 // 14.3 Add Cookie, https://w3c.github.io/webdriver/#dfn-adding-a-cookie
-ErrorOr<JsonValue, WebDriverError> Session::add_cookie(JsonValue const& payload)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::add_cookie(JsonValue const& payload)
 {
     // 1. Let data be the result of getting a property named cookie from the parameters argument.
     if (!payload.is_object() || !payload.as_object().has_object("cookie"sv))
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Payload doesn't have a cookie object");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload doesn't have a cookie object");
 
     auto const& maybe_data = payload.as_object().get("cookie"sv);
 
@@ -1153,12 +1153,12 @@ ErrorOr<JsonValue, WebDriverError> Session::add_cookie(JsonValue const& payload)
     //    return error with error code invalid argument.
     // NOTE: Table is here: https://w3c.github.io/webdriver/#dfn-table-for-cookie-conversion
     if (!maybe_data.is_object())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Value \"cookie\' is not an object");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Value \"cookie\' is not an object");
 
     auto const& data = maybe_data.as_object();
 
     if (!data.has("name"sv) || !data.has("value"sv))
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Cookie-Object doesn't contain all required keys");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Cookie-Object doesn't contain all required keys");
 
     // 3. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1174,17 +1174,17 @@ ErrorOr<JsonValue, WebDriverError> Session::add_cookie(JsonValue const& payload)
     //    or cookie expiry time is not an integer type, or it less than 0 or greater than the maximum safe integer,
     //    return error with error code invalid argument.
     if (data.get("name"sv).is_null() || data.get("value"sv).is_null())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Cookie-Object is malformed: name or value are null");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Cookie-Object is malformed: name or value are null");
     if (data.has("secure"sv) && !data.get("secure"sv).is_bool())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Cookie-Object is malformed: secure is not bool");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Cookie-Object is malformed: secure is not bool");
     if (data.has("httpOnly"sv) && !data.get("httpOnly"sv).is_bool())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Cookie-Object is malformed: httpOnly is not bool");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Cookie-Object is malformed: httpOnly is not bool");
     Optional<Core::DateTime> expiry_time;
     if (data.has("expiry"sv)) {
         auto expiry_argument = data.get("expiry"sv);
         if (!expiry_argument.is_u32()) {
             // NOTE: less than 0 or greater than safe integer are handled by the JSON parser
-            return WebDriverError::from_code(ErrorCode::InvalidArgument, "Cookie-Object is malformed: expiry is not u32");
+            return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Cookie-Object is malformed: expiry is not u32");
         }
         expiry_time = Core::DateTime::from_timestamp(expiry_argument.as_u32());
     }
@@ -1196,12 +1196,12 @@ ErrorOr<JsonValue, WebDriverError> Session::add_cookie(JsonValue const& payload)
     if (auto name_attribute = data.get("name"sv); name_attribute.is_string())
         cookie.name = name_attribute.as_string();
     else
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Expect name attribute to be string");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Expect name attribute to be string");
 
     if (auto value_attribute = data.get("value"sv); value_attribute.is_string())
         cookie.value = value_attribute.as_string();
     else
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Expect value attribute to be string");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Expect value attribute to be string");
 
     // Cookie path
     //     The value if the entry exists, otherwise "/".
@@ -1209,7 +1209,7 @@ ErrorOr<JsonValue, WebDriverError> Session::add_cookie(JsonValue const& payload)
         if (auto path_attribute = data.get("path"sv); path_attribute.is_string())
             cookie.path = path_attribute.as_string();
         else
-            return WebDriverError::from_code(ErrorCode::InvalidArgument, "Expect path attribute to be string");
+            return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Expect path attribute to be string");
     } else {
         cookie.path = "/";
     }
@@ -1221,7 +1221,7 @@ ErrorOr<JsonValue, WebDriverError> Session::add_cookie(JsonValue const& payload)
         if (auto domain_attribute = data.get("domain"sv); domain_attribute.is_string())
             cookie.domain = domain_attribute.as_string();
         else
-            return WebDriverError::from_code(ErrorCode::InvalidArgument, "Expect domain attribute to be string");
+            return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Expect domain attribute to be string");
     }
 
     // Cookie secure only
@@ -1277,7 +1277,7 @@ void Session::delete_cookies(Optional<StringView> const& name)
 }
 
 // 14.4 Delete Cookie, https://w3c.github.io/webdriver/#dfn-delete-cookie
-ErrorOr<JsonValue, WebDriverError> Session::delete_cookie(StringView name)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::delete_cookie(StringView name)
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1292,7 +1292,7 @@ ErrorOr<JsonValue, WebDriverError> Session::delete_cookie(StringView name)
 }
 
 // 14.5 Delete All Cookies, https://w3c.github.io/webdriver/#dfn-delete-all-cookies
-ErrorOr<JsonValue, WebDriverError> Session::delete_all_cookies()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::delete_all_cookies()
 {
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1307,13 +1307,13 @@ ErrorOr<JsonValue, WebDriverError> Session::delete_all_cookies()
 }
 
 // https://w3c.github.io/webdriver/#dfn-encoding-a-canvas-as-base64
-static ErrorOr<String, WebDriverError> encode_bitmap_as_canvas_element(Gfx::Bitmap const& bitmap)
+static ErrorOr<String, Web::WebDriver::Error> encode_bitmap_as_canvas_element(Gfx::Bitmap const& bitmap)
 {
     // FIXME: 1. If the canvas element’s bitmap’s origin-clean flag is set to false, return error with error code unable to capture screen.
 
     // 2. If the canvas element’s bitmap has no pixels (i.e. either its horizontal dimension or vertical dimension is zero) then return error with error code unable to capture screen.
     if (bitmap.width() == 0 || bitmap.height() == 0)
-        return WebDriverError::from_code(ErrorCode::UnableToCaptureScreen, "Captured screenshot is empty"sv);
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnableToCaptureScreen, "Captured screenshot is empty"sv);
 
     // 3. Let file be a serialization of the canvas element’s bitmap as a file, using "image/png" as an argument.
     auto file = Gfx::PNGWriter::encode(bitmap);
@@ -1333,7 +1333,7 @@ static ErrorOr<String, WebDriverError> encode_bitmap_as_canvas_element(Gfx::Bitm
 }
 
 // 17.1 Take Screenshot, https://w3c.github.io/webdriver/#take-screenshot
-ErrorOr<JsonValue, WebDriverError> Session::take_screenshot()
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::take_screenshot()
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1343,7 +1343,7 @@ ErrorOr<JsonValue, WebDriverError> Session::take_screenshot()
     //     b. Let screenshot result be the result of trying to call draw a bounding box from the framebuffer, given root rect as an argument.
     auto screenshot = m_browser_connection->take_screenshot();
     if (!screenshot.is_valid())
-        return WebDriverError::from_code(ErrorCode::UnableToCaptureScreen, "Unable to capture screenshot"sv);
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnableToCaptureScreen, "Unable to capture screenshot"sv);
 
     //     c. Let canvas be a canvas element of screenshot result’s data.
     //     d. Let encoding result be the result of trying encoding a canvas as Base64 canvas.
@@ -1355,7 +1355,7 @@ ErrorOr<JsonValue, WebDriverError> Session::take_screenshot()
 }
 
 // 17.2 Take Element Screenshot, https://w3c.github.io/webdriver/#dfn-take-element-screenshot
-ErrorOr<JsonValue, WebDriverError> Session::take_element_screenshot(StringView parameter_element_id)
+ErrorOr<JsonValue, Web::WebDriver::Error> Session::take_element_screenshot(StringView parameter_element_id)
 {
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(check_for_open_top_level_browsing_context_or_return_error());
@@ -1373,7 +1373,7 @@ ErrorOr<JsonValue, WebDriverError> Session::take_element_screenshot(StringView p
     //     b. Let screenshot result be the result of trying to call draw a bounding box from the framebuffer, given element rect as an argument.
     auto screenshot = m_browser_connection->take_element_screenshot(element_id);
     if (!screenshot.is_valid())
-        return WebDriverError::from_code(ErrorCode::UnableToCaptureScreen, "Unable to capture screenshot"sv);
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnableToCaptureScreen, "Unable to capture screenshot"sv);
 
     //     c. Let canvas be a canvas element of screenshot result’s data.
     //     d. Let encoding result be the result of trying encoding a canvas as Base64 canvas.

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -165,40 +165,6 @@ Web::WebDriver::Response Session::set_timeouts(JsonValue const& payload)
     return JsonValue {};
 }
 
-// 10.1 Navigate To, https://w3c.github.io/webdriver/#dfn-navigate-to
-Web::WebDriver::Response Session::navigate_to(JsonValue const& payload)
-{
-    // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
-    TRY(check_for_open_top_level_browsing_context_or_return_error());
-
-    // FIXME 2. Handle any user prompts and return its value if it is an error.
-
-    // 3. If the url property is missing from the parameters argument or it is not a string, return error with error code invalid argument.
-    if (!payload.is_object() || !payload.as_object().has_string("url"sv)) {
-        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload doesn't have a string url");
-    }
-
-    // 4. Let url be the result of getting a property named url from the parameters argument.
-    URL url(payload.as_object().get_ptr("url"sv)->as_string());
-
-    // FIXME: 5. If url is not an absolute URL or an absolute URL with fragment, return error with error code invalid argument. [URL]
-
-    // 6. Let url be the result of getting a property named url from the parameters argument.
-    // Duplicate step?
-
-    // 7. Navigate the current top-level browsing context to url.
-    m_browser_connection->async_set_url(url);
-
-    // FIXME: 8. Run the post-navigation checks and return its value if it is an error.
-
-    // FIXME: 9. Wait for navigation to complete and return its value if it is an error.
-
-    // FIXME: 10. Set the current browsing context to the current top-level browsing context.
-
-    // 11. Return success with data null.
-    return JsonValue();
-}
-
 // 10.2 Get Current URL, https://w3c.github.io/webdriver/#dfn-get-current-url
 Web::WebDriver::Response Session::get_current_url()
 {

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -41,6 +41,12 @@ public:
     ErrorOr<void, Web::WebDriver::Error> check_for_open_top_level_browsing_context_or_return_error();
     String const& current_window_handle() { return m_current_window_handle; }
 
+    WebContentConnection& web_content_connection()
+    {
+        VERIFY(m_web_content_connection);
+        return *m_web_content_connection;
+    }
+
     ErrorOr<void> start();
     ErrorOr<void> stop();
     JsonObject get_timeouts();

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -51,7 +51,6 @@ public:
     ErrorOr<void> stop();
     JsonObject get_timeouts();
     Web::WebDriver::Response set_timeouts(JsonValue const& payload);
-    Web::WebDriver::Response get_current_url();
     Web::WebDriver::Response back();
     Web::WebDriver::Response forward();
     Web::WebDriver::Response refresh();

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -51,7 +51,6 @@ public:
     ErrorOr<void> stop();
     JsonObject get_timeouts();
     Web::WebDriver::Response set_timeouts(JsonValue const& payload);
-    Web::WebDriver::Response navigate_to(JsonValue const& url);
     Web::WebDriver::Response get_current_url();
     Web::WebDriver::Response back();
     Web::WebDriver::Response forward();

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -12,6 +12,7 @@
 #include <AK/JsonValue.h>
 #include <AK/RefPtr.h>
 #include <LibWeb/WebDriver/Error.h>
+#include <LibWeb/WebDriver/Response.h>
 #include <WebDriver/BrowserConnection.h>
 #include <WebDriver/TimeoutsConfiguration.h>
 #include <unistd.h>
@@ -41,42 +42,42 @@ public:
     ErrorOr<void> start();
     ErrorOr<void> stop();
     JsonObject get_timeouts();
-    ErrorOr<JsonValue, Web::WebDriver::Error> set_timeouts(JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> navigate_to(JsonValue const& url);
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_current_url();
-    ErrorOr<JsonValue, Web::WebDriver::Error> back();
-    ErrorOr<JsonValue, Web::WebDriver::Error> forward();
-    ErrorOr<JsonValue, Web::WebDriver::Error> refresh();
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_title();
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_window_handle();
+    Web::WebDriver::Response set_timeouts(JsonValue const& payload);
+    Web::WebDriver::Response navigate_to(JsonValue const& url);
+    Web::WebDriver::Response get_current_url();
+    Web::WebDriver::Response back();
+    Web::WebDriver::Response forward();
+    Web::WebDriver::Response refresh();
+    Web::WebDriver::Response get_title();
+    Web::WebDriver::Response get_window_handle();
     ErrorOr<void, Variant<Web::WebDriver::Error, Error>> close_window();
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_window_handles() const;
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_window_rect();
-    ErrorOr<JsonValue, Web::WebDriver::Error> set_window_rect(JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> maximize_window();
-    ErrorOr<JsonValue, Web::WebDriver::Error> minimize_window();
-    ErrorOr<JsonValue, Web::WebDriver::Error> find_element(JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> find_elements(JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> find_element_from_element(JsonValue const& payload, StringView parameter_element_id);
-    ErrorOr<JsonValue, Web::WebDriver::Error> find_elements_from_element(JsonValue const& payload, StringView parameter_element_id);
-    ErrorOr<JsonValue, Web::WebDriver::Error> is_element_selected(StringView element_id);
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_element_attribute(JsonValue const& payload, StringView element_id, StringView name);
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_element_property(JsonValue const& payload, StringView element_id, StringView name);
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_element_css_value(JsonValue const& payload, StringView element_id, StringView property_name);
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_element_text(JsonValue const& payload, StringView element_id);
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_element_tag_name(JsonValue const& payload, StringView element_id);
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_element_rect(StringView element_id);
-    ErrorOr<JsonValue, Web::WebDriver::Error> is_element_enabled(StringView element_id);
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_source();
-    ErrorOr<JsonValue, Web::WebDriver::Error> execute_script(JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> execute_async_script(JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_all_cookies();
-    ErrorOr<JsonValue, Web::WebDriver::Error> get_named_cookie(String const& name);
-    ErrorOr<JsonValue, Web::WebDriver::Error> add_cookie(JsonValue const& payload);
-    ErrorOr<JsonValue, Web::WebDriver::Error> delete_cookie(StringView name);
-    ErrorOr<JsonValue, Web::WebDriver::Error> delete_all_cookies();
-    ErrorOr<JsonValue, Web::WebDriver::Error> take_screenshot();
-    ErrorOr<JsonValue, Web::WebDriver::Error> take_element_screenshot(StringView element_id);
+    Web::WebDriver::Response get_window_handles() const;
+    Web::WebDriver::Response get_window_rect();
+    Web::WebDriver::Response set_window_rect(JsonValue const& payload);
+    Web::WebDriver::Response maximize_window();
+    Web::WebDriver::Response minimize_window();
+    Web::WebDriver::Response find_element(JsonValue const& payload);
+    Web::WebDriver::Response find_elements(JsonValue const& payload);
+    Web::WebDriver::Response find_element_from_element(JsonValue const& payload, StringView parameter_element_id);
+    Web::WebDriver::Response find_elements_from_element(JsonValue const& payload, StringView parameter_element_id);
+    Web::WebDriver::Response is_element_selected(StringView element_id);
+    Web::WebDriver::Response get_element_attribute(JsonValue const& payload, StringView element_id, StringView name);
+    Web::WebDriver::Response get_element_property(JsonValue const& payload, StringView element_id, StringView name);
+    Web::WebDriver::Response get_element_css_value(JsonValue const& payload, StringView element_id, StringView property_name);
+    Web::WebDriver::Response get_element_text(JsonValue const& payload, StringView element_id);
+    Web::WebDriver::Response get_element_tag_name(JsonValue const& payload, StringView element_id);
+    Web::WebDriver::Response get_element_rect(StringView element_id);
+    Web::WebDriver::Response is_element_enabled(StringView element_id);
+    Web::WebDriver::Response get_source();
+    Web::WebDriver::Response execute_script(JsonValue const& payload);
+    Web::WebDriver::Response execute_async_script(JsonValue const& payload);
+    Web::WebDriver::Response get_all_cookies();
+    Web::WebDriver::Response get_named_cookie(String const& name);
+    Web::WebDriver::Response add_cookie(JsonValue const& payload);
+    Web::WebDriver::Response delete_cookie(StringView name);
+    Web::WebDriver::Response delete_all_cookies();
+    Web::WebDriver::Response take_screenshot();
+    Web::WebDriver::Response take_element_screenshot(StringView element_id);
 
 private:
     void delete_cookies(Optional<StringView> const& name = {});

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -11,10 +11,12 @@
 #include <AK/Error.h>
 #include <AK/JsonValue.h>
 #include <AK/RefPtr.h>
+#include <LibCore/Promise.h>
 #include <LibWeb/WebDriver/Error.h>
 #include <LibWeb/WebDriver/Response.h>
 #include <WebDriver/BrowserConnection.h>
 #include <WebDriver/TimeoutsConfiguration.h>
+#include <WebDriver/WebContentConnection.h>
 #include <unistd.h>
 
 namespace WebDriver {
@@ -97,13 +99,20 @@ private:
     ErrorOr<Vector<LocalElement>, Web::WebDriver::Error> locator_strategy_tag_name(LocalElement const&, StringView);
     ErrorOr<Vector<LocalElement>, Web::WebDriver::Error> locator_strategy_x_path(LocalElement const&, StringView);
 
+    enum class ServerType {
+        Browser,
+        WebContent,
+    };
+    using ServerPromise = Core::Promise<ErrorOr<void>>;
+    ErrorOr<NonnullRefPtr<Core::LocalServer>> create_server(String const& socket_path, ServerType type, NonnullRefPtr<ServerPromise> promise);
+
     NonnullRefPtr<Client> m_client;
     bool m_started { false };
     unsigned m_id { 0 };
     HashMap<String, NonnullOwnPtr<Window>> m_windows;
     String m_current_window_handle;
-    RefPtr<Core::LocalServer> m_local_server;
     RefPtr<BrowserConnection> m_browser_connection;
+    RefPtr<WebContentConnection> m_web_content_connection;
 
     // https://w3c.github.io/webdriver/#dfn-session-script-timeout
     TimeoutsConfiguration m_timeouts_configuration;

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -48,7 +48,7 @@ public:
     }
 
     ErrorOr<void> start();
-    ErrorOr<void> stop();
+    Web::WebDriver::Response stop();
     JsonObject get_timeouts();
     Web::WebDriver::Response set_timeouts(JsonValue const& payload);
     Web::WebDriver::Response back();

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -11,9 +11,9 @@
 #include <AK/Error.h>
 #include <AK/JsonValue.h>
 #include <AK/RefPtr.h>
+#include <LibWeb/WebDriver/Error.h>
 #include <WebDriver/BrowserConnection.h>
 #include <WebDriver/TimeoutsConfiguration.h>
-#include <WebDriver/WebDriverError.h>
 #include <unistd.h>
 
 namespace WebDriver {
@@ -34,55 +34,55 @@ public:
         i32 id;
     };
 
-    ErrorOr<Window*, WebDriverError> current_window();
-    ErrorOr<void, WebDriverError> check_for_open_top_level_browsing_context_or_return_error();
+    ErrorOr<Window*, Web::WebDriver::Error> current_window();
+    ErrorOr<void, Web::WebDriver::Error> check_for_open_top_level_browsing_context_or_return_error();
     String const& current_window_handle() { return m_current_window_handle; }
 
     ErrorOr<void> start();
     ErrorOr<void> stop();
     JsonObject get_timeouts();
-    ErrorOr<JsonValue, WebDriverError> set_timeouts(JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> navigate_to(JsonValue const& url);
-    ErrorOr<JsonValue, WebDriverError> get_current_url();
-    ErrorOr<JsonValue, WebDriverError> back();
-    ErrorOr<JsonValue, WebDriverError> forward();
-    ErrorOr<JsonValue, WebDriverError> refresh();
-    ErrorOr<JsonValue, WebDriverError> get_title();
-    ErrorOr<JsonValue, WebDriverError> get_window_handle();
-    ErrorOr<void, Variant<WebDriverError, Error>> close_window();
-    ErrorOr<JsonValue, WebDriverError> get_window_handles() const;
-    ErrorOr<JsonValue, WebDriverError> get_window_rect();
-    ErrorOr<JsonValue, WebDriverError> set_window_rect(JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> maximize_window();
-    ErrorOr<JsonValue, WebDriverError> minimize_window();
-    ErrorOr<JsonValue, WebDriverError> find_element(JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> find_elements(JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> find_element_from_element(JsonValue const& payload, StringView parameter_element_id);
-    ErrorOr<JsonValue, WebDriverError> find_elements_from_element(JsonValue const& payload, StringView parameter_element_id);
-    ErrorOr<JsonValue, WebDriverError> is_element_selected(StringView element_id);
-    ErrorOr<JsonValue, WebDriverError> get_element_attribute(JsonValue const& payload, StringView element_id, StringView name);
-    ErrorOr<JsonValue, WebDriverError> get_element_property(JsonValue const& payload, StringView element_id, StringView name);
-    ErrorOr<JsonValue, WebDriverError> get_element_css_value(JsonValue const& payload, StringView element_id, StringView property_name);
-    ErrorOr<JsonValue, WebDriverError> get_element_text(JsonValue const& payload, StringView element_id);
-    ErrorOr<JsonValue, WebDriverError> get_element_tag_name(JsonValue const& payload, StringView element_id);
-    ErrorOr<JsonValue, WebDriverError> get_element_rect(StringView element_id);
-    ErrorOr<JsonValue, WebDriverError> is_element_enabled(StringView element_id);
-    ErrorOr<JsonValue, WebDriverError> get_source();
-    ErrorOr<JsonValue, WebDriverError> execute_script(JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> execute_async_script(JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> get_all_cookies();
-    ErrorOr<JsonValue, WebDriverError> get_named_cookie(String const& name);
-    ErrorOr<JsonValue, WebDriverError> add_cookie(JsonValue const& payload);
-    ErrorOr<JsonValue, WebDriverError> delete_cookie(StringView name);
-    ErrorOr<JsonValue, WebDriverError> delete_all_cookies();
-    ErrorOr<JsonValue, WebDriverError> take_screenshot();
-    ErrorOr<JsonValue, WebDriverError> take_element_screenshot(StringView element_id);
+    ErrorOr<JsonValue, Web::WebDriver::Error> set_timeouts(JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> navigate_to(JsonValue const& url);
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_current_url();
+    ErrorOr<JsonValue, Web::WebDriver::Error> back();
+    ErrorOr<JsonValue, Web::WebDriver::Error> forward();
+    ErrorOr<JsonValue, Web::WebDriver::Error> refresh();
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_title();
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_window_handle();
+    ErrorOr<void, Variant<Web::WebDriver::Error, Error>> close_window();
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_window_handles() const;
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_window_rect();
+    ErrorOr<JsonValue, Web::WebDriver::Error> set_window_rect(JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> maximize_window();
+    ErrorOr<JsonValue, Web::WebDriver::Error> minimize_window();
+    ErrorOr<JsonValue, Web::WebDriver::Error> find_element(JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> find_elements(JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> find_element_from_element(JsonValue const& payload, StringView parameter_element_id);
+    ErrorOr<JsonValue, Web::WebDriver::Error> find_elements_from_element(JsonValue const& payload, StringView parameter_element_id);
+    ErrorOr<JsonValue, Web::WebDriver::Error> is_element_selected(StringView element_id);
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_element_attribute(JsonValue const& payload, StringView element_id, StringView name);
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_element_property(JsonValue const& payload, StringView element_id, StringView name);
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_element_css_value(JsonValue const& payload, StringView element_id, StringView property_name);
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_element_text(JsonValue const& payload, StringView element_id);
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_element_tag_name(JsonValue const& payload, StringView element_id);
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_element_rect(StringView element_id);
+    ErrorOr<JsonValue, Web::WebDriver::Error> is_element_enabled(StringView element_id);
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_source();
+    ErrorOr<JsonValue, Web::WebDriver::Error> execute_script(JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> execute_async_script(JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_all_cookies();
+    ErrorOr<JsonValue, Web::WebDriver::Error> get_named_cookie(String const& name);
+    ErrorOr<JsonValue, Web::WebDriver::Error> add_cookie(JsonValue const& payload);
+    ErrorOr<JsonValue, Web::WebDriver::Error> delete_cookie(StringView name);
+    ErrorOr<JsonValue, Web::WebDriver::Error> delete_all_cookies();
+    ErrorOr<JsonValue, Web::WebDriver::Error> take_screenshot();
+    ErrorOr<JsonValue, Web::WebDriver::Error> take_element_screenshot(StringView element_id);
 
 private:
     void delete_cookies(Optional<StringView> const& name = {});
-    ErrorOr<JsonArray, WebDriverError> find(LocalElement const& start_node, StringView location_strategy, StringView selector);
+    ErrorOr<JsonArray, Web::WebDriver::Error> find(LocalElement const& start_node, StringView location_strategy, StringView selector);
 
-    using ElementLocationStrategyHandler = ErrorOr<Vector<LocalElement>, WebDriverError> (Session::*)(LocalElement const&, StringView);
+    using ElementLocationStrategyHandler = ErrorOr<Vector<LocalElement>, Web::WebDriver::Error> (Session::*)(LocalElement const&, StringView);
     struct LocatorStrategy {
         String name;
         ElementLocationStrategyHandler handler;
@@ -90,11 +90,11 @@ private:
 
     static Vector<LocatorStrategy> s_locator_strategies;
 
-    ErrorOr<Vector<LocalElement>, WebDriverError> locator_strategy_css_selectors(LocalElement const&, StringView);
-    ErrorOr<Vector<LocalElement>, WebDriverError> locator_strategy_link_text(LocalElement const&, StringView);
-    ErrorOr<Vector<LocalElement>, WebDriverError> locator_strategy_partial_link_text(LocalElement const&, StringView);
-    ErrorOr<Vector<LocalElement>, WebDriverError> locator_strategy_tag_name(LocalElement const&, StringView);
-    ErrorOr<Vector<LocalElement>, WebDriverError> locator_strategy_x_path(LocalElement const&, StringView);
+    ErrorOr<Vector<LocalElement>, Web::WebDriver::Error> locator_strategy_css_selectors(LocalElement const&, StringView);
+    ErrorOr<Vector<LocalElement>, Web::WebDriver::Error> locator_strategy_link_text(LocalElement const&, StringView);
+    ErrorOr<Vector<LocalElement>, Web::WebDriver::Error> locator_strategy_partial_link_text(LocalElement const&, StringView);
+    ErrorOr<Vector<LocalElement>, Web::WebDriver::Error> locator_strategy_tag_name(LocalElement const&, StringView);
+    ErrorOr<Vector<LocalElement>, Web::WebDriver::Error> locator_strategy_x_path(LocalElement const&, StringView);
 
     NonnullRefPtr<Client> m_client;
     bool m_started { false };

--- a/Userland/Services/WebDriver/TimeoutsConfiguration.cpp
+++ b/Userland/Services/WebDriver/TimeoutsConfiguration.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/JsonObject.h>
 #include <WebDriver/TimeoutsConfiguration.h>
-#include <WebDriver/WebDriverError.h>
 
 namespace WebDriver {
 
@@ -35,7 +34,7 @@ JsonObject timeouts_object(TimeoutsConfiguration const& timeouts)
 }
 
 // https://w3c.github.io/webdriver/#ref-for-dfn-json-deserialize-3
-ErrorOr<TimeoutsConfiguration, WebDriverError> json_deserialize_as_a_timeouts_configuration(JsonValue const& value)
+ErrorOr<TimeoutsConfiguration, Web::WebDriver::Error> json_deserialize_as_a_timeouts_configuration(JsonValue const& value)
 {
     constexpr i64 max_safe_integer = 9007199254740991;
 
@@ -44,7 +43,7 @@ ErrorOr<TimeoutsConfiguration, WebDriverError> json_deserialize_as_a_timeouts_co
 
     // 2. If value is not a JSON Object, return error with error code invalid argument.
     if (!value.is_object())
-        return WebDriverError::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
 
     // 3. If value has a property with the key "script":
     if (value.as_object().has("script"sv)) {
@@ -53,7 +52,7 @@ ErrorOr<TimeoutsConfiguration, WebDriverError> json_deserialize_as_a_timeouts_co
 
         // 2. If script duration is a number and less than 0 or greater than maximum safe integer, or it is not null, return error with error code invalid argument.
         if ((script_duration.is_number() && (script_duration.to_i64() < 0 || script_duration.to_i64() > max_safe_integer)) || !script_duration.is_null())
-            return WebDriverError::from_code(ErrorCode::InvalidArgument, "Invalid script duration");
+            return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Invalid script duration");
 
         // 3. Set timeouts’s script timeout to script duration.
         timeouts.script_timeout = script_duration.is_null() ? Optional<u64> {} : script_duration.to_u64();
@@ -66,7 +65,7 @@ ErrorOr<TimeoutsConfiguration, WebDriverError> json_deserialize_as_a_timeouts_co
 
         // 2. If page load duration is less than 0 or greater than maximum safe integer, return error with error code invalid argument.
         if (!page_load_duration.is_number() || page_load_duration.to_i64() < 0 || page_load_duration.to_i64() > max_safe_integer)
-            return WebDriverError::from_code(ErrorCode::InvalidArgument, "Invalid page load duration");
+            return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Invalid page load duration");
 
         // 3. Set timeouts’s page load timeout to page load duration.
         timeouts.page_load_timeout = page_load_duration.to_u64();
@@ -79,7 +78,7 @@ ErrorOr<TimeoutsConfiguration, WebDriverError> json_deserialize_as_a_timeouts_co
 
         // 2. If implicit duration is less than 0 or greater than maximum safe integer, return error with error code invalid argument.
         if (!implicit_duration.is_number() || implicit_duration.to_i64() < 0 || implicit_duration.to_i64() > max_safe_integer)
-            return WebDriverError::from_code(ErrorCode::InvalidArgument, "Invalid implicit duration");
+            return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Invalid implicit duration");
 
         // 3. Set timeouts’s implicit wait timeout to implicit duration.
         timeouts.implicit_wait_timeout = implicit_duration.to_u64();

--- a/Userland/Services/WebDriver/TimeoutsConfiguration.h
+++ b/Userland/Services/WebDriver/TimeoutsConfiguration.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "WebDriverError.h"
 #include <AK/Forward.h>
 #include <AK/Optional.h>
+#include <LibWeb/WebDriver/Error.h>
 
 namespace WebDriver {
 
@@ -20,6 +20,6 @@ struct TimeoutsConfiguration {
 };
 
 JsonObject timeouts_object(TimeoutsConfiguration const&);
-ErrorOr<TimeoutsConfiguration, WebDriverError> json_deserialize_as_a_timeouts_configuration(JsonValue const&);
+ErrorOr<TimeoutsConfiguration, Web::WebDriver::Error> json_deserialize_as_a_timeouts_configuration(JsonValue const&);
 
 }

--- a/Userland/Services/WebDriver/WebContentConnection.cpp
+++ b/Userland/Services/WebDriver/WebContentConnection.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Services/WebDriver/Client.h>
+#include <Services/WebDriver/WebContentConnection.h>
+
+namespace WebDriver {
+
+WebContentConnection::WebContentConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, NonnullRefPtr<Client> client, unsigned session_id)
+    : IPC::ConnectionFromClient<WebDriverClientEndpoint, WebDriverServerEndpoint>(*this, move(socket), 1)
+    , m_client(move(client))
+    , m_session_id(session_id)
+{
+}
+
+void WebContentConnection::die()
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Session {} was closed remotely. Shutting down...", m_session_id);
+    m_client->close_session(m_session_id);
+}
+
+}

--- a/Userland/Services/WebDriver/WebContentConnection.h
+++ b/Userland/Services/WebDriver/WebContentConnection.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/Stream.h>
+#include <LibIPC/ConnectionFromClient.h>
+#include <Services/WebContent/WebDriverClientEndpoint.h>
+#include <Services/WebContent/WebDriverServerEndpoint.h>
+
+namespace WebDriver {
+
+class Client;
+
+class WebContentConnection
+    : public IPC::ConnectionFromClient<WebDriverClientEndpoint, WebDriverServerEndpoint> {
+    C_OBJECT_ABSTRACT(WebContentConnection)
+public:
+    WebContentConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, NonnullRefPtr<Client> client, unsigned session_id);
+
+    virtual void die() override;
+
+private:
+    NonnullRefPtr<Client> m_client;
+    unsigned m_session_id { 0 };
+};
+
+}

--- a/Userland/Services/WebDriver/main.cpp
+++ b/Userland/Services/WebDriver/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibCore/ArgsParser.h>
+#include <LibCore/Directory.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/System.h>
 #include <LibCore/TCPServer.h>
@@ -35,6 +36,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
+    TRY(Core::System::pledge("stdio accept cpath rpath recvfd inet unix proc exec fattr"));
+
+    TRY(Core::Directory::create("/tmp/webdriver"sv, Core::Directory::CreateDirectories::Yes));
     TRY(Core::System::pledge("stdio accept rpath recvfd inet unix proc exec fattr"));
 
     Core::EventLoop loop;
@@ -67,7 +71,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/bin/Browser", "rx"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/res/icons", "r"));
-    TRY(Core::System::unveil("/tmp", "rwc"));
+    TRY(Core::System::unveil("/tmp/webdriver", "rwc"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     TRY(Core::System::pledge("stdio accept rpath recvfd unix proc exec fattr"));


### PR DESCRIPTION
The goal here is to ultimately avoid any IPC between WebDriver and the Browser at all. By moving the WebDriver endpoint implementations to WebContent, we can much more easily implement WebDriver for Ladybird. Further, we will have a much better representation of DOM elements since we'll be in the process that owns them.

The idea is that as we make this transition, we will keep the IPC socket between the Browser and WebDriver, and we add a new socket between WebContent and WebDriver. Once all endpoints are migrated, the Browser socket and the IPC around it can all be removed. At that point, we should also be able to support a headless WebDriver mode.

This moves just a few of the endpoints over to WebContent for a first round.