### PR TITLE
LibVideo: Don't crash when a decoder error is encountered while seeking

### DIFF
--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -106,6 +106,11 @@ Time PlaybackManager::duration()
 
 void PlaybackManager::on_decoder_error(DecoderError error)
 {
+    // If we don't switch to playing/paused before stopping/becoming corrupted, the player will crash
+    // due to the invalid playback time.
+    if (is_seeking())
+        end_seek();
+
     switch (error.category()) {
     case DecoderErrorCategory::EndOfStream:
         dbgln_if(PLAYBACK_MANAGER_DEBUG, "{}", error.string_literal());


### PR DESCRIPTION
When errors are encountered by PlaybackManager, it attempts to switch states to either Stopped or Corrupted. However, that causes it to set the last presentation media time to the current playback time while the last presentation time is unexpectedly negative because the seek never ended.

Ending the seek before the state changes to Stopped or Corrupted prevents this situation from happening.