### PR TITLE
LibGUI: Cache Bitmap loads for all widgets

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -174,4 +174,9 @@ struct Formatter<String> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder&, String const&);
 };
 
+template<>
+inline constexpr bool Detail::IsHashCompatible<String, StringView> = true;
+template<>
+inline constexpr bool Detail::IsHashCompatible<StringView, String> = true;
+
 }

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
@@ -13,6 +13,7 @@
 #include <LibCore/ConfigFile.h>
 #include <LibCore/File.h>
 #include <LibGUI/AbstractThemePreview.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/Bitmap.h>
 
@@ -21,12 +22,12 @@ namespace GUI {
 AbstractThemePreview::AbstractThemePreview(Gfx::Palette const& preview_palette)
     : m_preview_palette(preview_palette)
 {
-    m_active_window_icon = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/window.png"sv).release_value_but_fixme_should_propagate_errors();
-    m_inactive_window_icon = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/window.png"sv).release_value_but_fixme_should_propagate_errors();
+    m_active_window_icon = BitmapCache::load_bitmap("/res/icons/16x16/window.png"sv).release_value_but_fixme_should_propagate_errors();
+    m_inactive_window_icon = BitmapCache::load_bitmap("/res/icons/16x16/window.png"sv).release_value_but_fixme_should_propagate_errors();
 
-    m_default_close_bitmap = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/window-close.png"sv).release_value_but_fixme_should_propagate_errors();
-    m_default_maximize_bitmap = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/upward-triangle.png"sv).release_value_but_fixme_should_propagate_errors();
-    m_default_minimize_bitmap = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/downward-triangle.png"sv).release_value_but_fixme_should_propagate_errors();
+    m_default_close_bitmap = BitmapCache::load_bitmap("/res/icons/16x16/window-close.png"sv).release_value_but_fixme_should_propagate_errors();
+    m_default_maximize_bitmap = BitmapCache::load_bitmap("/res/icons/16x16/upward-triangle.png"sv).release_value_but_fixme_should_propagate_errors();
+    m_default_minimize_bitmap = BitmapCache::load_bitmap("/res/icons/16x16/downward-triangle.png"sv).release_value_but_fixme_should_propagate_errors();
 
     VERIFY(m_active_window_icon);
     VERIFY(m_inactive_window_icon);

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGUI/AutocompleteProvider.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Model.h>
 #include <LibGUI/TableView.h>
@@ -52,13 +53,13 @@ public:
             if (index.column() == Column::Icon) {
                 if (suggestion.language == CodeComprehension::Language::Cpp) {
                     if (!s_cpp_identifier_icon) {
-                        s_cpp_identifier_icon = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/completion/cpp-identifier.png"sv).release_value_but_fixme_should_propagate_errors();
+                        s_cpp_identifier_icon = BitmapCache::load_bitmap("/res/icons/16x16/completion/cpp-identifier.png"sv).release_value_but_fixme_should_propagate_errors();
                     }
                     return *s_cpp_identifier_icon;
                 }
                 if (suggestion.language == CodeComprehension::Language::Unspecified) {
                     if (!s_unspecified_identifier_icon) {
-                        s_unspecified_identifier_icon = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/completion/unspecified-identifier.png"sv).release_value_but_fixme_should_propagate_errors();
+                        s_unspecified_identifier_icon = BitmapCache::load_bitmap("/res/icons/16x16/completion/unspecified-identifier.png"sv).release_value_but_fixme_should_propagate_errors();
                     }
                     return *s_unspecified_identifier_icon;
                 }

--- a/Userland/Libraries/LibGUI/BitmapCache.cpp
+++ b/Userland/Libraries/LibGUI/BitmapCache.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022, Leon Albrecht <leon.a@serenityos.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/String.h>
+#include <LibGUI/BitmapCache.h>
+
+namespace GUI {
+
+HashMap<String, RefPtr<Gfx::Bitmap>> BitmapCache::s_cache {};
+
+ErrorOr<RefPtr<Gfx::Bitmap>> BitmapCache::load_bitmap(StringView path, SilenceImageLoadingErrors silence_errors)
+{
+
+    if (auto maybe_bitmap = s_cache.find(path); maybe_bitmap != s_cache.end()) {
+        // Don't return nullptr for a previously failed load, if the caller wants us
+        // to not silence errors, instead we will try to reload the image
+        if (silence_errors == SilenceImageLoadingErrors::Yes || maybe_bitmap->value)
+            return maybe_bitmap->value;
+    }
+
+    auto bitmap_or_error = Gfx::Bitmap::try_load_from_file(path);
+    if (bitmap_or_error.is_error()) {
+        if (silence_errors == SilenceImageLoadingErrors::No)
+            return bitmap_or_error.release_error();
+
+        dbgln("Failed to load Bitmap from {}: {}", path, bitmap_or_error.error());
+        TRY(s_cache.try_set(
+            TRY(String::from_utf8(path)), nullptr));
+        return bitmap_or_error.release_error();
+    }
+    TRY(s_cache.try_set(
+        TRY(String::from_utf8(path)), bitmap_or_error.value()));
+
+    return bitmap_or_error.release_value();
+}
+
+}

--- a/Userland/Libraries/LibGUI/BitmapCache.h
+++ b/Userland/Libraries/LibGUI/BitmapCache.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Leon Albrecht <leon.a@serenityos.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/HashMap.h>
+#include <AK/Optional.h>
+#include <LibGUI/Widget.h>
+#include <LibGfx/Bitmap.h>
+
+namespace GUI {
+
+enum class SilenceImageLoadingErrors {
+    No,
+    Yes
+};
+
+class BitmapCache {
+public:
+    // NOTE: This silences loading errors by default and will return nullptr instead
+    //       This allows us to continue gracefully when for example the image is not available.
+    //       Most widgets just don't draw missing images, while still working correctly otherwise.
+    //       If writing to the cache or string allocation fails on the other hand,
+    //       we are usually in a bad enough position to allow a crash, aka OOM
+    static ErrorOr<RefPtr<Gfx::Bitmap>> load_bitmap(StringView path, SilenceImageLoadingErrors silence_errors = SilenceImageLoadingErrors::Yes);
+
+private:
+    static HashMap<String, RefPtr<Gfx::Bitmap>> s_cache;
+};
+
+}

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -7,6 +7,7 @@
 #include <AK/StringBuilder.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
@@ -182,9 +183,9 @@ void Button::set_icon(RefPtr<Gfx::Bitmap> icon)
 
 void Button::set_icon_from_path(DeprecatedString const& path)
 {
-    auto maybe_bitmap = Gfx::Bitmap::try_load_from_file(path);
+    auto maybe_bitmap = BitmapCache::load_bitmap(path);
     if (maybe_bitmap.is_error()) {
-        dbgln("Unable to load bitmap `{}` for button icon", path);
+        dbgln("Unable to load bitmap `{}` for button icon: {}", path, maybe_bitmap.error());
         return;
     }
     set_icon(maybe_bitmap.release_value());

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     ActionGroup.cpp
     Application.cpp
     AutocompleteProvider.cpp
+    BitmapCache.cpp
     BoxLayout.cpp
     Breadcrumbbar.cpp
     Button.cpp

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/ColorPicker.h>
@@ -187,8 +188,8 @@ ColorPicker::ColorPicker(Color color, Window* parent_window, DeprecatedString ti
     : Dialog(parent_window)
     , m_color(color)
 {
-    set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/color-chooser.png"sv).release_value_but_fixme_should_propagate_errors());
-    set_title(title);
+    set_icon(BitmapCache::load_bitmap("/res/icons/16x16/color-chooser.png"sv).release_value_but_fixme_should_propagate_errors());
+    set_title(move(title));
     set_resizable(false);
     resize(480, 326);
 

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/ComboBox.h>
 #include <LibGUI/Desktop.h>
@@ -102,7 +103,7 @@ ComboBox::ComboBox()
 
     m_open_button = add<Button>();
     m_open_button->set_button_style(Gfx::ButtonStyle::ThickCap);
-    m_open_button->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/downward-triangle.png"sv).release_value_but_fixme_should_propagate_errors());
+    m_open_button->set_icon(BitmapCache::load_bitmap("/res/icons/16x16/downward-triangle.png"sv).release_value_but_fixme_should_propagate_errors());
     m_open_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_open_button->on_click = [this](auto) {
         if (!m_list_view->item_count())

--- a/Userland/Libraries/LibGUI/CommonActions.cpp
+++ b/Userland/Libraries/LibGUI/CommonActions.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/Version.h>
 #include <LibGUI/AboutDialog.h>
 #include <LibGUI/Action.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/CommandPalette.h>
 #include <LibGUI/Icon.h>
 
@@ -29,78 +30,78 @@ NonnullRefPtr<Action> make_about_action(DeprecatedString const& app_name, Icon c
 
 NonnullRefPtr<Action> make_open_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("&Open...", { Mod_Ctrl, Key_O }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("&Open...", { Mod_Ctrl, Key_O }, BitmapCache::load_bitmap("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Open an existing file");
     return action;
 }
 
 NonnullRefPtr<Action> make_save_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("&Save", { Mod_Ctrl, Key_S }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/save.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("&Save", { Mod_Ctrl, Key_S }, BitmapCache::load_bitmap("/res/icons/16x16/save.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Save the current file");
     return action;
 }
 
 NonnullRefPtr<Action> make_save_as_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("Save &As...", { Mod_Ctrl | Mod_Shift, Key_S }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/save-as.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("Save &As...", { Mod_Ctrl | Mod_Shift, Key_S }, BitmapCache::load_bitmap("/res/icons/16x16/save-as.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Save the current file with a new name");
     return action;
 }
 
 NonnullRefPtr<Action> make_move_to_front_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("Move to &Front", { Mod_Ctrl | Mod_Shift, Key_Up }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/move-to-front.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("Move to &Front", { Mod_Ctrl | Mod_Shift, Key_Up }, BitmapCache::load_bitmap("/res/icons/16x16/move-to-front.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Move to the top of the stack");
     return action;
 }
 
 NonnullRefPtr<Action> make_move_to_back_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("Move to &Back", { Mod_Ctrl | Mod_Shift, Key_Down }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/move-to-back.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("Move to &Back", { Mod_Ctrl | Mod_Shift, Key_Down }, BitmapCache::load_bitmap("/res/icons/16x16/move-to-back.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Move to the bottom of the stack");
     return action;
 }
 
 NonnullRefPtr<Action> make_undo_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return Action::create("&Undo", { Mod_Ctrl, Key_Z }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/undo.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return Action::create("&Undo", { Mod_Ctrl, Key_Z }, BitmapCache::load_bitmap("/res/icons/16x16/undo.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_redo_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return Action::create("&Redo", { Mod_Ctrl | Mod_Shift, Key_Z }, { Mod_Ctrl, Key_Y }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/redo.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return Action::create("&Redo", { Mod_Ctrl | Mod_Shift, Key_Z }, { Mod_Ctrl, Key_Y }, BitmapCache::load_bitmap("/res/icons/16x16/redo.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_delete_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return Action::create("&Delete", { Mod_None, Key_Delete }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/delete.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return Action::create("&Delete", { Mod_None, Key_Delete }, BitmapCache::load_bitmap("/res/icons/16x16/delete.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_cut_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("Cu&t", { Mod_Ctrl, Key_X }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-cut.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("Cu&t", { Mod_Ctrl, Key_X }, BitmapCache::load_bitmap("/res/icons/16x16/edit-cut.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Cut to clipboard");
     return action;
 }
 
 NonnullRefPtr<Action> make_copy_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("&Copy", { Mod_Ctrl, Key_C }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-copy.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("&Copy", { Mod_Ctrl, Key_C }, BitmapCache::load_bitmap("/res/icons/16x16/edit-copy.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Copy to clipboard");
     return action;
 }
 
 NonnullRefPtr<Action> make_paste_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("&Paste", { Mod_Ctrl, Key_V }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/paste.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("&Paste", { Mod_Ctrl, Key_V }, BitmapCache::load_bitmap("/res/icons/16x16/paste.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Paste from clipboard");
     return action;
 }
 
 NonnullRefPtr<Action> make_insert_emoji_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("&Insert Emoji...", { Mod_Ctrl | Mod_Alt, Key_Space }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/emoji.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("&Insert Emoji...", { Mod_Ctrl | Mod_Alt, Key_Space }, BitmapCache::load_bitmap("/res/icons/16x16/emoji.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Open the Emoji Picker");
     return action;
 }
@@ -109,7 +110,7 @@ NonnullRefPtr<Action> make_fullscreen_action(Function<void(Action&)> callback, C
 {
     auto action = Action::create("&Fullscreen", { Mod_None, Key_F11 }, move(callback), parent);
     action->set_status_tip("Enter fullscreen mode");
-    action->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/fullscreen.png"sv).release_value_but_fixme_should_propagate_errors());
+    action->set_icon(BitmapCache::load_bitmap("/res/icons/16x16/fullscreen.png"sv).release_value_but_fixme_should_propagate_errors());
     return action;
 }
 
@@ -122,85 +123,85 @@ NonnullRefPtr<Action> make_quit_action(Function<void(Action&)> callback)
 
 NonnullRefPtr<Action> make_help_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("&Manual", { Mod_None, Key_F1 }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-help.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("&Manual", { Mod_None, Key_F1 }, BitmapCache::load_bitmap("/res/icons/16x16/app-help.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Show help contents");
     return action;
 }
 
 NonnullRefPtr<Action> make_go_back_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("Go &Back", { Mod_Alt, Key_Left }, { MouseButton::Backward }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-back.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("Go &Back", { Mod_Alt, Key_Left }, { MouseButton::Backward }, BitmapCache::load_bitmap("/res/icons/16x16/go-back.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Move one step backward in history");
     return action;
 }
 
 NonnullRefPtr<Action> make_go_forward_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("Go &Forward", { Mod_Alt, Key_Right }, { MouseButton::Forward }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-forward.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("Go &Forward", { Mod_Alt, Key_Right }, { MouseButton::Forward }, BitmapCache::load_bitmap("/res/icons/16x16/go-forward.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Move one step forward in history");
     return action;
 }
 
 NonnullRefPtr<Action> make_go_home_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return Action::create("Go &Home", { Mod_Alt, Key_Home }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-home.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return Action::create("Go &Home", { Mod_Alt, Key_Home }, BitmapCache::load_bitmap("/res/icons/16x16/go-home.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_close_tab_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("&Close Tab", { Mod_Ctrl, Key_W }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/close-tab.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("&Close Tab", { Mod_Ctrl, Key_W }, BitmapCache::load_bitmap("/res/icons/16x16/close-tab.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Close current tab");
     return action;
 }
 
 NonnullRefPtr<Action> make_reload_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return Action::create("&Reload", { Mod_Ctrl, Key_R }, Key_F5, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/reload.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return Action::create("&Reload", { Mod_Ctrl, Key_R }, Key_F5, BitmapCache::load_bitmap("/res/icons/16x16/reload.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_select_all_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return Action::create("Select &All", { Mod_Ctrl, Key_A }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/select-all.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return Action::create("Select &All", { Mod_Ctrl, Key_A }, BitmapCache::load_bitmap("/res/icons/16x16/select-all.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_rename_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return Action::create("Re&name", Key_F2, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/rename.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return Action::create("Re&name", Key_F2, BitmapCache::load_bitmap("/res/icons/16x16/rename.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_properties_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return Action::create("P&roperties", { Mod_Alt, Key_Return }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/properties.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return Action::create("P&roperties", { Mod_Alt, Key_Return }, BitmapCache::load_bitmap("/res/icons/16x16/properties.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_zoom_in_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return GUI::Action::create("Zoom &In", { Mod_Ctrl, Key_Equal }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/zoom-in.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return GUI::Action::create("Zoom &In", { Mod_Ctrl, Key_Equal }, BitmapCache::load_bitmap("/res/icons/16x16/zoom-in.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_reset_zoom_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return GUI::Action::create("&Reset Zoom", { Mod_Ctrl, Key_0 }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/zoom-reset.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return GUI::Action::create("&Reset Zoom", { Mod_Ctrl, Key_0 }, BitmapCache::load_bitmap("/res/icons/16x16/zoom-reset.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_zoom_out_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return GUI::Action::create("Zoom &Out", { Mod_Ctrl, Key_Minus }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/zoom-out.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return GUI::Action::create("Zoom &Out", { Mod_Ctrl, Key_Minus }, BitmapCache::load_bitmap("/res/icons/16x16/zoom-out.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_rotate_clockwise_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return GUI::Action::create("Rotate Clock&wise", { Mod_Ctrl | Mod_Shift, Key_GreaterThan }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-rotate-cw.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return GUI::Action::create("Rotate Clock&wise", { Mod_Ctrl | Mod_Shift, Key_GreaterThan }, BitmapCache::load_bitmap("/res/icons/16x16/edit-rotate-cw.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_rotate_counterclockwise_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return GUI::Action::create("Rotate &Counterclockwise", { Mod_Ctrl | Mod_Shift, Key_LessThan }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-rotate-ccw.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return GUI::Action::create("Rotate &Counterclockwise", { Mod_Ctrl | Mod_Shift, Key_LessThan }, BitmapCache::load_bitmap("/res/icons/16x16/edit-rotate-ccw.png"sv).release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_command_palette_action(Window* window)
 {
-    auto action = Action::create("&Commands...", { Mod_Ctrl | Mod_Shift, Key_A }, MUST(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/find.png"sv)), [=](auto&) {
+    auto action = Action::create("&Commands...", { Mod_Ctrl | Mod_Shift, Key_A }, BitmapCache::load_bitmap("/res/icons/16x16/find.png"sv).release_value_but_fixme_should_propagate_errors(), [=](auto&) {
         auto command_palette = CommandPalette::construct(*window);
         if (command_palette->exec() != GUI::Dialog::ExecResult::OK)
             return;

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -13,6 +13,7 @@
 #include <LibCore/MappedFile.h>
 #include <LibCore/StandardPaths.h>
 #include <LibELF/Image.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/FileIconProvider.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Painter.h>
@@ -70,8 +71,8 @@ static void initialize_if_needed()
 
     auto config = Core::ConfigFile::open("/etc/FileIconProvider.ini").release_value_but_fixme_should_propagate_errors();
 
-    s_symlink_emblem = Gfx::Bitmap::try_load_from_file("/res/icons/symlink-emblem.png"sv).release_value_but_fixme_should_propagate_errors();
-    s_symlink_emblem_small = Gfx::Bitmap::try_load_from_file("/res/icons/symlink-emblem-small.png"sv).release_value_but_fixme_should_propagate_errors();
+    s_symlink_emblem = BitmapCache::load_bitmap("/res/icons/symlink-emblem.png"sv).release_value_but_fixme_should_propagate_errors();
+    s_symlink_emblem_small = BitmapCache::load_bitmap("/res/icons/symlink-emblem-small.png"sv).release_value_but_fixme_should_propagate_errors();
 
     s_hard_disk_icon = Icon::default_icon("hard-disk"sv);
     s_directory_icon = Icon::default_icon("filetype-folder"sv);

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -9,6 +9,7 @@
 #include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/Action.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/CommonLocationsProvider.h>
@@ -75,11 +76,11 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
     case Mode::OpenMultiple:
     case Mode::OpenFolder:
         set_title("Open");
-        set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors());
+        set_icon(BitmapCache::load_bitmap("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors());
         break;
     case Mode::Save:
         set_title("Save as");
-        set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/save-as.png"sv).release_value_but_fixme_should_propagate_errors());
+        set_icon(BitmapCache::load_bitmap("/res/icons/16x16/save-as.png"sv).release_value_but_fixme_should_propagate_errors());
         break;
     }
     resize(560, 320);
@@ -113,7 +114,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
     };
 
     auto open_parent_directory_action = Action::create(
-        "Open parent directory", { Mod_Alt, Key_Up }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open-parent-directory.png"sv).release_value_but_fixme_should_propagate_errors(), [this](Action const&) {
+        "Open parent directory", { Mod_Alt, Key_Up }, BitmapCache::load_bitmap("/res/icons/16x16/open-parent-directory.png"sv).release_value_but_fixme_should_propagate_errors(), [this](Action const&) {
             set_path(DeprecatedString::formatted("{}/..", m_model->root_path()));
         },
         this);
@@ -127,7 +128,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
     toolbar.add_separator();
 
     auto mkdir_action = Action::create(
-        "New directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/mkdir.png"sv).release_value_but_fixme_should_propagate_errors(), [this](Action const&) {
+        "New directory...", { Mod_Ctrl | Mod_Shift, Key_N }, BitmapCache::load_bitmap("/res/icons/16x16/mkdir.png"sv).release_value_but_fixme_should_propagate_errors(), [this](Action const&) {
             DeprecatedString value;
             if (InputBox::show(this, value, "Enter name:"sv, "New directory"sv) == InputBox::ExecResult::OK && !value.is_empty()) {
                 auto new_dir_path = LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", m_model->root_path(), value));

--- a/Userland/Libraries/LibGUI/FontPicker.cpp
+++ b/Userland/Libraries/LibGUI/FontPicker.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/QuickSort.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/FontPicker.h>
 #include <LibGUI/FontPickerDialogGML.h>
@@ -24,7 +25,7 @@ FontPicker::FontPicker(Window* parent_window, Gfx::Font const* current_font, boo
 {
     set_title("Font picker");
     resize(430, 280);
-    set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-font-editor.png"sv).release_value_but_fixme_should_propagate_errors());
+    set_icon(BitmapCache::load_bitmap("/res/icons/16x16/app-font-editor.png"sv).release_value_but_fixme_should_propagate_errors());
 
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
     widget->load_from_gml(font_picker_dialog_gml).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibGUI/LinkLabel.cpp
+++ b/Userland/Libraries/LibGUI/LinkLabel.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibGUI/Action.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/LinkLabel.h>
@@ -29,7 +30,7 @@ LinkLabel::LinkLabel(DeprecatedString text)
 
 void LinkLabel::setup_actions()
 {
-    m_open_action = GUI::Action::create("Show in File Manager", {}, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-file-manager.png"sv).release_value_but_fixme_should_propagate_errors(), [&](const GUI::Action&) {
+    m_open_action = GUI::Action::create("Show in File Manager", {}, BitmapCache::load_bitmap("/res/icons/16x16/app-file-manager.png"sv).release_value_but_fixme_should_propagate_errors(), [&](const GUI::Action&) {
         if (on_click)
             on_click();
     });

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/LexicalPath.h>
 #include <AK/NumberFormat.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/ImageWidget.h>
@@ -76,13 +77,13 @@ RefPtr<Gfx::Bitmap> MessageBox::icon() const
 {
     switch (m_type) {
     case Type::Information:
-        return Gfx::Bitmap::try_load_from_file("/res/icons/32x32/msgbox-information.png"sv).release_value_but_fixme_should_propagate_errors();
+        return BitmapCache::load_bitmap("/res/icons/32x32/msgbox-information.png"sv).release_value_but_fixme_should_propagate_errors();
     case Type::Warning:
-        return Gfx::Bitmap::try_load_from_file("/res/icons/32x32/msgbox-warning.png"sv).release_value_but_fixme_should_propagate_errors();
+        return BitmapCache::load_bitmap("/res/icons/32x32/msgbox-warning.png"sv).release_value_but_fixme_should_propagate_errors();
     case Type::Error:
-        return Gfx::Bitmap::try_load_from_file("/res/icons/32x32/msgbox-error.png"sv).release_value_but_fixme_should_propagate_errors();
+        return BitmapCache::load_bitmap("/res/icons/32x32/msgbox-error.png"sv).release_value_but_fixme_should_propagate_errors();
     case Type::Question:
-        return Gfx::Bitmap::try_load_from_file("/res/icons/32x32/msgbox-question.png"sv).release_value_but_fixme_should_propagate_errors();
+        return BitmapCache::load_bitmap("/res/icons/32x32/msgbox-question.png"sv).release_value_but_fixme_should_propagate_errors();
     default:
         return nullptr;
     }

--- a/Userland/Libraries/LibGUI/MultiView.cpp
+++ b/Userland/Libraries/LibGUI/MultiView.cpp
@@ -8,6 +8,7 @@
 #include <AK/StringBuilder.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/Model.h>
 #include <LibGUI/MultiView.h>
 #include <LibGUI/Window.h>
@@ -101,19 +102,19 @@ void MultiView::set_column_visible(int column_index, bool visible)
 void MultiView::build_actions()
 {
     m_view_as_icons_action = Action::create_checkable(
-        "Icon view", { Mod_Ctrl, KeyCode::Key_1 }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/icon-view.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+        "Icon view", { Mod_Ctrl, KeyCode::Key_1 }, BitmapCache::load_bitmap("/res/icons/16x16/icon-view.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
             set_view_mode(ViewMode::Icon);
         },
         this);
 
     m_view_as_table_action = Action::create_checkable(
-        "Table view", { Mod_Ctrl, KeyCode::Key_2 }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/table-view.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+        "Table view", { Mod_Ctrl, KeyCode::Key_2 }, BitmapCache::load_bitmap("/res/icons/16x16/table-view.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
             set_view_mode(ViewMode::Table);
         },
         this);
 
     m_view_as_columns_action = Action::create_checkable(
-        "Columns view", { Mod_Ctrl, KeyCode::Key_3 }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/columns-view.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+        "Columns view", { Mod_Ctrl, KeyCode::Key_3 }, BitmapCache::load_bitmap("/res/icons/16x16/columns-view.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
             set_view_mode(ViewMode::Columns);
         },
         this);

--- a/Userland/Libraries/LibGUI/PasswordInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/PasswordInputDialog.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/PasswordInputDialog.h>
@@ -27,7 +28,7 @@ PasswordInputDialog::PasswordInputDialog(Window* parent_window, DeprecatedString
 
     auto& key_icon_label = *widget->find_descendant_of_type_named<GUI::Label>("key_icon_label");
 
-    key_icon_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/32x32/key.png"sv).release_value_but_fixme_should_propagate_errors());
+    key_icon_label.set_icon(BitmapCache::load_bitmap("/res/icons/32x32/key.png"sv).release_value_but_fixme_should_propagate_errors());
 
     auto& server_label = *widget->find_descendant_of_type_named<GUI::Label>("server_label");
     server_label.set_text(move(server));

--- a/Userland/Libraries/LibGUI/SpinBox.cpp
+++ b/Userland/Libraries/LibGUI/SpinBox.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/SpinBox.h>
 #include <LibGUI/TextBox.h>
@@ -48,13 +49,13 @@ SpinBox::SpinBox()
 
     m_increment_button = add<Button>();
     m_increment_button->set_button_style(Gfx::ButtonStyle::ThickCap);
-    m_increment_button->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/upward-triangle.png"sv).release_value_but_fixme_should_propagate_errors());
+    m_increment_button->set_icon(BitmapCache::load_bitmap("/res/icons/16x16/upward-triangle.png"sv).release_value_but_fixme_should_propagate_errors());
     m_increment_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_increment_button->on_click = [this](auto) { set_value(m_value + 1); };
     m_increment_button->set_auto_repeat_interval(150);
     m_decrement_button = add<Button>();
     m_decrement_button->set_button_style(Gfx::ButtonStyle::ThickCap);
-    m_decrement_button->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/downward-triangle.png"sv).release_value_but_fixme_should_propagate_errors());
+    m_decrement_button->set_icon(BitmapCache::load_bitmap("/res/icons/16x16/downward-triangle.png"sv).release_value_but_fixme_should_propagate_errors());
     m_decrement_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_decrement_button->on_click = [this](auto) { set_value(m_value - 1); };
     m_decrement_button->set_auto_repeat_interval(150);

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -15,6 +15,7 @@
 #include <LibCore/Timer.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/AutocompleteProvider.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/EditingEngine.h>
 #include <LibGUI/EmojiInputDialog.h>
@@ -93,7 +94,7 @@ void TextEditor::create_actions()
     m_paste_action->set_enabled(is_editable() && Clipboard::the().fetch_mime_type().starts_with("text/"sv));
     if (is_multi_line()) {
         m_go_to_line_action = Action::create(
-            "Go to line...", { Mod_Ctrl, Key_L }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-to.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+            "Go to line...", { Mod_Ctrl, Key_L }, BitmapCache::load_bitmap("/res/icons/16x16/go-to.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
                 DeprecatedString value;
                 if (InputBox::show(window(), value, "Line:"sv, "Go to line"sv) == InputBox::ExecResult::OK) {
                     auto line_target = value.to_uint();

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -11,6 +11,7 @@
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Painter.h>
@@ -170,7 +171,7 @@ Optional<UISize> Toolbar::calculated_min_size() const
 
 ErrorOr<void> Toolbar::create_overflow_objects()
 {
-    m_overflow_action = Action::create("Overflow Menu", { Mod_Ctrl | Mod_Shift, Key_O }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/overflow-menu.png"sv)), [&](auto&) {
+    m_overflow_action = Action::create("Overflow Menu", { Mod_Ctrl | Mod_Shift, Key_O }, TRY(BitmapCache::load_bitmap("/res/icons/16x16/overflow-menu.png"sv)), [&](auto&) {
         m_overflow_menu->popup(m_overflow_button->screen_relative_rect().bottom_left(), {}, m_overflow_button->rect());
     });
     m_overflow_action->set_status_tip("Show hidden toolbar actions");

--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Debug.h>
 #include <LibCore/Object.h>
+#include <LibGUI/BitmapCache.h>
 #include <LibGUI/HeaderView.h>
 #include <LibGUI/Model.h>
 #include <LibGUI/Painter.h>
@@ -42,8 +43,8 @@ TreeView::TreeView()
     set_background_role(ColorRole::Base);
     set_foreground_role(ColorRole::BaseText);
     set_column_headers_visible(false);
-    m_expand_bitmap = Gfx::Bitmap::try_load_from_file("/res/icons/serenity/treeview-expand.png"sv).release_value_but_fixme_should_propagate_errors();
-    m_collapse_bitmap = Gfx::Bitmap::try_load_from_file("/res/icons/serenity/treeview-collapse.png"sv).release_value_but_fixme_should_propagate_errors();
+    m_expand_bitmap = BitmapCache::load_bitmap("/res/icons/serenity/treeview-expand.png"sv).release_value_but_fixme_should_propagate_errors();
+    m_collapse_bitmap = BitmapCache::load_bitmap("/res/icons/serenity/treeview-collapse.png"sv).release_value_but_fixme_should_propagate_errors();
 }
 
 ModelIndex TreeView::index_at_event_position(Gfx::IntPoint a_position, bool& is_toggle) const


### PR DESCRIPTION
#### AK: Mark String as HashCompatible with StringView
This allows us to index hash based containers without allocating a full
String

#### LibGUI: Add a simple BitmapCache

This will allow us to share bitmaps between Widgets using the same image
This also silences loading errors, because they can usually be ignored
and the widget be painted without the image.

#### LibGUI: Cache Bitmap loads for all widgets

This saves us some loads for common bitmaps, like the downwards triangle

Note:
This now allways silences load failures and painting will usually just
elide the hypothetical image.

Done by a regex search and replace with:
```
Gfx::Bitmap::try_load_from_file\((".*"sv)\)
```
and
```
BitmapCache::load_bitmap($1)
```
plus one edge case, that previously was a MUST