### PR TITLE
LibWeb: Do not layout table cells during column width calculation

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -27,7 +27,7 @@ public:
     virtual float automatic_content_height() const override;
 
 private:
-    void calculate_column_widths(Box const& row, CSS::Length const& table_width, Vector<ColumnWidth>& column_widths, AvailableSpace const&);
+    void calculate_column_widths(Box const& row, CSS::Length const& table_width, Vector<ColumnWidth>& column_widths);
     void layout_row(Box const& row, Vector<ColumnWidth>& column_widths, AvailableSpace const&);
 
     float m_automatic_content_height { 0 };


### PR DESCRIPTION
This change makes table rows to not exceed table container width by making following changes:
1. Do not call layout_inside for cells during columns width calculation.
2. Call compute_height not before but after layout_inside.