### PR TITLE
LibGUI: Fix wrong copyright header email for recent OpacitySlider change

### DIFF
--- a/Userland/Libraries/LibGUI/OpacitySlider.cpp
+++ b/Userland/Libraries/LibGUI/OpacitySlider.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
- * Copyright (c) 2023, networkException <networkexception@serenityos.social>
+ * Copyright (c) 2023, networkException <networkexception@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */


### PR DESCRIPTION
This pull request fixes the wrong email domain being used for the copyright header change in f828bf64791c976d75d53dc73a41790adc727017