### PR TITLE
Browser: A Barebones Implemntation of the Accessibility Tree

### DIFF
--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -1093,3 +1093,8 @@ void WebContentView::notify_server_did_finish_handling_input_event(bool event_wa
     //        we don't need to do anything here. But we'll need to once we start asking web content first.
     (void)event_was_accepted;
 }
+
+void WebContentView::notify_server_did_get_accessibility_tree(DeprecatedString const&)
+{
+    dbgln("TODO: support accessibility tree in Ladybird");
+}

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -144,6 +144,7 @@ public:
     virtual void notify_server_did_get_source(const AK::URL& url, DeprecatedString const& source) override;
     virtual void notify_server_did_get_dom_tree(DeprecatedString const& dom_tree) override;
     virtual void notify_server_did_get_dom_node_properties(i32 node_id, DeprecatedString const& specified_style, DeprecatedString const& computed_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing) override;
+    virtual void notify_server_did_get_accessibility_tree(DeprecatedString const& accessibility_tree) override;
     virtual void notify_server_did_output_js_console_message(i32 message_index) override;
     virtual void notify_server_did_get_js_console_messages(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages) override;
     virtual void notify_server_did_change_favicon(Gfx::Bitmap const& favicon) override;

--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -15,6 +15,7 @@
 #include <LibGUI/TreeView.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
+#include <LibWebView/AccessibilityTreeModel.h>
 #include <LibWebView/DOMTreeModel.h>
 #include <LibWebView/OutOfProcessWebView.h>
 #include <LibWebView/StylePropertiesModel.h>
@@ -90,6 +91,11 @@ InspectorWidget::InspectorWidget()
         const auto& index = m_dom_tree_view->selection().first();
         set_selection(index);
     };
+
+    auto& accessibility_tree_container = top_tab_widget.add_tab<GUI::Widget>("Accessibility");
+    accessibility_tree_container.set_layout<GUI::VerticalBoxLayout>();
+    accessibility_tree_container.layout()->set_margins({ 4, 4, 4, 4 });
+    m_accessibility_tree_view = accessibility_tree_container.add<GUI::TreeView>();
 
     auto& bottom_tab_widget = splitter.add<GUI::TabWidget>();
 
@@ -210,6 +216,13 @@ void InspectorWidget::clear_style_json()
     m_element_size_view->set_box_model({});
     m_element_size_view->set_node_content_width(0);
     m_element_size_view->set_node_content_height(0);
+}
+
+void InspectorWidget::set_accessibility_json(StringView json)
+{
+    m_accessibility_tree_view->set_model(WebView::AccessibilityTreeModel::create(json, *m_accessibility_tree_view));
+
+    // TODO: Support selections from accessibility tab
 }
 
 }

--- a/Userland/Applications/Browser/InspectorWidget.h
+++ b/Userland/Applications/Browser/InspectorWidget.h
@@ -43,6 +43,7 @@ public:
     void set_dom_json(StringView);
     void clear_dom_json();
     void set_dom_node_properties_json(Selection, StringView computed_values_json, StringView resolved_values_json, StringView custom_properties_json, StringView node_box_sizing_json);
+    void set_accessibility_json(StringView);
 
     void set_selection(Selection);
     void select_default_node();
@@ -59,6 +60,7 @@ private:
     RefPtr<WebView::OutOfProcessWebView> m_web_view;
 
     RefPtr<GUI::TreeView> m_dom_tree_view;
+    RefPtr<GUI::TreeView> m_accessibility_tree_view;
     RefPtr<GUI::TableView> m_computed_style_table_view;
     RefPtr<GUI::TableView> m_resolved_style_table_view;
     RefPtr<GUI::TableView> m_custom_properties_table_view;

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -244,8 +244,10 @@ Tab::Tab(BrowserWindow& window)
 
         update_status();
 
-        if (m_dom_inspector_widget)
+        if (m_dom_inspector_widget) {
             m_web_content_view->inspect_dom_tree();
+            m_web_content_view->inspect_accessibility_tree();
+        }
     };
 
     view().on_navigate_back = [this]() {
@@ -419,6 +421,11 @@ Tab::Tab(BrowserWindow& window)
 
     view().on_get_dom_node_properties = [this](auto node_id, auto& specified, auto& computed, auto& custom_properties, auto& node_box_sizing) {
         m_dom_inspector_widget->set_dom_node_properties_json({ node_id }, specified, computed, custom_properties, node_box_sizing);
+    };
+
+    view().on_get_accessibility_tree = [this](auto& accessibility_tree) {
+        if (m_dom_inspector_widget)
+            m_dom_inspector_widget->set_accessibility_json(accessibility_tree);
     };
 
     view().on_js_console_new_message = [this](auto message_index) {
@@ -666,6 +673,7 @@ void Tab::show_inspector_window(Browser::Tab::InspectorTarget inspector_target)
         m_dom_inspector_widget = window->set_main_widget<InspectorWidget>();
         m_dom_inspector_widget->set_web_view(*m_web_content_view);
         m_web_content_view->inspect_dom_tree();
+        m_web_content_view->inspect_accessibility_tree();
     }
 
     if (inspector_target == InspectorTarget::HoveredElement) {

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -74,6 +74,9 @@ set(SOURCES
     DOM/AbstractRange.cpp
     DOM/Attr.cpp
     DOM/Attr.idl
+    DOM/ARIAMixin.cpp
+    DOM/ARIAMixin.idl
+    DOM/ARIARoleNames.cpp
     DOM/CDATASection.cpp
     DOM/CharacterData.cpp
     DOM/CharacterData.idl

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SOURCES
     DOM/AbortController.cpp
     DOM/AbortSignal.cpp
     DOM/AbstractRange.cpp
+    DOM/AccessibilityTreeNode.cpp
     DOM/Attr.cpp
     DOM/Attr.idl
     DOM/ARIAMixin.cpp

--- a/Userland/Libraries/LibWeb/DOM/ARIAMixin.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ARIAMixin.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/ARIAMixin.h>
+#include <LibWeb/DOM/ARIARoleNames.h>
+#include <LibWeb/Infra/CharacterTypes.h>
+
+namespace Web::DOM {
+
+// https://www.w3.org/TR/wai-aria-1.2/#introroles
+FlyString ARIAMixin::role_or_default() const
+{
+    // 1. Use the rules of the host language to detect that an element has a role attribute and to identify the attribute value string for it.
+    auto role_string = role();
+
+    // 2. Separate the attribute value string for that attribute into a sequence of whitespace-free substrings by separating on whitespace.
+    auto role_list = role_string.split_view(Infra::is_ascii_whitespace);
+
+    // 3. Compare the substrings to all the names of the non-abstract WAI-ARIA roles. Case-sensitivity of the comparison inherits from the case-sensitivity of the host language.
+    for (auto const& role : role_list) {
+        // 4. Use the first such substring in textual order that matches the name of a non-abstract WAI-ARIA role.
+        if (ARIARoleNames::is_non_abstract_aria_role(role))
+            return role;
+    }
+
+    // https://www.w3.org/TR/wai-aria-1.2/#document-handling_author-errors_roles
+    // If the role attribute contains no tokens matching the name of a non-abstract WAI-ARIA role, the user agent MUST treat the element as if no role had been provided.
+    // https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics
+    return default_role();
+}
+
+}

--- a/Userland/Libraries/LibWeb/DOM/ARIAMixin.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ARIAMixin.cpp
@@ -32,4 +32,30 @@ FlyString ARIAMixin::role_or_default() const
     return default_role();
 }
 
+// https://www.w3.org/TR/wai-aria-1.2/#global_states
+bool ARIAMixin::has_global_aria_attribute() const
+{
+    return !aria_atomic().is_null()
+        || !aria_busy().is_null()
+        || !aria_controls().is_null()
+        || !aria_current().is_null()
+        || !aria_described_by().is_null()
+        || !aria_details().is_null()
+        || !aria_disabled().is_null()
+        || !aria_drop_effect().is_null()
+        || !aria_error_message().is_null()
+        || !aria_flow_to().is_null()
+        || !aria_grabbed().is_null()
+        || !aria_has_popup().is_null()
+        || !aria_hidden().is_null()
+        || !aria_invalid().is_null()
+        || !aria_key_shortcuts().is_null()
+        || !aria_label().is_null()
+        || !aria_labelled_by().is_null()
+        || !aria_live().is_null()
+        || !aria_owns().is_null()
+        || !aria_relevant().is_null()
+        || !aria_role_description().is_null();
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/ARIAMixin.h
+++ b/Userland/Libraries/LibWeb/DOM/ARIAMixin.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2022, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
+
+namespace Web::DOM {
+
+class ARIAMixin {
+
+public:
+    virtual ~ARIAMixin() = default;
+
+    virtual DeprecatedString role() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_role(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_active_descendant() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_active_descendant(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_atomic() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_atomic(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_auto_complete() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_auto_complete(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_busy() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_busy(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_checked() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_checked(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_col_count() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_col_count(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_col_index() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_col_index(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_col_span() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_col_span(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_controls() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_controls(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_current() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_current(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_described_by() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_described_by(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_details() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_details(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_drop_effect() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_drop_effect(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_error_message() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_error_message(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_disabled() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_disabled(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_expanded() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_expanded(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_flow_to() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_flow_to(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_grabbed() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_grabbed(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_has_popup() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_has_popup(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_hidden() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_hidden(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_invalid() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_invalid(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_key_shortcuts() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_key_shortcuts(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_label() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_label(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_labelled_by() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_labelled_by(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_level() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_level(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_live() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_live(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_modal() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_modal(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_multi_line() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_multi_line(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_multi_selectable() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_multi_selectable(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_orientation() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_orientation(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_owns() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_owns(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_placeholder() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_placeholder(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_pos_in_set() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_pos_in_set(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_pressed() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_pressed(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_read_only() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_read_only(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_relevant() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_relevant(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_required() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_required(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_role_description() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_role_description(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_row_count() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_row_count(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_row_index() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_row_index(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_row_span() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_row_span(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_selected() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_selected(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_set_size() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_set_size(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_sort() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_sort(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_value_max() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_value_max(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_value_min() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_value_min(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_value_now() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_value_now(DeprecatedString const&) = 0;
+    virtual DeprecatedString aria_value_text() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_value_text(DeprecatedString const&) = 0;
+
+    // https://www.w3.org/TR/html-aria/#docconformance
+    virtual FlyString default_role() const { return {}; };
+
+    FlyString role_or_default() const;
+
+protected:
+    ARIAMixin() = default;
+};
+
+}

--- a/Userland/Libraries/LibWeb/DOM/ARIAMixin.h
+++ b/Userland/Libraries/LibWeb/DOM/ARIAMixin.h
@@ -136,6 +136,8 @@ public:
 
     FlyString role_or_default() const;
 
+    bool has_global_aria_attribute() const;
+
 protected:
     ARIAMixin() = default;
 };

--- a/Userland/Libraries/LibWeb/DOM/ARIAMixin.h
+++ b/Userland/Libraries/LibWeb/DOM/ARIAMixin.h
@@ -136,6 +136,12 @@ public:
 
     FlyString role_or_default() const;
 
+    // https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion
+    virtual bool exclude_from_accessibility_tree() const = 0;
+
+    // https://www.w3.org/TR/wai-aria-1.2/#tree_inclusion
+    virtual bool include_in_accessibility_tree() const = 0;
+
     bool has_global_aria_attribute() const;
 
 protected:

--- a/Userland/Libraries/LibWeb/DOM/ARIAMixin.idl
+++ b/Userland/Libraries/LibWeb/DOM/ARIAMixin.idl
@@ -1,0 +1,53 @@
+// https://www.w3.org/TR/wai-aria-1.2/#ARIAMixin
+interface mixin ARIAMixin {
+	attribute DOMString? role;
+
+	attribute DOMString? ariaAtomic;
+	attribute DOMString? ariaAutoComplete;
+	attribute DOMString? ariaBusy;
+	attribute DOMString? ariaChecked;
+	attribute DOMString? ariaColCount;
+	attribute DOMString? ariaColIndex;
+
+	attribute DOMString? ariaColSpan;
+
+	attribute DOMString? ariaCurrent;
+
+
+
+	attribute DOMString? ariaDisabled;
+
+	attribute DOMString? ariaExpanded;
+
+	attribute DOMString? ariaHasPopup;
+	attribute DOMString? ariaHidden;
+	attribute DOMString? ariaInvalid;
+	attribute DOMString? ariaKeyShortcuts;
+	attribute DOMString? ariaLabel;
+
+	attribute DOMString? ariaLevel;
+	attribute DOMString? ariaLive;
+	attribute DOMString? ariaModal;
+	attribute DOMString? ariaMultiLine;
+	attribute DOMString? ariaMultiSelectable;
+	attribute DOMString? ariaOrientation;
+
+	attribute DOMString? ariaPlaceholder;
+	attribute DOMString? ariaPosInSet;
+	attribute DOMString? ariaPressed;
+	attribute DOMString? ariaReadOnly;
+
+	attribute DOMString? ariaRequired;
+	attribute DOMString? ariaRoleDescription;
+	attribute DOMString? ariaRowCount;
+	attribute DOMString? ariaRowIndex;
+
+	attribute DOMString? ariaRowSpan;
+	attribute DOMString? ariaSelected;
+	attribute DOMString? ariaSetSize;
+	attribute DOMString? ariaSort;
+	attribute DOMString? ariaValueMax;
+	attribute DOMString? ariaValueMin;
+	attribute DOMString? ariaValueNow;
+	attribute DOMString? ariaValueText;
+};

--- a/Userland/Libraries/LibWeb/DOM/ARIARoleNames.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ARIARoleNames.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2022, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/ARIARoleNames.h>
+
+namespace Web::DOM::ARIARoleNames {
+
+#define __ENUMERATE_ARIA_ROLE(name) FlyString name;
+ENUMERATE_ARIA_ROLES
+#undef __ENUMERATE_ARIA_ROLE
+
+[[gnu::constructor]] static void initialize()
+{
+    static bool s_initialized = false;
+    if (s_initialized)
+        return;
+
+#define __ENUMERATE_ARIA_ROLE(name) name = #name;
+    ENUMERATE_ARIA_ROLES
+#undef __ENUMERATE_ARIA_ROLE
+
+    // Special case for C++ keyword
+    switch_ = "switch";
+    s_initialized = true;
+}
+
+// https://www.w3.org/TR/wai-aria-1.2/#abstract_roles
+bool is_abstract_aria_role(FlyString const& role)
+{
+    return role.is_one_of(
+        ARIARoleNames::command,
+        ARIARoleNames::composite,
+        ARIARoleNames::input,
+        ARIARoleNames::landmark,
+        ARIARoleNames::range,
+        ARIARoleNames::roletype,
+        ARIARoleNames::section,
+        ARIARoleNames::sectionhead,
+        ARIARoleNames::select,
+        ARIARoleNames::structure,
+        ARIARoleNames::widget,
+        ARIARoleNames::window);
+}
+
+// https://www.w3.org/TR/wai-aria-1.2/#widget_roles
+bool is_widget_aria_role(FlyString const& role)
+{
+    return role.to_lowercase().is_one_of(
+        ARIARoleNames::button,
+        ARIARoleNames::checkbox,
+        ARIARoleNames::gridcell,
+        ARIARoleNames::link,
+        ARIARoleNames::menuitem,
+        ARIARoleNames::menuitemcheckbox,
+        ARIARoleNames::option,
+        ARIARoleNames::progressbar,
+        ARIARoleNames::radio,
+        ARIARoleNames::scrollbar,
+        ARIARoleNames::searchbox,
+        ARIARoleNames::separator, // TODO: Only when focusable
+        ARIARoleNames::slider,
+        ARIARoleNames::spinbutton,
+        ARIARoleNames::switch_,
+        ARIARoleNames::tab,
+        ARIARoleNames::tabpanel,
+        ARIARoleNames::textbox,
+        ARIARoleNames::treeitem,
+        ARIARoleNames::combobox,
+        ARIARoleNames::grid,
+        ARIARoleNames::listbox,
+        ARIARoleNames::menu,
+        ARIARoleNames::menubar,
+        ARIARoleNames::radiogroup,
+        ARIARoleNames::tablist,
+        ARIARoleNames::tree,
+        ARIARoleNames::treegrid);
+}
+
+// https://www.w3.org/TR/wai-aria-1.2/#document_structure_roles
+bool is_document_structure_aria_role(FlyString const& role)
+{
+    return role.to_lowercase().is_one_of(
+        ARIARoleNames::application,
+        ARIARoleNames::article,
+        ARIARoleNames::blockquote,
+        ARIARoleNames::caption,
+        ARIARoleNames::cell,
+        ARIARoleNames::columnheader,
+        ARIARoleNames::definition,
+        ARIARoleNames::deletion,
+        ARIARoleNames::directory,
+        ARIARoleNames::document,
+        ARIARoleNames::emphasis,
+        ARIARoleNames::feed,
+        ARIARoleNames::figure,
+        ARIARoleNames::generic,
+        ARIARoleNames::group,
+        ARIARoleNames::heading,
+        ARIARoleNames::img,
+        ARIARoleNames::insertion,
+        ARIARoleNames::list,
+        ARIARoleNames::listitem,
+        ARIARoleNames::math,
+        ARIARoleNames::meter,
+        ARIARoleNames::none,
+        ARIARoleNames::note,
+        ARIARoleNames::paragraph,
+        ARIARoleNames::presentation,
+        ARIARoleNames::row,
+        ARIARoleNames::rowgroup,
+        ARIARoleNames::rowheader,
+        ARIARoleNames::separator, // TODO: Only when not focusable
+        ARIARoleNames::strong,
+        ARIARoleNames::subscript,
+        ARIARoleNames::table,
+        ARIARoleNames::term,
+        ARIARoleNames::time,
+        ARIARoleNames::toolbar,
+        ARIARoleNames::tooltip);
+}
+
+// https://www.w3.org/TR/wai-aria-1.2/#landmark_roles
+bool is_landmark_aria_role(FlyString const& role)
+{
+    return role.to_lowercase().is_one_of(
+        ARIARoleNames::banner,
+        ARIARoleNames::complementary,
+        ARIARoleNames::contentinfo,
+        ARIARoleNames::form,
+        ARIARoleNames::main,
+        ARIARoleNames::navigation,
+        ARIARoleNames::region,
+        ARIARoleNames::search);
+}
+
+// https://www.w3.org/TR/wai-aria-1.2/#live_region_roles
+bool is_live_region_aria_role(FlyString const& role)
+{
+    return role.to_lowercase().is_one_of(
+        ARIARoleNames::alert,
+        ARIARoleNames::log,
+        ARIARoleNames::marquee,
+        ARIARoleNames::status,
+        ARIARoleNames::timer);
+}
+
+// https://www.w3.org/TR/wai-aria-1.2/#window_roles
+bool is_windows_aria_role(FlyString const& role)
+{
+    return role.to_lowercase().is_one_of(
+        ARIARoleNames::alertdialog,
+        ARIARoleNames::dialog);
+}
+
+bool is_non_abstract_aria_role(FlyString const& role)
+{
+    return is_widget_aria_role(role)
+        || is_document_structure_aria_role(role)
+        || is_landmark_aria_role(role)
+        || is_live_region_aria_role(role)
+        || is_windows_aria_role(role);
+}
+
+}

--- a/Userland/Libraries/LibWeb/DOM/ARIARoleNames.h
+++ b/Userland/Libraries/LibWeb/DOM/ARIARoleNames.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+
+namespace Web::DOM::ARIARoleNames {
+
+#define ENUMERATE_ARIA_ROLES                \
+    __ENUMERATE_ARIA_ROLE(alert)            \
+    __ENUMERATE_ARIA_ROLE(alertdialog)      \
+    __ENUMERATE_ARIA_ROLE(application)      \
+    __ENUMERATE_ARIA_ROLE(article)          \
+    __ENUMERATE_ARIA_ROLE(banner)           \
+    __ENUMERATE_ARIA_ROLE(blockquote)       \
+    __ENUMERATE_ARIA_ROLE(button)           \
+    __ENUMERATE_ARIA_ROLE(caption)          \
+    __ENUMERATE_ARIA_ROLE(cell)             \
+    __ENUMERATE_ARIA_ROLE(checkbox)         \
+    __ENUMERATE_ARIA_ROLE(code)             \
+    __ENUMERATE_ARIA_ROLE(columnheader)     \
+    __ENUMERATE_ARIA_ROLE(combobox)         \
+    __ENUMERATE_ARIA_ROLE(command)          \
+    __ENUMERATE_ARIA_ROLE(complementary)    \
+    __ENUMERATE_ARIA_ROLE(composite)        \
+    __ENUMERATE_ARIA_ROLE(contentinfo)      \
+    __ENUMERATE_ARIA_ROLE(definition)       \
+    __ENUMERATE_ARIA_ROLE(deletion)         \
+    __ENUMERATE_ARIA_ROLE(dialog)           \
+    __ENUMERATE_ARIA_ROLE(directory)        \
+    __ENUMERATE_ARIA_ROLE(document)         \
+    __ENUMERATE_ARIA_ROLE(emphasis)         \
+    __ENUMERATE_ARIA_ROLE(feed)             \
+    __ENUMERATE_ARIA_ROLE(figure)           \
+    __ENUMERATE_ARIA_ROLE(form)             \
+    __ENUMERATE_ARIA_ROLE(generic)          \
+    __ENUMERATE_ARIA_ROLE(grid)             \
+    __ENUMERATE_ARIA_ROLE(gridcell)         \
+    __ENUMERATE_ARIA_ROLE(group)            \
+    __ENUMERATE_ARIA_ROLE(heading)          \
+    __ENUMERATE_ARIA_ROLE(img)              \
+    __ENUMERATE_ARIA_ROLE(input)            \
+    __ENUMERATE_ARIA_ROLE(insertion)        \
+    __ENUMERATE_ARIA_ROLE(landmark)         \
+    __ENUMERATE_ARIA_ROLE(link)             \
+    __ENUMERATE_ARIA_ROLE(list)             \
+    __ENUMERATE_ARIA_ROLE(listbox)          \
+    __ENUMERATE_ARIA_ROLE(listitem)         \
+    __ENUMERATE_ARIA_ROLE(log)              \
+    __ENUMERATE_ARIA_ROLE(main)             \
+    __ENUMERATE_ARIA_ROLE(marquee)          \
+    __ENUMERATE_ARIA_ROLE(math)             \
+    __ENUMERATE_ARIA_ROLE(meter)            \
+    __ENUMERATE_ARIA_ROLE(menu)             \
+    __ENUMERATE_ARIA_ROLE(menubar)          \
+    __ENUMERATE_ARIA_ROLE(menuitem)         \
+    __ENUMERATE_ARIA_ROLE(menuitemcheckbox) \
+    __ENUMERATE_ARIA_ROLE(menuitemradio)    \
+    __ENUMERATE_ARIA_ROLE(navigation)       \
+    __ENUMERATE_ARIA_ROLE(none)             \
+    __ENUMERATE_ARIA_ROLE(note)             \
+    __ENUMERATE_ARIA_ROLE(option)           \
+    __ENUMERATE_ARIA_ROLE(paragraph)        \
+    __ENUMERATE_ARIA_ROLE(presentation)     \
+    __ENUMERATE_ARIA_ROLE(progressbar)      \
+    __ENUMERATE_ARIA_ROLE(radio)            \
+    __ENUMERATE_ARIA_ROLE(radiogroup)       \
+    __ENUMERATE_ARIA_ROLE(range)            \
+    __ENUMERATE_ARIA_ROLE(region)           \
+    __ENUMERATE_ARIA_ROLE(roletype)         \
+    __ENUMERATE_ARIA_ROLE(row)              \
+    __ENUMERATE_ARIA_ROLE(rowgroup)         \
+    __ENUMERATE_ARIA_ROLE(rowheader)        \
+    __ENUMERATE_ARIA_ROLE(scrollbar)        \
+    __ENUMERATE_ARIA_ROLE(search)           \
+    __ENUMERATE_ARIA_ROLE(searchbox)        \
+    __ENUMERATE_ARIA_ROLE(section)          \
+    __ENUMERATE_ARIA_ROLE(sectionhead)      \
+    __ENUMERATE_ARIA_ROLE(select)           \
+    __ENUMERATE_ARIA_ROLE(separator)        \
+    __ENUMERATE_ARIA_ROLE(slider)           \
+    __ENUMERATE_ARIA_ROLE(spinbutton)       \
+    __ENUMERATE_ARIA_ROLE(status)           \
+    __ENUMERATE_ARIA_ROLE(strong)           \
+    __ENUMERATE_ARIA_ROLE(structure)        \
+    __ENUMERATE_ARIA_ROLE(subscript)        \
+    __ENUMERATE_ARIA_ROLE(superscript)      \
+    __ENUMERATE_ARIA_ROLE(switch_)          \
+    __ENUMERATE_ARIA_ROLE(tab)              \
+    __ENUMERATE_ARIA_ROLE(table)            \
+    __ENUMERATE_ARIA_ROLE(tablist)          \
+    __ENUMERATE_ARIA_ROLE(tabpanel)         \
+    __ENUMERATE_ARIA_ROLE(term)             \
+    __ENUMERATE_ARIA_ROLE(textbox)          \
+    __ENUMERATE_ARIA_ROLE(time)             \
+    __ENUMERATE_ARIA_ROLE(timer)            \
+    __ENUMERATE_ARIA_ROLE(toolbar)          \
+    __ENUMERATE_ARIA_ROLE(tooltip)          \
+    __ENUMERATE_ARIA_ROLE(tree)             \
+    __ENUMERATE_ARIA_ROLE(treegrid)         \
+    __ENUMERATE_ARIA_ROLE(treeitem)         \
+    __ENUMERATE_ARIA_ROLE(widget)           \
+    __ENUMERATE_ARIA_ROLE(window)
+
+#define __ENUMERATE_ARIA_ROLE(name) extern FlyString name;
+ENUMERATE_ARIA_ROLES
+#undef __ENUMERATE_ARIA_ROLE
+
+bool is_abstract_aria_role(FlyString const&);
+bool is_widget_aria_role(FlyString const&);
+bool is_document_structure_aria_role(FlyString const&);
+bool is_landmark_aria_role(FlyString const&);
+bool is_live_region_aria_role(FlyString const&);
+bool is_windows_aria_role(FlyString const&);
+
+bool is_non_abstract_aria_role(FlyString const&);
+
+}

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Tuple.h>
+#include <LibWeb/DOM/AccessibilityTreeNode.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/DOM/Node.h>
+#include <LibWeb/DOM/Text.h>
+
+namespace Web::DOM {
+
+JS::NonnullGCPtr<AccessibilityTreeNode> AccessibilityTreeNode::create(Document* document, DOM::Node const* value)
+{
+    return *document->heap().allocate<AccessibilityTreeNode>(document->realm(), value);
+}
+
+AccessibilityTreeNode::AccessibilityTreeNode(JS::GCPtr<DOM::Node> value)
+    : m_value(value)
+{
+    m_children = {};
+}
+
+void AccessibilityTreeNode::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) const
+{
+    if (value()->is_document()) {
+        VERIFY_NOT_REACHED();
+    } else if (value()->is_element()) {
+        auto const* element = static_cast<DOM::Element*>(value().ptr());
+
+        if (element->include_in_accessibility_tree()) {
+            MUST(object.add("type"sv, "element"sv));
+
+            auto role = element->role_or_default();
+            bool has_role = !role.is_null() && !role.is_empty() && !ARIARoleNames::is_abstract_aria_role(role);
+
+            if (has_role)
+                MUST(object.add("role"sv, role.view()));
+            else
+                MUST(object.add("role"sv, ""sv));
+        } else {
+            VERIFY_NOT_REACHED();
+        }
+
+    } else if (value()->is_text()) {
+        MUST(object.add("type"sv, "text"sv));
+
+        auto const* text_node = static_cast<DOM::Text*>(value().ptr());
+        MUST(object.add("text"sv, text_node->data()));
+    }
+
+    if (value()->has_child_nodes()) {
+        auto node_children = MUST(object.add_array("children"sv));
+        for (auto child : children()) {
+            if (child->value()->is_uninteresting_whitespace_node())
+                continue;
+            JsonObjectSerializer<StringBuilder> child_object = MUST(node_children.add_object());
+            child->serialize_tree_as_json(child_object);
+            MUST(child_object.finish());
+        }
+        MUST(node_children.finish());
+    }
+}
+
+void AccessibilityTreeNode::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(*value());
+    for (auto child : children())
+        child->visit_edges(visitor);
+}
+
+}

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.h
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonObjectSerializer.h>
+#include <AK/Vector.h>
+#include <LibJS/Heap/Cell.h>
+#include <LibWeb/DOM/Node.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::DOM {
+
+class AccessibilityTreeNode final : public JS::Cell {
+    JS_CELL(AccessibilityTreeNode, JS::Cell)
+public:
+    static JS::NonnullGCPtr<AccessibilityTreeNode> create(Document*, DOM::Node const*);
+    virtual ~AccessibilityTreeNode() override = default;
+
+    JS::GCPtr<DOM::Node> value() const { return m_value; }
+    void set_value(JS::GCPtr<DOM::Node> value) { m_value = value; }
+    Vector<AccessibilityTreeNode*> children() const { return m_children; }
+    void append_child(AccessibilityTreeNode* child) { m_children.append(child); }
+
+    void serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) const;
+
+protected:
+    virtual void visit_edges(Visitor&) override;
+
+private:
+    explicit AccessibilityTreeNode(JS::GCPtr<DOM::Node>);
+
+    JS::GCPtr<DOM::Node> m_value;
+    Vector<AccessibilityTreeNode*> m_children;
+};
+
+}

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2338,4 +2338,23 @@ JS::NonnullGCPtr<DOM::Document> Document::appropriate_template_contents_owner_do
     return *this;
 }
 
+DeprecatedString Document::dump_accessibility_tree_as_json()
+{
+    StringBuilder builder;
+    auto accessibility_tree = AccessibilityTreeNode::create(this, nullptr);
+    build_accessibility_tree(*&accessibility_tree);
+    auto json = MUST(JsonObjectSerializer<>::try_create(builder));
+
+    // Empty document
+    if (!accessibility_tree->value()) {
+        MUST(json.add("type"sv, "element"sv));
+        MUST(json.add("role"sv, "document"sv));
+    } else {
+        accessibility_tree->serialize_tree_as_json(json);
+    }
+
+    MUST(json.finish());
+    return builder.to_deprecated_string();
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -447,6 +447,8 @@ public:
 
     bool query_command_supported(DeprecatedString const&) const;
 
+    DeprecatedString dump_accessibility_tree_as_json();
+
 protected:
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -11,6 +11,7 @@
 #include <LibWeb/Bindings/ElementPrototype.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
 #include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/DOM/ARIAMixin.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/NamedNodeMap.h>
@@ -40,7 +41,8 @@ struct ScrollIntoViewOptions : public ScrollOptions {
 class Element
     : public ParentNode
     , public ChildNode<Element>
-    , public NonDocumentTypeChildNode<Element> {
+    , public NonDocumentTypeChildNode<Element>
+    , public ARIAMixin {
     WEB_PLATFORM_OBJECT(Element, ParentNode);
 
 public:
@@ -176,6 +178,72 @@ public:
 
     // https://w3c.github.io/csswg-drafts/cssom-view-1/#dom-element-scrollintoview
     ErrorOr<void> scroll_into_view(Optional<Variant<bool, ScrollIntoViewOptions>> = {});
+
+    // https://www.w3.org/TR/wai-aria-1.2/#ARIAMixin
+#define ARIA_IMPL(name, attribute)                                               \
+    DeprecatedString name() const override                                       \
+    {                                                                            \
+        return get_attribute(attribute);                                         \
+    }                                                                            \
+                                                                                 \
+    WebIDL::ExceptionOr<void> set_##name(DeprecatedString const& value) override \
+    {                                                                            \
+        TRY(set_attribute(attribute, value));                                    \
+        return {};                                                               \
+    }
+
+    // https://www.w3.org/TR/wai-aria-1.2/#accessibilityroleandproperties-correspondence
+    ARIA_IMPL(role, "role");
+    ARIA_IMPL(aria_active_descendant, "aria-activedescendant");
+    ARIA_IMPL(aria_atomic, "aria-atomic");
+    ARIA_IMPL(aria_auto_complete, "aria-autocomplete");
+    ARIA_IMPL(aria_busy, "aria-busy");
+    ARIA_IMPL(aria_checked, "aria-checked");
+    ARIA_IMPL(aria_col_count, "aria-colcount");
+    ARIA_IMPL(aria_col_index, "aria-colindex");
+    ARIA_IMPL(aria_col_span, "aria-colspan");
+    ARIA_IMPL(aria_controls, "aria-controls");
+    ARIA_IMPL(aria_current, "aria-current");
+    ARIA_IMPL(aria_described_by, "aria-describedby");
+    ARIA_IMPL(aria_details, "aria-details");
+    ARIA_IMPL(aria_drop_effect, "aria-dropeffect");
+    ARIA_IMPL(aria_error_message, "aria-errormessage");
+    ARIA_IMPL(aria_disabled, "aria-disabled");
+    ARIA_IMPL(aria_expanded, "aria-expanded");
+    ARIA_IMPL(aria_flow_to, "aria-flowto");
+    ARIA_IMPL(aria_grabbed, "aria-grabbed");
+    ARIA_IMPL(aria_has_popup, "aria-haspopup");
+    ARIA_IMPL(aria_hidden, "aria-hidden");
+    ARIA_IMPL(aria_invalid, "aria-invalid");
+    ARIA_IMPL(aria_key_shortcuts, "aria-keyshortcuts");
+    ARIA_IMPL(aria_label, "aria-label");
+    ARIA_IMPL(aria_labelled_by, "aria-labelledby");
+    ARIA_IMPL(aria_level, "aria-level");
+    ARIA_IMPL(aria_live, "aria-live");
+    ARIA_IMPL(aria_modal, "aria-modal");
+    ARIA_IMPL(aria_multi_line, "aria-multiline");
+    ARIA_IMPL(aria_multi_selectable, "aria-multiselectable");
+    ARIA_IMPL(aria_orientation, "aria-orientation");
+    ARIA_IMPL(aria_owns, "aria-owns");
+    ARIA_IMPL(aria_placeholder, "aria-placeholder");
+    ARIA_IMPL(aria_pos_in_set, "aria-posinset");
+    ARIA_IMPL(aria_pressed, "aria-pressed");
+    ARIA_IMPL(aria_read_only, "aria-readonly");
+    ARIA_IMPL(aria_relevant, "aria-relevant");
+    ARIA_IMPL(aria_required, "aria-required");
+    ARIA_IMPL(aria_role_description, "aria-roledescription");
+    ARIA_IMPL(aria_row_count, "aria-rowcount");
+    ARIA_IMPL(aria_row_index, "aria-rowindex");
+    ARIA_IMPL(aria_row_span, "aria-rowspan");
+    ARIA_IMPL(aria_selected, "aria-selected");
+    ARIA_IMPL(aria_set_size, "aria-setsize");
+    ARIA_IMPL(aria_sort, "aria-sort");
+    ARIA_IMPL(aria_value_max, "aria-valuemax");
+    ARIA_IMPL(aria_value_min, "aria-valuemin");
+    ARIA_IMPL(aria_value_now, "aria-valuenow");
+    ARIA_IMPL(aria_value_text, "aria-valuetext");
+
+#undef ARIA_IMPL
 
 protected:
     Element(Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -245,6 +245,10 @@ public:
 
 #undef ARIA_IMPL
 
+    virtual bool exclude_from_accessibility_tree() const override;
+
+    virtual bool include_in_accessibility_tree() const override;
+
 protected:
     Element(Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -1,5 +1,6 @@
 #import <CSS/CSSStyleDeclaration.idl>
 #import <DOM/Attr.idl>
+#import <DOM/ARIAMixin.idl>
 #import <DOM/ChildNode.idl>
 #import <DOM/DOMTokenList.idl>
 #import <DOM/InnerHTML.idl>
@@ -83,3 +84,5 @@ interface Element : Node {
 Element includes ParentNode;
 Element includes ChildNode;
 Element includes InnerHTML;
+// https://www.w3.org/TR/wai-aria-1.2/#idl_element
+Element includes ARIAMixin;

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -12,6 +12,8 @@
 #include <AK/RefPtr.h>
 #include <AK/TypeCasts.h>
 #include <AK/Vector.h>
+#include <LibWeb/DOM/ARIARoleNames.h>
+#include <LibWeb/DOM/AccessibilityTreeNode.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/DOMParsing/XMLSerializer.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -639,6 +641,8 @@ protected:
     // https://dom.spec.whatwg.org/#registered-observer-list
     // "Nodes have a strong reference to registered observers in their registered observer list." https://dom.spec.whatwg.org/#garbage-collection
     Vector<RegisteredObserver&> m_registered_observer_list;
+
+    void build_accessibility_tree(AccessibilityTreeNode& parent) const;
 
 private:
     void queue_tree_mutation_record(JS::NonnullGCPtr<NodeList> added_nodes, JS::NonnullGCPtr<NodeList> removed_nodes, Node* previous_sibling, Node* next_sibling);

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -136,6 +136,7 @@ namespace Web::DOM {
 class AbstractRange;
 class AbortController;
 class AbortSignal;
+class AccessibilityTreeNode;
 class Attr;
 class CDATASection;
 class CharacterData;

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/Window.h>
 
@@ -82,6 +83,15 @@ i32 HTMLAnchorElement::default_tab_index_value() const
 {
     // See the base function for the spec comments.
     return 0;
+}
+
+FlyString HTMLAnchorElement::default_role() const
+{
+    // https://www.w3.org/TR/html-aria/#el-a-no-href
+    if (!href().is_null())
+        return DOM::ARIARoleNames::link;
+    // https://www.w3.org/TR/html-aria/#el-a
+    return DOM::ARIARoleNames::generic;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -50,6 +50,8 @@ private:
     {
         queue_an_element_task(source, move(steps));
     }
+
+    virtual FlyString default_role() const override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/Window.h>
 
@@ -40,6 +41,15 @@ i32 HTMLAreaElement::default_tab_index_value() const
 {
     // See the base function for the spec comments.
     return 0;
+}
+
+FlyString HTMLAreaElement::default_role() const
+{
+    // https://www.w3.org/TR/html-aria/#el-area-no-href
+    if (!href().is_null())
+        return DOM::ARIARoleNames::link;
+    // https://www.w3.org/TR/html-aria/#el-area
+    return DOM::ARIARoleNames::generic;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -39,6 +39,8 @@ private:
     {
         queue_an_element_task(source, move(steps));
     }
+
+    virtual FlyString default_role() const override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/WindowEventHandlers.h>
 
@@ -21,6 +22,9 @@ public:
 
     virtual void parse_attribute(FlyString const&, DeprecatedString const&) override;
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
+
+    // https://www.w3.org/TR/html-aria/#el-body
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::generic; };
 
 private:
     HTMLBodyElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
@@ -52,6 +53,9 @@ public:
     // ^HTMLElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const override { return true; }
+
+    // https://www.w3.org/TR/html-aria/#el-button
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::button; }
 
 private:
     HTMLButtonElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLDataElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDataElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLDataElement final : public HTMLElement {
 
 public:
     virtual ~HTMLDataElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-data
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::generic; }
 
 private:
     HTMLDataElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLDataListElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDataListElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,8 @@ class HTMLDataListElement final : public HTMLElement {
 
 public:
     virtual ~HTMLDataListElement() override;
+
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::listbox; }
 
 private:
     HTMLDataListElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLDetailsElement final : public HTMLElement {
 
 public:
     virtual ~HTMLDetailsElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-details
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::group; };
 
 private:
     HTMLDetailsElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLDialogElement final : public HTMLElement {
 
 public:
     virtual ~HTMLDialogElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-dialog
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::dialog; }
 
 private:
     HTMLDialogElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLDivElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDivElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLDivElement final : public HTMLElement {
 
 public:
     virtual ~HTMLDivElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-div
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::generic; }
 
 private:
     HTMLDivElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/StringBuilder.h>
 #include <LibJS/Interpreter.h>
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/IDLEventListener.h>
 #include <LibWeb/DOM/ShadowRoot.h>
@@ -325,6 +326,90 @@ void HTMLElement::blur()
     run_unfocusing_steps(this);
 
     // User agents may selectively or uniformly ignore calls to this method for usability reasons.
+}
+
+FlyString HTMLElement::default_role() const
+{
+    // https://www.w3.org/TR/html-aria/#el-article
+    if (local_name() == TagNames::article)
+        return DOM::ARIARoleNames::article;
+    // https://www.w3.org/TR/html-aria/#el-aside
+    if (local_name() == TagNames::aside)
+        return DOM::ARIARoleNames::complementary;
+    // https://www.w3.org/TR/html-aria/#el-b
+    if (local_name() == TagNames::b)
+        return DOM::ARIARoleNames::generic;
+    // https://www.w3.org/TR/html-aria/#el-bdi
+    if (local_name() == TagNames::bdi)
+        return DOM::ARIARoleNames::generic;
+    // https://www.w3.org/TR/html-aria/#el-bdo
+    if (local_name() == TagNames::bdo)
+        return DOM::ARIARoleNames::generic;
+    // https://www.w3.org/TR/html-aria/#el-code
+    if (local_name() == TagNames::code)
+        return DOM::ARIARoleNames::code;
+    // https://www.w3.org/TR/html-aria/#el-dfn
+    if (local_name() == TagNames::dfn)
+        return DOM::ARIARoleNames::term;
+    // https://www.w3.org/TR/html-aria/#el-em
+    if (local_name() == TagNames::em)
+        return DOM::ARIARoleNames::emphasis;
+    // https://www.w3.org/TR/html-aria/#el-figure
+    if (local_name() == TagNames::figure)
+        return DOM::ARIARoleNames::figure;
+    // https://www.w3.org/TR/html-aria/#el-footer
+    if (local_name() == TagNames::footer) {
+        // TODO: If not a descendant of an article, aside, main, nav or section element, or an element with role=article, complementary, main, navigation or region then role=contentinfo
+        // Otherwise, role=generic
+        return DOM::ARIARoleNames::generic;
+    }
+    // https://www.w3.org/TR/html-aria/#el-header
+    if (local_name() == TagNames::header) {
+        // TODO: If not a descendant of an article, aside, main, nav or section element, or an element with role=article, complementary, main, navigation or region then role=banner
+        // Otherwise, role=generic
+        return DOM::ARIARoleNames::generic;
+    }
+    // https://www.w3.org/TR/html-aria/#el-hgroup
+    if (local_name() == TagNames::hgroup)
+        return DOM::ARIARoleNames::generic;
+    // https://www.w3.org/TR/html-aria/#el-i
+    if (local_name() == TagNames::i)
+        return DOM::ARIARoleNames::generic;
+    // https://www.w3.org/TR/html-aria/#el-main
+    if (local_name() == TagNames::main)
+        return DOM::ARIARoleNames::main;
+    // https://www.w3.org/TR/html-aria/#el-nav
+    if (local_name() == TagNames::nav)
+        return DOM::ARIARoleNames::navigation;
+    // https://www.w3.org/TR/html-aria/#el-samp
+    if (local_name() == TagNames::samp)
+        return DOM::ARIARoleNames::generic;
+    // https://www.w3.org/TR/html-aria/#el-section
+    if (local_name() == TagNames::section) {
+        // TODO:  role=region if the section element has an accessible name
+        //        Otherwise, no corresponding role
+        return DOM::ARIARoleNames::region;
+    }
+    // https://www.w3.org/TR/html-aria/#el-small
+    if (local_name() == TagNames::small)
+        return DOM::ARIARoleNames::generic;
+    // https://www.w3.org/TR/html-aria/#el-strong
+    if (local_name() == TagNames::strong)
+        return DOM::ARIARoleNames::strong;
+    // https://www.w3.org/TR/html-aria/#el-sub
+    if (local_name() == TagNames::sub)
+        return DOM::ARIARoleNames::subscript;
+    // https://www.w3.org/TR/html-aria/#el-summary
+    if (local_name() == TagNames::summary)
+        return DOM::ARIARoleNames::button;
+    // https://www.w3.org/TR/html-aria/#el-sup
+    if (local_name() == TagNames::sup)
+        return DOM::ARIARoleNames::superscript;
+    // https://www.w3.org/TR/html-aria/#el-u
+    if (local_name() == TagNames::u)
+        return DOM::ARIARoleNames::generic;
+
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -59,6 +59,8 @@ public:
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const { return false; }
 
+    virtual FlyString default_role() const override;
+
 protected:
     HTMLElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
@@ -34,6 +35,8 @@ public:
 
     // https://html.spec.whatwg.org/multipage/forms.html#category-autocapitalize
     virtual bool is_auto_capitalize_inheriting() const override { return true; }
+
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::group; }
 
 private:
     HTMLFieldSetElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 
@@ -35,6 +36,9 @@ public:
 
     JS::NonnullGCPtr<DOM::HTMLCollection> elements() const;
     unsigned length() const;
+
+    // https://www.w3.org/TR/html-aria/#el-form
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::form; }
 
 private:
     HTMLFormElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLHRElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHRElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLHRElement final : public HTMLElement {
 
 public:
     virtual ~HTMLHRElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-hr
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::separator; }
 
 private:
     HTMLHRElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -17,6 +18,14 @@ public:
     virtual ~HTMLHeadingElement() override;
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
+
+    // https://www.w3.org/TR/html-aria/#el-h1-h6
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::heading; }
+    virtual DeprecatedString aria_level() const override
+    {
+        // TODO: aria-level = the number in the element's tag name
+        return get_attribute("aria-level");
+    }
 
 private:
     HTMLHeadingElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -17,6 +18,9 @@ public:
     virtual ~HTMLHtmlElement() override;
 
     bool should_use_body_background_properties() const;
+
+    // https://www.w3.org/TR/html-aria/#el-html
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::document; }
 
 private:
     HTMLHtmlElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -7,6 +7,7 @@
 #include <LibGfx/Bitmap.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/HTML/EventNames.h>
@@ -195,6 +196,16 @@ bool HTMLImageElement::complete() const
         return true;
 
     return false;
+}
+
+FlyString HTMLImageElement::default_role() const
+{
+    // https://www.w3.org/TR/html-aria/#el-img
+    // https://www.w3.org/TR/html-aria/#el-img-no-alt
+    if (alt().is_null() || !alt().is_empty())
+        return DOM::ARIARoleNames::img;
+    // https://www.w3.org/TR/html-aria/#el-img-empty-alt
+    return DOM::ARIARoleNames::presentation;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -43,6 +43,8 @@ public:
     // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-complete
     bool complete() const;
 
+    virtual FlyString default_role() const override;
+
 private:
     HTMLImageElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -866,4 +866,66 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_selection_range(u32 start, u32 e
     return {};
 }
 
+FlyString HTMLInputElement::default_role() const
+{
+    // https://www.w3.org/TR/html-aria/#el-input-button
+    if (type_state() == TypeAttributeState::Button)
+        return DOM::ARIARoleNames::button;
+    // https://www.w3.org/TR/html-aria/#el-input-checkbox
+    if (type_state() == TypeAttributeState::Checkbox)
+        return DOM::ARIARoleNames::checkbox;
+    // https://www.w3.org/TR/html-aria/#el-input-email
+    if (type_state() == TypeAttributeState::Email && attribute("list").is_null())
+        return DOM::ARIARoleNames::textbox;
+    // https://www.w3.org/TR/html-aria/#el-input-image
+    if (type_state() == TypeAttributeState::ImageButton)
+        return DOM::ARIARoleNames::button;
+    // https://www.w3.org/TR/html-aria/#el-input-number
+    if (type_state() == TypeAttributeState::Number)
+        return DOM::ARIARoleNames::spinbutton;
+    // https://www.w3.org/TR/html-aria/#el-input-radio
+    if (type_state() == TypeAttributeState::RadioButton)
+        return DOM::ARIARoleNames::radio;
+    // https://www.w3.org/TR/html-aria/#el-input-range
+    if (type_state() == TypeAttributeState::Range)
+        return DOM::ARIARoleNames::slider;
+    // https://www.w3.org/TR/html-aria/#el-input-reset
+    if (type_state() == TypeAttributeState::ResetButton)
+        return DOM::ARIARoleNames::button;
+    // https://www.w3.org/TR/html-aria/#el-input-text-list
+    if ((type_state() == TypeAttributeState::Text
+            || type_state() == TypeAttributeState::Search
+            || type_state() == TypeAttributeState::Telephone
+            || type_state() == TypeAttributeState::URL
+            || type_state() == TypeAttributeState::Email)
+        && !attribute("list").is_null())
+        return DOM::ARIARoleNames::combobox;
+    // https://www.w3.org/TR/html-aria/#el-input-search
+    if (type_state() == TypeAttributeState::Search && attribute("list").is_null())
+        return DOM::ARIARoleNames::textbox;
+    // https://www.w3.org/TR/html-aria/#el-input-submit
+    if (type_state() == TypeAttributeState::SubmitButton)
+        return DOM::ARIARoleNames::button;
+    // https://www.w3.org/TR/html-aria/#el-input-tel
+    if (type_state() == TypeAttributeState::Telephone)
+        return DOM::ARIARoleNames::textbox;
+    // https://www.w3.org/TR/html-aria/#el-input-text
+    if (type_state() == TypeAttributeState::Text && attribute("list").is_null())
+        return DOM::ARIARoleNames::textbox;
+    // https://www.w3.org/TR/html-aria/#el-input-url
+    if (type_state() == TypeAttributeState::URL && attribute("list").is_null())
+        return DOM::ARIARoleNames::textbox;
+
+    // https://www.w3.org/TR/html-aria/#el-input-color
+    // https://www.w3.org/TR/html-aria/#el-input-date
+    // https://www.w3.org/TR/html-aria/#el-input-datetime-local
+    // https://www.w3.org/TR/html-aria/#el-input-file
+    // https://www.w3.org/TR/html-aria/#el-input-hidden
+    // https://www.w3.org/TR/html-aria/#el-input-month
+    // https://www.w3.org/TR/html-aria/#el-input-password
+    // https://www.w3.org/TR/html-aria/#el-input-time
+    // https://www.w3.org/TR/html-aria/#el-input-week
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -120,6 +120,8 @@ public:
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const override { return type_state() != TypeAttributeState::Hidden; }
 
+    virtual FlyString default_role() const override;
+
 private:
     HTMLInputElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLLIElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLIElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLLIElement final : public HTMLElement {
 
 public:
     virtual ~HTMLLIElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-li
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::listitem; };
 
 private:
     HTMLLIElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLMenuElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMenuElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLMenuElement final : public HTMLElement {
 
 public:
     virtual ~HTMLMenuElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-menu
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::list; }
 
 private:
     HTMLMenuElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -20,6 +21,9 @@ public:
     // ^HTMLElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const override { return true; }
+
+    // https://www.w3.org/TR/html-aria/#el-meter
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::meter; }
 
 private:
     HTMLMeterElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLModElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLModElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Assertions.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLModElement.h>
 
@@ -16,5 +17,16 @@ HTMLModElement::HTMLModElement(DOM::Document& document, DOM::QualifiedName quali
 }
 
 HTMLModElement::~HTMLModElement() = default;
+
+FlyString HTMLModElement::default_role() const
+{
+    // https://www.w3.org/TR/html-aria/#el-del
+    if (local_name() == TagNames::del)
+        return DOM::ARIARoleNames::deletion;
+    // https://www.w3.org/TR/html-aria/#el-ins
+    if (local_name() == TagNames::ins)
+        return DOM::ARIARoleNames::insertion;
+    VERIFY_NOT_REACHED();
+}
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLModElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLModElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,8 @@ class HTMLModElement final : public HTMLElement {
 
 public:
     virtual ~HTMLModElement() override;
+
+    virtual FlyString default_role() const override;
 
 private:
     HTMLModElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLOListElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOListElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLOListElement final : public HTMLElement {
 
 public:
     virtual ~HTMLOListElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-ol
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::list; }
 
 private:
     HTMLOListElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptGroupElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptGroupElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLOptGroupElement final : public HTMLElement {
 
 public:
     virtual ~HTMLOptGroupElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-optgroup
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::group; }
 
 private:
     HTMLOptGroupElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/StringBuilder.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/HTMLOptGroupElement.h>
@@ -138,6 +139,13 @@ bool HTMLOptionElement::disabled() const
     // An option element is disabled if its disabled attribute is present or if it is a child of an optgroup element whose disabled attribute is present.
     return has_attribute(AttributeNames::disabled)
         || (parent() && is<HTMLOptGroupElement>(parent()) && static_cast<HTMLOptGroupElement const&>(*parent()).has_attribute(AttributeNames::disabled));
+}
+
+FlyString HTMLOptionElement::default_role() const
+{
+    // https://www.w3.org/TR/html-aria/#el-option
+    // TODO: Only an option element that is in a list of options or that represents a suggestion in a datalist should return option
+    return DOM::ARIARoleNames::option;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -30,6 +30,8 @@ public:
 
     bool disabled() const;
 
+    virtual FlyString default_role() const override;
+
 private:
     friend class Bindings::OptionConstructor;
     friend class HTMLSelectElement;

--- a/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
@@ -42,6 +43,9 @@ public:
     virtual bool is_labelable() const override { return true; }
 
     virtual void reset_algorithm() override;
+
+    // https://www.w3.org/TR/html-aria/#el-output
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::status; }
 
 private:
     HTMLOutputElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLParagraphElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLParagraphElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -17,6 +18,9 @@ public:
     virtual ~HTMLParagraphElement() override;
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
+
+    // https://www.w3.org/TR/html-aria/#el-p
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::paragraph; }
 
 private:
     HTMLParagraphElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLPreElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLPreElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLPreElement final : public HTMLElement {
 
 public:
     virtual ~HTMLPreElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-pre
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::generic; }
 
 private:
     HTMLPreElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -31,6 +32,9 @@ public:
     virtual bool is_labelable() const override { return true; }
 
     bool using_system_appearance() const;
+
+    // https://www.w3.org/TR/html-aria/#el-progress
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::progressbar; }
 
 private:
     HTMLProgressElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLQuoteElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLQuoteElement.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Assertions.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLQuoteElement.h>
 
 namespace Web::HTML {
@@ -16,5 +18,16 @@ HTMLQuoteElement::HTMLQuoteElement(DOM::Document& document, DOM::QualifiedName q
 }
 
 HTMLQuoteElement::~HTMLQuoteElement() = default;
+
+FlyString HTMLQuoteElement::default_role() const
+{
+    // https://www.w3.org/TR/html-aria/#el-blockquote
+    if (local_name() == TagNames::blockquote)
+        return DOM::ARIARoleNames::blockquote;
+    // https://www.w3.org/TR/html-aria/#el-q
+    if (local_name() == TagNames::q)
+        return DOM::ARIARoleNames::generic;
+    VERIFY_NOT_REACHED();
+}
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLQuoteElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLQuoteElement.h
@@ -16,6 +16,8 @@ class HTMLQuoteElement final : public HTMLElement {
 public:
     virtual ~HTMLQuoteElement() override;
 
+    virtual FlyString default_role() const override;
+
 private:
     HTMLQuoteElement(DOM::Document&, DOM::QualifiedName);
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -156,4 +156,18 @@ DeprecatedString const& HTMLSelectElement::type() const
     return select_multiple;
 }
 
+FlyString HTMLSelectElement::default_role() const
+{
+    // https://www.w3.org/TR/html-aria/#el-select-multiple-or-size-greater-1
+    if (has_attribute("multiple"))
+        return DOM::ARIARoleNames::listbox;
+    if (has_attribute("size")) {
+        auto size_attribute = attribute("size").to_int();
+        if (size_attribute.has_value() && size_attribute.value() > 1)
+            return DOM::ARIARoleNames::listbox;
+    }
+    // https://www.w3.org/TR/html-aria/#el-select
+    return DOM::ARIARoleNames::combobox;
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -60,6 +60,8 @@ public:
 
     DeprecatedString const& type() const;
 
+    virtual FlyString default_role() const override;
+
 private:
     HTMLSelectElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLSpanElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSpanElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLSpanElement final : public HTMLElement {
 
 public:
     virtual ~HTMLSpanElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-span
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::generic; }
 
 private:
     HTMLSpanElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCaptionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCaptionElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -17,6 +18,9 @@ public:
     virtual ~HTMLTableCaptionElement() override;
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
+
+    // https://www.w3.org/TR/html-aria/#el-caption
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::caption; }
 
 private:
     HTMLTableCaptionElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -69,4 +69,19 @@ void HTMLTableCellElement::set_row_span(unsigned int value)
     MUST(set_attribute(HTML::AttributeNames::rowspan, DeprecatedString::number(value)));
 }
 
+FlyString HTMLTableCellElement::default_role() const
+{
+    // TODO: For td:
+    //       role=cell if the ancestor table element is exposed as a role=table
+    //       role=gridcell if the ancestor table element is exposed as a role=grid or treegrid
+    //       No corresponding role if the ancestor table element is not exposed as a role=table, grid or treegrid
+    //       For th:
+    //       role=columnheader, rowheader or cell if the ancestor table element is exposed as a role=table
+    //        role=columnheader, rowheader or gridcell if the ancestor table element is exposed as a role=grid or treegrid
+    //        No corresponding role if the ancestor table element is not exposed as a role=table, grid or treegrid
+    // https://www.w3.org/TR/html-aria/#el-td
+    // https://www.w3.org/TR/html-aria/#el-th
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.h
@@ -22,6 +22,8 @@ public:
     void set_col_span(unsigned);
     void set_row_span(unsigned);
 
+    virtual FlyString default_role() const override;
+
 private:
     HTMLTableCellElement(DOM::Document&, DOM::QualifiedName);
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.h
@@ -42,6 +42,9 @@ public:
     WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> insert_row(long index);
     WebIDL::ExceptionOr<void> delete_row(long index);
 
+    // https://www.w3.org/TR/html-aria/#el-table
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::table; }
+
 private:
     HTMLTableElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -22,6 +23,9 @@ public:
     int section_row_index() const;
     WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableCellElement>> insert_cell(i32 index);
     WebIDL::ExceptionOr<void> delete_cell(i32 index);
+
+    // https://www.w3.org/TR/html-aria/#el-tr
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::row; }
 
 private:
     HTMLTableRowElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -20,6 +21,11 @@ public:
     JS::NonnullGCPtr<DOM::HTMLCollection> rows() const;
     WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> insert_row(long index);
     WebIDL::ExceptionOr<void> delete_row(long index);
+
+    // https://www.w3.org/TR/html-aria/#el-tbody
+    // https://www.w3.org/TR/html-aria/#el-tfoot
+    // https://www.w3.org/TR/html-aria/#el-thead
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::rowgroup; }
 
 private:
     HTMLTableSectionElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
@@ -49,6 +50,9 @@ public:
     virtual bool is_labelable() const override { return true; }
 
     virtual void reset_algorithm() override;
+
+    // https://www.w3.org/TR/html-aria/#el-textarea
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::textbox; }
 
 private:
     HTMLTextAreaElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLTimeElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTimeElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLTimeElement final : public HTMLElement {
 
 public:
     virtual ~HTMLTimeElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-time
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::time; }
 
 private:
     HTMLTimeElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLUListElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLUListElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ARIARoleNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -15,6 +16,9 @@ class HTMLUListElement final : public HTMLElement {
 
 public:
     virtual ~HTMLUListElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-ul
+    virtual FlyString default_role() const override { return DOM::ARIARoleNames::list; }
 
 private:
     HTMLUListElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWebView/AccessibilityTreeModel.cpp
+++ b/Userland/Libraries/LibWebView/AccessibilityTreeModel.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/AccessibilityTreeModel.h>
+
+namespace WebView {
+
+AccessibilityTreeModel::AccessibilityTreeModel(JsonObject accessibility_tree, GUI::TreeView* tree_view)
+    : m_tree_view(tree_view)
+    , m_accessibility_tree(move(accessibility_tree))
+{
+    map_accessibility_nodes_to_parent(nullptr, &m_accessibility_tree);
+}
+
+AccessibilityTreeModel::~AccessibilityTreeModel() = default;
+
+GUI::ModelIndex AccessibilityTreeModel::index(int row, int column, GUI::ModelIndex const& parent) const
+{
+    if (!parent.is_valid()) {
+        return create_index(row, column, &m_accessibility_tree);
+    }
+
+    auto const& parent_node = *static_cast<JsonObject const*>(parent.internal_data());
+    auto const* children = get_children(parent_node);
+    if (!children)
+        return create_index(row, column, &m_accessibility_tree);
+
+    auto const& child_node = children->at(row).as_object();
+    return create_index(row, column, &child_node);
+}
+
+GUI::ModelIndex AccessibilityTreeModel::parent_index(GUI::ModelIndex const& index) const
+{
+    if (!index.is_valid())
+        return {};
+
+    auto const& node = *static_cast<JsonObject const*>(index.internal_data());
+
+    auto const* parent_node = get_parent(node);
+    if (!parent_node)
+        return {};
+
+    // If the parent is the root document, we know it has index 0, 0
+    if (parent_node == &m_accessibility_tree) {
+        return create_index(0, 0, parent_node);
+    }
+
+    // Otherwise, we need to find the grandparent, to find the index of parent within that
+    auto const* grandparent_node = get_parent(*parent_node);
+    VERIFY(grandparent_node);
+
+    auto const* grandparent_children = get_children(*grandparent_node);
+    if (!grandparent_children)
+        return {};
+
+    for (size_t grandparent_child_index = 0; grandparent_child_index < grandparent_children->size(); ++grandparent_child_index) {
+        auto const& child = grandparent_children->at(grandparent_child_index).as_object();
+        if (&child == parent_node)
+            return create_index(grandparent_child_index, 0, parent_node);
+    }
+
+    return {};
+}
+
+int AccessibilityTreeModel::row_count(GUI::ModelIndex const& index) const
+{
+    if (!index.is_valid())
+        return 1;
+
+    auto const& node = *static_cast<JsonObject const*>(index.internal_data());
+    auto const* children = get_children(node);
+    return children ? children->size() : 0;
+}
+
+int AccessibilityTreeModel::column_count(const GUI::ModelIndex&) const
+{
+    return 1;
+}
+
+GUI::Variant AccessibilityTreeModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
+{
+    auto const& node = *static_cast<JsonObject const*>(index.internal_data());
+    auto type = node.get("type"sv).as_string_or("unknown"sv);
+
+    if (role == GUI::ModelRole::Display) {
+        if (type == "text")
+            return node.get("text"sv).as_string();
+
+        auto node_role = node.get("role"sv).as_string();
+        if (type != "element")
+            return node_role;
+
+        StringBuilder builder;
+        builder.append(node_role.to_lowercase());
+        return builder.to_deprecated_string();
+    }
+    return {};
+}
+
+void AccessibilityTreeModel::map_accessibility_nodes_to_parent(JsonObject const* parent, JsonObject const* node)
+{
+    m_accessibility_node_to_parent_map.set(node, parent);
+
+    auto const* children = get_children(*node);
+    if (!children)
+        return;
+
+    children->for_each([&](auto const& child) {
+        auto const& child_node = child.as_object();
+        map_accessibility_nodes_to_parent(node, &child_node);
+    });
+}
+
+}

--- a/Userland/Libraries/LibWebView/AccessibilityTreeModel.h
+++ b/Userland/Libraries/LibWebView/AccessibilityTreeModel.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonObject.h>
+#include <LibGUI/Model.h>
+#include <LibWeb/CSS/Selector.h>
+
+namespace WebView {
+
+class AccessibilityTreeModel final : public GUI::Model {
+public:
+    static NonnullRefPtr<AccessibilityTreeModel> create(StringView accessibility_tree, GUI::TreeView& tree_view)
+    {
+        auto json_or_error = JsonValue::from_string(accessibility_tree).release_value_but_fixme_should_propagate_errors();
+        return adopt_ref(*new AccessibilityTreeModel(json_or_error.as_object(), &tree_view));
+    }
+
+    static NonnullRefPtr<AccessibilityTreeModel> create(StringView accessibility_tree)
+    {
+        auto json_or_error = JsonValue::from_string(accessibility_tree).release_value_but_fixme_should_propagate_errors();
+        return adopt_ref(*new AccessibilityTreeModel(json_or_error.as_object(), nullptr));
+    }
+
+    virtual ~AccessibilityTreeModel() override;
+
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
+    virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
+    virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
+    virtual GUI::ModelIndex index(int row, int column, GUI::ModelIndex const& parent = GUI::ModelIndex()) const override;
+    virtual GUI::ModelIndex parent_index(GUI::ModelIndex const&) const override;
+
+private:
+    AccessibilityTreeModel(JsonObject, GUI::TreeView*);
+
+    ALWAYS_INLINE JsonObject const* get_parent(JsonObject const& o) const
+    {
+        auto parent_node = m_accessibility_node_to_parent_map.get(&o);
+        VERIFY(parent_node.has_value());
+        return *parent_node;
+    }
+
+    ALWAYS_INLINE static JsonArray const* get_children(JsonObject const& o)
+    {
+        if (auto const* maybe_children = o.get_ptr("children"sv); maybe_children)
+            return &maybe_children->as_array();
+        return nullptr;
+    }
+
+    void map_accessibility_nodes_to_parent(JsonObject const* parent, JsonObject const* child);
+
+    GUI::TreeView* m_tree_view { nullptr };
+    JsonObject m_accessibility_tree;
+    HashMap<JsonObject const*, JsonObject const*> m_accessibility_node_to_parent_map;
+};
+
+}

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    AccessibilityTreeModel.cpp
     DOMTreeModel.cpp
     OutOfProcessWebView.cpp
     RequestServerAdapter.cpp

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -830,4 +830,15 @@ void OutOfProcessWebView::notify_server_did_finish_handling_input_event(bool eve
     process_next_input_event();
 }
 
+void OutOfProcessWebView::inspect_accessibility_tree()
+{
+    client().async_inspect_accessibility_tree();
+}
+
+void OutOfProcessWebView::notify_server_did_get_accessibility_tree(DeprecatedString const& accessibility_tree)
+{
+    if (on_get_accessibility_tree)
+        on_get_accessibility_tree(accessibility_tree);
+}
+
 }

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -50,6 +50,7 @@ public:
         DeprecatedString node_box_sizing_json;
     };
     Optional<DOMNodeProperties> inspect_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement>);
+    void inspect_accessibility_tree();
     void clear_inspected_dom_node();
     i32 get_hovered_node_id();
 
@@ -97,6 +98,7 @@ public:
     Function<void(const AK::URL&, DeprecatedString const&)> on_get_source;
     Function<void(DeprecatedString const&)> on_get_dom_tree;
     Function<void(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing)> on_get_dom_node_properties;
+    Function<void(DeprecatedString const&)> on_get_accessibility_tree;
     Function<void(i32 message_id)> on_js_console_new_message;
     Function<void(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages)> on_get_js_console_messages;
     Function<Vector<Web::Cookie::Cookie>(AK::URL const& url)> on_get_all_cookies;
@@ -170,6 +172,7 @@ private:
     virtual void notify_server_did_get_source(const AK::URL& url, DeprecatedString const& source) override;
     virtual void notify_server_did_get_dom_tree(DeprecatedString const& dom_tree) override;
     virtual void notify_server_did_get_dom_node_properties(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing) override;
+    virtual void notify_server_did_get_accessibility_tree(DeprecatedString const& accessibility_tree) override;
     virtual void notify_server_did_output_js_console_message(i32 message_index) override;
     virtual void notify_server_did_get_js_console_messages(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages) override;
     virtual void notify_server_did_change_favicon(Gfx::Bitmap const& favicon) override;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -50,6 +50,7 @@ public:
     virtual void notify_server_did_get_source(const AK::URL& url, DeprecatedString const& source) = 0;
     virtual void notify_server_did_get_dom_tree(DeprecatedString const& dom_tree) = 0;
     virtual void notify_server_did_get_dom_node_properties(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing) = 0;
+    virtual void notify_server_did_get_accessibility_tree(DeprecatedString const& accessibility_tree) = 0;
     virtual void notify_server_did_output_js_console_message(i32 message_index) = 0;
     virtual void notify_server_did_get_js_console_messages(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages) = 0;
     virtual void notify_server_did_change_favicon(Gfx::Bitmap const& favicon) = 0;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -285,4 +285,9 @@ void WebContentClient::did_finish_handling_input_event(bool event_was_accepted)
     m_view.notify_server_did_finish_handling_input_event(event_was_accepted);
 }
 
+void WebContentClient::did_get_accessibility_tree(DeprecatedString const& accessibility_tree)
+{
+    m_view.notify_server_did_get_accessibility_tree(accessibility_tree);
+}
+
 }

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -54,6 +54,7 @@ private:
     virtual void did_get_source(AK::URL const&, DeprecatedString const&) override;
     virtual void did_get_dom_tree(DeprecatedString const&) override;
     virtual void did_get_dom_node_properties(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing) override;
+    virtual void did_get_accessibility_tree(DeprecatedString const&) override;
     virtual void did_output_js_console_message(i32 message_index) override;
     virtual void did_get_js_console_messages(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages) override;
     virtual void did_change_favicon(Gfx::ShareableBitmap const&) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -595,4 +595,11 @@ void ConnectionFromClient::prompt_closed(DeprecatedString const& response)
     m_page_host->prompt_closed(response);
 }
 
+void ConnectionFromClient::inspect_accessibility_tree()
+{
+    if (auto* doc = page().top_level_browsing_context().active_document()) {
+        async_did_get_accessibility_tree(doc->dump_accessibility_tree_as_json());
+    }
+}
+
 }

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -68,6 +68,7 @@ private:
     virtual void get_source() override;
     virtual void inspect_dom_tree() override;
     virtual Messages::WebContentServer::InspectDomNodeResponse inspect_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> const& pseudo_element) override;
+    virtual void inspect_accessibility_tree() override;
     virtual Messages::WebContentServer::GetHoveredNodeIdResponse get_hovered_node_id() override;
     virtual Messages::WebContentServer::DumpLayoutTreeResponse dump_layout_tree() override;
     virtual void set_content_filters(Vector<DeprecatedString> const&) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -38,6 +38,7 @@ endpoint WebContentClient
     did_get_source(URL url, DeprecatedString source) =|
     did_get_dom_tree(DeprecatedString dom_tree) =|
     did_get_dom_node_properties(i32 node_id, DeprecatedString computed_style, DeprecatedString resolved_style, DeprecatedString custom_properties, DeprecatedString node_box_sizing_json) =|
+    did_get_accessibility_tree(DeprecatedString accessibility_tree) =|
     did_change_favicon(Gfx::ShareableBitmap favicon) =|
     did_request_all_cookies(URL url) => (Vector<Web::Cookie::Cookie> cookies)
     did_request_named_cookie(URL url, DeprecatedString name) => (Optional<Web::Cookie::Cookie> cookie)

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -37,6 +37,7 @@ endpoint WebContentServer
     get_source() =|
     inspect_dom_tree() =|
     inspect_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> pseudo_element) => (bool has_style, DeprecatedString computed_style,  DeprecatedString resolved_style,  DeprecatedString custom_properties, DeprecatedString node_box_sizing)
+    inspect_accessibility_tree() =|
     get_hovered_node_id() => (i32 node_id)
     js_console_input(DeprecatedString js_source) =|
     js_console_request_messages(i32 start_index) =|


### PR DESCRIPTION
This PR introduces the start of support for the accessibility tree through partial implementations of WAI-ARIA and HTML AAM. The way to view this currently is to go to the accessibility tab of the browser inspector:
![image](https://user-images.githubusercontent.com/9423342/206923765-6ce810ca-e3b1-4137-adf6-6cdecc311a4c.png)
There are a few major limitations of this initial cut:

1. The accessible name and description algorithm is not implemented, so these are not displayed.
2. The role hierarchy is not implemented, so we do not expose ARIA states and properties as required there.
3. The accessibility tree is not exposed via an accessibility API, and even if it was...
4. There is no screen reader in Serenity (bit of a chicken and egg there :P)