### PR TITLE
LibCore: Use ';' to split socket path in `SOCKET_TAKEOVER`

### DIFF
--- a/Base/usr/share/man/man5/SystemServer.md
+++ b/Base/usr/share/man/man5/SystemServer.md
@@ -48,10 +48,10 @@ Note that:
 When SystemServer runs a service which has `Socket` defined, it will create the sockets and then pass an environment variable named `SOCKET_TAKEOVER` to the launched service. This environment variable is structured as follows:
 
 ```console
-SOCKET_TAKEOVER=/tmp/socket1:3 /tmp/socket2:4
+SOCKET_TAKEOVER=/tmp/socket1:3;/tmp/socket2:4
 ```
 
-Items in the variable are separated by spaces, and each item has two components separated by a colon. The first part is the path of the socket requested, and the second part is the file descriptor number that was passed to the newly created service. The service can then parse this information and obtain file descriptors for each socket.
+Items in the variable are separated by semicolons, and each item has two components separated by a colon. The first part is the path of the socket requested, and the second part is the file descriptor number that was passed to the newly created service. The service can then parse this information and obtain file descriptors for each socket.
 
 ## Examples
 

--- a/Userland/Libraries/LibCore/SystemServerTakeover.cpp
+++ b/Userland/Libraries/LibCore/SystemServerTakeover.cpp
@@ -23,7 +23,7 @@ static void parse_sockets_from_system_server()
         return;
     }
 
-    for (auto& socket : StringView { sockets, strlen(sockets) }.split_view(' ')) {
+    for (auto const socket : StringView { sockets, strlen(sockets) }.split_view(';')) {
         auto params = socket.split_view(':');
         s_overtaken_sockets.set(params[0].to_deprecated_string(), strtol(params[1].to_deprecated_string().characters(), nullptr, 10));
     }

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -202,7 +202,7 @@ void Service::spawn(int socket_fd)
 
                 int new_fd = dup(socket.fd);
                 if (i != 0)
-                    builder.append(' ');
+                    builder.append(';');
                 builder.appendff("{}:{}", socket.path, new_fd);
             }
         }


### PR DESCRIPTION
This allow to use socket path with spaces inside.

Closes #16436.
