### PR TITLE
LibHTTP: Don't read and drop data if status line can't be read

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -251,16 +251,11 @@ void Job::on_socket_connected()
             }
 
             if (!can_read_line.value()) {
-                dbgln_if(JOB_DEBUG, "Job {} cannot read line", m_request.url());
-                auto maybe_buf = receive(64);
-                if (maybe_buf.is_error()) {
-                    dbgln_if(JOB_DEBUG, "Job {} cannot read any bytes!", m_request.url());
-                    return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-                }
-
-                dbgln_if(JOB_DEBUG, "{} bytes was read", maybe_buf.value().bytes().size());
-                return;
+                dbgln_if(JOB_DEBUG, "Job {} cannot read a full line", m_request.url());
+                // TODO: Should we retry here instead of failing instantly?
+                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
             }
+
             auto maybe_line = read_line(PAGE_SIZE);
             if (maybe_line.is_error()) {
                 dbgln_if(JOB_DEBUG, "Job {} could not read line: {}", m_request.url(), maybe_line.error());


### PR DESCRIPTION
The idea of reading some amount of data presumably was to check if the stream is still operable. However, this permanently breaks the request format, as those 64 bytes are just lost forever.

Instead, just let the request fail instantly for now and think about making it retry some time in the future. Since `can_read_line` updates the read buffer beforehand, this should only happen in the rarest of cases anyways (and it so far only ever happened on a mis-implemented Stream).