### PR TITLE
LibIPC+Userland: Properly declare `IPC::encode` and `IPC::decode` base templates and specializations

### DIFF
--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -14,8 +14,6 @@
 #include <LibGUI/Widget.h>
 #include <LibGfx/ShareableBitmap.h>
 #include <LibHTTP/Job.h>
-#include <LibWeb/Cookie/Cookie.h>
-#include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/Forward.h>
 
 namespace WebView {

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -9,6 +9,7 @@
 #include "BackgroundSettingsWidget.h"
 #include <AK/StringBuilder.h>
 #include <Applications/DisplaySettings/BackgroundSettingsGML.h>
+#include <LibConfig/Client.h>
 #include <LibCore/ConfigFile.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Application.h>
@@ -25,9 +26,6 @@
 #include <LibGUI/MessageBox.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/SystemTheme.h>
-
-// Including this after to avoid LibIPC errors
-#include <LibConfig/Client.h>
 
 namespace DisplaySettings {
 

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -6,14 +6,12 @@
  */
 
 #include "KeyboardSettingsWidget.h"
+#include <LibConfig/Client.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/SettingsWindow.h>
 #include <LibMain/Main.h>
-
-// Including this after to avoid LibIPC errors
-#include <LibConfig/Client.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {

--- a/Userland/Applications/SoundPlayer/main.cpp
+++ b/Userland/Applications/SoundPlayer/main.cpp
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-// FIXME: LibIPC Decoder and Encoder are sensitive to include order here
-#include <LibImageDecoderClient/Client.h>
-
 #include "AlbumCoverVisualizationWidget.h"
 #include "BarsVisualizationWidget.h"
 #include "Player.h"
@@ -24,6 +21,7 @@
 #include <LibGUI/Menubar.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/CharacterBitmap.h>
+#include <LibImageDecoderClient/Client.h>
 #include <LibMain/Main.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)

--- a/Userland/Applications/TerminalSettings/main.cpp
+++ b/Userland/Applications/TerminalSettings/main.cpp
@@ -5,15 +5,13 @@
  */
 
 #include "TerminalSettingsWidget.h"
+#include <LibConfig/Client.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/SettingsWindow.h>
 #include <LibMain/Main.h>
-
-// Including this after to avoid LibIPC errors
-#include <LibConfig/Client.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -15,15 +15,12 @@
 #include <Applications/ThemeEditor/MetricPropertyGML.h>
 #include <Applications/ThemeEditor/PathPropertyGML.h>
 #include <Applications/ThemeEditor/ThemeEditorGML.h>
-// FIXME: LibIPC Decoder and Encoder are sensitive to include order here
-// clang-format off
-#include <LibGUI/ConnectionToWindowServer.h>
-// clang-format on
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
+#include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/Frame.h>
 #include <LibGUI/GroupBox.h>

--- a/Userland/Libraries/LibCore/AnonymousBuffer.h
+++ b/Userland/Libraries/LibCore/AnonymousBuffer.h
@@ -74,7 +74,10 @@ private:
 
 namespace IPC {
 
+template<>
 bool encode(Encoder&, Core::AnonymousBuffer const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, Core::AnonymousBuffer&);
 
 }

--- a/Userland/Libraries/LibCore/DateTime.h
+++ b/Userland/Libraries/LibCore/DateTime.h
@@ -54,7 +54,10 @@ private:
 
 namespace IPC {
 
+template<>
 bool encode(Encoder&, Core::DateTime const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, Core::DateTime&);
 
 }

--- a/Userland/Libraries/LibCore/Proxy.h
+++ b/Userland/Libraries/LibCore/Proxy.h
@@ -52,6 +52,11 @@ struct ProxyData {
 }
 
 namespace IPC {
+
+template<>
 bool encode(Encoder&, Core::ProxyData const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, Core::ProxyData&);
+
 }

--- a/Userland/Libraries/LibDNS/Answer.cpp
+++ b/Userland/Libraries/LibDNS/Answer.cpp
@@ -100,12 +100,14 @@ ErrorOr<void> AK::Formatter<DNS::RecordClass>::format(AK::FormatBuilder& builder
 
 namespace IPC {
 
+template<>
 bool encode(Encoder& encoder, DNS::Answer const& answer)
 {
     encoder << answer.name().as_string() << (u16)answer.type() << (u16)answer.class_code() << answer.ttl() << answer.record_data() << answer.mdns_cache_flush();
     return true;
 }
 
+template<>
 ErrorOr<void> decode(Decoder& decoder, DNS::Answer& answer)
 {
     String name;

--- a/Userland/Libraries/LibDNS/Answer.h
+++ b/Userland/Libraries/LibDNS/Answer.h
@@ -94,7 +94,10 @@ struct AK::Formatter<DNS::RecordClass> : StandardFormatter {
 
 namespace IPC {
 
+template<>
 bool encode(Encoder&, DNS::Answer const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, DNS::Answer&);
 
 }

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -5,13 +5,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-// FIXME: LibIPC Decoder and Encoder are sensitive to include order here
-// clang-format off
-#include <LibGUI/ConnectionToWindowServer.h>
-// clang-format on
 #include <AK/LexicalPath.h>
 #include <LibCore/File.h>
 #include <LibFileSystemAccessClient/Client.h>
+#include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Window.h>
 

--- a/Userland/Libraries/LibGUI/Desktop.cpp
+++ b/Userland/Libraries/LibGUI/Desktop.cpp
@@ -7,12 +7,10 @@
 
 #include <AK/Badge.h>
 #include <AK/TemporaryChange.h>
+#include <LibConfig/Client.h>
 #include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/Desktop.h>
 #include <string.h>
-
-// Including this after to avoid LibIPC errors
-#include <LibConfig/Client.h>
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -366,12 +366,14 @@ Vector<Color> Color::tints(u32 steps, float max) const
 
 }
 
+template<>
 bool IPC::encode(Encoder& encoder, Color const& color)
 {
     encoder << color.value();
     return true;
 }
 
+template<>
 ErrorOr<void> IPC::decode(Decoder& decoder, Color& color)
 {
     u32 rgba;

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -568,7 +568,10 @@ struct Formatter<Gfx::Color> : public Formatter<StringView> {
 
 namespace IPC {
 
+template<>
 bool encode(Encoder&, Gfx::Color const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, Gfx::Color&);
 
 }

--- a/Userland/Libraries/LibGfx/Point.cpp
+++ b/Userland/Libraries/LibGfx/Point.cpp
@@ -51,12 +51,14 @@ String FloatPoint::to_string() const
 
 namespace IPC {
 
+template<>
 bool encode(Encoder& encoder, Gfx::IntPoint const& point)
 {
     encoder << point.x() << point.y();
     return true;
 }
 
+template<>
 ErrorOr<void> decode(Decoder& decoder, Gfx::IntPoint& point)
 {
     int x = 0;

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -290,7 +290,10 @@ struct Formatter<Gfx::Point<T>> : Formatter<FormatString> {
 
 namespace IPC {
 
+template<>
 bool encode(Encoder&, Gfx::IntPoint const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, Gfx::IntPoint&);
 
 }

--- a/Userland/Libraries/LibGfx/Rect.cpp
+++ b/Userland/Libraries/LibGfx/Rect.cpp
@@ -30,12 +30,14 @@ String FloatRect::to_string() const
 
 namespace IPC {
 
+template<>
 bool encode(Encoder& encoder, Gfx::IntRect const& rect)
 {
     encoder << rect.location() << rect.size();
     return true;
 }
 
+template<>
 ErrorOr<void> decode(Decoder& decoder, Gfx::IntRect& rect)
 {
     Gfx::IntPoint point;

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -1031,7 +1031,10 @@ struct Formatter<Gfx::Rect<T>> : Formatter<FormatString> {
 
 namespace IPC {
 
+template<>
 bool encode(Encoder&, Gfx::IntRect const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, Gfx::IntRect&);
 
 }

--- a/Userland/Libraries/LibGfx/ShareableBitmap.cpp
+++ b/Userland/Libraries/LibGfx/ShareableBitmap.cpp
@@ -22,6 +22,7 @@ ShareableBitmap::ShareableBitmap(NonnullRefPtr<Bitmap> bitmap, Tag)
 
 namespace IPC {
 
+template<>
 bool encode(Encoder& encoder, Gfx::ShareableBitmap const& shareable_bitmap)
 {
     encoder << shareable_bitmap.is_valid();
@@ -39,6 +40,7 @@ bool encode(Encoder& encoder, Gfx::ShareableBitmap const& shareable_bitmap)
     return true;
 }
 
+template<>
 ErrorOr<void> decode(Decoder& decoder, Gfx::ShareableBitmap& shareable_bitmap)
 {
     bool valid = false;

--- a/Userland/Libraries/LibGfx/ShareableBitmap.h
+++ b/Userland/Libraries/LibGfx/ShareableBitmap.h
@@ -34,7 +34,10 @@ private:
 
 namespace IPC {
 
+template<>
 bool encode(Encoder&, Gfx::ShareableBitmap const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, Gfx::ShareableBitmap&);
 
 }

--- a/Userland/Libraries/LibGfx/Size.cpp
+++ b/Userland/Libraries/LibGfx/Size.cpp
@@ -27,12 +27,14 @@ String FloatSize::to_string() const
 
 namespace IPC {
 
+template<>
 bool encode(Encoder& encoder, Gfx::IntSize const& size)
 {
     encoder << size.width() << size.height();
     return true;
 }
 
+template<>
 ErrorOr<void> decode(Decoder& decoder, Gfx::IntSize& size)
 {
     int width = 0;

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -188,7 +188,10 @@ struct Formatter<Gfx::Size<T>> : Formatter<FormatString> {
 
 namespace IPC {
 
+template<>
 bool encode(Encoder&, Gfx::IntSize const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, Gfx::IntSize&);
 
 }

--- a/Userland/Libraries/LibIPC/Decoder.cpp
+++ b/Userland/Libraries/LibIPC/Decoder.cpp
@@ -170,6 +170,7 @@ ErrorOr<void> Decoder::decode([[maybe_unused]] File& file)
     return {};
 }
 
+template<>
 ErrorOr<void> decode(Decoder& decoder, Core::AnonymousBuffer& buffer)
 {
     bool valid;
@@ -187,6 +188,7 @@ ErrorOr<void> decode(Decoder& decoder, Core::AnonymousBuffer& buffer)
     return {};
 }
 
+template<>
 ErrorOr<void> decode(Decoder& decoder, Core::DateTime& datetime)
 {
     i64 timestamp;
@@ -195,6 +197,7 @@ ErrorOr<void> decode(Decoder& decoder, Core::DateTime& datetime)
     return {};
 }
 
+template<>
 ErrorOr<void> decode(Decoder& decoder, Core::ProxyData& data)
 {
     UnderlyingType<decltype(data.type)> type;

--- a/Userland/Libraries/LibIPC/Encoder.cpp
+++ b/Userland/Libraries/LibIPC/Encoder.cpp
@@ -196,6 +196,7 @@ Encoder& Encoder::operator<<(File const& file)
     return *this;
 }
 
+template<>
 bool encode(Encoder& encoder, Core::AnonymousBuffer const& buffer)
 {
     encoder << buffer.is_valid();
@@ -206,12 +207,14 @@ bool encode(Encoder& encoder, Core::AnonymousBuffer const& buffer)
     return true;
 }
 
+template<>
 bool encode(Encoder& encoder, Core::DateTime const& datetime)
 {
     encoder << static_cast<i64>(datetime.timestamp());
     return true;
 }
 
+template<>
 bool encode(Encoder& encoder, Core::ProxyData const& proxy)
 {
     encoder << to_underlying(proxy.type);

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -16,7 +16,7 @@
 namespace IPC {
 
 template<typename T>
-bool encode(Encoder&, T&)
+bool encode(Encoder&, T const&)
 {
     static_assert(DependentFalse<T>, "Base IPC::encode() was instantiated");
     VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibIPC/Forward.h
+++ b/Userland/Libraries/LibIPC/Forward.h
@@ -15,4 +15,10 @@ class Message;
 class File;
 class Stub;
 
+template<typename T>
+bool encode(Encoder&, T const&);
+
+template<typename T>
+ErrorOr<void> decode(Decoder&, T&);
+
 }

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -7,8 +7,6 @@
 #pragma once
 
 #include <AK/HashMap.h>
-// Need to include this before RequestClientEndpoint.h as that one includes LibIPC/(De En)coder.h, which would bomb if included before this.
-#include <LibCore/Proxy.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <RequestServer/RequestClientEndpoint.h>
 #include <RequestServer/RequestServerEndpoint.h>

--- a/Userland/Libraries/LibWeb/Cookie/Cookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/Cookie.cpp
@@ -38,6 +38,7 @@ SameSite same_site_from_string(StringView same_site_mode)
 
 }
 
+template<>
 bool IPC::encode(Encoder& encoder, Web::Cookie::Cookie const& cookie)
 {
     encoder << cookie.name;
@@ -56,6 +57,7 @@ bool IPC::encode(Encoder& encoder, Web::Cookie::Cookie const& cookie)
     return true;
 }
 
+template<>
 ErrorOr<void> IPC::decode(Decoder& decoder, Web::Cookie::Cookie& cookie)
 {
     TRY(decoder.decode(cookie.name));

--- a/Userland/Libraries/LibWeb/Cookie/Cookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/Cookie.h
@@ -46,7 +46,10 @@ SameSite same_site_from_string(StringView same_site_mode);
 
 namespace IPC {
 
+template<>
 bool encode(Encoder&, Web::Cookie::Cookie const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, Web::Cookie::Cookie&);
 
 }

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -347,6 +347,7 @@ Optional<Core::DateTime> parse_date_time(StringView date_string)
 
 }
 
+template<>
 bool IPC::encode(Encoder& encoder, Web::Cookie::ParsedCookie const& cookie)
 {
     encoder << cookie.name;
@@ -362,6 +363,7 @@ bool IPC::encode(Encoder& encoder, Web::Cookie::ParsedCookie const& cookie)
     return true;
 }
 
+template<>
 ErrorOr<void> IPC::decode(Decoder& decoder, Web::Cookie::ParsedCookie& cookie)
 {
     TRY(decoder.decode(cookie.name));

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
@@ -32,7 +32,10 @@ Optional<ParsedCookie> parse_cookie(String const& cookie_string);
 
 namespace IPC {
 
+template<>
 bool encode(Encoder&, Web::Cookie::ParsedCookie const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, Web::Cookie::ParsedCookie&);
 
 }

--- a/Userland/Libraries/LibWeb/WebDriver/Response.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Response.cpp
@@ -27,6 +27,7 @@ Response::Response(Error&& error)
 
 }
 
+template<>
 bool IPC::encode(Encoder& encoder, Web::WebDriver::Response const& response)
 {
     response.visit(
@@ -46,6 +47,7 @@ bool IPC::encode(Encoder& encoder, Web::WebDriver::Response const& response)
     return true;
 }
 
+template<>
 ErrorOr<void> IPC::decode(Decoder& decoder, Web::WebDriver::Response& response)
 {
     ResponseType type {};

--- a/Userland/Libraries/LibWeb/WebDriver/Response.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Response.h
@@ -46,7 +46,10 @@ private:
 
 namespace IPC {
 
+template<>
 bool encode(Encoder&, Web::WebDriver::Response const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, Web::WebDriver::Response&);
 
 }

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -8,7 +8,6 @@
 
 #include <AK/HashMap.h>
 #include <LibIPC/ConnectionToServer.h>
-#include <LibWeb/Cookie/ParsedCookie.h>
 #include <WebContent/WebContentClientEndpoint.h>
 #include <WebContent/WebContentServerEndpoint.h>
 

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
@@ -4,15 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-// FIXME: LibIPC Decoder and Encoder are sensitive to include order here
-// clang-format off
-#include <LibGUI/ConnectionToWindowServer.h>
-// clang-format on
 #include <AK/Debug.h>
 #include <FileSystemAccessServer/ConnectionFromClient.h>
 #include <LibCore/File.h>
 #include <LibCore/IODevice.h>
 #include <LibGUI/Application.h>
+#include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/MessageBox.h>
 

--- a/Userland/Services/NotificationServer/ConnectionFromClient.h
+++ b/Userland/Services/NotificationServer/ConnectionFromClient.h
@@ -7,11 +7,9 @@
 #pragma once
 
 #include <LibIPC/ConnectionFromClient.h>
-#include <WindowServer/ScreenLayout.h>
-
-// Must be included after WindowServer/ScreenLayout.h
 #include <NotificationServer/NotificationClientEndpoint.h>
 #include <NotificationServer/NotificationServerEndpoint.h>
+#include <WindowServer/ScreenLayout.h>
 
 namespace NotificationServer {
 

--- a/Userland/Services/RequestServer/ConnectionFromClient.h
+++ b/Userland/Services/RequestServer/ConnectionFromClient.h
@@ -7,8 +7,6 @@
 #pragma once
 
 #include <AK/HashMap.h>
-// Need to include this before RequestClientEndpoint.h as that one includes LibIPC/(De En)coder.h, which would bomb if included before this.
-#include <LibCore/Proxy.h>
 #include <LibIPC/ConnectionFromClient.h>
 #include <RequestServer/Forward.h>
 #include <RequestServer/RequestClientEndpoint.h>

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -19,7 +19,6 @@
 #include <LibJS/Parser.h>
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
-#include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/HTML/BrowsingContext.h>

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -13,7 +13,6 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Handle.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
-#include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/Platform/Timer.h>

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -4,9 +4,6 @@
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 
-// FIXME: This isn't used here, but the generated IPC fails to compile without this include.
-#include <LibWeb/WebDriver/Response.h>
-
 endpoint WebContentClient
 {
     did_start_loading(URL url) =|

--- a/Userland/Services/WindowServer/ScreenLayout.h
+++ b/Userland/Services/WindowServer/ScreenLayout.h
@@ -73,9 +73,16 @@ public:
 
 namespace IPC {
 
+template<>
 bool encode(Encoder&, WindowServer::ScreenLayout::Screen const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, WindowServer::ScreenLayout::Screen&);
+
+template<>
 bool encode(Encoder&, WindowServer::ScreenLayout const&);
+
+template<>
 ErrorOr<void> decode(Decoder&, WindowServer::ScreenLayout&);
 
 }

--- a/Userland/Services/WindowServer/ScreenLayout.ipp
+++ b/Userland/Services/WindowServer/ScreenLayout.ipp
@@ -6,14 +6,12 @@
 
 #include <AK/ScopeGuard.h>
 #include <Kernel/API/Graphics.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 #include <Services/WindowServer/ScreenLayout.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
-
-// Must be included after LibIPC/Forward.h
-#include <LibIPC/Decoder.h>
-#include <LibIPC/Encoder.h>
 
 namespace WindowServer {
 

--- a/Userland/Services/WindowServer/ScreenLayout.ipp
+++ b/Userland/Services/WindowServer/ScreenLayout.ipp
@@ -394,12 +394,14 @@ bool ScreenLayout::try_auto_add_display_connector(String const& device_path)
 
 namespace IPC {
 
-bool encode(Encoder& encoder, const WindowServer::ScreenLayout::Screen& screen)
+template<>
+bool encode(Encoder& encoder, WindowServer::ScreenLayout::Screen const& screen)
 {
     encoder << screen.mode << screen.device << screen.location << screen.resolution << screen.scale_factor;
     return true;
 }
 
+template<>
 ErrorOr<void> decode(Decoder& decoder, WindowServer::ScreenLayout::Screen& screen)
 {
     WindowServer::ScreenLayout::Screen::Mode mode;
@@ -416,12 +418,14 @@ ErrorOr<void> decode(Decoder& decoder, WindowServer::ScreenLayout::Screen& scree
     return {};
 }
 
-bool encode(Encoder& encoder, const WindowServer::ScreenLayout& screen_layout)
+template<>
+bool encode(Encoder& encoder, WindowServer::ScreenLayout const& screen_layout)
 {
     encoder << screen_layout.screens << screen_layout.main_screen_index;
     return true;
 }
 
+template<>
 ErrorOr<void> decode(Decoder& decoder, WindowServer::ScreenLayout& screen_layout)
 {
     Vector<WindowServer::ScreenLayout::Screen> screens;


### PR DESCRIPTION
Fixes #9584

This ensures that the base templates are declared so that they may actually be specialized (instead of just overloaded), and ensures that the custom type definitions are actually declared as template specializations.