### PR TITLE
Everywhere: Remove entirely unused headers

### DIFF
--- a/AK/Hex.cpp
+++ b/AK/Hex.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Array.h>
 #include <AK/Hex.h>
 #include <AK/StringBuilder.h>
 #include <AK/Types.h>

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/IterationDecision.h>
 #include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
 

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/Array.h>
 #include <AK/Concepts.h>
 #include <AK/Function.h>
 #include <AK/Types.h>

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/IterationDecision.h>
 #include <Applications/Browser/Browser.h>
 #include <Applications/Browser/BrowserWindow.h>
 #include <Applications/Browser/CookieJar.h>

--- a/Userland/Applications/Piano/TrackManager.h
+++ b/Userland/Applications/Piano/TrackManager.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "Music.h"
-#include <AK/Array.h>
 #include <AK/FixedArray.h>
 #include <AK/Noncopyable.h>
 #include <AK/NonnullOwnPtr.h>

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -12,7 +12,6 @@
 #include <AK/EnumBits.h>
 #include <AK/Function.h>
 #include <AK/IPv4Address.h>
-#include <AK/MemMem.h>
 #include <AK/Noncopyable.h>
 #include <AK/Result.h>
 #include <AK/Span.h>

--- a/Userland/Libraries/LibGPU/Device.h
+++ b/Userland/Libraries/LibGPU/Device.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/Array.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Vector.h>
 #include <LibGPU/DeviceInfo.h>

--- a/Userland/Libraries/LibGPU/RasterizerOptions.h
+++ b/Userland/Libraries/LibGPU/RasterizerOptions.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/Array.h>
 #include <LibGPU/Config.h>
 #include <LibGPU/Enums.h>
 #include <LibGfx/Rect.h>

--- a/Userland/Libraries/LibGUI/GML/AST.h
+++ b/Userland/Libraries/LibGUI/GML/AST.h
@@ -11,7 +11,6 @@
 #include <AK/Error.h>
 #include <AK/Forward.h>
 #include <AK/HashMap.h>
-#include <AK/IterationDecision.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonValue.h>
 #include <AK/NonnullRefPtr.h>

--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Array.h>
 #include <AK/Debug.h>
 #include <AK/Endian.h>
 #include <AK/Vector.h>

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -7,7 +7,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Array.h>
 #include <AK/DateConstants.h>
 #include <AK/DeprecatedString.h>
 #include <AK/Function.h>

--- a/Userland/Libraries/LibWeb/WebDriver/ElementLocationStrategies.h
+++ b/Userland/Libraries/LibWeb/WebDriver/ElementLocationStrategies.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/Array.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/DOM/NodeList.h>
 #include <LibWeb/Forward.h>

--- a/Userland/Utilities/stty.cpp
+++ b/Userland/Utilities/stty.cpp
@@ -7,7 +7,6 @@
 
 #define __USE_MISC
 #define TTYDEFCHARS
-#include <AK/Array.h>
 #include <AK/DeprecatedString.h>
 #include <AK/Optional.h>
 #include <AK/Result.h>


### PR DESCRIPTION
This PR begins to remove some entirely useless `#include`s, that are not used in any way whatsoever.

Let's take `AK/IterationDecision.h` as an example: It defines an `enum class IterationDecision`. It also includes something else (`AK/Platform.h`), but that should never be the reason to include `IterationDecision.h`.

Therefore, all files that include IterationDecision.h but don't use the `IterationDecision` class anywhere can be cleaned up.

I wrote a small script to do that, but before I do that at a big scale, let's see what you think about these small initial tests.

Thanks to other scripts (which now begin to actually work thanks to #16775 and #15235), I can make a very good guess as to how many compilation units (cpp files) transitively include a header in one way or another. This PR reduces how often each header is compiled:
- AK/Array.h: 2712 → 2712
- AK/IterationDecision.h: 2745 → 2722
- AK/MemMem.h: 1128 → 337

This means that about 800 compiler invocations no longer have to read `AK/MemMem.h` at all. Hooray, this should speed compilation up a bit!

AK/IterationDecision.h seems to be very popular, and is often included by something else indirectly; the same happens with Array.h, so I don't expect that this is going to speed anything up.

If this gets accepted, I can make another PR with hopefully many more compilation speedups.

YAKBAIT: Use LibCpp or something to automatically extract all declared and defined symbols of a .h file.