### PR TITLE
LibSQL: Implement prepared statement placeholders and the UPDATE statement, plus usability changes

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -63,7 +63,7 @@ struct Endpoint {
 
 static bool is_primitive_type(DeprecatedString const& type)
 {
-    return type.is_one_of("u8", "i8", "u16", "i16", "u32", "i32", "u64", "i64", "bool", "double", "float", "int", "unsigned", "unsigned int");
+    return type.is_one_of("u8", "i8", "u16", "i16", "u32", "i32", "u64", "i64", "size_t", "bool", "double", "float", "int", "unsigned", "unsigned int");
 }
 
 static DeprecatedString message_name(DeprecatedString const& endpoint, DeprecatedString const& message, bool is_response)

--- a/Tests/LibSQL/TestSqlExpressionParser.cpp
+++ b/Tests/LibSQL/TestSqlExpressionParser.cpp
@@ -131,6 +131,19 @@ TEST_CASE(null_literal)
     validate("NULL"sv);
 }
 
+TEST_CASE(bind_parameter)
+{
+    auto validate = [](StringView sql) {
+        auto result = parse(sql);
+        EXPECT(!result.is_error());
+
+        auto expression = result.release_value();
+        EXPECT(is<SQL::AST::Placeholder>(*expression));
+    };
+
+    validate("?"sv);
+}
+
 TEST_CASE(column_name)
 {
     EXPECT(parse(".column_name"sv).is_error());

--- a/Tests/LibSQL/TestSqlStatementParser.cpp
+++ b/Tests/LibSQL/TestSqlStatementParser.cpp
@@ -752,6 +752,13 @@ TEST_CASE(nested_subquery_limit)
     EXPECT(parse(DeprecatedString::formatted("SELECT * FROM ({});"sv, subquery)).is_error());
 }
 
+TEST_CASE(bound_parameter_limit)
+{
+    auto subquery = DeprecatedString::repeated("?, "sv, SQL::AST::Limits::maximum_bound_parameters);
+    EXPECT(!parse(DeprecatedString::formatted("INSERT INTO table_name VALUES ({}42);"sv, subquery)).is_error());
+    EXPECT(parse(DeprecatedString::formatted("INSERT INTO table_name VALUES ({}?);"sv, subquery)).is_error());
+}
+
 TEST_CASE(describe_table)
 {
     EXPECT(parse("DESCRIBE"sv).is_error());

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -145,9 +145,16 @@ MainWidget::MainWidget()
     m_run_script_action = GUI::Action::create("Run script", { Mod_Alt, Key_F9 }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/play.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         m_results.clear();
         m_current_line_for_parsing = 0;
+
         // TODO select the database to use in UI.
-        m_connection_id = m_sql_client->connect("test");
-        read_next_sql_statement_of_editor();
+        constexpr auto database_name = "Test"sv;
+
+        if (auto connection_id = m_sql_client->connect(database_name); connection_id.has_value()) {
+            m_connection_id = connection_id.release_value();
+            read_next_sql_statement_of_editor();
+        } else {
+            warnln("\033[33;1mCould not connect to:\033[0m {}", database_name);
+        }
     });
 
     auto& toolbar_container = add<GUI::ToolbarContainer>();

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -214,13 +214,13 @@ MainWidget::MainWidget()
     m_statusbar->segment(2).set_fixed_width(font().width("Ln 0000, Col 000"sv) + font().max_glyph_width());
 
     m_sql_client = SQL::SQLClient::try_create().release_value_but_fixme_should_propagate_errors();
-    m_sql_client->on_execution_success = [this](auto, auto, auto, auto, auto) {
+    m_sql_client->on_execution_success = [this](auto, auto, auto, auto, auto, auto) {
         read_next_sql_statement_of_editor();
     };
-    m_sql_client->on_next_result = [this](auto, auto const& row) {
+    m_sql_client->on_next_result = [this](auto, auto, auto const& row) {
         m_results.append(row);
     };
-    m_sql_client->on_results_exhausted = [this](auto, auto) {
+    m_sql_client->on_results_exhausted = [this](auto, auto, auto) {
         if (m_results.size() == 0)
             return;
         if (m_results[0].size() == 0)

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -479,7 +479,7 @@ DeprecatedString MainWidget::read_next_sql_statement_of_editor()
     } while ((m_editor_line_level > 0) || piece.is_empty());
 
     auto statement_id = m_sql_client->prepare_statement(m_connection_id, piece.to_deprecated_string());
-    m_sql_client->async_execute_statement(statement_id);
+    m_sql_client->async_execute_statement(statement_id, {});
 
     return piece.to_deprecated_string();
 }

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -24,6 +24,7 @@
 #include <LibSQL/AST/Lexer.h>
 #include <LibSQL/AST/Token.h>
 #include <LibSQL/SQLClient.h>
+#include <LibSQL/Value.h>
 
 #include "MainWidget.h"
 #include "ScriptEditor.h"
@@ -224,8 +225,12 @@ MainWidget::MainWidget()
     m_sql_client->on_execution_success = [this](auto, auto, auto, auto, auto, auto) {
         read_next_sql_statement_of_editor();
     };
-    m_sql_client->on_next_result = [this](auto, auto, auto const& row) {
-        m_results.append(row);
+    m_sql_client->on_next_result = [this](auto, auto, auto row) {
+        m_results.append({});
+        m_results.last().ensure_capacity(row.size());
+
+        for (auto const& value : row)
+            m_results.last().unchecked_append(value.to_deprecated_string());
     };
     m_sql_client->on_results_exhausted = [this](auto, auto, auto) {
         if (m_results.size() == 0)

--- a/Userland/DevTools/SQLStudio/MainWidget.h
+++ b/Userland/DevTools/SQLStudio/MainWidget.h
@@ -65,7 +65,7 @@ private:
     Optional<DeprecatedString> read_next_line_of_editor();
     size_t m_current_line_for_parsing { 0 };
     int m_editor_line_level { 0 };
-    int m_connection_id { 0 };
+    u64 m_connection_id { 0 };
 };
 
 }

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -992,6 +992,8 @@ public:
     RefPtr<Expression> const& where_clause() const { return m_where_clause; }
     RefPtr<ReturningClause> const& returning_clause() const { return m_returning_clause; }
 
+    virtual ResultOr<ResultSet> execute(ExecutionContext&) const override;
+
 private:
     RefPtr<CommonTableExpressionList> m_common_table_expression_list;
     ConflictResolution m_conflict_resolution;

--- a/Userland/Libraries/LibSQL/AST/Delete.cpp
+++ b/Userland/Libraries/LibSQL/AST/Delete.cpp
@@ -31,6 +31,7 @@ ResultOr<ResultSet> Delete::execute(ExecutionContext& context) const
         TRY(context.database->remove(table_row));
 
         // FIXME: Implement the RETURNING clause.
+        result.insert_row(table_row, {});
     }
 
     return result;

--- a/Userland/Libraries/LibSQL/AST/Expression.cpp
+++ b/Userland/Libraries/LibSQL/AST/Expression.cpp
@@ -29,6 +29,13 @@ ResultOr<Value> NullLiteral::evaluate(ExecutionContext&) const
     return Value {};
 }
 
+ResultOr<Value> Placeholder::evaluate(ExecutionContext& context) const
+{
+    if (parameter_index() >= context.placeholder_values.size())
+        return Result { SQLCommand::Unknown, SQLErrorCode::InvalidNumberOfPlaceholderValues };
+    return context.placeholder_values[parameter_index()];
+}
+
 ResultOr<Value> NestedExpression::evaluate(ExecutionContext& context) const
 {
     return expression()->evaluate(context);

--- a/Userland/Libraries/LibSQL/AST/Parser.h
+++ b/Userland/Libraries/LibSQL/AST/Parser.h
@@ -19,6 +19,7 @@ namespace Limits {
 // https://www.sqlite.org/limits.html
 constexpr size_t maximum_expression_tree_depth = 1000;
 constexpr size_t maximum_subquery_depth = 100;
+constexpr size_t maximum_bound_parameters = 1000;
 }
 
 class Parser {
@@ -52,6 +53,7 @@ private:
         Vector<Error> m_errors;
         size_t m_current_expression_depth { 0 };
         size_t m_current_subquery_depth { 0 };
+        size_t m_bound_parameters { 0 };
     };
 
     NonnullRefPtr<Statement> parse_statement();
@@ -71,6 +73,7 @@ private:
     NonnullRefPtr<Expression> parse_secondary_expression(NonnullRefPtr<Expression> primary);
     bool match_secondary_expression() const;
     RefPtr<Expression> parse_literal_value_expression();
+    RefPtr<Expression> parse_bind_parameter_expression();
     RefPtr<Expression> parse_column_name_expression(DeprecatedString with_parsed_identifier = {}, bool with_parsed_period = false);
     RefPtr<Expression> parse_unary_operator_expression();
     RefPtr<Expression> parse_binary_operator_expression(NonnullRefPtr<Expression> lhs);

--- a/Userland/Libraries/LibSQL/AST/Statement.cpp
+++ b/Userland/Libraries/LibSQL/AST/Statement.cpp
@@ -11,9 +11,9 @@
 
 namespace SQL::AST {
 
-ResultOr<ResultSet> Statement::execute(AK::NonnullRefPtr<Database> database) const
+ResultOr<ResultSet> Statement::execute(AK::NonnullRefPtr<Database> database, Span<Value const> placeholder_values) const
 {
-    ExecutionContext context { move(database), this, nullptr };
+    ExecutionContext context { move(database), this, placeholder_values, nullptr };
     auto result = TRY(execute(context));
 
     // FIXME: When transactional sessions are supported, don't auto-commit modifications.

--- a/Userland/Libraries/LibSQL/AST/Token.h
+++ b/Userland/Libraries/LibSQL/AST/Token.h
@@ -171,6 +171,7 @@ namespace SQL::AST {
     __ENUMERATE_SQL_TOKEN("_blob_", BlobLiteral, Blob)                    \
     __ENUMERATE_SQL_TOKEN("_eof_", Eof, Invalid)                          \
     __ENUMERATE_SQL_TOKEN("_invalid_", Invalid, Invalid)                  \
+    __ENUMERATE_SQL_TOKEN("?", Placeholder, Operator)                     \
     __ENUMERATE_SQL_TOKEN("&", Ampersand, Operator)                       \
     __ENUMERATE_SQL_TOKEN("*", Asterisk, Operator)                        \
     __ENUMERATE_SQL_TOKEN(",", Comma, Punctuation)                        \

--- a/Userland/Libraries/LibSQL/AST/Update.cpp
+++ b/Userland/Libraries/LibSQL/AST/Update.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibSQL/AST/AST.h>
+#include <LibSQL/Database.h>
+#include <LibSQL/Meta.h>
+#include <LibSQL/Row.h>
+
+namespace SQL::AST {
+
+ResultOr<ResultSet> Update::execute(ExecutionContext& context) const
+{
+    auto const& schema_name = m_qualified_table_name->schema_name();
+    auto const& table_name = m_qualified_table_name->table_name();
+    auto table_def = TRY(context.database->get_table(schema_name, table_name));
+
+    Vector<Row> matched_rows;
+
+    for (auto& table_row : TRY(context.database->select_all(*table_def))) {
+        context.current_row = &table_row;
+
+        if (auto const& where_clause = this->where_clause()) {
+            auto where_result = TRY(where_clause->evaluate(context)).to_bool();
+            if (!where_result.has_value() || !where_result.value())
+                continue;
+        }
+
+        TRY(matched_rows.try_append(move(table_row)));
+    }
+
+    ResultSet result { SQLCommand::Update };
+
+    for (auto& update_column : m_update_columns) {
+        auto row_value = TRY(update_column.expression->evaluate(context));
+
+        for (auto& table_row : matched_rows) {
+            auto& row_descriptor = *table_row.descriptor();
+
+            for (auto const& column_name : update_column.column_names) {
+                if (!table_row.has(column_name))
+                    return Result { SQLCommand::Update, SQLErrorCode::ColumnDoesNotExist, column_name };
+
+                auto column_index = row_descriptor.find_if([&](auto element) { return element.name == column_name; }).index();
+                auto column_type = row_descriptor[column_index].type;
+
+                if (!row_value.is_type_compatible_with(column_type))
+                    return Result { SQLCommand::Update, SQLErrorCode::InvalidValueType, column_name };
+
+                table_row[column_index] = row_value;
+            }
+
+            TRY(context.database->update(table_row));
+            result.insert_row(table_row, {});
+        }
+    }
+
+    return result;
+}
+
+}

--- a/Userland/Libraries/LibSQL/CMakeLists.txt
+++ b/Userland/Libraries/LibSQL/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     AST/Statement.cpp
     AST/SyntaxHighlighter.cpp
     AST/Token.cpp
+    AST/Update.cpp
     BTree.cpp
     BTreeIterator.cpp
     Database.cpp
@@ -26,7 +27,7 @@ set(SOURCES
     TreeNode.cpp
     Tuple.cpp
     Value.cpp
-    )
+)
 
 if (SERENITYOS)
     list(APPEND SOURCES SQLClient.cpp)

--- a/Userland/Libraries/LibSQL/Result.h
+++ b/Userland/Libraries/LibSQL/Result.h
@@ -41,27 +41,28 @@ constexpr char const* command_tag(SQLCommand command)
     }
 }
 
-#define ENUMERATE_SQL_ERRORS(S)                                                          \
-    S(NoError, "No error")                                                               \
-    S(InternalError, "{}")                                                               \
-    S(NotYetImplemented, "{}")                                                           \
-    S(DatabaseUnavailable, "Database Unavailable")                                       \
-    S(StatementUnavailable, "Statement with id '{}' Unavailable")                        \
-    S(SyntaxError, "Syntax Error")                                                       \
-    S(DatabaseDoesNotExist, "Database '{}' does not exist")                              \
-    S(SchemaDoesNotExist, "Schema '{}' does not exist")                                  \
-    S(SchemaExists, "Schema '{}' already exist")                                         \
-    S(TableDoesNotExist, "Table '{}' does not exist")                                    \
-    S(ColumnDoesNotExist, "Column '{}' does not exist")                                  \
-    S(AmbiguousColumnName, "Column name '{}' is ambiguous")                              \
-    S(TableExists, "Table '{}' already exist")                                           \
-    S(InvalidType, "Invalid type '{}'")                                                  \
-    S(InvalidDatabaseName, "Invalid database name '{}'")                                 \
-    S(InvalidValueType, "Invalid type for attribute '{}'")                               \
-    S(InvalidNumberOfValues, "Number of values does not match number of columns")        \
-    S(BooleanOperatorTypeMismatch, "Cannot apply '{}' operator to non-boolean operands") \
-    S(NumericOperatorTypeMismatch, "Cannot apply '{}' operator to non-numeric operands") \
-    S(IntegerOperatorTypeMismatch, "Cannot apply '{}' operator to non-numeric operands") \
+#define ENUMERATE_SQL_ERRORS(S)                                                                   \
+    S(NoError, "No error")                                                                        \
+    S(InternalError, "{}")                                                                        \
+    S(NotYetImplemented, "{}")                                                                    \
+    S(DatabaseUnavailable, "Database Unavailable")                                                \
+    S(StatementUnavailable, "Statement with id '{}' Unavailable")                                 \
+    S(SyntaxError, "Syntax Error")                                                                \
+    S(DatabaseDoesNotExist, "Database '{}' does not exist")                                       \
+    S(SchemaDoesNotExist, "Schema '{}' does not exist")                                           \
+    S(SchemaExists, "Schema '{}' already exist")                                                  \
+    S(TableDoesNotExist, "Table '{}' does not exist")                                             \
+    S(ColumnDoesNotExist, "Column '{}' does not exist")                                           \
+    S(AmbiguousColumnName, "Column name '{}' is ambiguous")                                       \
+    S(TableExists, "Table '{}' already exist")                                                    \
+    S(InvalidType, "Invalid type '{}'")                                                           \
+    S(InvalidDatabaseName, "Invalid database name '{}'")                                          \
+    S(InvalidValueType, "Invalid type for attribute '{}'")                                        \
+    S(InvalidNumberOfPlaceholderValues, "Number of values does not match number of placeholders") \
+    S(InvalidNumberOfValues, "Number of values does not match number of columns")                 \
+    S(BooleanOperatorTypeMismatch, "Cannot apply '{}' operator to non-boolean operands")          \
+    S(NumericOperatorTypeMismatch, "Cannot apply '{}' operator to non-numeric operands")          \
+    S(IntegerOperatorTypeMismatch, "Cannot apply '{}' operator to non-numeric operands")          \
     S(InvalidOperator, "Invalid operator '{}'")
 
 enum class SQLErrorCode {

--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -9,35 +9,35 @@
 
 namespace SQL {
 
-void SQLClient::connected(int connection_id, DeprecatedString const& connected_to_database)
+void SQLClient::connected(u64 connection_id, DeprecatedString const& connected_to_database)
 {
     if (on_connected)
         on_connected(connection_id, connected_to_database);
 }
 
-void SQLClient::disconnected(int connection_id)
+void SQLClient::disconnected(u64 connection_id)
 {
     if (on_disconnected)
         on_disconnected(connection_id);
 }
 
-void SQLClient::connection_error(int connection_id, int code, DeprecatedString const& message)
+void SQLClient::connection_error(u64 connection_id, SQLErrorCode const& code, DeprecatedString const& message)
 {
     if (on_connection_error)
         on_connection_error(connection_id, code, message);
     else
-        warnln("Connection error for connection_id {}: {} ({})", connection_id, message, code);
+        warnln("Connection error for connection_id {}: {} ({})", connection_id, message, to_underlying(code));
 }
 
-void SQLClient::execution_error(int statement_id, int code, DeprecatedString const& message)
+void SQLClient::execution_error(u64 statement_id, SQLErrorCode const& code, DeprecatedString const& message)
 {
     if (on_execution_error)
         on_execution_error(statement_id, code, message);
     else
-        warnln("Execution error for statement_id {}: {} ({})", statement_id, message, code);
+        warnln("Execution error for statement_id {}: {} ({})", statement_id, message, to_underlying(code));
 }
 
-void SQLClient::execution_success(int statement_id, bool has_results, int created, int updated, int deleted)
+void SQLClient::execution_success(u64 statement_id, bool has_results, size_t created, size_t updated, size_t deleted)
 {
     if (on_execution_success)
         on_execution_success(statement_id, has_results, created, updated, deleted);
@@ -45,7 +45,7 @@ void SQLClient::execution_success(int statement_id, bool has_results, int create
         outln("{} row(s) created, {} updated, {} deleted", created, updated, deleted);
 }
 
-void SQLClient::next_result(int statement_id, Vector<DeprecatedString> const& row)
+void SQLClient::next_result(u64 statement_id, Vector<DeprecatedString> const& row)
 {
     if (on_next_result) {
         on_next_result(statement_id, row);
@@ -61,7 +61,7 @@ void SQLClient::next_result(int statement_id, Vector<DeprecatedString> const& ro
     outln();
 }
 
-void SQLClient::results_exhausted(int statement_id, int total_rows)
+void SQLClient::results_exhausted(u64 statement_id, size_t total_rows)
 {
     if (on_results_exhausted)
         on_results_exhausted(statement_id, total_rows);

--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -9,26 +9,6 @@
 
 namespace SQL {
 
-void SQLClient::connected(u64 connection_id, DeprecatedString const& connected_to_database)
-{
-    if (on_connected)
-        on_connected(connection_id, connected_to_database);
-}
-
-void SQLClient::disconnected(u64 connection_id)
-{
-    if (on_disconnected)
-        on_disconnected(connection_id);
-}
-
-void SQLClient::connection_error(u64 connection_id, SQLErrorCode const& code, DeprecatedString const& message)
-{
-    if (on_connection_error)
-        on_connection_error(connection_id, code, message);
-    else
-        warnln("Connection error for connection_id {}: {} ({})", connection_id, message, to_underlying(code));
-}
-
 void SQLClient::execution_error(u64 statement_id, u64 execution_id, SQLErrorCode const& code, DeprecatedString const& message)
 {
     if (on_execution_error)

--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -29,26 +29,26 @@ void SQLClient::connection_error(u64 connection_id, SQLErrorCode const& code, De
         warnln("Connection error for connection_id {}: {} ({})", connection_id, message, to_underlying(code));
 }
 
-void SQLClient::execution_error(u64 statement_id, SQLErrorCode const& code, DeprecatedString const& message)
+void SQLClient::execution_error(u64 statement_id, u64 execution_id, SQLErrorCode const& code, DeprecatedString const& message)
 {
     if (on_execution_error)
-        on_execution_error(statement_id, code, message);
+        on_execution_error(statement_id, execution_id, code, message);
     else
         warnln("Execution error for statement_id {}: {} ({})", statement_id, message, to_underlying(code));
 }
 
-void SQLClient::execution_success(u64 statement_id, bool has_results, size_t created, size_t updated, size_t deleted)
+void SQLClient::execution_success(u64 statement_id, u64 execution_id, bool has_results, size_t created, size_t updated, size_t deleted)
 {
     if (on_execution_success)
-        on_execution_success(statement_id, has_results, created, updated, deleted);
+        on_execution_success(statement_id, execution_id, has_results, created, updated, deleted);
     else
         outln("{} row(s) created, {} updated, {} deleted", created, updated, deleted);
 }
 
-void SQLClient::next_result(u64 statement_id, Vector<DeprecatedString> const& row)
+void SQLClient::next_result(u64 statement_id, u64 execution_id, Vector<DeprecatedString> const& row)
 {
     if (on_next_result) {
-        on_next_result(statement_id, row);
+        on_next_result(statement_id, execution_id, row);
         return;
     }
     bool first = true;
@@ -61,10 +61,10 @@ void SQLClient::next_result(u64 statement_id, Vector<DeprecatedString> const& ro
     outln();
 }
 
-void SQLClient::results_exhausted(u64 statement_id, size_t total_rows)
+void SQLClient::results_exhausted(u64 statement_id, u64 execution_id, size_t total_rows)
 {
     if (on_results_exhausted)
-        on_results_exhausted(statement_id, total_rows);
+        on_results_exhausted(statement_id, execution_id, total_rows);
     else
         outln("{} total row(s)", total_rows);
 }

--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -25,12 +25,13 @@ void SQLClient::execution_success(u64 statement_id, u64 execution_id, bool has_r
         outln("{} row(s) created, {} updated, {} deleted", created, updated, deleted);
 }
 
-void SQLClient::next_result(u64 statement_id, u64 execution_id, Vector<DeprecatedString> const& row)
+void SQLClient::next_result(u64 statement_id, u64 execution_id, Vector<SQL::Value> const& row)
 {
     if (on_next_result) {
         on_next_result(statement_id, execution_id, row);
         return;
     }
+
     bool first = true;
     for (auto& column : row) {
         if (!first)

--- a/Userland/Libraries/LibSQL/SQLClient.h
+++ b/Userland/Libraries/LibSQL/SQLClient.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibIPC/ConnectionToServer.h>
+#include <LibSQL/Result.h>
 #include <SQLServer/SQLClientEndpoint.h>
 #include <SQLServer/SQLServerEndpoint.h>
 
@@ -19,13 +20,13 @@ class SQLClient
     IPC_CLIENT_CONNECTION(SQLClient, "/tmp/session/%sid/portal/sql"sv)
     virtual ~SQLClient() = default;
 
-    Function<void(int, DeprecatedString const&)> on_connected;
-    Function<void(int)> on_disconnected;
-    Function<void(int, int, DeprecatedString const&)> on_connection_error;
-    Function<void(int, int, DeprecatedString const&)> on_execution_error;
-    Function<void(int, bool, int, int, int)> on_execution_success;
-    Function<void(int, Vector<DeprecatedString> const&)> on_next_result;
-    Function<void(int, int)> on_results_exhausted;
+    Function<void(u64, DeprecatedString const&)> on_connected;
+    Function<void(u64)> on_disconnected;
+    Function<void(u64, SQLErrorCode, DeprecatedString const&)> on_connection_error;
+    Function<void(u64, SQLErrorCode, DeprecatedString const&)> on_execution_error;
+    Function<void(u64, bool, size_t, size_t, size_t)> on_execution_success;
+    Function<void(u64, Vector<DeprecatedString> const&)> on_next_result;
+    Function<void(u64, size_t)> on_results_exhausted;
 
 private:
     SQLClient(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
@@ -33,13 +34,13 @@ private:
     {
     }
 
-    virtual void connected(int connection_id, DeprecatedString const& connected_to_database) override;
-    virtual void connection_error(int connection_id, int code, DeprecatedString const& message) override;
-    virtual void execution_success(int statement_id, bool has_results, int created, int updated, int deleted) override;
-    virtual void next_result(int statement_id, Vector<DeprecatedString> const&) override;
-    virtual void results_exhausted(int statement_id, int total_rows) override;
-    virtual void execution_error(int statement_id, int code, DeprecatedString const& message) override;
-    virtual void disconnected(int connection_id) override;
+    virtual void connected(u64 connection_id, DeprecatedString const& connected_to_database) override;
+    virtual void connection_error(u64 connection_id, SQLErrorCode const& code, DeprecatedString const& message) override;
+    virtual void execution_success(u64 statement_id, bool has_results, size_t created, size_t updated, size_t deleted) override;
+    virtual void next_result(u64 statement_id, Vector<DeprecatedString> const&) override;
+    virtual void results_exhausted(u64 statement_id, size_t total_rows) override;
+    virtual void execution_error(u64 statement_id, SQLErrorCode const& code, DeprecatedString const& message) override;
+    virtual void disconnected(u64 connection_id) override;
 };
 
 }

--- a/Userland/Libraries/LibSQL/SQLClient.h
+++ b/Userland/Libraries/LibSQL/SQLClient.h
@@ -22,7 +22,7 @@ class SQLClient
 
     Function<void(u64, u64, SQLErrorCode, DeprecatedString const&)> on_execution_error;
     Function<void(u64, u64, bool, size_t, size_t, size_t)> on_execution_success;
-    Function<void(u64, u64, Vector<DeprecatedString> const&)> on_next_result;
+    Function<void(u64, u64, Span<SQL::Value const>)> on_next_result;
     Function<void(u64, u64, size_t)> on_results_exhausted;
 
 private:
@@ -32,7 +32,7 @@ private:
     }
 
     virtual void execution_success(u64 statement_id, u64 execution_id, bool has_results, size_t created, size_t updated, size_t deleted) override;
-    virtual void next_result(u64 statement_id, u64 execution_id, Vector<DeprecatedString> const&) override;
+    virtual void next_result(u64 statement_id, u64 execution_id, Vector<SQL::Value> const&) override;
     virtual void results_exhausted(u64 statement_id, u64 execution_id, size_t total_rows) override;
     virtual void execution_error(u64 statement_id, u64 execution_id, SQLErrorCode const& code, DeprecatedString const& message) override;
 };

--- a/Userland/Libraries/LibSQL/SQLClient.h
+++ b/Userland/Libraries/LibSQL/SQLClient.h
@@ -23,10 +23,10 @@ class SQLClient
     Function<void(u64, DeprecatedString const&)> on_connected;
     Function<void(u64)> on_disconnected;
     Function<void(u64, SQLErrorCode, DeprecatedString const&)> on_connection_error;
-    Function<void(u64, SQLErrorCode, DeprecatedString const&)> on_execution_error;
-    Function<void(u64, bool, size_t, size_t, size_t)> on_execution_success;
-    Function<void(u64, Vector<DeprecatedString> const&)> on_next_result;
-    Function<void(u64, size_t)> on_results_exhausted;
+    Function<void(u64, u64, SQLErrorCode, DeprecatedString const&)> on_execution_error;
+    Function<void(u64, u64, bool, size_t, size_t, size_t)> on_execution_success;
+    Function<void(u64, u64, Vector<DeprecatedString> const&)> on_next_result;
+    Function<void(u64, u64, size_t)> on_results_exhausted;
 
 private:
     SQLClient(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
@@ -36,10 +36,10 @@ private:
 
     virtual void connected(u64 connection_id, DeprecatedString const& connected_to_database) override;
     virtual void connection_error(u64 connection_id, SQLErrorCode const& code, DeprecatedString const& message) override;
-    virtual void execution_success(u64 statement_id, bool has_results, size_t created, size_t updated, size_t deleted) override;
-    virtual void next_result(u64 statement_id, Vector<DeprecatedString> const&) override;
-    virtual void results_exhausted(u64 statement_id, size_t total_rows) override;
-    virtual void execution_error(u64 statement_id, SQLErrorCode const& code, DeprecatedString const& message) override;
+    virtual void execution_success(u64 statement_id, u64 execution_id, bool has_results, size_t created, size_t updated, size_t deleted) override;
+    virtual void next_result(u64 statement_id, u64 execution_id, Vector<DeprecatedString> const&) override;
+    virtual void results_exhausted(u64 statement_id, u64 execution_id, size_t total_rows) override;
+    virtual void execution_error(u64 statement_id, u64 execution_id, SQLErrorCode const& code, DeprecatedString const& message) override;
     virtual void disconnected(u64 connection_id) override;
 };
 

--- a/Userland/Libraries/LibSQL/SQLClient.h
+++ b/Userland/Libraries/LibSQL/SQLClient.h
@@ -20,9 +20,6 @@ class SQLClient
     IPC_CLIENT_CONNECTION(SQLClient, "/tmp/session/%sid/portal/sql"sv)
     virtual ~SQLClient() = default;
 
-    Function<void(u64, DeprecatedString const&)> on_connected;
-    Function<void(u64)> on_disconnected;
-    Function<void(u64, SQLErrorCode, DeprecatedString const&)> on_connection_error;
     Function<void(u64, u64, SQLErrorCode, DeprecatedString const&)> on_execution_error;
     Function<void(u64, u64, bool, size_t, size_t, size_t)> on_execution_success;
     Function<void(u64, u64, Vector<DeprecatedString> const&)> on_next_result;
@@ -34,13 +31,10 @@ private:
     {
     }
 
-    virtual void connected(u64 connection_id, DeprecatedString const& connected_to_database) override;
-    virtual void connection_error(u64 connection_id, SQLErrorCode const& code, DeprecatedString const& message) override;
     virtual void execution_success(u64 statement_id, u64 execution_id, bool has_results, size_t created, size_t updated, size_t deleted) override;
     virtual void next_result(u64 statement_id, u64 execution_id, Vector<DeprecatedString> const&) override;
     virtual void results_exhausted(u64 statement_id, u64 execution_id, size_t total_rows) override;
     virtual void execution_error(u64 statement_id, u64 execution_id, SQLErrorCode const& code, DeprecatedString const& message) override;
-    virtual void disconnected(u64 connection_id) override;
 };
 
 }

--- a/Userland/Libraries/LibSQL/Tuple.cpp
+++ b/Userland/Libraries/LibSQL/Tuple.cpp
@@ -176,15 +176,6 @@ DeprecatedString Tuple::to_deprecated_string() const
     return builder.build();
 }
 
-Vector<DeprecatedString> Tuple::to_deprecated_string_vector() const
-{
-    Vector<DeprecatedString> ret;
-    for (auto& value : m_data) {
-        ret.append(value.to_deprecated_string());
-    }
-    return ret;
-}
-
 void Tuple::copy_from(Tuple const& other)
 {
     if (*m_descriptor != *other.m_descriptor) {

--- a/Userland/Libraries/LibSQL/Tuple.h
+++ b/Userland/Libraries/LibSQL/Tuple.h
@@ -37,7 +37,6 @@ public:
 
     [[nodiscard]] DeprecatedString to_deprecated_string() const;
     explicit operator DeprecatedString() const { return to_deprecated_string(); }
-    [[nodiscard]] Vector<DeprecatedString> to_deprecated_string_vector() const;
 
     bool operator<(Tuple const& other) const { return compare(other) < 0; }
     bool operator<=(Tuple const& other) const { return compare(other) <= 0; }
@@ -68,6 +67,8 @@ public:
     [[nodiscard]] int compare(Tuple const&) const;
     [[nodiscard]] int match(Tuple const&) const;
     [[nodiscard]] u32 hash() const;
+
+    [[nodiscard]] Vector<Value> take_data() { return move(m_data); }
 
 protected:
     [[nodiscard]] Optional<size_t> index_of(StringView) const;

--- a/Userland/Libraries/LibSQL/Value.cpp
+++ b/Userland/Libraries/LibSQL/Value.cpp
@@ -100,6 +100,21 @@ StringView Value::type_name() const
     }
 }
 
+bool Value::is_type_compatible_with(SQLType other_type) const
+{
+    switch (type()) {
+    case SQLType::Null:
+        return false;
+    case SQLType::Integer:
+    case SQLType::Float:
+        return other_type == SQLType::Integer || other_type == SQLType::Float;
+    default:
+        break;
+    }
+
+    return type() == other_type;
+}
+
 bool Value::is_null() const
 {
     return !m_value.has_value();

--- a/Userland/Libraries/LibSQL/Value.h
+++ b/Userland/Libraries/LibSQL/Value.h
@@ -13,6 +13,7 @@
 #include <AK/StringView.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibIPC/Forward.h>
 #include <LibSQL/Forward.h>
 #include <LibSQL/Result.h>
 #include <LibSQL/Type.h>
@@ -129,3 +130,13 @@ struct AK::Formatter<SQL::Value> : Formatter<StringView> {
         return Formatter<StringView>::format(builder, value.to_deprecated_string());
     }
 };
+
+namespace IPC {
+
+template<>
+bool encode(Encoder&, SQL::Value const&);
+
+template<>
+ErrorOr<void> decode(Decoder&, SQL::Value&);
+
+}

--- a/Userland/Libraries/LibSQL/Value.h
+++ b/Userland/Libraries/LibSQL/Value.h
@@ -47,6 +47,7 @@ public:
 
     [[nodiscard]] SQLType type() const;
     [[nodiscard]] StringView type_name() const;
+    [[nodiscard]] bool is_type_compatible_with(SQLType) const;
     [[nodiscard]] bool is_null() const;
 
     [[nodiscard]] DeprecatedString to_deprecated_string() const;

--- a/Userland/Services/SQLServer/ConnectionFromClient.cpp
+++ b/Userland/Services/SQLServer/ConnectionFromClient.cpp
@@ -71,12 +71,13 @@ Messages::SQLServer::PrepareStatementResponse ConnectionFromClient::prepare_stat
     return { result.value() };
 }
 
-void ConnectionFromClient::execute_statement(int statement_id)
+void ConnectionFromClient::execute_statement(int statement_id, Vector<SQL::Value> const& placeholder_values)
 {
     dbgln_if(SQLSERVER_DEBUG, "ConnectionFromClient::execute_query_statement(statement_id: {})", statement_id);
     auto statement = SQLStatement::statement_for(statement_id);
     if (statement && statement->connection()->client_id() == client_id()) {
-        statement->execute();
+        // FIXME: Support taking parameters from IPC requests.
+        statement->execute(move(const_cast<Vector<SQL::Value>&>(placeholder_values)));
     } else {
         dbgln_if(SQLSERVER_DEBUG, "Statement has disappeared");
         async_execution_error(statement_id, (int)SQL::SQLErrorCode::StatementUnavailable, DeprecatedString::formatted("{}", statement_id));

--- a/Userland/Services/SQLServer/ConnectionFromClient.cpp
+++ b/Userland/Services/SQLServer/ConnectionFromClient.cpp
@@ -37,8 +37,10 @@ void ConnectionFromClient::die()
 Messages::SQLServer::ConnectResponse ConnectionFromClient::connect(DeprecatedString const& database_name)
 {
     dbgln_if(SQLSERVER_DEBUG, "ConnectionFromClient::connect(database_name: {})", database_name);
-    auto database_connection = DatabaseConnection::construct(database_name, client_id());
-    return { database_connection->connection_id() };
+
+    if (auto database_connection = DatabaseConnection::create(database_name, client_id()); !database_connection.is_error())
+        return { database_connection.value()->connection_id() };
+    return { {} };
 }
 
 void ConnectionFromClient::disconnect(u64 connection_id)

--- a/Userland/Services/SQLServer/ConnectionFromClient.h
+++ b/Userland/Services/SQLServer/ConnectionFromClient.h
@@ -29,9 +29,9 @@ private:
     explicit ConnectionFromClient(NonnullOwnPtr<Core::Stream::LocalSocket>, int client_id);
 
     virtual Messages::SQLServer::ConnectResponse connect(DeprecatedString const&) override;
-    virtual Messages::SQLServer::PrepareStatementResponse prepare_statement(int, DeprecatedString const&) override;
-    virtual void execute_statement(int, Vector<SQL::Value> const& placeholder_values) override;
-    virtual void disconnect(int) override;
+    virtual Messages::SQLServer::PrepareStatementResponse prepare_statement(u64, DeprecatedString const&) override;
+    virtual void execute_statement(u64, Vector<SQL::Value> const& placeholder_values) override;
+    virtual void disconnect(u64) override;
 };
 
 }

--- a/Userland/Services/SQLServer/ConnectionFromClient.h
+++ b/Userland/Services/SQLServer/ConnectionFromClient.h
@@ -30,7 +30,7 @@ private:
 
     virtual Messages::SQLServer::ConnectResponse connect(DeprecatedString const&) override;
     virtual Messages::SQLServer::PrepareStatementResponse prepare_statement(u64, DeprecatedString const&) override;
-    virtual void execute_statement(u64, Vector<SQL::Value> const& placeholder_values) override;
+    virtual Messages::SQLServer::ExecuteStatementResponse execute_statement(u64, Vector<SQL::Value> const& placeholder_values) override;
     virtual void disconnect(u64) override;
 };
 

--- a/Userland/Services/SQLServer/ConnectionFromClient.h
+++ b/Userland/Services/SQLServer/ConnectionFromClient.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/Vector.h>
 #include <LibIPC/ConnectionFromClient.h>
 #include <SQLServer/SQLClientEndpoint.h>
 #include <SQLServer/SQLServerEndpoint.h>
@@ -29,7 +30,7 @@ private:
 
     virtual Messages::SQLServer::ConnectResponse connect(DeprecatedString const&) override;
     virtual Messages::SQLServer::PrepareStatementResponse prepare_statement(int, DeprecatedString const&) override;
-    virtual void execute_statement(int) override;
+    virtual void execute_statement(int, Vector<SQL::Value> const& placeholder_values) override;
     virtual void disconnect(int) override;
 };
 

--- a/Userland/Services/SQLServer/DatabaseConnection.h
+++ b/Userland/Services/SQLServer/DatabaseConnection.h
@@ -19,20 +19,20 @@ class DatabaseConnection final : public Core::Object {
 public:
     ~DatabaseConnection() override = default;
 
-    static RefPtr<DatabaseConnection> connection_for(int connection_id);
-    int connection_id() const { return m_connection_id; }
+    static RefPtr<DatabaseConnection> connection_for(u64 connection_id);
+    u64 connection_id() const { return m_connection_id; }
     int client_id() const { return m_client_id; }
     RefPtr<SQL::Database> database() { return m_database; }
     void disconnect();
-    SQL::ResultOr<int> prepare_statement(StringView sql);
+    SQL::ResultOr<u64> prepare_statement(StringView sql);
 
 private:
     DatabaseConnection(DeprecatedString database_name, int client_id);
 
     RefPtr<SQL::Database> m_database { nullptr };
     DeprecatedString m_database_name;
-    int m_connection_id;
-    int m_client_id;
+    u64 m_connection_id { 0 };
+    int m_client_id { 0 };
     bool m_accept_statements { false };
 };
 

--- a/Userland/Services/SQLServer/DatabaseConnection.h
+++ b/Userland/Services/SQLServer/DatabaseConnection.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/NonnullRefPtr.h>
 #include <LibCore/Object.h>
 #include <LibSQL/Database.h>
 #include <LibSQL/Result.h>
@@ -14,26 +15,26 @@
 namespace SQLServer {
 
 class DatabaseConnection final : public Core::Object {
-    C_OBJECT(DatabaseConnection)
+    C_OBJECT_ABSTRACT(DatabaseConnection)
 
 public:
+    static ErrorOr<NonnullRefPtr<DatabaseConnection>> create(DeprecatedString database_name, int client_id);
     ~DatabaseConnection() override = default;
 
     static RefPtr<DatabaseConnection> connection_for(u64 connection_id);
     u64 connection_id() const { return m_connection_id; }
     int client_id() const { return m_client_id; }
-    RefPtr<SQL::Database> database() { return m_database; }
+    NonnullRefPtr<SQL::Database> database() { return m_database; }
     void disconnect();
     SQL::ResultOr<u64> prepare_statement(StringView sql);
 
 private:
-    DatabaseConnection(DeprecatedString database_name, int client_id);
+    DatabaseConnection(NonnullRefPtr<SQL::Database> database, DeprecatedString database_name, int client_id);
 
-    RefPtr<SQL::Database> m_database { nullptr };
+    NonnullRefPtr<SQL::Database> m_database;
     DeprecatedString m_database_name;
     u64 m_connection_id { 0 };
     int m_client_id { 0 };
-    bool m_accept_statements { false };
 };
 
 }

--- a/Userland/Services/SQLServer/DatabaseConnection.h
+++ b/Userland/Services/SQLServer/DatabaseConnection.h
@@ -8,6 +8,7 @@
 
 #include <LibCore/Object.h>
 #include <LibSQL/Database.h>
+#include <LibSQL/Result.h>
 #include <SQLServer/Forward.h>
 
 namespace SQLServer {
@@ -23,7 +24,7 @@ public:
     int client_id() const { return m_client_id; }
     RefPtr<SQL::Database> database() { return m_database; }
     void disconnect();
-    int prepare_statement(DeprecatedString const& sql);
+    SQL::ResultOr<int> prepare_statement(StringView sql);
 
 private:
     DatabaseConnection(DeprecatedString database_name, int client_id);

--- a/Userland/Services/SQLServer/SQLClient.ipc
+++ b/Userland/Services/SQLServer/SQLClient.ipc
@@ -1,10 +1,12 @@
+#include <LibSQL/Result.h>
+
 endpoint SQLClient
 {
-    connected(int connection_id, DeprecatedString connected_to_database) =|
-    connection_error(int connection_id, int code, DeprecatedString message) =|
-    execution_success(int statement_id, bool has_results, int created, int updated, int deleted) =|
-    next_result(int statement_id, Vector<DeprecatedString> row) =|
-    results_exhausted(int statement_id, int total_rows) =|
-    execution_error(int statement_id, int code, DeprecatedString message) =|
-    disconnected(int connection_id) =|
+    connected(u64 connection_id, DeprecatedString connected_to_database) =|
+    connection_error(u64 connection_id, SQL::SQLErrorCode code, DeprecatedString message) =|
+    execution_success(u64 statement_id, bool has_results, size_t created, size_t updated, size_t deleted) =|
+    next_result(u64 statement_id, Vector<DeprecatedString> row) =|
+    results_exhausted(u64 statement_id, size_t total_rows) =|
+    execution_error(u64 statement_id, SQL::SQLErrorCode code, DeprecatedString message) =|
+    disconnected(u64 connection_id) =|
 }

--- a/Userland/Services/SQLServer/SQLClient.ipc
+++ b/Userland/Services/SQLServer/SQLClient.ipc
@@ -4,9 +4,9 @@ endpoint SQLClient
 {
     connected(u64 connection_id, DeprecatedString connected_to_database) =|
     connection_error(u64 connection_id, SQL::SQLErrorCode code, DeprecatedString message) =|
-    execution_success(u64 statement_id, bool has_results, size_t created, size_t updated, size_t deleted) =|
-    next_result(u64 statement_id, Vector<DeprecatedString> row) =|
-    results_exhausted(u64 statement_id, size_t total_rows) =|
-    execution_error(u64 statement_id, SQL::SQLErrorCode code, DeprecatedString message) =|
+    execution_success(u64 statement_id, u64 execution_id, bool has_results, size_t created, size_t updated, size_t deleted) =|
+    next_result(u64 statement_id, u64 execution_id, Vector<DeprecatedString> row) =|
+    results_exhausted(u64 statement_id, u64 execution_id, size_t total_rows) =|
+    execution_error(u64 statement_id, u64 execution_id, SQL::SQLErrorCode code, DeprecatedString message) =|
     disconnected(u64 connection_id) =|
 }

--- a/Userland/Services/SQLServer/SQLClient.ipc
+++ b/Userland/Services/SQLServer/SQLClient.ipc
@@ -2,11 +2,8 @@
 
 endpoint SQLClient
 {
-    connected(u64 connection_id, DeprecatedString connected_to_database) =|
-    connection_error(u64 connection_id, SQL::SQLErrorCode code, DeprecatedString message) =|
     execution_success(u64 statement_id, u64 execution_id, bool has_results, size_t created, size_t updated, size_t deleted) =|
     next_result(u64 statement_id, u64 execution_id, Vector<DeprecatedString> row) =|
     results_exhausted(u64 statement_id, u64 execution_id, size_t total_rows) =|
     execution_error(u64 statement_id, u64 execution_id, SQL::SQLErrorCode code, DeprecatedString message) =|
-    disconnected(u64 connection_id) =|
 }

--- a/Userland/Services/SQLServer/SQLClient.ipc
+++ b/Userland/Services/SQLServer/SQLClient.ipc
@@ -1,9 +1,10 @@
 #include <LibSQL/Result.h>
+#include <LibSQL/Value.h>
 
 endpoint SQLClient
 {
     execution_success(u64 statement_id, u64 execution_id, bool has_results, size_t created, size_t updated, size_t deleted) =|
-    next_result(u64 statement_id, u64 execution_id, Vector<DeprecatedString> row) =|
+    next_result(u64 statement_id, u64 execution_id, Vector<SQL::Value> row) =|
     results_exhausted(u64 statement_id, u64 execution_id, size_t total_rows) =|
     execution_error(u64 statement_id, u64 execution_id, SQL::SQLErrorCode code, DeprecatedString message) =|
 }

--- a/Userland/Services/SQLServer/SQLServer.ipc
+++ b/Userland/Services/SQLServer/SQLServer.ipc
@@ -4,6 +4,6 @@ endpoint SQLServer
 {
     connect(DeprecatedString name) => (u64 connection_id)
     prepare_statement(u64 connection_id, DeprecatedString statement) => (Optional<u64> statement_id)
-    execute_statement(u64 statement_id, Vector<SQL::Value> placeholder_values) =|
+    execute_statement(u64 statement_id, Vector<SQL::Value> placeholder_values) => (Optional<u64> execution_id)
     disconnect(u64 connection_id) =|
 }

--- a/Userland/Services/SQLServer/SQLServer.ipc
+++ b/Userland/Services/SQLServer/SQLServer.ipc
@@ -1,7 +1,9 @@
+#include <LibSQL/Value.h>
+
 endpoint SQLServer
 {
     connect(DeprecatedString name) => (int connection_id)
     prepare_statement(int connection_id, DeprecatedString statement) => (int statement_id)
-    execute_statement(int statement_id) =|
+    execute_statement(int statement_id, Vector<SQL::Value> placeholder_values) =|
     disconnect(int connection_id) =|
 }

--- a/Userland/Services/SQLServer/SQLServer.ipc
+++ b/Userland/Services/SQLServer/SQLServer.ipc
@@ -2,8 +2,8 @@
 
 endpoint SQLServer
 {
-    connect(DeprecatedString name) => (u64 connection_id)
+    connect(DeprecatedString name) => (Optional<u64> connection_id)
     prepare_statement(u64 connection_id, DeprecatedString statement) => (Optional<u64> statement_id)
     execute_statement(u64 statement_id, Vector<SQL::Value> placeholder_values) => (Optional<u64> execution_id)
-    disconnect(u64 connection_id) =|
+    disconnect(u64 connection_id) => ()
 }

--- a/Userland/Services/SQLServer/SQLServer.ipc
+++ b/Userland/Services/SQLServer/SQLServer.ipc
@@ -2,8 +2,8 @@
 
 endpoint SQLServer
 {
-    connect(DeprecatedString name) => (int connection_id)
-    prepare_statement(int connection_id, DeprecatedString statement) => (int statement_id)
-    execute_statement(int statement_id, Vector<SQL::Value> placeholder_values) =|
-    disconnect(int connection_id) =|
+    connect(DeprecatedString name) => (u64 connection_id)
+    prepare_statement(u64 connection_id, DeprecatedString statement) => (Optional<u64> statement_id)
+    execute_statement(u64 statement_id, Vector<SQL::Value> placeholder_values) =|
+    disconnect(u64 connection_id) =|
 }

--- a/Userland/Services/SQLServer/SQLStatement.cpp
+++ b/Userland/Services/SQLServer/SQLStatement.cpp
@@ -125,7 +125,7 @@ void SQLStatement::next(u64 execution_id, SQL::ResultSet result, size_t result_s
 
     if (!result.is_empty()) {
         auto result_row = result.take_first();
-        client_connection->async_next_result(statement_id(), execution_id, result_row.row.to_deprecated_string_vector());
+        client_connection->async_next_result(statement_id(), execution_id, result_row.row.take_data());
 
         deferred_invoke([this, execution_id, result = move(result), result_size]() {
             next(execution_id, move(result), result_size);

--- a/Userland/Services/SQLServer/SQLStatement.cpp
+++ b/Userland/Services/SQLServer/SQLStatement.cpp
@@ -74,9 +74,7 @@ Optional<u64> SQLStatement::execute(Vector<SQL::Value> placeholder_values)
     m_ongoing_executions.set(execution_id);
 
     deferred_invoke([this, placeholder_values = move(placeholder_values), execution_id] {
-        VERIFY(!connection()->database().is_null());
-
-        auto execution_result = m_statement->execute(connection()->database().release_nonnull(), placeholder_values);
+        auto execution_result = m_statement->execute(connection()->database(), placeholder_values);
         m_ongoing_executions.remove(execution_id);
 
         if (execution_result.is_error()) {

--- a/Userland/Services/SQLServer/SQLStatement.cpp
+++ b/Userland/Services/SQLServer/SQLStatement.cpp
@@ -24,12 +24,23 @@ RefPtr<SQLStatement> SQLStatement::statement_for(int statement_id)
 
 static int s_next_statement_id = 0;
 
-SQLStatement::SQLStatement(DatabaseConnection& connection, DeprecatedString sql)
+SQL::ResultOr<NonnullRefPtr<SQLStatement>> SQLStatement::create(DatabaseConnection& connection, StringView sql)
+{
+    auto parser = SQL::AST::Parser(SQL::AST::Lexer(sql));
+    auto statement = parser.next_statement();
+
+    if (parser.has_errors())
+        return SQL::Result { SQL::SQLCommand::Unknown, SQL::SQLErrorCode::SyntaxError, parser.errors()[0].to_deprecated_string() };
+
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) SQLStatement(connection, move(statement))));
+}
+
+SQLStatement::SQLStatement(DatabaseConnection& connection, NonnullRefPtr<SQL::AST::Statement> statement)
     : Core::Object(&connection)
     , m_statement_id(s_next_statement_id++)
-    , m_sql(move(sql))
+    , m_statement(move(statement))
 {
-    dbgln_if(SQLSERVER_DEBUG, "SQLStatement({}, {})", connection.connection_id(), sql);
+    dbgln_if(SQLSERVER_DEBUG, "SQLStatement({})", connection.connection_id());
     s_statements.set(m_statement_id, *this);
 }
 
@@ -47,7 +58,6 @@ void SQLStatement::report_error(SQL::Result result)
     else
         warnln("Cannot return execution error. Client disconnected");
 
-    m_statement = nullptr;
     m_result = {};
 }
 
@@ -61,12 +71,6 @@ void SQLStatement::execute()
     }
 
     deferred_invoke([this] {
-        auto parse_result = parse();
-        if (parse_result.is_error()) {
-            report_error(parse_result.release_error());
-            return;
-        }
-
         VERIFY(!connection()->database().is_null());
 
         auto execution_result = m_statement->execute(connection()->database().release_nonnull());
@@ -91,16 +95,6 @@ void SQLStatement::execute()
             client_connection->async_execution_success(statement_id(), false, 0, m_result->size(), 0);
         }
     });
-}
-
-SQL::ResultOr<void> SQLStatement::parse()
-{
-    auto parser = SQL::AST::Parser(SQL::AST::Lexer(m_sql));
-    m_statement = parser.next_statement();
-
-    if (parser.has_errors())
-        return SQL::Result { SQL::SQLCommand::Unknown, SQL::SQLErrorCode::SyntaxError, parser.errors()[0].to_deprecated_string() };
-    return {};
 }
 
 bool SQLStatement::should_send_result_rows() const

--- a/Userland/Services/SQLServer/SQLStatement.cpp
+++ b/Userland/Services/SQLServer/SQLStatement.cpp
@@ -12,17 +12,16 @@
 
 namespace SQLServer {
 
-static HashMap<int, NonnullRefPtr<SQLStatement>> s_statements;
+static HashMap<u64, NonnullRefPtr<SQLStatement>> s_statements;
+static u64 s_next_statement_id = 0;
 
-RefPtr<SQLStatement> SQLStatement::statement_for(int statement_id)
+RefPtr<SQLStatement> SQLStatement::statement_for(u64 statement_id)
 {
     if (s_statements.contains(statement_id))
         return *s_statements.get(statement_id).value();
     dbgln_if(SQLSERVER_DEBUG, "Invalid statement_id {}", statement_id);
     return nullptr;
 }
-
-static int s_next_statement_id = 0;
 
 SQL::ResultOr<NonnullRefPtr<SQLStatement>> SQLStatement::create(DatabaseConnection& connection, StringView sql)
 {
@@ -54,7 +53,7 @@ void SQLStatement::report_error(SQL::Result result)
     remove_from_parent();
 
     if (client_connection)
-        client_connection->async_execution_error(statement_id(), (int)result.error(), result.error_string());
+        client_connection->async_execution_error(statement_id(), result.error(), result.error_string());
     else
         warnln("Cannot return execution error. Client disconnected");
 
@@ -129,7 +128,7 @@ void SQLStatement::next()
             next();
         });
     } else {
-        client_connection->async_results_exhausted(statement_id(), (int)m_index);
+        client_connection->async_results_exhausted(statement_id(), m_index);
     }
 }
 

--- a/Userland/Services/SQLServer/SQLStatement.cpp
+++ b/Userland/Services/SQLServer/SQLStatement.cpp
@@ -94,7 +94,14 @@ Optional<u64> SQLStatement::execute(Vector<SQL::Value> placeholder_values)
             auto result_size = result.size();
             next(execution_id, move(result), result_size);
         } else {
-            client_connection->async_execution_success(statement_id(), execution_id, false, 0, result.size(), 0);
+            if (result.command() == SQL::SQLCommand::Insert)
+                client_connection->async_execution_success(statement_id(), execution_id, false, result.size(), 0, 0);
+            else if (result.command() == SQL::SQLCommand::Update)
+                client_connection->async_execution_success(statement_id(), execution_id, false, 0, result.size(), 0);
+            else if (result.command() == SQL::SQLCommand::Delete)
+                client_connection->async_execution_success(statement_id(), execution_id, false, 0, 0, result.size());
+            else
+                client_connection->async_execution_success(statement_id(), execution_id, false, 0, 0, 0);
         }
     });
 

--- a/Userland/Services/SQLServer/SQLStatement.h
+++ b/Userland/Services/SQLServer/SQLStatement.h
@@ -25,8 +25,8 @@ public:
     static SQL::ResultOr<NonnullRefPtr<SQLStatement>> create(DatabaseConnection&, StringView sql);
     ~SQLStatement() override = default;
 
-    static RefPtr<SQLStatement> statement_for(int statement_id);
-    int statement_id() const { return m_statement_id; }
+    static RefPtr<SQLStatement> statement_for(u64 statement_id);
+    u64 statement_id() const { return m_statement_id; }
     DatabaseConnection* connection() { return dynamic_cast<DatabaseConnection*>(parent()); }
     void execute(Vector<SQL::Value> placeholder_values);
 
@@ -37,7 +37,7 @@ private:
     void next();
     void report_error(SQL::Result);
 
-    int m_statement_id;
+    u64 m_statement_id { 0 };
     size_t m_index { 0 };
     NonnullRefPtr<SQL::AST::Statement> m_statement;
     Optional<SQL::ResultSet> m_result {};

--- a/Userland/Services/SQLServer/SQLStatement.h
+++ b/Userland/Services/SQLServer/SQLStatement.h
@@ -18,28 +18,27 @@
 namespace SQLServer {
 
 class SQLStatement final : public Core::Object {
-    C_OBJECT(SQLStatement)
+    C_OBJECT_ABSTRACT(SQLStatement)
 
 public:
+    static SQL::ResultOr<NonnullRefPtr<SQLStatement>> create(DatabaseConnection&, StringView sql);
     ~SQLStatement() override = default;
 
     static RefPtr<SQLStatement> statement_for(int statement_id);
     int statement_id() const { return m_statement_id; }
-    DeprecatedString const& sql() const { return m_sql; }
     DatabaseConnection* connection() { return dynamic_cast<DatabaseConnection*>(parent()); }
     void execute();
 
 private:
-    SQLStatement(DatabaseConnection&, DeprecatedString sql);
-    SQL::ResultOr<void> parse();
+    SQLStatement(DatabaseConnection&, NonnullRefPtr<SQL::AST::Statement> statement);
+
     bool should_send_result_rows() const;
     void next();
     void report_error(SQL::Result);
 
     int m_statement_id;
-    DeprecatedString m_sql;
     size_t m_index { 0 };
-    RefPtr<SQL::AST::Statement> m_statement { nullptr };
+    NonnullRefPtr<SQL::AST::Statement> m_statement;
     Optional<SQL::ResultSet> m_result {};
 };
 

--- a/Userland/Services/SQLServer/SQLStatement.h
+++ b/Userland/Services/SQLServer/SQLStatement.h
@@ -28,17 +28,21 @@ public:
     static RefPtr<SQLStatement> statement_for(u64 statement_id);
     u64 statement_id() const { return m_statement_id; }
     DatabaseConnection* connection() { return dynamic_cast<DatabaseConnection*>(parent()); }
-    void execute(Vector<SQL::Value> placeholder_values);
+    Optional<u64> execute(Vector<SQL::Value> placeholder_values);
 
 private:
     SQLStatement(DatabaseConnection&, NonnullRefPtr<SQL::AST::Statement> statement);
 
     bool should_send_result_rows() const;
-    void next();
-    void report_error(SQL::Result);
+    void next(u64 execution_id);
+    void report_error(SQL::Result, u64 execution_id);
 
     u64 m_statement_id { 0 };
     size_t m_index { 0 };
+
+    HashTable<u64> m_ongoing_executions;
+    u64 m_next_execution_id { 0 };
+
     NonnullRefPtr<SQL::AST::Statement> m_statement;
     Optional<SQL::ResultSet> m_result {};
 };

--- a/Userland/Services/SQLServer/SQLStatement.h
+++ b/Userland/Services/SQLServer/SQLStatement.h
@@ -33,18 +33,16 @@ public:
 private:
     SQLStatement(DatabaseConnection&, NonnullRefPtr<SQL::AST::Statement> statement);
 
-    bool should_send_result_rows() const;
-    void next(u64 execution_id);
+    bool should_send_result_rows(SQL::ResultSet const& result) const;
+    void next(u64 execution_id, SQL::ResultSet result, size_t result_size);
     void report_error(SQL::Result, u64 execution_id);
 
     u64 m_statement_id { 0 };
-    size_t m_index { 0 };
 
     HashTable<u64> m_ongoing_executions;
     u64 m_next_execution_id { 0 };
 
     NonnullRefPtr<SQL::AST::Statement> m_statement;
-    Optional<SQL::ResultSet> m_result {};
 };
 
 }

--- a/Userland/Services/SQLServer/SQLStatement.h
+++ b/Userland/Services/SQLServer/SQLStatement.h
@@ -8,6 +8,7 @@
 
 #include <AK/DeprecatedString.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/Vector.h>
 #include <LibCore/Object.h>
 #include <LibSQL/AST/AST.h>
 #include <LibSQL/Result.h>
@@ -27,7 +28,7 @@ public:
     static RefPtr<SQLStatement> statement_for(int statement_id);
     int statement_id() const { return m_statement_id; }
     DatabaseConnection* connection() { return dynamic_cast<DatabaseConnection*>(parent()); }
-    void execute();
+    void execute(Vector<SQL::Value> placeholder_values);
 
 private:
     SQLStatement(DatabaseConnection&, NonnullRefPtr<SQL::AST::Statement> statement);

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -76,9 +76,9 @@ public:
 
         m_sql_client = SQL::SQLClient::try_create().release_value_but_fixme_should_propagate_errors();
 
-        m_sql_client->on_execution_success = [this](auto, auto, auto has_results, auto updated, auto created, auto deleted) {
+        m_sql_client->on_execution_success = [this](auto, auto, auto has_results, auto created, auto updated, auto deleted) {
             if (updated != 0 || created != 0 || deleted != 0) {
-                outln("{} row(s) updated, {} created, {} deleted", updated, created, deleted);
+                outln("{} row(s) created, {} updated, {} deleted", created, updated, deleted);
             }
             if (!has_results) {
                 read_sql();

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -292,7 +292,7 @@ private:
                 });
         } else {
             auto statement_id = m_sql_client->prepare_statement(m_connection_id, piece);
-            m_sql_client->async_execute_statement(statement_id);
+            m_sql_client->async_execute_statement(statement_id, {});
         }
 
         // ...But m_keep_running can also be set to false by a command handler.

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -85,7 +85,7 @@ public:
             }
         };
 
-        m_sql_client->on_next_result = [](auto, auto, auto const& row) {
+        m_sql_client->on_next_result = [](auto, auto, auto row) {
             StringBuilder builder;
             builder.join(", "sv, row);
             outln("{}", builder.build());

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -84,7 +84,7 @@ public:
             read_sql();
         };
 
-        m_sql_client->on_execution_success = [this](auto, auto has_results, auto updated, auto created, auto deleted) {
+        m_sql_client->on_execution_success = [this](auto, auto, auto has_results, auto updated, auto created, auto deleted) {
             if (updated != 0 || created != 0 || deleted != 0) {
                 outln("{} row(s) updated, {} created, {} deleted", updated, created, deleted);
             }
@@ -93,13 +93,13 @@ public:
             }
         };
 
-        m_sql_client->on_next_result = [](auto, auto const& row) {
+        m_sql_client->on_next_result = [](auto, auto, auto const& row) {
             StringBuilder builder;
             builder.join(", "sv, row);
             outln("{}", builder.build());
         };
 
-        m_sql_client->on_results_exhausted = [this](auto, auto total_rows) {
+        m_sql_client->on_results_exhausted = [this](auto, auto, auto total_rows) {
             outln("{} row(s)", total_rows);
             read_sql();
         };
@@ -109,7 +109,7 @@ public:
             m_loop.quit(to_underlying(code));
         };
 
-        m_sql_client->on_execution_error = [this](auto, auto, auto const& message) {
+        m_sql_client->on_execution_error = [this](auto, auto, auto, auto const& message) {
             outln("\033[33;1mExecution error:\033[0m {}", message);
             read_sql();
         };


### PR DESCRIPTION
This:
1. Implements the `UPDATE` command
2. Implements placeholder values with the `?` token
3. Changes SQL IPC to send `SQL::Value` types rather than values converted to strings
4. A handful of changes to make prepared statements useful (parse statements once, per-execution ID and result tracking, etc.)

All in the name of :cookie:s!