### PR TITLE
LibWeb: Speed up gradient painting quite a lot

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1842,7 +1842,14 @@ void Painter::set_pixel(IntPoint p, Color color, bool blend)
     // scaling and call set_pixel() -- do not scale the pixel.
     if (!clip_rect().contains(point / scale()))
         return;
-    auto& dst = m_target->scanline(point.y())[point.x()];
+    set_physical_pixel(point, color, blend);
+}
+
+void Painter::set_physical_pixel(IntPoint physical_point, Color color, bool blend)
+{
+    // This function should only be called after translation, clipping, etc has been handled elsewhere
+    // if not use set_pixel().
+    auto& dst = m_target->scanline(physical_point.y())[physical_point.x()];
     if (!blend || color.alpha() == 255)
         dst = color.value();
     else if (color.alpha())

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -71,7 +71,6 @@ static ColorStopData resolve_color_stop_positions(auto const& color_stop_list, a
         max_previous_color_stop_or_hint = value;
         return value;
     };
-    // Move this step somewhere generic (since I think this code can be mostly reused for conic gradients)
     size_t resolved_index = 0;
     for (auto& stop : color_stop_list) {
         if (stop.transition_hint.has_value())


### PR DESCRIPTION
Previously gradient painting was dominated by the clipping checks in `Painter::set_pixel()`.  
This PR changes gradient painting to use a new `Painter::fill_pixels()` function (which does all these checks outside the hot loop).

With this change gradient painting drops from 96% of the profile to 51% when scrolling around on gradients.html. 
A nice 45% reduction :^)