### PR TITLE
LibCore: Change Core::System::mkstemp's argument to a ByteBuffer

### DIFF
--- a/Tests/Kernel/TestPosixFallocate.cpp
+++ b/Tests/Kernel/TestPosixFallocate.cpp
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteBuffer.h>
 #include <LibCore/System.h>
 #include <LibTest/TestCase.h>
 
 TEST_CASE(posix_fallocate_basics)
 {
-    char pattern[] = "/tmp/posix_fallocate.XXXXXX";
-    auto fd = MUST(Core::System::mkstemp(pattern));
+    auto buffer = MUST(AK::ByteBuffer::copy("/tmp/posix_fallocate.XXXXXX"sv.bytes()));
+    auto fd = MUST(Core::System::mkstemp(buffer));
     VERIFY(fd >= 0);
 
     {

--- a/Userland/Libraries/LibCore/Account.cpp
+++ b/Userland/Libraries/LibCore/Account.cpp
@@ -300,22 +300,18 @@ ErrorOr<void> Account::sync()
     auto new_shadow_file_content = TRY(generate_shadow_file());
 #endif
 
-    // FIXME: mkstemp taking Span<char> makes this code entirely un-AKable.
-    //        Make this code less char-pointery.
-    char new_passwd_name[] = "/etc/passwd.XXXXXX";
-    size_t new_passwd_name_length = strlen(new_passwd_name);
+    auto new_passwd_name = TRY(ByteBuffer::copy("/etc/passwd.XXXXXX"sv.bytes()));
 #ifndef AK_OS_BSD_GENERIC
-    char new_shadow_name[] = "/etc/shadow.XXXXXX";
-    size_t new_shadow_name_length = strlen(new_shadow_name);
+    auto new_shadow_name = TRY(ByteBuffer::copy("/etc/shadow.XXXXXX"sv.bytes()));
 #endif
 
     {
-        auto new_passwd_fd = TRY(Core::System::mkstemp({ new_passwd_name, new_passwd_name_length }));
+        auto new_passwd_fd = TRY(Core::System::mkstemp(new_passwd_name));
         ScopeGuard new_passwd_fd_guard = [new_passwd_fd] { close(new_passwd_fd); };
         TRY(Core::System::fchmod(new_passwd_fd, 0644));
 
 #ifndef AK_OS_BSD_GENERIC
-        auto new_shadow_fd = TRY(Core::System::mkstemp({ new_shadow_name, new_shadow_name_length }));
+        auto new_shadow_fd = TRY(Core::System::mkstemp(new_shadow_name));
         ScopeGuard new_shadow_fd_guard = [new_shadow_fd] { close(new_shadow_fd); };
         TRY(Core::System::fchmod(new_shadow_fd, 0600));
 #endif
@@ -329,9 +325,9 @@ ErrorOr<void> Account::sync()
 #endif
     }
 
-    TRY(Core::System::rename({ new_passwd_name, new_passwd_name_length }, "/etc/passwd"sv));
+    TRY(Core::System::rename(new_passwd_name, "/etc/passwd"sv));
 #ifndef AK_OS_BSD_GENERIC
-    TRY(Core::System::rename({ new_shadow_name, new_shadow_name_length }, "/etc/shadow"sv));
+    TRY(Core::System::rename(new_shadow_name, "/etc/shadow"sv));
 #endif
 
     return {};

--- a/Userland/Libraries/LibCore/Group.cpp
+++ b/Userland/Libraries/LibCore/Group.cpp
@@ -51,11 +51,10 @@ ErrorOr<void> Group::sync()
 
     auto new_group_file_content = TRY(generate_group_file());
 
-    char new_group_name[] = "/etc/group.XXXXXX";
-    size_t new_group_name_length = strlen(new_group_name);
+    auto new_group_name = TRY(ByteBuffer::copy("/etc/group.XXXXXX"sv.bytes()));
 
     {
-        auto new_group_fd = TRY(Core::System::mkstemp({ new_group_name, new_group_name_length }));
+        auto new_group_fd = TRY(Core::System::mkstemp(new_group_name));
         ScopeGuard new_group_fd_guard([new_group_fd] { close(new_group_fd); });
         TRY(Core::System::fchmod(new_group_fd, 0664));
 
@@ -63,7 +62,7 @@ ErrorOr<void> Group::sync()
         VERIFY(static_cast<size_t>(nwritten) == new_group_file_content.length());
     }
 
-    TRY(Core::System::rename({ new_group_name, new_group_name_length }, "/etc/group"sv));
+    TRY(Core::System::rename(new_group_name, "/etc/group"sv));
 
     return {};
 }

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteBuffer.h>
 #include <AK/DeprecatedString.h>
 #include <AK/FixedArray.h>
 #include <AK/ScopedValueRollback.h>
@@ -983,9 +984,9 @@ ErrorOr<pid_t> fork()
     return pid;
 }
 
-ErrorOr<int> mkstemp(Span<char> pattern)
+ErrorOr<int> mkstemp(ByteBuffer pattern)
 {
-    int fd = ::mkstemp(pattern.data());
+    int fd = ::mkstemp(reinterpret_cast<char*>(pattern.data()));
     if (fd < 0)
         return Error::from_syscall("mkstemp"sv, -errno);
     return fd;

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -158,7 +158,7 @@ ErrorOr<void> mkdir(StringView path, mode_t);
 ErrorOr<void> chdir(StringView path);
 ErrorOr<void> rmdir(StringView path);
 ErrorOr<pid_t> fork();
-ErrorOr<int> mkstemp(Span<char> pattern);
+ErrorOr<int> mkstemp(ByteBuffer pattern);
 ErrorOr<void> fchmod(int fd, mode_t mode);
 ErrorOr<void> fchown(int fd, uid_t, gid_t);
 ErrorOr<void> rename(StringView old_path, StringView new_path);

--- a/Userland/Utilities/groupdel.cpp
+++ b/Userland/Utilities/groupdel.cpp
@@ -57,11 +57,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // We can now safely delete the group
 
     // Create a temporary group file
-    char temp_group[] = "/etc/group.XXXXXX";
-    StringView temp_group_view { temp_group, strlen(temp_group) };
+    auto temp_group = TRY(ByteBuffer::copy("/etc/group.XXXXXX"sv.bytes()));
 
     auto unlink_temp_files = [&] {
-        if (Core::System::unlink(temp_group_view).is_error())
+        if (Core::System::unlink(temp_group).is_error())
             perror("unlink");
     };
 
@@ -93,8 +92,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    TRY(Core::System::chmod(temp_group_view, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH));
-    TRY(Core::System::rename(temp_group_view, "/etc/group"sv));
+    TRY(Core::System::chmod(temp_group, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH));
+    TRY(Core::System::rename(temp_group, "/etc/group"sv));
 
     unlink_temp_files_guard.disarm();
 


### PR DESCRIPTION
This leads to cleaner usages in call sites compared to a Span<char>. This commit also removes a FIXME in LibCore/Account.cpp :^)