### PR TITLE
Base: Reenable the disabled LibCore::Stream tests

### DIFF
--- a/Base/home/anon/.config/Tests.ini
+++ b/Base/home/anon/.config/Tests.ini
@@ -1,7 +1,7 @@
 [Global]
 SkipDirectories=Kernel/Legacy Shell
 SkipRegex=^ue-.*$
-SkipTests=TestCommonmark TestLibCoreStream function.sh
+SkipTests=TestCommonmark function.sh
 NotTestsPattern=^.*(txt|frm|inc)$
 
 [test-js]


### PR DESCRIPTION
Got semi-yakbaited into looking into the LibCore test failures that we had on CI a few months ago, but I can't get it to flake with either local testing or with running a few rounds of CI in a fork of the repository.

Either the CI flakes have been resolved somewhere along the way, or it needs more tries to reproduce than I anticipated. In either case, needlessly stressing the CI feels like the wrong move there, so just enabling the test temporarily and disabling it again once I get a stack trace to work with (feel free to do so in case it starts flaking) seems like the better option.