### PR TITLE
LibGUI+Everywhere: Use fallible Window::set_main_widget() everywhere :^)

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -80,7 +80,7 @@ private:
         m_slider_window = add<GUI::Window>(window());
         m_slider_window->set_window_type(GUI::WindowType::Popup);
 
-        m_root_container = TRY(m_slider_window->try_set_main_widget<GUI::Frame>());
+        m_root_container = TRY(m_slider_window->set_main_widget<GUI::Frame>());
         m_root_container->set_fill_with_background_color(true);
         m_root_container->set_layout<GUI::VerticalBoxLayout>();
         m_root_container->layout()->set_margins({ 4 });
@@ -245,7 +245,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Audio");
     window->set_window_type(GUI::WindowType::Applet);
 
-    auto audio_widget = TRY(window->try_set_main_widget<AudioWidget>());
+    auto audio_widget = TRY(window->set_main_widget<AudioWidget>());
     window->show();
 
     // This positioning code depends on the window actually existing.

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     main_window->set_rect(670, 65, 325, 500);
     main_window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto table_view = TRY(main_window->try_set_main_widget<GUI::TableView>());
+    auto table_view = TRY(main_window->set_main_widget<GUI::TableView>());
     auto model = ClipboardHistoryModel::create();
     table_view->set_model(model);
 
@@ -65,7 +65,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     applet_window->set_title("ClipboardHistory");
     applet_window->set_window_type(GUI::WindowType::Applet);
     applet_window->set_has_alpha_channel(true);
-    auto icon_widget = TRY(applet_window->try_set_main_widget<GUI::ImageWidget>());
+    auto icon_widget = TRY(applet_window->set_main_widget<GUI::ImageWidget>());
     icon_widget->set_tooltip("Clipboard History");
     icon_widget->load_from_file("/res/icons/16x16/edit-copy.png"sv);
     icon_widget->on_click = [&main_window = *main_window] {

--- a/Userland/Applets/Keymap/KeymapStatusWindow.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWindow.cpp
@@ -14,7 +14,7 @@ KeymapStatusWindow::KeymapStatusWindow()
 {
     set_window_type(GUI::WindowType::Applet);
     set_has_alpha_channel(true);
-    m_status_widget = &set_main_widget<KeymapStatusWidget>();
+    m_status_widget = set_main_widget<KeymapStatusWidget>().release_value_but_fixme_should_propagate_errors();
 
     auto current_keymap = MUST(Keyboard::CharacterMap::fetch_system_map());
     auto current_keymap_name = current_keymap.character_map_name();

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -187,7 +187,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_window_type(GUI::WindowType::Applet);
     window->set_has_alpha_channel(true);
     window->resize(16, 16);
-    auto icon = TRY(window->try_set_main_widget<NetworkWidget>(display_notifications));
+    auto icon = TRY(window->set_main_widget<NetworkWidget>(display_notifications));
     icon->load_from_file("/res/icons/16x16/network.png"sv);
     window->resize(16, 16);
     window->show();

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -276,7 +276,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         window->set_window_type(GUI::WindowType::Applet);
         window->resize(GraphWidget::history_size + 2, 15);
 
-        auto graph_widget = TRY(window->try_set_main_widget<GraphWidget>(graph_type, graph_color, Optional<Gfx::Color> {}));
+        auto graph_widget = TRY(window->set_main_widget<GraphWidget>(graph_type, graph_color, Optional<Gfx::Color> {}));
         window->show();
         applet_windows.append(move(window));
 

--- a/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
+++ b/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
@@ -148,7 +148,7 @@ DesktopStatusWindow::DesktopStatusWindow()
 {
     set_window_type(GUI::WindowType::Applet);
     set_has_alpha_channel(true);
-    m_widget = &set_main_widget<DesktopStatusWidget>();
+    m_widget = set_main_widget<DesktopStatusWidget>().release_value_but_fixme_should_propagate_errors();
 }
 
 void DesktopStatusWindow::wm_event(GUI::WMEvent& event)

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -385,7 +385,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(640 + 4, 480 + 4);
     window->set_resizable(false);
     window->set_double_buffering_enabled(true);
-    auto widget = TRY(window->try_set_main_widget<GLContextWidget>());
+    auto widget = TRY(window->set_main_widget<GLContextWidget>());
 
     auto& time = widget->add<GUI::Label>();
     time.set_visible(false);

--- a/Userland/Applications/AnalogClock/main.cpp
+++ b/Userland/Applications/AnalogClock/main.cpp
@@ -30,7 +30,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(170, 170);
     window->set_resizable(false);
-    auto clock = TRY(window->try_set_main_widget<AnalogClock>());
+    auto clock = TRY(window->set_main_widget<AnalogClock>());
 
     auto show_window_frame_action = GUI::Action::create_checkable(
         "Show Window &Frame", { Mod_Alt, KeyCode::Key_F }, [&](auto& action) {

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -165,14 +165,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Assistant::AppState app_state;
     Assistant::Database db { app_state };
 
-    auto& container = window->set_main_widget<GUI::Frame>();
-    container.set_fill_with_background_color(true);
-    container.set_frame_shape(Gfx::FrameShape::Window);
-    auto& layout = container.set_layout<GUI::VerticalBoxLayout>();
+    auto container = TRY(window->set_main_widget<GUI::Frame>());
+    container->set_fill_with_background_color(true);
+    container->set_frame_shape(Gfx::FrameShape::Window);
+    auto& layout = container->set_layout<GUI::VerticalBoxLayout>();
     layout.set_margins({ 8 });
 
-    auto& text_box = container.add<GUI::TextBox>();
-    auto& results_container = container.add<GUI::Widget>();
+    auto& text_box = container->add<GUI::TextBox>();
+    auto& results_container = container->add<GUI::Widget>();
     auto& results_layout = results_container.set_layout<GUI::VerticalBoxLayout>();
 
     auto mark_selected_item = [&]() {

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -47,28 +47,28 @@ private:
     BookmarkEditor(Window* parent_window, StringView title, StringView url)
         : Dialog(parent_window)
     {
-        auto& widget = set_main_widget<GUI::Widget>();
-        if (!widget.load_from_gml(edit_bookmark_gml))
+        auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+        if (!widget->load_from_gml(edit_bookmark_gml))
             VERIFY_NOT_REACHED();
 
         set_resizable(false);
         resize(260, 85);
 
-        m_title_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("title_textbox");
+        m_title_textbox = *widget->find_descendant_of_type_named<GUI::TextBox>("title_textbox");
         m_title_textbox->set_text(title);
         m_title_textbox->set_focus(true);
         m_title_textbox->select_all();
 
-        m_url_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("url_textbox");
+        m_url_textbox = *widget->find_descendant_of_type_named<GUI::TextBox>("url_textbox");
         m_url_textbox->set_text(url);
 
-        auto& ok_button = *widget.find_descendant_of_type_named<GUI::Button>("ok_button");
+        auto& ok_button = *widget->find_descendant_of_type_named<GUI::Button>("ok_button");
         ok_button.on_click = [this](auto) {
             done(ExecResult::OK);
         };
         ok_button.set_default(true);
 
-        auto& cancel_button = *widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+        auto& cancel_button = *widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
         cancel_button.on_click = [this](auto) {
             done(ExecResult::Cancel);
         };

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -73,12 +73,12 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
     set_icon(app_icon.bitmap_for_size(16));
     set_title("Browser");
 
-    auto& widget = set_main_widget<GUI::Widget>();
-    widget.load_from_gml(browser_window_gml);
+    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    widget->load_from_gml(browser_window_gml);
 
-    auto& top_line = *widget.find_descendant_of_type_named<GUI::HorizontalSeparator>("top_line");
+    auto& top_line = *widget->find_descendant_of_type_named<GUI::HorizontalSeparator>("top_line");
 
-    m_tab_widget = *widget.find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
+    m_tab_widget = *widget->find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
     m_tab_widget->on_tab_count_change = [&top_line](size_t tab_count) {
         top_line.set_visible(tab_count > 1);
     };

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -70,18 +70,18 @@ void Tab::start_download(const URL& url)
     window->resize(300, 170);
     window->set_title(DeprecatedString::formatted("0% of {}", url.basename()));
     window->set_resizable(false);
-    window->set_main_widget<DownloadWidget>(url);
+    (void)window->set_main_widget<DownloadWidget>(url).release_value_but_fixme_should_propagate_errors();
     window->show();
 }
 
 void Tab::view_source(const URL& url, DeprecatedString const& source)
 {
     auto window = GUI::Window::construct(&this->window());
-    auto& editor = window->set_main_widget<GUI::TextEditor>();
-    editor.set_text(source);
-    editor.set_mode(GUI::TextEditor::ReadOnly);
-    editor.set_syntax_highlighter(make<Web::HTML::SyntaxHighlighter>());
-    editor.set_ruler_visible(true);
+    auto editor = window->set_main_widget<GUI::TextEditor>().release_value_but_fixme_should_propagate_errors();
+    editor->set_text(source);
+    editor->set_mode(GUI::TextEditor::ReadOnly);
+    editor->set_syntax_highlighter(make<Web::HTML::SyntaxHighlighter>());
+    editor->set_ruler_visible(true);
     window->resize(640, 480);
     window->set_title(url.to_deprecated_string());
     window->set_icon(g_icon_bag.filetype_text);
@@ -663,7 +663,7 @@ void Tab::show_inspector_window(Browser::Tab::InspectorTarget inspector_target)
         window->on_close = [&]() {
             m_web_content_view->clear_inspected_dom_node();
         };
-        m_dom_inspector_widget = window->set_main_widget<InspectorWidget>();
+        m_dom_inspector_widget = window->set_main_widget<InspectorWidget>().release_value_but_fixme_should_propagate_errors();
         m_dom_inspector_widget->set_web_view(*m_web_content_view);
         m_web_content_view->inspect_dom_tree();
     }
@@ -702,7 +702,7 @@ void Tab::show_console_window()
         console_window->resize(500, 300);
         console_window->set_title("JS Console");
         console_window->set_icon(g_icon_bag.filetype_javascript);
-        m_console_widget = console_window->set_main_widget<ConsoleWidget>();
+        m_console_widget = console_window->set_main_widget<ConsoleWidget>().release_value_but_fixme_should_propagate_errors();
         m_console_widget->on_js_input = [this](DeprecatedString const& js_source) {
             m_web_content_view->js_console_input(js_source);
         };
@@ -723,7 +723,7 @@ void Tab::show_storage_inspector()
         storage_window->resize(500, 300);
         storage_window->set_title("Storage inspector");
         storage_window->set_icon(g_icon_bag.cookie);
-        m_storage_widget = storage_window->set_main_widget<StorageWidget>();
+        m_storage_widget = storage_window->set_main_widget<StorageWidget>().release_value_but_fixme_should_propagate_errors();
         m_storage_widget->on_update_cookie = [this](Web::Cookie::Cookie cookie) {
             if (on_update_cookie)
                 on_update_cookie(move(cookie));
@@ -760,7 +760,7 @@ void Tab::show_history_inspector()
         history_window->resize(500, 300);
         history_window->set_title("History");
         history_window->set_icon(g_icon_bag.history);
-        m_history_widget = history_window->set_main_widget<HistoryWidget>();
+        m_history_widget = history_window->set_main_widget<HistoryWidget>().release_value_but_fixme_should_propagate_errors();
     }
 
     m_history_widget->clear_history_entries();

--- a/Userland/Applications/Calculator/RoundingDialog.cpp
+++ b/Userland/Applications/Calculator/RoundingDialog.cpp
@@ -39,18 +39,18 @@ RoundingDialog::RoundingDialog(GUI::Window* parent_window, StringView title)
     set_resizable(false);
     set_title(title);
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
 
-    main_widget.set_fill_with_background_color(true);
-    main_widget.set_layout<GUI::VerticalBoxLayout>();
+    main_widget->set_fill_with_background_color(true);
+    main_widget->set_layout<GUI::VerticalBoxLayout>();
 
     m_rounding_spinbox = GUI::SpinBox::construct();
     m_buttons_container = GUI::Widget::construct();
     m_ok_button = GUI::DialogButton::construct("OK");
     m_cancel_button = GUI::DialogButton::construct("Cancel");
 
-    main_widget.add_child(*m_rounding_spinbox);
-    main_widget.add_child(*m_buttons_container);
+    main_widget->add_child(*m_rounding_spinbox);
+    main_widget->add_child(*m_buttons_container);
 
     m_buttons_container->set_layout<GUI::HorizontalBoxLayout>();
     m_buttons_container->layout()->add_spacer();

--- a/Userland/Applications/Calculator/main.cpp
+++ b/Userland/Applications/Calculator/main.cpp
@@ -35,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_resizable(false);
     window->resize(250, 215);
 
-    auto widget = TRY(window->try_set_main_widget<CalculatorWidget>());
+    auto widget = TRY(window->set_main_widget<CalculatorWidget>());
 
     window->set_icon(app_icon.bitmap_for_size(16));
 

--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -28,11 +28,11 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     set_resizable(false);
     set_icon(parent_window->icon());
 
-    auto& widget = set_main_widget<GUI::Widget>();
-    widget.set_fill_with_background_color(true);
-    widget.set_layout<GUI::VerticalBoxLayout>();
+    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    widget->set_fill_with_background_color(true);
+    widget->set_layout<GUI::VerticalBoxLayout>();
 
-    auto& top_container = widget.add<GUI::Widget>();
+    auto& top_container = widget->add<GUI::Widget>();
     top_container.set_layout<GUI::VerticalBoxLayout>();
     top_container.set_fixed_height(45);
     top_container.layout()->set_margins(4);
@@ -45,12 +45,12 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     auto& event_title_textbox = top_container.add<GUI::TextBox>();
     event_title_textbox.set_fixed_height(20);
 
-    auto& middle_container = widget.add<GUI::Widget>();
+    auto& middle_container = widget->add<GUI::Widget>();
     middle_container.set_layout<GUI::HorizontalBoxLayout>();
     middle_container.set_fixed_height(25);
     middle_container.layout()->set_margins(4);
 
-    auto& time_container = widget.add<GUI::Widget>();
+    auto& time_container = widget->add<GUI::Widget>();
     time_container.set_layout<GUI::HorizontalBoxLayout>();
     time_container.set_fixed_height(25);
     time_container.layout()->set_margins(4);
@@ -87,9 +87,9 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     starting_meridiem_combo.set_model(MeridiemListModel::create());
     starting_meridiem_combo.set_selected_index(0);
 
-    widget.layout()->add_spacer();
+    widget->layout()->add_spacer();
 
-    auto& button_container = widget.add<GUI::Widget>();
+    auto& button_container = widget->add<GUI::Widget>();
     button_container.set_fixed_height(20);
     button_container.set_layout<GUI::HorizontalBoxLayout>();
     button_container.layout()->add_spacer();

--- a/Userland/Applications/Calendar/main.cpp
+++ b/Userland/Applications/Calendar/main.cpp
@@ -42,7 +42,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(600, 480);
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->load_from_gml(calendar_window_gml);
 
     auto toolbar = main_widget->find_descendant_of_type_named<GUI::Toolbar>("toolbar");

--- a/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
@@ -86,8 +86,8 @@ CharacterMapWidget::CharacterMapWidget()
     m_find_glyphs_action = GUI::Action::create("&Find glyphs...", { Mod_Ctrl, Key_F }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/find.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         if (m_find_window.is_null()) {
             m_find_window = GUI::Window::construct(window());
-            auto& search_widget = m_find_window->set_main_widget<CharacterSearchWidget>();
-            search_widget.on_character_selected = [&](auto code_point) {
+            auto search_widget = m_find_window->set_main_widget<CharacterSearchWidget>().release_value_but_fixme_should_propagate_errors();
+            search_widget->on_character_selected = [&](auto code_point) {
                 m_glyph_map->set_active_glyph(code_point);
                 m_glyph_map->scroll_to_glyph(code_point);
             };

--- a/Userland/Applications/CharacterMap/main.cpp
+++ b/Userland/Applications/CharacterMap/main.cpp
@@ -68,7 +68,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(600, 400);
 
-    auto character_map_widget = TRY(window->try_set_main_widget<CharacterMapWidget>());
+    auto character_map_widget = TRY(window->set_main_widget<CharacterMapWidget>());
     character_map_widget->initialize_menubar(*window);
 
     auto font_query = Config::read_string("CharacterMap"sv, "History"sv, "Font"sv, Gfx::FontDatabase::the().default_font_query());

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -181,7 +181,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             unlink_coredump(coredump_path);
     };
 
-    auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto widget = TRY(window->set_main_widget<GUI::Widget>());
     widget->load_from_gml(crash_reporter_window_gml);
 
     auto& icon_image_widget = *widget->find_descendant_of_type_named<GUI::ImageWidget>("icon");

--- a/Userland/Applications/Escalator/EscalatorWindow.cpp
+++ b/Userland/Applications/Escalator/EscalatorWindow.cpp
@@ -31,10 +31,10 @@ EscalatorWindow::EscalatorWindow(StringView executable, Vector<StringView> argum
     set_resizable(false);
     set_minimizable(false);
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    main_widget.load_from_gml(escalator_gml);
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(escalator_gml);
 
-    RefPtr<GUI::Label> app_label = *main_widget.find_descendant_of_type_named<GUI::Label>("description");
+    RefPtr<GUI::Label> app_label = *main_widget->find_descendant_of_type_named<GUI::Label>("description");
 
     DeprecatedString prompt;
     if (options.description.is_empty())
@@ -44,10 +44,10 @@ EscalatorWindow::EscalatorWindow(StringView executable, Vector<StringView> argum
 
     app_label->set_text(prompt);
 
-    m_icon_image_widget = *main_widget.find_descendant_of_type_named<GUI::ImageWidget>("icon");
+    m_icon_image_widget = *main_widget->find_descendant_of_type_named<GUI::ImageWidget>("icon");
     m_icon_image_widget->set_bitmap(app_icon.bitmap_for_size(32));
 
-    m_ok_button = *main_widget.find_descendant_of_type_named<GUI::DialogButton>("ok_button");
+    m_ok_button = *main_widget->find_descendant_of_type_named<GUI::DialogButton>("ok_button");
     m_ok_button->on_click = [this](auto) {
         auto result = check_password();
         if (result.is_error()) {
@@ -57,12 +57,12 @@ EscalatorWindow::EscalatorWindow(StringView executable, Vector<StringView> argum
     };
     m_ok_button->set_default(true);
 
-    m_cancel_button = *main_widget.find_descendant_of_type_named<GUI::DialogButton>("cancel_button");
+    m_cancel_button = *main_widget->find_descendant_of_type_named<GUI::DialogButton>("cancel_button");
     m_cancel_button->on_click = [this](auto) {
         close();
     };
 
-    m_password_input = *main_widget.find_descendant_of_type_named<GUI::PasswordBox>("password");
+    m_password_input = *main_widget->find_descendant_of_type_named<GUI::PasswordBox>("password");
 }
 
 ErrorOr<void> EscalatorWindow::check_password()

--- a/Userland/Applications/FileManager/FileUtils.cpp
+++ b/Userland/Applications/FileManager/FileUtils.cpp
@@ -99,7 +99,7 @@ ErrorOr<void> run_file_operation(FileOperation operation, Vector<DeprecatedStrin
     auto pipe_input_file = TRY(Core::Stream::File::adopt_fd(pipe_fds[0], Core::Stream::OpenMode::Read));
     auto buffered_pipe = TRY(Core::Stream::BufferedFile::create(move(pipe_input_file)));
 
-    (void)TRY(window->try_set_main_widget<FileOperationProgressWidget>(operation, move(buffered_pipe), pipe_fds[0]));
+    (void)TRY(window->set_main_widget<FileOperationProgressWidget>(operation, move(buffered_pipe), pipe_fds[0]));
     window->resize(320, 190);
     if (parent_window)
         window->center_within(*parent_window);

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -31,18 +31,18 @@ PropertiesWindow::PropertiesWindow(DeprecatedString const& path, bool disable_re
 {
     auto lexical_path = LexicalPath(path);
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    main_widget.set_layout<GUI::VerticalBoxLayout>();
-    main_widget.layout()->set_spacing(6);
-    main_widget.layout()->set_margins(4);
-    main_widget.set_fill_with_background_color(true);
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    main_widget->set_layout<GUI::VerticalBoxLayout>();
+    main_widget->layout()->set_spacing(6);
+    main_widget->layout()->set_margins(4);
+    main_widget->set_fill_with_background_color(true);
 
     set_rect({ 0, 0, 360, 420 });
     set_resizable(false);
 
     set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/properties.png"sv).release_value_but_fixme_should_propagate_errors());
 
-    auto& tab_widget = main_widget.add<GUI::TabWidget>();
+    auto& tab_widget = main_widget->add<GUI::TabWidget>();
 
     auto& general_tab = tab_widget.add_tab<GUI::Widget>("General");
     general_tab.load_from_gml(properties_window_general_tab_gml);
@@ -142,7 +142,7 @@ PropertiesWindow::PropertiesWindow(DeprecatedString const& path, bool disable_re
     auto others_execute = general_tab.find_descendant_of_type_named<GUI::CheckBox>("others_execute");
     setup_permission_checkboxes(*others_read, *others_write, *others_execute, { S_IROTH, S_IWOTH, S_IXOTH }, m_mode);
 
-    auto& button_widget = main_widget.add<GUI::Widget>();
+    auto& button_widget = main_widget->add<GUI::Widget>();
     button_widget.set_layout<GUI::HorizontalBoxLayout>();
     button_widget.set_fixed_height(22);
     button_widget.layout()->set_spacing(5);

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -351,7 +351,7 @@ ErrorOr<int> run_in_desktop_mode()
     window->set_window_type(GUI::WindowType::Desktop);
     window->set_has_alpha_channel(true);
 
-    auto desktop_widget = TRY(window->try_set_main_widget<FileManager::DesktopWidget>());
+    auto desktop_widget = TRY(window->set_main_widget<FileManager::DesktopWidget>());
     (void)TRY(desktop_widget->try_set_layout<GUI::VerticalBoxLayout>());
 
     auto directory_view = TRY(desktop_widget->try_add<DirectoryView>(DirectoryView::Mode::Desktop));
@@ -579,7 +579,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
     auto height = Config::read_i32("FileManager"sv, "Window"sv, "Height"sv, 480);
     auto was_maximized = Config::read_bool("FileManager"sv, "Window"sv, "Maximized"sv, false);
 
-    auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto widget = TRY(window->set_main_widget<GUI::Widget>());
 
     widget->load_from_gml(file_manager_window_gml);
 

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -65,7 +65,7 @@ ErrorOr<RefPtr<GUI::Window>> MainWidget::create_preview_window()
     window->resize(400, 150);
     window->center_within(*this->window());
 
-    auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->load_from_gml(font_preview_window_gml);
 
     m_preview_label = find_descendant_of_type_named<GUI::Label>("preview_label");

--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(640, 470);
 
-    auto font_editor = TRY(window->try_set_main_widget<FontEditor::MainWidget>());
+    auto font_editor = TRY(window->set_main_widget<FontEditor::MainWidget>());
     TRY(font_editor->initialize_menubar(*window));
 
     if (path) {

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -61,7 +61,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Help");
     window->resize(570, 500);
 
-    auto main_widget = TRY(window->try_set_main_widget<MainWidget>());
+    auto main_widget = TRY(window->set_main_widget<MainWidget>());
     TRY(main_widget->initialize_fallibles(window));
     TRY(main_widget->set_start_page(query_parameters));
 

--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -99,16 +99,16 @@ FindDialog::FindDialog()
     set_resizable(false);
     set_title("Find");
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    if (!main_widget.load_from_gml(find_dialog_gml))
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    if (!main_widget->load_from_gml(find_dialog_gml))
         VERIFY_NOT_REACHED();
 
-    m_text_editor = *main_widget.find_descendant_of_type_named<GUI::TextBox>("text_editor");
-    m_find_button = *main_widget.find_descendant_of_type_named<GUI::Button>("find_button");
-    m_find_all_button = *main_widget.find_descendant_of_type_named<GUI::Button>("find_all_button");
-    m_cancel_button = *main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    m_text_editor = *main_widget->find_descendant_of_type_named<GUI::TextBox>("text_editor");
+    m_find_button = *main_widget->find_descendant_of_type_named<GUI::Button>("find_button");
+    m_find_all_button = *main_widget->find_descendant_of_type_named<GUI::Button>("find_all_button");
+    m_cancel_button = *main_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
 
-    auto& radio_container = *main_widget.find_descendant_of_type_named<GUI::Widget>("radio_container");
+    auto& radio_container = *main_widget->find_descendant_of_type_named<GUI::Widget>("radio_container");
     for (size_t i = 0; i < options.size(); i++) {
         auto action = options[i];
         auto& radio = radio_container.add<GUI::RadioButton>();

--- a/Userland/Applications/HexEditor/GoToOffsetDialog.cpp
+++ b/Userland/Applications/HexEditor/GoToOffsetDialog.cpp
@@ -96,15 +96,15 @@ GoToOffsetDialog::GoToOffsetDialog()
     set_resizable(false);
     set_title("Go to Offset");
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    if (!main_widget.load_from_gml(go_to_offset_dialog_gml))
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    if (!main_widget->load_from_gml(go_to_offset_dialog_gml))
         VERIFY_NOT_REACHED();
 
-    m_text_editor = *main_widget.find_descendant_of_type_named<GUI::TextBox>("text_editor");
-    m_go_button = *main_widget.find_descendant_of_type_named<GUI::Button>("go_button");
-    m_offset_type_box = *main_widget.find_descendant_of_type_named<GUI::ComboBox>("offset_type");
-    m_offset_from_box = *main_widget.find_descendant_of_type_named<GUI::ComboBox>("offset_from");
-    m_statusbar = *main_widget.find_descendant_of_type_named<GUI::Statusbar>("statusbar");
+    m_text_editor = *main_widget->find_descendant_of_type_named<GUI::TextBox>("text_editor");
+    m_go_button = *main_widget->find_descendant_of_type_named<GUI::Button>("go_button");
+    m_offset_type_box = *main_widget->find_descendant_of_type_named<GUI::ComboBox>("offset_type");
+    m_offset_from_box = *main_widget->find_descendant_of_type_named<GUI::ComboBox>("offset_from");
+    m_statusbar = *main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 
     m_offset_type.append("Decimal");
     m_offset_type.append("Hexadecimal");

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -35,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Hex Editor");
     window->resize(640, 400);
 
-    auto hex_editor_widget = TRY(window->try_set_main_widget<HexEditorWidget>());
+    auto hex_editor_widget = TRY(window->set_main_widget<HexEditorWidget>());
 
     window->on_close_request = [&]() -> GUI::Window::CloseRequestDecision {
         if (hex_editor_widget->request_close())

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -56,7 +56,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("Image Viewer");
 
-    auto root_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto root_widget = TRY(window->set_main_widget<GUI::Widget>());
     root_widget->set_fill_with_background_color(true);
     root_widget->set_layout<GUI::VerticalBoxLayout>();
     root_widget->layout()->set_spacing(2);

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = GUI::Window::construct();
     window->set_title("Keyboard Mapper");
     window->set_icon(app_icon.bitmap_for_size(16));
-    auto keyboard_mapper_widget = TRY(window->try_set_main_widget<KeyboardMapperWidget>());
+    auto keyboard_mapper_widget = TRY(window->set_main_widget<KeyboardMapperWidget>());
     window->resize(775, 315);
     window->set_resizable(false);
 

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -51,8 +51,8 @@ private:
     KeymapSelectionDialog(Window* parent_window, Vector<DeprecatedString> const& selected_keymaps)
         : Dialog(parent_window)
     {
-        auto& widget = set_main_widget<GUI::Widget>();
-        if (!widget.load_from_gml(keymap_dialog_gml))
+        auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+        if (!widget->load_from_gml(keymap_dialog_gml))
             VERIFY_NOT_REACHED();
 
         set_resizable(false);
@@ -77,7 +77,7 @@ private:
 
         m_selected_keymap = m_character_map_files.first();
 
-        m_keymaps_combobox = *widget.find_descendant_of_type_named<GUI::ComboBox>("keymaps_combobox");
+        m_keymaps_combobox = *widget->find_descendant_of_type_named<GUI::ComboBox>("keymaps_combobox");
         m_keymaps_combobox->set_only_allow_values_from_model(true);
         m_keymaps_combobox->set_model(*GUI::ItemListModel<DeprecatedString>::create(m_character_map_files));
         m_keymaps_combobox->set_selected_index(0);
@@ -86,12 +86,12 @@ private:
             m_selected_keymap = keymap;
         };
 
-        auto& ok_button = *widget.find_descendant_of_type_named<GUI::Button>("ok_button");
+        auto& ok_button = *widget->find_descendant_of_type_named<GUI::Button>("ok_button");
         ok_button.on_click = [this](auto) {
             done(ExecResult::OK);
         };
 
-        auto& cancel_button = *widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+        auto& cancel_button = *widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
         cancel_button.on_click = [this](auto) {
             done(ExecResult::Cancel);
         };

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -61,7 +61,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(window_dimensions, window_dimensions);
     window->set_minimizable(false);
     window->set_icon(app_icon.bitmap_for_size(16));
-    auto magnifier = TRY(window->try_set_main_widget<MagnifierWidget>());
+    auto magnifier = TRY(window->set_main_widget<MagnifierWidget>());
 
     auto file_menu = TRY(window->try_add_menu("&File"));
     TRY(file_menu->try_add_action(GUI::CommonActions::make_save_as_action([&](auto&) {

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -41,7 +41,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-mail"sv);
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto mail_widget = TRY(window->try_set_main_widget<MailWidget>());
+    auto mail_widget = TRY(window->set_main_widget<MailWidget>());
 
     window->set_title("Mail");
     window->resize(640, 400);

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto pdf_viewer_widget = TRY(window->try_set_main_widget<PDFViewerWidget>());
+    auto pdf_viewer_widget = TRY(window->set_main_widget<PDFViewerWidget>());
 
     pdf_viewer_widget->initialize_menubar(*window);
 

--- a/Userland/Applications/PartitionEditor/main.cpp
+++ b/Userland/Applications/PartitionEditor/main.cpp
@@ -52,7 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return Error::from_string_view(error_message);
     }
 
-    auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto widget = TRY(window->set_main_widget<GUI::Widget>());
     widget->load_from_gml(partition_editor_window_gml);
 
     auto device_paths = get_device_paths();

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -42,7 +42,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = GUI::Icon::default_icon("app-piano"sv);
     auto window = GUI::Window::construct();
-    auto main_widget = TRY(window->try_set_main_widget<MainWidget>(track_manager, audio_loop));
+    auto main_widget = TRY(window->set_main_widget<MainWidget>(track_manager, audio_loop));
     window->set_title("Piano");
     window->resize(840, 600);
     window->set_icon(app_icon.bitmap_for_size(16));

--- a/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
@@ -27,31 +27,31 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
     set_icon(parent_window->icon());
     resize(200, 220);
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    main_widget.set_fill_with_background_color(true);
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    main_widget->set_fill_with_background_color(true);
 
-    auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
+    auto& layout = main_widget->set_layout<GUI::VerticalBoxLayout>();
     layout.set_margins(4);
 
-    auto& name_label = main_widget.add<GUI::Label>("Name:");
+    auto& name_label = main_widget->add<GUI::Label>("Name:");
     name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
-    m_name_textbox = main_widget.add<GUI::TextBox>();
+    m_name_textbox = main_widget->add<GUI::TextBox>();
     m_name_textbox->on_change = [this] {
         m_image_name = m_name_textbox->text();
     };
     auto default_name = Config::read_string("PixelPaint"sv, "NewImage"sv, "Name"sv);
     m_name_textbox->set_text(default_name);
 
-    auto& width_label = main_widget.add<GUI::Label>("Width:");
+    auto& width_label = main_widget->add<GUI::Label>("Width:");
     width_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
-    auto& width_spinbox = main_widget.add<GUI::SpinBox>();
+    auto& width_spinbox = main_widget->add<GUI::SpinBox>();
 
-    auto& height_label = main_widget.add<GUI::Label>("Height:");
+    auto& height_label = main_widget->add<GUI::Label>("Height:");
     height_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
-    auto& height_spinbox = main_widget.add<GUI::SpinBox>();
+    auto& height_spinbox = main_widget->add<GUI::SpinBox>();
 
     enum class BackgroundIndex {
         Transparent = 0,
@@ -81,10 +81,10 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
         return BackgroundIndex::Custom;
     }();
 
-    auto& background_label = main_widget.add<GUI::Label>("Background:");
+    auto& background_label = main_widget->add<GUI::Label>("Background:");
     background_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
-    auto& background_color_combo = main_widget.add<GUI::ComboBox>();
-    auto& background_color_input = main_widget.add<GUI::ColorInput>();
+    auto& background_color_combo = main_widget->add<GUI::ComboBox>();
+    auto& background_color_input = main_widget->add<GUI::ColorInput>();
     background_color_input.set_visible(false);
     background_color_combo.set_only_allow_values_from_model(true);
     background_color_combo.set_model(*GUI::ItemListModel<StringView, decltype(suggested_backgrounds)>::create(suggested_backgrounds));
@@ -110,10 +110,10 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
         m_background_color = background_color_input.color();
     };
 
-    auto& set_defaults_checkbox = main_widget.add<GUI::CheckBox>();
+    auto& set_defaults_checkbox = main_widget->add<GUI::CheckBox>();
     set_defaults_checkbox.set_text("Use these settings as default");
 
-    auto& button_container = main_widget.add<GUI::Widget>();
+    auto& button_container = main_widget->add<GUI::Widget>();
     button_container.set_layout<GUI::HorizontalBoxLayout>();
 
     auto& ok_button = button_container.add<GUI::Button>("OK");

--- a/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
@@ -20,33 +20,33 @@ CreateNewLayerDialog::CreateNewLayerDialog(Gfx::IntSize suggested_size, GUI::Win
     set_icon(parent_window->icon());
     resize(200, 200);
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    main_widget.set_fill_with_background_color(true);
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    main_widget->set_fill_with_background_color(true);
 
-    auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
+    auto& layout = main_widget->set_layout<GUI::VerticalBoxLayout>();
     layout.set_margins(4);
 
-    auto& name_label = main_widget.add<GUI::Label>("Name:");
+    auto& name_label = main_widget->add<GUI::Label>("Name:");
     name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
-    m_name_textbox = main_widget.add<GUI::TextBox>();
+    m_name_textbox = main_widget->add<GUI::TextBox>();
     m_name_textbox->set_text("Layer"sv);
     m_name_textbox->select_all();
     m_name_textbox->on_change = [this] {
         m_layer_name = m_name_textbox->text();
     };
 
-    auto& width_label = main_widget.add<GUI::Label>("Width:");
+    auto& width_label = main_widget->add<GUI::Label>("Width:");
     width_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
-    auto& width_spinbox = main_widget.add<GUI::SpinBox>();
+    auto& width_spinbox = main_widget->add<GUI::SpinBox>();
 
-    auto& height_label = main_widget.add<GUI::Label>("Height:");
+    auto& height_label = main_widget->add<GUI::Label>("Height:");
     height_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
-    auto& height_spinbox = main_widget.add<GUI::SpinBox>();
+    auto& height_spinbox = main_widget->add<GUI::SpinBox>();
 
-    auto& button_container = main_widget.add<GUI::Widget>();
+    auto& button_container = main_widget->add<GUI::Widget>();
     button_container.set_layout<GUI::HorizontalBoxLayout>();
 
     auto& ok_button = button_container.add<GUI::Button>("OK");

--- a/Userland/Applications/PixelPaint/EditGuideDialog.cpp
+++ b/Userland/Applications/PixelPaint/EditGuideDialog.cpp
@@ -23,15 +23,15 @@ EditGuideDialog::EditGuideDialog(GUI::Window* parent_window, DeprecatedString co
     resize(200, 130);
     set_resizable(false);
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    if (!main_widget.load_from_gml(edit_guide_dialog_gml))
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    if (!main_widget->load_from_gml(edit_guide_dialog_gml))
         VERIFY_NOT_REACHED();
 
-    auto horizontal_radio = main_widget.find_descendant_of_type_named<GUI::RadioButton>("orientation_horizontal_radio");
-    auto vertical_radio = main_widget.find_descendant_of_type_named<GUI::RadioButton>("orientation_vertical_radio");
-    auto ok_button = main_widget.find_descendant_of_type_named<GUI::Button>("ok_button");
-    auto cancel_button = main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
-    m_offset_text_box = main_widget.find_descendant_of_type_named<GUI::TextBox>("offset_text_box");
+    auto horizontal_radio = main_widget->find_descendant_of_type_named<GUI::RadioButton>("orientation_horizontal_radio");
+    auto vertical_radio = main_widget->find_descendant_of_type_named<GUI::RadioButton>("orientation_vertical_radio");
+    auto ok_button = main_widget->find_descendant_of_type_named<GUI::Button>("ok_button");
+    auto cancel_button = main_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
+    m_offset_text_box = main_widget->find_descendant_of_type_named<GUI::TextBox>("offset_text_box");
 
     VERIFY(horizontal_radio);
     VERIFY(ok_button);

--- a/Userland/Applications/PixelPaint/FilterGallery.cpp
+++ b/Userland/Applications/PixelPaint/FilterGallery.cpp
@@ -21,15 +21,15 @@ FilterGallery::FilterGallery(GUI::Window* parent_window, ImageEditor* editor)
     resize(400, 250);
     set_resizable(true);
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    if (!main_widget.load_from_gml(filter_gallery_gml))
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    if (!main_widget->load_from_gml(filter_gallery_gml))
         VERIFY_NOT_REACHED();
 
-    m_filter_tree = main_widget.find_descendant_of_type_named<GUI::TreeView>("tree_view");
-    auto apply_button = main_widget.find_descendant_of_type_named<GUI::Button>("apply_button");
-    auto cancel_button = main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
-    m_config_widget = main_widget.find_descendant_of_type_named<GUI::Widget>("config_widget");
-    m_preview_widget = main_widget.find_descendant_of_type_named<FilterPreviewWidget>("preview_widget");
+    m_filter_tree = main_widget->find_descendant_of_type_named<GUI::TreeView>("tree_view");
+    auto apply_button = main_widget->find_descendant_of_type_named<GUI::Button>("apply_button");
+    auto cancel_button = main_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
+    m_config_widget = main_widget->find_descendant_of_type_named<GUI::Widget>("config_widget");
+    m_preview_widget = main_widget->find_descendant_of_type_named<FilterPreviewWidget>("preview_widget");
 
     VERIFY(m_filter_tree);
     VERIFY(apply_button);

--- a/Userland/Applications/PixelPaint/FilterParams.h
+++ b/Userland/Applications/PixelPaint/FilterParams.h
@@ -48,11 +48,11 @@ private:
         set_title(builder.string_view());
 
         resize(200, 250);
-        auto& main_widget = set_main_widget<GUI::Frame>();
-        main_widget.set_frame_shape(Gfx::FrameShape::Container);
-        main_widget.set_frame_shadow(Gfx::FrameShadow::Raised);
-        main_widget.set_fill_with_background_color(true);
-        auto& layout = main_widget.template set_layout<GUI::VerticalBoxLayout>();
+        auto main_widget = set_main_widget<GUI::Frame>().release_value_but_fixme_should_propagate_errors();
+        main_widget->set_frame_shape(Gfx::FrameShape::Container);
+        main_widget->set_frame_shadow(Gfx::FrameShadow::Raised);
+        main_widget->set_fill_with_background_color(true);
+        auto& layout = main_widget->template set_layout<GUI::VerticalBoxLayout>();
         layout.set_margins(4);
 
         size_t index = 0;
@@ -60,7 +60,7 @@ private:
         size_t rows = N;
 
         for (size_t row = 0; row < rows; ++row) {
-            auto& horizontal_container = main_widget.template add<GUI::Widget>();
+            auto& horizontal_container = main_widget->template add<GUI::Widget>();
             horizontal_container.template set_layout<GUI::HorizontalBoxLayout>();
             for (size_t column = 0; column < columns; ++column) {
                 if (index < columns * rows) {
@@ -81,13 +81,13 @@ private:
             }
         }
 
-        auto& norm_checkbox = main_widget.template add<GUI::CheckBox>("Normalize");
+        auto& norm_checkbox = main_widget->template add<GUI::CheckBox>("Normalize");
         norm_checkbox.set_checked(false);
 
-        auto& wrap_checkbox = main_widget.template add<GUI::CheckBox>("Wrap");
+        auto& wrap_checkbox = main_widget->template add<GUI::CheckBox>("Wrap");
         wrap_checkbox.set_checked(m_should_wrap);
 
-        auto& button = main_widget.template add<GUI::Button>("Done");
+        auto& button = main_widget->template add<GUI::Button>("Done");
         button.on_click = [&](auto) {
             m_should_wrap = wrap_checkbox.is_checked();
             if (norm_checkbox.is_checked())

--- a/Userland/Applications/PixelPaint/LevelsDialog.cpp
+++ b/Userland/Applications/PixelPaint/LevelsDialog.cpp
@@ -18,8 +18,8 @@ LevelsDialog::LevelsDialog(GUI::Window* parent_window, ImageEditor* editor)
     set_title("Levels");
     set_icon(parent_window->icon());
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    if (!main_widget.load_from_gml(levels_dialog_gml))
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    if (!main_widget->load_from_gml(levels_dialog_gml))
         VERIFY_NOT_REACHED();
 
     resize(305, 202);
@@ -27,12 +27,12 @@ LevelsDialog::LevelsDialog(GUI::Window* parent_window, ImageEditor* editor)
 
     m_editor = editor;
 
-    m_brightness_slider = main_widget.find_descendant_of_type_named<GUI::ValueSlider>("brightness_slider");
-    m_contrast_slider = main_widget.find_descendant_of_type_named<GUI::ValueSlider>("contrast_slider");
-    m_gamma_slider = main_widget.find_descendant_of_type_named<GUI::ValueSlider>("gamma_slider");
-    auto context_label = main_widget.find_descendant_of_type_named<GUI::Label>("context_label");
-    auto apply_button = main_widget.find_descendant_of_type_named<GUI::Button>("apply_button");
-    auto cancel_button = main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    m_brightness_slider = main_widget->find_descendant_of_type_named<GUI::ValueSlider>("brightness_slider");
+    m_contrast_slider = main_widget->find_descendant_of_type_named<GUI::ValueSlider>("contrast_slider");
+    m_gamma_slider = main_widget->find_descendant_of_type_named<GUI::ValueSlider>("gamma_slider");
+    auto context_label = main_widget->find_descendant_of_type_named<GUI::Label>("context_label");
+    auto apply_button = main_widget->find_descendant_of_type_named<GUI::Button>("apply_button");
+    auto cancel_button = main_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
 
     VERIFY(m_brightness_slider);
     VERIFY(m_contrast_slider);

--- a/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
@@ -27,13 +27,13 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize suggested_size, GUI::Window* p
     resize(260, 228);
     set_icon(parent_window->icon());
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    if (!main_widget.load_from_gml(resize_image_dialog_gml))
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    if (!main_widget->load_from_gml(resize_image_dialog_gml))
         VERIFY_NOT_REACHED();
 
-    auto width_spinbox = main_widget.find_descendant_of_type_named<GUI::SpinBox>("width_spinbox");
-    auto height_spinbox = main_widget.find_descendant_of_type_named<GUI::SpinBox>("height_spinbox");
-    auto keep_aspect_ratio_checkbox = main_widget.find_descendant_of_type_named<GUI::CheckBox>("keep_aspect_ratio_checkbox");
+    auto width_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("width_spinbox");
+    auto height_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("height_spinbox");
+    auto keep_aspect_ratio_checkbox = main_widget->find_descendant_of_type_named<GUI::CheckBox>("keep_aspect_ratio_checkbox");
 
     VERIFY(width_spinbox);
     VERIFY(height_spinbox);
@@ -67,10 +67,10 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize suggested_size, GUI::Window* p
         }
     };
 
-    auto nearest_neighbor_radio = main_widget.find_descendant_of_type_named<GUI::RadioButton>("nearest_neighbor_radio");
-    auto smooth_pixels_radio = main_widget.find_descendant_of_type_named<GUI::RadioButton>("smooth_pixels_radio");
-    auto bilinear_radio = main_widget.find_descendant_of_type_named<GUI::RadioButton>("bilinear_radio");
-    auto resize_canvas_radio = main_widget.find_descendant_of_type_named<GUI::RadioButton>("resize_canvas");
+    auto nearest_neighbor_radio = main_widget->find_descendant_of_type_named<GUI::RadioButton>("nearest_neighbor_radio");
+    auto smooth_pixels_radio = main_widget->find_descendant_of_type_named<GUI::RadioButton>("smooth_pixels_radio");
+    auto bilinear_radio = main_widget->find_descendant_of_type_named<GUI::RadioButton>("bilinear_radio");
+    auto resize_canvas_radio = main_widget->find_descendant_of_type_named<GUI::RadioButton>("resize_canvas");
 
     VERIFY(nearest_neighbor_radio);
     VERIFY(smooth_pixels_radio);
@@ -99,8 +99,8 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize suggested_size, GUI::Window* p
             m_scaling_mode = Gfx::Painter::ScalingMode::None;
     };
 
-    auto ok_button = main_widget.find_descendant_of_type_named<GUI::Button>("ok_button");
-    auto cancel_button = main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    auto ok_button = main_widget->find_descendant_of_type_named<GUI::Button>("ok_button");
+    auto cancel_button = main_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
 
     VERIFY(ok_button);
     VERIFY(cancel_button);

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -48,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(800, 510);
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto main_widget = TRY(window->try_set_main_widget<PixelPaint::MainWidget>());
+    auto main_widget = TRY(window->set_main_widget<PixelPaint::MainWidget>());
 
     TRY(main_widget->initialize_menubar(*window));
 

--- a/Userland/Applications/Presenter/main.cpp
+++ b/Userland/Applications/Presenter/main.cpp
@@ -26,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::Window::try_create());
     window->set_title("Presenter");
     window->set_icon(GUI::Icon::default_icon("app-display-settings"sv).bitmap_for_size(16));
-    auto main_widget = TRY(window->try_set_main_widget<PresenterWidget>());
+    auto main_widget = TRY(window->set_main_widget<PresenterWidget>());
     TRY(main_widget->initialize_menubar());
     window->show();
 

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -41,24 +41,24 @@ RunWindow::RunWindow()
     set_resizable(false);
     set_minimizable(false);
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    main_widget.load_from_gml(run_gml);
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(run_gml);
 
-    m_icon_image_widget = *main_widget.find_descendant_of_type_named<GUI::ImageWidget>("icon");
+    m_icon_image_widget = *main_widget->find_descendant_of_type_named<GUI::ImageWidget>("icon");
     m_icon_image_widget->set_bitmap(app_icon.bitmap_for_size(32));
 
-    m_path_combo_box = *main_widget.find_descendant_of_type_named<GUI::ComboBox>("path");
+    m_path_combo_box = *main_widget->find_descendant_of_type_named<GUI::ComboBox>("path");
     m_path_combo_box->set_model(m_path_history_model);
     if (!m_path_history.is_empty())
         m_path_combo_box->set_selected_index(0);
 
-    m_ok_button = *main_widget.find_descendant_of_type_named<GUI::DialogButton>("ok_button");
+    m_ok_button = *main_widget->find_descendant_of_type_named<GUI::DialogButton>("ok_button");
     m_ok_button->on_click = [this](auto) {
         do_run();
     };
     m_ok_button->set_default(true);
 
-    m_cancel_button = *main_widget.find_descendant_of_type_named<GUI::DialogButton>("cancel_button");
+    m_cancel_button = *main_widget->find_descendant_of_type_named<GUI::DialogButton>("cancel_button");
     m_cancel_button->on_click = [this](auto) {
         close();
     };

--- a/Userland/Applications/Settings/main.cpp
+++ b/Userland/Applications/Settings/main.cpp
@@ -102,7 +102,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(help_menu->try_add_action(GUI::CommonActions::make_command_palette_action(window)));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Settings", app_icon, window)));
 
-    auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>();
 

--- a/Userland/Applications/SoundPlayer/main.cpp
+++ b/Userland/Applications/SoundPlayer/main.cpp
@@ -48,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     // start in advanced view by default
-    Player* player = TRY(window->try_set_main_widget<SoundPlayerWidgetAdvancedView>(window, audio_client));
+    Player* player = TRY(window->set_main_widget<SoundPlayerWidgetAdvancedView>(window, audio_client));
 
     if (!file_path.is_empty()) {
         player->play_file_path(file_path);

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -141,14 +141,14 @@ static NonnullRefPtr<GUI::Window> create_progress_window()
     window->resize(240, 50);
     window->center_on_screen();
 
-    auto& main_widget = window->set_main_widget<GUI::Widget>();
-    main_widget.set_fill_with_background_color(true);
-    main_widget.set_layout<GUI::VerticalBoxLayout>();
+    auto main_widget = window->set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    main_widget->set_fill_with_background_color(true);
+    main_widget->set_layout<GUI::VerticalBoxLayout>();
 
-    auto& label = main_widget.add<GUI::Label>("Analyzing storage space...");
+    auto& label = main_widget->add<GUI::Label>("Analyzing storage space...");
     label.set_fixed_height(22);
 
-    auto& progresslabel = main_widget.add<GUI::Label>();
+    auto& progresslabel = main_widget->add<GUI::Label>();
     progresslabel.set_name("progresslabel");
     progresslabel.set_fixed_height(22);
 
@@ -321,11 +321,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     // Load widgets.
-    auto& mainwidget = window->set_main_widget<GUI::Widget>();
-    mainwidget.load_from_gml(space_analyzer_gml);
-    auto& breadcrumbbar = *mainwidget.find_descendant_of_type_named<GUI::Breadcrumbbar>("breadcrumbbar");
-    auto& treemapwidget = *mainwidget.find_descendant_of_type_named<SpaceAnalyzer::TreeMapWidget>("tree_map");
-    auto& statusbar = *mainwidget.find_descendant_of_type_named<GUI::Statusbar>("statusbar");
+    auto mainwidget = TRY(window->set_main_widget<GUI::Widget>());
+    mainwidget->load_from_gml(space_analyzer_gml);
+    auto& breadcrumbbar = *mainwidget->find_descendant_of_type_named<GUI::Breadcrumbbar>("breadcrumbbar");
+    auto& treemapwidget = *mainwidget->find_descendant_of_type_named<SpaceAnalyzer::TreeMapWidget>("tree_map");
+    auto& statusbar = *mainwidget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 
     treemapwidget.set_focus(true);
 

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -45,14 +45,14 @@ CellTypeDialog::CellTypeDialog(Vector<Position> const& positions, Sheet& sheet, 
     set_icon(parent->icon());
     resize(285, 360);
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    main_widget.set_layout<GUI::VerticalBoxLayout>().set_margins(4);
-    main_widget.set_fill_with_background_color(true);
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    main_widget->set_layout<GUI::VerticalBoxLayout>().set_margins(4);
+    main_widget->set_fill_with_background_color(true);
 
-    auto& tab_widget = main_widget.add<GUI::TabWidget>();
+    auto& tab_widget = main_widget->add<GUI::TabWidget>();
     setup_tabs(tab_widget, positions, sheet);
 
-    auto& buttonbox = main_widget.add<GUI::Widget>();
+    auto& buttonbox = main_widget->add<GUI::Widget>();
     buttonbox.set_shrink_to_fit(true);
     auto& button_layout = buttonbox.set_layout<GUI::HorizontalBoxLayout>();
     button_layout.set_spacing(10);

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -67,11 +67,11 @@ HelpWindow::HelpWindow(GUI::Window* parent)
     set_title("Spreadsheet Functions Help");
     set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-help.png"sv).release_value_but_fixme_should_propagate_errors());
 
-    auto& widget = set_main_widget<GUI::Widget>();
-    widget.set_layout<GUI::VerticalBoxLayout>();
-    widget.set_fill_with_background_color(true);
+    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    widget->set_layout<GUI::VerticalBoxLayout>();
+    widget->set_fill_with_background_color(true);
 
-    auto& splitter = widget.add<GUI::HorizontalSplitter>();
+    auto& splitter = widget->add<GUI::HorizontalSplitter>();
     auto& left_frame = splitter.add<GUI::Frame>();
     left_frame.set_layout<GUI::VerticalBoxLayout>();
     // FIXME: Get rid of the magic number, dynamically calculate initial size based on left frame contents
@@ -112,14 +112,14 @@ HelpWindow::HelpWindow(GUI::Window* parent)
             window->set_title(DeprecatedString::formatted("Spreadsheet Help - Example {} for {}", name, entry));
             window->on_close = [window = window.ptr()] { window->remove_from_parent(); };
 
-            auto& widget = window->set_main_widget<SpreadsheetWidget>(window, NonnullRefPtrVector<Sheet> {}, false);
-            auto sheet = Sheet::from_json(value.as_object(), widget.workbook());
+            auto widget = window->set_main_widget<SpreadsheetWidget>(window, NonnullRefPtrVector<Sheet> {}, false).release_value_but_fixme_should_propagate_errors();
+            auto sheet = Sheet::from_json(value.as_object(), widget->workbook());
             if (!sheet) {
                 GUI::MessageBox::show_error(this, DeprecatedString::formatted("Corrupted example '{}' in '{}'", name, url.path()));
                 return;
             }
 
-            widget.add_sheet(sheet.release_nonnull());
+            widget->add_sheet(sheet.release_nonnull());
             window->show();
         } else if (url.host() == "doc") {
             auto entry = LexicalPath::basename(url.path());

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -81,11 +81,11 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, NonnullRefPtrVe
     m_inline_documentation_window->set_rect(m_cell_value_editor->rect().translated(0, m_cell_value_editor->height() + 7).inflated(6, 6));
     m_inline_documentation_window->set_window_type(GUI::WindowType::Tooltip);
     m_inline_documentation_window->set_resizable(false);
-    auto& inline_widget = m_inline_documentation_window->set_main_widget<GUI::Frame>();
-    inline_widget.set_fill_with_background_color(true);
-    inline_widget.set_layout<GUI::VerticalBoxLayout>().set_margins(4);
-    inline_widget.set_frame_shape(Gfx::FrameShape::Box);
-    m_inline_documentation_label = inline_widget.add<GUI::Label>();
+    auto inline_widget = m_inline_documentation_window->set_main_widget<GUI::Frame>().release_value_but_fixme_should_propagate_errors();
+    inline_widget->set_fill_with_background_color(true);
+    inline_widget->set_layout<GUI::VerticalBoxLayout>().set_margins(4);
+    inline_widget->set_frame_shape(Gfx::FrameShape::Box);
+    m_inline_documentation_label = inline_widget->add<GUI::Label>();
     m_inline_documentation_label->set_fill_with_background_color(true);
     m_inline_documentation_label->set_autosize(false);
     m_inline_documentation_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -58,13 +58,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(640, 480);
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto& spreadsheet_widget = window->set_main_widget<Spreadsheet::SpreadsheetWidget>(*window, NonnullRefPtrVector<Spreadsheet::Sheet> {}, filename == nullptr);
+    auto spreadsheet_widget = TRY(window->set_main_widget<Spreadsheet::SpreadsheetWidget>(*window, NonnullRefPtrVector<Spreadsheet::Sheet> {}, filename == nullptr));
 
-    spreadsheet_widget.initialize_menubar(*window);
-    spreadsheet_widget.update_window_title();
+    spreadsheet_widget->initialize_menubar(*window);
+    spreadsheet_widget->update_window_title();
 
     window->on_close_request = [&]() -> GUI::Window::CloseRequestDecision {
-        if (spreadsheet_widget.request_close())
+        if (spreadsheet_widget->request_close())
             return GUI::Window::CloseRequestDecision::Close;
         return GUI::Window::CloseRequestDecision::StayOpen;
     };
@@ -73,7 +73,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (filename) {
         auto file = TRY(FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, filename));
-        spreadsheet_widget.load_file(file);
+        spreadsheet_widget->load_file(file);
     }
 
     return app->exec();

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -278,7 +278,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("System Monitor");
     window->resize(560, 430);
 
-    auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->load_from_gml(system_monitor_gml);
     auto& tabwidget = *main_widget->find_descendant_of_type_named<GUI::TabWidget>("main_tabs");
     statusbar = main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
@@ -512,7 +512,7 @@ ErrorOr<NonnullRefPtr<GUI::Window>> build_process_window(pid_t pid)
     auto app_icon = GUI::Icon::default_icon("app-system-monitor"sv);
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->load_from_gml(process_window_gml);
 
     GUI::ModelIndex process_index;

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -172,7 +172,7 @@ static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget
     window->set_resizable(false);
     window->resize(300, 90);
 
-    auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
     main_widget->set_background_role(ColorRole::Button);
     (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
@@ -291,7 +291,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Terminal");
     window->set_obey_widget_min_size(false);
 
-    auto terminal = TRY(window->try_set_main_widget<VT::TerminalWidget>(ptm_fd, true));
+    auto terminal = TRY(window->set_main_widget<VT::TerminalWidget>(ptm_fd, true));
     terminal->on_command_exit = [&] {
         app->quit(0);
     };

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::Window::try_create());
     window->resize(640, 400);
 
-    auto text_widget = TRY(window->try_set_main_widget<MainWidget>());
+    auto text_widget = TRY(window->set_main_widget<MainWidget>());
 
     text_widget->editor().set_focus(true);
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -47,7 +47,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-theme-editor"sv);
     auto window = GUI::Window::construct();
 
-    auto main_widget = TRY(window->try_set_main_widget<ThemeEditor::MainWidget>());
+    auto main_widget = TRY(window->set_main_widget<ThemeEditor::MainWidget>());
 
     if (path.has_value()) {
         // Note: This is deferred to ensure that the window has already popped and thus proper window stealing can be performed.

--- a/Userland/Applications/VideoPlayer/main.cpp
+++ b/Userland/Applications/VideoPlayer/main.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(640, 480);
     window->set_resizable(true);
 
-    auto main_widget = TRY(window->try_set_main_widget<VideoPlayer::VideoPlayerWidget>(window));
+    auto main_widget = TRY(window->set_main_widget<VideoPlayer::VideoPlayerWidget>(window));
     main_widget->update_title();
     main_widget->initialize_menubar(window);
 

--- a/Userland/Applications/Welcome/main.cpp
+++ b/Userland/Applications/Welcome/main.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->center_on_screen();
     window->set_title("Welcome");
     window->set_icon(app_icon.bitmap_for_size(16));
-    auto welcome_widget = TRY(window->try_set_main_widget<WelcomeWidget>());
+    auto welcome_widget = TRY(window->set_main_widget<WelcomeWidget>());
 
     window->show();
 

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -62,7 +62,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     advice_window->set_has_alpha_channel(true);
     advice_window->set_alpha_hit_threshold(1.0f);
 
-    auto advice_widget = TRY(advice_window->try_set_main_widget<SpeechBubble>(catdog_widget));
+    auto advice_widget = TRY(advice_window->set_main_widget<SpeechBubble>(catdog_widget));
     (void)TRY(advice_widget->try_set_layout<GUI::VerticalBoxLayout>());
     advice_widget->layout()->set_spacing(0);
 

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -97,7 +97,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Eyes Demo", app_icon, window)));
 
-    auto eyes_widget = TRY(window->try_set_main_widget<EyesWidget>(num_eyes, full_rows, extra_columns));
+    auto eyes_widget = TRY(window->set_main_widget<EyesWidget>(num_eyes, full_rows, extra_columns));
     eyes_widget->on_context_menu_request = [&](auto& event) {
         file_menu->popup(event.screen_position());
     };

--- a/Userland/Demos/GradientScreensaver/GradientScreensaver.cpp
+++ b/Userland/Demos/GradientScreensaver/GradientScreensaver.cpp
@@ -97,7 +97,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(Desktop::Screensaver::create_window("Screensaver"sv, "app-screensaver"sv));
 
-    auto screensaver_window = TRY(window->try_set_main_widget<Screensaver>(64, 48, 10000));
+    auto screensaver_window = TRY(window->set_main_widget<Screensaver>(64, 48, 10000));
     screensaver_window->set_fill_with_background_color(false);
     screensaver_window->set_override_cursor(Gfx::StandardCursor::Hidden);
     screensaver_window->update();

--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -200,7 +200,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-libgfx-demo"sv));
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->try_set_main_widget<Canvas>());
+    (void)TRY(window->set_main_widget<Canvas>());
     window->show();
 
     return app->exec();

--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -121,7 +121,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-libgfx-demo"sv));
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->try_set_main_widget<Canvas>());
+    (void)TRY(window->set_main_widget<Canvas>());
     window->show();
 
     return app->exec();

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -413,7 +413,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_obey_widget_min_size(false);
     window->set_minimum_size(320, 240);
     window->resize(window->minimum_size() * 2);
-    auto mandelbrot = TRY(window->try_set_main_widget<Mandelbrot>());
+    auto mandelbrot = TRY(window->set_main_widget<Mandelbrot>());
 
     auto file_menu = TRY(window->try_add_menu("&File"));
 

--- a/Userland/Demos/ModelGallery/main.cpp
+++ b/Userland/Demos/ModelGallery/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Model Gallery");
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(430, 480);
-    (void)TRY(window->try_set_main_widget<GalleryWidget>());
+    (void)TRY(window->set_main_widget<GalleryWidget>());
 
     window->show();
     return app->exec();

--- a/Userland/Demos/Screensaver/main.cpp
+++ b/Userland/Demos/Screensaver/main.cpp
@@ -86,7 +86,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(help_menu->try_add_action(GUI::CommonActions::make_command_palette_action(window)));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Screensaver", app_icon, window)));
 
-    auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>();
 

--- a/Userland/Demos/Starfield/Starfield.cpp
+++ b/Userland/Demos/Starfield/Starfield.cpp
@@ -167,7 +167,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(Desktop::Screensaver::create_window("Starfield"sv, "app-starfield"sv));
 
-    auto starfield_window = TRY(window->try_set_main_widget<Starfield>(refresh_rate));
+    auto starfield_window = TRY(window->set_main_widget<Starfield>(refresh_rate));
     starfield_window->set_fill_with_background_color(false);
     starfield_window->set_override_cursor(Gfx::StandardCursor::Hidden);
     starfield_window->update();

--- a/Userland/Demos/Tubes/main.cpp
+++ b/Userland/Demos/Tubes/main.cpp
@@ -30,7 +30,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(Desktop::Screensaver::create_window("Tubes"sv, "app-tubes"sv));
     window->update();
 
-    auto tubes_widget = TRY(window->try_set_main_widget<Tubes>(refresh_rate));
+    auto tubes_widget = TRY(window->set_main_widget<Tubes>(refresh_rate));
     tubes_widget->set_fill_with_background_color(false);
     tubes_widget->set_override_cursor(Gfx::StandardCursor::Hidden);
     window->show();

--- a/Userland/Demos/WidgetGallery/main.cpp
+++ b/Userland/Demos/WidgetGallery/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(430, 480);
     window->set_title("Widget Gallery");
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->try_set_main_widget<GalleryWidget>());
+    (void)TRY(window->set_main_widget<GalleryWidget>());
     window->show();
 
     return app->exec();

--- a/Userland/DevTools/GMLPlayground/main.cpp
+++ b/Userland/DevTools/GMLPlayground/main.cpp
@@ -84,14 +84,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(800, 600);
 
-    auto splitter = TRY(window->try_set_main_widget<GUI::HorizontalSplitter>());
+    auto splitter = TRY(window->set_main_widget<GUI::HorizontalSplitter>());
     auto editor = TRY(splitter->try_add<GUI::TextEditor>());
     auto preview_frame_widget = TRY(splitter->try_add<GUI::Frame>());
 
     auto preview_window = TRY(GUI::Window::try_create());
     preview_window->set_title("Preview - GML Playground");
     preview_window->set_icon(app_icon.bitmap_for_size(16));
-    auto preview_window_widget = TRY(preview_window->try_set_main_widget<GUI::Widget>());
+    auto preview_window_widget = TRY(preview_window->set_main_widget<GUI::Widget>());
     preview_window_widget->set_fill_with_background_color(true);
 
     GUI::Widget* preview = preview_frame_widget;

--- a/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.cpp
@@ -17,13 +17,13 @@ GitCommitDialog::GitCommitDialog(GUI::Window* parent)
     set_title("Commit");
     set_icon(parent->icon());
 
-    auto& widget = set_main_widget<GUI::Widget>();
-    widget.load_from_gml(git_commit_dialog_gml);
+    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    widget->load_from_gml(git_commit_dialog_gml);
 
-    m_message_editor = widget.find_descendant_of_type_named<GUI::TextEditor>("message_editor");
-    m_cancel_button = widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
-    m_commit_button = widget.find_descendant_of_type_named<GUI::Button>("commit_button");
-    m_line_and_col_label = widget.find_descendant_of_type_named<GUI::Label>("line_and_col_label");
+    m_message_editor = widget->find_descendant_of_type_named<GUI::TextEditor>("message_editor");
+    m_cancel_button = widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
+    m_commit_button = widget->find_descendant_of_type_named<GUI::Button>("commit_button");
+    m_line_and_col_label = widget->find_descendant_of_type_named<GUI::Label>("line_and_col_label");
 
     m_message_editor->on_change = [this]() {
         m_commit_button->set_enabled(!m_message_editor->text().is_empty() && on_commit);

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
@@ -49,10 +49,10 @@ NewProjectDialog::NewProjectDialog(GUI::Window* parent)
     set_resizable(false);
     set_title("New project");
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    main_widget.load_from_gml(new_project_dialog_gml);
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(new_project_dialog_gml);
 
-    m_icon_view_container = *main_widget.find_descendant_of_type_named<GUI::Widget>("icon_view_container");
+    m_icon_view_container = *main_widget->find_descendant_of_type_named<GUI::Widget>("icon_view_container");
     m_icon_view = m_icon_view_container->add<GUI::IconView>();
     m_icon_view->set_always_wrap_item_labels(true);
     m_icon_view->set_model(m_model);
@@ -65,24 +65,24 @@ NewProjectDialog::NewProjectDialog(GUI::Window* parent)
             do_create_project();
     };
 
-    m_description_label = *main_widget.find_descendant_of_type_named<GUI::Label>("description_label");
-    m_name_input = *main_widget.find_descendant_of_type_named<GUI::TextBox>("name_input");
+    m_description_label = *main_widget->find_descendant_of_type_named<GUI::Label>("description_label");
+    m_name_input = *main_widget->find_descendant_of_type_named<GUI::TextBox>("name_input");
     m_name_input->on_change = [&]() {
         update_dialog();
     };
-    m_create_in_input = *main_widget.find_descendant_of_type_named<GUI::TextBox>("create_in_input");
+    m_create_in_input = *main_widget->find_descendant_of_type_named<GUI::TextBox>("create_in_input");
     m_create_in_input->on_change = [&]() {
         update_dialog();
     };
-    m_full_path_label = *main_widget.find_descendant_of_type_named<GUI::Label>("full_path_label");
+    m_full_path_label = *main_widget->find_descendant_of_type_named<GUI::Label>("full_path_label");
 
-    m_ok_button = *main_widget.find_descendant_of_type_named<GUI::Button>("ok_button");
+    m_ok_button = *main_widget->find_descendant_of_type_named<GUI::Button>("ok_button");
     m_ok_button->set_default(true);
     m_ok_button->on_click = [this](auto) {
         do_create_project();
     };
 
-    m_cancel_button = *main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    m_cancel_button = *main_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
     m_cancel_button->on_click = [this](auto) {
         done(ExecResult::Cancel);
     };

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -94,7 +94,7 @@ ErrorOr<void> Editor::initialize_tooltip_window()
         s_tooltip_window->set_window_type(GUI::WindowType::Tooltip);
     }
     if (s_tooltip_page_view.is_null()) {
-        s_tooltip_page_view = TRY(s_tooltip_window->try_set_main_widget<WebView::OutOfProcessWebView>());
+        s_tooltip_page_view = TRY(s_tooltip_window->set_main_widget<WebView::OutOfProcessWebView>());
     }
     return {};
 }

--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -149,7 +149,7 @@ Locator::Locator(Core::Object* parent)
     m_popup_window->set_window_type(GUI::WindowType::Popup);
     m_popup_window->set_rect(0, 0, 500, 200);
 
-    m_suggestion_view = m_popup_window->set_main_widget<GUI::TableView>();
+    m_suggestion_view = m_popup_window->set_main_widget<GUI::TableView>().release_value_but_fixme_should_propagate_errors();
     m_suggestion_view->set_column_headers_visible(false);
 
     m_suggestion_view->on_activation = [this](auto& index) {

--- a/Userland/DevTools/Inspector/main.cpp
+++ b/Userland/DevTools/Inspector/main.cpp
@@ -99,7 +99,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }));
     help_menu.add_action(GUI::CommonActions::make_about_action("Inspector", app_icon, window));
 
-    auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto widget = TRY(window->set_main_widget<GUI::Widget>());
     widget->set_fill_with_background_color(true);
     widget->set_layout<GUI::VerticalBoxLayout>();
 

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -86,7 +86,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(800, 600);
 
-    auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>();
 
@@ -318,19 +318,19 @@ static bool prompt_to_stop_profiling(pid_t pid, DeprecatedString const& process_
     window->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-profiler.png"sv).release_value_but_fixme_should_propagate_errors());
     window->center_on_screen();
 
-    auto& widget = window->set_main_widget<GUI::Widget>();
-    widget.set_fill_with_background_color(true);
-    auto& layout = widget.set_layout<GUI::VerticalBoxLayout>();
+    auto widget = window->set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    widget->set_fill_with_background_color(true);
+    auto& layout = widget->set_layout<GUI::VerticalBoxLayout>();
     layout.set_margins({ 0, 0, 16 });
 
-    auto& timer_label = widget.add<GUI::Label>("...");
+    auto& timer_label = widget->add<GUI::Label>("...");
     Core::ElapsedTimer clock;
     clock.start();
     auto update_timer = Core::Timer::construct(100, [&] {
         timer_label.set_text(DeprecatedString::formatted("{:.1} seconds", clock.elapsed() / 1000.0f));
     });
 
-    auto& stop_button = widget.add<GUI::Button>("Stop");
+    auto& stop_button = widget->add<GUI::Button>("Stop");
     stop_button.set_fixed_size(140, 22);
     stop_button.on_click = [&](auto) {
         GUI::Application::the()->quit();

--- a/Userland/DevTools/SQLStudio/main.cpp
+++ b/Userland/DevTools/SQLStudio/main.cpp
@@ -30,7 +30,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("SQL Studio");
 
-    auto main_widget = TRY(window->try_set_main_widget<MainWidget>());
+    auto main_widget = TRY(window->set_main_widget<MainWidget>());
     main_widget->initialize_menu(window);
 
     window->on_close_request = [&] {

--- a/Userland/Games/2048/GameSizeDialog.cpp
+++ b/Userland/Games/2048/GameSizeDialog.cpp
@@ -25,16 +25,16 @@ GameSizeDialog::GameSizeDialog(GUI::Window* parent, size_t board_size, size_t ta
     set_icon(parent->icon());
     set_resizable(false);
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    if (!main_widget.load_from_gml(game_size_dialog_gml))
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    if (!main_widget->load_from_gml(game_size_dialog_gml))
         VERIFY_NOT_REACHED();
 
-    auto board_size_spinbox = main_widget.find_descendant_of_type_named<GUI::SpinBox>("board_size_spinbox");
+    auto board_size_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("board_size_spinbox");
     board_size_spinbox->set_value(m_board_size);
 
-    auto tile_value_label = main_widget.find_descendant_of_type_named<GUI::Label>("tile_value_label");
+    auto tile_value_label = main_widget->find_descendant_of_type_named<GUI::Label>("tile_value_label");
     tile_value_label->set_text(DeprecatedString::number(target_tile()));
-    auto target_spinbox = main_widget.find_descendant_of_type_named<GUI::SpinBox>("target_spinbox");
+    auto target_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("target_spinbox");
     target_spinbox->set_max(Game::max_power_for_board(m_board_size));
     target_spinbox->set_value(m_target_tile_power);
 
@@ -48,20 +48,20 @@ GameSizeDialog::GameSizeDialog(GUI::Window* parent, size_t board_size, size_t ta
         tile_value_label->set_text(DeprecatedString::number(target_tile()));
     };
 
-    auto evil_ai_checkbox = main_widget.find_descendant_of_type_named<GUI::CheckBox>("evil_ai_checkbox");
+    auto evil_ai_checkbox = main_widget->find_descendant_of_type_named<GUI::CheckBox>("evil_ai_checkbox");
     evil_ai_checkbox->set_checked(m_evil_ai);
     evil_ai_checkbox->on_checked = [this](auto checked) { m_evil_ai = checked; };
 
-    auto temporary_checkbox = main_widget.find_descendant_of_type_named<GUI::CheckBox>("temporary_checkbox");
+    auto temporary_checkbox = main_widget->find_descendant_of_type_named<GUI::CheckBox>("temporary_checkbox");
     temporary_checkbox->set_checked(m_temporary);
     temporary_checkbox->on_checked = [this](auto checked) { m_temporary = checked; };
 
-    auto cancel_button = main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    auto cancel_button = main_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
     cancel_button->on_click = [this](auto) {
         done(ExecResult::Cancel);
     };
 
-    auto ok_button = main_widget.find_descendant_of_type_named<GUI::Button>("ok_button");
+    auto ok_button = main_widget->find_descendant_of_type_named<GUI::Button>("ok_button");
     ok_button->on_click = [this](auto) {
         done(ExecResult::OK);
     };

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -66,15 +66,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("2048");
     window->resize(315, 336);
 
-    auto& main_widget = window->set_main_widget<GUI::Widget>();
-    if (!main_widget.load_from_gml(game_window_gml))
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    if (!main_widget->load_from_gml(game_window_gml))
         VERIFY_NOT_REACHED();
 
     Game game { board_size, target_tile, evil_ai };
 
-    auto board_view = TRY(main_widget.find_descendant_of_type_named<GUI::Widget>("board_view_container")->try_add<BoardView>(&game.board()));
+    auto board_view = TRY(main_widget->find_descendant_of_type_named<GUI::Widget>("board_view_container")->try_add<BoardView>(&game.board()));
     board_view->set_focus(true);
-    auto statusbar = main_widget.find_descendant_of_type_named<GUI::Statusbar>("statusbar");
+    auto statusbar = main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 
     app->on_action_enter = [&](GUI::Action& action) {
         auto text = action.status_tip();

--- a/Userland/Games/BrickGame/main.cpp
+++ b/Userland/Games/BrickGame/main.cpp
@@ -49,7 +49,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(360, 462);
     window->set_resizable(false);
 
-    auto game = TRY(window->try_set_main_widget<BrickGame>(app_name));
+    auto game = TRY(window->set_main_widget<BrickGame>(app_name));
 
     auto game_menu = TRY(window->try_add_menu("&Game"));
 

--- a/Userland/Games/Chess/PromotionDialog.cpp
+++ b/Userland/Games/Chess/PromotionDialog.cpp
@@ -17,13 +17,13 @@ PromotionDialog::PromotionDialog(ChessWidget& chess_widget)
     set_icon(chess_widget.window()->icon());
     resize(70 * 4, 70);
 
-    auto& main_widget = set_main_widget<GUI::Frame>();
-    main_widget.set_frame_shape(Gfx::FrameShape::Container);
-    main_widget.set_fill_with_background_color(true);
-    main_widget.set_layout<GUI::HorizontalBoxLayout>();
+    auto main_widget = set_main_widget<GUI::Frame>().release_value_but_fixme_should_propagate_errors();
+    main_widget->set_frame_shape(Gfx::FrameShape::Container);
+    main_widget->set_fill_with_background_color(true);
+    main_widget->set_layout<GUI::HorizontalBoxLayout>();
 
     for (auto const& type : { Chess::Type::Queen, Chess::Type::Knight, Chess::Type::Rook, Chess::Type::Bishop }) {
-        auto& button = main_widget.add<GUI::Button>("");
+        auto& button = main_widget->add<GUI::Button>("");
         button.set_fixed_height(70);
         button.set_icon(chess_widget.get_piece_graphic({ chess_widget.board().turn(), type }));
         button.on_click = [this, type](auto) {

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-chess"sv));
 
     auto window = TRY(GUI::Window::try_create());
-    auto widget = TRY(window->try_set_main_widget<ChessWidget>());
+    auto widget = TRY(window->set_main_widget<ChessWidget>());
 
     TRY(Core::System::unveil("/sys/kernel/processes", "r"));
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Games/ColorLines/main.cpp
+++ b/Userland/Games/ColorLines/main.cpp
@@ -48,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(436, 481);
     window->set_resizable(false);
 
-    auto game = TRY(window->try_set_main_widget<ColorLines>(app_name));
+    auto game = TRY(window->set_main_widget<ColorLines>(app_name));
 
     auto game_menu = TRY(window->try_add_menu("&Game"));
 

--- a/Userland/Games/FlappyBug/main.cpp
+++ b/Userland/Games/FlappyBug/main.cpp
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Flappy Bug");
     window->set_double_buffering_enabled(false);
     window->set_resizable(false);
-    auto widget = TRY(window->try_set_main_widget<FlappyBug::Game>(TRY(FlappyBug::Game::Bug::construct()), TRY(FlappyBug::Game::Cloud::construct())));
+    auto widget = TRY(window->set_main_widget<FlappyBug::Game>(TRY(FlappyBug::Game::Bug::construct()), TRY(FlappyBug::Game::Cloud::construct())));
 
     widget->on_game_end = [&](u32 score) {
         if (score <= high_score)

--- a/Userland/Games/Flood/SettingsDialog.cpp
+++ b/Userland/Games/Flood/SettingsDialog.cpp
@@ -27,30 +27,30 @@ SettingsDialog::SettingsDialog(GUI::Window* parent, size_t board_rows, size_t bo
     set_icon(parent->icon());
     set_resizable(false);
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    if (!main_widget.load_from_gml(settings_dialog_gml))
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    if (!main_widget->load_from_gml(settings_dialog_gml))
         VERIFY_NOT_REACHED();
 
-    auto board_rows_spinbox = main_widget.find_descendant_of_type_named<GUI::SpinBox>("board_rows_spinbox");
+    auto board_rows_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("board_rows_spinbox");
     board_rows_spinbox->set_value(m_board_rows);
 
     board_rows_spinbox->on_change = [&](auto value) {
         m_board_rows = value;
     };
 
-    auto board_columns_spinbox = main_widget.find_descendant_of_type_named<GUI::SpinBox>("board_columns_spinbox");
+    auto board_columns_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("board_columns_spinbox");
     board_columns_spinbox->set_value(m_board_columns);
 
     board_columns_spinbox->on_change = [&](auto value) {
         m_board_columns = value;
     };
 
-    auto cancel_button = main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    auto cancel_button = main_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
     cancel_button->on_click = [this](auto) {
         done(ExecResult::Cancel);
     };
 
-    auto ok_button = main_widget.find_descendant_of_type_named<GUI::Button>("ok_button");
+    auto ok_button = main_widget->find_descendant_of_type_named<GUI::Button>("ok_button");
     ok_button->on_click = [this](auto) {
         done(ExecResult::OK);
     };

--- a/Userland/Games/Flood/main.cpp
+++ b/Userland/Games/Flood/main.cpp
@@ -82,16 +82,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Flood");
     window->resize(304, 325);
 
-    auto& main_widget = window->set_main_widget<GUI::Widget>();
-    if (!main_widget.load_from_gml(flood_window_gml))
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    if (!main_widget->load_from_gml(flood_window_gml))
         VERIFY_NOT_REACHED();
 
-    auto board_widget = TRY(main_widget.find_descendant_of_type_named<GUI::Widget>("board_widget_container")->try_add<BoardWidget>(board_rows, board_columns));
+    auto board_widget = TRY(main_widget->find_descendant_of_type_named<GUI::Widget>("board_widget_container")->try_add<BoardWidget>(board_rows, board_columns));
     board_widget->board()->randomize();
     int ai_moves = get_number_of_moves_from_ai(*board_widget->board());
     int moves_made = 0;
 
-    auto statusbar = main_widget.find_descendant_of_type_named<GUI::Statusbar>("statusbar");
+    auto statusbar = main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 
     app->on_action_enter = [&](GUI::Action& action) {
         auto text = action.status_tip();

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -52,7 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_double_buffering_enabled(false);
     window->set_title("Game Of Life");
 
-    auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->load_from_gml(game_of_life_gml);
     main_widget->set_fill_with_background_color(true);
 

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -122,16 +122,16 @@ void Game::show_score_card(bool game_over)
     score_dialog->set_resizable(false);
     score_dialog->set_icon(window()->icon());
 
-    auto& score_widget = score_dialog->set_main_widget<GUI::Widget>();
-    score_widget.set_fill_with_background_color(true);
-    auto& layout = score_widget.set_layout<GUI::HorizontalBoxLayout>();
+    auto score_widget = score_dialog->set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    score_widget->set_fill_with_background_color(true);
+    auto& layout = score_widget->set_layout<GUI::HorizontalBoxLayout>();
     layout.set_margins(10);
     layout.set_spacing(15);
 
-    auto& card_container = score_widget.add<GUI::Widget>();
+    auto& card_container = score_widget->add<GUI::Widget>();
     auto& score_card = card_container.add<ScoreCard>(m_players, game_over);
 
-    auto& button_container = score_widget.add<GUI::Widget>();
+    auto& button_container = score_widget->add<GUI::Widget>();
     button_container.set_shrink_to_fit(true);
     button_container.set_layout<GUI::VerticalBoxLayout>();
 

--- a/Userland/Games/Hearts/SettingsDialog.cpp
+++ b/Userland/Games/Hearts/SettingsDialog.cpp
@@ -19,13 +19,13 @@ SettingsDialog::SettingsDialog(GUI::Window* parent, DeprecatedString player_name
     set_icon(parent->icon());
     set_resizable(false);
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    main_widget.set_fill_with_background_color(true);
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    main_widget->set_fill_with_background_color(true);
 
-    auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
+    auto& layout = main_widget->set_layout<GUI::VerticalBoxLayout>();
     layout.set_margins(4);
 
-    auto& name_box = main_widget.add<GUI::Widget>();
+    auto& name_box = main_widget->add<GUI::Widget>();
     auto& input_layout = name_box.set_layout<GUI::HorizontalBoxLayout>();
     input_layout.set_spacing(4);
 
@@ -38,7 +38,7 @@ SettingsDialog::SettingsDialog(GUI::Window* parent, DeprecatedString player_name
         m_player_name = textbox.text();
     };
 
-    auto& button_box = main_widget.add<GUI::Widget>();
+    auto& button_box = main_widget->add<GUI::Widget>();
     auto& button_layout = button_box.set_layout<GUI::HorizontalBoxLayout>();
     button_layout.set_spacing(10);
 

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -50,7 +50,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::Window::try_create());
     window->set_title("Hearts");
 
-    auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto widget = TRY(window->set_main_widget<GUI::Widget>());
     widget->load_from_gml(hearts_gml);
 
     auto& game = *widget->find_descendant_of_type_named<Hearts::Game>("game");

--- a/Userland/Games/MasterWord/main.cpp
+++ b/Userland/Games/MasterWord/main.cpp
@@ -46,7 +46,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("MasterWord");
     window->set_resizable(false);
 
-    auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->load_from_gml(master_word_gml);
     auto& game = *main_widget->find_descendant_of_type_named<MasterWord::WordGame>("word_game");
     auto& statusbar = *main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");

--- a/Userland/Games/Minesweeper/CustomGameDialog.cpp
+++ b/Userland/Games/Minesweeper/CustomGameDialog.cpp
@@ -45,15 +45,15 @@ CustomGameDialog::CustomGameDialog(Window* parent_window)
     set_resizable(false);
     set_title("Custom game");
 
-    auto& main_widget = set_main_widget<GUI::Widget>();
-    if (!main_widget.load_from_gml(minesweeper_custom_game_window_gml))
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    if (!main_widget->load_from_gml(minesweeper_custom_game_window_gml))
         VERIFY_NOT_REACHED();
 
-    m_columns_spinbox = *main_widget.find_descendant_of_type_named<GUI::SpinBox>("columns_spinbox");
-    m_rows_spinbox = *main_widget.find_descendant_of_type_named<GUI::SpinBox>("rows_spinbox");
-    m_mines_spinbox = *main_widget.find_descendant_of_type_named<GUI::SpinBox>("mines_spinbox");
-    m_ok_button = *main_widget.find_descendant_of_type_named<GUI::Button>("ok_button");
-    m_cancel_button = *main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    m_columns_spinbox = *main_widget->find_descendant_of_type_named<GUI::SpinBox>("columns_spinbox");
+    m_rows_spinbox = *main_widget->find_descendant_of_type_named<GUI::SpinBox>("rows_spinbox");
+    m_mines_spinbox = *main_widget->find_descendant_of_type_named<GUI::SpinBox>("mines_spinbox");
+    m_ok_button = *main_widget->find_descendant_of_type_named<GUI::Button>("ok_button");
+    m_cancel_button = *main_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
 
     m_columns_spinbox->on_change = [this](auto) {
         set_max_mines();

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -49,7 +49,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Minesweeper");
     window->resize(139, 177);
 
-    auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto widget = TRY(window->set_main_widget<GUI::Widget>());
     widget->load_from_gml(minesweeper_window_gml);
 
     auto& separator = *widget->find_descendant_of_type_named<GUI::HorizontalSeparator>("separator");

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -48,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Snake");
     window->resize(324, 345);
 
-    auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto widget = TRY(window->set_main_widget<GUI::Widget>());
     TRY(widget->try_load_from_gml(snake_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Snake::Game>("game");

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -83,7 +83,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (mode >= Solitaire::Mode::__Count)
         update_mode(Solitaire::Mode::SingleCardDraw);
 
-    auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto widget = TRY(window->set_main_widget<GUI::Widget>());
     TRY(widget->try_load_from_gml(solitaire_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Solitaire::Game>("game");

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -117,7 +117,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (statistic_display >= StatisticDisplay::__Count)
         update_statistic_display(StatisticDisplay::HighScore);
 
-    auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto widget = TRY(window->set_main_widget<GUI::Widget>());
     TRY(widget->try_load_from_gml(spider_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Spider::Game>("game");

--- a/Userland/Libraries/LibGUI/AboutDialog.cpp
+++ b/Userland/Libraries/LibGUI/AboutDialog.cpp
@@ -30,15 +30,15 @@ AboutDialog::AboutDialog(StringView name, StringView version, Gfx::Bitmap const*
     if (parent_window)
         set_icon(parent_window->icon());
 
-    auto& widget = set_main_widget<Widget>();
-    widget.set_fill_with_background_color(true);
-    widget.set_layout<VerticalBoxLayout>();
-    widget.layout()->set_spacing(0);
+    auto widget = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
+    widget->set_fill_with_background_color(true);
+    widget->set_layout<VerticalBoxLayout>();
+    widget->layout()->set_spacing(0);
 
-    auto& banner_image = widget.add<GUI::ImageWidget>();
+    auto& banner_image = widget->add<GUI::ImageWidget>();
     banner_image.load_from_file("/res/graphics/brand-banner.png"sv);
 
-    auto& content_container = widget.add<Widget>();
+    auto& content_container = widget->add<Widget>();
     content_container.set_layout<HorizontalBoxLayout>();
 
     auto& left_container = content_container.add<Widget>();

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -44,7 +44,7 @@ private:
     {
         set_window_type(WindowType::Tooltip);
         set_obey_widget_min_size(false);
-        m_label = set_main_widget<Label>();
+        m_label = set_main_widget<Label>().release_value_but_fixme_should_propagate_errors();
         m_label->set_background_role(Gfx::ColorRole::Tooltip);
         m_label->set_foreground_role(Gfx::ColorRole::TooltipText);
         m_label->set_fill_with_background_color(true);

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -92,11 +92,11 @@ AutocompleteBox::AutocompleteBox(TextEditor& editor)
     m_popup_window->set_obey_widget_min_size(false);
     m_popup_window->set_rect(0, 0, 175, 25);
 
-    auto& main_widget = m_popup_window->set_main_widget<GUI::Widget>();
-    main_widget.set_fill_with_background_color(true);
-    main_widget.set_layout<GUI::VerticalBoxLayout>();
+    auto main_widget = m_popup_window->set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    main_widget->set_fill_with_background_color(true);
+    main_widget->set_layout<GUI::VerticalBoxLayout>();
 
-    m_suggestion_view = main_widget.add<GUI::TableView>();
+    m_suggestion_view = main_widget->add<GUI::TableView>();
     m_suggestion_view->set_frame_shadow(Gfx::FrameShadow::Plain);
     m_suggestion_view->set_frame_thickness(1);
     m_suggestion_view->set_column_headers_visible(false);
@@ -109,7 +109,7 @@ AutocompleteBox::AutocompleteBox(TextEditor& editor)
         apply_suggestion();
     };
 
-    m_no_suggestions_view = main_widget.add<GUI::Label>("No suggestions");
+    m_no_suggestions_view = main_widget->add<GUI::Label>("No suggestions");
 }
 
 void AutocompleteBox::update_suggestions(Vector<CodeComprehension::AutocompleteResultEntry>&& suggestions)

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -206,12 +206,12 @@ void ColorPicker::set_color_has_alpha_channel(bool has_alpha)
 
 void ColorPicker::build_ui()
 {
-    auto& root_container = set_main_widget<Widget>();
-    root_container.set_layout<VerticalBoxLayout>();
-    root_container.layout()->set_margins(4);
-    root_container.set_fill_with_background_color(true);
+    auto root_container = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
+    root_container->set_layout<VerticalBoxLayout>();
+    root_container->layout()->set_margins(4);
+    root_container->set_fill_with_background_color(true);
 
-    auto& tab_widget = root_container.add<GUI::TabWidget>();
+    auto& tab_widget = root_container->add<GUI::TabWidget>();
 
     auto& tab_palette = tab_widget.add_tab<Widget>("Palette");
     tab_palette.set_layout<VerticalBoxLayout>();
@@ -227,7 +227,7 @@ void ColorPicker::build_ui()
 
     build_ui_custom(tab_custom_color);
 
-    auto& button_container = root_container.add<Widget>();
+    auto& button_container = root_container->add<Widget>();
     button_container.set_preferred_height(GUI::SpecialDimension::Fit);
     button_container.set_layout<HorizontalBoxLayout>();
     button_container.layout()->set_spacing(4);

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -116,7 +116,7 @@ ComboBox::ComboBox()
     m_list_window = add<Window>(window());
     m_list_window->set_window_type(GUI::WindowType::Popup);
 
-    m_list_view = m_list_window->set_main_widget<ListView>();
+    m_list_view = m_list_window->set_main_widget<ListView>().release_value_but_fixme_should_propagate_errors();
     m_list_view->set_should_hide_unnecessary_scrollbars(true);
     m_list_view->set_alternating_row_colors(false);
     m_list_view->set_hover_highlighting(true);

--- a/Userland/Libraries/LibGUI/CommandPalette.cpp
+++ b/Userland/Libraries/LibGUI/CommandPalette.cpp
@@ -182,15 +182,15 @@ CommandPalette::CommandPalette(GUI::Window& parent_window, ScreenPosition screen
 
     collect_actions(parent_window);
 
-    auto& main_widget = set_main_widget<GUI::Frame>();
-    main_widget.set_frame_shape(Gfx::FrameShape::Window);
-    main_widget.set_fill_with_background_color(true);
+    auto main_widget = set_main_widget<GUI::Frame>().release_value_but_fixme_should_propagate_errors();
+    main_widget->set_frame_shape(Gfx::FrameShape::Window);
+    main_widget->set_fill_with_background_color(true);
 
-    auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
+    auto& layout = main_widget->set_layout<GUI::VerticalBoxLayout>();
     layout.set_margins(4);
 
-    m_text_box = main_widget.add<GUI::TextBox>();
-    m_table_view = main_widget.add<GUI::TableView>();
+    m_text_box = main_widget->add<GUI::TextBox>();
+    m_table_view = main_widget->add<GUI::TableView>();
     m_model = adopt_ref(*new ActionModel(m_actions));
     m_table_view->set_column_headers_visible(false);
 

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -92,8 +92,8 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
     : Dialog(parent_window)
     , m_category_action_group(make<ActionGroup>())
 {
-    auto& main_widget = set_main_widget<Frame>();
-    if (!main_widget.load_from_gml(emoji_input_dialog_gml))
+    auto main_widget = set_main_widget<Frame>().release_value_but_fixme_should_propagate_errors();
+    if (!main_widget->load_from_gml(emoji_input_dialog_gml))
         VERIFY_NOT_REACHED();
 
     set_window_type(GUI::WindowType::Popup);
@@ -101,10 +101,10 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
     set_blocks_emoji_input(true);
     resize(400, 300);
 
-    auto& scrollable_container = *main_widget.find_descendant_of_type_named<GUI::ScrollableContainerWidget>("scrollable_container"sv);
-    m_search_box = main_widget.find_descendant_of_type_named<GUI::TextBox>("search_box"sv);
-    m_toolbar = main_widget.find_descendant_of_type_named<GUI::Toolbar>("toolbar"sv);
-    m_emojis_widget = main_widget.find_descendant_of_type_named<GUI::Widget>("emojis"sv);
+    auto& scrollable_container = *main_widget->find_descendant_of_type_named<GUI::ScrollableContainerWidget>("scrollable_container"sv);
+    m_search_box = main_widget->find_descendant_of_type_named<GUI::TextBox>("search_box"sv);
+    m_toolbar = main_widget->find_descendant_of_type_named<GUI::Toolbar>("toolbar"sv);
+    m_emojis_widget = main_widget->find_descendant_of_type_named<GUI::Widget>("emojis"sv);
     m_emojis = supported_emoji();
 
     m_category_action_group->set_exclusive(true);

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -84,16 +84,16 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
     }
     resize(560, 320);
 
-    auto& widget = set_main_widget<GUI::Widget>();
-    if (!widget.load_from_gml(file_picker_dialog_gml))
+    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    if (!widget->load_from_gml(file_picker_dialog_gml))
         VERIFY_NOT_REACHED();
 
-    auto& toolbar = *widget.find_descendant_of_type_named<GUI::Toolbar>("toolbar");
+    auto& toolbar = *widget->find_descendant_of_type_named<GUI::Toolbar>("toolbar");
 
-    m_location_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("location_textbox");
+    m_location_textbox = *widget->find_descendant_of_type_named<GUI::TextBox>("location_textbox");
     m_location_textbox->set_text(path);
 
-    m_view = *widget.find_descendant_of_type_named<GUI::MultiView>("view");
+    m_view = *widget->find_descendant_of_type_named<GUI::MultiView>("view");
     m_view->set_selection_mode(m_mode == Mode::OpenMultiple ? GUI::AbstractView::SelectionMode::MultiSelection : GUI::AbstractView::SelectionMode::SingleSelection);
     m_view->set_model(MUST(SortingProxyModel::create(*m_model)));
     m_view->set_model_column(FileSystemModel::Column::Name);
@@ -150,7 +150,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
     toolbar.add_action(m_view->view_as_table_action());
     toolbar.add_action(m_view->view_as_columns_action());
 
-    m_filename_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("filename_textbox");
+    m_filename_textbox = *widget->find_descendant_of_type_named<GUI::TextBox>("filename_textbox");
     m_filename_textbox->set_focus(true);
     if (m_mode == Mode::Save) {
         LexicalPath lexical_filename { filename };
@@ -183,14 +183,14 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
         }
     };
 
-    auto& ok_button = *widget.find_descendant_of_type_named<GUI::Button>("ok_button");
+    auto& ok_button = *widget->find_descendant_of_type_named<GUI::Button>("ok_button");
     ok_button.set_text(ok_button_name(m_mode));
     ok_button.on_click = [this](auto) {
         on_file_return();
     };
     ok_button.set_enabled(m_mode == Mode::OpenFolder || !m_filename_textbox->text().is_empty());
 
-    auto& cancel_button = *widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    auto& cancel_button = *widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
     cancel_button.set_text("Cancel");
     cancel_button.on_click = [this](auto) {
         done(ExecResult::Cancel);
@@ -237,7 +237,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
         m_view->view_as_columns_action().set_enabled(false);
     };
 
-    auto& common_locations_tray = *widget.find_descendant_of_type_named<GUI::Tray>("common_locations_tray");
+    auto& common_locations_tray = *widget->find_descendant_of_type_named<GUI::Tray>("common_locations_tray");
     m_model->on_complete = [&] {
         m_view->set_active_widget(&m_view->current_view());
         for (auto& location_button : m_common_location_buttons)

--- a/Userland/Libraries/LibGUI/FontPicker.cpp
+++ b/Userland/Libraries/LibGUI/FontPicker.cpp
@@ -26,26 +26,26 @@ FontPicker::FontPicker(Window* parent_window, Gfx::Font const* current_font, boo
     resize(430, 280);
     set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-font-editor.png"sv).release_value_but_fixme_should_propagate_errors());
 
-    auto& widget = set_main_widget<GUI::Widget>();
-    if (!widget.load_from_gml(font_picker_dialog_gml))
+    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    if (!widget->load_from_gml(font_picker_dialog_gml))
         VERIFY_NOT_REACHED();
 
-    m_family_list_view = *widget.find_descendant_of_type_named<ListView>("family_list_view");
+    m_family_list_view = *widget->find_descendant_of_type_named<ListView>("family_list_view");
     m_family_list_view->set_model(ItemListModel<DeprecatedString>::create(m_families));
     m_family_list_view->horizontal_scrollbar().set_visible(false);
 
-    m_variant_list_view = *widget.find_descendant_of_type_named<ListView>("variant_list_view");
+    m_variant_list_view = *widget->find_descendant_of_type_named<ListView>("variant_list_view");
     m_variant_list_view->set_model(ItemListModel<DeprecatedString>::create(m_variants));
     m_variant_list_view->horizontal_scrollbar().set_visible(false);
 
-    m_size_spin_box = *widget.find_descendant_of_type_named<SpinBox>("size_spin_box");
+    m_size_spin_box = *widget->find_descendant_of_type_named<SpinBox>("size_spin_box");
     m_size_spin_box->set_range(1, 255);
 
-    m_size_list_view = *widget.find_descendant_of_type_named<ListView>("size_list_view");
+    m_size_list_view = *widget->find_descendant_of_type_named<ListView>("size_list_view");
     m_size_list_view->set_model(ItemListModel<int>::create(m_sizes));
     m_size_list_view->horizontal_scrollbar().set_visible(false);
 
-    m_sample_text_label = *widget.find_descendant_of_type_named<Label>("sample_text_label");
+    m_sample_text_label = *widget->find_descendant_of_type_named<Label>("sample_text_label");
 
     m_families.clear();
     Gfx::FontDatabase::the().for_each_typeface([&](auto& typeface) {
@@ -157,13 +157,13 @@ FontPicker::FontPicker(Window* parent_window, Gfx::Font const* current_font, boo
         update_font();
     };
 
-    auto& ok_button = *widget.find_descendant_of_type_named<GUI::Button>("ok_button");
+    auto& ok_button = *widget->find_descendant_of_type_named<GUI::Button>("ok_button");
     ok_button.on_click = [this](auto) {
         done(ExecResult::OK);
     };
     ok_button.set_default(true);
 
-    auto& cancel_button = *widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    auto& cancel_button = *widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
     cancel_button.on_click = [this](auto) {
         done(ExecResult::Cancel);
     };

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -49,20 +49,20 @@ void InputBox::on_done(ExecResult result)
 
 void InputBox::build(InputType input_type)
 {
-    auto& widget = set_main_widget<Widget>();
+    auto widget = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
 
-    int text_width = widget.font().width(m_prompt);
-    int title_width = widget.font().width(title()) + 24 /* icon, plus a little padding -- not perfect */;
+    int text_width = widget->font().width(m_prompt);
+    int title_width = widget->font().width(title()) + 24 /* icon, plus a little padding -- not perfect */;
     int max_width = max(text_width, title_width);
 
-    widget.set_layout<VerticalBoxLayout>();
-    widget.set_fill_with_background_color(true);
-    widget.set_preferred_height(SpecialDimension::Fit);
+    widget->set_layout<VerticalBoxLayout>();
+    widget->set_fill_with_background_color(true);
+    widget->set_preferred_height(SpecialDimension::Fit);
 
-    widget.layout()->set_margins(6);
-    widget.layout()->set_spacing(6);
+    widget->layout()->set_margins(6);
+    widget->layout()->set_spacing(6);
 
-    auto& label_editor_container = widget.add<Widget>();
+    auto& label_editor_container = widget->add<Widget>();
     label_editor_container.set_layout<HorizontalBoxLayout>();
     label_editor_container.set_preferred_height(SpecialDimension::Fit);
 
@@ -83,7 +83,7 @@ void InputBox::build(InputType input_type)
     if (!m_placeholder.is_null())
         m_text_editor->set_placeholder(m_placeholder);
 
-    auto& button_container_outer = widget.add<Widget>();
+    auto& button_container_outer = widget->add<Widget>();
     button_container_outer.set_preferred_height(SpecialDimension::Fit);
     button_container_outer.set_layout<VerticalBoxLayout>();
 
@@ -113,7 +113,7 @@ void InputBox::build(InputType input_type)
     };
     m_text_editor->set_focus(true);
 
-    set_rect(x(), y(), max_width + 140, widget.effective_preferred_size().height().as_int());
+    set_rect(x(), y(), max_width + 140, widget->effective_preferred_size().height().as_int());
 }
 
 }

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -110,21 +110,21 @@ bool MessageBox::should_include_no_button() const
 
 void MessageBox::build()
 {
-    auto& widget = set_main_widget<Widget>();
+    auto widget = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
 
-    int text_width = widget.font().width(m_text);
+    int text_width = widget->font().width(m_text);
     auto number_of_lines = m_text.split('\n').size();
-    int padded_text_height = widget.font().glyph_height() * 1.6;
+    int padded_text_height = widget->font().glyph_height() * 1.6;
     int total_text_height = number_of_lines * padded_text_height;
     int icon_width = 0;
 
-    widget.set_layout<VerticalBoxLayout>();
-    widget.set_fill_with_background_color(true);
+    widget->set_layout<VerticalBoxLayout>();
+    widget->set_fill_with_background_color(true);
 
-    widget.layout()->set_margins(8);
-    widget.layout()->set_spacing(6);
+    widget->layout()->set_margins(8);
+    widget->layout()->set_spacing(6);
 
-    auto& message_container = widget.add<Widget>();
+    auto& message_container = widget->add<Widget>();
     message_container.set_layout<HorizontalBoxLayout>();
     message_container.layout()->set_spacing(8);
 
@@ -143,7 +143,7 @@ void MessageBox::build()
     if (m_type != Type::None)
         label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
-    auto& button_container = widget.add<Widget>();
+    auto& button_container = widget->add<Widget>();
     button_container.set_layout<HorizontalBoxLayout>();
     button_container.set_fixed_height(24);
     button_container.layout()->set_spacing(8);

--- a/Userland/Libraries/LibGUI/PasswordInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/PasswordInputDialog.cpp
@@ -22,30 +22,30 @@ PasswordInputDialog::PasswordInputDialog(Window* parent_window, DeprecatedString
     resize(340, 122);
     set_title(move(title));
 
-    auto& widget = set_main_widget<Widget>();
+    auto widget = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
 
-    widget.load_from_gml(password_input_dialog_gml);
+    widget->load_from_gml(password_input_dialog_gml);
 
-    auto& key_icon_label = *widget.find_descendant_of_type_named<GUI::Label>("key_icon_label");
+    auto& key_icon_label = *widget->find_descendant_of_type_named<GUI::Label>("key_icon_label");
 
     key_icon_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/32x32/key.png"sv).release_value_but_fixme_should_propagate_errors());
 
-    auto& server_label = *widget.find_descendant_of_type_named<GUI::Label>("server_label");
+    auto& server_label = *widget->find_descendant_of_type_named<GUI::Label>("server_label");
     server_label.set_text(move(server));
 
-    auto& username_label = *widget.find_descendant_of_type_named<GUI::Label>("username_label");
+    auto& username_label = *widget->find_descendant_of_type_named<GUI::Label>("username_label");
     username_label.set_text(move(username));
 
-    auto& password_box = *widget.find_descendant_of_type_named<GUI::PasswordBox>("password_box");
+    auto& password_box = *widget->find_descendant_of_type_named<GUI::PasswordBox>("password_box");
 
-    auto& ok_button = *widget.find_descendant_of_type_named<GUI::Button>("ok_button");
+    auto& ok_button = *widget->find_descendant_of_type_named<GUI::Button>("ok_button");
     ok_button.on_click = [&](auto) {
         dbgln("GUI::PasswordInputDialog: OK button clicked");
         m_password = password_box.text();
         done(ExecResult::OK);
     };
 
-    auto& cancel_button = *widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    auto& cancel_button = *widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
     cancel_button.on_click = [this](auto) {
         dbgln("GUI::PasswordInputDialog: Cancel button clicked");
         done(ExecResult::Cancel);

--- a/Userland/Libraries/LibGUI/ProcessChooser.cpp
+++ b/Userland/Libraries/LibGUI/ProcessChooser.cpp
@@ -31,11 +31,11 @@ ProcessChooser::ProcessChooser(StringView window_title, StringView button_label,
     resize(300, 340);
     center_on_screen();
 
-    auto& widget = set_main_widget<GUI::Widget>();
-    widget.set_fill_with_background_color(true);
-    widget.set_layout<GUI::VerticalBoxLayout>();
+    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    widget->set_fill_with_background_color(true);
+    widget->set_layout<GUI::VerticalBoxLayout>();
 
-    m_table_view = widget.add<GUI::TableView>();
+    m_table_view = widget->add<GUI::TableView>();
     auto process_model = RunningProcessesModel::create();
     auto sorting_model = MUST(GUI::SortingProxyModel::create(process_model));
     sorting_model->set_sort_role(GUI::ModelRole::Display);
@@ -46,7 +46,7 @@ ProcessChooser::ProcessChooser(StringView window_title, StringView button_label,
 
     m_table_view->on_activation = [this](ModelIndex const& index) { set_pid_from_index_and_close(index); };
 
-    auto& button_container = widget.add<GUI::Widget>();
+    auto& button_container = widget->add<GUI::Widget>();
     button_container.set_fixed_height(30);
     button_container.set_layout<GUI::HorizontalBoxLayout>();
     button_container.layout()->set_margins({ 0, 4, 0 });

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -32,7 +32,7 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(DeprecatedString t
     window->set_resizable(false);
     window->set_minimizable(false);
 
-    auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
     (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
     main_widget->layout()->set_margins(4);

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -143,19 +143,11 @@ public:
     void set_main_widget(Widget*);
 
     template<class T, class... Args>
-    inline ErrorOr<NonnullRefPtr<T>> try_set_main_widget(Args&&... args)
+    inline ErrorOr<NonnullRefPtr<T>> set_main_widget(Args&&... args)
     {
         auto widget = TRY(T::try_create(forward<Args>(args)...));
         set_main_widget(widget.ptr());
         return widget;
-    }
-
-    template<class T, class... Args>
-    inline T& set_main_widget(Args&&... args)
-    {
-        auto widget = T::construct(forward<Args>(args)...);
-        set_main_widget(widget.ptr());
-        return *widget;
     }
 
     Widget* default_return_key_widget() { return m_default_return_key_widget; }

--- a/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
@@ -27,19 +27,19 @@ WizardDialog::WizardDialog(Window* parent_window)
     if (parent_window)
         set_icon(parent_window->icon());
 
-    auto& main_widget = set_main_widget<Widget>();
-    main_widget.set_fill_with_background_color(true);
-    main_widget.set_layout<VerticalBoxLayout>();
-    main_widget.layout()->set_spacing(0);
+    auto main_widget = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
+    main_widget->set_fill_with_background_color(true);
+    main_widget->set_layout<VerticalBoxLayout>();
+    main_widget->layout()->set_spacing(0);
 
-    m_page_container_widget = main_widget.add<Widget>();
+    m_page_container_widget = main_widget->add<Widget>();
     m_page_container_widget->set_fixed_size(500, 315);
     m_page_container_widget->set_layout<VerticalBoxLayout>();
 
-    auto& separator = main_widget.add<SeparatorWidget>(Gfx::Orientation::Horizontal);
+    auto& separator = main_widget->add<SeparatorWidget>(Gfx::Orientation::Horizontal);
     separator.set_fixed_height(2);
 
-    auto& nav_container_widget = main_widget.add<Widget>();
+    auto& nav_container_widget = main_widget->add<Widget>();
     nav_container_widget.set_layout<HorizontalBoxLayout>();
     nav_container_widget.set_fixed_height(42);
     nav_container_widget.layout()->set_margins({ 0, 10 });

--- a/Userland/Libraries/LibWebView/DumpLayoutTree/main.cpp
+++ b/Userland/Libraries/LibWebView/DumpLayoutTree/main.cpp
@@ -16,10 +16,10 @@ int main(int argc, char** argv)
     window->set_title("DumpLayoutTree");
     window->resize(800, 600);
     window->show();
-    auto& web_view = window->set_main_widget<WebView::OutOfProcessWebView>();
-    web_view.load(URL::create_with_file_scheme(argv[1]));
-    web_view.on_load_finish = [&](auto&) {
-        auto dump = web_view.dump_layout_tree();
+    auto web_view = window->set_main_widget<WebView::OutOfProcessWebView>().release_value_but_fixme_should_propagate_errors();
+    web_view->load(URL::create_with_file_scheme(argv[1]));
+    web_view->on_load_finish = [&](auto&) {
+        auto dump = web_view->dump_layout_tree();
         write(STDOUT_FILENO, dump.characters(), dump.length() + 1);
         _exit(0);
     };

--- a/Userland/Services/LoginServer/LoginWindow.cpp
+++ b/Userland/Services/LoginServer/LoginWindow.cpp
@@ -20,24 +20,24 @@ LoginWindow::LoginWindow(GUI::Window* parent)
     set_closeable(false);
     set_icon(GUI::Icon::default_icon("ladyball"sv).bitmap_for_size(16));
 
-    auto& widget = set_main_widget<GUI::Widget>();
-    widget.load_from_gml(login_window_gml);
-    m_banner = *widget.find_descendant_of_type_named<GUI::ImageWidget>("banner");
+    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    widget->load_from_gml(login_window_gml);
+    m_banner = *widget->find_descendant_of_type_named<GUI::ImageWidget>("banner");
     m_banner->load_from_file("/res/graphics/brand-banner.png"sv);
     m_banner->set_auto_resize(true);
 
-    m_username = *widget.find_descendant_of_type_named<GUI::TextBox>("username");
+    m_username = *widget->find_descendant_of_type_named<GUI::TextBox>("username");
     m_username->set_focus(true);
-    m_password = *widget.find_descendant_of_type_named<GUI::PasswordBox>("password");
+    m_password = *widget->find_descendant_of_type_named<GUI::PasswordBox>("password");
 
-    m_log_in_button = *widget.find_descendant_of_type_named<GUI::Button>("log_in");
+    m_log_in_button = *widget->find_descendant_of_type_named<GUI::Button>("log_in");
     m_log_in_button->on_click = [&](auto) {
         if (on_submit)
             on_submit();
     };
     m_log_in_button->set_default(true);
 
-    m_fail_message = *widget.find_descendant_of_type_named<GUI::Label>("fail_message");
+    m_fail_message = *widget->find_descendant_of_type_named<GUI::Label>("fail_message");
     m_username->on_change = [&] {
         m_fail_message->set_text("");
     };

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -67,20 +67,20 @@ NotificationWindow::NotificationWindow(i32 client_id, DeprecatedString const& te
 
     m_original_rect = rect;
 
-    auto& widget = set_main_widget<GUI::Widget>();
+    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
 
-    widget.set_fill_with_background_color(true);
-    widget.set_layout<GUI::HorizontalBoxLayout>();
-    widget.layout()->set_margins(8);
-    widget.layout()->set_spacing(6);
+    widget->set_fill_with_background_color(true);
+    widget->set_layout<GUI::HorizontalBoxLayout>();
+    widget->layout()->set_margins(8);
+    widget->layout()->set_spacing(6);
 
-    m_image = &widget.add<GUI::ImageWidget>();
+    m_image = &widget->add<GUI::ImageWidget>();
     m_image->set_visible(icon.is_valid());
     if (icon.is_valid()) {
         m_image->set_bitmap(icon.bitmap());
     }
 
-    auto& left_container = widget.add<GUI::Widget>();
+    auto& left_container = widget->add<GUI::Widget>();
     left_container.set_layout<GUI::VerticalBoxLayout>();
 
     m_title_label = &left_container.add<GUI::Label>(title);

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -40,14 +40,14 @@ ClockWidget::ClockWidget()
     m_calendar_window->set_window_type(GUI::WindowType::Popup);
     m_calendar_window->resize(m_window_size.width(), m_window_size.height());
 
-    auto& root_container = m_calendar_window->set_main_widget<GUI::Frame>();
-    root_container.set_fill_with_background_color(true);
-    root_container.set_layout<GUI::VerticalBoxLayout>();
-    root_container.layout()->set_margins({ 2, 0 });
-    root_container.layout()->set_spacing(0);
-    root_container.set_frame_shape(Gfx::FrameShape::Window);
+    auto root_container = m_calendar_window->set_main_widget<GUI::Frame>().release_value_but_fixme_should_propagate_errors();
+    root_container->set_fill_with_background_color(true);
+    root_container->set_layout<GUI::VerticalBoxLayout>();
+    root_container->layout()->set_margins({ 2, 0 });
+    root_container->layout()->set_spacing(0);
+    root_container->set_frame_shape(Gfx::FrameShape::Window);
 
-    auto& navigation_container = root_container.add<GUI::Widget>();
+    auto& navigation_container = root_container->add<GUI::Widget>();
     navigation_container.set_fixed_height(24);
     navigation_container.set_layout<GUI::HorizontalBoxLayout>();
     navigation_container.layout()->set_margins({ 2 });
@@ -109,10 +109,10 @@ ClockWidget::ClockWidget()
             m_selected_calendar_button->set_text(m_calendar->formatted_date());
     };
 
-    auto& separator1 = root_container.add<GUI::HorizontalSeparator>();
+    auto& separator1 = root_container->add<GUI::HorizontalSeparator>();
     separator1.set_fixed_height(2);
 
-    auto& calendar_container = root_container.add<GUI::Widget>();
+    auto& calendar_container = root_container->add<GUI::Widget>();
     calendar_container.set_layout<GUI::HorizontalBoxLayout>();
     calendar_container.layout()->set_margins({ 2 });
 
@@ -127,10 +127,10 @@ ClockWidget::ClockWidget()
         m_selected_calendar_button->set_text(m_calendar->formatted_date());
     };
 
-    auto& separator2 = root_container.add<GUI::HorizontalSeparator>();
+    auto& separator2 = root_container->add<GUI::HorizontalSeparator>();
     separator2.set_fixed_height(2);
 
-    auto& settings_container = root_container.add<GUI::Widget>();
+    auto& settings_container = root_container->add<GUI::Widget>();
     settings_container.set_fixed_height(24);
     settings_container.set_layout<GUI::HorizontalBoxLayout>();
     settings_container.layout()->set_margins({ 2 });

--- a/Userland/Services/Taskbar/ShutdownDialog.cpp
+++ b/Userland/Services/Taskbar/ShutdownDialog.cpp
@@ -42,15 +42,15 @@ Vector<char const*> ShutdownDialog::show()
 ShutdownDialog::ShutdownDialog()
     : Dialog(nullptr)
 {
-    auto& widget = set_main_widget<GUI::Widget>();
-    widget.set_fill_with_background_color(true);
-    widget.set_layout<GUI::VerticalBoxLayout>();
-    widget.layout()->set_spacing(0);
+    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    widget->set_fill_with_background_color(true);
+    widget->set_layout<GUI::VerticalBoxLayout>();
+    widget->layout()->set_spacing(0);
 
-    auto& banner_image = widget.add<GUI::ImageWidget>();
+    auto& banner_image = widget->add<GUI::ImageWidget>();
     banner_image.load_from_file("/res/graphics/brand-banner.png"sv);
 
-    auto& content_container = widget.add<GUI::Widget>();
+    auto& content_container = widget->add<GUI::Widget>();
     content_container.set_layout<GUI::HorizontalBoxLayout>();
 
     auto& left_container = content_container.add<GUI::Widget>();

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -72,7 +72,7 @@ TaskbarWindow::TaskbarWindow()
 
 ErrorOr<void> TaskbarWindow::populate_taskbar()
 {
-    auto main_widget = TRY(try_set_main_widget<TaskbarWidget>());
+    auto main_widget = TRY(set_main_widget<TaskbarWidget>());
     (void)TRY(main_widget->try_set_layout<GUI::HorizontalBoxLayout>());
     main_widget->layout()->set_margins({ 2, 3, 0, 3 });
 

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -117,7 +117,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Optional<Gfx::IntRect> crop_region;
     if (select_region) {
         auto window = GUI::Window::construct();
-        auto& container = window->set_main_widget<SelectableLayover>(window);
+        auto container = TRY(window->set_main_widget<SelectableLayover>(window));
 
         window->set_title("shot");
         window->set_has_alpha_channel(true);
@@ -125,7 +125,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         window->show();
         app->exec();
 
-        crop_region = container.region();
+        crop_region = container->region();
         if (crop_region.value().is_empty()) {
             dbgln("cancelled...");
             return 0;


### PR DESCRIPTION
Rip that bandaid off!

This does the following, in one big, awkward jump:
- Replace all uses of `set_main_widget<Foo>()` with the `try` version.
- Remove `set_main_widget<Foo>()`.
- Rename the `try` version to just be `set_main_widget` because it's now the only one.

The majority of places that call `set_main_widget<Foo>()` are inside constructors, so this unfortunately gives us a big batch of new `release_value_but_fixme_should_propagate_errors()` calls.