### PR TITLE
LibWeb: Use AntiAliasingPainter for canvas painting

### DIFF
--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -754,19 +754,17 @@ void AntiAliasingPainter::stroke_segment_intersection(FloatPoint const& current_
         }
     }
 
-    m_intersection_edge_path.clear();
-    m_intersection_edge_path.move_to(current_rotated_90deg);
+    Path intersection_edge_path;
+    intersection_edge_path.move_to(current_rotated_90deg);
     if (edge_spike_90.has_value())
-        m_intersection_edge_path.line_to(edge_spike_90.value());
-    m_intersection_edge_path.line_to(previous_rotated_270deg);
-
-    m_intersection_edge_path.line_to(current_rotated_270deg);
+        intersection_edge_path.line_to(edge_spike_90.value());
+    intersection_edge_path.line_to(previous_rotated_270deg);
+    intersection_edge_path.line_to(current_rotated_270deg);
     if (edge_spike_270.has_value())
-        m_intersection_edge_path.line_to(edge_spike_270.value());
-    m_intersection_edge_path.line_to(previous_rotated_90deg);
-    m_intersection_edge_path.close();
-
-    fill_path(m_intersection_edge_path, color);
+        intersection_edge_path.line_to(edge_spike_270.value());
+    intersection_edge_path.line_to(previous_rotated_90deg);
+    intersection_edge_path.close();
+    fill_path(intersection_edge_path, color);
 }
 
 // rotates a rectangle around 0,0

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -44,7 +44,8 @@ void AntiAliasingPainter::draw_anti_aliased_line(FloatPoint actual_from, FloatPo
     int int_thickness = AK::ceil(thickness);
     auto mapped_from = m_transform.map(actual_from);
     auto mapped_to = m_transform.map(actual_to);
-    auto length = mapped_to.distance_from(mapped_from);
+    auto distance = mapped_to.distance_from(mapped_from);
+    auto length = distance + 1;
 
     // Axis-aligned lines:
     if (mapped_from.y() == mapped_to.y()) {
@@ -63,10 +64,10 @@ void AntiAliasingPainter::draw_anti_aliased_line(FloatPoint actual_from, FloatPo
 
     if constexpr (path_hacks == FixmeEnableHacksForBetterPathPainting::Yes) {
         // FIXME: SVG stoke_path() hack:
-        // When painting stokes SVG asks for many thickness * < 1px lines.
-        // It actually wants a thickness * thickness dot centered at that point.
+        // When painting stokes SVG asks for many very short lines...
+        // These look better just painted as dots/AA rectangles
         // (Technically this should be rotated or a circle, but that currently gives worse results)
-        if (length < 1.0f)
+        if (distance < 1.0f)
             return fill_rect(Gfx::FloatRect::centered_at(mapped_from, { thickness, thickness }), color);
     }
 

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -88,8 +88,6 @@ private:
 
     Painter& m_underlying_painter;
     AffineTransform m_transform;
-    Path m_intersection_edge_path;
-    Path m_rotated_rectangle_path;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -9,6 +9,7 @@
 
 #include <AK/Variant.h>
 #include <LibGfx/AffineTransform.h>
+#include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Painter.h>
@@ -101,7 +102,8 @@ private:
     void did_draw(Gfx::FloatRect const&);
     PreparedText prepare_text(String const& text, float max_width = INFINITY);
 
-    OwnPtr<Gfx::Painter> painter();
+    Gfx::Painter* painter();
+    Optional<Gfx::AntiAliasingPainter> antialiased_painter();
 
     HTMLCanvasElement& canvas_element();
     HTMLCanvasElement const& canvas_element() const;
@@ -110,6 +112,7 @@ private:
     void fill_internal(Gfx::Path&, String const& fill_rule);
 
     JS::NonnullGCPtr<HTMLCanvasElement> m_element;
+    OwnPtr<Gfx::Painter> m_painter;
 
     // https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-origin-clean
     bool m_origin_clean { true };


### PR DESCRIPTION
I think this adds a small but noticeable improvement in most cases, and is more like how other browsers handle canvas rendering

Examples After -> Before:

![image](https://user-images.githubusercontent.com/11597044/204676275-d00b0203-2b00-4132-81e5-456f7dfadb84.png) 
![image](https://user-images.githubusercontent.com/11597044/204679085-f7e95808-f27e-49f8-95da-2124172706b9.png)
---
![image](https://user-images.githubusercontent.com/11597044/204676388-90814986-a2ff-4440-aeb6-9216a8b24f99.png)
![image](https://user-images.githubusercontent.com/11597044/204679170-414a897a-edf3-4bc9-875a-49587123a8ad.png)
---
![image](https://user-images.githubusercontent.com/11597044/204676471-92b0abbb-a4fd-4e51-9bb0-769172dbe16b.png)
![image](https://user-images.githubusercontent.com/11597044/204679306-372d8026-9ddc-4874-b7f6-6af7fc656ddf.png)
