### PR TITLE
LibGUI: Improve navigation in ColumnsView :^)

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -303,6 +303,11 @@ void AbstractScrollableWidget::scroll_to_bottom()
     scroll_into_view({ 0, content_height(), 0, 0 }, Orientation::Vertical);
 }
 
+void AbstractScrollableWidget::scroll_to_right()
+{
+    scroll_into_view({ content_width(), 0, 0, 0 }, Orientation::Horizontal);
+}
+
 void AbstractScrollableWidget::set_automatic_scrolling_timer_active(bool active)
 {
     if (active == m_active_scrolling_enabled)

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
@@ -56,6 +56,7 @@ public:
 
     void scroll_to_top();
     void scroll_to_bottom();
+    void scroll_to_right();
     void update_scrollbar_ranges();
 
     void set_automatic_scrolling_timer_active(bool);

--- a/Userland/Libraries/LibGUI/ColumnsView.cpp
+++ b/Userland/Libraries/LibGUI/ColumnsView.cpp
@@ -435,6 +435,25 @@ void ColumnsView::move_cursor(CursorMovement movement, SelectionUpdate selection
         set_cursor(new_index, selection_update);
 }
 
+Gfx::IntRect ColumnsView::index_content_rect(ModelIndex const& index)
+{
+    int column_x = 0;
+    for (auto const& column : m_columns) {
+        if (column.parent_index == index.parent())
+            return { column_x, index.row() * item_height(), column.width, item_height() };
+
+        column_x += column.width + column_separator_width();
+    }
+    return {};
+}
+
+void ColumnsView::scroll_into_view(ModelIndex const& index, bool scroll_horizontally, bool scroll_vertically)
+{
+    if (!model())
+        return;
+    AbstractScrollableWidget::scroll_into_view(index_content_rect(index), scroll_horizontally, scroll_vertically);
+}
+
 Gfx::IntRect ColumnsView::content_rect(ModelIndex const& index) const
 {
     if (!index.is_valid())

--- a/Userland/Libraries/LibGUI/ColumnsView.cpp
+++ b/Userland/Libraries/LibGUI/ColumnsView.cpp
@@ -184,7 +184,7 @@ void ColumnsView::paint_event(PaintEvent& event)
         if (height() > separator_height)
             separator_height = height();
         painter.draw_line({ column_x + column.width, 0 }, { column_x + column.width, separator_height }, palette().button());
-        column_x += column.width + 1;
+        column_x += column.width + column_separator_width();
     }
 }
 
@@ -232,7 +232,7 @@ void ColumnsView::update_column_sizes()
             if (row_width > column.width)
                 column.width = row_width;
         }
-        total_width += column.width + 1;
+        total_width += column.width + column_separator_width();
     }
 
     set_content_size({ total_width, total_height });
@@ -251,7 +251,7 @@ Optional<ColumnsView::Column> ColumnsView::column_at_event_position(Gfx::IntPoin
         if (position.x() < column_x)
             break;
         if (position.x() > column_x + column.width) {
-            column_x += column.width;
+            column_x += column.width + column_separator_width();
             continue;
         }
 

--- a/Userland/Libraries/LibGUI/ColumnsView.cpp
+++ b/Userland/Libraries/LibGUI/ColumnsView.cpp
@@ -205,6 +205,10 @@ void ColumnsView::push_column(ModelIndex const& parent_index)
     dbgln("Adding a new column");
     m_columns.append({ parent_index, 0 });
     update_column_sizes();
+
+    // FIXME: Find a way not to jump the view so much when changing folders within the same directory.
+    scroll_to_right();
+
     update();
 }
 

--- a/Userland/Libraries/LibGUI/ColumnsView.cpp
+++ b/Userland/Libraries/LibGUI/ColumnsView.cpp
@@ -235,6 +235,9 @@ void ColumnsView::update_column_sizes()
         total_width += column.width + column_separator_width();
     }
 
+    // "Hide" last separator behind a window frame.
+    total_width -= column_separator_width();
+
     set_content_size({ total_width, total_height });
 }
 

--- a/Userland/Libraries/LibGUI/ColumnsView.cpp
+++ b/Userland/Libraries/LibGUI/ColumnsView.cpp
@@ -241,12 +241,10 @@ void ColumnsView::update_column_sizes()
     set_content_size({ total_width, total_height });
 }
 
-Optional<ColumnsView::Column> ColumnsView::column_at_event_position(Gfx::IntPoint a_position) const
+Optional<ColumnsView::Column> ColumnsView::column_at_event_position(Gfx::IntPoint position) const
 {
     if (!model())
         return {};
-
-    auto position = a_position.translated(horizontal_scrollbar().value() - frame_thickness(), vertical_scrollbar().value() - frame_thickness());
 
     int column_x = 0;
 
@@ -288,8 +286,9 @@ ModelIndex ColumnsView::index_at_event_position_in_column(Gfx::IntPoint position
     return model()->index(row, m_model_column, column.parent_index);
 }
 
-ModelIndex ColumnsView::index_at_event_position(Gfx::IntPoint position) const
+ModelIndex ColumnsView::index_at_event_position(Gfx::IntPoint widget_position) const
 {
+    auto position = to_content_position(widget_position);
     auto const& column = column_at_event_position(position);
     if (!column.has_value())
         return {};
@@ -307,11 +306,12 @@ void ColumnsView::mousedown_event(MouseEvent& event)
     if (event.button() != MouseButton::Primary)
         return;
 
-    auto column = column_at_event_position(event.position());
+    auto position = to_content_position(event.position());
+    auto column = column_at_event_position(position);
     if (!column.has_value())
         return;
 
-    auto index = index_at_event_position_in_column(event.position(), *column);
+    auto index = index_at_event_position_in_column(position, *column);
     if (index.is_valid() && !(event.modifiers() & Mod_Ctrl)) {
         if (model()->row_count(index))
             push_column(index);
@@ -321,8 +321,8 @@ void ColumnsView::mousedown_event(MouseEvent& event)
     if (selection_mode() == SelectionMode::MultiSelection) {
         m_rubber_banding = true;
         m_rubber_band_origin_column = *column;
-        m_rubber_band_origin = event.position().y();
-        m_rubber_band_current = event.position().y();
+        m_rubber_band_origin = position.y();
+        m_rubber_band_current = position.y();
     }
 }
 

--- a/Userland/Libraries/LibGUI/ColumnsView.h
+++ b/Userland/Libraries/LibGUI/ColumnsView.h
@@ -22,6 +22,8 @@ public:
     virtual Gfx::IntRect content_rect(ModelIndex const&) const override;
     virtual Gfx::IntRect paint_invalidation_rect(ModelIndex const&) const override;
 
+    virtual void scroll_into_view(ModelIndex const&, bool scroll_horizontally, bool scroll_vertically) override;
+
 private:
     ColumnsView();
     virtual ~ColumnsView() override = default;
@@ -54,6 +56,7 @@ private:
 
     Optional<Column> column_at_event_position(Gfx::IntPoint) const;
     ModelIndex index_at_event_position_in_column(Gfx::IntPoint, Column const&) const;
+    Gfx::IntRect index_content_rect(ModelIndex const&);
 
     bool m_rubber_banding { false };
     int m_rubber_band_origin { 0 };

--- a/Userland/Libraries/LibGUI/ColumnsView.h
+++ b/Userland/Libraries/LibGUI/ColumnsView.h
@@ -32,6 +32,7 @@ private:
     int icon_size() const { return 16; }
     int icon_spacing() const { return 2; }
     int text_padding() const { return 2; }
+    int column_separator_width() const { return 1; }
 
     virtual void model_did_update(unsigned flags) override;
     virtual void second_paint_event(PaintEvent&) override;


### PR DESCRIPTION
preparation:

- **LibGUI: Replace a magic number with ColumnsView::column_separator_width**
- **LibGUI: Don't show last separator in column**
  ![](https://user-images.githubusercontent.com/16520278/209832430-18c6ce2a-3491-4d6a-b417-5a0584454349.png)

---

the main part:

- **LibGUI: Determine model index from a content position in ColumnsView**

  We didn't take the scroll value into account when we were converting a position to an index, which basically prevented us from selecting a desired file if a list wasn't small enough to fit entirely in the widget box.
  
  ![](https://user-images.githubusercontent.com/16520278/209843150-070761aa-a901-4332-9189-23bd2d32c146.gif)

- **LibGUI: Don't destroy columns after selecting already opened one**

  Before | This PR
  ---|---
  ![](https://user-images.githubusercontent.com/16520278/209842989-b1369901-c1a9-4261-bbe5-85766e30e86a.gif) | ![](https://user-images.githubusercontent.com/16520278/209842997-4c382857-36ab-4e02-ba74-d2179615adb4.gif)

- **LibGUI: Teach ColumnsView where indexes are placed (and scroll to them)**

  This makes the view to scroll when pressing arrow keys! :^)

  Before | This PR
  ---|---
  ![](https://user-images.githubusercontent.com/16520278/209842501-833ceb75-0013-4649-bf61-020d1f0ceda2.gif) | ![](https://user-images.githubusercontent.com/16520278/209842028-d39e9638-cf6f-440e-b10a-40c8807302dc.gif)

- **LibGUI: Automatically scroll to a new column on adding it in ColumnsView**

  Before | This PR
  ---|---
  ![](https://user-images.githubusercontent.com/16520278/209841924-5b860b27-7178-48a8-995b-e7195f27570c.gif) | ![](https://user-images.githubusercontent.com/16520278/209842766-76057eb9-8be7-4fd7-a6f4-a79f55071cc9.gif)