### PR TITLE
Meta: Add $SERENITY_CUSTOM_QEMU_ARGS to qemu cmd

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -502,5 +502,6 @@ else
         $SERENITY_PACKET_LOGGING_ARG \
         $SERENITY_NETFLAGS_WITH_DEFAULT_DEVICE \
         $SERENITY_KERNEL_AND_INITRD \
-        -append "${SERENITY_KERNEL_CMDLINE}"
+        -append "${SERENITY_KERNEL_CMDLINE}" \
+        
 fi


### PR DESCRIPTION
This PR adds `$SERENITY_CUSTOM_QEMU_ARGS` to the qemu run command

The use case for this is passing `-full-screen` to the qemu run command (on Mac, the normal qemu window is not resizable and the bottom is cut off)

This PR is more of an idea at this point, and I'm putting it out there to see if anyone else thinks it's a good idea! 