### PR TITLE
UserspaceEmulator: Add error checking for `F2XM1` instruction

### DIFF
--- a/AK/FloatingPoint.h
+++ b/AK/FloatingPoint.h
@@ -257,6 +257,21 @@ constexpr double convert_to_native_double(I input) { return float_to_float<Doubl
 template<typename I>
 constexpr float convert_to_native_float(I input) { return float_to_float<SingleFloatingPointBits>(input).as_float(); }
 
+template<typename T>
+constexpr bool is_signaling_nan(T input)
+{
+#if __has_builtin(__builtin_issignaling)
+    return __builtin_issignaling(input);
+#else
+    if (!isnan(input))
+        return false;
+
+    auto extract = FloatExtractor<T>(input);
+
+    return extract.exponent == FloatExtractor<T>::exponent_max && (extract.mantissa >> (FloatExtractor<T>::mantissa_bits - 1)) == 0;
+#endif
+}
+
 }
 
 #if USING_AK_GLOBALLY
@@ -270,4 +285,6 @@ using AK::convert_from_native_float;
 using AK::convert_to_native_double;
 using AK::convert_to_native_float;
 using AK::float_to_float;
+
+using AK::is_signaling_nan;
 #endif

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -715,6 +715,27 @@ struct Formatter<FormatString> : Formatter<StringView> {
     ErrorOr<void> vformat(FormatBuilder& builder, StringView fmtstr, TypeErasedFormatParams& params);
 };
 
+template<typename... Parameters>
+struct Formatted {
+    Formatted(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+        : m_format(fmtstr.view())
+        , m_params(parameters...)
+    {
+    }
+
+    StringView m_format;
+    VariadicFormatParams<Parameters...> m_params;
+};
+
+template<typename... Parameters>
+struct Formatter<Formatted<Parameters...>> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Formatted<Parameters...> const& formattable)
+    {
+        auto params = formattable.m_params;
+        return Formatter<FormatString>::vformat(builder, formattable.m_format, params);
+    }
+};
+
 template<>
 struct Formatter<Error> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Error const& error)
@@ -763,6 +784,7 @@ using AK::dbgln;
 using AK::CheckedFormatString;
 using AK::FormatIfSupported;
 using AK::FormatString;
+using AK::Formatted;
 
 #    define dbgln_if(flag, fmt, ...)       \
         do {                               \

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -130,6 +130,13 @@ void SoftCPU::dump() const
     fflush(stdout);
 }
 
+void SoftCPU::check_pending_fpu_exceptions()
+{
+    // FIXME: If FPU SW.ES (Status word bit "Exception Summary") is 1,
+    //        and CR0.NE ("Numeric error") is 1,
+    //        then raise #MF exception ("x87 Floating-Point Exception").
+}
+
 void SoftCPU::update_code_cache()
 {
     auto* region = m_emulator.mmu().find_region({ cs(), eip() });
@@ -2901,7 +2908,12 @@ void SoftCPU::UD1(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::UD2(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::VERR_RM16(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::VERW_RM16(const X86::Instruction&) { TODO_INSN(); }
-void SoftCPU::WAIT(const X86::Instruction&) { TODO_INSN(); }
+void SoftCPU::WAIT(const X86::Instruction&)
+{
+    // FIXME: If CR0.TS ("Task switched") and CR0.MP ("Monitor co-processor") are 1,
+    //        raise #NM ("Device Not Available")
+    check_pending_fpu_exceptions();
+}
 void SoftCPU::WBINVD(const X86::Instruction&) { TODO_INSN(); }
 
 void SoftCPU::XADD_RM16_reg16(const X86::Instruction& insn)

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.h
@@ -1346,6 +1346,8 @@ private:
     template<typename Op>
     void generic_RM32_CL(Op, const X86::Instruction&);
 
+    void check_pending_fpu_exceptions();
+
     void update_code_cache();
 
     void write_segment_register(X86::SegmentRegister, ValueWithShadow<u16>);

--- a/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
@@ -40,14 +40,14 @@ namespace UserspaceEmulator { // NOLINT(readability-implicit-bool-conversion) 0/
 
 ALWAYS_INLINE void SoftFPU::warn_if_mmx_absolute(u8 index) const
 {
-    if (m_reg_is_mmx[index]) [[unlikely]] {
+    if (is_mmx(index)) [[unlikely]] {
         reportln("\033[31;1mWarning! Use of an MMX register as an FPU value ({} abs)\033[0m\n"sv, index);
         m_emulator.dump_backtrace();
     }
 }
 ALWAYS_INLINE void SoftFPU::warn_if_fpu_absolute(u8 index) const
 {
-    if (!m_reg_is_mmx[index]) [[unlikely]] {
+    if (!is_mmx(index)) [[unlikely]] {
         reportln("\033[31;1mWarning! Use of an FPU value ({} abs)  as an MMX register\033[0m\n"sv, index);
         m_emulator.dump_backtrace();
     }
@@ -75,6 +75,11 @@ ALWAYS_INLINE void SoftFPU::fpu_set(u8 index, long double value)
 {
     VERIFY(index < 8);
     fpu_set_absolute((m_fpu_stack_top + index) % 8, value);
+}
+bool SoftFPU::is_mmx(u8 index) const
+{
+    VERIFY(index < 8);
+    return m_reg_is_mmx[index];
 }
 MMX SoftFPU::mmx_get(u8 index) const
 {
@@ -926,7 +931,7 @@ void SoftFPU::FTST(const X86::Instruction&)
 }
 void SoftFPU::FXAM(const X86::Instruction&)
 {
-    if (m_reg_is_mmx[m_fpu_stack_top]) {
+    if (is_mmx(m_fpu_stack_top)) {
         // technically a subset of NaN/INF, with the Tag set to valid,
         // but we have our own helper for this
         set_c0(0);

--- a/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
@@ -1024,9 +1024,16 @@ void SoftFPU::F2XM1(const X86::Instruction&)
 {
     // FIXME: Raise #IA #D #U #P
     // FIXME: Set C1 on when result was rounded up, cleared otherwise
-    // FIXME: Validate ST(0) is in range –1.0 to +1.0
     auto val = fpu_get(0);
-    fpu_set(0, exp2(val) - 1.0l);
+    // Validate ST(0) is in range –1.0 to +1.0.
+    // If the source value is outside this range, the result is undefined.
+    // In practice, the result is the input value.
+    if (val >= -1.0 && val <= 1.0) {
+        fpu_set(0, exp2(val) - 1.0l);
+    } else {
+        fpu_set(0, val);
+        reportln("\033[31;1mWarning! Source operand for F2XM1 is out of range! ({}, should be in range -1.0 to +1.0)\033[0m\n"sv, val);
+    }
 }
 void SoftFPU::FYL2X(const X86::Instruction&)
 {

--- a/Userland/DevTools/UserspaceEmulator/SoftFPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftFPU.h
@@ -269,6 +269,9 @@ private:
     template<FloatingPoint T>
     T convert_checked(long double);
 
+    template<typename Func>
+    void capture_host_fpu_exceptions(Func f);
+
     ALWAYS_INLINE void fpu_set_unordered()
     {
         set_c0(1);

--- a/Userland/DevTools/UserspaceEmulator/SoftFPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftFPU.h
@@ -59,6 +59,8 @@ public:
     void fpu_set_absolute(u8 index, long double value);
     void fpu_set(u8 index, long double value);
 
+    bool is_mmx(u8 index) const;
+
     MMX mmx_get(u8 index) const;
     void mmx_set(u8 index, MMX value);
 

--- a/Userland/DevTools/UserspaceEmulator/SoftFPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftFPU.h
@@ -479,7 +479,10 @@ private:
     void FFREE(const X86::Instruction&);
     void FFREEP(const X86::Instruction&); // undocumented
 
-    // FIXME: Non N- versions?
+    // NOTE: You might have come across variants of these instructions
+    //       that don't have the N- prefix. These are not real instructions.
+    //       Rather, they are assembled as two instructions: an FWAIT instruction,
+    //       followed by its corresponding N- instruction.
     void FNINIT(const X86::Instruction&);
     void FNCLEX(const X86::Instruction&);
 

--- a/Userland/Libraries/LibC/float.h
+++ b/Userland/Libraries/LibC/float.h
@@ -7,6 +7,10 @@
 
 #pragma once
 
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+
 // Defined in fenv.cpp, but we must not include fenv.h, so here's its prototype.
 int fegetround(void);
 
@@ -51,3 +55,5 @@ int fegetround(void);
 #define FLT_HAS_SUBNORM 1
 #define DBL_HAS_SUBNORM 1
 #define LDBL_HAS_SUBNORM 1
+
+__END_DECLS

--- a/Userland/Libraries/LibC/math.h
+++ b/Userland/Libraries/LibC/math.h
@@ -76,7 +76,7 @@ __BEGIN_DECLS
 #define FP_ZERO 2
 #define FP_SUBNORMAL 3
 #define FP_NORMAL 4
-#define fpclassify(x) __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_ZERO, FP_SUBNORMAL, FP_ZERO, x)
+#define fpclassify(x) __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, x)
 
 #define signbit(x) __builtin_signbit(x)
 #define isnan(x) __builtin_isnan(x)


### PR DESCRIPTION
The Intel Software Developer's Manual specifies:

    The value of the source operand must lie in the range –1.0 to +1.0.
    If the source value is outside this range, the result is undefined.

In practice, if the input value is outside of this range, most processors and emulators just set the result to the input value.

Replicate this behaviour, and print a warning, fixing a FIXME in the process :^)