### PR TITLE
AK: Synchronize explicit instantiations of to_int and to_uint

### DIFF
--- a/AK/DeprecatedString.cpp
+++ b/AK/DeprecatedString.cpp
@@ -172,7 +172,8 @@ Optional<T> DeprecatedString::to_int(TrimWhitespace trim_whitespace) const
 template Optional<i8> DeprecatedString::to_int(TrimWhitespace) const;
 template Optional<i16> DeprecatedString::to_int(TrimWhitespace) const;
 template Optional<i32> DeprecatedString::to_int(TrimWhitespace) const;
-template Optional<i64> DeprecatedString::to_int(TrimWhitespace) const;
+template Optional<long> DeprecatedString::to_int(TrimWhitespace) const;
+template Optional<long long> DeprecatedString::to_int(TrimWhitespace) const;
 
 template<typename T>
 Optional<T> DeprecatedString::to_uint(TrimWhitespace trim_whitespace) const

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -157,8 +157,6 @@ template Optional<u16> convert_to_uint(StringView str, TrimWhitespace);
 template Optional<u32> convert_to_uint(StringView str, TrimWhitespace);
 template Optional<unsigned long> convert_to_uint(StringView str, TrimWhitespace);
 template Optional<unsigned long long> convert_to_uint(StringView str, TrimWhitespace);
-template Optional<long> convert_to_uint(StringView str, TrimWhitespace);
-template Optional<long long> convert_to_uint(StringView str, TrimWhitespace);
 
 template<typename T>
 Optional<T> convert_to_uint_from_hex(StringView str, TrimWhitespace trim_whitespace)

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -239,8 +239,6 @@ template Optional<u16> StringView::to_uint() const;
 template Optional<u32> StringView::to_uint() const;
 template Optional<unsigned long> StringView::to_uint() const;
 template Optional<unsigned long long> StringView::to_uint() const;
-template Optional<long> StringView::to_uint() const;
-template Optional<long long> StringView::to_uint() const;
 
 #ifndef KERNEL
 Optional<double> StringView::to_double(TrimWhitespace trim_whitespace) const

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -259,7 +259,7 @@ bool Editor::load_history(DeprecatedString const& path)
     auto hist = StringView { data.data(), data.size() };
     for (auto& str : hist.split_view("\n\n"sv)) {
         auto it = str.find("::"sv).value_or(0);
-        auto time = str.substring_view(0, it).to_uint<time_t>().value_or(0);
+        auto time = str.substring_view(0, it).to_int<time_t>().value_or(0);
         auto string = str.substring_view(it == 0 ? it : it + 2);
         m_history.append({ string, time });
     }
@@ -320,7 +320,7 @@ bool Editor::save_history(DeprecatedString const& path)
             file->line_begin(), file->line_end(), m_history.begin(), m_history.end(), final_history,
             [](StringView str) {
                 auto it = str.find("::"sv).value_or(0);
-                auto time = str.substring_view(0, it).to_uint<time_t>().value_or(0);
+                auto time = str.substring_view(0, it).to_int<time_t>().value_or(0);
                 auto string = str.substring_view(it == 0 ? it : it + 2);
                 return HistoryEntry { string, time };
             },


### PR DESCRIPTION
This is needed to fix the Ladybird build on macOS, which can't link `to_int<time_t>` (which is `to_int<long>`).