### PR TITLE
LibWeb+WebContent+headless-browser: CSS Pixels part 2

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
+#include <LibWeb/PixelUnits.h>
 
 namespace Web::CSS {
 
@@ -28,6 +29,11 @@ Length::Length(float value, Type type)
     , m_value(value)
 {
 }
+Length::Length(CSSPixels value, Type type)
+    : m_type(type)
+    , m_value(value.value())
+{
+}
 Length::~Length() = default;
 
 Length Length::make_auto()
@@ -38,6 +44,11 @@ Length Length::make_auto()
 Length Length::make_px(float value)
 {
     return Length(value, Type::Px);
+}
+
+Length Length::make_px(CSSPixels value)
+{
+    return Length(value.value(), Type::Px);
 }
 
 Length Length::make_calculated(NonnullRefPtr<CalculatedStyleValue> calculated_style_value)

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -9,6 +9,7 @@
 #include <AK/DeprecatedString.h>
 #include <LibGfx/Forward.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/PixelUnits.h>
 
 namespace Web::CSS {
 
@@ -40,10 +41,12 @@ public:
     // this file already. To break the cyclic dependency, we must move all method definitions out.
     Length(int value, Type type);
     Length(float value, Type type);
+    Length(CSSPixels value, Type type);
     ~Length();
 
     static Length make_auto();
     static Length make_px(float value);
+    static Length make_px(CSSPixels value);
     static Length make_calculated(NonnullRefPtr<CalculatedStyleValue>);
     Length percentage_of(Percentage const&) const;
 

--- a/Userland/Libraries/LibWeb/CSS/Screen.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Screen.cpp
@@ -33,7 +33,13 @@ void Screen::visit_edges(Cell::Visitor& visitor)
 
 Gfx::IntRect Screen::screen_rect() const
 {
-    return window().page()->screen_rect();
+    auto screen_rect_in_css_pixels = window().page()->web_exposed_screen_area();
+    return {
+        screen_rect_in_css_pixels.x().value(),
+        screen_rect_in_css_pixels.y().value(),
+        screen_rect_in_css_pixels.width().value(),
+        screen_rect_in_css_pixels.height().value()
+    };
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1210,7 +1210,7 @@ static void scroll_an_element_into_view(DOM::Element& element, Bindings::ScrollB
     if (!layout_node)
         return;
 
-    page->client().page_did_request_scroll_into_view(verify_cast<Layout::Box>(*layout_node).paint_box()->absolute_padding_box_rect().to_rounded<int>());
+    page->client().page_did_request_scroll_into_view(verify_cast<Layout::Box>(*layout_node).paint_box()->absolute_padding_box_rect().to_type<CSSPixels>());
 }
 
 // https://w3c.github.io/csswg-drafts/cssom-view-1/#dom-element-scrollintoview

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -375,7 +375,7 @@ void BrowsingContext::set_needs_display(Gfx::IntRect const& rect)
 
     if (is_top_level()) {
         if (m_page)
-            m_page->client().page_did_invalidate(to_top_level_rect(rect));
+            m_page->client().page_did_invalidate(to_top_level_rect(rect.to_type<CSSPixels>()));
         return;
     }
 
@@ -389,7 +389,7 @@ void BrowsingContext::scroll_to(Gfx::IntPoint position)
         active_document()->force_layout();
 
     if (m_page)
-        m_page->client().page_did_request_scroll_to(position);
+        m_page->client().page_did_request_scroll_to(position.to_type<CSSPixels>());
 }
 
 void BrowsingContext::scroll_to_anchor(DeprecatedString const& fragment)
@@ -427,17 +427,17 @@ void BrowsingContext::scroll_to_anchor(DeprecatedString const& fragment)
     }
 
     if (m_page)
-        m_page->client().page_did_request_scroll_into_view(enclosing_int_rect(float_rect));
+        m_page->client().page_did_request_scroll_into_view(float_rect.to_type<CSSPixels>());
 }
 
-Gfx::IntRect BrowsingContext::to_top_level_rect(Gfx::IntRect const& a_rect)
+CSSPixelRect BrowsingContext::to_top_level_rect(CSSPixelRect const& a_rect)
 {
     auto rect = a_rect;
     rect.set_location(to_top_level_position(a_rect.location()));
     return rect;
 }
 
-Gfx::IntPoint BrowsingContext::to_top_level_position(Gfx::IntPoint a_position)
+CSSPixelPoint BrowsingContext::to_top_level_position(CSSPixelPoint a_position)
 {
     auto position = a_position;
     for (auto ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
@@ -447,7 +447,7 @@ Gfx::IntPoint BrowsingContext::to_top_level_position(Gfx::IntPoint a_position)
             return {};
         if (!ancestor->container()->layout_node())
             return {};
-        position.translate_by(ancestor->container()->layout_node()->box_type_agnostic_position().to_type<int>());
+        position.translate_by(ancestor->container()->layout_node()->box_type_agnostic_position().to_type<CSSPixels>());
     }
     return position;
 }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -183,8 +183,8 @@ public:
     HTML::BrowsingContextContainer* container() { return m_container; }
     HTML::BrowsingContextContainer const* container() const { return m_container; }
 
-    Gfx::IntPoint to_top_level_position(Gfx::IntPoint);
-    Gfx::IntRect to_top_level_rect(Gfx::IntRect const&);
+    CSSPixelPoint to_top_level_position(CSSPixelPoint);
+    CSSPixelRect to_top_level_rect(CSSPixelRect const&);
 
     DOM::Position const& cursor_position() const { return m_cursor_position; }
     void set_cursor_position(DOM::Position);

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -673,12 +673,12 @@ Optional<CSS::MediaFeatureValue> Window::query_media_feature(CSS::MediaFeatureID
     // FIXME: device-aspect-ratio
     case CSS::MediaFeatureID::DeviceHeight:
         if (auto* page = this->page()) {
-            return CSS::MediaFeatureValue(CSS::Length::make_px(page->screen_rect().height()));
+            return CSS::MediaFeatureValue(CSS::Length::make_px(page->web_exposed_screen_area().height().value()));
         }
         return CSS::MediaFeatureValue(0);
     case CSS::MediaFeatureID::DeviceWidth:
         if (auto* page = this->page()) {
-            return CSS::MediaFeatureValue(CSS::Length::make_px(page->screen_rect().width()));
+            return CSS::MediaFeatureValue(CSS::Length::make_px(page->web_exposed_screen_area().width().value()));
         }
         return CSS::MediaFeatureValue(0);
     case CSS::MediaFeatureID::DisplayMode:

--- a/Userland/Libraries/LibWeb/Layout/Label.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Label.cpp
@@ -22,7 +22,7 @@ Label::Label(DOM::Document& document, HTML::HTMLLabelElement* element, NonnullRe
 
 Label::~Label() = default;
 
-void Label::handle_mousedown_on_label(Badge<Painting::TextPaintable>, Gfx::IntPoint, unsigned button)
+void Label::handle_mousedown_on_label(Badge<Painting::TextPaintable>, CSSPixelPoint, unsigned button)
 {
     if (button != GUI::MouseButton::Primary)
         return;
@@ -33,14 +33,14 @@ void Label::handle_mousedown_on_label(Badge<Painting::TextPaintable>, Gfx::IntPo
     m_tracking_mouse = true;
 }
 
-void Label::handle_mouseup_on_label(Badge<Painting::TextPaintable>, Gfx::IntPoint position, unsigned button)
+void Label::handle_mouseup_on_label(Badge<Painting::TextPaintable>, CSSPixelPoint position, unsigned button)
 {
     if (!m_tracking_mouse || button != GUI::MouseButton::Primary)
         return;
 
     if (auto* control = labeled_control(); control) {
-        bool is_inside_control = enclosing_int_rect(control->paint_box()->absolute_rect()).contains(position);
-        bool is_inside_label = enclosing_int_rect(paint_box()->absolute_rect()).contains(position);
+        bool is_inside_control = enclosing_int_rect(control->paint_box()->absolute_rect()).to_type<CSSPixels>().contains(position);
+        bool is_inside_label = enclosing_int_rect(paint_box()->absolute_rect()).to_type<CSSPixels>().contains(position);
 
         if (is_inside_control || is_inside_label)
             control->paintable()->handle_associated_label_mouseup({});
@@ -49,23 +49,23 @@ void Label::handle_mouseup_on_label(Badge<Painting::TextPaintable>, Gfx::IntPoin
     m_tracking_mouse = false;
 }
 
-void Label::handle_mousemove_on_label(Badge<Painting::TextPaintable>, Gfx::IntPoint position, unsigned)
+void Label::handle_mousemove_on_label(Badge<Painting::TextPaintable>, CSSPixelPoint position, unsigned)
 {
     if (!m_tracking_mouse)
         return;
 
     if (auto* control = labeled_control(); control) {
-        bool is_inside_control = enclosing_int_rect(control->paint_box()->absolute_rect()).contains(position);
-        bool is_inside_label = enclosing_int_rect(paint_box()->absolute_rect()).contains(position);
+        bool is_inside_control = enclosing_int_rect(control->paint_box()->absolute_rect()).to_type<CSSPixels>().contains(position);
+        bool is_inside_label = enclosing_int_rect(paint_box()->absolute_rect()).to_type<CSSPixels>().contains(position);
 
         control->paintable()->handle_associated_label_mousemove({}, is_inside_control || is_inside_label);
     }
 }
 
-bool Label::is_inside_associated_label(LabelableNode const& control, Gfx::IntPoint position)
+bool Label::is_inside_associated_label(LabelableNode const& control, CSSPixelPoint position)
 {
     if (auto* label = label_for_control_node(control); label)
-        return enclosing_int_rect(label->paint_box()->absolute_rect()).contains(position);
+        return enclosing_int_rect(label->paint_box()->absolute_rect()).to_type<CSSPixels>().contains(position);
     return false;
 }
 

--- a/Userland/Libraries/LibWeb/Layout/Label.h
+++ b/Userland/Libraries/LibWeb/Layout/Label.h
@@ -18,15 +18,15 @@ public:
     Label(DOM::Document&, HTML::HTMLLabelElement*, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~Label() override;
 
-    static bool is_inside_associated_label(LabelableNode const&, Gfx::IntPoint);
+    static bool is_inside_associated_label(LabelableNode const&, CSSPixelPoint);
     static bool is_associated_label_hovered(LabelableNode const&);
 
     const HTML::HTMLLabelElement& dom_node() const { return static_cast<const HTML::HTMLLabelElement&>(*BlockContainer::dom_node()); }
     HTML::HTMLLabelElement& dom_node() { return static_cast<HTML::HTMLLabelElement&>(*BlockContainer::dom_node()); }
 
-    void handle_mousedown_on_label(Badge<Painting::TextPaintable>, Gfx::IntPoint, unsigned button);
-    void handle_mouseup_on_label(Badge<Painting::TextPaintable>, Gfx::IntPoint, unsigned button);
-    void handle_mousemove_on_label(Badge<Painting::TextPaintable>, Gfx::IntPoint, unsigned button);
+    void handle_mousedown_on_label(Badge<Painting::TextPaintable>, CSSPixelPoint, unsigned button);
+    void handle_mouseup_on_label(Badge<Painting::TextPaintable>, CSSPixelPoint, unsigned button);
+    void handle_mousemove_on_label(Badge<Painting::TextPaintable>, CSSPixelPoint, unsigned button);
 
     LabelableNode* labeled_control();
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -569,14 +569,14 @@ bool EventHandler::handle_doubleclick(Gfx::IntPoint position, unsigned button, u
 
     if (button == GUI::MouseButton::Primary) {
         if (auto result = paint_root()->hit_test(position.to_type<float>(), Painting::HitTestType::TextCursor); result.has_value()) {
-            auto paintable = result->paintable;
-            if (!paintable->dom_node())
+            auto hit_paintable = result->paintable;
+            if (!hit_paintable->dom_node())
                 return true;
 
-            auto const& layout_node = paintable->layout_node();
-            if (!layout_node.is_text_node())
+            auto const& hit_layout_node = hit_paintable->layout_node();
+            if (!hit_layout_node.is_text_node())
                 return true;
-            auto const& text_for_rendering = verify_cast<Layout::TextNode>(layout_node).text_for_rendering();
+            auto const& text_for_rendering = verify_cast<Layout::TextNode>(hit_layout_node).text_for_rendering();
 
             int first_word_break_before = [&] {
                 // Start from one before the index position to prevent selecting only spaces between words, caused by the addition below.

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -14,6 +14,7 @@
 #include <LibGfx/Forward.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Page/EditEventHandler.h>
+#include <LibWeb/PixelUnits.h>
 
 namespace Web {
 
@@ -22,11 +23,11 @@ public:
     explicit EventHandler(Badge<HTML::BrowsingContext>, HTML::BrowsingContext&);
     ~EventHandler();
 
-    bool handle_mouseup(Gfx::IntPoint, unsigned button, unsigned buttons, unsigned modifiers);
-    bool handle_mousedown(Gfx::IntPoint, unsigned button, unsigned buttons, unsigned modifiers);
-    bool handle_mousemove(Gfx::IntPoint, unsigned buttons, unsigned modifiers);
-    bool handle_mousewheel(Gfx::IntPoint, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
-    bool handle_doubleclick(Gfx::IntPoint, unsigned button, unsigned buttons, unsigned modifiers);
+    bool handle_mouseup(CSSPixelPoint, unsigned button, unsigned buttons, unsigned modifiers);
+    bool handle_mousedown(CSSPixelPoint, unsigned button, unsigned buttons, unsigned modifiers);
+    bool handle_mousemove(CSSPixelPoint, unsigned buttons, unsigned modifiers);
+    bool handle_mousewheel(CSSPixelPoint, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
+    bool handle_doubleclick(CSSPixelPoint, unsigned button, unsigned buttons, unsigned modifiers);
 
     bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);
     bool handle_keyup(KeyCode, unsigned modifiers, u32 code_point);

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -122,29 +122,29 @@ DevicePixelRect Page::rounded_device_rect(CSSPixelRect rect) const
     };
 }
 
-bool Page::handle_mousewheel(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y)
+bool Page::handle_mousewheel(DevicePixelPoint position, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y)
 {
-    return top_level_browsing_context().event_handler().handle_mousewheel(position, button, buttons, modifiers, wheel_delta_x, wheel_delta_y);
+    return top_level_browsing_context().event_handler().handle_mousewheel(device_to_css_point(position), button, buttons, modifiers, wheel_delta_x, wheel_delta_y);
 }
 
-bool Page::handle_mouseup(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers)
+bool Page::handle_mouseup(DevicePixelPoint position, unsigned button, unsigned buttons, unsigned modifiers)
 {
-    return top_level_browsing_context().event_handler().handle_mouseup(position, button, buttons, modifiers);
+    return top_level_browsing_context().event_handler().handle_mouseup(device_to_css_point(position), button, buttons, modifiers);
 }
 
-bool Page::handle_mousedown(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers)
+bool Page::handle_mousedown(DevicePixelPoint position, unsigned button, unsigned buttons, unsigned modifiers)
 {
-    return top_level_browsing_context().event_handler().handle_mousedown(position, button, buttons, modifiers);
+    return top_level_browsing_context().event_handler().handle_mousedown(device_to_css_point(position), button, buttons, modifiers);
 }
 
-bool Page::handle_mousemove(Gfx::IntPoint position, unsigned buttons, unsigned modifiers)
+bool Page::handle_mousemove(DevicePixelPoint position, unsigned buttons, unsigned modifiers)
 {
-    return top_level_browsing_context().event_handler().handle_mousemove(position, buttons, modifiers);
+    return top_level_browsing_context().event_handler().handle_mousemove(device_to_css_point(position), buttons, modifiers);
 }
 
-bool Page::handle_doubleclick(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers)
+bool Page::handle_doubleclick(DevicePixelPoint position, unsigned button, unsigned buttons, unsigned modifiers)
 {
-    return top_level_browsing_context().event_handler().handle_doubleclick(position, button, buttons, modifiers);
+    return top_level_browsing_context().event_handler().handle_doubleclick(device_to_css_point(position), button, buttons, modifiers);
 }
 
 bool Page::handle_keydown(KeyCode key, unsigned modifiers, u32 code_point)

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -54,14 +55,71 @@ Gfx::Palette Page::palette() const
     return m_client.palette();
 }
 
-Gfx::IntRect Page::screen_rect() const
+// https://w3c.github.io/csswg-drafts/cssom-view-1/#web-exposed-screen-area
+CSSPixelRect Page::web_exposed_screen_area() const
 {
-    return m_client.screen_rect();
+    auto device_pixel_rect = m_client.screen_rect();
+    auto scale = client().device_pixels_per_css_pixel();
+    return {
+        device_pixel_rect.x().value() / scale,
+        device_pixel_rect.y().value() / scale,
+        device_pixel_rect.width().value() / scale,
+        device_pixel_rect.height().value() / scale
+    };
 }
 
 CSS::PreferredColorScheme Page::preferred_color_scheme() const
 {
     return m_client.preferred_color_scheme();
+}
+
+CSSPixelPoint Page::device_to_css_point(DevicePixelPoint point) const
+{
+    return {
+        point.x().value() / client().device_pixels_per_css_pixel(),
+        point.y().value() / client().device_pixels_per_css_pixel(),
+    };
+}
+
+DevicePixelPoint Page::css_to_device_point(CSSPixelPoint point) const
+{
+    return {
+        point.x().value() * client().device_pixels_per_css_pixel(),
+        point.y().value() * client().device_pixels_per_css_pixel(),
+    };
+}
+
+CSSPixelRect Page::device_to_css_rect(DevicePixelRect rect) const
+{
+    auto scale = client().device_pixels_per_css_pixel();
+    return {
+        rect.x().value() / scale,
+        rect.y().value() / scale,
+        rect.width().value() / scale,
+        rect.height().value() / scale
+    };
+}
+
+DevicePixelRect Page::enclosing_device_rect(CSSPixelRect rect) const
+{
+    auto scale = client().device_pixels_per_css_pixel();
+    return {
+        floorf(rect.x().value() * scale),
+        floorf(rect.y().value() * scale),
+        ceilf(rect.width().value() * scale),
+        ceilf(rect.height().value() * scale)
+    };
+}
+
+DevicePixelRect Page::rounded_device_rect(CSSPixelRect rect) const
+{
+    auto scale = client().device_pixels_per_css_pixel();
+    return {
+        roundf(rect.x().value() * scale),
+        roundf(rect.y().value() * scale),
+        roundf(rect.width().value() * scale),
+        roundf(rect.height().value() * scale)
+    };
 }
 
 bool Page::handle_mousewheel(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y)

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -25,6 +26,7 @@
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Loader/FileRequest.h>
+#include <LibWeb/PixelUnits.h>
 
 namespace Web {
 
@@ -54,6 +56,12 @@ public:
 
     void load_html(StringView, const AK::URL&);
 
+    CSSPixelPoint device_to_css_point(DevicePixelPoint) const;
+    DevicePixelPoint css_to_device_point(CSSPixelPoint) const;
+    CSSPixelRect device_to_css_rect(DevicePixelRect) const;
+    DevicePixelRect enclosing_device_rect(CSSPixelRect) const;
+    DevicePixelRect rounded_device_rect(CSSPixelRect) const;
+
     bool handle_mouseup(Gfx::IntPoint, unsigned button, unsigned buttons, unsigned modifiers);
     bool handle_mousedown(Gfx::IntPoint, unsigned button, unsigned buttons, unsigned modifiers);
     bool handle_mousemove(Gfx::IntPoint, unsigned buttons, unsigned modifiers);
@@ -64,7 +72,7 @@ public:
     bool handle_keyup(KeyCode, unsigned modifiers, u32 code_point);
 
     Gfx::Palette palette() const;
-    Gfx::IntRect screen_rect() const;
+    CSSPixelRect web_exposed_screen_area() const;
     CSS::PreferredColorScheme preferred_color_scheme() const;
 
     bool is_same_origin_policy_enabled() const { return m_same_origin_policy_enabled; }
@@ -139,9 +147,10 @@ public:
     virtual Page const& page() const = 0;
     virtual bool is_connection_open() const = 0;
     virtual Gfx::Palette palette() const = 0;
-    virtual Gfx::IntRect screen_rect() const = 0;
+    virtual DevicePixelRect screen_rect() const = 0;
+    virtual float device_pixels_per_css_pixel() const = 0;
     virtual CSS::PreferredColorScheme preferred_color_scheme() const = 0;
-    virtual void paint(Gfx::IntRect const&, Gfx::Bitmap&) = 0;
+    virtual void paint(DevicePixelRect const&, Gfx::Bitmap&) = 0;
     virtual void page_did_change_title(DeprecatedString const&) { }
     virtual void page_did_request_navigate_back() { }
     virtual void page_did_request_navigate_forward() { }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -62,11 +62,11 @@ public:
     DevicePixelRect enclosing_device_rect(CSSPixelRect) const;
     DevicePixelRect rounded_device_rect(CSSPixelRect) const;
 
-    bool handle_mouseup(Gfx::IntPoint, unsigned button, unsigned buttons, unsigned modifiers);
-    bool handle_mousedown(Gfx::IntPoint, unsigned button, unsigned buttons, unsigned modifiers);
-    bool handle_mousemove(Gfx::IntPoint, unsigned buttons, unsigned modifiers);
-    bool handle_mousewheel(Gfx::IntPoint, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
-    bool handle_doubleclick(Gfx::IntPoint, unsigned button, unsigned buttons, unsigned modifiers);
+    bool handle_mouseup(DevicePixelPoint, unsigned button, unsigned buttons, unsigned modifiers);
+    bool handle_mousedown(DevicePixelPoint, unsigned button, unsigned buttons, unsigned modifiers);
+    bool handle_mousemove(DevicePixelPoint, unsigned buttons, unsigned modifiers);
+    bool handle_mousewheel(DevicePixelPoint, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
+    bool handle_doubleclick(DevicePixelPoint, unsigned button, unsigned buttons, unsigned modifiers);
 
     bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);
     bool handle_keyup(KeyCode, unsigned modifiers, u32 code_point);
@@ -166,21 +166,21 @@ public:
     virtual void page_did_finish_loading(const AK::URL&) { }
     virtual void page_did_change_selection() { }
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) { }
-    virtual void page_did_request_context_menu(Gfx::IntPoint) { }
-    virtual void page_did_request_link_context_menu(Gfx::IntPoint, const AK::URL&, [[maybe_unused]] DeprecatedString const& target, [[maybe_unused]] unsigned modifiers) { }
-    virtual void page_did_request_image_context_menu(Gfx::IntPoint, const AK::URL&, [[maybe_unused]] DeprecatedString const& target, [[maybe_unused]] unsigned modifiers, Gfx::Bitmap const*) { }
+    virtual void page_did_request_context_menu(CSSPixelPoint) { }
+    virtual void page_did_request_link_context_menu(CSSPixelPoint, AK::URL const&, [[maybe_unused]] DeprecatedString const& target, [[maybe_unused]] unsigned modifiers) { }
+    virtual void page_did_request_image_context_menu(CSSPixelPoint, AK::URL const&, [[maybe_unused]] DeprecatedString const& target, [[maybe_unused]] unsigned modifiers, Gfx::Bitmap const*) { }
     virtual void page_did_click_link(const AK::URL&, [[maybe_unused]] DeprecatedString const& target, [[maybe_unused]] unsigned modifiers) { }
     virtual void page_did_middle_click_link(const AK::URL&, [[maybe_unused]] DeprecatedString const& target, [[maybe_unused]] unsigned modifiers) { }
-    virtual void page_did_enter_tooltip_area(Gfx::IntPoint, DeprecatedString const&) { }
+    virtual void page_did_enter_tooltip_area(CSSPixelPoint, DeprecatedString const&) { }
     virtual void page_did_leave_tooltip_area() { }
     virtual void page_did_hover_link(const AK::URL&) { }
     virtual void page_did_unhover_link() { }
-    virtual void page_did_invalidate(Gfx::IntRect const&) { }
+    virtual void page_did_invalidate(CSSPixelRect const&) { }
     virtual void page_did_change_favicon(Gfx::Bitmap const&) { }
     virtual void page_did_layout() { }
     virtual void page_did_request_scroll(i32, i32) { }
-    virtual void page_did_request_scroll_to(Gfx::IntPoint) { }
-    virtual void page_did_request_scroll_into_view(Gfx::IntRect const&) { }
+    virtual void page_did_request_scroll_to(CSSPixelPoint) { }
+    virtual void page_did_request_scroll_into_view(CSSPixelRect const&) { }
     virtual void page_did_request_alert(DeprecatedString const&) { }
     virtual void page_did_request_confirm(DeprecatedString const&) { }
     virtual void page_did_request_prompt(DeprecatedString const&, DeprecatedString const&) { }

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -77,7 +77,7 @@ void paint_border(PaintContext& context, BorderEdge edge, Gfx::IntRect const& re
 
     auto color = border_data.color;
     auto border_style = border_data.line_style;
-    int int_width = ceil(width);
+    int int_width = ceilf(width);
 
     struct Points {
         Gfx::IntPoint p1;
@@ -257,7 +257,7 @@ void paint_all_borders(PaintContext& context, Gfx::FloatRect const& bordered_rec
         top_right = { 0, 0 };
 
     auto int_width = [&](auto value) -> int {
-        return ceil(value);
+        return ceilf(value);
     };
 
     Gfx::IntRect top_border_rect = {

--- a/Userland/Libraries/LibWeb/Painting/LabelablePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/LabelablePaintable.cpp
@@ -35,7 +35,7 @@ Layout::FormAssociatedLabelableNode& LabelablePaintable::layout_box()
     return static_cast<Layout::FormAssociatedLabelableNode&>(PaintableBox::layout_box());
 }
 
-LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mousedown(Badge<EventHandler>, Gfx::IntPoint, unsigned button, unsigned)
+LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mousedown(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned)
 {
     if (button != GUI::MouseButton::Primary || !layout_box().dom_node().enabled())
         return DispatchEventOfSameName::No;
@@ -46,12 +46,12 @@ LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mousedown
     return DispatchEventOfSameName::Yes;
 }
 
-LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mouseup(Badge<EventHandler>, Gfx::IntPoint position, unsigned button, unsigned)
+LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mouseup(Badge<EventHandler>, CSSPixelPoint position, unsigned button, unsigned)
 {
     if (!m_tracking_mouse || button != GUI::MouseButton::Primary || !layout_box().dom_node().enabled())
         return DispatchEventOfSameName::No;
 
-    bool is_inside_node_or_label = enclosing_int_rect(absolute_rect()).contains(position);
+    bool is_inside_node_or_label = absolute_rect().to_type<CSSPixels>().contains(position);
     if (!is_inside_node_or_label)
         is_inside_node_or_label = Layout::Label::is_inside_associated_label(layout_box(), position);
 
@@ -61,12 +61,12 @@ LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mouseup(B
     return DispatchEventOfSameName::Yes;
 }
 
-LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mousemove(Badge<EventHandler>, Gfx::IntPoint position, unsigned, unsigned)
+LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mousemove(Badge<EventHandler>, CSSPixelPoint position, unsigned, unsigned)
 {
     if (!m_tracking_mouse || !layout_box().dom_node().enabled())
         return DispatchEventOfSameName::No;
 
-    bool is_inside_node_or_label = enclosing_int_rect(absolute_rect()).contains(position);
+    bool is_inside_node_or_label = absolute_rect().to_type<CSSPixels>().contains(position);
     if (!is_inside_node_or_label)
         is_inside_node_or_label = Layout::Label::is_inside_associated_label(layout_box(), position);
 

--- a/Userland/Libraries/LibWeb/Painting/LabelablePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/LabelablePaintable.h
@@ -21,9 +21,9 @@ public:
     Layout::FormAssociatedLabelableNode& layout_box();
 
     virtual bool wants_mouse_events() const override { return true; }
-    virtual DispatchEventOfSameName handle_mousedown(Badge<EventHandler>, Gfx::IntPoint, unsigned button, unsigned modifiers) override;
-    virtual DispatchEventOfSameName handle_mouseup(Badge<EventHandler>, Gfx::IntPoint, unsigned button, unsigned modifiers) override;
-    virtual DispatchEventOfSameName handle_mousemove(Badge<EventHandler>, Gfx::IntPoint, unsigned buttons, unsigned modifiers) override;
+    virtual DispatchEventOfSameName handle_mousedown(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers) override;
+    virtual DispatchEventOfSameName handle_mouseup(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers) override;
+    virtual DispatchEventOfSameName handle_mousemove(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers) override;
 
     void handle_associated_label_mousedown(Badge<Layout::Label>);
     void handle_associated_label_mouseup(Badge<Layout::Label>);

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.cpp
@@ -8,10 +8,9 @@
 
 namespace Web {
 
-PaintContext::PaintContext(Gfx::Painter& painter, Palette const& palette, Gfx::IntPoint scroll_offset)
+PaintContext::PaintContext(Gfx::Painter& painter, Palette const& palette)
     : m_painter(painter)
     , m_palette(palette)
-    , m_scroll_offset(scroll_offset)
 {
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.h
@@ -16,7 +16,7 @@ namespace Web {
 
 class PaintContext {
 public:
-    PaintContext(Gfx::Painter& painter, Palette const& palette, Gfx::IntPoint scroll_offset);
+    PaintContext(Gfx::Painter& painter, Palette const& palette);
 
     Gfx::Painter& painter() const { return m_painter; }
     Palette const& palette() const { return m_palette; }
@@ -32,14 +32,12 @@ public:
     Gfx::IntRect viewport_rect() const { return m_viewport_rect; }
     void set_viewport_rect(Gfx::IntRect const& rect) { m_viewport_rect = rect; }
 
-    Gfx::IntPoint scroll_offset() const { return m_scroll_offset; }
-
     bool has_focus() const { return m_focus; }
     void set_has_focus(bool focus) { m_focus = focus; }
 
     PaintContext clone(Gfx::Painter& painter) const
     {
-        auto clone = PaintContext(painter, m_palette, m_scroll_offset);
+        auto clone = PaintContext(painter, m_palette);
         clone.m_viewport_rect = m_viewport_rect;
         clone.m_should_show_line_box_borders = m_should_show_line_box_borders;
         clone.m_focus = m_focus;
@@ -52,7 +50,6 @@ private:
     Palette m_palette;
     Optional<SVGContext> m_svg_context;
     Gfx::IntRect m_viewport_rect;
-    Gfx::IntPoint m_scroll_offset;
     bool m_should_show_line_box_borders { false };
     bool m_focus { false };
 };

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -10,22 +10,22 @@
 
 namespace Web::Painting {
 
-Paintable::DispatchEventOfSameName Paintable::handle_mousedown(Badge<EventHandler>, Gfx::IntPoint, unsigned, unsigned)
+Paintable::DispatchEventOfSameName Paintable::handle_mousedown(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned)
 {
     return DispatchEventOfSameName::Yes;
 }
 
-Paintable::DispatchEventOfSameName Paintable::handle_mouseup(Badge<EventHandler>, Gfx::IntPoint, unsigned, unsigned)
+Paintable::DispatchEventOfSameName Paintable::handle_mouseup(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned)
 {
     return DispatchEventOfSameName::Yes;
 }
 
-Paintable::DispatchEventOfSameName Paintable::handle_mousemove(Badge<EventHandler>, Gfx::IntPoint, unsigned, unsigned)
+Paintable::DispatchEventOfSameName Paintable::handle_mousemove(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned)
 {
     return DispatchEventOfSameName::Yes;
 }
 
-bool Paintable::handle_mousewheel(Badge<EventHandler>, Gfx::IntPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y)
+bool Paintable::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y)
 {
     if (auto* containing_block = this->containing_block()) {
         if (!containing_block->is_scrollable())
@@ -41,7 +41,7 @@ bool Paintable::handle_mousewheel(Badge<EventHandler>, Gfx::IntPoint, unsigned, 
     return false;
 }
 
-Optional<HitTestResult> Paintable::hit_test(Gfx::FloatPoint, HitTestType) const
+Optional<HitTestResult> Paintable::hit_test(CSSPixelPoint, HitTestType) const
 {
     return {};
 }

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -89,7 +89,7 @@ public:
     virtual void before_children_paint(PaintContext&, PaintPhase) const { }
     virtual void after_children_paint(PaintContext&, PaintPhase) const { }
 
-    virtual Optional<HitTestResult> hit_test(Gfx::FloatPoint, HitTestType) const;
+    virtual Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const;
 
     virtual bool wants_mouse_events() const { return false; }
 
@@ -100,12 +100,12 @@ public:
     // When these methods return true, the DOM event with the same name will be
     // dispatch at the mouse_event_target if it returns a valid DOM::Node, or
     // the layout node's associated DOM node if it doesn't.
-    virtual DispatchEventOfSameName handle_mousedown(Badge<EventHandler>, Gfx::IntPoint, unsigned button, unsigned modifiers);
-    virtual DispatchEventOfSameName handle_mouseup(Badge<EventHandler>, Gfx::IntPoint, unsigned button, unsigned modifiers);
-    virtual DispatchEventOfSameName handle_mousemove(Badge<EventHandler>, Gfx::IntPoint, unsigned buttons, unsigned modifiers);
+    virtual DispatchEventOfSameName handle_mousedown(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers);
+    virtual DispatchEventOfSameName handle_mouseup(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers);
+    virtual DispatchEventOfSameName handle_mousemove(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers);
     virtual DOM::Node* mouse_event_target() const { return nullptr; }
 
-    virtual bool handle_mousewheel(Badge<EventHandler>, Gfx::IntPoint, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
+    virtual bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
 
     Layout::Node const& layout_node() const { return m_layout_node; }
     Layout::Node& layout_node() { return const_cast<Layout::Node&>(m_layout_node); }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -115,7 +115,7 @@ public:
     virtual void before_children_paint(PaintContext&, PaintPhase) const override;
     virtual void after_children_paint(PaintContext&, PaintPhase) const override;
 
-    virtual Optional<HitTestResult> hit_test(Gfx::FloatPoint, HitTestType) const override;
+    virtual Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const override;
 
     void invalidate_stacking_context();
 
@@ -188,9 +188,9 @@ public:
 
     virtual void paint(PaintContext&, PaintPhase) const override;
     virtual bool wants_mouse_events() const override { return false; }
-    virtual bool handle_mousewheel(Badge<EventHandler>, Gfx::IntPoint, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y) override;
+    virtual bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y) override;
 
-    virtual Optional<HitTestResult> hit_test(Gfx::FloatPoint, HitTestType) const override;
+    virtual Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const override;
 
 protected:
     PaintableWithLines(Layout::BlockContainer const&);

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -439,17 +439,22 @@ static TraversalDecision for_each_in_subtree_of_type_within_same_stacking_contex
     return TraversalDecision::Continue;
 }
 
-Optional<HitTestResult> StackingContext::hit_test(Gfx::FloatPoint position, HitTestType type) const
+Optional<HitTestResult> StackingContext::hit_test(CSSPixelPoint position, HitTestType type) const
 {
     if (!m_box.is_visible())
         return {};
 
-    auto transform_origin = this->transform_origin();
-    auto transformed_position = affine_transform_matrix().inverse().value_or({}).map(position - transform_origin) + transform_origin;
+    auto transform_origin = this->transform_origin().to_type<CSSPixels>();
+    // NOTE: This CSSPixels -> Float -> CSSPixels conversion is because we can't AffineTransform::map() a CSSPixelPoint.
+    Gfx::FloatPoint offset_position {
+        position.x().value() - transform_origin.x().value(),
+        position.y().value() - transform_origin.y().value()
+    };
+    auto transformed_position = affine_transform_matrix().inverse().value_or({}).map(offset_position).to_type<CSSPixels>() + transform_origin;
 
     // FIXME: Support more overflow variations.
     if (paintable().computed_values().overflow_x() == CSS::Overflow::Hidden && paintable().computed_values().overflow_y() == CSS::Overflow::Hidden) {
-        if (!paintable().absolute_border_box_rect().contains(transformed_position.x(), transformed_position.y()))
+        if (!paintable().absolute_border_box_rect().contains(transformed_position.x().value(), transformed_position.y().value()))
             return {};
     }
 
@@ -473,7 +478,7 @@ Optional<HitTestResult> StackingContext::hit_test(Gfx::FloatPoint position, HitT
     for_each_in_subtree_of_type_within_same_stacking_context_in_reverse<PaintableBox>(paintable(), [&](PaintableBox const& paint_box) {
         // FIXME: Support more overflow variations.
         if (paint_box.computed_values().overflow_x() == CSS::Overflow::Hidden && paint_box.computed_values().overflow_y() == CSS::Overflow::Hidden) {
-            if (!paint_box.absolute_border_box_rect().contains(transformed_position.x(), transformed_position.y()))
+            if (!paint_box.absolute_border_box_rect().contains(transformed_position.x().value(), transformed_position.y().value()))
                 return TraversalDecision::SkipChildrenAndContinue;
         }
 
@@ -511,7 +516,7 @@ Optional<HitTestResult> StackingContext::hit_test(Gfx::FloatPoint position, HitT
     for_each_in_subtree_of_type_within_same_stacking_context_in_reverse<PaintableBox>(paintable(), [&](auto const& paint_box) {
         // FIXME: Support more overflow variations.
         if (paint_box.computed_values().overflow_x() == CSS::Overflow::Hidden && paint_box.computed_values().overflow_y() == CSS::Overflow::Hidden) {
-            if (!paint_box.absolute_border_box_rect().contains(transformed_position.x(), transformed_position.y()))
+            if (!paint_box.absolute_border_box_rect().contains(transformed_position.x().value(), transformed_position.y().value()))
                 return TraversalDecision::SkipChildrenAndContinue;
         }
 
@@ -532,7 +537,7 @@ Optional<HitTestResult> StackingContext::hit_test(Gfx::FloatPoint position, HitT
         for_each_in_subtree_of_type_within_same_stacking_context_in_reverse<PaintableBox>(paintable(), [&](auto const& paint_box) {
             // FIXME: Support more overflow variations.
             if (paint_box.computed_values().overflow_x() == CSS::Overflow::Hidden && paint_box.computed_values().overflow_y() == CSS::Overflow::Hidden) {
-                if (!paint_box.absolute_border_box_rect().contains(transformed_position.x(), transformed_position.y()))
+                if (!paint_box.absolute_border_box_rect().contains(transformed_position.x().value(), transformed_position.y().value()))
                     return TraversalDecision::SkipChildrenAndContinue;
             }
 
@@ -561,7 +566,7 @@ Optional<HitTestResult> StackingContext::hit_test(Gfx::FloatPoint position, HitT
     }
 
     // 1. the background and borders of the element forming the stacking context.
-    if (paintable().absolute_border_box_rect().contains(transformed_position)) {
+    if (paintable().absolute_border_box_rect().contains(transformed_position.x().value(), transformed_position.y().value())) {
         return HitTestResult {
             .paintable = paintable(),
         };

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.h
@@ -32,7 +32,7 @@ public:
 
     void paint_descendants(PaintContext&, Layout::Node const&, StackingContextPaintPhase) const;
     void paint(PaintContext&) const;
-    Optional<HitTestResult> hit_test(Gfx::FloatPoint, HitTestType) const;
+    Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const;
 
     Gfx::FloatMatrix4x4 const& transform_matrix() const { return m_transform; }
     Gfx::AffineTransform affine_transform_matrix() const;

--- a/Userland/Libraries/LibWeb/Painting/TextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/TextPaintable.cpp
@@ -36,7 +36,7 @@ DOM::Node* TextPaintable::mouse_event_target() const
     return nullptr;
 }
 
-TextPaintable::DispatchEventOfSameName TextPaintable::handle_mousedown(Badge<EventHandler>, Gfx::IntPoint position, unsigned button, unsigned)
+TextPaintable::DispatchEventOfSameName TextPaintable::handle_mousedown(Badge<EventHandler>, CSSPixelPoint position, unsigned button, unsigned)
 {
     auto* label = layout_node().first_ancestor_of_type<Layout::Label>();
     if (!label)
@@ -46,7 +46,7 @@ TextPaintable::DispatchEventOfSameName TextPaintable::handle_mousedown(Badge<Eve
     return DispatchEventOfSameName::Yes;
 }
 
-TextPaintable::DispatchEventOfSameName TextPaintable::handle_mouseup(Badge<EventHandler>, Gfx::IntPoint position, unsigned button, unsigned)
+TextPaintable::DispatchEventOfSameName TextPaintable::handle_mouseup(Badge<EventHandler>, CSSPixelPoint position, unsigned button, unsigned)
 {
     auto* label = layout_node().first_ancestor_of_type<Layout::Label>();
     if (!label)
@@ -57,7 +57,7 @@ TextPaintable::DispatchEventOfSameName TextPaintable::handle_mouseup(Badge<Event
     return DispatchEventOfSameName::Yes;
 }
 
-TextPaintable::DispatchEventOfSameName TextPaintable::handle_mousemove(Badge<EventHandler>, Gfx::IntPoint position, unsigned button, unsigned)
+TextPaintable::DispatchEventOfSameName TextPaintable::handle_mousemove(Badge<EventHandler>, CSSPixelPoint position, unsigned button, unsigned)
 {
     auto* label = layout_node().first_ancestor_of_type<Layout::Label>();
     if (!label)

--- a/Userland/Libraries/LibWeb/Painting/TextPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/TextPaintable.h
@@ -18,9 +18,9 @@ public:
 
     virtual bool wants_mouse_events() const override;
     virtual DOM::Node* mouse_event_target() const override;
-    virtual DispatchEventOfSameName handle_mousedown(Badge<EventHandler>, Gfx::IntPoint, unsigned button, unsigned modifiers) override;
-    virtual DispatchEventOfSameName handle_mouseup(Badge<EventHandler>, Gfx::IntPoint, unsigned button, unsigned modifiers) override;
-    virtual DispatchEventOfSameName handle_mousemove(Badge<EventHandler>, Gfx::IntPoint, unsigned button, unsigned modifiers) override;
+    virtual DispatchEventOfSameName handle_mousedown(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers) override;
+    virtual DispatchEventOfSameName handle_mouseup(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers) override;
+    virtual DispatchEventOfSameName handle_mousemove(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers) override;
 
 private:
     explicit TextPaintable(Layout::TextNode const&);

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -52,13 +52,13 @@ MouseEvent* MouseEvent::create(JS::Realm& realm, FlyString const& event_name, Mo
     return realm.heap().allocate<MouseEvent>(realm, realm, event_name, event_init);
 }
 
-MouseEvent* MouseEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, unsigned buttons, unsigned mouse_button)
+MouseEvent* MouseEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, unsigned buttons, unsigned mouse_button)
 {
     MouseEventInit event_init {};
-    event_init.offset_x = offset_x;
-    event_init.offset_y = offset_y;
-    event_init.client_x = client_x;
-    event_init.client_y = client_y;
+    event_init.offset_x = static_cast<double>(offset_x.value());
+    event_init.offset_y = static_cast<double>(offset_y.value());
+    event_init.client_x = static_cast<double>(client_x.value());
+    event_init.client_y = static_cast<double>(client_y.value());
     event_init.button = determine_button(mouse_button);
     event_init.buttons = buttons;
     return MouseEvent::create(realm, event_name, event_init);

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/TypeCasts.h>
+#include <LibWeb/PixelUnits.h>
 #include <LibWeb/UIEvents/EventModifier.h>
 #include <LibWeb/UIEvents/UIEvent.h>
 
@@ -27,7 +28,7 @@ class MouseEvent : public UIEvent {
 
 public:
     static MouseEvent* create(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init = {});
-    static MouseEvent* create_from_platform_event(JS::Realm&, FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, unsigned buttons, unsigned mouse_button = 1);
+    static MouseEvent* create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, unsigned buttons, unsigned mouse_button = 1);
 
     virtual ~MouseEvent() override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
@@ -28,13 +28,13 @@ WheelEvent* WheelEvent::create(JS::Realm& realm, FlyString const& event_name, Wh
     return realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init);
 }
 
-WheelEvent* WheelEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, double delta_x, double delta_y, unsigned buttons, unsigned button)
+WheelEvent* WheelEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button)
 {
     WheelEventInit event_init {};
-    event_init.offset_x = offset_x;
-    event_init.offset_y = offset_y;
-    event_init.client_x = client_x;
-    event_init.client_y = client_y;
+    event_init.offset_x = static_cast<double>(offset_x.value());
+    event_init.offset_y = static_cast<double>(offset_y.value());
+    event_init.client_x = static_cast<double>(client_x.value());
+    event_init.client_y = static_cast<double>(client_y.value());
     event_init.button = button;
     event_init.buttons = buttons;
     event_init.delta_x = delta_x;

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
@@ -30,7 +30,7 @@ class WheelEvent final : public MouseEvent {
 
 public:
     static WheelEvent* create(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init = {});
-    static WheelEvent* create_from_platform_event(JS::Realm&, FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, double delta_x, double delta_y, unsigned buttons, unsigned button);
+    static WheelEvent* create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button);
 
     virtual ~WheelEvent() override;
 

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -149,7 +149,7 @@ void ConnectionFromClient::paint(Gfx::IntRect const& content_rect, i32 backing_s
 void ConnectionFromClient::flush_pending_paint_requests()
 {
     for (auto& pending_paint : m_pending_paint_requests) {
-        m_page_host->paint(pending_paint.content_rect, *pending_paint.bitmap);
+        m_page_host->paint(pending_paint.content_rect.to_type<Web::DevicePixels>(), *pending_paint.bitmap);
         async_did_paint(pending_paint.content_rect, pending_paint.bitmap_id);
     }
     m_pending_paint_requests.clear();
@@ -461,9 +461,9 @@ Messages::WebContentServer::TakeDocumentScreenshotResponse ConnectionFromClient:
         return { {} };
 
     auto const& content_size = m_page_host->content_size();
-    Gfx::IntRect rect { { 0, 0 }, content_size };
+    Web::DevicePixelRect rect { { 0, 0 }, content_size };
 
-    auto bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, rect.size()).release_value_but_fixme_should_propagate_errors();
+    auto bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>()).release_value_but_fixme_should_propagate_errors();
     m_page_host->paint(rect, *bitmap);
 
     return { bitmap->to_shareable_bitmap() };

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -157,27 +157,27 @@ void ConnectionFromClient::flush_pending_paint_requests()
 
 void ConnectionFromClient::mouse_down(Gfx::IntPoint position, unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
-    report_finished_handling_input_event(page().handle_mousedown(position, button, buttons, modifiers));
+    report_finished_handling_input_event(page().handle_mousedown(position.to_type<Web::DevicePixels>(), button, buttons, modifiers));
 }
 
 void ConnectionFromClient::mouse_move(Gfx::IntPoint position, [[maybe_unused]] unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
-    report_finished_handling_input_event(page().handle_mousemove(position, buttons, modifiers));
+    report_finished_handling_input_event(page().handle_mousemove(position.to_type<Web::DevicePixels>(), buttons, modifiers));
 }
 
 void ConnectionFromClient::mouse_up(Gfx::IntPoint position, unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
-    report_finished_handling_input_event(page().handle_mouseup(position, button, buttons, modifiers));
+    report_finished_handling_input_event(page().handle_mouseup(position.to_type<Web::DevicePixels>(), button, buttons, modifiers));
 }
 
 void ConnectionFromClient::mouse_wheel(Gfx::IntPoint position, unsigned int button, unsigned int buttons, unsigned int modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
 {
-    report_finished_handling_input_event(page().handle_mousewheel(position, button, buttons, modifiers, wheel_delta_x, wheel_delta_y));
+    report_finished_handling_input_event(page().handle_mousewheel(position.to_type<Web::DevicePixels>(), button, buttons, modifiers, wheel_delta_x, wheel_delta_y));
 }
 
 void ConnectionFromClient::doubleclick(Gfx::IntPoint position, unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
-    report_finished_handling_input_event(page().handle_doubleclick(position, button, buttons, modifiers));
+    report_finished_handling_input_event(page().handle_doubleclick(position.to_type<Web::DevicePixels>(), button, buttons, modifiers));
 }
 
 void ConnectionFromClient::key_down(i32 key, unsigned int modifiers, u32 code_point)

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -26,7 +26,7 @@ PageHost::PageHost(ConnectionFromClient& client)
 {
     setup_palette();
     m_invalidation_coalescing_timer = Web::Platform::Timer::create_single_shot(0, [this] {
-        m_client.async_did_invalidate_content_rect(m_invalidation_rect);
+        m_client.async_did_invalidate_content_rect({ m_invalidation_rect.x().value(), m_invalidation_rect.y().value(), m_invalidation_rect.width().value(), m_invalidation_rect.height().value() });
         m_invalidation_rect = {};
     });
 }
@@ -130,9 +130,9 @@ void PageHost::set_viewport_rect(Gfx::IntRect const& rect)
     page().top_level_browsing_context().set_viewport_rect(rect);
 }
 
-void PageHost::page_did_invalidate(Gfx::IntRect const& content_rect)
+void PageHost::page_did_invalidate(Web::CSSPixelRect const& content_rect)
 {
-    m_invalidation_rect = m_invalidation_rect.united(content_rect);
+    m_invalidation_rect = m_invalidation_rect.united(page().enclosing_device_rect(content_rect));
     if (!m_invalidation_coalescing_timer->is_active())
         m_invalidation_coalescing_timer->start();
 }
@@ -213,19 +213,23 @@ void PageHost::page_did_request_scroll(i32 x_delta, i32 y_delta)
     m_client.async_did_request_scroll(x_delta, y_delta);
 }
 
-void PageHost::page_did_request_scroll_to(Gfx::IntPoint scroll_position)
+void PageHost::page_did_request_scroll_to(Web::CSSPixelPoint scroll_position)
 {
-    m_client.async_did_request_scroll_to(scroll_position);
+    m_client.async_did_request_scroll_to({ scroll_position.x().value(), scroll_position.y().value() });
 }
 
-void PageHost::page_did_request_scroll_into_view(Gfx::IntRect const& rect)
+void PageHost::page_did_request_scroll_into_view(Web::CSSPixelRect const& rect)
 {
-    m_client.async_did_request_scroll_into_view(rect);
+    auto device_pixel_rect = page().enclosing_device_rect(rect);
+    m_client.async_did_request_scroll_into_view({ device_pixel_rect.x().value(),
+        device_pixel_rect.y().value(),
+        device_pixel_rect.width().value(),
+        device_pixel_rect.height().value() });
 }
 
-void PageHost::page_did_enter_tooltip_area(Gfx::IntPoint content_position, DeprecatedString const& title)
+void PageHost::page_did_enter_tooltip_area(Web::CSSPixelPoint content_position, DeprecatedString const& title)
 {
-    m_client.async_did_enter_tooltip_area(content_position, title);
+    m_client.async_did_enter_tooltip_area({ content_position.x().value(), content_position.y().value() }, title);
 }
 
 void PageHost::page_did_leave_tooltip_area()
@@ -268,14 +272,14 @@ void PageHost::page_did_finish_loading(const URL& url)
     m_client.async_did_finish_loading(url);
 }
 
-void PageHost::page_did_request_context_menu(Gfx::IntPoint content_position)
+void PageHost::page_did_request_context_menu(Web::CSSPixelPoint content_position)
 {
-    m_client.async_did_request_context_menu(content_position);
+    m_client.async_did_request_context_menu(page().css_to_device_point(content_position).to_type<int>());
 }
 
-void PageHost::page_did_request_link_context_menu(Gfx::IntPoint content_position, const URL& url, DeprecatedString const& target, unsigned modifiers)
+void PageHost::page_did_request_link_context_menu(Web::CSSPixelPoint content_position, URL const& url, DeprecatedString const& target, unsigned modifiers)
 {
-    m_client.async_did_request_link_context_menu(content_position, url, target, modifiers);
+    m_client.async_did_request_link_context_menu(page().css_to_device_point(content_position).to_type<int>(), url, target, modifiers);
 }
 
 void PageHost::page_did_request_alert(DeprecatedString const& message)
@@ -328,10 +332,10 @@ void PageHost::page_did_change_favicon(Gfx::Bitmap const& favicon)
     m_client.async_did_change_favicon(favicon.to_shareable_bitmap());
 }
 
-void PageHost::page_did_request_image_context_menu(Gfx::IntPoint content_position, const URL& url, DeprecatedString const& target, unsigned modifiers, Gfx::Bitmap const* bitmap_pointer)
+void PageHost::page_did_request_image_context_menu(Web::CSSPixelPoint content_position, URL const& url, DeprecatedString const& target, unsigned modifiers, Gfx::Bitmap const* bitmap_pointer)
 {
     auto bitmap = bitmap_pointer ? bitmap_pointer->to_shareable_bitmap() : Gfx::ShareableBitmap();
-    m_client.async_did_request_image_context_menu(content_position, url, target, modifiers, bitmap);
+    m_client.async_did_request_image_context_menu({ content_position.x().value(), content_position.y().value() }, url, target, modifiers, bitmap);
 }
 
 Vector<Web::Cookie::Cookie> PageHost::page_did_request_all_cookies(URL const& url)

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -118,7 +118,7 @@ void PageHost::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& targ
         return;
     }
 
-    Web::PaintContext context(painter, palette(), content_rect.top_left().to_type<int>());
+    Web::PaintContext context(painter, palette());
     context.set_should_show_line_box_borders(m_should_show_line_box_borders);
     context.set_viewport_rect(content_rect.to_type<int>());
     context.set_has_focus(m_has_focus);

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -104,10 +104,10 @@ Web::Layout::InitialContainingBlock* PageHost::layout_root()
     return document->layout_node();
 }
 
-void PageHost::paint(Gfx::IntRect const& content_rect, Gfx::Bitmap& target)
+void PageHost::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& target)
 {
     Gfx::Painter painter(target);
-    Gfx::IntRect bitmap_rect { {}, content_rect.size() };
+    Gfx::IntRect bitmap_rect { {}, content_rect.size().to_type<int>() };
 
     if (auto* document = page().top_level_browsing_context().active_document())
         document->update_layout();
@@ -118,9 +118,9 @@ void PageHost::paint(Gfx::IntRect const& content_rect, Gfx::Bitmap& target)
         return;
     }
 
-    Web::PaintContext context(painter, palette(), content_rect.top_left());
+    Web::PaintContext context(painter, palette(), content_rect.top_left().to_type<int>());
     context.set_should_show_line_box_borders(m_should_show_line_box_borders);
-    context.set_viewport_rect(content_rect);
+    context.set_viewport_rect(content_rect.to_type<int>());
     context.set_has_focus(m_has_focus);
     layout_root->paint_all_phases(context);
 }
@@ -152,10 +152,10 @@ void PageHost::page_did_layout()
     auto* layout_root = this->layout_root();
     VERIFY(layout_root);
     if (layout_root->paint_box()->has_overflow())
-        m_content_size = enclosing_int_rect(layout_root->paint_box()->scrollable_overflow_rect().value()).size();
+        m_content_size = page().enclosing_device_rect(layout_root->paint_box()->scrollable_overflow_rect().value().to_type<Web::CSSPixels>()).size();
     else
-        m_content_size = enclosing_int_rect(layout_root->paint_box()->absolute_rect()).size();
-    m_client.async_did_layout(m_content_size);
+        m_content_size = page().enclosing_device_rect(layout_root->paint_box()->absolute_rect().to_type<Web::CSSPixels>()).size();
+    m_client.async_did_layout(m_content_size.to_type<int>());
 }
 
 void PageHost::page_did_change_title(DeprecatedString const& title)

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -55,7 +55,7 @@ private:
     virtual Web::DevicePixelRect screen_rect() const override { return m_screen_rect; }
     virtual float device_pixels_per_css_pixel() const override { return m_screen_display_scale; }
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override { return m_preferred_color_scheme; }
-    virtual void page_did_invalidate(Gfx::IntRect const&) override;
+    virtual void page_did_invalidate(Web::CSSPixelRect const&) override;
     virtual void page_did_change_selection() override;
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) override;
     virtual void page_did_layout() override;
@@ -70,16 +70,16 @@ private:
     virtual Gfx::IntRect page_did_request_minimize_window() override;
     virtual Gfx::IntRect page_did_request_fullscreen_window() override;
     virtual void page_did_request_scroll(i32, i32) override;
-    virtual void page_did_request_scroll_to(Gfx::IntPoint) override;
-    virtual void page_did_request_scroll_into_view(Gfx::IntRect const&) override;
-    virtual void page_did_enter_tooltip_area(Gfx::IntPoint, DeprecatedString const&) override;
+    virtual void page_did_request_scroll_to(Web::CSSPixelPoint) override;
+    virtual void page_did_request_scroll_into_view(Web::CSSPixelRect const&) override;
+    virtual void page_did_enter_tooltip_area(Web::CSSPixelPoint, DeprecatedString const&) override;
     virtual void page_did_leave_tooltip_area() override;
     virtual void page_did_hover_link(const URL&) override;
     virtual void page_did_unhover_link() override;
     virtual void page_did_click_link(const URL&, DeprecatedString const& target, unsigned modifiers) override;
     virtual void page_did_middle_click_link(const URL&, DeprecatedString const& target, unsigned modifiers) override;
-    virtual void page_did_request_context_menu(Gfx::IntPoint) override;
-    virtual void page_did_request_link_context_menu(Gfx::IntPoint, const URL&, DeprecatedString const& target, unsigned modifiers) override;
+    virtual void page_did_request_context_menu(Web::CSSPixelPoint) override;
+    virtual void page_did_request_link_context_menu(Web::CSSPixelPoint, URL const&, DeprecatedString const& target, unsigned modifiers) override;
     virtual void page_did_start_loading(const URL&, bool) override;
     virtual void page_did_create_main_document() override;
     virtual void page_did_finish_loading(const URL&) override;
@@ -90,7 +90,7 @@ private:
     virtual void page_did_request_accept_dialog() override;
     virtual void page_did_request_dismiss_dialog() override;
     virtual void page_did_change_favicon(Gfx::Bitmap const&) override;
-    virtual void page_did_request_image_context_menu(Gfx::IntPoint, const URL&, DeprecatedString const& target, unsigned modifiers, Gfx::Bitmap const*) override;
+    virtual void page_did_request_image_context_menu(Web::CSSPixelPoint, const URL&, DeprecatedString const& target, unsigned modifiers, Gfx::Bitmap const*) override;
     virtual Vector<Web::Cookie::Cookie> page_did_request_all_cookies(URL const&) override;
     virtual Optional<Web::Cookie::Cookie> page_did_request_named_cookie(URL const&, DeprecatedString const&) override;
     virtual DeprecatedString page_did_request_cookie(const URL&, Web::Cookie::Source) override;
@@ -115,7 +115,7 @@ private:
     bool m_has_focus { false };
 
     RefPtr<Web::Platform::Timer> m_invalidation_coalescing_timer;
-    Gfx::IntRect m_invalidation_rect;
+    Web::DevicePixelRect m_invalidation_rect;
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
 
     RefPtr<WebDriverConnection> m_webdriver;

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -9,6 +9,7 @@
 
 #include <LibGfx/Rect.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/PixelUnits.h>
 #include <WebContent/Forward.h>
 
 namespace WebContent {
@@ -26,11 +27,12 @@ public:
     virtual Web::Page& page() override { return *m_page; }
     virtual Web::Page const& page() const override { return *m_page; }
 
-    virtual void paint(Gfx::IntRect const& content_rect, Gfx::Bitmap&) override;
+    virtual void paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap&) override;
 
     void set_palette_impl(Gfx::PaletteImpl const&);
     void set_viewport_rect(Gfx::IntRect const&);
-    void set_screen_rects(Vector<Gfx::IntRect, 4> const& rects, size_t main_screen_index) { m_screen_rect = rects[main_screen_index]; };
+    void set_screen_rects(Vector<Gfx::IntRect, 4> const& rects, size_t main_screen_index) { m_screen_rect = rects[main_screen_index].to_type<Web::DevicePixels>(); }
+    void set_screen_display_scale(float device_pixels_per_css_pixel) { m_screen_display_scale = device_pixels_per_css_pixel; }
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
     void set_should_show_line_box_borders(bool b) { m_should_show_line_box_borders = b; }
     void set_has_focus(bool);
@@ -38,7 +40,7 @@ public:
     void set_window_position(Gfx::IntPoint);
     void set_window_size(Gfx::IntSize);
 
-    Gfx::IntSize content_size() const { return m_content_size; }
+    Web::DevicePixelSize content_size() const { return m_content_size; }
 
     ErrorOr<void> connect_to_webdriver(DeprecatedString const& webdriver_ipc_path);
 
@@ -50,7 +52,8 @@ private:
     // ^PageClient
     virtual bool is_connection_open() const override;
     virtual Gfx::Palette palette() const override;
-    virtual Gfx::IntRect screen_rect() const override { return m_screen_rect; }
+    virtual Web::DevicePixelRect screen_rect() const override { return m_screen_rect; }
+    virtual float device_pixels_per_css_pixel() const override { return m_screen_display_scale; }
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override { return m_preferred_color_scheme; }
     virtual void page_did_invalidate(Gfx::IntRect const&) override;
     virtual void page_did_change_selection() override;
@@ -104,8 +107,10 @@ private:
     ConnectionFromClient& m_client;
     NonnullOwnPtr<Web::Page> m_page;
     RefPtr<Gfx::PaletteImpl> m_palette_impl;
-    Gfx::IntRect m_screen_rect;
-    Gfx::IntSize m_content_size;
+    Web::DevicePixelRect m_screen_rect;
+    Web::DevicePixelSize m_content_size;
+    // FIXME: Actually set this based on the device's pixel ratio.
+    float m_screen_display_scale { 1.0f };
     bool m_should_show_line_box_borders { false };
     bool m_has_focus { false };
 

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1521,7 +1521,7 @@ Messages::WebDriverClient::TakeScreenshotResponse WebDriverConnection::take_scre
     auto root_rect = calculate_absolute_rect_of_element(m_page_client.page(), *document->document_element());
 
     auto encoded_string = TRY(Web::WebDriver::capture_element_screenshot(
-        [&](auto const& rect, auto& bitmap) { m_page_client.paint(rect, bitmap); },
+        [&](auto const& rect, auto& bitmap) { m_page_client.paint(rect.template to_type<Web::DevicePixels>(), bitmap); },
         m_page_client.page(),
         *document->document_element(),
         root_rect));
@@ -1554,7 +1554,7 @@ Messages::WebDriverClient::TakeElementScreenshotResponse WebDriverConnection::ta
     auto element_rect = calculate_absolute_rect_of_element(m_page_client.page(), *element);
 
     auto encoded_string = TRY(Web::WebDriver::capture_element_screenshot(
-        [&](auto const& rect, auto& bitmap) { m_page_client.paint(rect, bitmap); },
+        [&](auto const& rect, auto& bitmap) { m_page_client.paint(rect.template to_type<Web::DevicePixels>(), bitmap); },
         m_page_client.page(),
         *element,
         element_rect));

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -87,7 +87,7 @@ public:
             return;
         }
 
-        Web::PaintContext context(painter, palette(), content_rect.top_left().to_type<int>());
+        Web::PaintContext context(painter, palette());
         context.set_should_show_line_box_borders(false);
         context.set_viewport_rect(content_rect.to_type<int>());
         context.set_has_focus(true);

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -76,21 +76,20 @@ public:
     virtual void paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& target) override
     {
         Gfx::Painter painter(target);
-        Gfx::IntRect int_content_rect { content_rect.x().value(), content_rect.y().value(), content_rect.width().value(), content_rect.height().value() };
 
         if (auto* document = page().top_level_browsing_context().active_document())
             document->update_layout();
 
-        painter.fill_rect({ {}, int_content_rect.size() }, palette().base());
+        painter.fill_rect({ {}, content_rect.size().to_type<int>() }, palette().base());
 
         auto* layout_root = this->layout_root();
         if (!layout_root) {
             return;
         }
 
-        Web::PaintContext context(painter, palette(), int_content_rect.top_left());
+        Web::PaintContext context(painter, palette(), content_rect.top_left().to_type<int>());
         context.set_should_show_line_box_borders(false);
-        context.set_viewport_rect(int_content_rect);
+        context.set_viewport_rect(content_rect.to_type<int>());
         context.set_has_focus(true);
         layout_root->paint_all_phases(context);
     }
@@ -177,15 +176,15 @@ public:
     {
     }
 
-    virtual void page_did_request_context_menu(Gfx::IntPoint) override
+    virtual void page_did_request_context_menu(Web::CSSPixelPoint) override
     {
     }
 
-    virtual void page_did_request_link_context_menu(Gfx::IntPoint, AK::URL const&, DeprecatedString const&, unsigned) override
+    virtual void page_did_request_link_context_menu(Web::CSSPixelPoint, AK::URL const&, DeprecatedString const&, unsigned) override
     {
     }
 
-    virtual void page_did_request_image_context_menu(Gfx::IntPoint, AK::URL const&, DeprecatedString const&, unsigned, Gfx::Bitmap const*) override
+    virtual void page_did_request_image_context_menu(Web::CSSPixelPoint, AK::URL const&, DeprecatedString const&, unsigned, Gfx::Bitmap const*) override
     {
     }
 
@@ -197,7 +196,7 @@ public:
     {
     }
 
-    virtual void page_did_enter_tooltip_area(Gfx::IntPoint, DeprecatedString const&) override
+    virtual void page_did_enter_tooltip_area(Web::CSSPixelPoint, DeprecatedString const&) override
     {
     }
 
@@ -213,7 +212,7 @@ public:
     {
     }
 
-    virtual void page_did_invalidate(Gfx::IntRect const&) override
+    virtual void page_did_invalidate(Web::CSSPixelRect const&) override
     {
     }
 
@@ -225,7 +224,7 @@ public:
     {
     }
 
-    virtual void page_did_request_scroll_into_view(Gfx::IntRect const&) override
+    virtual void page_did_request_scroll_into_view(Web::CSSPixelRect const&) override
     {
     }
 


### PR DESCRIPTION
Part 2 of https://github.com/SerenityOS/serenity/pull/15989

Converts PageClient to using the new pixel units. Otherwise, some assorted bits and pieces that prepare for later changes.