### PR TITLE
LibC+LibELF: Share heap blocks between LibC and DynamicLoader

### DIFF
--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -84,6 +84,7 @@ function(serenity_libc target_name fs_name)
     serenity_install_sources()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdlib -fpic")
     add_library(${target_name} SHARED ${SOURCES})
+    target_compile_options(${target_name} PUBLIC -D_SHARED_LIBC)
     install(TARGETS ${target_name} DESTINATION ${CMAKE_INSTALL_LIBDIR})
     set_target_properties(${target_name} PROPERTIES OUTPUT_NAME ${fs_name})
     # Avoid creating a dependency cycle between system libraries and the C++ standard library. This is necessary

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBC_SOURCES
     link.cpp
     locale.cpp
     malloc.cpp
+    malloc_integration.cpp
     math.cpp
     mntent.cpp
     net.cpp
@@ -167,6 +168,8 @@ set_property(
         APPEND
         PROPERTY ADDITIONAL_CLEAN_FILES ${TEMP_OBJ_FILES}
 )
+
+list(REMOVE_ITEM SOURCES malloc.cpp)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nolibc")
 serenity_libc(LibC c)

--- a/Userland/Libraries/LibC/assert.cpp
+++ b/Userland/Libraries/LibC/assert.cpp
@@ -19,7 +19,7 @@ extern bool __stdio_is_initialized;
 
 void __assertion_failed(char const* msg)
 {
-    if (__heap_is_stable) {
+    if (__heap_is_stable()) {
         dbgln("ASSERTION FAILED: {}", msg);
         if (__stdio_is_initialized)
             warnln("ASSERTION FAILED: {}", msg);

--- a/Userland/Libraries/LibC/bits/malloc_integration.h
+++ b/Userland/Libraries/LibC/bits/malloc_integration.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Gunnar Beutner <gunnar@beutner.name>
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+
+#ifdef _SHARED_LIBC
+typedef ErrorOr<void*> (*MallocFunction)(size_t);
+typedef void (*FreeFunction)(void*);
+typedef ErrorOr<void*> (*CallocFunction)(size_t, size_t);
+typedef ErrorOr<void*> (*ReallocFunction)(void*, size_t);
+typedef int (*PosixMemalignFunction)(void**, size_t, size_t);
+typedef ErrorOr<void*> (*AlignedAllocFunction)(size_t, size_t);
+typedef size_t (*MallocSizeFunction)(void const*);
+typedef size_t (*MallocGoodSizeFunction)(size_t);
+typedef void (*SerenityDumpMallocStats)();
+typedef bool (*HeapIsStableFunction)();
+typedef bool (*SetAllocationEnabledFunction)(bool);
+
+extern "C" {
+extern MallocFunction __malloc;
+extern FreeFunction __free;
+extern CallocFunction __calloc;
+extern ReallocFunction __realloc;
+extern PosixMemalignFunction __posix_memalign;
+extern AlignedAllocFunction __aligned_alloc;
+extern MallocSizeFunction __malloc_size;
+extern MallocGoodSizeFunction __malloc_good_size;
+extern SerenityDumpMallocStats __serenity_dump_malloc_stats;
+extern HeapIsStableFunction ___heap_is_stable;
+extern SetAllocationEnabledFunction ___set_allocation_enabled;
+}
+#else
+ErrorOr<void*> __malloc(size_t);
+void __free(void*);
+ErrorOr<void*> __calloc(size_t, size_t);
+ErrorOr<void*> __realloc(void*, size_t);
+int __posix_memalign(void**, size_t, size_t);
+ErrorOr<void*> __aligned_alloc(size_t, size_t);
+size_t __malloc_size(void const*);
+size_t __malloc_good_size(size_t);
+void __serenity_dump_malloc_stats();
+bool ___heap_is_stable();
+bool ___set_allocation_enabled(bool);
+#endif

--- a/Userland/Libraries/LibC/libcinit.cpp
+++ b/Userland/Libraries/LibC/libcinit.cpp
@@ -33,7 +33,9 @@ int* __errno_location()
 void __libc_init()
 {
     __auxiliary_vector_init();
+#ifndef _SHARED_LIBC
     __malloc_init();
+#endif
     __stdio_init();
 }
 

--- a/Userland/Libraries/LibC/malloc.cpp
+++ b/Userland/Libraries/LibC/malloc.cpp
@@ -707,4 +707,16 @@ void serenity_dump_malloc_stats()
     dbgln("number of cold keeps: {}", g_malloc_stats.number_of_cold_keeps);
     dbgln("number of frees: {}", g_malloc_stats.number_of_frees);
 }
+
+bool __set_allocation_enabled(bool new_value)
+{
+#ifndef NO_TLS
+    auto old_state = s_allocation_enabled;
+    s_allocation_enabled = new_value;
+    return old_state;
+#else
+    (void)new_value;
+    return true;
+#endif
+}
 }

--- a/Userland/Libraries/LibC/malloc_integration.cpp
+++ b/Userland/Libraries/LibC/malloc_integration.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022, Gunnar Beutner <gbeutner@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <bits/malloc_integration.h>
+#include <stdlib.h>
+#include <sys/internals.h>
+
+#ifdef _SHARED_LIBC
+// These are filled in by the dynamic loader.
+MallocFunction __malloc;
+FreeFunction __free;
+CallocFunction __calloc;
+ReallocFunction __realloc;
+PosixMemalignFunction __posix_memalign;
+AlignedAllocFunction __aligned_alloc;
+MallocSizeFunction __malloc_size;
+MallocGoodSizeFunction __malloc_good_size;
+SerenityDumpMallocStats __serenity_dump_malloc_stats;
+HeapIsStableFunction ___heap_is_stable;
+SetAllocationEnabledFunction ___set_allocation_enabled;
+#endif
+
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/malloc.html
+void* malloc(size_t size)
+{
+    auto ptr_or_error = __malloc(size);
+    if (ptr_or_error.is_error()) {
+        errno = ptr_or_error.error().code();
+        return nullptr;
+    }
+    return ptr_or_error.value();
+}
+
+void free(void* ptr)
+{
+    __free(ptr);
+}
+
+void* calloc(size_t count, size_t size)
+{
+    auto ptr_or_error = __calloc(count, size);
+    if (ptr_or_error.is_error()) {
+        errno = ptr_or_error.error().code();
+        return nullptr;
+    }
+    return ptr_or_error.value();
+}
+
+int posix_memalign(void** memptr, size_t alignment, size_t size)
+{
+    return __posix_memalign(memptr, alignment, size);
+}
+
+void* aligned_alloc(size_t alignment, size_t size)
+{
+    auto ptr_or_error = __aligned_alloc(alignment, size);
+    if (ptr_or_error.is_error()) {
+        errno = ptr_or_error.error().code();
+        return nullptr;
+    }
+    return ptr_or_error.value();
+}
+
+size_t malloc_size(void const* ptr)
+{
+    return __malloc_size(ptr);
+}
+
+size_t malloc_good_size(size_t size)
+{
+    return __malloc_good_size(size);
+}
+
+void* realloc(void* ptr, size_t size)
+{
+    auto ptr_or_error = __realloc(ptr, size);
+    if (ptr_or_error.is_error()) {
+        errno = ptr_or_error.error().code();
+        return nullptr;
+    }
+    return ptr_or_error.value();
+}
+
+void serenity_dump_malloc_stats()
+{
+    __serenity_dump_malloc_stats();
+}
+
+bool __heap_is_stable()
+{
+    return ___heap_is_stable();
+}
+
+bool __set_allocation_enabled(bool new_value)
+{
+    return ___set_allocation_enabled(new_value);
+}

--- a/Userland/Libraries/LibC/mallocdefs.h
+++ b/Userland/Libraries/LibC/mallocdefs.h
@@ -19,12 +19,6 @@
 static constexpr unsigned short size_classes[] = { 16, 32, 64, 128, 256, 496, 1008, 2032, 4080, 8176, 16368, 32752, 0 };
 static constexpr size_t num_size_classes = (sizeof(size_classes) / sizeof(unsigned short)) - 1;
 
-#ifndef NO_TLS
-extern "C" {
-extern __thread bool s_allocation_enabled;
-}
-#endif
-
 consteval bool check_size_classes_alignment()
 {
     for (size_t i = 0; i < num_size_classes; i++) {

--- a/Userland/Libraries/LibC/mallocdefs.h
+++ b/Userland/Libraries/LibC/mallocdefs.h
@@ -16,7 +16,7 @@
 
 #define PAGE_ROUND_UP(x) ((((size_t)(x)) + PAGE_SIZE - 1) & (~(PAGE_SIZE - 1)))
 
-static constexpr unsigned short size_classes[] = { 16, 32, 64, 128, 256, 496, 1008, 2032, 4080, 8176, 16368, 32752, 0 };
+static constexpr unsigned short size_classes[] = { 16, 32, 64, 128, 256, 496, 1008, 2032, 4080, 8176, 16368, 32736, 0 };
 static constexpr size_t num_size_classes = (sizeof(size_classes) / sizeof(unsigned short)) - 1;
 
 consteval bool check_size_classes_alignment()

--- a/Userland/Libraries/LibC/sys/internals.h
+++ b/Userland/Libraries/LibC/sys/internals.h
@@ -22,6 +22,8 @@ extern bool __stdio_is_initialized;
 extern bool __heap_is_stable;
 extern void* __auxiliary_vector;
 
+extern bool __set_allocation_enabled(bool);
+
 int __cxa_atexit(AtExitFunction exit_function, void* parameter, void* dso_handle);
 void __cxa_finalize(void* dso_handle);
 __attribute__((noreturn)) void __cxa_pure_virtual(void) __attribute__((weak));

--- a/Userland/Libraries/LibC/sys/internals.h
+++ b/Userland/Libraries/LibC/sys/internals.h
@@ -19,9 +19,9 @@ extern void __begin_atexit_locking(void);
 extern void _init(void);
 extern bool __environ_is_malloced;
 extern bool __stdio_is_initialized;
-extern bool __heap_is_stable;
 extern void* __auxiliary_vector;
 
+extern bool __heap_is_stable();
 extern bool __set_allocation_enabled(bool);
 
 int __cxa_atexit(AtExitFunction exit_function, void* parameter, void* dso_handle);


### PR DESCRIPTION
Previously LibC and DynamicLoader had their own separate heaps because DynamicLoader has its own statically linked private copy of LibC. This change updates LibC to forward calls to the allocation functions to the DynamicLoader.

This saves about 448kB of committed pages per process and about 28kB of dirty pages.