### PR TITLE
Kernel: Add some Aarch64 processor register accessors

### DIFF
--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -46,6 +46,31 @@ struct alignas(u64) ID_AA64ISAR0_EL1 {
 };
 static_assert(sizeof(ID_AA64ISAR0_EL1) == 8);
 
+// https://developer.arm.com/documentation/ddi0595/2021-12/AArch64-Registers/MPIDR-EL1--Multiprocessor-Affinity-Register?lang=en
+// MPIDR_EL1, Multiprocessor Affinity Register
+struct alignas(u64) MPIDR_EL1 {
+    int Aff0 : 8;
+    int Aff1 : 8;
+    int Aff2 : 8;
+    int MT : 1;
+    int : 5;
+    int U : 1;
+    int : 1;
+    int Aff3 : 8;
+    int : 24;
+
+    static inline MPIDR_EL1 read()
+    {
+        MPIDR_EL1 affinity_register;
+
+        asm("mrs %[value], MPIDR_EL1"
+            : [value] "=r"(affinity_register));
+
+        return affinity_register;
+    }
+};
+static_assert(sizeof(MPIDR_EL1) == 8);
+
 // https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/ID-AA64MMFR0-EL1--AArch64-Memory-Model-Feature-Register-0
 // Memory Model Feature Register 0
 struct alignas(u64) ID_AA64MMFR0_EL1 {

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -311,6 +311,28 @@ struct alignas(u64) SCTLR_EL1 {
 };
 static_assert(sizeof(SCTLR_EL1) == 8);
 
+// https://developer.arm.com/documentation/ddi0601/2022-09/AArch64-Registers/MIDR-EL1--Main-ID-Register?lang=en
+// MIDR_EL1, Main ID Register
+struct alignas(u64) MIDR_EL1 {
+    int Revision : 4;
+    int PartNum : 12;
+    int Architecture : 4;
+    int Variant : 4;
+    int Implementer : 8;
+    int : 32;
+
+    static inline MIDR_EL1 read()
+    {
+        MIDR_EL1 affinity_register;
+
+        asm("mrs %[value], MIDR_EL1"
+            : [value] "=r"(affinity_register));
+
+        return affinity_register;
+    }
+};
+static_assert(sizeof(MIDR_EL1) == 8);
+
 // https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/HCR-EL2--Hypervisor-Configuration-Register
 // Hypervisor Configuration Register
 struct alignas(u64) HCR_EL2 {

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -762,4 +762,19 @@ struct alignas(u64) NZCV {
 };
 static_assert(sizeof(NZCV) == 8);
 
+// https://developer.arm.com/documentation/ddi0595/2021-03/AArch64-Registers/PMCCNTR-EL0--Performance-Monitors-Cycle-Count-Register
+// PMCCNTR_EL0, Performance Monitors Cycle Count Register
+struct alignas(u64) PMCCNTR_EL0 {
+    u64 CCNT : 64;
+
+    static inline PMCCNTR_EL0 read()
+    {
+        PMCCNTR_EL0 pmccntr_el0;
+        asm volatile("mrs %[value], pmccntr_el0"
+                     : [value] "=r"(pmccntr_el0));
+        return pmccntr_el0;
+    }
+};
+static_assert(sizeof(PMCCNTR_EL0) == 8);
+
 }

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -102,6 +102,24 @@ struct alignas(u64) ID_AA64MMFR0_EL1 {
 };
 static_assert(sizeof(ID_AA64MMFR0_EL1) == 8);
 
+// https://developer.arm.com/documentation/ddi0595/2020-12/AArch64-Registers/CNTFRQ-EL0--Counter-timer-Frequency-register
+// CNTFRQ_EL0, Counter-timer Frequency register
+struct alignas(u64) CNTFRQ_EL0 {
+    int : 32;
+    int ClockFrequency : 32;
+
+    static inline CNTFRQ_EL0 read()
+    {
+        CNTFRQ_EL0 frequency;
+
+        asm("mrs %[value], CNTFRQ_EL0"
+            : [value] "=r"(frequency));
+
+        return frequency;
+    }
+};
+static_assert(sizeof(CNTFRQ_EL0) == 8);
+
 // https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/TCR-EL1--Translation-Control-Register--EL1-
 // Translation Control Register
 struct alignas(u64) TCR_EL1 {

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, James Mintram <me@jamesrm.com>
  * Copyright (c) 2021, Marcin Undak <mcinek@gmail.com>
+ * Copyright (c) 2022, Konrad <konrad@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -12,6 +13,38 @@
 #include <AK/Types.h>
 
 namespace Kernel::Aarch64 {
+
+// https://developer.arm.com/documentation/ddi0601/2022-09/AArch64-Registers/ID-AA64ISAR0-EL1--AArch64-Instruction-Set-Attribute-Register-0?lang=en
+// ID_AA64ISAR0_EL1, AArch64 Instruction Set Attribute Register 0
+struct alignas(u64) ID_AA64ISAR0_EL1 {
+    int : 4;
+    int AES : 4;
+    int SHA1 : 4;
+    int SHA2 : 4;
+    int CRC32 : 4;
+    int Atomic : 4;
+    int TME : 4;
+    int RDM : 4;
+    int SHA3 : 4;
+    int SM3 : 4;
+    int SM4 : 4;
+    int DP : 4;
+    int FHM : 4;
+    int TS : 4;
+    int TLB : 4;
+    int RNDR : 4;
+
+    static inline ID_AA64ISAR0_EL1 read()
+    {
+        ID_AA64ISAR0_EL1 feature_register;
+
+        asm("mrs %[value], ID_AA64ISAR0_EL1"
+            : [value] "=r"(feature_register));
+
+        return feature_register;
+    }
+};
+static_assert(sizeof(ID_AA64ISAR0_EL1) == 8);
 
 // https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/ID-AA64MMFR0-EL1--AArch64-Memory-Model-Feature-Register-0
 // Memory Model Feature Register 0

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -741,4 +741,25 @@ struct DAIF {
     }
 };
 static_assert(sizeof(DAIF) == 8);
+
+// https://developer.arm.com/documentation/ddi0595/2021-03/AArch64-Registers/NZCV--Condition-Flags
+// NZCV, Condition Flags
+struct alignas(u64) NZCV {
+    u64 : 28;
+    u64 V : 1;
+    u64 C : 1;
+    u64 Z : 1;
+    u64 N : 1;
+    u64 : 32;
+
+    static inline NZCV read()
+    {
+        NZCV nzcv;
+        asm volatile("mrs %[value], nzcv"
+                     : [value] "=r"(nzcv));
+        return nzcv;
+    }
+};
+static_assert(sizeof(NZCV) == 8);
+
 }


### PR DESCRIPTION
This PR is a one in the series Iʼll propose as a split from [broader draft PR](https://github.com/SerenityOS/serenity/pull/16622) I wasnʼt able to handle correctly.