### PR TITLE
LibWeb: Add @@toStringTag to platform object prototypes

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2574,6 +2574,8 @@ void @prototype_class@::initialize(JS::Realm& realm)
     }
 
     generator.append(R"~~~(
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "@name@"), JS::Attribute::Configurable);
+
     Object::initialize(realm);
 }
 )~~~");


### PR DESCRIPTION
This was forgotten to be added in the LibWeb GC conversion. This caused some brand checks to fail in skribbl.io's JavaScript and thus caused unexpected exceptions.