### PR TITLE
LibGUI: Allow strings to be uppercased, lowercased and snakecased.

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1050,6 +1050,16 @@ void TextEditor::keydown_event(KeyEvent& event)
         }
     }
 
+    if (event.shift() && event.ctrl() && event.key() == KeyCode::Key_U) {
+        uppercase_selection();
+    }
+    if (event.shift() && event.ctrl() && event.key() == KeyCode::Key_L) {
+        lowercase_selection();
+    }
+    if (event.shift() && event.ctrl() && event.key() == KeyCode::Key_N) {
+        snakecase_selection();
+    }
+
     event.ignore();
 }
 
@@ -1107,6 +1117,42 @@ void TextEditor::unindent_line()
 
         set_cursor({ m_cursor.line(), temp_column <= unindent_size ? 0 : temp_column - unindent_size });
     }
+}
+
+void TextEditor::uppercase_selection() {
+    if (!has_selection())
+        return;
+    auto const selection_start = m_selection.start() > m_selection.end() ? m_selection.end() : m_selection.start();
+    auto const selection_end = m_selection.end() > m_selection.start() ? m_selection.end() : m_selection.start();
+
+    auto const range = TextRange(selection_start, selection_end);
+    auto selectedText = document().text_in_range(range);
+    selectedText = selectedText.to_uppercase();
+    execute<ReplaceAllTextCommand>(selectedText, range, "Uppercase a selection");
+}
+
+void TextEditor::lowercase_selection() {
+    if (!has_selection())
+        return;
+    auto const selection_start = m_selection.start() > m_selection.end() ? m_selection.end() : m_selection.start();
+    auto const selection_end = m_selection.end() > m_selection.start() ? m_selection.end() : m_selection.start();
+
+    auto const range = TextRange(selection_start, selection_end);
+    auto selectedText = document().text_in_range(range);
+    selectedText = selectedText.to_lowercase();
+    execute<ReplaceAllTextCommand>(selectedText, range, "Lowercase a selection");
+}
+
+void TextEditor::snakecase_selection() {
+    if (!has_selection())
+        return;
+    auto const selection_start = m_selection.start() > m_selection.end() ? m_selection.end() : m_selection.start();
+    auto const selection_end = m_selection.end() > m_selection.start() ? m_selection.end() : m_selection.start();
+
+    auto const range = TextRange(selection_start, selection_end);
+    auto selectedText = document().text_in_range(range);
+    selectedText = selectedText.to_snakecase();
+    execute<ReplaceAllTextCommand>(selectedText, range, "Snake case a selection");
 }
 
 void TextEditor::delete_previous_word()

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -162,6 +162,9 @@ public:
     void indent_selection();
     void unindent_selection();
     void unindent_line();
+    void uppercase_selection();
+    void lowercase_selection();
+    void snakecase_selection();
 
     Function<void()> on_change;
     Function<void(bool modified)> on_modified_change;

--- a/Userland/Libraries/LibWeb/FileAPI/File.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/File.cpp
@@ -24,7 +24,7 @@ File::~File() = default;
 WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> File::create(JS::Realm& realm, Vector<BlobPart> const& file_bits, DeprecatedString const& file_name, Optional<FilePropertyBag> const& options)
 {
     // 1. Let bytes be the result of processing blob parts given fileBits and options.
-    auto bytes = TRY_OR_RETURN_OOM(realm, process_blob_parts(file_bits, static_cast<Optional<BlobPropertyBag> const&>(*options)));
+    auto bytes = TRY_OR_RETURN_OOM(realm, process_blob_parts(file_bits, options.has_value() ? static_cast<BlobPropertyBag const&>(*options) : Optional<BlobPropertyBag> {}));
 
     // 2. Let n be the fileName argument to the constructor.
     //    NOTE: Underlying OS filesystems use differing conventions for file name; with constructed files, mandating UTF-16 lessens ambiquity when file names are converted to byte sequences.


### PR DESCRIPTION
Added three shortcuts on TextEditor:
1) ctrl+shift+U will uppercase selected text.
2) ctrl+shift+L will lowercase selected text.
3) ctrl+shift+N will snake case selected text.