### PR TITLE
Meta: Fix build on some unammed distros that doesn't append `/usr/sbin` in their path

### DIFF
--- a/Meta/.shell_include.sh
+++ b/Meta/.shell_include.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # shellcheck disable=SC2034
 # SC2034: "Variable appears unused. Verify it or export it."
 #         Those are intentional here, as the file is meant to be included elsewhere.
@@ -13,3 +13,32 @@ die() {
     echo "die: $*"
     exit 1
 }
+
+find_executable() {
+  paths=("/usr/sbin" "/sbin")
+
+  if [ "$(uname -s)" = "Darwin" ]; then
+    paths+=("/usr/local/opt/e2fsprogs/bin" "/usr/local/opt/e2fsprogs/sbin")
+    paths+=("/opt/homebrew/opt/e2fsprogs/bin" "/opt/homebrew/opt/e2fsprogs/sbin")
+  fi
+
+  executable="${1}"
+
+  # Prefer tools from PATH over fallback paths
+  if command -v "${executable}"; then
+    return 0
+  fi
+
+  for path in "${paths[@]}"; do
+    if command -v "${path}/${executable}"; then
+      return 0
+    fi
+  done
+
+  # We return the executable's name back to provide meaningful messages on future failure
+  echo "${executable}"
+}
+
+FUSE2FS_PATH="$(find_executable fuse2fs)"
+RESIZE2FS_PATH="$(find_executable resize2fs)"
+E2FSCK="$(find_executable e2fsck)"

--- a/Meta/.shell_include.sh
+++ b/Meta/.shell_include.sh
@@ -41,4 +41,4 @@ find_executable() {
 
 FUSE2FS_PATH="$(find_executable fuse2fs)"
 RESIZE2FS_PATH="$(find_executable resize2fs)"
-E2FSCK="$(find_executable e2fsck)"
+E2FSCK_PATH="$(find_executable e2fsck)"

--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -1,17 +1,4 @@
-#!/bin/sh
-
-# Note: This is done before `set -e` to let `command` fail if needed
-FUSE2FS_PATH=$(command -v fuse2fs)
-RESIZE2FS_PATH=$(command -v resize2fs)
-
-if [ -z "$FUSE2FS_PATH" ]; then
-    FUSE2FS_PATH=/usr/sbin/fuse2fs
-fi
-
-if [ -z "$RESIZE2FS_PATH" ]; then
-    RESIZE2FS_PATH=/usr/sbin/resize2fs
-fi
-
+#!/usr/bin/env bash
 set -e
 
 SCRIPT_DIR="$(dirname "${0}")"
@@ -41,26 +28,6 @@ if [ "$(id -u)" != 0 ]; then
 else
     : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
 fi
-
-if [ "$(uname -s)" = "Darwin" ]; then
-    export PATH="/usr/local/opt/e2fsprogs/bin:$PATH"
-    export PATH="/usr/local/opt/e2fsprogs/sbin:$PATH"
-    export PATH="/opt/homebrew/opt/e2fsprogs/bin:$PATH"
-    export PATH="/opt/homebrew/opt/e2fsprogs/sbin:$PATH"
-
-    E2FSCK="e2fsck"
-    RESIZE2FS_PATH="resize2fs"
-elif [ ! -f "$E2FSCK" ]; then
-    E2FSCK="$(command -v e2fsck)"
-
-    if [ ! -f "$E2FSCK" ]; then
-        E2FSCK="/usr/sbin/e2fsck"
-        if [ ! -f "$E2FSCK" ]; then
-            E2FSCK="/sbin/e2fsck"
-        fi
-    fi
-fi
-
 
 # Prepend the toolchain qemu directory so we pick up QEMU from there
 PATH="$SCRIPT_DIR/../Toolchain/Local/qemu/bin:$PATH"

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -83,7 +83,7 @@ if [ -f _disk_image ]; then
 
     echo "checking existing image"
     result=0
-    "$E2FSCK" -f -y _disk_image || result=$?
+    "$E2FSCK_PATH" -f -y _disk_image || result=$?
     if [ $result -ge 4 ]; then
         rm -f _disk_image
         USE_EXISTING=0

--- a/Meta/build-native-partition.sh
+++ b/Meta/build-native-partition.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
This patch adds the `find_executable()` function that will hopefully find executables in a distro-agnostic way and that is (hopefully as well) easily upgradable.

Fixes  #16176 
Note: I don't understand how 45e22dafb3d487341809a54ae63bf005300b5bea works, as the failure of `command` will cause the script to exit due to `set -e`.