### PR TITLE
Piano: Guard against all allocations at top level of the audio pipeline

### DIFF
--- a/Userland/Applications/Piano/TrackManager.cpp
+++ b/Userland/Applications/Piano/TrackManager.cpp
@@ -9,6 +9,7 @@
 
 #include "TrackManager.h"
 #include "Music.h"
+#include <AK/NoAllocationGuard.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/TypedTransfer.h>
 #include <LibDSP/Effects.h>
@@ -35,6 +36,7 @@ void TrackManager::time_forward(int amount)
 
 void TrackManager::fill_buffer(FixedArray<DSP::Sample>& buffer)
 {
+    NoAllocationGuard guard;
     VERIFY(buffer.size() == m_temporary_track_buffer.size());
     size_t sample_count = buffer.size();
     // No need to zero the temp buffer as the track overwrites it anyways.


### PR DESCRIPTION
Chunk 3 of #16049

Therefore, we don't rely on LibDSP Processors to use allocation guards themselves. It also demonstrates that nested allocation guards work correctly :^)