### PR TITLE
Kernel/aarch64: Initialize components that are already working

### DIFF
--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -130,7 +130,8 @@ extern "C" [[noreturn]] void init()
     dmesgln("Initialize MMU");
     Memory::MemoryManager::initialize(0);
     DeviceManagement::initialize();
-    JailManagement::the();
+    SysFSComponentRegistry::initialize();
+    DeviceManagement::the().attach_null_device(*NullDevice::must_initialize());
 
     // Invoke all static global constructors in the kernel.
     // Note that we want to do this as early as possible.
@@ -148,6 +149,9 @@ extern "C" [[noreturn]] void init()
     Processor::enable_interrupts();
 
     TimeManagement::initialize(0);
+
+    ProcFSComponentRegistry::initialize();
+    JailManagement::the();
 
     auto firmware_version = query_firmware_version();
     dmesgln("Firmware version: {}", firmware_version);


### PR DESCRIPTION
`SysFSComponentRegistry`, `ProcFSComponentRegistry` and `attach_null_device` "just work" already; let's include them to match x86_64 as closely as possible.

![image](https://user-images.githubusercontent.com/108444335/206337476-2c240a2d-4466-4c84-91ac-9a8636f83ae8.png)
