### PR TITLE
LibArchive: Start porting `tar` to `Core::Stream` (and a bunch of supporting changes in `LibCore`)

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzTar.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTar.cpp
@@ -25,9 +25,6 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 
     auto tar_stream = tar_stream_or_error.release_value();
 
-    if (!tar_stream->valid())
-        return 0;
-
     while (!tar_stream->finished()) {
         auto const& header = tar_stream->header();
 

--- a/Userland/Libraries/LibArchive/Tar.cpp
+++ b/Userland/Libraries/LibArchive/Tar.cpp
@@ -30,6 +30,16 @@ void TarFileHeader::calculate_checksum()
     VERIFY(String::formatted("{:06o}", expected_checksum()).copy_characters_to_buffer(m_checksum, sizeof(m_checksum)));
 }
 
+bool TarFileHeader::is_zero_block() const
+{
+    u8 const* buffer = reinterpret_cast<u8 const*>(this);
+    for (size_t i = 0; i < sizeof(TarFileHeader); ++i) {
+        if (buffer[i] != 0)
+            return false;
+    }
+    return true;
+}
+
 bool TarFileHeader::content_is_like_extended_header() const
 {
     return type_flag() == TarFileType::ExtendedHeader || type_flag() == TarFileType::GlobalExtendedHeader;

--- a/Userland/Libraries/LibArchive/Tar.h
+++ b/Userland/Libraries/LibArchive/Tar.h
@@ -129,6 +129,7 @@ public:
     unsigned expected_checksum() const;
     void calculate_checksum();
 
+    bool is_zero_block() const;
     bool content_is_like_extended_header() const;
 
     void set_filename_and_prefix(StringView filename);

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -33,9 +33,9 @@ private:
 
 class TarInputStream {
 public:
-    TarInputStream(InputStream&);
+    static ErrorOr<NonnullOwnPtr<TarInputStream>> construct(NonnullOwnPtr<Core::Stream::Stream>);
     ErrorOr<void> advance();
-    bool finished() const { return m_finished; }
+    bool finished() const { return m_stream->is_eof(); }
     bool valid() const;
     TarFileHeader const& header() const { return m_header; }
     TarFileStream file_contents();
@@ -44,11 +44,12 @@ public:
     ErrorOr<void> for_each_extended_header(F func);
 
 private:
+    TarInputStream(NonnullOwnPtr<Core::Stream::Stream>);
+
     TarFileHeader m_header;
-    InputStream& m_stream;
+    NonnullOwnPtr<Core::Stream::Stream> m_stream;
     unsigned long m_file_offset { 0 };
     int m_generation { 0 };
-    bool m_finished { false };
 
     friend class TarFileStream;
 };

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -35,7 +35,7 @@ class TarInputStream {
 public:
     static ErrorOr<NonnullOwnPtr<TarInputStream>> construct(NonnullOwnPtr<Core::Stream::Stream>);
     ErrorOr<void> advance();
-    bool finished() const { return m_stream->is_eof(); }
+    bool finished() const { return m_found_end_of_archive || m_stream->is_eof(); }
     ErrorOr<bool> valid() const;
     TarFileHeader const& header() const { return m_header; }
     TarFileStream file_contents();
@@ -51,6 +51,7 @@ private:
     NonnullOwnPtr<Core::Stream::Stream> m_stream;
     unsigned long m_file_offset { 0 };
     int m_generation { 0 };
+    bool m_found_end_of_archive { false };
 
     friend class TarFileStream;
 };

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -45,6 +45,7 @@ public:
 
 private:
     TarInputStream(NonnullOwnPtr<Core::Stream::Stream>);
+    ErrorOr<void> load_next_header();
 
     TarFileHeader m_header;
     NonnullOwnPtr<Core::Stream::Stream> m_stream;

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -36,7 +36,7 @@ public:
     static ErrorOr<NonnullOwnPtr<TarInputStream>> construct(NonnullOwnPtr<Core::Stream::Stream>);
     ErrorOr<void> advance();
     bool finished() const { return m_stream->is_eof(); }
-    bool valid() const;
+    ErrorOr<bool> valid() const;
     TarFileHeader const& header() const { return m_header; }
     TarFileStream file_contents();
 

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -8,20 +8,20 @@
 #pragma once
 
 #include <AK/Span.h>
-#include <AK/Stream.h>
 #include <LibArchive/Tar.h>
+#include <LibCore/Stream.h>
 
 namespace Archive {
 
 class TarInputStream;
 
-class TarFileStream : public InputStream {
+class TarFileStream : public Core::Stream::Stream {
 public:
-    size_t read(Bytes) override;
-    bool unreliable_eof() const override;
-
-    bool read_or_error(Bytes) override;
-    bool discard_or_error(size_t count) override;
+    virtual ErrorOr<Bytes> read(Bytes) override;
+    virtual ErrorOr<size_t> write(ReadonlyBytes) override;
+    virtual bool is_eof() const override;
+    virtual bool is_open() const override { return true; };
+    virtual void close() override {};
 
 private:
     TarFileStream(TarInputStream& stream);
@@ -77,7 +77,7 @@ inline ErrorOr<void> TarInputStream::for_each_extended_header(F func)
 
     auto header_size = TRY(header().size());
     ByteBuffer file_contents_buffer = TRY(ByteBuffer::create_zeroed(header_size));
-    VERIFY(file_stream.read(file_contents_buffer) == header_size);
+    VERIFY(TRY(file_stream.read(file_contents_buffer)).size() == header_size);
 
     StringView file_contents { file_contents_buffer };
 

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -714,4 +714,72 @@ ErrorOr<int> LocalSocket::release_fd()
     return fd;
 }
 
+WrappedAKInputStream::WrappedAKInputStream(NonnullOwnPtr<InputStream> stream)
+    : m_stream(move(stream))
+{
+}
+
+ErrorOr<Bytes> WrappedAKInputStream::read(Bytes bytes)
+{
+    auto bytes_read = m_stream->read(bytes);
+
+    if (m_stream->has_any_error())
+        return Error::from_string_literal("Underlying InputStream indicated an error");
+
+    return bytes.slice(0, bytes_read);
+}
+
+ErrorOr<size_t> WrappedAKInputStream::write(ReadonlyBytes)
+{
+    VERIFY_NOT_REACHED();
+}
+
+bool WrappedAKInputStream::is_eof() const
+{
+    return m_stream->unreliable_eof();
+}
+
+bool WrappedAKInputStream::is_open() const
+{
+    return true;
+}
+
+void WrappedAKInputStream::close()
+{
+}
+
+WrappedAKOutputStream::WrappedAKOutputStream(NonnullOwnPtr<OutputStream> stream)
+    : m_stream(move(stream))
+{
+}
+
+ErrorOr<Bytes> WrappedAKOutputStream::read(Bytes)
+{
+    VERIFY_NOT_REACHED();
+}
+
+ErrorOr<size_t> WrappedAKOutputStream::write(ReadonlyBytes bytes)
+{
+    auto bytes_written = m_stream->write(bytes);
+
+    if (m_stream->has_any_error())
+        return Error::from_string_literal("Underlying OutputStream indicated an error");
+
+    return bytes_written;
+}
+
+bool WrappedAKOutputStream::is_eof() const
+{
+    VERIFY_NOT_REACHED();
+}
+
+bool WrappedAKOutputStream::is_open() const
+{
+    return true;
+}
+
+void WrappedAKOutputStream::close()
+{
+}
+
 }

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -41,6 +41,10 @@ public:
     /// is returned once EOF is encountered. The block size determines the size
     /// of newly allocated chunks while reading.
     virtual ErrorOr<ByteBuffer> read_all(size_t block_size = 4096);
+    /// Discards the given number of bytes from the stream.
+    /// Unless specifically overwritten, this just uses read() to read into an
+    /// internal stack-based buffer.
+    virtual ErrorOr<void> discard(size_t discarded_bytes);
 
     virtual bool is_writable() const { return false; }
     /// Tries to write the entire contents of the buffer. It is possible for
@@ -97,6 +101,9 @@ public:
     /// Shrinks or extends the stream to the given size. Returns an errno in
     /// the case of an error.
     virtual ErrorOr<void> truncate(off_t length) = 0;
+    /// Seeks until after the given amount of bytes to be discarded instead of
+    /// reading and discarding everything manually;
+    virtual ErrorOr<void> discard(size_t discarded_bytes) override;
 };
 
 /// The Socket class is the base class for all concrete BSD-style socket
@@ -973,6 +980,7 @@ class WrappedAKInputStream final : public Stream {
 public:
     WrappedAKInputStream(NonnullOwnPtr<InputStream> stream);
     virtual ErrorOr<Bytes> read(Bytes) override;
+    virtual ErrorOr<void> discard(size_t discarded_bytes) override;
     virtual ErrorOr<size_t> write(ReadonlyBytes) override;
     virtual bool is_eof() const override;
     virtual bool is_open() const override;

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -968,4 +968,32 @@ private:
 using ReusableTCPSocket = BasicReusableSocket<TCPSocket>;
 using ReusableUDPSocket = BasicReusableSocket<UDPSocket>;
 
+// Note: This is only a temporary hack, to break up the task of moving away from AK::Stream into smaller parts.
+class WrappedAKInputStream final : public Stream {
+public:
+    WrappedAKInputStream(NonnullOwnPtr<InputStream> stream);
+    virtual ErrorOr<Bytes> read(Bytes) override;
+    virtual ErrorOr<size_t> write(ReadonlyBytes) override;
+    virtual bool is_eof() const override;
+    virtual bool is_open() const override;
+    virtual void close() override;
+
+private:
+    NonnullOwnPtr<InputStream> m_stream;
+};
+
+// Note: This is only a temporary hack, to break up the task of moving away from AK::Stream into smaller parts.
+class WrappedAKOutputStream final : public Stream {
+public:
+    WrappedAKOutputStream(NonnullOwnPtr<OutputStream> stream);
+    virtual ErrorOr<Bytes> read(Bytes) override;
+    virtual ErrorOr<size_t> write(ReadonlyBytes) override;
+    virtual bool is_eof() const override;
+    virtual bool is_open() const override;
+    virtual void close() override;
+
+private:
+    NonnullOwnPtr<OutputStream> m_stream;
+};
+
 }

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -88,11 +88,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }());
 
         auto tar_stream = TRY(Archive::TarInputStream::construct(move(input_stream)));
-        // FIXME: implement ErrorOr<TarInputStream>?
-        if (!tar_stream->valid()) {
-            warnln("the provided file is not a well-formatted ustar file");
-            return 1;
-        }
 
         HashMap<String, String> global_overrides;
         HashMap<String, String> local_overrides;


### PR DESCRIPTION
Looks like we will have a whole bunch of "why does this change from `AK::Stream` to `Core::Stream` somewhere in the middle" in the next few weeks, at least as long as not everything has been reworked to use the new API. :^)