### PR TITLE
WebDriver: Implement `POST /session/{id}/window` endpoint

### DIFF
--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -63,6 +63,7 @@ static constexpr auto s_webdriver_endpoints = Array {
     ROUTE(GET, "/session/:session_id/title"sv, get_title),
     ROUTE(GET, "/session/:session_id/window"sv, get_window_handle),
     ROUTE(DELETE, "/session/:session_id/window"sv, close_window),
+    ROUTE(POST, "/session/:session_id/window"sv, switch_to_window),
     ROUTE(GET, "/session/:session_id/window/handles"sv, get_window_handles),
     ROUTE(GET, "/session/:session_id/window/rect"sv, get_window_rect),
     ROUTE(POST, "/session/:session_id/window/rect"sv, set_window_rect),

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -49,6 +49,7 @@ public:
     // 11. Contexts, https://w3c.github.io/webdriver/#contexts
     virtual Response get_window_handle(Parameters parameters, JsonValue payload) = 0;
     virtual Response close_window(Parameters parameters, JsonValue payload) = 0;
+    virtual Response switch_to_window(Parameters parameters, JsonValue payload) = 0;
     virtual Response get_window_handles(Parameters parameters, JsonValue payload) = 0;
     virtual Response get_window_rect(Parameters parameters, JsonValue payload) = 0;
     virtual Response set_window_rect(Parameters parameters, JsonValue payload) = 0;

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -17,6 +17,7 @@ endpoint WebDriverClient {
     get_title() => (Web::WebDriver::Response response)
     get_window_handle() => (Web::WebDriver::Response response)
     close_window() => (Web::WebDriver::Response response)
+    switch_to_window(JsonValue payload) => (Web::WebDriver::Response response)
     get_window_handles() => (Web::WebDriver::Response response)
     get_window_rect() => (Web::WebDriver::Response response)
     set_window_rect(JsonValue payload) => (Web::WebDriver::Response response)

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -52,6 +52,7 @@ private:
     virtual Messages::WebDriverClient::GetTitleResponse get_title() override;
     virtual Messages::WebDriverClient::GetWindowHandleResponse get_window_handle() override;
     virtual Messages::WebDriverClient::CloseWindowResponse close_window() override;
+    virtual Messages::WebDriverClient::SwitchToWindowResponse switch_to_window(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::GetWindowHandlesResponse get_window_handles() override;
     virtual Messages::WebDriverClient::GetWindowRectResponse get_window_rect() override;
     virtual Messages::WebDriverClient::SetWindowRectResponse set_window_rect(JsonValue const& payload) override;

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -322,6 +322,15 @@ Web::WebDriver::Response Client::close_window(Web::WebDriver::Parameters paramet
     return open_windows;
 }
 
+// 11.3 Switch to Window, https://w3c.github.io/webdriver/#dfn-switch-to-window
+// POST /session/{session id}/window
+Web::WebDriver::Response Client::switch_to_window(Web::WebDriver::Parameters parameters, AK::JsonValue payload)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/window");
+    auto* session = TRY(find_session_with_id(parameters[0]));
+    return session->web_content_connection().switch_to_window(payload);
+}
+
 // 11.4 Get Window Handles, https://w3c.github.io/webdriver/#dfn-get-window-handles
 // GET /session/{session id}/window/handles
 Web::WebDriver::Response Client::get_window_handles(Web::WebDriver::Parameters parameters, JsonValue)

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -46,6 +46,7 @@ private:
     virtual Web::WebDriver::Response get_title(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response get_window_handle(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response close_window(Web::WebDriver::Parameters parameters, JsonValue payload) override;
+    virtual Web::WebDriver::Response switch_to_window(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response get_window_handles(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response get_window_rect(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response set_window_rect(Web::WebDriver::Parameters parameters, JsonValue payload) override;


### PR DESCRIPTION
Implements another endpoint on #15551. Aside from the usual changes, this PR makes `WebContent::WebDriverConnection::get_property` a public static method rather than a private one since the `WebDriver` client code needs to extract properties from a `JsonValue` as well. Please let me know if there is a better practice I should follow with making this function commonly available.