### PR TITLE
Kernel: Add helper function to check if a Process is in jail

### DIFF
--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/PowerStateSwitch.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/PowerStateSwitch.cpp
@@ -46,12 +46,9 @@ ErrorOr<void> SysFSPowerStateSwitchNode::truncate(u64 size)
 
 ErrorOr<size_t> SysFSPowerStateSwitchNode::write_bytes(off_t offset, size_t count, UserOrKernelBuffer const& data, OpenFileDescription*)
 {
-    TRY(Process::current().jail().with([&](auto const& my_jail) -> ErrorOr<void> {
-        // Note: If we are in a jail, don't let the current process to change the power state.
-        if (my_jail)
-            return Error::from_errno(EPERM);
-        return {};
-    }));
+    // Note: If we are in a jail, don't let the current process to change the power state.
+    if (Process::current().is_currently_in_jail())
+        return Error::from_errno(EPERM);
     if (Checked<off_t>::addition_would_overflow(offset, count))
         return Error::from_errno(EOVERFLOW);
     if (offset > 0)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/BooleanVariable.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/BooleanVariable.cpp
@@ -23,12 +23,10 @@ ErrorOr<size_t> SysFSSystemBooleanVariable::write_bytes(off_t, size_t count, Use
     char value = 0;
     TRY(buffer.read(&value, 1));
 
-    TRY(Process::current().jail().with([&](auto& my_jail) -> ErrorOr<void> {
-        // Note: If we are in a jail, don't let the current process to change the variable.
-        if (my_jail)
-            return Error::from_errno(EPERM);
-        return {};
-    }));
+    // NOTE: If we are in a jail, don't let the current process to change the variable.
+    if (Process::current().is_currently_in_jail())
+        return Error::from_errno(EPERM);
+
     if (count != 1)
         return Error::from_errno(EINVAL);
     if (value == '0') {

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -240,6 +240,11 @@ public:
 
     SpinlockProtected<RefPtr<Jail>, LockRank::Process>& jail() { return m_attached_jail; }
 
+    bool is_currently_in_jail() const
+    {
+        return m_attached_jail.with([&](auto& jail) -> bool { return !jail.is_null(); });
+    }
+
     NonnullRefPtr<Credentials> credentials() const;
 
     bool is_dumpable() const


### PR DESCRIPTION
Use this helper function in various places to replace the old code of acquiring the SpinlockProtected<RefPtr<Jail>> of a Process to do that validation.

This is a follow-up PR to #16802, as being promised by me to do so :)

cc @ADKaster 