### PR TITLE
AK: Change Statistics::median() to be mathematically correct

### DIFF
--- a/AK/Statistics.h
+++ b/AK/Statistics.h
@@ -55,6 +55,11 @@ public:
     T const median()
     {
         quick_sort(m_values);
+        // If the number of values is even, the median is the arithmetic mean of the two middle values
+        if (size() % 2 == 0) {
+            auto index = size() / 2;
+            return (m_values.at(index) + m_values.at(index + 1)) / 2;
+        }
         return m_values.at(size() / 2);
     }
 


### PR DESCRIPTION
The previous implementation of Statistics::median() was slightly incorrect with an even number of elements since in those cases it needs to be the arithmetic mean of the two elements that share the middle position.

I was just exploring the Codebase when i saw that the Statics::median() method isn't quite mathematically correct.

