### PR TITLE
LibJS: Reduce AST memory usage

### DIFF
--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -71,7 +71,7 @@ Sheet::Sheet(Workbook& workbook)
                     for (auto& traceback_frame : error.traceback()) {
                         auto& function_name = traceback_frame.function_name;
                         auto& source_range = traceback_frame.source_range;
-                        dbgln("  {} at {}:{}:{}", function_name, source_range.filename, source_range.start.line, source_range.start.column);
+                        dbgln("  {} at {}:{}:{}", function_name, source_range.filename(), source_range.start.line, source_range.start.column);
                     }
                 } else {
                     warnln();

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -122,13 +122,13 @@ GUI::Variant SheetModel::data(const GUI::ModelIndex& index, GUI::ModelRole role)
         StringBuilder builder;
         builder.appendff("{}\n", error.get_without_side_effects(object.vm().names.message).to_string_without_side_effects());
         for (auto const& frame : trace.in_reverse()) {
-            if (frame.source_range.filename.contains("runtime.js"sv)) {
+            if (frame.source_range.filename().contains("runtime.js"sv)) {
                 if (frame.function_name == "<unknown>")
                     builder.appendff("  in a builtin function at line {}, column {}\n", frame.source_range.start.line, frame.source_range.start.column);
                 else
                     builder.appendff("  while evaluating builtin '{}'\n", frame.function_name);
-            } else if (frame.source_range.filename.starts_with("cell "sv)) {
-                builder.appendff("  in cell '{}', at line {}, column {}\n", frame.source_range.filename.substring_view(5), frame.source_range.start.line, frame.source_range.start.column);
+            } else if (frame.source_range.filename().starts_with("cell "sv)) {
+                builder.appendff("  in cell '{}', at line {}, column {}\n", frame.source_range.filename().substring_view(5), frame.source_range.start.line, frame.source_range.start.column);
             }
         }
         return builder.to_string();

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -61,6 +61,18 @@ private:
     ExecutingASTNodeChain m_chain_node;
 };
 
+ASTNode::ASTNode(SourceRange source_range)
+    : m_source_code(source_range.code)
+    , m_start_offset(source_range.start.offset)
+    , m_end_offset(source_range.end.offset)
+{
+}
+
+SourceRange ASTNode::source_range() const
+{
+    return m_source_code->range_from_offsets(m_start_offset, m_end_offset);
+}
+
 String ASTNode::class_name() const
 {
     // NOTE: We strip the "JS::" prefix.
@@ -4792,6 +4804,11 @@ ModuleRequest::ModuleRequest(FlyString module_specifier_, Vector<Assertion> asse
     quick_sort(assertions, [](Assertion const& lhs, Assertion const& rhs) {
         return lhs.key < rhs.key;
     });
+}
+
+String const& SourceRange::filename() const
+{
+    return code->filename();
 }
 
 }

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1387,13 +1387,13 @@ ThrowCompletionOr<Reference> Expression::to_reference(Interpreter&) const
 
 ThrowCompletionOr<Reference> Identifier::to_reference(Interpreter& interpreter) const
 {
-    if (m_cached_environment_coordinate.has_value()) {
+    if (m_cached_environment_coordinate.is_valid()) {
         Environment* environment = nullptr;
-        if (m_cached_environment_coordinate->index == EnvironmentCoordinate::global_marker) {
+        if (m_cached_environment_coordinate.index == EnvironmentCoordinate::global_marker) {
             environment = &interpreter.vm().current_realm()->global_environment();
         } else {
             environment = interpreter.vm().running_execution_context().lexical_environment;
-            for (size_t i = 0; i < m_cached_environment_coordinate->hops; ++i)
+            for (size_t i = 0; i < m_cached_environment_coordinate.hops; ++i)
                 environment = environment->outer_environment();
             VERIFY(environment);
             VERIFY(environment->is_declarative_environment());
@@ -1406,7 +1406,7 @@ ThrowCompletionOr<Reference> Identifier::to_reference(Interpreter& interpreter) 
 
     auto reference = TRY(interpreter.vm().resolve_binding(string()));
     if (reference.environment_coordinate().has_value())
-        m_cached_environment_coordinate = reference.environment_coordinate();
+        m_cached_environment_coordinate = reference.environment_coordinate().value();
     return reference;
 }
 

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -52,8 +52,7 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const;
     virtual void dump(int indent) const;
 
-    SourceRange const& source_range() const { return m_source_range; }
-    SourceRange& source_range() { return m_source_range; }
+    SourceRange source_range() const;
 
     String class_name() const;
 
@@ -84,13 +83,12 @@ public:
     virtual bool is_class_method() const { return false; }
 
 protected:
-    explicit ASTNode(SourceRange source_range)
-        : m_source_range(source_range)
-    {
-    }
+    explicit ASTNode(SourceRange);
 
 private:
-    SourceRange m_source_range;
+    RefPtr<SourceCode> m_source_code;
+    u32 m_start_offset { 0 };
+    u32 m_end_offset { 0 };
 };
 
 class Statement : public ASTNode {

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1222,7 +1222,7 @@ private:
     virtual bool is_identifier() const override { return true; }
 
     FlyString m_string;
-    mutable Optional<EnvironmentCoordinate> m_cached_environment_coordinate;
+    mutable EnvironmentCoordinate m_cached_environment_coordinate;
 };
 
 class PrivateIdentifier final : public Expression {

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1212,7 +1212,6 @@ public:
     }
 
     FlyString const& string() const { return m_string; }
-    void set_lexically_bound_function_argument_index(size_t index) { m_lexically_bound_function_argument = index; }
 
     virtual Completion execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
@@ -1223,7 +1222,6 @@ private:
     virtual bool is_identifier() const override { return true; }
 
     FlyString m_string;
-    Optional<size_t> m_lexically_bound_function_argument;
     mutable Optional<EnvironmentCoordinate> m_cached_environment_coordinate;
 };
 

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -244,6 +244,7 @@ set(SOURCES
     Runtime/WeakSetPrototype.cpp
     Runtime/WrappedFunction.cpp
     Script.cpp
+    SourceCode.cpp
     SourceTextModule.cpp
     SyntaxHighlighter.cpp
     SyntheticModule.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -188,6 +188,8 @@ class Script;
 class Shape;
 class Statement;
 class StringOrSymbol;
+class SourceCode;
+struct SourceRange;
 class SourceTextModule;
 class Symbol;
 class Token;

--- a/Userland/Libraries/LibJS/Lexer.h
+++ b/Userland/Libraries/LibJS/Lexer.h
@@ -20,8 +20,8 @@ public:
 
     Token next();
 
-    StringView source() const { return m_source; };
-    StringView filename() const { return m_filename; };
+    String const& source() const { return m_source; };
+    String const& filename() const { return m_filename; };
 
     void disallow_html_comments() { m_allow_html_comments = false; };
 
@@ -57,13 +57,13 @@ private:
 
     TokenType consume_regex_literal();
 
-    StringView m_source;
+    String m_source;
     size_t m_position { 0 };
     Token m_current_token;
     char m_current_char { 0 };
     bool m_eof { false };
 
-    StringView m_filename;
+    String m_filename;
     size_t m_line_number { 1 };
     size_t m_line_column { 0 };
 

--- a/Userland/Libraries/LibJS/MarkupGenerator.cpp
+++ b/Userland/Libraries/LibJS/MarkupGenerator.cpp
@@ -150,7 +150,7 @@ void MarkupGenerator::trace_to_html(TracebackFrame const& traceback_frame, Strin
         auto last_slash_index = filename.find_last('/');
         return last_slash_index.has_value() ? filename.substring_view(*last_slash_index + 1) : filename;
     };
-    auto filename = escape_html_entities(get_filename_from_path(traceback_frame.source_range.filename));
+    auto filename = escape_html_entities(get_filename_from_path(traceback_frame.source_range.filename()));
     auto trace = String::formatted("at {} ({}:{}:{})", function_name, filename, line, column);
 
     html_output.appendff("&nbsp;&nbsp;{}<br>", trace);

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -222,15 +222,6 @@ public:
     {
         VERIFY(is_top_level() || m_parent_scope);
 
-        if (!m_contains_access_to_arguments_object) {
-            for (auto& it : m_identifier_and_argument_index_associations) {
-                for (auto& identifier : it.value) {
-                    if (!has_declaration(identifier.string()))
-                        identifier.set_lexically_bound_function_argument_index(it.key);
-                }
-            }
-        }
-
         for (size_t i = 0; i < m_functions_to_hoist.size(); i++) {
             auto const& function_declaration = m_functions_to_hoist[i];
             if (m_lexical_names.contains(function_declaration.name()) || m_forbidden_var_names.contains(function_declaration.name()))
@@ -250,11 +241,6 @@ public:
 
         VERIFY(m_parser.m_state.current_scope_pusher == this);
         m_parser.m_state.current_scope_pusher = m_parent_scope;
-    }
-
-    void associate_identifier_with_argument_index(NonnullRefPtr<Identifier> identifier, size_t index)
-    {
-        m_identifier_and_argument_index_associations.ensure(index).append(move(identifier));
     }
 
     void set_contains_await_expression()
@@ -289,7 +275,6 @@ private:
     NonnullRefPtrVector<FunctionDeclaration> m_functions_to_hoist;
 
     Optional<Vector<FunctionDeclaration::Parameter>> m_function_parameters;
-    HashMap<size_t, NonnullRefPtrVector<Identifier>> m_identifier_and_argument_index_associations;
 
     bool m_contains_access_to_arguments_object { false };
     bool m_contains_direct_call_to_eval { false };

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -343,6 +343,7 @@ private:
         }
     };
 
+    NonnullRefPtr<SourceCode> m_source_code;
     Vector<Position> m_rule_starts;
     ParserState m_state;
     FlyString m_filename;

--- a/Userland/Libraries/LibJS/Runtime/EnvironmentCoordinate.h
+++ b/Userland/Libraries/LibJS/Runtime/EnvironmentCoordinate.h
@@ -12,10 +12,13 @@
 namespace JS {
 
 struct EnvironmentCoordinate {
-    size_t hops { 0 };
-    size_t index { 0 };
+    u32 hops { invalid_marker };
+    u32 index { invalid_marker };
 
-    static constexpr size_t global_marker = 0xffffffff;
+    bool is_valid() const { return hops != invalid_marker && index != invalid_marker; }
+
+    static constexpr u32 global_marker = 0xffffffff;
+    static constexpr u32 invalid_marker = 0xfffffffe;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -565,8 +565,11 @@ ThrowCompletionOr<Reference> VM::get_identifier_reference(Environment* environme
 
     // Note: This is an optimization for looking up the same reference.
     Optional<EnvironmentCoordinate> environment_coordinate;
-    if (index.has_value())
-        environment_coordinate = EnvironmentCoordinate { .hops = hops, .index = index.value() };
+    if (index.has_value()) {
+        VERIFY(hops <= NumericLimits<u32>::max());
+        VERIFY(index.value() <= NumericLimits<u32>::max());
+        environment_coordinate = EnvironmentCoordinate { .hops = static_cast<u32>(hops), .index = static_cast<u32>(index.value()) };
+    }
 
     // 3. If exists is true, then
     if (exists) {

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -728,8 +728,8 @@ void VM::dump_backtrace() const
     for (ssize_t i = m_execution_context_stack.size() - 1; i >= 0; --i) {
         auto& frame = m_execution_context_stack[i];
         if (frame->current_node) {
-            auto& source_range = frame->current_node->source_range();
-            dbgln("-> {} @ {}:{},{}", frame->function_name, source_range.filename, source_range.start.line, source_range.start.column);
+            auto source_range = frame->current_node->source_range();
+            dbgln("-> {} @ {}:{},{}", frame->function_name, source_range.filename(), source_range.start.line, source_range.start.column);
         } else {
             dbgln("-> {}", frame->function_name);
         }

--- a/Userland/Libraries/LibJS/SourceCode.cpp
+++ b/Userland/Libraries/LibJS/SourceCode.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Utf8View.h>
+#include <LibJS/SourceCode.h>
+#include <LibJS/SourceRange.h>
+#include <LibJS/Token.h>
+
+namespace JS {
+
+NonnullRefPtr<SourceCode> SourceCode::create(String filename, String code)
+{
+    return adopt_ref(*new SourceCode(move(filename), move(code)));
+}
+
+SourceCode::SourceCode(String filename, String code)
+    : m_filename(move(filename))
+    , m_code(move(code))
+{
+}
+
+String const& SourceCode::filename() const
+{
+    return m_filename;
+}
+
+String const& SourceCode::code() const
+{
+    return m_code;
+}
+
+SourceRange SourceCode::range_from_offsets(u32 start_offset, u32 end_offset) const
+{
+    Position start;
+    Position end;
+
+    size_t line = 1;
+    size_t column = 1;
+
+    bool previous_code_point_was_carriage_return = false;
+
+    Utf8View view(m_code);
+    for (auto it = view.begin(); it != view.end(); ++it) {
+
+        if (start_offset == view.byte_offset_of(it)) {
+            start = Position {
+                .line = line,
+                .column = column,
+                .offset = start_offset,
+            };
+        }
+
+        if (end_offset == view.byte_offset_of(it)) {
+            end = Position {
+                .line = line,
+                .column = column,
+                .offset = end_offset,
+            };
+            break;
+        }
+
+        u32 code_point = *it;
+
+        bool is_line_terminator = code_point == '\r' || (code_point == '\n' && !previous_code_point_was_carriage_return) || code_point == LINE_SEPARATOR || code_point == PARAGRAPH_SEPARATOR;
+        previous_code_point_was_carriage_return = code_point == '\r';
+
+        if (is_line_terminator) {
+            ++line;
+            column = 1;
+            continue;
+        }
+        ++column;
+    }
+
+    return SourceRange { *this, start, end };
+}
+
+}

--- a/Userland/Libraries/LibJS/SourceCode.h
+++ b/Userland/Libraries/LibJS/SourceCode.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <LibJS/Forward.h>
+
+namespace JS {
+
+class SourceCode : public RefCounted<SourceCode> {
+public:
+    static NonnullRefPtr<SourceCode> create(String filename, String code);
+
+    String const& filename() const;
+    String const& code() const;
+
+    SourceRange range_from_offsets(u32 start_offset, u32 end_offset) const;
+
+private:
+    SourceCode(String filename, String code);
+
+    String m_filename;
+    String m_code;
+};
+
+}

--- a/Userland/Libraries/LibJS/SourceRange.h
+++ b/Userland/Libraries/LibJS/SourceRange.h
@@ -8,6 +8,7 @@
 
 #include <AK/StringView.h>
 #include <AK/Types.h>
+#include <LibJS/SourceCode.h>
 
 namespace JS {
 
@@ -20,9 +21,11 @@ struct Position {
 struct SourceRange {
     [[nodiscard]] bool contains(Position const& position) const { return position.offset <= end.offset && position.offset >= start.offset; }
 
-    StringView filename;
+    NonnullRefPtr<SourceCode> code;
     Position start;
     Position end;
+
+    String const& filename() const;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ExceptionReporter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ExceptionReporter.cpp
@@ -34,7 +34,7 @@ void report_exception_to_console(JS::Value value, JS::Realm& realm, ErrorInPromi
             for (auto& traceback_frame : error_value.traceback()) {
                 auto& function_name = traceback_frame.function_name;
                 auto& source_range = traceback_frame.source_range;
-                dbgln("  {} at {}:{}:{}", function_name, source_range.filename, source_range.start.line, source_range.start.column);
+                dbgln("  {} at {}:{}:{}", function_name, source_range.filename(), source_range.start.line, source_range.start.column);
             }
             console.report_exception(error_value, error_in_promise == ErrorInPromise::Yes);
 


### PR DESCRIPTION
This PR has one patch for all `ASTNode` objects and two for `Identifier`.

Combined, they yield a 95 MiB reduction in memory usage on https://twitter.com/awesomekling