### PR TITLE
Meta/Lagom: Link Threads::Threads

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -54,6 +54,9 @@ endif()
 option(BUILD_SHARED_LIBS "Build shared libraries instead of static libraries" ON)
 
 find_package(Threads REQUIRED)
+# FIXME: This global link libraries is required to workaround linker issues (on some systems)
+# from the Ladybird import. See https://github.com/SerenityOS/serenity/issues/16847
+link_libraries(Threads::Threads)
 
 if (ENABLE_LAGOM_CCACHE)
     include(setup_ccache)


### PR DESCRIPTION
This is required for me to be able to build both Serenity and Ladybird from the same repo. Without this the two builds seem to stomp on each other, then fail to link.

cc @ADKaster, I'm not sure this is the correct fix or if something else is broken, but it's been quite a pain trying to use Ladybird since the merge.