### PR TITLE
LibJS: Remove workaround for Clang misalignment in MathematicalValue

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/MathematicalValue.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/MathematicalValue.h
@@ -95,11 +95,7 @@ private:
 
     static ValueType value_from_number(double number);
 
-    // NOTE: The specific alignment is to avoid an UBSAN error with Clang i686, due to Clang
-    //       disagreeing with UBSAN on the alignment of doubles. See:
-    //       https://github.com/llvm/llvm-project/issues/54845
-    //       https://github.com/SerenityOS/serenity/issues/13614
-    alignas(8) ValueType m_value { 0.0 };
+    ValueType m_value { 0.0 };
 };
 
 }


### PR DESCRIPTION
As noted in 269a931, this has been fixed in Clang 15.