### PR TITLE
LibWeb: Don't collapse TextNode if it's editable

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -255,6 +255,9 @@ void InlineLevelIterator::enter_text_node(Layout::TextNode const& text_node)
         do_respect_linebreaks = true;
     }
 
+    if (text_node.dom_node().is_editable() && !text_node.dom_node().is_uninteresting_whitespace_node())
+        do_collapse = false;
+
     // FIXME: The const_cast here is gross.
     const_cast<TextNode&>(text_node).compute_text_for_rendering(do_collapse);
 


### PR DESCRIPTION
Fixes #16127