### PR TITLE
LibVT: Prevent `u16` underflow when resizing terminal to a height of 1

### DIFF
--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -781,7 +781,7 @@ void Terminal::scroll_up(u16 region_top, u16 region_bottom, size_t count)
     }
     // Set dirty flag on swapped lines.
     // The other lines have implicitly been set dirty by being cleared.
-    for (u16 row = region_top; row <= region_bottom - count; ++row)
+    for (u16 row = region_top; row + count <= region_bottom; ++row)
         active_buffer()[row].set_dirty(true);
     m_client.terminal_history_changed(history_delta);
 }


### PR DESCRIPTION
Resizing the Terminal window to its smallest size no longer crashes.

Fixes #7296.