### PR TITLE
LibJS: Fix two assignment problems

### DIFF
--- a/Userland/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
+++ b/Userland/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
@@ -6,7 +6,7 @@ test("assignment to function call", () => {
 });
 
 test("assignment to function call in strict mode", () => {
-    expect("'use strict'; foo() = 'foo'").not.toEval();
+    expect("'use strict'; foo() = 'foo'").toEval();
 });
 
 test("assignment to inline function call", () => {
@@ -29,4 +29,27 @@ test("assignment to invalid LHS is syntax error", () => {
     expect("1 >>= 1").not.toEval();
     expect("1 >>>= 1").not.toEval();
     expect("1 = 1").not.toEval();
+    expect("1 &&= 1").not.toEval();
+    expect("1 ||= 1").not.toEval();
+    expect("1 ??= 1").not.toEval();
+});
+
+test("assignment to call LHS is only syntax error for new operators", () => {
+    expect("f() += 1").toEval();
+    expect("f() -= 1").toEval();
+    expect("f() *= 1").toEval();
+    expect("f() /= 1").toEval();
+    expect("f() %= 1").toEval();
+    expect("f() **= 1").toEval();
+    expect("f() &= 1").toEval();
+    expect("f() |= 1").toEval();
+    expect("f() ^= 1").toEval();
+    expect("f() <<= 1").toEval();
+    expect("f() >>= 1").toEval();
+    expect("f() >>>= 1").toEval();
+    expect("f() = 1").toEval();
+
+    expect("f() &&= 1").not.toEval();
+    expect("f() ||= 1").not.toEval();
+    expect("f() ??= 1").not.toEval();
 });

--- a/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
@@ -98,6 +98,16 @@ describe("special left hand sides", () => {
             eval("for (f() in [0]) { expect().fail() }");
         }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");
     });
+
+    test("Cannot change constant declaration in body", () => {
+        const vals = [];
+        for (const v in [1, 2]) {
+            expect(() => v++).toThrowWithMessage(TypeError, "Invalid assignment to const variable");
+            vals.push(v);
+        }
+
+        expect(vals).toEqual(["0", "1"]);
+    });
 });
 
 test("remove properties while iterating", () => {

--- a/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
@@ -142,4 +142,14 @@ describe("special left hand sides", () => {
             eval("for (f() of [0]) { expect().fail() }");
         }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");
     });
+
+    test("Cannot change constant declaration in body", () => {
+        const vals = [];
+        for (const v of [1, 2]) {
+            expect(() => v++).toThrowWithMessage(TypeError, "Invalid assignment to const variable");
+            vals.push(v);
+        }
+
+        expect(vals).toEqual([1, 2]);
+    });
 });


### PR DESCRIPTION
The web reality one was discussed by ECMA in https://github.com/tc39/ecma262/pull/2193 but does seem to be stuck/forgotten.

Since this is a web reality we should just allow this unfortunately.
Note that this doesn't break any test262 tests as this is explicitly not tested (because the big engines do allow it as well)

This fixes 5 :heavy_check_mark: test262 tests