### PR TITLE
LibCore: Add Core::throttle(function, timeout)

### DIFF
--- a/Userland/Libraries/LibCore/Throttle.h
+++ b/Userland/Libraries/LibCore/Throttle.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Tim Ledbetter <timledbetter@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/Timer.h>
+
+namespace Core {
+
+template<typename TFunction>
+auto throttle(TFunction function, int timeout)
+{
+    RefPtr<Core::Timer> timer;
+    return [=]<typename... T>(T... args) mutable {
+        if (!timer)
+            timer = Core::Timer::create_single_shot(timeout, nullptr);
+        else if (timer->is_active())
+            return;
+        timer->start();
+        function(args...);
+    };
+};
+
+}


### PR DESCRIPTION
This helper is similar to the debounce function, but instead of waiting for its timeout to expire it fires immediately and waits until its timeout has expired to fire again.

See #16546 for a discussion about using this with the move tool.

I am also looking at performance improvements for the PixelPaint levels dialog that could benefit from this and I'm sure there are other places too.
