### PR TITLE
userdel: More intensive usage of LibCore

### DIFF
--- a/Userland/Libraries/LibCore/Account.cpp
+++ b/Userland/Libraries/LibCore/Account.cpp
@@ -259,28 +259,19 @@ ErrorOr<DeprecatedString> Account::generate_shadow_file() const
     struct spwd* p;
     errno = 0;
     while ((p = getspent())) {
-        if (p->sp_namp == m_username) {
-            builder.appendff("{}:{}:{}:{}:{}:{}:{}:{}:{}\n",
-                m_username, m_password_hash,
-                (p->sp_lstchg == -1) ? "" : DeprecatedString::formatted("{}", p->sp_lstchg),
-                (p->sp_min == -1) ? "" : DeprecatedString::formatted("{}", p->sp_min),
-                (p->sp_max == -1) ? "" : DeprecatedString::formatted("{}", p->sp_max),
-                (p->sp_warn == -1) ? "" : DeprecatedString::formatted("{}", p->sp_warn),
-                (p->sp_inact == -1) ? "" : DeprecatedString::formatted("{}", p->sp_inact),
-                (p->sp_expire == -1) ? "" : DeprecatedString::formatted("{}", p->sp_expire),
-                (p->sp_flag == 0) ? "" : DeprecatedString::formatted("{}", p->sp_flag));
+        if (p->sp_namp == m_username)
+            builder.appendff("{}:{}", m_username, m_password_hash);
+        else
+            builder.appendff("{}:{}", p->sp_namp, p->sp_pwdp);
 
-        } else {
-            builder.appendff("{}:{}:{}:{}:{}:{}:{}:{}:{}\n",
-                p->sp_namp, p->sp_pwdp,
-                (p->sp_lstchg == -1) ? "" : DeprecatedString::formatted("{}", p->sp_lstchg),
-                (p->sp_min == -1) ? "" : DeprecatedString::formatted("{}", p->sp_min),
-                (p->sp_max == -1) ? "" : DeprecatedString::formatted("{}", p->sp_max),
-                (p->sp_warn == -1) ? "" : DeprecatedString::formatted("{}", p->sp_warn),
-                (p->sp_inact == -1) ? "" : DeprecatedString::formatted("{}", p->sp_inact),
-                (p->sp_expire == -1) ? "" : DeprecatedString::formatted("{}", p->sp_expire),
-                (p->sp_flag == 0) ? "" : DeprecatedString::formatted("{}", p->sp_flag));
-        }
+        builder.appendff(":{}:{}:{}:{}:{}:{}:{}\n",
+            (p->sp_lstchg == -1) ? "" : DeprecatedString::formatted("{}", p->sp_lstchg),
+            (p->sp_min == -1) ? "" : DeprecatedString::formatted("{}", p->sp_min),
+            (p->sp_max == -1) ? "" : DeprecatedString::formatted("{}", p->sp_max),
+            (p->sp_warn == -1) ? "" : DeprecatedString::formatted("{}", p->sp_warn),
+            (p->sp_inact == -1) ? "" : DeprecatedString::formatted("{}", p->sp_inact),
+            (p->sp_expire == -1) ? "" : DeprecatedString::formatted("{}", p->sp_expire),
+            (p->sp_flag == 0) ? "" : DeprecatedString::formatted("{}", p->sp_flag));
     }
     endspent();
 

--- a/Userland/Libraries/LibCore/Account.cpp
+++ b/Userland/Libraries/LibCore/Account.cpp
@@ -231,6 +231,8 @@ ErrorOr<DeprecatedString> Account::generate_passwd_file() const
             break;
 
         if (pwd->pw_name == m_username) {
+            if (m_deleted)
+                continue;
             builder.appendff("{}:!:{}:{}:{}:{}:{}\n",
                 m_username,
                 m_uid, m_gid,
@@ -259,9 +261,11 @@ ErrorOr<DeprecatedString> Account::generate_shadow_file() const
     struct spwd* p;
     errno = 0;
     while ((p = getspent())) {
-        if (p->sp_namp == m_username)
+        if (p->sp_namp == m_username) {
+            if (m_deleted)
+                continue;
             builder.appendff("{}:{}", m_username, m_password_hash);
-        else
+        } else
             builder.appendff("{}:{}", p->sp_namp, p->sp_pwdp);
 
         builder.appendff(":{}:{}:{}:{}:{}:{}:{}\n",

--- a/Userland/Libraries/LibCore/Account.h
+++ b/Userland/Libraries/LibCore/Account.h
@@ -52,6 +52,7 @@ public:
     void set_gid(gid_t gid) { m_gid = gid; }
     void set_shell(StringView shell) { m_shell = shell; }
     void set_gecos(StringView gecos) { m_gecos = gecos; }
+    void set_deleted() { m_deleted = true; };
     void delete_password();
 
     // A null password means that this account was missing from /etc/shadow.
@@ -86,6 +87,7 @@ private:
     DeprecatedString m_home_directory;
     DeprecatedString m_shell;
     Vector<gid_t> m_extra_gids;
+    bool m_deleted { false };
 };
 
 }


### PR DESCRIPTION
The PR contains two changes:
- Use `Core::File::remove()` instead of spawning `/bin/rm`
- Use `Core::Account::sync()` to interact with sensitive files