### PR TITLE
WebContent+WebDriver: Move all element state commands from section 12.4 over to WebContent

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -611,10 +611,6 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
         active_tab().view().scroll_element_into_view(element_id);
     };
 
-    new_tab.webdriver_endpoints().on_get_element_text = [this](i32 element_id) {
-        return active_tab().view().get_element_text(element_id);
-    };
-
     new_tab.webdriver_endpoints().on_get_element_tag_name = [this](i32 element_id) {
         return active_tab().view().get_element_tag_name(element_id);
     };

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -611,14 +611,6 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
         active_tab().view().scroll_element_into_view(element_id);
     };
 
-    new_tab.webdriver_endpoints().on_get_active_documents_type = [this]() {
-        return active_tab().view().get_active_documents_type();
-    };
-
-    new_tab.webdriver_endpoints().on_get_computed_value_for_element = [this](i32 element_id, String const& property_name) {
-        return active_tab().view().get_computed_value_for_element(element_id, property_name);
-    };
-
     new_tab.webdriver_endpoints().on_get_element_text = [this](i32 element_id) {
         return active_tab().view().get_element_text(element_id);
     };

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -611,10 +611,6 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
         active_tab().view().scroll_element_into_view(element_id);
     };
 
-    new_tab.webdriver_endpoints().on_get_element_rect = [this](i32 element_id) {
-        return active_tab().view().get_element_rect(element_id);
-    };
-
     new_tab.webdriver_endpoints().on_is_element_enabled = [this](i32 element_id) {
         return active_tab().view().is_element_enabled(element_id);
     };

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -611,10 +611,6 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
         active_tab().view().scroll_element_into_view(element_id);
     };
 
-    new_tab.webdriver_endpoints().on_is_element_enabled = [this](i32 element_id) {
-        return active_tab().view().is_element_enabled(element_id);
-    };
-
     new_tab.webdriver_endpoints().on_serialize_source = [this]() {
         return active_tab().view().serialize_source();
     };

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -611,10 +611,6 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
         active_tab().view().scroll_element_into_view(element_id);
     };
 
-    new_tab.webdriver_endpoints().on_get_element_attribute = [this](i32 element_id, String const& name) {
-        return active_tab().view().get_element_attribute(element_id, name);
-    };
-
     new_tab.webdriver_endpoints().on_get_element_property = [this](i32 element_id, String const& name) {
         return active_tab().view().get_element_property(element_id, name);
     };

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -611,10 +611,6 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
         active_tab().view().scroll_element_into_view(element_id);
     };
 
-    new_tab.webdriver_endpoints().on_get_element_property = [this](i32 element_id, String const& name) {
-        return active_tab().view().get_element_property(element_id, name);
-    };
-
     new_tab.webdriver_endpoints().on_get_active_documents_type = [this]() {
         return active_tab().view().get_active_documents_type();
     };

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -611,10 +611,6 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
         active_tab().view().scroll_element_into_view(element_id);
     };
 
-    new_tab.webdriver_endpoints().on_get_element_tag_name = [this](i32 element_id) {
-        return active_tab().view().get_element_tag_name(element_id);
-    };
-
     new_tab.webdriver_endpoints().on_get_element_rect = [this](i32 element_id) {
         return active_tab().view().get_element_rect(element_id);
     };

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -611,10 +611,6 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
         active_tab().view().scroll_element_into_view(element_id);
     };
 
-    new_tab.webdriver_endpoints().on_is_element_selected = [this](i32 element_id) {
-        return active_tab().view().is_element_selected(element_id);
-    };
-
     new_tab.webdriver_endpoints().on_get_element_attribute = [this](i32 element_id, String const& name) {
         return active_tab().view().get_element_attribute(element_id, name);
     };

--- a/Userland/Applications/Browser/WebDriverConnection.cpp
+++ b/Userland/Applications/Browser/WebDriverConnection.cpp
@@ -146,17 +146,6 @@ void WebDriverConnection::scroll_element_into_view(i32 element_id)
     }
 }
 
-Messages::WebDriverSessionClient::GetElementTagNameResponse WebDriverConnection::get_element_tag_name(i32 element_id)
-{
-    dbgln("WebDriverConnection: get_computed_value_for_element");
-    if (auto browser_window = m_browser_window.strong_ref()) {
-        auto& tab = browser_window->active_tab();
-        if (tab.webdriver_endpoints().on_get_element_tag_name)
-            return { tab.webdriver_endpoints().on_get_element_tag_name(element_id) };
-    }
-    return { "" };
-}
-
 Messages::WebDriverSessionClient::GetElementRectResponse WebDriverConnection::get_element_rect(i32 element_id)
 {
     dbgln("WebDriverConnection: get_element_rect {}", element_id);

--- a/Userland/Applications/Browser/WebDriverConnection.cpp
+++ b/Userland/Applications/Browser/WebDriverConnection.cpp
@@ -146,17 +146,6 @@ void WebDriverConnection::scroll_element_into_view(i32 element_id)
     }
 }
 
-Messages::WebDriverSessionClient::IsElementEnabledResponse WebDriverConnection::is_element_enabled(i32 element_id)
-{
-    dbgln("WebDriverConnection: is_element_enabled {}", element_id);
-    if (auto browser_window = m_browser_window.strong_ref()) {
-        auto& tab = browser_window->active_tab();
-        if (tab.webdriver_endpoints().on_is_element_enabled)
-            return { tab.webdriver_endpoints().on_is_element_enabled(element_id) };
-    }
-    return { false };
-}
-
 Messages::WebDriverSessionClient::TakeScreenshotResponse WebDriverConnection::take_screenshot()
 {
     dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: take_screenshot");

--- a/Userland/Applications/Browser/WebDriverConnection.cpp
+++ b/Userland/Applications/Browser/WebDriverConnection.cpp
@@ -146,28 +146,6 @@ void WebDriverConnection::scroll_element_into_view(i32 element_id)
     }
 }
 
-Messages::WebDriverSessionClient::GetActiveDocumentsTypeResponse WebDriverConnection::get_active_documents_type()
-{
-    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_active_documents_type");
-    if (auto browser_window = m_browser_window.strong_ref()) {
-        auto& tab = browser_window->active_tab();
-        if (tab.webdriver_endpoints().on_get_active_documents_type)
-            return { tab.webdriver_endpoints().on_get_active_documents_type() };
-    }
-    return { "" };
-}
-
-Messages::WebDriverSessionClient::GetComputedValueForElementResponse WebDriverConnection::get_computed_value_for_element(i32 element_id, String const& property_name)
-{
-    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_computed_value_for_element");
-    if (auto browser_window = m_browser_window.strong_ref()) {
-        auto& tab = browser_window->active_tab();
-        if (tab.webdriver_endpoints().on_get_computed_value_for_element)
-            return { tab.webdriver_endpoints().on_get_computed_value_for_element(element_id, property_name) };
-    }
-    return { "" };
-}
-
 Messages::WebDriverSessionClient::GetElementTextResponse WebDriverConnection::get_element_text(i32 element_id)
 {
     dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_element_text");

--- a/Userland/Applications/Browser/WebDriverConnection.cpp
+++ b/Userland/Applications/Browser/WebDriverConnection.cpp
@@ -146,17 +146,6 @@ void WebDriverConnection::scroll_element_into_view(i32 element_id)
     }
 }
 
-Messages::WebDriverSessionClient::GetElementPropertyResponse WebDriverConnection::get_element_property(i32 element_id, String const& name)
-{
-    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_element_property");
-    if (auto browser_window = m_browser_window.strong_ref()) {
-        auto& tab = browser_window->active_tab();
-        if (tab.webdriver_endpoints().on_get_element_property)
-            return { tab.webdriver_endpoints().on_get_element_property(element_id, name) };
-    }
-    return { {} };
-}
-
 Messages::WebDriverSessionClient::GetActiveDocumentsTypeResponse WebDriverConnection::get_active_documents_type()
 {
     dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_active_documents_type");

--- a/Userland/Applications/Browser/WebDriverConnection.cpp
+++ b/Userland/Applications/Browser/WebDriverConnection.cpp
@@ -146,17 +146,6 @@ void WebDriverConnection::scroll_element_into_view(i32 element_id)
     }
 }
 
-Messages::WebDriverSessionClient::GetElementTextResponse WebDriverConnection::get_element_text(i32 element_id)
-{
-    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_element_text");
-    if (auto browser_window = m_browser_window.strong_ref()) {
-        auto& tab = browser_window->active_tab();
-        if (tab.webdriver_endpoints().on_get_element_text)
-            return { tab.webdriver_endpoints().on_get_element_text(element_id) };
-    }
-    return { "" };
-}
-
 Messages::WebDriverSessionClient::GetElementTagNameResponse WebDriverConnection::get_element_tag_name(i32 element_id)
 {
     dbgln("WebDriverConnection: get_computed_value_for_element");

--- a/Userland/Applications/Browser/WebDriverConnection.cpp
+++ b/Userland/Applications/Browser/WebDriverConnection.cpp
@@ -146,17 +146,6 @@ void WebDriverConnection::scroll_element_into_view(i32 element_id)
     }
 }
 
-Messages::WebDriverSessionClient::GetElementAttributeResponse WebDriverConnection::get_element_attribute(i32 element_id, String const& name)
-{
-    dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_element_attribute");
-    if (auto browser_window = m_browser_window.strong_ref()) {
-        auto& tab = browser_window->active_tab();
-        if (tab.webdriver_endpoints().on_get_element_attribute)
-            return { tab.webdriver_endpoints().on_get_element_attribute(element_id, name) };
-    }
-    return { {} };
-}
-
 Messages::WebDriverSessionClient::GetElementPropertyResponse WebDriverConnection::get_element_property(i32 element_id, String const& name)
 {
     dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_element_property");

--- a/Userland/Applications/Browser/WebDriverConnection.cpp
+++ b/Userland/Applications/Browser/WebDriverConnection.cpp
@@ -146,17 +146,6 @@ void WebDriverConnection::scroll_element_into_view(i32 element_id)
     }
 }
 
-Messages::WebDriverSessionClient::GetElementRectResponse WebDriverConnection::get_element_rect(i32 element_id)
-{
-    dbgln("WebDriverConnection: get_element_rect {}", element_id);
-    if (auto browser_window = m_browser_window.strong_ref()) {
-        auto& tab = browser_window->active_tab();
-        if (tab.webdriver_endpoints().on_get_element_rect)
-            return { tab.webdriver_endpoints().on_get_element_rect(element_id) };
-    }
-    return { {} };
-}
-
 Messages::WebDriverSessionClient::IsElementEnabledResponse WebDriverConnection::is_element_enabled(i32 element_id)
 {
     dbgln("WebDriverConnection: is_element_enabled {}", element_id);

--- a/Userland/Applications/Browser/WebDriverConnection.cpp
+++ b/Userland/Applications/Browser/WebDriverConnection.cpp
@@ -146,17 +146,6 @@ void WebDriverConnection::scroll_element_into_view(i32 element_id)
     }
 }
 
-Messages::WebDriverSessionClient::IsElementSelectedResponse WebDriverConnection::is_element_selected(i32 element_id)
-{
-    dbgln("WebDriverConnection: is_element_selected {}", element_id);
-    if (auto browser_window = m_browser_window.strong_ref()) {
-        auto& tab = browser_window->active_tab();
-        if (tab.webdriver_endpoints().on_is_element_selected)
-            return { tab.webdriver_endpoints().on_is_element_selected(element_id) };
-    }
-    return { false };
-}
-
 Messages::WebDriverSessionClient::GetElementAttributeResponse WebDriverConnection::get_element_attribute(i32 element_id, String const& name)
 {
     dbgln_if(WEBDRIVER_DEBUG, "WebDriverConnection: get_element_attribute");

--- a/Userland/Applications/Browser/WebDriverConnection.h
+++ b/Userland/Applications/Browser/WebDriverConnection.h
@@ -49,7 +49,6 @@ public:
     virtual void add_cookie(Web::Cookie::ParsedCookie const&) override;
     virtual void update_cookie(Web::Cookie::Cookie const&) override;
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebDriverSessionClient::GetElementPropertyResponse get_element_property(i32 element_id, String const& name) override;
     virtual Messages::WebDriverSessionClient::GetActiveDocumentsTypeResponse get_active_documents_type() override;
     virtual Messages::WebDriverSessionClient::GetComputedValueForElementResponse get_computed_value_for_element(i32 element_id, String const& property_name) override;
     virtual Messages::WebDriverSessionClient::GetElementTextResponse get_element_text(i32 element_id) override;

--- a/Userland/Applications/Browser/WebDriverConnection.h
+++ b/Userland/Applications/Browser/WebDriverConnection.h
@@ -49,7 +49,6 @@ public:
     virtual void add_cookie(Web::Cookie::ParsedCookie const&) override;
     virtual void update_cookie(Web::Cookie::Cookie const&) override;
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebDriverSessionClient::GetElementTextResponse get_element_text(i32 element_id) override;
     virtual Messages::WebDriverSessionClient::GetElementTagNameResponse get_element_tag_name(i32 element_id) override;
     virtual Messages::WebDriverSessionClient::GetElementRectResponse get_element_rect(i32 element_id) override;
     virtual Messages::WebDriverSessionClient::IsElementEnabledResponse is_element_enabled(i32 element_id) override;

--- a/Userland/Applications/Browser/WebDriverConnection.h
+++ b/Userland/Applications/Browser/WebDriverConnection.h
@@ -49,7 +49,6 @@ public:
     virtual void add_cookie(Web::Cookie::ParsedCookie const&) override;
     virtual void update_cookie(Web::Cookie::Cookie const&) override;
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebDriverSessionClient::IsElementEnabledResponse is_element_enabled(i32 element_id) override;
     virtual Messages::WebDriverSessionClient::TakeScreenshotResponse take_screenshot() override;
     virtual Messages::WebDriverSessionClient::TakeElementScreenshotResponse take_element_screenshot(i32 element_id) override;
 

--- a/Userland/Applications/Browser/WebDriverConnection.h
+++ b/Userland/Applications/Browser/WebDriverConnection.h
@@ -49,7 +49,6 @@ public:
     virtual void add_cookie(Web::Cookie::ParsedCookie const&) override;
     virtual void update_cookie(Web::Cookie::Cookie const&) override;
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebDriverSessionClient::IsElementSelectedResponse is_element_selected(i32 element_id) override;
     virtual Messages::WebDriverSessionClient::GetElementAttributeResponse get_element_attribute(i32 element_id, String const& name) override;
     virtual Messages::WebDriverSessionClient::GetElementPropertyResponse get_element_property(i32 element_id, String const& name) override;
     virtual Messages::WebDriverSessionClient::GetActiveDocumentsTypeResponse get_active_documents_type() override;

--- a/Userland/Applications/Browser/WebDriverConnection.h
+++ b/Userland/Applications/Browser/WebDriverConnection.h
@@ -49,7 +49,6 @@ public:
     virtual void add_cookie(Web::Cookie::ParsedCookie const&) override;
     virtual void update_cookie(Web::Cookie::Cookie const&) override;
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebDriverSessionClient::GetElementRectResponse get_element_rect(i32 element_id) override;
     virtual Messages::WebDriverSessionClient::IsElementEnabledResponse is_element_enabled(i32 element_id) override;
     virtual Messages::WebDriverSessionClient::TakeScreenshotResponse take_screenshot() override;
     virtual Messages::WebDriverSessionClient::TakeElementScreenshotResponse take_element_screenshot(i32 element_id) override;

--- a/Userland/Applications/Browser/WebDriverConnection.h
+++ b/Userland/Applications/Browser/WebDriverConnection.h
@@ -49,7 +49,6 @@ public:
     virtual void add_cookie(Web::Cookie::ParsedCookie const&) override;
     virtual void update_cookie(Web::Cookie::Cookie const&) override;
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebDriverSessionClient::GetElementAttributeResponse get_element_attribute(i32 element_id, String const& name) override;
     virtual Messages::WebDriverSessionClient::GetElementPropertyResponse get_element_property(i32 element_id, String const& name) override;
     virtual Messages::WebDriverSessionClient::GetActiveDocumentsTypeResponse get_active_documents_type() override;
     virtual Messages::WebDriverSessionClient::GetComputedValueForElementResponse get_computed_value_for_element(i32 element_id, String const& property_name) override;

--- a/Userland/Applications/Browser/WebDriverConnection.h
+++ b/Userland/Applications/Browser/WebDriverConnection.h
@@ -49,7 +49,6 @@ public:
     virtual void add_cookie(Web::Cookie::ParsedCookie const&) override;
     virtual void update_cookie(Web::Cookie::Cookie const&) override;
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebDriverSessionClient::GetElementTagNameResponse get_element_tag_name(i32 element_id) override;
     virtual Messages::WebDriverSessionClient::GetElementRectResponse get_element_rect(i32 element_id) override;
     virtual Messages::WebDriverSessionClient::IsElementEnabledResponse is_element_enabled(i32 element_id) override;
     virtual Messages::WebDriverSessionClient::TakeScreenshotResponse take_screenshot() override;

--- a/Userland/Applications/Browser/WebDriverConnection.h
+++ b/Userland/Applications/Browser/WebDriverConnection.h
@@ -49,8 +49,6 @@ public:
     virtual void add_cookie(Web::Cookie::ParsedCookie const&) override;
     virtual void update_cookie(Web::Cookie::Cookie const&) override;
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebDriverSessionClient::GetActiveDocumentsTypeResponse get_active_documents_type() override;
-    virtual Messages::WebDriverSessionClient::GetComputedValueForElementResponse get_computed_value_for_element(i32 element_id, String const& property_name) override;
     virtual Messages::WebDriverSessionClient::GetElementTextResponse get_element_text(i32 element_id) override;
     virtual Messages::WebDriverSessionClient::GetElementTagNameResponse get_element_tag_name(i32 element_id) override;
     virtual Messages::WebDriverSessionClient::GetElementRectResponse get_element_rect(i32 element_id) override;

--- a/Userland/Applications/Browser/WebDriverEndpoints.h
+++ b/Userland/Applications/Browser/WebDriverEndpoints.h
@@ -24,7 +24,6 @@ public:
     ~WebDriverEndpoints() = default;
 
     Function<void(i32 element_id)> on_scroll_element_into_view;
-    Function<bool(i32 element_id)> on_is_element_enabled;
     Function<Gfx::ShareableBitmap(i32 element_id)> on_take_element_screenshot;
     Function<String()> on_serialize_source;
     Function<Messages::WebContentServer::WebdriverExecuteScriptResponse(String const& body, Vector<String> const& json_arguments, Optional<u64> const& timeout, bool async)> on_execute_script;

--- a/Userland/Applications/Browser/WebDriverEndpoints.h
+++ b/Userland/Applications/Browser/WebDriverEndpoints.h
@@ -24,7 +24,6 @@ public:
     ~WebDriverEndpoints() = default;
 
     Function<void(i32 element_id)> on_scroll_element_into_view;
-    Function<Optional<String>(i32 element_id, String const&)> on_get_element_property;
     Function<String()> on_get_active_documents_type;
     Function<String(i32 element_id, String const&)> on_get_computed_value_for_element;
     Function<String(i32 element_id)> on_get_element_text;

--- a/Userland/Applications/Browser/WebDriverEndpoints.h
+++ b/Userland/Applications/Browser/WebDriverEndpoints.h
@@ -24,8 +24,6 @@ public:
     ~WebDriverEndpoints() = default;
 
     Function<void(i32 element_id)> on_scroll_element_into_view;
-    Function<String()> on_get_active_documents_type;
-    Function<String(i32 element_id, String const&)> on_get_computed_value_for_element;
     Function<String(i32 element_id)> on_get_element_text;
     Function<String(i32 element_id)> on_get_element_tag_name;
     Function<Gfx::IntRect(i32 element_id)> on_get_element_rect;

--- a/Userland/Applications/Browser/WebDriverEndpoints.h
+++ b/Userland/Applications/Browser/WebDriverEndpoints.h
@@ -24,7 +24,6 @@ public:
     ~WebDriverEndpoints() = default;
 
     Function<void(i32 element_id)> on_scroll_element_into_view;
-    Function<String(i32 element_id)> on_get_element_tag_name;
     Function<Gfx::IntRect(i32 element_id)> on_get_element_rect;
     Function<bool(i32 element_id)> on_is_element_enabled;
     Function<Gfx::ShareableBitmap(i32 element_id)> on_take_element_screenshot;

--- a/Userland/Applications/Browser/WebDriverEndpoints.h
+++ b/Userland/Applications/Browser/WebDriverEndpoints.h
@@ -24,7 +24,6 @@ public:
     ~WebDriverEndpoints() = default;
 
     Function<void(i32 element_id)> on_scroll_element_into_view;
-    Function<String(i32 element_id)> on_get_element_text;
     Function<String(i32 element_id)> on_get_element_tag_name;
     Function<Gfx::IntRect(i32 element_id)> on_get_element_rect;
     Function<bool(i32 element_id)> on_is_element_enabled;

--- a/Userland/Applications/Browser/WebDriverEndpoints.h
+++ b/Userland/Applications/Browser/WebDriverEndpoints.h
@@ -24,7 +24,6 @@ public:
     ~WebDriverEndpoints() = default;
 
     Function<void(i32 element_id)> on_scroll_element_into_view;
-    Function<bool(i32 element_id)> on_is_element_selected;
     Function<Optional<String>(i32 element_id, String const&)> on_get_element_attribute;
     Function<Optional<String>(i32 element_id, String const&)> on_get_element_property;
     Function<String()> on_get_active_documents_type;

--- a/Userland/Applications/Browser/WebDriverEndpoints.h
+++ b/Userland/Applications/Browser/WebDriverEndpoints.h
@@ -24,7 +24,6 @@ public:
     ~WebDriverEndpoints() = default;
 
     Function<void(i32 element_id)> on_scroll_element_into_view;
-    Function<Optional<String>(i32 element_id, String const&)> on_get_element_attribute;
     Function<Optional<String>(i32 element_id, String const&)> on_get_element_property;
     Function<String()> on_get_active_documents_type;
     Function<String(i32 element_id, String const&)> on_get_computed_value_for_element;

--- a/Userland/Applications/Browser/WebDriverEndpoints.h
+++ b/Userland/Applications/Browser/WebDriverEndpoints.h
@@ -24,7 +24,6 @@ public:
     ~WebDriverEndpoints() = default;
 
     Function<void(i32 element_id)> on_scroll_element_into_view;
-    Function<Gfx::IntRect(i32 element_id)> on_get_element_rect;
     Function<bool(i32 element_id)> on_is_element_enabled;
     Function<Gfx::ShareableBitmap(i32 element_id)> on_take_element_screenshot;
     Function<String()> on_serialize_source;

--- a/Userland/Applications/Browser/WebDriverSessionClient.ipc
+++ b/Userland/Applications/Browser/WebDriverSessionClient.ipc
@@ -25,7 +25,6 @@ endpoint WebDriverSessionClient {
     add_cookie(Web::Cookie::ParsedCookie cookie) =|
     update_cookie(Web::Cookie::Cookie cookie) =|
     scroll_element_into_view(i32 element_id) => ()
-    get_element_property(i32 element_id, String name) => (Optional<String> property)
     get_active_documents_type() => (String type)
     get_computed_value_for_element(i32 element_id, String property_name) => (String computed_value)
     get_element_text(i32 element_id) => (String text)

--- a/Userland/Applications/Browser/WebDriverSessionClient.ipc
+++ b/Userland/Applications/Browser/WebDriverSessionClient.ipc
@@ -25,7 +25,6 @@ endpoint WebDriverSessionClient {
     add_cookie(Web::Cookie::ParsedCookie cookie) =|
     update_cookie(Web::Cookie::Cookie cookie) =|
     scroll_element_into_view(i32 element_id) => ()
-    get_element_attribute(i32 element_id, String name) => (Optional<String> atttibute)
     get_element_property(i32 element_id, String name) => (Optional<String> property)
     get_active_documents_type() => (String type)
     get_computed_value_for_element(i32 element_id, String property_name) => (String computed_value)

--- a/Userland/Applications/Browser/WebDriverSessionClient.ipc
+++ b/Userland/Applications/Browser/WebDriverSessionClient.ipc
@@ -25,8 +25,6 @@ endpoint WebDriverSessionClient {
     add_cookie(Web::Cookie::ParsedCookie cookie) =|
     update_cookie(Web::Cookie::Cookie cookie) =|
     scroll_element_into_view(i32 element_id) => ()
-    get_active_documents_type() => (String type)
-    get_computed_value_for_element(i32 element_id, String property_name) => (String computed_value)
     get_element_text(i32 element_id) => (String text)
     get_element_tag_name(i32 element_id) => (String tag_name)
     get_element_rect(i32 element_id) => (Gfx::IntRect rect)

--- a/Userland/Applications/Browser/WebDriverSessionClient.ipc
+++ b/Userland/Applications/Browser/WebDriverSessionClient.ipc
@@ -25,7 +25,6 @@ endpoint WebDriverSessionClient {
     add_cookie(Web::Cookie::ParsedCookie cookie) =|
     update_cookie(Web::Cookie::Cookie cookie) =|
     scroll_element_into_view(i32 element_id) => ()
-    is_element_selected(i32 element_id) => (bool selected)
     get_element_attribute(i32 element_id, String name) => (Optional<String> atttibute)
     get_element_property(i32 element_id, String name) => (Optional<String> property)
     get_active_documents_type() => (String type)

--- a/Userland/Applications/Browser/WebDriverSessionClient.ipc
+++ b/Userland/Applications/Browser/WebDriverSessionClient.ipc
@@ -25,7 +25,6 @@ endpoint WebDriverSessionClient {
     add_cookie(Web::Cookie::ParsedCookie cookie) =|
     update_cookie(Web::Cookie::Cookie cookie) =|
     scroll_element_into_view(i32 element_id) => ()
-    is_element_enabled(i32 element_id) => (bool enabled)
     take_screenshot() => (Gfx::ShareableBitmap data)
     take_element_screenshot(i32 element_id) => (Gfx::ShareableBitmap data)
 }

--- a/Userland/Applications/Browser/WebDriverSessionClient.ipc
+++ b/Userland/Applications/Browser/WebDriverSessionClient.ipc
@@ -25,7 +25,6 @@ endpoint WebDriverSessionClient {
     add_cookie(Web::Cookie::ParsedCookie cookie) =|
     update_cookie(Web::Cookie::Cookie cookie) =|
     scroll_element_into_view(i32 element_id) => ()
-    get_element_rect(i32 element_id) => (Gfx::IntRect rect)
     is_element_enabled(i32 element_id) => (bool enabled)
     take_screenshot() => (Gfx::ShareableBitmap data)
     take_element_screenshot(i32 element_id) => (Gfx::ShareableBitmap data)

--- a/Userland/Applications/Browser/WebDriverSessionClient.ipc
+++ b/Userland/Applications/Browser/WebDriverSessionClient.ipc
@@ -25,7 +25,6 @@ endpoint WebDriverSessionClient {
     add_cookie(Web::Cookie::ParsedCookie cookie) =|
     update_cookie(Web::Cookie::Cookie cookie) =|
     scroll_element_into_view(i32 element_id) => ()
-    get_element_text(i32 element_id) => (String text)
     get_element_tag_name(i32 element_id) => (String tag_name)
     get_element_rect(i32 element_id) => (Gfx::IntRect rect)
     is_element_enabled(i32 element_id) => (bool enabled)

--- a/Userland/Applications/Browser/WebDriverSessionClient.ipc
+++ b/Userland/Applications/Browser/WebDriverSessionClient.ipc
@@ -25,7 +25,6 @@ endpoint WebDriverSessionClient {
     add_cookie(Web::Cookie::ParsedCookie cookie) =|
     update_cookie(Web::Cookie::Cookie cookie) =|
     scroll_element_into_view(i32 element_id) => ()
-    get_element_tag_name(i32 element_id) => (String tag_name)
     get_element_rect(i32 element_id) => (Gfx::IntRect rect)
     is_element_enabled(i32 element_id) => (bool enabled)
     take_screenshot() => (Gfx::ShareableBitmap data)

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.cpp
@@ -39,5 +39,38 @@ ENUMERATE_HTML_ATTRIBUTES
 }
 
 }
+
+// https://html.spec.whatwg.org/#boolean-attribute
+bool is_boolean_attribute(FlyString const& attribute)
+{
+    // NOTE: This is the list of attributes from https://html.spec.whatwg.org/#attributes-3
+    //       with a Value column value of "Boolean attribute".
+    return attribute.is_one_of(
+        AttributeNames::allowfullscreen,
+        AttributeNames::async,
+        AttributeNames::autofocus,
+        AttributeNames::autoplay,
+        AttributeNames::checked,
+        AttributeNames::controls,
+        AttributeNames::default_,
+        AttributeNames::defer,
+        AttributeNames::disabled,
+        AttributeNames::formnovalidate,
+        AttributeNames::inert,
+        AttributeNames::ismap,
+        AttributeNames::itemscope,
+        AttributeNames::loop,
+        AttributeNames::multiple,
+        AttributeNames::muted,
+        AttributeNames::nomodule,
+        AttributeNames::novalidate,
+        AttributeNames::open,
+        AttributeNames::playsinline,
+        AttributeNames::readonly,
+        AttributeNames::required,
+        AttributeNames::reversed,
+        AttributeNames::selected);
+}
+
 }
 }

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -77,8 +77,10 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(id)                         \
     __ENUMERATE_HTML_ATTRIBUTE(imagesizes)                 \
     __ENUMERATE_HTML_ATTRIBUTE(imagesrcset)                \
+    __ENUMERATE_HTML_ATTRIBUTE(inert)                      \
     __ENUMERATE_HTML_ATTRIBUTE(integrity)                  \
     __ENUMERATE_HTML_ATTRIBUTE(ismap)                      \
+    __ENUMERATE_HTML_ATTRIBUTE(itemscope)                  \
     __ENUMERATE_HTML_ATTRIBUTE(label)                      \
     __ENUMERATE_HTML_ATTRIBUTE(lang)                       \
     __ENUMERATE_HTML_ATTRIBUTE(language)                   \
@@ -92,6 +94,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(method)                     \
     __ENUMERATE_HTML_ATTRIBUTE(min)                        \
     __ENUMERATE_HTML_ATTRIBUTE(multiple)                   \
+    __ENUMERATE_HTML_ATTRIBUTE(muted)                      \
     __ENUMERATE_HTML_ATTRIBUTE(name)                       \
     __ENUMERATE_HTML_ATTRIBUTE(nohref)                     \
     __ENUMERATE_HTML_ATTRIBUTE(nomodule)                   \

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -232,5 +232,8 @@ ENUMERATE_HTML_ATTRIBUTES
 #undef __ENUMERATE_HTML_ATTRIBUTE
 
 }
+
+bool is_boolean_attribute(FlyString const& attribute);
+
 }
 }

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -559,11 +559,6 @@ void OutOfProcessWebView::scroll_element_into_view(i32 element_id)
     return client().scroll_element_into_view(element_id);
 }
 
-Optional<String> OutOfProcessWebView::get_element_attribute(i32 element_id, String const& name)
-{
-    return client().get_element_attribute(element_id, name);
-}
-
 Optional<String> OutOfProcessWebView::get_element_property(i32 element_id, String const& name)
 {
     return client().get_element_property(element_id, name);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -559,11 +559,6 @@ void OutOfProcessWebView::scroll_element_into_view(i32 element_id)
     return client().scroll_element_into_view(element_id);
 }
 
-String OutOfProcessWebView::get_element_tag_name(i32 element_id)
-{
-    return client().get_element_tag_name(element_id);
-}
-
 Gfx::IntRect OutOfProcessWebView::get_element_rect(i32 element_id)
 {
     return client().get_element_rect(element_id);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -559,11 +559,6 @@ void OutOfProcessWebView::scroll_element_into_view(i32 element_id)
     return client().scroll_element_into_view(element_id);
 }
 
-Optional<String> OutOfProcessWebView::get_element_property(i32 element_id, String const& name)
-{
-    return client().get_element_property(element_id, name);
-}
-
 String OutOfProcessWebView::get_active_documents_type()
 {
     return client().get_active_documents_type();

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -559,11 +559,6 @@ void OutOfProcessWebView::scroll_element_into_view(i32 element_id)
     return client().scroll_element_into_view(element_id);
 }
 
-bool OutOfProcessWebView::is_element_selected(i32 element_id)
-{
-    return client().is_element_selected(element_id);
-}
-
 Optional<String> OutOfProcessWebView::get_element_attribute(i32 element_id, String const& name)
 {
     return client().get_element_attribute(element_id, name);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -559,11 +559,6 @@ void OutOfProcessWebView::scroll_element_into_view(i32 element_id)
     return client().scroll_element_into_view(element_id);
 }
 
-String OutOfProcessWebView::get_element_text(i32 element_id)
-{
-    return client().get_element_text(element_id);
-}
-
 String OutOfProcessWebView::get_element_tag_name(i32 element_id)
 {
     return client().get_element_tag_name(element_id);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -559,16 +559,6 @@ void OutOfProcessWebView::scroll_element_into_view(i32 element_id)
     return client().scroll_element_into_view(element_id);
 }
 
-String OutOfProcessWebView::get_active_documents_type()
-{
-    return client().get_active_documents_type();
-}
-
-String OutOfProcessWebView::get_computed_value_for_element(i32 element_id, String const& property_name)
-{
-    return client().get_computed_value_for_element(element_id, property_name);
-}
-
 String OutOfProcessWebView::get_element_text(i32 element_id)
 {
     return client().get_element_text(element_id);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -559,11 +559,6 @@ void OutOfProcessWebView::scroll_element_into_view(i32 element_id)
     return client().scroll_element_into_view(element_id);
 }
 
-Gfx::IntRect OutOfProcessWebView::get_element_rect(i32 element_id)
-{
-    return client().get_element_rect(element_id);
-}
-
 bool OutOfProcessWebView::is_element_enabled(i32 element_id)
 {
     return client().is_element_enabled(element_id);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -559,11 +559,6 @@ void OutOfProcessWebView::scroll_element_into_view(i32 element_id)
     return client().scroll_element_into_view(element_id);
 }
 
-bool OutOfProcessWebView::is_element_enabled(i32 element_id)
-{
-    return client().is_element_enabled(element_id);
-}
-
 void OutOfProcessWebView::set_content_filters(Vector<String> filters)
 {
     client().async_set_content_filters(filters);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -64,7 +64,6 @@ public:
     OrderedHashMap<String, String> get_session_storage_entries();
 
     void scroll_element_into_view(i32 element_id);
-    Optional<String> get_element_attribute(i32 element_id, String const& name);
     Optional<String> get_element_property(i32 element_id, String const& name);
     String get_active_documents_type();
     String get_computed_value_for_element(i32 element_id, String const& property_name);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -64,7 +64,6 @@ public:
     OrderedHashMap<String, String> get_session_storage_entries();
 
     void scroll_element_into_view(i32 element_id);
-    String get_element_text(i32 element_id);
     String get_element_tag_name(i32 element_id);
     Gfx::IntRect get_element_rect(i32 element_id);
     bool is_element_enabled(i32 element_id);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -64,7 +64,6 @@ public:
     OrderedHashMap<String, String> get_session_storage_entries();
 
     void scroll_element_into_view(i32 element_id);
-    Gfx::IntRect get_element_rect(i32 element_id);
     bool is_element_enabled(i32 element_id);
 
     void set_content_filters(Vector<String>);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -64,7 +64,6 @@ public:
     OrderedHashMap<String, String> get_session_storage_entries();
 
     void scroll_element_into_view(i32 element_id);
-    bool is_element_selected(i32 element_id);
     Optional<String> get_element_attribute(i32 element_id, String const& name);
     Optional<String> get_element_property(i32 element_id, String const& name);
     String get_active_documents_type();

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -64,8 +64,6 @@ public:
     OrderedHashMap<String, String> get_session_storage_entries();
 
     void scroll_element_into_view(i32 element_id);
-    String get_active_documents_type();
-    String get_computed_value_for_element(i32 element_id, String const& property_name);
     String get_element_text(i32 element_id);
     String get_element_tag_name(i32 element_id);
     Gfx::IntRect get_element_rect(i32 element_id);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -64,7 +64,6 @@ public:
     OrderedHashMap<String, String> get_session_storage_entries();
 
     void scroll_element_into_view(i32 element_id);
-    Optional<String> get_element_property(i32 element_id, String const& name);
     String get_active_documents_type();
     String get_computed_value_for_element(i32 element_id, String const& property_name);
     String get_element_text(i32 element_id);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -64,7 +64,6 @@ public:
     OrderedHashMap<String, String> get_session_storage_entries();
 
     void scroll_element_into_view(i32 element_id);
-    String get_element_tag_name(i32 element_id);
     Gfx::IntRect get_element_rect(i32 element_id);
     bool is_element_enabled(i32 element_id);
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -64,7 +64,6 @@ public:
     OrderedHashMap<String, String> get_session_storage_entries();
 
     void scroll_element_into_view(i32 element_id);
-    bool is_element_enabled(i32 element_id);
 
     void set_content_filters(Vector<String>);
     void set_proxy_mappings(Vector<String> proxies, HashMap<String, size_t> mappings);

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -525,15 +525,6 @@ static Gfx::IntRect calculate_absolute_rect_of_element(Web::Page const& page, We
     };
 }
 
-Messages::WebContentServer::GetElementRectResponse ConnectionFromClient::get_element_rect(i32 element_id)
-{
-    auto element = find_element_by_id(element_id);
-    if (!element.has_value())
-        return { {} };
-
-    return { calculate_absolute_rect_of_element(page(), *element) };
-}
-
 Messages::WebContentServer::IsElementEnabledResponse ConnectionFromClient::is_element_enabled(i32 element_id)
 {
     auto element = find_element_by_id(element_id);

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -28,8 +28,6 @@
 #include <LibWeb/Geometry/DOMRect.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
-#include <LibWeb/HTML/HTMLInputElement.h>
-#include <LibWeb/HTML/HTMLOptionElement.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/Storage.h>
 #include <LibWeb/HTML/Window.h>
@@ -495,27 +493,6 @@ void ConnectionFromClient::scroll_element_into_view(i32 element_id)
 
     // 2. Run Function.[[Call]](scrollIntoView, options) with element as the this value.
     element->scroll_into_view(options);
-}
-
-Messages::WebContentServer::IsElementSelectedResponse ConnectionFromClient::is_element_selected(i32 element_id)
-{
-    auto element = find_element_by_id(element_id);
-    if (!element.has_value())
-        return { false };
-
-    bool selected = false;
-
-    if (is<Web::HTML::HTMLInputElement>(*element)) {
-        auto& input = dynamic_cast<Web::HTML::HTMLInputElement&>(*element);
-        using enum Web::HTML::HTMLInputElement::TypeAttributeState;
-
-        if (input.type_state() == Checkbox || input.type_state() == RadioButton)
-            selected = input.checked();
-    } else if (is<Web::HTML::HTMLOptionElement>(*element)) {
-        selected = dynamic_cast<Web::HTML::HTMLOptionElement&>(*element).selected();
-    }
-
-    return { selected };
 }
 
 Messages::WebContentServer::GetElementAttributeResponse ConnectionFromClient::get_element_attribute(i32 element_id, String const& name)

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -494,15 +494,6 @@ void ConnectionFromClient::scroll_element_into_view(i32 element_id)
     element->scroll_into_view(options);
 }
 
-Messages::WebContentServer::GetElementTextResponse ConnectionFromClient::get_element_text(i32 element_id)
-{
-    auto element = find_element_by_id(element_id);
-    if (!element.has_value())
-        return { "" };
-
-    return { element->layout_node()->dom_node()->text_content() };
-}
-
 Messages::WebContentServer::GetElementTagNameResponse ConnectionFromClient::get_element_tag_name(i32 element_id)
 {
     auto element = find_element_by_id(element_id);

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -495,28 +495,6 @@ void ConnectionFromClient::scroll_element_into_view(i32 element_id)
     element->scroll_into_view(options);
 }
 
-Messages::WebContentServer::GetElementPropertyResponse ConnectionFromClient::get_element_property(i32 element_id, String const& name)
-{
-    auto element = find_element_by_id(element_id);
-    if (!element.has_value())
-        return Optional<String> {};
-
-    auto property_or_error = element->get(name);
-    if (property_or_error.is_throw_completion())
-        return Optional<String> {};
-
-    auto property = property_or_error.release_value();
-
-    if (property.is_undefined())
-        return Optional<String> {};
-
-    auto string_or_error = property.to_string(element->vm());
-    if (string_or_error.is_error())
-        return Optional<String> {};
-
-    return { string_or_error.release_value() };
-}
-
 Messages::WebContentServer::GetActiveDocumentsTypeResponse ConnectionFromClient::get_active_documents_type()
 {
     auto* active_document = page().top_level_browsing_context().active_document();

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -494,15 +494,6 @@ void ConnectionFromClient::scroll_element_into_view(i32 element_id)
     element->scroll_into_view(options);
 }
 
-Messages::WebContentServer::GetElementTagNameResponse ConnectionFromClient::get_element_tag_name(i32 element_id)
-{
-    auto element = find_element_by_id(element_id);
-    if (!element.has_value())
-        return { "" };
-
-    return { element->tag_name() };
-}
-
 // https://w3c.github.io/webdriver/#dfn-calculate-the-absolute-position
 static Gfx::IntPoint calculate_absolute_position_of_element(Web::Page const& page, JS::NonnullGCPtr<Web::Geometry::DOMRect> rect)
 {

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -20,7 +20,6 @@
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibJS/Runtime/JSONObject.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
-#include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/NodeList.h>
@@ -493,44 +492,6 @@ void ConnectionFromClient::scroll_element_into_view(i32 element_id)
 
     // 2. Run Function.[[Call]](scrollIntoView, options) with element as the this value.
     element->scroll_into_view(options);
-}
-
-Messages::WebContentServer::GetActiveDocumentsTypeResponse ConnectionFromClient::get_active_documents_type()
-{
-    auto* active_document = page().top_level_browsing_context().active_document();
-
-    if (!active_document)
-        return { "" };
-
-    auto type = active_document->document_type();
-
-    switch (type) {
-    case Web::DOM::Document::Type::HTML:
-        return { "html" };
-        break;
-    case Web::DOM::Document::Type::XML:
-        return { "xml" };
-        break;
-    }
-
-    return { "" };
-}
-
-Messages::WebContentServer::GetComputedValueForElementResponse ConnectionFromClient::get_computed_value_for_element(i32 element_id, String const& property_name)
-{
-    auto element = find_element_by_id(element_id);
-    if (!element.has_value())
-        return { "" };
-
-    auto property_id = Web::CSS::property_id_from_string(property_name);
-
-    auto computed_values = element->computed_css_values();
-    if (!computed_values)
-        return { "" };
-
-    auto style_value = computed_values->property(property_id);
-
-    return { style_value->to_string() };
 }
 
 Messages::WebContentServer::GetElementTextResponse ConnectionFromClient::get_element_text(i32 element_id)

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -26,7 +26,6 @@
 #include <LibWeb/Dump.h>
 #include <LibWeb/Geometry/DOMRect.h>
 #include <LibWeb/HTML/BrowsingContext.h>
-#include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/Storage.h>
 #include <LibWeb/HTML/Window.h>
@@ -523,26 +522,6 @@ static Gfx::IntRect calculate_absolute_rect_of_element(Web::Page const& page, We
         static_cast<int>(bounding_rect->width()),
         static_cast<int>(bounding_rect->height())
     };
-}
-
-Messages::WebContentServer::IsElementEnabledResponse ConnectionFromClient::is_element_enabled(i32 element_id)
-{
-    auto element = find_element_by_id(element_id);
-    if (!element.has_value())
-        return { false };
-
-    auto* document = page().top_level_browsing_context().active_document();
-    if (!document)
-        return { false };
-
-    bool enabled = !document->is_xml_document();
-
-    if (enabled && is<Web::HTML::FormAssociatedElement>(*element)) {
-        auto& form_associated_element = dynamic_cast<Web::HTML::FormAssociatedElement&>(*element);
-        enabled = form_associated_element.enabled();
-    }
-
-    return { enabled };
 }
 
 Messages::WebContentServer::TakeElementScreenshotResponse ConnectionFromClient::take_element_screenshot(i32 element_id)

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -495,15 +495,6 @@ void ConnectionFromClient::scroll_element_into_view(i32 element_id)
     element->scroll_into_view(options);
 }
 
-Messages::WebContentServer::GetElementAttributeResponse ConnectionFromClient::get_element_attribute(i32 element_id, String const& name)
-{
-    auto element = find_element_by_id(element_id);
-    if (!element.has_value())
-        return Optional<String> {};
-
-    return { element->get_attribute(name) };
-}
-
 Messages::WebContentServer::GetElementPropertyResponse ConnectionFromClient::get_element_property(i32 element_id, String const& name)
 {
     auto element = find_element_by_id(element_id);

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -84,7 +84,6 @@ private:
     virtual void js_console_request_messages(i32) override;
 
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebContentServer::GetElementTagNameResponse get_element_tag_name(i32 element_id) override;
     virtual Messages::WebContentServer::GetElementRectResponse get_element_rect(i32 element_id) override;
     virtual Messages::WebContentServer::IsElementEnabledResponse is_element_enabled(i32 element_id) override;
     virtual Messages::WebContentServer::TakeElementScreenshotResponse take_element_screenshot(i32 element_id) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -84,7 +84,6 @@ private:
     virtual void js_console_request_messages(i32) override;
 
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebContentServer::GetElementAttributeResponse get_element_attribute(i32 element_id, String const& name) override;
     virtual Messages::WebContentServer::GetElementPropertyResponse get_element_property(i32 element_id, String const& name) override;
     virtual Messages::WebContentServer::GetActiveDocumentsTypeResponse get_active_documents_type() override;
     virtual Messages::WebContentServer::GetComputedValueForElementResponse get_computed_value_for_element(i32 element_id, String const& property_name) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -84,8 +84,6 @@ private:
     virtual void js_console_request_messages(i32) override;
 
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebContentServer::GetActiveDocumentsTypeResponse get_active_documents_type() override;
-    virtual Messages::WebContentServer::GetComputedValueForElementResponse get_computed_value_for_element(i32 element_id, String const& property_name) override;
     virtual Messages::WebContentServer::GetElementTextResponse get_element_text(i32 element_id) override;
     virtual Messages::WebContentServer::GetElementTagNameResponse get_element_tag_name(i32 element_id) override;
     virtual Messages::WebContentServer::GetElementRectResponse get_element_rect(i32 element_id) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -84,7 +84,6 @@ private:
     virtual void js_console_request_messages(i32) override;
 
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebContentServer::GetElementRectResponse get_element_rect(i32 element_id) override;
     virtual Messages::WebContentServer::IsElementEnabledResponse is_element_enabled(i32 element_id) override;
     virtual Messages::WebContentServer::TakeElementScreenshotResponse take_element_screenshot(i32 element_id) override;
     virtual Messages::WebContentServer::TakeDocumentScreenshotResponse take_document_screenshot() override;

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -84,7 +84,6 @@ private:
     virtual void js_console_request_messages(i32) override;
 
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebContentServer::IsElementSelectedResponse is_element_selected(i32 element_id) override;
     virtual Messages::WebContentServer::GetElementAttributeResponse get_element_attribute(i32 element_id, String const& name) override;
     virtual Messages::WebContentServer::GetElementPropertyResponse get_element_property(i32 element_id, String const& name) override;
     virtual Messages::WebContentServer::GetActiveDocumentsTypeResponse get_active_documents_type() override;

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -84,7 +84,6 @@ private:
     virtual void js_console_request_messages(i32) override;
 
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebContentServer::GetElementPropertyResponse get_element_property(i32 element_id, String const& name) override;
     virtual Messages::WebContentServer::GetActiveDocumentsTypeResponse get_active_documents_type() override;
     virtual Messages::WebContentServer::GetComputedValueForElementResponse get_computed_value_for_element(i32 element_id, String const& property_name) override;
     virtual Messages::WebContentServer::GetElementTextResponse get_element_text(i32 element_id) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -84,7 +84,6 @@ private:
     virtual void js_console_request_messages(i32) override;
 
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebContentServer::IsElementEnabledResponse is_element_enabled(i32 element_id) override;
     virtual Messages::WebContentServer::TakeElementScreenshotResponse take_element_screenshot(i32 element_id) override;
     virtual Messages::WebContentServer::TakeDocumentScreenshotResponse take_document_screenshot() override;
 

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -84,7 +84,6 @@ private:
     virtual void js_console_request_messages(i32) override;
 
     virtual void scroll_element_into_view(i32 element_id) override;
-    virtual Messages::WebContentServer::GetElementTextResponse get_element_text(i32 element_id) override;
     virtual Messages::WebContentServer::GetElementTagNameResponse get_element_tag_name(i32 element_id) override;
     virtual Messages::WebContentServer::GetElementRectResponse get_element_rect(i32 element_id) override;
     virtual Messages::WebContentServer::IsElementEnabledResponse is_element_enabled(i32 element_id) override;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -43,7 +43,6 @@ endpoint WebContentServer
     js_console_request_messages(i32 start_index) =|
 
     scroll_element_into_view(i32 element_id) => ()
-    get_element_attribute(i32 element_id, String name) => (Optional<String> attribute)
     get_element_property(i32 element_id, String name) => (Optional<String> property)
     get_active_documents_type() => (String type)
     get_computed_value_for_element(i32 element_id, String property_name) => (String computed_value)

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -43,7 +43,6 @@ endpoint WebContentServer
     js_console_request_messages(i32 start_index) =|
 
     scroll_element_into_view(i32 element_id) => ()
-    get_element_property(i32 element_id, String name) => (Optional<String> property)
     get_active_documents_type() => (String type)
     get_computed_value_for_element(i32 element_id, String property_name) => (String computed_value)
     get_element_text(i32 element_id) => (String text)

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -43,7 +43,6 @@ endpoint WebContentServer
     js_console_request_messages(i32 start_index) =|
 
     scroll_element_into_view(i32 element_id) => ()
-    get_element_text(i32 element_id) => (String text)
     get_element_tag_name(i32 element_id) => (String tag_name)
     get_element_rect(i32 element_id) => (Gfx::IntRect rect)
     is_element_enabled(i32 element_id) => (bool enabled)

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -43,7 +43,6 @@ endpoint WebContentServer
     js_console_request_messages(i32 start_index) =|
 
     scroll_element_into_view(i32 element_id) => ()
-    is_element_enabled(i32 element_id) => (bool enabled)
     take_element_screenshot(i32 element_id) => (Gfx::ShareableBitmap data)
     take_document_screenshot() => (Gfx::ShareableBitmap data)
 

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -43,7 +43,6 @@ endpoint WebContentServer
     js_console_request_messages(i32 start_index) =|
 
     scroll_element_into_view(i32 element_id) => ()
-    get_element_tag_name(i32 element_id) => (String tag_name)
     get_element_rect(i32 element_id) => (Gfx::IntRect rect)
     is_element_enabled(i32 element_id) => (bool enabled)
     take_element_screenshot(i32 element_id) => (Gfx::ShareableBitmap data)

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -43,8 +43,6 @@ endpoint WebContentServer
     js_console_request_messages(i32 start_index) =|
 
     scroll_element_into_view(i32 element_id) => ()
-    get_active_documents_type() => (String type)
-    get_computed_value_for_element(i32 element_id, String property_name) => (String computed_value)
     get_element_text(i32 element_id) => (String text)
     get_element_tag_name(i32 element_id) => (String tag_name)
     get_element_rect(i32 element_id) => (Gfx::IntRect rect)

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -43,7 +43,6 @@ endpoint WebContentServer
     js_console_request_messages(i32 start_index) =|
 
     scroll_element_into_view(i32 element_id) => ()
-    is_element_selected(i32 element_id) => (bool selected)
     get_element_attribute(i32 element_id, String name) => (Optional<String> attribute)
     get_element_property(i32 element_id, String name) => (Optional<String> property)
     get_active_documents_type() => (String type)

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -43,7 +43,6 @@ endpoint WebContentServer
     js_console_request_messages(i32 start_index) =|
 
     scroll_element_into_view(i32 element_id) => ()
-    get_element_rect(i32 element_id) => (Gfx::IntRect rect)
     is_element_enabled(i32 element_id) => (bool enabled)
     take_element_screenshot(i32 element_id) => (Gfx::ShareableBitmap data)
     take_document_screenshot() => (Gfx::ShareableBitmap data)

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -20,4 +20,5 @@ endpoint WebDriverClient {
     get_element_text(String element_id) => (Web::WebDriver::Response response)
     get_element_tag_name(String element_id) => (Web::WebDriver::Response response)
     get_element_rect(String element_id) => (Web::WebDriver::Response response)
+    is_element_enabled(String element_id) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -19,4 +19,5 @@ endpoint WebDriverClient {
     get_element_css_value(String element_id, String name) => (Web::WebDriver::Response response)
     get_element_text(String element_id) => (Web::WebDriver::Response response)
     get_element_tag_name(String element_id) => (Web::WebDriver::Response response)
+    get_element_rect(String element_id) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -17,4 +17,5 @@ endpoint WebDriverClient {
     get_element_attribute(String element_id, String name) => (Web::WebDriver::Response response)
     get_element_property(String element_id, String name) => (Web::WebDriver::Response response)
     get_element_css_value(String element_id, String name) => (Web::WebDriver::Response response)
+    get_element_text(String element_id) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -15,4 +15,5 @@ endpoint WebDriverClient {
     find_elements_from_element(JsonValue payload, String element_id) => (Web::WebDriver::Response response)
     is_element_selected(String element_id) => (Web::WebDriver::Response response)
     get_element_attribute(String element_id, String name) => (Web::WebDriver::Response response)
+    get_element_property(String element_id, String name) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -16,4 +16,5 @@ endpoint WebDriverClient {
     is_element_selected(String element_id) => (Web::WebDriver::Response response)
     get_element_attribute(String element_id, String name) => (Web::WebDriver::Response response)
     get_element_property(String element_id, String name) => (Web::WebDriver::Response response)
+    get_element_css_value(String element_id, String name) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -13,4 +13,5 @@ endpoint WebDriverClient {
     find_elements(JsonValue payload) => (Web::WebDriver::Response response)
     find_element_from_element(JsonValue payload, String element_id) => (Web::WebDriver::Response response)
     find_elements_from_element(JsonValue payload, String element_id) => (Web::WebDriver::Response response)
+    is_element_selected(String element_id) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -14,4 +14,5 @@ endpoint WebDriverClient {
     find_element_from_element(JsonValue payload, String element_id) => (Web::WebDriver::Response response)
     find_elements_from_element(JsonValue payload, String element_id) => (Web::WebDriver::Response response)
     is_element_selected(String element_id) => (Web::WebDriver::Response response)
+    get_element_attribute(String element_id, String name) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -18,4 +18,5 @@ endpoint WebDriverClient {
     get_element_property(String element_id, String name) => (Web::WebDriver::Response response)
     get_element_css_value(String element_id, String name) => (Web::WebDriver::Response response)
     get_element_text(String element_id) => (Web::WebDriver::Response response)
+    get_element_tag_name(String element_id) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -608,6 +608,24 @@ Messages::WebDriverClient::GetElementTextResponse WebDriverConnection::get_eleme
     return make_success_response(move(rendered_text));
 }
 
+// 12.4.6 Get Element Tag Name, https://w3c.github.io/webdriver/#dfn-get-element-tag-name
+Messages::WebDriverClient::GetElementTagNameResponse WebDriverConnection::get_element_tag_name(String const& element_id)
+{
+    // 1. If the current browsing context is no longer open, return error with error code no such window.
+    TRY(ensure_open_top_level_browsing_context());
+
+    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+
+    // 3. Let element be the result of trying to get a known connected element with url variable element id.
+    auto* element = TRY(get_known_connected_element(element_id));
+
+    // 4. Let qualified name be the result of getting element’s tagName IDL attribute.
+    auto qualified_name = element->tag_name();
+
+    // 5. Return success with data qualified name.
+    return make_success_response(move(qualified_name));
+}
+
 // https://w3c.github.io/webdriver/#dfn-no-longer-open
 ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::ensure_open_top_level_browsing_context()
 {

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -12,6 +12,7 @@
 #include <AK/JsonValue.h>
 #include <AK/Vector.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/HTMLOptionElement.h>
@@ -83,7 +84,7 @@ static JsonObject web_element_reference_object(Web::DOM::Node const& element)
 }
 
 // https://w3c.github.io/webdriver/#dfn-get-a-known-connected-element
-static ErrorOr<Web::DOM::ParentNode*, Web::WebDriver::Error> get_known_connected_element(StringView element_id)
+static ErrorOr<Web::DOM::Element*, Web::WebDriver::Error> get_known_connected_element(StringView element_id)
 {
     // NOTE: The whole concept of "connected elements" is not implemented yet. See get_or_create_a_web_element_reference().
     //       For now the element is only represented by its ID.
@@ -93,12 +94,10 @@ static ErrorOr<Web::DOM::ParentNode*, Web::WebDriver::Error> get_known_connected
 
     auto* node = Web::DOM::Node::from_id(*element);
 
-    if (!node)
+    if (!node || !node->is_element())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchElement, String::formatted("Could not find element with ID: {}", element_id));
-    if (!is<Web::DOM::ParentNode>(node))
-        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchElement, String::formatted("Element with ID is not a parent node: {}", element_id));
 
-    return static_cast<Web::DOM::ParentNode*>(node);
+    return static_cast<Web::DOM::Element*>(node);
 }
 
 static ErrorOr<String, Web::WebDriver::Error> get_property(JsonValue const& payload, StringView key)

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -590,6 +590,24 @@ Messages::WebDriverClient::GetElementCssValueResponse WebDriverConnection::get_e
     return make_success_response(move(computed_value));
 }
 
+// 12.4.5 Get Element Text, https://w3c.github.io/webdriver/#dfn-get-element-text
+Messages::WebDriverClient::GetElementTextResponse WebDriverConnection::get_element_text(String const& element_id)
+{
+    // 1. If the current browsing context is no longer open, return error with error code no such window.
+    TRY(ensure_open_top_level_browsing_context());
+
+    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+
+    // 3. Let element be the result of trying to get a known connected element with url variable element id.
+    auto* element = TRY(get_known_connected_element(element_id));
+
+    // 4. Let rendered text be the result of performing implementation-specific steps whose result is exactly the same as the result of a Function.[[Call]](null, element) with bot.dom.getVisibleText as the this value.
+    auto rendered_text = element->text_content();
+
+    // 5. Return success with data rendered text.
+    return make_success_response(move(rendered_text));
+}
+
 // https://w3c.github.io/webdriver/#dfn-no-longer-open
 ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::ensure_open_top_level_browsing_context()
 {

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -44,6 +44,7 @@ private:
     virtual Messages::WebDriverClient::FindElementFromElementResponse find_element_from_element(JsonValue const& payload, String const& element_id) override;
     virtual Messages::WebDriverClient::FindElementsFromElementResponse find_elements_from_element(JsonValue const& payload, String const& element_id) override;
     virtual Messages::WebDriverClient::IsElementSelectedResponse is_element_selected(String const& element_id) override;
+    virtual Messages::WebDriverClient::GetElementAttributeResponse get_element_attribute(String const& element_id, String const& name) override;
 
     ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();
     void restore_the_window();

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -50,6 +50,7 @@ private:
     virtual Messages::WebDriverClient::GetElementTextResponse get_element_text(String const& element_id) override;
     virtual Messages::WebDriverClient::GetElementTagNameResponse get_element_tag_name(String const& element_id) override;
     virtual Messages::WebDriverClient::GetElementRectResponse get_element_rect(String const& element_id) override;
+    virtual Messages::WebDriverClient::IsElementEnabledResponse is_element_enabled(String const& element_id) override;
 
     ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();
     void restore_the_window();

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -43,6 +43,7 @@ private:
     virtual Messages::WebDriverClient::FindElementsResponse find_elements(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::FindElementFromElementResponse find_element_from_element(JsonValue const& payload, String const& element_id) override;
     virtual Messages::WebDriverClient::FindElementsFromElementResponse find_elements_from_element(JsonValue const& payload, String const& element_id) override;
+    virtual Messages::WebDriverClient::IsElementSelectedResponse is_element_selected(String const& element_id) override;
 
     ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();
     void restore_the_window();

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -46,6 +46,7 @@ private:
     virtual Messages::WebDriverClient::IsElementSelectedResponse is_element_selected(String const& element_id) override;
     virtual Messages::WebDriverClient::GetElementAttributeResponse get_element_attribute(String const& element_id, String const& name) override;
     virtual Messages::WebDriverClient::GetElementPropertyResponse get_element_property(String const& element_id, String const& name) override;
+    virtual Messages::WebDriverClient::GetElementCssValueResponse get_element_css_value(String const& element_id, String const& name) override;
 
     ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();
     void restore_the_window();

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -45,6 +45,7 @@ private:
     virtual Messages::WebDriverClient::FindElementsFromElementResponse find_elements_from_element(JsonValue const& payload, String const& element_id) override;
     virtual Messages::WebDriverClient::IsElementSelectedResponse is_element_selected(String const& element_id) override;
     virtual Messages::WebDriverClient::GetElementAttributeResponse get_element_attribute(String const& element_id, String const& name) override;
+    virtual Messages::WebDriverClient::GetElementPropertyResponse get_element_property(String const& element_id, String const& name) override;
 
     ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();
     void restore_the_window();

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -49,6 +49,7 @@ private:
     virtual Messages::WebDriverClient::GetElementCssValueResponse get_element_css_value(String const& element_id, String const& name) override;
     virtual Messages::WebDriverClient::GetElementTextResponse get_element_text(String const& element_id) override;
     virtual Messages::WebDriverClient::GetElementTagNameResponse get_element_tag_name(String const& element_id) override;
+    virtual Messages::WebDriverClient::GetElementRectResponse get_element_rect(String const& element_id) override;
 
     ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();
     void restore_the_window();

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -47,6 +47,7 @@ private:
     virtual Messages::WebDriverClient::GetElementAttributeResponse get_element_attribute(String const& element_id, String const& name) override;
     virtual Messages::WebDriverClient::GetElementPropertyResponse get_element_property(String const& element_id, String const& name) override;
     virtual Messages::WebDriverClient::GetElementCssValueResponse get_element_css_value(String const& element_id, String const& name) override;
+    virtual Messages::WebDriverClient::GetElementTextResponse get_element_text(String const& element_id) override;
 
     ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();
     void restore_the_window();

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -48,6 +48,7 @@ private:
     virtual Messages::WebDriverClient::GetElementPropertyResponse get_element_property(String const& element_id, String const& name) override;
     virtual Messages::WebDriverClient::GetElementCssValueResponse get_element_css_value(String const& element_id, String const& name) override;
     virtual Messages::WebDriverClient::GetElementTextResponse get_element_text(String const& element_id) override;
+    virtual Messages::WebDriverClient::GetElementTagNameResponse get_element_tag_name(String const& element_id) override;
 
     ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();
     void restore_the_window();

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -717,8 +717,7 @@ Web::WebDriver::Response Client::handle_is_element_enabled(Vector<StringView> co
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/enabled");
     auto* session = TRY(find_session_with_id(parameters[0]));
-    auto result = TRY(session->is_element_enabled(parameters[1]));
-    return make_json_value(result);
+    return session->web_content_connection().is_element_enabled(parameters[1]);
 }
 
 // 13.1 Get Page Source, https://w3c.github.io/webdriver/#dfn-get-page-source

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -668,12 +668,11 @@ Web::WebDriver::Response Client::handle_get_element_attribute(Vector<StringView>
 
 // 12.4.3 Get Element Property, https://w3c.github.io/webdriver/#dfn-get-element-property
 // GET /session/{session id}/element/{element id}/property/{name}
-Web::WebDriver::Response Client::handle_get_element_property(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_get_element_property(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/property/<name>");
     auto* session = TRY(find_session_with_id(parameters[0]));
-    auto result = TRY(session->get_element_property(payload, parameters[1], parameters[2]));
-    return make_json_value(result);
+    return session->web_content_connection().get_element_property(parameters[1], parameters[2]);
 }
 
 // 12.4.4 Get Element CSS Value, https://w3c.github.io/webdriver/#dfn-get-element-css-value

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -686,12 +686,11 @@ Web::WebDriver::Response Client::handle_get_element_css_value(Vector<StringView>
 
 // 12.4.5 Get Element Text, https://w3c.github.io/webdriver/#dfn-get-element-text
 // GET /session/{session id}/element/{element id}/text
-Web::WebDriver::Response Client::handle_get_element_text(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_get_element_text(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/text");
     auto* session = TRY(find_session_with_id(parameters[0]));
-    auto result = TRY(session->get_element_text(payload, parameters[1]));
-    return make_json_value(result);
+    return session->web_content_connection().get_element_text(parameters[1]);
 }
 
 // 12.4.6 Get Element Tag Name, https://w3c.github.io/webdriver/#dfn-get-element-tag-name

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -708,8 +708,7 @@ Web::WebDriver::Response Client::handle_get_element_rect(Vector<StringView> cons
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/rect");
     auto* session = TRY(find_session_with_id(parameters[0]));
-    auto result = TRY(session->get_element_rect(parameters[1]));
-    return make_json_value(result);
+    return session->web_content_connection().get_element_rect(parameters[1]);
 }
 
 // 12.4.8 Is Element Enabled, https://w3c.github.io/webdriver/#dfn-is-element-enabled

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -677,12 +677,11 @@ Web::WebDriver::Response Client::handle_get_element_property(Vector<StringView> 
 
 // 12.4.4 Get Element CSS Value, https://w3c.github.io/webdriver/#dfn-get-element-css-value
 // GET /session/{session id}/element/{element id}/css/{property name}
-Web::WebDriver::Response Client::handle_get_element_css_value(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_get_element_css_value(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/css/<property_name>");
     auto* session = TRY(find_session_with_id(parameters[0]));
-    auto result = TRY(session->get_element_css_value(payload, parameters[1], parameters[2]));
-    return make_json_value(result);
+    return session->web_content_connection().get_element_css_value(parameters[1], parameters[2]);
 }
 
 // 12.4.5 Get Element Text, https://w3c.github.io/webdriver/#dfn-get-element-text

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -659,12 +659,11 @@ Web::WebDriver::Response Client::handle_is_element_selected(Vector<StringView> c
 
 // 12.4.2 Get Element Attribute, https://w3c.github.io/webdriver/#dfn-get-element-attribute
 // GET /session/{session id}/element/{element id}/attribute/{name}
-Web::WebDriver::Response Client::handle_get_element_attribute(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_get_element_attribute(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/attribute/<name>");
     auto* session = TRY(find_session_with_id(parameters[0]));
-    auto result = TRY(session->get_element_attribute(payload, parameters[1], parameters[2]));
-    return make_json_value(result);
+    return session->web_content_connection().get_element_attribute(parameters[1], parameters[2]);
 }
 
 // 12.4.3 Get Element Property, https://w3c.github.io/webdriver/#dfn-get-element-property

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -654,8 +654,7 @@ Web::WebDriver::Response Client::handle_is_element_selected(Vector<StringView> c
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/selected");
     auto* session = TRY(find_session_with_id(parameters[0]));
-    auto result = TRY(session->is_element_selected(parameters[1]));
-    return make_json_value(result);
+    return session->web_content_connection().is_element_selected(parameters[1]);
 }
 
 // 12.4.2 Get Element Attribute, https://w3c.github.io/webdriver/#dfn-get-element-attribute

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -695,12 +695,11 @@ Web::WebDriver::Response Client::handle_get_element_text(Vector<StringView> cons
 
 // 12.4.6 Get Element Tag Name, https://w3c.github.io/webdriver/#dfn-get-element-tag-name
 // GET /session/{session id}/element/{element id}/name
-Web::WebDriver::Response Client::handle_get_element_tag_name(Vector<StringView> const& parameters, JsonValue const& payload)
+Web::WebDriver::Response Client::handle_get_element_tag_name(Vector<StringView> const& parameters, JsonValue const&)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/name");
     auto* session = TRY(find_session_with_id(parameters[0]));
-    auto result = TRY(session->get_element_tag_name(payload, parameters[1]));
-    return make_json_value(result);
+    return session->web_content_connection().get_element_tag_name(parameters[1]);
 }
 
 // 12.4.7 Get Element Rect, https://w3c.github.io/webdriver/#dfn-get-element-rect

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -323,34 +323,6 @@ static ErrorOr<i32, Web::WebDriver::Error> get_known_connected_element(StringVie
     return maybe_element_id.release_value();
 }
 
-// 12.4.2 Get Element Attribute, https://w3c.github.io/webdriver/#dfn-get-element-attribute
-Web::WebDriver::Response Session::get_element_attribute(JsonValue const&, StringView parameter_element_id, StringView name)
-{
-    // 1. If the current browsing context is no longer open, return error with error code no such window.
-    TRY(check_for_open_top_level_browsing_context_or_return_error());
-
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
-
-    // 3. Let element be the result of trying to get a known connected element with url variable element id.
-    auto element_id = TRY(get_known_connected_element(parameter_element_id));
-
-    // FIXME: The case that the element does not exist is not handled at all and null is returned in that case.
-
-    // 4. Let result be the result of the first matching condition:
-    // -> FIXME: If name is a boolean attribute
-    //    NOTE: LibWeb doesn't know about boolean attributes directly
-    //    "true" (string) if the element has the attribute, otherwise null.
-    // -> Otherwise
-    //    The result of getting an attribute by name name.
-    auto result = m_browser_connection->get_element_attribute(element_id, name);
-
-    if (!result.has_value())
-        return JsonValue(AK::JsonValue::Type::Null);
-
-    // 5. Return success with data result.
-    return JsonValue(result.release_value());
-}
-
 // 12.4.3 Get Element Property, https://w3c.github.io/webdriver/#dfn-get-element-property
 Web::WebDriver::Response Session::get_element_property(JsonValue const&, StringView parameter_element_id, StringView name)
 {

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -312,26 +312,6 @@ static ErrorOr<i32, Web::WebDriver::Error> get_known_connected_element(StringVie
     return maybe_element_id.release_value();
 }
 
-// 12.4.8 Is Element Enabled, https://w3c.github.io/webdriver/#dfn-is-element-enabled
-Web::WebDriver::Response Session::is_element_enabled(StringView parameter_element_id)
-{
-    // 1. If the current browsing context is no longer open, return error with error code no such window.
-    TRY(check_for_open_top_level_browsing_context_or_return_error());
-
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
-
-    // 3. Let element be the result of trying to get a known connected element with url variable element id.
-    auto element_id = TRY(get_known_connected_element(parameter_element_id));
-
-    // 4. Let enabled be a boolean initially set to true if the current browsing context’s active document’s type is not "xml".
-    // 5. Otherwise, let enabled to false and jump to the last step of this algorithm.
-    // 6. Set enabled to false if a form control is disabled.
-    auto enabled = m_browser_connection->is_element_enabled(element_id);
-
-    // 7. Return success with data enabled.
-    return JsonValue { enabled };
-}
-
 // 13.1 Get Page Source, https://w3c.github.io/webdriver/#dfn-get-page-source
 Web::WebDriver::Response Session::get_source()
 {

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -300,17 +300,6 @@ Web::WebDriver::Response Session::get_window_handles() const
     return JsonValue { handles };
 }
 
-static JsonValue serialize_rect(Gfx::IntRect const& rect)
-{
-    JsonObject serialized_rect = {};
-    serialized_rect.set("x", rect.x());
-    serialized_rect.set("y", rect.y());
-    serialized_rect.set("width", rect.width());
-    serialized_rect.set("height", rect.height());
-
-    return serialized_rect;
-}
-
 // https://w3c.github.io/webdriver/#dfn-get-a-known-connected-element
 static ErrorOr<i32, Web::WebDriver::Error> get_known_connected_element(StringView element_id)
 {
@@ -321,36 +310,6 @@ static ErrorOr<i32, Web::WebDriver::Error> get_known_connected_element(StringVie
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Element ID is not an integer");
 
     return maybe_element_id.release_value();
-}
-
-// 12.4.7 Get Element Rect, https://w3c.github.io/webdriver/#dfn-get-element-rect
-Web::WebDriver::Response Session::get_element_rect(StringView parameter_element_id)
-{
-    // 1. If the current browsing context is no longer open, return error with error code no such window.
-    TRY(check_for_open_top_level_browsing_context_or_return_error());
-
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
-
-    // 3. Let element be the result of trying to get a known connected element with url variable element id.
-    auto element_id = TRY(get_known_connected_element(parameter_element_id));
-
-    // 4. Calculate the absolute position of element and let it be coordinates.
-    // 5. Let rect be element’s bounding rectangle.
-    auto rect = m_browser_connection->get_element_rect(element_id);
-
-    // 6. Let body be a new JSON Object initialized with:
-    // "x"
-    //     The first value of coordinates.
-    // "y"
-    //     The second value of coordinates.
-    // "width"
-    //     Value of rect’s width dimension.
-    // "height"
-    //     Value of rect’s height dimension.
-    auto body = serialize_rect(rect);
-
-    // 7. Return success with data body.
-    return body;
 }
 
 // 12.4.8 Is Element Enabled, https://w3c.github.io/webdriver/#dfn-is-element-enabled

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -323,29 +323,6 @@ static ErrorOr<i32, Web::WebDriver::Error> get_known_connected_element(StringVie
     return maybe_element_id.release_value();
 }
 
-// 12.4.5 Get Element Text, https://w3c.github.io/webdriver/#dfn-get-element-text
-Web::WebDriver::Response Session::get_element_text(JsonValue const&, StringView parameter_element_id)
-{
-    // 1. If the current browsing context is no longer open, return error with error code no such window.
-    TRY(check_for_open_top_level_browsing_context_or_return_error());
-
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
-
-    // FIXME: 3. Let element be the result of trying to get a known connected element with url variable element id.
-    auto maybe_element_id = parameter_element_id.to_int();
-    if (!maybe_element_id.has_value())
-        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Element ID is not an i32");
-
-    auto element_id = maybe_element_id.release_value();
-
-    // 4. Let rendered text be the result of performing implementation-specific steps whose result is exactly the
-    //    same as the result of a Function.[[Call]](null, element) with bot.dom.getVisibleText as the this value.
-    auto rendered_text = m_browser_connection->get_element_text(element_id);
-
-    // 5. Return success with data rendered text.
-    return JsonValue(rendered_text);
-}
-
 // 12.4.6 Get Element Tag Name, https://w3c.github.io/webdriver/#dfn-get-element-tag-name
 Web::WebDriver::Response Session::get_element_tag_name(JsonValue const&, StringView parameter_element_id)
 {

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -323,32 +323,6 @@ static ErrorOr<i32, Web::WebDriver::Error> get_known_connected_element(StringVie
     return maybe_element_id.release_value();
 }
 
-// 12.4.4 Get Element CSS Value, https://w3c.github.io/webdriver/#dfn-get-element-css-value
-Web::WebDriver::Response Session::get_element_css_value(JsonValue const&, StringView parameter_element_id, StringView property_name)
-{
-    // 1. If the current browsing context is no longer open, return error with error code no such window.
-    TRY(check_for_open_top_level_browsing_context_or_return_error());
-
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
-
-    // 3. Let element be the result of trying to get a known connected element with url variable element id.
-    auto element_id = TRY(get_known_connected_element(parameter_element_id));
-
-    // 4. Let computed value be the result of the first matching condition:
-    // -> current browsing context’s active document’s type is not "xml"
-    //    computed value of parameter property name from element’s style declarations. property name is obtained from url variables.
-    // -> Otherwise
-    //    "" (empty string)
-    auto active_documents_type = m_browser_connection->get_active_documents_type();
-    if (active_documents_type == "xml")
-        return JsonValue("");
-
-    auto computed_value = m_browser_connection->get_computed_value_for_element(element_id, property_name);
-
-    // 5. Return success with data computed value.
-    return JsonValue(computed_value);
-}
-
 // 12.4.5 Get Element Text, https://w3c.github.io/webdriver/#dfn-get-element-text
 Web::WebDriver::Response Session::get_element_text(JsonValue const&, StringView parameter_element_id)
 {

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -323,30 +323,6 @@ static ErrorOr<i32, Web::WebDriver::Error> get_known_connected_element(StringVie
     return maybe_element_id.release_value();
 }
 
-// 12.4.1 Is Element Selected, https://w3c.github.io/webdriver/#dfn-is-element-selected
-Web::WebDriver::Response Session::is_element_selected(StringView parameter_element_id)
-{
-    // 1. If the current browsing context is no longer open, return error with error code no such window.
-    TRY(check_for_open_top_level_browsing_context_or_return_error());
-
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
-
-    // 3. Let element be the result of trying to get a known connected element with url variable element id.
-    auto element_id = TRY(get_known_connected_element(parameter_element_id));
-
-    // 4. Let selected be the value corresponding to the first matching statement:
-    //    element is an input element with a type attribute in the Checkbox- or Radio Button state
-    //      -> The result of element’s checkedness.
-    //    element is an option element
-    //      -> The result of element’s selectedness.
-    //    Otherwise
-    //      -> False.
-    auto selected = m_browser_connection->is_element_selected(element_id);
-
-    // 5. Return success with data selected.
-    return JsonValue { selected };
-}
-
 // 12.4.2 Get Element Attribute, https://w3c.github.io/webdriver/#dfn-get-element-attribute
 Web::WebDriver::Response Session::get_element_attribute(JsonValue const&, StringView parameter_element_id, StringView name)
 {

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -323,24 +323,6 @@ static ErrorOr<i32, Web::WebDriver::Error> get_known_connected_element(StringVie
     return maybe_element_id.release_value();
 }
 
-// 12.4.6 Get Element Tag Name, https://w3c.github.io/webdriver/#dfn-get-element-tag-name
-Web::WebDriver::Response Session::get_element_tag_name(JsonValue const&, StringView parameter_element_id)
-{
-    // 1. If the current browsing context is no longer open, return error with error code no such window.
-    TRY(check_for_open_top_level_browsing_context_or_return_error());
-
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
-
-    // 3. Let element be the result of trying to get a known connected element with url variable element id.
-    auto element_id = TRY(get_known_connected_element(parameter_element_id));
-
-    // 4. Let qualified name be the result of getting element’s tagName IDL attribute.
-    auto qualified_name = m_browser_connection->get_element_tag_name(element_id);
-
-    // 5. Return success with data qualified name.
-    return JsonValue(qualified_name);
-}
-
 // 12.4.7 Get Element Rect, https://w3c.github.io/webdriver/#dfn-get-element-rect
 Web::WebDriver::Response Session::get_element_rect(StringView parameter_element_id)
 {

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -323,28 +323,6 @@ static ErrorOr<i32, Web::WebDriver::Error> get_known_connected_element(StringVie
     return maybe_element_id.release_value();
 }
 
-// 12.4.3 Get Element Property, https://w3c.github.io/webdriver/#dfn-get-element-property
-Web::WebDriver::Response Session::get_element_property(JsonValue const&, StringView parameter_element_id, StringView name)
-{
-    // 1. If the current browsing context is no longer open, return error with error code no such window.
-    TRY(check_for_open_top_level_browsing_context_or_return_error());
-
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
-
-    // 3. Let element be the result of trying to get a known connected element with url variable element id.
-    auto element_id = TRY(get_known_connected_element(parameter_element_id));
-
-    // 4. Let property be the result of calling the Object.[[GetProperty]](name) on element.
-    auto property = m_browser_connection->get_element_property(element_id, name);
-
-    // 5. Let result be the value of property if not undefined, or null.
-    if (!property.has_value())
-        return JsonValue();
-
-    // 6. Return success with data result.
-    return JsonValue(property.release_value());
-}
-
 // 12.4.4 Get Element CSS Value, https://w3c.github.io/webdriver/#dfn-get-element-css-value
 Web::WebDriver::Response Session::get_element_css_value(JsonValue const&, StringView parameter_element_id, StringView property_name)
 {

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -58,7 +58,6 @@ public:
     Web::WebDriver::Response get_window_handle();
     ErrorOr<void, Variant<Web::WebDriver::Error, Error>> close_window();
     Web::WebDriver::Response get_window_handles() const;
-    Web::WebDriver::Response is_element_selected(StringView element_id);
     Web::WebDriver::Response get_element_attribute(JsonValue const& payload, StringView element_id, StringView name);
     Web::WebDriver::Response get_element_property(JsonValue const& payload, StringView element_id, StringView name);
     Web::WebDriver::Response get_element_css_value(JsonValue const& payload, StringView element_id, StringView property_name);

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -58,7 +58,6 @@ public:
     Web::WebDriver::Response get_window_handle();
     ErrorOr<void, Variant<Web::WebDriver::Error, Error>> close_window();
     Web::WebDriver::Response get_window_handles() const;
-    Web::WebDriver::Response get_element_text(JsonValue const& payload, StringView element_id);
     Web::WebDriver::Response get_element_tag_name(JsonValue const& payload, StringView element_id);
     Web::WebDriver::Response get_element_rect(StringView element_id);
     Web::WebDriver::Response is_element_enabled(StringView element_id);

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -58,7 +58,6 @@ public:
     Web::WebDriver::Response get_window_handle();
     ErrorOr<void, Variant<Web::WebDriver::Error, Error>> close_window();
     Web::WebDriver::Response get_window_handles() const;
-    Web::WebDriver::Response get_element_css_value(JsonValue const& payload, StringView element_id, StringView property_name);
     Web::WebDriver::Response get_element_text(JsonValue const& payload, StringView element_id);
     Web::WebDriver::Response get_element_tag_name(JsonValue const& payload, StringView element_id);
     Web::WebDriver::Response get_element_rect(StringView element_id);

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -58,7 +58,6 @@ public:
     Web::WebDriver::Response get_window_handle();
     ErrorOr<void, Variant<Web::WebDriver::Error, Error>> close_window();
     Web::WebDriver::Response get_window_handles() const;
-    Web::WebDriver::Response is_element_enabled(StringView element_id);
     Web::WebDriver::Response get_source();
     Web::WebDriver::Response execute_script(JsonValue const& payload);
     Web::WebDriver::Response execute_async_script(JsonValue const& payload);

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -58,7 +58,6 @@ public:
     Web::WebDriver::Response get_window_handle();
     ErrorOr<void, Variant<Web::WebDriver::Error, Error>> close_window();
     Web::WebDriver::Response get_window_handles() const;
-    Web::WebDriver::Response get_element_rect(StringView element_id);
     Web::WebDriver::Response is_element_enabled(StringView element_id);
     Web::WebDriver::Response get_source();
     Web::WebDriver::Response execute_script(JsonValue const& payload);

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -58,7 +58,6 @@ public:
     Web::WebDriver::Response get_window_handle();
     ErrorOr<void, Variant<Web::WebDriver::Error, Error>> close_window();
     Web::WebDriver::Response get_window_handles() const;
-    Web::WebDriver::Response get_element_tag_name(JsonValue const& payload, StringView element_id);
     Web::WebDriver::Response get_element_rect(StringView element_id);
     Web::WebDriver::Response is_element_enabled(StringView element_id);
     Web::WebDriver::Response get_source();

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -58,7 +58,6 @@ public:
     Web::WebDriver::Response get_window_handle();
     ErrorOr<void, Variant<Web::WebDriver::Error, Error>> close_window();
     Web::WebDriver::Response get_window_handles() const;
-    Web::WebDriver::Response get_element_attribute(JsonValue const& payload, StringView element_id, StringView name);
     Web::WebDriver::Response get_element_property(JsonValue const& payload, StringView element_id, StringView name);
     Web::WebDriver::Response get_element_css_value(JsonValue const& payload, StringView element_id, StringView property_name);
     Web::WebDriver::Response get_element_text(JsonValue const& payload, StringView element_id);

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -58,7 +58,6 @@ public:
     Web::WebDriver::Response get_window_handle();
     ErrorOr<void, Variant<Web::WebDriver::Error, Error>> close_window();
     Web::WebDriver::Response get_window_handles() const;
-    Web::WebDriver::Response get_element_property(JsonValue const& payload, StringView element_id, StringView name);
     Web::WebDriver::Response get_element_css_value(JsonValue const& payload, StringView element_id, StringView property_name);
     Web::WebDriver::Response get_element_text(JsonValue const& payload, StringView element_id);
     Web::WebDriver::Response get_element_tag_name(JsonValue const& payload, StringView element_id);


### PR DESCRIPTION
[Screencast from 2022-11-10 10-43-44.webm](https://user-images.githubusercontent.com/5600524/201140566-37009053-c4f1-42be-a57e-a850fc122e8c.webm)
