### PR TITLE
CrashReporter: Make the close button work again

### DIFF
--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -264,9 +264,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto& close_button = *widget->find_descendant_of_type_named<GUI::Button>("close_button");
     close_button.on_click = [&](auto) {
-        if (unlink_on_exit)
-            unlink_coredump(coredump_path);
-        app->quit();
+        window->close();
     };
     close_button.set_focus(true);
 

--- a/Userland/Libraries/LibGUI/IncrementalSearchBanner.cpp
+++ b/Userland/Libraries/LibGUI/IncrementalSearchBanner.cpp
@@ -20,39 +20,39 @@ IncrementalSearchBanner::IncrementalSearchBanner(TextEditor& editor)
     : m_editor(editor)
 {
     load_from_gml(incremental_search_banner_gml);
-    m_index_label = find_descendant_of_type_named<Label>("index_label");
+    m_index_label = find_descendant_of_type_named<Label>("incremental_search_banner_index_label");
 
-    m_wrap_search_button = find_descendant_of_type_named<Button>("wrap_search_button");
+    m_wrap_search_button = find_descendant_of_type_named<Button>("incremental_search_banner_wrap_search_button");
     m_wrap_search_button->on_checked = [this](auto is_checked) {
         m_wrap_search = is_checked
             ? TextDocument::SearchShouldWrap::Yes
             : TextDocument::SearchShouldWrap::No;
     };
 
-    m_match_case_button = find_descendant_of_type_named<Button>("match_case_button");
+    m_match_case_button = find_descendant_of_type_named<Button>("incremental_search_banner_match_case_button");
     m_match_case_button->on_checked = [this](auto is_checked) {
         m_match_case = is_checked;
         m_editor->reset_search_results();
         search(TextEditor::SearchDirection::Forward);
     };
 
-    m_close_button = find_descendant_of_type_named<Button>("close_button");
+    m_close_button = find_descendant_of_type_named<Button>("incremental_search_banner_close_button");
     m_close_button->set_text("\xE2\x9D\x8C");
     m_close_button->on_click = [this](auto) {
         hide();
     };
 
-    m_next_button = find_descendant_of_type_named<Button>("next_button");
+    m_next_button = find_descendant_of_type_named<Button>("incremental_search_banner_next_button");
     m_next_button->on_click = [this](auto) {
         search(TextEditor::SearchDirection::Forward);
     };
 
-    m_previous_button = find_descendant_of_type_named<Button>("previous_button");
+    m_previous_button = find_descendant_of_type_named<Button>("incremental_search_banner_previous_button");
     m_previous_button->on_click = [this](auto) {
         search(TextEditor::SearchDirection::Backward);
     };
 
-    m_search_textbox = find_descendant_of_type_named<TextBox>("search_textbox");
+    m_search_textbox = find_descendant_of_type_named<TextBox>("incremental_search_banner_search_textbox");
     m_search_textbox->on_change = [this]() {
         m_editor->reset_search_results();
         search(TextEditor::SearchDirection::Forward);

--- a/Userland/Libraries/LibGUI/IncrementalSearchBanner.gml
+++ b/Userland/Libraries/LibGUI/IncrementalSearchBanner.gml
@@ -6,7 +6,7 @@
     }
 
     @GUI::TextBox {
-        name: "search_textbox"
+        name: "incremental_search_banner_search_textbox"
         max_width: 250
         preferred_width: "grow"
         placeholder: "Find"
@@ -19,7 +19,7 @@
         }
 
         @GUI::Button {
-            name: "previous_button"
+            name: "incremental_search_banner_previous_button"
             icon: "/res/icons/16x16/go-up.png"
             fixed_width: 18
             button_style: "Coolbar"
@@ -27,7 +27,7 @@
         }
 
         @GUI::Button {
-            name: "next_button"
+            name: "incremental_search_banner_next_button"
             icon: "/res/icons/16x16/go-down.png"
             fixed_width: 18
             button_style: "Coolbar"
@@ -36,7 +36,7 @@
     }
 
     @GUI::Label {
-        name: "index_label"
+        name: "incremental_search_banner_index_label"
         text_alignment: "CenterLeft"
     }
 
@@ -49,7 +49,7 @@
         }
 
         @GUI::Button {
-            name: "wrap_search_button"
+            name: "incremental_search_banner_wrap_search_button"
             fixed_width: 24
             icon: "/res/icons/16x16/reload.png"
             tooltip: "Wrap Search"
@@ -60,7 +60,7 @@
         }
 
         @GUI::Button {
-            name: "match_case_button"
+            name: "incremental_search_banner_match_case_button"
             fixed_width: 24
             icon: "/res/icons/16x16/app-font-editor.png"
             tooltip: "Match Case"
@@ -73,7 +73,7 @@
     @GUI::VerticalSeparator {}
 
     @GUI::Button {
-        name: "close_button"
+        name: "incremental_search_banner_close_button"
         fixed_size: [15, 16]
         button_style: "Coolbar"
         focus_policy: "NoFocus"


### PR DESCRIPTION
The issue comes from a name collision that confuses `find_descendant_of_type_named` between `CrashReporter`'s close button and the one from the `IncrementalSearchBanner`