### PR TITLE
Kernel: Use `size_t` to keep track of the number of pages in a region

### DIFF
--- a/Kernel/Memory/PhysicalRegion.cpp
+++ b/Kernel/Memory/PhysicalRegion.cpp
@@ -63,7 +63,7 @@ void PhysicalRegion::initialize_zones()
     make_zones(small_zone_size);
 }
 
-OwnPtr<PhysicalRegion> PhysicalRegion::try_take_pages_from_beginning(unsigned page_count)
+OwnPtr<PhysicalRegion> PhysicalRegion::try_take_pages_from_beginning(size_t page_count)
 {
     VERIFY(page_count > 0);
     VERIFY(page_count < m_pages);

--- a/Kernel/Memory/PhysicalRegion.h
+++ b/Kernel/Memory/PhysicalRegion.h
@@ -28,10 +28,10 @@ public:
 
     PhysicalAddress lower() const { return m_lower; }
     PhysicalAddress upper() const { return m_upper; }
-    unsigned size() const { return m_pages; }
+    size_t size() const { return m_pages; }
     bool contains(PhysicalAddress paddr) const { return paddr >= m_lower && paddr < m_upper; }
 
-    OwnPtr<PhysicalRegion> try_take_pages_from_beginning(unsigned);
+    OwnPtr<PhysicalRegion> try_take_pages_from_beginning(size_t);
 
     RefPtr<PhysicalPage> take_free_page();
     NonnullRefPtrVector<PhysicalPage> take_contiguous_free_pages(size_t count);
@@ -52,7 +52,7 @@ private:
 
     PhysicalAddress m_lower;
     PhysicalAddress m_upper;
-    unsigned m_pages { 0 };
+    size_t m_pages { 0 };
 };
 
 }


### PR DESCRIPTION
We were previously using a 32-bit unsigned integer for this, which caused us to start truncating region sizes when multiplied with `PAGE_SIZE` on hardware with a lot of memory.

This is split out from #16351, as this is a fix that works independently and the overarching PR still has some issues that need to be resolved.