### PR TITLE
LibGfx+LibPDF: Floaty fonts (aka subpixel positioned glyphs)

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -170,7 +170,7 @@ private:
 
         if (m_show_percent) {
             auto volume_text = m_audio_muted ? "mute" : DeprecatedString::formatted("{}%", m_audio_volume);
-            painter.draw_text({ 16, 3, 24, 16 }, volume_text, Gfx::FontDatabase::default_fixed_width_font(), Gfx::TextAlignment::TopLeft, palette().window_text());
+            painter.draw_text(Gfx::IntRect { 16, 3, 24, 16 }, volume_text, Gfx::FontDatabase::default_fixed_width_font(), Gfx::TextAlignment::TopLeft, palette().window_text());
         }
     }
 

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -217,7 +217,7 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
 
             int const editor_x = content_to_frame_position({ x, 0 }).x();
             painter.draw_line({ editor_x, 0 }, { editor_x, m_ruler_thickness }, ruler_fg_color);
-            painter.draw_text({ { editor_x + 2, 0 }, { m_ruler_thickness, m_ruler_thickness - 2 } }, DeprecatedString::formatted("{}", x), painter.font(), Gfx::TextAlignment::CenterLeft, ruler_text_color);
+            painter.draw_text(Gfx::IntRect { { editor_x + 2, 0 }, { m_ruler_thickness, m_ruler_thickness - 2 } }, DeprecatedString::formatted("{}", x), painter.font(), Gfx::TextAlignment::CenterLeft, ruler_text_color);
         }
 
         // Vertical ruler
@@ -234,7 +234,7 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
 
             int const editor_y = content_to_frame_position({ 0, y }).y();
             painter.draw_line({ 0, editor_y }, { m_ruler_thickness, editor_y }, ruler_fg_color);
-            painter.draw_text({ { 0, editor_y - m_ruler_thickness }, { m_ruler_thickness, m_ruler_thickness } }, DeprecatedString::formatted("{}", y), painter.font(), Gfx::TextAlignment::BottomRight, ruler_text_color);
+            painter.draw_text(Gfx::IntRect { { 0, editor_y - m_ruler_thickness }, { m_ruler_thickness, m_ruler_thickness } }, DeprecatedString::formatted("{}", y), painter.font(), Gfx::TextAlignment::BottomRight, ruler_text_color);
         }
 
         // Mouse position indicator

--- a/Userland/Applications/PixelPaint/Tools/TextTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.cpp
@@ -142,7 +142,7 @@ void TextTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
     auto text_bitmap = text_bitmap_result.release_value();
     auto text_painter = GUI::Painter(text_bitmap);
     text_painter.set_font(*m_selected_font);
-    text_painter.draw_text({ 0, 0, text_width, text_height }, typed_text, Gfx::TextAlignment::TopLeft, m_text_color);
+    text_painter.draw_text(Gfx::IntRect { 0, 0, text_width, text_height }, typed_text, Gfx::TextAlignment::TopLeft, m_text_color);
 
     m_text_editor->update();
 

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -32,7 +32,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         m_network_link_down_bitmap = Gfx::Bitmap::try_create(m_network_connected_bitmap->format(), m_network_connected_bitmap->size()).release_value_but_fixme_should_propagate_errors();
         {
             Gfx::Painter painter(*m_network_link_down_bitmap);
-            painter.blit_filtered({}, *m_network_connected_bitmap, m_network_connected_bitmap->rect(), [](Color color) {
+            painter.blit_filtered(Gfx::IntPoint {}, *m_network_connected_bitmap, m_network_connected_bitmap->rect(), [](Color color) {
                 return color.to_grayscale();
             });
         }

--- a/Userland/Applications/Welcome/WelcomeWidget.cpp
+++ b/Userland/Applications/Welcome/WelcomeWidget.cpp
@@ -109,7 +109,7 @@ void WelcomeWidget::paint_event(GUI::PaintEvent& event)
     painter.add_clip_rect(event.rect());
 
     static auto font = Gfx::BitmapFont::load_from_file("/res/fonts/MarietaRegular24.font"sv);
-    painter.draw_text({ 12, 4, 1, 30 }, "Welcome to "sv, *font, Gfx::TextAlignment::CenterLeft, palette().base_text());
-    painter.draw_text({ 12 + static_cast<int>(ceilf(font->width("Welcome to "sv))), 4, 1, 30 }, "Serenity"sv, font->bold_variant(), Gfx::TextAlignment::CenterLeft, palette().base_text());
-    painter.draw_text({ 12 + static_cast<int>(ceilf(font->width("Welcome to "sv))) + static_cast<int>(ceilf(font->bold_variant().width("Serenity"sv))), 4, 1, 30 }, "OS"sv, font->bold_variant(), Gfx::TextAlignment::CenterLeft, palette().base() == palette().window() ? palette().base_text() : palette().base());
+    painter.draw_text(Gfx::IntRect { 12, 4, 1, 30 }, "Welcome to "sv, *font, Gfx::TextAlignment::CenterLeft, palette().base_text());
+    painter.draw_text(Gfx::IntRect { 12 + static_cast<int>(ceilf(font->width("Welcome to "sv))), 4, 1, 30 }, "Serenity"sv, font->bold_variant(), Gfx::TextAlignment::CenterLeft, palette().base_text());
+    painter.draw_text(Gfx::IntRect { 12 + static_cast<int>(ceilf(font->width("Welcome to "sv))) + static_cast<int>(ceilf(font->bold_variant().width("Serenity"sv))), 4, 1, 30 }, "OS"sv, font->bold_variant(), Gfx::TextAlignment::CenterLeft, palette().base() == palette().window() ? palette().base_text() : palette().base());
 }

--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -135,26 +135,26 @@ void Canvas::draw()
     painter.draw_rect({ 20, 260, 480, 320 }, Color::DarkGray);
 
     painter.draw_rect({ 520, 260, 240, 80 }, Color::DarkGray);
-    painter.draw_text({ 520, 260, 240, 80 }, "CenterLeft"sv, Gfx::TextAlignment::CenterLeft, Color::White);
-    painter.draw_text({ 520, 260, 240, 80 }, "Center"sv, Gfx::TextAlignment::Center, Color::White);
-    painter.draw_text({ 520, 260, 240, 80 }, "CenterRight"sv, Gfx::TextAlignment::CenterRight, Color::White);
-    painter.draw_text({ 520, 260, 240, 80 }, "TopLeft"sv, Gfx::TextAlignment::TopLeft, Color::White);
-    painter.draw_text({ 520, 260, 240, 80 }, "TopRight"sv, Gfx::TextAlignment::TopRight, Color::White);
-    painter.draw_text({ 520, 260, 240, 80 }, "BottomLeft"sv, Gfx::TextAlignment::BottomLeft, Color::White);
-    painter.draw_text({ 520, 260, 240, 80 }, "BottomRight"sv, Gfx::TextAlignment::BottomRight, Color::White);
+    painter.draw_text(Gfx::IntRect { 520, 260, 240, 80 }, "CenterLeft"sv, Gfx::TextAlignment::CenterLeft, Color::White);
+    painter.draw_text(Gfx::IntRect { 520, 260, 240, 80 }, "Center"sv, Gfx::TextAlignment::Center, Color::White);
+    painter.draw_text(Gfx::IntRect { 520, 260, 240, 80 }, "CenterRight"sv, Gfx::TextAlignment::CenterRight, Color::White);
+    painter.draw_text(Gfx::IntRect { 520, 260, 240, 80 }, "TopLeft"sv, Gfx::TextAlignment::TopLeft, Color::White);
+    painter.draw_text(Gfx::IntRect { 520, 260, 240, 80 }, "TopRight"sv, Gfx::TextAlignment::TopRight, Color::White);
+    painter.draw_text(Gfx::IntRect { 520, 260, 240, 80 }, "BottomLeft"sv, Gfx::TextAlignment::BottomLeft, Color::White);
+    painter.draw_text(Gfx::IntRect { 520, 260, 240, 80 }, "BottomRight"sv, Gfx::TextAlignment::BottomRight, Color::White);
 
     painter.draw_rect({ 520, 360, 240, 30 }, Color::DarkGray);
-    painter.draw_text({ 520, 360, 240, 30 }, "Emojis! 🙂😂🐞🦄"sv, Gfx::TextAlignment::Center, Color::White);
+    painter.draw_text(Gfx::IntRect { 520, 360, 240, 30 }, "Emojis! 🙂😂🐞🦄"sv, Gfx::TextAlignment::Center, Color::White);
 
     painter.draw_rect({ 520, 410, 240, 80 }, Color::DarkGray);
-    painter.draw_text({ 520, 415, 240, 20 }, "Normal text"sv, Gfx::FontDatabase::default_font(), Gfx::TextAlignment::CenterLeft, Color::Red);
-    painter.draw_text({ 520, 430, 240, 20 }, "Bold text"sv, Gfx::FontDatabase::default_font().bold_variant(), Gfx::TextAlignment::CenterLeft, Color::Green);
-    painter.draw_text({ 520, 450, 240, 20 }, "Normal text (fixed width)"sv, Gfx::FontDatabase::default_fixed_width_font(), Gfx::TextAlignment::CenterLeft, Color::Blue);
-    painter.draw_text({ 520, 465, 240, 20 }, "Bold text (fixed width)"sv, Gfx::FontDatabase::default_fixed_width_font().bold_variant(), Gfx::TextAlignment::CenterLeft, Color::Yellow);
+    painter.draw_text(Gfx::IntRect { 520, 415, 240, 20 }, "Normal text"sv, Gfx::FontDatabase::default_font(), Gfx::TextAlignment::CenterLeft, Color::Red);
+    painter.draw_text(Gfx::IntRect { 520, 430, 240, 20 }, "Bold text"sv, Gfx::FontDatabase::default_font().bold_variant(), Gfx::TextAlignment::CenterLeft, Color::Green);
+    painter.draw_text(Gfx::IntRect { 520, 450, 240, 20 }, "Normal text (fixed width)"sv, Gfx::FontDatabase::default_fixed_width_font(), Gfx::TextAlignment::CenterLeft, Color::Blue);
+    painter.draw_text(Gfx::IntRect { 520, 465, 240, 20 }, "Bold text (fixed width)"sv, Gfx::FontDatabase::default_fixed_width_font().bold_variant(), Gfx::TextAlignment::CenterLeft, Color::Yellow);
 
     auto font = Gfx::BitmapFont::load_from_file("/res/fonts/PebbletonBold14.font"sv);
     painter.draw_rect({ 520, 510, 240, 30 }, Color::DarkGray);
-    painter.draw_text({ 520, 510, 240, 30 }, "Hello friends! :^)"sv, *font, Gfx::TextAlignment::Center, Color::White);
+    painter.draw_text(Gfx::IntRect { 520, 510, 240, 30 }, "Hello friends! :^)"sv, *font, Gfx::TextAlignment::Center, Color::White);
 
     painter.fill_rect({ 520, 560, 10, 20 }, Color::White);
     painter.fill_rect({ 530, 560, 10, 20 }, Color::WarmGray);

--- a/Userland/Libraries/LibCards/CardPainter.cpp
+++ b/Userland/Libraries/LibCards/CardPainter.cpp
@@ -207,7 +207,7 @@ void CardPainter::paint_inverted_card(Gfx::Bitmap& bitmap, Gfx::Bitmap const& so
 {
     Gfx::Painter painter { bitmap };
     painter.clear_rect(bitmap.rect(), Gfx::Color::Transparent);
-    painter.blit_filtered({ 0, 0 }, source_to_invert, source_to_invert.rect(), [&](Color color) {
+    painter.blit_filtered(Gfx::IntPoint {}, source_to_invert, source_to_invert.rect(), [&](Color color) {
         return color.inverted();
     });
 }

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -727,10 +727,10 @@ void AbstractView::draw_item_text(Gfx::Painter& painter, ModelIndex const& index
 
         // Highlight the text background first
         auto background_searching_length = searching_length;
-        painter.draw_text([&](Gfx::IntRect const& rect, Utf8CodePointIterator&) {
+        painter.draw_text([&](Gfx::FloatRect const& rect, Utf8CodePointIterator&) {
             if (background_searching_length > 0) {
                 background_searching_length--;
-                painter.fill_rect(rect.inflated(0, 2), palette().highlight_searching());
+                painter.fill_rect(rect.to_type<int>().inflated(0, 2), palette().highlight_searching());
             }
         },
             text_rect, item_text, font, alignment, elision);
@@ -739,7 +739,7 @@ void AbstractView::draw_item_text(Gfx::Painter& painter, ModelIndex const& index
         auto text_searching_length = searching_length;
         auto highlight_text_color = palette().highlight_searching_text();
         searching_length = searching_text.length();
-        painter.draw_text([&](Gfx::IntRect const& rect, Utf8CodePointIterator& it) {
+        painter.draw_text([&](auto const& rect, Utf8CodePointIterator& it) {
             if (text_searching_length > 0) {
                 text_searching_length--;
                 painter.draw_glyph_or_emoji(rect.location(), it, font, highlight_text_color);

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -117,7 +117,7 @@ void Label::size_to_fit()
 
 int Label::text_calculated_preferred_height() const
 {
-    return Gfx::TextLayout(&font(), Utf8View { m_text }, text_rect()).bounding_rect(Gfx::TextWrapping::Wrap, Gfx::Painter::LINE_SPACING).height();
+    return int(AK::ceil(Gfx::TextLayout(&font(), Utf8View { m_text }, text_rect().to_type<float>()).bounding_rect(Gfx::TextWrapping::Wrap, Gfx::Painter::LINE_SPACING).height()));
 }
 
 Optional<UISize> Label::calculated_preferred_size() const

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
     Filters/StackBlurFilter.cpp
     Font/BitmapFont.cpp
     Font/Emoji.cpp
+    Font/Font.cpp
     Font/FontDatabase.cpp
     Font/OpenType/Cmap.cpp
     Font/OpenType/Font.cpp

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -52,6 +52,10 @@ public:
     void set_slope(u8 slope) { m_slope = slope; }
 
     Glyph glyph(u32 code_point) const override;
+    Glyph glyph(u32 code_point, GlyphSubpixelOffset) const override { return glyph(code_point); }
+
+    float glyph_left_bearing(u32) const override { return 0; }
+
     Glyph raw_glyph(u32 code_point) const;
     bool contains_glyph(u32 code_point) const override;
     bool contains_raw_glyph(u32 code_point) const { return m_glyph_widths[code_point] > 0; }

--- a/Userland/Libraries/LibGfx/Font/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/Font.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Font/Font.h>
+
+namespace Gfx {
+
+GlyphRasterPosition GlyphRasterPosition::get_nearest_fit_for(FloatPoint position)
+{
+    constexpr auto subpixel_divisions = GlyphSubpixelOffset::subpixel_divisions();
+    auto fit = [](float pos, int& blit_pos, u8& subpixel_offset) {
+        blit_pos = floorf(pos);
+        subpixel_offset = round_to<u8>((pos - blit_pos) / (1.0f / subpixel_divisions));
+        if (subpixel_offset >= subpixel_divisions) {
+            blit_pos += 1;
+            subpixel_offset = 0;
+        }
+    };
+    int blit_x, blit_y;
+    u8 subpixel_x, subpixel_y;
+    fit(position.x(), blit_x, subpixel_x);
+    fit(position.y(), blit_y, subpixel_y);
+    return GlyphRasterPosition { { blit_x, blit_y }, { subpixel_x, subpixel_y } };
+}
+
+}

--- a/Userland/Libraries/LibGfx/Font/Font.h
+++ b/Userland/Libraries/LibGfx/Font/Font.h
@@ -86,6 +86,29 @@ private:
     float m_ascent;
 };
 
+struct GlyphSubpixelOffset {
+    u8 x;
+    u8 y;
+
+    // TODO: Allow setting this at runtime via some config?
+    static constexpr int subpixel_divisions() { return 3; }
+    FloatPoint to_float_point() const { return FloatPoint(x / float(subpixel_divisions()), y / float(subpixel_divisions())); }
+
+    bool operator==(GlyphSubpixelOffset const&) const = default;
+};
+
+struct GlyphRasterPosition {
+    // Where the glyph bitmap should be drawn/blitted.
+    IntPoint blit_position;
+
+    // A subpixel offset to be used when rendering the glyph.
+    // This improves kerning and alignment at the expense of caching a few extra bitmaps.
+    // This is (currently) snapped to thirds of a subpixel (i.e. 0, 0.33, 0.66).
+    GlyphSubpixelOffset subpixel_offset;
+
+    static GlyphRasterPosition get_nearest_fit_for(FloatPoint position);
+};
+
 struct FontPixelMetrics {
     float size { 0 };
     float x_height { 0 };
@@ -124,8 +147,10 @@ public:
 
     virtual u16 weight() const = 0;
     virtual Glyph glyph(u32 code_point) const = 0;
+    virtual Glyph glyph(u32 code_point, GlyphSubpixelOffset) const = 0;
     virtual bool contains_glyph(u32 code_point) const = 0;
 
+    virtual float glyph_left_bearing(u32 code_point) const = 0;
     virtual float glyph_width(u32 code_point) const = 0;
     virtual float glyph_or_emoji_width(u32 code_point) const = 0;
     virtual float glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const = 0;

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -554,14 +554,14 @@ float Font::glyphs_horizontal_kerning(u32 left_glyph_id, u32 right_glyph_id, flo
 }
 
 // FIXME: "loca" and "glyf" are not available for CFF fonts.
-RefPtr<Gfx::Bitmap> Font::rasterize_glyph(u32 glyph_id, float x_scale, float y_scale) const
+RefPtr<Gfx::Bitmap> Font::rasterize_glyph(u32 glyph_id, float x_scale, float y_scale, Gfx::GlyphSubpixelOffset subpixel_offset) const
 {
     if (glyph_id >= glyph_count()) {
         glyph_id = 0;
     }
     auto glyph_offset = m_loca.get_glyph_offset(glyph_id);
     auto glyph = m_glyf.glyph(glyph_offset);
-    return glyph.rasterize(m_hhea.ascender(), m_hhea.descender(), x_scale, y_scale, [&](u16 glyph_id) {
+    return glyph.rasterize(m_hhea.ascender(), m_hhea.descender(), x_scale, y_scale, subpixel_offset, [&](u16 glyph_id) {
         if (glyph_id >= glyph_count()) {
             glyph_id = 0;
         }

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -28,7 +28,7 @@ public:
     virtual Gfx::ScaledFontMetrics metrics(float x_scale, float y_scale) const override;
     virtual Gfx::ScaledGlyphMetrics glyph_metrics(u32 glyph_id, float x_scale, float y_scale) const override;
     virtual float glyphs_horizontal_kerning(u32 left_glyph_id, u32 right_glyph_id, float x_scale) const override;
-    virtual RefPtr<Gfx::Bitmap> rasterize_glyph(u32 glyph_id, float x_scale, float y_scale) const override;
+    virtual RefPtr<Gfx::Bitmap> rasterize_glyph(u32 glyph_id, float x_scale, float y_scale, Gfx::GlyphSubpixelOffset) const override;
     virtual u32 glyph_count() const override;
     virtual u16 units_per_em() const override;
     virtual u32 glyph_id_for_code_point(u32 code_point) const override { return m_cmap.glyph_id_for_code_point(code_point); }

--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.cpp
@@ -346,11 +346,12 @@ void Glyf::Glyph::rasterize_impl(Gfx::PathRasterizer& rasterizer, Gfx::AffineTra
     rasterizer.draw_path(path);
 }
 
-RefPtr<Gfx::Bitmap> Glyf::Glyph::rasterize_simple(i16 font_ascender, i16 font_descender, float x_scale, float y_scale) const
+RefPtr<Gfx::Bitmap> Glyf::Glyph::rasterize_simple(i16 font_ascender, i16 font_descender, float x_scale, float y_scale, Gfx::GlyphSubpixelOffset subpixel_offset) const
 {
     u32 width = (u32)(ceilf((m_xmax - m_xmin) * x_scale)) + 2;
     u32 height = (u32)(ceilf((font_ascender - font_descender) * y_scale)) + 2;
     Gfx::PathRasterizer rasterizer(Gfx::IntSize(width, height));
+    rasterizer.translate(subpixel_offset.to_float_point());
     auto affine = Gfx::AffineTransform().scale(x_scale, -y_scale).translate(-m_xmin, -font_ascender);
     rasterize_impl(rasterizer, affine);
     return rasterizer.accumulate();

--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
@@ -10,6 +10,7 @@
 #include <AK/Vector.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/OpenType/Tables.h>
 #include <LibGfx/Font/PathRasterizer.h>
 #include <math.h>
@@ -55,13 +56,13 @@ public:
             }
         }
         template<typename GlyphCb>
-        RefPtr<Gfx::Bitmap> rasterize(i16 font_ascender, i16 font_descender, float x_scale, float y_scale, GlyphCb glyph_callback) const
+        RefPtr<Gfx::Bitmap> rasterize(i16 font_ascender, i16 font_descender, float x_scale, float y_scale, Gfx::GlyphSubpixelOffset subpixel_offset, GlyphCb glyph_callback) const
         {
             switch (m_type) {
             case Type::Simple:
-                return rasterize_simple(font_ascender, font_descender, x_scale, y_scale);
+                return rasterize_simple(font_ascender, font_descender, x_scale, y_scale, subpixel_offset);
             case Type::Composite:
-                return rasterize_composite(font_ascender, font_descender, x_scale, y_scale, glyph_callback);
+                return rasterize_composite(font_ascender, font_descender, x_scale, y_scale, subpixel_offset, glyph_callback);
             }
             VERIFY_NOT_REACHED();
         }
@@ -94,7 +95,7 @@ public:
         };
 
         void rasterize_impl(Gfx::PathRasterizer&, Gfx::AffineTransform const&) const;
-        RefPtr<Gfx::Bitmap> rasterize_simple(i16 ascender, i16 descender, float x_scale, float y_scale) const;
+        RefPtr<Gfx::Bitmap> rasterize_simple(i16 ascender, i16 descender, float x_scale, float y_scale, Gfx::GlyphSubpixelOffset) const;
 
         template<typename GlyphCb>
         void rasterize_composite_loop(Gfx::PathRasterizer& rasterizer, Gfx::AffineTransform const& transform, GlyphCb glyph_callback) const
@@ -120,11 +121,12 @@ public:
         }
 
         template<typename GlyphCb>
-        RefPtr<Gfx::Bitmap> rasterize_composite(i16 font_ascender, i16 font_descender, float x_scale, float y_scale, GlyphCb glyph_callback) const
+        RefPtr<Gfx::Bitmap> rasterize_composite(i16 font_ascender, i16 font_descender, float x_scale, float y_scale, Gfx::GlyphSubpixelOffset subpixel_offset, GlyphCb glyph_callback) const
         {
             u32 width = (u32)(ceilf((m_xmax - m_xmin) * x_scale)) + 1;
             u32 height = (u32)(ceilf((font_ascender - font_descender) * y_scale)) + 1;
             Gfx::PathRasterizer rasterizer(Gfx::IntSize(width, height));
+            rasterizer.translate(subpixel_offset.to_float_point());
             auto affine = Gfx::AffineTransform().scale(x_scale, -y_scale).translate(-m_xmin, -font_ascender);
 
             rasterize_composite_loop(rasterizer, affine, glyph_callback);

--- a/Userland/Libraries/LibGfx/Font/PathRasterizer.cpp
+++ b/Userland/Libraries/LibGfx/Font/PathRasterizer.cpp
@@ -19,9 +19,8 @@ PathRasterizer::PathRasterizer(Gfx::IntSize size)
 
 void PathRasterizer::draw_path(Gfx::Path& path)
 {
-    for (auto& line : path.split_lines()) {
-        draw_line(line.from, line.to);
-    }
+    for (auto& line : path.split_lines())
+        draw_line(line.from.translated(translation()), line.to.translated(translation()));
 }
 
 RefPtr<Gfx::Bitmap> PathRasterizer::accumulate()

--- a/Userland/Libraries/LibGfx/Font/PathRasterizer.h
+++ b/Userland/Libraries/LibGfx/Font/PathRasterizer.h
@@ -18,10 +18,15 @@ public:
     void draw_path(Gfx::Path&);
     RefPtr<Gfx::Bitmap> accumulate();
 
+    void translate(Gfx::FloatPoint delta) { m_translation.translate_by(delta); }
+    Gfx::FloatPoint translation() const { return m_translation; }
+
 private:
     void draw_line(Gfx::FloatPoint, Gfx::FloatPoint);
 
     Gfx::IntSize m_size;
+    Gfx::FloatPoint m_translation;
+
     Vector<float> m_data;
 };
 

--- a/Userland/Libraries/LibGfx/Font/VectorFont.h
+++ b/Userland/Libraries/LibGfx/Font/VectorFont.h
@@ -8,6 +8,7 @@
 
 #include <AK/Noncopyable.h>
 #include <AK/RefCounted.h>
+#include <LibGfx/Font/Font.h>
 #include <LibGfx/Forward.h>
 
 namespace Gfx {
@@ -36,7 +37,7 @@ public:
     virtual ScaledFontMetrics metrics(float x_scale, float y_scale) const = 0;
     virtual ScaledGlyphMetrics glyph_metrics(u32 glyph_id, float x_scale, float y_scale) const = 0;
     virtual float glyphs_horizontal_kerning(u32 left_glyph_id, u32 right_glyph_id, float x_scale) const = 0;
-    virtual RefPtr<Gfx::Bitmap> rasterize_glyph(u32 glyph_id, float x_scale, float y_scale) const = 0;
+    virtual RefPtr<Gfx::Bitmap> rasterize_glyph(u32 glyph_id, float x_scale, float y_scale, GlyphSubpixelOffset) const = 0;
     virtual u32 glyph_count() const = 0;
     virtual u16 units_per_em() const = 0;
     virtual u32 glyph_id_for_code_point(u32 code_point) const = 0;

--- a/Userland/Libraries/LibGfx/Font/WOFF/Font.h
+++ b/Userland/Libraries/LibGfx/Font/WOFF/Font.h
@@ -26,7 +26,7 @@ public:
     virtual Gfx::ScaledFontMetrics metrics(float x_scale, float y_scale) const override { return m_input_font->metrics(x_scale, y_scale); }
     virtual Gfx::ScaledGlyphMetrics glyph_metrics(u32 glyph_id, float x_scale, float y_scale) const override { return m_input_font->glyph_metrics(glyph_id, x_scale, y_scale); }
     virtual float glyphs_horizontal_kerning(u32 left_glyph_id, u32 right_glyph_id, float x_scale) const override { return m_input_font->glyphs_horizontal_kerning(left_glyph_id, right_glyph_id, x_scale); }
-    virtual RefPtr<Gfx::Bitmap> rasterize_glyph(u32 glyph_id, float x_scale, float y_scale) const override { return m_input_font->rasterize_glyph(glyph_id, x_scale, y_scale); }
+    virtual RefPtr<Gfx::Bitmap> rasterize_glyph(u32 glyph_id, float x_scale, float y_scale, Gfx::GlyphSubpixelOffset subpixel_offset) const override { return m_input_font->rasterize_glyph(glyph_id, x_scale, y_scale, subpixel_offset); }
     virtual u32 glyph_count() const override { return m_input_font->glyph_count(); }
     virtual u16 units_per_em() const override { return m_input_font->units_per_em(); }
     virtual u32 glyph_id_for_code_point(u32 code_point) const override { return m_input_font->glyph_id_for_code_point(code_point); }

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1375,20 +1375,20 @@ void Painter::draw_scaled_bitmap(IntRect const& a_dst_rect, Gfx::Bitmap const& s
     }
 }
 
-FLATTEN void Painter::draw_glyph(IntPoint point, u32 code_point, Color color)
+FLATTEN void Painter::draw_glyph(FloatPoint point, u32 code_point, Color color)
 {
     draw_glyph(point, code_point, font(), color);
 }
 
-FLATTEN void Painter::draw_glyph(IntPoint point, u32 code_point, Font const& font, Color color)
+FLATTEN void Painter::draw_glyph(FloatPoint point, u32 code_point, Font const& font, Color color)
 {
     auto glyph = font.glyph(code_point);
     auto top_left = point + IntPoint(glyph.left_bearing(), 0);
 
     if (glyph.is_glyph_bitmap()) {
-        draw_bitmap(top_left, glyph.glyph_bitmap(), color);
+        draw_bitmap(top_left.to_type<int>(), glyph.glyph_bitmap(), color);
     } else {
-        blit_filtered(top_left, *glyph.bitmap(), glyph.bitmap()->rect(), [color](Color pixel) -> Color {
+        blit_filtered(top_left.to_type<int>(), *glyph.bitmap(), glyph.bitmap()->rect(), [color](Color pixel) -> Color {
             return pixel.multiply(color);
         });
     }
@@ -1405,7 +1405,7 @@ void Painter::draw_emoji(IntPoint point, Gfx::Bitmap const& emoji, Font const& f
     draw_scaled_bitmap(dst_rect, emoji, emoji.rect());
 }
 
-void Painter::draw_glyph_or_emoji(IntPoint point, u32 code_point, Font const& font, Color color)
+void Painter::draw_glyph_or_emoji(FloatPoint point, u32 code_point, Font const& font, Color color)
 {
     StringBuilder builder;
     builder.append_code_point(code_point);
@@ -1413,7 +1413,7 @@ void Painter::draw_glyph_or_emoji(IntPoint point, u32 code_point, Font const& fo
     return draw_glyph_or_emoji(point, it, font, color);
 }
 
-void Painter::draw_glyph_or_emoji(IntPoint point, Utf8CodePointIterator& it, Font const& font, Color color)
+void Painter::draw_glyph_or_emoji(FloatPoint point, Utf8CodePointIterator& it, Font const& font, Color color)
 {
     // FIXME: These should live somewhere else.
     constexpr u32 text_variation_selector = 0xFE0E;
@@ -1454,7 +1454,7 @@ void Painter::draw_glyph_or_emoji(IntPoint point, Utf8CodePointIterator& it, Fon
 
     // If we didn't find a text glyph, or have an emoji variation selector or regional indicator, try to draw an emoji glyph.
     if (auto const* emoji = Emoji::emoji_for_code_point_iterator(it)) {
-        draw_emoji(point, *emoji, font);
+        draw_emoji(point.to_type<int>(), *emoji, font);
         return;
     }
 
@@ -1469,8 +1469,28 @@ void Painter::draw_glyph_or_emoji(IntPoint point, Utf8CodePointIterator& it, Fon
     draw_glyph(point, 0xFFFD, font, color);
 }
 
+void Painter::draw_glyph(IntPoint point, u32 code_point, Color color)
+{
+    draw_glyph(point.to_type<float>(), code_point, font(), color);
+}
+
+void Painter::draw_glyph(IntPoint point, u32 code_point, Font const& font, Color color)
+{
+    draw_glyph(point.to_type<float>(), code_point, font, color);
+}
+
+void Painter::draw_glyph_or_emoji(IntPoint point, u32 code_point, Font const& font, Color color)
+{
+    draw_glyph_or_emoji(point.to_type<float>(), code_point, font, color);
+}
+
+void Painter::draw_glyph_or_emoji(IntPoint point, Utf8CodePointIterator& it, Font const& font, Color color)
+{
+    draw_glyph_or_emoji(point.to_type<float>(), it, font, color);
+}
+
 template<typename DrawGlyphFunction>
-void draw_text_line(IntRect const& a_rect, Utf8View const& text, Font const& font, TextAlignment alignment, TextDirection direction, DrawGlyphFunction draw_glyph)
+void draw_text_line(FloatRect const& a_rect, Utf8View const& text, Font const& font, TextAlignment alignment, TextDirection direction, DrawGlyphFunction draw_glyph)
 {
     auto rect = a_rect;
 
@@ -1498,12 +1518,12 @@ void draw_text_line(IntRect const& a_rect, Utf8View const& text, Font const& fon
     }
 
     if (is_vertically_centered_text_alignment(alignment)) {
-        int distance_from_baseline_to_bottom = (font.pixel_size() - 1) - font.baseline();
+        auto distance_from_baseline_to_bottom = (font.pixel_size() - 1) - font.baseline();
         rect.translate_by(0, distance_from_baseline_to_bottom / 2);
     }
 
     auto point = rect.location();
-    int space_width = font.glyph_width(' ') + font.glyph_spacing();
+    auto space_width = font.glyph_width(' ') + font.glyph_spacing();
 
     if (direction == TextDirection::RTL) {
         point.translate_by(rect.width(), 0); // Start drawing from the end
@@ -1519,11 +1539,11 @@ void draw_text_line(IntRect const& a_rect, Utf8View const& text, Font const& fon
             continue;
         }
 
-        int kerning = round_to<int>(font.glyphs_horizontal_kerning(last_code_point, code_point));
-        if (kerning != 0.f)
+        auto kerning = font.glyphs_horizontal_kerning(last_code_point, code_point);
+        if (kerning != 0.0f)
             point.translate_by(direction == TextDirection::LTR ? kerning : -kerning, 0);
 
-        IntSize glyph_size(font.glyph_or_emoji_width(code_point) + font.glyph_spacing(), font.pixel_size());
+        FloatSize glyph_size(font.glyph_or_emoji_width(code_point) + font.glyph_spacing(), font.pixel_size());
         if (direction == TextDirection::RTL)
             point.translate_by(-glyph_size.width(), 0); // If we are drawing right to left, we have to move backwards before drawing the glyph
         draw_glyph({ point, glyph_size }, it);
@@ -1698,14 +1718,14 @@ bool Painter::text_contains_bidirectional_text(Utf8View const& text, TextDirecti
 }
 
 template<typename DrawGlyphFunction>
-void Painter::do_draw_text(IntRect const& rect, Utf8View const& text, Font const& font, TextAlignment alignment, TextElision elision, TextWrapping wrapping, DrawGlyphFunction draw_glyph)
+void Painter::do_draw_text(FloatRect const& rect, Utf8View const& text, Font const& font, TextAlignment alignment, TextElision elision, TextWrapping wrapping, DrawGlyphFunction draw_glyph)
 {
     if (draw_text_get_length(text) == 0)
         return;
 
     TextLayout layout(&font, text, rect);
 
-    int line_height = font.pixel_size() + LINE_SPACING;
+    auto line_height = font.pixel_size() + LINE_SPACING;
 
     auto lines = layout.lines(elision, wrapping, LINE_SPACING);
     auto bounding_rect = layout.bounding_rect(wrapping, LINE_SPACING);
@@ -1722,10 +1742,10 @@ void Painter::do_draw_text(IntRect const& rect, Utf8View const& text, Font const
         bounding_rect.set_location({ (rect.right() + 1) - bounding_rect.width(), rect.y() });
         break;
     case TextAlignment::CenterLeft:
-        bounding_rect.set_location({ rect.x(), rect.center().y() - (bounding_rect.height() / 2) });
+        bounding_rect.set_location({ rect.x(), rect.center().y() - int(bounding_rect.height() / 2) });
         break;
     case TextAlignment::CenterRight:
-        bounding_rect.set_location({ (rect.right() + 1) - bounding_rect.width(), rect.center().y() - (bounding_rect.height() / 2) });
+        bounding_rect.set_location({ (rect.right() + 1) - bounding_rect.width(), rect.center().y() - int(bounding_rect.height() / 2) });
         break;
     case TextAlignment::Center:
         bounding_rect.center_within(rect);
@@ -1749,7 +1769,7 @@ void Painter::do_draw_text(IntRect const& rect, Utf8View const& text, Font const
     for (size_t i = 0; i < lines.size(); ++i) {
         auto line = Utf8View { lines[i] };
 
-        IntRect line_rect { bounding_rect.x(), bounding_rect.y() + static_cast<int>(i) * line_height, bounding_rect.width(), line_height };
+        FloatRect line_rect { bounding_rect.x(), bounding_rect.y() + i * line_height, bounding_rect.width(), line_height };
         line_rect.intersect(rect);
 
         TextDirection line_direction = get_text_direction(line);
@@ -1779,67 +1799,102 @@ void Painter::do_draw_text(IntRect const& rect, Utf8View const& text, Font const
     }
 }
 
-void Painter::draw_text(IntRect const& rect, StringView text, TextAlignment alignment, Color color, TextElision elision, TextWrapping wrapping)
+void Painter::draw_text(FloatRect const& rect, StringView text, TextAlignment alignment, Color color, TextElision elision, TextWrapping wrapping)
 {
     draw_text(rect, text, font(), alignment, color, elision, wrapping);
+}
+
+void Painter::draw_text(FloatRect const& rect, Utf32View const& text, TextAlignment alignment, Color color, TextElision elision, TextWrapping wrapping)
+{
+    draw_text(rect, text, font(), alignment, color, elision, wrapping);
+}
+
+void Painter::draw_text(FloatRect const& rect, StringView raw_text, Font const& font, TextAlignment alignment, Color color, TextElision elision, TextWrapping wrapping)
+{
+    Utf8View text { raw_text };
+    do_draw_text(rect, text, font, alignment, elision, wrapping, [&](FloatRect const& r, Utf8CodePointIterator& it) {
+        draw_glyph_or_emoji(r.location(), it, font, color);
+    });
+}
+
+void Painter::draw_text(FloatRect const& rect, Utf32View const& raw_text, Font const& font, TextAlignment alignment, Color color, TextElision elision, TextWrapping wrapping)
+{
+    // FIXME: UTF-32 should eventually be completely removed, but for the time
+    // being some places might depend on it, so we do some internal conversion.
+    StringBuilder builder;
+    builder.append(raw_text);
+    auto text = Utf8View { builder.string_view() };
+    do_draw_text(rect, text, font, alignment, elision, wrapping, [&](FloatRect const& r, Utf8CodePointIterator& it) {
+        draw_glyph_or_emoji(r.location(), it, font, color);
+    });
+}
+
+void Painter::draw_text(Function<void(FloatRect const&, Utf8CodePointIterator&)> draw_one_glyph, FloatRect const& rect, Utf8View const& text, Font const& font, TextAlignment alignment, TextElision elision, TextWrapping wrapping)
+{
+    VERIFY(scale() == 1); // FIXME: Add scaling support.
+
+    do_draw_text(rect, text, font, alignment, elision, wrapping, [&](FloatRect const& r, Utf8CodePointIterator& it) {
+        draw_one_glyph(r, it);
+    });
+}
+
+void Painter::draw_text(Function<void(FloatRect const&, Utf8CodePointIterator&)> draw_one_glyph, FloatRect const& rect, StringView raw_text, Font const& font, TextAlignment alignment, TextElision elision, TextWrapping wrapping)
+{
+    VERIFY(scale() == 1); // FIXME: Add scaling support.
+
+    Utf8View text { raw_text };
+    do_draw_text(rect, text, font, alignment, elision, wrapping, [&](FloatRect const& r, Utf8CodePointIterator& it) {
+        draw_one_glyph(r, it);
+    });
+}
+
+void Painter::draw_text(Function<void(FloatRect const&, Utf8CodePointIterator&)> draw_one_glyph, FloatRect const& rect, Utf32View const& raw_text, Font const& font, TextAlignment alignment, TextElision elision, TextWrapping wrapping)
+{
+    VERIFY(scale() == 1); // FIXME: Add scaling support.
+
+    // FIXME: UTF-32 should eventually be completely removed, but for the time
+    // being some places might depend on it, so we do some internal conversion.
+    StringBuilder builder;
+    builder.append(raw_text);
+    auto text = Utf8View { builder.string_view() };
+    do_draw_text(rect, text, font, alignment, elision, wrapping, [&](FloatRect const& r, Utf8CodePointIterator& it) {
+        draw_one_glyph(r, it);
+    });
+}
+
+void Painter::draw_text(IntRect const& rect, StringView text, TextAlignment alignment, Color color, TextElision elision, TextWrapping wrapping)
+{
+    draw_text(rect.to_type<float>(), text, font(), alignment, color, elision, wrapping);
 }
 
 void Painter::draw_text(IntRect const& rect, Utf32View const& text, TextAlignment alignment, Color color, TextElision elision, TextWrapping wrapping)
 {
-    draw_text(rect, text, font(), alignment, color, elision, wrapping);
+    draw_text(rect.to_type<float>(), text, font(), alignment, color, elision, wrapping);
 }
 
 void Painter::draw_text(IntRect const& rect, StringView raw_text, Font const& font, TextAlignment alignment, Color color, TextElision elision, TextWrapping wrapping)
 {
-    Utf8View text { raw_text };
-    do_draw_text(rect, text, font, alignment, elision, wrapping, [&](IntRect const& r, Utf8CodePointIterator& it) {
-        draw_glyph_or_emoji(r.location(), it, font, color);
-    });
+    draw_text(rect.to_type<float>(), raw_text, font, alignment, color, elision, wrapping);
 }
 
 void Painter::draw_text(IntRect const& rect, Utf32View const& raw_text, Font const& font, TextAlignment alignment, Color color, TextElision elision, TextWrapping wrapping)
 {
-    // FIXME: UTF-32 should eventually be completely removed, but for the time
-    // being some places might depend on it, so we do some internal conversion.
-    StringBuilder builder;
-    builder.append(raw_text);
-    auto text = Utf8View { builder.string_view() };
-    do_draw_text(rect, text, font, alignment, elision, wrapping, [&](IntRect const& r, Utf8CodePointIterator& it) {
-        draw_glyph_or_emoji(r.location(), it, font, color);
-    });
+    return draw_text(rect.to_type<float>(), raw_text, font, alignment, color, elision, wrapping);
 }
 
-void Painter::draw_text(Function<void(IntRect const&, Utf8CodePointIterator&)> draw_one_glyph, IntRect const& rect, Utf8View const& text, Font const& font, TextAlignment alignment, TextElision elision, TextWrapping wrapping)
+void Painter::draw_text(Function<void(FloatRect const&, Utf8CodePointIterator&)> draw_one_glyph, IntRect const& rect, Utf8View const& text, Font const& font, TextAlignment alignment, TextElision elision, TextWrapping wrapping)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
-    do_draw_text(rect, text, font, alignment, elision, wrapping, [&](IntRect const& r, Utf8CodePointIterator& it) {
-        draw_one_glyph(r, it);
-    });
+    return draw_text(move(draw_one_glyph), rect.to_type<float>(), text, font, alignment, elision, wrapping);
 }
 
-void Painter::draw_text(Function<void(IntRect const&, Utf8CodePointIterator&)> draw_one_glyph, IntRect const& rect, StringView raw_text, Font const& font, TextAlignment alignment, TextElision elision, TextWrapping wrapping)
+void Painter::draw_text(Function<void(FloatRect const&, Utf8CodePointIterator&)> draw_one_glyph, IntRect const& rect, StringView raw_text, Font const& font, TextAlignment alignment, TextElision elision, TextWrapping wrapping)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
-    Utf8View text { raw_text };
-    do_draw_text(rect, text, font, alignment, elision, wrapping, [&](IntRect const& r, Utf8CodePointIterator& it) {
-        draw_one_glyph(r, it);
-    });
+    return draw_text(move(draw_one_glyph), rect.to_type<float>(), raw_text, font, alignment, elision, wrapping);
 }
 
-void Painter::draw_text(Function<void(IntRect const&, Utf8CodePointIterator&)> draw_one_glyph, IntRect const& rect, Utf32View const& raw_text, Font const& font, TextAlignment alignment, TextElision elision, TextWrapping wrapping)
+void Painter::draw_text(Function<void(FloatRect const&, Utf8CodePointIterator&)> draw_one_glyph, IntRect const& rect, Utf32View const& raw_text, Font const& font, TextAlignment alignment, TextElision elision, TextWrapping wrapping)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
-    // FIXME: UTF-32 should eventually be completely removed, but for the time
-    // being some places might depend on it, so we do some internal conversion.
-    StringBuilder builder;
-    builder.append(raw_text);
-    auto text = Utf8View { builder.string_view() };
-    do_draw_text(rect, text, font, alignment, elision, wrapping, [&](IntRect const& r, Utf8CodePointIterator& it) {
-        draw_one_glyph(r, it);
-    });
+    return draw_text(move(draw_one_glyph), rect.to_type<float>(), raw_text, font, alignment, elision, wrapping);
 }
 
 void Painter::set_pixel(IntPoint p, Color color, bool blend)
@@ -2481,7 +2536,7 @@ void Painter::draw_text_run(FloatPoint baseline_start, Utf8View const& string, F
 {
     auto pixel_metrics = font.pixel_metrics();
     float x = baseline_start.x();
-    int y = baseline_start.y() - pixel_metrics.ascent;
+    float y = baseline_start.y() - pixel_metrics.ascent;
     float space_width = font.glyph_or_emoji_width(' ');
 
     u32 last_code_point = 0;
@@ -2496,7 +2551,7 @@ void Painter::draw_text_run(FloatPoint baseline_start, Utf8View const& string, F
 
         // FIXME: this is probably not the real space taken for complex emojis
         x += font.glyphs_horizontal_kerning(last_code_point, code_point);
-        draw_glyph_or_emoji({ static_cast<int>(x), y }, code_point_iterator, font, color);
+        draw_glyph_or_emoji(FloatPoint { x, y }, code_point_iterator, font, color);
         x += font.glyph_or_emoji_width(code_point) + font.glyph_spacing();
         last_code_point = code_point;
     }

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1382,13 +1382,14 @@ FLATTEN void Painter::draw_glyph(FloatPoint point, u32 code_point, Color color)
 
 FLATTEN void Painter::draw_glyph(FloatPoint point, u32 code_point, Font const& font, Color color)
 {
-    auto glyph = font.glyph(code_point);
-    auto top_left = point + IntPoint(glyph.left_bearing(), 0);
+    auto top_left = point + FloatPoint(font.glyph_left_bearing(code_point), 0);
+    auto glyph_position = Gfx::GlyphRasterPosition::get_nearest_fit_for(top_left);
+    auto glyph = font.glyph(code_point, glyph_position.subpixel_offset);
 
     if (glyph.is_glyph_bitmap()) {
         draw_bitmap(top_left.to_type<int>(), glyph.glyph_bitmap(), color);
     } else {
-        blit_filtered(top_left.to_type<int>(), *glyph.bitmap(), glyph.bitmap()->rect(), [color](Color pixel) -> Color {
+        blit_filtered(glyph_position.blit_position, *glyph.bitmap(), glyph.bitmap()->rect(), [color](Color pixel) -> Color {
             return pixel.multiply(color);
         });
     }

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -81,19 +81,30 @@ public:
     void blit_offset(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect, IntPoint);
     void blit_disabled(IntPoint, Gfx::Bitmap const&, IntRect const&, Palette const&);
     void blit_tiled(IntRect const&, Gfx::Bitmap const&, IntRect const& src_rect);
+    void draw_text(FloatRect const&, StringView, Font const&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
+    void draw_text(FloatRect const&, StringView, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
+    void draw_text(FloatRect const&, Utf32View const&, Font const&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
+    void draw_text(FloatRect const&, Utf32View const&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
+    void draw_text(Function<void(FloatRect const&, Utf8CodePointIterator&)>, FloatRect const&, StringView, Font const&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
+    void draw_text(Function<void(FloatRect const&, Utf8CodePointIterator&)>, FloatRect const&, Utf8View const&, Font const&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
+    void draw_text(Function<void(FloatRect const&, Utf8CodePointIterator&)>, FloatRect const&, Utf32View const&, Font const&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
     void draw_text(IntRect const&, StringView, Font const&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
     void draw_text(IntRect const&, StringView, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
     void draw_text(IntRect const&, Utf32View const&, Font const&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
     void draw_text(IntRect const&, Utf32View const&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
-    void draw_text(Function<void(IntRect const&, Utf8CodePointIterator&)>, IntRect const&, StringView, Font const&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
-    void draw_text(Function<void(IntRect const&, Utf8CodePointIterator&)>, IntRect const&, Utf8View const&, Font const&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
-    void draw_text(Function<void(IntRect const&, Utf8CodePointIterator&)>, IntRect const&, Utf32View const&, Font const&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
+    void draw_text(Function<void(FloatRect const&, Utf8CodePointIterator&)>, IntRect const&, StringView, Font const&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
+    void draw_text(Function<void(FloatRect const&, Utf8CodePointIterator&)>, IntRect const&, Utf8View const&, Font const&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
+    void draw_text(Function<void(FloatRect const&, Utf8CodePointIterator&)>, IntRect const&, Utf32View const&, Font const&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);
     void draw_ui_text(Gfx::IntRect const&, StringView, Gfx::Font const&, TextAlignment, Gfx::Color);
     void draw_glyph(IntPoint, u32, Color);
     void draw_glyph(IntPoint, u32, Font const&, Color);
     void draw_emoji(IntPoint, Gfx::Bitmap const&, Font const&);
     void draw_glyph_or_emoji(IntPoint, u32, Font const&, Color);
     void draw_glyph_or_emoji(IntPoint, Utf8CodePointIterator&, Font const&, Color);
+    void draw_glyph(FloatPoint, u32, Color);
+    void draw_glyph(FloatPoint, u32, Font const&, Color);
+    void draw_glyph_or_emoji(FloatPoint, u32, Font const&, Color);
+    void draw_glyph_or_emoji(FloatPoint, Utf8CodePointIterator&, Font const&, Color);
     void draw_circle_arc_intersecting(IntRect const&, IntPoint, int radius, Color, int thickness);
 
     // Streamlined text drawing routine that does no wrapping/elision/alignment.
@@ -214,7 +225,7 @@ private:
     Vector<DirectionalRun> split_text_into_directional_runs(Utf8View const&, TextDirection initial_direction);
     bool text_contains_bidirectional_text(Utf8View const&, TextDirection);
     template<typename DrawGlyphFunction>
-    void do_draw_text(IntRect const&, Utf8View const& text, Font const&, TextAlignment, TextElision, TextWrapping, DrawGlyphFunction);
+    void do_draw_text(FloatRect const&, Utf8View const& text, Font const&, TextAlignment, TextElision, TextWrapping, DrawGlyphFunction);
 };
 
 class PainterStateSaver {

--- a/Userland/Libraries/LibGfx/TextLayout.h
+++ b/Userland/Libraries/LibGfx/TextLayout.h
@@ -44,7 +44,7 @@ enum class FitWithinRect {
 //   b) Taking the Lines from TextLayout and painting each glyph.
 class TextLayout {
 public:
-    TextLayout(Gfx::Font const* font, Utf8View const& text, IntRect const& rect)
+    TextLayout(Gfx::Font const* font, Utf8View const& text, FloatRect const& rect)
         : m_font(font)
         , m_text(text)
         , m_rect(rect)
@@ -57,15 +57,15 @@ public:
     Utf8View const& text() const { return m_text; }
     void set_text(Utf8View const& text) { m_text = text; }
 
-    IntRect const& rect() const { return m_rect; }
-    void set_rect(IntRect const& rect) { m_rect = rect; }
+    FloatRect const& rect() const { return m_rect; }
+    void set_rect(FloatRect const& rect) { m_rect = rect; }
 
     Vector<DeprecatedString, 32> lines(TextElision elision, TextWrapping wrapping, int line_spacing) const
     {
         return wrap_lines(elision, wrapping, line_spacing, FitWithinRect::Yes);
     }
 
-    IntRect bounding_rect(TextWrapping wrapping, int line_spacing) const;
+    FloatRect bounding_rect(TextWrapping wrapping, int line_spacing) const;
 
 private:
     Vector<DeprecatedString, 32> wrap_lines(TextElision, TextWrapping, int line_spacing, FitWithinRect) const;
@@ -73,7 +73,7 @@ private:
 
     Font const* m_font;
     Utf8View m_text;
-    IntRect m_rect;
+    FloatRect m_rect;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -41,7 +41,7 @@ public:
     virtual u32 char_code_to_code_point(u16 char_code) const = 0;
     virtual float get_char_width(u16 char_code) const = 0;
 
-    virtual void draw_glyph(Gfx::Painter& painter, Gfx::IntPoint point, float width, u32 char_code, Color color) = 0;
+    virtual void draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u32 char_code, Color color) = 0;
 
     virtual bool is_standard_font() const { return m_is_standard_font; }
     virtual Type type() const = 0;

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -94,15 +94,16 @@ PDFErrorOr<void> PS1FontProgram::create(ReadonlyBytes const& bytes, RefPtr<Encod
     return parse_encrypted_portion(decrypted);
 }
 
-RefPtr<Gfx::Bitmap> PS1FontProgram::rasterize_glyph(u32 char_code, float width)
+RefPtr<Gfx::Bitmap> PS1FontProgram::rasterize_glyph(u32 char_code, float width, Gfx::GlyphSubpixelOffset subpixel_offset)
 {
     auto path = build_char(char_code, width);
     auto bounding_box = path.bounding_box().size();
 
-    u32 w = (u32)ceilf(bounding_box.width()) + 1;
-    u32 h = (u32)ceilf(bounding_box.height()) + 1;
+    u32 w = (u32)ceilf(bounding_box.width()) + 2;
+    u32 h = (u32)ceilf(bounding_box.height()) + 2;
 
     Gfx::PathRasterizer rasterizer(Gfx::IntSize(w, h));
+    rasterizer.translate(subpixel_offset.to_float_point());
     rasterizer.draw_path(path);
     return rasterizer.accumulate();
 }

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <LibGfx/AffineTransform.h>
+#include <LibGfx/Font/Font.h>
 #include <LibGfx/Path.h>
 #include <LibPDF/Error.h>
 
@@ -20,7 +21,7 @@ class PS1FontProgram : public RefCounted<PS1FontProgram> {
 public:
     PDFErrorOr<void> create(ReadonlyBytes const&, RefPtr<Encoding>, size_t cleartext_length, size_t encrypted_length);
 
-    RefPtr<Gfx::Bitmap> rasterize_glyph(u32 char_code, float width);
+    RefPtr<Gfx::Bitmap> rasterize_glyph(u32 char_code, float width, Gfx::GlyphSubpixelOffset);
     Gfx::Path build_char(u32 char_code, float width);
 
     RefPtr<Encoding> encoding() const { return m_encoding; }

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -68,7 +68,7 @@ float TrueTypeFont::get_char_width(u16 char_code) const
     return static_cast<float>(width) / 1000.0f;
 }
 
-void TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::IntPoint point, float, u32 char_code, Color color)
+void TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float, u32 char_code, Color color)
 {
     if (!m_data.font)
         return;

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -24,7 +24,7 @@ public:
     u32 char_code_to_code_point(u16 char_code) const override;
     float get_char_width(u16 char_code) const override;
 
-    void draw_glyph(Gfx::Painter&, Gfx::IntPoint, float, u32, Color) override;
+    void draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u32, Color) override;
 
     Type type() const override { return PDFFont::Type::TrueType; }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -27,7 +27,7 @@ public:
     u32 char_code_to_code_point(u16 char_code) const override;
     float get_char_width(u16 char_code) const override;
 
-    void draw_glyph(Gfx::Painter&, Gfx::IntPoint, float, u32, Color) override {};
+    void draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u32, Color) override {};
 
     Type type() const override { return PDFFont::Type::Type0; }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/Font/ScaledFont.h>
 #include <LibPDF/Fonts/PDFFont.h>
 #include <LibPDF/Fonts/PS1FontProgram.h>
 
@@ -27,13 +28,13 @@ public:
     u32 char_code_to_code_point(u16 char_code) const override;
     float get_char_width(u16 char_code) const override;
 
-    void draw_glyph(Gfx::Painter& painter, Gfx::IntPoint point, float width, u32 char_code, Color color) override;
+    void draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u32 char_code, Color color) override;
 
     Type type() const override { return PDFFont::Type::Type1; }
 
 private:
     Data m_data;
-    HashMap<u32, RefPtr<Gfx::Bitmap>> m_glyph_cache;
+    HashMap<Gfx::GlyphIndexWithSubpixelOffset, RefPtr<Gfx::Bitmap>> m_glyph_cache;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -747,7 +747,7 @@ void Renderer::show_text(DeprecatedString const& string)
         auto glyph_width = char_width * font_size;
 
         if (code_point != 0x20)
-            text_state().font->draw_glyph(m_painter, glyph_position.to_type<int>(), glyph_width, char_code, state().paint_color);
+            text_state().font->draw_glyph(m_painter, glyph_position, glyph_width, char_code, state().paint_color);
 
         auto tx = glyph_width;
         tx += text_state().character_spacing;

--- a/Userland/Services/WindowServer/Overlays.cpp
+++ b/Userland/Services/WindowServer/Overlays.cpp
@@ -213,7 +213,7 @@ Gfx::Font const& ScreenNumberOverlay::font()
 
 void ScreenNumberOverlay::render_overlay_bitmap(Gfx::Painter& painter)
 {
-    painter.draw_text({ {}, rect().size() }, DeprecatedString::formatted("{}", m_screen.index() + 1), font(), Gfx::TextAlignment::Center, Color::White);
+    painter.draw_text(Gfx::IntRect { {}, rect().size() }, DeprecatedString::formatted("{}", m_screen.index() + 1), font(), Gfx::TextAlignment::Center, Color::White);
 }
 
 Gfx::IntRect ScreenNumberOverlay::calculate_content_rect_for_screen(Screen& screen)
@@ -264,7 +264,7 @@ void WindowGeometryOverlay::update_rect()
 
 void WindowGeometryOverlay::render_overlay_bitmap(Gfx::Painter& painter)
 {
-    painter.draw_text({ {}, rect().size() }, m_label, WindowManager::the().font(), Gfx::TextAlignment::Center, Color::White);
+    painter.draw_text(Gfx::IntRect { {}, rect().size() }, m_label, WindowManager::the().font(), Gfx::TextAlignment::Center, Color::White);
 }
 
 void WindowGeometryOverlay::window_rect_changed()


### PR DESCRIPTION
As demo'd earlier on Discord this improves TTF/vector font rendering by allowing rendering glyphs offset by subpixel values.
Currently the subpixel rendering is snapped to thirds of a pixel (so 0, 0.33, and 0.66), which does a decent job without using too much space (there's still a _tiny_ bit of jitter on the subpixel level, but you have to look for it).

The glyph bitmaps are still cached so with this enabled you can end up with up to 9 bitmaps per glyph (assuming you encounter every possible x/y offset).

**Before:**

[screen-capture - 2023-01-04T170229.982.webm](https://user-images.githubusercontent.com/11597044/210682289-363329d5-17d4-465b-9b25-b6c3640a4319.webm)

**After:**

[screen-capture - 2023-01-04T165928.196.webm](https://user-images.githubusercontent.com/11597044/210682269-2377732d-7f21-43de-bfe9-f29b2aefa41a.webm)

(Note that the subpixel divisions can easily be changed later by tweaking a constant)

cc @kleinesfilmroellchen, might fix #16807 