### PR TITLE
LibLine: Retry on failures reading "Report cursor position" terminal command response

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -2006,7 +2006,7 @@ VTState actual_rendered_string_length_step(StringMetrics& metrics, size_t index,
     return state;
 }
 
-static Result<char, Editor::Error> try_read_char_for_vt_dsr_with_retries()
+static Result<char, Editor::Error> read_cursor_position_response_char_with_retries()
 {
     char c;
     Editor::Error error;
@@ -2040,7 +2040,7 @@ static Result<char, Editor::Error> try_read_char_for_vt_dsr_with_retries()
     return error;
 }
 
-Result<Vector<size_t, 2>, Editor::Error> Editor::vt_dsr()
+Result<Vector<size_t, 2>, Editor::Error> Editor::get_cursor_position()
 {
     char buf[16];
 
@@ -2094,7 +2094,7 @@ Result<Vector<size_t, 2>, Editor::Error> Editor::vt_dsr()
     size_t row { 1 }, col { 1 };
 
     do {
-        char c = TRY(try_read_char_for_vt_dsr_with_retries());
+        char c = TRY(read_cursor_position_response_char_with_retries());
 
         switch (state) {
         case Free:

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -276,7 +276,7 @@ private:
 
     void ensure_free_lines_from_origin(size_t count);
 
-    Result<Vector<size_t, 2>, Error> vt_dsr();
+    Result<Vector<size_t, 2>, Error> get_cursor_position();
     void remove_at_index(size_t);
 
     enum class ModificationKind {
@@ -372,7 +372,7 @@ private:
 
     bool set_origin(bool quit_on_error = true)
     {
-        auto position = vt_dsr();
+        auto position = get_cursor_position();
         if (!position.is_error()) {
             set_origin(position.value()[0], position.value()[1]);
             return true;


### PR DESCRIPTION
Apparently, `top`'s terminal escape sequence command heavy usage delays the terminal's response to LibLine's "Report cursor position" command. As a result, `LibLine::Editor::get_line()` was returning an error which caused the Shell process to exit.

Fixes #16306.