### PR TITLE
LibPDF: Add missing character quirk for WinAnsiEncoding Type1 fonts

### DIFF
--- a/Userland/Libraries/LibPDF/Encoding.cpp
+++ b/Userland/Libraries/LibPDF/Encoding.cpp
@@ -115,6 +115,7 @@ NonnullRefPtr<Encoding> Encoding::windows_encoding()
     encoding->m_name_mapping.set(#name, name##_code_point);
         ENUMERATE_LATIN_CHARACTER_SET(ENUMERATE)
 #undef ENUMERATE
+        encoding->m_windows = true;
     }
 
     return encoding;
@@ -168,6 +169,14 @@ NonnullRefPtr<Encoding> Encoding::zapf_encoding()
 CharDescriptor const& Encoding::get_char_code_descriptor(u16 char_code) const
 {
     return const_cast<Encoding*>(this)->m_descriptors.ensure(char_code);
+}
+
+bool Encoding::should_map_to_bullet(u16 char_code) const
+{
+    // PDF Annex D table D.2, note 3:
+    // In WinAnsiEncoding, all unused codes greater than 40 (octal) map to the bullet character. However, only
+    // code 225 (octal) shall be specifically assigned to the bullet character; other codes are subject to future re-assignment.
+    return m_windows && char_code > 040 && !m_descriptors.contains(char_code);
 }
 
 }

--- a/Userland/Libraries/LibPDF/Encoding.h
+++ b/Userland/Libraries/LibPDF/Encoding.h
@@ -96,7 +96,7 @@
     FN("]", bracketright, 93, 93, 93, 93)                           \
     FN(" ̆", breve, 198, 249, -1, 24)                                \
     FN("¦", brokenbar, -1, -1, 166, 166)                            \
-    FN("•", bullet, 183, 165, 149, 128) /* FIXME: Note 3 */         \
+    FN("•", bullet, 183, 165, 149, 128)                             \
     FN("c", c, 99, 99, 99, 99)                                      \
     FN("ˇ", caron, 207, 255, -1, 25)                                \
     FN("ç", ccedilla, -1, 141, 231, 231)                            \
@@ -647,9 +647,13 @@ public:
 
     CharDescriptor const& get_char_code_descriptor(u16 char_code) const;
 
+    bool should_map_to_bullet(u16 char_code) const;
+
 protected:
     HashMap<u16, CharDescriptor> m_descriptors;
     HashMap<DeprecatedString, u16> m_name_mapping;
+
+    bool m_windows { false };
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -48,6 +48,9 @@ u32 TrueTypeFont::char_code_to_code_point(u16 char_code) const
     if (m_data.to_unicode)
         TODO();
 
+    if (m_data.encoding->should_map_to_bullet(char_code))
+        return 8226; // Bullet.
+
     auto descriptor = m_data.encoding->get_char_code_descriptor(char_code);
     return descriptor.code_point;
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -57,6 +57,9 @@ u32 Type1Font::char_code_to_code_point(u16 char_code) const
     if (m_data.to_unicode)
         TODO();
 
+    if (m_data.encoding->should_map_to_bullet(char_code))
+        return 8226; // Bullet.
+
     auto descriptor = m_data.encoding->get_char_code_descriptor(char_code);
     return descriptor.code_point;
 }


### PR DESCRIPTION
Type1 fonts with the encoding name "WinAnsiEncoding" should render missing characters above character code 40 (octal) as a "bullet" character.
    
This patch achieves that via a check in char_code_to_code_point() that simply overrides the code point if the conditions are met.
    
I didn't have a good way to test this, so I've only verified that it works by manually overriding inputs to the function during the rendering stage.
    
This takes care of a FIXME in the Annex D part of the PDF specification.

cc @mattco98 @metalvoidzz