### PR TITLE
LibGUI: Swap Next and Previous button on IncrementalSearchBanner

### DIFF
--- a/Userland/Libraries/LibGUI/IncrementalSearchBanner.gml
+++ b/Userland/Libraries/LibGUI/IncrementalSearchBanner.gml
@@ -19,16 +19,16 @@
         }
 
         @GUI::Button {
-            name: "next_button"
-            icon: "/res/icons/16x16/go-down.png"
+            name: "previous_button"
+            icon: "/res/icons/16x16/go-up.png"
             fixed_width: 18
             button_style: "Coolbar"
             focus_policy: "NoFocus"
         }
 
         @GUI::Button {
-            name: "previous_button"
-            icon: "/res/icons/16x16/go-up.png"
+            name: "next_button"
+            icon: "/res/icons/16x16/go-down.png"
             fixed_width: 18
             button_style: "Coolbar"
             focus_policy: "NoFocus"


### PR DESCRIPTION
This order seems more natural as it is used in basically all apps on other systems (e.g. Firefox, CLion,...).