### PR TITLE
Assorted LibPDF improvements

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -29,7 +29,7 @@ struct Page;
 
 class ColorSpace : public RefCounted<ColorSpace> {
 public:
-    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, FlyString const& name, Page const& page);
+    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, FlyString const& name, NonnullRefPtr<DictObject> resources);
 
     virtual ~ColorSpace() = default;
 
@@ -91,7 +91,7 @@ private:
 
 class ICCBasedColorSpace final : public ColorSpace {
 public:
-    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, Page const&, Vector<Value>&& parameters);
+    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, NonnullRefPtr<DictObject> resources, Vector<Value>&& parameters);
 
     ~ICCBasedColorSpace() override = default;
 

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -74,6 +74,7 @@
     A(HTO)                        \
     A(ICCBased)                   \
     A(ID)                         \
+    A(Image)                      \
     A(Index)                      \
     A(JBIG2Decode)                \
     A(JPXDecode)                  \
@@ -133,6 +134,7 @@
     A(W)                          \
     A(WhitePoint)                 \
     A(Widths)                     \
+    A(XObject)                    \
     A(XYZ)                        \
     A(ca)                         \
     A(op)

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -364,6 +364,7 @@ String Parser::parse_hex_string()
             int hex_value = 0;
 
             for (int i = 0; i < 2; i++) {
+                m_reader.consume_whitespace();
                 auto ch = m_reader.consume();
                 if (ch == '>') {
                     // The hex string contains an odd number of characters, and the last character
@@ -373,7 +374,6 @@ String Parser::parse_hex_string()
                     builder.append(static_cast<char>(hex_value));
                     return builder.to_string();
                 }
-
                 VERIFY(isxdigit(ch));
 
                 hex_value *= 16;

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -592,7 +592,38 @@ RENDERER_TODO(shade)
 RENDERER_TODO(inline_image_begin)
 RENDERER_TODO(inline_image_begin_data)
 RENDERER_TODO(inline_image_end)
-RENDERER_TODO(paint_xobject)
+RENDERER_HANDLER(paint_xobject)
+{
+    VERIFY(args.size() > 0);
+    auto resources = extra_resources.value_or(m_page.resources);
+    auto xobject_name = args[0].get<NonnullRefPtr<Object>>()->cast<NameObject>()->name();
+    auto xobjects_dict = MUST(resources->get_dict(m_document, CommonNames::XObject));
+    auto xobject = MUST(xobjects_dict->get_stream(m_document, xobject_name));
+
+    auto subtype = MUST(xobject->dict()->get_name(m_document, CommonNames::Subtype))->name();
+    if (subtype == CommonNames::Image) {
+        dbgln("Skipping image");
+        return {};
+    }
+
+    MUST(handle_save_state({}));
+    Vector<Value> matrix;
+    if (xobject->dict()->contains(CommonNames::Matrix)) {
+        matrix = xobject->dict()->get_array(m_document, CommonNames::Matrix).value()->elements();
+    } else {
+        matrix = Vector { Value { 1 }, Value { 0 }, Value { 0 }, Value { 1 }, Value { 0 }, Value { 0 } };
+    }
+    MUST(handle_concatenate_matrix(matrix));
+    Optional<NonnullRefPtr<DictObject>> xobject_resources {};
+    if (xobject->dict()->contains(CommonNames::Resources)) {
+        xobject_resources = xobject->dict()->get_dict(m_document, CommonNames::Resources).value();
+    }
+    auto operators = TRY(Parser::parse_operators(m_document, xobject->bytes()));
+    for (auto& op : operators)
+        TRY(handle_operator(op, xobject_resources));
+    MUST(handle_restore_state({}));
+    return {};
+}
 
 RENDERER_HANDLER(marked_content_point)
 {

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -193,9 +193,40 @@ RENDERER_HANDLER(path_line)
     return {};
 }
 
-RENDERER_TODO(path_cubic_bezier_curve)
-RENDERER_TODO(path_cubic_bezier_curve_no_first_control)
-RENDERER_TODO(path_cubic_bezier_curve_no_second_control)
+RENDERER_HANDLER(path_cubic_bezier_curve)
+{
+    VERIFY(args.size() == 6);
+    m_current_path.cubic_bezier_curve_to(
+        map(args[0].to_float(), args[1].to_float()),
+        map(args[2].to_float(), args[3].to_float()),
+        map(args[4].to_float(), args[5].to_float()));
+    return {};
+}
+
+RENDERER_HANDLER(path_cubic_bezier_curve_no_first_control)
+{
+    VERIFY(args.size() == 4);
+    VERIFY(!m_current_path.segments().is_empty());
+    auto current_point = m_current_path.segments().rbegin()->point();
+    m_current_path.cubic_bezier_curve_to(
+        current_point,
+        map(args[0].to_float(), args[1].to_float()),
+        map(args[2].to_float(), args[3].to_float()));
+    return {};
+}
+
+RENDERER_HANDLER(path_cubic_bezier_curve_no_second_control)
+{
+    VERIFY(args.size() == 4);
+    VERIFY(!m_current_path.segments().is_empty());
+    auto first_control_point = map(args[0].to_float(), args[1].to_float());
+    auto second_control_point = map(args[2].to_float(), args[3].to_float());
+    m_current_path.cubic_bezier_curve_to(
+        first_control_point,
+        second_control_point,
+        second_control_point);
+    return {};
+}
 
 RENDERER_HANDLER(path_close)
 {

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -10,7 +10,7 @@
 #include <LibPDF/Renderer.h>
 
 #define RENDERER_HANDLER(name) \
-    PDFErrorOr<void> Renderer::handle_##name([[maybe_unused]] Vector<Value> const& args)
+    PDFErrorOr<void> Renderer::handle_##name([[maybe_unused]] Vector<Value> const& args, [[maybe_unused]] Optional<NonnullRefPtr<DictObject>> extra_resources)
 
 #define RENDERER_TODO(name)                                         \
     RENDERER_HANDLER(name)                                          \
@@ -86,20 +86,20 @@ PDFErrorOr<void> Renderer::render()
     return {};
 }
 
-PDFErrorOr<void> Renderer::handle_operator(Operator const& op)
+PDFErrorOr<void> Renderer::handle_operator(Operator const& op, Optional<NonnullRefPtr<DictObject>> extra_resources)
 {
     switch (op.type()) {
-#define V(name, snake_name, symbol)               \
-    case OperatorType::name:                      \
-        TRY(handle_##snake_name(op.arguments())); \
+#define V(name, snake_name, symbol)                                 \
+    case OperatorType::name:                                        \
+        MUST(handle_##snake_name(op.arguments(), extra_resources)); \
         break;
         ENUMERATE_OPERATORS(V)
 #undef V
     case OperatorType::TextNextLineShowString:
-        TRY(handle_text_next_line_show_string(op.arguments()));
+        MUST(handle_text_next_line_show_string(op.arguments()));
         break;
     case OperatorType::TextNextLineShowStringSetSpacing:
-        TRY(handle_text_next_line_show_string_set_spacing(op.arguments()));
+        MUST(handle_text_next_line_show_string_set_spacing(op.arguments()));
         break;
     }
 
@@ -172,9 +172,9 @@ RENDERER_TODO(set_flatness_tolerance)
 
 RENDERER_HANDLER(set_graphics_state_from_dict)
 {
-    VERIFY(m_page.resources->contains(CommonNames::ExtGState));
+    auto resources = extra_resources.value_or(m_page.resources);
     auto dict_name = MUST(m_document->resolve_to<NameObject>(args[0]))->name();
-    auto ext_gstate_dict = MUST(m_page.resources->get_dict(m_document, CommonNames::ExtGState));
+    auto ext_gstate_dict = MUST(resources->get_dict(m_document, CommonNames::ExtGState));
     auto target_dict = MUST(ext_gstate_dict->get_dict(m_document, dict_name));
     TRY(set_graphics_state_from_dict(target_dict));
     return {};
@@ -375,8 +375,9 @@ RENDERER_HANDLER(text_set_leading)
 
 RENDERER_HANDLER(text_set_font)
 {
+    auto resources = extra_resources.value_or(m_page.resources);
     auto target_font_name = MUST(m_document->resolve_to<NameObject>(args[0]))->name();
-    auto fonts_dictionary = MUST(m_page.resources->get_dict(m_document, CommonNames::Font));
+    auto fonts_dictionary = MUST(resources->get_dict(m_document, CommonNames::Font));
     auto font_dictionary = MUST(fonts_dictionary->get_dict(m_document, target_font_name));
     auto font = TRY(PDFFont::create(m_document, font_dictionary));
     text_state().font = font;
@@ -499,14 +500,14 @@ RENDERER_TODO(type3_font_set_glyph_width_and_bbox)
 
 RENDERER_HANDLER(set_stroking_space)
 {
-    state().stroke_color_space = TRY(get_color_space(args[0], m_page.resources));
+    state().stroke_color_space = TRY(get_color_space(args[0], extra_resources.value_or(m_page.resources)));
     VERIFY(state().stroke_color_space);
     return {};
 }
 
 RENDERER_HANDLER(set_painting_space)
 {
-    state().paint_color_space = TRY(get_color_space(args[0], m_page.resources));
+    state().paint_color_space = TRY(get_color_space(args[0], extra_resources.value_or(m_page.resources)));
     VERIFY(state().paint_color_space);
     return {};
 }

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -468,14 +468,14 @@ RENDERER_TODO(type3_font_set_glyph_width_and_bbox)
 
 RENDERER_HANDLER(set_stroking_space)
 {
-    state().stroke_color_space = TRY(get_color_space(args[0]));
+    state().stroke_color_space = TRY(get_color_space(args[0], m_page.resources));
     VERIFY(state().stroke_color_space);
     return {};
 }
 
 RENDERER_HANDLER(set_painting_space)
 {
-    state().paint_color_space = TRY(get_color_space(args[0]));
+    state().paint_color_space = TRY(get_color_space(args[0], m_page.resources));
     VERIFY(state().paint_color_space);
     return {};
 }
@@ -691,10 +691,10 @@ void Renderer::show_text(String const& string)
     m_text_matrix.translate(delta_x / text_rendering_matrix.x_scale(), 0.0f);
 }
 
-PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space(Value const& value)
+PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space(Value const& value, NonnullRefPtr<DictObject> resources)
 {
     auto name = value.get<NonnullRefPtr<Object>>()->cast<NameObject>()->name();
-    return TRY(ColorSpace::create(m_document, name, m_page));
+    return TRY(ColorSpace::create(m_document, name, resources));
 }
 
 Gfx::AffineTransform const& Renderer::calculate_text_rendering_matrix()

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -99,7 +99,7 @@ private:
 
     PDFErrorOr<void> set_graphics_state_from_dict(NonnullRefPtr<DictObject>);
     void show_text(String const&);
-    PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space(Value const&);
+    PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space(Value const&, NonnullRefPtr<DictObject>);
 
     ALWAYS_INLINE GraphicsState const& state() const { return m_graphics_state_stack.last(); }
     ALWAYS_INLINE GraphicsState& state() { return m_graphics_state_stack.last(); }

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -89,13 +89,13 @@ private:
 
     PDFErrorOr<void> render();
 
-    PDFErrorOr<void> handle_operator(Operator const&);
+    PDFErrorOr<void> handle_operator(Operator const&, Optional<NonnullRefPtr<DictObject>> = {});
 #define V(name, snake_name, symbol) \
-    PDFErrorOr<void> handle_##snake_name(Vector<Value> const& args);
+    PDFErrorOr<void> handle_##snake_name(Vector<Value> const& args, Optional<NonnullRefPtr<DictObject>> = {});
     ENUMERATE_OPERATORS(V)
 #undef V
-    PDFErrorOr<void> handle_text_next_line_show_string(Vector<Value> const& args);
-    PDFErrorOr<void> handle_text_next_line_show_string_set_spacing(Vector<Value> const& args);
+    PDFErrorOr<void> handle_text_next_line_show_string(Vector<Value> const& args, Optional<NonnullRefPtr<DictObject>> = {});
+    PDFErrorOr<void> handle_text_next_line_show_string_set_spacing(Vector<Value> const& args, Optional<NonnullRefPtr<DictObject>> = {});
 
     PDFErrorOr<void> set_graphics_state_from_dict(NonnullRefPtr<DictObject>);
     void show_text(String const&);


### PR DESCRIPTION
This PR contains a number of assorted LibPDF improvements, namely:
 * RunLengthDecode Filter support
 * Basic XObject rendering (Form objects are rendered, Images are skipped)
 * Cubic Bazier rendering
 * Fix on hexstring parsing

I set out to implement only the first item, but when wanting to try it out with a real document that used that encoding. I found one in https://github.com/mozilla/pdf.js/issues/626, and while trying to visualise it I stumbled across the other issues.

With these changes the document above loads and shows a logo on the first page, which wasn't happening before. I've learned quite a bit about PDF in the process, which is great (I knew basically nothing before this).