### PR TITLE
LibWeb: Fix a (charming) comment typo

### DIFF
--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -45,17 +45,49 @@ enum class DeviceClass : u32 {
 };
 char const* device_class_name(DeviceClass);
 
+// ICC v4, 7.2.6 Data colour space field, Table 19 — Data colour space signatures
+enum class ColorSpace : u32 {
+    nCIEXYZ = 0x58595A20,       // 'XYZ '
+    CIELAB = 0x4C616220,        // 'Lab '
+    CIELUV = 0x4C757620,        // 'Luv '
+    YCbCr = 0x59436272,         // 'YCbr'
+    CIEYxy = 0x59787920,        // 'Yxy '
+    RGB = 0x52474220,           // 'RGB '
+    Gray = 0x47524159,          // 'GRAY'
+    HSV = 0x48535620,           // 'HSV '
+    HLS = 0x484C5320,           // 'HLS '
+    CMYK = 0x434D594B,          // 'CMYK'
+    CMY = 0x434D5920,           // 'CMY '
+    TwoColor = 0x32434C52,      // '2CLR'
+    ThreeColor = 0x33434C52,    // '3CLR'
+    FourColor = 0x34434C52,     // '4CLR'
+    FiveColor = 0x35434C52,     // '5CLR'
+    SixColor = 0x36434C52,      // '6CLR'
+    SevenColor = 0x37434C52,    // '7CLR'
+    EightColor = 0x38434C52,    // '8CLR'
+    NineColor = 0x39434C52,     // '9CLR'
+    TenColor = 0x41434C52,      // 'ACLR'
+    ElevenColor = 0x42434C52,   // 'BCLR'
+    TwelveColor = 0x43434C52,   // 'CCLR'
+    ThirteenColor = 0x44434C52, // 'DCLR'
+    FourteenColor = 0x45434C52, // 'ECLR'
+    FifteenColor = 0x46434C52,  // 'FCLR'
+};
+char const* color_space_name(ColorSpace);
+
 class Profile : public RefCounted<Profile> {
 public:
     static ErrorOr<NonnullRefPtr<Profile>> try_load_from_externally_owned_memory(ReadonlyBytes bytes);
 
     Version version() const { return m_version; }
     DeviceClass device_class() const { return m_device_class; }
+    ColorSpace data_color_space() const { return m_data_color_space; }
     time_t creation_timestamp() const { return m_creation_timestamp; }
 
 private:
     Version m_version;
     DeviceClass m_device_class;
+    ColorSpace m_data_color_space;
     time_t m_creation_timestamp;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -93,7 +93,7 @@ void CanvasRenderingContext2D::stroke_rect(float x, float y, float width, float 
     auto& drawing_state = this->drawing_state();
 
     auto rect = drawing_state.transform.map(Gfx::FloatRect(x, y, width, height));
-    // We could remove the rounding here, but the lines look better when they have whole number pixel endponts.
+    // We could remove the rounding here, but the lines look better when they have whole number pixel endpoints.
     auto top_left = drawing_state.transform.map(Gfx::FloatPoint(x, y)).to_rounded<float>();
     auto top_right = drawing_state.transform.map(Gfx::FloatPoint(x + width - 1, y)).to_rounded<float>();
     auto bottom_left = drawing_state.transform.map(Gfx::FloatPoint(x, y + height - 1)).to_rounded<float>();

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -23,6 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     outln("version: {}", profile->version());
     outln("device class: {}", Gfx::ICC::device_class_name(profile->device_class()));
+    outln("data color space: {}", Gfx::ICC::color_space_name(profile->data_color_space()));
     outln("creation date and time: {}", Core::DateTime::from_timestamp(profile->creation_timestamp()).to_deprecated_string());
 
     return 0;


### PR DESCRIPTION
While here, dump the data color space of an ICC profile. (This is adding something about color spaces to ICCProfile instead of just adding color-unrelated metadata as before.)