### PR TITLE
Presenter: Add editing functionality

### DIFF
--- a/Userland/Applications/Presenter/Presentation.cpp
+++ b/Userland/Applications/Presenter/Presentation.cpp
@@ -147,7 +147,7 @@ ErrorOr<Gfx::IntSize> Presentation::parse_presentation_size(JsonObject const& me
     };
 }
 
-void Presentation::paint(Gfx::Painter& painter) const
+void Presentation::paint(Gfx::Painter& painter)
 {
     auto display_area = painter.clip_rect();
     // These two should be the same, but better be safe than sorry.

--- a/Userland/Applications/Presenter/Presentation.cpp
+++ b/Userland/Applications/Presenter/Presentation.cpp
@@ -148,6 +148,37 @@ ErrorOr<Gfx::IntSize> Presentation::parse_presentation_size(JsonObject const& me
     };
 }
 
+JsonObject Presentation::to_json() const
+{
+    JsonObject json_object;
+    json_object.set("version", PRESENTATION_FORMAT_VERSION);
+    json_object.set("slides", slides_to_json());
+    json_object.set("metadata", metadata_to_json());
+    auto json_string = json_object.to_deprecated_string();
+
+    return json_object;
+}
+
+JsonObject Presentation::metadata_to_json() const
+{
+    JsonObject metadata_object;
+    metadata_object.set("author", m_metadata.author);
+    metadata_object.set("last-modified"sv, m_metadata.last_modified);
+    metadata_object.set("title", m_metadata.title);
+    metadata_object.set("aspect"sv, m_metadata.aspect_ratio);
+    metadata_object.set("width"sv, m_metadata.width);
+    return metadata_object;
+}
+
+JsonArray Presentation::slides_to_json() const
+{
+    JsonArray slides;
+    for (auto const& slide : m_slides) {
+        slides.append(slide.to_json());
+    }
+    return slides;
+}
+
 void Presentation::paint(Gfx::Painter& painter)
 {
     auto display_area = painter.clip_rect();

--- a/Userland/Applications/Presenter/Presentation.h
+++ b/Userland/Applications/Presenter/Presentation.h
@@ -52,12 +52,16 @@ public:
     // This assumes that the caller has clipped the painter to exactly the display area.
     void paint(Gfx::Painter& painter);
 
+    JsonObject to_json() const;
+
 private:
     static Metadata parse_metadata(JsonObject const& metadata_object);
     static ErrorOr<Gfx::IntSize> parse_presentation_size(JsonObject const& metadata_object);
 
     Presentation(Gfx::IntSize normative_size, Metadata metadata, DeprecatedString file_path);
     static NonnullOwnPtr<Presentation> construct(Gfx::IntSize normative_size, Metadata metadata, DeprecatedString file_path);
+    JsonObject metadata_to_json() const;
+    JsonArray slides_to_json() const;
 
     void append_slide(Slide slide);
 

--- a/Userland/Applications/Presenter/Presentation.h
+++ b/Userland/Applications/Presenter/Presentation.h
@@ -30,7 +30,7 @@ public:
     StringView author() const;
     Gfx::IntSize normative_size() const { return m_normative_size; }
 
-    Slide const& current_slide() const { return m_slides[m_current_slide.value()]; }
+    Slide& current_slide() { return m_slides[m_current_slide.value()]; }
     unsigned current_slide_number() const { return m_current_slide.value(); }
     unsigned current_frame_in_slide_number() const { return m_current_frame_in_slide.value(); }
 
@@ -39,7 +39,7 @@ public:
     void go_to_first_slide();
 
     // This assumes that the caller has clipped the painter to exactly the display area.
-    void paint(Gfx::Painter& painter) const;
+    void paint(Gfx::Painter& painter);
 
 private:
     static HashMap<DeprecatedString, DeprecatedString> parse_metadata(JsonObject const& metadata_object);

--- a/Userland/Applications/Presenter/Presentation.h
+++ b/Userland/Applications/Presenter/Presentation.h
@@ -17,6 +17,14 @@
 
 static constexpr int const PRESENTATION_FORMAT_VERSION = 1;
 
+struct Metadata {
+    DeprecatedString author;
+    DeprecatedString title;
+    DeprecatedString last_modified;
+    int width;
+    DeprecatedString aspect_ratio;
+};
+
 // In-memory representation of the presentation stored in a file.
 // This class also contains all the parser code for loading .presenter files.
 class Presentation {
@@ -26,6 +34,7 @@ public:
     // We can't pass this class directly in an ErrorOr because some of the components are not properly moveable under these conditions.
     static ErrorOr<NonnullOwnPtr<Presentation>> load_from_file(StringView file_name, NonnullRefPtr<GUI::Window> window);
 
+    StringView file_path() const { return m_file_path; }
     StringView title() const;
     StringView author() const;
     Gfx::IntSize normative_size() const { return m_normative_size; }
@@ -33,6 +42,8 @@ public:
     Slide& current_slide() { return m_slides[m_current_slide.value()]; }
     unsigned current_slide_number() const { return m_current_slide.value(); }
     unsigned current_frame_in_slide_number() const { return m_current_frame_in_slide.value(); }
+
+    void set_file_path(DeprecatedString file_path) { m_file_path = move(file_path); }
 
     void next_frame();
     void previous_frame();
@@ -42,18 +53,20 @@ public:
     void paint(Gfx::Painter& painter);
 
 private:
-    static HashMap<DeprecatedString, DeprecatedString> parse_metadata(JsonObject const& metadata_object);
+    static Metadata parse_metadata(JsonObject const& metadata_object);
     static ErrorOr<Gfx::IntSize> parse_presentation_size(JsonObject const& metadata_object);
 
-    Presentation(Gfx::IntSize normative_size, HashMap<DeprecatedString, DeprecatedString> metadata);
-    static NonnullOwnPtr<Presentation> construct(Gfx::IntSize normative_size, HashMap<DeprecatedString, DeprecatedString> metadata);
+    Presentation(Gfx::IntSize normative_size, Metadata metadata, DeprecatedString file_path);
+    static NonnullOwnPtr<Presentation> construct(Gfx::IntSize normative_size, Metadata metadata, DeprecatedString file_path);
 
     void append_slide(Slide slide);
+
+    DeprecatedString m_file_path;
 
     Vector<Slide> m_slides {};
     // This is not a pixel size, but an abstract size used by the slide objects for relative positioning.
     Gfx::IntSize m_normative_size;
-    HashMap<DeprecatedString, DeprecatedString> m_metadata;
+    Metadata m_metadata;
 
     Checked<unsigned> m_current_slide { 0 };
     Checked<unsigned> m_current_frame_in_slide { 0 };

--- a/Userland/Applications/Presenter/PresenterWidget.h
+++ b/Userland/Applications/Presenter/PresenterWidget.h
@@ -32,8 +32,11 @@ protected:
     virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
+    virtual void mousedown_event(GUI::MouseEvent&) override;
 
 private:
+    Gfx::IntRect presentation_rect();
+
     OwnPtr<Presentation> m_current_presentation;
     RefPtr<GUI::Action> m_next_slide_action;
     RefPtr<GUI::Action> m_previous_slide_action;

--- a/Userland/Applications/Presenter/Slide.cpp
+++ b/Userland/Applications/Presenter/Slide.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Slide.h"
+#include "SlideObject.h"
 #include <AK/JsonObject.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <LibGUI/Window.h>
@@ -50,4 +51,9 @@ void Slide::paint(Gfx::Painter& painter, unsigned int current_frame, Gfx::FloatS
 
     // FIXME: Move this to user settings.
     painter.draw_text(painter.clip_rect(), title(), Gfx::TextAlignment::BottomCenter);
+}
+
+void Slide::add_slide_object(NonnullRefPtr<SlideObject> slide_object)
+{
+    m_slide_objects.append(move(slide_object));
 }

--- a/Userland/Applications/Presenter/Slide.cpp
+++ b/Userland/Applications/Presenter/Slide.cpp
@@ -57,3 +57,18 @@ void Slide::add_slide_object(NonnullRefPtr<SlideObject> slide_object)
 {
     m_slide_objects.append(move(slide_object));
 }
+
+JsonObject Slide::to_json() const
+{
+    JsonObject json;
+    json.set("title"sv, m_title);
+    JsonArray json_slide_objects;
+    for (auto& slide_object : slide_objects()) {
+        JsonObject object;
+        object.set("type"sv, slide_object.type());
+        slide_object.save_to(object);
+        json_slide_objects.append(move(object));
+    }
+    json.set("objects"sv, move(json_slide_objects));
+    return json;
+}

--- a/Userland/Applications/Presenter/Slide.h
+++ b/Userland/Applications/Presenter/Slide.h
@@ -20,10 +20,12 @@ public:
     // FIXME: shouldn't be hard-coded to 1.
     unsigned frame_count() const { return 1; }
     StringView title() const { return m_title; }
+    NonnullRefPtrVector<SlideObject> slide_objects() const { return m_slide_objects; }
 
     void paint(Gfx::Painter&, unsigned current_frame, Gfx::FloatSize display_scale) const;
 
     void add_slide_object(NonnullRefPtr<SlideObject> slide_object);
+    JsonObject to_json() const;
 
 private:
     Slide(NonnullRefPtrVector<SlideObject> slide_objects, DeprecatedString title);

--- a/Userland/Applications/Presenter/Slide.h
+++ b/Userland/Applications/Presenter/Slide.h
@@ -23,6 +23,8 @@ public:
 
     void paint(Gfx::Painter&, unsigned current_frame, Gfx::FloatSize display_scale) const;
 
+    void add_slide_object(NonnullRefPtr<SlideObject> slide_object);
+
 private:
     Slide(NonnullRefPtrVector<SlideObject> slide_objects, DeprecatedString title);
 

--- a/Userland/Applications/Presenter/SlideObject.cpp
+++ b/Userland/Applications/Presenter/SlideObject.cpp
@@ -82,6 +82,18 @@ Text::Text()
     REGISTER_STRING_PROPERTY("font", font, set_font);
 }
 
+Text::Text(DeprecatedString text, Gfx::IntPoint position, DeprecatedString font, int font_size, unsigned font_weight, Gfx::Color color)
+    : m_text(move(text))
+    , m_font(font)
+    , m_font_size(font_size)
+    , m_font_weight(font_weight)
+    , m_text_alignment(Gfx::TextAlignment::TopLeft)
+{
+    // FIXME: Actually calculate the size needed to fit the text
+    m_rect = Gfx::IntRect(position, { 100, 100 });
+    m_color = color;
+}
+
 void Text::paint(Gfx::Painter& painter, Gfx::FloatSize display_scale) const
 {
     auto scaled_bounding_box = this->transformed_bounding_box(painter.clip_rect(), display_scale);

--- a/Userland/Applications/Presenter/SlideObject.h
+++ b/Userland/Applications/Presenter/SlideObject.h
@@ -48,7 +48,7 @@ protected:
 
 // Objects with a foreground color.
 class GraphicsObject : public SlideObject {
-    C_OBJECT_ABSTRACT(SlideObject);
+    C_OBJECT_ABSTRACT(GraphicsObject);
 
 public:
     virtual ~GraphicsObject() = default;
@@ -64,10 +64,11 @@ protected:
 };
 
 class Text : public GraphicsObject {
-    C_OBJECT(SlideObject);
+    C_OBJECT(Text);
 
 public:
     Text();
+    Text(DeprecatedString text, Gfx::IntPoint position, DeprecatedString font, int font_size, unsigned font_weight, Gfx::Color color);
     virtual ~Text() = default;
 
     virtual void paint(Gfx::Painter&, Gfx::FloatSize display_scale) const override;

--- a/Userland/Applications/Presenter/SlideObject.h
+++ b/Userland/Applications/Presenter/SlideObject.h
@@ -39,11 +39,13 @@ public:
 
     void set_rect(Gfx::IntRect rect) { m_rect = rect; }
     Gfx::IntRect rect() const { return m_rect; }
+    DeprecatedString type() const { return m_type; }
 
 protected:
-    SlideObject();
+    SlideObject(DeprecatedString type);
 
     Gfx::IntRect m_rect;
+    DeprecatedString m_type;
 };
 
 // Objects with a foreground color.
@@ -57,7 +59,7 @@ public:
     Gfx::Color color() const { return m_color; }
 
 protected:
-    GraphicsObject();
+    GraphicsObject(DeprecatedString type);
 
     // FIXME: Change the default color based on the color scheme
     Gfx::Color m_color { Gfx::Color::Black };

--- a/Userland/Applications/Presenter/main.cpp
+++ b/Userland/Applications/Presenter/main.cpp
@@ -15,7 +15,7 @@
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     // rpath is required to load .presenter files, unix, sendfd and recvfd are required to talk to ImageDecoder and WindowServer.
-    TRY(Core::System::pledge("stdio rpath unix sendfd recvfd"));
+    TRY(Core::System::pledge("stdio rpath wpath cpath unix sendfd recvfd"));
 
     DeprecatedString file_to_load;
     Core::ArgsParser argument_parser;


### PR DESCRIPTION
This patch enables the user to click anywhere on the slide. A pop-up will ask for some text and that text will be inserted, where the user clicked. 
It also adds the ability for the presentation to be serialized to JSON, allowing saving of files.
It always adds text in font size 16 and in Liberation Serif. 
The next step would probably be to add a tool system similar to PixelPaint. 