### PR TITLE
FileManager: Clear the selection after deleting files

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -546,6 +546,7 @@ void DirectoryView::do_delete(bool should_confirm)
     auto paths = selected_file_paths();
     VERIFY(!paths.is_empty());
     delete_paths(paths, should_confirm, window());
+    current_view().selection().clear();
 }
 
 bool DirectoryView::can_modify_current_selection()


### PR DESCRIPTION
This fixes a crash that occurs when deleting multiple files with FileManager and is more logical in general.