### PR TITLE
Documentation+Meta: Try harder to make serenity.sh do the right thing on macOS

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -41,6 +41,15 @@ Note that you might need additional dev packages in order to build QEMU on your 
 sudo apt install libgtk-3-dev libpixman-1-dev libsdl2-dev libspice-server-dev
 ```
 
+#### CMake version 3.25.0 or later
+
+Serenity-specific patches were upstreamed to CMake in major version 3.25. To avoid carrying
+patches to CMake, the minimum required CMake to build Serenity is set to that version.
+If more patches are upstreamed to CMake, the minimum will be bumped again once that version releases.
+
+To accomodate distributions that do not ship bleeding-edge CMake versions, the build scripts will
+attempt to build CMake from source if the version on your path is older than 3.25.x.
+
 ### Windows
 
 If you're on Windows you can use WSL2 to build SerenityOS. Please have a look at the [Windows guide](BuildInstructionsWindows.md)

--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -11,7 +11,9 @@ sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2
 ```
 Optional: `fuse2fs` for [building images without root](https://github.com/SerenityOS/serenity/pull/11224).
 
-#### GCC 12
+#### GCC 12 or Clang 13
+
+A host compiler that supports C++20 features is required for building host tools, the newer the better. Tested versions include gcc-12 and clang-13.
 
 On Ubuntu gcc-12 is available in the repositories of 22.04 (Jammy) and later.
 If you are running an older version, you will either need to upgrade, or find an alternative installation source.

--- a/Documentation/BuildInstructionsMacOS.md
+++ b/Documentation/BuildInstructionsMacOS.md
@@ -13,7 +13,7 @@ Make sure you also have all the following dependencies installed:
 
 ```console
 # core
-brew install coreutils e2fsprogs qemu bash gcc@12 imagemagick ninja cmake ccache rsync zstd
+brew install coreutils e2fsprogs qemu bash imagemagick ninja cmake ccache rsync zstd
 
 # (option 1) fuse + ext2
 brew install m4 autoconf automake libtool
@@ -24,14 +24,22 @@ Toolchain/BuildFuseExt2.sh
 brew install genext2fs
 ```
 
+If you have Xcode version 13 or older, also install a newer host compiler from homebrew. Xcode 14 is known to work.
+
+```console
+brew install llvm@15
+# OR
+brew install gcc@12
+```
+
+# Notes
+
 If you're building on M1 Mac and have Homebrew installed in both Rosetta and native environments,
 you have to make sure that required packages are installed only in one of the environments. Otherwise,
 these installations can conflict during the build process, which is manifested in hard to diagnose issues.
 Building on M1 natively without Rosetta is recommended, as the build process should be faster without Rosetta
 overhead.
 
-Notes:
+Installing macfuse for the first time requires enabling its system extension in System Preferences and then restarting your machine. The output from installing macfuse with brew says this, but it's easy to miss.
 
-- Installing macfuse for the first time requires enabling its system extension in System Preferences and then restarting
-  your machine. The output from installing macfuse with brew says this, but it's easy to miss.
-- It's important to make sure that Xcode is not only installed but also accordingly updated, otherwise CMake will run into incompatibilities with GCC.
+It's important to make sure that Xcode is not only installed but also accordingly updated, otherwise CMake will run into incompatibilities with GCC.

--- a/Documentation/BuildInstructionsMacOS.md
+++ b/Documentation/BuildInstructionsMacOS.md
@@ -43,3 +43,7 @@ overhead.
 Installing macfuse for the first time requires enabling its system extension in System Preferences and then restarting your machine. The output from installing macfuse with brew says this, but it's easy to miss.
 
 It's important to make sure that Xcode is not only installed but also accordingly updated, otherwise CMake will run into incompatibilities with GCC.
+
+Homebrew is known to ship bleeding edge CMake versions, but building CMake from source with homebrew
+gcc or llvm may not work. If homebrew does not offer cmake 3.25.x+ on your platform, it may be neccessary
+to manually run Toolchain/BuildCMake.sh with Apple clang from Xcode as the first compiler in your $PATH.

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -192,17 +192,17 @@ pick_host_compiler() {
         return
     fi
 
-    find_newest_compiler egcc gcc gcc-12 /usr/local/bin/gcc-12 /opt/homebrew/bin/gcc-12
-    if is_supported_compiler "$HOST_COMPILER"; then
-        export CC="${HOST_COMPILER}"
-        export CXX="${HOST_COMPILER/gcc/g++}"
-        return
-    fi
-
     find_newest_compiler clang clang-13 clang-14 clang-15 /opt/homebrew/opt/llvm/bin/clang
     if is_supported_compiler "$HOST_COMPILER"; then
         export CC="${HOST_COMPILER}"
         export CXX="${HOST_COMPILER/clang/clang++}"
+        return
+    fi
+
+    find_newest_compiler egcc gcc gcc-12 /usr/local/bin/gcc-12 /opt/homebrew/bin/gcc-12
+    if is_supported_compiler "$HOST_COMPILER"; then
+        export CC="${HOST_COMPILER}"
+        export CXX="${HOST_COMPILER/gcc/g++}"
         return
     fi
 

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -154,7 +154,8 @@ is_supported_compiler() {
     local MAJOR_VERSION=""
     MAJOR_VERSION="${VERSION%%.*}"
     if $COMPILER --version 2>&1 | grep "Apple clang" >/dev/null; then
-        return 1
+        # Apple Clang version check
+        [ "$MAJOR_VERSION" -ge 14 ] && return 0
     elif $COMPILER --version 2>&1 | grep "clang" >/dev/null; then
         # Clang version check
         [ "$MAJOR_VERSION" -ge 13 ] && return 0
@@ -170,9 +171,6 @@ find_newest_compiler() {
     local BEST_CANDIDATE=""
     for CANDIDATE in "$@"; do
         if ! command -v "$CANDIDATE" >/dev/null 2>&1; then
-            continue
-        fi
-        if $CANDIDATE --version 2>&1 | grep "Apple clang" >/dev/null; then
             continue
         fi
         if ! $CANDIDATE -dumpversion >/dev/null 2>&1; then


### PR DESCRIPTION
Update a few things:

- Allow Apple clang 14 as a host compiler. It's been known to work for a while now, so let's stop skipping it entirely in serenity.sh
- Prefer clang to gcc as a host compiler. This will make Apple clang a higher priority than homebrew gcc on macOS platforms, and probably will make people stop pushing patches that work great in GCC and fail to compile on clang CI :^)
- Document that either clang or gcc as a host compiler will work :tm:
- Document why we're suddenly building CMake from source.