### PR TITLE
LibVideo: Handle corrupted video errors without spamming dialogs

### DIFF
--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -127,7 +127,7 @@ void VideoPlayerWidget::toggle_pause()
         resume_playback();
 }
 
-void VideoPlayerWidget::on_decoding_error(Video::DecoderError error)
+void VideoPlayerWidget::on_decoding_error(Video::DecoderError const& error)
 {
     StringView text_format;
 

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
@@ -35,7 +35,7 @@ private:
     VideoPlayerWidget(GUI::Window&);
 
     void update_play_pause_icon();
-    void on_decoding_error(Video::DecoderError);
+    void on_decoding_error(Video::DecoderError const&);
     void display_next_frame();
 
     void cycle_sizing_modes();

--- a/Userland/Libraries/LibVideo/DecoderError.h
+++ b/Userland/Libraries/LibVideo/DecoderError.h
@@ -46,9 +46,14 @@ public:
         return DecoderError::with_description(category, String::vformatted(format_string.view(), variadic_format_params));
     }
 
+    static DecoderError from_source_location(DecoderErrorCategory category, StringView description, SourceLocation location = SourceLocation::current())
+    {
+        return DecoderError::format(category, "[{} @ {}:{}]: {}", location.function_name(), location.filename(), location.line_number(), description);
+    }
+
     static DecoderError corrupted(StringView description, SourceLocation location = SourceLocation::current())
     {
-        return DecoderError::format(DecoderErrorCategory::Corrupted, "{}: {}", location, description);
+        return DecoderError::from_source_location(DecoderErrorCategory::Corrupted, description, location);
     }
 
     static DecoderError not_implemented(SourceLocation location = SourceLocation::current())
@@ -76,9 +81,8 @@ private:
         auto _result = ((expression));                                     \
         if (_result.is_error()) [[unlikely]] {                             \
             auto _error_string = _result.release_error().string_literal(); \
-            return DecoderError::format(                                   \
-                ((category)), "{}: {}",                                    \
-                SourceLocation::current(), _error_string);                 \
+            return DecoderError::from_source_location(                     \
+                ((category)), _error_string, SourceLocation::current());   \
         }                                                                  \
         _result.release_value();                                           \
     })


### PR DESCRIPTION
No longer will the video player explode with error dialogs that then lock the user out of closing them.

To avoid issues where the playback state becomes invalid when an error occurs, I've made all decoder errors pass through the frame queue. This way, when a video is corrupted, there should be no chance that the playback state becomes invalid due to setting the state to Corrupted in the event handler while a presentation event is still pending. Or at least I think that was what caused some issues I was seeing :^)

This system should be a lot more robust if any future errors need to be handled.

Here's a completely harmless error message screenshot:

![image](https://user-images.githubusercontent.com/3149592/200837032-7913672b-75ab-4a34-8ccb-a282ebe5760f.png)
