### PR TITLE
Documentation: Document fix for missing /etc/mtab

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -88,6 +88,8 @@ Meta/serenity.sh run
 This will compile all of SerenityOS and install the built files into the `Build/x86_64/Root` directory inside your Git
 repository. It will also build a disk image and start SerenityOS using QEMU.
 
+If, during build, an error like `fusermount: failed to open /etc/mtab: No such file or directory` appears, you have installed `fuse2fs` but your system does not provide the mtab symlink for various reasons. Simply create this symlink with `ln -sv /proc/self/mounts /etc/mtab`.
+
 Note that the `anon` user is able to become `root` without a password by default, as a development convenience.
 To prevent this, remove `anon` from the `wheel` group and he will no longer be able to run `/bin/su`.
 


### PR DESCRIPTION
/etc/mtab is identical to /proc/self/mounts, but it does not exist under many circumstances, e.g. chroot'ed or in WSL. The fact that many userspace programs rely on this file existing and the user needing to create symlinks manually has been a long-standing issue (there's pretty old forum posts on Debian and Arch Linux forums about it), but it's not fixed upstream. This short mention should save people some time.