### PR TITLE
HexEditor: Handle some errors inside the editor

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -36,7 +36,7 @@ public:
     size_t buffer_size() const { return m_document->size(); }
     ErrorOr<void> open_new_file(size_t size);
     void open_file(NonnullRefPtr<Core::File> file);
-    void fill_selection(u8 fill_byte);
+    ErrorOr<void> fill_selection(u8 fill_byte);
     Optional<u8> get_byte(size_t position);
     bool save_as(NonnullRefPtr<Core::File>);
     bool save();
@@ -101,14 +101,14 @@ private:
     size_t cell_width() const { return character_width() * 3; }
     size_t offset_margin_width() const { return 80; }
 
-    void hex_mode_keydown_event(GUI::KeyEvent&);
-    void text_mode_keydown_event(GUI::KeyEvent&);
+    ErrorOr<void> hex_mode_keydown_event(GUI::KeyEvent&);
+    ErrorOr<void> text_mode_keydown_event(GUI::KeyEvent&);
 
     void set_content_length(size_t); // I might make this public if I add fetching data on demand.
     void update_status();
     void did_change();
-    void did_complete_action(size_t position, u8 old_value, u8 new_value);
-    void did_complete_action(size_t position, ByteBuffer&& old_values, ByteBuffer&& new_values);
+    ErrorOr<void> did_complete_action(size_t position, u8 old_value, u8 new_value);
+    ErrorOr<void> did_complete_action(size_t position, ByteBuffer&& old_values, ByteBuffer&& new_values);
 
     void reset_cursor_blink_state();
 };

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -245,7 +245,9 @@ HexEditorWidget::HexEditorWidget()
         DeprecatedString value;
         if (GUI::InputBox::show(window(), value, "Fill byte (hex):"sv, "Fill Selection"sv) == GUI::InputBox::ExecResult::OK && !value.is_empty()) {
             auto fill_byte = strtol(value.characters(), nullptr, 16);
-            m_editor->fill_selection(fill_byte);
+            auto result = m_editor->fill_selection(fill_byte);
+            if (result.is_error())
+                GUI::MessageBox::show_error(window(), DeprecatedString::formatted("{}", result.error()));
         }
     });
     m_fill_selection_action->set_enabled(false);


### PR DESCRIPTION
Specifically, the ones HexEditor::did_complete_action possibly raised in case creating an undo stack entry or pushing it onto the undo stack fails. In this case, an error popup is displayed and the modifications are undone.

This removes 2 FIXMEs inside the code :^)