### PR TITLE
Ports: Unbreak ScummVM icon pack generation

### DIFF
--- a/Ports/scummvm/package.sh
+++ b/Ports/scummvm/package.sh
@@ -32,7 +32,7 @@ function post_install() {
         git clone https://github.com/scummvm/scummvm-icons "$(basename ${icons_build_dir})"
         cd "$(basename ${icons_build_dir})"
 
-        ./gen-set.py 19700101
+        ./gen-set.py 20210825
         cp gui-icons-*.dat "${SERENITY_INSTALL_ROOT}/usr/local/share/scummvm/gui-icons.dat"
     fi
 }


### PR DESCRIPTION
The ScummVM icon repository no longer accepts "1970-01-01" as a valid start date for the icon pack generation. We now use the oldest commit date in the repository which _is_ accepted.