### PR TITLE
PixelPaint: Move tool scaling function now works in all directions

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -89,7 +89,7 @@ void MoveTool::on_mousemove(Layer* layer, MouseEvent& event)
             break;
         }
         scaling_origin.translate_by(delta);
-        if (m_keep_ascept_ratio) {
+        if (m_keep_aspect_ratio) {
             auto aspect_ratio = m_layer_being_moved->size().aspect_ratio();
             scaling_origin = opposite_corner.end_point_for_aspect_ratio(scaling_origin, aspect_ratio);
         }
@@ -133,7 +133,7 @@ void MoveTool::on_mouseup(Layer* layer, MouseEvent& event)
 bool MoveTool::on_keydown(GUI::KeyEvent& event)
 {
     if (event.key() == Key_Shift)
-        m_keep_ascept_ratio = true;
+        m_keep_aspect_ratio = true;
 
     if (m_scaling)
         return true;
@@ -172,7 +172,7 @@ bool MoveTool::on_keydown(GUI::KeyEvent& event)
 void MoveTool::on_keyup(GUI::KeyEvent& event)
 {
     if (event.key() == Key_Shift)
-        m_keep_ascept_ratio = false;
+        m_keep_aspect_ratio = false;
 }
 
 void MoveTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -12,6 +12,12 @@
 
 namespace PixelPaint {
 
+enum class ResizeAnchorLocation {
+    BottomLeft,
+    BottomRight,
+    TopLeft,
+    TopRight
+};
 class MoveTool final : public Tool {
 public:
     MoveTool() = default;
@@ -28,14 +34,14 @@ public:
 private:
     virtual StringView tool_name() const override { return "Move Tool"sv; }
     ErrorOr<void> update_cached_preview_bitmap(Layer const* layer);
+    Optional<ResizeAnchorLocation const> resize_anchor_location_from_cursor_position(Layer const*, MouseEvent&);
 
     RefPtr<Layer> m_layer_being_moved;
     Gfx::IntPoint m_event_origin;
     Gfx::IntPoint m_layer_origin;
-    Gfx::IntPoint m_new_scaled_layer_location;
-    Gfx::IntSize m_new_layer_size;
+    Gfx::IntRect m_new_layer_rect;
     bool m_scaling { false };
-    bool m_mouse_in_resize_corner { false };
+    Optional<ResizeAnchorLocation const> m_resize_anchor_location {};
     bool m_keep_ascept_ratio { false };
 
     RefPtr<Gfx::Bitmap> m_cached_preview_bitmap { nullptr };

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -42,7 +42,7 @@ private:
     Gfx::IntRect m_new_layer_rect;
     bool m_scaling { false };
     Optional<ResizeAnchorLocation const> m_resize_anchor_location {};
-    bool m_keep_ascept_ratio { false };
+    bool m_keep_aspect_ratio { false };
 
     RefPtr<Gfx::Bitmap> m_cached_preview_bitmap { nullptr };
 };


### PR DESCRIPTION
It is now possible to scale the current layer using the move tool from all four corners of the layer boundary. Previously scaling was only possible from the bottom right of the image.

This patch also clamps the width and height of the scaled image to 1 pixel, rather than growing the image once the user scales past the opposite corner.

Here is a video demonstrating the new functionality:

https://user-images.githubusercontent.com/2817754/208587395-06e6afe9-b075-4d44-8ad6-9cf668ef4e5f.mp4


