### PR TITLE
Browser: Remove previous history entry in History::replace_current()

### DIFF
--- a/Userland/Applications/Browser/History.cpp
+++ b/Userland/Applications/Browser/History.cpp
@@ -35,6 +35,7 @@ void History::replace_current(const URL& url, String const& title)
     if (m_current == -1)
         return;
 
+    m_items.remove(m_current);
     m_current--;
     push(url, title);
 }


### PR DESCRIPTION
The lack of this action caused a bug in my original patch (https://github.com/SerenityOS/serenity/pull/16004) that appeared when accessing a site that redirected the client and it was the first site the client loaded .