### PR TITLE
Meta: Switch to the Lagom directory before building fuzzers

### DIFF
--- a/Meta/Lagom/BuildFuzzers.sh
+++ b/Meta/Lagom/BuildFuzzers.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+SCRIPT_PATH="$(dirname "${0}")"
+cd "${SCRIPT_PATH}"
+
 BEST_CLANG_CANDIDATE=""
 
 die() {


### PR DESCRIPTION
This confused quite a number of people in the past, and it is still slightly annoying to always switch the directory when testing both the OS and the fuzzer build. Instead, let's just switch to the correct directory automatically.