### PR TITLE
Meta: Return 0 from the fuzzing function in most cases

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
@@ -13,12 +13,12 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
     auto bufstream_result = Core::Stream::MemoryStream::construct({ data, size });
     if (bufstream_result.is_error()) {
         dbgln("MemoryStream::construct() failed.");
-        return 1;
+        return 0;
     }
     auto bufstream = bufstream_result.release_value();
 
     auto brotli_stream = Compress::BrotliDecompressionStream { *bufstream };
 
-    auto uncompressed = brotli_stream.read_all();
-    return uncompressed.is_error();
+    (void)brotli_stream.read_all();
+    return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzDeflateCompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzDeflateCompression.cpp
@@ -9,6 +9,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto result = Compress::DeflateCompressor::compress_all(ReadonlyBytes { data, size });
-    return result.has_value();
+    (void)Compress::DeflateCompressor::compress_all(ReadonlyBytes { data, size });
+    return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzDeflateDecompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzDeflateDecompression.cpp
@@ -9,6 +9,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto result = Compress::DeflateDecompressor::decompress_all(ReadonlyBytes { data, size });
-    return result.has_value();
+    (void)Compress::DeflateDecompressor::decompress_all(ReadonlyBytes { data, size });
+    return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
@@ -21,7 +21,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
     for (;;) {
         auto samples = flac->get_more_samples();
         if (samples.is_error())
-            return 2;
+            return 0;
         if (samples.value().size() > 0)
             break;
     }

--- a/Meta/Lagom/Fuzzers/FuzzGzipCompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGzipCompression.cpp
@@ -9,6 +9,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto result = Compress::GzipCompressor::compress_all(ReadonlyBytes { data, size });
-    return result.has_value();
+    (void)Compress::GzipCompressor::compress_all(ReadonlyBytes { data, size });
+    return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzGzipDecompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGzipDecompression.cpp
@@ -9,6 +9,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto result = Compress::GzipDecompressor::decompress_all(ReadonlyBytes { data, size });
+    (void)Compress::GzipDecompressor::decompress_all(ReadonlyBytes { data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzHttpRequest.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzHttpRequest.cpp
@@ -12,7 +12,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto request_wrapper = HTTP::HttpRequest::from_raw_request(ReadonlyBytes { data, size });
     if (!request_wrapper.has_value())
-        return 1;
+        return 0;
 
     auto& request = request_wrapper.value();
     VERIFY(request.method() != HTTP::HttpRequest::Method::Invalid);

--- a/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
@@ -21,7 +21,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
     for (;;) {
         auto samples = mp3->get_more_samples();
         if (samples.is_error())
-            return 2;
+            return 0;
         if (samples.value().size() > 0)
             break;
     }

--- a/Meta/Lagom/Fuzzers/FuzzMatroskaReader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMatroskaReader.cpp
@@ -11,10 +11,8 @@ extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
     auto matroska_reader_result = Video::Matroska::Reader::from_data({ data, size });
     if (matroska_reader_result.is_error())
-        return -1;
-    if (auto result = matroska_reader_result.value().segment_information(); result.is_error())
-        return -1;
-    if (auto result = matroska_reader_result.value().track_count(); result.is_error())
-        return -1;
+        return 0;
+    (void)matroska_reader_result.value().segment_information();
+    (void)matroska_reader_result.value().track_count();
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzVP9Decoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzVP9Decoder.cpp
@@ -10,7 +10,6 @@
 extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
     Video::VP9::Decoder vp9_decoder;
-    if (auto decode_error = vp9_decoder.receive_sample({ data, size }); decode_error.is_error())
-        return -1;
+    (void)vp9_decoder.receive_sample({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
@@ -23,7 +23,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
     for (;;) {
         auto samples = wav->get_more_samples();
         if (samples.is_error())
-            return 2;
+            return 0;
         if (samples.value().size() > 0)
             break;
     }

--- a/Meta/Lagom/Fuzzers/FuzzZlibDecompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzZlibDecompression.cpp
@@ -9,6 +9,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto result = Compress::Zlib::decompress_all(ReadonlyBytes { data, size });
-    return result.has_value();
+    (void)Compress::Zlib::decompress_all(ReadonlyBytes { data, size });
+    return 0;
 }


### PR DESCRIPTION
[LibFuzzer documentation](https://llvm.org/docs/LibFuzzer.html) states that all return values except for 0 and -1 are currently reserved for future use. -1 is a special return value that causes LibFuzzer to not add a testing input to the testing corpus, regardless of the code coverage that it causes.