### PR TITLE
Shell: Add where builtin

### DIFF
--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -25,6 +25,7 @@
 
 #define ENUMERATE_SHELL_BUILTINS()     \
     __ENUMERATE_SHELL_BUILTIN(alias)   \
+    __ENUMERATE_SHELL_BUILTIN(where)   \
     __ENUMERATE_SHELL_BUILTIN(cd)      \
     __ENUMERATE_SHELL_BUILTIN(cdh)     \
     __ENUMERATE_SHELL_BUILTIN(pwd)     \


### PR DESCRIPTION
# Note
I know we have the `which` executable which's feature-set overlaps with this. But this PR creates the more
general version and use case of the which command: The `where` builtin.

The command is based on the behavior of the z-shell.
Namely it tries to resolve every argument one by one.

When resolving (in the order below) the following results can occur:
  1. The argument is a shell built-in command. Then print it.
  2. The argument is an alias. In this case we print the mapped value.
  3. The argument was found in the `PATH` environment variable.
     In this case we print the resolved absolute path and try to find more occurrences in the `PATH`
  4. None of the above. If no earlier argument in the argument list got resolved,
     we print the error `{argument} not found`.

If at least one argument got resolved, we return with exit code 0, otherwise 1.

The builtin has the following flags to modify the behaviour according
to the users needs:
  - `-p --path-only`: This skips the built-in and alias checks
  (step 1 & 2)
  - `-s --follow-symlink`: This follows the symlinks of an executable to
  its symlink-free location.
  - `-w --type`: This displays the type of the found object
  without any additional descriptive information.

# Example
![image](https://user-images.githubusercontent.com/39677514/209467031-b2b6cd43-49eb-40a6-b518-c26a45c4b4bc.png)

