### PR TITLE
LibGfx: Handle alpha values in color distances 

### DIFF
--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -24,6 +24,9 @@ void AntiAliasingPainter::draw_anti_aliased_line(FloatPoint actual_from, FloatPo
     // FIXME: Implement this :P
     VERIFY(style == Painter::LineStyle::Solid);
 
+    if (color.alpha() == 0)
+        return;
+
     // FIMXE:
     // This is not a proper line drawing algorithm.
     // It's hack-ish AA rotated rectangle painting.

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -257,11 +257,12 @@ public:
 
     constexpr float distance_squared_to(Color const& other) const
     {
-        int a = other.red() - red();
-        int b = other.green() - green();
-        int c = other.blue() - blue();
-        int d = other.alpha() - alpha();
-        return (a * a + b * b + c * c + d * d) / (4.0f * 255.0f * 255.0f);
+        int delta_red = other.red() - red();
+        int delta_green = other.green() - green();
+        int delta_blue = other.blue() - blue();
+        int delta_alpha = other.alpha() - alpha();
+        auto rgb_distance = (delta_red * delta_red + delta_green * delta_green + delta_blue * delta_blue) / (3.0f * 255 * 255);
+        return delta_alpha * delta_alpha / (2.0f * 255 * 255) + rgb_distance * alpha() * other.alpha() / (255 * 255);
     }
 
     constexpr u8 luminosity() const

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1833,11 +1833,10 @@ void Painter::set_pixel(IntPoint const& p, Color color, bool blend)
     if (!clip_rect().contains(point / scale()))
         return;
     auto& dst = m_target->scanline(point.y())[point.x()];
-    if (!blend) {
+    if (!blend)
         dst = color.value();
-    } else {
+    else if (color.alpha())
         dst = Color::from_argb(dst).blend(color).value();
-    }
 }
 
 Optional<Color> Painter::get_pixel(IntPoint const& p)


### PR DESCRIPTION
This aims to fix some weirdness I noticed in pixel paint, where the bucket tool treats transparent pixels with different RGB values as different colors.   

So if you write a message in transparent red ink, then fill the background with a color, your hidden messages shows up... While fun, it seems like a bug:

[screen-capture - 2022-11-28T225024.002.webm](https://user-images.githubusercontent.com/11597044/204397429-99d4fc1c-fb5a-42ca-a37e-28b89bf643a1.webm)