### PR TITLE
CI: Use gcc-12 in nightly Android host lagom build stage

### DIFF
--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -55,6 +55,8 @@ jobs:
           cmake -GNinja -B tools-build \
             -DBUILD_LAGOM=OFF \
             -DENABLE_LAGOM_CCACHE=ON \
+            -DCMAKE_C_COMPILER=gcc-12 \
+            -DCMAKE_CXX_COMPILER=g++-12 \
             -DCMAKE_INSTALL_PREFIX=tool-install \
             -Dpackage=LagomTools
           ninja -C tools-build install


### PR DESCRIPTION
This was (understandably) missed in the gcc-12 update, since we were implicitly using gcc-11 for the host build as it's the default on Ubuntu 20.04.

cc @linusg for your list :D