### PR TITLE
Kernel+Tests: Handful of fixes and tests for the rmdir() syscall

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -834,8 +834,6 @@ ErrorOr<void> VirtualFileSystem::rmdir(Credentials const& credentials, StringVie
     if (last_component == "."sv)
         return EINVAL;
 
-    // FIXME: We should return ENOTEMPTY if the last component of the path is ".."
-
     if (!inode.is_directory())
         return ENOTDIR;
 

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -828,7 +828,12 @@ ErrorOr<void> VirtualFileSystem::rmdir(Credentials const& credentials, StringVie
     auto custody = TRY(resolve_path(credentials, path, base, &parent_custody));
     auto& inode = custody->inode();
 
-    // FIXME: We should return EINVAL if the last component of the path is "."
+    auto last_component = KLexicalPath::basename(path);
+
+    // [EINVAL] The path argument contains a last component that is dot.
+    if (last_component == "."sv)
+        return EINVAL;
+
     // FIXME: We should return ENOTEMPTY if the last component of the path is ".."
 
     if (!inode.is_directory())

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -822,6 +822,7 @@ ErrorOr<void> VirtualFileSystem::symlink(Credentials const& credentials, StringV
     return {};
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/rmdir.html
 ErrorOr<void> VirtualFileSystem::rmdir(Credentials const& credentials, StringView path, Custody& base)
 {
     RefPtr<Custody> parent_custody;
@@ -834,15 +835,22 @@ ErrorOr<void> VirtualFileSystem::rmdir(Credentials const& credentials, StringVie
     if (last_component == "."sv)
         return EINVAL;
 
+    // [ENOTDIR] A component of path names an existing file that is neither a directory
+    //           nor a symbolic link to a directory.
     if (!inode.is_directory())
         return ENOTDIR;
 
+    // [EBUSY] The directory to be removed is currently in use by the system or some process
+    //         and the implementation considers this to be an error.
+    // NOTE: If there is no parent, that means we're trying to rmdir the root directory!
     if (!parent_custody)
         return EBUSY;
 
     auto& parent_inode = parent_custody->inode();
     auto parent_metadata = parent_inode.metadata();
 
+    // [EACCES] Search permission is denied on a component of the path prefix,
+    //          or write permission is denied on the parent directory of the directory to be removed.
     if (!parent_metadata.may_write(credentials))
         return EACCES;
 
@@ -857,9 +865,12 @@ ErrorOr<void> VirtualFileSystem::rmdir(Credentials const& credentials, StringVie
         return {};
     }));
 
+    // [ENOTEMPTY] The path argument names a directory that is not an empty directory,
+    //             or there are hard links to the directory other than dot or a single entry in dot-dot.
     if (child_count != 2)
         return ENOTEMPTY;
 
+    // [EROFS] The directory entry to be removed resides on a read-only file system.
     if (custody->is_readonly())
         return EROFS;
 

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -855,8 +855,13 @@ ErrorOr<void> VirtualFileSystem::rmdir(Credentials const& credentials, StringVie
         return EACCES;
 
     if (parent_metadata.is_sticky()) {
-        if (!credentials.is_superuser() && inode.metadata().uid != credentials.euid())
+        // [EACCES] The S_ISVTX flag is set on the directory containing the file referred to by the path argument
+        //          and the process does not satisfy the criteria specified in XBD Directory Protection.
+        if (!credentials.is_superuser()
+            && inode.metadata().uid != credentials.euid()
+            && parent_metadata.uid != credentials.euid()) {
             return EACCES;
+        }
     }
 
     size_t child_count = 0;

--- a/Tests/LibC/TestIo.cpp
+++ b/Tests/LibC/TestIo.cpp
@@ -317,6 +317,26 @@ TEST_CASE(tmpfs_massive_file)
     EXPECT_EQ(rc, 0);
 }
 
+TEST_CASE(rmdir_dot)
+{
+    int rc = mkdir("/home/anon/rmdir-test-1", 0700);
+    EXPECT_EQ(rc, 0);
+
+    rc = rmdir("/home/anon/rmdir-test-1/.");
+    EXPECT_NE(rc, 0);
+    EXPECT_EQ(errno, EINVAL);
+
+    rc = chdir("/home/anon/rmdir-test-1");
+    EXPECT_EQ(rc, 0);
+
+    rc = rmdir(".");
+    VERIFY(rc != 0);
+    EXPECT_EQ(errno, EINVAL);
+
+    rc = rmdir("/home/anon/rmdir-test-1");
+    EXPECT_EQ(rc, 0);
+}
+
 TEST_CASE(rmdir_while_inside_dir)
 {
     int rc = mkdir("/home/anon/testdir", 0700);

--- a/Tests/LibC/TestIo.cpp
+++ b/Tests/LibC/TestIo.cpp
@@ -337,6 +337,25 @@ TEST_CASE(rmdir_dot)
     EXPECT_EQ(rc, 0);
 }
 
+TEST_CASE(rmdir_dot_dot)
+{
+    int rc = mkdir("/home/anon/rmdir-test-2", 0700);
+    EXPECT_EQ(rc, 0);
+
+    rc = mkdir("/home/anon/rmdir-test-2/foo", 0700);
+    EXPECT_EQ(rc, 0);
+
+    rc = rmdir("/home/anon/rmdir-test-2/foo/..");
+    EXPECT_NE(rc, 0);
+    EXPECT_EQ(errno, ENOTEMPTY);
+
+    rc = rmdir("/home/anon/rmdir-test-2/foo");
+    EXPECT_EQ(rc, 0);
+
+    rc = rmdir("/home/anon/rmdir-test-2");
+    EXPECT_EQ(rc, 0);
+}
+
 TEST_CASE(rmdir_while_inside_dir)
 {
     int rc = mkdir("/home/anon/testdir", 0700);


### PR DESCRIPTION
While cleaning out some ancient FIXMEs, I ran into some other issues with `rmdir()` so here are a bunch of fixes for that. :^)