### PR TITLE
LibWeb: Bring FrameLoader closer to spec

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.h
@@ -45,7 +45,7 @@ private:
 
     void load_error_page(const AK::URL& failed_url, DeprecatedString const& error_message);
     void load_favicon(RefPtr<Gfx::Bitmap> bitmap = nullptr);
-    bool parse_document(DOM::Document&, ByteBuffer const& data);
+    ErrorOr<void> load_document(DOM::Document&, ByteBuffer const& data);
 
     void store_response_cookies(AK::URL const& url, DeprecatedString const& cookies);
 

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -232,6 +232,73 @@ void MimeType::set_parameter(DeprecatedString const& name, DeprecatedString cons
     m_parameters.set(name, value);
 }
 
+// https://mimesniff.spec.whatwg.org/#image-mime-type
+bool MimeType::is_image() const
+{
+    return m_type == "image"sv;
+}
+
+// https://mimesniff.spec.whatwg.org/#audio-or-video-mime-type
+bool MimeType::is_audio_or_video() const
+{
+    return m_type == "audio"sv
+        || m_type == "video"sv
+        || essence() == "application/ogg"sv;
+}
+
+// https://mimesniff.spec.whatwg.org/#font-mime-type
+bool MimeType::is_font() const
+{
+    return m_type == "font"
+        || essence().is_one_of(
+            "application/font-cff"sv,
+            "application/font-off"sv,
+            "application/font-sfnt"sv,
+            "application/font-ttf"sv,
+            "application/font-woff"sv,
+            "application/vnd.ms-fontobject"sv,
+            "application/vnd.ms-opentype"sv);
+}
+
+// https://mimesniff.spec.whatwg.org/#zip-based-mime-type
+bool MimeType::is_zip_based() const
+{
+    return m_subtype.ends_with("+zip"sv)
+        || essence() == "application/zip"sv;
+}
+
+// https://mimesniff.spec.whatwg.org/#archive-mime-type
+bool MimeType::is_archive() const
+{
+    return essence().is_one_of(
+        "application/x-rar-compressed",
+        "application/zip",
+        "application/x-gzip");
+}
+
+// https://mimesniff.spec.whatwg.org/#xml-mime-type
+bool MimeType::is_xml() const
+{
+    return m_subtype.ends_with("+xml"sv)
+        || essence().is_one_of(
+            "text/xml"sv,
+            "application/xml"sv);
+}
+
+// https://mimesniff.spec.whatwg.org/#html-mime-type
+bool MimeType::is_html() const
+{
+    return essence() == "text/html"sv;
+}
+
+// https://mimesniff.spec.whatwg.org/#scriptable-mime-type
+bool MimeType::is_scriptable() const
+{
+    return is_xml()
+        || is_html()
+        || essence() == "application/pdf"sv;
+}
+
 // https://mimesniff.spec.whatwg.org/#javascript-mime-type
 bool MimeType::is_javascript() const
 {
@@ -252,6 +319,15 @@ bool MimeType::is_javascript() const
         "text/livescript"sv,
         "text/x-ecmascript"sv,
         "text/x-javascript"sv);
+}
+
+// https://mimesniff.spec.whatwg.org/#json-mime-type
+bool MimeType::is_json() const
+{
+    return m_subtype.ends_with("+json"sv)
+        || essence().is_one_of(
+            "application/json"sv,
+            "text/json"sv);
 }
 
 }

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -26,7 +26,16 @@ public:
     DeprecatedString const& subtype() const { return m_subtype; }
     OrderedHashMap<DeprecatedString, DeprecatedString> const& parameters() const { return m_parameters; }
 
+    bool is_image() const;
+    bool is_audio_or_video() const;
+    bool is_font() const;
+    bool is_zip_based() const;
+    bool is_archive() const;
+    bool is_xml() const;
+    bool is_html() const;
+    bool is_scriptable() const;
     bool is_javascript() const;
+    bool is_json() const;
 
     void set_parameter(DeprecatedString const& name, DeprecatedString const& value);
 


### PR DESCRIPTION
This is the first step in an effort to bring FrameLoader closer to spec.

Changes:
* Add `is_*` methods to MIMEType.
* Use the new `is_*` methods in parse_document.
* Rename `parse_document` to `load_document`.
* Try to match the spec for the load document algorithm.
    * Implement a unified `build_media_document`
    * Implement `build_html_document`
 
The efforts could be:
* `load_document` should return null when no suitable type is found.
* Separate resource loading from navigation.
* Implement navigate algorithm.