### PR TITLE
FuzzTar+tar: Advance the stream before continuing

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzTar.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTar.cpp
@@ -19,8 +19,12 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
     while (!tar_stream.finished()) {
         auto const& header = tar_stream.header();
 
-        if (!header.content_is_like_extended_header())
-            continue;
+        if (!header.content_is_like_extended_header()) {
+            if (tar_stream.advance().is_error())
+                return 0;
+            else
+                continue;
+        }
 
         switch (header.type_flag()) {
         case Archive::TarFileType::GlobalExtendedHeader:

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -124,6 +124,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     VERIFY_NOT_REACHED();
                 }
 
+                TRY(tar_stream.advance());
                 continue;
             }
 
@@ -141,6 +142,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     long_name.append(reinterpret_cast<char*>(buffer.data()), bytes_read);
 
                 local_overrides.set("path", long_name.to_string());
+                TRY(tar_stream.advance());
                 continue;
             }
             default:


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=53733, which was caused by a regression introduced in c88d8a2.