### PR TITLE
LibWeb: Check if block creates BFC even if all it's children are inline

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -487,8 +487,10 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontal
 
     if ((!m_left_floats.current_boxes.is_empty() || !m_right_floats.current_boxes.is_empty())
         && creates_block_formatting_context(child_box)) {
-        available_width_within_containing_block -= m_left_floats.current_width + m_right_floats.current_width;
-        x += m_left_floats.current_width;
+        auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(child_box, root(), m_state);
+        auto space = space_used_by_floats(box_in_root_rect.y());
+        available_width_within_containing_block -= space.left + space.right;
+        x += space.left;
     }
 
     if (child_box.containing_block()->computed_values().text_align() == CSS::TextAlign::LibwebCenter) {

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -377,12 +377,11 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     OwnPtr<FormattingContext> independent_formatting_context;
     if (!box.is_replaced_box() && box.has_children()) {
-        if (box.children_are_inline()) {
-            layout_inline_children(verify_cast<BlockContainer>(box), layout_mode, box_state.available_inner_space_or_constraints_from(available_space));
+        if (auto independent_formatting_context = create_independent_formatting_context_if_needed(m_state, box)) {
+            independent_formatting_context->run(box, layout_mode, box_state.available_inner_space_or_constraints_from(available_space));
         } else {
-            independent_formatting_context = create_independent_formatting_context_if_needed(m_state, box);
-            if (independent_formatting_context)
-                independent_formatting_context->run(box, layout_mode, box_state.available_inner_space_or_constraints_from(available_space));
+            if (box.children_are_inline())
+                layout_inline_children(verify_cast<BlockContainer>(box), layout_mode, box_state.available_inner_space_or_constraints_from(available_space));
             else
                 layout_block_level_children(verify_cast<BlockContainer>(box), layout_mode, box_state.available_inner_space_or_constraints_from(available_space));
         }

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -155,7 +155,8 @@ OwnPtr<FormattingContext> FormattingContext::create_independent_formatting_conte
     }
 
     VERIFY(is_block_formatting_context());
-    VERIFY(!child_box.children_are_inline());
+    if (child_box.children_are_inline())
+        return {};
 
     // The child box is a block container that doesn't create its own BFC.
     // It will be formatted by this BFC.


### PR DESCRIPTION
1. Even if block has all children inline there need to be a check if it creates BFC because otherwise IFC will be looking in wrong parent BFC to calculate space used by floats.

2. y of box should be taken in account while calculating space used by floats.

html to reproduce problems I want to address:
```html
<!DOCTYPE html>
<html>
  <head>
    <style>
      .box1 {
        float: left;
        background-color: slateblue;
        width: 50px;
        height: 50px;
      }

      .box2 {
        width: 100px;
        height: 100px;
        background-color: salmon;
        overflow: hidden;
      }

      .box3 {
        width: 100px;
        height: 100px;
        background-color: olivedrab;
        overflow: hidden;
      }
    </style>
  </head>
  <body>
    <div class="box1"></div>
    <div class="box2">hm</div>
    <div class="box3">hmm</div>
  </body>
</html>
```