### PR TITLE
Shell: Add `where` command

### DIFF
--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -25,6 +25,7 @@
 
 #define ENUMERATE_SHELL_BUILTINS()     \
     __ENUMERATE_SHELL_BUILTIN(alias)   \
+    __ENUMERATE_SHELL_BUILTIN(where)   \
     __ENUMERATE_SHELL_BUILTIN(cd)      \
     __ENUMERATE_SHELL_BUILTIN(cdh)     \
     __ENUMERATE_SHELL_BUILTIN(pwd)     \


### PR DESCRIPTION
The command is based on the behavior of the z-shell. Namely it tries to resolve every argument one by one.

When resolving (in the order below) the following results can occur:
  1. The argument is a shell built-in command.
  2. The argument is an alias. In this case we print the mapped value.
  3. The argument was found in the `PATH` environment variable. In this case we print the resolved absolute path.
  4. None of the above. If no earlier argument got resolved, we print the error `{argument} not found`.

If at least one argument got resolved or no arguments where passed, we return with exit code 0, otherwise 1.