### PR TITLE
WebContent+WebDriver: Implement `POST /session/{session_id}/window/new`

### DIFF
--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -200,7 +200,8 @@ public:
     // https://html.spec.whatwg.org/multipage/input.html#show-the-picker,-if-applicable
     virtual void page_did_request_file_picker(WeakPtr<DOM::EventTarget>, [[maybe_unused]] bool multiple) {};
 
-protected:
+    virtual NonnullOwnPtr<PageClient> new_client_from_current() = 0;
+
     virtual ~PageClient() = default;
 };
 

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -65,6 +65,7 @@ static constexpr auto s_webdriver_endpoints = Array {
     ROUTE(DELETE, "/session/:session_id/window"sv, close_window),
     ROUTE(POST, "/session/:session_id/window"sv, switch_to_window),
     ROUTE(GET, "/session/:session_id/window/handles"sv, get_window_handles),
+    ROUTE(POST, "/session/:session_id/window/new"sv, new_window),
     ROUTE(GET, "/session/:session_id/window/rect"sv, get_window_rect),
     ROUTE(POST, "/session/:session_id/window/rect"sv, set_window_rect),
     ROUTE(POST, "/session/:session_id/window/maximize"sv, maximize_window),

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -51,6 +51,7 @@ public:
     virtual Response close_window(Parameters parameters, JsonValue payload) = 0;
     virtual Response switch_to_window(Parameters parameters, JsonValue payload) = 0;
     virtual Response get_window_handles(Parameters parameters, JsonValue payload) = 0;
+    virtual Response new_window(Parameters parameters, JsonValue payload) = 0;
     virtual Response get_window_rect(Parameters parameters, JsonValue payload) = 0;
     virtual Response set_window_rect(Parameters parameters, JsonValue payload) = 0;
     virtual Response maximize_window(Parameters parameters, JsonValue payload) = 0;

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -378,4 +378,9 @@ void PageHost::request_file(NonnullRefPtr<Web::FileRequest>& file_request)
     m_client.request_file(file_request);
 }
 
+NonnullOwnPtr<Web::PageClient> PageHost::new_client_from_current()
+{
+    return PageHost::create(m_client);
+}
+
 }

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -98,6 +98,7 @@ private:
     virtual void page_did_update_cookie(Web::Cookie::Cookie) override;
     virtual void page_did_update_resource_count(i32) override;
     virtual void request_file(NonnullRefPtr<Web::FileRequest>&) override;
+    virtual NonnullOwnPtr<PageClient> new_client_from_current() override;
 
     explicit PageHost(ConnectionFromClient&);
 

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -19,6 +19,7 @@ endpoint WebDriverClient {
     close_window() => (Web::WebDriver::Response response)
     switch_to_window(JsonValue payload) => (Web::WebDriver::Response response)
     get_window_handles() => (Web::WebDriver::Response response)
+    new_window(JsonValue payload) => (Web::WebDriver::Response response)
     get_window_rect() => (Web::WebDriver::Response response)
     set_window_rect(JsonValue payload) => (Web::WebDriver::Response response)
     maximize_window() => (Web::WebDriver::Response response)

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -54,6 +54,7 @@ private:
     virtual Messages::WebDriverClient::CloseWindowResponse close_window() override;
     virtual Messages::WebDriverClient::SwitchToWindowResponse switch_to_window(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::GetWindowHandlesResponse get_window_handles() override;
+    virtual Messages::WebDriverClient::NewWindowResponse new_window(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::GetWindowRectResponse get_window_rect() override;
     virtual Messages::WebDriverClient::SetWindowRectResponse set_window_rect(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::MaximizeWindowResponse maximize_window() override;
@@ -125,6 +126,7 @@ private:
     struct Window {
         DeprecatedString handle;
         bool is_open { false };
+        NonnullOwnPtr<Web::PageClient> client;
     };
     HashMap<DeprecatedString, Window> m_windows;
     DeprecatedString m_current_window_handle;

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -344,6 +344,14 @@ Web::WebDriver::Response Client::get_window_handles(Web::WebDriver::Parameters p
     return session->web_content_connection().get_window_handles();
 }
 
+// 11.5 New Window, https://w3c.github.io/webdriver/#dfn-new-window
+Web::WebDriver::Response Client::new_window(Web::WebDriver::Parameters parameters, JsonValue payload)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/window/new");
+    auto* session = TRY(find_session_with_id(parameters[0]));
+    return session->web_content_connection().new_window(payload);
+}
+
 // 11.8.1 Get Window Rect, https://w3c.github.io/webdriver/#dfn-get-window-rect
 // GET /session/{session id}/window/rect
 Web::WebDriver::Response Client::get_window_rect(Web::WebDriver::Parameters parameters, JsonValue)

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -54,6 +54,7 @@ private:
     virtual Web::WebDriver::Response close_window(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response switch_to_window(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response get_window_handles(Web::WebDriver::Parameters parameters, JsonValue payload) override;
+    virtual Web::WebDriver::Response new_window(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response get_window_rect(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response set_window_rect(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response maximize_window(Web::WebDriver::Parameters parameters, JsonValue payload) override;

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -243,6 +243,11 @@ public:
         request->on_file_request_finish(file);
     }
 
+    NonnullOwnPtr<Web::PageClient> new_client_from_current() override
+    {
+        return HeadlessBrowserPageClient::create();
+    }
+
 private:
     HeadlessBrowserPageClient()
         : m_page(make<Web::Page>(*this))


### PR DESCRIPTION
Implement the endpoint for creating new windows. Right now, this simply creates a new `PageClient` from the initial `PageClient` and adds it to the map of handles to windows. This adds another endpoint for #15551.