### PR TITLE
Kernel+Base: Add more restrictions on jailed processes, add Jails in Mitigations(7) man page

### DIFF
--- a/Base/usr/share/man/man7/Mitigations.md
+++ b/Base/usr/share/man/man7/Mitigations.md
@@ -90,6 +90,33 @@ Date:   Mon Jan 20 22:12:04 2020 +0100
 Kernel: Add a basic implementation of unveil()
 ```
 
+### Jails
+
+`jails` are mitigation originating from FreeBSD.
+It allows a program to be placed inside a lightweight OS-level virtualization environment.
+
+Current restrictions on jailed processes:
+- Process ID view isolation, being limited (both in `/proc` and `/sys/kernel/processes`) to only processes that share the same jail.
+
+Special restrictions on filesystem also apply:
+- Write access is forbidden to the `/sys/kernel/power_state` node.
+- Read accesses is forbidden by default to all nodes in `/sys/kernel` directory, except for:
+    `df`, `interrupts`, `keymap`, `memstat`, `processes`, `stats` and `uptime`.
+- Write access is forbidden to kernel variables (which are located in `/sys/kernel/variables`).
+
+It was first added in the following [commit](https://github.com/SerenityOS/serenity/commit/5e062414c11df31ed595c363990005eef00fa263),
+for kernel support, and the following commits added basic userspace utilities:
+
+```
+commit 5e062414c11df31ed595c363990005eef00fa263
+Author: Liav A <liavalb@gmail.com>
+Date:   Wed Nov 2 22:26:02 2022 +0200
+
+Kernel: Add support for jails
+
+...
+```
+
 ### Readonly atexit
 
 [Readonly atexit](https://isopenbsdsecu.re/mitigations/atexit_hardening/) is a mitigation originating from OpenBSD.

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/DiskUsage.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/DiskUsage.h
@@ -23,6 +23,8 @@ public:
 private:
     SysFSDiskUsage(SysFSDirectory const& parent_directory);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h
@@ -28,6 +28,8 @@ protected:
     virtual ErrorOr<void> refresh_data(OpenFileDescription&) const override;
     virtual ErrorOr<void> try_generate(KBufferBuilder&) = 0;
 
+    virtual bool is_readable_by_jailed_processes() const { return false; }
+
     mutable Mutex m_refresh_lock;
 };
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Interrupts.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Interrupts.h
@@ -23,6 +23,8 @@ public:
 private:
     explicit SysFSInterrupts(SysFSDirectory const& parent_directory);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Keymap.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Keymap.h
@@ -23,6 +23,8 @@ public:
 private:
     explicit SysFSKeymap(SysFSDirectory const& parent_directory);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/MemoryStatus.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/MemoryStatus.h
@@ -23,6 +23,8 @@ public:
 private:
     explicit SysFSMemoryStatus(SysFSDirectory const& parent_directory);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/ARP.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/ARP.h
@@ -22,6 +22,8 @@ public:
 private:
     explicit SysFSNetworkARPStats(SysFSDirectory const&);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Adapters.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Adapters.h
@@ -22,6 +22,8 @@ public:
 private:
     explicit SysFSNetworkAdaptersStats(SysFSDirectory const&);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Local.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Local.h
@@ -22,6 +22,8 @@ public:
 private:
     explicit SysFSLocalNetStats(SysFSDirectory const&);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Route.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Route.h
@@ -22,6 +22,8 @@ public:
 private:
     explicit SysFSNetworkRouteStats(SysFSDirectory const&);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/TCP.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/TCP.h
@@ -22,6 +22,8 @@ public:
 private:
     explicit SysFSNetworkTCPStats(SysFSDirectory const&);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/UDP.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/UDP.h
@@ -22,6 +22,8 @@ public:
 private:
     explicit SysFSNetworkUDPStats(SysFSDirectory const&);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.h
@@ -23,6 +23,8 @@ public:
 private:
     explicit SysFSOverallProcesses(SysFSDirectory const& parent_directory);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/SystemStatistics.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/SystemStatistics.h
@@ -23,6 +23,8 @@ public:
 private:
     explicit SysFSSystemStatistics(SysFSDirectory const& parent_directory);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Uptime.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Uptime.h
@@ -22,6 +22,8 @@ public:
 private:
     explicit SysFSUptime(SysFSDirectory const& parent_directory);
     virtual ErrorOr<void> try_generate(KBufferBuilder& builder) override;
+
+    virtual bool is_readable_by_jailed_processes() const override { return true; }
 };
 
 }


### PR DESCRIPTION
The Jails concept was introduced into the `Mitigations(7)` manual page first in #16027.
After some thinking, I concluded that more restrictions on jailed processes is the right thing to do, hence,
I added a few basic restrictions mainly for the `/sys/kernel` directory - please note that I don't try to hide the presenece
of the sysfs nodes, but instead let userland find those nodes and fail with `EPERM` error upon reading or writing to them, which is much more sensible as these nodes are not gone, just not accessible in the context of a Jail. Also, it ensures we don't bloat the SysFS code with unnecessary checks for that folder.