### PR TITLE
LibJS: Add and begin using a completion-compatible string builder

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -231,6 +231,7 @@ set(SOURCES
     Runtime/Temporal/ZonedDateTime.cpp
     Runtime/Temporal/ZonedDateTimeConstructor.cpp
     Runtime/Temporal/ZonedDateTimePrototype.cpp
+    Runtime/ThrowableStringBuilder.cpp
     Runtime/TypedArray.cpp
     Runtime/TypedArrayConstructor.cpp
     Runtime/TypedArrayPrototype.cpp

--- a/Userland/Libraries/LibJS/Runtime/ThrowableStringBuilder.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ThrowableStringBuilder.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Utf16View.h>
+#include <LibJS/Runtime/ThrowableStringBuilder.h>
+
+namespace JS {
+
+ThrowableStringBuilder::ThrowableStringBuilder(VM& vm)
+    : m_vm(vm)
+{
+}
+
+ThrowCompletionOr<void> ThrowableStringBuilder::append(char ch)
+{
+    if (try_append(ch).is_error())
+        return m_vm.throw_completion<InternalError>(ErrorType::NotEnoughMemoryToAllocate, length() + 1);
+    return {};
+}
+
+ThrowCompletionOr<void> ThrowableStringBuilder::append(StringView string)
+{
+    if (try_append(string).is_error())
+        return m_vm.throw_completion<InternalError>(ErrorType::NotEnoughMemoryToAllocate, length() + string.length());
+    return {};
+}
+
+ThrowCompletionOr<void> ThrowableStringBuilder::append(Utf16View const& string)
+{
+    if (try_append(string).is_error())
+        return m_vm.throw_completion<InternalError>(ErrorType::NotEnoughMemoryToAllocate, length() + (string.length_in_code_units() * 2));
+    return {};
+}
+
+ThrowCompletionOr<void> ThrowableStringBuilder::append_code_point(u32 value)
+{
+    if (auto result = try_append_code_point(value); result.is_error())
+        return m_vm.throw_completion<InternalError>(ErrorType::NotEnoughMemoryToAllocate, length() + sizeof(value));
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/ThrowableStringBuilder.h
+++ b/Userland/Libraries/LibJS/Runtime/ThrowableStringBuilder.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringBuilder.h>
+#include <AK/StringView.h>
+#include <LibJS/Forward.h>
+#include <LibJS/Runtime/Completion.h>
+#include <LibJS/Runtime/ErrorTypes.h>
+#include <LibJS/Runtime/VM.h>
+
+namespace JS {
+
+class ThrowableStringBuilder : public AK::StringBuilder {
+public:
+    explicit ThrowableStringBuilder(VM&);
+
+    ThrowCompletionOr<void> append(char);
+    ThrowCompletionOr<void> append(StringView);
+    ThrowCompletionOr<void> append(Utf16View const&);
+    ThrowCompletionOr<void> append_code_point(u32 value);
+
+private:
+    VM& m_vm;
+};
+
+}


### PR DESCRIPTION
`ThrowableStringBuilder` is a thin wrapper around `StringBuilder` to map results from the `try_*` methods to a throw completion. This will let us try to throw on OOM conditions rather than just blowing up.

Fixes #16814. We now get:

![Screenshot from 2023-01-05 15-35-15](https://user-images.githubusercontent.com/5600524/210875005-20c6a301-108a-4df2-983a-2e2d7a31b9aa.png)

