### PR TITLE
AK: Bring back the AK_DONT_REPLACE_STD #define

### DIFF
--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -34,7 +34,7 @@ requires(AK::Detail::IsIntegral<T>)
 
 }
 
-#if !USING_AK_GLOBALLY
+#if !USING_AK_GLOBALLY || defined(AK_DONT_REPLACE_STD)
 #    define AK_REPLACED_STD_NAMESPACE AK::replaced_std
 #else
 #    define AK_REPLACED_STD_NAMESPACE std


### PR DESCRIPTION
This was removed in a910961f37d1da9dafb6385e348266746354cf98 in favour of the more general USING_AK_GLOBALLY #define, but Ladybird (and probably other projects) depend on the smaller hammer to include STL headers and keep the USING_AK_GLOBALLY behaviour, so put it back and preserve its behaviour.