### PR TITLE
Kernel/Graphics: VirtIO GPU fixes to restore reasonably basic functionality & good performance

### DIFF
--- a/Kernel/Graphics/VirtIOGPU/DisplayConnector.cpp
+++ b/Kernel/Graphics/VirtIOGPU/DisplayConnector.cpp
@@ -122,9 +122,9 @@ ErrorOr<void> VirtIODisplayConnector::flush_rectangle(size_t buffer_index, FBRec
         .height = rect.height
     };
 
-    m_graphics_adapter->transfer_framebuffer_data_to_host({}, *this, dirty_rect, true);
+    TRY(m_graphics_adapter->transfer_framebuffer_data_to_host({}, *this, dirty_rect, true));
     // Flushing directly to screen
-    flush_displayed_image(dirty_rect, true);
+    TRY(flush_displayed_image(dirty_rect, true));
     return {};
 }
 
@@ -139,9 +139,9 @@ ErrorOr<void> VirtIODisplayConnector::flush_first_surface()
         .height = m_display_info.rect.height
     };
 
-    m_graphics_adapter->transfer_framebuffer_data_to_host({}, *this, dirty_rect, true);
+    TRY(m_graphics_adapter->transfer_framebuffer_data_to_host({}, *this, dirty_rect, true));
     // Flushing directly to screen
-    flush_displayed_image(dirty_rect, true);
+    TRY(flush_displayed_image(dirty_rect, true));
     return {};
 }
 
@@ -241,10 +241,11 @@ void VirtIODisplayConnector::draw_ntsc_test_pattern(Badge<VirtIOGraphicsAdapter>
     dbgln_if(VIRTIO_DEBUG, "Finish drawing the pattern");
 }
 
-void VirtIODisplayConnector::flush_displayed_image(Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer)
+ErrorOr<void> VirtIODisplayConnector::flush_displayed_image(Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer)
 {
     VERIFY(m_graphics_adapter->operation_lock().is_locked());
-    m_graphics_adapter->flush_displayed_image({}, *this, dirty_rect, main_buffer);
+    TRY(m_graphics_adapter->flush_displayed_image({}, *this, dirty_rect, main_buffer));
+    return {};
 }
 
 void VirtIODisplayConnector::set_dirty_displayed_rect(Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer)

--- a/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
+++ b/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
@@ -42,7 +42,7 @@ public:
 private:
     void initialize_console();
     virtual bool mutable_mode_setting_capable() const override { return true; }
-    virtual bool double_framebuffering_capable() const override { return true; }
+    virtual bool double_framebuffering_capable() const override { return false; }
     virtual bool partial_flush_support() const override { return true; }
     virtual ErrorOr<void> set_mode_setting(ModeSetting const&) override;
     virtual ErrorOr<void> set_safe_mode_setting() override;
@@ -85,9 +85,6 @@ private:
     LockRefPtr<Graphics::Console> m_console;
     Graphics::VirtIOGPU::Protocol::DisplayInfoResponse::Display m_display_info {};
     Graphics::VirtIOGPU::ScanoutID m_scanout_id;
-
-    // 2D framebuffer Member data
-    Atomic<size_t, AK::memory_order_relaxed> m_last_set_buffer_index { 0 };
 
     constexpr static size_t NUM_TRANSFER_REGION_PAGES = 256;
 };

--- a/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
+++ b/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
@@ -68,7 +68,7 @@ private:
 private:
     VirtIODisplayConnector(VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id);
 
-    void flush_displayed_image(Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
+    ErrorOr<void> flush_displayed_image(Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
     void set_dirty_displayed_rect(Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
 
     void query_display_information();

--- a/Kernel/Graphics/VirtIOGPU/GPU3DDevice.h
+++ b/Kernel/Graphics/VirtIOGPU/GPU3DDevice.h
@@ -95,10 +95,10 @@ class VirtIOGPU3DDevice : public CharacterDevice {
     friend class DeviceManagement;
 
 public:
-    static NonnullLockRefPtr<VirtIOGPU3DDevice> must_create(VirtIOGraphicsAdapter const&);
+    static ErrorOr<NonnullLockRefPtr<VirtIOGPU3DDevice>> try_create(VirtIOGraphicsAdapter&);
 
 private:
-    VirtIOGPU3DDevice(VirtIOGraphicsAdapter const& graphics_adapter, NonnullOwnPtr<Memory::Region> transfer_buffer_region);
+    VirtIOGPU3DDevice(VirtIOGraphicsAdapter const& graphics_adapter, NonnullOwnPtr<Memory::Region> transfer_buffer_region, Graphics::VirtIOGPU::ContextID kernel_context_id);
 
     class PerContextState final : public AtomicRefCounted<PerContextState> {
     public:

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
@@ -56,7 +56,6 @@ ErrorOr<void> VirtIOGraphicsAdapter::mode_set_resolution(Badge<VirtIODisplayConn
     VERIFY(connector.scanout_id() < VIRTIO_GPU_MAX_SCANOUTS);
     auto rounded_buffer_size = TRY(calculate_framebuffer_size(width, height));
     TRY(attach_physical_range_to_framebuffer(connector, true, 0, rounded_buffer_size));
-    TRY(attach_physical_range_to_framebuffer(connector, false, rounded_buffer_size, rounded_buffer_size));
     return {};
 }
 

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -40,7 +40,6 @@ public:
     static NonnullLockRefPtr<VirtIOGraphicsAdapter> initialize(PCI::DeviceIdentifier const&);
 
     virtual void initialize() override;
-    void initialize_3d_device();
 
     ErrorOr<void> mode_set_resolution(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, size_t width, size_t height);
     void set_dirty_displayed_rect(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
@@ -49,6 +48,8 @@ public:
 
 private:
     ErrorOr<void> attach_physical_range_to_framebuffer(VirtIODisplayConnector& connector, bool main_buffer, size_t framebuffer_offset, size_t framebuffer_size);
+
+    ErrorOr<void> initialize_3d_device();
 
     void flush_dirty_rectangle(Graphics::VirtIOGPU::ScanoutID, Graphics::VirtIOGPU::ResourceID, Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect);
     struct Scanout {


### PR DESCRIPTION
Earlier today I tested the VirtIO GPU driver and saw that performance regressed tremendously since the last time I checked it. People on the discord server also reported same observations, so I concluded that we regressed the driver somehow.

This PR does 3 things:
- Introduce proper error propagation around the driver code so we know if something failed.
- Disable double buffering completely on the driver - it seems that with this feature being turned on, performance is actually worse. Also, there's a weird bug that the screen never gets updated (I tested this condition for 1 screen) when applying the third commit (which is also the third *thing*).
- Synchronous GPU commands no longer rely on the clunky Wait queue mechanism, but instead we have new polling timeout-based mechanism to ensure we never get stuck because of faulty hardware (and I did manage in the past to get into some weird stuck-in-loop state with the VirtIOGPU driver and if I recall correctly, it seemed to be something faulty with QEMU rather our Kernel). This matches what other drivers do around in the Kernel - they never get stuck in forever loop, but instead they have a timeout in that loop so the system keeps being functional.

cc @ccapitalK @AtkinsSJ @sunverwerth 