### PR TITLE
LibGfx: Fix some more antialiased line off-by-ones 

### DIFF
--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -770,29 +770,4 @@ void AntiAliasingPainter::stroke_segment_intersection(FloatPoint const& current_
     fill_path(intersection_edge_path, color);
 }
 
-FloatQuad AntiAliasingPainter::build_rotated_rectangle(FloatPoint const& direction, float width)
-{
-    // Rotates a rectangle around 0,0
-    double half_size = width / 2;
-    double radian = atan2(direction.y(), direction.x());
-    if (radian < 0) {
-        radian += (2 * M_PI);
-    }
-    // Rotated by: (xcosθ−ysinθ ,xsinθ+ycosθ)
-    // p1     p2
-    //
-    //   x,y
-    //
-    // p4     p3
-    double cos_radian = cos(radian);
-    double sin_radian = sin(radian);
-
-    // FIXME: Performing the rotation with AffineTransform::rotate_quad seems to generate more glitches at the edges than rotating manually
-    return FloatQuad(
-        { ((-half_size * cos_radian) - (-half_size * sin_radian)), ((-half_size * sin_radian) + (-half_size * cos_radian)) },
-        { ((half_size * cos_radian) - (-half_size * sin_radian)), ((half_size * sin_radian) + (-half_size * cos_radian)) },
-        { ((half_size * cos_radian)) - (half_size * sin_radian), ((half_size * sin_radian) + (half_size * cos_radian)) },
-        { ((-half_size * cos_radian) - (half_size * sin_radian)), ((-half_size * sin_radian) + (half_size * cos_radian)) });
-}
-
 }

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -687,15 +687,18 @@ void AntiAliasingPainter::fill_rect_with_rounded_corners(IntRect const& a_rect, 
 
 void AntiAliasingPainter::stroke_segment_intersection(FloatPoint const& current_line_a, FloatPoint const& current_line_b, FloatLine const& previous_line, Color color, float thickness)
 {
-    // starting point of the current line is where the last line ended... this is an intersection
+    // FIXME: This is currently drawn in slightly the wrong place most of the time.
+    // FIXME: This is sometimes drawn when the intersection would not be visible anyway.
+
+    // Starting point of the current line is where the last line ended... this is an intersection.
     auto intersection = current_line_a;
     auto previous_line_b = (previous_line.a());
 
-    // if both are straight lines we can simply draw a rectangle at the intersection
+    // If both are straight lines we can simply draw a rectangle at the intersection.
     if ((current_line_a.x() == current_line_b.x() || current_line_a.y() == current_line_b.y()) && (previous_line.a().x() == previous_line.b().x() || previous_line.a().y() == previous_line.b().y())) {
         intersection = m_transform.map(current_line_a);
 
-        // adjust coordinates to handle rounding offsets
+        // Adjust coordinates to handle rounding offsets.
         auto intersection_rect = IntSize(thickness, thickness);
         float drawing_edge_offset = fmodf(thickness, 2.0f) < 0.5f && thickness > 3 ? 1 : 0;
         auto integer_part = [](float x) { return floorf(x); };
@@ -720,20 +723,20 @@ void AntiAliasingPainter::stroke_segment_intersection(FloatPoint const& current_
     float scale_to_move_current = (thickness / 2) / intersection.distance_from(current_line_b);
     float scale_to_move_previous = (thickness / 2) / intersection.distance_from(previous_line_b);
 
-    // move the point on the line by half of the thickness
+    // Move the point on the line by half of the thickness.
     double offset_current_edge_x = scale_to_move_current * (current_line_b.x() - intersection.x());
     double offset_current_edge_y = scale_to_move_current * (current_line_b.y() - intersection.y());
     double offset_prev_edge_x = scale_to_move_previous * (previous_line_b.x() - intersection.x());
     double offset_prev_edge_y = scale_to_move_previous * (previous_line_b.y() - intersection.y());
 
-    // rotate the point by 90 and 270 degrees to get the points for both edges
+    // Rotate the point by 90 and 270 degrees to get the points for both edges.
     double rad_90deg = 0.5 * M_PI;
     FloatPoint current_rotated_90deg = { (offset_current_edge_x * cos(rad_90deg) - offset_current_edge_y * sin(rad_90deg)), (offset_current_edge_x * sin(rad_90deg) + offset_current_edge_y * cos(rad_90deg)) };
     FloatPoint current_rotated_270deg = intersection - current_rotated_90deg;
     FloatPoint previous_rotated_90deg = { (offset_prev_edge_x * cos(rad_90deg) - offset_prev_edge_y * sin(rad_90deg)), (offset_prev_edge_x * sin(rad_90deg) + offset_prev_edge_y * cos(rad_90deg)) };
     FloatPoint previous_rotated_270deg = intersection - previous_rotated_90deg;
 
-    // translate coordinates to the intersection point
+    // Translate coordinates to the intersection point.
     current_rotated_90deg += intersection;
     previous_rotated_90deg += intersection;
 
@@ -767,15 +770,15 @@ void AntiAliasingPainter::stroke_segment_intersection(FloatPoint const& current_
     fill_path(intersection_edge_path, color);
 }
 
-// rotates a rectangle around 0,0
 FloatQuad AntiAliasingPainter::build_rotated_rectangle(FloatPoint const& direction, float width)
 {
+    // Rotates a rectangle around 0,0
     double half_size = width / 2;
     double radian = atan2(direction.y(), direction.x());
     if (radian < 0) {
         radian += (2 * M_PI);
     }
-    // rotated by: (xcosθ−ysinθ ,xsinθ+ycosθ)
+    // Rotated by: (xcosθ−ysinθ ,xsinθ+ycosθ)
     // p1     p2
     //
     //   x,y

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -19,7 +19,7 @@
 namespace Gfx {
 
 template<AntiAliasingPainter::FixmeEnableHacksForBetterPathPainting path_hacks>
-void AntiAliasingPainter::draw_anti_aliased_line(FloatPoint actual_from, FloatPoint actual_to, Color color, float thickness, Painter::LineStyle style, Color)
+void AntiAliasingPainter::draw_anti_aliased_line(FloatPoint actual_from, FloatPoint actual_to, Color color, float thickness, Painter::LineStyle style, Color, LineLengthMode line_length_mode)
 {
     // FIXME: Implement this :P
     VERIFY(style == Painter::LineStyle::Solid);
@@ -45,7 +45,7 @@ void AntiAliasingPainter::draw_anti_aliased_line(FloatPoint actual_from, FloatPo
     auto mapped_from = m_transform.map(actual_from);
     auto mapped_to = m_transform.map(actual_to);
     auto distance = mapped_to.distance_from(mapped_from);
-    auto length = distance + 1;
+    auto length = distance + (line_length_mode == LineLengthMode::PointToPoint);
 
     // Axis-aligned lines:
     if (mapped_from.y() == mapped_to.y()) {
@@ -107,7 +107,7 @@ void AntiAliasingPainter::draw_anti_aliased_line(FloatPoint actual_from, FloatPo
     float x_error = 0;
     float x_error_per_y = x_gradient - x_step;
 
-    auto y_offset = int_thickness;
+    auto y_offset = int_thickness + 1;
     auto x_offset = int(x_gradient * y_offset);
     int const line_start_x = mapped_from.x();
     int const line_start_y = mapped_from.y();
@@ -154,9 +154,9 @@ void AntiAliasingPainter::draw_anti_aliased_line(FloatPoint actual_from, FloatPo
     }
 }
 
-void AntiAliasingPainter::draw_line_for_path(FloatPoint const& actual_from, FloatPoint const& actual_to, Color color, float thickness, Painter::LineStyle style, Color alternate_color)
+void AntiAliasingPainter::draw_line_for_path(FloatPoint const& actual_from, FloatPoint const& actual_to, Color color, float thickness, Painter::LineStyle style, Color alternate_color, LineLengthMode line_length_mode)
 {
-    draw_anti_aliased_line<FixmeEnableHacksForBetterPathPainting::Yes>(actual_from, actual_to, color, thickness, style, alternate_color);
+    draw_anti_aliased_line<FixmeEnableHacksForBetterPathPainting::Yes>(actual_from, actual_to, color, thickness, style, alternate_color, line_length_mode);
 }
 
 void AntiAliasingPainter::draw_dotted_line(IntPoint point1, IntPoint point2, Color color, int thickness)
@@ -201,11 +201,11 @@ void AntiAliasingPainter::draw_dotted_line(IntPoint point1, IntPoint point2, Col
     }
 }
 
-void AntiAliasingPainter::draw_line(FloatPoint const& actual_from, FloatPoint const& actual_to, Color color, float thickness, Painter::LineStyle style, Color alternate_color)
+void AntiAliasingPainter::draw_line(FloatPoint const& actual_from, FloatPoint const& actual_to, Color color, float thickness, Painter::LineStyle style, Color alternate_color, LineLengthMode line_length_mode)
 {
     if (style == Painter::LineStyle::Dotted)
         return draw_dotted_line(actual_from.to_rounded<int>(), actual_to.to_rounded<int>(), color, static_cast<int>(round(thickness)));
-    draw_anti_aliased_line<FixmeEnableHacksForBetterPathPainting::No>(actual_from, actual_to, color, thickness, style, alternate_color);
+    draw_anti_aliased_line<FixmeEnableHacksForBetterPathPainting::No>(actual_from, actual_to, color, thickness, style, alternate_color, line_length_mode);
 }
 
 void AntiAliasingPainter::fill_path(Path& path, Color color, Painter::WindingRule rule)

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -19,8 +19,20 @@ public:
     {
     }
 
-    void draw_line(FloatPoint const&, FloatPoint const&, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid, Color alternate_color = Color::Transparent);
-    void draw_line_for_path(FloatPoint const&, FloatPoint const&, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid, Color alternate_color = Color::Transparent);
+    enum class LineLengthMode {
+        // E.g. A line from 0,1 -> 2,1 is 3px long
+        PointToPoint,
+        // E.g. A line from 0,1 -> 2,1 is 2px long
+        Distance
+    };
+
+    void draw_line(FloatPoint const&, FloatPoint const&, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid, Color alternate_color = Color::Transparent, LineLengthMode line_length_mode = LineLengthMode::PointToPoint);
+    void draw_line_for_path(FloatPoint const&, FloatPoint const&, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid, Color alternate_color = Color::Transparent, LineLengthMode line_length_mode = LineLengthMode::PointToPoint);
+    void draw_line_for_fill_path(FloatPoint const& from, FloatPoint const& to, Color color, float thickness = 1)
+    {
+        draw_line_for_path(from, to, color, thickness, Painter::LineStyle::Solid, Color {}, LineLengthMode::Distance);
+    }
+
     void fill_path(Path&, Color, Painter::WindingRule rule = Painter::WindingRule::Nonzero);
     void stroke_path(Path const&, Color, float thickness);
     void draw_quadratic_bezier_curve(FloatPoint const& control_point, FloatPoint const&, FloatPoint const&, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid);
@@ -81,8 +93,10 @@ private:
         Yes,
         No,
     };
+
     template<FixmeEnableHacksForBetterPathPainting path_hacks>
-    void draw_anti_aliased_line(FloatPoint, FloatPoint, Color, float thickness, Painter::LineStyle style, Color alternate_color);
+    void draw_anti_aliased_line(FloatPoint, FloatPoint, Color, float thickness, Painter::LineStyle style, Color alternate_color, LineLengthMode line_length_mode = LineLengthMode::PointToPoint);
+
     void stroke_segment_intersection(FloatPoint const& current_line_a, FloatPoint const& current_line_b, FloatLine const& previous_line, Color, float thickness);
 
     Painter& m_underlying_painter;

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -84,7 +84,6 @@ private:
     template<FixmeEnableHacksForBetterPathPainting path_hacks>
     void draw_anti_aliased_line(FloatPoint, FloatPoint, Color, float thickness, Painter::LineStyle style, Color alternate_color);
     void stroke_segment_intersection(FloatPoint const& current_line_a, FloatPoint const& current_line_b, FloatLine const& previous_line, Color, float thickness);
-    FloatQuad build_rotated_rectangle(FloatPoint const& direction, float width);
 
     Painter& m_underlying_painter;
     AffineTransform m_transform;

--- a/Userland/Libraries/LibGfx/FillPathImplementation.h
+++ b/Userland/Libraries/LibGfx/FillPathImplementation.h
@@ -47,8 +47,8 @@ void fill_path(Painter& painter, Path const& path, Color color, Gfx::Painter::Wi
     using GridCoordinateType = Conditional<fill_path_mode == FillPathMode::PlaceOnIntGrid, int, float>;
     using PointType = Point<GridCoordinateType>;
     auto draw_line = [&](auto... args) {
-        if constexpr (requires { painter.draw_line_for_path(args...); })
-            painter.draw_line_for_path(args...);
+        if constexpr (requires { painter.draw_line_for_fill_path(args...); })
+            painter.draw_line_for_fill_path(args...);
         else
             painter.draw_line(args...);
     };


### PR DESCRIPTION
Well this is embarrassing :^(

It seems my last PR #16254 slightly worsened filled SVG rendering (particularly for small icons). It seems like most things expect the line length to be the point-to-point distance, but the fill_path() expects it to be the actual distance... or my brain is fried. 
