### PR TITLE
AK: Take the chunk header size into account when freeing objects

### DIFF
--- a/AK/BumpAllocator.h
+++ b/AK/BumpAllocator.h
@@ -181,7 +181,7 @@ public:
         this->for_each_chunk([&](auto chunk) {
             auto base_ptr = align_up_to(chunk + sizeof(typename Allocator::ChunkHeader), alignof(T));
             // Compute the offset of the first byte *after* this chunk:
-            FlatPtr end_offset = base_ptr + this->m_chunk_size - chunk;
+            FlatPtr end_offset = base_ptr + this->m_chunk_size - chunk - sizeof(typename Allocator::ChunkHeader);
             if (chunk == this->m_current_chunk)
                 end_offset = this->m_byte_offset_into_current_chunk;
             // Compute the offset of the first byte *after* the last valid object, in case the end of the chunk does not align with the end of an object:


### PR DESCRIPTION
Previously we allowed the end_offset to be larger than the chunk itself, which made it so that certain input sizes would make the logic attempt to delete a nonexistent object.
Fixes #16308.