### PR TITLE
LibGfx+LibGUI: Make fill_pixel relative + don't use unnecessarily large buffer bitmap in ColorPicker

### DIFF
--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -678,7 +678,7 @@ void ColorField::resize_event(ResizeEvent&)
 ColorSlider::ColorSlider(double value)
     : m_value(value)
 {
-    m_color_bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { 32, 360 }).release_value_but_fixme_should_propagate_errors();
+    m_color_bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { 1, 360 }).release_value_but_fixme_should_propagate_errors();
     auto painter = Gfx::Painter(*m_color_bitmap);
 
     for (int h = 0; h < 360; h++) {
@@ -687,7 +687,7 @@ ColorSlider::ColorSlider(double value)
         hsv.saturation = 1.0;
         hsv.value = 1.0;
         Color color = Color::from_hsv(hsv);
-        painter.draw_line({ 0, h }, { 32, h }, color);
+        painter.set_pixel({ 0, h }, color);
     }
 }
 

--- a/Userland/Libraries/LibGUI/OpacitySlider.cpp
+++ b/Userland/Libraries/LibGUI/OpacitySlider.cpp
@@ -40,16 +40,12 @@ void OpacitySlider::paint_event(PaintEvent& event)
     Gfx::StylePainter::paint_transparency_grid(painter, inner_rect, palette());
 
     // Alpha gradient
-    for (int pos = inner_rect.first_edge_for_orientation(orientation()); pos <= inner_rect.last_edge_for_orientation(orientation()); ++pos) {
-        float relative_offset = (float)pos / (float)inner_rect.primary_size_for_orientation(orientation());
-        float alpha = relative_offset * 255.0f;
-        Color color = m_base_color.with_alpha(static_cast<u8>(AK::min(alpha, UINT8_MAX)));
-        if (orientation() == Gfx::Orientation::Horizontal) {
-            painter.fill_rect({ pos, inner_rect.top(), 1, inner_rect.height() }, color);
-        } else {
-            painter.fill_rect({ inner_rect.left(), pos, inner_rect.right(), 1 }, color);
-        }
-    }
+    painter.fill_pixels(
+        inner_rect,
+        [&, orientation = orientation()](auto point) {
+            return m_base_color.with_alpha(static_cast<u8>(AK::min(point.primary_offset_for_orientation(orientation) * 255.0f, UINT8_MAX)));
+        },
+        true);
 
     constexpr int notch_size = 3;
     if (orientation() == Gfx::Orientation::Horizontal) {

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -248,7 +248,7 @@ public:
     {
         painter.fill_pixels(
             rect.to_type<int>(), [&](auto point) {
-                return sample_color(location_transform(point.x(), point.y()));
+                return sample_color(location_transform(point.x() * static_cast<float>(rect.width().value()), point.y() * static_cast<float>(rect.height().value())));
             },
             m_requires_blending);
     }


### PR DESCRIPTION
Using relative float coordinates 0 to 1 for x and y in the callback based fill_pixel.
This way it's a lot more intuitive to support scaling whenever it's used.

Also use fill_pixel for the opacity slider, just as a preparation for scaling, but really just because I think it's more elegant that way.

I have to admit, the ColorPicker thing is a bit tacked on.. but laziness compels me to not make a separate PR.