### PR TITLE
Meta: Use the correct cache paths in the wasm workflow

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -30,23 +30,25 @@ jobs:
       - name: "Create build directories"
         run: |
           mkdir -p ${{ github.workspace }}/Build/lagom-tools/TZDB
-          mkdir -p ${{ github.workspace }}/Build/lagom-tools/UCD
-          mkdir -p ${{ github.workspace }}/Build/lagom-tools/CLDR
-          mkdir -p ${{ github.workspace }}/Build/wasm
+          mkdir -p ${{ github.workspace }}/Build/wasm/UCD
+          mkdir -p ${{ github.workspace }}/Build/wasm/CLDR
       - name: "TimeZoneData cache"
         uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
         with:
           path: ${{ github.workspace }}/Build/lagom-tools/TZDB
           key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
+      - name: "Copy over TZDB cache"
+        run: |
+          cp -r ${{ github.workspace }}/Build/lagom-tools/TZDB ${{ github.workspace }}/Build/wasm/TZDB
       - name: "UnicodeData cache"
         uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
         with:
-          path: ${{ github.workspace }}/Build/lagom-tools/UCD
+          path: ${{ github.workspace }}/Build/wasm/UCD
           key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
       - name: "UnicodeLocale cache"
         uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
         with:
-          path: ${{ github.workspace }}/Build/lagom-tools/CLDR
+          path: ${{ github.workspace }}/Build/wasm/CLDR
           key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}
       - name: "Build host lagom tools"
         run: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -69,6 +69,7 @@ jobs:
             -S ${{ github.workspace }}/Meta/Lagom \
             -DLagomTools_DIR=${{ github.workspace }}/Build/lagom-tools/share/LagomTools \
             -DBUILD_LAGOM=ON \
+            -DBUILD_SHARED_LIBS=OFF
       - name: "Build libjs.{js,wasm}"
         run: |
           ninja -C ${{ github.workspace }}/Build/wasm libjs.js


### PR DESCRIPTION
Previously we were caching unicode data for the lagom tools, but we
should've been caching them for the actual build instead.