### PR TITLE
LibJS: Fix rounding in DifferenceInstant & Rename balanceResult to result on step 5.2 of DifferenceTemporalZonedDateTime

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
@@ -1145,13 +1145,13 @@ ThrowCompletionOr<DurationRecord> add_duration(VM& vm, double years1, double mon
 
     // 11. If largestUnit is not one of "year", "month", "week", or "day", then
     if (!largest_unit.is_one_of("year"sv, "month"sv, "week"sv, "day"sv)) {
-        // a. Let diffNs be ! DifferenceInstant(relativeTo.[[Nanoseconds]], endNs, 1, "nanosecond", "halfExpand").
-        auto* diff_ns = difference_instant(vm, relative_to.nanoseconds(), *end_ns, 1, "nanosecond"sv, "halfExpand"sv);
+        // a. Let diffNs be ! DifferenceInstant(relativeTo.[[Nanoseconds]], endNs, 1, "nanosecond", largestUnit, "halfExpand").
+        auto diff_ns = MUST(difference_instant(vm, relative_to.nanoseconds(), *end_ns, 1, "nanosecond"sv, largest_unit, "halfExpand"sv));
 
         // b. Assert: The following steps cannot fail due to overflow in the Number domain because abs(diffNs) ≤ 2 × nsMaxInstant.
 
         // c. Let result be ! BalanceDuration(0, 0, 0, 0, 0, 0, diffNs, largestUnit).
-        auto result = MUST(balance_duration(vm, 0, 0, 0, 0, 0, 0, diff_ns->big_integer(), largest_unit));
+        auto result = MUST(balance_duration(vm, 0, 0, 0, 0, 0, 0, Crypto::SignedBigInteger { diff_ns.nanoseconds }, largest_unit));
 
         // d. Return ? CreateDurationRecord(0, 0, 0, 0, result.[[Hours]], result.[[Minutes]], result.[[Seconds]], result.[[Milliseconds]], result.[[Microseconds]], result.[[Nanoseconds]]).
         return create_duration_record(vm, 0, 0, 0, 0, result.hours, result.minutes, result.seconds, result.milliseconds, result.microseconds, result.nanoseconds);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
@@ -48,7 +48,7 @@ ThrowCompletionOr<Instant*> to_temporal_instant(VM&, Value item);
 ThrowCompletionOr<BigInt*> parse_temporal_instant(VM&, String const& iso_string);
 i32 compare_epoch_nanoseconds(BigInt const&, BigInt const&);
 ThrowCompletionOr<BigInt*> add_instant(VM&, BigInt const& epoch_nanoseconds, double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds);
-BigInt* difference_instant(VM&, BigInt const& nanoseconds1, BigInt const& nanoseconds2, u64 rounding_increment, StringView smallest_unit, StringView rounding_mode);
+ThrowCompletionOr<TimeDurationRecord> difference_instant(VM&, BigInt const& nanoseconds1, BigInt const& nanoseconds2, u64 rounding_increment, StringView smallest_unit, StringView largest_unit, StringView rounding_mode);
 BigInt* round_temporal_instant(VM&, BigInt const& nanoseconds, u64 increment, StringView unit, StringView rounding_mode);
 ThrowCompletionOr<String> temporal_instant_to_string(VM&, Instant&, Value time_zone, Variant<StringView, u8> const& precision);
 ThrowCompletionOr<Duration*> difference_temporal_instant(VM&, DifferenceOperation, Instant const&, Value other, Value options);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -586,16 +586,12 @@ ThrowCompletionOr<Duration*> difference_temporal_zoned_date_time(VM& vm, Differe
 
     // 5. If settings.[[LargestUnit]] is not one of "year", "month", "week", or "day", then
     if (!settings.largest_unit.is_one_of("year"sv, "month"sv, "week"sv, "day"sv)) {
-        // a. Let differenceNs be ! DifferenceInstant(zonedDateTime.[[Nanoseconds]], other.[[Nanoseconds]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
-        auto* difference_ns = difference_instant(vm, zoned_date_time.nanoseconds(), other->nanoseconds(), settings.rounding_increment, settings.smallest_unit, settings.rounding_mode);
 
-        // b. Assert: The following steps cannot fail due to overflow in the Number domain because abs(differenceNs) ≤ 2 × nsMaxInstant.
+        // a. Let result be ! DifferenceInstant(zonedDateTime.[[Nanoseconds]], other.[[Nanoseconds]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[LargestUnit]], settings.[[RoundingMode]]).
+        auto result = MUST(difference_instant(vm, zoned_date_time.nanoseconds(), other->nanoseconds(), settings.rounding_increment, settings.smallest_unit, settings.largest_unit, settings.rounding_mode));
 
-        // c. Let balanceResult be ! BalanceDuration(0, 0, 0, 0, 0, 0, differenceNs, settings.[[LargestUnit]]).
-        auto balance_result = MUST(balance_duration(vm, 0, 0, 0, 0, 0, 0, difference_ns->big_integer(), settings.largest_unit));
-
-        // d. Return ! CreateTemporalDuration(0, 0, 0, 0, sign × balanceResult.[[Hours]], sign × balanceResult.[[Minutes]], sign × balanceResult.[[Seconds]], sign × balanceResult.[[Milliseconds]], sign × balanceResult.[[Microseconds]], sign × balanceResult.[[Nanoseconds]]).
-        return MUST(create_temporal_duration(vm, 0, 0, 0, 0, sign * balance_result.hours, sign * balance_result.minutes, sign * balance_result.seconds, sign * balance_result.milliseconds, sign * balance_result.microseconds, sign * balance_result.nanoseconds));
+        // b. Return ! CreateTemporalDuration(0, 0, 0, 0, sign × result.[[Hours]], sign × result.[[Minutes]], sign × result.[[Seconds]], sign × result.[[Milliseconds]], sign × result.[[Microseconds]], sign × result.[[Nanoseconds]]).
+        return MUST(create_temporal_duration(vm, 0, 0, 0, 0, sign * result.hours, sign * result.minutes, sign * result.seconds, sign * result.milliseconds, sign * result.microseconds, sign * result.nanoseconds));
     }
 
     // 6. If ? TimeZoneEquals(zonedDateTime.[[TimeZone]], other.[[TimeZone]]) is false, then

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.since.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.since.js
@@ -9,8 +9,8 @@ describe("correct behavior", () => {
             [2345679011n, 123456789n, "PT2.222222222S"],
             [123456789n, 0n, "PT0.123456789S"],
             [0n, 123456789n, "-PT0.123456789S"],
-            [123456789123456789n, 0n, "PT34293H33M9.123456789S"],
-            [0n, 123456789123456789n, "-PT34293H33M9.123456789S"],
+            [123456789123456789n, 0n, "PT34293H33M9.123456784S"],
+            [0n, 123456789123456789n, "-PT34293H33M9.123456784S"],
         ];
         const utc = new Temporal.TimeZone("UTC");
         for (const [arg, argOther, expected] of values) {
@@ -34,7 +34,7 @@ describe("correct behavior", () => {
             ["second", "PT9556H5M6S"],
             ["millisecond", "PT9556H5M6.007S"],
             ["microsecond", "PT9556H5M6.007008S"],
-            ["nanosecond", "PT9556H5M6.007008009S"],
+            ["nanosecond", "PT9556H5M6.007008008S"],
         ];
         for (const [smallestUnit, expected] of values) {
             expect(zonedDateTime.since(other, { smallestUnit }).toString()).toBe(expected);
@@ -50,11 +50,11 @@ describe("correct behavior", () => {
             ["month", "P13M2DT4H5M6.007008009S"],
             ["week", "P56W6DT4H5M6.007008009S"],
             ["day", "P398DT4H5M6.007008009S"],
-            ["hour", "PT9556H5M6.007008009S"],
-            ["minute", "PT573365M6.007008009S"],
-            ["second", "PT34401906.007008009S"],
-            ["millisecond", "PT34401906.007008009S"],
-            ["microsecond", "PT34401906.007008009S"],
+            ["hour", "PT9556H5M6.007008008S"],
+            ["minute", "PT573365M6.007008008S"],
+            ["second", "PT34401906.007008008S"],
+            ["millisecond", "PT34401906.007008008S"],
+            ["microsecond", "PT34401906.007008008S"],
             ["nanosecond", "PT34401906.007008008S"],
         ];
         for (const [largestUnit, expected] of values) {

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.until.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.until.js
@@ -9,8 +9,8 @@ describe("correct behavior", () => {
             [123456789n, 2345679011n, "PT2.222222222S"],
             [0n, 123456789n, "PT0.123456789S"],
             [123456789n, 0n, "-PT0.123456789S"],
-            [0n, 123456789123456789n, "PT34293H33M9.123456789S"],
-            [123456789123456789n, 0n, "-PT34293H33M9.123456789S"],
+            [0n, 123456789123456789n, "PT34293H33M9.123456784S"],
+            [123456789123456789n, 0n, "-PT34293H33M9.123456784S"],
         ];
         const utc = new Temporal.TimeZone("UTC");
         for (const [arg, argOther, expected] of values) {
@@ -34,7 +34,7 @@ describe("correct behavior", () => {
             ["second", "PT9556H5M6S"],
             ["millisecond", "PT9556H5M6.007S"],
             ["microsecond", "PT9556H5M6.007008S"],
-            ["nanosecond", "PT9556H5M6.007008009S"],
+            ["nanosecond", "PT9556H5M6.007008008S"],
         ];
         for (const [smallestUnit, expected] of values) {
             expect(zonedDateTime.until(other, { smallestUnit }).toString()).toBe(expected);
@@ -50,11 +50,11 @@ describe("correct behavior", () => {
             ["month", "P13M2DT4H5M6.007008009S"],
             ["week", "P56W6DT4H5M6.007008009S"],
             ["day", "P398DT4H5M6.007008009S"],
-            ["hour", "PT9556H5M6.007008009S"],
-            ["minute", "PT573365M6.007008009S"],
-            ["second", "PT34401906.007008009S"],
-            ["millisecond", "PT34401906.007008009S"],
-            ["microsecond", "PT34401906.007008009S"],
+            ["hour", "PT9556H5M6.007008008S"],
+            ["minute", "PT573365M6.007008008S"],
+            ["second", "PT34401906.007008008S"],
+            ["millisecond", "PT34401906.007008008S"],
+            ["microsecond", "PT34401906.007008008S"],
             ["nanosecond", "PT34401906.007008008S"],
         ];
         for (const [largestUnit, expected] of values) {


### PR DESCRIPTION
This is my first attempt at a contribution for Serenity and I believe that this should satisfy 2 boxes on https://github.com/SerenityOS/serenity/issues/15525#issue-1402313071

https://github.com/tc39/proposal-temporal/commit/e192f2c3a870c29be4d586d423f7f47361d88543 - Fix rounding in DifferenceInstant
https://github.com/tc39/proposal-temporal/commit/72b58dc8e322224096880960fd1f1f88ff14099a - Editorial: Rename balanceResult to result on step 5.2 of DifferenceTemporalZonedDateTime

Looking at the whole of DifferenceTemporalZonedDateTime it looks like there may be further updates to be considered however this was not in the scope of the task in the original issue so I have not implemented it at this stage but would be happy to revisit

Additionally the tests have been updated to match. Hopefully I've understood the task at hand properly and any guidance for the future is appreciated

