### PR TITLE
Meta: seperate ccache setup and detect ccache being passed as a compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,7 @@ if(NOT COMMAND serenity_option)
 endif()
 include(serenity_options)
 
-find_program(CCACHE_PROGRAM ccache)
-if(CCACHE_PROGRAM)
-    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
-    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
-endif()
+include(setup_ccache)
 
 if (NOT HACKSTUDIO_BUILD)
 

--- a/Meta/CMake/setup_ccache.cmake
+++ b/Meta/CMake/setup_ccache.cmake
@@ -1,0 +1,9 @@
+#
+# ccache setup
+#
+
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
+endif()

--- a/Meta/CMake/setup_ccache.cmake
+++ b/Meta/CMake/setup_ccache.cmake
@@ -2,8 +2,17 @@
 # ccache setup
 #
 
+list(APPEND COMPILERS
+    "CMAKE_C_COMPILER"
+    "CMAKE_CXX_COMPILER"
+)
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
-    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
-    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
+    foreach(compiler ${COMPILERS})
+        get_filename_component(compiler_path "${${compiler}}" REALPATH)
+        get_filename_component(compiler_name "${compiler_path}" NAME)
+        if (NOT ${compiler_name} MATCHES "ccache")
+            set("${compiler}_LAUNCHER" "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
+        endif()
+    endforeach()
 endif()

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -49,11 +49,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries instead of static libraries" ON
 find_package(Threads REQUIRED)
 
 if (ENABLE_LAGOM_CCACHE)
-    find_program(CCACHE_PROGRAM ccache)
-    if(CCACHE_PROGRAM)
-        set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
-        set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
-    endif()
+    include(setup_ccache)
 endif()
 
 if (ENABLE_FUZZERS_LIBFUZZER OR ENABLE_FUZZERS_OSSFUZZ)


### PR DESCRIPTION
This PR seperates the ccache setup found in the root CMakeLists and the Lagom CMakeLists into its own cmake component and expands thats cmake component to detect if the compiler used is already pointing towards ccache.

Some distros set up symlinks for common compilers to call ccache, simplifying the process of using it.
For example on Fedora:
`gcc` invokes `/usr/lib64/ccache/gcc` which is a symlink to `/usr/bin/ccache`

While ccache invoking itself is harmless, other compiler wrappers that may be used with ccache, like icecc, become unhappy when they invoke themselves and terminate compilation.