### PR TITLE
Calculator: Support repeating, chaining operations and other improvements

### DIFF
--- a/Userland/Applications/Calculator/Calculator.cpp
+++ b/Userland/Applications/Calculator/Calculator.cpp
@@ -12,6 +12,12 @@
 
 Optional<Crypto::BigFraction> Calculator::operation_with_literal_argument(Operation operation, Crypto::BigFraction argument)
 {
+    // Support binary operations with percentages, for example "2+3%" == 2.06
+    if (m_binary_operation_in_progress != Operation::None && operation == Operation::Percent) {
+        argument = m_binary_operation_saved_left_side * Crypto::BigFraction { 1, 100 } * argument;
+        operation = Operation::None; // Don't apply the "%" operation twice
+    }
+
     // If a previous operation is still in progress, finish it
     // Makes hitting "1+2+3=" equivalent to hitting "1+2=+3="
     if (m_binary_operation_in_progress != Operation::None) {
@@ -20,7 +26,8 @@ Optional<Crypto::BigFraction> Calculator::operation_with_literal_argument(Operat
 
     switch (operation) {
     case Operation::None:
-        VERIFY_NOT_REACHED();
+        m_current_value = argument;
+        break;
 
     case Operation::Add:
     case Operation::Subtract:

--- a/Userland/Applications/Calculator/Calculator.h
+++ b/Userland/Applications/Calculator/Calculator.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <LibCrypto/BigFraction/BigFraction.h>
 
 // This type implements the regular calculator
@@ -36,11 +37,13 @@ public:
         MemClear,
         MemRecall,
         MemSave,
-        MemAdd
+        MemAdd,
+
+        Equals
     };
 
-    Crypto::BigFraction begin_operation(Operation, Crypto::BigFraction);
-    Crypto::BigFraction finish_operation(Crypto::BigFraction);
+    Optional<Crypto::BigFraction> operation_with_literal_argument(Operation, Crypto::BigFraction);
+    Optional<Crypto::BigFraction> operation_without_argument(Operation);
 
     bool has_error() const { return m_has_error; }
 
@@ -48,8 +51,16 @@ public:
     void clear_error() { m_has_error = false; }
 
 private:
-    Operation m_operation_in_progress { Operation::None };
-    Crypto::BigFraction m_saved_argument {};
     Crypto::BigFraction m_mem {};
+
+    Crypto::BigFraction m_current_value {};
+
+    Operation m_binary_operation_in_progress { Operation::None };
+    Crypto::BigFraction m_binary_operation_saved_left_side {};
+
+    Operation m_previous_operation { Operation::None };
+    Crypto::BigFraction m_previous_binary_operation_right_side {};
     bool m_has_error { false };
+
+    Crypto::BigFraction finish_binary_operation(Crypto::BigFraction const& left_side, Operation operation, Crypto::BigFraction const& right_side);
 };

--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -159,7 +159,8 @@ void CalculatorWidget::keydown_event(GUI::KeyEvent& event)
         m_keypad.set_value(m_calculator.finish_operation(m_keypad.value()));
         mimic_pressed_button(m_equals_button);
     } else if (event.code_point() >= '0' && event.code_point() <= '9') {
-        auto const digit = m_keypad.type_digit(event.code_point() - '0');
+        auto const digit = event.code_point() - '0';
+        m_keypad.type_digit(digit);
         mimic_pressed_button(m_digit_button[digit]);
     } else if (event.code_point() == '.') {
         m_keypad.type_decimal_point();

--- a/Userland/Applications/Calculator/Keypad.cpp
+++ b/Userland/Applications/Calculator/Keypad.cpp
@@ -135,6 +135,11 @@ DeprecatedString Keypad::to_deprecated_string() const
     return builder.to_deprecated_string();
 }
 
+bool Keypad::in_typing_state() const
+{
+    return m_state == State::TypingDecimal || m_state == State::TypingInteger;
+}
+
 void Keypad::set_rounding_length(unsigned rounding_threshold)
 {
     m_displayed_fraction_length = rounding_threshold;

--- a/Userland/Applications/Calculator/Keypad.cpp
+++ b/Userland/Applications/Calculator/Keypad.cpp
@@ -12,7 +12,7 @@
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibCrypto/NumberTheory/ModularFunctions.h>
 
-unsigned Keypad::type_digit(int digit)
+void Keypad::type_digit(int digit)
 {
     switch (m_state) {
     case State::External:
@@ -34,7 +34,6 @@ unsigned Keypad::type_digit(int digit)
         m_frac_length.set_to(m_frac_length.plus(1));
         break;
     }
-    return m_frac_length.to_u64();
 }
 
 void Keypad::type_decimal_point()

--- a/Userland/Applications/Calculator/Keypad.h
+++ b/Userland/Applications/Calculator/Keypad.h
@@ -21,7 +21,7 @@ public:
     Keypad() = default;
     ~Keypad() = default;
 
-    unsigned type_digit(int digit);
+    void type_digit(int digit);
     void type_decimal_point();
     void type_backspace();
 

--- a/Userland/Applications/Calculator/Keypad.h
+++ b/Userland/Applications/Calculator/Keypad.h
@@ -35,6 +35,8 @@ public:
 
     DeprecatedString to_deprecated_string() const;
 
+    bool in_typing_state() const;
+
 private:
     // Internal representation of the current decimal value.
     // Those variables are only used when the user is entering a value.


### PR DESCRIPTION
Make the calculator behave a bit more like a physical desktop calculator:

- Fix key animations when using the keyboard (ec3ec22)
- Add support for chaining binary operations, like "1+2+3" (which would previously evaluate as 5)  
![GIF of 1+2+3](https://user-images.githubusercontent.com/6043048/209569496-90a4514b-6052-408e-822a-33976e3c5291.gif)
- Add support for hitting "=" repeatedly to repeat last addition/subtraction/multiplication/division  
![GIF of repeatedly hitting "="](https://user-images.githubusercontent.com/6043048/209569585-3b9ca472-2ca7-4a67-ad68-b2f50847b17b.gif)
- Make the percent key calculate a percentage of the left side o when used in an addition/subtraction/multiplication/division  
![GIF of calculating 25% of 30](https://user-images.githubusercontent.com/6043048/209569733-f433534b-72c2-4ce4-9a7a-7c98f487bb92.gif)
- Make it possible to change our mind when selecting addition/subtraction/multiplication/division  
![GIF of "2+-*/3"](https://user-images.githubusercontent.com/6043048/209569987-8455c14e-0ea5-4d73-b49b-6dc05e4c5601.gif)

:^)