### PR TITLE
LibWeb: Add null checks before derefencing Bitmaps in ImageStyleValue

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1714,22 +1714,22 @@ bool ImageStyleValue::equals(StyleValue const& other) const
 
 Optional<int> ImageStyleValue::natural_width() const
 {
-    if (resource())
-        return bitmap(0)->width();
+    if (auto* b = bitmap(0); b != nullptr)
+        return b->width();
     return {};
 }
 
 Optional<int> ImageStyleValue::natural_height() const
 {
-    if (resource())
-        return bitmap(0)->height();
+    if (auto* b = bitmap(0); b != nullptr)
+        return b->height();
     return {};
 }
 
 void ImageStyleValue::paint(PaintContext& context, Gfx::IntRect const& dest_rect, CSS::ImageRendering image_rendering) const
 {
-    if (resource())
-        context.painter().draw_scaled_bitmap(dest_rect, *bitmap(m_current_frame_index), bitmap(0)->rect(), 1.0f, to_gfx_scaling_mode(image_rendering));
+    if (auto* b = bitmap(m_current_frame_index); b != nullptr)
+        context.painter().draw_scaled_bitmap(dest_rect, *b, bitmap(0)->rect(), 1.0f, to_gfx_scaling_mode(image_rendering));
 }
 
 static void serialize_color_stop_list(StringBuilder& builder, auto const& color_stop_list)

--- a/Userland/Libraries/LibWeb/Loader/ImageResource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ImageResource.cpp
@@ -48,19 +48,21 @@ void ImageResource::decode_if_needed() const
         return;
 
     auto image = Platform::ImageCodecPlugin::the().decode_image(encoded_data());
+    m_has_attempted_decode = true;
 
-    if (image.has_value()) {
-        m_loop_count = image.value().loop_count;
-        m_animated = image.value().is_animated;
-        m_decoded_frames.resize(image.value().frames.size());
-        for (size_t i = 0; i < m_decoded_frames.size(); ++i) {
-            auto& frame = m_decoded_frames[i];
-            frame.bitmap = image.value().frames[i].bitmap;
-            frame.duration = image.value().frames[i].duration;
-        }
+    if (!image.has_value()) {
+        dbgln("Could not decode image resource {}", url());
+        return;
     }
 
-    m_has_attempted_decode = true;
+    m_loop_count = image.value().loop_count;
+    m_animated = image.value().is_animated;
+    m_decoded_frames.resize(image.value().frames.size());
+    for (size_t i = 0; i < m_decoded_frames.size(); ++i) {
+        auto& frame = m_decoded_frames[i];
+        frame.bitmap = image.value().frames[i].bitmap;
+        frame.duration = image.value().frames[i].duration;
+    }
 }
 
 Gfx::Bitmap const* ImageResource::bitmap(size_t frame_index) const


### PR DESCRIPTION
Loading a Wikipedia's article (sample: https://en.wikipedia.org/wiki/Artemis_1 ) currently crashes due to nullptr dereference inside `ImageStyleWidth::natural_width`. This simply adds a few checks for nullptr

This is a reduced example that causes the crash this PR fixes:

```
<style>
ul {
    list-style-image: url(https://www.shutterstock.com/image-vector/green-check-mark-icon-vector-600w-1242693565.jpg);
}
</style>
<ul><li></li></ul>
```
