### PR TITLE
Replace history entry if loading URL because of a redirect

### DIFF
--- a/Userland/Applications/Browser/History.cpp
+++ b/Userland/Applications/Browser/History.cpp
@@ -30,6 +30,15 @@ void History::push(const URL& url, String const& title)
     m_current++;
 }
 
+void History::replace_current(const URL& url, String const& title)
+{
+    if (m_current == -1)
+        return;
+
+    m_current--;
+    push(url, title);
+}
+
 History::URLTitlePair History::current() const
 {
     if (m_current == -1)

--- a/Userland/Applications/Browser/History.h
+++ b/Userland/Applications/Browser/History.h
@@ -20,6 +20,7 @@ public:
     void dump() const;
 
     void push(const URL& url, String const& title);
+    void replace_current(const URL& url, String const& title);
     void update_title(String const& title);
     URLTitlePair current() const;
 

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -202,9 +202,15 @@ Tab::Tab(BrowserWindow& window)
     m_bookmark_button->set_icon(g_icon_bag.bookmark_contour);
     m_bookmark_button->set_fixed_size(22, 22);
 
-    view().on_load_start = [this](auto& url) {
+    view().on_load_start = [this](auto& url, bool is_redirect) {
         m_navigating_url = url;
         m_loaded = false;
+
+        // If we are loading due to a redirect, we replace the current history entry
+        // with the loaded URL
+        if (is_redirect) {
+            m_history.replace_current(url, title());
+        }
 
         update_status();
 

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -215,10 +215,10 @@ bool FrameLoader::load(LoadRequest& request, Type type)
 
     auto& url = request.url();
 
-    if (type == Type::Navigation || type == Type::Reload) {
+    if (type == Type::Navigation || type == Type::Reload || type == Type::Redirect) {
         if (auto* page = browsing_context().page()) {
             if (&page->top_level_browsing_context() == &m_browsing_context)
-                page->client().page_did_start_loading(url);
+                page->client().page_did_start_loading(url, type == Type::Redirect);
         }
     }
 
@@ -401,7 +401,7 @@ void FrameLoader::resource_did_load()
                 return;
             }
             m_redirects_count++;
-            load(url.complete_url(location.value()), FrameLoader::Type::Navigation);
+            load(url.complete_url(location.value()), Type::Redirect);
             return;
         }
     }

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.h
@@ -21,6 +21,7 @@ public:
         Navigation,
         Reload,
         IFrame,
+        Redirect,
     };
 
     static void set_default_favicon_path(String);

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -152,7 +152,7 @@ public:
     virtual Gfx::IntRect page_did_request_maximize_window() { return {}; }
     virtual Gfx::IntRect page_did_request_minimize_window() { return {}; }
     virtual Gfx::IntRect page_did_request_fullscreen_window() { return {}; }
-    virtual void page_did_start_loading(const AK::URL&) { }
+    virtual void page_did_start_loading(const AK::URL&, bool is_redirect) { (void)is_redirect; }
     virtual void page_did_create_main_document() { }
     virtual void page_did_finish_loading(const AK::URL&) { }
     virtual void page_did_change_selection() { }

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -298,7 +298,7 @@ void OutOfProcessWebView::notify_server_did_middle_click_link(Badge<WebContentCl
         on_link_middle_click(url, target, modifiers);
 }
 
-void OutOfProcessWebView::notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL& url)
+void OutOfProcessWebView::notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL& url, bool)
 {
     m_url = url;
     if (on_load_start)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -298,11 +298,11 @@ void OutOfProcessWebView::notify_server_did_middle_click_link(Badge<WebContentCl
         on_link_middle_click(url, target, modifiers);
 }
 
-void OutOfProcessWebView::notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL& url, bool)
+void OutOfProcessWebView::notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL& url, bool is_redirect)
 {
     m_url = url;
     if (on_load_start)
-        on_load_start(url);
+        on_load_start(url, is_redirect);
 }
 
 void OutOfProcessWebView::notify_server_did_finish_loading(Badge<WebContentClient>, const AK::URL& url)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -82,7 +82,7 @@ public:
     Function<void(const AK::URL&, String const& target, unsigned modifiers)> on_link_middle_click;
     Function<void(const AK::URL&)> on_link_hover;
     Function<void(String const&)> on_title_change;
-    Function<void(const AK::URL&)> on_load_start;
+    Function<void(const AK::URL&, bool)> on_load_start;
     Function<void(const AK::URL&)> on_load_finish;
     Function<void()> on_navigate_back;
     Function<void()> on_navigate_forward;
@@ -147,7 +147,7 @@ private:
     virtual void notify_server_did_unhover_link(Badge<WebContentClient>) override;
     virtual void notify_server_did_click_link(Badge<WebContentClient>, const AK::URL&, String const& target, unsigned modifiers) override;
     virtual void notify_server_did_middle_click_link(Badge<WebContentClient>, const AK::URL&, String const& target, unsigned modifiers) override;
-    virtual void notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL&, bool is_redirect) override;
+    virtual void notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL&, bool) override;
     virtual void notify_server_did_finish_loading(Badge<WebContentClient>, const AK::URL&) override;
     virtual void notify_server_did_request_navigate_back(Badge<WebContentClient>) override;
     virtual void notify_server_did_request_navigate_forward(Badge<WebContentClient>) override;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -147,7 +147,7 @@ private:
     virtual void notify_server_did_unhover_link(Badge<WebContentClient>) override;
     virtual void notify_server_did_click_link(Badge<WebContentClient>, const AK::URL&, String const& target, unsigned modifiers) override;
     virtual void notify_server_did_middle_click_link(Badge<WebContentClient>, const AK::URL&, String const& target, unsigned modifiers) override;
-    virtual void notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL&) override;
+    virtual void notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL&, bool is_redirect) override;
     virtual void notify_server_did_finish_loading(Badge<WebContentClient>, const AK::URL&) override;
     virtual void notify_server_did_request_navigate_back(Badge<WebContentClient>) override;
     virtual void notify_server_did_request_navigate_forward(Badge<WebContentClient>) override;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -33,7 +33,7 @@ public:
     virtual void notify_server_did_unhover_link(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_click_link(Badge<WebContentClient>, const AK::URL&, String const& target, unsigned modifiers) = 0;
     virtual void notify_server_did_middle_click_link(Badge<WebContentClient>, const AK::URL&, String const& target, unsigned modifiers) = 0;
-    virtual void notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL&) = 0;
+    virtual void notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL&, bool is_redirect) = 0;
     virtual void notify_server_did_finish_loading(Badge<WebContentClient>, const AK::URL&) = 0;
     virtual void notify_server_did_request_navigate_back(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_request_navigate_forward(Badge<WebContentClient>) = 0;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -131,9 +131,9 @@ void WebContentClient::did_middle_click_link(AK::URL const& url, String const& t
     m_view.notify_server_did_middle_click_link({}, url, target, modifiers);
 }
 
-void WebContentClient::did_start_loading(AK::URL const& url)
+void WebContentClient::did_start_loading(AK::URL const& url, bool is_redirect)
 {
-    m_view.notify_server_did_start_loading({}, url);
+    m_view.notify_server_did_start_loading({}, url, is_redirect);
 }
 
 void WebContentClient::did_request_context_menu(Gfx::IntPoint const& content_position)

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -47,7 +47,7 @@ private:
     virtual void did_unhover_link() override;
     virtual void did_click_link(AK::URL const&, String const&, unsigned) override;
     virtual void did_middle_click_link(AK::URL const&, String const&, unsigned) override;
-    virtual void did_start_loading(AK::URL const&) override;
+    virtual void did_start_loading(AK::URL const&, bool) override;
     virtual void did_request_context_menu(Gfx::IntPoint const&) override;
     virtual void did_request_link_context_menu(Gfx::IntPoint const&, AK::URL const&, String const&, unsigned) override;
     virtual void did_request_image_context_menu(Gfx::IntPoint const&, AK::URL const&, String const&, unsigned, Gfx::ShareableBitmap const&) override;

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -253,9 +253,9 @@ void PageHost::page_did_middle_click_link(const URL& url, [[maybe_unused]] Strin
     m_client.async_did_middle_click_link(url, target, modifiers);
 }
 
-void PageHost::page_did_start_loading(const URL& url)
+void PageHost::page_did_start_loading(const URL& url, bool is_redirect)
 {
-    m_client.async_did_start_loading(url);
+    m_client.async_did_start_loading(url, is_redirect);
 }
 
 void PageHost::page_did_create_main_document()

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -77,7 +77,7 @@ private:
     virtual void page_did_middle_click_link(const URL&, String const& target, unsigned modifiers) override;
     virtual void page_did_request_context_menu(Gfx::IntPoint const&) override;
     virtual void page_did_request_link_context_menu(Gfx::IntPoint const&, const URL&, String const& target, unsigned modifiers) override;
-    virtual void page_did_start_loading(const URL&) override;
+    virtual void page_did_start_loading(const URL&, bool) override;
     virtual void page_did_create_main_document() override;
     virtual void page_did_finish_loading(const URL&) override;
     virtual void page_did_request_alert(String const&) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -6,7 +6,7 @@
 
 endpoint WebContentClient
 {
-    did_start_loading(URL url) =|
+    did_start_loading(URL url, bool is_redirect) =|
     did_finish_loading(URL url) =|
     did_request_navigate_back() =|
     did_request_navigate_forward() =|

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -155,7 +155,7 @@ public:
     {
     }
 
-    virtual void page_did_start_loading(AK::URL const&) override
+    virtual void page_did_start_loading(AK::URL const&, bool) override
     {
     }
 


### PR DESCRIPTION
We now replace the current history entry if the page-load has been caused because of a redirect. This makes it able to traverse the history if one of the entries redirects you, which previously caused an infinite history traversion loop. We do this by labeling loads with a new FrameLoader::Type::Redirect, and handling that case differently in the browser :^))