### PR TITLE
VideoPlayer: Remove PlaybackManager from children when opening a video

### DIFF
--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -69,9 +69,15 @@ VideoPlayerWidget::VideoPlayerWidget(GUI::Window& window)
     m_volume_slider->set_fixed_width(100);
 }
 
+void VideoPlayerWidget::close_file()
+{
+    if (m_playback_manager)
+        m_playback_manager = nullptr;
+}
+
 void VideoPlayerWidget::open_file(StringView filename)
 {
-    auto load_file_result = Video::PlaybackManager::from_file(this, filename);
+    auto load_file_result = Video::PlaybackManager::from_file(*this, filename);
 
     if (load_file_result.is_error()) {
         on_decoding_error(load_file_result.release_error());
@@ -81,6 +87,7 @@ void VideoPlayerWidget::open_file(StringView filename)
     m_path = filename;
     update_title();
 
+    close_file();
     m_playback_manager = load_file_result.release_value();
     resume_playback();
 }

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
@@ -22,6 +22,7 @@ class VideoPlayerWidget final : public GUI::Widget {
     C_OBJECT(VideoPlayerWidget)
 
 public:
+    void close_file();
     void open_file(StringView filename);
     void resume_playback();
     void pause_playback();
@@ -59,7 +60,7 @@ private:
     RefPtr<GUI::Action> m_cycle_sizing_modes_action;
     RefPtr<GUI::HorizontalSlider> m_volume_slider;
 
-    RefPtr<Video::PlaybackManager> m_playback_manager;
+    OwnPtr<Video::PlaybackManager> m_playback_manager;
 };
 
 }

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -91,15 +91,12 @@ private:
 static constexpr size_t FRAME_BUFFER_COUNT = 4;
 using VideoFrameQueue = Queue<FrameQueueItem, FRAME_BUFFER_COUNT>;
 
-class PlaybackManager : public Core::Object {
-    C_OBJECT(PlaybackManager)
-
+class PlaybackManager {
 public:
-    static DecoderErrorOr<NonnullRefPtr<PlaybackManager>> from_file(Object* event_handler, StringView file);
-    static DecoderErrorOr<NonnullRefPtr<PlaybackManager>> from_data(Object* event_handler, Span<u8> data);
+    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_file(Core::Object& event_handler, StringView file);
+    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_data(Core::Object& event_handler, Span<u8> data);
 
-    PlaybackManager(Object* event_handler, NonnullOwnPtr<Demuxer>& demuxer, Track video_track, NonnullOwnPtr<VideoDecoder>& decoder);
-    ~PlaybackManager() override = default;
+    PlaybackManager(Core::Object& event_handler, NonnullOwnPtr<Demuxer>& demuxer, Track video_track, NonnullOwnPtr<VideoDecoder>&& decoder);
 
     void resume_playback();
     void pause_playback();
@@ -110,7 +107,6 @@ public:
 
     u64 number_of_skipped_frames() const { return m_skipped_frames; }
 
-    void event(Core::Event& event) override;
     void on_decoder_error(DecoderError error);
 
     Time current_playback_time();
@@ -129,6 +125,7 @@ private:
     bool decode_and_queue_one_sample();
     void on_decode_timer();
 
+    Core::Object& m_event_handler;
     Core::EventLoop& m_main_loop;
 
     PlaybackStatus m_status { PlaybackStatus::Stopped };


### PR DESCRIPTION
VideoPlayerWidget was keeping a reference to PlaybackManager when changing files, so the old and new managers would both send frames to be presented at the same time, causing it to flicker back and forth between the two videos. Removing the PlaybackManager from the VideoPlayerWidget causes it to be destroyed properly, preventing events from continuing to be sent.