### PR TITLE
LibThreading: Add thread priority controls to Thread

### DIFF
--- a/Userland/Libraries/LibThreading/Thread.cpp
+++ b/Userland/Libraries/LibThreading/Thread.cpp
@@ -29,6 +29,27 @@ Threading::Thread::~Thread()
     }
 }
 
+ErrorOr<void> Threading::Thread::set_priority(int priority)
+{
+    // MacOS has an extra __opaque field, so list initialization will not compile on MacOS Lagom.
+    sched_param scheduling_parameters {};
+    scheduling_parameters.sched_priority = priority;
+    int result = pthread_setschedparam(m_tid, 0, &scheduling_parameters);
+    if (result != 0)
+        return Error::from_errno(result);
+    return {};
+}
+
+ErrorOr<int> Threading::Thread::get_priority() const
+{
+    sched_param scheduling_parameters {};
+    int policy;
+    int result = pthread_getschedparam(m_tid, &policy, &scheduling_parameters);
+    if (result != 0)
+        return Error::from_errno(result);
+    return scheduling_parameters.sched_priority;
+}
+
 void Threading::Thread::start()
 {
     int rc = pthread_create(

--- a/Userland/Libraries/LibThreading/Thread.h
+++ b/Userland/Libraries/LibThreading/Thread.h
@@ -24,6 +24,9 @@ class Thread final : public Core::Object {
 public:
     virtual ~Thread();
 
+    ErrorOr<void> set_priority(int priority);
+    ErrorOr<int> get_priority() const;
+
     void start();
     void detach();
 


### PR DESCRIPTION
Chunk 1 from #16049

This exposes the now properly working thread APIs on the higher level.