### PR TITLE
LibJS: Some parser fixes

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -3627,13 +3627,32 @@ Completion TaggedTemplateLiteral::execute(Interpreter& interpreter) const
     // NOTE: This is both
     //  MemberExpression : MemberExpression TemplateLiteral
     //  CallExpression : CallExpression TemplateLiteral
-    // As the only difference is the first step.
 
     // 1. Let tagRef be ? Evaluation of MemberExpression.
     // 1. Let tagRef be ? Evaluation of CallExpression.
-
     // 2. Let tagFunc be ? GetValue(tagRef).
-    auto tag = TRY(m_tag->execute(interpreter)).release_value();
+    // NOTE: This is much more complicated than the spec because we have to
+    //       handle every type of reference. If we handle evaluation closer
+    //       to the spec this could be improved.
+    Value tag_this_value;
+    Value tag;
+    if (auto tag_reference = TRY(m_tag->to_reference(interpreter)); tag_reference.is_valid_reference()) {
+        tag = TRY(tag_reference.get_value(vm));
+        if (tag_reference.is_environment_reference()) {
+            auto& environment = tag_reference.base_environment();
+            if (environment.has_this_binding())
+                tag_this_value = TRY(environment.get_this_binding(vm));
+            else
+                tag_this_value = js_undefined();
+        } else {
+            tag_this_value = tag_reference.get_this_value();
+        }
+    } else {
+        auto result = TRY(m_tag->execute(interpreter));
+        VERIFY(result.has_value());
+        tag = result.release_value();
+        tag_this_value = js_undefined();
+    }
 
     // 3. Let thisCall be this CallExpression.
     // 3. Let thisCall be this MemberExpression.
@@ -3655,7 +3674,7 @@ Completion TaggedTemplateLiteral::execute(Interpreter& interpreter) const
         arguments.append(TRY(expressions[i].execute(interpreter)).release_value());
 
     // 5. Return ? EvaluateCall(tagFunc, tagRef, TemplateLiteral, tailCall).
-    return call(vm, tag, js_undefined(), move(arguments));
+    return call(vm, tag, tag_this_value, move(arguments));
 }
 
 // 13.2.8.3 GetTemplateObject ( templateLiteral ), https://tc39.es/ecma262/#sec-gettemplateobject

--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -610,8 +610,15 @@ Token Lexer::next()
             consume();
             m_template_states.last().in_expr = true;
         } else {
+            // TemplateCharacter ::
+            //     $ [lookahead ≠ {]
+            //     \ TemplateEscapeSequence
+            //     \ NotEscapeSequence
+            //     LineContinuation
+            //     LineTerminatorSequence
+            //     SourceCharacter but not one of ` or \ or $ or LineTerminator
             while (!match('$', '{') && m_current_char != '`' && !is_eof()) {
-                if (match('\\', '$') || match('\\', '`'))
+                if (match('\\', '$') || match('\\', '`') || match('\\', '\\'))
                     consume();
                 consume();
             }

--- a/Userland/Libraries/LibJS/Tests/modules/basic-modules.js
+++ b/Userland/Libraries/LibJS/Tests/modules/basic-modules.js
@@ -239,3 +239,9 @@ describe("failing modules cascade", () => {
         );
     });
 });
+
+describe("scoping in modules", () => {
+    test("functions within functions", () => {
+        expectModulePassed("./function-in-function.mjs");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/modules/function-in-function.mjs
+++ b/Userland/Libraries/LibJS/Tests/modules/function-in-function.mjs
@@ -1,0 +1,11 @@
+function foo() {
+    function bar() {}
+    bar.baz = "value on bar";
+
+    return bar;
+}
+
+foo.bippity = "boppity";
+const fooResult = foo();
+
+export const passed = fooResult.baz === "value on bar" && foo.bippity === "boppity";

--- a/Userland/Libraries/LibJS/Tests/tagged-template-literals.js
+++ b/Userland/Libraries/LibJS/Tests/tagged-template-literals.js
@@ -163,4 +163,17 @@ describe("tagged template literal functionality", () => {
         let secondResult = call(value => value, 2);
         expect(firstResult).toBe(secondResult);
     });
+
+    test("this value of call comes from reference", () => {
+        let thisValue = null;
+        const obj = {
+            func() {
+                thisValue = this;
+            },
+        };
+
+        obj.func``;
+
+        expect(thisValue).toBe(obj);
+    });
 });

--- a/Userland/Libraries/LibJS/Tests/template-literals.js
+++ b/Userland/Libraries/LibJS/Tests/template-literals.js
@@ -7,6 +7,9 @@ test("plain literals with expression-like characters", () => {
 
 test("plain literals with escaped special characters", () => {
     expect(`foo\``).toBe("foo`");
+    expect(`foo\\`).toBe("foo\\");
+    expect(`foo\\\``).toBe("foo\\`");
+    expect(`foo\\\\`).toBe("foo\\\\");
     expect(`foo\$`).toBe("foo$");
     expect(`foo \${"bar"}`).toBe('foo ${"bar"}');
 });


### PR DESCRIPTION
Fixes #16044.

It is a bit harder than it looks because you have to check https://tc39.es/ecma262/#sec-static-semantics-lexicallyscopeddeclarations and https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations .
Also if someone has a suggestion how to nicely comment this spec in the code let me know the parser part is always hard :(.

Also this fixes 2 test262 tests, although none from the scoping fix....... (:makemore:)