### PR TITLE
Help: Link to LibLocale

### DIFF
--- a/Userland/Applications/Help/CMakeLists.txt
+++ b/Userland/Applications/Help/CMakeLists.txt
@@ -19,5 +19,5 @@ set(GENERATED_SOURCES
 )
 
 serenity_app(Help ICON app-help)
-target_link_libraries(Help PRIVATE LibCore LibWebView LibWeb LibMarkdown LibGfx LibGUI LibDesktop LibMain LibManual)
+target_link_libraries(Help PRIVATE LibCore LibWebView LibWeb LibMarkdown LibGfx LibGUI LibDesktop LibMain LibManual LibLocale)
 link_with_locale_data(Help)


### PR DESCRIPTION
This managed to fly under my radar for the LibManual PR, and somehow it
only happens for the Clang build but doesn't always trigger on CI.