### PR TITLE
LibWeb: Support `repeating-radial-gradient()`s

### DIFF
--- a/Base/res/html/misc/gradients.html
+++ b/Base/res/html/misc/gradients.html
@@ -198,6 +198,18 @@
         .grad-radial-4 {
             background-image: radial-gradient(200px 100px ellipse at 25% 50%, yellow, #009966, purple);
         }
+
+        .grad-radial-repeat-1 {
+            background-image: repeating-radial-gradient(#e66465, #9198e5 20%);
+        }
+
+        .grad-radial-repeat-2 {
+            background-image: repeating-radial-gradient(closest-side, #3f87a6, #ebf8e1, #f69d3c);
+        }
+
+        .grad-radial-repeat-3 {
+            background-image: repeating-radial-gradient(circle at 100%, #333, #333 10px, #eee 10px, #eee 20px);
+        }
     </style>
   </head>
   <body>
@@ -253,6 +265,10 @@
     <div class="rect grad-radial-2"></div>
     <div class="rect grad-radial-3"></div>
     <div class="rect grad-radial-4"></div>
+    <b>Repeating radial gradients</b><br>
+    <div class="rect grad-radial-repeat-1"></div>
+    <div class="rect grad-radial-repeat-2"></div>
+    <div class="rect grad-radial-repeat-3"></div>
   </body>
   <script>
     const boxes = document.querySelectorAll(".box, .rect");

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2655,7 +2655,13 @@ RefPtr<StyleValue> Parser::parse_radial_gradient_function(ComponentValue const& 
     if (!component_value.is_function())
         return {};
 
+    auto repeating_gradient = GradientRepeating::No;
+
     auto function_name = component_value.function().name();
+
+    function_name = consume_if_starts_with(function_name, "repeating-"sv, [&] {
+        repeating_gradient = GradientRepeating::Yes;
+    });
 
     if (!function_name.equals_ignoring_case("radial-gradient"sv))
         return {};
@@ -2786,7 +2792,7 @@ RefPtr<StyleValue> Parser::parse_radial_gradient_function(ComponentValue const& 
     if (!color_stops.has_value())
         return {};
 
-    return RadialGradientStyleValue::create(ending_shape, size, at_position, move(*color_stops));
+    return RadialGradientStyleValue::create(ending_shape, size, at_position, move(*color_stops), repeating_gradient);
 }
 
 Optional<PositionValue> Parser::parse_position(TokenStream<ComponentValue>& tokens, PositionValue initial_value)

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1984,6 +1984,8 @@ bool PositionValue::operator==(PositionValue const& other) const
 String RadialGradientStyleValue::to_string() const
 {
     StringBuilder builder;
+    if (is_repeating())
+        builder.append("repeating-"sv);
     builder.appendff("radial-gradient({} "sv,
         m_ending_shape == EndingShape::Circle ? "circle"sv : "ellipse"sv);
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -1232,10 +1232,10 @@ public:
 
     using Size = Variant<Extent, CircleSize, EllipseSize>;
 
-    static NonnullRefPtr<RadialGradientStyleValue> create(EndingShape ending_shape, Size size, PositionValue position, Vector<LinearColorStopListElement> color_stop_list)
+    static NonnullRefPtr<RadialGradientStyleValue> create(EndingShape ending_shape, Size size, PositionValue position, Vector<LinearColorStopListElement> color_stop_list, GradientRepeating repeating)
     {
         VERIFY(color_stop_list.size() >= 2);
-        return adopt_ref(*new RadialGradientStyleValue(ending_shape, size, position, move(color_stop_list)));
+        return adopt_ref(*new RadialGradientStyleValue(ending_shape, size, position, move(color_stop_list), repeating));
     }
 
     virtual String to_string() const override;
@@ -1255,15 +1255,18 @@ public:
 
     Gfx::FloatSize resolve_size(Layout::Node const&, Gfx::FloatPoint, Gfx::FloatRect const&) const;
 
+    bool is_repeating() const { return m_repeating == GradientRepeating::Yes; }
+
     virtual ~RadialGradientStyleValue() override = default;
 
 private:
-    RadialGradientStyleValue(EndingShape ending_shape, Size size, PositionValue position, Vector<LinearColorStopListElement> color_stop_list)
+    RadialGradientStyleValue(EndingShape ending_shape, Size size, PositionValue position, Vector<LinearColorStopListElement> color_stop_list, GradientRepeating repeating)
         : AbstractImageStyleValue(Type::RadialGradient)
         , m_ending_shape(ending_shape)
         , m_size(size)
         , m_position(position)
         , m_color_stop_list(move(color_stop_list))
+        , m_repeating(repeating)
     {
     }
 
@@ -1271,6 +1274,7 @@ private:
     Size m_size;
     PositionValue m_position;
     Vector<LinearColorStopListElement> m_color_stop_list;
+    GradientRepeating m_repeating;
 
     struct ResolvedData {
         Painting::RadialGradientData data;

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -163,7 +163,7 @@ RadialGradientData resolve_radial_gradient_data(Layout::Node const& node, Gfx::F
         radial_gradient.color_stop_list(), [&](auto const& length_percentage) {
             return length_percentage.resolved(node, gradient_length).to_px(node) / gradient_size.width();
         },
-        false);
+        radial_gradient.is_repeating());
     return { resolved_color_stops };
 }
 


### PR DESCRIPTION
Close enough, that covers all the standard gradient types. 
|                                                                                    | LibWeb                                                                                                          | Chrome                                                                                                          |
|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| `repeating-radial-gradient(#e66465, #9198e5 20%)`                                  | ![image](https://user-images.githubusercontent.com/11597044/205412155-06d75efb-3278-4ea6-8d3f-f7e8b990894f.png) | ![image](https://user-images.githubusercontent.com/11597044/205412201-c8b8ee8d-4365-4d39-9bb8-74642c872a94.png) |
| `repeating-radial-gradient(closest-side, #3f87a6, #ebf8e1, #f69d3c)`               | ![image](https://user-images.githubusercontent.com/11597044/205412162-24d95b34-75e2-4615-a527-888e7a3cbae3.png) | ![image](https://user-images.githubusercontent.com/11597044/205412214-1e1752cb-6460-455d-a9e0-138df20d7db5.png) |
| `repeating-radial-gradient(circle at 100%, #333, #333 10px, #eee 10px, #eee 20px)` | ![image](https://user-images.githubusercontent.com/11597044/205412172-b34a8542-41fa-4d45-af7a-31937789f1de.png) | ![image](https://user-images.githubusercontent.com/11597044/205412228-4f1a52fe-86aa-4a4c-a44f-c36c4e710041.png) |