### PR TITLE
PixelPaint: Disable bucket tool outside of the current selection

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
@@ -50,6 +50,9 @@ void BucketTool::on_mousedown(Layer* layer, MouseEvent& event)
     if (!layer->rect().contains(layer_event.position()))
         return;
 
+    if (auto selection = layer->image().selection(); !selection.is_empty() && !selection.is_selected(layer_event.position()))
+        return;
+
     GUI::Painter painter(layer->get_scratch_edited_bitmap());
 
     flood_fill(layer->get_scratch_edited_bitmap(), layer_event.position(), m_editor->color_for(layer_event), m_threshold);


### PR DESCRIPTION
Here is a video showing the issue:

https://user-images.githubusercontent.com/2817754/208019256-338389f2-467c-4d46-9912-ab9668c8a70b.mp4


This patch ensures that the user cannot use the bucket tool outside of the active selection.