### PR TITLE
HackStudio: Error propagation improvements

### DIFF
--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -18,13 +18,16 @@
 
 namespace HackStudio {
 
-EditorWrapper::EditorWrapper()
+ErrorOr<NonnullRefPtr<EditorWrapper>> EditorWrapper::try_create()
 {
-    set_layout<GUI::VerticalBoxLayout>();
-    m_filename_title = untitled_label;
+    NonnullRefPtr<EditorWrapper> editor_wrapper = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) EditorWrapper()));
+    TRY(editor_wrapper->initialize_editor());
+    return editor_wrapper;
+}
 
-    // FIXME: Propagate errors instead of giving up
-    m_editor = MUST(Editor::try_create());
+ErrorOr<void> EditorWrapper::initialize_editor()
+{
+    m_editor = TRY(Editor::try_create());
 
     add_child(*m_editor);
     m_editor->set_ruler_visible(true);
@@ -42,6 +45,14 @@ EditorWrapper::EditorWrapper()
         update_title();
         update_editor_window_title();
     };
+
+    return {};
+}
+
+EditorWrapper::EditorWrapper()
+{
+    set_layout<GUI::VerticalBoxLayout>();
+    m_filename_title = untitled_label;
 }
 
 LanguageClient& EditorWrapper::language_client() { return m_editor->language_client(); }

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -12,6 +12,7 @@
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/Label.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Palette.h>
@@ -37,8 +38,11 @@ ErrorOr<void> EditorWrapper::initialize_editor()
         set_current_editor_wrapper(this);
     };
 
-    m_editor->on_open = [](DeprecatedString const& path) {
-        open_file(path);
+    m_editor->on_open = [this](DeprecatedString const& path) {
+        auto open_file_result = open_file(path);
+        if (open_file_result.is_error()) {
+            GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Can't open file named {}: {}", path, open_file_result.error()));
+        }
     };
 
     m_editor->on_modified_change = [this](bool) {

--- a/Userland/DevTools/HackStudio/EditorWrapper.h
+++ b/Userland/DevTools/HackStudio/EditorWrapper.h
@@ -22,9 +22,11 @@ namespace HackStudio {
 class Editor;
 
 class EditorWrapper : public GUI::Widget {
-    C_OBJECT(EditorWrapper)
+    C_OBJECT_ABSTRACT(EditorWrapper)
 
 public:
+    static ErrorOr<NonnullRefPtr<EditorWrapper>> try_create();
+
     virtual ~EditorWrapper() override = default;
 
     Editor& editor() { return *m_editor; }
@@ -56,6 +58,8 @@ private:
     static constexpr auto untitled_label = "(Untitled)"sv;
 
     EditorWrapper();
+
+    ErrorOr<void> initialize_editor();
 
     void update_title();
 

--- a/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
+++ b/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
@@ -10,6 +10,7 @@
 #include <AK/StringBuilder.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/TableView.h>
 #include <LibGUI/TextBox.h>
 #include <LibGfx/Font/FontDatabase.h>
@@ -127,9 +128,12 @@ FindInFilesWidget::FindInFilesWidget()
 
     m_result_view = add<GUI::TableView>();
 
-    m_result_view->on_activation = [](auto& index) {
+    m_result_view->on_activation = [this](auto& index) {
         auto& match = *(const Match*)index.internal_data();
-        open_file(match.filename);
+        auto open_file_result = open_file(match.filename);
+        if (open_file_result.is_error()) {
+            GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Can't open file named {}: {}", match.filename, open_file_result.error()));
+        }
         current_editor().set_selection(match.range);
         current_editor().set_focus(true);
     };

--- a/Userland/DevTools/HackStudio/HackStudio.h
+++ b/Userland/DevTools/HackStudio/HackStudio.h
@@ -15,9 +15,9 @@
 namespace HackStudio {
 
 GUI::TextEditor& current_editor();
-void open_file(DeprecatedString const&);
+ErrorOr<void> open_file(DeprecatedString const&);
 RefPtr<EditorWrapper> current_editor_wrapper();
-void open_file(DeprecatedString const&, size_t line, size_t column);
+ErrorOr<void> open_file(DeprecatedString const&, size_t line, size_t column);
 Project& project();
 DeprecatedString currently_open_file();
 void set_current_editor_wrapper(RefPtr<EditorWrapper>);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -770,28 +770,28 @@ void HackStudioWidget::add_new_editor_tab_widget(GUI::Widget& parent)
 
 void HackStudioWidget::add_new_editor(GUI::TabWidget& parent)
 {
-    auto& wrapper = parent.add_tab<EditorWrapper>("(Untitled)");
-    parent.set_active_widget(&wrapper);
+    auto wrapper = parent.try_add_tab<EditorWrapper>("(Untitled)").release_value_but_fixme_should_propagate_errors();
+    parent.set_active_widget(wrapper);
     if (parent.children().size() > 1 || m_all_editor_tab_widgets.size() > 1)
         parent.set_close_button_enabled(true);
 
     auto previous_editor_wrapper = m_current_editor_wrapper;
     m_current_editor_wrapper = wrapper;
     m_all_editor_wrappers.append(wrapper);
-    wrapper.editor().set_focus(true);
-    wrapper.editor().set_font(*m_editor_font);
-    wrapper.set_project_root(m_project->root_path());
-    wrapper.editor().on_cursor_change = [this] { on_cursor_change(); };
-    wrapper.on_change = [this] { update_gml_preview(); };
+    wrapper->editor().set_focus(true);
+    wrapper->editor().set_font(*m_editor_font);
+    wrapper->set_project_root(m_project->root_path());
+    wrapper->editor().on_cursor_change = [this] { on_cursor_change(); };
+    wrapper->on_change = [this] { update_gml_preview(); };
     set_edit_mode(EditMode::Text);
     if (previous_editor_wrapper && previous_editor_wrapper->editor().editing_engine()->is_regular())
-        wrapper.editor().set_editing_engine(make<GUI::RegularEditingEngine>());
+        wrapper->editor().set_editing_engine(make<GUI::RegularEditingEngine>());
     else if (previous_editor_wrapper && previous_editor_wrapper->editor().editing_engine()->is_vim())
-        wrapper.editor().set_editing_engine(make<GUI::VimEditingEngine>());
+        wrapper->editor().set_editing_engine(make<GUI::VimEditingEngine>());
     else
-        wrapper.editor().set_editing_engine(make<GUI::RegularEditingEngine>());
+        wrapper->editor().set_editing_engine(make<GUI::RegularEditingEngine>());
 
-    wrapper.on_tab_close_request = [this, &parent](auto& tab) {
+    wrapper->on_tab_close_request = [this, &parent](auto& tab) {
         parent.deferred_invoke([this, &parent, &tab] {
             set_current_editor_wrapper(tab);
             parent.remove_tab(tab);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -38,7 +38,7 @@ class HackStudioWidget : public GUI::Widget {
 public:
     virtual ~HackStudioWidget() override;
 
-    bool open_file(DeprecatedString const& filename, size_t line = 0, size_t column = 0);
+    ErrorOr<void> open_file(DeprecatedString const& filename, size_t line = 0, size_t column = 0);
     void close_file_in_all_editors(DeprecatedString const& filename);
 
     void update_actions();
@@ -73,11 +73,11 @@ public:
         Coredump
     };
 
-    void open_coredump(DeprecatedString const& coredump_path);
+    ErrorOr<void> open_coredump(DeprecatedString const& coredump_path);
     void for_each_open_file(Function<void(ProjectFile const&)>);
     bool semantic_syntax_highlighting_is_enabled() const;
 
-    static Vector<DeprecatedString> read_recent_projects();
+    static ErrorOr<Vector<DeprecatedString>> read_recent_projects();
 
     void update_current_editor_title();
     void update_window_title();
@@ -90,7 +90,7 @@ private:
     Vector<DeprecatedString> selected_file_paths() const;
 
     HackStudioWidget(DeprecatedString path_to_project);
-    void open_project(DeprecatedString const& root_path);
+    ErrorOr<void> open_project(DeprecatedString const& root_path);
 
     enum class EditMode {
         Text,
@@ -129,9 +129,9 @@ private:
     NonnullRefPtr<GUI::Action> create_open_project_configuration_action();
     void create_location_history_actions();
 
-    void add_new_editor_tab_widget(GUI::Widget& parent);
-    void add_new_editor(GUI::TabWidget& parent);
-    RefPtr<EditorWrapper> get_editor_of_file(DeprecatedString const& filename);
+    ErrorOr<void> add_new_editor_tab_widget(GUI::Widget& parent);
+    ErrorOr<void> add_new_editor(GUI::TabWidget& parent);
+    ErrorOr<RefPtr<EditorWrapper>> get_editor_of_file(DeprecatedString const& filename);
     DeprecatedString get_project_executable_path() const;
 
     void on_action_tab_change();
@@ -141,19 +141,20 @@ private:
 
     void handle_external_file_deletion(DeprecatedString const& filepath);
     void stop_debugger_if_running();
-    void close_current_project();
+    ErrorOr<void> close_current_project();
 
     void create_open_files_view(GUI::Widget& parent);
     void create_toolbar(GUI::Widget& parent);
     void create_action_tab(GUI::Widget& parent);
     void create_file_menu(GUI::Window&);
-    void update_recent_projects_submenu();
     void create_edit_menu(GUI::Window&);
     void create_build_menu(GUI::Window&);
     void create_view_menu(GUI::Window&);
     void create_help_menu(GUI::Window&);
     void create_project_tab(GUI::Widget& parent);
     void configure_project_tree_view();
+
+    ErrorOr<void> update_recent_projects_submenu();
 
     void run();
     void build();

--- a/Userland/DevTools/HackStudio/Locator.h
+++ b/Userland/DevTools/HackStudio/Locator.h
@@ -22,7 +22,7 @@ public:
 
 private:
     void update_suggestions();
-    void open_suggestion(const GUI::ModelIndex&);
+    ErrorOr<void> open_suggestion(const GUI::ModelIndex&);
 
     Locator(Core::Object* parent = nullptr);
 

--- a/Userland/DevTools/HackStudio/ProjectDeclarations.cpp
+++ b/Userland/DevTools/HackStudio/ProjectDeclarations.cpp
@@ -18,15 +18,15 @@ void HackStudio::ProjectDeclarations::set_declared_symbols(DeprecatedString cons
         on_update();
 }
 
-Optional<GUI::Icon> HackStudio::ProjectDeclarations::get_icon_for(CodeComprehension::DeclarationType type)
+ErrorOr<Optional<GUI::Icon>> HackStudio::ProjectDeclarations::get_icon_for(CodeComprehension::DeclarationType type)
 {
-    static GUI::Icon struct_icon(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Struct.png"sv).release_value_but_fixme_should_propagate_errors());
-    static GUI::Icon class_icon(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Class.png"sv).release_value_but_fixme_should_propagate_errors());
-    static GUI::Icon function_icon(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Function.png"sv).release_value_but_fixme_should_propagate_errors());
-    static GUI::Icon variable_icon(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Variable.png"sv).release_value_but_fixme_should_propagate_errors());
-    static GUI::Icon preprocessor_icon(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Preprocessor.png"sv).release_value_but_fixme_should_propagate_errors());
-    static GUI::Icon member_icon(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Member.png"sv).release_value_but_fixme_should_propagate_errors());
-    static GUI::Icon namespace_icon(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Namespace.png"sv).release_value_but_fixme_should_propagate_errors());
+    static GUI::Icon struct_icon(TRY(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Struct.png"sv)));
+    static GUI::Icon class_icon(TRY(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Class.png"sv)));
+    static GUI::Icon function_icon(TRY(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Function.png"sv)));
+    static GUI::Icon variable_icon(TRY(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Variable.png"sv)));
+    static GUI::Icon preprocessor_icon(TRY(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Preprocessor.png"sv)));
+    static GUI::Icon member_icon(TRY(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Member.png"sv)));
+    static GUI::Icon namespace_icon(TRY(Gfx::Bitmap::try_load_from_file("/res/icons/hackstudio/Namespace.png"sv)));
     switch (type) {
     case CodeComprehension::DeclarationType::Struct:
         return struct_icon;
@@ -43,6 +43,6 @@ Optional<GUI::Icon> HackStudio::ProjectDeclarations::get_icon_for(CodeComprehens
     case CodeComprehension::DeclarationType::Namespace:
         return namespace_icon;
     default:
-        return {};
+        return { {} };
     }
 }

--- a/Userland/DevTools/HackStudio/ProjectDeclarations.h
+++ b/Userland/DevTools/HackStudio/ProjectDeclarations.h
@@ -25,7 +25,7 @@ public:
 
     void set_declared_symbols(DeprecatedString const& filename, Vector<CodeComprehension::Declaration> const&);
 
-    static Optional<GUI::Icon> get_icon_for(CodeComprehension::DeclarationType);
+    static ErrorOr<Optional<GUI::Icon>> get_icon_for(CodeComprehension::DeclarationType);
 
     Function<void()> on_update = nullptr;
 

--- a/Userland/DevTools/HackStudio/ToDoEntriesWidget.cpp
+++ b/Userland/DevTools/HackStudio/ToDoEntriesWidget.cpp
@@ -8,6 +8,7 @@
 #include "HackStudio.h"
 #include "ToDoEntries.h"
 #include <LibGUI/BoxLayout.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGfx/Font/FontDatabase.h>
 
 namespace HackStudio {
@@ -102,9 +103,12 @@ ToDoEntriesWidget::ToDoEntriesWidget()
     set_layout<GUI::VerticalBoxLayout>();
     m_result_view = add<GUI::TableView>();
 
-    m_result_view->on_activation = [](auto& index) {
+    m_result_view->on_activation = [this](auto& index) {
         auto& match = *(CodeComprehension::TodoEntry const*)index.internal_data();
-        open_file(match.filename, match.line, match.column);
+        auto open_file_result = open_file(match.filename, match.line, match.column);
+        if (open_file_result.is_error()) {
+            GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Can't open file named {}: {}", match.filename, open_file_result.error()));
+        }
     };
 }
 


### PR DESCRIPTION
These commits are intended to improve the error propagation inside HackStudio.

Initially this started as a FIXME roulette to allow EditorWrapper to be able to fail without giving up, however to allow these errors to be presented to the user it was necessary for additional work.

There is a lot of this that still needs to be done in HackStudio for error handling but early review is probably a good idea to ensure this is the right approach before continuing as this PR as it stands will ultimately add 2 new FIXMEs.