### PR TITLE
LibJS: Validate TypedArray when calling TypedArray.prototype.values

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -1623,7 +1623,12 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::values)
 {
     auto& realm = *vm.current_realm();
 
+    // 1. Let O be the this value.
     auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // FIXME 2. Perform ? ValidateTypedArray(O).
+
+    // 3. Return CreateArrayIterator(O, value).
     return ArrayIterator::create(realm, typed_array, Object::PropertyKind::Value);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -1624,9 +1624,8 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::values)
     auto& realm = *vm.current_realm();
 
     // 1. Let O be the this value.
-    auto* typed_array = TRY(typed_array_from_this(vm));
-
-    // FIXME 2. Perform ? ValidateTypedArray(O).
+    // 2. Perform ? ValidateTypedArray(O).
+    auto* typed_array = TRY(validate_typed_array_from_this(vm));
 
     // 3. Return CreateArrayIterator(O, value).
     return ArrayIterator::create(realm, typed_array, Object::PropertyKind::Value);


### PR DESCRIPTION
This should get https://github.com/tc39/test262/blob/main/test/built-ins/TypedArray/prototype/values/detached-buffer.js working :)