### PR TITLE
Kernel/aarch64: Make it build, GNU edition

### DIFF
--- a/Kernel/Arch/aarch64/RPi/InterruptController.h
+++ b/Kernel/Arch/aarch64/RPi/InterruptController.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <AK/Types.h>
 #include <Kernel/Arch/aarch64/IRQController.h>
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -544,6 +544,8 @@ set(SOURCES
 
 add_compile_options(-fsigned-char)
 add_compile_options(-Wno-unknown-warning-option -Wvla -Wnull-dereference)
+# -Wvolatile is broken in C++20 and GCC will report bogus errors around it.
+add_compile_options(-Wno-volatile)
 add_compile_options(-fno-rtti -ffreestanding -fbuiltin)
 
 if ("${SERENITY_ARCH}" STREQUAL "x86_64")


### PR DESCRIPTION
Disable -Wvolatile because that is totally and utterly broken and will hopefully be removed in C++23.