### PR TITLE
Everywhere: Compatability updates for Android and musl

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -496,6 +496,22 @@ if (BUILD_LAGOM)
         add_executable(test262-runner ../../Tests/LibJS/test262-runner.cpp)
         target_link_libraries(test262-runner LibJS LibCore)
 
+        if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+            include(CheckCSourceCompiles)
+            # Check for musl's declaration of __assert_fail
+            check_c_source_compiles(
+                "
+                #include <assert.h>
+                __attribute__((__noreturn__)) void __assert_fail(char const* assertion, char const* file, int line, char const* function) {}
+                int main() {}
+                "
+                ASSERT_FAIL_HAS_INT
+            )
+        endif()
+        if (ASSERT_FAIL_HAS_INT OR EMSCRIPTEN)
+            target_compile_definitions(test262-runner PRIVATE ASSERT_FAIL_HAS_INT)
+        endif()
+
         add_executable(wasm ../../Userland/Utilities/wasm.cpp)
         target_link_libraries(wasm LibCore LibWasm LibLine LibMain)
 

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -556,13 +556,16 @@ static bool g_in_assert = false;
     exit(12);
 }
 
+// FIXME: Use a SIGABRT handler here instead of overriding internal libc assertion handlers.
+//        Fixing this will likely require updating the test driver as well to pull the assertion failure
+//        message out of stderr rather than from the json object printed to stdout.
 #ifdef AK_OS_SERENITY
 void __assertion_failed(char const* assertion)
 {
     handle_failed_assert(assertion);
 }
 #else
-#    ifdef AK_OS_EMSCRIPTEN
+#    ifdef ASSERT_FAIL_HAS_INT /* Set by CMake */
 extern "C" __attribute__((__noreturn__)) void __assert_fail(char const* assertion, char const* file, int line, char const* function)
 #    else
 extern "C" __attribute__((__noreturn__)) void __assert_fail(char const* assertion, char const* file, unsigned int line, char const* function)

--- a/Userland/Libraries/LibELF/Validation.cpp
+++ b/Userland/Libraries/LibELF/Validation.cpp
@@ -11,6 +11,7 @@
 #include <LibC/elf.h>
 #include <LibELF/Validation.h>
 #include <limits.h>
+#include <pthread.h>
 
 namespace ELF {
 

--- a/Userland/Libraries/LibThreading/ConditionVariable.h
+++ b/Userland/Libraries/LibThreading/ConditionVariable.h
@@ -9,7 +9,6 @@
 #include <AK/Function.h>
 #include <LibThreading/Mutex.h>
 #include <pthread.h>
-#include <sys/cdefs.h>
 #include <sys/types.h>
 
 namespace Threading {

--- a/Userland/Utilities/ntpquery.cpp
+++ b/Userland/Utilities/ntpquery.cpp
@@ -187,7 +187,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     iovec iov { &packet, sizeof(packet) };
     char control_message_buffer[CMSG_SPACE(sizeof(timeval))];
-    msghdr msg = { &peer_address, sizeof(peer_address), &iov, 1, control_message_buffer, sizeof(control_message_buffer), 0 };
+    msghdr msg = {};
+    msg.msg_name = &peer_address;
+    msg.msg_namelen = sizeof(peer_address);
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = control_message_buffer;
+    msg.msg_controllen = sizeof(control_message_buffer);
+    msg.msg_flags = 0;
+
     rc = recvmsg(fd, &msg, 0);
     if (rc < 0) {
         perror("recvmsg");


### PR DESCRIPTION
With these patches, we can build Lagom on musl based distros like Alpine. 

It also fixes one issue with the Android build.

Running ./Meta/serenity.sh test lagom *almost* passes all tests on Alpine. TestTLSHandshake crashes in ::freeaddrinfo from the new fancy AddressInfoVector. 