### PR TITLE
LibGUI: Fix bug in the ColorPicker's spinbox not changing colors

### DIFF
--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -283,8 +283,13 @@ void ColorPicker::build_ui_custom(Widget& root_container)
     m_custom_color = horizontal_container.add<CustomColorWidget>(m_color);
     m_custom_color->set_preferred_size(299, 260);
     m_custom_color->on_pick = [this](Color color) {
-        if (m_color == color)
+        if (m_color == color) {
+            // NOTE: This call to update() is needed so that when changing the vertical color slider with the initial Color::White
+            //       selected value (which doesn't change with that slider as in all the slider's values the new color at that position
+            //       will still be Color::White) the spinbox colors are updated.
+            update();
             return;
+        }
 
         m_color = color;
         update_color_widgets();


### PR DESCRIPTION
Before this patch, when having the initial spinbox color value (Color::White), if you changed the color value in the vertical color picker it didn't update the spinbox's colors.

This is fixed by manually calling update() in the color picker's onchange() handler if the new color is equal to the previous color, which is the case in the initial spinbox's case as it will always be white unless it is changed (and won't be affected by the vertical color picker).

I added a NOTE in the source to explain this "opaque" update() call :))