### PR TITLE
AK+Everywhere: Return non-const types from Ptr class operators 

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -93,26 +93,17 @@ public:
         return exchange(m_ptr, nullptr);
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL T* ptr()
+    ALWAYS_INLINE RETURNS_NONNULL T* ptr() const
     {
         VERIFY(m_ptr);
         return m_ptr;
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL const T* ptr() const
-    {
-        VERIFY(m_ptr);
-        return m_ptr;
-    }
+    ALWAYS_INLINE RETURNS_NONNULL T* operator->() const { return ptr(); }
 
-    ALWAYS_INLINE RETURNS_NONNULL T* operator->() { return ptr(); }
-    ALWAYS_INLINE RETURNS_NONNULL const T* operator->() const { return ptr(); }
+    ALWAYS_INLINE T& operator*() const { return *ptr(); }
 
-    ALWAYS_INLINE T& operator*() { return *ptr(); }
-    ALWAYS_INLINE const T& operator*() const { return *ptr(); }
-
-    ALWAYS_INLINE RETURNS_NONNULL operator const T*() const { return ptr(); }
-    ALWAYS_INLINE RETURNS_NONNULL operator T*() { return ptr(); }
+    ALWAYS_INLINE RETURNS_NONNULL operator T*() const { return ptr(); }
 
     operator bool() const = delete;
     bool operator!() const = delete;

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -156,47 +156,27 @@ public:
         return *ptr;
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL T* ptr()
-    {
-        return as_nonnull_ptr();
-    }
-    ALWAYS_INLINE RETURNS_NONNULL T const* ptr() const
+    ALWAYS_INLINE RETURNS_NONNULL T* ptr() const
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL T* operator->()
-    {
-        return as_nonnull_ptr();
-    }
-    ALWAYS_INLINE RETURNS_NONNULL T const* operator->() const
+    ALWAYS_INLINE RETURNS_NONNULL T* operator->() const
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE T& operator*()
-    {
-        return *as_nonnull_ptr();
-    }
-    ALWAYS_INLINE T const& operator*() const
+    ALWAYS_INLINE T& operator*() const
     {
         return *as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL operator T*()
-    {
-        return as_nonnull_ptr();
-    }
-    ALWAYS_INLINE RETURNS_NONNULL operator T const*() const
+    ALWAYS_INLINE RETURNS_NONNULL operator T*() const
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE operator T&()
-    {
-        return *as_nonnull_ptr();
-    }
-    ALWAYS_INLINE operator T const&() const
+    ALWAYS_INLINE operator T&() const
     {
         return *as_nonnull_ptr();
     }
@@ -217,7 +197,8 @@ public:
 
     bool operator==(NonnullRefPtr const& other) const { return m_ptr == other.m_ptr; }
 
-    bool operator==(NonnullRefPtr& other) { return m_ptr == other.m_ptr; }
+    template<typename RawPtr>
+    bool operator==(RawPtr other) const requires(IsPointer<RawPtr>) { return m_ptr == other; }
 
     // clang-format off
 private:

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -131,35 +131,21 @@ public:
         return NonnullOwnPtr<U>(NonnullOwnPtr<U>::Adopt, static_cast<U&>(*leak_ptr()));
     }
 
-    T* ptr() { return m_ptr; }
-    const T* ptr() const { return m_ptr; }
+    T* ptr() const { return m_ptr; }
 
-    T* operator->()
+    T* operator->() const
     {
         VERIFY(m_ptr);
         return m_ptr;
     }
 
-    const T* operator->() const
-    {
-        VERIFY(m_ptr);
-        return m_ptr;
-    }
-
-    T& operator*()
+    T& operator*() const
     {
         VERIFY(m_ptr);
         return *m_ptr;
     }
 
-    const T& operator*() const
-    {
-        VERIFY(m_ptr);
-        return *m_ptr;
-    }
-
-    operator const T*() const { return m_ptr; }
-    operator T*() { return m_ptr; }
+    operator T*() const { return m_ptr; }
 
     operator bool() { return !!m_ptr; }
 

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -231,31 +231,19 @@ public:
         return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *ptr);
     }
 
-    ALWAYS_INLINE T* ptr() { return as_ptr(); }
-    ALWAYS_INLINE T const* ptr() const { return as_ptr(); }
+    ALWAYS_INLINE T* ptr() const { return as_ptr(); }
 
-    ALWAYS_INLINE T* operator->()
+    ALWAYS_INLINE T* operator->() const
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE T const* operator->() const
-    {
-        return as_nonnull_ptr();
-    }
-
-    ALWAYS_INLINE T& operator*()
+    ALWAYS_INLINE T& operator*() const
     {
         return *as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE T const& operator*() const
-    {
-        return *as_nonnull_ptr();
-    }
-
-    ALWAYS_INLINE operator T const*() const { return as_ptr(); }
-    ALWAYS_INLINE operator T*() { return as_ptr(); }
+    ALWAYS_INLINE operator T*() const { return as_ptr(); }
 
     ALWAYS_INLINE operator bool() { return !is_null(); }
 
@@ -263,17 +251,11 @@ public:
 
     bool operator==(RefPtr const& other) const { return as_ptr() == other.as_ptr(); }
 
-    bool operator==(RefPtr& other) { return as_ptr() == other.as_ptr(); }
-
     template<typename U>
     bool operator==(NonnullRefPtr<U> const& other) const { return as_ptr() == other.m_ptr; }
 
-    template<typename U>
-    bool operator==(NonnullRefPtr<U>& other) { return as_ptr() == other.m_ptr; }
-
-    bool operator==(T const* other) const { return as_ptr() == other; }
-
-    bool operator==(T* other) { return as_ptr() == other; }
+    template<typename RawPtr>
+    bool operator==(RawPtr other) const requires(IsPointer<RawPtr>) { return as_ptr() == other; }
 
     ALWAYS_INLINE bool is_null() const { return !m_ptr; }
 

--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -117,10 +117,8 @@ public:
     }
 
     T* ptr() const { return unsafe_ptr(); }
-    T* operator->() { return unsafe_ptr(); }
-    const T* operator->() const { return unsafe_ptr(); }
-    operator const T*() const { return unsafe_ptr(); }
-    operator T*() { return unsafe_ptr(); }
+    T* operator->() const { return unsafe_ptr(); }
+    operator T*() const { return unsafe_ptr(); }
 
     [[nodiscard]] T* unsafe_ptr() const
     {

--- a/Userland/Applications/MouseSettings/ThemeWidget.cpp
+++ b/Userland/Applications/MouseSettings/ThemeWidget.cpp
@@ -119,7 +119,7 @@ ThemeWidget::ThemeWidget()
     m_mouse_cursor_model->change_theme(theme_name);
 
     m_theme_name_box = find_descendant_of_type_named<GUI::ComboBox>("theme_name_box");
-    m_theme_name_box->on_change = [this](String const& value, GUI::ModelIndex const&) mutable {
+    m_theme_name_box->on_change = [this](String const& value, GUI::ModelIndex const&) {
         m_mouse_cursor_model->change_theme(value);
         set_modified(true);
     };

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -199,18 +199,18 @@ static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget
     find_forwards->set_fixed_width(25);
     find_forwards->set_icon(TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/downward-triangle.png"sv)));
 
-    find_textbox->on_return_pressed = [find_backwards]() mutable {
+    find_textbox->on_return_pressed = [find_backwards] {
         find_backwards->click();
     };
 
-    find_textbox->on_shift_return_pressed = [find_forwards]() mutable {
+    find_textbox->on_shift_return_pressed = [find_forwards] {
         find_forwards->click();
     };
 
     auto match_case = TRY(main_widget->try_add<GUI::CheckBox>("Case sensitive"));
     auto wrap_around = TRY(main_widget->try_add<GUI::CheckBox>("Wrap around"));
 
-    find_backwards->on_click = [&terminal, find_textbox, match_case, wrap_around](auto) mutable {
+    find_backwards->on_click = [&terminal, find_textbox, match_case, wrap_around](auto) {
         auto needle = find_textbox->text();
         if (needle.is_empty()) {
             return;

--- a/Userland/Libraries/LibCore/Promise.h
+++ b/Userland/Libraries/LibCore/Promise.h
@@ -42,7 +42,7 @@ public:
     RefPtr<Promise<T>> map(T func(Result&))
     {
         RefPtr<Promise<T>> new_promise = Promise<T>::construct();
-        on_resolved = [new_promise, func](Result& result) mutable {
+        on_resolved = [new_promise, func](Result& result) {
             auto t = func(result);
             new_promise->resolve(move(t));
         };

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -47,7 +47,7 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
 
     if (show_defaults_button == ShowDefaultsButton::Yes) {
         window->m_reset_button = TRY(button_container->try_add<GUI::DialogButton>("Defaults"));
-        window->m_reset_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
+        window->m_reset_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) {
             window->reset_default_values();
         };
     }
@@ -55,24 +55,24 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
     TRY(button_container->layout()->try_add_spacer());
 
     window->m_ok_button = TRY(button_container->try_add<GUI::DialogButton>("OK"));
-    window->m_ok_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
+    window->m_ok_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) {
         window->apply_settings();
         GUI::Application::the()->quit();
     };
 
     window->m_cancel_button = TRY(button_container->try_add<GUI::DialogButton>("Cancel"));
-    window->m_cancel_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
+    window->m_cancel_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) {
         window->cancel_settings();
         GUI::Application::the()->quit();
     };
 
     window->m_apply_button = TRY(button_container->try_add<GUI::DialogButton>("Apply"));
     window->m_apply_button->set_enabled(false);
-    window->m_apply_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
+    window->m_apply_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) {
         window->apply_settings();
     };
 
-    window->on_close_request = [window = window->make_weak_ptr<SettingsWindow>()]() mutable -> Window::CloseRequestDecision {
+    window->on_close_request = [window = window->make_weak_ptr<SettingsWindow>()]() -> Window::CloseRequestDecision {
         if (!window->is_modified())
             return Window::CloseRequestDecision::Close;
 

--- a/Userland/Libraries/LibIDL/IDLParser.cpp
+++ b/Userland/Libraries/LibIDL/IDLParser.cpp
@@ -114,7 +114,7 @@ HashMap<String, String> Parser::parse_extended_attributes()
         if (lexer.consume_specific('=')) {
             bool did_open_paren = false;
             auto value = lexer.consume_until(
-                [&did_open_paren](auto ch) mutable {
+                [&did_open_paren](auto ch) {
                     if (ch == '(') {
                         did_open_paren = true;
                         return false;

--- a/Userland/Libraries/LibIPC/Connection.cpp
+++ b/Userland/Libraries/LibIPC/Connection.cpp
@@ -172,7 +172,7 @@ ErrorOr<Vector<u8>> ConnectionBase::read_as_much_as_possible_from_socket_without
 
         auto bytes_read = maybe_bytes_read.release_value();
         if (bytes_read.is_empty()) {
-            m_deferred_invoker->schedule([strong_this = NonnullRefPtr(*this)]() mutable {
+            m_deferred_invoker->schedule([strong_this = NonnullRefPtr(*this)] {
                 strong_this->shutdown();
             });
             if (!bytes.is_empty())
@@ -211,7 +211,7 @@ ErrorOr<void> ConnectionBase::drain_messages_from_peer()
     }
 
     if (!m_unprocessed_messages.is_empty()) {
-        m_deferred_invoker->schedule([strong_this = NonnullRefPtr(*this)]() mutable {
+        m_deferred_invoker->schedule([strong_this = NonnullRefPtr(*this)] {
             strong_this->handle_messages();
         });
     }

--- a/Userland/Libraries/LibJS/Heap/GCPtr.h
+++ b/Userland/Libraries/LibJS/Heap/GCPtr.h
@@ -72,20 +72,15 @@ public:
         return *this;
     }
 
-    T* operator->() { return m_ptr; }
-    T const* operator->() const { return m_ptr; }
+    T* operator->() const { return m_ptr; }
 
-    T& operator*() { return *m_ptr; }
-    T const& operator*() const { return *m_ptr; }
+    T& operator*() const { return *m_ptr; }
 
-    T* ptr() { return m_ptr; }
-    T const* ptr() const { return m_ptr; }
+    T* ptr() const { return m_ptr; }
 
-    operator T*() { return m_ptr; }
-    operator T const*() const { return m_ptr; }
+    operator T*() const { return m_ptr; }
 
-    operator T&() { return *m_ptr; }
-    operator T const&() const { return *m_ptr; }
+    operator T&() const { return *m_ptr; }
 
 private:
     T* m_ptr { nullptr };
@@ -181,20 +176,14 @@ public:
         return *this;
     }
 
-    T* operator->() { return m_ptr; }
-    T const* operator->() const { return m_ptr; }
-
-    T& operator*() { return *m_ptr; }
-    T const& operator*() const { return *m_ptr; }
-
-    T* ptr() { return m_ptr; }
-    T const* ptr() const { return m_ptr; }
+    T* operator->() const { return m_ptr; }
+    T& operator*() const { return *m_ptr; }
+    T* ptr() const { return m_ptr; }
 
     operator bool() const { return !!m_ptr; }
     bool operator!() const { return !m_ptr; }
 
-    operator T*() { return m_ptr; }
-    operator T const*() const { return m_ptr; }
+    operator T*() const { return m_ptr; }
 
 private:
     T* m_ptr { nullptr };

--- a/Userland/Libraries/LibJS/Heap/Handle.h
+++ b/Userland/Libraries/LibJS/Heap/Handle.h
@@ -60,25 +60,14 @@ public:
     {
     }
 
-    T* cell()
+    T* cell() const
     {
         if (!m_impl)
             return nullptr;
         return static_cast<T*>(m_impl->cell());
     }
 
-    T const* cell() const
-    {
-        if (!m_impl)
-            return nullptr;
-        return static_cast<T const*>(m_impl->cell());
-    }
-
-    T* ptr()
-    {
-        return cell();
-    }
-    T const* ptr() const
+    T* ptr() const
     {
         return cell();
     }
@@ -88,20 +77,12 @@ public:
         return m_impl.is_null();
     }
 
-    T* operator->()
-    {
-        return cell();
-    }
-    T const* operator->() const
+    T* operator->() const
     {
         return cell();
     }
 
-    T& operator*()
-    {
-        return *cell();
-    }
-    T const& operator*() const
+    T& operator*() const
     {
         return *cell();
     }
@@ -115,8 +96,7 @@ public:
         return cell();
     }
 
-    operator T*() { return cell(); }
-    operator T const*() const { return cell(); }
+    operator T*() const { return cell(); }
 
 private:
     explicit Handle(NonnullRefPtr<HandleImpl> impl)

--- a/Userland/Libraries/LibJS/Runtime/PromiseJobs.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseJobs.cpp
@@ -92,7 +92,7 @@ PromiseJob create_promise_reaction_job(VM& vm, PromiseReaction& reaction, Value 
 {
     // 1. Let job be a new Job Abstract Closure with no parameters that captures reaction and argument and performs the following steps when called:
     //    See run_reaction_job for "the following steps".
-    auto job = [&vm, reaction = make_handle(&reaction), argument = make_handle(argument)]() mutable {
+    auto job = [&vm, reaction = make_handle(&reaction), argument = make_handle(argument)] {
         return run_reaction_job(vm, *reaction.cell(), argument.value());
     };
 

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -128,7 +128,7 @@ JS::VM& main_thread_vm()
 
                 // 5. Queue a global task on the DOM manipulation task source given global to fire an event named rejectionhandled at global, using PromiseRejectionEvent,
                 //    with the promise attribute initialized to promise, and the reason attribute initialized to the value of promise's [[PromiseResult]] internal slot.
-                HTML::queue_global_task(HTML::Task::Source::DOMManipulation, global, [&global, &promise]() mutable {
+                HTML::queue_global_task(HTML::Task::Source::DOMManipulation, global, [&global, &promise] {
                     // FIXME: This currently assumes that global is a WindowObject.
                     auto& window = verify_cast<HTML::Window>(global);
 
@@ -178,12 +178,12 @@ JS::VM& main_thread_vm()
         };
 
         // 8.1.5.4.2 HostEnqueueFinalizationRegistryCleanupJob(finalizationRegistry), https://html.spec.whatwg.org/multipage/webappapis.html#hostenqueuefinalizationregistrycleanupjob
-        vm->host_enqueue_finalization_registry_cleanup_job = [](JS::FinalizationRegistry& finalization_registry) mutable {
+        vm->host_enqueue_finalization_registry_cleanup_job = [](JS::FinalizationRegistry& finalization_registry) {
             // 1. Let global be finalizationRegistry.[[Realm]]'s global object.
             auto& global = finalization_registry.realm().global_object();
 
             // 2. Queue a global task on the JavaScript engine task source given global to perform the following steps:
-            HTML::queue_global_task(HTML::Task::Source::JavaScriptEngine, global, [&finalization_registry]() mutable {
+            HTML::queue_global_task(HTML::Task::Source::JavaScriptEngine, global, [&finalization_registry] {
                 // 1. Let entry be finalizationRegistry.[[CleanupCallback]].[[Callback]].[[Realm]]'s environment settings object.
                 auto& entry = host_defined_environment_settings_object(*finalization_registry.cleanup_callback().callback.cell()->realm());
 
@@ -224,7 +224,7 @@ JS::VM& main_thread_vm()
             auto* script = active_script();
 
             // NOTE: This keeps job_settings alive by keeping realm alive, which is holding onto job_settings.
-            HTML::queue_a_microtask(script ? script->settings_object().responsible_document().ptr() : nullptr, [job_settings, job = move(job), script_or_module = move(script_or_module)]() mutable {
+            HTML::queue_a_microtask(script ? script->settings_object().responsible_document().ptr() : nullptr, [job_settings, job = move(job), script_or_module = move(script_or_module)] {
                 // The dummy execution context has to be kept up here to keep it alive for the duration of the function.
                 Optional<JS::ExecutionContext> dummy_execution_context;
 

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -101,7 +101,7 @@ void AbortSignal::follow(JS::NonnullGCPtr<AbortSignal> parent_signal)
 
     // 3. Otherwise, add the following abort steps to parentSignal:
     // NOTE: `this` and `parent_signal` are protected by AbortSignal using JS::SafeFunction.
-    parent_signal->add_abort_algorithm([this, parent_signal]() mutable {
+    parent_signal->add_abort_algorithm([this, parent_signal] {
         // 1. Signal abort on followingSignal with parentSignal’s abort reason.
         signal_abort(parent_signal->reason());
     });

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1559,13 +1559,13 @@ void Document::completely_finish_loading()
 
     // 4. If container is an iframe element, then queue an element task on the DOM manipulation task source given container to run the iframe load event steps given container.
     if (container && is<HTML::HTMLIFrameElement>(*container)) {
-        container->queue_an_element_task(HTML::Task::Source::DOMManipulation, [container]() mutable {
+        container->queue_an_element_task(HTML::Task::Source::DOMManipulation, [container] {
             run_iframe_load_event_steps(static_cast<HTML::HTMLIFrameElement&>(*container));
         });
     }
     // 5. Otherwise, if container is non-null, then queue an element task on the DOM manipulation task source given container to fire an event named load at container.
     else if (container) {
-        container->queue_an_element_task(HTML::Task::Source::DOMManipulation, [container]() mutable {
+        container->queue_an_element_task(HTML::Task::Source::DOMManipulation, [container] {
             container->dispatch_event(*DOM::Event::create(container->realm(), HTML::EventNames::load));
         });
     }

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -171,7 +171,7 @@ void EventTarget::add_an_event_listener(DOMEventListener& listener)
     // 5. If listener’s signal is not null, then add the following abort steps to it:
     if (listener.signal) {
         // NOTE: `this` and `listener` are protected by AbortSignal using JS::SafeFunction.
-        listener.signal->add_abort_algorithm([this, &listener]() mutable {
+        listener.signal->add_abort_algorithm([this, &listener] {
             // 1. Remove an event listener with eventTarget and listener.
             remove_an_event_listener(listener);
         });

--- a/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
@@ -125,7 +125,7 @@ JS::NonnullGCPtr<JS::Promise> fetch_impl(JS::VM& vm, RequestInfo const& input, R
             })));
 
     // 11. Add the following abort steps to requestObject’s signal:
-    request_object->signal()->add_abort_algorithm([&vm, locally_aborted, request, controller, promise_capability_handle = JS::make_handle(*promise_capability), request_object_handle = JS::make_handle(*request_object), response_object_handle]() mutable {
+    request_object->signal()->add_abort_algorithm([&vm, locally_aborted, request, controller, promise_capability_handle = JS::make_handle(*promise_capability), request_object_handle = JS::make_handle(*request_object), response_object_handle] {
         dbgln_if(WEB_FETCH_DEBUG, "Fetch: Request object signal's abort algorithm called");
 
         auto& promise_capability = *promise_capability_handle;

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/PendingResponse.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/PendingResponse.cpp
@@ -56,7 +56,7 @@ void PendingResponse::run_callback() const
 {
     VERIFY(m_callback);
     VERIFY(m_response);
-    Platform::EventLoopPlugin::the().deferred_invoke([strong_this = JS::make_handle(const_cast<PendingResponse&>(*this))]() mutable {
+    Platform::EventLoopPlugin::the().deferred_invoke([strong_this = JS::make_handle(const_cast<PendingResponse&>(*this))] {
         strong_this->m_callback(*strong_this->m_response);
         strong_this->m_request->remove_pending_response({}, *strong_this.ptr());
     });

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -1142,7 +1142,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::traverse_the_history(size_t entry_ind
     if (new_document->ready_state() == "complete"sv) {
         // then queue a global task on the DOM manipulation task source given newDocument's relevant global object to run the following steps:
 
-        queue_global_task(Task::Source::DOMManipulation, relevant_global_object(*new_document), [new_document]() mutable {
+        queue_global_task(Task::Source::DOMManipulation, relevant_global_object(*new_document), [new_document] {
             // 1. If newDocument's page showing flag is true, then abort these steps.
             if (new_document->page_showing())
                 return;
@@ -1211,7 +1211,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::traverse_the_history(size_t entry_ind
     // 20. If hashChanged is true,
     if (hash_changed) {
         // then queue a global task on the DOM manipulation task source given newDocument's relevant global object
-        queue_global_task(Task::Source::DOMManipulation, relevant_global_object(*new_document), [new_document]() mutable {
+        queue_global_task(Task::Source::DOMManipulation, relevant_global_object(*new_document), [new_document] {
             // to fire an event named hashchange at newDocument's relevant global object,
             // using HashChangeEvent, with the oldURL attribute initialized to oldURL
             // and the newURL attribute initialized to newURL.
@@ -1330,7 +1330,7 @@ void BrowsingContext::set_system_visibility_state(VisibilityState visibility_sta
     // has changed to newState, it must queue a task on the user interaction task source to update
     // the visibility state of all the Document objects in the top-level browsing context's document family with newState.
     auto document_family = top_level_browsing_context().document_family();
-    queue_global_task(Task::Source::UserInteraction, Bindings::main_thread_vm().current_realm()->global_object(), [visibility_state, document_family = move(document_family)]() mutable {
+    queue_global_task(Task::Source::UserInteraction, Bindings::main_thread_vm().current_realm()->global_object(), [visibility_state, document_family = move(document_family)] {
         for (auto& document : document_family) {
             document->update_the_visibility_state(visibility_state);
         }

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -121,7 +121,7 @@ WebIDL::ExceptionOr<void> CanvasRenderingContext2D::draw_image_internal(CanvasIm
     if (usability == CanvasImageSourceUsability::Bad)
         return {};
 
-    auto const* bitmap = image.visit([](auto const& source) { return source->bitmap(); });
+    auto const* bitmap = image.visit([](auto const& source) -> Gfx::Bitmap const* { return source->bitmap(); });
     if (!bitmap)
         return {};
 

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -103,7 +103,7 @@ void FormAssociatedElement::reset_form_owner()
     if (is_listed() && html_element.has_attribute(HTML::AttributeNames::form) && html_element.is_connected()) {
         // 1. If the first element in element's tree, in tree order, to have an ID that is identical to element's form content attribute's value, is a form element, then associate the element with that form element.
         auto form_value = html_element.attribute(HTML::AttributeNames::form);
-        html_element.root().for_each_in_inclusive_subtree_of_type<HTMLFormElement>([this, &form_value](HTMLFormElement& form_element) mutable {
+        html_element.root().for_each_in_inclusive_subtree_of_type<HTMLFormElement>([this, &form_value](HTMLFormElement& form_element) {
             if (form_element.attribute(HTML::AttributeNames::id) == form_value) {
                 set_form(&form_element);
                 return IterationDecision::Break;

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -534,7 +534,7 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
     // set to source.
     // FIXME: "navigate" means implementing the navigation algorithm here:
     //        https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
-    hyperlink_element_utils_queue_an_element_task(Task::Source::DOMManipulation, [url_string, target]() mutable {
+    hyperlink_element_utils_queue_an_element_task(Task::Source::DOMManipulation, [url_string, target] {
         target->loader().load(url_string, FrameLoader::Type::Navigation);
     });
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -123,7 +123,7 @@ void HTMLInputElement::set_files(JS::GCPtr<FileAPI::FileList> files)
 void HTMLInputElement::update_the_file_selection(JS::NonnullGCPtr<FileAPI::FileList> files)
 {
     // 1. Queue an element task on the user interaction task source given element and the following steps:
-    queue_an_element_task(Task::Source::UserInteraction, [this, files]() mutable {
+    queue_an_element_task(Task::Source::UserInteraction, [this, files] {
         // 1. Update element's selected files so that it represents the user's selection.
         this->set_files(files.ptr());
 

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -88,7 +88,7 @@ void MessagePort::post_message(JS::Value message)
 
     // FIXME: This is an ad-hoc hack implementation instead, since we don't currently
     //        have serialization and deserialization of messages.
-    main_thread_event_loop().task_queue().add(HTML::Task::create(HTML::Task::Source::PostedMessage, nullptr, [target_port, message]() mutable {
+    main_thread_event_loop().task_queue().add(HTML::Task::create(HTML::Task::Source::PostedMessage, nullptr, [target_port, message] {
         MessageEventInit event_init {};
         event_init.data = message;
         event_init.origin = "<origin>";

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -250,7 +250,7 @@ void HTMLParser::the_end()
     }
 
     // 6. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following substeps:
-    old_queue_global_task_with_document(HTML::Task::Source::DOMManipulation, *m_document, [document = m_document]() mutable {
+    old_queue_global_task_with_document(HTML::Task::Source::DOMManipulation, *m_document, [document = m_document] {
         // 1. Set the Document's load timing info's DOM content loaded event start time to the current high resolution time given the Document's relevant global object.
         document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::unsafe_shared_current_time();
 
@@ -279,7 +279,7 @@ void HTMLParser::the_end()
     });
 
     // 9. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following steps:
-    old_queue_global_task_with_document(HTML::Task::Source::DOMManipulation, *m_document, [document = m_document]() mutable {
+    old_queue_global_task_with_document(HTML::Task::Source::DOMManipulation, *m_document, [document = m_document] {
         // 1. Update the current document readiness to "complete".
         document->update_readiness(HTML::DocumentReadyState::Complete);
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -228,7 +228,7 @@ void EnvironmentSettingsObject::notify_about_rejected_promises(Badge<EventLoop>)
     auto& global = global_object();
 
     // 5. Queue a global task on the DOM manipulation task source given global to run the following substep:
-    queue_global_task(Task::Source::DOMManipulation, global, [this, &global, list = move(list)]() mutable {
+    queue_global_task(Task::Source::DOMManipulation, global, [this, &global, list = move(list)] {
         // 1. For each promise p in list:
         for (auto promise : list) {
 

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -495,7 +495,7 @@ i32 Window::run_timer_initialization_steps(TimerHandler handler, i32 timeout, JS
     // 8. Assert: initiating script is not null, since this algorithm is always called from some script.
 
     // 9. Let task be a task that runs the following substeps:
-    JS::SafeFunction<void()> task = [this, handler = move(handler), timeout, arguments = move(arguments), repeat, id]() mutable {
+    JS::SafeFunction<void()> task = [this, handler = move(handler), timeout, arguments = move(arguments), repeat, id] {
         // 1. If id does not exist in global's map of active timers, then abort these steps.
         if (!m_timers.contains(id))
             return;
@@ -564,7 +564,7 @@ i32 Window::run_timer_initialization_steps(TimerHandler handler, i32 timeout, JS
 // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks
 i32 Window::request_animation_frame_impl(WebIDL::CallbackType& js_callback)
 {
-    return m_animation_frame_callback_driver.add([this, js_callback = JS::make_handle(js_callback)](auto) mutable {
+    return m_animation_frame_callback_driver.add([this, js_callback = JS::make_handle(js_callback)](auto) {
         // 3. Invoke callback, passing now as the only argument,
         auto result = WebIDL::invoke_callback(*js_callback, {}, JS::Value(performance().now()));
 
@@ -802,7 +802,7 @@ void Window::fire_a_page_transition_event(FlyString const& event_name, bool pers
 void Window::queue_microtask_impl(WebIDL::CallbackType& callback)
 {
     // The queueMicrotask(callback) method must queue a microtask to invoke callback,
-    HTML::queue_a_microtask(&associated_document(), [this, &callback]() mutable {
+    HTML::queue_a_microtask(&associated_document(), [this, &callback] {
         auto result = WebIDL::invoke_callback(callback, {});
         // and if callback throws an exception, report the exception.
         if (result.is_error())
@@ -906,7 +906,7 @@ WebIDL::ExceptionOr<void> Window::post_message_impl(JS::Value message, String co
 {
     // FIXME: This is an ad-hoc hack implementation instead, since we don't currently
     //        have serialization and deserialization of messages.
-    HTML::queue_global_task(HTML::Task::Source::PostedMessage, *this, [this, message]() mutable {
+    HTML::queue_global_task(HTML::Task::Source::PostedMessage, *this, [this, message] {
         HTML::MessageEventInit event_init {};
         event_init.data = message;
         event_init.origin = "<origin>";
@@ -961,7 +961,7 @@ void Window::start_an_idle_period()
 
     // 5. Queue a task on the queue associated with the idle-task task source,
     //    which performs the steps defined in the invoke idle callbacks algorithm with window and getDeadline as parameters.
-    HTML::queue_global_task(HTML::Task::Source::IdleTask, *this, [this]() mutable {
+    HTML::queue_global_task(HTML::Task::Source::IdleTask, *this, [this] {
         invoke_idle_callbacks();
     });
 }
@@ -985,7 +985,7 @@ void Window::invoke_idle_callbacks()
             HTML::report_exception(result, realm());
         // 4. If window's list of runnable idle callbacks is not empty, queue a task which performs the steps
         //    in the invoke idle callbacks algorithm with getDeadline and window as a parameters and return from this algorithm
-        HTML::queue_global_task(HTML::Task::Source::IdleTask, *this, [this]() mutable {
+        HTML::queue_global_task(HTML::Task::Source::IdleTask, *this, [this] {
             invoke_idle_callbacks();
         });
     }

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -154,7 +154,7 @@ void Worker::run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_setti
 
             auto& event_loop = get_vm_event_loop(m_document->realm().vm());
 
-            event_loop.task_queue().add(HTML::Task::create(HTML::Task::Source::PostedMessage, nullptr, [this, message]() mutable {
+            event_loop.task_queue().add(HTML::Task::create(HTML::Task::Source::PostedMessage, nullptr, [this, message] {
                 MessageEventInit event_init {};
                 event_init.data = message;
                 event_init.origin = "<origin>";

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -168,7 +168,7 @@ void ResourceClient::set_resource(Resource* resource)
         // This ensures that these callbacks always happen in a consistent way, instead of being invoked
         // synchronously in some cases, and asynchronously in others.
         if (resource->is_loaded() || resource->is_failed()) {
-            Platform::EventLoopPlugin::the().deferred_invoke([weak_this = make_weak_ptr(), strong_resource = NonnullRefPtr { *m_resource }]() mutable {
+            Platform::EventLoopPlugin::the().deferred_invoke([weak_this = make_weak_ptr(), strong_resource = NonnullRefPtr { *m_resource }] {
                 if (!weak_this)
                     return;
 

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -285,7 +285,7 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
 
         if (timeout.has_value() && timeout.value() > 0) {
             auto timer = Platform::Timer::create_single_shot(timeout.value(), nullptr);
-            timer->on_timeout = [timer, protocol_request, timeout_callback = move(timeout_callback)]() mutable {
+            timer->on_timeout = [timer, protocol_request, timeout_callback = move(timeout_callback)] {
                 protocol_request->stop();
                 if (timeout_callback)
                     timeout_callback();

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -178,7 +178,7 @@ void XMLDocumentBuilder::document_end()
         (void)m_document.scripts_to_execute_when_parsing_has_finished().take_first();
     }
     // Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following substeps:
-    old_queue_global_task_with_document(HTML::Task::Source::DOMManipulation, m_document, [document = &m_document]() mutable {
+    old_queue_global_task_with_document(HTML::Task::Source::DOMManipulation, m_document, [document = &m_document] {
         // Set the Document's load timing info's DOM content loaded event start time to the current high resolution time given the Document's relevant global object.
         document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::unsafe_shared_current_time();
 
@@ -206,7 +206,7 @@ void XMLDocumentBuilder::document_end()
     });
 
     // Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following steps:
-    old_queue_global_task_with_document(HTML::Task::Source::DOMManipulation, m_document, [document = &m_document]() mutable {
+    old_queue_global_task_with_document(HTML::Task::Source::DOMManipulation, m_document, [document = &m_document] {
         // Update the current document readiness to "complete".
         document->update_readiness(HTML::DocumentReadyState::Complete);
 

--- a/Userland/Services/SQLServer/SQLStatement.cpp
+++ b/Userland/Services/SQLServer/SQLStatement.cpp
@@ -60,7 +60,7 @@ void SQLStatement::execute()
         return;
     }
 
-    deferred_invoke([this]() mutable {
+    deferred_invoke([this] {
         auto parse_result = parse();
         if (parse_result.is_error()) {
             report_error(parse_result.release_error());

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -36,7 +36,7 @@ ErrorOr<NonnullRefPtr<Core::LocalServer>> Session::create_server(String const& s
     auto server = TRY(Core::LocalServer::try_create());
     server->listen(socket_path);
 
-    server->on_accept = [this, promise](auto client_socket) mutable {
+    server->on_accept = [this, promise](auto client_socket) {
         auto maybe_connection = adopt_nonnull_ref_or_enomem(new (nothrow) WebContentConnection(move(client_socket), m_client, session_id()));
         if (maybe_connection.is_error()) {
             promise->resolve(maybe_connection.release_error());
@@ -49,7 +49,7 @@ ErrorOr<NonnullRefPtr<Core::LocalServer>> Session::create_server(String const& s
         promise->resolve({});
     };
 
-    server->on_accept_error = [promise](auto error) mutable {
+    server->on_accept_error = [promise](auto error) {
         promise->resolve(move(error));
     };
 

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -234,7 +234,7 @@ void ConnectionFromClient::flash_menubar_menu(i32 window_id, i32 menu_id)
             m_flashed_menu_timer->stop();
         }
 
-        m_flashed_menu_timer = Core::Timer::create_single_shot(75, [weak_window = window.make_weak_ptr<Window>()]() mutable {
+        m_flashed_menu_timer = Core::Timer::create_single_shot(75, [weak_window = window.make_weak_ptr<Window>()] {
             if (!weak_window)
                 return;
             weak_window->menubar().flash_menu(nullptr);

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -327,7 +327,7 @@ public:
             , m_socket(move(socket))
             , m_job(HTTP::Job::construct(move(request), *m_output_stream))
         {
-            m_job->on_headers_received = [weak_this = make_weak_ptr()](auto& response_headers, auto response_code) mutable {
+            m_job->on_headers_received = [weak_this = make_weak_ptr()](auto& response_headers, auto response_code) {
                 if (auto strong_this = weak_this.strong_ref()) {
                     strong_this->m_response_code = response_code;
                     for (auto& header : response_headers) {
@@ -335,8 +335,8 @@ public:
                     }
                 }
             };
-            m_job->on_finish = [weak_this = make_weak_ptr()](bool success) mutable {
-                Core::deferred_invoke([weak_this, success]() mutable {
+            m_job->on_finish = [weak_this = make_weak_ptr()](bool success) {
+                Core::deferred_invoke([weak_this, success] {
                     if (auto strong_this = weak_this.strong_ref()) {
                         ReadonlyBytes response_bytes { strong_this->m_output_stream->bytes().data(), strong_this->m_output_stream->offset() };
                         auto response_buffer = ByteBuffer::copy(response_bytes).release_value_but_fixme_should_propagate_errors();
@@ -406,7 +406,7 @@ public:
             , m_socket(move(socket))
             , m_job(HTTP::HttpsJob::construct(move(request), *m_output_stream))
         {
-            m_job->on_headers_received = [weak_this = make_weak_ptr()](auto& response_headers, auto response_code) mutable {
+            m_job->on_headers_received = [weak_this = make_weak_ptr()](auto& response_headers, auto response_code) {
                 if (auto strong_this = weak_this.strong_ref()) {
                     strong_this->m_response_code = response_code;
                     for (auto& header : response_headers) {
@@ -414,8 +414,8 @@ public:
                     }
                 }
             };
-            m_job->on_finish = [weak_this = make_weak_ptr()](bool success) mutable {
-                Core::deferred_invoke([weak_this, success]() mutable {
+            m_job->on_finish = [weak_this = make_weak_ptr()](bool success) {
+                Core::deferred_invoke([weak_this, success] {
                     if (auto strong_this = weak_this.strong_ref()) {
                         ReadonlyBytes response_bytes { strong_this->m_output_stream->bytes().data(), strong_this->m_output_stream->offset() };
                         auto response_buffer = ByteBuffer::copy(response_bytes).release_value_but_fixme_should_propagate_errors();
@@ -475,7 +475,7 @@ public:
             , m_socket(move(socket))
             , m_job(Gemini::Job::construct(move(request), *m_output_stream))
         {
-            m_job->on_headers_received = [weak_this = make_weak_ptr()](auto& response_headers, auto response_code) mutable {
+            m_job->on_headers_received = [weak_this = make_weak_ptr()](auto& response_headers, auto response_code) {
                 if (auto strong_this = weak_this.strong_ref()) {
                     strong_this->m_response_code = response_code;
                     for (auto& header : response_headers) {
@@ -483,8 +483,8 @@ public:
                     }
                 }
             };
-            m_job->on_finish = [weak_this = make_weak_ptr()](bool success) mutable {
-                Core::deferred_invoke([weak_this, success]() mutable {
+            m_job->on_finish = [weak_this = make_weak_ptr()](bool success) {
+                Core::deferred_invoke([weak_this, success] {
                     if (auto strong_this = weak_this.strong_ref()) {
                         ReadonlyBytes response_bytes { strong_this->m_output_stream->bytes().data(), strong_this->m_output_stream->offset() };
                         auto response_buffer = ByteBuffer::copy(response_bytes).release_value_but_fixme_should_propagate_errors();
@@ -717,7 +717,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     dbgln("Taking screenshot after {} seconds !", take_screenshot_after);
     auto timer = Core::Timer::create_single_shot(
         take_screenshot_after * 1000,
-        [page_client = move(page_client)]() mutable {
+        [page_client = move(page_client)] {
             // FIXME: Allow passing the output path as argument
             String output_file_path = "output.png";
             dbgln("Saving to {}", output_file_path);


### PR DESCRIPTION
This may be a matter opinion, but I don't think the constness of the operator overloads for pointer-like classes is correct right now. 

Just because the pointer is const, does not mean the value it points to necessarily is. 
So the `const` operator overloads for Ptr wrapper classes should not add `const` qualifiers to the values they return. 

This makes these wrapper classes behave more like normal/raw pointers (and also makes them more constant with their STL counterparts). 

Doing this allows removing the duplicate non-const overload implementations of these operators, and remove a whole load of  unnecessary `mutable`  qualifiers on lambdas (that capture these pointers by value, but are not actually mutating any of the lambdas state).  