### PR TITLE
LibJS: Reduce flakes??

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTime.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTime.js
@@ -37,12 +37,15 @@ describe("correct behavior", () => {
             },
         };
 
-        const plainDateTime = Temporal.Now.plainDateTime(calendar, "UTC");
-        const plainDateTimeWithOffset = Temporal.Now.plainDateTime(calendar, timeZone);
+        const [plainDateTime, plainDateTimeWithOffset] = withinSameSecond(() => {
+            return [
+                Temporal.Now.plainDateTime(calendar, "UTC"),
+                Temporal.Now.plainDateTime(calendar, timeZone),
+            ];
+        });
 
         if (plainDateTime.year !== plainDateTimeWithOffset.year) return;
 
-        // Let's hope the duration between the above two lines is less than a second :^)
         const differenceSeconds =
             plainDateTimeToEpochSeconds(plainDateTimeWithOffset) -
             plainDateTimeToEpochSeconds(plainDateTime);
@@ -58,12 +61,15 @@ describe("correct behavior", () => {
             },
         };
 
-        const plainDateTime = Temporal.Now.plainDateTime(calendar, "UTC");
-        const plainDateTimeWithOffset = Temporal.Now.plainDateTime(calendar, timeZone);
+        const [plainDateTime, plainDateTimeWithOffset] = withinSameSecond(() => {
+            return [
+                Temporal.Now.plainDateTime(calendar, "UTC"),
+                Temporal.Now.plainDateTime(calendar, timeZone),
+            ];
+        });
 
         if (plainDateTime.year !== plainDateTimeWithOffset.year) return;
 
-        // Let's hope the duration between the above two lines is less than a second :^)
         const differenceSeconds =
             plainDateTimeToEpochSeconds(plainDateTimeWithOffset) -
             plainDateTimeToEpochSeconds(plainDateTime);

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTimeISO.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTimeISO.js
@@ -35,12 +35,12 @@ describe("correct behavior", () => {
             },
         };
 
-        const plainDateTime = Temporal.Now.plainDateTimeISO("UTC");
-        const plainDateTimeWithOffset = Temporal.Now.plainDateTimeISO(timeZone);
+        const [plainDateTime, plainDateTimeWithOffset] = withinSameSecond(() => {
+            return [Temporal.Now.plainDateTimeISO("UTC"), Temporal.Now.plainDateTimeISO(timeZone)];
+        });
 
         if (plainDateTime.year !== plainDateTimeWithOffset.year) return;
 
-        // Let's hope the duration between the above two lines is less than a second :^)
         const differenceSeconds =
             plainDateTimeToEpochSeconds(plainDateTimeWithOffset) -
             plainDateTimeToEpochSeconds(plainDateTime);
@@ -55,12 +55,12 @@ describe("correct behavior", () => {
             },
         };
 
-        const plainDateTime = Temporal.Now.plainDateTimeISO("UTC");
-        const plainDateTimeWithOffset = Temporal.Now.plainDateTimeISO(timeZone);
+        const [plainDateTime, plainDateTimeWithOffset] = withinSameSecond(() => {
+            return [Temporal.Now.plainDateTimeISO("UTC"), Temporal.Now.plainDateTimeISO(timeZone)];
+        });
 
         if (plainDateTime.year !== plainDateTimeWithOffset.year) return;
 
-        // Let's hope the duration between the above two lines is less than a second :^)
         const differenceSeconds =
             plainDateTimeToEpochSeconds(plainDateTimeWithOffset) -
             plainDateTimeToEpochSeconds(plainDateTime);


### PR DESCRIPTION
Before these tests could be flaky if they happened to be called around the edge of a second. Now we try up to 25 times to execute the tests while staying within the same second.

If you know of other tests like this let me know!
(I just searched for the now removed comment "Let's hope the duration between the above two lines is less than a second :^)")

This should fix failures like the one mentioned in this comment: https://github.com/SerenityOS/serenity/pull/16279#pullrequestreview-1202407645