### PR TITLE
LibGfx+LibPDF: Apply subpixel offset in affine transformation

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.cpp
@@ -351,8 +351,10 @@ RefPtr<Gfx::Bitmap> Glyf::Glyph::rasterize_simple(i16 font_ascender, i16 font_de
     u32 width = (u32)(ceilf((m_xmax - m_xmin) * x_scale)) + 2;
     u32 height = (u32)(ceilf((font_ascender - font_descender) * y_scale)) + 2;
     Gfx::PathRasterizer rasterizer(Gfx::IntSize(width, height));
-    rasterizer.translate(subpixel_offset.to_float_point());
-    auto affine = Gfx::AffineTransform().scale(x_scale, -y_scale).translate(-m_xmin, -font_ascender);
+    auto affine = Gfx::AffineTransform()
+                      .translate(subpixel_offset.to_float_point())
+                      .scale(x_scale, -y_scale)
+                      .translate(-m_xmin, -font_ascender);
     rasterize_impl(rasterizer, affine);
     return rasterizer.accumulate();
 }

--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
@@ -126,8 +126,10 @@ public:
             u32 width = (u32)(ceilf((m_xmax - m_xmin) * x_scale)) + 1;
             u32 height = (u32)(ceilf((font_ascender - font_descender) * y_scale)) + 1;
             Gfx::PathRasterizer rasterizer(Gfx::IntSize(width, height));
-            rasterizer.translate(subpixel_offset.to_float_point());
-            auto affine = Gfx::AffineTransform().scale(x_scale, -y_scale).translate(-m_xmin, -font_ascender);
+            auto affine = Gfx::AffineTransform()
+                              .translate(subpixel_offset.to_float_point())
+                              .scale(x_scale, -y_scale)
+                              .translate(-m_xmin, -font_ascender);
 
             rasterize_composite_loop(rasterizer, affine, glyph_callback);
 

--- a/Userland/Libraries/LibGfx/Font/PathRasterizer.cpp
+++ b/Userland/Libraries/LibGfx/Font/PathRasterizer.cpp
@@ -20,7 +20,7 @@ PathRasterizer::PathRasterizer(Gfx::IntSize size)
 void PathRasterizer::draw_path(Gfx::Path& path)
 {
     for (auto& line : path.split_lines())
-        draw_line(line.from.translated(translation()), line.to.translated(translation()));
+        draw_line(line.from, line.to);
 }
 
 RefPtr<Gfx::Bitmap> PathRasterizer::accumulate()

--- a/Userland/Libraries/LibGfx/Font/PathRasterizer.h
+++ b/Userland/Libraries/LibGfx/Font/PathRasterizer.h
@@ -18,15 +18,10 @@ public:
     void draw_path(Gfx::Path&);
     RefPtr<Gfx::Bitmap> accumulate();
 
-    void translate(Gfx::FloatPoint delta) { m_translation.translate_by(delta); }
-    Gfx::FloatPoint translation() const { return m_translation; }
-
 private:
     void draw_line(Gfx::FloatPoint, Gfx::FloatPoint);
 
     Gfx::IntSize m_size;
-    Gfx::FloatPoint m_translation;
-
     Vector<float> m_data;
 };
 

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
@@ -22,7 +22,7 @@ public:
     PDFErrorOr<void> create(ReadonlyBytes const&, RefPtr<Encoding>, size_t cleartext_length, size_t encrypted_length);
 
     RefPtr<Gfx::Bitmap> rasterize_glyph(u32 char_code, float width, Gfx::GlyphSubpixelOffset);
-    Gfx::Path build_char(u32 char_code, float width);
+    Gfx::Path build_char(u32 char_code, float width, Gfx::GlyphSubpixelOffset);
 
     RefPtr<Encoding> encoding() const { return m_encoding; }
     Gfx::FloatPoint glyph_translation(u32 char_code, float width) const;


### PR DESCRIPTION
Was going to fix this up but was ninja merged :^)

> Can we make the translation part of the AffineTransform instead of doing it separately?

Yep, I'd just mixed up my order of transformations before so did it separately. 


