### PR TITLE
PixelPaint: Redraw active layer boundary when the active layer changes

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -497,6 +497,8 @@ void ImageEditor::set_active_layer(Layer* layer)
         if (on_active_layer_change)
             on_active_layer_change({});
     }
+    if (m_show_active_layer_boundary)
+        update();
 }
 
 ErrorOr<void> ImageEditor::add_new_layer_from_selection()


### PR DESCRIPTION
Just a quick fix for something I came across while testing the move tool. The active layer boundary wasn't being redrawn when a new layer was selected

Here's a video of the fixed behaviour:

https://user-images.githubusercontent.com/2817754/208208833-a185de11-d9bc-4244-b9d6-d745eb988ce8.mp4


