### PR TITLE
Hackstudio: Use `GUI::TextEditor` actions for cut/copy/paste buttons

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1171,6 +1171,7 @@ void HackStudioWidget::set_current_editor_wrapper(RefPtr<EditorWrapper> editor_w
     update_window_title();
     update_current_editor_title();
     update_tree_view();
+    update_toolbar_actions();
     set_current_editor_tab_widget(static_cast<GUI::TabWidget*>(m_current_editor_wrapper->parent()));
     m_current_editor_tab_widget->set_active_widget(editor_wrapper);
     update_statusbar();
@@ -1263,9 +1264,9 @@ void HackStudioWidget::create_toolbar(GUI::Widget& parent)
     toolbar.add_action(*m_delete_action);
     toolbar.add_separator();
 
-    toolbar.add_action(GUI::CommonActions::make_cut_action([this](auto&) { current_editor().cut_action().activate(); }, m_editors_splitter));
-    toolbar.add_action(GUI::CommonActions::make_copy_action([this](auto&) { current_editor().copy_action().activate(); }, m_editors_splitter));
-    toolbar.add_action(GUI::CommonActions::make_paste_action([this](auto&) { current_editor().paste_action().activate(); }, m_editors_splitter));
+    m_cut_button = toolbar.add_action(current_editor().cut_action());
+    m_copy_button = toolbar.add_action(current_editor().copy_action());
+    m_paste_button = toolbar.add_action(current_editor().paste_action());
     toolbar.add_separator();
     toolbar.add_action(GUI::CommonActions::make_undo_action([this](auto&) { current_editor().undo_action().activate(); }, m_editors_splitter));
     toolbar.add_action(GUI::CommonActions::make_redo_action([this](auto&) { current_editor().redo_action().activate(); }, m_editors_splitter));
@@ -1651,6 +1652,13 @@ void HackStudioWidget::update_tree_view()
         m_project_tree_view->expand_all_parents_of(index);
         m_project_tree_view->set_cursor(index, GUI::AbstractView::SelectionUpdate::Set);
     }
+}
+
+void HackStudioWidget::update_toolbar_actions()
+{
+    m_copy_button->set_action(current_editor().copy_action());
+    m_paste_button->set_action(current_editor().paste_action());
+    m_cut_button->set_action(current_editor().cut_action());
 }
 
 void HackStudioWidget::update_window_title()

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -16,6 +16,7 @@
 #include "GMLPreviewWidget.h"
 #include "Git/DiffViewer.h"
 #include "Git/GitWidget.h"
+#include "LibGUI/Button.h"
 #include "Locator.h"
 #include "Project.h"
 #include "ProjectBuilder.h"
@@ -163,6 +164,7 @@ private:
 
     void update_gml_preview();
     void update_tree_view();
+    void update_toolbar_actions();
     void on_cursor_change();
     void file_renamed(DeprecatedString const& old_name, DeprecatedString const& new_name);
 
@@ -256,6 +258,10 @@ private:
     RefPtr<GUI::Action> m_no_wrapping_action;
     RefPtr<GUI::Action> m_wrap_anywhere_action;
     RefPtr<GUI::Action> m_wrap_at_words_action;
+
+    RefPtr<GUI::Button> m_cut_button;
+    RefPtr<GUI::Button> m_paste_button;
+    RefPtr<GUI::Button> m_copy_button;
 
     Mode m_mode { Mode::Code };
     OwnPtr<Coredump::Inspector> m_coredump_inspector;


### PR DESCRIPTION
This fixes a bug where hackstudio's language server would crash upon clicking the 'cut' button when no text is selected.  This was because the actions were not disabled on empty selection.

We now disable the actions if there is empty selection inside the editor. To do this, we first store the button references inside the widget and update their actions when updating the current editor (for example: when changing the tabs).

Before:
Upon Selection (Take note of the cut,copy and paste buttons):
![grafik](https://user-images.githubusercontent.com/19624096/209448612-59489b94-838f-4b65-bdaa-412ef497e5be.png)

Upon Deselection:
![grafik](https://user-images.githubusercontent.com/19624096/209448601-2e61b828-b180-4fc4-b4af-e266d015f77f.png)

 
After:

Upon Selection:
![grafik](https://user-images.githubusercontent.com/19624096/209448539-137b1f0b-0330-4b3c-b4fb-f5f394af9195.png)

Upon Deselection:
![grafik](https://user-images.githubusercontent.com/19624096/209448522-70a2bfbd-f6cd-4dba-bb0a-a765c34c2589.png)
