### PR TITLE
PixelPaint: StatusBar and ColorPicker update when moving the cursor

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -344,6 +344,8 @@ void ImageEditor::set_editor_color_to_color_at_mouse_position(GUI::MouseEvent co
         color = layer->currently_edited_bitmap().get_pixel(position);
     }
 
+    set_appended_status_info(DeprecatedString::formatted("R:{}, G:{}, B:{}, A:{} [{}]", color.red(), color.green(), color.blue(), color.alpha(), color.to_deprecated_string()));
+
     // We picked a transparent pixel, do nothing.
     if (!color.alpha())
         return;
@@ -866,6 +868,13 @@ void ImageEditor::draw_marching_ants_pixel(Gfx::Painter& painter, int x, int y) 
 void ImageEditor::selection_did_change()
 {
     update();
+}
+
+void ImageEditor::set_appended_status_info(DeprecatedString new_status_info)
+{
+    m_appended_status_info = new_status_info;
+    if (on_appended_status_info_change)
+        on_appended_status_info_change(m_appended_status_info);
 }
 
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -350,9 +350,9 @@ void ImageEditor::set_editor_color_to_color_at_mouse_position(GUI::MouseEvent co
     if (!color.alpha())
         return;
 
-    if (event.button() == GUI::MouseButton::Primary)
+    if (event.buttons() & GUI::MouseButton::Primary)
         set_primary_color(color);
-    else if (event.button() == GUI::MouseButton::Secondary)
+    if (event.buttons() & GUI::MouseButton::Secondary)
         set_secondary_color(color);
 }
 

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -123,6 +123,9 @@ public:
     void set_modified(DeprecatedString action_text);
     void set_unmodified();
     void update_modified();
+    Function<void(DeprecatedString)> on_appended_status_info_change;
+    DeprecatedString appended_status_info() { return m_appended_status_info; };
+    void set_appended_status_info(DeprecatedString);
 
 private:
     explicit ImageEditor(NonnullRefPtr<Image>);
@@ -192,6 +195,7 @@ private:
     void draw_marching_ants_pixel(Gfx::Painter&, int x, int y) const;
 
     Core::EventLoop& m_gui_event_loop;
+    DeprecatedString m_appended_status_info;
 };
 
 }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1117,7 +1117,7 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
         auto const& image_size = current_image_editor()->image().size();
         auto image_rectangle = Gfx::IntRect { 0, 0, image_size.width(), image_size.height() };
         if (image_rectangle.contains(mouse_position)) {
-            m_statusbar->set_override_text(mouse_position.to_deprecated_string());
+            update_status_bar(current_image_editor()->appended_status_info());
             m_histogram_widget->set_color_at_mouseposition(current_image_editor()->image().color_at(mouse_position));
             m_vectorscope_widget->set_color_at_mouseposition(current_image_editor()->image().color_at(mouse_position));
         } else {
@@ -1125,6 +1125,11 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
             m_histogram_widget->set_color_at_mouseposition(Color::Transparent);
             m_vectorscope_widget->set_color_at_mouseposition(Color::Transparent);
         }
+        m_last_image_editor_mouse_position = mouse_position;
+    };
+
+    image_editor.on_appended_status_info_change = [&](auto const& appended_status_info) {
+        update_status_bar(appended_status_info);
     };
 
     image_editor.on_leave = [&]() {
@@ -1217,4 +1222,15 @@ void MainWidget::update_window_modified()
 {
     window()->set_modified(m_tab_widget->is_any_tab_modified());
 }
+void MainWidget::update_status_bar(DeprecatedString appended_text)
+{
+    StringBuilder builder = StringBuilder();
+    builder.append(m_last_image_editor_mouse_position.to_deprecated_string());
+    if (!appended_text.is_empty()) {
+        builder.append(" "sv);
+        builder.append(appended_text);
+    }
+    m_statusbar->set_override_text(builder.to_deprecated_string());
+}
+
 }

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -60,6 +60,7 @@ private:
     virtual void drop_event(GUI::DropEvent&) override;
 
     void update_window_modified();
+    void update_status_bar(DeprecatedString appended_text = DeprecatedString::empty());
 
     ProjectLoader m_loader;
 
@@ -107,6 +108,8 @@ private:
 
     RefPtr<GUI::Action> m_layer_via_copy;
     RefPtr<GUI::Action> m_layer_via_cut;
+
+    Gfx::IntPoint m_last_image_editor_mouse_position;
 };
 
 }

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
@@ -22,6 +22,24 @@ void PickerTool::on_mousedown(Layer* layer, MouseEvent& event)
     m_editor->set_editor_color_to_color_at_mouse_position(layer_event, m_sample_all_layers);
 }
 
+void PickerTool::on_mouseup(Layer*, MouseEvent& event)
+{
+    auto layer_event = event.layer_event();
+    if (layer_event.buttons() & GUI::MouseButton::Primary || layer_event.buttons() & GUI::MouseButton::Secondary)
+        return;
+    m_editor->set_appended_status_info(DeprecatedString::empty());
+}
+
+void PickerTool::on_mousemove(Layer* layer, MouseEvent& event)
+{
+    if (!layer)
+        return;
+    auto layer_event = event.layer_event();
+    if (!(layer_event.buttons() & GUI::MouseButton::Primary || layer_event.buttons() & GUI::MouseButton::Secondary))
+        return;
+    m_editor->set_editor_color_to_color_at_mouse_position(layer_event, m_sample_all_layers);
+}
+
 GUI::Widget* PickerTool::get_properties_widget()
 {
     if (!m_properties_widget) {

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.h
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.h
@@ -18,6 +18,8 @@ public:
     virtual ~PickerTool() override = default;
 
     virtual void on_mousedown(Layer*, MouseEvent&) override;
+    virtual void on_mouseup(Layer*, MouseEvent&) override;
+    virtual void on_mousemove(Layer*, MouseEvent&) override;
 
     virtual GUI::Widget* get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Eyedropper; }


### PR DESCRIPTION
MainWidget and ImageEditor now expose StatusBar append messages so tools can append messages after the ImageEditor cursor location coordinates.

ColorPIcker also has onmove support to live render the colors that you are selecting.