### PR TITLE
Meta: Fix `mke2fs` on MacOS

### DIFF
--- a/Meta/.shell_include.sh
+++ b/Meta/.shell_include.sh
@@ -20,9 +20,8 @@ die() {
 find_executable() {
   paths=("/usr/sbin" "/sbin")
 
-  if [ "$(uname -s)" = "Darwin" ]; then
-    paths+=("/usr/local/opt/e2fsprogs/bin" "/usr/local/opt/e2fsprogs/sbin")
-    paths+=("/opt/homebrew/opt/e2fsprogs/bin" "/opt/homebrew/opt/e2fsprogs/sbin")
+  if [ "$(uname -s)" = "Darwin" ] && [ -n "${HOMEBREW_PREFIX}" ]; then
+    paths+=("${HOMEBREW_PREFIX}/opt/e2fsprogs/bin" "${HOMEBREW_PREFIX}/opt/e2fsprogs/sbin")
   fi
 
   executable="${1}"
@@ -45,3 +44,4 @@ find_executable() {
 FUSE2FS_PATH="$(find_executable fuse2fs)"
 RESIZE2FS_PATH="$(find_executable resize2fs)"
 E2FSCK_PATH="$(find_executable e2fsck)"
+MKE2FS_PATH="$(find_executable mke2fs)"

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -119,11 +119,7 @@ if [ $USE_EXISTING -ne 1 ]; then
         (echo "e 0"; echo 83; echo n; echo 0; echo "*"; echo "quit") | fdisk -e "$VND"
         newfs_ext2fs -D $INODE_SIZE -n $INODE_COUNT "/dev/r${VND}i" || die "could not create filesystem"
     else
-        if [ -x /sbin/mke2fs ]; then
-            /sbin/mke2fs -q -I $INODE_SIZE -N $INODE_COUNT _disk_image || die "could not create filesystem"
-        else
-            mke2fs -q -I $INODE_SIZE -N $INODE_COUNT _disk_image || die "could not create filesystem"
-        fi
+        "${MKE2FS_PATH}" -q -I "${INODE_SIZE}" -N "${INODE_COUNT}" _disk_image || die "could not create filesystem"
     fi
     echo "done"
 fi


### PR DESCRIPTION
Use `Meta/.shell_include.sh` to find the `mke2fs` executable.