### PR TITLE
Meta: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+/Userland/Applications/CrashReporter @linusg
+/Userland/Libraries/LibJS @linusg
+/Userland/Libraries/LibWeb/Fetch @linusg
+/Userland/Libraries/LibWeb/HTML/Scripting @linusg
+/Userland/Libraries/LibWeb/Infra @linusg
+/Userland/Libraries/LibWeb/WebDriver @linusg
+/Userland/Libraries/LibWeb/WebIDL @linusg
+/Userland/Utilities/js.cpp @linusg
+*.js @linusg


### PR DESCRIPTION
These are the areas of the system where I'd like GitHub to inform me about changes, other maintainers are of course free to add themselves.

Subscribing to all notifications and using email filters is no longer practical :^)

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners