### PR TITLE
Kernel/Plan9FS: Propagate errors in Plan9FSMessage::append_data

### DIFF
--- a/Kernel/FileSystem/Plan9FS/Inode.cpp
+++ b/Kernel/FileSystem/Plan9FS/Inode.cpp
@@ -111,7 +111,7 @@ ErrorOr<size_t> Plan9FSInode::write_bytes_locked(off_t offset, size_t size, User
 
     Plan9FSMessage message { fs(), Plan9FSMessage::Type::Twrite };
     message << fid() << (u64)offset;
-    message.append_data(data_copy->view());
+    TRY(message.append_data(data_copy->view()));
     TRY(fs().post_message_and_wait_for_a_reply(message));
 
     u32 nwritten;

--- a/Kernel/FileSystem/Plan9FS/Message.cpp
+++ b/Kernel/FileSystem/Plan9FS/Message.cpp
@@ -38,11 +38,11 @@ Plan9FSMessage& Plan9FSMessage::operator<<(StringView string)
     return *this;
 }
 
-void Plan9FSMessage::append_data(StringView data)
+ErrorOr<void> Plan9FSMessage::append_data(StringView data)
 {
     *this << static_cast<u32>(data.length());
-    // FIXME: Handle append failure.
-    (void)m_builder.append(data);
+    TRY(m_builder.append(data));
+    return {};
 }
 
 Plan9FSMessage::Decoder& Plan9FSMessage::Decoder::operator>>(u8& number)

--- a/Kernel/FileSystem/Plan9FS/Message.h
+++ b/Kernel/FileSystem/Plan9FS/Message.h
@@ -135,7 +135,7 @@ public:
     Plan9FSMessage& operator<<(u32);
     Plan9FSMessage& operator<<(u64);
     Plan9FSMessage& operator<<(StringView);
-    void append_data(StringView);
+    ErrorOr<void> append_data(StringView);
 
     template<typename T>
     Plan9FSMessage& operator>>(T& t)


### PR DESCRIPTION
A small patch that takes care of a FIXME