### PR TITLE
Kernel/Net: Introduce a new mechanism to initialize a PCI device

### DIFF
--- a/Kernel/Net/Intel/E1000ENetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.h
@@ -21,9 +21,9 @@ namespace Kernel {
 class E1000ENetworkAdapter final
     : public E1000NetworkAdapter {
 public:
-    static ErrorOr<LockRefPtr<E1000ENetworkAdapter>> try_to_initialize(PCI::DeviceIdentifier const&);
-
-    virtual bool initialize() override;
+    static ErrorOr<bool> probe(PCI::DeviceIdentifier const&);
+    static ErrorOr<NonnullLockRefPtr<NetworkAdapter>> create(PCI::DeviceIdentifier const&);
+    virtual ErrorOr<void> initialize(Badge<NetworkingManagement>) override;
 
     virtual ~E1000ENetworkAdapter() override;
 

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.h
@@ -30,7 +30,10 @@ public:
     virtual StringView purpose() const override { return class_name(); }
 
 private:
-    E1000ENetworkAdapter(PCI::Address, u8 irq, NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<KString>);
+    E1000ENetworkAdapter(PCI::Address, u8 irq,
+        NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
+        NonnullOwnPtr<Memory::Region> tx_buffer_region, NonnullOwnPtr<Memory::Region> rx_descriptors_region,
+        NonnullOwnPtr<Memory::Region> tx_descriptors_region, NonnullOwnPtr<KString>);
 
     virtual StringView class_name() const override { return "E1000ENetworkAdapter"sv; }
 

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -35,10 +35,17 @@ public:
     virtual StringView device_name() const override { return "E1000"sv; }
 
 protected:
+    static constexpr size_t rx_buffer_size = 8192;
+    static constexpr size_t tx_buffer_size = 8192;
+
     void setup_interrupts();
     void setup_link();
 
-    E1000NetworkAdapter(PCI::Address, u8 irq, NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<KString>);
+    E1000NetworkAdapter(PCI::Address, u8 irq,
+        NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
+        NonnullOwnPtr<Memory::Region> tx_buffer_region, NonnullOwnPtr<Memory::Region> rx_descriptors_region,
+        NonnullOwnPtr<Memory::Region> tx_descriptors_region, NonnullOwnPtr<KString>);
+
     virtual bool handle_irq(RegisterState const&) override;
     virtual StringView class_name() const override { return "E1000NetworkAdapter"sv; }
 
@@ -85,10 +92,10 @@ protected:
 
     NonnullOwnPtr<IOWindow> m_registers_io_window;
 
-    OwnPtr<Memory::Region> m_rx_descriptors_region;
-    OwnPtr<Memory::Region> m_tx_descriptors_region;
-    OwnPtr<Memory::Region> m_rx_buffer_region;
-    OwnPtr<Memory::Region> m_tx_buffer_region;
+    NonnullOwnPtr<Memory::Region> m_rx_descriptors_region;
+    NonnullOwnPtr<Memory::Region> m_tx_descriptors_region;
+    NonnullOwnPtr<Memory::Region> m_rx_buffer_region;
+    NonnullOwnPtr<Memory::Region> m_tx_buffer_region;
     Array<void*, number_of_rx_descriptors> m_rx_buffers;
     Array<void*, number_of_tx_descriptors> m_tx_buffers;
     bool m_has_eeprom { false };

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -20,9 +20,9 @@ class E1000NetworkAdapter : public NetworkAdapter
     , public PCI::Device
     , public IRQHandler {
 public:
-    static ErrorOr<LockRefPtr<E1000NetworkAdapter>> try_to_initialize(PCI::DeviceIdentifier const&);
-
-    virtual bool initialize();
+    static ErrorOr<bool> probe(PCI::DeviceIdentifier const&);
+    static ErrorOr<NonnullLockRefPtr<NetworkAdapter>> create(PCI::DeviceIdentifier const&);
+    virtual ErrorOr<void> initialize(Badge<NetworkingManagement>) override;
 
     virtual ~E1000NetworkAdapter() override;
 

--- a/Kernel/Net/LoopbackAdapter.h
+++ b/Kernel/Net/LoopbackAdapter.h
@@ -18,6 +18,8 @@ public:
     static LockRefPtr<LoopbackAdapter> try_create();
     virtual ~LoopbackAdapter() override;
 
+    virtual ErrorOr<void> initialize(Badge<NetworkingManagement>) override { VERIFY_NOT_REACHED(); }
+
     virtual void send_raw(ReadonlyBytes) override;
     virtual StringView class_name() const override { return "LoopbackAdapter"sv; }
     virtual bool link_up() override { return true; }

--- a/Kernel/Net/NE2000/NetworkAdapter.h
+++ b/Kernel/Net/NE2000/NetworkAdapter.h
@@ -20,7 +20,9 @@ class NE2000NetworkAdapter final : public NetworkAdapter
     , public PCI::Device
     , public IRQHandler {
 public:
-    static ErrorOr<LockRefPtr<NE2000NetworkAdapter>> try_to_initialize(PCI::DeviceIdentifier const&);
+    static ErrorOr<bool> probe(PCI::DeviceIdentifier const&);
+    static ErrorOr<NonnullLockRefPtr<NetworkAdapter>> create(PCI::DeviceIdentifier const&);
+    virtual ErrorOr<void> initialize(Badge<NetworkingManagement>) override;
 
     virtual ~NE2000NetworkAdapter() override;
 

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -42,6 +42,7 @@ struct PacketWithTimestamp final : public AtomicRefCounted<PacketWithTimestamp> 
     IntrusiveListNode<PacketWithTimestamp, LockRefPtr<PacketWithTimestamp>> packet_node;
 };
 
+class NetworkingManagement;
 class NetworkAdapter
     : public AtomicRefCounted<NetworkAdapter>
     , public LockWeakable<NetworkAdapter> {
@@ -51,6 +52,7 @@ public:
     virtual ~NetworkAdapter();
 
     virtual StringView class_name() const = 0;
+    virtual ErrorOr<void> initialize(Badge<NetworkingManagement>) = 0;
 
     StringView name() const { return m_name->view(); }
     MACAddress mac_address() { return m_mac_address; }

--- a/Kernel/Net/NetworkingManagement.cpp
+++ b/Kernel/Net/NetworkingManagement.cpp
@@ -93,18 +93,34 @@ ErrorOr<NonnullOwnPtr<KString>> NetworkingManagement::generate_interface_name_fr
     return name;
 }
 
+struct PCINetworkDriverInitializer {
+    ErrorOr<bool> (*probe)(PCI::DeviceIdentifier const&) = nullptr;
+    ErrorOr<NonnullLockRefPtr<NetworkAdapter>> (*create)(PCI::DeviceIdentifier const&) = nullptr;
+};
+
+static constexpr PCINetworkDriverInitializer s_initializers[] = {
+    { RTL8168NetworkAdapter::probe, RTL8168NetworkAdapter::create },
+    { RTL8139NetworkAdapter::probe, RTL8139NetworkAdapter::create },
+    { NE2000NetworkAdapter::probe, NE2000NetworkAdapter::create },
+    { E1000NetworkAdapter::probe, E1000NetworkAdapter::create },
+    { E1000ENetworkAdapter::probe, E1000ENetworkAdapter::create },
+};
+
 UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<NetworkAdapter>> NetworkingManagement::determine_network_device(PCI::DeviceIdentifier const& device_identifier) const
 {
-    if (auto candidate = TRY(E1000NetworkAdapter::try_to_initialize(device_identifier)))
-        return candidate.release_nonnull();
-    if (auto candidate = TRY(E1000ENetworkAdapter::try_to_initialize(device_identifier)))
-        return candidate.release_nonnull();
-    if (auto candidate = TRY(RTL8139NetworkAdapter::try_to_initialize(device_identifier)))
-        return candidate.release_nonnull();
-    if (auto candidate = TRY(RTL8168NetworkAdapter::try_to_initialize(device_identifier)))
-        return candidate.release_nonnull();
-    if (auto candidate = TRY(NE2000NetworkAdapter::try_to_initialize(device_identifier)))
-        return candidate.release_nonnull();
+    for (auto& initializer : s_initializers) {
+        auto initializer_probe_found_driver_match_or_error = initializer.probe(device_identifier);
+        if (initializer_probe_found_driver_match_or_error.is_error()) {
+            dmesgln("Networking: Failed to probe device {}, due to {}", device_identifier.address(), initializer_probe_found_driver_match_or_error.error());
+            continue;
+        }
+        auto initializer_probe_found_driver_match = initializer_probe_found_driver_match_or_error.release_value();
+        if (initializer_probe_found_driver_match) {
+            auto adapter = TRY(initializer.create(device_identifier));
+            TRY(adapter->initialize({}));
+            return adapter;
+        }
+    }
     return Error::from_string_literal("Unsupported network adapter");
 }
 

--- a/Kernel/Net/Realtek/RTL8139NetworkAdapter.h
+++ b/Kernel/Net/Realtek/RTL8139NetworkAdapter.h
@@ -22,7 +22,9 @@ class RTL8139NetworkAdapter final : public NetworkAdapter
     , public PCI::Device
     , public IRQHandler {
 public:
-    static ErrorOr<LockRefPtr<RTL8139NetworkAdapter>> try_to_initialize(PCI::DeviceIdentifier const&);
+    static ErrorOr<bool> probe(PCI::DeviceIdentifier const&);
+    static ErrorOr<NonnullLockRefPtr<NetworkAdapter>> create(PCI::DeviceIdentifier const&);
+    virtual ErrorOr<void> initialize(Badge<NetworkingManagement>) override;
 
     virtual ~RTL8139NetworkAdapter() override;
 

--- a/Kernel/Net/Realtek/RTL8139NetworkAdapter.h
+++ b/Kernel/Net/Realtek/RTL8139NetworkAdapter.h
@@ -35,7 +35,7 @@ public:
     virtual StringView device_name() const override { return "RTL8139"sv; }
 
 private:
-    RTL8139NetworkAdapter(PCI::Address, u8 irq, NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<KString>);
+    RTL8139NetworkAdapter(PCI::Address, u8 irq, NonnullOwnPtr<Memory::Region> rx_buffer, NonnullOwnPtr<Memory::Region> packet_buffer, NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<KString>);
     virtual bool handle_irq(RegisterState const&) override;
     virtual StringView class_name() const override { return "RTL8139NetworkAdapter"sv; }
 
@@ -53,11 +53,11 @@ private:
 
     NonnullOwnPtr<IOWindow> m_registers_io_window;
     u8 m_interrupt_line { 0 };
-    OwnPtr<Memory::Region> m_rx_buffer;
+    NonnullOwnPtr<Memory::Region> m_rx_buffer;
     u16 m_rx_buffer_offset { 0 };
     Vector<OwnPtr<Memory::Region>> m_tx_buffers;
     u8 m_tx_next_buffer { 0 };
-    OwnPtr<Memory::Region> m_packet_buffer;
+    NonnullOwnPtr<Memory::Region> m_packet_buffer;
     bool m_link_up { false };
     EntropySource m_entropy_source;
 };

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
@@ -22,7 +22,9 @@ class RTL8168NetworkAdapter final : public NetworkAdapter
     , public PCI::Device
     , public IRQHandler {
 public:
-    static ErrorOr<LockRefPtr<RTL8168NetworkAdapter>> try_to_initialize(PCI::DeviceIdentifier const&);
+    static ErrorOr<bool> probe(PCI::DeviceIdentifier const&);
+    static ErrorOr<NonnullLockRefPtr<NetworkAdapter>> create(PCI::DeviceIdentifier const&);
+    virtual ErrorOr<void> initialize(Badge<NetworkingManagement>) override;
 
     virtual ~RTL8168NetworkAdapter() override;
 


### PR DESCRIPTION
Instead of using a clunky if-statement paradigm, we now have all drivers
being declaring two methods for their adapter class - create and probe.
These methods are linked in each PCINetworkDriverInitializer structure,
in a new s_initializers static list of them.
Then, when we probe for a PCI device, we use each probe method and if
there's a match, then the corresponding create method is called. After
the adapter instance is created, we call the virtual initialize method
on it, because many drivers actually require a sort of post-construction
initialization sequence to ensure the network adapter can properly
function.

As a result of this change, it's much more easy to add more drivers and
the initialization code is more readable and it's easier to understand
when and where things could fail in the whole initialization sequence.

This was suggested by @awesomekling in the video he made when making #16433.

Also completing #16545.