### PR TITLE
LibGUI: Stop duplicating mouse events of cursor tracking widget

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -385,8 +385,8 @@ void Window::handle_mouse_event(MouseEvent& event)
         } else {
             auto is_hovered = m_automatic_cursor_tracking_widget.ptr() == result.widget.ptr();
             set_hovered_widget(is_hovered ? m_automatic_cursor_tracking_widget.ptr() : nullptr);
-            return;
         }
+        return;
     }
     set_hovered_widget(result.widget);
     if (event.buttons() != 0 && !m_automatic_cursor_tracking_widget)


### PR DESCRIPTION
Previously we didn't always return when there was an automatic cursor tracking widget. This meant for certain events e.g. a MouseUp over the tracking widget, the event would be fired twice on the same widget (once on `m_automatic_cursor_tracking_widget` then again on `result.widget` outside the if).

Fixes #16737

This appears to have just been a mistake in the changes from https://github.com/SerenityOS/serenity/commit/5b02e6a46b8349babcb54c2363484232fbef0b30
