### PR TITLE
LibWeb: Fix up some slightly weird scaling for `radial-gradient`s

### DIFF
--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -330,7 +330,7 @@ Color Color::mixed_with(Color other, float weight) const
     // This is needed for linear-gradient()s in LibWeb.
     auto mixed_alpha = mix<float>(alpha(), other.alpha(), weight);
     auto premultiplied_mix_channel = [&](float channel, float other_channel, float weight) {
-        return round_to<u8>(mix<float>(channel * (alpha() / 255.0f), other_channel * (other.alpha() / 255.0f), weight) / (mixed_alpha / 255.0f));
+        return round_to<u8>(mix<float>(channel * alpha(), other_channel * other.alpha(), weight) / mixed_alpha);
     };
     return Gfx::Color {
         premultiplied_mix_channel(red(), other.red(), weight),

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1832,7 +1832,7 @@ void Painter::set_pixel(IntPoint p, Color color, bool blend)
     if (!clip_rect().contains(point / scale()))
         return;
     auto& dst = m_target->scanline(point.y())[point.x()];
-    if (!blend)
+    if (!blend || color.alpha() == 255)
         dst = color.value();
     else if (color.alpha())
         dst = Color::from_argb(dst).blend(color).value();

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -2178,7 +2178,9 @@ bool RadialGradientStyleValue::equals(StyleValue const& other) const
 void RadialGradientStyleValue::paint(PaintContext& context, Gfx::IntRect const& dest_rect, CSS::ImageRendering) const
 {
     VERIFY(m_resolved.has_value());
-    Painting::paint_radial_gradient(context, dest_rect.to_type<DevicePixels>(), m_resolved->data, m_resolved->center.to_rounded<DevicePixels>(), m_resolved->gradient_size);
+    Painting::paint_radial_gradient(context, dest_rect.to_type<DevicePixels>(), m_resolved->data,
+        context.rounded_device_point(m_resolved->center.to_type<CSSPixels>()),
+        context.rounded_device_size(m_resolved->gradient_size.to_type<CSSPixels>()));
 }
 
 DeprecatedString ConicGradientStyleValue::to_deprecated_string() const

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -304,18 +304,18 @@ void paint_conic_gradient(PaintContext& context, DevicePixelRect const& gradient
     });
 }
 
-void paint_radial_gradient(PaintContext& context, DevicePixelRect const& gradient_rect, RadialGradientData const& data, DevicePixelPoint center, Gfx::FloatSize size)
+void paint_radial_gradient(PaintContext& context, DevicePixelRect const& gradient_rect, RadialGradientData const& data, DevicePixelPoint center, DevicePixelSize size)
 {
     // A conservative guesstimate on how many colors we need to generate:
     auto max_dimension = max(gradient_rect.width(), gradient_rect.height());
-    int max_visible_gradient = max(max_dimension.value() / 2, min(size.width(), max_dimension.value()));
+    auto max_visible_gradient = max(max_dimension / 2, min(size.width(), max_dimension.value())).value();
     GradientLine gradient_line(max_visible_gradient, data.color_stops);
     auto center_point = Gfx::FloatPoint { center.to_type<int>() }.translated(0.5, 0.5);
     gradient_line.paint_into_rect(context.painter(), gradient_rect, [&](DevicePixels x, DevicePixels y) {
         // FIXME: See if there's a more efficient calculation we do there :^)
-        auto point = context.scale_to_css_point({ x, y }).to_type<float>() - center_point;
-        auto gradient_x = point.x() / size.width();
-        auto gradient_y = point.y() / size.height();
+        auto point = Gfx::FloatPoint(x.value(), y.value()) - center_point;
+        auto gradient_x = point.x() / size.width().value();
+        auto gradient_y = point.y() / size.height().value();
         return AK::sqrt(gradient_x * gradient_x + gradient_y * gradient_y) * max_visible_gradient;
     });
 }

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.h
@@ -47,6 +47,6 @@ RadialGradientData resolve_radial_gradient_data(Layout::Node const&, CSSPixelSiz
 
 void paint_linear_gradient(PaintContext&, DevicePixelRect const&, LinearGradientData const&);
 void paint_conic_gradient(PaintContext&, DevicePixelRect const&, ConicGradientData const&, DevicePixelPoint position);
-void paint_radial_gradient(PaintContext&, DevicePixelRect const&, RadialGradientData const&, DevicePixelPoint position, Gfx::FloatSize size);
+void paint_radial_gradient(PaintContext&, DevicePixelRect const&, RadialGradientData const&, DevicePixelPoint position, DevicePixelSize size);
 
 }


### PR DESCRIPTION
Noticed some slightly silly scaling stuff for radial gradients where CSS pixels were passed as device pixels (see commit for details). 

cc @AtkinsSJ  (my fault for not looking closely enough when I gave you that patch :sweat_smile:) 