### PR TITLE
Kernel: Introduce the RAMFS filesystem and support for init RAMFS instance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,21 @@ add_custom_target(image
     DEPENDS qemu-image
 )
 
+add_custom_target(initramfs-directory
+    COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SerenityOS_SOURCE_DIR}" "SERENITY_ARCH=${SERENITY_ARCH}" "SERENITY_TOOLCHAIN=${CMAKE_CXX_COMPILER_ID}" "LLVM_VERSION=${CMAKE_CXX_COMPILER_VERSION}" "${SerenityOS_SOURCE_DIR}/Meta/build-initramfs-image.sh"
+    BYPRODUCTS "${CMAKE_BINARY_DIR}/InitRootFS"
+    USES_TERMINAL
+)
+
+add_custom_target(initramfs-image
+    COMMAND $<TARGET_FILE:Lagom::InitRAMFSTool> --force-uid 0 --force-gid 0 -f initramfs.serecpio InitRootFS/
+    BYPRODUCTS "${CMAKE_BINARY_DIR}/initramfs.serecpio"
+    USES_TERMINAL
+)
+
 add_custom_target(qemu-image
+    COMMAND ${CMAKE_MAKE_PROGRAM} initramfs-directory
+    COMMAND ${CMAKE_MAKE_PROGRAM} initramfs-image
     COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SerenityOS_SOURCE_DIR}" "SERENITY_ARCH=${SERENITY_ARCH}" "SERENITY_TOOLCHAIN=${CMAKE_CXX_COMPILER_ID}" "LLVM_VERSION=${CMAKE_CXX_COMPILER_VERSION}" "${SerenityOS_SOURCE_DIR}/Meta/build-image-qemu.sh"
     BYPRODUCTS "${CMAKE_BINARY_DIR}/_disk_image"
     USES_TERMINAL

--- a/Kernel/API/initramfs_definitions.h
+++ b/Kernel/API/initramfs_definitions.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+struct [[gnu::packed]] initramfs_image_header {
+    u8 magic[8];   // stands for 534552454350494F ("SERECPIO")
+    u8 endianness; // NOTE: Value 0 is for little-endian, 1 for big-endian
+    u8 padding[7];
+    u32 inodes_count;
+    u32 data_blocks_count;
+    u8 data_block_alignment_size_power_2; // NOTE: Minimum value is 12 for 4096 bytes, max value is 24 for 16 MiB
+    u8 reserved;
+    u16 flags;
+    u32 inodes_section_start;
+    u32 inodes_names_section_start;
+    u32 data_blocks_section_start;
+};
+
+struct [[gnu::packed]] initramfs_inode {
+    u32 name_offset;
+    u32 name_length;
+    u32 file_size;
+    u32 blocks_count;
+    u32 blocks_offset;
+    u32 uid;
+    u32 gid;
+    i64 mtime_seconds;
+    u64 mtime_nanoseconds;
+    u32 major;
+    u32 minor;
+    u16 mode;
+};

--- a/Kernel/Arch/x86_64/init.cpp
+++ b/Kernel/Arch/x86_64/init.cpp
@@ -131,8 +131,10 @@ READONLY_AFTER_INIT char const* kernel_cmdline;
 READONLY_AFTER_INIT u32 multiboot_flags;
 READONLY_AFTER_INIT multiboot_memory_map_t* multiboot_memory_map;
 READONLY_AFTER_INIT size_t multiboot_memory_map_count;
-READONLY_AFTER_INIT multiboot_module_entry_t* multiboot_modules;
 READONLY_AFTER_INIT size_t multiboot_modules_count;
+READONLY_AFTER_INIT PhysicalAddress multiboot_module_ramdisk_physical_start;
+READONLY_AFTER_INIT PhysicalAddress multiboot_module_ramdisk_physical_end;
+READONLY_AFTER_INIT PhysicalAddress multiboot_module_ramdisk_physical_string_addr;
 READONLY_AFTER_INIT PhysicalAddress multiboot_framebuffer_addr;
 READONLY_AFTER_INIT u32 multiboot_framebuffer_pitch;
 READONLY_AFTER_INIT u32 multiboot_framebuffer_width;
@@ -163,8 +165,10 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
     multiboot_flags = boot_info.multiboot_flags;
     multiboot_memory_map = (multiboot_memory_map_t*)boot_info.multiboot_memory_map;
     multiboot_memory_map_count = boot_info.multiboot_memory_map_count;
-    multiboot_modules = (multiboot_module_entry_t*)boot_info.multiboot_modules;
     multiboot_modules_count = boot_info.multiboot_modules_count;
+    multiboot_module_ramdisk_physical_start = PhysicalAddress { boot_info.multiboot_module_ramdisk_physical_start };
+    multiboot_module_ramdisk_physical_end = PhysicalAddress { boot_info.multiboot_module_ramdisk_physical_end };
+    multiboot_module_ramdisk_physical_string_addr = PhysicalAddress { boot_info.multiboot_module_ramdisk_physical_string_addr };
     multiboot_framebuffer_addr = PhysicalAddress { boot_info.multiboot_framebuffer_addr };
     multiboot_framebuffer_pitch = boot_info.multiboot_framebuffer_pitch;
     multiboot_framebuffer_width = boot_info.multiboot_framebuffer_width;
@@ -177,11 +181,25 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
     // We need to copy the command line before kmalloc is initialized,
     // as it may overwrite parts of multiboot!
     CommandLine::early_initialize(kernel_cmdline);
-    memcpy(multiboot_copy_boot_modules_array, multiboot_modules, multiboot_modules_count * sizeof(multiboot_module_entry_t));
-    multiboot_copy_boot_modules_count = multiboot_modules_count;
 
     new (&bsp_processor()) Processor();
     bsp_processor().early_initialize(0);
+
+    if (multiboot_modules_count > 0) {
+        dbgln("Initramfs image {}, end {}", multiboot_module_ramdisk_physical_start, multiboot_module_ramdisk_physical_end);
+        if (multiboot_module_ramdisk_physical_start > PhysicalAddress(0xffffffff) || multiboot_module_ramdisk_physical_end > PhysicalAddress(0xffffffff)) {
+            // FIXME: Add support for using initramfs images in such memory regions.
+            dbgln("Detected initramfs higher than 4GB, ignoring");
+        } else {
+            multiboot_copy_boot_modules_array[0].start = multiboot_module_ramdisk_physical_start.get();
+            multiboot_copy_boot_modules_array[0].end = multiboot_module_ramdisk_physical_end.get();
+            if (multiboot_module_ramdisk_physical_string_addr <= PhysicalAddress(0xffffffff)) {
+                multiboot_copy_boot_modules_array[0].string_addr = multiboot_module_ramdisk_physical_string_addr.get();
+            }
+        }
+        if (multiboot_modules_count > 1)
+            dbgln("Detected more than one multiboot modules, ignoring the rest.");
+    }
 
     // Invoke the constructors needed for the kernel heap
     for (ctor_func_t* ctor = start_heap_ctors; ctor < end_heap_ctors; ctor++)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -713,7 +713,25 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     target_link_libraries(Kernel PRIVATE kernel_heap clang_rt.builtins)
 endif()
 
-add_custom_command(
+if ("${SERENITY_ARCH}" STREQUAL "x86_64")
+    set(KERNEL_ELF_OBJCOPY_TARGET "elf64-x86-64")
+endif()
+
+# In x86_64 the Kernel is linked to the Pre-kernel binary.
+if ("${SERENITY_ARCH}" STREQUAL "x86_64")
+    add_custom_command(
+        TARGET Kernel POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E env NM=${CMAKE_NM} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
+        COMMAND ${CMAKE_COMMAND} -E env OBJCOPY=${CMAKE_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
+        COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
+        COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel
+        COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel
+        COMMAND $<TARGET_FILE:Lagom::ELFBaker> Kernel Kernel.drow.standalone
+        COMMAND ${CMAKE_OBJCOPY} -I binary -O ${KERNEL_ELF_OBJCOPY_TARGET} --rename-section .data=.Kernel_drow --set-section-alignment .Kernel_drow=4096  --set-section-flags .Kernel_drow=load Kernel.drow.standalone Kernel.o
+        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel.o ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
+    )
+elseif ("${SERENITY_ARCH}" STREQUAL "aarch64")
+    add_custom_command(
         TARGET Kernel POST_BUILD
         COMMAND "${CMAKE_COMMAND}" -E env NM=${CMAKE_NM} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
         COMMAND "${CMAKE_COMMAND}" -E env OBJCOPY=${CMAKE_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
@@ -721,9 +739,16 @@ add_custom_command(
         COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel
         COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel
         BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
-)
+    )
+endif()
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel" DESTINATION boot)
+# In x86_64 the Kernel is linked to the Pre-kernel binary.
+if ("${SERENITY_ARCH}" STREQUAL "x86_64")
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Prekernel/Kernel" DESTINATION boot)
+elseif ("${SERENITY_ARCH}" STREQUAL "aarch64")
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel" DESTINATION boot)
+endif()
+
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel.debug" DESTINATION boot)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kernel.map" DESTINATION res)
 

--- a/Kernel/FileSystem/RAMFS/FileSystem.cpp
+++ b/Kernel/FileSystem/RAMFS/FileSystem.cpp
@@ -5,8 +5,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/StringView.h>
 #include <Kernel/FileSystem/RAMFS/FileSystem.h>
 #include <Kernel/FileSystem/RAMFS/Inode.h>
+#include <Kernel/Memory/TypedMapping.h>
+#include <Kernel/Storage/StorageManagement.h>
 
 namespace Kernel {
 
@@ -35,6 +38,101 @@ unsigned RAMFS::next_inode_index()
     MutexLocker locker(m_lock);
 
     return m_next_inode_index++;
+}
+
+UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<RAMFSInode>> RAMFS::try_create_ramfs_inode_for_initramfs(PhysicalAddress initramfs_image_inodes_data_blocks_section_start, initramfs_inode const& inode, RAMFSInode const& parent_directory_inode)
+{
+    InodeMetadata metadata;
+    metadata.size = inode.file_size;
+    metadata.mode = inode.mode;
+    metadata.uid = inode.uid;
+    metadata.gid = inode.gid;
+    metadata.link_count = 1;
+    metadata.atime = Time::from_timespec({ inode.mtime_seconds, 0 });
+    metadata.ctime = Time::from_timespec({ inode.mtime_seconds, 0 });
+    metadata.mtime = Time::from_timespec({ inode.mtime_seconds, 0 });
+    metadata.dtime = Time::from_timespec({ inode.mtime_seconds, 0 });
+    metadata.block_size = PAGE_SIZE;
+    metadata.block_count = inode.blocks_count;
+
+    if (Kernel::is_character_device(inode.mode) || Kernel::is_block_device(inode.mode)) {
+        metadata.major_device = inode.major;
+        metadata.minor_device = inode.minor;
+    }
+
+    if (metadata.is_directory()) {
+        return RAMFSInode::try_create_as_directory(*this, metadata, parent_directory_inode);
+    }
+
+    if (inode.file_size == 0) {
+        return RAMFSInode::try_create_with_empty_content(*this, metadata, parent_directory_inode);
+    }
+
+    auto inode_data_blocks_offset = initramfs_image_inodes_data_blocks_section_start.offset(inode.blocks_offset << 12);
+    return RAMFSInode::try_create_with_content(*this, metadata, inode_data_blocks_offset, metadata.block_count, parent_directory_inode);
+}
+
+static ErrorOr<NonnullLockRefPtr<RAMFSInode>> ensure_initramfs_path(RAMFSInode& inode, StringView full_name)
+{
+    auto first_path_part = full_name.find_first_split_view('/');
+    if (first_path_part == full_name)
+        return inode;
+    auto result = inode.lookup(first_path_part);
+    if (result.is_error()) {
+        VERIFY(result.error() != Error::from_errno(ENOENT));
+        return result.release_error();
+    }
+    auto next_inode = static_ptr_cast<RAMFSInode>(result.release_value());
+    return ensure_initramfs_path(*next_inode, full_name.substring_view(1 + first_path_part.length()));
+}
+
+UNMAP_AFTER_INIT ErrorOr<void> RAMFS::populate_initramfs(PhysicalAddress initramfs_image_start, PhysicalAddress initramfs_image_end)
+{
+    auto& fs_root_inode = static_cast<RAMFSInode&>(root_inode());
+    auto current_address = initramfs_image_start;
+    auto image_header = TRY(Memory::map_typed<initramfs_image_header>(current_address));
+    if (StringView { image_header->magic, 8 } != "SERECPIO"sv) {
+        dmesgln("InitRAMFS: invalid magic bytes");
+        return Error::from_errno(EINVAL);
+    }
+
+    // FIXME: Although we could create an initramfs archive with block size larger than
+    // 4096 bytes, for now we still can't handle it elegantly, so for now let's not support it.
+    if (image_header->data_block_alignment_size_power_2 != 12) {
+        dmesgln("InitRAMFS: data block size alignment is not supported");
+        return Error::from_errno(ENOTSUP);
+    }
+
+    dmesgln("InitRAMFS: {} endian, inodes count {}, data block size - {} bytes", image_header->endianness == 1 ? "big" : "little", image_header->inodes_count, 1 << image_header->data_block_alignment_size_power_2);
+    auto initramfs_image_inodes_section_start = initramfs_image_start.offset(image_header->inodes_section_start);
+    auto initramfs_image_inodes_names_section_start = initramfs_image_start.offset(image_header->inodes_names_section_start);
+    auto initramfs_image_inodes_data_blocks_section_start = initramfs_image_start.offset(image_header->data_blocks_section_start);
+
+    for (size_t inode_index = 0; inode_index < image_header->inodes_count; inode_index++) {
+        auto inode_paddr_location = initramfs_image_inodes_section_start.offset(sizeof(initramfs_inode) * inode_index);
+        VERIFY(initramfs_image_end > inode_paddr_location);
+        auto inode = TRY(Memory::map_typed<initramfs_inode>(inode_paddr_location));
+
+        auto name_offset = initramfs_image_inodes_names_section_start.offset(inode->name_offset);
+        VERIFY(initramfs_image_end > name_offset);
+        auto inode_name = TRY(Memory::map_typed<u8>(name_offset, inode->name_length));
+        auto name = StringView { inode_name.ptr(), inode->name_length };
+
+        auto parent_directory_inode = TRY(ensure_initramfs_path(fs_root_inode, name));
+        auto new_inode = TRY(try_create_ramfs_inode_for_initramfs(initramfs_image_inodes_data_blocks_section_start, *inode, parent_directory_inode));
+
+        auto basename = name.find_last_split_view('/');
+        TRY(parent_directory_inode->add_child(new_inode, basename, inode->mode));
+    }
+    return {};
+}
+
+UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<RAMFS>> RAMFS::try_create_as_populated_initramfs(Badge<StorageManagement>, PhysicalAddress initramfs_image_start, PhysicalAddress initramfs_image_end)
+{
+    auto fs = static_ptr_cast<RAMFS>(TRY(RAMFS::try_create()));
+    TRY(fs->initialize());
+    TRY(fs->populate_initramfs(initramfs_image_start, initramfs_image_end));
+    return fs;
 }
 
 }

--- a/Kernel/FileSystem/RAMFS/FileSystem.h
+++ b/Kernel/FileSystem/RAMFS/FileSystem.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <Kernel/API/initramfs_definitions.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/FileSystem/Inode.h>
 #include <Kernel/Forward.h>
@@ -18,6 +19,8 @@ class RAMFS final : public FileSystem {
 
 public:
     virtual ~RAMFS() override;
+
+    static ErrorOr<NonnullLockRefPtr<RAMFS>> try_create_as_populated_initramfs(Badge<StorageManagement>, PhysicalAddress initramfs_image_start, PhysicalAddress initramfs_image_end);
     static ErrorOr<NonnullLockRefPtr<FileSystem>> try_create();
     virtual ErrorOr<void> initialize() override;
 
@@ -29,6 +32,9 @@ public:
 
 private:
     RAMFS();
+
+    ErrorOr<NonnullLockRefPtr<RAMFSInode>> try_create_ramfs_inode_for_initramfs(PhysicalAddress initramfs_image_inodes_data_blocks_section_start, initramfs_inode const& inode, RAMFSInode const& parent_directory_inode);
+    ErrorOr<void> populate_initramfs(PhysicalAddress initramfs_image_start, PhysicalAddress initramfs_image_end);
 
     LockRefPtr<RAMFSInode> m_root_inode;
 

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -26,7 +26,7 @@
 namespace Kernel {
 
 static Singleton<VirtualFileSystem> s_the;
-static constexpr int root_mount_flags = MS_NODEV | MS_NOSUID | MS_RDONLY;
+static constexpr int root_mount_flags = 0;
 
 UNMAP_AFTER_INIT void VirtualFileSystem::initialize()
 {

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -216,15 +216,12 @@ ErrorOr<void> VirtualFileSystem::mount_root(FileSystem& fs)
     }
 
     m_root_inode = root_inode;
-    if (fs.is_file_backed()) {
-        auto pseudo_path = TRY(static_cast<FileBackedFileSystem&>(fs).file_description().pseudo_path());
-        dmesgln("VirtualFileSystem: mounted root({}) from {} ({})", fs.fsid(), fs.class_name(), pseudo_path);
-        m_file_backed_file_systems_list.with([&](auto& list) {
+    dmesgln("VirtualFileSystem: mounted root({}) from type {}", fs.fsid(), fs.class_name());
+
+    m_file_backed_file_systems_list.with([&](auto& list) {
+        if (fs.is_file_backed())
             list.append(static_cast<FileBackedFileSystem&>(fs));
-        });
-    } else {
-        dmesgln("VirtualFileSystem: mounted root({}) from {}", fs.fsid(), fs.class_name());
-    }
+    });
 
     m_file_systems_list.with([&](auto& fs_list) {
         fs_list.append(fs);

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -54,6 +54,7 @@ template<LockRank Rank>
 class RecursiveSpinlock;
 class Scheduler;
 class Socket;
+class StorageManagement;
 class SysFS;
 class SysFSDirectory;
 class SysFSRootDirectory;

--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -8,14 +8,21 @@ set(SOURCES
     )
 
 if ("${SERENITY_ARCH}" STREQUAL "x86_64")
-    set(PREKERNEL_TARGET Prekernel64)
+    set(PREKERNEL_TARGET kernel_x86-64)
 elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
     message(SEND_ERROR "Prekernel is not needed on aarch64 and should not be compiled!")
 endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
 
-add_executable(${PREKERNEL_TARGET} ${SOURCES})
+add_library(KernelObject OBJECT IMPORTED)
+
+set_property(TARGET KernelObject PROPERTY 
+    IMPORTED_OBJECTS ${CMAKE_CURRENT_BINARY_DIR}/../Kernel.o
+)
+
+add_executable(${PREKERNEL_TARGET} ${SOURCES} $<TARGET_OBJECTS:KernelObject>)
+add_dependencies(${PREKERNEL_TARGET} Kernel)
 target_compile_options(${PREKERNEL_TARGET} PRIVATE -no-pie -fno-pic -fno-threadsafe-statics)
 
 target_link_options(${PREKERNEL_TARGET} PRIVATE LINKER:-T ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld -nostdlib LINKER:--no-pie)
@@ -27,13 +34,20 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     target_link_libraries(${PREKERNEL_TARGET} PRIVATE clang_rt.builtins)
 endif()
 
+if ("${SERENITY_ARCH}" STREQUAL "x86_64")
+    set(ELF_OBJCOPY_TARGET "elf32-i386")
+elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
+    message(SEND_ERROR "Prekernel is not needed on aarch64 and should not be compiled!")
+endif()
+
+
 add_custom_command(
     TARGET ${PREKERNEL_TARGET} POST_BUILD
-    COMMAND ${CMAKE_OBJCOPY} -O elf32-i386 ${CMAKE_CURRENT_BINARY_DIR}/${PREKERNEL_TARGET} ${CMAKE_CURRENT_BINARY_DIR}/Prekernel
+    COMMAND ${CMAKE_OBJCOPY} -O ${ELF_OBJCOPY_TARGET} ${CMAKE_CURRENT_BINARY_DIR}/${PREKERNEL_TARGET} ${CMAKE_CURRENT_BINARY_DIR}/Kernel
     BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Prekernel
 )
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Prekernel" DESTINATION boot)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel" DESTINATION boot)
 
 # Remove options which the Prekernel environment doesn't support.
 get_target_property(PREKERNEL_TARGET_OPTIONS ${PREKERNEL_TARGET} COMPILE_OPTIONS)

--- a/Kernel/Prekernel/Prekernel.h
+++ b/Kernel/Prekernel/Prekernel.h
@@ -41,8 +41,11 @@ struct [[gnu::packed]] BootInfo {
     u32 multiboot_flags;
     u64 multiboot_memory_map;
     u32 multiboot_memory_map_count;
-    u64 multiboot_modules;
+    u64 multiboot_modules_physical_ptr;
     u32 multiboot_modules_count;
+    u32 multiboot_module_ramdisk_physical_start;
+    u32 multiboot_module_ramdisk_physical_end;
+    u32 multiboot_module_ramdisk_physical_string_addr;
     u64 multiboot_framebuffer_addr;
     u32 multiboot_framebuffer_pitch;
     u32 multiboot_framebuffer_width;

--- a/Kernel/Prekernel/init.cpp
+++ b/Kernel/Prekernel/init.cpp
@@ -27,6 +27,9 @@ extern "C" [[noreturn]] void __stack_chk_fail();
 extern "C" u8 start_of_prekernel_image[];
 extern "C" u8 end_of_prekernel_image[];
 
+extern "C" u8 _binary_Kernel_drow_standalone_start[];
+extern "C" u8 end_of_prekernel_image_after_kernel_image[];
+
 extern "C" u8 gdt64ptr[];
 extern "C" u16 code64_sel;
 extern "C" u64 boot_pml4t[512];
@@ -74,14 +77,27 @@ extern "C" [[noreturn]] void init();
 
 u64 generate_secure_seed();
 
+static bool is_drow_kernel(ElfW(Phdr) & program_header)
+{
+    if (program_header.p_align < PAGE_SIZE)
+        return false;
+    if (program_header.p_vaddr != program_header.p_offset)
+        return false;
+    if (program_header.p_filesz != program_header.p_memsz)
+        return false;
+    return true;
+}
+
 extern "C" [[noreturn]] void init()
 {
-    if (multiboot_info_ptr->mods_count < 1)
-        halt();
-
     multiboot_module_entry_t* kernel_module = (multiboot_module_entry_t*)(FlatPtr)multiboot_info_ptr->mods_addr;
-
-    u8* kernel_image = (u8*)(FlatPtr)kernel_module->start;
+    for (size_t i = 0; i < multiboot_info_ptr->mods_count; i++) {
+        // Note: We require the DROW kernel and other multiboot modules to be placed
+        // on a page boundary.
+        if (kernel_module[i].start & (PAGE_SIZE - 1))
+            halt();
+    }
+    u8* kernel_image = _binary_Kernel_drow_standalone_start;
     // copy the ELF header and program headers because we might end up overwriting them
     ElfW(Ehdr) kernel_elf_header = *(ElfW(Ehdr)*)kernel_image;
     ElfW(Phdr) kernel_program_headers[16];
@@ -89,7 +105,7 @@ extern "C" [[noreturn]] void init()
         halt();
     __builtin_memcpy(kernel_program_headers, kernel_image + kernel_elf_header.e_phoff, sizeof(ElfW(Phdr)) * kernel_elf_header.e_phnum);
 
-    FlatPtr kernel_physical_base = 0x200000;
+    FlatPtr kernel_physical_base = (FlatPtr)kernel_image;
     FlatPtr default_kernel_load_base = KERNEL_MAPPING_BASE + 0x200000;
 
     FlatPtr kernel_load_base = default_kernel_load_base;
@@ -105,6 +121,9 @@ extern "C" [[noreturn]] void init()
         auto& kernel_program_header = kernel_program_headers[i];
         if (kernel_program_header.p_type != PT_LOAD)
             continue;
+        // we require that the ELF kernel is a DROW
+        if (!is_drow_kernel(kernel_program_header))
+            halt();
         auto start = kernel_load_base + kernel_program_header.p_vaddr;
         auto end = start + kernel_program_header.p_memsz;
         if (start < (FlatPtr)end_of_prekernel_image)
@@ -154,23 +173,6 @@ extern "C" [[noreturn]] void init()
 
     reload_cr3();
 
-    for (ssize_t i = kernel_elf_header.e_phnum - 1; i >= 0; i--) {
-        auto& kernel_program_header = kernel_program_headers[i];
-        if (kernel_program_header.p_type != PT_LOAD)
-            continue;
-        __builtin_memmove((u8*)kernel_load_base + kernel_program_header.p_vaddr, kernel_image + kernel_program_header.p_offset, kernel_program_header.p_filesz);
-    }
-
-    for (ssize_t i = kernel_elf_header.e_phnum - 1; i >= 0; i--) {
-        auto& kernel_program_header = kernel_program_headers[i];
-        if (kernel_program_header.p_type != PT_LOAD)
-            continue;
-        __builtin_memset((u8*)kernel_load_base + kernel_program_header.p_vaddr + kernel_program_header.p_filesz, 0, kernel_program_header.p_memsz - kernel_program_header.p_filesz);
-    }
-
-    multiboot_info_ptr->mods_count--;
-    multiboot_info_ptr->mods_addr += sizeof(multiboot_module_entry_t);
-
     auto adjust_by_mapping_base = [kernel_mapping_base](auto ptr) {
         return (decltype(ptr))((FlatPtr)ptr + kernel_mapping_base);
     };
@@ -194,8 +196,16 @@ extern "C" [[noreturn]] void init()
     info.multiboot_flags = multiboot_info_ptr->flags;
     info.multiboot_memory_map = adjust_by_mapping_base((FlatPtr)multiboot_info_ptr->mmap_addr);
     info.multiboot_memory_map_count = multiboot_info_ptr->mmap_length / sizeof(multiboot_memory_map_t);
-    info.multiboot_modules = adjust_by_mapping_base((FlatPtr)multiboot_info_ptr->mods_addr);
+    info.multiboot_modules_physical_ptr = (FlatPtr)multiboot_info_ptr->mods_addr;
     info.multiboot_modules_count = multiboot_info_ptr->mods_count;
+
+    if (info.multiboot_modules_count > 0) {
+        auto* entry = reinterpret_cast<multiboot_module_entry*>(multiboot_info_ptr->mods_addr);
+        info.multiboot_module_ramdisk_physical_start = entry->start;
+        info.multiboot_module_ramdisk_physical_end = entry->end;
+        info.multiboot_module_ramdisk_physical_string_addr = entry->string_addr;
+    }
+
     if ((multiboot_info_ptr->flags & MULTIBOOT_INFO_FRAMEBUFFER_INFO) != 0) {
         info.multiboot_framebuffer_addr = multiboot_info_ptr->framebuffer_addr;
         info.multiboot_framebuffer_pitch = multiboot_info_ptr->framebuffer_pitch;

--- a/Kernel/Prekernel/linker.ld
+++ b/Kernel/Prekernel/linker.ld
@@ -44,4 +44,13 @@ SECTIONS
     } :bss
 
     end_of_prekernel_image = .;
+
+    .Kernel_drow ALIGN(4K) : AT (ADDR(.Kernel_drow))
+    {
+        _binary_Kernel_drow_standalone_start = .;
+        KEEP(*(.Kernel_drow))
+    }
+
+    end_of_prekernel_image_after_kernel_image = .;
+
 }

--- a/Meta/Lagom/Tools/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CMakeLists.txt
@@ -13,6 +13,7 @@ endfunction()
 
 add_subdirectory(CodeGenerators)
 add_subdirectory(ConfigureComponents)
+add_subdirectory(ELFBaker)
 add_subdirectory(IPCMagicLinter)
 
 if (ENABLE_JAKT)

--- a/Meta/Lagom/Tools/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CMakeLists.txt
@@ -14,6 +14,7 @@ endfunction()
 add_subdirectory(CodeGenerators)
 add_subdirectory(ConfigureComponents)
 add_subdirectory(ELFBaker)
+add_subdirectory(InitRAMFSTool)
 add_subdirectory(IPCMagicLinter)
 
 if (ENABLE_JAKT)

--- a/Meta/Lagom/Tools/ELFBaker/CMakeLists.txt
+++ b/Meta/Lagom/Tools/ELFBaker/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES
+    main.cpp
+)
+
+lagom_tool(ELFBaker LIBS LibMain)

--- a/Meta/Lagom/Tools/ELFBaker/main.cpp
+++ b/Meta/Lagom/Tools/ELFBaker/main.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Error.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <AK/Vector.h>
+#include <LibC/elf.h>
+#include <LibCore/File.h>
+#include <LibELF/Image.h>
+#include <LibMain/Main.h>
+
+using ELF32BitsImage = ELF::BitnessSpecificImage<Elf32_Ehdr, Elf32_Phdr, Elf32_Shdr>;
+using ELF64BitsImage = ELF::BitnessSpecificImage<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr>;
+
+template<typename T>
+class ELFBaker {
+public:
+    ELFBaker(ByteBuffer& input)
+        : m_input_data(input)
+        , m_input_image(m_input_data)
+        , m_input_header(m_input_image.get_header())
+        , m_input_program_headers(m_input_image.get_program_headers())
+        , m_input_sections(m_input_image.get_sections())
+        , m_program_loads_size(compute_program_load_sizes())
+        , m_relocated_sections_size(compute_relocated_sections_size())
+    {
+    }
+
+    ErrorOr<ByteBuffer> bake()
+    {
+        TRY(check_eligibility());
+
+        auto& input_header = m_input_image.get_header();
+        size_t section_table_size = input_header.e_shnum * input_header.e_shentsize;
+
+        auto result = TRY(ByteBuffer::create_zeroed(m_program_loads_size + section_table_size + m_relocated_sections_size));
+
+        size_t offset = execute_program_headers(result);
+        offset += move_section_table(result, offset);
+        offset += move_sections(result, offset);
+
+        return result;
+    }
+
+private:
+    ErrorOr<void> check_eligibility() const
+    {
+        if (!(m_input_header.e_type == ET_EXEC || m_input_header.e_type == ET_DYN))
+            return Error::from_string_literal("Bad ELF type");
+        if (m_input_program_headers.is_empty())
+            return Error::from_string_literal("No program headers");
+
+        auto& first_program_header = m_input_program_headers[0];
+        if (first_program_header.p_type != PT_LOAD)
+            return Error::from_string_literal("First program header is not of PT_LOAD type");
+        if (first_program_header.p_offset != 0 || first_program_header.p_filesz < sizeof(typename T::Header))
+            return Error::from_string_literal("First program header does not contain ELF header, use FILEHDR flag in linker script");
+        if (first_program_header.p_filesz > (m_input_header.e_phoff + m_input_header.e_phentsize * m_input_header.e_phnum))
+            return Error::from_string_literal("First program header does not contain program header, use PHDRS flag in linker script");
+
+        return {};
+    }
+
+    size_t execute_program_headers(ByteBuffer& output)
+    {
+        T output_image(output);
+
+        for (auto& program_header : m_input_program_headers) {
+            if (program_header.p_type == PT_LOAD) {
+                auto src_span = m_input_data.span().slice(program_header.p_offset, program_header.p_filesz);
+                auto dst_span = output.span().slice(program_header.p_vaddr, program_header.p_filesz);
+                src_span.copy_to(dst_span);
+            }
+        }
+
+        for (auto& program_header : output_image.get_program_headers()) {
+            program_header.p_filesz = program_header.p_memsz;
+            program_header.p_offset = program_header.p_vaddr;
+        }
+
+        return m_program_loads_size;
+    }
+
+    size_t move_section_table(ByteBuffer& output, size_t offset)
+    {
+        T output_image(output);
+        auto& output_header = output_image.get_header();
+        size_t section_table_size = m_input_header.e_shnum * m_input_header.e_shentsize;
+
+        auto src_span = m_input_data.span().slice(m_input_header.e_shoff, section_table_size);
+        auto dst_span = output.span().slice(offset, section_table_size);
+        src_span.copy_to(dst_span);
+
+        output_header.e_shoff = offset;
+
+        return section_table_size;
+    }
+
+    size_t move_sections(ByteBuffer& output, size_t offset)
+    {
+        T output_image(output);
+
+        for (auto& section : output_image.get_sections()) {
+            if (section.sh_addr == 0 && section.sh_size > 0) {
+                auto src_span = m_input_data.span().slice(section.sh_offset, section.sh_size);
+                auto dst_span = output.span().slice(offset, section.sh_size);
+                src_span.copy_to(dst_span);
+
+                section.sh_offset = offset;
+
+                offset += section.sh_size;
+            } else {
+                section.sh_offset = section.sh_addr;
+            }
+        }
+
+        return offset;
+    }
+
+    size_t compute_program_load_sizes() const
+    {
+        size_t total = 0;
+
+        for (auto& program_header : m_input_program_headers) {
+            size_t program_end = program_header.p_vaddr + program_header.p_memsz;
+            total = max(total, program_end);
+        }
+
+        return total;
+    }
+
+    size_t compute_relocated_sections_size() const
+    {
+        size_t total = 0;
+
+        for (auto& section : m_input_sections) {
+            if (section.sh_addr == 0 && section.sh_size > 0) {
+                total += section.sh_size;
+            }
+        }
+
+        return total;
+    }
+
+    ByteBuffer& m_input_data;
+    T m_input_image;
+    typename T::Header m_input_header;
+    Span<typename T::ProgramHeader> m_input_program_headers;
+    Span<typename T::SectionHeader> m_input_sections;
+    size_t m_program_loads_size;
+    size_t m_relocated_sections_size;
+};
+
+using Elf32Baker = ELFBaker<ELF32BitsImage>;
+using Elf64Baker = ELFBaker<ELF64BitsImage>;
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    if (arguments.argc < 3) {
+        warnln("Usage: {} kernel.elf kernel.drow", arguments.argv[0]);
+        warnln("Bakes ELF into DROW for usage with prekernel.");
+        return 1;
+    }
+
+    auto src_file = TRY(Core::File::open(arguments.argv[1], Core::OpenMode::ReadOnly));
+
+    auto src_data = src_file->read_all();
+    auto& ehdr = *reinterpret_cast<Elf32_Ehdr const*>(src_data.data());
+    if (!IS_ELF(ehdr)) {
+        warnln("Error: '{}' is not an ELF file", arguments.argv[1]);
+        return 1;
+    }
+
+    ByteBuffer output;
+    switch (ehdr.e_ident[EI_CLASS]) {
+    case ELFCLASS32:
+        output = TRY(Elf32Baker(src_data).bake());
+        break;
+    case ELFCLASS64:
+        output = TRY(Elf64Baker(src_data).bake());
+        break;
+    default:
+        warnln("Error: '{}' has an unknown ELF class", arguments.argv[1]);
+        return 1;
+    }
+
+    auto dst_file = TRY(Core::File::open(arguments.argv[2], Core::OpenMode::Truncate | Core::OpenMode::WriteOnly));
+    if (!dst_file->write(output.data(), output.size())) {
+        warnln("Error: Failed to write '{}'", arguments.argv[2]);
+        return 1;
+    }
+
+    return 0;
+}

--- a/Meta/Lagom/Tools/InitRAMFSTool/CMakeLists.txt
+++ b/Meta/Lagom/Tools/InitRAMFSTool/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES
+    main.cpp
+)
+
+lagom_tool(InitRAMFSTool LIBS LibMain)

--- a/Meta/Lagom/Tools/InitRAMFSTool/main.cpp
+++ b/Meta/Lagom/Tools/InitRAMFSTool/main.cpp
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Error.h>
+#include <AK/LexicalPath.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <AK/Vector.h>
+#include <Kernel/API/Device.h>
+#include <Kernel/API/initramfs_definitions.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/DirIterator.h>
+#include <LibCore/File.h>
+#include <LibCore/Stream.h>
+#include <LibCore/System.h>
+#include <LibMain/Main.h>
+
+void create_inode(initramfs_inode& result_inode, size_t data_blocks_offset, struct stat& statbuf, size_t file_size, size_t inode_name_offset, size_t inode_name_length, size_t inode_blocks_count)
+{
+    // FIXME: Should we consider supporting non-ASCII UTF-8 characters?
+    result_inode.name_offset = inode_name_offset;
+    result_inode.name_length = inode_name_length;
+    result_inode.file_size = file_size;
+    result_inode.mode = statbuf.st_mode;
+    result_inode.major = serenity_dev_major(statbuf.st_rdev);
+    result_inode.minor = serenity_dev_minor(statbuf.st_rdev);
+    result_inode.blocks_count = inode_blocks_count;
+    result_inode.blocks_offset = data_blocks_offset;
+    result_inode.uid = statbuf.st_uid;
+    result_inode.gid = statbuf.st_gid;
+    result_inode.mtime_seconds = statbuf.st_mtime;
+    // FIXME: Find a way to put the nanoseconds value in platform-agnostic way.
+    result_inode.mtime_nanoseconds = 0;
+}
+
+ErrorOr<void> write_inode_data_to_file(Core::Stream::File& output_file_stream, ReadonlyBytes file_buffer_bytes)
+{
+    auto nwritten = TRY(output_file_stream.write(file_buffer_bytes));
+    if (nwritten != file_buffer_bytes.size())
+        return Error::from_string_literal("InitRAMFSTool: Failed to write a complete file buffer.");
+    return {};
+}
+
+enum class EntryType {
+    Directory,
+    File,
+    Link,
+};
+
+static void print_warning(Error error, EntryType entry_type, StringView path)
+{
+    if (entry_type == EntryType::Directory) {
+        warnln("Couldn't find directory '{}': {}", path, error);
+        return;
+    }
+    if (entry_type == EntryType::File) {
+        warnln("Couldn't find file '{}': {}", path, error);
+        return;
+    }
+    if (entry_type == EntryType::Link) {
+        warnln("Couldn't find link '{}': {}", path, error);
+        return;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static void handle_statbuf_with_force_owners(struct stat& statbuf, Optional<size_t> const& force_uid, Optional<size_t> const& force_gid)
+{
+    if (force_uid.has_value())
+        statbuf.st_uid = force_uid.value();
+    if (force_gid.has_value())
+        statbuf.st_uid = force_gid.value();
+}
+
+static ErrorOr<struct stat> handle_lstat_with_possible_forced_owners(EntryType entry_type, StringView path, Optional<size_t> const& force_uid, Optional<size_t> const& force_gid)
+{
+    auto statbuf_or_error = Core::System::lstat(path);
+    if (statbuf_or_error.is_error()) {
+        print_warning(Error::copy(statbuf_or_error.error()), entry_type, path);
+        return statbuf_or_error.release_error();
+    }
+    auto statbuf = statbuf_or_error.release_value();
+    handle_statbuf_with_force_owners(statbuf, force_uid, force_gid);
+    return statbuf;
+}
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    StringView output_file_path;
+    StringView directory_to_handle;
+    Optional<size_t> possible_alignment_power;
+    Optional<size_t> force_uid;
+    Optional<size_t> force_gid;
+    bool force = false;
+    Core::ArgsParser parser;
+    parser.add_option(possible_alignment_power, "Data block alignment power", "data-block-alignment", 'a', "Alignment Power");
+    parser.add_option(force, "Overwrite existing output file", "force", 'f');
+    parser.add_option(force_uid, "Force UID", "force-uid", 'u', "Forced User Owner ID");
+    parser.add_option(force_gid, "Force GID", "force-gid", 'g', "Forced Group Owner ID");
+    parser.add_positional_argument(output_file_path, "Output file path", "outputfile", Core::ArgsParser::Required::Yes);
+    parser.add_positional_argument(directory_to_handle, "Directory Path", "directory_path", Core::ArgsParser::Required::Yes);
+    parser.parse(arguments);
+
+    TRY(Core::System::pledge("stdio rpath wpath cpath"));
+
+    auto cwd = TRY(Core::System::getcwd());
+    TRY(Core::System::unveil(LexicalPath::absolute_path(cwd, output_file_path), "wc"sv));
+    TRY(Core::System::unveil(LexicalPath::absolute_path(cwd, directory_to_handle), "r"sv));
+    TRY(Core::System::unveil(nullptr, nullptr));
+
+    if (Core::File::exists(output_file_path)) {
+        if (force) {
+            outln("{} already exists, overwriting...", output_file_path);
+        } else {
+            warnln("{} already exists, aborting!", output_file_path);
+            return 1;
+        }
+    }
+
+    outln("Archive: {}", output_file_path);
+
+    size_t alignment_power = possible_alignment_power.value_or(12);
+    if (alignment_power < 12 || alignment_power > 24)
+        return Error::from_string_literal("InitRAMFSTool: Invalid alignment power being specified!");
+
+    size_t block_size = 1 << alignment_power;
+
+    initramfs_image_header header {};
+    memset(&header, 0, sizeof(initramfs_image_header));
+    memcpy(header.magic, "SERECPIO", 8);
+    header.data_block_alignment_size_power_2 = alignment_power;
+    // NOTE: We start by writing the data blocks section first, so we already
+    // know the offset of this section which is 1 << alignment_power representing
+    // the mathematical expression of 2 to the poewr of alignment_power.
+    // Other section will be written after that section is done being written to.
+    header.data_blocks_section_start = block_size;
+    auto output_file_stream = TRY(Core::Stream::File::open(output_file_path, Core::Stream::OpenMode::Write));
+    TRY(output_file_stream->truncate(block_size));
+
+    // NOTE: Write the file header first. This already includes the magic bytes
+    // and the alignment of data blocks as well as the start offset of the data
+    // blocks section because we know these values.
+    // Other important values will be written in the final stage when we "finalize"
+    // processing the file.
+    TRY(output_file_stream->write(ReadonlyBytes { &header, sizeof(initramfs_image_header) }));
+
+    u32 current_data_blocks_count = 0;
+    u32 current_inode_name_offset = 0;
+    Vector<initramfs_inode> inodes;
+    Vector<String> inodes_paths;
+
+    // NOTE: Start writing data blocks section directly to the file now!
+    TRY(output_file_stream->seek(block_size, SeekMode::SetPosition));
+
+    auto add_link = [&](initramfs_inode& result_inode, struct stat& statbuf, StringView relative_root_child_path, StringView linked_path) -> ErrorOr<void> {
+        size_t needed_padding_size = (1 << alignment_power) - (linked_path.length() % (block_size));
+        size_t total_aligned_buffer_size = linked_path.length() + needed_padding_size;
+        size_t inode_blocks_count = total_aligned_buffer_size / block_size;
+
+        create_inode(result_inode, current_data_blocks_count, statbuf, linked_path.length(), current_inode_name_offset, relative_root_child_path.length(), inode_blocks_count);
+        TRY(write_inode_data_to_file(*output_file_stream, linked_path.bytes()));
+
+        // NOTE: Add the padding size to the location we are writing to, to
+        // ensure we meet the alignment requirement always!
+        TRY(output_file_stream->seek(needed_padding_size, SeekMode::FromCurrentPosition));
+        return {};
+    };
+
+    auto add_file = [&](initramfs_inode& result_inode, struct stat& statbuf, Core::Stream::File& file, StringView relative_root_child_path) -> ErrorOr<void> {
+        auto file_buffer = TRY(file.read_until_eof());
+        size_t needed_padding_size = (1 << alignment_power) - (file_buffer.size() % (block_size));
+        size_t total_aligned_buffer_size = file_buffer.size() + needed_padding_size;
+        size_t inode_blocks_count = total_aligned_buffer_size / block_size;
+
+        create_inode(result_inode, current_data_blocks_count, statbuf, file_buffer.size(), current_inode_name_offset, relative_root_child_path.length(), inode_blocks_count);
+        TRY(write_inode_data_to_file(*output_file_stream, file_buffer.bytes()));
+
+        // NOTE: Add the padding size to the location we are writing to, to
+        // ensure we meet the alignment requirement always!
+        TRY(output_file_stream->seek(needed_padding_size, SeekMode::FromCurrentPosition));
+        return {};
+    };
+
+    auto add_directory = [&](DeprecatedString path, auto handle_directory) -> ErrorOr<void> {
+        Core::DirIterator it(path, Core::DirIterator::Flags::SkipParentAndBaseDir);
+        while (it.has_next()) {
+            auto child_path = it.next_full_path();
+            auto relative_root_child_path = child_path.substring_view(directory_to_handle.length());
+            if (Core::File::is_directory(child_path)) {
+                auto statbuf = TRY(handle_lstat_with_possible_forced_owners(EntryType::Directory, child_path, force_uid, force_gid));
+                initramfs_inode inode_buf;
+                memset(&inode_buf, 0, sizeof(initramfs_inode));
+                inode_buf.name_offset = current_inode_name_offset;
+                inode_buf.name_length = relative_root_child_path.length();
+                inode_buf.file_size = 0;
+                inode_buf.mode = statbuf.st_mode;
+                inode_buf.uid = statbuf.st_uid;
+                inode_buf.gid = statbuf.st_gid;
+                if (force_uid.has_value())
+                    inode_buf.uid = force_uid.value();
+                if (force_gid.has_value())
+                    inode_buf.gid = force_gid.value();
+                inode_buf.mtime_seconds = statbuf.st_mtime;
+                // FIXME: Find a way to put the nanoseconds value in platform-agnostic way.
+                inode_buf.mtime_nanoseconds = 0;
+                TRY(inodes.try_append(inode_buf));
+                TRY(inodes_paths.try_append(TRY(String::from_utf8(relative_root_child_path))));
+                current_inode_name_offset += relative_root_child_path.length();
+                auto result = handle_directory(child_path, handle_directory);
+                if (result.is_error())
+                    warnln("Couldn't add directory '{}': {}", child_path, result.error());
+            } else {
+                initramfs_inode inode_buf;
+                if (Core::File::is_link(child_path)) {
+                    auto linked_path = TRY(Core::System::readlink(child_path));
+                    auto statbuf = TRY(handle_lstat_with_possible_forced_owners(EntryType::Link, child_path, force_uid, force_gid));
+                    TRY(add_link(inode_buf, statbuf, relative_root_child_path, linked_path));
+                } else {
+                    auto statbuf = TRY(handle_lstat_with_possible_forced_owners(EntryType::File, child_path, force_uid, force_gid));
+                    auto file_stream = TRY(Core::Stream::File::open(child_path, Core::Stream::OpenMode::Read));
+                    TRY(add_file(inode_buf, statbuf, *file_stream, relative_root_child_path));
+                }
+                TRY(inodes.try_append(inode_buf));
+                TRY(inodes_paths.try_append(TRY(String::from_utf8(relative_root_child_path))));
+                current_data_blocks_count += inode_buf.blocks_count;
+                current_inode_name_offset += relative_root_child_path.length();
+            }
+        }
+        return {};
+    };
+
+    if (Core::File::is_directory(directory_to_handle)) {
+        auto result = add_directory(directory_to_handle, add_directory);
+        if (result.is_error())
+            warnln("Couldn't add directory '{}': {}", directory_to_handle, result.error());
+    } else {
+        warnln("Couldn't add non-directory for output file content '{}'", directory_to_handle);
+        return 1;
+    }
+
+    // NOTE: Ensure file is truncated to have aligned size after finishing writing the
+    // data blocks section.
+    size_t inodes_section_start = block_size + current_data_blocks_count * block_size;
+    TRY(output_file_stream->truncate(inodes_section_start));
+    TRY(output_file_stream->seek(inodes_section_start, SeekMode::SetPosition));
+
+    // NOTE: After the data blocks section, we put the inodes section.
+    // Then, the inodes paths section is placed afterwards.
+    header.inodes_section_start = inodes_section_start;
+    header.inodes_names_section_start = inodes_section_start + sizeof(initramfs_inode) * inodes.size();
+
+    header.inodes_count = inodes.size();
+    header.data_blocks_count = current_data_blocks_count;
+    for (auto& inode : inodes) {
+        TRY(output_file_stream->write(ReadonlyBytes { &inode, sizeof(initramfs_inode) }));
+    }
+
+    for (auto& inode_path : inodes_paths) {
+        TRY(output_file_stream->write(inode_path.bytes()));
+    }
+
+    TRY(output_file_stream->seek(0, SeekMode::SetPosition));
+    TRY(output_file_stream->write(ReadonlyBytes { &header, sizeof(initramfs_image_header) }));
+    return 0;
+}

--- a/Meta/build-initramfs-image.sh
+++ b/Meta/build-initramfs-image.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+
+set -e
+
+die() {
+    echo "die: $*"
+    exit 1
+}
+
+[ -z "$SERENITY_SOURCE_DIR" ] && die "SERENITY_SOURCE_DIR is not set"
+[ -d "$SERENITY_SOURCE_DIR/Base" ] || die "$SERENITY_SOURCE_DIR/Base doesn't exist"
+
+printf "creating initial filesystem structure for initramfs... "
+for dir in dev sys bin etc proc mnt tmp boot mod var/run usr/local usr/lib; do
+    mkdir -p InitRootFS/$dir
+done
+
+if rsync --chown 2>&1 | grep "missing argument" >/dev/null; then
+    rsync -aH --chown=0:0 --inplace --update "$SERENITY_SOURCE_DIR"/Base/ InitRootFS/
+    rsync -aH --chown=0:0 --inplace --update Root/usr/lib/libsystem.so InitRootFS/usr/lib/libsystem.so 
+    rsync -aH --chown=0:0 --inplace --update Root/usr/lib/libc.so InitRootFS/usr/lib/libc.so 
+    rsync -aH --chown=0:0 --inplace --update Root/usr/lib/libcore.so.serenity InitRootFS/usr/lib/libcore.so.serenity
+    rsync -aH --chown=0:0 --inplace --update Root/usr/lib/libcore.so InitRootFS/usr/lib/libcore.so
+    rsync -aH --chown=0:0 --inplace --update Root/usr/lib/libbuggiebox.so.serenity InitRootFS/usr/lib/libbuggiebox.so.serenity 
+    rsync -aH --chown=0:0 --inplace --update Root/usr/lib/libbuggiebox.so InitRootFS/usr/lib/libbuggiebox.so 
+    rsync -aH --chown=0:0 --inplace --update Root/bin/BuggieBox InitRootFS/bin/BuggieBox
+    rsync -aH --chown=0:0 --inplace --update Root/usr/lib/Loader.so InitRootFS/usr/lib/Loader.so    
+else
+    rsync -aH --inplace --update "$SERENITY_SOURCE_DIR"/Base/ InitRootFS/
+    rsync -aH --inplace --update Root/usr/lib/libsystem.so InitRootFS/usr/lib/libsystem.so 
+    rsync -aH --inplace --update Root/usr/lib/libc.so InitRootFS/usr/lib/libc.so 
+    rsync -aH --inplace --update Root/usr/lib/libcore.so.serenity InitRootFS/usr/lib/libcore.so.serenity
+    rsync -aH --inplace --update Root/usr/lib/libcore.so InitRootFS/usr/lib/libcore.so
+    rsync -aH --inplace --update Root/usr/lib/libbuggiebox.so.serenity InitRootFS/usr/lib/libbuggiebox.so.serenity 
+    rsync -aH --inplace --update Root/usr/lib/libbuggiebox.so InitRootFS/usr/lib/libbuggiebox.so 
+    rsync -aH --inplace --update Root/bin/BuggieBox InitRootFS/bin/BuggieBox
+    rsync -aH --inplace --update Root/usr/lib/Loader.so InitRootFS/usr/lib/Loader.so
+fi
+
+chmod 700 InitRootFS/boot
+chmod 700 InitRootFS/mod
+chmod 1777 InitRootFS/tmp
+echo "done"
+
+printf "creating utmp file in initramfs... "
+echo "{}" > InitRootFS/var/run/utmp
+chmod 664 InitRootFS/var/run/utmp
+
+# If umask was 027 or similar when the repo was cloned,
+# file permissions in Base/ are too restrictive. Restore
+# the permissions needed in the image.
+chmod -R g+rX,o+rX "$SERENITY_SOURCE_DIR"/Base/* InitRootFS/
+
+echo "/bin/sh" > InitRootFS/etc/shells
+
+printf "installing users... "
+mkdir -p InitRootFS/root
+
+printf "installing shortcuts... "
+ln -sf /bin/BuggieBox InitRootFS/bin/uname
+ln -sf /bin/BuggieBox InitRootFS/bin/env
+ln -sf /bin/BuggieBox InitRootFS/bin/lsblk
+ln -sf /bin/BuggieBox InitRootFS/bin/file
+ln -sf /bin/BuggieBox InitRootFS/bin/df
+ln -sf /bin/BuggieBox InitRootFS/bin/mount
+ln -sf /bin/BuggieBox InitRootFS/bin/umount
+ln -sf /bin/BuggieBox InitRootFS/bin/mkdir
+ln -sf /bin/BuggieBox InitRootFS/bin/rmdir
+ln -sf /bin/BuggieBox InitRootFS/bin/rm
+ln -sf /bin/BuggieBox InitRootFS/bin/chown
+ln -sf /bin/BuggieBox InitRootFS/bin/chmod
+ln -sf /bin/BuggieBox InitRootFS/bin/cp
+ln -sf /bin/BuggieBox InitRootFS/bin/ln
+ln -sf /bin/BuggieBox InitRootFS/bin/ls
+ln -sf /bin/BuggieBox InitRootFS/bin/mv
+ln -sf /bin/BuggieBox InitRootFS/bin/cat
+ln -sf /bin/BuggieBox InitRootFS/bin/md5sum
+ln -sf /bin/BuggieBox InitRootFS/bin/sha1sum
+ln -sf /bin/BuggieBox InitRootFS/bin/sha256sum
+ln -sf /bin/BuggieBox InitRootFS/bin/sha512sum
+ln -sf /bin/BuggieBox InitRootFS/bin/sh
+ln -sf /bin/BuggieBox InitRootFS/bin/uniq
+ln -sf /bin/BuggieBox InitRootFS/bin/id
+ln -sf /bin/BuggieBox InitRootFS/bin/tail
+ln -sf /bin/BuggieBox InitRootFS/bin/find
+ln -sf /bin/BuggieBox InitRootFS/bin/less
+ln -sf /bin/BuggieBox InitRootFS/bin/mknod
+ln -sf /bin/BuggieBox InitRootFS/bin/ps
+ln -sf /bin/BuggieBox InitRootFS/bin/Shell
+ln -sf /bin/BuggieBox InitRootFS/bin/init
+ln -sf /bin/BuggieBox InitRootFS/bin/test
+ln -sf /bin/BuggieBox InitRootFS/bin/clear
+ln -sf /bin/BuggieBox InitRootFS/bin/dmesg
+ln -sf /bin/BuggieBox InitRootFS/bin/errno
+ln -sf /bin/BuggieBox InitRootFS/bin/base64
+ln -sf /bin/BuggieBox InitRootFS/bin/unveil
+ln -sf /bin/BuggieBox InitRootFS/bin/pledge
+ln -sf /bin/BuggieBox InitRootFS/bin/whoami
+ln -sf /bin/BuggieBox InitRootFS/bin/touch
+ln -sf /bin/BuggieBox InitRootFS/bin/top
+ln -sf /bin/BuggieBox InitRootFS/bin/timezone
+ln -sf /bin/BuggieBox InitRootFS/bin/tac
+ln -sf /bin/BuggieBox InitRootFS/bin/sysctl
+ln -sf /bin/BuggieBox InitRootFS/bin/sync
+ln -sf /bin/BuggieBox InitRootFS/bin/stat
+ln -sf /bin/BuggieBox InitRootFS/bin/sort
+ln -sf /bin/BuggieBox InitRootFS/bin/shuf
+ln -sf /bin/BuggieBox InitRootFS/bin/mktemp
+ln -sf /bin/BuggieBox InitRootFS/bin/lspci
+ln -sf /bin/BuggieBox InitRootFS/bin/lsusb
+ln -sf /bin/BuggieBox InitRootFS/bin/lsirq
+ln -sf /bin/BuggieBox InitRootFS/bin/lscpu
+ln -sf /bin/BuggieBox InitRootFS/bin/ldd
+ln -sf /bin/BuggieBox InitRootFS/bin/readelf
+ln -sf test InitRootFS/bin/[
+echo "done"
+
+CP="cp"
+
+# cp on macOS and BSD systems do not support the --preserve= option.
+# gcp comes with coreutils, which is already a dependency.
+OS="$(uname -s)"
+if [ "$OS" = "Darwin" ] || echo "$OS" | grep -qe 'BSD$'; then
+	CP="gcp"
+fi
+
+if [ "$SERENITY_ARCH" != "aarch64" ]; then
+    $CP --preserve=timestamps "$SERENITY_SOURCE_DIR"/Toolchain/Local/"$SERENITY_ARCH"/"$SERENITY_ARCH"-pc-serenity/lib/libgcc_s.so InitRootFS/usr/lib
+fi
+
+echo "done setting up initramfs directory"

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -35,9 +35,11 @@ fi
 if rsync --chown 2>&1 | grep "missing argument" >/dev/null; then
     rsync -aH --chown=0:0 --inplace --update "$SERENITY_SOURCE_DIR"/Base/ mnt/
     rsync -aH --chown=0:0 --inplace --update Root/ mnt/
+    rsync -aH --chown=0:0 --inplace --update initramfs.serecpio mnt/boot/initramfs.serecpio
 else
     rsync -aH --inplace --update "$SERENITY_SOURCE_DIR"/Base/ mnt/
     rsync -aH --inplace --update Root/ mnt/
+    rsync -aH --inplace --update initramfs.serecpio mnt/boot/initramfs.serecpio
     chown -R 0:0 mnt/
 fi
 

--- a/Meta/check-style.py
+++ b/Meta/check-style.py
@@ -30,6 +30,7 @@ LICENSE_HEADER_CHECK_EXCLUDES = {
 }
 LIBC_CHECK_EXCLUDES = {
     'Kernel/',
+    'Meta/Lagom/Tools/ELFBaker/',
     'Userland/Libraries/LibELF/',
     'Userland/Libraries/LibRegex/'
 }

--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -49,7 +49,7 @@ exec $SERENITY_KERNEL_DEBUGGER \
     -ex "file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-x86_64}$toolchain_suffix/Kernel/Prekernel/$prekernel_image" \
     -ex "set confirm off" \
     -ex "directory $SCRIPT_DIR/../Build/${SERENITY_ARCH:-x86_64}$toolchain_suffix/" \
-    -ex "add-symbol-file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-x86_64}$toolchain_suffix/Kernel/Kernel -o $kernel_base" \
+    -ex "add-symbol-file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-x86_64}$toolchain_suffix/Kernel/Prekernel/Kernel -o $kernel_base" \
     -ex "set confirm on" \
     -ex "set arch $gdb_arch" \
     -ex "set print frame-arguments none" \

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -300,8 +300,7 @@ if [ "$SERENITY_ARCH" = "aarch64" ]; then
     "
 else
     SERENITY_KERNEL_AND_INITRD="
-    -kernel Kernel/Prekernel/Prekernel
-    -initrd Kernel/Kernel
+    -kernel Kernel/Prekernel/Kernel
     "
 fi
 

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -299,10 +299,22 @@ if [ "$SERENITY_ARCH" = "aarch64" ]; then
     -kernel Kernel/Kernel
     "
 else
-    SERENITY_KERNEL_AND_INITRD="
-    -kernel Kernel/Prekernel/Kernel
-    "
+    [ -z "$SERENITY_ENABLE_INITRAMFS" ] && SERENITY_ENABLE_INITRAMFS="off"
+    if [ "$SERENITY_ENABLE_INITRAMFS" = "off" ]; then
+        SERENITY_KERNEL_AND_INITRD="
+        -kernel Kernel/Prekernel/Kernel
+        "
+    else
+        SERENITY_KERNEL_AND_INITRD="
+        -kernel Kernel/Prekernel/Kernel
+        -initrd initramfs.serecpio
+        "
+    fi
 fi
+
+
+
+
 
 
 [ -z "$SERENITY_COMMON_QEMU_ARGS" ] && SERENITY_COMMON_QEMU_ARGS="

--- a/Userland/BuggieBox/CMakeLists.txt
+++ b/Userland/BuggieBox/CMakeLists.txt
@@ -6,7 +6,7 @@ serenity_component(
 
 function (buggiebox_utility src)
     get_filename_component(utility ${src} NAME_WE)
-    target_sources(BuggieBox PRIVATE ${src})
+    target_sources(LibBuggieBox PRIVATE ${src})
     set_source_files_properties(${src} PROPERTIES COMPILE_DEFINITIONS "serenity_main=${utility}_main")
 endfunction()
 
@@ -39,13 +39,16 @@ set(utility_srcs
     ../Utilities/uniq.cpp
 )
 
+serenity_lib(LibBuggieBox buggiebox)
+target_compile_definitions(LibBuggieBox PRIVATE -DEXCLUDE_SERENITY_MAIN)
+target_link_libraries(LibBuggieBox PRIVATE LibShellStatic LibGfxStatic LibCoreStatic LibIPCStatic LibRegexStatic LibCompressStatic LibCryptoStatic LibLineStatic)
+target_sources(LibBuggieBox PRIVATE ../Shell/main.cpp)
+set_source_files_properties( ../Shell/main.cpp PROPERTIES COMPILE_DEFINITIONS "serenity_main=sh_main")
+
 serenity_bin(BuggieBox)
 target_sources(BuggieBox PRIVATE main.cpp)
-target_link_libraries(BuggieBox PRIVATE LibMain LibShell LibCompress LibCore LibCrypto LibGfx LibLine LibRegex)
-
+target_link_libraries(BuggieBox PRIVATE LibC LibMain LibBuggieBox)
 foreach(file IN LISTS utility_srcs)
    buggiebox_utility(${file})
 endforeach()
 
-target_sources(BuggieBox PRIVATE ../Shell/main.cpp)
-set_source_files_properties( ../Shell/main.cpp PROPERTIES COMPILE_DEFINITIONS "serenity_main=sh_main")

--- a/Userland/BuggieBox/CMakeLists.txt
+++ b/Userland/BuggieBox/CMakeLists.txt
@@ -73,7 +73,7 @@ target_sources(LibBuggieBox PRIVATE ../Shell/main.cpp)
 set_source_files_properties( ../Shell/main.cpp PROPERTIES COMPILE_DEFINITIONS "serenity_main=sh_main")
 
 serenity_bin(BuggieBox)
-target_sources(BuggieBox PRIVATE main.cpp)
+target_sources(BuggieBox PRIVATE main.cpp init.cpp)
 target_link_libraries(BuggieBox PRIVATE LibC LibMain LibBuggieBox)
 foreach(file IN LISTS utility_srcs)
    buggiebox_utility(${file})

--- a/Userland/BuggieBox/CMakeLists.txt
+++ b/Userland/BuggieBox/CMakeLists.txt
@@ -11,37 +11,64 @@ function (buggiebox_utility src)
 endfunction()
 
 set(utility_srcs
+    ../Utilities/base64.cpp
+    ../Utilities/blockdev.cpp
     ../Utilities/cat.cpp
+    ../Utilities/clear.cpp
     ../Utilities/checksum.cpp
     ../Utilities/chmod.cpp
     ../Utilities/chown.cpp
     ../Utilities/cp.cpp
+    ../Utilities/dd.cpp
     ../Utilities/df.cpp
+    ../Utilities/dmesg.cpp
     ../Utilities/env.cpp
+    ../Utilities/errno.cpp
     ../Utilities/file.cpp
     ../Utilities/find.cpp
+    ../Utilities/head.cpp
     ../Utilities/id.cpp
     ../Utilities/less.cpp
+    ../Utilities/ldd.cpp
     ../Utilities/ln.cpp
     ../Utilities/ls.cpp
     ../Utilities/lsblk.cpp
+    ../Utilities/lscpu.cpp
+    ../Utilities/lsirq.cpp
+    ../Utilities/lspci.cpp
+    ../Utilities/lsusb.cpp
     ../Utilities/mkdir.cpp
     ../Utilities/mknod.cpp
+    ../Utilities/mktemp.cpp
     ../Utilities/mount.cpp
     ../Utilities/mv.cpp
+    ../Utilities/pledge.cpp
     ../Utilities/ps.cpp
+    ../Utilities/readelf.cpp
     ../Utilities/rm.cpp
     ../Utilities/rmdir.cpp
+    ../Utilities/shuf.cpp
+    ../Utilities/sort.cpp
+    ../Utilities/stat.cpp
+    ../Utilities/sync.cpp
+    ../Utilities/sysctl.cpp
+    ../Utilities/tac.cpp
     ../Utilities/tail.cpp
+    ../Utilities/test.cpp
+    ../Utilities/timezone.cpp
+    ../Utilities/top.cpp
+    ../Utilities/touch.cpp
     ../Utilities/tree.cpp
     ../Utilities/umount.cpp
     ../Utilities/uname.cpp
     ../Utilities/uniq.cpp
+    ../Utilities/unveil.cpp
+    ../Utilities/whoami.cpp
 )
 
 serenity_lib(LibBuggieBox buggiebox)
 target_compile_definitions(LibBuggieBox PRIVATE -DEXCLUDE_SERENITY_MAIN)
-target_link_libraries(LibBuggieBox PRIVATE LibShellStatic LibGfxStatic LibCoreStatic LibIPCStatic LibRegexStatic LibCompressStatic LibCryptoStatic LibLineStatic)
+target_link_libraries(LibBuggieBox PRIVATE LibShellStatic LibGfxStatic LibCoreStatic LibIPCStatic LibRegexStatic LibCompressStatic LibCryptoStatic LibLineStatic LibUSBDBStatic LibPCIDBStatic)
 target_sources(LibBuggieBox PRIVATE ../Shell/main.cpp)
 set_source_files_properties( ../Shell/main.cpp PROPERTIES COMPILE_DEFINITIONS "serenity_main=sh_main")
 
@@ -52,3 +79,4 @@ foreach(file IN LISTS utility_srcs)
    buggiebox_utility(${file})
 endforeach()
 
+add_definitions(-D_BUGGIE_BOX)

--- a/Userland/BuggieBox/Globals.h
+++ b/Userland/BuggieBox/Globals.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+extern bool g_follow_symlinks;
+extern bool g_there_was_an_error;
+extern bool g_have_seen_action_command;

--- a/Userland/BuggieBox/init.cpp
+++ b/Userland/BuggieBox/init.cpp
@@ -1,0 +1,507 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Peter Elliott <pelliott@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "init.h"
+#include <AK/Assertions.h>
+#include <AK/ByteBuffer.h>
+#include <AK/Debug.h>
+#include <AK/String.h>
+#include <Kernel/API/DeviceEvent.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/ConfigFile.h>
+#include <LibCore/DirIterator.h>
+#include <LibCore/Event.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/File.h>
+#include <LibCore/System.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <grp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+DeprecatedString g_system_mode = "text";
+
+static void sigchld_handler(int)
+{
+    for (;;) {
+        int status = 0;
+        pid_t pid = waitpid(-1, &status, WNOHANG);
+        if (pid < 0) {
+            perror("waitpid");
+            break;
+        }
+        if (pid == 0)
+            break;
+
+        dbgln_if(SYSTEMSERVER_DEBUG, "Reaped child with pid {}, exit status {}", pid, status);
+    }
+}
+
+static ErrorOr<void> determine_system_mode()
+{
+    ArmedScopeGuard declare_text_mode_on_failure([&] {
+        // Note: Only if the mode is not set to self-test, degrade it to text mode.
+        if (g_system_mode != "self-test")
+            g_system_mode = "text";
+    });
+
+    auto f = Core::File::construct("/sys/kernel/system_mode");
+    if (!f->open(Core::OpenMode::ReadOnly)) {
+        dbgln("Failed to read system_mode: {}", f->error_string());
+        // Continue and assume "text" mode.
+        return {};
+    }
+    const DeprecatedString system_mode = DeprecatedString::copy(f->read_all(), Chomp);
+    if (f->error()) {
+        dbgln("Failed to read system_mode: {}", f->error_string());
+        // Continue and assume "text" mode.
+        return {};
+    }
+
+    g_system_mode = system_mode;
+    declare_text_mode_on_failure.disarm();
+
+    dbgln("Read system_mode: {}", g_system_mode);
+
+    struct stat file_state;
+    int rc = lstat("/dev/gpu/connector0", &file_state);
+    if (rc != 0 && g_system_mode == "graphical") {
+        dbgln("WARNING: No device nodes at /dev/gpu/ directory. This is probably a sign of disabled graphics functionality.");
+        dbgln("To cope with this, I'll turn off graphical mode.");
+        g_system_mode = "text";
+    }
+    return {};
+}
+
+static ErrorOr<void> chown_all_matching_device_nodes_under_specific_directory(StringView directory, group const& group)
+{
+    struct stat cur_file_stat;
+
+    Core::DirIterator di(directory, Core::DirIterator::SkipParentAndBaseDir);
+    if (di.has_error())
+        VERIFY_NOT_REACHED();
+    while (di.has_next()) {
+        auto entry_name = di.next_full_path();
+        auto rc = stat(entry_name.characters(), &cur_file_stat);
+        if (rc < 0)
+            continue;
+        TRY(Core::System::chown(entry_name, 0, group.gr_gid));
+    }
+    return {};
+}
+
+static ErrorOr<void> chown_all_matching_device_nodes(group const& group, unsigned major_number)
+{
+    struct stat cur_file_stat;
+
+    Core::DirIterator di("/dev/", Core::DirIterator::SkipParentAndBaseDir);
+    if (di.has_error())
+        VERIFY_NOT_REACHED();
+    while (di.has_next()) {
+        auto entry_name = di.next_full_path();
+        auto rc = stat(entry_name.characters(), &cur_file_stat);
+        if (rc < 0)
+            continue;
+        if (major(cur_file_stat.st_rdev) != major_number)
+            continue;
+        TRY(Core::System::chown(entry_name, 0, group.gr_gid));
+    }
+    return {};
+}
+
+inline char offset_character_with_number(char base_char, u8 offset)
+{
+    char offsetted_char = base_char;
+    VERIFY(static_cast<size_t>(offsetted_char) + static_cast<size_t>(offset) < 256);
+    offsetted_char += offset;
+    return offsetted_char;
+}
+
+static ErrorOr<void> create_devtmpfs_block_device(StringView name, mode_t mode, unsigned major, unsigned minor)
+{
+    return Core::System::mknod(name, mode | S_IFBLK, makedev(major, minor));
+}
+
+static ErrorOr<void> create_devtmpfs_char_device(StringView name, mode_t mode, unsigned major, unsigned minor)
+{
+    return Core::System::mknod(name, mode | S_IFCHR, makedev(major, minor));
+}
+
+static ErrorOr<void> populate_devtmpfs_char_devices_based_on_sysfs()
+{
+    Core::DirIterator di("/sys/dev/char/", Core::DirIterator::SkipParentAndBaseDir);
+    if (di.has_error()) {
+        warnln("Failed to open /sys/dev/char - {}", di.error());
+        return Error::from_errno(di.error());
+    }
+    while (di.has_next()) {
+        auto entry_name = di.next_path().split(':');
+        VERIFY(entry_name.size() == 2);
+        auto major_number = entry_name[0].to_uint<unsigned>().value();
+        auto minor_number = entry_name[1].to_uint<unsigned>().value();
+        switch (major_number) {
+        case 2: {
+            switch (minor_number) {
+            case 10: {
+                TRY(create_devtmpfs_char_device("/dev/devctl"sv, 0660, 2, 10));
+                break;
+            }
+            default:
+                warnln("Unknown character device {}:{}", major_number, minor_number);
+            }
+            break;
+        }
+
+        default:
+            break;
+        }
+    }
+    return {};
+}
+
+static ErrorOr<void> populate_devtmpfs_devices_based_on_devctl()
+{
+    auto f = Core::File::construct("/dev/devctl");
+    if (!f->open(Core::OpenMode::ReadOnly)) {
+        warnln("Failed to open /dev/devctl - {}", f->error_string());
+        VERIFY_NOT_REACHED();
+    }
+
+    DeviceEvent event;
+    while (f->read((u8*)&event, sizeof(DeviceEvent)) > 0) {
+        if (event.state != DeviceEvent::Inserted)
+            continue;
+        auto major_number = event.major_number;
+        auto minor_number = event.minor_number;
+        bool is_block_device = (event.is_block_device == 1);
+        switch (major_number) {
+        case 116: {
+            if (!is_block_device) {
+                auto name = TRY(String::formatted("/dev/audio/{}", minor_number));
+                TRY(create_devtmpfs_char_device(name.bytes_as_string_view(), 0220, 116, minor_number));
+                break;
+            }
+            break;
+        }
+        case 28: {
+            auto name = TRY(String::formatted("/dev/gpu/render{}", minor_number));
+            TRY(create_devtmpfs_block_device(name.bytes_as_string_view(), 0666, 28, minor_number));
+            break;
+        }
+        case 226: {
+            auto name = TRY(String::formatted("/dev/gpu/connector{}", minor_number));
+            TRY(create_devtmpfs_char_device(name.bytes_as_string_view(), 0666, 226, minor_number));
+            break;
+        }
+        case 229: {
+            if (!is_block_device) {
+                auto name = TRY(String::formatted("/dev/hvc0p{}", minor_number));
+                TRY(create_devtmpfs_char_device(name.bytes_as_string_view(), 0666, 229, minor_number));
+            }
+            break;
+        }
+        case 10: {
+            if (!is_block_device) {
+                switch (minor_number) {
+                case 0: {
+                    TRY(create_devtmpfs_char_device("/dev/input/mouse/0"sv, 0666, 10, 0));
+                    break;
+                }
+                case 183: {
+                    TRY(create_devtmpfs_char_device("/dev/hwrng"sv, 0666, 10, 183));
+                    break;
+                }
+                default:
+                    warnln("Unknown character device {}:{}", major_number, minor_number);
+                }
+            }
+            break;
+        }
+        case 85: {
+            if (!is_block_device) {
+                switch (minor_number) {
+                case 0: {
+                    TRY(create_devtmpfs_char_device("/dev/input/keyboard/0"sv, 0666, 85, 0));
+                    break;
+                }
+                default:
+                    warnln("Unknown character device {}:{}", major_number, minor_number);
+                }
+            }
+            break;
+        }
+        case 1: {
+            if (!is_block_device) {
+                switch (minor_number) {
+                case 5: {
+                    TRY(create_devtmpfs_char_device("/dev/zero"sv, 0666, 1, 5));
+                    break;
+                }
+                case 1: {
+                    TRY(create_devtmpfs_char_device("/dev/mem"sv, 0666, 1, 1));
+                    break;
+                }
+                case 3: {
+                    TRY(create_devtmpfs_char_device("/dev/null"sv, 0666, 1, 3));
+                    break;
+                }
+                case 7: {
+                    TRY(create_devtmpfs_char_device("/dev/full"sv, 0666, 1, 7));
+                    break;
+                }
+                case 8: {
+                    TRY(create_devtmpfs_char_device("/dev/random"sv, 0666, 1, 8));
+                    break;
+                }
+                default:
+                    warnln("Unknown character device {}:{}", major_number, minor_number);
+                    break;
+                }
+            }
+            break;
+        }
+        case 30: {
+            if (!is_block_device) {
+                auto name = TRY(String::formatted("/dev/kcov{}", minor_number));
+                TRY(create_devtmpfs_char_device(name.bytes_as_string_view(), 0666, 30, minor_number));
+            }
+            break;
+        }
+        case 3: {
+            if (is_block_device) {
+                auto name = TRY(String::formatted("/dev/hd{}", offset_character_with_number('a', minor_number)));
+                TRY(create_devtmpfs_block_device(name.bytes_as_string_view(), 0600, 3, minor_number));
+            }
+            break;
+        }
+        case 5: {
+            if (!is_block_device) {
+                switch (minor_number) {
+                case 1: {
+                    TRY(create_devtmpfs_char_device("/dev/console"sv, 0666, 5, 1));
+                    break;
+                }
+                case 2: {
+                    TRY(create_devtmpfs_char_device("/dev/ptmx"sv, 0666, 5, 2));
+                    break;
+                }
+                case 0: {
+                    TRY(create_devtmpfs_char_device("/dev/tty"sv, 0666, 5, 0));
+                    break;
+                }
+                default:
+                    warnln("Unknown character device {}:{}", major_number, minor_number);
+                }
+            }
+            break;
+        }
+        case 4: {
+            if (!is_block_device) {
+                switch (minor_number) {
+                case 0: {
+                    TRY(create_devtmpfs_char_device("/dev/tty0"sv, 0620, 4, 0));
+                    break;
+                }
+                case 1: {
+                    TRY(create_devtmpfs_char_device("/dev/tty1"sv, 0620, 4, 1));
+                    break;
+                }
+                case 2: {
+                    TRY(create_devtmpfs_char_device("/dev/tty2"sv, 0620, 4, 2));
+                    break;
+                }
+                case 3: {
+                    TRY(create_devtmpfs_char_device("/dev/tty3"sv, 0620, 4, 3));
+                    break;
+                }
+                case 64: {
+                    TRY(create_devtmpfs_char_device("/dev/ttyS0"sv, 0620, 4, 64));
+                    break;
+                }
+                case 65: {
+                    TRY(create_devtmpfs_char_device("/dev/ttyS1"sv, 0620, 4, 65));
+                    break;
+                }
+                case 66: {
+                    TRY(create_devtmpfs_char_device("/dev/ttyS2"sv, 0620, 4, 66));
+                    break;
+                }
+                case 67: {
+                    TRY(create_devtmpfs_char_device("/dev/ttyS3"sv, 0666, 4, 67));
+                    break;
+                }
+                default:
+                    warnln("Unknown character device {}:{}", major_number, minor_number);
+                }
+            }
+            break;
+        }
+        default:
+            if (!is_block_device)
+                warnln("Unknown character device {}:{}", major_number, minor_number);
+            else
+                warnln("Unknown block device {}:{}", major_number, minor_number);
+            break;
+        }
+    }
+    return {};
+}
+
+static ErrorOr<void> populate_devtmpfs()
+{
+    mode_t old_mask = umask(0);
+    printf("Changing umask %#o\n", old_mask);
+    TRY(populate_devtmpfs_char_devices_based_on_sysfs());
+    TRY(populate_devtmpfs_devices_based_on_devctl());
+    umask(old_mask);
+    return {};
+}
+
+static ErrorOr<void> prepare_synthetic_filesystems()
+{
+    // FIXME: Find a better way to all of this stuff, without hardcoding all of this!
+    TRY(Core::System::mount(-1, "/proc"sv, "proc"sv, MS_NOSUID));
+    TRY(Core::System::mount(-1, "/sys"sv, "sys"sv, 0));
+    TRY(Core::System::mount(-1, "/dev"sv, "ram"sv, MS_NOSUID | MS_NOEXEC | MS_NOREGULAR));
+
+    TRY(Core::System::mount(-1, "/tmp"sv, "ram"sv, MS_NOSUID | MS_NODEV));
+    // NOTE: Set /tmp to have a sticky bit with 0777 permissions.
+    TRY(Core::System::chmod("/tmp"sv, 01777));
+
+    TRY(Core::System::mkdir("/dev/audio"sv, 0755));
+    TRY(Core::System::mkdir("/dev/input"sv, 0755));
+    TRY(Core::System::mkdir("/dev/input/keyboard"sv, 0755));
+    TRY(Core::System::mkdir("/dev/input/mouse"sv, 0755));
+
+    TRY(Core::System::symlink("/proc/self/fd/0"sv, "/dev/stdin"sv));
+    TRY(Core::System::symlink("/proc/self/fd/1"sv, "/dev/stdout"sv));
+    TRY(Core::System::symlink("/proc/self/fd/2"sv, "/dev/stderr"sv));
+
+    TRY(Core::System::mkdir("/dev/gpu"sv, 0755));
+
+    TRY(populate_devtmpfs());
+
+    TRY(Core::System::mkdir("/dev/pts"sv, 0755));
+
+    TRY(Core::System::mount(-1, "/dev/pts"sv, "devpts"sv, 0));
+
+    TRY(Core::System::symlink("/dev/random"sv, "/dev/urandom"sv));
+
+    TRY(Core::System::chmod("/dev/urandom"sv, 0666));
+
+    auto phys_group = TRY(Core::System::getgrnam("phys"sv));
+    VERIFY(phys_group.has_value());
+    // FIXME: Try to find a way to not hardcode the major number of display connector device nodes.
+    TRY(chown_all_matching_device_nodes(phys_group.value(), 29));
+
+    auto const filter_chown_ENOENT = [](ErrorOr<void> result) -> ErrorOr<void> {
+        auto const chown_enoent = Error::from_syscall("chown"sv, -ENOENT);
+        if (result.is_error() && result.error() == chown_enoent) {
+            dbgln("{}", result.release_error());
+            return {};
+        }
+        return result;
+    };
+
+    TRY(filter_chown_ENOENT(Core::System::chown("/dev/input/keyboard/0"sv, 0, phys_group.value().gr_gid)));
+    TRY(filter_chown_ENOENT(Core::System::chown("/dev/input/mouse/0"sv, 0, phys_group.value().gr_gid)));
+
+    auto tty_group = TRY(Core::System::getgrnam("tty"sv));
+    VERIFY(tty_group.has_value());
+    // FIXME: Try to find a way to not hardcode the major number of tty nodes.
+    TRY(chown_all_matching_device_nodes(tty_group.release_value(), 4));
+
+    auto audio_group = TRY(Core::System::getgrnam("audio"sv));
+    VERIFY(audio_group.has_value());
+    TRY(Core::System::chown("/dev/audio"sv, 0, audio_group->gr_gid));
+    TRY(chown_all_matching_device_nodes_under_specific_directory("/dev/audio"sv, audio_group.release_value()));
+
+    // Note: We open the /dev/null device and set file descriptors 0, 1, 2 to it
+    // because otherwise these file descriptors won't have a custody, making
+    // the ProcFS file descriptor links (at /proc/PID/fd/{0,1,2}) to have an
+    // absolute path of "device:1,3" instead of something like "/dev/null".
+    // This affects also every other process that inherits the file descriptors
+    // from SystemServer, so it is important for other things (also for ProcFS
+    // tests that are running in CI mode).
+    int stdin_new_fd = TRY(Core::System::open("/dev/null"sv, O_NONBLOCK));
+
+    TRY(Core::System::dup2(stdin_new_fd, 0));
+    TRY(Core::System::dup2(stdin_new_fd, 1));
+    TRY(Core::System::dup2(stdin_new_fd, 2));
+
+    TRY(Core::System::endgrent());
+    return {};
+}
+
+static ErrorOr<void> create_tmp_coredump_directory()
+{
+    dbgln("Creating /tmp/coredump directory");
+    auto old_umask = umask(0);
+    // FIXME: the coredump directory should be made read-only once CrashDaemon is no longer responsible for compressing coredumps
+    TRY(Core::System::mkdir("/tmp/coredump"sv, 0777));
+    umask(old_umask);
+    return {};
+}
+
+static ErrorOr<void> set_default_coredump_directory()
+{
+    dbgln("Setting /tmp/coredump as the coredump directory");
+    auto sysfs_coredump_directory_variable_fd = TRY(Core::System::open("/sys/kernel/variables/coredump_directory"sv, O_RDWR));
+    ScopeGuard close_on_exit([&] {
+        close(sysfs_coredump_directory_variable_fd);
+    });
+    auto tmp_coredump_directory_path = "/tmp/coredump"sv;
+    auto nwritten = TRY(Core::System::write(sysfs_coredump_directory_variable_fd, tmp_coredump_directory_path.bytes()));
+    VERIFY(static_cast<size_t>(nwritten) == tmp_coredump_directory_path.length());
+    return {};
+}
+
+static ErrorOr<void> create_tmp_semaphore_directory()
+{
+    dbgln("Creating /tmp/semaphore directory");
+    auto old_umask = umask(0);
+    TRY(Core::System::mkdir("/tmp/semaphore"sv, 0777));
+    umask(old_umask);
+    return {};
+}
+
+static ErrorOr<void> prepare_init_filesystem_environment()
+{
+    TRY(prepare_synthetic_filesystems());
+    TRY(create_tmp_coredump_directory());
+    TRY(set_default_coredump_directory());
+    TRY(create_tmp_semaphore_directory());
+    return {};
+}
+
+ErrorOr<int> buggiebox_init_main(Main::Arguments arguments)
+{
+    StringView boot_device_name;
+    Core::ArgsParser args_parser;
+    args_parser.add_positional_argument(boot_device_name, "Boot device", "device", Core::ArgsParser::Required::No);
+    args_parser.parse(arguments);
+
+    TRY(prepare_init_filesystem_environment());
+    TRY(determine_system_mode());
+    //[[maybe_unused]] auto result = continue_boot_sequence(boot_device_name.is_null() ? Optional<StringView> {} : boot_device_name);
+
+    Core::EventLoop event_loop;
+    event_loop.register_signal(SIGCHLD, sigchld_handler);
+
+    pid_t pid = TRY(Core::System::fork());
+    if (pid == 0)
+        TRY(Core::System::exec("/bin/BuggieBox"sv, Vector { "emergency_shell"sv }, Core::System::SearchInPath::No));
+
+    event_loop.exec();
+    VERIFY_NOT_REACHED();
+}

--- a/Userland/BuggieBox/init.h
+++ b/Userland/BuggieBox/init.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibMain/Main.h>
+
+ErrorOr<int> buggiebox_init_main(Main::Arguments arguments);

--- a/Userland/BuggieBox/main.cpp
+++ b/Userland/BuggieBox/main.cpp
@@ -7,36 +7,69 @@
 
 #include <AK/LexicalPath.h>
 #include <LibMain/Main.h>
+#include <Userland/BuggieBox/Globals.h>
+#include <Userland/Libraries/LibC/unistd.h>
 #include <Userland/Shell/Shell.h>
 
+bool g_follow_symlinks = false;
+bool g_there_was_an_error = false;
+bool g_have_seen_action_command = false;
+
 #define ENUMERATE_UTILITIES(E) \
+    E(blockdev)                \
+    E(base64)                  \
     E(cat)                     \
+    E(clear)                   \
     E(checksum)                \
     E(chmod)                   \
     E(chown)                   \
     E(cp)                      \
+    E(dd)                      \
     E(df)                      \
+    E(dmesg)                   \
     E(env)                     \
+    E(errno)                   \
     E(file)                    \
     E(find)                    \
+    E(head)                    \
     E(id)                      \
     E(less)                    \
+    E(ldd)                     \
     E(ln)                      \
     E(ls)                      \
+    E(lscpu)                   \
+    E(lspci)                   \
+    E(lsusb)                   \
+    E(lsirq)                   \
     E(lsblk)                   \
     E(mkdir)                   \
     E(mknod)                   \
+    E(mktemp)                  \
     E(mount)                   \
     E(mv)                      \
+    E(pledge)                  \
     E(ps)                      \
     E(rm)                      \
     E(sh)                      \
+    E(readelf)                 \
     E(rmdir)                   \
+    E(shuf)                    \
+    E(sort)                    \
+    E(stat)                    \
+    E(sync)                    \
+    E(sysctl)                  \
+    E(tac)                     \
     E(tail)                    \
+    E(test)                    \
+    E(timezone)                \
+    E(top)                     \
+    E(touch)                   \
     E(tree)                    \
     E(umount)                  \
     E(uname)                   \
-    E(uniq)
+    E(uniq)                    \
+    E(unveil)                  \
+    E(whoami)
 
 // Declare the entrypoints of all the tools that we delegate to.
 // Relying on `decltype(serenity_main)` ensures that we always stay consistent with the `serenity_main` signature.
@@ -47,9 +80,19 @@ ENUMERATE_UTILITIES(DECLARE_ENTRYPOINT)
 static void fail()
 {
     out(stderr, "Direct running of BuggieBox was detected without finding a proper requested utility.\n");
-    out(stderr, "The following programs are supported: uname, env, lsblk, file, df, mount, umount, mkdir, ");
-    out(stderr, "rmdir, rm, chown, chmod, cp, ln, ls, mv, cat, md5sum, sha1sum, sha256sum, sha512sum, sh, uniq, id, tail, ");
-    out(stderr, "find, less, mknod, ps\n");
+    out(stderr, "The following programs are supported: clear, head, dmesg, uname, errno, env, lsblk, file, df, mount, umount, mkdir, ");
+    out(stderr, "rmdir, rm, chown, chmod, cp, ln, ls, mv, cat, dd, md5sum, sha1sum, sha256sum, sha512sum, base64, sh, uniq, id, tail, unveil, pledge ");
+    out(stderr, "find, less, mknod, ps, [, whoami, touch, top, timezone, tac, sysctl, sync, stat, sort, shuf, mktemp, lspci, lscpu, lsirq, ldd, readelf\n");
+    out(stderr, "To use one of these included utilities, create a symbolic link with the target being this binary, and ensure the basename");
+    out(stderr, "is included within.\n");
+}
+
+static void fail_with_unknown_utility(StringView requested_utility_name)
+{
+    out(stderr, "Running of BuggieBox was detected without finding the requested utility \"{}\".\n", requested_utility_name);
+    out(stderr, "The following programs are supported: clear, head, dmesg, errno, uname, env, lsblk, file, df, mount, umount, mkdir, ");
+    out(stderr, "rmdir, rm, chown, chmod, cp, ln, ls, mv, cat, dd, md5sum, sha1sum, sha256sum, sha512sum, base64, sh, uniq, id, tail, unveil, pledge ");
+    out(stderr, "find, less, mknod, ps, [, whoami, touch, top, timezone, tac, sysctl, sync, stat, sort, shuf, mktemp, lspci, lscpu, lsirq, ldd, readelf\n");
     out(stderr, "To use one of these included utilities, create a symbolic link with the target being this binary, and ensure the basename");
     out(stderr, "is included within.\n");
 }
@@ -70,6 +113,7 @@ static constexpr Runner s_runners[] = {
     { "sha256sum"sv, checksum_main },
     { "sha512sum"sv, checksum_main },
     { "Shell"sv, sh_main },
+    { "["sv, test_main },
 };
 
 static ErrorOr<int> run_program(Main::Arguments arguments, LexicalPath const& runbase, bool& found_runner)
@@ -92,8 +136,10 @@ static ErrorOr<int> buggiebox_main(Main::Arguments arguments)
     bool found_runner = false;
     LexicalPath runbase { arguments.strings[0] };
     auto result = TRY(run_program(arguments, runbase, found_runner));
-    if (!found_runner)
-        fail();
+    if (!found_runner) {
+        fail_with_unknown_utility(arguments.strings[0]);
+        return 1;
+    }
     return result;
 }
 

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -143,8 +143,8 @@ endif()
 set_source_files_properties(ssp.cpp PROPERTIES COMPILE_FLAGS "-fno-stack-protector")
 
 add_library(LibCStaticWithoutDeps STATIC ${SOURCES})
-target_link_libraries(LibCStaticWithoutDeps PUBLIC ssp LibTimeZone PRIVATE NoCoverage)
-add_dependencies(LibCStaticWithoutDeps LibSystem LibUBSanitizer)
+target_link_libraries(LibCStaticWithoutDeps PUBLIC ssp_nonshared LibTimeZone PRIVATE NoCoverage)
+add_dependencies(LibCStaticWithoutDeps LibSystemStatic LibUBSanitizerStatic)
 
 add_custom_target(LibCStatic
         COMMAND ${CMAKE_AR} -x $<TARGET_FILE:LibCStaticWithoutDeps>

--- a/Userland/Libraries/LibCodeComprehension/CMakeLists.txt
+++ b/Userland/Libraries/LibCodeComprehension/CMakeLists.txt
@@ -4,6 +4,9 @@ set(SOURCES
 )
 
 serenity_lib(LibCodeComprehension codecomprehension)
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibCodeComprehensionStatic codecomprehension)
+endif()
 
 add_subdirectory(Cpp)
 add_subdirectory(Shell)

--- a/Userland/Libraries/LibCompress/CMakeLists.txt
+++ b/Userland/Libraries/LibCompress/CMakeLists.txt
@@ -8,3 +8,8 @@ set(SOURCES
 
 serenity_lib(LibCompress compress)
 target_link_libraries(LibCompress PRIVATE LibCore LibCrypto)
+
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibCompressStatic compress)
+    target_link_libraries(LibCompressStatic PRIVATE LibCoreStatic LibCryptoStatic)
+endif()

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -57,6 +57,11 @@ endif()
 serenity_lib(LibCore core)
 target_link_libraries(LibCore PRIVATE LibCrypt LibSystem)
 
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibCoreStatic core)
+    target_link_libraries(LibCoreStatic PRIVATE LibCryptStatic LibSystemStatic)
+endif()
+
 if (APPLE)
     target_link_libraries(LibCore PUBLIC "-framework CoreFoundation")
     target_link_libraries(LibCore PUBLIC "-framework CoreServices")

--- a/Userland/Libraries/LibCrypt/CMakeLists.txt
+++ b/Userland/Libraries/LibCrypt/CMakeLists.txt
@@ -12,3 +12,8 @@ set(SOURCES
 
 serenity_lib(LibCrypt crypt)
 target_link_libraries(LibCrypt PRIVATE LibCryptSHA2)
+
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibCryptStatic crypt)
+    target_link_libraries(LibCryptStatic PRIVATE LibCryptSHA2)
+endif()

--- a/Userland/Libraries/LibCrypto/CMakeLists.txt
+++ b/Userland/Libraries/LibCrypto/CMakeLists.txt
@@ -34,3 +34,8 @@ set(SOURCES
 
 serenity_lib(LibCrypto crypto)
 target_link_libraries(LibCrypto PRIVATE LibCore)
+
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibCryptoStatic crypto)
+    target_link_libraries(LibCryptoStatic PRIVATE LibCoreStatic)
+endif()

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -406,7 +406,7 @@ static Result<void, DlErrorMessage> link_main_library(DeprecatedString const& pa
             initialize_libc(*object);
         }
 
-        if (loader.filepath().ends_with("/libsystem.so"sv)) {
+        if (loader.filepath().ends_with("/libsystem.so"sv) || loader.filepath().ends_with("/libbuggiebox.so"sv) || loader.filepath().ends_with("/libbuggiebox.so.serenity"sv)) {
             VERIFY(!loader.text_segments().is_empty());
             for (auto const& segment : loader.text_segments()) {
                 auto flags = static_cast<int>(VirtualMemoryRangeFlags::SyscallCode) | static_cast<int>(VirtualMemoryRangeFlags::Immutable);

--- a/Userland/Libraries/LibELF/Image.h
+++ b/Userland/Libraries/LibELF/Image.h
@@ -18,6 +18,41 @@
 
 namespace ELF {
 
+template<typename ElfHeader, typename ElfPhdr, typename ElfShdr>
+class BitnessSpecificImage {
+public:
+    using Header = ElfHeader;
+    using ProgramHeader = ElfPhdr;
+    using SectionHeader = ElfShdr;
+
+    BitnessSpecificImage(ByteBuffer& image)
+        : m_image(image)
+    {
+    }
+
+    ElfHeader& get_header()
+    {
+        return *reinterpret_cast<ElfHeader*>(m_image.data());
+    }
+
+    Span<ElfPhdr> get_program_headers()
+    {
+        auto& header = get_header();
+        auto program_headers = reinterpret_cast<ElfPhdr*>(m_image.data() + header.e_phoff);
+        return Span<ElfPhdr>(program_headers, header.e_phnum);
+    }
+
+    Span<ElfShdr> get_sections()
+    {
+        auto& header = get_header();
+        auto sections = reinterpret_cast<ElfShdr*>(m_image.data() + header.e_shoff);
+        return Span<ElfShdr>(sections, header.e_shnum);
+    }
+
+private:
+    ByteBuffer& m_image;
+};
+
 class Image {
 public:
     explicit Image(ReadonlyBytes, bool verbose_logging = true);

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -59,3 +59,8 @@ set(SOURCES
 
 serenity_lib(LibGfx gfx)
 target_link_libraries(LibGfx PRIVATE LibCompress LibCore LibCrypto LibTextCodec LibIPC)
+
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibGfxStatic gfx)
+    target_link_libraries(LibGfxStatic PRIVATE LibCompressStatic LibCoreStatic LibCryptoStatic LibTextCodecStatic LibIPCStatic)
+endif()

--- a/Userland/Libraries/LibIPC/CMakeLists.txt
+++ b/Userland/Libraries/LibIPC/CMakeLists.txt
@@ -6,3 +6,8 @@ set(SOURCES
 
 serenity_lib(LibIPC ipc)
 target_link_libraries(LibIPC PRIVATE LibCore)
+
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibIPCStatic ipc)
+    target_link_libraries(LibIPCStatic PRIVATE LibCoreStatic)
+endif()

--- a/Userland/Libraries/LibLine/CMakeLists.txt
+++ b/Userland/Libraries/LibLine/CMakeLists.txt
@@ -8,3 +8,8 @@ set(SOURCES
 
 serenity_lib(LibLine line)
 target_link_libraries(LibLine PRIVATE LibCore)
+
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibLineStatic line)
+    target_link_libraries(LibLineStatic PRIVATE LibCoreStatic)
+endif()

--- a/Userland/Libraries/LibPCIDB/CMakeLists.txt
+++ b/Userland/Libraries/LibPCIDB/CMakeLists.txt
@@ -3,3 +3,5 @@ set(SOURCES
 )
 
 serenity_lib(LibPCIDB pcidb)
+
+serenity_lib_static(LibPCIDBStatic pcidb)

--- a/Userland/Libraries/LibRegex/CMakeLists.txt
+++ b/Userland/Libraries/LibRegex/CMakeLists.txt
@@ -12,3 +12,8 @@ endif()
 
 serenity_lib(LibRegex regex)
 target_link_libraries(LibRegex PRIVATE LibCore LibUnicode)
+
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibRegexStatic regex)
+    target_link_libraries(LibRegexStatic PRIVATE LibCoreStatic LibUnicodeStatic)
+endif()

--- a/Userland/Libraries/LibSyntax/CMakeLists.txt
+++ b/Userland/Libraries/LibSyntax/CMakeLists.txt
@@ -3,3 +3,7 @@ set(SOURCES
 )
 
 serenity_lib(LibSyntax syntax)
+
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibSyntaxStatic syntax)
+endif()

--- a/Userland/Libraries/LibTextCodec/CMakeLists.txt
+++ b/Userland/Libraries/LibTextCodec/CMakeLists.txt
@@ -3,3 +3,7 @@ set(SOURCES
 )
 
 serenity_lib(LibTextCodec textcodec)
+
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibTextCodecStatic textcodec)
+endif()

--- a/Userland/Libraries/LibUSBDB/CMakeLists.txt
+++ b/Userland/Libraries/LibUSBDB/CMakeLists.txt
@@ -3,3 +3,5 @@ set(SOURCES
 )
 
 serenity_lib(LibUSBDB usbdb)
+
+serenity_lib_static(LibUSBDBStatic usbdb)

--- a/Userland/Libraries/LibUnicode/CMakeLists.txt
+++ b/Userland/Libraries/LibUnicode/CMakeLists.txt
@@ -13,4 +13,11 @@ set(GENERATED_SOURCES ${CURRENT_LIB_GENERATED})
 
 serenity_lib(LibUnicode unicode)
 target_link_libraries(LibUnicode PRIVATE LibCore)
+
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibUnicodeStatic unicode)
+    target_link_libraries(LibUnicodeStatic PRIVATE LibCoreStatic)
+    target_compile_definitions(LibUnicodeStatic PRIVATE ENABLE_UNICODE_DATA=$<BOOL:${ENABLE_UNICODE_DATABASE_DOWNLOAD}>)
+endif()
+
 target_compile_definitions(LibUnicode PRIVATE ENABLE_UNICODE_DATA=$<BOOL:${ENABLE_UNICODE_DATABASE_DOWNLOAD}>)

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -386,6 +386,10 @@ static ErrorOr<void> populate_devtmpfs()
 
 static ErrorOr<void> prepare_synthetic_filesystems()
 {
+    // FIXME: Don't hardcode the fs type as the ext2 filesystem and once there's
+    // more than this filesystem implementation (which is suitable for usage on
+    // physical storage), find a way to detect it.
+    TRY(Core::System::mount(-1, "/"sv, "ext2"sv, MS_REMOUNT | MS_NODEV | MS_NOSUID | MS_RDONLY));
     // FIXME: Find a better way to all of this stuff, without hardcoding all of this!
     TRY(Core::System::mount(-1, "/proc"sv, "proc"sv, MS_NOSUID));
     TRY(Core::System::mount(-1, "/sys"sv, "sys"sv, 0));

--- a/Userland/Shell/CMakeLists.txt
+++ b/Userland/Shell/CMakeLists.txt
@@ -18,9 +18,16 @@ set(SOURCES
 serenity_lib(LibShell shell)
 target_link_libraries(LibShell PRIVATE LibCore LibLine LibSyntax LibRegex)
 
+if (NOT BUILD_LAGOM AND NOT BUILD_LAGOM_TOOLS)
+    serenity_lib_static(LibShellStatic shell)
+    target_link_libraries(LibShellStatic PRIVATE LibCoreStatic LibLineStatic LibSyntaxStatic LibRegexStatic)
+endif()
+
 if (SERENITYOS)
     target_sources(LibShell PRIVATE SyntaxHighlighter.cpp)
+    target_sources(LibShellStatic PRIVATE SyntaxHighlighter.cpp)
     target_link_libraries(LibShell PRIVATE LibCodeComprehension)
+    target_link_libraries(LibShellStatic PRIVATE LibCodeComprehensionStatic)
 endif()
 
 if (ENABLE_FUZZERS)

--- a/Userland/Utilities/find.cpp
+++ b/Userland/Utilities/find.cpp
@@ -24,9 +24,15 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+// NOTE: We exclude this when building the BuggieBox program because it's already
+// included there.
+#ifndef _BUGGIE_BOX
 bool g_follow_symlinks = false;
 bool g_there_was_an_error = false;
 bool g_have_seen_action_command = false;
+#else
+#    include <BuggieBox/Globals.h>
+#endif
 
 template<typename... Parameters>
 [[noreturn]] static void fatal_error(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)

--- a/Userland/Utilities/test.cpp
+++ b/Userland/Utilities/test.cpp
@@ -14,7 +14,13 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+// NOTE: We exclude this when building the BuggieBox program because it's already
+// included there.
+#ifndef _BUGGIE_BOX
 bool g_there_was_an_error = false;
+#else
+#    include <BuggieBox/Globals.h>
+#endif
 
 [[noreturn, gnu::format(printf, 1, 2)]] static void fatal_error(char const* format, ...)
 {


### PR DESCRIPTION
This was taken from #14936.
The idea is to have initramfs support also because the aarch64 people need this so they could boot without writing SPI driver and SD (MMC) driver too, for now.

cc @ADKaster @FireFox317 