### PR TITLE
Ports: Fix warning when building with `useconfigure="false"`

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -13,7 +13,7 @@ export MAKEJOBS="${MAKEJOBS:-$(nproc)}"
 buildstep() {
     local buildstep_name=$1
     shift
-    if [ -z "$@" ]; then
+    if [ "$#" -eq '0' ]; then
         "${buildstep_name}"
     else
         "$@"


### PR DESCRIPTION
The `buildstep` function tests whether the positional arguments evaluate to an emtpy string, but could fail when multiple positional arguments were provided. This resulted in the following warning when building the Composer port, for example:

```
../.port_include.sh: line 16: [: echo: binary operator expected
```

Prevent this warning by testing against the number of positional arguments, instead.