### PR TITLE
LibAudio: Fixes to allow playing wavs with sample rates lower than 44100

### DIFF
--- a/Userland/Applications/SoundPlayer/main.cpp
+++ b/Userland/Applications/SoundPlayer/main.cpp
@@ -26,13 +26,13 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath thread unix"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath thread unix proc"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     auto audio_client = TRY(Audio::ConnectionToServer::try_create());
     auto decoder_client = TRY(ImageDecoderClient::Client::try_create());
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath thread"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath thread proc"));
 
     auto app_icon = GUI::Icon::default_icon("app-sound-player"sv);
 

--- a/Userland/Libraries/LibAudio/ConnectionToServer.cpp
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.cpp
@@ -55,7 +55,8 @@ void ConnectionToServer::die()
             m_enqueuer_loop->quit(0);
         }
     }
-    (void)m_background_audio_enqueuer->join();
+    if (m_background_audio_enqueuer->is_started())
+        (void)m_background_audio_enqueuer->join();
 }
 
 ErrorOr<void> ConnectionToServer::async_enqueue(FixedArray<Sample>&& samples)

--- a/Userland/Libraries/LibAudio/Resampler.h
+++ b/Userland/Libraries/LibAudio/Resampler.h
@@ -62,7 +62,8 @@ public:
     template<ArrayLike<SampleType> Samples, size_t vector_inline_capacity = 0>
     ErrorOr<void> try_resample_into_end(Vector<SampleType, vector_inline_capacity>& destination, Samples&& to_resample)
     {
-        TRY(destination.try_ensure_capacity(destination.size() + to_resample.size() * ceil_div(m_source, m_target)));
+        float ratio = (m_source > m_target) ? static_cast<float>(m_source) / m_target : static_cast<float>(m_target) / m_source;
+        TRY(destination.try_ensure_capacity(destination.size() + to_resample.size() * ratio));
         for (auto sample : to_resample) {
             process_sample(sample, sample);
 


### PR DESCRIPTION
This recording of Africa by Toto has a sample rate of 22050. https://www.ee.columbia.edu/~dpwe/sounds/music/africa-toto.wav

Before these changes, trying to play it in aplay, SoundPlayer, or Piano would crash the respective applications.

SoundPlayer crashed previously because it was missing a proc pledge, which seems unrelated to the actual issue.

Resampler::try_resample_into_end used integer division to try to figure out the new sample rate that should be used, which is almost never correct when the original sample rate is not an exact integer multiple of 44100, and that integer multiple is > 1.

Also fix an issue where it was trivial to get aplay, SoundPlayer and Piano to crash on exit by checking that we actually started the background audio thread before trying to join it: not doing this now asserts.

Note that SoundPlayer can now play the track and it sounds glitchy, while aplay tries to play it at like, 1/4 speed.