### PR TITLE
LibWeb: Implement window.open

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -430,6 +430,14 @@ void BrowserWindow::build_menus()
     scripting_enabled_action->set_checked(true);
     debug_menu.add_action(scripting_enabled_action);
 
+    auto block_pop_ups_action = GUI::Action::create_checkable(
+        "Block Pop-ups", [this](auto& action) {
+            active_tab().view().debug_request("block-pop-ups", action.is_checked() ? "on" : "off");
+        },
+        this);
+    block_pop_ups_action->set_checked(true);
+    debug_menu.add_action(block_pop_ups_action);
+
     auto same_origin_policy_action = GUI::Action::create_checkable(
         "Enable Same Origin &Policy", [this](auto& action) {
             active_tab().view().debug_request("same-origin-policy", action.is_checked() ? "on" : "off");

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -499,6 +499,17 @@ WebIDL::ExceptionOr<Document*> Document::open(String const&, String const&)
     return this;
 }
 
+// https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-open-window
+WebIDL::ExceptionOr<JS::GCPtr<HTML::WindowProxy>> Document::open(String const& url, String const& name, String const& features)
+{
+    // 1. If this is not fully active, then throw an "InvalidAccessError" DOMException exception.
+    if (!is_fully_active())
+        return WebIDL::InvalidAccessError::create(realm(), "Cannot perform open on a document that isn't fully active."sv);
+
+    // 2. Return the result of running the window open steps with url, name, and features.
+    return window().open_impl(url, name, features);
+}
+
 // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#closing-the-input-stream
 WebIDL::ExceptionOr<void> Document::close()
 {

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -33,6 +33,7 @@
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/HTML/WindowProxy.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::DOM {
@@ -295,6 +296,7 @@ public:
     WebIDL::ExceptionOr<void> writeln(Vector<String> const& strings);
 
     WebIDL::ExceptionOr<Document*> open(String const& = "", String const& = "");
+    WebIDL::ExceptionOr<JS::GCPtr<HTML::WindowProxy>> open(String const& url, String const& name, String const& features);
     WebIDL::ExceptionOr<void> close();
 
     HTML::Window* default_view() { return m_window.ptr(); }

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -43,8 +43,7 @@ interface Document : Node {
     readonly attribute Window? defaultView;
 
     [CEReactions] Document open(optional DOMString unused1, optional DOMString unused2);
-    // FIXME: implement ExceptionOr<HTML::Window> Document::open(...)
-    // WindowProxy? open(USVString url, DOMString name, DOMString features);
+    WindowProxy? open(USVString url, DOMString name, DOMString features);
     [CEReactions] undefined close();
     [CEReactions] undefined write(DOMString... text);
     [CEReactions] undefined writeln(DOMString... text);

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -246,6 +246,7 @@ void BrowsingContext::visit_edges(Cell::Visitor& visitor)
         visitor.visit(entry.document);
     visitor.visit(m_container);
     visitor.visit(m_window_proxy);
+    visitor.visit(m_opener_browsing_context);
     visitor.visit(m_group);
     visitor.visit(m_parent);
     visitor.visit(m_first_child);

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -651,118 +651,128 @@ JS::GCPtr<DOM::Node> BrowsingContext::currently_focused_area()
     return candidate;
 }
 
-BrowsingContext* BrowsingContext::choose_a_browsing_context(StringView name, bool)
+// https://html.spec.whatwg.org/#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
+BrowsingContext::ChosenBrowsingContext BrowsingContext::choose_a_browsing_context(StringView name, bool no_opener)
 {
-    // The rules for choosing a browsing context, given a browsing context name
-    // name, a browsing context current, and a boolean noopener are as follows:
+    // The rules for choosing a browsing context, given a browsing context name name, a browsing context current, and
+    // a boolean noopener are as follows:
 
     // 1. Let chosen be null.
     JS::GCPtr<BrowsingContext> chosen = nullptr;
 
-    // FIXME: 2. Let windowType be "existing or none".
+    // 2. Let windowType be "existing or none".
+    auto window_type = WindowType::ExistingOrNone;
 
-    // FIXME: 3. Let sandboxingFlagSet be current's active document's active
-    // sandboxing flag set.
+    // 3. Let sandboxingFlagSet be current's active document's active sandboxing flag set.
+    auto sandboxing_flag_set = active_document()->active_sandboxing_flag_set();
 
     // 4. If name is the empty string or an ASCII case-insensitive match for "_self", then set chosen to current.
-    if (name.is_empty() || name.equals_ignoring_case("_self"sv))
+    if (name.is_empty() || name.equals_ignoring_case("_self"sv)) {
         chosen = this;
+    }
 
-    // 5. Otherwise, if name is an ASCII case-insensitive match for "_parent",
-    // set chosen to current's parent browsing context, if any, and current
-    // otherwise.
-    if (name.equals_ignoring_case("_parent"sv)) {
+    // 5. Otherwise, if name is an ASCII case-insensitive match for "_parent", set chosen to current's parent browsing
+    //    context, if any, and current otherwise.
+    else if (name.equals_ignoring_case("_parent"sv)) {
         if (auto parent = this->parent())
             chosen = parent;
         else
             chosen = this;
     }
 
-    // 6. Otherwise, if name is an ASCII case-insensitive match for "_top", set
-    // chosen to current's top-level browsing context, if any, and current
-    // otherwise.
-    if (name.equals_ignoring_case("_top"sv)) {
+    // 6. Otherwise, if name is an ASCII case-insensitive match for "_top", set chosen to current's top-level browsing
+    //    context, if any, and current otherwise.
+    else if (name.equals_ignoring_case("_top"sv)) {
         chosen = &top_level_browsing_context();
     }
 
-    // FIXME: 7. Otherwise, if name is not an ASCII case-insensitive match for
-    // "_blank", there exists a browsing context whose name is the same as name,
-    // current is familiar with that browsing context, and the user agent
-    // determines that the two browsing contexts are related enough that it is
-    // ok if they reach each other, set chosen to that browsing context. If
-    // there are multiple matching browsing contexts, the user agent should set
-    // chosen to one in some arbitrary consistent manner, such as the most
-    // recently opened, most recently focused, or more closely related.
-    if (!name.equals_ignoring_case("_blank"sv)) {
+    // FIXME: 7. Otherwise, if name is not an ASCII case-insensitive match for "_blank", there exists a browsing context
+    //           whose name is the same as name, current is familiar with that browsing context, and the user agent
+    //           determines that the two browsing contexts are related enough that it is ok if they reach each other,
+    //           set chosen to that browsing context. If there are multiple matching browsing contexts, the user agent
+    //           should set chosen to one in some arbitrary consistent manner, such as the most recently opened, most
+    //           recently focused, or more closely related.
+    else if (!name.equals_ignoring_case("_blank"sv)) {
+        dbgln("FIXME: Find matching browser context for name {}", name);
         chosen = this;
     } else {
-        // 8. Otherwise, a new browsing context is being requested, and what
-        // happens depends on the user agent's configuration and abilities — it
-        // is determined by the rules given for the first applicable option from
-        // the following list:
-        dbgln("FIXME: Create a new browsing context!");
+        // 8. Otherwise, a new browsing context is being requested, and what happens depends on the user agent's
+        //    configuration and abilities — it is determined by the rules given for the first applicable option from
+        //    the following list:
 
-        // --> If current's active window does not have transient activation and
-        //     the user agent has been configured to not show popups (i.e., the
-        //     user agent has a "popup blocker" enabled)
-        //
-        //     The user agent may inform the user that a popup has been blocked.
+        // --> If current's active window does not have transient activation and the user agent has been configured to
+        //     not show popups (i.e., the user agent has a "popup blocker" enabled)
+        VERIFY(m_page);
+        if (!active_window()->has_transient_activation() && m_page->should_block_pop_ups()) {
+            // FIXME: The user agent may inform the user that a popup has been blocked.
+            dbgln("Pop-up blocked!");
+        }
 
-        // --> If sandboxingFlagSet has the sandboxed auxiliary navigation
-        //     browsing context flag set
-        //
-        //     The user agent may report to a developer console that a popup has
-        //     been blocked.
+        // --> If sandboxingFlagSet has the sandboxed auxiliary navigation browsing context flag set
+        else if (sandboxing_flag_set.flags & SandboxingFlagSet::SandboxedAuxiliaryNavigation) {
+            // FIXME: The user agent may report to a developer console that a popup has been blocked.
+            dbgln("Pop-up blocked!");
+        }
 
-        // --> If the user agent has been configured such that in this instance
-        //     it will create a new browsing context
-        //
-        //     1. Set windowType to "new and unrestricted".
+        // --> If the user agent has been configured such that in this instance it will create a new browsing context
+        else if (true) { // FIXME: When is this the case?
+            // 1. Set windowType to "new and unrestricted".
+            window_type = WindowType::NewAndUnrestricted;
 
-        //     2. If current's top-level browsing context's active document's
-        //     cross-origin opener policy's value is "same-origin" or
-        //     "same-origin-plus-COEP", then:
+            // 2. If current's top-level browsing context's active document's cross-origin opener policy's value is
+            //    "same-origin" or "same-origin-plus-COEP", then:
+            if (top_level_browsing_context().active_document()->cross_origin_opener_policy().value == CrossOriginOpenerPolicyValue::SameOrigin || top_level_browsing_context().active_document()->cross_origin_opener_policy().value == CrossOriginOpenerPolicyValue::SameOriginPlusCOEP) {
+                // 1. Let currentDocument be current's active document.
+                auto* current_document = top_level_browsing_context().active_document();
 
-        //         2.1. Let currentDocument be current's active document.
+                // 2. If currentDocument's origin is not same origin with currentDocument's relevant settings object's
+                //    top-level origin, then set noopener to true, name to "_blank", and windowType to "new with no opener".
+                if (!current_document->origin().is_same_origin(current_document->relevant_settings_object().top_level_origin)) {
+                    no_opener = true;
+                    name = "_blank"sv;
+                    window_type = WindowType::NewWithNoOpener;
+                }
+            }
 
-        //         2.2. If currentDocument's origin is not same origin with
-        //         currentDocument's relevant settings object's top-level
-        //         origin, then set noopener to true, name to "_blank", and
-        //         windowType to "new with no opener".
+            // 3. If noopener is true, then set chosen to the result of creating a new top-level browsing context.
+            if (no_opener) {
+                chosen = HTML::BrowsingContext::create_a_new_top_level_browsing_context(*m_page);
+            }
 
-        //     3. If noopener is true, then set chosen to the result of creating
-        //     a new top-level browsing context.
+            // 4. Otherwise:
+            else {
+                // 1. Set chosen to the result of creating a new auxiliary browsing context with current.
+                // FIXME: We have no concept of auxiliary browsing context
+                chosen = HTML::BrowsingContext::create_a_new_top_level_browsing_context(*m_page);
 
-        //     4. Otherwise:
+                // 2. If sandboxingFlagSet's sandboxed navigation browsing context flag is set, then current must be
+                //    set as chosen's one permitted sandboxed navigator.
+                // FIXME: We have no concept of one permitted sandboxed navigator
+            }
 
-        //         4.1. Set chosen to the result of creating a new auxiliary
-        //         browsing context with current.
+            // 5. If sandboxingFlagSet's sandbox propagates to auxiliary browsing contexts flag is set, then all the
+            //    flags that are set in sandboxingFlagSet must be set in chosen's popup sandboxing flag set.
+            // FIXME: Our BrowsingContexts do not have SandboxingFlagSets yet, only documents do
 
-        //         4.2. If sandboxingFlagSet's sandboxed navigation browsing
-        //         context flag is set, then current must be set as chosen's one
-        //         permitted sandboxed navigator.
+            // 6. If name is not an ASCII case-insensitive match for "_blank", then set chosen's name to name.
+            if (!name.equals_ignoring_case("_blank"sv))
+                chosen->set_name(name);
+        }
 
-        //     5. If sandboxingFlagSet's sandbox propagates to auxiliary
-        //     browsing contexts flag is set, then all the flags that are set in
-        //     sandboxingFlagSet must be set in chosen's popup sandboxing flag
-        //     set.
+        // --> If the user agent has been configured such that in this instance t will reuse current
+        else if (false) { // FIXME: When is this the case?
+            // Set chosen to current.
+            chosen = *this;
+        }
 
-        //     6. If name is not an ASCII case-insensitive match for "_blank",
-        //     then set chosen's name to name.
-
-        // --> If the user agent has been configured such that in this instance
-        //     it will reuse current
-        //
-        //     Set chosen to current.
-
-        // --> If the user agent has been configured such that in this instance
-        //     it will not find a browsing context
-        //
-        //     Do nothing.
+        // --> If the user agent has been configured such that in this instance it will not find a browsing context
+        else if (false) { // FIXME: When is this the case?
+            // Do nothing.
+        }
     }
 
     // 9. Return chosen and windowType.
-    return chosen;
+    return { chosen, window_type };
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#document-tree-child-browsing-context

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -163,7 +163,18 @@ public:
 
     BrowsingContext const& top_level_browsing_context() const { return const_cast<BrowsingContext*>(this)->top_level_browsing_context(); }
 
-    BrowsingContext* choose_a_browsing_context(StringView name, bool noopener);
+    enum class WindowType {
+        ExistingOrNone,
+        NewAndUnrestricted,
+        NewWithNoOpener,
+    };
+
+    struct ChosenBrowsingContext {
+        JS::GCPtr<BrowsingContext> browsing_context;
+        WindowType window_type;
+    };
+
+    ChosenBrowsingContext choose_a_browsing_context(StringView name, bool no_opener);
 
     size_t document_tree_child_browsing_context_count() const;
 

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -124,6 +124,10 @@ public:
     HTML::WindowProxy* window_proxy();
     HTML::WindowProxy const* window_proxy() const;
 
+    JS::GCPtr<BrowsingContext> opener_browsing_context() const { return m_opener_browsing_context; }
+
+    void set_opener_browsing_context(JS::GCPtr<BrowsingContext> browsing_context) { m_opener_browsing_context = browsing_context; }
+
     HTML::Window* active_window();
     HTML::Window const* active_window() const;
 
@@ -287,6 +291,9 @@ private:
 
     // https://html.spec.whatwg.org/multipage/browsers.html#browsing-context
     JS::GCPtr<HTML::WindowProxy> m_window_proxy;
+
+    // https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context
+    JS::GCPtr<BrowsingContext> m_opener_browsing_context;
 
     DOM::Position m_cursor_position;
     RefPtr<Platform::Timer> m_cursor_blink_timer;

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -241,6 +241,8 @@ public:
     VisibilityState system_visibility_state() const;
     void set_system_visibility_state(VisibilityState);
 
+    void set_is_popup(bool is_popup) { m_is_popup = is_popup; }
+
     // https://html.spec.whatwg.org/multipage/window-object.html#a-browsing-context-is-discarded
     void discard();
     bool has_been_discarded() const { return m_has_been_discarded; }
@@ -297,6 +299,9 @@ private:
 
     // https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group
     JS::GCPtr<BrowsingContextGroup> m_group;
+
+    // https://html.spec.whatwg.org/multipage/browsers.html#is-popup
+    bool m_is_popup { false };
 
     // https://html.spec.whatwg.org/multipage/interaction.html#system-visibility-state
     VisibilityState m_system_visibility_state { VisibilityState::Hidden };

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/Reporting.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/Reporting.cpp
@@ -26,12 +26,12 @@ void check_if_access_between_two_browsing_contexts_should_be_reported(BrowsingCo
     // 4. Let accessorAccessedRelationship be a new accessor-accessed relationship with value none.
     auto accessor_accessed_relationship = AccessorAccessedRelationship::None;
 
-    // FIXME: 5. If accessed's top-level browsing context's opener browsing context is accessor or an ancestor of accessor, then set accessorAccessedRelationship to accessor is opener.
-    if (false)
+    // 5. If accessed's top-level browsing context's opener browsing context is accessor or an ancestor of accessor, then set accessorAccessedRelationship to accessor is opener.
+    if (auto opener = accessed.top_level_browsing_context().opener_browsing_context(); opener && (opener == &accessor || opener->is_ancestor_of(accessor)))
         accessor_accessed_relationship = AccessorAccessedRelationship::AccessorIsOpener;
 
-    // FIXME: 6. If accessor's top-level browsing context's opener browsing context is accessed or an ancestor of accessed, then set accessorAccessedRelationship to accessor is openee.
-    if (false)
+    // 6. If accessor's top-level browsing context's opener browsing context is accessed or an ancestor of accessed, then set accessorAccessedRelationship to accessor is openee.
+    if (auto opener = accessor.top_level_browsing_context().opener_browsing_context(); opener && (opener == &accessed || opener->is_ancestor_of(accessed)))
         accessor_accessed_relationship = AccessorAccessedRelationship::AccessorIsOpenee;
 
     // FIXME: 7. Queue violation reports for accesses, given accessorAccessedRelationship, accessor's top-level browsing context's active document's cross-origin opener policy, accessed's top-level browsing context's active document's cross-origin opener policy, accessor's active document's URL, accessed's active document's URL, accessor's top-level browsing context's initial URL, accessed's top-level browsing context's initial URL, accessor's active document's origin, accessed's active document's origin, accessor's top-level browsing context's opener origin at creation, accessed's top-level browsing context's opener origin at creation, accessor's top-level browsing context's active document's referrer, accessed's top-level browsing context's active document's referrer, P, and environment.

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -493,7 +493,7 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
     // 7. Let target be the first return value of applying the rules for
     // choosing a browsing context given targetAttributeValue, source, and
     // noopener.
-    auto* target = source->choose_a_browsing_context(target_attribute_value, noopener);
+    auto target = source->choose_a_browsing_context(target_attribute_value, noopener).browsing_context;
 
     // 8. If target is null, then return.
     if (!target)
@@ -534,7 +534,7 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
     // set to source.
     // FIXME: "navigate" means implementing the navigation algorithm here:
     //        https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
-    hyperlink_element_utils_queue_an_element_task(Task::Source::DOMManipulation, [url_string, target] {
+    hyperlink_element_utils_queue_an_element_task(Task::Source::DOMManipulation, [url_string, &target] {
         target->loader().load(url_string, FrameLoader::Type::Navigation);
     });
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -111,7 +111,6 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
             // 1. Clean up after running script with settings.
             settings.clean_up_after_running_script();
 
-            dbgln("rethrow");
             // 2. Rethrow evaluationStatus.[[Value]].
             return JS::throw_completion(*evaluation_status.value());
         }
@@ -121,16 +120,12 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
             // 1. Clean up after running script with settings.
             settings.clean_up_after_running_script();
 
-            dbgln("network error");
-
             // 2. Throw a "NetworkError" DOMException.
             return throw_completion(WebIDL::NetworkError::create(settings.realm(), "Script error."));
         }
 
         // 3. Otherwise, rethrow errors is false. Perform the following steps:
         VERIFY(rethrow_errors == RethrowErrors::No);
-
-        dbgln("no rethrow, stat: {}", evaluation_status.value().value().to_string_without_side_effects());
 
         // 1. Report the exception given by evaluationStatus.[[Value]] for script.
         report_exception(evaluation_status, settings_object().realm());

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -393,6 +393,32 @@ JS::Object& relevant_global_object(JS::Object const& object)
     return relevant_realm(object).global_object();
 }
 
+// https://html.spec.whatwg.org/multipage/webappapis.html#concept-entry-realm
+JS::Realm& entry_realm()
+{
+    auto& event_loop = HTML::main_thread_event_loop();
+    auto& vm = event_loop.vm();
+
+    // With this in hand, we define the entry execution context to be the most recently pushed item in the JavaScript execution context stack that is a realm execution context.
+    // The entry realm is the entry execution context's Realm component.
+    // NOTE: Currently all execution contexts in LibJS are realm execution contexts
+    return *vm.running_execution_context().realm;
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object
+EnvironmentSettingsObject& entry_settings_object()
+{
+    // Then, the entry settings object is the environment settings object of the entry realm.
+    return Bindings::host_defined_environment_settings_object(entry_realm());
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#entry-global-object
+JS::Object& entry_global_object()
+{
+    // Similarly, the entry global object is the global object of the entry realm.
+    return entry_realm().global_object();
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#secure-context
 bool is_secure_context(Environment const& environment)
 {

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -151,6 +151,22 @@ void EnvironmentSettingsObject::prepare_to_run_callback()
         context->skip_when_determining_incumbent_counter++;
 }
 
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url
+AK::URL EnvironmentSettingsObject::parse_url(StringView url)
+{
+    // 1. Let encoding be document's character encoding, if document was given, and environment settings object's API URL character encoding otherwise.
+    // FIXME: Pass in environment settings object's API URL character encoding.
+
+    // 2. Let baseURL be document's base URL, if document was given, and environment settings object's API base URL otherwise.
+    auto base_url = api_base_url();
+
+    // 3. Let urlRecord be the result of applying the URL parser to url, with baseURL and encoding.
+    // 4. If urlRecord is failure, then return failure.
+    // 5. Let urlString be the result of applying the URL serializer to urlRecord.
+    // 6. Return urlString as the resulting URL string and urlRecord as the resulting URL record.
+    return base_url.complete_url(url);
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback
 void EnvironmentSettingsObject::clean_up_after_running_callback()
 {

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -143,6 +143,9 @@ JS::Realm& relevant_realm(JS::Object const&);
 EnvironmentSettingsObject& relevant_settings_object(JS::Object const&);
 EnvironmentSettingsObject& relevant_settings_object(DOM::Node const&);
 JS::Object& relevant_global_object(JS::Object const&);
+JS::Realm& entry_realm();
+EnvironmentSettingsObject& entry_settings_object();
+JS::Object& entry_global_object();
 [[nodiscard]] bool is_secure_context(Environment const&);
 [[nodiscard]] bool is_non_secure_context(Environment const&);
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -85,6 +85,8 @@ struct EnvironmentSettingsObject
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-cross-origin-isolated-capability
     virtual CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability() = 0;
 
+    AK::URL parse_url(StringView);
+
     JS::Realm& realm();
     JS::Object& global_object();
     EventLoop& responsible_event_loop();

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Base64.h>
+#include <AK/GenericLexer.h>
 #include <AK/String.h>
 #include <AK/Utf8View.h>
 #include <LibJS/Runtime/AbstractOperations.h>
@@ -47,6 +48,7 @@
 #include <LibWeb/HTML/WindowProxy.h>
 #include <LibWeb/HighResolutionTime/Performance.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
+#include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Layout/InitialContainingBlock.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/RequestIdleCallback/IdleDeadline.h>
@@ -118,6 +120,181 @@ CSS::Screen& Window::screen()
     if (!m_screen)
         m_screen = heap().allocate<CSS::Screen>(realm(), *this);
     return *m_screen;
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#normalizing-the-feature-name
+static StringView normalize_feature_name(StringView name)
+{
+    // For legacy reasons, there are some aliases of some feature names. To normalize a feature name name, switch on name:
+
+    // "screenx"
+    if (name == "screenx"sv) {
+        // Return "left".
+        return "left"sv;
+    }
+    // "screeny"
+    else if (name == "screeny"sv) {
+        // Return "top".
+        return "top"sv;
+    }
+    // "innerwidth"
+    else if (name == "innerwidth"sv) {
+        // Return "width".
+        return "width"sv;
+    }
+    // "innerheight"
+    else if (name == "innerheight") {
+        // Return "height".
+        return "height"sv;
+    }
+    // Anything else
+    else {
+        // Return name.
+        return name;
+    }
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-window-open-features-tokenize
+static OrderedHashMap<String, String> tokenize_open_features(StringView features)
+{
+    // 1. Let tokenizedFeatures be a new ordered map.
+    OrderedHashMap<String, String> tokenized_features;
+
+    // 2. Let position point at the first code point of features.
+    GenericLexer lexer(features);
+
+    // https://html.spec.whatwg.org/multipage/nav-history-apis.html#feature-separator
+    auto is_feature_separator = [](auto character) {
+        return Infra::is_ascii_whitespace(character) || character == '=' || character == ',';
+    };
+
+    // 3. While position is not past the end of features:
+    while (!lexer.is_eof()) {
+        // 1. Let name be the empty string.
+        String name;
+
+        // 2. Let value be the empty string.
+        String value;
+
+        // 3. Collect a sequence of code points that are feature separators from features given position. This skips past leading separators before the name.
+        lexer.ignore_while(is_feature_separator);
+
+        // 4. Collect a sequence of code points that are not feature separators from features given position. Set name to the collected characters, converted to ASCII lowercase.
+        name = lexer.consume_until(is_feature_separator).to_lowercase_string();
+
+        // 5. Set name to the result of normalizing the feature name name.
+        name = normalize_feature_name(name);
+
+        // 6. While position is not past the end of features and the code point at position in features is not U+003D (=):
+        //    1. If the code point at position in features is U+002C (,), or if it is not a feature separator, then break.
+        //    2. Advance position by 1.
+        lexer.ignore_while(Infra::is_ascii_whitespace);
+
+        // 7. If the code point at position in features is a feature separator:
+        //    1. While position is not past the end of features and the code point at position in features is a feature separator:
+        //       1. If the code point at position in features is U+002C (,), then break.
+        //       2. Advance position by 1.
+        lexer.ignore_while([](auto character) { return Infra::is_ascii_whitespace(character) || character == '='; });
+
+        // 2. Collect a sequence of code points that are not feature separators code points from features given position. Set value to the collected code points, converted to ASCII lowercase.
+        value = lexer.consume_until(is_feature_separator).to_lowercase_string();
+
+        // 8. If name is not the empty string, then set tokenizedFeatures[name] to value.
+        if (!name.is_empty())
+            tokenized_features.set(move(name), move(value));
+    }
+
+    // 4. Return tokenizedFeatures.
+    return tokenized_features;
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-window-open-features-parse-boolean
+static bool parse_boolean_feature(StringView value)
+{
+    // 1. If value is the empty string, then return true.
+    if (value.is_empty())
+        return true;
+
+    // 2. If value is "yes", then return true.
+    if (value == "yes"sv)
+        return true;
+
+    // 3. If value is "true", then return true.
+    if (value == "true"sv)
+        return true;
+
+    // 4. Let parsed be the result of parsing value as an integer.
+    auto parsed = value.to_int<i64>();
+
+    // 5. If parsed is an error, then set it to 0.
+    if (!parsed.has_value())
+        parsed = 0;
+
+    // 6. Return false if parsed is 0, and true otherwise.
+    return *parsed != 0;
+}
+
+//  https://html.spec.whatwg.org/multipage/window-object.html#popup-window-is-requested
+static bool check_if_a_popup_window_is_requested(OrderedHashMap<String, String> const& tokenized_features)
+{
+    // 1. If tokenizedFeatures is empty, then return false.
+    if (tokenized_features.is_empty())
+        return false;
+
+    // 2. If tokenizedFeatures["popup"] exists, then return the result of parsing tokenizedFeatures["popup"] as a boolean feature.
+    if (auto popup_feature = tokenized_features.get("popup"sv); popup_feature.has_value())
+        return parse_boolean_feature(*popup_feature);
+
+    // https://html.spec.whatwg.org/multipage/window-object.html#window-feature-is-set
+    auto check_if_a_window_feature_is_set = [&](StringView feature_name, bool default_value) {
+        // 1. If tokenizedFeatures[featureName] exists, then return the result of parsing tokenizedFeatures[featureName] as a boolean feature.
+        if (auto feature = tokenized_features.get(feature_name); feature.has_value())
+            return parse_boolean_feature(*feature);
+
+        // 2. Return defaultValue.
+        return default_value;
+    };
+
+    // 3. Let location be the result of checking if a window feature is set, given tokenizedFeatures, "location", and false.
+    auto location = check_if_a_window_feature_is_set("location"sv, false);
+
+    // 4. Let toolbar be the result of checking if a window feature is set, given tokenizedFeatures, "toolbar", and false.
+    auto toolbar = check_if_a_window_feature_is_set("toolbar"sv, false);
+
+    // 5. If location and toolbar are both false, then return true.
+    if (!location && !toolbar)
+        return true;
+
+    // 6. Let menubar be the result of checking if a window feature is set, given tokenizedFeatures, menubar", and false.
+    auto menubar = check_if_a_window_feature_is_set("menubar"sv, false);
+
+    // 7. If menubar is false, then return true.
+    if (!menubar)
+        return true;
+
+    // 8. Let resizable be the result of checking if a window feature is set, given tokenizedFeatures, "resizable", and true.
+    auto resizable = check_if_a_window_feature_is_set("resizable"sv, true);
+
+    // 9. If resizable is false, then return true.
+    if (!resizable)
+        return true;
+
+    // 10. Let scrollbars be the result of checking if a window feature is set, given tokenizedFeatures, "scrollbars", and false.
+    auto scrollbars = check_if_a_window_feature_is_set("scrollbars"sv, false);
+
+    // 11. If scrollbars is false, then return true.
+    if (!scrollbars)
+        return true;
+
+    // 12. Let status be the result of checking if a window feature is set, given tokenizedFeatures, "status", and false.
+    auto status = check_if_a_window_feature_is_set("status"sv, false);
+
+    // 13. If status is false, then return true.
+    if (!status)
+        return true;
+
+    // 14. Return false.
+    return false;
 }
 
 void Window::alert_impl(String const& message)

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -61,6 +61,7 @@ public:
     bool import_maps_allowed() const { return m_import_maps_allowed; }
     void set_import_maps_allowed(bool import_maps_allowed) { m_import_maps_allowed = import_maps_allowed; }
 
+    WebIDL::ExceptionOr<JS::GCPtr<HTML::WindowProxy>> open_impl(StringView url, StringView target, StringView features);
     void alert_impl(String const&);
     bool confirm_impl(String const&);
     String prompt_impl(String const&, String const&);
@@ -245,6 +246,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(session_storage_getter);
     JS_DECLARE_NATIVE_FUNCTION(origin_getter);
 
+    JS_DECLARE_NATIVE_FUNCTION(open);
     JS_DECLARE_NATIVE_FUNCTION(alert);
     JS_DECLARE_NATIVE_FUNCTION(confirm);
     JS_DECLARE_NATIVE_FUNCTION(prompt);

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -71,6 +71,9 @@ public:
     bool is_scripting_enabled() const { return m_is_scripting_enabled; }
     void set_is_scripting_enabled(bool b) { m_is_scripting_enabled = b; }
 
+    bool should_block_pop_ups() const { return m_should_block_pop_ups; }
+    void set_should_block_pop_ups(bool b) { m_should_block_pop_ups = b; }
+
     bool is_webdriver_active() const { return m_is_webdriver_active; }
     void set_is_webdriver_active(bool b) { m_is_webdriver_active = b; }
 
@@ -90,6 +93,8 @@ private:
     bool m_same_origin_policy_enabled { false };
 
     bool m_is_scripting_enabled { true };
+
+    bool m_should_block_pop_ups { true };
 
     // https://w3c.github.io/webdriver/#dfn-webdriver-active-flag
     // The webdriver-active flag is set to true when the user agent is under remote control. It is initially false.

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -249,6 +249,10 @@ void ConnectionFromClient::debug_request(String const& request, String const& ar
         m_page_host->page().set_is_scripting_enabled(argument == "on");
     }
 
+    if (request == "block-pop-ups") {
+        m_page_host->page().set_should_block_pop_ups(argument == "on");
+    }
+
     if (request == "dump-local-storage") {
         if (auto* doc = page().top_level_browsing_context().active_document())
             doc->window().local_storage()->dump();


### PR DESCRIPTION
This implementation is some-what complete, with the most common missing/broken feature being opening pages in new tabs using the "_blank" target.

This is currently broken due to 2 reasons:
 - We currently always claim the Window does not have transient activation, as we do not track the transient activation timestamp yet. This means that all such window.open calls are detected as pop-ups, and as such they are blocked. This can be easily bypassed by unchecking the 'Block Pop-ups' checkbox in the debug menu.
 - There is currently no mechanism for the WebContent process to request a new tab to be created by the Browser process, and as such the call to BrowsingContext::choose_a_browsing_context does not actually open another tab.