### PR TITLE
LibWeb: Refactor and improve GridFormattingContext

### DIFF
--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -150,6 +150,13 @@ that I don't quite understand. -->
     <div class="grid-item" style="grid-row: 2 / span 3;">1</div>
 </div>
 
+<div style="
+        display: grid;
+        grid-template-columns: minmax(0, calc(100% - var(--Layout-sidebar-width) - var(--Layout-gutter))) 0 auto
+    ">
+    <div style="grid-column: 2/span 2;"></div>
+</div>
+
 <p>End of crash tests</p>
 
 <!-- Different column sizes -->
@@ -473,4 +480,41 @@ length value, and as a minimum two lengths with an auto. -->
   style="
     grid-row-end: span 3;
   ">2</div>
+</div>
+
+<!-- Column-gaps with overflowing column spans -->
+<p>There should be 1 column that starts at column 2 and spans until the end.</p>
+<div 
+    class="grid-container"
+    style="
+        grid-column-gap: 16px;
+        grid-template-columns: 1fr 1fr;
+    ">
+    <div class="grid-item" style="grid-column: 2 / span 5;">1</div>
+</div>
+
+<!-- Column-gaps with overflowing column spans and row spans -->
+<p>There should be 1 column that starts at column 2 and spans until the end.</p>
+<div 
+    class="grid-container"
+    style="
+        grid-column-gap: 16px;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 20px;
+    ">
+    <div class="grid-item" style="grid-column: 2 / span 5; grid-row: span 4">1</div>
+</div>
+
+<!-- Grid shouldn't expand to 3 columns as having too much span doesn't change size. -->
+<p>The bottom row should take up half the width of the grid.</p>
+<div 
+    class="grid-container"
+    style="
+        grid-template-columns: 1fr 1fr;
+    ">
+    <div class="grid-item" style="
+        grid-column: 1 / span 3;
+        grid-row: 1;
+    ">1</div>
+    <div class="grid-item">1</div>
 </div>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -305,19 +305,8 @@ void FlexFormattingContext::generate_anonymous_flex_items()
     HashMap<int, Vector<FlexItem>> order_item_bucket;
 
     flex_container().for_each_child_of_type<Box>([&](Box& child_box) {
-        // Skip anonymous text runs that are only whitespace.
-        if (child_box.is_anonymous() && !child_box.is_generated() && !child_box.first_child_of_type<BlockContainer>()) {
-            bool contains_only_white_space = true;
-            child_box.for_each_in_subtree([&](auto const& node) {
-                if (!is<TextNode>(node) || !static_cast<TextNode const&>(node).dom_node().data().is_whitespace()) {
-                    contains_only_white_space = false;
-                    return IterationDecision::Break;
-                }
-                return IterationDecision::Continue;
-            });
-            if (contains_only_white_space)
-                return IterationDecision::Continue;
-        }
+        if (can_skip_is_anonymous_text_run(child_box))
+            return IterationDecision::Continue;
 
         // Skip any "out-of-flow" children
         if (child_box.is_out_of_flow(*this))

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1473,4 +1473,21 @@ bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpa
         || (box.computed_values().height().contains_percentage() && !available_space.height.is_definite());
 }
 
+bool FormattingContext::can_skip_is_anonymous_text_run(Box& box)
+{
+    if (box.is_anonymous() && !box.is_generated() && !box.first_child_of_type<BlockContainer>()) {
+        bool contains_only_white_space = true;
+        box.for_each_in_subtree([&](auto const& node) {
+            if (!is<TextNode>(node) || !static_cast<TextNode const&>(node).dom_node().data().is_whitespace()) {
+                contains_only_white_space = false;
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
+        if (contains_only_white_space)
+            return true;
+    }
+    return false;
+}
+
 }

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -81,6 +81,7 @@ public:
     virtual void determine_height_of_child(Box const&, AvailableSpace const&) { }
 
     virtual Gfx::FloatPoint calculate_static_position(Box const&) const;
+    bool can_skip_is_anonymous_text_run(Box&);
 
 protected:
     FormattingContext(Type, LayoutState&, Box const&, FormattingContext* parent = nullptr);

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -267,8 +267,8 @@ void GridFormattingContext::place_item_with_row_and_column_position(Box const& b
     column_start -= 1;
     m_positioned_boxes.append({ child_box, row_start, row_span, column_start, column_span });
 
-    m_occupation_grid.maybe_add_row(row_start + row_span);
-    m_occupation_grid.maybe_add_column(column_start + column_span);
+    m_occupation_grid.maybe_add_row(row_start + 1);
+    m_occupation_grid.maybe_add_column(column_start + 1);
     m_occupation_grid.set_occupied(column_start, column_start + column_span, row_start, row_start + row_span);
 }
 
@@ -505,8 +505,8 @@ void GridFormattingContext::place_item_with_column_position(Box const& box, Box 
         auto_placement_cursor_y++;
     auto_placement_cursor_x = column_start;
 
-    m_occupation_grid.maybe_add_column(auto_placement_cursor_x + column_span);
-    m_occupation_grid.maybe_add_row(auto_placement_cursor_y + row_span);
+    m_occupation_grid.maybe_add_column(auto_placement_cursor_x + 1);
+    m_occupation_grid.maybe_add_row(auto_placement_cursor_y + 1);
 
     // 4.1.1.2. Increment the cursor's row position until a value is found where the grid item does not
     // overlap any occupied grid cells (creating new rows in the implicit grid as necessary).

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -22,21 +22,6 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
     auto& box_state = m_state.get_mutable(box);
     auto grid_template_columns = box.computed_values().grid_template_columns();
     auto grid_template_rows = box.computed_values().grid_template_rows();
-    auto should_skip_is_anonymous_text_run = [&](Box& child_box) -> bool {
-        if (child_box.is_anonymous() && !child_box.first_child_of_type<BlockContainer>()) {
-            bool contains_only_white_space = true;
-            child_box.for_each_in_subtree([&](auto const& node) {
-                if (!is<TextNode>(node) || !static_cast<TextNode const&>(node).dom_node().data().is_whitespace()) {
-                    contains_only_white_space = false;
-                    return IterationDecision::Break;
-                }
-                return IterationDecision::Continue;
-            });
-            if (contains_only_white_space)
-                return true;
-        }
-        return false;
-    };
 
     auto resolve_definite_track_size = [&](CSS::GridSize const& grid_size) -> float {
         VERIFY(grid_size.is_definite());
@@ -110,7 +95,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
     Vector<PositionedBox> positioned_boxes;
     Vector<Box const&> boxes_to_place;
     box.for_each_child_of_type<Box>([&](Box& child_box) {
-        if (should_skip_is_anonymous_text_run(child_box))
+        if (can_skip_is_anonymous_text_run(child_box))
             return IterationDecision::Continue;
         boxes_to_place.append(child_box);
         return IterationDecision::Continue;


### PR DESCRIPTION
This PR introduces a large-ish refactor of the GridFormattingContext to make it more legible.

Also, fix the case when a grid item had an indicated span that was larger than the grid. Previously, were increasing the amount of rows/columns to accommodate that span, when really it should be truncated (the truncation was done in PR 16669).