### PR TITLE
Everywhere: Introduce the COMPILER() and the OS() macros

### DIFF
--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -11,7 +11,7 @@
 template<Unsigned IntType>
 inline constexpr int popcount(IntType value)
 {
-#if defined(AK_COMPILER_CLANG) || defined(AK_COMPILER_GCC)
+#if COMPILER(CLANG) || COMPILER(GCC)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))
         return __builtin_popcount(value);
@@ -39,7 +39,7 @@ inline constexpr int popcount(IntType value)
 template<Unsigned IntType>
 inline constexpr int count_trailing_zeroes(IntType value)
 {
-#if defined(AK_COMPILER_CLANG) || defined(AK_COMPILER_GCC)
+#if COMPILER(CLANG) || COMPILER(GCC)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))
         return __builtin_ctz(value);
@@ -77,7 +77,7 @@ inline constexpr int count_trailing_zeroes_safe(IntType value)
 template<Unsigned IntType>
 inline constexpr int count_leading_zeroes(IntType value)
 {
-#if defined(AK_COMPILER_CLANG) || defined(AK_COMPILER_GCC)
+#if COMPILER(CLANG) || COMPILER(GCC)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))
         return __builtin_clz(value) - (32 - (8 * sizeof(IntType)));
@@ -101,7 +101,7 @@ inline constexpr int count_leading_zeroes(IntType value)
 // This is required for math.cpp internal_scalbn
 inline constexpr int count_leading_zeroes(unsigned __int128 value)
 {
-#    if defined(AK_COMPILER_CLANG) || defined(AK_COMPILER_GCC)
+#    if COMPILER(CLANG) || COMPILER(GCC)
     return (value > __UINT64_MAX__) ? __builtin_clzll(value >> 64) : 64 + __builtin_clzll(value);
 #    else
     unsigned __int128 mask = (unsigned __int128)1 << 127;
@@ -132,7 +132,7 @@ inline constexpr int count_leading_zeroes_safe(IntType value)
 template<Integral IntType>
 inline constexpr int bit_scan_forward(IntType value)
 {
-#if defined(AK_COMPILER_CLANG) || defined(AK_COMPILER_GCC)
+#if COMPILER(CLANG) || COMPILER(GCC)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))
         return __builtin_ffs(value);

--- a/AK/BumpAllocator.h
+++ b/AK/BumpAllocator.h
@@ -103,7 +103,7 @@ protected:
         void* new_chunk = (void*)s_unused_allocation_cache.exchange(0);
         if (!new_chunk) {
             if constexpr (use_mmap) {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
                 new_chunk = serenity_mmap(nullptr, m_chunk_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_RANDOMIZED | MAP_PRIVATE, 0, 0, m_chunk_size, "BumpAllocator Chunk");
 #else
                 new_chunk = mmap(nullptr, m_chunk_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);

--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -302,7 +302,7 @@ public:
     template<typename U, typename V>
     [[nodiscard]] static constexpr bool addition_would_overflow(U u, V v)
     {
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
         Checked checked;
         checked = u;
         checked += v;
@@ -315,7 +315,7 @@ public:
     template<typename U, typename V>
     [[nodiscard]] static constexpr bool multiplication_would_overflow(U u, V v)
     {
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
         Checked checked;
         checked = u;
         checked *= v;

--- a/AK/CheckedFormatString.h
+++ b/AK/CheckedFormatString.h
@@ -15,7 +15,7 @@
 #ifdef ENABLE_COMPILETIME_FORMAT_CHECK
 // FIXME: Seems like clang doesn't like calling 'consteval' functions inside 'consteval' functions quite the same way as GCC does,
 //        it seems to entirely forget that it accepted that parameters to a 'consteval' function to begin with.
-#    if defined(AK_COMPILER_CLANG) || defined(__CLION_IDE__) || defined(__CLION_IDE_)
+#    if COMPILER(CLANG) || defined(__CLION_IDE__) || defined(__CLION_IDE_)
 #        undef ENABLE_COMPILETIME_FORMAT_CHECK
 #    endif
 #endif

--- a/AK/Endian.h
+++ b/AK/Endian.h
@@ -10,7 +10,7 @@
 #include <AK/Forward.h>
 #include <AK/Platform.h>
 
-#if defined(AK_OS_MACOS)
+#if OS(MACOS)
 #    include <libkern/OSByteOrder.h>
 #    include <machine/endian.h>
 

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -10,7 +10,7 @@
 #include <AK/Try.h>
 #include <AK/Variant.h>
 
-#if defined(AK_OS_SERENITY) && defined(KERNEL)
+#if OS(SERENITY) && defined(KERNEL)
 #    include <LibC/errno_codes.h>
 #else
 #    include <errno.h>
@@ -88,7 +88,7 @@ public:
     {
     }
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     ErrorOr(ErrnoCode code)
         : m_value_or_error(Error::from_errno(code))
     {

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -11,7 +11,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/kstdio.h>
 
-#if defined(AK_OS_SERENITY) && !defined(KERNEL)
+#if OS(SERENITY) && !defined(KERNEL)
 #    include <serenity.h>
 #endif
 
@@ -877,7 +877,7 @@ void vdbgln(StringView fmtstr, TypeErasedFormatParams& params)
 
     StringBuilder builder;
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    ifdef KERNEL
     if (Kernel::Processor::is_initialized()) {
         struct timespec ts = {};
@@ -914,7 +914,7 @@ void vdbgln(StringView fmtstr, TypeErasedFormatParams& params)
 
     auto const string = builder.string_view();
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    ifdef KERNEL
     if (!Kernel::Processor::is_initialized()) {
         kernelearlyputstr(string.characters_without_null_termination(), string.length());
@@ -930,7 +930,7 @@ void vdmesgln(StringView fmtstr, TypeErasedFormatParams& params)
 {
     StringBuilder builder;
 
-#    ifdef AK_OS_SERENITY
+#    if OS(SERENITY)
     struct timespec ts = {};
 
     if (TimeManagement::is_initialized())
@@ -957,7 +957,7 @@ void v_critical_dmesgln(StringView fmtstr, TypeErasedFormatParams& params)
     // at OOM conditions.
 
     StringBuilder builder;
-#    ifdef AK_OS_SERENITY
+#    if OS(SERENITY)
     if (Kernel::Processor::is_initialized() && Kernel::Thread::current()) {
         auto& thread = *Kernel::Thread::current();
         builder.appendff("[{}({}:{})]: ", thread.process().name(), thread.pid().value(), thread.tid().value());

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -690,7 +690,7 @@ template<>
 struct Formatter<Error> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Error const& error)
     {
-#if defined(AK_OS_SERENITY) && defined(KERNEL)
+#if OS(SERENITY) && defined(KERNEL)
         if (error.is_errno())
             return Formatter<FormatString>::format(builder, "Error(errno={})"sv, error.code());
         return Formatter<FormatString>::format(builder, "Error({})"sv, error.string_literal());

--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -165,7 +165,7 @@ public:
 
     // Note: For some reason, clang does not consider `member` as declared here, and as declared above (`SubstitutedIntrusiveListNode<T, Container> T::*`)
     //       to be of equal types. so for now, just make the members public on clang.
-#if !defined(AK_COMPILER_CLANG)
+#if !COMPILER(CLANG)
 private:
     template<class T_, typename Container_, SubstitutedIntrusiveListNode<T_, Container_> T_::*member>
     friend class ::AK::Detail::IntrusiveList;

--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -198,7 +198,7 @@ public:
 
     static constexpr bool IsRaw = IsPointer<Container>;
 
-#if !defined(AK_COMPILER_CLANG)
+#if !COMPILER(CLANG)
 private:
     template<Integral TK, typename TV, typename TContainer, SubstitutedIntrusiveRedBlackTreeNode<TK, TV, TContainer> TV::*member>
     friend class ::AK::Detail::IntrusiveRedBlackTree;

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -11,7 +11,7 @@
 #include <AK/Vector.h>
 
 // On Linux distros that use mlibc `basename` is defined as a macro that expands to `__mlibc_gnu_basename` or `__mlibc_gnu_basename_c`, so we undefine it.
-#if defined(AK_OS_LINUX) && defined(basename)
+#if OS(LINUX) && defined(basename)
 #    undef basename
 #endif
 

--- a/AK/NoAllocationGuard.h
+++ b/AK/NoAllocationGuard.h
@@ -39,7 +39,7 @@ private:
     {
 #if defined(KERNEL)
         return Processor::current_thread()->get_allocation_enabled();
-#elif defined(AK_OS_SERENITY)
+#elif OS(SERENITY)
         // This extern thread-local lives in our LibC, which doesn't exist on other systems.
         return s_allocation_enabled;
 #else
@@ -51,7 +51,7 @@ private:
     {
 #if defined(KERNEL)
         Processor::current_thread()->set_allocation_enabled(value);
-#elif defined(AK_OS_SERENITY)
+#elif OS(SERENITY)
         s_allocation_enabled = value;
 #else
         (void)value;

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -34,46 +34,46 @@
 #endif
 
 #if defined(__clang__)
-#    define AK_COMPILER_CLANG
+#    define AK_COMPILER_CLANG 1
 #elif defined(__GNUC__)
-#    define AK_COMPILER_GCC
+#    define AK_COMPILER_GCC 1
 #endif
 
 #if defined(__serenity__)
-#    define AK_OS_SERENITY
+#    define AK_OS_SERENITY 1
 #endif
 
 #if defined(__linux__)
-#    define AK_OS_LINUX
+#    define AK_OS_LINUX 1
 #endif
 
 #if defined(__APPLE__) && defined(__MACH__)
-#    define AK_OS_MACOS
-#    define AK_OS_BSD_GENERIC
+#    define AK_OS_MACOS 1
+#    define AK_OS_BSD_GENERIC 1
 #endif
 
 #if defined(__FreeBSD__)
-#    define AK_OS_BSD_GENERIC
-#    define AK_OS_FREEBSD
+#    define AK_OS_BSD_GENERIC 1
+#    define AK_OS_FREEBSD 1
 #endif
 
 #if defined(__NetBSD__)
-#    define AK_OS_BSD_GENERIC
-#    define AK_OS_NETBSD
+#    define AK_OS_BSD_GENERIC 1
+#    define AK_OS_NETBSD 1
 #endif
 
 #if defined(__OpenBSD__)
-#    define AK_OS_BSD_GENERIC
-#    define AK_OS_OPENBSD
+#    define AK_OS_BSD_GENERIC 1
+#    define AK_OS_OPENBSD 1
 #endif
 
 #if defined(__DragonFly__)
-#    define AK_OS_BSD_GENERIC
-#    define AK_OS_DRAGONFLY
+#    define AK_OS_BSD_GENERIC 1
+#    define AK_OS_DRAGONFLY 1
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)
-#    define AK_OS_WINDOWS
+#    define AK_OS_WINDOWS 1
 #endif
 
 #if defined(__ANDROID__)
@@ -85,14 +85,16 @@
 #    endif
 #    undef STR
 #    undef __STR
-#    define AK_OS_ANDROID
+#    define AK_OS_ANDROID 1
 #endif
 
 #if defined(__EMSCRIPTEN__)
-#    define AK_OS_EMSCRIPTEN
+#    define AK_OS_EMSCRIPTEN 1
 #endif
 
 #define ARCH(arch) (defined(AK_ARCH_##arch) && AK_ARCH_##arch)
+#define OS(os) (defined(AK_OS_##os) && AK_OS_##os)
+#define COMPILER(compiler) (defined(AK_COMPILER_##compiler) && AK_COMPILER_##compiler)
 
 #if ARCH(I386) || ARCH(X86_64)
 #    define VALIDATE_IS_X86()
@@ -106,7 +108,7 @@
 #    define VALIDATE_IS_AARCH64() static_assert(false, "Trying to include aarch64 only header on non aarch64 platform");
 #endif
 
-#if !defined(AK_COMPILER_CLANG) && !defined(__CLION_IDE_) && !defined(__CLION_IDE__)
+#if !COMPILER(CLANG) && !defined(__CLION_IDE_) && !defined(__CLION_IDE__)
 #    define AK_HAS_CONDITIONALLY_TRIVIAL
 #endif
 
@@ -147,7 +149,7 @@
 #ifdef DISALLOW
 #    undef DISALLOW
 #endif
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    define DISALLOW(message) __attribute__((diagnose_if(1, message, "error")))
 #else
 #    define DISALLOW(message) __attribute__((error(message)))
@@ -167,25 +169,25 @@
 #    define ASAN_UNPOISON_MEMORY_REGION(addr, size)
 #endif
 
-#ifndef AK_OS_SERENITY
+#if !OS(SERENITY)
 // On macOS (at least Mojave), Apple's version of this header is not wrapped
 // in extern "C".
-#    ifdef AK_OS_MACOS
+#    if OS(MACOS)
 extern "C" {
 #    endif
 #    include <unistd.h>
 #    undef PAGE_SIZE
 #    define PAGE_SIZE sysconf(_SC_PAGESIZE)
-#    ifdef AK_OS_MACOS
+#    if OS(MACOS)
 };
 #    endif
 #endif
 
-#if defined(AK_OS_WINDOWS)
+#if OS(WINDOWS)
 #    define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
 #endif
 
-#if defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_FREEBSD)
+#if OS(BSD_GENERIC) && !OS(FREEBSD)
 #    define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
 #    define CLOCK_REALTIME_COARSE CLOCK_REALTIME
 #endif

--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -16,7 +16,7 @@
 #    include <math.h>
 #endif
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 extern "C" size_t strlen(char const*);
 #else
 #    include <string.h>
@@ -463,7 +463,7 @@ template<typename T, typename V>
 struct VaArgNextArgument {
     ALWAYS_INLINE T operator()(V ap) const
     {
-#ifdef AK_OS_WINDOWS
+#if OS(WINDOWS)
         // GCC on msys2 complains about the type of ap,
         // so let's force the compiler to believe it's a
         // va_list.

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -9,7 +9,7 @@
 #include <AK/Platform.h>
 #include <AK/Types.h>
 
-#if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID)
+#if OS(SERENITY) || OS(ANDROID)
 #    include <stdlib.h>
 #endif
 
@@ -17,11 +17,11 @@
 #    include <unistd.h>
 #endif
 
-#if defined(AK_OS_MACOS)
+#if OS(MACOS)
 #    include <sys/random.h>
 #endif
 
-#if defined(AK_OS_WINDOWS)
+#if OS(WINDOWS)
 #    include <random>
 #    include <unistd.h>
 #endif
@@ -30,10 +30,10 @@ namespace AK {
 
 inline void fill_with_random([[maybe_unused]] void* buffer, [[maybe_unused]] size_t length)
 {
-#if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID)
+#if OS(SERENITY) || OS(ANDROID)
     arc4random_buf(buffer, length);
 #elif defined(OSS_FUZZ)
-#elif defined(__unix__) or defined(AK_OS_MACOS)
+#elif defined(__unix__) or OS(MACOS)
     [[maybe_unused]] int rc = getentropy(buffer, length);
 #else
     char* char_buffer = static_cast<char*>(buffer);

--- a/AK/Singleton.h
+++ b/AK/Singleton.h
@@ -13,7 +13,7 @@
 #    include <Kernel/Arch/Processor.h>
 #    include <Kernel/Arch/ScopedCritical.h>
 #    include <Kernel/Locking/SpinlockProtected.h>
-#elif defined(AK_OS_WINDOWS)
+#elif OS(WINDOWS)
 // Forward declare to avoid pulling Windows.h into every file in existence.
 extern "C" __declspec(dllimport) void __stdcall Sleep(unsigned long);
 #    ifndef sched_yield
@@ -23,7 +23,7 @@ extern "C" __declspec(dllimport) void __stdcall Sleep(unsigned long);
 #    include <sched.h>
 #endif
 
-#ifndef AK_OS_SERENITY
+#if !OS(SERENITY)
 #    include <new>
 #endif
 

--- a/AK/StackInfo.cpp
+++ b/AK/StackInfo.cpp
@@ -10,11 +10,11 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    include <serenity.h>
-#elif defined(AK_OS_LINUX) or defined(AK_OS_MACOS)
+#elif OS(LINUX) or OS(MACOS)
 #    include <pthread.h>
-#elif defined(AK_OS_FREEBSD)
+#elif OS(FREEBSD)
 #    include <pthread.h>
 #    include <pthread_np.h>
 #endif
@@ -23,17 +23,17 @@ namespace AK {
 
 StackInfo::StackInfo()
 {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     if (get_stack_bounds(&m_base, &m_size) < 0) {
         perror("get_stack_bounds");
         VERIFY_NOT_REACHED();
     }
-#elif defined(AK_OS_LINUX) or defined(AK_OS_FREEBSD)
+#elif OS(LINUX) or OS(FREEBSD)
     int rc;
     pthread_attr_t attr;
     pthread_attr_init(&attr);
 
-#    ifdef AK_OS_LINUX
+#    if OS(LINUX)
     if ((rc = pthread_getattr_np(pthread_self(), &attr)) != 0) {
         fprintf(stderr, "pthread_getattr_np: %s\n", strerror(rc));
         VERIFY_NOT_REACHED();
@@ -50,7 +50,7 @@ StackInfo::StackInfo()
         VERIFY_NOT_REACHED();
     }
     pthread_attr_destroy(&attr);
-#elif defined(AK_OS_MACOS)
+#elif OS(MACOS)
     // NOTE: !! On MacOS, pthread_get_stackaddr_np gives the TOP of the stack, not the bottom!
     FlatPtr top_of_stack = (FlatPtr)pthread_get_stackaddr_np(pthread_self());
     m_size = (size_t)pthread_get_stacksize_np(pthread_self());

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -544,7 +544,7 @@ template<typename T>
 inline constexpr bool IsDestructible = requires { declval<T>().~T(); };
 
 template<typename T>
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 inline constexpr bool IsTriviallyDestructible = __is_trivially_destructible(T);
 #else
 inline constexpr bool IsTriviallyDestructible = __has_trivial_destructor(T) && IsDestructible<T>;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -8,7 +8,7 @@
 
 #include <AK/Platform.h>
 
-#if defined(AK_COMPILER_CLANG) || defined(__CLION_IDE__)
+#if COMPILER(CLANG) || defined(__CLION_IDE__)
 #    pragma clang diagnostic ignored "-Wunqualified-std-cast-call"
 #endif
 

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -348,7 +348,7 @@ struct CaseInsensitiveStringViewTraits : public Traits<StringView> {
 
 // FIXME: Remove this when clang fully supports consteval (specifically in the context of default parameter initialization).
 // See: https://stackoverflow.com/questions/68789984/immediate-function-as-default-function-argument-initializer-in-clang
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    define AK_STRING_VIEW_LITERAL_CONSTEVAL constexpr
 #else
 #    define AK_STRING_VIEW_LITERAL_CONSTEVAL consteval

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -16,7 +16,7 @@
 struct timeval;
 struct timespec;
 
-#if defined(AK_OS_WINDOWS)
+#if OS(WINDOWS)
 #    include <time.h>
 #endif
 

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -35,7 +35,7 @@ using f128 = long double;
 #    endif
 #endif
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 
 using size_t = __SIZE_TYPE__;
 using ssize_t = MakeSigned<size_t>;
@@ -66,7 +66,7 @@ using pid_t = int;
 using __ptrdiff_t = __PTRDIFF_TYPE__;
 #    endif
 
-#    if defined(AK_OS_WINDOWS)
+#    if OS(WINDOWS)
 using ssize_t = MakeSigned<size_t>;
 using mode_t = unsigned short;
 #    endif

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -12,7 +12,7 @@
 #include <AK/Vector.h>
 
 // On Linux distros that use mlibc `basename` is defined as a macro that expands to `__mlibc_gnu_basename` or `__mlibc_gnu_basename_c`, so we undefine it.
-#if defined(AK_OS_LINUX) && defined(basename)
+#if OS(LINUX) && defined(basename)
 #    undef basename
 #endif
 

--- a/AK/kmalloc.cpp
+++ b/AK/kmalloc.cpp
@@ -7,7 +7,7 @@
 
 #include <AK/kmalloc.h>
 
-#if defined(AK_OS_SERENITY) && !defined(KERNEL)
+#if OS(SERENITY) && !defined(KERNEL)
 
 #    include <AK/Assertions.h>
 

--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -26,10 +26,10 @@ inline void kfree_sized(void* ptr, size_t)
 }
 #endif
 
-#ifndef AK_OS_SERENITY
+#if !OS(SERENITY)
 #    include <AK/Types.h>
 
-#    ifndef AK_OS_MACOS
+#    if !OS(MACOS)
 extern "C" {
 inline size_t malloc_good_size(size_t size) { return size; }
 }

--- a/AK/kstdio.h
+++ b/AK/kstdio.h
@@ -8,7 +8,7 @@
 
 #include <AK/Platform.h>
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    ifdef KERNEL
 #        include <Kernel/kstdio.h>
 #    else

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -207,7 +207,7 @@ enum Function {
         __Count
 };
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 struct StringArgument {
     char const* characters;
     size_t length { 0 };

--- a/Kernel/Arch/x86/i386/Atomics.cpp
+++ b/Kernel/Arch/x86/i386/Atomics.cpp
@@ -8,7 +8,7 @@
 
 extern "C" {
 
-#if defined(AK_COMPILER_GCC) // FIXME: Remove this file once GCC supports 8-byte atomics on i686
+#if COMPILER(GCC) // FIXME: Remove this file once GCC supports 8-byte atomics on i686
 
 u64 kernel__atomic_compare_exchange_8(u64 volatile*, u64*, u64, int, int);
 #    pragma redefine_extname kernel__atomic_compare_exchange_8 __atomic_compare_exchange_8

--- a/Kernel/StdLib.cpp
+++ b/Kernel/StdLib.cpp
@@ -206,7 +206,7 @@ ErrorOr<void> memset_user(void* dest_ptr, int c, size_t n)
     return {};
 }
 
-#if defined(AK_COMPILER_CLANG) && defined(ENABLE_KERNEL_LTO)
+#if COMPILER(CLANG) && defined(ENABLE_KERNEL_LTO)
 // Due to a chicken-and-egg situation, certain linker-defined symbols that are added on-demand (like the GOT)
 // need to be present before LTO bitcode files are compiled. And since we don't link to any native object files,
 // the linker does not know that _GLOBAL_OFFSET_TABLE_ is needed, so it doesn't define it, so linking as a PIE fails.

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -778,7 +778,7 @@ public:
 private:
 };
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #pragma clang diagnostic pop
 #endif)~~~");
 }
@@ -808,7 +808,7 @@ void build(StringBuilder& builder, Vector<Endpoint> const& endpoints)
 #include <LibIPC/Message.h>
 #include <LibIPC/Stub.h>
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdefaulted-function-deleted"
 #endif)~~~");

--- a/Meta/Lagom/Wasm/js_repl.cpp
+++ b/Meta/Lagom/Wasm/js_repl.cpp
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#ifndef AK_OS_EMSCRIPTEN
+#if !OS(EMSCRIPTEN)
 #    error "This program is for Emscripten only"
 #endif
 

--- a/Tests/AK/TestRefPtr.cpp
+++ b/Tests/AK/TestRefPtr.cpp
@@ -97,12 +97,12 @@ TEST_CASE(assign_moved_self)
 {
     RefPtr<Object> object = adopt_ref(*new Object);
     EXPECT_EQ(object->ref_count(), 1u);
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wself-move"
 #endif
     object = move(object);
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic pop
 #endif
     EXPECT_EQ(object->ref_count(), 1u);
@@ -113,12 +113,12 @@ TEST_CASE(assign_copy_self)
     RefPtr<Object> object = adopt_ref(*new Object);
     EXPECT_EQ(object->ref_count(), 1u);
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wself-assign-overloaded"
 #endif
     object = object;
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic pop
 #endif
 

--- a/Tests/AK/TestWeakPtr.cpp
+++ b/Tests/AK/TestWeakPtr.cpp
@@ -10,7 +10,7 @@
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wunused-private-field"
 #endif
@@ -24,7 +24,7 @@ private:
     int m_member { 123 };
 };
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic pop
 #endif
 

--- a/Tests/Kernel/TestSigAltStack.cpp
+++ b/Tests/Kernel/TestSigAltStack.cpp
@@ -6,7 +6,7 @@
 
 #include <AK/Platform.h>
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang optimize off
 #else
 #    pragma GCC optimize("O0")

--- a/Tests/Kernel/crash.cpp
+++ b/Tests/Kernel/crash.cpp
@@ -23,7 +23,7 @@
 
 using Test::Crash;
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang optimize off
 #else
 #    pragma GCC optimize("O0")

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -6,7 +6,7 @@
 
 #include <AK/Platform.h>
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang optimize off
 #else
 #    pragma GCC optimize("O0")

--- a/Tests/LibC/TestMemalign.cpp
+++ b/Tests/LibC/TestMemalign.cpp
@@ -91,13 +91,13 @@ TEST_CASE(aligned_alloc_fuzz)
 
 TEST_CASE(aligned_alloc_not_power2)
 {
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wnon-power-of-two-alignment"
 #endif
     EXPECT_EQ(aligned_alloc(7, 256), nullptr);
     EXPECT_EQ(errno, EINVAL);
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic pop
 #endif
 }

--- a/Tests/LibCompress/TestBrotli.cpp
+++ b/Tests/LibCompress/TestBrotli.cpp
@@ -12,7 +12,7 @@
 static void run_test(StringView const file_name)
 {
     // This makes sure that the tests will run both on target and in Lagom.
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     DeprecatedString path = DeprecatedString::formatted("/usr/Tests/LibCompress/brotli-test-files/{}", file_name);
 #else
     DeprecatedString path = DeprecatedString::formatted("brotli-test-files/{}", file_name);
@@ -88,7 +88,7 @@ TEST_CASE(brotli_single_x)
 TEST_CASE(brotli_decompress_zero_one_bin)
 {
     // This makes sure that the tests will run both on target and in Lagom.
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     DeprecatedString path = "/usr/Tests/LibCompress/brotli-test-files/zero-one.bin";
 #else
     DeprecatedString path = "brotli-test-files/zero-one.bin";

--- a/Tests/LibGL/TestRender.cpp
+++ b/Tests/LibGL/TestRender.cpp
@@ -14,7 +14,7 @@
 #include <LibGfx/QOIWriter.h>
 #include <LibTest/TestCase.h>
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    define REFERENCE_IMAGE_DIR "/usr/Tests/LibGL/reference-images"
 #else
 #    define REFERENCE_IMAGE_DIR "reference-images"

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -26,7 +26,7 @@
 #include <signal.h>
 #include <unistd.h>
 
-#if !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN)
+#if !OS(MACOS) && !OS(EMSCRIPTEN)
 // Only used to disable core dumps
 #    include <sys/prctl.h>
 #endif
@@ -556,13 +556,13 @@ static bool g_in_assert = false;
     exit(12);
 }
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 void __assertion_failed(char const* assertion)
 {
     handle_failed_assert(assertion);
 }
 #else
-#    ifdef AK_OS_EMSCRIPTEN
+#    if OS(EMSCRIPTEN)
 extern "C" __attribute__((__noreturn__)) void __assert_fail(char const* assertion, char const* file, int line, char const* function)
 #    else
 extern "C" __attribute__((__noreturn__)) void __assert_fail(char const* assertion, char const* file, unsigned int line, char const* function)
@@ -595,7 +595,7 @@ int main(int argc, char** argv)
     args_parser.add_option(disable_core_dumping, "Disable core dumping", "disable-core-dump", 0);
     args_parser.parse(argc, argv);
 
-#if !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN)
+#if !OS(MACOS) && !OS(EMSCRIPTEN)
     if (disable_core_dumping && prctl(PR_SET_DUMPABLE, 0, 0) < 0) {
         perror("prctl(PR_SET_DUMPABLE)");
         return exit_wrong_arguments;

--- a/Tests/Spreadsheet/test-spreadsheet.cpp
+++ b/Tests/Spreadsheet/test-spreadsheet.cpp
@@ -9,7 +9,7 @@
 
 TEST_ROOT("Userland/Applications/Spreadsheet/Tests");
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 static constexpr auto s_spreadsheet_runtime_path = "/res/js/Spreadsheet/runtime.js"sv;
 #else
 static constexpr auto s_spreadsheet_runtime_path = "../../../../Base/res/js/Spreadsheet/runtime.js"sv;
@@ -32,7 +32,7 @@ TESTJS_RUN_FILE_FUNCTION(DeprecatedString const&, JS::Interpreter& interpreter, 
         interpreter.vm().pop_execution_context();
     };
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     run_file(s_spreadsheet_runtime_path);
 #else
     run_file(LexicalPath::join(Test::JS::g_test_root, s_spreadsheet_runtime_path).string());

--- a/Userland/Applications/KeyboardMapper/KeyPositions.h
+++ b/Userland/Applications/KeyboardMapper/KeyPositions.h
@@ -21,7 +21,7 @@ struct KeyPosition {
 
 #define KEY_COUNT 63
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wc99-designator"
 #endif
@@ -99,6 +99,6 @@ struct KeyPosition keys[KEY_COUNT] = {
     // clang-format on
 };
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic pop
 #endif

--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -25,7 +25,7 @@
 #include <syscall.h>
 #include <unistd.h>
 
-#if defined(AK_COMPILER_GCC)
+#if COMPILER(GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -29,7 +29,7 @@
 #include <syscall.h>
 #include <termios.h>
 
-#if defined(AK_COMPILER_GCC)
+#if COMPILER(GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#if defined(AK_COMPILER_GCC)
+#if COMPILER(GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
@@ -16,7 +16,7 @@
 
 #include <unistd.h>
 
-#if defined(AK_COMPILER_GCC)
+#if COMPILER(GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/Libraries/LibC/arch/x86_64/memset.cpp
+++ b/Userland/Libraries/LibC/arch/x86_64/memset.cpp
@@ -41,7 +41,7 @@ namespace {
 }
 }
 
-#if !defined(AK_COMPILER_CLANG) && !defined(_DYNAMIC_LOADER)
+#if !COMPILER(CLANG) && !defined(_DYNAMIC_LOADER)
 [[gnu::ifunc("resolve_memset")]] void* memset(void*, int, size_t);
 #else
 // DynamicLoader can't self-relocate IFUNCs.

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wdouble-promotion"
 #endif
@@ -1151,6 +1151,6 @@ float nearbyintf(float value) NOEXCEPT
 }
 }
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic pop
 #endif

--- a/Userland/Libraries/LibCompress/BrotliDictionary.cpp
+++ b/Userland/Libraries/LibCompress/BrotliDictionary.cpp
@@ -9,11 +9,11 @@
 
 // Include the 119.9 KiB of dictionary data from a binary file
 extern u8 const brotli_dictionary_data[];
-#if defined(AK_OS_MACOS)
+#if OS(MACOS)
 asm(".const_data\n"
     ".globl _brotli_dictionary_data\n"
     "_brotli_dictionary_data:\n");
-#elif defined(AK_OS_EMSCRIPTEN)
+#elif OS(EMSCRIPTEN)
 asm(".section .data, \"\",@\n"
     ".global brotli_dictionary_data\n"
     "brotli_dictionary_data:\n");
@@ -23,7 +23,7 @@ asm(".section .rodata\n"
     "brotli_dictionary_data:\n");
 #endif
 asm(".incbin \"LibCompress/BrotliDictionaryData.bin\"\n"
-#if (!defined(AK_OS_WINDOWS) && !defined(AK_OS_EMSCRIPTEN))
+#if (!OS(WINDOWS) && !OS(EMSCRIPTEN))
     ".previous\n");
 #else
 );

--- a/Userland/Libraries/LibCore/Account.h
+++ b/Userland/Libraries/LibCore/Account.h
@@ -11,14 +11,14 @@
 #include <AK/Vector.h>
 #include <LibCore/SecretString.h>
 #include <pwd.h>
-#ifndef AK_OS_BSD_GENERIC
+#if !OS(BSD_GENERIC)
 #    include <shadow.h>
 #endif
 #include <sys/types.h>
 
 namespace Core {
 
-#ifdef AK_OS_BSD_GENERIC
+#if OS(BSD_GENERIC)
 struct spwd {
     char* sp_namp;
     char* sp_pwdp;
@@ -73,7 +73,7 @@ private:
     Account(passwd const& pwd, spwd const& spwd, Vector<gid_t> extra_gids);
 
     ErrorOr<DeprecatedString> generate_passwd_file() const;
-#ifndef AK_OS_BSD_GENERIC
+#if !OS(BSD_GENERIC)
     ErrorOr<DeprecatedString> generate_shadow_file() const;
 #endif
 

--- a/Userland/Libraries/LibCore/Command.cpp
+++ b/Userland/Libraries/LibCore/Command.cpp
@@ -16,7 +16,7 @@
 namespace Core {
 
 // Only supported in serenity mode because we use `posix_spawn_file_actions_addchdir`
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 
 ErrorOr<CommandResult> command(DeprecatedString const& command_string, Optional<LexicalPath> chdir)
 {

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -36,7 +36,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    include <LibCore/Account.h>
 
 extern bool s_global_initializers_ran;
@@ -160,7 +160,7 @@ private:
             return allocator->allocate();
         }))
     {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         m_socket->on_ready_to_read = [this] {
             u32 length;
             auto maybe_bytes_read = m_socket->read({ (u8*)&length, sizeof(length) });
@@ -236,7 +236,7 @@ public:
             JsonObject response;
             response.set("type", type);
             response.set("pid", getpid());
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
             char buffer[1024];
             if (get_process_name(buffer, sizeof(buffer)) >= 0) {
                 response.set("process_name", buffer);
@@ -312,7 +312,7 @@ EventLoop::EventLoop([[maybe_unused]] MakeInspectable make_inspectable)
     : m_wake_pipe_fds(&s_wake_pipe_fds)
     , m_private(make<Private>())
 {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     if (!s_global_initializers_ran) {
         // NOTE: Trying to have an event loop as a global variable will lead to initialization-order fiascos,
         //       as the event loop constructor accesses and/or sets other global variables.
@@ -334,7 +334,7 @@ EventLoop::EventLoop([[maybe_unused]] MakeInspectable make_inspectable)
         s_pid = getpid();
         s_event_loop_stack->append(*this);
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         if (getuid() != 0) {
             if (getenv("MAKE_INSPECTABLE") == "1"sv)
                 make_inspectable = Core::EventLoop::MakeInspectable::Yes;
@@ -361,7 +361,7 @@ EventLoop::~EventLoop()
 
 bool connect_to_inspector_server()
 {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     auto maybe_path = SessionManagement::parse_path_with_sid("/tmp/session/%sid/portal/inspectables"sv);
     if (maybe_path.is_error()) {
         dbgln("connect_to_inspector_server: {}", maybe_path.error());

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -19,12 +19,12 @@
 #include <unistd.h>
 #include <utime.h>
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    include <serenity.h>
 #endif
 
 // On Linux distros that use glibc `basename` is defined as a macro that expands to `__xpg_basename`, so we undefine it
-#if defined(AK_OS_LINUX) && defined(basename)
+#if OS(LINUX) && defined(basename)
 #    undef basename
 #endif
 
@@ -243,7 +243,7 @@ DeprecatedString File::absolute_path(DeprecatedString const& path)
     return LexicalPath::canonicalized_path(full_path.string());
 }
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 
 ErrorOr<DeprecatedString> File::read_link(DeprecatedString const& link_path)
 {
@@ -455,7 +455,7 @@ ErrorOr<void, File::CopyError> File::copy_file(DeprecatedString const& dst_path,
 
     if (has_flag(preserve_mode, PreserveMode::Timestamps)) {
         struct timespec times[2] = {
-#ifdef AK_OS_MACOS
+#if OS(MACOS)
             src_stat.st_atimespec,
             src_stat.st_mtimespec,
 #else
@@ -510,7 +510,7 @@ ErrorOr<void, File::CopyError> File::copy_directory(DeprecatedString const& dst_
 
     if (has_flag(preserve_mode, PreserveMode::Timestamps)) {
         struct timespec times[2] = {
-#ifdef AK_OS_MACOS
+#if OS(MACOS)
             src_stat.st_atimespec,
             src_stat.st_mtimespec,
 #else

--- a/Userland/Libraries/LibCore/FileWatcher.cpp
+++ b/Userland/Libraries/LibCore/FileWatcher.cpp
@@ -21,7 +21,7 @@
 namespace Core {
 
 // Only supported in serenity mode because we use InodeWatcher syscalls
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 
 static Optional<FileWatcherEvent> get_event_from_fd(int fd, HashMap<unsigned, DeprecatedString> const& wd_to_path)
 {

--- a/Userland/Libraries/LibCore/Group.cpp
+++ b/Userland/Libraries/LibCore/Group.cpp
@@ -23,7 +23,7 @@ ErrorOr<DeprecatedString> Group::generate_group_file() const
     ScopeGuard grent_guard([] { endgrent(); });
     setgrent();
     errno = 0;
-#ifndef AK_OS_MACOS
+#if !OS(MACOS)
     struct group group;
     struct group* gr = nullptr;
     char buffer[1024] = { 0 };
@@ -71,7 +71,7 @@ ErrorOr<void> Group::sync()
     return {};
 }
 
-#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID)
+#if !OS(BSD_GENERIC) && !OS(ANDROID)
 ErrorOr<void> Group::add_group(Group& group)
 {
     if (group.name().is_empty())
@@ -127,7 +127,7 @@ ErrorOr<Vector<Group>> Group::all()
     ScopeGuard grent_guard([] { endgrent(); });
     setgrent();
     errno = 0;
-#ifndef AK_OS_MACOS
+#if !OS(MACOS)
     struct group group;
     struct group* gr = nullptr;
     char buffer[1024] = { 0 };

--- a/Userland/Libraries/LibCore/Group.h
+++ b/Userland/Libraries/LibCore/Group.h
@@ -15,7 +15,7 @@ namespace Core {
 
 class Group {
 public:
-#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID)
+#if !OS(BSD_GENERIC) && !OS(ANDROID)
     static ErrorOr<void> add_group(Group& group);
 #endif
 

--- a/Userland/Libraries/LibCore/LocalServer.cpp
+++ b/Userland/Libraries/LibCore/LocalServer.cpp
@@ -81,7 +81,7 @@ bool LocalServer::listen(DeprecatedString const& address)
     fcntl(m_fd, F_SETFD, FD_CLOEXEC);
 #endif
     VERIFY(m_fd >= 0);
-#ifndef AK_OS_MACOS
+#if !OS(MACOS)
     rc = fchmod(m_fd, 0600);
     if (rc < 0) {
         perror("fchmod");
@@ -118,7 +118,7 @@ ErrorOr<NonnullOwnPtr<Stream::LocalSocket>> LocalServer::accept()
     VERIFY(m_listening);
     sockaddr_un un;
     socklen_t un_size = sizeof(un);
-#ifndef AK_OS_MACOS
+#if !OS(MACOS)
     int accepted_fd = ::accept4(m_fd, (sockaddr*)&un, &un_size, SOCK_NONBLOCK | SOCK_CLOEXEC);
 #else
     int accepted_fd = ::accept(m_fd, (sockaddr*)&un, &un_size);
@@ -127,7 +127,7 @@ ErrorOr<NonnullOwnPtr<Stream::LocalSocket>> LocalServer::accept()
         return Error::from_syscall("accept"sv, -errno);
     }
 
-#ifdef AK_OS_MACOS
+#if OS(MACOS)
     int option = 1;
     ioctl(m_fd, FIONBIO, &option);
     (void)fcntl(accepted_fd, F_SETFD, FD_CLOEXEC);

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -12,7 +12,7 @@
 #include <errno.h>
 #include <spawn.h>
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    include <serenity.h>
 #endif
 
@@ -51,7 +51,7 @@ struct ArgvList {
 
     ErrorOr<pid_t> spawn()
     {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         posix_spawn_file_actions_t spawn_actions;
         posix_spawn_file_actions_init(&spawn_actions);
         if (!m_working_directory.is_empty())

--- a/Userland/Libraries/LibCore/StandardPaths.cpp
+++ b/Userland/Libraries/LibCore/StandardPaths.cpp
@@ -57,7 +57,7 @@ DeprecatedString StandardPaths::config_directory()
 
     StringBuilder builder;
     builder.append(home_directory());
-#if defined(AK_OS_MACOS)
+#if OS(MACOS)
     builder.append("/Library/Preferences"sv);
 #else
     builder.append("/.config"sv);
@@ -72,9 +72,9 @@ DeprecatedString StandardPaths::data_directory()
 
     StringBuilder builder;
     builder.append(home_directory());
-#if defined(AK_OS_SERENITY)
+#if OS(SERENITY)
     builder.append("/.data"sv);
-#elif defined(AK_OS_MACOS)
+#elif OS(MACOS)
     builder.append("/Library/Application Support"sv);
 #else
     builder.append("/.local/share"sv);

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -14,10 +14,10 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    include <serenity.h>
 #endif
-#ifdef AK_OS_FREEBSD
+#if OS(FREEBSD)
 #    include <sys/ucred.h>
 #endif
 
@@ -596,9 +596,9 @@ ErrorOr<NonnullOwnPtr<LocalSocket>> LocalSocket::adopt_fd(int fd, PreventSIGPIPE
 
 ErrorOr<int> LocalSocket::receive_fd(int flags)
 {
-#if defined(AK_OS_SERENITY)
+#if OS(SERENITY)
     return Core::System::recvfd(m_helper.fd(), flags);
-#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS)
+#elif OS(LINUX) || OS(MACOS)
     union {
         struct cmsghdr cmsghdr;
         char control[CMSG_SPACE(sizeof(int))];
@@ -641,9 +641,9 @@ ErrorOr<int> LocalSocket::receive_fd(int flags)
 
 ErrorOr<void> LocalSocket::send_fd(int fd)
 {
-#if defined(AK_OS_SERENITY)
+#if OS(SERENITY)
     return Core::System::sendfd(m_helper.fd(), fd);
-#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS)
+#elif OS(LINUX) || OS(MACOS)
     char c = 'F';
     struct iovec iov {
         .iov_base = &c,
@@ -682,13 +682,13 @@ ErrorOr<void> LocalSocket::send_fd(int fd)
 
 ErrorOr<pid_t> LocalSocket::peer_pid() const
 {
-#ifdef AK_OS_MACOS
+#if OS(MACOS)
     pid_t pid;
     socklen_t pid_size = sizeof(pid);
-#elif defined(AK_OS_FREEBSD)
+#elif OS(FREEBSD)
     struct xucred creds = {};
     socklen_t creds_size = sizeof(creds);
-#elif defined(AK_OS_OPENBSD)
+#elif OS(OPENBSD)
     struct sockpeercred creds = {};
     socklen_t creds_size = sizeof(creds);
 #else
@@ -696,10 +696,10 @@ ErrorOr<pid_t> LocalSocket::peer_pid() const
     socklen_t creds_size = sizeof(creds);
 #endif
 
-#ifdef AK_OS_MACOS
+#if OS(MACOS)
     TRY(System::getsockopt(m_helper.fd(), SOL_LOCAL, LOCAL_PEERPID, &pid, &pid_size));
     return pid;
-#elif defined(AK_OS_FREEBSD)
+#elif OS(FREEBSD)
     TRY(System::getsockopt(m_helper.fd(), SOL_LOCAL, LOCAL_PEERCRED, &creds, &creds_size));
     return creds.cr_pid;
 #else

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -26,13 +26,13 @@
 #include <time.h>
 #include <utime.h>
 
-#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID)
+#if !OS(BSD_GENERIC) && !OS(ANDROID)
 #    include <shadow.h>
 #endif
 
 namespace Core::System {
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 ErrorOr<void> beep();
 ErrorOr<void> pledge(StringView promises, StringView execpromises = {});
 ErrorOr<void> unveil(StringView path, StringView permissions);
@@ -78,17 +78,17 @@ ALWAYS_INLINE ErrorOr<void> unveil(std::nullptr_t, std::nullptr_t)
     return unveil(StringView {}, StringView {});
 }
 
-#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID)
+#if !OS(BSD_GENERIC) && !OS(ANDROID)
 ErrorOr<Optional<struct spwd>> getspent();
 ErrorOr<Optional<struct spwd>> getspnam(StringView name);
 #endif
 
-#ifndef AK_OS_MACOS
+#if !OS(MACOS)
 ErrorOr<int> accept4(int sockfd, struct sockaddr*, socklen_t*, int flags);
 #endif
 
 ErrorOr<void> sigaction(int signal, struct sigaction const* action, struct sigaction* old_action);
-#if defined(AK_OS_MACOS) || defined(AK_OS_OPENBSD) || defined(AK_OS_FREEBSD)
+#if OS(MACOS) || OS(OPENBSD) || OS(FREEBSD)
 ErrorOr<sig_t> signal(int signal, sig_t handler);
 #else
 ErrorOr<sighandler_t> signal(int signal, sighandler_t handler);
@@ -159,7 +159,7 @@ ErrorOr<void> unlink(StringView path);
 ErrorOr<void> utime(StringView path, Optional<struct utimbuf>);
 ErrorOr<struct utsname> uname();
 ErrorOr<Array<int, 2>> pipe2(int flags);
-#ifndef AK_OS_ANDROID
+#if !OS(ANDROID)
 ErrorOr<void> adjtime(const struct timeval* delta, struct timeval* old_delta);
 #endif
 enum class SearchInPath {
@@ -167,13 +167,13 @@ enum class SearchInPath {
     Yes,
 };
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 ErrorOr<void> exec_command(Vector<StringView>& command, bool preserve_env);
 #endif
 
 ErrorOr<void> exec(StringView filename, Span<StringView> arguments, SearchInPath, Optional<Span<StringView>> environment = {});
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 ErrorOr<void> join_jail(u64 jail_index);
 ErrorOr<u64> create_jail(StringView jail_name);
 #endif
@@ -206,7 +206,7 @@ ErrorOr<void> unlockpt(int fildes);
 ErrorOr<void> access(StringView pathname, int mode);
 ErrorOr<DeprecatedString> readlink(StringView pathname);
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 ErrorOr<void> posix_fallocate(int fd, off_t offset, off_t length);
 #endif
 

--- a/Userland/Libraries/LibCore/TCPServer.cpp
+++ b/Userland/Libraries/LibCore/TCPServer.cpp
@@ -79,7 +79,7 @@ ErrorOr<NonnullOwnPtr<Stream::TCPSocket>> TCPServer::accept()
     VERIFY(m_listening);
     sockaddr_in in;
     socklen_t in_size = sizeof(in);
-#ifndef AK_OS_MACOS
+#if !OS(MACOS)
     int accepted_fd = TRY(Core::System::accept4(m_fd, (sockaddr*)&in, &in_size, SOCK_NONBLOCK | SOCK_CLOEXEC));
 #else
     int accepted_fd = TRY(Core::System::accept(m_fd, (sockaddr*)&in, &in_size));
@@ -87,7 +87,7 @@ ErrorOr<NonnullOwnPtr<Stream::TCPSocket>> TCPServer::accept()
 
     auto socket = TRY(Stream::TCPSocket::adopt_fd(accepted_fd));
 
-#ifdef AK_OS_MACOS
+#if OS(MACOS)
     // FIXME: Ideally, we should let the caller decide whether it wants the
     //        socket to be nonblocking or not, but there are currently places
     //        which depend on this.

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -64,7 +64,7 @@ void DwarfInfo::populate_compilation_units()
         // HACK: Clang generates line programs for embedded resource assembly files, but not compile units.
         // Meaning that for graphical applications, some line info data would be unread, triggering the assertion below.
         // As a fix, we don't create compilation units for line programs that come from resource files.
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
         if (line_program->source_files().size() == 1 && line_program->source_files()[0].name.view().contains("serenity_icon_"sv)) {
             debug_info_stream.seek(unit_offset);
         } else

--- a/Userland/Libraries/LibEDID/EDID.cpp
+++ b/Userland/Libraries/LibEDID/EDID.cpp
@@ -24,7 +24,7 @@ namespace EDID {
 
 // clang doesn't like passing around pointers to members in packed structures,
 // even though we're only using them for arithmetic purposes
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    pragma clang diagnostic ignored "-Waddress-of-packed-member"
 #endif
 

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -26,7 +26,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#ifndef AK_OS_SERENITY
+#if !OS(SERENITY)
 static void* mmap_with_name(void* addr, size_t length, int prot, int flags, int fd, off_t offset, char const*)
 {
     return mmap(addr, length, prot, flags, fd, offset);
@@ -171,7 +171,7 @@ bool DynamicLoader::load_stage_2(unsigned flags)
         for (auto& text_segment : m_text_segments) {
             VERIFY(text_segment.address().get() != 0);
 
-#ifndef AK_OS_MACOS
+#if !OS(MACOS)
             // Remap this text region as private.
             if (mremap(text_segment.address().as_ptr(), text_segment.size(), text_segment.size(), MAP_PRIVATE) == MAP_FAILED) {
                 perror("mremap .text: MAP_PRIVATE");
@@ -240,7 +240,7 @@ Result<NonnullRefPtr<DynamicObject>, DlErrorMessage> DynamicLoader::load_stage_3
             return DlErrorMessage { DeprecatedString::formatted("mprotect .relro: PROT_READ: {}", strerror(errno)) };
         }
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         if (set_mmap_name(m_relro_segment_address.as_ptr(), m_relro_segment_size, DeprecatedString::formatted("{}: .relro", m_filepath).characters()) < 0) {
             return DlErrorMessage { DeprecatedString::formatted("set_mmap_name .relro: {}", strerror(errno)) };
         }

--- a/Userland/Libraries/LibGPU/Driver.cpp
+++ b/Userland/Libraries/LibGPU/Driver.cpp
@@ -15,9 +15,9 @@ namespace GPU {
 // FIXME: Think of a better way to configure these paths. Maybe use ConfigServer?
 static HashMap<DeprecatedString, DeprecatedString> const s_driver_path_map
 {
-#if defined(AK_OS_SERENITY)
+#if OS(SERENITY)
     { "softgpu", "libsoftgpu.so.serenity" },
-#elif defined(AK_OS_MACOS)
+#elif OS(MACOS)
     { "softgpu", "liblagom-softgpu.dylib" },
 #else
     { "softgpu", "liblagom-softgpu.so.0" },

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -6,15 +6,15 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#if defined(AK_COMPILER_GCC)
-#    pragma GCC optimize("O3")
-#endif
-
 #include "FillPathImplementation.h"
 #include <AK/Function.h>
 #include <AK/NumericLimits.h>
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/Line.h>
+
+#if COMPILER(GCC)
+#    pragma GCC optimize("O3")
+#endif
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -501,7 +501,7 @@ Bitmap::~Bitmap()
 void Bitmap::set_mmap_name([[maybe_unused]] DeprecatedString const& name)
 {
     VERIFY(m_needs_munmap);
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     ::set_mmap_name(m_data, size_in_bytes(), name.characters());
 #endif
 }
@@ -519,7 +519,7 @@ void Bitmap::set_volatile()
 {
     if (m_volatile)
         return;
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     int rc = madvise(m_data, size_in_bytes(), MADV_SET_VOLATILE);
     if (rc < 0) {
         perror("madvise(MADV_SET_VOLATILE)");
@@ -536,7 +536,7 @@ void Bitmap::set_volatile()
         return true;
     }
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     int rc = madvise(m_data, size_in_bytes(), MADV_SET_NONVOLATILE);
     if (rc < 0) {
         if (errno == ENOMEM) {
@@ -569,7 +569,7 @@ ErrorOr<BackingStore> Bitmap::allocate_backing_store(BitmapFormat format, IntSiz
     auto const data_size_in_bytes = size_in_bytes(pitch, size.height() * scale_factor);
 
     int map_flags = MAP_ANONYMOUS | MAP_PRIVATE;
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     map_flags |= MAP_PURGEABLE;
     void* data = mmap_with_name(nullptr, data_size_in_bytes, PROT_READ | PROT_WRITE, map_flags, 0, 0, DeprecatedString::formatted("GraphicsBitmap [{}]", size).characters());
 #else

--- a/Userland/Libraries/LibGfx/Filters/FastBoxBlurFilter.cpp
+++ b/Userland/Libraries/LibGfx/Filters/FastBoxBlurFilter.cpp
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#if defined(AK_COMPILER_GCC)
-#    pragma GCC optimize("O3")
-#endif
-
 #include <AK/Function.h>
 #include <AK/Vector.h>
 #include <LibGfx/Filters/FastBoxBlurFilter.h>
+
+#if COMPILER(GCC)
+#    pragma GCC optimize("O3")
+#endif
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/Filters/StackBlurFilter.cpp
+++ b/Userland/Libraries/LibGfx/Filters/StackBlurFilter.cpp
@@ -5,14 +5,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#if defined(AK_COMPILER_GCC)
-#    pragma GCC optimize("O3")
-#endif
-
 #include <AK/Array.h>
 #include <AK/Math.h>
 #include <AK/Vector.h>
 #include <LibGfx/Filters/StackBlurFilter.h>
+
+#if COMPILER(GCC)
+#    pragma GCC optimize("O3")
+#endif
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -36,7 +36,7 @@
 #include <LibGfx/TextLayout.h>
 #include <stdio.h>
 
-#if defined(AK_COMPILER_GCC)
+#if COMPILER(GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/Libraries/LibGfx/VectorN.h
+++ b/Userland/Libraries/LibGfx/VectorN.h
@@ -21,7 +21,7 @@
 #define STRINGIFY_HELPER(x) #x
 #define STRINGIFY(x) STRINGIFY_HELPER(x)
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    define UNROLL_LOOP _Pragma(STRINGIFY(unroll))
 #else
 #    define UNROLL_LOOP _Pragma(STRINGIFY(GCC unroll(LOOP_UNROLL_N)))

--- a/Userland/Libraries/LibJS/Heap/BlockAllocator.cpp
+++ b/Userland/Libraries/LibJS/Heap/BlockAllocator.cpp
@@ -21,7 +21,7 @@ BlockAllocator::~BlockAllocator()
 {
     for (auto* block : m_blocks) {
         ASAN_UNPOISON_MEMORY_REGION(block, HeapBlock::block_size);
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         if (munmap(block, HeapBlock::block_size) < 0) {
             perror("munmap");
             VERIFY_NOT_REACHED();
@@ -39,7 +39,7 @@ void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
         size_t random_index = get_random_uniform(m_blocks.size());
         auto* block = m_blocks.unstable_take(random_index);
         ASAN_UNPOISON_MEMORY_REGION(block, HeapBlock::block_size);
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         if (set_mmap_name(block, HeapBlock::block_size, name) < 0) {
             perror("set_mmap_name");
             VERIFY_NOT_REACHED();
@@ -48,7 +48,7 @@ void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
         return block;
     }
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     auto* block = (HeapBlock*)serenity_mmap(nullptr, HeapBlock::block_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_RANDOMIZED | MAP_PRIVATE, 0, 0, HeapBlock::block_size, name);
     VERIFY(block != MAP_FAILED);
 #else
@@ -62,7 +62,7 @@ void BlockAllocator::deallocate_block(void* block)
 {
     VERIFY(block);
     if (m_blocks.size() >= max_cached_blocks) {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         if (munmap(block, HeapBlock::block_size) < 0) {
             perror("munmap");
             VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -20,13 +20,13 @@
 #include <LibJS/SafeFunction.h>
 #include <setjmp.h>
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    include <serenity.h>
 #endif
 
 namespace JS {
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 static int gc_perf_string_id;
 #endif
 
@@ -36,7 +36,7 @@ static __thread HashMap<FlatPtr*, size_t>* s_custom_ranges_for_conservative_scan
 Heap::Heap(VM& vm)
     : m_vm(vm)
 {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     auto gc_signpost_string = "Garbage collection"sv;
     gc_perf_string_id = perf_register_string(gc_signpost_string.characters_without_null_termination(), gc_signpost_string.length());
 #endif
@@ -91,7 +91,7 @@ void Heap::collect_garbage(CollectionType collection_type, bool print_report)
     VERIFY(!m_collecting_garbage);
     TemporaryChange change(m_collecting_garbage, true);
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     static size_t global_gc_counter = 0;
     perf_event(PERF_EVENT_SIGNPOST, gc_perf_string_id, global_gc_counter++);
 #endif

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.cpp
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.cpp
@@ -20,7 +20,7 @@ namespace JS {
 
 NonnullOwnPtr<HeapBlock> HeapBlock::create_with_cell_size(Heap& heap, size_t cell_size)
 {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     char name[64];
     snprintf(name, sizeof(name), "LibJS: HeapBlock(%zu)", cell_size);
 #else

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -201,7 +201,7 @@ GlobalObject::~GlobalObject() = default;
 
 JS_DEFINE_NATIVE_FUNCTION(GlobalObject::gc)
 {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     dbgln("Forced garbage collection requested!");
 #endif
     vm.heap().collect_garbage();

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -11,7 +11,7 @@
 #include <LibJS/Runtime/NumberConstructor.h>
 #include <LibJS/Runtime/NumberObject.h>
 
-#if defined(AK_COMPILER_CLANG)
+#if COMPILER(CLANG)
 #    define EPSILON_VALUE AK::exp2(-52.)
 #    define MAX_SAFE_INTEGER_VALUE AK::exp2(53.) - 1
 #    define MIN_SAFE_INTEGER_VALUE -(AK::exp2(53.) - 1)

--- a/Userland/Libraries/LibMain/Main.cpp
+++ b/Userland/Libraries/LibMain/Main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
     if (result.is_error()) {
         auto error = result.release_error();
         warnln("\033[31;1mRuntime error\033[0m: {}", error);
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         dbgln("\033[31;1mExiting with runtime error\033[0m: {}", error);
 #endif
         return Main::return_code_for_errors();

--- a/Userland/Libraries/LibRegex/C/Regex.cpp
+++ b/Userland/Libraries/LibRegex/C/Regex.cpp
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifndef AK_OS_SERENITY
+#if !OS(SERENITY)
 #    error "This file is intended for use on Serenity only to implement POSIX regex.h"
 #endif
 

--- a/Userland/Libraries/LibRegex/RegexError.h
+++ b/Userland/Libraries/LibRegex/RegexError.h
@@ -8,7 +8,7 @@
 
 #include <AK/DeprecatedString.h>
 #include <AK/Types.h>
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    include <bits/regex_defs.h>
 #else
 #    include <LibC/bits/regex_defs.h>

--- a/Userland/Libraries/LibRegex/RegexOptions.h
+++ b/Userland/Libraries/LibRegex/RegexOptions.h
@@ -8,7 +8,7 @@
 
 #include <AK/Types.h>
 #include <stdio.h>
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    include <bits/regex_defs.h>
 #else
 #    include <LibC/bits/regex_defs.h>

--- a/Userland/Libraries/LibTest/CrashTest.cpp
+++ b/Userland/Libraries/LibTest/CrashTest.cpp
@@ -12,7 +12,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#if !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN)
+#if !OS(MACOS) && !OS(EMSCRIPTEN)
 #    include <sys/prctl.h>
 #endif
 
@@ -38,7 +38,7 @@ bool Crash::run(RunType run_type)
             perror("fork");
             VERIFY_NOT_REACHED();
         } else if (pid == 0) {
-#if !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN)
+#if !OS(MACOS) && !OS(EMSCRIPTEN)
             if (prctl(PR_SET_DUMPABLE, 0, 0) < 0)
                 perror("prctl(PR_SET_DUMPABLE)");
 #endif

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -37,7 +37,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    include <serenity.h>
 #endif
 
@@ -292,7 +292,7 @@ inline JSFileResult TestRunner::run_file_test(DeprecatedString const& test_path)
 {
     g_currently_running_test = test_path;
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     auto string_id = perf_register_string(test_path.characters(), test_path.length());
     perf_event(PERF_EVENT_SIGNPOST, string_id, 0);
 #endif
@@ -540,7 +540,7 @@ inline void TestRunner::print_file_result(JSFileResult const& file_result) const
 
     if (!file_result.logged_messages.is_empty()) {
         print_modifiers({ FG_GRAY, FG_BOLD });
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         outln("     ℹ Console output:");
 #else
         // This emoji has a second invisible byte after it. The one above does not
@@ -555,7 +555,7 @@ inline void TestRunner::print_file_result(JSFileResult const& file_result) const
         auto test_error = file_result.error.value();
 
         print_modifiers({ FG_RED });
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         outln("     ❌ The file failed to parse");
 #else
         // No invisible byte here, but the spacing still needs to be altered on the host
@@ -582,14 +582,14 @@ inline void TestRunner::print_file_result(JSFileResult const& file_result) const
             print_modifiers({ FG_GRAY, FG_BOLD });
 
             if (failed) {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
                 out("     ❌ Suite:  ");
 #else
                 // No invisible byte here, but the spacing still needs to be altered on the host
                 out("    ❌ Suite:  ");
 #endif
             } else {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
                 out("     ⚠ Suite:  ");
 #else
                 // This emoji has a second invisible byte after it. The one above does not

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
 
     bool print_times = false;
     bool print_progress =
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         true; // Use OSC 9 to print progress
 #else
         false;
@@ -140,7 +140,7 @@ int main(int argc, char** argv)
     if (specified_test_root) {
         test_root = DeprecatedString { specified_test_root };
     } else {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         test_root = LexicalPath::join("/home/anon/Tests"sv, DeprecatedString::formatted("{}-tests", program_name.split_view('-').last())).string();
 #else
         char* serenity_source_dir = getenv("SERENITY_SOURCE_DIR");
@@ -158,7 +158,7 @@ int main(int argc, char** argv)
     }
 
     if (common_path.is_empty()) {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         common_path = "/home/anon/Tests/js-tests/test-common.js";
 #else
         char* serenity_source_dir = getenv("SERENITY_SOURCE_DIR");

--- a/Userland/Libraries/LibThreading/Mutex.h
+++ b/Userland/Libraries/LibThreading/Mutex.h
@@ -24,7 +24,7 @@ public:
     Mutex()
         : m_lock_count(0)
     {
-#ifndef AK_OS_SERENITY
+#if !OS(SERENITY)
         pthread_mutexattr_t attr;
         pthread_mutexattr_init(&attr);
         pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
@@ -41,7 +41,7 @@ public:
     void unlock();
 
 private:
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     pthread_mutex_t m_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 #else
     pthread_mutex_t m_mutex;

--- a/Userland/Libraries/LibThreading/Thread.cpp
+++ b/Userland/Libraries/LibThreading/Thread.cpp
@@ -15,7 +15,7 @@ Threading::Thread::Thread(Function<intptr_t()> action, StringView thread_name)
     , m_thread_name(thread_name.is_null() ? ""sv : thread_name)
 {
     register_property("thread_name", [&] { return JsonValue { m_thread_name }; });
-#if defined(AK_OS_SERENITY) || defined(AK_OS_LINUX)
+#if OS(SERENITY) || OS(LINUX)
     // FIXME: Print out a pretty TID for BSD and macOS platforms, too
     register_property("tid", [&] { return JsonValue { m_tid }; });
 #endif
@@ -64,7 +64,7 @@ void Threading::Thread::start()
         static_cast<void*>(this));
 
     VERIFY(rc == 0);
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     if (!m_thread_name.is_empty()) {
         rc = pthread_setname_np(m_tid, m_thread_name.characters());
         VERIFY(rc == 0);

--- a/Userland/Libraries/LibTimeZone/TimeZone.cpp
+++ b/Userland/Libraries/LibTimeZone/TimeZone.cpp
@@ -102,7 +102,7 @@ StringView current_time_zone()
         return "UTC"sv;
     }
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     return system_time_zone();
 #else
     static constexpr auto zoneinfo = "/zoneinfo/"sv;
@@ -128,7 +128,7 @@ StringView current_time_zone()
 
 ErrorOr<void> change_time_zone([[maybe_unused]] StringView time_zone)
 {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     TimeZoneFile time_zone_file("w");
 
     if (auto new_time_zone = canonicalize_time_zone(time_zone); new_time_zone.has_value())

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -13,7 +13,7 @@
 #include "Decoder.h"
 #include "Utilities.h"
 
-#if defined(AK_COMPILER_GCC)
+#if COMPILER(GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -14,7 +14,7 @@
 #include "Parser.h"
 #include "Utilities.h"
 
-#if defined(AK_COMPILER_GCC)
+#if COMPILER(GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -18,7 +18,7 @@
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Platform/Timer.h>
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
 #    include <serenity.h>
 #endif
 
@@ -127,7 +127,7 @@ static DeprecatedString sanitized_url_for_logging(AK::URL const& url)
 
 static void emit_signpost(DeprecatedString const& message, int id)
 {
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     auto string_id = perf_register_string(message.characters(), message.length());
     perf_event(PERF_EVENT_SIGNPOST, string_id, id);
 #else

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -26,21 +26,21 @@ namespace Web {
 #    define CPU_STRING "AArch64"
 #endif
 
-#if defined(AK_OS_SERENITY)
+#if OS(SERENITY)
 #    define OS_STRING "SerenityOS"
-#elif defined(AK_OS_LINUX)
+#elif OS(LINUX)
 #    define OS_STRING "Linux"
-#elif defined(AK_OS_MACOS)
+#elif OS(MACOS)
 #    define OS_STRING "macOS"
-#elif defined(AK_OS_WINDOWS)
+#elif OS(WINDOWS)
 #    define OS_STRING "Windows"
-#elif defined(AK_OS_FREEBSD)
+#elif OS(FREEBSD)
 #    define OS_STRING "FreeBSD"
-#elif defined(AK_OS_OPENBSD)
+#elif OS(OPENBSD)
 #    define OS_STRING "OpenBSD"
-#elif defined(AK_OS_NETBSD)
+#elif OS(NETBSD)
 #    define OS_STRING "NetBSD"
-#elif defined(AK_OS_DRAGONFLY)
+#elif OS(DRAGONFLY)
 #    define OS_STRING "DragonFly"
 #else
 #    error Unknown OS

--- a/Userland/Libraries/LibWebView/DOMTreeModel.cpp
+++ b/Userland/Libraries/LibWebView/DOMTreeModel.cpp
@@ -19,7 +19,7 @@ DOMTreeModel::DOMTreeModel(JsonObject dom_tree, GUI::TreeView* tree_view)
     , m_dom_tree(move(dom_tree))
 {
     // FIXME: Get these from the outside somehow instead of hard-coding paths here.
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     m_document_icon.set_bitmap_for_size(16, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-html.png"sv).release_value_but_fixme_should_propagate_errors());
     m_element_icon.set_bitmap_for_size(16, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/inspector-object.png"sv).release_value_but_fixme_should_propagate_errors());
     m_text_icon.set_bitmap_for_size(16, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-unknown.png"sv).release_value_but_fixme_should_propagate_errors());
@@ -123,7 +123,7 @@ GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
     auto type = node.get("type"sv).as_string_or("unknown"sv);
 
     // FIXME: This FIXME can go away when we fix the one below.
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     if (role == GUI::ModelRole::ForegroundColor) {
         // FIXME: Allow models to return a foreground color *role*.
         //        Then we won't need to have a GUI::TreeView& member anymore.
@@ -138,7 +138,7 @@ GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
 #endif
 
     // FIXME: This FIXME can go away when the icons are provided from the outside (see constructor).
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
     if (role == GUI::ModelRole::Icon) {
         if (type == "document")
             return m_document_icon;

--- a/Userland/Libraries/LibX86/Instruction.cpp
+++ b/Userland/Libraries/LibX86/Instruction.cpp
@@ -9,7 +9,7 @@
 #include <LibX86/Instruction.h>
 #include <LibX86/Interpreter.h>
 
-#if defined(AK_COMPILER_GCC)
+#if COMPILER(GCC)
 #    pragma GCC optimize("O3")
 #endif
 

--- a/Userland/Services/LookupServer/MulticastDNS.h
+++ b/Userland/Services/LookupServer/MulticastDNS.h
@@ -36,7 +36,7 @@ private:
     Name m_hostname;
 
     static constexpr sockaddr_in mdns_addr {
-#ifdef AK_OS_BSD_GENERIC
+#if OS(BSD_GENERIC)
         .sin_len = sizeof(struct sockaddr_in),
 #endif
         .sin_family = AF_INET,

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -90,7 +90,7 @@ void ConnectionFromClient::load_url(const URL& url)
 {
     dbgln_if(SPAM_DEBUG, "handle: WebContentServer::LoadURL: url={}", url);
 
-#if defined(AK_OS_SERENITY)
+#if OS(SERENITY)
     DeprecatedString process_name;
     if (url.host().is_empty())
         process_name = "WebContent";

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -625,7 +625,7 @@ void BarewordLiteral::highlight_in_editor(Line::Editor& editor, Shell& shell, Hi
             Line::Style bold = { Line::Style::Bold };
             Line::Style style = bold;
 
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
             if (runnable->kind == Shell::RunnablePath::Kind::Executable || runnable->kind == Shell::RunnablePath::Kind::Alias) {
                 auto name = shell.help_path_for({}, *runnable);
                 if (name.has_value()) {

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -563,7 +563,7 @@ public:
         }
 
         auto output = DeprecatedString::join(' ', arguments.get<JS::MarkedVector<JS::Value>>());
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         m_console.output_debug_message(log_level, output);
 #endif
 

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -306,7 +306,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #endif
 
     bool print_progress =
-#ifdef AK_OS_SERENITY
+#if OS(SERENITY)
         true; // Use OSC 9 to print progress
 #else
         false;


### PR DESCRIPTION
This commit introduces a OS() and a COMPILER() macro, which are meant to unify all of the os and compiler checks because we would use #if defined(...),  #ifdef ... and #if ...