### PR TITLE
LibVideo/VP9: Apply higher optimization levels to Decoder and Parser

### DIFF
--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -12,6 +12,10 @@
 #include "Decoder.h"
 #include "Utilities.h"
 
+#if defined(AK_COMPILER_GCC)
+#    pragma GCC optimize("O3")
+#endif
+
 namespace Video::VP9 {
 
 Decoder::Decoder()

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -13,6 +13,10 @@
 #include "Parser.h"
 #include "Utilities.h"
 
+#if defined(AK_COMPILER_GCC)
+#    pragma GCC optimize("O3")
+#endif
+
 namespace Video::VP9 {
 
 #define TRY_READ(expression) DECODER_TRY(DecoderErrorCategory::Corrupted, expression)


### PR DESCRIPTION
With this change, decode times on GCC as measured by TestVP9Decode are reduced by about 15%. Not a bad improvement for a few added lines :^)