### PR TITLE
Meta+Base: Un-break the userspace coverage build

### DIFF
--- a/Base/home/anon/Tests/run-tests-and-shutdown.sh
+++ b/Base/home/anon/Tests/run-tests-and-shutdown.sh
@@ -13,6 +13,7 @@ unset LLVM_PROFILE_FILE
 echo "Failed: $fail_count" > ./test-results.log
 
 if test $DO_SHUTDOWN_AFTER_TESTS {
+    sync
     shutdown -n
 }
 

--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -89,6 +89,9 @@ function(serenity_libc target_name fs_name)
     # Avoid creating a dependency cycle between system libraries and the C++ standard library. This is necessary
     # to ensure that initialization functions will be called in the right order (libc++ must come after LibPthread).
     target_link_options(${target_name} PRIVATE -static-libstdc++)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$" AND ENABLE_USERSPACE_COVERAGE_COLLECTION)
+       target_link_libraries(${target_name} PRIVATE clang_rt.profile)
+    endif()
     target_link_directories(LibC PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
     serenity_generated_sources(${target_name})
 endfunction()

--- a/Meta/analyze-qemu-coverage.sh
+++ b/Meta/analyze-qemu-coverage.sh
@@ -3,6 +3,7 @@
 set -eo pipefail
 
 SCRIPT_DIR="$(dirname "${0}")"
+SERENITY_ROOT="$(realpath "${SCRIPT_DIR}"/..)"
 
 if [ -z "$SERENITY_ARCH" ]; then
     SERENITY_ARCH="x86_64"
@@ -13,7 +14,7 @@ if [ "$SERENITY_TOOLCHAIN" = "Clang" ]; then
     toolchain_suffix="clang"
 fi
 
-BUILD_DIR="${SCRIPT_DIR}/../Build/${SERENITY_ARCH}${toolchain_suffix}"
+BUILD_DIR="${SERENITY_ROOT}/Build/${SERENITY_ARCH}${toolchain_suffix}"
 TEMP_PROFDATA="$BUILD_DIR/tmp_profile_data"
 
 mkdir -p "$TEMP_PROFDATA"
@@ -62,12 +63,12 @@ if [ ! -f "$COVERAGE_PREPARE" ]; then
     fi
 fi
 
-CLANG_BINDIR="${SCRIPT_DIR}/../Toolchain/Local/clang/bin"
+CLANG_BINDIR="${SERENITY_ROOT}/Toolchain/Local/clang/bin"
 
 # shellcheck disable=SC2128,SC2086 # all_binaries variable needs expanded to space separated string, not newline separated string
 python3 "$COVERAGE_PREPARE" \
     --unified-report \
-    -C "$SCRIPT_DIR/.." \
+    -C "${SERENITY_ROOT}" \
     "$CLANG_BINDIR/llvm-profdata" "$CLANG_BINDIR/llvm-cov" \
     "$TEMP_PROFDATA/" \
     "$BUILD_DIR/reports/" \


### PR DESCRIPTION
We broke the Nightly azure pipeline run for UT coverage back a few months ago. Let's make those not instantly fail anymore.

And a few other changes that "should" have no effect, but might make that pipeline less flaky.