### PR TITLE
HackStudio: Avoid infinite tab switch loop when opening multiple files

### DIFF
--- a/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
+++ b/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
@@ -131,7 +131,7 @@ FindInFilesWidget::FindInFilesWidget()
         auto& match = *(const Match*)index.internal_data();
         open_file(match.filename);
         current_editor().set_selection(match.range);
-        current_editor().set_focus(true);
+        focus_current_editor();
     };
 
     m_button->on_click = [this](auto) {

--- a/Userland/DevTools/HackStudio/HackStudio.h
+++ b/Userland/DevTools/HackStudio/HackStudio.h
@@ -15,6 +15,7 @@
 namespace HackStudio {
 
 GUI::TextEditor& current_editor();
+void focus_current_editor();
 void open_file(DeprecatedString const&);
 RefPtr<EditorWrapper> current_editor_wrapper();
 void open_file(DeprecatedString const&, size_t line, size_t column);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -80,6 +80,7 @@ public:
 
     static Vector<DeprecatedString> read_recent_projects();
 
+    void focus_current_editor();
     void update_current_editor_title();
     void update_window_title();
 
@@ -260,5 +261,7 @@ private:
     Mode m_mode { Mode::Code };
     OwnPtr<Coredump::Inspector> m_coredump_inspector;
     OwnPtr<ProjectBuilder> m_project_builder;
+
+    RefPtr<EditorWrapper> m_expected_focus_editor { nullptr };
 };
 }

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -152,6 +152,11 @@ GUI::TextEditor& current_editor()
     return s_hack_studio_widget->current_editor();
 }
 
+void focus_current_editor()
+{
+    return s_hack_studio_widget->focus_current_editor();
+}
+
 void open_file(DeprecatedString const& filename)
 {
     s_hack_studio_widget->open_file(filename);


### PR DESCRIPTION
Wanted to look at this one since it looked quite funny :^)

This seemed to come from an awkward interplay of deferred callbacks and doubly deferred callbacks. This is now fixed with a workaround to prevent `current_editor().set_focus(true)' from updating the editor if the current editor changed by the time the (deferred) focus event fires.

But the infinite loop came from something like this:

```
set_tab(A)        // Active tab A
defer set_tab(A)  // from on_change()
set_tab(B)        // Active tab B
defer set_tab(B)  // from on_change()
```
-> Deferred invokes run:

```
set_tab(A)        // Tab changed from B -> A
defer set_tab(A)  // fire on_change() -- queue new defer
set_tab(B)        // Tab changed from A -> B
defer set_tab(B)  // fire on_change() -- queue new defer
```
:infinteyakloop:

Fixes https://github.com/SerenityOS/serenity/issues/16263