### PR TITLE
Meta: Support `Date` and `Intl` in the WASM REPL

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -476,7 +476,7 @@ if (BUILD_LAGOM)
         target_link_libraries(js LibCrypto LibJS LibLine LibLocale LibMain LibTextCodec Threads::Threads)
         if (EMSCRIPTEN)
             add_executable(libjs Wasm/js_repl.cpp)
-            target_link_libraries(libjs LibJS)
+            target_link_libraries(libjs LibJS LibLocale LibTimeZone LibUnicode)
             target_link_options(libjs PRIVATE
                     -sEXPORTED_FUNCTIONS=_initialize_repl,_execute
                     -sEXPORTED_RUNTIME_METHODS=allocateUTF8
@@ -703,7 +703,7 @@ if (BUILD_LAGOM)
         if (APPLE)
             if("arm64" IN_LIST CMAKE_OSX_ARCHITECTURES AND "x86_64" IN_LIST CMAKE_OSX_ARCHITECTURES)
                 set(CPACK_SYSTEM_NAME "macOS-universal2")
-            else() 
+            else()
                 set(CPACK_SYSTEM_NAME "macOS-${CMAKE_SYSTEM_PROCESSOR}")
             endif()
         else()

--- a/Meta/Lagom/Wasm/js_repl.cpp
+++ b/Meta/Lagom/Wasm/js_repl.cpp
@@ -29,6 +29,7 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #ifndef AK_OS_EMSCRIPTEN
@@ -349,8 +350,11 @@ private:
     int m_group_stack_depth { 0 };
 };
 
-extern "C" int initialize_repl()
+extern "C" int initialize_repl(char const* time_zone)
 {
+    if (time_zone)
+        setenv("TZ", time_zone, 1);
+
     g_vm = JS::VM::create();
     g_vm->enable_default_host_import_module_dynamically_hook();
 


### PR DESCRIPTION
If you try entering `new Date();` on https://libjs.dev/repl, you will get the following assertion:
```
Uncaught RuntimeError: Aborted(Assertion failed: time_zone.has_value(), at: /home/runner/work/serenity/serenity/Userland/Libraries/LibJS/Runtime/Date.cpp,331,get_named_time_zone_offset_nanoseconds)
```

This links in the TZDB data to fix the above assertion, and lets the REPL website tell us our current time zone (because the file system we have access to will not contain that information).

![Screenshot from 2022-12-05 17-22-12](https://user-images.githubusercontent.com/5600524/205755472-f185a8cd-60b0-4a50-874a-ca6460506ef5.png)


libjs-website PR: https://github.com/linusg/libjs-website/pull/28
