### PR TITLE
Kernel: Allow opening some device nodes sparingly for jailed processes

### DIFF
--- a/Base/usr/share/man/man7/Mitigations.md
+++ b/Base/usr/share/man/man7/Mitigations.md
@@ -103,6 +103,8 @@ Special restrictions on filesystem also apply:
 - Read accesses is forbidden by default to all nodes in `/sys/kernel` directory, except for:
     `df`, `interrupts`, `keymap`, `memstat`, `processes`, `stats` and `uptime`.
 - Write access is forbidden to kernel variables (which are located in `/sys/kernel/variables`).
+- Open access is forbidden to all device nodes except for `/dev/full`, `/dev/null`, `/dev/zero`, `/dev/random` and various
+    other TTY/PTY devices (not including Kernel virtual consoles).
 
 It was first added in the following [commit](https://github.com/SerenityOS/serenity/commit/5e062414c11df31ed595c363990005eef00fa263),
 for kernel support, and the following commits added basic userspace utilities:

--- a/Kernel/Bus/VirtIO/ConsolePort.cpp
+++ b/Kernel/Bus/VirtIO/ConsolePort.cpp
@@ -166,7 +166,7 @@ ErrorOr<NonnullLockRefPtr<OpenFileDescription>> ConsolePort::open(int options)
     if (!m_open)
         m_console.send_open_control_message(m_port, true);
 
-    return File::open(options);
+    return Device::open(options);
 }
 
 }

--- a/Kernel/Devices/ConsoleDevice.h
+++ b/Kernel/Devices/ConsoleDevice.h
@@ -28,6 +28,8 @@ public:
     virtual ErrorOr<size_t> read(OpenFileDescription&, u64, Kernel::UserOrKernelBuffer&, size_t) override;
     virtual ErrorOr<size_t> write(OpenFileDescription&, u64, Kernel::UserOrKernelBuffer const&, size_t) override;
     virtual StringView class_name() const override { return "Console"sv; }
+    // ^Device
+    virtual bool is_openable_by_jailed_processes() const override { return true; }
 
     void put_char(char);
 

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -43,6 +43,7 @@ public:
     MinorNumber minor() const { return m_minor; }
 
     virtual ErrorOr<NonnullOwnPtr<KString>> pseudo_path(OpenFileDescription const&) const override;
+    virtual ErrorOr<NonnullLockRefPtr<OpenFileDescription>> open(int options) override;
 
     UserID uid() const { return m_uid; }
     GroupID gid() const { return m_gid; }
@@ -50,6 +51,7 @@ public:
     virtual bool is_device() const override { return true; }
     virtual void will_be_destroyed() override;
     virtual void after_inserting();
+    virtual bool is_openable_by_jailed_processes() const { return false; }
     void process_next_queued_request(Badge<AsyncDeviceRequest>, AsyncDeviceRequest const&);
 
     template<typename AsyncRequestType, typename... Args>

--- a/Kernel/Devices/FullDevice.h
+++ b/Kernel/Devices/FullDevice.h
@@ -20,6 +20,9 @@ public:
 private:
     FullDevice();
 
+    // ^Device
+    virtual bool is_openable_by_jailed_processes() const override { return true; }
+
     // ^CharacterDevice
     virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) override;

--- a/Kernel/Devices/KCOVDevice.cpp
+++ b/Kernel/Devices/KCOVDevice.cpp
@@ -74,7 +74,7 @@ ErrorOr<NonnullLockRefPtr<OpenFileDescription>> KCOVDevice::open(int options)
     kcov_instance->set_state(KCOVInstance::OPENED);
     proc_instance->set(pid, kcov_instance);
 
-    return File::open(options);
+    return Device::open(options);
 }
 
 ErrorOr<void> KCOVDevice::ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg)

--- a/Kernel/Devices/NullDevice.h
+++ b/Kernel/Devices/NullDevice.h
@@ -20,6 +20,10 @@ public:
 
 private:
     NullDevice();
+
+    // ^Device
+    virtual bool is_openable_by_jailed_processes() const override { return true; }
+
     // ^CharacterDevice
     virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) override;

--- a/Kernel/Devices/RandomDevice.h
+++ b/Kernel/Devices/RandomDevice.h
@@ -20,6 +20,9 @@ public:
 private:
     RandomDevice();
 
+    // ^Device
+    virtual bool is_openable_by_jailed_processes() const override { return true; }
+
     // ^CharacterDevice
     virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) override;

--- a/Kernel/Devices/SelfTTYDevice.h
+++ b/Kernel/Devices/SelfTTYDevice.h
@@ -20,6 +20,9 @@ public:
 private:
     SelfTTYDevice();
 
+    // ^Device
+    virtual bool is_openable_by_jailed_processes() const override { return true; }
+
     // ^CharacterDevice
     virtual ErrorOr<NonnullLockRefPtr<OpenFileDescription>> open(int options) override;
     virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override;

--- a/Kernel/Devices/ZeroDevice.h
+++ b/Kernel/Devices/ZeroDevice.h
@@ -20,6 +20,9 @@ public:
 private:
     ZeroDevice();
 
+    // ^Device
+    virtual bool is_openable_by_jailed_processes() const override { return true; }
+
     // ^CharacterDevice
     virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) override;

--- a/Kernel/TTY/MasterPTY.h
+++ b/Kernel/TTY/MasterPTY.h
@@ -29,6 +29,10 @@ public:
 
 private:
     explicit MasterPTY(unsigned index, NonnullOwnPtr<DoubleBuffer> buffer);
+
+    // ^Device
+    virtual bool is_openable_by_jailed_processes() const override { return true; }
+
     // ^CharacterDevice
     virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) override;

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -26,6 +26,9 @@ public:
     virtual FileBlockerSet& blocker_set() override;
 
 private:
+    // ^Device
+    virtual bool is_openable_by_jailed_processes() const override { return true; }
+
     // ^TTY
     virtual ErrorOr<NonnullOwnPtr<KString>> pseudo_name() const override;
     virtual ErrorOr<size_t> on_tty_write(UserOrKernelBuffer const&, size_t) override;


### PR DESCRIPTION
Relies on #16029.
The ideas I wrote for applying more restrictions seem OK to me, so I picked the first one and wrote it down in a small patch. It makes sense to me that we will only restrict open access when we are in jail, because if for some reason someone wants to pass a device node file descriptor to a jailed process, we should allow that to happen.