### PR TITLE
LibJS+AK: More work to reduce memory usage on twitter dot com

### DIFF
--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -729,6 +729,18 @@ public:
         MUST(try_resize_and_keep_capacity(new_size));
     }
 
+    void shrink_to_fit()
+    {
+        if (size() == capacity())
+            return;
+        Vector new_vector;
+        new_vector.ensure_capacity(size());
+        for (auto& element : *this) {
+            new_vector.unchecked_append(move(element));
+        }
+        *this = move(new_vector);
+    }
+
     using ConstIterator = SimpleIterator<Vector const, VisibleType const>;
     using Iterator = SimpleIterator<Vector, VisibleType>;
     using ReverseIterator = SimpleReverseIterator<Vector, VisibleType>;

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -62,8 +62,8 @@ private:
 };
 
 ASTNode::ASTNode(SourceRange source_range)
-    : m_source_code(source_range.code)
-    , m_start_offset(source_range.start.offset)
+    : m_start_offset(source_range.start.offset)
+    , m_source_code(source_range.code)
     , m_end_offset(source_range.end.offset)
 {
 }

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -43,7 +43,7 @@ template<class T, class... Args>
 static inline NonnullRefPtr<T>
 create_ast_node(SourceRange range, Args&&... args)
 {
-    return adopt_ref(*new T(range, forward<Args>(args)...));
+    return adopt_ref(*new T(move(range), forward<Args>(args)...));
 }
 
 class ASTNode : public RefCounted<ASTNode> {

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -280,6 +280,14 @@ public:
         m_children.append(move(child));
     }
 
+    void shrink_to_fit()
+    {
+        m_children.shrink_to_fit();
+        m_lexical_declarations.shrink_to_fit();
+        m_var_declarations.shrink_to_fit();
+        m_functions_hoistable_with_annexB_extension.shrink_to_fit();
+    }
+
     NonnullRefPtrVector<Statement> const& children() const { return m_children; }
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1782,9 +1782,9 @@ class MemberExpression final : public Expression {
 public:
     MemberExpression(SourceRange source_range, NonnullRefPtr<Expression> object, NonnullRefPtr<Expression> property, bool computed = false)
         : Expression(source_range)
+        , m_computed(computed)
         , m_object(move(object))
         , m_property(move(property))
-        , m_computed(computed)
     {
     }
 
@@ -1804,9 +1804,9 @@ public:
 private:
     virtual bool is_member_expression() const override { return true; }
 
+    bool m_computed { false };
     NonnullRefPtr<Expression> m_object;
     NonnullRefPtr<Expression> m_property;
-    bool m_computed { false };
 };
 
 class OptionalChain final : public Expression {

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -90,8 +90,10 @@ protected:
     explicit ASTNode(SourceRange);
 
 private:
-    RefPtr<SourceCode> m_source_code;
+    // NOTE: These members are carefully ordered so that `m_start_offset` is packed with the padding after RefCounted::m_ref_count.
+    //       This creates a 4-byte padding hole after `m_end_offset` which is used to pack subclasses better.
     u32 m_start_offset { 0 };
+    RefPtr<SourceCode> m_source_code;
     u32 m_end_offset { 0 };
 };
 

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -678,10 +678,10 @@ private:
     Vector<FunctionParameter> const m_parameters;
     const i32 m_function_length;
     FunctionKind m_kind;
-    bool m_is_strict_mode { false };
-    bool m_might_need_arguments_object { false };
-    bool m_contains_direct_call_to_eval { false };
-    bool m_is_arrow_function { false };
+    bool m_is_strict_mode : 1 { false };
+    bool m_might_need_arguments_object : 1 { false };
+    bool m_contains_direct_call_to_eval : 1 { false };
+    bool m_is_arrow_function : 1 { false };
 };
 
 class FunctionDeclaration final

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1713,7 +1713,7 @@ private:
 
 class ObjectProperty final : public ASTNode {
 public:
-    enum class Type {
+    enum class Type : u8 {
         KeyValue,
         Getter,
         Setter,
@@ -1723,10 +1723,10 @@ public:
 
     ObjectProperty(SourceRange source_range, NonnullRefPtr<Expression> key, RefPtr<Expression> value, Type property_type, bool is_method)
         : ASTNode(source_range)
-        , m_key(move(key))
-        , m_value(move(value))
         , m_property_type(property_type)
         , m_is_method(is_method)
+        , m_key(move(key))
+        , m_value(move(value))
     {
     }
 
@@ -1744,10 +1744,10 @@ public:
     virtual Completion execute(Interpreter&) const override;
 
 private:
-    NonnullRefPtr<Expression> m_key;
-    RefPtr<Expression> m_value;
     Type m_property_type;
     bool m_is_method { false };
+    NonnullRefPtr<Expression> m_key;
+    RefPtr<Expression> m_value;
 };
 
 class ObjectExpression final : public Expression {

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1551,7 +1551,7 @@ Bytecode::CodeGenerationErrorOr<void> CallExpression::generate_bytecode(Bytecode
         generator.emit<Bytecode::Op::Store>(callee_reg);
     }
 
-    TRY(arguments_to_array_for_call(generator, m_arguments));
+    TRY(arguments_to_array_for_call(generator, arguments()));
 
     Bytecode::Op::Call::CallType call_type;
     if (is<NewExpression>(*this)) {

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1807,6 +1807,7 @@ NonnullRefPtr<ObjectExpression> Parser::parse_object_expression()
         m_state.invalid_property_range_in_object_expression.set(object_expression_offset, invalid_object_literal_property_range->start);
     }
 
+    properties.shrink_to_fit();
     return create_ast_node<ObjectExpression>(
         { m_source_code, rule_start.position(), position() },
         move(properties));
@@ -1835,6 +1836,8 @@ NonnullRefPtr<ArrayExpression> Parser::parse_array_expression()
     }
 
     consume(TokenType::BracketClose);
+
+    elements.shrink_to_fit();
     return create_ast_node<ArrayExpression>({ m_source_code, rule_start.position(), position() }, move(elements));
 }
 
@@ -2022,6 +2025,7 @@ NonnullRefPtr<Expression> Parser::parse_expression(int min_precedence, Associati
             consume();
             expressions.append(parse_expression(2));
         }
+        expressions.shrink_to_fit();
         expression = create_ast_node<SequenceExpression>({ m_source_code, rule_start.position(), position() }, move(expressions));
     }
     return expression;
@@ -2461,6 +2465,8 @@ void Parser::parse_statement_list(ScopeNode& output_node, AllowLabelledFunction 
             break;
         }
     }
+
+    output_node.shrink_to_fit();
 }
 
 // FunctionBody, https://tc39.es/ecma262/#prod-FunctionBody
@@ -2729,6 +2735,8 @@ Vector<FunctionParameter> Parser::parse_formal_parameters(int& function_length, 
     // Otherwise, we need a closing parenthesis (which is consumed elsewhere). If we get neither, it's an error.
     if (!match(TokenType::Eof) && !match(TokenType::ParenClose))
         expected(Token::name(TokenType::ParenClose));
+
+    parameters.shrink_to_fit();
     return parameters;
 }
 
@@ -3032,6 +3040,8 @@ NonnullRefPtr<VariableDeclaration> Parser::parse_variable_declaration(bool for_l
     }
     if (!for_loop_variable_declaration)
         consume_or_insert_semicolon();
+
+    declarations.shrink_to_fit();
 
     auto declaration = create_ast_node<VariableDeclaration>({ m_source_code, rule_start.position(), position() }, declaration_kind, move(declarations));
     return declaration;

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -2350,7 +2350,7 @@ NonnullRefPtr<Expression> Parser::parse_call_expression(NonnullRefPtr<Expression
     if (is<SuperExpression>(*lhs))
         return create_ast_node<SuperCall>({ m_source_code, rule_start.position(), position() }, move(arguments));
 
-    return create_ast_node<CallExpression>({ m_source_code, rule_start.position(), position() }, move(lhs), move(arguments));
+    return CallExpression::create({ m_source_code, rule_start.position(), position() }, move(lhs), arguments.span());
 }
 
 NonnullRefPtr<NewExpression> Parser::parse_new_expression()
@@ -2380,7 +2380,7 @@ NonnullRefPtr<NewExpression> Parser::parse_new_expression()
         consume(TokenType::ParenClose);
     }
 
-    return create_ast_node<NewExpression>({ m_source_code, rule_start.position(), position() }, move(callee), move(arguments));
+    return NewExpression::create({ m_source_code, rule_start.position(), position() }, move(callee), move(arguments));
 }
 
 NonnullRefPtr<YieldExpression> Parser::parse_yield_expression()

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -231,4 +231,9 @@ void DeclarativeEnvironment::initialize_or_set_mutable_binding(Badge<ScopeNode>,
     MUST(initialize_or_set_mutable_binding(vm, name, value));
 }
 
+void DeclarativeEnvironment::shrink_to_fit()
+{
+    m_bindings.shrink_to_fit();
+}
+
 }

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -57,6 +57,8 @@ public:
     ThrowCompletionOr<void> set_mutable_binding_direct(VM&, size_t index, Value, bool strict);
     ThrowCompletionOr<Value> get_binding_value_direct(VM&, size_t index, bool strict);
 
+    void shrink_to_fit();
+
 private:
     ThrowCompletionOr<void> initialize_binding_direct(VM&, Binding&, Value);
     ThrowCompletionOr<Value> get_binding_value_direct(VM&, Binding&, bool strict);

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -577,6 +577,11 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
         MUST(var_environment->set_mutable_binding(vm, declaration.name(), function, false));
     }
 
+    if (is<DeclarativeEnvironment>(*lex_environment))
+        static_cast<DeclarativeEnvironment*>(lex_environment)->shrink_to_fit();
+    if (is<DeclarativeEnvironment>(*var_environment))
+        static_cast<DeclarativeEnvironment*>(var_environment)->shrink_to_fit();
+
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionKind.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionKind.h
@@ -8,7 +8,7 @@
 
 namespace JS {
 
-enum class FunctionKind {
+enum class FunctionKind : u8 {
     Normal,
     Generator,
     Async,


### PR DESCRIPTION
Here's a collection of patches that together reduce the memory footprint on https://twitter.com/awesomekling by 26.7 MiB (roughly 11% of total size.)

Most of them are about improving struct packing in the AST. There's also a new `Vector::shrink_to_fit()` API which shrinks the vector so that `size() == capacity()` and no extra capacity is wasted. This is useful for vectors that will not see any more appends, like those in the AST once parsing is finished.