### PR TITLE
LibCompress(+LibCore): Port `ZlibCompressor` to `Core::Stream`

### DIFF
--- a/Tests/LibCompress/TestZlib.cpp
+++ b/Tests/LibCompress/TestZlib.cpp
@@ -20,7 +20,7 @@ TEST_CASE(zlib_decompress_simple)
 
     const u8 uncompressed[] = "This is a simple text file :)";
 
-    auto const decompressed = Compress::Zlib::decompress_all(compressed);
+    auto const decompressed = Compress::ZlibDecompressor::decompress_all(compressed);
     EXPECT(decompressed.value().bytes() == (ReadonlyBytes { uncompressed, sizeof(uncompressed) - 1 }));
 }
 

--- a/Tests/LibCompress/TestZlib.cpp
+++ b/Tests/LibCompress/TestZlib.cpp
@@ -23,3 +23,22 @@ TEST_CASE(zlib_decompress_simple)
     auto const decompressed = Compress::Zlib::decompress_all(compressed);
     EXPECT(decompressed.value().bytes() == (ReadonlyBytes { uncompressed, sizeof(uncompressed) - 1 }));
 }
+
+TEST_CASE(zlib_compress_simple)
+{
+    // Note: This is just the output of our compression function from an arbitrary point in time.
+    // This test is intended to ensure that the decompression doesn't change unintentionally,
+    // it does not make any guarantees for correctness.
+
+    Array<u8, 37> const compressed {
+        0x78, 0x9C, 0x0B, 0xC9, 0xC8, 0x2C, 0x56, 0xC8, 0x2C, 0x56, 0x48, 0x54,
+        0x28, 0xCE, 0xCC, 0x2D, 0xC8, 0x49, 0x55, 0x28, 0x49, 0xAD, 0x28, 0x51,
+        0x48, 0xCB, 0xCC, 0x49, 0x55, 0xB0, 0xD2, 0x04, 0x00, 0x99, 0x5E, 0x09,
+        0xE8
+    };
+
+    const u8 uncompressed[] = "This is a simple text file :)";
+
+    auto const freshly_pressed = Compress::ZlibCompressor::compress_all({ uncompressed, sizeof(uncompressed) - 1 });
+    EXPECT(freshly_pressed.value().bytes() == compressed.span());
+}

--- a/Userland/Libraries/LibCompress/Zlib.h
+++ b/Userland/Libraries/LibCompress/Zlib.h
@@ -42,16 +42,16 @@ struct ZlibHeader {
 };
 static_assert(sizeof(ZlibHeader) == sizeof(u16));
 
-class Zlib {
+class ZlibDecompressor {
 public:
     Optional<ByteBuffer> decompress();
     u32 checksum();
 
-    static Optional<Zlib> try_create(ReadonlyBytes data);
+    static Optional<ZlibDecompressor> try_create(ReadonlyBytes data);
     static Optional<ByteBuffer> decompress_all(ReadonlyBytes);
 
 private:
-    Zlib(ZlibHeader, ReadonlyBytes data);
+    ZlibDecompressor(ZlibHeader, ReadonlyBytes data);
 
     ZlibHeader m_header;
 

--- a/Userland/Libraries/LibCompress/Zlib.h
+++ b/Userland/Libraries/LibCompress/Zlib.h
@@ -62,21 +62,22 @@ private:
 
 class ZlibCompressor : public OutputStream {
 public:
-    ZlibCompressor(OutputStream&, ZlibCompressionLevel = ZlibCompressionLevel::Default);
+    static ErrorOr<NonnullOwnPtr<ZlibCompressor>> construct(OutputStream&, ZlibCompressionLevel = ZlibCompressionLevel::Default);
     ~ZlibCompressor();
 
     size_t write(ReadonlyBytes) override;
     bool write_or_error(ReadonlyBytes) override;
     void finish();
 
-    static Optional<ByteBuffer> compress_all(ReadonlyBytes bytes, ZlibCompressionLevel = ZlibCompressionLevel::Default);
+    static ErrorOr<ByteBuffer> compress_all(ReadonlyBytes bytes, ZlibCompressionLevel = ZlibCompressionLevel::Default);
 
 private:
+    ZlibCompressor(OutputStream&, ZlibCompressionLevel);
     void write_header(ZlibCompressionMethod, ZlibCompressionLevel);
 
     bool m_finished { false };
     OutputBitStream m_output_stream;
-    OwnPtr<OutputStream> m_compressor;
+    NonnullOwnPtr<OutputStream> m_compressor;
     Crypto::Checksum::Adler32 m_adler32_checksum;
 };
 

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -830,4 +830,33 @@ bool WrapInAKInputStream::discard_or_error(size_t count)
     return true;
 }
 
+WrapInAKOutputStream::WrapInAKOutputStream(Core::Stream::Stream& stream)
+    : m_stream(stream)
+{
+}
+
+size_t WrapInAKOutputStream::write(ReadonlyBytes bytes)
+{
+    if (has_any_error())
+        return 0;
+
+    auto length_or_error = m_stream.write(bytes);
+    if (length_or_error.is_error()) {
+        set_fatal_error();
+        return 0;
+    }
+
+    return length_or_error.value();
+}
+
+bool WrapInAKOutputStream::write_or_error(ReadonlyBytes bytes)
+{
+    if (write(bytes) < bytes.size()) {
+        set_fatal_error();
+        return false;
+    }
+
+    return true;
+}
+
 }

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -1042,4 +1042,15 @@ private:
     Core::Stream::Stream& m_stream;
 };
 
+// Note: This is only a temporary hack, to break up the task of moving away from AK::Stream into smaller parts.
+class WrapInAKOutputStream final : public OutputStream {
+public:
+    WrapInAKOutputStream(Core::Stream::Stream& stream);
+    virtual size_t write(ReadonlyBytes) override;
+    virtual bool write_or_error(ReadonlyBytes) override;
+
+private:
+    Core::Stream::Stream& m_stream;
+};
+
 }

--- a/Userland/Libraries/LibGfx/Font/WOFF/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/WOFF/Font.cpp
@@ -120,7 +120,7 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_externally_owned_memory(Readonl
         if (font_buffer_offset + orig_length > font_buffer.size())
             return Error::from_string_literal("Uncompressed WOFF table too big");
         if (comp_length < orig_length) {
-            auto decompressed = Compress::Zlib::decompress_all(buffer.slice(offset, comp_length));
+            auto decompressed = Compress::ZlibDecompressor::decompress_all(buffer.slice(offset, comp_length));
             if (!decompressed.has_value())
                 return Error::from_string_literal("Could not decompress WOFF table");
             if (orig_length != decompressed->size())

--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -707,7 +707,7 @@ static ErrorOr<void> decode_png_bitmap(PNGLoadingContext& context)
     if (context.color_type == PNG::ColorType::IndexedColor && context.palette_data.is_empty())
         return Error::from_string_literal("PNGImageDecoderPlugin: Didn't see a PLTE chunk for a palletized image, or it was empty.");
 
-    auto result = Compress::Zlib::decompress_all(context.compressed_data.span());
+    auto result = Compress::ZlibDecompressor::decompress_all(context.compressed_data.span());
     if (!result.has_value()) {
         context.state = PNGLoadingContext::State::Error;
         return Error::from_string_literal("PNGImageDecoderPlugin: Decompression failed");

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -264,11 +264,7 @@ ErrorOr<void> PNGWriter::add_IDAT_chunk(Gfx::Bitmap const& bitmap)
         TRY(uncompressed_block_data.try_append(best_filter.buffer));
     }
 
-    auto maybe_zlib_buffer = Compress::ZlibCompressor::compress_all(uncompressed_block_data, Compress::ZlibCompressionLevel::Best);
-    if (!maybe_zlib_buffer.has_value()) {
-        return Error::from_string_literal("PNGWriter: ZlibCompressor failed");
-    }
-    auto zlib_buffer = maybe_zlib_buffer.release_value();
+    auto zlib_buffer = TRY(Compress::ZlibCompressor::compress_all(uncompressed_block_data, Compress::ZlibCompressionLevel::Best));
 
     TRY(png_chunk.add(zlib_buffer.data(), zlib_buffer.size()));
     TRY(add_chunk(png_chunk));

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -51,12 +51,12 @@ static ErrorOr<ByteBuffer> handle_content_encoding(ByteBuffer const& buf, Deprec
 
         // Even though the content encoding is "deflate", it's actually deflate with the zlib wrapper.
         // https://tools.ietf.org/html/rfc7230#section-4.2.2
-        auto uncompressed = Compress::Zlib::decompress_all(buf);
+        auto uncompressed = Compress::ZlibDecompressor::decompress_all(buf);
         if (!uncompressed.has_value()) {
             // From the RFC:
             // "Note: Some non-conformant implementations send the "deflate"
             //        compressed data without the zlib wrapper."
-            dbgln_if(JOB_DEBUG, "Job::handle_content_encoding: Zlib::decompress_all() failed. Trying DeflateDecompressor::decompress_all()");
+            dbgln_if(JOB_DEBUG, "Job::handle_content_encoding: ZlibDecompressor::decompress_all() failed. Trying DeflateDecompressor::decompress_all()");
             uncompressed = TRY(Compress::DeflateDecompressor::decompress_all(buf));
         }
 


### PR DESCRIPTION
In case you are wondering why the usage of `OutputBitStream` is suddenly gone, Zlib itself doesn't actually require any of the bitstream-ness that was provided.