### PR TITLE
PixelPaint: Single-clicking the BrushTool now adds to undo_stack

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
@@ -51,6 +51,7 @@ void BrushTool::on_mousedown(Layer* layer, MouseEvent& event)
     layer->did_modify_bitmap(Gfx::IntRect::centered_on(layer_event.position(), Gfx::IntSize { m_size * 2, m_size * 2 }));
     m_last_position = layer_event.position();
     m_has_clicked = true;
+    m_was_drawing = true;
 }
 
 void BrushTool::on_mousemove(Layer* layer, MouseEvent& event)


### PR DESCRIPTION
Simple change, prior to this BrushTool and EraseTool would not have update the undo_stack for the ImageEditor unless you were clicking and dragging.

m_was_drawing set to true if the bitmap was modified allows the brushtool to update the ImageEditor via check on mouseup and subsequently calling did_complete_action()