### PR TITLE
PixelPaint: Propagate errors in {flip,crop,rotate,resize} functions

### DIFF
--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -48,7 +48,7 @@ class Image : public RefCounted<Image> {
 public:
     static ErrorOr<NonnullRefPtr<Image>> try_create_with_size(Gfx::IntSize);
     static ErrorOr<NonnullRefPtr<Image>> try_create_from_pixel_paint_json(JsonObject const&);
-    static ErrorOr<NonnullRefPtr<Image>> try_create_from_bitmap(NonnullRefPtr<Gfx::Bitmap>);
+    static ErrorOr<NonnullRefPtr<Image>> try_create_from_bitmap(NonnullRefPtr<Gfx::Bitmap> const&);
 
     static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> try_decode_bitmap(ReadonlyBytes);
 
@@ -73,8 +73,8 @@ public:
     void paint_into(GUI::Painter&, Gfx::IntRect const& dest_rect) const;
 
     ErrorOr<void> serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const;
-    ErrorOr<void> export_bmp_to_file(Core::File&, bool preserve_alpha_channel);
-    ErrorOr<void> export_png_to_file(Core::File&, bool preserve_alpha_channel);
+    ErrorOr<void> export_bmp_to_file(Core::File&, bool preserve_alpha_channel) const;
+    ErrorOr<void> export_png_to_file(Core::File&, bool preserve_alpha_channel) const;
     ErrorOr<void> export_qoi_to_file(Core::File&) const;
 
     void move_layer_to_front(Layer&);

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -97,10 +97,10 @@ public:
 
     size_t index_of(Layer const&) const;
 
-    void flip(Gfx::Orientation orientation);
-    void rotate(Gfx::RotationDirection direction);
-    void crop(Gfx::IntRect const& rect);
-    void resize(Gfx::IntSize new_size, Gfx::Painter::ScalingMode scaling_mode);
+    ErrorOr<void> flip(Gfx::Orientation orientation);
+    ErrorOr<void> rotate(Gfx::RotationDirection direction);
+    ErrorOr<void> crop(Gfx::IntRect const& rect);
+    ErrorOr<void> resize(Gfx::IntSize new_size, Gfx::Painter::ScalingMode scaling_mode);
 
     Optional<Gfx::IntRect> nonempty_content_bounding_rect() const;
 

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -83,7 +83,7 @@ void Layer::did_modify_bitmap(Gfx::IntRect const& rect, NotifyClients notify_cli
 
     // NOTE: If NotifyClients::NO is passed to this function the caller should handle notifying
     //       the clients of any bitmap changes.
-    if (notify_clients == NotifyClients::YES)
+    if (notify_clients == NotifyClients::Yes)
         m_image.layer_did_modify_bitmap({}, *this, rect);
     update_cached_bitmap();
 }

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -56,18 +56,23 @@ public:
     DeprecatedString const& name() const { return m_name; }
     void set_name(DeprecatedString);
 
-    void flip(Gfx::Orientation orientation);
-    void rotate(Gfx::RotationDirection direction);
-    void crop(Gfx::IntRect const& rect);
-    void resize(Gfx::IntSize new_size, Gfx::Painter::ScalingMode scaling_mode);
-    void resize(Gfx::IntRect const& new_rect, Gfx::Painter::ScalingMode scaling_mode);
-    void resize(Gfx::IntSize new_size, Gfx::IntPoint new_location, Gfx::Painter::ScalingMode scaling_mode);
+    enum NotifyClients {
+        YES,
+        NO
+    };
+
+    ErrorOr<void> flip(Gfx::Orientation orientation, NotifyClients notify_clients = NotifyClients::YES);
+    ErrorOr<void> rotate(Gfx::RotationDirection direction, NotifyClients notify_clients = NotifyClients::YES);
+    ErrorOr<void> crop(Gfx::IntRect const& rect, NotifyClients notify_clients = NotifyClients::YES);
+    ErrorOr<void> resize(Gfx::IntSize new_size, Gfx::Painter::ScalingMode scaling_mode, NotifyClients notify_clients = NotifyClients::YES);
+    ErrorOr<void> resize(Gfx::IntRect const& new_rect, Gfx::Painter::ScalingMode scaling_mode, NotifyClients notify_clients = NotifyClients::YES);
+    ErrorOr<void> resize(Gfx::IntSize new_size, Gfx::IntPoint new_location, Gfx::Painter::ScalingMode scaling_mode, NotifyClients notify_clients = NotifyClients::YES);
 
     Optional<Gfx::IntRect> nonempty_content_bounding_rect() const;
 
     ErrorOr<void> try_set_bitmaps(NonnullRefPtr<Gfx::Bitmap> content, RefPtr<Gfx::Bitmap> mask);
 
-    void did_modify_bitmap(Gfx::IntRect const& = {});
+    void did_modify_bitmap(Gfx::IntRect const& = {}, NotifyClients notify_clients = NotifyClients::YES);
 
     void set_selected(bool selected) { m_selected = selected; }
     bool is_selected() const { return m_selected; }

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -56,23 +56,23 @@ public:
     DeprecatedString const& name() const { return m_name; }
     void set_name(DeprecatedString);
 
-    enum NotifyClients {
-        YES,
-        NO
+    enum class NotifyClients {
+        Yes,
+        No
     };
 
-    ErrorOr<void> flip(Gfx::Orientation orientation, NotifyClients notify_clients = NotifyClients::YES);
-    ErrorOr<void> rotate(Gfx::RotationDirection direction, NotifyClients notify_clients = NotifyClients::YES);
-    ErrorOr<void> crop(Gfx::IntRect const& rect, NotifyClients notify_clients = NotifyClients::YES);
-    ErrorOr<void> resize(Gfx::IntSize new_size, Gfx::Painter::ScalingMode scaling_mode, NotifyClients notify_clients = NotifyClients::YES);
-    ErrorOr<void> resize(Gfx::IntRect const& new_rect, Gfx::Painter::ScalingMode scaling_mode, NotifyClients notify_clients = NotifyClients::YES);
-    ErrorOr<void> resize(Gfx::IntSize new_size, Gfx::IntPoint new_location, Gfx::Painter::ScalingMode scaling_mode, NotifyClients notify_clients = NotifyClients::YES);
+    ErrorOr<void> flip(Gfx::Orientation orientation, NotifyClients notify_clients = NotifyClients::Yes);
+    ErrorOr<void> rotate(Gfx::RotationDirection direction, NotifyClients notify_clients = NotifyClients::Yes);
+    ErrorOr<void> crop(Gfx::IntRect const& rect, NotifyClients notify_clients = NotifyClients::Yes);
+    ErrorOr<void> resize(Gfx::IntSize new_size, Gfx::Painter::ScalingMode scaling_mode, NotifyClients notify_clients = NotifyClients::Yes);
+    ErrorOr<void> resize(Gfx::IntRect const& new_rect, Gfx::Painter::ScalingMode scaling_mode, NotifyClients notify_clients = NotifyClients::Yes);
+    ErrorOr<void> resize(Gfx::IntSize new_size, Gfx::IntPoint new_location, Gfx::Painter::ScalingMode scaling_mode, NotifyClients notify_clients = NotifyClients::Yes);
 
     Optional<Gfx::IntRect> nonempty_content_bounding_rect() const;
 
     ErrorOr<void> try_set_bitmaps(NonnullRefPtr<Gfx::Bitmap> content, RefPtr<Gfx::Bitmap> mask);
 
-    void did_modify_bitmap(Gfx::IntRect const& = {}, NotifyClients notify_clients = NotifyClients::YES);
+    void did_modify_bitmap(Gfx::IntRect const& = {}, NotifyClients notify_clients = NotifyClients::Yes);
 
     void set_selected(bool selected) { m_selected = selected; }
     bool is_selected() const { return m_selected; }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -15,6 +15,7 @@
 #include "FilterParams.h"
 #include "LevelsDialog.h"
 #include "ResizeImageDialog.h"
+#include <AK/String.h>
 #include <Applications/PixelPaint/PixelPaintWindowGML.h>
 #include <LibConfig/Client.h>
 #include <LibCore/Debounce.h>
@@ -565,14 +566,22 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         "Flip Image &Vertically", g_icon_bag.edit_flip_vertical, [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
-            editor->image().flip(Gfx::Orientation::Vertical);
+            auto image_flip_or_error = editor->image().flip(Gfx::Orientation::Vertical);
+            if (image_flip_or_error.is_error()) {
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flip image: {}", image_flip_or_error.error().string_literal())));
+                return;
+            }
             editor->did_complete_action("Flip Image Vertically"sv);
         }));
     m_image_menu->add_action(GUI::Action::create(
         "Flip Image &Horizontally", g_icon_bag.edit_flip_horizontal, [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
-            editor->image().flip(Gfx::Orientation::Horizontal);
+            auto image_flip_or_error = editor->image().flip(Gfx::Orientation::Horizontal);
+            if (image_flip_or_error.is_error()) {
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flip image: {}", image_flip_or_error.error().string_literal())));
+                return;
+            }
             editor->did_complete_action("Flip Image Horizontally"sv);
         }));
     m_image_menu->add_separator();
@@ -581,7 +590,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
-            editor->image().rotate(Gfx::RotationDirection::CounterClockwise);
+            auto image_rotate_or_error = editor->image().rotate(Gfx::RotationDirection::CounterClockwise);
+            if (image_rotate_or_error.is_error()) {
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to rotate image: {}", image_rotate_or_error.error().string_literal())));
+                return;
+            }
             editor->did_complete_action("Rotate Image Counterclockwise"sv);
         }));
 
@@ -589,7 +602,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
-            editor->image().rotate(Gfx::RotationDirection::Clockwise);
+            auto image_rotate_or_error = editor->image().rotate(Gfx::RotationDirection::Clockwise);
+            if (image_rotate_or_error.is_error()) {
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to rotate image: {}", image_rotate_or_error.error().string_literal())));
+                return;
+            }
             editor->did_complete_action("Rotate Image Clockwise"sv);
         }));
     m_image_menu->add_separator();
@@ -599,7 +616,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             VERIFY(editor);
             auto dialog = PixelPaint::ResizeImageDialog::construct(editor->image().size(), &window);
             if (dialog->exec() == GUI::Dialog::ExecResult::OK) {
-                editor->image().resize(dialog->desired_size(), dialog->scaling_mode());
+                auto image_resize_or_error = editor->image().resize(dialog->desired_size(), dialog->scaling_mode());
+                if (image_resize_or_error.is_error()) {
+                    GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to resize image: {}", image_resize_or_error.error().string_literal())));
+                    return;
+                }
                 editor->did_complete_action("Resize Image"sv);
             }
         }));
@@ -611,7 +632,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             if (editor->image().selection().is_empty())
                 return;
             auto crop_rect = editor->image().rect().intersected(editor->image().selection().bounding_rect());
-            editor->image().crop(crop_rect);
+            auto image_crop_or_error = editor->image().crop(crop_rect);
+            if (image_crop_or_error.is_error()) {
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop image: {}", image_crop_or_error.error().string_literal())));
+                return;
+            }
             editor->image().selection().clear();
             editor->did_complete_action("Crop Image to Selection"sv);
         }));
@@ -625,7 +650,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             if (!content_bounding_rect.has_value())
                 return;
 
-            editor->image().crop(content_bounding_rect.value());
+            auto image_crop_or_error = editor->image().crop(content_bounding_rect.value());
+            if (image_crop_or_error.is_error()) {
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop image: {}", image_crop_or_error.error().string_literal())));
+                return;
+            }
             editor->did_complete_action("Crop Image to Content"sv);
         }));
 
@@ -833,7 +862,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto active_layer = editor->active_layer();
             if (!active_layer)
                 return;
-            active_layer->flip(Gfx::Orientation::Vertical);
+            auto layer_flip_or_error = active_layer->flip(Gfx::Orientation::Vertical);
+            if (layer_flip_or_error.is_error()) {
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flip layer: {}", layer_flip_or_error.error().string_literal())));
+                return;
+            }
             editor->did_complete_action("Flip Layer Vertically"sv);
         }));
     m_layer_menu->add_action(GUI::Action::create(
@@ -843,7 +876,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto active_layer = editor->active_layer();
             if (!active_layer)
                 return;
-            active_layer->flip(Gfx::Orientation::Horizontal);
+            auto layer_flip_or_error = active_layer->flip(Gfx::Orientation::Horizontal);
+            if (layer_flip_or_error.is_error()) {
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flip layer: {}", layer_flip_or_error.error().string_literal())));
+                return;
+            }
             editor->did_complete_action("Flip Layer Horizontally"sv);
         }));
     m_layer_menu->add_separator();
@@ -855,7 +892,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto active_layer = editor->active_layer();
             if (!active_layer)
                 return;
-            active_layer->rotate(Gfx::RotationDirection::CounterClockwise);
+            auto layer_rotate_or_error = active_layer->rotate(Gfx::RotationDirection::CounterClockwise);
+            if (layer_rotate_or_error.is_error()) {
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to rotate layer: {}", layer_rotate_or_error.error().string_literal())));
+                return;
+            }
             editor->did_complete_action("Rotate Layer Counterclockwise"sv);
         }));
 
@@ -866,7 +907,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto active_layer = editor->active_layer();
             if (!active_layer)
                 return;
-            active_layer->rotate(Gfx::RotationDirection::Clockwise);
+            auto layer_rotate_or_error = active_layer->rotate(Gfx::RotationDirection::Clockwise);
+            if (layer_rotate_or_error.is_error()) {
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to rotate layer: {}", layer_rotate_or_error.error().string_literal())));
+                return;
+            }
             editor->did_complete_action("Rotate Layer Clockwise"sv);
         }));
 
@@ -881,7 +926,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 return;
             auto intersection = editor->image().rect().intersected(editor->image().selection().bounding_rect());
             auto crop_rect = intersection.translated(-active_layer->location());
-            active_layer->crop(crop_rect);
+            auto layer_crop_or_error = active_layer->crop(crop_rect);
+            if (layer_crop_or_error.is_error()) {
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop layer: {}", layer_crop_or_error.error().string_literal())));
+                return;
+            }
             active_layer->set_location(intersection.location());
             editor->image().selection().clear();
             editor->did_complete_action("Crop Layer to Selection"sv);
@@ -896,7 +945,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto content_bounding_rect = active_layer->nonempty_content_bounding_rect();
             if (!content_bounding_rect.has_value())
                 return;
-            active_layer->crop(content_bounding_rect.value());
+            auto layer_crop_or_error = active_layer->crop(content_bounding_rect.value());
+            if (layer_crop_or_error.is_error()) {
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop layer: {}", layer_crop_or_error.error().string_literal())));
+                return;
+            }
             active_layer->set_location(content_bounding_rect->location());
             editor->did_complete_action("Crop Layer to Content"sv);
         }));

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -9,8 +9,10 @@
 #include "../Image.h"
 #include "../ImageEditor.h"
 #include "../Layer.h"
+#include <AK/String.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Menu.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Filters/ContrastFilter.h>
@@ -101,8 +103,11 @@ void MoveTool::on_mouseup(Layer* layer, MouseEvent& event)
         return;
 
     if (m_scaling) {
-        m_editor->active_layer()->resize(m_new_layer_size, m_new_scaled_layer_location, Gfx::Painter::ScalingMode::BilinearBlend);
-        m_editor->layers_did_change();
+        auto resized_or_error = m_editor->active_layer()->resize(m_new_layer_size, m_new_scaled_layer_location, Gfx::Painter::ScalingMode::BilinearBlend);
+        if (resized_or_error.is_error())
+            GUI::MessageBox::show_error(m_editor->window(), MUST(String::formatted("Failed to resize layer: {}", resized_or_error.error().string_literal())));
+        else
+            m_editor->layers_did_change();
     }
 
     m_scaling = false;


### PR DESCRIPTION
We now propagate errors when using the {Layer,Image}::flip(), {Layer,Image}::crop(), {Layer,Image}::rotate() and {Layer,Image}::resize() functions.

We handle these errors by show an error DialogBox with the error's message.

This removes 8 FIXMEs:))