### PR TITLE
LibIPC+AK: Support Variants in IPC

### DIFF
--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -225,8 +225,9 @@ IsLvalueReference<T>;
 template<NotLvalueReference... Ts>
 struct Variant
     : public Detail::MergeAndDeduplicatePacks<Detail::VariantConstructors<Ts, Variant<Ts...>>...> {
-private:
+public:
     using IndexType = Conditional<sizeof...(Ts) < 255, u8, size_t>; // Note: size+1 reserved for internal value checks
+private:
     static constexpr IndexType invalid_index = sizeof...(Ts);
 
     template<typename T>

--- a/Userland/Libraries/LibIPC/Decoder.cpp
+++ b/Userland/Libraries/LibIPC/Decoder.cpp
@@ -208,4 +208,10 @@ ErrorOr<void> decode(Decoder& decoder, Core::ProxyData& data)
     return {};
 }
 
+// No-op.
+ErrorOr<void> Decoder::decode(AK::Empty&)
+{
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibIPC/Encoder.cpp
+++ b/Userland/Libraries/LibIPC/Encoder.cpp
@@ -196,6 +196,12 @@ Encoder& Encoder::operator<<(File const& file)
     return *this;
 }
 
+// No-op.
+Encoder& Encoder::operator<<(AK::Empty const&)
+{
+    return *this;
+}
+
 template<>
 bool encode(Encoder& encoder, Core::AnonymousBuffer const& buffer)
 {

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -9,6 +9,7 @@
 #include <AK/Concepts.h>
 #include <AK/HashMap.h>
 #include <AK/StdLibExtras.h>
+#include <AK/Variant.h>
 #include <LibCore/SharedCircularQueue.h>
 #include <LibIPC/Forward.h>
 #include <LibIPC/Message.h>
@@ -49,6 +50,7 @@ public:
     Encoder& operator<<(URL const&);
     Encoder& operator<<(Dictionary const&);
     Encoder& operator<<(File const&);
+    Encoder& operator<<(AK::Empty const&);
     template<typename K, typename V>
     Encoder& operator<<(HashMap<K, V> const& hashmap)
     {
@@ -84,6 +86,17 @@ public:
     Encoder& operator<<(Core::SharedSingleProducerCircularQueue<T, Size> const& queue)
     {
         *this << IPC::File(queue.fd());
+        return *this;
+    }
+
+    // Note: We require any encodeable variant to have Empty as its first variant, as only possibly-empty variants can be default constructed.
+    //       The default constructability is required by generated IPC message marshalling code.
+    template<typename... VariantTypes>
+    Encoder& operator<<(AK::Variant<AK::Empty, VariantTypes...> const& variant)
+    {
+        // Note: This might be either u8 or size_t depending on the size of the variant; both are encodeable.
+        *this << variant.index();
+        variant.visit([this](auto const& underlying_value) { *this << underlying_value; });
         return *this;
     }
 


### PR DESCRIPTION
The format is quite simply the type index followed by the type in its own native encoding; just implementing the receive side with static typing is a bit convoluted. The only limitation of this implementation is that the variant type has to contain an Empty somewhere as it is not default constructible otherwise.

This is intended to support some interesting service management in the future. Feel free to not merge if you don't like dead code, but we can resurrect this PR at any time when Variants over IPC are actually required.