### PR TITLE
AK: Fix build with !USING_AK_GLOBALLY (AK + Jakt Part 3 of N!)

### DIFF
--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -8,6 +8,8 @@
 
 #include "Concepts.h"
 
+namespace AK {
+
 template<Unsigned IntType>
 inline constexpr int popcount(IntType value)
 {
@@ -147,3 +149,14 @@ inline constexpr int bit_scan_forward(IntType value)
     return 1 + count_trailing_zeroes(static_cast<MakeUnsigned<IntType>>(value));
 #endif
 }
+
+}
+
+#if USING_AK_GLOBALLY
+using AK::bit_scan_forward;
+using AK::count_leading_zeroes;
+using AK::count_leading_zeroes_safe;
+using AK::count_trailing_zeroes;
+using AK::count_trailing_zeroes_safe;
+using AK::popcount;
+#endif

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -264,7 +264,6 @@ inline NonnullRefPtr<T> make_ref_counted(Args&&... args)
 {
     return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *new T { forward<Args>(args)... });
 }
-}
 
 template<typename T>
 struct Traits<NonnullRefPtr<T>> : public GenericTraits<NonnullRefPtr<T>> {
@@ -273,6 +272,8 @@ struct Traits<NonnullRefPtr<T>> : public GenericTraits<NonnullRefPtr<T>> {
     static unsigned hash(NonnullRefPtr<T> const& p) { return ptr_hash(p.ptr()); }
     static bool equals(NonnullRefPtr<T> const& a, NonnullRefPtr<T> const& b) { return a.ptr() == b.ptr(); }
 };
+
+}
 
 #if USING_AK_GLOBALLY
 using AK::adopt_ref;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -16,6 +16,8 @@
 
 #include <AK/Assertions.h>
 
+namespace AK {
+
 template<typename T, typename U>
 constexpr auto round_up_to_power_of_two(T value, U power_of_two)
 requires(AK::Detail::IsIntegral<T> && AK::Detail::IsIntegral<U>)
@@ -30,21 +32,23 @@ requires(AK::Detail::IsIntegral<T>)
     return value && !((value) & (value - 1));
 }
 
+}
+
 #ifndef AK_DONT_REPLACE_STD
 namespace std { // NOLINT(cert-dcl58-cpp) Names in std to aid tools
 
 // NOTE: These are in the "std" namespace since some compilers and static analyzers rely on it.
 
 template<typename T>
-constexpr T&& forward(RemoveReference<T>& param)
+constexpr T&& forward(AK::Detail::RemoveReference<T>& param)
 {
     return static_cast<T&&>(param);
 }
 
 template<typename T>
-constexpr T&& forward(RemoveReference<T>&& param) noexcept
+constexpr T&& forward(AK::Detail::RemoveReference<T>&& param) noexcept
 {
-    static_assert(!IsLvalueReference<T>, "Can't forward an rvalue as an lvalue.");
+    static_assert(!AK::Detail::IsLvalueReference<T>, "Can't forward an rvalue as an lvalue.");
     return static_cast<T&&>(param);
 }
 
@@ -59,8 +63,16 @@ constexpr T&& move(T& arg)
 #    include <utility>
 #endif
 
+#if !USING_AK_GLOBALLY
+namespace AK {
+#endif
+
 using std::forward;
 using std::move;
+
+#if !USING_AK_GLOBALLY
+}
+#endif
 
 namespace AK::Detail {
 template<typename T>
@@ -182,10 +194,12 @@ using AK::ceil_div;
 using AK::clamp;
 using AK::exchange;
 using AK::is_constant_evaluated;
+using AK::is_power_of_two;
 using AK::max;
 using AK::min;
 using AK::mix;
 using AK::RawPtr;
+using AK::round_up_to_power_of_two;
 using AK::swap;
 using AK::to_underlying;
 #endif


### PR DESCRIPTION
A couple headers expected names to be in the global namespace, qualify those names to make sure they're resolved even when the names are not exported.
One header placed its functions in the global namespace, move those to the AK namespace to make the concepts resolve.

Please let at least one CI pass before merging, while it did compile locally, I'm not sure if everything is okay yet.