### PR TITLE
AK+Everywhere: Replace DistinctNumeric bool parameters with named ones

### DIFF
--- a/AK/ArbitrarySizedEnum.h
+++ b/AK/ArbitrarySizedEnum.h
@@ -113,13 +113,12 @@ struct ArbitrarySizedEnum : public T {
     }
 };
 
-#define AK_MAKE_ARBITRARY_SIZED_ENUM(EnumName, T, ...)                               \
-    namespace EnumName {                                                             \
-    using EnumName = ArbitrarySizedEnum<DistinctNumeric<T, struct __##EnumName##Tag, \
-        false, true, false, false, false, false>>;                                   \
-    using Type = EnumName;                                                           \
-    using UnderlyingType = T;                                                        \
-    inline constexpr static EnumName __VA_ARGS__;                                    \
+#define AK_MAKE_ARBITRARY_SIZED_ENUM(EnumName, T, ...)                                                                         \
+    namespace EnumName {                                                                                                       \
+    using EnumName = ArbitrarySizedEnum<DistinctNumeric<T, struct __##EnumName##Tag, AK::DistinctNumericFeature::Comparison>>; \
+    using Type = EnumName;                                                                                                     \
+    using UnderlyingType = T;                                                                                                  \
+    inline constexpr static EnumName __VA_ARGS__;                                                                              \
     }
 
 }

--- a/AK/DistinctNumeric.h
+++ b/AK/DistinctNumeric.h
@@ -51,6 +51,7 @@ namespace AK {
 namespace DistinctNumericFeature {
 enum Arithmetic {};
 enum CastToBool {};
+enum CastToUnderlying {};
 enum Comparison {};
 enum Flags {};
 enum Increment {};
@@ -73,6 +74,7 @@ class DistinctNumeric {
 
         constexpr void set(DistinctNumericFeature::Arithmetic const&) { arithmetic = true; }
         constexpr void set(DistinctNumericFeature::CastToBool const&) { cast_to_bool = true; }
+        constexpr void set(DistinctNumericFeature::CastToUnderlying const&) { cast_to_underlying = true; }
         constexpr void set(DistinctNumericFeature::Comparison const&) { comparisons = true; }
         constexpr void set(DistinctNumericFeature::Flags const&) { flags = true; }
         constexpr void set(DistinctNumericFeature::Increment const&) { increment = true; }
@@ -80,6 +82,7 @@ class DistinctNumeric {
 
         bool arithmetic { false };
         bool cast_to_bool { false };
+        bool cast_to_underlying { false };
         bool comparisons { false };
         bool flags { false };
         bool increment { false };
@@ -103,6 +106,13 @@ public:
     constexpr bool operator==(Self const& other) const
     {
         return this->m_value == other.m_value;
+    }
+
+    // Only implemented when `CastToUnderlying` is true:
+    constexpr explicit operator T() const
+    {
+        static_assert(options.cast_to_underlying, "Cast to underlying type is only available for DistinctNumeric types with 'CastToUnderlying'.");
+        return value();
     }
 
     // Only implemented when `Increment` is true:
@@ -316,6 +326,7 @@ struct Formatter<DistinctNumeric<T, X, Opts...>> : Formatter<T> {
     struct NAME##_decl {                                                                        \
         using Arithmetic [[maybe_unused]] = AK::DistinctNumericFeature::Arithmetic;             \
         using CastToBool [[maybe_unused]] = AK::DistinctNumericFeature::CastToBool;             \
+        using CastToUnderlying [[maybe_unused]] = AK::DistinctNumericFeature::CastToUnderlying; \
         using Comparison [[maybe_unused]] = AK::DistinctNumericFeature::Comparison;             \
         using Flags [[maybe_unused]] = AK::DistinctNumericFeature::Flags;                       \
         using Increment [[maybe_unused]] = AK::DistinctNumericFeature::Increment;               \

--- a/Tests/AK/TestDistinctNumeric.cpp
+++ b/Tests/AK/TestDistinctNumeric.cpp
@@ -13,7 +13,7 @@ class ForType {
 public:
     static void check_size()
     {
-        AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(T, false, false, false, false, false, false, TheNumeric);
+        AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(T, TheNumeric);
         EXPECT_EQ(sizeof(T), sizeof(TheNumeric));
     }
 };
@@ -34,14 +34,14 @@ TEST_CASE(check_size)
     ForType<double>::check_size();
 }
 
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, false, false, false, false, false, false, BareNumeric);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, true, false, false, false, false, false, IncrNumeric);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, false, true, false, false, false, false, CmpNumeric);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, false, false, true, false, false, false, BoolNumeric);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, false, false, false, true, false, false, FlagsNumeric);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, false, false, false, false, true, false, ShiftNumeric);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, false, false, false, false, false, true, ArithNumeric);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, true, true, true, true, true, true, GeneralNumeric);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, BareNumeric);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, IncrNumeric, Increment);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, CmpNumeric, Comparison);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, BoolNumeric, CastToBool);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, FlagsNumeric, Flags);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, ShiftNumeric, Shift);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, ArithNumeric, Arithmetic);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, GeneralNumeric, Arithmetic, CastToBool, Comparison, Flags, Increment, Shift);
 
 TEST_CASE(address_identity)
 {
@@ -230,21 +230,21 @@ TEST_CASE(negative_incr)
 {
     BareNumeric a = 12;
     a++;
-    // error: static assertion failed: 'a++' is only available for DistinctNumeric types with 'Incr'.
+    // error: static assertion failed: 'a++' is only available for DistinctNumeric types with 'Increment'.
 }
 
 TEST_CASE(negative_cmp)
 {
     BareNumeric a = 12;
     [[maybe_unused]] auto res = (a < a);
-    // error: static assertion failed: 'a<b' is only available for DistinctNumeric types with 'Cmp'.
+    // error: static assertion failed: 'a<b' is only available for DistinctNumeric types with 'Comparison'.
 }
 
 TEST_CASE(negative_bool)
 {
     BareNumeric a = 12;
     [[maybe_unused]] auto res = !a;
-    // error: static assertion failed: '!a', 'a&&b', 'a||b' and similar operators are only available for DistinctNumeric types with 'Bool'.
+    // error: static assertion failed: '!a', 'a&&b', 'a||b' and similar operators are only available for DistinctNumeric types with 'CastToBool'.
 }
 
 TEST_CASE(negative_flags)
@@ -265,7 +265,7 @@ TEST_CASE(negative_arith)
 {
     BareNumeric a = 12;
     [[maybe_unused]] auto res = (a + a);
-    // error: static assertion failed: 'a+b' is only available for DistinctNumeric types with 'Arith'.
+    // error: static assertion failed: 'a+b' is only available for DistinctNumeric types with 'Arithmetic'.
 }
 
 TEST_CASE(negative_incompatible)

--- a/Tests/AK/TestDistinctNumeric.cpp
+++ b/Tests/AK/TestDistinctNumeric.cpp
@@ -41,7 +41,8 @@ AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, BoolNumeric, CastToBool);
 AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, FlagsNumeric, Flags);
 AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, ShiftNumeric, Shift);
 AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, ArithNumeric, Arithmetic);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, GeneralNumeric, Arithmetic, CastToBool, Comparison, Flags, Increment, Shift);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, UnderlyingNumeric, CastToUnderlying);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, GeneralNumeric, Arithmetic, CastToBool, CastToUnderlying, Comparison, Flags, Increment, Shift);
 
 TEST_CASE(address_identity)
 {
@@ -103,6 +104,14 @@ TEST_CASE(operator_bool)
     EXPECT_EQ(!a, true);
     EXPECT_EQ(!b, false);
     EXPECT_EQ(!c, false);
+}
+
+TEST_CASE(operator_underlying)
+{
+    UnderlyingNumeric a = 0;
+    UnderlyingNumeric b = 42;
+    EXPECT_EQ(static_cast<int>(a), 0);
+    EXPECT_EQ(static_cast<int>(b), 42);
 }
 
 TEST_CASE(operator_flags)
@@ -216,6 +225,9 @@ TEST_CASE(composability)
     EXPECT_EQ(-b, GeneralNumeric(-1));
     EXPECT_EQ(a + b, b);
     EXPECT_EQ(b * GeneralNumeric(42), GeneralNumeric(42));
+    // Underlying
+    EXPECT_EQ(static_cast<int>(a), 0);
+    EXPECT_EQ(static_cast<int>(b), 1);
 }
 
 /*
@@ -266,6 +278,13 @@ TEST_CASE(negative_arith)
     BareNumeric a = 12;
     [[maybe_unused]] auto res = (a + a);
     // error: static assertion failed: 'a+b' is only available for DistinctNumeric types with 'Arithmetic'.
+}
+
+TEST_CASE(negative_underlying)
+{
+    BareNumeric a = 12;
+    [[maybe_unused]] int res = static_cast<int>(a);
+    // error: static assertion failed: Cast to underlying type is only available for DistinctNumeric types with 'CastToUnderlying'.
 }
 
 TEST_CASE(negative_incompatible)

--- a/Userland/Libraries/LibJS/Bytecode/IdentifierTable.h
+++ b/Userland/Libraries/LibJS/Bytecode/IdentifierTable.h
@@ -12,7 +12,7 @@
 
 namespace JS::Bytecode {
 
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(size_t, false, true, false, false, false, false, IdentifierTableIndex);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(size_t, IdentifierTableIndex, Comparison);
 
 class IdentifierTable {
     AK_MAKE_NONMOVABLE(IdentifierTable);

--- a/Userland/Libraries/LibJS/Bytecode/StringTable.h
+++ b/Userland/Libraries/LibJS/Bytecode/StringTable.h
@@ -12,7 +12,7 @@
 
 namespace JS::Bytecode {
 
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(size_t, false, true, false, false, false, false, StringTableIndex);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(size_t, StringTableIndex, Comparison);
 
 class StringTable {
     AK_MAKE_NONMOVABLE(StringTable);

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -29,13 +29,13 @@ struct LinkError {
     Vector<OtherErrors> other_errors;
 };
 
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, true, true, false, false, false, true, FunctionAddress);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, true, true, false, false, false, true, ExternAddress);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, true, true, false, false, false, true, TableAddress);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, true, true, false, false, false, true, GlobalAddress);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, true, true, false, false, false, true, ElementAddress);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, true, true, false, false, false, true, DataAddress);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, true, true, false, false, false, true, MemoryAddress);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, FunctionAddress, Arithmetic, Comparison, Increment);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, ExternAddress, Arithmetic, Comparison, Increment);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, TableAddress, Arithmetic, Comparison, Increment);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, GlobalAddress, Arithmetic, Comparison, Increment);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, ElementAddress, Arithmetic, Comparison, Increment);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, DataAddress, Arithmetic, Comparison, Increment);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, MemoryAddress, Arithmetic, Comparison, Increment);
 
 // FIXME: These should probably be made generic/virtual if/when we decide to do something more
 //        fancy than just a dumb interpreter.

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -57,7 +57,7 @@ AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, LocalIndex);
 AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, GlobalIndex);
 AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, LabelIndex);
 AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, DataIndex);
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, true, true, false, true, false, true, InstructionPointer);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, InstructionPointer, Arithmetic, Comparison, Flags, Increment);
 
 ParseError with_eof_check(InputStream const& stream, ParseError error_if_not_eof);
 


### PR DESCRIPTION
This means that rather than this:

```c++
AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, true, true, false, false, false, true, FunctionAddress);
```

We now have this:
```c++
AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, FunctionAddress, Arithmetic, Comparison, Increment);
```

Which is a lot more readable. :^)

cc: @alimpfard 