### PR TITLE
unzip: Verify extracted files against CRC32 checksums

### DIFF
--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -121,7 +121,7 @@ target_link_libraries(test-fuzz PRIVATE LibGemini LibGfx LibHTTP LibIPC LibJS Li
 target_link_libraries(test-imap PRIVATE LibIMAP)
 target_link_libraries(test-pthread PRIVATE LibThreading)
 target_link_libraries(unveil PRIVATE LibMain)
-target_link_libraries(unzip PRIVATE LibArchive LibCompress)
+target_link_libraries(unzip PRIVATE LibArchive LibCompress LibCrypto)
 target_link_libraries(update-cpp-test-results PRIVATE LibCpp)
 target_link_libraries(useradd PRIVATE LibCrypt)
 target_link_libraries(wallpaper PRIVATE LibGfx LibGUI)

--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -85,19 +85,17 @@ static bool unpack_zip_member(Archive::ZipMember zip_member, bool quiet)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    char const* path;
+    StringView zip_file_path;
     bool quiet { false };
-    DeprecatedString output_directory_path;
+    StringView output_directory_path;
     Vector<StringView> file_filters;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(output_directory_path, "Directory to receive the archive content", "output-directory", 'd', "path");
     args_parser.add_option(quiet, "Be less verbose", "quiet", 'q');
-    args_parser.add_positional_argument(path, "File to unzip", "path", Core::ArgsParser::Required::Yes);
+    args_parser.add_positional_argument(zip_file_path, "File to unzip", "path", Core::ArgsParser::Required::Yes);
     args_parser.add_positional_argument(file_filters, "Files or filters in the archive to extract", "files", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
-
-    DeprecatedString zip_file_path { path };
 
     struct stat st = TRY(Core::System::stat(zip_file_path));
 


### PR DESCRIPTION
This also replaces the use of ```DeprecatedString``` with ```StringView``` in ```unzip```.