### PR TITLE
LibWeb: Fully Implement `get_an_elements_noopener`

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -19,6 +19,7 @@ class HTMLAnchorElement final
 public:
     virtual ~HTMLAnchorElement() override;
 
+    DeprecatedString rel() const { return attribute(HTML::AttributeNames::rel); }
     DeprecatedString target() const { return attribute(HTML::AttributeNames::target); }
     DeprecatedString download() const { return attribute(HTML::AttributeNames::download); }
 
@@ -44,6 +45,7 @@ private:
     virtual bool hyperlink_element_utils_is_html_anchor_element() const final { return true; }
     virtual bool hyperlink_element_utils_is_connected() const final { return is_connected(); }
     virtual DeprecatedString hyperlink_element_utils_target() const final { return target(); }
+    virtual DeprecatedString hyperlink_element_utils_rel() const final { return rel(); }
     virtual void hyperlink_element_utils_queue_an_element_task(HTML::Task::Source source, Function<void()> steps) override
     {
         queue_an_element_task(source, move(steps));

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -34,6 +34,7 @@ private:
     virtual bool hyperlink_element_utils_is_html_anchor_element() const override { return false; }
     virtual bool hyperlink_element_utils_is_connected() const override { return is_connected(); }
     virtual DeprecatedString hyperlink_element_utils_target() const override { return ""; }
+    virtual DeprecatedString hyperlink_element_utils_rel() const override { return ""; }
     virtual void hyperlink_element_utils_queue_an_element_task(HTML::Task::Source source, Function<void()> steps) override
     {
         queue_an_element_task(source, move(steps));

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -7,6 +7,7 @@
 #include <AK/URLParser.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLHyperlinkElementUtils.h>
+#include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Loader/FrameLoader.h>
 
 namespace Web::HTML {
@@ -555,16 +556,20 @@ DeprecatedString HTMLHyperlinkElementUtils::get_an_elements_target() const
     return "";
 }
 
+// https://html.spec.whatwg.org/multipage/links.html#get-an-element's-noopener
 bool HTMLHyperlinkElementUtils::get_an_elements_noopener(StringView target) const
 {
     // To get an element's noopener, given an a, area, or form element element and a string target:
+    auto rel = hyperlink_element_utils_rel().to_lowercase();
+    auto link_types = rel.view().split_view_if(Infra::is_ascii_whitespace);
 
-    // FIXME: 1. If element's link types include the noopener or noreferrer
-    // keyword, then return true.
+    // 1. If element's link types include the noopener or noreferrer keyword, then return true.
+    if (link_types.contains_slow("noopener"sv) || link_types.contains_slow("noreferrer"sv))
+        return true;
 
-    // FIXME: 2. If element's link types do not include the opener keyword and
-    // target is an ASCII case-insensitive match for "_blank", then return true.
-    if (target.equals_ignoring_case("_blank"sv))
+    // 2. If element's link types do not include the opener keyword and
+    //    target is an ASCII case-insensitive match for "_blank", then return true.
+    if (!link_types.contains_slow("opener"sv) && target.equals_ignoring_case("_blank"sv))
         return true;
 
     // 3. Return false.

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
@@ -55,6 +55,7 @@ protected:
     virtual bool hyperlink_element_utils_is_html_anchor_element() const = 0;
     virtual bool hyperlink_element_utils_is_connected() const = 0;
     virtual DeprecatedString hyperlink_element_utils_target() const = 0;
+    virtual DeprecatedString hyperlink_element_utils_rel() const = 0;
     virtual void hyperlink_element_utils_queue_an_element_task(HTML::Task::Source source, Function<void()> steps) = 0;
 
     void set_the_url();


### PR DESCRIPTION
This removes two fix me in HTMLHyperlinkElementUtils