### PR TITLE
AK: Add DeprecatedString::find_last(StringView)

### DIFF
--- a/AK/DeprecatedString.h
+++ b/AK/DeprecatedString.h
@@ -158,7 +158,7 @@ public:
     [[nodiscard]] Optional<size_t> find(char needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
     [[nodiscard]] Optional<size_t> find(StringView needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
     [[nodiscard]] Optional<size_t> find_last(char needle) const { return StringUtils::find_last(*this, needle); }
-    // FIXME: Implement find_last(StringView) for API symmetry.
+    [[nodiscard]] Optional<size_t> find_last(StringView needle) const { return StringUtils::find_last(*this, needle); }
     Vector<size_t> find_all(StringView needle) const;
     using SearchDirection = StringUtils::SearchDirection;
     [[nodiscard]] Optional<size_t> find_any_of(StringView needles, SearchDirection direction) const { return StringUtils::find_any_of(*this, needles, direction); }

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -407,6 +407,17 @@ Optional<size_t> find_last(StringView haystack, char needle)
     return {};
 }
 
+Optional<size_t> find_last(StringView haystack, StringView needle)
+{
+    for (size_t i = haystack.length(); i > 0; --i) {
+        auto value = StringUtils::find(haystack, needle, i - 1);
+        if (value.has_value())
+            return value;
+    }
+
+    return {};
+}
+
 Optional<size_t> find_last_not(StringView haystack, char needle)
 {
     for (size_t i = haystack.length(); i > 0; --i) {

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -90,6 +90,7 @@ StringView trim_whitespace(StringView string, TrimMode mode);
 Optional<size_t> find(StringView haystack, char needle, size_t start = 0);
 Optional<size_t> find(StringView haystack, StringView needle, size_t start = 0);
 Optional<size_t> find_last(StringView haystack, char needle);
+Optional<size_t> find_last(StringView haystack, StringView needle);
 Optional<size_t> find_last_not(StringView haystack, char needle);
 Vector<size_t> find_all(StringView haystack, StringView needle);
 enum class SearchDirection {

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -116,8 +116,8 @@ public:
     }
     [[nodiscard]] Optional<size_t> find(StringView needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
     [[nodiscard]] Optional<size_t> find_last(char needle) const { return StringUtils::find_last(*this, needle); }
+    [[nodiscard]] Optional<size_t> find_last(StringView needle) const { return StringUtils::find_last(*this, needle); }
     [[nodiscard]] Optional<size_t> find_last_not(char needle) const { return StringUtils::find_last_not(*this, needle); }
-    // FIXME: Implement find_last(StringView) for API symmetry.
 
     [[nodiscard]] Vector<size_t> find_all(StringView needle) const;
 


### PR DESCRIPTION
This adds the DeprecatedString::find_last() as wrapper for StringUtils::find_last for the StringView type.