### PR TITLE
LibGUI: Propagate errors from the UndoStack

### DIFF
--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -9,6 +9,7 @@
 #include "GlyphEditorWidget.h"
 #include "NewFontDialog.h"
 #include <AK/Array.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringUtils.h>
 #include <Applications/FontEditor/FontEditorWindowGML.h>
@@ -816,7 +817,11 @@ void MainWidget::undo()
 {
     if (!m_undo_stack->can_undo())
         return;
-    m_undo_stack->undo();
+    auto undo_or_error = m_undo_stack->undo();
+    if (undo_or_error.is_error()) {
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Error while undoing: {}", undo_or_error.error())));
+        return;
+    }
 
     auto glyph = m_undo_selection->restored_active_glyph();
     auto glyph_width = edited_font().raw_glyph_width(glyph);
@@ -846,7 +851,11 @@ void MainWidget::redo()
 {
     if (!m_undo_stack->can_redo())
         return;
-    m_undo_stack->redo();
+    auto redo_or_error = m_undo_stack->redo();
+    if (redo_or_error.is_error()) {
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Error while redoing: {}", redo_or_error.error())));
+        return;
+    }
 
     auto glyph = m_undo_selection->restored_active_glyph();
     auto glyph_width = edited_font().raw_glyph_width(glyph);

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -181,16 +181,20 @@ HexDocumentUndoCommand::HexDocumentUndoCommand(WeakPtr<HexDocument> document, si
 {
 }
 
-void HexDocumentUndoCommand::undo()
+ErrorOr<void> HexDocumentUndoCommand::undo()
 {
     for (size_t i = 0; i < m_old.size(); i++)
         m_document->set(m_position + i, m_old[i]);
+
+    return {};
 }
 
-void HexDocumentUndoCommand::redo()
+ErrorOr<void> HexDocumentUndoCommand::redo()
 {
     for (size_t i = 0; i < m_new.size(); i++)
         m_document->set(m_position + i, m_new[i]);
+
+    return {};
 }
 
 bool HexDocumentUndoCommand::merge_with(GUI::Command const& other)

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -87,8 +87,8 @@ class HexDocumentUndoCommand : public GUI::Command {
 public:
     HexDocumentUndoCommand(WeakPtr<HexDocument> document, size_t position);
 
-    virtual void undo() override;
-    virtual void redo() override;
+    virtual ErrorOr<void> undo() override;
+    virtual ErrorOr<void> redo() override;
     virtual DeprecatedString action_text() const override { return "Update cell"; }
 
     virtual bool merge_with(GUI::Command const& other) override;

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -13,6 +13,7 @@
 #include <AK/DeprecatedString.h>
 #include <AK/Format.h>
 #include <AK/ScopeGuard.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Clipboard.h>
@@ -880,7 +881,12 @@ bool HexEditor::undo()
     if (!m_undo_stack.can_undo())
         return false;
 
-    m_undo_stack.undo();
+    auto undo_or_error = m_undo_stack.undo();
+    if (undo_or_error.is_error()) {
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Error while undoing: {}", undo_or_error.error())));
+        return false;
+    }
+
     reset_cursor_blink_state();
     update();
     update_status();
@@ -893,7 +899,12 @@ bool HexEditor::redo()
     if (!m_undo_stack.can_redo())
         return false;
 
-    m_undo_stack.redo();
+    auto redo_or_error = m_undo_stack.redo();
+    if (redo_or_error.is_error()) {
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Error while redoing: {}", redo_or_error.error())));
+        return false;
+    }
+
     reset_cursor_blink_state();
     update();
     update_status();

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -481,15 +481,14 @@ ImageUndoCommand::ImageUndoCommand(Image& image, DeprecatedString action_text)
 {
 }
 
-void ImageUndoCommand::undo()
+ErrorOr<void> ImageUndoCommand::undo()
 {
-    // FIXME: Handle errors.
-    (void)m_image.restore_snapshot(*m_snapshot);
+    return m_image.restore_snapshot(*m_snapshot);
 }
 
-void ImageUndoCommand::redo()
+ErrorOr<void> ImageUndoCommand::redo()
 {
-    undo();
+    return undo();
 }
 
 void Image::flip(Gfx::Orientation orientation)

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -125,8 +125,8 @@ class ImageUndoCommand : public GUI::Command {
 public:
     ImageUndoCommand(Image&, DeprecatedString action_text);
 
-    virtual void undo() override;
-    virtual void redo() override;
+    virtual ErrorOr<void> undo() override;
+    virtual ErrorOr<void> redo() override;
     virtual DeprecatedString action_text() const override { return m_action_text; }
 
 private:

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -207,18 +207,22 @@ CellsUndoCommand::CellsUndoCommand(Cell& cell, DeprecatedString const& previous_
     m_cell_changes.append(CellChange(cell, previous_data));
 }
 
-void CellsUndoCommand::undo()
+ErrorOr<void> CellsUndoCommand::undo()
 {
     for (size_t i = 0; i < m_cell_changes.size(); ++i) {
         m_cell_changes[i].cell().set_data(m_cell_changes[i].previous_data());
     }
+
+    return {};
 }
 
-void CellsUndoCommand::redo()
+ErrorOr<void> CellsUndoCommand::redo()
 {
     for (size_t i = 0; i < m_cell_changes.size(); ++i) {
         m_cell_changes[i].cell().set_data(m_cell_changes[i].new_data());
     }
+
+    return {};
 }
 
 }

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.h
@@ -51,8 +51,8 @@ public:
     CellsUndoCommand(Cell&, DeprecatedString const&);
     CellsUndoCommand(Vector<CellChange>);
 
-    virtual void undo() override;
-    virtual void redo() override;
+    virtual ErrorOr<void> undo() override;
+    virtual ErrorOr<void> redo() override;
 
 private:
     Vector<CellChange> m_cell_changes;

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -8,6 +8,7 @@
 #include "CellSyntaxHighlighter.h"
 #include "HelpWindow.h"
 #include "LibFileSystemAccessClient/Client.h"
+#include <AK/String.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -465,7 +466,12 @@ void SpreadsheetWidget::undo()
     if (!m_undo_stack.can_undo())
         return;
 
-    m_undo_stack.undo();
+    auto undo_or_error = m_undo_stack.undo();
+    if (undo_or_error.is_error()) {
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Error while undoing: {}", undo_or_error.error())));
+        return;
+    }
+
     update();
 }
 
@@ -474,7 +480,12 @@ void SpreadsheetWidget::redo()
     if (!m_undo_stack.can_redo())
         return;
 
-    m_undo_stack.redo();
+    auto redo_or_error = m_undo_stack.redo();
+    if (redo_or_error.is_error()) {
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Error while redoing: {}", redo_or_error.error())));
+        return;
+    }
+
     update();
 }
 

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/String.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
@@ -129,7 +130,11 @@ MainWidget::MainWidget()
         auto editor = dynamic_cast<ScriptEditor*>(m_tab_widget->active_widget());
         if (!editor)
             return;
-        editor->document().undo();
+        auto document_undo_or_error = editor->document().undo();
+        if (document_undo_or_error.is_error()) {
+            GUI::MessageBox::show_error(window(), MUST(String::formatted("Error while undoing: {}", document_undo_or_error.error())));
+            return;
+        }
         update_editor_actions(editor);
     });
 
@@ -139,7 +144,11 @@ MainWidget::MainWidget()
         auto editor = dynamic_cast<ScriptEditor*>(m_tab_widget->active_widget());
         if (!editor)
             return;
-        editor->document().redo();
+        auto document_redo_or_error = editor->document().redo();
+        if (document_redo_or_error.is_error()) {
+            GUI::MessageBox::show_error(window(), MUST(String::formatted("Error while redoing: {}", document_redo_or_error.error())));
+            return;
+        }
         update_editor_actions(editor);
     });
 

--- a/Userland/Libraries/LibGUI/Command.h
+++ b/Userland/Libraries/LibGUI/Command.h
@@ -15,8 +15,8 @@ class Command {
 public:
     virtual ~Command() = default;
 
-    virtual void undo() { }
-    virtual void redo() { }
+    virtual ErrorOr<void> undo() { return {}; };
+    virtual ErrorOr<void> redo() { return {}; };
 
     virtual DeprecatedString action_text() const { return {}; }
     virtual bool merge_with(Command const&) { return false; }

--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -438,14 +438,18 @@ MoveLineUpOrDownCommand::MoveLineUpOrDownCommand(TextDocument& document, KeyEven
 {
 }
 
-void MoveLineUpOrDownCommand::redo()
+ErrorOr<void> MoveLineUpOrDownCommand::redo()
 {
     move_lines(m_direction);
+
+    return {};
 }
 
-void MoveLineUpOrDownCommand::undo()
+ErrorOr<void> MoveLineUpOrDownCommand::undo()
 {
     move_lines(!m_direction);
+
+    return {};
 }
 
 bool MoveLineUpOrDownCommand::merge_with(GUI::Command const&)

--- a/Userland/Libraries/LibGUI/EditingEngine.h
+++ b/Userland/Libraries/LibGUI/EditingEngine.h
@@ -89,8 +89,8 @@ protected:
 class MoveLineUpOrDownCommand : public TextDocumentUndoCommand {
 public:
     MoveLineUpOrDownCommand(TextDocument&, KeyEvent event, EditingEngine&);
-    virtual void undo() override;
-    virtual void redo() override;
+    virtual ErrorOr<void> undo() override;
+    virtual ErrorOr<void> redo() override;
     bool merge_with(GUI::Command const&) override;
     DeprecatedString action_text() const override;
 

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -118,8 +118,8 @@ public:
 
     bool can_undo() const { return m_undo_stack.can_undo(); }
     bool can_redo() const { return m_undo_stack.can_redo(); }
-    void undo();
-    void redo();
+    ErrorOr<void> undo();
+    ErrorOr<void> redo();
 
     UndoStack const& undo_stack() const { return m_undo_stack; }
 
@@ -199,11 +199,13 @@ public:
     virtual ~TextDocumentUndoCommand() = default;
     virtual void perform_formatting(TextDocument::Client const&) { }
 
-    void execute_from(TextDocument::Client const& client)
+    ErrorOr<void> execute_from(TextDocument::Client const& client)
     {
         m_client = &client;
-        redo();
+        TRY(redo());
         m_client = nullptr;
+
+        return {};
     }
 
 protected:
@@ -219,8 +221,8 @@ public:
     InsertTextCommand(TextDocument&, DeprecatedString const&, TextPosition const&);
     virtual ~InsertTextCommand() = default;
     virtual void perform_formatting(TextDocument::Client const&) override;
-    virtual void undo() override;
-    virtual void redo() override;
+    virtual ErrorOr<void> undo() override;
+    virtual ErrorOr<void> redo() override;
     virtual bool merge_with(GUI::Command const&) override;
     virtual DeprecatedString action_text() const override;
     DeprecatedString const& text() const { return m_text; }
@@ -235,8 +237,8 @@ class RemoveTextCommand : public TextDocumentUndoCommand {
 public:
     RemoveTextCommand(TextDocument&, DeprecatedString const&, TextRange const&);
     virtual ~RemoveTextCommand() = default;
-    virtual void undo() override;
-    virtual void redo() override;
+    virtual ErrorOr<void> undo() override;
+    virtual ErrorOr<void> redo() override;
     TextRange const& range() const { return m_range; }
     virtual bool merge_with(GUI::Command const&) override;
     virtual DeprecatedString action_text() const override;
@@ -255,8 +257,8 @@ public:
 
     InsertLineCommand(TextDocument&, TextPosition, DeprecatedString&&, InsertPosition);
     virtual ~InsertLineCommand() = default;
-    virtual void undo() override;
-    virtual void redo() override;
+    virtual ErrorOr<void> undo() override;
+    virtual ErrorOr<void> redo() override;
     virtual DeprecatedString action_text() const override;
 
 private:
@@ -272,8 +274,8 @@ class ReplaceAllTextCommand final : public GUI::TextDocumentUndoCommand {
 public:
     ReplaceAllTextCommand(GUI::TextDocument& document, DeprecatedString const& text, GUI::TextRange const& range, DeprecatedString const& action_text);
     virtual ~ReplaceAllTextCommand() = default;
-    void redo() override;
-    void undo() override;
+    ErrorOr<void> redo() override;
+    ErrorOr<void> undo() override;
     bool merge_with(GUI::Command const&) override;
     DeprecatedString action_text() const override;
     DeprecatedString const& text() const { return m_text; }
@@ -288,8 +290,8 @@ private:
 class IndentSelection : public TextDocumentUndoCommand {
 public:
     IndentSelection(TextDocument&, size_t tab_width, TextRange const&);
-    virtual void undo() override;
-    virtual void redo() override;
+    virtual ErrorOr<void> undo() override;
+    virtual ErrorOr<void> redo() override;
     TextRange const& range() const { return m_range; }
 
 private:
@@ -300,8 +302,8 @@ private:
 class UnindentSelection : public TextDocumentUndoCommand {
 public:
     UnindentSelection(TextDocument&, size_t tab_width, TextRange const&);
-    virtual void undo() override;
-    virtual void redo() override;
+    virtual ErrorOr<void> undo() override;
+    virtual ErrorOr<void> redo() override;
     TextRange const& range() const { return m_range; }
 
 private:
@@ -312,8 +314,8 @@ private:
 class CommentSelection : public TextDocumentUndoCommand {
 public:
     CommentSelection(TextDocument&, StringView, StringView, TextRange const&);
-    virtual void undo() override;
-    virtual void redo() override;
+    virtual ErrorOr<void> undo() override;
+    virtual ErrorOr<void> redo() override;
     TextRange const& range() const { return m_range; }
 
 private:
@@ -325,8 +327,8 @@ private:
 class UncommentSelection : public TextDocumentUndoCommand {
 public:
     UncommentSelection(TextDocument&, StringView, StringView, TextRange const&);
-    virtual void undo() override;
-    virtual void redo() override;
+    virtual ErrorOr<void> undo() override;
+    virtual ErrorOr<void> redo() override;
     TextRange const& range() const { return m_range; }
 
 private:

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -9,6 +9,7 @@
 #include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
 #include <AK/ScopeGuard.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/TemporaryChange.h>
 #include <LibCore/File.h>
@@ -21,6 +22,7 @@
 #include <LibGUI/IncrementalSearchBanner.h>
 #include <LibGUI/InputBox.h>
 #include <LibGUI/Menu.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/RegularEditingEngine.h>
 #include <LibGUI/Scrollbar.h>
@@ -2299,13 +2301,21 @@ void TextEditor::set_cursor_line_highlighting(bool highlighted)
 void TextEditor::undo()
 {
     clear_selection();
-    document().undo();
+    auto document_undo_or_error = document().undo();
+    if (document_undo_or_error.is_error()) {
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Error while undoing: {}", document_undo_or_error.error())));
+        return;
+    }
 }
 
 void TextEditor::redo()
 {
     clear_selection();
-    document().redo();
+    auto document_redo_or_error = document().redo();
+    if (document_redo_or_error.is_error()) {
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Error while redoing: {}", document_redo_or_error.error())));
+        return;
+    }
 }
 
 void TextEditor::set_text_is_secret(bool text_is_secret)

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -362,7 +362,7 @@ private:
         auto command = make<T>(*m_document, forward<Args>(args)...);
         command->perform_formatting(*this);
         will_execute(*command);
-        command->execute_from(*this);
+        command->execute_from(*this).release_value_but_fixme_should_propagate_errors();
         m_document->add_to_undo_stack(move(command));
     }
 

--- a/Userland/Libraries/LibGUI/UndoStack.h
+++ b/Userland/Libraries/LibGUI/UndoStack.h
@@ -25,8 +25,8 @@ public:
     bool can_undo() const;
     bool can_redo() const;
 
-    void undo();
-    void redo();
+    ErrorOr<void> undo();
+    ErrorOr<void> redo();
 
     void set_current_unmodified();
     bool is_current_modified() const;


### PR DESCRIPTION
* LibGUI+Userland: Propagate errors in GUI::*::{undo,redo}()
* PixelPaint: Refactor Image::restore_snapshot() for error handling

This removes a single FIXME :^)