### PR TITLE
Kernel/Graphics: Introduce a new mechanism to initialize a PCI device

### DIFF
--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -24,14 +24,15 @@ class BochsGraphicsAdapter final : public GenericGraphicsAdapter
     friend class GraphicsManagement;
 
 public:
-    static NonnullLockRefPtr<BochsGraphicsAdapter> initialize(PCI::DeviceIdentifier const&);
+    static ErrorOr<bool> probe(PCI::DeviceIdentifier const&);
+    static ErrorOr<NonnullLockRefPtr<GenericGraphicsAdapter>> create(PCI::DeviceIdentifier const&);
     virtual ~BochsGraphicsAdapter() = default;
     virtual StringView device_name() const override { return "BochsGraphicsAdapter"sv; }
 
 private:
     ErrorOr<void> initialize_adapter(PCI::DeviceIdentifier const&);
 
-    explicit BochsGraphicsAdapter(PCI::DeviceIdentifier const&);
+    explicit BochsGraphicsAdapter(PCI::Address const&);
 
     LockRefPtr<DisplayConnector> m_display_connector;
 };

--- a/Kernel/Graphics/GraphicsManagement.h
+++ b/Kernel/Graphics/GraphicsManagement.h
@@ -50,7 +50,7 @@ public:
 private:
     void enable_vga_text_mode_console_cursor();
 
-    bool determine_and_initialize_graphics_device(PCI::DeviceIdentifier const&);
+    ErrorOr<void> determine_and_initialize_graphics_device(PCI::DeviceIdentifier const&);
 
     void initialize_preset_resolution_generic_display_connector();
 

--- a/Kernel/Graphics/Intel/NativeDisplayConnector.h
+++ b/Kernel/Graphics/Intel/NativeDisplayConnector.h
@@ -81,7 +81,7 @@ class IntelNativeDisplayConnector final
     friend class DeviceManagement;
 
 public:
-    static NonnullLockRefPtr<IntelNativeDisplayConnector> must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, PhysicalAddress registers_region_address, size_t registers_region_length);
+    static ErrorOr<NonnullLockRefPtr<IntelNativeDisplayConnector>> try_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, PhysicalAddress registers_region_address, size_t registers_region_length);
 
 private:
     // ^DisplayConnector

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
@@ -20,7 +20,8 @@ class IntelNativeGraphicsAdapter final
     , public PCI::Device {
 
 public:
-    static LockRefPtr<IntelNativeGraphicsAdapter> initialize(PCI::DeviceIdentifier const&);
+    static ErrorOr<bool> probe(PCI::DeviceIdentifier const&);
+    static ErrorOr<NonnullLockRefPtr<GenericGraphicsAdapter>> create(PCI::DeviceIdentifier const&);
 
     virtual ~IntelNativeGraphicsAdapter() = default;
 

--- a/Kernel/Graphics/VMWare/GraphicsAdapter.h
+++ b/Kernel/Graphics/VMWare/GraphicsAdapter.h
@@ -26,7 +26,8 @@ class VMWareGraphicsAdapter final
     friend class GraphicsManagement;
 
 public:
-    static LockRefPtr<VMWareGraphicsAdapter> try_initialize(PCI::DeviceIdentifier const&);
+    static ErrorOr<bool> probe(PCI::DeviceIdentifier const&);
+    static ErrorOr<NonnullLockRefPtr<GenericGraphicsAdapter>> create(PCI::DeviceIdentifier const&);
     virtual ~VMWareGraphicsAdapter() = default;
 
     virtual StringView device_name() const override { return "VMWareGraphicsAdapter"sv; }

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -37,7 +37,8 @@ class VirtIOGraphicsAdapter final
     friend class VirtIOGPU3DDevice;
 
 public:
-    static NonnullLockRefPtr<VirtIOGraphicsAdapter> initialize(PCI::DeviceIdentifier const&);
+    static ErrorOr<bool> probe(PCI::DeviceIdentifier const&);
+    static ErrorOr<NonnullLockRefPtr<GenericGraphicsAdapter>> create(PCI::DeviceIdentifier const&);
 
     virtual void initialize() override;
 


### PR DESCRIPTION
Relies on #16532.

Instead of using a clunky switch-case paradigm, we now have all drivers
being declaring two methods for their adapter class - create and probe.
These methods are linked in each PCIGraphicsDriverInitializer structure,
in a new s_initializers static list of them.
Then, when we probe for a PCI device, we use each probe method and if
there's a match, then the corresponding create method is called.

As a result of this change, it's much more easy to add more drivers and
the initialization code is more readable.