### PR TITLE
Kernel: Disallow executing SUID binaries if process is jailed

### DIFF
--- a/Base/usr/share/man/man7/Mitigations.md
+++ b/Base/usr/share/man/man7/Mitigations.md
@@ -105,6 +105,7 @@ Special restrictions on filesystem also apply:
 - Write access is forbidden to kernel variables (which are located in `/sys/kernel/variables`).
 - Open access is forbidden to all device nodes except for `/dev/full`, `/dev/null`, `/dev/zero`, `/dev/random` and various
     other TTY/PTY devices (not including Kernel virtual consoles).
+- Executing SUID binaries is forbidden.
 
 It was first added in the following [commit](https://github.com/SerenityOS/serenity/commit/5e062414c11df31ed595c363990005eef00fa263),
 for kernel support, and the following commits added basic userspace utilities:

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -118,6 +118,7 @@ class Process final
         // FIXME: This should be a NonnullRefPtr
         RefPtr<Credentials> credentials;
         bool dumpable { false };
+        bool executable_is_setid { false };
         Atomic<bool> has_promises { false };
         Atomic<u32> promises { 0 };
         Atomic<bool> has_execpromises { false };


### PR DESCRIPTION
Check if the process we are currently running is in a jail, and if that is the case, fail early with the EPERM error code.