### PR TITLE
PixelPaint: Ensure layers are painted consistently when panning and zooming

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -37,17 +37,16 @@ Image::Image(Gfx::IntSize size)
 {
 }
 
-void Image::paint_into(GUI::Painter& painter, Gfx::IntRect const& dest_rect) const
+void Image::paint_into(GUI::Painter& painter, Gfx::IntRect const& dest_rect, float scale) const
 {
-    float scale = (float)dest_rect.width() / (float)rect().width();
     Gfx::PainterStateSaver saver(painter);
     painter.add_clip_rect(dest_rect);
     for (auto const& layer : m_layers) {
         if (!layer.is_visible())
             continue;
-        auto target = dest_rect.translated(layer.location().x() * scale, layer.location().y() * scale);
+        auto target = dest_rect.to_type<float>().translated(layer.location().x() * scale, layer.location().y() * scale);
         target.set_size(layer.size().width() * scale, layer.size().height() * scale);
-        painter.draw_scaled_bitmap(target, layer.display_bitmap(), layer.rect(), (float)layer.opacity_percent() / 100.0f);
+        painter.draw_scaled_bitmap(target.to_type<int>(), layer.display_bitmap(), layer.rect(), (float)layer.opacity_percent() / 100.0f);
     }
 }
 
@@ -150,7 +149,7 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Image::try_compose_bitmap(Gfx::BitmapFormat 
 {
     auto bitmap = TRY(Gfx::Bitmap::create(format, m_size));
     GUI::Painter painter(bitmap);
-    paint_into(painter, { 0, 0, m_size.width(), m_size.height() });
+    paint_into(painter, { 0, 0, m_size.width(), m_size.height() }, 1.0f);
     return bitmap;
 }
 
@@ -343,7 +342,7 @@ void Image::flatten_all_layers()
     auto& bottom_layer = m_layers.at(0);
 
     GUI::Painter painter(bottom_layer.content_bitmap());
-    paint_into(painter, { 0, 0, m_size.width(), m_size.height() });
+    paint_into(painter, { 0, 0, m_size.width(), m_size.height() }, 1.0f);
 
     for (size_t index = m_layers.size() - 1; index > 0; index--) {
         auto& layer = m_layers.at(index);
@@ -364,7 +363,7 @@ void Image::merge_visible_layers()
         if (m_layers.at(index).is_visible()) {
             auto& bottom_layer = m_layers.at(index);
             GUI::Painter painter(bottom_layer.content_bitmap());
-            paint_into(painter, { 0, 0, m_size.width(), m_size.height() });
+            paint_into(painter, { 0, 0, m_size.width(), m_size.height() }, 1.0f);
             select_layer(&bottom_layer);
             index++;
             break;

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -69,7 +69,7 @@ public:
     ErrorOr<NonnullRefPtr<Image>> take_snapshot() const;
     ErrorOr<void> restore_snapshot(Image const&);
 
-    void paint_into(GUI::Painter&, Gfx::IntRect const& dest_rect) const;
+    void paint_into(GUI::Painter&, Gfx::IntRect const& dest_rect, float scale) const;
 
     ErrorOr<void> serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const;
     ErrorOr<void> export_bmp_to_file(NonnullOwnPtr<Core::Stream::Stream>, bool preserve_alpha_channel) const;

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -153,10 +153,10 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
     Gfx::StylePainter::paint_transparency_grid(painter, content_rect(), palette());
 
     painter.draw_rect(content_rect().inflated(2, 2), Color::Black);
-    m_image->paint_into(painter, content_rect());
+    m_image->paint_into(painter, content_rect(), scale());
 
     if (m_active_layer && m_show_active_layer_boundary)
-        painter.draw_rect(content_to_frame_rect(m_active_layer->relative_rect()).to_rounded<int>().inflated(2, 2), Color::Black);
+        painter.draw_rect(content_to_frame_rect(m_active_layer->relative_rect()).to_type<int>().inflated(2, 2), Color::Black);
 
     if (m_show_pixel_grid && scale() > m_pixel_grid_threshold) {
         auto event_image_rect = enclosing_int_rect(frame_to_content_rect(event.rect())).inflated(1, 1);


### PR DESCRIPTION
This patch aims to fix an issue where whitespace would appear at the edges of a layer when panning and zooming.

This behaviour was caused by rounding errors when calculating the position and size of the destination rect in `Image::paint_into()`.

Here is a video showing the edge of the canvas appearing and disappearing at the bottom and right edge of the layer when zooming:
 (you may need to enlarge the video to see the offending whitespace.)

https://user-images.githubusercontent.com/2817754/210777858-51bc821d-d5e4-4255-a764-62227b13c3fb.mp4

After:

https://user-images.githubusercontent.com/2817754/210777903-de123677-6e71-4d6e-b18c-954cfb3d1b2c.mp4