### PR TITLE
LibJS: Remove call to ToPositiveInteger after CalendarDaysInMonth

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -343,7 +343,7 @@ ThrowCompletionOr<Value> calendar_days_in_week(VM& vm, Object& calendar, Object&
 }
 
 // 12.2.17 CalendarDaysInMonth ( calendar, dateLike ), https://tc39.es/proposal-temporal/#sec-temporal-calendardaysinmonth
-ThrowCompletionOr<Value> calendar_days_in_month(VM& vm, Object& calendar, Object& date_like)
+ThrowCompletionOr<double> calendar_days_in_month(VM& vm, Object& calendar, Object& date_like)
 {
     // 1. Assert: Type(calendar) is Object.
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
@@ -55,7 +55,7 @@ ThrowCompletionOr<Value> calendar_day_of_year(VM&, Object& calendar, Object& dat
 ThrowCompletionOr<Value> calendar_week_of_year(VM&, Object& calendar, Object& date_like);
 ThrowCompletionOr<Value> calendar_year_of_week(VM&, Object& calendar, Object& date_like);
 ThrowCompletionOr<Value> calendar_days_in_week(VM&, Object& calendar, Object& date_like);
-ThrowCompletionOr<Value> calendar_days_in_month(VM&, Object& calendar, Object& date_like);
+ThrowCompletionOr<double> calendar_days_in_month(VM&, Object& calendar, Object& date_like);
 ThrowCompletionOr<Value> calendar_days_in_year(VM&, Object& calendar, Object& date_like);
 ThrowCompletionOr<Value> calendar_months_in_year(VM&, Object& calendar, Object& date_like);
 ThrowCompletionOr<Value> calendar_in_leap_year(VM&, Object& calendar, Object& date_like);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
@@ -287,7 +287,7 @@ ThrowCompletionOr<Duration*> difference_temporal_plain_year_month(VM& vm, Differ
     return MUST(create_temporal_duration(vm, sign * result.years, sign * result.months, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
-// 9.5.8 AddDurationToOrSubtractDurationFromPlainYearMonth ( operation, yearMonth, temporalDurationLike, options ), https://tc39.es/proposal-temporal/#sec-temporal-addtemporalplainyearmonth
+// 9.5.8 AddDurationToOrSubtractDurationFromPlainYearMonth ( operation, yearMonth, temporalDurationLike, options ), https://tc39.es/proposal-temporal/#sec-temporal-adddurationtoorsubtractdurationfromplainyearmonth
 ThrowCompletionOr<PlainYearMonth*> add_duration_to_or_subtract_duration_from_plain_year_month(VM& vm, ArithmeticOperation operation, PlainYearMonth& year_month, Value temporal_duration_like, Value options_value)
 {
     auto& realm = *vm.current_realm();
@@ -323,7 +323,7 @@ ThrowCompletionOr<PlainYearMonth*> add_duration_to_or_subtract_duration_from_pla
 
     // 9. If sign < 0, then
     if (sign < 0) {
-        // a. Let dayFromCalendar be ? CalendarDaysInMonth(calendar, yearMonth).
+        // a. Let day be ? CalendarDaysInMonth(calendar, yearMonth).
         day = TRY(calendar_days_in_month(vm, calendar, year_month));
     }
     // 10. Else,

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
@@ -324,10 +324,7 @@ ThrowCompletionOr<PlainYearMonth*> add_duration_to_or_subtract_duration_from_pla
     // 9. If sign < 0, then
     if (sign < 0) {
         // a. Let dayFromCalendar be ? CalendarDaysInMonth(calendar, yearMonth).
-        auto day_from_calendar = TRY(calendar_days_in_month(vm, calendar, year_month));
-
-        // b. Let day be ? ToPositiveInteger(dayFromCalendar).
-        day = TRY(to_positive_integer(vm, day_from_calendar));
+        day = TRY(calendar_days_in_month(vm, calendar, year_month));
     }
     // 10. Else,
     else {


### PR DESCRIPTION
Implements: https://github.com/tc39/proposal-temporal/commit/261692a
Fixes a part of #15525

In order to remove the call to to_positive_integer() there neeeded
to be a change of return type from ThrowCompletionOr<Value> to
ThrowCompletionOr<double>.
This is one of the changes that will come anyways with the following
commit: https://github.com/tc39/proposal-temporal/commit/11aad40. :^)