### PR TITLE
CI: Only run `wasm` action on PRs with related changes

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,5 +1,12 @@
 name: Build Wasm Modules
-on: [ push, pull_request ]
+on:
+  pull_request:
+    paths:
+      - "AK/**"
+      - "Userland/Libraries/LibJS/**"
+      - "Userland/Libraries/LibWasm/**"
+      - "Userland/Libraries/LibWeb/**"
+  push:
 
 env:
   SERENITY_SOURCE_DIR: ${{ github.workspace }}


### PR DESCRIPTION
This prevents us from using CI minutes on changes completely unrelated to `wasm`, `libjs` and `libweb`.