### PR TITLE
LibCore: Add support for ReadonlyBytes to MemoryStream

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto bufstream_result = Core::Stream::MemoryStream::construct({ const_cast<uint8_t*>(data), size });
+    auto bufstream_result = Core::Stream::MemoryStream::construct({ data, size });
     if (bufstream_result.is_error()) {
         dbgln("MemoryStream::construct() failed.");
         return 1;

--- a/Meta/Lagom/Fuzzers/FuzzTar.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTar.cpp
@@ -12,8 +12,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    // FIXME: Create a ReadonlyBytes variant of Core::Stream::MemoryStream.
-    auto input_stream_or_error = Core::Stream::MemoryStream::construct(Bytes { const_cast<uint8_t*>(data), size });
+    auto input_stream_or_error = Core::Stream::MemoryStream::construct({ data, size });
 
     if (input_stream_or_error.is_error())
         return 0;

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -78,8 +78,7 @@ static Optional<ByteBuffer> handle_content_encoding(ByteBuffer const& buf, Strin
     } else if (content_encoding == "br") {
         dbgln_if(JOB_DEBUG, "Job::handle_content_encoding: buf is brotli compressed!");
 
-        // FIXME: MemoryStream is both read and write, however we only need the read part here
-        auto bufstream_result = Core::Stream::MemoryStream::construct({ const_cast<u8*>(buf.data()), buf.size() });
+        auto bufstream_result = Core::Stream::MemoryStream::construct({ buf.data(), buf.size() });
         if (bufstream_result.is_error()) {
             dbgln("Job::handle_content_encoding: MemoryStream::construct() failed.");
             return {};


### PR DESCRIPTION
This fixes two FIXMEs (and one more that would be upcoming in the next set of `Core::Stream` changes). :^)