### PR TITLE
LibPDF: Add support for outline destinations in Name Trees

### DIFF
--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -355,7 +355,8 @@ void PDFViewerWidget::open_file(Core::File& file)
     if (maybe_error.is_error()) {
         auto error = maybe_error.release_error();
         warnln("{}", error.message());
-        GUI::MessageBox::show_error(nullptr, "Failed to load the document."sv);
+        auto user_error_message = DeprecatedString::formatted("Failed to load the document. Error:\n{}.", error.message());
+        GUI::MessageBox::show_error(nullptr, user_error_message.view());
     }
 }
 

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -93,12 +93,14 @@
     A(Length1)                    \
     A(Length2)                    \
     A(Length3)                    \
+    A(Limits)                     \
     A(Linearized)                 \
     A(ML)                         \
     A(Matrix)                     \
     A(MediaBox)                   \
     A(MissingWidth)               \
     A(N)                          \
+    A(Names)                      \
     A(Next)                       \
     A(O)                          \
     A(OP)                         \

--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -232,9 +232,15 @@ PDFErrorOr<Destination> Document::create_destination_from_parameters(NonnullRefP
     auto page_ref = array->at(0);
     auto type_name = TRY(array->get_name_at(this, 1))->name();
 
-    Vector<float> parameters;
-    for (size_t i = 2; i < array->size(); i++)
-        parameters.append(array->at(i).to_float());
+    Vector<Optional<float>> parameters;
+    TRY(parameters.try_ensure_capacity(array->size() - 2));
+    for (size_t i = 2; i < array->size(); i++) {
+        auto& param = array->at(i);
+        if (param.has<nullptr_t>())
+            parameters.unchecked_append({});
+        else
+            parameters.append(param.to_float());
+    }
 
     Destination::Type type;
     if (type_name == CommonNames::XYZ) {

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -116,20 +116,7 @@ public:
     template<IsValueType T>
     PDFErrorOr<UnwrappedValueType<T>> resolve_to(Value const& value)
     {
-        auto resolved = TRY(resolve(value));
-
-        if constexpr (IsSame<T, bool>)
-            return resolved.get<bool>();
-        else if constexpr (IsSame<T, int>)
-            return resolved.get<int>();
-        else if constexpr (IsSame<T, float>)
-            return resolved.get<float>();
-        else if constexpr (IsSame<T, Object>)
-            return resolved.get<NonnullRefPtr<Object>>();
-        else if constexpr (IsObject<T>)
-            return resolved.get<NonnullRefPtr<Object>>()->cast<T>();
-
-        VERIFY_NOT_REACHED();
+        return cast_to<T>(TRY(resolve(value)));
     }
 
 private:

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -136,6 +136,7 @@ private:
     PDFErrorOr<NonnullRefPtrVector<OutlineItem>> build_outline_item_chain(Value const& first_ref, HashMap<u32, u32> const&);
 
     PDFErrorOr<Destination> create_destination_from_parameters(NonnullRefPtr<ArrayObject>, HashMap<u32, u32> const&);
+    PDFErrorOr<Destination> create_destination_from_dictionary_entry(NonnullRefPtr<Object> const& entry, HashMap<u32, u32> const& page_number_by_index_ref);
 
     PDFErrorOr<NonnullRefPtr<Object>> get_inheritable_object(FlyString const& name, NonnullRefPtr<DictObject>);
 

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -139,6 +139,10 @@ private:
 
     PDFErrorOr<NonnullRefPtr<Object>> get_inheritable_object(FlyString const& name, NonnullRefPtr<DictObject>);
 
+    PDFErrorOr<NonnullRefPtr<Object>> find_in_name_tree(NonnullRefPtr<DictObject> root, FlyString name);
+    PDFErrorOr<NonnullRefPtr<Object>> find_in_name_tree_nodes(NonnullRefPtr<ArrayObject> siblings, FlyString name);
+    PDFErrorOr<NonnullRefPtr<Object>> find_in_key_value_array(NonnullRefPtr<ArrayObject> key_value_array, FlyString name);
+
     NonnullRefPtr<DocumentParser> m_parser;
     RefPtr<DictObject> m_catalog;
     RefPtr<DictObject> m_trailer;

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -227,16 +227,16 @@ struct Formatter<PDF::Destination> : Formatter<FormatString> {
         }
 
         StringBuilder param_builder;
-        TRY(Formatter<FormatString>::format(builder, "{{ type={} page="sv, type_str));
-        if (destination.page.has_value())
-            TRY(builder.put_literal("{}"sv));
+        builder.builder().appendff("{{ type={} page="sv, type_str);
+        if (!destination.page.has_value())
+            TRY(builder.put_literal("{{}}"sv));
         else
             TRY(builder.put_u64(destination.page.value()));
         for (auto& param : destination.parameters) {
             TRY(builder.put_f64(double(param)));
             TRY(builder.put_literal(" "sv));
         }
-        return builder.put_literal("}}"sv);
+        return builder.put_literal(" }}"sv);
     }
 };
 

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -51,7 +51,7 @@ struct Destination {
 
     Type type;
     Optional<u32> page;
-    Vector<float> parameters;
+    Vector<Optional<float>> parameters;
 };
 
 struct OutlineItem final : public RefCounted<OutlineItem> {
@@ -232,9 +232,15 @@ struct Formatter<PDF::Destination> : Formatter<FormatString> {
             TRY(builder.put_literal("{{}}"sv));
         else
             TRY(builder.put_u64(destination.page.value()));
-        for (auto& param : destination.parameters) {
-            TRY(builder.put_f64(double(param)));
-            TRY(builder.put_literal(" "sv));
+        if (!destination.parameters.is_empty()) {
+            TRY(builder.put_literal(" parameters="sv));
+            for (auto const& param : destination.parameters) {
+                if (param.has_value())
+                    TRY(builder.put_f64(double(param.value())));
+                else
+                    TRY(builder.put_literal("{{}}"sv));
+                TRY(builder.put_literal(" "sv));
+            }
         }
         return builder.put_literal(" }}"sv);
     }

--- a/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
+++ b/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
@@ -10,6 +10,11 @@
 
 namespace PDF {
 
+PDFErrorOr<NonnullRefPtr<Object>> ArrayObject::get_object_at(Document* document, size_t index) const
+{
+    return document->resolve_to<Object>(at(index));
+}
+
 PDFErrorOr<NonnullRefPtr<Object>> DictObject::get_object(Document* document, FlyString const& key) const
 {
     return document->resolve_to<Object>(get_value(key));
@@ -23,10 +28,22 @@ PDFErrorOr<NonnullRefPtr<Object>> DictObject::get_object(Document* document, Fly
         return document->resolve_to<class_name>(m_elements[index]);                                                    \
     }                                                                                                                  \
                                                                                                                        \
+    NonnullRefPtr<class_name> ArrayObject::get_##snake_name##_at(size_t index) const                                   \
+    {                                                                                                                  \
+        VERIFY(index < m_elements.size());                                                                             \
+        return cast_to<class_name>(m_elements[index]);                                                                 \
+    }                                                                                                                  \
+                                                                                                                       \
     PDFErrorOr<NonnullRefPtr<class_name>> DictObject::get_##snake_name(Document* document, FlyString const& key) const \
     {                                                                                                                  \
-        return document->resolve_to<class_name>(get(key).value());                                                     \
+        return document->resolve_to<class_name>(get_value(key));                                                       \
+    }                                                                                                                  \
+                                                                                                                       \
+    NonnullRefPtr<class_name> DictObject::get_##snake_name(FlyString const& key) const                                 \
+    {                                                                                                                  \
+        return cast_to<class_name>(get_value(key));                                                                    \
     }
+
 ENUMERATE_OBJECT_TYPES(DEFINE_ACCESSORS)
 #undef DEFINE_INDEXER
 

--- a/Userland/Libraries/LibPDF/ObjectDerivatives.h
+++ b/Userland/Libraries/LibPDF/ObjectDerivatives.h
@@ -82,8 +82,12 @@ public:
     ALWAYS_INLINE Value const& operator[](size_t index) const { return at(index); }
     ALWAYS_INLINE Value const& at(size_t index) const { return m_elements[index]; }
 
-#define DEFINE_INDEXER(class_name, snake_name) \
-    PDFErrorOr<NonnullRefPtr<class_name>> get_##snake_name##_at(Document*, size_t index) const;
+    PDFErrorOr<NonnullRefPtr<Object>> get_object_at(Document* document, size_t index) const;
+    NonnullRefPtr<Object> get_object_at(size_t index) const { return at(index).get<NonnullRefPtr<Object>>(); };
+
+#define DEFINE_INDEXER(class_name, snake_name)                                                  \
+    PDFErrorOr<NonnullRefPtr<class_name>> get_##snake_name##_at(Document*, size_t index) const; \
+    NonnullRefPtr<class_name> get_##snake_name##_at(size_t index) const;
     ENUMERATE_OBJECT_TYPES(DEFINE_INDEXER)
 #undef DEFINE_INDEXER
 
@@ -128,8 +132,9 @@ public:
 
     PDFErrorOr<NonnullRefPtr<Object>> get_object(Document*, FlyString const& key) const;
 
-#define DEFINE_GETTER(class_name, snake_name) \
-    PDFErrorOr<NonnullRefPtr<class_name>> get_##snake_name(Document*, FlyString const& key) const;
+#define DEFINE_GETTER(class_name, snake_name)                                                      \
+    PDFErrorOr<NonnullRefPtr<class_name>> get_##snake_name(Document*, FlyString const& key) const; \
+    NonnullRefPtr<class_name> get_##snake_name(FlyString const& key) const;
     ENUMERATE_OBJECT_TYPES(DEFINE_GETTER)
 #undef DEFINE_GETTER
 

--- a/Userland/Libraries/LibPDF/ObjectDerivatives.h
+++ b/Userland/Libraries/LibPDF/ObjectDerivatives.h
@@ -195,4 +195,20 @@ private:
     Value m_value;
 };
 
+template<IsValueType T>
+UnwrappedValueType<T> cast_to(Value const& value)
+{
+    if constexpr (IsSame<T, bool>)
+        return value.get<bool>();
+    else if constexpr (IsSame<T, int>)
+        return value.get<int>();
+    else if constexpr (IsSame<T, float>)
+        return value.get<float>();
+    else if constexpr (IsSame<T, Object>)
+        return value.get<NonnullRefPtr<Object>>();
+    else if constexpr (IsObject<T>)
+        return value.get<NonnullRefPtr<Object>>()->cast<T>();
+    VERIFY_NOT_REACHED();
+}
+
 }


### PR DESCRIPTION
PDF outline destinations (i.e., information of the page/zoom/location-in-page of each item in the Outline) can be stored in a few different parts of the document, and one of those (destinations in a "Name Tree") was not implemented yet. With the destination missing, the titles were still being shown in the Outline View, but upon selection the document didn't change to the requested page. The PDF specification document uses this mechanism, which is how I found the missing functionality.

This PR implements that missing functionality. It also takes the chance to improve a bit some of the core Object classes in LibPDF for easier object navigation/extraction.

Before:
![PDF32000_2008.pdf_p1_before](https://user-images.githubusercontent.com/620848/210838443-45badc6e-1a73-4554-a101-145087127bfb.png)

After:
![PDF32000_2008.pdf_p1_after](https://user-images.githubusercontent.com/620848/210838477-f3d536b7-9bbe-46b9-b018-9d0db905340e.png)