### PR TITLE
FATFS Filename Handling Fixes (and minor VFS FIXME)

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -50,6 +50,13 @@ If more patches are upstreamed to CMake, the minimum will be bumped again once t
 To accommodate distributions that do not ship bleeding-edge CMake versions, the build scripts will
 attempt to build CMake from source if the version on your path is older than 3.25.x.
 
+If you have previously compiled SerenityOS with an older or distribution-provided version of CMake,
+you will need to manually remove the CMakeCache.txt files, as these files reference the older CMake version and path.
+```console
+rm Build/*/CMakeCache.txt
+```
+
+
 ### Windows
 
 If you're on Windows you can use WSL2 to build SerenityOS. Please have a look at the [Windows guide](BuildInstructionsWindows.md)

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -36,7 +36,8 @@ private:
     static constexpr u8 end_entry_byte = 0x00;
     static constexpr u8 unused_entry_byte = 0xE5;
 
-    static constexpr u8 lfn_entry_text_termination = 0xFF;
+    static constexpr u8 lfn_entry_character_termination = 0x00;
+    static constexpr u8 lfn_entry_unused_byte = 0xFF;
 
     static constexpr u16 first_fat_year = 1980;
 

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -649,7 +649,11 @@ ErrorOr<void> VirtualFileSystem::rename(Credentials const& credentials, Custody&
     if (!new_custody_or_error.is_error()) {
         auto& new_custody = *new_custody_or_error.value();
         auto& new_inode = new_custody.inode();
-        // FIXME: Is this really correct? Check what other systems do.
+        // When the source/dest inodes are the same (in other words,
+        // when `old_path` and `new_path` are the same), perform a no-op
+        // and return success.
+        // Linux (`vfs_rename()`) and OpenBSD (`dorenameat()`) appear to have
+        // this same no-op behavior.
         if (&new_inode == &old_inode)
             return {};
         if (new_parent_inode.metadata().is_sticky()) {


### PR DESCRIPTION
# FATFS Filename Handling Fixes (and minor VFS FIXME)

## FATFS
This fixes two issues I encountered with FATFS:
 1. Filenames that were shorter than 8.3 characters would be truncated (`HELLO.TXT -> HELL.TX`), due to an off-by-one bug in how the space character (used to pad 8.3 filenames) was stripped.
 2. Long filenames (those greater than 8.3) which did not completely fill a long filename entry/character array would have null bytes included at the end of the filename. This led to errors attempting to access the file.

### Verification
1. Created a FAT32 file system image, and used Linux to populate a few files in the name:
```console
 $ dd if=/dev/zero of=fat32.img count=50 bs=1M
 $ fdisk fat32.img  # create DOS disk-label and W95 FAT32 LBA primary partition, https://fejlesztek.hu/create-a-fat-file-system-image-on-linux/
 $ mkfs.vfat -F 32 fat32.img
 $ sudo mount fat32.img fat-mount/
 $ cd fat-mount/
 $ echo 'HELLO FAT32' | sudo tee HELLO.TXT  # filename is shorter than 8 chars
 $ echo 'hi' | sudo tee IAMEIGHT.TXT  # filename is exactly 8.3
 $ echo 'LFN stuff' | sudo VERY_LONG_FILE_NAME.TXT  # long filename
```
2. Booted QEMU with an extra disk: `-drive file=path/to/fat32.img,format=raw,index=1,media=disk`.
3. Mounted and checked out file system:
![image](https://user-images.githubusercontent.com/1073184/210156729-338cb60f-c19d-40a4-ae70-f6c0d23f0e6a.png)

## VirtualFS
Removed a FIXME about an implementation question (with justification for the implementation).
