### PR TITLE
Kernel+LibC: Some improvements to posix_fallocate()

### DIFF
--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -115,6 +115,8 @@ public:
     virtual bool is_socket() const { return false; }
     virtual bool is_inode_watcher() const { return false; }
 
+    virtual bool is_regular_file() const { return false; }
+
     virtual FileBlockerSet& blocker_set() { return m_blocker_set; }
 
     size_t attach_count() const { return m_attach_count; }

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -120,4 +120,9 @@ ErrorOr<void> InodeFile::chmod(Credentials const& credentials, OpenFileDescripti
     return VirtualFileSystem::the().chmod(credentials, *description.custody(), mode);
 }
 
+bool InodeFile::is_regular_file() const
+{
+    return inode().metadata().is_regular_file();
+}
+
 }

--- a/Kernel/FileSystem/InodeFile.h
+++ b/Kernel/FileSystem/InodeFile.h
@@ -49,6 +49,8 @@ public:
     virtual bool is_inode() const override { return true; }
 
 private:
+    virtual bool is_regular_file() const override;
+
     explicit InodeFile(NonnullLockRefPtr<Inode>&&);
     NonnullLockRefPtr<Inode> m_inode;
 };

--- a/Kernel/Syscalls/fallocate.cpp
+++ b/Kernel/Syscalls/fallocate.cpp
@@ -51,7 +51,6 @@ ErrorOr<FlatPtr> Process::sys$posix_fallocate(int fd, Userspace<off_t const*> us
     //       truncate instead
     TRY(file.inode().truncate(checked_size.value()));
 
-    // FIXME: ENOSPC: There is not enough space left on the device containing the file referred to by fd.
     // FIXME: EINTR: A signal was caught during execution.
     return 0;
 }

--- a/Kernel/Syscalls/fallocate.cpp
+++ b/Kernel/Syscalls/fallocate.cpp
@@ -37,7 +37,8 @@ ErrorOr<FlatPtr> Process::sys$posix_fallocate(int fd, Userspace<off_t const*> us
     if (description->is_fifo())
         return ESPIPE;
 
-    if (!S_ISREG(TRY(description->file().stat()).st_mode))
+    // [ENODEV] The fd argument does not refer to a regular file.
+    if (!description->file().is_regular_file())
         return ENODEV;
 
     VERIFY(description->file().is_inode());

--- a/Tests/Kernel/CMakeLists.txt
+++ b/Tests/Kernel/CMakeLists.txt
@@ -40,6 +40,7 @@ set(LIBTEST_BASED_SOURCES
     TestEmptySharedInodeVMObject.cpp
     TestInvalidUIDSet.cpp
     TestSharedInodeVMObject.cpp
+    TestPosixFallocate.cpp
     TestPrivateInodeVMObject.cpp
     TestKernelAlarm.cpp
     TestKernelFilePermissions.cpp

--- a/Tests/Kernel/TestPosixFallocate.cpp
+++ b/Tests/Kernel/TestPosixFallocate.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/System.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(posix_fallocate_basics)
+{
+    char pattern[] = "/tmp/posix_fallocate.XXXXXX";
+    auto fd = MUST(Core::System::mkstemp(pattern));
+    VERIFY(fd >= 0);
+
+    {
+        // Valid use, grows file to new size.
+        auto result = Core::System::posix_fallocate(fd, 0, 1024);
+        EXPECT_EQ(result.is_error(), false);
+
+        auto stat = MUST(Core::System::fstat(fd));
+        EXPECT_EQ(stat.st_size, 1024);
+    }
+
+    {
+        // Invalid fd (-1)
+        auto result = Core::System::posix_fallocate(-1, 0, 1024);
+        EXPECT_EQ(result.is_error(), true);
+        EXPECT_EQ(result.error().code(), EBADF);
+    }
+
+    {
+        // Invalid length (-1)
+        auto result = Core::System::posix_fallocate(fd, 0, -1);
+        EXPECT_EQ(result.is_error(), true);
+        EXPECT_EQ(result.error().code(), EINVAL);
+    }
+
+    {
+        // Invalid length (0)
+        auto result = Core::System::posix_fallocate(fd, 0, 0);
+        EXPECT_EQ(result.is_error(), true);
+        EXPECT_EQ(result.error().code(), EINVAL);
+    }
+
+    {
+        // Invalid offset (-1)
+        auto result = Core::System::posix_fallocate(fd, -1, 1024);
+        EXPECT_EQ(result.is_error(), true);
+        EXPECT_EQ(result.error().code(), EINVAL);
+    }
+
+    MUST(Core::System::close(fd));
+}
+
+TEST_CASE(posix_fallocate_on_device_file)
+{
+    auto fd = MUST(Core::System::open("/dev/zero"sv, O_RDWR));
+    VERIFY(fd >= 0);
+    auto result = Core::System::posix_fallocate(fd, 0, 100);
+    EXPECT_EQ(result.is_error(), true);
+    EXPECT_EQ(result.error().code(), ENODEV);
+    MUST(Core::System::close(fd));
+}
+
+TEST_CASE(posix_fallocate_on_pipe)
+{
+    auto pipefds = MUST(Core::System::pipe2(0));
+    auto result = Core::System::posix_fallocate(pipefds[1], 0, 100);
+    EXPECT_EQ(result.is_error(), true);
+    EXPECT_EQ(result.error().code(), ESPIPE);
+    MUST(Core::System::close(pipefds[0]));
+    MUST(Core::System::close(pipefds[1]));
+}

--- a/Userland/Libraries/LibC/fcntl.cpp
+++ b/Userland/Libraries/LibC/fcntl.cpp
@@ -117,7 +117,7 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice)
 int posix_fallocate(int fd, off_t offset, off_t len)
 {
     // posix_fallocate does not set errno.
-    return static_cast<int>(syscall(SC_posix_fallocate, fd, &offset, &len));
+    return -static_cast<int>(syscall(SC_posix_fallocate, fd, &offset, &len));
 }
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/utimensat.html

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1400,4 +1400,14 @@ ErrorOr<String> readlink(StringView pathname)
 #endif
 }
 
+#ifdef AK_OS_SERENITY
+ErrorOr<void> posix_fallocate(int fd, off_t offset, off_t length)
+{
+    int rc = ::posix_fallocate(fd, offset, length);
+    if (rc != 0)
+        return Error::from_syscall("posix_fallocate"sv, -rc);
+    return {};
+}
+#endif
+
 }

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -206,4 +206,8 @@ ErrorOr<void> unlockpt(int fildes);
 ErrorOr<void> access(StringView pathname, int mode);
 ErrorOr<String> readlink(StringView pathname);
 
+#ifdef AK_OS_SERENITY
+ErrorOr<void> posix_fallocate(int fd, off_t offset, off_t length);
+#endif
+
 }


### PR DESCRIPTION
Cool things like:
- Make `posix_fallocate()` actually report errors correctly
- Make `sys$posix_fallocate()` on a non-regular file return the right error
- Add `Core::System::posix_fallocate()`
- And more!