### PR TITLE
Meta: Manually compute the length of the WASM JS REPL source string

### DIFF
--- a/Meta/Lagom/Wasm/js_repl.cpp
+++ b/Meta/Lagom/Wasm/js_repl.cpp
@@ -386,7 +386,7 @@ extern "C" int initialize_repl(char const* time_zone)
     return 0;
 }
 
-extern "C" bool execute(char const* s, u32 length)
+extern "C" bool execute(char const* source)
 {
-    return parse_and_run(*g_interpreter, { s, length }, "REPL"sv);
+    return parse_and_run(*g_interpreter, { source, strlen(source) }, "REPL"sv);
 }


### PR DESCRIPTION
The REPL does not have a reliable way to tell us the UTF-8 byte count of the source string, so we must use `strlen()` ourselves.

Before:
![Screenshot from 2022-12-06 08-35-04](https://user-images.githubusercontent.com/5600524/205926644-63cb79ac-54ba-492a-95ff-4b88bb4ac7f9.png)


After:
![Screenshot from 2022-12-06 08-42-02](https://user-images.githubusercontent.com/5600524/205928060-08e660a6-d8e9-440b-95f5-e28e3b9aeab3.png)

libjs-website PR: https://github.com/linusg/libjs-website/pull/29