### PR TITLE
LibPDF: initial image rendering support

### DIFF
--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -63,6 +63,8 @@ public:
     void set_page_view_mode(PageViewMode);
     bool show_clipping_paths() const { return m_rendering_preferences.show_clipping_paths; }
     void set_show_clipping_paths(bool);
+    bool show_images() const { return m_rendering_preferences.show_images; }
+    void set_show_images(bool);
 
 protected:
     PDFViewer();

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -180,6 +180,10 @@ void PDFViewerWidget::initialize_toolbar(GUI::Toolbar& toolbar)
     m_show_clipping_paths->set_text("Show clipping paths");
     m_show_clipping_paths->set_checked(m_viewer->show_clipping_paths(), GUI::AllowCallback::No);
     m_show_clipping_paths->on_checked = [&](auto checked) { m_viewer->set_show_clipping_paths(checked); };
+    m_show_images = toolbar.add<GUI::CheckBox>();
+    m_show_images->set_text("Show images");
+    m_show_images->set_checked(m_viewer->show_images(), GUI::AllowCallback::No);
+    m_show_images->on_checked = [&](auto checked) { m_viewer->set_show_images(checked); };
 }
 
 void PDFViewerWidget::open_file(Core::File& file)

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.h
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.h
@@ -47,6 +47,7 @@ private:
     RefPtr<GUI::Action> m_page_view_mode_single;
     RefPtr<GUI::Action> m_page_view_mode_multiple;
     RefPtr<GUI::CheckBox> m_show_clipping_paths;
+    RefPtr<GUI::CheckBox> m_show_images;
 
     bool m_sidebar_open { false };
     ByteBuffer m_buffer;

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -194,6 +194,11 @@ ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::try_create_with_anonymous_buffer(BitmapFo
     return adopt_nonnull_ref_or_enomem(new (nothrow) Bitmap(format, move(buffer), size, scale_factor, palette));
 }
 
+ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::try_create_from_serialized_byte_buffer(ByteBuffer&& buffer)
+{
+    return try_create_from_serialized_bytes(buffer.bytes());
+}
+
 /// Read a bitmap as described by:
 /// - actual size
 /// - width
@@ -203,9 +208,9 @@ ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::try_create_with_anonymous_buffer(BitmapFo
 /// - palette count
 /// - palette data (= palette count * BGRA8888)
 /// - image data (= actual size * u8)
-ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::try_create_from_serialized_byte_buffer(ByteBuffer&& buffer)
+ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::try_create_from_serialized_bytes(ReadonlyBytes bytes)
 {
-    InputMemoryStream stream { buffer };
+    InputMemoryStream stream { bytes };
     size_t actual_size;
     unsigned width;
     unsigned height;

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -98,6 +98,7 @@ public:
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_load_from_file(StringView path, int scale_factor = 1);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_load_from_fd_and_close(int fd, StringView path);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_create_with_anonymous_buffer(BitmapFormat, Core::AnonymousBuffer, IntSize, int intrinsic_scale, Vector<ARGB32> const& palette);
+    static ErrorOr<NonnullRefPtr<Bitmap>> try_create_from_serialized_bytes(ReadonlyBytes);
     static ErrorOr<NonnullRefPtr<Bitmap>> try_create_from_serialized_byte_buffer(ByteBuffer&&);
 
     static bool is_path_a_supported_image_format(StringView path)

--- a/Userland/Libraries/LibPDF/CMakeLists.txt
+++ b/Userland/Libraries/LibPDF/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     Fonts/TrueTypeFont.cpp
     Fonts/Type0Font.cpp
     Fonts/Type1Font.cpp
+    Interpolation.cpp
     ObjectDerivatives.cpp
     Parser.cpp
     Reader.cpp

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -73,6 +73,11 @@ Color DeviceGrayColorSpace::color(Vector<Value> const& arguments) const
     return Color(gray, gray, gray);
 }
 
+Vector<float> DeviceGrayColorSpace::default_decode() const
+{
+    return { 0.0f, 1.0f };
+}
+
 NonnullRefPtr<DeviceRGBColorSpace> DeviceRGBColorSpace::the()
 {
     static auto instance = adopt_ref(*new DeviceRGBColorSpace());
@@ -86,6 +91,11 @@ Color DeviceRGBColorSpace::color(Vector<Value> const& arguments) const
     auto g = static_cast<u8>(arguments[1].to_float() * 255.0f);
     auto b = static_cast<u8>(arguments[2].to_float() * 255.0f);
     return Color(r, g, b);
+}
+
+Vector<float> DeviceRGBColorSpace::default_decode() const
+{
+    return { 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f };
 }
 
 NonnullRefPtr<DeviceCMYKColorSpace> DeviceCMYKColorSpace::the()
@@ -102,6 +112,11 @@ Color DeviceCMYKColorSpace::color(Vector<Value> const& arguments) const
     auto y = arguments[2].to_float();
     auto k = arguments[3].to_float();
     return Color::from_cmyk(c, m, y, k);
+}
+
+Vector<float> DeviceCMYKColorSpace::default_decode() const
+{
+    return { 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f };
 }
 
 PDFErrorOr<NonnullRefPtr<CalRGBColorSpace>> CalRGBColorSpace::create(Document* document, Vector<Value>&& parameters)
@@ -274,6 +289,11 @@ Color CalRGBColorSpace::color(Vector<Value> const& arguments) const
     return Color(red, green, blue);
 }
 
+Vector<float> CalRGBColorSpace::default_decode() const
+{
+    return { 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f };
+}
+
 PDFErrorOr<NonnullRefPtr<ColorSpace>> ICCBasedColorSpace::create(Document* document, Vector<Value>&& parameters)
 {
     if (parameters.is_empty())
@@ -309,6 +329,11 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ICCBasedColorSpace::create(Document* docum
 }
 
 Color ICCBasedColorSpace::color(Vector<Value> const&) const
+{
+    VERIFY_NOT_REACHED();
+}
+
+Vector<float> ICCBasedColorSpace::default_decode() const
 {
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -11,7 +11,23 @@
 
 namespace PDF {
 
-PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(Document* document, FlyString const& name, NonnullRefPtr<DictObject> resources)
+#define ENUMERATE(name, ever_needs_parameters) \
+    ColorSpaceFamily ColorSpaceFamily::name { #name, ever_needs_parameters };
+ENUMERATE_COLOR_SPACE_FAMILIES(ENUMERATE);
+#undef ENUMERATE
+
+PDFErrorOr<ColorSpaceFamily> ColorSpaceFamily::get(FlyString const& family_name)
+{
+#define ENUMERATE(f_name, ever_needs_parameters) \
+    if (family_name == f_name.name()) {          \
+        return ColorSpaceFamily::f_name;         \
+    }
+    ENUMERATE_COLOR_SPACE_FAMILIES(ENUMERATE)
+#undef ENUMERATE
+    return Error(Error::Type::MalformedPDF, DeprecatedString::formatted("Unknown ColorSpace family {}", family_name));
+}
+
+PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(FlyString const& name)
 {
     // Simple color spaces with no parameters, which can be specified directly
     if (name == CommonNames::DeviceGray)
@@ -22,14 +38,11 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(Document* document, Fly
         return DeviceCMYKColorSpace::the();
     if (name == CommonNames::Pattern)
         TODO();
+    VERIFY_NOT_REACHED();
+}
 
-    // The color space is a complex color space with parameters that resides in
-    // the resource dictionary
-    auto color_space_resource_dict = TRY(resources->get_dict(document, CommonNames::ColorSpace));
-    if (!color_space_resource_dict->contains(name))
-        TODO();
-
-    auto color_space_array = TRY(color_space_resource_dict->get_array(document, name));
+PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(Document* document, NonnullRefPtr<ArrayObject> color_space_array)
+{
     auto color_space_name = TRY(color_space_array->get_name_at(document, 0))->name();
 
     Vector<Value> parameters;
@@ -41,7 +54,7 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(Document* document, Fly
         return TRY(CalRGBColorSpace::create(document, move(parameters)));
 
     if (color_space_name == CommonNames::ICCBased)
-        return TRY(ICCBasedColorSpace::create(document, resources, move(parameters)));
+        return TRY(ICCBasedColorSpace::create(document, move(parameters)));
 
     dbgln("Unknown color space: {}", color_space_name);
     TODO();
@@ -261,7 +274,7 @@ Color CalRGBColorSpace::color(Vector<Value> const& arguments) const
     return Color(red, green, blue);
 }
 
-PDFErrorOr<NonnullRefPtr<ColorSpace>> ICCBasedColorSpace::create(Document* document, NonnullRefPtr<DictObject> resources, Vector<Value>&& parameters)
+PDFErrorOr<NonnullRefPtr<ColorSpace>> ICCBasedColorSpace::create(Document* document, Vector<Value>&& parameters)
 {
     if (parameters.is_empty())
         return Error { Error::Type::MalformedPDF, "ICCBased color space expected one parameter" };
@@ -283,11 +296,16 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ICCBasedColorSpace::create(Document* docum
             name = CommonNames::DeviceCMYK;
         else
             VERIFY_NOT_REACHED();
-    } else {
-        name = TRY(dict->get_name(document, CommonNames::Alternate))->name();
+        return ColorSpace::create(name);
     }
 
-    return TRY(ColorSpace::create(document, name, resources));
+    auto alternate_color_space_object = MUST(dict->get_object(document, CommonNames::Alternate));
+    if (alternate_color_space_object->is<NameObject>()) {
+        return ColorSpace::create(alternate_color_space_object->cast<NameObject>()->name());
+    }
+
+    dbgln("Alternate color spaces in array format not supported yet ");
+    TODO();
 }
 
 Color ICCBasedColorSpace::color(Vector<Value> const&) const

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "AK/Forward.h"
 #include <AK/FlyString.h>
 #include <LibGfx/Color.h>
 #include <LibPDF/Value.h>
@@ -54,6 +55,8 @@ public:
     virtual ~ColorSpace() = default;
 
     virtual Color color(Vector<Value> const& arguments) const = 0;
+    virtual int number_of_components() const = 0;
+    virtual Vector<float> default_decode() const = 0;
     virtual ColorSpaceFamily const& family() const = 0;
 };
 
@@ -64,6 +67,8 @@ public:
     ~DeviceGrayColorSpace() override = default;
 
     Color color(Vector<Value> const& arguments) const override;
+    int number_of_components() const override { return 1; }
+    Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceGray; }
 
 private:
@@ -77,6 +82,8 @@ public:
     ~DeviceRGBColorSpace() override = default;
 
     Color color(Vector<Value> const& arguments) const override;
+    int number_of_components() const override { return 3; }
+    Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceRGB; }
 
 private:
@@ -90,6 +97,8 @@ public:
     ~DeviceCMYKColorSpace() override = default;
 
     Color color(Vector<Value> const& arguments) const override;
+    int number_of_components() const override { return 4; }
+    Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceCMYK; }
 
 private:
@@ -103,6 +112,8 @@ public:
     ~CalRGBColorSpace() override = default;
 
     Color color(Vector<Value> const& arguments) const override;
+    int number_of_components() const override { return 3; }
+    Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::CalRGB; }
 
 private:
@@ -121,6 +132,8 @@ public:
     ~ICCBasedColorSpace() override = default;
 
     Color color(Vector<Value> const& arguments) const override;
+    int number_of_components() const override { VERIFY_NOT_REACHED(); }
+    Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::ICCBased; }
 
 private:

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -10,30 +10,51 @@
 #include <LibGfx/Color.h>
 #include <LibPDF/Value.h>
 
-#define ENUMERATE_COLOR_SPACES(V) \
-    V(DeviceGray)                 \
-    V(DeviceRGB)                  \
-    V(DeviceCMYK)                 \
-    V(CalGray)                    \
-    V(CalRGB)                     \
-    V(Lab)                        \
-    V(ICCBased)                   \
-    V(Indexed)                    \
-    V(Pattern)                    \
-    V(Separation)                 \
-    V(DeviceN)
+#define ENUMERATE_COLOR_SPACE_FAMILIES(V) \
+    V(DeviceGray, true)                   \
+    V(DeviceRGB, true)                    \
+    V(DeviceCMYK, true)                   \
+    V(CalGray, false)                     \
+    V(CalRGB, false)                      \
+    V(Lab, false)                         \
+    V(ICCBased, false)                    \
+    V(Indexed, false)                     \
+    V(Pattern, false)                     \
+    V(Separation, false)                  \
+    V(DeviceN, false)
 
 namespace PDF {
 
-struct Page;
+class ColorSpaceFamily {
+public:
+    ColorSpaceFamily(FlyString name, bool never_needs_paramaters_p)
+        : m_name(move(name))
+        , m_never_needs_parameters(never_needs_paramaters_p)
+    {
+    }
+
+    FlyString name() const { return m_name; };
+    bool never_needs_parameters() const { return m_never_needs_parameters; };
+    static PDFErrorOr<ColorSpaceFamily> get(FlyString const&);
+
+#define ENUMERATE(name, ever_needs_parameters) static ColorSpaceFamily name;
+    ENUMERATE_COLOR_SPACE_FAMILIES(ENUMERATE)
+#undef ENUMERATE
+
+private:
+    FlyString m_name;
+    bool m_never_needs_parameters;
+};
 
 class ColorSpace : public RefCounted<ColorSpace> {
 public:
-    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, FlyString const& name, NonnullRefPtr<DictObject> resources);
+    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(FlyString const&);
+    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, NonnullRefPtr<ArrayObject>);
 
     virtual ~ColorSpace() = default;
 
     virtual Color color(Vector<Value> const& arguments) const = 0;
+    virtual ColorSpaceFamily const& family() const = 0;
 };
 
 class DeviceGrayColorSpace final : public ColorSpace {
@@ -43,6 +64,7 @@ public:
     ~DeviceGrayColorSpace() override = default;
 
     Color color(Vector<Value> const& arguments) const override;
+    ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceGray; }
 
 private:
     DeviceGrayColorSpace() = default;
@@ -55,6 +77,7 @@ public:
     ~DeviceRGBColorSpace() override = default;
 
     Color color(Vector<Value> const& arguments) const override;
+    ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceRGB; }
 
 private:
     DeviceRGBColorSpace() = default;
@@ -67,6 +90,7 @@ public:
     ~DeviceCMYKColorSpace() override = default;
 
     Color color(Vector<Value> const& arguments) const override;
+    ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceCMYK; }
 
 private:
     DeviceCMYKColorSpace() = default;
@@ -79,6 +103,7 @@ public:
     ~CalRGBColorSpace() override = default;
 
     Color color(Vector<Value> const& arguments) const override;
+    ColorSpaceFamily const& family() const override { return ColorSpaceFamily::CalRGB; }
 
 private:
     CalRGBColorSpace() = default;
@@ -91,11 +116,12 @@ private:
 
 class ICCBasedColorSpace final : public ColorSpace {
 public:
-    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, NonnullRefPtr<DictObject> resources, Vector<Value>&& parameters);
+    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, Vector<Value>&& parameters);
 
     ~ICCBasedColorSpace() override = default;
 
     Color color(Vector<Value> const& arguments) const override;
+    ColorSpaceFamily const& family() const override { return ColorSpaceFamily::ICCBased; }
 
 private:
     ICCBasedColorSpace() = delete;

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -37,6 +37,7 @@
     A(DW)                         \
     A(DCTDecode)                  \
     A(DecodeParms)                \
+    A(Decode)                     \
     A(DescendantFonts)            \
     A(Dest)                       \
     A(Dests)                      \
@@ -70,11 +71,13 @@
     A(FontFile3)                  \
     A(Gamma)                      \
     A(H)                          \
+    A(Height)                     \
     A(HT)                         \
     A(HTO)                        \
     A(ICCBased)                   \
     A(ID)                         \
     A(Image)                      \
+    A(ImageMask)                  \
     A(Index)                      \
     A(JBIG2Decode)                \
     A(JPXDecode)                  \
@@ -133,6 +136,7 @@
     A(UserUnit)                   \
     A(W)                          \
     A(WhitePoint)                 \
+    A(Width)                      \
     A(Widths)                     \
     A(XObject)                    \
     A(XYZ)                        \

--- a/Userland/Libraries/LibPDF/Error.h
+++ b/Userland/Libraries/LibPDF/Error.h
@@ -16,6 +16,7 @@ public:
         Parse,
         Internal,
         MalformedPDF,
+        RenderingUnsupported
     };
 
     Error(AK::Error error)
@@ -36,6 +37,9 @@ public:
             break;
         case Type::MalformedPDF:
             m_message = DeprecatedString::formatted("Malformed PDF file: {}", message);
+            break;
+        case Type::RenderingUnsupported:
+            m_message = DeprecatedString::formatted("Rendering of feature not supported: {}", message);
             break;
         }
     }

--- a/Userland/Libraries/LibPDF/Interpolation.cpp
+++ b/Userland/Libraries/LibPDF/Interpolation.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Rodrigo Tobar <rtobarc@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibPDF/Interpolation.h>
+
+namespace PDF {
+
+static float slope(float x_min, float x_max, float y_min, float y_max)
+{
+    return (y_max - y_min) / (x_max - x_min);
+}
+
+LinearInterpolation1D::LinearInterpolation1D(float x_min, float x_max, float y_min, float y_max)
+    : m_x_min(x_min)
+    , m_y_min(y_min)
+    , m_slope(slope(x_min, x_max, y_min, y_max))
+{
+}
+
+float LinearInterpolation1D::interpolate(float x) const
+{
+    return m_y_min + ((x - m_x_min) * m_slope);
+}
+
+void LinearInterpolation1D::interpolate(Span<float> const& x, Span<float> y) const
+{
+    for (size_t i = 0; i < x.size(); ++i) {
+        y[i] = interpolate(x[i]);
+    }
+}
+
+}

--- a/Userland/Libraries/LibPDF/Interpolation.h
+++ b/Userland/Libraries/LibPDF/Interpolation.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Rodrigo Tobar <rtobarc@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Span.h>
+#include <AK/Vector.h>
+
+namespace PDF {
+
+class LinearInterpolation1D {
+
+public:
+    LinearInterpolation1D(float x_min, float x_max, float y_min, float y_max);
+    float interpolate(float) const;
+    void interpolate(Span<float> const& x, Span<float> y) const;
+
+private:
+    float m_x_min;
+    float m_y_min;
+    float m_slope;
+};
+
+}

--- a/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
+++ b/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
@@ -50,6 +50,16 @@ DeprecatedString NameObject::to_deprecated_string(int) const
     return builder.to_deprecated_string();
 }
 
+Vector<float> ArrayObject::float_elements() const
+{
+    Vector<float> values;
+    values.ensure_capacity(m_elements.size());
+    for (auto const& value : m_elements) {
+        values.append(value.to_float());
+    }
+    return values;
+}
+
 DeprecatedString ArrayObject::to_deprecated_string(int indent) const
 {
     StringBuilder builder;

--- a/Userland/Libraries/LibPDF/ObjectDerivatives.h
+++ b/Userland/Libraries/LibPDF/ObjectDerivatives.h
@@ -74,6 +74,7 @@ public:
 
     [[nodiscard]] ALWAYS_INLINE size_t size() const { return m_elements.size(); }
     [[nodiscard]] ALWAYS_INLINE Vector<Value> elements() const { return m_elements; }
+    [[nodiscard]] Vector<float> float_elements() const;
 
     ALWAYS_INLINE auto begin() const { return m_elements.begin(); }
     ALWAYS_INLINE auto end() const { return m_elements.end(); }

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -319,8 +319,7 @@ RENDERER_HANDLER(path_fill_nonzero)
 
 RENDERER_HANDLER(path_fill_nonzero_deprecated)
 {
-    TRY(handle_path_fill_nonzero(args));
-    return {};
+    return handle_path_fill_nonzero(args);
 }
 
 RENDERER_HANDLER(path_fill_evenodd)
@@ -334,29 +333,25 @@ RENDERER_HANDLER(path_fill_evenodd)
 RENDERER_HANDLER(path_fill_stroke_nonzero)
 {
     m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_color, state().line_width);
-    TRY(handle_path_fill_nonzero(args));
-    return {};
+    return handle_path_fill_nonzero(args);
 }
 
 RENDERER_HANDLER(path_fill_stroke_evenodd)
 {
     m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_color, state().line_width);
-    TRY(handle_path_fill_evenodd(args));
-    return {};
+    return handle_path_fill_evenodd(args);
 }
 
 RENDERER_HANDLER(path_close_fill_stroke_nonzero)
 {
     m_current_path.close();
-    TRY(handle_path_fill_stroke_nonzero(args));
-    return {};
+    return handle_path_fill_stroke_nonzero(args);
 }
 
 RENDERER_HANDLER(path_close_fill_stroke_evenodd)
 {
     m_current_path.close();
-    TRY(handle_path_fill_stroke_evenodd(args));
-    return {};
+    return handle_path_fill_stroke_evenodd(args);
 }
 
 RENDERER_HANDLER(path_end)

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -86,6 +86,12 @@ struct GraphicsState {
 
 struct RenderingPreferences {
     bool show_clipping_paths { false };
+    bool show_images { true };
+
+    unsigned hash() const
+    {
+        return static_cast<unsigned>(show_clipping_paths) | static_cast<unsigned>(show_images) << 1;
+    }
 };
 
 class Renderer {
@@ -109,6 +115,9 @@ private:
     void end_path_paint();
     PDFErrorOr<void> set_graphics_state_from_dict(NonnullRefPtr<DictObject>);
     void show_text(DeprecatedString const&);
+    PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> load_image(NonnullRefPtr<StreamObject>);
+    PDFErrorOr<void> show_image(NonnullRefPtr<StreamObject>);
+    void show_empty_image(int width, int height);
     PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space_from_resources(Value const&, NonnullRefPtr<DictObject>);
     PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space_from_document(NonnullRefPtr<Object>);
 
@@ -127,6 +136,7 @@ private:
     ALWAYS_INLINE Gfx::Rect<T> map(Gfx::Rect<T>) const;
 
     Gfx::AffineTransform const& calculate_text_rendering_matrix();
+    Gfx::AffineTransform calculate_image_space_transformation(int width, int height);
 
     RefPtr<Document> m_document;
     RefPtr<Gfx::Bitmap> m_bitmap;

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -109,7 +109,8 @@ private:
     void end_path_paint();
     PDFErrorOr<void> set_graphics_state_from_dict(NonnullRefPtr<DictObject>);
     void show_text(DeprecatedString const&);
-    PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space(Value const&, NonnullRefPtr<DictObject>);
+    PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space_from_resources(Value const&, NonnullRefPtr<DictObject>);
+    PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space_from_document(NonnullRefPtr<Object>);
 
     ALWAYS_INLINE GraphicsState const& state() const { return m_graphics_state_stack.last(); }
     ALWAYS_INLINE GraphicsState& state() { return m_graphics_state_stack.last(); }


### PR DESCRIPTION
This is the current set of changes that allow LibPDF to render Images. Not all formats are supported, but seems to be a good start. A rendering preference allows users to toggle whether they want images to be rendered or not (in which case an empty rectangle is shown, useful for images that are not supported yet).

This required a bit of refactoring of the ColorSpace classes, both in terms of the information they provide and how they are created. Some other minor utilities have been added (ArrayObject -> Vector<float> method, linear 1d interpolator, new Error::Type category, Gfx::Bitmap creation from ReadonlyBytes).

Some small examples:
![SPEAD_Protocol_Rev1_2012.pdf_p9_after](https://user-images.githubusercontent.com/620848/204826497-9a546d98-ea1e-473d-9a84-84e856576dc3.png)
![fit11-talk.pdf_p5_after](https://user-images.githubusercontent.com/620848/204826515-f44623a6-2c52-46fb-b478-895a652eb525.png)
