### PR TITLE
LibLine: fix save line condition

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -1909,7 +1909,7 @@ VTState actual_rendered_string_length_step(StringMetrics& metrics, size_t index,
     };
 
     // FIXME: current_line.visible_length can go above maximum_line_width when using masks
-    if (maximum_line_width.has_value() && maximum_line_width.value() >= current_line.visible_length)
+    if (maximum_line_width.has_value() && current_line.visible_length >= maximum_line_width.value())
         save_line();
 
     ScopeGuard bit_length_update { [&last_return, &current_line, &index]() {


### PR DESCRIPTION
Fix the condition used by `actual_rendered_string_length_step()` to check if the line reached the desired length.

Recent PR [15976](https://github.com/SerenityOS/serenity/pull/15976) introduced support for  escaped content (for unicode escape sequences) when computing visible length. Trying that patch I have been experiencing bad result with simple command like `md README.md | less` (see first screenshot). 

![Screenshot_20221110_214859](https://user-images.githubusercontent.com/385030/201202849-62b32192-49ca-4cae-b0ba-3da84f9f2aaf.png)

The condition used by the function to understand when a line has reached the desired length was inverted.

This with my own patch:
![Screenshot_20221110_215026](https://user-images.githubusercontent.com/385030/201203165-d1849afe-3708-47a6-a3f2-cc80c138557a.png)




