### PR TITLE
PixelPaint: Add background color options to "new image" dialog

### DIFF
--- a/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
@@ -1,14 +1,19 @@
 /*
  * Copyright (c) 2020, Ben Jilks <benjyjilks@gmail.com>
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "CreateNewImageDialog.h"
+#include <AK/Array.h>
 #include <LibConfig/Client.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/CheckBox.h>
+#include <LibGUI/ColorInput.h>
+#include <LibGUI/ComboBox.h>
+#include <LibGUI/ItemListModel.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/SpinBox.h>
 #include <LibGUI/TextBox.h>
@@ -48,6 +53,63 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
 
     auto& height_spinbox = main_widget.add<GUI::SpinBox>();
 
+    enum class BackgroundIndex {
+        Transparent = 0,
+        White,
+        Black,
+        Custom
+    };
+
+    static constexpr AK::Array suggested_backgrounds = {
+        "Transparent"sv,
+        "White"sv,
+        "Black"sv,
+        "Custom"sv
+    };
+
+    m_background_color = Color::from_string(
+        Config::read_string("PixelPaint"sv, "NewImage"sv, "Background"sv))
+                             .value_or(Color::Transparent);
+
+    auto selected_background_index = [&] {
+        if (m_background_color == Gfx::Color::Transparent)
+            return BackgroundIndex::Transparent;
+        if (m_background_color == Gfx::Color::White)
+            return BackgroundIndex::White;
+        if (m_background_color == Gfx::Color::Black)
+            return BackgroundIndex::Black;
+        return BackgroundIndex::Custom;
+    }();
+
+    auto& background_label = main_widget.add<GUI::Label>("Background:");
+    background_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    auto& background_color_combo = main_widget.add<GUI::ComboBox>();
+    auto& background_color_input = main_widget.add<GUI::ColorInput>();
+    background_color_input.set_visible(false);
+    background_color_combo.set_only_allow_values_from_model(true);
+    background_color_combo.set_model(*GUI::ItemListModel<StringView, decltype(suggested_backgrounds)>::create(suggested_backgrounds));
+    background_color_combo.on_change = [&](auto&, const GUI::ModelIndex& index) {
+        auto background_index = static_cast<BackgroundIndex>(index.row());
+        m_background_color = [&]() -> Gfx::Color {
+            switch (background_index) {
+            case BackgroundIndex::Transparent:
+                return Gfx::Color::Transparent;
+            case BackgroundIndex::White:
+                return Gfx::Color::White;
+            case BackgroundIndex::Black:
+                return Gfx::Color::Black;
+            default:
+                return m_background_color;
+            }
+        }();
+        background_color_input.set_color(m_background_color);
+        background_color_input.set_visible(background_index == BackgroundIndex::Custom);
+    };
+    background_color_combo.set_selected_index(to_underlying(selected_background_index));
+    background_color_input.on_change = [&] {
+        m_background_color = background_color_input.color();
+    };
+
     auto& set_defaults_checkbox = main_widget.add<GUI::CheckBox>();
     set_defaults_checkbox.set_text("Use these settings as default");
 
@@ -60,6 +122,7 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
             Config::write_string("PixelPaint"sv, "NewImage"sv, "Name"sv, m_image_name);
             Config::write_i32("PixelPaint"sv, "NewImage"sv, "Width"sv, m_image_size.width());
             Config::write_i32("PixelPaint"sv, "NewImage"sv, "Height"sv, m_image_size.height());
+            Config::write_string("PixelPaint"sv, "NewImage"sv, "Background"sv, m_background_color.to_deprecated_string());
         }
 
         done(ExecResult::OK);

--- a/Userland/Applications/PixelPaint/CreateNewImageDialog.h
+++ b/Userland/Applications/PixelPaint/CreateNewImageDialog.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGUI/Dialog.h>
+#include <LibGfx/Color.h>
 
 namespace PixelPaint {
 
@@ -16,12 +17,14 @@ class CreateNewImageDialog final : public GUI::Dialog {
 public:
     Gfx::IntSize image_size() const { return m_image_size; }
     DeprecatedString const& image_name() const { return m_image_name; }
+    Gfx::Color background_color() const { return m_background_color; }
 
 private:
     CreateNewImageDialog(GUI::Window* parent_window);
 
     DeprecatedString m_image_name;
     Gfx::IntSize m_image_size;
+    Gfx::Color m_background_color {};
 
     RefPtr<GUI::TextBox> m_name_textbox;
 };

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -159,7 +159,9 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 auto image = PixelPaint::Image::try_create_with_size(dialog->image_size()).release_value_but_fixme_should_propagate_errors();
                 auto bg_layer = PixelPaint::Layer::try_create_with_size(*image, image->size(), "Background").release_value_but_fixme_should_propagate_errors();
                 image->add_layer(*bg_layer);
-                bg_layer->content_bitmap().fill(Color::White);
+                auto background_color = dialog->background_color();
+                if (background_color != Gfx::Color::Transparent)
+                    bg_layer->content_bitmap().fill(background_color);
 
                 auto& editor = create_new_editor(*image);
                 auto image_title = dialog->image_name().trim_whitespace();


### PR DESCRIPTION
This now allows you to select a background color for your new image, and optionally allows saving that default. You can pick between Transparent, White, Black, or a custom color (similar to other editors).

[screen-capture - 2022-12-13T235910.283.webm](https://user-images.githubusercontent.com/11597044/207471267-89498cda-5a74-4758-863b-d8a3983da31a.webm)

This also fixes a little thing that was slightly inconsistent, before "New Image" would always create an image with a white background (whereas opening pixel paint would default to a transparent background).