### PR TITLE
3DFileViewer: Propagate key events to the window

### DIFF
--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -198,6 +198,8 @@ void GLContextWidget::keydown_event(GUI::KeyEvent& event)
         window()->set_fullscreen(false);
         return;
     }
+
+    event.ignore();
 }
 
 void GLContextWidget::timer_event(Core::TimerEvent&)


### PR DESCRIPTION
Before this, shortcuts would not work due to key events not being propagated to the window.