### PR TITLE
LibWeb: Paint repeating background images over entire paint box

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -309,11 +309,11 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
 
         image.resolve_for_size(layout_node, image_rect.size().to_type<float>());
 
-        while (image_y < css_clip_rect.bottom()) {
+        while (image_y <= css_clip_rect.bottom()) {
             image_rect.set_y(image_y);
 
             auto image_x = initial_image_x;
-            while (image_x < css_clip_rect.right()) {
+            while (image_x <= css_clip_rect.right()) {
                 image_rect.set_x(image_x);
                 auto image_device_rect = context.rounded_device_rect(image_rect);
                 if (image_device_rect != last_image_device_rect && image_device_rect.intersects(context.device_viewport_rect()))


### PR DESCRIPTION
We were previously missing the bottom- and right-most pixels. This fixes the errant red line showing on the Acid2 forehead.

![Screenshot from 2022-12-31 14-10-19](https://user-images.githubusercontent.com/5600524/210153662-01f56e6e-1687-4e34-ab18-f283b3f8efa5.png)
