### PR TITLE
JsonValue+JsonObject+JsonArray: Partially refactor to use new `String` class

### DIFF
--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -71,7 +71,7 @@ public:
     template<typename Builder>
     void serialize(Builder&) const;
 
-    [[nodiscard]] DeprecatedString to_deprecated_string() const { return serialized<StringBuilder>(); }
+    [[nodiscard]] DeprecatedString to_deprecated_string() const { return serialized<StringBuilder>().to_deprecated_string(); }
 
     template<typename Callback>
     void for_each(Callback callback) const
@@ -109,7 +109,7 @@ inline typename Builder::OutputType JsonArray::serialized() const
 {
     Builder builder;
     serialize(builder);
-    return builder.build();
+    return MUST(builder.to_string());
 }
 
 }

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -196,7 +196,7 @@ inline void JsonValue::serialize(Builder& builder) const
     switch (m_type) {
     case Type::String: {
         builder.append('\"');
-        builder.append_escaped_for_json({ m_value.as_string->characters(), m_value.as_string->length() });
+        builder.append_escaped_for_json({ m_value.as_deprecated_string->characters(), m_value.as_deprecated_string->length() });
         builder.append('\"');
     } break;
     case Type::Array:

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -66,7 +66,7 @@ public:
 
     [[nodiscard]] JsonValue const* get_ptr(StringView key) const
     {
-        auto it = m_members.find(key);
+        auto it = m_members.find(MUST(String::from_utf8(key)));
         if (it == m_members.end())
             return nullptr;
         return &(*it).value;
@@ -74,7 +74,7 @@ public:
 
     [[nodiscard]] [[nodiscard]] bool has(StringView key) const
     {
-        return m_members.contains(key);
+        return m_members.contains(MUST(String::from_utf8(key)));
     }
 
     [[nodiscard]] bool has_null(StringView key) const
@@ -137,6 +137,11 @@ public:
 
     void set(DeprecatedString const& key, JsonValue value)
     {
+        m_members.set(MUST(String::from_deprecated_string(key)), move(value));
+    }
+
+    void set(String const& key, JsonValue value)
+    {
         m_members.set(key, move(value));
     }
 
@@ -157,7 +162,7 @@ public:
 
     bool remove(StringView key)
     {
-        return m_members.remove(key);
+        return m_members.remove(MUST(String::from_utf8(key)));
     }
 
     template<typename Builder>
@@ -169,7 +174,7 @@ public:
     [[nodiscard]] DeprecatedString to_deprecated_string() const { return serialized<StringBuilder>().to_deprecated_string(); }
 
 private:
-    OrderedHashMap<DeprecatedString, JsonValue> m_members;
+    OrderedHashMap<String, JsonValue> m_members;
 };
 
 template<typename Builder>

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -163,8 +163,8 @@ JsonValue::JsonValue(char const* cstring)
 #if !defined(KERNEL)
 JsonValue::JsonValue(double value)
     : m_type(Type::Double)
+    , m_value(value)
 {
-    m_value.set(value);
 }
 #endif
 
@@ -179,9 +179,9 @@ JsonValue::JsonValue(DeprecatedString const& value)
 }
 
 JsonValue::JsonValue(String const& value)
+    : m_type(Type::String)
+    , m_value(String(value))
 {
-    m_type = Type::String;
-    m_value.set(String(value));
 }
 
 JsonValue::JsonValue(StringView value)
@@ -191,26 +191,26 @@ JsonValue::JsonValue(StringView value)
 
 JsonValue::JsonValue(JsonObject const& value)
     : m_type(Type::Object)
+    , m_value(new JsonObject(value))
 {
-    m_value.set(new JsonObject(value));
 }
 
 JsonValue::JsonValue(JsonArray const& value)
     : m_type(Type::Array)
+    , m_value(new JsonArray(value))
 {
-    m_value.set(new JsonArray(value));
 }
 
 JsonValue::JsonValue(JsonObject&& value)
     : m_type(Type::Object)
+    , m_value(new JsonObject(move(value)))
 {
-    m_value.set(new JsonObject(move(value)));
 }
 
 JsonValue::JsonValue(JsonArray&& value)
     : m_type(Type::Array)
+    , m_value(new JsonArray(move(value)))
 {
-    m_value.set(new JsonArray(move(value)));
 }
 
 void JsonValue::clear()

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -131,48 +131,28 @@ bool JsonValue::equals(JsonValue const& other) const
     return false;
 }
 
-JsonValue::JsonValue(int value)
+JsonValue::JsonValue(i32 value)
     : m_type(Type::Int32)
+    , m_value(value)
 {
-    m_value.set(static_cast<i32>(value));
 }
 
-JsonValue::JsonValue(unsigned value)
+JsonValue::JsonValue(u32 value)
     : m_type(Type::UnsignedInt32)
+    , m_value(value)
 {
-    m_value.set(static_cast<u32>(value));
 }
 
-JsonValue::JsonValue(long value)
-    : m_type(sizeof(long) == 8 ? Type::Int64 : Type::Int32)
-{
-    if constexpr (sizeof(long) == 8)
-        m_value.set(static_cast<i64>(value));
-    else
-        m_value.set(static_cast<i32>(value));
-}
-
-JsonValue::JsonValue(unsigned long value)
-    : m_type(sizeof(long) == 8 ? Type::UnsignedInt64 : Type::UnsignedInt32)
-{
-    if constexpr (sizeof(long) == 8)
-        m_value.set(static_cast<u64>(value));
-    else
-        m_value.set(static_cast<u32>(value));
-}
-
-JsonValue::JsonValue(long long value)
+JsonValue::JsonValue(i64 value)
     : m_type(Type::Int64)
+    , m_value(value)
 {
-    static_assert(sizeof(long long unsigned) == 8);
-    m_value.set(static_cast<i64>(value));
 }
 
-JsonValue::JsonValue(long long unsigned value)
+JsonValue::JsonValue(u64 value)
     : m_type(Type::UnsignedInt64)
+    , m_value(value)
 {
-    static_assert(sizeof(long long unsigned) == 8);
-    m_value.set(static_cast<u64>(value));
 }
 
 JsonValue::JsonValue(char const* cstring)

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -42,20 +42,35 @@ void JsonValue::copy_from(JsonValue const& other)
 {
     m_type = other.m_type;
     switch (m_type) {
-    case Type::Null:
-        m_value.set(Empty {});
-        break;
     case Type::String:
         m_value.set(String(other.m_value.get<String>()));
         break;
-    case Type::Object:
-        m_value.set(new JsonObject(*other.m_value.get<JsonObject*>()));
+    case Type::Double:
+        m_value.set(other.m_value.get<double>());
         break;
     case Type::Array:
         m_value.set(new JsonArray(*other.m_value.get<JsonArray*>()));
         break;
-    default:
+    case Type::Object:
+        m_value.set(new JsonObject(*other.m_value.get<JsonObject*>()));
+        break;
+    case Type::Int32:
+        m_value.set(other.m_value.get<i32>());
+        break;
+    case Type::UnsignedInt32:
+        m_value.set(other.m_value.get<u32>());
+        break;
+    case Type::Int64:
+        m_value.set(other.m_value.get<i64>());
+        break;
+    case Type::UnsignedInt64:
         m_value.set(other.m_value.get<u64>());
+        break;
+    case Type::Bool:
+        m_value.set(other.m_value.get<bool>());
+        break;
+    default:
+        m_value.set(Empty {});
         break;
     }
 }

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -39,9 +39,9 @@ void JsonValue::copy_from(JsonValue const& other)
     m_type = other.m_type;
     switch (m_type) {
     case Type::String:
-        VERIFY(!m_value.as_string);
-        m_value.as_string = other.m_value.as_string;
-        m_value.as_string->ref();
+        VERIFY(!m_value.as_deprecated_string);
+        m_value.as_deprecated_string = other.m_value.as_deprecated_string;
+        m_value.as_deprecated_string->ref();
         break;
     case Type::Object:
         m_value.as_object = new JsonObject(*other.m_value.as_object);
@@ -79,7 +79,7 @@ bool JsonValue::equals(JsonValue const& other) const
     if (is_bool() && other.is_bool() && as_bool() == other.as_bool())
         return true;
 
-    if (is_string() && other.is_string() && as_string() == other.as_string())
+    if (is_string() && other.is_string() && as_deprecated_string() == other.as_deprecated_string())
         return true;
 
 #if !defined(KERNEL)
@@ -174,8 +174,8 @@ JsonValue::JsonValue(DeprecatedString const& value)
         m_type = Type::Null;
     } else {
         m_type = Type::String;
-        m_value.as_string = const_cast<StringImpl*>(value.impl());
-        m_value.as_string->ref();
+        m_value.as_deprecated_string = const_cast<StringImpl*>(value.impl());
+        m_value.as_deprecated_string->ref();
     }
 }
 
@@ -212,7 +212,7 @@ void JsonValue::clear()
 {
     switch (m_type) {
     case Type::String:
-        m_value.as_string->unref();
+        m_value.as_deprecated_string->unref();
         break;
     case Type::Object:
         delete m_value.as_object;
@@ -224,7 +224,7 @@ void JsonValue::clear()
         break;
     }
     m_type = Type::Null;
-    m_value.as_string = nullptr;
+    m_value.as_deprecated_string = nullptr;
 }
 
 #ifndef KERNEL

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -66,7 +66,7 @@ public:
     requires(SameAs<RemoveCVReference<T>, bool>)
     JsonValue(T value)
         : m_type(Type::Bool)
-        , m_value { .as_bool = value }
+        , m_value(value)
     {
     }
 

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -47,12 +47,10 @@ public:
     JsonValue& operator=(JsonValue const&);
     JsonValue& operator=(JsonValue&&);
 
-    JsonValue(int);
-    JsonValue(unsigned);
-    JsonValue(long);
-    JsonValue(long unsigned);
-    JsonValue(long long);
-    JsonValue(long long unsigned);
+    JsonValue(i32);
+    JsonValue(u32);
+    JsonValue(i64);
+    JsonValue(u64);
 
 #if !defined(KERNEL)
     JsonValue(double);

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -85,17 +85,17 @@ public:
     void serialize(Builder&) const;
 
 #ifndef KERNEL
-    DeprecatedString as_string_or(DeprecatedString const& alternative) const
+    DeprecatedString as_deprecated_string_or(DeprecatedString const& alternative) const
     {
         if (is_string())
-            return as_string();
+            return as_deprecated_string();
         return alternative;
     }
 
     DeprecatedString to_deprecated_string() const
     {
         if (is_string())
-            return as_string();
+            return as_deprecated_string();
         return serialized<StringBuilder>();
     }
 #endif
@@ -165,10 +165,10 @@ public:
     }
 
 #ifndef KERNEL
-    DeprecatedString as_string() const
+    DeprecatedString as_deprecated_string() const
     {
         VERIFY(is_string());
-        return *m_value.as_string;
+        return *m_value.as_deprecated_string;
     }
 #endif
 
@@ -271,7 +271,7 @@ private:
 
     union {
 #ifndef KERNEL
-        StringImpl* as_string { nullptr };
+        StringImpl* as_deprecated_string { nullptr };
 #endif
         JsonArray* as_array;
         JsonObject* as_object;

--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/GenericLexer.h>
 #include <AK/HashMap.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 
 namespace AK {
@@ -17,7 +17,7 @@ class SourceGenerator {
     AK_MAKE_NONCOPYABLE(SourceGenerator);
 
 public:
-    using MappingType = HashMap<StringView, DeprecatedString>;
+    using MappingType = HashMap<StringView, String>;
 
     explicit SourceGenerator(StringBuilder& builder, char opening = '@', char closing = '@')
         : m_builder(builder)
@@ -37,7 +37,7 @@ public:
 
     SourceGenerator fork() { return SourceGenerator { m_builder, m_mapping, m_opening, m_closing }; }
 
-    void set(StringView key, DeprecatedString value)
+    void set(StringView key, String value)
     {
         if (key.contains(m_opening) || key.contains(m_closing)) {
             warnln("SourceGenerator keys cannot contain the opening/closing delimiters `{}` and `{}`. (Keys are only wrapped in these when using them, not when setting them.)", m_opening, m_closing);
@@ -46,7 +46,7 @@ public:
         m_mapping.set(key, move(value));
     }
 
-    DeprecatedString get(StringView key) const
+    String get(StringView key) const
     {
         auto result = m_mapping.get(key);
         if (!result.has_value()) {
@@ -57,7 +57,7 @@ public:
     }
 
     StringView as_string_view() const { return m_builder.string_view(); }
-    DeprecatedString as_string() const { return m_builder.build(); }
+    ErrorOr<String> as_string() const { return m_builder.to_string(); }
 
     void append(StringView pattern)
     {
@@ -92,15 +92,15 @@ public:
     }
 
     template<size_t N>
-    DeprecatedString get(char const (&key)[N])
+    String get(char const (&key)[N])
     {
         return get(StringView { key, N - 1 });
     }
 
     template<size_t N>
-    void set(char const (&key)[N], DeprecatedString value)
+    void set(char const (&key)[N], String value)
     {
-        set(StringView { key, N - 1 }, value);
+        set(StringView { key, N - 1 }, move(value));
     }
 
     template<size_t N>

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -16,7 +16,7 @@ namespace AK {
 
 class StringBuilder {
 public:
-    using OutputType = DeprecatedString;
+    using OutputType = String;
 
     static ErrorOr<StringBuilder> create(size_t initial_capacity = inline_capacity);
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
@@ -588,7 +588,7 @@ static ErrorOr<void> parse_hour_cycles(DeprecatedString core_path, CLDR& cldr)
     };
 
     time_data_object.as_object().for_each_member([&](auto const& key, JsonValue const& value) {
-        auto allowed_hour_cycles_string = value.as_object().get("_allowed"sv).as_string();
+        auto allowed_hour_cycles_string = value.as_object().get("_allowed"sv).as_deprecated_string();
         auto allowed_hour_cycles = allowed_hour_cycles_string.split_view(' ');
 
         Vector<Locale::HourCycle> hour_cycles;
@@ -653,7 +653,7 @@ static ErrorOr<void> parse_week_data(DeprecatedString core_path, CLDR& cldr)
     auto const& weekend_end_object = week_data_object.as_object().get("weekendEnd"sv);
 
     minimum_days_object.as_object().for_each_member([&](auto const& region, auto const& value) {
-        auto minimum_days = value.as_string().template to_uint<u8>();
+        auto minimum_days = value.as_deprecated_string().template to_uint<u8>();
         cldr.minimum_days.set(region, *minimum_days);
 
         if (!cldr.minimum_days_regions.contains_slow(region))
@@ -661,13 +661,13 @@ static ErrorOr<void> parse_week_data(DeprecatedString core_path, CLDR& cldr)
     });
 
     first_day_object.as_object().for_each_member([&](auto const& region, auto const& value) {
-        parse_regional_weekdays(region, value.as_string(), cldr.first_day, cldr.first_day_regions);
+        parse_regional_weekdays(region, value.as_deprecated_string(), cldr.first_day, cldr.first_day_regions);
     });
     weekend_start_object.as_object().for_each_member([&](auto const& region, auto const& value) {
-        parse_regional_weekdays(region, value.as_string(), cldr.weekend_start, cldr.weekend_start_regions);
+        parse_regional_weekdays(region, value.as_deprecated_string(), cldr.weekend_start, cldr.weekend_start_regions);
     });
     weekend_end_object.as_object().for_each_member([&](auto const& region, auto const& value) {
-        parse_regional_weekdays(region, value.as_string(), cldr.weekend_end, cldr.weekend_end_regions);
+        parse_regional_weekdays(region, value.as_deprecated_string(), cldr.weekend_end, cldr.weekend_end_regions);
     });
 
     return {};
@@ -690,8 +690,8 @@ static ErrorOr<void> parse_meta_zones(DeprecatedString core_path, CLDR& cldr)
         auto const& meta_zone = mapping.as_object().get("_other"sv);
         auto const& golden_zone = mapping.as_object().get("_type"sv);
 
-        if (auto time_zone = TimeZone::time_zone_from_string(golden_zone.as_string()); time_zone.has_value()) {
-            auto& golden_zones = cldr.meta_zones.ensure(meta_zone.as_string());
+        if (auto time_zone = TimeZone::time_zone_from_string(golden_zone.as_deprecated_string()); time_zone.has_value()) {
+            auto& golden_zones = cldr.meta_zones.ensure(meta_zone.as_deprecated_string());
             golden_zones.append(*time_zone);
         }
     });
@@ -1099,7 +1099,7 @@ static void parse_interval_patterns(Calendar& calendar, JsonObject const& interv
 
     interval_formats_object.for_each_member([&](auto const& skeleton, auto const& value) {
         if (skeleton == "intervalFormatFallback"sv) {
-            auto range_format = split_default_range_pattern(skeleton, value.as_string());
+            auto range_format = split_default_range_pattern(skeleton, value.as_deprecated_string());
             calendar.default_range_format = cldr.unique_range_patterns.ensure(move(range_format));
             return;
         }
@@ -1111,7 +1111,7 @@ static void parse_interval_patterns(Calendar& calendar, JsonObject const& interv
             VERIFY(field.length() == 1);
             auto name = name_of_field(field[0]);
 
-            auto format = parse_date_time_pattern_raw(pattern.as_string(), skeleton, cldr).release_value();
+            auto format = parse_date_time_pattern_raw(pattern.as_deprecated_string(), skeleton, cldr).release_value();
 
             auto range_format = split_range_pattern(skeleton, name, format.pattern, format);
             range_formats.append(cldr.unique_range_patterns.ensure(move(range_format)));
@@ -1274,13 +1274,13 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
         };
 
         narrow_symbols.for_each_member([&](auto const& key, JsonValue const& value) {
-            append_symbol(symbol_lists[0], key, value.as_string());
+            append_symbol(symbol_lists[0], key, value.as_deprecated_string());
         });
         short_symbols.for_each_member([&](auto const& key, JsonValue const& value) {
-            append_symbol(symbol_lists[1], key, value.as_string());
+            append_symbol(symbol_lists[1], key, value.as_deprecated_string());
         });
         long_symbols.for_each_member([&](auto const& key, JsonValue const& value) {
-            append_symbol(symbol_lists[2], key, value.as_string());
+            append_symbol(symbol_lists[2], key, value.as_deprecated_string());
         });
 
         store_symbol_lists(Locale::CalendarSymbol::Era, move(symbol_lists));
@@ -1298,13 +1298,13 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
         };
 
         narrow_symbols.for_each_member([&](auto const& key, JsonValue const& value) {
-            append_symbol(symbol_lists[0], key, value.as_string());
+            append_symbol(symbol_lists[0], key, value.as_deprecated_string());
         });
         short_symbols.for_each_member([&](auto const& key, JsonValue const& value) {
-            append_symbol(symbol_lists[1], key, value.as_string());
+            append_symbol(symbol_lists[1], key, value.as_deprecated_string());
         });
         long_symbols.for_each_member([&](auto const& key, JsonValue const& value) {
-            append_symbol(symbol_lists[2], key, value.as_string());
+            append_symbol(symbol_lists[2], key, value.as_deprecated_string());
         });
 
         store_symbol_lists(Locale::CalendarSymbol::Month, move(symbol_lists));
@@ -1334,13 +1334,13 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
         };
 
         narrow_symbols.for_each_member([&](auto const& key, JsonValue const& value) {
-            append_symbol(symbol_lists[0], key, value.as_string());
+            append_symbol(symbol_lists[0], key, value.as_deprecated_string());
         });
         short_symbols.for_each_member([&](auto const& key, JsonValue const& value) {
-            append_symbol(symbol_lists[1], key, value.as_string());
+            append_symbol(symbol_lists[1], key, value.as_deprecated_string());
         });
         long_symbols.for_each_member([&](auto const& key, JsonValue const& value) {
-            append_symbol(symbol_lists[2], key, value.as_string());
+            append_symbol(symbol_lists[2], key, value.as_deprecated_string());
         });
 
         store_symbol_lists(Locale::CalendarSymbol::Weekday, move(symbol_lists));
@@ -1358,13 +1358,13 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
         };
 
         narrow_symbols.for_each_member([&](auto const& key, JsonValue const& value) {
-            append_symbol(symbol_lists[0], key, value.as_string());
+            append_symbol(symbol_lists[0], key, value.as_deprecated_string());
         });
         short_symbols.for_each_member([&](auto const& key, JsonValue const& value) {
-            append_symbol(symbol_lists[1], key, value.as_string());
+            append_symbol(symbol_lists[1], key, value.as_deprecated_string());
         });
         long_symbols.for_each_member([&](auto const& key, JsonValue const& value) {
-            append_symbol(symbol_lists[2], key, value.as_string());
+            append_symbol(symbol_lists[2], key, value.as_deprecated_string());
         });
 
         store_symbol_lists(Locale::CalendarSymbol::DayPeriod, move(symbol_lists));
@@ -1395,7 +1395,7 @@ static ErrorOr<void> parse_calendars(DeprecatedString locale_calendars_path, CLD
             auto format = patterns_object.get(name);
             auto skeleton = skeletons_object.get(name);
 
-            auto format_index = parse_date_time_pattern(format.as_string(), skeleton.as_string_or(DeprecatedString::empty()), cldr).value();
+            auto format_index = parse_date_time_pattern(format.as_deprecated_string(), skeleton.as_deprecated_string_or(DeprecatedString::empty()), cldr).value();
 
             if (patterns)
                 patterns->append(cldr.unique_patterns.get(format_index));
@@ -1441,7 +1441,7 @@ static ErrorOr<void> parse_calendars(DeprecatedString locale_calendars_path, CLD
         auto const& date_time_formats_object = value.as_object().get("dateTimeFormats"sv);
         auto const& available_formats_object = date_time_formats_object.as_object().get("availableFormats"sv);
         available_formats_object.as_object().for_each_member([&](auto const& skeleton, JsonValue const& pattern) {
-            auto pattern_index = parse_date_time_pattern(pattern.as_string(), skeleton, cldr);
+            auto pattern_index = parse_date_time_pattern(pattern.as_deprecated_string(), skeleton, cldr);
             if (!pattern_index.has_value())
                 return;
 
@@ -1494,7 +1494,7 @@ static ErrorOr<void> parse_time_zone_names(DeprecatedString locale_time_zone_nam
 
         auto const& name = names.as_object().get(key);
         if (name.is_string())
-            return cldr.unique_strings.ensure(name.as_string());
+            return cldr.unique_strings.ensure(name.as_deprecated_string());
 
         return {};
     };
@@ -1525,9 +1525,9 @@ static ErrorOr<void> parse_time_zone_names(DeprecatedString locale_time_zone_nam
     TimeZoneNamesList time_zones;
 
     TimeZoneFormat time_zone_formats {};
-    parse_hour_format(hour_format_string.as_string(), time_zone_formats);
-    time_zone_formats.gmt_format = cldr.unique_strings.ensure(gmt_format_string.as_string());
-    time_zone_formats.gmt_zero_format = cldr.unique_strings.ensure(gmt_zero_format_string.as_string());
+    parse_hour_format(hour_format_string.as_deprecated_string(), time_zone_formats);
+    time_zone_formats.gmt_format = cldr.unique_strings.ensure(gmt_format_string.as_deprecated_string());
+    time_zone_formats.gmt_zero_format = cldr.unique_strings.ensure(gmt_zero_format_string.as_deprecated_string());
 
     auto parse_time_zone = [&](StringView meta_zone, JsonObject const& meta_zone_object) {
         auto golden_zones = cldr.meta_zones.find(meta_zone);
@@ -1608,8 +1608,8 @@ static ErrorOr<void> parse_day_periods(DeprecatedString core_path, CLDR& cldr)
         if (!day_period.has_value())
             return {};
 
-        auto begin = parse_hour(ranges.get("_from"sv).as_string());
-        auto end = parse_hour(ranges.get("_before"sv).as_string());
+        auto begin = parse_hour(ranges.get("_from"sv).as_deprecated_string());
+        auto end = parse_hour(ranges.get("_before"sv).as_deprecated_string());
 
         return DayPeriod { *day_period, begin, end };
     };

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
@@ -258,7 +258,7 @@ static ErrorOr<void> parse_core_aliases(DeprecatedString core_supplemental_path,
 
     auto append_aliases = [&](auto& alias_object, auto& alias_map) {
         alias_object.as_object().for_each_member([&](auto const& key, JsonValue const& value) {
-            auto alias = value.as_object().get("_replacement"sv).as_string();
+            auto alias = value.as_object().get("_replacement"sv).as_deprecated_string();
 
             if (key.contains('-')) {
                 auto mapping = TRY_OR_DISCARD(parse_language_mapping(cldr, key, alias));
@@ -290,7 +290,7 @@ static ErrorOr<void> parse_likely_subtags(DeprecatedString core_supplemental_pat
     auto const& likely_subtags_object = supplemental_object.as_object().get("likelySubtags"sv);
 
     likely_subtags_object.as_object().for_each_member([&](auto const& key, JsonValue const& value) {
-        auto mapping = TRY_OR_DISCARD(parse_language_mapping(cldr, key, value.as_string()));
+        auto mapping = TRY_OR_DISCARD(parse_language_mapping(cldr, key, value.as_deprecated_string()));
         cldr.max_variant_size = max(mapping.key.variants.size(), cldr.max_variant_size);
         cldr.max_variant_size = max(mapping.alias.variants.size(), cldr.max_variant_size);
         cldr.likely_subtags.append(move(mapping));
@@ -313,22 +313,22 @@ static ErrorOr<void> parse_identity(DeprecatedString locale_path, CLDR& cldr, Lo
     auto const& script_string = identity_object.as_object().get("script"sv);
     auto const& variant_string = identity_object.as_object().get("variant"sv);
 
-    locale.language = language_string.as_string();
+    locale.language = language_string.as_deprecated_string();
 
     if (territory_string.is_string()) {
-        locale.territory = territory_string.as_string();
+        locale.territory = territory_string.as_deprecated_string();
         if (!cldr.territories.contains_slow(*locale.territory))
             cldr.territories.append(*locale.territory);
     }
 
     if (script_string.is_string()) {
-        auto script = script_string.as_string();
+        auto script = script_string.as_deprecated_string();
         if (!cldr.scripts.contains_slow(script))
             cldr.scripts.append(script);
     }
 
     if (variant_string.is_string()) {
-        locale.variant = variant_string.as_string();
+        locale.variant = variant_string.as_deprecated_string();
         if (!cldr.variants.contains_slow(*locale.variant))
             cldr.variants.append(*locale.variant);
     }
@@ -350,8 +350,8 @@ static ErrorOr<void> parse_locale_display_patterns(DeprecatedString locale_path,
     auto const& locale_separator = locale_display_patterns_object.as_object().get("localeSeparator"sv);
 
     DisplayPattern patterns {};
-    patterns.locale_pattern = cldr.unique_strings.ensure(locale_pattern.as_string());
-    patterns.locale_separator = cldr.unique_strings.ensure(locale_separator.as_string());
+    patterns.locale_pattern = cldr.unique_strings.ensure(locale_pattern.as_deprecated_string());
+    patterns.locale_separator = cldr.unique_strings.ensure(locale_separator.as_deprecated_string());
 
     locale.display_patterns = cldr.unique_display_patterns.ensure(move(patterns));
     return {};
@@ -391,7 +391,7 @@ static ErrorOr<void> parse_unicode_extension_keywords(DeprecatedString bcp47_pat
             return;
 
         auto const& name = value.as_object().get("_alias"sv);
-        cldr.keyword_names.set(key, name.as_string());
+        cldr.keyword_names.set(key, name.as_deprecated_string());
 
         auto& keywords = cldr.keywords.ensure(key);
 
@@ -413,12 +413,12 @@ static ErrorOr<void> parse_unicode_extension_keywords(DeprecatedString bcp47_pat
                 return;
 
             if (auto const& preferred = properties.as_object().get("_preferred"sv); preferred.is_string()) {
-                cldr.keyword_aliases.ensure(key).append({ preferred.as_string(), keyword });
+                cldr.keyword_aliases.ensure(key).append({ preferred.as_deprecated_string(), keyword });
                 return;
             }
 
             if (auto const& alias = properties.as_object().get("_alias"sv); alias.is_string())
-                cldr.keyword_aliases.ensure(key).append({ keyword, alias.as_string() });
+                cldr.keyword_aliases.ensure(key).append({ keyword, alias.as_deprecated_string() });
 
             keywords.append(keyword);
         });
@@ -459,7 +459,7 @@ static ErrorOr<void> parse_locale_languages(DeprecatedString locale_path, CLDR& 
             return;
 
         auto index = cldr.languages.find_first_index(key).value();
-        languages[index] = cldr.unique_strings.ensure(value.as_string());
+        languages[index] = cldr.unique_strings.ensure(value.as_deprecated_string());
     });
 
     locale.languages = cldr.unique_language_lists.ensure(move(languages));
@@ -482,7 +482,7 @@ static ErrorOr<void> parse_locale_territories(DeprecatedString locale_path, CLDR
 
     territories_object.as_object().for_each_member([&](auto const& key, JsonValue const& value) {
         if (auto index = cldr.territories.find_first_index(key); index.has_value())
-            territories[*index] = cldr.unique_strings.ensure(value.as_string());
+            territories[*index] = cldr.unique_strings.ensure(value.as_deprecated_string());
     });
 
     locale.territories = cldr.unique_territory_lists.ensure(move(territories));
@@ -505,7 +505,7 @@ static ErrorOr<void> parse_locale_scripts(DeprecatedString locale_path, CLDR& cl
 
     scripts_object.as_object().for_each_member([&](auto const& key, JsonValue const& value) {
         if (auto index = cldr.scripts.find_first_index(key); index.has_value())
-            scripts[*index] = cldr.unique_strings.ensure(value.as_string());
+            scripts[*index] = cldr.unique_strings.ensure(value.as_deprecated_string());
     });
 
     locale.scripts = cldr.unique_script_lists.ensure(move(scripts));
@@ -547,10 +547,10 @@ static ErrorOr<void> parse_locale_list_patterns(DeprecatedString misc_path, CLDR
         auto type = list_pattern_type(key);
         auto style = list_pattern_style(key);
 
-        auto start = cldr.unique_strings.ensure(value.as_object().get("start"sv).as_string());
-        auto middle = cldr.unique_strings.ensure(value.as_object().get("middle"sv).as_string());
-        auto end = cldr.unique_strings.ensure(value.as_object().get("end"sv).as_string());
-        auto pair = cldr.unique_strings.ensure(value.as_object().get("2"sv).as_string());
+        auto start = cldr.unique_strings.ensure(value.as_object().get("start"sv).as_deprecated_string());
+        auto middle = cldr.unique_strings.ensure(value.as_object().get("middle"sv).as_deprecated_string());
+        auto end = cldr.unique_strings.ensure(value.as_object().get("end"sv).as_deprecated_string());
+        auto pair = cldr.unique_strings.ensure(value.as_object().get("2"sv).as_deprecated_string());
 
         if (!cldr.list_pattern_types.contains_slow(type))
             cldr.list_pattern_types.append(type);
@@ -583,7 +583,7 @@ static ErrorOr<void> parse_locale_layout(DeprecatedString misc_path, CLDR& cldr,
     };
 
     auto const& character_order_string = orientation_object.as_object().get("characterOrder"sv);
-    auto const& character_order = character_order_string.as_string();
+    auto const& character_order = character_order_string.as_deprecated_string();
 
     TextLayout layout {};
     layout.character_order = text_layout_character_order(character_order);
@@ -630,10 +630,10 @@ static ErrorOr<void> parse_locale_currencies(DeprecatedString numbers_path, CLDR
         auto const& numeric_name = value.as_object().get("displayName-count-other"sv);
 
         auto index = cldr.currencies.find_first_index(key).value();
-        long_currencies[index] = cldr.unique_strings.ensure(long_name.as_string());
-        short_currencies[index] = cldr.unique_strings.ensure(short_name.as_string());
-        narrow_currencies[index] = narrow_name.is_null() ? 0 : cldr.unique_strings.ensure(narrow_name.as_string());
-        numeric_currencies[index] = cldr.unique_strings.ensure(numeric_name.is_null() ? long_name.as_string() : numeric_name.as_string());
+        long_currencies[index] = cldr.unique_strings.ensure(long_name.as_deprecated_string());
+        short_currencies[index] = cldr.unique_strings.ensure(short_name.as_deprecated_string());
+        narrow_currencies[index] = narrow_name.is_null() ? 0 : cldr.unique_strings.ensure(narrow_name.as_deprecated_string());
+        numeric_currencies[index] = cldr.unique_strings.ensure(numeric_name.is_null() ? long_name.as_deprecated_string() : numeric_name.as_deprecated_string());
     });
 
     locale.long_currencies = cldr.unique_currency_lists.ensure(move(long_currencies));
@@ -667,7 +667,7 @@ static ErrorOr<void> parse_locale_calendars(DeprecatedString locale_path, CLDR& 
             index = supported_calendars.find_first_index(*alias);
         }
 
-        calendars[*index] = cldr.unique_strings.ensure(calendar.as_string());
+        calendars[*index] = cldr.unique_strings.ensure(calendar.as_deprecated_string());
     });
 
     locale.calendars = cldr.unique_calendar_lists.ensure(move(calendars));
@@ -719,9 +719,9 @@ static ErrorOr<void> parse_locale_date_fields(DeprecatedString dates_path, CLDR&
         auto const& narrow_name = fields_object.as_object().get(DeprecatedString::formatted("{}-narrow", key)).as_object().get("displayName"sv);
 
         auto index = cldr.date_fields.find_first_index(key).value();
-        long_date_fields[index] = cldr.unique_strings.ensure(long_name.as_string());
-        short_date_fields[index] = cldr.unique_strings.ensure(short_name.as_string());
-        narrow_date_fields[index] = cldr.unique_strings.ensure(narrow_name.as_string());
+        long_date_fields[index] = cldr.unique_strings.ensure(long_name.as_deprecated_string());
+        short_date_fields[index] = cldr.unique_strings.ensure(short_name.as_deprecated_string());
+        narrow_date_fields[index] = cldr.unique_strings.ensure(narrow_name.as_deprecated_string());
     });
 
     locale.long_date_fields = cldr.unique_date_field_lists.ensure(move(long_date_fields));
@@ -753,16 +753,16 @@ static ErrorOr<void> parse_number_system_keywords(DeprecatedString locale_number
             keywords.append(move(index));
     };
 
-    append_numbering_system(default_numbering_system_object.as_string());
+    append_numbering_system(default_numbering_system_object.as_deprecated_string());
 
     other_numbering_systems_object.as_object().for_each_member([&](auto const&, JsonValue const& value) {
-        append_numbering_system(value.as_string());
+        append_numbering_system(value.as_deprecated_string());
     });
 
     locale_numbers_object.as_object().for_each_member([&](auto const& key, JsonValue const& value) {
         if (!key.starts_with("defaultNumberingSystem-alt-"sv))
             return;
-        append_numbering_system(value.as_string());
+        append_numbering_system(value.as_deprecated_string());
     });
 
     locale.number_system_keywords = cldr.unique_keyword_lists.ensure(move(keywords));
@@ -843,7 +843,7 @@ static ErrorOr<void> parse_default_content_locales(DeprecatedString core_path, C
     auto const& default_content_array = default_content.as_object().get("defaultContent"sv);
 
     default_content_array.as_array().for_each([&](JsonValue const& value) {
-        auto locale = value.as_string();
+        auto locale = value.as_deprecated_string();
         StringView default_locale = locale;
 
         while (true) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
@@ -249,11 +249,11 @@ static ErrorOr<void> parse_number_system_digits(DeprecatedString core_supplement
     auto const& number_systems_object = supplemental_object.as_object().get("numberingSystems"sv);
 
     number_systems_object.as_object().for_each_member([&](auto const& number_system, auto const& digits_object) {
-        auto type = digits_object.as_object().get("_type"sv).as_string();
+        auto type = digits_object.as_object().get("_type"sv).as_deprecated_string();
         if (type != "numeric"sv)
             return;
 
-        auto digits = digits_object.as_object().get("_digits"sv).as_string();
+        auto digits = digits_object.as_object().get("_digits"sv).as_deprecated_string();
 
         Utf8View utf8_digits { digits };
         VERIFY(utf8_digits.length() == 10);
@@ -443,7 +443,7 @@ static ErrorOr<void> parse_number_systems(DeprecatedString locale_numbers_path, 
             if (split_key.size() != 3)
                 return;
 
-            auto patterns = value.as_string().split(';');
+            auto patterns = value.as_deprecated_string().split(';');
             NumberFormat format {};
 
             if (auto type = split_key[0].template to_uint<u64>(); type.has_value()) {
@@ -516,7 +516,7 @@ static ErrorOr<void> parse_number_systems(DeprecatedString locale_numbers_path, 
                 if (to_underlying(*numeric_symbol) >= symbols.size())
                     symbols.resize(to_underlying(*numeric_symbol) + 1);
 
-                auto symbol_index = cldr.unique_strings.ensure(localization.as_string());
+                auto symbol_index = cldr.unique_strings.ensure(localization.as_deprecated_string());
                 symbols[to_underlying(*numeric_symbol)] = symbol_index;
             });
 
@@ -524,7 +524,7 @@ static ErrorOr<void> parse_number_systems(DeprecatedString locale_numbers_path, 
             // the range pattern.
             auto misc_patterns_key = DeprecatedString::formatted("{}{}", misc_patterns_prefix, system);
             auto misc_patterns = locale_numbers_object.as_object().get(misc_patterns_key);
-            auto range_separator = misc_patterns.as_object().get("range"sv).as_string();
+            auto range_separator = misc_patterns.as_object().get("range"sv).as_deprecated_string();
 
             auto begin_index = range_separator.find("{0}"sv).value() + "{0}"sv.length();
             auto end_index = range_separator.find("{1}"sv).value();
@@ -542,7 +542,7 @@ static ErrorOr<void> parse_number_systems(DeprecatedString locale_numbers_path, 
             auto& number_system = ensure_number_system(system);
 
             auto format_object = value.as_object().get("standard"sv);
-            parse_number_pattern(format_object.as_string().split(';'), cldr, NumberFormatType::Standard, number_system.decimal_format, &number_system);
+            parse_number_pattern(format_object.as_deprecated_string().split(';'), cldr, NumberFormatType::Standard, number_system.decimal_format, &number_system);
 
             auto const& long_format = value.as_object().get("long"sv).as_object().get("decimalFormat"sv);
             number_system.decimal_long_formats = parse_number_format(long_format.as_object());
@@ -554,10 +554,10 @@ static ErrorOr<void> parse_number_systems(DeprecatedString locale_numbers_path, 
             auto& number_system = ensure_number_system(system);
 
             auto format_object = value.as_object().get("standard"sv);
-            parse_number_pattern(format_object.as_string().split(';'), cldr, NumberFormatType::Standard, number_system.currency_format);
+            parse_number_pattern(format_object.as_deprecated_string().split(';'), cldr, NumberFormatType::Standard, number_system.currency_format);
 
             format_object = value.as_object().get("accounting"sv);
-            parse_number_pattern(format_object.as_string().split(';'), cldr, NumberFormatType::Standard, number_system.accounting_format);
+            parse_number_pattern(format_object.as_deprecated_string().split(';'), cldr, NumberFormatType::Standard, number_system.accounting_format);
 
             number_system.currency_unit_formats = parse_number_format(value.as_object());
 
@@ -570,13 +570,13 @@ static ErrorOr<void> parse_number_systems(DeprecatedString locale_numbers_path, 
             auto& number_system = ensure_number_system(system);
 
             auto format_object = value.as_object().get("standard"sv);
-            parse_number_pattern(format_object.as_string().split(';'), cldr, NumberFormatType::Standard, number_system.percent_format);
+            parse_number_pattern(format_object.as_deprecated_string().split(';'), cldr, NumberFormatType::Standard, number_system.percent_format);
         } else if (key.starts_with(scientific_formats_prefix)) {
             auto system = key.substring(scientific_formats_prefix.length());
             auto& number_system = ensure_number_system(system);
 
             auto format_object = value.as_object().get("standard"sv);
-            parse_number_pattern(format_object.as_string().split(';'), cldr, NumberFormatType::Standard, number_system.scientific_format);
+            parse_number_pattern(format_object.as_deprecated_string().split(';'), cldr, NumberFormatType::Standard, number_system.scientific_format);
         }
     });
 
@@ -590,7 +590,7 @@ static ErrorOr<void> parse_number_systems(DeprecatedString locale_numbers_path, 
         locale.number_systems.append(system_index);
     }
 
-    locale.minimum_grouping_digits = minimum_grouping_digits.as_string().template to_uint<u8>().value();
+    locale.minimum_grouping_digits = minimum_grouping_digits.as_deprecated_string().template to_uint<u8>().value();
     return {};
 }
 
@@ -657,7 +657,7 @@ static ErrorOr<void> parse_units(DeprecatedString locale_units_path, CLDR& cldr,
                 auto plurality = unit_key.substring_view(unit_pattern_prefix.length());
                 format.plurality = Locale::plural_category_from_string(plurality);
 
-                auto zero_format = pattern_value.as_string().replace("{0}"sv, "{number}"sv, ReplaceMode::FirstOnly);
+                auto zero_format = pattern_value.as_deprecated_string().replace("{0}"sv, "{number}"sv, ReplaceMode::FirstOnly);
                 zero_format = parse_identifiers(zero_format, "unitIdentifier"sv, cldr, format);
 
                 format.positive_format_index = cldr.unique_strings.ensure(zero_format.replace("{number}"sv, "{plusSign}{number}"sv, ReplaceMode::FirstOnly));

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
@@ -348,7 +348,7 @@ static ErrorOr<void> parse_plural_rules(DeprecatedString core_supplemental_path,
                 VERIFY(key.starts_with(rule_prefix));
 
                 auto category = key.substring_view(rule_prefix.length());
-                parse_condition(category, condition.as_string(), locale->rules_for_form(form));
+                parse_condition(category, condition.as_deprecated_string(), locale->rules_for_form(form));
             });
         });
     });
@@ -386,7 +386,7 @@ static ErrorOr<void> parse_plural_ranges(DeprecatedString core_supplemental_path
             auto start = range.substring(*start_index, *end_index - *start_index);
             auto end = range.substring(*end_index + end_segment.length());
 
-            locale->plural_ranges.empend(move(start), move(end), category.as_string());
+            locale->plural_ranges.empend(move(start), move(end), category.as_deprecated_string());
         });
     });
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
@@ -100,7 +100,7 @@ static ErrorOr<void> parse_date_fields(DeprecatedString locale_dates_path, CLDR&
         format.style = style.to_titlecase_string();
         format.plurality = plurality.to_titlecase_string();
         format.tense_or_number = cldr.unique_strings.ensure(tense_or_number);
-        format.pattern = cldr.unique_strings.ensure(pattern.as_string());
+        format.pattern = cldr.unique_strings.ensure(pattern.as_deprecated_string());
 
         locale.time_units.append(cldr.unique_formats.ensure(move(format)));
     };

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateEmojiData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateEmojiData.cpp
@@ -6,8 +6,8 @@
 
 #include "GeneratorUtil.h"
 #include <AK/AnyOf.h>
-#include <AK/DeprecatedString.h>
 #include <AK/SourceGenerator.h>
+#include <AK/String.h>
 #include <AK/StringUtils.h>
 #include <AK/Types.h>
 #include <LibCore/ArgsParser.h>
@@ -18,13 +18,13 @@
 
 struct Emoji {
     size_t name { 0 };
-    Optional<DeprecatedString> image_path;
+    Optional<String> image_path;
     Unicode::EmojiGroup group;
-    DeprecatedString subgroup;
+    String subgroup;
     u32 display_order { 0 };
     Vector<u32> code_points;
-    DeprecatedString encoded_code_points;
-    DeprecatedString status;
+    String encoded_code_points;
+    String status;
     size_t code_point_array_index { 0 };
 };
 
@@ -45,7 +45,7 @@ static void set_image_path_for_emoji(StringView emoji_resource_path, Emoji& emoj
         builder.appendff("U+{:X}", code_point);
     }
 
-    auto path = DeprecatedString::formatted("{}/{}.png", emoji_resource_path, builder.build());
+    auto path = String::formatted("{}/{}.png", emoji_resource_path, builder.build());
     if (Core::File::exists(path))
         emoji.image_path = move(path);
 }
@@ -58,7 +58,7 @@ static ErrorOr<void> parse_emoji_test_data(Core::Stream::BufferedFile& file, Emo
     Array<u8, 1024> buffer;
 
     Unicode::EmojiGroup group;
-    DeprecatedString subgroup;
+    String subgroup;
     u32 display_order { 0 };
 
     while (TRY(file.can_read_line())) {
@@ -179,7 +179,7 @@ static ErrorOr<void> generate_emoji_data_implementation(Core::Stream::BufferedFi
     SourceGenerator generator { builder };
 
     generator.set("string_index_type"sv, emoji_data.unique_strings.type_that_fits());
-    generator.set("emojis_size"sv, DeprecatedString::number(emoji_data.emojis.size()));
+    generator.set("emojis_size"sv, String::number(emoji_data.emojis.size()));
 
     generator.append(R"~~~(
 #include <AK/Array.h>
@@ -199,7 +199,7 @@ namespace Unicode {
     for (auto const& emoji : emoji_data.emojis) {
         total_code_point_count += emoji.code_points.size();
     }
-    generator.set("total_code_point_count", DeprecatedString::number(total_code_point_count));
+    generator.set("total_code_point_count", String::number(total_code_point_count));
 
     generator.append(R"~~~(
 static constexpr Array<u32, @total_code_point_count@> s_emoji_code_points { {)~~~");
@@ -208,7 +208,7 @@ static constexpr Array<u32, @total_code_point_count@> s_emoji_code_points { {)~~
     for (auto const& emoji : emoji_data.emojis) {
         for (auto code_point : emoji.code_points) {
             generator.append(first ? " "sv : ", "sv);
-            generator.append(DeprecatedString::formatted("{:#x}", code_point));
+            generator.append(String::formatted("{:#x}", code_point));
             first = false;
         }
     }
@@ -246,11 +246,11 @@ struct EmojiData {
 static constexpr Array<EmojiData, @emojis_size@> s_emojis { {)~~~");
 
     for (auto const& emoji : emoji_data.emojis) {
-        generator.set("name"sv, DeprecatedString::number(emoji.name));
-        generator.set("group"sv, DeprecatedString::number(to_underlying(emoji.group)));
-        generator.set("display_order"sv, DeprecatedString::number(emoji.display_order));
-        generator.set("code_point_start"sv, DeprecatedString::number(emoji.code_point_array_index));
-        generator.set("code_point_count"sv, DeprecatedString::number(emoji.code_points.size()));
+        generator.set("name"sv, String::number(emoji.name));
+        generator.set("group"sv, String::number(to_underlying(emoji.group)));
+        generator.set("display_order"sv, String::number(emoji.display_order));
+        generator.set("code_point_start"sv, String::number(emoji.code_point_array_index));
+        generator.set("code_point_count"sv, String::number(emoji.code_points.size()));
 
         generator.append(R"~~~(
     { @name@, @group@, @display_order@, @code_point_start@, @code_point_count@ },)~~~");
@@ -313,7 +313,7 @@ static ErrorOr<void> generate_emoji_installation(Core::Stream::BufferedFile& fil
 
         generator.append("@emoji@"sv);
         generator.append(" - "sv);
-        generator.append(DeprecatedString::join(" "sv, emoji.code_points, "U+{:X}"sv));
+        generator.append(String::join(" "sv, emoji.code_points, "U+{:X}"sv));
         generator.append(" @name@ (@status@)\n"sv);
     }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
@@ -140,7 +140,7 @@ bool media_feature_type_is_range(MediaFeatureID media_feature_id)
         VERIFY(feature.has("type"sv));
         auto feature_type = feature.get("type"sv);
         VERIFY(feature_type.is_string());
-        member_generator.set("is_range", feature_type.as_string() == "range" ? "true" : "false");
+        member_generator.set("is_range", feature_type.as_deprecated_string() == "range" ? "true" : "false");
         member_generator.append(R"~~~(
     case MediaFeatureID::@name:titlecase@:
         return @is_range@;)~~~");
@@ -178,7 +178,7 @@ bool media_feature_accepts_type(MediaFeatureID media_feature_id, MediaFeatureVal
             auto& values_array = values.as_array();
             for (auto& type : values_array.values()) {
                 VERIFY(type.is_string());
-                auto type_name = type.as_string();
+                auto type_name = type.as_deprecated_string();
                 // Skip identifiers.
                 if (type_name[0] != '<')
                     continue;
@@ -256,7 +256,7 @@ bool media_feature_accepts_identifier(MediaFeatureID media_feature_id, ValueID i
             auto& values_array = values.as_array();
             for (auto& identifier : values_array.values()) {
                 VERIFY(identifier.is_string());
-                auto identifier_name = identifier.as_string();
+                auto identifier_name = identifier.as_deprecated_string();
                 // Skip types.
                 if (identifier_name[0] == '<')
                     continue;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -58,8 +58,8 @@ enum class PropertyID {
     Custom,
 )~~~");
 
-    Vector<DeprecatedString> shorthand_property_ids;
-    Vector<DeprecatedString> longhand_property_ids;
+    Vector<String> shorthand_property_ids;
+    Vector<String> longhand_property_ids;
 
     properties.for_each_member([&](auto& name, auto& value) {
         VERIFY(value.is_object());
@@ -74,7 +74,7 @@ enum class PropertyID {
 
     for (auto& name : shorthand_property_ids) {
         auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name));
+        member_generator.set("name:titlecase", MUST(title_casify(name)));
 
         member_generator.append(R"~~~(
     @name:titlecase@,
@@ -83,21 +83,21 @@ enum class PropertyID {
 
     for (auto& name : longhand_property_ids) {
         auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name));
+        member_generator.set("name:titlecase", MUST(title_casify(name)));
 
         member_generator.append(R"~~~(
     @name:titlecase@,
 )~~~");
     }
 
-    generator.set("first_property_id", title_casify(first_property_id));
-    generator.set("last_property_id", title_casify(last_property_id));
+    generator.set("first_property_id", MUST(title_casify(first_property_id)));
+    generator.set("last_property_id", MUST(title_casify(last_property_id)));
 
-    generator.set("first_shorthand_property_id", title_casify(shorthand_property_ids.first()));
-    generator.set("last_shorthand_property_id", title_casify(shorthand_property_ids.last()));
+    generator.set("first_shorthand_property_id", MUST(title_casify(shorthand_property_ids.first())));
+    generator.set("last_shorthand_property_id", MUST(title_casify(shorthand_property_ids.last())));
 
-    generator.set("first_longhand_property_id", title_casify(longhand_property_ids.first()));
-    generator.set("last_longhand_property_id", title_casify(longhand_property_ids.last()));
+    generator.set("first_longhand_property_id", MUST(title_casify(longhand_property_ids.first())));
+    generator.set("last_longhand_property_id", MUST(title_casify(longhand_property_ids.last())));
 
     generator.append(R"~~~(
 };
@@ -166,8 +166,8 @@ PropertyID property_id_from_camel_case_string(StringView string)
 
         auto member_generator = generator.fork();
         member_generator.set("name", name);
-        member_generator.set("name:titlecase", title_casify(name));
-        member_generator.set("name:camelcase", camel_casify(name));
+        member_generator.set("name:titlecase", MUST(title_casify(name)));
+        member_generator.set("name:camelcase", MUST(camel_casify(name)));
         member_generator.append(R"~~~(
     if (string.equals_ignoring_case("@name:camelcase@"sv))
         return PropertyID::@name:titlecase@;
@@ -187,7 +187,7 @@ PropertyID property_id_from_string(StringView string)
 
         auto member_generator = generator.fork();
         member_generator.set("name", name);
-        member_generator.set("name:titlecase", title_casify(name));
+        member_generator.set("name:titlecase", MUST(title_casify(name)));
         member_generator.append(R"~~~(
     if (string.equals_ignoring_case("@name@"sv))
         return PropertyID::@name:titlecase@;
@@ -207,7 +207,7 @@ StringView string_from_property_id(PropertyID property_id) {
 
         auto member_generator = generator.fork();
         member_generator.set("name", name);
-        member_generator.set("name:titlecase", title_casify(name));
+        member_generator.set("name:titlecase", MUST(title_casify(name)));
         member_generator.append(R"~~~(
     case PropertyID::@name:titlecase@:
         return "@name@"sv;
@@ -237,7 +237,7 @@ bool is_inherited_property(PropertyID property_id)
 
         if (inherited) {
             auto member_generator = generator.fork();
-            member_generator.set("name:titlecase", title_casify(name));
+            member_generator.set("name:titlecase", MUST(title_casify(name)));
             member_generator.append(R"~~~(
     case PropertyID::@name:titlecase@:
         return true;
@@ -265,7 +265,7 @@ bool property_affects_layout(PropertyID property_id)
 
         if (affects_layout) {
             auto member_generator = generator.fork();
-            member_generator.set("name:titlecase", title_casify(name));
+            member_generator.set("name:titlecase", MUST(title_casify(name)));
             member_generator.append(R"~~~(
     case PropertyID::@name:titlecase@:
 )~~~");
@@ -293,7 +293,7 @@ bool property_affects_stacking_context(PropertyID property_id)
 
         if (affects_stacking_context) {
             auto member_generator = generator.fork();
-            member_generator.set("name:titlecase", title_casify(name));
+            member_generator.set("name:titlecase", MUST(title_casify(name)));
             member_generator.append(R"~~~(
     case PropertyID::@name:titlecase@:
 )~~~");
@@ -328,10 +328,10 @@ NonnullRefPtr<StyleValue> property_initial_value(PropertyID property_id)
         }
         auto& initial_value = object.get("initial"sv);
         VERIFY(initial_value.is_string());
-        auto initial_value_string = initial_value.as_deprecated_string();
+        auto initial_value_string = initial_value.as_string();
 
         auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name));
+        member_generator.set("name:titlecase", MUST(title_casify(name)));
         member_generator.set("initial_value_string", initial_value_string);
         member_generator.append(R"~~~(
         {
@@ -376,7 +376,7 @@ bool property_has_quirk(PropertyID property_id, Quirk quirk)
 
             if (!quirks.is_empty()) {
                 auto property_generator = generator.fork();
-                property_generator.set("name:titlecase", title_casify(name));
+                property_generator.set("name:titlecase", MUST(title_casify(name)));
                 property_generator.append(R"~~~(
     case PropertyID::@name:titlecase@: {
         switch (quirk) {
@@ -384,7 +384,7 @@ bool property_has_quirk(PropertyID property_id, Quirk quirk)
                 for (auto& quirk : quirks.values()) {
                     VERIFY(quirk.is_string());
                     auto quirk_generator = property_generator.fork();
-                    quirk_generator.set("quirk:titlecase", title_casify(quirk.as_deprecated_string()));
+                    quirk_generator.set("quirk:titlecase", MUST(title_casify(quirk.as_string())));
                     quirk_generator.append(R"~~~(
         case Quirk::@quirk:titlecase@:
             return true;
@@ -421,23 +421,23 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
         auto has_valid_identifiers = object.has("valid-identifiers"sv);
         if (has_valid_types || has_valid_identifiers) {
             auto property_generator = generator.fork();
-            property_generator.set("name:titlecase", title_casify(name));
+            property_generator.set("name:titlecase", MUST(title_casify(name)));
             property_generator.append(R"~~~(
     case PropertyID::@name:titlecase@: {
 )~~~");
 
             auto output_numeric_value_check = [](SourceGenerator& generator, StringView type_check_function, StringView value_getter, Span<StringView> resolved_type_names, StringView min_value, StringView max_value) {
                 auto test_generator = generator.fork();
-                test_generator.set("type_check_function", type_check_function);
-                test_generator.set("value_getter", value_getter);
+                test_generator.set("type_check_function", MUST(String::from_utf8(type_check_function)));
+                test_generator.set("value_getter", MUST(String::from_utf8(value_getter)));
                 test_generator.append(R"~~~(
         if ((style_value.@type_check_function@())~~~");
                 if (!min_value.is_empty() && min_value != "-∞") {
-                    test_generator.set("minvalue", min_value);
+                    test_generator.set("minvalue", MUST(String::from_utf8(min_value)));
                     test_generator.append(" && (style_value.@value_getter@ >= @minvalue@)");
                 }
                 if (!max_value.is_empty() && max_value != "∞") {
-                    test_generator.set("maxvalue", max_value);
+                    test_generator.set("maxvalue", MUST(String::from_utf8(max_value)));
                     test_generator.append(" && (style_value.@value_getter@ <= @maxvalue@)");
                 }
                 test_generator.append(")");
@@ -446,7 +446,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
         || (style_value.is_calculated() && ()~~~");
                     bool first = true;
                     for (auto& type_name : resolved_type_names) {
-                        test_generator.set("resolved_type_name", type_name);
+                        test_generator.set("resolved_type_name", MUST(String::from_utf8(type_name)));
                         if (!first)
                             test_generator.append(" || ");
                         test_generator.append("style_value.as_calculated().resolved_type() == CalculatedStyleValue::ResolvedType::@resolved_type_name@");
@@ -467,7 +467,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                 if (!valid_types.is_empty()) {
                     for (auto& type : valid_types.values()) {
                         VERIFY(type.is_string());
-                        auto type_parts = type.as_deprecated_string().split_view(' ');
+                        auto type_parts = type.as_string().bytes_as_string_view().split_view(' ');
                         auto type_name = type_parts.first();
                         auto type_args = type_parts.size() > 1 ? type_parts[1] : ""sv;
                         StringView min_value;
@@ -525,7 +525,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                         } else {
                             // Assume that any other type names are defined in Enums.json.
                             // If they're not, the output won't compile, but that's fine since it's invalid.
-                            property_generator.set("type_name:snakecase", snake_casify(type_name));
+                            property_generator.set("type_name:snakecase", MUST(snake_casify(MUST(String::from_utf8(type_name)))));
                             property_generator.append(R"~~~(
         if (auto converted_identifier = value_id_to_@type_name:snakecase@(style_value.to_identifier()); converted_identifier.has_value())
             return true;
@@ -546,7 +546,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                     for (auto& identifier : valid_identifiers.values()) {
                         VERIFY(identifier.is_string());
                         auto identifier_generator = generator.fork();
-                        identifier_generator.set("identifier:titlecase", title_casify(identifier.as_deprecated_string()));
+                        identifier_generator.set("identifier:titlecase", MUST(title_casify(identifier.as_string())));
                         identifier_generator.append(R"~~~(
         case ValueID::@identifier:titlecase@:
 )~~~");
@@ -584,8 +584,8 @@ size_t property_maximum_value_count(PropertyID property_id)
             auto max_values = value.as_object().get("max-values"sv);
             VERIFY(max_values.is_number() && !max_values.is_double());
             auto property_generator = generator.fork();
-            property_generator.set("name:titlecase", title_casify(name));
-            property_generator.set("max_values", max_values.to_deprecated_string());
+            property_generator.set("name:titlecase", MUST(title_casify(name)));
+            property_generator.set("max_values", max_values.to_string());
             property_generator.append(R"~~~(
     case PropertyID::@name:titlecase@:
         return @max_values@;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -328,7 +328,7 @@ NonnullRefPtr<StyleValue> property_initial_value(PropertyID property_id)
         }
         auto& initial_value = object.get("initial"sv);
         VERIFY(initial_value.is_string());
-        auto initial_value_string = initial_value.as_string();
+        auto initial_value_string = initial_value.as_deprecated_string();
 
         auto member_generator = generator.fork();
         member_generator.set("name:titlecase", title_casify(name));
@@ -384,7 +384,7 @@ bool property_has_quirk(PropertyID property_id, Quirk quirk)
                 for (auto& quirk : quirks.values()) {
                     VERIFY(quirk.is_string());
                     auto quirk_generator = property_generator.fork();
-                    quirk_generator.set("quirk:titlecase", title_casify(quirk.as_string()));
+                    quirk_generator.set("quirk:titlecase", title_casify(quirk.as_deprecated_string()));
                     quirk_generator.append(R"~~~(
         case Quirk::@quirk:titlecase@:
             return true;
@@ -467,7 +467,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                 if (!valid_types.is_empty()) {
                     for (auto& type : valid_types.values()) {
                         VERIFY(type.is_string());
-                        auto type_parts = type.as_string().split_view(' ');
+                        auto type_parts = type.as_deprecated_string().split_view(' ');
                         auto type_name = type_parts.first();
                         auto type_args = type_parts.size() > 1 ? type_parts[1] : ""sv;
                         StringView min_value;
@@ -546,7 +546,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                     for (auto& identifier : valid_identifiers.values()) {
                         VERIFY(identifier.is_string());
                         auto identifier_generator = generator.fork();
-                        identifier_generator.set("identifier:titlecase", title_casify(identifier.as_string()));
+                        identifier_generator.set("identifier:titlecase", title_casify(identifier.as_deprecated_string()));
                         identifier_generator.append(R"~~~(
         case ValueID::@identifier:titlecase@:
 )~~~");

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
@@ -39,13 +39,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     return 0;
 }
 
-static DeprecatedString title_casify_transform_function(StringView input)
+static String title_casify_transform_function(StringView input)
 {
     // Transform function names look like `fooBar`, so we just have to make the first character uppercase.
     StringBuilder builder;
     builder.append(toupper(input[0]));
     builder.append(input.substring_view(1));
-    return builder.to_deprecated_string();
+    return MUST(builder.to_string());
 }
 
 ErrorOr<void> generate_header_file(JsonObject& transforms_data, Core::Stream::File& file)
@@ -169,7 +169,7 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
         const JsonArray& parameters = value.as_object().get("parameters"sv).as_array();
         bool first = true;
         parameters.for_each([&](JsonValue const& value) {
-            GenericLexer lexer { value.as_object().get("type"sv).as_deprecated_string() };
+            GenericLexer lexer { value.as_object().get("type"sv).as_string() };
             VERIFY(lexer.consume_specific('<'));
             auto parameter_type_name = lexer.consume_until('>');
             VERIFY(lexer.consume_specific('>'));
@@ -189,7 +189,7 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
             member_generator.append(first ? " "sv : ", "sv);
             first = false;
 
-            member_generator.append(DeprecatedString::formatted("{{ TransformFunctionParameterType::{}, {}}}", parameter_type, value.as_object().get("required"sv).to_deprecated_string()));
+            member_generator.append(MUST(String::formatted("{{ TransformFunctionParameterType::{}, {}}}", parameter_type, value.as_object().get("required"sv).to_string())));
         });
 
         member_generator.append(R"~~~( }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
@@ -169,7 +169,7 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
         const JsonArray& parameters = value.as_object().get("parameters"sv).as_array();
         bool first = true;
         parameters.for_each([&](JsonValue const& value) {
-            GenericLexer lexer { value.as_object().get("type"sv).as_string() };
+            GenericLexer lexer { value.as_object().get("type"sv).as_deprecated_string() };
             VERIFY(lexer.consume_specific('<'));
             auto parameter_type_name = lexer.consume_until('>');
             VERIFY(lexer.consume_specific('>'));

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
@@ -57,7 +57,7 @@ enum class ValueID {
 
     identifier_data.for_each([&](auto& name) {
         auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name.to_deprecated_string()));
+        member_generator.set("name:titlecase", MUST(title_casify(name.to_string())));
 
         member_generator.append(R"~~~(
     @name:titlecase@,
@@ -95,8 +95,8 @@ ValueID value_id_from_string(StringView string)
 
     identifier_data.for_each([&](auto& name) {
         auto member_generator = generator.fork();
-        member_generator.set("name", name.to_deprecated_string());
-        member_generator.set("name:titlecase", title_casify(name.to_deprecated_string()));
+        member_generator.set("name", name.to_string());
+        member_generator.set("name:titlecase", MUST(title_casify(name.to_string())));
         member_generator.append(R"~~~(
     if (string.equals_ignoring_case("@name@"sv))
         return ValueID::@name:titlecase@;
@@ -113,8 +113,8 @@ const char* string_from_value_id(ValueID value_id) {
 
     identifier_data.for_each([&](auto& name) {
         auto member_generator = generator.fork();
-        member_generator.set("name", name.to_deprecated_string());
-        member_generator.set("name:titlecase", title_casify(name.to_deprecated_string()));
+        member_generator.set("name", name.to_string());
+        member_generator.set("name:titlecase", MUST(title_casify(name.to_string())));
         member_generator.append(R"~~~(
     case ValueID::@name:titlecase@:
         return "@name@";

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GeneratorUtil.h
@@ -7,15 +7,16 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/Error.h>
 #include <AK/JsonObject.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/Stream.h>
 #include <ctype.h>
 
-DeprecatedString title_casify(DeprecatedString const& dashy_name)
+ErrorOr<String> title_casify(String const& dashy_name)
 {
-    auto parts = dashy_name.split('-');
+    auto parts = dashy_name.bytes_as_string_view().split_view('-');
     StringBuilder builder;
     for (auto& part : parts) {
         if (part.is_empty())
@@ -25,10 +26,10 @@ DeprecatedString title_casify(DeprecatedString const& dashy_name)
             continue;
         builder.append(part.substring_view(1, part.length() - 1));
     }
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
-DeprecatedString camel_casify(StringView dashy_name)
+ErrorOr<String> camel_casify(StringView dashy_name)
 {
     auto parts = dashy_name.split_view('-');
     StringBuilder builder;
@@ -46,10 +47,10 @@ DeprecatedString camel_casify(StringView dashy_name)
             continue;
         builder.append(part.substring_view(1, part.length() - 1));
     }
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
-DeprecatedString snake_casify(DeprecatedString const& dashy_name)
+ErrorOr<String> snake_casify(String const& dashy_name)
 {
     return dashy_name.replace("-"sv, "_"sv, ReplaceMode::All);
 }

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -48,7 +48,7 @@ TEST_CASE(load_form)
 
     widgets.for_each([&](JsonValue const& widget_value) {
         auto& widget_object = widget_value.as_object();
-        auto widget_class = widget_object.get("class"sv).as_string();
+        auto widget_class = widget_object.get("class"sv).as_deprecated_string();
         widget_object.for_each_member([&]([[maybe_unused]] auto& property_name, [[maybe_unused]] const JsonValue& property_value) {
         });
     });
@@ -58,26 +58,26 @@ TEST_CASE(json_empty_string)
 {
     auto json = JsonValue::from_string("\"\""sv).value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().is_null(), false);
-    EXPECT_EQ(json.as_string().is_empty(), true);
+    EXPECT_EQ(json.as_deprecated_string().is_null(), false);
+    EXPECT_EQ(json.as_deprecated_string().is_empty(), true);
 }
 
 TEST_CASE(json_string)
 {
     auto json = JsonValue::from_string("\"A\""sv).value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().is_null(), false);
-    EXPECT_EQ(json.as_string().length(), size_t { 1 });
-    EXPECT_EQ(json.as_string() == "A", true);
+    EXPECT_EQ(json.as_deprecated_string().is_null(), false);
+    EXPECT_EQ(json.as_deprecated_string().length(), size_t { 1 });
+    EXPECT_EQ(json.as_deprecated_string() == "A", true);
 }
 
 TEST_CASE(json_utf8_character)
 {
     auto json = JsonValue::from_string("\"\\u0041\""sv).value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().is_null(), false);
-    EXPECT_EQ(json.as_string().length(), size_t { 1 });
-    EXPECT_EQ(json.as_string() == "A", true);
+    EXPECT_EQ(json.as_deprecated_string().is_null(), false);
+    EXPECT_EQ(json.as_deprecated_string().length(), size_t { 1 });
+    EXPECT_EQ(json.as_deprecated_string() == "A", true);
 }
 
 /*
@@ -90,10 +90,10 @@ TEST_CASE(json_utf8_multibyte)
 
     auto& json = json_or_error.value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().is_null(), false);
-    EXPECT_EQ(json.as_string().length(), size_t { 2 });
-    EXPECT_EQ(json.as_string() == "š", true);
-    EXPECT_EQ(json.as_string() == "\xc5\xa1", true);
+    EXPECT_EQ(json.as_deprecated_string().is_null(), false);
+    EXPECT_EQ(json.as_deprecated_string().length(), size_t { 2 });
+    EXPECT_EQ(json.as_deprecated_string() == "š", true);
+    EXPECT_EQ(json.as_deprecated_string() == "\xc5\xa1", true);
 }
 */
 

--- a/Tests/LibJS/test-test262.cpp
+++ b/Tests/LibJS/test-test262.cpp
@@ -270,7 +270,7 @@ static ErrorOr<HashMap<size_t, TestResult>> run_test_files(Span<DeprecatedString
             if (!result_object_or_error.is_error() && result_object_or_error.value().is_object()) {
                 auto& result_object = result_object_or_error.value().as_object();
                 if (auto result_string = result_object.get_ptr("result"sv); result_string && result_string->is_string()) {
-                    auto const& view = result_string->as_string();
+                    auto const& view = result_string->as_deprecated_string();
                     // Timeout and assert fail already are the result of the stopping test
                     if (view == "timeout"sv || view == "assert_fail"sv) {
                         failed = false;

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -434,7 +434,7 @@ static bool verify_test(Result<void, TestError>& result, TestMetadata const& met
     if (metadata.is_async && output.has("output"sv)) {
         auto& output_messages = output.get("output"sv);
         VERIFY(output_messages.is_string());
-        if (output_messages.as_string().contains("AsyncTestFailure:InternalError: TODO("sv)) {
+        if (output_messages.as_deprecated_string().contains("AsyncTestFailure:InternalError: TODO("sv)) {
             output.set("todo_error", true);
             output.set("result", "todo_error");
         }

--- a/Tests/LibMarkdown/TestCommonmark.cpp
+++ b/Tests/LibMarkdown/TestCommonmark.cpp
@@ -35,8 +35,8 @@ TEST_SETUP
             testcase.get("start_line"sv),
             testcase.get("end_line"sv));
 
-        DeprecatedString markdown = testcase.get("markdown"sv).as_string();
-        DeprecatedString html = testcase.get("html"sv).as_string();
+        DeprecatedString markdown = testcase.get("markdown"sv).as_deprecated_string();
+        DeprecatedString html = testcase.get("html"sv).as_deprecated_string();
 
         Test::TestSuite::the().add_case(adopt_ref(*new Test::TestCase(
             name, [markdown, html]() {

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -127,7 +127,7 @@ private:
         int connected_adapters = 0;
         json.value().as_array().for_each([&adapter_info, &connected_adapters](auto& value) {
             auto& if_object = value.as_object();
-            auto ip_address = if_object.get("ipv4_address"sv).as_string_or("no IP");
+            auto ip_address = if_object.get("ipv4_address"sv).as_deprecated_string_or("no IP");
             auto ifname = if_object.get("name"sv).to_deprecated_string();
             auto link_up = if_object.get("link_up"sv).as_bool();
             auto link_speed = if_object.get("link_speed"sv).to_i32();

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -90,15 +90,15 @@ ErrorOr<NonnullRefPtr<Image>> Image::try_create_from_pixel_paint_json(JsonObject
     auto layers_value = json.get("layers"sv);
     for (auto& layer_value : layers_value.as_array().values()) {
         auto& layer_object = layer_value.as_object();
-        auto name = layer_object.get("name"sv).as_string();
+        auto name = layer_object.get("name"sv).as_deprecated_string();
 
-        auto bitmap_base64_encoded = layer_object.get("bitmap"sv).as_string();
+        auto bitmap_base64_encoded = layer_object.get("bitmap"sv).as_deprecated_string();
         auto bitmap_data = TRY(decode_base64(bitmap_base64_encoded));
         auto bitmap = TRY(try_decode_bitmap(bitmap_data));
         auto layer = TRY(Layer::try_create_with_bitmap(*image, move(bitmap), name));
 
         if (auto mask_object = layer_object.get("mask"sv); !mask_object.is_null()) {
-            auto mask_base64_encoded = mask_object.as_string();
+            auto mask_base64_encoded = mask_object.as_deprecated_string();
             auto mask_data = TRY(decode_base64(mask_base64_encoded));
             auto mask = TRY(try_decode_bitmap(mask_data));
             TRY(layer->try_set_bitmaps(layer->content_bitmap(), mask));

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1126,7 +1126,7 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
             if (!offset_value.is_number())
                 return;
 
-            auto orientation_string = orientation_value.as_string();
+            auto orientation_string = orientation_value.as_deprecated_string();
             PixelPaint::Guide::Orientation orientation;
             if (orientation_string == "horizontal"sv)
                 orientation = PixelPaint::Guide::Orientation::Horizontal;

--- a/Userland/Applications/Presenter/Presentation.cpp
+++ b/Userland/Applications/Presenter/Presentation.cpp
@@ -128,7 +128,7 @@ ErrorOr<Gfx::IntSize> Presentation::parse_presentation_size(JsonObject const& me
 
     // We intentionally discard floating-point data here. If you need more resolution, just use a larger width.
     auto const width = maybe_width.to_int();
-    auto const aspect_parts = maybe_aspect.as_string().split_view(':');
+    auto const aspect_parts = maybe_aspect.as_deprecated_string().split_view(':');
     if (aspect_parts.size() != 2)
         return Error::from_string_view("Aspect specification must have the exact format `width:height`"sv);
     auto aspect_width = aspect_parts[0].to_int<int>();

--- a/Userland/Applications/Presenter/Slide.cpp
+++ b/Userland/Applications/Presenter/Slide.cpp
@@ -21,7 +21,7 @@ Slide::Slide(NonnullRefPtrVector<SlideObject> slide_objects, DeprecatedString ti
 ErrorOr<Slide> Slide::parse_slide(JsonObject const& slide_json, NonnullRefPtr<GUI::Window> window)
 {
     // FIXME: Use the text with the "title" role for a title, if there is no title given.
-    auto title = slide_json.get("title"sv).as_string_or("Untitled slide");
+    auto title = slide_json.get("title"sv).as_deprecated_string_or("Untitled slide");
 
     auto const& maybe_slide_objects = slide_json.get("objects"sv);
     if (!maybe_slide_objects.is_array())

--- a/Userland/Applications/Presenter/SlideObject.cpp
+++ b/Userland/Applications/Presenter/SlideObject.cpp
@@ -26,7 +26,7 @@ ErrorOr<NonnullRefPtr<SlideObject>> SlideObject::parse_slide_object(JsonObject c
     if (!maybe_type.is_string())
         return Error::from_string_view("Slide object must have a type"sv);
 
-    auto type = maybe_type.as_string();
+    auto type = maybe_type.as_deprecated_string();
     RefPtr<SlideObject> object;
     if (type == "text"sv)
         object = TRY(try_make_ref_counted<Text>());

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -93,7 +93,7 @@ static ErrorOr<void> fill_mounts(Vector<MountInfo>& output)
         auto& filesystem_object = value.as_object();
         MountInfo mount_info;
         mount_info.mount_point = filesystem_object.get("mount_point"sv).to_deprecated_string();
-        mount_info.source = filesystem_object.get("source"sv).as_string_or("none"sv);
+        mount_info.source = filesystem_object.get("source"sv).as_deprecated_string_or("none"sv);
         TRY(output.try_append(mount_info));
         return {};
     }));

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -377,7 +377,7 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
     auto sheet = adopt_ref(*new Sheet(workbook));
     auto rows = object.get("rows"sv).to_u32(default_row_count);
     auto columns = object.get("columns"sv);
-    auto name = object.get("name"sv).as_string_or("Sheet");
+    auto name = object.get("name"sv).as_deprecated_string_or("Sheet");
     if (object.has("cells"sv) && !object.has_object("cells"sv))
         return {};
 
@@ -389,7 +389,7 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
     // FIXME: Better error checking.
     if (columns.is_array()) {
         columns.as_array().for_each([&](auto& value) {
-            sheet->m_columns.append(value.as_string());
+            sheet->m_columns.append(value.as_deprecated_string());
             return IterationDecision::Continue;
         });
     }
@@ -404,9 +404,9 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
 
     auto read_format = [](auto& format, auto const& obj) {
         if (auto value = obj.get("foreground_color"sv); value.is_string())
-            format.foreground_color = Color::from_string(value.as_string());
+            format.foreground_color = Color::from_string(value.as_deprecated_string());
         if (auto value = obj.get("background_color"sv); value.is_string())
-            format.background_color = Color::from_string(value.as_string());
+            format.background_color = Color::from_string(value.as_deprecated_string());
     };
 
     if (object.has_object("cells"sv)) {
@@ -417,7 +417,7 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
 
             auto position = position_option.value();
             auto& obj = value.as_object();
-            auto kind = obj.get("kind"sv).as_string_or("LiteralString") == "LiteralString" ? Cell::LiteralString : Cell::Formula;
+            auto kind = obj.get("kind"sv).as_deprecated_string_or("LiteralString") == "LiteralString" ? Cell::LiteralString : Cell::Formula;
 
             OwnPtr<Cell> cell;
             switch (kind) {
@@ -426,7 +426,7 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
                 break;
             case Cell::Formula: {
                 auto& vm = sheet->interpreter().vm();
-                auto value_or_error = JS::call(vm, parse_function, json, JS::PrimitiveString::create(vm, obj.get("value"sv).as_string()));
+                auto value_or_error = JS::call(vm, parse_function, json, JS::PrimitiveString::create(vm, obj.get("value"sv).as_deprecated_string()));
                 if (value_or_error.is_error()) {
                     warnln("Failed to load previous value for cell {}, leaving as undefined", position.to_cell_identifier(sheet));
                     value_or_error = JS::js_undefined();
@@ -446,9 +446,9 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
                 if (auto value = meta_obj.get("length"sv); value.is_number())
                     meta.length = value.to_i32();
                 if (auto value = meta_obj.get("format"sv); value.is_string())
-                    meta.format = value.as_string();
+                    meta.format = value.as_deprecated_string();
                 if (auto value = meta_obj.get("alignment"sv); value.is_string()) {
-                    auto alignment = Gfx::text_alignment_from_string(value.as_string());
+                    auto alignment = Gfx::text_alignment_from_string(value.as_deprecated_string());
                     if (alignment.has_value())
                         meta.alignment = alignment.value();
                 }

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -50,7 +50,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
                 if (!object.get("link_up"sv).as_bool())
                     return *m_network_link_down_bitmap;
                 else
-                    return object.get("ipv4_address"sv).as_string_or(""sv).is_empty() ? *m_network_disconnected_bitmap : *m_network_connected_bitmap;
+                    return object.get("ipv4_address"sv).as_deprecated_string_or(""sv).is_empty() ? *m_network_disconnected_bitmap : *m_network_connected_bitmap;
             });
         net_adapters_fields.empend("name", "Name", Gfx::TextAlignment::CenterLeft);
         net_adapters_fields.empend("class_name", "Class", Gfx::TextAlignment::CenterLeft);
@@ -65,7 +65,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
             });
         net_adapters_fields.empend("IPv4", Gfx::TextAlignment::CenterLeft,
             [](JsonObject const& object) -> DeprecatedString {
-                return object.get("ipv4_address"sv).as_string_or(""sv);
+                return object.get("ipv4_address"sv).as_deprecated_string_or(""sv);
             });
         net_adapters_fields.empend("packets_in", "Pkt In", Gfx::TextAlignment::CenterRight);
         net_adapters_fields.empend("packets_out", "Pkt Out", Gfx::TextAlignment::CenterRight);

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
@@ -98,7 +98,7 @@ ProcessMemoryMapWidget::ProcessMemoryMapWidget()
             return GUI::Variant(0);
         },
         [](JsonObject const& object) {
-            auto pagemap = object.get("pagemap"sv).as_string_or({});
+            auto pagemap = object.get("pagemap"sv).as_deprecated_string_or({});
             return pagemap;
         });
     pid_vm_fields.empend("cow_pages", "# CoW", Gfx::TextAlignment::CenterRight);

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -202,7 +202,7 @@ static HashMap<DeprecatedString, DeprecatedString>& man_paths()
             if (!json_value.is_string())
                 continue;
 
-            Core::DirIterator it(json_value.as_string(), Core::DirIterator::Flags::SkipDots);
+            Core::DirIterator it(json_value.as_deprecated_string(), Core::DirIterator::Flags::SkipDots);
             while (it.has_next()) {
                 auto path = it.next_full_path();
                 auto title = LexicalPath::title(path);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -229,7 +229,7 @@ Vector<DeprecatedString> HackStudioWidget::read_recent_projects()
     for (auto& json_value : value.as_array().values()) {
         if (!json_value.is_string())
             return {};
-        paths.append(json_value.as_string());
+        paths.append(json_value.as_deprecated_string());
     }
 
     return paths;

--- a/Userland/DevTools/HackStudio/ProjectConfig.cpp
+++ b/Userland/DevTools/HackStudio/ProjectConfig.cpp
@@ -40,7 +40,7 @@ Optional<DeprecatedString> ProjectConfig::read_key(DeprecatedString key_name) co
     if (!value.is_string())
         return {};
 
-    return { value.as_string() };
+    return { value.as_deprecated_string() };
 }
 
 }

--- a/Userland/DevTools/Inspector/RemoteProcess.cpp
+++ b/Userland/DevTools/Inspector/RemoteProcess.cpp
@@ -32,7 +32,7 @@ void RemoteProcess::handle_identify_response(JsonObject const& response)
     int pid = response.get("pid"sv).to_int();
     VERIFY(pid == m_pid);
 
-    m_process_name = response.get("process_name"sv).as_string_or({});
+    m_process_name = response.get("process_name"sv).as_deprecated_string_or({});
 
     if (on_update)
         on_update();

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -225,7 +225,7 @@ public:
 
     void handle_request(JsonObject const& request)
     {
-        auto type = request.get("type"sv).as_string_or({});
+        auto type = request.get("type"sv).as_deprecated_string_or({});
 
         if (type.is_null()) {
             dbgln("RPC client sent request without type field");

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -407,7 +407,7 @@ requires IsBaseOf<Object, T>
             } options[] = { __VA_ARGS__ };                                   \
             if (!value.is_string())                                          \
                 return false;                                                \
-            auto string_value = value.as_string();                           \
+            auto string_value = value.as_deprecated_string();                \
             for (size_t i = 0; i < array_size(options); ++i) {               \
                 auto& option = options[i];                                   \
                 if (string_value == option.string_value) {                   \

--- a/Userland/Libraries/LibCoredump/Reader.cpp
+++ b/Userland/Libraries/LibCoredump/Reader.cpp
@@ -214,7 +214,7 @@ DeprecatedString Reader::process_executable_path() const
 {
     auto process_info = this->process_info();
     auto executable_path = process_info.get("executable_path"sv);
-    return executable_path.as_string_or({});
+    return executable_path.as_deprecated_string_or({});
 }
 
 Vector<DeprecatedString> Reader::process_arguments() const
@@ -226,7 +226,7 @@ Vector<DeprecatedString> Reader::process_arguments() const
     Vector<DeprecatedString> vector;
     arguments.as_array().for_each([&](auto& value) {
         if (value.is_string())
-            vector.append(value.as_string());
+            vector.append(value.as_deprecated_string());
     });
     return vector;
 }
@@ -240,7 +240,7 @@ Vector<DeprecatedString> Reader::process_environment() const
     Vector<DeprecatedString> vector;
     environment.as_array().for_each([&](auto& value) {
         if (value.is_string())
-            vector.append(value.as_string());
+            vector.append(value.as_deprecated_string());
     });
     return vector;
 }
@@ -265,7 +265,7 @@ HashMap<DeprecatedString, DeprecatedString> Reader::metadata() const
         return {};
     HashMap<DeprecatedString, DeprecatedString> metadata;
     metadata_json_value.value().as_object().for_each_member([&](auto& key, auto& value) {
-        metadata.set(key, value.as_string_or({}));
+        metadata.set(key, value.as_deprecated_string_or({}));
     });
     return metadata;
 }

--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -455,7 +455,7 @@ void DebugSession::update_loaded_libs()
 
     vm_entries.for_each([&](auto& entry) {
         // TODO: check that region is executable
-        auto vm_name = entry.as_object().get("name"sv).as_string();
+        auto vm_name = entry.as_object().get("name"sv).as_deprecated_string();
 
         auto object_path = get_path_to_object(vm_name);
         if (!object_path.has_value())

--- a/Userland/Libraries/LibGUI/UIDimensions.h
+++ b/Userland/Libraries/LibGUI/UIDimensions.h
@@ -151,7 +151,7 @@ public:
     [[nodiscard]] static Optional<UIDimension> construct_from_json_value(AK::JsonValue const value)
     {
         if (value.is_string()) {
-            DeprecatedString value_literal = value.as_string();
+            DeprecatedString value_literal = value.as_deprecated_string();
             if (value_literal == "shrink")
                 return UIDimension { SpecialDimension::Shrink };
             else if (value_literal == "grow")

--- a/Userland/Libraries/LibGUI/Variant.cpp
+++ b/Userland/Libraries/LibGUI/Variant.cpp
@@ -43,7 +43,7 @@ Variant& Variant::operator=(JsonValue const& value)
     }
 
     if (value.is_string()) {
-        set(value.as_string());
+        set(value.as_deprecated_string());
         return *this;
     }
 

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -107,19 +107,19 @@ Widget::Widget()
         [this](auto& value) {
             if (!value.is_string())
                 return false;
-            if (value.as_string() == "ClickFocus") {
+            if (value.as_deprecated_string() == "ClickFocus") {
                 set_focus_policy(GUI::FocusPolicy::ClickFocus);
                 return true;
             }
-            if (value.as_string() == "NoFocus") {
+            if (value.as_deprecated_string() == "NoFocus") {
                 set_focus_policy(GUI::FocusPolicy::NoFocus);
                 return true;
             }
-            if (value.as_string() == "TabFocus") {
+            if (value.as_deprecated_string() == "TabFocus") {
                 set_focus_policy(GUI::FocusPolicy::TabFocus);
                 return true;
             }
-            if (value.as_string() == "StrongFocus") {
+            if (value.as_deprecated_string() == "StrongFocus") {
                 set_focus_policy(GUI::FocusPolicy::StrongFocus);
                 return true;
             }
@@ -157,7 +157,7 @@ Widget::Widget()
         [this](auto& value) {
             if (!value.is_string())
                 return false;
-            auto str = value.as_string();
+            auto str = value.as_deprecated_string();
             if (str == "NoRole") {
                 set_foreground_role(Gfx::ColorRole::NoRole);
                 return true;
@@ -179,7 +179,7 @@ Widget::Widget()
         [this](auto& value) {
             if (!value.is_string())
                 return false;
-            auto str = value.as_string();
+            auto str = value.as_deprecated_string();
             if (str == "NoRole") {
                 set_background_role(Gfx::ColorRole::NoRole);
                 return true;

--- a/Userland/Libraries/LibIPC/Encoder.cpp
+++ b/Userland/Libraries/LibIPC/Encoder.cpp
@@ -163,7 +163,8 @@ Encoder& Encoder::operator<<(ByteBuffer const& value)
 
 Encoder& Encoder::operator<<(JsonValue const& value)
 {
-    *this << value.serialized<StringBuilder>();
+    // FIXME: Switch away from deprecated string
+    *this << value.serialized<StringBuilder>().to_deprecated_string();
     return *this;
 }
 

--- a/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
+++ b/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
@@ -65,7 +65,7 @@ Vector<u32> CharacterMapFile::read_map(JsonObject const& json, DeprecatedString 
 
     auto map_arr = json.get(name).as_array();
     for (size_t i = 0; i < map_arr.size(); i++) {
-        auto key_value = map_arr.at(i).as_string();
+        auto key_value = map_arr.at(i).as_deprecated_string();
         if (key_value.length() == 0) {
             buffer[i] = 0;
         } else if (key_value.length() == 1) {

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -424,7 +424,7 @@ inline JSFileResult TestRunner::run_file_test(DeprecatedString const& test_path)
 
             auto result = test_value.as_object().get("result"sv);
             VERIFY(result.is_string());
-            auto result_string = result.as_string();
+            auto result_string = result.as_deprecated_string();
             if (result_string == "pass") {
                 test.result = Test::Result::Pass;
                 m_counts.tests_passed++;
@@ -435,7 +435,7 @@ inline JSFileResult TestRunner::run_file_test(DeprecatedString const& test_path)
                 VERIFY(test_value.as_object().has("details"sv));
                 auto details = test_value.as_object().get("details"sv);
                 VERIFY(result.is_string());
-                test.details = details.as_string();
+                test.details = details.as_deprecated_string();
             } else {
                 test.result = Test::Result::Skip;
                 if (suite.most_severe_test_result == Test::Result::Pass)

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -375,7 +375,7 @@ void FrameLoader::store_response_cookies(AK::URL const& url, DeprecatedString co
     for (auto const& set_cookie_entry : set_cookie_json_value.as_array().values()) {
         VERIFY(set_cookie_entry.type() == JsonValue::Type::String);
 
-        auto cookie = Cookie::parse_cookie(set_cookie_entry.as_string());
+        auto cookie = Cookie::parse_cookie(set_cookie_entry.as_deprecated_string());
         if (!cookie.has_value())
             continue;
 

--- a/Userland/Libraries/LibWeb/WebDriver/Capabilities.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Capabilities.cpp
@@ -23,7 +23,7 @@ static Response deserialize_as_a_page_load_strategy(JsonValue value)
         return Error::from_code(ErrorCode::InvalidArgument, "Capability pageLoadStrategy must be a string"sv);
 
     // 2. If there is no entry in the table of page load strategies with keyword value return an error with error code invalid argument.
-    if (!value.as_string().is_one_of("none"sv, "eager"sv, "normal"sv))
+    if (!value.as_deprecated_string().is_one_of("none"sv, "eager"sv, "normal"sv))
         return Error::from_code(ErrorCode::InvalidArgument, "Invalid pageLoadStrategy capability"sv);
 
     // 3. Return success with data value.
@@ -38,7 +38,7 @@ static Response deserialize_as_an_unhandled_prompt_behavior(JsonValue value)
         return Error::from_code(ErrorCode::InvalidArgument, "Capability unhandledPromptBehavior must be a string"sv);
 
     // 2. If value is not present as a keyword in the known prompt handling approaches table return an error with error code invalid argument.
-    if (!value.as_string().is_one_of("dismiss"sv, "accept"sv, "dismiss and notify"sv, "accept and notify"sv, "ignore"sv))
+    if (!value.as_deprecated_string().is_one_of("dismiss"sv, "accept"sv, "dismiss and notify"sv, "accept and notify"sv, "ignore"sv))
         return Error::from_code(ErrorCode::InvalidArgument, "Invalid pageLoadStrategy capability"sv);
 
     // 3. Return success with data value.
@@ -267,20 +267,20 @@ static JsonValue match_capabilities(JsonObject const& capabilities)
         // -> "browserName"
         if (name == "browserName"sv) {
             // If value is not a string equal to the "browserName" entry in matched capabilities, return success with data null.
-            if (value.as_string() != matched_capabilities.get(name).as_string())
+            if (value.as_deprecated_string() != matched_capabilities.get(name).as_deprecated_string())
                 return AK::Error::from_string_view("browserName"sv);
         }
         // -> "browserVersion"
         else if (name == "browserVersion"sv) {
             // Compare value to the "browserVersion" entry in matched capabilities using an implementation-defined comparison algorithm. The comparison is to accept a value that places constraints on the version using the "<", "<=", ">", and ">=" operators.
             // If the two values do not match, return success with data null.
-            if (!matches_browser_version(value.as_string(), matched_capabilities.get(name).as_string()))
+            if (!matches_browser_version(value.as_deprecated_string(), matched_capabilities.get(name).as_deprecated_string()))
                 return AK::Error::from_string_view("browserVersion"sv);
         }
         // -> "platformName"
         else if (name == "platformName"sv) {
             // If value is not a string equal to the "platformName" entry in matched capabilities, return success with data null.
-            if (!matches_platform_name(value.as_string(), matched_capabilities.get(name).as_string()))
+            if (!matches_platform_name(value.as_deprecated_string(), matched_capabilities.get(name).as_deprecated_string()))
                 return AK::Error::from_string_view("platformName"sv);
         }
         // -> "acceptInsecureCerts"

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -263,7 +263,8 @@ ErrorOr<void, Client::WrappedError> Client::handle_request(JsonValue body)
 ErrorOr<void, Client::WrappedError> Client::send_success_response(JsonValue result)
 {
     result = make_success_response(move(result));
-    auto content = result.serialized<StringBuilder>();
+    // FIXME: switch away from deprecated string
+    auto content = result.serialized<StringBuilder>().to_deprecated_string();
 
     StringBuilder builder;
     builder.append("HTTP/1.0 200 OK\r\n"sv);

--- a/Userland/Libraries/LibWebView/DOMTreeModel.cpp
+++ b/Userland/Libraries/LibWebView/DOMTreeModel.cpp
@@ -119,8 +119,8 @@ static DeprecatedString with_whitespace_collapsed(StringView string)
 GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
 {
     auto const& node = *static_cast<JsonObject const*>(index.internal_data());
-    auto node_name = node.get("name"sv).as_string();
-    auto type = node.get("type"sv).as_string_or("unknown"sv);
+    auto node_name = node.get("name"sv).as_deprecated_string();
+    auto type = node.get("type"sv).as_deprecated_string_or("unknown"sv);
 
     // FIXME: This FIXME can go away when we fix the one below.
 #ifdef AK_OS_SERENITY
@@ -151,9 +151,9 @@ GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
 
     if (role == GUI::ModelRole::Display) {
         if (type == "text")
-            return with_whitespace_collapsed(node.get("text"sv).as_string());
+            return with_whitespace_collapsed(node.get("text"sv).as_deprecated_string());
         if (type == "comment"sv)
-            return DeprecatedString::formatted("<!--{}-->", node.get("data"sv).as_string());
+            return DeprecatedString::formatted("<!--{}-->", node.get("data"sv).as_deprecated_string());
         if (type != "element")
             return node_name;
 

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -228,7 +228,7 @@ static ErrorOr<PropertyType, Web::WebDriver::Error> get_property(JsonValue const
     if constexpr (IsSame<PropertyType, DeprecatedString>) {
         if (!property->is_string())
             return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, DeprecatedString::formatted("Property '{}' is not a String", key));
-        return property->as_string();
+        return property->as_deprecated_string();
     } else if constexpr (IsSame<PropertyType, bool>) {
         if (!property->is_bool())
             return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, DeprecatedString::formatted("Property '{}' is not a Boolean", key));
@@ -333,7 +333,7 @@ Messages::WebDriverClient::NavigateToResponse WebDriverConnection::navigate_to(J
     // 2. Let url be the result of getting the property url from the parameters argument.
     if (!payload.is_object() || !payload.as_object().has_string("url"sv))
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload doesn't have a string `url`"sv);
-    URL url(payload.as_object().get_ptr("url"sv)->as_string());
+    URL url(payload.as_object().get_ptr("url"sv)->as_deprecated_string());
 
     // FIXME: 3. If url is not an absolute URL or is not an absolute URL with fragment or not a local scheme, return error with error code invalid argument.
 

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -81,7 +81,7 @@ static void initialize_session_from_capabilities(WebContentConnection& web_conte
 
     // 2. If strategy is a string, set the current session’s page loading strategy to strategy. Otherwise, set the page loading strategy to normal and set a property of capabilities with name "pageLoadStrategy" and value "normal".
     if (strategy && strategy->is_string())
-        web_content_connection.async_set_page_load_strategy(Web::WebDriver::page_load_strategy_from_string(strategy->as_string()));
+        web_content_connection.async_set_page_load_strategy(Web::WebDriver::page_load_strategy_from_string(strategy->as_deprecated_string()));
     else
         capabilities.set("pageLoadStrategy"sv, "normal"sv);
 
@@ -115,7 +115,7 @@ static void initialize_session_from_capabilities(WebContentConnection& web_conte
     // 8. Apply changes to the user agent for any implementation-defined capabilities selected during the capabilities processing step.
     auto const* behavior = capabilities.get_ptr("unhandledPromptBehavior"sv);
     if (behavior && behavior->is_string())
-        web_content_connection.async_set_unhandled_prompt_behavior(Web::WebDriver::unhandled_prompt_behavior_from_string(behavior->as_string()));
+        web_content_connection.async_set_unhandled_prompt_behavior(Web::WebDriver::unhandled_prompt_behavior_from_string(behavior->as_deprecated_string()));
     else
         capabilities.set("unhandledPromptBehavior"sv, "dismiss and notify"sv);
 }

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1880,28 +1880,28 @@ ErrorOr<Vector<Line::CompletionSuggestion>> Shell::complete_via_program_itself(s
             auto parsed = parsed_result.release_value();
             if (parsed.is_object()) {
                 auto& object = parsed.as_object();
-                auto kind = object.get("kind"sv).as_string_or("plain");
+                auto kind = object.get("kind"sv).as_deprecated_string_or("plain");
                 if (kind == "path") {
-                    auto base = object.get("base"sv).as_string_or("");
-                    auto part = object.get("part"sv).as_string_or("");
+                    auto base = object.get("base"sv).as_deprecated_string_or("");
+                    auto part = object.get("part"sv).as_deprecated_string_or("");
                     auto executable_only = object.get("executable_only"sv).to_bool(false) ? ExecutableOnly::Yes : ExecutableOnly::No;
                     suggestions.extend(complete_path(base, part, part.length(), executable_only, nullptr, nullptr));
                 } else if (kind == "program") {
-                    auto name = object.get("name"sv).as_string_or("");
+                    auto name = object.get("name"sv).as_deprecated_string_or("");
                     suggestions.extend(complete_program_name(name, name.length()));
                 } else if (kind == "proxy") {
                     if (m_completion_stack_info.size_free() < 4 * KiB) {
                         dbgln("Not enough stack space, recursion?");
                         return IterationDecision::Continue;
                     }
-                    auto argv = object.get("argv"sv).as_string_or("");
+                    auto argv = object.get("argv"sv).as_deprecated_string_or("");
                     dbgln("Proxy completion for {}", argv);
                     suggestions.extend(complete(argv));
                 } else if (kind == "plain") {
                     Line::CompletionSuggestion suggestion {
-                        object.get("completion"sv).as_string_or(""),
-                        object.get("trailing_trivia"sv).as_string_or(""),
-                        object.get("display_trivia"sv).as_string_or(""),
+                        object.get("completion"sv).as_deprecated_string_or(""),
+                        object.get("trailing_trivia"sv).as_deprecated_string_or(""),
+                        object.get("display_trivia"sv).as_deprecated_string_or(""),
                     };
                     suggestion.static_offset = object.get("static_offset"sv).to_u64(0);
                     suggestion.invariant_offset = object.get("invariant_offset"sv).to_u64(0);

--- a/Userland/Utilities/fortune.cpp
+++ b/Userland/Utilities/fortune.cpp
@@ -30,13 +30,13 @@ public:
         if (!entry.has("quote"sv) || !entry.has("author"sv) || !entry.has("utc_time"sv) || !entry.has("url"sv))
             return {};
         // From here on, trust that it's probably fine.
-        q.m_quote = entry.get("quote"sv).as_string();
-        q.m_author = entry.get("author"sv).as_string();
+        q.m_quote = entry.get("quote"sv).as_deprecated_string();
+        q.m_author = entry.get("author"sv).as_deprecated_string();
         // It is sometimes parsed as u32, sometimes as u64, depending on how large the number is.
         q.m_utc_time = entry.get("utc_time"sv).to_number<u64>();
-        q.m_url = entry.get("url"sv).as_string();
+        q.m_url = entry.get("url"sv).as_deprecated_string();
         if (entry.has("context"sv))
-            q.m_context = entry.get("context"sv).as_string();
+            q.m_context = entry.get("context"sv).as_deprecated_string();
 
         return q;
     }

--- a/Userland/Utilities/gron.cpp
+++ b/Userland/Utilities/gron.cpp
@@ -102,5 +102,6 @@ static void print(StringView name, JsonValue const& value, Vector<DeprecatedStri
         break;
     }
 
-    outln("{}{};", value.serialized<StringBuilder>(), color_off);
+    // FIXME: move to new String class
+    outln("{}{};", value.serialized<StringBuilder>().to_deprecated_string(), color_off);
 }

--- a/Userland/Utilities/lscpu.cpp
+++ b/Userland/Utilities/lscpu.cpp
@@ -23,10 +23,10 @@ static void print_cache_info(StringView description, JsonObject const& cache_obj
 static void print_cpu_info(JsonObject const& value)
 {
     outln("CPU {}:", value.get("processor"sv).as_u32());
-    outln("\tVendor ID: {}", value.get("vendor_id"sv).as_string());
+    outln("\tVendor ID: {}", value.get("vendor_id"sv).as_deprecated_string());
     if (value.has("hypervisor_vendor_id"sv))
-        outln("\tHypervisor Vendor ID: {}", value.get("hypervisor_vendor_id"sv).as_string());
-    outln("\tBrand: {}", value.get("brand"sv).as_string());
+        outln("\tHypervisor Vendor ID: {}", value.get("hypervisor_vendor_id"sv).as_deprecated_string());
+    outln("\tBrand: {}", value.get("brand"sv).as_deprecated_string());
     outln("\tFamily: {}", value.get("family"sv).as_u32());
     outln("\tModel: {}", value.get("model"sv).as_u32());
     outln("\tStepping: {}", value.get("stepping"sv).as_u32());
@@ -47,7 +47,7 @@ static void print_cpu_info(JsonObject const& value)
     auto& features = value.get("features"sv).as_array();
 
     for (auto const& feature : features.values())
-        out("{} ", feature.as_string());
+        out("{} ", feature.as_deprecated_string());
 
     outln();
 }

--- a/Userland/Utilities/mount.cpp
+++ b/Userland/Utilities/mount.cpp
@@ -157,7 +157,7 @@ static ErrorOr<void> print_mounts()
         auto& fs_object = value.as_object();
         auto class_name = fs_object.get("class_name"sv).to_deprecated_string();
         auto mount_point = fs_object.get("mount_point"sv).to_deprecated_string();
-        auto source = fs_object.get("source"sv).as_string_or("none");
+        auto source = fs_object.get("source"sv).as_deprecated_string_or("none");
         auto readonly = fs_object.get("readonly"sv).to_bool();
         auto mount_flags = fs_object.get("mount_flags"sv).to_int();
 


### PR DESCRIPTION
This PR refactors `JsonValue`, `JsonObject`, and `JsonArray` to use the new `String` class internally. Any method using `DeprecatedString` has been renamed to reflect this and `DeprecatedString`s are created on the fly when needed.