### PR TITLE
LibAudio: Set asynchronous audio enqueuer thread to maximum priority

### DIFF
--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -26,7 +26,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio thread rpath cpath wpath recvfd sendfd unix"));
+    TRY(Core::System::pledge("stdio thread rpath cpath wpath recvfd sendfd unix proc"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 

--- a/Userland/Libraries/LibAudio/ConnectionToServer.cpp
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.cpp
@@ -14,6 +14,7 @@
 #include <LibAudio/UserSampleQueue.h>
 #include <LibCore/Event.h>
 #include <LibThreading/Mutex.h>
+#include <sched.h>
 #include <time.h>
 
 namespace Audio {
@@ -58,8 +59,10 @@ void ConnectionToServer::die()
 
 ErrorOr<void> ConnectionToServer::async_enqueue(FixedArray<Sample>&& samples)
 {
-    if (!m_background_audio_enqueuer->is_started())
+    if (!m_background_audio_enqueuer->is_started()) {
         m_background_audio_enqueuer->start();
+        TRY(m_background_audio_enqueuer->set_priority(THREAD_PRIORITY_MAX));
+    }
 
     update_good_sleep_time();
     m_user_queue->append(move(samples));

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -64,10 +64,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     // If we're downsampling, we need to appropriately load more samples at once.
     size_t const load_size = static_cast<size_t>(LOAD_CHUNK_SIZE * static_cast<double>(loader->sample_rate()) / static_cast<double>(audio_client->get_sample_rate()));
-    // We assume that the loader can load samples at at least 2x speed (testing confirms 9x-12x for FLAC, 14x for WAV).
-    // Therefore, when the server-side buffer can only play as long as the time it takes us to load a chunk,
-    // we give it new data.
-    unsigned const min_buffer_size = load_size / 2;
 
     auto print_playback_update = [&]() {
         out("\033[u");
@@ -115,7 +111,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 // We're done and the server is done
                 break;
             }
-            while (audio_client->remaining_samples() > min_buffer_size) {
+            while (audio_client->remaining_samples() > load_size) {
                 // The server has enough data for now
                 print_playback_update();
                 usleep(1'000'000 / 10);

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -23,7 +23,7 @@ constexpr size_t LOAD_CHUNK_SIZE = 128 * KiB;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath sendfd unix thread"));
+    TRY(Core::System::pledge("stdio rpath sendfd unix thread proc"));
 
     StringView path {};
     bool should_loop = false;
@@ -50,7 +50,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
     auto loader = maybe_loader.release_value();
 
-    TRY(Core::System::pledge("stdio sendfd thread"));
+    TRY(Core::System::pledge("stdio sendfd thread proc"));
 
     outln("\033[34;1m Playing\033[0m: {}", path);
     outln("\033[34;1m  Format\033[0m: {} {} Hz, {}-bit, {}",


### PR DESCRIPTION
Chunk 5 of #16049

Anything that handles audio in this way should run at maximum priority.

**Note regarding Ports**: This may break ports that use audio. @GMTA informed me that at least quake3 uses pledge and I could not find any other ports which use pledge + audio with a quick search. I can not get quake3 to install, therefore I don't know whether this is a problem.