### PR TITLE
Meta: Add devcontainer configuration for use with Github Codespaces 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+    "name": "Ubuntu",
+    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+
+    // Features to add to the dev container. More info: https://containers.dev/implementors/features.
+    "features": {
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainers-contrib/features/pre-commit:1": {},
+        "./serenity": {
+            "llvm_version": 15,
+            "enable_ladybird": true,
+            "enable_serenity": true
+        },
+        "ghcr.io/devcontainers/features/desktop-lite": {
+            "password": "vscode",
+            "webPort": "6080",
+            "vncPort": "5901"
+        }
+    },
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [6080, 5901],
+    "portsAttributes": {
+        "5901": {
+            "label": "VNC"
+        },
+        "6080": {
+            "label": "Web VNC"
+        }
+    },
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "pre-commit install; pre-commit install --hook-type commit-msg"
+
+    // Configure tool-specific properties.
+    // "customizations": {},
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root",
+}

--- a/.devcontainer/serenity/devcontainer-feature.json
+++ b/.devcontainer/serenity/devcontainer-feature.json
@@ -1,0 +1,28 @@
+{
+    "name": "Serenity Development",
+    "id": "serenity",
+    "version": "1.0.0",
+    "description": "Enable development of Serenity and Lagom libraries and applications",
+    "options": {
+        "llvm_version": {
+            "type": "string",
+            "proposals": [
+                14,
+                15,
+                "trunk"
+            ],
+            "default": 15,
+            "description": "Select LLVM compiler version to use"
+        },
+        "enable_ladybird": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install Qt6 packages for Ladybird development"
+        },
+        "enable_serenity": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install packages for SerenityOS development"
+        }
+    }
+}

--- a/.devcontainer/serenity/install.sh
+++ b/.devcontainer/serenity/install.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -e
+
+# Feature options
+
+LLVM_VERSION=${LLVM_VERSION:-15}
+ENABLE_LADYBIRD=${ENABLE_LADYBIRD:-true}
+ENABLE_SERENITY=${ENABLE_SERENITY:-true}
+
+### Check distro
+
+if [ ! -f /etc/lsb-release ]; then
+    echo "Not an Ubuntu container, add logic for your distro to the serenity feature or use Ubuntu"
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+. /etc/lsb-release
+
+### Declare helper functions
+
+install_llvm_key() {
+    wget -O /usr/share/keyrings/llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key
+    echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/${DISTRIB_CODENAME}/ llvm-toolchain-${DISTRIB_CODENAME} main" | tee -a /etc/apt/sources.list.d/llvm.list
+    if [ ! "${LLVM_VERSION}" = "trunk" ]; then
+        echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/${DISTRIB_CODENAME}/ llvm-toolchain-${DISTRIB_CODENAME}-${LLVM_VERSION} main" | tee -a /etc/apt/sources.list.d/llvm.list
+    fi
+    apt update -y
+}
+
+### Install packages
+
+apt update -y
+apt install -y build-essential cmake ninja-build ccache shellcheck
+if [ "${ENABLE_LADYBIRD}" = "true" ]; then
+    apt install -y libgl1-mesa-dev qt6-base-dev qt6-tools-dev-tools qt6-wayland
+fi
+if [ "${ENABLE_SERENITY}" = "true" ]; then
+    apt install -y curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs genext2fs qemu-system-gui qemu-system-x86 qemu-utils rsync unzip texinfo
+fi
+
+### Ensure new enough host compiler is available
+
+VERSION="0.0.0"
+if command -v clang >/dev/null 2>&1; then
+    VERSION="$(clang -dumpversion)"
+fi
+MAJOR_VERSION="${VERSION%%.*}"
+
+if [ "${LLVM_VERSION}" = "trunk" ]; then
+    install_llvm_key
+
+    apt install -y llvm clang clangd clang-tools lld lldb clang-tidy clang-format
+elif [ "${MAJOR_VERSION}" -lt "${LLVM_VERSION}" ]; then
+    FAILED_INSTALL=0
+    apt install -y "llvm-${LLVM_VERSION}" "clang-${LLVM_VERSION}" "clangd-${LLVM_VERSION}" "clang-tools-${LLVM_VERSION}" "lld-${LLVM_VERSION}" "lldb-${LLVM_VERSION}" "clang-tidy-${LLVM_VERSION}" "clang-format-${LLVM_VERSION}"  || FAILED_INSTALL=1
+
+    if [ "${FAILED_INSTALL}" -ne 0 ]; then
+        install_llvm_key
+        apt install -y "llvm-${LLVM_VERSION}" "clang-${LLVM_VERSION}" "clangd-${LLVM_VERSION}" "clang-tools-${LLVM_VERSION}" "lld-${LLVM_VERSION}" "lldb-${LLVM_VERSION}" "clang-tidy-${LLVM_VERSION}" "clang-format-${LLVM_VERSION}"
+    fi
+fi

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -156,9 +156,11 @@ is_supported_compiler() {
     if $COMPILER --version 2>&1 | grep "Apple clang" >/dev/null; then
         return 1
     elif $COMPILER --version 2>&1 | grep "clang" >/dev/null; then
-        [ "$MAJOR_VERSION" -gt 12 ] && return 0
+        # Clang version check
+        [ "$MAJOR_VERSION" -ge 13 ] && return 0
     else
-        [ "$MAJOR_VERSION" -gt 10 ] && return 0
+        # GCC version check
+        [ "$MAJOR_VERSION" -ge 12 ] && return 0
     fi
     return 1
 }


### PR DESCRIPTION
This configuration allows developing serenity and ladybird in github codespaces. It should also help anyone who wants to use a devcontainer locally.

While we're here, fix the is_supported_compiler check in serenity.sh We were checking the compilers against clang-12 and gcc-10. Since the check itself is confusing, some comments are warranted.