### PR TITLE
AK: Remove tilde from URL::PercentEncodeSet::EncodeURI

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -406,7 +406,7 @@ bool URL::code_point_is_in_percent_encode_set(u32 code_point, URL::PercentEncode
     case URL::PercentEncodeSet::EncodeURI:
         // NOTE: This is the same percent encode set that JS encodeURI() uses.
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
-        return code_point >= 0x7E || (!is_ascii_alphanumeric(code_point) && !";,/?:@&=+$-_.!~*'()#"sv.contains(static_cast<char>(code_point)));
+        return code_point > 0x7E || (!is_ascii_alphanumeric(code_point) && !";,/?:@&=+$-_.!~*'()#"sv.contains(static_cast<char>(code_point)));
     default:
         VERIFY_NOT_REACHED();
     }


### PR DESCRIPTION
Per RFC 3986, tilde is an unreserved character and should not be percent-encoded.

https://www.rfc-editor.org/rfc/rfc3986#section-2.3