### PR TITLE
Everywhere: Fix badly-formatted and unused includes

### DIFF
--- a/AK/EnumBits.h
+++ b/AK/EnumBits.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "AK/StdLibExtras.h"
+#include <AK/StdLibExtras.h>
 
 // Enables bitwise operators for the specified Enum type.
 //

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "AK/StringUtils.h"
 #include <AK/DeprecatedString.h>
+#include <AK/StringUtils.h>
 
 namespace AK {
 

--- a/AK/UBSanitizer.h
+++ b/AK/UBSanitizer.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "AK/Noncopyable.h"
-#include "AK/StdLibExtras.h"
 #include <AK/Atomic.h>
+#include <AK/Noncopyable.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
 namespace AK::UBSanitizer {

--- a/Kernel/Devices/Audio/Management.h
+++ b/Kernel/Devices/Audio/Management.h
@@ -10,7 +10,6 @@
 #include <AK/Error.h>
 #include <AK/IntrusiveList.h>
 #include <AK/OwnPtr.h>
-#include <AK/Time.h>
 #include <AK/Types.h>
 #include <Kernel/Devices/Audio/Controller.h>
 #include <Kernel/Library/LockRefPtr.h>

--- a/Kernel/Devices/DeviceManagement.h
+++ b/Kernel/Devices/DeviceManagement.h
@@ -9,7 +9,6 @@
 #include <AK/Badge.h>
 #include <AK/Error.h>
 #include <AK/OwnPtr.h>
-#include <AK/Time.h>
 #include <AK/Types.h>
 #include <Kernel/API/DeviceEvent.h>
 #include <Kernel/API/TimePage.h>

--- a/Kernel/Devices/HID/HIDManagement.h
+++ b/Kernel/Devices/HID/HIDManagement.h
@@ -9,7 +9,6 @@
 #include <AK/Atomic.h>
 #include <AK/CircularQueue.h>
 #include <AK/Error.h>
-#include <AK/Time.h>
 #include <AK/Types.h>
 #include <Kernel/API/KeyCode.h>
 #include <Kernel/API/MousePacket.h>

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/IterationDecision.h>
 #include <AK/Platform.h>
 #include <AK/Singleton.h>
 #include <AK/StringView.h>

--- a/Tests/AK/TestVector.cpp
+++ b/Tests/AK/TestVector.cpp
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "AK/ReverseIterator.h"
 #include <LibTest/TestCase.h>
 
 #include <AK/DeprecatedString.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/OwnPtr.h>
+#include <AK/ReverseIterator.h>
 #include <AK/Vector.h>
 
 TEST_CASE(construct)

--- a/Tests/LibCore/TestLibCoreSharedSingleProducerCircularQueue.cpp
+++ b/Tests/LibCore/TestLibCoreSharedSingleProducerCircularQueue.cpp
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "sched.h"
 #include <LibCore/SharedCircularQueue.h>
 #include <LibTest/TestCase.h>
 #include <LibThreading/Thread.h>
+#include <sched.h>
 
 using TestQueue = Core::SharedSingleProducerCircularQueue<int>;
 using QueueError = ErrorOr<int, TestQueue::QueueStatus>;

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "LibRegex/RegexMatcher.h"
 #include <LibTest/TestCase.h> // import first, to prevent warning of VERIFY* redefinition
 
 #include <AK/StringBuilder.h>
 #include <AK/Tuple.h>
 #include <LibRegex/Regex.h>
 #include <LibRegex/RegexDebug.h>
+#include <LibRegex/RegexMatcher.h>
 #include <stdio.h>
 
 static ECMAScriptOptions match_test_api_options(const ECMAScriptOptions options)

--- a/Userland/Applets/Keymap/KeymapStatusWidget.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWidget.cpp
@@ -5,8 +5,8 @@
  */
 
 #include "KeymapStatusWidget.h"
-#include "LibGUI/ActionGroup.h"
 #include <LibGUI/Action.h>
+#include <LibGUI/ActionGroup.h>
 #include <LibGUI/ConnectionToWindowManagerServer.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Process.h>

--- a/Userland/Applications/Browser/History/HistoryModel.h
+++ b/Userland/Applications/Browser/History/HistoryModel.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "Applications/Browser/History.h"
 #include <AK/Vector.h>
+#include <Applications/Browser/History.h>
 #include <LibGUI/Model.h>
 #include <LibGUI/Widget.h>
 

--- a/Userland/Applications/Browser/History/HistoryWidget.h
+++ b/Userland/Applications/Browser/History/HistoryWidget.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "Applications/Browser/History.h"
+#include "../History.h"
 #include "HistoryModel.h"
 #include <LibGUI/FilteringProxyModel.h>
 #include <LibGUI/TextBox.h>

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "LibGUI/CheckBox.h"
 #include <LibGUI/Button.h>
+#include <LibGUI/CheckBox.h>
 #include <LibGUI/ListView.h>
 #include <LibGUI/SettingsWindow.h>
 

--- a/Userland/Applications/PDFViewer/NumericInput.cpp
+++ b/Userland/Applications/PDFViewer/NumericInput.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "NumericInput.h"
-#include "ctype.h"
+#include <ctype.h>
 
 NumericInput::NumericInput()
 {

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -6,11 +6,9 @@
  */
 
 #include "PDFViewerWidget.h"
-#include "AK/Assertions.h"
-#include "AK/DeprecatedString.h"
-#include "AK/Format.h"
-#include "LibGUI/Forward.h"
-#include "LibPDF/Document.h"
+#include <AK/Assertions.h>
+#include <AK/DeprecatedString.h>
+#include <AK/Format.h>
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
 #include <AK/Variant.h>
@@ -19,6 +17,7 @@
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/FilePicker.h>
+#include <LibGUI/Forward.h>
 #include <LibGUI/InputBox.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
@@ -30,6 +29,7 @@
 #include <LibGUI/TableView.h>
 #include <LibGUI/Toolbar.h>
 #include <LibGUI/ToolbarContainer.h>
+#include <LibPDF/Document.h>
 
 class PagedErrorsModel : public GUI::Model {
 

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.h
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.h
@@ -6,11 +6,11 @@
 
 #pragma once
 
-#include "AK/NonnullRefPtr.h"
-#include "AK/RefPtr.h"
 #include "NumericInput.h"
 #include "PDFViewer.h"
 #include "SidebarWidget.h"
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefPtr.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/CheckBox.h>

--- a/Userland/Applications/PDFViewer/SidebarWidget.h
+++ b/Userland/Applications/PDFViewer/SidebarWidget.h
@@ -6,11 +6,11 @@
 
 #pragma once
 
-#include "LibGUI/ModelIndex.h"
-#include "LibPDF/Document.h"
 #include "OutlineModel.h"
+#include <LibGUI/ModelIndex.h>
 #include <LibGUI/TreeView.h>
 #include <LibGUI/Widget.h>
+#include <LibPDF/Document.h>
 
 class SidebarWidget final : public GUI::Widget {
     C_OBJECT(SidebarWidget)

--- a/Userland/Applications/Piano/RollWidget.cpp
+++ b/Userland/Applications/Piano/RollWidget.cpp
@@ -8,9 +8,9 @@
  */
 
 #include "RollWidget.h"
-#include "LibGUI/Event.h"
 #include "TrackManager.h"
 #include <AK/IntegralMath.h>
+#include <LibGUI/Event.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Scrollbar.h>
 #include <LibGfx/Font/Font.h>

--- a/Userland/Applications/PixelPaint/Tools/TextTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.cpp
@@ -7,10 +7,10 @@
 #include "TextTool.h"
 #include "../ImageEditor.h"
 #include "../Layer.h"
-#include "LibGUI/FontPicker.h"
 #include <LibGUI/Action.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
+#include <LibGUI/FontPicker.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>

--- a/Userland/Applications/Presenter/PresenterWidget.cpp
+++ b/Userland/Applications/Presenter/PresenterWidget.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "PresenterWidget.h"
-#include "LibGUI/MessageBox.h"
 #include "Presentation.h"
 #include <AK/Format.h>
 #include <LibCore/MimeData.h>
@@ -14,6 +13,7 @@
 #include <LibGUI/Event.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menu.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Forward.h>

--- a/Userland/Applications/Presenter/PresenterWidget.h
+++ b/Userland/Applications/Presenter/PresenterWidget.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "LibGUI/Action.h"
 #include "Presentation.h"
+#include <LibGUI/Action.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/UIDimensions.h>
 #include <LibGUI/Widget.h>

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -7,7 +7,7 @@
 #include "SpreadsheetWidget.h"
 #include "CellSyntaxHighlighter.h"
 #include "HelpWindow.h"
-#include "LibFileSystemAccessClient/Client.h"
+#include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -8,13 +8,13 @@
 #include "ExportDialog.h"
 #include "ImportDialog.h"
 #include "JSIntegration.h"
-#include "LibGUI/MessageBox.h"
 #include "Readers/CSV.h"
 #include <AK/ByteBuffer.h>
 #include <AK/StringView.h>
 #include <LibCore/File.h>
 #include <LibCore/MimeData.h>
 #include <LibFileSystemAccessClient/Client.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Window.h>
 #include <LibJS/Runtime/GlobalObject.h>

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "HelpWindow.h"
-#include "LibFileSystemAccessClient/Client.h"
 #include "Spreadsheet.h"
 #include "SpreadsheetWidget.h"
 #include <AK/ScopeGuard.h>
@@ -13,6 +12,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
+#include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/FilePicker.h>

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -16,7 +16,6 @@
 #include "GMLPreviewWidget.h"
 #include "Git/DiffViewer.h"
 #include "Git/GitWidget.h"
-#include "LibGUI/Button.h"
 #include "Locator.h"
 #include "Project.h"
 #include "ProjectBuilder.h"
@@ -25,6 +24,7 @@
 #include "ToDoEntriesWidget.h"
 #include <LibCoredump/Inspector.h>
 #include <LibGUI/ActionGroup.h>
+#include <LibGUI/Button.h>
 #include <LibGUI/Scrollbar.h>
 #include <LibGUI/Splitter.h>
 #include <LibGUI/Widget.h>

--- a/Userland/DevTools/HackStudio/ProjectBuilder.h
+++ b/Userland/DevTools/HackStudio/ProjectBuilder.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "AK/Error.h"
 #include "Project.h"
 #include "TerminalWrapper.h"
+#include <AK/Error.h>
 #include <AK/Noncopyable.h>
 #include <LibCore/TempFile.h>
 

--- a/Userland/DevTools/Profiler/FlameGraphView.cpp
+++ b/Userland/DevTools/Profiler/FlameGraphView.cpp
@@ -5,12 +5,12 @@
  */
 
 #include "FlameGraphView.h"
-#include "DevTools/Profiler/Profile.h"
-#include "LibGfx/Forward.h"
+#include "Profile.h"
 #include <AK/Function.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Widget.h>
 #include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Forward.h>
 #include <LibGfx/Palette.h>
 
 namespace Profiler {

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.h
@@ -6,13 +6,13 @@
 
 #pragma once
 
-#include "AK/Debug.h"
 #include "Emulator.h"
 #include "Region.h"
 #include "SoftFPU.h"
 #include "SoftVPU.h"
 #include "ValueWithShadow.h"
 #include <AK/ByteReader.h>
+#include <AK/Debug.h>
 #include <LibX86/Instruction.h>
 #include <LibX86/Interpreter.h>
 

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "AK/JsonObject.h"
 #include <AK/Format.h>
+#include <AK/JsonObject.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/Version.h>

--- a/Userland/Libraries/LibIMAP/Client.cpp
+++ b/Userland/Libraries/LibIMAP/Client.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "AK/OwnPtr.h"
+#include <AK/OwnPtr.h>
 #include <LibCore/Stream.h>
 #include <LibIMAP/Client.h>
 

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "AK/Forward.h"
 #include <AK/FlyString.h>
+#include <AK/Forward.h>
 #include <LibGfx/Color.h>
 #include <LibPDF/Value.h>
 

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -5,11 +5,11 @@
  */
 
 #include "RegexByteCode.h"
-#include "AK/StringBuilder.h"
 #include "RegexDebug.h"
 #include <AK/BinarySearch.h>
 #include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
+#include <AK/StringBuilder.h>
 #include <LibUnicode/CharacterTypes.h>
 
 namespace regex {

--- a/Userland/Services/EchoServer/Client.cpp
+++ b/Userland/Services/EchoServer/Client.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "Client.h"
-#include "LibCore/EventLoop.h"
+#include <LibCore/EventLoop.h>
 
 Client::Client(int id, NonnullOwnPtr<Core::Stream::TCPSocket> socket)
     : m_id(id)

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "LibGUI/Window.h"
 #include "ShutdownDialog.h"
 #include "TaskbarWindow.h"
 #include <AK/Debug.h>
@@ -25,6 +24,7 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/MenuItem.h>
 #include <LibGUI/Process.h>
+#include <LibGUI/Window.h>
 #include <LibGfx/SystemTheme.h>
 #include <LibMain/Main.h>
 #include <WindowServer/Window.h>

--- a/Userland/Services/WindowServer/WMConnectionFromClient.h
+++ b/Userland/Services/WindowServer/WMConnectionFromClient.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "AK/NonnullRefPtr.h"
 #include <AK/HashMap.h>
+#include <AK/NonnullRefPtr.h>
 #include <LibIPC/ConnectionFromClient.h>
 #include <WindowServer/WindowManagerClientEndpoint.h>
 #include <WindowServer/WindowManagerServerEndpoint.h>

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -5,8 +5,8 @@
  */
 
 #include "AST.h"
+#include "Formatter.h"
 #include "Shell.h"
-#include "Shell/Formatter.h"
 #include <AK/DeprecatedString.h>
 #include <AK/LexicalPath.h>
 #include <AK/ScopeGuard.h>

--- a/Userland/Utilities/fgrep.cpp
+++ b/Userland/Utilities/fgrep.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "AK/DeprecatedString.h"
 #include <AK/Assertions.h>
+#include <AK/DeprecatedString.h>
 #include <AK/Format.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "LibCore/Directory.h"
 #include <AK/Assertions.h>
 #include <AK/LexicalPath.h>
 #include <AK/Span.h>
@@ -13,6 +12,7 @@
 #include <LibCompress/Gzip.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DirIterator.h>
+#include <LibCore/Directory.h>
 #include <LibCore/File.h>
 #include <LibCore/FileStream.h>
 #include <LibCore/Stream.h>


### PR DESCRIPTION
This cleans up our includes:
- by fixing badly-formatted includes (e.g. `#include "AK/StdLibExtras.h"`)
- by removing completely unused includes.

This re-uses the least-controversial changes from #16764 and #15282, as well as a lot of new instances that have been introduced in the meantime.