### PR TITLE
Fix more typos

### DIFF
--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -204,7 +204,7 @@ can't be built with Clang yet.
 
 To build the Clang-based toolchain, run `BuildClang.sh` from the `Toolchain` directory. The script will build a Clang
 toolchain that is capable of building applications for the build host and serenity, 
-for all supported architecutres (i686, x86_64 and aarch64).
+for all supported architectures (i686, x86_64 and aarch64).
 
 **Warning:** While the build script is running, your computer may slow down extremely or even lock up for short
 intervals.  This generally happens if you have more CPU cores than free RAM in gigabytes. To fix this, limit the number

--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -47,7 +47,7 @@ Serenity-specific patches were upstreamed to CMake in major version 3.25. To avo
 patches to CMake, the minimum required CMake to build Serenity is set to that version.
 If more patches are upstreamed to CMake, the minimum will be bumped again once that version releases.
 
-To accomodate distributions that do not ship bleeding-edge CMake versions, the build scripts will
+To accommodate distributions that do not ship bleeding-edge CMake versions, the build scripts will
 attempt to build CMake from source if the version on your path is older than 3.25.x.
 
 ### Windows

--- a/Documentation/BuildInstructionsMacOS.md
+++ b/Documentation/BuildInstructionsMacOS.md
@@ -45,5 +45,5 @@ Installing macfuse for the first time requires enabling its system extension in 
 It's important to make sure that Xcode is not only installed but also accordingly updated, otherwise CMake will run into incompatibilities with GCC.
 
 Homebrew is known to ship bleeding edge CMake versions, but building CMake from source with homebrew
-gcc or llvm may not work. If homebrew does not offer cmake 3.25.x+ on your platform, it may be neccessary
+gcc or llvm may not work. If homebrew does not offer cmake 3.25.x+ on your platform, it may be necessary
 to manually run Toolchain/BuildCMake.sh with Apple clang from Xcode as the first compiler in your $PATH.

--- a/Documentation/Kernel/DevelopmentGuidelines.md
+++ b/Documentation/Kernel/DevelopmentGuidelines.md
@@ -34,7 +34,7 @@ An exception to this is when there's simply no way to propagate the error code t
 Maybe it's a `ATAPort` (in the IDE ATA code) that asynchronously tries to handle reading data from the harddrive,
 but because of the async operation, we can't send the `errno` code back to userland, so we what we do is
 to ensure that internal functions still use the `ErrorOr<>` return type, and in main calling function, we use
-other meaningful infrastructure utilties in the Kernel to indicate that the operation failed.
+other meaningful infrastructure utilities in the Kernel to indicate that the operation failed.
 
 ## We don't break userspace - the SerenityOS version
 
@@ -58,7 +58,7 @@ each git commit is bisectable by itself.
 **It's expected that changes to the Kernel will be tested with userland utilities to ensure the changes
 are not creating any misbehaves in the userland functionality.**
 
-Even more strictier than what has been said above - we don't remove functionality unless it's absolutely
+Even more stricter than what has been said above - we don't remove functionality unless it's absolutely
 clear that nobody uses that functionality. Even when it's absolutely clear that nobody uses some kind
 of kernel functionality, it could still be useful to think about how to make it more available and usable
 to the SerenityOS project community.
@@ -112,7 +112,7 @@ in the past and many of them were removed eventually.**
 We, as the SerenityOS project, take seriously the concept of security information.
 Many security mitigations have been implemented in the Kernel, and are documented in a
 [different file](../../Base/usr/share/man/man7/Mitigations.md).
-As kernel developers, we should be even more strictier on the security measures being
+As kernel developers, we should be even more stricter on the security measures being
 taken than the rest of system.
 One of the core guidelines in that aspect **is to never undermine any security measure
 that was implemented, at the very least.**

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -214,6 +214,7 @@ struct tm* localtime_r(time_t const* t, struct tm* tm)
 
 time_t timegm(struct tm* tm)
 {
+    tm->tm_isdst = 0;
     return tm_to_time(tm, { __utc, __builtin_strlen(__utc) });
 }
 

--- a/Userland/Libraries/LibGfx/ICCProfile.cpp
+++ b/Userland/Libraries/LibGfx/ICCProfile.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Endian.h>
 #include <LibGfx/ICCProfile.h>
+#include <time.h>
 
 // V2 spec: https://color.org/specification/ICC.1-2001-04.pdf
 // V4 spec: https://color.org/specification/ICC.1-2022-05.pdf
@@ -13,6 +14,58 @@
 namespace Gfx::ICC {
 
 namespace {
+
+// ICC V4, 4.2 dateTimeNumber
+// "All the dateTimeNumber values in a profile shall be in Coordinated Universal Time [...]."
+struct DateTimeNumber {
+    BigEndian<u16> year;
+    BigEndian<u16> month;
+    BigEndian<u16> day;
+    BigEndian<u16> hour;
+    BigEndian<u16> minutes;
+    BigEndian<u16> seconds;
+};
+
+ErrorOr<time_t> parse_date_time_number(DateTimeNumber const& date_time)
+{
+    // ICC V4, 4.2 dateTimeNumber
+
+    // "Number of the month (1 to 12)"
+    if (date_time.month < 1 || date_time.month > 12)
+        return Error::from_string_literal("ICC::Profile: dateTimeNumber month out of bounds");
+
+    // "Number of the day of the month (1 to 31)"
+    if (date_time.day < 1 || date_time.day > 31)
+        return Error::from_string_literal("ICC::Profile: dateTimeNumber day out of bounds");
+
+    // "Number of hours (0 to 23)"
+    if (date_time.hour > 23)
+        return Error::from_string_literal("ICC::Profile: dateTimeNumber hour out of bounds");
+
+    // "Number of minutes (0 to 59)"
+    if (date_time.minutes > 59)
+        return Error::from_string_literal("ICC::Profile: dateTimeNumber minutes out of bounds");
+
+    // "Number of seconds (0 to 59)"
+    // ICC profiles apparently can't be created during leap seconds (seconds would be 60 there, but the spec doesn't allow that).
+    if (date_time.seconds > 59)
+        return Error::from_string_literal("ICC::Profile: dateTimeNumber seconds out of bounds");
+
+    struct tm tm = {};
+    tm.tm_year = date_time.year - 1900;
+    tm.tm_mon = date_time.month - 1;
+    tm.tm_mday = date_time.day;
+    tm.tm_hour = date_time.hour;
+    tm.tm_min = date_time.minutes;
+    tm.tm_sec = date_time.seconds;
+    // timegm() doesn't read tm.tm_isdst, tm.tm_wday, and tm.tm_yday, no need to fill them in.
+
+    time_t timestamp = timegm(&tm);
+    if (timestamp == -1)
+        return Error::from_string_literal("ICC::Profile: dateTimeNumber not representable as timestamp");
+
+    return timestamp;
+}
 
 // ICC V4, 7.2 Profile header
 struct ICCHeader {
@@ -27,12 +80,7 @@ struct ICCHeader {
     BigEndian<u32> data_color_space;
     BigEndian<u32> pcs; // "Profile Connection Space"
 
-    BigEndian<u16> year;
-    BigEndian<u16> month;
-    BigEndian<u16> day;
-    BigEndian<u16> hour;
-    BigEndian<u16> minutes;
-    BigEndian<u16> seconds;
+    DateTimeNumber profile_creation_time;
 
     BigEndian<u32> profile_file_signature;
     BigEndian<u32> primary_platform;
@@ -78,6 +126,12 @@ ErrorOr<DeviceClass> parse_device_class(ICCHeader const& header)
     return Error::from_string_literal("ICC::Profile: Invalid device class");
 }
 
+ErrorOr<time_t> parse_creation_date_time(ICCHeader const& header)
+{
+    // iCC v4, 7.2.8 Date and time field
+    return parse_date_time_number(header.profile_creation_time);
+}
+
 ErrorOr<void> parse_file_signature(ICCHeader const& header)
 {
     // iCC v4, 7.2.9 Profile file signature field
@@ -121,6 +175,7 @@ ErrorOr<NonnullRefPtr<Profile>> Profile::try_load_from_externally_owned_memory(R
     TRY(parse_file_signature(header));
     profile->m_version = TRY(parse_version(header));
     profile->m_device_class = TRY(parse_device_class(header));
+    profile->m_creation_timestamp = TRY(parse_creation_date_time(header));
 
     return profile;
 }

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -51,10 +51,12 @@ public:
 
     Version version() const { return m_version; }
     DeviceClass device_class() const { return m_device_class; }
+    time_t creation_timestamp() const { return m_creation_timestamp; }
 
 private:
     Version m_version;
     DeviceClass m_device_class;
+    time_t m_creation_timestamp;
 };
 
 }

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/StringView.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/DateTime.h>
 #include <LibCore/MappedFile.h>
 #include <LibGfx/ICCProfile.h>
 
@@ -22,6 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     outln("version: {}", profile->version());
     outln("device class: {}", Gfx::ICC::device_class_name(profile->device_class()));
+    outln("creation date and time: {}", Core::DateTime::from_timestamp(profile->creation_timestamp()).to_deprecated_string());
 
     return 0;
 }


### PR DESCRIPTION
While here, teach ICCProfile to parse the profile creation date and time, and make icc print it.

Screenshot:

```
% Build/lagom/icc ~/src/Compact-ICC-Profiles/profiles/sRGB-v2-nano.icc
version: 2.1.0
device class: DisplayDevice
creation date and time: 2018-03-20 05:14:29
```