### PR TITLE
PDFVIewer + LibPDF: Improve Document Outline display

### DIFF
--- a/Userland/Applications/PDFViewer/OutlineModel.cpp
+++ b/Userland/Applications/PDFViewer/OutlineModel.cpp
@@ -7,16 +7,17 @@
 #include "OutlineModel.h"
 #include <LibGfx/Font/FontDatabase.h>
 
-NonnullRefPtr<OutlineModel> OutlineModel::create(NonnullRefPtr<PDF::OutlineDict> const& outline)
+ErrorOr<NonnullRefPtr<OutlineModel>> OutlineModel::create(NonnullRefPtr<PDF::OutlineDict> const& outline)
 {
-    return adopt_ref(*new OutlineModel(outline));
+    auto outline_model = adopt_ref(*new OutlineModel(outline));
+    outline_model->m_closed_item_icon.set_bitmap_for_size(16, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/book.png"sv)));
+    outline_model->m_open_item_icon.set_bitmap_for_size(16, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/book-open.png"sv)));
+    return outline_model;
 }
 
 OutlineModel::OutlineModel(NonnullRefPtr<PDF::OutlineDict> const& outline)
     : m_outline(outline)
 {
-    m_closed_item_icon.set_bitmap_for_size(16, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/book.png"sv).release_value_but_fixme_should_propagate_errors());
-    m_open_item_icon.set_bitmap_for_size(16, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/book-open.png"sv).release_value_but_fixme_should_propagate_errors());
 }
 
 void OutlineModel::set_index_open_state(const GUI::ModelIndex& index, bool is_open)

--- a/Userland/Applications/PDFViewer/OutlineModel.cpp
+++ b/Userland/Applications/PDFViewer/OutlineModel.cpp
@@ -10,6 +10,7 @@
 #include <LibGUI/ModelRole.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/TextAlignment.h>
+#include <LibPDF/Document.h>
 
 enum Columns {
     Page,
@@ -58,6 +59,12 @@ int OutlineModel::tree_column() const
 int OutlineModel::column_count(const GUI::ModelIndex&) const
 {
     return Columns::_Count;
+}
+
+PDF::Destination const& OutlineModel::get_destination(GUI::ModelIndex const& index)
+{
+    auto* outline_item = static_cast<PDF::OutlineItem*>(index.internal_data());
+    return outline_item->dest;
 }
 
 GUI::Variant OutlineModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const

--- a/Userland/Applications/PDFViewer/OutlineModel.h
+++ b/Userland/Applications/PDFViewer/OutlineModel.h
@@ -12,7 +12,7 @@
 
 class OutlineModel final : public GUI::Model {
 public:
-    static NonnullRefPtr<OutlineModel> create(NonnullRefPtr<PDF::OutlineDict> const& outline);
+    static ErrorOr<NonnullRefPtr<OutlineModel>> create(NonnullRefPtr<PDF::OutlineDict> const& outline);
 
     void set_index_open_state(const GUI::ModelIndex& index, bool is_open);
 

--- a/Userland/Applications/PDFViewer/OutlineModel.h
+++ b/Userland/Applications/PDFViewer/OutlineModel.h
@@ -23,6 +23,8 @@ public:
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex&) const override;
 
+    static PDF::Destination const& get_destination(GUI::ModelIndex const&);
+
 private:
     OutlineModel(NonnullRefPtr<PDF::OutlineDict> const& outline);
 

--- a/Userland/Applications/PDFViewer/OutlineModel.h
+++ b/Userland/Applications/PDFViewer/OutlineModel.h
@@ -18,6 +18,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex&) const override;
     virtual int column_count(const GUI::ModelIndex&) const override;
+    virtual int tree_column() const override;
     virtual GUI::Variant data(const GUI::ModelIndex& index, GUI::ModelRole role) const override;
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex&) const override;

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -376,11 +376,11 @@ PDF::PDFErrorOr<void> PDFViewerWidget::try_open_file(Core::File& file)
 
     if (document->outline()) {
         auto outline = document->outline();
-        m_sidebar->set_outline(outline.release_nonnull());
+        TRY(m_sidebar->set_outline(outline.release_nonnull()));
         m_sidebar->set_visible(true);
         m_sidebar_open = true;
     } else {
-        m_sidebar->set_outline({});
+        TRY(m_sidebar->set_outline({}));
         m_sidebar->set_visible(false);
         m_sidebar_open = false;
     }

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -10,6 +10,7 @@
 #include "AK/DeprecatedString.h"
 #include "AK/Format.h"
 #include "LibGUI/Forward.h"
+#include "LibPDF/Document.h"
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
 #include <AK/Variant.h>
@@ -167,6 +168,13 @@ PDFViewerWidget::PDFViewerWidget()
     m_sidebar = h_splitter.add<SidebarWidget>();
     m_sidebar->set_preferred_width(200);
     m_sidebar->set_visible(false);
+    m_sidebar->on_destination_selected = [&](PDF::Destination const& destination) {
+        auto maybe_page = destination.page;
+        if (!maybe_page.has_value())
+            return;
+        auto page = maybe_page.release_value();
+        m_viewer->set_current_page(page);
+    };
 
     auto& v_splitter = h_splitter.add<GUI::VerticalSplitter>();
     v_splitter.layout()->set_spacing(4);

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.h
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.h
@@ -32,6 +32,7 @@ private:
     PDFViewerWidget();
 
     void initialize_toolbar(GUI::Toolbar&);
+    PDF::PDFErrorOr<void> try_open_file(Core::File&);
 
     RefPtr<PDFViewer> m_viewer;
     RefPtr<SidebarWidget> m_sidebar;

--- a/Userland/Applications/PDFViewer/SidebarWidget.cpp
+++ b/Userland/Applications/PDFViewer/SidebarWidget.cpp
@@ -22,6 +22,8 @@ SidebarWidget::SidebarWidget()
 
     m_outline_tree_view = outline_container.add<GUI::TreeView>();
     m_outline_tree_view->set_activates_on_selection(true);
+    m_outline_tree_view->set_should_fill_selected_rows(true);
+    m_outline_tree_view->set_selection_behavior(GUI::AbstractView::SelectionBehavior::SelectRows);
 
     auto& thumbnails_container = tab_bar.add_tab<GUI::Widget>("Thumbnails");
     thumbnails_container.set_layout<GUI::VerticalBoxLayout>();

--- a/Userland/Applications/PDFViewer/SidebarWidget.cpp
+++ b/Userland/Applications/PDFViewer/SidebarWidget.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "SidebarWidget.h"
+#include "OutlineModel.h"
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/TabWidget.h>
 
@@ -24,6 +25,13 @@ SidebarWidget::SidebarWidget()
     m_outline_tree_view->set_activates_on_selection(true);
     m_outline_tree_view->set_should_fill_selected_rows(true);
     m_outline_tree_view->set_selection_behavior(GUI::AbstractView::SelectionBehavior::SelectRows);
+    m_outline_tree_view->on_selection_change = [this]() {
+        auto& selection = m_outline_tree_view->selection();
+        if (selection.is_empty())
+            return;
+        auto destination = OutlineModel::get_destination(selection.first());
+        on_destination_selected(destination);
+    };
 
     auto& thumbnails_container = tab_bar.add_tab<GUI::Widget>("Thumbnails");
     thumbnails_container.set_layout<GUI::VerticalBoxLayout>();

--- a/Userland/Applications/PDFViewer/SidebarWidget.h
+++ b/Userland/Applications/PDFViewer/SidebarWidget.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "LibGUI/ModelIndex.h"
+#include "LibPDF/Document.h"
 #include "OutlineModel.h"
 #include <LibGUI/TreeView.h>
 #include <LibGUI/Widget.h>
@@ -15,6 +17,8 @@ class SidebarWidget final : public GUI::Widget {
 
 public:
     ~SidebarWidget() override = default;
+
+    Function<void(PDF::Destination const&)> on_destination_selected;
 
     ErrorOr<void> set_outline(RefPtr<PDF::OutlineDict> outline)
     {

--- a/Userland/Applications/PDFViewer/SidebarWidget.h
+++ b/Userland/Applications/PDFViewer/SidebarWidget.h
@@ -16,15 +16,16 @@ class SidebarWidget final : public GUI::Widget {
 public:
     ~SidebarWidget() override = default;
 
-    void set_outline(RefPtr<PDF::OutlineDict> outline)
+    ErrorOr<void> set_outline(RefPtr<PDF::OutlineDict> outline)
     {
         if (outline) {
-            m_model = OutlineModel::create(outline.release_nonnull());
+            m_model = TRY(OutlineModel::create(outline.release_nonnull()));
             m_outline_tree_view->set_model(m_model);
         } else {
             m_model = RefPtr<OutlineModel> {};
             m_outline_tree_view->set_model({});
         }
+        return {};
     }
 
 private:

--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -273,6 +273,9 @@ PDFErrorOr<NonnullRefPtr<OutlineItem>> Document::build_outline_item(NonnullRefPt
         VERIFY(outline_item_dict->contains(CommonNames::Last));
         auto first_ref = outline_item_dict->get_value(CommonNames::First);
         auto children = TRY(build_outline_item_chain(first_ref));
+        for (auto& child : children) {
+            child.parent = outline_item;
+        }
         outline_item->children = move(children);
     }
 


### PR DESCRIPTION
This PR improves and expands the functionality of the Outline view of PDFViewer by:
 * Removed some `release_value_but_fixme_should_propagate_errors` calls in `OutlineModel`, similar to how Andreas was doing in one of the FIXME roulette videos.
 * Correctly calculating the parent index in the `OutlineModel` class, where information was missing and there problems with the implementation. The previous bogus implementation meant that navigation through the TreeView was broken, with the selection jumping to unexpected places.
 * Added a new column to show the destination page for each outline item
 * Changing to said page when an outline item is selected.
 


![T1_SPEC.pdf_p41_after](https://user-images.githubusercontent.com/620848/208249476-b10f3a95-7f26-4cdc-90cb-230e3411c9bf.png)
