### PR TITLE
WindowServer: Do not add existing menu items (by ptr) to m_menus

### DIFF
--- a/Userland/Services/WindowServer/Menubar.h
+++ b/Userland/Services/WindowServer/Menubar.h
@@ -18,7 +18,20 @@ class Menubar {
 public:
     void add_menu(Menu& menu, Gfx::IntRect window_rect)
     {
-        // FIXME: Check against duplicate menu additions.
+        bool duplicate_menu_detected = false;
+
+        for_each_menu([&](Menu& existing_menu) {
+            if (&menu == &existing_menu) {
+                dbgln("Duplicate Menu \"{}\" ({})", menu.name(), &menu);
+                duplicate_menu_detected = true;
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
+        if (duplicate_menu_detected) {
+            return;
+        }
+
         m_menus.append(menu);
         layout_menu(menu, window_rect);
     }


### PR DESCRIPTION
This resolves a fixme requesting that we do not add duplicate menus