### PR TITLE
LibGUI+SoundPlayer+VideoPlayer: Set the play/pause action text on state change

### DIFF
--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -170,6 +170,7 @@ void SoundPlayerWidgetAdvancedView::play_state_changed(Player::PlayState state)
 
     m_play_action->set_enabled(state != PlayState::NoFileLoaded);
     m_play_action->set_icon(state == PlayState::Playing ? m_pause_icon : m_play_icon);
+    m_play_action->set_text(state == PlayState::Playing ? "Pause"sv : "Play"sv);
 
     m_stop_action->set_enabled(state != PlayState::Stopped && state != PlayState::NoFileLoaded);
 

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -110,15 +110,19 @@ void VideoPlayerWidget::update_play_pause_icon()
     if (!m_playback_manager) {
         m_play_pause_action->set_enabled(false);
         m_play_pause_action->set_icon(m_play_icon);
+        m_play_pause_action->set_text("Play"sv);
         return;
     }
 
     m_play_pause_action->set_enabled(true);
 
-    if (m_playback_manager->is_playing())
+    if (m_playback_manager->is_playing()) {
         m_play_pause_action->set_icon(m_pause_icon);
-    else
+        m_play_pause_action->set_text("Pause"sv);
+    } else {
         m_play_pause_action->set_icon(m_play_icon);
+        m_play_pause_action->set_text("Play"sv);
+    }
 }
 
 void VideoPlayerWidget::resume_playback()

--- a/Userland/Libraries/LibGUI/AbstractButton.h
+++ b/Userland/Libraries/LibGUI/AbstractButton.h
@@ -20,7 +20,7 @@ public:
 
     Function<void(bool)> on_checked;
 
-    void set_text(String);
+    virtual void set_text(String);
     String const& text() const { return m_text; }
 
     bool is_exclusive() const { return m_exclusive; }

--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -275,9 +275,6 @@ void Action::set_text(String text)
     if (m_text == text)
         return;
     m_text = move(text);
-    for_each_toolbar_button([&](auto& button) {
-        button.set_text_from_action();
-    });
     for_each_menu_item([&](auto& menu_item) {
         menu_item.update_from_action({});
     });

--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -275,6 +275,9 @@ void Action::set_text(String text)
     if (m_text == text)
         return;
     m_text = move(text);
+    for_each_toolbar_button([&](auto& button) {
+        button.set_text(m_text);
+    });
     for_each_menu_item([&](auto& menu_item) {
         menu_item.update_from_action({});
     });

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -169,25 +169,6 @@ void Button::set_action(Action& action)
     set_checkable(action.is_checkable());
     if (action.is_checkable())
         set_checked(action.is_checked());
-    set_text_from_action();
-}
-
-static String create_tooltip_for_action(Action const& action)
-{
-    StringBuilder builder;
-    builder.append(action.text());
-    if (action.shortcut().is_valid()) {
-        builder.append(" ("sv);
-        builder.append(action.shortcut().to_string());
-        builder.append(')');
-    }
-    return builder.to_string();
-}
-
-void Button::set_text_from_action()
-{
-    set_text(action()->text());
-    set_tooltip(create_tooltip_for_action(*action()));
 }
 
 void Button::set_icon(RefPtr<Gfx::Bitmap> icon)

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -50,7 +50,6 @@ public:
     Action* action() { return m_action; }
     Action const* action() const { return m_action; }
     void set_action(Action&);
-    void set_text_from_action();
 
     virtual bool is_uncheckable() const override;
 

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -51,12 +51,24 @@ private:
         if (action.group() && action.group()->is_exclusive())
             set_exclusive(true);
         set_action(action);
+        set_tooltip(tooltip(action));
         set_focus_policy(FocusPolicy::NoFocus);
         if (action.icon())
             set_icon(action.icon());
         else
             set_text(action.text());
         set_button_style(Gfx::ButtonStyle::Coolbar);
+    }
+    String tooltip(Action const& action) const
+    {
+        StringBuilder builder;
+        builder.append(action.text());
+        if (action.shortcut().is_valid()) {
+            builder.append(" ("sv);
+            builder.append(action.shortcut().to_string());
+            builder.append(')');
+        }
+        return builder.to_string();
     }
 
     virtual void enter_event(Core::Event& event) override

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -59,6 +59,17 @@ private:
             set_text(action.text());
         set_button_style(Gfx::ButtonStyle::Coolbar);
     }
+
+    virtual void set_text(String text) override
+    {
+        auto const* action = this->action();
+        VERIFY(action);
+
+        set_tooltip(tooltip(*action));
+        if (!action->icon())
+            Button::set_text(move(text));
+    }
+
     String tooltip(Action const& action) const
     {
         StringBuilder builder;


### PR DESCRIPTION
The reverted commit caused the the EmojiInputDialog to have an ellipsis next to the toolbar icons:

![Screenshot_from_2022-11-18_12-04-33](https://user-images.githubusercontent.com/5600524/202857209-a006963c-1497-4ba1-9958-99bd67404118.png)

This reimplements the intent of that patch to allow the SoundPlayer and VideoPlayer to update the play/pause button tooltip when the play state changes:

[Screencast from 2022-11-19 09-56-20.webm](https://user-images.githubusercontent.com/5600524/202857293-e6920942-bc63-4281-b91d-a8c70b39cc22.webm)

