### PR TITLE
Toolchain: Add libxcrypt to serenity.nix

### DIFF
--- a/Toolchain/serenity.nix
+++ b/Toolchain/serenity.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation {
   buildInputs = [
     # Example Run-time Additional Dependencies
     openssl
+    libxcrypt
     xlibsWrapper
     qemu
     e2fsprogs


### PR DESCRIPTION
Should deal with build errors related to a missing crypt.h file