### PR TITLE
PixelPaint: Add a preview when scaling with the move tool

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -50,9 +50,11 @@ void MoveTool::on_mousemove(Layer* layer, MouseEvent& event)
         return;
 
     constexpr int sensitivity = 20;
-    Gfx::IntPoint grab_rect_position = Gfx::IntPoint(layer->location().x() + layer->size().width() - sensitivity / 2, layer->location().y() + layer->size().height() - sensitivity / 2);
-    Gfx::IntRect grab_rect = Gfx::IntRect(grab_rect_position, Gfx::IntSize(sensitivity, sensitivity));
-    auto updated_is_in_lower_right_corner = grab_rect.contains(event.image_event().position()); // check if the mouse is in the lower right corner
+    auto bottom_right_layer_coordinates = layer->relative_rect().bottom_right().translated(1);
+    auto bottom_right_frame_coordinates = m_editor->content_to_frame_position(bottom_right_layer_coordinates).to_rounded<int>();
+    auto grab_rect_top_left = bottom_right_frame_coordinates.translated(-sensitivity / 2);
+    auto grab_rect = Gfx::IntRect(grab_rect_top_left, Gfx::IntSize(sensitivity, sensitivity));
+    auto updated_is_in_lower_right_corner = grab_rect.contains(event.raw_event().position()); // check if the mouse is in the lower right corner
     if (m_mouse_in_resize_corner != updated_is_in_lower_right_corner) {
         m_mouse_in_resize_corner = updated_is_in_lower_right_corner;
         m_editor->update_tool_cursor();

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -13,6 +13,7 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Window.h>
+#include <LibGfx/Filters/ContrastFilter.h>
 
 namespace PixelPaint {
 
@@ -57,6 +58,9 @@ void MoveTool::on_mousemove(Layer* layer, MouseEvent& event)
         m_editor->update_tool_cursor();
     }
 
+    if (!m_layer_being_moved)
+        return;
+
     if (m_scaling) {
         auto cursor_location = event.image_event().position();
         auto width = abs(m_layer_being_moved->location().x() - cursor_location.x());
@@ -70,15 +74,13 @@ void MoveTool::on_mousemove(Layer* layer, MouseEvent& event)
         }
         m_new_layer_size = Gfx::IntSize(width, height);
         // TODO: Change this according to which direction the user is scaling
-        m_new_scaled_layer_location = Gfx::IntPoint(m_layer_being_moved->location().x(), m_layer_being_moved->location().y());
+        m_new_scaled_layer_location = m_layer_being_moved->location();
+    } else {
+        auto& image_event = event.image_event();
+        auto delta = image_event.position() - m_event_origin;
+        m_layer_being_moved->set_location(m_layer_origin.translated(delta));
     }
-
-    auto& image_event = event.image_event();
-    if (!m_layer_being_moved || m_scaling)
-        return;
-    auto delta = image_event.position() - m_event_origin;
-    m_layer_being_moved->set_location(m_layer_origin.translated(delta));
-    m_editor->layers_did_change();
+    m_editor->update();
 }
 
 void MoveTool::on_mouseup(Layer* layer, MouseEvent& event)
@@ -98,10 +100,12 @@ void MoveTool::on_mouseup(Layer* layer, MouseEvent& event)
 
     if (m_scaling) {
         m_editor->active_layer()->resize(m_new_layer_size, m_new_scaled_layer_location, Gfx::Painter::ScalingMode::BilinearBlend);
+        m_editor->layers_did_change();
     }
 
     m_scaling = false;
     m_layer_being_moved = nullptr;
+    m_cached_preview_bitmap = nullptr;
     m_editor->update_tool_cursor();
     m_editor->did_complete_action(tool_name());
 }
@@ -149,6 +153,38 @@ void MoveTool::on_keyup(GUI::KeyEvent& event)
 {
     if (event.key() == Key_Shift)
         m_keep_ascept_ratio = false;
+}
+
+void MoveTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
+{
+    if (layer != m_layer_being_moved.ptr() || !m_scaling)
+        return;
+
+    GUI::Painter painter(*m_editor);
+    painter.add_clip_rect(event.rect());
+    painter.translate(editor_layer_location(*layer));
+
+    auto dst_rect = Gfx::IntRect(Gfx::IntPoint(0, 0), m_scaling ? m_new_layer_size : layer->size());
+    auto rect_in_editor = m_editor->content_to_frame_rect(dst_rect).to_rounded<int>();
+    painter.draw_rect(rect_in_editor, Color::Black);
+    if (!m_cached_preview_bitmap.is_null() || !update_cached_preview_bitmap(layer).is_error()) {
+        painter.add_clip_rect(m_editor->content_rect());
+        painter.draw_scaled_bitmap(rect_in_editor, *m_cached_preview_bitmap, m_cached_preview_bitmap->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+    }
+}
+
+ErrorOr<void> MoveTool::update_cached_preview_bitmap(Layer const* layer)
+{
+    auto editor_rect_size = m_editor->frame_inner_rect().size();
+    auto const& source_bitmap = layer->content_bitmap();
+    auto preview_bitmap_size = editor_rect_size.contains(source_bitmap.size()) ? source_bitmap.size() : editor_rect_size;
+
+    m_cached_preview_bitmap = TRY(Gfx::Bitmap::try_create(source_bitmap.format(), preview_bitmap_size));
+    GUI::Painter preview_painter(*m_cached_preview_bitmap);
+    preview_painter.draw_scaled_bitmap(m_cached_preview_bitmap->rect(), source_bitmap, source_bitmap.rect(), 0.8f, Gfx::Painter::ScalingMode::BilinearBlend);
+    Gfx::ContrastFilter preview_filter(0.5f);
+    preview_filter.apply(*m_cached_preview_bitmap, m_cached_preview_bitmap->rect(), *m_cached_preview_bitmap, m_cached_preview_bitmap->rect());
+    return {};
 }
 
 Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> MoveTool::cursor()

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -22,10 +22,12 @@ public:
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual bool on_keydown(GUI::KeyEvent const&) override;
     virtual void on_keyup(GUI::KeyEvent&) override;
+    virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
 
 private:
     virtual StringView tool_name() const override { return "Move Tool"sv; }
+    ErrorOr<void> update_cached_preview_bitmap(Layer const* layer);
 
     RefPtr<Layer> m_layer_being_moved;
     Gfx::IntPoint m_event_origin;
@@ -35,6 +37,8 @@ private:
     bool m_scaling { false };
     bool m_mouse_in_resize_corner { false };
     bool m_keep_ascept_ratio { false };
+
+    RefPtr<Gfx::Bitmap> m_cached_preview_bitmap { nullptr };
 };
 
 }


### PR DESCRIPTION
This patch adds a preview when using the scaling function of the move tool.

https://user-images.githubusercontent.com/2817754/208017215-602c8590-ef5e-42fb-bea6-10e156884080.mp4


I have also fixed an issue where it was difficult to enter the move scaling mode when zoomed in or out too far. You have to be within 10 pixels either side of the bottom right of the active layer to activate scaling mode, but the previous code used 

There are some minor issues that I have found when implementing this that I wouldn't mind some input on:

* When scaling it is possible for the preview to draw over the rulers if they are displayed. I can see that this issue is also present for other tools that use `on_second_paint()` to draw temporary overlays (Rectangle Select, Lasso, etc.). I'm not sure of the best way to fix this issue and because it affects more than just the move tool I believe it is beyond the scope of this PR.
* The preview currently draws over the top of all other layers regardless of z-order. You could get this to work by copying all layers, in the correct order, when constructing the preview bitmap.
* I have made the preview image dark and transparent rather than hiding the current layer, as I couldn't find an easy way to do that.