### PR TITLE
LibThreading+Everywhere: Support returning error from `BackgroundAction`

### DIFF
--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -144,8 +144,9 @@ void FileProvider::query(DeprecatedString const& query, Function<void(NonnullRef
             }
             return results;
         },
-        [on_complete = move(on_complete)](auto results) {
+        [on_complete = move(on_complete)](auto results) -> ErrorOr<void> {
             on_complete(move(results));
+            return {};
         });
 }
 
@@ -192,8 +193,9 @@ void FileProvider::build_filesystem_cache()
             dbgln("Built cache in {} ms", timer.elapsed());
             return 0;
         },
-        [this](auto) {
+        [this](auto) -> ErrorOr<void> {
             m_building_cache = false;
+            return {};
         });
 }
 

--- a/Userland/Applications/DisplaySettings/MonitorWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.cpp
@@ -37,17 +37,19 @@ bool MonitorWidget::set_wallpaper(DeprecatedString path)
             return Gfx::Bitmap::try_load_from_file(path);
         },
 
-        [this, path](ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap_or_error) {
+        [this, path](ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap_or_error) -> ErrorOr<void> {
             // If we've been requested to change while we were loading the bitmap, don't bother spending the cost to
             // move and render the now stale bitmap.
             if (is_different_to_current_wallpaper_path(path))
-                return;
+                return {};
             if (bitmap_or_error.is_error())
                 m_wallpaper_bitmap = nullptr;
             else
                 m_wallpaper_bitmap = bitmap_or_error.release_value();
             m_desktop_dirty = true;
             update();
+
+            return bitmap_or_error.is_error() ? bitmap_or_error.release_error() : ErrorOr<void> {};
         });
 
     if (path.is_empty())

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -120,10 +120,11 @@ void ThreadStackWidget::refresh()
             return Symbolication::symbolicate_thread(pid, tid, Symbolication::IncludeSourcePosition::No);
         },
 
-        [weak_this = make_weak_ptr()](auto result) {
+        [weak_this = make_weak_ptr()](auto result) -> ErrorOr<void> {
             if (!weak_this)
-                return;
+                return {};
             Core::EventLoop::current().post_event(const_cast<Core::Object&>(*weak_this), make<CompletionEvent>(move(result)));
+            return {};
         });
 }
 

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -670,7 +670,7 @@ bool FileSystemModel::fetch_thumbnail_for(Node const& node)
             return render_thumbnail(path);
         },
 
-        [this, path, weak_this](auto thumbnail_or_error) {
+        [this, path, weak_this](auto thumbnail_or_error) -> ErrorOr<void> {
             if (thumbnail_or_error.is_error()) {
                 s_thumbnail_cache.set(path, nullptr);
                 dbgln("Failed to load thumbnail for {}: {}", path, thumbnail_or_error.error());
@@ -681,7 +681,7 @@ bool FileSystemModel::fetch_thumbnail_for(Node const& node)
             // The model was destroyed, no need to update
             // progress or call any event handlers.
             if (weak_this.is_null())
-                return;
+                return {};
 
             m_thumbnail_progress++;
             if (on_thumbnail_progress)
@@ -692,6 +692,7 @@ bool FileSystemModel::fetch_thumbnail_for(Node const& node)
             }
 
             did_update(UpdateFlag::DontInvalidateIndices);
+            return {};
         });
 
     return false;

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -53,8 +53,8 @@ TabWidget::TabWidget()
 
 ErrorOr<void> TabWidget::try_add_widget(Widget& widget)
 {
-    m_tabs.append({ widget.title(), nullptr, &widget, false });
-    add_child(widget);
+    TRY(m_tabs.try_append({ widget.title(), nullptr, &widget, false }));
+    TRY(try_add_child(widget));
     update_focus_policy();
     if (on_tab_count_change)
         on_tab_count_change(m_tabs.size());

--- a/Userland/Libraries/LibThreading/BackgroundAction.h
+++ b/Userland/Libraries/LibThreading/BackgroundAction.h
@@ -52,16 +52,21 @@ public:
     virtual ~BackgroundAction() = default;
 
 private:
-    BackgroundAction(Function<Result(BackgroundAction&)> action, Function<void(Result)> on_complete)
+    BackgroundAction(Function<Result(BackgroundAction&)> action, Function<ErrorOr<void>(Result)> on_complete, Optional<Function<void(Error)>> on_error = {})
         : Core::Object(&background_thread())
         , m_action(move(action))
         , m_on_complete(move(on_complete))
     {
+        if (on_error.has_value())
+            m_on_error = on_error.release_value();
+
         enqueue_work([this, origin_event_loop = &Core::EventLoop::current()] {
             m_result = m_action(*this);
             if (m_on_complete) {
                 origin_event_loop->deferred_invoke([this] {
-                    m_on_complete(m_result.release_value());
+                    auto maybe_error = m_on_complete(m_result.release_value());
+                    if (maybe_error.is_error())
+                        m_on_error(maybe_error.release_error());
                     remove_from_parent();
                 });
                 origin_event_loop->wake();
@@ -73,7 +78,10 @@ private:
 
     bool m_cancelled { false };
     Function<Result(BackgroundAction&)> m_action;
-    Function<void(Result)> m_on_complete;
+    Function<ErrorOr<void>(Result)> m_on_complete;
+    Function<void(Error)> m_on_error = [](Error error) {
+        dbgln("Error occurred while running a BackgroundAction: {}", error);
+    };
     Optional<Result> m_result;
 };
 


### PR DESCRIPTION
This patch allows returning an `Error` from the `on_complete` callback in `BackgroundAction`.

It also adds a custom callback to manage errors returned during its execution.