### PR TITLE
AK: Rearrange Error's members to reduce its size by 8 bytes

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -68,14 +68,14 @@ private:
     }
 
     Error(StringView syscall_name, int rc)
-        : m_code(-rc)
-        , m_string_literal(syscall_name)
+        : m_string_literal(syscall_name)
+        , m_code(-rc)
         , m_syscall(true)
     {
     }
 
-    int m_code { 0 };
     StringView m_string_literal;
+    int m_code { 0 };
     bool m_syscall { false };
 };
 


### PR DESCRIPTION
This shrinks `sizeof(Error)` from 32 bytes to 24 bytes, which in turn will shrink `sizeof(ErrorOr<T>)` by the same amount (in cases where `sizeof(T)` is less than `sizeof(Error)`).