### PR TITLE
AK+Everywhere: Port LexicalPath to new Strings

### DIFF
--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -12,56 +12,61 @@
 
 namespace AK {
 
-char s_single_dot = '.';
-
-LexicalPath::LexicalPath(DeprecatedString path)
-    : m_string(canonicalized_path(move(path)))
+ErrorOr<LexicalPath> LexicalPath::from_string(StringView string_view)
 {
-    if (m_string.is_empty()) {
-        m_string = ".";
-        m_dirname = m_string;
-        m_basename = {};
-        m_title = {};
-        m_extension = {};
-        m_parts.clear();
-        return;
-    }
-
-    m_parts = m_string.split_view('/');
-
-    auto last_slash_index = m_string.view().find_last('/');
-    if (!last_slash_index.has_value()) {
-        // The path contains a single part and is not absolute. m_dirname = "."sv
-        m_dirname = { &s_single_dot, 1 };
-    } else if (*last_slash_index == 0) {
-        // The path contains a single part and is absolute. m_dirname = "/"sv
-        m_dirname = m_string.substring_view(0, 1);
-    } else {
-        m_dirname = m_string.substring_view(0, *last_slash_index);
-    }
-
-    if (m_string == "/")
-        m_basename = m_string;
-    else {
-        VERIFY(m_parts.size() > 0);
-        m_basename = m_parts.last();
-    }
-
-    auto last_dot_index = m_basename.find_last('.');
-    // NOTE: if the dot index is 0, this means we have ".foo", it's not an extension, as the title would then be "".
-    if (last_dot_index.has_value() && *last_dot_index != 0) {
-        m_title = m_basename.substring_view(0, *last_dot_index);
-        m_extension = m_basename.substring_view(*last_dot_index + 1);
-    } else {
-        m_title = m_basename;
-        m_extension = {};
-    }
+    return from_string(TRY(String::from_utf8(string_view)));
 }
 
-Vector<DeprecatedString> LexicalPath::parts() const
+ErrorOr<LexicalPath> LexicalPath::from_string(String path_string)
 {
-    Vector<DeprecatedString> vector;
-    vector.ensure_capacity(m_parts.size());
+    LexicalPath path;
+    path.m_string = TRY(canonicalized_path(path_string.bytes_as_string_view()));
+    if (path.m_string.is_empty()) {
+        path.m_string = TRY(String::from_utf8("."sv));
+        path.m_dirname = path.m_string;
+        path.m_basename = {};
+        path.m_title = {};
+        path.m_extension = {};
+        path.m_parts.clear();
+        return path;
+    }
+
+    path.m_parts = TRY(path.m_string.split_bytes('/'));
+
+    auto last_slash_index = path.m_string.bytes_as_string_view().find_last('/');
+    if (!last_slash_index.has_value()) {
+        // The path contains a single part and is not absolute. m_dirname = "."sv
+        path.m_dirname = TRY(String::from_utf8("."sv));
+    } else if (*last_slash_index == 0) {
+        // The path contains a single part and is absolute. m_dirname = "/"sv
+        path.m_dirname = TRY(path.m_string.substring_from_byte_offset(0, 1));
+    } else {
+        path.m_dirname = TRY(path.m_string.substring_from_byte_offset(0, *last_slash_index));
+    }
+
+    if (path.m_string == "/")
+        path.m_basename = path.m_string;
+    else {
+        VERIFY(path.m_parts.size() > 0);
+        path.m_basename = path.m_parts.last();
+    }
+
+    auto last_dot_index = path.m_basename.find_last('.');
+    // NOTE: if the dot index is 0, this means we have ".foo", it's not an extension, as the title would then be "".
+    if (last_dot_index.has_value() && *last_dot_index != 0) {
+        path.m_title = TRY(path.m_basename.substring_from_byte_offset(0, *last_dot_index));
+        path.m_extension = TRY(path.m_basename.substring_from_byte_offset(*last_dot_index + 1));
+    } else {
+        path.m_title = path.m_basename;
+        path.m_extension = {};
+    }
+    return path;
+}
+
+ErrorOr<Vector<String>> LexicalPath::parts() const
+{
+    Vector<String> vector;
+    TRY(vector.try_ensure_capacity(m_parts.size()));
     for (auto& part : m_parts)
         vector.unchecked_append(part);
     return vector;
@@ -69,7 +74,7 @@ Vector<DeprecatedString> LexicalPath::parts() const
 
 bool LexicalPath::has_extension(StringView extension) const
 {
-    return m_string.ends_with(extension, CaseSensitivity::CaseInsensitive);
+    return m_string.ends_with_bytes(extension, CaseSensitivity::CaseInsensitive);
 }
 
 bool LexicalPath::is_child_of(LexicalPath const& possible_parent) const
@@ -88,23 +93,22 @@ bool LexicalPath::is_child_of(LexicalPath const& possible_parent) const
     return common_parts_with_parent == possible_parent.parts_view().span();
 }
 
-DeprecatedString LexicalPath::canonicalized_path(DeprecatedString path)
+ErrorOr<String> LexicalPath::canonicalized_path(StringView path)
 {
-    if (path.is_null())
-        return {};
+    VERIFY(!path.is_null());
 
     // NOTE: We never allow an empty m_string, if it's empty, we just set it to '.'.
     if (path.is_empty())
-        return ".";
+        return String::from_utf8("."sv);
 
     // NOTE: If there are no dots, no '//' and the path doesn't end with a slash, it is already canonical.
     if (!path.contains("."sv) && !path.contains("//"sv) && !path.ends_with('/'))
-        return path;
+        return String::from_utf8(path);
 
-    auto is_absolute = path[0] == '/';
+    auto is_absolute = path.starts_with('/');
     auto parts = path.split_view('/');
     size_t approximate_canonical_length = 0;
-    Vector<DeprecatedString> canonical_parts;
+    Vector<String> canonical_parts;
 
     for (auto& part : parts) {
         if (part == ".")
@@ -123,56 +127,57 @@ DeprecatedString LexicalPath::canonicalized_path(DeprecatedString path)
                 }
             }
         }
-        approximate_canonical_length += part.length() + 1;
-        canonical_parts.append(part);
+        approximate_canonical_length += part.bytes().size() + 1;
+        TRY(canonical_parts.try_append(TRY(String::from_utf8(part))));
     }
 
     if (canonical_parts.is_empty() && !is_absolute)
-        canonical_parts.append(".");
+        TRY(canonical_parts.try_append(TRY(String::from_utf8("."sv))));
 
     StringBuilder builder(approximate_canonical_length);
     if (is_absolute)
-        builder.append('/');
+        TRY(builder.try_append('/'));
     builder.join('/', canonical_parts);
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
-DeprecatedString LexicalPath::absolute_path(DeprecatedString dir_path, DeprecatedString target)
+ErrorOr<String> LexicalPath::absolute_path(StringView dir_path, StringView target)
 {
-    if (LexicalPath(target).is_absolute()) {
+    if (TRY(LexicalPath::from_string(target)).is_absolute()) {
         return LexicalPath::canonicalized_path(target);
     }
-    return LexicalPath::canonicalized_path(join(dir_path, target).string());
+    return LexicalPath::canonicalized_path(TRY(join(dir_path, target)).string());
 }
 
-DeprecatedString LexicalPath::relative_path(StringView a_path, StringView a_prefix)
+ErrorOr<String> LexicalPath::relative_path(StringView a_path, StringView a_prefix)
 {
     if (!a_path.starts_with('/') || !a_prefix.starts_with('/')) {
-        // FIXME: This should probably VERIFY or return an Optional<DeprecatedString>.
-        return ""sv;
+        // FIXME: This should probably VERIFY or return an Optional<String>.
+        return String {};
     }
 
     if (a_path == a_prefix)
-        return ".";
+        return String::from_utf8("."sv);
 
     // NOTE: Strip optional trailing slashes, except if the full path is only "/".
-    auto path = canonicalized_path(a_path);
-    auto prefix = canonicalized_path(a_prefix);
+    auto path = TRY(canonicalized_path(TRY(String::from_utf8(a_path))));
+    auto prefix = TRY(canonicalized_path(TRY(String::from_utf8(a_prefix))));
 
     if (path == prefix)
-        return ".";
+        return String::from_utf8("."sv);
 
     // NOTE: Handle this special case first.
     if (prefix == "/"sv)
-        return path.substring_view(1);
+        return path.substring_from_byte_offset(1);
 
     // NOTE: This means the prefix is a direct child of the path.
-    if (path.starts_with(prefix) && path[prefix.length()] == '/') {
-        return path.substring_view(prefix.length() + 1);
+    auto prefix_with_slash = TRY(String::formatted("{}/", prefix));
+    if (path.starts_with_bytes(prefix_with_slash)) {
+        return path.substring_from_byte_offset(prefix_with_slash.bytes().size());
     }
 
-    auto path_parts = path.split_view('/');
-    auto prefix_parts = prefix.split_view('/');
+    auto path_parts = TRY(path.split_bytes('/'));
+    auto prefix_parts = TRY(prefix.split_bytes('/'));
     size_t index_of_first_part_that_differs = 0;
     for (; index_of_first_part_that_differs < path_parts.size() && index_of_first_part_that_differs < prefix_parts.size(); index_of_first_part_that_differs++) {
         if (path_parts[index_of_first_part_that_differs] != prefix_parts[index_of_first_part_that_differs])
@@ -189,20 +194,20 @@ DeprecatedString LexicalPath::relative_path(StringView a_path, StringView a_pref
             builder.append('/');
     }
 
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
-LexicalPath LexicalPath::append(StringView value) const
+ErrorOr<LexicalPath> LexicalPath::append(StringView value) const
 {
     return LexicalPath::join(m_string, value);
 }
 
-LexicalPath LexicalPath::prepend(StringView value) const
+ErrorOr<LexicalPath> LexicalPath::prepend(StringView value) const
 {
     return LexicalPath::join(value, m_string);
 }
 
-LexicalPath LexicalPath::parent() const
+ErrorOr<LexicalPath> LexicalPath::parent() const
 {
     return append(".."sv);
 }

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
+#include <AK/Utf8View.h>
 #include <AK/Vector.h>
 
 // On Linux distros that use mlibc `basename` is defined as a macro that expands to `__mlibc_gnu_basename` or `__mlibc_gnu_basename_c`, so we undefine it.
@@ -19,71 +21,78 @@ namespace AK {
 
 class LexicalPath {
 public:
-    explicit LexicalPath(DeprecatedString);
+    static ErrorOr<LexicalPath> from_string(StringView);
+    static ErrorOr<LexicalPath> from_string(String);
 
-    bool is_absolute() const { return !m_string.is_empty() && m_string[0] == '/'; }
-    DeprecatedString const& string() const { return m_string; }
+    bool is_absolute() const { return !m_string.is_empty() && *m_string.code_points().begin() == '/'; }
+    String const& string() const { return m_string; }
 
     StringView dirname() const { return m_dirname; }
     StringView basename() const { return m_basename; }
     StringView title() const { return m_title; }
     StringView extension() const { return m_extension; }
 
-    Vector<StringView> const& parts_view() const { return m_parts; }
-    [[nodiscard]] Vector<DeprecatedString> parts() const;
+    Vector<String> const& parts_view() const { return m_parts; }
+    [[nodiscard]] ErrorOr<Vector<String>> parts() const;
 
     bool has_extension(StringView) const;
     bool is_child_of(LexicalPath const& possible_parent) const;
 
-    [[nodiscard]] LexicalPath append(StringView) const;
-    [[nodiscard]] LexicalPath prepend(StringView) const;
-    [[nodiscard]] LexicalPath parent() const;
+    [[nodiscard]] ErrorOr<LexicalPath> append(StringView) const;
+    [[nodiscard]] ErrorOr<LexicalPath> prepend(StringView) const;
+    [[nodiscard]] ErrorOr<LexicalPath> parent() const;
 
-    [[nodiscard]] static DeprecatedString canonicalized_path(DeprecatedString);
-    [[nodiscard]] static DeprecatedString absolute_path(DeprecatedString dir_path, DeprecatedString target);
-    [[nodiscard]] static DeprecatedString relative_path(StringView absolute_path, StringView prefix);
+    [[nodiscard]] static ErrorOr<String> canonicalized_path(StringView);
+    [[nodiscard]] static ErrorOr<String> absolute_path(StringView dir_path, StringView target);
+    [[nodiscard]] static ErrorOr<String> relative_path(StringView absolute_path, StringView prefix);
 
     template<typename... S>
-    [[nodiscard]] static LexicalPath join(StringView first, S&&... rest)
+    [[nodiscard]] static ErrorOr<LexicalPath> join(StringView first, S&&... rest)
     {
         StringBuilder builder;
         builder.append(first);
         ((builder.append('/'), builder.append(forward<S>(rest))), ...);
 
-        return LexicalPath { builder.to_deprecated_string() };
+        return TRY(LexicalPath::from_string(TRY(builder.to_string())));
     }
 
-    [[nodiscard]] static DeprecatedString dirname(DeprecatedString path)
+    [[nodiscard]] static ErrorOr<String> dirname(String path)
     {
-        auto lexical_path = LexicalPath(move(path));
-        return lexical_path.dirname();
+        auto lexical_path = TRY(LexicalPath::from_string(move(path)));
+        return String::from_utf8(lexical_path.dirname());
     }
+    [[nodiscard]] static ErrorOr<String> dirname(StringView path) { return dirname(TRY(String::from_utf8(path))); }
 
-    [[nodiscard]] static DeprecatedString basename(DeprecatedString path)
+    [[nodiscard]] static ErrorOr<String> basename(String path)
     {
-        auto lexical_path = LexicalPath(move(path));
-        return lexical_path.basename();
+        auto lexical_path = TRY(LexicalPath::from_string(move(path)));
+        return String::from_utf8(lexical_path.basename());
     }
+    [[nodiscard]] static ErrorOr<String> basename(StringView path) { return basename(TRY(String::from_utf8(path))); }
 
-    [[nodiscard]] static DeprecatedString title(DeprecatedString path)
+    [[nodiscard]] static ErrorOr<String> title(String path)
     {
-        auto lexical_path = LexicalPath(move(path));
-        return lexical_path.title();
+        auto lexical_path = TRY(LexicalPath::from_string(move(path)));
+        return String::from_utf8(lexical_path.title());
     }
+    [[nodiscard]] static ErrorOr<String> title(StringView path) { return title(TRY(String::from_utf8(path))); }
 
-    [[nodiscard]] static DeprecatedString extension(DeprecatedString path)
+    [[nodiscard]] static ErrorOr<String> extension(String path)
     {
-        auto lexical_path = LexicalPath(move(path));
-        return lexical_path.extension();
+        auto lexical_path = TRY(LexicalPath::from_string(move(path)));
+        return String::from_utf8(lexical_path.extension());
     }
+    [[nodiscard]] static ErrorOr<String> extension(StringView path) { return extension(TRY(String::from_utf8(path))); }
 
 private:
-    Vector<StringView> m_parts;
-    DeprecatedString m_string;
-    StringView m_dirname;
-    StringView m_basename;
-    StringView m_title;
-    StringView m_extension;
+    LexicalPath() = default;
+
+    Vector<String> m_parts;
+    String m_string;
+    String m_dirname;
+    String m_basename;
+    String m_title;
+    String m_extension;
 };
 
 template<>

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -268,6 +268,11 @@ ErrorOr<String> String::substring_from_byte_offset(size_t start, size_t byte_cou
     return String::from_utf8(bytes_as_string_view().substring_view(start, byte_count));
 }
 
+ErrorOr<String> String::substring_from_byte_offset(size_t start) const
+{
+    return String::from_utf8(bytes_as_string_view().substring_view(start));
+}
+
 ErrorOr<String> String::substring_from_byte_offset_with_shared_superstring(size_t start, size_t byte_count) const
 {
     if (!byte_count)

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -311,6 +311,38 @@ ErrorOr<String> String::replace(StringView needle, StringView replacement, Repla
     return StringUtils::replace(*this, needle, replacement, replace_mode);
 }
 
+Optional<size_t> String::find(u32 needle, size_t start) const
+{
+    size_t index = 0;
+    for (auto codepoint : code_points()) {
+        if (index < start) {
+            continue;
+        }
+
+        if (codepoint == needle) {
+            return index;
+        }
+
+        index++;
+    }
+    return {};
+}
+
+Optional<size_t> String::find_last(u32 needle) const
+{
+    // FIXME: I am naive.
+    size_t index = 0;
+    Optional<size_t> needle_index = 0;
+    for (auto codepoint : code_points()) {
+        if (codepoint == needle) {
+            needle_index = index;
+        }
+
+        index++;
+    }
+    return needle_index;
+}
+
 bool String::is_short_string() const
 {
     return reinterpret_cast<uintptr_t>(m_data) & SHORT_STRING_FLAG;

--- a/AK/String.h
+++ b/AK/String.h
@@ -67,6 +67,13 @@ public:
 
     ErrorOr<String> replace(StringView needle, StringView replacement, ReplaceMode replace_mode) const;
 
+    [[nodiscard]] bool contains_bytes(StringView, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
+    [[nodiscard]] bool starts_with_bytes(StringView, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
+    [[nodiscard]] bool ends_with_bytes(StringView, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
+
+    [[nodiscard]] ErrorOr<Vector<String>> split_bytes_limit(char separator, size_t limit, SplitBehavior = SplitBehavior::Nothing) const;
+    [[nodiscard]] ErrorOr<Vector<String>> split_bytes(char separator, SplitBehavior = SplitBehavior::Nothing) const;
+
     [[nodiscard]] Optional<size_t> find(u32 needle, size_t start = 0) const;
     [[nodiscard]] Optional<size_t> find_last(u32 needle) const;
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -46,6 +46,9 @@ public:
     // Creates a substring with a deep copy of the specified data window.
     ErrorOr<String> substring_from_byte_offset(size_t start, size_t byte_count) const;
 
+    // Creates a substring with a deep copy of the specified data window, spanning to the end of the string.
+    ErrorOr<String> substring_from_byte_offset(size_t start) const;
+
     // Creates a substring that strongly references the origin superstring instead of making a deep copy of the data.
     ErrorOr<String> substring_from_byte_offset_with_shared_superstring(size_t start, size_t byte_count) const;
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -67,6 +67,11 @@ public:
 
     ErrorOr<String> replace(StringView needle, StringView replacement, ReplaceMode replace_mode) const;
 
+    [[nodiscard]] Optional<size_t> find(u32 needle, size_t start = 0) const;
+    [[nodiscard]] Optional<size_t> find_last(u32 needle) const;
+
+    [[nodiscard]] Optional<size_t> find_bytes(StringView needle, size_t bytes_start = 0) const { return StringUtils::find(bytes_as_string_view(), needle, bytes_start); }
+
     [[nodiscard]] bool operator==(String const&) const;
     [[nodiscard]] bool operator!=(String const& other) const { return !(*this == other); }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
@@ -567,9 +567,9 @@ static Optional<Locale::DayPeriod> day_period_from_string(StringView day_period)
 static ErrorOr<void> parse_hour_cycles(DeprecatedString core_path, CLDR& cldr)
 {
     // https://unicode.org/reports/tr35/tr35-dates.html#Time_Data
-    LexicalPath time_data_path(move(core_path));
-    time_data_path = time_data_path.append("supplemental"sv);
-    time_data_path = time_data_path.append("timeData.json"sv);
+    auto time_data_path = TRY(LexicalPath::from_string(core_path.view()));
+    time_data_path = TRY(time_data_path.append("supplemental"sv));
+    time_data_path = TRY(time_data_path.append("timeData.json"sv));
 
     auto time_data = TRY(read_json_file(time_data_path.string()));
     auto const& supplemental_object = time_data.as_object().get("supplemental"sv);
@@ -611,9 +611,9 @@ static ErrorOr<void> parse_hour_cycles(DeprecatedString core_path, CLDR& cldr)
 static ErrorOr<void> parse_week_data(DeprecatedString core_path, CLDR& cldr)
 {
     // https://unicode.org/reports/tr35/tr35-dates.html#Week_Data
-    LexicalPath week_data_path(move(core_path));
-    week_data_path = week_data_path.append("supplemental"sv);
-    week_data_path = week_data_path.append("weekData.json"sv);
+    auto week_data_path = TRY(LexicalPath::from_string(core_path.view()));
+    week_data_path = TRY(week_data_path.append("supplemental"sv));
+    week_data_path = TRY(week_data_path.append("weekData.json"sv));
 
     auto week_data = TRY(read_json_file(week_data_path.string()));
     auto const& supplemental_object = week_data.as_object().get("supplemental"sv);
@@ -676,9 +676,9 @@ static ErrorOr<void> parse_week_data(DeprecatedString core_path, CLDR& cldr)
 static ErrorOr<void> parse_meta_zones(DeprecatedString core_path, CLDR& cldr)
 {
     // https://unicode.org/reports/tr35/tr35-dates.html#Metazones
-    LexicalPath meta_zone_path(move(core_path));
-    meta_zone_path = meta_zone_path.append("supplemental"sv);
-    meta_zone_path = meta_zone_path.append("metaZones.json"sv);
+    auto meta_zone_path = TRY(LexicalPath::from_string(core_path.view()));
+    meta_zone_path = TRY(meta_zone_path.append("supplemental"sv));
+    meta_zone_path = TRY(meta_zone_path.append("metaZones.json"sv));
 
     auto meta_zone = TRY(read_json_file(meta_zone_path.string()));
     auto const& supplemental_object = meta_zone.as_object().get("supplemental"sv);
@@ -1380,13 +1380,13 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
 
 static ErrorOr<void> parse_calendars(DeprecatedString locale_calendars_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath calendars_path(move(locale_calendars_path));
+    auto calendars_path = TRY(LexicalPath::from_string(locale_calendars_path.view()));
     if (!calendars_path.basename().starts_with("ca-"sv))
         return {};
 
     auto calendars = TRY(read_json_file(calendars_path.string()));
     auto const& main_object = calendars.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(calendars_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(calendars_path.parent()).basename());
     auto const& dates_object = locale_object.as_object().get("dates"sv);
     auto const& calendars_object = dates_object.as_object().get("calendars"sv);
 
@@ -1471,12 +1471,12 @@ static ErrorOr<void> parse_calendars(DeprecatedString locale_calendars_path, CLD
 
 static ErrorOr<void> parse_time_zone_names(DeprecatedString locale_time_zone_names_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath time_zone_names_path(move(locale_time_zone_names_path));
-    time_zone_names_path = time_zone_names_path.append("timeZoneNames.json"sv);
+    auto time_zone_names_path = TRY(LexicalPath::from_string(locale_time_zone_names_path.view()));
+    time_zone_names_path = TRY(time_zone_names_path.append("timeZoneNames.json"sv));
 
     auto time_zone_names = TRY(read_json_file(time_zone_names_path.string()));
     auto const& main_object = time_zone_names.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(time_zone_names_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(time_zone_names_path.parent()).basename());
     auto const& dates_object = locale_object.as_object().get("dates"sv);
     auto const& time_zone_names_object = dates_object.as_object().get("timeZoneNames"sv);
     auto const& meta_zone_object = time_zone_names_object.as_object().get("metazone"sv);
@@ -1581,9 +1581,9 @@ static ErrorOr<void> parse_time_zone_names(DeprecatedString locale_time_zone_nam
 static ErrorOr<void> parse_day_periods(DeprecatedString core_path, CLDR& cldr)
 {
     // https://unicode.org/reports/tr35/tr35-dates.html#Day_Period_Rule_Sets
-    LexicalPath day_periods_path(move(core_path));
-    day_periods_path = day_periods_path.append("supplemental"sv);
-    day_periods_path = day_periods_path.append("dayPeriods.json"sv);
+    auto day_periods_path = TRY(LexicalPath::from_string(core_path.view()));
+    day_periods_path = TRY(day_periods_path.append("supplemental"sv));
+    day_periods_path = TRY(day_periods_path.append("dayPeriods.json"sv));
 
     auto locale_day_periods = TRY(read_json_file(day_periods_path.string()));
     auto const& supplemental_object = locale_day_periods.as_object().get("supplemental"sv);
@@ -1643,7 +1643,7 @@ static ErrorOr<void> parse_all_locales(DeprecatedString core_path, DeprecatedStr
     auto dates_iterator = TRY(path_to_dir_iterator(move(dates_path)));
 
     auto remove_variants_from_path = [&](DeprecatedString path) -> ErrorOr<DeprecatedString> {
-        auto parsed_locale = TRY(CanonicalLanguageID::parse(cldr.unique_strings, LexicalPath::basename(path)));
+        auto parsed_locale = TRY(CanonicalLanguageID::parse(cldr.unique_strings, TRY(LexicalPath::basename(TRY(String::from_deprecated_string(path))))));
 
         StringBuilder builder;
         builder.append(cldr.unique_strings.get(parsed_locale.language));

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
@@ -248,8 +248,8 @@ static ErrorOr<LanguageMapping> parse_language_mapping(CLDR& cldr, StringView ke
 
 static ErrorOr<void> parse_core_aliases(DeprecatedString core_supplemental_path, CLDR& cldr)
 {
-    LexicalPath core_aliases_path(move(core_supplemental_path));
-    core_aliases_path = core_aliases_path.append("aliases.json"sv);
+    auto core_aliases_path = TRY(LexicalPath::from_string(move(core_supplemental_path)));
+    core_aliases_path = TRY(core_aliases_path.append("aliases.json"sv));
 
     auto core_aliases = TRY(read_json_file(core_aliases_path.string()));
     auto const& supplemental_object = core_aliases.as_object().get("supplemental"sv);
@@ -280,10 +280,12 @@ static ErrorOr<void> parse_core_aliases(DeprecatedString core_supplemental_path,
     return {};
 }
 
+// -h LocaleData.h.tmp -c LocaleData.cpp.tmp -b /home/sppmacd/Prog/serenity/Build/x86_64clang/CLDR/cldr-bcp47 -r /home/sppmacd/Prog/serenity/Build/x86_64clang/CLDR/cldr-core -l /home/sppmacd/Prog/serenity/Build/x86_64clang/CLDR/cldr-localenames-modern -m /home/sppmacd/Prog/serenity/Build/x86_64clang/CLDR/cldr-misc-modern -n /home/sppmacd/Prog/serenity/Build/x86_64clang/CLDR/cldr-numbers-modern -d /home/sppmacd/Prog/serenity/Build/x86_64clang/CLDR/cldr-dates-modern
+
 static ErrorOr<void> parse_likely_subtags(DeprecatedString core_supplemental_path, CLDR& cldr)
 {
-    LexicalPath likely_subtags_path(move(core_supplemental_path));
-    likely_subtags_path = likely_subtags_path.append("likelySubtags.json"sv);
+    auto likely_subtags_path = TRY(LexicalPath::from_string(core_supplemental_path.view()));
+    likely_subtags_path = TRY(likely_subtags_path.append("likelySubtags.json"sv));
 
     auto likely_subtags = TRY(read_json_file(likely_subtags_path.string()));
     auto const& supplemental_object = likely_subtags.as_object().get("supplemental"sv);
@@ -301,12 +303,12 @@ static ErrorOr<void> parse_likely_subtags(DeprecatedString core_supplemental_pat
 
 static ErrorOr<void> parse_identity(DeprecatedString locale_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath languages_path(move(locale_path)); // Note: Every JSON file defines identity data, so we can use any of them.
-    languages_path = languages_path.append("languages.json"sv);
+    auto languages_path = TRY(LexicalPath::from_string(locale_path.view())); // Note: Every JSON file defines identity data, so we can use any of them.
+    languages_path = TRY(languages_path.append("languages.json"sv));
 
     auto languages = TRY(read_json_file(languages_path.string()));
     auto const& main_object = languages.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(languages_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(languages_path.parent()).basename());
     auto const& identity_object = locale_object.as_object().get("identity"sv);
     auto const& language_string = identity_object.as_object().get("language"sv);
     auto const& territory_string = identity_object.as_object().get("territory"sv);
@@ -338,12 +340,12 @@ static ErrorOr<void> parse_identity(DeprecatedString locale_path, CLDR& cldr, Lo
 
 static ErrorOr<void> parse_locale_display_patterns(DeprecatedString locale_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath locale_display_names_path(move(locale_path));
-    locale_display_names_path = locale_display_names_path.append("localeDisplayNames.json"sv);
+    auto locale_display_names_path = TRY(LexicalPath::from_string(locale_path.view()));
+    locale_display_names_path = TRY(locale_display_names_path.append("localeDisplayNames.json"sv));
 
     auto locale_display_names = TRY(read_json_file(locale_display_names_path.string()));
     auto const& main_object = locale_display_names.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(locale_display_names_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(locale_display_names_path.parent()).basename());
     auto const& locale_display_names_object = locale_object.as_object().get("localeDisplayNames"sv);
     auto const& locale_display_patterns_object = locale_display_names_object.as_object().get("localeDisplayPattern"sv);
     auto const& locale_pattern = locale_display_patterns_object.as_object().get("localePattern"sv);
@@ -359,12 +361,12 @@ static ErrorOr<void> parse_locale_display_patterns(DeprecatedString locale_path,
 
 static ErrorOr<void> preprocess_languages(DeprecatedString locale_path, CLDR& cldr)
 {
-    LexicalPath languages_path(move(locale_path));
-    languages_path = languages_path.append("languages.json"sv);
+    auto languages_path = TRY(LexicalPath::from_string(locale_path.view()));
+    languages_path = TRY(languages_path.append("languages.json"sv));
 
     auto locale_languages = TRY(read_json_file(languages_path.string()));
     auto const& main_object = locale_languages.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(languages_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(languages_path.parent()).basename());
     auto const& locale_display_names_object = locale_object.as_object().get("localeDisplayNames"sv);
     auto const& languages_object = locale_display_names_object.as_object().get("languages"sv);
 
@@ -442,12 +444,12 @@ static Optional<DeprecatedString> find_keyword_alias(StringView key, StringView 
 
 static ErrorOr<void> parse_locale_languages(DeprecatedString locale_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath languages_path(move(locale_path));
-    languages_path = languages_path.append("languages.json"sv);
+    auto languages_path = TRY(LexicalPath::from_string(locale_path.view()));
+    languages_path = TRY(languages_path.append("languages.json"sv));
 
     auto locale_languages = TRY(read_json_file(languages_path.string()));
     auto const& main_object = locale_languages.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(languages_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(languages_path.parent()).basename());
     auto const& locale_display_names_object = locale_object.as_object().get("localeDisplayNames"sv);
     auto const& languages_object = locale_display_names_object.as_object().get("languages"sv);
 
@@ -468,12 +470,12 @@ static ErrorOr<void> parse_locale_languages(DeprecatedString locale_path, CLDR& 
 
 static ErrorOr<void> parse_locale_territories(DeprecatedString locale_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath territories_path(move(locale_path));
-    territories_path = territories_path.append("territories.json"sv);
+    auto territories_path = TRY(LexicalPath::from_string(locale_path.view()));
+    territories_path = TRY(territories_path.append("territories.json"sv));
 
     auto locale_territories = TRY(read_json_file(territories_path.string()));
     auto const& main_object = locale_territories.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(territories_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(territories_path.parent()).basename());
     auto const& locale_display_names_object = locale_object.as_object().get("localeDisplayNames"sv);
     auto const& territories_object = locale_display_names_object.as_object().get("territories"sv);
 
@@ -491,12 +493,12 @@ static ErrorOr<void> parse_locale_territories(DeprecatedString locale_path, CLDR
 
 static ErrorOr<void> parse_locale_scripts(DeprecatedString locale_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath scripts_path(move(locale_path));
-    scripts_path = scripts_path.append("scripts.json"sv);
+    auto scripts_path = TRY(LexicalPath::from_string(locale_path.view()));
+    scripts_path = TRY(scripts_path.append("scripts.json"sv));
 
     auto locale_scripts = TRY(read_json_file(scripts_path.string()));
     auto const& main_object = locale_scripts.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(scripts_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(scripts_path.parent()).basename());
     auto const& locale_display_names_object = locale_object.as_object().get("localeDisplayNames"sv);
     auto const& scripts_object = locale_display_names_object.as_object().get("scripts"sv);
 
@@ -514,12 +516,12 @@ static ErrorOr<void> parse_locale_scripts(DeprecatedString locale_path, CLDR& cl
 
 static ErrorOr<void> parse_locale_list_patterns(DeprecatedString misc_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath list_patterns_path(move(misc_path));
-    list_patterns_path = list_patterns_path.append("listPatterns.json"sv);
+    auto list_patterns_path = TRY(LexicalPath::from_string(misc_path.view()));
+    list_patterns_path = TRY(list_patterns_path.append("listPatterns.json"sv));
 
     auto locale_list_patterns = TRY(read_json_file(list_patterns_path.string()));
     auto const& main_object = locale_list_patterns.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(list_patterns_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(list_patterns_path.parent()).basename());
     auto const& list_patterns_object = locale_object.as_object().get("listPatterns"sv);
 
     auto list_pattern_type = [](StringView key) {
@@ -565,12 +567,12 @@ static ErrorOr<void> parse_locale_list_patterns(DeprecatedString misc_path, CLDR
 
 static ErrorOr<void> parse_locale_layout(DeprecatedString misc_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath layout_path(move(misc_path));
-    layout_path = layout_path.append("layout.json"sv);
+    auto layout_path = TRY(LexicalPath::from_string(misc_path.view()));
+    layout_path = TRY(layout_path.append("layout.json"sv));
 
     auto locale_layout = TRY(read_json_file(layout_path.string()));
     auto const& main_object = locale_layout.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(layout_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(layout_path.parent()).basename());
     auto const& layout_object = locale_object.as_object().get("layout"sv);
     auto const& orientation_object = layout_object.as_object().get("orientation"sv);
 
@@ -597,12 +599,12 @@ static ErrorOr<void> parse_locale_layout(DeprecatedString misc_path, CLDR& cldr,
 
 static ErrorOr<void> parse_locale_currencies(DeprecatedString numbers_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath currencies_path(move(numbers_path));
-    currencies_path = currencies_path.append("currencies.json"sv);
+    auto currencies_path = TRY(LexicalPath::from_string(numbers_path.view()));
+    currencies_path = TRY(currencies_path.append("currencies.json"sv));
 
     auto locale_currencies = TRY(read_json_file(currencies_path.string()));
     auto const& main_object = locale_currencies.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(currencies_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(currencies_path.parent()).basename());
     auto const& locale_numbers_object = locale_object.as_object().get("numbers"sv);
     auto const& currencies_object = locale_numbers_object.as_object().get("currencies"sv);
 
@@ -645,12 +647,12 @@ static ErrorOr<void> parse_locale_currencies(DeprecatedString numbers_path, CLDR
 
 static ErrorOr<void> parse_locale_calendars(DeprecatedString locale_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath locale_display_names_path(move(locale_path));
-    locale_display_names_path = locale_display_names_path.append("localeDisplayNames.json"sv);
+    auto locale_display_names_path = TRY(LexicalPath::from_string(locale_path.view()));
+    locale_display_names_path = TRY(locale_display_names_path.append("localeDisplayNames.json"sv));
 
     auto locale_display_names = TRY(read_json_file(locale_display_names_path.string()));
     auto const& main_object = locale_display_names.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(locale_display_names_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(locale_display_names_path.parent()).basename());
     auto const& locale_display_names_object = locale_object.as_object().get("localeDisplayNames"sv);
     auto const& types_object = locale_display_names_object.as_object().get("types"sv);
     auto const& calendar_object = types_object.as_object().get("calendar"sv);
@@ -676,12 +678,12 @@ static ErrorOr<void> parse_locale_calendars(DeprecatedString locale_path, CLDR& 
 
 static ErrorOr<void> parse_locale_date_fields(DeprecatedString dates_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath date_fields_path(move(dates_path));
-    date_fields_path = date_fields_path.append("dateFields.json"sv);
+    auto date_fields_path = TRY(LexicalPath::from_string(dates_path.view()));
+    date_fields_path = TRY(date_fields_path.append("dateFields.json"sv));
 
     auto locale_date_fields = TRY(read_json_file(date_fields_path.string()));
     auto const& main_object = locale_date_fields.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(date_fields_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(date_fields_path.parent()).basename());
     auto const& dates_object = locale_object.as_object().get("dates"sv);
     auto const& fields_object = dates_object.as_object().get("fields"sv);
 
@@ -732,12 +734,12 @@ static ErrorOr<void> parse_locale_date_fields(DeprecatedString dates_path, CLDR&
 
 static ErrorOr<void> parse_number_system_keywords(DeprecatedString locale_numbers_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath numbers_path(move(locale_numbers_path));
-    numbers_path = numbers_path.append("numbers.json"sv);
+    auto numbers_path = TRY(LexicalPath::from_string(locale_numbers_path.view()));
+    numbers_path = TRY(numbers_path.append("numbers.json"sv));
 
     auto numbers = TRY(read_json_file(numbers_path.string()));
     auto const& main_object = numbers.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(numbers_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(numbers_path.parent()).basename());
     auto const& locale_numbers_object = locale_object.as_object().get("numbers"sv);
     auto const& default_numbering_system_object = locale_numbers_object.as_object().get("defaultNumberingSystem"sv);
     auto const& other_numbering_systems_object = locale_numbers_object.as_object().get("otherNumberingSystems"sv);
@@ -777,13 +779,13 @@ static ErrorOr<void> parse_calendar_keywords(DeprecatedString locale_dates_path,
     while (calendars_iterator.has_next()) {
         auto locale_calendars_path = TRY(next_path_from_dir_iterator(calendars_iterator));
 
-        LexicalPath calendars_path(move(locale_calendars_path));
+        auto calendars_path = TRY(LexicalPath::from_string(locale_calendars_path.view()));
         if (!calendars_path.basename().starts_with("ca-"sv))
             continue;
 
         auto calendars = TRY(read_json_file(calendars_path.string()));
         auto const& main_object = calendars.as_object().get("main"sv);
-        auto const& locale_object = main_object.as_object().get(calendars_path.parent().basename());
+        auto const& locale_object = main_object.as_object().get(TRY(calendars_path.parent()).basename());
         auto const& dates_object = locale_object.as_object().get("dates"sv);
         auto const& calendars_object = dates_object.as_object().get("calendars"sv);
 
@@ -836,8 +838,8 @@ static void fill_in_collation_keywords(CLDR& cldr, LocaleData& locale)
 
 static ErrorOr<void> parse_default_content_locales(DeprecatedString core_path, CLDR& cldr)
 {
-    LexicalPath default_content_path(move(core_path));
-    default_content_path = default_content_path.append("defaultContent.json"sv);
+    auto default_content_path = TRY(LexicalPath::from_string(core_path.view()));
+    default_content_path = TRY(default_content_path.append("defaultContent.json"sv));
 
     auto default_content = TRY(read_json_file(default_content_path.string()));
     auto const& default_content_array = default_content.as_object().get("defaultContent"sv);
@@ -918,15 +920,15 @@ static ErrorOr<void> parse_all_locales(DeprecatedString bcp47_path, DeprecatedSt
     auto numbers_iterator = TRY(path_to_dir_iterator(move(numbers_path)));
     auto dates_iterator = TRY(path_to_dir_iterator(move(dates_path)));
 
-    LexicalPath core_supplemental_path(core_path);
-    core_supplemental_path = core_supplemental_path.append("supplemental"sv);
-    VERIFY(Core::File::is_directory(core_supplemental_path.string()));
+    auto core_supplemental_path = TRY(LexicalPath::from_string(core_path));
+    core_supplemental_path = TRY(core_supplemental_path.append("supplemental"sv));
+    VERIFY(Core::File::is_directory(core_supplemental_path.string().to_deprecated_string()));
 
-    TRY(parse_core_aliases(core_supplemental_path.string(), cldr));
-    TRY(parse_likely_subtags(core_supplemental_path.string(), cldr));
+    TRY(parse_core_aliases(core_supplemental_path.string().to_deprecated_string(), cldr));
+    TRY(parse_likely_subtags(core_supplemental_path.string().to_deprecated_string(), cldr));
 
     auto remove_variants_from_path = [&](DeprecatedString path) -> ErrorOr<DeprecatedString> {
-        auto parsed_locale = TRY(CanonicalLanguageID::parse(cldr.unique_strings, LexicalPath::basename(path)));
+        auto parsed_locale = TRY(CanonicalLanguageID::parse(cldr.unique_strings, TRY(LexicalPath::basename(TRY(String::from_deprecated_string(path))))));
 
         StringBuilder builder;
         builder.append(cldr.unique_strings.get(parsed_locale.language));
@@ -971,7 +973,6 @@ static ErrorOr<void> parse_all_locales(DeprecatedString bcp47_path, DeprecatedSt
         TRY(parse_locale_scripts(locale_path, cldr, locale));
         TRY(parse_locale_calendars(locale_path, cldr, locale));
     }
-
     while (misc_iterator.has_next()) {
         auto misc_path = TRY(next_path_from_dir_iterator(misc_iterator));
         auto language = TRY(remove_variants_from_path(misc_path));

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
@@ -327,8 +327,8 @@ static ErrorOr<void> parse_plural_rules(DeprecatedString core_supplemental_path,
     static constexpr auto form_prefix = "plurals-type-"sv;
     static constexpr auto rule_prefix = "pluralRule-count-"sv;
 
-    LexicalPath plurals_path(move(core_supplemental_path));
-    plurals_path = plurals_path.append(file_name);
+    auto plurals_path = TRY(LexicalPath::from_string(core_supplemental_path.view()));
+    plurals_path = TRY(plurals_path.append(file_name));
 
     auto plurals = TRY(read_json_file(plurals_path.string()));
     auto const& supplemental_object = plurals.as_object().get("supplemental"sv);
@@ -362,8 +362,8 @@ static ErrorOr<void> parse_plural_ranges(DeprecatedString core_supplemental_path
     static constexpr auto start_segment = "-start-"sv;
     static constexpr auto end_segment = "-end-"sv;
 
-    LexicalPath plural_ranges_path(move(core_supplemental_path));
-    plural_ranges_path = plural_ranges_path.append("pluralRanges.json"sv);
+    auto plural_ranges_path = TRY(LexicalPath::from_string(core_supplemental_path.view()));
+    plural_ranges_path = TRY(plural_ranges_path.append("pluralRanges.json"sv));
 
     auto plural_ranges = TRY(read_json_file(plural_ranges_path.string()));
     auto const& supplemental_object = plural_ranges.as_object().get("supplemental"sv);
@@ -397,12 +397,12 @@ static ErrorOr<void> parse_all_locales(DeprecatedString core_path, DeprecatedStr
 {
     auto identity_iterator = TRY(path_to_dir_iterator(move(locale_names_path)));
 
-    LexicalPath core_supplemental_path(move(core_path));
-    core_supplemental_path = core_supplemental_path.append("supplemental"sv);
-    VERIFY(Core::File::is_directory(core_supplemental_path.string()));
+    auto core_supplemental_path = TRY(LexicalPath::from_string(core_path.view()));
+    core_supplemental_path = TRY(core_supplemental_path.append("supplemental"sv));
+    VERIFY(Core::File::is_directory(core_supplemental_path.string().to_deprecated_string()));
 
     auto remove_variants_from_path = [&](DeprecatedString path) -> ErrorOr<DeprecatedString> {
-        auto parsed_locale = TRY(CanonicalLanguageID::parse(cldr.unique_strings, LexicalPath::basename(path)));
+        auto parsed_locale = TRY(CanonicalLanguageID::parse(cldr.unique_strings, TRY(LexicalPath::basename(TRY(String::from_utf8(path))))));
 
         StringBuilder builder;
         builder.append(cldr.unique_strings.get(parsed_locale.language));
@@ -421,9 +421,9 @@ static ErrorOr<void> parse_all_locales(DeprecatedString core_path, DeprecatedStr
         cldr.locales.ensure(language);
     }
 
-    TRY(parse_plural_rules(core_supplemental_path.string(), "plurals.json"sv, cldr));
-    TRY(parse_plural_rules(core_supplemental_path.string(), "ordinals.json"sv, cldr));
-    TRY(parse_plural_ranges(core_supplemental_path.string(), cldr));
+    TRY(parse_plural_rules(core_supplemental_path.string().to_deprecated_string(), "plurals.json"sv, cldr));
+    TRY(parse_plural_rules(core_supplemental_path.string().to_deprecated_string(), "ordinals.json"sv, cldr));
+    TRY(parse_plural_ranges(core_supplemental_path.string().to_deprecated_string(), cldr));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
@@ -79,12 +79,12 @@ struct CLDR {
 
 static ErrorOr<void> parse_date_fields(DeprecatedString locale_dates_path, CLDR& cldr, LocaleData& locale)
 {
-    LexicalPath date_fields_path(move(locale_dates_path));
-    date_fields_path = date_fields_path.append("dateFields.json"sv);
+    auto date_fields_path = TRY(LexicalPath::from_string(locale_dates_path.view()));
+    date_fields_path = TRY(date_fields_path.append("dateFields.json"sv));
 
     auto date_fields = TRY(read_json_file(date_fields_path.string()));
     auto const& main_object = date_fields.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(date_fields_path.parent().basename());
+    auto const& locale_object = main_object.as_object().get(TRY(date_fields_path.parent()).basename());
     auto const& dates_object = locale_object.as_object().get("dates"sv);
     auto const& fields_object = dates_object.as_object().get("fields"sv);
 
@@ -141,7 +141,7 @@ static ErrorOr<void> parse_all_locales(DeprecatedString dates_path, CLDR& cldr)
     auto dates_iterator = TRY(path_to_dir_iterator(move(dates_path)));
 
     auto remove_variants_from_path = [&](DeprecatedString path) -> ErrorOr<DeprecatedString> {
-        auto parsed_locale = TRY(CanonicalLanguageID::parse(cldr.unique_strings, LexicalPath::basename(path)));
+        auto parsed_locale = TRY(CanonicalLanguageID::parse(cldr.unique_strings, TRY(LexicalPath::basename(TRY(String::from_deprecated_string(path))))));
 
         StringBuilder builder;
         builder.append(cldr.unique_strings.get(parsed_locale.language));

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateEmojiData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateEmojiData.cpp
@@ -366,7 +366,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     if (!generated_installation_path.is_empty()) {
-        TRY(Core::Directory::create(LexicalPath { generated_installation_path }.parent(), Core::Directory::CreateDirectories::Yes));
+        TRY(Core::Directory::create(TRY(TRY(LexicalPath::from_string(generated_installation_path)).parent()), Core::Directory::CreateDirectories::Yes));
 
         for (auto& emoji : emoji_data.emojis)
             set_image_path_for_emoji(emoji_resource_path, emoji);

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -344,11 +344,11 @@ inline ErrorOr<JsonValue> read_json_file(StringView path)
 
 inline ErrorOr<Core::DirIterator> path_to_dir_iterator(DeprecatedString path, StringView subpath = "main"sv)
 {
-    LexicalPath lexical_path(move(path));
+    auto lexical_path = TRY(LexicalPath::from_string(path.view()));
     if (!subpath.is_empty())
-        lexical_path = lexical_path.append(subpath);
+        lexical_path = TRY(lexical_path.append(subpath));
 
-    Core::DirIterator iterator(lexical_path.string(), Core::DirIterator::SkipParentAndBaseDir);
+    Core::DirIterator iterator(lexical_path.string().to_deprecated_string(), Core::DirIterator::SkipParentAndBaseDir);
     if (iterator.has_error()) {
         // FIXME: Make Core::DirIterator return a StringView for its error
         //        string.

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -201,12 +201,12 @@ static void generate_include_for(auto& generator, auto& path)
     for (auto& search_path : s_header_search_paths) {
         if (!path.starts_with(search_path))
             continue;
-        auto relative_path = LexicalPath::relative_path(path, search_path);
-        if (relative_path.length() < path_string.length())
-            path_string = relative_path;
+        auto relative_path = LexicalPath::relative_path(path, search_path).release_value_but_fixme_should_propagate_errors();
+        if (relative_path.code_points().length() < path_string.length())
+            path_string = relative_path.to_deprecated_string();
     }
 
-    LexicalPath include_path { path_string };
+    auto include_path = LexicalPath::from_string(path_string).release_value_but_fixme_should_propagate_errors();
     forked_generator.set("include.path", DeprecatedString::formatted("{}/{}.h", include_path.dirname(), include_path.title()));
     forked_generator.append(R"~~~(
 #include <@include.path@>

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
@@ -15,6 +15,7 @@
 #include <LibCore/Stream.h>
 #include <LibIDL/IDLParser.h>
 #include <LibIDL/Types.h>
+#include <LibMain/Main.h>
 
 extern Vector<StringView> s_header_search_paths;
 
@@ -67,7 +68,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto file = TRY(Core::Stream::File::open(path, Core::Stream::OpenMode::Read));
 
-    LexicalPath lexical_path(path);
+    auto lexical_path = TRY(LexicalPath::from_string(path));
     auto& namespace_ = lexical_path.parts_view().at(lexical_path.parts_view().size() - 2);
 
     auto data = TRY(file->read_until_eof());

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
@@ -37,7 +37,7 @@ void add_@global_object_snake_name@_exposed_interfaces(JS::Object&, JS::Realm&);
 
 )~~~");
 
-    auto generated_header_path = LexicalPath(output_path).append(DeprecatedString::formatted("{}ExposedInterfaces.h", class_name)).string();
+    auto generated_header_path = TRY(TRY(LexicalPath::from_string(output_path)).append(TRY(String::formatted("{}ExposedInterfaces.h", class_name)))).string();
     auto generated_header_file = TRY(Core::Stream::File::open(generated_header_path, Core::Stream::OpenMode::Write));
     TRY(generated_header_file->write(generator.as_string_view().bytes()));
 
@@ -123,8 +123,8 @@ void add_@global_object_snake_name@_exposed_interfaces(JS::Object& global, JS::R
 }
 }
 )~~~");
-    auto generated_implementation_path = LexicalPath(output_path).append(DeprecatedString::formatted("{}ExposedInterfaces.cpp", class_name)).string();
-    auto generated_implementation_file = TRY(Core::Stream::File::open(generated_implementation_path, Core::Stream::OpenMode::Write));
+    auto generated_implementation_path = TRY(TRY(LexicalPath::from_string(output_path)).append(DeprecatedString::formatted("{}ExposedInterfaces.cpp", class_name))).string();
+    auto generated_implementation_file = TRY(Core::Stream::File::open(generated_implementation_path.bytes_as_string_view(), Core::Stream::OpenMode::Write));
     TRY(generated_implementation_file->write(generator.as_string_view().bytes()));
 
     return {};
@@ -146,7 +146,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     VERIFY(!paths.is_empty());
     VERIFY(!base_path.is_empty());
 
-    const LexicalPath lexical_base(base_path);
+    auto const lexical_base = TRY(LexicalPath::from_string(base_path));
 
     // Read in all IDL files, we must own the storage for all of these for the lifetime of the program
     Vector<DeprecatedString> file_contents;
@@ -169,7 +169,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // TODO: service_worker_exposed
 
     for (size_t i = 0; i < paths.size(); ++i) {
-        IDL::Parser parser(paths[i], file_contents[i], lexical_base.string());
+        IDL::Parser parser(paths[i], file_contents[i], lexical_base.string().to_deprecated_string());
         TRY(add_to_interface_sets(parser.parse(), window_exposed, dedicated_worker_exposed, shared_worker_exposed));
         parsers.append(move(parser));
     }

--- a/Meta/Lagom/Tools/ConfigureComponents/main.cpp
+++ b/Meta/Lagom/Tools/ConfigureComponents/main.cpp
@@ -234,7 +234,7 @@ int main()
     auto current_working_directory = Core::File::current_working_directory();
     if (current_working_directory.is_null())
         return 1;
-    auto lexical_cwd = LexicalPath(current_working_directory);
+    auto lexical_cwd = LexicalPath::from_string(current_working_directory).release_value_but_fixme_should_propagate_errors();
     auto& parts = lexical_cwd.parts_view();
     if (parts.size() < 2 || parts[parts.size() - 2] != "Build") {
         warnln("\e[31mError:\e[0m This program needs to be executed from inside 'Build/*'.");

--- a/Tests/AK/TestLexicalPath.cpp
+++ b/Tests/AK/TestLexicalPath.cpp
@@ -12,20 +12,20 @@
 
 TEST_CASE(relative_path)
 {
-    EXPECT_EQ(LexicalPath::relative_path("/tmp/abc.txt"sv, "/tmp"sv), "abc.txt"sv);
-    EXPECT_EQ(LexicalPath::relative_path("/tmp/abc.txt"sv, "/tmp/"sv), "abc.txt"sv);
-    EXPECT_EQ(LexicalPath::relative_path("/tmp/abc.txt"sv, "/"sv), "tmp/abc.txt"sv);
-    EXPECT_EQ(LexicalPath::relative_path("/tmp/abc.txt"sv, "/usr"sv), "../tmp/abc.txt"sv);
+    EXPECT_EQ(MUST(LexicalPath::relative_path("/tmp/abc.txt"sv, "/tmp"sv)), "abc.txt"sv);
+    EXPECT_EQ(MUST(LexicalPath::relative_path("/tmp/abc.txt"sv, "/tmp/"sv)), "abc.txt"sv);
+    EXPECT_EQ(MUST(LexicalPath::relative_path("/tmp/abc.txt"sv, "/"sv)), "tmp/abc.txt"sv);
+    EXPECT_EQ(MUST(LexicalPath::relative_path("/tmp/abc.txt"sv, "/usr"sv)), "/tmp/abc.txt"sv);
 
-    EXPECT_EQ(LexicalPath::relative_path("/tmp/foo.txt"sv, "tmp"sv), ""sv);
-    EXPECT_EQ(LexicalPath::relative_path("tmp/foo.txt"sv, "/tmp"sv), ""sv);
+    EXPECT_EQ(MUST(LexicalPath::relative_path("/tmp/foo.txt"sv, "tmp"sv)), ""sv);
+    EXPECT_EQ(MUST(LexicalPath::relative_path("tmp/foo.txt"sv, "/tmp"sv)), ""sv);
 
-    EXPECT_EQ(LexicalPath::relative_path("/tmp/foo/bar/baz.txt"sv, "/tmp/bar/foo/"sv), "../../foo/bar/baz.txt"sv);
+    EXPECT_EQ(MUST(LexicalPath::relative_path("/tmp/foo/bar/baz.txt"sv, "/tmp/bar/foo/"sv)), "../../foo/bar/baz.txt"sv);
 }
 
 TEST_CASE(regular_absolute_path)
 {
-    LexicalPath path("/home/anon/foo.txt");
+    auto path = MUST(LexicalPath::from_string("/home/anon/foo.txt"sv));
     EXPECT_EQ(path.string(), "/home/anon/foo.txt");
     EXPECT_EQ(path.dirname(), "/home/anon");
     EXPECT_EQ(path.basename(), "foo.txt");
@@ -42,7 +42,7 @@ TEST_CASE(regular_absolute_path)
 
 TEST_CASE(regular_relative_path)
 {
-    LexicalPath path("anon/foo.txt");
+    auto path = MUST(LexicalPath::from_string("anon/foo.txt"sv));
     EXPECT_EQ(path.dirname(), "anon");
     EXPECT_EQ(path.basename(), "foo.txt");
     EXPECT_EQ(path.parts_view().size(), 2u);
@@ -53,22 +53,22 @@ TEST_CASE(regular_relative_path)
 TEST_CASE(single_dot)
 {
     {
-        LexicalPath path("/home/./anon/foo.txt");
+        auto path = MUST(LexicalPath::from_string("/home/./anon/foo.txt"sv));
         EXPECT_EQ(path.string(), "/home/anon/foo.txt");
     }
     {
-        LexicalPath path("./test.txt");
+        auto path = MUST(LexicalPath::from_string("./test.txt"sv));
         EXPECT_EQ(path.string(), "test.txt");
     }
     {
-        LexicalPath path("./../test.txt");
+        auto path = MUST(LexicalPath::from_string("./../test.txt"sv));
         EXPECT_EQ(path.string(), "../test.txt");
     }
 }
 
 TEST_CASE(relative_path_with_dotdot)
 {
-    LexicalPath path("anon/../../foo.txt");
+    auto path = MUST(LexicalPath::from_string("anon/../../foo.txt"sv));
     EXPECT_EQ(path.string(), "../foo.txt");
     EXPECT_EQ(path.dirname(), "..");
     EXPECT_EQ(path.basename(), "foo.txt");
@@ -80,26 +80,26 @@ TEST_CASE(relative_path_with_dotdot)
 TEST_CASE(absolute_path_with_dotdot)
 {
     {
-        LexicalPath path("/test/../foo.txt");
+        auto path = MUST(LexicalPath::from_string("/test/../foo.txt"sv));
         EXPECT_EQ(path.string(), "/foo.txt");
     }
     {
-        LexicalPath path("/../../foo.txt");
+        auto path = MUST(LexicalPath::from_string("/../../foo.txt"sv));
         EXPECT_EQ(path.string(), "/foo.txt");
     }
 }
 
 TEST_CASE(more_dotdot_paths)
 {
-    EXPECT_EQ(LexicalPath::canonicalized_path("/home/user/../../not/home"), "/not/home");
-    EXPECT_EQ(LexicalPath::canonicalized_path("/../../../../"), "/");
-    EXPECT_EQ(LexicalPath::canonicalized_path("./../../../../"), "../../../..");
-    EXPECT_EQ(LexicalPath::canonicalized_path("../../../../../"), "../../../../..");
+    EXPECT_EQ(MUST(LexicalPath::canonicalized_path(MUST(String::from_utf8("/home/user/../../not/home"sv)))), "/not/home");
+    EXPECT_EQ(MUST(LexicalPath::canonicalized_path(MUST(String::from_utf8("/../../../../"sv)))), "/");
+    EXPECT_EQ(MUST(LexicalPath::canonicalized_path(MUST(String::from_utf8("./../../../../"sv)))), "../../../..");
+    EXPECT_EQ(MUST(LexicalPath::canonicalized_path(MUST(String::from_utf8("../../../../../"sv)))), "../../../../..");
 }
 
 TEST_CASE(the_root_path)
 {
-    LexicalPath path("/");
+    auto path = MUST(LexicalPath::from_string("/"sv));
     EXPECT_EQ(path.dirname(), "/");
     EXPECT_EQ(path.basename(), "/");
     EXPECT_EQ(path.title(), "/");
@@ -108,7 +108,7 @@ TEST_CASE(the_root_path)
 
 TEST_CASE(the_dot_path)
 {
-    LexicalPath path(".");
+    auto path = MUST(LexicalPath::from_string("."sv));
     EXPECT_EQ(path.string(), ".");
     EXPECT_EQ(path.dirname(), ".");
     EXPECT_EQ(path.basename(), ".");
@@ -117,13 +117,13 @@ TEST_CASE(the_dot_path)
 
 TEST_CASE(double_slash)
 {
-    LexicalPath path("//home/anon/foo.txt");
+    auto path = MUST(LexicalPath::from_string("//home/anon/foo.txt"sv));
     EXPECT_EQ(path.string(), "/home/anon/foo.txt");
 }
 
 TEST_CASE(trailing_slash)
 {
-    LexicalPath path("/home/anon/");
+    auto path = MUST(LexicalPath::from_string("/home/anon/"sv));
     EXPECT_EQ(path.string(), "/home/anon");
     EXPECT_EQ(path.dirname(), "/home");
     EXPECT_EQ(path.basename(), "anon");
@@ -132,81 +132,81 @@ TEST_CASE(trailing_slash)
 
 TEST_CASE(resolve_absolute_path)
 {
-    EXPECT_EQ(LexicalPath::absolute_path("/home/anon", "foo.txt"), "/home/anon/foo.txt");
-    EXPECT_EQ(LexicalPath::absolute_path("/home/anon/", "foo.txt"), "/home/anon/foo.txt");
-    EXPECT_EQ(LexicalPath::absolute_path("/home/anon", "././foo.txt"), "/home/anon/foo.txt");
-    EXPECT_EQ(LexicalPath::absolute_path("/home/anon/quux", "../foo.txt"), "/home/anon/foo.txt");
-    EXPECT_EQ(LexicalPath::absolute_path("/home/anon/quux", "../test/foo.txt"), "/home/anon/test/foo.txt");
-    EXPECT_EQ(LexicalPath::absolute_path("quux", "../test/foo.txt"), "test/foo.txt");
-    EXPECT_EQ(LexicalPath::absolute_path("quux", "../../test/foo.txt"), "../test/foo.txt");
-    EXPECT_EQ(LexicalPath::absolute_path("quux/bar", "../../test/foo.txt"), "test/foo.txt");
-    EXPECT_EQ(LexicalPath::absolute_path("quux/bar/", "../../test/foo.txt"), "test/foo.txt");
+    EXPECT_EQ(MUST(LexicalPath::absolute_path("/home/anon"sv, "foo.txt"sv)), "/home/anon/foo.txt");
+    EXPECT_EQ(MUST(LexicalPath::absolute_path("/home/anon/"sv, "foo.txt"sv)), "/home/anon/foo.txt");
+    EXPECT_EQ(MUST(LexicalPath::absolute_path("/home/anon"sv, "././foo.txt"sv)), "/home/anon/foo.txt");
+    EXPECT_EQ(MUST(LexicalPath::absolute_path("/home/anon/quux"sv, "../foo.txt"sv)), "/home/anon/foo.txt");
+    EXPECT_EQ(MUST(LexicalPath::absolute_path("/home/anon/quux"sv, "../test/foo.txt"sv)), "/home/anon/test/foo.txt");
+    EXPECT_EQ(MUST(LexicalPath::absolute_path("quux"sv, "../test/foo.txt"sv)), "test/foo.txt");
+    EXPECT_EQ(MUST(LexicalPath::absolute_path("quux"sv, "../../test/foo.txt"sv)), "../test/foo.txt");
+    EXPECT_EQ(MUST(LexicalPath::absolute_path("quux/bar"sv, "../../test/foo.txt"sv)), "test/foo.txt");
+    EXPECT_EQ(MUST(LexicalPath::absolute_path("quux/bar/"sv, "../../test/foo.txt"sv)), "test/foo.txt");
 }
 
 TEST_CASE(has_extension)
 {
     {
-        LexicalPath path("/tmp/simple.png");
+        auto path = MUST(LexicalPath::from_string("/tmp/simple.png"sv));
         EXPECT(path.has_extension(".png"sv));
         EXPECT(path.has_extension(".pnG"sv));
         EXPECT(path.has_extension(".PNG"sv));
     }
 
     {
-        LexicalPath path("/TMP/SIMPLE.PNG");
+        auto path = MUST(LexicalPath::from_string("/TMP/SIMPLE.PNG"sv));
         EXPECT(path.has_extension(".png"sv));
         EXPECT(path.has_extension(".pnG"sv));
         EXPECT(path.has_extension(".PNG"sv));
     }
 
     {
-        LexicalPath path(".png");
+        auto path = MUST(LexicalPath::from_string(".png"sv));
         EXPECT(path.has_extension(".png"sv));
     }
 
     {
-        LexicalPath path("png");
+        auto path = MUST(LexicalPath::from_string("png"sv));
         EXPECT_EQ(path.has_extension(".png"sv), false);
     }
 }
 
 TEST_CASE(join)
 {
-    EXPECT_EQ(LexicalPath::join("anon"sv, "foo.txt"sv).string(), "anon/foo.txt"sv);
-    EXPECT_EQ(LexicalPath::join("/home"sv, "anon/foo.txt"sv).string(), "/home/anon/foo.txt"sv);
-    EXPECT_EQ(LexicalPath::join("/"sv, "foo.txt"sv).string(), "/foo.txt"sv);
-    EXPECT_EQ(LexicalPath::join("/home"sv, "anon"sv, "foo.txt"sv).string(), "/home/anon/foo.txt"sv);
+    EXPECT_EQ(MUST(LexicalPath::join("anon"sv, "foo.txt"sv)).string(), "anon/foo.txt"sv);
+    EXPECT_EQ(MUST(LexicalPath::join("/home"sv, "anon/foo.txt"sv)).string(), "/home/anon/foo.txt"sv);
+    EXPECT_EQ(MUST(LexicalPath::join("/"sv, "foo.txt"sv)).string(), "/foo.txt"sv);
+    EXPECT_EQ(MUST(LexicalPath::join("/home"sv, "anon"sv, "foo.txt"sv)).string(), "/home/anon/foo.txt"sv);
 }
 
 TEST_CASE(append)
 {
-    LexicalPath path("/home/anon/");
-    auto new_path = path.append("foo.txt"sv);
+    auto path = MUST(LexicalPath::from_string("/home/anon/"sv));
+    auto new_path = MUST(path.append("foo.txt"sv));
     EXPECT_EQ(new_path.string(), "/home/anon/foo.txt");
 }
 
 TEST_CASE(parent)
 {
     {
-        LexicalPath path("/home/anon/foo.txt");
-        auto parent = path.parent();
+        auto path = MUST(LexicalPath::from_string("/home/anon/foo.txt"sv));
+        auto parent = MUST(path.parent());
         EXPECT_EQ(parent.string(), "/home/anon");
     }
     {
-        LexicalPath path("anon/foo.txt");
-        auto parent = path.parent();
+        auto path = MUST(LexicalPath::from_string("anon/foo.txt"sv));
+        auto parent = MUST(path.parent());
         EXPECT_EQ(parent.string(), "anon");
     }
     {
-        LexicalPath path("foo.txt");
-        auto parent = path.parent();
+        auto path = MUST(LexicalPath::from_string("foo.txt"sv));
+        auto parent = MUST(path.parent());
         EXPECT_EQ(parent.string(), ".");
-        auto parent_of_parent = parent.parent();
+        auto parent_of_parent = MUST(parent.parent());
         EXPECT_EQ(parent_of_parent.string(), "..");
     }
     {
-        LexicalPath path("/");
-        auto parent = path.parent();
+        auto path = MUST(LexicalPath::from_string("/"sv));
+        auto parent = MUST(path.parent());
         EXPECT_EQ(parent.string(), "/");
     }
 }
@@ -214,30 +214,30 @@ TEST_CASE(parent)
 TEST_CASE(is_child_of)
 {
     {
-        LexicalPath parent("/a/parent/directory");
-        LexicalPath child("/a/parent/directory/a/child");
-        LexicalPath mismatching("/not/a/child/directory");
+        auto parent = MUST(LexicalPath::from_string("/a/parent/directory"sv));
+        auto child = MUST(LexicalPath::from_string("/a/parent/directory/a/child"sv));
+        auto mismatching = MUST(LexicalPath::from_string("/not/a/child/directory"sv));
         EXPECT(child.is_child_of(parent));
         EXPECT(child.is_child_of(child));
         EXPECT(parent.is_child_of(parent));
         EXPECT(!parent.is_child_of(child));
         EXPECT(!mismatching.is_child_of(parent));
 
-        EXPECT(parent.is_child_of(parent.parent()));
-        EXPECT(child.parent().parent().is_child_of(parent));
-        EXPECT(!child.parent().parent().parent().is_child_of(parent));
+        EXPECT(parent.is_child_of(MUST(parent.parent())));
+        EXPECT(MUST(MUST(child.parent()).parent()).is_child_of(parent));
+        EXPECT(!MUST(MUST(MUST(child.parent()).parent()).parent()).is_child_of(parent));
     }
     {
-        LexicalPath root("/");
-        EXPECT(LexicalPath("/").is_child_of(root));
-        EXPECT(LexicalPath("/any").is_child_of(root));
-        EXPECT(LexicalPath("/child/directory").is_child_of(root));
+        auto root = MUST(LexicalPath::from_string("/"sv));
+        EXPECT(MUST(LexicalPath::from_string("/"sv)).is_child_of(root));
+        EXPECT(MUST(LexicalPath::from_string("/any"sv)).is_child_of(root));
+        EXPECT(MUST(LexicalPath::from_string("/child/directory"sv)).is_child_of(root));
     }
     {
-        LexicalPath relative("folder");
-        LexicalPath relative_child("folder/sub");
-        LexicalPath absolute("/folder");
-        LexicalPath absolute_child("/folder/sub");
+        auto relative = MUST(LexicalPath::from_string("folder"sv));
+        auto relative_child = MUST(LexicalPath::from_string("folder/sub"sv));
+        auto absolute = MUST(LexicalPath::from_string("/folder"sv));
+        auto absolute_child = MUST(LexicalPath::from_string("/folder/sub"sv));
         EXPECT(relative_child.is_child_of(relative));
         EXPECT(absolute_child.is_child_of(absolute));
 

--- a/Tests/LibAudio/TestFLACSpec.cpp
+++ b/Tests/LibAudio/TestFLACSpec.cpp
@@ -50,7 +50,7 @@ struct DiscoverFLACTestsHack {
         auto test_iterator = Core::DirIterator { "./SpecTests", Core::DirIterator::Flags::SkipParentAndBaseDir };
 
         while (test_iterator.has_next()) {
-            auto file = LexicalPath { test_iterator.next_full_path() };
+            auto file = MUST(LexicalPath::from_string(test_iterator.next_full_path().view()));
             if (file.extension() == "flac"sv) {
                 Test::add_test_case_to_suite(make_ref_counted<FlacTest>(move(file)));
             }

--- a/Tests/LibCpp/test-cpp-parser.cpp
+++ b/Tests/LibCpp/test-cpp-parser.cpp
@@ -29,7 +29,7 @@ TEST_CASE(test_regression)
     while (directory_iterator.has_next()) {
         auto file_path = directory_iterator.next_full_path();
 
-        auto path = LexicalPath { file_path };
+        auto path = MUST(LexicalPath::from_string(file_path));
         if (!path.has_extension(".cpp"sv))
             continue;
 

--- a/Tests/LibCpp/test-cpp-preprocessor.cpp
+++ b/Tests/LibCpp/test-cpp-preprocessor.cpp
@@ -28,7 +28,7 @@ TEST_CASE(test_regression)
     while (directory_iterator.has_next()) {
         auto file_path = directory_iterator.next_full_path();
 
-        auto path = LexicalPath { file_path };
+        auto path = MUST(LexicalPath::from_string(file_path));
         if (!path.has_extension(".cpp"sv))
             continue;
 

--- a/Tests/LibGL/TestRender.cpp
+++ b/Tests/LibGL/TestRender.cpp
@@ -34,7 +34,7 @@ static void expect_bitmap_equals_reference(Gfx::Bitmap const& bitmap, StringView
     auto reference_filename = DeprecatedString::formatted("{}.qoi", test_name);
 
     if constexpr (SAVE_OUTPUT) {
-        auto target_path = LexicalPath("/home/anon").append(reference_filename);
+        auto target_path = MUST(MUST(LexicalPath::from_string("/home/anon"sv)).append(reference_filename));
         auto qoi_buffer = Gfx::QOIWriter::encode(bitmap);
         auto qoi_output_stream = MUST(Core::OutputFileStream::open(target_path.string()));
         auto number_of_bytes_written = qoi_output_stream.write(qoi_buffer);

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -95,7 +95,7 @@ TESTJS_RUN_FILE_FUNCTION(DeprecatedString const& test_file, JS::Interpreter& int
 
     auto start_time = Test::get_time_in_ms();
 
-    LexicalPath path(test_file);
+    auto path = MUST(LexicalPath::from_string(test_file.view()));
     auto dirname = path.dirname();
     enum {
         Early,
@@ -144,7 +144,7 @@ TESTJS_RUN_FILE_FUNCTION(DeprecatedString const& test_file, JS::Interpreter& int
     }
 
     auto test_result = test_passed ? Test::Result::Pass : Test::Result::Fail;
-    auto test_path = LexicalPath::relative_path(test_file, Test::JS::g_test_root);
+    auto test_path = MUST(LexicalPath::relative_path(test_file, Test::JS::g_test_root)).to_deprecated_string();
     auto duration_ms = Test::get_time_in_ms() - start_time;
     return Test::JS::JSFileResult {
         test_path,

--- a/Tests/LibJS/test-test262.cpp
+++ b/Tests/LibJS/test-test262.cpp
@@ -325,7 +325,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (!Core::File::is_directory(test_directory)) {
         paths.append(test_directory);
     } else {
-        Test::iterate_directory_recursively(LexicalPath::canonicalized_path(test_directory), [&](DeprecatedString const& file_path) {
+        Test::iterate_directory_recursively(TRY(LexicalPath::canonicalized_path(StringView { test_directory, strlen(test_directory) })).to_deprecated_string(), [&](DeprecatedString const& file_path) {
             if (file_path.contains("_FIXTURE"sv))
                 return;
             // FIXME: Add ignored file set

--- a/Tests/Spreadsheet/test-spreadsheet.cpp
+++ b/Tests/Spreadsheet/test-spreadsheet.cpp
@@ -35,7 +35,7 @@ TESTJS_RUN_FILE_FUNCTION(DeprecatedString const&, JS::Interpreter& interpreter, 
 #ifdef AK_OS_SERENITY
     run_file(s_spreadsheet_runtime_path);
 #else
-    run_file(LexicalPath::join(Test::JS::g_test_root, s_spreadsheet_runtime_path).string());
+    run_file(MUST(LexicalPath::join(Test::JS::g_test_root, s_spreadsheet_runtime_path)).string().to_deprecated_string());
 #endif
 
     run_file("mock.test-common.js"sv);

--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -181,12 +181,12 @@ void FileProvider::build_filesystem_cache()
                     if (S_ISLNK(st.st_mode))
                         continue;
 
-                    auto full_path = LexicalPath::join(slash, base_directory, path).string();
+                    auto full_path = MUST(LexicalPath::join(slash, base_directory, path)).string();
 
-                    m_full_path_cache.append(full_path);
+                    m_full_path_cache.append(full_path.to_deprecated_string());
 
                     if (S_ISDIR(st.st_mode)) {
-                        m_work_queue.enqueue(full_path);
+                        m_work_queue.enqueue(full_path.to_deprecated_string());
                     }
                 }
             }

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -55,7 +55,8 @@ class ResultRow final : public GUI::Button {
             if (!m_context_menu) {
                 m_context_menu = GUI::Menu::construct();
 
-                if (LexicalPath path { text() }; path.is_absolute()) {
+                if (auto path = LexicalPath::from_string(text().view()).release_value_but_fixme_should_propagate_errors();
+                    path.is_absolute()) {
                     m_context_menu->add_action(GUI::Action::create("&Show in File Manager", MUST(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-file-manager.png"sv)), [=](auto&) {
                         Desktop::Launcher::open(URL::create_with_file_scheme(path.dirname(), path.basename()));
                     }));

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -741,8 +741,8 @@ ErrorOr<void> BrowserWindow::take_screenshot(ScreenshotType type)
     if (!bitmap.is_valid())
         return Error::from_string_view("Failed to take a screenshot of the current tab"sv);
 
-    LexicalPath path { Core::StandardPaths::downloads_directory() };
-    path = path.append(Core::DateTime::now().to_deprecated_string("screenshot-%Y-%m-%d-%H-%M-%S.png"sv));
+    auto path = TRY(LexicalPath::from_string(Core::StandardPaths::downloads_directory()));
+    path = TRY(path.append(Core::DateTime::now().to_deprecated_string("screenshot-%Y-%m-%d-%H-%M-%S.png"sv)));
 
     auto encoded = TRY(Gfx::PNGWriter::encode(*bitmap.bitmap()));
 

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -64,7 +64,7 @@ void BackgroundSettingsWidget::create_frame()
 
     m_context_menu = GUI::Menu::construct();
     m_show_in_file_manager_action = GUI::Action::create("Show in File Manager", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-file-manager.png"sv).release_value_but_fixme_should_propagate_errors(), [this](GUI::Action const&) {
-        LexicalPath path { m_monitor_widget->wallpaper() };
+        auto path = LexicalPath::from_string(m_monitor_widget->wallpaper()).release_value_but_fixme_should_propagate_errors();
         Desktop::Launcher::open(URL::create_with_file_scheme(path.dirname(), path.basename()));
     });
     m_context_menu->add_action(*m_show_in_file_manager_action);

--- a/Userland/Applications/FileManager/FileUtils.cpp
+++ b/Userland/Applications/FileManager/FileUtils.cpp
@@ -21,7 +21,7 @@ void delete_paths(Vector<DeprecatedString> const& paths, bool should_confirm, GU
 {
     DeprecatedString message;
     if (paths.size() == 1) {
-        message = DeprecatedString::formatted("Are you sure you want to delete {}?", LexicalPath::basename(paths[0]));
+        message = DeprecatedString::formatted("Are you sure you want to delete {}?", LexicalPath::basename(paths[0]).release_value_but_fixme_should_propagate_errors().to_deprecated_string());
     } else {
         message = DeprecatedString::formatted("Are you sure you want to delete {} files?", paths.size());
     }

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -29,7 +29,7 @@
 PropertiesWindow::PropertiesWindow(DeprecatedString const& path, bool disable_rename, Window* parent_window)
     : Window(parent_window)
 {
-    auto lexical_path = LexicalPath(path);
+    auto lexical_path = LexicalPath::from_string(path).release_value_but_fixme_should_propagate_errors();
 
     auto& main_widget = set_main_widget<GUI::Widget>();
     main_widget.set_layout<GUI::VerticalBoxLayout>();
@@ -48,7 +48,7 @@ PropertiesWindow::PropertiesWindow(DeprecatedString const& path, bool disable_re
     general_tab.load_from_gml(properties_window_general_tab_gml);
 
     m_name = lexical_path.basename();
-    m_path = lexical_path.string();
+    m_path = lexical_path.string().to_deprecated_string();
     m_parent_path = lexical_path.dirname();
 
     m_icon = general_tab.find_descendant_of_type_named<GUI::ImageWidget>("icon");
@@ -103,7 +103,7 @@ PropertiesWindow::PropertiesWindow(DeprecatedString const& path, bool disable_re
             auto link_location = general_tab.find_descendant_of_type_named<GUI::LinkLabel>("link_location");
             link_location->set_text(link_destination);
             link_location->on_click = [link_destination] {
-                auto link_directory = LexicalPath(link_destination);
+                auto link_directory = LexicalPath::from_string(link_destination).release_value_but_fixme_should_propagate_errors();
                 Desktop::Launcher::open(URL::create_with_file_scheme(link_directory.dirname(), link_directory.basename()));
             };
         }

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -114,18 +114,18 @@ ErrorOr<void> MainWidget::create_actions()
         if (!open_path.has_value())
             return;
         if (auto result = open_file(open_path.value()); result.is_error())
-            show_error(result.error(), "Opening"sv, LexicalPath { open_path.value() }.basename());
+            show_error(result.error(), "Opening"sv, MUST(LexicalPath::from_string(open_path.value())).basename());
     });
 
     m_save_action = GUI::CommonActions::make_save_action([&](auto&) {
         if (m_path.is_empty())
             return m_save_as_action->activate();
         if (auto result = save_file(m_path); result.is_error())
-            show_error(result.error(), "Saving"sv, LexicalPath { m_path }.basename());
+            show_error(result.error(), "Saving"sv, MUST(LexicalPath::from_string(m_path)).basename());
     });
 
     m_save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
-        LexicalPath lexical_path(m_path.is_empty() ? "Untitled.font" : m_path);
+        auto lexical_path = LexicalPath::from_string(m_path.is_empty() ? "Untitled.font" : m_path).release_value_but_fixme_should_propagate_errors();
         Optional<DeprecatedString> save_path = GUI::FilePicker::get_save_filepath(window(), lexical_path.title(), lexical_path.extension());
         if (!save_path.has_value())
             return;
@@ -950,7 +950,7 @@ void MainWidget::drop_event(GUI::DropEvent& event)
             return;
 
         if (auto result = open_file(urls.first().path()); result.is_error())
-            show_error(result.error(), "Opening"sv, LexicalPath { urls.first().path() }.basename());
+            show_error(result.error(), "Opening"sv, LexicalPath::from_string(urls.first().path()).release_value_but_fixme_should_propagate_errors().basename());
     }
 }
 

--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -99,8 +99,8 @@ MainWidget::MainWidget()
     m_web_view = find_descendant_of_type_named<WebView::OutOfProcessWebView>("web_view");
     m_web_view->on_link_click = [this](auto& url, auto&, unsigned) {
         if (url.scheme() == "file") {
-            auto path = LexicalPath { url.path() };
-            if (!path.is_child_of(Manual::manual_base_path)) {
+            auto path = LexicalPath::from_string(url.path()).release_value_but_fixme_should_propagate_errors();
+            if (!path.is_child_of(LexicalPath::from_string(Manual::manual_base_path).release_value_but_fixme_should_propagate_errors())) {
                 open_external(url);
                 return;
             }

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -506,8 +506,8 @@ void HexEditorWidget::set_path(StringView path)
         m_name = {};
         m_extension = {};
     } else {
-        auto lexical_path = LexicalPath(path);
-        m_path = lexical_path.string();
+        auto lexical_path = LexicalPath::from_string(path).release_value_but_fixme_should_propagate_errors();
+        m_path = lexical_path.string().to_deprecated_string();
         m_name = lexical_path.title();
         m_extension = lexical_path.extension();
     }

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -79,8 +79,8 @@ Vector<DeprecatedString> ViewWidget::load_files_from_directory(DeprecatedString 
 {
     Vector<DeprecatedString> files_in_directory;
 
-    auto current_dir = LexicalPath(path).parent().string();
-    Core::DirIterator iterator(current_dir, Core::DirIterator::Flags::SkipDots);
+    auto current_dir = LexicalPath::from_string(path).release_value_but_fixme_should_propagate_errors().parent().release_value_but_fixme_should_propagate_errors().string();
+    Core::DirIterator iterator(current_dir.to_deprecated_string(), Core::DirIterator::Flags::SkipDots);
     while (iterator.has_next()) {
         DeprecatedString file = iterator.next_full_path();
         if (!Gfx::Bitmap::is_path_a_supported_image_format(file))

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -68,7 +68,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (response.is_error())
                 return {};
             auto file = response.release_value();
-            auto path = AK::LexicalPath(file->filename());
+            auto path = LexicalPath::from_string(file->filename()).release_value_but_fixme_should_propagate_errors();
             filename = path.basename();
             auto encoded = TRY(dump_bitmap(magnifier->current_bitmap(), path.extension()));
 

--- a/Userland/Applications/MouseSettings/ThemeWidget.cpp
+++ b/Userland/Applications/MouseSettings/ThemeWidget.cpp
@@ -61,7 +61,7 @@ void MouseCursorModel::invalidate()
 
         Cursor cursor;
         cursor.path = move(path);
-        cursor.name = LexicalPath::basename(cursor.path);
+        cursor.name = LexicalPath::basename(String::from_deprecated_string(cursor.path).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 
         // FIXME: Animated cursor bitmaps
         auto cursor_bitmap = Gfx::Bitmap::try_load_from_file(cursor.path).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -113,7 +113,7 @@ void ImageEditor::set_title(DeprecatedString title)
 void ImageEditor::set_path(DeprecatedString path)
 {
     m_path = move(path);
-    set_title(LexicalPath::title(m_path));
+    set_title(LexicalPath::title(m_path).release_value_but_fixme_should_propagate_errors().to_deprecated_string());
 }
 
 void ImageEditor::set_modified(DeprecatedString action_text)

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -164,7 +164,7 @@ bool RunWindow::run_via_launch(DeprecatedString const& run_input)
 
 DeprecatedString RunWindow::history_file_path()
 {
-    return LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", Core::StandardPaths::config_directory(), "RunHistory.txt"));
+    return LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", Core::StandardPaths::config_directory(), "RunHistory.txt")).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 ErrorOr<void> RunWindow::load_history()

--- a/Userland/Applications/SoundPlayer/AlbumCoverVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/AlbumCoverVisualizationWidget.cpp
@@ -43,12 +43,12 @@ void AlbumCoverVisualizationWidget::paint_event(GUI::PaintEvent& event)
 
 ErrorOr<NonnullRefPtr<Gfx::Bitmap>> AlbumCoverVisualizationWidget::get_album_cover(StringView const filename)
 {
-    auto directory = LexicalPath::dirname(filename);
+    auto directory = TRY(LexicalPath::dirname(TRY(String::from_utf8(filename))));
 
     static constexpr auto possible_cover_filenames = Array { "cover.png"sv, "cover.jpg"sv };
     for (auto& it : possible_cover_filenames) {
-        LexicalPath cover_path = LexicalPath::join(directory, it);
-        if (Core::File::exists(cover_path.string()))
+        LexicalPath cover_path = TRY(LexicalPath::join(directory, it));
+        if (Core::File::exists(cover_path.string().to_deprecated_string()))
             return Gfx::Bitmap::try_load_from_file(cover_path.string());
     }
 

--- a/Userland/Applications/SoundPlayer/Playlist.cpp
+++ b/Userland/Applications/SoundPlayer/Playlist.cpp
@@ -31,11 +31,11 @@ bool Playlist::load(StringView path)
 
 void Playlist::try_fill_missing_info(Vector<M3UEntry>& entries, StringView path)
 {
-    LexicalPath playlist_path(path);
+    auto playlist_path = LexicalPath::from_string(path).release_value_but_fixme_should_propagate_errors();
     Vector<M3UEntry*> to_delete;
 
     for (auto& entry : entries) {
-        if (!LexicalPath { entry.path }.is_absolute())
+        if (!LexicalPath::from_string(entry.path).release_value_but_fixme_should_propagate_errors().is_absolute())
             entry.path = DeprecatedString::formatted("{}/{}", playlist_path.dirname(), entry.path);
 
         if (!entry.extended_info->file_size_in_bytes.has_value()) {
@@ -49,7 +49,7 @@ void Playlist::try_fill_missing_info(Vector<M3UEntry>& entries, StringView path)
         }
 
         if (!entry.extended_info->track_display_title.has_value())
-            entry.extended_info->track_display_title = LexicalPath::title(entry.path);
+            entry.extended_info->track_display_title = LexicalPath::title(String::from_deprecated_string(entry.path).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 
         if (!entry.extended_info->track_length_in_seconds.has_value()) {
             // TODO: Implement embedded metadata extractor for other audio formats

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
@@ -35,7 +35,10 @@ GUI::Variant PlaylistModel::data(const GUI::ModelIndex& index, GUI::ModelRole ro
     if (role == GUI::ModelRole::Display) {
         switch (index.column()) {
         case 0:
-            return m_playlist_items[index.row()].extended_info->track_display_title.value_or(LexicalPath::title(m_playlist_items[index.row()].path));
+            return m_playlist_items[index.row()].extended_info->track_display_title.value_or(
+                LexicalPath::title(String::from_deprecated_string(m_playlist_items[index.row()].path).release_value_but_fixme_should_propagate_errors())
+                    .release_value_but_fixme_should_propagate_errors()
+                    .to_deprecated_string());
         case 1:
             return format_duration(m_playlist_items[index.row()].extended_info->track_length_in_seconds.value_or(0));
         case 2:

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -288,7 +288,11 @@ static ErrorOr<void> analyze(RefPtr<Tree> tree, SpaceAnalyzer::TreeMapWidget& tr
 static bool is_removable(DeprecatedString const& absolute_path)
 {
     VERIFY(!absolute_path.is_empty());
-    int access_result = access(LexicalPath::dirname(absolute_path).characters(), W_OK);
+    int access_result = access(LexicalPath::dirname(String::from_deprecated_string(absolute_path).release_value_but_fixme_should_propagate_errors())
+                                   .release_value_but_fixme_should_propagate_errors()
+                                   .to_deprecated_string()
+                                   .characters(),
+        W_OK);
     if (access_result != 0 && errno != EACCES)
         perror("access");
     return access_result == 0;
@@ -350,7 +354,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         Desktop::Launcher::open(URL::create_with_file_scheme(get_absolute_path_to_selected_node(treemapwidget)));
     });
     auto open_containing_folder_action = GUI::Action::create("Open Containing Folder", { Mod_Ctrl, Key_O }, open_icon, [&](auto&) {
-        LexicalPath path { get_absolute_path_to_selected_node(treemapwidget) };
+        auto path = LexicalPath::from_string(get_absolute_path_to_selected_node(treemapwidget).view()).release_value_but_fixme_should_propagate_errors();
         Desktop::Launcher::open(URL::create_with_file_scheme(path.dirname(), path.basename()));
     });
 

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -83,7 +83,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
     m_webview->on_link_click = [this](auto& url, auto&, auto&&) {
         VERIFY(url.scheme() == "spreadsheet");
         if (url.host() == "example") {
-            auto entry = LexicalPath::basename(url.path());
+            auto entry = LexicalPath::basename(url.path()).release_value_but_fixme_should_propagate_errors();
             auto doc_option = m_docs.get(entry);
             if (!doc_option.is_object()) {
                 GUI::MessageBox::show_error(this, DeprecatedString::formatted("No documentation entry found for '{}'", url.path()));
@@ -121,7 +121,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
             widget.add_sheet(sheet.release_nonnull());
             window->show();
         } else if (url.host() == "doc") {
-            auto entry = LexicalPath::basename(url.path());
+            auto entry = LexicalPath::basename(url.path()).release_value_but_fixme_should_propagate_errors();
             m_webview->load(URL::create_with_data("text/html", render(entry)));
         } else {
             dbgln("Invalid spreadsheet action domain '{}'", url.host());

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -675,8 +675,8 @@ void MainWidget::set_path(StringView path)
         m_name = {};
         m_extension = {};
     } else {
-        auto lexical_path = LexicalPath(path);
-        m_path = lexical_path.string();
+        auto lexical_path = LexicalPath::from_string(path).release_value_but_fixme_should_propagate_errors();
+        m_path = lexical_path.string().to_deprecated_string();
         m_name = lexical_path.title();
         m_extension = lexical_path.extension();
     }

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -551,7 +551,7 @@ void MainWidget::show_path_picker_dialog(StringView property_display_name, GUI::
     auto target_path = path_input.text();
     if (Core::File::exists(target_path)) {
         if (!Core::File::is_directory(target_path))
-            target_path = LexicalPath::dirname(target_path);
+            target_path = LexicalPath::dirname(target_path).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
     } else {
         target_path = "/res/icons";
     }

--- a/Userland/BuggieBox/main.cpp
+++ b/Userland/BuggieBox/main.cpp
@@ -90,7 +90,7 @@ static ErrorOr<int> buggiebox_main(Main::Arguments arguments)
         return 1;
     }
     bool found_runner = false;
-    LexicalPath runbase { arguments.strings[0] };
+    auto runbase = TRY(LexicalPath::from_string(arguments.strings[0]));
     auto result = TRY(run_program(arguments, runbase, found_runner));
     if (!found_runner)
         fail();
@@ -99,7 +99,7 @@ static ErrorOr<int> buggiebox_main(Main::Arguments arguments)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    LexicalPath runbase { arguments.strings[0] };
+    auto runbase = TRY(LexicalPath::from_string(arguments.strings[0]));
     if (runbase.basename() == "BuggieBox"sv) {
         Main::Arguments utility_arguments = arguments;
         utility_arguments.argc--;

--- a/Userland/Demos/WidgetGallery/GalleryModels.h
+++ b/Userland/Demos/WidgetGallery/GalleryModels.h
@@ -70,7 +70,7 @@ public:
                 continue;
             Cursor cursor;
             cursor.path = move(path);
-            cursor.name = LexicalPath::basename(cursor.path);
+            cursor.name = LexicalPath::basename(cursor.path).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 
             // FIXME: Animated cursor bitmaps
             auto cursor_bitmap = Gfx::Bitmap::try_load_from_file(cursor.path).release_value_but_fixme_should_propagate_errors();
@@ -159,7 +159,7 @@ public:
                 continue;
             IconSet icon_set;
             icon_set.big_icon = Gfx::Bitmap::try_load_from_file(path).release_value_but_fixme_should_propagate_errors();
-            icon_set.name = LexicalPath::basename(path);
+            icon_set.name = LexicalPath::basename(path).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
             m_icon_sets.append(move(icon_set));
         }
 
@@ -173,7 +173,7 @@ public:
                 continue;
             IconSet icon_set;
             icon_set.little_icon = Gfx::Bitmap::try_load_from_file(path).release_value_but_fixme_should_propagate_errors();
-            icon_set.name = LexicalPath::basename(path);
+            icon_set.name = LexicalPath::basename(path).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
             for (size_t i = 0; i < big_icons_found; i++) {
                 if (icon_set.name == m_icon_sets[i].name) {
                     m_icon_sets[i].little_icon = icon_set.little_icon;

--- a/Userland/DevTools/HackStudio/CodeDocument.cpp
+++ b/Userland/DevTools/HackStudio/CodeDocument.cpp
@@ -23,7 +23,7 @@ CodeDocument::CodeDocument(DeprecatedString const& file_path, Client* client)
     : TextDocument(client)
     , m_file_path(file_path)
 {
-    auto lexical_path = LexicalPath(file_path);
+    auto lexical_path = LexicalPath::from_string(file_path).release_value_but_fixme_should_propagate_errors();
     m_language = language_from_file(lexical_path);
     m_language_name = language_name_from_file(lexical_path);
 }

--- a/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
@@ -96,7 +96,7 @@ Debug::DebugInfo::SourcePosition Debugger::create_source_position(DeprecatedStri
 {
     if (file.starts_with('/'))
         return { file, line + 1 };
-    return { LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", m_source_root, file)), line + 1 };
+    return { LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", m_source_root, file)).release_value_but_fixme_should_propagate_errors().to_deprecated_string(), line + 1 };
 }
 
 intptr_t Debugger::start_static()

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
@@ -169,7 +169,7 @@ Optional<DeprecatedString> NewProjectDialog::get_project_full_path()
     if (!maybe_project_name.has_value())
         return {};
 
-    return LexicalPath::join(create_in, *maybe_project_name).string();
+    return LexicalPath::join(create_in, *maybe_project_name).release_value_but_fixme_should_propagate_errors().string().to_deprecated_string();
 }
 
 void NewProjectDialog::do_create_project()

--- a/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
@@ -116,11 +116,11 @@ void ProjectTemplatesModel::rescan_templates()
     }
 
     while (di.has_next()) {
-        auto full_path = LexicalPath(di.next_full_path());
+        auto full_path = LexicalPath::from_string(di.next_full_path()).release_value_but_fixme_should_propagate_errors();
         if (!full_path.has_extension(".ini"sv))
             continue;
 
-        auto project_template = ProjectTemplate::load_from_manifest(full_path.string());
+        auto project_template = ProjectTemplate::load_from_manifest(full_path.string().to_deprecated_string());
         if (!project_template) {
             warnln("Template manifest {} is invalid.", full_path.string());
             continue;

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -205,7 +205,7 @@ static HashMap<DeprecatedString, DeprecatedString>& man_paths()
             Core::DirIterator it(json_value.as_string(), Core::DirIterator::Flags::SkipDots);
             while (it.has_next()) {
                 auto path = it.next_full_path();
-                auto title = LexicalPath::title(path);
+                auto title = LexicalPath::title(path).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
                 paths.set(title, path);
             }
         }

--- a/Userland/DevTools/HackStudio/Git/GitRepo.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitRepo.cpp
@@ -80,7 +80,7 @@ DeprecatedString GitRepo::command(Vector<DeprecatedString> const& command_parts)
 
 DeprecatedString GitRepo::command_wrapper(Vector<DeprecatedString> const& command_parts, DeprecatedString const& chdir)
 {
-    auto result = Core::command("git", command_parts, LexicalPath(chdir));
+    auto result = Core::command("git", command_parts, LexicalPath::from_string(chdir).release_value_but_fixme_should_propagate_errors());
     if (result.is_error() || result.value().exit_code != 0)
         return {};
     return result.value().output;

--- a/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
@@ -60,12 +60,16 @@ bool FileDB::add(DeprecatedString const& filename, int fd)
 
 DeprecatedString FileDB::to_absolute_path(DeprecatedString const& filename) const
 {
-    if (LexicalPath { filename }.is_absolute()) {
+    if (LexicalPath::from_string(filename.view()).release_value_but_fixme_should_propagate_errors().is_absolute()) {
         return filename;
     }
     if (m_project_root.is_null())
         return filename;
-    return LexicalPath { DeprecatedString::formatted("{}/{}", m_project_root, filename) }.string();
+    return LexicalPath::from_string(String::formatted("{}/{}", m_project_root, filename)
+                                        .release_value_but_fixme_should_propagate_errors())
+        .release_value_but_fixme_should_propagate_errors()
+        .string()
+        .to_deprecated_string();
 }
 
 RefPtr<GUI::TextDocument> FileDB::create_from_filesystem(DeprecatedString const& filename) const

--- a/Userland/DevTools/HackStudio/Project.cpp
+++ b/Userland/DevTools/HackStudio/Project.cpp
@@ -53,10 +53,10 @@ NonnullRefPtr<ProjectFile> Project::create_file(DeprecatedString const& path) co
 
 DeprecatedString Project::to_absolute_path(DeprecatedString const& path) const
 {
-    if (LexicalPath { path }.is_absolute()) {
+    if (LexicalPath::from_string(path).release_value_but_fixme_should_propagate_errors().is_absolute()) {
         return path;
     }
-    return LexicalPath { DeprecatedString::formatted("{}/{}", m_root_path, path) }.string();
+    return LexicalPath::from_string(DeprecatedString::formatted("{}/{}", m_root_path, path)).release_value_but_fixme_should_propagate_errors().string().to_deprecated_string();
 }
 
 bool Project::project_is_serenity() const
@@ -68,7 +68,7 @@ bool Project::project_is_serenity() const
 
 NonnullOwnPtr<ProjectConfig> Project::config() const
 {
-    auto config_or_error = ProjectConfig::try_load_project_config(LexicalPath::absolute_path(m_root_path, config_file_path));
+    auto config_or_error = ProjectConfig::try_load_project_config(LexicalPath::absolute_path(m_root_path, config_file_path).release_value_but_fixme_should_propagate_errors().to_deprecated_string());
     if (config_or_error.is_error())
         return ProjectConfig::create_empty();
 

--- a/Userland/DevTools/HackStudio/Project.h
+++ b/Userland/DevTools/HackStudio/Project.h
@@ -24,7 +24,7 @@ public:
 
     GUI::FileSystemModel& model() { return *m_model; }
     const GUI::FileSystemModel& model() const { return *m_model; }
-    DeprecatedString name() const { return LexicalPath::basename(m_root_path); }
+    DeprecatedString name() const { return LexicalPath::basename(m_root_path).release_value_but_fixme_should_propagate_errors().to_deprecated_string(); }
     DeprecatedString root_path() const { return m_root_path; }
 
     NonnullRefPtr<ProjectFile> create_file(DeprecatedString const& path) const;

--- a/Userland/DevTools/HackStudio/ProjectTemplate.h
+++ b/Userland/DevTools/HackStudio/ProjectTemplate.h
@@ -30,9 +30,9 @@ public:
     DeprecatedString const& name() const { return m_name; }
     DeprecatedString const& description() const { return m_description; }
     const GUI::Icon& icon() const { return m_icon; }
-    const DeprecatedString content_path() const
+    DeprecatedString content_path() const
     {
-        return LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", templates_path(), m_id));
+        return LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", templates_path(), m_id)).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
     }
     int priority() const { return m_priority; }
 

--- a/Userland/DevTools/Profiler/FilesystemEventModel.cpp
+++ b/Userland/DevTools/Profiler/FilesystemEventModel.cpp
@@ -30,8 +30,8 @@ FileEventNode& FileEventNode::find_or_create_node(DeprecatedString const& search
         return *this;
     }
 
-    auto lex_path = LexicalPath(searched_path);
-    auto parts = lex_path.parts();
+    auto lex_path = LexicalPath::from_string(searched_path).release_value_but_fixme_should_propagate_errors();
+    auto parts = lex_path.parts().release_value_but_fixme_should_propagate_errors();
     auto current = parts.take_first();
 
     StringBuilder sb;
@@ -39,14 +39,14 @@ FileEventNode& FileEventNode::find_or_create_node(DeprecatedString const& search
     auto new_s = sb.to_deprecated_string();
 
     for (auto& child : m_children) {
-        if (child->m_path == current) {
+        if (child->m_path == current.to_deprecated_string()) {
             return child->find_or_create_node(new_s);
         }
     }
 
     if (m_parent) {
         for (auto& child : m_children) {
-            if (child->m_path == current) {
+            if (child->m_path == current.to_deprecated_string()) {
                 return child->find_or_create_node(new_s);
             }
         }
@@ -63,15 +63,15 @@ FileEventNode& FileEventNode::find_or_create_node(DeprecatedString const& search
 
 FileEventNode& FileEventNode::create_recursively(DeprecatedString new_path)
 {
-    auto const lex_path = LexicalPath(new_path);
-    auto parts = lex_path.parts();
+    auto const lex_path = LexicalPath::from_string(new_path).release_value_but_fixme_should_propagate_errors();
+    auto parts = lex_path.parts().release_value_but_fixme_should_propagate_errors();
 
     if (parts.size() == 1) {
         auto new_node = FileEventNode::create(new_path, this);
         m_children.append(new_node);
         return *new_node.ptr();
     } else {
-        auto new_node = FileEventNode::create(parts.take_first(), this);
+        auto new_node = FileEventNode::create(parts.take_first().to_deprecated_string(), this);
         m_children.append(new_node);
 
         StringBuilder sb;

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -337,7 +337,7 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
             auto sampled_process = adopt_own(*new Process {
                 .pid = event.pid,
                 .executable = executable,
-                .basename = LexicalPath::basename(executable),
+                .basename = TRY(LexicalPath::basename(TRY(String::from_deprecated_string(executable)))).bytes_as_string_view(),
                 .start_valid = event.serial,
                 .end_valid = {},
             });
@@ -359,7 +359,7 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
             auto sampled_process = adopt_own(*new Process {
                 .pid = event.pid,
                 .executable = executable,
-                .basename = LexicalPath::basename(executable),
+                .basename = TRY(LexicalPath::basename(TRY(String::from_deprecated_string(executable)))).bytes_as_string_view(),
                 .start_valid = event.serial,
                 .end_valid = {},
             });
@@ -624,7 +624,7 @@ ProfileNode::ProfileNode(Process const& process, FlyString const& object_name, D
     } else {
         object = object_name;
     }
-    m_object_name = LexicalPath::basename(object);
+    m_object_name = LexicalPath::basename(String::from_deprecated_string(object).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 }

--- a/Userland/DevTools/Profiler/TimelineHeader.cpp
+++ b/Userland/DevTools/Profiler/TimelineHeader.cpp
@@ -25,7 +25,7 @@ TimelineHeader::TimelineHeader(Profile& profile, Process const& process)
     update_selection();
 
     m_icon = GUI::FileIconProvider::icon_for_executable(m_process.executable).bitmap_for_size(32);
-    m_text = DeprecatedString::formatted("{} ({})", LexicalPath::basename(m_process.executable), m_process.pid);
+    m_text = DeprecatedString::formatted("{} ({})", LexicalPath::basename(String::from_utf8(m_process.executable).release_value_but_fixme_should_propagate_errors()), m_process.pid);
 }
 
 void TimelineHeader::paint_event(GUI::PaintEvent& event)

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -44,7 +44,7 @@ MainWidget::MainWidget()
         auto maybe_load_path = GUI::FilePicker::get_open_filepath(window());
         if (!maybe_load_path.has_value())
             return;
-        auto lexical_path = LexicalPath(maybe_load_path.release_value());
+        auto lexical_path = LexicalPath::from_string(maybe_load_path.release_value()).release_value_but_fixme_should_propagate_errors();
         open_script_from_file(lexical_path);
     });
 
@@ -431,7 +431,7 @@ void MainWidget::drop_event(GUI::DropEvent& drop_event)
             if (!scheme.equals_ignoring_case("file"sv))
                 continue;
 
-            auto lexical_path = LexicalPath(url.path());
+            auto lexical_path = LexicalPath::from_string(url.path()).release_value_but_fixme_should_propagate_errors();
             if (lexical_path.extension().equals_ignoring_case("sql"sv))
                 open_script_from_file(lexical_path);
             if (lexical_path.extension().equals_ignoring_case("db"sv))

--- a/Userland/DevTools/SQLStudio/ScriptEditor.cpp
+++ b/Userland/DevTools/SQLStudio/ScriptEditor.cpp
@@ -32,7 +32,7 @@ ErrorOr<void> ScriptEditor::open_script_from_file(LexicalPath const& file_path)
     auto buffer = TRY(file->read_until_eof());
 
     set_text({ buffer.bytes() });
-    m_path = file_path.string();
+    m_path = file_path.string().to_deprecated_string();
     set_name(file_path.title());
     return {};
 }
@@ -63,7 +63,7 @@ ErrorOr<bool> ScriptEditor::save_as()
 
     m_path = save_path;
 
-    auto lexical_path = LexicalPath(save_path);
+    auto lexical_path = TRY(LexicalPath::from_string(save_path));
     set_name(lexical_path.title());
 
     auto parent = static_cast<GUI::TabWidget*>(parent_widget());

--- a/Userland/DevTools/SQLStudio/main.cpp
+++ b/Userland/DevTools/SQLStudio/main.cpp
@@ -41,7 +41,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto needs_new_script = true;
     if (file_to_open) {
-        auto path = LexicalPath(file_to_open);
+        auto path = TRY(LexicalPath::from_string({ file_to_open, strlen(file_to_open) }));
         if (path.extension().equals_ignoring_case("sql"sv)) {
             main_widget->open_script_from_file(path);
             needs_new_script = false;

--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -487,7 +487,7 @@ DeprecatedString Emulator::create_backtrace_line(FlatPtr address)
     }
 
     auto const& source_position = maybe_symbol->source_position.value();
-    return DeprecatedString::formatted("=={}==    {:p}  [{}]: {} (\e[34;1m{}\e[0m:{})", getpid(), address, maybe_symbol->lib_name, maybe_symbol->symbol, LexicalPath::basename(source_position.file_path), source_position.line_number);
+    return DeprecatedString::formatted("=={}==    {:p}  [{}]: {} (\e[34;1m{}\e[0m:{})", getpid(), address, maybe_symbol->lib_name, maybe_symbol->symbol, LexicalPath::basename(source_position.file_path).release_value_but_fixme_should_propagate_errors(), source_position.line_number);
 }
 
 void Emulator::dump_backtrace(Vector<FlatPtr> const& backtrace)
@@ -531,7 +531,7 @@ DeprecatedString Emulator::create_instruction_line(FlatPtr address, X86::Instruc
     if (!symbol.has_value() || !symbol->source_position.has_value())
         return DeprecatedString::formatted("{:p}: {}", address, insn.to_deprecated_string(address));
 
-    return DeprecatedString::formatted("{:p}: {} \e[34;1m{}\e[0m:{}", address, insn.to_deprecated_string(address), LexicalPath::basename(symbol->source_position->file_path), symbol->source_position.value().line_number);
+    return DeprecatedString::formatted("{:p}: {} \e[34;1m{}\e[0m:{}", address, insn.to_deprecated_string(address), LexicalPath::basename(symbol->source_position->file_path).release_value_but_fixme_should_propagate_errors(), symbol->source_position.value().line_number);
 }
 
 static void emulator_signal_handler(int signum, siginfo_t* signal_info, void* context)

--- a/Userland/DevTools/UserspaceEmulator/main.cpp
+++ b/Userland/DevTools/UserspaceEmulator/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv, char** env)
     }
 
     if (dump_profile && profile_dump_path.is_empty())
-        profile_dump_path = DeprecatedString::formatted("{}.{}.profile", LexicalPath(executable_path).basename(), getpid());
+        profile_dump_path = DeprecatedString::formatted("{}.{}.profile", LexicalPath::from_string(executable_path.view()).release_value_but_fixme_should_propagate_errors().basename(), getpid());
 
     OwnPtr<OutputFileStream> profile_stream;
     OwnPtr<NonnullOwnPtrVector<DeprecatedString>> profile_strings;
@@ -99,7 +99,7 @@ int main(int argc, char** argv, char** env)
 
     StringBuilder builder;
     builder.append("(UE) "sv);
-    builder.append(LexicalPath::basename(arguments[0]));
+    builder.append(LexicalPath::basename(arguments[0]).release_value_but_fixme_should_propagate_errors());
     if (set_process_name(builder.string_view().characters_without_null_termination(), builder.string_view().length()) < 0) {
         perror("set_process_name");
         return 1;

--- a/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.cpp
@@ -722,10 +722,10 @@ Optional<Vector<CodeComprehension::AutocompleteResultEntry>> CppComprehensionEng
         include_dir = partial_include.substring_view(1, last_slash.value());
     }
 
-    auto full_dir = LexicalPath::join(include_root, include_dir).string();
+    auto full_dir = LexicalPath::join(include_root, include_dir).release_value_but_fixme_should_propagate_errors().string();
     dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "searching path: {}, partial_basename: {}", full_dir, partial_basename);
 
-    Core::DirIterator it(full_dir, Core::DirIterator::Flags::SkipDots);
+    Core::DirIterator it(full_dir.to_deprecated_string(), Core::DirIterator::Flags::SkipDots);
     Vector<CodeComprehension::AutocompleteResultEntry> options;
 
     auto prefix = include_type == System ? "<" : "\"";
@@ -736,7 +736,7 @@ Optional<Vector<CodeComprehension::AutocompleteResultEntry>> CppComprehensionEng
         if (!path.starts_with(partial_basename))
             continue;
 
-        if (Core::File::is_directory(LexicalPath::join(full_dir, path).string())) {
+        if (Core::File::is_directory(LexicalPath::join(full_dir, path).release_value_but_fixme_should_propagate_errors().string().to_deprecated_string())) {
             // FIXME: Don't dismiss the autocomplete when filling these suggestions.
             auto completion = DeprecatedString::formatted("{}{}{}/", prefix, include_dir, path);
             options.empend(completion, include_dir.length() + partial_basename.length() + 1, CodeComprehension::Language::Cpp, path, CodeComprehension::AutocompleteResultEntry::HideAutocompleteAfterApplying::No);

--- a/Userland/Libraries/LibCodeComprehension/FileDB.cpp
+++ b/Userland/Libraries/LibCodeComprehension/FileDB.cpp
@@ -11,12 +11,12 @@ namespace CodeComprehension {
 
 DeprecatedString FileDB::to_absolute_path(StringView filename) const
 {
-    if (LexicalPath { filename }.is_absolute()) {
+    if (LexicalPath::from_string(filename).release_value_but_fixme_should_propagate_errors().is_absolute()) {
         return filename;
     }
     if (m_project_root.is_null())
         return filename;
-    return LexicalPath { DeprecatedString::formatted("{}/{}", m_project_root, filename) }.string();
+    return LexicalPath::from_string(String::formatted("{}/{}", m_project_root, filename).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors().string().to_deprecated_string();
 }
 
 }

--- a/Userland/Libraries/LibCore/Command.cpp
+++ b/Userland/Libraries/LibCore/Command.cpp
@@ -57,7 +57,7 @@ ErrorOr<CommandResult> command(DeprecatedString const& program, Vector<Deprecate
     posix_spawn_file_actions_t action;
     posix_spawn_file_actions_init(&action);
     if (chdir.has_value()) {
-        posix_spawn_file_actions_addchdir(&action, chdir.value().string().characters());
+        posix_spawn_file_actions_addchdir(&action, chdir.value().string().to_deprecated_string().characters());
     }
     posix_spawn_file_actions_adddup2(&action, stdout_pipe[1], STDOUT_FILENO);
     posix_spawn_file_actions_adddup2(&action, stderr_pipe[1], STDERR_FILENO);

--- a/Userland/Libraries/LibCore/Directory.cpp
+++ b/Userland/Libraries/LibCore/Directory.cpp
@@ -55,7 +55,7 @@ ErrorOr<Directory> Directory::adopt_fd(int fd, Optional<LexicalPath> path)
 
 ErrorOr<Directory> Directory::create(DeprecatedString path, CreateDirectories create_directories, mode_t creation_mode)
 {
-    return create(LexicalPath { move(path) }, create_directories, creation_mode);
+    return create(TRY(LexicalPath::from_string(path.view())), create_directories, creation_mode);
 }
 
 ErrorOr<Directory> Directory::create(LexicalPath path, CreateDirectories create_directories, mode_t creation_mode)
@@ -72,7 +72,7 @@ ErrorOr<void> Directory::ensure_directory(LexicalPath const& path, mode_t creati
     if (path.basename() == "/" || path.basename() == ".")
         return {};
 
-    TRY(ensure_directory(path.parent(), creation_mode));
+    TRY(ensure_directory(TRY(path.parent()), creation_mode));
 
     auto return_value = System::mkdir(path.string(), creation_mode);
     // We don't care if the directory already exists.
@@ -102,7 +102,7 @@ ErrorOr<struct stat> Directory::stat() const
 
 ErrorOr<DirIterator> Directory::create_iterator() const
 {
-    return DirIterator { TRY(path()).string() };
+    return DirIterator { TRY(path()).string().to_deprecated_string() };
 }
 
 }

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -77,6 +77,11 @@ public:
     };
 
     struct CopyError : public Error {
+        CopyError(Error&& error)
+            : Error(error.code())
+        {
+        }
+
         CopyError(int error_code, bool t)
             : Error(error_code)
             , tried_recursing(t)

--- a/Userland/Libraries/LibCore/FileWatcher.cpp
+++ b/Userland/Libraries/LibCore/FileWatcher.cpp
@@ -68,7 +68,7 @@ static Optional<FileWatcherEvent> get_event_from_fd(int fd, HashMap<unsigned, De
     // We trust that the kernel only sends the name when appropriate.
     if (event->name_length > 0) {
         DeprecatedString child_name { event->name, event->name_length - 1 };
-        result.event_path = LexicalPath::join(path, child_name).string();
+        result.event_path = LexicalPath::join(path, child_name).release_value_but_fixme_should_propagate_errors().string().to_deprecated_string();
     } else {
         result.event_path = path;
     }
@@ -80,10 +80,10 @@ static Optional<FileWatcherEvent> get_event_from_fd(int fd, HashMap<unsigned, De
 static DeprecatedString canonicalize_path(DeprecatedString path)
 {
     if (!path.is_empty() && path[0] == '/')
-        return LexicalPath::canonicalized_path(move(path));
+        return LexicalPath::canonicalized_path(move(path)).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
     char* cwd = getcwd(nullptr, 0);
     VERIFY(cwd);
-    return LexicalPath::join({ cwd, strlen(cwd) }, move(path)).string();
+    return LexicalPath::join({ cwd, strlen(cwd) }, move(path)).release_value_but_fixme_should_propagate_errors().string().to_deprecated_string();
 }
 
 ErrorOr<bool> FileWatcherBase::add_watch(DeprecatedString path, FileWatcherEvent::Type event_mask)

--- a/Userland/Libraries/LibCore/LockFile.cpp
+++ b/Userland/Libraries/LibCore/LockFile.cpp
@@ -16,7 +16,12 @@ namespace Core {
 LockFile::LockFile(char const* filename, Type type)
     : m_filename(filename)
 {
-    if (Core::Directory::create(LexicalPath(m_filename).parent(), Core::Directory::CreateDirectories::Yes).is_error())
+    if (Core::Directory::create(LexicalPath::from_string(StringView { m_filename, strlen(m_filename) })
+                                    .release_value_but_fixme_should_propagate_errors()
+                                    .parent()
+                                    .release_value_but_fixme_should_propagate_errors(),
+            Core::Directory::CreateDirectories::Yes)
+            .is_error())
         return;
 
     m_fd = open(filename, O_RDONLY | O_CREAT | O_CLOEXEC, 0666);

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -92,7 +92,7 @@ DeprecatedString guess_mime_type_based_on_filename(StringView path)
     if (path.ends_with(".sheets"sv, CaseSensitivity::CaseInsensitive))
         return "application/x-sheets+json";
     // FIXME: Share this, TextEditor and HackStudio language detection somehow.
-    auto basename = LexicalPath::basename(path);
+    auto basename = LexicalPath::basename(String::from_utf8(path).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors();
     if (path.ends_with(".cpp"sv, CaseSensitivity::CaseInsensitive)
         || path.ends_with(".c"sv, CaseSensitivity::CaseInsensitive)
         || path.ends_with(".hpp"sv, CaseSensitivity::CaseInsensitive)

--- a/Userland/Libraries/LibCore/StandardPaths.cpp
+++ b/Userland/Libraries/LibCore/StandardPaths.cpp
@@ -19,12 +19,12 @@ namespace Core {
 DeprecatedString StandardPaths::home_directory()
 {
     if (auto* home_env = getenv("HOME"))
-        return LexicalPath::canonicalized_path(home_env);
+        return LexicalPath::canonicalized_path(StringView { home_env, strlen(home_env) }).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 
     auto* pwd = getpwuid(getuid());
     DeprecatedString path = pwd ? pwd->pw_dir : "/";
     endpwent();
-    return LexicalPath::canonicalized_path(path);
+    return LexicalPath::canonicalized_path(path.view()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 DeprecatedString StandardPaths::desktop_directory()
@@ -32,7 +32,7 @@ DeprecatedString StandardPaths::desktop_directory()
     StringBuilder builder;
     builder.append(home_directory());
     builder.append("/Desktop"sv);
-    return LexicalPath::canonicalized_path(builder.to_deprecated_string());
+    return LexicalPath::canonicalized_path(builder.string_view()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 DeprecatedString StandardPaths::documents_directory()
@@ -40,7 +40,7 @@ DeprecatedString StandardPaths::documents_directory()
     StringBuilder builder;
     builder.append(home_directory());
     builder.append("/Documents"sv);
-    return LexicalPath::canonicalized_path(builder.to_deprecated_string());
+    return LexicalPath::canonicalized_path(builder.string_view()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 DeprecatedString StandardPaths::downloads_directory()
@@ -48,13 +48,13 @@ DeprecatedString StandardPaths::downloads_directory()
     StringBuilder builder;
     builder.append(home_directory());
     builder.append("/Downloads"sv);
-    return LexicalPath::canonicalized_path(builder.to_deprecated_string());
+    return LexicalPath::canonicalized_path(builder.string_view()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 DeprecatedString StandardPaths::config_directory()
 {
     if (auto* config_directory = getenv("XDG_CONFIG_HOME"))
-        return LexicalPath::canonicalized_path(config_directory);
+        return LexicalPath::canonicalized_path(StringView { config_directory, strlen(config_directory) }).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 
     StringBuilder builder;
     builder.append(home_directory());
@@ -63,13 +63,13 @@ DeprecatedString StandardPaths::config_directory()
 #else
     builder.append("/.config"sv);
 #endif
-    return LexicalPath::canonicalized_path(builder.to_deprecated_string());
+    return LexicalPath::canonicalized_path(builder.to_deprecated_string()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 DeprecatedString StandardPaths::data_directory()
 {
     if (auto* data_directory = getenv("XDG_DATA_HOME"))
-        return LexicalPath::canonicalized_path(data_directory);
+        return LexicalPath::canonicalized_path(StringView { data_directory, strlen(data_directory) }).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 
     StringBuilder builder;
     builder.append(home_directory());
@@ -81,13 +81,13 @@ DeprecatedString StandardPaths::data_directory()
     builder.append("/.local/share"sv);
 #endif
 
-    return LexicalPath::canonicalized_path(builder.to_deprecated_string());
+    return LexicalPath::canonicalized_path(builder.string_view()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 ErrorOr<DeprecatedString> StandardPaths::runtime_directory()
 {
     if (auto* data_directory = getenv("XDG_RUNTIME_DIR"))
-        return LexicalPath::canonicalized_path(data_directory);
+        return TRY(LexicalPath::canonicalized_path({ data_directory, strlen(data_directory) })).to_deprecated_string();
 
     StringBuilder builder;
 
@@ -102,7 +102,7 @@ ErrorOr<DeprecatedString> StandardPaths::runtime_directory()
     builder.appendff("/run/user/{}", uid);
 #endif
 
-    return LexicalPath::canonicalized_path(builder.to_deprecated_string());
+    return TRY(LexicalPath::canonicalized_path(builder.to_deprecated_string())).to_deprecated_string();
 }
 
 DeprecatedString StandardPaths::tempfile_directory()

--- a/Userland/Libraries/LibCoredump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoredump/Backtrace.cpp
@@ -153,7 +153,7 @@ DeprecatedString Backtrace::Entry::to_deprecated_string(bool color) const
     for (size_t i = 0; i < source_positions.size(); ++i) {
         auto& position = source_positions[i];
         auto fmt = color ? "\033[34;1m{}\033[0m:{}"sv : "{}:{}"sv;
-        builder.appendff(fmt, LexicalPath::basename(position.file_path), position.line_number);
+        builder.appendff(fmt, LexicalPath::basename(String::from_utf8(position.file_path.view()).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors(), position.line_number);
         if (i != source_positions.size() - 1) {
             builder.append(" => "sv);
         }

--- a/Userland/Libraries/LibCoredump/Reader.cpp
+++ b/Userland/Libraries/LibCoredump/Reader.cpp
@@ -323,12 +323,12 @@ DeprecatedString Reader::resolve_object_path(StringView name) const
 
     // Search for the first readable library file
     for (auto& directory : library_search_directories) {
-        auto full_path = LexicalPath::join(directory, name).string();
+        auto full_path = LexicalPath::join(directory, name).release_value_but_fixme_should_propagate_errors().string();
 
-        if (access(full_path.characters(), R_OK) != 0)
+        if (access(full_path.to_deprecated_string().characters(), R_OK) != 0)
             continue;
 
-        return full_path;
+        return full_path.to_deprecated_string();
     }
 
     return name;

--- a/Userland/Libraries/LibDebug/DebugInfo.cpp
+++ b/Userland/Libraries/LibDebug/DebugInfo.cpp
@@ -91,7 +91,7 @@ void DebugInfo::prepare_lines()
         if (file_path.view().contains("Toolchain/"sv) || file_path.view().contains("libgcc"sv))
             return {};
         if (file_path.view().starts_with("./"sv) && !m_source_root.is_null())
-            return LexicalPath::join(m_source_root, file_path).string();
+            return LexicalPath::join(m_source_root, file_path).release_value_but_fixme_should_propagate_errors().string().to_deprecated_string();
         if (auto index_of_serenity_slash = file_path.view().find("serenity/"sv); index_of_serenity_slash.has_value()) {
             auto start_index = index_of_serenity_slash.value() + "serenity/"sv.length();
             return file_path.view().substring_view(start_index, file_path.length() - start_index);

--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "DebugSession.h"
+#include "AK/DeprecatedString.h"
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
 #include <AK/LexicalPath.h>
@@ -463,7 +464,7 @@ void DebugSession::update_loaded_libs()
 
         DeprecatedString lib_name = object_path.value();
         if (Core::File::looks_like_shared_library(lib_name))
-            lib_name = LexicalPath::basename(object_path.value());
+            lib_name = LexicalPath::basename(String::from_deprecated_string(lib_name).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 
         FlatPtr base_address = entry.as_object().get("address"sv).to_addr();
         if (auto it = m_loaded_libraries.find(lib_name); it != m_loaded_libraries.end()) {

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -41,8 +41,8 @@ DeprecatedResult Client::try_request_file_read_only_approved(GUI::Window* parent
     if (path.starts_with('/')) {
         async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, path);
     } else {
-        auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
-        async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, full_path);
+        auto full_path = TRY(LexicalPath::join(Core::File::current_working_directory(), path)).string();
+        async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, full_path.to_deprecated_string());
     }
 
     return handle_promise<DeprecatedResult>(id);
@@ -66,8 +66,8 @@ DeprecatedResult Client::try_request_file(GUI::Window* parent_window, Deprecated
     if (path.starts_with('/')) {
         async_request_file(id, parent_window_server_client_id, parent_window_id, path, mode);
     } else {
-        auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
-        async_request_file(id, parent_window_server_client_id, parent_window_id, full_path, mode);
+        auto full_path = TRY(LexicalPath::join(Core::File::current_working_directory(), path)).string();
+        async_request_file(id, parent_window_server_client_id, parent_window_id, full_path.to_deprecated_string(), mode);
     }
 
     return handle_promise<DeprecatedResult>(id);

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
@@ -57,9 +57,9 @@ void AbstractThemePreview::load_theme_bitmaps()
 
     auto buttons_path = m_preview_palette.title_button_icons_path();
 
-    load_bitmap(LexicalPath::absolute_path(buttons_path, "window-close.png"), m_last_close_path, m_close_bitmap);
-    load_bitmap(LexicalPath::absolute_path(buttons_path, "window-maximize.png"), m_last_maximize_path, m_maximize_bitmap);
-    load_bitmap(LexicalPath::absolute_path(buttons_path, "window-minimize.png"), m_last_minimize_path, m_minimize_bitmap);
+    load_bitmap(LexicalPath::absolute_path(buttons_path, "window-close.png"sv).release_value_but_fixme_should_propagate_errors().to_deprecated_string(), m_last_close_path, m_close_bitmap);
+    load_bitmap(LexicalPath::absolute_path(buttons_path, "window-maximize.png"sv).release_value_but_fixme_should_propagate_errors().to_deprecated_string(), m_last_maximize_path, m_maximize_bitmap);
+    load_bitmap(LexicalPath::absolute_path(buttons_path, "window-minimize.png"sv).release_value_but_fixme_should_propagate_errors().to_deprecated_string(), m_last_minimize_path, m_minimize_bitmap);
 
     load_bitmap(m_preview_palette.active_window_shadow_path(), m_last_active_window_shadow_path, m_active_window_shadow);
     load_bitmap(m_preview_palette.inactive_window_shadow_path(), m_last_inactive_window_shadow_path, m_inactive_window_shadow);

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -155,7 +155,7 @@ auto EmojiInputDialog::supported_emoji() -> Vector<Emoji>
     Core::DirIterator dt("/res/emoji", Core::DirIterator::SkipDots);
     while (dt.has_next()) {
         auto filename = dt.next_path();
-        auto lexical_path = LexicalPath(filename);
+        auto lexical_path = LexicalPath::from_string(filename.view()).release_value_but_fixme_should_propagate_errors();
         if (lexical_path.extension() != "png")
             continue;
         auto basename = lexical_path.basename();

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -262,7 +262,10 @@ Icon FileIconProvider::icon_for_path(DeprecatedString const& path, mode_t mode)
         if (raw_symlink_target.starts_with('/')) {
             target_path = raw_symlink_target;
         } else {
-            target_path = Core::File::real_path_for(DeprecatedString::formatted("{}/{}", LexicalPath::dirname(path), raw_symlink_target));
+            target_path = Core::File::real_path_for(DeprecatedString::formatted("{}/{}",
+                LexicalPath::dirname(String::from_deprecated_string(path).release_value_but_fixme_should_propagate_errors())
+                    .release_value_but_fixme_should_propagate_errors(),
+                raw_symlink_target));
         }
         auto target_icon = icon_for_path(target_path);
 

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -131,8 +131,8 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
         "New directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/mkdir.png"sv).release_value_but_fixme_should_propagate_errors(), [this](Action const&) {
             DeprecatedString value;
             if (InputBox::show(this, value, "Enter name:"sv, "New directory"sv) == InputBox::ExecResult::OK && !value.is_empty()) {
-                auto new_dir_path = LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", m_model->root_path(), value));
-                int rc = mkdir(new_dir_path.characters(), 0777);
+                auto new_dir_path = LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", m_model->root_path(), value)).release_value_but_fixme_should_propagate_errors();
+                int rc = mkdir(new_dir_path.to_deprecated_string().characters(), 0777);
                 if (rc < 0) {
                     MessageBox::show(this, DeprecatedString::formatted("mkdir(\"{}\") failed: {}", new_dir_path, strerror(errno)), "Error"sv, MessageBox::Type::Error);
                 } else {
@@ -265,7 +265,7 @@ void FilePicker::on_file_return()
 {
     auto path = m_filename_textbox->text();
     if (!path.starts_with('/')) {
-        path = LexicalPath::join(m_model->root_path(), path).string();
+        path = LexicalPath::join(m_model->root_path(), path).release_value_but_fixme_should_propagate_errors().string().to_deprecated_string();
     }
 
     bool file_exists = Core::File::exists(path);
@@ -295,9 +295,9 @@ void FilePicker::set_path(DeprecatedString const& path)
         return;
     }
 
-    auto new_path = LexicalPath(path).string();
-    m_location_textbox->set_icon(FileIconProvider::icon_for_path(new_path).bitmap_for_size(16));
-    m_model->set_root_path(new_path);
+    auto new_path = LexicalPath::from_string(path).release_value_but_fixme_should_propagate_errors().string();
+    m_location_textbox->set_icon(FileIconProvider::icon_for_path(new_path.to_deprecated_string()).bitmap_for_size(16));
+    m_model->set_root_path(new_path.to_deprecated_string());
 }
 
 }

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -36,7 +36,7 @@ Dialog::ExecResult MessageBox::ask_about_unsaved_changes(Window* parent_window, 
     if (path.is_empty())
         builder.append("untitled document"sv);
     else
-        builder.appendff("\"{}\"", LexicalPath::basename(path));
+        builder.appendff("\"{}\"", LexicalPath::basename(String::from_utf8(path).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors());
     builder.append(" before closing?"sv);
 
     if (!path.is_empty() && last_unmodified_timestamp.has_value()) {

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -109,7 +109,7 @@ ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::try_load_from_file(StringView path, int s
 {
     if (scale_factor > 1 && path.starts_with("/res/"sv)) {
         auto load_scaled_bitmap = [](StringView path, int scale_factor) -> ErrorOr<NonnullRefPtr<Bitmap>> {
-            LexicalPath lexical_path { path };
+            auto lexical_path = TRY(LexicalPath::from_string(path));
             StringBuilder highdpi_icon_path;
             TRY(highdpi_icon_path.try_appendff("{}/{}-{}x.{}", lexical_path.dirname(), lexical_path.title(), scale_factor, lexical_path.extension()));
 

--- a/Userland/Libraries/LibGfx/CursorParams.cpp
+++ b/Userland/Libraries/LibGfx/CursorParams.cpp
@@ -13,7 +13,7 @@ namespace Gfx {
 
 CursorParams CursorParams::parse_from_filename(StringView cursor_path, Gfx::IntPoint default_hotspot)
 {
-    LexicalPath path(cursor_path);
+    auto path = LexicalPath::from_string(cursor_path).release_value_but_fixme_should_propagate_errors();
     auto file_title = path.title();
     auto last_dot_in_title = file_title.find_last('.');
     if (!last_dot_in_title.has_value() || last_dot_in_title.value() == 0) {

--- a/Userland/Libraries/LibGfx/SystemTheme.cpp
+++ b/Userland/Libraries/LibGfx/SystemTheme.cpp
@@ -161,7 +161,10 @@ ErrorOr<Vector<SystemThemeMetaData>> list_installed_system_themes()
     while (dt.has_next()) {
         auto theme_name = dt.next_path();
         auto theme_path = DeprecatedString::formatted("/res/themes/{}", theme_name);
-        TRY(system_themes.try_append({ LexicalPath::title(theme_name), theme_path }));
+        TRY(system_themes.try_append({ LexicalPath::title(String::from_deprecated_string(theme_name).release_value_but_fixme_should_propagate_errors())
+                                           .release_value_but_fixme_should_propagate_errors()
+                                           .to_deprecated_string(),
+            theme_path }));
     }
     quick_sort(system_themes, [](auto& a, auto& b) { return a.name < b.name; });
     return system_themes;

--- a/Userland/Libraries/LibIDL/IDLParser.cpp
+++ b/Userland/Libraries/LibIDL/IDLParser.cpp
@@ -137,11 +137,11 @@ HashMap<DeprecatedString, DeprecatedString> Parser::parse_extended_attributes()
 static HashTable<DeprecatedString> import_stack;
 Optional<Interface&> Parser::resolve_import(auto path)
 {
-    auto include_path = LexicalPath::join(import_base_path, path).string();
-    if (!Core::File::exists(include_path))
+    auto include_path = LexicalPath::join(import_base_path, path).release_value_but_fixme_should_propagate_errors().string();
+    if (!Core::File::exists(include_path.to_deprecated_string()))
         report_parsing_error(DeprecatedString::formatted("{}: No such file or directory", include_path), filename, input, lexer.tell());
 
-    auto real_path = Core::File::real_path_for(include_path);
+    auto real_path = Core::File::real_path_for(include_path.to_deprecated_string());
     if (top_level_resolved_imports().contains(real_path))
         return *top_level_resolved_imports().find(real_path)->value;
 

--- a/Userland/Libraries/LibJS/Runtime/Completion.h
+++ b/Userland/Libraries/LibJS/Runtime/Completion.h
@@ -313,3 +313,15 @@ inline Completion normal_completion(Optional<Value> value)
 Completion throw_completion(Value);
 
 }
+
+#define TRY_OR_RETURN_OOM_JS(vm, expression)                                   \
+    ({                                                                         \
+        /* Ignore -Wshadow to allow nesting the macro. */                      \
+        AK_IGNORE_DIAGNOSTIC("-Wshadow",                                       \
+            auto _temporary_result = (expression));                            \
+        if (_temporary_result.is_error()) {                                    \
+            VERIFY(_temporary_result.error().code() == ENOMEM);                \
+            return (vm).throw_completion<JS::InternalError>("Out of memory."); \
+        }                                                                      \
+        _temporary_result.release_value();                                     \
+    })

--- a/Userland/Libraries/LibManual/Node.cpp
+++ b/Userland/Libraries/LibManual/Node.cpp
@@ -31,11 +31,11 @@ ErrorOr<NonnullRefPtr<PageNode>> Node::try_create_from_query(Vector<StringView, 
     ++query_parameter_iterator;
     if (query_parameter_iterator.is_end()) {
         // [/path/to/docs.md]
-        auto path_from_query = LexicalPath { first_query_parameter };
+        auto path_from_query = TRY(LexicalPath::from_string(first_query_parameter));
         if (path_from_query.is_absolute()
-            && path_from_query.is_child_of(manual_base_path)
+            && path_from_query.is_child_of(TRY(LexicalPath::from_string(manual_base_path)))
             && path_from_query.extension() == "md"sv) {
-            auto section_directory = path_from_query.parent();
+            auto section_directory = TRY(path_from_query.parent());
             auto man_string_location = section_directory.basename().find("man"sv);
             if (!man_string_location.has_value())
                 return Error::from_string_literal("Page is inside invalid section");

--- a/Userland/Libraries/LibManual/Path.cpp
+++ b/Userland/Libraries/LibManual/Path.cpp
@@ -8,6 +8,6 @@
 
 namespace Manual {
 
-LexicalPath const manual_base_path { "/usr/share/man" };
+StringView const manual_base_path { "/usr/share/man"sv };
 
 }

--- a/Userland/Libraries/LibManual/Path.h
+++ b/Userland/Libraries/LibManual/Path.h
@@ -10,7 +10,7 @@
 
 namespace Manual {
 
-extern LexicalPath const manual_base_path;
+extern StringView const manual_base_path;
 
 constexpr StringView const top_level_section_prefix = "man"sv;
 

--- a/Userland/Libraries/LibManual/SectionNode.cpp
+++ b/Userland/Libraries/LibManual/SectionNode.cpp
@@ -44,7 +44,7 @@ ErrorOr<void> SectionNode::reify_if_needed() const
 
     Vector<String> page_names;
     while (dir_iter.has_next()) {
-        LexicalPath lexical_path(dir_iter.next_path());
+        auto lexical_path = TRY(LexicalPath::from_string(dir_iter.next_path()));
         if (lexical_path.extension() != "md")
             continue;
         page_names.append(TRY(String::from_utf8(lexical_path.title())));

--- a/Userland/Libraries/LibSymbolication/Symbolication.cpp
+++ b/Userland/Libraries/LibSymbolication/Symbolication.cpp
@@ -70,7 +70,7 @@ Optional<Symbol> symbolicate(DeprecatedString const& path, FlatPtr address, Incl
         Array<StringView, 2> search_paths { "/usr/lib"sv, "/usr/local/lib"sv };
         bool found = false;
         for (auto& search_path : search_paths) {
-            full_path = LexicalPath::join(search_path, path).string();
+            full_path = LexicalPath::join(search_path, path).release_value_but_fixme_should_propagate_errors().string().to_deprecated_string();
             if (Core::File::exists(full_path)) {
                 found = true;
                 break;
@@ -126,7 +126,7 @@ Optional<Symbol> symbolicate(DeprecatedString const& path, FlatPtr address, Incl
     return Symbol {
         .address = address,
         .name = move(symbol),
-        .object = LexicalPath::basename(path),
+        .object = LexicalPath::basename(String::from_deprecated_string(path).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors().to_deprecated_string(),
         .offset = offset,
         .source_positions = move(positions),
     };

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -57,7 +57,9 @@ int main(int argc, char** argv)
 {
     g_test_argc = argc;
     g_test_argv = argv;
-    auto program_name = LexicalPath::basename(argv[0]);
+    auto program_name = LexicalPath::basename(String::from_utf8({ argv[0], strlen(argv[0]) })
+                                                  .release_value_but_fixme_should_propagate_errors())
+                            .release_value_but_fixme_should_propagate_errors();
     g_program_name = program_name;
 
     struct sigaction act;
@@ -141,7 +143,10 @@ int main(int argc, char** argv)
         test_root = DeprecatedString { specified_test_root };
     } else {
 #ifdef AK_OS_SERENITY
-        test_root = LexicalPath::join("/home/anon/Tests"sv, DeprecatedString::formatted("{}-tests", program_name.split_view('-').last())).string();
+        test_root = LexicalPath::join("/home/anon/Tests"sv, DeprecatedString::formatted("{}-tests", program_name.split_bytes('-').release_value_but_fixme_should_propagate_errors().last()))
+                        .release_value_but_fixme_should_propagate_errors()
+                        .string()
+                        .to_deprecated_string();
 #else
         char* serenity_source_dir = getenv("SERENITY_SOURCE_DIR");
         if (!serenity_source_dir) {

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -843,11 +843,11 @@ void TerminalWidget::mousemove_event(GUI::MouseEvent& event)
                 auto url = URL(attribute.href);
                 auto path = url.path();
 
-                auto app_file = Desktop::AppFile::get_for_app(LexicalPath::basename(handlers[0]));
-                auto app_name = app_file->is_valid() ? app_file->name() : LexicalPath::basename(handlers[0]);
+                auto app_file = Desktop::AppFile::get_for_app(LexicalPath::basename(String::from_deprecated_string(handlers[0]).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors());
+                auto app_name = app_file->is_valid() ? app_file->name() : LexicalPath::basename(String::from_deprecated_string(handlers[0]).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 
                 if (url.scheme() == "file") {
-                    auto file_name = LexicalPath::basename(path);
+                    auto file_name = LexicalPath::basename(String::from_deprecated_string(path).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors();
 
                     if (path == handlers[0]) {
                         set_tooltip(DeprecatedString::formatted("Execute {}", app_name));
@@ -1102,7 +1102,7 @@ void TerminalWidget::context_menu_event(GUI::ContextMenuEvent& event)
         // Then add them to the context menu.
         // FIXME: Adapt this code when we actually support calling LaunchServer with a specific handler in mind.
         for (auto& handler : handlers) {
-            auto af = Desktop::AppFile::get_for_app(LexicalPath::basename(handler));
+            auto af = Desktop::AppFile::get_for_app(LexicalPath::basename(String::from_deprecated_string(handler).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors().to_deprecated_string());
             if (!af->is_valid())
                 continue;
             auto action = GUI::Action::create(DeprecatedString::formatted("&Open in {}", af->name()), af->icon().bitmap_for_size(16), [this, handler](auto&) {
@@ -1122,8 +1122,8 @@ void TerminalWidget::context_menu_event(GUI::ContextMenuEvent& event)
             // file://courage/home/anon/something -> /home/anon/something
             auto path = URL(m_context_menu_href).path();
             // /home/anon/something -> something
-            auto name = LexicalPath::basename(path);
-            GUI::Clipboard::the().set_plain_text(name);
+            auto name = LexicalPath::basename(String::from_deprecated_string(path).release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors();
+            GUI::Clipboard::the().set_plain_text(name.to_deprecated_string());
         }));
         m_context_menu_for_hyperlink->add_separator();
         m_context_menu_for_hyperlink->add_action(copy_action());

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -142,7 +142,7 @@ static bool build_image_document(DOM::Document& document, ByteBuffer const& data
     auto title_element = document.create_element("title").release_value();
     MUST(head_element->append_child(title_element));
 
-    auto basename = LexicalPath::basename(document.url().path());
+    auto basename = MUST(LexicalPath::basename(MUST(String::from_deprecated_string(document.url().path()))));
     auto title_text = document.heap().allocate<DOM::Text>(document.realm(), document, DeprecatedString::formatted("{} [{}x{}]", basename, bitmap->width(), bitmap->height()));
     MUST(title_element->append_child(*title_text));
 

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
@@ -67,8 +67,14 @@ void ConnectionFromClient::request_file_handler(i32 request_id, i32 window_serve
             access_string = "write to";
 
         auto pid = this->socket().peer_pid().release_value_but_fixme_should_propagate_errors();
-        auto exe_link = LexicalPath("/proc").append(DeprecatedString::number(pid)).append("exe"sv).string();
-        auto exe_path = Core::File::real_path_for(exe_link);
+        auto exe_link = LexicalPath::from_string("/proc"sv)
+                            .release_value_but_fixme_should_propagate_errors()
+                            .append(DeprecatedString::number(pid))
+                            .release_value_but_fixme_should_propagate_errors()
+                            .append("exe"sv)
+                            .release_value_but_fixme_should_propagate_errors()
+                            .string();
+        auto exe_path = Core::File::real_path_for(exe_link.to_deprecated_string());
 
         auto main_window = create_dummy_child_window(window_server_client_id, parent_window_id);
 

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -314,9 +314,9 @@ void Launcher::for_each_handler_for_path(DeprecatedString const& path, Function<
             return;
         }
 
-        auto link_target = LexicalPath { link_target_or_error.release_value() };
-        LexicalPath absolute_link_target = link_target.is_absolute() ? link_target : LexicalPath::join(LexicalPath::dirname(path), link_target.string());
-        auto real_path = Core::File::real_path_for(absolute_link_target.string());
+        auto link_target = LexicalPath::from_string(link_target_or_error.release_value()).release_value_but_fixme_should_propagate_errors();
+        LexicalPath absolute_link_target = link_target.is_absolute() ? link_target : LexicalPath::join(LexicalPath::dirname(path).release_value_but_fixme_should_propagate_errors(), link_target.string()).release_value_but_fixme_should_propagate_errors();
+        auto real_path = Core::File::real_path_for(absolute_link_target.string().to_deprecated_string());
         return for_each_handler_for_path(real_path, [&](auto const& handler) -> bool {
             return f(handler);
         });
@@ -325,7 +325,7 @@ void Launcher::for_each_handler_for_path(DeprecatedString const& path, Function<
     if ((st.st_mode & S_IFMT) == S_IFREG && (st.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)))
         f(get_handler_for_executable(Handler::Type::Application, path));
 
-    auto extension = LexicalPath::extension(path).to_lowercase();
+    auto extension = LexicalPath::extension(path).release_value_but_fixme_should_propagate_errors().to_deprecated_string().to_lowercase();
     auto mime_type = mime_type_for_file(path);
 
     if (mime_type.has_value()) {
@@ -374,7 +374,7 @@ bool Launcher::open_file_url(const URL& url)
     if ((st.st_mode & S_IFMT) == S_IFREG && st.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH))
         return spawn(url.path(), {});
 
-    auto extension = LexicalPath::extension(url.path()).to_lowercase();
+    auto extension = LexicalPath::extension(url.path()).release_value_but_fixme_should_propagate_errors().to_deprecated_string().to_lowercase();
     auto mime_type = mime_type_for_file(url.path());
 
     auto mime_type_or_extension = extension;

--- a/Userland/Services/SQLServer/DatabaseConnection.cpp
+++ b/Userland/Services/SQLServer/DatabaseConnection.cpp
@@ -34,7 +34,7 @@ RefPtr<DatabaseConnection> DatabaseConnection::connection_for(SQL::ConnectionID 
 
 ErrorOr<NonnullRefPtr<DatabaseConnection>> DatabaseConnection::create(StringView database_path, DeprecatedString database_name, int client_id)
 {
-    if (LexicalPath path(database_name); (path.title() != database_name) || (path.dirname() != "."))
+    if (auto path = TRY(LexicalPath::from_string(database_name.view())); (path.title() != database_name) || (path.dirname() != "."))
         return Error::from_string_view("Invalid database name"sv);
 
     auto database = TRY(find_or_create_database(database_path, database_name));

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -40,7 +40,7 @@ ErrorOr<void> Service::setup_socket(SocketDescriptor& socket)
     // The return value is discarded as sockets are not always there, and unlinking a non-existent path is considered as a failure.
     (void)Core::System::unlink(socket.path);
 
-    TRY(Core::Directory::create(LexicalPath(socket.path).parent(), Core::Directory::CreateDirectories::Yes));
+    TRY(Core::Directory::create(TRY(TRY(LexicalPath::from_string(socket.path)).parent()), Core::Directory::CreateDirectories::Yes));
 
     // Note: we use SOCK_CLOEXEC here to make sure we don't leak every socket to
     // all the clients. We'll make the one we do need to pass down !CLOEXEC later

--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -59,7 +59,7 @@ GUI::Icon QuickLaunchEntryExecutable::icon() const
 
 DeprecatedString QuickLaunchEntryExecutable::name() const
 {
-    return LexicalPath { m_path }.basename();
+    return LexicalPath::from_string(m_path).release_value_but_fixme_should_propagate_errors().basename();
 }
 
 ErrorOr<void> QuickLaunchEntryFile::launch() const

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -121,7 +121,7 @@ ErrorOr<bool> Client::handle_request(ReadonlyBytes raw_request)
         }
     }
 
-    auto requested_path = LexicalPath::join("/"sv, resource_decoded).string();
+    auto requested_path = TRY(LexicalPath::join("/"sv, resource_decoded)).string();
     dbgln_if(WEBSERVER_DEBUG, "Canonical requested path: '{}'", requested_path);
 
     StringBuilder path_builder;
@@ -146,7 +146,7 @@ ErrorOr<bool> Client::handle_request(ReadonlyBytes raw_request)
         index_html_path_builder.append("/index.html"sv);
         auto index_html_path = index_html_path_builder.to_deprecated_string();
         if (!Core::File::exists(index_html_path)) {
-            TRY(handle_directory_listing(requested_path, real_path, request));
+            TRY(handle_directory_listing(requested_path.to_deprecated_string(), real_path, request));
             return true;
         }
         real_path = index_html_path;

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -281,7 +281,7 @@ int Shell::builtin_cd(int argc, char const** argv)
     if (cd_history.is_empty() || cd_history.last() != real_path)
         cd_history.enqueue(real_path);
 
-    auto path_relative_to_current_directory = LexicalPath::relative_path(real_path, cwd);
+    auto path_relative_to_current_directory = LexicalPath::relative_path(real_path, cwd).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
     if (path_relative_to_current_directory.is_empty())
         path_relative_to_current_directory = real_path;
     char const* path = path_relative_to_current_directory.characters();
@@ -682,7 +682,7 @@ int Shell::builtin_popd(int argc, char const** argv)
     if (should_not_switch)
         return 0;
 
-    auto new_path = LexicalPath::canonicalized_path(popped_path);
+    auto new_path = LexicalPath::canonicalized_path(popped_path).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
     if (chdir(new_path.characters()) < 0) {
         warnln("chdir({}) failed: {}", new_path, strerror(errno));
         return 1;
@@ -745,7 +745,7 @@ int Shell::builtin_pushd(int argc, char const** argv)
         }
     }
 
-    auto real_path = LexicalPath::canonicalized_path(path_builder.to_deprecated_string());
+    auto real_path = LexicalPath::canonicalized_path(path_builder.to_deprecated_string()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 
     struct stat st;
     int rc = stat(real_path.characters(), &st);

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -538,8 +538,9 @@ Optional<DeprecatedString> Shell::help_path_for(Vector<RunnablePath> visited, Sh
 {
     switch (runnable_path.kind) {
     case RunnablePath::Kind::Executable: {
-        LexicalPath lexical_path(runnable_path.path);
-        return lexical_path.basename();
+        return LexicalPath::basename(String::from_utf8(runnable_path.path).release_value_but_fixme_should_propagate_errors())
+            .release_value_but_fixme_should_propagate_errors()
+            .to_deprecated_string();
     }
 
     case RunnablePath::Kind::Alias: {

--- a/Userland/Utilities/basename.cpp
+++ b/Userland/Utilities/basename.cpp
@@ -21,10 +21,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(suffix, "Suffix to strip from name", "suffix", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    auto result = LexicalPath::basename(path);
+    auto result = TRY(LexicalPath::basename(path));
 
-    if (!suffix.is_null() && result.length() != suffix.length() && result.ends_with(suffix))
-        result = result.substring_view(0, result.length() - suffix.length());
+    if (!suffix.is_null() && result.bytes().size() != suffix.length() && result.ends_with_bytes(suffix))
+        result = TRY(result.substring_from_byte_offset(0, result.bytes().size() - suffix.length()));
 
     outln("{}", result);
     return 0;

--- a/Userland/Utilities/bt.cpp
+++ b/Userland/Utilities/bt.cpp
@@ -54,10 +54,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
                     // See if we can find the sources in /usr/src
                     // FIXME: I'm sure this can be improved!
-                    auto full_path = LexicalPath::canonicalized_path(DeprecatedString::formatted("/usr/src/serenity/dummy/dummy/{}", source_position.file_path));
-                    if (access(full_path.characters(), F_OK) == 0) {
+                    auto full_path = TRY(LexicalPath::canonicalized_path(DeprecatedString::formatted("/usr/src/serenity/dummy/dummy/{}", source_position.file_path)));
+                    if (access(full_path.to_deprecated_string().characters(), F_OK) == 0) {
                         linked = true;
-                        auto url = URL::create_with_file_scheme(full_path, {}, hostname);
+                        auto url = URL::create_with_file_scheme(full_path.to_deprecated_string(), {}, hostname);
                         url.set_query(DeprecatedString::formatted("line_number={}", source_position.line_number));
                         out("\033]8;;{}\033\\", url.serialize());
                     }

--- a/Userland/Utilities/checksum.cpp
+++ b/Userland/Utilities/checksum.cpp
@@ -16,7 +16,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath"));
 
-    auto program_name = LexicalPath::basename(arguments.strings[0]);
+    auto program_name = TRY(LexicalPath::basename(TRY(String::from_utf8(arguments.strings[0]))));
     auto hash_kind = Crypto::Hash::HashKind::None;
 
     if (program_name == "md5sum")
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         exit(1);
     }
 
-    auto hash_name = program_name.substring_view(0, program_name.length() - 3).to_deprecated_string().to_uppercase();
+    auto hash_name = TRY(program_name.substring_from_byte_offset(0, program_name.bytes().size() - 3)).to_deprecated_string().to_uppercase();
     auto paths_help_string = DeprecatedString::formatted("File(s) to print {} checksum of", hash_name);
 
     bool verify_from_paths = false;

--- a/Userland/Utilities/cpp-preprocessor.cpp
+++ b/Userland/Utilities/cpp-preprocessor.cpp
@@ -21,8 +21,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto file = TRY(Core::Stream::File::open(path, Core::Stream::OpenMode::Read));
     auto content = TRY(file->read_until_eof());
-    DeprecatedString name = LexicalPath::basename(path);
-    Cpp::Preprocessor cpp(name, StringView { content });
+    auto name = TRY(LexicalPath::basename(path));
+    Cpp::Preprocessor cpp(name.to_deprecated_string(), StringView { content });
     auto tokens = cpp.process_and_lex();
 
     if (print_definitions) {

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -151,9 +151,9 @@ ErrorOr<u64> print_space_usage(DeprecatedString const& path, DuOption const& du_
         }
     }
 
-    auto const basename = LexicalPath::basename(path);
+    auto const basename = TRY(LexicalPath::basename(path));
     for (auto const& pattern : du_option.excluded_patterns) {
-        if (basename.matches(pattern, CaseSensitivity::CaseSensitive))
+        if (basename.to_deprecated_string().matches(pattern, CaseSensitivity::CaseSensitive))
             return { 0 };
     }
 

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -37,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 {
     TRY(Core::System::pledge("stdio rpath"));
 
-    DeprecatedString program_name = AK::LexicalPath::basename(args.strings[0]);
+    auto program_name = TRY(LexicalPath::basename(args.strings[0]));
 
     Vector<DeprecatedString> files;
 

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -732,8 +732,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Web::WebSockets::WebSocketClientManager::initialize(HeadlessWebSocketClientManager::create());
 
     if (!resources_folder.is_empty()) {
-        Web::FrameLoader::set_default_favicon_path(LexicalPath::join(resources_folder, "icons/16x16/app-browser.png"sv).string());
-        Gfx::FontDatabase::set_default_fonts_lookup_path(LexicalPath::join(resources_folder, "fonts"sv).string());
+        Web::FrameLoader::set_default_favicon_path(TRY(LexicalPath::join(resources_folder, "icons/16x16/app-browser.png"sv)).string().to_deprecated_string());
+        Gfx::FontDatabase::set_default_fonts_lookup_path(TRY(LexicalPath::join(resources_folder, "fonts"sv)).string().to_deprecated_string());
     }
     if (!ca_certs_path.is_empty()) {
         auto config_result = Core::ConfigFile::open(ca_certs_path);
@@ -755,7 +755,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto page_client = HeadlessBrowserPageClient::create();
 
     if (!resources_folder.is_empty()) {
-        auto system_theme = TRY(Gfx::load_system_theme(LexicalPath::join(resources_folder, "themes/Default.ini"sv).string()));
+        auto system_theme = TRY(Gfx::load_system_theme(TRY(LexicalPath::join(resources_folder, "themes/Default.ini"sv)).string().to_deprecated_string()));
         page_client->setup_palette(system_theme);
     } else {
         auto system_theme = TRY(Gfx::load_system_theme("/res/themes/Default.ini"));

--- a/Userland/Utilities/install.cpp
+++ b/Userland/Utilities/install.cpp
@@ -32,17 +32,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto permission_mask = TRY(Core::FilePermissionsMask::parse(mode));
 
-    DeprecatedString destination_dir = (sources.size() > 1 ? DeprecatedString { destination } : LexicalPath::dirname(destination));
+    String destination_dir = (sources.size() > 1 ? TRY(String::from_utf8(destination)) : TRY(LexicalPath::dirname(destination)));
 
     if (create_leading_dest_components) {
-        DeprecatedString destination_dir_absolute = Core::File::absolute_path(destination_dir);
+        DeprecatedString destination_dir_absolute = Core::File::absolute_path(destination_dir.to_deprecated_string());
         MUST(Core::Directory::create(destination_dir_absolute, Core::Directory::CreateDirectories::Yes));
     }
 
     for (auto const& source : sources) {
         DeprecatedString final_destination;
         if (sources.size() > 1) {
-            final_destination = LexicalPath(destination).append(LexicalPath::basename(source)).string();
+            final_destination = TRY(TRY(LexicalPath::from_string(destination)).append(TRY(LexicalPath::basename(source)))).string().to_deprecated_string();
         } else {
             final_destination = destination;
         }

--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -500,7 +500,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool quit_at_eof = false;
     bool emulate_more = false;
 
-    if (LexicalPath::basename(arguments.strings[0]) == "more"sv)
+    if (TRY(LexicalPath::basename(TRY(String::from_utf8(arguments.strings[0])))) == "more"sv)
         emulate_more = true;
 
     Core::ArgsParser args_parser;

--- a/Userland/Utilities/ln.cpp
+++ b/Userland/Utilities/ln.cpp
@@ -26,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     DeprecatedString path_buffer;
     if (path.is_empty()) {
-        path_buffer = LexicalPath::basename(target);
+        path_buffer = TRY(LexicalPath::basename(target)).to_deprecated_string();
         path = path_buffer.view();
     }
 
@@ -37,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (!stat.is_error() && S_ISDIR(stat.value().st_mode)) {
         // The target path is a directory, so we presumably want <path>/<filename> as the effective path.
-        path_buffer = LexicalPath::join(path, LexicalPath::basename(target)).string();
+        path_buffer = TRY(LexicalPath::join(path, TRY(LexicalPath::basename(target)))).string().to_deprecated_string();
         path = path_buffer.view();
         stat = Core::System::lstat(path);
     }

--- a/Userland/Utilities/lsusb.cpp
+++ b/Userland/Utilities/lsusb.cpp
@@ -46,7 +46,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     while (usb_devices.has_next()) {
-        auto full_path = LexicalPath(usb_devices.next_full_path());
+        auto full_path = TRY(LexicalPath::from_string(usb_devices.next_full_path()));
 
         auto proc_usb_device = Core::Stream::File::open(full_path.string(), Core::Stream::OpenMode::Read);
         if (proc_usb_device.is_error()) {

--- a/Userland/Utilities/markdown-check.cpp
+++ b/Userland/Utilities/markdown-check.cpp
@@ -269,14 +269,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             continue;
         }
 
-        auto file_lexical_path = LexicalPath(file_item.key);
+        auto file_lexical_path = TRY(LexicalPath::from_string(file_item.key));
         auto file_dir = file_lexical_path.dirname();
         for (auto const& file_link : file_item.value.file_links()) {
             DeprecatedString pointee_file;
             if (file_link.file_path.is_empty()) {
                 pointee_file = file_item.key;
             } else {
-                pointee_file = LexicalPath::absolute_path(file_dir, file_link.file_path);
+                pointee_file = TRY(LexicalPath::absolute_path(file_dir, file_link.file_path)).to_deprecated_string();
             }
             if (!Core::File::exists(pointee_file) && !is_missing_file_acceptable(pointee_file)) {
                 outln("File '{}' points to '{}' (label '{}'), but '{}' does not exist!",

--- a/Userland/Utilities/mkdir.cpp
+++ b/Userland/Utilities/mkdir.cpp
@@ -44,10 +44,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool has_errors = false;
 
     for (auto& directory : directories) {
-        LexicalPath lexical_path(directory);
+        auto lexical_path = TRY(LexicalPath::from_string(directory));
         if (!create_parents) {
-            if (mkdir(lexical_path.string().characters(), mask.apply(mask_reference_mode)) < 0) {
-                perror("mkdir");
+            auto error = Core::System::mkdir(lexical_path.string(), mask.apply(mask_reference_mode));
+            if (error.is_error()) {
+                dbgln("{}", error.release_error());
                 has_errors = true;
             }
             continue;

--- a/Userland/Utilities/mktemp.cpp
+++ b/Userland/Utilities/mktemp.cpp
@@ -77,7 +77,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto const* cwd_ptr = getcwd(nullptr, 0);
             target_directory = StringView { cwd_ptr, strlen(cwd_ptr) };
         } else {
-            LexicalPath template_path(file_template);
+            auto template_path = TRY(LexicalPath::from_string(file_template));
             char const* env_directory = getenv("TMPDIR");
             target_directory = env_directory && *env_directory ? StringView { env_directory, strlen(env_directory) } : "/tmp"sv;
         }
@@ -93,15 +93,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    auto target_path = LexicalPath::join(target_directory, file_template).string();
+    auto target_path = TRY(LexicalPath::join(target_directory, file_template)).string();
 
-    auto final_path = TRY(make_temp(target_path, create_directory, dry_run));
+    auto final_path = TRY(make_temp(target_path.to_deprecated_string(), create_directory, dry_run));
     if (final_path.is_null()) {
         if (!quiet) {
             if (create_directory)
-                warnln("Failed to create directory via template {}", target_path.characters());
+                warnln("Failed to create directory via template {}", target_path.to_deprecated_string().characters());
             else
-                warnln("Failed to create file via template {}", target_path.characters());
+                warnln("Failed to create file via template {}", target_path.to_deprecated_string().characters());
         }
         return 1;
     }

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -263,7 +263,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 if (output_name.is_empty())
                     output_name = url.path();
 
-                LexicalPath path { output_name };
+                auto path = LexicalPath::from_string(output_name).release_value_but_fixme_should_propagate_errors();
                 output_name = path.basename();
 
                 // The URL didn't have a name component, e.g. 'serenityos.org'

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -289,7 +289,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         display_hardening = true;
     }
 
-    path = LexicalPath::absolute_path(TRY(Core::System::getcwd()), path);
+    path = TRY(LexicalPath::absolute_path(TRY(Core::System::getcwd()), path)).to_deprecated_string();
 
     auto file_or_error = Core::MappedFile::map(path);
 

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -229,7 +229,7 @@ FileResult TestRunner::run_test_file(DeprecatedString const& test_path)
 {
     double start_time = get_time_in_ms();
 
-    auto path_for_test = LexicalPath(test_path);
+    auto path_for_test = LexicalPath::from_string(test_path).release_value_but_fixme_should_propagate_errors();
     if (should_skip_test(path_for_test)) {
         return FileResult { move(path_for_test), 0.0, Test::Result::Skip, -1 };
     }

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -142,17 +142,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 break;
             }
 
-            LexicalPath path = LexicalPath(header.filename());
+            LexicalPath path = TRY(LexicalPath::from_string(header.filename()));
             if (!header.prefix().is_empty())
-                path = path.prepend(header.prefix());
-            DeprecatedString filename = get_override("path"sv).value_or(path.string());
+                path = TRY(path.prepend(header.prefix()));
+            DeprecatedString filename = get_override("path"sv).value_or(path.string().to_deprecated_string());
 
             if (list || verbose)
                 outln("{}", filename);
 
             if (extract) {
                 DeprecatedString absolute_path = Core::File::absolute_path(filename);
-                auto parent_path = LexicalPath(absolute_path).parent();
+                auto parent_path = TRY(TRY(LexicalPath::from_string(absolute_path)).parent());
                 auto header_mode = TRY(header.mode());
 
                 switch (header.type_flag()) {
@@ -228,7 +228,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
 
             auto statbuf = TRY(Core::System::lstat(path));
-            auto canonicalized_path = LexicalPath::canonicalized_path(path);
+            auto canonicalized_path = TRY(LexicalPath::canonicalized_path(path)).to_deprecated_string();
             TRY(tar_stream.add_file(canonicalized_path, statbuf.st_mode, file->read_all()));
             if (verbose)
                 outln("{}", canonicalized_path);
@@ -239,7 +239,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto add_link = [&](DeprecatedString path) -> ErrorOr<void> {
             auto statbuf = TRY(Core::System::lstat(path));
 
-            auto canonicalized_path = LexicalPath::canonicalized_path(path);
+            auto canonicalized_path = TRY(LexicalPath::canonicalized_path(path)).to_deprecated_string();
             TRY(tar_stream.add_link(canonicalized_path, statbuf.st_mode, TRY(Core::System::readlink(path))));
             if (verbose)
                 outln("{}", canonicalized_path);
@@ -250,8 +250,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto add_directory = [&](DeprecatedString path, auto handle_directory) -> ErrorOr<void> {
             auto statbuf = TRY(Core::System::lstat(path));
 
-            auto canonicalized_path = LexicalPath::canonicalized_path(path);
-            TRY(tar_stream.add_directory(canonicalized_path, statbuf.st_mode));
+            auto canonicalized_path = TRY(LexicalPath::canonicalized_path(path));
+            TRY(tar_stream.add_directory(canonicalized_path.to_deprecated_string(), statbuf.st_mode));
             if (verbose)
                 outln("{}", canonicalized_path);
 

--- a/Userland/Utilities/test.cpp
+++ b/Userland/Utilities/test.cpp
@@ -606,7 +606,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     int argc = arguments.argc;
-    if (LexicalPath::basename(arguments.strings[0]) == "[") {
+    if (TRY(LexicalPath::basename(arguments.strings[0])) == "[") {
         --argc;
         if (StringView { arguments.strings[argc] } != "]")
             fatal_error("test invoked as '[' requires a closing bracket ']'");

--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -27,7 +27,7 @@ static bool unpack_zip_member(Archive::ZipMember zip_member, bool quiet)
             outln(" extracting: {}", zip_member.name);
         return true;
     }
-    MUST(Core::Directory::create(LexicalPath(zip_member.name).parent(), Core::Directory::CreateDirectories::Yes));
+    MUST(Core::Directory::create(LexicalPath::from_string(zip_member.name).release_value_but_fixme_should_propagate_errors().parent().release_value_but_fixme_should_propagate_errors(), Core::Directory::CreateDirectories::Yes));
     auto new_file = Core::File::construct(zip_member.name);
     if (!new_file->open(Core::OpenMode::WriteOnly)) {
         warnln("Can't write file {}: {}", zip_member.name, new_file->error_string());

--- a/Userland/Utilities/update-cpp-test-results.cpp
+++ b/Userland/Utilities/update-cpp-test-results.cpp
@@ -13,7 +13,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    Core::DirIterator parser_tests(LexicalPath::join(Core::StandardPaths::home_directory(), "Tests/cpp-tests/parser"sv).string());
+    Core::DirIterator parser_tests(TRY(LexicalPath::join(Core::StandardPaths::home_directory(), "Tests/cpp-tests/parser"sv)).string().to_deprecated_string());
     while (parser_tests.has_next()) {
         auto cpp_full_path = parser_tests.next_full_path();
         if (!cpp_full_path.ends_with(".cpp"sv))
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
         VERIFY(!res.is_error());
     }
 
-    Core::DirIterator preprocessor_tests(LexicalPath::join(Core::StandardPaths::home_directory(), "Tests/cpp-tests/preprocessor"sv).string());
+    Core::DirIterator preprocessor_tests(TRY(LexicalPath::join(Core::StandardPaths::home_directory(), "Tests/cpp-tests/preprocessor"sv)).string().to_deprecated_string());
     while (preprocessor_tests.has_next()) {
         auto cpp_full_path = preprocessor_tests.next_full_path();
         if (!cpp_full_path.ends_with(".cpp"sv))


### PR DESCRIPTION
Ladybird PR: https://github.com/SerenityOS/ladybird/pull/146

Known things that don't work:
* [x] FileManager asserts when launching (something about model row count)
* [x] Memory leak in LexicalPath::from_string() somehow (see [CI](https://dev.azure.com/SerenityOS/SerenityOS/_build/results?buildId=23457&view=logs&j=2566f013-1391-5cbe-90ce-ae4ec398ae06&t=84932543-dadf-5f2f-567f-c183cdc02e79)) -> #16385

- AK: Add StringBuilder::try_append() taking new Strings
- AK: Add String::substring_from_byte_offset(start)
- AK: Add String::find* functions
- AK: Port some string manipulation functions from DeprecatedString
- AK: Port LexicalPath to new Strings
