### PR TITLE
Kernel: Add dmesgln_pci logging for Kernel::PCI

### DIFF
--- a/Kernel/Arch/x86_64/PCI/IDELegacyModeController.h
+++ b/Kernel/Arch/x86_64/PCI/IDELegacyModeController.h
@@ -21,6 +21,8 @@ class PCIIDELegacyModeController final : public IDEController
 public:
     static NonnullLockRefPtr<PCIIDELegacyModeController> initialize(PCI::DeviceIdentifier const&, bool force_pio);
 
+    virtual StringView device_name() const override { return "PCIIDELegacyModeController"sv; }
+
     bool is_bus_master_capable() const;
     bool is_pci_native_mode_enabled() const;
 

--- a/Kernel/Bus/PCI/Device.h
+++ b/Kernel/Bus/PCI/Device.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Format.h>
+#include <AK/StringBuilder.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Definitions.h>
 
@@ -16,6 +18,9 @@ public:
     Address pci_address() const { return m_pci_address; };
 
     virtual ~Device() = default;
+
+    virtual StringView device_name() const = 0;
+
     void enable_pin_based_interrupts() const;
     void disable_pin_based_interrupts() const;
 
@@ -34,5 +39,17 @@ protected:
 private:
     Address m_pci_address;
 };
+
+template<typename... Parameters>
+void dmesgln_pci(Device const& device, AK::CheckedFormatString<Parameters...>&& fmt, Parameters const&... parameters)
+{
+    AK::StringBuilder builder;
+    if (builder.try_append("{}: {}: "sv).is_error())
+        return;
+    if (builder.try_append(fmt.view()).is_error())
+        return;
+    AK::VariadicFormatParams variadic_format_params { device.device_name(), device.pci_address(), parameters... };
+    vdmesgln(builder.string_view(), variadic_format_params);
+}
 
 }

--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -75,9 +75,9 @@ ErrorOr<NonnullLockRefPtr<UHCIController>> UHCIController::try_to_initialize(PCI
 
 ErrorOr<void> UHCIController::initialize()
 {
-    dmesgln("UHCI: Controller found {} @ {}", PCI::get_hardware_id(pci_address()), pci_address());
-    dmesgln("UHCI: I/O base {}", m_registers_io_window);
-    dmesgln("UHCI: Interrupt line: {}", interrupt_number());
+    dmesgln_pci(*this, "Controller found {} @ {}", PCI::get_hardware_id(pci_address()), pci_address());
+    dmesgln_pci(*this, "I/O base {}", m_registers_io_window);
+    dmesgln_pci(*this, "Interrupt line: {}", interrupt_number());
 
     TRY(spawn_async_poll_process());
     TRY(spawn_port_process());

--- a/Kernel/Bus/USB/UHCI/UHCIController.h
+++ b/Kernel/Bus/USB/UHCI/UHCIController.h
@@ -38,6 +38,7 @@ public:
     virtual ~UHCIController() override;
 
     virtual StringView purpose() const override { return "UHCI"sv; }
+    virtual StringView device_name() const override { return purpose(); }
 
     virtual ErrorOr<void> initialize() override;
     virtual ErrorOr<void> reset() override;

--- a/Kernel/Bus/VirtIO/Console.h
+++ b/Kernel/Bus/VirtIO/Console.h
@@ -22,6 +22,7 @@ public:
     virtual ~Console() override = default;
 
     virtual StringView purpose() const override { return class_name(); }
+    virtual StringView device_name() const override { return class_name(); }
 
     unsigned device_id() const
     {

--- a/Kernel/Bus/VirtIO/RNG.h
+++ b/Kernel/Bus/VirtIO/RNG.h
@@ -21,6 +21,7 @@ class RNG final
 public:
     static NonnullLockRefPtr<RNG> must_create(PCI::DeviceIdentifier const&);
     virtual StringView purpose() const override { return class_name(); }
+    virtual StringView device_name() const override { return class_name(); }
     virtual ~RNG() override = default;
 
     virtual void initialize() override;

--- a/Kernel/Devices/Audio/AC97.h
+++ b/Kernel/Devices/Audio/AC97.h
@@ -32,6 +32,7 @@ public:
 
     // ^IRQHandler
     virtual StringView purpose() const override { return "AC97"sv; }
+    virtual StringView device_name() const override { return purpose(); }
 
 private:
     enum NativeAudioMixerRegister : u8 {

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -26,6 +26,7 @@ class BochsGraphicsAdapter final : public GenericGraphicsAdapter
 public:
     static NonnullLockRefPtr<BochsGraphicsAdapter> initialize(PCI::DeviceIdentifier const&);
     virtual ~BochsGraphicsAdapter() = default;
+    virtual StringView device_name() const override { return "BochsGraphicsAdapter"sv; }
 
 private:
     ErrorOr<void> initialize_adapter(PCI::DeviceIdentifier const&);

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -43,8 +43,8 @@ ErrorOr<void> IntelNativeGraphicsAdapter::initialize_adapter()
     auto bar0_space_size = PCI::get_BAR_space_size(address, PCI::HeaderType0BaseRegister::BAR0);
     VERIFY(bar0_space_size == 0x80000);
     auto bar2_space_size = PCI::get_BAR_space_size(address, PCI::HeaderType0BaseRegister::BAR2);
-    dmesgln("Intel Native Graphics Adapter @ {}, MMIO @ {}, space size is {:x} bytes", address, PhysicalAddress(PCI::get_BAR0(address)), bar0_space_size);
-    dmesgln("Intel Native Graphics Adapter @ {}, framebuffer @ {}", address, PhysicalAddress(PCI::get_BAR2(address)));
+    dmesgln_pci(*this, "MMIO @ {}, space size is {:x} bytes", PhysicalAddress(PCI::get_BAR0(address)), bar0_space_size);
+    dmesgln_pci(*this, "framebuffer @ {}", PhysicalAddress(PCI::get_BAR2(address)));
     PCI::enable_bus_mastering(address);
 
     m_display_connector = IntelNativeDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR2(address) & 0xfffffff0), bar2_space_size, PhysicalAddress(PCI::get_BAR0(address) & 0xfffffff0), bar0_space_size);

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
@@ -24,6 +24,8 @@ public:
 
     virtual ~IntelNativeGraphicsAdapter() = default;
 
+    virtual StringView device_name() const override { return "IntelNativeGraphicsAdapter"sv; }
+
 private:
     ErrorOr<void> initialize_adapter();
 

--- a/Kernel/Graphics/VMWare/GraphicsAdapter.h
+++ b/Kernel/Graphics/VMWare/GraphicsAdapter.h
@@ -29,6 +29,8 @@ public:
     static LockRefPtr<VMWareGraphicsAdapter> try_initialize(PCI::DeviceIdentifier const&);
     virtual ~VMWareGraphicsAdapter() = default;
 
+    virtual StringView device_name() const override { return "VMWareGraphicsAdapter"sv; }
+
     ErrorOr<void> modeset_primary_screen_resolution(Badge<VMWareDisplayConnector>, size_t width, size_t height);
     size_t primary_screen_width(Badge<VMWareDisplayConnector>) const;
     size_t primary_screen_height(Badge<VMWareDisplayConnector>) const;

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -41,6 +41,8 @@ public:
 
     virtual void initialize() override;
 
+    virtual StringView device_name() const override { return "VirtIOGraphicsAdapter"sv; }
+
     ErrorOr<void> mode_set_resolution(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, size_t width, size_t height);
     void set_dirty_displayed_rect(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
     ErrorOr<void> flush_displayed_image(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -192,16 +192,17 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::setup_interrupts()
 
 UNMAP_AFTER_INIT bool E1000NetworkAdapter::initialize()
 {
-    dmesgln("E1000: Found @ {}", pci_address());
+    dmesgln_pci(*this, "Found @ {}", pci_address());
+
     enable_bus_mastering(pci_address());
 
-    dmesgln("E1000: IO base: {}", m_registers_io_window);
-    dmesgln("E1000: Interrupt line: {}", interrupt_number());
+    dmesgln_pci(*this, "IO base: {}", m_registers_io_window);
+    dmesgln_pci(*this, "Interrupt line: {}", interrupt_number());
     detect_eeprom();
-    dmesgln("E1000: Has EEPROM? {}", m_has_eeprom);
+    dmesgln_pci(*this, "Has EEPROM? {}", m_has_eeprom);
     read_mac_address();
     auto const& mac = mac_address();
-    dmesgln("E1000: MAC address: {}", mac.to_string());
+    dmesgln_pci(*this, "MAC address: {}", mac.to_string());
 
     initialize_rx_descriptors();
     initialize_tx_descriptors();

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -32,6 +32,7 @@ public:
     virtual bool link_full_duplex() override;
 
     virtual StringView purpose() const override { return class_name(); }
+    virtual StringView device_name() const override { return "E1000"sv; }
 
 protected:
     void setup_interrupts();

--- a/Kernel/Net/NE2000/NetworkAdapter.h
+++ b/Kernel/Net/NE2000/NetworkAdapter.h
@@ -39,6 +39,7 @@ public:
     virtual bool link_full_duplex() override { return true; }
 
     virtual StringView purpose() const override { return class_name(); }
+    virtual StringView device_name() const override { return class_name(); }
 
 private:
     NE2000NetworkAdapter(PCI::Address, u8, NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<KString>);

--- a/Kernel/Net/Realtek/RTL8139NetworkAdapter.h
+++ b/Kernel/Net/Realtek/RTL8139NetworkAdapter.h
@@ -32,6 +32,7 @@ public:
     virtual bool link_full_duplex() override;
 
     virtual StringView purpose() const override { return class_name(); }
+    virtual StringView device_name() const override { return "RTL8139"sv; }
 
 private:
     RTL8139NetworkAdapter(PCI::Address, u8 irq, NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<KString>);

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
@@ -32,6 +32,7 @@ public:
     virtual i32 link_speed() override;
 
     virtual StringView purpose() const override { return class_name(); }
+    virtual StringView device_name() const override { return class_name(); }
 
 private:
     // FIXME: should this be increased? (maximum allowed here is 1024) - memory usage vs packet loss chance tradeoff

--- a/Kernel/Storage/ATA/AHCI/Controller.cpp
+++ b/Kernel/Storage/ATA/AHCI/Controller.cpp
@@ -27,7 +27,7 @@ UNMAP_AFTER_INIT NonnullLockRefPtr<AHCIController> AHCIController::initialize(PC
 
 bool AHCIController::reset()
 {
-    dmesgln("{}: AHCI controller reset", pci_address());
+    dmesgln_pci(*this, "{}: AHCI controller reset", pci_address());
     {
         SpinlockLocker locker(m_hba_control_lock);
         hba().control_regs.ghc = 1;

--- a/Kernel/Storage/ATA/AHCI/Controller.h
+++ b/Kernel/Storage/ATA/AHCI/Controller.h
@@ -27,6 +27,8 @@ public:
     static NonnullLockRefPtr<AHCIController> initialize(PCI::DeviceIdentifier const& pci_device_identifier);
     virtual ~AHCIController() override;
 
+    virtual StringView device_name() const override { return "AHCI"sv; }
+
     virtual LockRefPtr<StorageDevice> device(u32 index) const override;
     virtual bool reset() override;
     virtual bool shutdown() override;

--- a/Kernel/Storage/NVMe/NVMeController.cpp
+++ b/Kernel/Storage/NVMe/NVMeController.cpp
@@ -169,7 +169,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::identify_and_init_namespaces()
         sub.identify.cns = NVMe_CNS_ID_ACTIVE_NS & 0xff;
         status = submit_admin_command(sub, true);
         if (status) {
-            dmesgln("Failed to identify active namespace command");
+            dmesgln_pci(*this, "Failed to identify active namespace command");
             return EFAULT;
         }
         if (void* fault_at; !safe_memcpy(active_namespace_list, prp_dma_region->vaddr().as_ptr(), NVMe_IDENTIFY_SIZE, fault_at)) {
@@ -192,7 +192,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::identify_and_init_namespaces()
             sub.identify.nsid = nsid;
             status = submit_admin_command(sub, true);
             if (status) {
-                dmesgln("Failed identify namespace with nsid {}", nsid);
+                dmesgln_pci(*this, "Failed identify namespace with nsid {}", nsid);
                 return EFAULT;
             }
             static_assert(sizeof(IdentifyNamespace) == NVMe_IDENTIFY_SIZE);
@@ -263,7 +263,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::create_admin_queue(Optional<u8> i
     auto cq_size = round_up_to_power_of_two(CQ_SIZE(qdepth), 4096);
     auto sq_size = round_up_to_power_of_two(SQ_SIZE(qdepth), 4096);
     if (!reset_controller()) {
-        dmesgln("Failed to reset the NVMe controller");
+        dmesgln_pci(*this, "Failed to reset the NVMe controller");
         return EFAULT;
     }
     {
@@ -285,7 +285,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::create_admin_queue(Optional<u8> i
     m_controller_regs->asq = reinterpret_cast<u64>(AK::convert_between_host_and_little_endian(sq_dma_pages.first().paddr().as_ptr()));
 
     if (!start_controller()) {
-        dmesgln("Failed to restart the NVMe controller");
+        dmesgln_pci(*this, "Failed to restart the NVMe controller");
         return EFAULT;
     }
     set_admin_queue_ready_flag();

--- a/Kernel/Storage/NVMe/NVMeController.h
+++ b/Kernel/Storage/NVMe/NVMeController.h
@@ -30,6 +30,7 @@ public:
     ErrorOr<void> initialize(bool is_queue_polled);
     LockRefPtr<StorageDevice> device(u32 index) const override;
     size_t devices_count() const override;
+    virtual StringView device_name() const override { return "NVMeController"sv; }
 
 protected:
     bool reset() override;


### PR DESCRIPTION
Adds an overload of logging function `dmesgln` that uses `PCI::Device` to automatically prefix the log with the PCI address. 

See #15880 for context. 