### PR TITLE
Kernel+LibThreading: Allow dead threads to be joined, and generally overhaul thread behavior

### DIFF
--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -824,7 +824,12 @@ public:
             return EDEADLK;
 
         SpinlockLocker lock(m_lock);
-        if (!m_is_joinable || state() == Thread::State::Dead)
+
+        // Joining dead threads is allowed for two main reasons:
+        // - Thread join behavior should not be racy when a thread is joined and exiting at roughly the same time.
+        //   This is common behavior when threads are given a signal to end (meaning they are going to exit ASAP) and then joined.
+        // - POSIX requires that exited threads are joinable (at least, there is no language in the specification forbidding it).
+        if (!m_is_joinable || state() == Thread::State::Invalid)
             return EINVAL;
 
         add_blocker();

--- a/Userland/Libraries/LibThreading/Thread.cpp
+++ b/Userland/Libraries/LibThreading/Thread.cpp
@@ -9,7 +9,9 @@
 #include <string.h>
 #include <unistd.h>
 
-Threading::Thread::Thread(Function<intptr_t()> action, StringView thread_name)
+namespace Threading {
+
+Thread::Thread(Function<intptr_t()> action, StringView thread_name)
     : Core::Object(nullptr)
     , m_action(move(action))
     , m_thread_name(thread_name.is_null() ? ""sv : thread_name)
@@ -21,7 +23,7 @@ Threading::Thread::Thread(Function<intptr_t()> action, StringView thread_name)
 #endif
 }
 
-Threading::Thread::~Thread()
+Thread::~Thread()
 {
     if (m_tid && !m_detached) {
         dbgln("Destroying thread \"{}\"({}) while it is still running!", m_thread_name, m_tid);
@@ -29,7 +31,7 @@ Threading::Thread::~Thread()
     }
 }
 
-ErrorOr<void> Threading::Thread::set_priority(int priority)
+ErrorOr<void> Thread::set_priority(int priority)
 {
     // MacOS has an extra __opaque field, so list initialization will not compile on MacOS Lagom.
     sched_param scheduling_parameters {};
@@ -40,7 +42,7 @@ ErrorOr<void> Threading::Thread::set_priority(int priority)
     return {};
 }
 
-ErrorOr<int> Threading::Thread::get_priority() const
+ErrorOr<int> Thread::get_priority() const
 {
     sched_param scheduling_parameters {};
     int policy;
@@ -50,7 +52,7 @@ ErrorOr<int> Threading::Thread::get_priority() const
     return scheduling_parameters.sched_priority;
 }
 
-void Threading::Thread::start()
+void Thread::start()
 {
     int rc = pthread_create(
         &m_tid,
@@ -74,7 +76,7 @@ void Threading::Thread::start()
     m_started = true;
 }
 
-void Threading::Thread::detach()
+void Thread::detach()
 {
     VERIFY(!m_detached);
 
@@ -82,4 +84,6 @@ void Threading::Thread::detach()
     VERIFY(rc == 0);
 
     m_detached = true;
+}
+
 }

--- a/Userland/Libraries/LibThreading/Thread.cpp
+++ b/Userland/Libraries/LibThreading/Thread.cpp
@@ -52,6 +52,12 @@ ErrorOr<int> Thread::get_priority() const
     return scheduling_parameters.sched_priority;
 }
 
+DeprecatedString Thread::thread_name() const { return m_thread_name; }
+
+pthread_t Thread::tid() const { return m_tid; }
+
+bool Thread::is_started() const { return m_started; }
+
 void Thread::start()
 {
     int rc = pthread_create(

--- a/Userland/Libraries/LibThreading/Thread.h
+++ b/Userland/Libraries/LibThreading/Thread.h
@@ -33,9 +33,9 @@ public:
     template<typename T = void>
     Result<T, ThreadError> join();
 
-    DeprecatedString thread_name() const { return m_thread_name; }
-    pthread_t tid() const { return m_tid; }
-    bool is_started() const { return m_started; }
+    DeprecatedString thread_name() const;
+    pthread_t tid() const;
+    bool is_started() const;
 
 private:
     explicit Thread(Function<intptr_t()> action, StringView thread_name = {});

--- a/Userland/Libraries/LibThreading/Thread.h
+++ b/Userland/Libraries/LibThreading/Thread.h
@@ -63,3 +63,11 @@ Result<T, ThreadError> Thread::join()
 }
 
 }
+
+template<>
+struct AK::Formatter<Threading::Thread> : AK::Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Threading::Thread const& thread)
+    {
+        return Formatter<FormatString>::format(builder, "Thread \"{}\"({})"sv, thread.thread_name(), thread.tid());
+    }
+};


### PR DESCRIPTION
## Part 1: yes, you can join a dead thread, you should be able to, POSIX tells you to, I checked
Joining dead threads should be allowed for two main reasons:
- Thread join behavior should not be racy when a thread is joined and exiting at roughly the same time. This is common behavior when threads are given a signal to end (meaning they are going to exit ASAP) and then joined.
- POSIX requires that exited threads are joinable. This means that we're more spec compliant here without hacky userland workarounds.

The behavior is still well-defined; e.g. it doesn't allow a dead detached thread to be joined or a thread to be joined more than once.

## Part 2: Make `Threading::Thread` thread-safe (lol) and well-behaved

TL;DR: also allow joining dead threads, just use one well-defined state variable and also crash whenever the user mishandles threads (as that usually leads to issues down the line + concurrency is hard)

## Part 3: Thread tests that are enabled and actually pass

(yay)