### PR TITLE
LibCore: Stop WindowServer crashing when DisplaySettings saves and exits

### DIFF
--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -368,7 +368,7 @@ bool connect_to_inspector_server()
         return false;
     }
     auto inspector_server_path = maybe_path.value();
-    auto maybe_socket = Stream::LocalSocket::connect(inspector_server_path);
+    auto maybe_socket = Stream::LocalSocket::connect(inspector_server_path, Stream::PreventSIGPIPE::Yes);
     if (maybe_socket.is_error()) {
         dbgln("connect_to_inspector_server: Failed to connect: {}", maybe_socket.error());
         return false;

--- a/Userland/Libraries/LibCore/LocalServer.cpp
+++ b/Userland/Libraries/LibCore/LocalServer.cpp
@@ -133,7 +133,7 @@ ErrorOr<NonnullOwnPtr<Stream::LocalSocket>> LocalServer::accept()
     (void)fcntl(accepted_fd, F_SETFD, FD_CLOEXEC);
 #endif
 
-    return Stream::LocalSocket::adopt_fd(accepted_fd);
+    return Stream::LocalSocket::adopt_fd(accepted_fd, Stream::PreventSIGPIPE::Yes);
 }
 
 }


### PR DESCRIPTION
Since https://github.com/SerenityOS/serenity/commit/ce4b66e9088532fa90710bf3bf2cf267a356788e, failing to write to a socket will cause a `SIGPIPE` signal, which terminates the process. This happens when clicking `[OK]` in DisplaySettings, which causes the following:
1. Send IPC to WindowServer about new fonts and things.
2. WindowServer updates and queues up messages for every open window (including DisplaySettings) that there's a new set of fonts to use.
3. DisplaySettings exits before WindowServer's IPC messages are actually sent.
4. WindowServer tries to send the message to DisplaySettings, but it's gone. SIGPIPE!
5. All running GUI applications then lose the WindowServer connection and crash.

The solution is to pass the `MSG_NOSIGNAL` flag to the "read/write from socket" syscalls, to tell them not to send `SIGPIPE`. `EPIPE` is returned instead, which is handled more gracefully by disconnecting from that socket.

This PR implements this by adding `int read_flags` and `int write_flags` parameters to the `Core::Stream::Socket` constructor. These are then passed along to the syscalls, preventing the catastrophic explosions. This does mean that a Socket is locked to always passing the same flags when reading or writing. I think this is fine for what we need, and passing different flags to each call would make buffered sockets an unpredictable nightmare.