### PR TITLE
LibIPC: Change `IPC::encode` to be fallible and change default encoders from `operator<<` to the fallible encoding

### DIFF
--- a/Userland/DevTools/HackStudio/AutoCompleteResponse.h
+++ b/Userland/DevTools/HackStudio/AutoCompleteResponse.h
@@ -16,14 +16,14 @@
 namespace IPC {
 
 template<>
-inline bool encode(Encoder& encoder, CodeComprehension::AutocompleteResultEntry const& response)
+inline ErrorOr<void> encode(Encoder& encoder, CodeComprehension::AutocompleteResultEntry const& response)
 {
-    encoder << response.completion;
-    encoder << response.partial_input_length;
-    encoder << response.language;
-    encoder << response.display_text;
-    encoder << response.hide_autocomplete_after_applying;
-    return true;
+    TRY(encoder.encode(response.completion));
+    TRY(encoder.encode(response.partial_input_length));
+    TRY(encoder.encode(response.language));
+    TRY(encoder.encode(response.display_text));
+    TRY(encoder.encode(response.hide_autocomplete_after_applying));
+    return {};
 }
 
 template<>
@@ -39,12 +39,12 @@ inline ErrorOr<CodeComprehension::AutocompleteResultEntry> decode(Decoder& decod
 }
 
 template<>
-inline bool encode(Encoder& encoder, CodeComprehension::ProjectLocation const& location)
+inline ErrorOr<void> encode(Encoder& encoder, CodeComprehension::ProjectLocation const& location)
 {
-    encoder << location.file;
-    encoder << location.line;
-    encoder << location.column;
-    return true;
+    TRY(encoder.encode(location.file));
+    TRY(encoder.encode(location.line));
+    TRY(encoder.encode(location.column));
+    return {};
 }
 
 template<>
@@ -58,14 +58,13 @@ inline ErrorOr<CodeComprehension::ProjectLocation> decode(Decoder& decoder)
 }
 
 template<>
-inline bool encode(Encoder& encoder, CodeComprehension::Declaration const& declaration)
+inline ErrorOr<void> encode(Encoder& encoder, CodeComprehension::Declaration const& declaration)
 {
-    encoder << declaration.name;
-    if (!encode(encoder, declaration.position))
-        return false;
-    encoder << declaration.type;
-    encoder << declaration.scope;
-    return true;
+    TRY(encoder.encode(declaration.name));
+    TRY(encoder.encode(declaration.position));
+    TRY(encoder.encode(declaration.type));
+    TRY(encoder.encode(declaration.scope));
+    return {};
 }
 
 template<>
@@ -80,13 +79,13 @@ inline ErrorOr<CodeComprehension::Declaration> decode(Decoder& decoder)
 }
 
 template<>
-inline bool encode(Encoder& encoder, CodeComprehension::TodoEntry const& entry)
+inline ErrorOr<void> encode(Encoder& encoder, CodeComprehension::TodoEntry const& entry)
 {
-    encoder << entry.content;
-    encoder << entry.filename;
-    encoder << entry.line;
-    encoder << entry.column;
-    return true;
+    TRY(encoder.encode(entry.content));
+    TRY(encoder.encode(entry.filename));
+    TRY(encoder.encode(entry.line));
+    TRY(encoder.encode(entry.column));
+    return {};
 }
 
 template<>
@@ -101,15 +100,14 @@ inline ErrorOr<CodeComprehension::TodoEntry> decode(Decoder& decoder)
 }
 
 template<>
-inline bool encode(Encoder& encoder, CodeComprehension::TokenInfo const& location)
+inline ErrorOr<void> encode(Encoder& encoder, CodeComprehension::TokenInfo const& location)
 {
-    encoder << (u32)location.type;
-    static_assert(sizeof(location.type) == sizeof(u32));
-    encoder << location.start_line;
-    encoder << location.start_column;
-    encoder << location.end_line;
-    encoder << location.end_column;
-    return true;
+    TRY(encoder.encode(location.type));
+    TRY(encoder.encode(location.start_line));
+    TRY(encoder.encode(location.start_column));
+    TRY(encoder.encode(location.end_line));
+    TRY(encoder.encode(location.end_column));
+    return {};
 }
 
 template<>

--- a/Userland/Libraries/LibCore/AnonymousBuffer.h
+++ b/Userland/Libraries/LibCore/AnonymousBuffer.h
@@ -75,7 +75,7 @@ private:
 namespace IPC {
 
 template<>
-bool encode(Encoder&, Core::AnonymousBuffer const&);
+ErrorOr<void> encode(Encoder&, Core::AnonymousBuffer const&);
 
 template<>
 ErrorOr<Core::AnonymousBuffer> decode(Decoder&);

--- a/Userland/Libraries/LibCore/DateTime.h
+++ b/Userland/Libraries/LibCore/DateTime.h
@@ -69,7 +69,7 @@ struct Formatter<Core::DateTime> : StandardFormatter {
 namespace IPC {
 
 template<>
-bool encode(Encoder&, Core::DateTime const&);
+ErrorOr<void> encode(Encoder&, Core::DateTime const&);
 
 template<>
 ErrorOr<Core::DateTime> decode(Decoder&);

--- a/Userland/Libraries/LibCore/Proxy.h
+++ b/Userland/Libraries/LibCore/Proxy.h
@@ -54,7 +54,7 @@ struct ProxyData {
 namespace IPC {
 
 template<>
-bool encode(Encoder&, Core::ProxyData const&);
+ErrorOr<void> encode(Encoder&, Core::ProxyData const&);
 
 template<>
 ErrorOr<Core::ProxyData> decode(Decoder&);

--- a/Userland/Libraries/LibDNS/Answer.cpp
+++ b/Userland/Libraries/LibDNS/Answer.cpp
@@ -101,10 +101,16 @@ ErrorOr<void> AK::Formatter<DNS::RecordClass>::format(AK::FormatBuilder& builder
 namespace IPC {
 
 template<>
-bool encode(Encoder& encoder, DNS::Answer const& answer)
+ErrorOr<void> encode(Encoder& encoder, DNS::Answer const& answer)
 {
-    encoder << answer.name().as_string() << (u16)answer.type() << (u16)answer.class_code() << answer.ttl() << answer.record_data() << answer.mdns_cache_flush();
-    return true;
+    TRY(encoder.encode(answer.name().as_string()));
+    TRY(encoder.encode(static_cast<u16>(answer.type())));
+    TRY(encoder.encode(static_cast<u16>(answer.class_code())));
+    TRY(encoder.encode(answer.ttl()));
+    TRY(encoder.encode(answer.record_data()));
+    TRY(encoder.encode(answer.mdns_cache_flush()));
+
+    return {};
 }
 
 template<>

--- a/Userland/Libraries/LibDNS/Answer.h
+++ b/Userland/Libraries/LibDNS/Answer.h
@@ -95,7 +95,7 @@ struct AK::Formatter<DNS::RecordClass> : StandardFormatter {
 namespace IPC {
 
 template<>
-bool encode(Encoder&, DNS::Answer const&);
+ErrorOr<void> encode(Encoder&, DNS::Answer const&);
 
 template<>
 ErrorOr<DNS::Answer> decode(Decoder&);

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -366,10 +366,9 @@ Vector<Color> Color::tints(u32 steps, float max) const
 }
 
 template<>
-bool IPC::encode(Encoder& encoder, Color const& color)
+ErrorOr<void> IPC::encode(Encoder& encoder, Color const& color)
 {
-    encoder << color.value();
-    return true;
+    return encoder.encode(color.value());
 }
 
 template<>

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -574,7 +574,7 @@ struct Formatter<Gfx::Color> : public Formatter<StringView> {
 namespace IPC {
 
 template<>
-bool encode(Encoder&, Gfx::Color const&);
+ErrorOr<void> encode(Encoder&, Gfx::Color const&);
 
 template<>
 ErrorOr<Gfx::Color> decode(Decoder&);

--- a/Userland/Libraries/LibGfx/Point.cpp
+++ b/Userland/Libraries/LibGfx/Point.cpp
@@ -52,10 +52,11 @@ DeprecatedString FloatPoint::to_deprecated_string() const
 namespace IPC {
 
 template<>
-bool encode(Encoder& encoder, Gfx::IntPoint const& point)
+ErrorOr<void> encode(Encoder& encoder, Gfx::IntPoint const& point)
 {
-    encoder << point.x() << point.y();
-    return true;
+    TRY(encoder.encode(point.x()));
+    TRY(encoder.encode(point.y()));
+    return {};
 }
 
 template<>

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -291,7 +291,7 @@ struct Formatter<Gfx::Point<T>> : Formatter<FormatString> {
 namespace IPC {
 
 template<>
-bool encode(Encoder&, Gfx::IntPoint const&);
+ErrorOr<void> encode(Encoder&, Gfx::IntPoint const&);
 
 template<>
 ErrorOr<Gfx::IntPoint> decode(Decoder&);

--- a/Userland/Libraries/LibGfx/Rect.cpp
+++ b/Userland/Libraries/LibGfx/Rect.cpp
@@ -30,10 +30,11 @@ DeprecatedString FloatRect::to_deprecated_string() const
 namespace IPC {
 
 template<>
-bool encode(Encoder& encoder, Gfx::IntRect const& rect)
+ErrorOr<void> encode(Encoder& encoder, Gfx::IntRect const& rect)
 {
-    encoder << rect.location() << rect.size();
-    return true;
+    TRY(encoder.encode(rect.location()));
+    TRY(encoder.encode(rect.size()));
+    return {};
 }
 
 template<>

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -1039,7 +1039,7 @@ struct Formatter<Gfx::Rect<T>> : Formatter<FormatString> {
 namespace IPC {
 
 template<>
-bool encode(Encoder&, Gfx::IntRect const&);
+ErrorOr<void> encode(Encoder&, Gfx::IntRect const&);
 
 template<>
 ErrorOr<Gfx::IntRect> decode(Decoder&);

--- a/Userland/Libraries/LibGfx/ShareableBitmap.cpp
+++ b/Userland/Libraries/LibGfx/ShareableBitmap.cpp
@@ -23,21 +23,23 @@ ShareableBitmap::ShareableBitmap(NonnullRefPtr<Bitmap> bitmap, Tag)
 namespace IPC {
 
 template<>
-bool encode(Encoder& encoder, Gfx::ShareableBitmap const& shareable_bitmap)
+ErrorOr<void> encode(Encoder& encoder, Gfx::ShareableBitmap const& shareable_bitmap)
 {
-    encoder << shareable_bitmap.is_valid();
+    TRY(encoder.encode(shareable_bitmap.is_valid()));
     if (!shareable_bitmap.is_valid())
-        return true;
+        return {};
+
     auto& bitmap = *shareable_bitmap.bitmap();
-    encoder << IPC::File(bitmap.anonymous_buffer().fd());
-    encoder << bitmap.size();
-    encoder << static_cast<u32>(bitmap.scale());
-    encoder << static_cast<u32>(bitmap.format());
+    TRY(encoder.encode(IPC::File(bitmap.anonymous_buffer().fd())));
+    TRY(encoder.encode(bitmap.size()));
+    TRY(encoder.encode(static_cast<u32>(bitmap.scale())));
+    TRY(encoder.encode(static_cast<u32>(bitmap.format())));
     if (bitmap.is_indexed()) {
         auto palette = bitmap.palette_to_vector();
-        encoder << palette;
+        TRY(encoder.encode(palette));
     }
-    return true;
+
+    return {};
 }
 
 template<>

--- a/Userland/Libraries/LibGfx/ShareableBitmap.h
+++ b/Userland/Libraries/LibGfx/ShareableBitmap.h
@@ -36,7 +36,7 @@ private:
 namespace IPC {
 
 template<>
-bool encode(Encoder&, Gfx::ShareableBitmap const&);
+ErrorOr<void> encode(Encoder&, Gfx::ShareableBitmap const&);
 
 template<>
 ErrorOr<Gfx::ShareableBitmap> decode(Decoder&);

--- a/Userland/Libraries/LibGfx/Size.cpp
+++ b/Userland/Libraries/LibGfx/Size.cpp
@@ -28,10 +28,11 @@ DeprecatedString FloatSize::to_deprecated_string() const
 namespace IPC {
 
 template<>
-bool encode(Encoder& encoder, Gfx::IntSize const& size)
+ErrorOr<void> encode(Encoder& encoder, Gfx::IntSize const& size)
 {
-    encoder << size.width() << size.height();
-    return true;
+    TRY(encoder.encode(size.width()));
+    TRY(encoder.encode(size.height()));
+    return {};
 }
 
 template<>

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -214,7 +214,7 @@ struct Formatter<Gfx::Size<T>> : Formatter<FormatString> {
 namespace IPC {
 
 template<>
-bool encode(Encoder&, Gfx::IntSize const&);
+ErrorOr<void> encode(Encoder&, Gfx::IntSize const&);
 
 template<>
 ErrorOr<Gfx::IntSize> decode(Decoder&);

--- a/Userland/Libraries/LibIPC/Dictionary.h
+++ b/Userland/Libraries/LibIPC/Dictionary.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
 
@@ -35,6 +36,14 @@ public:
         for (auto& it : m_entries) {
             callback(it.key, it.value);
         }
+    }
+
+    template<FallibleFunction<DeprecatedString const&, DeprecatedString const&> Callback>
+    ErrorOr<void> try_for_each_entry(Callback&& callback) const
+    {
+        for (auto const& it : m_entries)
+            TRY(callback(it.key, it.value));
+        return {};
     }
 
     HashMap<DeprecatedString, DeprecatedString> const& entries() const { return m_entries; }

--- a/Userland/Libraries/LibIPC/Encoder.cpp
+++ b/Userland/Libraries/LibIPC/Encoder.cpp
@@ -14,6 +14,7 @@
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/Proxy.h>
+#include <LibCore/System.h>
 #include <LibIPC/Dictionary.h>
 #include <LibIPC/Encoder.h>
 #include <LibIPC/File.h>
@@ -21,132 +22,113 @@
 namespace IPC {
 
 template<>
-bool encode(Encoder& encoder, float const& value)
+ErrorOr<void> encode(Encoder& encoder, float const& value)
 {
     return encoder.encode(bit_cast<u32>(value));
 }
 
 template<>
-bool encode(Encoder& encoder, double const& value)
+ErrorOr<void> encode(Encoder& encoder, double const& value)
 {
     return encoder.encode(bit_cast<u64>(value));
 }
 
 template<>
-bool encode(Encoder& encoder, StringView const& value)
+ErrorOr<void> encode(Encoder& encoder, StringView const& value)
 {
-    auto result = encoder.append(reinterpret_cast<u8 const*>(value.characters_without_null_termination()), value.length());
-    return !result.is_error();
+    TRY(encoder.append(reinterpret_cast<u8 const*>(value.characters_without_null_termination()), value.length()));
+    return {};
 }
 
 template<>
-bool encode(Encoder& encoder, DeprecatedString const& value)
+ErrorOr<void> encode(Encoder& encoder, DeprecatedString const& value)
 {
     if (value.is_null())
         return encoder.encode(-1);
 
-    if (!encoder.encode(static_cast<i32>(value.length())))
-        return false;
-    return encoder.encode(value.view());
+    TRY(encoder.encode(static_cast<i32>(value.length())));
+    TRY(encoder.encode(value.view()));
+    return {};
 }
 
 template<>
-bool encode(Encoder& encoder, ByteBuffer const& value)
+ErrorOr<void> encode(Encoder& encoder, ByteBuffer const& value)
 {
-    if (!encoder.encode(static_cast<i32>(value.size())))
-        return false;
-
-    auto result = encoder.append(value.data(), value.size());
-    return !result.is_error();
+    TRY(encoder.encode(static_cast<i32>(value.size())));
+    TRY(encoder.append(value.data(), value.size()));
+    return {};
 }
 
 template<>
-bool encode(Encoder& encoder, JsonValue const& value)
+ErrorOr<void> encode(Encoder& encoder, JsonValue const& value)
 {
     return encoder.encode(value.serialized<StringBuilder>());
 }
 
 template<>
-bool encode(Encoder& encoder, URL const& value)
+ErrorOr<void> encode(Encoder& encoder, URL const& value)
 {
     return encoder.encode(value.to_deprecated_string());
 }
 
 template<>
-bool encode(Encoder& encoder, Dictionary const& dictionary)
+ErrorOr<void> encode(Encoder& encoder, Dictionary const& dictionary)
 {
-    if (!encoder.encode(static_cast<u64>(dictionary.size())))
-        return false;
+    TRY(encoder.encode(static_cast<u64>(dictionary.size())));
 
-    bool had_error = false;
+    TRY(dictionary.try_for_each_entry([&](auto const& key, auto const& value) -> ErrorOr<void> {
+        TRY(encoder.encode(key));
+        TRY(encoder.encode(value));
+        return {};
+    }));
 
-    dictionary.for_each_entry([&](auto const& key, auto const& value) {
-        if (had_error)
-            return;
-        if (!encoder.encode(key) || !encoder.encode(value))
-            had_error = true;
-    });
-
-    return !had_error;
+    return {};
 }
 
 template<>
-bool encode(Encoder& encoder, File const& file)
+ErrorOr<void> encode(Encoder& encoder, File const& file)
 {
     int fd = file.fd();
 
-    if (fd != -1) {
-        auto result = dup(fd);
-        if (result < 0) {
-            perror("dup");
-            VERIFY_NOT_REACHED();
-        }
-        fd = result;
-    }
+    if (fd != -1)
+        fd = TRY(Core::System::dup(fd));
 
-    if (encoder.append_file_descriptor(fd).is_error())
-        return false;
-    return true;
+    TRY(encoder.append_file_descriptor(fd));
+    return {};
 }
 
 template<>
-bool encode(Encoder&, Empty const&)
+ErrorOr<void> encode(Encoder&, Empty const&)
 {
-    return true;
+    return {};
 }
 
 template<>
-bool encode(Encoder& encoder, Core::AnonymousBuffer const& buffer)
+ErrorOr<void> encode(Encoder& encoder, Core::AnonymousBuffer const& buffer)
 {
-    if (!encoder.encode(buffer.is_valid()))
-        return false;
+    TRY(encoder.encode(buffer.is_valid()));
 
     if (buffer.is_valid()) {
-        if (!encoder.encode(static_cast<u32>(buffer.size())))
-            return false;
-        if (!encoder.encode(IPC::File { buffer.fd() }))
-            return false;
+        TRY(encoder.encode(static_cast<u32>(buffer.size())));
+        TRY(encoder.encode(IPC::File { buffer.fd() }));
     }
 
-    return true;
+    return {};
 }
 
 template<>
-bool encode(Encoder& encoder, Core::DateTime const& datetime)
+ErrorOr<void> encode(Encoder& encoder, Core::DateTime const& datetime)
 {
     return encoder.encode(static_cast<i64>(datetime.timestamp()));
 }
 
 template<>
-bool encode(Encoder& encoder, Core::ProxyData const& proxy)
+ErrorOr<void> encode(Encoder& encoder, Core::ProxyData const& proxy)
 {
-    if (!encoder.encode(proxy.type))
-        return false;
-    if (!encoder.encode(proxy.host_ipv4))
-        return false;
-    if (!encoder.encode(proxy.port))
-        return false;
-    return true;
+    TRY(encoder.encode(proxy.type));
+    TRY(encoder.encode(proxy.host_ipv4));
+    TRY(encoder.encode(proxy.port));
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -11,6 +11,7 @@
 #include <AK/StdLibExtras.h>
 #include <AK/Variant.h>
 #include <LibCore/SharedCircularQueue.h>
+#include <LibIPC/Concepts.h>
 #include <LibIPC/Forward.h>
 #include <LibIPC/Message.h>
 
@@ -30,80 +31,6 @@ public:
     {
     }
 
-    Encoder& operator<<(bool);
-    Encoder& operator<<(u8);
-    Encoder& operator<<(u16);
-    Encoder& operator<<(unsigned);
-    Encoder& operator<<(unsigned long);
-    Encoder& operator<<(unsigned long long);
-    Encoder& operator<<(i8);
-    Encoder& operator<<(i16);
-    Encoder& operator<<(i32);
-    Encoder& operator<<(i64);
-    Encoder& operator<<(float);
-    Encoder& operator<<(double);
-    Encoder& operator<<(char const*);
-    Encoder& operator<<(StringView);
-    Encoder& operator<<(DeprecatedString const&);
-    Encoder& operator<<(ByteBuffer const&);
-    Encoder& operator<<(JsonValue const&);
-    Encoder& operator<<(URL const&);
-    Encoder& operator<<(Dictionary const&);
-    Encoder& operator<<(File const&);
-    Encoder& operator<<(AK::Empty const&);
-    template<typename K, typename V>
-    Encoder& operator<<(HashMap<K, V> const& hashmap)
-    {
-        *this << (u32)hashmap.size();
-        for (auto it : hashmap) {
-            *this << it.key;
-            *this << it.value;
-        }
-        return *this;
-    }
-
-    template<typename K, typename V>
-    Encoder& operator<<(OrderedHashMap<K, V> const& hashmap)
-    {
-        *this << (u32)hashmap.size();
-        for (auto it : hashmap) {
-            *this << it.key;
-            *this << it.value;
-        }
-        return *this;
-    }
-
-    template<typename T>
-    Encoder& operator<<(Vector<T> const& vector)
-    {
-        *this << (u64)vector.size();
-        for (auto& value : vector)
-            *this << value;
-        return *this;
-    }
-
-    template<typename T, size_t Size>
-    Encoder& operator<<(Core::SharedSingleProducerCircularQueue<T, Size> const& queue)
-    {
-        *this << IPC::File(queue.fd());
-        return *this;
-    }
-
-    template<typename... VariantTypes>
-    Encoder& operator<<(AK::Variant<VariantTypes...> const& variant)
-    {
-        *this << variant.index();
-        variant.visit([this](auto const& underlying_value) { *this << underlying_value; });
-        return *this;
-    }
-
-    template<Enum T>
-    Encoder& operator<<(T const& enum_value)
-    {
-        *this << AK::to_underlying(enum_value);
-        return *this;
-    }
-
     template<typename T>
     Encoder& operator<<(T const& value)
     {
@@ -112,18 +39,29 @@ public:
     }
 
     template<typename T>
-    Encoder& operator<<(Optional<T> const& optional)
+    bool encode(T const& value);
+
+    ErrorOr<void> extend_capacity(size_t capacity)
     {
-        *this << optional.has_value();
-        if (optional.has_value())
-            *this << optional.value();
-        return *this;
+        return m_buffer.data.try_ensure_capacity(m_buffer.data.size() + capacity);
     }
 
-    template<typename T>
-    void encode(T const& value)
+    void append(u8 value)
     {
-        IPC::encode(*this, value);
+        m_buffer.data.unchecked_append(value);
+    }
+
+    ErrorOr<void> append(u8 const* values, size_t count)
+    {
+        TRY(extend_capacity(count));
+        m_buffer.data.unchecked_append(values, count);
+        return {};
+    }
+
+    ErrorOr<void> append_file_descriptor(int fd)
+    {
+        auto auto_fd = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) AutoCloseFileDescriptor(fd)));
+        return m_buffer.fds.try_append(move(auto_fd));
     }
 
 private:
@@ -132,5 +70,138 @@ private:
 
     MessageBuffer& m_buffer;
 };
+
+template<Arithmetic T>
+bool encode(Encoder& encoder, T const& value)
+{
+    if (encoder.extend_capacity(sizeof(T)).is_error())
+        return false;
+
+    if constexpr (sizeof(T) == 1) {
+        encoder.append(static_cast<u8>(value));
+    } else if constexpr (sizeof(T) == 2) {
+        encoder.append(static_cast<u8>(value));
+        encoder.append(static_cast<u8>(value >> 8));
+    } else if constexpr (sizeof(T) == 4) {
+        encoder.append(static_cast<u8>(value));
+        encoder.append(static_cast<u8>(value >> 8));
+        encoder.append(static_cast<u8>(value >> 16));
+        encoder.append(static_cast<u8>(value >> 24));
+    } else if constexpr (sizeof(T) == 8) {
+        encoder.append(static_cast<u8>(value));
+        encoder.append(static_cast<u8>(value >> 8));
+        encoder.append(static_cast<u8>(value >> 16));
+        encoder.append(static_cast<u8>(value >> 24));
+        encoder.append(static_cast<u8>(value >> 32));
+        encoder.append(static_cast<u8>(value >> 40));
+        encoder.append(static_cast<u8>(value >> 48));
+        encoder.append(static_cast<u8>(value >> 56));
+    } else {
+        static_assert(DependentFalse<T>);
+    }
+
+    return true;
+}
+
+template<Enum T>
+bool encode(Encoder& encoder, T const& value)
+{
+    return encoder.encode(to_underlying(value));
+}
+
+template<>
+bool encode(Encoder&, float const&);
+
+template<>
+bool encode(Encoder&, double const&);
+
+template<>
+bool encode(Encoder&, StringView const&);
+
+template<>
+bool encode(Encoder&, DeprecatedString const&);
+
+template<>
+bool encode(Encoder&, ByteBuffer const&);
+
+template<>
+bool encode(Encoder&, JsonValue const&);
+
+template<>
+bool encode(Encoder&, URL const&);
+
+template<>
+bool encode(Encoder&, Dictionary const&);
+
+template<>
+bool encode(Encoder&, File const&);
+
+template<>
+bool encode(Encoder&, Empty const&);
+
+template<Concepts::Vector T>
+bool encode(Encoder& encoder, T const& vector)
+{
+    if (!encoder.encode(static_cast<u64>(vector.size())))
+        return false;
+
+    for (auto const& value : vector) {
+        if (!encoder.encode(value))
+            return false;
+    }
+
+    return true;
+}
+
+template<Concepts::HashMap T>
+bool encode(Encoder& encoder, T const& hashmap)
+{
+    if (!encoder.encode(static_cast<u32>(hashmap.size())))
+        return false;
+
+    for (auto it : hashmap) {
+        if (!encoder.encode(it.key))
+            return false;
+        if (!encoder.encode(it.value))
+            return false;
+    }
+
+    return true;
+}
+
+template<Concepts::SharedSingleProducerCircularQueue T>
+bool encode(Encoder& encoder, T const& queue)
+{
+    return encoder.encode(IPC::File { queue.fd() });
+}
+
+template<Concepts::Optional T>
+bool encode(Encoder& encoder, T const& optional)
+{
+    if (!encoder.encode(optional.has_value()))
+        return false;
+
+    if (optional.has_value())
+        return encoder.encode(optional.value());
+    return true;
+}
+
+template<Concepts::Variant T>
+bool encode(Encoder& encoder, T const& variant)
+{
+    if (!encoder.encode(variant.index()))
+        return false;
+
+    return variant.visit([&](auto const& value) {
+        return encoder.encode(value);
+    });
+}
+
+// This must be last so that it knows about the above specializations.
+template<typename T>
+bool Encoder::encode(T const& value)
+{
+    return IPC::encode(*this, value);
+}
 
 }

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -32,13 +32,6 @@ public:
     }
 
     template<typename T>
-    Encoder& operator<<(T const& value)
-    {
-        (void)encode(value);
-        return *this;
-    }
-
-    template<typename T>
     ErrorOr<void> encode(T const& value);
 
     ErrorOr<void> extend_capacity(size_t capacity)

--- a/Userland/Libraries/LibIPC/Forward.h
+++ b/Userland/Libraries/LibIPC/Forward.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Error.h>
+
 namespace IPC {
 
 class Decoder;
@@ -16,7 +18,7 @@ class File;
 class Stub;
 
 template<typename T>
-bool encode(Encoder&, T const&);
+ErrorOr<void> encode(Encoder&, T const&);
 
 template<typename T>
 ErrorOr<T> decode(Decoder&);

--- a/Userland/Libraries/LibIPC/Message.h
+++ b/Userland/Libraries/LibIPC/Message.h
@@ -54,7 +54,7 @@ public:
     virtual int message_id() const = 0;
     virtual char const* message_name() const = 0;
     virtual bool valid() const = 0;
-    virtual MessageBuffer encode() const = 0;
+    virtual ErrorOr<MessageBuffer> encode() const = 0;
 
 protected:
     Message() = default;

--- a/Userland/Libraries/LibIPC/Stub.h
+++ b/Userland/Libraries/LibIPC/Stub.h
@@ -25,7 +25,7 @@ public:
 
     virtual u32 magic() const = 0;
     virtual DeprecatedString name() const = 0;
-    virtual OwnPtr<MessageBuffer> handle(Message const&) = 0;
+    virtual ErrorOr<OwnPtr<MessageBuffer>> handle(Message const&) = 0;
 
 protected:
     Stub() = default;

--- a/Userland/Libraries/LibSQL/Value.h
+++ b/Userland/Libraries/LibSQL/Value.h
@@ -191,7 +191,7 @@ struct AK::Formatter<SQL::Value> : Formatter<StringView> {
 namespace IPC {
 
 template<>
-bool encode(Encoder&, SQL::Value const&);
+ErrorOr<void> encode(Encoder&, SQL::Value const&);
 
 template<>
 ErrorOr<SQL::Value> decode(Decoder&);

--- a/Userland/Libraries/LibWeb/Cookie/Cookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/Cookie.cpp
@@ -39,22 +39,22 @@ SameSite same_site_from_string(StringView same_site_mode)
 }
 
 template<>
-bool IPC::encode(Encoder& encoder, Web::Cookie::Cookie const& cookie)
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::Cookie::Cookie const& cookie)
 {
-    encoder << cookie.name;
-    encoder << cookie.value;
-    encoder << cookie.domain;
-    encoder << cookie.path;
-    encoder << cookie.creation_time;
-    encoder << cookie.expiry_time;
-    encoder << cookie.host_only;
-    encoder << cookie.http_only;
-    encoder << cookie.last_access_time;
-    encoder << cookie.persistent;
-    encoder << cookie.secure;
-    encoder << cookie.same_site;
+    TRY(encoder.encode(cookie.name));
+    TRY(encoder.encode(cookie.value));
+    TRY(encoder.encode(cookie.domain));
+    TRY(encoder.encode(cookie.path));
+    TRY(encoder.encode(cookie.creation_time));
+    TRY(encoder.encode(cookie.expiry_time));
+    TRY(encoder.encode(cookie.host_only));
+    TRY(encoder.encode(cookie.http_only));
+    TRY(encoder.encode(cookie.last_access_time));
+    TRY(encoder.encode(cookie.persistent));
+    TRY(encoder.encode(cookie.secure));
+    TRY(encoder.encode(cookie.same_site));
 
-    return true;
+    return {};
 }
 
 template<>

--- a/Userland/Libraries/LibWeb/Cookie/Cookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/Cookie.h
@@ -47,7 +47,7 @@ SameSite same_site_from_string(StringView same_site_mode);
 namespace IPC {
 
 template<>
-bool encode(Encoder&, Web::Cookie::Cookie const&);
+ErrorOr<void> encode(Encoder&, Web::Cookie::Cookie const&);
 
 template<>
 ErrorOr<Web::Cookie::Cookie> decode(Decoder&);

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -348,19 +348,19 @@ Optional<Core::DateTime> parse_date_time(StringView date_string)
 }
 
 template<>
-bool IPC::encode(Encoder& encoder, Web::Cookie::ParsedCookie const& cookie)
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::Cookie::ParsedCookie const& cookie)
 {
-    encoder << cookie.name;
-    encoder << cookie.value;
-    encoder << cookie.expiry_time_from_expires_attribute;
-    encoder << cookie.expiry_time_from_max_age_attribute;
-    encoder << cookie.domain;
-    encoder << cookie.path;
-    encoder << cookie.secure_attribute_present;
-    encoder << cookie.http_only_attribute_present;
-    encoder << cookie.same_site_attribute;
+    TRY(encoder.encode(cookie.name));
+    TRY(encoder.encode(cookie.value));
+    TRY(encoder.encode(cookie.expiry_time_from_expires_attribute));
+    TRY(encoder.encode(cookie.expiry_time_from_max_age_attribute));
+    TRY(encoder.encode(cookie.domain));
+    TRY(encoder.encode(cookie.path));
+    TRY(encoder.encode(cookie.secure_attribute_present));
+    TRY(encoder.encode(cookie.http_only_attribute_present));
+    TRY(encoder.encode(cookie.same_site_attribute));
 
-    return true;
+    return {};
 }
 
 template<>

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
@@ -33,7 +33,7 @@ Optional<ParsedCookie> parse_cookie(DeprecatedString const& cookie_string);
 namespace IPC {
 
 template<>
-bool encode(Encoder&, Web::Cookie::ParsedCookie const&);
+ErrorOr<void> encode(Encoder&, Web::Cookie::ParsedCookie const&);
 
 template<>
 ErrorOr<Web::Cookie::ParsedCookie> decode(Decoder&);

--- a/Userland/Libraries/LibWeb/WebDriver/Response.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Response.cpp
@@ -28,23 +28,23 @@ Response::Response(Error&& error)
 }
 
 template<>
-bool IPC::encode(Encoder& encoder, Web::WebDriver::Response const& response)
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::WebDriver::Response const& response)
 {
-    response.visit(
-        [](Empty) { VERIFY_NOT_REACHED(); },
-        [&](JsonValue const& value) {
-            encoder << ResponseType::Success;
-            encoder << value;
+    return response.visit(
+        [](Empty) -> ErrorOr<void> { VERIFY_NOT_REACHED(); },
+        [&](JsonValue const& value) -> ErrorOr<void> {
+            TRY(encoder.encode(ResponseType::Success));
+            TRY(encoder.encode(value));
+            return {};
         },
-        [&](Web::WebDriver::Error const& error) {
-            encoder << ResponseType::Error;
-            encoder << error.http_status;
-            encoder << error.error;
-            encoder << error.message;
-            encoder << error.data;
+        [&](Web::WebDriver::Error const& error) -> ErrorOr<void> {
+            TRY(encoder.encode(ResponseType::Error));
+            TRY(encoder.encode(error.http_status));
+            TRY(encoder.encode(error.error));
+            TRY(encoder.encode(error.message));
+            TRY(encoder.encode(error.data));
+            return {};
         });
-
-    return true;
 }
 
 template<>

--- a/Userland/Libraries/LibWeb/WebDriver/Response.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Response.h
@@ -47,7 +47,7 @@ private:
 namespace IPC {
 
 template<>
-bool encode(Encoder&, Web::WebDriver::Response const&);
+ErrorOr<void> encode(Encoder&, Web::WebDriver::Response const&);
 
 template<>
 ErrorOr<Web::WebDriver::Response> decode(Decoder&);

--- a/Userland/Services/WindowServer/ScreenLayout.h
+++ b/Userland/Services/WindowServer/ScreenLayout.h
@@ -74,13 +74,13 @@ public:
 namespace IPC {
 
 template<>
-bool encode(Encoder&, WindowServer::ScreenLayout::Screen const&);
+ErrorOr<void> encode(Encoder&, WindowServer::ScreenLayout::Screen const&);
 
 template<>
 ErrorOr<WindowServer::ScreenLayout::Screen> decode(Decoder&);
 
 template<>
-bool encode(Encoder&, WindowServer::ScreenLayout const&);
+ErrorOr<void> encode(Encoder&, WindowServer::ScreenLayout const&);
 
 template<>
 ErrorOr<WindowServer::ScreenLayout> decode(Decoder&);

--- a/Userland/Services/WindowServer/ScreenLayout.ipp
+++ b/Userland/Services/WindowServer/ScreenLayout.ipp
@@ -393,10 +393,15 @@ bool ScreenLayout::try_auto_add_display_connector(DeprecatedString const& device
 namespace IPC {
 
 template<>
-bool encode(Encoder& encoder, WindowServer::ScreenLayout::Screen const& screen)
+ErrorOr<void> encode(Encoder& encoder, WindowServer::ScreenLayout::Screen const& screen)
 {
-    encoder << screen.mode << screen.device << screen.location << screen.resolution << screen.scale_factor;
-    return true;
+    TRY(encoder.encode(screen.mode));
+    TRY(encoder.encode(screen.device));
+    TRY(encoder.encode(screen.location));
+    TRY(encoder.encode(screen.resolution));
+    TRY(encoder.encode(screen.scale_factor));
+
+    return {};
 }
 
 template<>
@@ -412,10 +417,12 @@ ErrorOr<WindowServer::ScreenLayout::Screen> decode(Decoder& decoder)
 }
 
 template<>
-bool encode(Encoder& encoder, WindowServer::ScreenLayout const& screen_layout)
+ErrorOr<void> encode(Encoder& encoder, WindowServer::ScreenLayout const& screen_layout)
 {
-    encoder << screen_layout.screens << screen_layout.main_screen_index;
-    return true;
+    TRY(encoder.encode(screen_layout.screens));
+    TRY(encoder.encode(screen_layout.main_screen_index));
+
+    return {};
 }
 
 template<>


### PR DESCRIPTION
This changes the declaration of `IPC::encode` to be:
```c++
template<typename T>
ErrorOr<void> encode(Encoder&, T const&);
```

In order to allow propagating errors from user-defined encoders. All `Encoder::operator<<(T)` overloads are converted to this encoding method, as the stream operator just masks errors.