### PR TITLE
Kernel: Make Device::after_inserting to return ErrorOr<void>

### DIFF
--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -32,13 +32,14 @@ void Device::after_inserting_add_to_device_management()
     DeviceManagement::the().after_inserting_device({}, *this);
 }
 
-void Device::after_inserting()
+ErrorOr<void> Device::after_inserting()
 {
     after_inserting_add_to_device_management();
     VERIFY(!m_sysfs_component);
     auto sys_fs_component = SysFSDeviceComponent::must_create(*this);
     m_sysfs_component = sys_fs_component;
     after_inserting_add_to_device_identifier_directory();
+    return {};
 }
 
 void Device::will_be_destroyed()

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -50,7 +50,7 @@ public:
 
     virtual bool is_device() const override { return true; }
     virtual void will_be_destroyed() override;
-    virtual void after_inserting();
+    virtual ErrorOr<void> after_inserting();
     virtual bool is_openable_by_jailed_processes() const { return false; }
     void process_next_queued_request(Badge<AsyncDeviceRequest>, AsyncDeviceRequest const&);
 

--- a/Kernel/Devices/DeviceManagement.h
+++ b/Kernel/Devices/DeviceManagement.h
@@ -58,7 +58,7 @@ public:
     requires(requires(Args... args) { DeviceType::try_create(args...); })
     {
         auto device = TRY(DeviceType::try_create(forward<Args>(args)...));
-        device->after_inserting();
+        TRY(device->after_inserting());
         return device;
     }
 
@@ -66,7 +66,7 @@ public:
     static inline ErrorOr<NonnullLockRefPtr<DeviceType>> try_create_device(Args&&... args)
     {
         auto device = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) DeviceType(forward<Args>(args)...)));
-        device->after_inserting();
+        TRY(device->after_inserting());
         return device;
     }
 

--- a/Kernel/Graphics/DisplayConnector.h
+++ b/Kernel/Graphics/DisplayConnector.h
@@ -148,6 +148,8 @@ private:
     virtual void will_be_destroyed() override;
     virtual ErrorOr<void> after_inserting() override;
 
+    ErrorOr<void> allocate_framebuffer_resources(size_t rounded_size);
+
     ErrorOr<bool> ioctl_requires_ownership(unsigned request) const;
 
     OwnPtr<Memory::Region> m_framebuffer_region;
@@ -159,7 +161,7 @@ private:
 
 protected:
     Optional<PhysicalAddress> const m_framebuffer_address;
-    size_t const m_framebuffer_resource_size;
+    size_t m_framebuffer_resource_size;
 
 private:
     LockRefPtr<Memory::SharedFramebufferVMObject> m_shared_framebuffer_vmobject;

--- a/Kernel/Graphics/DisplayConnector.h
+++ b/Kernel/Graphics/DisplayConnector.h
@@ -146,7 +146,7 @@ private:
     DisplayConnector(DisplayConnector&&) = delete;
 
     virtual void will_be_destroyed() override;
-    virtual void after_inserting() override;
+    virtual ErrorOr<void> after_inserting() override;
 
     ErrorOr<bool> ioctl_requires_ownership(unsigned request) const;
 

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -37,23 +37,27 @@ StorageDevice::StorageDevice(Badge<RamdiskDevice>, LUNAddress logical_unit_numbe
 {
 }
 
-void StorageDevice::after_inserting()
+ErrorOr<void> StorageDevice::after_inserting()
 {
     after_inserting_add_to_device_management();
     auto sysfs_storage_device_directory = StorageDeviceSysFSDirectory::create(SysFSStorageDirectory::the(), *this);
     m_sysfs_device_directory = sysfs_storage_device_directory;
     SysFSStorageDirectory::the().plug({}, *sysfs_storage_device_directory);
     VERIFY(!m_symlink_sysfs_component);
-    auto sys_fs_component = MUST(SysFSSymbolicLinkDeviceComponent::try_create(SysFSBlockDevicesDirectory::the(), *this, *m_sysfs_device_directory));
+    auto sys_fs_component = TRY(SysFSSymbolicLinkDeviceComponent::try_create(SysFSBlockDevicesDirectory::the(), *this, *m_sysfs_device_directory));
     m_symlink_sysfs_component = sys_fs_component;
     after_inserting_add_symlink_to_device_identifier_directory();
+    return {};
 }
 
 void StorageDevice::will_be_destroyed()
 {
-    VERIFY(m_symlink_sysfs_component);
-    before_will_be_destroyed_remove_symlink_from_device_identifier_directory();
-    m_symlink_sysfs_component.clear();
+    // NOTE: We check if m_symlink_sysfs_component is not null, because if we failed
+    // in StorageDevice::after_inserting(), then that method will not set m_symlink_sysfs_component.
+    if (m_symlink_sysfs_component) {
+        before_will_be_destroyed_remove_symlink_from_device_identifier_directory();
+        m_symlink_sysfs_component.clear();
+    }
     SysFSStorageDirectory::the().unplug({}, *m_sysfs_device_directory);
     before_will_be_destroyed_remove_from_device_management();
 }

--- a/Kernel/Storage/StorageDevice.h
+++ b/Kernel/Storage/StorageDevice.h
@@ -88,7 +88,7 @@ protected:
     virtual StringView class_name() const override;
 
 private:
-    virtual void after_inserting() override;
+    virtual ErrorOr<void> after_inserting() override;
     virtual void will_be_destroyed() override;
 
     mutable IntrusiveListNode<StorageDevice, LockRefPtr<StorageDevice>> m_list_node;

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -22,8 +22,8 @@ ErrorOr<NonnullLockRefPtr<MasterPTY>> MasterPTY::try_create(unsigned int index)
     auto master_pty = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) MasterPTY(index, move(buffer))));
     auto slave_pty = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) SlavePTY(*master_pty, index)));
     master_pty->m_slave = slave_pty;
-    master_pty->after_inserting();
-    slave_pty->after_inserting();
+    TRY(master_pty->after_inserting());
+    TRY(slave_pty->after_inserting());
     return master_pty;
 }
 

--- a/Kernel/TTY/PTYMultiplexer.cpp
+++ b/Kernel/TTY/PTYMultiplexer.cpp
@@ -35,7 +35,7 @@ UNMAP_AFTER_INIT PTYMultiplexer::~PTYMultiplexer() = default;
 
 UNMAP_AFTER_INIT void PTYMultiplexer::initialize()
 {
-    the().after_inserting();
+    MUST(the().after_inserting());
 }
 
 ErrorOr<NonnullLockRefPtr<OpenFileDescription>> PTYMultiplexer::open(int options)


### PR DESCRIPTION
Instead of just returning nothing, let's return Error or nothing. This makes us more paranoid about failure in this method, so when initializing a DisplayConnector, we try our best to ensure it succeeds, and if not we safely tear down the internal members of the object.

Because we try our best to ensure a DisplayConnector initialization succeeds, this makes the Intel driver to work again, because if we can't allocate a Region for the whole PCI BAR mapped region, then we will try to allocate a Region with 16 MiB window size, so it doesn't eat the entire Kernel-allocated virtual memory space.

This restores the Intel video driver functionality as well to make things much more sane in terms of stability :)