### PR TITLE
Piano+LibAudio+LibIPC: Realtime enqueueing, stage 1

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -8,12 +8,23 @@
 
 #include <AK/Iterator.h>
 #include <AK/Span.h>
+#include <AK/StdLibExtras.h>
+#include <AK/TypedTransfer.h>
 
 namespace AK {
 
 template<typename T, size_t Size>
 struct Array {
     using ValueType = T;
+
+    // This is a static function because constructors mess up Array's POD-ness.
+    static Array from_span(Span<T> span)
+    {
+        Array array;
+        VERIFY(span.size() == Size);
+        TypedTransfer<T>::copy(array.data(), span.data(), Size);
+        return array;
+    }
 
     [[nodiscard]] constexpr T const* data() const { return __data; }
     [[nodiscard]] constexpr T* data() { return __data; }

--- a/Userland/Applications/Piano/AudioPlayerLoop.cpp
+++ b/Userland/Applications/Piano/AudioPlayerLoop.cpp
@@ -6,18 +6,54 @@
  */
 
 #include "AudioPlayerLoop.h"
-
+#include "Music.h"
 #include "TrackManager.h"
+#include <AK/Assertions.h>
 #include <AK/FixedArray.h>
+#include <AK/Forward.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/NumericLimits.h>
+#include <AK/StdLibExtras.h>
+#include <AK/Time.h>
 #include <LibAudio/ConnectionToServer.h>
+#include <LibAudio/Queue.h>
 #include <LibAudio/Resampler.h>
 #include <LibAudio/Sample.h>
-#include <LibCore/EventLoop.h>
+#include <LibIPC/Connection.h>
+#include <LibThreading/Thread.h>
+#include <sched.h>
+#include <time.h>
 
-AudioPlayerLoop::AudioPlayerLoop(TrackManager& track_manager, bool& need_to_write_wav, Audio::WavWriter& wav_writer)
+struct AudioLoopDeferredInvoker final : public IPC::DeferredInvoker {
+    static constexpr size_t INLINE_FUNCTIONS = 4;
+
+    virtual ~AudioLoopDeferredInvoker() = default;
+
+    virtual void schedule(Function<void()> function) override
+    {
+        deferred_functions.append(move(function));
+    }
+
+    void run_functions()
+    {
+        if (deferred_functions.size() > INLINE_FUNCTIONS)
+            dbgln("Warning: Audio loop has more than {} deferred functions, audio might glitch!", INLINE_FUNCTIONS);
+        while (!deferred_functions.is_empty()) {
+            auto function = deferred_functions.take_last();
+            function();
+        }
+    }
+
+    Vector<Function<void()>, INLINE_FUNCTIONS> deferred_functions;
+};
+
+AudioPlayerLoop::AudioPlayerLoop(TrackManager& track_manager, Atomic<bool>& need_to_write_wav, Threading::MutexProtected<Audio::WavWriter>& wav_writer)
     : m_track_manager(track_manager)
     , m_buffer(FixedArray<DSP::Sample>::must_create_but_fixme_should_propagate_errors(sample_count))
+    , m_pipeline_thread(Threading::Thread::construct([this]() {
+        return this->pipeline_thread_main();
+    },
+          "Audio pipeline"sv))
     , m_need_to_write_wav(need_to_write_wav)
     , m_wav_writer(wav_writer)
 {
@@ -28,37 +64,90 @@ AudioPlayerLoop::AudioPlayerLoop(TrackManager& track_manager, bool& need_to_writ
         target_sample_rate = Music::sample_rate;
     m_resampler = Audio::ResampleHelper<DSP::Sample>(Music::sample_rate, target_sample_rate);
 
-    // FIXME: I said I would never write such a hack again, but here we are.
-    // This code should die as soon as possible anyways, so it doesn't matter.
-    // Please don't use this as an example to write good audio code; it's just here as a temporary hack.
-    Core::EventLoop::register_timer(*this, 5, true, Core::TimerShouldFireWhenNotVisible::Yes);
+    MUST(m_pipeline_thread->set_priority(sched_get_priority_max(0)));
+    m_pipeline_thread->start();
 }
 
-void AudioPlayerLoop::timer_event(Core::TimerEvent&)
+AudioPlayerLoop::~AudioPlayerLoop()
 {
-    while (m_audio_client->remaining_samples() < sample_count)
-        enqueue_audio();
+    // Tell the pipeline to exit and wait for the last audio cycle to finish.
+    m_exit_requested.store(true);
+    auto result = m_pipeline_thread->join();
+    // FIXME: Get rid of the EINVAL/ESRCH check once we allow to join dead threads.
+    VERIFY(!result.is_error() || result.error() == EINVAL || result.error() == ESRCH);
+
+    m_audio_client->shutdown();
 }
 
-void AudioPlayerLoop::enqueue_audio()
+intptr_t AudioPlayerLoop::pipeline_thread_main()
 {
-    m_track_manager.fill_buffer(m_buffer);
-    // FIXME: Handle OOM better.
-    auto audio_buffer = m_resampler->resample(m_buffer);
-    (void)m_audio_client->async_enqueue(audio_buffer);
+    m_audio_client->set_deferred_invoker(make<AudioLoopDeferredInvoker>());
+    auto& deferred_invoker = static_cast<AudioLoopDeferredInvoker&>(m_audio_client->deferred_invoker());
 
-    // FIXME: This should be done somewhere else.
-    if (m_need_to_write_wav) {
-        m_need_to_write_wav = false;
-        m_track_manager.reset();
-        m_track_manager.set_should_loop(false);
-        do {
-            m_track_manager.fill_buffer(m_buffer);
-            m_wav_writer.write_samples(m_buffer.span());
-        } while (m_track_manager.transport()->time());
-        m_track_manager.reset();
-        m_track_manager.set_should_loop(true);
-        m_wav_writer.finalize();
+    m_audio_client->async_start_playback();
+
+    while (!m_exit_requested.load()) {
+        deferred_invoker.run_functions();
+
+        // The track manager guards against allocations itself.
+        m_track_manager.fill_buffer(m_buffer);
+
+        auto result = send_audio_to_server();
+        // Tolerate errors in the audio pipeline; we don't want this thread to crash the program. This might likely happen with OOM.
+        if (result.is_error()) [[unlikely]] {
+            dbgln("Error in audio pipeline: {}", result.error());
+            m_track_manager.reset();
+        }
+
+        write_wav_if_needed();
+    }
+    m_audio_client->async_pause_playback();
+    return static_cast<intptr_t>(0);
+}
+
+ErrorOr<void> AudioPlayerLoop::send_audio_to_server()
+{
+    TRY(m_resampler->try_resample_into_end(m_remaining_samples, m_buffer));
+
+    auto sample_rate = static_cast<double>(m_resampler->target());
+    auto buffer_play_time_ns = 1'000'000'000.0 / (sample_rate / static_cast<double>(Audio::AUDIO_BUFFER_SIZE));
+    auto good_sleep_time = Time::from_nanoseconds(static_cast<unsigned>(buffer_play_time_ns)).to_timespec();
+
+    size_t start_of_chunk_to_write = 0;
+    while (start_of_chunk_to_write + Audio::AUDIO_BUFFER_SIZE <= m_remaining_samples.size()) {
+        auto const exact_chunk = m_remaining_samples.span().slice(start_of_chunk_to_write, Audio::AUDIO_BUFFER_SIZE);
+        auto exact_chunk_array = Array<Audio::Sample, Audio::AUDIO_BUFFER_SIZE>::from_span(exact_chunk);
+
+        TRY(m_audio_client->blocking_realtime_enqueue(exact_chunk_array, [&]() {
+            nanosleep(&good_sleep_time, nullptr);
+        }));
+
+        start_of_chunk_to_write += Audio::AUDIO_BUFFER_SIZE;
+    }
+    m_remaining_samples.remove(0, start_of_chunk_to_write);
+    VERIFY(m_remaining_samples.size() < Audio::AUDIO_BUFFER_SIZE);
+
+    return {};
+}
+
+void AudioPlayerLoop::write_wav_if_needed()
+{
+    bool _true = true;
+    if (m_need_to_write_wav.compare_exchange_strong(_true, false)) {
+        m_audio_client->async_pause_playback();
+        m_wav_writer.with_locked([this](auto& wav_writer) {
+            m_track_manager.reset();
+            m_track_manager.set_should_loop(false);
+            do {
+                m_track_manager.fill_buffer(m_buffer);
+                wav_writer.write_samples(m_buffer.span());
+            } while (m_track_manager.transport()->time());
+            // FIXME: Make sure that the new TrackManager APIs aren't as bad.
+            m_track_manager.reset();
+            m_track_manager.set_should_loop(true);
+            wav_writer.finalize();
+        });
+        m_audio_client->async_start_playback();
     }
 }
 

--- a/Userland/Applications/Piano/AudioPlayerLoop.h
+++ b/Userland/Applications/Piano/AudioPlayerLoop.h
@@ -26,7 +26,7 @@ public:
     void enqueue_audio();
 
     void toggle_paused();
-    bool is_playing() { return m_should_play_audio; }
+    bool is_playing() const { return m_should_play_audio; }
 
 private:
     AudioPlayerLoop(TrackManager& track_manager, bool& need_to_write_wav, Audio::WavWriter& wav_writer);

--- a/Userland/Applications/Piano/AudioPlayerLoop.h
+++ b/Userland/Applications/Piano/AudioPlayerLoop.h
@@ -15,6 +15,7 @@
 #include <LibCore/Event.h>
 #include <LibCore/Object.h>
 #include <LibDSP/Music.h>
+#include <LibThreading/Thread.h>
 
 class TrackManager;
 
@@ -23,23 +24,30 @@ class TrackManager;
 class AudioPlayerLoop final : public Core::Object {
     C_OBJECT(AudioPlayerLoop)
 public:
+    virtual ~AudioPlayerLoop() override;
+
     void enqueue_audio();
 
     void toggle_paused();
     bool is_playing() const { return m_should_play_audio; }
 
 private:
-    AudioPlayerLoop(TrackManager& track_manager, bool& need_to_write_wav, Audio::WavWriter& wav_writer);
+    AudioPlayerLoop(TrackManager& track_manager, Atomic<bool>& need_to_write_wav, Threading::MutexProtected<Audio::WavWriter>& wav_writer);
 
-    virtual void timer_event(Core::TimerEvent&) override;
+    intptr_t pipeline_thread_main();
+    ErrorOr<void> send_audio_to_server();
+    void write_wav_if_needed();
 
     TrackManager& m_track_manager;
     FixedArray<DSP::Sample> m_buffer;
     Optional<Audio::ResampleHelper<DSP::Sample>> m_resampler;
     RefPtr<Audio::ConnectionToServer> m_audio_client;
+    NonnullRefPtr<Threading::Thread> m_pipeline_thread;
+    Vector<Audio::Sample, Audio::AUDIO_BUFFER_SIZE> m_remaining_samples {};
 
-    bool m_should_play_audio = true;
+    Atomic<bool> m_should_play_audio { true };
+    Atomic<bool> m_exit_requested { false };
 
-    bool& m_need_to_write_wav;
-    Audio::WavWriter& m_wav_writer;
+    Atomic<bool>& m_need_to_write_wav;
+    Threading::MutexProtected<Audio::WavWriter>& m_wav_writer;
 };

--- a/Userland/Applications/Piano/CMakeLists.txt
+++ b/Userland/Applications/Piano/CMakeLists.txt
@@ -21,4 +21,4 @@ set(SOURCES
 )
 
 serenity_app(Piano ICON app-piano)
-target_link_libraries(Piano PRIVATE LibAudio LibCore LibDSP LibGfx LibGUI LibIPC LibMain)
+target_link_libraries(Piano PRIVATE LibAudio LibCore LibDSP LibGfx LibGUI LibIPC LibMain LibThreading)

--- a/Userland/Libraries/LibAudio/ConnectionToServer.cpp
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.cpp
@@ -11,6 +11,7 @@
 #include <AK/Time.h>
 #include <AK/Types.h>
 #include <LibAudio/ConnectionToServer.h>
+#include <LibAudio/Queue.h>
 #include <LibAudio/UserSampleQueue.h>
 #include <LibCore/Event.h>
 #include <LibThreading/Mutex.h>
@@ -114,6 +115,11 @@ void ConnectionToServer::custom_event(Core::CustomEvent&)
 ErrorOr<void, AudioQueue::QueueStatus> ConnectionToServer::realtime_enqueue(Array<Sample, AUDIO_BUFFER_SIZE> samples)
 {
     return m_buffer->try_enqueue(samples);
+}
+
+ErrorOr<void> ConnectionToServer::blocking_realtime_enqueue(Array<Sample, AUDIO_BUFFER_SIZE> samples, Function<void()> wait_function)
+{
+    return m_buffer->try_blocking_enqueue(samples, move(wait_function));
 }
 
 unsigned ConnectionToServer::total_played_samples() const

--- a/Userland/Libraries/LibAudio/ConnectionToServer.h
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.h
@@ -45,6 +45,7 @@ public:
 
     // Returns immediately with the appropriate status if the buffer is full; use in conjunction with remaining_buffers to get low latency.
     ErrorOr<void, AudioQueue::QueueStatus> realtime_enqueue(Array<Sample, AUDIO_BUFFER_SIZE> samples);
+    ErrorOr<void> blocking_realtime_enqueue(Array<Sample, AUDIO_BUFFER_SIZE> samples, Function<void()> wait_function);
 
     // This information can be deducted from the shared audio buffer.
     unsigned total_played_samples() const;

--- a/Userland/Libraries/LibAudio/Resampler.h
+++ b/Userland/Libraries/LibAudio/Resampler.h
@@ -52,10 +52,10 @@ public:
     }
 
     template<ArrayLike<SampleType> Samples>
-    Vector<SampleType> resample(Samples&& to_resample)
+    ErrorOr<Vector<SampleType>> try_resample(Samples&& to_resample)
     {
         Vector<SampleType> resampled;
-        resampled.ensure_capacity(to_resample.size() * ceil_div(m_source, m_target));
+        TRY(resampled.try_ensure_capacity(to_resample.size() * ceil_div(m_source, m_target)));
         for (auto sample : to_resample) {
             process_sample(sample, sample);
 
@@ -64,6 +64,12 @@ public:
         }
 
         return resampled;
+    }
+
+    template<ArrayLike<SampleType> Samples>
+    Vector<SampleType> resample(Samples&& to_resample)
+    {
+        return MUST(try_resample(forward<Samples>(to_resample)));
     }
 
     void reset()

--- a/Userland/Libraries/LibAudio/Resampler.h
+++ b/Userland/Libraries/LibAudio/Resampler.h
@@ -55,15 +55,21 @@ public:
     ErrorOr<Vector<SampleType>> try_resample(Samples&& to_resample)
     {
         Vector<SampleType> resampled;
-        TRY(resampled.try_ensure_capacity(to_resample.size() * ceil_div(m_source, m_target)));
+        TRY(try_resample_into_end(resampled, forward<Samples>(to_resample)));
+        return resampled;
+    }
+
+    template<ArrayLike<SampleType> Samples, size_t vector_inline_capacity = 0>
+    ErrorOr<void> try_resample_into_end(Vector<SampleType, vector_inline_capacity>& destination, Samples&& to_resample)
+    {
+        TRY(destination.try_ensure_capacity(destination.size() + to_resample.size() * ceil_div(m_source, m_target)));
         for (auto sample : to_resample) {
             process_sample(sample, sample);
 
             while (read_sample(sample, sample))
-                resampled.unchecked_append(sample);
+                destination.unchecked_append(sample);
         }
-
-        return resampled;
+        return {};
     }
 
     template<ArrayLike<SampleType> Samples>

--- a/Userland/Libraries/LibIPC/Connection.cpp
+++ b/Userland/Libraries/LibIPC/Connection.cpp
@@ -105,7 +105,10 @@ ErrorOr<void> ConnectionBase::post_message(MessageBuffer buffer)
         dbgln("LibIPC::Connection FIXME Warning, needed {} writes needed to send message of size {}B, this is pretty bad, as it spins on the EventLoop", writes_done, initial_size);
     }
 
-    m_responsiveness_timer->start();
+    // Note: This disables responsiveness detection when an event loop is absent.
+    //       There are no users which both need this feature but don't have an event loop.
+    if (Core::EventLoop::has_been_instantiated())
+        m_responsiveness_timer->start();
     return {};
 }
 

--- a/Userland/Libraries/LibIPC/Connection.h
+++ b/Userland/Libraries/LibIPC/Connection.h
@@ -42,6 +42,7 @@ public:
 
     void set_fd_passing_socket(NonnullOwnPtr<Core::Stream::LocalSocket>);
     void set_deferred_invoker(NonnullOwnPtr<DeferredInvoker>);
+    DeferredInvoker& deferred_invoker() { return *m_deferred_invoker; }
 
     bool is_open() const { return m_socket->is_open(); }
     ErrorOr<void> post_message(Message const&);


### PR DESCRIPTION
Chunk 7 of #16049

TL;DR: Without changing latency, Piano now runs without technical (i.e. measurable but not hearable) or hearable audio glitches. Before, it was running with strongly noticeable glitches, which would worsen once the system load increased. After this change, Piano's audio performance is almost independent of system load, remaining glitch-free as long as there are necessary CPU resources (which is <~8% of CPU time at the moment).

Note that this PR does the minimal amount of work required to improve the status quo in a first step, will be improved upon later, and does intentionally not contain changes to LibDSP.

These changes additionally required
- some minor changes to LibAudio so that we can access the correct APIs in the first place
- decoupling LibIPC from EventLoop for good (Ladybird might want to take advantage of this!)
- a lot of atomics and mutexes so that we're multithreading safely

It also includes a framerate decrease for Piano's UI because the drawing code is really slow and the high, unsynced framerate can cause problems for WindowServer.

### Performance measurements

These measurements were all done with a 2000 measurement moving average, as individual pipeline times jump around wildly.

Before this PR, the full pipeline of audio generation -> resampling -> sending it off to the queue takes around 1.5ms - 3.5ms under normal loads (three tracks and several notes at the same time on all tracks), and when the system load increases, this time frequently jumps up to 6ms and higher.

#### However - large caveat:

This does not take into account the background thread which is enqueueing audio to the audio server. This thread, under the same circumstances described above, is too slow at a rate of ~3Hz with some 10Hz bursts (based on the AudioServer complain messages in the console, available on a normal master build, try it yourself). **This means that no matter how few milliseconds the audio pipeline actually takes, the data processing between these three threads and two processes is too slow at least three times per second.** This is audible.

#### After this PR

First of all, there are no complaint messages from the AudioServer under described normal circumstances. By never, I mean not in the several hours I have tested this code. The only instances of complaint messages is with extremely high system load, which is to be expected and not a problem specific to Piano.

The same performance measurements, **this time even including the total audio enqueue time** (but other than that, measuring the same computations as before), result in an *extremely consistent* average of 1.8ms - 2.2ms. Statistically speaking, the mean has increased, but the variance has decreased much more.

I hope I have convinced you that (1) measuring performance across multithreading refactors is more subjective than you think and (2) trusting your ears (especially when the console messages agree with your ears) is something that is necessary for audio programming.

I hope I have further convinced you that this new architecture is not, in fact, more complicated than the old one. I consider it significantly simpler and more straightforward to understand.