### PR TITLE
CI: Upgrade `actions/github-script` to v6

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Lint PR commits
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const rules = [


### PR DESCRIPTION
Upgrades all instances of actions/github-script to v6 (there is only one instance).

Tested here: https://github.com/martinfalisse/test/pull/1/checks

Quoting [filiphsps](https://github.com/filiphsps) :
This PR partially fi_xes (scrambled as to not autoclose) https://github.com/SerenityOS/serenity/issues/15547.