### PR TITLE
LibWeb+WebContent: Use new String class in CSS::StyleValue

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
@@ -71,7 +71,7 @@ enum class MediaFeatureID {)~~~");
 };
 
 Optional<MediaFeatureID> media_feature_id_from_string(StringView);
-char const* string_from_media_feature_id(MediaFeatureID);
+StringView string_from_media_feature_id(MediaFeatureID);
 
 bool media_feature_type_is_range(MediaFeatureID);
 bool media_feature_accepts_type(MediaFeatureID, MediaFeatureValueType);
@@ -109,7 +109,7 @@ Optional<MediaFeatureID> media_feature_id_from_string(StringView string)
     return {};
 }
 
-char const* string_from_media_feature_id(MediaFeatureID media_feature_id)
+StringView string_from_media_feature_id(MediaFeatureID media_feature_id)
 {
     switch (media_feature_id) {)~~~");
 
@@ -119,7 +119,7 @@ char const* string_from_media_feature_id(MediaFeatureID media_feature_id)
         member_generator.set("name:titlecase", title_casify(name));
         member_generator.append(R"~~~(
     case MediaFeatureID::@name:titlecase@:
-        return "@name@";)~~~");
+        return "@name@"sv;)~~~");
     });
 
     generator.append(R"~~~(

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
@@ -68,7 +68,7 @@ enum class ValueID {
 };
 
 ValueID value_id_from_string(StringView);
-const char* string_from_value_id(ValueID);
+StringView string_from_value_id(ValueID);
 
 }
 
@@ -107,7 +107,7 @@ ValueID value_id_from_string(StringView string)
     return ValueID::Invalid;
 }
 
-const char* string_from_value_id(ValueID value_id) {
+StringView string_from_value_id(ValueID value_id) {
     switch (value_id) {
 )~~~");
 
@@ -117,13 +117,13 @@ const char* string_from_value_id(ValueID value_id) {
         member_generator.set("name:titlecase", title_casify(name.to_deprecated_string()));
         member_generator.append(R"~~~(
     case ValueID::@name:titlecase@:
-        return "@name@";
+        return "@name@"sv;
         )~~~");
     });
 
     generator.append(R"~~~(
     default:
-        return "(invalid CSS::ValueID)";
+        return "(invalid CSS::ValueID)"sv;
     }
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Angle.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Angle.cpp
@@ -41,11 +41,11 @@ Angle Angle::percentage_of(Percentage const& percentage) const
     return Angle { percentage.as_fraction() * m_value, m_type };
 }
 
-DeprecatedString Angle::to_deprecated_string() const
+ErrorOr<String> Angle::to_string() const
 {
     if (is_calculated())
-        return m_calculated_style->to_deprecated_string();
-    return DeprecatedString::formatted("{}{}", m_value, unit_name());
+        return m_calculated_style->to_string();
+    return String::formatted("{}{}", m_value, unit_name());
 }
 
 float Angle::to_degrees() const

--- a/Userland/Libraries/LibWeb/CSS/Angle.h
+++ b/Userland/Libraries/LibWeb/CSS/Angle.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/RefPtr.h>
+#include <AK/String.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -33,7 +33,7 @@ public:
     bool is_calculated() const { return m_type == Type::Calculated; }
     NonnullRefPtr<CalculatedStyleValue> calculated_style_value() const;
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
     float to_degrees() const;
 
     bool operator==(Angle const& other) const
@@ -57,6 +57,6 @@ template<>
 struct AK::Formatter<Web::CSS::Angle> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::Angle const& angle)
     {
-        return Formatter<StringView>::format(builder, angle.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(angle.to_string()));
     }
 };

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -201,7 +201,7 @@ DeprecatedString CSSStyleDeclaration::get_property_value(StringView property_nam
     auto maybe_property = property(property_id);
     if (!maybe_property.has_value())
         return {};
-    return maybe_property->value->to_deprecated_string();
+    return maybe_property->value->to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertypriority
@@ -291,7 +291,7 @@ DeprecatedString PropertyOwningCSSStyleDeclaration::serialized() const
         // FIXME: 4. Shorthand loop: For each shorthand in shorthands, follow these substeps: ...
 
         // 5. Let value be the result of invoking serialize a CSS value of declaration.
-        auto value = declaration.value->to_deprecated_string();
+        auto value = declaration.value->to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 
         // 6. Let serialized declaration be the result of invoking serialize a CSS declaration with property name property, value value,
         //    and the important flag set if declaration has its important flag set.
@@ -340,7 +340,7 @@ JS::ThrowCompletionOr<JS::Value> CSSStyleDeclaration::internal_get(JS::PropertyK
     if (property_id == CSS::PropertyID::Invalid)
         return Base::internal_get(name, receiver);
     if (auto maybe_property = property(property_id); maybe_property.has_value())
-        return { JS::PrimitiveString::create(vm(), maybe_property->value->to_deprecated_string()) };
+        return { JS::PrimitiveString::create(vm(), maybe_property->value->to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string()) };
     return { JS::PrimitiveString::create(vm(), DeprecatedString::empty()) };
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Frequency.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.cpp
@@ -40,11 +40,11 @@ Frequency Frequency::percentage_of(Percentage const& percentage) const
     return Frequency { percentage.as_fraction() * m_value, m_type };
 }
 
-DeprecatedString Frequency::to_deprecated_string() const
+ErrorOr<String> Frequency::to_string() const
 {
     if (is_calculated())
-        return m_calculated_style->to_deprecated_string();
-    return DeprecatedString::formatted("{}{}", m_value, unit_name());
+        return m_calculated_style->to_string();
+    return String::formatted("{}{}", m_value, unit_name());
 }
 
 float Frequency::to_hertz() const

--- a/Userland/Libraries/LibWeb/CSS/Frequency.h
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/RefPtr.h>
+#include <AK/String.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -30,7 +30,7 @@ public:
     bool is_calculated() const { return m_type == Type::Calculated; }
     NonnullRefPtr<CalculatedStyleValue> calculated_style_value() const;
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
     float to_hertz() const;
 
     bool operator==(Frequency const& other) const
@@ -54,6 +54,6 @@ template<>
 struct AK::Formatter<Web::CSS::Frequency> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::Frequency const& frequency)
     {
-        return Formatter<StringView>::format(builder, frequency.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(frequency.to_string()));
     }
 };

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
@@ -33,25 +33,25 @@ GridTrackPlacement::GridTrackPlacement()
 {
 }
 
-DeprecatedString GridTrackPlacement::to_deprecated_string() const
+ErrorOr<String> GridTrackPlacement::to_string() const
 {
     StringBuilder builder;
     if (is_auto()) {
         builder.append("auto"sv);
-        return builder.to_deprecated_string();
+        return builder.to_string();
     }
     if (is_span()) {
         builder.append("span"sv);
         builder.append(" "sv);
     }
     if (m_span_count_or_position != 0) {
-        builder.append(DeprecatedString::number(m_span_count_or_position));
+        builder.append(TRY(String::number(m_span_count_or_position)));
         builder.append(" "sv);
     }
     if (has_line_name()) {
         builder.append(m_line_name);
     }
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <AK/String.h>
 
 namespace Web::CSS {
 
@@ -36,7 +37,7 @@ public:
     Type type() const { return m_type; }
     DeprecatedString line_name() const { return m_line_name; }
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
     bool operator==(GridTrackPlacement const& other) const
     {
         return m_type == other.type() && m_span_count_or_position == other.raw_value();

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -6,6 +6,7 @@
 
 #include "GridTrackSize.h"
 #include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/Percentage.h>
 #include <LibWeb/CSS/StyleValue.h>
@@ -44,15 +45,15 @@ GridSize GridSize::make_auto()
     return GridSize(CSS::Length::make_auto());
 }
 
-DeprecatedString GridSize::to_deprecated_string() const
+ErrorOr<String> GridSize::to_string() const
 {
     switch (m_type) {
     case Type::Length:
-        return m_length.to_deprecated_string();
+        return m_length.to_string();
     case Type::Percentage:
-        return m_percentage.to_deprecated_string();
+        return m_percentage.to_string();
     case Type::FlexibleLength:
-        return DeprecatedString::formatted("{}fr", m_flexible_length);
+        return String::formatted("{}fr", m_flexible_length);
     }
     VERIFY_NOT_REACHED();
 }
@@ -68,15 +69,15 @@ GridMinMax::GridMinMax(GridSize min_grid_size, GridSize max_grid_size)
 {
 }
 
-DeprecatedString GridMinMax::to_deprecated_string() const
+ErrorOr<String> GridMinMax::to_string() const
 {
     StringBuilder builder;
     builder.append("minmax("sv);
-    builder.appendff("{}", m_min_grid_size.to_deprecated_string());
+    builder.appendff("{}", TRY(m_min_grid_size.to_string()));
     builder.append(", "sv);
-    builder.appendff("{}", m_max_grid_size.to_deprecated_string());
+    builder.appendff("{}", TRY(m_max_grid_size.to_string()));
     builder.append(")"sv);
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 GridRepeat::GridRepeat(GridTrackSizeList grid_track_size_list, int repeat_count)
@@ -96,7 +97,7 @@ GridRepeat::GridRepeat()
 {
 }
 
-DeprecatedString GridRepeat::to_deprecated_string() const
+ErrorOr<String> GridRepeat::to_string() const
 {
     StringBuilder builder;
     builder.append("repeat("sv);
@@ -114,9 +115,9 @@ DeprecatedString GridRepeat::to_deprecated_string() const
         VERIFY_NOT_REACHED();
     }
     builder.append(", "sv);
-    builder.appendff("{}", m_grid_track_size_list.to_deprecated_string());
+    builder.appendff("{}", TRY(m_grid_track_size_list.to_string()));
     builder.append(")"sv);
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 ExplicitGridTrack::ExplicitGridTrack(CSS::GridMinMax grid_minmax)
@@ -137,15 +138,15 @@ ExplicitGridTrack::ExplicitGridTrack(CSS::GridSize grid_size)
 {
 }
 
-DeprecatedString ExplicitGridTrack::to_deprecated_string() const
+ErrorOr<String> ExplicitGridTrack::to_string() const
 {
     switch (m_type) {
     case Type::MinMax:
-        return m_grid_minmax.to_deprecated_string();
+        return m_grid_minmax.to_string();
     case Type::Repeat:
-        return m_grid_repeat.to_deprecated_string();
+        return m_grid_repeat.to_string();
     case Type::Default:
-        return m_grid_size.to_deprecated_string();
+        return m_grid_size.to_string();
     default:
         VERIFY_NOT_REACHED();
     }
@@ -168,7 +169,7 @@ GridTrackSizeList GridTrackSizeList::make_auto()
     return GridTrackSizeList();
 }
 
-DeprecatedString GridTrackSizeList::to_deprecated_string() const
+ErrorOr<String> GridTrackSizeList::to_string() const
 {
     StringBuilder builder;
     auto print_line_names = [&](size_t index) -> void {
@@ -186,7 +187,7 @@ DeprecatedString GridTrackSizeList::to_deprecated_string() const
             print_line_names(i);
             builder.append(" "sv);
         }
-        builder.append(m_track_list[i].to_deprecated_string());
+        builder.append(TRY(m_track_list[i].to_string()));
         if (i < m_track_list.size() - 1)
             builder.append(" "sv);
     }
@@ -194,7 +195,7 @@ DeprecatedString GridTrackSizeList::to_deprecated_string() const
         builder.append(" "sv);
         print_line_names(m_track_list.size());
     }
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
@@ -52,7 +52,7 @@ public:
         return (m_type == Type::Length && !m_length.is_auto()) || is_percentage();
     }
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
     bool operator==(GridSize const& other) const
     {
         return m_type == other.type()
@@ -78,7 +78,7 @@ public:
     GridSize min_grid_size() const& { return m_min_grid_size; }
     GridSize max_grid_size() const& { return m_max_grid_size; }
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
     bool operator==(GridMinMax const& other) const
     {
         return m_min_grid_size == other.min_grid_size()
@@ -100,7 +100,7 @@ public:
     Vector<CSS::ExplicitGridTrack> track_list() const { return m_track_list; }
     Vector<Vector<DeprecatedString>> line_names() const { return m_line_names; }
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
     bool operator==(GridTrackSizeList const& other) const
     {
         return m_line_names == other.line_names() && m_track_list == other.track_list();
@@ -133,7 +133,7 @@ public:
     GridTrackSizeList grid_track_size_list() const& { return m_grid_track_size_list; }
     Type type() const& { return m_type; }
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
     bool operator==(GridRepeat const& other) const
     {
         if (m_type != other.type())
@@ -183,7 +183,7 @@ public:
 
     Type type() const { return m_type; }
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
     bool operator==(ExplicitGridTrack const& other) const
     {
         if (is_repeat() && other.is_repeat())

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -112,13 +112,13 @@ CSSPixels Length::to_px(Layout::Node const& layout_node) const
     return to_px(viewport_rect, layout_node.font().pixel_metrics(), layout_node.computed_values().font_size(), root_element->layout_node()->computed_values().font_size());
 }
 
-DeprecatedString Length::to_deprecated_string() const
+ErrorOr<String> Length::to_string() const
 {
     if (is_calculated())
-        return m_calculated_style->to_deprecated_string();
+        return m_calculated_style->to_string();
     if (is_auto())
-        return "auto";
-    return DeprecatedString::formatted("{}{}", m_value, unit_name());
+        return String::from_utf8("auto"sv);
+    return String::formatted("{}{}", m_value, unit_name());
 }
 
 char const* Length::unit_name() const

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <LibGfx/Forward.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
@@ -118,7 +119,7 @@ public:
         }
     }
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
 
     // We have a RefPtr<CalculatedStyleValue> member, but can't include the header StyleValue.h as it includes
     // this file already. To break the cyclic dependency, we must move all method definitions out.
@@ -141,6 +142,6 @@ template<>
 struct AK::Formatter<Web::CSS::Length> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::Length const& length)
     {
-        return Formatter<StringView>::format(builder, length.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(length.to_string()));
     }
 };

--- a/Userland/Libraries/LibWeb/CSS/MediaList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.cpp
@@ -49,7 +49,7 @@ DeprecatedString MediaList::item(u32 index) const
     if (!is_supported_property_index(index))
         return {};
 
-    return m_media[index].to_deprecated_string();
+    return m_media[index].to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 // https://www.w3.org/TR/cssom-1/#dom-medialist-appendmedium
@@ -70,7 +70,7 @@ void MediaList::delete_medium(DeprecatedString medium)
     if (!m)
         return;
     m_media.remove_all_matching([&](auto& existing) -> bool {
-        return m->to_deprecated_string() == existing->to_deprecated_string();
+        return m->to_string().release_value_but_fixme_should_propagate_errors() == existing->to_string().release_value_but_fixme_should_propagate_errors();
     });
     // FIXME: If nothing was removed, then throw a NotFoundError exception.
 }
@@ -100,7 +100,7 @@ JS::Value MediaList::item_value(size_t index) const
 {
     if (index >= m_media.size())
         return JS::js_undefined();
-    return JS::PrimitiveString::create(vm(), m_media[index].to_deprecated_string());
+    return JS::PrimitiveString::create(vm(), m_media[index].to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string());
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.h
@@ -47,7 +47,7 @@ public:
     {
     }
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
 
     bool is_ident() const { return m_value.has<ValueID>(); }
     bool is_length() const { return m_value.has<Length>(); }
@@ -146,7 +146,7 @@ public:
     }
 
     bool evaluate(HTML::Window const&) const;
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
 
 private:
     enum class Type {
@@ -202,7 +202,7 @@ struct MediaCondition {
     static NonnullOwnPtr<MediaCondition> from_or_list(NonnullOwnPtrVector<MediaCondition>&&);
 
     MatchResult evaluate(HTML::Window const&) const;
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
 
 private:
     MediaCondition() = default;
@@ -241,7 +241,7 @@ public:
 
     bool matches() const { return m_matches; }
     bool evaluate(HTML::Window const&);
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
 
 private:
     MediaQuery() = default;
@@ -270,7 +270,7 @@ template<>
 struct Formatter<Web::CSS::MediaFeature> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::MediaFeature const& media_feature)
     {
-        return Formatter<StringView>::format(builder, media_feature.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(media_feature.to_string()));
     }
 };
 
@@ -278,7 +278,7 @@ template<>
 struct Formatter<Web::CSS::MediaCondition> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::MediaCondition const& media_condition)
     {
-        return Formatter<StringView>::format(builder, media_condition.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(media_condition.to_string()));
     }
 };
 
@@ -286,7 +286,7 @@ template<>
 struct Formatter<Web::CSS::MediaQuery> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::MediaQuery const& media_query)
     {
-        return Formatter<StringView>::format(builder, media_query.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(media_query.to_string()));
     }
 };
 

--- a/Userland/Libraries/LibWeb/CSS/Number.h
+++ b/Userland/Libraries/LibWeb/CSS/Number.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <math.h>
 
@@ -69,11 +69,11 @@ public:
         return { Type::Number, m_value / other.m_value };
     }
 
-    DeprecatedString to_deprecated_string() const
+    ErrorOr<String> to_string() const
     {
         if (m_type == Type::IntegerWithExplicitSign)
-            return DeprecatedString::formatted("{:+}", m_value);
-        return DeprecatedString::number(m_value);
+            return String::formatted("{:+}", m_value);
+        return String::number(m_value);
     }
 
     bool operator==(Number const& other) const
@@ -91,6 +91,6 @@ template<>
 struct AK::Formatter<Web::CSS::Number> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::Number const& number)
     {
-        return Formatter<StringView>::format(builder, number.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(number.to_string()));
     }
 };

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3966,7 +3966,7 @@ RefPtr<StyleValue> Parser::parse_color_value(ComponentValue const& component_val
 RefPtr<StyleValue> Parser::parse_string_value(ComponentValue const& component_value)
 {
     if (component_value.is(Token::Type::String))
-        return StringStyleValue::create(component_value.token().string());
+        return StringStyleValue::create(String::from_utf8(component_value.token().string()).release_value_but_fixme_should_propagate_errors());
 
     return {};
 }
@@ -5238,7 +5238,7 @@ RefPtr<StyleValue> Parser::parse_font_family_value(Vector<ComponentValue> const&
                 return nullptr;
             if (!is_comma_or_eof(i + 1))
                 return nullptr;
-            font_families.append(StringStyleValue::create(part.token().string()));
+            font_families.append(StringStyleValue::create(String::from_utf8(part.token().string()).release_value_but_fixme_should_propagate_errors()));
             i++;
             continue;
         }
@@ -5266,7 +5266,7 @@ RefPtr<StyleValue> Parser::parse_font_family_value(Vector<ComponentValue> const&
         if (part.is(Token::Type::Comma)) {
             if (current_name_parts.is_empty())
                 return nullptr;
-            font_families.append(StringStyleValue::create(DeprecatedString::join(' ', current_name_parts)));
+            font_families.append(StringStyleValue::create(String::from_utf8(DeprecatedString::join(' ', current_name_parts)).release_value_but_fixme_should_propagate_errors()));
             current_name_parts.clear();
             // Can't have a trailing comma
             if (i + 1 == component_values.size())
@@ -5276,7 +5276,7 @@ RefPtr<StyleValue> Parser::parse_font_family_value(Vector<ComponentValue> const&
     }
 
     if (!current_name_parts.is_empty()) {
-        font_families.append(StringStyleValue::create(DeprecatedString::join(' ', current_name_parts)));
+        font_families.append(StringStyleValue::create(String::from_utf8(DeprecatedString::join(' ', current_name_parts)).release_value_but_fixme_should_propagate_errors()));
         current_name_parts.clear();
     }
 

--- a/Userland/Libraries/LibWeb/CSS/Percentage.h
+++ b/Userland/Libraries/LibWeb/CSS/Percentage.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/Variant.h>
 #include <LibWeb/CSS/Angle.h>
 #include <LibWeb/CSS/Frequency.h>
@@ -31,9 +31,9 @@ public:
     float value() const { return m_value; }
     float as_fraction() const { return m_value * 0.01f; }
 
-    DeprecatedString to_deprecated_string() const
+    ErrorOr<String> to_string() const
     {
-        return DeprecatedString::formatted("{}%", m_value);
+        return String::formatted("{}%", m_value);
     }
 
     bool operator==(Percentage const& other) const { return m_value == other.m_value; }
@@ -128,12 +128,12 @@ public:
             });
     }
 
-    DeprecatedString to_deprecated_string() const
+    ErrorOr<String> to_string() const
     {
         if (is_percentage())
-            return m_value.template get<Percentage>().to_deprecated_string();
+            return m_value.template get<Percentage>().to_string();
 
-        return m_value.template get<T>().to_deprecated_string();
+        return m_value.template get<T>().to_string();
     }
 
     bool operator==(PercentageOr<T> const& other) const
@@ -231,7 +231,7 @@ template<>
 struct AK::Formatter<Web::CSS::Percentage> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::Percentage const& percentage)
     {
-        return Formatter<StringView>::format(builder, percentage.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(percentage.to_string()));
     }
 };
 
@@ -239,7 +239,7 @@ template<>
 struct AK::Formatter<Web::CSS::AnglePercentage> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::AnglePercentage const& angle_percentage)
     {
-        return Formatter<StringView>::format(builder, angle_percentage.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(angle_percentage.to_string()));
     }
 };
 
@@ -247,7 +247,7 @@ template<>
 struct AK::Formatter<Web::CSS::FrequencyPercentage> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::FrequencyPercentage const& frequency_percentage)
     {
-        return Formatter<StringView>::format(builder, frequency_percentage.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(frequency_percentage.to_string()));
     }
 };
 
@@ -255,7 +255,7 @@ template<>
 struct AK::Formatter<Web::CSS::LengthPercentage> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::LengthPercentage const& length_percentage)
     {
-        return Formatter<StringView>::format(builder, length_percentage.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(length_percentage.to_string()));
     }
 };
 
@@ -263,6 +263,6 @@ template<>
 struct AK::Formatter<Web::CSS::TimePercentage> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::TimePercentage const& time_percentage)
     {
-        return Formatter<StringView>::format(builder, time_percentage.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(time_percentage.to_string()));
     }
 };

--- a/Userland/Libraries/LibWeb/CSS/Ratio.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Ratio.cpp
@@ -22,9 +22,9 @@ bool Ratio::is_degenerate() const
         || !isfinite(m_second_value) || m_second_value == 0;
 }
 
-DeprecatedString Ratio::to_deprecated_string() const
+ErrorOr<String> Ratio::to_string() const
 {
-    return DeprecatedString::formatted("{} / {}", m_first_value, m_second_value);
+    return String::formatted("{} / {}", m_first_value, m_second_value);
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Ratio.h
+++ b/Userland/Libraries/LibWeb/CSS/Ratio.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 
 namespace Web::CSS {
 
@@ -17,7 +17,7 @@ public:
     float value() const { return m_first_value / m_second_value; }
     bool is_degenerate() const;
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
 
 private:
     float m_first_value { 0 };

--- a/Userland/Libraries/LibWeb/CSS/Resolution.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Resolution.cpp
@@ -21,9 +21,9 @@ Resolution::Resolution(float value, Type type)
 {
 }
 
-DeprecatedString Resolution::to_deprecated_string() const
+ErrorOr<String> Resolution::to_string() const
 {
-    return DeprecatedString::formatted("{}{}", m_value, unit_name());
+    return String::formatted("{}{}", m_value, unit_name());
 }
 
 float Resolution::to_dots_per_pixel() const

--- a/Userland/Libraries/LibWeb/CSS/Resolution.h
+++ b/Userland/Libraries/LibWeb/CSS/Resolution.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -24,7 +24,7 @@ public:
     Resolution(int value, Type type);
     Resolution(float value, Type type);
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
     float to_dots_per_pixel() const;
 
     bool operator==(Resolution const& other) const

--- a/Userland/Libraries/LibWeb/CSS/Serialize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Serialize.cpp
@@ -182,11 +182,11 @@ DeprecatedString serialize_a_url(StringView url)
     return builder.to_deprecated_string();
 }
 
-DeprecatedString serialize_a_srgb_value(Color color)
+ErrorOr<String> serialize_a_srgb_value(Color color)
 {
     StringBuilder builder;
     serialize_a_srgb_value(builder, color);
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Serialize.h
+++ b/Userland/Libraries/LibWeb/CSS/Serialize.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
@@ -29,7 +30,7 @@ DeprecatedString escape_a_character_as_code_point(u32 character);
 DeprecatedString serialize_an_identifier(StringView ident);
 DeprecatedString serialize_a_string(StringView string);
 DeprecatedString serialize_a_url(StringView url);
-DeprecatedString serialize_a_srgb_value(Color color);
+ErrorOr<String> serialize_a_srgb_value(Color color);
 
 template<typename T, typename SerializeItem>
 void serialize_a_comma_separated_list(StringBuilder& builder, Vector<T> const& items, SerializeItem serialize_item)

--- a/Userland/Libraries/LibWeb/CSS/Size.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Size.cpp
@@ -74,22 +74,22 @@ bool Size::contains_percentage() const
     }
 }
 
-DeprecatedString Size::to_deprecated_string() const
+ErrorOr<String> Size::to_string() const
 {
     switch (m_type) {
     case Type::Auto:
-        return "auto";
+        return String::from_utf8("auto"sv);
     case Type::Length:
     case Type::Percentage:
-        return m_length_percentage.to_deprecated_string();
+        return m_length_percentage.to_string();
     case Type::MinContent:
-        return "min-content";
+        return String::from_utf8("min-content"sv);
     case Type::MaxContent:
-        return "max-content";
+        return String::from_utf8("max-content"sv);
     case Type::FitContent:
-        return DeprecatedString::formatted("fit-content({})", m_length_percentage.to_deprecated_string());
+        return String::formatted("fit-content({})", TRY(m_length_percentage.to_string()));
     case Type::None:
-        return "none";
+        return String::from_utf8("none"sv);
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/Size.h
+++ b/Userland/Libraries/LibWeb/CSS/Size.h
@@ -63,7 +63,7 @@ public:
         return m_length_percentage.length();
     }
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
 
 private:
     Size(Type type, LengthPercentage);
@@ -78,6 +78,6 @@ template<>
 struct AK::Formatter<Web::CSS::Size> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::Size const& size)
     {
-        return Formatter<StringView>::format(builder, size.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(size.to_string()));
     }
 };

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1175,7 +1175,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
             if (family.is_identifier()) {
                 found_font = find_generic_font(family.to_identifier());
             } else if (family.is_string()) {
-                found_font = find_font(family.to_deprecated_string());
+                found_font = find_font(family.to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string());
             }
             if (found_font)
                 break;
@@ -1183,7 +1183,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
     } else if (family_value->is_identifier()) {
         found_font = find_generic_font(family_value->to_identifier());
     } else if (family_value->is_string()) {
-        found_font = find_font(family_value->to_deprecated_string());
+        found_font = find_font(family_value->to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string());
     }
 
     if (!found_font) {

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -81,7 +81,7 @@ CSS::Size StyleProperties::size_value(CSS::PropertyID id) const
     }
 
     // FIXME: Support `fit-content(<length>)`
-    dbgln("FIXME: Unsupported size value: `{}`, treating as `auto`", value->to_deprecated_string());
+    dbgln("FIXME: Unsupported size value: `{}`, treating as `auto`", value->to_string());
     return CSS::Size::make_auto();
 }
 
@@ -191,13 +191,13 @@ float StyleProperties::opacity() const
             if (maybe_percentage.has_value())
                 unclamped_opacity = maybe_percentage->as_fraction();
             else
-                dbgln("Unable to resolve calc() as opacity (percentage): {}", value->to_deprecated_string());
+                dbgln("Unable to resolve calc() as opacity (percentage): {}", value->to_string());
         } else {
             auto maybe_number = value->as_calculated().resolve_number();
             if (maybe_number.has_value())
                 unclamped_opacity = maybe_number.value();
             else
-                dbgln("Unable to resolve calc() as opacity (number): {}", value->to_deprecated_string());
+                dbgln("Unable to resolve calc() as opacity (number): {}", value->to_string());
         }
     } else if (value->is_percentage()) {
         unclamped_opacity = value->as_percentage().percentage().as_fraction();
@@ -488,7 +488,7 @@ CSS::ContentData StyleProperties::content() const
         StringBuilder builder;
         for (auto const& item : content_style_value.content().values()) {
             if (item.is_string()) {
-                builder.append(item.to_deprecated_string());
+                builder.append(item.to_string().release_value_but_fixme_should_propagate_errors());
             } else {
                 // TODO: Implement quotes, counters, images, and other things.
             }
@@ -500,7 +500,7 @@ CSS::ContentData StyleProperties::content() const
             StringBuilder alt_text_builder;
             for (auto const& item : content_style_value.alt_text()->values()) {
                 if (item.is_string()) {
-                    alt_text_builder.append(item.to_deprecated_string());
+                    alt_text_builder.append(item.to_string().release_value_but_fixme_should_propagate_errors());
                 } else {
                     // TODO: Implement counters
                 }
@@ -598,7 +598,7 @@ Vector<CSS::TextDecorationLine> StyleProperties::text_decoration_line() const
     if (value->is_identifier() && value->to_identifier() == ValueID::None)
         return {};
 
-    dbgln("FIXME: Unsupported value for text-decoration-line: {}", value->to_deprecated_string());
+    dbgln("FIXME: Unsupported value for text-decoration-line: {}", value->to_string());
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -313,16 +313,16 @@ BackgroundStyleValue::BackgroundStyleValue(
     VERIFY(!m_color->is_value_list());
 }
 
-DeprecatedString BackgroundStyleValue::to_deprecated_string() const
+ErrorOr<String> BackgroundStyleValue::to_string() const
 {
     if (m_layer_count == 1) {
-        return DeprecatedString::formatted("{} {} {} {} {} {} {} {}", m_color->to_deprecated_string(), m_image->to_deprecated_string(), m_position->to_deprecated_string(), m_size->to_deprecated_string(), m_repeat->to_deprecated_string(), m_attachment->to_deprecated_string(), m_origin->to_deprecated_string(), m_clip->to_deprecated_string());
+        return String::formatted("{} {} {} {} {} {} {} {}", TRY(m_color->to_string()), TRY(m_image->to_string()), TRY(m_position->to_string()), TRY(m_size->to_string()), TRY(m_repeat->to_string()), TRY(m_attachment->to_string()), TRY(m_origin->to_string()), TRY(m_clip->to_string()));
     }
 
     auto get_layer_value_string = [](NonnullRefPtr<StyleValue> const& style_value, size_t index) {
         if (style_value->is_value_list())
-            return style_value->as_value_list().value_at(index, true)->to_deprecated_string();
-        return style_value->to_deprecated_string();
+            return style_value->as_value_list().value_at(index, true)->to_string();
+        return style_value->to_string();
     };
 
     StringBuilder builder;
@@ -330,11 +330,11 @@ DeprecatedString BackgroundStyleValue::to_deprecated_string() const
         if (i)
             builder.append(", "sv);
         if (i == m_layer_count - 1)
-            builder.appendff("{} ", m_color->to_deprecated_string());
-        builder.appendff("{} {} {} {} {} {} {}", get_layer_value_string(m_image, i), get_layer_value_string(m_position, i), get_layer_value_string(m_size, i), get_layer_value_string(m_repeat, i), get_layer_value_string(m_attachment, i), get_layer_value_string(m_origin, i), get_layer_value_string(m_clip, i));
+            builder.appendff("{} ", TRY(m_color->to_string()));
+        builder.appendff("{} {} {} {} {} {} {}", TRY(get_layer_value_string(m_image, i)), TRY(get_layer_value_string(m_position, i)), TRY(get_layer_value_string(m_size, i)), TRY(get_layer_value_string(m_repeat, i)), TRY(get_layer_value_string(m_attachment, i)), TRY(get_layer_value_string(m_origin, i)), TRY(get_layer_value_string(m_clip, i)));
     }
 
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 bool BackgroundStyleValue::equals(StyleValue const& other) const
@@ -352,9 +352,9 @@ bool BackgroundStyleValue::equals(StyleValue const& other) const
         && m_clip->equals(typed_other.m_clip);
 }
 
-DeprecatedString BackgroundRepeatStyleValue::to_deprecated_string() const
+ErrorOr<String> BackgroundRepeatStyleValue::to_string() const
 {
-    return DeprecatedString::formatted("{} {}", CSS::to_string(m_repeat_x), CSS::to_string(m_repeat_y));
+    return String::formatted("{} {}", CSS::to_string(m_repeat_x), CSS::to_string(m_repeat_y));
 }
 
 bool BackgroundRepeatStyleValue::equals(StyleValue const& other) const
@@ -365,9 +365,9 @@ bool BackgroundRepeatStyleValue::equals(StyleValue const& other) const
     return m_repeat_x == typed_other.m_repeat_x && m_repeat_y == typed_other.m_repeat_y;
 }
 
-DeprecatedString BackgroundSizeStyleValue::to_deprecated_string() const
+ErrorOr<String> BackgroundSizeStyleValue::to_string() const
 {
-    return DeprecatedString::formatted("{} {}", m_size_x.to_deprecated_string(), m_size_y.to_deprecated_string());
+    return String::formatted("{} {}", TRY(m_size_x.to_string()), TRY(m_size_y.to_string()));
 }
 
 bool BackgroundSizeStyleValue::equals(StyleValue const& other) const
@@ -378,9 +378,9 @@ bool BackgroundSizeStyleValue::equals(StyleValue const& other) const
     return m_size_x == typed_other.m_size_x && m_size_y == typed_other.m_size_y;
 }
 
-DeprecatedString BorderStyleValue::to_deprecated_string() const
+ErrorOr<String> BorderStyleValue::to_string() const
 {
-    return DeprecatedString::formatted("{} {} {}", m_border_width->to_deprecated_string(), m_border_style->to_deprecated_string(), m_border_color->to_deprecated_string());
+    return String::formatted("{} {} {}", TRY(m_border_width->to_string()), TRY(m_border_style->to_string()), TRY(m_border_color->to_string()));
 }
 
 bool BorderStyleValue::equals(StyleValue const& other) const
@@ -393,11 +393,11 @@ bool BorderStyleValue::equals(StyleValue const& other) const
         && m_border_color->equals(typed_other.m_border_color);
 }
 
-DeprecatedString BorderRadiusStyleValue::to_deprecated_string() const
+ErrorOr<String> BorderRadiusStyleValue::to_string() const
 {
     if (m_horizontal_radius == m_vertical_radius)
-        return m_horizontal_radius.to_deprecated_string();
-    return DeprecatedString::formatted("{} / {}", m_horizontal_radius.to_deprecated_string(), m_vertical_radius.to_deprecated_string());
+        return m_horizontal_radius.to_string();
+    return String::formatted("{} / {}", TRY(m_horizontal_radius.to_string()), TRY(m_vertical_radius.to_string()));
 }
 
 bool BorderRadiusStyleValue::equals(StyleValue const& other) const
@@ -410,9 +410,9 @@ bool BorderRadiusStyleValue::equals(StyleValue const& other) const
         && m_vertical_radius == typed_other.m_vertical_radius;
 }
 
-DeprecatedString BorderRadiusShorthandStyleValue::to_deprecated_string() const
+ErrorOr<String> BorderRadiusShorthandStyleValue::to_string() const
 {
-    return DeprecatedString::formatted("{} {} {} {} / {} {} {} {}", m_top_left->horizontal_radius().to_deprecated_string(), m_top_right->horizontal_radius().to_deprecated_string(), m_bottom_right->horizontal_radius().to_deprecated_string(), m_bottom_left->horizontal_radius().to_deprecated_string(), m_top_left->vertical_radius().to_deprecated_string(), m_top_right->vertical_radius().to_deprecated_string(), m_bottom_right->vertical_radius().to_deprecated_string(), m_bottom_left->vertical_radius().to_deprecated_string());
+    return String::formatted("{} {} {} {} / {} {} {} {}", TRY(m_top_left->horizontal_radius().to_string()), TRY(m_top_right->horizontal_radius().to_string()), TRY(m_bottom_right->horizontal_radius().to_string()), TRY(m_bottom_left->horizontal_radius().to_string()), TRY(m_top_left->vertical_radius().to_string()), TRY(m_top_right->vertical_radius().to_string()), TRY(m_bottom_right->vertical_radius().to_string()), TRY(m_bottom_left->vertical_radius().to_string()));
 }
 
 bool BorderRadiusShorthandStyleValue::equals(StyleValue const& other) const
@@ -615,9 +615,9 @@ void CalculatedStyleValue::CalculationResult::divide_by(CalculationResult const&
         });
 }
 
-DeprecatedString CalculatedStyleValue::to_deprecated_string() const
+ErrorOr<String> CalculatedStyleValue::to_string() const
 {
-    return DeprecatedString::formatted("calc({})", m_expression->to_deprecated_string());
+    return String::formatted("calc({})", TRY(m_expression->to_string()));
 }
 
 bool CalculatedStyleValue::equals(StyleValue const& other) const
@@ -625,81 +625,81 @@ bool CalculatedStyleValue::equals(StyleValue const& other) const
     if (type() != other.type())
         return false;
     // This is a case where comparing the strings actually makes sense.
-    return to_deprecated_string() == other.to_deprecated_string();
+    return to_string().release_value_but_fixme_should_propagate_errors() == other.to_string().release_value_but_fixme_should_propagate_errors();
 }
 
-DeprecatedString CalculatedStyleValue::CalcNumberValue::to_deprecated_string() const
+ErrorOr<String> CalculatedStyleValue::CalcNumberValue::to_string() const
 {
     return value.visit(
-        [](Number const& number) { return DeprecatedString::number(number.value()); },
-        [](NonnullOwnPtr<CalcNumberSum> const& sum) { return DeprecatedString::formatted("({})", sum->to_deprecated_string()); });
+        [](Number const& number) { return String::number(number.value()); },
+        [](NonnullOwnPtr<CalcNumberSum> const& sum) { return String::formatted("({})", sum->to_string()); });
 }
 
-DeprecatedString CalculatedStyleValue::CalcValue::to_deprecated_string() const
+ErrorOr<String> CalculatedStyleValue::CalcValue::to_string() const
 {
     return value.visit(
-        [](Number const& number) { return DeprecatedString::number(number.value()); },
-        [](NonnullOwnPtr<CalcSum> const& sum) { return DeprecatedString::formatted("({})", sum->to_deprecated_string()); },
-        [](auto const& v) { return v.to_deprecated_string(); });
+        [](Number const& number) { return String::number(number.value()); },
+        [](NonnullOwnPtr<CalcSum> const& sum) { return String::formatted("({})", sum->to_string()); },
+        [](auto const& v) { return v.to_string(); });
 }
 
-DeprecatedString CalculatedStyleValue::CalcSum::to_deprecated_string() const
+ErrorOr<String> CalculatedStyleValue::CalcSum::to_string() const
 {
     StringBuilder builder;
-    builder.append(first_calc_product->to_deprecated_string());
+    builder.append(TRY(first_calc_product->to_string()));
     for (auto const& item : zero_or_more_additional_calc_products)
-        builder.append(item.to_deprecated_string());
-    return builder.to_deprecated_string();
+        builder.append(TRY(item.to_string()));
+    return builder.to_string();
 }
 
-DeprecatedString CalculatedStyleValue::CalcNumberSum::to_deprecated_string() const
+ErrorOr<String> CalculatedStyleValue::CalcNumberSum::to_string() const
 {
     StringBuilder builder;
-    builder.append(first_calc_number_product->to_deprecated_string());
+    builder.append(TRY(first_calc_number_product->to_string()));
     for (auto const& item : zero_or_more_additional_calc_number_products)
-        builder.append(item.to_deprecated_string());
-    return builder.to_deprecated_string();
+        builder.append(TRY(item.to_string()));
+    return builder.to_string();
 }
 
-DeprecatedString CalculatedStyleValue::CalcProduct::to_deprecated_string() const
+ErrorOr<String> CalculatedStyleValue::CalcProduct::to_string() const
 {
     StringBuilder builder;
-    builder.append(first_calc_value.to_deprecated_string());
+    builder.append(TRY(first_calc_value.to_string()));
     for (auto const& item : zero_or_more_additional_calc_values)
-        builder.append(item.to_deprecated_string());
-    return builder.to_deprecated_string();
+        builder.append(TRY(item.to_string()));
+    return builder.to_string();
 }
 
-DeprecatedString CalculatedStyleValue::CalcSumPartWithOperator::to_deprecated_string() const
+ErrorOr<String> CalculatedStyleValue::CalcSumPartWithOperator::to_string() const
 {
-    return DeprecatedString::formatted(" {} {}", op == SumOperation::Add ? "+"sv : "-"sv, value->to_deprecated_string());
+    return String::formatted(" {} {}", op == SumOperation::Add ? "+"sv : "-"sv, TRY(value->to_string()));
 }
 
-DeprecatedString CalculatedStyleValue::CalcProductPartWithOperator::to_deprecated_string() const
+ErrorOr<String> CalculatedStyleValue::CalcProductPartWithOperator::to_string() const
 {
     auto value_string = value.visit(
-        [](CalcValue const& v) { return v.to_deprecated_string(); },
-        [](CalcNumberValue const& v) { return v.to_deprecated_string(); });
-    return DeprecatedString::formatted(" {} {}", op == ProductOperation::Multiply ? "*"sv : "/"sv, value_string);
+        [](CalcValue const& v) { return v.to_string(); },
+        [](CalcNumberValue const& v) { return v.to_string(); });
+    return String::formatted(" {} {}", op == ProductOperation::Multiply ? "*"sv : "/"sv, value_string);
 }
 
-DeprecatedString CalculatedStyleValue::CalcNumberProduct::to_deprecated_string() const
+ErrorOr<String> CalculatedStyleValue::CalcNumberProduct::to_string() const
 {
     StringBuilder builder;
-    builder.append(first_calc_number_value.to_deprecated_string());
+    builder.append(TRY(first_calc_number_value.to_string()));
     for (auto const& item : zero_or_more_additional_calc_number_values)
-        builder.append(item.to_deprecated_string());
-    return builder.to_deprecated_string();
+        builder.append(TRY(item.to_string()));
+    return builder.to_string();
 }
 
-DeprecatedString CalculatedStyleValue::CalcNumberProductPartWithOperator::to_deprecated_string() const
+ErrorOr<String> CalculatedStyleValue::CalcNumberProductPartWithOperator::to_string() const
 {
-    return DeprecatedString::formatted(" {} {}", op == ProductOperation::Multiply ? "*"sv : "/"sv, value.to_deprecated_string());
+    return String::formatted(" {} {}", op == ProductOperation::Multiply ? "*"sv : "/"sv, TRY(value.to_string()));
 }
 
-DeprecatedString CalculatedStyleValue::CalcNumberSumPartWithOperator::to_deprecated_string() const
+ErrorOr<String> CalculatedStyleValue::CalcNumberSumPartWithOperator::to_string() const
 {
-    return DeprecatedString::formatted(" {} {}", op == SumOperation::Add ? "+"sv : "-"sv, value->to_deprecated_string());
+    return String::formatted(" {} {}", op == SumOperation::Add ? "+"sv : "-"sv, TRY(value->to_string()));
 }
 
 Optional<Angle> CalculatedStyleValue::resolve_angle() const
@@ -1149,7 +1149,7 @@ CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberSumPartW
     return value->resolve(layout_node, percentage_basis);
 }
 
-DeprecatedString ColorStyleValue::to_deprecated_string() const
+ErrorOr<String> ColorStyleValue::to_string() const
 {
     return serialize_a_srgb_value(m_color);
 }
@@ -1161,11 +1161,11 @@ bool ColorStyleValue::equals(StyleValue const& other) const
     return m_color == other.as_color().m_color;
 }
 
-DeprecatedString ContentStyleValue::to_deprecated_string() const
+ErrorOr<String> ContentStyleValue::to_string() const
 {
     if (has_alt_text())
-        return DeprecatedString::formatted("{} / {}", m_content->to_deprecated_string(), m_alt_text->to_deprecated_string());
-    return m_content->to_deprecated_string();
+        return String::formatted("{} / {}", TRY(m_content->to_string()), TRY(m_alt_text->to_string()));
+    return m_content->to_string();
 }
 
 bool ContentStyleValue::equals(StyleValue const& other) const
@@ -1223,7 +1223,7 @@ float Filter::Color::resolved_amount() const
     return 1.0f;
 }
 
-DeprecatedString FilterValueListStyleValue::to_deprecated_string() const
+ErrorOr<String> FilterValueListStyleValue::to_string() const
 {
     StringBuilder builder {};
     bool first = true;
@@ -1234,13 +1234,13 @@ DeprecatedString FilterValueListStyleValue::to_deprecated_string() const
             [&](Filter::Blur const& blur) {
                 builder.append("blur("sv);
                 if (blur.radius.has_value())
-                    builder.append(blur.radius->to_deprecated_string());
+                    builder.append(blur.radius->to_string().release_value());
             },
             [&](Filter::DropShadow const& drop_shadow) {
                 builder.appendff("drop-shadow({} {}"sv,
                     drop_shadow.offset_x, drop_shadow.offset_y);
                 if (drop_shadow.radius.has_value())
-                    builder.appendff(" {}", drop_shadow.radius->to_deprecated_string());
+                    builder.appendff(" {}", drop_shadow.radius->to_string());
                 if (drop_shadow.color.has_value()) {
                     builder.append(' ');
                     serialize_a_srgb_value(builder, *drop_shadow.color);
@@ -1251,7 +1251,7 @@ DeprecatedString FilterValueListStyleValue::to_deprecated_string() const
                 if (hue_rotate.angle.has_value()) {
                     hue_rotate.angle->visit(
                         [&](Angle const& angle) {
-                            builder.append(angle.to_deprecated_string());
+                            builder.append(angle.to_string().release_value());
                         },
                         [&](auto&) {
                             builder.append('0');
@@ -1281,12 +1281,12 @@ DeprecatedString FilterValueListStyleValue::to_deprecated_string() const
                         }
                     }());
                 if (color.amount.has_value())
-                    builder.append(color.amount->to_deprecated_string());
+                    builder.append(color.amount->to_string().release_value());
             });
         builder.append(')');
         first = false;
     }
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 static bool operator==(Filter::Blur const& a, Filter::Blur const& b)
@@ -1347,9 +1347,9 @@ bool FilterValueListStyleValue::equals(StyleValue const& other) const
     return true;
 }
 
-DeprecatedString FlexStyleValue::to_deprecated_string() const
+ErrorOr<String> FlexStyleValue::to_string() const
 {
-    return DeprecatedString::formatted("{} {} {}", m_grow->to_deprecated_string(), m_shrink->to_deprecated_string(), m_basis->to_deprecated_string());
+    return String::formatted("{} {} {}", TRY(m_grow->to_string()), TRY(m_shrink->to_string()), TRY(m_basis->to_string()));
 }
 
 bool FlexStyleValue::equals(StyleValue const& other) const
@@ -1362,9 +1362,9 @@ bool FlexStyleValue::equals(StyleValue const& other) const
         && m_basis->equals(typed_other.m_basis);
 }
 
-DeprecatedString FlexFlowStyleValue::to_deprecated_string() const
+ErrorOr<String> FlexFlowStyleValue::to_string() const
 {
-    return DeprecatedString::formatted("{} {}", m_flex_direction->to_deprecated_string(), m_flex_wrap->to_deprecated_string());
+    return String::formatted("{} {}", TRY(m_flex_direction->to_string()), TRY(m_flex_wrap->to_string()));
 }
 
 bool FlexFlowStyleValue::equals(StyleValue const& other) const
@@ -1376,9 +1376,9 @@ bool FlexFlowStyleValue::equals(StyleValue const& other) const
         && m_flex_wrap->equals(typed_other.m_flex_wrap);
 }
 
-DeprecatedString FontStyleValue::to_deprecated_string() const
+ErrorOr<String> FontStyleValue::to_string() const
 {
-    return DeprecatedString::formatted("{} {} {} / {} {}", m_font_style->to_deprecated_string(), m_font_weight->to_deprecated_string(), m_font_size->to_deprecated_string(), m_line_height->to_deprecated_string(), m_font_families->to_deprecated_string());
+    return String::formatted("{} {} {} / {} {}", TRY(m_font_style->to_string()), TRY(m_font_weight->to_string()), TRY(m_font_size->to_string()), TRY(m_line_height->to_string()), TRY(m_font_families->to_string()));
 }
 
 bool FontStyleValue::equals(StyleValue const& other) const
@@ -1400,11 +1400,11 @@ bool FrequencyStyleValue::equals(StyleValue const& other) const
     return m_frequency == other.as_frequency().m_frequency;
 }
 
-DeprecatedString GridTrackPlacementShorthandStyleValue::to_deprecated_string() const
+ErrorOr<String> GridTrackPlacementShorthandStyleValue::to_string() const
 {
     if (m_end->grid_track_placement().is_auto())
-        return DeprecatedString::formatted("{}", m_start->grid_track_placement().to_deprecated_string());
-    return DeprecatedString::formatted("{} / {}", m_start->grid_track_placement().to_deprecated_string(), m_end->grid_track_placement().to_deprecated_string());
+        return String::formatted("{}", TRY(m_start->grid_track_placement().to_string()));
+    return String::formatted("{} / {}", TRY(m_start->grid_track_placement().to_string()), TRY(m_end->grid_track_placement().to_string()));
 }
 
 bool GridTrackPlacementShorthandStyleValue::equals(StyleValue const& other) const
@@ -1416,9 +1416,9 @@ bool GridTrackPlacementShorthandStyleValue::equals(StyleValue const& other) cons
         && m_end->equals(typed_other.m_end);
 }
 
-DeprecatedString GridTrackPlacementStyleValue::to_deprecated_string() const
+ErrorOr<String> GridTrackPlacementStyleValue::to_string() const
 {
-    return m_grid_track_placement.to_deprecated_string();
+    return m_grid_track_placement.to_string();
 }
 
 bool GridTrackPlacementStyleValue::equals(StyleValue const& other) const
@@ -1429,9 +1429,9 @@ bool GridTrackPlacementStyleValue::equals(StyleValue const& other) const
     return m_grid_track_placement == typed_other.grid_track_placement();
 }
 
-DeprecatedString GridTrackSizeStyleValue::to_deprecated_string() const
+ErrorOr<String> GridTrackSizeStyleValue::to_string() const
 {
-    return m_grid_track_size_list.to_deprecated_string();
+    return m_grid_track_size_list.to_string();
 }
 
 bool GridTrackSizeStyleValue::equals(StyleValue const& other) const
@@ -1442,9 +1442,9 @@ bool GridTrackSizeStyleValue::equals(StyleValue const& other) const
     return m_grid_track_size_list == typed_other.grid_track_size_list();
 }
 
-DeprecatedString IdentifierStyleValue::to_deprecated_string() const
+ErrorOr<String> IdentifierStyleValue::to_string() const
 {
-    return CSS::string_from_value_id(m_id);
+    return String::from_utf8(CSS::string_from_value_id(m_id));
 }
 
 bool IdentifierStyleValue::equals(StyleValue const& other) const
@@ -1706,9 +1706,9 @@ Gfx::Bitmap const* ImageStyleValue::bitmap(size_t frame_index) const
     return resource()->bitmap(frame_index);
 }
 
-DeprecatedString ImageStyleValue::to_deprecated_string() const
+ErrorOr<String> ImageStyleValue::to_string() const
 {
-    return serialize_a_url(m_url.to_deprecated_string());
+    return String::from_deprecated_string(serialize_a_url(m_url.to_deprecated_string()));
 }
 
 bool ImageStyleValue::equals(StyleValue const& other) const
@@ -1746,22 +1746,22 @@ static void serialize_color_stop_list(StringBuilder& builder, auto const& color_
             builder.append(", "sv);
 
         if (element.transition_hint.has_value()) {
-            builder.appendff("{}, "sv, element.transition_hint->value.to_deprecated_string());
+            builder.appendff("{}, "sv, element.transition_hint->value.to_string());
         }
 
         serialize_a_srgb_value(builder, element.color_stop.color);
         for (auto position : Array { &element.color_stop.position, &element.color_stop.second_position }) {
             if (position->has_value())
-                builder.appendff(" {}"sv, (*position)->to_deprecated_string());
+                builder.appendff(" {}"sv, (*position)->to_string());
         }
         first = false;
     }
 }
 
-DeprecatedString LinearGradientStyleValue::to_deprecated_string() const
+ErrorOr<String> LinearGradientStyleValue::to_string() const
 {
     StringBuilder builder;
-    auto side_or_corner_to_deprecated_string = [](SideOrCorner value) {
+    auto side_or_corner_to_string = [](SideOrCorner value) {
         switch (value) {
         case SideOrCorner::Top:
             return "top"sv;
@@ -1791,15 +1791,15 @@ DeprecatedString LinearGradientStyleValue::to_deprecated_string() const
     builder.append("linear-gradient("sv);
     m_direction.visit(
         [&](SideOrCorner side_or_corner) {
-            builder.appendff("{}{}, "sv, m_gradient_type == GradientType::Standard ? "to "sv : ""sv, side_or_corner_to_deprecated_string(side_or_corner));
+            builder.appendff("{}{}, "sv, m_gradient_type == GradientType::Standard ? "to "sv : ""sv, side_or_corner_to_string(side_or_corner));
         },
         [&](Angle const& angle) {
-            builder.appendff("{}, "sv, angle.to_deprecated_string());
+            builder.appendff("{}, "sv, angle.to_string());
         });
 
     serialize_color_stop_list(builder, m_color_stop_list);
     builder.append(")"sv);
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 static bool operator==(LinearGradientStyleValue::GradientDirection const& a, LinearGradientStyleValue::GradientDirection const& b)
@@ -1947,7 +1947,7 @@ void PositionValue::serialize(StringBuilder& builder) const
             }());
         },
         [&](LengthPercentage length_percentage) {
-            builder.append(length_percentage.to_deprecated_string());
+            builder.append(length_percentage.to_string().release_value_but_fixme_should_propagate_errors());
         });
     builder.append(' ');
     if (has_relative_edges)
@@ -1968,7 +1968,7 @@ void PositionValue::serialize(StringBuilder& builder) const
             }());
         },
         [&](LengthPercentage length_percentage) {
-            builder.append(length_percentage.to_deprecated_string());
+            builder.append(length_percentage.to_string().release_value_but_fixme_should_propagate_errors());
         });
 }
 
@@ -1981,7 +1981,7 @@ bool PositionValue::operator==(PositionValue const& other) const
         && variant_equals(vertical_position, other.vertical_position));
 }
 
-DeprecatedString RadialGradientStyleValue::to_deprecated_string() const
+ErrorOr<String> RadialGradientStyleValue::to_string() const
 {
     StringBuilder builder;
     if (is_repeating())
@@ -2006,8 +2006,8 @@ DeprecatedString RadialGradientStyleValue::to_deprecated_string() const
                 }
             }());
         },
-        [&](CircleSize const& circle_size) { builder.append(circle_size.radius.to_deprecated_string()); },
-        [&](EllipseSize const& ellipse_size) { builder.appendff("{} {}", ellipse_size.radius_a.to_deprecated_string(), ellipse_size.radius_b.to_deprecated_string()); });
+        [&](CircleSize const& circle_size) { builder.append(circle_size.radius.to_string().release_value()); },
+        [&](EllipseSize const& ellipse_size) { builder.appendff("{} {}", ellipse_size.radius_a.to_string(), ellipse_size.radius_b.to_string()); });
 
     if (m_position != PositionValue::center()) {
         builder.appendff(" at "sv);
@@ -2017,7 +2017,7 @@ DeprecatedString RadialGradientStyleValue::to_deprecated_string() const
     builder.append(", "sv);
     serialize_color_stop_list(builder, m_color_stop_list);
     builder.append(')');
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 Gfx::FloatSize RadialGradientStyleValue::resolve_size(Layout::Node const& node, Gfx::FloatPoint center, Gfx::FloatRect const& size) const
@@ -2183,7 +2183,7 @@ void RadialGradientStyleValue::paint(PaintContext& context, DevicePixelRect cons
         context.rounded_device_size(m_resolved->gradient_size.to_type<CSSPixels>()));
 }
 
-DeprecatedString ConicGradientStyleValue::to_deprecated_string() const
+ErrorOr<String> ConicGradientStyleValue::to_string() const
 {
     StringBuilder builder;
     if (is_repeating())
@@ -2192,7 +2192,7 @@ DeprecatedString ConicGradientStyleValue::to_deprecated_string() const
     bool has_from_angle = false;
     bool has_at_position = false;
     if ((has_from_angle = m_from_angle.to_degrees() != 0))
-        builder.appendff("from {}", m_from_angle.to_deprecated_string());
+        builder.appendff("from {}", TRY(m_from_angle.to_string()));
     if ((has_at_position = m_position != PositionValue::center())) {
         if (has_from_angle)
             builder.append(' ');
@@ -2203,7 +2203,7 @@ DeprecatedString ConicGradientStyleValue::to_deprecated_string() const
         builder.append(", "sv);
     serialize_color_stop_list(builder, m_color_stop_list);
     builder.append(')');
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 void ConicGradientStyleValue::resolve_for_size(Layout::Node const& node, CSSPixelSize size) const
@@ -2252,9 +2252,9 @@ bool LengthStyleValue::equals(StyleValue const& other) const
     return m_length == other.as_length().m_length;
 }
 
-DeprecatedString ListStyleStyleValue::to_deprecated_string() const
+ErrorOr<String> ListStyleStyleValue::to_string() const
 {
-    return DeprecatedString::formatted("{} {} {}", m_position->to_deprecated_string(), m_image->to_deprecated_string(), m_style_type->to_deprecated_string());
+    return String::formatted("{} {} {}", TRY(m_position->to_string()), TRY(m_image->to_string()), TRY(m_style_type->to_string()));
 }
 
 bool ListStyleStyleValue::equals(StyleValue const& other) const
@@ -2267,14 +2267,14 @@ bool ListStyleStyleValue::equals(StyleValue const& other) const
         && m_style_type->equals(typed_other.m_style_type);
 }
 
-DeprecatedString NumericStyleValue::to_deprecated_string() const
+ErrorOr<String> NumericStyleValue::to_string() const
 {
     return m_value.visit(
         [](float value) {
-            return DeprecatedString::formatted("{}", value);
+            return String::formatted("{}", value);
         },
         [](i64 value) {
-            return DeprecatedString::formatted("{}", value);
+            return String::formatted("{}", value);
         });
 }
 
@@ -2289,9 +2289,9 @@ bool NumericStyleValue::equals(StyleValue const& other) const
     return m_value.get<float>() == other.as_numeric().m_value.get<float>();
 }
 
-DeprecatedString OverflowStyleValue::to_deprecated_string() const
+ErrorOr<String> OverflowStyleValue::to_string() const
 {
-    return DeprecatedString::formatted("{} {}", m_overflow_x->to_deprecated_string(), m_overflow_y->to_deprecated_string());
+    return String::formatted("{} {}", TRY(m_overflow_x->to_string()), TRY(m_overflow_y->to_string()));
 }
 
 bool OverflowStyleValue::equals(StyleValue const& other) const
@@ -2303,9 +2303,9 @@ bool OverflowStyleValue::equals(StyleValue const& other) const
         && m_overflow_y->equals(typed_other.m_overflow_y);
 }
 
-DeprecatedString PercentageStyleValue::to_deprecated_string() const
+ErrorOr<String> PercentageStyleValue::to_string() const
 {
-    return m_percentage.to_deprecated_string();
+    return m_percentage.to_string();
 }
 
 bool PercentageStyleValue::equals(StyleValue const& other) const
@@ -2315,9 +2315,9 @@ bool PercentageStyleValue::equals(StyleValue const& other) const
     return m_percentage == other.as_percentage().m_percentage;
 }
 
-DeprecatedString PositionStyleValue::to_deprecated_string() const
+ErrorOr<String> PositionStyleValue::to_string() const
 {
-    auto to_deprecated_string = [](PositionEdge edge) {
+    auto to_string = [](PositionEdge edge) {
         switch (edge) {
         case PositionEdge::Left:
             return "left";
@@ -2331,7 +2331,7 @@ DeprecatedString PositionStyleValue::to_deprecated_string() const
         VERIFY_NOT_REACHED();
     };
 
-    return DeprecatedString::formatted("{} {} {} {}", to_deprecated_string(m_edge_x), m_offset_x.to_deprecated_string(), to_deprecated_string(m_edge_y), m_offset_y.to_deprecated_string());
+    return String::formatted("{} {} {} {}", to_string(m_edge_x), m_offset_x.to_string(), to_string(m_edge_y), TRY(m_offset_y.to_string()));
 }
 
 bool PositionStyleValue::equals(StyleValue const& other) const
@@ -2345,9 +2345,9 @@ bool PositionStyleValue::equals(StyleValue const& other) const
         && m_offset_y == typed_other.m_offset_y;
 }
 
-DeprecatedString RectStyleValue::to_deprecated_string() const
+ErrorOr<String> RectStyleValue::to_string() const
 {
-    return DeprecatedString::formatted("rect({} {} {} {})", m_rect.top_edge, m_rect.right_edge, m_rect.bottom_edge, m_rect.left_edge);
+    return String::formatted("rect({} {} {} {})", m_rect.top_edge, m_rect.right_edge, m_rect.bottom_edge, m_rect.left_edge);
 }
 
 bool RectStyleValue::equals(StyleValue const& other) const
@@ -2365,13 +2365,13 @@ bool ResolutionStyleValue::equals(StyleValue const& other) const
     return m_resolution == other.as_resolution().m_resolution;
 }
 
-DeprecatedString ShadowStyleValue::to_deprecated_string() const
+ErrorOr<String> ShadowStyleValue::to_string() const
 {
     StringBuilder builder;
-    builder.appendff("{} {} {} {} {}", m_color.to_deprecated_string(), m_offset_x.to_deprecated_string(), m_offset_y.to_deprecated_string(), m_blur_radius.to_deprecated_string(), m_spread_distance.to_deprecated_string());
+    builder.appendff("{} {} {} {} {}", String::from_deprecated_string(m_color.to_deprecated_string()), TRY(m_offset_x.to_string()), TRY(m_offset_y.to_string()), TRY(m_blur_radius.to_string()), TRY(m_spread_distance.to_string()));
     if (m_placement == ShadowPlacement::Inner)
         builder.append(" inset"sv);
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 bool ShadowStyleValue::equals(StyleValue const& other) const
@@ -2394,9 +2394,9 @@ bool StringStyleValue::equals(StyleValue const& other) const
     return m_string == other.as_string().m_string;
 }
 
-DeprecatedString TextDecorationStyleValue::to_deprecated_string() const
+ErrorOr<String> TextDecorationStyleValue::to_string() const
 {
-    return DeprecatedString::formatted("{} {} {} {}", m_line->to_deprecated_string(), m_thickness->to_deprecated_string(), m_style->to_deprecated_string(), m_color->to_deprecated_string());
+    return String::formatted("{} {} {} {}", TRY(m_line->to_string()), TRY(m_thickness->to_string()), TRY(m_style->to_string()), TRY(m_color->to_string()));
 }
 
 bool TextDecorationStyleValue::equals(StyleValue const& other) const
@@ -2417,7 +2417,7 @@ bool TimeStyleValue::equals(StyleValue const& other) const
     return m_time == other.as_time().m_time;
 }
 
-DeprecatedString TransformationStyleValue::to_deprecated_string() const
+ErrorOr<String> TransformationStyleValue::to_string() const
 {
     StringBuilder builder;
     builder.append(CSS::to_string(m_transform_function));
@@ -2425,7 +2425,7 @@ DeprecatedString TransformationStyleValue::to_deprecated_string() const
     builder.join(", "sv, m_values);
     builder.append(')');
 
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 bool TransformationStyleValue::equals(StyleValue const& other) const
@@ -2444,12 +2444,12 @@ bool TransformationStyleValue::equals(StyleValue const& other) const
     return true;
 }
 
-DeprecatedString UnresolvedStyleValue::to_deprecated_string() const
+ErrorOr<String> UnresolvedStyleValue::to_string() const
 {
     StringBuilder builder;
     for (auto& value : m_values)
-        builder.append(value.to_deprecated_string());
-    return builder.to_deprecated_string();
+        builder.append(String::from_deprecated_string(value.to_deprecated_string()).release_value());
+    return builder.to_string();
 }
 
 bool UnresolvedStyleValue::equals(StyleValue const& other) const
@@ -2457,7 +2457,7 @@ bool UnresolvedStyleValue::equals(StyleValue const& other) const
     if (type() != other.type())
         return false;
     // This is a case where comparing the strings actually makes sense.
-    return to_deprecated_string() == other.to_deprecated_string();
+    return to_string().release_value_but_fixme_should_propagate_errors() == other.to_string().release_value_but_fixme_should_propagate_errors();
 }
 
 bool UnsetStyleValue::equals(StyleValue const& other) const
@@ -2465,21 +2465,21 @@ bool UnsetStyleValue::equals(StyleValue const& other) const
     return type() == other.type();
 }
 
-DeprecatedString StyleValueList::to_deprecated_string() const
+ErrorOr<String> StyleValueList::to_string() const
 {
-    DeprecatedString separator = "";
+    auto separator = ""sv;
     switch (m_separator) {
     case Separator::Space:
-        separator = " ";
+        separator = " "sv;
         break;
     case Separator::Comma:
-        separator = ", ";
+        separator = ", "sv;
         break;
     default:
         VERIFY_NOT_REACHED();
     }
 
-    return DeprecatedString::join(separator, m_values);
+    return String::from_deprecated_string(DeprecatedString::join(separator, m_values));
 }
 
 bool StyleValueList::equals(StyleValue const& other) const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -16,6 +16,7 @@
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/URL.h>
 #include <AK/Variant.h>
@@ -403,7 +404,7 @@ public:
     virtual Length to_length() const { VERIFY_NOT_REACHED(); }
     virtual float to_number() const { return 0; }
     virtual float to_integer() const { return 0; }
-    virtual DeprecatedString to_deprecated_string() const = 0;
+    virtual ErrorOr<String> to_string() const = 0;
 
     bool operator==(StyleValue const& other) const { return equals(other); }
 
@@ -426,7 +427,7 @@ public:
 
     Angle const& angle() const { return m_angle; }
 
-    virtual DeprecatedString to_deprecated_string() const override { return m_angle.to_deprecated_string(); }
+    virtual ErrorOr<String> to_string() const override { return m_angle.to_string(); }
 
     virtual bool equals(StyleValue const& other) const override
     {
@@ -472,7 +473,7 @@ public:
     NonnullRefPtr<StyleValue> repeat() const { return m_repeat; }
     NonnullRefPtr<StyleValue> size() const { return m_size; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -509,7 +510,7 @@ public:
     Repeat repeat_x() const { return m_repeat_x; }
     Repeat repeat_y() const { return m_repeat_y; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -536,7 +537,7 @@ public:
     LengthPercentage size_x() const { return m_size_x; }
     LengthPercentage size_y() const { return m_size_y; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -566,7 +567,7 @@ public:
     NonnullRefPtr<StyleValue> border_style() const { return m_border_style; }
     NonnullRefPtr<StyleValue> border_color() const { return m_border_color; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -598,7 +599,7 @@ public:
     LengthPercentage const& vertical_radius() const { return m_vertical_radius; }
     bool is_elliptical() const { return m_is_elliptical; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -630,7 +631,7 @@ public:
     NonnullRefPtr<BorderRadiusStyleValue> bottom_right() const { return m_bottom_right; }
     NonnullRefPtr<BorderRadiusStyleValue> bottom_left() const { return m_bottom_left; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -702,14 +703,14 @@ public:
 
     struct CalcNumberValue {
         Variant<Number, NonnullOwnPtr<CalcNumberSum>> value;
-        DeprecatedString to_deprecated_string() const;
+        ErrorOr<String> to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     struct CalcValue {
         Variant<Number, Angle, Frequency, Length, Percentage, Time, NonnullOwnPtr<CalcSum>> value;
-        DeprecatedString to_deprecated_string() const;
+        ErrorOr<String> to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
         bool contains_percentage() const;
@@ -724,7 +725,7 @@ public:
         NonnullOwnPtr<CalcProduct> first_calc_product;
         NonnullOwnPtrVector<CalcSumPartWithOperator> zero_or_more_additional_calc_products;
 
-        DeprecatedString to_deprecated_string() const;
+        ErrorOr<String> to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
 
@@ -739,7 +740,7 @@ public:
         NonnullOwnPtr<CalcNumberProduct> first_calc_number_product;
         NonnullOwnPtrVector<CalcNumberSumPartWithOperator> zero_or_more_additional_calc_number_products;
 
-        DeprecatedString to_deprecated_string() const;
+        ErrorOr<String> to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
@@ -748,7 +749,7 @@ public:
         CalcValue first_calc_value;
         NonnullOwnPtrVector<CalcProductPartWithOperator> zero_or_more_additional_calc_values;
 
-        DeprecatedString to_deprecated_string() const;
+        ErrorOr<String> to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
         bool contains_percentage() const;
@@ -762,7 +763,7 @@ public:
         SumOperation op;
         NonnullOwnPtr<CalcProduct> value;
 
-        DeprecatedString to_deprecated_string() const;
+        ErrorOr<String> to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
         bool contains_percentage() const;
@@ -772,7 +773,7 @@ public:
         ProductOperation op;
         Variant<CalcValue, CalcNumberValue> value;
 
-        DeprecatedString to_deprecated_string() const;
+        ErrorOr<String> to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
 
@@ -783,7 +784,7 @@ public:
         CalcNumberValue first_calc_number_value;
         NonnullOwnPtrVector<CalcNumberProductPartWithOperator> zero_or_more_additional_calc_number_values;
 
-        DeprecatedString to_deprecated_string() const;
+        ErrorOr<String> to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
@@ -792,7 +793,7 @@ public:
         ProductOperation op;
         CalcNumberValue value;
 
-        DeprecatedString to_deprecated_string() const;
+        ErrorOr<String> to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
@@ -805,7 +806,7 @@ public:
         SumOperation op;
         NonnullOwnPtr<CalcNumberProduct> value;
 
-        DeprecatedString to_deprecated_string() const;
+        ErrorOr<String> to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
@@ -815,7 +816,7 @@ public:
         return adopt_ref(*new CalculatedStyleValue(move(calc_sum), resolved_type));
     }
 
-    DeprecatedString to_deprecated_string() const override;
+    ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
     ResolvedType resolved_type() const { return m_resolved_type; }
     NonnullOwnPtr<CalcSum> const& expression() const { return m_expression; }
@@ -864,7 +865,7 @@ public:
     virtual ~ColorStyleValue() override = default;
 
     Color color() const { return m_color; }
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool has_color() const override { return true; }
     virtual Color to_color(Layout::NodeWithStyle const&) const override { return m_color; }
 
@@ -891,7 +892,7 @@ public:
     bool has_alt_text() const { return !m_alt_text.is_null(); }
     StyleValueList const* alt_text() const { return m_alt_text; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -917,7 +918,7 @@ public:
 
     Vector<FilterFunction> const& filter_value_list() const { return m_filter_value_list; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
     virtual ~FilterValueListStyleValue() override = default;
@@ -948,7 +949,7 @@ public:
     NonnullRefPtr<StyleValue> shrink() const { return m_shrink; }
     NonnullRefPtr<StyleValue> basis() const { return m_basis; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -979,7 +980,7 @@ public:
     NonnullRefPtr<StyleValue> flex_direction() const { return m_flex_direction; }
     NonnullRefPtr<StyleValue> flex_wrap() const { return m_flex_wrap; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1005,7 +1006,7 @@ public:
     NonnullRefPtr<StyleValue> line_height() const { return m_line_height; }
     NonnullRefPtr<StyleValue> font_families() const { return m_font_families; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1037,7 +1038,7 @@ public:
 
     Frequency const& frequency() const { return m_frequency; }
 
-    virtual DeprecatedString to_deprecated_string() const override { return m_frequency.to_deprecated_string(); }
+    virtual ErrorOr<String> to_string() const override { return m_frequency.to_string(); }
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1056,7 +1057,7 @@ public:
     virtual ~GridTrackPlacementStyleValue() override = default;
 
     CSS::GridTrackPlacement const& grid_track_placement() const { return m_grid_track_placement; }
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1084,7 +1085,7 @@ public:
     NonnullRefPtr<GridTrackPlacementStyleValue> start() const { return m_start; }
     NonnullRefPtr<GridTrackPlacementStyleValue> end() const { return m_end; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1108,7 +1109,7 @@ public:
 
     CSS::GridTrackSizeList grid_track_size_list() const { return m_grid_track_size_list; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1136,7 +1137,7 @@ public:
     virtual CSS::ValueID to_identifier() const override { return m_id; }
     virtual bool has_color() const override;
     virtual Color to_color(Layout::NodeWithStyle const& node) const override;
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1170,7 +1171,7 @@ public:
     static NonnullRefPtr<ImageStyleValue> create(AK::URL const& url) { return adopt_ref(*new ImageStyleValue(url)); }
     virtual ~ImageStyleValue() override = default;
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
     virtual void load_any_resources(DOM::Document&) override;
@@ -1238,7 +1239,7 @@ public:
         return adopt_ref(*new RadialGradientStyleValue(ending_shape, size, position, move(color_stop_list), repeating));
     }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
 
     void paint(PaintContext&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const override;
 
@@ -1293,7 +1294,7 @@ public:
         return adopt_ref(*new ConicGradientStyleValue(from_angle, position, move(color_stop_list), repeating));
     }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
 
     void paint(PaintContext&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const override;
 
@@ -1355,7 +1356,7 @@ public:
         return adopt_ref(*new LinearGradientStyleValue(direction, move(color_stop_list), type, repeating));
     }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual ~LinearGradientStyleValue() override = default;
     virtual bool equals(StyleValue const& other) const override;
 
@@ -1405,7 +1406,7 @@ public:
     }
     virtual ~InheritStyleValue() override = default;
 
-    DeprecatedString to_deprecated_string() const override { return "inherit"; }
+    ErrorOr<String> to_string() const override { return String::from_utf8("inherit"sv); }
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1424,7 +1425,7 @@ public:
     }
     virtual ~InitialStyleValue() override = default;
 
-    DeprecatedString to_deprecated_string() const override { return "initial"; }
+    ErrorOr<String> to_string() const override { return String::from_utf8("initial"sv); }
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1444,7 +1445,7 @@ public:
     virtual bool has_auto() const override { return m_length.is_auto(); }
     virtual bool has_length() const override { return true; }
     virtual bool has_identifier() const override { return has_auto(); }
-    virtual DeprecatedString to_deprecated_string() const override { return m_length.to_deprecated_string(); }
+    virtual ErrorOr<String> to_string() const override { return m_length.to_string(); }
     virtual Length to_length() const override { return m_length; }
     virtual ValueID to_identifier() const override { return has_auto() ? ValueID::Auto : ValueID::Invalid; }
     virtual NonnullRefPtr<StyleValue> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const override;
@@ -1475,7 +1476,7 @@ public:
     NonnullRefPtr<StyleValue> image() const { return m_image; }
     NonnullRefPtr<StyleValue> style_type() const { return m_style_type; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1521,7 +1522,7 @@ public:
     virtual bool has_integer() const override { return m_value.has<i64>(); }
     virtual float to_integer() const override { return m_value.get<i64>(); }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1545,7 +1546,7 @@ public:
     NonnullRefPtr<StyleValue> overflow_x() const { return m_overflow_x; }
     NonnullRefPtr<StyleValue> overflow_y() const { return m_overflow_y; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1571,7 +1572,7 @@ public:
     Percentage const& percentage() const { return m_percentage; }
     Percentage& percentage() { return m_percentage; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1597,7 +1598,7 @@ public:
     PositionEdge edge_y() const { return m_edge_y; }
     LengthPercentage const& offset_y() const { return m_offset_y; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1626,7 +1627,7 @@ public:
 
     Resolution const& resolution() const { return m_resolution; }
 
-    virtual DeprecatedString to_deprecated_string() const override { return m_resolution.to_deprecated_string(); }
+    virtual ErrorOr<String> to_string() const override { return m_resolution.to_string(); }
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1655,7 +1656,7 @@ public:
     Length const& spread_distance() const { return m_spread_distance; }
     ShadowPlacement placement() const { return m_placement; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1682,23 +1683,23 @@ private:
 
 class StringStyleValue : public StyleValue {
 public:
-    static NonnullRefPtr<StringStyleValue> create(DeprecatedString const& string)
+    static NonnullRefPtr<StringStyleValue> create(String const& string)
     {
         return adopt_ref(*new StringStyleValue(string));
     }
     virtual ~StringStyleValue() override = default;
 
-    DeprecatedString to_deprecated_string() const override { return m_string; }
+    ErrorOr<String> to_string() const override { return m_string; }
     virtual bool equals(StyleValue const& other) const override;
 
 private:
-    explicit StringStyleValue(DeprecatedString const& string)
+    explicit StringStyleValue(String const& string)
         : StyleValue(Type::String)
         , m_string(string)
     {
     }
 
-    DeprecatedString m_string;
+    String m_string;
 };
 
 class TextDecorationStyleValue final : public StyleValue {
@@ -1718,7 +1719,7 @@ public:
     NonnullRefPtr<StyleValue> style() const { return m_style; }
     NonnullRefPtr<StyleValue> color() const { return m_color; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1751,7 +1752,7 @@ public:
 
     Time const& time() const { return m_time; }
 
-    virtual DeprecatedString to_deprecated_string() const override { return m_time.to_deprecated_string(); }
+    virtual ErrorOr<String> to_string() const override { return m_time.to_string(); }
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1775,7 +1776,7 @@ public:
     CSS::TransformFunction transform_function() const { return m_transform_function; }
     NonnullRefPtrVector<StyleValue> values() const { return m_values; }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1798,7 +1799,7 @@ public:
     }
     virtual ~UnresolvedStyleValue() override = default;
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
     Vector<Parser::ComponentValue> const& values() const { return m_values; }
@@ -1825,7 +1826,7 @@ public:
     }
     virtual ~UnsetStyleValue() override = default;
 
-    DeprecatedString to_deprecated_string() const override { return "unset"; }
+    ErrorOr<String> to_string() const override { return String::from_utf8("unset"sv); }
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1852,7 +1853,7 @@ public:
         return m_values[i];
     }
 
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
 
 private:
@@ -1873,7 +1874,7 @@ public:
     virtual ~RectStyleValue() override = default;
 
     EdgeRect rect() const { return m_rect; }
-    virtual DeprecatedString to_deprecated_string() const override;
+    virtual ErrorOr<String> to_string() const override;
     virtual bool has_rect() const override { return true; }
     virtual EdgeRect to_rect() const override { return m_rect; }
     virtual bool equals(StyleValue const& other) const override;
@@ -1894,6 +1895,6 @@ template<>
 struct AK::Formatter<Web::CSS::StyleValue> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::StyleValue const& style_value)
     {
-        return Formatter<StringView>::format(builder, style_value.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(style_value.to_string()));
     }
 };

--- a/Userland/Libraries/LibWeb/CSS/Time.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Time.cpp
@@ -40,11 +40,11 @@ Time Time::percentage_of(Percentage const& percentage) const
     return Time { percentage.as_fraction() * m_value, m_type };
 }
 
-DeprecatedString Time::to_deprecated_string() const
+ErrorOr<String> Time::to_string() const
 {
     if (is_calculated())
-        return m_calculated_style->to_deprecated_string();
-    return DeprecatedString::formatted("{}{}", m_value, unit_name());
+        return m_calculated_style->to_string();
+    return String::formatted("{}{}", m_value, unit_name());
 }
 
 float Time::to_seconds() const

--- a/Userland/Libraries/LibWeb/CSS/Time.h
+++ b/Userland/Libraries/LibWeb/CSS/Time.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/RefPtr.h>
+#include <AK/String.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -31,7 +31,7 @@ public:
     bool is_calculated() const { return m_type == Type::Calculated; }
     NonnullRefPtr<CalculatedStyleValue> calculated_style_value() const;
 
-    DeprecatedString to_deprecated_string() const;
+    ErrorOr<String> to_string() const;
     float to_seconds() const;
 
     bool operator==(Time const& other) const
@@ -55,6 +55,6 @@ template<>
 struct AK::Formatter<Web::CSS::Time> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::Time const& time)
     {
-        return Formatter<StringView>::format(builder, time.to_deprecated_string());
+        return Formatter<StringView>::format(builder, TRY(time.to_string()));
     }
 };

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -283,7 +283,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
         };
         Vector<NameAndValue> properties;
         verify_cast<DOM::Element>(*layout_node.dom_node()).computed_css_values()->for_each_property([&](auto property_id, auto& value) {
-            properties.append({ CSS::string_from_property_id(property_id), value.to_deprecated_string() });
+            properties.append({ CSS::string_from_property_id(property_id), value.to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string() });
         });
         quick_sort(properties, [](auto& a, auto& b) { return a.name < b.name; });
 
@@ -642,14 +642,14 @@ void dump_style_rule(StringBuilder& builder, CSS::CSSStyleRule const& rule, int 
     auto& style_declaration = verify_cast<CSS::PropertyOwningCSSStyleDeclaration>(rule.declaration());
     for (auto& property : style_declaration.properties()) {
         indent(builder, indent_levels);
-        builder.appendff("    {}: '{}'", CSS::string_from_property_id(property.property_id), property.value->to_deprecated_string());
+        builder.appendff("    {}: '{}'", CSS::string_from_property_id(property.property_id), property.value->to_string());
         if (property.important == CSS::Important::Yes)
             builder.append(" \033[31;1m!important\033[0m"sv);
         builder.append('\n');
     }
     for (auto& property : style_declaration.custom_properties()) {
         indent(builder, indent_levels);
-        builder.appendff("    {}: '{}'", property.key, property.value.value->to_deprecated_string());
+        builder.appendff("    {}: '{}'", property.key, property.value.value->to_string());
         if (property.value.important == CSS::Important::Yes)
             builder.append(" \033[31;1m!important\033[0m"sv);
         builder.append('\n');

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -319,7 +319,7 @@ Gfx::FloatMatrix4x4 StackingContext::get_transformation_matrix(CSS::Transformati
             return Gfx::rotation_matrix({ 0.0f, 0.0f, 1.0f }, value(0));
         break;
     default:
-        dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Unhandled transformation function {}", CSS::TransformationStyleValue::create(transformation.function, {})->to_deprecated_string());
+        dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Unhandled transformation function {}", CSS::TransformationStyleValue::create(transformation.function, {})->to_string());
     }
     return Gfx::FloatMatrix4x4::identity();
 }

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -306,7 +306,7 @@ Messages::WebContentServer::InspectDomNodeResponse ConnectionFromClient::inspect
 
             auto serializer = MUST(JsonObjectSerializer<>::try_create(builder));
             properties.for_each_property([&](auto property_id, auto& value) {
-                MUST(serializer.add(Web::CSS::string_from_property_id(property_id), value.to_deprecated_string()));
+                MUST(serializer.add(Web::CSS::string_from_property_id(property_id), value.to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string()));
             });
             MUST(serializer.finish());
 
@@ -323,7 +323,7 @@ Messages::WebContentServer::InspectDomNodeResponse ConnectionFromClient::inspect
                 for (auto const& property : element_to_check->custom_properties()) {
                     if (!seen_properties.contains(property.key)) {
                         seen_properties.set(property.key);
-                        MUST(serializer.add(property.key, property.value.value->to_deprecated_string()));
+                        MUST(serializer.add(property.key, property.value.value->to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string()));
                     }
                 }
 

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1065,7 +1065,7 @@ Messages::WebDriverClient::GetElementCssValueResponse WebDriverConnection::get_e
         auto property = Web::CSS::property_id_from_string(name);
 
         if (auto* computed_values = element->computed_css_values())
-            computed_value = computed_values->property(property)->to_deprecated_string();
+            computed_value = computed_values->property(property)->to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
     }
     // -> Otherwise
     else {


### PR DESCRIPTION
Converts uses of DeprecatedString to String in StyleValue, and patches surrounding files that depend on these functions.

At some point I had to stop converting other classes so stuff like MediaList, StyleComputer, StyleProperties weren't fully converted.