### PR TITLE
AudioServer: Detect improperly detached audio clients

### DIFF
--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -70,7 +70,7 @@ void Mixer::mix()
             }
         }
 
-        active_mix_queues.remove_all_matching([&](auto& entry) { return !entry->client(); });
+        active_mix_queues.remove_all_matching([&](auto& entry) { return !entry->is_connected(); });
 
         Array<Audio::Sample, HARDWARE_BUFFER_SIZE> mixed_buffer;
 


### PR DESCRIPTION
Chunk 6 of #16049

Because IPC is used very little in audio server communication, a ping-pong method like WindowServer is neither a good nor a reliable way of detecting detached audio clients. AudioServer was previously doing nothing to detect the kinds of clients that never closed their connection properly, which happens e.g. when a program is force-closed. Due to reference-counting cycles, the associated client connection queues were being kept alive. However, the is_open method of local sockets reliably detects all kinds of disconnected sockets and can easily be adapted for this use case. With this fix, we no longer get "Audio client can't keep up" spam on improperly disconnected clients, and the client queues don't fill up indefinitely, reducing processing and memory usage in AudioServer.