### PR TITLE
Meta+CMake: Extract Wasm spec tests into the binary directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,6 @@ add_custom_target(components ALL)
 option(BUILD_EVERYTHING "Build all optional components" ON)
 
 include(utils)
-include(wasm_spec_tests)
 include(flac_spec_tests)
 
 serenity_component(

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -69,7 +69,6 @@ if (ENABLE_FUZZERS OR CMAKE_CROSSCOMPILING)
     set(BUILD_LAGOM_TOOLS OFF)
 endif()
 
-include(wasm_spec_tests)
 include(flac_spec_tests)
 include(lagom_compile_options)
 
@@ -664,13 +663,12 @@ if (BUILD_LAGOM)
             ../../Tests/LibWasm/test-wasm.cpp
             ../../Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp)
         target_link_libraries(test-wasm LibCore LibTest LibWasm LibJS)
+        # FIXME: Don't require passing test-common.js path if you only want to pass a custom Test root path
         add_test(
             NAME WasmParser
-            COMMAND test-wasm --show-progress=false
+            COMMAND test-wasm --show-progress=false ${CMAKE_CURRENT_BINARY_DIR}/Userland/Libraries/LibWasm/Tests ${SERENITY_PROJECT_ROOT}/Userland/Libraries/LibJS/Tests/test-common.js
         )
-        set_tests_properties(WasmParser PROPERTIES
-            ENVIRONMENT SERENITY_SOURCE_DIR=${SERENITY_PROJECT_ROOT}
-            SKIP_RETURN_CODE 1)
+        set_tests_properties(WasmParser PROPERTIES SKIP_RETURN_CODE 1)
 
         # Tests that are not LibTest based
         # Shell

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -154,7 +154,8 @@ mkdir -p mnt/home/anon
 mkdir -p mnt/home/anon/Desktop
 mkdir -p mnt/home/anon/Downloads
 mkdir -p mnt/home/nona
-rm -fr mnt/home/anon/Tests/js-tests mnt/home/anon/Tests/web-tests mnt/home/anon/Tests/cpp-tests mnt/home/anon/Tests/wasm-tests 
+# FIXME: Handle these test copies using CMake install rules 
+rm -fr mnt/home/anon/Tests/js-tests mnt/home/anon/Tests/web-tests mnt/home/anon/Tests/cpp-tests
 mkdir -p mnt/home/anon/Tests/cpp-tests/
 cp "$SERENITY_SOURCE_DIR"/README.md mnt/home/anon/
 cp -r "$SERENITY_SOURCE_DIR"/Userland/Libraries/LibJS/Tests mnt/home/anon/Tests/js-tests
@@ -162,7 +163,6 @@ cp -r "$SERENITY_SOURCE_DIR"/Userland/Libraries/LibWeb/Tests mnt/home/anon/Tests
 cp -r "$SERENITY_SOURCE_DIR"/Userland/Libraries/LibCodeComprehension/Cpp/Tests mnt/home/anon/Tests/cpp-tests/comprehension
 cp -r "$SERENITY_SOURCE_DIR"/Userland/Libraries/LibCpp/Tests/parser mnt/home/anon/Tests/cpp-tests/parser
 cp -r "$SERENITY_SOURCE_DIR"/Userland/Libraries/LibCpp/Tests/preprocessor mnt/home/anon/Tests/cpp-tests/preprocessor
-cp -r "$SERENITY_SOURCE_DIR"/Userland/Libraries/LibWasm/Tests mnt/home/anon/Tests/wasm-tests
 cp -r "$SERENITY_SOURCE_DIR"/Userland/Libraries/LibJS/Tests/test-common.js mnt/home/anon/Tests/wasm-tests
 cp -r "$SERENITY_SOURCE_DIR"/Userland/Applications/Spreadsheet/Tests mnt/home/anon/Tests/spreadsheet-tests
 

--- a/Userland/Libraries/LibWasm/CMakeLists.txt
+++ b/Userland/Libraries/LibWasm/CMakeLists.txt
@@ -9,3 +9,7 @@ set(SOURCES
 
 serenity_lib(LibWasm wasm)
 target_link_libraries(LibWasm PRIVATE LibCore)
+
+# FIXME: Install these into usr/Tests/LibWasm
+include(wasm_spec_tests)
+install(DIRECTORY Tests/ DESTINATION home/anon/Tests/wasm-tests)


### PR DESCRIPTION
Clean up the Wasm spec tests CMake rules to extract and compile the wat files into wasm files in the LibWasm binary directory instead of its source directory. Also make the rules more robust to missing host tools, and use more CMake install rules for the test files rather than relying on build-root-filesystem.sh. Add some FIXMEs for later, we really shouldn't be doing installation of test files into /home/anon at the build-root-filesystem stage in $CURRENT_YEAR. Tests go in /usr/Tests