### PR TITLE
Remove `Hashmap::ensure_capacity`

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -34,7 +34,7 @@ public:
 
     HashMap(std::initializer_list<Entry> list)
     {
-        ensure_capacity(list.size());
+        MUST(try_ensure_capacity(list.size()));
         for (auto& item : list)
             set(item.key, item.value);
     }
@@ -124,7 +124,6 @@ public:
         return m_table.find(Traits<Key>::hash(key), [&](auto& entry) { return Traits<K>::equals(key, entry.key); });
     }
 
-    void ensure_capacity(size_t capacity) { m_table.ensure_capacity(capacity); }
     ErrorOr<void> try_ensure_capacity(size_t capacity) { return m_table.try_ensure_capacity(capacity); }
 
     Optional<typename Traits<V>::ConstPeekType> get(K const& key) const

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -81,7 +81,7 @@ UNMAP_AFTER_INIT CommandLine::CommandLine(StringView cmdline_from_bootloader)
 {
     s_the = this;
     auto const& args = m_string->view().split_view(' ');
-    m_params.ensure_capacity(args.size());
+    MUST(m_params.try_ensure_capacity(args.size()));
     add_arguments(args);
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
@@ -8,6 +8,7 @@
 #include <AK/AllOf.h>
 #include <AK/CharacterTypes.h>
 #include <AK/DeprecatedString.h>
+#include <AK/Error.h>
 #include <AK/Find.h>
 #include <AK/Format.h>
 #include <AK/GenericLexer.h>
@@ -1991,9 +1992,9 @@ static constexpr Array<@type@, @size@> @name@ { {)~~~");
     append_mapping(cldr.weekend_end_regions, cldr.weekend_end, "u8"sv, "s_weekend_end"sv, [](auto weekend_end) { return to_underlying(weekend_end); });
     generator.append("\n");
 
-    auto append_from_string = [&](StringView enum_title, StringView enum_snake, auto const& values, Vector<Alias> const& aliases = {}) {
+    auto append_from_string = [&](StringView enum_title, StringView enum_snake, auto const& values, Vector<Alias> const& aliases = {}) -> ErrorOr<void> {
         HashValueMap<DeprecatedString> hashes;
-        hashes.ensure_capacity(values.size());
+        TRY(hashes.try_ensure_capacity(values.size()));
 
         for (auto const& value : values)
             hashes.set(value.hash(), format_identifier(enum_title, value));
@@ -2001,13 +2002,15 @@ static constexpr Array<@type@, @size@> @name@ { {)~~~");
             hashes.set(alias.alias.hash(), format_identifier(enum_title, alias.alias));
 
         generate_value_from_string(generator, "{}_from_string"sv, enum_title, enum_snake, move(hashes));
+
+        return {};
     };
 
-    append_from_string("HourCycleRegion"sv, "hour_cycle_region"sv, cldr.hour_cycle_regions);
-    append_from_string("MinimumDaysRegion"sv, "minimum_days_region"sv, cldr.minimum_days_regions);
-    append_from_string("FirstDayRegion"sv, "first_day_region"sv, cldr.first_day_regions);
-    append_from_string("WeekendStartRegion"sv, "weekend_start_region"sv, cldr.weekend_start_regions);
-    append_from_string("WeekendEndRegion"sv, "weekend_end_region"sv, cldr.weekend_end_regions);
+    TRY(append_from_string("HourCycleRegion"sv, "hour_cycle_region"sv, cldr.hour_cycle_regions));
+    TRY(append_from_string("MinimumDaysRegion"sv, "minimum_days_region"sv, cldr.minimum_days_regions));
+    TRY(append_from_string("FirstDayRegion"sv, "first_day_region"sv, cldr.first_day_regions));
+    TRY(append_from_string("WeekendStartRegion"sv, "weekend_start_region"sv, cldr.weekend_start_regions));
+    TRY(append_from_string("WeekendEndRegion"sv, "weekend_end_region"sv, cldr.weekend_end_regions));
 
     generator.append(R"~~~(
 static Optional<Calendar> keyword_to_calendar(KeywordCalendar keyword)

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -9,6 +9,7 @@
 #include <AK/Array.h>
 #include <AK/CharacterTypes.h>
 #include <AK/DeprecatedString.h>
+#include <AK/Error.h>
 #include <AK/Find.h>
 #include <AK/HashMap.h>
 #include <AK/Optional.h>
@@ -1190,9 +1191,9 @@ bool code_point_has_@enum_snake@(u32 code_point, @enum_title@ @enum_snake@)
 )~~~");
     };
 
-    auto append_from_string = [&](StringView enum_title, StringView enum_snake, auto const& prop_list, Vector<Alias> const& aliases) {
+    auto append_from_string = [&](StringView enum_title, StringView enum_snake, auto const& prop_list, Vector<Alias> const& aliases) -> ErrorOr<void> {
         HashValueMap<StringView> hashes;
-        hashes.ensure_capacity(prop_list.size() + aliases.size());
+        TRY(hashes.try_ensure_capacity(prop_list.size() + aliases.size()));
 
         ValueFromStringOptions options {};
 
@@ -1209,22 +1210,24 @@ bool code_point_has_@enum_snake@(u32 code_point, @enum_title@ @enum_snake@)
             hashes.set(alias.alias.hash(), alias.alias);
 
         generate_value_from_string(generator, "{}_from_string"sv, enum_title, enum_snake, move(hashes), options);
+
+        return {};
     };
 
-    append_from_string("Locale"sv, "locale"sv, unicode_data.locales, {});
+    TRY(append_from_string("Locale"sv, "locale"sv, unicode_data.locales, {}));
 
     append_prop_search("GeneralCategory"sv, "general_category"sv, "s_general_categories"sv);
-    append_from_string("GeneralCategory"sv, "general_category"sv, unicode_data.general_categories, unicode_data.general_category_aliases);
+    TRY(append_from_string("GeneralCategory"sv, "general_category"sv, unicode_data.general_categories, unicode_data.general_category_aliases));
 
     append_prop_search("Property"sv, "property"sv, "s_properties"sv);
-    append_from_string("Property"sv, "property"sv, unicode_data.prop_list, unicode_data.prop_aliases);
+    TRY(append_from_string("Property"sv, "property"sv, unicode_data.prop_list, unicode_data.prop_aliases));
 
     append_prop_search("Script"sv, "script"sv, "s_scripts"sv);
     append_prop_search("Script"sv, "script_extension"sv, "s_script_extensions"sv);
-    append_from_string("Script"sv, "script"sv, unicode_data.script_list, unicode_data.script_aliases);
+    TRY(append_from_string("Script"sv, "script"sv, unicode_data.script_list, unicode_data.script_aliases));
 
     append_prop_search("Block"sv, "block"sv, "s_blocks"sv);
-    append_from_string("Block"sv, "block"sv, unicode_data.block_list, unicode_data.block_aliases);
+    TRY(append_from_string("Block"sv, "block"sv, unicode_data.block_list, unicode_data.block_aliases));
 
     append_prop_search("GraphemeBreakProperty"sv, "grapheme_break_property"sv, "s_grapheme_break_properties"sv);
     append_prop_search("WordBreakProperty"sv, "word_break_property"sv, "s_word_break_properties"sv);

--- a/Tests/LibJS/test-test262.cpp
+++ b/Tests/LibJS/test-test262.cpp
@@ -222,10 +222,10 @@ public:
     NonnullOwnPtr<Core::Stream::File> m_output;
 };
 
-static HashMap<size_t, TestResult> run_test_files(Span<DeprecatedString> files, size_t offset, StringView command, char const* const arguments[])
+static ErrorOr<HashMap<size_t, TestResult>> run_test_files(Span<DeprecatedString> files, size_t offset, StringView command, char const* const arguments[])
 {
     HashMap<size_t, TestResult> results {};
-    results.ensure_capacity(files.size());
+    TRY(results.try_ensure_capacity(files.size()));
     size_t test_index = 0;
 
     auto fail_all_after = [&] {
@@ -378,9 +378,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     while (index < paths.size()) {
         print_progress();
         auto this_batch_size = min(batch_size, paths.size() - index);
-        auto batch_results = run_test_files(paths.span().slice(index, this_batch_size), index, args[0], raw_args.data());
+        auto batch_results = TRY(run_test_files(paths.span().slice(index, this_batch_size), index, args[0], raw_args.data()));
 
-        results.ensure_capacity(results.size() + batch_results.size());
+        TRY(results.try_ensure_capacity(results.size() + batch_results.size()));
         for (auto& [key, value] : batch_results) {
             results.set(key, value);
             ++result_counts[static_cast<size_t>(value)];

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/Format.h>
 #include <AK/NonnullRefPtr.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/ResolvedCSSStyleDeclaration.h>
@@ -531,7 +532,13 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
     }
 
     if (!m_element->layout_node()) {
-        auto style = m_element->document().style_computer().compute_style(const_cast<DOM::Element&>(*m_element));
+        auto style_or_error = m_element->document().style_computer().compute_style(const_cast<DOM::Element&>(*m_element));
+        if (style_or_error.is_error()) {
+            dbgln("ResolvedCSSStyleDeclaration::property style computer failed");
+            return {};
+        }
+        auto style = style_or_error.release_value();
+
         // FIXME: This is a stopgap until we implement shorthand -> longhand conversion.
         auto value = style->maybe_null_property(property_id);
         if (!value) {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -56,7 +56,7 @@ public:
     DOM::Document const& document() const { return m_document; }
 
     NonnullRefPtr<StyleProperties> create_document_style() const;
-    NonnullRefPtr<StyleProperties> compute_style(DOM::Element&, Optional<CSS::Selector::PseudoElement> = {}) const;
+    ErrorOr<NonnullRefPtr<StyleProperties>> compute_style(DOM::Element&, Optional<CSS::Selector::PseudoElement> = {}) const;
 
     // https://www.w3.org/TR/css-cascade/#origin
     enum class CascadeOrigin {
@@ -78,7 +78,7 @@ public:
     void load_fonts_from_sheet(CSSStyleSheet const&);
 
 private:
-    void compute_cascaded_values(StyleProperties&, DOM::Element&, Optional<CSS::Selector::PseudoElement>) const;
+    ErrorOr<void> compute_cascaded_values(StyleProperties&, DOM::Element&, Optional<CSS::Selector::PseudoElement>) const;
     void compute_font(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;
     void compute_defaulted_values(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;
     void absolutize_values(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -400,7 +400,9 @@ Element::NeedsRelayout Element::recompute_style()
 {
     set_needs_style_update(false);
     VERIFY(parent());
-    auto new_computed_css_values = document().style_computer().compute_style(*this);
+
+    // FIXME propagate errors
+    auto new_computed_css_values = MUST(document().style_computer().compute_style(*this));
 
     auto required_invalidation = RequiredInvalidation::Relayout;
 

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -24,7 +24,7 @@ private:
         bool has_svg_root = false;
     };
 
-    void create_layout_tree(DOM::Node&, Context&);
+    ErrorOr<void> create_layout_tree(DOM::Node&, Context&);
 
     void push_parent(Layout::NodeWithStyle& node) { m_ancestor_stack.append(node); }
     void pop_parent() { m_ancestor_stack.take_last(); }
@@ -45,7 +45,7 @@ private:
         Prepend,
     };
     void insert_node_into_inline_or_block_ancestor(Layout::Node&, CSS::Display, AppendOrPrepend);
-    void create_pseudo_element_if_needed(DOM::Element&, CSS::Selector::PseudoElement, AppendOrPrepend);
+    ErrorOr<void> create_pseudo_element_if_needed(DOM::Element&, CSS::Selector::PseudoElement, AppendOrPrepend);
 
     JS::GCPtr<Layout::Node> m_layout_root;
     Vector<Layout::NodeWithStyle&> m_ancestor_stack;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -374,7 +374,7 @@ Messages::WebContentServer::InspectDomNodeResponse ConnectionFromClient::inspect
             // FIXME: Pseudo-elements only exist as Layout::Nodes, which don't have style information
             //        in a format we can use. So, we run the StyleComputer again to get the specified
             //        values, and have to ignore the computed values and custom properties.
-            auto pseudo_element_style = page().focused_context().active_document()->style_computer().compute_style(element, pseudo_element);
+            auto pseudo_element_style = MUST(page().focused_context().active_document()->style_computer().compute_style(element, pseudo_element));
             DeprecatedString computed_values = serialize_json(pseudo_element_style);
             DeprecatedString resolved_values = "{}";
             DeprecatedString custom_properties_json = "{}";


### PR DESCRIPTION
This used try_ensure_capacity instead of ensure_capacity but also adds 2 FIXMEs where errors couldn't easily be propagated