### PR TITLE
LibGfx: Improve AA stroke_path() line intersections a little 

### DIFF
--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -169,6 +169,13 @@ public:
         return rect;
     }
 
+    [[nodiscard]] Rect<T> translated(T dboth) const
+    {
+        Rect<T> rect = *this;
+        rect.translate_by(dboth);
+        return rect;
+    }
+
     [[nodiscard]] Rect<T> translated(Point<T> const& delta) const
     {
         Rect<T> rect = *this;


### PR DESCRIPTION
Mostly just removing some now unnecessary hacks and rounding, and also simplify things a little. 

This does not visually improve _much_, but it does fix (some of) the misalignment on the canvas house demo:
Before:
![image](https://user-images.githubusercontent.com/11597044/209586281-e08688cf-5494-4856-8500-73133dcb2612.png)
After:
![image](https://user-images.githubusercontent.com/11597044/209586260-f7934556-a513-4d3d-ab83-3962815dcc69.png)
