### PR TITLE
LibGUI: Don't highlight extension text when saving files with FilePicker

### DIFF
--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -153,8 +153,17 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
     m_filename_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("filename_textbox");
     m_filename_textbox->set_focus(true);
     if (m_mode == Mode::Save) {
+        LexicalPath lexical_filename { filename };
         m_filename_textbox->set_text(filename);
-        m_filename_textbox->select_all();
+
+        if (auto extension = lexical_filename.extension(); !extension.is_empty()) {
+            TextPosition start_of_filename { 0, 0 };
+            TextPosition end_of_filename { 0, filename.length() - extension.length() - 1 };
+
+            m_filename_textbox->set_selection({ end_of_filename, start_of_filename });
+        } else {
+            m_filename_textbox->select_all();
+        }
     }
     m_filename_textbox->on_return_pressed = [&] {
         on_file_return();


### PR DESCRIPTION
By default, only highlight the base name of the file to-be-saved. When the file includes an extension, it's useful to be able to just start typing a file name without having to manually de-select the extension (or having to rewrite the extension).

[Screencast from 2023-01-03 08-34-03.webm](https://user-images.githubusercontent.com/5600524/210368258-4bd6f2cb-9e28-4b2d-91ac-6d02d17c2ca7.webm)
