### PR TITLE
WebDriver: Partially implement `/session/{id}/print` endpoint

### DIFF
--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -53,5 +53,5 @@ endpoint WebDriverClient {
     send_alert_text(JsonValue payload) => (Web::WebDriver::Response response)
     take_screenshot() => (Web::WebDriver::Response response)
     take_element_screenshot(String element_id) => (Web::WebDriver::Response response)
-    print_page() => (Web::WebDriver::Response response)
+    print_page(JsonValue payload) => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -88,7 +88,7 @@ private:
     virtual Messages::WebDriverClient::SendAlertTextResponse send_alert_text(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::TakeScreenshotResponse take_screenshot() override;
     virtual Messages::WebDriverClient::TakeElementScreenshotResponse take_element_screenshot(String const& element_id) override;
-    virtual Messages::WebDriverClient::PrintPageResponse print_page() override;
+    virtual Messages::WebDriverClient::PrintPageResponse print_page(JsonValue const& payload) override;
 
     ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();
     ErrorOr<void, Web::WebDriver::Error> handle_any_user_prompts();

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -648,11 +648,11 @@ Web::WebDriver::Response Client::take_element_screenshot(Web::WebDriver::Paramet
 
 // 18.1 Print Page, https://w3c.github.io/webdriver/#dfn-print-page
 // POST /session/{session id}/print
-Web::WebDriver::Response Client::print_page(Web::WebDriver::Parameters parameters, JsonValue)
+Web::WebDriver::Response Client::print_page(Web::WebDriver::Parameters parameters, JsonValue payload)
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session id>/print");
     auto* session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().print_page();
+    return session->web_content_connection().print_page(payload);
 }
 
 }


### PR DESCRIPTION
Partially implements task in issue [#15551](https://github.com/SerenityOS/serenity/issues/15551).
Did not implement steps 23-27 of Print Page because we potentially need an external library to encode data as a PDF
([https://w3c.github.io/webdriver/#print-page](url)). Please let me know if there is existing functionality for this.