### PR TITLE
Ladybird: install SQLServer binary

### DIFF
--- a/Ladybird/cmake/InstallRules.cmake
+++ b/Ladybird/cmake/InstallRules.cmake
@@ -18,6 +18,16 @@ install(TARGETS ladybird
     DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
+install(TARGETS SQLServer
+  EXPORT ladybirdTargets
+  RUNTIME
+    COMPONENT ladybird_Runtime
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+  BUNDLE
+    COMPONENT ladybird_Runtime
+    DESTINATION bundle
+)
+
 install(TARGETS WebContent
   EXPORT ladybirdTargets
   RUNTIME
@@ -30,8 +40,9 @@ install(TARGETS WebContent
 
 include("${SERENITY_SOURCE_DIR}/Meta/Lagom/get_linked_lagom_libraries.cmake")
 get_linked_lagom_libraries(ladybird ladybird_lagom_libraries)
+get_linked_lagom_libraries(SQLServer sqlserver_lagom_libraries)
 get_linked_lagom_libraries(WebContent webcontent_lagom_libraries)
-list(APPEND all_required_lagom_libraries ${ladybird_lagom_libraries} ${webcontent_lagom_libraries})
+list(APPEND all_required_lagom_libraries ${ladybird_lagom_libraries} ${sqlserver_lagom_libraries} ${webcontent_lagom_libraries})
 list(REMOVE_DUPLICATES all_required_lagom_libraries)
 
 install(TARGETS ${all_required_lagom_libraries}


### PR DESCRIPTION
Install the SQLServer binary added in 2cb3ae132a5bc7e42ea36d01801c2466da78b2bf so that it's actually available on the target system when doing a standalone build of Ladybird.