### PR TITLE
AK: Disallow implicit pointer-to-boolean conversion in JsonValue

### DIFF
--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -168,12 +168,6 @@ JsonValue::JsonValue(double value)
 }
 #endif
 
-JsonValue::JsonValue(bool value)
-    : m_type(Type::Bool)
-{
-    m_value.as_bool = value;
-}
-
 JsonValue::JsonValue(DeprecatedString const& value)
 {
     if (value.is_null()) {

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -55,12 +55,20 @@ public:
 #if !defined(KERNEL)
     JsonValue(double);
 #endif
-    JsonValue(bool);
     JsonValue(char const*);
 #ifndef KERNEL
     JsonValue(DeprecatedString const&);
 #endif
     JsonValue(StringView);
+
+    template<typename T>
+    requires(SameAs<RemoveCVReference<T>, bool>)
+    JsonValue(T value)
+        : m_type(Type::Bool)
+        , m_value { .as_bool = value }
+    {
+    }
+
     JsonValue(JsonArray const&);
     JsonValue(JsonObject const&);
 

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -311,6 +311,15 @@ requires IsBaseOf<Object, T>
         [this] { return this->getter(); },                       \
         {});
 
+#define REGISTER_WRITE_ONLY_STRING_PROPERTY(property_name, setter) \
+    register_property(                                             \
+        property_name,                                             \
+        {},                                                        \
+        [this](auto& value) {                                      \
+            this->setter(value.to_deprecated_string());            \
+            return true;                                           \
+        });
+
 #define REGISTER_READONLY_SIZE_PROPERTY(property_name, getter) \
     register_property(                                         \
         property_name,                                         \

--- a/Userland/Libraries/LibCore/Property.h
+++ b/Userland/Libraries/LibCore/Property.h
@@ -26,7 +26,12 @@ public:
         return m_setter(value);
     }
 
-    JsonValue get() const { return m_getter(); }
+    JsonValue get() const
+    {
+        if (!m_getter)
+            return {};
+        return m_getter();
+    }
 
     DeprecatedString const& name() const { return m_name; }
     bool is_readonly() const { return !m_setter; }

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -42,7 +42,7 @@ Button::Button(DeprecatedString text)
         { Gfx::ButtonStyle::Normal, "Normal" },
         { Gfx::ButtonStyle::Coolbar, "Coolbar" });
 
-    REGISTER_STRING_PROPERTY("icon", icon, set_icon_from_path);
+    REGISTER_WRITE_ONLY_STRING_PROPERTY("icon", set_icon_from_path);
     REGISTER_BOOL_PROPERTY("default", is_default, set_default);
 }
 

--- a/Userland/Libraries/LibGUI/ImageWidget.cpp
+++ b/Userland/Libraries/LibGUI/ImageWidget.cpp
@@ -26,7 +26,7 @@ ImageWidget::ImageWidget(StringView)
 
     REGISTER_BOOL_PROPERTY("auto_resize", auto_resize, set_auto_resize);
     REGISTER_BOOL_PROPERTY("should_stretch", should_stretch, set_should_stretch);
-    REGISTER_STRING_PROPERTY("bitmap", bitmap, load_from_file);
+    REGISTER_WRITE_ONLY_STRING_PROPERTY("bitmap", load_from_file);
 }
 
 void ImageWidget::set_bitmap(Gfx::Bitmap const* bitmap)

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -34,7 +34,7 @@ Label::Label(DeprecatedString text)
 
     REGISTER_STRING_PROPERTY("text", text, set_text);
     REGISTER_BOOL_PROPERTY("autosize", is_autosize, set_autosize);
-    REGISTER_STRING_PROPERTY("icon", icon, set_icon_from_path);
+    REGISTER_WRITE_ONLY_STRING_PROPERTY("icon", set_icon_from_path);
 }
 
 void Label::set_autosize(bool autosize, size_t padding)


### PR DESCRIPTION
And remove the few instances where this was happening in LibGUI.