### PR TITLE
LibAudio: Fix two bugs related to the AudioServer connection audio enqueuer thread

### DIFF
--- a/Userland/Libraries/LibAudio/ConnectionToServer.h
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.h
@@ -81,7 +81,7 @@ private:
     NonnullOwnPtr<UserSampleQueue> m_user_queue;
 
     NonnullRefPtr<Threading::Thread> m_background_audio_enqueuer;
-    Core::EventLoop* m_enqueuer_loop;
+    Core::EventLoop* m_enqueuer_loop { nullptr };
     Threading::Mutex m_enqueuer_loop_destruction;
 
     // A good amount of time to sleep when the queue is full.


### PR DESCRIPTION
# LibAudio: Initialize enqueuer event loop to null pointer
If this is not done, the event loop pointer will be initialized to exploded MALLOC_SCRUB_BYTEs and the null pointer check at destruction time will fail, causing a crash any time an audio client without a started enqueuer thread exits. With this change, we correctly skip quitting the event loop both when it was never started (if the enqueuer thread never ran) as well as if it already exited (if the enqueuer thread exited fast enough) without additional logic for the two very different cases.

# LibAudio: Restore exact audio enqueuer thread mutex behavior
This was changed with a recent move to MutexLocker, but the exact previous behavior is safer as it holds the lock for the minimum amount of time in both locations. We don't want to introduce these kinds of subtle bugs.