### PR TITLE
LibC+Tests: Fix aarch64 userspace build with clang

### DIFF
--- a/Tests/Kernel/CMakeLists.txt
+++ b/Tests/Kernel/CMakeLists.txt
@@ -2,7 +2,6 @@ set(TEST_SOURCES
     bind-local-socket-to-symlink.cpp
     crash-fcntl-invalid-cmd.cpp
     elf-execve-mmap-race.cpp
-    elf-symbolication-kernel-read-exploit.cpp
     fuzz-syscalls.cpp
     kill-pidtid-confusion.cpp
     mmap-write-into-running-programs-executable-file.cpp
@@ -20,6 +19,10 @@ set(TEST_SOURCES
     uaf-close-while-blocked-in-read.cpp
     unveil-symlinks.cpp
 )
+
+if (NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    list(APPEND TEST_SOURCES elf-symbolication-kernel-read-exploit.cpp)
+endif()
 
 # FIXME: These tests do not use LibTest
 foreach(source IN LISTS TEST_SOURCES)

--- a/Userland/Libraries/LibC/sys/arch/regs.h
+++ b/Userland/Libraries/LibC/sys/arch/regs.h
@@ -10,4 +10,6 @@
 
 #if ARCH(X86_64)
 #    include "x86_64/regs.h"
+#elif ARCH(AARCH64)
+#    include "aarch64/regs.h"
 #endif


### PR DESCRIPTION
Two trivial fixes:

LibC: Include aarch64 regs.h for AK_ARCH_AARCH64. Looks like this got mangled in the i686 removal.

Tests: Skip legacy exploit reproducer test on aarch64. This old symbolication exploit proof of concept doesn't link on aarch64
with the Clang toolchain. We should revisit these as as whole to see if
they're worth keeping around in general.