### PR TITLE
Userland: Enhance jail-attach utility to support existing and new jails

### DIFF
--- a/Base/usr/share/man/man1/jail-attach.md
+++ b/Base/usr/share/man/man1/jail-attach.md
@@ -13,9 +13,19 @@ $ jail-attach <jail index> <command>
 `jail-attach` attaches a new process by specifying a command, to an existing jail, with a
 specified jail index.
 
+## Options
+
+* `-i`, `--jail-index`: Use an already existing jail with its index
+* `-n`, `--jail-name`: Create a new jail with a provided name
+
 ## Examples
 
 ```sh
-# Attach the command "ps -ef" to a jail with the index 0
-$ jail-attach 0 ps -ef
+# Attach the command "ps -ef" to an already existing jail with the index 0
+$ jail-attach -i 0 ps -ef
+```
+
+```sh
+# Attach the command "/bin/Shell" to a new jail with the name "test jail"
+$ jail-attach -n "test jail" /bin/Shell
 ```


### PR DESCRIPTION
The Core::System::create_jail function already provided the new jail index, so it was a matter of picking up the result in LibCore join_jail function to use the new jail.