### PR TITLE
AK: Support fixed formatting to print real numbers

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -651,7 +651,7 @@ void StandardFormatter::parse(TypeErasedFormatParams& params, FormatParser& pars
     else if (parser.consume_specific('p'))
         m_mode = Mode::Pointer;
     else if (parser.consume_specific('f'))
-        m_mode = Mode::Float;
+        m_mode = Mode::FixedPoint;
     else if (parser.consume_specific('a'))
         m_mode = Mode::Hexfloat;
     else if (parser.consume_specific('A'))
@@ -794,7 +794,7 @@ ErrorOr<void> Formatter<long double>::format(FormatBuilder& builder, long double
 {
     u8 base;
     bool upper_case;
-    if (m_mode == Mode::Default || m_mode == Mode::Float) {
+    if (m_mode == Mode::Default || m_mode == Mode::FixedPoint) {
         base = 10;
         upper_case = false;
     } else if (m_mode == Mode::Hexfloat) {
@@ -817,7 +817,7 @@ ErrorOr<void> Formatter<double>::format(FormatBuilder& builder, double value)
 {
     u8 base;
     bool upper_case;
-    if (m_mode == Mode::Default || m_mode == Mode::Float) {
+    if (m_mode == Mode::Default || m_mode == Mode::FixedPoint) {
         base = 10;
         upper_case = false;
     } else if (m_mode == Mode::Hexfloat) {

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -292,7 +292,7 @@ struct StandardFormatter {
         Character,
         String,
         Pointer,
-        Float,
+        FixedPoint,
         Hexfloat,
         HexfloatUppercase,
         HexDump,
@@ -520,7 +520,7 @@ struct Formatter<FixedPoint<precision, Underlying>> : StandardFormatter {
     {
         u8 base;
         bool upper_case;
-        if (m_mode == Mode::Default || m_mode == Mode::Float) {
+        if (m_mode == Mode::Default || m_mode == Mode::FixedPoint) {
             base = 10;
             upper_case = false;
         } else if (m_mode == Mode::Hexfloat) {

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -150,6 +150,12 @@ public:
         Default = OnlyIfNeeded,
     };
 
+    enum class RealNumberDisplayMode {
+        FixedPoint,
+        General,
+        Default = General,
+    };
+
     explicit FormatBuilder(StringBuilder& builder)
         : m_builder(builder)
     {
@@ -200,7 +206,8 @@ public:
         size_t min_width = 0,
         size_t precision = 6,
         char fill = ' ',
-        SignMode sign_mode = SignMode::OnlyIfNeeded);
+        SignMode sign_mode = SignMode::OnlyIfNeeded,
+        RealNumberDisplayMode = RealNumberDisplayMode::Default);
 
 #ifndef KERNEL
     ErrorOr<void> put_f80(
@@ -211,7 +218,8 @@ public:
         size_t min_width = 0,
         size_t precision = 6,
         char fill = ' ',
-        SignMode sign_mode = SignMode::OnlyIfNeeded);
+        SignMode sign_mode = SignMode::OnlyIfNeeded,
+        RealNumberDisplayMode = RealNumberDisplayMode::Default);
 
     ErrorOr<void> put_f64(
         double value,
@@ -222,7 +230,8 @@ public:
         size_t min_width = 0,
         size_t precision = 6,
         char fill = ' ',
-        SignMode sign_mode = SignMode::OnlyIfNeeded);
+        SignMode sign_mode = SignMode::OnlyIfNeeded,
+        RealNumberDisplayMode = RealNumberDisplayMode::Default);
 #endif
 
     ErrorOr<void> put_hexdump(
@@ -520,9 +529,12 @@ struct Formatter<FixedPoint<precision, Underlying>> : StandardFormatter {
     {
         u8 base;
         bool upper_case;
+        FormatBuilder::RealNumberDisplayMode real_number_display_mode = FormatBuilder::RealNumberDisplayMode::General;
         if (m_mode == Mode::Default || m_mode == Mode::FixedPoint) {
             base = 10;
             upper_case = false;
+            if (m_mode == Mode::FixedPoint)
+                real_number_display_mode = FormatBuilder::RealNumberDisplayMode::FixedPoint;
         } else if (m_mode == Mode::Hexfloat) {
             base = 16;
             upper_case = false;
@@ -539,7 +551,7 @@ struct Formatter<FixedPoint<precision, Underlying>> : StandardFormatter {
         i64 integer = value.ltrunk();
         constexpr u64 one = static_cast<Underlying>(1) << precision;
         u64 fraction_raw = value.raw() & (one - 1);
-        return builder.put_fixed_point(integer, fraction_raw, one, base, upper_case, m_zero_pad, m_align, m_width.value(), m_precision.value(), m_fill, m_sign_mode);
+        return builder.put_fixed_point(integer, fraction_raw, one, base, upper_case, m_zero_pad, m_align, m_width.value(), m_precision.value(), m_fill, m_sign_mode, real_number_display_mode);
     }
 };
 


### PR DESCRIPTION
~~This has been implemented to remove the hackish function in `NumberFormat`~~ (This part needs more thought as it make `human_readable_size()` inconsistent in its rounding) but results in various improvements all over the system.

As an example, in `3D Viewer`, we now display a message with consistent length. The formatting for `ms` is `{:.1f}`.
On the video, the `ms` second per frame once goes to an unexpected flat "26", that's no longer the case :^)

https://user-images.githubusercontent.com/26030965/208272900-01a39611-a5ec-4c47-9b5e-47ada3a5c022.mp4