### PR TITLE
LibWeb: Cloning and comparing Attr and ProcessingInstruction DOM nodes

### DIFF
--- a/Base/res/html/tests/Attr-cloneNode.html
+++ b/Base/res/html/tests/Attr-cloneNode.html
@@ -1,0 +1,38 @@
+<html>
+<body>
+  <pre id="out"></pre>
+  <script>
+    function log(s) {
+      document.getElementById("out").innerHTML += s + "\n"
+    }
+
+    window.onload = function() {
+      let e = document.createElement("div")
+      e.setAttribute("foo", "bar")
+      let attr = e.getAttributeNode("foo")
+      let clone = attr.cloneNode()
+
+      function dumpAttr(name, attr) {
+        log(name + ": " + attr)
+        log(name + ".ownerElement: " + attr.ownerElement)
+        log(name + ".namespaceURI: " + attr.namespaceURI)
+        log(name + ".localName: " + attr.localName)
+        log(name + ".name: " + attr.name)
+        log(name + ".value: " + attr.value)
+        log(name + ".specified: " + attr.specified)
+        log("")
+      }
+
+      dumpAttr("attr", attr)
+      dumpAttr("clone", clone)
+
+      log("attr === clone -> " + (attr === clone))
+      log("attr.isEqualNode(clone) -> " + attr.isEqualNode(clone))
+
+      e.setAttribute("baz", "bux")
+      let other = e.getAttributeNode("baz")
+      log("attr.isEqualNode(other) -> " + attr.isEqualNode(other))
+    }
+  </script>
+</body>
+</html>

--- a/Base/res/html/tests/ProcessingInstruction-cloneNode.html
+++ b/Base/res/html/tests/ProcessingInstruction-cloneNode.html
@@ -1,0 +1,31 @@
+<html>
+<body>
+  <pre id="out"></pre>
+  <script>
+    function log(s) {
+      document.getElementById("out").innerHTML += s + "\n"
+    }
+
+    window.onload = function() {
+      let pi = document.createProcessingInstruction("someTarget", "someData")
+      let clone = pi.cloneNode()
+
+      function dumpProcessingInstruction(name, pi) {
+        log(name + ": " + pi)
+        log(name + ".target: " + pi.target)
+        log(name + ".data: " + pi.data)
+        log("")
+      }
+
+      dumpProcessingInstruction("pi", pi)
+      dumpProcessingInstruction("clone", clone)
+
+      log("pi === clone -> " + (pi === clone))
+      log("pi.isEqualNode(clone) -> " + pi.isEqualNode(clone))
+
+      let other = document.createProcessingInstruction("baz", "bux")
+      log("pi.isEqualNode(other) -> " + pi.isEqualNode(other))
+    }
+  </script>
+</body>
+</html>

--- a/Userland/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attr.cpp
@@ -15,12 +15,17 @@ namespace Web::DOM {
 
 JS::NonnullGCPtr<Attr> Attr::create(Document& document, FlyString local_name, DeprecatedString value, Element const* owner_element)
 {
-    return *document.heap().allocate<Attr>(document.realm(), document, move(local_name), move(value), owner_element);
+    return *document.heap().allocate<Attr>(document.realm(), document, QualifiedName(move(local_name), {}, {}), move(value), owner_element);
 }
 
-Attr::Attr(Document& document, FlyString local_name, DeprecatedString value, Element const* owner_element)
+JS::NonnullGCPtr<Attr> Attr::clone(Document& document)
+{
+    return *heap().allocate<Attr>(realm(), document, m_qualified_name, m_value, nullptr);
+}
+
+Attr::Attr(Document& document, QualifiedName qualified_name, DeprecatedString value, Element const* owner_element)
     : Node(document, NodeType::ATTRIBUTE_NODE)
-    , m_qualified_name(move(local_name), {}, {})
+    , m_qualified_name(move(qualified_name))
     , m_value(move(value))
     , m_owner_element(owner_element)
 {

--- a/Userland/Libraries/LibWeb/DOM/Attr.h
+++ b/Userland/Libraries/LibWeb/DOM/Attr.h
@@ -19,6 +19,7 @@ class Attr final : public Node {
 
 public:
     static JS::NonnullGCPtr<Attr> create(Document&, FlyString local_name, DeprecatedString value, Element const* = nullptr);
+    JS::NonnullGCPtr<Attr> clone(Document&);
 
     virtual ~Attr() override = default;
 
@@ -42,7 +43,7 @@ public:
     void handle_attribute_changes(Element&, DeprecatedString const& old_value, DeprecatedString const& new_value);
 
 private:
-    Attr(Document&, FlyString local_name, DeprecatedString value, Element const*);
+    Attr(Document&, QualifiedName, DeprecatedString value, Element const*);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -29,6 +29,7 @@
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/DOM/NodeIterator.h>
+#include <LibWeb/DOM/ProcessingInstruction.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
@@ -1231,6 +1232,17 @@ JS::NonnullGCPtr<Text> Document::create_text_node(DeprecatedString const& data)
 JS::NonnullGCPtr<Comment> Document::create_comment(DeprecatedString const& data)
 {
     return *heap().allocate<Comment>(realm(), *this, data);
+}
+
+// https://dom.spec.whatwg.org/#dom-document-createprocessinginstruction
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ProcessingInstruction>> Document::create_processing_instruction(DeprecatedString const& target, DeprecatedString const& data)
+{
+    // FIXME: 1. If target does not match the Name production, then throw an "InvalidCharacterError" DOMException.
+
+    // FIXME: 2. If data contains the string "?>", then throw an "InvalidCharacterError" DOMException.
+
+    // 3. Return a new ProcessingInstruction node, with target set to target, data set to data, and node document set to this.
+    return JS::NonnullGCPtr { *heap().allocate<ProcessingInstruction>(realm(), *this, data, target) };
 }
 
 JS::NonnullGCPtr<Range> Document::create_range()

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -227,6 +227,8 @@ public:
     JS::NonnullGCPtr<DocumentFragment> create_document_fragment();
     JS::NonnullGCPtr<Text> create_text_node(DeprecatedString const& data);
     JS::NonnullGCPtr<Comment> create_comment(DeprecatedString const& data);
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<ProcessingInstruction>> create_processing_instruction(DeprecatedString const& target, DeprecatedString const& data);
+
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> create_event(DeprecatedString const& interface);
     JS::NonnullGCPtr<Range> create_range();
 

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -12,6 +12,7 @@
 #import <DOM/NodeIterator.idl>
 #import <DOM/NodeList.idl>
 #import <DOM/ParentNode.idl>
+#import <DOM/ProcessingInstruction.idl>
 #import <DOM/Range.idl>
 #import <DOM/Text.idl>
 #import <DOM/TreeWalker.idl>
@@ -78,6 +79,8 @@ interface Document : Node {
     DocumentFragment createDocumentFragment();
     Text createTextNode(DOMString data);
     Comment createComment(DOMString data);
+    [NewObject] ProcessingInstruction createProcessingInstruction(DOMString target, DOMString data);
+
     Range createRange();
     Event createEvent(DOMString interface);
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1274,8 +1274,16 @@ bool Node::is_equal_node(Node const* other_node) const
             return false;
         break;
     }
-    case (u16)NodeType::PROCESSING_INSTRUCTION_NODE:
-        TODO();
+    case (u16)NodeType::PROCESSING_INSTRUCTION_NODE: {
+        // Its target and data.
+        auto& this_processing_instruction = verify_cast<ProcessingInstruction>(*this);
+        auto& other_processing_instruction = verify_cast<ProcessingInstruction>(*other_node);
+        if (this_processing_instruction.target() != other_processing_instruction.target())
+            return false;
+        if (this_processing_instruction.data() != other_processing_instruction.data())
+            return false;
+        break;
+    }
     default:
         break;
     }

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -750,10 +750,10 @@ JS::NonnullGCPtr<Node> Node::clone_node(Document* document, bool clone_children)
         document_type_copy->set_system_id(document_type->system_id());
         copy = move(document_type_copy);
     } else if (is<Attr>(this)) {
-        // FIXME:
         // Attr
         // Set copy’s namespace, namespace prefix, local name, and value to those of node.
-        dbgln("clone_node() not implemented for Attribute");
+        auto& attr = static_cast<Attr&>(*this);
+        copy = attr.clone(*document);
     } else if (is<Text>(this)) {
         // Text
         auto text = verify_cast<Text>(this);

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1262,8 +1262,19 @@ bool Node::is_equal_node(Node const* other_node) const
             return false;
         break;
     }
+    case (u16)NodeType::ATTRIBUTE_NODE: {
+        // Its namespace, local name, and value.
+        auto& this_attr = verify_cast<Attr>(*this);
+        auto& other_attr = verify_cast<Attr>(*other_node);
+        if (this_attr.namespace_uri() != other_attr.namespace_uri())
+            return false;
+        if (this_attr.local_name() != other_attr.local_name())
+            return false;
+        if (this_attr.value() != other_attr.value())
+            return false;
+        break;
+    }
     case (u16)NodeType::PROCESSING_INSTRUCTION_NODE:
-    case (u16)NodeType::ATTRIBUTE_NODE:
         TODO();
     default:
         break;

--- a/Userland/Libraries/LibWeb/DOM/ProcessingInstruction.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ProcessingInstruction.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ProcessingInstruction.h>
 #include <LibWeb/Layout/TextNode.h>
 
@@ -13,6 +15,7 @@ ProcessingInstruction::ProcessingInstruction(Document& document, DeprecatedStrin
     : CharacterData(document, NodeType::PROCESSING_INSTRUCTION_NODE, data)
     , m_target(target)
 {
+    set_prototype(&Bindings::cached_web_prototype(document.realm(), "ProcessingInstruction"));
 }
 
 }


### PR DESCRIPTION
This PR adds support for `Node.cloneNode()` and `Node.isEqualNode()` on `Attr` and `ProcessingInstruction` DOM nodes.

I also had to add `Document.createProcessingInstruction()` to be able to test the `ProcessingInstruction` changes.