### PR TITLE
LibWeb: Display DragonFly in the user agent string

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -40,6 +40,8 @@ namespace Web {
 #    define OS_STRING "OpenBSD"
 #elif defined(AK_OS_NETBSD)
 #    define OS_STRING "NetBSD"
+#elif defined(AK_OS_DRAGONFLY)
+#    define OS_STRING "DragonFly"
 #else
 #    error Unknown OS
 #endif


### PR DESCRIPTION
Previously when build for DragonFly BSD we would error out with unknown os error. Now we just define OS_STRING as DragonFly.