### PR TITLE
LibArchive: Simplify error handling + bugfix

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzTar.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTar.cpp
@@ -34,8 +34,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
             return 0;
         }
 
-        auto maybe_error = tar_stream.advance();
-        if (maybe_error.is_error())
+        if (tar_stream.advance().is_error())
             return 0;
     }
 

--- a/Userland/Libraries/LibArchive/TarStream.cpp
+++ b/Userland/Libraries/LibArchive/TarStream.cpp
@@ -104,11 +104,7 @@ ErrorOr<void> TarInputStream::advance()
 
     m_generation++;
 
-    auto header_size_or_error = m_header.size();
-    if (header_size_or_error.is_error())
-        return header_size_or_error.release_error();
-    auto header_size = header_size_or_error.release_value();
-
+    auto header_size = TRY(m_header.size());
     VERIFY(m_stream.discard_or_error(block_ceiling(header_size) - m_file_offset));
     m_file_offset = 0;
 

--- a/Userland/Libraries/LibArchive/TarStream.cpp
+++ b/Userland/Libraries/LibArchive/TarStream.cpp
@@ -84,12 +84,11 @@ bool TarFileStream::discard_or_error(size_t count)
 TarInputStream::TarInputStream(InputStream& stream)
     : m_stream(stream)
 {
-    if (!m_stream.read_or_error(Bytes(&m_header, sizeof(m_header)))) {
+    if (!m_stream.read_or_error(Bytes(&m_header, sizeof(m_header))) || !m_stream.discard_or_error(block_size - sizeof(TarFileHeader))) {
         m_finished = true;
         m_stream.handle_any_error(); // clear out errors so we don't assert
         return;
     }
-    VERIFY(m_stream.discard_or_error(block_size - sizeof(TarFileHeader)));
 }
 
 static constexpr unsigned long block_ceiling(unsigned long offset)

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -75,11 +75,7 @@ inline ErrorOr<void> TarInputStream::for_each_extended_header(F func)
 
     Archive::TarFileStream file_stream = file_contents();
 
-    auto header_size_or_error = header().size();
-    if (header_size_or_error.is_error())
-        return header_size_or_error.release_error();
-    auto header_size = header_size_or_error.release_value();
-
+    auto header_size = TRY(header().size());
     ByteBuffer file_contents_buffer = TRY(ByteBuffer::create_zeroed(header_size));
     VERIFY(file_stream.read(file_contents_buffer) == header_size);
 

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -159,11 +159,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (extract) {
                 String absolute_path = Core::File::absolute_path(filename);
                 auto parent_path = LexicalPath(absolute_path).parent();
-
-                auto header_mode_or_error = header.mode();
-                if (header_mode_or_error.is_error())
-                    return header_mode_or_error.release_error();
-                auto header_mode = header_mode_or_error.release_value();
+                auto header_mode = TRY(header.mode());
 
                 switch (header.type_flag()) {
                 case Archive::TarFileType::NormalFile:
@@ -204,9 +200,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             // Non-global headers should be cleared after every file.
             local_overrides.clear();
 
-            auto maybe_error = tar_stream.advance();
-            if (maybe_error.is_error())
-                return maybe_error.error();
+            TRY(tar_stream.advance());
         }
         file_stream.close();
 


### PR DESCRIPTION
Context: #16008

We can't use ```TRY``` here as much as I'd like, since the API of TarFileStream is somewhat limited by InputStream.

This PR also fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52498