### PR TITLE
LibSQL: Convert string values to a double in a locale-independent manner

### DIFF
--- a/Userland/Libraries/LibSQL/Value.cpp
+++ b/Userland/Libraries/LibSQL/Value.cpp
@@ -231,14 +231,7 @@ Optional<double> Value::to_double() const
         return {};
 
     return m_value->visit(
-        [](DeprecatedString const& value) -> Optional<double> {
-            char* end = nullptr;
-            double result = strtod(value.characters(), &end);
-
-            if (end == value.characters())
-                return {};
-            return result;
-        },
+        [](DeprecatedString const& value) -> Optional<double> { return value.to_double(); },
         [](Integer auto value) -> Optional<double> { return static_cast<double>(value); },
         [](double value) -> Optional<double> { return value; },
         [](bool value) -> Optional<double> { return static_cast<double>(value); },


### PR DESCRIPTION
This currently uses strtod, which is locale-dependent. Use the locale- independent method added in 65ee9b4134225398f0a5109eb79b0baba98c9cd6.