### PR TITLE
Presenter: Allow presentation wide default colour scheme.

### DIFF
--- a/Userland/Applications/Presenter/Presentation.h
+++ b/Userland/Applications/Presenter/Presentation.h
@@ -28,6 +28,8 @@ public:
 
     StringView title() const;
     StringView author() const;
+    Gfx::Color background_color() const;
+    Gfx::Color foreground_color() const;
     Gfx::IntSize normative_size() const { return m_normative_size; }
 
     Slide const& current_slide() const { return m_slides[m_current_slide.value()]; }
@@ -37,6 +39,7 @@ public:
     void next_frame();
     void previous_frame();
     void go_to_first_slide();
+    void set_color_scheme(Gfx::Color, Gfx::Color);
 
     // This assumes that the caller has clipped the painter to exactly the display area.
     void paint(Gfx::Painter& painter) const;
@@ -57,4 +60,7 @@ private:
 
     Checked<unsigned> m_current_slide { 0 };
     Checked<unsigned> m_current_frame_in_slide { 0 };
+
+    Gfx::Color m_background_color;
+    Gfx::Color m_foreground_color;
 };

--- a/Userland/Applications/Presenter/PresenterWidget.cpp
+++ b/Userland/Applications/Presenter/PresenterWidget.cpp
@@ -68,6 +68,23 @@ ErrorOr<void> PresenterWidget::initialize_menubar()
         this->window()->set_fullscreen(true);
     })));
 
+    auto black_background_action = GUI::Action::create("&Black background", { KeyCode::Key_B }, [this](auto&) {
+        if (m_current_presentation) {
+            m_current_presentation->set_color_scheme(Color::Black, Color::LightGray);
+            update();
+        }
+    });
+    auto white_background_action = GUI::Action::create("&White background", { KeyCode::Key_W }, [this](auto&) {
+        if (m_current_presentation) {
+            m_current_presentation->set_color_scheme(Color::White, Color::DarkGray);
+            update();
+        }
+    });
+    TRY(presentation_menu.try_add_action(black_background_action));
+    TRY(presentation_menu.try_add_action(white_background_action));
+    m_black_background_action = black_background_action;
+    m_white_background_action = white_background_action;
+
     return {};
 }
 
@@ -79,6 +96,7 @@ void PresenterWidget::set_file(StringView file_name)
     } else {
         m_current_presentation = presentation.release_value();
         window()->set_title(DeprecatedString::formatted(title_template, m_current_presentation->title(), m_current_presentation->author()));
+        m_current_presentation->set_color_scheme(m_current_presentation->background_color(), m_current_presentation->foreground_color());
         set_min_size(m_current_presentation->normative_size());
         // This will apply the new minimum size.
         update();

--- a/Userland/Applications/Presenter/PresenterWidget.h
+++ b/Userland/Applications/Presenter/PresenterWidget.h
@@ -35,4 +35,6 @@ private:
     OwnPtr<Presentation> m_current_presentation;
     RefPtr<GUI::Action> m_next_slide_action;
     RefPtr<GUI::Action> m_previous_slide_action;
+    RefPtr<GUI::Action> m_black_background_action;
+    RefPtr<GUI::Action> m_white_background_action;
 };

--- a/Userland/Applications/Presenter/Slide.cpp
+++ b/Userland/Applications/Presenter/Slide.cpp
@@ -18,7 +18,7 @@ Slide::Slide(NonnullRefPtrVector<SlideObject> slide_objects, DeprecatedString ti
 {
 }
 
-ErrorOr<Slide> Slide::parse_slide(JsonObject const& slide_json, NonnullRefPtr<GUI::Window> window)
+ErrorOr<Slide> Slide::parse_slide(JsonObject const& slide_json, NonnullRefPtr<GUI::Window> window, Color default_color)
 {
     // FIXME: Use the text with the "title" role for a title, if there is no title given.
     auto title = slide_json.get("title"sv).as_string_or("Untitled slide");
@@ -34,7 +34,7 @@ ErrorOr<Slide> Slide::parse_slide(JsonObject const& slide_json, NonnullRefPtr<GU
             return Error::from_string_view("Slides must be objects"sv);
         auto const& slide_object_json = maybe_slide_object_json.as_object();
 
-        auto slide_object = TRY(SlideObject::parse_slide_object(slide_object_json, window));
+        auto slide_object = TRY(SlideObject::parse_slide_object(slide_object_json, window, default_color));
         slide_objects.append(move(slide_object));
     }
 

--- a/Userland/Applications/Presenter/Slide.h
+++ b/Userland/Applications/Presenter/Slide.h
@@ -15,7 +15,7 @@
 // A single slide of a presentation.
 class Slide final {
 public:
-    static ErrorOr<Slide> parse_slide(JsonObject const& slide_json, NonnullRefPtr<GUI::Window> window);
+    static ErrorOr<Slide> parse_slide(JsonObject const& slide_json, NonnullRefPtr<GUI::Window> window, Color default_color);
 
     // FIXME: shouldn't be hard-coded to 1.
     unsigned frame_count() const { return 1; }

--- a/Userland/Applications/Presenter/SlideObject.cpp
+++ b/Userland/Applications/Presenter/SlideObject.cpp
@@ -18,7 +18,7 @@
 #include <LibGfx/TextWrapping.h>
 #include <LibImageDecoderClient/Client.h>
 
-ErrorOr<NonnullRefPtr<SlideObject>> SlideObject::parse_slide_object(JsonObject const& slide_object_json, NonnullRefPtr<GUI::Window> window)
+ErrorOr<NonnullRefPtr<SlideObject>> SlideObject::parse_slide_object(JsonObject const& slide_object_json, NonnullRefPtr<GUI::Window> window, Gfx::Color default_color)
 {
     auto image_decoder_client = TRY(ImageDecoderClient::Client::try_create());
 
@@ -29,7 +29,7 @@ ErrorOr<NonnullRefPtr<SlideObject>> SlideObject::parse_slide_object(JsonObject c
     auto type = maybe_type.as_string();
     RefPtr<SlideObject> object;
     if (type == "text"sv)
-        object = TRY(try_make_ref_counted<Text>());
+        object = TRY(try_make_ref_counted<Text>(default_color));
     else if (type == "image"sv)
         object = TRY(try_make_ref_counted<Image>(image_decoder_client, window));
     else
@@ -80,6 +80,16 @@ Text::Text()
     REGISTER_TEXT_ALIGNMENT_PROPERTY("text-alignment", text_alignment, set_text_alignment);
     REGISTER_INT_PROPERTY("font-size", font_size, set_font_size);
     REGISTER_STRING_PROPERTY("font", font, set_font);
+}
+
+Text::Text(Gfx::Color default_color)
+{
+    REGISTER_STRING_PROPERTY("text", text, set_text);
+    REGISTER_FONT_WEIGHT_PROPERTY("font-weight", font_weight, set_font_weight);
+    REGISTER_TEXT_ALIGNMENT_PROPERTY("text-alignment", text_alignment, set_text_alignment);
+    REGISTER_INT_PROPERTY("font-size", font_size, set_font_size);
+    REGISTER_STRING_PROPERTY("font", font, set_font);
+    this->set_color(default_color);
 }
 
 void Text::paint(Gfx::Painter& painter, Gfx::FloatSize display_scale) const

--- a/Userland/Applications/Presenter/SlideObject.h
+++ b/Userland/Applications/Presenter/SlideObject.h
@@ -29,7 +29,7 @@ class SlideObject : public Core::Object {
 public:
     virtual ~SlideObject() = default;
 
-    static ErrorOr<NonnullRefPtr<SlideObject>> parse_slide_object(JsonObject const& slide_object_json, NonnullRefPtr<GUI::Window> window);
+    static ErrorOr<NonnullRefPtr<SlideObject>> parse_slide_object(JsonObject const& slide_object_json, NonnullRefPtr<GUI::Window> window, Color default_color);
 
     // FIXME: Actually determine this from the file data.
     bool is_visible_during_frame([[maybe_unused]] unsigned frame_number) const { return true; }
@@ -68,6 +68,7 @@ class Text : public GraphicsObject {
 
 public:
     Text();
+    Text(Color);
     virtual ~Text() = default;
 
     virtual void paint(Gfx::Painter&, Gfx::FloatSize display_scale) const override;


### PR DESCRIPTION
Also allow toggling between a black and white background.
Makes some progress towards the items on  #15767 for black screen, white screen, and templates.
![PresentationColorScheme](https://user-images.githubusercontent.com/227077/207766727-d555e5e1-8cb8-4a40-b0bb-0290039bc9c8.png)

