### PR TITLE
LibWeb+LibWebSocket: DOM WebSocket subprotocol support

### DIFF
--- a/Ladybird/WebSocketClientManagerLadybird.cpp
+++ b/Ladybird/WebSocketClientManagerLadybird.cpp
@@ -19,10 +19,11 @@ NonnullRefPtr<WebSocketClientManagerLadybird> WebSocketClientManagerLadybird::cr
 WebSocketClientManagerLadybird::WebSocketClientManagerLadybird() = default;
 WebSocketClientManagerLadybird::~WebSocketClientManagerLadybird() = default;
 
-RefPtr<Web::WebSockets::WebSocketClientSocket> WebSocketClientManagerLadybird::connect(AK::URL const& url, DeprecatedString const& origin)
+RefPtr<Web::WebSockets::WebSocketClientSocket> WebSocketClientManagerLadybird::connect(AK::URL const& url, DeprecatedString const& origin, Vector<DeprecatedString> const& protocols)
 {
     WebSocket::ConnectionInfo connection_info(url);
     connection_info.set_origin(origin);
+    connection_info.set_protocols(protocols);
 
     auto impl = adopt_ref(*new WebSocketImplQt);
     auto web_socket = WebSocket::WebSocket::create(move(connection_info), move(impl));

--- a/Ladybird/WebSocketClientManagerLadybird.h
+++ b/Ladybird/WebSocketClientManagerLadybird.h
@@ -19,7 +19,7 @@ public:
     static NonnullRefPtr<WebSocketClientManagerLadybird> create();
 
     virtual ~WebSocketClientManagerLadybird() override;
-    virtual RefPtr<Web::WebSockets::WebSocketClientSocket> connect(AK::URL const&, DeprecatedString const& origin) override;
+    virtual RefPtr<Web::WebSockets::WebSocketClientSocket> connect(AK::URL const&, DeprecatedString const& origin, Vector<DeprecatedString> const& protocols) override;
 
 private:
     WebSocketClientManagerLadybird();

--- a/Ladybird/WebSocketLadybird.cpp
+++ b/Ladybird/WebSocketLadybird.cpp
@@ -74,6 +74,11 @@ Web::WebSockets::WebSocket::ReadyState WebSocketLadybird::ready_state()
     VERIFY_NOT_REACHED();
 }
 
+DeprecatedString WebSocketLadybird::subprotocol_in_use()
+{
+    return m_websocket->subprotocol_in_use();
+}
+
 void WebSocketLadybird::send(ByteBuffer binary_or_text_message, bool is_text)
 {
     m_websocket->send(WebSocket::Message(binary_or_text_message, is_text));

--- a/Ladybird/WebSocketLadybird.h
+++ b/Ladybird/WebSocketLadybird.h
@@ -21,6 +21,7 @@ public:
     virtual ~WebSocketLadybird() override;
 
     virtual Web::WebSockets::WebSocket::ReadyState ready_state() override;
+    virtual DeprecatedString subprotocol_in_use() override;
     virtual void send(ByteBuffer binary_or_text_message, bool is_text) override;
     virtual void send(StringView message) override;
     virtual void close(u16 code, DeprecatedString reason) override;

--- a/Userland/Libraries/LibProtocol/WebSocket.cpp
+++ b/Userland/Libraries/LibProtocol/WebSocket.cpp
@@ -20,6 +20,11 @@ WebSocket::ReadyState WebSocket::ready_state()
     return (WebSocket::ReadyState)m_client->ready_state({}, *this);
 }
 
+DeprecatedString WebSocket::subprotocol_in_use()
+{
+    return (DeprecatedString)m_client->subprotocol_in_use({}, *this);
+}
+
 void WebSocket::send(ByteBuffer binary_or_text_message, bool is_text)
 {
     m_client->send({}, *this, move(binary_or_text_message), is_text);

--- a/Userland/Libraries/LibProtocol/WebSocket.h
+++ b/Userland/Libraries/LibProtocol/WebSocket.h
@@ -53,6 +53,8 @@ public:
 
     ReadyState ready_state();
 
+    DeprecatedString subprotocol_in_use();
+
     void send(ByteBuffer binary_or_text_message, bool is_text);
     void send(StringView text_message);
     void close(u16 code = 1005, DeprecatedString reason = {});

--- a/Userland/Libraries/LibProtocol/WebSocketClient.cpp
+++ b/Userland/Libraries/LibProtocol/WebSocketClient.cpp
@@ -34,6 +34,13 @@ u32 WebSocketClient::ready_state(Badge<WebSocket>, WebSocket& connection)
     return IPCProxy::ready_state(connection.id());
 }
 
+DeprecatedString WebSocketClient::subprotocol_in_use(Badge<WebSocket>, WebSocket& connection)
+{
+    if (!m_connections.contains(connection.id()))
+        return DeprecatedString::empty();
+    return IPCProxy::subprotocol_in_use(connection.id());
+}
+
 void WebSocketClient::send(Badge<WebSocket>, WebSocket& connection, ByteBuffer data, bool is_text)
 {
     if (!m_connections.contains(connection.id()))

--- a/Userland/Libraries/LibProtocol/WebSocketClient.h
+++ b/Userland/Libraries/LibProtocol/WebSocketClient.h
@@ -24,6 +24,7 @@ public:
     RefPtr<WebSocket> connect(const URL&, DeprecatedString const& origin = {}, Vector<DeprecatedString> const& protocols = {}, Vector<DeprecatedString> const& extensions = {}, HashMap<DeprecatedString, DeprecatedString> const& request_headers = {});
 
     u32 ready_state(Badge<WebSocket>, WebSocket&);
+    DeprecatedString subprotocol_in_use(Badge<WebSocket>, WebSocket&);
     void send(Badge<WebSocket>, WebSocket&, ByteBuffer, bool is_text);
     void close(Badge<WebSocket>, WebSocket&, u16 code, DeprecatedString reason);
     bool set_certificate(Badge<WebSocket>, WebSocket&, DeprecatedString, DeprecatedString);

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/QuickSort.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibWeb/DOM/Document.h>
@@ -45,7 +46,7 @@ WebSocketClientSocket::~WebSocketClientSocket() = default;
 WebSocketClientManager::WebSocketClientManager() = default;
 
 // https://websockets.spec.whatwg.org/#dom-websocket-websocket
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> WebSocket::construct_impl(JS::Realm& realm, DeprecatedString const& url)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> WebSocket::construct_impl(JS::Realm& realm, DeprecatedString const& url, Optional<Variant<DeprecatedString, Vector<DeprecatedString>>> const& protocols)
 {
     auto& window = verify_cast<HTML::Window>(realm.global_object());
     AK::URL url_record(url);
@@ -55,18 +56,39 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> WebSocket::construct_impl(JS::R
         return WebIDL::SyntaxError::create(realm, "Invalid protocol");
     if (!url_record.fragment().is_empty())
         return WebIDL::SyntaxError::create(realm, "Presence of URL fragment is invalid");
-    // 5. If `protocols` is a string, set `protocols` to a sequence consisting of just that string
-    // 6. If any of the values in `protocols` occur more than once or otherwise fail to match the requirements, throw SyntaxError
-    return realm.heap().allocate<WebSocket>(realm, window, url_record);
+    Vector<DeprecatedString> protocols_sequence;
+    if (protocols.has_value()) {
+        // 5. If `protocols` is a string, set `protocols` to a sequence consisting of just that string
+        if (protocols.value().has<DeprecatedString>())
+            protocols_sequence.append(protocols.value().get<DeprecatedString>());
+        else
+            protocols_sequence = protocols.value().get<Vector<DeprecatedString>>();
+        // 6. If any of the values in `protocols` occur more than once or otherwise fail to match the requirements, throw SyntaxError
+        auto sorted_protocols = protocols_sequence;
+        quick_sort(sorted_protocols);
+        for (size_t i = 0; i < sorted_protocols.size(); i++) {
+            // https://datatracker.ietf.org/doc/html/rfc6455
+            // The elements that comprise this value MUST be non-empty strings with characters in the range U+0021 to U+007E not including
+            // separator characters as defined in [RFC2616] and MUST all be unique strings.
+            auto protocol = sorted_protocols[i];
+            if (i < sorted_protocols.size() - 1 && protocol == sorted_protocols[i + 1])
+                return WebIDL::SyntaxError::create(realm, "Found a duplicate protocol name in the specified list");
+            for (auto character : protocol) {
+                if (character < '\x21' || character > '\x7E')
+                    return WebIDL::SyntaxError::create(realm, "Found invalid character in subprotocol name");
+            }
+        }
+    }
+    return realm.heap().allocate<WebSocket>(realm, window, url_record, protocols_sequence);
 }
 
-WebSocket::WebSocket(HTML::Window& window, AK::URL& url)
+WebSocket::WebSocket(HTML::Window& window, AK::URL& url, Vector<DeprecatedString> const& protocols)
     : EventTarget(window.realm())
     , m_window(window)
 {
     // FIXME: Integrate properly with FETCH as per https://fetch.spec.whatwg.org/#websocket-opening-handshake
     auto origin_string = m_window->associated_document().origin().serialize();
-    m_websocket = WebSocketClientManager::the().connect(url, origin_string);
+    m_websocket = WebSocketClientManager::the().connect(url, origin_string, protocols);
     m_websocket->on_open = [weak_this = make_weak_ptr<WebSocket>()] {
         if (!weak_this)
             return;
@@ -130,9 +152,7 @@ DeprecatedString WebSocket::protocol() const
 {
     if (!m_websocket)
         return DeprecatedString::empty();
-    // https://websockets.spec.whatwg.org/#feedback-from-the-protocol
-    // FIXME: Change the protocol attribute's value to the subprotocol in use, if it is not the null value.
-    return DeprecatedString::empty();
+    return m_websocket->subprotocol_in_use();
 }
 
 // https://websockets.spec.whatwg.org/#dom-websocket-close

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.h
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.h
@@ -37,7 +37,7 @@ public:
         Closed = 3,
     };
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> construct_impl(JS::Realm&, DeprecatedString const& url);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> construct_impl(JS::Realm&, DeprecatedString const& url, Optional<Variant<DeprecatedString, Vector<DeprecatedString>>> const& protocols);
 
     virtual ~WebSocket() override;
 
@@ -66,7 +66,7 @@ private:
     void on_error();
     void on_close(u16 code, DeprecatedString reason, bool was_clean);
 
-    WebSocket(HTML::Window&, AK::URL&);
+    WebSocket(HTML::Window&, AK::URL&, Vector<DeprecatedString> const& protocols);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -99,6 +99,7 @@ public:
     };
 
     virtual Web::WebSockets::WebSocket::ReadyState ready_state() = 0;
+    virtual DeprecatedString subprotocol_in_use() = 0;
 
     virtual void send(ByteBuffer binary_or_text_message, bool is_text) = 0;
     virtual void send(StringView text_message) = 0;
@@ -120,7 +121,7 @@ public:
     static void initialize(RefPtr<WebSocketClientManager>);
     static WebSocketClientManager& the();
 
-    virtual RefPtr<WebSocketClientSocket> connect(AK::URL const&, DeprecatedString const& origin) = 0;
+    virtual RefPtr<WebSocketClientSocket> connect(AK::URL const&, DeprecatedString const& origin, Vector<DeprecatedString> const& protocols) = 0;
 
 protected:
     explicit WebSocketClientManager();

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.idl
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.idl
@@ -5,8 +5,7 @@
 [Exposed=(Window,Worker)]
 interface WebSocket : EventTarget {
 
-    // FIXME: A second "protocols" argument should be added once supported
-    constructor(USVString url);
+    constructor(USVString url, optional (DOMString or sequence<DOMString>) protocols);
 
     readonly attribute USVString url;
 

--- a/Userland/Libraries/LibWebSocket/WebSocket.h
+++ b/Userland/Libraries/LibWebSocket/WebSocket.h
@@ -32,6 +32,8 @@ public:
 
     ReadyState ready_state();
 
+    DeprecatedString subprotocol_in_use();
+
     // Call this to start the WebSocket connection.
     void start();
 
@@ -94,6 +96,8 @@ private:
     };
 
     InternalState m_state { InternalState::NotStarted };
+
+    DeprecatedString m_subprotocol_in_use { DeprecatedString::empty() };
 
     DeprecatedString m_websocket_key;
     bool m_has_read_server_handshake_first_line { false };

--- a/Userland/Libraries/LibWebView/WebSocketClientAdapter.cpp
+++ b/Userland/Libraries/LibWebView/WebSocketClientAdapter.cpp
@@ -87,6 +87,11 @@ Web::WebSockets::WebSocket::ReadyState WebSocketClientSocketAdapter::ready_state
     VERIFY_NOT_REACHED();
 }
 
+DeprecatedString WebSocketClientSocketAdapter::subprotocol_in_use()
+{
+    return m_websocket->subprotocol_in_use();
+}
+
 void WebSocketClientSocketAdapter::send(ByteBuffer binary_or_text_message, bool is_text)
 {
     m_websocket->send(binary_or_text_message, is_text);
@@ -115,9 +120,9 @@ WebSocketClientManagerAdapter::WebSocketClientManagerAdapter(NonnullRefPtr<Proto
 
 WebSocketClientManagerAdapter::~WebSocketClientManagerAdapter() = default;
 
-RefPtr<Web::WebSockets::WebSocketClientSocket> WebSocketClientManagerAdapter::connect(const AK::URL& url, DeprecatedString const& origin)
+RefPtr<Web::WebSockets::WebSocketClientSocket> WebSocketClientManagerAdapter::connect(const AK::URL& url, DeprecatedString const& origin, Vector<DeprecatedString> const& protocols)
 {
-    auto underlying_websocket = m_websocket_client->connect(url, origin);
+    auto underlying_websocket = m_websocket_client->connect(url, origin, protocols);
     if (!underlying_websocket)
         return {};
     return WebSocketClientSocketAdapter::create(underlying_websocket.release_nonnull());

--- a/Userland/Libraries/LibWebView/WebSocketClientAdapter.h
+++ b/Userland/Libraries/LibWebView/WebSocketClientAdapter.h
@@ -26,6 +26,7 @@ public:
     virtual ~WebSocketClientSocketAdapter() override;
 
     virtual Web::WebSockets::WebSocket::ReadyState ready_state() override;
+    virtual DeprecatedString subprotocol_in_use() override;
 
     virtual void send(ByteBuffer binary_or_text_message, bool is_text) override;
     virtual void send(StringView text_message) override;
@@ -43,7 +44,7 @@ public:
 
     virtual ~WebSocketClientManagerAdapter() override;
 
-    virtual RefPtr<Web::WebSockets::WebSocketClientSocket> connect(const AK::URL&, DeprecatedString const& origin) override;
+    virtual RefPtr<Web::WebSockets::WebSocketClientSocket> connect(const AK::URL&, DeprecatedString const& origin, Vector<DeprecatedString> const& protocols) override;
 
 private:
     WebSocketClientManagerAdapter(NonnullRefPtr<Protocol::WebSocketClient>);

--- a/Userland/Services/WebSocket/ConnectionFromClient.cpp
+++ b/Userland/Services/WebSocket/ConnectionFromClient.cpp
@@ -75,6 +75,15 @@ Messages::WebSocketServer::ReadyStateResponse ConnectionFromClient::ready_state(
     return (u32)ReadyState::Closed;
 }
 
+Messages::WebSocketServer::SubprotocolInUseResponse ConnectionFromClient::subprotocol_in_use(i32 connection_id)
+{
+    RefPtr<WebSocket> connection = m_connections.get(connection_id).value_or({});
+    if (connection) {
+        return (DeprecatedString)connection->subprotocol_in_use();
+    }
+    return (DeprecatedString)DeprecatedString::empty();
+}
+
 void ConnectionFromClient::send(i32 connection_id, bool is_text, ByteBuffer const& data)
 {
     RefPtr<WebSocket> connection = m_connections.get(connection_id).value_or({});

--- a/Userland/Services/WebSocket/ConnectionFromClient.h
+++ b/Userland/Services/WebSocket/ConnectionFromClient.h
@@ -28,6 +28,7 @@ private:
 
     virtual Messages::WebSocketServer::ConnectResponse connect(URL const&, DeprecatedString const&, Vector<DeprecatedString> const&, Vector<DeprecatedString> const&, IPC::Dictionary const&) override;
     virtual Messages::WebSocketServer::ReadyStateResponse ready_state(i32) override;
+    virtual Messages::WebSocketServer::SubprotocolInUseResponse subprotocol_in_use(i32) override;
     virtual void send(i32, bool, ByteBuffer const&) override;
     virtual void close(i32, u16, DeprecatedString const&) override;
     virtual Messages::WebSocketServer::SetCertificateResponse set_certificate(i32, DeprecatedString const&, DeprecatedString const&) override;

--- a/Userland/Services/WebSocket/WebSocketServer.ipc
+++ b/Userland/Services/WebSocket/WebSocketServer.ipc
@@ -5,6 +5,7 @@ endpoint WebSocketServer
     // Connection API
     connect(URL url, DeprecatedString origin, Vector<DeprecatedString> protocols, Vector<DeprecatedString> extensions, IPC::Dictionary additional_request_headers) => (i32 connection_id)
     ready_state(i32 connection_id) => (u32 ready_state)
+    subprotocol_in_use(i32 connection_id) => (DeprecatedString subprotocol_in_use)
     send(i32 connection_id, bool is_text, ByteBuffer data) =|
     close(i32 connection_id, u16 code, DeprecatedString reason) =|
 

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -593,6 +593,11 @@ public:
             VERIFY_NOT_REACHED();
         }
 
+        virtual DeprecatedString subprotocol_in_use() override
+        {
+            return m_websocket->subprotocol_in_use();
+        }
+
         virtual void send(ByteBuffer binary_or_text_message, bool is_text) override
         {
             m_websocket->send(WebSocket::Message(binary_or_text_message, is_text));
@@ -662,10 +667,11 @@ public:
 
     virtual ~HeadlessWebSocketClientManager() override { }
 
-    virtual RefPtr<Web::WebSockets::WebSocketClientSocket> connect(AK::URL const& url, DeprecatedString const& origin) override
+    virtual RefPtr<Web::WebSockets::WebSocketClientSocket> connect(AK::URL const& url, DeprecatedString const& origin, Vector<DeprecatedString> const& protocols) override
     {
         WebSocket::ConnectionInfo connection_info(url);
         connection_info.set_origin(origin);
+        connection_info.set_protocols(protocols);
 
         auto connection = HeadlessWebSocket::create(WebSocket::WebSocket::create(move(connection_info)));
         return connection;


### PR DESCRIPTION
Hello!

This PR adds support for WebSocket subprotocols to [WebSocket DOM objects](https://websockets.spec.whatwg.org/), with some necessary plumbing to LibWebSocket and its clients.

I wasn't totally sure whether to store the "subprotocol in use" in `WebSocket::WebSocket` (LibWebSocket) or `Web::WebSockets::WebSocket` (LibWeb), but I went with the former as it's a protocol-level concept that should probably be exposed to any client of LibWebSocket. Let me know if you prefer the other approach, though.

I tested this by running a local websocket server and loading [this test page](https://gist.github.com/eggpi/6f8b711c4a988f8b5c1cd16bd609acf8) on Firefox 107, Chrome 108 and Ladybird. The results are:

- Ladybird ([screenshot](https://user-images.githubusercontent.com/489134/210134386-6cd9e319-4209-44b3-abbf-19c0d86d785b.png)) passes all tests :^)
- Chrome ([screenshot](https://user-images.githubusercontent.com/489134/210134365-c1b4bc2f-c92d-4f6c-a2ff-ed9b05dec107.png)) passes all tests.
- Firefox ([screenshot](https://user-images.githubusercontent.com/489134/210134329-54f1e8df-4614-4d19-84e8-6479e2ef9d92.png)) fails the first test, because it allows the server to set a subprotocol that was not requested by the client. I think this is not in line with the spec.

