### PR TITLE
LibWeb: Implement `radial-gradient()`s and other tweaks

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -182,6 +182,22 @@
                 chocolate 20deg 30deg
             );
         }
+
+        .grad-radial-1 {
+            background-image: radial-gradient(#e66465, #9198e5);
+        }
+
+        .grad-radial-2 {
+            background-image: radial-gradient(closest-side, #3f87a6, #ebf8e1, #f69d3c);
+        }
+
+        .grad-radial-3 {
+            background-image: radial-gradient(circle at 100px, #333, #333 50%, #eee 75%, #333 75%);
+        }
+
+        .grad-radial-4 {
+            background-image: radial-gradient(200px 100px ellipse at 25% 50%, yellow, #009966, purple);
+        }
     </style>
   </head>
   <body>
@@ -232,6 +248,11 @@
     <b>Repeating conic gradients</b><br>
     <div class="box grad-conic-repeat-1"></div>
     <div class="box grad-conic-repeat-2"></div>
+    <b>Radial gradients</b><br>
+    <div class="rect grad-radial-1"></div>
+    <div class="rect grad-radial-2"></div>
+    <div class="rect grad-radial-3"></div>
+    <div class="rect grad-radial-4"></div>
   </body>
   <script>
     const boxes = document.querySelectorAll(".box, .rect");

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2644,7 +2644,7 @@ RefPtr<StyleValue> Parser::parse_conic_gradient_function(ComponentValue const& c
     return ConicGradientStyleValue::create(from_angle, at_position, move(*color_stops), repeating_gradient);
 }
 
-Optional<PositionValue> Parser::parse_position(TokenStream<ComponentValue>& tokens)
+Optional<PositionValue> Parser::parse_position(TokenStream<ComponentValue>& tokens, PositionValue initial_value)
 {
     auto transaction = tokens.begin_transaction();
     tokens.skip_whitespace();
@@ -2700,7 +2700,7 @@ Optional<PositionValue> Parser::parse_position(TokenStream<ComponentValue>& toke
     // [ left | center | right ] || [ top | center | bottom ]
     auto alternation_1 = [&]() -> Optional<PositionValue> {
         auto transaction = tokens.begin_transaction();
-        PositionValue position {};
+        PositionValue position = initial_value;
         auto& first_token = tokens.next_token();
         if (!first_token.is(Token::Type::Ident))
             return {};
@@ -2709,15 +2709,17 @@ Optional<PositionValue> Parser::parse_position(TokenStream<ComponentValue>& toke
         auto horizontal_position = parse_horizontal_preset(ident);
         if (horizontal_position.has_value()) {
             position.horizontal_position = *horizontal_position;
+            auto transaction_optional_parse = tokens.begin_transaction();
             tokens.skip_whitespace();
             if (tokens.has_next_token()) {
                 auto& second_token = tokens.next_token();
-                if (!second_token.is(Token::Type::Ident))
-                    return {};
-                auto vertical_position = parse_vertical_preset(second_token.token().ident());
-                if (!vertical_position.has_value())
-                    return {};
-                position.vertical_position = *vertical_position;
+                if (second_token.is(Token::Type::Ident)) {
+                    auto vertical_position = parse_vertical_preset(second_token.token().ident());
+                    if (vertical_position.has_value()) {
+                        transaction_optional_parse.commit();
+                        position.vertical_position = *vertical_position;
+                    }
+                }
             }
         } else {
             // <vertical-position> <horizontal-position>?
@@ -2725,14 +2727,17 @@ Optional<PositionValue> Parser::parse_position(TokenStream<ComponentValue>& toke
             if (!vertical_position.has_value())
                 return {};
             position.vertical_position = *vertical_position;
+            auto transaction_optional_parse = tokens.begin_transaction();
+            tokens.skip_whitespace();
             if (tokens.has_next_token()) {
                 auto& second_token = tokens.next_token();
-                if (!second_token.is(Token::Type::Ident))
-                    return {};
-                auto horizontal_position = parse_horizontal_preset(second_token.token().ident());
-                if (!horizontal_position.has_value())
-                    return {};
-                position.horizontal_position = *horizontal_position;
+                if (second_token.is(Token::Type::Ident)) {
+                    auto horizontal_position = parse_horizontal_preset(second_token.token().ident());
+                    if (horizontal_position.has_value()) {
+                        transaction_optional_parse.commit();
+                        position.horizontal_position = *horizontal_position;
+                    }
+                }
             }
         }
         transaction.commit();
@@ -2743,7 +2748,7 @@ Optional<PositionValue> Parser::parse_position(TokenStream<ComponentValue>& toke
     // [ top | center | bottom | <length-percentage> ]?
     auto alternation_2 = [&]() -> Optional<PositionValue> {
         auto transaction = tokens.begin_transaction();
-        PositionValue position {};
+        PositionValue position = initial_value;
         auto& first_token = tokens.next_token();
         if (first_token.is(Token::Type::Ident)) {
             auto horizontal_position = parse_horizontal_preset(first_token.token().ident());
@@ -2756,19 +2761,22 @@ Optional<PositionValue> Parser::parse_position(TokenStream<ComponentValue>& toke
                 return {};
             position.horizontal_position = dimension->length_percentage();
         }
+        auto transaction_optional_parse = tokens.begin_transaction();
         tokens.skip_whitespace();
         if (tokens.has_next_token()) {
             auto& second_token = tokens.next_token();
             if (second_token.is(Token::Type::Ident)) {
                 auto vertical_position = parse_vertical_preset(second_token.token().ident());
-                if (!vertical_position.has_value())
-                    return {};
-                position.vertical_position = *vertical_position;
+                if (vertical_position.has_value()) {
+                    transaction_optional_parse.commit();
+                    position.vertical_position = *vertical_position;
+                }
             } else {
                 auto dimension = parse_dimension(second_token);
-                if (!dimension.has_value() || !dimension->is_length_percentage())
-                    return {};
-                position.vertical_position = dimension->length_percentage();
+                if (dimension.has_value() && dimension->is_length_percentage()) {
+                    transaction_optional_parse.commit();
+                    position.vertical_position = dimension->length_percentage();
+                }
             }
         }
         transaction.commit();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2386,6 +2386,30 @@ static Optional<Vector<TElement>> parse_color_stop_list(auto& tokens, auto is_po
     return color_stops;
 }
 
+Optional<Vector<LinearColorStopListElement>> Parser::parse_linear_color_stop_list(TokenStream<ComponentValue>& tokens)
+{
+    // <color-stop-list> =
+    //   <linear-color-stop> , [ <linear-color-hint>? , <linear-color-stop> ]#
+    return parse_color_stop_list<LinearColorStopListElement>(
+        tokens,
+        [](Dimension& dimension) { return dimension.is_length_percentage(); },
+        [](Dimension& dimension) { return dimension.length_percentage(); },
+        [&](auto& token) { return parse_color(token); },
+        [&](auto& token) { return parse_dimension(token); });
+}
+
+Optional<Vector<AngularColorStopListElement>> Parser::parse_angular_color_stop_list(TokenStream<ComponentValue>& tokens)
+{
+    // <angular-color-stop-list> =
+    //   <angular-color-stop> , [ <angular-color-hint>? , <angular-color-stop> ]#
+    return parse_color_stop_list<AngularColorStopListElement>(
+        tokens,
+        [](Dimension& dimension) { return dimension.is_angle_percentage(); },
+        [](Dimension& dimension) { return dimension.angle_percentage(); },
+        [&](auto& token) { return parse_color(token); },
+        [&](auto& token) { return parse_dimension(token); });
+}
+
 static StringView consume_if_starts_with(StringView str, StringView start, auto found_callback)
 {
     if (str.starts_with(start, CaseSensitivity::CaseInsensitive)) {
@@ -2516,19 +2540,7 @@ RefPtr<StyleValue> Parser::parse_linear_gradient_function(ComponentValue const& 
     if (has_direction_param && !tokens.next_token().is(Token::Type::Comma))
         return {};
 
-    // <color-stop-list> =
-    //      <linear-color-stop> , [ <linear-color-hint>? , <linear-color-stop> ]#
-    auto is_length_percentage = [](Dimension& dimension) {
-        return dimension.is_length_percentage();
-    };
-    auto get_length_percentage = [](Dimension& dimension) {
-        return dimension.length_percentage();
-    };
-    auto color_stops = parse_color_stop_list<LinearColorStopListElement>(
-        tokens, is_length_percentage, get_length_percentage,
-        [&](auto& token) { return parse_color(token); },
-        [&](auto& token) { return parse_dimension(token); });
-
+    auto color_stops = parse_linear_color_stop_list(tokens);
     if (!color_stops.has_value())
         return {};
 
@@ -2625,19 +2637,7 @@ RefPtr<StyleValue> Parser::parse_conic_gradient_function(ComponentValue const& c
     if ((got_from_angle || got_at_position || got_color_interpolation_method) && !tokens.next_token().is(Token::Type::Comma))
         return {};
 
-    // <angular-color-stop-list> =
-    //   <angular-color-stop> , [ <angular-color-hint>? , <angular-color-stop> ]#
-    auto is_angle_percentage = [](Dimension& dimension) {
-        return dimension.is_angle_percentage();
-    };
-    auto get_angle_percentage = [](Dimension& dimension) {
-        return dimension.angle_percentage();
-    };
-    auto color_stops = parse_color_stop_list<AngularColorStopListElement>(
-        tokens, is_angle_percentage, get_angle_percentage,
-        [&](auto& token) { return parse_color(token); },
-        [&](auto& token) { return parse_dimension(token); });
-
+    auto color_stops = parse_angular_color_stop_list(tokens);
     if (!color_stops.has_value())
         return {};
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -269,6 +269,7 @@ private:
 
     RefPtr<StyleValue> parse_linear_gradient_function(ComponentValue const&);
     RefPtr<StyleValue> parse_conic_gradient_function(ComponentValue const&);
+    RefPtr<StyleValue> parse_radial_gradient_function(ComponentValue const&);
 
     ParseErrorOr<NonnullRefPtr<StyleValue>> parse_css_value(PropertyID, TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_css_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -264,6 +264,9 @@ private:
     };
     Optional<AK::URL> parse_url_function(ComponentValue const&, AllowedDataUrlType = AllowedDataUrlType::None);
 
+    Optional<Vector<LinearColorStopListElement>> parse_linear_color_stop_list(TokenStream<ComponentValue>&);
+    Optional<Vector<AngularColorStopListElement>> parse_angular_color_stop_list(TokenStream<ComponentValue>&);
+
     RefPtr<StyleValue> parse_linear_gradient_function(ComponentValue const&);
     RefPtr<StyleValue> parse_conic_gradient_function(ComponentValue const&);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -255,7 +255,7 @@ private:
     Optional<GridMinMax> parse_min_max(Vector<ComponentValue> const&);
     Optional<GridRepeat> parse_repeat(Vector<ComponentValue> const&);
     Optional<ExplicitGridTrack> parse_track_sizing_function(ComponentValue const&);
-    Optional<PositionValue> parse_position(TokenStream<ComponentValue>&);
+    Optional<PositionValue> parse_position(TokenStream<ComponentValue>&, PositionValue initial_value = PositionValue::center());
 
     enum class AllowedDataUrlType {
         None,

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1821,19 +1821,10 @@ bool LinearGradientStyleValue::equals(StyleValue const& other_) const
     if (type() != other_.type())
         return false;
     auto& other = other_.as_linear_gradient();
-
-    if (m_gradient_type != other.m_gradient_type
-        || m_repeating != other.m_repeating
-        || m_direction != other.m_direction
-        || m_color_stop_list.size() != other.m_color_stop_list.size()) {
-        return false;
-    }
-
-    for (size_t i = 0; i < m_color_stop_list.size(); i++) {
-        if (m_color_stop_list[i] != other.m_color_stop_list[i])
-            return false;
-    }
-    return true;
+    return (m_gradient_type == other.m_gradient_type
+        && m_repeating == other.m_repeating
+        && m_direction == other.m_direction
+        && m_color_stop_list == other.m_color_stop_list);
 }
 
 float LinearGradientStyleValue::angle_degrees(Gfx::FloatSize const& gradient_size) const
@@ -2183,9 +2174,15 @@ void ConicGradientStyleValue::paint(PaintContext& context, Gfx::IntRect const& d
     Painting::paint_conic_gradient(context, dest_rect, m_resolved->data, m_resolved->position.to_rounded<int>());
 }
 
-bool ConicGradientStyleValue::equals(StyleValue const&) const
+bool ConicGradientStyleValue::equals(StyleValue const& other) const
 {
-    return false;
+    if (type() != other.type())
+        return false;
+    auto& other_gradient = other.as_conic_gradient();
+    return (m_from_angle == other_gradient.m_from_angle
+        && m_position == other_gradient.m_position
+        && m_color_stop_list == other_gradient.m_color_stop_list
+        && m_repeating == other_gradient.m_repeating);
 }
 
 float ConicGradientStyleValue::angle_degrees() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -1271,6 +1271,14 @@ private:
     Size m_size;
     PositionValue m_position;
     Vector<LinearColorStopListElement> m_color_stop_list;
+
+    struct ResolvedData {
+        Painting::RadialGradientData data;
+        Gfx::FloatSize gradient_size;
+        Gfx::FloatPoint center;
+    };
+
+    mutable Optional<ResolvedData> m_resolved;
 };
 
 class ConicGradientStyleValue final : public AbstractImageStyleValue {

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -90,6 +90,7 @@ class Percentage;
 class PercentageStyleValue;
 class PositionStyleValue;
 class PropertyOwningCSSStyleDeclaration;
+class RadialGradientStyleValue;
 class RectStyleValue;
 class Resolution;
 class ResolutionStyleValue;

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -220,19 +220,19 @@ public:
         }
     }
 
-    Gfx::Color get_color(int index) const
+    Gfx::Color get_color(uint64_t index) const
     {
         return m_gradient_line_colors[clamp(index, 0, m_gradient_line_colors.size() - 1)];
     }
 
     Gfx::Color sample_color(float loc) const
     {
-        auto repeat_wrap_if_required = [&](int loc) {
+        auto repeat_wrap_if_required = [&](uint64_t loc) {
             if (m_repeating)
-                return (loc + m_start_offset) % static_cast<int>(m_gradient_line_colors.size());
+                return (loc + m_start_offset) % m_gradient_line_colors.size();
             return loc;
         };
-        auto int_loc = static_cast<int>(floor(loc));
+        auto int_loc = static_cast<uint64_t>(floor(loc));
         auto blend = loc - int_loc;
         auto color = get_color(repeat_wrap_if_required(int_loc));
         // Blend between the two neighbouring colors (this fixes some nasty aliasing issues at small angles)
@@ -314,7 +314,7 @@ void paint_radial_gradient(PaintContext& context, Gfx::IntRect const& gradient_r
         auto point = (Gfx::FloatPoint { x, y } - center_point);
         auto gradient_x = point.x() / size.width();
         auto gradient_y = point.y() / size.height();
-        return AK::sqrt(gradient_x * gradient_x + gradient_y * gradient_y) * size.width();
+        return AK::sqrt(gradient_x * gradient_x + gradient_y * gradient_y) * max_visible_gradient;
     });
 }
 

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.h
@@ -37,10 +37,16 @@ struct ConicGradientData {
     ColorStopData color_stops;
 };
 
+struct RadialGradientData {
+    ColorStopData color_stops;
+};
+
 LinearGradientData resolve_linear_gradient_data(Layout::Node const&, Gfx::FloatSize const&, CSS::LinearGradientStyleValue const&);
 ConicGradientData resolve_conic_gradient_data(Layout::Node const&, CSS::ConicGradientStyleValue const&);
+RadialGradientData resolve_radial_gradient_data(Layout::Node const&, Gfx::FloatSize const&, CSS::RadialGradientStyleValue const&);
 
 void paint_linear_gradient(PaintContext&, Gfx::IntRect const&, LinearGradientData const&);
 void paint_conic_gradient(PaintContext&, Gfx::IntRect const&, ConicGradientData const&, Gfx::IntPoint position);
+void paint_radial_gradient(PaintContext&, Gfx::IntRect const&, RadialGradientData const&, Gfx::IntPoint position, Gfx::FloatSize const& size);
 
 }


### PR DESCRIPTION
This implements `radial-gradient()`s along with a few fixes to `conic-gradient()`s.

Like with `conic-gradient()`s pretty much everything is inherited from `linear-gradient()`s, so this already supports most features (double position color stops, hints, etc).


|                                                                            | LibWeb                                                                                                          | Chrome                                                                                                          |
|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| `radial-gradient(#e66465, #9198e5)`                                        | ![image](https://user-images.githubusercontent.com/11597044/201500395-63106927-ad56-46a7-82ba-e75d2d3a2d77.png) | ![image](https://user-images.githubusercontent.com/11597044/201500428-5800856c-33c6-4784-8ece-6055b17e0769.png) |
| `radial-gradient(closest-side, #3f87a6, #ebf8e1, #f69d3c)`                 | ![image](https://user-images.githubusercontent.com/11597044/201500401-266d3167-11ec-4f7e-a753-045f1e519e5d.png) | ![image](https://user-images.githubusercontent.com/11597044/201500434-c582748b-d8ab-4772-a595-1c95520c0281.png) |
| `radial-gradient(circle at 100px, #333, #333 50%, #eee 75%, #333 75%)`     | ![image](https://user-images.githubusercontent.com/11597044/201500409-a7e75043-657f-4c28-a43c-858badaf4176.png) | ![image](https://user-images.githubusercontent.com/11597044/201500437-b1fe3d54-cbfd-4f15-b868-bbf58e0df157.png) |
| `radial-gradient(200px 100px ellipse at 25% 50%, yellow, #009966, purple)` | ![image](https://user-images.githubusercontent.com/11597044/201500417-f0c3e1c3-118f-4c8f-bfdb-18ab32aa52b7.png) | ![image](https://user-images.githubusercontent.com/11597044/201500440-c2ac8336-5f70-42c9-9dc0-4d457e5d75e4.png) |

P.s. Yes the painting really is only a few lines... Most of this is parsing and resolving :pensive: (so hopefully, should not conflict with #15989 too much).