### PR TITLE
AK: Remove Bitmap::must_create()

### DIFF
--- a/AK/Bitmap.h
+++ b/AK/Bitmap.h
@@ -35,11 +35,6 @@ public:
         return bitmap;
     }
 
-    static Bitmap must_create(size_t size, bool default_value)
-    {
-        return MUST(create(size, default_value));
-    }
-
     Bitmap() = default;
 
     Bitmap(u8* data, size_t size, bool is_owning = false)

--- a/AK/Bitmap.h
+++ b/AK/Bitmap.h
@@ -22,7 +22,7 @@ class Bitmap : public BitmapView {
     AK_MAKE_NONCOPYABLE(Bitmap);
 
 public:
-    static ErrorOr<Bitmap> try_create(size_t size, bool default_value)
+    static ErrorOr<Bitmap> create(size_t size, bool default_value)
     {
         VERIFY(size != 0);
 
@@ -37,7 +37,7 @@ public:
 
     static Bitmap must_create(size_t size, bool default_value)
     {
-        return MUST(try_create(size, default_value));
+        return MUST(create(size, default_value));
     }
 
     Bitmap() = default;

--- a/Kernel/Bus/PCI/Controller/HostController.cpp
+++ b/Kernel/Bus/PCI/Controller/HostController.cpp
@@ -14,7 +14,7 @@ namespace Kernel::PCI {
 
 HostController::HostController(PCI::Domain const& domain)
     : m_domain(domain)
-    , m_enumerated_buses(Bitmap::try_create(256, false).release_value_but_fixme_should_propagate_errors())
+    , m_enumerated_buses(Bitmap::create(256, false).release_value_but_fixme_should_propagate_errors())
 {
 }
 

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
@@ -31,7 +31,7 @@ NonnullLockRefPtr<VirtIOGraphicsAdapter> VirtIOGraphicsAdapter::initialize(PCI::
         "VirtGPU Scratch Space"sv,
         Memory::Region::Access::ReadWrite));
 
-    auto active_context_ids = Bitmap::must_create(VREND_MAX_CTX, false);
+    auto active_context_ids = MUST(Bitmap::create(VREND_MAX_CTX, false));
     auto adapter = adopt_lock_ref(*new (nothrow) VirtIOGraphicsAdapter(device_identifier, move(active_context_ids), move(scratch_space_region)));
     adapter->initialize();
     MUST(adapter->initialize_adapter());

--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -279,7 +279,7 @@ NonnullRefPtr<PhysicalPage> AnonymousVMObject::allocate_committed_page(Badge<Reg
 ErrorOr<void> AnonymousVMObject::ensure_cow_map()
 {
     if (m_cow_map.is_null())
-        m_cow_map = TRY(Bitmap::try_create(page_count(), true));
+        m_cow_map = TRY(Bitmap::create(page_count(), true));
     return {};
 }
 

--- a/Kernel/Memory/PrivateInodeVMObject.cpp
+++ b/Kernel/Memory/PrivateInodeVMObject.cpp
@@ -23,14 +23,14 @@ ErrorOr<NonnullLockRefPtr<PrivateInodeVMObject>> PrivateInodeVMObject::try_creat
     auto size = max(inode.size(), (offset + range_size));
     VERIFY(size > 0);
     auto new_physical_pages = TRY(VMObject::try_create_physical_pages(size));
-    auto dirty_pages = TRY(Bitmap::try_create(new_physical_pages.size(), false));
+    auto dirty_pages = TRY(Bitmap::create(new_physical_pages.size(), false));
     return adopt_nonnull_lock_ref_or_enomem(new (nothrow) PrivateInodeVMObject(inode, move(new_physical_pages), move(dirty_pages)));
 }
 
 ErrorOr<NonnullLockRefPtr<VMObject>> PrivateInodeVMObject::try_clone()
 {
     auto new_physical_pages = TRY(this->try_clone_physical_pages());
-    auto dirty_pages = TRY(Bitmap::try_create(new_physical_pages.size(), false));
+    auto dirty_pages = TRY(Bitmap::create(new_physical_pages.size(), false));
     return adopt_nonnull_lock_ref_or_enomem<VMObject>(new (nothrow) PrivateInodeVMObject(*this, move(new_physical_pages), move(dirty_pages)));
 }
 

--- a/Kernel/Memory/SharedInodeVMObject.cpp
+++ b/Kernel/Memory/SharedInodeVMObject.cpp
@@ -26,7 +26,7 @@ ErrorOr<NonnullLockRefPtr<SharedInodeVMObject>> SharedInodeVMObject::try_create_
     if (auto shared_vmobject = inode.shared_vmobject())
         return shared_vmobject.release_nonnull();
     auto new_physical_pages = TRY(VMObject::try_create_physical_pages(size));
-    auto dirty_pages = TRY(Bitmap::try_create(new_physical_pages.size(), false));
+    auto dirty_pages = TRY(Bitmap::create(new_physical_pages.size(), false));
     auto vmobject = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) SharedInodeVMObject(inode, move(new_physical_pages), move(dirty_pages))));
     TRY(vmobject->inode().set_shared_vmobject(*vmobject));
     return vmobject;
@@ -35,7 +35,7 @@ ErrorOr<NonnullLockRefPtr<SharedInodeVMObject>> SharedInodeVMObject::try_create_
 ErrorOr<NonnullLockRefPtr<VMObject>> SharedInodeVMObject::try_clone()
 {
     auto new_physical_pages = TRY(this->try_clone_physical_pages());
-    auto dirty_pages = TRY(Bitmap::try_create(new_physical_pages.size(), false));
+    auto dirty_pages = TRY(Bitmap::create(new_physical_pages.size(), false));
     return adopt_nonnull_lock_ref_or_enomem<VMObject>(new (nothrow) SharedInodeVMObject(*this, move(new_physical_pages), move(dirty_pages)));
 }
 

--- a/Tests/AK/TestBitmap.cpp
+++ b/Tests/AK/TestBitmap.cpp
@@ -16,14 +16,14 @@ TEST_CASE(construct_empty)
 
 TEST_CASE(find_first_set)
 {
-    auto bitmap = Bitmap::must_create(128, false);
+    auto bitmap = MUST(Bitmap::create(128, false));
     bitmap.set(69, true);
     EXPECT_EQ(bitmap.find_first_set().value(), 69u);
 }
 
 TEST_CASE(find_first_unset)
 {
-    auto bitmap = Bitmap::must_create(128, true);
+    auto bitmap = MUST(Bitmap::create(128, true));
     bitmap.set(51, false);
     EXPECT_EQ(bitmap.find_first_unset().value(), 51u);
 }
@@ -31,7 +31,7 @@ TEST_CASE(find_first_unset)
 TEST_CASE(find_one_anywhere_set)
 {
     {
-        auto bitmap = Bitmap::must_create(168, false);
+        auto bitmap = MUST(Bitmap::create(168, false));
         bitmap.set(34, true);
         bitmap.set(97, true);
         EXPECT_EQ(bitmap.find_one_anywhere_set(0).value(), 34u);
@@ -48,7 +48,7 @@ TEST_CASE(find_one_anywhere_set)
         EXPECT_EQ(bitmap.find_one_anywhere_set(128).value(), 34u);
     }
     {
-        auto bitmap = Bitmap::must_create(128 + 24, false);
+        auto bitmap = MUST(Bitmap::create(128 + 24, false));
         bitmap.set(34, true);
         bitmap.set(126, true);
         EXPECT_EQ(bitmap.find_one_anywhere_set(0).value(), 34u);
@@ -56,7 +56,7 @@ TEST_CASE(find_one_anywhere_set)
         EXPECT_EQ(bitmap.find_one_anywhere_set(64).value(), 126u);
     }
     {
-        auto bitmap = Bitmap::must_create(32, false);
+        auto bitmap = MUST(Bitmap::create(32, false));
         bitmap.set(12, true);
         bitmap.set(24, true);
         auto got = bitmap.find_one_anywhere_set(0).value();
@@ -67,7 +67,7 @@ TEST_CASE(find_one_anywhere_set)
 TEST_CASE(find_one_anywhere_unset)
 {
     {
-        auto bitmap = Bitmap::must_create(168, true);
+        auto bitmap = MUST(Bitmap::create(168, true));
         bitmap.set(34, false);
         bitmap.set(97, false);
         EXPECT_EQ(bitmap.find_one_anywhere_unset(0).value(), 34u);
@@ -84,7 +84,7 @@ TEST_CASE(find_one_anywhere_unset)
         EXPECT_EQ(bitmap.find_one_anywhere_unset(128).value(), 34u);
     }
     {
-        auto bitmap = Bitmap::must_create(128 + 24, true);
+        auto bitmap = MUST(Bitmap::create(128 + 24, true));
         bitmap.set(34, false);
         bitmap.set(126, false);
         EXPECT_EQ(bitmap.find_one_anywhere_unset(0).value(), 34u);
@@ -92,7 +92,7 @@ TEST_CASE(find_one_anywhere_unset)
         EXPECT_EQ(bitmap.find_one_anywhere_unset(64).value(), 126u);
     }
     {
-        auto bitmap = Bitmap::must_create(32, true);
+        auto bitmap = MUST(Bitmap::create(32, true));
         bitmap.set(12, false);
         bitmap.set(24, false);
         auto got = bitmap.find_one_anywhere_unset(0).value();
@@ -102,7 +102,7 @@ TEST_CASE(find_one_anywhere_unset)
 
 TEST_CASE(find_first_range)
 {
-    auto bitmap = Bitmap::must_create(128, true);
+    auto bitmap = MUST(Bitmap::create(128, true));
     bitmap.set(47, false);
     bitmap.set(48, false);
     bitmap.set(49, false);
@@ -118,7 +118,7 @@ TEST_CASE(find_first_range)
 TEST_CASE(set_range)
 {
     {
-        auto bitmap = Bitmap::must_create(128, false);
+        auto bitmap = MUST(Bitmap::create(128, false));
         bitmap.set_range(41, 10, true);
         EXPECT_EQ(bitmap.get(40), false);
         EXPECT_EQ(bitmap.get(41), true);
@@ -134,7 +134,7 @@ TEST_CASE(set_range)
         EXPECT_EQ(bitmap.get(51), false);
     }
     {
-        auto bitmap = Bitmap::must_create(288, false);
+        auto bitmap = MUST(Bitmap::create(288, false));
         bitmap.set_range(48, 32, true);
         bitmap.set_range(94, 39, true);
         bitmap.set_range(190, 71, true);
@@ -152,12 +152,12 @@ TEST_CASE(set_range)
 TEST_CASE(find_first_fit)
 {
     {
-        auto bitmap = Bitmap::must_create(32, true);
+        auto bitmap = MUST(Bitmap::create(32, true));
         auto fit = bitmap.find_first_fit(1);
         EXPECT_EQ(fit.has_value(), false);
     }
     {
-        auto bitmap = Bitmap::must_create(32, true);
+        auto bitmap = MUST(Bitmap::create(32, true));
         bitmap.set(31, false);
         auto fit = bitmap.find_first_fit(1);
         EXPECT_EQ(fit.has_value(), true);
@@ -165,7 +165,7 @@ TEST_CASE(find_first_fit)
     }
 
     for (size_t i = 0; i < 128; ++i) {
-        auto bitmap = Bitmap::must_create(128, true);
+        auto bitmap = MUST(Bitmap::create(128, true));
         bitmap.set(i, false);
         auto fit = bitmap.find_first_fit(1);
         EXPECT_EQ(fit.has_value(), true);
@@ -173,7 +173,7 @@ TEST_CASE(find_first_fit)
     }
 
     for (size_t i = 0; i < 127; ++i) {
-        auto bitmap = Bitmap::must_create(128, true);
+        auto bitmap = MUST(Bitmap::create(128, true));
         bitmap.set(i, false);
         bitmap.set(i + 1, false);
         auto fit = bitmap.find_first_fit(2);
@@ -184,7 +184,7 @@ TEST_CASE(find_first_fit)
     size_t bitmap_size = 1024;
     for (size_t chunk_size = 1; chunk_size < 64; ++chunk_size) {
         for (size_t i = 0; i < bitmap_size - chunk_size; ++i) {
-            auto bitmap = Bitmap::must_create(bitmap_size, true);
+            auto bitmap = MUST(Bitmap::create(bitmap_size, true));
             for (size_t c = 0; c < chunk_size; ++c)
                 bitmap.set(i + c, false);
             auto fit = bitmap.find_first_fit(chunk_size);
@@ -196,7 +196,7 @@ TEST_CASE(find_first_fit)
 
 TEST_CASE(find_longest_range_of_unset_bits_edge)
 {
-    auto bitmap = Bitmap::must_create(36, true);
+    auto bitmap = MUST(Bitmap::create(36, true));
     bitmap.set_range(32, 4, false);
     size_t found_range_size = 0;
     auto result = bitmap.find_longest_range_of_unset_bits(1, found_range_size);
@@ -206,7 +206,7 @@ TEST_CASE(find_longest_range_of_unset_bits_edge)
 
 TEST_CASE(count_in_range)
 {
-    auto bitmap = Bitmap::must_create(256, false);
+    auto bitmap = MUST(Bitmap::create(256, false));
     bitmap.set(14, true);
     bitmap.set(17, true);
     bitmap.set(19, true);
@@ -252,14 +252,14 @@ TEST_CASE(count_in_range)
 TEST_CASE(byte_aligned_access)
 {
     {
-        auto bitmap = Bitmap::must_create(16, true);
+        auto bitmap = MUST(Bitmap::create(16, true));
         EXPECT_EQ(bitmap.count_in_range(0, 16, true), 16u);
         EXPECT_EQ(bitmap.count_in_range(8, 8, true), 8u);
         EXPECT_EQ(bitmap.count_in_range(0, 8, true), 8u);
         EXPECT_EQ(bitmap.count_in_range(4, 8, true), 8u);
     }
     {
-        auto bitmap = Bitmap::must_create(16, false);
+        auto bitmap = MUST(Bitmap::create(16, false));
         bitmap.set_range(4, 8, true);
         EXPECT_EQ(bitmap.count_in_range(0, 16, true), 8u);
         EXPECT_EQ(bitmap.count_in_range(8, 8, true), 4u);
@@ -267,7 +267,7 @@ TEST_CASE(byte_aligned_access)
         EXPECT_EQ(bitmap.count_in_range(4, 8, true), 8u);
     }
     {
-        auto bitmap = Bitmap::must_create(8, false);
+        auto bitmap = MUST(Bitmap::create(8, false));
         bitmap.set(2, true);
         bitmap.set(4, true);
         EXPECT_EQ(bitmap.count_in_range(0, 2, true), 0u);

--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -48,7 +48,7 @@ public:
     void will_track_seen_events(size_t profile_event_count)
     {
         if (m_seen_events.size() != profile_event_count)
-            m_seen_events = Bitmap::must_create(profile_event_count, false);
+            m_seen_events = Bitmap::create(profile_event_count, false).release_value_but_fixme_should_propagate_errors();
     }
     bool has_seen_event(size_t event_index) const { return m_seen_events.get(event_index); }
     void did_see_event(size_t event_index) { m_seen_events.set(event_index, true); }

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -655,7 +655,7 @@ void Bitmap::flood_visit_from_point(Gfx::IntPoint start_point, int threshold,
 
     points_to_visit.enqueue(start_point);
     pixel_reached(start_point);
-    auto flood_mask = AK::Bitmap::must_create(width() * height(), false);
+    auto flood_mask = AK::Bitmap::create(width() * height(), false).release_value_but_fixme_should_propagate_errors();
 
     flood_mask.set(width() * start_point.y() + start_point.x(), true);
 

--- a/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
@@ -13,7 +13,7 @@ namespace JS::Bytecode::Passes {
 
 static NonnullOwnPtr<BasicBlock> eliminate_loads(BasicBlock const& block, size_t number_of_registers)
 {
-    auto array_ranges = Bitmap::must_create(number_of_registers, false);
+    auto array_ranges = Bitmap::create(number_of_registers, false).release_value_but_fixme_should_propagate_errors();
 
     for (auto it = InstructionStreamIterator(block.instruction_stream()); !it.at_end(); ++it) {
         if ((*it).type() == Instruction::Type::NewArray) {


### PR DESCRIPTION
Instead of having `try_create()` return `ErrorOr`, and `must_create()` asserting, let's have a single `create()` method that returns `ErrorOr`, and move the error-handling to user code.