### PR TITLE
PDF clipping improved + assorted PDFViewer improvements

### DIFF
--- a/Userland/Applications/PDFViewer/NumericInput.cpp
+++ b/Userland/Applications/PDFViewer/NumericInput.cpp
@@ -29,7 +29,6 @@ NumericInput::NumericInput()
         auto new_number_opt = builder.to_string().to_int();
         if (!new_number_opt.has_value()) {
             m_needs_text_reset = true;
-            set_text(builder.to_string());
             return;
         } else {
             m_needs_text_reset = false;

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -11,6 +11,7 @@
 #include <LibGUI/AbstractScrollableWidget.h>
 #include <LibGfx/Bitmap.h>
 #include <LibPDF/Document.h>
+#include <LibPDF/Renderer.h>
 
 static constexpr size_t initial_zoom_level = 8;
 
@@ -60,6 +61,8 @@ public:
 
     PageViewMode page_view_mode() const { return m_page_view_mode; }
     void set_page_view_mode(PageViewMode);
+    bool show_clipping_paths() const { return m_rendering_preferences.show_clipping_paths; }
+    void set_show_clipping_paths(bool);
 
 protected:
     PDFViewer();
@@ -90,6 +93,7 @@ private:
     u8 m_zoom_level { initial_zoom_level };
     PageDimensionCache m_page_dimension_cache;
     PageViewMode m_page_view_mode;
+    PDF::RenderingPreferences m_rendering_preferences;
 
     Gfx::IntPoint m_pan_starting_position;
     int m_rotations { 0 };

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -37,6 +37,8 @@ PDFViewerWidget::PDFViewerWidget()
     m_viewer = splitter.add<PDFViewer>();
     m_viewer->on_page_change = [&](auto new_page) {
         m_page_text_box->set_current_number(new_page + 1, GUI::AllowCallback::No);
+        m_go_to_prev_page_action->set_enabled(new_page > 0);
+        m_go_to_next_page_action->set_enabled(new_page < m_viewer->document()->get_page_count() - 1);
     };
 
     initialize_toolbar(toolbar);

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -149,10 +149,12 @@ void PDFViewerWidget::initialize_toolbar(GUI::Toolbar& toolbar)
     m_page_view_mode_single = GUI::Action::create_checkable("Single", [&](auto&) {
         m_viewer->set_page_view_mode(PDFViewer::PageViewMode::Single);
     });
+    m_page_view_mode_single->set_status_tip("Show single page at a time");
 
     m_page_view_mode_multiple = GUI::Action::create_checkable("Multiple", [&](auto&) {
         m_viewer->set_page_view_mode(PDFViewer::PageViewMode::Multiple);
     });
+    m_page_view_mode_multiple->set_status_tip("Show multiple pages at a time");
 
     if (m_viewer->page_view_mode() == PDFViewer::PageViewMode::Single) {
         m_page_view_mode_single->set_checked(true);
@@ -163,6 +165,9 @@ void PDFViewerWidget::initialize_toolbar(GUI::Toolbar& toolbar)
     m_page_view_action_group.add_action(*m_page_view_mode_single);
     m_page_view_action_group.add_action(*m_page_view_mode_multiple);
     m_page_view_action_group.set_exclusive(true);
+    toolbar.add_action(*m_page_view_mode_single);
+    toolbar.add_action(*m_page_view_mode_multiple);
+    toolbar.add_separator();
 
     toolbar.add_action(*m_zoom_in_action);
     toolbar.add_action(*m_zoom_out_action);

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -167,6 +167,12 @@ void PDFViewerWidget::initialize_toolbar(GUI::Toolbar& toolbar)
     toolbar.add_action(*m_reset_zoom_action);
     toolbar.add_action(*m_rotate_counterclockwise_action);
     toolbar.add_action(*m_rotate_clockwise_action);
+    toolbar.add_separator();
+
+    m_show_clipping_paths = toolbar.add<GUI::CheckBox>();
+    m_show_clipping_paths->set_text("Show clipping paths");
+    m_show_clipping_paths->set_checked(m_viewer->show_clipping_paths(), GUI::AllowCallback::No);
+    m_show_clipping_paths->on_checked = [&](auto checked) { m_viewer->set_show_clipping_paths(checked); };
 }
 
 void PDFViewerWidget::open_file(Core::File& file)
@@ -214,6 +220,7 @@ void PDFViewerWidget::open_file(Core::File& file)
     m_reset_zoom_action->set_enabled(true);
     m_rotate_counterclockwise_action->set_enabled(true);
     m_rotate_clockwise_action->set_enabled(true);
+    m_show_clipping_paths->set_checked(m_viewer->show_clipping_paths(), GUI::AllowCallback::No);
 
     if (document->outline()) {
         auto outline = document->outline();

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.h
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
+#include "AK/RefPtr.h"
 #include "NumericInput.h"
 #include "PDFViewer.h"
 #include "SidebarWidget.h"
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
-#include <LibGUI/TextBox.h>
+#include <LibGUI/CheckBox.h>
 #include <LibGUI/Widget.h>
 
 class PDFViewer;
@@ -45,6 +46,7 @@ private:
     GUI::ActionGroup m_page_view_action_group;
     RefPtr<GUI::Action> m_page_view_mode_single;
     RefPtr<GUI::Action> m_page_view_mode_multiple;
+    RefPtr<GUI::CheckBox> m_show_clipping_paths;
 
     bool m_sidebar_open { false };
     ByteBuffer m_buffer;

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -21,9 +21,9 @@
 
 namespace PDF {
 
-PDFErrorOr<void> Renderer::render(Document& document, Page const& page, RefPtr<Gfx::Bitmap> bitmap)
+PDFErrorOr<void> Renderer::render(Document& document, Page const& page, RefPtr<Gfx::Bitmap> bitmap, RenderingPreferences rendering_preferences)
 {
-    return Renderer(document, page, bitmap).render();
+    return Renderer(document, page, bitmap, rendering_preferences).render();
 }
 
 static void rect_path(Gfx::Path& path, float x, float y, float width, float height)
@@ -48,12 +48,13 @@ static Gfx::Path rect_path(Gfx::Rect<T> rect)
     return rect_path(rect.x(), rect.y(), rect.width(), rect.height());
 }
 
-Renderer::Renderer(RefPtr<Document> document, Page const& page, RefPtr<Gfx::Bitmap> bitmap)
+Renderer::Renderer(RefPtr<Document> document, Page const& page, RefPtr<Gfx::Bitmap> bitmap, RenderingPreferences rendering_preferences)
     : m_document(document)
     , m_bitmap(bitmap)
     , m_page(page)
     , m_painter(*bitmap)
     , m_anti_aliasing_painter(m_painter)
+    , m_rendering_preferences(rendering_preferences)
 {
     auto media_box = m_page.media_box;
 
@@ -247,6 +248,9 @@ void Renderer::begin_path_paint()
 {
     auto bounding_box = map(state().clipping_paths.current.bounding_box());
     m_painter.clear_clip_rect();
+    if (m_rendering_preferences.show_clipping_paths) {
+        m_painter.stroke_path(rect_path(bounding_box), Color::Black, 1);
+    }
     m_painter.add_clip_rect(bounding_box.to_type<int>());
 }
 

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -66,8 +66,14 @@ struct TextState {
     bool knockout { true };
 };
 
+struct ClippingPaths {
+    Gfx::Path current;
+    Gfx::Path next;
+};
+
 struct GraphicsState {
     Gfx::AffineTransform ctm;
+    ClippingPaths clipping_paths;
     RefPtr<ColorSpace> stroke_color_space { DeviceGrayColorSpace::the() };
     RefPtr<ColorSpace> paint_color_space { DeviceGrayColorSpace::the() };
     Gfx::Color stroke_color { Gfx::Color::NamedColor::Black };
@@ -97,6 +103,8 @@ private:
     PDFErrorOr<void> handle_text_next_line_show_string(Vector<Value> const& args);
     PDFErrorOr<void> handle_text_next_line_show_string_set_spacing(Vector<Value> const& args);
 
+    void begin_path_paint();
+    void end_path_paint();
     PDFErrorOr<void> set_graphics_state_from_dict(NonnullRefPtr<DictObject>);
     void show_text(String const&);
     PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space(Value const&);

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -86,12 +86,16 @@ struct GraphicsState {
     TextState text_state {};
 };
 
+struct RenderingPreferences {
+    bool show_clipping_paths { false };
+};
+
 class Renderer {
 public:
-    static PDFErrorOr<void> render(Document&, Page const&, RefPtr<Gfx::Bitmap>);
+    static PDFErrorOr<void> render(Document&, Page const&, RefPtr<Gfx::Bitmap>, RenderingPreferences preferences);
 
 private:
-    Renderer(RefPtr<Document>, Page const&, RefPtr<Gfx::Bitmap>);
+    Renderer(RefPtr<Document>, Page const&, RefPtr<Gfx::Bitmap>, RenderingPreferences);
 
     PDFErrorOr<void> render();
 
@@ -130,6 +134,7 @@ private:
     Page const& m_page;
     Gfx::Painter m_painter;
     Gfx::AntiAliasingPainter m_anti_aliasing_painter;
+    RenderingPreferences m_rendering_preferences;
 
     Gfx::Path m_current_path;
     Vector<GraphicsState> m_graphics_state_stack;


### PR DESCRIPTION
This PR fixes the path clipping logic in LibPDF's Renderer. Path clipping needs some extra elements on the graphics state, and works differently from how it was previously implemented.

While doing this I also thought it'd be a good idea to add a user toggle to show these clipping paths, so I surfaced that toggle from the Renderer all the way through to the PDFViewerWidget. Since this might not be the only rendering-related option, I've created a RenderingPreferences struct to hold all the potential preferences we might want to support.

While doing *that* I also found a couple of quirks on PDFViewer itself, which I'm also submitting fixes to.