### PR TITLE
Browser: Go back/forward when pressing back/forward mouse buttons

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -445,6 +445,16 @@ Tab::Tab(BrowserWindow& window)
         load(url);
     };
 
+    view().on_back_button = [this] {
+        if (m_history.can_go_back())
+            go_back();
+    };
+
+    view().on_forward_button = [this] {
+        if (m_history.can_go_forward())
+            go_forward();
+    };
+
     m_tab_context_menu = GUI::Menu::construct();
     m_tab_context_menu->add_action(GUI::CommonActions::make_reload_action([this](auto&) {
         reload();

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -174,6 +174,12 @@ void OutOfProcessWebView::mousedown_event(GUI::MouseEvent& event)
 void OutOfProcessWebView::mouseup_event(GUI::MouseEvent& event)
 {
     enqueue_input_event(event);
+
+    if (event.button() == GUI::MouseButton::Backward && on_back_button) {
+        on_back_button();
+    } else if (event.button() == GUI::MouseButton::Forward && on_forward_button) {
+        on_forward_button();
+    }
 }
 
 void OutOfProcessWebView::mousemove_event(GUI::MouseEvent& event)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -111,6 +111,8 @@ public:
     Function<Gfx::IntRect()> on_maximize_window;
     Function<Gfx::IntRect()> on_minimize_window;
     Function<Gfx::IntRect()> on_fullscreen_window;
+    Function<void()> on_back_button;
+    Function<void()> on_forward_button;
 
 private:
     OutOfProcessWebView();


### PR DESCRIPTION
This currently doesn't work when running Serenity through QEMU, as it doesn't pass the side button events over to Serenity due to some bug or missing feature.

This makes SerenityOS browser match ladybird's behavior.

It'd be really nice if someone running serenity on bare metal could test this, but I have tested it replacing the button check with the GUI::MouseButton::Middle and it works as intended:^)

This is a duplicate of  #16010, as I closed it on accident 😅