### PR TITLE
LibGfx: Prevent calling `to_type<T>()` on `Line/Point/Rect/Size<T>`

### DIFF
--- a/Userland/Libraries/LibGfx/Line.h
+++ b/Userland/Libraries/LibGfx/Line.h
@@ -134,6 +134,13 @@ public:
     void set_a(Point<T> const& a) { m_a = a; }
     void set_b(Point<T> const& b) { m_b = b; }
 
+    template<typename U>
+    requires(!IsSame<T, U>)
+        [[nodiscard]] ALWAYS_INLINE constexpr Line<U> to_type() const
+    {
+        return Line<U>(*this);
+    }
+
     String to_string() const;
 
 private:

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -229,7 +229,8 @@ public:
     [[nodiscard]] Point end_point_for_aspect_ratio(Point const& previous_end_point, float aspect_ratio) const;
 
     template<typename U>
-    [[nodiscard]] Point<U> to_type() const
+    requires(!IsSame<T, U>)
+        [[nodiscard]] Point<U> to_type() const
     {
         return Point<U>(*this);
     }

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -949,7 +949,8 @@ public:
     }
 
     template<typename U>
-    [[nodiscard]] ALWAYS_INLINE Rect<U> to_type() const
+    requires(!IsSame<T, U>)
+        [[nodiscard]] ALWAYS_INLINE Rect<U> to_type() const
     {
         return Rect<U>(*this);
     }

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -151,7 +151,8 @@ public:
     }
 
     template<typename U>
-    [[nodiscard]] ALWAYS_INLINE constexpr Size<U> to_type() const
+    requires(!IsSame<T, U>)
+        [[nodiscard]] ALWAYS_INLINE constexpr Size<U> to_type() const
     {
         return Size<U>(*this);
     }


### PR DESCRIPTION
Also, add `Line::to_type<T>()` since that was missing.

Calling to_type() with the same type as the existing object accomplishes nothing except wasting some cycles and making the code more verbose, and it is hard to spot. Nobody does this in the code currently (yay!) but I made this mistake repeatedly when doing my step-by-step CSS Pixels conversion, so lets' make it easier to catch them.