### PR TITLE
LibWeb: Return the position at end-of-line in TextCursor hit-test

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -700,7 +700,7 @@ Optional<HitTestResult> PaintableWithLines::hit_test(Gfx::FloatPoint const& posi
                 return HitTestResult { *fragment.layout_node().paintable(), fragment.text_index_at(position.x()) };
             }
             if (fragment_absolute_rect.top() <= position.y())
-                last_good_candidate = HitTestResult { *fragment.layout_node().paintable(), fragment.text_index_at(position.x()) };
+                last_good_candidate = HitTestResult { *fragment.layout_node().paintable(), fragment.length() + 1 };
         }
     }
 


### PR DESCRIPTION
When starting to drag the cursor below the text, we would start the selection from the closest point in the line above in the last fragment. This is not the behavior seen in other browsers, and it causes weird behavior when the cursor is to the left of the last fragment, for instances when trying to select with the text `before <span>middle</span> after`.

By starting the selection from the _end_ of the last fragment, including the line end character, selection behavior is similar to that of other browsers.