### PR TITLE
FileSystemAccessServer: Use `Core::Stream`

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -69,7 +69,7 @@ static bool is_primitive_type(DeprecatedString const& type)
 static bool is_simple_type(DeprecatedString const& type)
 {
     // Small types that it makes sense just to pass by value.
-    return type.is_one_of("Gfx::Color", "Gfx::IntPoint", "Gfx::FloatPoint", "Gfx::IntSize", "Gfx::FloatSize");
+    return type.is_one_of("Gfx::Color", "Gfx::IntPoint", "Gfx::FloatPoint", "Gfx::IntSize", "Gfx::FloatSize", "Core::Stream::OpenMode");
 }
 
 static bool is_primitive_or_simple_type(DeprecatedString const& type)

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Badge.h>
 #include <AK/CircularBuffer.h>
 #include <AK/DeprecatedString.h>
 #include <AK/EnumBits.h>
@@ -20,6 +21,7 @@
 #include <AK/Variant.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/SocketAddress.h>
+#include <LibIPC/Forward.h>
 #include <errno.h>
 #include <netdb.h>
 
@@ -298,6 +300,12 @@ public:
     virtual void close() override;
     virtual ErrorOr<off_t> seek(i64 offset, SeekMode) override;
     virtual ErrorOr<void> truncate(off_t length) override;
+
+    int leak_fd(Badge<::IPC::File>)
+    {
+        m_should_close_file_descriptor = ShouldCloseFileDescriptor::No;
+        return m_fd;
+    }
 
     virtual ~File() override
     {

--- a/Userland/Libraries/LibIPC/File.h
+++ b/Userland/Libraries/LibIPC/File.h
@@ -9,6 +9,7 @@
 
 #include <AK/Noncopyable.h>
 #include <AK/StdLibExtras.h>
+#include <LibCore/Stream.h>
 #include <unistd.h>
 
 namespace IPC {
@@ -36,6 +37,12 @@ public:
     File(int fd, Tag)
         : m_fd(fd)
         , m_close_on_destruction(true)
+    {
+    }
+
+    template<typename... Args>
+    File(Core::Stream::File& file, Args... args)
+        : File(file.leak_fd(Badge<File> {}), args...)
     {
     }
 

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
@@ -7,7 +7,7 @@
 #include <AK/Debug.h>
 #include <FileSystemAccessServer/ConnectionFromClient.h>
 #include <LibCore/File.h>
-#include <LibCore/IODevice.h>
+#include <LibCore/Stream.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/FilePicker.h>
@@ -43,15 +43,15 @@ RefPtr<GUI::Window> ConnectionFromClient::create_dummy_child_window(i32 window_s
     return window;
 }
 
-void ConnectionFromClient::request_file_handler(i32 request_id, i32 window_server_client_id, i32 parent_window_id, DeprecatedString const& path, Core::OpenMode const& requested_access, ShouldPrompt prompt)
+void ConnectionFromClient::request_file_handler(i32 request_id, i32 window_server_client_id, i32 parent_window_id, DeprecatedString const& path, Core::Stream::OpenMode requested_access, ShouldPrompt prompt)
 {
     VERIFY(path.starts_with("/"sv));
 
     bool approved = false;
     auto maybe_permissions = m_approved_files.get(path);
 
-    auto relevant_permissions = requested_access & (Core::OpenMode::ReadOnly | Core::OpenMode::WriteOnly);
-    VERIFY(relevant_permissions != Core::OpenMode::NotOpen);
+    auto relevant_permissions = requested_access & (Core::Stream::OpenMode::Read | Core::Stream::OpenMode::Write);
+    VERIFY(relevant_permissions != Core::Stream::OpenMode::NotOpen);
 
     if (maybe_permissions.has_value())
         approved = has_flag(maybe_permissions.value(), relevant_permissions);
@@ -59,11 +59,11 @@ void ConnectionFromClient::request_file_handler(i32 request_id, i32 window_serve
     if (!approved) {
         DeprecatedString access_string;
 
-        if (has_flag(requested_access, Core::OpenMode::ReadWrite))
+        if (has_flag(requested_access, Core::Stream::OpenMode::ReadWrite))
             access_string = "read and write";
-        else if (has_flag(requested_access, Core::OpenMode::ReadOnly))
+        else if (has_flag(requested_access, Core::Stream::OpenMode::Read))
             access_string = "read from";
-        else if (has_flag(requested_access, Core::OpenMode::WriteOnly))
+        else if (has_flag(requested_access, Core::Stream::OpenMode::Write))
             access_string = "write to";
 
         auto pid = this->socket().peer_pid().release_value_but_fixme_should_propagate_errors();
@@ -91,13 +91,13 @@ void ConnectionFromClient::request_file_handler(i32 request_id, i32 window_serve
     }
 
     if (approved) {
-        auto file = Core::File::open(path, requested_access);
+        auto file = Core::Stream::File::open(path, requested_access);
 
         if (file.is_error()) {
             dbgln("FileSystemAccessServer: Couldn't open {}, error {}", path, file.error());
             async_handle_prompt_end(request_id, errno, Optional<IPC::File> {}, path);
         } else {
-            async_handle_prompt_end(request_id, 0, IPC::File(file.value()->leak_fd(), IPC::File::CloseAfterSending), path);
+            async_handle_prompt_end(request_id, 0, IPC::File(*file.release_value(), IPC::File::CloseAfterSending), path);
         }
     } else {
         async_handle_prompt_end(request_id, -1, Optional<IPC::File> {}, path);
@@ -106,18 +106,18 @@ void ConnectionFromClient::request_file_handler(i32 request_id, i32 window_serve
 
 void ConnectionFromClient::request_file_read_only_approved(i32 request_id, i32 window_server_client_id, i32 parent_window_id, DeprecatedString const& path)
 {
-    request_file_handler(request_id, window_server_client_id, parent_window_id, path, Core::OpenMode::ReadOnly, ShouldPrompt::No);
+    request_file_handler(request_id, window_server_client_id, parent_window_id, path, Core::Stream::OpenMode::Read, ShouldPrompt::No);
 }
 
-void ConnectionFromClient::request_file(i32 request_id, i32 window_server_client_id, i32 parent_window_id, DeprecatedString const& path, Core::OpenMode const& requested_access)
+void ConnectionFromClient::request_file(i32 request_id, i32 window_server_client_id, i32 parent_window_id, DeprecatedString const& path, Core::Stream::OpenMode requested_access)
 {
     request_file_handler(request_id, window_server_client_id, parent_window_id, path, requested_access, ShouldPrompt::Yes);
 }
 
-void ConnectionFromClient::prompt_open_file(i32 request_id, i32 window_server_client_id, i32 parent_window_id, DeprecatedString const& window_title, DeprecatedString const& path_to_view, Core::OpenMode const& requested_access)
+void ConnectionFromClient::prompt_open_file(i32 request_id, i32 window_server_client_id, i32 parent_window_id, DeprecatedString const& window_title, DeprecatedString const& path_to_view, Core::Stream::OpenMode requested_access)
 {
-    auto relevant_permissions = requested_access & (Core::OpenMode::ReadOnly | Core::OpenMode::WriteOnly);
-    VERIFY(relevant_permissions != Core::OpenMode::NotOpen);
+    auto relevant_permissions = requested_access & (Core::Stream::OpenMode::Read | Core::Stream::OpenMode::Write);
+    VERIFY(relevant_permissions != Core::Stream::OpenMode::NotOpen);
 
     auto main_window = create_dummy_child_window(window_server_client_id, parent_window_id);
 
@@ -126,10 +126,10 @@ void ConnectionFromClient::prompt_open_file(i32 request_id, i32 window_server_cl
     prompt_helper(request_id, user_picked_file, requested_access);
 }
 
-void ConnectionFromClient::prompt_save_file(i32 request_id, i32 window_server_client_id, i32 parent_window_id, DeprecatedString const& name, DeprecatedString const& ext, DeprecatedString const& path_to_view, Core::OpenMode const& requested_access)
+void ConnectionFromClient::prompt_save_file(i32 request_id, i32 window_server_client_id, i32 parent_window_id, DeprecatedString const& name, DeprecatedString const& ext, DeprecatedString const& path_to_view, Core::Stream::OpenMode requested_access)
 {
-    auto relevant_permissions = requested_access & (Core::OpenMode::ReadOnly | Core::OpenMode::WriteOnly);
-    VERIFY(relevant_permissions != Core::OpenMode::NotOpen);
+    auto relevant_permissions = requested_access & (Core::Stream::OpenMode::Read | Core::Stream::OpenMode::Write);
+    VERIFY(relevant_permissions != Core::Stream::OpenMode::NotOpen);
 
     auto main_window = create_dummy_child_window(window_server_client_id, parent_window_id);
 
@@ -138,11 +138,11 @@ void ConnectionFromClient::prompt_save_file(i32 request_id, i32 window_server_cl
     prompt_helper(request_id, user_picked_file, requested_access);
 }
 
-void ConnectionFromClient::prompt_helper(i32 request_id, Optional<DeprecatedString> const& user_picked_file, Core::OpenMode const& requested_access)
+void ConnectionFromClient::prompt_helper(i32 request_id, Optional<DeprecatedString> const& user_picked_file, Core::Stream::OpenMode requested_access)
 {
     if (user_picked_file.has_value()) {
         VERIFY(user_picked_file->starts_with("/"sv));
-        auto file = Core::File::open(user_picked_file.value(), requested_access);
+        auto file = Core::Stream::File::open(user_picked_file.value(), requested_access);
 
         if (file.is_error()) {
             dbgln("FileSystemAccessServer: Couldn't open {}, error {}", user_picked_file.value(), file.error());
@@ -150,13 +150,13 @@ void ConnectionFromClient::prompt_helper(i32 request_id, Optional<DeprecatedStri
             async_handle_prompt_end(request_id, errno, Optional<IPC::File> {}, user_picked_file);
         } else {
             auto maybe_permissions = m_approved_files.get(user_picked_file.value());
-            auto new_permissions = requested_access & (Core::OpenMode::ReadOnly | Core::OpenMode::WriteOnly);
+            auto new_permissions = requested_access & (Core::Stream::OpenMode::Read | Core::Stream::OpenMode::Write);
             if (maybe_permissions.has_value())
                 new_permissions |= maybe_permissions.value();
 
             m_approved_files.set(user_picked_file.value(), new_permissions);
 
-            async_handle_prompt_end(request_id, 0, IPC::File(file.value()->leak_fd(), IPC::File::CloseAfterSending), user_picked_file);
+            async_handle_prompt_end(request_id, 0, IPC::File(*file.release_value(), IPC::File::CloseAfterSending), user_picked_file);
         }
     } else {
         async_handle_prompt_end(request_id, -1, Optional<IPC::File> {}, Optional<DeprecatedString> {});

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.h
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.h
@@ -28,22 +28,22 @@ private:
     explicit ConnectionFromClient(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     virtual void request_file_read_only_approved(i32, i32, i32, DeprecatedString const&) override;
-    virtual void request_file(i32, i32, i32, DeprecatedString const&, Core::OpenMode const&) override;
-    virtual void prompt_open_file(i32, i32, i32, DeprecatedString const&, DeprecatedString const&, Core::OpenMode const&) override;
-    virtual void prompt_save_file(i32, i32, i32, DeprecatedString const&, DeprecatedString const&, DeprecatedString const&, Core::OpenMode const&) override;
+    virtual void request_file(i32, i32, i32, DeprecatedString const&, Core::Stream::OpenMode) override;
+    virtual void prompt_open_file(i32, i32, i32, DeprecatedString const&, DeprecatedString const&, Core::Stream::OpenMode) override;
+    virtual void prompt_save_file(i32, i32, i32, DeprecatedString const&, DeprecatedString const&, DeprecatedString const&, Core::Stream::OpenMode) override;
 
-    void prompt_helper(i32, Optional<DeprecatedString> const&, Core::OpenMode const&);
+    void prompt_helper(i32, Optional<DeprecatedString> const&, Core::Stream::OpenMode);
     RefPtr<GUI::Window> create_dummy_child_window(i32, i32);
 
     enum class ShouldPrompt {
         No,
         Yes
     };
-    void request_file_handler(i32, i32, i32, DeprecatedString const&, Core::OpenMode const&, ShouldPrompt);
+    void request_file_handler(i32, i32, i32, DeprecatedString const&, Core::Stream::OpenMode, ShouldPrompt);
 
     virtual Messages::FileSystemAccessServer::ExposeWindowServerClientIdResponse expose_window_server_client_id() override;
 
-    HashMap<DeprecatedString, Core::OpenMode> m_approved_files;
+    HashMap<DeprecatedString, Core::Stream::OpenMode> m_approved_files;
 };
 
 }

--- a/Userland/Services/FileSystemAccessServer/FileSystemAccessServer.ipc
+++ b/Userland/Services/FileSystemAccessServer/FileSystemAccessServer.ipc
@@ -1,12 +1,12 @@
 #include <AK/URL.h>
-#include <LibCore/IODevice.h>
+#include <LibCore/Stream.h>
 
 endpoint FileSystemAccessServer
 {
     request_file_read_only_approved(i32 request_id, i32 window_server_client_id, i32 window_id, DeprecatedString path) =|
-    request_file(i32 request_id, i32 window_server_client_id, i32 window_id, DeprecatedString path, Core::OpenMode requested_access) =|
-    prompt_open_file(i32 request_id, i32 window_server_client_id, i32 window_id, DeprecatedString window_title, DeprecatedString path_to_view, Core::OpenMode requested_access) =|
-    prompt_save_file(i32 request_id, i32 window_server_client_id, i32 window_id, DeprecatedString title, DeprecatedString ext, DeprecatedString path_to_view, Core::OpenMode requested_access) =|
+    request_file(i32 request_id, i32 window_server_client_id, i32 window_id, DeprecatedString path, Core::Stream::OpenMode requested_access) =|
+    prompt_open_file(i32 request_id, i32 window_server_client_id, i32 window_id, DeprecatedString window_title, DeprecatedString path_to_view, Core::Stream::OpenMode requested_access) =|
+    prompt_save_file(i32 request_id, i32 window_server_client_id, i32 window_id, DeprecatedString title, DeprecatedString ext, DeprecatedString path_to_view, Core::Stream::OpenMode requested_access) =|
 
     expose_window_server_client_id() => (i32 client_id)
 }


### PR DESCRIPTION
This patch also updates corresponding functions from `LibFileSystemAccessServerClient`.

From the `FileSystemAccessClient` point of view, it only makes the server take `Core::Stream::OpenMode` instead of `Core::OpenMode`. So, `enum` conversions only happen within deprecated functions and not in the new `Core::Stream` friendly API.

On the server side, it just removes two usages of `Core::File::open()`.

As it seems that #16548 will implement the rest of the `Core::Stream` friendly API. It makes sense to me to merge this PR before to start on a good base.