### PR TITLE
PixelPaint: Encode layers in PixelPaint project files as PNG (+ error propagation)

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -121,31 +121,32 @@ ErrorOr<NonnullRefPtr<Image>> Image::try_create_from_pixel_paint_json(JsonObject
     return image;
 }
 
-void Image::serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const
+ErrorOr<void> Image::serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const
 {
-    MUST(json.add("width"sv, m_size.width()));
-    MUST(json.add("height"sv, m_size.height()));
+    TRY(json.add("width"sv, m_size.width()));
+    TRY(json.add("height"sv, m_size.height()));
     {
-        auto json_layers = MUST(json.add_array("layers"sv));
+        auto json_layers = TRY(json.add_array("layers"sv));
         for (auto const& layer : m_layers) {
             Gfx::BMPWriter bmp_writer;
-            auto json_layer = MUST(json_layers.add_object());
-            MUST(json_layer.add("width"sv, layer.size().width()));
-            MUST(json_layer.add("height"sv, layer.size().height()));
-            MUST(json_layer.add("name"sv, layer.name()));
-            MUST(json_layer.add("locationx"sv, layer.location().x()));
-            MUST(json_layer.add("locationy"sv, layer.location().y()));
-            MUST(json_layer.add("opacity_percent"sv, layer.opacity_percent()));
-            MUST(json_layer.add("visible"sv, layer.is_visible()));
-            MUST(json_layer.add("selected"sv, layer.is_selected()));
-            MUST(json_layer.add("bitmap"sv, encode_base64(bmp_writer.dump(layer.content_bitmap()))));
+            auto json_layer = TRY(json_layers.add_object());
+            TRY(json_layer.add("width"sv, layer.size().width()));
+            TRY(json_layer.add("height"sv, layer.size().height()));
+            TRY(json_layer.add("name"sv, layer.name()));
+            TRY(json_layer.add("locationx"sv, layer.location().x()));
+            TRY(json_layer.add("locationy"sv, layer.location().y()));
+            TRY(json_layer.add("opacity_percent"sv, layer.opacity_percent()));
+            TRY(json_layer.add("visible"sv, layer.is_visible()));
+            TRY(json_layer.add("selected"sv, layer.is_selected()));
+            TRY(json_layer.add("bitmap"sv, encode_base64(bmp_writer.dump(layer.content_bitmap()))));
             if (layer.is_masked())
-                MUST(json_layer.add("mask"sv, encode_base64(bmp_writer.dump(*layer.mask_bitmap()))));
-            MUST(json_layer.finish());
+                TRY(json_layer.add("mask"sv, encode_base64(bmp_writer.dump(*layer.mask_bitmap()))));
+            TRY(json_layer.finish());
         }
 
-        MUST(json_layers.finish());
+        TRY(json_layers.finish());
     }
+    return {};
 }
 
 ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Image::try_compose_bitmap(Gfx::BitmapFormat format) const

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -128,7 +128,6 @@ ErrorOr<void> Image::serialize_as_json(JsonObjectSerializer<StringBuilder>& json
     {
         auto json_layers = TRY(json.add_array("layers"sv));
         for (auto const& layer : m_layers) {
-            Gfx::BMPWriter bmp_writer;
             auto json_layer = TRY(json_layers.add_object());
             TRY(json_layer.add("width"sv, layer.size().width()));
             TRY(json_layer.add("height"sv, layer.size().height()));
@@ -138,9 +137,9 @@ ErrorOr<void> Image::serialize_as_json(JsonObjectSerializer<StringBuilder>& json
             TRY(json_layer.add("opacity_percent"sv, layer.opacity_percent()));
             TRY(json_layer.add("visible"sv, layer.is_visible()));
             TRY(json_layer.add("selected"sv, layer.is_selected()));
-            TRY(json_layer.add("bitmap"sv, encode_base64(bmp_writer.dump(layer.content_bitmap()))));
+            TRY(json_layer.add("bitmap"sv, encode_base64(TRY(Gfx::PNGWriter::encode(layer.content_bitmap())))));
             if (layer.is_masked())
-                TRY(json_layer.add("mask"sv, encode_base64(bmp_writer.dump(*layer.mask_bitmap()))));
+                TRY(json_layer.add("mask"sv, encode_base64(TRY(Gfx::PNGWriter::encode(*layer.mask_bitmap())))));
             TRY(json_layer.finish());
         }
 

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -72,7 +72,7 @@ public:
 
     void paint_into(GUI::Painter&, Gfx::IntRect const& dest_rect) const;
 
-    void serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const;
+    ErrorOr<void> serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const;
     ErrorOr<void> export_bmp_to_file(Core::File&, bool preserve_alpha_channel);
     ErrorOr<void> export_png_to_file(Core::File&, bool preserve_alpha_channel);
     ErrorOr<void> export_qoi_to_file(Core::File&) const;

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -733,26 +733,26 @@ void ImageEditor::save_project_as()
     set_unmodified();
 }
 
-Result<void, DeprecatedString> ImageEditor::save_project_to_file(Core::File& file) const
+ErrorOr<void> ImageEditor::save_project_to_file(Core::File& file) const
 {
     StringBuilder builder;
-    auto json = MUST(JsonObjectSerializer<>::try_create(builder));
-    m_image->serialize_as_json(json);
-    auto json_guides = MUST(json.add_array("guides"sv));
+    auto json = TRY(JsonObjectSerializer<>::try_create(builder));
+    TRY(m_image->serialize_as_json(json));
+    auto json_guides = TRY(json.add_array("guides"sv));
     for (auto const& guide : m_guides) {
-        auto json_guide = MUST(json_guides.add_object());
-        MUST(json_guide.add("offset"sv, (double)guide.offset()));
+        auto json_guide = TRY(json_guides.add_object());
+        TRY(json_guide.add("offset"sv, (double)guide.offset()));
         if (guide.orientation() == Guide::Orientation::Vertical)
-            MUST(json_guide.add("orientation"sv, "vertical"));
+            TRY(json_guide.add("orientation"sv, "vertical"));
         else if (guide.orientation() == Guide::Orientation::Horizontal)
-            MUST(json_guide.add("orientation"sv, "horizontal"));
-        MUST(json_guide.finish());
+            TRY(json_guide.add("orientation"sv, "horizontal"));
+        TRY(json_guide.finish());
     }
-    MUST(json_guides.finish());
-    MUST(json.finish());
+    TRY(json_guides.finish());
+    TRY(json.finish());
 
     if (!file.write(builder.string_view()))
-        return DeprecatedString { file.error_string() };
+        return Error::from_errno(file.error());
     return {};
 }
 

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -148,7 +148,7 @@ private:
     GUI::MouseEvent event_adjusted_for_layer(GUI::MouseEvent const&, Layer const&) const;
     GUI::MouseEvent event_with_pan_and_scale_applied(GUI::MouseEvent const&) const;
 
-    Result<void, DeprecatedString> save_project_to_file(Core::File&) const;
+    ErrorOr<void> save_project_to_file(Core::File&) const;
 
     int calculate_ruler_step_size() const;
     Gfx::IntRect mouse_indicator_rect_x() const;


### PR DESCRIPTION
Previously layers weren't compressed at all and the file size could go up really fast in a project with multiple layers.  By switching to PNG, the situation is slightly better now.

Interestingly enough, this change won't break compatibility with old files, as PixelPaint loads layers using ImageDecoder which will try every codec possible. :^)