### PR TITLE
Userland: Call `event.ignore()` for keydown events in a bunch of applications

### DIFF
--- a/Userland/Applications/Piano/MainWidget.h
+++ b/Userland/Applications/Piano/MainWidget.h
@@ -39,8 +39,8 @@ private:
     virtual void keyup_event(GUI::KeyEvent&) override;
     virtual void custom_event(Core::CustomEvent&) override;
 
-    void note_key_action(int key_code, DSP::Keyboard::Switch);
-    void special_key_action(int key_code);
+    bool note_key_action(int key_code, DSP::Keyboard::Switch);
+    bool special_key_action(int key_code);
 
     void turn_off_pressed_keys();
     void turn_on_pressed_keys();

--- a/Userland/Applications/Presenter/PresenterWidget.cpp
+++ b/Userland/Applications/Presenter/PresenterWidget.cpp
@@ -108,6 +108,7 @@ void PresenterWidget::keydown_event(GUI::KeyEvent& event)
         event.accept();
         break;
     default:
+        event.ignore();
         break;
     }
 }

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -331,6 +331,8 @@ void TreeMapWidget::keydown_event(GUI::KeyEvent& event)
         set_viewpoint(m_viewpoint == 0 ? m_path.size() : m_viewpoint - 1);
     else if (event.key() == KeyCode::Key_Right)
         set_viewpoint(m_viewpoint == m_path.size() ? 0 : m_viewpoint + 1);
+    else
+        event.ignore();
 }
 
 void TreeMapWidget::mousewheel_event(GUI::MouseEvent& event)

--- a/Userland/Games/BrickGame/BrickGame.cpp
+++ b/Userland/Games/BrickGame/BrickGame.cpp
@@ -471,6 +471,7 @@ void BrickGame::keydown_event(GUI::KeyEvent& event)
         render_request = m_brick_game->move_down_fast();
         break;
     default:
+        event.ignore();
         break;
     }
     if (render_request == Bricks::RenderRequest::RequestUpdate)

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -365,6 +365,7 @@ void ChessWidget::keydown_event(GUI::KeyEvent& event)
         playback_move(PlaybackDirection::Last);
         break;
     default:
+        event.ignore();
         return;
     }
     update();

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -580,8 +580,11 @@ void Game::keydown_event(GUI::KeyEvent& event)
     } else if (event.key() == KeyCode::Key_Space) {
         if (m_human_can_play && m_state == State::Play)
             play_card(m_players[0], pick_first_card_ltr(m_players[0]));
-    } else if (event.shift() && event.key() == KeyCode::Key_F11)
+    } else if (event.shift() && event.key() == KeyCode::Key_F11) {
         dump_state();
+    } else {
+        event.ignore();
+    }
 }
 
 void Game::play_card(Player& player, size_t card_index)

--- a/Userland/Games/MasterWord/WordGame.cpp
+++ b/Userland/Games/MasterWord/WordGame.cpp
@@ -113,6 +113,8 @@ void WordGame::keydown_event(GUI::KeyEvent& event)
                 reset();
             }
         }
+    } else {
+        event.ignore();
     }
 
     update();

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -207,8 +207,10 @@ void Game::update_score(int to_add)
 
 void Game::keydown_event(GUI::KeyEvent& event)
 {
-    if (is_moving_cards() || m_new_game_animation || m_game_over_animation)
+    if (is_moving_cards() || m_new_game_animation || m_game_over_animation) {
+        event.ignore();
         return;
+    }
 
     if (event.shift() && event.key() == KeyCode::Key_F12) {
         start_game_over_animation();
@@ -220,6 +222,8 @@ void Game::keydown_event(GUI::KeyEvent& event)
         if constexpr (SOLITAIRE_DEBUG) {
             dump_layout();
         }
+    } else {
+        event.ignore();
     }
 }
 


### PR DESCRIPTION
This makes Action shortcuts work again. :^)

I noticed the problem with Solitaire, (rumours of my Solitaire addiction are purely fictional...) but it turned out to affect a bunch of other games and apps, so I've corrected those too.