### PR TITLE
LibJS: Explictly assert that a null GCPtr is not dereferenced

### DIFF
--- a/Userland/Libraries/LibJS/Heap/GCPtr.h
+++ b/Userland/Libraries/LibJS/Heap/GCPtr.h
@@ -52,6 +52,7 @@ public:
     NonnullGCPtr& operator=(GCPtr<T> const& other)
     {
         m_ptr = const_cast<T*>(other.ptr());
+        VERIFY(m_ptr);
         return *this;
     }
 
@@ -186,8 +187,18 @@ public:
         return *this;
     }
 
-    T* operator->() const { return m_ptr; }
-    T& operator*() const { return *m_ptr; }
+    T* operator->() const
+    {
+        VERIFY(m_ptr);
+        return m_ptr;
+    }
+
+    T& operator*() const
+    {
+        VERIFY(m_ptr);
+        return *m_ptr;
+    }
+
     T* ptr() const { return m_ptr; }
 
     operator bool() const { return !!m_ptr; }


### PR DESCRIPTION
No crashes found with test-js or by browsing a bunch of web pages. We *do* crash on the following:
```html
<html>
<body foo="bar">
<script type="text/javascript">
    let foo = document.body.getAttributeNode("foo");
    console.log(foo);

    let clone = foo.cloneNode();
    console.log(clone);
</script>
</body>
</html>
```

Which is the case that caught this error to begin with and should be fixed by #16469.