### PR TITLE
AK: Refactor Stack to prevent accidental heap allocation footguns

### DIFF
--- a/AK/Stack.h
+++ b/AK/Stack.h
@@ -1,15 +1,17 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/Vector.h>
+#include <AK/Array.h>
 
 namespace AK {
 
+// A fixed-size stack that can never allocate.
 template<typename T, size_t stack_size>
 class Stack {
 public:
@@ -18,30 +20,30 @@ public:
 
     bool push(T const& item)
     {
-        if (m_stack.size() >= stack_size)
+        if (index >= stack_size)
             return false;
 
-        m_stack.unchecked_append(item);
+        m_stack[index++] = item;
         return true;
     }
 
     bool push(T&& item)
     {
-        if (m_stack.size() >= stack_size)
+        if (index >= stack_size)
             return false;
 
-        m_stack.unchecked_append(move(item));
+        m_stack[index++] = item;
         return true;
     }
 
     bool is_empty() const
     {
-        return m_stack.is_empty();
+        return index == 0;
     }
 
     size_t size() const
     {
-        return m_stack.size();
+        return index;
     }
 
     bool pop()
@@ -49,27 +51,34 @@ public:
         if (is_empty())
             return false;
 
-        m_stack.resize_and_keep_capacity(m_stack.size() - 1);
+        m_stack[--index].~T();
         return true;
     }
 
     T& top()
     {
-        return m_stack.last();
+        VERIFY(!is_empty());
+        return m_stack[index - 1];
     }
 
     T const& top() const
     {
-        return m_stack.last();
+        VERIFY(!is_empty());
+        return m_stack[index - 1];
     }
 
     bool contains_slow(T const& value) const
     {
-        return m_stack.contains_slow(value);
+        for (size_t i = 0; i < index; ++i) {
+            if (Traits<T>::equals(m_stack[i], value))
+                return true;
+        }
+        return false;
     }
 
 private:
-    Vector<T, stack_size> m_stack;
+    Array<T, stack_size> m_stack;
+    size_t index { 0 };
 };
 
 }


### PR DESCRIPTION
Using Vector can allow for accidental heap allocation beyond the inline capacity, even if only when implementing a new internal API. Array prevents this just by it being incapable of allocating beyond the inline capacity. This change has the nice side benefit of shrinking all Stack instantiations by the size of a pointer, as the heap allocation pointer previously present through Vector is now gone.