### PR TITLE
LibAudio: Prevent int overflow in the user buffer queue.

### DIFF
--- a/Userland/Libraries/LibAudio/UserSampleQueue.cpp
+++ b/Userland/Libraries/LibAudio/UserSampleQueue.cpp
@@ -51,6 +51,7 @@ size_t UserSampleQueue::size()
 size_t UserSampleQueue::remaining_samples()
 {
     Threading::MutexLocker lock(m_sample_mutex);
+    VERIFY(m_backing_samples.size() >= m_samples_to_discard);
     return m_backing_samples.size() - m_samples_to_discard;
 }
 


### PR DESCRIPTION
The `UserSampleQueue::remaining_samples` calculates the result by subtracting two unsigned int numbers. That can lead to integer overflow. Check when the minuend is smaller or equal to the subtrahend and return zero.