### PR TITLE
LibIPC: Remove some encoding inconsistencies and footguns

### DIFF
--- a/Userland/Libraries/LibIPC/Decoder.cpp
+++ b/Userland/Libraries/LibIPC/Decoder.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/JsonValue.h>
+#include <AK/NumericLimits.h>
 #include <AK/URL.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/DateTime.h>
@@ -16,19 +17,24 @@
 
 namespace IPC {
 
+ErrorOr<size_t> Decoder::decode_size()
+{
+    return static_cast<size_t>(TRY(decode<u32>()));
+}
+
 template<>
 ErrorOr<DeprecatedString> decode(Decoder& decoder)
 {
-    auto length = TRY(decoder.decode<i32>());
-    if (length < 0)
+    auto length = TRY(decoder.decode_size());
+    if (length == NumericLimits<u32>::max())
         return DeprecatedString {};
     if (length == 0)
         return DeprecatedString::empty();
 
     char* text_buffer = nullptr;
-    auto text_impl = StringImpl::create_uninitialized(static_cast<size_t>(length), text_buffer);
+    auto text_impl = StringImpl::create_uninitialized(length, text_buffer);
 
-    Bytes bytes { text_buffer, static_cast<size_t>(length) };
+    Bytes bytes { text_buffer, length };
     TRY(decoder.decode_into(bytes));
 
     return DeprecatedString { *text_impl };
@@ -37,8 +43,8 @@ ErrorOr<DeprecatedString> decode(Decoder& decoder)
 template<>
 ErrorOr<ByteBuffer> decode(Decoder& decoder)
 {
-    auto length = TRY(decoder.decode<i32>());
-    if (length <= 0)
+    auto length = TRY(decoder.decode_size());
+    if (length == 0)
         return ByteBuffer {};
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(length));
@@ -65,10 +71,7 @@ ErrorOr<URL> decode(Decoder& decoder)
 template<>
 ErrorOr<Dictionary> decode(Decoder& decoder)
 {
-    auto size = TRY(decoder.decode<u64>());
-    if (size >= NumericLimits<i32>::max())
-        VERIFY_NOT_REACHED();
-
+    auto size = TRY(decoder.decode_size());
     Dictionary dictionary {};
 
     for (size_t i = 0; i < size; ++i) {
@@ -99,7 +102,7 @@ ErrorOr<Core::AnonymousBuffer> decode(Decoder& decoder)
     if (auto valid = TRY(decoder.decode<bool>()); !valid)
         return Core::AnonymousBuffer {};
 
-    auto size = TRY(decoder.decode<u32>());
+    auto size = TRY(decoder.decode_size());
     auto anon_file = TRY(decoder.decode<IPC::File>());
 
     return Core::AnonymousBuffer::create_from_anon_fd(anon_file.take_fd(), size);

--- a/Userland/Libraries/LibIPC/Decoder.h
+++ b/Userland/Libraries/LibIPC/Decoder.h
@@ -50,6 +50,8 @@ public:
         return {};
     }
 
+    ErrorOr<size_t> decode_size();
+
     Core::Stream::LocalSocket& socket() { return m_socket; }
 
 private:
@@ -96,11 +98,9 @@ ErrorOr<Empty> decode(Decoder&);
 template<Concepts::Vector T>
 ErrorOr<T> decode(Decoder& decoder)
 {
-    auto size = TRY(decoder.decode<u64>());
-    if (size > NumericLimits<i32>::max())
-        return Error::from_string_literal("IPC: Invalid Vector size");
-
     T vector;
+
+    auto size = TRY(decoder.decode_size());
     TRY(vector.try_ensure_capacity(size));
 
     for (size_t i = 0; i < size; ++i) {
@@ -114,11 +114,10 @@ ErrorOr<T> decode(Decoder& decoder)
 template<Concepts::HashMap T>
 ErrorOr<T> decode(Decoder& decoder)
 {
-    auto size = TRY(decoder.decode<u32>());
-    if (size > NumericLimits<i32>::max())
-        return Error::from_string_literal("IPC: Invalid HashMap size");
-
     T hashmap;
+
+    auto size = TRY(decoder.decode_size());
+    TRY(hashmap.try_ensure_capacity(size));
 
     for (size_t i = 0; i < size; ++i) {
         auto key = TRY(decoder.decode<typename T::KeyType>());

--- a/Userland/Libraries/LibIPC/Encoder.cpp
+++ b/Userland/Libraries/LibIPC/Encoder.cpp
@@ -44,6 +44,11 @@ ErrorOr<void> encode(Encoder& encoder, double const& value)
 template<>
 ErrorOr<void> encode(Encoder& encoder, StringView const& value)
 {
+    // NOTE: Do not change this encoding without also updating LibC/netdb.cpp.
+    if (value.is_null())
+        return encoder.encode(NumericLimits<u32>::max());
+
+    TRY(encoder.encode_size(value.length()));
     TRY(encoder.append(reinterpret_cast<u8 const*>(value.characters_without_null_termination()), value.length()));
     return {};
 }
@@ -51,13 +56,7 @@ ErrorOr<void> encode(Encoder& encoder, StringView const& value)
 template<>
 ErrorOr<void> encode(Encoder& encoder, DeprecatedString const& value)
 {
-    // NOTE: Do not change this encoding without also updating LibC/netdb.cpp.
-    if (value.is_null())
-        return encoder.encode(NumericLimits<u32>::max());
-
-    TRY(encoder.encode_size(value.length()));
-    TRY(encoder.encode(value.view()));
-    return {};
+    return encoder.encode(value.view());
 }
 
 template<>

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -60,9 +60,6 @@ public:
     ErrorOr<void> encode_size(size_t size);
 
 private:
-    void encode_u32(u32);
-    void encode_u64(u64);
-
     MessageBuffer& m_buffer;
 };
 

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -57,6 +57,8 @@ public:
         return m_buffer.fds.try_append(move(auto_fd));
     }
 
+    ErrorOr<void> encode_size(size_t size);
+
 private:
     void encode_u32(u32);
     void encode_u64(u64);
@@ -134,7 +136,8 @@ ErrorOr<void> encode(Encoder&, Empty const&);
 template<Concepts::Vector T>
 ErrorOr<void> encode(Encoder& encoder, T const& vector)
 {
-    TRY(encoder.encode(static_cast<u64>(vector.size())));
+    // NOTE: Do not change this encoding without also updating LibC/netdb.cpp.
+    TRY(encoder.encode_size(vector.size()));
 
     for (auto const& value : vector)
         TRY(encoder.encode(value));
@@ -145,7 +148,7 @@ ErrorOr<void> encode(Encoder& encoder, T const& vector)
 template<Concepts::HashMap T>
 ErrorOr<void> encode(Encoder& encoder, T const& hashmap)
 {
-    TRY(encoder.encode(static_cast<u32>(hashmap.size())));
+    TRY(encoder.encode_size(hashmap.size()));
 
     for (auto it : hashmap) {
         TRY(encoder.encode(it.key));


### PR DESCRIPTION
These are things that tripped me up more times than I can to admit while working on #16637 and #16770, but I didn't want to change behavior too much in those PRs beyond the fallible changes.