### PR TITLE
Ports: Use absolute path of script

### DIFF
--- a/Ports/.hosted_defs.sh
+++ b/Ports/.hosted_defs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SCRIPT="$(dirname "${0}")"
+SCRIPT="$(realpath $(dirname "${BASH_SOURCE[0]}"))"
 
 export SERENITY_ARCH="${SERENITY_ARCH:-x86_64}"
 export SERENITY_TOOLCHAIN="${SERENITY_TOOLCHAIN:-GNU}"

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-SCRIPT="$(dirname "${0}")"
+SCRIPT="$(realpath $(dirname "${0}"))"
 
 if [ -z "${SERENITY_STRIPPED_ENV:-}" ]; then
     exec "${SCRIPT}/.strip_env.sh" "${@}"


### PR DESCRIPTION
The relative path returned by dirname cannot be used to source `.hosted_defs.sh` when inside a ports build directory, preventing `target_env` from working.
