### PR TITLE
gron: Add options for enabling/disabling colored output

### DIFF
--- a/Userland/Utilities/gron.cpp
+++ b/Userland/Utilities/gron.cpp
@@ -38,6 +38,19 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.set_general_help("Print each value in a JSON file with its fully expanded key.");
 
     StringView path;
+    args_parser.add_option(use_color, "Colorize output (default on tty)", "colorize", 'c');
+    args_parser.add_option(Core::ArgsParser::Option {
+        Core::ArgsParser::OptionArgumentMode::None,
+        "Monochrome (don't colorize output)",
+        "monochrome",
+        'm',
+        nullptr,
+        [](char const* s) {
+            VERIFY(s == nullptr);
+            use_color = false;
+            return true;
+        },
+    });
     args_parser.add_positional_argument(path, "Input", "input", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 


### PR DESCRIPTION
These match the options in the original gron:
https://github.com/tomnomnom/gron