### PR TITLE
LibWeb: Solve width for absolute positioned elemenent according to spec

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -595,9 +595,9 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
         //    then the width is shrink-to-fit. Then solve for 'left'
         if (left.is_auto() && width.is_auto() && !right.is_auto()) {
             auto result = calculate_shrink_to_fit_widths(box);
-            left = solve_for_left();
             auto available_width = solve_for_width();
             width = CSS::Length(min(max(result.preferred_minimum_width, available_width.to_px(box)), result.preferred_width), CSS::Length::Type::Px);
+            left = solve_for_left();
         }
 
         // 2. 'left' and 'right' are 'auto' and 'width' is not 'auto',


### PR DESCRIPTION
https://www.w3.org/TR/css-position-3/#abs-non-replaced-width says If left and width are auto and right is not auto, then the width is shrink-to-fit. Then solve for left.

This change makes width to be solved before left. Like it works if right and width are auto and left is not auto https://github.com/SerenityOS/serenity/blob/master/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp#L619-L622 where width is solved first and then solved right.

html I used for testing:
```html
<!DOCTYPE html>
<html lang="en" xml:lang="en">
  <head>
    <style type="text/css">
      .box {
        position: absolute;
        right: 100px;
      }
    </style>
  </head>
  <body>
    <div class="box">
      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a
      tempor ipsum, mollis fermentum justo. Curabitur mollis purus id ligula
      mollis sodales. Morbi nec mi blandit, elementum lectus eget, dignissim
      augue. Donec non varius nisi. Morbi suscipit lacus nec iaculis fringilla.
      Curabitur quis neque dignissim, aliquet ipsum vitae, vulputate est.
      Maecenas a eros a diam pellentesque venenatis. Cras neque mauris,
      ultricies at arcu et, fringilla commodo ex. Quisque ac faucibus nunc.
      Nullam facilisis, dui eu dictum ornare, enim sapien lobortis dui, sit amet
      fringilla risus dolor volutpat sapien. In ornare erat sed odio euismod
      sollicitudin. Sed fermentum, sapien ut rhoncus ullamcorper, dolor ipsum
      ultricies risus, nec efficitur justo ligula eget magna. Phasellus sapien
      leo, suscipit at tempor vel, consequat eget sem
    </div>
  </body>
</html>
```