### PR TITLE
AK: Add a new facility called TaggedPtr

### DIFF
--- a/AK/TaggedPtr.h
+++ b/AK/TaggedPtr.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022, Jun Zhang <jun@junz.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/IntegralMath.h>
+#include <AK/Platform.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+template<typename PtrType, unsigned Bits, typename TagType = unsigned>
+class TaggedPtr {
+public:
+    static constexpr auto available_low_bits = log2(alignof(PtrType));
+    static constexpr auto bit_mask = ~(uintptr_t)(((intptr_t)1 << available_low_bits) - 1);
+    static constexpr auto tag_mask = (uintptr_t)(((intptr_t)1 << Bits) - 1);
+
+    constexpr TaggedPtr() = default;
+
+    explicit TaggedPtr(PtrType ptr_value) { value = ptr_value; }
+
+    TaggedPtr(PtrType ptr_value, TagType tag_value)
+    {
+        set_ptr(ptr_value);
+        set_tag(tag_value);
+    }
+
+    PtrType ptr() { return (PtrType)(value & bit_mask); }
+
+    TagType tag() { return (TagType)(value & tag_mask); }
+
+    void set_ptr(PtrType ptr_value)
+    {
+        intptr_t ptr = (intptr_t)ptr_value;
+        assert((ptr & ~bit_mask) == 0 && "Pointer is not sufficiently aligned");
+        value = ptr | (value & ~bit_mask);
+    }
+
+    void set_tag(TagType tag_value)
+    {
+        intptr_t tag = static_cast<intptr_t>(tag_value);
+        assert((tag & ~tag_mask) == 0 && "Integer too large for field");
+        value |= tag;
+    }
+
+    bool operator<(TaggedPtr const& rhs) const { return value < rhs.value; }
+
+    bool operator>(TaggedPtr const& rhs) const { return value > rhs.value; }
+
+    bool operator==(TaggedPtr const& rhs) const
+    {
+        return value == rhs.value;
+    }
+
+    bool operator!=(TaggedPtr const& rhs) const
+    {
+        return value != rhs.value;
+    }
+
+    bool operator<=(TaggedPtr const& rhs) const
+    {
+        return value <= rhs.value;
+    }
+
+    bool operator>=(TaggedPtr const& rhs) const
+    {
+        return value >= rhs.value;
+    }
+
+private:
+    intptr_t value = 0;
+};
+
+}
+
+#if USING_AK_GLOBALLY
+using AK::TaggedPtr;
+#endif

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -65,6 +65,7 @@ set(AK_TEST_SOURCES
     TestStringFloatingPointConversions.cpp
     TestStringUtils.cpp
     TestStringView.cpp
+    TestTaggedPtr.cpp
     TestTime.cpp
     TestTrie.cpp
     TestTuple.cpp

--- a/Tests/AK/TestTaggedPtr.cpp
+++ b/Tests/AK/TestTaggedPtr.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "LibTest/Macros.h"
+#include <AK/TaggedPtr.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(empty_tagged_ptr)
+{
+    TaggedPtr<unsigned, 1> tagged_ptr;
+    EXPECT_EQ(tagged_ptr.ptr(), 0u);
+    EXPECT_EQ(tagged_ptr.tag(), 0u);
+}
+
+TEST_CASE(happy_path_tagged_ptr)
+{
+    int ptr_value = 42;
+    TaggedPtr<int*, 1> tagged_ptr;
+    tagged_ptr.set_ptr(&ptr_value);
+    tagged_ptr.set_tag(1);
+    EXPECT_EQ(tagged_ptr.ptr(), &ptr_value);
+    EXPECT_EQ(tagged_ptr.tag(), 1u);
+}
+
+TEST_CASE(enum_tagged_ptr)
+{
+    int ptr_value = 42;
+    enum class Tag {
+        value1,
+        value2,
+    };
+    TaggedPtr<int*, 2, Tag> tagged_ptr;
+    tagged_ptr.set_ptr(&ptr_value);
+    tagged_ptr.set_tag(Tag::value1);
+    EXPECT_EQ(tagged_ptr.ptr(), &ptr_value);
+    EXPECT_EQ(tagged_ptr.tag(), Tag::value1);
+}


### PR DESCRIPTION
TaggedPtr is a pointer with additional data associated with it, which is commonly used when we want to save some memory.

This implementation uses LLVM's `PointerIntPair` as a reference and with some simplification.