### PR TITLE
CI: Install gcc-12 for Android nightly CI job

### DIFF
--- a/Meta/Azure/Setup.yml
+++ b/Meta/Azure/Setup.yml
@@ -39,5 +39,7 @@ steps:
 
   - ${{ if eq(parameters.os, 'Android') }}:
     - script: |
-        sudo apt-get install ccache ninja-build unzip
+        sudo apt-get install ccache gcc-12 g++-12 libstdc++-12-dev ninja-build unzip
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100
       displayName: 'Install Dependencies'


### PR DESCRIPTION
This *also* got missed in the gcc-12 update, because we weren't installing an explicit gcc version prior. Hopefully that's the last of the long tail of issues from that migration!