### PR TITLE
LibWeb: Fix bug in BFC that independent FC assigned to wrong variable

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -377,7 +377,8 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     OwnPtr<FormattingContext> independent_formatting_context;
     if (!box.is_replaced_box() && box.has_children()) {
-        if (auto independent_formatting_context = create_independent_formatting_context_if_needed(m_state, box)) {
+        independent_formatting_context = create_independent_formatting_context_if_needed(m_state, box);
+        if (independent_formatting_context) {
             independent_formatting_context->run(box, layout_mode, box_state.available_inner_space_or_constraints_from(available_space));
         } else {
             if (box.children_are_inline())


### PR DESCRIPTION
Bug was introduced in 210bf8adf0c431be05659140fd6de3a2cc5b7d99 It makes new variable for independent_formatting_context instead of using earlier declared one which means that
parent_context_did_dimension_child_root_box will never be called.