### PR TITLE
pro: Add Basic Auth support

### DIFF
--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -173,7 +173,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         .help_string = "Add a header entry to the request",
         .long_name = "header",
         .short_name = 'H',
-        .value_name = "header-value",
+        .value_name = "key:value",
         .accept_value = [&](auto* s) {
             StringView header { s, strlen(s) };
             auto split = header.find(':');

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -246,11 +246,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto output_stream = ConditionalOutputFileStream { [&] { return should_save_stream_data; }, stdout };
 
     // https://httpwg.org/specs/rfc9110.html#authentication
-    if (!credentials.is_empty() && is_http_url) {
+    auto const has_credentials = !credentials.is_empty();
+    auto const has_manual_authorization_header = request_headers.contains("Authorization");
+    if (is_http_url && has_credentials && !has_manual_authorization_header) {
         // 11.2. Authentication Parameters
         // The authentication scheme is followed by additional information necessary for achieving authentication via
         // that scheme as (...) or a single sequence of characters capable of holding base64-encoded information.
-        // FIXME: Prevent overriding manually provided Authorization header
         auto const encoded_credentials = TRY(encode_base64(credentials.bytes()));
         auto const authorization = TRY(String::formatted("Basic {}", encoded_credentials));
         request_headers.set("Authorization", authorization.to_deprecated_string());

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -255,6 +255,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto const encoded_credentials = TRY(encode_base64(credentials.bytes()));
         auto const authorization = TRY(String::formatted("Basic {}", encoded_credentials));
         request_headers.set("Authorization", authorization.to_deprecated_string());
+    } else {
+        if (is_http_url && has_credentials && has_manual_authorization_header)
+            warnln("* Skipping encoding provided authorization, manual header present.");
+        if (!is_http_url && has_credentials)
+            warnln("* Skipping adding Authorization header, request was not for the HTTP protocol.");
     }
 
     Function<void()> setup_request = [&] {


### PR DESCRIPTION
This PR adds Basic Auth support via `-u` or `--auth` parameter, so that we can actually use it with Serenity's own WebServer :^)

**Teaser:**
<img width="608" alt="Screenshot 2022-12-21 at 17 35 51" src="https://user-images.githubusercontent.com/3741709/208957549-53545090-c539-4039-a52f-158f24755392.png">

Syntax is, as with the last PR, very cURL inspired.