### PR TITLE
AK+LibCore: Convert Core::ElapsedTimer to use AK::Time internally, and refactor callers

### DIFF
--- a/AK/DistinctNumeric.h
+++ b/AK/DistinctNumeric.h
@@ -24,7 +24,7 @@ namespace AK {
  * - No matter the values of these, `DistinctNumeric` always implements `==` and `!=`.
  * - If `Arithmetic` is present, then `a+b`, `a-b`, `+a`, `-a`, `a*b`, `a/b`, `a%b`, and the respective `a_=b` versions are implemented.
  * - If `CastToBool` is present, then `!a`, `a&&b`, and `a||b` are implemented (but not `operator bool()`, because of overzealous integer promotion rules).
- * - If `Comparison` is present, then `a>b`, `a<b`, `a>=b`, and `a<=b` are implemented.
+ * - If `Comparison` is present, then `a>b`, `a<b`, `a>=b`, and `a<=b` are implemented via operator<=>
  * - If `Flags` is present, then `~a`, `a&b`, `a|b`, `a^b`, `a&=b`, `a|=b`, and `a^=b` are implemented.
  * - If `Increment` is present, then `++a`, `a++`, `--a`, and `a--` are implemented.
  * - If `Shift` is present, then `a<<b`, `a>>b`, `a<<=b`, `a>>=b` are implemented.
@@ -37,9 +37,6 @@ namespace AK {
  *
  * I intentionally decided against overloading `&a` because these shall remain
  * numeric types.
- *
- * The C++20 `operator<=>` would require, among other things `std::weak_equality`.
- * Since we do not have that, it cannot be implemented.
  *
  * The are many operators that do not work on `int`, so I left them out:
  * `a[b]`, `*a`, `a->b`, `a.b`, `a->*b`, `a.*b`.
@@ -144,27 +141,12 @@ public:
     }
 
     // Only implemented when `Comparison` is true:
-    constexpr bool operator>(Self const& other) const
+    constexpr int operator<=>(Self const& other) const
     {
-        static_assert(options.comparisons, "'a>b' is only available for DistinctNumeric types with 'Comparison'.");
-        return this->m_value > other.m_value;
+        static_assert(options.comparisons, "'a<=>b' is only available for DistinctNumeric types with 'Comparison'.");
+        return this->m_value > other.m_value ? 1 : this->m_value < other.m_value ? -1
+                                                                                 : 0;
     }
-    constexpr bool operator<(Self const& other) const
-    {
-        static_assert(options.comparisons, "'a<b' is only available for DistinctNumeric types with 'Comparison'.");
-        return this->m_value < other.m_value;
-    }
-    constexpr bool operator>=(Self const& other) const
-    {
-        static_assert(options.comparisons, "'a>=b' is only available for DistinctNumeric types with 'Comparison'.");
-        return this->m_value >= other.m_value;
-    }
-    constexpr bool operator<=(Self const& other) const
-    {
-        static_assert(options.comparisons, "'a<=b' is only available for DistinctNumeric types with 'Comparison'.");
-        return this->m_value <= other.m_value;
-    }
-    // 'operator<=>' cannot be implemented. See class comment.
 
     // Only implemented when `CastToBool` is true:
     constexpr bool operator!() const

--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -256,26 +256,6 @@ Time& Time::operator-=(Time const& other)
     return *this;
 }
 
-bool Time::operator<(Time const& other) const
-{
-    return m_seconds < other.m_seconds || (m_seconds == other.m_seconds && m_nanoseconds < other.m_nanoseconds);
-}
-
-bool Time::operator<=(Time const& other) const
-{
-    return m_seconds < other.m_seconds || (m_seconds == other.m_seconds && m_nanoseconds <= other.m_nanoseconds);
-}
-
-bool Time::operator>(Time const& other) const
-{
-    return m_seconds > other.m_seconds || (m_seconds == other.m_seconds && m_nanoseconds > other.m_nanoseconds);
-}
-
-bool Time::operator>=(Time const& other) const
-{
-    return m_seconds > other.m_seconds || (m_seconds == other.m_seconds && m_nanoseconds >= other.m_nanoseconds);
-}
-
 Time Time::from_half_sanitized(i64 seconds, i32 extra_seconds, u32 nanoseconds)
 {
     VERIFY(nanoseconds < 1'000'000'000);

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -346,43 +346,6 @@ inline void timespec_to_timeval(TimespecType const& ts, TimevalType& tv)
     tv.tv_usec = ts.tv_nsec / 1000;
 }
 
-template<TimeSpecType T>
-inline bool operator>=(T const& a, T const& b)
-{
-    return a.tv_sec > b.tv_sec || (a.tv_sec == b.tv_sec && a.tv_nsec >= b.tv_nsec);
-}
-
-template<TimeSpecType T>
-inline bool operator>(T const& a, T const& b)
-{
-    return a.tv_sec > b.tv_sec || (a.tv_sec == b.tv_sec && a.tv_nsec > b.tv_nsec);
-}
-
-template<TimeSpecType T>
-inline bool operator<(T const& a, T const& b)
-{
-    return a.tv_sec < b.tv_sec || (a.tv_sec == b.tv_sec && a.tv_nsec < b.tv_nsec);
-}
-
-template<TimeSpecType T>
-inline bool operator<=(T const& a, T const& b)
-
-{
-    return a.tv_sec < b.tv_sec || (a.tv_sec == b.tv_sec && a.tv_nsec <= b.tv_nsec);
-}
-
-template<TimeSpecType T>
-inline bool operator==(T const& a, T const& b)
-{
-    return a.tv_sec == b.tv_sec && a.tv_nsec == b.tv_nsec;
-}
-
-template<TimeSpecType T>
-inline bool operator!=(T const& a, T const& b)
-{
-    return a.tv_sec != b.tv_sec || a.tv_nsec != b.tv_nsec;
-}
-
 // To use these, add a ``using namespace AK::TimeLiterals`` at block or file scope
 namespace TimeLiterals {
 
@@ -412,10 +375,4 @@ using AK::timeval_add;
 using AK::timeval_sub;
 using AK::timeval_to_timespec;
 using AK::years_to_days_since_epoch;
-using AK::operator<=;
-using AK::operator<;
-using AK::operator>;
-using AK::operator>=;
-using AK::operator==;
-using AK::operator!=;
 #endif

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -254,15 +254,24 @@ public:
     [[nodiscard]] bool is_zero() const { return (m_seconds == 0) && (m_nanoseconds == 0); }
     [[nodiscard]] bool is_negative() const { return m_seconds < 0; }
 
-    bool operator==(Time const& other) const { return this->m_seconds == other.m_seconds && this->m_nanoseconds == other.m_nanoseconds; }
     Time operator+(Time const& other) const;
     Time& operator+=(Time const& other);
     Time operator-(Time const& other) const;
     Time& operator-=(Time const& other);
-    bool operator<(Time const& other) const;
-    bool operator<=(Time const& other) const;
-    bool operator>(Time const& other) const;
-    bool operator>=(Time const& other) const;
+
+    constexpr bool operator==(Time const& other) const = default;
+    constexpr int operator<=>(Time const& other) const
+    {
+        if (int cmp = (m_seconds > other.m_seconds ? 1 : m_seconds < other.m_seconds ? -1
+                                                                                     : 0);
+            cmp != 0)
+            return cmp;
+        if (int cmp = (m_nanoseconds > other.m_nanoseconds ? 1 : m_nanoseconds < other.m_nanoseconds ? -1
+                                                                                                     : 0);
+            cmp != 0)
+            return cmp;
+        return 0;
+    }
 
 private:
     constexpr explicit Time(i64 seconds, u32 nanoseconds)

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -383,6 +383,16 @@ inline bool operator!=(T const& a, T const& b)
     return a.tv_sec != b.tv_sec || a.tv_nsec != b.tv_nsec;
 }
 
+// To use these, add a ``using namespace AK::TimeLiterals`` at block or file scope
+namespace TimeLiterals {
+
+constexpr Time operator""_ns(unsigned long long nanoseconds) { return Time::from_nanoseconds(static_cast<i64>(nanoseconds)); }
+constexpr Time operator""_us(unsigned long long microseconds) { return Time::from_microseconds(static_cast<i64>(microseconds)); }
+constexpr Time operator""_ms(unsigned long long milliseconds) { return Time::from_milliseconds(static_cast<i64>(milliseconds)); }
+constexpr Time operator""_sec(unsigned long long seconds) { return Time::from_seconds(static_cast<i64>(seconds)); }
+
+}
+
 }
 
 #if USING_AK_GLOBALLY

--- a/Tests/AK/TestTime.cpp
+++ b/Tests/AK/TestTime.cpp
@@ -475,3 +475,18 @@ TEST_CASE(years_to_days_since_epoch_span)
         EXPECT_EQ(actual_days, expected_days);
     }
 }
+
+TEST_CASE(user_defined_literals)
+{
+    using namespace AK::TimeLiterals;
+    static_assert(Time::from_nanoseconds(123) == 123_ns, "Factory is same as UDL");
+
+    static_assert(100_ms > 10_ms, "LT UDL");
+    static_assert(1000_ns == 1_us, "EQ UDL");
+    static_assert(1_sec > 1_ms, "GT UDL");
+    static_assert(100_ms >= 100'000_us, "GE UDL (eq)");
+    static_assert(100_ms >= 99'999_us, "GE UDL (gt)");
+    static_assert(100_ms <= 100'000_us, "LE UDL (eq)");
+    static_assert(100_ms <= 100'001_us, "LE UDL (lt)");
+    static_assert(1_sec != 2_sec, "NE UDL");
+}

--- a/Tests/Kernel/TestKernelAlarm.cpp
+++ b/Tests/Kernel/TestKernelAlarm.cpp
@@ -22,7 +22,7 @@ public:
 
     static void test_signal_handler(int signal)
     {
-        auto actual_duration = Time::from_milliseconds(SuccessContext::signal_timer.elapsed());
+        auto actual_duration = SuccessContext::signal_timer.elapsed_time();
         auto expected_duration = SuccessContext::timer_value;
 
         // Add a small buffer to allow for latency on the system.

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -116,7 +116,7 @@ private:
     float m_rotation_speed = 60.f;
     bool m_show_frame_rate = false;
     int m_cycles = 0;
-    int m_accumulated_time = 0;
+    Time m_accumulated_time = {};
     RefPtr<GUI::Label> m_stats;
     GLint m_wrap_s_mode = GL_REPEAT;
     GLint m_wrap_t_mode = GL_REPEAT;
@@ -265,10 +265,10 @@ void GLContextWidget::timer_event(Core::TimerEvent&)
     m_context->present();
 
     if ((m_cycles % 30) == 0) {
-        auto render_time = m_accumulated_time / 30.0;
+        auto render_time = static_cast<double>(m_accumulated_time.to_milliseconds()) / 30.0;
         auto frame_rate = render_time > 0 ? 1000 / render_time : 0;
         m_stats->set_text(DeprecatedString::formatted("{:.0f} fps, {:.1f} ms", frame_rate, render_time));
-        m_accumulated_time = 0;
+        m_accumulated_time = {};
 
         glEnable(GL_LIGHT0);
         glEnable(GL_LIGHT1);
@@ -285,7 +285,7 @@ void GLContextWidget::timer_event(Core::TimerEvent&)
 
     update();
 
-    m_accumulated_time += timer.elapsed();
+    m_accumulated_time += timer.elapsed_time();
     m_cycles++;
 }
 

--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -128,7 +128,7 @@ void DownloadWidget::did_progress(Optional<u32> total_size, u32 downloaded_size)
         StringBuilder builder;
         builder.append("Downloaded "sv);
         builder.append(human_readable_size(downloaded_size));
-        builder.appendff(" in {} sec", m_elapsed_timer.elapsed() / 1000);
+        builder.appendff(" in {} sec", m_elapsed_timer.elapsed_time().to_seconds());
         m_progress_label->set_text(builder.to_deprecated_string());
     }
 

--- a/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
+++ b/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
@@ -141,13 +141,13 @@ void FileOperationProgressWidget::did_error(StringView message)
 
 DeprecatedString FileOperationProgressWidget::estimate_time(off_t bytes_done, off_t total_byte_count)
 {
-    int elapsed = m_elapsed_timer.elapsed() / 1000;
+    i64 const elapsed_seconds = m_elapsed_timer.elapsed_time().to_seconds();
 
-    if (bytes_done == 0 || elapsed < 3)
+    if (bytes_done == 0 || elapsed_seconds < 3)
         return "Estimating...";
 
     off_t bytes_left = total_byte_count - bytes_done;
-    int seconds_remaining = (bytes_left * elapsed) / bytes_done;
+    int seconds_remaining = (bytes_left * elapsed_seconds) / bytes_done;
 
     if (seconds_remaining < 30)
         return DeprecatedString::formatted("{} seconds", 5 + seconds_remaining - seconds_remaining % 5);

--- a/Userland/Demos/CatDog/CatDog.cpp
+++ b/Userland/Demos/CatDog/CatDog.cpp
@@ -100,6 +100,8 @@ bool CatDog::is_inspector() const
 
 void CatDog::timer_event(Core::TimerEvent&)
 {
+    using namespace AK::TimeLiterals;
+
     if (has_flag(m_state, State::Alert))
         return;
 
@@ -127,7 +129,7 @@ void CatDog::timer_event(Core::TimerEvent&)
     if (has_any_flag(m_state, State::Directions)) {
         m_idle_sleep_timer.start();
     } else {
-        if (m_idle_sleep_timer.elapsed() > 5'000)
+        if (m_idle_sleep_timer.elapsed_time() > 5_sec)
             m_state |= State::Sleeping;
         else
             m_state |= State::Idle;

--- a/Userland/DevTools/HackStudio/LanguageClient.cpp
+++ b/Userland/DevTools/HackStudio/LanguageClient.cpp
@@ -192,11 +192,13 @@ ConnectionToServerWrapper* ConnectionToServerInstances::get_instance_wrapper(Dep
 
 void ConnectionToServerWrapper::on_crash()
 {
+    using namespace AK::TimeLiterals;
+
     show_crash_notification();
     m_connection.clear();
 
-    static constexpr int max_crash_frequency_seconds = 10;
-    if (m_last_crash_timer.is_valid() && m_last_crash_timer.elapsed() / 1000 < max_crash_frequency_seconds) {
+    static constexpr Time max_crash_frequency = 10_sec;
+    if (m_last_crash_timer.is_valid() && m_last_crash_timer.elapsed_time() < max_crash_frequency) {
         dbgln("LanguageServer crash frequency is too high");
         m_respawn_allowed = false;
 

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -327,7 +327,7 @@ static bool prompt_to_stop_profiling(pid_t pid, DeprecatedString const& process_
     Core::ElapsedTimer clock;
     clock.start();
     auto update_timer = Core::Timer::construct(100, [&] {
-        timer_label.set_text(DeprecatedString::formatted("{:.1} seconds", clock.elapsed() / 1000.0f));
+        timer_label.set_text(DeprecatedString::formatted("{:.1} seconds", static_cast<float>(clock.elapsed()) / 1000.0f));
     });
 
     auto& stop_button = widget->add<GUI::Button>("Stop");

--- a/Userland/Libraries/LibCore/ElapsedTimer.cpp
+++ b/Userland/Libraries/LibCore/ElapsedTimer.cpp
@@ -7,8 +7,6 @@
 #include <AK/Assertions.h>
 #include <AK/Time.h>
 #include <LibCore/ElapsedTimer.h>
-#include <sys/time.h>
-#include <time.h>
 
 namespace Core {
 
@@ -22,34 +20,25 @@ ElapsedTimer ElapsedTimer::start_new()
 void ElapsedTimer::start()
 {
     m_valid = true;
-    timespec now_spec;
-    clock_gettime(m_precise ? CLOCK_MONOTONIC : CLOCK_MONOTONIC_COARSE, &now_spec);
-    m_origin_time.tv_sec = now_spec.tv_sec;
-    m_origin_time.tv_usec = now_spec.tv_nsec / 1000;
+    m_origin_time = m_precise ? Time::now_monotonic() : Time::now_monotonic_coarse();
 }
 
 void ElapsedTimer::reset()
 {
     m_valid = false;
-    m_origin_time = { 0, 0 };
+    m_origin_time = {};
 }
 
-int ElapsedTimer::elapsed() const
+i64 ElapsedTimer::elapsed() const
 {
-    VERIFY(is_valid());
-    struct timeval now;
-    timespec now_spec;
-    clock_gettime(m_precise ? CLOCK_MONOTONIC : CLOCK_MONOTONIC_COARSE, &now_spec);
-    now.tv_sec = now_spec.tv_sec;
-    now.tv_usec = now_spec.tv_nsec / 1000;
-    struct timeval diff;
-    timeval_sub(now, m_origin_time, diff);
-    return diff.tv_sec * 1000 + diff.tv_usec / 1000;
+    return elapsed_time().to_milliseconds();
 }
 
 Time ElapsedTimer::elapsed_time() const
 {
-    return Time::from_milliseconds(elapsed());
+    VERIFY(is_valid());
+    auto now = m_precise ? Time::now_monotonic() : Time::now_monotonic_coarse();
+    return now - m_origin_time;
 }
 
 }

--- a/Userland/Libraries/LibCore/ElapsedTimer.h
+++ b/Userland/Libraries/LibCore/ElapsedTimer.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Time.h>
-#include <sys/time.h>
 
 namespace Core {
 
@@ -23,17 +22,16 @@ public:
     bool is_valid() const { return m_valid; }
     void start();
     void reset();
-    int elapsed() const;
+
+    i64 elapsed() const; // milliseconds
     Time elapsed_time() const;
 
-    const struct timeval& origin_time() const { return m_origin_time; }
+    Time const& origin_time() const { return m_origin_time; }
 
 private:
+    Time m_origin_time {};
     bool m_precise { false };
     bool m_valid { false };
-    struct timeval m_origin_time {
-        0, 0
-    };
 };
 
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -252,6 +252,8 @@ void TextEditor::doubleclick_event(MouseEvent& event)
 
 void TextEditor::mousedown_event(MouseEvent& event)
 {
+    using namespace AK::TimeLiterals;
+
     if (event.button() != MouseButton::Primary) {
         return;
     }
@@ -262,7 +264,7 @@ void TextEditor::mousedown_event(MouseEvent& event)
     if (is_displayonly())
         return;
 
-    if (m_triple_click_timer.is_valid() && m_triple_click_timer.elapsed() < 250) {
+    if (m_triple_click_timer.is_valid() && m_triple_click_timer.elapsed_time() < 250_ms) {
         m_triple_click_timer = Core::ElapsedTimer();
         select_current_line();
         return;

--- a/Userland/Libraries/LibJS/Bytecode/PassManager.h
+++ b/Userland/Libraries/LibJS/Bytecode/PassManager.h
@@ -6,10 +6,9 @@
 
 #pragma once
 
+#include <LibCore/ElapsedTimer.h>
 #include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Generator.h>
-#include <sys/time.h>
-#include <time.h>
 
 namespace JS::Bytecode {
 
@@ -28,31 +27,18 @@ public:
     virtual void perform(PassPipelineExecutable&) = 0;
     void started()
     {
-        gettimeofday(&m_start_time, nullptr);
+        m_timer.start();
     }
     void finished()
     {
-        struct timeval end_time {
-            0, 0
-        };
-        gettimeofday(&end_time, nullptr);
-        time_t interval_s = end_time.tv_sec - m_start_time.tv_sec;
-        suseconds_t interval_us = end_time.tv_usec;
-        if (interval_us < m_start_time.tv_usec) {
-            interval_s -= 1;
-            interval_us += 1000000;
-        }
-        interval_us -= m_start_time.tv_usec;
-        m_time_difference = interval_s * 1000000 + interval_us;
+        m_time_difference = m_timer.elapsed_time();
     }
 
-    u64 elapsed() const { return m_time_difference; }
+    u64 elapsed() const { return m_time_difference.to_microseconds(); }
 
 protected:
-    struct timeval m_start_time {
-        0, 0
-    };
-    u64 m_time_difference { 0 };
+    Core::ElapsedTimer m_timer;
+    Time m_time_difference {};
 };
 
 class PassManager : public Pass {

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -1570,7 +1570,7 @@ void Device::draw_statistics_overlay(Gfx::Bitmap& target)
     static int frame_counter;
 
     frame_counter++;
-    int milliseconds = 0;
+    i64 milliseconds = 0;
     if (timer.is_valid())
         milliseconds = timer.elapsed();
     else

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -795,6 +795,8 @@ void TerminalWidget::mouseup_event(GUI::MouseEvent& event)
 
 void TerminalWidget::mousedown_event(GUI::MouseEvent& event)
 {
+    using namespace AK::TimeLiterals;
+
     if (event.button() == GUI::MouseButton::Primary) {
         m_left_mousedown_position = event.position();
         m_left_mousedown_position_buffer = buffer_position_at(m_left_mousedown_position);
@@ -809,7 +811,7 @@ void TerminalWidget::mousedown_event(GUI::MouseEvent& event)
         m_active_href = {};
         m_active_href_id = {};
 
-        if (m_triple_click_timer.is_valid() && m_triple_click_timer.elapsed() < 250) {
+        if (m_triple_click_timer.is_valid() && m_triple_click_timer.elapsed_time() < 250_ms) {
             int start_column = 0;
             int end_column = m_terminal.columns() - 1;
 

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
@@ -39,8 +39,7 @@ JS::GCPtr<NavigationTiming::PerformanceTiming> Performance::timing()
 
 double Performance::time_origin() const
 {
-    auto origin = m_timer.origin_time();
-    return (origin.tv_sec * 1000.0) + (origin.tv_usec / 1000.0);
+    return static_cast<double>(m_timer.origin_time().to_milliseconds());
 }
 
 }

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.h
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.h
@@ -17,7 +17,7 @@ class Performance final : public DOM::EventTarget {
 public:
     virtual ~Performance() override;
 
-    double now() const { return m_timer.elapsed(); }
+    double now() const { return static_cast<double>(m_timer.elapsed()); }
     double time_origin() const;
 
     JS::GCPtr<NavigationTiming::PerformanceTiming> timing();

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -243,6 +243,8 @@ void Service::spawn(int socket_fd)
 
 void Service::did_exit(int exit_code)
 {
+    using namespace AK::TimeLiterals;
+
     VERIFY(m_pid > 0);
     VERIFY(!m_multi_instance);
 
@@ -254,10 +256,10 @@ void Service::did_exit(int exit_code)
     if (!m_keep_alive)
         return;
 
-    int run_time_in_msec = m_run_timer.elapsed();
+    auto run_time = m_run_timer.elapsed_time();
     bool exited_successfully = exit_code == 0;
 
-    if (!exited_successfully && run_time_in_msec < 1000) {
+    if (!exited_successfully && run_time < 1_sec) {
         switch (m_restart_attempts) {
         case 0:
             dbgln("Trying again");

--- a/Userland/Services/WindowServer/Animation.cpp
+++ b/Userland/Services/WindowServer/Animation.cpp
@@ -47,7 +47,7 @@ void Animation::was_removed(Badge<Compositor>)
 
 bool Animation::update(Badge<Compositor>, Gfx::Painter& painter, Screen& screen, Gfx::DisjointIntRectSet& flush_rects)
 {
-    int elapsed_ms = m_timer.elapsed();
+    i64 const elapsed_ms = m_timer.elapsed();
     float progress = min((float)elapsed_ms / (float)m_duration, 1.0f);
 
     if (on_update)

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1086,8 +1086,8 @@ auto WindowManager::DoubleClickInfo::metadata_for_button(MouseButton button) -> 
 
 bool WindowManager::is_considered_doubleclick(MouseEvent const& event, DoubleClickInfo::ClickMetadata const& metadata) const
 {
-    int elapsed_since_last_click = metadata.clock.elapsed();
-    if (elapsed_since_last_click < m_double_click_speed) {
+    i64 elapsed_ms_since_last_click = metadata.clock.elapsed();
+    if (elapsed_ms_since_last_click < m_double_click_speed) {
         auto diff = event.position() - metadata.last_position;
         auto distance_travelled_squared = diff.x() * diff.x() + diff.y() * diff.y();
         if (distance_travelled_squared <= (m_max_distance_for_double_click * m_max_distance_for_double_click))

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -1007,7 +1007,7 @@ int Shell::builtin_time(int argc, char const** argv)
             block_on_job(job);
             exit_code = job.exit_code();
         }
-        iteration_times.add(timer.elapsed());
+        iteration_times.add(static_cast<float>(timer.elapsed()));
     }
 
     if (number_of_iterations == 1) {

--- a/Userland/Utilities/abench.cpp
+++ b/Userland/Utilities/abench.cpp
@@ -40,7 +40,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     auto loader = maybe_loader.release_value();
 
     Core::ElapsedTimer sample_timer { true };
-    u64 total_loader_time = 0;
+    i64 total_loader_time = 0;
     int remaining_samples = sample_count > 0 ? sample_count : NumericLimits<int>::max();
     unsigned total_loaded_samples = 0;
 
@@ -48,8 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         if (remaining_samples > 0) {
             sample_timer = sample_timer.start_new();
             auto samples = loader->get_more_samples(min(MAX_CHUNK_SIZE, remaining_samples));
-            auto elapsed = static_cast<u64>(sample_timer.elapsed());
-            total_loader_time += static_cast<u64>(elapsed);
+            total_loader_time += sample_timer.elapsed();
             if (!samples.is_error()) {
                 remaining_samples -= samples.value().size();
                 total_loaded_samples += samples.value().size();

--- a/Userland/Utilities/disk_benchmark.cpp
+++ b/Userland/Utilities/disk_benchmark.cpp
@@ -43,8 +43,10 @@ static ErrorOr<Result> benchmark(DeprecatedString const& filename, int file_size
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    using namespace AK::TimeLiterals;
+
     DeprecatedString directory = ".";
-    int time_per_benchmark = 10;
+    i64 time_per_benchmark_sec = 10;
     Vector<size_t> file_sizes;
     Vector<size_t> block_sizes;
     bool allow_cache = false;
@@ -52,10 +54,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Core::ArgsParser args_parser;
     args_parser.add_option(allow_cache, "Allow using disk cache", "cache", 'c');
     args_parser.add_option(directory, "Path to a directory where we can store the disk benchmark temp file", "directory", 'd', "directory");
-    args_parser.add_option(time_per_benchmark, "Time elapsed per benchmark", "time-per-benchmark", 't', "time-per-benchmark");
+    args_parser.add_option(time_per_benchmark_sec, "Time elapsed per benchmark (seconds)", "time-per-benchmark", 't', "time-per-benchmark");
     args_parser.add_option(file_sizes, "A comma-separated list of file sizes", "file-size", 'f', "file-size");
     args_parser.add_option(block_sizes, "A comma-separated list of block sizes", "block-size", 'b', "block-size");
     args_parser.parse(arguments);
+
+    Time const time_per_benchmark = Time::from_seconds(time_per_benchmark_sec);
 
     if (file_sizes.size() == 0) {
         file_sizes = { 131072, 262144, 524288, 1048576, 5242880 };
@@ -82,7 +86,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
             outln("Running: file_size={} block_size={}", file_size, block_size);
             auto timer = Core::ElapsedTimer::start_new();
-            while (timer.elapsed() < time_per_benchmark * 1000) {
+            while (timer.elapsed_time() < time_per_benchmark) {
                 out(".");
                 fflush(stdout);
                 auto result = TRY(benchmark(filename, file_size, buffer_result.value(), allow_cache));


### PR DESCRIPTION
- Add some UDLs for AK::Time, and start using them where people are comparing AK::Time to constants
- Stop using clock_gettime() and gettimeofday in LibCore and LibJS and just use AK::Time
- Convert callers of ElapsedTime::elapsed() to elapsed_time( )  where it makes sense.
- Refactor some other callers of ElapsedTime to do simpler things, and fix some fallout from using AK::Time::to_milliseconds(), changing the type of ElapsedTime::elapsed() from int to i64.

In general, let's keep the ball rolling on moving away from bespoke "integer `<time unit>`" usages in the codebase and use AK::Time instead :)