### PR TITLE
LibJS: Keep GeneratorObject's stored execution context's internals alive 

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -81,6 +81,7 @@ set(SOURCES
     Runtime/ErrorConstructor.cpp
     Runtime/ErrorPrototype.cpp
     Runtime/ErrorTypes.cpp
+    Runtime/ExecutionContext.cpp
     Runtime/FinalizationRegistry.cpp
     Runtime/FinalizationRegistryConstructor.cpp
     Runtime/FinalizationRegistryPrototype.cpp

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/ExecutionContext.h>
+
+namespace JS {
+
+ExecutionContext::ExecutionContext(Heap& heap)
+    : arguments(heap)
+{
+}
+
+ExecutionContext::ExecutionContext(MarkedVector<Value> existing_arguments)
+    : arguments(move(existing_arguments))
+{
+}
+
+ExecutionContext ExecutionContext::copy() const
+{
+    ExecutionContext copy { arguments };
+
+    copy.function = function;
+    copy.realm = realm;
+    copy.script_or_module = script_or_module;
+    copy.lexical_environment = lexical_environment;
+    copy.variable_environment = variable_environment;
+    copy.private_environment = private_environment;
+    copy.current_node = current_node;
+    copy.function_name = function_name;
+    copy.this_value = this_value;
+    copy.is_strict_mode = is_strict_mode;
+
+    return copy;
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <LibJS/Runtime/ExecutionContext.h>
+#include <LibJS/Runtime/FunctionObject.h>
 
 namespace JS {
 
@@ -36,6 +37,22 @@ ExecutionContext ExecutionContext::copy() const
     copy.is_strict_mode = is_strict_mode;
 
     return copy;
+}
+
+void ExecutionContext::visit_edges(Cell::Visitor& visitor)
+{
+    visitor.visit(function);
+    visitor.visit(realm);
+    visitor.visit(variable_environment);
+    visitor.visit(lexical_environment);
+    visitor.visit(private_environment);
+    visitor.visit(context_owner);
+    visitor.visit(this_value);
+    script_or_module.visit(
+        [](Empty) {},
+        [&](auto& script_or_module) {
+            visitor.visit(script_or_module);
+        });
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -21,34 +22,12 @@ using ScriptOrModule = Variant<Empty, NonnullGCPtr<Script>, NonnullGCPtr<Module>
 
 // 9.4 Execution Contexts, https://tc39.es/ecma262/#sec-execution-contexts
 struct ExecutionContext {
-    explicit ExecutionContext(Heap& heap)
-        : arguments(heap)
-    {
-    }
+    explicit ExecutionContext(Heap& heap);
 
-    [[nodiscard]] ExecutionContext copy() const
-    {
-        ExecutionContext copy { arguments };
-
-        copy.function = function;
-        copy.realm = realm;
-        copy.script_or_module = script_or_module;
-        copy.lexical_environment = lexical_environment;
-        copy.variable_environment = variable_environment;
-        copy.private_environment = private_environment;
-        copy.current_node = current_node;
-        copy.function_name = function_name;
-        copy.this_value = this_value;
-        copy.is_strict_mode = is_strict_mode;
-
-        return copy;
-    }
+    [[nodiscard]] ExecutionContext copy() const;
 
 private:
-    explicit ExecutionContext(MarkedVector<Value> existing_arguments)
-        : arguments(move(existing_arguments))
-    {
-    }
+    explicit ExecutionContext(MarkedVector<Value> existing_arguments);
 
 public:
     FunctionObject* function { nullptr };                // [[Function]]

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -26,6 +26,8 @@ struct ExecutionContext {
 
     [[nodiscard]] ExecutionContext copy() const;
 
+    void visit_edges(Cell::Visitor&);
+
 private:
     explicit ExecutionContext(MarkedVector<Value> existing_arguments);
 

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -50,6 +50,7 @@ void GeneratorObject::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_generating_function);
     visitor.visit(m_previous_value);
+    m_execution_context.visit_edges(visitor);
 }
 
 // 27.5.3.2 GeneratorValidate ( generator, generatorBrand ), https://tc39.es/ecma262/#sec-generatorvalidate


### PR DESCRIPTION
This would previously crash with a heap UAF when storing the result of
`yield 1` into `e` on the second `next` call:
```js
function* a() { const e = yield 1; }
b = a();
b.next();
gc();
b.next();
```