### PR TITLE
Demos: Unify the screensavers

### DIFF
--- a/Userland/Demos/Screensaver/CMakeLists.txt
+++ b/Userland/Demos/Screensaver/CMakeLists.txt
@@ -8,4 +8,4 @@ set(SOURCES
 )
 
 serenity_app(Screensaver ICON app-screensaver)
-target_link_libraries(Screensaver PRIVATE LibGUI LibCore LibGfx LibMain)
+target_link_libraries(Screensaver PRIVATE LibDesktop LibGUI LibCore LibGfx LibMain)

--- a/Userland/Demos/Starfield/CMakeLists.txt
+++ b/Userland/Demos/Starfield/CMakeLists.txt
@@ -8,4 +8,4 @@ set(SOURCES
 )
 
 serenity_app(Starfield ICON app-starfield)
-target_link_libraries(Starfield PRIVATE LibGUI LibCore LibGfx LibMain)
+target_link_libraries(Starfield PRIVATE LibDesktop LibGUI LibCore LibGfx LibMain)

--- a/Userland/Demos/Tubes/CMakeLists.txt
+++ b/Userland/Demos/Tubes/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
 )
 
 serenity_app(Tubes ICON app-tubes)
-target_link_libraries(Tubes PRIVATE LibGUI LibCore LibGfx LibGL LibMain)
+target_link_libraries(Tubes PRIVATE LibCore LibDesktop LibGfx LibGL LibGUI LibMain)

--- a/Userland/Demos/Tubes/Tubes.cpp
+++ b/Userland/Demos/Tubes/Tubes.cpp
@@ -16,7 +16,6 @@
 #include <LibGfx/Bitmap.h>
 
 constexpr size_t grid_resolution = 15;
-constexpr int mouse_max_distance_move = 10;
 constexpr int reset_every_ticks = 900;
 constexpr double rotation_range = 35.;
 constexpr u8 tube_maximum_count = 12;
@@ -78,6 +77,7 @@ static IntVector3 vector_for_direction(Direction direction)
 Tubes::Tubes(int interval)
     : m_grid(MUST(FixedArray<u8>::try_create(grid_resolution * grid_resolution * grid_resolution)))
 {
+    on_screensaver_exit = []() { GUI::Application::the()->quit(); };
     start_timer(interval);
 }
 
@@ -147,25 +147,6 @@ bool Tubes::is_valid_grid_position(Gfx::IntVector3 position)
 void Tubes::set_grid(IntVector3 position, u8 value)
 {
     m_grid[position.z() * grid_resolution * grid_resolution + position.y() * grid_resolution + position.x()] = value;
-}
-
-void Tubes::mousemove_event(GUI::MouseEvent& event)
-{
-    if (m_mouse_origin.is_null()) {
-        m_mouse_origin = event.position();
-    } else if (event.position().distance_from(m_mouse_origin) > mouse_max_distance_move) {
-        GUI::Application::the()->quit();
-    }
-}
-
-void Tubes::mousedown_event(GUI::MouseEvent&)
-{
-    GUI::Application::the()->quit();
-}
-
-void Tubes::keydown_event(GUI::KeyEvent&)
-{
-    GUI::Application::the()->quit();
 }
 
 void Tubes::paint_event(GUI::PaintEvent& event)

--- a/Userland/Demos/Tubes/Tubes.h
+++ b/Userland/Demos/Tubes/Tubes.h
@@ -8,8 +8,8 @@
 
 #include <AK/FixedArray.h>
 #include <AK/Vector.h>
+#include <LibDesktop/Screensaver.h>
 #include <LibGL/GLContext.h>
-#include <LibGUI/Widget.h>
 #include <LibGfx/Vector3.h>
 
 enum class Direction : u8 {
@@ -31,7 +31,7 @@ struct Tube {
     double progress_to_target { 0 };
 };
 
-class Tubes final : public GUI::Widget {
+class Tubes final : public Desktop::Screensaver {
     C_OBJECT(Tubes)
 public:
     virtual ~Tubes() override = default;
@@ -51,14 +51,10 @@ private:
 
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void timer_event(Core::TimerEvent&) override;
-    virtual void keydown_event(GUI::KeyEvent&) override;
-    virtual void mousedown_event(GUI::MouseEvent& event) override;
-    virtual void mousemove_event(GUI::MouseEvent& event) override;
 
     RefPtr<Gfx::Bitmap> m_bitmap;
     FixedArray<u8> m_grid;
     OwnPtr<GL::GLContext> m_gl_context;
-    Gfx::IntPoint m_mouse_origin;
     u64 m_ticks { 0 };
     Vector<Tube> m_tubes;
 };

--- a/Userland/Demos/Tubes/main.cpp
+++ b/Userland/Demos/Tubes/main.cpp
@@ -27,16 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath prot_exec"));
 
-    auto app_icon = GUI::Icon::default_icon("app-tubes"sv);
-    auto window = TRY(GUI::Window::try_create());
-
-    window->set_double_buffering_enabled(true);
-    window->set_title("Tubes");
-    window->set_resizable(false);
-    window->set_frameless(true);
-    window->set_fullscreen(true);
-    window->set_minimizable(false);
-    window->set_icon(app_icon.bitmap_for_size(16));
+    auto window = TRY(Desktop::Screensaver::create_window("Tubes"sv, "app-tubes"sv));
     window->update();
 
     auto tubes_widget = TRY(window->try_set_main_widget<Tubes>(refresh_rate));

--- a/Userland/Libraries/LibDesktop/CMakeLists.txt
+++ b/Userland/Libraries/LibDesktop/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     AppFile.cpp
     Launcher.cpp
+    Screensaver.cpp
 )
 
 set(GENERATED_SOURCES
@@ -9,4 +10,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_lib(LibDesktop desktop)
-target_link_libraries(LibDesktop PRIVATE LibCore LibIPC LibGUI)
+target_link_libraries(LibDesktop PRIVATE LibCore LibIPC LibGfx LibGUI)

--- a/Userland/Libraries/LibDesktop/Screensaver.cpp
+++ b/Userland/Libraries/LibDesktop/Screensaver.cpp
@@ -10,6 +10,7 @@
 namespace Desktop {
 
 static constexpr int mouse_max_distance_move = 10;
+static constexpr int mouse_tracking_delay_milliseconds = 750;
 
 ErrorOr<NonnullRefPtr<GUI::Window>> Screensaver::create_window(StringView title, StringView icon)
 {
@@ -39,6 +40,10 @@ void Screensaver::mousedown_event(GUI::MouseEvent&)
 
 void Screensaver::mousemove_event(GUI::MouseEvent& event)
 {
+    auto now = AK::Time::now_monotonic();
+    if ((now - m_start_time).to_milliseconds() < mouse_tracking_delay_milliseconds)
+        return;
+
     if (!m_mouse_origin.has_value())
         m_mouse_origin = event.position();
     else if (event.position().distance_from(m_mouse_origin.value()) > mouse_max_distance_move)

--- a/Userland/Libraries/LibDesktop/Screensaver.cpp
+++ b/Userland/Libraries/LibDesktop/Screensaver.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibDesktop/Screensaver.h>
+#include <LibGUI/Icon.h>
+
+namespace Desktop {
+
+static constexpr int mouse_max_distance_move = 10;
+
+ErrorOr<NonnullRefPtr<GUI::Window>> Screensaver::create_window(StringView title, StringView icon)
+{
+    auto window = TRY(GUI::Window::try_create());
+    window->set_double_buffering_enabled(false);
+    window->set_frameless(true);
+    window->set_fullscreen(true);
+    window->set_minimizable(false);
+    window->set_resizable(false);
+    window->set_title(title);
+
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon(icon));
+    window->set_icon(app_icon.bitmap_for_size(16));
+
+    return window;
+}
+
+void Screensaver::keydown_event(GUI::KeyEvent&)
+{
+    trigger_exit();
+}
+
+void Screensaver::mousedown_event(GUI::MouseEvent&)
+{
+    trigger_exit();
+}
+
+void Screensaver::mousemove_event(GUI::MouseEvent& event)
+{
+    if (!m_mouse_origin.has_value())
+        m_mouse_origin = event.position();
+    else if (event.position().distance_from(m_mouse_origin.value()) > mouse_max_distance_move)
+        trigger_exit();
+}
+
+void Screensaver::trigger_exit()
+{
+    if (on_screensaver_exit)
+        on_screensaver_exit();
+}
+
+}

--- a/Userland/Libraries/LibDesktop/Screensaver.h
+++ b/Userland/Libraries/LibDesktop/Screensaver.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/Function.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
+#include <LibGUI/Widget.h>
+#include <LibGUI/Window.h>
+#include <LibGfx/Point.h>
+
+namespace Desktop {
+
+class Screensaver : public GUI::Widget {
+    C_OBJECT_ABSTRACT(Screensaver)
+public:
+    Function<void()> on_screensaver_exit;
+
+    static ErrorOr<NonnullRefPtr<GUI::Window>> create_window(StringView title, StringView icon);
+
+    virtual void keydown_event(GUI::KeyEvent&) override;
+    virtual void mousedown_event(GUI::MouseEvent& event) override;
+    virtual void mousemove_event(GUI::MouseEvent& event) override;
+
+private:
+    void trigger_exit();
+
+    Optional<Gfx::IntPoint> m_mouse_origin;
+};
+
+}

--- a/Userland/Libraries/LibDesktop/Screensaver.h
+++ b/Userland/Libraries/LibDesktop/Screensaver.h
@@ -10,6 +10,7 @@
 #include <AK/Function.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
+#include <AK/Time.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Point.h>
@@ -27,10 +28,17 @@ public:
     virtual void mousedown_event(GUI::MouseEvent& event) override;
     virtual void mousemove_event(GUI::MouseEvent& event) override;
 
+protected:
+    Screensaver()
+        : m_start_time(AK::Time::now_monotonic())
+    {
+    }
+
 private:
     void trigger_exit();
 
     Optional<Gfx::IntPoint> m_mouse_origin;
+    AK::Time m_start_time;
 };
 
 }


### PR DESCRIPTION
The screensavers share some logic, so centralize that into a new `Desktop::Screensaver` class. Also, jt could not demo my Tubes app since his mouse movement immediately closed the screensaver, so add some logic to prevent that from happening again.