### PR TITLE
LibWeb: Actually return the same object in [SameObject] property getters

### DIFF
--- a/Base/res/html/tests/sameobject-behavior-for-htmlcollection-properties.html
+++ b/Base/res/html/tests/sameobject-behavior-for-htmlcollection-properties.html
@@ -1,0 +1,52 @@
+<html>
+<style>
+.ball {
+  border-radius: 9999px;
+  width: 40px;
+  height: 40px;
+  display: inline-block;
+}
+.pass {
+  background: green;
+}
+.fail {
+  background: red;
+}
+</style>
+<p>This test verifies that various HTMLCollection properties have <b>[SameObject]</b> behavior.</p>
+<p>You should see a bunch of green balls below this line.</p>
+  <div id="out"></div>
+  <form><table><thead><tr><td></td></tr></thead></table></form>
+
+<script>
+  let out = document.querySelector("#out")
+
+  function test(expr) {
+    let a = eval(expr)
+    let b = eval(expr)
+    let e = document.createElement("div")
+    e.className = "ball " + ((a === b) ? "pass" : "fail")
+    out.appendChild(e)
+  }
+
+  let table = document.querySelector("table")
+  let tr = document.querySelector("tr")
+  let form = document.querySelector("form")
+  let thead = document.querySelector("thead")
+
+  test("table.tBodies")
+  test("table.rows")
+  test("thead.rows")
+  test("tr.cells")
+  test("form.elements")
+
+  test("document.applets")
+  test("document.anchors")
+  test("document.images")
+  test("document.embeds")
+  test("document.plugins")
+  test("document.links")
+  test("document.forms")
+  test("document.scripts")
+</script>
+</html>

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -60,14 +60,14 @@ interface Document : Node {
     HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);
     HTMLCollection getElementsByClassName(DOMString className);
 
-    readonly attribute HTMLCollection applets;
-    readonly attribute HTMLCollection anchors;
-    readonly attribute HTMLCollection images;
-    readonly attribute HTMLCollection embeds;
-    readonly attribute HTMLCollection plugins;
-    readonly attribute HTMLCollection links;
-    readonly attribute HTMLCollection forms;
-    readonly attribute HTMLCollection scripts;
+    [SameObject] readonly attribute HTMLCollection applets;
+    [SameObject] readonly attribute HTMLCollection anchors;
+    [SameObject] readonly attribute HTMLCollection images;
+    [SameObject] readonly attribute HTMLCollection embeds;
+    [SameObject] readonly attribute HTMLCollection plugins;
+    [SameObject] readonly attribute HTMLCollection links;
+    [SameObject] readonly attribute HTMLCollection forms;
+    [SameObject] readonly attribute HTMLCollection scripts;
 
     // FIXME: Should return an HTMLAllCollection
     readonly attribute HTMLCollection all;

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -33,6 +33,7 @@ HTMLFormElement::~HTMLFormElement() = default;
 void HTMLFormElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
+    visitor.visit(m_elements);
     for (auto& element : m_associated_elements)
         visitor.visit(element.ptr());
 }
@@ -185,11 +186,12 @@ static bool is_form_control(DOM::Element const& element)
 // https://html.spec.whatwg.org/multipage/forms.html#dom-form-elements
 JS::NonnullGCPtr<DOM::HTMLCollection> HTMLFormElement::elements() const
 {
-    // FIXME: This should return the same HTMLFormControlsCollection object every time,
-    //        but that would cause a reference cycle since HTMLCollection refs the root.
-    return DOM::HTMLCollection::create(const_cast<HTMLFormElement&>(*this), [](Element const& element) {
-        return is_form_control(element);
-    });
+    if (!m_elements) {
+        m_elements = DOM::HTMLCollection::create(const_cast<HTMLFormElement&>(*this), [](Element const& element) {
+            return is_form_control(element);
+        });
+    }
+    return *m_elements;
 }
 
 // https://html.spec.whatwg.org/multipage/forms.html#dom-form-length

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -39,6 +39,8 @@ private:
     bool m_firing_submission_events { false };
 
     Vector<JS::GCPtr<HTMLElement>> m_associated_elements;
+
+    JS::GCPtr<DOM::HTMLCollection> mutable m_elements;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
@@ -12,8 +12,8 @@ interface HTMLFormElement : HTMLElement {
 
     undefined submit();
 
-    // FIXME: Should be [SameObject] and a HTMLFormControlsCollection
-    readonly attribute HTMLCollection elements;
+    // FIXME: Should be a HTMLFormControlsCollection
+    [SameObject] readonly attribute HTMLCollection elements;
 
     readonly attribute unsigned long length;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.h
@@ -45,7 +45,12 @@ public:
 private:
     HTMLTableElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual void visit_edges(Cell::Visitor&) override;
+
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
+
+    JS::GCPtr<DOM::HTMLCollection> mutable m_rows;
+    JS::GCPtr<DOM::HTMLCollection> mutable m_t_bodies;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.idl
@@ -20,10 +20,10 @@ interface HTMLTableElement : HTMLElement {
     HTMLTableSectionElement createTFoot();
     undefined deleteTFoot();
 
-    readonly attribute HTMLCollection tBodies;
+    [SameObject] readonly attribute HTMLCollection tBodies;
     HTMLTableSectionElement createTBody();
 
-    readonly attribute HTMLCollection rows;
+    [SameObject] readonly attribute HTMLCollection rows;
     HTMLTableRowElement insertRow(optional long index = -1);
     undefined deleteRow(long index);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -23,17 +23,24 @@ HTMLTableRowElement::HTMLTableRowElement(DOM::Document& document, DOM::Qualified
 
 HTMLTableRowElement::~HTMLTableRowElement() = default;
 
+void HTMLTableRowElement::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_cells);
+}
+
 // https://html.spec.whatwg.org/multipage/tables.html#dom-tr-cells
 JS::NonnullGCPtr<DOM::HTMLCollection> HTMLTableRowElement::cells() const
 {
     // The cells attribute must return an HTMLCollection rooted at this tr element,
     // whose filter matches only td and th elements that are children of the tr element.
-    // FIXME: This should return the same HTMLCollection object every time,
-    //        but that would cause a reference cycle since HTMLCollection refs the root.
-    return DOM::HTMLCollection::create(const_cast<HTMLTableRowElement&>(*this), [this](Element const& element) {
-        return element.parent() == this
-            && is<HTMLTableCellElement>(element);
-    });
+    if (!m_cells) {
+        m_cells = DOM::HTMLCollection::create(const_cast<HTMLTableRowElement&>(*this), [this](Element const& element) {
+            return element.parent() == this
+                && is<HTMLTableCellElement>(element);
+        });
+    }
+    return *m_cells;
 }
 
 // https://html.spec.whatwg.org/multipage/tables.html#dom-tr-rowindex

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.h
@@ -25,6 +25,10 @@ public:
 
 private:
     HTMLTableRowElement(DOM::Document&, DOM::QualifiedName);
+
+    virtual void visit_edges(Cell::Visitor&) override;
+
+    JS::GCPtr<DOM::HTMLCollection> mutable m_cells;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -22,17 +22,24 @@ HTMLTableSectionElement::HTMLTableSectionElement(DOM::Document& document, DOM::Q
 
 HTMLTableSectionElement::~HTMLTableSectionElement() = default;
 
+void HTMLTableSectionElement::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_rows);
+}
+
 // https://html.spec.whatwg.org/multipage/tables.html#dom-tbody-rows
 JS::NonnullGCPtr<DOM::HTMLCollection> HTMLTableSectionElement::rows() const
 {
     // The rows attribute must return an HTMLCollection rooted at this element,
     // whose filter matches only tr elements that are children of this element.
-    // FIXME: This should return the same HTMLCollection object every time,
-    //        but that would cause a reference cycle since HTMLCollection refs the root.
-    return DOM::HTMLCollection::create(const_cast<HTMLTableSectionElement&>(*this), [this](Element const& element) {
-        return element.parent() == this
-            && is<HTMLTableRowElement>(element);
-    });
+    if (!m_rows) {
+        m_rows = DOM::HTMLCollection::create(const_cast<HTMLTableSectionElement&>(*this), [this](Element const& element) {
+            return element.parent() == this
+                && is<HTMLTableRowElement>(element);
+        });
+    }
+    return *m_rows;
 }
 
 // https://html.spec.whatwg.org/multipage/tables.html#dom-tbody-insertrow

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.h
@@ -23,6 +23,10 @@ public:
 
 private:
     HTMLTableSectionElement(DOM::Document&, DOM::QualifiedName);
+
+    virtual void visit_edges(Cell::Visitor&) override;
+
+    JS::GCPtr<DOM::HTMLCollection> mutable m_rows;
 };
 
 }


### PR DESCRIPTION
Now that the DOM lifetime is managed by the LibJS garbage collector, we no longer have to worry about reference cycles between `HTMLCollection` and elements with `[SameObject]` collection properties.

This PR solves 3 FIXMEs by implementing the expected `[SameObject]` behavior for various properties. A test page is also added for GBP.