### PR TITLE
LauncherServer+FileManager: Improve error handling in /proc folders

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -102,6 +102,8 @@ void DirectoryView::handle_activation(GUI::ModelIndex const& index)
     struct stat st;
     if (stat(path.characters(), &st) < 0) {
         perror("stat");
+        auto error_message = DeprecatedString::formatted("Could not stat {}: {}", path, strerror(errno));
+        GUI::MessageBox::show(window(), error_message, "File Manager"sv, GUI::MessageBox::Type::Error);
         return;
     }
 

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -309,8 +309,10 @@ void Launcher::for_each_handler_for_path(DeprecatedString const& path, Function<
 
     if (S_ISLNK(st.st_mode)) {
         auto link_target_or_error = Core::File::read_link(path);
-        if (link_target_or_error.is_error())
+        if (link_target_or_error.is_error()) {
             perror("read_link");
+            return;
+        }
 
         auto link_target = LexicalPath { link_target_or_error.release_value() };
         LexicalPath absolute_link_target = link_target.is_absolute() ? link_target : LexicalPath::join(LexicalPath::dirname(path), link_target.string());


### PR DESCRIPTION
- LaunchServer: Return if read_link fails in for_each_handler_for_path
- FileManager: Display message box if stat()'ing a file to activate fails
