### PR TITLE
LibGfx: Add Layers, an abstraction to draw shapes in one pass

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LineTool.cpp
@@ -10,15 +10,14 @@
 #include "LineTool.h"
 #include "../ImageEditor.h"
 #include "../Layer.h"
-#include <AK/Math.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/CheckBox.h>
 #include <LibGUI/Label.h>
-#include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/ValueSlider.h>
 #include <LibGfx/AntiAliasingPainter.h>
+#include <LibGfx/Layer.h>
 
 namespace PixelPaint {
 
@@ -65,7 +64,8 @@ void LineTool::draw_using(GUI::Painter& painter, Gfx::IntPoint start_position, G
         };
         aa_painter.draw_line(as_float_point(start_position), as_float_point(end_position), color, thickness);
     } else {
-        painter.draw_line(start_position, end_position, color, thickness);
+        auto layer = make_ref_counted<Gfx::Layer>(painter.target(), color);
+        painter.draw_line(start_position, end_position, color, thickness, {}, {}, layer);
     }
 }
 

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES
     ICOLoader.cpp
     ImageDecoder.cpp
     JPGLoader.cpp
+    Layer.cpp
     PBMLoader.cpp
     PGMLoader.cpp
     PNGLoader.cpp

--- a/Userland/Libraries/LibGfx/Layer.cpp
+++ b/Userland/Libraries/LibGfx/Layer.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, Lucas Chollet <lucas.chollet@free.fr>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Layer.h"
+#include <AK/Function.h>
+#include <LibGfx/Bitmap.h>
+
+namespace Gfx {
+
+Layer::Layer(NonnullRefPtr<Bitmap> target, Gfx::Color color)
+    : m_target(move(target))
+    , m_color(color)
+{
+}
+
+void Layer::add_point(Gfx::IntPoint const& position, Gfx::Color color)
+{
+    VERIFY(color == m_color);
+
+    m_points.set(position);
+}
+
+void Layer::draw()
+{
+    for (auto const& point : m_points) {
+        auto& pixel = m_target->scanline(point.y())[point.x()];
+        pixel = Color::from_argb(pixel).blend(m_color).value();
+    }
+}
+
+Layer::~Layer()
+{
+    draw();
+}
+
+}

--- a/Userland/Libraries/LibGfx/Layer.h
+++ b/Userland/Libraries/LibGfx/Layer.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, Lucas Chollet <lucas.chollet@free.fr>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashTable.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <LibGfx/Color.h>
+#include <LibGfx/Forward.h>
+#include <LibGfx/Point.h>
+
+namespace Gfx {
+
+class Layer : public RefCounted<Layer> {
+public:
+    Layer(NonnullRefPtr<Bitmap> target, Color color);
+    ~Layer();
+
+    void add_point(IntPoint const& position, Color color);
+
+private:
+    void draw();
+
+    NonnullRefPtr<Bitmap> m_target;
+
+    HashTable<IntPoint> m_points {};
+    Color m_color {};
+};
+
+}

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -13,6 +13,7 @@
 #include <LibGfx/Color.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/Layer.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/Size.h>
@@ -67,7 +68,7 @@ public:
     void set_pixel(int x, int y, Color color, bool blend = false) { set_pixel({ x, y }, color, blend); }
     Optional<Color> get_pixel(IntPoint);
     ErrorOr<NonnullRefPtr<Bitmap>> get_region_bitmap(IntRect const&, BitmapFormat format, Optional<IntRect&> actual_region = {});
-    void draw_line(IntPoint, IntPoint, Color, int thickness = 1, LineStyle style = LineStyle::Solid, Color alternate_color = Color::Transparent);
+    void draw_line(IntPoint, IntPoint, Color, int thickness = 1, LineStyle style = LineStyle::Solid, Color alternate_color = Color::Transparent, Optional<NonnullRefPtr<Layer>> = {});
     void draw_triangle_wave(IntPoint, IntPoint, Color color, int amplitude, int thickness = 1);
     void draw_quadratic_bezier_curve(IntPoint control_point, IntPoint, IntPoint, Color, int thickness = 1, LineStyle style = LineStyle::Solid);
     void draw_cubic_bezier_curve(IntPoint control_point_0, IntPoint control_point_1, IntPoint, IntPoint, Color, int thickness = 1, LineStyle style = LineStyle::Solid);
@@ -168,7 +169,7 @@ protected:
     void fill_physical_scanline_with_draw_op(int y, int x, int width, Color color);
     void fill_rect_with_draw_op(IntRect const&, Color);
     void blit_with_opacity(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect, float opacity, bool apply_alpha = true);
-    void draw_physical_pixel(IntPoint, Color, int thickness = 1);
+    void draw_physical_pixel(IntPoint, Color, int thickness = 1, Optional<NonnullRefPtr<Layer>> layer = {});
 
     struct State {
         Font const* font;
@@ -181,7 +182,7 @@ protected:
     State& state() { return m_state_stack.last(); }
     State const& state() const { return m_state_stack.last(); }
 
-    void fill_physical_rect(IntRect const&, Color);
+    void fill_physical_rect(IntRect const&, Color, Optional<NonnullRefPtr<Layer>> layer = {});
 
     IntRect m_clip_origin;
     NonnullRefPtr<Gfx::Bitmap> m_target;

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -148,7 +148,7 @@ public:
 
     IntPoint translation() const { return state().translation; }
 
-    Gfx::Bitmap* target() { return m_target.ptr(); }
+    NonnullRefPtr<Bitmap> target() { return m_target; }
 
     void save() { m_state_stack.append(m_state_stack.last()); }
     void restore()


### PR DESCRIPTION
This prevents multiple applications of color when drawing shapes that
require multiple pass on a pixel.

This includes (at least):
 - Horizontal or vertical lines with an even length
 - Lines with a thickness > 1
 - Filled and basic ellipses
 - Any shape drawn using overlapping lines

Resolves #13969

Before:

![before.png](https://user-images.githubusercontent.com/26030965/203037486-3f8d29a1-2597-40b9-9cdc-0088808061ea.png)

After:
![after.png](https://user-images.githubusercontent.com/26030965/203037672-b76ba8aa-d73f-4d14-8b3e-b5b1cb84f76b.png)
