### PR TITLE
LibWeb: Fix box-shadows where the border-radius is < the blur-radius

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -99,19 +99,21 @@ void paint_box_shadow(PaintContext& context, Gfx::IntRect const& content_rect, B
         auto extra_edge_width = non_blurred_shadow_rect.width() % 2;
         auto extra_edge_height = non_blurred_shadow_rect.height() % 2;
 
-        auto clip_corner_size = [&](auto& size, int x_bonus = 0, int y_bonus = 0) {
-            size.set_width(min(size.width(), max_edge_width + x_bonus));
-            size.set_height(min(size.height(), max_edge_height + y_bonus));
+        auto clip_corner_size = [&](auto& size, auto const& corner, int x_bonus = 0, int y_bonus = 0) {
+            auto max_x = max_edge_width + x_bonus;
+            auto max_y = max_edge_height + y_bonus;
+            auto min_x = max(corner.horizontal_radius, min(double_radius, max_x));
+            auto min_y = max(corner.vertical_radius, min(double_radius, max_y));
+            if (min_x <= max_x)
+                size.set_width(clamp(size.width(), min_x, max_x));
+            if (min_y <= max_y)
+                size.set_height(clamp(size.height(), min_y, max_y));
         };
 
-        if (!top_left_corner)
-            clip_corner_size(top_left_corner_size, extra_edge_width, extra_edge_height);
-        if (!top_right_corner)
-            clip_corner_size(top_right_corner_size, 0, extra_edge_height);
-        if (!bottom_left_corner)
-            clip_corner_size(bottom_left_corner_size, extra_edge_width);
-        if (!bottom_right_corner)
-            clip_corner_size(bottom_right_corner_size);
+        clip_corner_size(top_left_corner_size, top_left_corner, extra_edge_width, extra_edge_height);
+        clip_corner_size(top_right_corner_size, top_right_corner, 0, extra_edge_height);
+        clip_corner_size(bottom_left_corner_size, bottom_left_corner, extra_edge_width);
+        clip_corner_size(bottom_right_corner_size, bottom_right_corner);
 
         auto shadow_bitmap_rect = Gfx::IntRect(
             0, 0,


### PR DESCRIPTION
This fixes a rendering issue where box-shadows would not appear or render completely broken if the blur radius was larger than the border radius (border-radius < 2 * blur-radius to be exact).

`box-shadow: 10px 10px 40px black`:
| Before                                                                                                          | After                                                                                                           | Chrome                                                                                                          |
|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/11597044/205524436-847ebe62-c0e5-4e11-9c16-3088f1b6e380.png) | ![image](https://user-images.githubusercontent.com/11597044/205524477-659309ba-99a3-4d8d-8bff-88a0210950d4.png) | ![image](https://user-images.githubusercontent.com/11597044/205524531-54003fbd-03db-4764-9a76-3fbb33184e1c.png) |

This does not _appear_ to break anything new (though sadly I only have quite manual testing :disappointed:). 

---
_Box-shadows' rendering optimisations bring endless joy_