### PR TITLE
AK: Make StringUtils::matches() handle escaping correctly

### DIFF
--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -62,8 +62,11 @@ bool matches(StringView str, StringView mask, CaseSensitivity case_sensitivity, 
             record_span(string_ptr - string_start, 1);
             break;
         case '\\':
-            ++mask_ptr;
-            break;
+            // if backslash is last character in mask, just treat it as an exact match
+            // otherwise use it as escape for next character
+            if (mask_ptr + 1 < mask_end)
+                ++mask_ptr;
+            [[fallthrough]];
         default:
             auto p = *mask_ptr;
             auto ch = *string_ptr;

--- a/Base/home/anon/.config/BrowserContentFilters.txt
+++ b/Base/home/anon/.config/BrowserContentFilters.txt
@@ -400,8 +400,8 @@ glassboxdigital.io
 go-mpulse.net
 go2speed.org
 google-analytics.com
-google.com/gen_204?
-google.com/log?
+google.com/gen_204\?
+google.com/log\?
 googleadservices.com
 googleoptimize.com
 googlesyndication.com

--- a/Tests/AK/TestStringUtils.cpp
+++ b/Tests/AK/TestStringUtils.cpp
@@ -76,6 +76,21 @@ TEST_CASE(matches_trailing)
     EXPECT(AK::StringUtils::matches("ab"sv, "*ab****"sv));
 }
 
+TEST_CASE(match_backslash_escape)
+{
+    EXPECT(AK::StringUtils::matches("ab*"sv, "ab\\*"sv));
+    EXPECT(!AK::StringUtils::matches("abc"sv, "ab\\*"sv));
+    EXPECT(!AK::StringUtils::matches("abcd"sv, "ab\\*"sv));
+    EXPECT(AK::StringUtils::matches("ab?"sv, "ab\\?"sv));
+    EXPECT(!AK::StringUtils::matches("abc"sv, "ab\\?"sv));
+}
+
+TEST_CASE(match_trailing_backslash)
+{
+    EXPECT(AK::StringUtils::matches("x\\"sv, "x\\"sv));
+    EXPECT(AK::StringUtils::matches("x\\"sv, "x\\\\"sv));
+}
+
 TEST_CASE(convert_to_int)
 {
     auto value = AK::StringUtils::convert_to_int(StringView());


### PR DESCRIPTION
Previously any backslash and the character following it were ignored.
This commit adds a fall through to match the character following the
backslash without checking whether it is "special".
