### PR TITLE
Kernel: Fix includes when building aarch64

### DIFF
--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -24,6 +24,7 @@
 #include <Kernel/CommandLine.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Graphics/Console/BootFramebufferConsole.h>
+#include <Kernel/JailManagement.h>
 #include <Kernel/KSyms.h>
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Panic.h>

--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -8,6 +8,7 @@
 
 #include <AK/Bitmap.h>
 #include <AK/HashMap.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Try.h>
 #include <AK/Vector.h>
 #include <Kernel/Bus/PCI/Controller/HostController.h>

--- a/Kernel/Jail.h
+++ b/Kernel/Jail.h
@@ -16,6 +16,7 @@
 #include <Kernel/KString.h>
 #include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Locking/SpinlockProtected.h>
+#include <Kernel/Process.h>
 
 namespace Kernel {
 


### PR DESCRIPTION
This patch fixes some include problems on aarch64. aarch64 is still currently broken but this will get us back to the underlying problem of FloatExtractor.