### PR TITLE
Meta: Update all references of clang-format-14 to clang-format-15

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Nobody is perfect, and sometimes we mess things up. That said, here are some goo
 **Do:**
 
 * Write in idiomatic SerenityOS C++20, using the `AK` containers in all code.
-* Conform to the project coding style found in [CodingStyle.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Use `clang-format` (version 14 or later) to automatically format C++ files.
+* Conform to the project coding style found in [CodingStyle.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Use `clang-format` (version 15 or later) to automatically format C++ files. See [AdvancedBuildInstructions.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md) in Clang-format updates section to check how to acquire the tool.
 * Choose expressive variable, function and class names. Make it as obvious as possible what the code is doing.
 * Split your changes into separate, atomic commits (i.e. A commit per feature or fix, where the build, tests and the system are all functioning).
 * Make sure your commits are rebased on the master branch.

--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -213,3 +213,11 @@ of parallel compile tasks be setting the `MAKEJOBS` environment variable to a nu
 Once the build script finishes, you can use it to compile SerenityOS. Either set the `SERENITY_TOOLCHAIN` build
 option to `Clang` as shown [above](#cmake-build-options), or pass `Clang` as the TOOLCHAIN option to
 `Meta/serenity.sh`, for example: `Meta/serenity.sh run i686 Clang`.
+
+## Clang-format updates
+
+There 3 options to acquire an updated clang-format tool:
+1) If you have a Debian-based (apt-based) distribution, refer to [SelfHostedRunners.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/SelfHostedRunners.md) document to learn more about using the LLVM apt repositories to install the latest clang-format tool.
+2) Compile using `Toolchain/BuildClang.sh` as being pointed above use the compiled `Toolchain/Local/clang/bin/clang-format` binary.
+3) Compile LLVM from source as pointed [here](https://llvm.org/docs/GettingStarted.html#compiling-the-llvm-suite-source-code).
+    

--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -2,7 +2,7 @@
 
 For low-level styling (spaces, parentheses, brace placement, etc), all code should follow the format specified in `.clang-format` in the project root.
 
-**Important: Make sure you use `clang-format` version 14 or later!**
+**Important: Make sure you use `clang-format` version 15 or later!**
 
 This document describes the coding style used for C++ code in the Serenity Operating System project. All new code should conform to this style.
 

--- a/Documentation/QtCreatorConfiguration.md
+++ b/Documentation/QtCreatorConfiguration.md
@@ -38,7 +38,7 @@ Qt Creator should be set up correctly now, go ahead and explore the project and 
 
 ## Auto-Formatting
 
-You can use `clang-format` to help you with the [style guide](CodingStyle.md). Before you proceed, check that you're actually using clang-format version 14, as some OSes will ship older clang-format versions by default.
+You can use `clang-format` to help you with the [style guide](CodingStyle.md). Before you proceed, check that you're actually using clang-format version 15, as some OSes will ship older clang-format versions by default.
 
 - In QtCreator, go to "Help > About Plugins…"
 - Find the `Beautifier (experimental)` row (for example, by typing `beau` into the search)


### PR DESCRIPTION
Also, we add a section that describes how to get an updated clang-format with multiple possible options to do that.