### PR TITLE
LibWeb: Support special border width identifiers

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -85,19 +85,6 @@ CSS::Size StyleProperties::size_value(CSS::PropertyID id) const
     return CSS::Size::make_auto();
 }
 
-Length StyleProperties::length_or_fallback(CSS::PropertyID id, Length const& fallback) const
-{
-    auto value = property(id);
-
-    if (value->is_calculated())
-        return Length::make_calculated(value->as_calculated());
-
-    if (value->has_length())
-        return value->to_length();
-
-    return fallback;
-}
-
 LengthPercentage StyleProperties::length_percentage_or_fallback(CSS::PropertyID id, LengthPercentage const& fallback) const
 {
     return length_percentage(id).value_or(fallback);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -43,7 +43,6 @@ public:
     RefPtr<StyleValue> maybe_null_property(CSS::PropertyID) const;
 
     CSS::Size size_value(CSS::PropertyID) const;
-    Length length_or_fallback(CSS::PropertyID, Length const& fallback) const;
     LengthPercentage length_percentage_or_fallback(CSS::PropertyID, LengthPercentage const& fallback) const;
     Optional<LengthPercentage> length_percentage(CSS::PropertyID) const;
     LengthBox length_box(CSS::PropertyID left_id, CSS::PropertyID top_id, CSS::PropertyID right_id, CSS::PropertyID bottom_id, const CSS::Length& default_value) const;


### PR DESCRIPTION
- **LibWeb: Support special border width identifiers**

  Previously identifiers were resolved to zero length. This could be seen when a border declaration doesn't have specified width (e.g. `border: solid`), as the initial border width is ‘medium’.

  The spec doesn’t specify what the identifiers should really resolve to, but it gives us some example values and that's what I've used here. :^)

  Spec link: https://www.w3.org/TR/css-backgrounds-3/#border-width

  before | this pr
  ---|---
  ![image](https://user-images.githubusercontent.com/16520278/203870040-28f498b2-f19d-4f04-8dea-2105ad1f18dd.png) | ![screenshot](https://user-images.githubusercontent.com/16520278/203870024-4e2c1d11-4789-410d-ab2d-6af6ce26c453.png)



- **LibWeb: Remove unused StyleProperties::length_or_fallback function**

  
