### PR TITLE
Kernel: Ignore an invalid QEMU multiboot entry

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -121,11 +121,6 @@ if [ "$installed_major_version" -lt "$SERENITY_QEMU_MIN_REQ_MAJOR_VERSION" ] ||
     die
 fi
 
-# https://github.com/SerenityOS/serenity/issues/14952
-if [ "$installed_major_version" -ge 7 ] && [ "$installed_minor_version" -gt 0  ]; then
-    SERENITY_MACHINE_FORCE_VERSION_SEVEN_ZERO="-machine pc-i440fx-7.0"
-fi
-
 NATIVE_WINDOWS_QEMU="0"
 
 if command -v wslpath >/dev/null; then
@@ -267,7 +262,6 @@ if [ -z "$SERENITY_MACHINE" ]; then
         SERENITY_MACHINE="-M raspi3b -serial stdio"
     else
         SERENITY_MACHINE="
-        $SERENITY_MACHINE_FORCE_VERSION_SEVEN_ZERO
         -m $SERENITY_RAM_SIZE
         -smp $SERENITY_CPUS
         -display $SERENITY_QEMU_DISPLAY_BACKEND


### PR DESCRIPTION
This makes the kernel ignore a seemingly invalid QEMU multiboot entry and allows Serenity to boot once again on the q35 machine on x86-based platforms.

For reference, a similar fix was put in place by [this](https://gitlab.com/weinholt/loko/-/commit/1e88ef9067a3d53f1148e87962335a6a1bb12bc8) project.

Fixes #14952.