### PR TITLE
LibWeb: Develop grid track spans further

### DIFF
--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -411,3 +411,56 @@ length value, and as a minimum two lengths with an auto. -->
   <div class="grid-item" style="grid-column: 2 / span 1">1</div>
   <div class="grid-item">2</div>
 </div>
+
+<!-- Column end and span -->
+<p>There should be a column spanning 8 units, and then one spanning 4</p>
+<div 
+  class="grid-container"
+  style="
+    grid-template-columns: repeat(12,minmax(0,5fr));
+  ">
+  <div class="grid-item"
+  style="
+    grid-column-end: span 8;
+  ">1</div>
+  <div class="grid-item"
+  style="
+    grid-column-end: span 4;
+  ">2</div>
+</div>
+
+<!-- Column start span takes priority over column end span -->
+<p>There should be a column spanning 4 units, and then one spanning 8</p>
+<div 
+  class="grid-container"
+  style="
+    grid-template-columns: repeat(12,minmax(0,5fr));
+  ">
+  <div class="grid-item"
+  style="
+    grid-column-start: span 4;
+    grid-column-end: span 8;
+  ">1</div>
+  <div class="grid-item"
+  style="
+    grid-column-start: span 8;
+    grid-column-end: span 4;
+  ">2</div>
+</div>
+
+<!-- Row end and span -->
+<p>There should be a row spanning 2 units, and then one spanning 3</p>
+<div 
+  class="grid-container"
+  style="
+    grid-template-rows: repeat(5, 20px);
+  ">
+  <div class="grid-item"
+  style="
+    grid-row-end: span 2;
+  ">1</div>
+  <div class="grid-item"
+  style="
+    grid-row-end: span 3;
+  ">2</div>
+</div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -646,7 +646,11 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
             // column span, overflow the number of columns in the implicit grid, as determined earlier in this
             // algorithm.
             auto column_start = 0;
-            auto column_span = child_box.computed_values().grid_column_start().is_span() ? child_box.computed_values().grid_column_start().raw_value() : 1;
+            auto column_span = 1;
+            if (child_box.computed_values().grid_column_start().is_span())
+                column_span = child_box.computed_values().grid_column_start().raw_value();
+            else if (child_box.computed_values().grid_column_end().is_span())
+                column_span = child_box.computed_values().grid_column_end().raw_value();
             // https://drafts.csswg.org/css-grid/#auto-placement-algo
             // 8.5. Grid Item Placement Algorithm
             // 3.3. If the largest column span among all the items without a definite column position is larger
@@ -654,7 +658,11 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
             // that column span.
             occupation_grid.maybe_add_column(column_span);
             auto row_start = 0;
-            auto row_span = child_box.computed_values().grid_row_start().is_span() ? child_box.computed_values().grid_row_start().raw_value() : 1;
+            auto row_span = 1;
+            if (child_box.computed_values().grid_row_start().is_span())
+                row_span = child_box.computed_values().grid_row_start().raw_value();
+            else if (child_box.computed_values().grid_row_end().is_span())
+                row_span = child_box.computed_values().grid_row_end().raw_value();
             auto found_unoccupied_area = false;
             for (int row_index = auto_placement_cursor_y; row_index < occupation_grid.row_count(); row_index++) {
                 for (int column_index = auto_placement_cursor_x; column_index < occupation_grid.column_count(); column_index++) {


### PR DESCRIPTION
These changes make the grid formatter take advantage of span values when given for the grid-*-properties.

<table>
<th>Before</th>
<th>After</th>
<tr>
<td>
<a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/45781926/204611853-a8262ef4-eca5-4036-a957-ed1a06a47fff.png"><img src="https://user-images.githubusercontent.com/45781926/204611853-a8262ef4-eca5-4036-a957-ed1a06a47fff.png" alt="image" style="max-width: 100%;"></a>
</td>
<td>
<a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/45781926/204611865-b383fd3f-966b-41e4-a75f-5f3e1347e53a.png"><img src="https://user-images.githubusercontent.com/45781926/204611865-b383fd3f-966b-41e4-a75f-5f3e1347e53a.png" alt="image" style="max-width: 100%;"></a>
</td>
</tr>
</table>