### PR TITLE
Taskbar: Unbreak SDL2 port by changing include path

### DIFF
--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -7,13 +7,13 @@
 #pragma once
 
 #include "ClockWidget.h"
-#include "Taskbar/QuickLaunchWidget.h"
 #include "WindowList.h"
 #include <LibConfig/Listener.h>
 #include <LibDesktop/AppFile.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/ShareableBitmap.h>
+#include <Services/Taskbar/QuickLaunchWidget.h>
 #include <Services/WindowServer/ScreenLayout.h>
 
 class TaskbarWindow final : public GUI::Window


### PR DESCRIPTION
Ports would not be able to find `QuickLaunchWidget.h` this way. This broke as a result of merging #16183