### PR TITLE
Browser: Introduce action for opening bookmarks in a new window

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -125,7 +125,7 @@ BookmarksBarWidget::BookmarksBarWidget(DeprecatedString const& bookmarks_file, b
     auto default_action = GUI::Action::create(
         "&Open", g_icon_bag.go_to, [this](auto&) {
             if (on_bookmark_click)
-                on_bookmark_click(m_context_menu_url, OpenInNewTab::No);
+                on_bookmark_click(m_context_menu_url, Open::InSameTab);
         },
         this);
     m_context_menu_default_action = default_action;
@@ -133,7 +133,14 @@ BookmarksBarWidget::BookmarksBarWidget(DeprecatedString const& bookmarks_file, b
     m_context_menu->add_action(GUI::Action::create(
         "Open in New &Tab", g_icon_bag.new_tab, [this](auto&) {
             if (on_bookmark_click)
-                on_bookmark_click(m_context_menu_url, OpenInNewTab::Yes);
+                on_bookmark_click(m_context_menu_url, Open::InNewTab);
+        },
+        this));
+    m_context_menu->add_action(GUI::Action::create(
+        "Open in New Window", g_icon_bag.new_window, [this](auto&) {
+            if (on_bookmark_click) {
+                on_bookmark_click(m_context_menu_url, Open::InNewWindow);
+            }
         },
         this));
     m_context_menu->add_separator();
@@ -205,12 +212,12 @@ void BookmarksBarWidget::model_did_update(unsigned)
 
         button.on_click = [title, url, this](auto) {
             if (on_bookmark_click)
-                on_bookmark_click(url, OpenInNewTab::No);
+                on_bookmark_click(url, Open::InSameTab);
         };
 
         button.on_middle_mouse_click = [title, url, this](auto) {
             if (on_bookmark_click)
-                on_bookmark_click(url, OpenInNewTab::Yes);
+                on_bookmark_click(url, Open::InNewTab);
         };
 
         button.on_context_menu_request = [this, url](auto& context_menu_event) {

--- a/Userland/Applications/Browser/BookmarksBarWidget.h
+++ b/Userland/Applications/Browser/BookmarksBarWidget.h
@@ -26,12 +26,13 @@ public:
     GUI::Model* model() { return m_model.ptr(); }
     const GUI::Model* model() const { return m_model.ptr(); }
 
-    enum class OpenInNewTab {
-        Yes,
-        No
+    enum class Open {
+        InNewTab,
+        InSameTab,
+        InNewWindow
     };
 
-    Function<void(DeprecatedString const& url, OpenInNewTab)> on_bookmark_click;
+    Function<void(DeprecatedString const& url, Open)> on_bookmark_click;
     Function<void(DeprecatedString const&, DeprecatedString const&)> on_bookmark_hover;
 
     bool contains_bookmark(DeprecatedString const& url);

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -109,7 +109,7 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
     };
 
     m_window_actions.on_create_new_window = [this] {
-        GUI::Process::spawn_or_show_error(this, "/bin/Browser"sv);
+        create_new_window(g_home_url);
     };
 
     m_window_actions.on_next_tab = [this] {
@@ -583,6 +583,10 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
         });
     };
 
+    new_tab.on_window_open_request = [this](auto& url) {
+        create_new_window(url);
+    };
+
     new_tab.on_get_all_cookies = [this](auto& url) {
         return m_cookie_jar.get_all_cookies(url);
     };
@@ -629,6 +633,11 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
 
     if (activate)
         m_tab_widget->set_active_widget(&new_tab);
+}
+
+void BrowserWindow::create_new_window(URL url)
+{
+    GUI::Process::spawn_or_show_error(this, "/bin/Browser"sv, Array { url.to_deprecated_string() });
 }
 
 void BrowserWindow::content_filters_changed()

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -29,6 +29,7 @@ public:
     GUI::TabWidget& tab_widget();
     Tab& active_tab();
     void create_new_tab(URL, bool activate);
+    void create_new_window(URL);
 
     GUI::Action& go_back_action() { return *m_go_back_action; }
     GUI::Action& go_forward_action() { return *m_go_forward_action; }

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -580,9 +580,11 @@ void Tab::update_bookmark_button(DeprecatedString const& url)
 
 void Tab::did_become_active()
 {
-    BookmarksBarWidget::the().on_bookmark_click = [this](auto& url, auto open_in_new_tab) {
-        if (open_in_new_tab == BookmarksBarWidget::OpenInNewTab::Yes)
+    BookmarksBarWidget::the().on_bookmark_click = [this](auto& url, auto open) {
+        if (open == BookmarksBarWidget::Open::InNewTab)
             on_tab_open_request(url);
+        else if (open == BookmarksBarWidget::Open::InNewWindow)
+            on_window_open_request(url);
         else
             load(url);
     };

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -63,6 +63,7 @@ public:
     Function<void(const URL&)> on_tab_open_request;
     Function<void(Tab&)> on_tab_close_request;
     Function<void(Tab&)> on_tab_close_other_request;
+    Function<void(const URL&)> on_window_open_request;
     Function<void(Gfx::Bitmap const&)> on_favicon_change;
     Function<Vector<Web::Cookie::Cookie>(AK::URL const& url)> on_get_all_cookies;
     Function<Optional<Web::Cookie::Cookie>(AK::URL const& url, DeprecatedString const& name)> on_get_named_cookie;


### PR DESCRIPTION
This change introduces an action to bookmarks that allows them to be opened in a new browser window. This is done by accessing any bookmark's context menu and pressing "Open in New Window".

![Screenshot 2022-12-20 234044](https://user-images.githubusercontent.com/60799661/208848276-6cc957a6-5fcc-41a8-b6b7-885d929f4598.png)
