### PR TITLE
Kernel: Allocate VirtIOGPU context IDs from a bitmap

### DIFF
--- a/Kernel/Graphics/VirtIOGPU/GPU3DDevice.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GPU3DDevice.cpp
@@ -39,7 +39,7 @@ VirtIOGPU3DDevice::VirtIOGPU3DDevice(VirtIOGraphicsAdapter const& graphics_adapt
     , m_graphics_adapter(graphics_adapter)
     , m_transfer_buffer_region(move(transfer_buffer_region))
 {
-    m_kernel_context_id = m_graphics_adapter->create_context();
+    m_kernel_context_id = MUST(m_graphics_adapter->create_context());
 }
 
 void VirtIOGPU3DDevice::detach(OpenFileDescription& description)
@@ -65,7 +65,7 @@ ErrorOr<void> VirtIOGPU3DDevice::ioctl(OpenFileDescription& description, unsigne
             return EEXIST;
         SpinlockLocker locker(m_graphics_adapter->operation_lock());
         // TODO: Delete the context if it fails to be set in m_context_state_lookup
-        auto context_id = m_graphics_adapter->create_context();
+        auto context_id = TRY(m_graphics_adapter->create_context());
         LockRefPtr<PerContextState> per_context_state = TRY(PerContextState::try_create(context_id));
         TRY(m_context_state_lookup.try_set(&description, per_context_state));
         return {};

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
@@ -161,17 +161,6 @@ void VirtIOGraphicsAdapter::initialize()
     }
 }
 
-Graphics::VirtIOGPU::ResourceID VirtIOGraphicsAdapter::allocate_resource_id(Badge<VirtIODisplayConnector>)
-{
-    return m_resource_id_counter++;
-}
-
-Graphics::VirtIOGPU::ContextID VirtIOGraphicsAdapter::allocate_context_id(Badge<VirtIODisplayConnector>)
-{
-    // FIXME: This should really be tracked using a bitmap, instead of an atomic counter
-    return m_context_id_counter++;
-}
-
 bool VirtIOGraphicsAdapter::handle_device_config_change()
 {
     auto events = get_pending_events();

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -42,8 +42,6 @@ public:
     virtual void initialize() override;
     void initialize_3d_device();
 
-    bool edid_feature_accepted() const;
-
     ErrorOr<void> mode_set_resolution(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, size_t width, size_t height);
     void set_dirty_displayed_rect(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
     void flush_displayed_image(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -44,9 +44,6 @@ public:
 
     bool edid_feature_accepted() const;
 
-    Graphics::VirtIOGPU::ResourceID allocate_resource_id(Badge<VirtIODisplayConnector>);
-    Graphics::VirtIOGPU::ContextID allocate_context_id(Badge<VirtIODisplayConnector>);
-
     ErrorOr<void> mode_set_resolution(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, size_t width, size_t height);
     void set_dirty_displayed_rect(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
     void flush_displayed_image(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);


### PR DESCRIPTION
...brought to you by FIXME Roulette. :^)

I also removed some unused methods for allocation context or resource IDs.

This is something I know very little about, so any feedback is appreciated! I did see if I could figure out an ioctl for deleting context IDs too, but nope.

This is also unfortunately untested because running Serenity with `SERENITY_GL=1` gave me an error from Qemu, and VirGLDemo doesn't work without that.