### PR TITLE
Meta: Update actions/libjs-test262 action to newer version

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -151,7 +151,7 @@ jobs:
           mv wasm-new-results.json ../../libjs-website/wasm/data/results.json
 
       - name: Deploy to GitHub pages
-        uses: JamesIves/github-pages-deploy-action@4.1.1
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           git-config-name: BuggieBot
           git-config-email: buggiebot@serenityos.org
@@ -182,7 +182,7 @@ jobs:
           cpack -D CPACK_INSTALL_CMAKE_PROJECTS="$(pwd)/_deps/lagom-build;js;js;/"
 
       - name: Upload js package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: serenity-js
           path: libjs-test262/Build/serenity-js.tar.gz


### PR DESCRIPTION
This should get rid of the non node 16 and outdated command warnings.

:warning: Since this is master only I have not confirmed that this works, and testing on a local repo is kind of hard :warning:

Fixes some parts of #15547.