### PR TITLE
WebDriver+Friends: Implement user prompt endpoints

### DIFF
--- a/Base/res/html/misc/prompt.html
+++ b/Base/res/html/misc/prompt.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    </head>
+    <body>
+    <pre id=message></pre>
+    <script>
+        const closed = (message) => {
+            console.log(message);
+            document.getElementById('message').innerHTML = `Message: "${message}"\n`;
+        };
+
+        setTimeout(() => { console.log('This must not appear until after the prompt is closed.'); }, 1000);
+        closed(prompt("Hello friends!"));
+    </script>
+    </body>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -167,6 +167,7 @@
             <li><a href="events.html">simple DOM events</a></li>
             <li><a href="dom.html">simple DOM JS</a></li>
             <li><a href="alert.html">alert()</a></li>
+            <li><a href="prompt.html">prompt()</a></li>
             <li><a href="qsa.html">querySelectorAll()</a></li>
             <li><a href="innerHTML.html">innerHTML()</a></li>
             <li><a href="demo.html">fun demo</a></li>

--- a/Userland/Libraries/LibGUI/Dialog.cpp
+++ b/Userland/Libraries/LibGUI/Dialog.cpp
@@ -115,6 +115,8 @@ void Dialog::done(ExecResult result)
     if (!m_event_loop)
         return;
     m_result = result;
+    on_done(m_result);
+
     dbgln("{}: Quit event loop with result {}", *this, to_underlying(result));
     m_event_loop->quit(to_underlying(result));
 }

--- a/Userland/Libraries/LibGUI/Dialog.h
+++ b/Userland/Libraries/LibGUI/Dialog.h
@@ -52,6 +52,8 @@ public:
 protected:
     explicit Dialog(Window* parent_window, ScreenPosition = ScreenPosition::CenterWithinParent);
 
+    virtual void on_done(ExecResult) { }
+
 private:
     OwnPtr<Core::EventLoop> m_event_loop;
     ExecResult m_result { ExecResult::Aborted };

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -23,6 +23,7 @@ class CheckBox;
 class ComboBox;
 class Command;
 class CommandPalette;
+class Dialog;
 class DialogButton;
 class DragEvent;
 class DropEvent;

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -15,9 +15,9 @@
 
 namespace GUI {
 
-InputBox::InputBox(Window* parent_window, String& text_value, StringView prompt, StringView title, StringView placeholder, InputType input_type)
+InputBox::InputBox(Window* parent_window, String text_value, StringView prompt, StringView title, StringView placeholder, InputType input_type)
     : Dialog(parent_window)
-    , m_text_value(text_value)
+    , m_text_value(move(text_value))
     , m_prompt(prompt)
     , m_placeholder(placeholder)
 {
@@ -34,6 +34,17 @@ Dialog::ExecResult InputBox::show(Window* parent_window, String& text_value, Str
     auto result = box->exec();
     text_value = box->text_value();
     return result;
+}
+
+void InputBox::set_text_value(String text_value)
+{
+    m_text_editor->set_text(move(text_value));
+}
+
+void InputBox::on_done(ExecResult result)
+{
+    if (result == ExecResult::OK)
+        m_text_value = m_text_editor->text();
 }
 
 void InputBox::build(InputType input_type)
@@ -86,7 +97,6 @@ void InputBox::build(InputType input_type)
     m_ok_button->set_text("OK");
     m_ok_button->on_click = [this](auto) {
         dbgln("GUI::InputBox: OK button clicked");
-        m_text_value = m_text_editor->text();
         done(ExecResult::OK);
     };
     m_ok_button->set_default(true);

--- a/Userland/Libraries/LibGUI/InputBox.h
+++ b/Userland/Libraries/LibGUI/InputBox.h
@@ -24,12 +24,15 @@ public:
 
     static ExecResult show(Window* parent_window, String& text_value, StringView prompt, StringView title, StringView placeholder = {}, InputType input_type = InputType::Text);
 
+    String const& text_value() const { return m_text_value; }
+    void set_text_value(String text_value);
+
 private:
-    explicit InputBox(Window* parent_window, String& text_value, StringView prompt, StringView title, StringView placeholder, InputType input_type);
+    explicit InputBox(Window* parent_window, String text_value, StringView prompt, StringView title, StringView placeholder, InputType input_type);
 
-    String text_value() const { return m_text_value; }
-
+    virtual void on_done(ExecResult) override;
     void build(InputType input_type);
+
     String m_text_value;
     String m_prompt;
     String m_placeholder;

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -73,6 +73,10 @@ public:
 
     double compute_deadline() const;
 
+    // https://html.spec.whatwg.org/multipage/webappapis.html#pause
+    void set_execution_paused(bool execution_paused) { m_execution_paused = execution_paused; }
+    bool execution_paused() const { return m_execution_paused; }
+
 private:
     Type m_type { Type::Window };
 
@@ -104,6 +108,8 @@ private:
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#termination-nesting-level
     size_t m_termination_nesting_level { 0 };
+
+    bool m_execution_paused { false };
 };
 
 EventLoop& main_thread_event_loop();

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/TaskQueue.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/TaskQueue.cpp
@@ -24,6 +24,9 @@ void TaskQueue::add(NonnullOwnPtr<Task> task)
 
 OwnPtr<Task> TaskQueue::take_first_runnable()
 {
+    if (m_event_loop.execution_paused())
+        return nullptr;
+
     for (size_t i = 0; i < m_tasks.size(); ++i) {
         if (m_tasks[i]->is_runnable())
             return m_tasks.take(i);
@@ -33,6 +36,9 @@ OwnPtr<Task> TaskQueue::take_first_runnable()
 
 bool TaskQueue::has_runnable_tasks() const
 {
+    if (m_event_loop.execution_paused())
+        return false;
+
     for (auto& task : m_tasks) {
         if (task->is_runnable())
             return true;

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -93,6 +93,7 @@ static constexpr auto s_webdriver_endpoints = Array {
     ROUTE(POST, "/session/:session_id/cookie"sv, add_cookie),
     ROUTE(DELETE, "/session/:session_id/cookie/:name"sv, delete_cookie),
     ROUTE(DELETE, "/session/:session_id/cookie"sv, delete_all_cookies),
+    ROUTE(POST, "/session/:session_id/alert/dismiss"sv, dismiss_alert),
     ROUTE(GET, "/session/:session_id/screenshot"sv, take_screenshot),
     ROUTE(GET, "/session/:session_id/element/:element_id/screenshot"sv, take_element_screenshot),
 };

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -94,6 +94,7 @@ static constexpr auto s_webdriver_endpoints = Array {
     ROUTE(DELETE, "/session/:session_id/cookie/:name"sv, delete_cookie),
     ROUTE(DELETE, "/session/:session_id/cookie"sv, delete_all_cookies),
     ROUTE(POST, "/session/:session_id/alert/dismiss"sv, dismiss_alert),
+    ROUTE(POST, "/session/:session_id/alert/accept"sv, accept_alert),
     ROUTE(GET, "/session/:session_id/screenshot"sv, take_screenshot),
     ROUTE(GET, "/session/:session_id/element/:element_id/screenshot"sv, take_element_screenshot),
 };

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -95,6 +95,7 @@ static constexpr auto s_webdriver_endpoints = Array {
     ROUTE(DELETE, "/session/:session_id/cookie"sv, delete_all_cookies),
     ROUTE(POST, "/session/:session_id/alert/dismiss"sv, dismiss_alert),
     ROUTE(POST, "/session/:session_id/alert/accept"sv, accept_alert),
+    ROUTE(GET, "/session/:session_id/alert/text"sv, get_alert_text),
     ROUTE(GET, "/session/:session_id/screenshot"sv, take_screenshot),
     ROUTE(GET, "/session/:session_id/element/:element_id/screenshot"sv, take_element_screenshot),
 };

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -96,6 +96,7 @@ static constexpr auto s_webdriver_endpoints = Array {
     ROUTE(POST, "/session/:session_id/alert/dismiss"sv, dismiss_alert),
     ROUTE(POST, "/session/:session_id/alert/accept"sv, accept_alert),
     ROUTE(GET, "/session/:session_id/alert/text"sv, get_alert_text),
+    ROUTE(POST, "/session/:session_id/alert/text"sv, send_alert_text),
     ROUTE(GET, "/session/:session_id/screenshot"sv, take_screenshot),
     ROUTE(GET, "/session/:session_id/element/:element_id/screenshot"sv, take_element_screenshot),
 };

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -88,6 +88,7 @@ public:
 
     // 16. User prompts, https://w3c.github.io/webdriver/#user-prompts
     virtual Response dismiss_alert(Parameters parameters, JsonValue payload) = 0;
+    virtual Response accept_alert(Parameters parameters, JsonValue payload) = 0;
 
     // 17. Screen capture, https://w3c.github.io/webdriver/#screen-capture
     virtual Response take_screenshot(Parameters parameters, JsonValue payload) = 0;

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -89,6 +89,7 @@ public:
     // 16. User prompts, https://w3c.github.io/webdriver/#user-prompts
     virtual Response dismiss_alert(Parameters parameters, JsonValue payload) = 0;
     virtual Response accept_alert(Parameters parameters, JsonValue payload) = 0;
+    virtual Response get_alert_text(Parameters parameters, JsonValue payload) = 0;
 
     // 17. Screen capture, https://w3c.github.io/webdriver/#screen-capture
     virtual Response take_screenshot(Parameters parameters, JsonValue payload) = 0;

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -74,7 +74,7 @@ public:
     virtual Response get_element_rect(Parameters parameters, JsonValue payload) = 0;
     virtual Response is_element_enabled(Parameters parameters, JsonValue payload) = 0;
 
-    // 13. https://w3c.github.io/webdriver/#document, https://w3c.github.io/webdriver/#get-page-source
+    // 13. Document, https://w3c.github.io/webdriver/#document
     virtual Response get_source(Parameters parameters, JsonValue payload) = 0;
     virtual Response execute_script(Parameters parameters, JsonValue payload) = 0;
     virtual Response execute_async_script(Parameters parameters, JsonValue payload) = 0;

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -90,6 +90,7 @@ public:
     virtual Response dismiss_alert(Parameters parameters, JsonValue payload) = 0;
     virtual Response accept_alert(Parameters parameters, JsonValue payload) = 0;
     virtual Response get_alert_text(Parameters parameters, JsonValue payload) = 0;
+    virtual Response send_alert_text(Parameters parameters, JsonValue payload) = 0;
 
     // 17. Screen capture, https://w3c.github.io/webdriver/#screen-capture
     virtual Response take_screenshot(Parameters parameters, JsonValue payload) = 0;

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -86,6 +86,9 @@ public:
     virtual Response delete_cookie(Parameters parameters, JsonValue payload) = 0;
     virtual Response delete_all_cookies(Parameters parameters, JsonValue payload) = 0;
 
+    // 16. User prompts, https://w3c.github.io/webdriver/#user-prompts
+    virtual Response dismiss_alert(Parameters parameters, JsonValue payload) = 0;
+
     // 17. Screen capture, https://w3c.github.io/webdriver/#screen-capture
     virtual Response take_screenshot(Parameters parameters, JsonValue payload) = 0;
     virtual Response take_element_screenshot(Parameters parameters, JsonValue payload) = 0;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -348,20 +348,22 @@ void OutOfProcessWebView::notify_server_did_request_image_context_menu(Badge<Web
 void OutOfProcessWebView::notify_server_did_request_alert(Badge<WebContentClient>, String const& message)
 {
     GUI::MessageBox::show(window(), message, "Alert"sv, GUI::MessageBox::Type::Information);
+    client().async_alert_closed();
 }
 
-bool OutOfProcessWebView::notify_server_did_request_confirm(Badge<WebContentClient>, String const& message)
+void OutOfProcessWebView::notify_server_did_request_confirm(Badge<WebContentClient>, String const& message)
 {
     auto confirm_result = GUI::MessageBox::show(window(), message, "Confirm"sv, GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::OKCancel);
-    return confirm_result == GUI::Dialog::ExecResult::OK;
+    client().async_confirm_closed(confirm_result == GUI::Dialog::ExecResult::OK);
 }
 
-String OutOfProcessWebView::notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_)
+void OutOfProcessWebView::notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_)
 {
     String response { default_ };
     if (GUI::InputBox::show(window(), response, message, "Prompt"sv) == GUI::InputBox::ExecResult::OK)
-        return response;
-    return {};
+        client().async_prompt_closed(move(response));
+    else
+        client().async_prompt_closed({});
 }
 
 void OutOfProcessWebView::notify_server_did_get_source(const AK::URL& url, String const& source)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -378,6 +378,12 @@ void OutOfProcessWebView::notify_server_did_request_prompt(Badge<WebContentClien
     m_dialog = nullptr;
 }
 
+void OutOfProcessWebView::notify_server_did_request_set_prompt_text(Badge<WebContentClient>, String const& message)
+{
+    if (m_dialog && is<GUI::InputBox>(*m_dialog))
+        static_cast<GUI::InputBox&>(*m_dialog).set_text_value(message);
+}
+
 void OutOfProcessWebView::notify_server_did_request_accept_dialog(Badge<WebContentClient>)
 {
     if (m_dialog)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -156,8 +156,8 @@ private:
     virtual void notify_server_did_request_link_context_menu(Badge<WebContentClient>, Gfx::IntPoint const&, const AK::URL&, String const& target, unsigned modifiers) override;
     virtual void notify_server_did_request_image_context_menu(Badge<WebContentClient>, Gfx::IntPoint const&, const AK::URL&, String const& target, unsigned modifiers, Gfx::ShareableBitmap const&) override;
     virtual void notify_server_did_request_alert(Badge<WebContentClient>, String const& message) override;
-    virtual bool notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) override;
-    virtual String notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) override;
+    virtual void notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) override;
+    virtual void notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) override;
     virtual void notify_server_did_get_source(const AK::URL& url, String const& source) override;
     virtual void notify_server_did_get_dom_tree(String const& dom_tree) override;
     virtual void notify_server_did_get_dom_node_properties(i32 node_id, String const& specified_style, String const& computed_style, String const& custom_properties, String const& node_box_sizing) override;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -158,6 +158,7 @@ private:
     virtual void notify_server_did_request_alert(Badge<WebContentClient>, String const& message) override;
     virtual void notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) override;
     virtual void notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) override;
+    virtual void notify_server_did_request_set_prompt_text(Badge<WebContentClient>, String const& message) override;
     virtual void notify_server_did_request_accept_dialog(Badge<WebContentClient>) override;
     virtual void notify_server_did_request_dismiss_dialog(Badge<WebContentClient>) override;
     virtual void notify_server_did_get_source(const AK::URL& url, String const& source) override;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -158,6 +158,8 @@ private:
     virtual void notify_server_did_request_alert(Badge<WebContentClient>, String const& message) override;
     virtual void notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) override;
     virtual void notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) override;
+    virtual void notify_server_did_request_accept_dialog(Badge<WebContentClient>) override;
+    virtual void notify_server_did_request_dismiss_dialog(Badge<WebContentClient>) override;
     virtual void notify_server_did_get_source(const AK::URL& url, String const& source) override;
     virtual void notify_server_did_get_dom_tree(String const& dom_tree) override;
     virtual void notify_server_did_get_dom_node_properties(i32 node_id, String const& specified_style, String const& computed_style, String const& custom_properties, String const& node_box_sizing) override;
@@ -204,6 +206,7 @@ private:
     } m_client_state;
 
     RefPtr<Gfx::Bitmap> m_backup_bitmap;
+    RefPtr<GUI::Dialog> m_dialog;
 };
 
 }

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -44,6 +44,8 @@ public:
     virtual void notify_server_did_request_alert(Badge<WebContentClient>, String const& message) = 0;
     virtual void notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) = 0;
     virtual void notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) = 0;
+    virtual void notify_server_did_request_accept_dialog(Badge<WebContentClient>) = 0;
+    virtual void notify_server_did_request_dismiss_dialog(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_get_source(const AK::URL& url, String const& source) = 0;
     virtual void notify_server_did_get_dom_tree(String const& dom_tree) = 0;
     virtual void notify_server_did_get_dom_node_properties(i32 node_id, String const& specified_style, String const& computed_style, String const& custom_properties, String const& node_box_sizing) = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -44,6 +44,7 @@ public:
     virtual void notify_server_did_request_alert(Badge<WebContentClient>, String const& message) = 0;
     virtual void notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) = 0;
     virtual void notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) = 0;
+    virtual void notify_server_did_request_set_prompt_text(Badge<WebContentClient>, String const& message) = 0;
     virtual void notify_server_did_request_accept_dialog(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_request_dismiss_dialog(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_get_source(const AK::URL& url, String const& source) = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -42,8 +42,8 @@ public:
     virtual void notify_server_did_request_link_context_menu(Badge<WebContentClient>, Gfx::IntPoint const&, const AK::URL&, String const& target, unsigned modifiers) = 0;
     virtual void notify_server_did_request_image_context_menu(Badge<WebContentClient>, Gfx::IntPoint const&, const AK::URL&, String const& target, unsigned modifiers, Gfx::ShareableBitmap const&) = 0;
     virtual void notify_server_did_request_alert(Badge<WebContentClient>, String const& message) = 0;
-    virtual bool notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) = 0;
-    virtual String notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) = 0;
+    virtual void notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) = 0;
+    virtual void notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) = 0;
     virtual void notify_server_did_get_source(const AK::URL& url, String const& source) = 0;
     virtual void notify_server_did_get_dom_tree(String const& dom_tree) = 0;
     virtual void notify_server_did_get_dom_node_properties(i32 node_id, String const& specified_style, String const& computed_style, String const& custom_properties, String const& node_box_sizing) = 0;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -191,6 +191,11 @@ void WebContentClient::did_request_prompt(String const& message, String const& d
     m_view.notify_server_did_request_prompt({}, message, default_);
 }
 
+void WebContentClient::did_request_set_prompt_text(String const& message)
+{
+    m_view.notify_server_did_request_set_prompt_text({}, message);
+}
+
 void WebContentClient::did_request_accept_dialog()
 {
     m_view.notify_server_did_request_accept_dialog({});

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -181,14 +181,14 @@ void WebContentClient::did_request_alert(String const& message)
     m_view.notify_server_did_request_alert({}, message);
 }
 
-Messages::WebContentClient::DidRequestConfirmResponse WebContentClient::did_request_confirm(String const& message)
+void WebContentClient::did_request_confirm(String const& message)
 {
-    return m_view.notify_server_did_request_confirm({}, message);
+    m_view.notify_server_did_request_confirm({}, message);
 }
 
-Messages::WebContentClient::DidRequestPromptResponse WebContentClient::did_request_prompt(String const& message, String const& default_)
+void WebContentClient::did_request_prompt(String const& message, String const& default_)
 {
-    return m_view.notify_server_did_request_prompt({}, message, default_);
+    m_view.notify_server_did_request_prompt({}, message, default_);
 }
 
 void WebContentClient::did_change_favicon(Gfx::ShareableBitmap const& favicon)

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -191,6 +191,16 @@ void WebContentClient::did_request_prompt(String const& message, String const& d
     m_view.notify_server_did_request_prompt({}, message, default_);
 }
 
+void WebContentClient::did_request_accept_dialog()
+{
+    m_view.notify_server_did_request_accept_dialog({});
+}
+
+void WebContentClient::did_request_dismiss_dialog()
+{
+    m_view.notify_server_did_request_dismiss_dialog({});
+}
+
 void WebContentClient::did_change_favicon(Gfx::ShareableBitmap const& favicon)
 {
     if (!favicon.is_valid()) {

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -60,6 +60,7 @@ private:
     virtual void did_request_alert(String const&) override;
     virtual void did_request_confirm(String const&) override;
     virtual void did_request_prompt(String const&, String const&) override;
+    virtual void did_request_set_prompt_text(String const& message) override;
     virtual void did_request_accept_dialog() override;
     virtual void did_request_dismiss_dialog() override;
     virtual Messages::WebContentClient::DidRequestAllCookiesResponse did_request_all_cookies(AK::URL const&) override;

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -58,8 +58,8 @@ private:
     virtual void did_get_js_console_messages(i32 start_index, Vector<String> const& message_types, Vector<String> const& messages) override;
     virtual void did_change_favicon(Gfx::ShareableBitmap const&) override;
     virtual void did_request_alert(String const&) override;
-    virtual Messages::WebContentClient::DidRequestConfirmResponse did_request_confirm(String const&) override;
-    virtual Messages::WebContentClient::DidRequestPromptResponse did_request_prompt(String const&, String const&) override;
+    virtual void did_request_confirm(String const&) override;
+    virtual void did_request_prompt(String const&, String const&) override;
     virtual Messages::WebContentClient::DidRequestAllCookiesResponse did_request_all_cookies(AK::URL const&) override;
     virtual Messages::WebContentClient::DidRequestNamedCookieResponse did_request_named_cookie(AK::URL const&, String const&) override;
     virtual Messages::WebContentClient::DidRequestCookieResponse did_request_cookie(AK::URL const&, u8) override;

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -60,6 +60,8 @@ private:
     virtual void did_request_alert(String const&) override;
     virtual void did_request_confirm(String const&) override;
     virtual void did_request_prompt(String const&, String const&) override;
+    virtual void did_request_accept_dialog() override;
+    virtual void did_request_dismiss_dialog() override;
     virtual Messages::WebContentClient::DidRequestAllCookiesResponse did_request_all_cookies(AK::URL const&) override;
     virtual Messages::WebContentClient::DidRequestNamedCookieResponse did_request_named_cookie(AK::URL const&, String const&) override;
     virtual Messages::WebContentClient::DidRequestCookieResponse did_request_cookie(AK::URL const&, u8) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -576,4 +576,19 @@ void ConnectionFromClient::set_system_visibility_state(bool visible)
             : Web::HTML::VisibilityState::Hidden);
 }
 
+void ConnectionFromClient::alert_closed()
+{
+    m_page_host->alert_closed();
+}
+
+void ConnectionFromClient::confirm_closed(bool accepted)
+{
+    m_page_host->confirm_closed(accepted);
+}
+
+void ConnectionFromClient::prompt_closed(String const& response)
+{
+    m_page_host->prompt_closed(response);
+}
+
 }

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -84,6 +84,10 @@ private:
     virtual void run_javascript(String const&) override;
     virtual void js_console_request_messages(i32) override;
 
+    virtual void alert_closed() override;
+    virtual void confirm_closed(bool accepted) override;
+    virtual void prompt_closed(String const& response) override;
+
     virtual Messages::WebContentServer::TakeDocumentScreenshotResponse take_document_screenshot() override;
 
     virtual Messages::WebContentServer::GetLocalStorageEntriesResponse get_local_storage_entries() override;

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -305,6 +305,21 @@ void PageHost::prompt_closed(String response)
     }
 }
 
+void PageHost::dismiss_dialog()
+{
+    switch (m_pending_dialog) {
+    case PendingDialog::None:
+        break;
+    case PendingDialog::Alert:
+        m_client.async_did_request_accept_dialog();
+        break;
+    case PendingDialog::Confirm:
+    case PendingDialog::Prompt:
+        m_client.async_did_request_dismiss_dialog();
+        break;
+    }
+}
+
 void PageHost::page_did_change_favicon(Gfx::Bitmap const& favicon)
 {
     m_client.async_did_change_favicon(favicon.to_shareable_bitmap());

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -262,6 +262,9 @@ void PageHost::page_did_request_alert(String const& message)
     m_pending_dialog = PendingDialog::Alert;
     m_client.async_did_request_alert(message);
 
+    if (!message.is_empty())
+        m_pending_dialog_text = message;
+
     spin_event_loop_until_dialog_closed(m_client, m_pending_alert_response);
 }
 
@@ -270,6 +273,7 @@ void PageHost::alert_closed()
     if (m_pending_dialog == PendingDialog::Alert) {
         m_pending_dialog = PendingDialog::None;
         m_pending_alert_response = Empty {};
+        m_pending_dialog_text.clear();
     }
 }
 
@@ -277,6 +281,9 @@ bool PageHost::page_did_request_confirm(String const& message)
 {
     m_pending_dialog = PendingDialog::Confirm;
     m_client.async_did_request_confirm(message);
+
+    if (!message.is_empty())
+        m_pending_dialog_text = message;
 
     return spin_event_loop_until_dialog_closed(m_client, m_pending_confirm_response);
 }
@@ -286,6 +293,7 @@ void PageHost::confirm_closed(bool accepted)
     if (m_pending_dialog == PendingDialog::Confirm) {
         m_pending_dialog = PendingDialog::None;
         m_pending_confirm_response = accepted;
+        m_pending_dialog_text.clear();
     }
 }
 
@@ -293,6 +301,9 @@ String PageHost::page_did_request_prompt(String const& message, String const& de
 {
     m_pending_dialog = PendingDialog::Prompt;
     m_client.async_did_request_prompt(message, default_);
+
+    if (!message.is_empty())
+        m_pending_dialog_text = message;
 
     return spin_event_loop_until_dialog_closed(m_client, m_pending_prompt_response);
 }
@@ -302,6 +313,7 @@ void PageHost::prompt_closed(String response)
     if (m_pending_dialog == PendingDialog::Prompt) {
         m_pending_dialog = PendingDialog::None;
         m_pending_prompt_response = move(response);
+        m_pending_dialog_text.clear();
     }
 }
 

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -320,6 +320,19 @@ void PageHost::dismiss_dialog()
     }
 }
 
+void PageHost::accept_dialog()
+{
+    switch (m_pending_dialog) {
+    case PendingDialog::None:
+        break;
+    case PendingDialog::Alert:
+    case PendingDialog::Confirm:
+    case PendingDialog::Prompt:
+        m_client.async_did_request_accept_dialog();
+        break;
+    }
+}
+
 void PageHost::page_did_change_favicon(Gfx::Bitmap const& favicon)
 {
     m_client.async_did_change_favicon(favicon.to_shareable_bitmap());

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -55,6 +55,7 @@ public:
     };
     bool has_pending_dialog() const { return m_pending_dialog != PendingDialog::None; }
     PendingDialog pending_dialog() const { return m_pending_dialog; }
+    Optional<String> const& pending_dialog_text() const { return m_pending_dialog_text; }
     void dismiss_dialog();
     void accept_dialog();
 
@@ -112,6 +113,7 @@ private:
     RefPtr<WebDriverConnection> m_webdriver;
 
     PendingDialog m_pending_dialog { PendingDialog::None };
+    Optional<String> m_pending_dialog_text;
     Optional<Empty> m_pending_alert_response;
     Optional<bool> m_pending_confirm_response;
     Optional<String> m_pending_prompt_response;

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -43,6 +43,19 @@ public:
 
     ErrorOr<void> connect_to_webdriver(String const& webdriver_ipc_path);
 
+    void alert_closed();
+    void confirm_closed(bool accepted);
+    void prompt_closed(String response);
+
+    enum class PendingDialog {
+        None,
+        Alert,
+        Confirm,
+        Prompt,
+    };
+    bool has_pending_dialog() const { return m_pending_dialog != PendingDialog::None; }
+    PendingDialog pending_dialog() const { return m_pending_dialog; }
+
 private:
     // ^PageClient
     virtual Gfx::Palette palette() const override;
@@ -95,6 +108,11 @@ private:
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
 
     RefPtr<WebDriverConnection> m_webdriver;
+
+    PendingDialog m_pending_dialog { PendingDialog::None };
+    Optional<Empty> m_pending_alert_response;
+    Optional<bool> m_pending_confirm_response;
+    Optional<String> m_pending_prompt_response;
 };
 
 }

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -55,6 +55,7 @@ public:
     };
     bool has_pending_dialog() const { return m_pending_dialog != PendingDialog::None; }
     PendingDialog pending_dialog() const { return m_pending_dialog; }
+    void dismiss_dialog();
 
 private:
     // ^PageClient

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -56,6 +56,7 @@ public:
     bool has_pending_dialog() const { return m_pending_dialog != PendingDialog::None; }
     PendingDialog pending_dialog() const { return m_pending_dialog; }
     void dismiss_dialog();
+    void accept_dialog();
 
 private:
     // ^PageClient

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -32,6 +32,7 @@ endpoint WebContentClient
     did_request_alert(String message) =|
     did_request_confirm(String message) =|
     did_request_prompt(String message, String default_) =|
+    did_request_set_prompt_text(String message) =|
     did_request_accept_dialog() =|
     did_request_dismiss_dialog() =|
     did_get_source(URL url, String source) =|

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -29,9 +29,9 @@ endpoint WebContentClient
     did_request_context_menu(Gfx::IntPoint content_position) =|
     did_request_link_context_menu(Gfx::IntPoint content_position, URL url, String target, unsigned modifiers) =|
     did_request_image_context_menu(Gfx::IntPoint content_position, URL url, String target, unsigned modifiers, Gfx::ShareableBitmap bitmap) =|
-    did_request_alert(String message) => ()
-    did_request_confirm(String message) => (bool result)
-    did_request_prompt(String message, String default_) => (String response)
+    did_request_alert(String message) =|
+    did_request_confirm(String message) =|
+    did_request_prompt(String message, String default_) =|
     did_get_source(URL url, String source) =|
     did_get_dom_tree(String dom_tree) =|
     did_get_dom_node_properties(i32 node_id, String specified_style, String computed_style, String custom_properties, String node_box_sizing_json) =|

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -32,6 +32,8 @@ endpoint WebContentClient
     did_request_alert(String message) =|
     did_request_confirm(String message) =|
     did_request_prompt(String message, String default_) =|
+    did_request_accept_dialog() =|
+    did_request_dismiss_dialog() =|
     did_get_source(URL url, String source) =|
     did_get_dom_tree(String dom_tree) =|
     did_get_dom_node_properties(i32 node_id, String specified_style, String computed_style, String custom_properties, String node_box_sizing_json) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -65,4 +65,8 @@ endpoint WebContentServer
     handle_file_return(i32 error, Optional<IPC::File> file, i32 request_id) =|
 
     set_system_visibility_state(bool visible) =|
+
+    alert_closed() =|
+    confirm_closed(bool accepted) =|
+    prompt_closed(String response) =|
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -46,6 +46,7 @@ endpoint WebDriverClient {
     dismiss_alert() => (Web::WebDriver::Response response)
     accept_alert() => (Web::WebDriver::Response response)
     get_alert_text() => (Web::WebDriver::Response response)
+    send_alert_text(JsonValue payload) => (Web::WebDriver::Response response)
     take_screenshot() => (Web::WebDriver::Response response)
     take_element_screenshot(String element_id) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -43,6 +43,7 @@ endpoint WebDriverClient {
     add_cookie(JsonValue payload) => (Web::WebDriver::Response response)
     delete_cookie(String name) => (Web::WebDriver::Response response)
     delete_all_cookies() => (Web::WebDriver::Response response)
+    dismiss_alert() => (Web::WebDriver::Response response)
     take_screenshot() => (Web::WebDriver::Response response)
     take_element_screenshot(String element_id) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -45,6 +45,7 @@ endpoint WebDriverClient {
     delete_all_cookies() => (Web::WebDriver::Response response)
     dismiss_alert() => (Web::WebDriver::Response response)
     accept_alert() => (Web::WebDriver::Response response)
+    get_alert_text() => (Web::WebDriver::Response response)
     take_screenshot() => (Web::WebDriver::Response response)
     take_element_screenshot(String element_id) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -44,6 +44,7 @@ endpoint WebDriverClient {
     delete_cookie(String name) => (Web::WebDriver::Response response)
     delete_all_cookies() => (Web::WebDriver::Response response)
     dismiss_alert() => (Web::WebDriver::Response response)
+    accept_alert() => (Web::WebDriver::Response response)
     take_screenshot() => (Web::WebDriver::Response response)
     take_element_screenshot(String element_id) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1343,6 +1343,23 @@ Messages::WebDriverClient::DeleteAllCookiesResponse WebDriverConnection::delete_
     return JsonValue {};
 }
 
+// 16.1 Dismiss Alert, https://w3c.github.io/webdriver/#dismiss-alert
+Messages::WebDriverClient::DismissAlertResponse WebDriverConnection::dismiss_alert()
+{
+    // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
+    TRY(ensure_open_top_level_browsing_context());
+
+    // 2. If there is no current user prompt, return error with error code no such alert.
+    if (!m_page_host.has_pending_dialog())
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchAlert, "No user dialog is currently open"sv);
+
+    // 3. Dismiss the current user prompt.
+    m_page_host.dismiss_dialog();
+
+    // 4. Return success with data null.
+    return JsonValue {};
+}
+
 // 17.1 Take Screenshot, https://w3c.github.io/webdriver/#take-screenshot
 Messages::WebDriverClient::TakeScreenshotResponse WebDriverConnection::take_screenshot()
 {

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -322,7 +322,10 @@ Messages::WebDriverClient::NavigateToResponse WebDriverConnection::navigate_to(J
     URL url(payload.as_object().get_ptr("url"sv)->as_string());
 
     // FIXME: 3. If url is not an absolute URL or is not an absolute URL with fragment or not a local scheme, return error with error code invalid argument.
-    // FIXME: 4. Handle any user prompts and return its value if it is an error.
+
+    // 4. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
+
     // FIXME: 5. Let current URL be the current top-level browsing context’s active document’s URL.
     // FIXME: 6. If current URL and url do not have the same absolute URL:
     // FIXME:     a. If timer has not been started, start a timer. If this algorithm has not completed before timer reaches the session’s session page load timeout in milliseconds, return an error with error code timeout.
@@ -348,7 +351,8 @@ Messages::WebDriverClient::GetCurrentUrlResponse WebDriverConnection::get_curren
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let url be the serialization of the current top-level browsing context’s active document’s document URL.
     auto url = m_page_host.page().top_level_browsing_context().active_document()->url().to_string();
@@ -363,7 +367,8 @@ Messages::WebDriverClient::BackResponse WebDriverConnection::back()
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Traverse the history by a delta –1 for the current browsing context.
     m_web_content_client.async_did_request_navigate_back();
@@ -381,7 +386,8 @@ Messages::WebDriverClient::ForwardResponse WebDriverConnection::forward()
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Traverse the history by a delta 1 for the current browsing context.
     m_web_content_client.async_did_request_navigate_forward();
@@ -399,7 +405,8 @@ Messages::WebDriverClient::RefreshResponse WebDriverConnection::refresh()
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Initiate an overridden reload of the current top-level browsing context’s active document.
     m_web_content_client.async_did_request_refresh();
@@ -419,7 +426,8 @@ Messages::WebDriverClient::GetTitleResponse WebDriverConnection::get_title()
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let title be the initial value of the title IDL attribute of the current top-level browsing context's active document.
     auto title = m_page_host.page().top_level_browsing_context().active_document()->title();
@@ -444,7 +452,8 @@ Messages::WebDriverClient::CloseWindowResponse WebDriverConnection::close_window
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Close the current top-level browsing context.
     m_page_host.page().top_level_browsing_context().close();
@@ -478,7 +487,8 @@ Messages::WebDriverClient::GetWindowRectResponse WebDriverConnection::get_window
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Return success with data set to the WindowRect object for the current top-level browsing context.
     return serialize_rect(compute_window_rect(m_page_host.page()));
@@ -533,7 +543,9 @@ Messages::WebDriverClient::SetWindowRectResponse WebDriverConnection::set_window
     // 8. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 9. Handle any user prompts and return its value if it is an error.
+    // 9. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
+
     // FIXME: 10. Fully exit fullscreen.
 
     // 11. Restore the window.
@@ -572,7 +584,9 @@ Messages::WebDriverClient::MaximizeWindowResponse WebDriverConnection::maximize_
     // 2. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 3. Handle any user prompts and return its value if it is an error.
+    // 3. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
+
     // FIXME: 4. Fully exit fullscreen.
 
     // 5. Restore the window.
@@ -593,7 +607,9 @@ Messages::WebDriverClient::MinimizeWindowResponse WebDriverConnection::minimize_
     // 2. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 3. Handle any user prompts and return its value if it is an error.
+    // 3. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
+
     // FIXME: 4. Fully exit fullscreen.
 
     // 5. Iconify the window.
@@ -611,7 +627,8 @@ Messages::WebDriverClient::FullscreenWindowResponse WebDriverConnection::fullscr
     // 2. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 3. Handle any user prompts and return its value if it is an error.
+    // 3. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 4. Restore the window.
     restore_the_window();
@@ -643,7 +660,8 @@ Messages::WebDriverClient::FindElementResponse WebDriverConnection::find_element
     // 5. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 6. Handle any user prompts and return its value if it is an error.
+    // 6. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 7. Let start node be the current browsing context’s document element.
     auto* start_node = m_page_host.page().top_level_browsing_context().active_document();
@@ -680,7 +698,8 @@ Messages::WebDriverClient::FindElementsResponse WebDriverConnection::find_elemen
     // 5. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 6. Handle any user prompts and return its value if it is an error.
+    // 6. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 7. Let start node be the current browsing context’s document element.
     auto* start_node = m_page_host.page().top_level_browsing_context().active_document();
@@ -711,7 +730,8 @@ Messages::WebDriverClient::FindElementFromElementResponse WebDriverConnection::f
     // 5. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 6. Handle any user prompts and return its value if it is an error.
+    // 6. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 7. Let start node be the result of trying to get a known connected element with url variable element id.
     auto* start_node = TRY(get_known_connected_element(element_id));
@@ -744,7 +764,8 @@ Messages::WebDriverClient::FindElementsFromElementResponse WebDriverConnection::
     // 5. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 6. Handle any user prompts and return its value if it is an error.
+    // 6. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 7. Let start node be the result of trying to get a known connected element with url variable element id.
     auto* start_node = TRY(get_known_connected_element(element_id));
@@ -771,7 +792,8 @@ Messages::WebDriverClient::FindElementFromShadowRootResponse WebDriverConnection
     // 5. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 6. Handle any user prompts and return its value if it is an error.
+    // 6. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 7. Let start node be the result of trying to get a known shadow root with url variable shadow id.
     auto* start_node = TRY(get_known_shadow_root(shadow_id));
@@ -804,7 +826,8 @@ Messages::WebDriverClient::FindElementsFromShadowRootResponse WebDriverConnectio
     // 5. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 6. Handle any user prompts and return its value if it is an error.
+    // 6. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 7. Let start node be the result of trying to get a known shadow root with url variable shadow id.
     auto* start_node = TRY(get_known_shadow_root(shadow_id));
@@ -819,7 +842,8 @@ Messages::WebDriverClient::GetActiveElementResponse WebDriverConnection::get_act
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let active element be the active element of the current browsing context’s document element.
     auto* active_element = m_page_host.page().top_level_browsing_context().active_document()->active_element();
@@ -838,7 +862,8 @@ Messages::WebDriverClient::GetElementShadowRootResponse WebDriverConnection::get
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let element be the result of trying to get a known connected element with url variable element id.
     auto* element = TRY(get_known_connected_element(element_id));
@@ -863,7 +888,8 @@ Messages::WebDriverClient::IsElementSelectedResponse WebDriverConnection::is_ele
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let element be the result of trying to get a known connected element with url variable element id.
     auto* element = TRY(get_known_connected_element(element_id));
@@ -898,7 +924,8 @@ Messages::WebDriverClient::GetElementAttributeResponse WebDriverConnection::get_
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let element be the result of trying to get a known connected element with url variable element id.
     auto* element = TRY(get_known_connected_element(element_id));
@@ -930,7 +957,8 @@ Messages::WebDriverClient::GetElementPropertyResponse WebDriverConnection::get_e
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let element be the result of trying to get a known connected element with url variable element id.
     auto* element = TRY(get_known_connected_element(element_id));
@@ -960,7 +988,8 @@ Messages::WebDriverClient::GetElementCssValueResponse WebDriverConnection::get_e
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let element be the result of trying to get a known connected element with url variable element id.
     auto* element = TRY(get_known_connected_element(element_id));
@@ -992,7 +1021,8 @@ Messages::WebDriverClient::GetElementTextResponse WebDriverConnection::get_eleme
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let element be the result of trying to get a known connected element with url variable element id.
     auto* element = TRY(get_known_connected_element(element_id));
@@ -1010,7 +1040,8 @@ Messages::WebDriverClient::GetElementTagNameResponse WebDriverConnection::get_el
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let element be the result of trying to get a known connected element with url variable element id.
     auto* element = TRY(get_known_connected_element(element_id));
@@ -1028,7 +1059,8 @@ Messages::WebDriverClient::GetElementRectResponse WebDriverConnection::get_eleme
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let element be the result of trying to get a known connected element with url variable element id.
     auto* element = TRY(get_known_connected_element(element_id));
@@ -1058,7 +1090,8 @@ Messages::WebDriverClient::IsElementEnabledResponse WebDriverConnection::is_elem
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let element be the result of trying to get a known connected element with url variable element id.
     auto* element = TRY(get_known_connected_element(element_id));
@@ -1083,7 +1116,8 @@ Messages::WebDriverClient::GetSourceResponse WebDriverConnection::get_source()
     // 1. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     auto* document = m_page_host.page().top_level_browsing_context().active_document();
     Optional<String> source;
@@ -1340,7 +1374,8 @@ Messages::WebDriverClient::TakeElementScreenshotResponse WebDriverConnection::ta
     // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
 
-    // FIXME: 2. Handle any user prompts and return its value if it is an error.
+    // 2. Handle any user prompts and return its value if it is an error.
+    TRY(handle_any_user_prompts());
 
     // 3. Let element be the result of trying to get a known connected element with url variable element id.
     auto* element = TRY(get_known_connected_element(element_id));
@@ -1372,6 +1407,40 @@ ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::ensure_open_top_level_
     // A browsing context is said to be no longer open if it has been discarded.
     if (m_page_host.page().top_level_browsing_context().has_been_discarded())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchWindow, "Window not found"sv);
+    return {};
+}
+
+// https://w3c.github.io/webdriver/#dfn-handle-any-user-prompts
+ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::handle_any_user_prompts()
+{
+    // 1. If there is no current user prompt, abort these steps and return success.
+    if (!m_page_host.has_pending_dialog())
+        return {};
+
+    // 2. Perform the following substeps based on the current session’s user prompt handler:
+
+    // FIXME: The user prompt handler is a capability-level configuration, which we have no support
+    //        for yet. It defaults to "dismiss and notify", so that is all that is handled here.
+
+    // -> dismiss state
+    //    Dismiss the current user prompt.
+    // -> accept state
+    //    Accept the current user prompt.
+    // -> dismiss and notify state
+    if (true) {
+        // Dismiss the current user prompt.
+        m_page_host.dismiss_dialog();
+
+        // Return an annotated unexpected alert open error.
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnexpectedAlertOpen, "A user dialog is open"sv);
+    }
+    // -> accept and notify state
+    //    Accept the current user prompt.
+    //    Return an annotated unexpected alert open error.
+    // -> ignore state
+    //     Return an annotated unexpected alert open error.
+
+    // 3. Return success.
     return {};
 }
 

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1360,6 +1360,23 @@ Messages::WebDriverClient::DismissAlertResponse WebDriverConnection::dismiss_ale
     return JsonValue {};
 }
 
+// 16.2 Accept Alert, https://w3c.github.io/webdriver/#accept-alert
+Messages::WebDriverClient::AcceptAlertResponse WebDriverConnection::accept_alert()
+{
+    // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
+    TRY(ensure_open_top_level_browsing_context());
+
+    // 2. If there is no current user prompt, return error with error code no such alert.
+    if (!m_page_host.has_pending_dialog())
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchAlert, "No user dialog is currently open"sv);
+
+    // 3. Accept the current user prompt.
+    m_page_host.accept_dialog();
+
+    // 4. Return success with data null.
+    return JsonValue {};
+}
+
 // 17.1 Take Screenshot, https://w3c.github.io/webdriver/#take-screenshot
 Messages::WebDriverClient::TakeScreenshotResponse WebDriverConnection::take_screenshot()
 {

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1377,6 +1377,25 @@ Messages::WebDriverClient::AcceptAlertResponse WebDriverConnection::accept_alert
     return JsonValue {};
 }
 
+// 16.3 Get Alert Text, https://w3c.github.io/webdriver/#get-alert-text
+Messages::WebDriverClient::GetAlertTextResponse WebDriverConnection::get_alert_text()
+{
+    // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
+    TRY(ensure_open_top_level_browsing_context());
+
+    // 2. If there is no current user prompt, return error with error code no such alert.
+    if (!m_page_host.has_pending_dialog())
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchAlert, "No user dialog is currently open"sv);
+
+    // 3. Let message be the text message associated with the current user prompt, or otherwise be null.
+    auto const& message = m_page_host.pending_dialog_text();
+
+    // 4. Return success with data message.
+    if (message.has_value())
+        return *message;
+    return JsonValue {};
+}
+
 // 17.1 Take Screenshot, https://w3c.github.io/webdriver/#take-screenshot
 Messages::WebDriverClient::TakeScreenshotResponse WebDriverConnection::take_screenshot()
 {

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -78,6 +78,7 @@ private:
     virtual Messages::WebDriverClient::AddCookieResponse add_cookie(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::DeleteCookieResponse delete_cookie(String const& name) override;
     virtual Messages::WebDriverClient::DeleteAllCookiesResponse delete_all_cookies() override;
+    virtual Messages::WebDriverClient::DismissAlertResponse dismiss_alert() override;
     virtual Messages::WebDriverClient::TakeScreenshotResponse take_screenshot() override;
     virtual Messages::WebDriverClient::TakeElementScreenshotResponse take_element_screenshot(String const& element_id) override;
 

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -82,6 +82,7 @@ private:
     virtual Messages::WebDriverClient::TakeElementScreenshotResponse take_element_screenshot(String const& element_id) override;
 
     ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();
+    ErrorOr<void, Web::WebDriver::Error> handle_any_user_prompts();
     void restore_the_window();
     Gfx::IntRect maximize_the_window();
     Gfx::IntRect iconify_the_window();

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -80,6 +80,7 @@ private:
     virtual Messages::WebDriverClient::DeleteAllCookiesResponse delete_all_cookies() override;
     virtual Messages::WebDriverClient::DismissAlertResponse dismiss_alert() override;
     virtual Messages::WebDriverClient::AcceptAlertResponse accept_alert() override;
+    virtual Messages::WebDriverClient::GetAlertTextResponse get_alert_text() override;
     virtual Messages::WebDriverClient::TakeScreenshotResponse take_screenshot() override;
     virtual Messages::WebDriverClient::TakeElementScreenshotResponse take_element_screenshot(String const& element_id) override;
 

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -81,6 +81,7 @@ private:
     virtual Messages::WebDriverClient::DismissAlertResponse dismiss_alert() override;
     virtual Messages::WebDriverClient::AcceptAlertResponse accept_alert() override;
     virtual Messages::WebDriverClient::GetAlertTextResponse get_alert_text() override;
+    virtual Messages::WebDriverClient::SendAlertTextResponse send_alert_text(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::TakeScreenshotResponse take_screenshot() override;
     virtual Messages::WebDriverClient::TakeElementScreenshotResponse take_element_screenshot(String const& element_id) override;
 

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -79,6 +79,7 @@ private:
     virtual Messages::WebDriverClient::DeleteCookieResponse delete_cookie(String const& name) override;
     virtual Messages::WebDriverClient::DeleteAllCookiesResponse delete_all_cookies() override;
     virtual Messages::WebDriverClient::DismissAlertResponse dismiss_alert() override;
+    virtual Messages::WebDriverClient::AcceptAlertResponse accept_alert() override;
     virtual Messages::WebDriverClient::TakeScreenshotResponse take_screenshot() override;
     virtual Messages::WebDriverClient::TakeElementScreenshotResponse take_element_screenshot(String const& element_id) override;
 

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -548,6 +548,15 @@ Web::WebDriver::Response Client::dismiss_alert(Web::WebDriver::Parameters parame
     return session->web_content_connection().dismiss_alert();
 }
 
+// 16.2 Accept Alert, https://w3c.github.io/webdriver/#accept-alert
+// POST /session/{session id}/alert/accept
+Web::WebDriver::Response Client::accept_alert(Web::WebDriver::Parameters parameters, JsonValue)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/alert/accept");
+    auto* session = TRY(find_session_with_id(parameters[0]));
+    return session->web_content_connection().accept_alert();
+}
+
 // 17.1 Take Screenshot, https://w3c.github.io/webdriver/#take-screenshot
 // GET /session/{session id}/screenshot
 Web::WebDriver::Response Client::take_screenshot(Web::WebDriver::Parameters parameters, JsonValue)

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -539,6 +539,15 @@ Web::WebDriver::Response Client::delete_all_cookies(Web::WebDriver::Parameters p
     return session->web_content_connection().delete_all_cookies();
 }
 
+// 16.1 Dismiss Alert, https://w3c.github.io/webdriver/#dismiss-alert
+// POST /session/{session id}/alert/dismiss
+Web::WebDriver::Response Client::dismiss_alert(Web::WebDriver::Parameters parameters, JsonValue)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/alert/dismiss");
+    auto* session = TRY(find_session_with_id(parameters[0]));
+    return session->web_content_connection().dismiss_alert();
+}
+
 // 17.1 Take Screenshot, https://w3c.github.io/webdriver/#take-screenshot
 // GET /session/{session id}/screenshot
 Web::WebDriver::Response Client::take_screenshot(Web::WebDriver::Parameters parameters, JsonValue)

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -566,6 +566,15 @@ Web::WebDriver::Response Client::get_alert_text(Web::WebDriver::Parameters param
     return session->web_content_connection().get_alert_text();
 }
 
+// 16.4 Send Alert Text, https://w3c.github.io/webdriver/#send-alert-text
+// POST /session/{session id}/alert/text
+Web::WebDriver::Response Client::send_alert_text(Web::WebDriver::Parameters parameters, JsonValue payload)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/alert/text");
+    auto* session = TRY(find_session_with_id(parameters[0]));
+    return session->web_content_connection().send_alert_text(payload);
+}
+
 // 17.1 Take Screenshot, https://w3c.github.io/webdriver/#take-screenshot
 // GET /session/{session id}/screenshot
 Web::WebDriver::Response Client::take_screenshot(Web::WebDriver::Parameters parameters, JsonValue)

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -557,6 +557,15 @@ Web::WebDriver::Response Client::accept_alert(Web::WebDriver::Parameters paramet
     return session->web_content_connection().accept_alert();
 }
 
+// 16.3 Get Alert Text, https://w3c.github.io/webdriver/#get-alert-text
+// GET /session/{session id}/alert/text
+Web::WebDriver::Response Client::get_alert_text(Web::WebDriver::Parameters parameters, JsonValue)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/alert/text");
+    auto* session = TRY(find_session_with_id(parameters[0]));
+    return session->web_content_connection().get_alert_text();
+}
+
 // 17.1 Take Screenshot, https://w3c.github.io/webdriver/#take-screenshot
 // GET /session/{session id}/screenshot
 Web::WebDriver::Response Client::take_screenshot(Web::WebDriver::Parameters parameters, JsonValue)

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -79,6 +79,7 @@ private:
     virtual Web::WebDriver::Response dismiss_alert(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response accept_alert(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response get_alert_text(Web::WebDriver::Parameters parameters, JsonValue payload) override;
+    virtual Web::WebDriver::Response send_alert_text(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response take_screenshot(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response take_element_screenshot(Web::WebDriver::Parameters parameters, JsonValue payload) override;
 

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -76,6 +76,7 @@ private:
     virtual Web::WebDriver::Response add_cookie(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response delete_cookie(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response delete_all_cookies(Web::WebDriver::Parameters parameters, JsonValue payload) override;
+    virtual Web::WebDriver::Response dismiss_alert(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response take_screenshot(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response take_element_screenshot(Web::WebDriver::Parameters parameters, JsonValue payload) override;
 

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -77,6 +77,7 @@ private:
     virtual Web::WebDriver::Response delete_cookie(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response delete_all_cookies(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response dismiss_alert(Web::WebDriver::Parameters parameters, JsonValue payload) override;
+    virtual Web::WebDriver::Response accept_alert(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response take_screenshot(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response take_element_screenshot(Web::WebDriver::Parameters parameters, JsonValue payload) override;
 

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -78,6 +78,7 @@ private:
     virtual Web::WebDriver::Response delete_all_cookies(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response dismiss_alert(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response accept_alert(Web::WebDriver::Parameters parameters, JsonValue payload) override;
+    virtual Web::WebDriver::Response get_alert_text(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response take_screenshot(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response take_element_screenshot(Web::WebDriver::Parameters parameters, JsonValue payload) override;
 


### PR DESCRIPTION
This first changes the way we "pause" the event loop while waiting for a dialog to close; instead of blocking everything, we now just block the HTML event loop (so things like JS can't run), but allow the IPC event loop to continue. This lets the WebDriver endpoints interact with dialogs while they are open.

Ladybird counterpart: https://github.com/SerenityOS/ladybird/pull/129

[Screencast from 2022-11-16 09-02-17.webm](https://user-images.githubusercontent.com/5600524/202202337-6aeb0bf4-bf5d-422a-a145-06e9d69dde00.webm)

Ref #15551