### PR TITLE
LibGL: Two small platform type updates

### DIFF
--- a/Userland/Libraries/LibGL/Buffer.cpp
+++ b/Userland/Libraries/LibGL/Buffer.cpp
@@ -61,7 +61,7 @@ void GLContext::gl_buffer_sub_data(GLenum target, GLintptr offset, GLsizeiptr si
 
     auto& target_buffer = target == GL_ELEMENT_ARRAY_BUFFER ? m_element_array_buffer : m_array_buffer;
     RETURN_WITH_ERROR_IF(!target_buffer, GL_INVALID_OPERATION);
-    RETURN_WITH_ERROR_IF((offset + size) > target_buffer->size(), GL_INVALID_VALUE);
+    RETURN_WITH_ERROR_IF(static_cast<size_t>(offset + size) > target_buffer->size(), GL_INVALID_VALUE);
 
     target_buffer->replace_data(data, offset, size);
 }

--- a/Userland/Libraries/LibGL/GL/glplatform.h
+++ b/Userland/Libraries/LibGL/GL/glplatform.h
@@ -32,7 +32,7 @@ typedef long GLintptr;
 typedef unsigned int GLuint;
 typedef int GLfixed;
 typedef int GLsizei;
-typedef unsigned long GLsizeiptr;
+typedef long GLsizeiptr;
 typedef void GLvoid;
 typedef float GLfloat;
 typedef double GLclampd;

--- a/Userland/Libraries/LibGL/GL/glplatform.h
+++ b/Userland/Libraries/LibGL/GL/glplatform.h
@@ -28,8 +28,10 @@ typedef unsigned char GLboolean;
 typedef short GLshort;
 typedef unsigned short GLushort;
 typedef int GLint;
+typedef long GLint64;
 typedef long GLintptr;
 typedef unsigned int GLuint;
+typedef unsigned long GLuint64;
 typedef int GLfixed;
 typedef int GLsizei;
 typedef long GLsizeiptr;
@@ -40,11 +42,3 @@ typedef float GLclampf;
 typedef double GLdouble;
 typedef unsigned int GLenum;
 typedef unsigned int GLbitfield;
-
-#if defined(__x86_64__) || defined(__aarch64__)
-typedef long GLint64;
-typedef unsigned long GLuint64;
-#else
-typedef long long GLint64;
-typedef unsigned long long GLuint64;
-#endif


### PR DESCRIPTION
* We defined `GLsizeiptr` as the wrong type, causing compilation to fail for ports that would pull in SDL2's definition of this type
* We had i686-specific types that we no longer need now that i686's gone