### PR TITLE
Spreadsheet: Allow navigation keys to navigate an in focus cell

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -40,10 +40,6 @@ private:
 
         switch (event.key()) {
         case KeyCode::Key_Tab:
-        case KeyCode::Key_Left:
-        case KeyCode::Key_Right:
-        case KeyCode::Key_Up:
-        case KeyCode::Key_Down:
         case KeyCode::Key_Return:
             return true;
         default:


### PR DESCRIPTION
Previously, the arrow keys would only do cell navigation rather than move the cursor within the formula in the cell.