### PR TITLE
LibWeb: Fix clicking on links

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -534,7 +534,7 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
     // set to source.
     // FIXME: "navigate" means implementing the navigation algorithm here:
     //        https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
-    hyperlink_element_utils_queue_an_element_task(Task::Source::DOMManipulation, [url_string, &target] {
+    hyperlink_element_utils_queue_an_element_task(Task::Source::DOMManipulation, [url_string, target]() mutable {
         target->loader().load(url_string, FrameLoader::Type::Navigation);
     });
 }


### PR DESCRIPTION
Since ff2f31b LibWeb has segfaulted when clicking on links, as the browsing context (a GCPtr) in the lambda was captured by reference and was out of scope by the time the callback fired.

P.s. I'm not _entirely_ sure why this `const_cast` is required (seems to be something to do with the GCPtr class), but the compiler complains otherwise. 