### PR TITLE
LibC+LibELF: Add stack guard hardening

### DIFF
--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -65,8 +65,8 @@ extern ctor_func_t start_ctors[];
 extern ctor_func_t end_ctors[];
 
 // FIXME: Share this with the Intel Prekernel.
-extern size_t __stack_chk_guard;
-size_t __stack_chk_guard;
+extern uintptr_t __stack_chk_guard;
+uintptr_t __stack_chk_guard;
 
 READONLY_AFTER_INIT bool g_in_early_boot;
 

--- a/Kernel/Arch/x86/init.cpp
+++ b/Kernel/Arch/x86/init.cpp
@@ -68,8 +68,8 @@ extern ctor_func_t end_heap_ctors[];
 extern ctor_func_t start_ctors[];
 extern ctor_func_t end_ctors[];
 
-extern size_t __stack_chk_guard;
-READONLY_AFTER_INIT size_t __stack_chk_guard __attribute__((used));
+extern uintptr_t __stack_chk_guard;
+READONLY_AFTER_INIT uintptr_t __stack_chk_guard __attribute__((used));
 
 extern "C" u8 start_of_safemem_text[];
 extern "C" u8 end_of_safemem_text[];
@@ -234,7 +234,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
     // Initialize TimeManagement before using randomness!
     TimeManagement::initialize(0);
 
-    __stack_chk_guard = get_fast_random<size_t>();
+    __stack_chk_guard = get_fast_random<uintptr_t>();
 
     ProcFSComponentRegistry::initialize();
     JailManagement::the();

--- a/Kernel/Prekernel/init.cpp
+++ b/Kernel/Prekernel/init.cpp
@@ -20,8 +20,8 @@
 #endif
 
 // Defined in the linker script
-extern size_t __stack_chk_guard;
-size_t __stack_chk_guard __attribute__((used));
+extern uintptr_t __stack_chk_guard;
+uintptr_t __stack_chk_guard __attribute__((used));
 extern "C" [[noreturn]] void __stack_chk_fail();
 
 extern "C" u8 start_of_prekernel_image[];

--- a/Userland/Libraries/LibC/crt0.cpp
+++ b/Userland/Libraries/LibC/crt0.cpp
@@ -14,7 +14,7 @@
 #ifndef _DYNAMIC_LOADER
 extern "C" {
 
-extern size_t __stack_chk_guard;
+extern uintptr_t __stack_chk_guard;
 extern bool s_global_initializers_ran;
 
 int main(int, char**, char**);

--- a/Userland/Libraries/LibC/ssp.cpp
+++ b/Userland/Libraries/LibC/ssp.cpp
@@ -17,8 +17,8 @@
 
 extern "C" {
 
-extern size_t __stack_chk_guard;
-__attribute__((used)) size_t __stack_chk_guard = (size_t)0xc6c7c8c9;
+extern uintptr_t __stack_chk_guard;
+__attribute__((used)) uintptr_t __stack_chk_guard = (uintptr_t)0xc6c7c8c9;
 
 __attribute__((noreturn)) void __stack_chk_fail()
 {

--- a/Userland/Libraries/LibC/ssp.cpp
+++ b/Userland/Libraries/LibC/ssp.cpp
@@ -18,6 +18,7 @@
 extern "C" {
 
 extern uintptr_t __stack_chk_guard;
+// Initialized in `initialize_libc` (we leave a placeholder value here before initialization).
 __attribute__((used)) uintptr_t __stack_chk_guard = (uintptr_t)0xc6c7c8c9;
 
 __attribute__((noreturn)) void __stack_chk_fail()

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -258,7 +258,7 @@ static void initialize_libc(DynamicObject& libc)
     // This is not done in __libc_init, as we definitely have to return from that, and it might affect Loader as well.
     res = libc.lookup_symbol("__stack_chk_guard"sv);
     VERIFY(res.has_value());
-    arc4random_buf(res.value().address.as_ptr(), sizeof(size_t));
+    arc4random_buf(res.value().address.as_ptr(), sizeof(uintptr_t));
 
     res = libc.lookup_symbol("__environ_is_malloced"sv);
     VERIFY(res.has_value());


### PR DESCRIPTION
Employ the same hardening that glibc and the Linux kernel use for generating stack guards: zero the first byte of the guard such that if C-style string functions read out of bounds on the stack, we do not overwrite or potentially leak the stack guard.

You can see various implementations here:
* Linux: https://elixir.bootlin.com/linux/latest/source/include/linux/random.h#L57
* glibc: https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/dl-osinfo.h#l39
  * For some reason they removed the explanation from the source code...
* musl: https://git.musl-libc.org/cgit/musl/tree/src/env/__stack_chk_fail.c#n18
  * This does something different from Linux and glibc, it puts the null byte in the 2nd byte, supposedly to defend against off-by-one errors. We could do this instead.
