### PR TITLE
LibJS+LibUnicode: Unbreak support for UCD/CLDR/TZDB downloads being disabled

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -432,7 +432,9 @@ if (BUILD_LAGOM)
     # FIXME: LibLocaleData is an object lib in Lagom, because the weak symbol trick we use on serenity
     #    straight up isn't supposed to work per ELF rules
     target_link_libraries(LibLocale PRIVATE LibTimeZone)
-    install(TARGETS LibLocaleData EXPORT LagomTargets)
+    if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
+        install(TARGETS LibLocaleData EXPORT LagomTargets)
+    endif()
 
     add_serenity_subdirectory(Userland/Shell)
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -169,8 +169,10 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
     auto default_hour_cycle = ::Locale::get_default_regional_hour_cycle(data_locale);
 
     // Non-standard, default_hour_cycle will be empty if Unicode data generation is disabled.
-    if (!default_hour_cycle.has_value())
+    if (!default_hour_cycle.has_value()) {
+        date_time_format.set_time_zone(default_time_zone());
         return &date_time_format;
+    }
 
     Optional<::Locale::HourCycle> hour_cycle_value;
 


### PR DESCRIPTION
The general idea with these being off has been that you'll get obviously wrong / default values from the APIs, but we should be able to compile and run without crashing.