### PR TITLE
LibWeb: Make it possible to obtain the value of a custom property using `CSSStyleDeclaration.getPropertyValue()`

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -50,6 +50,7 @@ ErrorOr<void> generate_header_file(JsonObject& properties, Core::Stream::File& f
 #include <AK/StringView.h>
 #include <AK/Traits.h>
 #include <LibWeb/Forward.h>
+#include <AK/GenericLexer.h>
 
 namespace Web::CSS {
 
@@ -195,6 +196,8 @@ PropertyID property_id_from_string(StringView string)
     });
 
     generator.append(R"~~~(
+    if (string.starts_with("--"sv) && string != "--")
+        return PropertyID::Custom;
     return PropertyID::Invalid;
 }
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -70,6 +70,11 @@ Optional<StyleProperty> PropertyOwningCSSStyleDeclaration::property(PropertyID p
     return {};
 }
 
+Optional<StyleProperty> PropertyOwningCSSStyleDeclaration::custom_property(String const& custom_property_name) const
+{
+    return m_custom_properties.get(custom_property_name);
+}
+
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty
 WebIDL::ExceptionOr<void> PropertyOwningCSSStyleDeclaration::set_property(PropertyID property_id, StringView value, StringView priority)
 {
@@ -198,7 +203,9 @@ String CSSStyleDeclaration::get_property_value(StringView property_name) const
     auto property_id = property_id_from_string(property_name);
     if (property_id == CSS::PropertyID::Invalid)
         return {};
-    auto maybe_property = property(property_id);
+    auto maybe_property = property_id == CSS::PropertyID::Custom
+        ? custom_property(property_name.to_string())
+        : property(property_id);
     if (!maybe_property.has_value())
         return {};
     return maybe_property->value->to_string();

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -35,6 +35,7 @@ public:
     virtual String item(size_t index) const = 0;
 
     virtual Optional<StyleProperty> property(PropertyID) const = 0;
+    virtual Optional<StyleProperty> custom_property(String const& custom_property_name) const = 0;
 
     virtual WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority = ""sv) = 0;
     virtual WebIDL::ExceptionOr<String> remove_property(PropertyID) = 0;
@@ -77,7 +78,7 @@ public:
 
     Vector<StyleProperty> const& properties() const { return m_properties; }
     HashMap<String, StyleProperty> const& custom_properties() const { return m_custom_properties; }
-    Optional<StyleProperty> custom_property(String const& custom_property_name) const { return m_custom_properties.get(custom_property_name); }
+    virtual Optional<StyleProperty> custom_property(String const& custom_property_name) const override;
     size_t custom_property_count() const { return m_custom_properties.size(); }
 
     virtual String serialized() const final override;

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -554,6 +554,17 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
     };
 }
 
+Optional<StyleProperty> ResolvedCSSStyleDeclaration::custom_property(String const& custom_property_name) const
+{
+    const_cast<DOM::Document&>(m_element->document()).update_style();
+    for (auto current_element = m_element.ptr(); current_element; current_element = current_element->parent_element()) {
+        if (auto it = current_element->custom_properties().find(custom_property_name); it != current_element->custom_properties().end())
+            return it->value;
+    }
+
+    return {};
+}
+
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty
 WebIDL::ExceptionOr<void> ResolvedCSSStyleDeclaration::set_property(PropertyID, StringView, StringView)
 {

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
@@ -21,6 +21,7 @@ public:
     virtual size_t length() const override;
     virtual String item(size_t index) const override;
     virtual Optional<StyleProperty> property(PropertyID) const override;
+    virtual Optional<StyleProperty> custom_property(String const& custom_property_name) const override;
     virtual WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority) override;
     virtual WebIDL::ExceptionOr<String> remove_property(PropertyID) override;
 


### PR DESCRIPTION
This makes the colors of the charts on https://libjs.dev/test262/per-file/ display correctly.

