### PR TITLE
Everywhere: Avoid including AK/Time.h everywhere

### DIFF
--- a/Kernel/Devices/Audio/Management.h
+++ b/Kernel/Devices/Audio/Management.h
@@ -10,7 +10,6 @@
 #include <AK/Error.h>
 #include <AK/IntrusiveList.h>
 #include <AK/OwnPtr.h>
-#include <AK/Time.h>
 #include <AK/Types.h>
 #include <Kernel/Devices/Audio/Controller.h>
 #include <Kernel/Library/LockRefPtr.h>

--- a/Kernel/Devices/DeviceManagement.h
+++ b/Kernel/Devices/DeviceManagement.h
@@ -9,7 +9,6 @@
 #include <AK/Badge.h>
 #include <AK/Error.h>
 #include <AK/OwnPtr.h>
-#include <AK/Time.h>
 #include <AK/Types.h>
 #include <Kernel/API/DeviceEvent.h>
 #include <Kernel/API/TimePage.h>

--- a/Kernel/Devices/HID/HIDManagement.h
+++ b/Kernel/Devices/HID/HIDManagement.h
@@ -9,7 +9,6 @@
 #include <AK/Atomic.h>
 #include <AK/CircularQueue.h>
 #include <AK/Error.h>
-#include <AK/Time.h>
 #include <AK/Types.h>
 #include <Kernel/API/KeyCode.h>
 #include <Kernel/API/MousePacket.h>

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/StringView.h>
+#include <AK/Time.h>
 #include <Kernel/API/POSIX/errno.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/OpenFileDescription.h>

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/Error.h>
-#include <AK/Time.h>
+#include <AK/Forward.h>
 #include <Kernel/FileSystem/File.h>
 #include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Library/NonnullLockRefPtrVector.h>

--- a/Kernel/StdLib.cpp
+++ b/Kernel/StdLib.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Assertions.h>
 #include <AK/MemMem.h>
+#include <AK/Time.h>
 #include <AK/Types.h>
 #include <Kernel/Arch/SafeMem.h>
 #include <Kernel/Arch/SmapDisabler.h>

--- a/Kernel/StdLib.h
+++ b/Kernel/StdLib.h
@@ -9,7 +9,6 @@
 #include <AK/Checked.h>
 #include <AK/Error.h>
 #include <AK/Forward.h>
-#include <AK/Time.h>
 #include <AK/Userspace.h>
 #include <Kernel/KString.h>
 #include <Kernel/UnixTypes.h>

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/BuiltinWrappers.h>
+#include <AK/Time.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/OpenFileDescription.h>
 #include <Kernel/Net/Socket.h>

--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Format.h>
 #include <AK/String.h>
+#include <AK/Time.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
 #include <LibCore/MemoryStream.h>
@@ -279,7 +280,7 @@ TEST_CASE(udp_socket_read_write)
     auto udp_server = Core::UDPServer::construct();
     EXPECT(udp_server->bind({ 127, 0, 0, 1 }, 9090));
 
-    auto maybe_client_socket = Core::Stream::UDPSocket::connect({ { 127, 0, 0, 1 }, 9090 });
+    auto maybe_client_socket = Core::Stream::UDPSocket::connect({ { 127, 0, 0, 1 }, 9090 }, {});
     EXPECT(!maybe_client_socket.is_error());
     auto client_socket = maybe_client_socket.release_value();
 

--- a/Userland/Libraries/LibCore/ElapsedTimer.h
+++ b/Userland/Libraries/LibCore/ElapsedTimer.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/Time.h>
+#include <AK/Forward.h>
 #include <sys/time.h>
 
 namespace Core {

--- a/Userland/Libraries/LibCore/EventLoop.h
+++ b/Userland/Libraries/LibCore/EventLoop.h
@@ -14,7 +14,6 @@
 #include <AK/Noncopyable.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
-#include <AK/Time.h>
 #include <AK/Vector.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/DeferredInvocationContext.h>

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Stream.h"
+#include <AK/Time.h>
 #include <LibCore/System.h>
 #include <fcntl.h>
 #include <netdb.h>

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -16,7 +16,6 @@
 #include <AK/Noncopyable.h>
 #include <AK/Result.h>
 #include <AK/Span.h>
-#include <AK/Time.h>
 #include <AK/Variant.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/SocketAddress.h>
@@ -434,8 +433,8 @@ private:
 
 class UDPSocket final : public Socket {
 public:
-    static ErrorOr<NonnullOwnPtr<UDPSocket>> connect(DeprecatedString const& host, u16 port, Optional<Time> timeout = {});
-    static ErrorOr<NonnullOwnPtr<UDPSocket>> connect(SocketAddress const& address, Optional<Time> timeout = {});
+    static ErrorOr<NonnullOwnPtr<UDPSocket>> connect(DeprecatedString const& host, u16 port, Optional<Time> timeout);
+    static ErrorOr<NonnullOwnPtr<UDPSocket>> connect(SocketAddress const& address, Optional<Time> timeout);
 
     UDPSocket(UDPSocket&& other)
         : Socket(static_cast<Socket&&>(other))

--- a/Userland/Libraries/LibGUI/Calendar.cpp
+++ b/Userland/Libraries/LibGUI/Calendar.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/DateConstants.h>
+#include <AK/Time.h>
 #include <LibConfig/Client.h>
 #include <LibCore/DateTime.h>
 #include <LibGUI/Calendar.h>

--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Time.h>
 #include <LibJS/Console.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/StringConstructor.h>

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -11,6 +11,7 @@
 #include <AK/DateConstants.h>
 #include <AK/DeprecatedString.h>
 #include <AK/Function.h>
+#include <AK/Time.h>
 #include <AK/TypeCasts.h>
 #include <LibCore/DateTime.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -7,6 +7,7 @@
 #include <AK/Find.h>
 #include <AK/IterationDecision.h>
 #include <AK/NumericLimits.h>
+#include <AK/Time.h>
 #include <AK/Utf16View.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -66,6 +66,11 @@ StringView DateTimeFormat::style_to_string(Style style)
     }
 }
 
+AK::Time LocalTime::time_since_epoch() const
+{
+    return AK::Time::from_timestamp(year, month + 1, day + 1, hour, minute, second, millisecond);
+}
+
 // 11.5.1 ToDateTimeOptions ( options, required, defaults ), https://tc39.es/ecma402/#sec-todatetimeoptions
 ThrowCompletionOr<Object*> to_date_time_options(VM& vm, Value options_value, OptionRequired required, OptionDefaults defaults)
 {

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -9,7 +9,6 @@
 #include <AK/Array.h>
 #include <AK/DeprecatedString.h>
 #include <AK/StringView.h>
-#include <AK/Time.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <LibJS/Runtime/Completion.h>
@@ -162,10 +161,7 @@ enum class OptionDefaults {
 // Table 8: Record returned by ToLocalTime, https://tc39.es/ecma402/#table-datetimeformat-tolocaltime-record
 // Note: [[InDST]] is not included here - it is handled by LibUnicode / LibTimeZone.
 struct LocalTime {
-    AK::Time time_since_epoch() const
-    {
-        return AK::Time::from_timestamp(year, month + 1, day + 1, hour, minute, second, millisecond);
-    }
+    AK::Time time_since_epoch() const;
 
     int weekday { 0 };     // [[Weekday]]
     ::Locale::Era era {};  // [[Era]]

--- a/Userland/Libraries/LibLocale/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibLocale/DateTimeFormat.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Array.h>
 #include <AK/StringBuilder.h>
+#include <AK/Time.h>
 #include <LibLocale/DateTimeFormat.h>
 #include <LibLocale/Locale.h>
 #include <LibLocale/NumberFormat.h>

--- a/Userland/Libraries/LibLocale/DateTimeFormat.h
+++ b/Userland/Libraries/LibLocale/DateTimeFormat.h
@@ -9,7 +9,6 @@
 #include <AK/DeprecatedString.h>
 #include <AK/Optional.h>
 #include <AK/StringView.h>
-#include <AK/Time.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <LibLocale/Forward.h>

--- a/Userland/Libraries/LibTimeZone/TimeZone.cpp
+++ b/Userland/Libraries/LibTimeZone/TimeZone.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Debug.h>
 #include <AK/DeprecatedString.h>
+#include <AK/Time.h>
 #include <LibTimeZone/TimeZone.h>
 #include <limits.h>
 #include <stdio.h>

--- a/Userland/Libraries/LibTimeZone/TimeZone.h
+++ b/Userland/Libraries/LibTimeZone/TimeZone.h
@@ -11,7 +11,6 @@
 #include <AK/Error.h>
 #include <AK/Optional.h>
 #include <AK/StringView.h>
-#include <AK/Time.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <LibTimeZone/Forward.h>

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -11,6 +11,7 @@
 #include <AK/HashMap.h>
 #include <AK/Random.h>
 #include <AK/StringBuilder.h>
+#include <AK/Time.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/File.h>
 #include <LibCore/LocalServer.h>

--- a/Userland/Utilities/nc.cpp
+++ b/Userland/Utilities/nc.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/HashTable.h>
+#include <AK/Time.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Stream.h>
@@ -72,7 +73,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         Core::EventLoop loop;
-        auto socket = TRY(Core::Stream::UDPSocket::connect(target, port));
+        auto socket = TRY(Core::Stream::UDPSocket::connect(target, port, {}));
 
         if (verbose)
             warnln("connected to {}:{}", target, port);


### PR DESCRIPTION
This PR removes many `#include <AK/Time.h>` lines from headers, and adds it back to few `.cpp` files. This should reduce compilation times.

I was working on `AK/Time.h` #16760 and noticed that this triggers basically a full rebuild on every change. That's weird, let's improve that!

The biggest impact seems to be that `LibCore/Stream.h` used to depend on `AK/Time.h`, only because a single function (`UDPSocket::connect`) takes it as an optional argument. This used to trigger a re-run of all code generators, and recompilation of everything that does any I/O whatsoever. That's silly, let's improve that!

Hence this PR: Remove Time.h includes from places where it is very optional anyway.