### PR TITLE
LibWeb: Fix the main border around the repository infobox on the GitHub repository page

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -225,7 +225,6 @@
     ]
   },
   "border-bottom-style": {
-    "affects-layout": false,
     "initial": "none",
     "inherited": false,
     "valid-types": [
@@ -284,7 +283,6 @@
     ]
   },
   "border-left-style": {
-    "affects-layout": false,
     "initial": "none",
     "inherited": false,
     "valid-types": [
@@ -329,7 +327,6 @@
     ]
   },
   "border-right-style": {
-    "affects-layout": false,
     "initial": "none",
     "inherited": false,
     "valid-types": [
@@ -359,7 +356,6 @@
     ]
   },
   "border-style": {
-    "affects-layout": false,
     "initial": "none",
     "longhands": [
       "border-top-style",
@@ -401,7 +397,6 @@
     ]
   },
   "border-top-style": {
-    "affects-layout": false,
     "initial": "none",
     "inherited": false,
     "valid-types": [

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -543,7 +543,13 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
         //        specified first, so it's far from ideal.
         border.color = computed_style.color_or_fallback(color_property, *this, computed_values.color());
         border.line_style = computed_style.line_style(style_property).value_or(CSS::LineStyle::None);
-        if (border.line_style == CSS::LineStyle::None) {
+
+        // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-style
+        // none
+        //    No border. Color and width are ignored (i.e., the border has width 0). Note this means that the initial value of border-image-width will also resolve to zero.
+        // hidden
+        //    Same as none, but has different behavior in the border conflict resolution rules for border-collapsed tables [CSS2].
+        if (border.line_style == CSS::LineStyle::None || border.line_style == CSS::LineStyle::Hidden) {
             border.width = 0;
         } else {
             auto resolve_border_width = [&]() {


### PR DESCRIPTION
This is done by treating `border-style: hidden` the same as `border-style: none`.  The only difference between these two values is that `hidden` has different behaviour for border conflict resolution for border-collapsed tables in table layout, which we don't have yet.

Before:
![image](https://user-images.githubusercontent.com/25595356/210150698-0becde8c-47bd-4d08-854f-9581dc2a1f1e.png)

After:
![image](https://user-images.githubusercontent.com/25595356/210150711-abbd8bec-1d11-423a-a5f2-569397b58552.png)

The remaining borders around the infobox is caused by us not supporting the `border-collapse` property in table layout.

