### PR TITLE
Base: Unquote the timestamp in a quote

### DIFF
--- a/Base/res/fortunes.json
+++ b/Base/res/fortunes.json
@@ -100,7 +100,7 @@
   {
     "quote": "Changelog: All boogs fixed, thar be no moar boogs",
     "author": "CxByte",
-    "utc_time": "1627859603",
+    "utc_time": 1627859603,
     "url": "https://github.com/SerenityOS/serenity/pull/9127#issuecomment-890603297"
   },
   {


### PR DESCRIPTION
`fortune` was failing to read this and treating the timestamp as 0.

The irony in this being a quote about the absence of boogs is not lost on me. :^)