### PR TITLE
LibGUI: Add shortcut for inserting new line in TextEditor

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -246,6 +246,27 @@ private:
     TextRange m_range;
 };
 
+class InsertLineCommand : public TextDocumentUndoCommand {
+public:
+    enum class InsertPosition {
+        Above,
+        Below,
+    };
+
+    InsertLineCommand(TextDocument&, TextPosition, DeprecatedString&&, InsertPosition);
+    virtual ~InsertLineCommand() = default;
+    virtual void undo() override;
+    virtual void redo() override;
+    virtual DeprecatedString action_text() const override;
+
+private:
+    size_t compute_line_number() const;
+
+    TextPosition m_cursor;
+    DeprecatedString m_text;
+    InsertPosition m_pos;
+};
+
 class ReplaceAllTextCommand final : public GUI::TextDocumentUndoCommand {
 
 public:

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -890,6 +890,17 @@ void TextEditor::keydown_event(KeyEvent& event)
         try_update_autocomplete();
     } };
 
+    if (is_multi_line() && !event.alt() && event.ctrl() && event.key() == KeyCode::Key_Return) {
+        if (!is_editable())
+            return;
+
+        size_t indent_length = current_line().leading_spaces();
+        DeprecatedString indent = current_line().to_utf8().substring(0, indent_length);
+        auto insert_pos = event.shift() ? InsertLineCommand::InsertPosition::Above : InsertLineCommand::InsertPosition::Below;
+        execute<InsertLineCommand>(m_cursor, move(indent), insert_pos);
+        return;
+    }
+
     if (is_multi_line() && !event.shift() && !event.alt() && event.ctrl() && event.key() == KeyCode::Key_Space) {
         if (m_autocomplete_provider) {
             try_show_autocomplete(UserRequestedAutocomplete::Yes);


### PR DESCRIPTION
This adds shortcut for inserting a new empty indented line above/below current cursor position.

- `<Ctrl-Return>` for inserting line below.
- `<Ctrl-Shift-Return>` for inserting line above.

https://user-images.githubusercontent.com/57862491/205250288-c1174995-2863-4dda-8ff5-0eaf74e6764f.mp4

