### PR TITLE
Magnifier: Add grid and lockable position (while still updating)

### DIFF
--- a/Userland/Applications/Magnifier/CMakeLists.txt
+++ b/Userland/Applications/Magnifier/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
 )
 
 serenity_app(Magnifier ICON app-magnifier)
-target_link_libraries(Magnifier PRIVATE LibCore LibDesktop LibGfx LibGUI LibIPC LibMain LibFileSystemAccessClient)
+target_link_libraries(Magnifier PRIVATE LibConfig LibCore LibDesktop LibGfx LibGUI LibIPC LibMain LibFileSystemAccessClient)

--- a/Userland/Applications/Magnifier/MagnifierWidget.cpp
+++ b/Userland/Applications/Magnifier/MagnifierWidget.cpp
@@ -156,3 +156,29 @@ void MagnifierWidget::second_paint_event(GUI::PaintEvent&)
 
     m_color_filter->apply(*target, rect, *clone, rect);
 }
+
+void MagnifierWidget::mousemove_event(GUI::MouseEvent& event)
+{
+    if (m_locked_location.has_value() && m_currently_dragging && !m_pause_capture) {
+        auto current_position = event.position();
+        auto difference = current_position - m_last_drag_position;
+        Gfx::IntPoint remainder = { difference.x() % m_scale_factor, difference.y() % m_scale_factor };
+        auto moved_by = difference / m_scale_factor;
+        m_locked_location = m_locked_location.value() - moved_by;
+        m_last_drag_position = current_position - remainder;
+    }
+}
+
+void MagnifierWidget::mousedown_event(GUI::MouseEvent& event)
+{
+    if (event.button() == GUI::MouseButton::Primary && !m_pause_capture) {
+        m_currently_dragging = true;
+        m_last_drag_position = event.position();
+    }
+}
+
+void MagnifierWidget::mouseup_event(GUI::MouseEvent& event)
+{
+    if (event.button() == GUI::MouseButton::Primary)
+        m_currently_dragging = false;
+}

--- a/Userland/Applications/Magnifier/MagnifierWidget.cpp
+++ b/Userland/Applications/Magnifier/MagnifierWidget.cpp
@@ -20,7 +20,10 @@ MagnifierWidget::MagnifierWidget()
 void MagnifierWidget::set_scale_factor(int scale_factor)
 {
     VERIFY(scale_factor == 2 || scale_factor == 4 || scale_factor == 8);
+    if (m_scale_factor == scale_factor)
+        return;
     m_scale_factor = scale_factor;
+    layout_relevant_change_occurred();
     update();
 }
 
@@ -77,12 +80,14 @@ void MagnifierWidget::sync()
 
     auto size = frame_inner_rect().size();
     Gfx::IntSize grab_size { size.width() / m_scale_factor, size.height() / m_scale_factor };
+    VERIFY(grab_size.width() != 0 && grab_size.height() != 0);
 
     if (m_locked_location.has_value()) {
         m_grabbed_bitmap = GUI::ConnectionToWindowServer::the().get_screen_bitmap_around_location(grab_size, m_locked_location.value()).bitmap();
     } else {
         m_grabbed_bitmap = GUI::ConnectionToWindowServer::the().get_screen_bitmap_around_cursor(grab_size).bitmap();
     }
+
     m_grabbed_bitmaps.enqueue(m_grabbed_bitmap);
     update();
 }

--- a/Userland/Applications/Magnifier/MagnifierWidget.cpp
+++ b/Userland/Applications/Magnifier/MagnifierWidget.cpp
@@ -24,6 +24,14 @@ void MagnifierWidget::set_scale_factor(int scale_factor)
     update();
 }
 
+void MagnifierWidget::lock_location(bool lock)
+{
+    if (lock)
+        m_locked_location = GUI::ConnectionToWindowServer::the().get_global_cursor_position();
+    else
+        m_locked_location = {};
+}
+
 void MagnifierWidget::set_color_filter(OwnPtr<Gfx::ColorBlindnessFilter> color_filter)
 {
     m_color_filter = move(color_filter);
@@ -53,7 +61,12 @@ void MagnifierWidget::sync()
 
     auto size = frame_inner_rect().size();
     Gfx::IntSize grab_size { size.width() / m_scale_factor, size.height() / m_scale_factor };
-    m_grabbed_bitmap = GUI::ConnectionToWindowServer::the().get_screen_bitmap_around_cursor(grab_size).bitmap();
+
+    if (m_locked_location.has_value()) {
+        m_grabbed_bitmap = GUI::ConnectionToWindowServer::the().get_screen_bitmap_around_location(grab_size, m_locked_location.value()).bitmap();
+    } else {
+        m_grabbed_bitmap = GUI::ConnectionToWindowServer::the().get_screen_bitmap_around_cursor(grab_size).bitmap();
+    }
     m_grabbed_bitmaps.enqueue(m_grabbed_bitmap);
     update();
 }

--- a/Userland/Applications/Magnifier/MagnifierWidget.cpp
+++ b/Userland/Applications/Magnifier/MagnifierWidget.cpp
@@ -40,6 +40,14 @@ void MagnifierWidget::show_grid(bool new_value)
     update();
 }
 
+void MagnifierWidget::set_grid_color(Gfx::Color new_color)
+{
+    if (m_grid_color == new_color)
+        return;
+    m_grid_color = new_color;
+    update();
+}
+
 void MagnifierWidget::set_color_filter(OwnPtr<Gfx::ColorBlindnessFilter> color_filter)
 {
     m_color_filter = move(color_filter);
@@ -92,8 +100,6 @@ void MagnifierWidget::paint_event(GUI::PaintEvent& event)
         painter.draw_scaled_bitmap(frame_inner_rect(), *m_grabbed_bitmap, m_grabbed_bitmap->rect(), 1.0, Gfx::Painter::ScalingMode::NearestFractional);
 
     if (m_show_grid) {
-        auto line_color = Color(Color::NamedColor::Magenta);
-        line_color.set_alpha(100);
 
         auto grid_rect = frame_inner_rect();
         if (m_grabbed_bitmap)
@@ -109,10 +115,10 @@ void MagnifierWidget::paint_event(GUI::PaintEvent& event)
             end_x = grid_rect.right();
 
         for (int current_y = start_y; current_y <= end_y; current_y += m_scale_factor)
-            painter.draw_line({ start_x, current_y }, { end_x, current_y }, line_color);
+            painter.draw_line({ start_x, current_y }, { end_x, current_y }, m_grid_color);
 
         for (int current_x = start_y; current_x <= end_x; current_x += m_scale_factor)
-            painter.draw_line({ current_x, start_y }, { current_x, end_y }, line_color);
+            painter.draw_line({ current_x, start_y }, { current_x, end_y }, m_grid_color);
     }
 }
 

--- a/Userland/Applications/Magnifier/MagnifierWidget.h
+++ b/Userland/Applications/Magnifier/MagnifierWidget.h
@@ -21,6 +21,8 @@ public:
     virtual ~MagnifierWidget() override = default;
     void set_scale_factor(int scale_factor);
     virtual void set_color_filter(OwnPtr<Gfx::ColorBlindnessFilter>) override;
+    void show_grid(bool);
+
     void pause_capture(bool pause)
     {
         m_pause_capture = pause;
@@ -47,4 +49,5 @@ private:
     ssize_t m_frame_offset_from_head { 0 };
     bool m_pause_capture { false };
     Optional<Gfx::IntPoint> m_locked_location {};
+    bool m_show_grid { false };
 };

--- a/Userland/Applications/Magnifier/MagnifierWidget.h
+++ b/Userland/Applications/Magnifier/MagnifierWidget.h
@@ -27,6 +27,7 @@ public:
         if (!pause)
             m_frame_offset_from_head = 0;
     }
+    void lock_location(bool);
     void display_previous_frame();
     void display_next_frame();
     RefPtr<Gfx::Bitmap> current_bitmap() const { return m_grabbed_bitmap; };
@@ -45,4 +46,5 @@ private:
     CircularQueue<RefPtr<Gfx::Bitmap>, 512> m_grabbed_bitmaps {};
     ssize_t m_frame_offset_from_head { 0 };
     bool m_pause_capture { false };
+    Optional<Gfx::IntPoint> m_locked_location {};
 };

--- a/Userland/Applications/Magnifier/MagnifierWidget.h
+++ b/Userland/Applications/Magnifier/MagnifierWidget.h
@@ -47,6 +47,10 @@ private:
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void second_paint_event(GUI::PaintEvent&) override;
 
+    virtual void mousemove_event(GUI::MouseEvent&) override;
+    virtual void mousedown_event(GUI::MouseEvent&) override;
+    virtual void mouseup_event(GUI::MouseEvent&) override;
+
     void sync();
 
     int m_scale_factor { 2 };
@@ -55,6 +59,8 @@ private:
     CircularQueue<RefPtr<Gfx::Bitmap>, 512> m_grabbed_bitmaps {};
     ssize_t m_frame_offset_from_head { 0 };
     bool m_pause_capture { false };
+    bool m_currently_dragging { false };
+    Gfx::IntPoint m_last_drag_position {};
     Optional<Gfx::IntPoint> m_locked_location {};
     bool m_show_grid { false };
     Gfx::Color m_grid_color { 255, 0, 255, 100 };

--- a/Userland/Applications/Magnifier/MagnifierWidget.h
+++ b/Userland/Applications/Magnifier/MagnifierWidget.h
@@ -22,6 +22,8 @@ public:
     void set_scale_factor(int scale_factor);
     virtual void set_color_filter(OwnPtr<Gfx::ColorBlindnessFilter>) override;
     void show_grid(bool);
+    Gfx::Color grid_color() { return m_grid_color; }
+    void set_grid_color(Gfx::Color);
 
     void pause_capture(bool pause)
     {
@@ -50,4 +52,5 @@ private:
     bool m_pause_capture { false };
     Optional<Gfx::IntPoint> m_locked_location {};
     bool m_show_grid { false };
+    Gfx::Color m_grid_color { 255, 0, 255, 100 };
 };

--- a/Userland/Applications/Magnifier/MagnifierWidget.h
+++ b/Userland/Applications/Magnifier/MagnifierWidget.h
@@ -36,6 +36,11 @@ public:
     void display_next_frame();
     RefPtr<Gfx::Bitmap> current_bitmap() const { return m_grabbed_bitmap; };
 
+    virtual Optional<GUI::UISize> calculated_min_size() const override
+    {
+        return GUI::UISize { frame_thickness() * 2 + m_scale_factor, frame_thickness() * 2 + m_scale_factor };
+    }
+
 private:
     MagnifierWidget();
 

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -111,6 +111,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             magnifier->pause_capture(action.is_checked());
         });
 
+    auto lock_location_action = GUI::Action::create_checkable(
+        "&Lock Location", { Key_L }, [&](auto& action) {
+            magnifier->lock_location(action.is_checked());
+        });
+
     size_action_group->add_action(two_x_action);
     size_action_group->add_action(four_x_action);
     size_action_group->add_action(eight_x_action);
@@ -124,6 +129,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(view_menu->try_add_separator());
     TRY(view_menu->try_add_action(pause_action));
+    TRY(view_menu->try_add_action(lock_location_action));
 
     auto timeline_menu = TRY(window->try_add_menu("&Timeline"));
     auto previous_frame_action = GUI::Action::create(

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -11,6 +11,7 @@
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
+#include <LibGUI/ColorPicker.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
@@ -121,6 +122,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             magnifier->show_grid(action.is_checked());
         });
 
+    auto choose_grid_color_action = GUI::Action::create(
+        "Choose Grid &Color", [&](auto& action [[maybe_unused]]) {
+            auto dialog = GUI::ColorPicker::construct(magnifier->grid_color(), window, "Magnifier: choose grid color");
+            dialog->set_color_has_alpha_channel(true);
+            if (dialog->exec() == GUI::Dialog::ExecResult::OK)
+                magnifier->set_grid_color(dialog->color());
+        });
+
     size_action_group->add_action(two_x_action);
     size_action_group->add_action(four_x_action);
     size_action_group->add_action(eight_x_action);
@@ -136,6 +145,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(view_menu->try_add_action(pause_action));
     TRY(view_menu->try_add_action(lock_location_action));
     TRY(view_menu->try_add_action(show_grid_action));
+    TRY(view_menu->try_add_action(choose_grid_color_action));
 
     auto timeline_menu = TRY(window->try_add_menu("&Timeline"));
     auto previous_frame_action = GUI::Action::create(

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -116,6 +116,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             magnifier->lock_location(action.is_checked());
         });
 
+    auto show_grid_action = GUI::Action::create_checkable(
+        "Show &Grid", { Key_G }, [&](auto& action) {
+            magnifier->show_grid(action.is_checked());
+        });
+
     size_action_group->add_action(two_x_action);
     size_action_group->add_action(four_x_action);
     size_action_group->add_action(eight_x_action);
@@ -130,6 +135,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(view_menu->try_add_separator());
     TRY(view_menu->try_add_action(pause_action));
     TRY(view_menu->try_add_action(lock_location_action));
+    TRY(view_menu->try_add_action(show_grid_action));
 
     auto timeline_menu = TRY(window->try_add_menu("&Timeline"));
     auto previous_frame_action = GUI::Action::create(

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -459,12 +459,13 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::scaled(float sx, float sy) const
 
 ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::cropped(Gfx::IntRect crop, Optional<BitmapFormat> new_bitmap_format) const
 {
-    auto new_bitmap = TRY(Gfx::Bitmap::try_create(new_bitmap_format.value_or(format()), { crop.width(), crop.height() }, 1));
+    auto new_bitmap = TRY(Gfx::Bitmap::try_create(new_bitmap_format.value_or(format()), { crop.width(), crop.height() }, scale()));
+    auto scaled_crop = crop * scale();
 
-    for (int y = 0; y < crop.height(); ++y) {
-        for (int x = 0; x < crop.width(); ++x) {
-            int global_x = x + crop.left();
-            int global_y = y + crop.top();
+    for (int y = 0; y < scaled_crop.height(); ++y) {
+        for (int x = 0; x < scaled_crop.width(); ++x) {
+            int global_x = x + scaled_crop.left();
+            int global_y = y + scaled_crop.top();
             if (global_x >= physical_width() || global_y >= physical_height() || global_x < 0 || global_y < 0) {
                 new_bitmap->set_pixel(x, y, Gfx::Color::Black);
             } else {

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1150,6 +1150,8 @@ void Painter::blit(IntPoint position, Gfx::Bitmap const& source, IntRect const& 
 template<bool has_alpha_channel, typename GetPixel>
 ALWAYS_INLINE static void do_draw_integer_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& src_rect, Gfx::Bitmap const& source, int hfactor, int vfactor, GetPixel get_pixel, float opacity)
 {
+    int x_limit = min(target.physical_width() - 1, dst_rect.right());
+    int y_limit = min(target.physical_height() - 1, dst_rect.bottom());
     bool has_opacity = opacity != 1.0f;
     for (int y = 0; y < src_rect.height(); ++y) {
         int dst_y = dst_rect.y() + y * vfactor;
@@ -1157,10 +1159,10 @@ ALWAYS_INLINE static void do_draw_integer_scaled_bitmap(Gfx::Bitmap& target, Int
             auto src_pixel = get_pixel(source, x + src_rect.left(), y + src_rect.top());
             if (has_opacity)
                 src_pixel.set_alpha(src_pixel.alpha() * opacity);
-            for (int yo = 0; yo < vfactor; ++yo) {
+            for (int yo = 0; yo < vfactor && dst_y + yo <= y_limit; ++yo) {
                 auto* scanline = (Color*)target.scanline(dst_y + yo);
                 int dst_x = dst_rect.x() + x * hfactor;
-                for (int xo = 0; xo < hfactor; ++xo) {
+                for (int xo = 0; xo < hfactor && dst_x + xo <= x_limit; ++xo) {
                     if constexpr (has_alpha_channel)
                         scanline[dst_x + xo] = scanline[dst_x + xo].blend(src_pixel);
                     else
@@ -1178,6 +1180,12 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
     auto clipped_src_rect = int_src_rect.intersected(source.rect());
     if (clipped_src_rect.is_empty())
         return;
+
+    if (scaling_mode == Painter::ScalingMode::NearestFractional) {
+        int hfactor = (dst_rect.width() + int_src_rect.width() - 1) / int_src_rect.width();
+        int vfactor = (dst_rect.height() + int_src_rect.height() - 1) / int_src_rect.height();
+        return do_draw_integer_scaled_bitmap<has_alpha_channel>(target, dst_rect, int_src_rect, source, hfactor, vfactor, get_pixel, opacity);
+    }
 
     if constexpr (scaling_mode == Painter::ScalingMode::NearestNeighbor || scaling_mode == Painter::ScalingMode::SmoothPixels) {
         if (dst_rect == clipped_rect && int_src_rect == src_rect && !(dst_rect.width() % int_src_rect.width()) && !(dst_rect.height() % int_src_rect.height())) {
@@ -1280,6 +1288,9 @@ template<bool has_alpha_channel, typename GetPixel>
 ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& clipped_rect, Gfx::Bitmap const& source, FloatRect const& src_rect, GetPixel get_pixel, float opacity, Painter::ScalingMode scaling_mode)
 {
     switch (scaling_mode) {
+    case Painter::ScalingMode::NearestFractional:
+        do_draw_scaled_bitmap<has_alpha_channel, Painter::ScalingMode::NearestFractional>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
+        break;
     case Painter::ScalingMode::NearestNeighbor:
         do_draw_scaled_bitmap<has_alpha_channel, Painter::ScalingMode::NearestNeighbor>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
         break;

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -37,6 +37,7 @@ public:
     };
 
     enum class ScalingMode {
+        NearestFractional,
         NearestNeighbor,
         SmoothPixels,
         BilinearBlend,

--- a/Userland/Libraries/LibGfx/ShareableBitmap.cpp
+++ b/Userland/Libraries/LibGfx/ShareableBitmap.cpp
@@ -31,7 +31,7 @@ bool encode(Encoder& encoder, Gfx::ShareableBitmap const& shareable_bitmap)
     auto& bitmap = *shareable_bitmap.bitmap();
     encoder << IPC::File(bitmap.anonymous_buffer().fd());
     encoder << bitmap.size();
-    encoder << bitmap.scale();
+    encoder << static_cast<u32>(bitmap.scale());
     encoder << (u32)bitmap.format();
     if (bitmap.is_indexed()) {
         auto palette = bitmap.palette_to_vector();
@@ -64,7 +64,7 @@ ErrorOr<void> decode(Decoder& decoder, Gfx::ShareableBitmap& shareable_bitmap)
     if (Gfx::Bitmap::is_indexed(bitmap_format)) {
         TRY(decoder.decode(palette));
     }
-    auto buffer = TRY(Core::AnonymousBuffer::create_from_anon_fd(anon_file.take_fd(), Gfx::Bitmap::size_in_bytes(Gfx::Bitmap::minimum_pitch(size.width(), bitmap_format), size.height())));
+    auto buffer = TRY(Core::AnonymousBuffer::create_from_anon_fd(anon_file.take_fd(), Gfx::Bitmap::size_in_bytes(Gfx::Bitmap::minimum_pitch(size.width() * scale, bitmap_format), size.height() * scale)));
     auto bitmap = TRY(Gfx::Bitmap::try_create_with_anonymous_buffer(bitmap_format, move(buffer), size, scale, palette));
     shareable_bitmap = Gfx::ShareableBitmap { move(bitmap), Gfx::ShareableBitmap::ConstructWithKnownGoodBitmap };
     return {};

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -1216,7 +1216,7 @@ Messages::WindowServer::GetScreenBitmapAroundLocationResponse ConnectionFromClie
 
     if (intersecting_with_screens == 1) {
         auto& screen = Screen::closest_to_rect(rect);
-        auto crop_rect = rect.translated(-screen.rect().location()) * screen.scale_factor();
+        auto crop_rect = rect.translated(-screen.rect().location());
         auto bitmap_or_error = Compositor::the().front_bitmap_for_screenshot({}, screen).cropped(crop_rect);
         if (bitmap_or_error.is_error()) {
             dbgln("get_screen_bitmap_around_cursor: Failed to crop screenshot: {}", bitmap_or_error.error());

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -174,6 +174,7 @@ private:
     virtual Messages::WindowServer::GetScrollStepSizeResponse get_scroll_step_size() override;
     virtual Messages::WindowServer::GetScreenBitmapResponse get_screen_bitmap(Optional<Gfx::IntRect> const&, Optional<u32> const&) override;
     virtual Messages::WindowServer::GetScreenBitmapAroundCursorResponse get_screen_bitmap_around_cursor(Gfx::IntSize) override;
+    virtual Messages::WindowServer::GetScreenBitmapAroundLocationResponse get_screen_bitmap_around_location(Gfx::IntSize, Gfx::IntPoint) override;
     virtual void set_double_click_speed(i32) override;
     virtual Messages::WindowServer::GetDoubleClickSpeedResponse get_double_click_speed() override;
     virtual void set_mouse_buttons_switched(bool) override;

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -168,6 +168,7 @@ endpoint WindowServer
 
     get_screen_bitmap(Optional<Gfx::IntRect> rect, Optional<u32> screen_index) => (Gfx::ShareableBitmap bitmap)
     get_screen_bitmap_around_cursor(Gfx::IntSize size) => (Gfx::ShareableBitmap bitmap)
+    get_screen_bitmap_around_location(Gfx::IntSize size, Gfx::IntPoint location) => (Gfx::ShareableBitmap bitmap)
     get_color_under_cursor() => (Optional<Gfx::Color> color)
 
     pong() =|


### PR DESCRIPTION
This adds a bunch of features to Magnifier:

- option to display a grid
  - configurable color
  - color remembered across startups
- fixing the position while keeping on updating the "feed"
- ability to pan around in fixed mode
- scaling awareness (notice that the grid in the video fits 4 pixels each, because the system is set to scaling mode 2)


https://user-images.githubusercontent.com/28605587/205786648-57840f73-50bc-4f2e-90bf-448e7823368a.mp4



I had to fix some other things to get this working:

- SharableBitmap had a bug when handling scaled Bitmaps
- Bitmap::crop() forgot scaling

If you wonder why I added a new scaling mode just for this, previously the grid tended to get ever so slightly misaligned. (as it didn't actually perfectly fit, and the pixels were distorted as a side effect)
The scaling mode NearestFractional ensures that pixels always have the same width / height.

closes https://github.com/SerenityOS/serenity/issues/8370