### PR TITLE
Lagom: Fix up a missed usage of `Compress::Zlib` in the fuzzers

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzZlibDecompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzZlibDecompression.cpp
@@ -9,6 +9,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    (void)Compress::Zlib::decompress_all(ReadonlyBytes { data, size });
+    (void)Compress::ZlibDecompressor::decompress_all(ReadonlyBytes { data, size });
     return 0;
 }


### PR DESCRIPTION
This should get CI going again.