### PR TITLE
AK: Make it possible to not `using` AK classes into the global namespace

### DIFF
--- a/AK/AllOf.h
+++ b/AK/AllOf.h
@@ -32,4 +32,6 @@ template<IterableContainer Container>
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::all_of;
+#endif

--- a/AK/AnyOf.h
+++ b/AK/AnyOf.h
@@ -29,4 +29,6 @@ template<IterableContainer Container>
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::any_of;
+#endif

--- a/AK/ArbitrarySizedEnum.h
+++ b/AK/ArbitrarySizedEnum.h
@@ -123,4 +123,6 @@ struct ArbitrarySizedEnum : public T {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::ArbitrarySizedEnum;
+#endif

--- a/AK/Array.h
+++ b/AK/Array.h
@@ -111,5 +111,7 @@ constexpr static auto iota_array(T const offset = {})
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Array;
 using AK::iota_array;
+#endif

--- a/AK/Atomic.h
+++ b/AK/Atomic.h
@@ -442,5 +442,7 @@ public:
 };
 }
 
+#if USING_AK_GLOBALLY
 using AK::Atomic;
 using AK::full_memory_barrier;
+#endif

--- a/AK/AtomicRefCounted.h
+++ b/AK/AtomicRefCounted.h
@@ -83,5 +83,7 @@ public:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::AtomicRefCounted;
 using AK::AtomicRefCountedBase;
+#endif

--- a/AK/Badge.h
+++ b/AK/Badge.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+
 namespace AK {
 
 template<typename T>
@@ -26,4 +28,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Badge;
+#endif

--- a/AK/Base64.h
+++ b/AK/Base64.h
@@ -22,5 +22,7 @@ namespace AK {
 [[nodiscard]] String encode_base64(ReadonlyBytes);
 }
 
+#if USING_AK_GLOBALLY
 using AK::decode_base64;
 using AK::encode_base64;
+#endif

--- a/AK/BinaryHeap.h
+++ b/AK/BinaryHeap.h
@@ -108,4 +108,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::BinaryHeap;
+#endif

--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -67,4 +67,6 @@ constexpr auto binary_search(
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::binary_search;
+#endif

--- a/AK/BitCast.h
+++ b/AK/BitCast.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+
 namespace AK {
 
 template<typename T, typename U>
@@ -24,4 +26,6 @@ template<typename T, typename U>
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::bit_cast;
+#endif

--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -239,5 +239,7 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::InputBitStream;
 using AK::OutputBitStream;
+#endif

--- a/AK/Bitmap.h
+++ b/AK/Bitmap.h
@@ -191,4 +191,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Bitmap;
+#endif

--- a/AK/BitmapView.h
+++ b/AK/BitmapView.h
@@ -369,4 +369,6 @@ protected:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::BitmapView;
+#endif

--- a/AK/Buffered.h
+++ b/AK/Buffered.h
@@ -194,4 +194,6 @@ private:
 };
 }
 
+#if USING_AK_GLOBALLY
 using AK::Buffered;
+#endif

--- a/AK/BumpAllocator.h
+++ b/AK/BumpAllocator.h
@@ -197,5 +197,7 @@ inline Atomic<FlatPtr> BumpAllocator<use_mmap, size>::s_unused_allocation_cache 
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::BumpAllocator;
 using AK::UniformBumpAllocator;
+#endif

--- a/AK/ByteReader.h
+++ b/AK/ByteReader.h
@@ -55,4 +55,6 @@ struct ByteReader {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::ByteReader;
+#endif

--- a/AK/CharacterTypes.h
+++ b/AK/CharacterTypes.h
@@ -172,6 +172,7 @@ constexpr u32 to_ascii_base36_digit(u32 digit)
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::is_ascii;
 using AK::is_ascii_alpha;
 using AK::is_ascii_alphanumeric;
@@ -199,3 +200,4 @@ using AK::parse_ascii_hex_digit;
 using AK::to_ascii_base36_digit;
 using AK::to_ascii_lowercase;
 using AK::to_ascii_uppercase;
+#endif

--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -452,5 +452,7 @@ constexpr Checked<T> make_checked(T value)
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Checked;
 using AK::make_checked;
+#endif

--- a/AK/CircularDeque.h
+++ b/AK/CircularDeque.h
@@ -41,4 +41,6 @@ public:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::CircularDeque;
+#endif

--- a/AK/CircularDuplexStream.h
+++ b/AK/CircularDuplexStream.h
@@ -120,4 +120,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::CircularDuplexStream;
+#endif

--- a/AK/CircularQueue.h
+++ b/AK/CircularQueue.h
@@ -133,4 +133,6 @@ protected:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::CircularQueue;
+#endif

--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -281,10 +281,12 @@ static constexpr Complex<T> cexp(Complex<T> const& a)
 }
 }
 
+#    if USING_AK_GLOBALLY
 using AK::approx_eq;
 using AK::cexp;
 using AK::Complex;
 using AK::complex_imag_unit;
 using AK::complex_real_unit;
+#    endif
 
 #endif

--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -121,6 +121,7 @@ concept FallibleFunction = requires(Func&& func, Args&&... args) {
 // clang-format on
 }
 
+#if USING_AK_GLOBALLY
 using AK::Concepts::Arithmetic;
 using AK::Concepts::ArrayLike;
 using AK::Concepts::Enum;
@@ -138,3 +139,4 @@ using AK::Concepts::Signed;
 using AK::Concepts::SpecializationOf;
 using AK::Concepts::Unsigned;
 using AK::Concepts::VoidFunction;
+#endif

--- a/AK/DateConstants.h
+++ b/AK/DateConstants.h
@@ -39,9 +39,11 @@ static constexpr Array<StringView, 12> short_month_names = {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::long_day_names;
 using AK::long_month_names;
 using AK::micro_day_names;
 using AK::mini_day_names;
 using AK::short_day_names;
 using AK::short_month_names;
+#endif

--- a/AK/DateTimeLexer.h
+++ b/AK/DateTimeLexer.h
@@ -143,4 +143,6 @@ public:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::DateTimeLexer;
+#endif

--- a/AK/Demangle.h
+++ b/AK/Demangle.h
@@ -26,6 +26,8 @@ inline String demangle(StringView name)
 
 }
 
+#    if USING_AK_GLOBALLY
 using AK::demangle;
+#    endif
 
 #endif

--- a/AK/DisjointChunks.h
+++ b/AK/DisjointChunks.h
@@ -436,5 +436,7 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::DisjointChunks;
 using AK::DisjointSpans;
+#endif

--- a/AK/DistinctNumeric.h
+++ b/AK/DistinctNumeric.h
@@ -344,4 +344,6 @@ struct Traits<AK::DistinctNumeric<T, X, Opts...>> : public GenericTraits<AK::Dis
     static constexpr auto hash(DistinctNumeric<T, X, Opts...> const& d) { return Traits<T>::hash(d.value()); }
 };
 
+#if USING_AK_GLOBALLY
 using AK::DistinctNumeric;
+#endif

--- a/AK/DoublyLinkedList.h
+++ b/AK/DoublyLinkedList.h
@@ -201,4 +201,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::DoublyLinkedList;
+#endif

--- a/AK/Endian.h
+++ b/AK/Endian.h
@@ -145,6 +145,8 @@ requires(HasFormatter<T>) struct Formatter<BigEndian<T>> : Formatter<T> {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::BigEndian;
 using AK::LittleEndian;
 using AK::NetworkOrdered;
+#endif

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -125,5 +125,7 @@ public:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Error;
 using AK::ErrorOr;
+#endif

--- a/AK/FileStream.h
+++ b/AK/FileStream.h
@@ -168,7 +168,9 @@ private:
 
 }
 
+#    if USING_AK_GLOBALLY
 using AK::InputFileStream;
 using AK::OutputFileStream;
+#    endif
 
 #endif

--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -181,4 +181,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::FixedArray;
+#endif

--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -389,4 +389,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::FixedPoint;
+#endif

--- a/AK/FloatingPoint.h
+++ b/AK/FloatingPoint.h
@@ -232,6 +232,7 @@ constexpr float convert_to_native_float(I input) { return float_to_float<SingleF
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::DoubleFloatingPointBits;
 using AK::FloatExtractor;
 using AK::FloatingPointBits;
@@ -242,3 +243,4 @@ using AK::convert_from_native_float;
 using AK::convert_to_native_double;
 using AK::convert_to_native_float;
 using AK::float_to_float;
+#endif

--- a/AK/FloatingPointStringConversions.h
+++ b/AK/FloatingPointStringConversions.h
@@ -80,6 +80,8 @@ FloatingPointParseResults<T> parse_first_hexfloat_until_zero_character(char cons
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::parse_first_floating_point;
 using AK::parse_first_hexfloat_until_zero_character;
 using AK::parse_floating_point_completely;
+#endif

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -101,4 +101,6 @@ struct Traits<FlyString> : public GenericTraits<FlyString> {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::FlyString;
+#endif

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -698,16 +698,17 @@ struct Formatter<ErrorOr<T, ErrorType>> : Formatter<FormatString> {
 
 } // namespace AK
 
-#ifdef KERNEL
+#if USING_AK_GLOBALLY
+#    ifdef KERNEL
 using AK::critical_dmesgln;
 using AK::dmesgln;
-#else
+#    else
 using AK::out;
 using AK::outln;
 
 using AK::warn;
 using AK::warnln;
-#endif
+#    endif
 
 using AK::dbgln;
 
@@ -715,8 +716,10 @@ using AK::CheckedFormatString;
 using AK::FormatIfSupported;
 using AK::FormatString;
 
-#define dbgln_if(flag, fmt, ...)       \
-    do {                               \
-        if constexpr (flag)            \
-            dbgln(fmt, ##__VA_ARGS__); \
-    } while (0)
+#    define dbgln_if(flag, fmt, ...)       \
+        do {                               \
+            if constexpr (flag)            \
+                dbgln(fmt, ##__VA_ARGS__); \
+        } while (0)
+
+#endif

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -146,6 +146,7 @@ class [[nodiscard]] ErrorOr;
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Array;
 using AK::Atomic;
 using AK::Badge;
@@ -199,9 +200,11 @@ using AK::Utf8CodePointIterator;
 using AK::Utf8View;
 using AK::Vector;
 
-#ifdef KERNEL
+#    ifdef KERNEL
 using AK::LockRefPtr;
 using AK::LockRefPtrTraits;
 using AK::NonnullLockRefPtr;
 using AK::NonnullLockRefPtrVector;
+#    endif
+
 #endif

--- a/AK/Function.h
+++ b/AK/Function.h
@@ -265,4 +265,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Function;
+#endif

--- a/AK/FuzzyMatch.h
+++ b/AK/FuzzyMatch.h
@@ -19,5 +19,7 @@ FuzzyMatchResult fuzzy_match(StringView needle, StringView haystack);
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::fuzzy_match;
 using AK::FuzzyMatchResult;
+#endif

--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -239,7 +239,9 @@ constexpr auto is_quote = is_any_of("'\""sv);
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::GenericLexer;
 using AK::is_any_of;
 using AK::is_path_separator;
 using AK::is_quote;
+#endif

--- a/AK/GenericShorthands.h
+++ b/AK/GenericShorthands.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+
 namespace AK {
 
 template<typename T, typename... Ts>
@@ -63,6 +65,7 @@ template<typename T, typename... Ts>
 }
 }
 
+#if USING_AK_GLOBALLY
 using AK::first_is_larger_or_equal_than_all_of;
 using AK::first_is_larger_or_equal_than_one_of;
 using AK::first_is_larger_than_all_of;
@@ -72,3 +75,4 @@ using AK::first_is_smaller_or_equal_than_all_of;
 using AK::first_is_smaller_or_equal_than_one_of;
 using AK::first_is_smaller_than_all_of;
 using AK::first_is_smaller_than_one_of;
+#endif

--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -243,5 +243,7 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::HashMap;
 using AK::OrderedHashMap;
+#endif

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -724,5 +724,8 @@ private:
 };
 }
 
+#if USING_AK_GLOBALLY
+using AK::HashSetResult;
 using AK::HashTable;
 using AK::OrderedHashTable;
+#endif

--- a/AK/Hex.h
+++ b/AK/Hex.h
@@ -39,6 +39,8 @@ String encode_hex(ReadonlyBytes);
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::decode_hex;
 using AK::decode_hex_digit;
 using AK::encode_hex;
+#endif

--- a/AK/IDAllocator.h
+++ b/AK/IDAllocator.h
@@ -43,4 +43,6 @@ private:
 };
 }
 
+#if USING_AK_GLOBALLY
 using AK::IDAllocator;
+#endif

--- a/AK/IPv4Address.h
+++ b/AK/IPv4Address.h
@@ -176,4 +176,6 @@ struct Formatter<IPv4Address> : Formatter<String> {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::IPv4Address;
+#endif

--- a/AK/IPv6Address.h
+++ b/AK/IPv6Address.h
@@ -299,4 +299,6 @@ struct Formatter<IPv6Address> : Formatter<String> {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::IPv6Address;
+#endif

--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -461,5 +461,7 @@ using IntrusiveList = Detail::IntrusiveList<
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::IntrusiveList;
 using AK::IntrusiveListNode;
+#endif

--- a/AK/IntrusiveListRelaxedConst.h
+++ b/AK/IntrusiveListRelaxedConst.h
@@ -35,4 +35,6 @@ using IntrusiveListRelaxedConst = Detail::IntrusiveListRelaxedConst<
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::IntrusiveListRelaxedConst;
+#endif

--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -235,5 +235,7 @@ using IntrusiveRedBlackTree = Detail::IntrusiveRedBlackTree<
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::IntrusiveRedBlackTree;
 using AK::IntrusiveRedBlackTreeNode;
+#endif

--- a/AK/IterationDecision.h
+++ b/AK/IterationDecision.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+
 namespace AK {
 
 enum class IterationDecision {
@@ -15,4 +17,6 @@ enum class IterationDecision {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::IterationDecision;
+#endif

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -114,4 +114,6 @@ inline typename Builder::OutputType JsonArray::serialized() const
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::JsonArray;
+#endif

--- a/AK/JsonArraySerializer.h
+++ b/AK/JsonArraySerializer.h
@@ -225,4 +225,6 @@ struct JsonArraySerializer<void> {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::JsonArraySerializer;
+#endif

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -243,4 +243,6 @@ inline typename Builder::OutputType JsonValue::serialized() const
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::JsonObject;
+#endif

--- a/AK/JsonObjectSerializer.h
+++ b/AK/JsonObjectSerializer.h
@@ -262,4 +262,6 @@ ErrorOr<JsonObjectSerializer<Builder>> JsonArraySerializer<Builder>::add_object(
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::JsonObjectSerializer;
+#endif

--- a/AK/JsonParser.h
+++ b/AK/JsonParser.h
@@ -35,4 +35,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::JsonParser;
+#endif

--- a/AK/JsonPath.h
+++ b/AK/JsonPath.h
@@ -95,5 +95,7 @@ public:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::JsonPath;
 using AK::JsonPathElement;
+#endif

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -290,4 +290,6 @@ struct Formatter<JsonValue> : Formatter<StringView> {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::JsonValue;
+#endif

--- a/AK/LEB128.h
+++ b/AK/LEB128.h
@@ -114,4 +114,6 @@ struct LEB128 {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::LEB128;
+#endif

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -95,4 +95,6 @@ struct Formatter<LexicalPath> : Formatter<StringView> {
 
 };
 
+#if USING_AK_GLOBALLY
 using AK::LexicalPath;
+#endif

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -775,4 +775,6 @@ constexpr T ceil(T num)
 #undef AARCH64_INSTRUCTION
 }
 
+#if USING_AK_GLOBALLY
 using AK::round_to;
+#endif

--- a/AK/Memory.h
+++ b/AK/Memory.h
@@ -76,5 +76,7 @@ inline bool timing_safe_compare(void const* b1, void const* b2, size_t len)
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::secure_zero;
 using AK::timing_safe_compare;
+#endif

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -272,7 +272,9 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::DuplexMemoryStream;
 using AK::InputMemoryStream;
 using AK::InputStream;
 using AK::OutputMemoryStream;
+#endif

--- a/AK/NeverDestroyed.h
+++ b/AK/NeverDestroyed.h
@@ -40,4 +40,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::NeverDestroyed;
+#endif

--- a/AK/NoAllocationGuard.h
+++ b/AK/NoAllocationGuard.h
@@ -63,4 +63,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::NoAllocationGuard;
+#endif

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -185,8 +185,10 @@ struct Formatter<NonnullOwnPtr<T>> : Formatter<const T*> {
 
 }
 
-#if !defined(KERNEL)
+#if USING_AK_GLOBALLY
+#    if !defined(KERNEL)
 using AK::adopt_own;
 using AK::make;
-#endif
+#    endif
 using AK::NonnullOwnPtr;
+#endif

--- a/AK/NonnullOwnPtrVector.h
+++ b/AK/NonnullOwnPtrVector.h
@@ -17,4 +17,6 @@ class NonnullOwnPtrVector : public NonnullPtrVector<NonnullOwnPtr<T>, inline_cap
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::NonnullOwnPtrVector;
+#endif

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -256,6 +256,8 @@ struct Traits<NonnullRefPtr<T>> : public GenericTraits<NonnullRefPtr<T>> {
     static bool equals(NonnullRefPtr<T> const& a, NonnullRefPtr<T> const& b) { return a.ptr() == b.ptr(); }
 };
 
+#if USING_AK_GLOBALLY
 using AK::adopt_ref;
 using AK::make_ref_counted;
 using AK::NonnullRefPtr;
+#endif

--- a/AK/NonnullRefPtrVector.h
+++ b/AK/NonnullRefPtrVector.h
@@ -18,4 +18,6 @@ class NonnullRefPtrVector : public NonnullPtrVector<NonnullRefPtr<T>, inline_cap
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::NonnullRefPtrVector;
+#endif

--- a/AK/NumberFormat.h
+++ b/AK/NumberFormat.h
@@ -83,7 +83,9 @@ static inline String human_readable_digital_time(i64 time_in_seconds)
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::human_readable_digital_time;
 using AK::human_readable_size;
 using AK::human_readable_size_long;
 using AK::human_readable_time;
+#endif

--- a/AK/NumericLimits.h
+++ b/AK/NumericLimits.h
@@ -129,4 +129,6 @@ struct NumericLimits<long double> {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::NumericLimits;
+#endif

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -364,4 +364,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Optional;
+#endif

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -224,7 +224,9 @@ struct Traits<OwnPtr<T>> : public GenericTraits<OwnPtr<T>> {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::adopt_nonnull_own_or_enomem;
 using AK::adopt_own_if_nonnull;
 using AK::OwnPtr;
 using AK::try_make;
+#endif

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -1,11 +1,15 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, Nico Weber <thakis@chromium.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
+
+#ifndef USING_AK_GLOBALLY
+#    define USING_AK_GLOBALLY 1
+#endif
 
 #ifdef __i386__
 #    define AK_ARCH_I386 1

--- a/AK/Ptr32.h
+++ b/AK/Ptr32.h
@@ -56,4 +56,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Ptr32;
+#endif

--- a/AK/Queue.h
+++ b/AK/Queue.h
@@ -83,4 +83,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Queue;
+#endif

--- a/AK/QuickSort.h
+++ b/AK/QuickSort.h
@@ -151,4 +151,6 @@ void quick_sort(Collection& collection)
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::quick_sort;
+#endif

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -55,6 +55,8 @@ u32 get_random_uniform(u32 max_bounds);
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::fill_with_random;
 using AK::get_random;
 using AK::get_random_uniform;
+#endif

--- a/AK/RecursionDecision.h
+++ b/AK/RecursionDecision.h
@@ -16,4 +16,6 @@ enum class RecursionDecision {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::RecursionDecision;
+#endif

--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -587,4 +587,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::RedBlackTree;
+#endif

--- a/AK/RefCountForwarder.h
+++ b/AK/RefCountForwarder.h
@@ -29,4 +29,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::RefCountForwarder;
+#endif

--- a/AK/RefCounted.h
+++ b/AK/RefCounted.h
@@ -72,5 +72,7 @@ public:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::RefCounted;
 using AK::RefCountedBase;
+#endif

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -340,7 +340,9 @@ inline ErrorOr<NonnullRefPtr<T>> adopt_nonnull_ref_or_enomem(T* object)
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::adopt_ref_if_nonnull;
 using AK::RefPtr;
 using AK::static_ptr_cast;
 using AK::try_make_ref_counted;
+#endif

--- a/AK/Result.h
+++ b/AK/Result.h
@@ -118,4 +118,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Result;
+#endif

--- a/AK/ScopeGuard.h
+++ b/AK/ScopeGuard.h
@@ -50,5 +50,7 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::ArmedScopeGuard;
 using AK::ScopeGuard;
+#endif

--- a/AK/ScopeLogger.h
+++ b/AK/ScopeLogger.h
@@ -62,4 +62,6 @@ public:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::ScopeLogger;
+#endif

--- a/AK/ScopedValueRollback.h
+++ b/AK/ScopedValueRollback.h
@@ -34,4 +34,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::ScopedValueRollback;
+#endif

--- a/AK/Singleton.h
+++ b/AK/Singleton.h
@@ -134,4 +134,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Singleton;
+#endif

--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -302,4 +302,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::SinglyLinkedList;
+#endif

--- a/AK/SinglyLinkedListWithCount.h
+++ b/AK/SinglyLinkedListWithCount.h
@@ -139,4 +139,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::SinglyLinkedListWithCount;
+#endif

--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -123,4 +123,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::SourceGenerator;
+#endif

--- a/AK/SourceLocation.h
+++ b/AK/SourceLocation.h
@@ -49,4 +49,6 @@ struct AK::Formatter<AK::SourceLocation> : AK::Formatter<FormatString> {
     }
 };
 
+#if USING_AK_GLOBALLY
 using AK::SourceLocation;
+#endif

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -266,6 +266,8 @@ using Bytes = Span<u8>;
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Bytes;
 using AK::ReadonlyBytes;
 using AK::Span;
+#endif

--- a/AK/Stack.h
+++ b/AK/Stack.h
@@ -74,4 +74,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Stack;
+#endif

--- a/AK/StackInfo.h
+++ b/AK/StackInfo.h
@@ -31,4 +31,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::StackInfo;
+#endif

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -614,6 +614,8 @@ template<typename T, typename... Ts>
 inline constexpr bool IsOneOfIgnoringCV = (IsSameIgnoringCV<T, Ts> || ...);
 
 }
+
+#if USING_AK_GLOBALLY
 using AK::Detail::AddConst;
 using AK::Detail::AddConstToReferencedType;
 using AK::Detail::AddLvalueReference;
@@ -683,3 +685,4 @@ using AK::Detail::RemoveVolatile;
 using AK::Detail::TrueType;
 using AK::Detail::UnderlyingType;
 using AK::Detail::Void;
+#endif

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -178,6 +178,7 @@ __DEFINE_GENERIC_ABS(long double, 0.0L, fabsl);
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::array_size;
 using AK::ceil_div;
 using AK::clamp;
@@ -189,3 +190,4 @@ using AK::mix;
 using AK::RawPtr;
 using AK::swap;
 using AK::to_underlying;
+#endif

--- a/AK/String.h
+++ b/AK/String.h
@@ -335,6 +335,8 @@ InputStream& operator>>(InputStream& stream, String& string);
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::CaseInsensitiveStringTraits;
 using AK::escape_html_entities;
 using AK::String;
+#endif

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -96,4 +96,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::StringBuilder;
+#endif

--- a/AK/StringFloatingPointConversions.h
+++ b/AK/StringFloatingPointConversions.h
@@ -40,4 +40,6 @@ FloatingPointExponentialForm convert_floating_point_to_decimal_exponential_form(
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::convert_floating_point_to_decimal_exponential_form;
+#endif

--- a/AK/StringHash.h
+++ b/AK/StringHash.h
@@ -47,4 +47,6 @@ constexpr u32 case_insensitive_string_hash(char const* characters, size_t length
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::string_hash;
+#endif

--- a/AK/StringImpl.h
+++ b/AK/StringImpl.h
@@ -119,6 +119,8 @@ struct Formatter<StringImpl> : Formatter<StringView> {
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Chomp;
 using AK::NoChomp;
 using AK::StringImpl;
+#endif

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -109,8 +109,10 @@ size_t count(StringView, StringView needle);
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::CaseSensitivity;
 using AK::ReplaceMode;
 using AK::SplitBehavior;
 using AK::TrimMode;
 using AK::TrimWhitespace;
+#endif

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -357,5 +357,7 @@ struct CaseInsensitiveStringViewTraits : public Traits<StringView> {
     return AK::StringView(cstring, length);
 }
 
+#if USING_AK_GLOBALLY
 using AK::CaseInsensitiveStringViewTraits;
 using AK::StringView;
+#endif

--- a/AK/TemporaryChange.h
+++ b/AK/TemporaryChange.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+
 namespace AK {
 
 template<typename T>
@@ -26,4 +28,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::TemporaryChange;
+#endif

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -353,6 +353,7 @@ inline bool operator!=(const T& a, const T& b)
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::day_of_week;
 using AK::day_of_year;
 using AK::days_in_month;
@@ -375,3 +376,4 @@ using AK::operator>;
 using AK::operator>=;
 using AK::operator==;
 using AK::operator!=;
+#endif

--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -76,5 +76,7 @@ requires(Detail::IsPointerOfType<char, T>) struct Traits<T> : public GenericTrai
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::GenericTraits;
 using AK::Traits;
+#endif

--- a/AK/Trie.h
+++ b/AK/Trie.h
@@ -273,4 +273,6 @@ public:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Trie;
+#endif

--- a/AK/Tuple.h
+++ b/AK/Tuple.h
@@ -220,4 +220,6 @@ Tuple(Args... args) -> Tuple<Args...>;
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Tuple;
+#endif

--- a/AK/TypeCasts.h
+++ b/AK/TypeCasts.h
@@ -45,5 +45,7 @@ ALWAYS_INLINE CopyConst<InputType, OutputType>& verify_cast(InputType& input)
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::is;
 using AK::verify_cast;
+#endif

--- a/AK/TypeList.h
+++ b/AK/TypeList.h
@@ -66,8 +66,10 @@ constexpr void for_each_type_zipped(F&& f)
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::for_each_type;
 using AK::for_each_type_zipped;
 using AK::TypeList;
 using AK::TypeListElement;
 using AK::TypeWrapper;
+#endif

--- a/AK/URLParser.h
+++ b/AK/URLParser.h
@@ -65,4 +65,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::URLParser;
+#endif

--- a/AK/UUID.h
+++ b/AK/UUID.h
@@ -49,4 +49,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::UUID;
+#endif

--- a/AK/Userspace.h
+++ b/AK/Userspace.h
@@ -74,5 +74,7 @@ inline Userspace<T> static_ptr_cast(Userspace<U> const& ptr)
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::static_ptr_cast;
 using AK::Userspace;
+#endif

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -125,4 +125,6 @@ struct AK::Formatter<AK::Utf16View> : Formatter<FormatString> {
     }
 };
 
+#if USING_AK_GLOBALLY
 using AK::Utf16View;
+#endif

--- a/AK/Utf32View.h
+++ b/AK/Utf32View.h
@@ -121,4 +121,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Utf32View;
+#endif

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -132,5 +132,7 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Utf8CodePointIterator;
 using AK::Utf8View;
+#endif

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -491,5 +491,7 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Empty;
 using AK::Variant;
+#endif

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -828,4 +828,6 @@ Vector(Args... args) -> Vector<CommonType<Args...>>;
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Vector;
+#endif

--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -178,4 +178,6 @@ WeakPtr<T> make_weak_ptr_if_nonnull(T const* ptr)
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::WeakPtr;
+#endif

--- a/AK/Weakable.h
+++ b/AK/Weakable.h
@@ -87,4 +87,6 @@ private:
 
 }
 
+#if USING_AK_GLOBALLY
 using AK::Weakable;
+#endif


### PR DESCRIPTION
This patch adds the `USING_AK_GLOBALLY` macro which is enabled by default, but can be overridden by build flags.

This is a step towards integrating Jakt and AK types.