### PR TITLE
Everywhere: Use C++ concepts instead of requires clauses  

### DIFF
--- a/AK/BinaryBufferWriter.h
+++ b/AK/BinaryBufferWriter.h
@@ -19,7 +19,7 @@ public:
     }
 
     template<typename T>
-    requires(AK::Detail::IsTriviallyConstructible<T>) T& append_structure()
+    requires(IsTriviallyConstructible<T>) T& append_structure()
     {
         VERIFY((reinterpret_cast<FlatPtr>(m_target.data()) + m_offset) % alignof(T) == 0);
         VERIFY(m_offset + sizeof(T) <= m_target.size());

--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -46,7 +46,7 @@ template<typename T, template<typename...> typename S>
 concept SpecializationOf = IsSpecializationOf<T, S>;
 
 template<typename T>
-concept AnyString = Detail::IsConstructible<StringView, T>;
+concept AnyString = IsConstructible<StringView, T>;
 
 template<typename T, typename U>
 concept HashCompatible = IsHashCompatible<Detail::Decay<T>, Detail::Decay<U>>;

--- a/AK/DeprecatedString.h
+++ b/AK/DeprecatedString.h
@@ -282,9 +282,8 @@ public:
         return vformatted(fmtstr.view(), variadic_format_parameters);
     }
 
-    template<typename T>
+    template<Arithmetic T>
     [[nodiscard]] static DeprecatedString number(T value)
-    requires IsArithmetic<T>
     {
         return formatted("{}", value);
     }

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -16,7 +16,7 @@ class ByteBuffer;
 }
 
 class Bitmap;
-using ByteBuffer = AK::Detail::ByteBuffer<32>;
+using ByteBuffer = Detail::ByteBuffer<32>;
 class Error;
 class GenericLexer;
 class IPv4Address;

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -293,7 +293,7 @@ public:
     {
         if (m_capacity == 0)
             return;
-        if constexpr (!Detail::IsTriviallyDestructible<T>) {
+        if constexpr (!IsTriviallyDestructible<T>) {
             for (auto* bucket : *this)
                 bucket->~T();
         }

--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -24,7 +24,7 @@ struct ExtractIntrusiveRedBlackTreeTypes {
 };
 
 template<Integral K, typename V, typename Container = RawPtr<V>>
-using SubstitutedIntrusiveRedBlackTreeNode = IntrusiveRedBlackTreeNode<K, V, typename Detail::SubstituteIntrusiveContainerType<V, Container>::Type>;
+using SubstitutedIntrusiveRedBlackTreeNode = IntrusiveRedBlackTreeNode<K, V, typename SubstituteIntrusiveContainerType<V, Container>::Type>;
 
 template<Integral K, typename V, typename Container, SubstitutedIntrusiveRedBlackTreeNode<K, V, Container> V::*member>
 class IntrusiveRedBlackTree : public BaseRedBlackTree<K> {

--- a/AK/Statistics.h
+++ b/AK/Statistics.h
@@ -6,15 +6,15 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/Math.h>
 #include <AK/QuickSort.h>
-#include <AK/StdLibExtraDetails.h>
 #include <AK/Vector.h>
 
 namespace AK {
 
-template<typename T = float>
-requires(IsArithmetic<T>) class Statistics {
+template<Arithmetic T = float>
+class Statistics {
 public:
     Statistics() = default;
     ~Statistics() = default;

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -582,7 +582,7 @@ inline constexpr bool IsSpecializationOf<U<Us...>, U> = true;
 
 template<typename T>
 struct __Decay {
-    typedef Detail::RemoveCVReference<T> type;
+    typedef RemoveCVReference<T> type;
 };
 template<typename T>
 struct __Decay<T[]> {

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -36,13 +36,13 @@ namespace std { // NOLINT(cert-dcl58-cpp) Names in std to aid tools
 // NOTE: These are in the "std" namespace since some compilers and static analyzers rely on it.
 
 template<typename T>
-constexpr T&& forward(AK::Detail::RemoveReference<T>& param)
+constexpr T&& forward(RemoveReference<T>& param)
 {
     return static_cast<T&&>(param);
 }
 
 template<typename T>
-constexpr T&& forward(AK::Detail::RemoveReference<T>&& param) noexcept
+constexpr T&& forward(RemoveReference<T>&& param) noexcept
 {
     static_assert(!IsLvalueReference<T>, "Can't forward an rvalue as an lvalue.");
     return static_cast<T&&>(param);

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -134,16 +134,14 @@ InputStream& operator>>(InputStream& stream, Optional<T>& value)
     return stream;
 }
 
-template<typename Integral>
-InputStream& operator>>(InputStream& stream, Integral& value)
-requires IsIntegral<Integral>
+template<Integral I>
+InputStream& operator>>(InputStream& stream, I& value)
 {
     stream.read_or_error({ &value, sizeof(value) });
     return stream;
 }
-template<typename Integral>
-OutputStream& operator<<(OutputStream& stream, Integral value)
-requires IsIntegral<Integral>
+template<Integral I>
+OutputStream& operator<<(OutputStream& stream, I value)
 {
     stream.write_or_error({ &value, sizeof(value) });
     return stream;
@@ -151,16 +149,14 @@ requires IsIntegral<Integral>
 
 #ifndef KERNEL
 
-template<typename FloatingPoint>
-InputStream& operator>>(InputStream& stream, FloatingPoint& value)
-requires IsFloatingPoint<FloatingPoint>
+template<FloatingPoint F>
+InputStream& operator>>(InputStream& stream, F& value)
 {
     stream.read_or_error({ &value, sizeof(value) });
     return stream;
 }
-template<typename FloatingPoint>
-OutputStream& operator<<(OutputStream& stream, FloatingPoint value)
-requires IsFloatingPoint<FloatingPoint>
+template<FloatingPoint F>
+OutputStream& operator<<(OutputStream& stream, F value)
 {
     stream.write_or_error({ &value, sizeof(value) });
     return stream;

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -60,7 +60,7 @@ private:
 
 namespace AK {
 
-class InputStream : public virtual AK::Detail::Stream {
+class InputStream : public virtual Detail::Stream {
 public:
     // Reads at least one byte unless none are requested or none are available. Does nothing
     // and returns zero if there is already an error.
@@ -81,7 +81,7 @@ public:
     virtual bool discard_or_error(size_t count) = 0;
 };
 
-class OutputStream : public virtual AK::Detail::Stream {
+class OutputStream : public virtual Detail::Stream {
 public:
     virtual size_t write(ReadonlyBytes) = 0;
     virtual bool write_or_error(ReadonlyBytes) = 0;

--- a/AK/String.h
+++ b/AK/String.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/RefCounted.h>
@@ -74,9 +75,8 @@ public:
 
     [[nodiscard]] u32 hash() const;
 
-    template<typename T>
+    template<Arithmetic T>
     static ErrorOr<String> number(T value)
-    requires IsArithmetic<T>
     {
         return formatted("{}", value);
     }

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -93,7 +93,7 @@ private:
     u8 const* data() const { return m_buffer.data(); }
 
     static constexpr size_t inline_capacity = 256;
-    AK::Detail::ByteBuffer<inline_capacity> m_buffer;
+    Detail::ByteBuffer<inline_capacity> m_buffer;
 };
 
 }

--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -29,8 +29,8 @@ template<typename T>
 struct Traits : public GenericTraits<T> {
 };
 
-template<typename T>
-requires(IsIntegral<T>) struct Traits<T> : public GenericTraits<T> {
+template<Integral T>
+struct Traits<T> : public GenericTraits<T> {
     static constexpr bool is_trivial() { return true; }
     static constexpr unsigned hash(T value)
     {
@@ -42,8 +42,8 @@ requires(IsIntegral<T>) struct Traits<T> : public GenericTraits<T> {
 };
 
 #ifndef KERNEL
-template<typename T>
-requires(IsFloatingPoint<T>) struct Traits<T> : public GenericTraits<T> {
+template<FloatingPoint T>
+struct Traits<T> : public GenericTraits<T> {
     static constexpr bool is_trivial() { return true; }
     static constexpr unsigned hash(T value)
     {

--- a/AK/UFixedBigInt.h
+++ b/AK/UFixedBigInt.h
@@ -25,9 +25,9 @@ requires(sizeof(T) >= sizeof(u64) && IsUnsigned<T>) class UFixedBigInt;
 // constexpr inline bool Detail::IsIntegral<UFixedBigInt<T>> = true;
 
 template<typename T>
-constexpr inline bool Detail::IsUnsigned<UFixedBigInt<T>> = true;
+constexpr inline bool IsUnsigned<UFixedBigInt<T>> = true;
 template<typename T>
-constexpr inline bool Detail::IsSigned<UFixedBigInt<T>> = false;
+constexpr inline bool IsSigned<UFixedBigInt<T>> = false;
 
 template<typename T>
 struct NumericLimits<UFixedBigInt<T>> {

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Dropdown.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Dropdown.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "WidgetWithLabel.h"
+#include <AK/Concepts.h>
 #include <AK/Vector.h>
 #include <LibDSP/ProcessorParameter.h>
 #include <LibGUI/ComboBox.h>
@@ -14,8 +15,8 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/ModelIndex.h>
 
-template<typename EnumT>
-requires(IsEnum<EnumT>) class ProcessorParameterDropdown : public GUI::ComboBox {
+template<Enum EnumT>
+class ProcessorParameterDropdown : public GUI::ComboBox {
     C_OBJECT(ProcessorParameterDropdown);
 
 public:

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -460,9 +460,8 @@ void ArgsParser::add_option(StringView& value, char const* help_string, char con
     add_option(move(option));
 }
 
-template<typename Integral>
-void ArgsParser::add_option(Integral& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode)
-requires(IsIntegral<Integral>)
+template<Integral I>
+void ArgsParser::add_option(I& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode)
 {
     Option option {
         OptionArgumentMode::Required,
@@ -472,11 +471,11 @@ requires(IsIntegral<Integral>)
         value_name,
         [&value](char const* s) {
             auto view = StringView { s, strlen(s) };
-            Optional<Integral> opt;
-            if constexpr (IsSigned<Integral>)
-                opt = view.to_int<Integral>();
+            Optional<I> opt;
+            if constexpr (IsSigned<I>)
+                opt = view.to_int<I>();
             else
-                opt = view.to_uint<Integral>();
+                opt = view.to_uint<I>();
             value = opt.value_or(0);
             return opt.has_value();
         },

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/DeprecatedString.h>
 #include <AK/Function.h>
 #include <AK/Vector.h>
@@ -89,9 +90,8 @@ public:
     void add_option(char const*& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(DeprecatedString& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(StringView& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
-    template<typename Integral>
-    void add_option(Integral& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None)
-    requires(IsIntegral<Integral>);
+    template<Integral I>
+    void add_option(I& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(double& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(Optional<double>& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(Optional<size_t>& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/Span.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 
@@ -16,8 +17,8 @@ struct SignedDivisionResult;
 
 class SignedBigInteger {
 public:
-    template<typename T>
-    requires(IsSigned<T> && sizeof(T) <= sizeof(i32))
+    template<Signed T>
+    requires(sizeof(T) <= sizeof(i32))
     SignedBigInteger(T value)
         : m_sign(value < 0)
         , m_unsigned_data(abs(static_cast<i32>(value)))

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/Concepts.h>
 #include <AK/DeprecatedString.h>
 #include <AK/Span.h>
 #include <AK/Types.h>
@@ -25,8 +26,8 @@ public:
     static constexpr size_t BITS_IN_WORD = 32;
 
     // This constructor accepts any unsigned with size up to Word.
-    template<typename T>
-    requires(IsIntegral<T> && sizeof(T) <= sizeof(Word))
+    template<Integral T>
+    requires(sizeof(T) <= sizeof(Word))
     UnsignedBigInteger(T value)
     {
         m_words.append(static_cast<Word>(value));

--- a/Userland/Libraries/LibDSP/ProcessorParameter.h
+++ b/Userland/Libraries/LibDSP/ProcessorParameter.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/DeprecatedString.h>
 #include <AK/FixedPoint.h>
 #include <AK/Format.h>
@@ -146,8 +147,8 @@ private:
     Logarithmic const m_logarithmic;
 };
 
-template<typename EnumT>
-requires(IsEnum<EnumT>) class ProcessorEnumParameter final : public Detail::ProcessorParameterSingleValue<EnumT> {
+template<Enum EnumT>
+class ProcessorEnumParameter final : public Detail::ProcessorParameterSingleValue<EnumT> {
 public:
     ProcessorEnumParameter(DeprecatedString name, EnumT initial_value)
         : Detail::ProcessorParameterSingleValue<EnumT>(move(name), ParameterType::Enum, initial_value)

--- a/Userland/Libraries/LibEDID/EDID.cpp
+++ b/Userland/Libraries/LibEDID/EDID.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Concepts.h>
 #include <AK/Function.h>
 #include <AK/QuickSort.h>
 #include <LibEDID/EDID.h>
@@ -165,16 +166,16 @@ T Parser::read_host(T const* field) const
     return value;
 }
 
-template<typename T>
-requires(IsIntegral<T> && sizeof(T) > 1)
+template<Integral T>
+requires(sizeof(T) > 1)
 T Parser::read_le(T const* field) const
 {
     static_assert(sizeof(T) > 1);
     return AK::convert_between_host_and_little_endian(read_host(field));
 }
 
-template<typename T>
-requires(IsIntegral<T> && sizeof(T) > 1)
+template<Integral T>
+requires(sizeof(T) > 1)
 T Parser::read_be(T const* field) const
 {
     static_assert(sizeof(T) > 1);

--- a/Userland/Libraries/LibEDID/EDID.h
+++ b/Userland/Libraries/LibEDID/EDID.h
@@ -8,6 +8,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/ByteReader.h>
+#include <AK/Concepts.h>
 #include <AK/Endian.h>
 #include <AK/Error.h>
 #include <AK/FixedPoint.h>
@@ -437,12 +438,12 @@ private:
     template<typename T>
     T read_host(T const*) const;
 
-    template<typename T>
-    requires(IsIntegral<T> && sizeof(T) > 1)
+    template<Integral T>
+    requires(sizeof(T) > 1)
     T read_le(T const*) const;
 
-    template<typename T>
-    requires(IsIntegral<T> && sizeof(T) > 1)
+    template<Integral T>
+    requires(sizeof(T) > 1)
     T read_be(T const*) const;
 
     Definitions::EDID const& raw_edid() const;

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -44,8 +44,8 @@ public:
     u32 crc();
 
 private:
-    template<typename T>
-    requires(IsUnsigned<T>) ErrorOr<void> add(T);
+    template<Unsigned T>
+    ErrorOr<void> add(T);
 
     ByteBuffer m_data;
     DeprecatedString m_type;
@@ -77,8 +77,8 @@ u32 PNGChunk::crc()
     return crc;
 }
 
-template<typename T>
-requires(IsUnsigned<T>) ErrorOr<void> PNGChunk::add(T data)
+template<Unsigned T>
+ErrorOr<void> PNGChunk::add(T data)
 {
     TRY(m_data.try_append(&data, sizeof(T)));
     return {};

--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Concepts.h>
 #include <AK/DeprecatedString.h>
 #include <LibJS/Print.h>
 #include <LibJS/Runtime/Array.h>
@@ -362,9 +363,8 @@ ErrorOr<void> print_async_generator(JS::PrintContext& print_context, JS::AsyncGe
     return {};
 }
 
-template<typename T>
+template<Arithmetic T>
 ErrorOr<void> print_number(JS::PrintContext& print_context, T number)
-requires IsArithmetic<T>
 {
     TRY(js_out(print_context, "\033[35;1m"));
     TRY(js_out(print_context, "{}", number));

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/Forward.h>
 #include <LibCrypto/Forward.h>
 #include <LibJS/Forward.h>
@@ -167,9 +168,8 @@ Vector<T> merge_lists(Vector<T> const& a, Vector<T> const& b)
 }
 
 // x modulo y, https://tc39.es/ecma262/#eqn-modulo
-template<typename T, typename U>
+template<Arithmetic T, Arithmetic U>
 auto modulo(T x, U y)
-requires(IsArithmetic<T>, IsArithmetic<U>)
 {
     // The notation “x modulo y” (y must be finite and non-zero) computes a value k of the same sign as y (or zero) such that abs(k) < abs(y) and x - k = q × y for some integer q.
     VERIFY(y != 0);

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -10,6 +10,7 @@
 #include "RegexMatch.h"
 #include "RegexOptions.h"
 
+#include <AK/Concepts.h>
 #include <AK/DisjointChunks.h>
 #include <AK/Format.h>
 #include <AK/Forward.h>
@@ -339,9 +340,8 @@ public:
         Optimizer::append_alternation(*this, move(left), move(right));
     }
 
-    template<typename T>
+    template<Integral T>
     static void transform_bytecode_repetition_min_max(ByteCode& bytecode_to_repeat, T minimum, Optional<T> maximum, size_t min_repetition_mark_id, size_t max_repetition_mark_id, bool greedy = true)
-    requires(IsIntegral<T>)
     {
         if (!maximum.has_value()) {
             if (minimum == 0)
@@ -410,9 +410,8 @@ public:
         bytecode_to_repeat = move(new_bytecode);
     }
 
-    template<typename T>
+    template<Integral T>
     void insert_bytecode_repetition_n(ByteCode& bytecode_to_repeat, T n, size_t repetition_mark_id)
-    requires(IsIntegral<T>)
     {
         // LABEL _LOOP
         // REGEXP


### PR DESCRIPTION
Also, this patchset removes some unnecessary AK and Detail namespace scoping      