### PR TITLE
LibWeb: Inherit or default a property when `--var`

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -773,6 +773,14 @@ RefPtr<StyleValue> StyleComputer::resolve_unresolved_style_value(DOM::Element& e
     if (auto parsed_value = Parser::Parser::parse_css_value({}, Parser::ParsingContext { document() }, property_id, expanded_values))
         return parsed_value.release_nonnull();
 
+    if (expanded_values.is_empty()) {
+        auto const* parent_element = element.parent_or_shadow_host_element();
+        if (!parent_element || !parent_element->computed_css_values())
+            return property_initial_value(property_id);
+        if (auto property_or_null = parent_element->computed_css_values()->maybe_null_property(property_id))
+            return property_or_null.release_nonnull();
+        return property_initial_value(property_id);
+    }
     return {};
 }
 


### PR DESCRIPTION
... couldn't be resolved in the current context.

[The Standard](https://www.w3.org/TR/css-variables-1/#invalid-variables) suggests that an invalid variable of a property resolves to the inherited value of the property or the default value of the property.

This commit lays the foundation for the concept. The introduced check seems a bit hacky, but achieves the point. A major concern is the `computed_css_values()->maybe_null_property(property_id)` call. Empirical tests showed, that we crash on `nullptr` because the computed property of the parent is null. This is solved by defaulting to the initial value in this case.

I am sure this could be handled better and seems like this is only scratching a symptom of a order of execution problem. It seems to me that it would make more sense to have every property of the respective parent element computed at this point.

# Note
Initially i just wanted to fix this problem of a color mismatch but on testing I encountered numerous problems with the computed_css_values(). Help would be nice :^)

# Testcase
```css
.define-it {
   --myvar: green
}
.apply-it {
   color: var(--myvar).
}
```
```html
<div style="color: red">
  <a class="define-it apply-it">defined</a>
  <a class="apply-it">not defined (should be inherited)</a>
</div>

<div>
  <a class="define-it apply-it">defined</a>
  <a class="apply-it">not defined (should be initial)</a>
</div>
```
![image](https://user-images.githubusercontent.com/39677514/209451869-62fcfbcf-a83b-4dc8-897d-f391aff4b928.png)
![image](https://user-images.githubusercontent.com/39677514/209451873-88b7fef6-88e1-425a-a086-a42173515e0b.png)

