### PR TITLE
PixelPaint: Disabling layer-related actions when they are not possible

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -392,13 +392,13 @@ void Image::merge_visible_layers()
 
 void Image::merge_active_layer_up(Layer& layer)
 {
-    if (m_layers.size() < 2)
-        return;
+    // NOTE: The action for this should be disabled if there are fewer than 2 layers.
+    VERIFY(m_layers.size() >= 2);
+
     size_t layer_index = this->index_of(layer);
-    if ((layer_index + 1) == m_layers.size()) {
-        dbgln("Cannot merge layer up: layer is already at the top");
-        return; // FIXME: Notify user of error properly.
-    }
+
+    // NOTE: The action for this should be disabled if the active layer is already topmost.
+    VERIFY((layer_index + 1) != m_layers.size());
 
     auto& layer_above = m_layers.at(layer_index + 1);
     GUI::Painter painter(layer_above.content_bitmap());
@@ -409,13 +409,13 @@ void Image::merge_active_layer_up(Layer& layer)
 
 void Image::merge_active_layer_down(Layer& layer)
 {
-    if (m_layers.size() < 2)
-        return;
+    // NOTE: The action for this should be disabled if there are fewer than 2 layers.
+    VERIFY(m_layers.size() >= 2);
+
     int layer_index = this->index_of(layer);
-    if (layer_index == 0) {
-        dbgln("Cannot merge layer down: layer is already at the bottom");
-        return; // FIXME: Notify user of error properly.
-    }
+
+    // NOTE: The action for this should be disabled if the active layer is already bottommost.
+    VERIFY(layer_index != 0);
 
     auto& layer_below = m_layers.at(layer_index - 1);
     GUI::Painter painter(layer_below.content_bitmap());

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -681,6 +681,12 @@ void ImageEditor::image_did_change_rect(Gfx::IntRect const& new_image_rect)
     relayout();
 }
 
+void ImageEditor::image_did_modify_layer_stack()
+{
+    if (on_layer_stack_change)
+        on_layer_stack_change();
+}
+
 void ImageEditor::image_select_layer(Layer* layer)
 {
     set_active_layer(layer);

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -89,6 +89,8 @@ public:
     Function<void(void)> on_leave;
     Function<void(bool modified)> on_modified_change;
 
+    Function<void()> on_layer_stack_change;
+
     bool request_close();
 
     void save_project_as();
@@ -144,6 +146,7 @@ private:
 
     virtual void image_did_change(Gfx::IntRect const&) override;
     virtual void image_did_change_rect(Gfx::IntRect const&) override;
+    virtual void image_did_modify_layer_stack() override;
     virtual void image_select_layer(Layer*) override;
 
     virtual void selection_did_change() override;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -798,13 +798,15 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         m_layer_menu->popup(event.screen_position());
     };
     m_layer_menu->add_separator();
-    m_layer_menu->add_action(GUI::Action::create(
+
+    m_flatten_image_action = GUI::Action::create(
         "Fl&atten Image", { Mod_Ctrl, Key_F }, g_icon_bag.flatten_image, [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
             editor->image().flatten_all_layers();
             editor->did_complete_action("Flatten Image"sv);
-        }));
+        });
+    m_layer_menu->add_action(*m_flatten_image_action);
 
     m_layer_menu->add_action(GUI::Action::create(
         "&Merge Visible", { Mod_Ctrl, Key_M }, g_icon_bag.merge_visible, [&](auto&) {
@@ -1113,6 +1115,7 @@ void MainWidget::update_action_states_after_layer_stack_change()
         m_move_active_layer_to_back_action->set_enabled(false);
         m_move_active_layer_up_action->set_enabled(false);
         m_move_active_layer_down_action->set_enabled(false);
+        m_flatten_image_action->set_enabled(false);
         return;
     }
 
@@ -1129,6 +1132,8 @@ void MainWidget::update_action_states_after_layer_stack_change()
 
     m_move_active_layer_to_front_action->set_enabled(layer_count > 1 && !active_layer_is_frontmost);
     m_move_active_layer_to_back_action->set_enabled(layer_count > 1 && !active_layer_is_backmost);
+
+    m_flatten_image_action->set_enabled(layer_count >= 2);
 }
 
 ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -810,13 +810,14 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         });
     m_layer_menu->add_action(*m_flatten_image_action);
 
-    m_layer_menu->add_action(GUI::Action::create(
+    m_merge_visible_layers_action = GUI::Action::create(
         "&Merge Visible", { Mod_Ctrl, Key_M }, g_icon_bag.merge_visible, [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
             editor->image().merge_visible_layers();
             editor->did_complete_action("Merge Visible"sv);
-        }));
+        });
+    m_layer_menu->add_action(*m_merge_visible_layers_action);
 
     m_merge_active_layer_up_action = GUI::Action::create(
         "Merge &Active Layer Up", g_icon_bag.merge_active_layer_up, [&](auto&) {
@@ -1119,6 +1120,7 @@ void MainWidget::update_action_states_after_layer_stack_change()
         m_move_active_layer_down_action->set_enabled(false);
         m_flatten_image_action->set_enabled(false);
         m_remove_active_layer_action->set_enabled(false);
+        m_merge_visible_layers_action->set_enabled(false);
         return;
     }
 
@@ -1137,6 +1139,7 @@ void MainWidget::update_action_states_after_layer_stack_change()
     m_move_active_layer_to_back_action->set_enabled(layer_count > 1 && !active_layer_is_backmost);
 
     m_flatten_image_action->set_enabled(layer_count >= 2);
+    m_merge_visible_layers_action->set_enabled(layer_count >= 2);
 
     m_remove_active_layer_action->set_enabled(editor.active_layer() != nullptr);
 }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -767,7 +767,8 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
     m_layer_menu->add_action(*m_move_active_layer_down_action);
 
     m_layer_menu->add_separator();
-    m_layer_menu->add_action(GUI::Action::create(
+
+    m_remove_active_layer_action = GUI::Action::create(
         "&Remove Active Layer", { Mod_Ctrl, Key_D }, g_icon_bag.delete_layer, [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
@@ -792,7 +793,8 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 editor->layers_did_change();
                 m_layer_list_widget->select_top_layer();
             }
-        }));
+        });
+    m_layer_menu->add_action(*m_remove_active_layer_action);
 
     m_layer_list_widget->on_context_menu_request = [&](auto& event) {
         m_layer_menu->popup(event.screen_position());
@@ -1116,6 +1118,7 @@ void MainWidget::update_action_states_after_layer_stack_change()
         m_move_active_layer_up_action->set_enabled(false);
         m_move_active_layer_down_action->set_enabled(false);
         m_flatten_image_action->set_enabled(false);
+        m_remove_active_layer_action->set_enabled(false);
         return;
     }
 
@@ -1134,6 +1137,8 @@ void MainWidget::update_action_states_after_layer_stack_change()
     m_move_active_layer_to_back_action->set_enabled(layer_count > 1 && !active_layer_is_backmost);
 
     m_flatten_image_action->set_enabled(layer_count >= 2);
+
+    m_remove_active_layer_action->set_enabled(editor.active_layer() != nullptr);
 }
 
 ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -701,22 +701,30 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
 
     m_layer_menu->add_separator();
 
-    m_layer_menu->add_action(GUI::Action::create(
+    m_select_previous_layer_action = GUI::Action::create(
         "Select &Previous Layer", { 0, Key_PageUp }, g_icon_bag.previous_layer, [&](auto&) {
             m_layer_list_widget->cycle_through_selection(1);
-        }));
-    m_layer_menu->add_action(GUI::Action::create(
+        });
+    m_layer_menu->add_action(*m_select_previous_layer_action);
+
+    m_select_next_layer_action = GUI::Action::create(
         "Select &Next Layer", { 0, Key_PageDown }, g_icon_bag.next_layer, [&](auto&) {
             m_layer_list_widget->cycle_through_selection(-1);
-        }));
-    m_layer_menu->add_action(GUI::Action::create(
+        });
+    m_layer_menu->add_action(*m_select_next_layer_action);
+
+    m_select_top_layer_action = GUI::Action::create(
         "Select &Top Layer", { 0, Key_Home }, g_icon_bag.top_layer, [&](auto&) {
             m_layer_list_widget->select_top_layer();
-        }));
-    m_layer_menu->add_action(GUI::Action::create(
+        });
+    m_layer_menu->add_action(*m_select_top_layer_action);
+
+    m_select_bottom_layer_action = GUI::Action::create(
         "Select B&ottom Layer", { 0, Key_End }, g_icon_bag.bottom_layer, [&](auto&) {
             m_layer_list_widget->select_bottom_layer();
-        }));
+        });
+    m_layer_menu->add_action(*m_select_bottom_layer_action);
+
     m_layer_menu->add_separator();
     m_move_active_layer_to_front_action = GUI::CommonActions::make_move_to_front_action(
         [&](auto&) {
@@ -1137,6 +1145,10 @@ void MainWidget::update_action_states_after_layer_stack_change()
         m_rotate_active_layer_counterclockwise_action->set_enabled(false);
         m_crop_active_layer_to_selection_action->set_enabled(false);
         m_crop_active_layer_to_content_action->set_enabled(false);
+        m_select_previous_layer_action->set_enabled(false);
+        m_select_next_layer_action->set_enabled(false);
+        m_select_top_layer_action->set_enabled(false);
+        m_select_bottom_layer_action->set_enabled(false);
         return;
     }
 
@@ -1164,6 +1176,11 @@ void MainWidget::update_action_states_after_layer_stack_change()
     m_rotate_active_layer_counterclockwise_action->set_enabled(editor.active_layer() != nullptr);
     m_crop_active_layer_to_selection_action->set_enabled(editor.active_layer() != nullptr);
     m_crop_active_layer_to_content_action->set_enabled(editor.active_layer() != nullptr);
+
+    m_select_previous_layer_action->set_enabled(layer_count > 1 && !active_layer_is_frontmost);
+    m_select_next_layer_action->set_enabled(layer_count > 1 && !active_layer_is_backmost);
+    m_select_top_layer_action->set_enabled(layer_count > 1 && !active_layer_is_frontmost);
+    m_select_bottom_layer_action->set_enabled(layer_count > 1 && !active_layer_is_backmost);
 }
 
 ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -743,7 +743,8 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
     m_layer_menu->add_action(*m_move_active_layer_to_back_action);
 
     m_layer_menu->add_separator();
-    m_layer_menu->add_action(GUI::Action::create(
+
+    m_move_active_layer_up_action = GUI::Action::create(
         "Move Active Layer &Up", { Mod_Ctrl, Key_PageUp }, g_icon_bag.active_layer_up, [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
@@ -751,8 +752,10 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             if (!active_layer)
                 return;
             editor->image().move_layer_up(*active_layer);
-        }));
-    m_layer_menu->add_action(GUI::Action::create(
+        });
+    m_layer_menu->add_action(*m_move_active_layer_up_action);
+
+    m_move_active_layer_down_action = GUI::Action::create(
         "Move Active Layer &Down", { Mod_Ctrl, Key_PageDown }, g_icon_bag.active_layer_down, [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
@@ -760,7 +763,9 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             if (!active_layer)
                 return;
             editor->image().move_layer_down(*active_layer);
-        }));
+        });
+    m_layer_menu->add_action(*m_move_active_layer_down_action);
+
     m_layer_menu->add_separator();
     m_layer_menu->add_action(GUI::Action::create(
         "&Remove Active Layer", { Mod_Ctrl, Key_D }, g_icon_bag.delete_layer, [&](auto&) {
@@ -1106,6 +1111,8 @@ void MainWidget::update_action_states_after_layer_stack_change()
         m_merge_active_layer_down_action->set_enabled(false);
         m_move_active_layer_to_front_action->set_enabled(false);
         m_move_active_layer_to_back_action->set_enabled(false);
+        m_move_active_layer_up_action->set_enabled(false);
+        m_move_active_layer_down_action->set_enabled(false);
         return;
     }
 
@@ -1116,6 +1123,9 @@ void MainWidget::update_action_states_after_layer_stack_change()
 
     m_merge_active_layer_up_action->set_enabled(layer_count > 1 && !active_layer_is_frontmost);
     m_merge_active_layer_down_action->set_enabled(layer_count > 1 && !active_layer_is_backmost);
+
+    m_move_active_layer_up_action->set_enabled(layer_count > 1 && !active_layer_is_frontmost);
+    m_move_active_layer_down_action->set_enabled(layer_count > 1 && !active_layer_is_backmost);
 
     m_move_active_layer_to_front_action->set_enabled(layer_count > 1 && !active_layer_is_frontmost);
     m_move_active_layer_to_back_action->set_enabled(layer_count > 1 && !active_layer_is_backmost);

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -48,6 +48,8 @@ public:
 private:
     MainWidget();
 
+    void update_action_states_after_layer_stack_change();
+
     ImageEditor* current_image_editor();
     ImageEditor& create_new_editor(NonnullRefPtr<Image>);
     ErrorOr<void> create_image_from_clipboard();
@@ -108,6 +110,9 @@ private:
 
     RefPtr<GUI::Action> m_layer_via_copy;
     RefPtr<GUI::Action> m_layer_via_cut;
+
+    RefPtr<GUI::Action> m_merge_active_layer_up_action;
+    RefPtr<GUI::Action> m_merge_active_layer_down_action;
 
     Gfx::IntPoint m_last_image_editor_mouse_position;
 };

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -114,6 +114,9 @@ private:
     RefPtr<GUI::Action> m_merge_active_layer_up_action;
     RefPtr<GUI::Action> m_merge_active_layer_down_action;
 
+    RefPtr<GUI::Action> m_move_active_layer_to_front_action;
+    RefPtr<GUI::Action> m_move_active_layer_to_back_action;
+
     Gfx::IntPoint m_last_image_editor_mouse_position;
 };
 

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -120,6 +120,8 @@ private:
     RefPtr<GUI::Action> m_move_active_layer_down_action;
     RefPtr<GUI::Action> m_move_active_layer_up_action;
 
+    RefPtr<GUI::Action> m_flatten_image_action;
+
     Gfx::IntPoint m_last_image_editor_mouse_position;
 };
 

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -121,7 +121,7 @@ private:
     RefPtr<GUI::Action> m_move_active_layer_up_action;
 
     RefPtr<GUI::Action> m_flatten_image_action;
-
+    RefPtr<GUI::Action> m_merge_visible_layers_action;
     RefPtr<GUI::Action> m_remove_active_layer_action;
 
     Gfx::IntPoint m_last_image_editor_mouse_position;

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -124,6 +124,13 @@ private:
     RefPtr<GUI::Action> m_merge_visible_layers_action;
     RefPtr<GUI::Action> m_remove_active_layer_action;
 
+    RefPtr<GUI::Action> m_flip_active_layer_horizontally_action;
+    RefPtr<GUI::Action> m_flip_active_layer_vertically_action;
+    RefPtr<GUI::Action> m_rotate_active_layer_clockwise_action;
+    RefPtr<GUI::Action> m_rotate_active_layer_counterclockwise_action;
+    RefPtr<GUI::Action> m_crop_active_layer_to_selection_action;
+    RefPtr<GUI::Action> m_crop_active_layer_to_content_action;
+
     Gfx::IntPoint m_last_image_editor_mouse_position;
 };
 

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -131,6 +131,11 @@ private:
     RefPtr<GUI::Action> m_crop_active_layer_to_selection_action;
     RefPtr<GUI::Action> m_crop_active_layer_to_content_action;
 
+    RefPtr<GUI::Action> m_select_previous_layer_action;
+    RefPtr<GUI::Action> m_select_next_layer_action;
+    RefPtr<GUI::Action> m_select_top_layer_action;
+    RefPtr<GUI::Action> m_select_bottom_layer_action;
+
     Gfx::IntPoint m_last_image_editor_mouse_position;
 };
 

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -117,6 +117,9 @@ private:
     RefPtr<GUI::Action> m_move_active_layer_to_front_action;
     RefPtr<GUI::Action> m_move_active_layer_to_back_action;
 
+    RefPtr<GUI::Action> m_move_active_layer_down_action;
+    RefPtr<GUI::Action> m_move_active_layer_up_action;
+
     Gfx::IntPoint m_last_image_editor_mouse_position;
 };
 

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -122,6 +122,8 @@ private:
 
     RefPtr<GUI::Action> m_flatten_image_action;
 
+    RefPtr<GUI::Action> m_remove_active_layer_action;
+
     Gfx::IntPoint m_last_image_editor_mouse_position;
 };
 


### PR DESCRIPTION
Before these changes, all layer actions were always enabled.

After, they are contextually enabled or disabled depending on the state of the layer stack and the currently active layer.