### PR TITLE
LibCore: Fix up HTTP requests through a SOCKS5 proxy

### DIFF
--- a/Userland/Libraries/LibCore/SOCKSProxyClient.h
+++ b/Userland/Libraries/LibCore/SOCKSProxyClient.h
@@ -37,7 +37,9 @@ public:
     virtual ~SOCKSProxyClient() override;
 
     // ^Stream::Stream
+    virtual bool is_readable() const override { return m_socket.is_readable(); }
     virtual ErrorOr<Bytes> read(Bytes bytes) override { return m_socket.read(bytes); }
+    virtual bool is_writable() const override { return m_socket.is_writable(); }
     virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override { return m_socket.write(bytes); }
     virtual bool is_eof() const override { return m_socket.is_eof(); }
     virtual bool is_open() const override { return m_socket.is_open(); }

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -249,6 +249,9 @@ void Job::on_socket_connected()
             }
 
             if (!can_read_line.value()) {
+                // FIXME: Figure out what to do here if we can't read a full line (or just haven't buffered it yet).
+                //        For a properly implemented stream, can_read_line does try to fill the read buffer,
+                //        but in case this ever fails we shouldn't just be dropping the first 64 bytes of the request.
                 dbgln_if(JOB_DEBUG, "Job {} cannot read line", m_request.url());
                 auto maybe_buf = receive(64);
                 if (maybe_buf.is_error()) {


### PR DESCRIPTION
Previously, we were mysteriously missing the first 64 bytes of an HTTP response, which caused HTTP parsing to fail. This ended up being caused by the fact that our socket implementation for SOCKS5 didn't pass through readability and writability properly, causing `can_read_line` to not attempt to fill in the buffer, while `read` still did. Pass through those attributes from the underlying socket to mitigate those issues.

However, since our approach of "if we can't read a line, read 64 bytes of the request and drop them to the ground" isn't really great either (regardless of the stream implementation issue), add a `FIXME` for good measure so that we don't forget to look into this.