### PR TITLE
LibGfx+Userland: Make LibGfx::SystemTheme propagate errors

### DIFF
--- a/Userland/Applications/DisplaySettings/ThemePreviewWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemePreviewWidget.cpp
@@ -19,9 +19,11 @@ ThemePreviewWidget::ThemePreviewWidget(Gfx::Palette const& palette)
     set_fixed_size(304, 201);
 }
 
-void ThemePreviewWidget::set_theme(DeprecatedString path)
+ErrorOr<void> ThemePreviewWidget::set_theme(DeprecatedString path)
 {
-    set_theme_from_file(*Core::File::open(path, Core::OpenMode::ReadOnly).release_value_but_fixme_should_propagate_errors());
+    auto config_file = TRY(Core::File::open(path, Core::OpenMode::ReadOnly));
+    TRY(set_theme_from_file(config_file));
+    return {};
 }
 
 void ThemePreviewWidget::paint_preview(GUI::PaintEvent&)

--- a/Userland/Applications/DisplaySettings/ThemePreviewWidget.h
+++ b/Userland/Applications/DisplaySettings/ThemePreviewWidget.h
@@ -18,7 +18,7 @@ class ThemePreviewWidget final : public GUI::AbstractThemePreview {
     C_OBJECT(ThemePreviewWidget);
 
 public:
-    void set_theme(DeprecatedString path);
+    ErrorOr<void> set_theme(DeprecatedString path);
 
 private:
     explicit ThemePreviewWidget(Gfx::Palette const& palette);

--- a/Userland/Applications/ThemeEditor/MainWidget.h
+++ b/Userland/Applications/ThemeEditor/MainWidget.h
@@ -85,7 +85,7 @@ public:
     ErrorOr<void> initialize_menubar(GUI::Window&);
     GUI::Window::CloseRequestDecision request_close();
     void update_title();
-    void load_from_file(Core::File&);
+    ErrorOr<void> load_from_file(Core::File&);
 
 private:
     MainWidget();

--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -160,7 +160,10 @@ void PreviewWidget::drop_event(GUI::DropEvent& event)
         auto response = FileSystemAccessClient::Client::the().try_request_file(window(), urls.first().path(), Core::OpenMode::ReadOnly);
         if (response.is_error())
             return;
-        set_theme_from_file(*response.value());
+
+        auto set_theme_from_file_result = set_theme_from_file(response.release_value());
+        if (set_theme_from_file_result.is_error())
+            GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Setting theme from file has failed: {}", set_theme_from_file_result.error()));
     }
 }
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -56,8 +56,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, path.value());
                 if (response.is_error())
                     GUI::MessageBox::show_error(window, DeprecatedString::formatted("Opening \"{}\" failed: {}", path.value(), response.error()));
-                else
-                    main_widget->load_from_file(response.release_value());
+                else {
+                    auto load_from_file_result = main_widget->load_from_file(response.release_value());
+                    if (load_from_file_result.is_error())
+                        GUI::MessageBox::show_error(window, DeprecatedString::formatted("Loading theme from file has failed: {}", load_from_file_result.error()));
+                }
             });
     }
 

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
@@ -85,16 +85,16 @@ void AbstractThemePreview::set_theme(Core::AnonymousBuffer const& theme_buffer)
     set_preview_palette(m_preview_palette);
 }
 
-void AbstractThemePreview::set_theme_from_file(Core::File& file)
+ErrorOr<void> AbstractThemePreview::set_theme_from_file(Core::File& file)
 {
-    auto config_file = Core::ConfigFile::open(file.filename(), file.leak_fd()).release_value_but_fixme_should_propagate_errors();
-    auto theme = Gfx::load_system_theme(config_file);
-    VERIFY(theme.is_valid());
+    auto config_file = TRY(Core::ConfigFile::open(file.filename(), file.leak_fd()));
+    auto theme = TRY(Gfx::load_system_theme(config_file));
 
     m_preview_palette = Gfx::Palette(Gfx::PaletteImpl::create_with_anonymous_buffer(theme));
     set_preview_palette(m_preview_palette);
     if (on_theme_load_from_file)
         on_theme_load_from_file(file.filename());
+    return {};
 }
 
 void AbstractThemePreview::paint_window(StringView title, Gfx::IntRect const& rect, Gfx::WindowTheme::WindowState state, Gfx::Bitmap const& icon, int button_count)

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.h
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.h
@@ -24,7 +24,7 @@ public:
 
     Gfx::Palette const& preview_palette() const { return m_preview_palette; }
     void set_preview_palette(Gfx::Palette const&);
-    void set_theme_from_file(Core::File&);
+    ErrorOr<void> set_theme_from_file(Core::File&);
     void set_theme(Core::AnonymousBuffer const&);
 
     void paint_window(StringView title, Gfx::IntRect const& rect, Gfx::WindowTheme::WindowState, Gfx::Bitmap const& icon, int button_count = 3);

--- a/Userland/Libraries/LibGfx/SystemTheme.h
+++ b/Userland/Libraries/LibGfx/SystemTheme.h
@@ -271,15 +271,15 @@ struct SystemTheme {
 
 Core::AnonymousBuffer& current_system_theme_buffer();
 void set_system_theme(Core::AnonymousBuffer);
-Core::AnonymousBuffer load_system_theme(Core::ConfigFile const&);
-Core::AnonymousBuffer load_system_theme(DeprecatedString const& path);
+ErrorOr<Core::AnonymousBuffer> load_system_theme(Core::ConfigFile const&);
+ErrorOr<Core::AnonymousBuffer> load_system_theme(DeprecatedString const& path);
 
 struct SystemThemeMetaData {
     DeprecatedString name;
     DeprecatedString path;
 };
 
-Vector<SystemThemeMetaData> list_installed_system_themes();
+ErrorOr<Vector<SystemThemeMetaData>> list_installed_system_themes();
 
 }
 

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -227,7 +227,7 @@ ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu(GUI::Window& window)
     g_themes_menu = &system_menu->add_submenu("&Themes");
     g_themes_menu->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/themes.png"sv).release_value_but_fixme_should_propagate_errors());
 
-    g_themes = Gfx::list_installed_system_themes();
+    g_themes = TRY(Gfx::list_installed_system_themes());
     auto current_theme_name = GUI::ConnectionToWindowServer::the().get_system_theme();
 
     {

--- a/Userland/Services/WindowServer/main.cpp
+++ b/Userland/Services/WindowServer/main.cpp
@@ -44,8 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto wm_config = TRY(Core::ConfigFile::open("/etc/WindowServer.ini"));
     auto theme_name = wm_config->read_entry("Theme", "Name", "Default");
 
-    auto theme = Gfx::load_system_theme(DeprecatedString::formatted("/res/themes/{}.ini", theme_name));
-    VERIFY(theme.is_valid());
+    auto theme = TRY(Gfx::load_system_theme(DeprecatedString::formatted("/res/themes/{}.ini", theme_name)));
     Gfx::set_system_theme(theme);
     auto palette = Gfx::PaletteImpl::create_with_anonymous_buffer(theme);
 

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -766,10 +766,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto page_client = HeadlessBrowserPageClient::create();
 
-    if (!resources_folder.is_empty())
-        page_client->setup_palette(Gfx::load_system_theme(LexicalPath::join(resources_folder, "themes/Default.ini"sv).string()));
-    else
-        page_client->setup_palette(Gfx::load_system_theme("/res/themes/Default.ini"));
+    if (!resources_folder.is_empty()) {
+        auto system_theme = TRY(Gfx::load_system_theme(LexicalPath::join(resources_folder, "themes/Default.ini"sv).string()));
+        page_client->setup_palette(system_theme);
+    } else {
+        auto system_theme = TRY(Gfx::load_system_theme("/res/themes/Default.ini"));
+        page_client->setup_palette(system_theme);
+    }
 
     dbgln("Loading {}", url);
     page_client->load(AK::URL(url));


### PR DESCRIPTION
This patch introduces error propagation to Gfx::SystemTheme to remove instances of release_value_but_fixme_should_propagate_errors()

Userland applications that have been affected by this change have been updated to utilise this propagation and as a result 4 such instances of the aforementioned method have been removed

I would have liked to take this further and not introduced the MUST in the ThemesSettingsWidget constructor but with the way that LibGUI creates widgets I can not see a reasonable way to convert this into a factory created object without significant re-work to LibGUI which goes beyond the intended scope of this PR although happy to accept guidance
