### PR TITLE
LibGfx: Better ellipses

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -37,17 +37,10 @@ void EllipseTool::draw_using(GUI::Painter& painter, Gfx::IntPoint const& start_p
 
     switch (m_fill_mode) {
     case FillMode::Outline:
-        if (m_antialias_enabled) {
+        if (m_antialias_enabled)
             aa_painter.draw_ellipse(ellipse_intersecting_rect, m_editor->color_for(m_drawing_button), thickness);
-        } else {
-            // For some reason for non-AA draw_ellipse() the ellipse is outside of the rect (unlike all other ellipse drawing functions).
-            // Scale the ellipse rect by sqrt(2) to get an ellipse arc that appears as if it was inside of the rect.
-            // Ie. reduce the size by a factor of 1 - sqrt(1/2)
-            auto shrink_width = ellipse_intersecting_rect.width() * (1 - AK::Sqrt1_2<float>);
-            auto shrink_height = ellipse_intersecting_rect.height() * (1 - AK::Sqrt1_2<float>);
-            ellipse_intersecting_rect.shrink(shrink_width, shrink_height);
+        else
             painter.draw_ellipse_intersecting(ellipse_intersecting_rect, m_editor->color_for(m_drawing_button), thickness);
-        }
         break;
     case FillMode::Fill:
         if (m_antialias_enabled)


### PR DESCRIPTION
It is only used to draw non-antialiased and non-filled ellipses.


Old algorithm on the left and new on the right:
![ellipses](https://user-images.githubusercontent.com/26030965/201544324-7fe99aaa-d4b9-4dcf-8b28-9c878ee581ab.png)
