### PR TITLE
LibWeb: Fix integer overflow in gradient painting

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -220,19 +220,19 @@ public:
         }
     }
 
-    Gfx::Color get_color(uint64_t index) const
+    Gfx::Color get_color(i64 index) const
     {
         return m_gradient_line_colors[clamp(index, 0, m_gradient_line_colors.size() - 1)];
     }
 
     Gfx::Color sample_color(float loc) const
     {
-        auto repeat_wrap_if_required = [&](uint64_t loc) {
+        auto repeat_wrap_if_required = [&](i64 loc) {
             if (m_repeating)
-                return (loc + m_start_offset) % m_gradient_line_colors.size();
+                return (loc + m_start_offset) % static_cast<i64>(m_gradient_line_colors.size());
             return loc;
         };
-        auto int_loc = static_cast<uint64_t>(floor(loc));
+        auto int_loc = static_cast<i64>(floor(loc));
         auto blend = loc - int_loc;
         auto color = get_color(repeat_wrap_if_required(int_loc));
         // Blend between the two neighbouring colors (this fixes some nasty aliasing issues at small angles)


### PR DESCRIPTION
This would cause rendering glitches at the edges of gradients (at certain angles).