### PR TITLE
LibGUI: fix invalid ModelIndices during shift-click multiselection

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -493,6 +493,8 @@ void AbstractView::set_cursor(ModelIndex index, SelectionUpdate selection_update
             if (!m_selection.contains(index))
                 clear_selection();
         } else if (selection_update == SelectionUpdate::Shift) {
+            if (!selection_start_index().is_valid())
+                set_selection_start_index(index);
             select_range(index);
         }
 


### PR DESCRIPTION
Previously: If the widget was unfocused, the selection start index would be invalid. This would result in invalid selections when doing shift+click on the widget (while it is unfocused).

Now: if selection start index is invalid, we assign the selection start index to current index before we initiate multiselection.

Should Fix SerenityOS#11999 and the same bug inside FileManager.