### PR TITLE
LibWeb: Fix a bug in multiple line name parsing for CSS Grid

### DIFF
--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -131,6 +131,15 @@ that I don't quite understand. -->
   <div class="grid-item">1</div>
 </div>
   
+<div 
+  class="grid-container"
+  style="
+    grid-column-gap: 1px;
+    grid-template-columns: [name1 name2 name3] 1fr repeat(1, [name4 name5 name6] 1fr);
+  ">
+  <div class="grid-item">1</div>
+</div>
+  
 <p>End of crash tests</p>
 
 <!-- Different column sizes -->

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5868,6 +5868,7 @@ Optional<CSS::GridRepeat> Parser::parse_repeat(Vector<ComponentValue> const& com
             while (block_tokens.has_next_token()) {
                 auto current_block_token = block_tokens.next_token();
                 line_names.append(current_block_token.token().ident());
+                block_tokens.skip_whitespace();
             }
             line_names_list.append(line_names);
             part_two_tokens.skip_whitespace();
@@ -5966,6 +5967,7 @@ RefPtr<StyleValue> Parser::parse_grid_track_sizes(Vector<ComponentValue> const& 
             while (block_tokens.has_next_token()) {
                 auto current_block_token = block_tokens.next_token();
                 line_names.append(current_block_token.token().ident());
+                block_tokens.skip_whitespace();
             }
             line_names_list.append(line_names);
         } else {


### PR DESCRIPTION
This fixes a bug where having multiple line names causes the web engine to crash.