### PR TITLE
AK: Actually don't include <unistd.h> for windows in Platform.h

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -173,14 +173,16 @@
 #        define PAGE_SIZE 4096
 // On macOS (at least Mojave), Apple's version of this header is not wrapped
 // in extern "C".
-#    elif defined(AK_OS_MACOS)
+#    else
+#        if defined(AK_OS_MACOS)
 extern "C" {
-#    endif
-#    include <unistd.h>
-#    undef PAGE_SIZE
-#    define PAGE_SIZE sysconf(_SC_PAGESIZE)
-#    ifdef AK_OS_MACOS
+#        endif
+#        include <unistd.h>
+#        undef PAGE_SIZE
+#        define PAGE_SIZE sysconf(_SC_PAGESIZE)
+#        ifdef AK_OS_MACOS
 }
+#        endif
 #    endif
 #endif
 


### PR DESCRIPTION
I got the conditions wrong in #16445, oops :^)