### PR TITLE
Documentation: Add troubleshooting note regarding KVM GDB

### DIFF
--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -58,3 +58,8 @@ extensions, or you try to use VirtualBox without using a x64 virtualization mode
 - If booting on bare metal, your CPU is too old to boot Serenity.
 - If you're using VirtualBox, you need to enable PAE/NX. Check the instructions [here.](VirtualBox.md)
 - If you're using QEMU, the [CPU model configuration](https://qemu-project.gitlab.io/qemu/system/qemu-cpu-models.html) is not exposing PAE.
+
+### Boot fails with "KVM doesn't support guest debugging"
+- Update your host kernel to at least version `5.10`. This is the oldest kernel which properly supports the required KVM capability `KVM_CAP_SET_GUEST_DEBUG` (see corresponding [kernel commit](https://github.com/torvalds/linux/commit/b9b2782cd5)).
+- Make sure that your distro has the qemu debug feature actually enabled (the corresponding check is [here](https://gitlab.com/qemu-project/qemu/-/blob/222059a0fccf4af3be776fe35a5ea2d6a68f9a0b/accel/kvm/kvm-all.c#L2540)). 
+- Or, disable KVM debugging by setting this env var when running serenity: `SERENITY_DISABLE_GDB_SOCKET=1`


### PR DESCRIPTION
The connection between the error message `qemu-system-x86_64: -gdb tcp:127.0.0.1:1234: gdbstub: KVM doesn't support guest debugging` and the kernel version is not immediately clear, at least for Qemu newbies like me.