### PR TITLE
Help+LibManual: Without arguments, open index page instead of crashing

### DIFF
--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -213,7 +213,7 @@ ErrorOr<void> MainWidget::set_start_page(Vector<StringView, 2> query_parameters)
 
 ErrorOr<void> MainWidget::initialize_fallibles(GUI::Window& window)
 {
-    static String const help_index_path = TRY(TRY(try_make_ref_counted<Manual::PageNode>(Manual::sections[7 - 1], TRY(String::from_utf8("Help-index"sv))))->path());
+    static String const help_index_path = TRY(TRY(Manual::PageNode::help_index_page())->path());
     m_go_home_action = GUI::CommonActions::make_go_home_action([this](auto&) {
         m_history.push(help_index_path);
         open_page(help_index_path);

--- a/Userland/Libraries/LibManual/Node.cpp
+++ b/Userland/Libraries/LibManual/Node.cpp
@@ -25,8 +25,7 @@ ErrorOr<NonnullRefPtr<PageNode>> Node::try_create_from_query(Vector<StringView, 
     auto query_parameter_iterator = query_parameters.begin();
 
     if (query_parameter_iterator.is_end())
-        // BUG! No query was given.
-        VERIFY_NOT_REACHED();
+        return PageNode::help_index_page();
 
     auto first_query_parameter = *query_parameter_iterator;
     ++query_parameter_iterator;

--- a/Userland/Libraries/LibManual/PageNode.cpp
+++ b/Userland/Libraries/LibManual/PageNode.cpp
@@ -7,6 +7,7 @@
 
 #include "PageNode.h"
 #include "SectionNode.h"
+#include <AK/RefPtr.h>
 
 namespace Manual {
 
@@ -24,6 +25,12 @@ NonnullRefPtrVector<Node>& PageNode::children() const
 ErrorOr<String> PageNode::path() const
 {
     return TRY(String::formatted("{}/{}.md", TRY(m_section->path()), m_page));
+}
+
+ErrorOr<NonnullRefPtr<PageNode>> PageNode::help_index_page()
+{
+    static NonnullRefPtr<PageNode> const help_index_page = TRY(try_make_ref_counted<PageNode>(sections[7 - 1], TRY(String::from_utf8("Help-index"sv))));
+    return help_index_page;
 }
 
 }

--- a/Userland/Libraries/LibManual/PageNode.h
+++ b/Userland/Libraries/LibManual/PageNode.h
@@ -30,6 +30,8 @@ public:
 
     ErrorOr<String> path() const;
 
+    static ErrorOr<NonnullRefPtr<PageNode>> help_index_page();
+
 private:
     NonnullRefPtr<SectionNode> m_section;
     String m_page;


### PR DESCRIPTION
This is the old behavior before the recent LibManual refactor. It also moves the definition of the index page into LibManual for better reuse.