### PR TITLE
LibWeb: Fix some buttons in Github (vertical align and calculated line-height)

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -160,6 +160,9 @@ float StyleProperties::line_height(Layout::Node const& layout_node) const
         return Length(percentage.as_fraction(), Length::Type::Em).to_px(layout_node);
     }
 
+    if (line_height->is_calculated())
+        return CSS::Length::make_calculated(line_height->as_calculated()).to_px(layout_node);
+
     return layout_node.font().pixel_metrics().line_spacing();
 }
 

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -101,13 +101,22 @@ float box_baseline(LayoutState const& state, Box const& box)
 {
     auto const& box_state = state.get(box);
 
+    // https://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align
     auto const& vertical_align = box.computed_values().vertical_align();
     if (vertical_align.has<CSS::VerticalAlign>()) {
         switch (vertical_align.get<CSS::VerticalAlign>()) {
         case CSS::VerticalAlign::Top:
+            // Top: Align the top of the aligned subtree with the top of the line box.
             return box_state.border_box_top();
         case CSS::VerticalAlign::Bottom:
+            // Bottom: Align the bottom of the aligned subtree with the bottom of the line box.
             return box_state.content_height() + box_state.border_box_bottom();
+        case CSS::VerticalAlign::TextTop:
+            // TextTop: Align the top of the box with the top of the parent's content area (see 10.6.1).
+            return box.computed_values().font_size();
+        case CSS::VerticalAlign::TextBottom:
+            // TextTop: Align the bottom of the box with the bottom of the parent's content area (see 10.6.1).
+            return box_state.content_height() - (box.containing_block()->font().pixel_metrics().descent * 2);
         default:
             break;
         }


### PR DESCRIPTION
Some fixes for issues seen in the mini-buttons in Github.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/45781926/210174678-a7b9403e-748f-4d1d-9323-8500598d63c9.png"></td>
<td><img src="https://user-images.githubusercontent.com/45781926/210174667-e6c47e96-fa1a-4be4-8e41-3a140095195e.png"></td>
</tr>
</table>