### PR TITLE
LibWeb: Check HTML parser position is equal to or after insertion point

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -132,7 +132,7 @@ public:
     bool is_insertion_point_defined() const { return m_insertion_point.defined; }
     bool is_insertion_point_reached()
     {
-        return m_insertion_point.defined && m_insertion_point.position >= m_utf8_view.iterator_offset(m_utf8_iterator);
+        return m_insertion_point.defined && m_utf8_view.iterator_offset(m_utf8_iterator) >= m_insertion_point.position;
     }
     void undefine_insertion_point() { m_insertion_point.defined = false; }
     void store_insertion_point() { m_old_insertion_point = m_insertion_point; }


### PR DESCRIPTION
This used to be the other way around. If we just inserted input with document.write, this would always be true and not allow document.write to immediately parse its input (given that there's no pending parsing blocking script)