### PR TITLE
Kernel/aarch64: Remove counterproductive `volatile`

### DIFF
--- a/Kernel/Arch/aarch64/ASM_wrapper.h
+++ b/Kernel/Arch/aarch64/ASM_wrapper.h
@@ -63,7 +63,7 @@ inline ExceptionLevel get_current_exception_level()
 inline void wait_cycles(int n)
 {
     // FIXME: Make timer-based.
-    for (int volatile i = 0; i < n; i = i + 1) {
+    for (int i = 0; i < n; i = i + 1) {
         Processor::pause();
     }
 }


### PR DESCRIPTION
Should not be needed, and triggers -Wvolatile in gcc. See discussion on #16790.