### PR TITLE
PixelPaint: Draw the lasso tool preview path with two colors

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/LassoSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LassoSelectTool.cpp
@@ -144,7 +144,9 @@ void LassoSelectTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event
     painter.add_clip_rect(event.rect());
     if (layer)
         painter.translate(editor_layer_location(*layer));
-    painter.stroke_path(m_preview_path, Gfx::Color::Black, 1);
+    // FIXME: Find a way to draw this in a single call
+    painter.stroke_path(m_preview_path, Gfx::Color::Black, 3);
+    painter.stroke_path(m_preview_path, Gfx::Color::White, 1);
 }
 
 bool LassoSelectTool::on_keydown(GUI::KeyEvent& key_event)

--- a/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022-2023, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -139,15 +139,20 @@ void PolygonalSelectTool::on_second_paint(Layer const* layer, GUI::PaintEvent& e
 
     painter.translate(editor_layer_location(*layer));
 
-    for (size_t i = 0; i < m_polygon_points.size() - 1; i++) {
-        auto preview_start = editor_stroke_position(m_polygon_points.at(i), 1);
-        auto preview_end = editor_stroke_position(m_polygon_points.at(i + 1), 1);
-        painter.draw_line(preview_start, preview_end, Color::Black, 1);
-    }
+    auto draw_preview_lines = [&](auto color, auto thickness) {
+        for (size_t i = 0; i < m_polygon_points.size() - 1; i++) {
+            auto preview_start = editor_stroke_position(m_polygon_points.at(i), 1);
+            auto preview_end = editor_stroke_position(m_polygon_points.at(i + 1), 1);
+            painter.draw_line(preview_start, preview_end, color, thickness);
+        }
 
-    auto last_line_start = editor_stroke_position(m_polygon_points.at(m_polygon_points.size() - 1), 1);
-    auto last_line_stop = editor_stroke_position(m_last_selecting_cursor_position, 1);
-    painter.draw_line(last_line_start, last_line_stop, Color::Black, 1);
+        auto last_line_start = editor_stroke_position(m_polygon_points.at(m_polygon_points.size() - 1), 1);
+        auto last_line_stop = editor_stroke_position(m_last_selecting_cursor_position, 1);
+        painter.draw_line(last_line_start, last_line_stop, color, thickness);
+    };
+
+    draw_preview_lines(Gfx::Color::Black, 3);
+    draw_preview_lines(Gfx::Color::White, 1);
 }
 
 bool PolygonalSelectTool::on_keydown(GUI::KeyEvent& key_event)


### PR DESCRIPTION
This stops the preview path disappearing when entering a dark area of the image.

Before:

https://user-images.githubusercontent.com/2817754/210877586-35787dfc-a345-4681-b8cc-0e916b0de067.mp4

After:

https://user-images.githubusercontent.com/2817754/210877623-9b668957-fc0e-46db-b02e-0e5095fa95e2.mp4
