### PR TITLE
Toolchain: Fix missing makeinfo on macOS Ventura

### DIFF
--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -345,8 +345,8 @@ pushd "$DIR/Build/$ARCH"
             fi
 
             echo "XXX build gdb"
-            buildstep "gdb/build" "$MAKE" -j "$MAKEJOBS" || exit 1
-            buildstep "gdb/install" "$MAKE" install || exit 1
+            buildstep "gdb/build" "$MAKE" MAKEINFO=true -j "$MAKEJOBS" || exit 1
+            buildstep "gdb/install" "$MAKE" MAKEINFO=true install || exit 1
         popd
     fi
 


### PR DESCRIPTION
macOS ventura no longer comes with makeinfo. binutils has already been 
fixed - see https://github.com/SerenityOS/serenity/pull/15932

This patch does the same for GDB.