### PR TITLE
Kernel+lsirq: Track per-CPU IRQ handler call counts

### DIFF
--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -37,7 +37,7 @@ extern "C" void handle_interrupt(TrapFrame const* const)
 
             auto* handler = s_interrupt_handlers[irq];
             VERIFY(handler);
-            handler->increment_invoking_counter();
+            handler->increment_call_count();
             handler->handle_interrupt(regs);
             handler->eoi();
 

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -35,6 +35,8 @@ struct [[gnu::aligned(16)]] FPUState
 // FIXME: Remove this once we support SMP in aarch64
 extern Processor* g_current_processor;
 
+constexpr size_t MAX_CPU_COUNT = 1;
+
 class Processor {
     void* m_processor_specific_data[static_cast<size_t>(ProcessorSpecificDataID::__Count)];
 

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -61,7 +61,9 @@ struct [[gnu::aligned(64), gnu::packed]] FPUState
 class Processor;
 // Note: We only support 64 processors at most at the moment,
 // so allocate 64 slots of inline capacity in the container.
-using ProcessorContainer = Array<Processor*, 64>;
+
+constexpr size_t MAX_CPU_COUNT = 64;
+using ProcessorContainer = Array<Processor*, MAX_CPU_COUNT>;
 
 class Processor {
     friend class ProcessorInfo;

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -509,7 +509,7 @@ void handle_interrupt(TrapFrame* trap)
         handler = s_interrupt_handler[irq];
     }
     VERIFY(handler);
-    handler->increment_invoking_counter();
+    handler->increment_call_count();
     handler->handle_interrupt(regs);
     handler->eoi();
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Interrupts.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Interrupts.cpp
@@ -36,7 +36,7 @@ ErrorOr<void> SysFSInterrupts::try_generate(KBufferBuilder& builder)
             TRY(obj.add("controller"sv, handler.controller()));
             TRY(obj.add("cpu_handler"sv, 0)); // FIXME: Determine the responsible CPU for each interrupt handler.
             TRY(obj.add("device_sharing"sv, (unsigned)handler.sharing_devices_count()));
-            TRY(obj.add("call_count"sv, (unsigned)handler.get_invoking_count()));
+            TRY(obj.add("call_count"sv, handler.call_count()));
             TRY(obj.finish());
             return {};
         })();

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Interrupts.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Interrupts.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -34,9 +35,12 @@ ErrorOr<void> SysFSInterrupts::try_generate(KBufferBuilder& builder)
             TRY(obj.add("purpose"sv, handler.purpose()));
             TRY(obj.add("interrupt_line"sv, handler.interrupt_number()));
             TRY(obj.add("controller"sv, handler.controller()));
-            TRY(obj.add("cpu_handler"sv, 0)); // FIXME: Determine the responsible CPU for each interrupt handler.
             TRY(obj.add("device_sharing"sv, (unsigned)handler.sharing_devices_count()));
-            TRY(obj.add("call_count"sv, handler.call_count()));
+            auto per_cpu_call_counts = TRY(obj.add_array("per_cpu_call_counts"sv));
+            for (auto call_count : handler.per_cpu_call_counts()) {
+                TRY(per_cpu_call_counts.add(call_count));
+            }
+            TRY(per_cpu_call_counts.finish());
             TRY(obj.finish());
             return {};
         })();

--- a/Kernel/Interrupts/GenericInterruptHandler.cpp
+++ b/Kernel/Interrupts/GenericInterruptHandler.cpp
@@ -67,4 +67,9 @@ void GenericInterruptHandler::change_interrupt_number(u8 number)
     register_generic_interrupt_handler(InterruptManagement::acquire_mapped_interrupt_number(interrupt_number()), *this);
 }
 
+void GenericInterruptHandler::increment_call_count()
+{
+    ++m_call_count;
+}
+
 }

--- a/Kernel/Interrupts/GenericInterruptHandler.cpp
+++ b/Kernel/Interrupts/GenericInterruptHandler.cpp
@@ -67,9 +67,14 @@ void GenericInterruptHandler::change_interrupt_number(u8 number)
     register_generic_interrupt_handler(InterruptManagement::acquire_mapped_interrupt_number(interrupt_number()), *this);
 }
 
+Span<u32 const> GenericInterruptHandler::per_cpu_call_counts() const
+{
+    return m_per_cpu_call_counts.span().slice(0, Processor::count());
+}
+
 void GenericInterruptHandler::increment_call_count()
 {
-    ++m_call_count;
+    ++m_per_cpu_call_counts[Processor::current_id()];
 }
 
 }

--- a/Kernel/Interrupts/GenericInterruptHandler.h
+++ b/Kernel/Interrupts/GenericInterruptHandler.h
@@ -37,7 +37,7 @@ public:
 
     u8 interrupt_number() const { return m_interrupt_number; }
 
-    size_t get_invoking_count() const { return m_invoking_count; }
+    u32 call_count() const { return m_call_count; }
 
     virtual size_t sharing_devices_count() const = 0;
     virtual bool is_shared_handler() const = 0;
@@ -48,10 +48,7 @@ public:
     virtual StringView controller() const = 0;
 
     virtual bool eoi() = 0;
-    ALWAYS_INLINE void increment_invoking_counter()
-    {
-        m_invoking_count++;
-    }
+    void increment_call_count();
 
 protected:
     void change_interrupt_number(u8 number);
@@ -60,7 +57,7 @@ protected:
     void disable_remap() { m_disable_remap = true; }
 
 private:
-    Atomic<u32, AK::MemoryOrder::memory_order_relaxed> m_invoking_count { 0 };
+    Atomic<u32, AK::MemoryOrder::memory_order_relaxed> m_call_count { 0 };
     u8 m_interrupt_number { 0 };
     bool m_disable_remap { false };
     bool m_registered { false };

--- a/Kernel/Interrupts/GenericInterruptHandler.h
+++ b/Kernel/Interrupts/GenericInterruptHandler.h
@@ -37,7 +37,7 @@ public:
 
     u8 interrupt_number() const { return m_interrupt_number; }
 
-    u32 call_count() const { return m_call_count; }
+    Span<u32 const> per_cpu_call_counts() const;
 
     virtual size_t sharing_devices_count() const = 0;
     virtual bool is_shared_handler() const = 0;
@@ -57,7 +57,8 @@ protected:
     void disable_remap() { m_disable_remap = true; }
 
 private:
-    Atomic<u32, AK::MemoryOrder::memory_order_relaxed> m_call_count { 0 };
+    Array<u32, MAX_CPU_COUNT> m_per_cpu_call_counts {};
+
     u8 m_interrupt_number { 0 };
     bool m_disable_remap { false };
     bool m_registered { false };

--- a/Kernel/Interrupts/SharedIRQHandler.cpp
+++ b/Kernel/Interrupts/SharedIRQHandler.cpp
@@ -74,7 +74,7 @@ bool SharedIRQHandler::handle_interrupt(RegisterState const& regs)
     for (auto& handler : m_handlers) {
         dbgln_if(INTERRUPT_DEBUG, "Going for Interrupt Handling @ {}, Shared Interrupt {}", i, interrupt_number());
         if (handler.handle_interrupt(regs)) {
-            handler.increment_invoking_counter();
+            handler.increment_call_count();
             was_handled = true;
         }
         dbgln_if(INTERRUPT_DEBUG, "Going for Interrupt Handling @ {}, Shared Interrupt {} - End", i, interrupt_number());

--- a/Kernel/Interrupts/SpuriousInterruptHandler.cpp
+++ b/Kernel/Interrupts/SpuriousInterruptHandler.cpp
@@ -74,7 +74,7 @@ bool SpuriousInterruptHandler::handle_interrupt(RegisterState const& state)
     if (m_responsible_irq_controller->get_isr() & (1 << interrupt_number())) {
         m_real_irq = true; // remember that we had a real IRQ, when EOI later!
         if (m_real_handler->handle_interrupt(state)) {
-            m_real_handler->increment_invoking_counter();
+            m_real_handler->increment_call_count();
             return true;
         }
         return false;

--- a/Userland/Utilities/lsirq.cpp
+++ b/Userland/Utilities/lsirq.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,17 +21,30 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     TRY(Core::System::pledge("stdio"));
 
-    outln("      CPU0");
     auto file_contents = proc_interrupts->read_all();
     auto json = TRY(JsonValue::from_string(file_contents));
-    json.as_array().for_each([](auto& value) {
+
+    auto cpu_count = json.as_array().at(0).as_object().get("per_cpu_call_counts"sv).as_array().size();
+
+    out("      "sv);
+    for (size_t i = 0; i < cpu_count; ++i) {
+        out("{:>10}", String::formatted("CPU{}", i));
+    }
+    outln("");
+
+    json.as_array().for_each([cpu_count](JsonValue const& value) {
         auto& handler = value.as_object();
         auto purpose = handler.get("purpose"sv).to_string();
         auto interrupt = handler.get("interrupt_line"sv).to_string();
         auto controller = handler.get("controller"sv).to_string();
-        auto call_count = handler.get("call_count"sv).to_string();
+        auto call_counts = handler.get("per_cpu_call_counts"sv).as_array();
 
-        outln("{:>4}: {:10} {:10}  {:30}", interrupt, call_count, controller, purpose);
+        out("{:>4}: ", interrupt);
+
+        for (size_t i = 0; i < cpu_count; ++i)
+            out("{:>10}", call_counts[i].to_string());
+
+        outln("  {:10}  {:30}", controller, purpose);
     });
 
     return 0;


### PR DESCRIPTION
Each `GenericInterruptHandler` now tracks the number of calls that each CPU has serviced.
    
This allows the `lsirq` command line tool to display per-CPU call counts.