### PR TITLE
LibCore: Start replacing `DuplexMemoryStream` with a new, automatically allocating `Core::Stream::MemoryStream`

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto bufstream_result = Core::Stream::MemoryStream::construct({ data, size });
+    auto bufstream_result = Core::Stream::FixedMemoryStream::construct({ data, size });
     if (bufstream_result.is_error()) {
         dbgln("MemoryStream::construct() failed.");
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzTar.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTar.cpp
@@ -12,7 +12,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto input_stream_or_error = Core::Stream::MemoryStream::construct({ data, size });
+    auto input_stream_or_error = Core::Stream::FixedMemoryStream::construct({ data, size });
 
     if (input_stream_or_error.is_error())
         return 0;

--- a/Tests/LibCompress/TestDeflate.cpp
+++ b/Tests/LibCompress/TestDeflate.cpp
@@ -29,7 +29,7 @@ TEST_CASE(canonical_code_simple)
     };
 
     auto const huffman = Compress::CanonicalCode::from_bytes(code).value();
-    auto memory_stream = MUST(Core::Stream::MemoryStream::construct(input));
+    auto memory_stream = MUST(Core::Stream::FixedMemoryStream::construct(input));
     auto bit_stream = MUST(Core::Stream::LittleEndianInputBitStream::construct(move(memory_stream)));
 
     for (size_t idx = 0; idx < 9; ++idx)
@@ -49,7 +49,7 @@ TEST_CASE(canonical_code_complex)
     };
 
     auto const huffman = Compress::CanonicalCode::from_bytes(code).value();
-    auto memory_stream = MUST(Core::Stream::MemoryStream::construct(input));
+    auto memory_stream = MUST(Core::Stream::FixedMemoryStream::construct(input));
     auto bit_stream = MUST(Core::Stream::LittleEndianInputBitStream::construct(move(memory_stream)));
 
     for (size_t idx = 0; idx < 12; ++idx)

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -42,7 +42,7 @@ Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> FlacLoaderPlugin::try_creat
 
 Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> FlacLoaderPlugin::try_create(Bytes buffer)
 {
-    auto stream = LOADER_TRY(Core::Stream::MemoryStream::construct(buffer));
+    auto stream = LOADER_TRY(Core::Stream::FixedMemoryStream::construct(buffer));
     auto loader = make<FlacLoaderPlugin>(move(stream));
 
     LOADER_TRY(loader->initialize());
@@ -78,7 +78,7 @@ MaybeLoaderError FlacLoaderPlugin::parse_header()
     // Receive the streaminfo block
     auto streaminfo = TRY(next_meta_block(*bit_input));
     FLAC_VERIFY(streaminfo.type == FlacMetadataBlockType::STREAMINFO, LoaderError::Category::Format, "First block must be STREAMINFO");
-    auto streaminfo_data_memory = LOADER_TRY(Core::Stream::MemoryStream::construct(streaminfo.data.bytes()));
+    auto streaminfo_data_memory = LOADER_TRY(Core::Stream::FixedMemoryStream::construct(streaminfo.data.bytes()));
     auto streaminfo_data = LOADER_TRY(BigEndianInputBitStream::construct(Core::Stream::Handle<Core::Stream::Stream>(*streaminfo_data_memory)));
 
     // 11.10 METADATA_BLOCK_STREAMINFO
@@ -149,7 +149,7 @@ MaybeLoaderError FlacLoaderPlugin::parse_header()
 // 11.19. METADATA_BLOCK_PICTURE
 MaybeLoaderError FlacLoaderPlugin::load_picture(FlacRawMetadataBlock& block)
 {
-    auto memory_stream = LOADER_TRY(Core::Stream::MemoryStream::construct(block.data.bytes()));
+    auto memory_stream = LOADER_TRY(Core::Stream::FixedMemoryStream::construct(block.data.bytes()));
     auto picture_block_bytes = LOADER_TRY(BigEndianInputBitStream::construct(Core::Stream::Handle<Core::Stream::Stream>(*memory_stream)));
 
     PictureData picture {};
@@ -186,7 +186,7 @@ MaybeLoaderError FlacLoaderPlugin::load_picture(FlacRawMetadataBlock& block)
 // 11.13. METADATA_BLOCK_SEEKTABLE
 MaybeLoaderError FlacLoaderPlugin::load_seektable(FlacRawMetadataBlock& block)
 {
-    auto memory_stream = LOADER_TRY(Core::Stream::MemoryStream::construct(block.data.bytes()));
+    auto memory_stream = LOADER_TRY(Core::Stream::FixedMemoryStream::construct(block.data.bytes()));
     auto seektable_bytes = LOADER_TRY(BigEndianInputBitStream::construct(Core::Stream::Handle<Core::Stream::Stream>(*memory_stream)));
     for (size_t i = 0; i < block.length / 18; ++i) {
         // 11.14. SEEKPOINT

--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -31,7 +31,7 @@ Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> MP3LoaderPlugin::try_create(
 
 Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> MP3LoaderPlugin::try_create(Bytes buffer)
 {
-    auto stream = LOADER_TRY(Core::Stream::MemoryStream::construct(buffer));
+    auto stream = LOADER_TRY(Core::Stream::FixedMemoryStream::construct(buffer));
     auto loader = make<MP3LoaderPlugin>(move(stream));
 
     LOADER_TRY(loader->initialize());

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -35,7 +35,7 @@ Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> WavLoaderPlugin::try_create(
 
 Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> WavLoaderPlugin::try_create(Bytes buffer)
 {
-    auto stream = LOADER_TRY(Core::Stream::MemoryStream::construct(buffer));
+    auto stream = LOADER_TRY(Core::Stream::FixedMemoryStream::construct(buffer));
     auto loader = make<WavLoaderPlugin>(move(stream));
 
     LOADER_TRY(loader->initialize());
@@ -115,7 +115,7 @@ static ErrorOr<double> read_sample(Core::Stream::Stream& stream)
 LoaderSamples WavLoaderPlugin::samples_from_pcm_data(Bytes const& data, size_t samples_to_read) const
 {
     FixedArray<Sample> samples = LOADER_TRY(FixedArray<Sample>::try_create(samples_to_read));
-    auto stream = LOADER_TRY(Core::Stream::MemoryStream::construct(move(data)));
+    auto stream = LOADER_TRY(Core::Stream::FixedMemoryStream::construct(move(data)));
 
     switch (m_sample_format) {
     case PcmSampleFormat::Uint8:

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -309,7 +309,7 @@ void DeflateDecompressor::close()
 
 ErrorOr<ByteBuffer> DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
 {
-    auto memory_stream = TRY(Core::Stream::MemoryStream::construct(bytes));
+    auto memory_stream = TRY(Core::Stream::FixedMemoryStream::construct(bytes));
     DeflateDecompressor deflate_stream { move(memory_stream) };
     DuplexMemoryStream output_stream;
 

--- a/Userland/Libraries/LibCompress/Gzip.cpp
+++ b/Userland/Libraries/LibCompress/Gzip.cpp
@@ -153,7 +153,7 @@ Optional<DeprecatedString> GzipDecompressor::describe_header(ReadonlyBytes bytes
 
 ErrorOr<ByteBuffer> GzipDecompressor::decompress_all(ReadonlyBytes bytes)
 {
-    auto memory_stream = TRY(Core::Stream::MemoryStream::construct(bytes));
+    auto memory_stream = TRY(Core::Stream::FixedMemoryStream::construct(bytes));
     auto gzip_stream = make<GzipDecompressor>(move(memory_stream));
     DuplexMemoryStream output_stream;
 

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     IODevice.cpp
     LockFile.cpp
     MappedFile.cpp
+    MemoryStream.cpp
     MimeData.cpp
     NetworkJob.cpp
     Notifier.cpp

--- a/Userland/Libraries/LibCore/MemoryStream.cpp
+++ b/Userland/Libraries/LibCore/MemoryStream.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <filmroellchen@serenityos.org>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/MemoryStream.h>
+
+namespace Core::Stream {
+
+FixedMemoryStream::FixedMemoryStream(Bytes bytes)
+    : m_bytes(bytes)
+{
+}
+
+FixedMemoryStream::FixedMemoryStream(ReadonlyBytes bytes)
+    : m_bytes({ const_cast<u8*>(bytes.data()), bytes.size() })
+    , m_writing_enabled(false)
+{
+}
+
+ErrorOr<NonnullOwnPtr<FixedMemoryStream>> FixedMemoryStream::construct(Bytes bytes)
+{
+    return adopt_nonnull_own_or_enomem<FixedMemoryStream>(new (nothrow) FixedMemoryStream(bytes));
+}
+
+ErrorOr<NonnullOwnPtr<FixedMemoryStream>> FixedMemoryStream::construct(ReadonlyBytes bytes)
+{
+    return adopt_nonnull_own_or_enomem<FixedMemoryStream>(new (nothrow) FixedMemoryStream(bytes));
+}
+
+bool FixedMemoryStream::is_eof() const
+{
+    return m_offset >= m_bytes.size();
+}
+
+bool FixedMemoryStream::is_open() const
+{
+    return true;
+}
+
+void FixedMemoryStream::close()
+{
+    // FIXME: It doesn't make sense to close a memory stream. Therefore, we don't do anything here. Is that fine?
+}
+
+ErrorOr<void> FixedMemoryStream::truncate(off_t)
+{
+    return Error::from_errno(ENOTSUP);
+}
+
+ErrorOr<Bytes> FixedMemoryStream::read(Bytes bytes)
+{
+    auto to_read = min(remaining(), bytes.size());
+    if (to_read == 0)
+        return Bytes {};
+
+    m_bytes.slice(m_offset, to_read).copy_to(bytes);
+    m_offset += to_read;
+    return bytes.trim(to_read);
+}
+
+ErrorOr<off_t> FixedMemoryStream::seek(i64 offset, SeekMode seek_mode)
+{
+    switch (seek_mode) {
+    case SeekMode::SetPosition:
+        if (offset > static_cast<i64>(m_bytes.size()))
+            return Error::from_string_literal("Offset past the end of the stream memory");
+
+        m_offset = offset;
+        break;
+    case SeekMode::FromCurrentPosition:
+        if (offset + static_cast<i64>(m_offset) > static_cast<i64>(m_bytes.size()))
+            return Error::from_string_literal("Offset past the end of the stream memory");
+
+        m_offset += offset;
+        break;
+    case SeekMode::FromEndPosition:
+        if (offset > static_cast<i64>(m_bytes.size()))
+            return Error::from_string_literal("Offset past the start of the stream memory");
+
+        m_offset = m_bytes.size() - offset;
+        break;
+    }
+    return static_cast<off_t>(m_offset);
+}
+
+ErrorOr<size_t> FixedMemoryStream::write(ReadonlyBytes bytes)
+{
+    VERIFY(m_writing_enabled);
+
+    // FIXME: Can this not error?
+    auto const nwritten = bytes.copy_trimmed_to(m_bytes.slice(m_offset));
+    m_offset += nwritten;
+    return nwritten;
+}
+
+ErrorOr<void> FixedMemoryStream::write_entire_buffer(ReadonlyBytes bytes)
+{
+    if (remaining() < bytes.size())
+        return Error::from_string_literal("Write of entire buffer ends past the memory area");
+
+    TRY(write(bytes));
+    return {};
+}
+
+Bytes FixedMemoryStream::bytes()
+{
+    VERIFY(m_writing_enabled);
+    return m_bytes;
+}
+ReadonlyBytes FixedMemoryStream::bytes() const
+{
+    return m_bytes;
+}
+
+size_t FixedMemoryStream::offset() const
+{
+    return m_offset;
+}
+
+size_t FixedMemoryStream::remaining() const
+{
+    return m_bytes.size() - m_offset;
+}
+
+}

--- a/Userland/Libraries/LibCore/MemoryStream.h
+++ b/Userland/Libraries/LibCore/MemoryStream.h
@@ -15,16 +15,18 @@
 
 namespace Core::Stream {
 
-class MemoryStream final : public SeekableStream {
+/// A stream class that allows for reading/writing on a preallocated memory area
+/// using a single read/write head.
+class FixedMemoryStream final : public SeekableStream {
 public:
-    static ErrorOr<NonnullOwnPtr<MemoryStream>> construct(Bytes bytes)
+    static ErrorOr<NonnullOwnPtr<FixedMemoryStream>> construct(Bytes bytes)
     {
-        return adopt_nonnull_own_or_enomem<MemoryStream>(new (nothrow) MemoryStream(bytes));
+        return adopt_nonnull_own_or_enomem<FixedMemoryStream>(new (nothrow) FixedMemoryStream(bytes));
     }
 
-    static ErrorOr<NonnullOwnPtr<MemoryStream>> construct(ReadonlyBytes bytes)
+    static ErrorOr<NonnullOwnPtr<FixedMemoryStream>> construct(ReadonlyBytes bytes)
     {
-        return adopt_nonnull_own_or_enomem<MemoryStream>(new (nothrow) MemoryStream(bytes));
+        return adopt_nonnull_own_or_enomem<FixedMemoryStream>(new (nothrow) FixedMemoryStream(bytes));
     }
 
     virtual bool is_eof() const override { return m_offset >= m_bytes.size(); }
@@ -98,12 +100,12 @@ public:
     size_t remaining() const { return m_bytes.size() - m_offset; }
 
 protected:
-    explicit MemoryStream(Bytes bytes)
+    explicit FixedMemoryStream(Bytes bytes)
         : m_bytes(bytes)
     {
     }
 
-    explicit MemoryStream(ReadonlyBytes bytes)
+    explicit FixedMemoryStream(ReadonlyBytes bytes)
         : m_bytes({ const_cast<u8*>(bytes.data()), bytes.size() })
         , m_writing_enabled(false)
     {

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -80,7 +80,7 @@ static Optional<ByteBuffer> handle_content_encoding(ByteBuffer const& buf, Depre
     } else if (content_encoding == "br") {
         dbgln_if(JOB_DEBUG, "Job::handle_content_encoding: buf is brotli compressed!");
 
-        auto bufstream_result = Core::Stream::MemoryStream::construct({ buf.data(), buf.size() });
+        auto bufstream_result = Core::Stream::FixedMemoryStream::construct({ buf.data(), buf.size() });
         if (bufstream_result.is_error()) {
             dbgln("Job::handle_content_encoding: MemoryStream::construct() failed.");
             return {};

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -355,7 +355,7 @@ public:
     private:
         HTTPHeadlessRequest(HTTP::HttpRequest&& request, NonnullOwnPtr<Core::Stream::BufferedSocketBase> socket, ByteBuffer&& stream_backing_buffer)
             : m_stream_backing_buffer(move(stream_backing_buffer))
-            , m_output_stream(Core::Stream::MemoryStream::construct(m_stream_backing_buffer.bytes()).release_value_but_fixme_should_propagate_errors())
+            , m_output_stream(Core::Stream::FixedMemoryStream::construct(m_stream_backing_buffer.bytes()).release_value_but_fixme_should_propagate_errors())
             , m_socket(move(socket))
             , m_job(HTTP::Job::construct(move(request), *m_output_stream))
         {
@@ -381,7 +381,7 @@ public:
 
         Optional<u32> m_response_code;
         ByteBuffer m_stream_backing_buffer;
-        NonnullOwnPtr<Core::Stream::MemoryStream> m_output_stream;
+        NonnullOwnPtr<Core::Stream::FixedMemoryStream> m_output_stream;
         NonnullOwnPtr<Core::Stream::BufferedSocketBase> m_socket;
         NonnullRefPtr<HTTP::Job> m_job;
         HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> m_response_headers;
@@ -434,7 +434,7 @@ public:
     private:
         HTTPSHeadlessRequest(HTTP::HttpRequest&& request, NonnullOwnPtr<Core::Stream::BufferedSocketBase> socket, ByteBuffer&& stream_backing_buffer)
             : m_stream_backing_buffer(move(stream_backing_buffer))
-            , m_output_stream(Core::Stream::MemoryStream::construct(m_stream_backing_buffer.bytes()).release_value_but_fixme_should_propagate_errors())
+            , m_output_stream(Core::Stream::FixedMemoryStream::construct(m_stream_backing_buffer.bytes()).release_value_but_fixme_should_propagate_errors())
             , m_socket(move(socket))
             , m_job(HTTP::HttpsJob::construct(move(request), *m_output_stream))
         {
@@ -460,7 +460,7 @@ public:
 
         Optional<u32> m_response_code;
         ByteBuffer m_stream_backing_buffer;
-        NonnullOwnPtr<Core::Stream::MemoryStream> m_output_stream;
+        NonnullOwnPtr<Core::Stream::FixedMemoryStream> m_output_stream;
         NonnullOwnPtr<Core::Stream::BufferedSocketBase> m_socket;
         NonnullRefPtr<HTTP::HttpsJob> m_job;
         HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> m_response_headers;
@@ -503,7 +503,7 @@ public:
     private:
         GeminiHeadlessRequest(Gemini::GeminiRequest&& request, NonnullOwnPtr<Core::Stream::BufferedSocketBase> socket, ByteBuffer&& stream_backing_buffer)
             : m_stream_backing_buffer(move(stream_backing_buffer))
-            , m_output_stream(Core::Stream::MemoryStream::construct(m_stream_backing_buffer.bytes()).release_value_but_fixme_should_propagate_errors())
+            , m_output_stream(Core::Stream::FixedMemoryStream::construct(m_stream_backing_buffer.bytes()).release_value_but_fixme_should_propagate_errors())
             , m_socket(move(socket))
             , m_job(Gemini::Job::construct(move(request), *m_output_stream))
         {
@@ -529,7 +529,7 @@ public:
 
         Optional<u32> m_response_code;
         ByteBuffer m_stream_backing_buffer;
-        NonnullOwnPtr<Core::Stream::MemoryStream> m_output_stream;
+        NonnullOwnPtr<Core::Stream::FixedMemoryStream> m_output_stream;
         NonnullOwnPtr<Core::Stream::BufferedSocketBase> m_socket;
         NonnullRefPtr<Gemini::Job> m_job;
         HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> m_response_headers;


### PR DESCRIPTION
Today's target: SOCKSProxyClient.