### PR TITLE
SpaceAnalyzer: Do not reset the path to '/' after a refresh 

### DIFF
--- a/Userland/Applications/SpaceAnalyzer/CMakeLists.txt
+++ b/Userland/Applications/SpaceAnalyzer/CMakeLists.txt
@@ -7,6 +7,7 @@ compile_gml(SpaceAnalyzer.gml SpaceAnalyzerGML.h space_analyzer_gml)
 
 set(SOURCES
     TreeMapWidget.cpp
+    Tree.cpp
     main.cpp
 )
 

--- a/Userland/Applications/SpaceAnalyzer/Tree.cpp
+++ b/Userland/Applications/SpaceAnalyzer/Tree.cpp
@@ -5,7 +5,31 @@
  */
 
 #include "Tree.h"
+#include <AK/Function.h>
+#include <AK/HashMap.h>
+#include <AK/Queue.h>
 #include <AK/QuickSort.h>
+#include <LibCore/DirIterator.h>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static constexpr size_t FILES_ENCOUNTERED_UPDATE_STEP_SIZE = 25;
+
+long long int TreeNode::update_totals()
+{
+    long long int result = 0;
+    if (m_children) {
+        for (auto& child : *m_children) {
+            result += child.update_totals();
+        }
+        m_area = result;
+    } else {
+        result = m_area;
+    }
+    return result;
+}
 
 void TreeNode::sort_children_by_area() const
 {
@@ -13,4 +37,94 @@ void TreeNode::sort_children_by_area() const
         Vector<TreeNode>* children = const_cast<Vector<TreeNode>*>(m_children.ptr());
         quick_sort(*children, [](auto& a, auto& b) { return b.m_area < a.m_area; });
     }
+}
+
+struct QueueEntry {
+    QueueEntry(DeprecatedString path, TreeNode* node)
+        : path(move(path))
+        , node(node) {};
+    DeprecatedString path;
+    TreeNode* node { nullptr };
+};
+
+static MountInfo* find_mount_for_path(DeprecatedString path, Vector<MountInfo>& mounts)
+{
+    MountInfo* result = nullptr;
+    size_t length = 0;
+    for (auto& mount_info : mounts) {
+        DeprecatedString& mount_point = mount_info.mount_point;
+        if (path.starts_with(mount_point)) {
+            if (!result || mount_point.length() > length) {
+                result = &mount_info;
+                length = mount_point.length();
+            }
+        }
+    }
+    return result;
+}
+
+HashMap<int, int> TreeNode::populate_filesize_tree(Vector<MountInfo>& mounts, Function<void(size_t)> on_progress)
+{
+    VERIFY(!m_name.ends_with('/'));
+
+    Queue<QueueEntry> queue;
+    queue.enqueue(QueueEntry(m_name, this));
+    size_t files_encountered_count = 0;
+    HashMap<int, int> error_accumulator;
+
+    StringBuilder builder = StringBuilder();
+    builder.append(m_name);
+    builder.append('/');
+    MountInfo* root_mount_info = find_mount_for_path(builder.to_deprecated_string(), mounts);
+    if (!root_mount_info) {
+        return error_accumulator;
+    }
+    while (!queue.is_empty()) {
+        QueueEntry queue_entry = queue.dequeue();
+
+        builder.clear();
+        builder.append(queue_entry.path);
+        builder.append('/');
+
+        MountInfo* mount_info = find_mount_for_path(builder.to_deprecated_string(), mounts);
+        if (!mount_info || (mount_info != root_mount_info && mount_info->source != root_mount_info->source)) {
+            continue;
+        }
+
+        Core::DirIterator dir_iterator(builder.to_deprecated_string(), Core::DirIterator::SkipParentAndBaseDir);
+        if (dir_iterator.has_error()) {
+            int error_sum = error_accumulator.get(dir_iterator.error()).value_or(0);
+            error_accumulator.set(dir_iterator.error(), error_sum + 1);
+        } else {
+            queue_entry.node->m_children = make<Vector<TreeNode>>();
+            while (dir_iterator.has_next()) {
+                queue_entry.node->m_children->append(TreeNode(dir_iterator.next_path()));
+            }
+            for (auto& child : *queue_entry.node->m_children) {
+                files_encountered_count += 1;
+                if (!(files_encountered_count % FILES_ENCOUNTERED_UPDATE_STEP_SIZE))
+                    on_progress(files_encountered_count);
+
+                DeprecatedString& name = child.m_name;
+                int name_len = name.length();
+                builder.append(name);
+                struct stat st;
+                int stat_result = fstatat(dir_iterator.fd(), name.characters(), &st, AT_SYMLINK_NOFOLLOW);
+                if (stat_result < 0) {
+                    int error_sum = error_accumulator.get(errno).value_or(0);
+                    error_accumulator.set(errno, error_sum + 1);
+                } else {
+                    if (S_ISDIR(st.st_mode)) {
+                        queue.enqueue(QueueEntry(builder.to_deprecated_string(), &child));
+                    } else {
+                        child.m_area = st.st_size;
+                    }
+                }
+                builder.trim(name_len);
+            }
+        }
+    }
+
+    update_totals();
+    return error_accumulator;
 }

--- a/Userland/Applications/SpaceAnalyzer/Tree.cpp
+++ b/Userland/Applications/SpaceAnalyzer/Tree.cpp
@@ -128,3 +128,13 @@ HashMap<int, int> TreeNode::populate_filesize_tree(Vector<MountInfo>& mounts, Fu
     update_totals();
     return error_accumulator;
 }
+
+Optional<TreeNode const&> TreeNode::child_with_name(DeprecatedString name) const
+{
+    for (auto& child : *m_children) {
+        if (child.name() == name)
+            return child;
+    }
+
+    return {};
+}

--- a/Userland/Applications/SpaceAnalyzer/Tree.cpp
+++ b/Userland/Applications/SpaceAnalyzer/Tree.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Tree.h"
+#include <AK/QuickSort.h>
+
+void TreeNode::sort_children_by_area() const
+{
+    if (m_children) {
+        Vector<TreeNode>* children = const_cast<Vector<TreeNode>*>(m_children.ptr());
+        quick_sort(*children, [](auto& a, auto& b) { return b.m_area < a.m_area; });
+    }
+}

--- a/Userland/Applications/SpaceAnalyzer/Tree.h
+++ b/Userland/Applications/SpaceAnalyzer/Tree.h
@@ -32,6 +32,7 @@ public:
         return 0;
     }
     TreeNode const& child_at(size_t i) const { return m_children->at(i); }
+    Optional<TreeNode const&> child_with_name(DeprecatedString name) const;
     void sort_children_by_area() const;
     HashMap<int, int> populate_filesize_tree(Vector<MountInfo>& mounts, Function<void(size_t)> on_progress);
 

--- a/Userland/Applications/SpaceAnalyzer/Tree.h
+++ b/Userland/Applications/SpaceAnalyzer/Tree.h
@@ -12,7 +12,13 @@
 #include <AK/RefCounted.h>
 #include <AK/Vector.h>
 
-struct TreeNode final {
+struct MountInfo {
+    DeprecatedString mount_point;
+    DeprecatedString source;
+};
+
+class TreeNode final {
+public:
     TreeNode(DeprecatedString name)
         : m_name(move(name)) {};
 
@@ -27,19 +33,26 @@ struct TreeNode final {
     }
     TreeNode const& child_at(size_t i) const { return m_children->at(i); }
     void sort_children_by_area() const;
+    HashMap<int, int> populate_filesize_tree(Vector<MountInfo>& mounts, Function<void(size_t)> on_progress);
+
+private:
+    long long int update_totals();
 
     DeprecatedString m_name;
     i64 m_area { 0 };
     OwnPtr<Vector<TreeNode>> m_children;
 };
 
-struct Tree : public RefCounted<Tree> {
+class Tree : public RefCounted<Tree> {
+public:
     Tree(DeprecatedString root_name)
         : m_root(move(root_name)) {};
     ~Tree() {};
-    TreeNode m_root;
-    TreeNode const& root() const
+    TreeNode& root()
     {
         return m_root;
     };
+
+private:
+    TreeNode m_root;
 };

--- a/Userland/Applications/SpaceAnalyzer/Tree.h
+++ b/Userland/Applications/SpaceAnalyzer/Tree.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/DeprecatedString.h>
+#include <AK/Forward.h>
+#include <AK/OwnPtr.h>
+#include <AK/RefCounted.h>
+#include <AK/Vector.h>
+
+struct TreeNode final {
+    TreeNode(DeprecatedString name)
+        : m_name(move(name)) {};
+
+    DeprecatedString name() const { return m_name; }
+    i64 area() const { return m_area; }
+    size_t num_children() const
+    {
+        if (m_children) {
+            return m_children->size();
+        }
+        return 0;
+    }
+    TreeNode const& child_at(size_t i) const { return m_children->at(i); }
+    void sort_children_by_area() const;
+
+    DeprecatedString m_name;
+    i64 m_area { 0 };
+    OwnPtr<Vector<TreeNode>> m_children;
+};
+
+struct Tree : public RefCounted<Tree> {
+    Tree(DeprecatedString root_name)
+        : m_root(move(root_name)) {};
+    ~Tree() {};
+    TreeNode m_root;
+    TreeNode const& root() const
+    {
+        return m_root;
+    };
+};

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -36,7 +36,7 @@ static float get_normalized_aspect_ratio(float a, float b)
     }
 }
 
-static bool node_is_leaf(TreeMapNode const& node)
+static bool node_is_leaf(TreeNode const& node)
 {
     return node.num_children() == 0;
 }
@@ -46,7 +46,7 @@ bool TreeMapWidget::rect_can_contain_label(Gfx::IntRect const& rect) const
     return rect.height() >= font().presentation_size() && rect.width() > 20;
 }
 
-void TreeMapWidget::paint_cell_frame(GUI::Painter& painter, TreeMapNode const& node, Gfx::IntRect const& cell_rect, Gfx::IntRect const& inner_rect, int depth, HasLabel has_label) const
+void TreeMapWidget::paint_cell_frame(GUI::Painter& painter, TreeNode const& node, Gfx::IntRect const& cell_rect, Gfx::IntRect const& inner_rect, int depth, HasLabel has_label) const
 {
     if (cell_rect.width() <= 2 || cell_rect.height() <= 2) {
         painter.fill_rect(cell_rect, Color::Black);
@@ -102,7 +102,7 @@ void TreeMapWidget::paint_cell_frame(GUI::Painter& painter, TreeMapNode const& n
 }
 
 template<typename Function>
-void TreeMapWidget::lay_out_children(TreeMapNode const& node, Gfx::IntRect const& rect, int depth, Function callback)
+void TreeMapWidget::lay_out_children(TreeNode const& node, Gfx::IntRect const& rect, int depth, Function callback)
 {
     if (node.num_children() == 0) {
         return;
@@ -215,11 +215,11 @@ void TreeMapWidget::lay_out_children(TreeMapNode const& node, Gfx::IntRect const
     }
 }
 
-TreeMapNode const* TreeMapWidget::path_node(size_t n) const
+TreeNode const* TreeMapWidget::path_node(size_t n) const
 {
     if (!m_tree.ptr())
         return nullptr;
-    TreeMapNode const* iter = &m_tree->root();
+    TreeNode const* iter = &m_tree->root();
     size_t path_index = 0;
     while (iter && path_index < m_path.size() && path_index < n) {
         size_t child_index = m_path[path_index];
@@ -239,13 +239,13 @@ void TreeMapWidget::paint_event(GUI::PaintEvent& event)
 
     m_selected_node_cache = path_node(m_path.size());
 
-    TreeMapNode const* node = path_node(m_viewpoint);
+    TreeNode const* node = path_node(m_viewpoint);
     if (!node) {
         painter.fill_rect(frame_inner_rect(), Color::MidGray);
     } else if (node_is_leaf(*node)) {
         paint_cell_frame(painter, *node, frame_inner_rect(), Gfx::IntRect(), m_viewpoint - 1, HasLabel::Yes);
     } else {
-        lay_out_children(*node, frame_inner_rect(), m_viewpoint, [&](TreeMapNode const& node, int, Gfx::IntRect const& rect, Gfx::IntRect const& inner_rect, int depth, HasLabel has_label, IsRemainder remainder) {
+        lay_out_children(*node, frame_inner_rect(), m_viewpoint, [&](TreeNode const& node, int, Gfx::IntRect const& rect, Gfx::IntRect const& inner_rect, int depth, HasLabel has_label, IsRemainder remainder) {
             if (remainder == IsRemainder::No) {
                 paint_cell_frame(painter, node, rect, inner_rect, depth, has_label);
             } else {
@@ -261,12 +261,12 @@ void TreeMapWidget::paint_event(GUI::PaintEvent& event)
 
 Vector<int> TreeMapWidget::path_to_position(Gfx::IntPoint position)
 {
-    TreeMapNode const* node = path_node(m_viewpoint);
+    TreeNode const* node = path_node(m_viewpoint);
     if (!node) {
         return {};
     }
     Vector<int> path;
-    lay_out_children(*node, frame_inner_rect(), m_viewpoint, [&](TreeMapNode const&, int index, Gfx::IntRect const& rect, Gfx::IntRect const&, int, HasLabel, IsRemainder is_remainder) {
+    lay_out_children(*node, frame_inner_rect(), m_viewpoint, [&](TreeNode const&, int index, Gfx::IntRect const& rect, Gfx::IntRect const&, int, HasLabel, IsRemainder is_remainder) {
         if (is_remainder == IsRemainder::No && rect.contains(position)) {
             path.append(index);
         }
@@ -283,7 +283,7 @@ void TreeMapWidget::mousemove_event(GUI::MouseEvent& event)
     }
 
     auto* hovered_node = node;
-    lay_out_children(*node, frame_inner_rect(), m_viewpoint, [&](TreeMapNode const&, int index, Gfx::IntRect const& rect, Gfx::IntRect const&, int, HasLabel, IsRemainder is_remainder) {
+    lay_out_children(*node, frame_inner_rect(), m_viewpoint, [&](TreeNode const&, int index, Gfx::IntRect const& rect, Gfx::IntRect const&, int, HasLabel, IsRemainder is_remainder) {
         if (is_remainder == IsRemainder::No && rect.contains(event.position())) {
             hovered_node = &hovered_node->child_at(index);
         }
@@ -294,7 +294,7 @@ void TreeMapWidget::mousemove_event(GUI::MouseEvent& event)
 
 void TreeMapWidget::mousedown_event(GUI::MouseEvent& event)
 {
-    TreeMapNode const* node = path_node(m_viewpoint);
+    TreeNode const* node = path_node(m_viewpoint);
     if (node && !node_is_leaf(*node)) {
         Vector<int> path = path_to_position(event.position());
         if (!path.is_empty()) {
@@ -312,7 +312,7 @@ void TreeMapWidget::doubleclick_event(GUI::MouseEvent& event)
 {
     if (event.button() != GUI::MouseButton::Primary)
         return;
-    TreeMapNode const* node = path_node(m_viewpoint);
+    TreeNode const* node = path_node(m_viewpoint);
     if (node && !node_is_leaf(*node)) {
         Vector<int> path = path_to_position(event.position());
         m_path.shrink(m_viewpoint);
@@ -355,7 +355,7 @@ void TreeMapWidget::context_menu_event(GUI::ContextMenuEvent& context_menu_event
         on_context_menu_request(context_menu_event);
 }
 
-void TreeMapWidget::set_tree(RefPtr<TreeMap> tree)
+void TreeMapWidget::set_tree(RefPtr<Tree> tree)
 {
     m_tree = tree;
     m_path.clear();

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -357,11 +357,27 @@ void TreeMapWidget::context_menu_event(GUI::ContextMenuEvent& context_menu_event
         on_context_menu_request(context_menu_event);
 }
 
+void TreeMapWidget::recalculate_path_for_new_tree()
+{
+    TreeNode const* current = &m_tree->root();
+    size_t new_path_length = 0;
+    for (auto& segment : m_path) {
+        auto maybe_child = current->child_with_name(segment);
+        if (!maybe_child.has_value())
+            break;
+        new_path_length++;
+        current = &maybe_child.release_value();
+    }
+    m_path.shrink(new_path_length);
+    if (new_path_length < m_viewpoint)
+        m_viewpoint = new_path_length - 1;
+}
+
 void TreeMapWidget::set_tree(RefPtr<Tree> tree)
 {
     m_tree = tree;
-    m_path.clear();
-    m_viewpoint = 0;
+    recalculate_path_for_new_tree();
+
     if (on_path_change) {
         on_path_change();
     }

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.h
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Tree.h"
+#include <AK/DeprecatedString.h>
 #include <LibGUI/Frame.h>
 #include <LibGfx/Rect.h>
 
@@ -49,10 +50,10 @@ private:
     template<typename Function>
     void lay_out_children(TreeNode const&, Gfx::IntRect const&, int depth, Function);
     void paint_cell_frame(GUI::Painter&, TreeNode const&, Gfx::IntRect const&, Gfx::IntRect const&, int depth, HasLabel has_label) const;
-    Vector<int> path_to_position(Gfx::IntPoint);
+    Vector<DeprecatedString> path_to_position(Gfx::IntPoint);
 
     RefPtr<Tree> m_tree;
-    Vector<int> m_path;
+    Vector<DeprecatedString> m_path;
     size_t m_viewpoint { 0 };
     void const* m_selected_node_cache;
 };

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.h
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.h
@@ -6,26 +6,11 @@
 
 #pragma once
 
+#include "Tree.h"
 #include <LibGUI/Frame.h>
 #include <LibGfx/Rect.h>
 
 namespace SpaceAnalyzer {
-
-struct TreeMapNode {
-    virtual DeprecatedString name() const = 0;
-    virtual i64 area() const = 0;
-    virtual size_t num_children() const = 0;
-    virtual TreeMapNode const& child_at(size_t i) const = 0;
-    virtual void sort_children_by_area() const = 0;
-
-protected:
-    virtual ~TreeMapNode() = default;
-};
-
-struct TreeMap : public RefCounted<TreeMap> {
-    virtual ~TreeMap() = default;
-    virtual TreeMapNode const& root() const = 0;
-};
 
 class TreeMapWidget final : public GUI::Frame {
     C_OBJECT(TreeMapWidget)
@@ -35,10 +20,10 @@ public:
     Function<void()> on_path_change;
     Function<void(GUI::ContextMenuEvent&)> on_context_menu_request;
     size_t path_size() const;
-    TreeMapNode const* path_node(size_t n) const;
+    TreeNode const* path_node(size_t n) const;
     size_t viewpoint() const;
     void set_viewpoint(size_t);
-    void set_tree(RefPtr<TreeMap> tree);
+    void set_tree(RefPtr<Tree> tree);
 
 private:
     TreeMapWidget() = default;
@@ -62,11 +47,11 @@ private:
     };
 
     template<typename Function>
-    void lay_out_children(TreeMapNode const&, Gfx::IntRect const&, int depth, Function);
-    void paint_cell_frame(GUI::Painter&, TreeMapNode const&, Gfx::IntRect const&, Gfx::IntRect const&, int depth, HasLabel has_label) const;
+    void lay_out_children(TreeNode const&, Gfx::IntRect const&, int depth, Function);
+    void paint_cell_frame(GUI::Painter&, TreeNode const&, Gfx::IntRect const&, Gfx::IntRect const&, int depth, HasLabel has_label) const;
     Vector<int> path_to_position(Gfx::IntPoint);
 
-    RefPtr<TreeMap> m_tree;
+    RefPtr<Tree> m_tree;
     Vector<int> m_path;
     size_t m_viewpoint { 0 };
     void const* m_selected_node_cache;

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.h
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.h
@@ -51,6 +51,7 @@ private:
     void lay_out_children(TreeNode const&, Gfx::IntRect const&, int depth, Function);
     void paint_cell_frame(GUI::Painter&, TreeNode const&, Gfx::IntRect const&, Gfx::IntRect const&, int depth, HasLabel has_label) const;
     Vector<DeprecatedString> path_to_position(Gfx::IntPoint);
+    void recalculate_path_for_new_tree();
 
     RefPtr<Tree> m_tree;
     Vector<DeprecatedString> m_path;

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -183,7 +183,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto& file_menu = window->add_menu("&File");
     file_menu.add_action(GUI::Action::create("&Analyze", [&](auto&) {
-        if (auto result = analyze(tree, treemapwidget, statusbar); result.is_error()) {
+        // FIXME: Just modify the tree in memory instead of traversing the entire file system
+        // FIXME: Dispose of the old tree
+        auto new_tree = adopt_ref(*new Tree(""));
+        if (auto result = analyze(new_tree, treemapwidget, statusbar); result.is_error()) {
             GUI::MessageBox::show_error(window, DeprecatedString::formatted("{}", result.error()));
         }
     }));
@@ -237,9 +240,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
         }
 
-        // TODO: Refreshing data always causes resetting the viewport back to "/".
-        // It would be great if we found a way to preserve viewport across refreshes.
-        if (auto result = analyze(tree, treemapwidget, statusbar); result.is_error()) {
+        // FIXME: Dispose of the old tree
+        auto new_tree = adopt_ref(*new Tree(""));
+        if (auto result = analyze(new_tree, treemapwidget, statusbar); result.is_error()) {
             GUI::MessageBox::show_error(window, DeprecatedString::formatted("{}", result.error()));
         }
     });

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "Tree.h"
 #include "TreeMapWidget.h"
 #include <AK/Error.h>
 #include <AK/LexicalPath.h>
@@ -37,44 +38,6 @@
 
 static constexpr auto APP_NAME = "Space Analyzer"sv;
 static constexpr size_t FILES_ENCOUNTERED_UPDATE_STEP_SIZE = 25;
-
-struct TreeNode : public SpaceAnalyzer::TreeMapNode {
-    TreeNode(DeprecatedString name)
-        : m_name(move(name)) {};
-
-    virtual DeprecatedString name() const override { return m_name; }
-    virtual i64 area() const override { return m_area; }
-    virtual size_t num_children() const override
-    {
-        if (m_children) {
-            return m_children->size();
-        }
-        return 0;
-    }
-    virtual TreeNode const& child_at(size_t i) const override { return m_children->at(i); }
-    virtual void sort_children_by_area() const override
-    {
-        if (m_children) {
-            Vector<TreeNode>* children = const_cast<Vector<TreeNode>*>(m_children.ptr());
-            quick_sort(*children, [](auto& a, auto& b) { return b.m_area < a.m_area; });
-        }
-    }
-
-    DeprecatedString m_name;
-    i64 m_area { 0 };
-    OwnPtr<Vector<TreeNode>> m_children;
-};
-
-struct Tree : public SpaceAnalyzer::TreeMap {
-    Tree(DeprecatedString root_name)
-        : m_root(move(root_name)) {};
-    virtual ~Tree() {};
-    TreeNode m_root;
-    virtual SpaceAnalyzer::TreeMapNode const& root() const override
-    {
-        return m_root;
-    };
-};
 
 struct MountInfo {
     DeprecatedString mount_point;
@@ -301,7 +264,7 @@ static DeprecatedString get_absolute_path_to_selected_node(SpaceAnalyzer::TreeMa
         if (k != 0) {
             path_builder.append('/');
         }
-        SpaceAnalyzer::TreeMapNode const* node = treemapwidget.path_node(k);
+        TreeNode const* node = treemapwidget.path_node(k);
         path_builder.append(node->name());
     }
     return path_builder.build();
@@ -416,7 +379,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 continue;
             }
 
-            const SpaceAnalyzer::TreeMapNode* node = treemapwidget.path_node(k);
+            const TreeNode* node = treemapwidget.path_node(k);
 
             builder.append('/');
             builder.append(node->name());


### PR DESCRIPTION
This needed quite a bit of editing before being able to fix the problem. By the way, the code in SpaceAnalyzer was (and still is) littered with inefficient resource usage, unsafe code and a general lack of error handling. It requires more work to get up to the standards of the rest of the codebase