### PR TITLE
Documentation: Fix typo in AdvancedBuildInstructions.md

### DIFF
--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -216,7 +216,7 @@ option to `Clang` as shown [above](#cmake-build-options), or pass `Clang` as the
 
 ## Clang-format updates
 
-There 3 options to acquire an updated clang-format tool:
+There are 3 options to acquire an updated clang-format tool:
 1) If you have a Debian-based (apt-based) distribution, refer to [SelfHostedRunners.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/SelfHostedRunners.md) document to learn more about using the LLVM apt repositories to install the latest clang-format tool.
 2) Compile using `Toolchain/BuildClang.sh` as being pointed above use the compiled `Toolchain/Local/clang/bin/clang-format` binary.
 3) Compile LLVM from source as pointed [here](https://llvm.org/docs/GettingStarted.html#compiling-the-llvm-suite-source-code).


### PR DESCRIPTION
Fixes a small typo where the word `are` was missing