### PR TITLE
CI: Prevent build & tests when only modifying `README.md` and/or docs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,7 +1,16 @@
 name: Build, lint, and test
 
-on: [push, pull_request]
-
+on:
+  pull_request:
+    paths-ignore:
+      - "**/azure-pipelines.yml"
+      - "**/README.md"
+      - "Documentation/**"
+  push:
+    paths-ignore:
+      - "**/azure-pipelines.yml"
+      - "**/README.md"
+      - "Documentation/**"
 env:
   # Don't mix these up!
   # runner.workspace = /home/runner/work/serenity

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,11 @@ trigger:
   branches:
     include:
     - master
+  paths:
+    exclude:
+    - .github/
+    - README.md
+    - Documentation/*
 
 stages:
   - stage: Lagom


### PR DESCRIPTION
This commit prevents us from doing a complete build and running tests when only the `README.md` and/or `Documentation/**` files are modified (for example when adding someone to the contributors list) :^)