### PR TITLE
3DFileViewer: Properly propagate errors from WavefrontOBJLoader

### DIFF
--- a/Userland/Applications/3DFileViewer/MeshLoader.h
+++ b/Userland/Applications/3DFileViewer/MeshLoader.h
@@ -18,5 +18,5 @@ public:
     MeshLoader() = default;
     virtual ~MeshLoader() = default;
 
-    virtual RefPtr<Mesh> load(Core::File& file) = 0;
+    virtual ErrorOr<NonnullRefPtr<Mesh>> load(Core::File& file) = 0;
 };

--- a/Userland/Applications/3DFileViewer/WavefrontOBJLoader.h
+++ b/Userland/Applications/3DFileViewer/WavefrontOBJLoader.h
@@ -18,5 +18,5 @@ public:
     WavefrontOBJLoader() = default;
     ~WavefrontOBJLoader() override = default;
 
-    RefPtr<Mesh> load(Core::File& file) override;
+    ErrorOr<NonnullRefPtr<Mesh>> load(Core::File& file) override;
 };

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -320,8 +320,8 @@ bool GLContextWidget::load_file(Core::File& file)
     }
 
     auto new_mesh = m_mesh_loader->load(file);
-    if (new_mesh.is_null()) {
-        GUI::MessageBox::show(window(), DeprecatedString::formatted("Reading \"{}\" failed.", filename), "Error"sv, GUI::MessageBox::Type::Error);
+    if (new_mesh.is_error()) {
+        GUI::MessageBox::show(window(), DeprecatedString::formatted("Reading \"{}\" failed: {}", filename, new_mesh.release_error()), "Error"sv, GUI::MessageBox::Type::Error);
         return false;
     }
 
@@ -358,7 +358,7 @@ bool GLContextWidget::load_file(Core::File& file)
         dbgln("3DFileViewer: Couldn't load texture for {}", filename);
     }
 
-    m_mesh = new_mesh;
+    m_mesh = new_mesh.release_value();
     dbgln("3DFileViewer: mesh has {} triangles.", m_mesh->triangle_count());
 
     return true;


### PR DESCRIPTION
Fixes 3 FIXMEs.
