### PR TITLE
AK: Export Details and Concepts into the AK namespace (if not using `USING_AK_GLOBALLY`)

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -121,7 +121,9 @@ concept FallibleFunction = requires(Func&& func, Args&&... args) {
 // clang-format on
 }
 
-#if USING_AK_GLOBALLY
+#if !USING_AK_GLOBALLY
+namespace AK {
+#endif
 using AK::Concepts::Arithmetic;
 using AK::Concepts::ArrayLike;
 using AK::Concepts::Enum;
@@ -139,4 +141,6 @@ using AK::Concepts::Signed;
 using AK::Concepts::SpecializationOf;
 using AK::Concepts::Unsigned;
 using AK::Concepts::VoidFunction;
+#if !USING_AK_GLOBALLY
+}
 #endif

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -615,7 +615,9 @@ inline constexpr bool IsOneOfIgnoringCV = (IsSameIgnoringCV<T, Ts> || ...);
 
 }
 
-#if USING_AK_GLOBALLY
+#if !USING_AK_GLOBALLY
+namespace AK {
+#endif
 using AK::Detail::AddConst;
 using AK::Detail::AddConstToReferencedType;
 using AK::Detail::AddLvalueReference;
@@ -685,4 +687,6 @@ using AK::Detail::RemoveVolatile;
 using AK::Detail::TrueType;
 using AK::Detail::UnderlyingType;
 using AK::Detail::Void;
+#if !USING_AK_GLOBALLY
+}
 #endif

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -17,13 +17,13 @@
 #include <AK/Assertions.h>
 
 template<typename T, typename U>
-constexpr auto round_up_to_power_of_two(T value, U power_of_two) requires(IsIntegral<T>&& IsIntegral<U>)
+constexpr auto round_up_to_power_of_two(T value, U power_of_two) requires(AK::Detail::IsIntegral<T>&& AK::Detail::IsIntegral<U>)
 {
     return ((value - 1) & ~(power_of_two - 1)) + power_of_two;
 }
 
 template<typename T>
-constexpr bool is_power_of_two(T value) requires(IsIntegral<T>)
+constexpr bool is_power_of_two(T value) requires(AK::Detail::IsIntegral<T>)
 {
     return value && !((value) & (value - 1));
 }

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -72,7 +72,7 @@ using mode_t = unsigned short;
 #    endif
 #endif
 
-using FlatPtr = Conditional<sizeof(void*) == 8, u64, u32>;
+using FlatPtr = AK::Detail::Conditional<sizeof(void*) == 8, u64, u32>;
 
 constexpr u64 KiB = 1024;
 constexpr u64 MiB = KiB * KiB;

--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -40,14 +40,14 @@ inline size_t malloc_good_size(size_t size) { return size; }
 
 using std::nothrow;
 
-inline void* kmalloc_array(Checked<size_t> a, Checked<size_t> b)
+inline void* kmalloc_array(AK::Checked<size_t> a, AK::Checked<size_t> b)
 {
     auto size = a * b;
     VERIFY(!size.has_overflow());
     return kmalloc(size.value());
 }
 
-inline void* kmalloc_array(Checked<size_t> a, Checked<size_t> b, Checked<size_t> c)
+inline void* kmalloc_array(AK::Checked<size_t> a, AK::Checked<size_t> b, AK::Checked<size_t> c)
 {
     auto size = a * b * c;
     VERIFY(!size.has_overflow());


### PR DESCRIPTION
AK internals like to use concepts and details without a fully qualified name, which usually works just fine because we make everything AK-related available to the unqualified namespace.

However, this breaks as soon as we start not using `USING_AK_GLOBALLY`, due to those identifiers no longer being made available. Instead, we now just export those into the `AK` namespace instead.

I'm not sure if this is a good solution, but it seemed to be better than just fully-qualifying basically every usage of concepts and details inside AK. I also don't know what the best way of finding all problematic places would be, this is just what I found by importing a few data structure headers and trying to use them.