### PR TITLE
LibCards+Solitaire+Spider: Make widget creation fallible, and other tweaks

### DIFF
--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -353,6 +353,7 @@ inline ErrorOr<NonnullRefPtr<T>> adopt_nonnull_ref_or_enomem(T* object)
 }
 
 #if USING_AK_GLOBALLY
+using AK::adopt_nonnull_ref_or_enomem;
 using AK::adopt_ref_if_nonnull;
 using AK::RefPtr;
 using AK::static_ptr_cast;

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -21,20 +21,20 @@ static constexpr int s_timer_interval_ms = 1000 / 60;
 
 Game::Game()
 {
-    add_stack(adopt_ref(*new CardStack({ 10, 10 }, CardStack::Type::Stock)));
-    add_stack(adopt_ref(*new CardStack({ 10 + Card::width + 10, 10 }, CardStack::Type::Waste)));
-    add_stack(adopt_ref(*new CardStack({ 10 + Card::width + 10, 10 }, CardStack::Type::Play, stack_at_location(Waste))));
-    add_stack(adopt_ref(*new CardStack({ Game::width - 4 * Card::width - 40, 10 }, CardStack::Type::Foundation)));
-    add_stack(adopt_ref(*new CardStack({ Game::width - 3 * Card::width - 30, 10 }, CardStack::Type::Foundation)));
-    add_stack(adopt_ref(*new CardStack({ Game::width - 2 * Card::width - 20, 10 }, CardStack::Type::Foundation)));
-    add_stack(adopt_ref(*new CardStack({ Game::width - Card::width - 10, 10 }, CardStack::Type::Foundation)));
-    add_stack(adopt_ref(*new CardStack({ 10, 10 + Card::height + 10 }, CardStack::Type::Normal)));
-    add_stack(adopt_ref(*new CardStack({ 10 + Card::width + 10, 10 + Card::height + 10 }, CardStack::Type::Normal)));
-    add_stack(adopt_ref(*new CardStack({ 10 + 2 * Card::width + 20, 10 + Card::height + 10 }, CardStack::Type::Normal)));
-    add_stack(adopt_ref(*new CardStack({ 10 + 3 * Card::width + 30, 10 + Card::height + 10 }, CardStack::Type::Normal)));
-    add_stack(adopt_ref(*new CardStack({ 10 + 4 * Card::width + 40, 10 + Card::height + 10 }, CardStack::Type::Normal)));
-    add_stack(adopt_ref(*new CardStack({ 10 + 5 * Card::width + 50, 10 + Card::height + 10 }, CardStack::Type::Normal)));
-    add_stack(adopt_ref(*new CardStack({ 10 + 6 * Card::width + 60, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    MUST(add_stack(Gfx::IntPoint { 10, 10 }, CardStack::Type::Stock));
+    MUST(add_stack(Gfx::IntPoint { 10 + Card::width + 10, 10 }, CardStack::Type::Waste));
+    MUST(add_stack(Gfx::IntPoint { 10 + Card::width + 10, 10 }, CardStack::Type::Play, stack_at_location(Waste)));
+    MUST(add_stack(Gfx::IntPoint { Game::width - 4 * Card::width - 40, 10 }, CardStack::Type::Foundation));
+    MUST(add_stack(Gfx::IntPoint { Game::width - 3 * Card::width - 30, 10 }, CardStack::Type::Foundation));
+    MUST(add_stack(Gfx::IntPoint { Game::width - 2 * Card::width - 20, 10 }, CardStack::Type::Foundation));
+    MUST(add_stack(Gfx::IntPoint { Game::width - Card::width - 10, 10 }, CardStack::Type::Foundation));
+    MUST(add_stack(Gfx::IntPoint { 10, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    MUST(add_stack(Gfx::IntPoint { 10 + Card::width + 10, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    MUST(add_stack(Gfx::IntPoint { 10 + 2 * Card::width + 20, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    MUST(add_stack(Gfx::IntPoint { 10 + 3 * Card::width + 30, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    MUST(add_stack(Gfx::IntPoint { 10 + 4 * Card::width + 40, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    MUST(add_stack(Gfx::IntPoint { 10 + 5 * Card::width + 50, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    MUST(add_stack(Gfx::IntPoint { 10 + 6 * Card::width + 60, 10 + Card::height + 10 }, CardStack::Type::Normal));
 }
 
 static float rand_float()

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -55,12 +55,11 @@ void Game::timer_event(Core::TimerEvent&)
         m_game_over_animation = true;
         set_background_fill_enabled(false);
     } else if (m_game_over_animation) {
-        VERIFY(!m_animation.card().is_null());
-        if (m_animation.card()->position().x() >= Game::width || m_animation.card()->rect().right() <= 0)
+        if (m_animation.position().x() >= Game::width || m_animation.card_rect().right() <= 0)
             create_new_animation_card();
 
         if (m_animation.tick())
-            update(m_animation.card()->rect());
+            update(m_animation.card_rect());
     } else if (m_new_game_animation) {
         if (m_new_game_animation_delay < new_game_animation_delay) {
             ++m_new_game_animation_delay;
@@ -96,11 +95,12 @@ void Game::timer_event(Core::TimerEvent&)
 
 void Game::create_new_animation_card()
 {
-    auto card = Card::construct(static_cast<Cards::Suit>(get_random_uniform(to_underlying(Cards::Suit::__Count))), static_cast<Cards::Rank>(get_random_uniform(to_underlying(Cards::Rank::__Count))));
-    card->set_position({ get_random_uniform(Game::width - Card::width), get_random_uniform(Game::height / 8) });
+    auto suit = static_cast<Cards::Suit>(get_random_uniform(to_underlying(Cards::Suit::__Count)));
+    auto rank = static_cast<Cards::Rank>(get_random_uniform(to_underlying(Cards::Rank::__Count)));
+    Gfx::IntPoint position { get_random_uniform(Game::width - Card::width), get_random_uniform(Game::height / 8) };
 
-    int x_sgn = card->position().x() > (Game::width / 2) ? -1 : 1;
-    m_animation = Animation(card, rand_float() + .4f, x_sgn * (get_random_uniform(3) + 2), .6f + rand_float() * .4f);
+    int x_direction = position.x() > (Game::width / 2) ? -1 : 1;
+    m_animation = Animation(suit, rank, position, rand_float() + .4f, x_direction * (get_random_uniform(3) + 2), .6f + rand_float() * .4f);
 }
 
 void Game::set_background_fill_enabled(bool enabled)

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Till Mayer <till.mayer@web.de>
- * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -19,23 +19,29 @@ namespace Solitaire {
 static constexpr uint8_t new_game_animation_delay = 2;
 static constexpr int s_timer_interval_ms = 1000 / 60;
 
-Game::Game()
+ErrorOr<NonnullRefPtr<Game>> Game::try_create()
 {
-    MUST(add_stack(Gfx::IntPoint { 10, 10 }, CardStack::Type::Stock));
-    MUST(add_stack(Gfx::IntPoint { 10 + Card::width + 10, 10 }, CardStack::Type::Waste));
-    MUST(add_stack(Gfx::IntPoint { 10 + Card::width + 10, 10 }, CardStack::Type::Play, stack_at_location(Waste)));
-    MUST(add_stack(Gfx::IntPoint { Game::width - 4 * Card::width - 40, 10 }, CardStack::Type::Foundation));
-    MUST(add_stack(Gfx::IntPoint { Game::width - 3 * Card::width - 30, 10 }, CardStack::Type::Foundation));
-    MUST(add_stack(Gfx::IntPoint { Game::width - 2 * Card::width - 20, 10 }, CardStack::Type::Foundation));
-    MUST(add_stack(Gfx::IntPoint { Game::width - Card::width - 10, 10 }, CardStack::Type::Foundation));
-    MUST(add_stack(Gfx::IntPoint { 10, 10 + Card::height + 10 }, CardStack::Type::Normal));
-    MUST(add_stack(Gfx::IntPoint { 10 + Card::width + 10, 10 + Card::height + 10 }, CardStack::Type::Normal));
-    MUST(add_stack(Gfx::IntPoint { 10 + 2 * Card::width + 20, 10 + Card::height + 10 }, CardStack::Type::Normal));
-    MUST(add_stack(Gfx::IntPoint { 10 + 3 * Card::width + 30, 10 + Card::height + 10 }, CardStack::Type::Normal));
-    MUST(add_stack(Gfx::IntPoint { 10 + 4 * Card::width + 40, 10 + Card::height + 10 }, CardStack::Type::Normal));
-    MUST(add_stack(Gfx::IntPoint { 10 + 5 * Card::width + 50, 10 + Card::height + 10 }, CardStack::Type::Normal));
-    MUST(add_stack(Gfx::IntPoint { 10 + 6 * Card::width + 60, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    auto game = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Game()));
+
+    TRY(game->add_stack(Gfx::IntPoint { 10, 10 }, CardStack::Type::Stock));
+    TRY(game->add_stack(Gfx::IntPoint { 10 + Card::width + 10, 10 }, CardStack::Type::Waste));
+    TRY(game->add_stack(Gfx::IntPoint { 10 + Card::width + 10, 10 }, CardStack::Type::Play, game->stack_at_location(Waste)));
+    TRY(game->add_stack(Gfx::IntPoint { Game::width - 4 * Card::width - 40, 10 }, CardStack::Type::Foundation));
+    TRY(game->add_stack(Gfx::IntPoint { Game::width - 3 * Card::width - 30, 10 }, CardStack::Type::Foundation));
+    TRY(game->add_stack(Gfx::IntPoint { Game::width - 2 * Card::width - 20, 10 }, CardStack::Type::Foundation));
+    TRY(game->add_stack(Gfx::IntPoint { Game::width - Card::width - 10, 10 }, CardStack::Type::Foundation));
+    TRY(game->add_stack(Gfx::IntPoint { 10, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    TRY(game->add_stack(Gfx::IntPoint { 10 + Card::width + 10, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    TRY(game->add_stack(Gfx::IntPoint { 10 + 2 * Card::width + 20, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    TRY(game->add_stack(Gfx::IntPoint { 10 + 3 * Card::width + 30, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    TRY(game->add_stack(Gfx::IntPoint { 10 + 4 * Card::width + 40, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    TRY(game->add_stack(Gfx::IntPoint { 10 + 5 * Card::width + 50, 10 + Card::height + 10 }, CardStack::Type::Normal));
+    TRY(game->add_stack(Gfx::IntPoint { 10 + 6 * Card::width + 60, 10 + Card::height + 10 }, CardStack::Type::Normal));
+
+    return game;
 }
+
+Game::Game() = default;
 
 static float rand_float()
 {

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Till Mayer <till.mayer@web.de>
- * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -29,11 +29,12 @@ enum class GameOverReason {
 };
 
 class Game final : public Cards::CardGame {
-    C_OBJECT(Game)
+    C_OBJECT_ABSTRACT(Game)
 public:
     static constexpr int width = 640;
     static constexpr int height = 480;
 
+    static ErrorOr<NonnullRefPtr<Game>> try_create();
     virtual ~Game() override = default;
 
     Mode mode() const { return m_mode; }

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020, Till Mayer <till.mayer@web.de>
  * Copyright (c) 2021, the SerenityOS developers.
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -84,7 +84,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         update_mode(Solitaire::Mode::SingleCardDraw);
 
     auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
-    widget->load_from_gml(solitaire_gml);
+    TRY(widget->try_load_from_gml(solitaire_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Solitaire::Game>("game");
     game.set_focus(true);

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -49,19 +49,19 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::Window::try_create());
     window->set_title("Solitaire");
 
-    auto mode = static_cast<Solitaire::Mode>(Config::read_i32("Solitaire"sv, "Settings"sv, "Mode"sv, static_cast<int>(Solitaire::Mode::SingleCardDraw)));
+    auto mode = static_cast<Solitaire::Mode>(Config::read_u32("Solitaire"sv, "Settings"sv, "Mode"sv, to_underlying(Solitaire::Mode::SingleCardDraw)));
 
     auto update_mode = [&](Solitaire::Mode new_mode) {
         mode = new_mode;
-        Config::write_i32("Solitaire"sv, "Settings"sv, "Mode"sv, static_cast<int>(mode));
+        Config::write_u32("Solitaire"sv, "Settings"sv, "Mode"sv, to_underlying(mode));
     };
 
     auto high_score = [&]() {
         switch (mode) {
         case Solitaire::Mode::SingleCardDraw:
-            return static_cast<u32>(Config::read_i32("Solitaire"sv, "HighScores"sv, "SingleCardDraw"sv, 0));
+            return Config::read_u32("Solitaire"sv, "HighScores"sv, "SingleCardDraw"sv, 0);
         case Solitaire::Mode::ThreeCardDraw:
-            return static_cast<u32>(Config::read_i32("Solitaire"sv, "HighScores"sv, "ThreeCardDraw"sv, 0));
+            return Config::read_u32("Solitaire"sv, "HighScores"sv, "ThreeCardDraw"sv, 0);
         default:
             VERIFY_NOT_REACHED();
         }
@@ -70,10 +70,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto update_high_score = [&](u32 new_high_score) {
         switch (mode) {
         case Solitaire::Mode::SingleCardDraw:
-            Config::write_i32("Solitaire"sv, "HighScores"sv, "SingleCardDraw"sv, static_cast<int>(new_high_score));
+            Config::write_u32("Solitaire"sv, "HighScores"sv, "SingleCardDraw"sv, new_high_score);
             break;
         case Solitaire::Mode::ThreeCardDraw:
-            Config::write_i32("Solitaire"sv, "HighScores"sv, "ThreeCardDraw"sv, static_cast<int>(new_high_score));
+            Config::write_u32("Solitaire"sv, "HighScores"sv, "ThreeCardDraw"sv, new_high_score);
             break;
         default:
             VERIFY_NOT_REACHED();

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -299,6 +299,7 @@ void Game::move_focused_cards(CardStack& stack)
 void Game::mouseup_event(GUI::MouseEvent& event)
 {
     GUI::Frame::mouseup_event(event);
+    clear_hovered_stack();
 
     if (!is_moving_cards() || m_new_game_animation || m_draw_animation)
         return;
@@ -345,6 +346,18 @@ void Game::mousemove_event(GUI::MouseEvent& event)
     auto click_location = event.position();
     int dx = click_location.dx_relative_to(m_mouse_down_location);
     int dy = click_location.dy_relative_to(m_mouse_down_location);
+
+    if (auto target_stack = find_stack_to_drop_on(Cards::CardStack::MovementRule::Any)) {
+        if (target_stack != m_hovered_stack) {
+            clear_hovered_stack();
+
+            m_hovered_stack = move(target_stack);
+            m_hovered_stack->set_highlighted(true);
+            update(m_hovered_stack->bounding_box());
+        }
+    } else {
+        clear_hovered_stack();
+    }
 
     for (auto& to_intersect : moving_cards()) {
         mark_intersecting_stacks_dirty(to_intersect);
@@ -417,4 +430,15 @@ void Game::timer_event(Core::TimerEvent&)
         }
     }
 }
+
+void Game::clear_hovered_stack()
+{
+    if (!m_hovered_stack)
+        return;
+
+    m_hovered_stack->set_highlighted(false);
+    update(m_hovered_stack->bounding_box());
+    m_hovered_stack = nullptr;
+}
+
 }

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -20,15 +20,21 @@ static constexpr uint8_t new_game_animation_delay = 2;
 static constexpr uint8_t draw_animation_delay = 2;
 static constexpr int s_timer_interval_ms = 1000 / 60;
 
-Game::Game()
+ErrorOr<NonnullRefPtr<Game>> Game::try_create()
 {
-    MUST(add_stack(Gfx::IntPoint { 10, Game::height - Card::height - 10 }, CardStack::Type::Waste));
-    MUST(add_stack(Gfx::IntPoint { Game::width - Card::width - 10, Game::height - Card::height - 10 }, CardStack::Type::Stock));
+    auto game = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Game()));
+
+    TRY(game->add_stack(Gfx::IntPoint { 10, Game::height - Card::height - 10 }, CardStack::Type::Waste));
+    TRY(game->add_stack(Gfx::IntPoint { Game::width - Card::width - 10, Game::height - Card::height - 10 }, CardStack::Type::Stock));
 
     for (int i = 0; i < 10; i++) {
-        MUST(add_stack(Gfx::IntPoint { 10 + i * (Card::width + 10), 10 }, CardStack::Type::Normal));
+        TRY(game->add_stack(Gfx::IntPoint { 10 + i * (Card::width + 10), 10 }, CardStack::Type::Normal));
     }
+
+    return game;
 }
+
+Game::Game() = default;
 
 void Game::setup(Mode mode)
 {

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -22,11 +22,11 @@ static constexpr int s_timer_interval_ms = 1000 / 60;
 
 Game::Game()
 {
-    add_stack(adopt_ref(*new CardStack({ 10, Game::height - Card::height - 10 }, CardStack::Type::Waste)));
-    add_stack(adopt_ref(*new CardStack({ Game::width - Card::width - 10, Game::height - Card::height - 10 }, CardStack::Type::Stock)));
+    MUST(add_stack(Gfx::IntPoint { 10, Game::height - Card::height - 10 }, CardStack::Type::Waste));
+    MUST(add_stack(Gfx::IntPoint { Game::width - Card::width - 10, Game::height - Card::height - 10 }, CardStack::Type::Stock));
 
     for (int i = 0; i < 10; i++) {
-        add_stack(adopt_ref(*new CardStack({ 10 + i * (Card::width + 10), 10 }, CardStack::Type::Normal)));
+        MUST(add_stack(Gfx::IntPoint { 10 + i * (Card::width + 10), 10 }, CardStack::Type::Normal));
     }
 }
 

--- a/Userland/Games/Spider/Game.h
+++ b/Userland/Games/Spider/Game.h
@@ -91,6 +91,7 @@ private:
     void detect_full_stacks();
     void detect_victory();
     void move_focused_cards(CardStack& stack);
+    void clear_hovered_stack();
 
     void paint_event(GUI::PaintEvent&) override;
     void mousedown_event(GUI::MouseEvent&) override;
@@ -117,6 +118,8 @@ private:
     Gfx::IntRect m_original_stock_rect;
 
     uint32_t m_score { 500 };
+
+    RefPtr<CardStack> m_hovered_stack;
 };
 
 }

--- a/Userland/Games/Spider/Game.h
+++ b/Userland/Games/Spider/Game.h
@@ -30,11 +30,12 @@ enum class GameOverReason {
 };
 
 class Game final : public Cards::CardGame {
-    C_OBJECT(Game)
+    C_OBJECT_ABSTRACT(Game)
 public:
     static constexpr int width = 10 + 10 * Card::width + 90 + 10;
     static constexpr int height = 480;
 
+    static ErrorOr<NonnullRefPtr<Game>> try_create();
     ~Game() override = default;
 
     Mode mode() const { return m_mode; }

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021, Jamie Mansfield <jmansfield@cadixdev.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -57,11 +57,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::Window::try_create());
     window->set_title("Spider");
 
-    auto mode = static_cast<Spider::Mode>(Config::read_i32("Spider"sv, "Settings"sv, "Mode"sv, static_cast<int>(Spider::Mode::SingleSuit)));
+    auto mode = static_cast<Spider::Mode>(Config::read_u32("Spider"sv, "Settings"sv, "Mode"sv, to_underlying(Spider::Mode::SingleSuit)));
 
     auto update_mode = [&](Spider::Mode new_mode) {
         mode = new_mode;
-        Config::write_i32("Spider"sv, "Settings"sv, "Mode"sv, static_cast<int>(mode));
+        Config::write_u32("Spider"sv, "Settings"sv, "Mode"sv, to_underlying(mode));
     };
 
     auto mode_id = [&]() {
@@ -75,40 +75,40 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     };
 
-    auto statistic_display = static_cast<StatisticDisplay>(Config::read_i32("Spider"sv, "Settings"sv, "StatisticDisplay"sv, static_cast<int>(StatisticDisplay::HighScore)));
+    auto statistic_display = static_cast<StatisticDisplay>(Config::read_u32("Spider"sv, "Settings"sv, "StatisticDisplay"sv, to_underlying(StatisticDisplay::HighScore)));
     auto update_statistic_display = [&](StatisticDisplay new_statistic_display) {
         statistic_display = new_statistic_display;
-        Config::write_i32("Spider"sv, "Settings"sv, "StatisticDisplay"sv, static_cast<int>(statistic_display));
+        Config::write_u32("Spider"sv, "Settings"sv, "StatisticDisplay"sv, to_underlying(statistic_display));
     };
 
     auto high_score = [&]() {
-        return static_cast<u32>(Config::read_i32("Spider"sv, "HighScores"sv, mode_id(), 0));
+        return Config::read_u32("Spider"sv, "HighScores"sv, mode_id(), 0);
     };
 
     auto update_high_score = [&](u32 new_high_score) {
-        Config::write_i32("Spider"sv, "HighScores"sv, mode_id(), static_cast<int>(new_high_score));
+        Config::write_u32("Spider"sv, "HighScores"sv, mode_id(), new_high_score);
     };
 
     auto best_time = [&]() {
-        return static_cast<u32>(Config::read_i32("Spider"sv, "BestTimes"sv, mode_id(), 0));
+        return Config::read_u32("Spider"sv, "BestTimes"sv, mode_id(), 0);
     };
 
     auto update_best_time = [&](u32 new_best_time) {
-        Config::write_i32("Spider"sv, "BestTimes"sv, mode_id(), static_cast<int>(new_best_time));
+        Config::write_u32("Spider"sv, "BestTimes"sv, mode_id(), new_best_time);
     };
 
     auto total_wins = [&]() {
-        return static_cast<u32>(Config::read_i32("Spider"sv, "TotalWins"sv, mode_id(), 0));
+        return Config::read_u32("Spider"sv, "TotalWins"sv, mode_id(), 0);
     };
     auto increment_total_wins = [&]() {
-        Config::write_i32("Spider"sv, "TotalWins"sv, mode_id(), static_cast<int>(total_wins() + 1));
+        Config::write_u32("Spider"sv, "TotalWins"sv, mode_id(), total_wins() + 1);
     };
 
     auto total_losses = [&]() {
-        return static_cast<u32>(Config::read_i32("Spider"sv, "TotalLosses"sv, mode_id(), 0));
+        return Config::read_u32("Spider"sv, "TotalLosses"sv, mode_id(), 0);
     };
     auto increment_total_losses = [&]() {
-        Config::write_i32("Spider"sv, "TotalLosses"sv, mode_id(), static_cast<int>(total_losses() + 1));
+        Config::write_u32("Spider"sv, "TotalLosses"sv, mode_id(), total_losses() + 1);
     };
 
     if (mode >= Spider::Mode::__Count)

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -118,7 +118,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         update_statistic_display(StatisticDisplay::HighScore);
 
     auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
-    widget->load_from_gml(spider_gml);
+    TRY(widget->try_load_from_gml(spider_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Spider::Game>("game");
     game.set_focus(true);

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -33,11 +33,6 @@ CardGame::CardGame()
     set_background_color(background_color.value_or(Color::from_rgb(0x008000)));
 }
 
-void CardGame::add_stack(NonnullRefPtr<CardStack> stack)
-{
-    m_stacks.append(move(stack));
-}
-
 void CardGame::mark_intersecting_stacks_dirty(Cards::Card const& intersecting_card)
 {
     for (auto& stack : stacks()) {

--- a/Userland/Libraries/LibCards/CardGame.h
+++ b/Userland/Libraries/LibCards/CardGame.h
@@ -28,7 +28,13 @@ public:
     NonnullRefPtrVector<CardStack>& stacks() { return m_stacks; }
     NonnullRefPtrVector<CardStack> const& stacks() const { return m_stacks; }
     CardStack& stack_at_location(int location) { return m_stacks[location]; }
-    void add_stack(NonnullRefPtr<CardStack>);
+
+    template<class... Args>
+    ErrorOr<void> add_stack(Args&&... args)
+    {
+        auto stack = TRY(try_make_ref_counted<CardStack>(forward<Args>(args)...));
+        return m_stacks.try_append(move(stack));
+    }
     void mark_intersecting_stacks_dirty(Card const& intersecting_card);
 
     bool is_moving_cards() const { return !m_moving_cards.is_empty(); }


### PR DESCRIPTION
This was intended to be an ErrorOr Widget creation PR, but I got distracted with Solitaire things. :sweat_smile: 

- Make `CardGame::add_stack()` fallible, with a more convenient API.
- Make Solitaire and Spider's Widget initialization fallible.
- Save and load u32s to the config file directly instead of casting to i32.
- Highlight target stacks in Spider, as in Solitaire.
- Avoid repeatedly allocating cards for the game-over animation, by just painting the bitmap directly.