### PR TITLE
BindingsGenerator+CMake: Keep track of IDL dependencies

### DIFF
--- a/Meta/CMake/common_options.cmake
+++ b/Meta/CMake/common_options.cmake
@@ -2,6 +2,11 @@
 # Options common for the Serenity (target) and Lagom (host) builds
 #
 
+# Make relative paths in depfiles be relative to CMAKE_CURRENT_BINARY_DIR rather than to CMAKE_BINARY_DIR
+if (POLICY CMP0116)
+    cmake_policy(SET CMP0116 NEW)
+endif()
+
 serenity_option(ENABLE_COMPILETIME_FORMAT_CHECK ON CACHE BOOL "Enable compiletime format string checks")
 serenity_option(ENABLE_UNDEFINED_SANITIZER OFF CACHE BOOL "Enable undefined behavior sanitizer testing in gcc/clang")
 

--- a/Meta/CMake/libweb_generators.cmake
+++ b/Meta/CMake/libweb_generators.cmake
@@ -113,7 +113,7 @@ function (generate_js_bindings target)
             list(TRANSFORM include_paths PREPEND -i)
             add_custom_command(
                 OUTPUT "${bindings_src}"
-                COMMAND "$<TARGET_FILE:Lagom::BindingsGenerator>" "--${bindings_type}" ${include_paths} "${LIBWEB_INPUT_FOLDER}/${class}.idl" "${LIBWEB_INPUT_FOLDER}" > "${bindings_src}.tmp"
+                COMMAND "$<TARGET_FILE:Lagom::BindingsGenerator>" "--${bindings_type}" -o "${bindings_src}.tmp" ${include_paths} "${LIBWEB_INPUT_FOLDER}/${class}.idl" "${LIBWEB_INPUT_FOLDER}"
                 COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${bindings_src}.tmp" "${bindings_src}"
                 COMMAND "${CMAKE_COMMAND}" -E remove "${bindings_src}.tmp"
                 VERBATIM

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/CMakeLists.txt
@@ -3,5 +3,5 @@ set(SOURCES
     main.cpp
 )
 
-lagom_tool(BindingsGenerator LIBS LibIDL)
+lagom_tool(BindingsGenerator LIBS LibIDL LibMain)
 target_compile_options(BindingsGenerator PUBLIC -g)

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1980,9 +1980,8 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@function.name:snakecase@)
 )~~~");
 }
 
-void generate_constructor_header(IDL::Interface const& interface)
+void generate_constructor_header(IDL::Interface const& interface, StringBuilder& builder)
 {
-    StringBuilder builder;
     SourceGenerator generator { builder };
 
     generator.set("name", interface.name);
@@ -2032,13 +2031,10 @@ private:
 
 } // namespace Web::Bindings
 )~~~");
-
-    outln("{}", generator.as_string_view());
 }
 
-void generate_constructor_implementation(IDL::Interface const& interface)
+void generate_constructor_implementation(IDL::Interface const& interface, StringBuilder& builder)
 {
-    StringBuilder builder;
     SourceGenerator generator { builder };
 
     generator.set("name", interface.name);
@@ -2236,13 +2232,10 @@ void @constructor_class@::initialize(JS::Realm& realm)
     generator.append(R"~~~(
 } // namespace Web::Bindings
 )~~~");
-
-    outln("{}", generator.as_string_view());
 }
 
-void generate_prototype_header(IDL::Interface const& interface)
+void generate_prototype_header(IDL::Interface const& interface, StringBuilder& builder)
 {
-    StringBuilder builder;
     SourceGenerator generator { builder };
 
     generator.set("name", interface.name);
@@ -2356,13 +2349,10 @@ inline DeprecatedString idl_enum_to_deprecated_string(@enum.type.name@ value) {
     generator.append(R"~~~(
 } // namespace Web::Bindings
     )~~~");
-
-    outln("{}", generator.as_string_view());
 }
 
-void generate_prototype_implementation(IDL::Interface const& interface)
+void generate_prototype_implementation(IDL::Interface const& interface, StringBuilder& builder)
 {
-    StringBuilder builder;
     SourceGenerator generator { builder };
 
     generator.set("name", interface.name);
@@ -2801,14 +2791,11 @@ JS_DEFINE_NATIVE_FUNCTION(@prototype_class@::values)
     generator.append(R"~~~(
 } // namespace Web::Bindings
 )~~~");
-
-    outln("{}", generator.as_string_view());
 }
 
-void generate_iterator_prototype_header(IDL::Interface const& interface)
+void generate_iterator_prototype_header(IDL::Interface const& interface, StringBuilder& builder)
 {
     VERIFY(interface.pair_iterator_types.has_value());
-    StringBuilder builder;
     SourceGenerator generator { builder };
 
     generator.set("prototype_class", DeprecatedString::formatted("{}IteratorPrototype", interface.name));
@@ -2833,14 +2820,11 @@ private:
 
 } // namespace Web::Bindings
     )~~~");
-
-    outln("{}", generator.as_string_view());
 }
 
-void generate_iterator_prototype_implementation(IDL::Interface const& interface)
+void generate_iterator_prototype_implementation(IDL::Interface const& interface, StringBuilder& builder)
 {
     VERIFY(interface.pair_iterator_types.has_value());
-    StringBuilder builder;
     SourceGenerator generator { builder };
 
     generator.set("name", DeprecatedString::formatted("{}Iterator", interface.name));
@@ -2922,7 +2906,5 @@ JS_DEFINE_NATIVE_FUNCTION(@prototype_class@::next)
 
 } // namespace Web::Bindings
 )~~~");
-
-    outln("{}", generator.as_string_view());
 }
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
@@ -33,6 +33,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView path;
     StringView import_base_path;
     StringView output_path = "-"sv;
+    StringView depfile_path;
+    StringView depfile_target;
     bool constructor_header_mode = false;
     bool constructor_implementation_mode = false;
     bool prototype_header_mode = false;
@@ -57,6 +59,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         },
     });
     args_parser.add_option(output_path, "Path to output generated file into", "output-path", 'o', "output-path");
+    args_parser.add_option(depfile_path, "Path to write dependency file to", "depfile", 'd', "depfile-path");
+    args_parser.add_option(depfile_target, "Name of target in the depfile (default: output path)", "depfile-target", 't', "target");
     args_parser.add_positional_argument(path, "IDL file", "idl-file");
     args_parser.add_positional_argument(import_base_path, "Import base path", "import-base-path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
@@ -66,7 +70,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     LexicalPath lexical_path(path);
     auto& namespace_ = lexical_path.parts_view().at(lexical_path.parts_view().size() - 2);
 
-    auto data = TRY(file->read_all());
+    auto data = TRY(file->read_until_eof());
 
     if (import_base_path.is_null())
         import_base_path = lexical_path.dirname();
@@ -146,5 +150,19 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         IDL::generate_iterator_prototype_implementation(interface, output_builder);
 
     TRY(output_file->write(output_builder.string_view().bytes()));
+
+    if (!depfile_path.is_null()) {
+        auto depfile = TRY(Core::Stream::File::open_file_or_standard_stream(depfile_path, Core::Stream::OpenMode::Write));
+
+        StringBuilder depfile_builder;
+        depfile_builder.append(depfile_target.is_null() ? output_path : depfile_target);
+        depfile_builder.append(':');
+        for (auto const& path : parser.imported_files()) {
+            depfile_builder.append(" \\\n "sv);
+            depfile_builder.append(path);
+        }
+        depfile_builder.append('\n');
+        TRY(depfile->write(depfile_builder.string_view().bytes()));
+    }
     return 0;
 }

--- a/Userland/Libraries/LibIDL/IDLParser.cpp
+++ b/Userland/Libraries/LibIDL/IDLParser.cpp
@@ -1068,4 +1068,8 @@ HashTable<NonnullOwnPtr<Interface>>& Parser::top_level_interfaces()
     return top_level_parser()->interfaces;
 }
 
+Vector<DeprecatedString> Parser::imported_files() const
+{
+    return const_cast<Parser*>(this)->top_level_resolved_imports().keys();
+}
 }

--- a/Userland/Libraries/LibIDL/IDLParser.h
+++ b/Userland/Libraries/LibIDL/IDLParser.h
@@ -20,6 +20,8 @@ public:
     Parser(DeprecatedString filename, StringView contents, DeprecatedString import_base_path);
     Interface& parse();
 
+    Vector<DeprecatedString> imported_files() const;
+
 private:
     // https://webidl.spec.whatwg.org/#dfn-special-operation
     // A special operation is a getter, setter or deleter.


### PR DESCRIPTION
This is attempt number 2 at getting this merged.

This commit teaches BindingsGenerator to generate depfiles, which can be
used by CMake to ensure that bindings are properly regenerated when
imported IDL files change.

Two new options, --depfile and --depfile-target are added.

    --depfile sets the path for the dependency file.
    --depfile-target lets us set a target name different than the output
    file in the depfile. This option is needed because generated files are
    first written to a temporary file, but depfiles have to refer to the
    final location.
    These are analogous to GCC's -MF and -MT options respectively. The
    depfile's syntax matches the ones generated by GCC.

Note: This changes the minimal required CMake version to 3.20 if the
Make generator is used, and to 3.21 for the Xcode generator. Ninja is
not affected.
