### PR TITLE
LibGfx: Clean up OpenType parsing by using C++ structs and BigEndian<T> a lot more

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzTTF.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTTF.cpp
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGfx/Font/TrueType/Font.h>
+#include <LibGfx/Font/OpenType/Font.h>
 #include <stddef.h>
 #include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
-    (void)TTF::Font::try_load_from_externally_owned_memory({ data, size });
+    (void)OpenType::Font::try_load_from_externally_owned_memory({ data, size });
     return 0;
 }

--- a/Tests/LibTTF/TestCmap.cpp
+++ b/Tests/LibTTF/TestCmap.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGfx/Font/TrueType/Cmap.h>
+#include <LibGfx/Font/OpenType/Cmap.h>
 #include <LibTest/TestCase.h>
 
 TEST_CASE(test_cmap_format_4)
@@ -54,7 +54,7 @@ TEST_CASE(test_cmap_format_4)
         0, 0,
     };
     // clang-format on
-    auto cmap = TTF::Cmap::from_slice({ cmap_table, sizeof cmap_table }).value();
+    auto cmap = OpenType::Cmap::from_slice({ cmap_table, sizeof cmap_table }).value();
     cmap.set_active_index(0);
 
     // Format 4 can't handle code points > 0xffff.
@@ -74,7 +74,7 @@ TEST_CASE(test_cmap_format_4)
     // From https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values:
     // "the final start code and endCode values must be 0xFFFF. This segment need not contain any valid mappings.
     // (It can just map the single character code 0xFFFF to missingGlyph). However, the segment must be present."
-    // FIXME: Make TTF::Cmap::from_slice() reject inputs where this isn't true.
+    // FIXME: Make OpenType::Cmap::from_slice() reject inputs where this isn't true.
     EXPECT_EQ(cmap.glyph_id_for_code_point(0xfeff), 0u);
     EXPECT_EQ(cmap.glyph_id_for_code_point(0xffff), 0xffffu);
     EXPECT_EQ(cmap.glyph_id_for_code_point(0x1'0000), 0u);

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -17,11 +17,11 @@ set(SOURCES
     Font/BitmapFont.cpp
     Font/Emoji.cpp
     Font/FontDatabase.cpp
+    Font/OpenType/Cmap.cpp
+    Font/OpenType/Font.cpp
+    Font/OpenType/Glyf.cpp
     Font/PathRasterizer.cpp
     Font/ScaledFont.cpp
-    Font/TrueType/Cmap.cpp
-    Font/TrueType/Font.cpp
-    Font/TrueType/Glyf.cpp
     Font/Typeface.cpp
     Font/WOFF/Font.cpp
     GIFLoader.cpp

--- a/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -12,7 +12,7 @@
 #include <LibCore/File.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
-#include <LibGfx/Font/TrueType/Font.h>
+#include <LibGfx/Font/OpenType/Font.h>
 #include <LibGfx/Font/Typeface.h>
 #include <LibGfx/Font/WOFF/Font.h>
 #include <stdlib.h>
@@ -151,7 +151,7 @@ void FontDatabase::load_all_fonts_from_path(DeprecatedString const& root)
                 }
             } else if (path.ends_with(".ttf"sv)) {
                 // FIXME: What about .otf
-                if (auto font_or_error = TTF::Font::try_load_from_file(path); !font_or_error.is_error()) {
+                if (auto font_or_error = OpenType::Font::try_load_from_file(path); !font_or_error.is_error()) {
                     auto font = font_or_error.release_value();
                     auto typeface = get_or_create_typeface(font->family(), font->variant());
                     typeface->set_vector_font(move(font));

--- a/Userland/Libraries/LibGfx/Font/OpenType/Cmap.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Cmap.cpp
@@ -5,9 +5,9 @@
  */
 
 #include <AK/Optional.h>
-#include <LibGfx/Font/TrueType/Cmap.h>
+#include <LibGfx/Font/OpenType/Cmap.h>
 
-namespace TTF {
+namespace OpenType {
 
 extern u16 be_u16(u8 const*);
 extern u32 be_u32(u8 const*);

--- a/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
@@ -11,6 +11,8 @@
 
 namespace OpenType {
 
+// https://learn.microsoft.com/en-us/typography/opentype/spec/cmap
+// cmap — Character to Glyph Index Mapping Table
 class Cmap {
 public:
     class Subtable {

--- a/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
@@ -9,7 +9,7 @@
 #include <AK/Span.h>
 #include <stdint.h>
 
-namespace TTF {
+namespace OpenType {
 
 class Cmap {
 public:

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -52,7 +52,7 @@ u32 tag_from_str(char const* str)
 
 Optional<Head> Head::from_slice(ReadonlyBytes slice)
 {
-    if (slice.size() < (size_t)Sizes::Table) {
+    if (slice.size() < sizeof(FontHeaderTable)) {
         return {};
     }
     return Head(slice);
@@ -60,43 +60,42 @@ Optional<Head> Head::from_slice(ReadonlyBytes slice)
 
 u16 Head::units_per_em() const
 {
-    return be_u16(m_slice.offset_pointer((u32)Offsets::UnitsPerEM));
+    return header().units_per_em;
 }
 
 i16 Head::xmin() const
 {
-    return be_i16(m_slice.offset_pointer((u32)Offsets::XMin));
+    return header().x_min;
 }
 
 i16 Head::ymin() const
 {
-    return be_i16(m_slice.offset_pointer((u32)Offsets::YMin));
+    return header().y_min;
 }
 
 i16 Head::xmax() const
 {
-    return be_i16(m_slice.offset_pointer((u32)Offsets::XMax));
+    return header().x_max;
 }
 
 i16 Head::ymax() const
 {
-    return be_i16(m_slice.offset_pointer((u32)Offsets::YMax));
+    return header().y_max;
 }
 
 u16 Head::style() const
 {
-    return be_u16(m_slice.offset_pointer((u32)Offsets::Style));
+    return header().mac_style;
 }
 
 u16 Head::lowest_recommended_ppem() const
 {
-    return be_u16(m_slice.offset_pointer((u32)Offsets::LowestRecPPEM));
+    return header().lowest_rec_ppem;
 }
 
 IndexToLocFormat Head::index_to_loc_format() const
 {
-    i16 raw = be_i16(m_slice.offset_pointer((u32)Offsets::IndexToLocFormat));
-    switch (raw) {
+    switch (header().index_to_loc_format) {
     case 0:
         return IndexToLocFormat::Offset16;
     case 1:

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -107,7 +107,7 @@ IndexToLocFormat Head::index_to_loc_format() const
 
 Optional<Hhea> Hhea::from_slice(ReadonlyBytes slice)
 {
-    if (slice.size() < (size_t)Sizes::Table) {
+    if (slice.size() < sizeof(HorizontalHeaderTable)) {
         return {};
     }
     return Hhea(slice);
@@ -115,27 +115,27 @@ Optional<Hhea> Hhea::from_slice(ReadonlyBytes slice)
 
 i16 Hhea::ascender() const
 {
-    return be_i16(m_slice.offset_pointer((u32)Offsets::Ascender));
+    return header().ascender;
 }
 
 i16 Hhea::descender() const
 {
-    return be_i16(m_slice.offset_pointer((u32)Offsets::Descender));
+    return header().descender;
 }
 
 i16 Hhea::line_gap() const
 {
-    return be_i16(m_slice.offset_pointer((u32)Offsets::LineGap));
+    return header().line_gap;
 }
 
 u16 Hhea::advance_width_max() const
 {
-    return be_u16(m_slice.offset_pointer((u32)Offsets::AdvanceWidthMax));
+    return header().advance_width_max;
 }
 
 u16 Hhea::number_of_h_metrics() const
 {
-    return be_u16(m_slice.offset_pointer((u32)Offsets::NumberOfHMetrics));
+    return header().number_of_h_metrics;
 }
 
 Optional<Maxp> Maxp::from_slice(ReadonlyBytes slice)

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -9,15 +9,15 @@
 #include <AK/Checked.h>
 #include <AK/Try.h>
 #include <LibCore/MappedFile.h>
-#include <LibGfx/Font/TrueType/Cmap.h>
-#include <LibGfx/Font/TrueType/Font.h>
-#include <LibGfx/Font/TrueType/Glyf.h>
-#include <LibGfx/Font/TrueType/Tables.h>
+#include <LibGfx/Font/OpenType/Cmap.h>
+#include <LibGfx/Font/OpenType/Font.h>
+#include <LibGfx/Font/OpenType/Glyf.h>
+#include <LibGfx/Font/OpenType/Tables.h>
 #include <LibTextCodec/Decoder.h>
 #include <math.h>
 #include <sys/mman.h>
 
-namespace TTF {
+namespace OpenType {
 
 u16 be_u16(u8 const*);
 u32 be_u32(u8 const*);
@@ -206,12 +206,12 @@ i16 Kern::get_glyph_kerning(u16 left_glyph_id, u16 right_glyph_id) const
         auto coverage = be_u16(subtable_slice.offset(2 * sizeof(u16)));
 
         if (version != 0) {
-            dbgln("TTF::Kern: unsupported subtable version {}", version);
+            dbgln("OpenType::Kern: unsupported subtable version {}", version);
             continue;
         }
 
         if (subtable_slice.size() < length) {
-            dbgln("TTF::Kern: subtable has an invalid size {}", length);
+            dbgln("OpenType::Kern: subtable has an invalid size {}", length);
             continue;
         }
 
@@ -224,7 +224,7 @@ i16 Kern::get_glyph_kerning(u16 left_glyph_id, u16 right_glyph_id) const
 
         // FIXME: implement support for these features
         if (!is_horizontal || is_minimum || is_cross_stream || (reserved_bits > 0)) {
-            dbgln("TTF::Kern: FIXME: implement missing feature support for subtable");
+            dbgln("OpenType::Kern: FIXME: implement missing feature support for subtable");
             continue;
         }
 
@@ -235,7 +235,7 @@ i16 Kern::get_glyph_kerning(u16 left_glyph_id, u16 right_glyph_id) const
             subtable_kerning = read_glyph_kerning_format0(subtable_slice.slice(Sizes::SubtableHeader), left_glyph_id, right_glyph_id);
             break;
         default:
-            dbgln("TTF::Kern: FIXME: subtable format {} is unsupported", format);
+            dbgln("OpenType::Kern: FIXME: subtable format {} is unsupported", format);
             continue;
         }
         if (!subtable_kerning.has_value())

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -140,7 +140,7 @@ u16 Hhea::number_of_h_metrics() const
 
 Optional<Maxp> Maxp::from_slice(ReadonlyBytes slice)
 {
-    if (slice.size() < (size_t)Sizes::TableV0p5) {
+    if (slice.size() < sizeof(MaximumProfileVersion0_5)) {
         return {};
     }
     return Maxp(slice);
@@ -148,7 +148,7 @@ Optional<Maxp> Maxp::from_slice(ReadonlyBytes slice)
 
 u16 Maxp::num_glyphs() const
 {
-    return be_u16(m_slice.offset_pointer((u32)Offsets::NumGlyphs));
+    return header().num_glyphs;
 }
 
 Optional<Hmtx> Hmtx::from_slice(ReadonlyBytes slice, u32 num_glyphs, u32 number_of_h_metrics)

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -52,7 +52,7 @@ private:
 
     static ErrorOr<NonnullRefPtr<Font>> try_load_from_offset(ReadonlyBytes, unsigned index = 0);
 
-    Font(ReadonlyBytes bytes, Head&& head, Name&& name, Hhea&& hhea, Maxp&& maxp, Hmtx&& hmtx, Cmap&& cmap, Loca&& loca, Glyf&& glyf, OS2&& os2, Optional<Kern>&& kern)
+    Font(ReadonlyBytes bytes, Head&& head, Name&& name, Hhea&& hhea, Maxp&& maxp, Hmtx&& hmtx, Cmap&& cmap, Loca&& loca, Glyf&& glyf, Optional<OS2> os2, Optional<Kern>&& kern)
         : m_buffer(move(bytes))
         , m_head(move(head))
         , m_name(move(name))
@@ -80,7 +80,7 @@ private:
     Loca m_loca;
     Glyf m_glyf;
     Cmap m_cmap;
-    OS2 m_os2;
+    Optional<OS2> m_os2;
     Optional<Kern> m_kern;
 };
 

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -11,12 +11,12 @@
 #include <AK/StringView.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Font/Font.h>
-#include <LibGfx/Font/TrueType/Cmap.h>
-#include <LibGfx/Font/TrueType/Glyf.h>
-#include <LibGfx/Font/TrueType/Tables.h>
+#include <LibGfx/Font/OpenType/Cmap.h>
+#include <LibGfx/Font/OpenType/Glyf.h>
+#include <LibGfx/Font/OpenType/Tables.h>
 #include <LibGfx/Font/VectorFont.h>
 
-namespace TTF {
+namespace OpenType {
 
 class Font : public Gfx::VectorFont {
     AK_MAKE_NONCOPYABLE(Font);

--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.cpp
@@ -358,13 +358,14 @@ RefPtr<Gfx::Bitmap> Glyf::Glyph::rasterize_simple(i16 font_ascender, i16 font_de
 
 Glyf::Glyph Glyf::glyph(u32 offset) const
 {
-    VERIFY(m_slice.size() >= offset + (u32)Sizes::GlyphHeader);
-    i16 num_contours = be_i16(m_slice.offset_pointer(offset));
-    i16 xmin = be_i16(m_slice.offset_pointer(offset + (u32)Offsets::XMin));
-    i16 ymin = be_i16(m_slice.offset_pointer(offset + (u32)Offsets::YMin));
-    i16 xmax = be_i16(m_slice.offset_pointer(offset + (u32)Offsets::XMax));
-    i16 ymax = be_i16(m_slice.offset_pointer(offset + (u32)Offsets::YMax));
-    auto slice = ReadonlyBytes(m_slice.offset_pointer(offset + (u32)Sizes::GlyphHeader), m_slice.size() - offset - (u32)Sizes::GlyphHeader);
+    VERIFY(m_slice.size() >= offset + sizeof(GlyphHeader));
+    auto const& glyph_header = *bit_cast<GlyphHeader const*>(m_slice.offset_pointer(offset));
+    i16 num_contours = glyph_header.number_of_contours;
+    i16 xmin = glyph_header.x_min;
+    i16 ymin = glyph_header.y_min;
+    i16 xmax = glyph_header.x_max;
+    i16 ymax = glyph_header.y_max;
+    auto slice = m_slice.slice(offset + sizeof(GlyphHeader));
     return Glyph(slice, xmin, ymin, xmax, ymax, num_contours);
 }
 

--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.cpp
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGfx/Font/TrueType/Glyf.h>
+#include <LibGfx/Font/OpenType/Glyf.h>
 #include <LibGfx/Path.h>
 #include <LibGfx/Point.h>
 
-namespace TTF {
+namespace OpenType {
 
 extern u16 be_u16(u8 const* ptr);
 extern u32 be_u32(u8 const* ptr);

--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
@@ -16,6 +16,8 @@
 
 namespace OpenType {
 
+// https://learn.microsoft.com/en-us/typography/opentype/spec/loca
+// loca: Index to Location
 class Loca {
 public:
     static Optional<Loca> from_slice(ReadonlyBytes, u32 num_glyphs, IndexToLocFormat);
@@ -34,6 +36,8 @@ private:
     IndexToLocFormat m_index_to_loc_format;
 };
 
+// https://learn.microsoft.com/en-us/typography/opentype/spec/glyf
+// glyf: Glyph Data
 class Glyf {
 public:
     class Glyph {

--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
@@ -148,14 +148,13 @@ public:
     Glyph glyph(u32 offset) const;
 
 private:
-    enum class Offsets {
-        XMin = 2,
-        YMin = 4,
-        XMax = 6,
-        YMax = 8,
-    };
-    enum class Sizes {
-        GlyphHeader = 10,
+    // https://learn.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers
+    struct GlyphHeader {
+        BigEndian<i16> number_of_contours;
+        BigEndian<i16> x_min;
+        BigEndian<i16> y_min;
+        BigEndian<i16> x_max;
+        BigEndian<i16> y_max;
     };
 
     ReadonlyBytes m_slice;

--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
@@ -10,11 +10,11 @@
 #include <AK/Vector.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/Font/OpenType/Tables.h>
 #include <LibGfx/Font/PathRasterizer.h>
-#include <LibGfx/Font/TrueType/Tables.h>
 #include <math.h>
 
-namespace TTF {
+namespace OpenType {
 
 class Loca {
 public:

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -327,10 +327,32 @@ public:
     i16 get_glyph_kerning(u16 left_glyph_id, u16 right_glyph_id) const;
 
 private:
-    enum Sizes : size_t {
-        SubtableHeader = 6,
-        Format0Entry = 6,
+    struct Header {
+        BigEndian<u16> version;
+        BigEndian<u16> n_tables;
     };
+
+    struct SubtableHeader {
+        BigEndian<u16> version;
+        BigEndian<u16> length;
+        BigEndian<u16> coverage;
+    };
+
+    // https://learn.microsoft.com/en-us/typography/opentype/spec/kern#format-0
+    struct Format0 {
+        BigEndian<u16> n_pairs;
+        BigEndian<u16> search_range;
+        BigEndian<u16> entry_selector;
+        BigEndian<u16> range_shift;
+    };
+
+    struct Format0Pair {
+        BigEndian<u16> left;
+        BigEndian<u16> right;
+        FWord value;
+    };
+
+    Header const& header() const { return *bit_cast<Header const*>(m_slice.data()); }
 
     Kern(ReadonlyBytes slice, FixedArray<size_t> subtable_offsets)
         : m_slice(slice)

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -19,6 +19,15 @@ enum class IndexToLocFormat {
     Offset32,
 };
 
+struct Fixed {
+    BigEndian<u16> integer;
+    BigEndian<u16> fraction;
+};
+
+struct LongDateTime {
+    BigEndian<u64> value;
+};
+
 // https://learn.microsoft.com/en-us/typography/opentype/spec/head
 // head: Font Header Table
 class Head {
@@ -34,19 +43,28 @@ public:
     IndexToLocFormat index_to_loc_format() const;
 
 private:
-    enum class Offsets {
-        UnitsPerEM = 18,
-        XMin = 36,
-        YMin = 38,
-        XMax = 40,
-        YMax = 42,
-        Style = 44,
-        LowestRecPPEM = 46,
-        IndexToLocFormat = 50,
+    struct FontHeaderTable {
+        BigEndian<u16> major_version;
+        BigEndian<u16> minor_version;
+        Fixed font_revision;
+        BigEndian<u32> checksum_adjustment;
+        BigEndian<u32> magic_number;
+        BigEndian<u16> flags;
+        BigEndian<u16> units_per_em;
+        LongDateTime created;
+        LongDateTime modified;
+        BigEndian<i16> x_min;
+        BigEndian<i16> y_min;
+        BigEndian<i16> x_max;
+        BigEndian<i16> y_max;
+        BigEndian<u16> mac_style;
+        BigEndian<u16> lowest_rec_ppem;
+        BigEndian<i16> font_direction_hint;
+        BigEndian<i16> index_to_loc_format;
+        BigEndian<i16> glyph_data_format;
     };
-    enum class Sizes {
-        Table = 54,
-    };
+
+    FontHeaderTable const& header() const { return *bit_cast<FontHeaderTable const*>(m_slice.data()); }
 
     Head(ReadonlyBytes slice)
         : m_slice(slice)

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -177,9 +177,9 @@ public:
     GlyphHorizontalMetrics get_glyph_horizontal_metrics(u32 glyph_id) const;
 
 private:
-    enum class Sizes {
-        LongHorMetric = 4,
-        LeftSideBearing = 2
+    struct LongHorMetric {
+        BigEndian<u16> advance_width;
+        BigEndian<i16> lsb;
     };
 
     Hmtx(ReadonlyBytes slice, u32 num_glyphs, u32 number_of_h_metrics)

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -12,7 +12,7 @@
 #include <AK/FixedArray.h>
 #include <AK/Span.h>
 
-namespace TTF {
+namespace OpenType {
 
 enum class IndexToLocFormat {
     Offset16,

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -28,6 +28,11 @@ struct LongDateTime {
     BigEndian<u64> value;
 };
 
+struct Version16Dot16 {
+    BigEndian<u16> major;
+    BigEndian<u16> minor;
+};
+
 using FWord = BigEndian<i16>;
 using UFWord = BigEndian<u16>;
 
@@ -122,15 +127,34 @@ private:
 class Maxp {
 public:
     static Optional<Maxp> from_slice(ReadonlyBytes);
+
     u16 num_glyphs() const;
 
 private:
-    enum class Offsets {
-        NumGlyphs = 4
+    struct MaximumProfileVersion0_5 {
+        Version16Dot16 version;
+        BigEndian<u16> num_glyphs;
     };
-    enum class Sizes {
-        TableV0p5 = 6,
+
+    struct MaximumProfileVersion1_0 {
+        Version16Dot16 version;
+        BigEndian<u16> num_glyphs;
+        BigEndian<u16> max_points;
+        BigEndian<u16> max_contours;
+        BigEndian<u16> max_composite_points;
+        BigEndian<u16> max_composite_contours;
+        BigEndian<u16> max_zones;
+        BigEndian<u16> max_twilight_points;
+        BigEndian<u16> max_storage;
+        BigEndian<u16> max_function_defs;
+        BigEndian<u16> max_instruction_defs;
+        BigEndian<u16> max_stack_elements;
+        BigEndian<u16> max_size_of_instructions;
+        BigEndian<u16> max_component_elements;
+        BigEndian<u16> max_component_depths;
     };
+
+    MaximumProfileVersion0_5 const& header() const { return *bit_cast<MaximumProfileVersion0_5 const*>(m_slice.data()); }
 
     Maxp(ReadonlyBytes slice)
         : m_slice(slice)

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -28,6 +28,9 @@ struct LongDateTime {
     BigEndian<u64> value;
 };
 
+using FWord = BigEndian<i16>;
+using UFWord = BigEndian<u16>;
+
 // https://learn.microsoft.com/en-us/typography/opentype/spec/head
 // head: Font Header Table
 class Head {
@@ -86,16 +89,25 @@ public:
     u16 number_of_h_metrics() const;
 
 private:
-    enum class Offsets {
-        Ascender = 4,
-        Descender = 6,
-        LineGap = 8,
-        AdvanceWidthMax = 10,
-        NumberOfHMetrics = 34,
+    struct HorizontalHeaderTable {
+        BigEndian<u16> major_version;
+        BigEndian<u16> minor_version;
+        FWord ascender;
+        FWord descender;
+        FWord line_gap;
+        UFWord advance_width_max;
+        FWord min_left_side_bearing;
+        FWord min_right_side_bearing;
+        FWord x_max_extent;
+        BigEndian<i16> caret_slope_rise;
+        BigEndian<i16> caret_slope_run;
+        BigEndian<i16> caret_offset;
+        BigEndian<i16> reserved[4];
+        BigEndian<i16> metric_data_format;
+        BigEndian<u16> number_of_h_metrics;
     };
-    enum class Sizes {
-        Table = 36,
-    };
+
+    HorizontalHeaderTable const& header() const { return *bit_cast<HorizontalHeaderTable const*>(m_slice.data()); }
 
     Hhea(ReadonlyBytes slice)
         : m_slice(slice)

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -19,6 +19,8 @@ enum class IndexToLocFormat {
     Offset32,
 };
 
+// https://learn.microsoft.com/en-us/typography/opentype/spec/head
+// head: Font Header Table
 class Head {
 public:
     static Optional<Head> from_slice(ReadonlyBytes);
@@ -54,6 +56,8 @@ private:
     ReadonlyBytes m_slice;
 };
 
+// https://learn.microsoft.com/en-us/typography/opentype/spec/hhea
+// hhea - Horizontal Header Table
 class Hhea {
 public:
     static Optional<Hhea> from_slice(ReadonlyBytes);
@@ -83,6 +87,8 @@ private:
     ReadonlyBytes m_slice;
 };
 
+// https://learn.microsoft.com/en-us/typography/opentype/spec/maxp
+// Maxp: Maximum Profile
 class Maxp {
 public:
     static Optional<Maxp> from_slice(ReadonlyBytes);
@@ -109,6 +115,8 @@ struct GlyphHorizontalMetrics {
     i16 left_side_bearing;
 };
 
+// https://learn.microsoft.com/en-us/typography/opentype/spec/hmtx
+// hmtx: Horizontal Metrics Table
 class Hmtx {
 public:
     static Optional<Hmtx> from_slice(ReadonlyBytes, u32 num_glyphs, u32 number_of_h_metrics);
@@ -132,6 +140,8 @@ private:
     u32 m_number_of_h_metrics { 0 };
 };
 
+// https://learn.microsoft.com/en-us/typography/opentype/spec/os2
+// OS/2: OS/2 and Windows Metrics Table
 class OS2 {
 public:
     enum class Offsets {
@@ -158,6 +168,8 @@ private:
     ReadonlyBytes m_slice;
 };
 
+// https://learn.microsoft.com/en-us/typography/opentype/spec/name
+// name: Naming Table
 class Name {
 public:
     enum class Platform {
@@ -205,6 +217,8 @@ private:
     ReadonlyBytes m_slice;
 };
 
+// https://learn.microsoft.com/en-us/typography/opentype/spec/kern
+// kern - Kerning
 class Kern {
 public:
     static ErrorOr<Kern> from_slice(ReadonlyBytes);

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -35,6 +35,7 @@ struct Version16Dot16 {
 
 using FWord = BigEndian<i16>;
 using UFWord = BigEndian<u16>;
+using Tag = BigEndian<u32>;
 
 // https://learn.microsoft.com/en-us/typography/opentype/spec/head
 // head: Font Header Table
@@ -198,15 +199,6 @@ private:
 // OS/2: OS/2 and Windows Metrics Table
 class OS2 {
 public:
-    enum class Offsets {
-        WeightClass = 4,
-        Selection = 62,
-        TypographicAscender = 68,
-        TypographicDescender = 70,
-        TypographicLineGap = 72,
-        End = 78,
-    };
-
     u16 weight_class() const;
     u16 selection() const;
     i16 typographic_ascender() const;
@@ -219,6 +211,41 @@ public:
     }
 
 private:
+    struct Version0 {
+        BigEndian<u16> version;
+        BigEndian<i16> avg_char_width;
+        BigEndian<u16> us_weight_class;
+        BigEndian<u16> us_width_class;
+        BigEndian<u16> fs_type;
+        BigEndian<i16> y_subscript_x_size;
+        BigEndian<i16> y_subscript_y_size;
+        BigEndian<i16> y_subscript_x_offset;
+        BigEndian<i16> y_subscript_y_offset;
+        BigEndian<i16> y_superscript_x_size;
+        BigEndian<i16> y_superscript_y_size;
+        BigEndian<i16> y_superscript_x_offset;
+        BigEndian<i16> y_superscript_y_offset;
+        BigEndian<i16> y_strikeout_size;
+        BigEndian<i16> y_strikeout_position;
+        BigEndian<i16> s_family_class;
+        u8 panose[10];
+        BigEndian<u32> ul_unicode_range1;
+        BigEndian<u32> ul_unicode_range2;
+        BigEndian<u32> ul_unicode_range3;
+        BigEndian<u32> ul_unicode_range4;
+        Tag ach_vend_id;
+        BigEndian<u16> fs_selection;
+        BigEndian<u16> fs_first_char_index;
+        BigEndian<u16> us_last_char_index;
+        BigEndian<i16> s_typo_ascender;
+        BigEndian<i16> s_typo_descender;
+        BigEndian<i16> s_typo_line_gap;
+        BigEndian<u16> us_win_ascent;
+        BigEndian<u16> us_win_descent;
+    };
+
+    Version0 const& header() const { return *bit_cast<Version0 const*>(m_slice.data()); }
+
     ReadonlyBytes m_slice;
 };
 

--- a/Userland/Libraries/LibGfx/Font/WOFF/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/WOFF/Font.cpp
@@ -7,7 +7,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/IntegralMath.h>
 #include <LibCompress/Zlib.h>
-#include <LibGfx/Font/TrueType/Font.h>
+#include <LibGfx/Font/OpenType/Font.h>
 #include <LibGfx/Font/WOFF/Font.h>
 
 namespace WOFF {
@@ -142,7 +142,7 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_externally_owned_memory(Readonl
         font_buffer_offset += orig_length;
     }
 
-    auto input_font = TRY(TTF::Font::try_load_from_externally_owned_memory(font_buffer.bytes(), index));
+    auto input_font = TRY(OpenType::Font::try_load_from_externally_owned_memory(font_buffer.bytes(), index));
     auto font = adopt_ref(*new Font(input_font, move(font_buffer)));
     return font;
 }

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGfx/Font/OpenType/Font.h>
 #include <LibGfx/Font/ScaledFont.h>
-#include <LibGfx/Font/TrueType/Font.h>
 #include <LibGfx/Painter.h>
 #include <LibPDF/CommonNames.h>
 #include <LibPDF/Fonts/TrueTypeFont.h>
@@ -24,7 +24,7 @@ PDFErrorOr<PDFFont::CommonData> TrueTypeFont::parse_data(Document* document, Non
             return data;
 
         auto font_file_stream = TRY(descriptor->get_stream(document, CommonNames::FontFile2));
-        auto ttf_font = TRY(TTF::Font::try_load_from_externally_owned_memory(font_file_stream->bytes()));
+        auto ttf_font = TRY(OpenType::Font::try_load_from_externally_owned_memory(font_file_stream->bytes()));
         data.font = adopt_ref(*new Gfx::ScaledFont(*ttf_font, font_size, font_size));
     }
 

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
-#include <LibGfx/Font/TrueType/Font.h>
+#include <LibGfx/Font/OpenType/Font.h>
 #include <LibPDF/Fonts/PDFFont.h>
 
 namespace PDF {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -14,8 +14,8 @@
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/FontStyleMapping.h>
+#include <LibGfx/Font/OpenType/Font.h>
 #include <LibGfx/Font/ScaledFont.h>
-#include <LibGfx/Font/TrueType/Font.h>
 #include <LibGfx/Font/VectorFont.h>
 #include <LibGfx/Font/WOFF/Font.h>
 #include <LibWeb/CSS/CSSFontFaceRule.h>
@@ -92,10 +92,10 @@ private:
         // FIXME: This could maybe use the format() provided in @font-face as well, since often the mime type is just application/octet-stream and we have to try every format
         auto mime_type = resource()->mime_type();
         if (mime_type == "font/ttf"sv || mime_type == "application/x-font-ttf"sv)
-            return TRY(TTF::Font::try_load_from_externally_owned_memory(resource()->encoded_data()));
+            return TRY(OpenType::Font::try_load_from_externally_owned_memory(resource()->encoded_data()));
         if (mime_type == "font/woff"sv)
             return TRY(WOFF::Font::try_load_from_externally_owned_memory(resource()->encoded_data()));
-        auto ttf = TTF::Font::try_load_from_externally_owned_memory(resource()->encoded_data());
+        auto ttf = OpenType::Font::try_load_from_externally_owned_memory(resource()->encoded_data());
         if (!ttf.is_error())
             return ttf.release_value();
         auto woff = WOFF::Font::try_load_from_externally_owned_memory(resource()->encoded_data());
@@ -1459,7 +1459,7 @@ void StyleComputer::load_fonts_from_sheet(CSSStyleSheet const& sheet)
             continue;
 
         // NOTE: This is rather ad-hoc, we just look for the first valid
-        //       source URL that's either a WOFF or TTF file and try loading that.
+        //       source URL that's either a WOFF or OpenType file and try loading that.
         // FIXME: Find out exactly which resources we need to load and how.
         Optional<AK::URL> candidate_url;
         for (auto& source : font_face.sources()) {


### PR DESCRIPTION
Here's a first attempt to make our OpenType parser a nicer to work with.