### PR TITLE
LibCore: Add a read_line_unbounded() method to Stream

### DIFF
--- a/AK/Span.h
+++ b/AK/Span.h
@@ -186,11 +186,7 @@ public:
 
     [[nodiscard]] bool constexpr contains_slow(T const& value) const
     {
-        for (size_t i = 0; i < size(); ++i) {
-            if (at(i) == value)
-                return true;
-        }
-        return false;
+        return find_first_index(value).has_value();
     }
 
     [[nodiscard]] Optional<size_t> find_first_index(T const& value) const

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -9,6 +9,7 @@
 #include <AK/Array.h>
 #include <AK/Assertions.h>
 #include <AK/Iterator.h>
+#include <AK/Optional.h>
 #include <AK/TypedTransfer.h>
 #include <AK/Types.h>
 
@@ -190,6 +191,16 @@ public:
                 return true;
         }
         return false;
+    }
+
+    [[nodiscard]] Optional<size_t> find_first_index(T const& value) const
+    {
+        for (size_t i = 0; i < size(); ++i) {
+            if (at(i) == value) {
+                return i;
+            }
+        }
+        return {};
     }
 
     [[nodiscard]] bool constexpr starts_with(Span<T const> other) const


### PR DESCRIPTION
This PR adds support for reading arbitrarily long lines from an input stream, and updates the `uniq` utility to remove its line length constraint.