### PR TITLE
AK: Unref old m_data in String's move assignment

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -181,6 +181,9 @@ String::String(String&& other)
 
 String& String::operator=(String&& other)
 {
+    if (!is_short_string())
+        m_data->unref();
+
     m_data = exchange(other.m_data, nullptr);
     return *this;
 }

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -24,6 +24,13 @@ TEST_CASE(construct_empty)
     EXPECT_EQ(empty, ""sv);
 }
 
+TEST_CASE(move_assignment)
+{
+    String string1 = MUST(String::from_utf8("hello"sv));
+    string1 = MUST(String::from_utf8("friends!"sv));
+    EXPECT_EQ(string1, "friends!"sv);
+}
+
 TEST_CASE(short_strings)
 {
 #ifdef AK_ARCH_64_BIT


### PR DESCRIPTION
We were overridding the data pointer without unreffing it,
causing a memory leak when assigning a String.
