### PR TITLE
WindowServer: Reject Super+LMB window move if non-movable child visible

### DIFF
--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -219,6 +219,22 @@ void Window::handle_mouse_event(MouseEvent const& event)
     }
 }
 
+bool Window::has_non_movable_child()
+{
+    bool value = false;
+    if (m_child_windows.is_empty())
+        return value;
+    for (auto& child : m_child_windows) {
+        if (!child)
+            continue;
+        if (!child->is_movable() && child->is_visible()) {
+            child->request_close();
+            value = true;
+        }
+    }
+    return value;
+}
+
 void Window::update_window_menu_items()
 {
     if (!m_window_menu)

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -134,6 +134,7 @@ public:
     bool is_occluded() const { return m_occluded; }
     void set_occluded(bool);
 
+    bool has_non_movable_child();
     bool is_movable() const { return m_type == WindowType::Normal; }
 
     WindowFrame& frame() { return m_frame; }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1223,7 +1223,7 @@ void WindowManager::process_mouse_event_for_window(HitTestResult& result, MouseE
     // First check if we should initiate a move or resize (Super+LMB or Super+RMB).
     // In those cases, the event is swallowed by the window manager.
     if (!blocking_modal_window && window.is_movable()) {
-        if (!window.is_fullscreen() && m_keyboard_modifiers == Mod_Super && event.type() == Event::MouseDown && event.button() == MouseButton::Primary) {
+        if (!window.is_fullscreen() && m_keyboard_modifiers == Mod_Super && event.type() == Event::MouseDown && event.button() == MouseButton::Primary && !window.has_non_movable_child()) {
             start_window_move(window, event);
             return;
         }


### PR DESCRIPTION
This PR fixes the problem seen below, when a ComboBox is awaiting a selection and a Super+LMB move is started on the parent window:

![combobox-problem](https://blog.checksum.fail/images/Screenshot_2022-11-17_11-26-43.png)