### PR TITLE
LibWeb: Consider span in table column width calculation

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -58,6 +58,8 @@ private:
         size_t column_span;
         size_t row_span;
         CSSPixels baseline { 0 };
+        CSSPixels min_width { 0 };
+        CSSPixels max_width { 0 };
     };
 
     Vector<Cell> m_cells;


### PR DESCRIPTION
Implements following parts of CSS Tables 3 spec:
https://www.w3.org/TR/css-tables-3/#min-content-width-of-a-column-based-on-cells-of-span-up-to-n-n--1 https://www.w3.org/TR/css-tables-3/#max-content-width-of-a-column-based-on-cells-of-span-up-to-n-n--1

With this change most of the tables on SerenityOS wikipedia page finally start to be displayed correctly:
![Screenshot from 2023-01-07 01-25-13](https://user-images.githubusercontent.com/45686940/211110202-0c6241f9-4a70-495d-ace5-7d40f61373dc.png)
![Screenshot from 2023-01-07 01-25-27](https://user-images.githubusercontent.com/45686940/211110220-4ab8f2c5-b1c3-498a-a003-e3ab2b147054.png)
