### PR TITLE
LibIPC+IPCCompiler: Use `TRY` more liberally in generated decoders & do not default-construct decoded values

### DIFF
--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -226,7 +226,7 @@ template<NotLvalueReference... Ts>
 struct Variant
     : public Detail::MergeAndDeduplicatePacks<Detail::VariantConstructors<Ts, Variant<Ts...>>...> {
 public:
-    using IndexType = Conditional<sizeof...(Ts) < 255, u8, size_t>; // Note: size+1 reserved for internal value checks
+    using IndexType = Conditional<(sizeof...(Ts) < 255), u8, size_t>; // Note: size+1 reserved for internal value checks
 private:
     static constexpr IndexType invalid_index = sizeof...(Ts);
 
@@ -517,6 +517,9 @@ private:
     alignas(data_alignment) u8 m_data[data_size];
     IndexType m_index;
 };
+
+template<typename... Ts>
+struct TypeList<Variant<Ts...>> : TypeList<Ts...> { };
 
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -595,7 +595,7 @@ public:
         if (stream.handle_any_error()) {)~~~");
     if constexpr (GENERATE_DEBUG) {
         generator.appendln(R"~~~(
-                dbgln(\"Failed to read message endpoint magic\"))~~~");
+            dbgln("Failed to read message endpoint magic");)~~~");
     }
     generator.appendln(R"~~~(
             return {};
@@ -604,7 +604,7 @@ public:
         if (message_endpoint_magic != @endpoint.magic@) {)~~~");
     if constexpr (GENERATE_DEBUG) {
         generator.appendln(R"~~~(
-                dbgln(\"@endpoint.name@: Endpoint magic number message_endpoint_magic != @endpoint.magic@, not my message! (the other endpoint may have handled it)\"))~~~");
+            dbgln("@endpoint.name@: Endpoint magic number message_endpoint_magic != @endpoint.magic@, not my message! (the other endpoint may have handled it)");)~~~");
     }
     generator.appendln(R"~~~(
             return {};
@@ -615,7 +615,7 @@ public:
         if (stream.handle_any_error()) {)~~~");
     if constexpr (GENERATE_DEBUG) {
         generator.appendln(R"~~~(
-                dbgln(\"Failed to read message ID\"))~~~");
+            dbgln("Failed to read message ID");)~~~");
     }
     generator.appendln(R"~~~(
             return {};
@@ -646,7 +646,7 @@ public:
         default:)~~~");
     if constexpr (GENERATE_DEBUG) {
         generator.appendln(R"~~~(
-                dbgln(\"Failed to decode @endpoint.name@.({})\", message_id))~~~");
+            dbgln("Failed to decode @endpoint.name@.({})", message_id);)~~~");
     }
     generator.appendln(R"~~~(
             return {};
@@ -655,7 +655,7 @@ public:
         if (stream.handle_any_error()) {)~~~");
     if constexpr (GENERATE_DEBUG) {
         generator.appendln(R"~~~(
-                dbgln(\"Failed to read the message\");)~~~");
+            dbgln("Failed to read the message");)~~~");
     }
     generator.appendln(R"~~~(
             return {};

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -369,8 +369,7 @@ public:)~~~");
             parameter_generator.set("parameter.initial_value", "{}");
 
         parameter_generator.appendln(R"~~~(
-        @parameter.type@ @parameter.name@ = @parameter.initial_value@;
-        TRY(decoder.decode(@parameter.name@));)~~~");
+        auto @parameter.name@ = TRY((decoder.decode<@parameter.type@>()));)~~~");
 
         if (parameter.attributes.contains_slow("UTF8")) {
             parameter_generator.appendln(R"~~~(

--- a/Tests/AK/TestVariant.cpp
+++ b/Tests/AK/TestVariant.cpp
@@ -260,3 +260,16 @@ TEST_CASE(default_empty)
     EXPECT(my_variant.has<Empty>());
     EXPECT(!my_variant.has<int>());
 }
+
+TEST_CASE(type_list_specialization)
+{
+    EXPECT_EQ((TypeList<Variant<Empty>>::size), 1u);
+    EXPECT_EQ((TypeList<Variant<Empty, int>>::size), 2u);
+    EXPECT_EQ((TypeList<Variant<Empty, int, String>>::size), 3u);
+
+    using MyVariant = Variant<Empty, int, String>;
+    using MyList = TypeList<MyVariant>;
+    EXPECT((IsSame<typename MyList::template Type<0>, Empty>));
+    EXPECT((IsSame<typename MyList::template Type<1>, int>));
+    EXPECT((IsSame<typename MyList::template Type<2>, String>));
+}

--- a/Userland/DevTools/HackStudio/AutoCompleteResponse.h
+++ b/Userland/DevTools/HackStudio/AutoCompleteResponse.h
@@ -27,14 +27,15 @@ inline bool encode(Encoder& encoder, CodeComprehension::AutocompleteResultEntry 
 }
 
 template<>
-inline ErrorOr<void> decode(Decoder& decoder, CodeComprehension::AutocompleteResultEntry& response)
+inline ErrorOr<CodeComprehension::AutocompleteResultEntry> decode(Decoder& decoder)
 {
-    TRY(decoder.decode(response.completion));
-    TRY(decoder.decode(response.partial_input_length));
-    TRY(decoder.decode(response.language));
-    TRY(decoder.decode(response.display_text));
-    TRY(decoder.decode(response.hide_autocomplete_after_applying));
-    return {};
+    auto completion = TRY(decoder.decode<DeprecatedString>());
+    auto partial_input_length = TRY(decoder.decode<size_t>());
+    auto language = TRY(decoder.decode<CodeComprehension::Language>());
+    auto display_text = TRY(decoder.decode<DeprecatedString>());
+    auto hide_autocomplete_after_applying = TRY(decoder.decode<CodeComprehension::AutocompleteResultEntry::HideAutocompleteAfterApplying>());
+
+    return CodeComprehension::AutocompleteResultEntry { move(completion), partial_input_length, language, move(display_text), hide_autocomplete_after_applying };
 }
 
 template<>
@@ -47,12 +48,13 @@ inline bool encode(Encoder& encoder, CodeComprehension::ProjectLocation const& l
 }
 
 template<>
-inline ErrorOr<void> decode(Decoder& decoder, CodeComprehension::ProjectLocation& location)
+inline ErrorOr<CodeComprehension::ProjectLocation> decode(Decoder& decoder)
 {
-    TRY(decoder.decode(location.file));
-    TRY(decoder.decode(location.line));
-    TRY(decoder.decode(location.column));
-    return {};
+    auto file = TRY(decoder.decode<DeprecatedString>());
+    auto line = TRY(decoder.decode<size_t>());
+    auto column = TRY(decoder.decode<size_t>());
+
+    return CodeComprehension::ProjectLocation { move(file), line, column };
 }
 
 template<>
@@ -67,13 +69,14 @@ inline bool encode(Encoder& encoder, CodeComprehension::Declaration const& decla
 }
 
 template<>
-inline ErrorOr<void> decode(Decoder& decoder, CodeComprehension::Declaration& declaration)
+inline ErrorOr<CodeComprehension::Declaration> decode(Decoder& decoder)
 {
-    TRY(decoder.decode(declaration.name));
-    TRY(decoder.decode(declaration.position));
-    TRY(decoder.decode(declaration.type));
-    TRY(decoder.decode(declaration.scope));
-    return {};
+    auto name = TRY(decoder.decode<DeprecatedString>());
+    auto position = TRY(decoder.decode<CodeComprehension::ProjectLocation>());
+    auto type = TRY(decoder.decode<CodeComprehension::DeclarationType>());
+    auto scope = TRY(decoder.decode<DeprecatedString>());
+
+    return CodeComprehension::Declaration { move(name), position, type, move(scope) };
 }
 
 template<>
@@ -87,13 +90,14 @@ inline bool encode(Encoder& encoder, CodeComprehension::TodoEntry const& entry)
 }
 
 template<>
-inline ErrorOr<void> decode(Decoder& decoder, CodeComprehension::TodoEntry& entry)
+inline ErrorOr<CodeComprehension::TodoEntry> decode(Decoder& decoder)
 {
-    TRY(decoder.decode(entry.content));
-    TRY(decoder.decode(entry.filename));
-    TRY(decoder.decode(entry.line));
-    TRY(decoder.decode(entry.column));
-    return {};
+    auto content = TRY(decoder.decode<DeprecatedString>());
+    auto filename = TRY(decoder.decode<DeprecatedString>());
+    auto line = TRY(decoder.decode<size_t>());
+    auto column = TRY(decoder.decode<size_t>());
+
+    return CodeComprehension::TodoEntry { move(content), move(filename), line, column };
 }
 
 template<>
@@ -109,18 +113,15 @@ inline bool encode(Encoder& encoder, CodeComprehension::TokenInfo const& locatio
 }
 
 template<>
-inline ErrorOr<void> decode(Decoder& decoder, CodeComprehension::TokenInfo& entry)
+inline ErrorOr<CodeComprehension::TokenInfo> decode(Decoder& decoder)
 {
-    u32 semantic_type { 0 };
-    static_assert(sizeof(semantic_type) == sizeof(entry.type));
+    auto type = TRY(decoder.decode<CodeComprehension::TokenInfo::SemanticType>());
+    auto start_line = TRY(decoder.decode<size_t>());
+    auto start_column = TRY(decoder.decode<size_t>());
+    auto end_line = TRY(decoder.decode<size_t>());
+    auto end_column = TRY(decoder.decode<size_t>());
 
-    TRY(decoder.decode(semantic_type));
-    entry.type = static_cast<CodeComprehension::TokenInfo::SemanticType>(semantic_type);
-    TRY(decoder.decode(entry.start_line));
-    TRY(decoder.decode(entry.start_column));
-    TRY(decoder.decode(entry.end_line));
-    TRY(decoder.decode(entry.end_column));
-    return {};
+    return CodeComprehension::TokenInfo { type, start_line, start_column, end_line, end_column };
 }
 
 }

--- a/Userland/Libraries/LibCore/AnonymousBuffer.h
+++ b/Userland/Libraries/LibCore/AnonymousBuffer.h
@@ -78,6 +78,6 @@ template<>
 bool encode(Encoder&, Core::AnonymousBuffer const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, Core::AnonymousBuffer&);
+ErrorOr<Core::AnonymousBuffer> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibCore/DateTime.h
+++ b/Userland/Libraries/LibCore/DateTime.h
@@ -58,6 +58,6 @@ template<>
 bool encode(Encoder&, Core::DateTime const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, Core::DateTime&);
+ErrorOr<Core::DateTime> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibCore/Proxy.h
+++ b/Userland/Libraries/LibCore/Proxy.h
@@ -57,6 +57,6 @@ template<>
 bool encode(Encoder&, Core::ProxyData const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, Core::ProxyData&);
+ErrorOr<Core::ProxyData> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibDNS/Answer.cpp
+++ b/Userland/Libraries/LibDNS/Answer.cpp
@@ -108,21 +108,16 @@ bool encode(Encoder& encoder, DNS::Answer const& answer)
 }
 
 template<>
-ErrorOr<void> decode(Decoder& decoder, DNS::Answer& answer)
+ErrorOr<DNS::Answer> decode(Decoder& decoder)
 {
-    DeprecatedString name;
-    TRY(decoder.decode(name));
-    u16 record_type, class_code;
-    TRY(decoder.decode(record_type));
-    TRY(decoder.decode(class_code));
-    u32 ttl;
-    TRY(decoder.decode(ttl));
-    DeprecatedString record_data;
-    TRY(decoder.decode(record_data));
-    bool cache_flush;
-    TRY(decoder.decode(cache_flush));
-    answer = { { name }, (DNS::RecordType)record_type, (DNS::RecordClass)class_code, ttl, record_data, cache_flush };
-    return {};
+    auto name = TRY(decoder.decode<DeprecatedString>());
+    auto record_type = TRY(decoder.decode<DNS::RecordType>());
+    auto class_code = TRY(decoder.decode<DNS::RecordClass>());
+    auto ttl = TRY(decoder.decode<u32>());
+    auto record_data = TRY(decoder.decode<DeprecatedString>());
+    auto cache_flush = TRY(decoder.decode<bool>());
+
+    return DNS::Answer { name, record_type, class_code, ttl, record_data, cache_flush };
 }
 
 }

--- a/Userland/Libraries/LibDNS/Answer.h
+++ b/Userland/Libraries/LibDNS/Answer.h
@@ -98,6 +98,6 @@ template<>
 bool encode(Encoder&, DNS::Answer const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, DNS::Answer&);
+ErrorOr<DNS::Answer> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -374,12 +374,10 @@ bool IPC::encode(Encoder& encoder, Color const& color)
 }
 
 template<>
-ErrorOr<void> IPC::decode(Decoder& decoder, Color& color)
+ErrorOr<Gfx::Color> IPC::decode(Decoder& decoder)
 {
-    u32 rgba;
-    TRY(decoder.decode(rgba));
-    color = Color::from_argb(rgba);
-    return {};
+    auto rgba = TRY(decoder.decode<u32>());
+    return Gfx::Color::from_argb(rgba);
 }
 
 ErrorOr<void> AK::Formatter<Gfx::Color>::format(FormatBuilder& builder, Gfx::Color value)

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -577,6 +577,6 @@ template<>
 bool encode(Encoder&, Gfx::Color const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, Gfx::Color&);
+ErrorOr<Gfx::Color> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibGfx/Point.cpp
+++ b/Userland/Libraries/LibGfx/Point.cpp
@@ -59,14 +59,11 @@ bool encode(Encoder& encoder, Gfx::IntPoint const& point)
 }
 
 template<>
-ErrorOr<void> decode(Decoder& decoder, Gfx::IntPoint& point)
+ErrorOr<Gfx::IntPoint> decode(Decoder& decoder)
 {
-    int x = 0;
-    int y = 0;
-    TRY(decoder.decode(x));
-    TRY(decoder.decode(y));
-    point = { x, y };
-    return {};
+    auto x = TRY(decoder.decode<int>());
+    auto y = TRY(decoder.decode<int>());
+    return Gfx::IntPoint { x, y };
 }
 
 }

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -295,7 +295,7 @@ template<>
 bool encode(Encoder&, Gfx::IntPoint const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, Gfx::IntPoint&);
+ErrorOr<Gfx::IntPoint> decode(Decoder&);
 
 }
 

--- a/Userland/Libraries/LibGfx/Rect.cpp
+++ b/Userland/Libraries/LibGfx/Rect.cpp
@@ -38,14 +38,11 @@ bool encode(Encoder& encoder, Gfx::IntRect const& rect)
 }
 
 template<>
-ErrorOr<void> decode(Decoder& decoder, Gfx::IntRect& rect)
+ErrorOr<Gfx::IntRect> decode(Decoder& decoder)
 {
-    Gfx::IntPoint point;
-    Gfx::IntSize size;
-    TRY(decoder.decode(point));
-    TRY(decoder.decode(size));
-    rect = { point, size };
-    return {};
+    auto point = TRY(decoder.decode<Gfx::IntPoint>());
+    auto size = TRY(decoder.decode<Gfx::IntSize>());
+    return Gfx::IntRect { point, size };
 }
 
 }

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -1036,6 +1036,6 @@ template<>
 bool encode(Encoder&, Gfx::IntRect const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, Gfx::IntRect&);
+ErrorOr<Gfx::IntRect> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibGfx/ShareableBitmap.cpp
+++ b/Userland/Libraries/LibGfx/ShareableBitmap.cpp
@@ -32,7 +32,7 @@ bool encode(Encoder& encoder, Gfx::ShareableBitmap const& shareable_bitmap)
     encoder << IPC::File(bitmap.anonymous_buffer().fd());
     encoder << bitmap.size();
     encoder << static_cast<u32>(bitmap.scale());
-    encoder << (u32)bitmap.format();
+    encoder << static_cast<u32>(bitmap.format());
     if (bitmap.is_indexed()) {
         auto palette = bitmap.palette_to_vector();
         encoder << palette;
@@ -41,33 +41,28 @@ bool encode(Encoder& encoder, Gfx::ShareableBitmap const& shareable_bitmap)
 }
 
 template<>
-ErrorOr<void> decode(Decoder& decoder, Gfx::ShareableBitmap& shareable_bitmap)
+ErrorOr<Gfx::ShareableBitmap> decode(Decoder& decoder)
 {
-    bool valid = false;
-    TRY(decoder.decode(valid));
-    if (!valid) {
-        shareable_bitmap = {};
-        return {};
-    }
-    IPC::File anon_file;
-    TRY(decoder.decode(anon_file));
-    Gfx::IntSize size;
-    TRY(decoder.decode(size));
-    u32 scale;
-    TRY(decoder.decode(scale));
-    u32 raw_bitmap_format;
-    TRY(decoder.decode(raw_bitmap_format));
+    if (auto valid = TRY(decoder.decode<bool>()); !valid)
+        return Gfx::ShareableBitmap {};
+
+    auto anon_file = TRY(decoder.decode<IPC::File>());
+    auto size = TRY(decoder.decode<Gfx::IntSize>());
+    auto scale = TRY(decoder.decode<u32>());
+    auto raw_bitmap_format = TRY(decoder.decode<u32>());
     if (!Gfx::is_valid_bitmap_format(raw_bitmap_format))
         return Error::from_string_literal("IPC: Invalid Gfx::ShareableBitmap format");
-    auto bitmap_format = (Gfx::BitmapFormat)raw_bitmap_format;
+
+    auto bitmap_format = static_cast<Gfx::BitmapFormat>(raw_bitmap_format);
+
     Vector<Gfx::ARGB32> palette;
-    if (Gfx::Bitmap::is_indexed(bitmap_format)) {
-        TRY(decoder.decode(palette));
-    }
+    if (Gfx::Bitmap::is_indexed(bitmap_format))
+        palette = TRY(decoder.decode<decltype(palette)>());
+
     auto buffer = TRY(Core::AnonymousBuffer::create_from_anon_fd(anon_file.take_fd(), Gfx::Bitmap::size_in_bytes(Gfx::Bitmap::minimum_pitch(size.width() * scale, bitmap_format), size.height() * scale)));
     auto bitmap = TRY(Gfx::Bitmap::try_create_with_anonymous_buffer(bitmap_format, move(buffer), size, scale, palette));
-    shareable_bitmap = Gfx::ShareableBitmap { move(bitmap), Gfx::ShareableBitmap::ConstructWithKnownGoodBitmap };
-    return {};
+
+    return Gfx::ShareableBitmap { move(bitmap), Gfx::ShareableBitmap::ConstructWithKnownGoodBitmap };
 }
 
 }

--- a/Userland/Libraries/LibGfx/ShareableBitmap.h
+++ b/Userland/Libraries/LibGfx/ShareableBitmap.h
@@ -9,6 +9,7 @@
 #include <AK/RefPtr.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Size.h>
+#include <LibIPC/Forward.h>
 
 namespace Gfx {
 
@@ -38,6 +39,6 @@ template<>
 bool encode(Encoder&, Gfx::ShareableBitmap const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, Gfx::ShareableBitmap&);
+ErrorOr<Gfx::ShareableBitmap> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibGfx/Size.cpp
+++ b/Userland/Libraries/LibGfx/Size.cpp
@@ -35,14 +35,11 @@ bool encode(Encoder& encoder, Gfx::IntSize const& size)
 }
 
 template<>
-ErrorOr<void> decode(Decoder& decoder, Gfx::IntSize& size)
+ErrorOr<Gfx::IntSize> decode(Decoder& decoder)
 {
-    int width = 0;
-    int height = 0;
-    TRY(decoder.decode(width));
-    TRY(decoder.decode(height));
-    size = { width, height };
-    return {};
+    auto width = TRY(decoder.decode<int>());
+    auto height = TRY(decoder.decode<int>());
+    return Gfx::IntSize { width, height };
 }
 
 }

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -218,6 +218,6 @@ template<>
 bool encode(Encoder&, Gfx::IntSize const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, Gfx::IntSize&);
+ErrorOr<Gfx::IntSize> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibIPC/Concepts.h
+++ b/Userland/Libraries/LibIPC/Concepts.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/HashMap.h>
+#include <AK/Optional.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibCore/SharedCircularQueue.h>
+
+#pragma once
+
+// These concepts are used to help the compiler distinguish between specializations that would be
+// ambiguous otherwise. For example, if the specializations for int and Vector<T> were declared as
+// follows:
+//
+//     template<> ErrorOr<int> decode(Decoder& decoder);
+//     template<typename T> ErrorOr<Vector<T>> decode(Decoder& decoder);
+//
+// Then decode<int>() would be ambiguous because either declaration could work (the compiler would
+// not be able to distinguish if you wanted to decode an int or a Vector of int).
+namespace IPC::Concepts {
+
+namespace Detail {
+
+template<typename T>
+constexpr inline bool IsHashMap = false;
+template<typename K, typename V>
+constexpr inline bool IsHashMap<HashMap<K, V>> = true;
+template<typename K, typename V>
+constexpr inline bool IsHashMap<OrderedHashMap<K, V>> = true;
+
+template<typename T>
+constexpr inline bool IsOptional = false;
+template<typename T>
+constexpr inline bool IsOptional<Optional<T>> = true;
+
+template<typename T>
+constexpr inline bool IsSharedSingleProducerCircularQueue = false;
+template<typename T, size_t Size>
+constexpr inline bool IsSharedSingleProducerCircularQueue<Core::SharedSingleProducerCircularQueue<T, Size>> = true;
+
+template<typename T>
+constexpr inline bool IsVariant = false;
+template<typename... Ts>
+constexpr inline bool IsVariant<Variant<Ts...>> = true;
+
+template<typename T>
+constexpr inline bool IsVector = false;
+template<typename T>
+constexpr inline bool IsVector<Vector<T>> = true;
+
+}
+
+template<typename T>
+concept HashMap = Detail::IsHashMap<T>;
+
+template<typename T>
+concept Optional = Detail::IsOptional<T>;
+
+template<typename T>
+concept SharedSingleProducerCircularQueue = Detail::IsSharedSingleProducerCircularQueue<T>;
+
+template<typename T>
+concept Variant = Detail::IsVariant<T>;
+
+template<typename T>
+concept Vector = Detail::IsVector<T>;
+
+}

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -89,12 +89,9 @@ public:
         return *this;
     }
 
-    // Note: We require any encodeable variant to have Empty as its first variant, as only possibly-empty variants can be default constructed.
-    //       The default constructability is required by generated IPC message marshalling code.
     template<typename... VariantTypes>
-    Encoder& operator<<(AK::Variant<AK::Empty, VariantTypes...> const& variant)
+    Encoder& operator<<(AK::Variant<VariantTypes...> const& variant)
     {
-        // Note: This might be either u8 or size_t depending on the size of the variant; both are encodeable.
         *this << variant.index();
         variant.visit([this](auto const& underlying_value) { *this << underlying_value; });
         return *this;

--- a/Userland/Libraries/LibIPC/Forward.h
+++ b/Userland/Libraries/LibIPC/Forward.h
@@ -19,6 +19,6 @@ template<typename T>
 bool encode(Encoder&, T const&);
 
 template<typename T>
-ErrorOr<void> decode(Decoder&, T&);
+ErrorOr<T> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibSQL/Value.h
+++ b/Userland/Libraries/LibSQL/Value.h
@@ -194,6 +194,6 @@ template<>
 bool encode(Encoder&, SQL::Value const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, SQL::Value&);
+ErrorOr<SQL::Value> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibWeb/Cookie/Cookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/Cookie.cpp
@@ -58,19 +58,20 @@ bool IPC::encode(Encoder& encoder, Web::Cookie::Cookie const& cookie)
 }
 
 template<>
-ErrorOr<void> IPC::decode(Decoder& decoder, Web::Cookie::Cookie& cookie)
+ErrorOr<Web::Cookie::Cookie> IPC::decode(Decoder& decoder)
 {
-    TRY(decoder.decode(cookie.name));
-    TRY(decoder.decode(cookie.value));
-    TRY(decoder.decode(cookie.domain));
-    TRY(decoder.decode(cookie.path));
-    TRY(decoder.decode(cookie.creation_time));
-    TRY(decoder.decode(cookie.expiry_time));
-    TRY(decoder.decode(cookie.host_only));
-    TRY(decoder.decode(cookie.http_only));
-    TRY(decoder.decode(cookie.last_access_time));
-    TRY(decoder.decode(cookie.persistent));
-    TRY(decoder.decode(cookie.secure));
-    TRY(decoder.decode(cookie.same_site));
-    return {};
+    auto name = TRY(decoder.decode<DeprecatedString>());
+    auto value = TRY(decoder.decode<DeprecatedString>());
+    auto domain = TRY(decoder.decode<DeprecatedString>());
+    auto path = TRY(decoder.decode<DeprecatedString>());
+    auto creation_time = TRY(decoder.decode<Core::DateTime>());
+    auto expiry_time = TRY(decoder.decode<Core::DateTime>());
+    auto host_only = TRY(decoder.decode<bool>());
+    auto http_only = TRY(decoder.decode<bool>());
+    auto last_access_time = TRY(decoder.decode<Core::DateTime>());
+    auto persistent = TRY(decoder.decode<bool>());
+    auto secure = TRY(decoder.decode<bool>());
+    auto same_site = TRY(decoder.decode<Web::Cookie::SameSite>());
+
+    return Web::Cookie::Cookie { move(name), move(value), same_site, move(creation_time), move(last_access_time), move(expiry_time), move(domain), move(path), secure, http_only, host_only, persistent };
 }

--- a/Userland/Libraries/LibWeb/Cookie/Cookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/Cookie.h
@@ -50,6 +50,6 @@ template<>
 bool encode(Encoder&, Web::Cookie::Cookie const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, Web::Cookie::Cookie&);
+ErrorOr<Web::Cookie::Cookie> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -364,16 +364,17 @@ bool IPC::encode(Encoder& encoder, Web::Cookie::ParsedCookie const& cookie)
 }
 
 template<>
-ErrorOr<void> IPC::decode(Decoder& decoder, Web::Cookie::ParsedCookie& cookie)
+ErrorOr<Web::Cookie::ParsedCookie> IPC::decode(Decoder& decoder)
 {
-    TRY(decoder.decode(cookie.name));
-    TRY(decoder.decode(cookie.value));
-    TRY(decoder.decode(cookie.expiry_time_from_expires_attribute));
-    TRY(decoder.decode(cookie.expiry_time_from_max_age_attribute));
-    TRY(decoder.decode(cookie.domain));
-    TRY(decoder.decode(cookie.path));
-    TRY(decoder.decode(cookie.secure_attribute_present));
-    TRY(decoder.decode(cookie.http_only_attribute_present));
-    TRY(decoder.decode(cookie.same_site_attribute));
-    return {};
+    auto name = TRY(decoder.decode<DeprecatedString>());
+    auto value = TRY(decoder.decode<DeprecatedString>());
+    auto expiry_time_from_expires_attribute = TRY(decoder.decode<Optional<Core::DateTime>>());
+    auto expiry_time_from_max_age_attribute = TRY(decoder.decode<Optional<Core::DateTime>>());
+    auto domain = TRY(decoder.decode<Optional<DeprecatedString>>());
+    auto path = TRY(decoder.decode<Optional<DeprecatedString>>());
+    auto secure_attribute_present = TRY(decoder.decode<bool>());
+    auto http_only_attribute_present = TRY(decoder.decode<bool>());
+    auto same_site_attribute = TRY(decoder.decode<Web::Cookie::SameSite>());
+
+    return Web::Cookie::ParsedCookie { move(name), move(value), same_site_attribute, move(expiry_time_from_expires_attribute), move(expiry_time_from_max_age_attribute), move(domain), move(path), secure_attribute_present, http_only_attribute_present };
 }

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
@@ -36,6 +36,6 @@ template<>
 bool encode(Encoder&, Web::Cookie::ParsedCookie const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, Web::Cookie::ParsedCookie&);
+ErrorOr<Web::Cookie::ParsedCookie> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibWeb/WebDriver/Response.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Response.h
@@ -50,6 +50,6 @@ template<>
 bool encode(Encoder&, Web::WebDriver::Response const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, Web::WebDriver::Response&);
+ErrorOr<Web::WebDriver::Response> decode(Decoder&);
 
 }

--- a/Userland/Services/WindowServer/ScreenLayout.h
+++ b/Userland/Services/WindowServer/ScreenLayout.h
@@ -77,12 +77,12 @@ template<>
 bool encode(Encoder&, WindowServer::ScreenLayout::Screen const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, WindowServer::ScreenLayout::Screen&);
+ErrorOr<WindowServer::ScreenLayout::Screen> decode(Decoder&);
 
 template<>
 bool encode(Encoder&, WindowServer::ScreenLayout const&);
 
 template<>
-ErrorOr<void> decode(Decoder&, WindowServer::ScreenLayout&);
+ErrorOr<WindowServer::ScreenLayout> decode(Decoder&);
 
 }


### PR DESCRIPTION
The first change here is to make the generated decoders propagate errors with `TRY` semantics, rather than performing manual error checking and returning a null pointer to indicate an error.

The second change is to avoid default constructing decoded values before decoding them. This forced these decoded types to be default constructible, which had awkward side effects (like the `Variant` decoder needing the first variadic type to be `Empty`).

(One of the goals here is to make IPC have better support for transferring `ErrorOr` - to transfer `ErrorOr`, it'll be handy to just be able to transfer the `Variant` it stores).