### PR TITLE
LibWeb: Remove redundant BFC::is_block_formatting_context() method

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -53,8 +53,6 @@ public:
     virtual void determine_height_of_child(Box const&, AvailableSpace const&) override;
 
 private:
-    virtual bool is_block_formatting_context() const final { return true; }
-
     CSSPixels compute_auto_height_for_block_level_element(Box const&, AvailableSpace const&);
 
     void compute_width_for_floating_box(Box const&, AvailableSpace const&);


### PR DESCRIPTION
This is marked as virtual, but the super-method isn't, and also, the super-method already returns the correct value, so this isn't needed.