### PR TITLE
LibGfx+icc: Print fields that are fourccs registered with the ICC

### DIFF
--- a/Userland/Libraries/LibGfx/ICCProfile.cpp
+++ b/Userland/Libraries/LibGfx/ICCProfile.cpp
@@ -231,6 +231,7 @@ ErrorOr<DeviceAttributes> parse_device_attributes(ICCHeader const& header)
 ErrorOr<void> parse_file_signature(ICCHeader const& header)
 {
     // ICC v4, 7.2.9 Profile file signature field
+    // "The profile file signature field shall contain the value “acsp” (61637370h) as a profile file signature."
     if (header.profile_file_signature != 0x61637370)
         return Error::from_string_literal("ICC::Profile: profile file signature not 'acsp'");
     return {};

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -10,6 +10,16 @@
 #include <LibCore/MappedFile.h>
 #include <LibGfx/ICCProfile.h>
 
+template<class T>
+static void out_optional(char const* label, Optional<T> optional)
+{
+    out("{}: ", label);
+    if (optional.has_value())
+        outln("{}", *optional);
+    else
+        outln("(not set)");
+}
+
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     Core::ArgsParser args_parser;
@@ -49,12 +59,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     outln("rendering intent: {}", Gfx::ICC::rendering_intent_name(profile->rendering_intent()));
     outln("pcs illuminant: {}", profile->pcs_illuminant());
-
-    out("id: ");
-    if (auto id = profile->id(); id.has_value())
-        outln("{}", *id);
-    else
-        outln("(not set)");
+    out_optional("id", profile->id());
 
     return 0;
 }

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -31,6 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto icc_file = TRY(Core::MappedFile::map(icc_path));
     auto profile = TRY(Gfx::ICC::Profile::try_load_from_externally_owned_memory(icc_file->bytes()));
 
+    out_optional("preferred CMM type", profile->preferred_cmm_type());
     outln("version: {}", profile->version());
     outln("device class: {}", Gfx::ICC::device_class_name(profile->device_class()));
     outln("data color space: {}", Gfx::ICC::data_color_space_name(profile->data_color_space()));
@@ -46,6 +47,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (auto color_management_module_bits = flags.color_management_module_bits())
         outln("  CMM bits: 0x{:04x}", color_management_module_bits);
 
+    out_optional("device manufacturer", profile->device_manufacturer());
+    out_optional("device model", profile->device_model());
+
     auto device_attributes = profile->device_attributes();
     outln("device attributes: 0x{:016x}", device_attributes.bits());
     outln("  media is {}, {}, {}, {}",
@@ -59,6 +63,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     outln("rendering intent: {}", Gfx::ICC::rendering_intent_name(profile->rendering_intent()));
     outln("pcs illuminant: {}", profile->pcs_illuminant());
+    out_optional("creator", profile->creator());
     out_optional("id", profile->id());
 
     return 0;


### PR DESCRIPTION
Namely:
- preferred CMM type
- device manufacturer
- device model
- profile creator

These all have in common that they can take arbitrary values, so I added
a FourCC class to deal with them, instead of using an enum class.
I made distinct types for each of them, so that they aren't accidentally
mixed up.