### PR TITLE
LibWeb: Fix table-row y-position

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -276,6 +276,7 @@ void TableFormattingContext::run(Box const& box, LayoutMode, AvailableSpace cons
         row.baseline = max(row.baseline, cell.baseline);
     }
 
+    float row_top_offset = 0.0f;
     for (size_t y = 0; y < m_rows.size(); y++) {
         auto& row = m_rows[y];
         auto& row_state = m_state.get_mutable(row.box);
@@ -286,6 +287,8 @@ void TableFormattingContext::run(Box const& box, LayoutMode, AvailableSpace cons
 
         row_state.set_content_height(row.used_width);
         row_state.set_content_width(row_width);
+        row_state.set_content_y(row_top_offset);
+        row_top_offset += row_state.content_height();
     }
 
     float row_group_top_offset = 0.0f;


### PR DESCRIPTION
Fixes the y-position of rows when indicated through the display attribute `table-row`. Previously there was no y-offset between rows and so they would overlap.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/45781926/210138649-e93e8ec5-90f1-4f0b-862e-022e372ed39a.png"></td>
<td><img src="https://user-images.githubusercontent.com/45781926/210138670-8c29c446-e0cf-4d6b-8950-10223a598501.png"></td>
</tr>
</table>