### PR TITLE
LibGfx+icc: Print pcs illuminant

### DIFF
--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -115,6 +115,12 @@ private:
     u32 m_bits = 0;
 };
 
+struct XYZ {
+    double x { 0 };
+    double y { 0 };
+    double z { 0 };
+};
+
 class Profile : public RefCounted<Profile> {
 public:
     static ErrorOr<NonnullRefPtr<Profile>> try_load_from_externally_owned_memory(ReadonlyBytes bytes);
@@ -129,6 +135,7 @@ public:
     time_t creation_timestamp() const { return m_creation_timestamp; }
     Flags flags() const { return m_flags; }
     RenderingIntent rendering_intent() const { return m_rendering_intent; }
+    const XYZ& pcs_illuminant() const { return m_pcs_illuminant; }
 
 private:
     Version m_version;
@@ -138,6 +145,7 @@ private:
     time_t m_creation_timestamp;
     Flags m_flags;
     RenderingIntent m_rendering_intent;
+    XYZ m_pcs_illuminant;
 };
 
 }
@@ -148,6 +156,14 @@ struct Formatter<Gfx::ICC::Version> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Gfx::ICC::Version const& version)
     {
         return Formatter<FormatString>::format(builder, "{}.{}.{}"sv, version.major_version(), version.minor_version(), version.bugfix_version());
+    }
+};
+
+template<>
+struct Formatter<Gfx::ICC::XYZ> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Gfx::ICC::XYZ const& xyz)
+    {
+        return Formatter<FormatString>::format(builder, "X = {}, Y = {}, Z = {}"sv, xyz.x, xyz.y, xyz.z);
     }
 };
 }

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -37,6 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         outln("  CMM bits: 0x{:04x}", color_management_module_bits);
 
     outln("rendering intent: {}", Gfx::ICC::rendering_intent_name(profile->rendering_intent()));
+    outln("pcs illuminant: {}", profile->pcs_illuminant());
 
     return 0;
 }


### PR DESCRIPTION
I tried using `Fixed<>` here first. There were two problems:

1.

`BigEndian<Fixed<...>>` compiles but silently does the wrong thing:

- BigEndian casts its underlying type to u32 to get the raw bits,
  and then constructs the underlying type from the byte-swapped u32
  using using the Underlying(u32) ctor.
- Fixed<> returns just the integer part from its cast operator,
  and its ctor assumes that just the integer part is passed in too.

So I used a subclass of Fixed<> that has the needed semantics.

2.

But then that didn't build with GCC (clang was happy):

```
/home/runner/work/serenity/serenity/Meta/Lagom/../../AK/Endian.h:140:7: error: ignoring packed attribute because of unpacked non-POD field ‘Gfx::ICC::{anonymous}::s15Fixed16Number AK::BigEndian<Gfx::ICC::{anonymous}::s15Fixed16Number>::m_value’ [-Werror]
  140 |     T m_value { 0 };
      |       ^~~~~~~
```

So I gave up on that. It's less code this way anyways.