### PR TITLE
CI: Correct regex to retrieve git merge commit

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -29,7 +29,7 @@ jobs:
                 error: "Commit message lines are too long (maximum allowed is 72 characters, except for URLs)",
               },
               {
-                pattern: /^Merge branch/,
+                pattern: /^((?!^Merge branch).)*$/,
                 error: "Commit is a git merge commit, use the rebase command instead",
               },
               {


### PR DESCRIPTION
In 839c1a5, I wrongly assumed that a matched pattern will raise an error, it's the opposite. This patch "negates" the regex to solve the issue.

This version is not only locally tested (with `lint-commit.sh`) but also on my fork:
https://github.com/LucasChollet/serenity/pull/2

Sorry for this mess :cry: 