### PR TITLE
LibWeb: HTMLFormElement::reset

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -65,6 +65,9 @@ public:
 
     virtual HTMLElement& form_associated_element_to_html_element() = 0;
 
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-reset-control
+    virtual void reset_algorithm() {};
+
 protected:
     FormAssociatedElement() = default;
     virtual ~FormAssociatedElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -38,8 +38,8 @@ HTMLButtonElement::HTMLButtonElement(DOM::Document& document, DOM::QualifiedName
             break;
         case TypeAttributeState::Reset:
             // Reset Button
-            // FIXME: Reset element's form owner.
-            TODO();
+            // Reset element's form owner.
+            form()->reset_form();
             break;
         case TypeAttributeState::Button:
             // Button

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -22,8 +22,13 @@ public:
 
     void submit_form(JS::GCPtr<HTMLElement> submitter, bool from_submit_binding = false);
 
+    void reset_form();
+
     // NOTE: This is for the JS bindings. Use submit_form instead.
     void submit();
+
+    // NOTE: This is for the JS bindings. Use submit_form instead.
+    void reset();
 
     void add_associated_element(Badge<FormAssociatedElement>, HTMLElement&);
     void remove_associated_element(Badge<FormAssociatedElement>, HTMLElement&);
@@ -37,6 +42,9 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     bool m_firing_submission_events { false };
+
+    // https://html.spec.whatwg.org/multipage/forms.html#locked-for-reset
+    bool m_locked_for_reset { false };
 
     Vector<JS::GCPtr<HTMLElement>> m_associated_elements;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
@@ -11,6 +11,7 @@ interface HTMLFormElement : HTMLElement {
     [Reflect=novalidate] attribute boolean noValidate;
 
     undefined submit();
+    [CEReactions] undefined reset();
 
     // FIXME: Should be a HTMLFormControlsCollection
     [SameObject] readonly attribute HTMLCollection elements;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -736,6 +736,28 @@ DeprecatedString HTMLInputElement::value_sanitization_algorithm(DeprecatedString
     return value;
 }
 
+// https://html.spec.whatwg.org/multipage/input.html#the-input-element:concept-form-reset-control
+void HTMLInputElement::reset_algorithm()
+{
+    // The reset algorithm for input elements is to set the dirty value flag and dirty checkedness flag back to false,
+    m_dirty_value = false;
+    m_dirty_checkedness = false;
+
+    // set the value of the element to the value of the value content attribute, if there is one, or the empty string otherwise,
+    m_value = has_attribute(AttributeNames::value) ? get_attribute(AttributeNames::value) : DeprecatedString::empty();
+
+    // set the checkedness of the element to true if the element has a checked content attribute and false if it does not,
+    m_checked = has_attribute(AttributeNames::checked);
+
+    // empty the list of selected files,
+    m_selected_files = FileAPI::FileList::create(realm(), {});
+
+    // and then invoke the value sanitization algorithm, if the type attribute's current state defines one.
+    m_value = value_sanitization_algorithm(m_value);
+    if (m_text_node)
+        m_text_node->set_data(m_value);
+}
+
 void HTMLInputElement::form_associated_element_was_inserted()
 {
     create_shadow_tree_if_needed();

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -110,6 +110,8 @@ public:
     // https://html.spec.whatwg.org/multipage/forms.html#category-autocapitalize
     virtual bool is_auto_capitalize_inheriting() const override { return true; }
 
+    virtual void reset_algorithm() override;
+
     virtual void form_associated_element_was_inserted() override;
 
     // ^HTMLElement

--- a/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
@@ -17,4 +17,12 @@ HTMLOutputElement::HTMLOutputElement(DOM::Document& document, DOM::QualifiedName
 
 HTMLOutputElement::~HTMLOutputElement() = default;
 
+// https://html.spec.whatwg.org/multipage/form-elements.html#the-output-element:concept-form-reset-control
+void HTMLOutputElement::reset_algorithm()
+{
+    // 1. FIXME: String replace all with this element's default value within this element.
+
+    // 2. FIXME: Set this element's default value override to null.
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.h
@@ -41,6 +41,8 @@ public:
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const override { return true; }
 
+    virtual void reset_algorithm() override;
+
 private:
     HTMLOutputElement(DOM::Document&, DOM::QualifiedName);
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -90,6 +90,20 @@ Vector<JS::Handle<HTMLOptionElement>> HTMLSelectElement::list_of_options() const
     return list;
 }
 
+// https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element:concept-form-reset-control
+void HTMLSelectElement::reset_algorithm()
+{
+    // The reset algorithm for select elements is to go through all the option elements in the element's list of options,
+    for (auto const& option_element : list_of_options()) {
+        // set their selectedness to true if the option element has a selected attribute, and false otherwise,
+        option_element->m_selected = option_element->has_attribute(AttributeNames::selected);
+        // set their dirtiness to false,
+        option_element->m_dirty = false;
+        // and then have the option elements ask for a reset.
+        option_element->ask_for_a_reset();
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-selectedindex
 int HTMLSelectElement::selected_index() const
 {

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -56,6 +56,8 @@ public:
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const override { return true; }
 
+    virtual void reset_algorithm() override;
+
     DeprecatedString const& type() const;
 
 private:

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -24,4 +24,10 @@ i32 HTMLTextAreaElement::default_tab_index_value() const
     return 0;
 }
 
+// https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element:concept-form-reset-control
+void HTMLTextAreaElement::reset_algorithm()
+{
+    // FIXME: The reset algorithm for textarea elements is to set the dirty value flag back to false, and set the raw value of element to its child text content.
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -48,6 +48,8 @@ public:
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const override { return true; }
 
+    virtual void reset_algorithm() override;
+
 private:
     HTMLTextAreaElement(DOM::Document&, DOM::QualifiedName);
 


### PR DESCRIPTION
This patchset adds support for reset buttons (`<button type=reset/>`), and implements reset algorithms for the `input` and `select` elements.