### PR TITLE
LibX86: Fix disassembly on x86-64

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -234,7 +234,7 @@ int Emulator::exec()
     while (!m_shutdown) {
         if (m_steps_til_pause) [[likely]] {
             m_cpu->save_base_eip();
-            auto insn = X86::Instruction::from_stream(*m_cpu, X86::OperandSize::Size32, X86::AddressSize::Size32);
+            auto insn = X86::Instruction::from_stream(*m_cpu, X86::ProcessorMode::Protected);
             // Exec cycle
             if constexpr (trace) {
                 outln("{:p}  \033[33;1m{}\033[0m", m_cpu->base_eip(), insn.to_deprecated_string(m_cpu->base_eip(), symbol_provider));
@@ -301,7 +301,7 @@ void Emulator::handle_repl()
     // FIXME: Function names (base, call, jump)
     auto saved_eip = m_cpu->eip();
     m_cpu->save_base_eip();
-    auto insn = X86::Instruction::from_stream(*m_cpu, X86::OperandSize::Size32, X86::AddressSize::Size32);
+    auto insn = X86::Instruction::from_stream(*m_cpu, X86::ProcessorMode::Protected);
     // FIXME: This does not respect inlining
     //        another way of getting the current function is at need
     if (auto symbol = symbol_at(m_cpu->base_eip()); symbol.has_value()) {
@@ -311,7 +311,7 @@ void Emulator::handle_repl()
     outln("==> {}", create_instruction_line(m_cpu->base_eip(), insn));
     for (int i = 0; i < 7; ++i) {
         m_cpu->save_base_eip();
-        insn = X86::Instruction::from_stream(*m_cpu, X86::OperandSize::Size32, X86::AddressSize::Size32);
+        insn = X86::Instruction::from_stream(*m_cpu, X86::ProcessorMode::Protected);
         outln("    {}", create_instruction_line(m_cpu->base_eip(), insn));
     }
     // We don't want to increase EIP here, we just want the instructions

--- a/Userland/Libraries/LibX86/Disassembler.h
+++ b/Userland/Libraries/LibX86/Disassembler.h
@@ -23,10 +23,10 @@ public:
         if (!m_stream.can_read())
             return {};
 #if ARCH(I386)
-        return Instruction::from_stream(m_stream, OperandSize::Size32, AddressSize::Size32);
+        return Instruction::from_stream(m_stream, ProcessorMode::Protected);
 #else
 #    if ARCH(X86_64)
-        return Instruction::from_stream(m_stream, OperandSize::Size32, AddressSize::Size64);
+        return Instruction::from_stream(m_stream, ProcessorMode::Long);
 #    else
         dbgln("Unsupported platform");
         return {};

--- a/Userland/Libraries/LibX86/Instruction.h
+++ b/Userland/Libraries/LibX86/Instruction.h
@@ -1007,11 +1007,12 @@ ALWAYS_INLINE Instruction::Instruction(InstructionStreamType& stream, OperandSiz
     , m_address_size(address_size)
 {
     VERIFY(operand_size != OperandSize::Size64);
-    // Use address_size as the hint to switch into long mode, m_address_size refers to the default
-    // size of displacements/immediates, which is 32 even in long mode, with the exception of moffset (see below).
+    // Use address_size as the hint to switch into long mode.
+    // m_address_size refers to the default size of displacements/immediates, which is 32 even in long mode (2.2.1.3 Displacement, 2.2.1.5 Immediates),
+    // with the exception of moffset (see below).
     if (address_size == AddressSize::Size64) {
         m_operand_size = OperandSize::Size32;
-        m_address_size = AddressSize::Size64;
+        m_address_size = AddressSize::Size32;
         m_mode = ProcessorMode::Long;
     }
     u8 prefix_bytes = 0;
@@ -1124,7 +1125,7 @@ ALWAYS_INLINE Instruction::Instruction(InstructionStreamType& stream, OperandSiz
         return;
     }
 
-    // 2.2.1.3 Direct Memory-Offset MOVs
+    // 2.2.1.4 Direct Memory-Offset MOVs
     auto effective_address_size = m_address_size;
     if (m_mode == ProcessorMode::Long) {
         switch (m_descriptor->format) {


### PR DESCRIPTION
Thanks to #15465, `LibX86` has support for x86-64.
But attempting to disassemble things often failed with
```
disasm(46:46): ASSERTION FAILED: false
./Userland/Libraries/LibX86/Instruction.h:1228
```

This makes `disasm`, `sdb` and the Disassembly view in the profiler work in x86-64 builds.

