### PR TITLE
LibGfx+Overall: Remove `is_null` from `Point`, `Rect` and `Size`

### DIFF
--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -287,7 +287,7 @@ void LayerListWidget::mousemove_event(GUI::MouseEvent& event)
         gadget.movement_delta.set_y(inner_rect_max_height - gadget.rect.bottom());
 
     m_automatic_scroll_delta = automatic_scroll_delta_from_position(event.position());
-    set_automatic_scrolling_timer_active(vertical_scrollbar().is_scrollable() && !m_automatic_scroll_delta.is_null());
+    set_automatic_scrolling_timer_active(vertical_scrollbar().is_scrollable() && !m_automatic_scroll_delta.is_zero());
 
     relayout_gadgets();
 }

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -796,7 +796,7 @@ void AbstractView::drag_move_event(DragEvent& event)
 
     if (acceptable) {
         m_automatic_scroll_delta = automatic_scroll_delta_from_position(event.position());
-        set_automatic_scrolling_timer_active(!m_automatic_scroll_delta.is_null());
+        set_automatic_scrolling_timer_active(!m_automatic_scroll_delta.is_zero());
     }
 
     if (m_drop_candidate_index != new_drop_candidate_index) {
@@ -819,7 +819,7 @@ void AbstractView::drag_leave_event(Event&)
 
 void AbstractView::automatic_scrolling_timer_did_fire()
 {
-    if (m_automatic_scroll_delta.is_null())
+    if (m_automatic_scroll_delta.is_zero())
         return;
 
     vertical_scrollbar().increase_slider_by(m_automatic_scroll_delta.y());

--- a/Userland/Libraries/LibGUI/AbstractZoomPanWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractZoomPanWidget.cpp
@@ -13,7 +13,7 @@ constexpr float wheel_zoom_factor = 8.0f;
 
 void AbstractZoomPanWidget::set_scale(float new_scale)
 {
-    if (m_original_rect.is_null())
+    if (m_original_rect.is_empty())
         return;
 
     m_scale = clamp(new_scale, m_min_scale, m_max_scale);
@@ -36,7 +36,7 @@ void AbstractZoomPanWidget::scale_by(float delta)
 
 void AbstractZoomPanWidget::scale_centered(float new_scale, Gfx::IntPoint center)
 {
-    if (m_original_rect.is_null())
+    if (m_original_rect.is_empty())
         return;
 
     new_scale = clamp(new_scale, m_min_scale, m_max_scale);
@@ -154,7 +154,7 @@ void AbstractZoomPanWidget::mouseup_event(GUI::MouseEvent& event)
 
 void AbstractZoomPanWidget::relayout()
 {
-    if (m_original_rect.is_null())
+    if (m_original_rect.is_empty())
         return;
 
     m_content_rect.set_location({

--- a/Userland/Libraries/LibGUI/IconView.cpp
+++ b/Userland/Libraries/LibGUI/IconView.cpp
@@ -329,7 +329,7 @@ void IconView::mousemove_event(MouseEvent& event)
 
     if (m_rubber_banding) {
         m_out_of_view_position = event.position();
-        set_automatic_scrolling_timer_active(!m_rubber_band_scroll_delta.is_null());
+        set_automatic_scrolling_timer_active(!m_rubber_band_scroll_delta.is_zero());
 
         if (update_rubber_banding(event.position()))
             return;
@@ -342,7 +342,7 @@ void IconView::automatic_scrolling_timer_did_fire()
 {
     AbstractView::automatic_scrolling_timer_did_fire();
 
-    if (m_rubber_band_scroll_delta.is_null())
+    if (m_rubber_band_scroll_delta.is_zero())
         return;
 
     vertical_scrollbar().increase_slider_by(m_rubber_band_scroll_delta.y());

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -175,7 +175,7 @@ void Scrollbar::paint_event(PaintEvent& event)
         hovered_component_for_painting = Component::None;
 
     painter.fill_rect_with_dither_pattern(rect(), palette().button().lightened(1.3f), palette().button());
-    if (m_gutter_click_state != GutterClickState::NotPressed && has_scrubber() && !scrubber_rect().is_null() && hovered_component_for_painting == Component::Gutter) {
+    if (m_gutter_click_state != GutterClickState::NotPressed && has_scrubber() && !scrubber_rect().is_empty() && hovered_component_for_painting == Component::Gutter) {
         Gfx::IntRect rect_to_fill = rect();
         if (orientation() == Orientation::Vertical) {
             if (m_gutter_click_state == GutterClickState::BeforeScrubber) {
@@ -221,7 +221,7 @@ void Scrollbar::paint_event(PaintEvent& event)
         painter.draw_triangle(increment_location, orientation() == Orientation::Vertical ? s_down_arrow_coords : s_right_arrow_coords, (has_scrubber() && is_enabled() && !is_max()) ? palette().button_text() : palette().threed_shadow1());
     }
 
-    if (has_scrubber() && !scrubber_rect().is_null())
+    if (has_scrubber() && !scrubber_rect().is_empty())
         Gfx::StylePainter::paint_button(painter, scrubber_rect(), palette(), Gfx::ButtonStyle::ThickCap, false, hovered_component_for_painting == Component::Scrubber || m_pressed_component == Component::Scrubber);
 }
 

--- a/Userland/Libraries/LibGUI/Variant.h
+++ b/Userland/Libraries/LibGUI/Variant.h
@@ -100,7 +100,8 @@ public:
             [](Detail::Boolean v) { return v.value; },
             [](DeprecatedString const& v) { return !v.is_null(); },
             [](Integral auto v) { return v != 0; },
-            [](OneOf<Gfx::IntRect, Gfx::IntPoint, Gfx::IntSize> auto const& v) { return !v.is_null(); },
+            [](Gfx::IntPoint const& v) { return !v.is_zero(); },
+            [](OneOf<Gfx::IntRect, Gfx::IntSize> auto const& v) { return !v.is_empty(); },
             [](Enum auto const&) { return true; },
             [](OneOf<float, DeprecatedString, Color, NonnullRefPtr<Gfx::Font>, NonnullRefPtr<Gfx::Bitmap>, GUI::Icon> auto const&) { return true; });
     }

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -48,8 +48,7 @@ public:
     ALWAYS_INLINE void set_x(T x) { m_x = x; }
     ALWAYS_INLINE void set_y(T y) { m_y = y; }
 
-    [[nodiscard]] ALWAYS_INLINE bool is_null() const { return !m_x && !m_y; }
-    [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return m_x <= 0 && m_y <= 0; }
+    [[nodiscard]] ALWAYS_INLINE bool is_zero() const { return m_x == 0 && m_y == 0; }
 
     void translate_by(T dx, T dy)
     {

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -76,7 +76,6 @@ public:
     [[nodiscard]] ALWAYS_INLINE Point<T> const& location() const { return m_location; }
     [[nodiscard]] ALWAYS_INLINE Size<T> const& size() const { return m_size; }
 
-    [[nodiscard]] ALWAYS_INLINE bool is_null() const { return width() == 0 && height() == 0; }
     [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return width() <= 0 || height() <= 0; }
 
     ALWAYS_INLINE void translate_by(T dx, T dy) { m_location.translate_by(dx, dy); }
@@ -831,7 +830,7 @@ public:
             deltas.clear_with_capacity();
             for (auto& rect : rects) {
                 auto delta = calc_delta(rect);
-                if (!delta.is_null())
+                if (!delta.is_zero())
                     changes = true;
                 deltas.append(delta);
             }
@@ -868,9 +867,9 @@ public:
 
     [[nodiscard]] Rect<T> united(Rect<T> const& other) const
     {
-        if (is_null())
+        if (is_empty())
             return other;
-        if (other.is_null())
+        if (other.is_empty())
             return *this;
         Rect<T> rect;
         rect.set_left(min(left(), other.left()));

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -45,7 +45,6 @@ public:
     ALWAYS_INLINE constexpr void set_width(T w) { m_width = w; }
     ALWAYS_INLINE constexpr void set_height(T h) { m_height = h; }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr bool is_null() const { return !m_width && !m_height; }
     [[nodiscard]] ALWAYS_INLINE constexpr bool is_empty() const { return m_width <= 0 || m_height <= 0; }
 
     constexpr void scale_by(T dx, T dy)

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Debug.h>
 #include <AK/ExtraMathConstants.h>
+#include <AK/Optional.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
 #include <LibWeb/DOM/Document.h>
@@ -102,7 +103,7 @@ void SVGPathElement::parse_attribute(FlyString const& name, DeprecatedString con
 Gfx::Path path_from_path_instructions(Span<PathInstruction const> instructions)
 {
     Gfx::Path path;
-    Gfx::FloatPoint previous_control_point;
+    Optional<Gfx::FloatPoint> previous_control_point;
     PathInstructionType last_instruction = PathInstructionType::Invalid;
 
     for (auto& instruction : instructions) {
@@ -190,13 +191,13 @@ Gfx::Path path_from_path_instructions(Span<PathInstruction const> instructions)
         case PathInstructionType::SmoothQuadraticBezierCurve: {
             clear_last_control_point = false;
 
-            if (previous_control_point.is_null()
+            if (!previous_control_point.has_value()
                 || ((last_instruction != PathInstructionType::QuadraticBezierCurve) && (last_instruction != PathInstructionType::SmoothQuadraticBezierCurve))) {
                 previous_control_point = last_point;
             }
 
-            auto dx_end_control = last_point.dx_relative_to(previous_control_point);
-            auto dy_end_control = last_point.dy_relative_to(previous_control_point);
+            auto dx_end_control = last_point.dx_relative_to(previous_control_point.value());
+            auto dy_end_control = last_point.dy_relative_to(previous_control_point.value());
             auto control_point = Gfx::FloatPoint { last_point.x() + dx_end_control, last_point.y() + dy_end_control };
 
             Gfx::FloatPoint end_point = { data[0], data[1] };
@@ -231,7 +232,7 @@ Gfx::Path path_from_path_instructions(Span<PathInstruction const> instructions)
         case PathInstructionType::SmoothCurve: {
             clear_last_control_point = false;
 
-            if (previous_control_point.is_null()
+            if (!previous_control_point.has_value()
                 || ((last_instruction != PathInstructionType::Curve) && (last_instruction != PathInstructionType::SmoothCurve))) {
                 previous_control_point = last_point;
             }
@@ -240,8 +241,8 @@ Gfx::Path path_from_path_instructions(Span<PathInstruction const> instructions)
             // If the current point is (curx, cury) and the final control point of the previous path segment is (oldx2, oldy2),
             // then the reflected point (i.e., (newx1, newy1), the first control point of the current path segment) is:
             // (newx1, newy1) = (curx - (oldx2 - curx), cury - (oldy2 - cury))
-            auto reflected_previous_control_x = last_point.x() - previous_control_point.dx_relative_to(last_point);
-            auto reflected_previous_control_y = last_point.y() - previous_control_point.dy_relative_to(last_point);
+            auto reflected_previous_control_x = last_point.x() - previous_control_point.value().dx_relative_to(last_point);
+            auto reflected_previous_control_y = last_point.y() - previous_control_point.value().dy_relative_to(last_point);
             Gfx::FloatPoint c1 = Gfx::FloatPoint { reflected_previous_control_x, reflected_previous_control_y };
             Gfx::FloatPoint c2 = { data[0], data[1] };
             Gfx::FloatPoint p2 = { data[2], data[3] };

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -154,7 +154,7 @@ void ConnectionFromClient::popup_menu(i32 menu_id, Gfx::IntPoint screen_position
         return;
     }
     auto& menu = *(*it).value;
-    if (!button_rect.is_null())
+    if (!button_rect.is_empty())
         menu.open_button_menu(position, button_rect);
     else
         menu.popup(position);
@@ -654,7 +654,7 @@ void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect
     window->set_alpha_hit_threshold(alpha_hit_threshold);
     window->set_size_increment(size_increment);
     window->set_base_size(base_size);
-    if (resize_aspect_ratio.has_value() && !resize_aspect_ratio.value().is_null())
+    if (resize_aspect_ratio.has_value() && !resize_aspect_ratio.value().is_empty())
         window->set_resize_aspect_ratio(resize_aspect_ratio);
     window->invalidate(true, true);
     if (window->type() == WindowType::Applet)

--- a/Userland/Services/WindowServer/Overlays.cpp
+++ b/Userland/Services/WindowServer/Overlays.cpp
@@ -236,7 +236,7 @@ void WindowGeometryOverlay::update_rect()
 {
     if (auto* window = m_window.ptr()) {
         auto& wm = WindowManager::the();
-        if (!window->size_increment().is_null()) {
+        if (!window->size_increment().is_empty()) {
             int width_steps = (window->width() - window->base_size().width()) / window->size_increment().width();
             int height_steps = (window->height() - window->base_size().height()) / window->size_increment().height();
             m_label = DeprecatedString::formatted("{} ({}x{})", window->rect(), width_steps, height_steps);

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -943,7 +943,7 @@ bool WindowManager::process_ongoing_window_resize(MouseEvent const& event)
 
     m_resize_window->apply_minimum_size(new_rect);
 
-    if (!m_resize_window->size_increment().is_null()) {
+    if (!m_resize_window->size_increment().is_empty()) {
         int horizontal_incs = (new_rect.width() - m_resize_window->base_size().width()) / m_resize_window->size_increment().width();
         new_rect.set_width(m_resize_window->base_size().width() + horizontal_incs * m_resize_window->size_increment().width());
         int vertical_incs = (new_rect.height() - m_resize_window->base_size().height()) / m_resize_window->size_increment().height();


### PR DESCRIPTION
These types do not have support for nullness and we should use `Optional<T>` instead. Also, `Point::is_empty` is very silly and was defenestrated as a result.