### PR TITLE
Meta: Disable gdbstub when running under HVF on macOS

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -237,6 +237,12 @@ if command -v wslpath >/dev/null; then
    SERENITY_DISABLE_GDB_SOCKET=1
 fi
 
+if [ "$(uname)" = "Darwin" ] &&
+   [ "${SERENITY_VIRT_TECH_ARG}" = "--accel hvf" ]; then
+  # HVF doesn't support gdbstub per https://wiki.qemu.org/Features/HVF
+  SERENITY_DISABLE_GDB_SOCKET=1
+fi
+
 if [ -z "$SERENITY_DISABLE_GDB_SOCKET" ]; then
     SERENITY_EXTRA_QEMU_ARGS="$SERENITY_EXTRA_QEMU_ARGS -gdb tcp:${SERENITY_HOST_IP}:1234"
 fi


### PR DESCRIPTION
Without this, `serenity.sh run` fails with

    gdbstub: current accelerator doesn't support guest debugging

on an intel mac.