### PR TITLE
CMake: Pass NO_POLICY_SCOPE to options cmake helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if(NOT COMMAND serenity_option)
         set(${ARGV})
     endmacro()
 endif()
-include(serenity_options)
+include(serenity_options NO_POLICY_SCOPE)
 
 include(setup_ccache)
 

--- a/Meta/CMake/lagom_options.cmake
+++ b/Meta/CMake/lagom_options.cmake
@@ -2,7 +2,7 @@
 # Options specific to the Lagom (host) build
 #
 
-include(${CMAKE_CURRENT_LIST_DIR}/common_options.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/common_options.cmake NO_POLICY_SCOPE)
 
 serenity_option(ENABLE_ADDRESS_SANITIZER OFF CACHE BOOL "Enable address sanitizer testing in gcc/clang")
 serenity_option(ENABLE_MEMORY_SANITIZER OFF CACHE BOOL "Enable memory sanitizer testing in gcc/clang")

--- a/Meta/CMake/serenity_options.cmake
+++ b/Meta/CMake/serenity_options.cmake
@@ -2,7 +2,7 @@
 # Options specific to the Serenity (target) build
 #
 
-include(${CMAKE_CURRENT_LIST_DIR}/common_options.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/common_options.cmake NO_POLICY_SCOPE)
 
 serenity_option(ENABLE_PCI_IDS_DOWNLOAD ON CACHE BOOL "Enable download of the pci.ids database at build time")
 serenity_option(ENABLE_USB_IDS_DOWNLOAD ON CACHE BOOL "Enable download of the usb.ids database at build time")

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -34,7 +34,7 @@ if(NOT COMMAND serenity_option)
 endif()
 
 include(check_for_dependencies)
-include(lagom_options)
+include(lagom_options NO_POLICY_SCOPE)
 
 if(ENABLE_ALL_THE_DEBUG_MACROS)
     include(all_the_debug_macros)


### PR DESCRIPTION
Tell CMake to not create a new policy scope for the (lagom|serenity|common)_options.cmake helpers, and lets us set common policies for both projects in common_options.cmake that actually apply to the rest of the project, instead of just common_options.cmake itself.