### PR TITLE
Kernel: Mark Process::jail() method as const

### DIFF
--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -60,7 +60,7 @@ ErrorOr<NonnullOwnPtr<KString>> Device::pseudo_path(OpenFileDescription const&) 
 
 ErrorOr<NonnullLockRefPtr<OpenFileDescription>> Device::open(int options)
 {
-    TRY(Process::current().jail().with([&](auto& my_jail) -> ErrorOr<void> {
+    TRY(Process::current().jail().with([&](auto const& my_jail) -> ErrorOr<void> {
         if (my_jail && !is_openable_by_jailed_processes())
             return Error::from_errno(EPERM);
         return {};

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.cpp
@@ -52,7 +52,7 @@ ErrorOr<void> SysFSGlobalInformation::refresh_data(OpenFileDescription& descript
             return ENOMEM;
     }
     auto builder = TRY(KBufferBuilder::try_create());
-    TRY(Process::current().jail().with([&](auto& my_jail) -> ErrorOr<void> {
+    TRY(Process::current().jail().with([&](auto const& my_jail) -> ErrorOr<void> {
         if (my_jail && !is_readable_by_jailed_processes())
             return Error::from_errno(EPERM);
         return {};

--- a/Kernel/JailManagement.cpp
+++ b/Kernel/JailManagement.cpp
@@ -39,7 +39,7 @@ LockRefPtr<Jail> JailManagement::find_jail_by_index(JailIndex index)
 
 ErrorOr<void> JailManagement::for_each_in_same_jail(Function<ErrorOr<void>(Jail&)> callback)
 {
-    return Process::current().jail().with([&](auto& my_jail) -> ErrorOr<void> {
+    return Process::current().jail().with([&](auto const& my_jail) -> ErrorOr<void> {
         // Note: If we are in a jail, don't reveal anything about the outside world,
         // not even the fact that we are in which jail...
         if (my_jail)

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -67,7 +67,7 @@ ErrorOr<void> Process::for_each_in_same_jail(Function<ErrorOr<void>(Process&)> c
 {
     ErrorOr<void> result {};
     Process::all_instances().with([&](auto const& list) {
-        Process::current().jail().with([&](auto my_jail) {
+        Process::current().jail().with([&](auto const& my_jail) {
             for (auto& process : list) {
                 if (!my_jail) {
                     result = callback(process);
@@ -77,7 +77,7 @@ ErrorOr<void> Process::for_each_in_same_jail(Function<ErrorOr<void>(Process&)> c
                     if (&Process::current() == &process) {
                         result = callback(process);
                     } else {
-                        process.jail().with([&](auto& their_jail) {
+                        process.jail().with([&](auto const& their_jail) {
                             if (their_jail.ptr() == my_jail.ptr())
                                 result = callback(process);
                         });
@@ -96,7 +96,7 @@ ErrorOr<void> Process::for_each_child_in_same_jail(Function<ErrorOr<void>(Proces
     ProcessID my_pid = pid();
     ErrorOr<void> result {};
     Process::all_instances().with([&](auto const& list) {
-        jail().with([&](auto my_jail) {
+        jail().with([&](auto const& my_jail) {
             for (auto& process : list) {
                 if (!my_jail) {
                     if (process.ppid() == my_pid || process.has_tracee_thread(pid()))
@@ -109,7 +109,7 @@ ErrorOr<void> Process::for_each_child_in_same_jail(Function<ErrorOr<void>(Proces
                     if (&Process::current() == &process && (process.ppid() == my_pid || process.has_tracee_thread(pid()))) {
                         result = callback(process);
                     } else {
-                        process.jail().with([&](auto& their_jail) {
+                        process.jail().with([&](auto const& their_jail) {
                             if ((their_jail.ptr() == my_jail.ptr()) && (process.ppid() == my_pid || process.has_tracee_thread(pid())))
                                 result = callback(process);
                         });
@@ -127,7 +127,7 @@ ErrorOr<void> Process::for_each_in_pgrp_in_same_jail(ProcessGroupID pgid, Functi
 {
     ErrorOr<void> result {};
     Process::all_instances().with([&](auto const& list) {
-        jail().with([&](auto my_jail) {
+        jail().with([&](auto const& my_jail) {
             for (auto& process : list) {
                 if (!my_jail) {
                     if (!process.is_dead() && process.pgid() == pgid)
@@ -138,7 +138,7 @@ ErrorOr<void> Process::for_each_in_pgrp_in_same_jail(ProcessGroupID pgid, Functi
                     if (&Process::current() == &process && !process.is_dead() && process.pgid() == pgid) {
                         result = callback(process);
                     } else {
-                        process.jail().with([&](auto& their_jail) {
+                        process.jail().with([&](auto const& their_jail) {
                             if ((their_jail.ptr() == my_jail.ptr()) && !process.is_dead() && process.pgid() == pgid)
                                 result = callback(process);
                         });
@@ -485,7 +485,7 @@ void Process::crash(int signal, FlatPtr ip, bool out_of_memory)
 
 LockRefPtr<Process> Process::from_pid_in_same_jail(ProcessID pid)
 {
-    return Process::current().jail().with([&](auto& my_jail) -> LockRefPtr<Process> {
+    return Process::current().jail().with([&](auto const& my_jail) -> LockRefPtr<Process> {
         return all_instances().with([&](auto const& list) -> LockRefPtr<Process> {
             if (!my_jail) {
                 for (auto& process : list) {
@@ -496,7 +496,7 @@ LockRefPtr<Process> Process::from_pid_in_same_jail(ProcessID pid)
             } else {
                 for (auto& process : list) {
                     if (process.pid() == pid) {
-                        return process.jail().with([&](auto& other_process_jail) -> LockRefPtr<Process> {
+                        return process.jail().with([&](auto const& other_process_jail) -> LockRefPtr<Process> {
                             if (other_process_jail.ptr() == my_jail.ptr())
                                 return process;
                             return {};

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -238,7 +238,7 @@ public:
         return with_protected_data([](auto& protected_data) { return protected_data.ppid; });
     }
 
-    SpinlockProtected<RefPtr<Jail>, LockRank::Process>& jail() { return m_attached_jail; }
+    SpinlockProtected<RefPtr<Jail>, LockRank::Process> const& jail() { return m_attached_jail; }
 
     bool is_currently_in_jail() const
     {

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -474,7 +474,7 @@ ErrorOr<void> Process::do_exec(NonnullLockRefPtr<OpenFileDescription> main_progr
     VERIFY(!Processor::in_critical());
     auto main_program_metadata = main_program_description->metadata();
     // NOTE: Don't allow running SUID binaries at all if we are in a jail.
-    TRY(Process::current().jail().with([&](auto& my_jail) -> ErrorOr<void> {
+    TRY(Process::current().jail().with([&](auto const& my_jail) -> ErrorOr<void> {
         if (my_jail && (main_program_metadata.is_setuid() || main_program_metadata.is_setgid())) {
             return Error::from_errno(EPERM);
         }


### PR DESCRIPTION
We really don't want callers of this function to accidentally change the
jail, or even worse - remove the Process from an attached jail.
To ensure this never happens, we can just declare this method as const
so nobody can mutate it this way.

Relies on #16849.