### PR TITLE
LibGUI+Userland: Make the InputBox be able to validate input for not being empty, and use it

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -438,7 +438,7 @@ void BrowserWindow::build_menus()
 
     auto custom_user_agent = GUI::Action::create_checkable("Custom...", [this](auto& action) {
         DeprecatedString user_agent;
-        if (GUI::InputBox::show(this, user_agent, "Enter User Agent:"sv, "Custom User Agent"sv) != GUI::InputBox::ExecResult::OK || user_agent.is_empty() || user_agent.is_null()) {
+        if (GUI::InputBox::show(this, user_agent, "Enter User Agent:"sv, "Custom User Agent"sv, {}, GUI::InputType::NonemptyText) != GUI::InputBox::ExecResult::OK) {
             m_disable_user_agent_spoofing->activate();
             return;
         }
@@ -529,7 +529,7 @@ ErrorOr<void> BrowserWindow::load_search_engines(GUI::Menu& settings_menu)
 
     auto custom_search_engine_action = GUI::Action::create_checkable("Custom...", [&](auto& action) {
         DeprecatedString search_engine;
-        if (GUI::InputBox::show(this, search_engine, "Enter URL template:"sv, "Custom Search Engine"sv, "https://host/search?q={}"sv) != GUI::InputBox::ExecResult::OK || search_engine.is_empty()) {
+        if (GUI::InputBox::show(this, search_engine, "Enter URL template:"sv, "Custom Search Engine"sv, "https://host/search?q={}"sv, GUI::InputType::NonemptyText) != GUI::InputBox::ExecResult::OK) {
             m_disable_search_engine_action->activate();
             return;
         }

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -438,7 +438,7 @@ void BrowserWindow::build_menus()
 
     auto custom_user_agent = GUI::Action::create_checkable("Custom...", [this](auto& action) {
         DeprecatedString user_agent;
-        if (GUI::InputBox::show(this, user_agent, "Enter User Agent:"sv, "Custom User Agent"sv, {}, GUI::InputType::NonemptyText) != GUI::InputBox::ExecResult::OK) {
+        if (GUI::InputBox::show(this, user_agent, "Enter User Agent:"sv, "Custom User Agent"sv, GUI::InputType::NonemptyText) != GUI::InputBox::ExecResult::OK) {
             m_disable_user_agent_spoofing->activate();
             return;
         }
@@ -529,7 +529,7 @@ ErrorOr<void> BrowserWindow::load_search_engines(GUI::Menu& settings_menu)
 
     auto custom_search_engine_action = GUI::Action::create_checkable("Custom...", [&](auto& action) {
         DeprecatedString search_engine;
-        if (GUI::InputBox::show(this, search_engine, "Enter URL template:"sv, "Custom Search Engine"sv, "https://host/search?q={}"sv, GUI::InputType::NonemptyText) != GUI::InputBox::ExecResult::OK) {
+        if (GUI::InputBox::show(this, search_engine, "Enter URL template:"sv, "Custom Search Engine"sv, GUI::InputType::NonemptyText, "https://host/search?q={}"sv) != GUI::InputBox::ExecResult::OK) {
             m_disable_search_engine_action->activate();
             return;
         }

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -119,7 +119,7 @@ ContentFilterSettingsWidget::ContentFilterSettingsWidget()
     m_add_new_domain_button->on_click = [&](unsigned) {
         DeprecatedString text;
 
-        if (GUI::InputBox::show(window(), text, "Enter domain name"sv, "Add domain to Content Filter"sv, {}, GUI::InputType::NonemptyText) == GUI::Dialog::ExecResult::OK) {
+        if (GUI::InputBox::show(window(), text, "Enter domain name"sv, "Add domain to Content Filter"sv, GUI::InputType::NonemptyText) == GUI::Dialog::ExecResult::OK) {
             m_domain_list_model->add_domain(move(text));
             set_modified(true);
         }

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -119,8 +119,7 @@ ContentFilterSettingsWidget::ContentFilterSettingsWidget()
     m_add_new_domain_button->on_click = [&](unsigned) {
         DeprecatedString text;
 
-        if (GUI::InputBox::show(window(), text, "Enter domain name"sv, "Add domain to Content Filter"sv) == GUI::Dialog::ExecResult::OK
-            && !text.is_empty()) {
+        if (GUI::InputBox::show(window(), text, "Enter domain name"sv, "Add domain to Content Filter"sv, {}, GUI::InputType::NonemptyText) == GUI::Dialog::ExecResult::OK) {
             m_domain_list_model->add_domain(move(text));
             set_modified(true);
         }

--- a/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
@@ -70,7 +70,7 @@ CharacterMapWidget::CharacterMapWidget()
 
     m_go_to_glyph_action = GUI::Action::create("Go to glyph...", { Mod_Ctrl, Key_G }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-to.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         DeprecatedString input;
-        if (GUI::InputBox::show(window(), input, "Hexadecimal:"sv, "Go to glyph"sv) == GUI::InputBox::ExecResult::OK && !input.is_empty()) {
+        if (GUI::InputBox::show(window(), input, "Hexadecimal:"sv, "Go to glyph"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto maybe_code_point = AK::StringUtils::convert_to_uint_from_hex(input);
             if (!maybe_code_point.has_value())
                 return;

--- a/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
@@ -70,7 +70,7 @@ CharacterMapWidget::CharacterMapWidget()
 
     m_go_to_glyph_action = GUI::Action::create("Go to glyph...", { Mod_Ctrl, Key_G }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-to.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         DeprecatedString input;
-        if (GUI::InputBox::show(window(), input, "Hexadecimal:"sv, "Go to glyph"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
+        if (GUI::InputBox::show(window(), input, "Hexadecimal:"sv, "Go to glyph"sv, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto maybe_code_point = AK::StringUtils::convert_to_uint_from_hex(input);
             if (!maybe_code_point.has_value())
                 return;

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -571,7 +571,7 @@ void DirectoryView::setup_actions()
 {
     m_mkdir_action = GUI::Action::create("&New Directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/mkdir.png"sv).release_value_but_fixme_should_propagate_errors(), [&](GUI::Action const&) {
         DeprecatedString value;
-        if (GUI::InputBox::show(window(), value, "Enter name:"sv, "New directory"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
+        if (GUI::InputBox::show(window(), value, "Enter name:"sv, "New directory"sv, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto new_dir_path = LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", path(), value));
             int rc = mkdir(new_dir_path.characters(), 0777);
             if (rc < 0) {
@@ -583,7 +583,7 @@ void DirectoryView::setup_actions()
 
     m_touch_action = GUI::Action::create("New &File...", { Mod_Ctrl | Mod_Shift, Key_F }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png"sv).release_value_but_fixme_should_propagate_errors(), [&](GUI::Action const&) {
         DeprecatedString value;
-        if (GUI::InputBox::show(window(), value, "Enter name:"sv, "New file"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
+        if (GUI::InputBox::show(window(), value, "Enter name:"sv, "New file"sv, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto new_file_path = LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", path(), value));
             struct stat st;
             int rc = stat(new_file_path.characters(), &st);

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -571,7 +571,7 @@ void DirectoryView::setup_actions()
 {
     m_mkdir_action = GUI::Action::create("&New Directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/mkdir.png"sv).release_value_but_fixme_should_propagate_errors(), [&](GUI::Action const&) {
         DeprecatedString value;
-        if (GUI::InputBox::show(window(), value, "Enter name:"sv, "New directory"sv) == GUI::InputBox::ExecResult::OK && !value.is_empty()) {
+        if (GUI::InputBox::show(window(), value, "Enter name:"sv, "New directory"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto new_dir_path = LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", path(), value));
             int rc = mkdir(new_dir_path.characters(), 0777);
             if (rc < 0) {
@@ -583,7 +583,7 @@ void DirectoryView::setup_actions()
 
     m_touch_action = GUI::Action::create("New &File...", { Mod_Ctrl | Mod_Shift, Key_F }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png"sv).release_value_but_fixme_should_propagate_errors(), [&](GUI::Action const&) {
         DeprecatedString value;
-        if (GUI::InputBox::show(window(), value, "Enter name:"sv, "New file"sv) == GUI::InputBox::ExecResult::OK && !value.is_empty()) {
+        if (GUI::InputBox::show(window(), value, "Enter name:"sv, "New file"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto new_file_path = LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", path(), value));
             struct stat st;
             int rc = stat(new_file_path.characters(), &st);

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -243,7 +243,7 @@ ErrorOr<void> MainWidget::create_actions()
 
     m_go_to_glyph_action = GUI::Action::create("&Go to Glyph...", { Mod_Ctrl, Key_G }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-to.png"sv)), [&](auto&) {
         DeprecatedString input;
-        if (GUI::InputBox::show(window(), input, "Hexadecimal:"sv, "Go to glyph"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
+        if (GUI::InputBox::show(window(), input, "Hexadecimal:"sv, "Go to glyph"sv, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto maybe_code_point = AK::StringUtils::convert_to_uint_from_hex(input);
             if (!maybe_code_point.has_value())
                 return;

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -243,7 +243,7 @@ ErrorOr<void> MainWidget::create_actions()
 
     m_go_to_glyph_action = GUI::Action::create("&Go to Glyph...", { Mod_Ctrl, Key_G }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-to.png"sv)), [&](auto&) {
         DeprecatedString input;
-        if (GUI::InputBox::show(window(), input, "Hexadecimal:"sv, "Go to glyph"sv) == GUI::InputBox::ExecResult::OK && !input.is_empty()) {
+        if (GUI::InputBox::show(window(), input, "Hexadecimal:"sv, "Go to glyph"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto maybe_code_point = AK::StringUtils::convert_to_uint_from_hex(input);
             if (!maybe_code_point.has_value())
                 return;

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -100,7 +100,7 @@ HexEditorWidget::HexEditorWidget()
 
     m_new_action = GUI::Action::create("New", { Mod_Ctrl, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png"sv).release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
         DeprecatedString value;
-        if (request_close() && GUI::InputBox::show(window(), value, "Enter new file size:"sv, "New file size"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
+        if (request_close() && GUI::InputBox::show(window(), value, "Enter new file size:"sv, "New file size"sv, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto file_size = value.to_uint();
             if (!file_size.has_value()) {
                 GUI::MessageBox::show(window(), "Invalid file size entered."sv, "Error"sv, GUI::MessageBox::Type::Error);
@@ -243,7 +243,7 @@ HexEditorWidget::HexEditorWidget()
 
     m_fill_selection_action = GUI::Action::create("Fill &Selection...", { Mod_Ctrl, Key_B }, [&](const GUI::Action&) {
         DeprecatedString value;
-        if (GUI::InputBox::show(window(), value, "Fill byte (hex):"sv, "Fill Selection"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
+        if (GUI::InputBox::show(window(), value, "Fill byte (hex):"sv, "Fill Selection"sv, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto fill_byte = strtol(value.characters(), nullptr, 16);
             auto result = m_editor->fill_selection(fill_byte);
             if (result.is_error())

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -100,7 +100,7 @@ HexEditorWidget::HexEditorWidget()
 
     m_new_action = GUI::Action::create("New", { Mod_Ctrl, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png"sv).release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
         DeprecatedString value;
-        if (request_close() && GUI::InputBox::show(window(), value, "Enter new file size:"sv, "New file size"sv) == GUI::InputBox::ExecResult::OK && !value.is_empty()) {
+        if (request_close() && GUI::InputBox::show(window(), value, "Enter new file size:"sv, "New file size"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto file_size = value.to_uint();
             if (!file_size.has_value()) {
                 GUI::MessageBox::show(window(), "Invalid file size entered."sv, "Error"sv, GUI::MessageBox::Type::Error);
@@ -243,7 +243,7 @@ HexEditorWidget::HexEditorWidget()
 
     m_fill_selection_action = GUI::Action::create("Fill &Selection...", { Mod_Ctrl, Key_B }, [&](const GUI::Action&) {
         DeprecatedString value;
-        if (GUI::InputBox::show(window(), value, "Fill byte (hex):"sv, "Fill Selection"sv) == GUI::InputBox::ExecResult::OK && !value.is_empty()) {
+        if (GUI::InputBox::show(window(), value, "Fill byte (hex):"sv, "Fill Selection"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto fill_byte = strtol(value.characters(), nullptr, 16);
             auto result = m_editor->fill_selection(fill_byte);
             if (result.is_error())

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -370,7 +370,7 @@ PDF::PDFErrorOr<void> PDFViewerWidget::try_open_file(StringView path, NonnullOwn
     if (auto sh = document->security_handler(); sh && !sh->has_user_password()) {
         DeprecatedString password;
         while (true) {
-            auto result = GUI::InputBox::show(window(), password, "Password"sv, "Password required"sv, {}, GUI::InputType::Password);
+            auto result = GUI::InputBox::show(window(), password, "Password"sv, "Password required"sv, GUI::InputType::Password);
             if (result == GUI::Dialog::ExecResult::OK
                 && document->security_handler()->try_provide_user_password(password))
                 break;

--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -119,7 +119,7 @@ GalleryWidget::GalleryWidget()
 
     m_input_button->on_click = [&](auto) {
         DeprecatedString value;
-        if (GUI::InputBox::show(window(), value, "Enter input:"sv, "Input"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK)
+        if (GUI::InputBox::show(window(), value, "Enter input:"sv, "Input"sv, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK)
             m_text_editor->set_text(value);
     };
 

--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -119,7 +119,7 @@ GalleryWidget::GalleryWidget()
 
     m_input_button->on_click = [&](auto) {
         DeprecatedString value;
-        if (GUI::InputBox::show(window(), value, "Enter input:"sv, "Input"sv) == GUI::InputBox::ExecResult::OK && !value.is_empty())
+        if (GUI::InputBox::show(window(), value, "Enter input:"sv, "Input"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK)
             m_text_editor->set_text(value);
     };
 

--- a/Userland/Games/MasterWord/main.cpp
+++ b/Userland/Games/MasterWord/main.cpp
@@ -76,7 +76,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(settings_menu->try_add_action(GUI::Action::create("Set &Word Length", [&](auto&) {
         auto word_length = Config::read_i32("MasterWord"sv, ""sv, "word_length"sv, 5);
         auto word_length_string = DeprecatedString::number(word_length);
-        if (GUI::InputBox::show(window, word_length_string, "Word length:"sv, "MasterWord"sv) == GUI::InputBox::ExecResult::OK && !word_length_string.is_empty()) {
+        if (GUI::InputBox::show(window, word_length_string, "Word length:"sv, "MasterWord"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto maybe_word_length = word_length_string.template to_uint();
             if (!maybe_word_length.has_value() || maybe_word_length.value() < shortest_word || maybe_word_length.value() > longest_word) {
                 GUI::MessageBox::show(window, DeprecatedString::formatted("Please enter a number between {} and {}.", shortest_word, longest_word), "MasterWord"sv);
@@ -92,7 +92,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(settings_menu->try_add_action(GUI::Action::create("Set &Number Of Guesses", [&](auto&) {
         auto max_guesses = Config::read_i32("MasterWord"sv, ""sv, "max_guesses"sv, 5);
         auto max_guesses_string = DeprecatedString::number(max_guesses);
-        if (GUI::InputBox::show(window, max_guesses_string, "Maximum number of guesses:"sv, "MasterWord"sv) == GUI::InputBox::ExecResult::OK && !max_guesses_string.is_empty()) {
+        if (GUI::InputBox::show(window, max_guesses_string, "Maximum number of guesses:"sv, "MasterWord"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto maybe_max_guesses = max_guesses_string.template to_uint();
             if (!maybe_max_guesses.has_value() || maybe_max_guesses.value() < 1 || maybe_max_guesses.value() > 20) {
                 GUI::MessageBox::show(window, "Please enter a number between 1 and 20."sv, "MasterWord"sv);

--- a/Userland/Games/MasterWord/main.cpp
+++ b/Userland/Games/MasterWord/main.cpp
@@ -76,7 +76,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(settings_menu->try_add_action(GUI::Action::create("Set &Word Length", [&](auto&) {
         auto word_length = Config::read_i32("MasterWord"sv, ""sv, "word_length"sv, 5);
         auto word_length_string = DeprecatedString::number(word_length);
-        if (GUI::InputBox::show(window, word_length_string, "Word length:"sv, "MasterWord"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
+        if (GUI::InputBox::show(window, word_length_string, "Word length:"sv, "MasterWord"sv, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto maybe_word_length = word_length_string.template to_uint();
             if (!maybe_word_length.has_value() || maybe_word_length.value() < shortest_word || maybe_word_length.value() > longest_word) {
                 GUI::MessageBox::show(window, DeprecatedString::formatted("Please enter a number between {} and {}.", shortest_word, longest_word), "MasterWord"sv);
@@ -92,7 +92,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(settings_menu->try_add_action(GUI::Action::create("Set &Number Of Guesses", [&](auto&) {
         auto max_guesses = Config::read_i32("MasterWord"sv, ""sv, "max_guesses"sv, 5);
         auto max_guesses_string = DeprecatedString::number(max_guesses);
-        if (GUI::InputBox::show(window, max_guesses_string, "Maximum number of guesses:"sv, "MasterWord"sv, {}, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
+        if (GUI::InputBox::show(window, max_guesses_string, "Maximum number of guesses:"sv, "MasterWord"sv, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto maybe_max_guesses = max_guesses_string.template to_uint();
             if (!maybe_max_guesses.has_value() || maybe_max_guesses.value() < 1 || maybe_max_guesses.value() > 20) {
                 GUI::MessageBox::show(window, "Please enter a number between 1 and 20."sv, "MasterWord"sv);

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -129,7 +129,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
     auto mkdir_action = Action::create(
         "New directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/mkdir.png"sv).release_value_but_fixme_should_propagate_errors(), [this](Action const&) {
             DeprecatedString value;
-            if (InputBox::show(this, value, "Enter name:"sv, "New directory"sv, {}, GUI::InputType::NonemptyText) == InputBox::ExecResult::OK) {
+            if (InputBox::show(this, value, "Enter name:"sv, "New directory"sv, GUI::InputType::NonemptyText) == InputBox::ExecResult::OK) {
                 auto new_dir_path = LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", m_model->root_path(), value));
                 int rc = mkdir(new_dir_path.characters(), 0777);
                 if (rc < 0) {

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -129,7 +129,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
     auto mkdir_action = Action::create(
         "New directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/mkdir.png"sv).release_value_but_fixme_should_propagate_errors(), [this](Action const&) {
             DeprecatedString value;
-            if (InputBox::show(this, value, "Enter name:"sv, "New directory"sv) == InputBox::ExecResult::OK && !value.is_empty()) {
+            if (InputBox::show(this, value, "Enter name:"sv, "New directory"sv, {}, GUI::InputType::NonemptyText) == InputBox::ExecResult::OK) {
                 auto new_dir_path = LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", m_model->root_path(), value));
                 int rc = mkdir(new_dir_path.characters(), 0777);
                 if (rc < 0) {

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -71,6 +71,7 @@ void InputBox::build(InputType input_type)
 
     switch (input_type) {
     case InputType::Text:
+    case InputType::NonemptyText:
         m_text_editor = label_editor_container.add<TextBox>();
         break;
     case InputType::Password:
@@ -112,6 +113,13 @@ void InputBox::build(InputType input_type)
         m_cancel_button->click();
     };
     m_text_editor->set_focus(true);
+
+    if (input_type == InputType::NonemptyText) {
+        m_text_editor->on_change = [this] {
+            m_ok_button->set_enabled(!m_text_editor->text().is_empty());
+        };
+        m_text_editor->on_change();
+    }
 
     set_rect(x(), y(), max_width + 140, widget->effective_preferred_size().height().as_int());
 }

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -15,7 +15,7 @@
 
 namespace GUI {
 
-InputBox::InputBox(Window* parent_window, DeprecatedString text_value, StringView prompt, StringView title, StringView placeholder, InputType input_type)
+InputBox::InputBox(Window* parent_window, DeprecatedString text_value, StringView prompt, StringView title, InputType input_type, StringView placeholder)
     : Dialog(parent_window)
     , m_text_value(move(text_value))
     , m_prompt(prompt)
@@ -25,9 +25,9 @@ InputBox::InputBox(Window* parent_window, DeprecatedString text_value, StringVie
     build(input_type);
 }
 
-Dialog::ExecResult InputBox::show(Window* parent_window, DeprecatedString& text_value, StringView prompt, StringView title, StringView placeholder, InputType input_type)
+Dialog::ExecResult InputBox::show(Window* parent_window, DeprecatedString& text_value, StringView prompt, StringView title, InputType input_type, StringView placeholder)
 {
-    auto box = InputBox::construct(parent_window, text_value, prompt, title, placeholder, input_type);
+    auto box = InputBox::construct(parent_window, text_value, prompt, title, input_type, placeholder);
     box->set_resizable(false);
     if (parent_window)
         box->set_icon(parent_window->icon());

--- a/Userland/Libraries/LibGUI/InputBox.h
+++ b/Userland/Libraries/LibGUI/InputBox.h
@@ -23,13 +23,13 @@ class InputBox : public Dialog {
 public:
     virtual ~InputBox() override = default;
 
-    static ExecResult show(Window* parent_window, DeprecatedString& text_value, StringView prompt, StringView title, StringView placeholder = {}, InputType input_type = InputType::Text);
+    static ExecResult show(Window* parent_window, DeprecatedString& text_value, StringView prompt, StringView title, InputType input_type = InputType::Text, StringView placeholder = {});
 
     DeprecatedString const& text_value() const { return m_text_value; }
     void set_text_value(DeprecatedString text_value);
 
 private:
-    explicit InputBox(Window* parent_window, DeprecatedString text_value, StringView prompt, StringView title, StringView placeholder, InputType input_type);
+    explicit InputBox(Window* parent_window, DeprecatedString text_value, StringView prompt, StringView title, InputType input_type, StringView placeholder);
 
     virtual void on_done(ExecResult) override;
     void build(InputType input_type);

--- a/Userland/Libraries/LibGUI/InputBox.h
+++ b/Userland/Libraries/LibGUI/InputBox.h
@@ -32,10 +32,11 @@ private:
     explicit InputBox(Window* parent_window, DeprecatedString text_value, StringView prompt, StringView title, InputType input_type, StringView placeholder);
 
     virtual void on_done(ExecResult) override;
-    void build(InputType input_type);
+    void build();
 
     DeprecatedString m_text_value;
     DeprecatedString m_prompt;
+    InputType m_input_type;
     DeprecatedString m_placeholder;
 
     RefPtr<Button> m_ok_button;

--- a/Userland/Libraries/LibGUI/InputBox.h
+++ b/Userland/Libraries/LibGUI/InputBox.h
@@ -14,6 +14,7 @@ namespace GUI {
 
 enum class InputType {
     Text,
+    NonemptyText,
     Password
 };
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -367,7 +367,7 @@ void OutOfProcessWebView::notify_server_did_request_confirm(Badge<WebContentClie
 
 void OutOfProcessWebView::notify_server_did_request_prompt(Badge<WebContentClient>, DeprecatedString const& message, DeprecatedString const& default_)
 {
-    m_dialog = GUI::InputBox::construct(window(), default_, message, "Prompt"sv, StringView {}, GUI::InputType::Text);
+    m_dialog = GUI::InputBox::construct(window(), default_, message, "Prompt"sv, GUI::InputType::Text, StringView {});
     m_dialog->set_icon(window()->icon());
 
     if (m_dialog->exec() == GUI::InputBox::ExecResult::OK)


### PR DESCRIPTION
It seems like a lot (most?) places where InputBoxes are used check if the retrieved string isn't empty anyway - make this be reflected in the user interface, by disabling (graying out) the "OK" button when nothing is entered, so empty input isn't a viable option at all.

This PR accomplishes it by adding a new possible `GUI::InputType` option that can be passed to `InputBox::show`: `GUI::InputType::NonemptyText`.

| Example from FileManager |
|---|
| ![Example usage of NonnullTextType](https://user-images.githubusercontent.com/6043048/210110242-cf569aa3-4c88-484a-a414-cd4a2d1c7faa.gif) |
