### PR TITLE
LibWeb: Fix out of bounds grid error in Github

### DIFF
--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -139,7 +139,17 @@ that I don't quite understand. -->
   ">
   <div class="grid-item">1</div>
 </div>
-  
+
+<!-- Row-gaps with overflowing row spans. Github bug-->
+<div 
+    class="grid-container"
+    style="
+        grid-row-gap: 16px;
+        grid-template-rows: 1fr 1fr;
+    ">
+    <div class="grid-item" style="grid-row: 2 / span 3;">1</div>
+</div>
+
 <p>End of crash tests</p>
 
 <!-- Different column sizes -->

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1761,15 +1761,19 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
     };
 
     for (auto& positioned_box : positioned_boxes) {
-        auto row_span_without_overflows = positioned_box.row + positioned_box.row_span > static_cast<int>(m_grid_rows.size()) ? static_cast<int>(m_grid_rows.size()) - positioned_box.row : positioned_box.row_span;
-
         auto resolved_row_start = box.computed_values().row_gap().is_auto() ? positioned_box.row : positioned_box.row * 2;
-        auto resolved_row_end = ((positioned_box.row + row_span_without_overflows) * 2) - 1;
-        auto resolved_row_span = box.computed_values().row_gap().is_auto() ? row_span_without_overflows : resolved_row_end - resolved_row_start;
+        auto resolved_row_span = box.computed_values().row_gap().is_auto() ? positioned_box.row_span : positioned_box.row_span * 2;
+        if (!box.computed_values().row_gap().is_auto() && resolved_row_start == 0)
+            resolved_row_span -= 1;
+        if (resolved_row_start + resolved_row_span > static_cast<int>(m_grid_rows.size()))
+            resolved_row_span = m_grid_rows.size() - resolved_row_start;
 
         auto resolved_column_start = box.computed_values().column_gap().is_auto() ? positioned_box.column : positioned_box.column * 2;
-        auto resolved_column_end = ((positioned_box.column + positioned_box.column_span) * 2) - 1;
-        auto resolved_column_span = box.computed_values().column_gap().is_auto() ? positioned_box.column_span : resolved_column_end - resolved_column_start;
+        auto resolved_column_span = box.computed_values().column_gap().is_auto() ? positioned_box.column_span : positioned_box.column_span * 2;
+        if (!box.computed_values().column_gap().is_auto() && resolved_column_start == 0)
+            resolved_column_span -= 1;
+        if (resolved_column_start + resolved_column_span > static_cast<int>(m_grid_columns.size()))
+            resolved_column_span = m_grid_columns.size() - resolved_column_start;
 
         layout_box(
             resolved_row_start,


### PR DESCRIPTION
This fixes a bug found in PR #16658  where grids with the gap properties would trigger out of bounds errors when the {row,column} spans were too large.