### PR TITLE
LibFileSystemAccessClient+CrashReporter: Partial port to `Core::Stream`

### DIFF
--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -278,7 +278,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     save_backtrace_button.set_icon(TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/save.png"sv)));
     save_backtrace_button.on_click = [&](auto) {
         LexicalPath lexical_path(DeprecatedString::formatted("{}_{}_backtrace.txt", pid, app_name));
-        auto file_or_error = FileSystemAccessClient::Client::the().try_save_file(window, lexical_path.title(), lexical_path.extension());
+        auto file_or_error = FileSystemAccessClient::Client::the().try_save_file_deprecated(window, lexical_path.title(), lexical_path.extension());
         if (file_or_error.is_error())
             return;
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -142,7 +142,7 @@ HexEditorWidget::HexEditorWidget()
     });
 
     m_save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_save_file(window(), m_name, m_extension, Core::OpenMode::ReadWrite | Core::OpenMode::Truncate);
+        auto response = FileSystemAccessClient::Client::the().try_save_file_deprecated(window(), m_name, m_extension, Core::OpenMode::ReadWrite | Core::OpenMode::Truncate);
         if (response.is_error())
             return;
         auto file = response.release_value();

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -64,7 +64,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(file_menu->try_add_action(GUI::CommonActions::make_save_as_action([&](auto&) {
         AK::DeprecatedString filename = "file for saving";
         auto do_save = [&]() -> ErrorOr<void> {
-            auto response = FileSystemAccessClient::Client::the().try_save_file(window, "Capture", "png");
+            auto response = FileSystemAccessClient::Client::the().try_save_file_deprecated(window, "Capture", "png");
             if (response.is_error())
                 return {};
             auto file = response.release_value();

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -694,7 +694,7 @@ void ImageEditor::save_project()
 
 void ImageEditor::save_project_as()
 {
-    auto response = FileSystemAccessClient::Client::the().try_save_file(window(), m_title, "pp");
+    auto response = FileSystemAccessClient::Client::the().try_save_file_deprecated(window(), m_title, "pp");
     if (response.is_error())
         return;
     auto file = response.value();

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -212,7 +212,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             "As &BMP", [&](auto&) {
                 auto* editor = current_image_editor();
                 VERIFY(editor);
-                auto response = FileSystemAccessClient::Client::the().try_save_file(&window, editor->title(), "bmp");
+                auto response = FileSystemAccessClient::Client::the().try_save_file_deprecated(&window, editor->title(), "bmp");
                 if (response.is_error())
                     return;
                 auto preserve_alpha_channel = GUI::MessageBox::show(&window, "Do you wish to preserve transparency?"sv, "Preserve transparency?"sv, GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
@@ -227,7 +227,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 auto* editor = current_image_editor();
                 VERIFY(editor);
                 // TODO: fix bmp on line below?
-                auto response = FileSystemAccessClient::Client::the().try_save_file(&window, editor->title(), "png");
+                auto response = FileSystemAccessClient::Client::the().try_save_file_deprecated(&window, editor->title(), "png");
                 if (response.is_error())
                     return;
                 auto preserve_alpha_channel = GUI::MessageBox::show(&window, "Do you wish to preserve transparency?"sv, "Preserve transparency?"sv, GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
@@ -241,7 +241,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             "As &QOI", [&](auto&) {
                 auto* editor = current_image_editor();
                 VERIFY(editor);
-                auto response = FileSystemAccessClient::Client::the().try_save_file(&window, editor->title(), "qoi");
+                auto response = FileSystemAccessClient::Client::the().try_save_file_deprecated(&window, editor->title(), "qoi");
                 if (response.is_error())
                     return;
                 auto result = editor->image().export_qoi_to_file(response.value());
@@ -410,7 +410,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         }));
     m_edit_menu->add_action(GUI::Action::create(
         "Sa&ve Color Palette", g_icon_bag.save_color_palette, [&](auto&) {
-            auto response = FileSystemAccessClient::Client::the().try_save_file(&window, "untitled", "palette");
+            auto response = FileSystemAccessClient::Client::the().try_save_file_deprecated(&window, "untitled", "palette");
             if (response.is_error())
                 return;
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -155,7 +155,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, NonnullRefPtrVe
 
     m_save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
         DeprecatedString name = "workbook";
-        auto response = FileSystemAccessClient::Client::the().try_save_file(window(), name, "sheets");
+        auto response = FileSystemAccessClient::Client::the().try_save_file_deprecated(window(), name, "sheets");
         if (response.is_error())
             return;
         save(*response.value());

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -280,7 +280,7 @@ MainWidget::MainWidget()
     });
 
     m_save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_save_file(window(), m_name, m_extension);
+        auto response = FileSystemAccessClient::Client::the().try_save_file_deprecated(window(), m_name, m_extension);
         if (response.is_error())
             return;
 

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -218,7 +218,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 return;
             save_to_file(result.value());
         } else {
-            auto result = FileSystemAccessClient::Client::the().try_save_file(&window, "Theme", "ini", Core::OpenMode::ReadWrite | Core::OpenMode::Truncate);
+            auto result = FileSystemAccessClient::Client::the().try_save_file_deprecated(&window, "Theme", "ini", Core::OpenMode::ReadWrite | Core::OpenMode::Truncate);
             if (result.is_error())
                 return;
             save_to_file(result.value());
@@ -227,7 +227,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
     TRY(file_menu->try_add_action(*m_save_action));
 
     TRY(file_menu->try_add_action(GUI::CommonActions::make_save_as_action([&](auto&) {
-        auto result = FileSystemAccessClient::Client::the().try_save_file(&window, "Theme", "ini", Core::OpenMode::ReadWrite | Core::OpenMode::Truncate);
+        auto result = FileSystemAccessClient::Client::the().try_save_file_deprecated(&window, "Theme", "ini", Core::OpenMode::ReadWrite | Core::OpenMode::Truncate);
         if (result.is_error())
             return;
         save_to_file(result.value());

--- a/Userland/DevTools/GMLPlayground/main.cpp
+++ b/Userland/DevTools/GMLPlayground/main.cpp
@@ -134,7 +134,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto file_menu = TRY(window->try_add_menu("&File"));
 
     auto save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_save_file(window, "Untitled", "gml");
+        auto response = FileSystemAccessClient::Client::the().try_save_file_deprecated(window, "Untitled", "gml");
         if (response.is_error())
             return;
 

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -75,7 +75,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         dbgln("Imported PGN file from {}", result.value()->filename());
     })));
     TRY(game_menu->try_add_action(GUI::Action::create("&Export PGN...", { Mod_Ctrl, Key_S }, [&](auto&) {
-        auto result = FileSystemAccessClient::Client::the().try_save_file(window, "Untitled", "pgn");
+        auto result = FileSystemAccessClient::Client::the().try_save_file_deprecated(window, "Untitled", "pgn");
         if (result.is_error())
             return;
 

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -104,16 +104,21 @@ int File::leak_fd()
 
 bool File::is_device() const
 {
-    struct stat stat;
-    if (fstat(fd(), &stat) < 0)
-        return false;
-    return S_ISBLK(stat.st_mode) || S_ISCHR(stat.st_mode);
+    return is_device(fd());
 }
 
 bool File::is_device(DeprecatedString const& filename)
 {
     struct stat st;
     if (stat(filename.characters(), &st) < 0)
+        return false;
+    return S_ISBLK(st.st_mode) || S_ISCHR(st.st_mode);
+}
+
+bool File::is_device(int fd)
+{
+    struct stat st;
+    if (fstat(fd, &st) < 0)
         return false;
     return S_ISBLK(st.st_mode) || S_ISCHR(st.st_mode);
 }
@@ -152,16 +157,21 @@ bool File::is_char_device(DeprecatedString const& filename)
 
 bool File::is_directory() const
 {
-    struct stat stat;
-    if (fstat(fd(), &stat) < 0)
-        return false;
-    return S_ISDIR(stat.st_mode);
+    return is_directory(fd());
 }
 
 bool File::is_directory(DeprecatedString const& filename)
 {
     struct stat st;
     if (stat(filename.characters(), &st) < 0)
+        return false;
+    return S_ISDIR(st.st_mode);
+}
+
+bool File::is_directory(int fd)
+{
+    struct stat st;
+    if (fstat(fd, &st) < 0)
         return false;
     return S_ISDIR(st.st_mode);
 }

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -33,9 +33,11 @@ public:
 
     bool is_directory() const;
     static bool is_directory(DeprecatedString const& filename);
+    static bool is_directory(int fd);
 
     bool is_device() const;
     static bool is_device(DeprecatedString const& filename);
+    static bool is_device(int fd);
     bool is_block_device() const;
     static bool is_block_device(DeprecatedString const& filename);
     bool is_char_device() const;

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -23,10 +23,10 @@ Client& Client::the()
     return *s_the;
 }
 
-Result Client::try_request_file_read_only_approved(GUI::Window* parent_window, DeprecatedString const& path)
+DeprecatedResult Client::try_request_file_read_only_approved(GUI::Window* parent_window, DeprecatedString const& path)
 {
     auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { Core::Promise<Result>::construct(), parent_window });
+    m_promises.set(id, PromiseAndWindow { Core::Promise<DeprecatedResult>::construct(), parent_window });
 
     auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
     auto child_window_server_client_id = expose_window_server_client_id();
@@ -48,10 +48,10 @@ Result Client::try_request_file_read_only_approved(GUI::Window* parent_window, D
     return handle_promise(id);
 }
 
-Result Client::try_request_file(GUI::Window* parent_window, DeprecatedString const& path, Core::OpenMode mode)
+DeprecatedResult Client::try_request_file(GUI::Window* parent_window, DeprecatedString const& path, Core::OpenMode mode)
 {
     auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { Core::Promise<Result>::construct(), parent_window });
+    m_promises.set(id, PromiseAndWindow { Core::Promise<DeprecatedResult>::construct(), parent_window });
 
     auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
     auto child_window_server_client_id = expose_window_server_client_id();
@@ -73,10 +73,10 @@ Result Client::try_request_file(GUI::Window* parent_window, DeprecatedString con
     return handle_promise(id);
 }
 
-Result Client::try_open_file(GUI::Window* parent_window, DeprecatedString const& window_title, StringView path, Core::OpenMode requested_access)
+DeprecatedResult Client::try_open_file(GUI::Window* parent_window, DeprecatedString const& window_title, StringView path, Core::OpenMode requested_access)
 {
     auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { Core::Promise<Result>::construct(), parent_window });
+    m_promises.set(id, PromiseAndWindow { Core::Promise<DeprecatedResult>::construct(), parent_window });
 
     auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
     auto child_window_server_client_id = expose_window_server_client_id();
@@ -93,10 +93,10 @@ Result Client::try_open_file(GUI::Window* parent_window, DeprecatedString const&
     return handle_promise(id);
 }
 
-Result Client::try_save_file(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode requested_access)
+DeprecatedResult Client::try_save_file(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode requested_access)
 {
     auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { Core::Promise<Result>::construct(), parent_window });
+    m_promises.set(id, PromiseAndWindow { Core::Promise<DeprecatedResult>::construct(), parent_window });
 
     auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
     auto child_window_server_client_id = expose_window_server_client_id();
@@ -166,7 +166,7 @@ int Client::get_new_id()
     return new_id;
 }
 
-Result Client::handle_promise(int id)
+DeprecatedResult Client::handle_promise(int id)
 {
     auto result = m_promises.get(id)->promise->await();
     m_promises.remove(id);

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -26,7 +26,7 @@ Client& Client::the()
 DeprecatedResult Client::try_request_file_read_only_approved(GUI::Window* parent_window, DeprecatedString const& path)
 {
     auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { Core::Promise<DeprecatedResult>::construct(), parent_window });
+    m_promises.set(id, PromiseAndWindow { { Core::Promise<DeprecatedResult>::construct() }, parent_window });
 
     auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
     auto child_window_server_client_id = expose_window_server_client_id();
@@ -45,13 +45,13 @@ DeprecatedResult Client::try_request_file_read_only_approved(GUI::Window* parent
         async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, full_path);
     }
 
-    return handle_promise(id);
+    return handle_promise<DeprecatedResult>(id);
 }
 
 DeprecatedResult Client::try_request_file(GUI::Window* parent_window, DeprecatedString const& path, Core::OpenMode mode)
 {
     auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { Core::Promise<DeprecatedResult>::construct(), parent_window });
+    m_promises.set(id, PromiseAndWindow { { Core::Promise<DeprecatedResult>::construct() }, parent_window });
 
     auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
     auto child_window_server_client_id = expose_window_server_client_id();
@@ -70,13 +70,13 @@ DeprecatedResult Client::try_request_file(GUI::Window* parent_window, Deprecated
         async_request_file(id, parent_window_server_client_id, parent_window_id, full_path, mode);
     }
 
-    return handle_promise(id);
+    return handle_promise<DeprecatedResult>(id);
 }
 
 DeprecatedResult Client::try_open_file(GUI::Window* parent_window, DeprecatedString const& window_title, StringView path, Core::OpenMode requested_access)
 {
     auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { Core::Promise<DeprecatedResult>::construct(), parent_window });
+    m_promises.set(id, PromiseAndWindow { { Core::Promise<DeprecatedResult>::construct() }, parent_window });
 
     auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
     auto child_window_server_client_id = expose_window_server_client_id();
@@ -90,13 +90,13 @@ DeprecatedResult Client::try_open_file(GUI::Window* parent_window, DeprecatedStr
 
     async_prompt_open_file(id, parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
 
-    return handle_promise(id);
+    return handle_promise<DeprecatedResult>(id);
 }
 
 DeprecatedResult Client::try_save_file_deprecated(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode requested_access)
 {
     auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { Core::Promise<DeprecatedResult>::construct(), parent_window });
+    m_promises.set(id, PromiseAndWindow { { Core::Promise<DeprecatedResult>::construct() }, parent_window });
 
     auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
     auto child_window_server_client_id = expose_window_server_client_id();
@@ -110,7 +110,30 @@ DeprecatedResult Client::try_save_file_deprecated(GUI::Window* parent_window, De
 
     async_prompt_save_file(id, parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
 
-    return handle_promise(id);
+    return handle_promise<DeprecatedResult>(id);
+}
+
+Result Client::save_file(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::Stream::OpenMode requested_access)
+{
+    auto const id = get_new_id();
+    m_promises.set(id, PromiseAndWindow { { Core::Promise<Result>::construct() }, parent_window });
+
+    auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
+    auto child_window_server_client_id = expose_window_server_client_id();
+    auto parent_window_id = parent_window->window_id();
+
+    GUI::ConnectionToWindowServer::the().add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+
+    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
+        GUI::ConnectionToWindowServer::the().remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+    });
+
+    // The endpoint only cares about ReadOnly, WriteOnly and ReadWrite and both enum shares the same layout for these.
+    Core::OpenMode deprecated_requested_access = static_cast<Core::OpenMode>(requested_access);
+
+    async_prompt_save_file(id, parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), deprecated_requested_access);
+
+    return handle_promise<Result>(id);
 }
 
 void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> const& ipc_file, Optional<DeprecatedString> const& chosen_file)
@@ -118,37 +141,52 @@ void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> co
     auto potential_data = m_promises.get(request_id);
     VERIFY(potential_data.has_value());
     auto& request_data = potential_data.value();
+
+    auto const resolve_any_promise = [&promise = request_data.promise](Error&& error) {
+        if (promise.has<PromiseType<DeprecatedResult>>()) {
+            promise.get<PromiseType<DeprecatedResult>>()->resolve(move(error));
+            return;
+        }
+        promise.get<PromiseType<Result>>()->resolve(move(error));
+    };
+
     if (error != 0) {
         // We don't want to show an error message for non-existent files since some applications may want
         // to handle it as opening a new, named file.
         if (error != -1 && error != ENOENT)
             GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
-        request_data.promise->resolve(Error::from_errno(error));
+        resolve_any_promise(Error::from_errno(error));
         return;
     }
 
-    auto file = Core::File::construct();
-    auto fd = ipc_file->take_fd();
-    if (!file->open(fd, Core::OpenMode::ReadWrite, Core::File::ShouldCloseFileDescriptor::Yes) && file->error() != ENOENT) {
-        GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
-        request_data.promise->resolve(Error::from_errno(file->error()));
-        return;
-    }
-
-    if (file->is_device()) {
+    if (Core::File::is_device(ipc_file->fd())) {
         GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: Cannot open device files", *chosen_file));
-        request_data.promise->resolve(Error::from_string_literal("Cannot open device files"));
+        resolve_any_promise(Error::from_string_literal("Cannot open device files"));
         return;
     }
 
-    if (file->is_directory()) {
+    if (Core::File::is_directory(ipc_file->fd())) {
         GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: Cannot open directory", *chosen_file));
-        request_data.promise->resolve(Error::from_errno(EISDIR));
+        resolve_any_promise(Error::from_errno(EISDIR));
         return;
     }
 
-    file->set_filename(move(*chosen_file));
-    request_data.promise->resolve(file);
+    if (request_data.promise.has<PromiseType<DeprecatedResult>>()) {
+        auto file = Core::File::construct();
+        auto fd = ipc_file->take_fd();
+        file->open(fd, Core::OpenMode::ReadWrite, Core::File::ShouldCloseFileDescriptor::Yes);
+        file->set_filename(*chosen_file);
+
+        request_data.promise.get<PromiseType<DeprecatedResult>>()->resolve(file);
+        return;
+    }
+
+    auto file_or_error = Core::Stream::File::adopt_fd(ipc_file->take_fd(), Core::Stream::OpenMode::ReadWrite);
+    if (file_or_error.is_error()) {
+        resolve_any_promise(file_or_error.release_error());
+    }
+
+    request_data.promise.get<PromiseType<Result>>()->resolve(file_or_error.release_value());
 }
 
 void Client::die()
@@ -166,9 +204,10 @@ int Client::get_new_id()
     return new_id;
 }
 
-DeprecatedResult Client::handle_promise(int id)
+template<typename AnyResult>
+AnyResult Client::handle_promise(int id)
 {
-    auto result = m_promises.get(id)->promise->await();
+    auto result = m_promises.get(id)->promise.get<PromiseType<AnyResult>>()->await();
     m_promises.remove(id);
     return result;
 }

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -93,7 +93,7 @@ DeprecatedResult Client::try_open_file(GUI::Window* parent_window, DeprecatedStr
     return handle_promise(id);
 }
 
-DeprecatedResult Client::try_save_file(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode requested_access)
+DeprecatedResult Client::try_save_file_deprecated(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode requested_access)
 {
     auto const id = get_new_id();
     m_promises.set(id, PromiseAndWindow { Core::Promise<DeprecatedResult>::construct(), parent_window });

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -18,7 +18,7 @@
 
 namespace FileSystemAccessClient {
 
-using Result = ErrorOr<NonnullRefPtr<Core::File>>;
+using DeprecatedResult = ErrorOr<NonnullRefPtr<Core::File>>;
 
 class Client final
     : public IPC::ConnectionToServer<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint>
@@ -26,10 +26,10 @@ class Client final
     IPC_CLIENT_CONNECTION(Client, "/tmp/session/%sid/portal/filesystemaccess"sv)
 
 public:
-    Result try_request_file_read_only_approved(GUI::Window* parent_window, DeprecatedString const& path);
-    Result try_request_file(GUI::Window* parent_window, DeprecatedString const& path, Core::OpenMode mode);
-    Result try_open_file(GUI::Window* parent_window, DeprecatedString const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
-    Result try_save_file(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
+    DeprecatedResult try_request_file_read_only_approved(GUI::Window* parent_window, DeprecatedString const& path);
+    DeprecatedResult try_request_file(GUI::Window* parent_window, DeprecatedString const& path, Core::OpenMode mode);
+    DeprecatedResult try_open_file(GUI::Window* parent_window, DeprecatedString const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
+    DeprecatedResult try_save_file(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
 
     static Client& the();
 
@@ -45,10 +45,10 @@ private:
     virtual void handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> const& fd, Optional<DeprecatedString> const& chosen_file) override;
 
     int get_new_id();
-    Result handle_promise(int);
+    DeprecatedResult handle_promise(int);
 
     struct PromiseAndWindow {
-        RefPtr<Core::Promise<Result>> promise {};
+        RefPtr<Core::Promise<DeprecatedResult>> promise {};
         GUI::Window* parent_window { nullptr };
     };
 

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -19,6 +19,7 @@
 namespace FileSystemAccessClient {
 
 using DeprecatedResult = ErrorOr<NonnullRefPtr<Core::File>>;
+using Result = ErrorOr<NonnullOwnPtr<Core::Stream::File>>;
 
 class Client final
     : public IPC::ConnectionToServer<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint>
@@ -30,6 +31,8 @@ public:
     DeprecatedResult try_request_file(GUI::Window* parent_window, DeprecatedString const& path, Core::OpenMode mode);
     DeprecatedResult try_open_file(GUI::Window* parent_window, DeprecatedString const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
     DeprecatedResult try_save_file_deprecated(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
+
+    Result save_file(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::Stream::OpenMode requested_access = Core::Stream::OpenMode::Write | Core::Stream::OpenMode::Truncate);
 
     static Client& the();
 
@@ -45,10 +48,14 @@ private:
     virtual void handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> const& fd, Optional<DeprecatedString> const& chosen_file) override;
 
     int get_new_id();
-    DeprecatedResult handle_promise(int);
+    template<typename AnyResult>
+    AnyResult handle_promise(int);
+
+    template<typename T>
+    using PromiseType = RefPtr<Core::Promise<T>>;
 
     struct PromiseAndWindow {
-        RefPtr<Core::Promise<DeprecatedResult>> promise {};
+        Variant<PromiseType<DeprecatedResult>, PromiseType<Result>> promise;
         GUI::Window* parent_window { nullptr };
     };
 

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -29,7 +29,7 @@ public:
     DeprecatedResult try_request_file_read_only_approved(GUI::Window* parent_window, DeprecatedString const& path);
     DeprecatedResult try_request_file(GUI::Window* parent_window, DeprecatedString const& path, Core::OpenMode mode);
     DeprecatedResult try_open_file(GUI::Window* parent_window, DeprecatedString const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
-    DeprecatedResult try_save_file(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
+    DeprecatedResult try_save_file_deprecated(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
 
     static Client& the();
 


### PR DESCRIPTION
This is an attempt to port `LibFileSystemAccessClient` to `Core::Stream`.

The plan (yes, there is one :poggie:) is to:

1. Append _deprecated to the old API's members
2. Add a new API to the `LibFileSystemAccessClient` that returns `Core::Stream::File`s.
3. Port each user of the library one by one
4. Remove the old, deprecated API

This PR only target the `try_save_file()` function to ensure that we are going in the right direction.
Porting `try_request*` and `try_open_file` should be quite straightforward though.
