### PR TITLE
AK+LibRegex: A bunch of optimisation stuff

### DIFF
--- a/AK/BumpAllocator.h
+++ b/AK/BumpAllocator.h
@@ -91,7 +91,7 @@ protected:
             if (head_chunk == m_current_chunk)
                 VERIFY(chunk_header.next_chunk == 0);
             auto next_chunk = chunk_header.next_chunk;
-            fn(head_chunk);
+            fn(head_chunk + sizeof(ChunkHeader));
             head_chunk = next_chunk;
         }
     }
@@ -179,13 +179,13 @@ public:
     void destroy_all()
     {
         this->for_each_chunk([&](auto chunk) {
-            auto base_ptr = align_up_to(chunk + sizeof(typename Allocator::ChunkHeader), alignof(T));
+            auto base_ptr = align_up_to(chunk, alignof(T));
             // Compute the offset of the first byte *after* this chunk:
             FlatPtr end_offset = base_ptr + this->m_chunk_size - chunk;
+            if (chunk == this->m_current_chunk + sizeof(typename Allocator::ChunkHeader))
+                end_offset = this->m_byte_offset_into_current_chunk;
             // Compute the offset of the first byte *after* the last valid object, in case the end of the chunk does not align with the end of an object:
             end_offset = (end_offset / sizeof(T)) * sizeof(T);
-            if (chunk == this->m_current_chunk)
-                end_offset = this->m_byte_offset_into_current_chunk;
             for (; base_ptr - chunk < end_offset; base_ptr += sizeof(T))
                 reinterpret_cast<T*>(base_ptr)->~T();
         });

--- a/AK/DisjointChunks.h
+++ b/AK/DisjointChunks.h
@@ -316,6 +316,11 @@ public:
     {
         Vector<Span<T>, InlineSize> spans;
         spans.ensure_capacity(m_chunks.size());
+        if (m_chunks.size() == 1) {
+            spans.append(const_cast<ChunkType&>(m_chunks[0]).span());
+            return DisjointSpans<T, Vector<Span<T>, InlineSize>> { move(spans) };
+        }
+
         for (auto& chunk : m_chunks)
             spans.unchecked_append(const_cast<ChunkType&>(chunk).span());
         return DisjointSpans<T, Vector<Span<T>, InlineSize>> { move(spans) };

--- a/AK/DisjointChunks.h
+++ b/AK/DisjointChunks.h
@@ -70,7 +70,7 @@ private:
     ReferenceType m_chunks;
 };
 
-template<typename T>
+template<typename T, typename SpanContainer = Vector<Span<T>>>
 class DisjointSpans {
 public:
     DisjointSpans() = default;
@@ -78,7 +78,7 @@ public:
     DisjointSpans(DisjointSpans const&) = default;
     DisjointSpans(DisjointSpans&&) = default;
 
-    explicit DisjointSpans(Vector<Span<T>> spans)
+    explicit DisjointSpans(SpanContainer spans)
         : m_spans(move(spans))
     {
     }
@@ -185,7 +185,7 @@ private:
         return { m_spans.last(), index - (offset - m_spans.last().size()) };
     }
 
-    Vector<Span<T>> m_spans;
+    SpanContainer m_spans;
 };
 
 namespace Detail {
@@ -311,13 +311,14 @@ public:
         return all_of(m_chunks, [](auto& chunk) { return chunk.is_empty(); });
     }
 
-    DisjointSpans<T> spans() const&
+    template<size_t InlineSize = 0>
+    DisjointSpans<T, Vector<Span<T>, InlineSize>> spans() const&
     {
-        Vector<Span<T>> spans;
+        Vector<Span<T>, InlineSize> spans;
         spans.ensure_capacity(m_chunks.size());
         for (auto& chunk : m_chunks)
             spans.unchecked_append(const_cast<ChunkType&>(chunk).span());
-        return DisjointSpans<T> { move(spans) };
+        return DisjointSpans<T, Vector<Span<T>, InlineSize>> { move(spans) };
     }
 
     bool operator==(DisjointChunks const& other) const

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -257,6 +257,8 @@ struct Traits<Span<T>> : public GenericTraits<Span<T>> {
         }
         return hash;
     }
+
+    constexpr static bool is_trivial() { return true; }
 };
 
 using ReadonlyBytes = Span<u8 const>;

--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -31,7 +31,7 @@ public:
         }
     }
 
-    static size_t copy(T* destination, const T* source, size_t count)
+    static size_t copy(T* destination, T const* source, size_t count)
     {
         if (count == 0)
             return 0;
@@ -54,7 +54,7 @@ public:
         return count;
     }
 
-    static bool compare(const T* a, const T* b, size_t count)
+    static bool compare(T const* a, T const* b, size_t count)
     {
         if (count == 0)
             return true;
@@ -68,6 +68,19 @@ public:
         }
 
         return true;
+    }
+
+    static void delete_(T* ptr, size_t count)
+    {
+        if (count == 0)
+            return;
+
+        if constexpr (Traits<T>::is_trivial()) {
+            return;
+        }
+
+        for (size_t i = 0; i < count; ++i)
+            ptr[i].~T();
     }
 };
 

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -73,10 +73,8 @@ public:
     {
         if constexpr (inline_capacity > 0) {
             if (!m_outline_buffer) {
-                for (size_t i = 0; i < m_size; ++i) {
-                    new (&inline_buffer()[i]) StorageType(move(other.inline_buffer()[i]));
-                    other.inline_buffer()[i].~StorageType();
-                }
+                TypedTransfer<T>::move(inline_buffer(), other.inline_buffer(), m_size);
+                TypedTransfer<T>::delete_(other.inline_buffer(), m_size);
             }
         }
         other.m_outline_buffer = nullptr;

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -546,7 +546,7 @@ ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, M
                 return ExecutionResult::Failed_ExecuteLowPrioForks;
 
             auto count = m_bytecode->at(offset++);
-            auto range_data = m_bytecode->spans().slice(offset, count);
+            auto range_data = m_bytecode->template spans<4>().slice(offset, count);
             offset += count;
 
             auto ch = input.view.substring_view(state.string_position, 1)[0];

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -1060,9 +1060,11 @@ ALWAYS_INLINE ExecutionResult OpCode_Checkpoint::execute(MatchInput const& input
 
 ALWAYS_INLINE ExecutionResult OpCode_JumpNonEmpty::execute(MatchInput const& input, MatchState& state) const
 {
-    auto current_position = state.string_position;
+    u64 current_position = state.string_position;
     auto checkpoint_ip = state.instruction_position + size() + checkpoint();
-    if (input.checkpoints.get(checkpoint_ip).value_or(current_position) != current_position) {
+    auto checkpoint_position = input.checkpoints.find(checkpoint_ip);
+
+    if (checkpoint_position != input.checkpoints.end() && checkpoint_position->value != current_position) {
         auto form = this->form();
 
         if (form == OpCodeId::Jump) {

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -927,12 +927,12 @@ Vector<CompareTypeAndValuePair> OpCode_Compare::flat_compares() const
     return result;
 }
 
-Vector<String> OpCode_Compare::variable_arguments_to_string(Optional<MatchInput> input) const
+Vector<String> OpCode_Compare::variable_arguments_to_string(Optional<MatchInput const&> input) const
 {
     Vector<String> result;
 
     size_t offset { state().instruction_position + 3 };
-    RegexStringView view = ((input.has_value()) ? input.value().view : StringView {});
+    RegexStringView const& view = ((input.has_value()) ? input.value().view : StringView {});
 
     for (size_t i = 0; i < arguments_count(); ++i) {
         auto compare_type = (CharacterCompareType)m_bytecode->at(offset++);

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -746,7 +746,7 @@ public:
     ALWAYS_INLINE size_t arguments_count() const { return argument(0); }
     ALWAYS_INLINE size_t arguments_size() const { return argument(1); }
     String arguments_string() const override;
-    Vector<String> variable_arguments_to_string(Optional<MatchInput> input = {}) const;
+    Vector<String> variable_arguments_to_string(Optional<MatchInput const&> input = {}) const;
     Vector<CompareTypeAndValuePair> flat_compares() const;
     static bool matches_character_class(CharClass, u32, bool insensitive);
 

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -452,8 +452,6 @@ bool Matcher<Parser>::execute(MatchInput const& input, MatchState& state, size_t
                         (*it) = state;
                         it->instruction_position = state.fork_at_position;
                         it->initiating_fork = *input.fork_to_replace;
-                        it->capture_group_matches = state.capture_group_matches;
-                        it->matches = state.matches;
                         found = true;
                         break;
                     }

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -156,7 +156,7 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
 
         for (size_t j = 0; j < c_match_preallocation_count; ++j) {
             state.matches.empend();
-            state.capture_group_matches.unchecked_append({});
+            state.capture_group_matches.empend();
             state.capture_group_matches.at(j).ensure_capacity(capture_groups_count);
             for (size_t k = 0; k < capture_groups_count; ++k)
                 state.capture_group_matches.at(j).unchecked_append({});
@@ -306,8 +306,8 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
     RegexResult result {
         match_count != 0,
         match_count,
-        move(state.matches),
-        move(state.capture_group_matches),
+        move(state.matches).release(),
+        move(state.capture_group_matches).release(),
         operations,
         m_pattern->parser_result.capture_groups_count,
         m_pattern->parser_result.named_capture_groups_count,


### PR DESCRIPTION
The optimisation stuff brings the runtime of
```js
var re = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)?((?:file|https?|blob|chrome|webpack|resource|moz-extension).*?:\/.*?|\[native code\]|[^@]*(?:bundle|\d+\.js))(?::(\d+))?(?::(\d+))?\s*$/

let x = ""
for (let i = 0; i < 16000; ++i)
    x += "x"

re.test(x)
```
down to 11s from 45s (which is still a couple orders of magnitude slower than it should be).