### PR TITLE
LibJS: Prevent allocating intrinsic objects in constructors

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Map.h
+++ b/Userland/Libraries/LibJS/Runtime/Map.h
@@ -19,9 +19,6 @@ namespace JS {
 class Map : public Object {
     JS_OBJECT(Map, Object);
 
-    // NOTE: This awkwardness is due to Set using a Map internally.
-    friend class Set;
-
 public:
     static Map* create(Realm&);
 

--- a/Userland/Libraries/LibJS/Runtime/Set.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Set.cpp
@@ -15,14 +15,18 @@ Set* Set::create(Realm& realm)
 
 Set::Set(Object& prototype)
     : Object(prototype)
-    , m_values(*prototype.shape().realm().intrinsics().map_prototype())
 {
+}
+
+void Set::initialize(Realm& realm)
+{
+    m_values = Map::create(realm);
 }
 
 void Set::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    static_cast<Object&>(m_values).visit_edges(visitor);
+    visitor.visit(m_values);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Set.h
+++ b/Userland/Libraries/LibJS/Runtime/Set.h
@@ -19,28 +19,29 @@ class Set : public Object {
 public:
     static Set* create(Realm&);
 
+    virtual void initialize(Realm&) override;
     virtual ~Set() override = default;
 
     // NOTE: Unlike what the spec says, we implement Sets using an underlying map,
     //       so all the functions below do not directly implement the operations as
     //       defined by the specification.
 
-    void set_clear() { m_values.map_clear(); }
-    bool set_remove(Value const& value) { return m_values.map_remove(value); }
-    bool set_has(Value const& key) const { return m_values.map_has(key); }
-    void set_add(Value const& key) { m_values.map_set(key, js_undefined()); }
-    size_t set_size() const { return m_values.map_size(); }
+    void set_clear() { m_values->map_clear(); }
+    bool set_remove(Value const& value) { return m_values->map_remove(value); }
+    bool set_has(Value const& key) const { return m_values->map_has(key); }
+    void set_add(Value const& key) { m_values->map_set(key, js_undefined()); }
+    size_t set_size() const { return m_values->map_size(); }
 
-    auto begin() const { return m_values.begin(); }
-    auto begin() { return m_values.begin(); }
-    auto end() const { return m_values.end(); }
+    auto begin() const { return const_cast<Map const&>(*m_values).begin(); }
+    auto begin() { return m_values->begin(); }
+    auto end() const { return m_values->end(); }
 
 private:
     explicit Set(Object& prototype);
 
     virtual void visit_edges(Visitor& visitor) override;
 
-    Map m_values;
+    GCPtr<Map> m_values;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -462,8 +462,8 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
         return vm().names.ClassName.as_string();                                                                                 \
     }                                                                                                                            \
                                                                                                                                  \
-    PrototypeName::PrototypeName(Realm& realm)                                                                                   \
-        : Object(*realm.intrinsics().typed_array_prototype())                                                                    \
+    PrototypeName::PrototypeName(Object& prototype)                                                                              \
+        : Object(prototype)                                                                                                      \
     {                                                                                                                            \
     }                                                                                                                            \
                                                                                                                                  \
@@ -478,8 +478,8 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
         define_direct_property(vm.names.BYTES_PER_ELEMENT, Value((i32)sizeof(Type)), 0);                                         \
     }                                                                                                                            \
                                                                                                                                  \
-    ConstructorName::ConstructorName(Realm& realm)                                                                               \
-        : TypedArrayConstructor(realm.vm().names.ClassName.as_string(), *realm.intrinsics().typed_array_constructor())           \
+    ConstructorName::ConstructorName(Realm& realm, Object& prototype)                                                            \
+        : TypedArrayConstructor(realm.vm().names.ClassName.as_string(), prototype)                                               \
     {                                                                                                                            \
     }                                                                                                                            \
                                                                                                                                  \

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -484,7 +484,7 @@ ThrowCompletionOr<double> compare_typed_array_elements(VM&, Value x, Value y, Fu
         virtual ~PrototypeName() override;                                                  \
                                                                                             \
     private:                                                                                \
-        PrototypeName(Realm&);                                                              \
+        PrototypeName(Object& prototype);                                                   \
     };                                                                                      \
     class ConstructorName final : public TypedArrayConstructor {                            \
         JS_OBJECT(ConstructorName, TypedArrayConstructor);                                  \
@@ -497,7 +497,7 @@ ThrowCompletionOr<double> compare_typed_array_elements(VM&, Value x, Value y, Fu
         virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;  \
                                                                                             \
     private:                                                                                \
-        explicit ConstructorName(Realm&);                                                   \
+        explicit ConstructorName(Realm&, Object& prototype);                                \
         virtual bool has_constructor() const override                                       \
         {                                                                                   \
             return true;                                                                    \


### PR DESCRIPTION
Caught by `test-js -g`. We can't allocate in JS constructors because that may trigger GC to run, which will try to collect the object currently being constructed.