### PR TITLE
LibJS: Updates to Intl.DurationFormat

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -141,43 +141,68 @@ ThrowCompletionOr<Temporal::DurationRecord> to_duration_record(VM& vm, Value inp
 
     // 2. Let result be a new Duration Record with each field set to 0.
     Temporal::DurationRecord result = {};
+    bool any_defined = false;
 
-    // 3. Let any be false.
-    auto any = false;
+    auto set_duration_record_value = [&](auto const& name, auto& value_slot) -> ThrowCompletionOr<void> {
+        auto value = TRY(input_object.get(name));
 
-    // 4. For each row of Table 1, except the header row, in table order, do
-    for (auto const& duration_instances_component : duration_instances_components) {
-        // a. Let valueSlot be the Value Slot value of the current row.
-        auto value_slot = duration_instances_component.value_slot;
-
-        // b. Let unit be the Unit value of the current row.
-        auto unit = duration_instances_component.unit;
-
-        // c. Let value be ? Get(input, unit).
-        auto value = TRY(input_object.get(FlyString(unit)));
-
-        // d. If value is not undefined, then
         if (!value.is_undefined()) {
-            // i. Set any to true.
-            any = true;
-
-            // ii. Set value to ? ToIntegerIfIntegral(value).
-            auto value_number = TRY(Temporal::to_integer_if_integral(vm, value, ErrorType::TemporalInvalidDurationPropertyValueNonIntegral, unit, value));
-
-            // iii. Set result.[[<valueSlot>]] to value.
-            result.*value_slot = value_number;
+            value_slot = TRY(Temporal::to_integer_if_integral(vm, value, ErrorType::TemporalInvalidDurationPropertyValueNonIntegral, name, value));
+            any_defined = true;
         }
-    }
 
-    // 5. If any is false, throw a TypeError exception.
-    if (!any)
+        return {};
+    };
+
+    // 3. Let days be ? Get(input, "days").
+    // 4. If days is not undefined, set result.[[Days]] to ? ToIntegerIfIntegral(days).
+    TRY(set_duration_record_value(vm.names.days, result.days));
+
+    // 5. Let hours be ? Get(input, "hours").
+    // 6. If hours is not undefined, set result.[[Hours]] to ? ToIntegerIfIntegral(hours).
+    TRY(set_duration_record_value(vm.names.hours, result.hours));
+
+    // 7. Let microseconds be ? Get(input, "microseconds").
+    // 8. If microseconds is not undefined, set result.[[Microseconds]] to ? ToIntegerIfIntegral(microseconds).
+    TRY(set_duration_record_value(vm.names.microseconds, result.microseconds));
+
+    // 9. Let milliseconds be ? Get(input, "milliseconds").
+    // 10. If milliseconds is not undefined, set result.[[Milliseconds]] to ? ToIntegerIfIntegral(milliseconds).
+    TRY(set_duration_record_value(vm.names.milliseconds, result.milliseconds));
+
+    // 11. Let minutes be ? Get(input, "minutes").
+    // 12. If minutes is not undefined, set result.[[Minutes]] to ? ToIntegerIfIntegral(minutes).
+    TRY(set_duration_record_value(vm.names.minutes, result.minutes));
+
+    // 13. Let months be ? Get(input, "months").
+    // 14. If months is not undefined, set result.[[Months]] to ? ToIntegerIfIntegral(months).
+    TRY(set_duration_record_value(vm.names.months, result.months));
+
+    // 15. Let nanoseconds be ? Get(input, "nanoseconds").
+    // 16. If nanoseconds is not undefined, set result.[[Nanoseconds]] to ? ToIntegerIfIntegral(nanoseconds).
+    TRY(set_duration_record_value(vm.names.nanoseconds, result.nanoseconds));
+
+    // 17. Let seconds be ? Get(input, "seconds").
+    // 18. If seconds is not undefined, set result.[[Seconds]] to ? ToIntegerIfIntegral(seconds).
+    TRY(set_duration_record_value(vm.names.seconds, result.seconds));
+
+    // 19. Let weeks be ? Get(input, "weeks").
+    // 20. If weeks is not undefined, set result.[[Weeks]] to ? ToIntegerIfIntegral(weeks).
+    TRY(set_duration_record_value(vm.names.weeks, result.weeks));
+
+    // 21. Let years be ? Get(input, "years").
+    // 22. If years is not undefined, set result.[[Years]] to ? ToIntegerIfIntegral(years).
+    TRY(set_duration_record_value(vm.names.years, result.years));
+
+    // 23. If years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, and nanoseconds are all undefined, throw a TypeError exception.
+    if (!any_defined)
         return vm.throw_completion<TypeError>(ErrorType::TemporalInvalidDurationLikeObject);
 
-    // 6. If IsValidDurationRecord(result) is false, throw a RangeError exception.
+    // 24. If IsValidDurationRecord(result) is false, throw a RangeError exception.
     if (!is_valid_duration_record(result))
         return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidDurationLikeObject);
 
-    // 7. Return result.
+    // 25. Return result.
     return result;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -173,7 +173,11 @@ ThrowCompletionOr<Temporal::DurationRecord> to_duration_record(VM& vm, Value inp
     if (!any)
         return vm.throw_completion<TypeError>(ErrorType::TemporalInvalidDurationLikeObject);
 
-    // 6. Return result.
+    // 6. If IsValidDurationRecord(result) is false, throw a RangeError exception.
+    if (!is_valid_duration_record(result))
+        return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidDurationLikeObject);
+
+    // 7. Return result.
     return result;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -204,7 +204,7 @@ i8 duration_record_sign(Temporal::DurationRecord const& record)
 // 1.1.5 IsValidDurationRecord ( record ), https://tc39.es/proposal-intl-duration-format/#sec-isvaliddurationrecord
 bool is_valid_duration_record(Temporal::DurationRecord const& record)
 {
-    // 1. Let sign be ! DurationRecordSign(record).
+    // 1. Let sign be DurationRecordSign(record).
     auto sign = duration_record_sign(record);
 
     // 2. For each row of Table 1, except the header row, in table order, do
@@ -338,7 +338,7 @@ Vector<PatternPartition> partition_duration_format_pattern(VM& vm, DurationForma
         // h. Let value be duration.[[<valueSlot>]].
         auto value = duration.*value_slot;
 
-        // i. Let nfOpts be ! OrdinaryObjectCreate(null).
+        // i. Let nfOpts be OrdinaryObjectCreate(null).
         auto number_format_options = Object::create(realm, nullptr);
 
         // j. If unit is "seconds", "milliseconds", or "microseconds", then
@@ -485,7 +485,7 @@ Vector<PatternPartition> partition_duration_format_pattern(VM& vm, DurationForma
         }
     }
 
-    // 4. Let lfOpts be ! OrdinaryObjectCreate(null).
+    // 4. Let lfOpts be OrdinaryObjectCreate(null).
     auto list_format_options = Object::create(realm, nullptr);
 
     // 5. Perform ! CreateDataPropertyOrThrow(lfOpts, "type", "unit").

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -134,9 +134,16 @@ StringView DurationFormat::display_to_string(Display display)
 // 1.1.3 ToDurationRecord ( input ), https://tc39.es/proposal-intl-duration-format/#sec-todurationrecord
 ThrowCompletionOr<Temporal::DurationRecord> to_duration_record(VM& vm, Value input)
 {
-    // 1. If Type(input) is not Object, throw a TypeError exception.
-    if (!input.is_object())
+    // 1. If Type(input) is not Object, then
+    if (!input.is_object()) {
+        // a. If Type(input) is String, throw a RangeError exception.
+        if (input.is_string())
+            return vm.throw_completion<RangeError>(ErrorType::NotAnObject, input);
+
+        // b. Throw a TypeError exception.
         return vm.throw_completion<TypeError>(ErrorType::NotAnObject, input);
+    }
+
     auto& input_object = input.as_object();
 
     // 2. Let result be a new Duration Record with each field set to 0.

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.cpp
@@ -42,23 +42,19 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::format)
     // 3. Let record be ? ToDurationRecord(duration).
     auto record = TRY(to_duration_record(vm, vm.argument(0)));
 
-    // 4. If IsValidDurationRecord(record) is false, throw a RangeError exception.
-    if (!is_valid_duration_record(record))
-        return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidDurationLikeObject);
-
-    // 5. Let parts be PartitionDurationFormatPattern(df, record).
+    // 4. Let parts be PartitionDurationFormatPattern(df, record).
     auto parts = partition_duration_format_pattern(vm, *duration_format, record);
 
-    // 6. Let result be a new empty String.
+    // 5. Let result be a new empty String.
     StringBuilder result;
 
-    // 7. For each Record { [[Type]], [[Value]] } part in parts, do
+    // 6. For each Record { [[Type]], [[Value]] } part in parts, do
     for (auto const& part : parts) {
         // a. Set result to the string-concatenation of result and part.[[Value]].
         result.append(part.value);
     }
 
-    // 8. Return result.
+    // 7. Return result.
     return PrimitiveString::create(vm, result.build());
 }
 
@@ -74,18 +70,14 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::format_to_parts)
     // 3. Let record be ? ToDurationRecord(duration).
     auto record = TRY(to_duration_record(vm, vm.argument(0)));
 
-    // 4. If IsValidDurationRecord(record) is false, throw a RangeError exception.
-    if (!is_valid_duration_record(record))
-        return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidDurationLikeObject);
-
-    // 5. Let parts be PartitionDurationFormatPattern(df, record).
+    // 4. Let parts be PartitionDurationFormatPattern(df, record).
     auto parts = partition_duration_format_pattern(vm, *duration_format, record);
 
-    // 6. Let result be ! ArrayCreate(0).
+    // 5. Let result be ! ArrayCreate(0).
     auto result = MUST(Array::create(realm, 0));
 
-    // 7. Let n be 0.
-    // 8. For each { [[Type]], [[Value]] } part in parts, do
+    // 6. Let n be 0.
+    // 7. For each { [[Type]], [[Value]] } part in parts, do
     for (size_t n = 0; n < parts.size(); ++n) {
         auto const& part = parts[n];
 
@@ -104,7 +96,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::format_to_parts)
         // e. Increment n by 1.
     }
 
-    // 9. Return result.
+    // 8. Return result.
     return result;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.cpp
@@ -46,7 +46,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::format)
     if (!is_valid_duration_record(record))
         return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidDurationLikeObject);
 
-    // 5. Let parts be ! PartitionDurationFormatPattern(df, record).
+    // 5. Let parts be PartitionDurationFormatPattern(df, record).
     auto parts = partition_duration_format_pattern(vm, *duration_format, record);
 
     // 6. Let result be a new empty String.
@@ -78,7 +78,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::format_to_parts)
     if (!is_valid_duration_record(record))
         return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidDurationLikeObject);
 
-    // 5. Let parts be ! PartitionDurationFormatPattern(df, record).
+    // 5. Let parts be PartitionDurationFormatPattern(df, record).
     auto parts = partition_duration_format_pattern(vm, *duration_format, record);
 
     // 6. Let result be ! ArrayCreate(0).
@@ -89,7 +89,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::format_to_parts)
     for (size_t n = 0; n < parts.size(); ++n) {
         auto const& part = parts[n];
 
-        // a. Let obj be ! OrdinaryObjectCreate(%ObjectPrototype%).
+        // a. Let obj be OrdinaryObjectCreate(%ObjectPrototype%).
         auto object = Object::create(realm, realm.intrinsics().object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(obj, "type", part.[[Type]]).
@@ -117,7 +117,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::resolved_options)
     // 2. Perform ? RequireInternalSlot(df, [[InitializedDurationFormat]]).
     auto* duration_format = TRY(typed_this_object(vm));
 
-    // 3. Let options be ! OrdinaryObjectCreate(%Object.prototype%).
+    // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
     auto options = Object::create(realm, realm.intrinsics().object_prototype());
 
     // 4. For each row of Table 2, except the header row, in table order, do

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DurationFormat/DurationFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DurationFormat/DurationFormat.prototype.format.js
@@ -92,7 +92,11 @@ describe("correct behavior", () => {
 
 describe("errors", () => {
     test("non-object duration records", () => {
-        [-100, Infinity, NaN, "hello", 152n, Symbol("foo")].forEach(value => {
+        expect(() => {
+            new Intl.DurationFormat().format("hello");
+        }).toThrowWithMessage(RangeError, "is not an object");
+
+        [-100, Infinity, NaN, 152n, Symbol("foo"), true, null, undefined].forEach(value => {
             expect(() => {
                 new Intl.DurationFormat().format(value);
             }).toThrowWithMessage(TypeError, "is not an object");

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DurationFormat/DurationFormat.prototype.formatToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DurationFormat/DurationFormat.prototype.formatToParts.js
@@ -266,7 +266,11 @@ describe("correct behavior", () => {
 
 describe("errors", () => {
     test("non-object duration records", () => {
-        [-100, Infinity, NaN, "hello", 152n, Symbol("foo")].forEach(value => {
+        expect(() => {
+            new Intl.DurationFormat().formatToParts("hello");
+        }).toThrowWithMessage(RangeError, "is not an object");
+
+        [-100, Infinity, NaN, 152n, Symbol("foo"), true, null, undefined].forEach(value => {
             expect(() => {
                 new Intl.DurationFormat().formatToParts(value);
             }).toThrowWithMessage(TypeError, "is not an object");


### PR DESCRIPTION
```
Diff Tests:
    test/intl402/DurationFormat/prototype/format/invalid-arguments-throws.js        ❌ -> ✅
    test/intl402/DurationFormat/prototype/formatToParts/invalid-arguments-throws.js ❌ -> ✅
```