### PR TITLE
LibJS: Switch to bytecode interpreter to run generator functions for AST

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -103,11 +103,16 @@ ThrowCompletionOr<Value> GeneratorObject::execute(VM& vm, Completion const& comp
     completion_object->define_direct_property(vm.names.value, completion.value().value(), default_attributes);
 
     auto* bytecode_interpreter = Bytecode::Interpreter::current();
+
+    // If we're coming from a context which has no bytecode interpreter, e.g. from AST mode calling Generate.prototype.next,
+    // we need to make one to be able to continue, as generators are only supported in bytecode mode.
+    // See also ECMAScriptFunctionObject::ordinary_call_evaluate_body where this is done as well.
     OwnPtr<Bytecode::Interpreter> temp_bc_interpreter;
     if (!bytecode_interpreter) {
         temp_bc_interpreter = make<Bytecode::Interpreter>(realm);
         bytecode_interpreter = temp_bc_interpreter.ptr();
     }
+
     VERIFY(bytecode_interpreter);
 
     auto const* next_block = generated_continuation(m_previous_value);


### PR DESCRIPTION
The bytecode interpreter can execute generator functions while the AST interpreter cannot. This simply makes it create a new bytecode interpreter when one doesn't exist when executing a generator function. Doing so makes it automatically switch to the bytecode interpreter to execute any future code until it exits the generator.

```
Duration:
     -4.64s

Summary:
    Diff Tests:
        +2759 ✅   +206 ❌   +32 💥️    -2997 📝
```

```
42732 ✅ (88.04%) 1467 ❌ (3.02%) 112 ⚙️ (0.23%) 2 💀 (0.004%) 34 💥️ (0.07%) 4190 📝 (8.63%)
```

Difference as a file: [diff.txt](https://github.com/SerenityOS/serenity/files/10079439/diff.txt)

Demo of using for/of destructuring (currently only in AST) with generator functions
![Screenshot from 2022-11-23 22-15-50](https://user-images.githubusercontent.com/25595356/203655216-9a8a9529-6ab2-436b-a64a-65422f925f8c.png)
