### PR TITLE
LibWeb: CSS don't set resolve-failures (var/attr)

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -787,7 +787,8 @@ void StyleComputer::cascade_declarations(StyleProperties& style, DOM::Element& e
                 if (auto resolved = resolve_unresolved_style_value(element, property.property_id, property.value->as_unresolved()))
                     property_value = resolved.release_nonnull();
             }
-            set_property_expanding_shorthands(style, property.property_id, property_value, m_document);
+            if (!property_value->is_unresolved())
+                set_property_expanding_shorthands(style, property.property_id, property_value, m_document);
         }
     }
 
@@ -801,7 +802,8 @@ void StyleComputer::cascade_declarations(StyleProperties& style, DOM::Element& e
                     if (auto resolved = resolve_unresolved_style_value(element, property.property_id, property.value->as_unresolved()))
                         property_value = resolved.release_nonnull();
                 }
-                set_property_expanding_shorthands(style, property.property_id, property_value, m_document);
+                if (!property_value->is_unresolved())
+                    set_property_expanding_shorthands(style, property.property_id, property_value, m_document);
             }
         }
     }


### PR DESCRIPTION
Previously when resolving an attr or var-defined property with a "not-set" value like this `property: var(--ValueNotSet)`, we left the property unchanged (as an unresolved). We still don't change the property but rather we now also don't set unresolved properties. This is an intended behavior.

**[The Specification](https://www.w3.org/TR/css-variables-1/#invalid-variables)** suggests that, on resolving an attr or var property (custom properties) we have an invalid property when neither the variable inside the var, nor the backup value could be resolved.

An invalid property must be inherited or defaulted depending on it's type. We already do this with every "untouched" (as in m_property_values contains no entry for it) value. So not setting the var results in an inherited (or initial) value.

This also fixes another problem, where `text-decoration: var(--NotSet)` wouldn't be inherited, because the parent Elements didn't set `text-decoration` but rather all it's long-versions like `text-decoration-line` and so on.