### PR TITLE
LibGUI: Fix a typo

### DIFF
--- a/Userland/Libraries/LibGUI/GroupBox.cpp
+++ b/Userland/Libraries/LibGUI/GroupBox.cpp
@@ -52,7 +52,7 @@ void GroupBox::paint_event(PaintEvent& event)
 void GroupBox::fonts_change_event(FontsChangeEvent& event)
 {
     Widget::fonts_change_event(event);
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
 }
 
 void GroupBox::set_title(StringView title)

--- a/Userland/Libraries/LibGUI/ListView.cpp
+++ b/Userland/Libraries/LibGUI/ListView.cpp
@@ -57,10 +57,10 @@ void ListView::resize_event(ResizeEvent& event)
     AbstractView::resize_event(event);
 }
 
-void ListView::layout_relevant_change_occured()
+void ListView::layout_relevant_change_occurred()
 {
     update_content_size();
-    AbstractView::layout_relevant_change_occured();
+    AbstractView::layout_relevant_change_occurred();
 }
 
 void ListView::model_did_update(unsigned flags)

--- a/Userland/Libraries/LibGUI/ListView.h
+++ b/Userland/Libraries/LibGUI/ListView.h
@@ -54,7 +54,7 @@ private:
     virtual void keydown_event(KeyEvent&) override;
     virtual void resize_event(ResizeEvent&) override;
     virtual void mousemove_event(MouseEvent&) override;
-    virtual void layout_relevant_change_occured() override;
+    virtual void layout_relevant_change_occurred() override;
 
     virtual Optional<UISize> calculated_min_size() const override;
 

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -73,7 +73,7 @@ void ScrollableContainerWidget::resize_event(GUI::ResizeEvent& event)
     update_widget_position();
 }
 
-void ScrollableContainerWidget::layout_relevant_change_occured()
+void ScrollableContainerWidget::layout_relevant_change_occurred()
 {
     update_widget_min_size();
     update_scrollbar_visibility();

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
@@ -24,7 +24,7 @@ public:
 protected:
     virtual void did_scroll() override;
     virtual void resize_event(GUI::ResizeEvent&) override;
-    virtual void layout_relevant_change_occured() override;
+    virtual void layout_relevant_change_occurred() override;
 
 private:
     void update_widget_size();

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -58,7 +58,7 @@ ErrorOr<void> TabWidget::try_add_widget(Widget& widget)
     update_focus_policy();
     if (on_tab_count_change)
         on_tab_count_change(m_tabs.size());
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
     return {};
 }
 
@@ -85,7 +85,7 @@ void TabWidget::remove_widget(Widget& widget)
     if (on_tab_count_change)
         on_tab_count_change(m_tabs.size());
 
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
 }
 
 void TabWidget::remove_all_tabs_except(Widget& widget)
@@ -103,7 +103,7 @@ void TabWidget::remove_all_tabs_except(Widget& widget)
     if (on_tab_count_change)
         on_tab_count_change(1);
 
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
 }
 
 void TabWidget::update_focus_policy()
@@ -137,7 +137,7 @@ void TabWidget::set_active_widget(Widget* widget)
         });
     }
 
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
 
     update_bar();
 }
@@ -698,7 +698,7 @@ void TabWidget::doubleclick_event(MouseEvent& mouse_event)
 void TabWidget::set_container_margins(GUI::Margins const& margins)
 {
     m_container_margins = margins;
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
     update();
 }
 

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -199,10 +199,10 @@ Widget::Widget()
 
 Widget::~Widget() = default;
 
-void Widget::layout_relevant_change_occured()
+void Widget::layout_relevant_change_occurred()
 {
     if (auto* parent = parent_widget())
-        parent->layout_relevant_change_occured();
+        parent->layout_relevant_change_occurred();
     else if (window())
         window()->schedule_relayout();
 }
@@ -215,7 +215,7 @@ void Widget::child_event(Core::ChildEvent& event)
                 layout()->insert_widget_before(verify_cast<Widget>(*event.child()), verify_cast<Widget>(*event.insertion_before_child()));
             else
                 layout()->add_widget(verify_cast<Widget>(*event.child()));
-            layout_relevant_change_occured();
+            layout_relevant_change_occurred();
         }
         if (window() && event.child() && is<Widget>(*event.child()))
             window()->did_add_widget({}, verify_cast<Widget>(*event.child()));
@@ -229,7 +229,7 @@ void Widget::child_event(Core::ChildEvent& event)
         if (layout()) {
             if (event.child() && is<Widget>(*event.child()))
                 layout()->remove_widget(verify_cast<Widget>(*event.child()));
-            layout_relevant_change_occured();
+            layout_relevant_change_occurred();
         }
         if (window() && event.child() && is<Widget>(*event.child()))
             window()->did_remove_widget({}, verify_cast<Widget>(*event.child()));
@@ -426,7 +426,7 @@ void Widget::set_layout(NonnullRefPtr<Layout> layout)
     } else {
         update();
     }
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
 }
 
 void Widget::do_layout()
@@ -842,7 +842,7 @@ void Widget::set_min_size(UISize const& size)
     if (m_min_size == size)
         return;
     m_min_size = size;
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
 }
 
 void Widget::set_max_size(UISize const& size)
@@ -851,7 +851,7 @@ void Widget::set_max_size(UISize const& size)
     if (m_max_size == size)
         return;
     m_max_size = size;
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
 }
 
 void Widget::set_preferred_size(UISize const& size)
@@ -859,7 +859,7 @@ void Widget::set_preferred_size(UISize const& size)
     if (m_preferred_size == size)
         return;
     m_preferred_size = size;
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
 }
 
 Optional<UISize> Widget::calculated_preferred_size() const
@@ -891,7 +891,7 @@ void Widget::set_visible(bool visible)
     if (visible == m_visible)
         return;
     m_visible = visible;
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
     if (m_visible)
         update();
     if (!m_visible && is_focused())
@@ -1051,7 +1051,7 @@ void Widget::set_palette(Palette const& palette)
 void Widget::set_title(String title)
 {
     m_title = move(title);
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
     // For tab widget children, our change in title also affects the parent.
     if (parent_widget())
         parent_widget()->update();
@@ -1094,7 +1094,7 @@ void Widget::set_grabbable_margins(Margins const& margins)
     if (m_grabbable_margins == margins)
         return;
     m_grabbable_margins = margins;
-    layout_relevant_change_occured();
+    layout_relevant_change_occurred();
 }
 
 Gfx::IntRect Widget::relative_non_grabbable_rect() const

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -373,7 +373,7 @@ protected:
     // This is called after children have been painted.
     virtual void second_paint_event(PaintEvent&);
 
-    virtual void layout_relevant_change_occured();
+    virtual void layout_relevant_change_occurred();
     virtual void custom_layout() { }
     virtual void did_change_font() { }
     virtual void did_layout() { }


### PR DESCRIPTION
Change spelling from occured to occurred.

See [Grammerly](https://www.grammarly.com/blog/occurred-occured-ocurred/)