### PR TITLE
AK: Use base URL when the specified URL is empty

### DIFF
--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -201,7 +201,7 @@ URL URLParser::parse(StringView raw_input, URL const* base_url, Optional<URL> ur
 {
     dbgln_if(URL_PARSER_DEBUG, "URLParser::parse: Parsing '{}'", raw_input);
     if (raw_input.is_empty())
-        return {};
+        return base_url ? *base_url : URL {};
 
     if (raw_input.starts_with("data:"sv)) {
         auto maybe_url = parse_data_url(raw_input);

--- a/Tests/AK/TestURL.cpp
+++ b/Tests/AK/TestURL.cpp
@@ -9,6 +9,7 @@
 
 #include <AK/Base64.h>
 #include <AK/URL.h>
+#include <AK/URLParser.h>
 
 TEST_CASE(construct)
 {
@@ -405,4 +406,12 @@ TEST_CASE(complete_file_url_with_base)
     auto sub_url = url.complete_url("js/app.js");
     EXPECT(sub_url.is_valid());
     EXPECT_EQ(sub_url.path(), "/home/js/app.js");
+}
+
+TEST_CASE(empty_url_with_base_url)
+{
+    URL base_url { "https://foo.com/"sv };
+    URL parsed_url = URLParser::parse(""sv, &base_url);
+    EXPECT_EQ(parsed_url.is_valid(), true);
+    EXPECT(base_url.equals(parsed_url));
 }


### PR DESCRIPTION
Fixes #16688 