### PR TITLE
AK: Mark Error::from_ functions as [[nodiscard]]

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -21,9 +21,9 @@ namespace AK {
 
 class Error {
 public:
-    static Error from_errno(int code) { return Error(code); }
-    static Error from_syscall(StringView syscall_name, int rc) { return Error(syscall_name, rc); }
-    static Error from_string_view(StringView string_literal) { return Error(string_literal); }
+    [[nodiscard]] static Error from_errno(int code) { return Error(code); }
+    [[nodiscard]] static Error from_syscall(StringView syscall_name, int rc) { return Error(syscall_name, rc); }
+    [[nodiscard]] static Error from_string_view(StringView string_literal) { return Error(string_literal); }
 
     // NOTE: Prefer `from_string_literal` when directly typing out an error message:
     //
@@ -32,7 +32,7 @@ public:
     // If you need to return a static string based on a dynamic condition (like
     // picking an error from an array), then prefer `from_string_view` instead.
     template<size_t N>
-    ALWAYS_INLINE static Error from_string_literal(char const (&string_literal)[N])
+    [[nodiscard]] ALWAYS_INLINE static Error from_string_literal(char const (&string_literal)[N])
     {
         return from_string_view(StringView { string_literal, N - 1 });
     }

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -415,7 +415,7 @@ ErrorOr<void> DeflateDecompressor::decode_codes(CanonicalCode& literal_code, Opt
 
     auto literal_code_result = CanonicalCode::from_bytes(code_lengths.span().trim(literal_code_count));
     if (!literal_code_result.has_value())
-        Error::from_string_literal("Failed to decode the literal code");
+        return Error::from_string_literal("Failed to decode the literal code");
     literal_code = literal_code_result.value();
 
     // Now we extract the code that was used to encode distances in the block.
@@ -431,7 +431,7 @@ ErrorOr<void> DeflateDecompressor::decode_codes(CanonicalCode& literal_code, Opt
 
     auto distance_code_result = CanonicalCode::from_bytes(code_lengths.span().slice(literal_code_count));
     if (!distance_code_result.has_value())
-        Error::from_string_literal("Failed to decode the distance code");
+        return Error::from_string_literal("Failed to decode the distance code");
     distance_code = distance_code_result.value();
 
     return {};


### PR DESCRIPTION
Prevents mistakes like the one fixed in #16672.