### PR TITLE
Toolchain: Fix aarch64 toolchain GDB build

### DIFF
--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -340,6 +340,7 @@ pushd "$DIR/Build/$ARCH"
                                                         --target="$TARGET" \
                                                         --with-sysroot="$SYSROOT" \
                                                         --enable-shared \
+                                                        --disable-werror \
                                                         --disable-nls \
                                                         ${TRY_USE_LOCAL_TOOLCHAIN:+"--quiet"} || exit 1
             fi


### PR DESCRIPTION
We just need to pass -disable-werror, otherwise Clang will complain a lot.