### PR TITLE
LibJS: Allow specifying only roundingIncrement in NumberFormat options

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.js
@@ -244,11 +244,7 @@ describe("errors", () => {
         }).toThrowWithMessage(RangeError, "Value 5001 is NaN or is not between 1 and 5000");
 
         expect(() => {
-            new Intl.NumberFormat("en", {
-                roundingIncrement: 3,
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-            });
+            new Intl.NumberFormat("en", { roundingIncrement: 3 });
         }).toThrowWithMessage(RangeError, "3 is not a valid rounding increment");
 
         expect(() => {
@@ -459,11 +455,7 @@ describe("normal behavior", () => {
         [1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000].forEach(
             roundingIncrement => {
                 expect(() => {
-                    new Intl.NumberFormat("en", {
-                        roundingIncrement: roundingIncrement,
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                    });
+                    new Intl.NumberFormat("en", { roundingIncrement: roundingIncrement });
                 }).not.toThrow();
             }
         );

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.resolvedOptions.js
@@ -348,11 +348,7 @@ describe("correct behavior", () => {
 
         [1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000].forEach(
             roundingIncrement => {
-                const en2 = new Intl.NumberFormat("en", {
-                    roundingIncrement: roundingIncrement,
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2,
-                });
+                const en2 = new Intl.NumberFormat("en", { roundingIncrement: roundingIncrement });
                 expect(en2.resolvedOptions().roundingIncrement).toBe(roundingIncrement);
             }
         );


### PR DESCRIPTION
This is a normative change in the Intl.NumberFormat v3 spec. See:
https://github.com/tc39/proposal-intl-numberformat-v3/commit/a260aa3