### PR TITLE
PixelPaint: Add the Pen tool as the default tool

### DIFF
--- a/Userland/Applications/PixelPaint/ToolboxWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolboxWidget.cpp
@@ -51,7 +51,7 @@ ToolboxWidget::ToolboxWidget()
 
 void ToolboxWidget::setup_tools()
 {
-    auto add_tool = [&](StringView icon_name, GUI::Shortcut const& shortcut, NonnullOwnPtr<Tool> tool) {
+    auto add_tool = [&](StringView icon_name, GUI::Shortcut const& shortcut, NonnullOwnPtr<Tool> tool, bool is_default_tool = false) {
         auto action = GUI::Action::create_checkable(tool->tool_name(), shortcut, Gfx::Bitmap::try_load_from_file(String::formatted("/res/icons/pixelpaint/{}.png", icon_name)).release_value_but_fixme_should_propagate_errors(),
             [this, tool = tool.ptr()](auto& action) {
                 if (action.is_checked()) {
@@ -69,10 +69,15 @@ void ToolboxWidget::setup_tools()
         };
         tool->set_action(action);
         m_tools.append(move(tool));
+        if (is_default_tool) {
+            VERIFY(m_active_tool == nullptr);
+            m_active_tool = &m_tools[m_tools.size() - 1];
+            action->set_checked(true);
+        }
     };
 
     add_tool("move"sv, { 0, Key_M }, make<MoveTool>());
-    add_tool("pen"sv, { 0, Key_N }, make<PenTool>());
+    add_tool("pen"sv, { 0, Key_N }, make<PenTool>(), true);
     add_tool("brush"sv, { 0, Key_P }, make<BrushTool>());
     add_tool("bucket"sv, { Mod_Shift, Key_B }, make<BucketTool>());
     add_tool("spray"sv, { Mod_Shift, Key_S }, make<SprayTool>());


### PR DESCRIPTION
We now preselect the pen tool when PixelPaint is launched.

I think it'd make the ergonomics a tiny bit better as in my experience at least when I open a painting program I like to be able to sketch immediately without taking much consideration to the UI. I am however completely open to disagreements and simply ignoring this change:))

Other paint applications preselected tools:

> Paint, Paint3D : brush
> Krita: Freehand brush tool
> Gimp: Pencil tool
> PixelPaint: None (before this commit)