### PR TITLE
LibCards+Solitaire: Highlight cards beneath dragged cards that are valid targets

### DIFF
--- a/Base/etc/shellrc
+++ b/Base/etc/shellrc
@@ -2,11 +2,8 @@
 
 alias fm=FileManager
 alias mag=Magnifier
-alias ms=Minesweeper
 alias sh=Shell
-alias sn=Snake
 alias tb=Taskbar
-alias wg=WidgetGallery
 alias te=TextEditor
 alias he=HexEditor
 alias pp=PixelPaint
@@ -23,7 +20,6 @@ alias sdb=Debugger
 alias sm=SystemMonitor
 alias pv=Profiler
 alias ws=WebServer
-alias sl=Solitaire
 alias ue=UserspaceEmulator
 alias fe=FontEditor
 alias ss=Spreadsheet

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -35,15 +35,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Config::pledge_domains({ "Games", "Hearts" });
     Config::monitor_domain("Games");
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix proc exec"));
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/Hearts.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath proc exec"));
 
     TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
     TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil("/bin/GamesSettings", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto window = TRY(GUI::Window::try_create());
@@ -93,7 +94,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         game.setup(player_name);
     })));
     TRY(game_menu->try_add_separator());
-    TRY(game_menu->try_add_action(GUI::Action::create("&Settings", TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/settings.png"sv)), [&](auto&) {
+    TRY(game_menu->try_add_action(TRY(Cards::make_cards_settings_action(window))));
+    TRY(game_menu->try_add_action(GUI::Action::create("Hearts &Settings", TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/settings.png"sv)), [&](auto&) {
         change_settings();
     })));
     TRY(game_menu->try_add_separator());

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -272,6 +272,7 @@ void Game::mousedown_event(GUI::MouseEvent& event)
 void Game::mouseup_event(GUI::MouseEvent& event)
 {
     GUI::Frame::mouseup_event(event);
+    clear_hovered_card();
 
     if (!is_moving_cards() || m_game_over_animation || m_new_game_animation)
         return;
@@ -311,6 +312,18 @@ void Game::mousemove_event(GUI::MouseEvent& event)
     auto click_location = event.position();
     int dx = click_location.dx_relative_to(m_mouse_down_location);
     int dy = click_location.dy_relative_to(m_mouse_down_location);
+
+    if (auto target_stack = find_stack_to_drop_on(Cards::CardStack::MovementRule::Alternating); target_stack && !target_stack->is_empty()) {
+        if (auto& top_card = target_stack->peek(); top_card != m_hovered_card) {
+            clear_hovered_card();
+            m_hovered_card = top_card;
+
+            m_hovered_card->set_highlighted(true);
+            update(m_hovered_card->rect());
+        }
+    } else {
+        clear_hovered_card();
+    }
 
     for (auto& to_intersect : moving_cards()) {
         mark_intersecting_stacks_dirty(to_intersect);
@@ -617,6 +630,16 @@ void Game::perform_undo()
     if (on_undo_availability_change)
         on_undo_availability_change(false);
     invalidate_layout();
+}
+
+void Game::clear_hovered_card()
+{
+    if (!m_hovered_card)
+        return;
+
+    m_hovered_card->set_highlighted(false);
+    update(m_hovered_card->rect());
+    m_hovered_card = nullptr;
 }
 
 }

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -174,6 +174,7 @@ private:
     void create_new_animation_card();
     void set_background_fill_enabled(bool);
     void check_for_game_over();
+    void clear_hovered_card();
 
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
@@ -203,6 +204,8 @@ private:
     uint8_t m_passes_left_before_punishment { 0 };
 
     bool m_auto_collect { false };
+
+    RefPtr<Card> m_hovered_card;
 };
 
 }

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -27,7 +27,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix proc exec"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-solitaire"sv));
@@ -40,9 +40,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Config::pledge_domains({ "Games", "Solitaire" });
     Config::monitor_domain("Games");
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath proc exec"));
 
     TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil("/bin/GamesSettings", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto window = TRY(GUI::Window::try_create());
@@ -204,6 +205,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     undo_action->set_enabled(false);
     TRY(game_menu->try_add_action(undo_action));
     TRY(game_menu->try_add_separator());
+    TRY(game_menu->try_add_action(TRY(Cards::make_cards_settings_action(window))));
     TRY(game_menu->try_add_action(single_card_draw_action));
     TRY(game_menu->try_add_action(three_card_draw_action));
     TRY(game_menu->try_add_separator());

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -40,7 +40,7 @@ static DeprecatedString format_seconds(uint64_t seconds_elapsed)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix proc exec"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-spider"sv));
@@ -48,9 +48,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Config::pledge_domains({ "Games", "Spider" });
     Config::monitor_domain("Games");
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath proc exec"));
 
     TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil("/bin/GamesSettings", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto window = TRY(GUI::Window::try_create());
@@ -245,6 +246,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     undo_action->set_enabled(false);
     TRY(game_menu->try_add_action(undo_action));
     TRY(game_menu->try_add_separator());
+    TRY(game_menu->try_add_action(TRY(Cards::make_cards_settings_action(window))));
     TRY(game_menu->try_add_action(single_suit_action));
     TRY(game_menu->try_add_action(two_suit_action));
     TRY(game_menu->try_add_separator());

--- a/Userland/Libraries/LibCards/Card.cpp
+++ b/Userland/Libraries/LibCards/Card.cpp
@@ -26,7 +26,10 @@ void Card::paint(GUI::Painter& painter) const
     auto bitmap = [&]() {
         if (m_inverted)
             return m_upside_down ? card_painter.card_back_inverted() : card_painter.card_front_inverted(m_suit, m_rank);
-
+        if (m_highlighted) {
+            VERIFY(!m_upside_down);
+            return card_painter.card_front_highlighted(m_suit, m_rank);
+        }
         return m_upside_down ? card_painter.card_back() : card_painter.card_front(m_suit, m_rank);
     }();
     painter.blit(position(), bitmap, bitmap->rect());

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -104,6 +104,7 @@ public:
     void set_moving(bool moving) { m_moving = moving; }
     void set_upside_down(bool upside_down) { m_upside_down = upside_down; }
     void set_inverted(bool inverted) { m_inverted = inverted; }
+    void set_highlighted(bool highlighted) { m_highlighted = highlighted; }
 
     void save_old_position();
 
@@ -122,6 +123,7 @@ private:
     bool m_moving { false };
     bool m_upside_down { false };
     bool m_inverted { false };
+    bool m_highlighted { false };
 };
 
 enum class Shuffle {

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -9,9 +9,23 @@
 #include "CardGame.h"
 #include <LibCards/CardPainter.h>
 #include <LibConfig/Client.h>
+#include <LibGUI/Action.h>
+#include <LibGUI/Process.h>
+#include <LibGUI/Window.h>
 #include <LibGfx/Palette.h>
 
 namespace Cards {
+
+ErrorOr<NonnullRefPtr<GUI::Action>> make_cards_settings_action(GUI::Window* parent)
+{
+    auto action = GUI::Action::create(
+        "&Cards Settings", {}, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/games.png"sv)), [parent](auto&) {
+            GUI::Process::spawn_or_show_error(parent, "/bin/GamesSettings"sv, Array { "--open-tab", "cards" });
+        },
+        parent);
+    action->set_status_tip("Open the Game Settings for Cards");
+    return action;
+}
 
 CardGame::CardGame()
 {

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -126,5 +126,8 @@ void CardGame::set_background_color(Gfx::Color color)
     auto new_palette = palette();
     new_palette.set_color(Gfx::ColorRole::Background, color);
     set_palette(new_palette);
+
+    CardPainter::the().set_background_color(color);
 }
+
 }

--- a/Userland/Libraries/LibCards/CardGame.h
+++ b/Userland/Libraries/LibCards/CardGame.h
@@ -6,11 +6,15 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <LibCards/CardStack.h>
 #include <LibConfig/Listener.h>
+#include <LibGUI/Forward.h>
 #include <LibGUI/Frame.h>
 
 namespace Cards {
+
+ErrorOr<NonnullRefPtr<GUI::Action>> make_cards_settings_action(GUI::Window* parent = nullptr);
 
 class CardGame
     : public GUI::Frame

--- a/Userland/Libraries/LibCards/CardPainter.cpp
+++ b/Userland/Libraries/LibCards/CardPainter.cpp
@@ -102,6 +102,21 @@ NonnullRefPtr<Gfx::Bitmap> CardPainter::card_back()
     return *m_card_back;
 }
 
+NonnullRefPtr<Gfx::Bitmap> CardPainter::card_front_highlighted(Suit suit, Rank rank)
+{
+    auto suit_id = to_underlying(suit);
+    auto rank_id = to_underlying(rank);
+
+    auto& existing_bitmap = m_cards_highlighted[suit_id][rank_id];
+    if (!existing_bitmap.is_null())
+        return *existing_bitmap;
+
+    m_cards_highlighted[suit_id][rank_id] = create_card_bitmap();
+    paint_highlighted_card(*m_cards_highlighted[suit_id][rank_id], card_front(suit, rank));
+
+    return *m_cards_highlighted[suit_id][rank_id];
+}
+
 NonnullRefPtr<Gfx::Bitmap> CardPainter::card_front_inverted(Suit suit, Rank rank)
 {
     auto suit_id = to_underlying(suit);
@@ -138,6 +153,17 @@ void CardPainter::set_background_image_path(DeprecatedString path)
         paint_card_back(*m_card_back);
     if (!m_card_back_inverted.is_null())
         paint_inverted_card(*m_card_back_inverted, *m_card_back);
+}
+
+void CardPainter::set_background_color(Color background_color)
+{
+    m_background_color = background_color;
+
+    // Clear any cached card bitmaps that depend on the background color.
+    for (auto& suit_array : m_cards_highlighted) {
+        for (auto& rank_array : suit_array)
+            rank_array = nullptr;
+    }
 }
 
 NonnullRefPtr<Gfx::Bitmap> CardPainter::create_card_bitmap()
@@ -210,6 +236,19 @@ void CardPainter::paint_inverted_card(Gfx::Bitmap& bitmap, Gfx::Bitmap const& so
     painter.blit_filtered({ 0, 0 }, source_to_invert, source_to_invert.rect(), [&](Color color) {
         return color.inverted();
     });
+}
+
+void CardPainter::paint_highlighted_card(Gfx::Bitmap& bitmap, Gfx::Bitmap const& source_to_highlight)
+{
+    Gfx::Painter painter { bitmap };
+    auto paint_rect = source_to_highlight.rect();
+    auto background_complement = m_background_color.xored(Color::White);
+
+    painter.fill_rect_with_rounded_corners(paint_rect, Color::Black, Card::card_radius);
+    paint_rect.shrink(2, 2);
+    painter.fill_rect_with_rounded_corners(paint_rect, background_complement, Card::card_radius - 1);
+    paint_rect.shrink(2, 2);
+    painter.blit({ 4, 4 }, source_to_highlight, source_to_highlight.rect().shrunken(8, 8));
 }
 
 }

--- a/Userland/Libraries/LibCards/CardPainter.h
+++ b/Userland/Libraries/LibCards/CardPainter.h
@@ -9,6 +9,7 @@
 #include <AK/Array.h>
 #include <LibCards/Card.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/Color.h>
 
 namespace Cards {
 
@@ -20,8 +21,10 @@ public:
     NonnullRefPtr<Gfx::Bitmap> card_back();
     NonnullRefPtr<Gfx::Bitmap> card_front_inverted(Suit, Rank);
     NonnullRefPtr<Gfx::Bitmap> card_back_inverted();
+    NonnullRefPtr<Gfx::Bitmap> card_front_highlighted(Suit, Rank);
 
     void set_background_image_path(DeprecatedString path);
+    void set_background_color(Color);
 
 private:
     CardPainter();
@@ -29,13 +32,16 @@ private:
     void paint_card_front(Gfx::Bitmap&, Suit, Rank);
     void paint_card_back(Gfx::Bitmap&);
     void paint_inverted_card(Gfx::Bitmap& bitmap, Gfx::Bitmap const& source_to_invert);
+    void paint_highlighted_card(Gfx::Bitmap& bitmap, Gfx::Bitmap const& source_to_highlight);
 
     Array<Array<RefPtr<Gfx::Bitmap>, to_underlying(Rank::__Count)>, to_underlying(Suit::__Count)> m_cards;
     Array<Array<RefPtr<Gfx::Bitmap>, to_underlying(Rank::__Count)>, to_underlying(Suit::__Count)> m_cards_inverted;
+    Array<Array<RefPtr<Gfx::Bitmap>, to_underlying(Rank::__Count)>, to_underlying(Suit::__Count)> m_cards_highlighted;
     RefPtr<Gfx::Bitmap> m_card_back;
     RefPtr<Gfx::Bitmap> m_card_back_inverted;
 
     DeprecatedString m_background_image_path;
+    Color m_background_color;
 };
 
 }


### PR DESCRIPTION
And add a Card Settings menu item for convenience.

[Screencast from 2023-01-04 20-20-54.webm](https://user-images.githubusercontent.com/5600524/210683034-c5ba3fc9-95bd-4f3e-a738-274ddd6c7982.webm)
