### PR TITLE
AK: Use doubling method to improve pow() precision for large integers

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -728,6 +728,30 @@ ALWAYS_INLINE I round_to(double value)
 }
 #endif
 
+template<FloatingPoint T, Integral I>
+constexpr T upow(T x, I n)
+{
+    T y = 1.0;
+
+    do {
+        if (n & 1)
+            y *= x;
+        x *= x;
+        n >>= 1;
+    } while (n);
+
+    return y;
+}
+
+template<FloatingPoint T, Integral I>
+constexpr T ipow(T x, I n)
+{
+    if (n < 0)
+        return upow(1.0l / x, -n);
+
+    return upow(x, n);
+}
+
 template<FloatingPoint T>
 constexpr T pow(T x, T y)
 {
@@ -741,15 +765,10 @@ constexpr T pow(T x, T y)
         return 0;
     if (y == 1)
         return x;
+
     int y_as_int = (int)y;
-    if (y == (T)y_as_int) {
-        T result = x;
-        for (int i = 0; i < fabs<T>(y) - 1; ++i)
-            result *= x;
-        if (y < 0)
-            result = 1.0l / result;
-        return result;
-    }
+    if (y == (T)y_as_int)
+        return ipow(x, y_as_int);
 
     return exp2<T>(y * log2<T>(x));
 }

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -28,6 +28,7 @@ set(AK_TEST_SOURCES
     TestFixedArray.cpp
     TestFixedPoint.cpp
     TestFloatingPoint.cpp
+    TestFloatingPointMath.cpp    
     TestFloatingPointParsing.cpp
     TestFormat.cpp
     TestGenericLexer.cpp

--- a/Tests/AK/TestFloatingPointMath.cpp
+++ b/Tests/AK/TestFloatingPointMath.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022, Matheus Sousa <msamuel@aluno.puc-rio.br>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/Math.h>
+
+TEST_CASE(pow)
+{
+    EXPECT_EQ(AK::pow(10.0, -100.0), 0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001);
+}


### PR DESCRIPTION
The corner case mentioned in #15924 now gives the expected answer because the new code performs fewer multiplications, making it less prone to losing precision in float-point operations.