### PR TITLE
Kernel: Repair build for aarch64

### DIFF
--- a/Kernel/Arch/aarch64/RPi/InterruptController.h
+++ b/Kernel/Arch/aarch64/RPi/InterruptController.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <AK/Types.h>
 #include <Kernel/Arch/aarch64/IRQController.h>
 


### PR DESCRIPTION
This broke in 6fd478b6ce6e717132a5e9a9a907d0e56916701f due to insufficient testing on my part. Sorry!

Thankfully, I seem to be the first person to notice this, so noone else got hurt by this. I'll now build aarch64 before touching any file in that directory! :)