### PR TITLE
LibCore: Propagate the OOM errors from UDPServer::receive()

### DIFF
--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -291,7 +291,9 @@ TEST_CASE(udp_socket_read_write)
     usleep(100000);
 
     struct sockaddr_in client_address;
-    auto server_receive_buffer = udp_server->receive(64, client_address);
+    auto server_receive_buffer_or_error = udp_server->receive(64, client_address);
+    EXPECT(!server_receive_buffer_or_error.is_error());
+    auto server_receive_buffer = server_receive_buffer_or_error.release_value();
     EXPECT(!server_receive_buffer.is_empty());
 
     StringView server_received_data { server_receive_buffer.bytes() };

--- a/Userland/Libraries/LibCore/UDPServer.h
+++ b/Userland/Libraries/LibCore/UDPServer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Alexander Narsudinov <a.narsudinov@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -23,8 +24,8 @@ public:
     bool is_bound() const { return m_bound; }
 
     bool bind(IPv4Address const& address, u16 port);
-    ByteBuffer receive(size_t size, sockaddr_in& from);
-    ByteBuffer receive(size_t size)
+    ErrorOr<ByteBuffer> receive(size_t size, sockaddr_in& from);
+    ErrorOr<ByteBuffer> receive(size_t size)
     {
         struct sockaddr_in saddr;
         return receive(size, saddr);

--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -122,7 +122,8 @@ DHCPv4Client::DHCPv4Client(Vector<DeprecatedString> interfaces_with_dhcp_enabled
 {
     m_server = Core::UDPServer::construct(this);
     m_server->on_ready_to_receive = [this] {
-        auto buffer = m_server->receive(sizeof(DHCPv4Packet));
+        // TODO: we need to handle possible errors here somehow
+        auto buffer = MUST(m_server->receive(sizeof(DHCPv4Packet)));
         dbgln_if(DHCPV4CLIENT_DEBUG, "Received {} bytes", buffer.size());
         if (buffer.size() < sizeof(DHCPv4Packet) - DHCPV4_OPTION_FIELD_MAX_LENGTH + 1 || buffer.size() > sizeof(DHCPv4Packet)) {
             dbgln("we expected {}-{} bytes, this is a bad packet", sizeof(DHCPv4Packet) - DHCPV4_OPTION_FIELD_MAX_LENGTH + 1, sizeof(DHCPv4Packet));

--- a/Userland/Services/LookupServer/DNSServer.cpp
+++ b/Userland/Services/LookupServer/DNSServer.cpp
@@ -28,7 +28,7 @@ DNSServer::DNSServer(Object* parent)
 ErrorOr<void> DNSServer::handle_client()
 {
     sockaddr_in client_address;
-    auto buffer = receive(1024, client_address);
+    auto buffer = TRY(receive(1024, client_address));
     auto optional_request = Packet::from_raw_packet(buffer.data(), buffer.size());
     if (!optional_request.has_value()) {
         dbgln("Got an invalid DNS packet");

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -183,7 +183,7 @@ ErrorOr<Vector<Answer>> LookupServer::lookup(Name const& name, RecordType record
 
     // Fourth, look up .local names using mDNS instead of DNS nameservers.
     if (name.as_string().ends_with(".local"sv)) {
-        answers = m_mdns->lookup(name, record_type);
+        answers = TRY(m_mdns->lookup(name, record_type));
         for (auto& answer : answers)
             put_in_cache(answer);
         return answers;

--- a/Userland/Services/LookupServer/MulticastDNS.cpp
+++ b/Userland/Services/LookupServer/MulticastDNS.cpp
@@ -51,7 +51,8 @@ MulticastDNS::MulticastDNS(Object* parent)
 
 void MulticastDNS::handle_packet()
 {
-    auto buffer = receive(1024);
+    // TODO: propagate the error somehow
+    auto buffer = MUST(receive(1024));
     auto optional_packet = Packet::from_raw_packet(buffer.data(), buffer.size());
     if (!optional_packet.has_value()) {
         dbgln("Got an invalid mDNS packet");
@@ -167,7 +168,8 @@ Vector<Answer> MulticastDNS::lookup(Name const& name, RecordType record_type)
             return {};
         }
 
-        auto buffer = receive(1024);
+        // TODO: propagate the error somehow
+        auto buffer = MUST(receive(1024));
         if (buffer.is_empty())
             return {};
         auto optional_packet = Packet::from_raw_packet(buffer.data(), buffer.size());

--- a/Userland/Services/LookupServer/MulticastDNS.h
+++ b/Userland/Services/LookupServer/MulticastDNS.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Sergey Bugaev <bugaevc@serenityos.org>
+ * Copyright (c) 2022, Alexander Narsudinov <a.narsudinov@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,7 +21,7 @@ using namespace DNS;
 class MulticastDNS : public Core::UDPServer {
     C_OBJECT(MulticastDNS)
 public:
-    Vector<Answer> lookup(Name const&, RecordType record_type);
+    ErrorOr<Vector<Answer>> lookup(Name const&, RecordType record_type);
 
 private:
     explicit MulticastDNS(Object* parent = nullptr);

--- a/Userland/Services/LookupServer/MulticastDNS.h
+++ b/Userland/Services/LookupServer/MulticastDNS.h
@@ -29,7 +29,7 @@ private:
     void announce();
     ErrorOr<size_t> emit_packet(Packet const&, sockaddr_in const* destination = nullptr);
 
-    void handle_packet();
+    ErrorOr<void> handle_packet();
     void handle_query(Packet const&);
 
     Vector<IPv4Address> local_addresses() const;


### PR DESCRIPTION
Just another one round of FIXME roulette.

I tried to handle memory allocation errors in a more explicit way, but not sure that it suits the project way of doing it.

Feedback is welcome! :)