### PR TITLE
Documentation: Explain how to install gcc-12 on Ubuntu 20.04 (Focal)

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -16,6 +16,14 @@ Optional: `fuse2fs` for [building images without root](https://github.com/Sereni
 On Ubuntu gcc-12 is available in the repositories of 22.04 (Jammy) and later.
 If you are running an older version, you will either need to upgrade, or find an alternative installation source.
 
+On Ubuntu 20.04 (Focal) gcc-12 is not available.
+
+Add the `ubuntu-toolchain-r/test` PPA for WSL Installations or Focal version of Ubuntu.
+
+```console
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+```
+
 Next, update your local package information from this repository:
 
 ```console

--- a/Documentation/BuildInstructionsWindows.md
+++ b/Documentation/BuildInstructionsWindows.md
@@ -51,3 +51,13 @@ following command in an elevated PowerShell session: \
 You may have to reboot after enabling the WHPX feature.
 
 Afterwards you can start the VM with `Meta/serenity.sh run` as usual.
+
+## Note on Microsoft Store Ubuntu
+
+The Microsoft Store does not have the latest versions of Ubuntu.
+
+Please refrence the following section: 
+
+[Prerequisites](BuildInstructions.md#prerequisites).
+
+


### PR DESCRIPTION
Installing gcc-12 on the Ubuntu 20.04 (Focal)
requires the following PPA:

- ubuntu-toolchain-r/test

This commit provides the steps to add the required PPA

The versions of Ubuntu found in the Windows Store are Focal.

Windows Build Instructions are updated to reference the prerequisite.