### PR TITLE
LibCore+LibGUI: Add fallible versions of Widget::load_from_gml()

### DIFF
--- a/Userland/Applications/ThemeEditor/MainWidget.h
+++ b/Userland/Applications/ThemeEditor/MainWidget.h
@@ -77,9 +77,10 @@ struct PropertyTab {
 };
 
 class MainWidget final : public GUI::Widget {
-    C_OBJECT(MainWidget);
+    C_OBJECT_ABSTRACT(MainWidget);
 
 public:
+    static ErrorOr<NonnullRefPtr<MainWidget>> try_create();
     virtual ~MainWidget() override = default;
 
     ErrorOr<void> initialize_menubar(GUI::Window&);
@@ -88,7 +89,7 @@ public:
     ErrorOr<void> load_from_file(Core::File&);
 
 private:
-    MainWidget();
+    explicit MainWidget(NonnullRefPtr<AlignmentModel>);
 
     void save_to_file(Core::File&);
     ErrorOr<Core::AnonymousBuffer> encode();
@@ -96,7 +97,7 @@ private:
 
     void build_override_controls();
 
-    void add_property_tab(PropertyTab const&);
+    ErrorOr<void> add_property_tab(PropertyTab const&);
     void set_alignment(Gfx::AlignmentRole, Gfx::TextAlignment);
     void set_color(Gfx::ColorRole, Gfx::Color);
     void set_flag(Gfx::FlagRole, bool);

--- a/Userland/Applications/ThemeEditor/PreviewWidget.h
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.h
@@ -24,15 +24,16 @@ class MiniWidgetGallery;
 class PreviewWidget final
     : public GUI::AbstractThemePreview
     , public GUI::ColorFilterer {
-    C_OBJECT(PreviewWidget);
+    C_OBJECT_ABSTRACT(PreviewWidget);
 
 public:
+    static ErrorOr<NonnullRefPtr<PreviewWidget>> try_create();
     virtual ~PreviewWidget() override = default;
 
     virtual void set_color_filter(OwnPtr<Gfx::ColorBlindnessFilter>) override;
 
 private:
-    explicit PreviewWidget(Gfx::Palette const& = GUI::Application::the()->palette());
+    PreviewWidget();
 
     virtual void paint_preview(GUI::PaintEvent&) override;
     virtual void second_paint_event(GUI::PaintEvent&) override;

--- a/Userland/DevTools/GMLPlayground/main.cpp
+++ b/Userland/DevTools/GMLPlayground/main.cpp
@@ -121,8 +121,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     editor->on_change = [&] {
         preview->remove_all_children();
-        preview->load_from_gml(editor->text(), [](const DeprecatedString& class_name) -> RefPtr<Core::Object> {
-            return UnregisteredWidget::construct(class_name);
+        preview->load_from_gml(editor->text(), [](DeprecatedString const& class_name) -> ErrorOr<NonnullRefPtr<Core::Object>> {
+            return UnregisteredWidget::try_create(class_name);
         });
     };
 

--- a/Userland/DevTools/HackStudio/GMLPreviewWidget.cpp
+++ b/Userland/DevTools/HackStudio/GMLPreviewWidget.cpp
@@ -27,8 +27,8 @@ void GMLPreviewWidget::load_gml(DeprecatedString const& gml)
         return;
     }
 
-    load_from_gml(gml, [](DeprecatedString const& name) -> RefPtr<Core::Object> {
-        return GUI::Label::construct(DeprecatedString::formatted("{} is not registered as a GML element!", name));
+    load_from_gml(gml, [](DeprecatedString const& name) -> ErrorOr<NonnullRefPtr<Core::Object>> {
+        return GUI::Label::try_create(DeprecatedString::formatted("{} is not registered as a GML element!", name));
     });
 
     if (children().is_empty()) {

--- a/Userland/Games/Snake/Game.h
+++ b/Userland/Games/Snake/Game.h
@@ -14,9 +14,11 @@
 namespace Snake {
 
 class Game : public GUI::Frame {
-    C_OBJECT(Game);
+    C_OBJECT_ABSTRACT(Game);
 
 public:
+    static ErrorOr<NonnullRefPtr<Game>> try_create();
+
     virtual ~Game() override = default;
 
     void start();
@@ -28,7 +30,7 @@ public:
     Function<bool(u32)> on_score_update;
 
 private:
-    Game();
+    explicit Game(NonnullRefPtrVector<Gfx::Bitmap> food_bitmaps);
 
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void keydown_event(GUI::KeyEvent&) override;

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -49,7 +49,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(324, 345);
 
     auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
-    widget->load_from_gml(snake_gml);
+    TRY(widget->try_load_from_gml(snake_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Snake::Game>("game");
     game.set_focus(true);

--- a/Userland/Libraries/LibCore/Object.cpp
+++ b/Userland/Libraries/LibCore/Object.cpp
@@ -263,7 +263,7 @@ static HashMap<StringView, ObjectClassRegistration*>& object_classes()
     return s_map;
 }
 
-ObjectClassRegistration::ObjectClassRegistration(StringView class_name, Function<RefPtr<Object>()> factory, ObjectClassRegistration* parent_class)
+ObjectClassRegistration::ObjectClassRegistration(StringView class_name, Function<ErrorOr<NonnullRefPtr<Object>>()> factory, ObjectClassRegistration* parent_class)
     : m_class_name(class_name)
     , m_factory(move(factory))
     , m_parent_class(parent_class)

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -22,18 +22,18 @@
 
 namespace Core {
 
-#define REGISTER_ABSTRACT_CORE_OBJECT(namespace_, class_name)                                                                     \
-    namespace Core {                                                                                                              \
-    namespace Registration {                                                                                                      \
-    Core::ObjectClassRegistration registration_##class_name(#namespace_ "::" #class_name##sv, []() { return RefPtr<Object>(); }); \
-    }                                                                                                                             \
+#define REGISTER_ABSTRACT_CORE_OBJECT(namespace_, class_name)                                                                                                                             \
+    namespace Core {                                                                                                                                                                      \
+    namespace Registration {                                                                                                                                                              \
+    Core::ObjectClassRegistration registration_##class_name(#namespace_ "::" #class_name##sv, []() { return Error::from_string_literal("Attempted to construct an abstract object."); }); \
+    }                                                                                                                                                                                     \
     }
 
-#define REGISTER_CORE_OBJECT(namespace_, class_name)                                                                                                 \
-    namespace Core {                                                                                                                                 \
-    namespace Registration {                                                                                                                         \
-    Core::ObjectClassRegistration registration_##class_name(#namespace_ "::" #class_name##sv, []() { return namespace_::class_name::construct(); }); \
-    }                                                                                                                                                \
+#define REGISTER_CORE_OBJECT(namespace_, class_name)                                                                                                  \
+    namespace Core {                                                                                                                                  \
+    namespace Registration {                                                                                                                          \
+    Core::ObjectClassRegistration registration_##class_name(#namespace_ "::" #class_name##sv, []() { return namespace_::class_name::try_create(); }); \
+    }                                                                                                                                                 \
     }
 
 class ObjectClassRegistration {
@@ -41,12 +41,12 @@ class ObjectClassRegistration {
     AK_MAKE_NONMOVABLE(ObjectClassRegistration);
 
 public:
-    ObjectClassRegistration(StringView class_name, Function<RefPtr<Object>()> factory, ObjectClassRegistration* parent_class = nullptr);
+    ObjectClassRegistration(StringView class_name, Function<ErrorOr<NonnullRefPtr<Object>>()> factory, ObjectClassRegistration* parent_class = nullptr);
     ~ObjectClassRegistration() = default;
 
     StringView class_name() const { return m_class_name; }
     ObjectClassRegistration const* parent_class() const { return m_parent_class; }
-    RefPtr<Object> construct() const { return m_factory(); }
+    ErrorOr<NonnullRefPtr<Object>> construct() const { return m_factory(); }
     bool is_derived_from(ObjectClassRegistration const& base_class) const;
 
     static void for_each(Function<void(ObjectClassRegistration const&)>);
@@ -54,7 +54,7 @@ public:
 
 private:
     StringView m_class_name;
-    Function<RefPtr<Object>()> m_factory;
+    Function<ErrorOr<NonnullRefPtr<Object>>()> m_factory;
     ObjectClassRegistration* m_parent_class { nullptr };
 };
 

--- a/Userland/Libraries/LibGUI/GML/AST.h
+++ b/Userland/Libraries/LibGUI/GML/AST.h
@@ -202,18 +202,18 @@ public:
         }
     }
 
-    // Uses IterationDecision to allow the callback to interrupt the iteration, like a for-loop break.
-    template<IteratorFunction<NonnullRefPtr<Object>> Callback>
-    void for_each_child_object_interruptible(Callback callback)
+    template<FallibleFunction<NonnullRefPtr<Object>> Callback>
+    ErrorOr<void> try_for_each_child_object(Callback callback)
     {
         for (NonnullRefPtr<Node> child : m_sub_objects) {
             // doesn't capture layout as intended, as that's behind a kv-pair
             if (is<Object>(child.ptr())) {
                 auto object = static_ptr_cast<Object>(child);
-                if (callback(object) == IterationDecision::Break)
-                    return;
+                TRY(callback(object));
             }
         }
+
+        return {};
     }
 
     RefPtr<Object> layout_object() const

--- a/Userland/Libraries/LibGUI/GML/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GML/AutocompleteProvider.cpp
@@ -143,8 +143,8 @@ void AutocompleteProvider::provide_completions(Function<void(Vector<CodeComprehe
         // FIXME: Don't show properties that are already specified in the scope.
         auto registration = Core::ObjectClassRegistration::find(class_name);
         if (registration && (registration->is_derived_from(widget_class) || registration->is_derived_from(layout_class))) {
-            if (auto instance = registration->construct()) {
-                for (auto& it : instance->properties()) {
+            if (auto instance = registration->construct(); !instance.is_error()) {
+                for (auto& it : instance.value()->properties()) {
                     if (!it.value->is_readonly() && it.key.matches(pattern))
                         identifier_entries.empend(DeprecatedString::formatted("{}: ", it.key), partial_input_length, CodeComprehension::Language::Unspecified, it.key);
                 }

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -102,7 +102,7 @@ void ScrollableContainerWidget::set_widget(GUI::Widget* widget)
     update_widget_position();
 }
 
-ErrorOr<void> ScrollableContainerWidget::load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, RefPtr<Core::Object> (*unregistered_child_handler)(DeprecatedString const&))
+ErrorOr<void> ScrollableContainerWidget::load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&))
 {
     if (is<GUI::GML::GMLFile>(ast.ptr()))
         return load_from_gml_ast(static_ptr_cast<GUI::GML::GMLFile>(ast)->main_class(), unregistered_child_handler);
@@ -133,7 +133,7 @@ ErrorOr<void> ScrollableContainerWidget::load_from_gml_ast(NonnullRefPtr<GUI::GM
         if (auto* registration = Core::ObjectClassRegistration::find(class_name)) {
             child = TRY(registration->construct());
         } else {
-            child = unregistered_child_handler(class_name);
+            child = TRY(unregistered_child_handler(class_name));
         }
         if (!child)
             return Error::from_string_literal("Unable to construct a Widget class for ScrollableContainerWidget content_widget property");

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
@@ -30,7 +30,7 @@ private:
     void update_widget_size();
     void update_widget_position();
     void update_widget_min_size();
-    virtual bool load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, RefPtr<Core::Object> (*unregistered_child_handler)(DeprecatedString const&)) override;
+    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, RefPtr<Core::Object> (*unregistered_child_handler)(DeprecatedString const&)) override;
 
     ScrollableContainerWidget();
 

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
@@ -30,7 +30,7 @@ private:
     void update_widget_size();
     void update_widget_position();
     void update_widget_min_size();
-    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, RefPtr<Core::Object> (*unregistered_child_handler)(DeprecatedString const&)) override;
+    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&)) override;
 
     ScrollableContainerWidget();
 

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -354,11 +354,11 @@ public:
     void set_override_cursor(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>>);
 
     ErrorOr<void> try_load_from_gml(StringView);
-    ErrorOr<void> try_load_from_gml(StringView, RefPtr<Core::Object> (*unregistered_child_handler)(DeprecatedString const&));
+    ErrorOr<void> try_load_from_gml(StringView, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&));
 
     // FIXME: Replace all uses of load_from_gml() with try_load_from_gml()
     bool load_from_gml(StringView gml_string);
-    bool load_from_gml(StringView, RefPtr<Core::Object> (*unregistered_child_handler)(DeprecatedString const&));
+    bool load_from_gml(StringView, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&));
 
     // FIXME: remove this when all uses of shrink_to_fit are eliminated
     void set_shrink_to_fit(bool);
@@ -367,7 +367,7 @@ public:
     bool has_pending_drop() const;
 
     // In order for others to be able to call this, it needs to be public.
-    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, RefPtr<Core::Object> (*unregistered_child_handler)(DeprecatedString const&));
+    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&));
 
 protected:
     Widget();


### PR DESCRIPTION
This rewrites the loading-from-gml stuff to call the `try_create()` factory function instead of `construct()` to create objects.

The old `load_from_gml()` API is still around for now, it just calls the new ErrorOr version internally, so we can convert things gradually.

I've converted Snake here, as an example.