### PR TITLE
Meta: Fix some broken markdown links

### DIFF
--- a/Base/usr/share/man/man7/Mitigations.md
+++ b/Base/usr/share/man/man7/Mitigations.md
@@ -393,12 +393,12 @@ The location of the kernel code is randomized at boot time, this ensures that at
 can not use a hardcoded kernel addresses when attempting ROP, instead they must first find
 an additional information leak to expose the KASLR offset.
 
-It was first enabled in the following [commit](https://github.com/SerenityOS/serenity/commit/ece5a9a1088012ca9fadfb7e0bc3edd8029d36ad):
+It was first enabled in the following [commit](https://github.com/SerenityOS/serenity/commit/1ad0e05ea1d3491e4724669d6f00f5668d8e0aa1):
 
 ```
-commit ece5a9a1088012ca9fadfb7e0bc3edd8029d36ad
-Author Idan Horowitz <idan.horowitz@gmail.com>
-Date:  Mon Mar 21 22:59:48 2022 +0200
+commit 1ad0e05ea1d3491e4724669d6f00f5668d8e0aa1
+Author: Idan Horowitz <idan.horowitz@gmail.com>
+Date:   Mon Mar 21 22:59:48 2022 +0200
 
 Kernel: Add an extremely primitive version of KASLR
 ```

--- a/Base/usr/share/man/man7/Mitigations.md
+++ b/Base/usr/share/man/man7/Mitigations.md
@@ -13,7 +13,7 @@ to collect and describe the mitigations in one centralized place.
 
 ### SMEP (Supervisor Mode Execution Protection)
 
-[Supervisor Mode Execution Protection](https://software.intel.com/security-software-guidance/best-practices/related-intel-security-features-technologies) is an Intel CPU feature which prevents execution
+[Supervisor Mode Execution Protection](https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/best-practices/related-intel-security-features-technologies.html) is an Intel CPU feature which prevents execution
 of userspace code with kernel privileges.
 
 It was enabled in the following [commit](https://github.com/SerenityOS/serenity/commit/8602fa5b49aa4e2b039764a14698f0baa3ad0532):


### PR DESCRIPTION
This PR fixes two broken links in markdown files.

I noticed that `check-markdown.sh` spits out a set of URLs that it intentionally skips (to prevent network traffic), and manually checked every single one of the 224 URLs. It appears that exactly two of them are wrong, which are fixed by this PR.