### PR TITLE
LibGUI: Fix highlighting of elements in TreeView

### DIFF
--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -775,6 +775,7 @@ Gfx::IntRect TreeView::content_rect(ModelIndex const& index) const
     traverse_in_paint_order([&](ModelIndex const& current_index, Gfx::IntRect const& rect, Gfx::IntRect const&, int) {
         if (index == current_index) {
             found_rect = rect;
+            found_rect.translate_by(0, column_header().height());
             return IterationDecision::Break;
         }
         return IterationDecision::Continue;


### PR DESCRIPTION
Previously, incorrect items were highlighted when hovering over elements in TreeView when there was a column header.

Fixes #15761 