### PR TITLE
Meta: Don't depend on sudo for privilleged operations

### DIFF
--- a/Meta/.shell_include.sh
+++ b/Meta/.shell_include.sh
@@ -3,10 +3,13 @@
 # SC2034: "Variable appears unused. Verify it or export it."
 #         Those are intentional here, as the file is meant to be included elsewhere.
 
-SUDO="sudo"
+# NOTE: If using another privilege escalation binary make sure it is configured or has the appropiate flag
+#       to keep the current environment variables in the launched process (in sudo's case this is achieved
+#       through the -E flag described in sudo(8).
+SUDO="sudo -E"
 
 if [ "$(uname -s)" = "SerenityOS" ]; then
-    SUDO="pls"
+    SUDO="pls -E"
 fi
 
 die() {

--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -8,7 +8,7 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} -E -- sh -c "\"$0\" $* || exit 42"
+    ${SUDO} -- sh -c "\"$0\" $* || exit 42"
     case $? in
         1)
             die "this script needs to run as root"

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -8,7 +8,7 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} -E -- sh -c "\"$0\" $* || exit 42"
+    ${SUDO} -- sh -c "\"$0\" $* || exit 42"
     case $? in
         1)
             die "this script needs to run as root"

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -17,7 +17,7 @@ fi
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} -E -- sh -c "\"$0\" $* || exit 42"
+    ${SUDO} -- sh -c "\"$0\" $* || exit 42"
     case $? in
         1)
             die "this script needs to run as root"

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -25,7 +25,7 @@ if [ "$(id -u)" != 0 ]; then
         USE_FUSE2FS=1
     else
         set +e
-        ${SUDO} -E -- sh -c "\"$0\" $* || exit 42"
+        ${SUDO} -- sh -c "\"$0\" $* || exit 42"
         case $? in
             1)
                 die "this script needs to run as root"

--- a/Meta/build-native-partition.sh
+++ b/Meta/build-native-partition.sh
@@ -16,7 +16,7 @@ cleanup() {
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} -E -- sh -c "\"$0\" $* || exit 42"
+    ${SUDO} -- sh -c "\"$0\" $* || exit 42"
     case $? in
         1)
             die "this script needs to run as root"


### PR DESCRIPTION
We previously depended on sudo's specific -E flag to keep all the environment variables when performing a privillege escalation. We now incorporate the -E flag into the $SUDO variable, allowing for other privillege escalation binaries (such as doas) to be used (as long as they preserve the current environment variables).