### PR TITLE
LibAudio: Revert to using buffered file reading

### DIFF
--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -26,7 +26,7 @@ MaybeLoaderError LoaderPlugin::initialize()
     if (m_backing_memory.has_value())
         m_stream = LOADER_TRY(Core::Stream::MemoryStream::construct(m_backing_memory.value()));
     else
-        m_stream = LOADER_TRY(Core::Stream::File::open(m_path, Core::Stream::OpenMode::Read));
+        m_stream = LOADER_TRY(Core::Stream::BufferedFile::create(LOADER_TRY(Core::Stream::File::open(m_path, Core::Stream::OpenMode::Read))));
 
     return {};
 }


### PR DESCRIPTION
Chunk 2 of #16049

This was slowing down FLACLoader below realtime. The real solution is still to use mapped files but that has to wait until a larger refactor.