### PR TITLE
LibWeb: Clip hidden overflow by absolute rect of containing block

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -86,12 +86,8 @@ public:
 
     virtual void paint(PaintContext&, PaintPhase) const { }
 
-    enum class ShouldClipOverflow {
-        No,
-        Yes
-    };
-    virtual void before_children_paint(PaintContext&, PaintPhase, ShouldClipOverflow) const { }
-    virtual void after_children_paint(PaintContext&, PaintPhase, ShouldClipOverflow) const { }
+    virtual void before_children_paint(PaintContext&, PaintPhase) const { }
+    virtual void after_children_paint(PaintContext&, PaintPhase) const { }
 
     virtual Optional<HitTestResult> hit_test(Gfx::FloatPoint const&, HitTestType) const;
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -96,6 +96,8 @@ public:
         return m_overflow_data->scrollable_overflow_rect;
     }
 
+    Optional<Gfx::IntRect> clip_rect() const;
+
     void set_overflow_data(Optional<OverflowData> data) { m_overflow_data = move(data); }
     void set_containing_line_box_fragment(Optional<Layout::LineBoxFragmentCoordinate>);
 
@@ -110,8 +112,8 @@ public:
     DOM::Document const& document() const { return layout_box().document(); }
     DOM::Document& document() { return layout_box().document(); }
 
-    virtual void before_children_paint(PaintContext&, PaintPhase, ShouldClipOverflow) const override;
-    virtual void after_children_paint(PaintContext&, PaintPhase, ShouldClipOverflow) const override;
+    virtual void before_children_paint(PaintContext&, PaintPhase) const override;
+    virtual void after_children_paint(PaintContext&, PaintPhase) const override;
 
     virtual Optional<HitTestResult> hit_test(Gfx::FloatPoint const&, HitTestType) const override;
 
@@ -152,6 +154,8 @@ private:
 
     Optional<Gfx::FloatRect> mutable m_absolute_rect;
     Optional<Gfx::FloatRect> mutable m_absolute_paint_rect;
+
+    Optional<Gfx::IntRect> mutable m_clip_rect;
 
     mutable bool m_clipping_overflow { false };
     Optional<BorderRadiusCornerClipper> mutable m_overflow_corner_radius_clipper;

--- a/Userland/Libraries/LibWeb/Painting/SVGGraphicsPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGraphicsPaintable.cpp
@@ -19,9 +19,9 @@ Layout::SVGGraphicsBox const& SVGGraphicsPaintable::layout_box() const
     return static_cast<Layout::SVGGraphicsBox const&>(layout_node());
 }
 
-void SVGGraphicsPaintable::before_children_paint(PaintContext& context, PaintPhase phase, ShouldClipOverflow should_clip_overflow) const
+void SVGGraphicsPaintable::before_children_paint(PaintContext& context, PaintPhase phase) const
 {
-    SVGPaintable::before_children_paint(context, phase, should_clip_overflow);
+    SVGPaintable::before_children_paint(context, phase);
     if (phase != PaintPhase::Foreground)
         return;
 

--- a/Userland/Libraries/LibWeb/Painting/SVGGraphicsPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGGraphicsPaintable.h
@@ -13,7 +13,7 @@ namespace Web::Painting {
 
 class SVGGraphicsPaintable : public SVGPaintable {
 public:
-    virtual void before_children_paint(PaintContext&, PaintPhase, ShouldClipOverflow) const override;
+    virtual void before_children_paint(PaintContext&, PaintPhase) const override;
 
     Layout::SVGGraphicsBox const& layout_box() const;
 

--- a/Userland/Libraries/LibWeb/Painting/SVGPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGPaintable.cpp
@@ -20,17 +20,17 @@ Layout::SVGBox const& SVGPaintable::layout_box() const
     return static_cast<Layout::SVGBox const&>(layout_node());
 }
 
-void SVGPaintable::before_children_paint(PaintContext& context, PaintPhase phase, ShouldClipOverflow should_clip_overflow) const
+void SVGPaintable::before_children_paint(PaintContext& context, PaintPhase phase) const
 {
-    PaintableBox::before_children_paint(context, phase, should_clip_overflow);
+    PaintableBox::before_children_paint(context, phase);
     if (phase != PaintPhase::Foreground)
         return;
     context.svg_context().save();
 }
 
-void SVGPaintable::after_children_paint(PaintContext& context, PaintPhase phase, ShouldClipOverflow should_clip_overflow) const
+void SVGPaintable::after_children_paint(PaintContext& context, PaintPhase phase) const
 {
-    PaintableBox::after_children_paint(context, phase, should_clip_overflow);
+    PaintableBox::after_children_paint(context, phase);
     if (phase != PaintPhase::Foreground)
         return;
     context.svg_context().restore();

--- a/Userland/Libraries/LibWeb/Painting/SVGPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGPaintable.h
@@ -13,8 +13,8 @@ namespace Web::Painting {
 
 class SVGPaintable : public PaintableBox {
 public:
-    virtual void before_children_paint(PaintContext&, PaintPhase, ShouldClipOverflow) const override;
-    virtual void after_children_paint(PaintContext&, PaintPhase, ShouldClipOverflow) const override;
+    virtual void before_children_paint(PaintContext&, PaintPhase) const override;
+    virtual void after_children_paint(PaintContext&, PaintPhase) const override;
 
     Layout::SVGBox const& layout_box() const;
 

--- a/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -24,7 +24,7 @@ Layout::SVGSVGBox const& SVGSVGPaintable::layout_box() const
     return static_cast<Layout::SVGSVGBox const&>(layout_node());
 }
 
-void SVGSVGPaintable::before_children_paint(PaintContext& context, PaintPhase phase, ShouldClipOverflow should_clip_overflow) const
+void SVGSVGPaintable::before_children_paint(PaintContext& context, PaintPhase phase) const
 {
     if (phase != PaintPhase::Foreground)
         return;
@@ -32,12 +32,12 @@ void SVGSVGPaintable::before_children_paint(PaintContext& context, PaintPhase ph
     if (!context.has_svg_context())
         context.set_svg_context(SVGContext(absolute_rect()));
 
-    PaintableBox::before_children_paint(context, phase, should_clip_overflow);
+    PaintableBox::before_children_paint(context, phase);
 }
 
-void SVGSVGPaintable::after_children_paint(PaintContext& context, PaintPhase phase, ShouldClipOverflow should_clip_overflow) const
+void SVGSVGPaintable::after_children_paint(PaintContext& context, PaintPhase phase) const
 {
-    PaintableBox::after_children_paint(context, phase, should_clip_overflow);
+    PaintableBox::after_children_paint(context, phase);
     if (phase != PaintPhase::Foreground)
         return;
     context.clear_svg_context();

--- a/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.h
@@ -15,8 +15,8 @@ class SVGSVGPaintable : public PaintableBox {
 public:
     static NonnullRefPtr<SVGSVGPaintable> create(Layout::SVGSVGBox const&);
 
-    virtual void before_children_paint(PaintContext&, PaintPhase, ShouldClipOverflow) const override;
-    virtual void after_children_paint(PaintContext&, PaintPhase, ShouldClipOverflow) const override;
+    virtual void before_children_paint(PaintContext&, PaintPhase) const override;
+    virtual void after_children_paint(PaintContext&, PaintPhase) const override;
 
     Layout::SVGSVGBox const& layout_box() const;
 

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -72,7 +72,7 @@ static PaintPhase to_paint_phase(StackingContext::StackingContextPaintPhase phas
 void StackingContext::paint_descendants(PaintContext& context, Layout::Node const& box, StackingContextPaintPhase phase) const
 {
     if (auto* paintable = box.paintable())
-        paintable->before_children_paint(context, to_paint_phase(phase), Paintable::ShouldClipOverflow::Yes);
+        paintable->before_children_paint(context, to_paint_phase(phase));
 
     box.for_each_child([&](auto& child) {
         // If `child` establishes its own stacking context, skip over it.
@@ -125,7 +125,7 @@ void StackingContext::paint_descendants(PaintContext& context, Layout::Node cons
     });
 
     if (auto* paintable = box.paintable())
-        paintable->after_children_paint(context, to_paint_phase(phase), Paintable::ShouldClipOverflow::Yes);
+        paintable->after_children_paint(context, to_paint_phase(phase));
 }
 
 void StackingContext::paint_internal(PaintContext& context) const
@@ -137,13 +137,12 @@ void StackingContext::paint_internal(PaintContext& context) const
 
     auto paint_child = [&](auto* child) {
         auto parent = child->m_box.parent();
-        auto should_clip_overflow = child->m_box.is_absolutely_positioned() ? Paintable::ShouldClipOverflow::No : Paintable::ShouldClipOverflow::Yes;
         auto* paintable = parent ? parent->paintable() : nullptr;
         if (paintable)
-            paintable->before_children_paint(context, PaintPhase::Foreground, should_clip_overflow);
+            paintable->before_children_paint(context, PaintPhase::Foreground);
         child->paint(context);
         if (paintable)
-            paintable->after_children_paint(context, PaintPhase::Foreground, should_clip_overflow);
+            paintable->after_children_paint(context, PaintPhase::Foreground);
     };
 
     // Draw positioned descendants with negative z-indices (step 3)

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -177,6 +177,10 @@ void StackingContext::paint_internal(PaintContext& context) const
         // At this point, `paint_box` is a positioned descendant with z-index: auto
         // but no stacking context of its own.
         // FIXME: This is basically duplicating logic found elsewhere in this same function. Find a way to make this more elegant.
+        auto parent = paint_box.layout_node().parent();
+        auto* paintable = parent ? parent->paintable() : nullptr;
+        if (paintable)
+            paintable->before_children_paint(context, PaintPhase::Foreground);
         paint_node(paint_box.layout_box(), context, PaintPhase::Background);
         paint_node(paint_box.layout_box(), context, PaintPhase::Border);
         paint_descendants(context, paint_box.layout_box(), StackingContextPaintPhase::BackgroundAndBorders);
@@ -187,6 +191,8 @@ void StackingContext::paint_internal(PaintContext& context) const
         paint_node(paint_box.layout_box(), context, PaintPhase::FocusOutline);
         paint_node(paint_box.layout_box(), context, PaintPhase::Overlay);
         paint_descendants(context, paint_box.layout_box(), StackingContextPaintPhase::FocusAndOverlay);
+        if (paintable)
+            paintable->after_children_paint(context, PaintPhase::Foreground);
 
         return TraversalDecision::Continue;
     });


### PR DESCRIPTION
Since handling `overflow: hidden` in `PaintableBox::before_children_paint` while following paint traversal order can't result in correctly computed clip rectangle for elements that create their own stacking context (because `before_children_paint` is called only for parent but `overflow: hidden` can be set somewhere deeper but not in direct ancestor), here introduced new function `PaintableBox::clip_rect()` that computes clip rectangle by looking into containing block.

Example that displays right after fix:
```html
<!DOCTYPE html><html lang="en"><head><style>
      .outer-box {
        width: 300px;
        height: 300px;
        background-color: darkblue;
        overflow: hidden;
      }

      .inner-box {
        width: 600px;
        height: 600px;
        background-color: orangered;
        transform: translate(100px, 100px);
      }</style></head><body><div class="outer-box"><div><div class="inner-box"></div></div></div></body></html>
```