### PR TITLE
LibJS: Allow TypedArrays to become detached while sorting

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -358,10 +358,10 @@ ThrowCompletionOr<TypedArrayBase*> typed_array_create_same_type(VM& vm, TypedArr
     return result;
 }
 
-// 1.2.2.1.2 CompareTypedArrayElements ( x, y, comparefn, buffer ), https://tc39.es/proposal-change-array-by-copy/#sec-comparetypedarrayelements
-ThrowCompletionOr<double> compare_typed_array_elements(VM& vm, Value x, Value y, FunctionObject* comparefn, ArrayBuffer& buffer)
+// 1.2.2.1.2 CompareTypedArrayElements ( x, y, comparefn ), https://tc39.es/proposal-change-array-by-copy/#sec-comparetypedarrayelements
+ThrowCompletionOr<double> compare_typed_array_elements(VM& vm, Value x, Value y, FunctionObject* comparefn)
 {
-    // 1. Assert: Both Type(x) and Type(y) are Number or both are BigInt.
+    // 1. Assert: x is a Number and y is a Number, or x is a BigInt and y is a BigInt.
     VERIFY(((x.is_number() && y.is_number()) || (x.is_bigint() && y.is_bigint())));
 
     // 2. If comparefn is not undefined, then
@@ -370,15 +370,11 @@ ThrowCompletionOr<double> compare_typed_array_elements(VM& vm, Value x, Value y,
         auto value = TRY(call(vm, comparefn, js_undefined(), x, y));
         auto value_number = TRY(value.to_number(vm));
 
-        // b. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-        if (buffer.is_detached())
-            return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
-
-        //  c. If v is NaN, return +0𝔽.
+        // b. If v is NaN, return +0𝔽.
         if (value_number.is_nan())
             return 0;
 
-        // d. Return v.
+        // c. Return v.
         return value_number.as_double();
     }
 

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -459,7 +459,7 @@ private:
 
 ThrowCompletionOr<TypedArrayBase*> typed_array_create(VM&, FunctionObject& constructor, MarkedVector<Value> arguments);
 ThrowCompletionOr<TypedArrayBase*> typed_array_create_same_type(VM&, TypedArrayBase const& exemplar, MarkedVector<Value> arguments);
-ThrowCompletionOr<double> compare_typed_array_elements(VM&, Value x, Value y, FunctionObject* comparefn, ArrayBuffer&);
+ThrowCompletionOr<double> compare_typed_array_elements(VM&, Value x, Value y, FunctionObject* comparefn);
 
 #define JS_DECLARE_TYPED_ARRAY(ClassName, snake_name, PrototypeName, ConstructorName, Type) \
     class ClassName : public TypedArray<Type> {                                             \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -1640,8 +1640,8 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::to_sorted)
     // 9. Let j be 0.
     // 10. Repeat, while j < len,
     for (size_t j = 0; j < length; j++) {
-        // Perform ! Set(A, ! ToString(𝔽(j)), sortedList[j], true).
-        MUST(return_array->create_data_property_or_throw(j, sorted_list[j]));
+        // a. Perform ! Set(A, ! ToString(𝔽(j)), sortedList[j], true).
+        MUST(return_array->set(j, sorted_list[j], Object::ShouldThrowExceptions::Yes));
         // b. Set j to j + 1.
     }
 

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.toSorted.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.toSorted.js
@@ -49,6 +49,28 @@ test("basic functionality", () => {
     });
 });
 
+test("detached buffer", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const typedArray = new T(3);
+        typedArray[0] = 3;
+        typedArray[1] = 1;
+        typedArray[2] = 2;
+
+        const sortedTypedArray = typedArray.toSorted((a, b) => {
+            detachArrayBuffer(typedArray.buffer);
+            return a - b;
+        });
+
+        expect(typedArray[0]).toBeUndefined();
+        expect(typedArray[1]).toBeUndefined();
+        expect(typedArray[2]).toBeUndefined();
+
+        expect(sortedTypedArray[0]).toBe(1);
+        expect(sortedTypedArray[1]).toBe(2);
+        expect(sortedTypedArray[2]).toBe(3);
+    });
+});
+
 describe("errors", () => {
     test("null or undefined this value", () => {
         TYPED_ARRAYS.forEach(T => {


### PR DESCRIPTION
This is a normative change in the Change Array by Copy proposal. See:
https://github.com/tc39/proposal-change-array-by-copy/commit/17d8b54