### PR TITLE
Kernel: Add basic KASAN implementation

### DIFF
--- a/Kernel/AddressSanitizer.cpp
+++ b/Kernel/AddressSanitizer.cpp
@@ -1,56 +1,114 @@
 /*
  * Copyright (c) 2021, Brian Gianforcaro <bgianf@serenityos.org>
+ * Copyright (c) 2022, Keegan Saunders <keegan@undefinedbehaviour.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#if defined(__SANITIZE_ADDRESS__)
-
-#    include <Kernel/AddressSanitizer.h>
-
-void Kernel::AddressSanitizer::shadow_va_check_load(unsigned long address, size_t size, void* return_address)
-{
-    (void)address;
-    (void)size;
-    (void)return_address;
-}
-
-void Kernel::AddressSanitizer::shadow_va_check_store(unsigned long address, size_t size, void* return_address)
-{
-    (void)address;
-    (void)size;
-    (void)return_address;
-}
+#include <AK/Format.h>
+#include <AK/Platform.h>
+#include <Kernel/AddressSanitizer.h>
+#include <Kernel/Arch/Processor.h>
+#include <Kernel/BootInfo.h>
+#include <Kernel/KSyms.h>
 
 using namespace Kernel;
 using namespace Kernel::AddressSanitizer;
+
+constexpr uintptr_t KASAN_SHADOW_OFFSET = 0x6fc0000000;
+constexpr u32 KASAN_SCALE = 3;
+constexpr uintptr_t KASAN_GRANULE = 1UL << KASAN_SCALE;
+
+Atomic<bool> Kernel::AddressSanitizer::g_kasan_is_deadly { true };
+
+enum class Access {
+    Load,
+    Store,
+    __Count
+};
+
+static constexpr StringView AccessNames[] {
+    "load"sv,
+    "store"sv
+};
+
+static_assert(array_size(AccessNames) == to_underlying(Access::__Count));
+
+static inline u8* kasan_shadow_address(unsigned long address)
+{
+    return reinterpret_cast<u8*>((address >> KASAN_SCALE) + KASAN_SHADOW_OFFSET);
+}
+
+NO_SANITIZE_ADDRESS void Kernel::AddressSanitizer::poison(unsigned long address, size_t size, Poison value)
+{
+    (void)address;
+    (void)size;
+    (void)value;
+#ifdef ENABLE_KERNEL_ADDRESS_SANITIZER
+    // TODO: If the process page tables have a mapping for `address` and `size` that is
+    // the `kasan_zero` page: unmap those specific pages and allocate new physical
+    // pages which are writable into the location, then apply the poison.
+    // Otherwise, apply the poison to the existing region.
+#endif
+}
+
+NO_SANITIZE_ADDRESS static inline void shadow_va_check(unsigned long address, size_t size, Access access, void* return_address)
+{
+    (void)address;
+    (void)size;
+    (void)access;
+    (void)return_address;
+#ifdef ENABLE_KERNEL_ADDRESS_SANITIZER
+    address = align_down_to(address, KASAN_GRANULE);
+    auto shadow_size = align_up_to(size, KASAN_GRANULE) >> KASAN_SCALE;
+
+    auto shadow_address = kasan_shadow_address(address);
+
+    bool poisoned = false;
+    for (size_t i = 0; i < shadow_size; i++) {
+        if (shadow_address[i] != to_underlying(Poison::None)) {
+            poisoned = true;
+            break;
+        }
+    }
+
+    if (poisoned) {
+        critical_dmesgln("KASAN: invalid {} of size {} on address {:p}", AccessNames[to_underlying(access)], size, address);
+        dump_backtrace(g_kasan_is_deadly ? PrintToScreen::Yes : PrintToScreen::No);
+        if (g_kasan_is_deadly) {
+            critical_dmesgln("KASAN is configured to be deadly, halting the system.");
+            Processor::halt();
+        }
+    }
+#endif
+}
 
 extern "C" {
 
 // Define a macro to easily declare the KASAN load and store callbacks for
 // the various sizes of data type.
 //
-#    define ADDRESS_SANITIZER_LOAD_STORE(size)                                 \
-        void __asan_load##size(unsigned long);                                 \
-        void __asan_load##size(unsigned long address)                          \
-        {                                                                      \
-            shadow_va_check_load(address, size, __builtin_return_address(0));  \
-        }                                                                      \
-        void __asan_load##size##_noabort(unsigned long);                       \
-        void __asan_load##size##_noabort(unsigned long address)                \
-        {                                                                      \
-            shadow_va_check_load(address, size, __builtin_return_address(0));  \
-        }                                                                      \
-        void __asan_store##size(unsigned long);                                \
-        void __asan_store##size(unsigned long address)                         \
-        {                                                                      \
-            shadow_va_check_store(address, size, __builtin_return_address(0)); \
-        }                                                                      \
-        void __asan_store##size##_noabort(unsigned long);                      \
-        void __asan_store##size##_noabort(unsigned long address)               \
-        {                                                                      \
-            shadow_va_check_store(address, size, __builtin_return_address(0)); \
-        }
+#define ADDRESS_SANITIZER_LOAD_STORE(size)                                          \
+    void __asan_load##size(unsigned long);                                          \
+    void __asan_load##size(unsigned long address)                                   \
+    {                                                                               \
+        shadow_va_check(address, size, Access::Load, __builtin_return_address(0));  \
+    }                                                                               \
+    void __asan_load##size##_noabort(unsigned long);                                \
+    void __asan_load##size##_noabort(unsigned long address)                         \
+    {                                                                               \
+        shadow_va_check(address, size, Access::Load, __builtin_return_address(0));  \
+    }                                                                               \
+    void __asan_store##size(unsigned long);                                         \
+    void __asan_store##size(unsigned long address)                                  \
+    {                                                                               \
+        shadow_va_check(address, size, Access::Store, __builtin_return_address(0)); \
+    }                                                                               \
+    void __asan_store##size##_noabort(unsigned long);                               \
+    void __asan_store##size##_noabort(unsigned long address)                        \
+    {                                                                               \
+        shadow_va_check(address, size, Access::Store, __builtin_return_address(0)); \
+    }
 
 ADDRESS_SANITIZER_LOAD_STORE(1);
 ADDRESS_SANITIZER_LOAD_STORE(2);
@@ -58,30 +116,30 @@ ADDRESS_SANITIZER_LOAD_STORE(4);
 ADDRESS_SANITIZER_LOAD_STORE(8);
 ADDRESS_SANITIZER_LOAD_STORE(16);
 
-#    undef ADDRESS_SANITIZER_LOAD_STORE
+#undef ADDRESS_SANITIZER_LOAD_STORE
 
 void __asan_loadN(unsigned long, size_t);
 void __asan_loadN(unsigned long address, size_t size)
 {
-    shadow_va_check_load(address, size, __builtin_return_address(0));
+    shadow_va_check(address, size, Access::Load, __builtin_return_address(0));
 }
 
 void __asan_loadN_noabort(unsigned long, size_t);
 void __asan_loadN_noabort(unsigned long address, size_t size)
 {
-    shadow_va_check_load(address, size, __builtin_return_address(0));
+    shadow_va_check(address, size, Access::Load, __builtin_return_address(0));
 }
 
 void __asan_storeN(unsigned long, size_t);
 void __asan_storeN(unsigned long address, size_t size)
 {
-    shadow_va_check_store(address, size, __builtin_return_address(0));
+    shadow_va_check(address, size, Access::Store, __builtin_return_address(0));
 }
 
 void __asan_storeN_noabort(unsigned long, size_t);
 void __asan_storeN_noabort(unsigned long address, size_t size)
 {
-    shadow_va_check_store(address, size, __builtin_return_address(0));
+    shadow_va_check(address, size, Access::Store, __builtin_return_address(0));
 }
 
 // Performs shadow memory cleanup of the current thread's stack before a
@@ -102,5 +160,3 @@ void __asan_after_dynamic_init()
 {
 }
 }
-
-#endif

--- a/Kernel/AddressSanitizer.h
+++ b/Kernel/AddressSanitizer.h
@@ -1,17 +1,29 @@
 /*
  * Copyright (c) 2021, Brian Gianforcaro <bgianf@serenityos.org>
+ * Copyright (c) 2022, Keegan Saunders <keegan@undefinedbehavior.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/Atomic.h>
 #include <AK/Types.h>
 
 namespace Kernel::AddressSanitizer {
 
-void shadow_va_check_load(unsigned long address, size_t size, void* return_addr);
+extern Atomic<bool> g_kasan_is_deadly;
 
-void shadow_va_check_store(unsigned long address, size_t size, void* return_addr);
+enum class Poison : u8 {
+    None = 0,
+    Freed = 0xff
+};
 
+void poison(unsigned long address, size_t size, Poison value);
+
+void unpoison(unsigned long address, size_t size);
+inline void unpoison(unsigned long address, size_t size)
+{
+    poison(address, size, Poison::None);
+}
 }

--- a/Kernel/Arch/x86/init.cpp
+++ b/Kernel/Arch/x86/init.cpp
@@ -129,6 +129,10 @@ READONLY_AFTER_INIT PhysicalAddress boot_pdpt;
 READONLY_AFTER_INIT PhysicalAddress boot_pd0;
 READONLY_AFTER_INIT PhysicalAddress boot_pd_kernel;
 READONLY_AFTER_INIT PageTableEntry* boot_pd_kernel_pt1023;
+#ifdef ENABLE_KERNEL_ADDRESS_SANITIZER
+READONLY_AFTER_INIT PhysicalAddress boot_pd_kasan;
+READONLY_AFTER_INIT PhysicalAddress kasan_zero;
+#endif
 READONLY_AFTER_INIT char const* kernel_cmdline;
 READONLY_AFTER_INIT u32 multiboot_flags;
 READONLY_AFTER_INIT multiboot_memory_map_t* multiboot_memory_map;
@@ -163,6 +167,10 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
     boot_pd0 = PhysicalAddress { boot_info.boot_pd0 };
     boot_pd_kernel = PhysicalAddress { boot_info.boot_pd_kernel };
     boot_pd_kernel_pt1023 = (PageTableEntry*)boot_info.boot_pd_kernel_pt1023;
+#ifdef ENABLE_KERNEL_ADDRESS_SANITIZER
+    boot_pd_kasan = PhysicalAddress { boot_info.boot_pd_kasan };
+    kasan_zero = PhysicalAddress { boot_info.kasan_zero };
+#endif
     kernel_cmdline = (char const*)boot_info.kernel_cmdline;
     multiboot_flags = boot_info.multiboot_flags;
     multiboot_memory_map = (multiboot_memory_map_t*)boot_info.multiboot_memory_map;

--- a/Kernel/BootInfo.h
+++ b/Kernel/BootInfo.h
@@ -28,6 +28,10 @@ extern "C" PhysicalAddress boot_pdpt;
 extern "C" PhysicalAddress boot_pd0;
 extern "C" PhysicalAddress boot_pd_kernel;
 extern "C" Kernel::PageTableEntry* boot_pd_kernel_pt1023;
+#ifdef ENABLE_KERNEL_ADDRESS_SANITIZER
+extern "C" PhysicalAddress boot_pd_kasan;
+extern "C" PhysicalAddress kasan_zero;
+#endif
 extern "C" char const* kernel_cmdline;
 extern "C" u32 multiboot_flags;
 extern "C" multiboot_memory_map_t* multiboot_memory_map;

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -199,6 +199,7 @@ set(KERNEL_SOURCES
     FileSystem/SysFS/Subsystems/Kernel/Variables/CoredumpDirectory.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/DumpKmallocStack.cpp
+    FileSystem/SysFS/Subsystems/Kernel/Variables/KASANDeadly.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/StringVariable.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/UBSANDeadly.cpp
     FileSystem/TmpFS/FileSystem.cpp
@@ -661,10 +662,8 @@ if (ENABLE_KERNEL_UNDEFINED_SANITIZER)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
 endif()
 
-# Kernel Address Sanitize (KASAN) implementation is still a work in progress, this option
-# is not currently meant to be used, besides when developing Kernel ASAN support.
-#
 if (ENABLE_KERNEL_ADDRESS_SANITIZER)
+    add_definitions(-DENABLE_KERNEL_ADDRESS_SANITIZER)
     add_compile_options(-fsanitize=kernel-address)
     add_link_options(-fsanitize=kernel-address)
 endif()

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.cpp
@@ -11,6 +11,7 @@
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/CoredumpDirectory.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/DumpKmallocStack.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/KASANDeadly.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/UBSANDeadly.h>
 
 namespace Kernel {
@@ -21,6 +22,7 @@ UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSGlobalKernelVariablesDirectory> SysFSGlo
     MUST(global_variables_directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(SysFSCapsLockRemap::must_create(*global_variables_directory));
         list.append(SysFSDumpKmallocStacks::must_create(*global_variables_directory));
+        list.append(SysFSKASANDeadly::must_create(*global_variables_directory));
         list.append(SysFSUBSANDeadly::must_create(*global_variables_directory));
         list.append(SysFSCoredumpDirectory::must_create(*global_variables_directory));
         return {};

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/KASANDeadly.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/KASANDeadly.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2022, Keegan Saunders <keegan@undefinedbehaviour.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/AddressSanitizer.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/KASANDeadly.h>
+#include <Kernel/Sections.h>
+
+namespace Kernel {
+
+UNMAP_AFTER_INIT SysFSKASANDeadly::SysFSKASANDeadly(SysFSDirectory const& parent_directory)
+    : SysFSSystemBooleanVariable(parent_directory)
+{
+}
+
+UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSKASANDeadly> SysFSKASANDeadly::must_create(SysFSDirectory const& parent_directory)
+{
+    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSKASANDeadly(parent_directory)).release_nonnull();
+}
+
+bool SysFSKASANDeadly::value() const
+{
+    return Kernel::AddressSanitizer::g_kasan_is_deadly;
+}
+void SysFSKASANDeadly::set_value(bool new_value)
+{
+    Kernel::AddressSanitizer::g_kasan_is_deadly = new_value;
+}
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/KASANDeadly.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/KASANDeadly.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2022, Keegan Saunders <keegan@undefinedbehaviour.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/BooleanVariable.h>
+#include <Kernel/Library/LockRefPtr.h>
+#include <Kernel/UserOrKernelBuffer.h>
+
+namespace Kernel {
+
+class SysFSKASANDeadly final : public SysFSSystemBooleanVariable {
+public:
+    virtual StringView name() const override { return "kasan_is_deadly"sv; }
+    static NonnullLockRefPtr<SysFSKASANDeadly> must_create(SysFSDirectory const&);
+
+private:
+    virtual bool value() const override;
+    virtual void set_value(bool new_value) override;
+
+    explicit SysFSKASANDeadly(SysFSDirectory const&);
+};
+
+}

--- a/Kernel/Prekernel/Prekernel.h
+++ b/Kernel/Prekernel/Prekernel.h
@@ -33,6 +33,10 @@ struct [[gnu::packed]] BootInfo {
     u32 boot_pd0;
     u32 boot_pd_kernel;
     u64 boot_pd_kernel_pt1023;
+#ifdef ENABLE_KERNEL_ADDRESS_SANITIZER
+    u32 boot_pd_kasan;
+    u32 kasan_zero;
+#endif
     u64 kernel_cmdline;
     u32 multiboot_flags;
     u64 multiboot_memory_map;

--- a/Kernel/Prekernel/boot.S
+++ b/Kernel/Prekernel/boot.S
@@ -40,6 +40,17 @@ boot_pd_kernel_image_pts:
 .global boot_pd_kernel_pt1023
 boot_pd_kernel_pt1023:
 .skip 4096
+#ifdef ENABLE_KERNEL_ADDRESS_SANITIZER
+.global boot_pd_kasan
+boot_pd_kasan:
+.skip 4096
+.global boot_pde_kasan
+boot_pde_kasan:
+.skip 4096
+.global kasan_zero
+kasan_zero:
+.skip 4096
+#endif
 
 .section .text
 


### PR DESCRIPTION
Add a basic implementation of KASAN based off of the Fuschia explanation: https://cs.opensource.google/fuchsia/fuchsia/+/main:zircon/kernel/lib/instrumentation/asan/README.md

The idea is that Serenity can address up to 512GB of memory, so the Prekernel reserves 1/8th of that (64GB) and maps each page to a read-only zero page called `kasan_zero` at boot. This way, the system starts with all memory unpoisoned (a value of 0 in the shadow map).

Remaining work:

- [ ] Finish poison implementation (see TODO)
- [ ] Remove the 8-byte alignment and 8-byte size limitation

In future pull requests the following will be addressed as well:

* Heap redzones (adding special shadow bytes surrounding allocations)
* Global initialization (checking for global value overflows with ASan)