### PR TITLE
LibJS: Remove redundant starts_with()s from is_less_than() string branch

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -1568,11 +1568,6 @@ ThrowCompletionOr<TriState> is_less_than(VM& vm, Value lhs, Value rhs, bool left
         Utf8View x_code_points { x_string };
         Utf8View y_code_points { y_string };
 
-        if (x_code_points.starts_with(y_code_points))
-            return TriState::False;
-        if (y_code_points.starts_with(x_code_points))
-            return TriState::True;
-
         for (auto k = x_code_points.begin(), l = y_code_points.begin();
              k != x_code_points.end() && l != y_code_points.end();
              ++k, ++l) {
@@ -1584,7 +1579,10 @@ ThrowCompletionOr<TriState> is_less_than(VM& vm, Value lhs, Value rhs, bool left
                 }
             }
         }
-        VERIFY_NOT_REACHED();
+
+        return x_code_points.length() < y_code_points.length()
+            ? TriState::True
+            : TriState::False;
     }
 
     if (x_primitive.is_bigint() && y_primitive.is_string()) {


### PR DESCRIPTION
This is not in the spec and does pointless work:
- If either of them is true, we would determine the same result with the manual code point iteration and comparison
- If neither of them is true, we iterate from the start again and repeat the work that was just done

Instead, only have the manual loop from the spec and do a length comparison at the end.

Removing it brings the following microbenchmark from ~5.5s down to ~3.5s on my machine:

```js
const a = "x".repeat(100_000_000) + "a";
const b = "x".repeat(100_000_000) + "b";
a < b
```