### PR TITLE
AudioServer: Stop glitching when toggling mute

### DIFF
--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -100,8 +100,7 @@ void Mixer::mix()
         if (m_muted || m_main_volume < 0.01) {
             m_device->write(m_zero_filled_buffer.data(), static_cast<int>(m_zero_filled_buffer.size()));
         } else {
-            Array<u8, HARDWARE_BUFFER_SIZE_BYTES> buffer;
-            OutputMemoryStream stream { buffer };
+            OutputMemoryStream stream { m_stream_buffer };
 
             for (auto& mixed_sample : mixed_buffer) {
                 mixed_sample.log_multiply(static_cast<float>(m_main_volume));

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -133,6 +133,7 @@ private:
     NonnullRefPtr<Core::ConfigFile> m_config;
     RefPtr<Core::Timer> m_config_write_timer;
 
+    Array<u8, HARDWARE_BUFFER_SIZE_BYTES> m_stream_buffer;
     Array<u8, HARDWARE_BUFFER_SIZE_BYTES> const m_zero_filled_buffer {};
 
     void mix();

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -133,7 +133,7 @@ private:
     NonnullRefPtr<Core::ConfigFile> m_config;
     RefPtr<Core::Timer> m_config_write_timer;
 
-    Array<u8, HARDWARE_BUFFER_SIZE_BYTES> m_zero_filled_buffer;
+    Array<u8, HARDWARE_BUFFER_SIZE_BYTES> const m_zero_filled_buffer {};
 
     void mix();
 };


### PR DESCRIPTION
Initialize the `AudioServer::Mixer::m_zero_filled_buffer` to zero. The garbage memory inside that buffer was causing a glitch sound when the user was toggling the mute checkbox or was moving the volume slider on and off zero. Glitching was more obvious if the toggling was happening without any sound being played in parallel.

In addition to that, the `m_zero_filled_buffer` turned to const since there is no intention to modify its content.

Finally, the buffer provided to `OutputMemoryStream` was made a private class member since there is no reason to re-create it in every iteration.