### PR TITLE
AK+Everywhere: Return `Optional` from `JsonObject::get()` methods

### DIFF
--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -47,26 +47,6 @@ bool JsonObject::is_empty() const
     return m_members.is_empty();
 }
 
-JsonValue const& JsonObject::get_deprecated(StringView key) const
-{
-    auto const* value = get_ptr(key);
-    static JsonValue* s_null_value { nullptr };
-    if (!value) {
-        if (!s_null_value)
-            s_null_value = new JsonValue;
-        return *s_null_value;
-    }
-    return *value;
-}
-
-JsonValue const* JsonObject::get_ptr(StringView key) const
-{
-    auto it = m_members.find(key);
-    if (it == m_members.end())
-        return nullptr;
-    return &(*it).value;
-}
-
 Optional<JsonValue const&> JsonObject::get(StringView key) const
 {
     auto it = m_members.find(key);

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -35,10 +35,6 @@ public:
     [[nodiscard]] size_t size() const;
     [[nodiscard]] bool is_empty() const;
 
-    [[nodiscard]] JsonValue const& get_deprecated(StringView key) const;
-
-    [[nodiscard]] JsonValue const* get_ptr(StringView key) const;
-
     [[nodiscard]] bool has(StringView key) const;
 
     [[nodiscard]] bool has_null(StringView key) const;

--- a/Userland/Utilities/arp.cpp
+++ b/Userland/Utilities/arp.cpp
@@ -95,13 +95,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         Vector<JsonValue> sorted_regions = json.as_array().values();
         quick_sort(sorted_regions, [](auto& a, auto& b) {
-            return a.as_object().get_deprecated("ip_address"sv).to_deprecated_string() < b.as_object().get_deprecated("ip_address"sv).to_deprecated_string();
+            return a.as_object().get_deprecated_string("ip_address"sv).value_or({}) < b.as_object().get_deprecated_string("ip_address"sv).value_or({});
         });
 
         for (auto& value : sorted_regions) {
             auto& if_object = value.as_object();
 
-            auto ip_address = if_object.get_deprecated("ip_address"sv).to_deprecated_string();
+            auto ip_address = if_object.get_deprecated_string("ip_address"sv).value_or({});
 
             if (!flag_numeric) {
                 auto from_string = IPv4Address::from_string(ip_address);
@@ -114,7 +114,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto mac_address = if_object.get_deprecated("mac_address"sv).to_deprecated_string();
+            auto mac_address = if_object.get_deprecated_string("mac_address"sv).value_or({});
 
             if (proto_address_column != -1)
                 columns[proto_address_column].buffer = ip_address;

--- a/Userland/Utilities/df.cpp
+++ b/Userland/Utilities/df.cpp
@@ -62,15 +62,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto const& json = json_result.as_array();
     json.for_each([&](auto& value) {
         auto& fs_object = value.as_object();
-        auto fs = fs_object.get_deprecated("class_name"sv).to_deprecated_string();
-        auto total_block_count = fs_object.get_deprecated("total_block_count"sv).to_u64();
-        auto free_block_count = fs_object.get_deprecated("free_block_count"sv).to_u64();
+        auto fs = fs_object.get_deprecated_string("class_name"sv).value_or({});
+        auto total_block_count = fs_object.get_u64("total_block_count"sv).value_or(0);
+        auto free_block_count = fs_object.get_u64("free_block_count"sv).value_or(0);
         auto used_block_count = total_block_count - free_block_count;
-        auto total_inode_count = fs_object.get_deprecated("total_inode_count"sv).to_u64();
-        auto free_inode_count = fs_object.get_deprecated("free_inode_count"sv).to_u64();
+        auto total_inode_count = fs_object.get_u64("total_inode_count"sv).value_or(0);
+        auto free_inode_count = fs_object.get_u64("free_inode_count"sv).value_or(0);
         auto used_inode_count = total_inode_count - free_inode_count;
-        auto block_size = fs_object.get_deprecated("block_size"sv).to_u64();
-        auto mount_point = fs_object.get_deprecated("mount_point"sv).to_deprecated_string();
+        auto block_size = fs_object.get_u64("block_size"sv).value_or(0);
+        auto mount_point = fs_object.get_deprecated_string("mount_point"sv).value_or({});
 
         auto used_percentage = 100;
         if (total_block_count != 0)

--- a/Userland/Utilities/fortune.cpp
+++ b/Userland/Utilities/fortune.cpp
@@ -27,16 +27,15 @@ public:
             return {};
         auto& entry = value.as_object();
         Quote q;
-        if (!entry.has("quote"sv) || !entry.has("author"sv) || !entry.has("utc_time"sv) || !entry.has("url"sv))
+        if (!entry.has_string("quote"sv) || !entry.has_string("author"sv) || !entry.has_u64("utc_time"sv) || !entry.has_string("url"sv))
             return {};
         // From here on, trust that it's probably fine.
-        q.m_quote = entry.get_deprecated("quote"sv).as_string();
-        q.m_author = entry.get_deprecated("author"sv).as_string();
-        // It is sometimes parsed as u32, sometimes as u64, depending on how large the number is.
-        q.m_utc_time = entry.get_deprecated("utc_time"sv).to_number<u64>();
-        q.m_url = entry.get_deprecated("url"sv).as_string();
+        q.m_quote = entry.get_deprecated_string("quote"sv).value();
+        q.m_author = entry.get_deprecated_string("author"sv).value();
+        q.m_utc_time = entry.get_u64("utc_time"sv).value();
+        q.m_url = entry.get_deprecated_string("url"sv).value();
         if (entry.has("context"sv))
-            q.m_context = entry.get_deprecated("context"sv).as_string();
+            q.m_context = entry.get_deprecated_string("context"sv).value();
 
         return q;
     }

--- a/Userland/Utilities/ifconfig.cpp
+++ b/Userland/Utilities/ifconfig.cpp
@@ -38,16 +38,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         json.as_array().for_each([](auto& value) {
             auto& if_object = value.as_object();
 
-            auto name = if_object.get_deprecated("name"sv).to_deprecated_string();
-            auto class_name = if_object.get_deprecated("class_name"sv).to_deprecated_string();
-            auto mac_address = if_object.get_deprecated("mac_address"sv).to_deprecated_string();
-            auto ipv4_address = if_object.get_deprecated("ipv4_address"sv).to_deprecated_string();
-            auto netmask = if_object.get_deprecated("ipv4_netmask"sv).to_deprecated_string();
-            auto packets_in = if_object.get_deprecated("packets_in"sv).to_u32();
-            auto bytes_in = if_object.get_deprecated("bytes_in"sv).to_u32();
-            auto packets_out = if_object.get_deprecated("packets_out"sv).to_u32();
-            auto bytes_out = if_object.get_deprecated("bytes_out"sv).to_u32();
-            auto mtu = if_object.get_deprecated("mtu"sv).to_u32();
+            auto name = if_object.get_deprecated_string("name"sv).value_or({});
+            auto class_name = if_object.get_deprecated_string("class_name"sv).value_or({});
+            auto mac_address = if_object.get_deprecated_string("mac_address"sv).value_or({});
+            auto ipv4_address = if_object.get_deprecated_string("ipv4_address"sv).value_or({});
+            auto netmask = if_object.get_deprecated_string("ipv4_netmask"sv).value_or({});
+            auto packets_in = if_object.get_u32("packets_in"sv).value_or(0);
+            auto bytes_in = if_object.get_u32("bytes_in"sv).value_or(0);
+            auto packets_out = if_object.get_u32("packets_out"sv).value_or(0);
+            auto bytes_out = if_object.get_u32("bytes_out"sv).value_or(0);
+            auto mtu = if_object.get_u32("mtu"sv).value_or(0);
 
             outln("{}:", name);
             outln("\tmac: {}", mac_address);

--- a/Userland/Utilities/json.cpp
+++ b/Userland/Utilities/json.cpp
@@ -139,7 +139,7 @@ JsonValue query(JsonValue const& value, Vector<StringView>& key_parts, size_t ke
 
     JsonValue result {};
     if (value.is_object()) {
-        result = value.as_object().get_deprecated(key);
+        result = value.as_object().get(key).value_or({});
     } else if (value.is_array()) {
         auto key_as_index = key.to_int();
         if (key_as_index.has_value())

--- a/Userland/Utilities/lscpu.cpp
+++ b/Userland/Utilities/lscpu.cpp
@@ -16,35 +16,35 @@
 static void print_cache_info(StringView description, JsonObject const& cache_object)
 {
     outln("\t{}:", description);
-    outln("\t\tSize: {}", human_readable_size(cache_object.get_deprecated("size"sv).as_u32()));
-    outln("\t\tLine size: {}", human_readable_size(cache_object.get_deprecated("line_size"sv).as_u32()));
+    outln("\t\tSize: {}", human_readable_size(cache_object.get_u32("size"sv).value()));
+    outln("\t\tLine size: {}", human_readable_size(cache_object.get_u32("line_size"sv).value()));
 };
 
 static void print_cpu_info(JsonObject const& value)
 {
-    outln("CPU {}:", value.get_deprecated("processor"sv).as_u32());
-    outln("\tVendor ID: {}", value.get_deprecated("vendor_id"sv).as_string());
+    outln("CPU {}:", value.get_u32("processor"sv).value());
+    outln("\tVendor ID: {}", value.get_deprecated_string("vendor_id"sv).value());
     if (value.has("hypervisor_vendor_id"sv))
-        outln("\tHypervisor Vendor ID: {}", value.get_deprecated("hypervisor_vendor_id"sv).as_string());
-    outln("\tBrand: {}", value.get_deprecated("brand"sv).as_string());
-    outln("\tFamily: {}", value.get_deprecated("family"sv).as_u32());
-    outln("\tModel: {}", value.get_deprecated("model"sv).as_u32());
-    outln("\tStepping: {}", value.get_deprecated("stepping"sv).as_u32());
-    outln("\tType: {}", value.get_deprecated("type"sv).as_u32());
+        outln("\tHypervisor Vendor ID: {}", value.get_deprecated_string("hypervisor_vendor_id"sv).value());
+    outln("\tBrand: {}", value.get_deprecated_string("brand"sv).value());
+    outln("\tFamily: {}", value.get_u32("family"sv).value());
+    outln("\tModel: {}", value.get_u32("model"sv).value());
+    outln("\tStepping: {}", value.get_u32("stepping"sv).value());
+    outln("\tType: {}", value.get_u32("type"sv).value());
 
-    auto& caches = value.get_deprecated("caches"sv).as_object();
+    auto& caches = value.get_object("caches"sv).value();
     if (caches.has("l1_data"sv))
-        print_cache_info("L1 data cache"sv, caches.get_deprecated("l1_data"sv).as_object());
+        print_cache_info("L1 data cache"sv, caches.get_object("l1_data"sv).value());
     if (caches.has("l1_instruction"sv))
-        print_cache_info("L1 instruction cache"sv, caches.get_deprecated("l1_instruction"sv).as_object());
+        print_cache_info("L1 instruction cache"sv, caches.get_object("l1_instruction"sv).value());
     if (caches.has("l2"sv))
-        print_cache_info("L2 cache"sv, caches.get_deprecated("l2"sv).as_object());
+        print_cache_info("L2 cache"sv, caches.get_object("l2"sv).value());
     if (caches.has("l3"sv))
-        print_cache_info("L3 cache"sv, caches.get_deprecated("l3"sv).as_object());
+        print_cache_info("L3 cache"sv, caches.get_object("l3"sv).value());
 
     out("\tFeatures: ");
 
-    auto& features = value.get_deprecated("features"sv).as_array();
+    auto& features = value.get_array("features"sv).value();
 
     for (auto const& feature : features.values())
         out("{} ", feature.as_string());

--- a/Userland/Utilities/lsirq.cpp
+++ b/Userland/Utilities/lsirq.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto file_contents = TRY(proc_interrupts->read_until_eof());
     auto json = TRY(JsonValue::from_string(file_contents));
 
-    auto cpu_count = json.as_array().at(0).as_object().get_deprecated("per_cpu_call_counts"sv).as_array().size();
+    auto cpu_count = json.as_array().at(0).as_object().get_array("per_cpu_call_counts"sv)->size();
 
     out("      "sv);
     for (size_t i = 0; i < cpu_count; ++i) {
@@ -34,10 +34,10 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     json.as_array().for_each([cpu_count](JsonValue const& value) {
         auto& handler = value.as_object();
-        auto purpose = handler.get_deprecated("purpose"sv).to_deprecated_string();
-        auto interrupt = handler.get_deprecated("interrupt_line"sv).to_deprecated_string();
-        auto controller = handler.get_deprecated("controller"sv).to_deprecated_string();
-        auto call_counts = handler.get_deprecated("per_cpu_call_counts"sv).as_array();
+        auto purpose = handler.get_deprecated_string("purpose"sv).value_or({});
+        auto interrupt = handler.get_deprecated_string("interrupt_line"sv).value_or({});
+        auto controller = handler.get_deprecated_string("controller"sv).value_or({});
+        auto call_counts = handler.get_array("per_cpu_call_counts"sv).value();
 
         out("{:>4}: ", interrupt);
 

--- a/Userland/Utilities/lsjails.cpp
+++ b/Userland/Utilities/lsjails.cpp
@@ -25,8 +25,8 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto json = TRY(JsonValue::from_string(file_contents));
     json.as_array().for_each([](auto& value) {
         auto& jail = value.as_object();
-        auto index = jail.get_deprecated("index"sv).to_deprecated_string();
-        auto name = jail.get_deprecated("name"sv).to_deprecated_string();
+        auto index = jail.get_deprecated_string("index"sv).value_or({});
+        auto name = jail.get_deprecated_string("name"sv).value_or({});
 
         outln("{:4}     {:10}", index, name);
     });

--- a/Userland/Utilities/lsof.cpp
+++ b/Userland/Utilities/lsof.cpp
@@ -87,9 +87,9 @@ static Vector<OpenFile> get_open_files_by_pid(pid_t pid)
     json.as_array().for_each([pid, &files](JsonValue const& object) {
         OpenFile open_file;
         open_file.pid = pid;
-        open_file.fd = object.as_object().get_deprecated("fd"sv).to_int();
+        open_file.fd = object.as_object().get_integer<int>("fd"sv).value();
 
-        DeprecatedString name = object.as_object().get_deprecated("absolute_path"sv).to_deprecated_string();
+        DeprecatedString name = object.as_object().get_deprecated_string("absolute_path"sv).value_or({});
         VERIFY(parse_name(name, open_file));
         open_file.full_name = name;
 

--- a/Userland/Utilities/lsusb.cpp
+++ b/Userland/Utilities/lsusb.cpp
@@ -70,9 +70,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         json.as_array().for_each([usb_db, print_verbose](auto& value) {
             auto& device_descriptor = value.as_object();
 
-            auto device_address = device_descriptor.get_deprecated("device_address"sv).to_u32();
-            auto vendor_id = device_descriptor.get_deprecated("vendor_id"sv).to_u32();
-            auto product_id = device_descriptor.get_deprecated("product_id"sv).to_u32();
+            auto device_address = device_descriptor.get_u32("device_address"sv).value_or(0);
+            auto vendor_id = device_descriptor.get_u32("vendor_id"sv).value_or(0);
+            auto product_id = device_descriptor.get_u32("product_id"sv).value_or(0);
 
             if (usb_db) {
                 StringView vendor_string = usb_db->get_vendor(vendor_id);
@@ -87,52 +87,52 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
             if (print_verbose) {
                 outln("Device Descriptor");
-                outln("  bLength            {}", device_descriptor.get_deprecated("length"sv).to_u32());
-                outln("  bDescriptorType    {}", device_descriptor.get_deprecated("descriptor_type"sv).to_u32());
-                outln("  bcdUSB             {}", device_descriptor.get_deprecated("usb_spec_compliance_bcd"sv).to_u32());
-                outln("  bDeviceClass       {}", device_descriptor.get_deprecated("device_class"sv).to_u32());
-                outln("  bDeviceSubClass    {}", device_descriptor.get_deprecated("device_sub_class"sv).to_u32());
-                outln("  bDeviceProtocol    {}", device_descriptor.get_deprecated("device_protocol"sv).to_u32());
-                outln("  bMaxPacketSize     {}", device_descriptor.get_deprecated("max_packet_size"sv).to_u32());
+                outln("  bLength            {}", device_descriptor.get_u32("length"sv).value_or(0));
+                outln("  bDescriptorType    {}", device_descriptor.get_u32("descriptor_type"sv).value_or(0));
+                outln("  bcdUSB             {}", device_descriptor.get_u32("usb_spec_compliance_bcd"sv).value_or(0));
+                outln("  bDeviceClass       {}", device_descriptor.get_u32("device_class"sv).value_or(0));
+                outln("  bDeviceSubClass    {}", device_descriptor.get_u32("device_sub_class"sv).value_or(0));
+                outln("  bDeviceProtocol    {}", device_descriptor.get_u32("device_protocol"sv).value_or(0));
+                outln("  bMaxPacketSize     {}", device_descriptor.get_u32("max_packet_size"sv).value_or(0));
                 if (usb_db) {
                     StringView vendor_string = usb_db->get_vendor(vendor_id);
                     StringView device_string = usb_db->get_device(vendor_id, product_id);
-                    outln("  idVendor           0x{:04x} {}", device_descriptor.get_deprecated("vendor_id"sv).to_u32(), vendor_string);
-                    outln("  idProduct          0x{:04x} {}", device_descriptor.get_deprecated("product_id"sv).to_u32(), device_string);
+                    outln("  idVendor           0x{:04x} {}", device_descriptor.get_u32("vendor_id"sv).value_or(0), vendor_string);
+                    outln("  idProduct          0x{:04x} {}", device_descriptor.get_u32("product_id"sv).value_or(0), device_string);
                 } else {
-                    outln("  idVendor           0x{:04x}", device_descriptor.get_deprecated("vendor_id"sv).to_u32());
-                    outln("  idProduct          0x{:04x}", device_descriptor.get_deprecated("product_id"sv).to_u32());
+                    outln("  idVendor           0x{:04x}", device_descriptor.get_u32("vendor_id"sv).value_or(0));
+                    outln("  idProduct          0x{:04x}", device_descriptor.get_u32("product_id"sv).value_or(0));
                 }
-                outln("  bcdDevice          {}", device_descriptor.get_deprecated("device_release_bcd"sv).to_u32());
-                outln("  iManufacturer      {}", device_descriptor.get_deprecated("manufacturer_id_descriptor_index"sv).to_u32());
-                outln("  iProduct           {}", device_descriptor.get_deprecated("product_string_descriptor_index"sv).to_u32());
-                outln("  iSerial            {}", device_descriptor.get_deprecated("serial_number_descriptor_index"sv).to_u32());
-                outln("  bNumConfigurations {}", device_descriptor.get_deprecated("num_configurations"sv).to_u32());
+                outln("  bcdDevice          {}", device_descriptor.get_u32("device_release_bcd"sv).value_or(0));
+                outln("  iManufacturer      {}", device_descriptor.get_u32("manufacturer_id_descriptor_index"sv).value_or(0));
+                outln("  iProduct           {}", device_descriptor.get_u32("product_string_descriptor_index"sv).value_or(0));
+                outln("  iSerial            {}", device_descriptor.get_u32("serial_number_descriptor_index"sv).value_or(0));
+                outln("  bNumConfigurations {}", device_descriptor.get_u32("num_configurations"sv).value_or(0));
 
-                auto const& configuration_descriptors = value.as_object().get_deprecated("configurations"sv);
-                configuration_descriptors.as_array().for_each([&](auto& config_value) {
+                auto const& configuration_descriptors = value.as_object().get_array("configurations"sv).value();
+                configuration_descriptors.for_each([&](auto& config_value) {
                     auto const& configuration_descriptor = config_value.as_object();
                     outln("  Configuration Descriptor:");
-                    outln("    bLength          {}", configuration_descriptor.get_deprecated("length"sv).as_u32());
-                    outln("    bDescriptorType  {}", configuration_descriptor.get_deprecated("descriptor_type"sv).as_u32());
-                    outln("    wTotalLength     {}", configuration_descriptor.get_deprecated("total_length"sv).as_u32());
-                    outln("    bNumInterfaces   {}", configuration_descriptor.get_deprecated("number_of_interfaces"sv).as_u32());
-                    outln("    bmAttributes     0x{:02x}", configuration_descriptor.get_deprecated("attributes_bitmap"sv).as_u32());
-                    outln("    MaxPower         {}mA", configuration_descriptor.get_deprecated("max_power"sv).as_u32() * 2u);
+                    outln("    bLength          {}", configuration_descriptor.get_u32("length"sv).value_or(0));
+                    outln("    bDescriptorType  {}", configuration_descriptor.get_u32("descriptor_type"sv).value_or(0));
+                    outln("    wTotalLength     {}", configuration_descriptor.get_u32("total_length"sv).value_or(0));
+                    outln("    bNumInterfaces   {}", configuration_descriptor.get_u32("number_of_interfaces"sv).value_or(0));
+                    outln("    bmAttributes     0x{:02x}", configuration_descriptor.get_u32("attributes_bitmap"sv).value_or(0));
+                    outln("    MaxPower         {}mA", configuration_descriptor.get_u32("max_power"sv).value_or(0) * 2u);
 
-                    auto const& interface_descriptors = config_value.as_object().get_deprecated("interfaces"sv);
-                    interface_descriptors.as_array().for_each([&](auto& interface_value) {
+                    auto const& interface_descriptors = config_value.as_object().get_array("interfaces"sv).value();
+                    interface_descriptors.for_each([&](auto& interface_value) {
                         auto const& interface_descriptor = interface_value.as_object();
-                        auto const interface_class_code = interface_descriptor.get_deprecated("interface_class_code"sv).to_u32();
-                        auto const interface_subclass_code = interface_descriptor.get_deprecated("interface_sub_class_code"sv).to_u32();
-                        auto const interface_protocol_code = interface_descriptor.get_deprecated("interface_protocol"sv).to_u32();
+                        auto const interface_class_code = interface_descriptor.get_u32("interface_class_code"sv).value_or(0);
+                        auto const interface_subclass_code = interface_descriptor.get_u32("interface_sub_class_code"sv).value_or(0);
+                        auto const interface_protocol_code = interface_descriptor.get_u32("interface_protocol"sv).value_or(0);
 
                         outln("    Interface Descriptor:");
-                        outln("      bLength            {}", interface_descriptor.get_deprecated("length"sv).to_u32());
-                        outln("      bDescriptorType    {}", interface_descriptor.get_deprecated("descriptor_type"sv).to_u32());
-                        outln("      bInterfaceNumber   {}", interface_descriptor.get_deprecated("interface_number"sv).to_u32());
-                        outln("      bAlternateSetting  {}", interface_descriptor.get_deprecated("alternate_setting"sv).to_u32());
-                        outln("      bNumEndpoints      {}", interface_descriptor.get_deprecated("num_endpoints"sv).to_u32());
+                        outln("      bLength            {}", interface_descriptor.get_u32("length"sv).value_or(0));
+                        outln("      bDescriptorType    {}", interface_descriptor.get_u32("descriptor_type"sv).value_or(0));
+                        outln("      bInterfaceNumber   {}", interface_descriptor.get_u32("interface_number"sv).value_or(0));
+                        outln("      bAlternateSetting  {}", interface_descriptor.get_u32("alternate_setting"sv).value_or(0));
+                        outln("      bNumEndpoints      {}", interface_descriptor.get_u32("num_endpoints"sv).value_or(0));
                         if (usb_db) {
                             auto const interface_class = usb_db->get_class(interface_class_code);
                             auto const interface_subclass = usb_db->get_subclass(interface_class_code, interface_subclass_code);
@@ -145,19 +145,19 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                             outln("      bInterfaceSubClass {}", interface_subclass_code);
                             outln("      bInterfaceProtocol {}", interface_protocol_code);
                         }
-                        outln("      iInterface         {}", interface_descriptor.get_deprecated("interface_string_desc_index"sv).to_u32());
+                        outln("      iInterface         {}", interface_descriptor.get_u32("interface_string_desc_index"sv).value_or(0));
 
-                        auto const& endpoint_descriptors = interface_value.as_object().get_deprecated("endpoints"sv);
-                        endpoint_descriptors.as_array().for_each([&](auto& endpoint_value) {
+                        auto const& endpoint_descriptors = interface_value.as_object().get_array("endpoints"sv).value();
+                        endpoint_descriptors.for_each([&](auto& endpoint_value) {
                             auto const& endpoint_descriptor = endpoint_value.as_object();
-                            auto const endpoint_address = endpoint_descriptor.get_deprecated("endpoint_address"sv).to_u32();
+                            auto const endpoint_address = endpoint_descriptor.get_u32("endpoint_address"sv).value_or(0);
                             outln("      Endpoint Descriptor:");
-                            outln("        bLength            {}", endpoint_descriptor.get_deprecated("length"sv).to_u32());
-                            outln("        bDescriptorType    {}", endpoint_descriptor.get_deprecated("descriptor_type"sv).to_u32());
+                            outln("        bLength            {}", endpoint_descriptor.get_u32("length"sv).value_or(0));
+                            outln("        bDescriptorType    {}", endpoint_descriptor.get_u32("descriptor_type"sv).value_or(0));
                             outln("        bEndpointAddress   0x{:02x} EP {} {}", endpoint_address, (endpoint_address & 0xFu), ((endpoint_address & 0x80u) ? "IN" : "OUT"));
-                            outln("        bmAttributes       0x{:02x}", endpoint_descriptor.get_deprecated("attribute_bitmap"sv).to_u32());
-                            outln("        wMaxPacketSize     0x{:04x}", endpoint_descriptor.get_deprecated("max_packet_size"sv).to_u32());
-                            outln("        bInterval          {}", endpoint_descriptor.get_deprecated("polling_interval"sv).to_u32());
+                            outln("        bmAttributes       0x{:02x}", endpoint_descriptor.get_u32("attribute_bitmap"sv).value_or(0));
+                            outln("        wMaxPacketSize     0x{:04x}", endpoint_descriptor.get_u32("max_packet_size"sv).value_or(0));
+                            outln("        bInterval          {}", endpoint_descriptor.get_u32("polling_interval"sv).value_or(0));
                         });
                     });
                 });

--- a/Userland/Utilities/mount.cpp
+++ b/Userland/Utilities/mount.cpp
@@ -155,11 +155,11 @@ static ErrorOr<void> print_mounts()
 
     json.as_array().for_each([](auto& value) {
         auto& fs_object = value.as_object();
-        auto class_name = fs_object.get_deprecated("class_name"sv).to_deprecated_string();
-        auto mount_point = fs_object.get_deprecated("mount_point"sv).to_deprecated_string();
-        auto source = fs_object.get_deprecated("source"sv).as_string_or("none");
-        auto readonly = fs_object.get_deprecated("readonly"sv).to_bool();
-        auto mount_flags = fs_object.get_deprecated("mount_flags"sv).to_int();
+        auto class_name = fs_object.get_deprecated_string("class_name"sv).value_or({});
+        auto mount_point = fs_object.get_deprecated_string("mount_point"sv).value_or({});
+        auto source = fs_object.get_deprecated_string("source"sv).value_or("none");
+        auto readonly = fs_object.get_bool("readonly"sv).value_or(false);
+        auto mount_flags = fs_object.get_u32("mount_flags"sv).value_or(0);
 
         out("{} on {} type {} (", source, mount_point, class_name);
 

--- a/Userland/Utilities/netstat.cpp
+++ b/Userland/Utilities/netstat.cpp
@@ -163,16 +163,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         Vector<JsonValue> sorted_regions = json.as_array().values();
         quick_sort(sorted_regions, [](auto& a, auto& b) {
-            return a.as_object().get_deprecated("local_port"sv).to_u32() < b.as_object().get_deprecated("local_port"sv).to_u32();
+            return a.as_object().get_u32("local_port"sv).value_or(0) < b.as_object().get_u32("local_port"sv).value_or(0);
         });
 
         for (auto& value : sorted_regions) {
             auto& if_object = value.as_object();
 
-            auto bytes_in = if_object.get_deprecated("bytes_in"sv).to_deprecated_string();
-            auto bytes_out = if_object.get_deprecated("bytes_out"sv).to_deprecated_string();
+            auto bytes_in = if_object.get_deprecated_string("bytes_in"sv).value_or({});
+            auto bytes_out = if_object.get_deprecated_string("bytes_out"sv).value_or({});
 
-            auto peer_address = if_object.get_deprecated("peer_address"sv).to_deprecated_string();
+            auto peer_address = if_object.get_deprecated_string("peer_address"sv).value_or({});
             if (!flag_numeric) {
                 auto from_string = IPv4Address::from_string(peer_address);
                 auto addr = from_string.value().to_in_addr_t();
@@ -184,9 +184,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto peer_port = if_object.get_deprecated("peer_port"sv).to_deprecated_string();
+            auto peer_port = if_object.get_deprecated_string("peer_port"sv).value_or({});
             if (!flag_numeric) {
-                auto service = getservbyport(htons(if_object.get_deprecated("peer_port"sv).to_u32()), "tcp");
+                auto service = getservbyport(htons(if_object.get_u32("peer_port"sv).value_or(0)), "tcp");
                 if (service != nullptr) {
                     auto s_name = StringView { service->s_name, strlen(service->s_name) };
                     if (!s_name.is_empty())
@@ -194,7 +194,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto local_address = if_object.get_deprecated("local_address"sv).to_deprecated_string();
+            auto local_address = if_object.get_deprecated_string("local_address"sv).value_or({});
             if (!flag_numeric) {
                 auto from_string = IPv4Address::from_string(local_address);
                 auto addr = from_string.value().to_in_addr_t();
@@ -206,9 +206,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto local_port = if_object.get_deprecated("local_port"sv).to_deprecated_string();
+            auto local_port = if_object.get_deprecated_string("local_port"sv).value_or({});
             if (!flag_numeric) {
-                auto service = getservbyport(htons(if_object.get_deprecated("local_port"sv).to_u32()), "tcp");
+                auto service = getservbyport(htons(if_object.get_u32("local_port"sv).value_or(0)), "tcp");
                 if (service != nullptr) {
                     auto s_name = StringView { service->s_name, strlen(service->s_name) };
                     if (!s_name.is_empty())
@@ -216,8 +216,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto state = if_object.get_deprecated("state"sv).to_deprecated_string();
-            auto origin_pid = (if_object.has("origin_pid"sv)) ? if_object.get_deprecated("origin_pid"sv).to_u32() : -1;
+            auto state = if_object.get_deprecated_string("state"sv).value_or({});
+            auto origin_pid = (if_object.has("origin_pid"sv)) ? if_object.get_u32("origin_pid"sv).value_or(0) : -1;
 
             if (!flag_all && ((state == "Listen" && !flag_list) || (state != "Listen" && flag_list)))
                 continue;
@@ -250,13 +250,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         Vector<JsonValue> sorted_regions = json.as_array().values();
         quick_sort(sorted_regions, [](auto& a, auto& b) {
-            return a.as_object().get_deprecated("local_port"sv).to_u32() < b.as_object().get_deprecated("local_port"sv).to_u32();
+            return a.as_object().get_u32("local_port"sv).value_or(0) < b.as_object().get_u32("local_port"sv).value_or(0);
         });
 
         for (auto& value : sorted_regions) {
             auto& if_object = value.as_object();
 
-            auto local_address = if_object.get_deprecated("local_address"sv).to_deprecated_string();
+            auto local_address = if_object.get_deprecated_string("local_address"sv).value_or({});
             if (!flag_numeric) {
                 auto from_string = IPv4Address::from_string(local_address);
                 auto addr = from_string.value().to_in_addr_t();
@@ -268,9 +268,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto local_port = if_object.get_deprecated("local_port"sv).to_deprecated_string();
+            auto local_port = if_object.get_deprecated_string("local_port"sv).value_or({});
             if (!flag_numeric) {
-                auto service = getservbyport(htons(if_object.get_deprecated("local_port"sv).to_u32()), "udp");
+                auto service = getservbyport(htons(if_object.get_u32("local_port"sv).value_or(0)), "udp");
                 if (service != nullptr) {
                     auto s_name = StringView { service->s_name, strlen(service->s_name) };
                     if (!s_name.is_empty())
@@ -278,7 +278,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto peer_address = if_object.get_deprecated("peer_address"sv).to_deprecated_string();
+            auto peer_address = if_object.get_deprecated_string("peer_address"sv).value_or({});
             if (!flag_numeric) {
                 auto from_string = IPv4Address::from_string(peer_address);
                 auto addr = from_string.value().to_in_addr_t();
@@ -290,9 +290,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto peer_port = if_object.get_deprecated("peer_port"sv).to_deprecated_string();
+            auto peer_port = if_object.get_deprecated_string("peer_port"sv).value_or({});
             if (!flag_numeric) {
-                auto service = getservbyport(htons(if_object.get_deprecated("peer_port"sv).to_u32()), "udp");
+                auto service = getservbyport(htons(if_object.get_u32("peer_port"sv).value_or(0)), "udp");
                 if (service != nullptr) {
                     auto s_name = StringView { service->s_name, strlen(service->s_name) };
                     if (!s_name.is_empty())
@@ -300,7 +300,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto origin_pid = (if_object.has("origin_pid"sv)) ? if_object.get_deprecated("origin_pid"sv).to_u32() : -1;
+            auto origin_pid = (if_object.has("origin_pid"sv)) ? if_object.get_u32("origin_pid"sv).value_or(0) : -1;
 
             if (protocol_column != -1)
                 columns[protocol_column].buffer = "udp";

--- a/Userland/Utilities/pmap.cpp
+++ b/Userland/Utilities/pmap.cpp
@@ -43,31 +43,31 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Vector<JsonValue> sorted_regions = json.as_array().values();
     quick_sort(sorted_regions, [](auto& a, auto& b) {
-        return a.as_object().get_deprecated("address"sv).to_addr() < b.as_object().get_deprecated("address"sv).to_addr();
+        return a.as_object().get_addr("address"sv).value_or(0) < b.as_object().get_addr("address"sv).value_or(0);
     });
 
     for (auto& value : sorted_regions) {
         auto& map = value.as_object();
-        auto address = map.get_deprecated("address"sv).to_addr();
-        auto size = map.get_deprecated("size"sv).to_deprecated_string();
+        auto address = map.get_addr("address"sv).value_or(0);
+        auto size = map.get("size"sv).value_or({}).to_deprecated_string();
 
         auto access = DeprecatedString::formatted("{}{}{}{}{}",
-            (map.get_deprecated("readable"sv).to_bool() ? "r" : "-"),
-            (map.get_deprecated("writable"sv).to_bool() ? "w" : "-"),
-            (map.get_deprecated("executable"sv).to_bool() ? "x" : "-"),
-            (map.get_deprecated("shared"sv).to_bool() ? "s" : "-"),
-            (map.get_deprecated("syscall"sv).to_bool() ? "c" : "-"));
+            (map.get_bool("readable"sv).value_or(false) ? "r" : "-"),
+            (map.get_bool("writable"sv).value_or(false) ? "w" : "-"),
+            (map.get_bool("executable"sv).value_or(false) ? "x" : "-"),
+            (map.get_bool("shared"sv).value_or(false) ? "s" : "-"),
+            (map.get_bool("syscall"sv).value_or(false) ? "c" : "-"));
 
         out("{:p}  ", address);
         out("{:>10} ", size);
         if (extended) {
-            auto resident = map.get_deprecated("amount_resident"sv).to_deprecated_string();
-            auto dirty = map.get_deprecated("amount_dirty"sv).to_deprecated_string();
-            auto vmobject = map.get_deprecated("vmobject"sv).to_deprecated_string();
+            auto resident = map.get("amount_resident"sv).value_or({}).to_deprecated_string();
+            auto dirty = map.get("amount_dirty"sv).value_or({}).to_deprecated_string();
+            auto vmobject = map.get_deprecated_string("vmobject"sv).value_or({});
             if (vmobject.ends_with("VMObject"sv))
                 vmobject = vmobject.substring(0, vmobject.length() - 8);
-            auto purgeable = map.get_deprecated("purgeable"sv).to_deprecated_string();
-            auto cow_pages = map.get_deprecated("cow_pages"sv).to_deprecated_string();
+            auto purgeable = map.get("purgeable"sv).value_or({}).to_deprecated_string();
+            auto cow_pages = map.get("cow_pages"sv).value_or({}).to_deprecated_string();
             out("{:>10} ", resident);
             out("{:>10} ", dirty);
             out("{:6} ", access);
@@ -77,7 +77,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         } else {
             out("{:6} ", access);
         }
-        auto name = map.get_deprecated("name"sv).to_deprecated_string();
+        auto name = map.get_deprecated_string("name"sv).value_or({});
         out("{:20}", name);
         outln();
     }

--- a/Userland/Utilities/route.cpp
+++ b/Userland/Utilities/route.cpp
@@ -101,17 +101,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         Vector<JsonValue> sorted_regions = json.as_array().values();
         quick_sort(sorted_regions, [](auto& a, auto& b) {
-            return a.as_object().get_deprecated("destination"sv).to_deprecated_string() < b.as_object().get_deprecated("destination"sv).to_deprecated_string();
+            return a.as_object().get_deprecated_string("destination"sv).value_or({}) < b.as_object().get_deprecated_string("destination"sv).value_or({});
         });
 
         for (auto& value : sorted_regions) {
             auto& if_object = value.as_object();
 
-            auto destination = if_object.get_deprecated("destination"sv).to_deprecated_string();
-            auto gateway = if_object.get_deprecated("gateway"sv).to_deprecated_string();
-            auto genmask = if_object.get_deprecated("genmask"sv).to_deprecated_string();
-            auto interface = if_object.get_deprecated("interface"sv).to_deprecated_string();
-            auto flags = if_object.get_deprecated("flags"sv).to_u32();
+            auto destination = if_object.get_deprecated_string("destination"sv).value_or({});
+            auto gateway = if_object.get_deprecated_string("gateway"sv).value_or({});
+            auto genmask = if_object.get_deprecated_string("genmask"sv).value_or({});
+            auto interface = if_object.get_deprecated_string("interface"sv).value_or({});
+            auto flags = if_object.get_u32("flags"sv).value_or(0);
 
             StringBuilder flags_builder;
             if (flags & RTF_UP)

--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -40,10 +40,10 @@ ErrorOr<int> serenity_main(Main::Arguments)
     outln("\033[1m{:10} {:12} {:16} {:6} {}\033[0m", "USER", "TTY", "LOGIN@", "IDLE", "WHAT");
     json.as_object().for_each_member([&](auto& tty, auto& value) {
         const JsonObject& entry = value.as_object();
-        auto uid = entry.get_deprecated("uid"sv).to_u32();
-        [[maybe_unused]] auto pid = entry.get_deprecated("pid"sv).to_i32();
+        auto uid = entry.get_u32("uid"sv).value_or(0);
+        [[maybe_unused]] auto pid = entry.get_i32("pid"sv).value_or(0);
 
-        auto login_time = Core::DateTime::from_timestamp(entry.get_deprecated("login_at"sv).to_number<time_t>());
+        auto login_time = Core::DateTime::from_timestamp(entry.get_integer<time_t>("login_at"sv).value_or(0));
         auto login_at = login_time.to_deprecated_string("%b%d %H:%M:%S"sv);
 
         auto* pw = getpwuid(uid);


### PR DESCRIPTION
_Now not in one horrible mega-commit!_

`JsonObject::get(key)` used to return `JsonObject(JsonObject::Type::Null)` if either the value stored was null, or the key didn't exist. In some cases this distinction is important, so we also had `get_ptr()` which returned a raw pointer if the key wasn't found. Nowadays, we can return `Optional<Foo const&>` instead which is much nicer, so let's use that instead!

This PR both replaces `get()` and `get_ptr()` with a `get()` that returns `Optional`, and also adds a variety of `get_foo()` methods that return `Optional<Foo const&>` directly, so that user code does not need to check both that a value was returned, AND that the value was the correct type.

The `has_{some_kind_of_int}()` and `get_{some_kind_of_int}()` methods check the contained JsonValue's actual value will fit within the requested int type, instead of just looking at what type is used to internally store that value. A similar change could be done to the `JsonValue::is_foo()/as_foo()` methods, but that is a future yak for someone. As is, the majority of user code calls `is_number()` and `to_number<T>()` for these.