### PR TITLE
LibPDF: Outline and PS1 small improvements

### DIFF
--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -146,7 +146,7 @@ private:
 
     PDFErrorOr<void> build_outline();
     PDFErrorOr<NonnullRefPtr<OutlineItem>> build_outline_item(NonnullRefPtr<DictObject> const& outline_item_dict);
-    PDFErrorOr<NonnullRefPtrVector<OutlineItem>> build_outline_item_chain(Value const& first_ref, Value const& last_ref);
+    PDFErrorOr<NonnullRefPtrVector<OutlineItem>> build_outline_item_chain(Value const& first_ref);
 
     PDFErrorOr<Destination> create_destination_from_parameters(NonnullRefPtr<ArrayObject>);
 

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -38,6 +38,7 @@ enum ExtendedCommand {
     DotSection,
     VStem3,
     HStem3,
+    Seac = 6,
     Div = 12,
     CallOtherSubr = 16,
     Pop,
@@ -315,6 +316,7 @@ PDFErrorOr<PS1FontProgram::Glyph> PS1FontProgram::parse_glyph(ReadonlyBytes cons
                 case DotSection:
                 case VStem3:
                 case HStem3:
+                case Seac:
                     // FIXME: Do something with these?
                     state.sp = 0;
                     break;

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -27,8 +27,8 @@ PDFErrorOr<Type1Font::Data> Type1Font::parse_data(Document* document, NonnullRef
         if (!font_file_dict->contains(CommonNames::Length1, CommonNames::Length2))
             return Error { Error::Type::Parse, "Embedded type 1 font is incomplete" };
 
-        auto length1 = font_file_dict->get_value(CommonNames::Length1).get<int>();
-        auto length2 = font_file_dict->get_value(CommonNames::Length2).get<int>();
+        auto length1 = TRY(document->resolve(font_file_dict->get_value(CommonNames::Length1))).get<int>();
+        auto length2 = TRY(document->resolve(font_file_dict->get_value(CommonNames::Length2))).get<int>();
 
         data.font_program = adopt_ref(*new PS1FontProgram());
         TRY(data.font_program->create(font_file_stream->bytes(), data.encoding, length1, length2));


### PR DESCRIPTION
These are some minor improvements on how we load a document's outline (the outline is over-specified with links going up and down, left and right through the outline hierarchy, and they are not always in sync) and on Type1 font handling. After these changes we can load the Adobe Type 1 Font Format PDF!

![T1_SPEC.pdf_p29_after](https://user-images.githubusercontent.com/620848/207913629-9f3a781e-6b3b-436b-84a9-ae564ee220cd.png)