### PR TITLE
LibJS: Add spec comments and check for edge cases in a bunch of Math functions

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -636,13 +636,22 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::cosh)
 // 21.3.2.34 Math.tanh ( x ), https://tc39.es/ecma262/#sec-math.tanh
 JS_DEFINE_NATIVE_FUNCTION(MathObject::tanh)
 {
+    // 1. Let n be ? ToNumber(x).
     auto number = TRY(vm.argument(0).to_number(vm));
-    if (number.is_nan())
-        return js_nan();
+
+    // 2. If n is NaN, n is +0𝔽, or n is -0𝔽, return n.
+    if (number.is_nan() || number.is_positive_zero() || number.is_negative_zero())
+        return number;
+
+    // 3. If n is +∞𝔽, return 1𝔽.
     if (number.is_positive_infinity())
         return Value(1);
+
+    // 4. If n is -∞𝔽, return -1𝔽.
     if (number.is_negative_infinity())
         return Value(-1);
+
+    // 5. Return an implementation-approximated Number value representing the result of the hyperbolic tangent of ℝ(n).
     return Value(::tanh(number.as_double()));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -319,9 +319,18 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::acosh)
 // 21.3.2.4 Math.asin ( x ), https://tc39.es/ecma262/#sec-math.asin
 JS_DEFINE_NATIVE_FUNCTION(MathObject::asin)
 {
+    // 1. Let n be ? ToNumber(x).
     auto number = TRY(vm.argument(0).to_number(vm));
+
+    // 2. If n is NaN, n is +0𝔽, or n is -0𝔽, return n.
     if (number.is_nan() || number.is_positive_zero() || number.is_negative_zero())
         return number;
+
+    // 3. If n > 1𝔽 or n < -1𝔽, return NaN.
+    if (number.as_double() > 1 || number.as_double() < -1)
+        return js_nan();
+
+    // 4. Return an implementation-approximated Number value representing the result of the inverse sine of ℝ(n).
     return Value(::asin(number.as_double()));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -548,10 +548,27 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::log)
 // 21.3.2.23 Math.log2 ( x ), https://tc39.es/ecma262/#sec-math.log2
 JS_DEFINE_NATIVE_FUNCTION(MathObject::log2)
 {
-    auto value = TRY(vm.argument(0).to_number(vm)).as_double();
-    if (value < 0)
+    // 1. Let n be ? ToNumber(x).
+    auto number = TRY(vm.argument(0).to_number(vm));
+
+    // 2. If n is NaN or n is +∞𝔽, return n.
+    if (number.is_nan() || number.is_positive_infinity())
+        return number;
+
+    // 3. If n is 1𝔽, return +0𝔽.
+    if (number.as_double() == 1.)
+        return Value(0);
+
+    // 4. If n is +0𝔽 or n is -0𝔽, return -∞𝔽.
+    if (number.is_positive_zero() || number.is_negative_zero())
+        return js_negative_infinity();
+
+    // 5. If n < -0𝔽, return NaN.
+    if (number.as_double() < -0.)
         return js_nan();
-    return Value(::log2(value));
+
+    // 6. Return an implementation-approximated Number value representing the result of the base 2 logarithm of ℝ(n).
+    return Value(::log2(number.as_double()));
 }
 
 // 21.3.2.22 Math.log10 ( x ), https://tc39.es/ecma262/#sec-math.log10

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -574,10 +574,27 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::log2)
 // 21.3.2.22 Math.log10 ( x ), https://tc39.es/ecma262/#sec-math.log10
 JS_DEFINE_NATIVE_FUNCTION(MathObject::log10)
 {
-    auto value = TRY(vm.argument(0).to_number(vm)).as_double();
-    if (value < 0)
+    // 1. Let n be ? ToNumber(x).
+    auto number = TRY(vm.argument(0).to_number(vm));
+
+    // 2. If n is NaN or n is +∞𝔽, return n.
+    if (number.is_nan() || number.is_positive_infinity())
+        return number;
+
+    // 3. If n is 1𝔽, return +0𝔽.
+    if (number.as_double() == 1.)
+        return Value(0);
+
+    // 4. If n is +0𝔽 or n is -0𝔽, return -∞𝔽.
+    if (number.is_positive_zero() || number.is_negative_zero())
+        return js_negative_infinity();
+
+    // 5. If n < -0𝔽, return NaN.
+    if (number.as_double() < -0.)
         return js_nan();
-    return Value(::log10(value));
+
+    // 6. Return an implementation-approximated Number value representing the result of the base 10 logarithm of ℝ(n).
+    return Value(::log10(number.as_double()));
 }
 
 // 21.3.2.31 Math.sinh ( x ), https://tc39.es/ecma262/#sec-math.sinh

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -600,9 +600,14 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::log10)
 // 21.3.2.31 Math.sinh ( x ), https://tc39.es/ecma262/#sec-math.sinh
 JS_DEFINE_NATIVE_FUNCTION(MathObject::sinh)
 {
+    // 1. Let n be ? ToNumber(x).
     auto number = TRY(vm.argument(0).to_number(vm));
-    if (number.is_nan())
-        return js_nan();
+
+    // 2. If n is not finite or n is either +0𝔽 or -0𝔽, return n.
+    if (!number.is_finite_number() || number.is_positive_zero() || number.is_negative_zero())
+        return number;
+
+    // 3. Return an implementation-approximated Number value representing the result of the hyperbolic sine of ℝ(n).
     return Value(::sinh(number.as_double()));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -297,10 +297,23 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::acos)
 // 21.3.2.3 Math.acosh ( x ), https://tc39.es/ecma262/#sec-math.acosh
 JS_DEFINE_NATIVE_FUNCTION(MathObject::acosh)
 {
-    auto value = TRY(vm.argument(0).to_number(vm)).as_double();
-    if (value < 1)
+    // 1. Let n be ? ToNumber(x).
+    auto number = TRY(vm.argument(0).to_number(vm));
+
+    // 2. If n is NaN or n is +∞𝔽, return n.
+    if (number.is_nan() || number.is_positive_infinity())
+        return number;
+
+    // 3. If n is 1𝔽, return +0𝔽.
+    if (number.as_double() == 1.0)
+        return Value(0.0);
+
+    // 4. If n < 1𝔽, return NaN.
+    if (number.as_double() < 1)
         return js_nan();
-    return Value(::acosh(value));
+
+    // 5. Return an implementation-approximated Number value representing the result of the inverse hyperbolic cosine of ℝ(n).
+    return Value(::acosh(number.as_double()));
 }
 
 // 21.3.2.4 Math.asin ( x ), https://tc39.es/ecma262/#sec-math.asin

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -390,10 +390,23 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::atanh)
 // 21.3.2.21 Math.log1p ( x ), https://tc39.es/ecma262/#sec-math.log1p
 JS_DEFINE_NATIVE_FUNCTION(MathObject::log1p)
 {
-    auto value = TRY(vm.argument(0).to_number(vm)).as_double();
-    if (value < -1)
+    // 1. Let n be ? ToNumber(x).
+    auto number = TRY(vm.argument(0).to_number(vm));
+
+    // 2. If n is NaN, n is +0𝔽, n is -0𝔽, or n is +∞𝔽, return n.
+    if (number.is_nan() || number.is_positive_zero() || number.is_negative_zero() || number.is_positive_infinity())
+        return number;
+
+    // 3. If n is -1𝔽, return -∞𝔽.
+    if (number.as_double() == -1.)
+        return js_negative_infinity();
+
+    // 4. If n < -1𝔽, return NaN.
+    if (number.as_double() < -1.)
         return js_nan();
-    return Value(::log1p(value));
+
+    // 5. Return an implementation-approximated Number value representing the result of the natural logarithm of 1 + ℝ(n).
+    return Value(::log1p(number.as_double()));
 }
 
 // 21.3.2.9 Math.cbrt ( x ), https://tc39.es/ecma262/#sec-math.cbrt

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -522,10 +522,27 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::imul)
 // 21.3.2.20 Math.log ( x ), https://tc39.es/ecma262/#sec-math.log
 JS_DEFINE_NATIVE_FUNCTION(MathObject::log)
 {
-    auto value = TRY(vm.argument(0).to_number(vm)).as_double();
-    if (value < 0)
+    // 1. Let n be ? ToNumber(x).
+    auto number = TRY(vm.argument(0).to_number(vm));
+
+    // 2. If n is NaN or n is +∞𝔽, return n.
+    if (number.is_nan() || number.is_positive_infinity())
+        return number;
+
+    // 3. If n is 1𝔽, return +0𝔽.
+    if (number.as_double() == 1.)
+        return Value(0);
+
+    // 4. If n is +0𝔽 or n is -0𝔽, return -∞𝔽.
+    if (number.is_positive_zero() || number.is_negative_zero())
+        return js_negative_infinity();
+
+    // 5. If n < -0𝔽, return NaN.
+    if (number.as_double() < -0.)
         return js_nan();
-    return Value(::log(value));
+
+    // 6. Return an implementation-approximated Number value representing the result of the natural logarithm of ℝ(n).
+    return Value(::log(number.as_double()));
 }
 
 // 21.3.2.23 Math.log2 ( x ), https://tc39.es/ecma262/#sec-math.log2

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -364,10 +364,27 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::atan)
 // 21.3.2.7 Math.atanh ( x ), https://tc39.es/ecma262/#sec-math.atanh
 JS_DEFINE_NATIVE_FUNCTION(MathObject::atanh)
 {
-    auto value = TRY(vm.argument(0).to_number(vm)).as_double();
-    if (value > 1 || value < -1)
+    // 1. Let n be ? ToNumber(x).
+    auto number = TRY(vm.argument(0).to_number(vm));
+
+    // 2. If n is NaN, n is +0𝔽, or n is -0𝔽, return n.
+    if (number.is_nan() || number.is_positive_zero() || number.is_negative_zero())
+        return number;
+
+    // 3. If n > 1𝔽 or n < -1𝔽, return NaN.
+    if (number.as_double() > 1. || number.as_double() < -1.)
         return js_nan();
-    return Value(::atanh(value));
+
+    // 4. If n is 1𝔽, return +∞𝔽.
+    if (number.as_double() == 1.)
+        return js_infinity();
+
+    // 5. If n is -1𝔽, return -∞𝔽.
+    if (number.as_double() == -1.)
+        return js_negative_infinity();
+
+    // 6. Return an implementation-approximated Number value representing the result of the inverse hyperbolic tangent of ℝ(n).
+    return Value(::atanh(number.as_double()));
 }
 
 // 21.3.2.21 Math.log1p ( x ), https://tc39.es/ecma262/#sec-math.log1p

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -337,7 +337,15 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::asin)
 // 21.3.2.5 Math.asinh ( x ), https://tc39.es/ecma262/#sec-math.asinh
 JS_DEFINE_NATIVE_FUNCTION(MathObject::asinh)
 {
-    return Value(::asinh(TRY(vm.argument(0).to_number(vm)).as_double()));
+    // 1. Let n be ? ToNumber(x).
+    auto number = TRY(vm.argument(0).to_number(vm));
+
+    // 2. If n is not finite or n is either +0𝔽 or -0𝔽, return n.
+    if (!number.is_finite_number() || number.is_positive_zero() || number.is_negative_zero())
+        return number;
+
+    // 3. Return an implementation-approximated Number value representing the result of the inverse hyperbolic sine of ℝ(n).
+    return Value(::asinh(number.as_double()));
 }
 
 // 21.3.2.6 Math.atan ( x ), https://tc39.es/ecma262/#sec-math.atan

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.acosh.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.acosh.js
@@ -6,4 +6,7 @@ test("basic functionality", () => {
     expect(Math.acosh(0.5)).toBeNaN();
     expect(Math.acosh(1)).toBeCloseTo(0);
     expect(Math.acosh(2)).toBeCloseTo(1.316957);
+    expect(Math.acosh(NaN)).toBe(NaN);
+    expect(Math.acosh(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
+    expect(Math.acosh(1.0)).toBe(0.0);
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.asin.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.asin.js
@@ -12,4 +12,8 @@ test("basic functionality", () => {
     expect(Math.asin([1, 2, 3])).toBeNaN();
     expect(Math.asin({})).toBeNaN();
     expect(Math.asin("foo")).toBeNaN();
+    expect(Math.asin(NaN)).toBe(NaN);
+    expect(Math.asin(-0.0)).toBe(-0.0);
+    expect(Math.asin(1.1)).toBe(NaN);
+    expect(Math.asin(-1.1)).toBe(NaN);
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.asin.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.asin.js
@@ -5,8 +5,8 @@ test("basic functionality", () => {
     expect(Math.asin(null)).toBe(0);
     expect(Math.asin("")).toBe(0);
     expect(Math.asin([])).toBe(0);
-    // FIXME(LibM): expect(Math.asin(1)).toBeCloseTo(1.5707963267948966);
-    // FIXME(LibM): expect(Math.asin(-1)).toBeCloseTo(-1.5707963267948966);
+    expect(Math.asin(1)).toBeCloseTo(1.5707963267948966);
+    expect(Math.asin(-1)).toBeCloseTo(-1.5707963267948966);
     expect(Math.asin()).toBeNaN();
     expect(Math.asin(undefined)).toBeNaN();
     expect(Math.asin([1, 2, 3])).toBeNaN();

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.asinh.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.asinh.js
@@ -3,4 +3,9 @@ test("basic functionality", () => {
 
     expect(Math.asinh(0)).toBeCloseTo(0);
     expect(Math.asinh(1)).toBeCloseTo(0.881373);
+    expect(Math.asinh(NaN)).toBe(NaN);
+    expect(Math.asinh(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
+    expect(Math.asinh(Number.NEGATIVE_INFINITY)).toBe(Number.NEGATIVE_INFINITY);
+    expect(Math.asinh(0.0)).toBe(0.0);
+    expect(Math.asinh(-0.0)).toBe(-0.0);
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.atanh.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.atanh.js
@@ -7,4 +7,6 @@ test("basic functionality", () => {
     expect(Math.atanh(0)).toBe(0);
     expect(Math.atanh(0.5)).toBeCloseTo(0.549306);
     expect(Math.atanh(1)).toBe(Infinity);
+    expect(Math.atanh(NaN)).toBe(NaN);
+    expect(Math.atanh(-0.0)).toBe(-0.0);
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.log.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.log.js
@@ -5,4 +5,7 @@ test("basic functionality", () => {
     expect(Math.log(0)).toBe(-Infinity);
     expect(Math.log(1)).toBe(0);
     expect(Math.log(10)).toBeCloseTo(2.302585092994046);
+    expect(Math.log(NaN)).toBe(NaN);
+    expect(Math.log(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
+    expect(Math.log(-0.0)).toBe(Number.NEGATIVE_INFINITY);
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.log10.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.log10.js
@@ -6,4 +6,7 @@ test("basic functionality", () => {
     expect(Math.log10(0)).toBe(-Infinity);
     expect(Math.log10(-2)).toBe(NaN);
     expect(Math.log10(100000)).toBe(5);
+    expect(Math.log10(NaN)).toBe(NaN);
+    expect(Math.log10(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
+    expect(Math.log10(-0.0)).toBe(Number.NEGATIVE_INFINITY);
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.log1p.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.log1p.js
@@ -5,4 +5,7 @@ test("basic functionality", () => {
     expect(Math.log1p(-1)).toBe(-Infinity);
     expect(Math.log1p(0)).toBe(0);
     expect(Math.log1p(1)).toBeCloseTo(0.693147);
+    expect(Math.log1p(NaN)).toBe(NaN);
+    expect(Math.log1p(-0.0)).toBe(-0.0);
+    expect(Math.log1p(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.log2.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.log2.js
@@ -7,4 +7,7 @@ test("basic functionality", () => {
     expect(Math.log2(0)).toBe(-Infinity);
     expect(Math.log2(-2)).toBe(NaN);
     expect(Math.log2(1024)).toBe(10);
+    expect(Math.log2(NaN)).toBe(NaN);
+    expect(Math.log2(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
+    expect(Math.log2(-0.0)).toBe(Number.NEGATIVE_INFINITY);
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.sinh.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.sinh.js
@@ -3,4 +3,8 @@ test("basic functionality", () => {
 
     expect(Math.sinh(0)).toBe(0);
     expect(Math.sinh(1)).toBeCloseTo(1.1752011936438014);
+    expect(Math.sinh(NaN)).toBe(NaN);
+    expect(Math.sinh(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
+    expect(Math.sinh(Number.NEGATIVE_INFINITY)).toBe(Number.NEGATIVE_INFINITY);
+    expect(Math.sinh(-0.0)).toBe(-0.0);
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Math/Math.tanh.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Math/Math.tanh.js
@@ -5,4 +5,6 @@ test("basic functionality", () => {
     expect(Math.tanh(Infinity)).toBe(1);
     expect(Math.tanh(-Infinity)).toBe(-1);
     expect(Math.tanh(1)).toBeCloseTo(0.7615941559557649);
+    expect(Math.tanh(NaN)).toBe(NaN);
+    expect(Math.tanh(-0.0)).toBe(-0.0);
 });


### PR DESCRIPTION
I was hoping somebody would be yakbaited into this by my video but now I did it myself.
Also added tests.

This probably doesn't actually change behavior in most cases but does make us rely less upon the underlying math implementations "choices" for the edge cases.

Fixes the last failing regressions of test262 on serenity itself so I think these are now the same (although I haven't tested after the generator change)