### PR TITLE
LibWeb: Implement missing methods of NamedNodeMap

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -103,7 +103,7 @@ WebIDL::ExceptionOr<Attr const*> NamedNodeMap::remove_named_item(StringView qual
         return WebIDL::NotFoundError::create(realm(), DeprecatedString::formatted("Attribute with name '{}' not found", qualified_name));
 
     // 3. Return attr.
-    return nullptr;
+    return attribute;
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -92,6 +92,12 @@ WebIDL::ExceptionOr<Attr const*> NamedNodeMap::set_named_item(Attr& attribute)
     return set_attribute(attribute);
 }
 
+// https://dom.spec.whatwg.org/#dom-namednodemap-setnameditemns
+WebIDL::ExceptionOr<Attr const*> NamedNodeMap::set_named_item_ns(Attr& attribute)
+{
+    return set_attribute(attribute);
+}
+
 // https://dom.spec.whatwg.org/#dom-namednodemap-removenameditem
 WebIDL::ExceptionOr<Attr const*> NamedNodeMap::remove_named_item(StringView qualified_name)
 {

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -80,6 +80,12 @@ Attr const* NamedNodeMap::get_named_item(StringView qualified_name) const
     return get_attribute(qualified_name);
 }
 
+// https://dom.spec.whatwg.org/#dom-namednodemap-getnameditemns
+Attr const* NamedNodeMap::get_named_item_ns(StringView namespace_, StringView local_name) const
+{
+    return get_attribute_ns(namespace_, local_name);
+}
+
 // https://dom.spec.whatwg.org/#dom-namednodemap-setnameditem
 WebIDL::ExceptionOr<Attr const*> NamedNodeMap::set_named_item(Attr& attribute)
 {

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -106,6 +106,20 @@ WebIDL::ExceptionOr<Attr const*> NamedNodeMap::remove_named_item(StringView qual
     return attribute;
 }
 
+// https://dom.spec.whatwg.org/#dom-namednodemap-removenameditemns
+WebIDL::ExceptionOr<Attr const*> NamedNodeMap::remove_named_item_ns(StringView namespace_, StringView local_name)
+{
+    // 1. Let attr be the result of removing an attribute given namespace, localName, and element.
+    auto const* attribute = remove_attribute_ns(namespace_, local_name);
+
+    // 2. If attr is null, then throw a "NotFoundError" DOMException.
+    if (!attribute)
+        return WebIDL::NotFoundError::create(realm(), DeprecatedString::formatted("Attribute with namespace '{}' and local name '{}' not found", namespace_, local_name));
+
+    // 3. Return attr.
+    return attribute;
+}
+
 // https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name
 Attr* NamedNodeMap::get_attribute(StringView qualified_name, size_t* item_index)
 {
@@ -248,6 +262,22 @@ Attr const* NamedNodeMap::remove_attribute(StringView qualified_name)
 
     // 1. Let attr be the result of getting an attribute given qualifiedName and element.
     auto const* attribute = get_attribute(qualified_name, &item_index);
+
+    // 2. If attr is non-null, then remove attr.
+    if (attribute)
+        remove_attribute_at_index(item_index);
+
+    // 3. Return attr.
+    return attribute;
+}
+
+// https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-namespace
+Attr const* NamedNodeMap::remove_attribute_ns(StringView namespace_, StringView local_name)
+{
+    size_t item_index = 0;
+
+    // 1. Let attr be the result of getting an attribute given namespace, localName, and element.
+    auto const* attribute = get_attribute_ns(namespace_, local_name, &item_index);
 
     // 2. If attr is non-null, then remove attr.
     if (attribute)

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
  * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Alexander Narsudinov <a.narsudinov@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -125,6 +126,33 @@ Attr const* NamedNodeMap::get_attribute(StringView qualified_name, size_t* item_
                 return attribute.ptr();
         }
 
+        if (item_index)
+            ++(*item_index);
+    }
+
+    return nullptr;
+}
+
+// https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace
+Attr* NamedNodeMap::get_attribute_ns(StringView namespace_, StringView local_name, size_t* item_index)
+{
+    return const_cast<Attr*>(const_cast<NamedNodeMap const*>(this)->get_attribute_ns(namespace_, local_name, item_index));
+}
+
+// https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace
+Attr const* NamedNodeMap::get_attribute_ns(StringView namespace_, StringView local_name, size_t* item_index) const
+{
+    if (item_index)
+        *item_index = 0;
+
+    // 1. If namespace is the empty string, then set it to null.
+    if (namespace_.is_empty())
+        namespace_ = {};
+
+    // 2. Return the attribute in element’s attribute list whose namespace is namespace and local name is localName, if any; otherwise null.
+    for (auto const& attribute : m_attributes) {
+        if (attribute->namespace_uri() == namespace_ && attribute->local_name() == local_name)
+            return attribute.ptr();
         if (item_index)
             ++(*item_index);
     }

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -168,9 +168,8 @@ WebIDL::ExceptionOr<Attr const*> NamedNodeMap::set_attribute(Attr& attribute)
         return WebIDL::InUseAttributeError::create(realm(), "Attribute must not already be in use"sv);
 
     // 2. Let oldAttr be the result of getting an attribute given attr’s namespace, attr’s local name, and element.
-    // FIXME: When getNamedItemNS is implemented, use that instead.
     size_t old_attribute_index = 0;
-    auto* old_attribute = get_attribute(attribute.local_name(), &old_attribute_index);
+    auto* old_attribute = get_attribute_ns(attribute.namespace_uri(), attribute.local_name(), &old_attribute_index);
 
     // 3. If oldAttr is attr, return attr.
     if (old_attribute == &attribute)

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -36,6 +36,7 @@ public:
     // Methods defined by the spec for JavaScript:
     Attr const* item(u32 index) const;
     Attr const* get_named_item(StringView qualified_name) const;
+    Attr const* get_named_item_ns(StringView namespace_, StringView local_name) const;
     WebIDL::ExceptionOr<Attr const*> set_named_item(Attr& attribute);
     WebIDL::ExceptionOr<Attr const*> remove_named_item(StringView qualified_name);
 

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -39,6 +39,7 @@ public:
     Attr const* get_named_item_ns(StringView namespace_, StringView local_name) const;
     WebIDL::ExceptionOr<Attr const*> set_named_item(Attr& attribute);
     WebIDL::ExceptionOr<Attr const*> remove_named_item(StringView qualified_name);
+    WebIDL::ExceptionOr<Attr const*> remove_named_item_ns(StringView namespace_, StringView local_name);
 
     // Methods defined by the spec for internal use:
     Attr* get_attribute(StringView qualified_name, size_t* item_index = nullptr);
@@ -49,6 +50,7 @@ public:
     void replace_attribute(Attr& old_attribute, Attr& new_attribute, size_t old_attribute_index);
     void append_attribute(Attr& attribute);
     Attr const* remove_attribute(StringView qualified_name);
+    Attr const* remove_attribute_ns(StringView namespace_, StringView local_name);
 
 private:
     explicit NamedNodeMap(Element&);

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
  * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Alexander Narsudinov <a.narsudinov@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -40,7 +41,9 @@ public:
 
     // Methods defined by the spec for internal use:
     Attr* get_attribute(StringView qualified_name, size_t* item_index = nullptr);
+    Attr* get_attribute_ns(StringView namespace_, StringView local_name, size_t* item_index = nullptr);
     Attr const* get_attribute(StringView qualified_name, size_t* item_index = nullptr) const;
+    Attr const* get_attribute_ns(StringView namespace_, StringView local_name, size_t* item_index = nullptr) const;
     WebIDL::ExceptionOr<Attr const*> set_attribute(Attr& attribute);
     void replace_attribute(Attr& old_attribute, Attr& new_attribute, size_t old_attribute_index);
     void append_attribute(Attr& attribute);

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -38,6 +38,7 @@ public:
     Attr const* get_named_item(StringView qualified_name) const;
     Attr const* get_named_item_ns(StringView namespace_, StringView local_name) const;
     WebIDL::ExceptionOr<Attr const*> set_named_item(Attr& attribute);
+    WebIDL::ExceptionOr<Attr const*> set_named_item_ns(Attr& attribute);
     WebIDL::ExceptionOr<Attr const*> remove_named_item(StringView qualified_name);
     WebIDL::ExceptionOr<Attr const*> remove_named_item_ns(StringView namespace_, StringView local_name);
 

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.idl
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.idl
@@ -9,7 +9,7 @@ interface NamedNodeMap {
     Attr? getNamedItemNS(DOMString? namespace, DOMString localName);
 
     [CEReactions] Attr? setNamedItem(Attr attr);
-    // [CEReactions] Attr? setNamedItemNS(Attr attr);
+    [CEReactions] Attr? setNamedItemNS(Attr attr);
 
     [CEReactions] Attr removeNamedItem(DOMString qualifiedName);
     [CEReactions] Attr removeNamedItemNS(DOMString? namespace, DOMString localName);

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.idl
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.idl
@@ -6,7 +6,7 @@ interface NamedNodeMap {
 
     getter Attr? item(unsigned long index);
     getter Attr? getNamedItem(DOMString qualifiedName);
-    // Attr? getNamedItemNS(DOMString? namespace, DOMString localName);
+    Attr? getNamedItemNS(DOMString? namespace, DOMString localName);
 
     [CEReactions] Attr? setNamedItem(Attr attr);
     // [CEReactions] Attr? setNamedItemNS(Attr attr);

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.idl
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.idl
@@ -12,5 +12,5 @@ interface NamedNodeMap {
     // [CEReactions] Attr? setNamedItemNS(Attr attr);
 
     [CEReactions] Attr removeNamedItem(DOMString qualifiedName);
-    // [CEReactions] Attr removeNamedItemNS(DOMString? namespace, DOMString localName);
+    [CEReactions] Attr removeNamedItemNS(DOMString? namespace, DOMString localName);
 };


### PR DESCRIPTION
I've been looking SerenityOS youtube channel since 2020 and it looks fun to me to participate in FIXME roulette! :^)

In this PR I implemented a several missing namespace aware NamedNodeMap APIs and eliminated one FIXME related to it.

Your feedback is welcome :)