### PR TITLE
SQLStudio: Allow connecting to user-specified database, and other usability enhancements

### DIFF
--- a/Userland/DevTools/SQLStudio/CMakeLists.txt
+++ b/Userland/DevTools/SQLStudio/CMakeLists.txt
@@ -4,10 +4,16 @@ serenity_component(
     TARGETS SQLStudio
 )
 
+compile_gml(SQLStudio.gml SQLStudioGML.h sql_studio_gml)
+
 set(SOURCES
     main.cpp
     MainWidget.cpp
     ScriptEditor.cpp
+)
+
+set(GENERATED_SOURCES
+    SQLStudioGML.h
 )
 
 serenity_app(SQLStudio ICON app-sql-studio)

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -352,11 +352,6 @@ void MainWidget::open_script_from_file(LexicalPath const& file_path)
     m_tab_widget->set_active_widget(&editor);
 }
 
-void MainWidget::open_database_from_file(LexicalPath const&)
-{
-    TODO();
-}
-
 bool MainWidget::request_close()
 {
     auto any_scripts_modified { false };
@@ -485,10 +480,7 @@ void MainWidget::drop_event(GUI::DropEvent& drop_event)
                 continue;
 
             auto lexical_path = LexicalPath(url.path());
-            if (lexical_path.extension().equals_ignoring_case("sql"sv))
-                open_script_from_file(lexical_path);
-            if (lexical_path.extension().equals_ignoring_case("db"sv))
-                open_database_from_file(lexical_path);
+            open_script_from_file(lexical_path);
         }
     }
 }

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <DevTools/SQLStudio/SQLStudioGML.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
@@ -29,12 +30,14 @@
 #include "MainWidget.h"
 #include "ScriptEditor.h"
 
+REGISTER_WIDGET(SQLStudio, MainWidget);
+
 namespace SQLStudio {
 
 MainWidget::MainWidget()
 {
-    set_fill_with_background_color(true);
-    set_layout<GUI::VerticalBoxLayout>();
+    if (!load_from_gml(sql_studio_gml))
+        VERIFY_NOT_REACHED();
 
     m_new_action = GUI::Action::create("&New", { Mod_Ctrl, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
         open_new_script();
@@ -158,9 +161,7 @@ MainWidget::MainWidget()
         }
     });
 
-    auto& toolbar_container = add<GUI::ToolbarContainer>();
-    auto& toolbar = toolbar_container.add<GUI::Toolbar>();
-
+    auto& toolbar = *find_descendant_of_type_named<GUI::Toolbar>("toolbar"sv);
     toolbar.add_action(*m_new_action);
     toolbar.add_action(*m_open_action);
     toolbar.add_action(*m_save_action);
@@ -175,9 +176,7 @@ MainWidget::MainWidget()
     toolbar.add_separator();
     toolbar.add_action(*m_run_script_action);
 
-    m_tab_widget = add<GUI::TabWidget>();
-    m_tab_widget->set_close_button_enabled(true);
-    m_tab_widget->set_reorder_allowed(true);
+    m_tab_widget = find_descendant_of_type_named<GUI::TabWidget>("script_tab_widget"sv);
 
     m_tab_widget->on_tab_close_click = [&](auto& widget) {
         auto editor = dynamic_cast<ScriptEditor*>(&widget);
@@ -200,9 +199,7 @@ MainWidget::MainWidget()
         on_editor_change();
     };
 
-    m_action_tab_widget = add<GUI::TabWidget>();
-    m_action_tab_widget->set_fixed_height(0);
-    m_action_tab_widget->set_close_button_enabled(true);
+    m_action_tab_widget = find_descendant_of_type_named<GUI::TabWidget>("action_tab_widget"sv);
 
     m_query_results_widget = m_action_tab_widget->add_tab<GUI::Widget>("Results");
     m_query_results_widget->set_layout<GUI::VerticalBoxLayout>();
@@ -213,7 +210,7 @@ MainWidget::MainWidget()
         m_action_tab_widget->set_fixed_height(0);
     };
 
-    m_statusbar = add<GUI::Statusbar>(3);
+    m_statusbar = find_descendant_of_type_named<GUI::Statusbar>("statusbar"sv);
 
     m_statusbar->segment(1).set_mode(GUI::Statusbar::Segment::Mode::Fixed);
     m_statusbar->segment(1).set_fixed_width(font().width("000000 characters (00000 words) selected"sv) + font().max_glyph_width());

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -168,7 +168,7 @@ MainWidget::MainWidget()
             m_connection_id = *connection_id;
             m_run_script_action->set_enabled(true);
         } else {
-            warnln("\033[33;1mCould not connect to:\033[0m {}", database_name);
+            GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Could not connect to {}", database_name));
         }
     });
 
@@ -256,6 +256,12 @@ MainWidget::MainWidget()
     m_sql_client = SQL::SQLClient::try_create().release_value_but_fixme_should_propagate_errors();
     m_sql_client->on_execution_success = [this](auto, auto, auto, auto, auto, auto) {
         read_next_sql_statement_of_editor();
+    };
+    m_sql_client->on_execution_error = [this](auto, auto, auto, auto message) {
+        auto* editor = active_editor();
+        VERIFY(editor);
+
+        GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Error executing {}\n{}", editor->path(), message));
     };
     m_sql_client->on_next_result = [this](auto, auto, auto row) {
         m_results.append({});

--- a/Userland/DevTools/SQLStudio/MainWidget.h
+++ b/Userland/DevTools/SQLStudio/MainWidget.h
@@ -61,7 +61,7 @@ private:
     RefPtr<SQL::SQLClient> m_sql_client;
     Vector<Vector<DeprecatedString>> m_results;
 
-    DeprecatedString read_next_sql_statement_of_editor();
+    void read_next_sql_statement_of_editor();
     Optional<DeprecatedString> read_next_line_of_editor();
     size_t m_current_line_for_parsing { 0 };
     int m_editor_line_level { 0 };

--- a/Userland/DevTools/SQLStudio/MainWidget.h
+++ b/Userland/DevTools/SQLStudio/MainWidget.h
@@ -25,7 +25,6 @@ public:
     void initialize_menu(GUI::Window*);
     void open_new_script();
     void open_script_from_file(LexicalPath const&);
-    void open_database_from_file(LexicalPath const&);
 
     bool request_close();
 

--- a/Userland/DevTools/SQLStudio/MainWidget.h
+++ b/Userland/DevTools/SQLStudio/MainWidget.h
@@ -52,9 +52,11 @@ private:
     RefPtr<GUI::Action> m_paste_action;
     RefPtr<GUI::Action> m_undo_action;
     RefPtr<GUI::Action> m_redo_action;
+    RefPtr<GUI::Action> m_connect_to_database_action;
     RefPtr<GUI::Action> m_run_script_action;
 
     int m_new_script_counter { 1 };
+    RefPtr<GUI::ComboBox> m_databases_combo_box;
     RefPtr<GUI::TabWidget> m_tab_widget;
     RefPtr<GUI::Statusbar> m_statusbar;
     RefPtr<GUI::TabWidget> m_action_tab_widget;

--- a/Userland/DevTools/SQLStudio/MainWidget.h
+++ b/Userland/DevTools/SQLStudio/MainWidget.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Dylan Katz <dykatz@uw.edu>
+ * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -30,6 +31,8 @@ public:
 
 private:
     MainWidget();
+
+    ScriptEditor* active_editor();
 
     void update_title();
     void on_editor_change();

--- a/Userland/DevTools/SQLStudio/MainWidget.h
+++ b/Userland/DevTools/SQLStudio/MainWidget.h
@@ -62,13 +62,13 @@ private:
     RefPtr<GUI::TableView> m_query_results_table_view;
 
     RefPtr<SQL::SQLClient> m_sql_client;
+    Optional<SQL::ConnectionID> m_connection_id;
     Vector<Vector<DeprecatedString>> m_results;
 
     void read_next_sql_statement_of_editor();
     Optional<DeprecatedString> read_next_line_of_editor();
     size_t m_current_line_for_parsing { 0 };
     int m_editor_line_level { 0 };
-    SQL::ConnectionID m_connection_id { 0 };
 };
 
 }

--- a/Userland/DevTools/SQLStudio/SQLStudio.gml
+++ b/Userland/DevTools/SQLStudio/SQLStudio.gml
@@ -1,0 +1,27 @@
+@SQLStudio::MainWidget {
+    layout: @GUI::VerticalBoxLayout {}
+    fill_with_background_color: true
+
+    @GUI::ToolbarContainer {
+        @GUI::Toolbar {
+            name: "toolbar"
+        }
+    }
+
+    @GUI::TabWidget {
+        name: "script_tab_widget"
+        reorder_allowed: true
+        show_close_buttons: true
+    }
+
+    @GUI::TabWidget {
+        name: "action_tab_widget"
+        show_close_buttons: true
+        fixed_height: 0
+    }
+
+    @GUI::Statusbar {
+        name: "statusbar"
+        segment_count: 3
+    }
+}

--- a/Userland/DevTools/SQLStudio/ScriptEditor.h
+++ b/Userland/DevTools/SQLStudio/ScriptEditor.h
@@ -24,6 +24,8 @@ public:
     ErrorOr<bool> save_as();
     ErrorOr<bool> attempt_to_close();
 
+    DeprecatedString const& path() const { return m_path; }
+
 private:
     ScriptEditor();
 

--- a/Userland/DevTools/SQLStudio/main.cpp
+++ b/Userland/DevTools/SQLStudio/main.cpp
@@ -39,18 +39,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return GUI::Window::CloseRequestDecision::StayOpen;
     };
 
-    auto needs_new_script = true;
     if (file_to_open) {
         auto path = LexicalPath(file_to_open);
-        if (path.extension().equals_ignoring_case("sql"sv)) {
-            main_widget->open_script_from_file(path);
-            needs_new_script = false;
-        } else if (path.extension().equals_ignoring_case("db"sv)) {
-            main_widget->open_database_from_file(path);
-        }
-    }
-    if (needs_new_script)
+        main_widget->open_script_from_file(path);
+    } else {
         main_widget->open_new_script();
+    }
 
     window->show();
     return app->exec();

--- a/Userland/Services/SQLServer/ConnectionFromClient.cpp
+++ b/Userland/Services/SQLServer/ConnectionFromClient.cpp
@@ -49,7 +49,7 @@ Messages::SQLServer::ConnectResponse ConnectionFromClient::connect(DeprecatedStr
 
     if (auto database_connection = DatabaseConnection::create(m_database_path, database_name, client_id()); !database_connection.is_error())
         return { database_connection.value()->connection_id() };
-    return { {} };
+    return Optional<SQL::ConnectionID> {};
 }
 
 void ConnectionFromClient::disconnect(SQL::ConnectionID connection_id)
@@ -69,13 +69,13 @@ Messages::SQLServer::PrepareStatementResponse ConnectionFromClient::prepare_stat
     auto database_connection = DatabaseConnection::connection_for(connection_id);
     if (!database_connection) {
         dbgln("Database connection has disappeared");
-        return { {} };
+        return Optional<SQL::StatementID> {};
     }
 
     auto result = database_connection->prepare_statement(sql);
     if (result.is_error()) {
         dbgln_if(SQLSERVER_DEBUG, "Could not parse SQL statement: {}", result.error().error_string());
-        return { {} };
+        return Optional<SQL::StatementID> {};
     }
 
     dbgln_if(SQLSERVER_DEBUG, "ConnectionFromClient::prepare_statement -> statement_id = {}", result.value());
@@ -94,7 +94,7 @@ Messages::SQLServer::ExecuteStatementResponse ConnectionFromClient::execute_stat
 
     dbgln_if(SQLSERVER_DEBUG, "Statement has disappeared");
     async_execution_error(statement_id, -1, SQL::SQLErrorCode::StatementUnavailable, DeprecatedString::formatted("{}", statement_id));
-    return { {} };
+    return Optional<SQL::ExecutionID> {};
 }
 
 }

--- a/Userland/Services/SQLServer/SQLStatement.cpp
+++ b/Userland/Services/SQLServer/SQLStatement.cpp
@@ -134,7 +134,7 @@ void SQLStatement::next(SQL::ExecutionID execution_id, SQL::ResultSet result, si
         auto result_row = result.take_first();
         client_connection->async_next_result(statement_id(), execution_id, result_row.row.take_data());
 
-        deferred_invoke([this, execution_id, result = move(result), result_size]() {
+        deferred_invoke([this, execution_id, result = move(result), result_size]() mutable {
             next(execution_id, move(result), result_size);
         });
     } else {

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -275,6 +275,11 @@ private:
                 });
         } else if (auto statement_id = m_sql_client->prepare_statement(m_connection_id, piece); statement_id.has_value()) {
             m_sql_client->async_execute_statement(*statement_id, {});
+        } else {
+            warnln("\033[33;1mError parsing SQL statement\033[0m: {}", piece);
+            m_loop.deferred_invoke([this]() {
+                read_sql();
+            });
         }
 
         // ...But m_keep_running can also be set to false by a command handler.


### PR DESCRIPTION
[Screencast from 2022-12-28 23-18-25.webm](https://user-images.githubusercontent.com/5600524/209903254-4d73d956-75c6-4ea9-95ba-15b2a7fd808a.webm)

This currently allows one database connection per SQLStudio instance. It may be useful to amend this in the future to be one connection per script tab, or have a set of tabs per connection, or \<something else\>. But for now this is useful enough.

There's plenty more to improve; the results section in particular. Don't want this PR to grow endlessly though.