### PR TITLE
LibJS: Some work on exception handling and finally

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1987,7 +1987,8 @@ Bytecode::CodeGenerationErrorOr<void> TryStatement::generate_bytecode(Bytecode::
             generator.emit<Bytecode::Op::Jump>(finalizer_target);
         } else {
             auto& block = generator.make_block();
-            generator.emit<Bytecode::Op::FinishUnwind>(Bytecode::Label { block });
+            generator.emit<Bytecode::Op::LeaveUnwindContext>();
+            generator.emit<Bytecode::Op::Jump>(Bytecode::Label { block });
             next_block = &block;
         }
     }

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1927,6 +1927,7 @@ Bytecode::CodeGenerationErrorOr<void> TryStatement::generate_bytecode(Bytecode::
     if (m_finalizer) {
         auto& finalizer_block = generator.make_block();
         generator.switch_to_basic_block(finalizer_block);
+        generator.emit<Bytecode::Op::LeaveUnwindContext>();
         TRY(m_finalizer->generate_bytecode(generator));
         if (!generator.is_current_block_terminated()) {
             next_block = &generator.make_block();
@@ -1964,7 +1965,6 @@ Bytecode::CodeGenerationErrorOr<void> TryStatement::generate_bytecode(Bytecode::
 
         if (!generator.is_current_block_terminated()) {
             if (m_finalizer) {
-                generator.emit<Bytecode::Op::LeaveUnwindContext>();
                 generator.emit<Bytecode::Op::Jump>(finalizer_target);
             } else {
                 VERIFY(!next_block);

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -268,12 +268,17 @@ Label Generator::perform_needed_unwinds_for_labelled_break_and_return_target_blo
     for (auto& breakable_scope : m_breakable_scopes.in_reverse()) {
         for (; current_boundary > 0; --current_boundary) {
             auto boundary = m_boundaries[current_boundary - 1];
+            // FIXME: Handle ReturnToFinally in a graceful manner
+            //        We need to execute the finally block, but tell it to resume
+            //        execution at the designated label
             if (boundary == BlockBoundaryType::Unwind) {
                 emit<Bytecode::Op::LeaveUnwindContext>();
             } else if (boundary == BlockBoundaryType::LeaveLexicalEnvironment) {
                 emit<Bytecode::Op::LeaveEnvironment>(Bytecode::Op::EnvironmentMode::Lexical);
             } else if (boundary == BlockBoundaryType::LeaveVariableEnvironment) {
                 emit<Bytecode::Op::LeaveEnvironment>(Bytecode::Op::EnvironmentMode::Var);
+            } else if (boundary == BlockBoundaryType::ReturnToFinally) {
+                // FIXME: We need to enter the `finally`, while still scheduling the break to happen
             } else if (boundary == BlockBoundaryType::Break) {
                 // Make sure we don't process this boundary twice if the current breakable scope doesn't contain the target label.
                 --current_boundary;
@@ -295,12 +300,17 @@ Label Generator::perform_needed_unwinds_for_labelled_continue_and_return_target_
     for (auto& continuable_scope : m_continuable_scopes.in_reverse()) {
         for (; current_boundary > 0; --current_boundary) {
             auto boundary = m_boundaries[current_boundary - 1];
+            // FIXME: Handle ReturnToFinally in a graceful manner
+            //        We need to execute the finally block, but tell it to resume
+            //        execution at the designated label
             if (boundary == BlockBoundaryType::Unwind) {
                 emit<Bytecode::Op::LeaveUnwindContext>();
             } else if (boundary == BlockBoundaryType::LeaveLexicalEnvironment) {
                 emit<Bytecode::Op::LeaveEnvironment>(Bytecode::Op::EnvironmentMode::Lexical);
             } else if (boundary == BlockBoundaryType::LeaveVariableEnvironment) {
                 emit<Bytecode::Op::LeaveEnvironment>(Bytecode::Op::EnvironmentMode::Var);
+            } else if (boundary == BlockBoundaryType::ReturnToFinally) {
+                // FIXME: We need to enter the `finally`, while still scheduling the continue to happen
             } else if (boundary == BlockBoundaryType::Continue) {
                 // Make sure we don't process this boundary twice if the current continuable scope doesn't contain the target label.
                 --current_boundary;

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -31,7 +31,6 @@
     O(EnterUnwindContext)            \
     O(EnterObjectEnvironment)        \
     O(Exp)                           \
-    O(FinishUnwind)                  \
     O(GetById)                       \
     O(GetByValue)                    \
     O(GetIterator)                   \

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -91,10 +91,6 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable const& e
                     m_current_block = unwind_context.handler;
                     unwind_context.handler = nullptr;
 
-                    // If there's no finalizer, there's nowhere for the handler block to unwind to, so the unwind context is no longer needed.
-                    if (!unwind_context.finalizer)
-                        unwind_contexts().take_last();
-
                     accumulator() = exception_value;
                     m_saved_exception = {};
                     will_jump = true;
@@ -102,7 +98,6 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable const& e
                 }
                 if (unwind_context.finalizer) {
                     m_current_block = unwind_context.finalizer;
-                    unwind_contexts().take_last();
                     will_jump = true;
                     break;
                 }

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -103,6 +103,7 @@ private:
     Vector<Variant<NonnullOwnPtr<RegisterWindow>, RegisterWindow*>> m_register_windows;
     Optional<BasicBlock const*> m_pending_jump;
     Value m_return_value;
+    Handle<Value> m_saved_return_value;
     Executable const* m_current_executable { nullptr };
     Handle<Value> m_saved_exception;
     OwnPtr<JS::Interpreter> m_ast_interpreter;

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -744,19 +744,6 @@ void EnterUnwindContext::replace_references_impl(BasicBlock const& from, BasicBl
         m_finalizer_target = Label { to };
 }
 
-ThrowCompletionOr<void> FinishUnwind::execute_impl(Bytecode::Interpreter& interpreter) const
-{
-    interpreter.leave_unwind_context();
-    interpreter.jump(m_next_target);
-    return {};
-}
-
-void FinishUnwind::replace_references_impl(BasicBlock const& from, BasicBlock const& to)
-{
-    if (&m_next_target.block() == &from)
-        m_next_target = Label { to };
-}
-
 void CopyObjectExcludingProperties::replace_references_impl(Register from, Register to)
 {
     if (m_from_object == from)
@@ -1227,11 +1214,6 @@ DeprecatedString EnterUnwindContext::to_deprecated_string_impl(Bytecode::Executa
     auto handler_string = m_handler_target.has_value() ? DeprecatedString::formatted("{}", *m_handler_target) : "<empty>";
     auto finalizer_string = m_finalizer_target.has_value() ? DeprecatedString::formatted("{}", *m_finalizer_target) : "<empty>";
     return DeprecatedString::formatted("EnterUnwindContext handler:{} finalizer:{} entry:{}", handler_string, finalizer_string, m_entry_point);
-}
-
-DeprecatedString FinishUnwind::to_deprecated_string_impl(Bytecode::Executable const&) const
-{
-    return DeprecatedString::formatted("FinishUnwind next:{}", m_next_target);
 }
 
 DeprecatedString LeaveEnvironment::to_deprecated_string_impl(Bytecode::Executable const&) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -876,27 +876,6 @@ public:
     void replace_references_impl(Register, Register) { }
 };
 
-class FinishUnwind final : public Instruction {
-public:
-    constexpr static bool IsTerminator = true;
-
-    FinishUnwind(Label next)
-        : Instruction(Type::FinishUnwind)
-        , m_next_target(move(next))
-    {
-    }
-
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
-    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
-    void replace_references_impl(BasicBlock const&, BasicBlock const&);
-    void replace_references_impl(Register, Register) { }
-
-    Label next_target() const { return m_next_target; }
-
-private:
-    Label m_next_target;
-};
-
 class ContinuePendingUnwind final : public Instruction {
 public:
     constexpr static bool IsTerminator = true;

--- a/Userland/Libraries/LibJS/Bytecode/Pass/GenerateCFG.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/GenerateCFG.cpp
@@ -90,11 +90,6 @@ void GenerateCFG::perform(PassPipelineExecutable& executable)
             enter_label(&resume_target, current_block);
             continue;
         }
-        case FinishUnwind: {
-            auto const& next_target = static_cast<Op::FinishUnwind const&>(instruction).next_target();
-            enter_label(&next_target, current_block);
-            continue;
-        }
         default:
             // Otherwise, pop the current block off, it doesn't jump anywhere.
             iterators.take_last();


### PR DESCRIPTION
At some point of this we did not crash in `test-js -b` 🚀

The main issue now is further control-flow support through finally, like `break`s and `continue`s, which currently cause crashes (`try-finally-continue`)

Test262:
+28 ✅    -24 ❌    -4 💥️   