### PR TITLE
LibPDF + PDFViewer: Improve error handling, comment blocks

### DIFF
--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -319,7 +319,12 @@ PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> PDFViewer::render_page(u32 page_inde
     auto& page_size = m_page_dimension_cache.render_info[page_index].size;
     auto bitmap = TRY(Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, page_size.to_type<int>()));
 
-    TRY(PDF::Renderer::render(*m_document, page, bitmap, m_rendering_preferences));
+    auto maybe_errors = PDF::Renderer::render(*m_document, page, bitmap, m_rendering_preferences);
+    if (maybe_errors.is_error()) {
+        auto errors = maybe_errors.release_error();
+        on_render_errors(page_index, errors);
+        return bitmap;
+    }
 
     if (page.rotate + m_rotations != 0) {
         int rotation_count = ((page.rotate + m_rotations) / 90) % 4;

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -53,6 +53,7 @@ public:
     PDF::PDFErrorOr<void> set_document(RefPtr<PDF::Document>);
 
     Function<void(u32 new_page)> on_page_change;
+    Function<void(u32 page, PDF::Errors const& errors)> on_render_errors;
 
     void zoom_in();
     void zoom_out();

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -338,7 +338,7 @@ void PDFViewerWidget::open_file(Core::File& file)
 {
     window()->set_title(DeprecatedString::formatted("{} - PDF Viewer", file.filename()));
 
-    auto handle_error = [&]<typename T>(PDF::PDFErrorOr<T> maybe_error) {
+    auto handle_error = [&](auto&& maybe_error) {
         if (maybe_error.is_error()) {
             auto error = maybe_error.release_error();
             warnln("{}", error.message());

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -226,7 +226,7 @@ void PDFViewerWidget::initialize_toolbar(GUI::Toolbar& toolbar)
     auto open_outline_action = GUI::Action::create(
         "Toggle &Sidebar", { Mod_Ctrl, Key_S }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/sidebar.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
             m_sidebar_open = !m_sidebar_open;
-            m_sidebar->set_visible(m_sidebar_open ? true : false);
+            m_sidebar->set_visible(m_sidebar_open);
         },
         nullptr);
     open_outline_action->set_enabled(false);

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -6,6 +6,13 @@
  */
 
 #include "PDFViewerWidget.h"
+#include "AK/Assertions.h"
+#include "AK/DeprecatedString.h"
+#include "AK/Format.h"
+#include "LibGUI/Forward.h"
+#include <AK/HashMap.h>
+#include <AK/HashTable.h>
+#include <AK/Variant.h>
 #include <LibCore/File.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Application.h>
@@ -15,11 +22,138 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/MessageBox.h>
+#include <LibGUI/Model.h>
+#include <LibGUI/SortingProxyModel.h>
 #include <LibGUI/Splitter.h>
+#include <LibGUI/TableView.h>
 #include <LibGUI/Toolbar.h>
 #include <LibGUI/ToolbarContainer.h>
 
+class PagedErrorsModel : public GUI::Model {
+
+    enum Columns {
+        Page = 0,
+        Message,
+        _Count
+    };
+
+    using PageErrors = AK::OrderedHashTable<DeprecatedString>;
+    using PagedErrors = HashMap<u32, PageErrors>;
+
+public:
+    int row_count(GUI::ModelIndex const& index) const override
+    {
+        // There are two levels: number of pages and number of errors in page
+        if (!index.is_valid()) {
+            return static_cast<int>(m_paged_errors.size());
+        }
+        if (!index.parent().is_valid()) {
+            auto errors_in_page = m_paged_errors.get(index.row()).release_value().size();
+            return static_cast<int>(errors_in_page);
+        }
+        return 0;
+    }
+
+    int column_count(GUI::ModelIndex const&) const override
+    {
+        return Columns::_Count;
+    }
+
+    int tree_column() const override
+    {
+        return Columns::Page;
+    }
+
+    DeprecatedString column_name(int index) const override
+    {
+        switch (index) {
+        case 0:
+            return "Page";
+        case 1:
+            return "Message";
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
+    GUI::ModelIndex index(int row, int column, GUI::ModelIndex const& parent) const override
+    {
+        if (!parent.is_valid()) {
+            return create_index(row, column);
+        }
+        auto const& page = m_pages_with_errors[parent.row()];
+        return create_index(row, column, &page);
+    }
+
+    GUI::ModelIndex parent_index(GUI::ModelIndex const& index) const override
+    {
+        auto* const internal_data = index.internal_data();
+        if (internal_data == nullptr)
+            return {};
+        auto page = *static_cast<u32 const*>(internal_data);
+        auto page_idx = static_cast<int>(m_pages_with_errors.find_first_index(page).release_value());
+        return create_index(page_idx, index.column());
+    }
+
+    virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole) const override
+    {
+        if (!index.parent().is_valid()) {
+            switch (index.column()) {
+            case Columns::Page:
+                return m_pages_with_errors[index.row()] + 1;
+            case Columns::Message:
+                return DeprecatedString::formatted("{} errors", m_paged_errors.get(index.row()).release_value().size());
+            default:
+                VERIFY_NOT_REACHED();
+            }
+        }
+
+        auto page = *static_cast<u32 const*>(index.internal_data());
+        switch (index.column()) {
+        case Columns::Page:
+            return "";
+        case Columns::Message: {
+            auto page_errors = m_paged_errors.get(page).release_value();
+            // dbgln("Errors on page {}: {}. Requesting data for index {},{}", page, page_errors.size(), index.row(), index.column());
+            auto it = page_errors.begin();
+            auto row = index.row();
+            for (int i = 0; i < row; ++i, ++it)
+                ;
+            return *it;
+        }
+        }
+        VERIFY_NOT_REACHED();
+    }
+
+    void add_errors(u32 page, PDF::Errors const& errors)
+    {
+        auto old_size = total_error_count();
+        if (!m_pages_with_errors.contains_slow(page)) {
+            m_pages_with_errors.append(page);
+        }
+        auto& page_errors = m_paged_errors.ensure(page);
+        for (auto const& error : errors.errors())
+            page_errors.set(error.message());
+        auto new_size = total_error_count();
+        if (old_size != new_size)
+            invalidate();
+    }
+
+private:
+    size_t total_error_count() const
+    {
+        size_t count = 0;
+        for (auto const& entry : m_paged_errors)
+            count += entry.value.size();
+        return count;
+    }
+
+    Vector<u32> m_pages_with_errors;
+    PagedErrors m_paged_errors;
+};
+
 PDFViewerWidget::PDFViewerWidget()
+    : m_paged_errors_model(adopt_ref(*new PagedErrorsModel()))
 {
     set_fill_with_background_color(true);
     set_layout<GUI::VerticalBoxLayout>();
@@ -27,19 +161,33 @@ PDFViewerWidget::PDFViewerWidget()
     auto& toolbar_container = add<GUI::ToolbarContainer>();
     auto& toolbar = toolbar_container.add<GUI::Toolbar>();
 
-    auto& splitter = add<GUI::HorizontalSplitter>();
-    splitter.layout()->set_spacing(4);
+    auto& h_splitter = add<GUI::HorizontalSplitter>();
+    h_splitter.layout()->set_spacing(4);
 
-    m_sidebar = splitter.add<SidebarWidget>();
+    m_sidebar = h_splitter.add<SidebarWidget>();
     m_sidebar->set_preferred_width(200);
     m_sidebar->set_visible(false);
 
-    m_viewer = splitter.add<PDFViewer>();
+    auto& v_splitter = h_splitter.add<GUI::VerticalSplitter>();
+    v_splitter.layout()->set_spacing(4);
+
+    m_viewer = v_splitter.add<PDFViewer>();
     m_viewer->on_page_change = [&](auto new_page) {
         m_page_text_box->set_current_number(new_page + 1, GUI::AllowCallback::No);
         m_go_to_prev_page_action->set_enabled(new_page > 0);
         m_go_to_next_page_action->set_enabled(new_page < m_viewer->document()->get_page_count() - 1);
     };
+    m_viewer->on_render_errors = [&](u32 page, PDF::Errors const& errors) {
+        verify_cast<PagedErrorsModel>(m_paged_errors_model.ptr())->add_errors(page, errors);
+    };
+
+    m_errors_tree_view = v_splitter.add<GUI::TreeView>();
+    m_errors_tree_view->set_preferred_height(10);
+    m_errors_tree_view->column_header().set_visible(true);
+    m_errors_tree_view->set_should_fill_selected_rows(true);
+    m_errors_tree_view->set_selection_behavior(GUI::AbstractView::SelectionBehavior::SelectRows);
+    m_errors_tree_view->set_model(MUST(GUI::SortingProxyModel::create(m_paged_errors_model)));
+    m_errors_tree_view->set_key_column(0);
 
     initialize_toolbar(toolbar);
 }

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.h
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "AK/NonnullRefPtr.h"
 #include "AK/RefPtr.h"
 #include "NumericInput.h"
 #include "PDFViewer.h"
@@ -16,6 +17,7 @@
 #include <LibGUI/Widget.h>
 
 class PDFViewer;
+class PagedErrorsModel;
 
 class PDFViewerWidget final : public GUI::Widget {
     C_OBJECT(PDFViewerWidget)
@@ -33,6 +35,8 @@ private:
 
     RefPtr<PDFViewer> m_viewer;
     RefPtr<SidebarWidget> m_sidebar;
+    NonnullRefPtr<PagedErrorsModel> m_paged_errors_model;
+    RefPtr<GUI::TreeView> m_errors_tree_view;
     RefPtr<NumericInput> m_page_text_box;
     RefPtr<GUI::Label> m_total_page_label;
     RefPtr<GUI::Action> m_go_to_prev_page_action;

--- a/Userland/Libraries/LibPDF/Error.h
+++ b/Userland/Libraries/LibPDF/Error.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <AK/Vector.h>
 
 namespace PDF {
 
@@ -52,7 +53,33 @@ private:
     DeprecatedString m_message;
 };
 
+class Errors {
+
+public:
+    Errors() = default;
+    Errors(Error&& error)
+    {
+        m_errors.empend(move(error));
+    }
+
+    Vector<Error> const& errors() const
+    {
+        return m_errors;
+    }
+
+    void add_error(Error&& error)
+    {
+        m_errors.empend(move(error));
+    }
+
+private:
+    Vector<Error> m_errors;
+};
+
 template<typename T>
 using PDFErrorOr = ErrorOr<T, Error>;
+
+template<typename T>
+using PDFErrorsOr = ErrorOr<T, Errors>;
 
 }

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -39,18 +39,21 @@ void Parser::set_document(WeakPtr<Document> const& document)
 
 DeprecatedString Parser::parse_comment()
 {
-    if (!m_reader.matches('%'))
-        return {};
+    StringBuilder comment;
+    while (true) {
+        if (!m_reader.matches('%'))
+            break;
 
-    m_reader.consume();
-    auto comment_start_offset = m_reader.offset();
-    m_reader.move_until([&](auto) {
-        return m_reader.matches_eol();
-    });
-    DeprecatedString str = StringView(m_reader.bytes().slice(comment_start_offset, m_reader.offset() - comment_start_offset));
-    m_reader.consume_eol();
-    m_reader.consume_whitespace();
-    return str;
+        m_reader.consume();
+        auto comment_start_offset = m_reader.offset();
+        m_reader.move_until([&](auto) {
+            return m_reader.matches_eol();
+        });
+        comment.append(m_reader.bytes().slice(comment_start_offset, m_reader.offset() - comment_start_offset));
+        m_reader.consume_eol();
+        m_reader.consume_whitespace();
+    }
+    return comment.to_deprecated_string();
 }
 
 PDFErrorOr<Value> Parser::parse_value(CanBeIndirectValue can_be_indirect_value)

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -13,11 +13,10 @@
 #define RENDERER_HANDLER(name) \
     PDFErrorOr<void> Renderer::handle_##name([[maybe_unused]] Vector<Value> const& args, [[maybe_unused]] Optional<NonnullRefPtr<DictObject>> extra_resources)
 
-#define RENDERER_TODO(name)                                         \
-    RENDERER_HANDLER(name)                                          \
-    {                                                               \
-        dbgln("[PDF::Renderer] Unsupported draw operation " #name); \
-        TODO();                                                     \
+#define RENDERER_TODO(name)                                                        \
+    RENDERER_HANDLER(name)                                                         \
+    {                                                                              \
+        return Error(Error::Type::RenderingUnsupported, "draw operation: " #name); \
     }
 
 namespace PDF {

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -96,12 +96,12 @@ struct RenderingPreferences {
 
 class Renderer {
 public:
-    static PDFErrorOr<void> render(Document&, Page const&, RefPtr<Gfx::Bitmap>, RenderingPreferences preferences);
+    static PDFErrorsOr<void> render(Document&, Page const&, RefPtr<Gfx::Bitmap>, RenderingPreferences preferences);
 
 private:
     Renderer(RefPtr<Document>, Page const&, RefPtr<Gfx::Bitmap>, RenderingPreferences);
 
-    PDFErrorOr<void> render();
+    PDFErrorsOr<void> render();
 
     PDFErrorOr<void> handle_operator(Operator const&, Optional<NonnullRefPtr<DictObject>> = {});
 #define V(name, snake_name, symbol) \


### PR DESCRIPTION
This PR first modifies LibPDF's Renderer so that it works on a best-effort basis: instead of bailing out on the first error, it tries to execute all the drawing operations on the bitmap, and returns all errors that were found in the process. Additionally, unsupported drawing operations now don't cause an abort. On the other hand, PDFViewer now displays such errors in a TreeView with the first level being the page, and the second being the error.

I'm also including support for multi-line comment blocks, which previously weren't supported and thus made the DocumentParser crash on some PDF documents that contain multiple comment lines in a single block at the beginning.

Other minor fixes are included, which became apparent only after rebasing on the latest master (after ~a week without rebasing).

Before :cry: 
![TMMS-Quick-Start-Card2017.pdf_p1_before](https://user-images.githubusercontent.com/620848/207659407-0da8a8f0-8493-4845-ba58-826a9021a153.png)

After :smile: 
![TMMS-Quick-Start-Card2017.pdf_p1_after](https://user-images.githubusercontent.com/620848/207658872-392c21b3-c897-4b72-a0c1-2c4824b6cade.png)
