### PR TITLE
Lagom/ConfigureComponents: Run cmake command last

### DIFF
--- a/Meta/CMake/libgl_generators.cmake
+++ b/Meta/CMake/libgl_generators.cmake
@@ -10,5 +10,5 @@ function (generate_libgl_implementation)
         arguments -j "${LIBGL_INPUT_FOLDER}/GLAPI.json"
     )
 
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/GL/glapi.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/LibGL/GL/")
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/GL/glapi.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/LibGL/GL/" OPTIONAL)
 endfunction()

--- a/Meta/Lagom/Tools/ConfigureComponents/main.cpp
+++ b/Meta/Lagom/Tools/ConfigureComponents/main.cpp
@@ -348,8 +348,8 @@ int main()
         cmake_arguments.append(DeprecatedString::formatted("-DBUILD_{}={}", component.name.to_uppercase(), component.is_selected ? "ON" : "OFF"));
 
     warnln("\e[34mThe following command will be run:\e[0m");
-    outln("{} \\", DeprecatedString::join(' ', cmake_arguments));
-    outln("  && ninja clean\n  && rm -rf Root");
+    outln("ninja clean \\\n  && rm -rf Root \\");
+    outln("  && {}", DeprecatedString::join(' ', cmake_arguments));
     warn("\e[34mDo you want to run the command?\e[0m [Y/n] ");
     auto character = getchar();
     if (character == 'n' || character == 'N') {
@@ -357,13 +357,13 @@ int main()
         return 0;
     }
 
-    // Step 6: Run CMake, 'ninja clean' and 'rm -rf Root'
+    // Step 6: Run 'ninja clean', 'rm -rf Root' and CMake
     auto command = DeprecatedString::join(' ', cmake_arguments);
-    if (!run_system_command(command, "CMake"sv))
-        return 1;
     if (!run_system_command("ninja clean"sv, "Ninja"sv))
         return 1;
     if (!run_system_command("rm -rf Root"sv, "rm"sv))
+        return 1;
+    if (!run_system_command(command, "CMake"sv))
         return 1;
     return 0;
 }

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -46,7 +46,10 @@ foreach(CMD_SRC ${CMD_SOURCES})
     install(TARGETS ${TARGET_NAME} RUNTIME DESTINATION bin OPTIONAL)
 
     if (CMD_NAME IN_LIST SPECIAL_TARGETS)
-        install(CODE "file(RENAME ${CMAKE_INSTALL_PREFIX}/bin/${CMD_NAME}-bin ${CMAKE_INSTALL_PREFIX}/bin/${CMD_NAME})")
+        install(CODE
+            "if (EXISTS ${CMAKE_INSTALL_PREFIX}/bin/${CMD_NAME}-bin)
+                file(RENAME ${CMAKE_INSTALL_PREFIX}/bin/${CMD_NAME}-bin ${CMAKE_INSTALL_PREFIX}/bin/${CMD_NAME})
+            endif()")
     endif()
 endforeach()
 


### PR DESCRIPTION
Previously the tool was removing the Root directory after configuring cmake which was breaking the build, as some cmake rules put some necessary files there.

Moving the cmake command to be the last one makes it regenerate those files automatically. :^)