### PR TITLE
LibPDF: Bug fixes, quirks and a nice refactoring

### DIFF
--- a/Userland/Libraries/LibPDF/DocumentParser.h
+++ b/Userland/Libraries/LibPDF/DocumentParser.h
@@ -79,6 +79,7 @@ private:
     PDFErrorOr<LinearizationResult> initialize_linearization_dict();
     PDFErrorOr<void> initialize_linearized_xref_table();
     PDFErrorOr<void> initialize_non_linearized_xref_table();
+    PDFErrorOr<void> validate_xref_table_and_fix_if_necessary();
     PDFErrorOr<void> initialize_hint_tables();
     PDFErrorOr<PageOffsetHintTable> parse_page_offset_hint_table(ReadonlyBytes hint_stream_bytes);
     Vector<PageOffsetHintTableEntry> parse_all_page_offset_hint_table_entries(PageOffsetHintTable const&, ReadonlyBytes hint_stream_bytes);

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
@@ -16,18 +16,18 @@ namespace PDF {
 static bool is_standard_latin_font(FlyString const& font)
 {
     return font.is_one_of(
-        "Times-Roman",
-        "Helvetica",
-        "Courier",
-        "Times-Bold",
-        "Helvetica-Bold",
-        "Courier-Bold",
-        "Times-Italic",
-        "Helvetica-Oblique",
-        "Courier-Oblique",
-        "Times-BoldItalic",
-        "Helvetica-BoldOblique",
-        "Courier-BoldOblique");
+        "Times-Roman", "TimesNewRoman",
+        "Helvetica", "Arial",
+        "Courier", "CourierNew",
+        "Times-Bold", "TimesNewRoman,Bold",
+        "Helvetica-Bold", "Arial,Bold",
+        "Courier-Bold", "CourierNew,Bold",
+        "Times-Italic", "TimesNewRoman,Italic",
+        "Helvetica-Oblique", "Arial,Italic",
+        "Courier-Oblique", "CourierNew,Italic",
+        "Times-BoldItalic", "TimesNewRoman,BoldItalic",
+        "Helvetica-BoldOblique", "Arial,BoldItalic",
+        "Courier-BoldOblique", "CourierNew,BoldItalic");
 }
 
 PDFErrorOr<void> PDFFont::CommonData::load_from_dict(Document* document, NonnullRefPtr<DictObject> dict, float font_size)

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
@@ -12,6 +12,61 @@
 
 namespace PDF {
 
+static bool is_standard_latin_font(FlyString const& font)
+{
+    return font.is_one_of(
+        "Times-Roman",
+        "Helvetica",
+        "Courier",
+        "Times-Bold",
+        "Helvetica-Bold",
+        "Courier-Bold",
+        "Times-Italic",
+        "Helvetica-Oblique",
+        "Courier-Oblique",
+        "Times-BoldItalic",
+        "Helvetica-BoldOblique",
+        "Courier-BoldOblique");
+}
+
+PDFErrorOr<void> PDFFont::CommonData::load_from_dict(Document* document, NonnullRefPtr<DictObject> dict)
+{
+    auto base_font = TRY(dict->get_name(document, CommonNames::BaseFont))->name();
+    is_standard_font = is_standard_latin_font(base_font);
+
+    if (dict->contains(CommonNames::Encoding)) {
+        auto encoding_object = MUST(dict->get_object(document, CommonNames::Encoding));
+        encoding = TRY(Encoding::from_object(document, encoding_object));
+    } else {
+        // FIXME: The spec doesn't specify what the encoding should be in this case
+        if (is_standard_font)
+            encoding = Encoding::standard_encoding();
+        // Otherwise, use the built-in encoding of the font.
+    }
+
+    if (dict->contains(CommonNames::ToUnicode))
+        to_unicode = TRY(dict->get_stream(document, CommonNames::ToUnicode));
+
+    if (dict->contains(CommonNames::FirstChar) && dict->contains(CommonNames::LastChar) && dict->contains(CommonNames::Widths)) {
+        auto first_char = dict->get_value(CommonNames::FirstChar).get<int>();
+        auto last_char = dict->get_value(CommonNames::LastChar).get<int>();
+        auto widths_array = TRY(dict->get_array(document, CommonNames::Widths));
+
+        VERIFY(widths_array->size() == static_cast<size_t>(last_char - first_char + 1));
+
+        for (size_t i = 0; i < widths_array->size(); i++)
+            widths.set(first_char + i, widths_array->at(i).to_int());
+    }
+
+    if (dict->contains(CommonNames::FontDescriptor)) {
+        auto descriptor = TRY(dict->get_dict(document, CommonNames::FontDescriptor));
+        if (descriptor->contains(CommonNames::MissingWidth))
+            missing_width = descriptor->get_value(CommonNames::MissingWidth).to_int();
+    }
+
+    return {};
+}
+
 PDFErrorOr<NonnullRefPtr<PDFFont>> PDFFont::create(Document* document, NonnullRefPtr<DictObject> dict)
 {
     auto subtype = TRY(dict->get_name(document, CommonNames::Subtype))->name();

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <LibGfx/Forward.h>
 #include <LibPDF/Document.h>
+#include <LibPDF/Encoding.h>
 
 namespace PDF {
 
@@ -17,6 +19,17 @@ public:
         Type0,
         Type1,
         TrueType
+    };
+
+    // This is used both by Type 1 and TrueType fonts.
+    struct CommonData {
+        RefPtr<StreamObject> to_unicode;
+        RefPtr<Encoding> encoding;
+        HashMap<u16, u16> widths;
+        u16 missing_width;
+        bool is_standard_font;
+
+        PDFErrorOr<void> load_from_dict(Document*, NonnullRefPtr<DictObject>);
     };
 
     static PDFErrorOr<NonnullRefPtr<PDFFont>> create(Document*, NonnullRefPtr<DictObject>);

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -26,7 +26,7 @@ public:
     virtual u32 char_code_to_code_point(u16 char_code) const = 0;
     virtual float get_char_width(u16 char_code, float font_size) const = 0;
 
-    virtual void draw_glyph(Gfx::Painter& painter, Gfx::IntPoint const& point, float width, u32 code_point, Color color) = 0;
+    virtual void draw_glyph(Gfx::Painter& painter, Gfx::IntPoint const& point, float width, u32 char_code, Color color) = 0;
 
     virtual bool is_standard_font() const { return m_is_standard_font; }
     virtual Type type() const = 0;

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/Tuple.h>
 #include <LibGfx/Forward.h>
 #include <LibPDF/Document.h>
 #include <LibPDF/Encoding.h>
@@ -23,21 +24,22 @@ public:
 
     // This is used both by Type 1 and TrueType fonts.
     struct CommonData {
+        RefPtr<Gfx::Font> font;
         RefPtr<StreamObject> to_unicode;
         RefPtr<Encoding> encoding;
         HashMap<u16, u16> widths;
         u16 missing_width;
         bool is_standard_font;
 
-        PDFErrorOr<void> load_from_dict(Document*, NonnullRefPtr<DictObject>);
+        PDFErrorOr<void> load_from_dict(Document*, NonnullRefPtr<DictObject>, float font_size);
     };
 
-    static PDFErrorOr<NonnullRefPtr<PDFFont>> create(Document*, NonnullRefPtr<DictObject>);
+    static PDFErrorOr<NonnullRefPtr<PDFFont>> create(Document*, NonnullRefPtr<DictObject>, float font_size);
 
     virtual ~PDFFont() = default;
 
     virtual u32 char_code_to_code_point(u16 char_code) const = 0;
-    virtual float get_char_width(u16 char_code, float font_size) const = 0;
+    virtual float get_char_width(u16 char_code) const = 0;
 
     virtual void draw_glyph(Gfx::Painter& painter, Gfx::IntPoint const& point, float width, u32 char_code, Color color) = 0;
 
@@ -45,6 +47,8 @@ public:
     virtual Type type() const = 0;
 
 protected:
+    static Tuple<String, String> replacement_for_standard_latin_font(StringView);
+
     bool m_is_standard_font { false };
 };
 

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
@@ -20,11 +20,11 @@ class PS1FontProgram : public RefCounted<PS1FontProgram> {
 public:
     PDFErrorOr<void> parse(ReadonlyBytes const&, size_t cleartext_length, size_t encrypted_length);
 
-    RefPtr<Gfx::Bitmap> rasterize_glyph(u32 code_point, float width);
-    Gfx::Path build_char(u32 code_point, float width);
+    RefPtr<Gfx::Bitmap> rasterize_glyph(u32 char_code, float width);
+    Gfx::Path build_char(u32 char_code, float width);
 
     RefPtr<Encoding> encoding() const { return m_encoding; }
-    Gfx::FloatPoint glyph_translation(u32 code_point, float width) const;
+    Gfx::FloatPoint glyph_translation(u32 char_code, float width) const;
 
 private:
     struct Glyph {

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
@@ -18,7 +18,7 @@ class Encoding;
 
 class PS1FontProgram : public RefCounted<PS1FontProgram> {
 public:
-    PDFErrorOr<void> parse(ReadonlyBytes const&, size_t cleartext_length, size_t encrypted_length);
+    PDFErrorOr<void> create(ReadonlyBytes const&, RefPtr<Encoding>, size_t cleartext_length, size_t encrypted_length);
 
     RefPtr<Gfx::Bitmap> rasterize_glyph(u32 char_code, float width);
     Gfx::Path build_char(u32 char_code, float width);

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -6,28 +6,30 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <LibGfx/Font/TrueType/Font.h>
-#include <LibPDF/Fonts/Type1Font.h>
+#include <LibPDF/Fonts/PDFFont.h>
 
 namespace PDF {
 
 class TrueTypeFont : public PDFFont {
 public:
-    static PDFErrorOr<NonnullRefPtr<PDFFont>> create(Document*, NonnullRefPtr<DictObject>);
+    static PDFErrorOr<PDFFont::CommonData> parse_data(Document* document, NonnullRefPtr<DictObject> dict, float font_size);
 
-    TrueTypeFont(NonnullRefPtr<TTF::Font> ttf_font, Type1Font::Data);
+    static PDFErrorOr<NonnullRefPtr<PDFFont>> create(Document*, NonnullRefPtr<DictObject>, float font_size);
+
+    TrueTypeFont(PDFFont::CommonData);
     ~TrueTypeFont() override = default;
 
     u32 char_code_to_code_point(u16 char_code) const override;
-    float get_char_width(u16 char_code, float font_size) const override;
+    float get_char_width(u16 char_code) const override;
 
-    void draw_glyph(Gfx::Painter&, Gfx::IntPoint const&, float, u32, Color) override {};
+    void draw_glyph(Gfx::Painter&, Gfx::IntPoint const&, float, u32, Color) override;
 
     Type type() const override { return PDFFont::Type::TrueType; }
 
 private:
-    NonnullRefPtr<TTF::Font> m_ttf_font;
-    Type1Font::Data m_data;
+    PDFFont::CommonData m_data;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -82,7 +82,7 @@ u32 Type0Font::char_code_to_code_point(u16 char_code) const
     return char_code;
 }
 
-float Type0Font::get_char_width(u16 char_code, float) const
+float Type0Font::get_char_width(u16 char_code) const
 {
     u16 width;
     if (auto char_code_width = m_widths.get(char_code); char_code_width.has_value()) {

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -24,7 +24,7 @@ public:
     ~Type0Font() override = default;
 
     u32 char_code_to_code_point(u16 char_code) const override;
-    float get_char_width(u16 char_code, float font_size) const override;
+    float get_char_width(u16 char_code) const override;
 
     void draw_glyph(Gfx::Painter&, Gfx::IntPoint const&, float, u32, Color) override {};
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -5,91 +5,42 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGfx/AntiAliasingPainter.h>
+#include <LibGfx/Painter.h>
 #include <LibPDF/CommonNames.h>
 #include <LibPDF/Fonts/Type1Font.h>
 
 namespace PDF {
 
-static bool is_standard_latin_font(FlyString const& font)
+PDFErrorOr<Type1Font::Data> Type1Font::parse_data(Document* document, NonnullRefPtr<DictObject> dict, float font_size)
 {
-    return font.is_one_of(
-        "Times-Roman",
-        "Helvetica",
-        "Courier",
-        "Times-Bold",
-        "Helvetica-Bold",
-        "Courier-Bold",
-        "Times-Italic",
-        "Helvetica-Oblique",
-        "Courier-Oblique",
-        "Times-BoldItalic",
-        "Helvetica-BoldOblique",
-        "Courier-BoldOblique");
-}
+    Type1Font::Data data;
+    TRY(data.load_from_dict(document, dict, font_size));
 
-PDFErrorOr<Type1Font::Data> Type1Font::parse_data(Document* document, NonnullRefPtr<DictObject> dict)
-{
-    // FIXME: "Required except for the standard 14 fonts"...
-    //        "Beginning with PDF 1.5, the special treatment given to the standard 14
-    //        fonts is deprecated. [...] For backwards capability, conforming readers
-    //        shall still provide the special treatment identifier for the standard
-    //        14 fonts."
+    if (!data.is_standard_font) {
+        auto descriptor = TRY(dict->get_dict(document, CommonNames::FontDescriptor));
+        if (!descriptor->contains(CommonNames::FontFile))
+            return data;
 
-    RefPtr<Encoding> encoding;
+        auto font_file_stream = TRY(descriptor->get_stream(document, CommonNames::FontFile));
+        auto font_file_dict = font_file_stream->dict();
 
-    if (dict->contains(CommonNames::Encoding)) {
-        auto encoding_object = MUST(dict->get_object(document, CommonNames::Encoding));
-        encoding = TRY(Encoding::from_object(document, encoding_object));
-    } else {
-        auto base_font = MUST(dict->get_name(document, CommonNames::BaseFont))->name();
-        if (is_standard_latin_font(base_font)) {
-            // FIXME: The spec doesn't specify what the encoding should be in this case
-            encoding = Encoding::standard_encoding();
-        }
-        // Otherwise, use the built-in encoding of the font program.
+        if (!font_file_dict->contains(CommonNames::Length1, CommonNames::Length2))
+            return Error { Error::Type::Parse, "Embedded type 1 font is incomplete" };
+
+        auto length1 = font_file_dict->get_value(CommonNames::Length1).get<int>();
+        auto length2 = font_file_dict->get_value(CommonNames::Length2).get<int>();
+
+        data.font_program = adopt_ref(*new PS1FontProgram());
+        TRY(data.font_program->parse(font_file_stream->bytes(), length1, length2));
+        data.encoding = data.font_program->encoding();
     }
 
-    RefPtr<StreamObject> to_unicode;
-    if (dict->contains(CommonNames::ToUnicode))
-        to_unicode = MUST(dict->get_stream(document, CommonNames::ToUnicode));
-
-    auto first_char = dict->get_value(CommonNames::FirstChar).get<int>();
-    auto last_char = dict->get_value(CommonNames::LastChar).get<int>();
-    auto widths_array = MUST(dict->get_array(document, CommonNames::Widths));
-
-    VERIFY(widths_array->size() == static_cast<size_t>(last_char - first_char + 1));
-
-    HashMap<u16, u16> widths;
-    for (size_t i = 0; i < widths_array->size(); i++)
-        widths.set(first_char + i, widths_array->at(i).to_int());
-
-    u16 missing_width = 0;
-    auto descriptor = MUST(dict->get_dict(document, CommonNames::FontDescriptor));
-    if (descriptor->contains(CommonNames::MissingWidth))
-        missing_width = descriptor->get_value(CommonNames::MissingWidth).to_int();
-    if (!descriptor->contains(CommonNames::FontFile))
-        return Type1Font::Data { {}, to_unicode, encoding.release_nonnull(), move(widths), missing_width, true };
-
-    auto font_file_stream = TRY(descriptor->get_stream(document, CommonNames::FontFile));
-    auto font_file_dict = font_file_stream->dict();
-
-    if (!font_file_dict->contains(CommonNames::Length1, CommonNames::Length2))
-        return Error { Error::Type::Parse, "Embedded type 1 font is incomplete" };
-
-    auto length1 = font_file_dict->get_value(CommonNames::Length1).get<int>();
-    auto length2 = font_file_dict->get_value(CommonNames::Length2).get<int>();
-
-    auto font_program = adopt_ref(*new PS1FontProgram());
-    TRY(font_program->parse(font_file_stream->bytes(), length1, length2));
-    encoding = font_program->encoding();
-
-    return Type1Font::Data { font_program, to_unicode, encoding.release_nonnull(), move(widths), missing_width, false };
+    return data;
 }
 
-PDFErrorOr<NonnullRefPtr<Type1Font>> Type1Font::create(Document* document, NonnullRefPtr<DictObject> dict)
+PDFErrorOr<NonnullRefPtr<Type1Font>> Type1Font::create(Document* document, NonnullRefPtr<DictObject> dict, float font_size)
 {
-    auto data = TRY(Type1Font::parse_data(document, dict));
+    auto data = TRY(Type1Font::parse_data(document, dict, font_size));
     return adopt_ref(*new Type1Font(data));
 }
 
@@ -108,7 +59,7 @@ u32 Type1Font::char_code_to_code_point(u16 char_code) const
     return descriptor.code_point;
 }
 
-float Type1Font::get_char_width(u16 char_code, float) const
+float Type1Font::get_char_width(u16 char_code) const
 {
     u16 width;
     if (auto char_code_width = m_data.widths.get(char_code); char_code_width.has_value()) {

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -31,8 +31,10 @@ PDFErrorOr<Type1Font::Data> Type1Font::parse_data(Document* document, NonnullRef
         auto length2 = font_file_dict->get_value(CommonNames::Length2).get<int>();
 
         data.font_program = adopt_ref(*new PS1FontProgram());
-        TRY(data.font_program->parse(font_file_stream->bytes(), length1, length2));
-        data.encoding = data.font_program->encoding();
+        TRY(data.font_program->create(font_file_stream->bytes(), data.encoding, length1, length2));
+
+        if (!data.encoding)
+            data.encoding = data.font_program->encoding();
     }
 
     return data;

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -120,22 +120,22 @@ float Type1Font::get_char_width(u16 char_code, float) const
     return static_cast<float>(width) / 1000.0f;
 }
 
-void Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::IntPoint const& point, float width, u32 code_point, Color color)
+void Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::IntPoint const& point, float width, u32 char_code, Color color)
 {
     if (!m_data.font_program)
         return;
 
     RefPtr<Gfx::Bitmap> bitmap;
 
-    auto maybe_bitmap = m_glyph_cache.get(code_point);
+    auto maybe_bitmap = m_glyph_cache.get(char_code);
     if (maybe_bitmap.has_value()) {
         bitmap = maybe_bitmap.value();
     } else {
-        bitmap = m_data.font_program->rasterize_glyph(code_point, width);
-        m_glyph_cache.set(code_point, bitmap);
+        bitmap = m_data.font_program->rasterize_glyph(char_code, width);
+        m_glyph_cache.set(char_code, bitmap);
     }
 
-    auto translation = m_data.font_program->glyph_translation(code_point, width);
+    auto translation = m_data.font_program->glyph_translation(char_code, width);
     painter.blit_filtered(point.translated(translation.to_rounded<int>()), *bitmap, bitmap->rect(), [color](Color pixel) -> Color {
         return pixel.multiply(color);
     });

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <LibPDF/Encoding.h>
 #include <LibPDF/Fonts/PDFFont.h>
 #include <LibPDF/Fonts/PS1FontProgram.h>
 
@@ -14,25 +13,19 @@ namespace PDF {
 
 class Type1Font : public PDFFont {
 public:
-    // Also used by TrueTypeFont, which is very similar to Type1
-    struct Data {
+    struct Data : PDFFont::CommonData {
         RefPtr<PS1FontProgram> font_program;
-        RefPtr<StreamObject> to_unicode;
-        NonnullRefPtr<Encoding> encoding;
-        HashMap<u16, u16> widths;
-        u16 missing_width;
-        bool is_standard_font;
     };
 
-    static PDFErrorOr<Data> parse_data(Document*, NonnullRefPtr<DictObject> font_dict);
+    static PDFErrorOr<Data> parse_data(Document*, NonnullRefPtr<DictObject> font_dict, float font_size);
 
-    static PDFErrorOr<NonnullRefPtr<Type1Font>> create(Document*, NonnullRefPtr<DictObject>);
+    static PDFErrorOr<NonnullRefPtr<Type1Font>> create(Document*, NonnullRefPtr<DictObject>, float font_size);
 
     Type1Font(Data);
     ~Type1Font() override = default;
 
     u32 char_code_to_code_point(u16 char_code) const override;
-    float get_char_width(u16 char_code, float font_size) const override;
+    float get_char_width(u16 char_code) const override;
 
     void draw_glyph(Gfx::Painter& painter, Gfx::IntPoint const& point, float width, u32 char_code, Color color) override;
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -34,7 +34,7 @@ public:
     u32 char_code_to_code_point(u16 char_code) const override;
     float get_char_width(u16 char_code, float font_size) const override;
 
-    void draw_glyph(Gfx::Painter& painter, Gfx::IntPoint const& point, float width, u32 code_point, Color color) override;
+    void draw_glyph(Gfx::Painter& painter, Gfx::IntPoint const& point, float width, u32 char_code, Color color) override;
 
     Type type() const override { return PDFFont::Type::Type1; }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -162,7 +162,7 @@ RENDERER_HANDLER(set_dash_pattern)
     auto dash_array = MUST(m_document->resolve_to<ArrayObject>(args[0]));
     Vector<int> pattern;
     for (auto& element : *dash_array)
-        pattern.append(element.get<int>());
+        pattern.append(element.to_int());
     state().line_dash_pattern = LineDashPattern { pattern, args[1].get<int>() };
     return {};
 }

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -347,31 +347,13 @@ RENDERER_HANDLER(text_set_font)
     auto target_font_name = MUST(m_document->resolve_to<NameObject>(args[0]))->name();
     auto fonts_dictionary = MUST(m_page.resources->get_dict(m_document, CommonNames::Font));
     auto font_dictionary = MUST(fonts_dictionary->get_dict(m_document, target_font_name));
-    auto font = TRY(PDFFont::create(m_document, font_dictionary));
-    text_state().font = font;
-
-    // FIXME: We do not yet have the standard 14 fonts, as some of them are not open fonts,
-    //        so we just use LiberationSerif for everything
-
-    auto font_name = MUST(font_dictionary->get_name(m_document, CommonNames::BaseFont))->name().to_lowercase();
-    auto font_view = font_name.view();
-    bool is_bold = font_view.contains("bold"sv);
-    bool is_italic = font_view.contains("italic"sv);
-
-    String font_variant;
-
-    if (is_bold && is_italic) {
-        font_variant = "BoldItalic";
-    } else if (is_bold) {
-        font_variant = "Bold";
-    } else if (is_italic) {
-        font_variant = "Italic";
-    } else {
-        font_variant = "Regular";
-    }
 
     text_state().font_size = args[1].to_float();
-    text_state().font_variant = font_variant;
+
+    auto& text_rendering_matrix = calculate_text_rendering_matrix();
+    auto font_size = text_rendering_matrix.x_scale() * text_state().font_size;
+    auto font = TRY(PDFFont::create(m_document, font_dictionary, font_size));
+    text_state().font = font;
 
     m_text_rendering_matrix_is_dirty = true;
     return {};
@@ -643,36 +625,19 @@ void Renderer::show_text(String const& string)
 {
     auto& text_rendering_matrix = calculate_text_rendering_matrix();
 
-    auto font_type = text_state().font->type();
     auto font_size = text_rendering_matrix.x_scale() * text_state().font_size;
 
     auto glyph_position = text_rendering_matrix.map(Gfx::FloatPoint { 0.0f, 0.0f });
-
-    RefPtr<Gfx::Font> font;
-
-    // For types other than Type 1 and the standard 14 fonts, use Liberation Serif for now
-    if (font_type != PDFFont::Type::Type1 || text_state().font->is_standard_font()) {
-        font = Gfx::FontDatabase::the().get(text_state().font_family, text_state().font_variant, font_size);
-        VERIFY(font);
-
-        // Account for the reversed font baseline
-        glyph_position.set_y(glyph_position.y() - static_cast<float>(font->baseline()));
-    }
 
     auto original_position = glyph_position;
 
     for (auto char_code : string.bytes()) {
         auto code_point = text_state().font->char_code_to_code_point(char_code);
-        auto char_width = text_state().font->get_char_width(char_code, font_size);
+        auto char_width = text_state().font->get_char_width(char_code);
         auto glyph_width = char_width * font_size;
 
-        if (code_point != 0x20) {
-            if (font.is_null()) {
-                text_state().font->draw_glyph(m_painter, glyph_position.to_type<int>(), glyph_width, code_point, state().paint_color);
-            } else {
-                m_painter.draw_glyph(glyph_position.to_type<int>(), code_point, *font, state().paint_color);
-            }
-        }
+        if (code_point != 0x20)
+            text_state().font->draw_glyph(m_painter, glyph_position.to_type<int>(), glyph_width, char_code, state().paint_color);
 
         auto tx = glyph_width;
         tx += text_state().character_spacing;

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -57,8 +57,6 @@ struct TextState {
     float word_spacing { 0.0f };
     float horizontal_scaling { 1.0f };
     float leading { 0.0f };
-    FlyString font_family { "Liberation Serif" };
-    String font_variant { "Regular" };
     float font_size { 12.0f };
     RefPtr<PDFFont> font;
     TextRenderingMode rendering_mode { TextRenderingMode::Fill };
@@ -221,8 +219,6 @@ struct Formatter<PDF::TextState> : Formatter<StringView> {
         builder.appendff("    word_spacing={}\n", state.word_spacing);
         builder.appendff("    horizontal_scaling={}\n", state.horizontal_scaling);
         builder.appendff("    leading={}\n", state.leading);
-        builder.appendff("    font_family={}\n", state.font_family);
-        builder.appendff("    font_variant={}\n", state.font_variant);
         builder.appendff("    font_size={}\n", state.font_size);
         builder.appendff("    rendering_mode={}\n", state.rendering_mode);
         builder.appendff("    rise={}\n", state.rise);

--- a/Userland/Libraries/LibPDF/XRefTable.h
+++ b/Userland/Libraries/LibPDF/XRefTable.h
@@ -68,6 +68,8 @@ public:
             m_entries.append(entry);
     }
 
+    ALWAYS_INLINE Vector<XRefEntry>& entries() { return m_entries; }
+
     [[nodiscard]] ALWAYS_INLINE bool has_object(size_t index) const
     {
         return index < m_entries.size() && m_entries[index].byte_offset != -1;


### PR DESCRIPTION
This PR is mainly about fixing some bugs in the way LibPDF uses character codes to draw text strings, and a small issue in the renderer.

In addition, I've implemented a quirk that allows loading XRef tables that are broken in a very specific way that I have encountered sometimes. While this may seem a bit weird, most other parsers seem to do something very similar.

I've also refactored the way font data is loaded from the font dictionary. Entries that are common to Type 1 and TrueType fonts will now be loaded by the PDFFont base class, which makes the implementations much more simple and readable.

This patch makes the interaction between the renderer and the fonts simpler as well, and allows us to render embedded TrueType fonts.

cc @mattco98 