### PR TITLE
LibJS: Fix UTF-16 corruption in String.prototype.replace()

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
@@ -245,4 +245,6 @@ test("UTF-16", () => {
     expect("😀".replace(/\ud83d/u, "")).toBe("😀");
     expect("😀".replace(/\ude00/u, "")).toBe("😀");
     expect("😀".replace(/\ud83d\ude00/u, "")).toBe("");
+
+    expect("".replace("", "😀")).toBe("😀");
 });


### PR DESCRIPTION
We were mistakenly trying to append UTF-16 code units to a StringBuilder via the append(char) API. This patch fixes that by accumulating the result in a Vector<u16> instead.

This'll be a bit worse for performance, since we're now doing additional UTF-16 string conversions, but we're going for correctness at this stage and can worry about performance later.