### PR TITLE
LibJS: Avoid crash when evaluating cyclic modules not in a cycle

### DIFF
--- a/Userland/Libraries/LibJS/CyclicModule.cpp
+++ b/Userland/Libraries/LibJS/CyclicModule.cpp
@@ -196,9 +196,15 @@ ThrowCompletionOr<Promise*> CyclicModule::evaluate(VM& vm)
         // Note: This will continue this function with module.[[CycleRoot]]
         VERIFY(m_cycle_root && m_cycle_root->m_status == ModuleStatus::Linked && this != m_cycle_root);
         dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] evaluate[{}](vm) deferring to cycle root at {}", this, m_cycle_root);
-        return m_cycle_root->evaluate(vm);
+        return m_cycle_root->proceed_evaluate(vm);
     }
 
+    // Note: Steps 4 onwards are continued in CyclicModule::proceed_evaluate
+    return proceed_evaluate(vm);
+}
+
+ThrowCompletionOr<Promise*> CyclicModule::proceed_evaluate(VM& vm)
+{
     // 4. If module.[[TopLevelCapability]] is not empty, then
     if (m_top_level_capability != nullptr) {
         // a. Return module.[[TopLevelCapability]].[[Promise]].

--- a/Userland/Libraries/LibJS/CyclicModule.cpp
+++ b/Userland/Libraries/LibJS/CyclicModule.cpp
@@ -193,10 +193,12 @@ ThrowCompletionOr<Promise*> CyclicModule::evaluate(VM& vm)
 
     // 3. If module.[[Status]] is evaluating-async or evaluated, set module to module.[[CycleRoot]].
     if (m_status == ModuleStatus::EvaluatingAsync || m_status == ModuleStatus::Evaluated) {
-        // Note: This will continue this function with module.[[CycleRoot]]
-        VERIFY(m_cycle_root && m_cycle_root->m_status == ModuleStatus::Linked && this != m_cycle_root);
-        dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] evaluate[{}](vm) deferring to cycle root at {}", this, m_cycle_root);
-        return m_cycle_root->proceed_evaluate(vm);
+        // Note: Per the spec 'For a module not in a cycle this would be the module itself', thus we can
+        //       continue with this if there isn't a root.
+        if (m_cycle_root) {
+            dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] evaluate[{}](vm) deferring to cycle root at {}", this, m_cycle_root);
+            return m_cycle_root->proceed_evaluate(vm);
+        }
     }
 
     // Note: Steps 4 onwards are continued in CyclicModule::proceed_evaluate

--- a/Userland/Libraries/LibJS/CyclicModule.h
+++ b/Userland/Libraries/LibJS/CyclicModule.h
@@ -37,6 +37,8 @@ protected:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
+    virtual ThrowCompletionOr<Promise*> proceed_evaluate(VM& vm);
+
     virtual ThrowCompletionOr<u32> inner_module_linking(VM& vm, Vector<Module*>& stack, u32 index) override;
     virtual ThrowCompletionOr<u32> inner_module_evaluation(VM& vm, Vector<Module*>& stack, u32 index) override;
 


### PR DESCRIPTION
Cyclic modules are not a particular area of which I have a great deal of expertise, but I believe these changes are appropriate. cc @davidot (original author)

These changes have been made to get Ladybird to open Codeberg.org without crashing.