### PR TITLE
LibWebView+WebContent: Fix Browser action shortcuts

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -649,6 +649,7 @@ bool EventHandler::focus_previous_element()
 constexpr bool should_ignore_keydown_event(u32 code_point)
 {
     // FIXME: There are probably also keys with non-zero code points that should be filtered out.
+    // FIXME: We should take the modifier keys into consideration somehow. This treats "Ctrl+C" as just "c".
     return code_point == 0 || code_point == 27;
 }
 
@@ -666,16 +667,16 @@ bool EventHandler::fire_keyboard_event(FlyString const& event_name, HTML::Browsi
         }
 
         auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point);
-        return focused_element->dispatch_event(*event);
+        return !focused_element->dispatch_event(*event);
     }
 
     // FIXME: De-duplicate this. This is just to prevent wasting a KeyboardEvent allocation when recursing into an (i)frame.
     auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point);
 
     if (JS::GCPtr<HTML::HTMLElement> body = document->body())
-        return body->dispatch_event(*event);
+        return !body->dispatch_event(*event);
 
-    return document->root().dispatch_event(*event);
+    return !document->root().dispatch_event(*event);
 }
 
 bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_point)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -94,7 +94,7 @@ void OutOfProcessWebView::load_empty_document()
 
 void OutOfProcessWebView::paint_event(GUI::PaintEvent& event)
 {
-    GUI::AbstractScrollableWidget::paint_event(event);
+    Super::paint_event(event);
 
     // If the available size is empty, we don't have a front or back bitmap to draw.
     if (available_size().is_empty())
@@ -115,7 +115,7 @@ void OutOfProcessWebView::paint_event(GUI::PaintEvent& event)
 
 void OutOfProcessWebView::resize_event(GUI::ResizeEvent& event)
 {
-    GUI::AbstractScrollableWidget::resize_event(event);
+    Super::resize_event(event);
     handle_resize();
 }
 
@@ -193,7 +193,7 @@ void OutOfProcessWebView::doubleclick_event(GUI::MouseEvent& event)
 
 void OutOfProcessWebView::theme_change_event(GUI::ThemeChangeEvent& event)
 {
-    GUI::AbstractScrollableWidget::theme_change_event(event);
+    Super::theme_change_event(event);
     client().async_update_system_theme(Gfx::current_system_theme_buffer());
     request_repaint();
 }

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -26,6 +26,8 @@ class OutOfProcessWebView final
     , public ViewImplementation {
     C_OBJECT(OutOfProcessWebView);
 
+    using Super = GUI::AbstractScrollableWidget;
+
 public:
     virtual ~OutOfProcessWebView() override;
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2020-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/Queue.h>
 #include <AK/URL.h>
 #include <LibGUI/AbstractScrollableWidget.h>
 #include <LibGUI/Widget.h>
@@ -182,6 +184,7 @@ private:
     virtual Gfx::IntRect notify_server_did_request_minimize_window() override;
     virtual Gfx::IntRect notify_server_did_request_fullscreen_window() override;
     virtual void notify_server_did_request_file(Badge<WebContentClient>, String const& path, i32) override;
+    virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
     void request_repaint();
     void handle_resize();
@@ -190,6 +193,10 @@ private:
     WebContentClient& client();
 
     void handle_web_content_process_crash();
+
+    using InputEvent = Variant<GUI::KeyEvent, GUI::MouseEvent>;
+    void enqueue_input_event(InputEvent const&);
+    void process_next_input_event();
 
     AK::URL m_url;
 
@@ -210,6 +217,9 @@ private:
 
     RefPtr<Gfx::Bitmap> m_backup_bitmap;
     RefPtr<GUI::Dialog> m_dialog;
+
+    bool m_is_awaiting_response_for_input_event { false };
+    Queue<InputEvent> m_pending_input_events;
 };
 
 }

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -66,6 +66,7 @@ public:
     virtual Gfx::IntRect notify_server_did_request_minimize_window() = 0;
     virtual Gfx::IntRect notify_server_did_request_fullscreen_window() = 0;
     virtual void notify_server_did_request_file(Badge<WebContentClient>, String const& path, i32) = 0;
+    virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) = 0;
 };
 
 }

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -280,4 +280,9 @@ void WebContentClient::did_request_file(String const& path, i32 request_id)
     m_view.notify_server_did_request_file({}, path, request_id);
 }
 
+void WebContentClient::did_finish_handling_input_event(bool event_was_accepted)
+{
+    m_view.notify_server_did_finish_handling_input_event(event_was_accepted);
+}
+
 }

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -76,6 +76,7 @@ private:
     virtual Messages::WebContentClient::DidRequestMinimizeWindowResponse did_request_minimize_window() override;
     virtual Messages::WebContentClient::DidRequestFullscreenWindowResponse did_request_fullscreen_window() override;
     virtual void did_request_file(String const& path, i32) override;
+    virtual void did_finish_handling_input_event(bool event_was_accepted) override;
 
     ViewImplementation& m_view;
 };

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -158,37 +158,42 @@ void ConnectionFromClient::flush_pending_paint_requests()
 
 void ConnectionFromClient::mouse_down(Gfx::IntPoint const& position, unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
-    page().handle_mousedown(position, button, buttons, modifiers);
+    report_finished_handling_input_event(page().handle_mousedown(position, button, buttons, modifiers));
 }
 
 void ConnectionFromClient::mouse_move(Gfx::IntPoint const& position, [[maybe_unused]] unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
-    page().handle_mousemove(position, buttons, modifiers);
+    report_finished_handling_input_event(page().handle_mousemove(position, buttons, modifiers));
 }
 
 void ConnectionFromClient::mouse_up(Gfx::IntPoint const& position, unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
-    page().handle_mouseup(position, button, buttons, modifiers);
+    report_finished_handling_input_event(page().handle_mouseup(position, button, buttons, modifiers));
 }
 
 void ConnectionFromClient::mouse_wheel(Gfx::IntPoint const& position, unsigned int button, unsigned int buttons, unsigned int modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
 {
-    page().handle_mousewheel(position, button, buttons, modifiers, wheel_delta_x, wheel_delta_y);
+    report_finished_handling_input_event(page().handle_mousewheel(position, button, buttons, modifiers, wheel_delta_x, wheel_delta_y));
 }
 
 void ConnectionFromClient::doubleclick(Gfx::IntPoint const& position, unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
-    page().handle_doubleclick(position, button, buttons, modifiers);
+    report_finished_handling_input_event(page().handle_doubleclick(position, button, buttons, modifiers));
 }
 
 void ConnectionFromClient::key_down(i32 key, unsigned int modifiers, u32 code_point)
 {
-    page().handle_keydown((KeyCode)key, modifiers, code_point);
+    report_finished_handling_input_event(page().handle_keydown((KeyCode)key, modifiers, code_point));
 }
 
 void ConnectionFromClient::key_up(i32 key, unsigned int modifiers, u32 code_point)
 {
-    page().handle_keyup((KeyCode)key, modifiers, code_point);
+    report_finished_handling_input_event(page().handle_keyup((KeyCode)key, modifiers, code_point));
+}
+
+void ConnectionFromClient::report_finished_handling_input_event(bool event_was_handled)
+{
+    async_did_finish_handling_input_event(event_was_handled);
 }
 
 void ConnectionFromClient::debug_request(String const& request, String const& argument)

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -98,6 +98,8 @@ private:
 
     void flush_pending_paint_requests();
 
+    void report_finished_handling_input_event(bool event_was_handled);
+
     NonnullOwnPtr<PageHost> m_page_host;
     struct PaintRequest {
         Gfx::IntRect content_rect;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -52,6 +52,7 @@ endpoint WebContentClient
     did_request_minimize_window() => (Gfx::IntRect window_rect)
     did_request_fullscreen_window() => (Gfx::IntRect window_rect)
     did_request_file(String path, i32 request_id) =|
+    did_finish_handling_input_event(bool event_was_accepted) =|
 
     did_output_js_console_message(i32 message_index) =|
     did_get_js_console_messages(i32 start_index, Vector<String> message_types, Vector<String> messages) =|


### PR DESCRIPTION
Since 9e2bd9d261a8c0c1b5eeafde95ca310efc667204, the OOPWV has been
consuming all mouse and keyboard events, preventing action shortcuts
from working. So let's fix that. :^)

OOPWV now queues up input events, sending them one at a time to the
WebContent process and waiting for the new
`did_finish_handling_input_event(bool event_was_accepted) =|` IPC call
before sending the next one. If the event was not accepted, OOPWV
imitates the usual event bubbling: first passing the event to its
superclass, then to its parent widget, and finally propagating to any
Action shortcuts.

With this, shortcuts like Ctrl+I to open Browser's JS console work
again, except when a contenteditable field is selected. That's a
whole separate stack of yaks.

------

Please merge the Ladybird PR at the same time: https://github.com/SerenityOS/ladybird/pull/134