### PR TITLE
Utilities: Print arbitrary bytes in `ls` by fixing for loop in `print_escaped`

### DIFF
--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -207,12 +207,12 @@ static int print_escaped(StringView name)
         return utf8_name.length();
     }
 
-    for (int i = 0; name[i] != '\0'; i++) {
-        if (isprint(name[i])) {
-            putchar(name[i]);
+    for (auto c : name) {
+        if (isprint(c)) {
+            putchar(c);
             printed++;
         } else {
-            printed += printf("\\%03d", name[i]);
+            printed += printf("\\%03d", c);
         }
     }
 


### PR DESCRIPTION
Currently, `ls` crashes when printing certain byte sequences. This is likely due to an out-of-bounds error when iterating through the `StringView` representing the file name to be printed. We switch to using an index-based for loop to a range-based for loop. This fixes #16678.