### PR TITLE
WebDriver: Changes to allow Ladybird to use local socket files instead of manual FD-passing sockets

### DIFF
--- a/Userland/Libraries/LibCore/StandardPaths.cpp
+++ b/Userland/Libraries/LibCore/StandardPaths.cpp
@@ -8,8 +8,8 @@
 #include <AK/LexicalPath.h>
 #include <AK/Platform.h>
 #include <AK/StringBuilder.h>
+#include <LibCore/SessionManagement.h>
 #include <LibCore/StandardPaths.h>
-#include <LibCore/System.h>
 #include <pwd.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -92,7 +92,7 @@ ErrorOr<DeprecatedString> StandardPaths::runtime_directory()
     StringBuilder builder;
 
 #if defined(AK_OS_SERENITY)
-    auto sid = TRY(Core::System::getsid());
+    auto sid = TRY(Core::SessionManagement::root_session_id());
     builder.appendff("/tmp/session/{}", sid);
 #elif defined(AK_OS_MACOS)
     builder.append(home_directory());

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -257,7 +257,7 @@ ErrorOr<NonnullRefPtr<WebDriverConnection>> WebDriverConnection::connect(Web::Pa
     auto socket = TRY(Core::Stream::LocalSocket::connect(webdriver_ipc_path));
 
     dbgln_if(WEBDRIVER_DEBUG, "Connected to WebDriver");
-    return try_create(move(socket), page_client);
+    return adopt_nonnull_ref_or_enomem(new (nothrow) WebDriverConnection(move(socket), page_client));
 }
 
 WebDriverConnection::WebDriverConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, Web::PageClient& page_client)

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -26,7 +26,7 @@ namespace WebContent {
 
 class WebDriverConnection final
     : public IPC::ConnectionToServer<WebDriverClientEndpoint, WebDriverServerEndpoint> {
-    C_OBJECT(WebDriverConnection)
+    C_OBJECT_ABSTRACT(WebDriverConnection)
 
 public:
     static ErrorOr<NonnullRefPtr<WebDriverConnection>> connect(Web::PageClient& page_client, DeprecatedString const& webdriver_ipc_path);

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -8,6 +8,7 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibCore/LocalServer.h>
+#include <LibCore/StandardPaths.h>
 #include <LibCore/Stream.h>
 #include <LibCore/System.h>
 #include <LibIPC/SingleServer.h>
@@ -27,8 +28,9 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd accept unix rpath"));
 
     // This must be first; we can't check if /tmp/webdriver exists once we've unveiled other paths.
-    if (Core::File::exists("/tmp/webdriver"sv))
-        TRY(Core::System::unveil("/tmp/webdriver", "rw"));
+    auto webdriver_socket_path = DeprecatedString::formatted("{}/webdriver", TRY(Core::StandardPaths::runtime_directory()));
+    if (Core::File::exists(webdriver_socket_path))
+        TRY(Core::System::unveil(webdriver_socket_path, "rw"sv));
 
     TRY(Core::System::unveil("/sys/kernel/processes", "r"));
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AK/Function.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <LibCore/Object.h>
 #include <LibCore/Stream.h>
@@ -18,17 +19,22 @@
 
 namespace WebDriver {
 
+struct LaunchBrowserCallbacks {
+    Function<ErrorOr<pid_t>(DeprecatedString const&)> launch_browser;
+    Function<ErrorOr<pid_t>(DeprecatedString const&)> launch_headless_browser;
+};
+
 class Client final : public Web::WebDriver::Client {
     C_OBJECT_ABSTRACT(Client);
 
 public:
-    static ErrorOr<NonnullRefPtr<Client>> try_create(NonnullOwnPtr<Core::Stream::BufferedTCPSocket>, Core::Object* parent);
+    static ErrorOr<NonnullRefPtr<Client>> try_create(NonnullOwnPtr<Core::Stream::BufferedTCPSocket>, LaunchBrowserCallbacks, Core::Object* parent);
     virtual ~Client() override;
 
     void close_session(unsigned session_id);
 
 private:
-    Client(NonnullOwnPtr<Core::Stream::BufferedTCPSocket>, Core::Object* parent);
+    Client(NonnullOwnPtr<Core::Stream::BufferedTCPSocket>, LaunchBrowserCallbacks, Core::Object* parent);
 
     ErrorOr<Session*, Web::WebDriver::Error> find_session_with_id(StringView session_id);
     ErrorOr<NonnullOwnPtr<Session>, Web::WebDriver::Error> take_session_with_id(StringView session_id);
@@ -87,6 +93,8 @@ private:
 
     static NonnullOwnPtrVector<Session> s_sessions;
     static Atomic<unsigned> s_next_session_id;
+
+    LaunchBrowserCallbacks m_callbacks;
 };
 
 }

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -11,6 +11,7 @@
 #include "Session.h"
 #include "Client.h"
 #include <LibCore/LocalServer.h>
+#include <LibCore/StandardPaths.h>
 #include <LibCore/Stream.h>
 #include <LibCore/System.h>
 #include <unistd.h>
@@ -61,7 +62,7 @@ ErrorOr<void> Session::start()
 {
     auto promise = TRY(ServerPromise::try_create());
 
-    auto web_content_socket_path = DeprecatedString::formatted("/tmp/webdriver/session_{}_{}", getpid(), m_id);
+    auto web_content_socket_path = DeprecatedString::formatted("{}/webdriver/session_{}_{}", TRY(Core::StandardPaths::runtime_directory()), getpid(), m_id);
     auto web_content_server = TRY(create_server(web_content_socket_path, promise));
 
     if (m_options.headless) {

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -31,12 +31,12 @@ Session::~Session()
         warnln("Failed to stop session {}: {}", m_id, error.error());
 }
 
-ErrorOr<NonnullRefPtr<Core::LocalServer>> Session::create_server(DeprecatedString const& socket_path, NonnullRefPtr<ServerPromise> promise)
+ErrorOr<NonnullRefPtr<Core::LocalServer>> Session::create_server(NonnullRefPtr<ServerPromise> promise)
 {
-    dbgln("Listening for WebDriver connection on {}", socket_path);
+    dbgln("Listening for WebDriver connection on {}", *m_web_content_socket_path);
 
     auto server = TRY(Core::LocalServer::try_create());
-    server->listen(socket_path);
+    server->listen(*m_web_content_socket_path);
 
     server->on_accept = [this, promise](auto client_socket) {
         auto maybe_connection = adopt_nonnull_ref_or_enomem(new (nothrow) WebContentConnection(move(client_socket), m_client, session_id()));
@@ -62,13 +62,13 @@ ErrorOr<void> Session::start(LaunchBrowserCallbacks const& callbacks)
 {
     auto promise = TRY(ServerPromise::try_create());
 
-    auto web_content_socket_path = DeprecatedString::formatted("{}/webdriver/session_{}_{}", TRY(Core::StandardPaths::runtime_directory()), getpid(), m_id);
-    auto web_content_server = TRY(create_server(web_content_socket_path, promise));
+    m_web_content_socket_path = DeprecatedString::formatted("{}/webdriver/session_{}_{}", TRY(Core::StandardPaths::runtime_directory()), getpid(), m_id);
+    auto web_content_server = TRY(create_server(promise));
 
     if (m_options.headless)
-        m_browser_pid = TRY(callbacks.launch_headless_browser(web_content_socket_path));
+        m_browser_pid = TRY(callbacks.launch_headless_browser(*m_web_content_socket_path));
     else
-        m_browser_pid = TRY(callbacks.launch_browser(web_content_socket_path));
+        m_browser_pid = TRY(callbacks.launch_browser(*m_web_content_socket_path));
 
     // FIXME: Allow this to be more asynchronous. For now, this at least allows us to propagate
     //        errors received while accepting the Browser and WebContent sockets.
@@ -95,6 +95,10 @@ Web::WebDriver::Response Session::stop()
     if (m_browser_pid.has_value()) {
         MUST(Core::System::kill(*m_browser_pid, SIGTERM));
         m_browser_pid = {};
+    }
+    if (m_web_content_socket_path.has_value()) {
+        MUST(Core::System::unlink(*m_web_content_socket_path));
+        m_web_content_socket_path = {};
     }
 
     m_started = false;

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -19,6 +19,8 @@
 
 namespace WebDriver {
 
+struct LaunchBrowserCallbacks;
+
 class Session {
 public:
     Session(unsigned session_id, NonnullRefPtr<Client> client, Web::WebDriver::LadybirdOptions options);
@@ -32,7 +34,7 @@ public:
         return *m_web_content_connection;
     }
 
-    ErrorOr<void> start();
+    ErrorOr<void> start(LaunchBrowserCallbacks const&);
     Web::WebDriver::Response stop();
 
 private:

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -39,7 +39,7 @@ public:
 
 private:
     using ServerPromise = Core::Promise<ErrorOr<void>>;
-    ErrorOr<NonnullRefPtr<Core::LocalServer>> create_server(DeprecatedString const& socket_path, NonnullRefPtr<ServerPromise> promise);
+    ErrorOr<NonnullRefPtr<Core::LocalServer>> create_server(NonnullRefPtr<ServerPromise> promise);
 
     NonnullRefPtr<Client> m_client;
     Web::WebDriver::LadybirdOptions m_options;
@@ -48,6 +48,7 @@ private:
     unsigned m_id { 0 };
 
     RefPtr<WebContentConnection> m_web_content_connection;
+    Optional<DeprecatedString> m_web_content_socket_path;
     Optional<pid_t> m_browser_pid;
 };
 

--- a/Userland/Services/WebDriver/main.cpp
+++ b/Userland/Services/WebDriver/main.cpp
@@ -67,8 +67,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto webdriver_socket_path = DeprecatedString::formatted("{}/webdriver", TRY(Core::StandardPaths::runtime_directory()));
     TRY(Core::Directory::create(webdriver_socket_path, Core::Directory::CreateDirectories::Yes));
 
-    TRY(Core::System::pledge("stdio accept rpath recvfd inet unix proc exec fattr"));
-
     Core::EventLoop loop;
 
     auto server = TRY(Core::TCPServer::try_create());
@@ -106,6 +104,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil(webdriver_socket_path, "rwc"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    TRY(Core::System::pledge("stdio accept rpath recvfd unix proc exec fattr"));
+    TRY(Core::System::pledge("stdio accept cpath rpath recvfd unix proc exec fattr"));
     return loop.exec();
 }

--- a/Userland/Services/WebDriver/main.cpp
+++ b/Userland/Services/WebDriver/main.cpp
@@ -7,6 +7,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/Directory.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibCore/TCPServer.h>
 #include <LibMain/Main.h>
@@ -38,7 +39,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio accept cpath rpath recvfd inet unix proc exec fattr"));
 
-    TRY(Core::Directory::create("/tmp/webdriver"sv, Core::Directory::CreateDirectories::Yes));
+    auto webdriver_socket_path = DeprecatedString::formatted("{}/webdriver", TRY(Core::StandardPaths::runtime_directory()));
+    TRY(Core::Directory::create(webdriver_socket_path, Core::Directory::CreateDirectories::Yes));
+
     TRY(Core::System::pledge("stdio accept rpath recvfd inet unix proc exec fattr"));
 
     Core::EventLoop loop;
@@ -74,7 +77,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/bin/headless-browser", "rx"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/res/icons", "r"));
-    TRY(Core::System::unveil("/tmp/webdriver", "rwc"));
+    TRY(Core::System::unveil("/sys/kernel/processes", "r"));
+    TRY(Core::System::unveil(webdriver_socket_path, "rwc"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     TRY(Core::System::pledge("stdio accept rpath recvfd unix proc exec fattr"));


### PR DESCRIPTION
On Serenity, we can currently use local socket files for IPC communication between WebDriver and WebContent. On Ladybird, we weren't able to use this until recently, so we are using manually created socket FDs. This resulted in Ladybird needing to duplicate `WebDriver::Session`, so any changes to `Session` in Serenity would need to be re-written in Ladybird.

These are the changes needed within Serenity to allow Ladybird to use normal IPC ifra.

Ladbybird PR: https://github.com/SerenityOS/ladybird/pull/150