### PR TITLE
LibGL: Stop unnecessarily casting to `float`

### DIFF
--- a/Userland/Libraries/LibGL/GLAPI.json
+++ b/Userland/Libraries/LibGL/GLAPI.json
@@ -93,12 +93,12 @@
     },
     "ClearDepth": {
         "arguments": [
-            {"type": "GLdouble", "name": "depth"}
+            {"type": "GLdouble", "name": "depth", "cast_to": "GLfloat"}
         ]
     },
     "ClearDepthf": {
         "arguments": [
-            {"type": "GLfloat", "name": "depth", "cast_to": "GLdouble"}
+            {"type": "GLfloat", "name": "depth"}
         ],
         "implementation": "clear_depth"
     },
@@ -123,11 +123,11 @@
     },
     "Color": {
         "arguments": [
-            {"name": ["red", "green", "blue", "alpha"], "cast_to": "GLdouble"}
+            {"name": ["red", "green", "blue", "alpha"], "cast_to": "GLfloat"}
         ],
         "variants": {
             "argument_counts": [3, 4],
-            "argument_defaults": ["0.", "0.", "0.", "1."],
+            "argument_defaults": ["0.f", "0.f", "0.f", "1.f"],
             "convert_range": true,
             "pointer_argument": "v",
             "types": {
@@ -877,7 +877,7 @@
     },
     "Scale": {
         "arguments": [
-            {"name": ["x", "y", "z"], "cast_to": "GLdouble"}
+            {"name": ["x", "y", "z"], "cast_to": "GLfloat"}
         ],
         "variants": {
             "types": {
@@ -1111,7 +1111,7 @@
     },
     "Translate": {
         "arguments": [
-            {"name": ["x", "y", "z"], "cast_to": "GLdouble"}
+            {"name": ["x", "y", "z"], "cast_to": "GLfloat"}
         ],
         "variants": {
             "types": {

--- a/Userland/Libraries/LibGL/GLContext.cpp
+++ b/Userland/Libraries/LibGL/GLContext.cpp
@@ -117,13 +117,13 @@ void GLContext::gl_clear_color(GLclampf red, GLclampf green, GLclampf blue, GLcl
     m_clear_color.clamp(0.f, 1.f);
 }
 
-void GLContext::gl_clear_depth(GLdouble depth)
+void GLContext::gl_clear_depth(GLfloat depth)
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_clear_depth, depth);
 
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
 
-    m_clear_depth = clamp(static_cast<float>(depth), 0.f, 1.f);
+    m_clear_depth = clamp(depth, 0.f, 1.f);
 }
 
 void GLContext::gl_end()

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -110,9 +110,9 @@ public:
     void gl_begin(GLenum mode);
     void gl_clear(GLbitfield mask);
     void gl_clear_color(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha);
-    void gl_clear_depth(GLdouble depth);
+    void gl_clear_depth(GLfloat depth);
     void gl_clear_stencil(GLint s);
-    void gl_color(GLdouble r, GLdouble g, GLdouble b, GLdouble a);
+    void gl_color(GLfloat r, GLfloat g, GLfloat b, GLfloat a);
     void gl_delete_textures(GLsizei n, GLuint const* textures);
     void gl_end();
     void gl_frustum(GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdouble near_val, GLdouble far_val);
@@ -127,9 +127,9 @@ public:
     void gl_pop_matrix();
     void gl_mult_matrix(FloatMatrix4x4 const& matrix);
     void gl_rotate(GLfloat angle, GLfloat x, GLfloat y, GLfloat z);
-    void gl_scale(GLdouble x, GLdouble y, GLdouble z);
-    void gl_translate(GLdouble x, GLdouble y, GLdouble z);
-    void gl_vertex(GLdouble x, GLdouble y, GLdouble z, GLdouble w);
+    void gl_scale(GLfloat x, GLfloat y, GLfloat z);
+    void gl_translate(GLfloat x, GLfloat y, GLfloat z);
+    void gl_vertex(GLfloat x, GLfloat y, GLfloat z, GLfloat w);
     void gl_viewport(GLint x, GLint y, GLsizei width, GLsizei height);
     void gl_enable(GLenum);
     void gl_disable(GLenum);

--- a/Userland/Libraries/LibGL/Matrix.cpp
+++ b/Userland/Libraries/LibGL/Matrix.cpp
@@ -150,21 +150,21 @@ void GLContext::gl_rotate(GLfloat angle, GLfloat x, GLfloat y, GLfloat z)
     update_current_matrix(*m_current_matrix * rotation_mat);
 }
 
-void GLContext::gl_scale(GLdouble x, GLdouble y, GLdouble z)
+void GLContext::gl_scale(GLfloat x, GLfloat y, GLfloat z)
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_scale, x, y, z);
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
 
-    auto scale_matrix = Gfx::scale_matrix(FloatVector3 { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) });
+    auto scale_matrix = Gfx::scale_matrix(FloatVector3 { x, y, z });
     update_current_matrix(*m_current_matrix * scale_matrix);
 }
 
-void GLContext::gl_translate(GLdouble x, GLdouble y, GLdouble z)
+void GLContext::gl_translate(GLfloat x, GLfloat y, GLfloat z)
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_translate, x, y, z);
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
 
-    auto translation_matrix = Gfx::translation_matrix(FloatVector3 { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) });
+    auto translation_matrix = Gfx::translation_matrix(FloatVector3 { x, y, z });
     update_current_matrix(*m_current_matrix * translation_matrix);
 }
 

--- a/Userland/Libraries/LibGL/Vertex.cpp
+++ b/Userland/Libraries/LibGL/Vertex.cpp
@@ -90,16 +90,11 @@ void GLContext::gl_array_element(GLint i)
     }
 }
 
-void GLContext::gl_color(GLdouble r, GLdouble g, GLdouble b, GLdouble a)
+void GLContext::gl_color(GLfloat r, GLfloat g, GLfloat b, GLfloat a)
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_color, r, g, b, a);
 
-    m_current_vertex_color = {
-        static_cast<float>(r),
-        static_cast<float>(g),
-        static_cast<float>(b),
-        static_cast<float>(a),
-    };
+    m_current_vertex_color = { r, g, b, a };
 }
 
 void GLContext::gl_color_pointer(GLint size, GLenum type, GLsizei stride, void const* pointer)
@@ -289,13 +284,13 @@ void GLContext::gl_tex_coord_pointer(GLint size, GLenum type, GLsizei stride, vo
     tex_coord_pointer = { .size = size, .type = type, .normalize = false, .stride = stride, .pointer = data_pointer };
 }
 
-void GLContext::gl_vertex(GLdouble x, GLdouble y, GLdouble z, GLdouble w)
+void GLContext::gl_vertex(GLfloat x, GLfloat y, GLfloat z, GLfloat w)
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_vertex, x, y, z, w);
 
     GPU::Vertex vertex;
 
-    vertex.position = { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z), static_cast<float>(w) };
+    vertex.position = { x, y, z, w };
     vertex.color = m_current_vertex_color;
     for (size_t i = 0; i < m_device_info.num_texture_units; ++i)
         vertex.tex_coords[i] = m_current_vertex_tex_coord[i];


### PR DESCRIPTION
If the `GLContext`'s internal state uses a `float`, it makes no sense casting to and from `double`s.