### PR TITLE
Everywhere: Delete so many unused includes

### DIFF
--- a/AK/AtomicRefCounted.h
+++ b/AK/AtomicRefCounted.h
@@ -11,7 +11,6 @@
 #include <AK/Checked.h>
 #include <AK/Noncopyable.h>
 #include <AK/Platform.h>
-#include <AK/StdLibExtras.h>
 
 namespace AK {
 

--- a/AK/CheckedFormatString.h
+++ b/AK/CheckedFormatString.h
@@ -9,7 +9,6 @@
 #include <AK/AllOf.h>
 #include <AK/AnyOf.h>
 #include <AK/Array.h>
-#include <AK/StdLibExtras.h>
 #include <AK/StringView.h>
 
 #ifdef ENABLE_COMPILETIME_FORMAT_CHECK

--- a/AK/DeprecatedString.cpp
+++ b/AK/DeprecatedString.cpp
@@ -9,7 +9,6 @@
 #include <AK/FlyString.h>
 #include <AK/Format.h>
 #include <AK/Function.h>
-#include <AK/Memory.h>
 #include <AK/StdLibExtras.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>

--- a/AK/EnumBits.h
+++ b/AK/EnumBits.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/StdLibExtras.h>
+#include <AK/StdLibExtraDetails.h>
 
 // Enables bitwise operators for the specified Enum type.
 //

--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Concepts.h>
-#include <AK/Format.h>
 #include <AK/IntegralMath.h>
 #include <AK/NumericLimits.h>
 #include <AK/Types.h>

--- a/AK/FloatingPoint.h
+++ b/AK/FloatingPoint.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/BitCast.h>
-#include <AK/Concepts.h>
 #include <AK/Types.h>
 
 namespace AK {

--- a/AK/Memory.h
+++ b/AK/Memory.h
@@ -12,7 +12,6 @@
 #if defined(KERNEL)
 #    include <Kernel/StdLib.h>
 #else
-#    include <stdlib.h>
 #    include <string.h>
 #endif
 

--- a/AK/RefCounted.h
+++ b/AK/RefCounted.h
@@ -10,7 +10,6 @@
 #include <AK/Checked.h>
 #include <AK/Noncopyable.h>
 #include <AK/Platform.h>
-#include <AK/StdLibExtras.h>
 
 namespace AK {
 

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Checked.h>
 #include <AK/Format.h>
-#include <AK/Memory.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/Utf8View.h>

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -7,7 +7,6 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Checked.h>
 #include <AK/PrintfImplementation.h>
-#include <AK/StdLibExtras.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>

--- a/AK/StringImpl.cpp
+++ b/AK/StringImpl.cpp
@@ -7,7 +7,6 @@
 #include <AK/CharacterTypes.h>
 #include <AK/FlyString.h>
 #include <AK/HashTable.h>
-#include <AK/Memory.h>
 #include <AK/StringHash.h>
 #include <AK/StringImpl.h>
 #include <AK/kmalloc.h>

--- a/AK/StringImpl.cpp
+++ b/AK/StringImpl.cpp
@@ -8,7 +8,6 @@
 #include <AK/FlyString.h>
 #include <AK/HashTable.h>
 #include <AK/Memory.h>
-#include <AK/StdLibExtras.h>
 #include <AK/StringHash.h>
 #include <AK/StringImpl.h>
 #include <AK/kmalloc.h>

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -7,7 +7,6 @@
 
 #include <AK/CharacterTypes.h>
 #include <AK/MemMem.h>
-#include <AK/Memory.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -8,7 +8,6 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Find.h>
 #include <AK/Function.h>
-#include <AK/Memory.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>

--- a/AK/TypeCasts.h
+++ b/AK/TypeCasts.h
@@ -9,7 +9,6 @@
 #include <AK/Assertions.h>
 #include <AK/Forward.h>
 #include <AK/Platform.h>
-#include <AK/StdLibExtras.h>
 
 namespace AK {
 

--- a/AK/Userspace.h
+++ b/AK/Userspace.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Assertions.h>
-#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
 #ifdef KERNEL

--- a/Kernel/Arch/aarch64/RPi/InterruptController.cpp
+++ b/Kernel/Arch/aarch64/RPi/InterruptController.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <Kernel/Arch/aarch64/RPi/InterruptController.h>
 #include <Kernel/Arch/aarch64/RPi/MMIO.h>
 #include <Kernel/Interrupts/GenericInterruptHandler.h>

--- a/Kernel/Arch/x86_64/CPU.h
+++ b/Kernel/Arch/x86_64/CPU.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Atomic.h>
-#include <AK/Concepts.h>
 #include <AK/Vector.h>
 
 #include <Kernel/Arch/x86_64/DescriptorTable.h>

--- a/Kernel/Arch/x86_64/DescriptorTable.h
+++ b/Kernel/Arch/x86_64/DescriptorTable.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <Kernel/VirtualAddress.h>
 

--- a/Kernel/Arch/x86_64/ISABus/HID/PS2MouseDevice.cpp
+++ b/Kernel/Arch/x86_64/ISABus/HID/PS2MouseDevice.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Memory.h>
 #include <Kernel/Arch/x86_64/Hypervisor/VMWareBackdoor.h>
 #include <Kernel/Arch/x86_64/ISABus/HID/PS2MouseDevice.h>
 #include <Kernel/Debug.h>

--- a/Kernel/Arch/x86_64/Interrupts/APIC.cpp
+++ b/Kernel/Arch/x86_64/Interrupts/APIC.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Assertions.h>
-#include <AK/Memory.h>
 #include <AK/Singleton.h>
 #include <AK/Types.h>
 #include <Kernel/Arch/Delay.h>

--- a/Kernel/Devices/FullDevice.cpp
+++ b/Kernel/Devices/FullDevice.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Memory.h>
 #include <Kernel/API/POSIX/errno.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Devices/FullDevice.h>

--- a/Kernel/Devices/MemoryDevice.cpp
+++ b/Kernel/Devices/MemoryDevice.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Memory.h>
-#include <AK/StdLibExtras.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Devices/MemoryDevice.h>
 #include <Kernel/Memory/AnonymousVMObject.h>

--- a/Kernel/Devices/MemoryDevice.cpp
+++ b/Kernel/Devices/MemoryDevice.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Memory.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Devices/MemoryDevice.h>
 #include <Kernel/Memory/AnonymousVMObject.h>

--- a/Kernel/Devices/ZeroDevice.cpp
+++ b/Kernel/Devices/ZeroDevice.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Memory.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Devices/ZeroDevice.h>
 #include <Kernel/Sections.h>

--- a/Kernel/FileSystem/InodeWatcher.cpp
+++ b/Kernel/FileSystem/InodeWatcher.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Memory.h>
 #include <Kernel/FileSystem/Inode.h>
 #include <Kernel/FileSystem/InodeWatcher.h>
 #include <Kernel/Process.h>

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.cpp
@@ -6,7 +6,6 @@
 
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Access.h>
-#include <Kernel/Debug.h>
 #include <Kernel/FileSystem/SysFS/Registry.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h>

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.cpp
@@ -6,7 +6,6 @@
 
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Access.h>
-#include <Kernel/Debug.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.h>
 #include <Kernel/Sections.h>
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.cpp
@@ -6,7 +6,6 @@
 
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Access.h>
-#include <Kernel/Debug.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h>
 #include <Kernel/Sections.h>

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceAttribute.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceAttribute.cpp
@@ -6,7 +6,6 @@
 
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Access.h>
-#include <Kernel/Debug.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceAttribute.h>
 #include <Kernel/Sections.h>
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceDirectory.cpp
@@ -6,7 +6,6 @@
 
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Access.h>
-#include <Kernel/Debug.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceAttribute.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceDirectory.h>
 #include <Kernel/Graphics/DisplayConnector.h>

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceAttribute.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceAttribute.cpp
@@ -6,7 +6,6 @@
 
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Access.h>
-#include <Kernel/Debug.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceAttribute.h>
 #include <Kernel/Sections.h>
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceDirectory.cpp
@@ -6,7 +6,6 @@
 
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Access.h>
-#include <Kernel/Debug.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceAttribute.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceDirectory.h>
 #include <Kernel/Sections.h>

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -12,7 +12,6 @@
 #endif
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/IDs.h>
-#include <Kernel/Debug.h>
 #include <Kernel/Graphics/Bochs/Definitions.h>
 #include <Kernel/Graphics/Bochs/GraphicsAdapter.h>
 #include <Kernel/Graphics/Bochs/QEMUDisplayConnector.h>

--- a/Kernel/Graphics/Generic/DisplayConnector.cpp
+++ b/Kernel/Graphics/Generic/DisplayConnector.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <Kernel/Debug.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Graphics/Console/ContiguousFramebufferConsole.h>
 #include <Kernel/Graphics/Generic/DisplayConnector.h>

--- a/Kernel/Graphics/VMWare/DisplayConnector.cpp
+++ b/Kernel/Graphics/VMWare/DisplayConnector.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <Kernel/Debug.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Graphics/GraphicsManagement.h>
 #include <Kernel/Graphics/VMWare/Console.h>

--- a/Kernel/Graphics/VMWare/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VMWare/GraphicsAdapter.cpp
@@ -9,7 +9,6 @@
 #include <AK/Try.h>
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/IDs.h>
-#include <Kernel/Debug.h>
 #include <Kernel/Graphics/Console/ContiguousFramebufferConsole.h>
 #include <Kernel/Graphics/GraphicsManagement.h>
 #include <Kernel/Graphics/VMWare/Definitions.h>

--- a/Kernel/Heap/kmalloc.h
+++ b/Kernel/Heap/kmalloc.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Types.h>
-#include <Kernel/Debug.h>
 #include <LibC/limits.h>
 
 #define KMALLOC_SCRUB_BYTE 0xbb

--- a/Kernel/KBuffer.h
+++ b/Kernel/KBuffer.h
@@ -16,7 +16,6 @@
 // severely limited kmalloc heap.
 
 #include <AK/Assertions.h>
-#include <AK/Memory.h>
 #include <AK/StringView.h>
 #include <Kernel/Memory/MemoryManager.h>
 

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Assertions.h>
-#include <AK/Memory.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/StringView.h>
 #include <Kernel/Arch/CPU.h>

--- a/Kernel/Memory/PageDirectory.cpp
+++ b/Kernel/Memory/PageDirectory.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Memory.h>
 #include <AK/Singleton.h>
 #include <Kernel/Arch/CPU.h>
 #include <Kernel/Arch/PageDirectory.h>

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Memory.h>
 #include <AK/StringView.h>
 #include <Kernel/Arch/PageDirectory.h>
 #include <Kernel/Arch/PageFault.h>

--- a/Kernel/Net/TCP.h
+++ b/Kernel/Net/TCP.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/StdLibExtras.h>
 #include <Kernel/Net/IPv4.h>
 
 namespace Kernel {

--- a/Kernel/ProcessExposed.cpp
+++ b/Kernel/ProcessExposed.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <Kernel/Debug.h>
 #include <Kernel/FileSystem/ProcFS/DirectoryInode.h>
 #include <Kernel/FileSystem/ProcFS/LinkInode.h>
 #include <Kernel/KBufferBuilder.h>

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Memory.h>
 #include <AK/StringView.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Devices/DeviceManagement.h>

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -12,7 +12,6 @@
 #    include <Kernel/Arch/x86_64/PCSpeaker.h>
 #endif
 #include <Kernel/CommandLine.h>
-#include <Kernel/Debug.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Devices/HID/HIDManagement.h>
 #include <Kernel/Graphics/GraphicsManagement.h>

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
@@ -6,7 +6,6 @@
 
 #include "../LibUnicode/GeneratorUtil.h" // FIXME: Move this somewhere common.
 #include <AK/DeprecatedString.h>
-#include <AK/Format.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonParser.h>
 #include <AK/JsonValue.h>

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
-#include <AK/Format.h>
 #include <AK/HashFunctions.h>
 #include <AK/HashMap.h>
 #include <AK/JsonValue.h>

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <AK/DeprecatedString.h>
 #include <AK/LexicalPath.h>
 #include <AK/SourceGenerator.h>

--- a/Tests/AK/TestSpan.cpp
+++ b/Tests/AK/TestSpan.cpp
@@ -8,7 +8,6 @@
 
 #include <AK/Checked.h>
 #include <AK/Span.h>
-#include <AK/StdLibExtras.h>
 #include <string.h>
 
 TEST_CASE(constexpr_default_constructor_is_empty)

--- a/Tests/AK/TestTypeTraits.cpp
+++ b/Tests/AK/TestTypeTraits.cpp
@@ -6,7 +6,6 @@
 
 #include <LibTest/TestCase.h>
 
-#include <AK/StdLibExtras.h>
 #include <AK/TypeList.h>
 
 #define STATIC_EXPECT_EQ(lhs, rhs) \

--- a/Tests/AK/TestUFixedBigInt.cpp
+++ b/Tests/AK/TestUFixedBigInt.cpp
@@ -6,7 +6,6 @@
 
 #include <LibTest/TestCase.h>
 
-#include <AK/Format.h>
 #include <AK/NumericLimits.h>
 #include <AK/Random.h>
 #include <AK/UFixedBigInt.h>

--- a/Tests/Kernel/TestMemoryDeviceMmap.cpp
+++ b/Tests/Kernel/TestMemoryDeviceMmap.cpp
@@ -11,7 +11,6 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>

--- a/Tests/Kernel/crash-fcntl-invalid-cmd.cpp
+++ b/Tests/Kernel/crash-fcntl-invalid-cmd.cpp
@@ -8,7 +8,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
 
 int main(int, char**)

--- a/Tests/LibC/TestLibCInodeWatcher.cpp
+++ b/Tests/LibC/TestLibCInodeWatcher.cpp
@@ -11,7 +11,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
 #include <utime.h>
 

--- a/Tests/LibC/TestScanf.cpp
+++ b/Tests/LibC/TestScanf.cpp
@@ -8,7 +8,6 @@
 
 #include <AK/Array.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 typedef long double longdouble;

--- a/Tests/LibC/TestSearch.cpp
+++ b/Tests/LibC/TestSearch.cpp
@@ -6,7 +6,6 @@
 
 #include <LibTest/TestCase.h>
 
-#include <AK/Format.h>
 #include <bits/search.h>
 #include <search.h>
 #include <string.h>

--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -18,7 +18,6 @@
 #include <LibGfx/PPMLoader.h>
 #include <LibTest/TestCase.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 TEST_CASE(test_bmp)

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -6,6 +6,7 @@
 
 #include <LibTest/TestCase.h> // import first, to prevent warning of VERIFY* redefinition
 
+#include <AK/Debug.h>
 #include <AK/StringBuilder.h>
 #include <AK/Tuple.h>
 #include <LibRegex/Regex.h>

--- a/Tests/UserspaceEmulator/ue-write-oob.cpp
+++ b/Tests/UserspaceEmulator/ue-write-oob.cpp
@@ -8,7 +8,6 @@
 #include <LibCore/ArgsParser.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <sys/mman.h>
 
 static void write8(void* ptr) { *(uint8_t volatile*)ptr = 1; }

--- a/Userland/Applications/Browser/Database.cpp
+++ b/Userland/Applications/Browser/Database.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "Database.h"
-#include <AK/Format.h>
 #include <AK/StringView.h>
 
 namespace Browser {

--- a/Userland/Applications/Piano/ProcessorParameterWidget/ParameterWidget.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/ParameterWidget.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/NonnullRefPtr.h>
-#include <AK/StdLibExtraDetails.h>
 #include <LibCore/Object.h>
 #include <LibDSP/ProcessorParameter.h>
 #include <LibGUI/Label.h>

--- a/Userland/Applications/SoundPlayer/SampleWidget.cpp
+++ b/Userland/Applications/SoundPlayer/SampleWidget.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "SampleWidget.h"
-#include <AK/Math.h>
 #include <LibGUI/Painter.h>
 
 SampleWidget::SampleWidget()

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -16,7 +16,6 @@
 #include <LibGUI/Painter.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/StylePainter.h>
-#include <stdlib.h>
 
 REGISTER_WIDGET(SystemMonitor, MemoryStatsWidget)
 

--- a/Userland/Demos/Cube/Cube.cpp
+++ b/Userland/Demos/Cube/Cube.cpp
@@ -21,7 +21,6 @@
 #include <LibGfx/Vector3.h>
 #include <LibMain/Main.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
 
 int const WIDTH = 200;

--- a/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
@@ -6,6 +6,7 @@
 
 #include "FileDB.h"
 
+#include <AK/Debug.h>
 #include <AK/LexicalPath.h>
 #include <AK/NonnullRefPtr.h>
 

--- a/Userland/DevTools/Inspector/RemoteProcess.cpp
+++ b/Userland/DevTools/Inspector/RemoteProcess.cpp
@@ -8,7 +8,6 @@
 #include "RemoteObject.h"
 #include "RemoteObjectGraphModel.h"
 #include "RemoteObjectPropertyModel.h"
-#include <stdlib.h>
 
 namespace Inspector {
 

--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -9,7 +9,6 @@
 #include "MmapRegion.h"
 #include "SimpleRegion.h"
 #include "SoftCPU.h"
-#include <AK/Debug.h>
 #include <AK/FileStream.h>
 #include <AK/Format.h>
 #include <AK/LexicalPath.h>

--- a/Userland/Libraries/LibAudio/UserSampleQueue.h
+++ b/Userland/Libraries/LibAudio/UserSampleQueue.h
@@ -8,7 +8,6 @@
 
 #include <AK/DisjointChunks.h>
 #include <AK/FixedArray.h>
-#include <AK/Format.h>
 #include <AK/Noncopyable.h>
 #include <AK/Vector.h>
 #include <LibAudio/Sample.h>

--- a/Userland/Libraries/LibC/crt0_shared.cpp
+++ b/Userland/Libraries/LibC/crt0_shared.cpp
@@ -7,7 +7,6 @@
 #include <AK/Types.h>
 #include <assert.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <sys/internals.h>
 #include <unistd.h>
 

--- a/Userland/Libraries/LibC/dirent.cpp
+++ b/Userland/Libraries/LibC/dirent.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Assertions.h>
-#include <AK/Format.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Vector.h>

--- a/Userland/Libraries/LibC/getsubopt.cpp
+++ b/Userland/Libraries/LibC/getsubopt.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/ScopeGuard.h>
 #include <AK/StringView.h>
-#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/Userland/Libraries/LibC/grp.cpp
+++ b/Userland/Libraries/LibC/grp.cpp
@@ -12,7 +12,6 @@
 #include <errno_codes.h>
 #include <grp.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -20,7 +20,6 @@
 #include <fenv.h>
 #include <math.h>
 #include <stdint.h>
-#include <stdlib.h>
 
 #if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic push

--- a/Userland/Libraries/LibC/pthread.cpp
+++ b/Userland/Libraries/LibC/pthread.cpp
@@ -9,7 +9,6 @@
 #include <AK/Debug.h>
 #include <AK/Format.h>
 #include <AK/SinglyLinkedList.h>
-#include <AK/StdLibExtras.h>
 #include <Kernel/API/Syscall.h>
 #include <LibSystem/syscall.h>
 #include <bits/pthread_cancel.h>

--- a/Userland/Libraries/LibC/pty.cpp
+++ b/Userland/Libraries/LibC/pty.cpp
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <pty.h>

--- a/Userland/Libraries/LibC/pwd.cpp
+++ b/Userland/Libraries/LibC/pwd.cpp
@@ -11,7 +11,6 @@
 #include <errno.h>
 #include <pwd.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/Userland/Libraries/LibC/scanf.cpp
+++ b/Userland/Libraries/LibC/scanf.cpp
@@ -7,7 +7,6 @@
 #include <AK/Assertions.h>
 #include <AK/Format.h>
 #include <AK/GenericLexer.h>
-#include <AK/StdLibExtras.h>
 #include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/Userland/Libraries/LibC/shadow.cpp
+++ b/Userland/Libraries/LibC/shadow.cpp
@@ -11,7 +11,6 @@
 #include <errno.h>
 #include <shadow.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/Userland/Libraries/LibC/signal.cpp
+++ b/Userland/Libraries/LibC/signal.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
+#include <AK/StringView.h>
 #include <assert.h>
 #include <bits/pthread_cancel.h>
 #include <errno.h>

--- a/Userland/Libraries/LibC/spawn.cpp
+++ b/Userland/Libraries/LibC/spawn.cpp
@@ -18,7 +18,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -15,7 +15,6 @@
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
 #include <sys/times.h>

--- a/Userland/Libraries/LibC/wctype.cpp
+++ b/Userland/Libraries/LibC/wctype.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <string.h>
 #include <wctype.h>
 

--- a/Userland/Libraries/LibCore/GetPassword.cpp
+++ b/Userland/Libraries/LibCore/GetPassword.cpp
@@ -8,7 +8,6 @@
 #include <LibCore/GetPassword.h>
 #include <LibCore/System.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <termios.h>
 #include <unistd.h>
 

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/Mode.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/Mode.h
@@ -8,7 +8,6 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/Span.h>
-#include <AK/StdLibExtras.h>
 #include <LibCrypto/Cipher/Cipher.h>
 
 namespace Crypto {

--- a/Userland/Libraries/LibCrypto/Forward.h
+++ b/Userland/Libraries/LibCrypto/Forward.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/Concepts.h>
+#include <AK/StdLibExtraDetails.h>
 
 namespace Crypto {
 

--- a/Userland/Libraries/LibDNS/Packet.cpp
+++ b/Userland/Libraries/LibDNS/Packet.cpp
@@ -12,7 +12,6 @@
 #include <AK/MemoryStream.h>
 #include <AK/StringBuilder.h>
 #include <arpa/inet.h>
-#include <stdlib.h>
 
 namespace DNS {
 

--- a/Userland/Libraries/LibDesktop/Launcher.cpp
+++ b/Userland/Libraries/LibDesktop/Launcher.cpp
@@ -10,7 +10,6 @@
 #include <LaunchServer/LaunchServerEndpoint.h>
 #include <LibDesktop/Launcher.h>
 #include <LibIPC/ConnectionToServer.h>
-#include <stdlib.h>
 
 namespace Desktop {
 

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -7,7 +7,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <AK/Optional.h>
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>

--- a/Userland/Libraries/LibELF/Image.cpp
+++ b/Userland/Libraries/LibELF/Image.cpp
@@ -8,7 +8,6 @@
 #include <AK/BinarySearch.h>
 #include <AK/Debug.h>
 #include <AK/Demangle.h>
-#include <AK/Memory.h>
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>

--- a/Userland/Libraries/LibELF/Relocation.h
+++ b/Userland/Libraries/LibELF/Relocation.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Concepts.h>
 #include <Kernel/VirtualAddress.h>
 
 namespace ELF {

--- a/Userland/Libraries/LibGL/Buffer.cpp
+++ b/Userland/Libraries/LibGL/Buffer.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <LibGL/GLContext.h>
 
 namespace GL {

--- a/Userland/Libraries/LibGL/ClipPlane.cpp
+++ b/Userland/Libraries/LibGL/ClipPlane.cpp
@@ -7,7 +7,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <LibGL/GLContext.h>
 
 namespace GL {

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AK/Debug.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Optional.h>

--- a/Userland/Libraries/LibGL/Lighting.cpp
+++ b/Userland/Libraries/LibGL/Lighting.cpp
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <LibGL/GLContext.h>
 
 namespace GL {

--- a/Userland/Libraries/LibGL/List.cpp
+++ b/Userland/Libraries/LibGL/List.cpp
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <AK/TemporaryChange.h>
 #include <LibGL/GLContext.h>
 

--- a/Userland/Libraries/LibGL/Matrix.cpp
+++ b/Userland/Libraries/LibGL/Matrix.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <AK/Assertions.h>
-#include <AK/Debug.h>
 #include <LibGL/GLContext.h>
 
 namespace GL {

--- a/Userland/Libraries/LibGL/Shader.cpp
+++ b/Userland/Libraries/LibGL/Shader.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <AK/StringBuilder.h>
 #include <LibGL/GLContext.h>
 

--- a/Userland/Libraries/LibGL/Stencil.cpp
+++ b/Userland/Libraries/LibGL/Stencil.cpp
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <LibGL/GLContext.h>
 
 namespace GL {

--- a/Userland/Libraries/LibGL/Texture.cpp
+++ b/Userland/Libraries/LibGL/Texture.cpp
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <LibGL/GLContext.h>
 #include <LibGL/Image.h>
 #include <LibGPU/ImageDataLayout.h>

--- a/Userland/Libraries/LibGL/Vertex.cpp
+++ b/Userland/Libraries/LibGL/Vertex.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <AK/Assertions.h>
-#include <AK/Debug.h>
 #include <AK/NumericLimits.h>
 #include <LibGL/GLContext.h>
 

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -25,7 +25,6 @@
 #include <LibGUI/Toolbar.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Font/Emoji.h>
-#include <stdlib.h>
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/Process.cpp
+++ b/Userland/Libraries/LibGUI/Process.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <AK/StringView.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Process.h>

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -14,7 +14,6 @@
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 #include <ctype.h>
-#include <stdlib.h>
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/Filters/MatrixFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/MatrixFilter.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Math.h>
 #include <LibGfx/Filters/ColorFilter.h>
 #include <LibGfx/Matrix3x3.h>
 

--- a/Userland/Libraries/LibGfx/Filters/SepiaFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/SepiaFilter.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/StdLibExtras.h>
 #include <AK/StringView.h>
 #include <LibGfx/Filters/ColorFilter.h>
 #include <math.h>

--- a/Userland/Libraries/LibGfx/Filters/SpatialGaussianBlurFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/SpatialGaussianBlurFilter.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "GenericConvolutionFilter.h"
-#include <AK/StdLibExtras.h>
 #include <AK/StringView.h>
 
 namespace Gfx {

--- a/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -15,7 +15,6 @@
 #include <LibGfx/Font/OpenType/Font.h>
 #include <LibGfx/Font/Typeface.h>
 #include <LibGfx/Font/WOFF/Font.h>
-#include <stdlib.h>
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/Line.h
+++ b/Userland/Libraries/LibGfx/Line.h
@@ -12,7 +12,6 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
-#include <stdlib.h>
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/Line.h
+++ b/Userland/Libraries/LibGfx/Line.h
@@ -9,7 +9,6 @@
 #include <AK/DeprecatedString.h>
 #include <AK/Format.h>
 #include <AK/Optional.h>
-#include <AK/StdLibExtras.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>

--- a/Userland/Libraries/LibGfx/Rect.cpp
+++ b/Userland/Libraries/LibGfx/Rect.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/DeprecatedString.h>
-#include <AK/StdLibExtras.h>
 #include <AK/Vector.h>
 #include <LibGfx/Line.h>
 #include <LibGfx/Rect.h>

--- a/Userland/Libraries/LibGfx/VectorN.h
+++ b/Userland/Libraries/LibGfx/VectorN.h
@@ -11,7 +11,6 @@
 #include <AK/Array.h>
 #include <AK/DeprecatedString.h>
 #include <AK/Error.h>
-#include <AK/Format.h>
 #include <AK/Math.h>
 #include <AK/StdLibExtras.h>
 #include <AK/StringView.h>

--- a/Userland/Libraries/LibHTTP/HttpsJob.cpp
+++ b/Userland/Libraries/LibHTTP/HttpsJob.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <LibHTTP/HttpsJob.h>
 
 namespace HTTP {

--- a/Userland/Libraries/LibIMAP/Objects.h
+++ b/Userland/Libraries/LibIMAP/Objects.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Format.h>
 #include <AK/Function.h>
 #include <AK/Tuple.h>
 #include <AK/Variant.h>

--- a/Userland/Libraries/LibIPC/Connection.h
+++ b/Userland/Libraries/LibIPC/Connection.h
@@ -20,7 +20,6 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -8,7 +8,6 @@
  */
 
 #include <AK/Find.h>
-#include <AK/Format.h>
 #include <LibJS/AST.h>
 #include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Bytecode/Instruction.h>

--- a/Userland/Libraries/LibJS/Runtime/Map.h
+++ b/Userland/Libraries/LibJS/Runtime/Map.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Concepts.h>
 #include <AK/HashMap.h>
 #include <AK/RedBlackTree.h>
 #include <LibJS/Runtime/GlobalObject.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -24,7 +24,6 @@
 #include <LibJS/Runtime/Temporal/PlainTime.h>
 #include <LibJS/Runtime/Temporal/TimeZone.h>
 #include <LibJS/Runtime/Temporal/ZonedDateTime.h>
-#include <stdlib.h>
 
 namespace JS::Temporal {
 

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -10,7 +10,6 @@
 
 #include <AK/Assertions.h>
 #include <AK/BitCast.h>
-#include <AK/Concepts.h>
 #include <AK/DeprecatedString.h>
 #include <AK/Format.h>
 #include <AK/Forward.h>

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Debug.h>
 #include <AK/QuickSort.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Parser.h>

--- a/Userland/Libraries/LibLine/Style.h
+++ b/Userland/Libraries/LibLine/Style.h
@@ -10,7 +10,6 @@
 #include <AK/Types.h>
 #include <AK/Utf8View.h>
 #include <AK/Vector.h>
-#include <stdlib.h>
 
 namespace Line {
 

--- a/Userland/Libraries/LibLine/SuggestionDisplay.h
+++ b/Userland/Libraries/LibLine/SuggestionDisplay.h
@@ -10,7 +10,6 @@
 #include <AK/Forward.h>
 #include <LibLine/StringMetrics.h>
 #include <LibLine/SuggestionManager.h>
-#include <stdlib.h>
 
 namespace Line {
 

--- a/Userland/Libraries/LibLine/SuggestionManager.h
+++ b/Userland/Libraries/LibLine/SuggestionManager.h
@@ -11,7 +11,6 @@
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
 #include <LibLine/Style.h>
-#include <stdlib.h>
 
 namespace Line {
 

--- a/Userland/Libraries/LibMarkdown/LineIterator.cpp
+++ b/Userland/Libraries/LibMarkdown/LineIterator.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <LibMarkdown/LineIterator.h>
 
 namespace Markdown {

--- a/Userland/Libraries/LibMarkdown/Text.cpp
+++ b/Userland/Libraries/LibMarkdown/Text.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
 #include <LibMarkdown/Text.h>

--- a/Userland/Libraries/LibPDF/Forward.h
+++ b/Userland/Libraries/LibPDF/Forward.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Forward.h>
-#include <AK/StdLibExtras.h>
 
 namespace PDF {
 

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -8,7 +8,6 @@
 #include "RegexDebug.h"
 #include <AK/BinarySearch.h>
 #include <AK/CharacterTypes.h>
-#include <AK/Debug.h>
 #include <AK/StringBuilder.h>
 #include <LibUnicode/CharacterTypes.h>
 

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -12,7 +12,6 @@
 
 #include <AK/Concepts.h>
 #include <AK/DisjointChunks.h>
-#include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>

--- a/Userland/Libraries/LibRegex/RegexDebug.h
+++ b/Userland/Libraries/LibRegex/RegexDebug.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Debug.h>
 #include <AK/StringBuilder.h>
 #include <LibRegex/RegexMatcher.h>
 

--- a/Userland/Libraries/LibRegex/RegexOptimizer.cpp
+++ b/Userland/Libraries/LibRegex/RegexOptimizer.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Debug.h>
 #include <AK/QuickSort.h>
 #include <AK/RedBlackTree.h>
 #include <AK/Stack.h>

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -9,6 +9,7 @@
 #include "RegexDebug.h"
 #include <AK/AnyOf.h>
 #include <AK/CharacterTypes.h>
+#include <AK/Debug.h>
 #include <AK/DeprecatedString.h>
 #include <AK/GenericLexer.h>
 #include <AK/ScopeGuard.h>

--- a/Userland/Libraries/LibSQL/BTree.cpp
+++ b/Userland/Libraries/LibSQL/BTree.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <LibSQL/BTree.h>
 #include <LibSQL/Meta.h>
 

--- a/Userland/Libraries/LibSQL/BTreeIterator.cpp
+++ b/Userland/Libraries/LibSQL/BTreeIterator.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <LibSQL/BTree.h>
 
 namespace SQL {

--- a/Userland/Libraries/LibSQL/Database.cpp
+++ b/Userland/Libraries/LibSQL/Database.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <AK/DeprecatedString.h>
-#include <AK/Format.h>
 #include <AK/RefPtr.h>
 
 #include <LibSQL/BTree.h>

--- a/Userland/Libraries/LibSQL/Tuple.h
+++ b/Userland/Libraries/LibSQL/Tuple.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Debug.h>
 #include <AK/Vector.h>
 #include <LibSQL/Forward.h>
 #include <LibSQL/TupleDescriptor.h>

--- a/Userland/Libraries/LibTest/TestSuite.h
+++ b/Userland/Libraries/LibTest/TestSuite.h
@@ -10,7 +10,6 @@
 #include <LibTest/Macros.h> // intentionally first -- we redefine VERIFY and friends in here
 
 #include <AK/DeprecatedString.h>
-#include <AK/Format.h>
 #include <AK/Function.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <LibTest/TestCase.h>

--- a/Userland/Libraries/LibThreading/Mutex.h
+++ b/Userland/Libraries/LibThreading/Mutex.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <AK/Assertions.h>
-#include <AK/Format.h>
 #include <AK/Noncopyable.h>
 #include <AK/Types.h>
 #include <pthread.h>

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -34,7 +34,6 @@
 #include <ctype.h>
 #include <errno.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <unistd.h>

--- a/Userland/Libraries/LibVideo/Color/ColorConverter.cpp
+++ b/Userland/Libraries/LibVideo/Color/ColorConverter.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <AK/Math.h>
 #include <AK/StdLibExtras.h>
 #include <LibGfx/Matrix4x4.h>

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Debug.h>
 #include <AK/Function.h>
 #include <AK/Optional.h>
 #include <AK/Time.h>

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.h
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/Concepts.h>
 #include <AK/IntegralMath.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/Optional.h>

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.h
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <AK/Concepts.h>
-#include <AK/Debug.h>
 #include <AK/IntegralMath.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/Optional.h>

--- a/Userland/Libraries/LibVideo/VideoFrame.cpp
+++ b/Userland/Libraries/LibVideo/VideoFrame.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
 #include <LibVideo/Color/ColorConverter.h>

--- a/Userland/Libraries/LibVideo/VideoFrame.h
+++ b/Userland/Libraries/LibVideo/VideoFrame.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
-#include <AK/Concepts.h>
 #include <AK/FixedArray.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Size.h>

--- a/Userland/Libraries/LibWasm/AbstractMachine/Validator.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Validator.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Debug.h>
 #include <AK/HashTable.h>
 #include <AK/SourceLocation.h>
 #include <AK/Tuple.h>

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Debug.h>
 #include <AK/LEB128.h>
 #include <AK/ScopeGuard.h>
 #include <AK/ScopeLogger.h>

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Badge.h>
-#include <AK/Debug.h>
 #include <AK/DeprecatedString.h>
 #include <AK/DistinctNumeric.h>
 #include <AK/MemoryStream.h>

--- a/Userland/Libraries/LibWeb/Bindings/ExceptionOrUtils.h
+++ b/Userland/Libraries/LibWeb/Bindings/ExceptionOrUtils.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Optional.h>
-#include <AK/StdLibExtras.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <AK/OwnPtr.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/Quad.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -11,7 +11,6 @@
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/Progress.h>
-#include <stdlib.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.h
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/StdLibExtras.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibWeb/DOM/EventTarget.h>
 

--- a/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/SVGFormattingContext.h>
 #include <LibWeb/Layout/SVGGeometryBox.h>

--- a/Userland/Libraries/LibWeb/NavigationTiming/PerformanceTiming.h
+++ b/Userland/Libraries/LibWeb/NavigationTiming/PerformanceTiming.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/StdLibExtras.h>
 #include <LibWeb/HTML/Window.h>
 
 namespace Web::NavigationTiming {

--- a/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.h
+++ b/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/StdLibExtras.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 
 namespace Web::RequestIdleCallback {

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -15,7 +15,6 @@
 #include <LibCore/ConfigFile.h>
 #include <LibCore/Timer.h>
 #include <pthread.h>
-#include <stdlib.h>
 #include <sys/ioctl.h>
 
 namespace AudioServer {

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <FileSystemAccessServer/ConnectionFromClient.h>
 #include <LibCore/File.h>
 #include <LibCore/IODevice.h>

--- a/Userland/Utilities/flock.cpp
+++ b/Userland/Utilities/flock.cpp
@@ -7,7 +7,6 @@
 #include <AK/Format.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
-#include <stdlib.h>
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/Userland/Utilities/nc.cpp
+++ b/Userland/Utilities/nc.cpp
@@ -16,7 +16,6 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/select.h>
 #include <sys/socket.h>

--- a/Userland/Utilities/pidof.cpp
+++ b/Userland/Utilities/pidof.cpp
@@ -10,7 +10,6 @@
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/Userland/Utilities/pmemdump.cpp
+++ b/Userland/Utilities/pmemdump.cpp
@@ -14,7 +14,6 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>

--- a/Userland/Utilities/shuf.cpp
+++ b/Userland/Utilities/shuf.cpp
@@ -12,7 +12,6 @@
 #include <LibCore/Stream.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
-#include <stdlib.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -20,7 +20,6 @@
 #include <netinet/in.h>
 #include <signal.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>


### PR DESCRIPTION
I focused on files that are included often, or have a high "inclusion_count * file_length".

For each such header, I assembled a regex that basically includes all symbols declared/defined in that header, and used a little script to see whether each file that #includes something also uses any of the symbols. This is pessimistic, but is guaranteed to only flag includes that are really definitely unused.

12 additions and 153 deletions: Since so many headers were included "too often", they were sometimes forgotten to be included in other files. This PR adds them back in, hence the 12 additions.

Grepping for `#include`, one can make an educated guess how many compilation units transitively include each header. Using it before and after this PR reveals that most changes to AK/Format etc. are merely cosmetic, and unrelated headers also get included less often.

The most drastic effect is achieved with Debug.h: About 2600 compilation units no longer have to parse and store a huge list of debug macros. That should give some speedup!

Here's the full list:

```
path/to/some/header.h: CompilationUnitsOnMaster → CompilationUnitsWithThisPR
Build/x86_64/Kernel/Debug.h: 2708 → 363
AK/Memory.h: 378 → 118
Build/x86_64/AK/Debug.h: 512 → 336
Kernel/StdLib.h: 385 → 378
AK/Userspace.h: 423 → 416
Userland/Libraries/LibC/time.h: 1750 → 1744
Kernel/UnixTypes.h: 423 → 417
Kernel/KString.h: 2028 → 2022
Kernel/Arch/x86_64/mcontext.h: 859 → 853
Kernel/Arch/mcontext.h: 859 → 853
Kernel/Arch/aarch64/mcontext.h: 859 → 853
Kernel/API/POSIX/unistd.h: 1175 → 1169
Kernel/API/POSIX/ucontext.h: 828 → 822
Kernel/API/POSIX/time.h: 1782 → 1776
Kernel/API/POSIX/termios.h: 789 → 783
Kernel/API/POSIX/sys/wait.h: 787 → 781
Kernel/API/POSIX/sys/utsname.h: 763 → 757
Kernel/API/POSIX/sys/un.h: 1496 → 1490
Kernel/API/POSIX/sys/uio.h: 1498 → 1492
Kernel/API/POSIX/sys/times.h: 424 → 418
Kernel/API/POSIX/sys/time.h: 1411 → 1405
Kernel/API/POSIX/sys/statvfs.h: 424 → 418
Kernel/API/POSIX/sys/stat.h: 1029 → 1023
Kernel/API/POSIX/sys/socket.h: 1496 → 1490
Kernel/API/POSIX/sys/ptrace.h: 439 → 433
Kernel/API/POSIX/sys/mman.h: 538 → 532
Kernel/API/POSIX/signal.h: 838 → 832
Kernel/API/POSIX/serenity.h: 461 → 455
Kernel/API/POSIX/sched.h: 1127 → 1121
Kernel/API/POSIX/poll.h: 764 → 758
Kernel/API/POSIX/net/route.h: 427 → 421
Kernel/API/POSIX/netinet/in.h: 1376 → 1370
Kernel/API/POSIX/net/if.h: 429 → 423
Kernel/API/POSIX/net/if_arp.h: 424 → 418
Kernel/API/POSIX/futex.h: 461 → 455
Kernel/API/POSIX/fcntl.h: 832 → 826
Kernel/API/POSIX/dirent.h: 828 → 822
AK/Time.h: 1524 → 1518
AK/OwnPtr.h: 2207 → 2201
AK/NonnullOwnPtr.h: 2227 → 2221
(many more files with a reduction of less than 5)
```

Using the clumsy "inclusion_count * file_length" heuristic from above, this PR reduces the total (possibly empty) lines that need to be compiled for a full rebuild from 82'981'098 to 81'912'968. It's not much, but it's something. 1.3%, if you will. Don't take that number too seriously, compilation times don't work like that.