### PR TITLE
LibWebView: Update OOPWV's URL when a page starts/finishes loading

### DIFF
--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -300,12 +300,14 @@ void OutOfProcessWebView::notify_server_did_middle_click_link(Badge<WebContentCl
 
 void OutOfProcessWebView::notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL& url)
 {
+    m_url = url;
     if (on_load_start)
         on_load_start(url);
 }
 
 void OutOfProcessWebView::notify_server_did_finish_loading(Badge<WebContentClient>, const AK::URL& url)
 {
+    m_url = url;
     if (on_load_finish)
         on_load_finish(url);
 }


### PR DESCRIPTION
If the page's URL is changed from within the WebContent process (e.g. window.location.href is set from JavaScript, or a navigation is started from WebDriver), we would not store the URL at all within OOPWV. This prevented actions like reloading from working properly, as the browser would reload whatever URL was previously entered in the URL box.

Before:

[before.webm](https://user-images.githubusercontent.com/5600524/202862241-03351fb2-69bb-4398-8116-15a8eb4d71ef.webm)


After:

[after.webm](https://user-images.githubusercontent.com/5600524/202862247-9af92a34-9904-465b-b761-026372a59a71.webm)
