### PR TITLE
Documentation: Update VMWare and VirtualBox docs memory sections

### DIFF
--- a/Documentation/VMware.md
+++ b/Documentation/VMware.md
@@ -23,7 +23,7 @@ Creating a SerenityOS virtual machine is similar to any other virtual machine. T
 4. Choose any size for the hard disk. This disk will later be removed and replaced with the converted GRUB image from the previous stage.
 5. Select **Finish** to finalize creation of the virtual machine.
 6. Select the newly created virtual machine and click **Edit virtual machine settings**.
-7. Serenity requires at minimum 32 MB of memory. Set **Memory for this virtual machine** equal to or above 32 MB. The currently recommended size is 256 MB. Please note that Serenity is currently a 32-bit system, so anything above the ~3.5 GB mark will not be recognized.
+7. Serenity requires at minimum 512 MiB of memory. Set **Memory for this virtual machine** equal to or above 512 MiB. The currently recommended size is 1 GiB.
 8. Select the existing **Hard Disk** and click **Remove**.
 9. Select **Add**, select **Hard Disk**, select **IDE (Recommended)**, select **Use an existing virtual disk**.
 10. Click **Browse** and browse to where you stored the converted VMDK disk image from the previous stage and add it. Click **Finish**.

--- a/Documentation/VirtualBox.md
+++ b/Documentation/VirtualBox.md
@@ -31,7 +31,7 @@ Note that if you are on Windows and you do not have QEMU or VirtualBox in your P
 1. Open the **Create Virtual Machine** dialog. Switch to **Expert Mode**.
 2. Feel free to give it any name and store it anywhere.
 3. Switch the **Type** to **Other** and the **Version** to **Other/Unknown (64-bit)**.
-4. Serenity requires at minimum 256 MB of memory. Set **Memory size** equal to or above 256 MB. The currently recommended size is 1024 MB. Please note that Serenity is currently a 32-bit system, so anything above the ~3.5 GB mark will not be recognized.
+4. Serenity requires at minimum 512 MiB of memory. Set **Memory size** equal to or above 512 MiB. The currently recommended size is 1 GiB.
 5. For **Hard disk**, select **Use an existing virtual hard disk file**. Click the folder icon next to the dropdown to open the **Hard Disk Selector**.
 6. Click **Add**. Browse to where you stored the converted disk image from the previous stage and add it. Click **Choose**.
 7. Finally click **Create**.


### PR DESCRIPTION
Serenity is now a [64-bit only system](https://github.com/SerenityOS/serenity/blob/master/Documentation/FAQ.md#why-is-the-system-64-bit-only). This change updates the `VMWare.md` and `VirtualBox.md` documentation to remove the note about 3.5GB maximum memory, and also updates the minimum and recommended memory sizes to 512 MiB and 1 GiB respectively.
