### PR TITLE
LibWeb: Remove unused should_invalidate_styles_on_attribute_changes() hack

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -100,9 +100,6 @@ public:
     String referrer() const;
     void set_referrer(String);
 
-    bool should_invalidate_styles_on_attribute_changes() const { return m_should_invalidate_styles_on_attribute_changes; }
-    void set_should_invalidate_styles_on_attribute_changes(bool b) { m_should_invalidate_styles_on_attribute_changes = b; }
-
     void set_url(const AK::URL& url) { m_url = url; }
     AK::URL url() const { return m_url; }
     AK::URL fallback_base_url() const;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -128,7 +128,6 @@ HTMLParser::HTMLParser(DOM::Document& document, StringView input, String const& 
 {
     m_tokenizer.set_parser({}, *this);
     m_document->set_parser({}, *this);
-    m_document->set_should_invalidate_styles_on_attribute_changes(false);
     auto standardized_encoding = TextCodec::get_standardized_encoding(encoding);
     VERIFY(standardized_encoding.has_value());
     m_document->set_encoding(standardized_encoding.value());
@@ -144,7 +143,6 @@ HTMLParser::HTMLParser(DOM::Document& document)
 
 HTMLParser::~HTMLParser()
 {
-    m_document->set_should_invalidate_styles_on_attribute_changes(true);
 }
 
 void HTMLParser::visit_edges(Cell::Visitor& visitor)


### PR DESCRIPTION
This getter and setter were previously used to disable style invalidation on attribute changes during the HTML parsing phase (as it caused big site's loading to be slow). These functions are currently not used, so they can be removed:^)