### PR TITLE
PixelPaint: Guide tool and move tool performance improvements

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1075,12 +1075,13 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
         m_tab_widget->set_tab_title(image_editor, title);
     };
 
-    image_editor.on_modified_change = [&](auto const modified) {
+    image_editor.on_modified_change = Core::debounce([&](auto const modified) {
         m_tab_widget->set_tab_modified(image_editor, modified);
         update_window_modified();
         m_histogram_widget->image_changed();
         m_vectorscope_widget->image_changed();
-    };
+    },
+        100);
 
     image_editor.on_image_mouse_position_change = [&](auto const& mouse_position) {
         auto const& image_size = current_image_editor()->image().size();

--- a/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
@@ -91,7 +91,7 @@ void GuideTool::on_mouseup(Layer*, MouseEvent&)
         || (m_selected_guide->orientation() == Guide::Orientation::Horizontal && m_selected_guide->offset() > editor()->image().size().height())
         || (m_selected_guide->orientation() == Guide::Orientation::Vertical && m_selected_guide->offset() > editor()->image().size().width())) {
         editor()->remove_guide(*m_selected_guide);
-        editor()->layers_did_change();
+        editor()->update();
     }
 
     m_selected_guide = nullptr;
@@ -122,7 +122,7 @@ void GuideTool::on_mousemove(Layer*, MouseEvent& event)
 
     GUI::Application::the()->show_tooltip_immediately(DeprecatedString::formatted("{}", new_offset), GUI::Application::the()->tooltip_source_widget());
 
-    editor()->layers_did_change();
+    editor()->update();
 }
 
 void GuideTool::on_context_menu(Layer*, GUI::ContextMenuEvent& event)


### PR DESCRIPTION
This patch improves the performance of the move tool when using arrow keys and the guide tool when dragging a guide. 

Both of these scenarios would cause a lot of calls to `ImageEditor::update_modified()`, which would cause the histogram and vectorscope widgets to update repeatedly. This caused the program to lock up for large images.