### PR TITLE
Presenter: Add font styles for texts

### DIFF
--- a/Userland/Applications/Presenter/SlideObject.cpp
+++ b/Userland/Applications/Presenter/SlideObject.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/Stream.h>
 #include <LibGUI/Margins.h>
 #include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/FontStyleMapping.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Orientation.h>
 #include <LibGfx/Painter.h>
@@ -80,6 +81,7 @@ Text::Text()
     REGISTER_TEXT_ALIGNMENT_PROPERTY("text-alignment", text_alignment, set_text_alignment);
     REGISTER_INT_PROPERTY("font-size", font_size, set_font_size);
     REGISTER_STRING_PROPERTY("font", font, set_font);
+    REGISTER_STRING_PROPERTY("font-style", font_style, set_font_style);
 }
 
 void Text::paint(Gfx::Painter& painter, Gfx::FloatSize display_scale) const
@@ -87,7 +89,7 @@ void Text::paint(Gfx::Painter& painter, Gfx::FloatSize display_scale) const
     auto scaled_bounding_box = this->transformed_bounding_box(painter.clip_rect(), display_scale);
 
     auto scaled_font_size = display_scale.height() * static_cast<float>(m_font_size);
-    auto font = Gfx::FontDatabase::the().get(m_font, scaled_font_size, m_font_weight, 0, Gfx::Font::AllowInexactSizeMatch::Yes);
+    auto font = Gfx::FontDatabase::the().get(m_font, scaled_font_size, m_font_weight, Gfx::name_to_slope(m_font_style), Gfx::Font::AllowInexactSizeMatch::Yes);
     if (font.is_null())
         font = Gfx::FontDatabase::default_font();
 

--- a/Userland/Applications/Presenter/SlideObject.h
+++ b/Userland/Applications/Presenter/SlideObject.h
@@ -82,6 +82,8 @@ public:
     Gfx::TextAlignment text_alignment() const { return m_text_alignment; }
     void set_text(DeprecatedString text) { m_text = move(text); }
     StringView text() const { return m_text; }
+    void set_font_style(DeprecatedString font_style) { m_font_style = move(font_style); }
+    StringView font_style() const { return m_font_style; }
 
 protected:
     DeprecatedString m_text;
@@ -90,6 +92,7 @@ protected:
     int m_font_size { 18 };
     unsigned m_font_weight { Gfx::FontWeight::Regular };
     Gfx::TextAlignment m_text_alignment { Gfx::TextAlignment::CenterLeft };
+    DeprecatedString m_font_style;
 };
 
 // How to scale an image object.


### PR DESCRIPTION
Defaults to 'Regular' if not specified.

Makes progress on #15767  for adding text font styles. 

![image](https://user-images.githubusercontent.com/55517183/209456101-dfa171f5-8396-464c-bf3f-f19df9cc00c4.png)
