### PR TITLE
LibGUI+Userland: File picker error propagation

### DIFF
--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -86,7 +86,7 @@ void BackgroundSettingsWidget::create_frame()
 
     auto& button = *find_descendant_of_type_named<GUI::Button>("wallpaper_open_button");
     button.on_click = [this](auto) {
-        auto path = GUI::FilePicker::get_open_filepath(window(), "Select wallpaper from file system", "/res/wallpapers"sv);
+        auto path = GUI::FilePicker::get_open_filepath(window(), "Select wallpaper from file system", "/res/wallpapers"sv).release_value_but_fixme_should_propagate_errors();
         if (!path.has_value())
             return;
         m_wallpaper_view->selection().clear();

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -110,7 +110,7 @@ ErrorOr<void> MainWidget::create_actions()
     m_open_action = GUI::CommonActions::make_open_action([&](auto&) {
         if (!request_close())
             return;
-        Optional<DeprecatedString> open_path = GUI::FilePicker::get_open_filepath(window(), {}, "/res/fonts/"sv);
+        Optional<DeprecatedString> open_path = GUI::FilePicker::get_open_filepath(window(), {}, "/res/fonts/"sv).release_value_but_fixme_should_propagate_errors();
         if (!open_path.has_value())
             return;
         if (auto result = open_file(open_path.value()); result.is_error())
@@ -126,7 +126,7 @@ ErrorOr<void> MainWidget::create_actions()
 
     m_save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
         LexicalPath lexical_path(m_path.is_empty() ? "Untitled.font" : m_path);
-        Optional<DeprecatedString> save_path = GUI::FilePicker::get_save_filepath(window(), lexical_path.title(), lexical_path.extension());
+        Optional<DeprecatedString> save_path = GUI::FilePicker::get_save_filepath(window(), lexical_path.title(), lexical_path.extension()).release_value_but_fixme_should_propagate_errors();
         if (!save_path.has_value())
             return;
         if (auto result = save_file(save_path.value()); result.is_error())

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -109,7 +109,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // Actions
     auto open_action = GUI::CommonActions::make_open_action(
         [&](auto&) {
-            auto path = GUI::FilePicker::get_open_filepath(window, "Open Image");
+            auto path = GUI::FilePicker::get_open_filepath(window, "Open Image").release_value_but_fixme_should_propagate_errors();
             if (path.has_value()) {
                 widget->set_path(path.value());
                 widget->load_from_file(path.value());

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -50,7 +50,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (!keyboard_mapper_widget->request_close())
                 return;
 
-            Optional<DeprecatedString> path = GUI::FilePicker::get_open_filepath(window, "Open"sv, "/res/keymaps/"sv);
+            Optional<DeprecatedString> path = GUI::FilePicker::get_open_filepath(window, "Open"sv, "/res/keymaps/"sv).release_value_but_fixme_should_propagate_errors();
             if (!path.has_value())
                 return;
 
@@ -68,7 +68,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
         DeprecatedString name = "Unnamed";
-        Optional<DeprecatedString> save_path = GUI::FilePicker::get_save_filepath(window, name, "json");
+        Optional<DeprecatedString> save_path = GUI::FilePicker::get_save_filepath(window, name, "json").release_value_but_fixme_should_propagate_errors();
         if (!save_path.has_value())
             return;
 

--- a/Userland/Applications/Piano/SamplerWidget.cpp
+++ b/Userland/Applications/Piano/SamplerWidget.cpp
@@ -55,7 +55,7 @@ SamplerWidget::SamplerWidget(TrackManager& track_manager)
     m_open_button->set_focus_policy(GUI::FocusPolicy::TabFocus);
     m_open_button->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors());
     m_open_button->on_click = [this](auto) {
-        Optional<DeprecatedString> open_path = GUI::FilePicker::get_open_filepath(window());
+        Optional<DeprecatedString> open_path = GUI::FilePicker::get_open_filepath(window()).release_value_but_fixme_should_propagate_errors();
         if (!open_path.has_value())
             return;
         // TODO: We don't actually load the sample.

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -55,7 +55,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto& file_menu = window->add_menu("&File");
     file_menu.add_action(GUI::Action::create("Export", { Mod_Ctrl, Key_E }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/file-export.png"sv)), [&](const GUI::Action&) {
-        save_path = GUI::FilePicker::get_save_filepath(window, "Untitled", "wav");
+        save_path = GUI::FilePicker::get_save_filepath(window, "Untitled", "wav").release_value_but_fixme_should_propagate_errors();
         if (!save_path.has_value())
             return;
         DeprecatedString error;

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -65,7 +65,7 @@ RunWindow::RunWindow()
 
     m_browse_button = *find_descendant_of_type_named<GUI::DialogButton>("browse_button");
     m_browse_button->on_click = [this](auto) {
-        Optional<DeprecatedString> path = GUI::FilePicker::get_open_filepath(this, {}, Core::StandardPaths::home_directory(), false, GUI::Dialog::ScreenPosition::Center);
+        Optional<DeprecatedString> path = GUI::FilePicker::get_open_filepath(this, {}, Core::StandardPaths::home_directory(), false, GUI::Dialog::ScreenPosition::Center).release_value_but_fixme_should_propagate_errors();
         if (path.has_value())
             m_path_combo_box->set_text(path.value().view());
     };

--- a/Userland/Applications/SoundPlayer/main.cpp
+++ b/Userland/Applications/SoundPlayer/main.cpp
@@ -51,7 +51,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto file_menu = TRY(window->try_add_menu("&File"));
     TRY(file_menu->try_add_action(GUI::CommonActions::make_open_action([&](auto&) {
-        Optional<DeprecatedString> path = GUI::FilePicker::get_open_filepath(window, "Open sound file...");
+        Optional<DeprecatedString> path = GUI::FilePicker::get_open_filepath(window, "Open sound file...").release_value_but_fixme_should_propagate_errors();
         if (path.has_value()) {
             player->play_file_path(path.value());
         }

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -579,7 +579,7 @@ void MainWidget::show_path_picker_dialog(StringView property_display_name, GUI::
     } else {
         target_path = "/res/icons";
     }
-    auto result = GUI::FilePicker::get_open_filepath(window(), window_title, target_path, open_folder);
+    auto result = GUI::FilePicker::get_open_filepath(window(), window_title, target_path, open_folder).release_value_but_fixme_should_propagate_errors();
     if (!result.has_value())
         return;
     path_input.set_text(*result);

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -290,7 +290,7 @@ void VideoPlayerWidget::initialize_menubar(GUI::Window& window)
     // File menu
     auto& file_menu = window.add_menu("&File");
     file_menu.add_action(GUI::CommonActions::make_open_action([&](auto&) {
-        Optional<DeprecatedString> path = GUI::FilePicker::get_open_filepath(&window, "Open video file...");
+        Optional<DeprecatedString> path = GUI::FilePicker::get_open_filepath(&window, "Open video file...").release_value_but_fixme_should_propagate_errors();
         if (path.has_value())
             open_file(path.value());
     }));

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -421,7 +421,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(export_submenu.try_add_action(GUI::Action::create("As &BMP",
         [&](GUI::Action&) {
-            Optional<DeprecatedString> export_path = GUI::FilePicker::get_save_filepath(window, "untitled", "bmp");
+            Optional<DeprecatedString> export_path = GUI::FilePicker::get_save_filepath(window, "untitled", "bmp").release_value_but_fixme_should_propagate_errors();
             if (!export_path.has_value())
                 return;
             if (auto result = mandelbrot->export_image(export_path.value(), ImageType::BMP); result.is_error())
@@ -429,7 +429,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         })));
     TRY(export_submenu.try_add_action(GUI::Action::create("As &PNG", { Mod_Ctrl | Mod_Shift, Key_S },
         [&](GUI::Action&) {
-            Optional<DeprecatedString> export_path = GUI::FilePicker::get_save_filepath(window, "untitled", "png");
+            Optional<DeprecatedString> export_path = GUI::FilePicker::get_save_filepath(window, "untitled", "png").release_value_but_fixme_should_propagate_errors();
             if (!export_path.has_value())
                 return;
             if (auto result = mandelbrot->export_image(export_path.value(), ImageType::PNG); result.is_error())
@@ -437,7 +437,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         })));
     TRY(export_submenu.try_add_action(GUI::Action::create("As &QOI",
         [&](GUI::Action&) {
-            Optional<DeprecatedString> export_path = GUI::FilePicker::get_save_filepath(window, "untitled", "qoi");
+            Optional<DeprecatedString> export_path = GUI::FilePicker::get_save_filepath(window, "untitled", "qoi").release_value_but_fixme_should_propagate_errors();
             if (!export_path.has_value())
                 return;
             if (auto result = mandelbrot->export_image(export_path.value(), ImageType::QOI); result.is_error())

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
@@ -89,7 +89,7 @@ NewProjectDialog::NewProjectDialog(GUI::Window* parent)
 
     m_browse_button = *find_descendant_of_type_named<GUI::Button>("browse_button");
     m_browse_button->on_click = [this](auto) {
-        Optional<DeprecatedString> path = GUI::FilePicker::get_open_filepath(this, {}, Core::StandardPaths::home_directory(), true);
+        Optional<DeprecatedString> path = GUI::FilePicker::get_open_filepath(this, {}, Core::StandardPaths::home_directory(), true).release_value_but_fixme_should_propagate_errors();
         if (path.has_value())
             m_create_in_input->set_text(path.value().view());
     };

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -74,7 +74,7 @@ void EditorWrapper::save()
 {
     if (filename().is_empty()) {
         auto file_picker_action = GUI::CommonActions::make_save_as_action([&](auto&) {
-            Optional<DeprecatedString> save_path = GUI::FilePicker::get_save_filepath(window(), "file"sv, "txt"sv, project_root().value());
+            Optional<DeprecatedString> save_path = GUI::FilePicker::get_save_filepath(window(), "file"sv, "txt"sv, project_root().value()).release_value_but_fixme_should_propagate_errors();
             set_filename(save_path.value());
         });
         file_picker_action->activate();

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -872,7 +872,7 @@ ErrorOr<NonnullRefPtr<GUI::Action>> HackStudioWidget::create_open_action()
 {
     auto icon = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png"sv));
     return GUI::Action::create("&Open Project...", { Mod_Ctrl | Mod_Shift, Key_O }, icon, [this](auto&) {
-        auto open_path = GUI::FilePicker::get_open_filepath(window(), "Open project", m_project->root_path(), true);
+        auto open_path = GUI::FilePicker::get_open_filepath(window(), "Open project", m_project->root_path(), true).release_value_but_fixme_should_propagate_errors();
         if (!open_path.has_value())
             return;
         open_project(open_path.value());
@@ -904,7 +904,8 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_as_action()
         Optional<DeprecatedString> save_path = GUI::FilePicker::get_save_filepath(window(),
             old_filename.is_null() ? "Untitled"sv : old_path.title(),
             old_filename.is_null() ? "txt"sv : old_path.extension(),
-            Core::File::absolute_path(old_path.dirname()));
+            Core::File::absolute_path(old_path.dirname()))
+                                                   .release_value_but_fixme_should_propagate_errors();
         if (!save_path.has_value()) {
             return;
         }

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -69,7 +69,7 @@ MainWidget::MainWidget()
     });
 
     m_open_action = GUI::CommonActions::make_open_action([&](auto&) {
-        if (auto result = GUI::FilePicker::get_open_filepath(window()); result.has_value())
+        if (auto result = GUI::FilePicker::get_open_filepath(window()).release_value_but_fixme_should_propagate_errors(); result.has_value())
             open_script_from_file(LexicalPath { result.release_value() });
     });
 

--- a/Userland/DevTools/SQLStudio/ScriptEditor.cpp
+++ b/Userland/DevTools/SQLStudio/ScriptEditor.cpp
@@ -60,7 +60,7 @@ ErrorOr<bool> ScriptEditor::save()
 
 ErrorOr<bool> ScriptEditor::save_as()
 {
-    auto maybe_save_path = GUI::FilePicker::get_save_filepath(window(), name(), "sql");
+    auto maybe_save_path = TRY(GUI::FilePicker::get_save_filepath(window(), name(), "sql"));
     if (!maybe_save_path.has_value())
         return false;
 

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -32,9 +32,9 @@
 
 namespace GUI {
 
-Optional<DeprecatedString> FilePicker::get_open_filepath(Window* parent_window, DeprecatedString const& window_title, StringView path, bool folder, ScreenPosition screen_position)
+ErrorOr<Optional<DeprecatedString>> FilePicker::get_open_filepath(Window* parent_window, DeprecatedString const& window_title, StringView path, bool folder, ScreenPosition screen_position)
 {
-    auto picker = MUST(FilePicker::try_create(parent_window, folder ? Mode::OpenFolder : Mode::Open, ""sv, path, screen_position));
+    auto picker = TRY(FilePicker::try_create(parent_window, folder ? Mode::OpenFolder : Mode::Open, ""sv, path, screen_position));
 
     if (!window_title.is_null())
         picker->set_title(window_title);
@@ -43,26 +43,26 @@ Optional<DeprecatedString> FilePicker::get_open_filepath(Window* parent_window, 
         DeprecatedString file_path = picker->selected_file();
 
         if (file_path.is_null())
-            return {};
+            return { {} };
 
         return file_path;
     }
-    return {};
+    return { {} };
 }
 
-Optional<DeprecatedString> FilePicker::get_save_filepath(Window* parent_window, DeprecatedString const& title, DeprecatedString const& extension, StringView path, ScreenPosition screen_position)
+ErrorOr<Optional<DeprecatedString>> FilePicker::get_save_filepath(Window* parent_window, DeprecatedString const& title, DeprecatedString const& extension, StringView path, ScreenPosition screen_position)
 {
-    auto picker = MUST(FilePicker::try_create(parent_window, Mode::Save, DeprecatedString::formatted("{}.{}", title, extension), path, screen_position));
+    auto picker = TRY(FilePicker::try_create(parent_window, Mode::Save, DeprecatedString::formatted("{}.{}", title, extension), path, screen_position));
 
     if (picker->exec() == ExecResult::OK) {
         DeprecatedString file_path = picker->selected_file();
 
         if (file_path.is_null())
-            return {};
+            return { {} };
 
         return file_path;
     }
-    return {};
+    return { {} };
 }
 
 ErrorOr<NonnullRefPtr<FilePicker>> FilePicker::try_create(GUI::Window* parent_window, GUI::FilePicker::Mode mode, StringView filename, StringView path, GUI::Dialog::ScreenPosition screen_position)

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -34,7 +34,7 @@ namespace GUI {
 
 Optional<DeprecatedString> FilePicker::get_open_filepath(Window* parent_window, DeprecatedString const& window_title, StringView path, bool folder, ScreenPosition screen_position)
 {
-    auto picker = FilePicker::construct(parent_window, folder ? Mode::OpenFolder : Mode::Open, ""sv, path, screen_position);
+    auto picker = MUST(FilePicker::try_create(parent_window, folder ? Mode::OpenFolder : Mode::Open, ""sv, path, screen_position));
 
     if (!window_title.is_null())
         picker->set_title(window_title);
@@ -52,7 +52,7 @@ Optional<DeprecatedString> FilePicker::get_open_filepath(Window* parent_window, 
 
 Optional<DeprecatedString> FilePicker::get_save_filepath(Window* parent_window, DeprecatedString const& title, DeprecatedString const& extension, StringView path, ScreenPosition screen_position)
 {
-    auto picker = FilePicker::construct(parent_window, Mode::Save, DeprecatedString::formatted("{}.{}", title, extension), path, screen_position);
+    auto picker = MUST(FilePicker::try_create(parent_window, Mode::Save, DeprecatedString::formatted("{}.{}", title, extension), path, screen_position));
 
     if (picker->exec() == ExecResult::OK) {
         DeprecatedString file_path = picker->selected_file();
@@ -65,190 +65,199 @@ Optional<DeprecatedString> FilePicker::get_save_filepath(Window* parent_window, 
     return {};
 }
 
-FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, StringView path, ScreenPosition screen_position)
-    : Dialog(parent_window, screen_position)
-    , m_model(FileSystemModel::create(path))
-    , m_mode(mode)
+ErrorOr<NonnullRefPtr<FilePicker>> FilePicker::try_create(GUI::Window* parent_window, GUI::FilePicker::Mode mode, StringView filename, StringView path, GUI::Dialog::ScreenPosition screen_position)
 {
-    switch (m_mode) {
+    auto file_picker = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) FilePicker(parent_window, mode, path, screen_position)));
+
+    switch (mode) {
     case Mode::Open:
     case Mode::OpenMultiple:
     case Mode::OpenFolder:
-        set_title("Open");
-        set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors());
+        file_picker->set_title("Open");
+        file_picker->set_icon(TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png"sv)));
         break;
     case Mode::Save:
-        set_title("Save as");
-        set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/save-as.png"sv).release_value_but_fixme_should_propagate_errors());
+        file_picker->set_title("Save as");
+        file_picker->set_icon(TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/save-as.png"sv)));
         break;
     }
-    resize(560, 320);
 
-    auto& widget = set_main_widget<GUI::Widget>();
+    file_picker->resize(560, 320);
+
+    auto& widget = file_picker->set_main_widget<GUI::Widget>();
     if (!widget.load_from_gml(file_picker_dialog_gml))
         VERIFY_NOT_REACHED();
 
     auto& toolbar = *widget.find_descendant_of_type_named<GUI::Toolbar>("toolbar");
 
-    m_location_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("location_textbox");
-    m_location_textbox->set_text(path);
+    file_picker->m_location_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("location_textbox");
+    file_picker->m_location_textbox->set_text(path);
 
-    m_view = *widget.find_descendant_of_type_named<GUI::MultiView>("view");
-    m_view->set_selection_mode(m_mode == Mode::OpenMultiple ? GUI::AbstractView::SelectionMode::MultiSelection : GUI::AbstractView::SelectionMode::SingleSelection);
-    m_view->set_model(MUST(SortingProxyModel::create(*m_model)));
-    m_view->set_model_column(FileSystemModel::Column::Name);
-    m_view->set_key_column_and_sort_order(GUI::FileSystemModel::Column::Name, GUI::SortOrder::Ascending);
-    m_view->set_column_visible(FileSystemModel::Column::User, true);
-    m_view->set_column_visible(FileSystemModel::Column::Group, true);
-    m_view->set_column_visible(FileSystemModel::Column::Permissions, true);
-    m_view->set_column_visible(FileSystemModel::Column::Inode, true);
-    m_view->set_column_visible(FileSystemModel::Column::SymlinkTarget, true);
+    file_picker->m_view = *widget.find_descendant_of_type_named<GUI::MultiView>("view");
+    file_picker->m_view->set_selection_mode(mode == GUI::FilePicker::Mode::OpenMultiple ? GUI::AbstractView::SelectionMode::MultiSelection : GUI::AbstractView::SelectionMode::SingleSelection);
+    file_picker->m_view->set_model(TRY(SortingProxyModel::create(*file_picker->m_model)));
+    file_picker->m_view->set_model_column(FileSystemModel::Column::Name);
+    file_picker->m_view->set_key_column_and_sort_order(GUI::FileSystemModel::Column::Name, GUI::SortOrder::Ascending);
+    file_picker->m_view->set_column_visible(FileSystemModel::Column::User, true);
+    file_picker->m_view->set_column_visible(FileSystemModel::Column::Group, true);
+    file_picker->m_view->set_column_visible(FileSystemModel::Column::Permissions, true);
+    file_picker->m_view->set_column_visible(FileSystemModel::Column::Inode, true);
+    file_picker->m_view->set_column_visible(FileSystemModel::Column::SymlinkTarget, true);
 
-    m_model->register_client(*this);
+    file_picker->m_model->register_client(file_picker);
 
-    m_error_label = m_view->add<GUI::Label>();
-    m_error_label->set_font(m_error_label->font().bold_variant());
+    file_picker->m_error_label = file_picker->m_view->add<GUI::Label>();
+    file_picker->m_error_label->set_font(file_picker->m_error_label->font().bold_variant());
 
-    m_location_textbox->on_return_pressed = [this] {
-        set_path(m_location_textbox->text());
+    file_picker->m_location_textbox->on_return_pressed = [file_picker] {
+        file_picker->set_path(file_picker->m_location_textbox->text());
     };
 
     auto open_parent_directory_action = Action::create(
-        "Open parent directory", { Mod_Alt, Key_Up }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open-parent-directory.png"sv).release_value_but_fixme_should_propagate_errors(), [this](Action const&) {
-            set_path(DeprecatedString::formatted("{}/..", m_model->root_path()));
+        "Open parent directory", { Mod_Alt, Key_Up }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open-parent-directory.png"sv)), [file_picker](Action const&) {
+            file_picker->set_path(DeprecatedString::formatted("{}/..", file_picker->m_model->root_path()));
         },
-        this);
+        file_picker);
     toolbar.add_action(*open_parent_directory_action);
 
-    auto go_home_action = CommonActions::make_go_home_action([this](auto&) {
-        set_path(Core::StandardPaths::home_directory());
+    auto go_home_action = CommonActions::make_go_home_action([file_picker](auto&) {
+        file_picker->set_path(Core::StandardPaths::home_directory());
     },
-        this);
+        file_picker);
     toolbar.add_action(go_home_action);
     toolbar.add_separator();
 
     auto mkdir_action = Action::create(
-        "New directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/mkdir.png"sv).release_value_but_fixme_should_propagate_errors(), [this](Action const&) {
+        "New directory...", { Mod_Ctrl | Mod_Shift, Key_N }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/mkdir.png"sv)), [file_picker](Action const&) {
             DeprecatedString value;
-            if (InputBox::show(this, value, "Enter name:"sv, "New directory"sv) == InputBox::ExecResult::OK && !value.is_empty()) {
-                auto new_dir_path = LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", m_model->root_path(), value));
+            if (InputBox::show(file_picker, value, "Enter name:"sv, "New directory"sv) == InputBox::ExecResult::OK && !value.is_empty()) {
+                auto new_dir_path = LexicalPath::canonicalized_path(DeprecatedString::formatted("{}/{}", file_picker->m_model->root_path(), value));
                 int rc = mkdir(new_dir_path.characters(), 0777);
                 if (rc < 0) {
-                    MessageBox::show(this, DeprecatedString::formatted("mkdir(\"{}\") failed: {}", new_dir_path, strerror(errno)), "Error"sv, MessageBox::Type::Error);
+                    MessageBox::show(file_picker, DeprecatedString::formatted("mkdir(\"{}\") failed: {}", new_dir_path, strerror(errno)), "Error"sv, MessageBox::Type::Error);
                 } else {
-                    m_model->invalidate();
+                    file_picker->m_model->invalidate();
                 }
             }
         },
-        this);
+        file_picker);
 
     toolbar.add_action(*mkdir_action);
 
     toolbar.add_separator();
 
-    toolbar.add_action(m_view->view_as_icons_action());
-    toolbar.add_action(m_view->view_as_table_action());
-    toolbar.add_action(m_view->view_as_columns_action());
+    toolbar.add_action(file_picker->m_view->view_as_icons_action());
+    toolbar.add_action(file_picker->m_view->view_as_table_action());
+    toolbar.add_action(file_picker->m_view->view_as_columns_action());
 
-    m_filename_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("filename_textbox");
-    m_filename_textbox->set_focus(true);
-    if (m_mode == Mode::Save) {
-        m_filename_textbox->set_text(filename);
-        m_filename_textbox->select_all();
+    file_picker->m_filename_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("filename_textbox");
+    file_picker->m_filename_textbox->set_focus(true);
+    if (mode == Mode::Save) {
+        file_picker->m_filename_textbox->set_text(filename);
+        file_picker->m_filename_textbox->select_all();
     }
-    m_filename_textbox->on_return_pressed = [&] {
-        on_file_return();
+    file_picker->m_filename_textbox->on_return_pressed = [file_picker] {
+        file_picker->on_file_return();
     };
 
-    m_context_menu = GUI::Menu::construct();
-    m_context_menu->add_action(GUI::Action::create_checkable(
-        "Show dotfiles", { Mod_Ctrl, Key_H }, [&](auto& action) {
-            m_model->set_should_show_dotfiles(action.is_checked());
-            m_model->invalidate();
+    file_picker->m_context_menu = GUI::Menu::construct();
+    file_picker->m_context_menu->add_action(GUI::Action::create_checkable(
+        "Show dotfiles", { Mod_Ctrl, Key_H }, [file_picker](auto& action) {
+            file_picker->m_model->set_should_show_dotfiles(action.is_checked());
+            file_picker->m_model->invalidate();
         },
-        this));
+        file_picker));
 
-    m_view->on_context_menu_request = [&](const GUI::ModelIndex& index, const GUI::ContextMenuEvent& event) {
+    file_picker->m_view->on_context_menu_request = [file_picker](const GUI::ModelIndex& index, const GUI::ContextMenuEvent& event) {
         if (!index.is_valid()) {
-            m_context_menu->popup(event.screen_position());
+            file_picker->m_context_menu->popup(event.screen_position());
         }
     };
 
     auto& ok_button = *widget.find_descendant_of_type_named<GUI::Button>("ok_button");
-    ok_button.set_text(ok_button_name(m_mode));
-    ok_button.on_click = [this](auto) {
-        on_file_return();
+    ok_button.set_text(ok_button_name(mode));
+    ok_button.on_click = [file_picker](auto) {
+        file_picker->on_file_return();
     };
-    ok_button.set_enabled(m_mode == Mode::OpenFolder || !m_filename_textbox->text().is_empty());
+    ok_button.set_enabled(mode == Mode::OpenFolder || !file_picker->m_filename_textbox->text().is_empty());
 
     auto& cancel_button = *widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
     cancel_button.set_text("Cancel");
-    cancel_button.on_click = [this](auto) {
-        done(ExecResult::Cancel);
+    cancel_button.on_click = [file_picker](auto) {
+        file_picker->done(ExecResult::Cancel);
     };
 
-    m_filename_textbox->on_change = [&] {
-        ok_button.set_enabled(m_mode == Mode::OpenFolder || !m_filename_textbox->text().is_empty());
+    file_picker->m_filename_textbox->on_change = [file_picker, &ok_button, mode] {
+        ok_button.set_enabled(mode == Mode::OpenFolder || !file_picker->m_filename_textbox->text().is_empty());
     };
 
-    m_view->on_selection_change = [this] {
-        auto index = m_view->selection().first();
-        auto& filter_model = (SortingProxyModel&)*m_view->model();
+    file_picker->m_view->on_selection_change = [file_picker, mode] {
+        auto index = file_picker->m_view->selection().first();
+        auto& filter_model = (SortingProxyModel&)*file_picker->m_view->model();
         auto local_index = filter_model.map_to_source(index);
-        const FileSystemModel::Node& node = m_model->node(local_index);
+        const FileSystemModel::Node& node = file_picker->m_model->node(local_index);
 
-        auto should_open_folder = m_mode == Mode::OpenFolder;
+        auto should_open_folder = mode == Mode::OpenFolder;
         if (should_open_folder == node.is_directory()) {
-            m_filename_textbox->set_text(node.name);
-        } else if (m_mode != Mode::Save) {
-            m_filename_textbox->clear();
+            file_picker->m_filename_textbox->set_text(node.name);
+        } else if (mode != Mode::Save) {
+            file_picker->m_filename_textbox->clear();
         }
     };
 
-    m_view->on_activation = [this](auto& index) {
-        auto& filter_model = (SortingProxyModel&)*m_view->model();
+    file_picker->m_view->on_activation = [file_picker](auto& index) {
+        auto& filter_model = (SortingProxyModel&)*file_picker->m_view->model();
         auto local_index = filter_model.map_to_source(index);
-        const FileSystemModel::Node& node = m_model->node(local_index);
+        const FileSystemModel::Node& node = file_picker->m_model->node(local_index);
         auto path = node.full_path();
 
         if (node.is_directory() || node.is_symlink_to_directory()) {
-            set_path(path);
+            file_picker->set_path(path);
             // NOTE: 'node' is invalid from here on
         } else {
-            on_file_return();
+            file_picker->on_file_return();
         }
     };
 
-    m_model->on_directory_change_error = [&](int, char const* error_string) {
-        m_error_label->set_text(DeprecatedString::formatted("Could not open {}:\n{}", m_model->root_path(), error_string));
-        m_view->set_active_widget(m_error_label);
+    file_picker->m_model->on_directory_change_error = [file_picker](int, char const* error_string) {
+        file_picker->m_error_label->set_text(DeprecatedString::formatted("Could not open {}:\n{}", file_picker->m_model->root_path(), error_string));
+        file_picker->m_view->set_active_widget(file_picker->m_error_label);
 
-        m_view->view_as_icons_action().set_enabled(false);
-        m_view->view_as_table_action().set_enabled(false);
-        m_view->view_as_columns_action().set_enabled(false);
+        file_picker->m_view->view_as_icons_action().set_enabled(false);
+        file_picker->m_view->view_as_table_action().set_enabled(false);
+        file_picker->m_view->view_as_columns_action().set_enabled(false);
     };
 
     auto& common_locations_tray = *widget.find_descendant_of_type_named<GUI::Tray>("common_locations_tray");
-    m_model->on_complete = [&] {
-        m_view->set_active_widget(&m_view->current_view());
-        for (auto& location_button : m_common_location_buttons)
-            common_locations_tray.set_item_checked(location_button.tray_item_index, m_model->root_path() == location_button.path);
+    file_picker->m_model->on_complete = [file_picker, &common_locations_tray] {
+        file_picker->m_view->set_active_widget(&file_picker->m_view->current_view());
+        for (auto& location_button : file_picker->m_common_location_buttons)
+            common_locations_tray.set_item_checked(location_button.tray_item_index, file_picker->m_model->root_path() == location_button.path);
 
-        m_view->view_as_icons_action().set_enabled(true);
-        m_view->view_as_table_action().set_enabled(true);
-        m_view->view_as_columns_action().set_enabled(true);
+        file_picker->m_view->view_as_icons_action().set_enabled(true);
+        file_picker->m_view->view_as_table_action().set_enabled(true);
+        file_picker->m_view->view_as_columns_action().set_enabled(true);
     };
 
-    common_locations_tray.on_item_activation = [this](DeprecatedString const& path) {
-        set_path(path);
+    common_locations_tray.on_item_activation = [file_picker](DeprecatedString const& path) {
+        file_picker->set_path(path);
     };
     for (auto& location : CommonLocationsProvider::common_locations()) {
         auto index = common_locations_tray.add_item(location.name, FileIconProvider::icon_for_path(location.path).bitmap_for_size(16), location.path);
-        m_common_location_buttons.append({ location.path, index });
+        file_picker->m_common_location_buttons.append({ location.path, index });
     }
 
-    m_location_textbox->set_icon(FileIconProvider::icon_for_path(path).bitmap_for_size(16));
-    m_model->on_complete();
+    file_picker->m_location_textbox->set_icon(FileIconProvider::icon_for_path(path).bitmap_for_size(16));
+    file_picker->m_model->on_complete();
+
+    return file_picker;
+}
+
+FilePicker::FilePicker(Window* parent_window, Mode mode, StringView path, ScreenPosition screen_position)
+    : Dialog(parent_window, screen_position)
+    , m_model(FileSystemModel::create(path))
+    , m_mode(mode)
+{
 }
 
 FilePicker::~FilePicker()

--- a/Userland/Libraries/LibGUI/FilePicker.h
+++ b/Userland/Libraries/LibGUI/FilePicker.h
@@ -28,8 +28,8 @@ public:
         Save
     };
 
-    static Optional<DeprecatedString> get_open_filepath(Window* parent_window, DeprecatedString const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), bool folder = false, ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
-    static Optional<DeprecatedString> get_save_filepath(Window* parent_window, DeprecatedString const& title, DeprecatedString const& extension, StringView path = Core::StandardPaths::home_directory(), ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
+    static ErrorOr<Optional<DeprecatedString>> get_open_filepath(Window* parent_window, DeprecatedString const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), bool folder = false, ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
+    static ErrorOr<Optional<DeprecatedString>> get_save_filepath(Window* parent_window, DeprecatedString const& title, DeprecatedString const& extension, StringView path = Core::StandardPaths::home_directory(), ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
 
     virtual ~FilePicker() override;
 
@@ -43,7 +43,7 @@ private:
     // ^GUI::ModelClient
     virtual void model_did_update(unsigned) override;
 
-    FilePicker(Window* parent_window, Mode type = Mode::Open, StringView path = Core::StandardPaths::home_directory(), ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
+    FilePicker(Window* parent_window, Mode type = Mode::Open, StringView filename = "Untitled"sv, ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
     static ErrorOr<NonnullRefPtr<FilePicker>> try_create(Window* parent_window, Mode type = Mode::Open, StringView filename = "Untitled"sv, StringView path = Core::StandardPaths::home_directory(), ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
 
     static DeprecatedString ok_button_name(Mode mode)

--- a/Userland/Libraries/LibGUI/FilePicker.h
+++ b/Userland/Libraries/LibGUI/FilePicker.h
@@ -18,7 +18,7 @@ namespace GUI {
 class FilePicker final
     : public Dialog
     , private ModelClient {
-    C_OBJECT(FilePicker);
+    C_OBJECT_ABSTRACT(FilePicker);
 
 public:
     enum class Mode {
@@ -43,7 +43,8 @@ private:
     // ^GUI::ModelClient
     virtual void model_did_update(unsigned) override;
 
-    FilePicker(Window* parent_window, Mode type = Mode::Open, StringView filename = "Untitled"sv, StringView path = Core::StandardPaths::home_directory(), ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
+    FilePicker(Window* parent_window, Mode type = Mode::Open, StringView path = Core::StandardPaths::home_directory(), ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
+    static ErrorOr<NonnullRefPtr<FilePicker>> try_create(Window* parent_window, Mode type = Mode::Open, StringView filename = "Untitled"sv, StringView path = Core::StandardPaths::home_directory(), ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
 
     static DeprecatedString ok_button_name(Mode mode)
     {

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
@@ -121,7 +121,7 @@ void ConnectionFromClient::prompt_open_file(i32 request_id, i32 window_server_cl
 
     auto main_window = create_dummy_child_window(window_server_client_id, parent_window_id);
 
-    auto user_picked_file = GUI::FilePicker::get_open_filepath(main_window, window_title, path_to_view);
+    auto user_picked_file = GUI::FilePicker::get_open_filepath(main_window, window_title, path_to_view).release_value_but_fixme_should_propagate_errors();
 
     prompt_helper(request_id, user_picked_file, requested_access);
 }
@@ -133,7 +133,7 @@ void ConnectionFromClient::prompt_save_file(i32 request_id, i32 window_server_cl
 
     auto main_window = create_dummy_child_window(window_server_client_id, parent_window_id);
 
-    auto user_picked_file = GUI::FilePicker::get_save_filepath(main_window, name, ext, path_to_view);
+    auto user_picked_file = GUI::FilePicker::get_save_filepath(main_window, name, ext, path_to_view).release_value_but_fixme_should_propagate_errors();
 
     prompt_helper(request_id, user_picked_file, requested_access);
 }


### PR DESCRIPTION
This removes 4 fixmes in FilePicker `:^)` but adds 22 new ones where FilePicker is invoked `:^(`