### PR TITLE
Tests/AK: Re-enable `HashTable<double>` test

### DIFF
--- a/Tests/AK/TestHashTable.cpp
+++ b/Tests/AK/TestHashTable.cpp
@@ -268,8 +268,6 @@ TEST_CASE(floats)
     EXPECT(table.contains(2.0f));
 }
 
-// FIXME: Enable this test once it doesn't trigger UBSAN.
-#if 0
 TEST_CASE(doubles)
 {
     HashTable<double> table;
@@ -281,7 +279,6 @@ TEST_CASE(doubles)
     EXPECT(table.contains(1.0));
     EXPECT(table.contains(2.0));
 }
-#endif
 
 // Inserting and removing a bunch of elements will "thrash" the table, leading to a lot of "deleted" markers.
 BENCHMARK_CASE(benchmark_thrashing)


### PR DESCRIPTION
The incorrect UBSan alignment check that made this test fail has been fixed in Clang 15.

Closes #13614