### PR TITLE
LibGfx: Two small changes for ttf font compatibility

### DIFF
--- a/Userland/Libraries/LibGfx/Font/TrueType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/TrueType/Font.cpp
@@ -379,7 +379,7 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_externally_owned_memory(Readonl
     if (tag == tag_from_str("OTTO"))
         return Error::from_string_literal("CFF fonts not supported yet");
 
-    if (tag != 0x00010000)
+    if (tag != 0x00010000 && tag != tag_from_str("true"))
         return Error::from_string_literal("Not a valid font");
 
     return try_load_from_offset(buffer, 0);

--- a/Userland/Libraries/LibGfx/Font/TrueType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/TrueType/Font.cpp
@@ -489,9 +489,9 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_offset(ReadonlyBytes buffer, u3
         return Error::from_string_literal("Could not load Glyf");
     auto glyf = Glyf(opt_glyf_slice.value());
 
-    if (!opt_os2_slice.has_value())
-        return Error::from_string_literal("Could not load OS/2");
-    auto os2 = OS2(opt_os2_slice.value());
+    OS2 os2(TRY(ByteBuffer::create_zeroed(static_cast<size_t>(OS2::Offsets::End))));
+    if (opt_os2_slice.has_value())
+        os2 = OS2(opt_os2_slice.value());
 
     Optional<Kern> kern {};
     if (opt_kern_slice.has_value())

--- a/Userland/Libraries/LibGfx/Font/TrueType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/TrueType/Tables.h
@@ -140,6 +140,7 @@ public:
         TypographicAscender = 68,
         TypographicDescender = 70,
         TypographicLineGap = 72,
+        End = 78,
     };
 
     u16 weight_class() const;


### PR DESCRIPTION
These are required to make a lot of embedded TrueType fonts in PDF documents work.