### PR TITLE
Meta: Tweak shell_include.sh

### DIFF
--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -4,7 +4,7 @@ set -e
 
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
-. "${script_path}/.shell_include.sh"
+. "${script_path}/shell_include.sh"
 
 if [ "$(id -u)" != 0 ]; then
     set +e

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -4,7 +4,7 @@ set -e
 
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
-. "${script_path}/.shell_include.sh"
+. "${script_path}/shell_include.sh"
 
 if [ "$(id -u)" != 0 ]; then
     set +e

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -4,7 +4,7 @@ set -e
 
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
-. "${script_path}/.shell_include.sh"
+. "${script_path}/shell_include.sh"
 
 if [ ! -d "limine" ]; then
     echo "limine not found, the script will now build it"

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -3,7 +3,7 @@ set -e
 
 SCRIPT_DIR="$(dirname "${0}")"
 
-. "${SCRIPT_DIR}/.shell_include.sh"
+. "${SCRIPT_DIR}/shell_include.sh"
 
 USE_FUSE2FS=0
 

--- a/Meta/build-native-partition.sh
+++ b/Meta/build-native-partition.sh
@@ -4,7 +4,7 @@ set -e
 
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
-. "${script_path}/.shell_include.sh"
+. "${script_path}/shell_include.sh"
 
 cleanup() {
     if [ -d mnt ]; then

--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # shellcheck disable=SC2034
 # SC2034: "Variable appears unused. Verify it or export it."
 #         Those are intentional here, as the file is meant to be included elsewhere.


### PR DESCRIPTION
* `chmod -x` as it's for sourcing, not for executing
* Remove run line, for the same reason
* Rename it from .shell_include.sh to shell_include.sh, since e.g. `rg` doesn't search in hidden files by default

No behavior change.