### PR TITLE
LibWeb: Do not try to place floating blocks in anonymous nodes

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -85,10 +85,6 @@ static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layo
         return layout_parent;
     }
 
-    if ((layout_node.is_absolutely_positioned() || layout_node.is_floating()) && layout_parent.last_child()->children_are_inline() && layout_parent.last_child()->is_anonymous()) {
-        return *layout_parent.last_child();
-    }
-
     if (!layout_parent.children_are_inline()) {
         // Parent block has block-level children, insert this block into parent.
         return layout_parent;


### PR DESCRIPTION
Currently placing floating blocks in anonymous nodes makes https://stackoverflow.com/ hang so let's leave it to try to place only absolute blocks in anonymous nodes for now.

Also it breaks flex formatting when element with floating is
flex child.