### PR TITLE
LibJS: Make Error stack trace generation faster with a line break cache

### DIFF
--- a/AK/Utf8View.cpp
+++ b/AK/Utf8View.cpp
@@ -24,6 +24,11 @@ Utf8CodePointIterator Utf8View::iterator_at_byte_offset(size_t byte_offset) cons
     return end();
 }
 
+Utf8CodePointIterator Utf8View::iterator_at_byte_offset_without_validation(size_t byte_offset) const
+{
+    return Utf8CodePointIterator { reinterpret_cast<u8 const*>(m_string.characters_without_null_termination()) + byte_offset, m_string.length() - byte_offset };
+}
+
 size_t Utf8View::byte_offset_of(Utf8CodePointIterator const& it) const
 {
     VERIFY(it.m_ptr >= begin_ptr());

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -80,6 +80,8 @@ public:
     Utf8CodePointIterator end() const { return { end_ptr(), 0 }; }
     Utf8CodePointIterator iterator_at_byte_offset(size_t) const;
 
+    Utf8CodePointIterator iterator_at_byte_offset_without_validation(size_t) const;
+
     unsigned char const* bytes() const { return begin_ptr(); }
     size_t byte_length() const { return m_string.length(); }
     size_t byte_offset_of(Utf8CodePointIterator const&) const;

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -53,7 +53,9 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const;
     virtual void dump(int indent) const;
 
-    SourceRange source_range() const;
+    [[nodiscard]] SourceRange source_range() const;
+
+    void set_end_offset(Badge<Parser>, u32 end_offset) { m_end_offset = end_offset; }
 
     String class_name() const;
 

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -497,7 +497,7 @@ NonnullRefPtr<Program> Parser::parse_program(bool starts_in_strict_mode)
     else
         parse_module(program);
 
-    program->source_range().end = position();
+    program->set_end_offset({}, position().offset);
     return program;
 }
 

--- a/Userland/Libraries/LibJS/SourceCode.cpp
+++ b/Userland/Libraries/LibJS/SourceCode.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/BinarySearch.h>
 #include <AK/Utf8View.h>
 #include <LibJS/SourceCode.h>
 #include <LibJS/SourceRange.h>
@@ -32,18 +33,52 @@ String const& SourceCode::code() const
     return m_code;
 }
 
+void SourceCode::compute_line_break_offsets() const
+{
+    m_line_break_offsets = Vector<size_t> {};
+
+    if (m_code.is_empty())
+        return;
+
+    bool previous_code_point_was_carriage_return = false;
+    Utf8View view(m_code.view());
+    for (auto it = view.begin(); it != view.end(); ++it) {
+        u32 code_point = *it;
+        bool is_line_terminator = code_point == '\r' || (code_point == '\n' && !previous_code_point_was_carriage_return) || code_point == LINE_SEPARATOR || code_point == PARAGRAPH_SEPARATOR;
+        previous_code_point_was_carriage_return = code_point == '\r';
+
+        if (is_line_terminator)
+            m_line_break_offsets->append(view.byte_offset_of(it));
+    }
+}
+
 SourceRange SourceCode::range_from_offsets(u32 start_offset, u32 end_offset) const
 {
+    if (m_code.is_empty())
+        return { *this, {}, {} };
+
+    if (!m_line_break_offsets.has_value())
+        compute_line_break_offsets();
+
+    size_t line = 1;
+    size_t nearest_line_break_index = 0;
+    size_t nearest_preceding_line_break_offset = 0;
+
+    if (!m_line_break_offsets->is_empty()) {
+        binary_search(*m_line_break_offsets, start_offset, &nearest_line_break_index);
+        line = 1 + nearest_line_break_index;
+        nearest_preceding_line_break_offset = (*m_line_break_offsets)[nearest_line_break_index];
+    }
+
     Position start;
     Position end;
 
-    size_t line = 1;
     size_t column = 1;
 
     bool previous_code_point_was_carriage_return = false;
 
-    Utf8View view(m_code);
-    for (auto it = view.begin(); it != view.end(); ++it) {
+    Utf8View view(m_code.view());
+    for (auto it = view.iterator_at_byte_offset_without_validation(nearest_preceding_line_break_offset); it != view.end(); ++it) {
 
         if (start_offset == view.byte_offset_of(it)) {
             start = Position {

--- a/Userland/Libraries/LibJS/SourceCode.h
+++ b/Userland/Libraries/LibJS/SourceCode.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <AK/Vector.h>
 #include <LibJS/Forward.h>
 
 namespace JS {
@@ -23,8 +24,12 @@ public:
 private:
     SourceCode(String filename, String code);
 
+    void compute_line_break_offsets() const;
+
     String m_filename;
     String m_code;
+
+    Optional<Vector<size_t>> mutable m_line_break_offsets;
 };
 
 }


### PR DESCRIPTION
Generating Error objects got a lot slower after the introduction of SourceCode in b0b022507b2f73be2f4cef17deb8ece91dae6822.

This was noticeable with `test-js` which generates a lot of errors, so walking the source code over and over to compute (line, column) was eating a ton of time.

This patch makes repeated lookups a lot faster by building a cache of line break offsets in the source code. The cache is built on first offset lookup, so we only pay for this in code that actually throws.

On my machine, this takes `test-js` runtime from 6.7 sec to 4.3 sec.