### PR TITLE
CI: Skip Azure pipeline in a similar manner to GitHub Actions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,10 @@ While unadvertised PRs may get randomly merged by curious maintainers, you will 
 
 Ping them right away if it's something urgent! If it's less urgent, advertise your PR on Discord (`#code-review`) and ask if someone could review it.
 
+### How do I open a PR for early feedback?
+
+Prefer not to open PRs that aren't ready for final review. For early feedback, either discussion on Discord or opening a PR against your own fork is more appropriate. But if you must, you can put `[skip ci]` anywhere in the HEAD commit of your PR to at least prevent CI from running against your PR. When the PR is ready for review, remove the `[skip ci]` text.
+
 ### Who are the project maintainers?
 
 The project maintainers at this time are [@awesomekling](https://github.com/awesomekling), [@linusg](https://github.com/linusg), [@alimpfard](https://github.com/alimpfard), [@gunnarbeutner](https://github.com/gunnarbeutner), [@bgianfo](https://github.com/bgianfo), [@IdanHo](https://github.com/IdanHo), [@trflynn89](https://github.com/trflynn89), [@AtkinsSJ](https://github.com/AtkinsSJ), and [@ADKaster](https://github.com/ADKaster).

--- a/Meta/Azure/FilterPR.yml
+++ b/Meta/Azure/FilterPR.yml
@@ -1,0 +1,19 @@
+jobs:
+  - job: 'Filter_PR'
+
+    pool:
+      vmImage: ubuntu-latest
+
+    steps:
+    - checkout: self
+      persistCredentials: true
+      fetchDepth: 2
+
+    - script: |
+        commit_message=$(git log --skip 1 --max-count 1)
+
+        if [[ "${commit_message}" == *"[skip ci]"* ]]; then
+          echo "Skipping CI due to [skip ci] in commit message"
+          exit 1
+        fi
+      displayName: 'Skip CI'

--- a/Meta/Azure/Setup.yml
+++ b/Meta/Azure/Setup.yml
@@ -4,6 +4,7 @@ parameters:
 steps:
   - checkout: self
     persistCredentials: true
+    fetchDepth: 1
 
   - ${{ if eq(parameters.os, 'Serenity') }}:
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,16 @@ trigger:
     - master
 
 stages:
-  - stage: Lagom
+  - stage: FilterPR
     dependsOn: []
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+
+    jobs:
+      - template: Meta/Azure/FilterPR.yml
+
+  - stage: Lagom
+    dependsOn: FilterPR
+    condition: in(dependencies.FilterPR.result, 'Succeeded', 'Skipped')
 
     jobs:
       - template: Meta/Azure/Lagom.yml
@@ -24,7 +32,8 @@ stages:
           os: 'macOS'
 
   - stage: SerenityOS
-    dependsOn: []
+    dependsOn: FilterPR
+    condition: in(dependencies.FilterPR.result, 'Succeeded', 'Skipped')
 
     jobs:
       - template: Meta/Azure/Serenity.yml


### PR DESCRIPTION
If the HEAD commit message contains "[skip ci]", abort the Azure steps
early. Note we have to look at the HEAD~1 commit message because the
HEAD commit on PRs is actually Azure's merge branch.

This will still take CI resources to fetch the repository and inspect
the message, but by running in its own quick stage, that time should be
limited to less than a minute.

Example "skip":
https://dev.azure.com/SerenityOS/SerenityOS/_build/results?buildId=24034&view=logs&jobId=dc9fd9e3-3bca-54d4-3d73-78f0e7692e09&j=dc9fd9e3-3bca-54d4-3d73-78f0e7692e09&t=6eec0628-cd3b-5022-b8d7-182b3daeb4e0