### PR TITLE
LibJS: Remove some parser state from the AST

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1119,10 +1119,9 @@ private:
 
 class StringLiteral final : public Literal {
 public:
-    explicit StringLiteral(SourceRange source_range, String value, bool is_use_strict_directive = false)
+    explicit StringLiteral(SourceRange source_range, String value)
         : Literal(source_range)
         , m_value(move(value))
-        , m_is_use_strict_directive(is_use_strict_directive)
     {
     }
 
@@ -1131,13 +1130,11 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     StringView value() const { return m_value; }
-    bool is_use_strict_directive() const { return m_is_use_strict_directive; };
 
 private:
     virtual bool is_string_literal() const override { return true; }
 
     String m_value;
-    bool m_is_use_strict_directive;
 };
 
 class NullLiteral final : public Literal {

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1691,10 +1691,9 @@ private:
 
 class ObjectExpression final : public Expression {
 public:
-    explicit ObjectExpression(SourceRange source_range, NonnullRefPtrVector<ObjectProperty> properties = {}, Optional<SourceRange> first_invalid_property_range = {})
+    explicit ObjectExpression(SourceRange source_range, NonnullRefPtrVector<ObjectProperty> properties = {})
         : Expression(source_range)
         , m_properties(move(properties))
-        , m_first_invalid_property_range(move(first_invalid_property_range))
     {
     }
 
@@ -1702,13 +1701,10 @@ public:
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
-    Optional<SourceRange> const& invalid_property_range() const { return m_first_invalid_property_range; }
-
 private:
     virtual bool is_object_expression() const override { return true; }
 
     NonnullRefPtrVector<ObjectProperty> m_properties;
-    Optional<SourceRange> m_first_invalid_property_range;
 };
 
 class ArrayExpression final : public Expression {

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -462,6 +462,7 @@ bool Parser::parse_directive(ScopeNode& body)
 {
     bool found_use_strict = false;
     while (!done() && match(TokenType::StringLiteral)) {
+        auto raw_value = m_state.current_token.original_value();
         // It cannot be a labelled function since we hit a string literal.
         auto statement = parse_statement(AllowLabelledFunction::No);
         body.append(statement);
@@ -472,8 +473,7 @@ bool Parser::parse_directive(ScopeNode& body)
         if (!is<StringLiteral>(expression))
             break;
 
-        auto& string_literal = static_cast<StringLiteral const&>(expression);
-        if (string_literal.is_use_strict_directive()) {
+        if (raw_value.is_one_of("'use strict'"sv, "\"use strict\"")) {
             found_use_strict = true;
 
             if (m_state.string_legacy_octal_escape_sequence_in_scope)
@@ -1865,9 +1865,7 @@ NonnullRefPtr<StringLiteral> Parser::parse_string_literal(Token const& token, St
         }
     }
 
-    auto is_use_strict_directive = string_literal_type == StringLiteralType::Normal && (token.value() == "'use strict'" || token.value() == "\"use strict\"");
-
-    return create_ast_node<StringLiteral>({ m_source_code, rule_start.position(), position() }, string, is_use_strict_directive);
+    return create_ast_node<StringLiteral>({ m_source_code, rule_start.position(), position() }, string);
 }
 
 NonnullRefPtr<TemplateLiteral> Parser::parse_template_literal(bool is_tagged)

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -282,6 +282,7 @@ private:
         ScopePusher* current_scope_pusher { nullptr };
 
         HashMap<StringView, Optional<Position>> labels_in_scope;
+        HashMap<size_t, Position> invalid_property_range_in_object_expression;
         HashTable<StringView>* referenced_private_names { nullptr };
 
         bool strict_mode { false };


### PR DESCRIPTION
I was actually already working on removing the string directive one, but the second fix is way better.

In total this saves ~4 MiB (this PR alone) on twitter, I don't get quite as stable results for some reason.

This will conflict with #16215, but feel free to merge that one first!