### PR TITLE
LibPDF + PDFViewer: encryption handling fixes/improvements, bugfix on Errors view

### DIFF
--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -49,8 +49,7 @@ public:
             return static_cast<int>(m_paged_errors.size());
         }
         if (!index.parent().is_valid()) {
-            auto errors_in_page = m_paged_errors.get(index.row()).release_value().size();
-            return static_cast<int>(errors_in_page);
+            return static_cast<int>(error_count_in_page(index));
         }
         return 0;
     }
@@ -103,7 +102,7 @@ public:
             case Columns::Page:
                 return m_pages_with_errors[index.row()] + 1;
             case Columns::Message:
-                return DeprecatedString::formatted("{} errors", m_paged_errors.get(index.row()).release_value().size());
+                return DeprecatedString::formatted("{} errors", error_count_in_page(index));
             default:
                 VERIFY_NOT_REACHED();
             }
@@ -147,6 +146,13 @@ private:
         for (auto const& entry : m_paged_errors)
             count += entry.value.size();
         return count;
+    }
+
+    size_t error_count_in_page(GUI::ModelIndex const& index) const
+    {
+        VERIFY(!index.parent().is_valid());
+        auto page = m_pages_with_errors[index.row()];
+        return m_paged_errors.get(page).release_value().size();
     }
 
     Vector<u32> m_pages_with_errors;

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -19,6 +19,7 @@
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/FilePicker.h>
+#include <LibGUI/InputBox.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
@@ -366,8 +367,15 @@ PDF::PDFErrorOr<void> PDFViewerWidget::try_open_file(Core::File& file)
     auto document = TRY(PDF::Document::create(m_buffer));
 
     if (auto sh = document->security_handler(); sh && !sh->has_user_password()) {
-        // FIXME: Prompt the user for a password
-        VERIFY_NOT_REACHED();
+        DeprecatedString password;
+        while (true) {
+            auto result = GUI::InputBox::show(window(), password, "Password"sv, "Password required"sv, {}, GUI::InputType::Password);
+            if (result == GUI::Dialog::ExecResult::OK
+                && document->security_handler()->try_provide_user_password(password))
+                break;
+            if (result == GUI::Dialog::ExecResult::Cancel)
+                return {};
+        }
     }
 
     TRY(document->initialize());

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -134,6 +134,7 @@
     A(UCR)                        \
     A(UseBlackPTComp)             \
     A(UserUnit)                   \
+    A(V)                          \
     A(W)                          \
     A(WhitePoint)                 \
     A(Width)                      \

--- a/Userland/Libraries/LibPDF/Encryption.cpp
+++ b/Userland/Libraries/LibPDF/Encryption.cpp
@@ -187,9 +187,14 @@ bool StandardSecurityHandler::try_provide_user_password(StringView password_stri
     //    handlers of revision 3 or greater), the password supplied is the correct user
     //    password.
     auto u_bytes = m_u_entry.bytes();
+    bool has_user_password;
     if (m_revision >= 3)
-        return u_bytes.slice(0, 16) == password_buffer.bytes().slice(0, 16);
-    return u_bytes == password_buffer.bytes();
+        has_user_password = u_bytes.slice(0, 16) == password_buffer.bytes().slice(0, 16);
+    else
+        has_user_password = u_bytes == password_buffer.bytes();
+    if (!has_user_password)
+        m_encryption_key = {};
+    return has_user_password;
 }
 
 ByteBuffer StandardSecurityHandler::compute_encryption_key(ByteBuffer password_string)


### PR DESCRIPTION
This PR fixes some details on how we handle encrypted PDF documents. A logic error in the SecurityHandler code meant that the automatic attempt performed to decrypt PDF documents with an empty string always left the SecurityHandler thinking it had a valid user password, when this wasn't necessarily the case. This has been fixed, and an input dialog has been added so that useres are prompted for a password if the Document hasn't been decrypted successfully yet. The Encryption dictionary's Length item is also optional, but our code was accessing it unconditionally, so I've fixed that, giving us access to more documents.

Separately, a bugfix for the Errors view was needed. The original implementation had been tested with 1 or 2 pages documents, so the indexes of the pages on the errors map matched the page numbers, which are 0-indexed internally.