### PR TITLE
Ladybird: Tell Qt that we manually handle the Cookie header

### DIFF
--- a/Ladybird/RequestManagerQt.cpp
+++ b/Ladybird/RequestManagerQt.cpp
@@ -41,6 +41,8 @@ ErrorOr<NonnullRefPtr<RequestManagerQt::Request>> RequestManagerQt::Request::cre
     QNetworkRequest request { QString(url.to_deprecated_string().characters()) };
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::ManualRedirectPolicy);
     request.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, true);
+    request.setAttribute(QNetworkRequest::CookieLoadControlAttribute, QNetworkRequest::Manual);
+    request.setAttribute(QNetworkRequest::CookieSaveControlAttribute, QNetworkRequest::Manual);
 
     // NOTE: We disable HTTP2 as it's significantly slower (up to 5x, possibly more)
     request.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);


### PR DESCRIPTION
In some cases, Qt would silently drop the Cookie header and start causing Cookie authenticated requests to start failing.