### PR TITLE
LibCards+Solitaire: Preview cards in a stack with the right mouse button

### DIFF
--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -257,10 +257,14 @@ void Game::mousedown_event(GUI::MouseEvent& event)
                     if (is_auto_collecting() && attempt_to_move_card_to_foundations(to_check))
                         break;
 
-                    pick_up_cards_from_stack(to_check, click_location, Cards::CardStack::MovementRule::Alternating);
+                    if (event.button() == GUI::MouseButton::Secondary) {
+                        preview_card(to_check, click_location);
+                    } else {
+                        pick_up_cards_from_stack(to_check, click_location, Cards::CardStack::MovementRule::Alternating);
+                        m_mouse_down_location = click_location;
+                        m_mouse_down = true;
+                    }
 
-                    m_mouse_down_location = click_location;
-                    m_mouse_down = true;
                     start_timer_if_necessary();
                 }
             }
@@ -273,6 +277,11 @@ void Game::mouseup_event(GUI::MouseEvent& event)
 {
     GUI::Frame::mouseup_event(event);
     clear_hovered_stack();
+
+    if (is_previewing_card()) {
+        clear_card_preview();
+        return;
+    }
 
     if (!is_moving_cards() || m_game_over_animation || m_new_game_animation)
         return;

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -98,12 +98,14 @@ public:
     bool is_moving() const { return m_moving; }
     bool is_upside_down() const { return m_upside_down; }
     bool is_inverted() const { return m_inverted; }
+    bool is_previewed() const { return m_previewed; }
     Gfx::Color color() const { return (m_suit == Suit::Diamonds || m_suit == Suit::Hearts) ? Color::Red : Color::Black; }
 
     void set_position(const Gfx::IntPoint p) { m_rect.set_location(p); }
     void set_moving(bool moving) { m_moving = moving; }
     void set_upside_down(bool upside_down) { m_upside_down = upside_down; }
     void set_inverted(bool inverted) { m_inverted = inverted; }
+    void set_previewed(bool previewed) { m_previewed = previewed; }
 
     void save_old_position();
 
@@ -122,6 +124,7 @@ private:
     bool m_moving { false };
     bool m_upside_down { false };
     bool m_inverted { false };
+    bool m_previewed { false };
 };
 
 enum class Shuffle {

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -144,4 +144,22 @@ void CardGame::set_background_color(Gfx::Color color)
     CardPainter::the().set_background_color(color);
 }
 
+void CardGame::preview_card(CardStack& stack, Gfx::IntPoint click_location)
+{
+    if (!stack.preview_card(click_location))
+        return;
+
+    m_previewed_card_stack = stack;
+    update(stack.bounding_box());
+}
+
+void CardGame::clear_card_preview()
+{
+    VERIFY(m_previewed_card_stack);
+
+    update(m_previewed_card_stack->bounding_box());
+    m_previewed_card_stack->clear_card_preview();
+    m_previewed_card_stack = nullptr;
+}
+
 }

--- a/Userland/Libraries/LibCards/CardGame.h
+++ b/Userland/Libraries/LibCards/CardGame.h
@@ -41,6 +41,10 @@ public:
     void drop_cards_on_stack(CardStack&, CardStack::MovementRule);
     void clear_moving_cards();
 
+    bool is_previewing_card() const { return !m_previewed_card_stack.is_null(); }
+    void preview_card(CardStack&, Gfx::IntPoint click_location);
+    void clear_card_preview();
+
     void dump_layout() const;
 
 protected:
@@ -53,6 +57,7 @@ private:
 
     NonnullRefPtrVector<Card> m_moving_cards;
     RefPtr<CardStack> m_moving_cards_source_stack;
+    RefPtr<CardStack> m_previewed_card_stack;
 };
 
 }

--- a/Userland/Libraries/LibCards/CardStack.h
+++ b/Userland/Libraries/LibCards/CardStack.h
@@ -50,6 +50,10 @@ public:
 
     bool is_allowed_to_push(Card const&, size_t stack_size = 1, MovementRule movement_rule = MovementRule::Alternating) const;
     void add_all_grabbed_cards(Gfx::IntPoint click_location, NonnullRefPtrVector<Card>& grabbed, MovementRule movement_rule = MovementRule::Alternating);
+
+    bool preview_card(Gfx::IntPoint click_location);
+    void clear_card_preview();
+
     void paint(GUI::Painter&, Gfx::Color background_color);
     void clear();
 


### PR DESCRIPTION
I've made previous attempts to get the suit to always show (cfc3a2ebac3702c5517847a22a75e682aa219e9a), but that doesn't seem to be enough anymore, so this is just a nicer way to see what card is in the middle of a stack.

[Screencast from 2023-01-06 08-30-47.webm](https://user-images.githubusercontent.com/5600524/211022724-a8d035e1-f3f9-45ac-9b8d-1429af02f998.webm)
