### PR TITLE
LibWeb: Wrap out-of-flow block nodes in last anonymous block if possible

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -83,13 +83,15 @@ static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layo
         return layout_parent;
     }
 
-    if (!layout_parent.children_are_inline()) {
-        // Parent block has block-level children, insert this block into parent.
-        return layout_parent;
-    }
-
     if (layout_node.is_floating() || layout_node.is_absolutely_positioned()) {
         // Block is out-of-flow, it can have inline siblings if necessary.
+        if (layout_parent.last_child()->children_are_inline()) {
+            return *layout_parent.last_child();
+        }
+    }
+
+    if (!layout_parent.children_are_inline()) {
+        // Parent block has block-level children, insert this block into parent.
         return layout_parent;
     }
 


### PR DESCRIPTION
Join out-of-flow block nodes into last child of parent node if last child has inline children.

Example html that displays wrong:
```html
<html lang="en">
  <head>
    <style>
      .box {
        width: 100px;
        height: 100px;
        background-color: blanchedalmond;
        position: absolute;
        top: 10px;
        right: 10px;
        display: block;
      }
    </style>
  </head>
  <body><h1></h1><span id="label_abc">abc</span><div class="box"></div><span id="label_123">123</span></body>
</html>
```