### PR TITLE
Everywhere: Remove and forbid #include <LibC/XXX

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -11,7 +11,7 @@
 #include <AK/Variant.h>
 
 #if defined(AK_OS_SERENITY) && defined(KERNEL)
-#    include <LibC/errno_codes.h>
+#    include <errno_codes.h>
 #else
 #    include <errno.h>
 #    include <string.h>

--- a/AK/NoAllocationGuard.h
+++ b/AK/NoAllocationGuard.h
@@ -12,8 +12,8 @@
 #if defined(KERNEL)
 #    include <Kernel/Arch/Processor.h>
 #    include <Kernel/Heap/kmalloc.h>
-#else
-#    include <LibC/mallocdefs.h>
+#elif defined(AK_OS_SERENITY)
+#    include <mallocdefs.h>
 #endif
 
 namespace AK {

--- a/Tests/LibC/TestAbort.cpp
+++ b/Tests/LibC/TestAbort.cpp
@@ -6,7 +6,6 @@
 
 #include <LibTest/TestCase.h>
 
-#include <assert.h> // FIXME: Remove when `_abort` is moved to <stdlib.h>
 #include <signal.h>
 #include <stdlib.h>
 

--- a/Tests/LibC/TestMalloc.cpp
+++ b/Tests/LibC/TestMalloc.cpp
@@ -6,8 +6,8 @@
 
 #include <LibTest/TestCase.h>
 
-#include <LibC/mallocdefs.h>
 #include <errno.h>
+#include <mallocdefs.h>
 #include <stdlib.h>
 
 TEST_CASE(malloc_limits)

--- a/Tests/LibC/TestMemalign.cpp
+++ b/Tests/LibC/TestMemalign.cpp
@@ -6,7 +6,7 @@
 
 #include <LibTest/TestCase.h>
 
-#include <LibC/mallocdefs.h>
+#include <mallocdefs.h>
 #include <stdlib.h>
 
 static constexpr size_t runs = 5000;

--- a/Tests/LibELF/test-elf.cpp
+++ b/Tests/LibELF/test-elf.cpp
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibC/elf.h>
 #include <LibCore/File.h>
 #include <LibTest/TestCase.h>
+#include <elf.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>

--- a/Tests/LibRegex/RegexLibC.cpp
+++ b/Tests/LibRegex/RegexLibC.cpp
@@ -8,7 +8,7 @@
 
 #include <AK/StringBuilder.h>
 #include <AK/Vector.h>
-#include <LibC/regex.h>
+#include <regex.h>
 #include <stdio.h>
 
 TEST_CASE(catch_all)

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -11,8 +11,6 @@
 #include <AK/Types.h>
 #include <AK/URL.h>
 #include <Applications/CrashReporter/CrashReporterWindowGML.h>
-#include <LibC/serenity.h>
-#include <LibC/spawn.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
@@ -39,6 +37,8 @@
 #include <LibGUI/Window.h>
 #include <LibMain/Main.h>
 #include <LibThreading/BackgroundAction.h>
+#include <serenity.h>
+#include <spawn.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -11,7 +11,6 @@
 #include <AK/Platform.h>
 #include <AK/StringBuilder.h>
 #include <AK/Try.h>
-#include <LibC/sys/arch/regs.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibDebug/DebugInfo.h>
@@ -23,6 +22,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/arch/regs.h>
 #include <unistd.h>
 
 RefPtr<Line::Editor> editor;

--- a/Userland/DynamicLoader/main.cpp
+++ b/Userland/DynamicLoader/main.cpp
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibC/sys/internals.h>
-#include <LibC/unistd.h>
 #include <LibELF/AuxiliaryVector.h>
 #include <LibELF/DynamicLinker.h>
 #include <LibELF/Relocation.h>
+#include <sys/internals.h>
+#include <unistd.h>
 
 char* __static_environ[] = { nullptr }; // We don't get the environment without some libc workarounds..
 

--- a/Userland/Libraries/LibC/bits/stdio_file_implementation.h
+++ b/Userland/Libraries/LibC/bits/stdio_file_implementation.h
@@ -9,9 +9,9 @@
 #include <AK/Array.h>
 #include <AK/IntrusiveList.h>
 #include <AK/Types.h>
-#include <LibC/bits/FILE.h>
-#include <LibC/bits/pthread_integration.h>
-#include <LibC/bits/wchar.h>
+#include <bits/FILE.h>
+#include <bits/pthread_integration.h>
+#include <bits/wchar.h>
 #include <pthread.h>
 #include <sys/types.h>
 

--- a/Userland/Libraries/LibC/cxxabi.cpp
+++ b/Userland/Libraries/LibC/cxxabi.cpp
@@ -9,9 +9,9 @@
 #include <AK/Debug.h>
 #include <AK/Format.h>
 #include <AK/NeverDestroyed.h>
-#include <LibC/bits/pthread_integration.h>
-#include <LibC/mallocdefs.h>
 #include <assert.h>
+#include <bits/pthread_integration.h>
+#include <mallocdefs.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/Userland/Libraries/LibC/ifaddrs.cpp
+++ b/Userland/Libraries/LibC/ifaddrs.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibC/errno.h>
-#include <LibC/ifaddrs.h>
+#include <errno.h>
+#include <ifaddrs.h>
 
 int getifaddrs(struct ifaddrs**)
 {

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -16,7 +16,7 @@
 #include <AK/Math.h>
 #include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
-#include <LibC/assert.h>
+#include <assert.h>
 #include <fenv.h>
 #include <math.h>
 #include <stdint.h>

--- a/Userland/Libraries/LibC/net.cpp
+++ b/Userland/Libraries/LibC/net.cpp
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibC/errno.h>
-#include <LibC/net/if.h>
-#include <LibC/netinet/in.h>
+#include <errno.h>
+#include <net/if.h>
+#include <netinet/in.h>
 
 const in6_addr in6addr_any = IN6ADDR_ANY_INIT;
 const in6_addr in6addr_loopback = IN6ADDR_LOOPBACK_INIT;

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -11,9 +11,9 @@
 #include <AK/PrintfImplementation.h>
 #include <AK/ScopedValueRollback.h>
 #include <AK/StdLibExtras.h>
-#include <LibC/bits/mutex_locker.h>
-#include <LibC/bits/stdio_file_implementation.h>
 #include <assert.h>
+#include <bits/mutex_locker.h>
+#include <bits/stdio_file_implementation.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdarg.h>

--- a/Userland/Libraries/LibDebug/DebugSession.h
+++ b/Userland/Libraries/LibDebug/DebugSession.h
@@ -13,12 +13,12 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
-#include <LibC/sys/arch/regs.h>
 #include <LibCore/MappedFile.h>
 #include <LibDebug/DebugInfo.h>
 #include <LibDebug/ProcessInspector.h>
 #include <signal.h>
 #include <stdio.h>
+#include <sys/arch/regs.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/Userland/Libraries/LibDebug/ProcessInspector.h
+++ b/Userland/Libraries/LibDebug/ProcessInspector.h
@@ -9,7 +9,7 @@
 
 #include "LoadedLibrary.h"
 #include <AK/Types.h>
-#include <LibC/sys/arch/regs.h>
+#include <sys/arch/regs.h>
 
 namespace Debug {
 

--- a/Userland/Services/SpiceAgent/SpiceAgent.cpp
+++ b/Userland/Services/SpiceAgent/SpiceAgent.cpp
@@ -7,14 +7,14 @@
 #include "SpiceAgent.h"
 #include "ConnectionToClipboardServer.h"
 #include <AK/DeprecatedString.h>
-#include <LibC/memory.h>
-#include <LibC/unistd.h>
 #include <LibGfx/BMPLoader.h>
 #include <LibGfx/BMPWriter.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/JPGLoader.h>
 #include <LibGfx/PNGLoader.h>
 #include <LibGfx/PNGWriter.h>
+#include <memory.h>
+#include <unistd.h>
 
 SpiceAgent::SpiceAgent(int fd, ConnectionToClipboardServer& connection)
     : m_fd(fd)

--- a/Userland/Services/SpiceAgent/main.cpp
+++ b/Userland/Services/SpiceAgent/main.cpp
@@ -5,10 +5,10 @@
  */
 
 #include "SpiceAgent.h"
-#include <LibC/fcntl.h>
 #include <LibCore/System.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <LibMain/Main.h>
+#include <fcntl.h>
 
 static constexpr auto SPICE_DEVICE = "/dev/hvc0p1"sv;
 

--- a/Userland/Utilities/functrace.cpp
+++ b/Userland/Utilities/functrace.cpp
@@ -9,7 +9,6 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/StringBuilder.h>
 #include <Kernel/API/SyscallString.h>
-#include <LibC/sys/arch/regs.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
@@ -21,6 +20,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/arch/regs.h>
 #include <syscall.h>
 #include <unistd.h>
 

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -10,7 +10,6 @@
 #include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <Kernel/API/SyscallString.h>
-#include <LibC/sys/arch/regs.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/Stream.h>
 #include <LibCore/System.h>
@@ -21,6 +20,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/arch/regs.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/ptrace.h>


### PR DESCRIPTION
Found while trying to clean up unrelated things. (Sneak peek: I'm automating my script that removes completely-unused headers.)

In this PR:
- Drive-by commit that removes a stale FIXME. Yay!
- AK used to include a LibC file when building for Lagom, but only accidentally so. This restricts the include to builds of SerenityOS itself.
- Finally, remove 20 instances of `#include <LibC/XXX`, and add a linter rule against new such instances.

About the linter rule exceptions:
- The Kernel can include files from LibC just fine, but I decided against touching this because this way it's clearer that the Kernel has weird userland-dependencies.
- LibELF and LibRegex are used when building for Lagom, so `LibC` must be part of the include path.

The full list seems to be:

```
$ git grep -Ei '<LibC/' Kernel/
Kernel/API/InodeWatcherEvent.h:#    include <LibC/limits.h>
Kernel/Arch/aarch64/RegisterState.h:#include <LibC/sys/arch/aarch64/regs.h>
Kernel/Arch/x86_64/Interrupts.cpp:#include <LibC/mallocdefs.h>
Kernel/Arch/x86_64/RegisterState.h:#include <LibC/sys/arch/regs.h>
Kernel/Coredump.cpp:#include <LibC/elf.h>
Kernel/Devices/Audio/Channel.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/Devices/HID/KeyboardDevice.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/Devices/KCOVDevice.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/FileSystem/InodeFile.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/Graphics/DisplayConnector.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/Graphics/DisplayConnector.h:#include <LibC/sys/ioctl_numbers.h>
Kernel/Graphics/VirtIOGPU/GPU3DDevice.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/Heap/kmalloc.h:#include <LibC/limits.h>
Kernel/Memory/VirtualRange.cpp:#include <LibC/limits.h>
Kernel/Net/IPv4Socket.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/Net/LocalSocket.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/Prekernel/init.cpp:#include <LibC/elf.h>
Kernel/Process.cpp:#include <LibC/limits.h>
Kernel/Process.h:#include <LibC/elf.h>
Kernel/Process.h:#include <LibC/signal_numbers.h>
Kernel/Storage/StorageDevice.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/Syscalls/execve.cpp:#include <LibC/limits.h>
Kernel/Syscalls/ioctl.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/Syscalls/jail.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/Syscalls/mmap.cpp:#include <LibC/limits.h>
Kernel/Syscalls/prctl.cpp:#include <LibC/sys/prctl_numbers.h>
Kernel/TTY/MasterPTY.cpp:#include <LibC/signal_numbers.h>
Kernel/TTY/MasterPTY.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/TTY/TTY.cpp:#include <LibC/signal_numbers.h>
Kernel/TTY/TTY.cpp:#include <LibC/sys/ioctl_numbers.h>
Kernel/TTY/TTY.cpp:#include <LibC/sys/ttydefaults.h>
Kernel/Thread.cpp:#include <LibC/signal_numbers.h>
Kernel/Thread.h:#include <LibC/fd_set.h>
Kernel/Thread.h:#include <LibC/signal_numbers.h>
Kernel/ThreadTracer.h:#include <LibC/sys/arch/regs.h>
Kernel/kprintf.cpp:#include <LibC/stdarg.h>
```