### PR TITLE
LibWeb: Collapse borders of tables to fix Github bug

### DIFF
--- a/Base/res/html/misc/display-table.html
+++ b/Base/res/html/misc/display-table.html
@@ -1,0 +1,124 @@
+<style>
+  p {
+    margin-bottom: .5rem;
+    color: #808080;
+  }
+
+  .border-black {
+    border: 1px solid black;
+  }
+
+  .thick-border-black {
+    border: 10px solid black;
+  }
+
+  .table-border-black, table.table-border-black tr, table.table-border-black td  {
+    border: 1px solid black;
+  }
+
+  .table {
+    display: table;
+  }
+
+  .table-row {
+    display: table-row;
+  }
+
+  .table-cell {
+    display: table-cell;
+  }
+</style>
+
+<!-- Copied from html tests Userland/Libraries/LibWeb/Tests/Pages/Table.html -->
+<p>Empty table</p>
+<table id="empty-table"></table>
+
+<!-- Copied from html tests Userland/Libraries/LibWeb/Tests/Pages/Table.html -->
+<p>Full table</p>
+<table id="full-table">
+  <caption>
+    A Caption
+  </caption>
+  <thead>
+    <tr>
+      <th>Head Cell</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Body Cell</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td>Footer Cell</td>
+    </tr>
+  </tfoot>
+</table>
+
+<p>Table with 2 columns and border</p>
+<table class="table-border-black">
+  <tr>
+    <th>Firstname</th>
+    <th>Lastname</th>
+  </tr>
+  <tr>
+    <td>Peter</td>
+    <td>Griffin</td>
+  </tr>
+  <tr>
+    <td>Lois</td>
+    <td>Griffin</td>
+  </tr>
+</table>
+
+<!-- Border-collapse and hidden -->
+<p>No borders</p>
+<table class="table-border-black" style="border-collapse: collapse; border-style: hidden;">
+  <tr>
+    <th>Firstname</th>
+    <th>Lastname</th>
+  </tr>
+  <tr>
+    <td>Peter</td>
+    <td>Griffin</td>
+  </tr>
+  <tr>
+    <td>Lois</td>
+    <td>Griffin</td>
+  </tr>
+</table>
+
+<!-- Border-collapse and hidden with divs -->
+<p>No borders v2</p>
+<div class="table border-black" style="border-collapse: collapse; border-style: hidden;">
+  <div class="table-row border-black">
+    <div class="table-cell border-black">Firstname</div>
+    <div class="table-cell border-black">Lastname</div>
+  </div>
+  <div class="table-row border-black">
+    <div class="table-cell border-black">Peter</div>
+    <div class="table-cell border-black">Griffin</div>
+  </div>
+  <div class="table-row border-black">
+    <div class="table-cell border-black">Lois</div>
+    <div class="table-cell border-black">Griffin</div>
+  </div>
+</div>
+
+<!-- Border-collapse and hidden with divs -->
+<p>Columns should be tightly packed with no overflows nor extra space</p>
+<div class="table thick-border-black" style="border-collapse: collapse; border-style: hidden;">
+  <div class="table-row thick-border-black">
+    <div class="table-cell thick-border-black">Firstname</div>
+    <div class="table-cell thick-border-black">Lastname</div>
+  </div>
+  <div class="table-row thick-border-black">
+    <div class="table-cell thick-border-black">Peter</div>
+    <div class="table-cell thick-border-black">Griffin</div>
+  </div>
+  <div class="table-row thick-border-black">
+    <div class="table-cell thick-border-black">Lois</div>
+    <div class="table-cell thick-border-black">Griffin</div>
+  </div>
+</div>

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -72,6 +72,7 @@ public:
     static CSS::GridTrackPlacement grid_row_start() { return CSS::GridTrackPlacement::make_auto(); }
     static CSS::Size column_gap() { return CSS::Size::make_auto(); }
     static CSS::Size row_gap() { return CSS::Size::make_auto(); }
+    static CSS::BorderCollapse border_collapse() { return CSS::BorderCollapse::Separate; }
 };
 
 struct BackgroundLayerData {
@@ -192,6 +193,7 @@ public:
     CSS::GridTrackPlacement const& grid_row_start() const { return m_noninherited.grid_row_start; }
     CSS::Size const& column_gap() const { return m_noninherited.column_gap; }
     CSS::Size const& row_gap() const { return m_noninherited.row_gap; }
+    CSS::BorderCollapse border_collapse() const { return m_noninherited.border_collapse; }
 
     CSS::LengthBox const& inset() const { return m_noninherited.inset; }
     const CSS::LengthBox& margin() const { return m_noninherited.margin; }
@@ -316,6 +318,7 @@ protected:
         CSS::GridTrackPlacement grid_row_start { InitialValues::grid_row_start() };
         CSS::Size column_gap { InitialValues::column_gap() };
         CSS::Size row_gap { InitialValues::row_gap() };
+        CSS::BorderCollapse border_collapse { InitialValues::border_collapse() };
     } m_noninherited;
 };
 
@@ -396,6 +399,7 @@ public:
     void set_grid_row_start(CSS::GridTrackPlacement value) { m_noninherited.grid_row_start = value; }
     void set_column_gap(CSS::Size const& column_gap) { m_noninherited.column_gap = column_gap; }
     void set_row_gap(CSS::Size const& row_gap) { m_noninherited.row_gap = row_gap; }
+    void set_border_collapse(CSS::BorderCollapse const& border_collapse) { m_noninherited.border_collapse = border_collapse; }
 
     void set_fill(Color value) { m_inherited.fill = value; }
     void set_stroke(Color value) { m_inherited.stroke = value; }

--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -60,6 +60,10 @@
         "content-box",
         "padding-box"
     ],
+    "border-collapse": [
+      "separate",
+      "collapse"
+    ],
     "box-sizing": [
         "border-box",
         "content-box"

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -266,9 +266,8 @@
   "border-collapse": {
     "inherited": true,
     "initial": "separate",
-    "valid-identifiers": [
-      "collapse",
-      "separate"
+    "valid-types": [
+      "border-collapse"
     ]
   },
   "border-left-color": {

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -202,6 +202,8 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_bottom().line_style));
     case CSS::PropertyID::BorderBottomWidth:
         return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_bottom().width));
+    case CSS::PropertyID::BorderCollapse:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_collapse()));
     case CSS::PropertyID::BorderLeft: {
         auto border = layout_node.computed_values().border_left();
         auto width = LengthStyleValue::create(Length::make_px(border.width));

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -737,4 +737,10 @@ CSS::GridTrackPlacement StyleProperties::grid_row_start() const
     return value->as_grid_track_placement().grid_track_placement();
 }
 
+Optional<CSS::BorderCollapse> StyleProperties::border_collapse() const
+{
+    auto value = property(CSS::PropertyID::BorderCollapse);
+    return value_id_to_border_collapse(value->to_identifier());
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -90,6 +90,7 @@ public:
     CSS::GridTrackPlacement grid_column_start() const;
     CSS::GridTrackPlacement grid_row_end() const;
     CSS::GridTrackPlacement grid_row_start() const;
+    Optional<CSS::BorderCollapse> border_collapse() const;
 
     Vector<CSS::Transformation> transformations() const;
     CSS::TransformOrigin transform_origin() const;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -605,6 +605,9 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
 
     computed_values.set_column_gap(computed_style.size_value(CSS::PropertyID::ColumnGap));
     computed_values.set_row_gap(computed_style.size_value(CSS::PropertyID::RowGap));
+
+    if (auto border_collapse = computed_style.border_collapse(); border_collapse.has_value())
+        computed_values.set_border_collapse(border_collapse.value());
 }
 
 bool Node::is_root_element() const

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -190,6 +190,9 @@ void TableFormattingContext::distribute_width_to_columns(float extra_width)
     for (auto& column : m_columns)
         grid_max += column.max_width - column.min_width;
 
+    if (grid_max == 0)
+        return;
+
     for (auto& column : m_columns)
         column.used_width += ((column.max_width - column.min_width) / grid_max) * extra_width;
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -224,10 +224,10 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
 void PaintableBox::paint_border(PaintContext& context) const
 {
     auto borders_data = BordersData {
-        .top = computed_values().border_top(),
-        .right = computed_values().border_right(),
-        .bottom = computed_values().border_bottom(),
-        .left = computed_values().border_left(),
+        .top = box_model().border.top == 0 ? CSS::BorderData() : computed_values().border_top(),
+        .right = box_model().border.right == 0 ? CSS::BorderData() : computed_values().border_right(),
+        .bottom = box_model().border.bottom == 0 ? CSS::BorderData() : computed_values().border_bottom(),
+        .left = box_model().border.left == 0 ? CSS::BorderData() : computed_values().border_left(),
     };
     paint_all_borders(context, absolute_border_box_rect(), normalized_border_radii_data(), borders_data);
 }


### PR DESCRIPTION
Fixes a bug seen in Github caused by the collapse-border property to be unused in the TableFormattingContext.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/45781926/210282073-c46f03db-377d-4725-b17f-629f4316dcf7.png"></td>
<td><img src="https://user-images.githubusercontent.com/45781926/210282079-4121f14d-2cbd-4915-b196-2801b853bcc8.png"></td>
</tr>
</table>