### PR TITLE
KeyboardSettings: Add checkbox to enable Caps Lock mapping to Ctrl

### DIFF
--- a/Userland/Applications/KeyboardSettings/Keyboard.gml
+++ b/Userland/Applications/KeyboardSettings/Keyboard.gml
@@ -124,4 +124,18 @@
             name: "num_lock_checkbox"
         }
     }
+
+    @GUI::GroupBox {
+        title: "Caps Lock"
+        fixed_height: 60
+        layout: @GUI::HorizontalBoxLayout {
+            margins: [16, 8, 8]
+            spacing: 16
+        }
+
+        @GUI::CheckBox {
+            text: "Remap Caps Lock to Ctrl"
+            name: "caps_lock_remapped_to_ctrl_checkbox"
+        }
+    }
 }

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Hüseyin Aslıtürk <asliturk@hotmail.com>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022, Sam Cohen <sbcohen2000@gmail.com>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -257,6 +258,19 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
     m_num_lock_checkbox->on_checked = [&](auto) {
         set_modified(true);
     };
+
+    m_caps_lock_checkbox = find_descendant_of_type_named<GUI::CheckBox>("caps_lock_remapped_to_ctrl_checkbox");
+    auto caps_lock_is_remapped = read_caps_lock_to_ctrl_sys_variable();
+    if (caps_lock_is_remapped.is_error()) {
+        auto error_message = DeprecatedString::formatted("Could not determine if Caps Lock is remapped to Ctrl: {}", caps_lock_is_remapped.error());
+        GUI::MessageBox::show_error(window(), error_message);
+    } else {
+        m_caps_lock_checkbox->set_checked(caps_lock_is_remapped.value());
+    }
+    m_caps_lock_checkbox->set_enabled(getuid() == 0);
+    m_caps_lock_checkbox->on_checked = [&](auto) {
+        set_modified(true);
+    };
 }
 
 KeyboardSettingsWidget::~KeyboardSettingsWidget()
@@ -284,10 +298,25 @@ void KeyboardSettingsWidget::apply_settings()
     }
     m_initial_active_keymap = m_keymaps_list_model.active_keymap();
     Config::write_bool("KeyboardSettings"sv, "StartupEnable"sv, "NumLock"sv, m_num_lock_checkbox->is_checked());
+    write_caps_lock_to_ctrl_sys_variable(m_caps_lock_checkbox->is_checked());
 }
 
 void KeyboardSettingsWidget::set_keymaps(Vector<DeprecatedString> const& keymaps, DeprecatedString const& active_keymap)
 {
     auto keymaps_string = DeprecatedString::join(',', keymaps);
     GUI::Process::spawn_or_show_error(window(), "/bin/keymap"sv, Array { "-s", keymaps_string.characters(), "-m", active_keymap.characters() });
+}
+
+void KeyboardSettingsWidget::write_caps_lock_to_ctrl_sys_variable(bool caps_lock_to_ctrl)
+{
+    auto write_command = DeprecatedString::formatted("caps_lock_to_ctrl={}", caps_lock_to_ctrl ? "1" : "0");
+    GUI::Process::spawn_or_show_error(window(), "/bin/sysctl"sv, Array { "-w", write_command.characters() });
+}
+
+ErrorOr<bool> KeyboardSettingsWidget::read_caps_lock_to_ctrl_sys_variable()
+{
+    auto file = TRY(Core::Stream::File::open("/sys/kernel/variables/caps_lock_to_ctrl"sv, Core::Stream::OpenMode::Read));
+    auto buffer = TRY(file->read_until_eof());
+    DeprecatedString contents_string((char const*)buffer.data(), buffer.size(), Chomp);
+    return contents_string == "1";
 }

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -309,6 +309,9 @@ void KeyboardSettingsWidget::set_keymaps(Vector<DeprecatedString> const& keymaps
 
 void KeyboardSettingsWidget::write_caps_lock_to_ctrl_sys_variable(bool caps_lock_to_ctrl)
 {
+    if (getuid() != 0)
+        return;
+
     auto write_command = DeprecatedString::formatted("caps_lock_to_ctrl={}", caps_lock_to_ctrl ? "1" : "0");
     GUI::Process::spawn_or_show_error(window(), "/bin/sysctl"sv, Array { "-w", write_command.characters() });
 }

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.h
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/Vector.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/CheckBox.h>
@@ -28,6 +29,9 @@ private:
 
     void set_keymaps(Vector<DeprecatedString> const& keymaps, DeprecatedString const& active_keymap);
 
+    void write_caps_lock_to_ctrl_sys_variable(bool);
+    ErrorOr<bool> read_caps_lock_to_ctrl_sys_variable();
+
     Vector<DeprecatedString> m_initial_keymap_list;
 
     DeprecatedString m_initial_active_keymap;
@@ -35,6 +39,7 @@ private:
     RefPtr<GUI::ListView> m_selected_keymaps_listview;
     RefPtr<GUI::Label> m_active_keymap_label;
     RefPtr<GUI::CheckBox> m_num_lock_checkbox;
+    RefPtr<GUI::CheckBox> m_caps_lock_checkbox;
     RefPtr<GUI::Button> m_activate_keymap_button;
     RefPtr<GUI::Button> m_add_keymap_button;
     RefPtr<GUI::Button> m_remove_keymap_button;

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -27,7 +27,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath recvfd sendfd proc exec"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin/keymap", "x"));
+    TRY(Core::System::unveil("/bin/sysctl", "x"));
     TRY(Core::System::unveil("/sys/kernel/keymap", "r"));
+    TRY(Core::System::unveil("/sys/kernel/variables/caps_lock_to_ctrl", "r"));
     TRY(Core::System::unveil("/etc/Keyboard.ini", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 


### PR DESCRIPTION
This patch adds an additional control to KeyboardSettings allowing the user to map Caps Lock to Ctrl. Previously, this was only possible by writing to /sys/kernel/variables/caps_lock_to_ctrl.

Writing to /sys/kernel/variables/caps_lock_to_ctrl requires root privileges, but KeyboardSettings will not attempt to elevate the privilege of the user if they are not root. Instead, the checkbox is rendered as un-editable.