### PR TITLE
Spreadsheet: yakshaving around the export feature

### DIFF
--- a/Userland/Applications/Spreadsheet/ExportDialog.h
+++ b/Userland/Applications/Spreadsheet/ExportDialog.h
@@ -23,17 +23,14 @@ struct CSVExportDialogPage {
     explicit CSVExportDialogPage(Sheet const&);
 
     NonnullRefPtr<GUI::WizardPage> page() { return *m_page; }
-    Optional<XSV>& writer() { return m_previously_made_writer; }
-    Result<void, DeprecatedString> move_into(DeprecatedString const& target);
+    Optional<XSV> make_writer(OutputStream&);
 
 protected:
     void update_preview();
-    Optional<XSV> make_writer();
 
 private:
     Vector<Vector<DeprecatedString>> m_data;
     Vector<DeprecatedString> m_headers;
-    Optional<XSV> m_previously_made_writer;
     RefPtr<GUI::WizardPage> m_page;
     RefPtr<GUI::RadioButton> m_delimiter_comma_radio;
     RefPtr<GUI::RadioButton> m_delimiter_semicolon_radio;
@@ -54,8 +51,6 @@ private:
         "Repeat",
         "Backslash",
     };
-
-    DeprecatedString m_temp_output_file_path;
 };
 
 struct ExportDialog {

--- a/Userland/Applications/Spreadsheet/ExportDialog.h
+++ b/Userland/Applications/Spreadsheet/ExportDialog.h
@@ -23,7 +23,7 @@ struct CSVExportDialogPage {
     explicit CSVExportDialogPage(Sheet const&);
 
     NonnullRefPtr<GUI::WizardPage> page() { return *m_page; }
-    ErrorOr<XSV> make_writer(OutputStream&);
+    ErrorOr<NonnullOwnPtr<XSV>> make_writer(Core::Stream::Handle<Core::Stream::Stream>);
 
 protected:
     void update_preview();

--- a/Userland/Applications/Spreadsheet/ExportDialog.h
+++ b/Userland/Applications/Spreadsheet/ExportDialog.h
@@ -23,7 +23,7 @@ struct CSVExportDialogPage {
     explicit CSVExportDialogPage(Sheet const&);
 
     NonnullRefPtr<GUI::WizardPage> page() { return *m_page; }
-    Optional<XSV> make_writer(OutputStream&);
+    ErrorOr<XSV> make_writer(OutputStream&);
 
 protected:
     void update_preview();
@@ -54,7 +54,7 @@ private:
 };
 
 struct ExportDialog {
-    static Result<void, DeprecatedString> make_and_run_for(StringView mime, Core::File& file, Workbook&);
+    static ErrorOr<void> make_and_run_for(StringView mime, Core::File& file, Workbook&);
 };
 
 }

--- a/Userland/Applications/Spreadsheet/ExportDialog.h
+++ b/Userland/Applications/Spreadsheet/ExportDialog.h
@@ -54,7 +54,7 @@ private:
 };
 
 struct ExportDialog {
-    static ErrorOr<void> make_and_run_for(StringView mime, Core::File& file, Workbook&);
+    static ErrorOr<void> make_and_run_for(StringView mime, NonnullOwnPtr<Core::Stream::File>, DeprecatedString filename, Workbook&);
 };
 
 }

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -497,7 +497,7 @@ void SpreadsheetWidget::save(Core::File& file)
 {
     auto result = m_workbook->write_to_file(file);
     if (result.is_error()) {
-        GUI::MessageBox::show_error(window(), result.error());
+        GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Cannot save file: {}", result.error()));
         return;
     }
     undo_stack().set_current_unmodified();

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -64,7 +64,7 @@ Result<bool, DeprecatedString> Workbook::open_file(Core::File& file)
     return true;
 }
 
-Result<bool, DeprecatedString> Workbook::write_to_file(Core::File& file)
+ErrorOr<void> Workbook::write_to_file(Core::File& file)
 {
     auto mime = Core::guess_mime_type_based_on_filename(file.filename());
 
@@ -73,7 +73,7 @@ Result<bool, DeprecatedString> Workbook::write_to_file(Core::File& file)
 
     set_filename(file.filename());
     set_dirty(false);
-    return true;
+    return {};
 }
 
 Result<bool, DeprecatedString> Workbook::import_file(Core::File& file)

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -68,8 +68,10 @@ ErrorOr<void> Workbook::write_to_file(Core::File& file)
 {
     auto mime = Core::guess_mime_type_based_on_filename(file.filename());
 
+    auto file_stream = TRY(Core::Stream::File::adopt_fd(file.leak_fd(), Core::Stream::OpenMode::Write));
+
     // Make an export dialog, we might need to import it.
-    TRY(ExportDialog::make_and_run_for(mime, file, *this));
+    TRY(ExportDialog::make_and_run_for(mime, move(file_stream), file.filename(), *this));
 
     set_filename(file.filename());
     set_dirty(false);

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -18,7 +18,7 @@ public:
     Workbook(NonnullRefPtrVector<Sheet>&& sheets, GUI::Window& parent_window);
 
     Result<bool, DeprecatedString> open_file(Core::File&);
-    Result<bool, DeprecatedString> write_to_file(Core::File&);
+    ErrorOr<void> write_to_file(Core::File&);
 
     Result<bool, DeprecatedString> import_file(Core::File&);
 

--- a/Userland/Applications/Spreadsheet/Writers/CSV.h
+++ b/Userland/Applications/Spreadsheet/Writers/CSV.h
@@ -15,8 +15,8 @@ namespace Writer {
 template<typename ContainerType>
 class CSV : public XSV<ContainerType> {
 public:
-    CSV(OutputStream& output, ContainerType const& data, Vector<StringView> const& headers = {}, WriterBehavior behaviors = default_behaviors())
-        : XSV<ContainerType>(output, data, { ",", "\"", WriterTraits::Repeat }, headers, behaviors)
+    CSV(Core::Stream::Handle<Core::Stream::Stream> output, ContainerType const& data, Vector<StringView> headers = {}, WriterBehavior behaviors = default_behaviors())
+        : XSV<ContainerType>(move(output), data, { ",", "\"", WriterTraits::Repeat }, move(headers), behaviors)
     {
     }
 };

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -45,11 +45,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     TRY(Core::System::unveil("/sys/kernel/processes", "r"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/webcontent", "rw"));
-    // For writing temporary files when exporting.
-    TRY(Core::System::unveil("/tmp", "crw"));
     TRY(Core::System::unveil("/etc", "r"));
-    TRY(Core::System::unveil(Core::StandardPaths::home_directory(), "rwc"sv));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 


### PR DESCRIPTION
- port to Core::Stream
- use ErrorOr<> as a correct:tm: way of using TRY() macros
- don't use /tmp – start using MemoryStream for previews, and saving the file directly for anything else. this allows us to...
- tighten unveils