### PR TITLE
LibTLS: Migrate from `DeprecatedString` to `String`

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -220,6 +220,23 @@ ErrorOr<String> String::from_utf8(StringView view)
     return String { move(data) };
 }
 
+ErrorOr<String> String::from_utf8(StringView view, StringShouldChomp should_chomp)
+{
+    if (should_chomp == StringShouldChomp::Chomp) {
+        size_t chomped_length = view.length();
+        while (chomped_length > 0) {
+            char last_ch = view[chomped_length - 1];
+            if (!last_ch || last_ch == '\n' || last_ch == '\r')
+                --chomped_length;
+            else
+                break;
+        }
+        return TRY(from_utf8(view.substring_view(0, chomped_length)));
+    }
+
+    return TRY(from_utf8(view));
+}
+
 StringView String::bytes_as_string_view() const
 {
     return StringView(bytes());

--- a/AK/String.h
+++ b/AK/String.h
@@ -16,6 +16,11 @@
 
 namespace AK {
 
+enum StringShouldChomp {
+    NoChomp,
+    Chomp
+};
+
 namespace Detail {
 class StringData;
 }
@@ -41,6 +46,7 @@ public:
 
     // Creates a new String from a sequence of UTF-8 encoded code points.
     static ErrorOr<String> from_utf8(StringView);
+    static ErrorOr<String> from_utf8(StringView, StringShouldChomp);
 
     // Creates a substring with a deep copy of the specified data window.
     ErrorOr<String> substring_from_byte_offset(size_t start, size_t byte_count) const;

--- a/Userland/Libraries/LibTLS/Certificate.h
+++ b/Userland/Libraries/LibTLS/Certificate.h
@@ -10,6 +10,7 @@
 #include <AK/Forward.h>
 #include <AK/Optional.h>
 #include <AK/Singleton.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DateTime.h>
@@ -38,16 +39,16 @@ public:
     Crypto::PK::RSAPublicKey<Crypto::UnsignedBigInteger> public_key {};
     Crypto::PK::RSAPrivateKey<Crypto::UnsignedBigInteger> private_key {};
     struct Name {
-        DeprecatedString country;
-        DeprecatedString state;
-        DeprecatedString location;
-        DeprecatedString entity;
-        DeprecatedString subject;
-        DeprecatedString unit;
+        String country;
+        String state;
+        String location;
+        String entity;
+        String subject;
+        String unit;
     } issuer, subject;
     Core::DateTime not_before;
     Core::DateTime not_after;
-    Vector<DeprecatedString> SAN;
+    Vector<String> SAN;
     u8* ocsp { nullptr };
     Crypto::UnsignedBigInteger serial_number;
     ByteBuffer sign_key {};
@@ -65,64 +66,64 @@ public:
 
     bool is_valid() const;
 
-    DeprecatedString subject_identifier_string() const
+    ErrorOr<String> subject_identifier_string() const
     {
         StringBuilder cert_name;
         if (!subject.country.is_empty()) {
             cert_name.append("/C="sv);
-            cert_name.append(subject.country);
+            cert_name.append(subject.country.to_deprecated_string());
         }
         if (!subject.state.is_empty()) {
             cert_name.append("/ST="sv);
-            cert_name.append(subject.state);
+            cert_name.append(subject.state.to_deprecated_string());
         }
         if (!subject.location.is_empty()) {
             cert_name.append("/L="sv);
-            cert_name.append(subject.location);
+            cert_name.append(subject.location.to_deprecated_string());
         }
         if (!subject.entity.is_empty()) {
             cert_name.append("/O="sv);
-            cert_name.append(subject.entity);
+            cert_name.append(subject.entity.to_deprecated_string());
         }
         if (!subject.unit.is_empty()) {
             cert_name.append("/OU="sv);
-            cert_name.append(subject.unit);
+            cert_name.append(subject.unit.to_deprecated_string());
         }
         if (!subject.subject.is_empty()) {
             cert_name.append("/CN="sv);
-            cert_name.append(subject.subject);
+            cert_name.append(subject.subject.to_deprecated_string());
         }
-        return cert_name.build();
+        return TRY(String::from_deprecated_string(cert_name.build()));
     }
 
-    DeprecatedString issuer_identifier_string() const
+    ErrorOr<String> issuer_identifier_string() const
     {
         StringBuilder cert_name;
         if (!issuer.country.is_empty()) {
             cert_name.append("/C="sv);
-            cert_name.append(issuer.country);
+            cert_name.append(issuer.country.to_deprecated_string());
         }
         if (!issuer.state.is_empty()) {
             cert_name.append("/ST="sv);
-            cert_name.append(issuer.state);
+            cert_name.append(issuer.state.to_deprecated_string());
         }
         if (!issuer.location.is_empty()) {
             cert_name.append("/L="sv);
-            cert_name.append(issuer.location);
+            cert_name.append(issuer.location.to_deprecated_string());
         }
         if (!issuer.entity.is_empty()) {
             cert_name.append("/O="sv);
-            cert_name.append(issuer.entity);
+            cert_name.append(issuer.entity.to_deprecated_string());
         }
         if (!issuer.unit.is_empty()) {
             cert_name.append("/OU="sv);
-            cert_name.append(issuer.unit);
+            cert_name.append(issuer.unit.to_deprecated_string());
         }
         if (!issuer.subject.is_empty()) {
             cert_name.append("/CN="sv);
-            cert_name.append(issuer.subject);
+            cert_name.append(issuer.subject.to_deprecated_string());
         }
-        return cert_name.build();
+        return TRY(String::from_deprecated_string(cert_name.build()));
     }
 };
 


### PR DESCRIPTION
Please leave me some critical feedback! I'm trying to use this as a learning experience to better understand error propagation as well as the new `String` implementation :)