### PR TITLE
LibGUI: Use fallible `Widget::load_from_gml()` everywhere

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -48,8 +48,7 @@ private:
         : Dialog(parent_window)
     {
         auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-        if (!widget->load_from_gml(edit_bookmark_gml))
-            VERIFY_NOT_REACHED();
+        widget->try_load_from_gml(edit_bookmark_gml).release_value_but_fixme_should_propagate_errors();
 
         set_resizable(false);
         resize(260, 85);

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -48,7 +48,7 @@ private:
         : Dialog(parent_window)
     {
         auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-        widget->try_load_from_gml(edit_bookmark_gml).release_value_but_fixme_should_propagate_errors();
+        widget->load_from_gml(edit_bookmark_gml).release_value_but_fixme_should_propagate_errors();
 
         set_resizable(false);
         resize(260, 85);

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -74,7 +74,7 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
     set_title("Browser");
 
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    widget->load_from_gml(browser_window_gml);
+    widget->try_load_from_gml(browser_window_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& top_line = *widget->find_descendant_of_type_named<GUI::HorizontalSeparator>("top_line");
 

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -74,7 +74,7 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
     set_title("Browser");
 
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    widget->try_load_from_gml(browser_window_gml).release_value_but_fixme_should_propagate_errors();
+    widget->load_from_gml(browser_window_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& top_line = *widget->find_descendant_of_type_named<GUI::HorizontalSeparator>("top_line");
 

--- a/Userland/Applications/Browser/History/HistoryWidget.cpp
+++ b/Userland/Applications/Browser/History/HistoryWidget.cpp
@@ -11,7 +11,7 @@
 namespace Browser {
 HistoryWidget::HistoryWidget()
 {
-    try_load_from_gml(history_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(history_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_table_view = find_descendant_of_type_named<GUI::TableView>("history_tableview");
     m_textbox = find_descendant_of_type_named<GUI::TextBox>("history_filter_textbox");

--- a/Userland/Applications/Browser/History/HistoryWidget.cpp
+++ b/Userland/Applications/Browser/History/HistoryWidget.cpp
@@ -11,7 +11,7 @@
 namespace Browser {
 HistoryWidget::HistoryWidget()
 {
-    load_from_gml(history_widget_gml);
+    try_load_from_gml(history_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_table_view = find_descendant_of_type_named<GUI::TableView>("history_tableview");
     m_textbox = find_descendant_of_type_named<GUI::TextBox>("history_filter_textbox");

--- a/Userland/Applications/Browser/StorageWidget.cpp
+++ b/Userland/Applications/Browser/StorageWidget.cpp
@@ -18,7 +18,7 @@ namespace Browser {
 
 StorageWidget::StorageWidget()
 {
-    load_from_gml(storage_widget_gml);
+    try_load_from_gml(storage_widget_gml).release_value_but_fixme_should_propagate_errors();
     auto& tab_widget = *find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
 
     m_cookies_table_view = tab_widget.find_descendant_of_type_named<GUI::TableView>("cookies_tableview");

--- a/Userland/Applications/Browser/StorageWidget.cpp
+++ b/Userland/Applications/Browser/StorageWidget.cpp
@@ -18,7 +18,7 @@ namespace Browser {
 
 StorageWidget::StorageWidget()
 {
-    try_load_from_gml(storage_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(storage_widget_gml).release_value_but_fixme_should_propagate_errors();
     auto& tab_widget = *find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
 
     m_cookies_table_view = tab_widget.find_descendant_of_type_named<GUI::TableView>("cookies_tableview");

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -114,7 +114,7 @@ void Tab::update_status(Optional<DeprecatedString> text_override, i32 count_wait
 
 Tab::Tab(BrowserWindow& window)
 {
-    try_load_from_gml(tab_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_toolbar_container = *find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");
     auto& toolbar = *find_descendant_of_type_named<GUI::Toolbar>("toolbar");

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -114,7 +114,7 @@ void Tab::update_status(Optional<DeprecatedString> text_override, i32 count_wait
 
 Tab::Tab(BrowserWindow& window)
 {
-    load_from_gml(tab_gml);
+    try_load_from_gml(tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_toolbar_container = *find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");
     auto& toolbar = *find_descendant_of_type_named<GUI::Toolbar>("toolbar");

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
@@ -59,7 +59,7 @@ private:
 
 BrowserSettingsWidget::BrowserSettingsWidget()
 {
-    load_from_gml(browser_settings_widget_gml);
+    try_load_from_gml(browser_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_homepage_url_textbox = find_descendant_of_type_named<GUI::TextBox>("homepage_url_textbox");
     m_homepage_url_textbox->set_text(Config::read_string("Browser"sv, "Preferences"sv, "Home"sv, default_homepage_url), GUI::AllowCallback::No);

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
@@ -59,7 +59,7 @@ private:
 
 BrowserSettingsWidget::BrowserSettingsWidget()
 {
-    try_load_from_gml(browser_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(browser_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_homepage_url_textbox = find_descendant_of_type_named<GUI::TextBox>("homepage_url_textbox");
     m_homepage_url_textbox->set_text(Config::read_string("Browser"sv, "Preferences"sv, "Home"sv, default_homepage_url), GUI::AllowCallback::No);

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -108,7 +108,7 @@ void DomainListModel::reset_default_values()
 
 ContentFilterSettingsWidget::ContentFilterSettingsWidget()
 {
-    try_load_from_gml(content_filter_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(content_filter_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
     m_enable_content_filtering_checkbox = find_descendant_of_type_named<GUI::CheckBox>("enable_content_filtering_checkbox");
     m_domain_list_view = find_descendant_of_type_named<GUI::ListView>("domain_list_view");
     m_add_new_domain_button = find_descendant_of_type_named<GUI::Button>("add_new_domain_button");

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -108,7 +108,7 @@ void DomainListModel::reset_default_values()
 
 ContentFilterSettingsWidget::ContentFilterSettingsWidget()
 {
-    load_from_gml(content_filter_settings_widget_gml);
+    try_load_from_gml(content_filter_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
     m_enable_content_filtering_checkbox = find_descendant_of_type_named<GUI::CheckBox>("enable_content_filtering_checkbox");
     m_domain_list_view = find_descendant_of_type_named<GUI::ListView>("domain_list_view");
     m_add_new_domain_button = find_descendant_of_type_named<GUI::Button>("add_new_domain_button");

--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -18,7 +18,7 @@
 
 CalculatorWidget::CalculatorWidget()
 {
-    load_from_gml(calculator_gml);
+    try_load_from_gml(calculator_gml).release_value_but_fixme_should_propagate_errors();
 
     m_entry = *find_descendant_of_type_named<GUI::TextBox>("entry_textbox");
     m_entry->set_relative_rect(5, 5, 244, 26);

--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -18,7 +18,7 @@
 
 CalculatorWidget::CalculatorWidget()
 {
-    try_load_from_gml(calculator_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(calculator_gml).release_value_but_fixme_should_propagate_errors();
 
     m_entry = *find_descendant_of_type_named<GUI::TextBox>("entry_textbox");
     m_entry->set_relative_rect(5, 5, 244, 26);

--- a/Userland/Applications/Calendar/main.cpp
+++ b/Userland/Applications/Calendar/main.cpp
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(main_widget->try_load_from_gml(calendar_window_gml));
+    TRY(main_widget->load_from_gml(calendar_window_gml));
 
     auto toolbar = main_widget->find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     auto calendar = main_widget->find_descendant_of_type_named<GUI::Calendar>("calendar");

--- a/Userland/Applications/Calendar/main.cpp
+++ b/Userland/Applications/Calendar/main.cpp
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    main_widget->load_from_gml(calendar_window_gml);
+    TRY(main_widget->try_load_from_gml(calendar_window_gml));
 
     auto toolbar = main_widget->find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     auto calendar = main_widget->find_descendant_of_type_named<GUI::Calendar>("calendar");

--- a/Userland/Applications/CalendarSettings/CalendarSettingsWidget.cpp
+++ b/Userland/Applications/CalendarSettings/CalendarSettingsWidget.cpp
@@ -31,7 +31,7 @@ void CalendarSettingsWidget::reset_default_values()
 
 CalendarSettingsWidget::CalendarSettingsWidget()
 {
-    load_from_gml(calendar_settings_widget_gml);
+    try_load_from_gml(calendar_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_first_day_of_week_combobox = *find_descendant_of_type_named<GUI::ComboBox>("first_day_of_week");
     m_first_day_of_week_combobox->set_text(Config::read_string("Calendar"sv, "View"sv, "FirstDayOfWeek"sv, "Sunday"sv));

--- a/Userland/Applications/CalendarSettings/CalendarSettingsWidget.cpp
+++ b/Userland/Applications/CalendarSettings/CalendarSettingsWidget.cpp
@@ -31,7 +31,7 @@ void CalendarSettingsWidget::reset_default_values()
 
 CalendarSettingsWidget::CalendarSettingsWidget()
 {
-    try_load_from_gml(calendar_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(calendar_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_first_day_of_week_combobox = *find_descendant_of_type_named<GUI::ComboBox>("first_day_of_week");
     m_first_day_of_week_combobox->set_text(Config::read_string("Calendar"sv, "View"sv, "FirstDayOfWeek"sv, "Sunday"sv));

--- a/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
@@ -27,7 +27,7 @@
 
 CharacterMapWidget::CharacterMapWidget()
 {
-    try_load_from_gml(character_map_window_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(character_map_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_toolbar = find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     m_font_name_label = find_descendant_of_type_named<GUI::Label>("font_name");

--- a/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
@@ -27,7 +27,7 @@
 
 CharacterMapWidget::CharacterMapWidget()
 {
-    load_from_gml(character_map_window_gml);
+    try_load_from_gml(character_map_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_toolbar = find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     m_font_name_label = find_descendant_of_type_named<GUI::Label>("font_name");

--- a/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
@@ -53,7 +53,7 @@ private:
 
 CharacterSearchWidget::CharacterSearchWidget()
 {
-    load_from_gml(character_search_window_gml);
+    try_load_from_gml(character_search_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_search_input = find_descendant_of_type_named<GUI::TextBox>("search_input");
     m_search_button = find_descendant_of_type_named<GUI::Button>("search_button");

--- a/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
@@ -53,7 +53,7 @@ private:
 
 CharacterSearchWidget::CharacterSearchWidget()
 {
-    try_load_from_gml(character_search_window_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(character_search_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_search_input = find_descendant_of_type_named<GUI::TextBox>("search_input");
     m_search_button = find_descendant_of_type_named<GUI::Button>("search_button");

--- a/Userland/Applications/ClockSettings/ClockSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/ClockSettingsWidget.cpp
@@ -21,7 +21,7 @@ constexpr auto time_format_24h_seconds = "%T"sv;
 
 ClockSettingsWidget::ClockSettingsWidget()
 {
-    load_from_gml(clock_settings_widget_gml);
+    try_load_from_gml(clock_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_24_hour_radio = *find_descendant_of_type_named<GUI::RadioButton>("24hour_radio");
     auto& twelve_hour_radio = *find_descendant_of_type_named<GUI::RadioButton>("12hour_radio");

--- a/Userland/Applications/ClockSettings/ClockSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/ClockSettingsWidget.cpp
@@ -21,7 +21,7 @@ constexpr auto time_format_24h_seconds = "%T"sv;
 
 ClockSettingsWidget::ClockSettingsWidget()
 {
-    try_load_from_gml(clock_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(clock_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_24_hour_radio = *find_descendant_of_type_named<GUI::RadioButton>("24hour_radio");
     auto& twelve_hour_radio = *find_descendant_of_type_named<GUI::RadioButton>("12hour_radio");

--- a/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
@@ -61,7 +61,7 @@ ErrorOr<NonnullRefPtr<TimeZoneSettingsWidget>> TimeZoneSettingsWidget::create()
 
 TimeZoneSettingsWidget::TimeZoneSettingsWidget()
 {
-    load_from_gml(time_zone_settings_widget_gml);
+    try_load_from_gml(time_zone_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     static auto time_zones = TimeZone::all_time_zones();
     m_time_zone = TimeZone::system_time_zone();

--- a/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
@@ -61,7 +61,7 @@ ErrorOr<NonnullRefPtr<TimeZoneSettingsWidget>> TimeZoneSettingsWidget::create()
 
 TimeZoneSettingsWidget::TimeZoneSettingsWidget()
 {
-    try_load_from_gml(time_zone_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(time_zone_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     static auto time_zones = TimeZone::all_time_zones();
     m_time_zone = TimeZone::system_time_zone();

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -182,7 +182,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-    widget->load_from_gml(crash_reporter_window_gml);
+    TRY(widget->try_load_from_gml(crash_reporter_window_gml));
 
     auto& icon_image_widget = *widget->find_descendant_of_type_named<GUI::ImageWidget>("icon");
     icon_image_widget.set_bitmap(GUI::FileIconProvider::icon_for_executable(executable_path).bitmap_for_size(32));

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -182,7 +182,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(widget->try_load_from_gml(crash_reporter_window_gml));
+    TRY(widget->load_from_gml(crash_reporter_window_gml));
 
     auto& icon_image_widget = *widget->find_descendant_of_type_named<GUI::ImageWidget>("icon");
     icon_image_widget.set_bitmap(GUI::FileIconProvider::icon_for_executable(executable_path).bitmap_for_size(32));

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -42,7 +42,7 @@ BackgroundSettingsWidget::BackgroundSettingsWidget(bool& background_settings_cha
 
 void BackgroundSettingsWidget::create_frame()
 {
-    load_from_gml(background_settings_gml);
+    try_load_from_gml(background_settings_gml).release_value_but_fixme_should_propagate_errors();
 
     m_monitor_widget = *find_descendant_of_type_named<DisplaySettings::MonitorWidget>("monitor_widget");
 

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -42,7 +42,7 @@ BackgroundSettingsWidget::BackgroundSettingsWidget(bool& background_settings_cha
 
 void BackgroundSettingsWidget::create_frame()
 {
-    try_load_from_gml(background_settings_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(background_settings_gml).release_value_but_fixme_should_propagate_errors();
 
     m_monitor_widget = *find_descendant_of_type_named<DisplaySettings::MonitorWidget>("monitor_widget");
 

--- a/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
@@ -23,7 +23,7 @@ DesktopSettingsWidget::DesktopSettingsWidget()
 
 void DesktopSettingsWidget::create_frame()
 {
-    try_load_from_gml(desktop_settings_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(desktop_settings_gml).release_value_but_fixme_should_propagate_errors();
 
     m_workspace_rows_spinbox = *find_descendant_of_type_named<GUI::SpinBox>("workspace_rows_spinbox");
     m_workspace_rows_spinbox->on_change = [&](auto) {

--- a/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
@@ -23,7 +23,7 @@ DesktopSettingsWidget::DesktopSettingsWidget()
 
 void DesktopSettingsWidget::create_frame()
 {
-    load_from_gml(desktop_settings_gml);
+    try_load_from_gml(desktop_settings_gml).release_value_but_fixme_should_propagate_errors();
 
     m_workspace_rows_spinbox = *find_descendant_of_type_named<GUI::SpinBox>("workspace_rows_spinbox");
     m_workspace_rows_spinbox->on_change = [&](auto) {

--- a/Userland/Applications/DisplaySettings/EffectsSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/EffectsSettingsWidget.cpp
@@ -18,7 +18,7 @@ namespace DisplaySettings {
 
 EffectsSettingsWidget::EffectsSettingsWidget()
 {
-    load_from_gml(effects_settings_gml);
+    try_load_from_gml(effects_settings_gml).release_value_but_fixme_should_propagate_errors();
 
     m_geometry_combobox = find_descendant_of_type_named<ComboBox>("geometry_combobox");
     m_geometry_combobox->set_only_allow_values_from_model(true);

--- a/Userland/Applications/DisplaySettings/EffectsSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/EffectsSettingsWidget.cpp
@@ -18,7 +18,7 @@ namespace DisplaySettings {
 
 EffectsSettingsWidget::EffectsSettingsWidget()
 {
-    try_load_from_gml(effects_settings_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(effects_settings_gml).release_value_but_fixme_should_propagate_errors();
 
     m_geometry_combobox = find_descendant_of_type_named<ComboBox>("geometry_combobox");
     m_geometry_combobox->set_only_allow_values_from_model(true);

--- a/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
@@ -19,7 +19,7 @@ static void update_label_with_font(GUI::Label&, Gfx::Font const&);
 
 FontSettingsWidget::FontSettingsWidget()
 {
-    try_load_from_gml(font_settings_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(font_settings_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& default_font = Gfx::FontDatabase::default_font();
     m_default_font_label = *find_descendant_of_type_named<GUI::Label>("default_font_label");

--- a/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
@@ -19,7 +19,7 @@ static void update_label_with_font(GUI::Label&, Gfx::Font const&);
 
 FontSettingsWidget::FontSettingsWidget()
 {
-    load_from_gml(font_settings_gml);
+    try_load_from_gml(font_settings_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& default_font = Gfx::FontDatabase::default_font();
     m_default_font_label = *find_descendant_of_type_named<GUI::Label>("default_font_label");

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -71,7 +71,7 @@ void MonitorSettingsWidget::create_resolution_list()
 
 void MonitorSettingsWidget::create_frame()
 {
-    try_load_from_gml(monitor_settings_window_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(monitor_settings_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_monitor_widget = *find_descendant_of_type_named<DisplaySettings::MonitorWidget>("monitor_widget");
 

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -71,7 +71,7 @@ void MonitorSettingsWidget::create_resolution_list()
 
 void MonitorSettingsWidget::create_frame()
 {
-    load_from_gml(monitor_settings_window_gml);
+    try_load_from_gml(monitor_settings_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_monitor_widget = *find_descendant_of_type_named<DisplaySettings::MonitorWidget>("monitor_widget");
 

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
@@ -21,7 +21,7 @@ namespace DisplaySettings {
 ThemesSettingsWidget::ThemesSettingsWidget(bool& background_settings_changed)
     : m_background_settings_changed { background_settings_changed }
 {
-    load_from_gml(themes_settings_gml);
+    try_load_from_gml(themes_settings_gml).release_value_but_fixme_should_propagate_errors();
     m_themes = MUST(Gfx::list_installed_system_themes());
 
     size_t current_theme_index;

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
@@ -21,7 +21,7 @@ namespace DisplaySettings {
 ThemesSettingsWidget::ThemesSettingsWidget(bool& background_settings_changed)
     : m_background_settings_changed { background_settings_changed }
 {
-    try_load_from_gml(themes_settings_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(themes_settings_gml).release_value_but_fixme_should_propagate_errors();
     m_themes = MUST(Gfx::list_installed_system_themes());
 
     size_t current_theme_index;

--- a/Userland/Applications/Escalator/EscalatorWindow.cpp
+++ b/Userland/Applications/Escalator/EscalatorWindow.cpp
@@ -32,7 +32,7 @@ EscalatorWindow::EscalatorWindow(StringView executable, Vector<StringView> argum
     set_minimizable(false);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(escalator_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(escalator_gml).release_value_but_fixme_should_propagate_errors();
 
     RefPtr<GUI::Label> app_label = *main_widget->find_descendant_of_type_named<GUI::Label>("description");
 

--- a/Userland/Applications/Escalator/EscalatorWindow.cpp
+++ b/Userland/Applications/Escalator/EscalatorWindow.cpp
@@ -32,7 +32,7 @@ EscalatorWindow::EscalatorWindow(StringView executable, Vector<StringView> argum
     set_minimizable(false);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->load_from_gml(escalator_gml);
+    main_widget->try_load_from_gml(escalator_gml).release_value_but_fixme_should_propagate_errors();
 
     RefPtr<GUI::Label> app_label = *main_widget->find_descendant_of_type_named<GUI::Label>("description");
 

--- a/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
+++ b/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
@@ -23,7 +23,7 @@ FileOperationProgressWidget::FileOperationProgressWidget(FileOperation operation
     : m_operation(operation)
     , m_helper_pipe(move(helper_pipe))
 {
-    try_load_from_gml(file_operation_progress_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(file_operation_progress_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& button = *find_descendant_of_type_named<GUI::Button>("button");
 

--- a/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
+++ b/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
@@ -23,7 +23,7 @@ FileOperationProgressWidget::FileOperationProgressWidget(FileOperation operation
     : m_operation(operation)
     , m_helper_pipe(move(helper_pipe))
 {
-    load_from_gml(file_operation_progress_gml);
+    try_load_from_gml(file_operation_progress_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& button = *find_descendant_of_type_named<GUI::Button>("button");
 

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -45,7 +45,7 @@ PropertiesWindow::PropertiesWindow(DeprecatedString const& path, bool disable_re
     auto& tab_widget = main_widget->add<GUI::TabWidget>();
 
     auto& general_tab = tab_widget.add_tab<GUI::Widget>("General");
-    general_tab.try_load_from_gml(properties_window_general_tab_gml).release_value_but_fixme_should_propagate_errors();
+    general_tab.load_from_gml(properties_window_general_tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_name = lexical_path.basename();
     m_path = lexical_path.string();

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -45,7 +45,7 @@ PropertiesWindow::PropertiesWindow(DeprecatedString const& path, bool disable_re
     auto& tab_widget = main_widget->add<GUI::TabWidget>();
 
     auto& general_tab = tab_widget.add_tab<GUI::Widget>("General");
-    general_tab.load_from_gml(properties_window_general_tab_gml);
+    general_tab.try_load_from_gml(properties_window_general_tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_name = lexical_path.basename();
     m_path = lexical_path.string();

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -580,7 +580,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
     auto was_maximized = Config::read_bool("FileManager"sv, "Window"sv, "Maximized"sv, false);
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(widget->try_load_from_gml(file_manager_window_gml));
+    TRY(widget->load_from_gml(file_manager_window_gml));
 
     auto& toolbar_container = *widget->find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");
     auto& main_toolbar = *widget->find_descendant_of_type_named<GUI::Toolbar>("main_toolbar");

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -580,8 +580,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
     auto was_maximized = Config::read_bool("FileManager"sv, "Window"sv, "Maximized"sv, false);
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-
-    widget->load_from_gml(file_manager_window_gml);
+    TRY(widget->try_load_from_gml(file_manager_window_gml));
 
     auto& toolbar_container = *widget->find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");
     auto& main_toolbar = *widget->find_descendant_of_type_named<GUI::Toolbar>("main_toolbar");

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -66,7 +66,7 @@ ErrorOr<RefPtr<GUI::Window>> MainWidget::create_preview_window()
     window->center_within(*this->window());
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    main_widget->load_from_gml(font_preview_window_gml);
+    TRY(main_widget->try_load_from_gml(font_preview_window_gml));
 
     m_preview_label = find_descendant_of_type_named<GUI::Label>("preview_label");
     m_preview_label->set_font(edited_font());
@@ -420,7 +420,7 @@ ErrorOr<void> MainWidget::create_undo_stack()
 
 MainWidget::MainWidget()
 {
-    load_from_gml(font_editor_window_gml);
+    try_load_from_gml(font_editor_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_font_metadata_groupbox = find_descendant_of_type_named<GUI::GroupBox>("font_metadata_groupbox");
     m_unicode_block_container = find_descendant_of_type_named<GUI::Widget>("unicode_block_container");

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -66,7 +66,7 @@ ErrorOr<RefPtr<GUI::Window>> MainWidget::create_preview_window()
     window->center_within(*this->window());
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(main_widget->try_load_from_gml(font_preview_window_gml));
+    TRY(main_widget->load_from_gml(font_preview_window_gml));
 
     m_preview_label = find_descendant_of_type_named<GUI::Label>("preview_label");
     m_preview_label->set_font(edited_font());
@@ -420,7 +420,7 @@ ErrorOr<void> MainWidget::create_undo_stack()
 
 MainWidget::MainWidget()
 {
-    try_load_from_gml(font_editor_window_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(font_editor_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_font_metadata_groupbox = find_descendant_of_type_named<GUI::GroupBox>("font_metadata_groupbox");
     m_unicode_block_container = find_descendant_of_type_named<GUI::Widget>("unicode_block_container");

--- a/Userland/Applications/FontEditor/NewFontDialog.cpp
+++ b/Userland/Applications/FontEditor/NewFontDialog.cpp
@@ -128,7 +128,7 @@ NewFontDialog::NewFontDialog(GUI::Window* parent_window)
     set_title("New Font");
 
     m_font_properties_page = GUI::WizardPage::construct("Typeface properties", "Edit details about this font.");
-    m_font_properties_page->body_widget().load_from_gml(new_font_dialog_page_1_gml);
+    m_font_properties_page->body_widget().try_load_from_gml(new_font_dialog_page_1_gml).release_value_but_fixme_should_propagate_errors();
 
     m_name_textbox = m_font_properties_page->body_widget().find_descendant_of_type_named<GUI::TextBox>("name_textbox");
     m_family_textbox = m_font_properties_page->body_widget().find_descendant_of_type_named<GUI::TextBox>("family_textbox");
@@ -156,7 +156,7 @@ NewFontDialog::NewFontDialog(GUI::Window* parent_window)
     };
 
     m_glyph_properties_page = GUI::WizardPage::construct("Glyph properties", "Edit details about this font.");
-    m_glyph_properties_page->body_widget().load_from_gml(new_font_dialog_page_2_gml);
+    m_glyph_properties_page->body_widget().try_load_from_gml(new_font_dialog_page_2_gml).release_value_but_fixme_should_propagate_errors();
     m_glyph_properties_page->set_is_final_page(true);
 
     m_glyph_height_spinbox = m_glyph_properties_page->body_widget().find_descendant_of_type_named<GUI::SpinBox>("height_spinbox");

--- a/Userland/Applications/FontEditor/NewFontDialog.cpp
+++ b/Userland/Applications/FontEditor/NewFontDialog.cpp
@@ -128,7 +128,7 @@ NewFontDialog::NewFontDialog(GUI::Window* parent_window)
     set_title("New Font");
 
     m_font_properties_page = GUI::WizardPage::construct("Typeface properties", "Edit details about this font.");
-    m_font_properties_page->body_widget().try_load_from_gml(new_font_dialog_page_1_gml).release_value_but_fixme_should_propagate_errors();
+    m_font_properties_page->body_widget().load_from_gml(new_font_dialog_page_1_gml).release_value_but_fixme_should_propagate_errors();
 
     m_name_textbox = m_font_properties_page->body_widget().find_descendant_of_type_named<GUI::TextBox>("name_textbox");
     m_family_textbox = m_font_properties_page->body_widget().find_descendant_of_type_named<GUI::TextBox>("family_textbox");
@@ -156,7 +156,7 @@ NewFontDialog::NewFontDialog(GUI::Window* parent_window)
     };
 
     m_glyph_properties_page = GUI::WizardPage::construct("Glyph properties", "Edit details about this font.");
-    m_glyph_properties_page->body_widget().try_load_from_gml(new_font_dialog_page_2_gml).release_value_but_fixme_should_propagate_errors();
+    m_glyph_properties_page->body_widget().load_from_gml(new_font_dialog_page_2_gml).release_value_but_fixme_should_propagate_errors();
     m_glyph_properties_page->set_is_final_page(true);
 
     m_glyph_height_spinbox = m_glyph_properties_page->body_widget().find_descendant_of_type_named<GUI::SpinBox>("height_spinbox");

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
@@ -15,7 +15,7 @@ static constexpr StringView default_card_back_image_path = "/res/icons/cards/bug
 
 CardSettingsWidget::CardSettingsWidget()
 {
-    load_from_gml(card_settings_widget_gml);
+    try_load_from_gml(card_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     auto background_color = Gfx::Color::from_string(Config::read_string("Games"sv, "Cards"sv, "BackgroundColor"sv)).value_or(Gfx::Color::from_rgb(0x008000));
 

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
@@ -15,7 +15,7 @@ static constexpr StringView default_card_back_image_path = "/res/icons/cards/bug
 
 CardSettingsWidget::CardSettingsWidget()
 {
-    try_load_from_gml(card_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(card_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     auto background_color = Gfx::Color::from_string(Config::read_string("Games"sv, "Cards"sv, "BackgroundColor"sv)).value_or(Gfx::Color::from_rgb(0x008000));
 

--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -42,7 +42,7 @@ namespace Help {
 
 MainWidget::MainWidget()
 {
-    load_from_gml(help_window_gml);
+    try_load_from_gml(help_window_gml).release_value_but_fixme_should_propagate_errors();
     m_toolbar = find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     m_tab_widget = find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
     m_search_container = find_descendant_of_type_named<GUI::Widget>("search_container");

--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -42,7 +42,7 @@ namespace Help {
 
 MainWidget::MainWidget()
 {
-    try_load_from_gml(help_window_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(help_window_gml).release_value_but_fixme_should_propagate_errors();
     m_toolbar = find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     m_tab_widget = find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
     m_search_container = find_descendant_of_type_named<GUI::Widget>("search_container");

--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -100,7 +100,7 @@ FindDialog::FindDialog()
     set_title("Find");
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(find_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(find_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_text_editor = *main_widget->find_descendant_of_type_named<GUI::TextBox>("text_editor");
     m_find_button = *main_widget->find_descendant_of_type_named<GUI::Button>("find_button");

--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -100,8 +100,7 @@ FindDialog::FindDialog()
     set_title("Find");
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    if (!main_widget->load_from_gml(find_dialog_gml))
-        VERIFY_NOT_REACHED();
+    main_widget->try_load_from_gml(find_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_text_editor = *main_widget->find_descendant_of_type_named<GUI::TextBox>("text_editor");
     m_find_button = *main_widget->find_descendant_of_type_named<GUI::Button>("find_button");

--- a/Userland/Applications/HexEditor/GoToOffsetDialog.cpp
+++ b/Userland/Applications/HexEditor/GoToOffsetDialog.cpp
@@ -97,8 +97,7 @@ GoToOffsetDialog::GoToOffsetDialog()
     set_title("Go to Offset");
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    if (!main_widget->load_from_gml(go_to_offset_dialog_gml))
-        VERIFY_NOT_REACHED();
+    main_widget->try_load_from_gml(go_to_offset_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_text_editor = *main_widget->find_descendant_of_type_named<GUI::TextBox>("text_editor");
     m_go_button = *main_widget->find_descendant_of_type_named<GUI::Button>("go_button");

--- a/Userland/Applications/HexEditor/GoToOffsetDialog.cpp
+++ b/Userland/Applications/HexEditor/GoToOffsetDialog.cpp
@@ -97,7 +97,7 @@ GoToOffsetDialog::GoToOffsetDialog()
     set_title("Go to Offset");
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(go_to_offset_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(go_to_offset_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_text_editor = *main_widget->find_descendant_of_type_named<GUI::TextBox>("text_editor");
     m_go_button = *main_widget->find_descendant_of_type_named<GUI::Button>("go_button");

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -40,7 +40,7 @@ REGISTER_WIDGET(HexEditor, HexEditor);
 
 HexEditorWidget::HexEditorWidget()
 {
-    load_from_gml(hex_editor_window_gml);
+    try_load_from_gml(hex_editor_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_toolbar = *find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     m_toolbar_container = *find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -40,7 +40,7 @@ REGISTER_WIDGET(HexEditor, HexEditor);
 
 HexEditorWidget::HexEditorWidget()
 {
-    try_load_from_gml(hex_editor_window_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(hex_editor_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_toolbar = *find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     m_toolbar_container = *find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -52,8 +52,7 @@ private:
         : Dialog(parent_window)
     {
         auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-        if (!widget->load_from_gml(keymap_dialog_gml))
-            VERIFY_NOT_REACHED();
+        widget->try_load_from_gml(keymap_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
         set_resizable(false);
         resize(190, 54);
@@ -152,7 +151,7 @@ private:
 
 KeyboardSettingsWidget::KeyboardSettingsWidget()
 {
-    load_from_gml(keyboard_widget_gml);
+    try_load_from_gml(keyboard_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     auto proc_keymap = Core::File::construct("/sys/kernel/keymap");
     if (!proc_keymap->open(Core::OpenMode::ReadOnly))

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -52,7 +52,7 @@ private:
         : Dialog(parent_window)
     {
         auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-        widget->try_load_from_gml(keymap_dialog_gml).release_value_but_fixme_should_propagate_errors();
+        widget->load_from_gml(keymap_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
         set_resizable(false);
         resize(190, 54);
@@ -151,7 +151,7 @@ private:
 
 KeyboardSettingsWidget::KeyboardSettingsWidget()
 {
-    try_load_from_gml(keyboard_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(keyboard_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     auto proc_keymap = Core::File::construct("/sys/kernel/keymap");
     if (!proc_keymap->open(Core::OpenMode::ReadOnly))

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -24,7 +24,7 @@
 
 MailWidget::MailWidget()
 {
-    load_from_gml(mail_window_gml);
+    try_load_from_gml(mail_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_mailbox_list = *find_descendant_of_type_named<GUI::TreeView>("mailbox_list");
     m_individual_mailbox_view = *find_descendant_of_type_named<GUI::TableView>("individual_mailbox_view");

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -24,7 +24,7 @@
 
 MailWidget::MailWidget()
 {
-    try_load_from_gml(mail_window_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(mail_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_mailbox_list = *find_descendant_of_type_named<GUI::TreeView>("mailbox_list");
     m_individual_mailbox_view = *find_descendant_of_type_named<GUI::TableView>("individual_mailbox_view");

--- a/Userland/Applications/MailSettings/MailSettingsWidget.cpp
+++ b/Userland/Applications/MailSettings/MailSettingsWidget.cpp
@@ -42,7 +42,7 @@ MailSettingsWidget::MailSettingsWidget()
     m_common_ports.append("143");
     m_common_ports.append("993");
 
-    try_load_from_gml(mail_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(mail_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_server_inputbox = *find_descendant_of_type_named<GUI::TextBox>("server_input");
     m_server_inputbox->set_text(Config::read_string("Mail"sv, "Connection"sv, "Server"sv, ""sv));

--- a/Userland/Applications/MailSettings/MailSettingsWidget.cpp
+++ b/Userland/Applications/MailSettings/MailSettingsWidget.cpp
@@ -42,7 +42,7 @@ MailSettingsWidget::MailSettingsWidget()
     m_common_ports.append("143");
     m_common_ports.append("993");
 
-    load_from_gml(mail_settings_widget_gml);
+    try_load_from_gml(mail_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_server_inputbox = *find_descendant_of_type_named<GUI::TextBox>("server_input");
     m_server_inputbox->set_text(Config::read_string("Mail"sv, "Connection"sv, "Server"sv, ""sv));

--- a/Userland/Applications/MouseSettings/HighlightWidget.cpp
+++ b/Userland/Applications/MouseSettings/HighlightWidget.cpp
@@ -11,7 +11,7 @@
 
 HighlightWidget::HighlightWidget()
 {
-    try_load_from_gml(highlight_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(highlight_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_highlight_preview = find_descendant_of_type_named<GUI::Frame>("preview_frame")->add<MouseSettings::HighlightPreviewWidget>(palette());
 

--- a/Userland/Applications/MouseSettings/HighlightWidget.cpp
+++ b/Userland/Applications/MouseSettings/HighlightWidget.cpp
@@ -11,7 +11,7 @@
 
 HighlightWidget::HighlightWidget()
 {
-    load_from_gml(highlight_widget_gml);
+    try_load_from_gml(highlight_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_highlight_preview = find_descendant_of_type_named<GUI::Frame>("preview_frame")->add<MouseSettings::HighlightPreviewWidget>(palette());
 

--- a/Userland/Applications/MouseSettings/MouseWidget.cpp
+++ b/Userland/Applications/MouseSettings/MouseWidget.cpp
@@ -20,7 +20,7 @@ constexpr int double_click_speed_default = 250;
 
 MouseWidget::MouseWidget()
 {
-    try_load_from_gml(mouse_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(mouse_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_speed_label = *find_descendant_of_type_named<GUI::Label>("speed_label");
     m_speed_slider = *find_descendant_of_type_named<GUI::HorizontalSlider>("speed_slider");

--- a/Userland/Applications/MouseSettings/MouseWidget.cpp
+++ b/Userland/Applications/MouseSettings/MouseWidget.cpp
@@ -20,7 +20,7 @@ constexpr int double_click_speed_default = 250;
 
 MouseWidget::MouseWidget()
 {
-    load_from_gml(mouse_widget_gml);
+    try_load_from_gml(mouse_widget_gml).release_value_but_fixme_should_propagate_errors();
 
     m_speed_label = *find_descendant_of_type_named<GUI::Label>("speed_label");
     m_speed_slider = *find_descendant_of_type_named<GUI::HorizontalSlider>("speed_slider");

--- a/Userland/Applications/MouseSettings/ThemeWidget.cpp
+++ b/Userland/Applications/MouseSettings/ThemeWidget.cpp
@@ -98,7 +98,7 @@ void ThemeModel::invalidate()
 
 ThemeWidget::ThemeWidget()
 {
-    load_from_gml(theme_widget_gml);
+    try_load_from_gml(theme_widget_gml).release_value_but_fixme_should_propagate_errors();
     m_cursors_tableview = find_descendant_of_type_named<GUI::TableView>("cursors_tableview");
     m_cursors_tableview->set_highlight_selected_rows(true);
     m_cursors_tableview->set_alternating_row_colors(false);

--- a/Userland/Applications/MouseSettings/ThemeWidget.cpp
+++ b/Userland/Applications/MouseSettings/ThemeWidget.cpp
@@ -98,7 +98,7 @@ void ThemeModel::invalidate()
 
 ThemeWidget::ThemeWidget()
 {
-    try_load_from_gml(theme_widget_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(theme_widget_gml).release_value_but_fixme_should_propagate_errors();
     m_cursors_tableview = find_descendant_of_type_named<GUI::TableView>("cursors_tableview");
     m_cursors_tableview->set_highlight_selected_rows(true);
     m_cursors_tableview->set_alternating_row_colors(false);

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
@@ -30,7 +30,7 @@ static int netmask_to_cidr(IPv4Address const& address)
 
 NetworkSettingsWidget::NetworkSettingsWidget()
 {
-    load_from_gml(network_settings_gml);
+    try_load_from_gml(network_settings_gml).release_value_but_fixme_should_propagate_errors();
 
     m_adapters_combobox = *find_descendant_of_type_named<GUI::ComboBox>("adapters_combobox");
     m_enabled_checkbox = *find_descendant_of_type_named<GUI::CheckBox>("enabled_checkbox");

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
@@ -30,7 +30,7 @@ static int netmask_to_cidr(IPv4Address const& address)
 
 NetworkSettingsWidget::NetworkSettingsWidget()
 {
-    try_load_from_gml(network_settings_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(network_settings_gml).release_value_but_fixme_should_propagate_errors();
 
     m_adapters_combobox = *find_descendant_of_type_named<GUI::ComboBox>("adapters_combobox");
     m_enabled_checkbox = *find_descendant_of_type_named<GUI::CheckBox>("enabled_checkbox");

--- a/Userland/Applications/PartitionEditor/main.cpp
+++ b/Userland/Applications/PartitionEditor/main.cpp
@@ -53,7 +53,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-    widget->load_from_gml(partition_editor_window_gml);
+    TRY(widget->try_load_from_gml(partition_editor_window_gml));
 
     auto device_paths = get_device_paths();
 

--- a/Userland/Applications/PartitionEditor/main.cpp
+++ b/Userland/Applications/PartitionEditor/main.cpp
@@ -53,7 +53,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(widget->try_load_from_gml(partition_editor_window_gml));
+    TRY(widget->load_from_gml(partition_editor_window_gml));
 
     auto device_paths = get_device_paths();
 

--- a/Userland/Applications/PixelPaint/EditGuideDialog.cpp
+++ b/Userland/Applications/PixelPaint/EditGuideDialog.cpp
@@ -24,7 +24,7 @@ EditGuideDialog::EditGuideDialog(GUI::Window* parent_window, DeprecatedString co
     set_resizable(false);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(edit_guide_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(edit_guide_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto horizontal_radio = main_widget->find_descendant_of_type_named<GUI::RadioButton>("orientation_horizontal_radio");
     auto vertical_radio = main_widget->find_descendant_of_type_named<GUI::RadioButton>("orientation_vertical_radio");

--- a/Userland/Applications/PixelPaint/EditGuideDialog.cpp
+++ b/Userland/Applications/PixelPaint/EditGuideDialog.cpp
@@ -24,8 +24,7 @@ EditGuideDialog::EditGuideDialog(GUI::Window* parent_window, DeprecatedString co
     set_resizable(false);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    if (!main_widget->load_from_gml(edit_guide_dialog_gml))
-        VERIFY_NOT_REACHED();
+    main_widget->try_load_from_gml(edit_guide_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto horizontal_radio = main_widget->find_descendant_of_type_named<GUI::RadioButton>("orientation_horizontal_radio");
     auto vertical_radio = main_widget->find_descendant_of_type_named<GUI::RadioButton>("orientation_vertical_radio");

--- a/Userland/Applications/PixelPaint/FilterGallery.cpp
+++ b/Userland/Applications/PixelPaint/FilterGallery.cpp
@@ -22,7 +22,7 @@ FilterGallery::FilterGallery(GUI::Window* parent_window, ImageEditor* editor)
     set_resizable(true);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(filter_gallery_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(filter_gallery_gml).release_value_but_fixme_should_propagate_errors();
 
     m_filter_tree = main_widget->find_descendant_of_type_named<GUI::TreeView>("tree_view");
     auto apply_button = main_widget->find_descendant_of_type_named<GUI::Button>("apply_button");

--- a/Userland/Applications/PixelPaint/FilterGallery.cpp
+++ b/Userland/Applications/PixelPaint/FilterGallery.cpp
@@ -22,8 +22,7 @@ FilterGallery::FilterGallery(GUI::Window* parent_window, ImageEditor* editor)
     set_resizable(true);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    if (!main_widget->load_from_gml(filter_gallery_gml))
-        VERIFY_NOT_REACHED();
+    main_widget->try_load_from_gml(filter_gallery_gml).release_value_but_fixme_should_propagate_errors();
 
     m_filter_tree = main_widget->find_descendant_of_type_named<GUI::TreeView>("tree_view");
     auto apply_button = main_widget->find_descendant_of_type_named<GUI::Button>("apply_button");

--- a/Userland/Applications/PixelPaint/Filters/Median.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Median.cpp
@@ -46,7 +46,7 @@ RefPtr<GUI::Widget> Median::get_settings_widget()
 {
     if (!m_settings_widget) {
         m_settings_widget = GUI::Widget::construct();
-        m_settings_widget->try_load_from_gml(median_settings_gml).release_value_but_fixme_should_propagate_errors();
+        m_settings_widget->load_from_gml(median_settings_gml).release_value_but_fixme_should_propagate_errors();
         m_settings_widget->find_descendant_of_type_named<GUI::SpinBox>("filter_radius")->on_change = [this](auto value) {
             m_filter_radius = value;
             update_preview();

--- a/Userland/Applications/PixelPaint/Filters/Median.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Median.cpp
@@ -46,7 +46,7 @@ RefPtr<GUI::Widget> Median::get_settings_widget()
 {
     if (!m_settings_widget) {
         m_settings_widget = GUI::Widget::construct();
-        m_settings_widget->load_from_gml(median_settings_gml);
+        m_settings_widget->try_load_from_gml(median_settings_gml).release_value_but_fixme_should_propagate_errors();
         m_settings_widget->find_descendant_of_type_named<GUI::SpinBox>("filter_radius")->on_change = [this](auto value) {
             m_filter_radius = value;
             update_preview();

--- a/Userland/Applications/PixelPaint/LevelsDialog.cpp
+++ b/Userland/Applications/PixelPaint/LevelsDialog.cpp
@@ -19,8 +19,7 @@ LevelsDialog::LevelsDialog(GUI::Window* parent_window, ImageEditor* editor)
     set_icon(parent_window->icon());
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    if (!main_widget->load_from_gml(levels_dialog_gml))
-        VERIFY_NOT_REACHED();
+    main_widget->try_load_from_gml(levels_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     resize(305, 202);
     set_resizable(false);

--- a/Userland/Applications/PixelPaint/LevelsDialog.cpp
+++ b/Userland/Applications/PixelPaint/LevelsDialog.cpp
@@ -19,7 +19,7 @@ LevelsDialog::LevelsDialog(GUI::Window* parent_window, ImageEditor* editor)
     set_icon(parent_window->icon());
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(levels_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(levels_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     resize(305, 202);
     set_resizable(false);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -37,7 +37,7 @@ IconBag g_icon_bag;
 MainWidget::MainWidget()
     : Widget()
 {
-    load_from_gml(pixel_paint_window_gml);
+    try_load_from_gml(pixel_paint_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_toolbox = find_descendant_of_type_named<PixelPaint::ToolboxWidget>("toolbox");
     m_statusbar = *find_descendant_of_type_named<GUI::Statusbar>("statusbar");

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -37,7 +37,7 @@ IconBag g_icon_bag;
 MainWidget::MainWidget()
     : Widget()
 {
-    try_load_from_gml(pixel_paint_window_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(pixel_paint_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_toolbox = find_descendant_of_type_named<PixelPaint::ToolboxWidget>("toolbox");
     m_statusbar = *find_descendant_of_type_named<GUI::Statusbar>("statusbar");

--- a/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
@@ -28,7 +28,7 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize suggested_size, GUI::Window* p
     set_icon(parent_window->icon());
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(resize_image_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(resize_image_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto width_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("width_spinbox");
     auto height_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("height_spinbox");

--- a/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
@@ -28,8 +28,7 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize suggested_size, GUI::Window* p
     set_icon(parent_window->icon());
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    if (!main_widget->load_from_gml(resize_image_dialog_gml))
-        VERIFY_NOT_REACHED();
+    main_widget->try_load_from_gml(resize_image_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto width_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("width_spinbox");
     auto height_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("height_spinbox");

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -42,7 +42,7 @@ RunWindow::RunWindow()
     set_minimizable(false);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->load_from_gml(run_gml);
+    main_widget->try_load_from_gml(run_gml).release_value_but_fixme_should_propagate_errors();
 
     m_icon_image_widget = *main_widget->find_descendant_of_type_named<GUI::ImageWidget>("icon");
     m_icon_image_widget->set_bitmap(app_icon.bitmap_for_size(32));

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -42,7 +42,7 @@ RunWindow::RunWindow()
     set_minimizable(false);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(run_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(run_gml).release_value_but_fixme_should_propagate_errors();
 
     m_icon_image_widget = *main_widget->find_descendant_of_type_named<GUI::ImageWidget>("icon");
     m_icon_image_widget->set_bitmap(app_icon.bitmap_for_size(32));

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -322,7 +322,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     // Load widgets.
     auto mainwidget = TRY(window->set_main_widget<GUI::Widget>());
-    mainwidget->load_from_gml(space_analyzer_gml);
+    TRY(mainwidget->try_load_from_gml(space_analyzer_gml));
     auto& breadcrumbbar = *mainwidget->find_descendant_of_type_named<GUI::Breadcrumbbar>("breadcrumbbar");
     auto& treemapwidget = *mainwidget->find_descendant_of_type_named<SpaceAnalyzer::TreeMapWidget>("tree_map");
     auto& statusbar = *mainwidget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -322,7 +322,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     // Load widgets.
     auto mainwidget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(mainwidget->try_load_from_gml(space_analyzer_gml));
+    TRY(mainwidget->load_from_gml(space_analyzer_gml));
     auto& breadcrumbbar = *mainwidget->find_descendant_of_type_named<GUI::Breadcrumbbar>("breadcrumbbar");
     auto& treemapwidget = *mainwidget->find_descendant_of_type_named<SpaceAnalyzer::TreeMapWidget>("tree_map");
     auto& statusbar = *mainwidget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -318,7 +318,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
     }
 
     auto& conditional_fmt_tab = tabs.add_tab<GUI::Widget>("Conditional format");
-    conditional_fmt_tab.try_load_from_gml(cond_fmt_gml).release_value_but_fixme_should_propagate_errors();
+    conditional_fmt_tab.load_from_gml(cond_fmt_gml).release_value_but_fixme_should_propagate_errors();
     {
         auto& view = *conditional_fmt_tab.find_descendant_of_type_named<Spreadsheet::ConditionsView>("conditions_view");
         view.set_formats(&m_conditional_formats);
@@ -391,7 +391,7 @@ CellTypeMetadata CellTypeDialog::metadata() const
 ConditionView::ConditionView(ConditionalFormat& fmt)
     : m_format(fmt)
 {
-    try_load_from_gml(cond_fmt_view_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(cond_fmt_view_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& fg_input = *find_descendant_of_type_named<GUI::ColorInput>("foreground_input");
     auto& bg_input = *find_descendant_of_type_named<GUI::ColorInput>("background_input");

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -318,7 +318,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
     }
 
     auto& conditional_fmt_tab = tabs.add_tab<GUI::Widget>("Conditional format");
-    conditional_fmt_tab.load_from_gml(cond_fmt_gml);
+    conditional_fmt_tab.try_load_from_gml(cond_fmt_gml).release_value_but_fixme_should_propagate_errors();
     {
         auto& view = *conditional_fmt_tab.find_descendant_of_type_named<Spreadsheet::ConditionsView>("conditions_view");
         view.set_formats(&m_conditional_formats);
@@ -391,7 +391,7 @@ CellTypeMetadata CellTypeDialog::metadata() const
 ConditionView::ConditionView(ConditionalFormat& fmt)
     : m_format(fmt)
 {
-    load_from_gml(cond_fmt_view_gml);
+    try_load_from_gml(cond_fmt_view_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& fg_input = *find_descendant_of_type_named<GUI::ColorInput>("foreground_input");
     auto& bg_input = *find_descendant_of_type_named<GUI::ColorInput>("background_input");

--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -38,7 +38,7 @@ CSVExportDialogPage::CSVExportDialogPage(Sheet const& sheet)
         "CSV Export Options",
         "Please select the options for the csv file you wish to export to");
 
-    m_page->body_widget().try_load_from_gml(csv_export_gml).release_value_but_fixme_should_propagate_errors();
+    m_page->body_widget().load_from_gml(csv_export_gml).release_value_but_fixme_should_propagate_errors();
     m_page->set_is_final_page(true);
 
     m_delimiter_comma_radio = m_page->body_widget().find_descendant_of_type_named<GUI::RadioButton>("delimiter_comma_radio");
@@ -209,7 +209,7 @@ ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, NonnullOwnPtr<Core
 
         page->on_next_page = [] { return nullptr; };
 
-        TRY(page->body_widget().try_load_from_gml(select_format_page_gml));
+        TRY(page->body_widget().load_from_gml(select_format_page_gml));
         auto format_combo_box = page->body_widget().find_descendant_of_type_named<GUI::ComboBox>("select_format_page_format_combo_box");
 
         Vector<DeprecatedString> supported_formats {

--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -38,7 +38,7 @@ CSVExportDialogPage::CSVExportDialogPage(Sheet const& sheet)
         "CSV Export Options",
         "Please select the options for the csv file you wish to export to");
 
-    m_page->body_widget().load_from_gml(csv_export_gml);
+    m_page->body_widget().try_load_from_gml(csv_export_gml).release_value_but_fixme_should_propagate_errors();
     m_page->set_is_final_page(true);
 
     m_delimiter_comma_radio = m_page->body_widget().find_descendant_of_type_named<GUI::RadioButton>("delimiter_comma_radio");
@@ -209,7 +209,7 @@ ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, NonnullOwnPtr<Core
 
         page->on_next_page = [] { return nullptr; };
 
-        page->body_widget().load_from_gml(select_format_page_gml);
+        TRY(page->body_widget().try_load_from_gml(select_format_page_gml));
         auto format_combo_box = page->body_widget().find_descendant_of_type_named<GUI::ComboBox>("select_format_page_format_combo_box");
 
         Vector<DeprecatedString> supported_formats {

--- a/Userland/Applications/Spreadsheet/ImportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ImportDialog.cpp
@@ -32,7 +32,7 @@ CSVImportDialogPage::CSVImportDialogPage(StringView csv)
         "CSV Import Options",
         "Please select the options for the csv file you wish to import");
 
-    m_page->body_widget().try_load_from_gml(csv_import_gml).release_value_but_fixme_should_propagate_errors();
+    m_page->body_widget().load_from_gml(csv_import_gml).release_value_but_fixme_should_propagate_errors();
     m_page->set_is_final_page(true);
 
     m_delimiter_comma_radio = m_page->body_widget().find_descendant_of_type_named<GUI::RadioButton>("delimiter_comma_radio");
@@ -254,7 +254,7 @@ Result<NonnullRefPtrVector<Sheet>, DeprecatedString> ImportDialog::make_and_run_
 
         page->on_next_page = [] { return nullptr; };
 
-        page->body_widget().try_load_from_gml(select_format_page_gml).release_value_but_fixme_should_propagate_errors();
+        page->body_widget().load_from_gml(select_format_page_gml).release_value_but_fixme_should_propagate_errors();
         auto format_combo_box = page->body_widget().find_descendant_of_type_named<GUI::ComboBox>("select_format_page_format_combo_box");
 
         Vector<DeprecatedString> supported_formats {

--- a/Userland/Applications/Spreadsheet/ImportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ImportDialog.cpp
@@ -32,7 +32,7 @@ CSVImportDialogPage::CSVImportDialogPage(StringView csv)
         "CSV Import Options",
         "Please select the options for the csv file you wish to import");
 
-    m_page->body_widget().load_from_gml(csv_import_gml);
+    m_page->body_widget().try_load_from_gml(csv_import_gml).release_value_but_fixme_should_propagate_errors();
     m_page->set_is_final_page(true);
 
     m_delimiter_comma_radio = m_page->body_widget().find_descendant_of_type_named<GUI::RadioButton>("delimiter_comma_radio");
@@ -254,7 +254,7 @@ Result<NonnullRefPtrVector<Sheet>, DeprecatedString> ImportDialog::make_and_run_
 
         page->on_next_page = [] { return nullptr; };
 
-        page->body_widget().load_from_gml(select_format_page_gml);
+        page->body_widget().try_load_from_gml(select_format_page_gml).release_value_but_fixme_should_propagate_errors();
         auto format_combo_box = page->body_widget().find_descendant_of_type_named<GUI::ComboBox>("select_format_page_format_combo_box");
 
         Vector<DeprecatedString> supported_formats {

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -279,7 +279,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(560, 430);
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(main_widget->try_load_from_gml(system_monitor_gml));
+    TRY(main_widget->load_from_gml(system_monitor_gml));
     auto& tabwidget = *main_widget->find_descendant_of_type_named<GUI::TabWidget>("main_tabs");
     statusbar = main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 
@@ -513,7 +513,7 @@ ErrorOr<NonnullRefPtr<GUI::Window>> build_process_window(pid_t pid)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(main_widget->try_load_from_gml(process_window_gml));
+    TRY(main_widget->load_from_gml(process_window_gml));
 
     GUI::ModelIndex process_index;
     for (int row = 0; row < ProcessModel::the().row_count({}); ++row) {

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -279,7 +279,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(560, 430);
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    main_widget->load_from_gml(system_monitor_gml);
+    TRY(main_widget->try_load_from_gml(system_monitor_gml));
     auto& tabwidget = *main_widget->find_descendant_of_type_named<GUI::TabWidget>("main_tabs");
     statusbar = main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 
@@ -513,7 +513,7 @@ ErrorOr<NonnullRefPtr<GUI::Window>> build_process_window(pid_t pid)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    main_widget->load_from_gml(process_window_gml);
+    TRY(main_widget->try_load_from_gml(process_window_gml));
 
     GUI::ModelIndex process_index;
     for (int row = 0; row < ProcessModel::the().row_count({}); ++row) {

--- a/Userland/Applications/TerminalSettings/TerminalSettingsWidget.cpp
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsWidget.cpp
@@ -32,7 +32,7 @@
 
 TerminalSettingsMainWidget::TerminalSettingsMainWidget()
 {
-    try_load_from_gml(terminal_settings_main_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(terminal_settings_main_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& beep_bell_radio = *find_descendant_of_type_named<GUI::RadioButton>("beep_bell_radio");
     auto& visual_bell_radio = *find_descendant_of_type_named<GUI::RadioButton>("visual_bell_radio");
@@ -102,7 +102,7 @@ TerminalSettingsMainWidget::TerminalSettingsMainWidget()
 
 TerminalSettingsViewWidget::TerminalSettingsViewWidget()
 {
-    try_load_from_gml(terminal_settings_view_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(terminal_settings_view_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& slider = *find_descendant_of_type_named<GUI::HorizontalOpacitySlider>("background_opacity_slider");
     m_opacity = Config::read_i32("Terminal"sv, "Window"sv, "Opacity"sv);

--- a/Userland/Applications/TerminalSettings/TerminalSettingsWidget.cpp
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsWidget.cpp
@@ -32,7 +32,7 @@
 
 TerminalSettingsMainWidget::TerminalSettingsMainWidget()
 {
-    load_from_gml(terminal_settings_main_gml);
+    try_load_from_gml(terminal_settings_main_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& beep_bell_radio = *find_descendant_of_type_named<GUI::RadioButton>("beep_bell_radio");
     auto& visual_bell_radio = *find_descendant_of_type_named<GUI::RadioButton>("visual_bell_radio");
@@ -102,7 +102,7 @@ TerminalSettingsMainWidget::TerminalSettingsMainWidget()
 
 TerminalSettingsViewWidget::TerminalSettingsViewWidget()
 {
-    load_from_gml(terminal_settings_view_gml);
+    try_load_from_gml(terminal_settings_view_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& slider = *find_descendant_of_type_named<GUI::HorizontalOpacitySlider>("background_opacity_slider");
     m_opacity = Config::read_i32("Terminal"sv, "Window"sv, "Opacity"sv);

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -49,7 +49,7 @@ namespace TextEditor {
 
 MainWidget::MainWidget()
 {
-    load_from_gml(text_editor_window_gml);
+    try_load_from_gml(text_editor_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_toolbar = *find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     m_toolbar_container = *find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -49,7 +49,7 @@ namespace TextEditor {
 
 MainWidget::MainWidget()
 {
-    try_load_from_gml(text_editor_window_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(text_editor_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_toolbar = *find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     m_toolbar_container = *find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -212,7 +212,7 @@ ErrorOr<NonnullRefPtr<MainWidget>> MainWidget::try_create()
 
     auto main_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) MainWidget(move(alignment_model))));
 
-    TRY(main_widget->try_load_from_gml(theme_editor_gml));
+    TRY(main_widget->load_from_gml(theme_editor_gml));
     main_widget->m_preview_widget = main_widget->find_descendant_of_type_named<ThemeEditor::PreviewWidget>("preview_widget");
     main_widget->m_property_tabs = main_widget->find_descendant_of_type_named<GUI::TabWidget>("property_tabs");
 
@@ -451,7 +451,7 @@ ErrorOr<void> MainWidget::add_property_tab(PropertyTab const& property_tab)
             row_widget->set_fixed_height(22);
             TRY(property.role.visit(
                 [&](Gfx::AlignmentRole role) -> ErrorOr<void> {
-                    TRY(row_widget->try_load_from_gml(alignment_property_gml));
+                    TRY(row_widget->load_from_gml(alignment_property_gml));
 
                     auto& name_label = *row_widget->find_descendant_of_type_named<GUI::Label>("name");
                     name_label.set_text(to_string(role));
@@ -468,7 +468,7 @@ ErrorOr<void> MainWidget::add_property_tab(PropertyTab const& property_tab)
                     return {};
                 },
                 [&](Gfx::ColorRole role) -> ErrorOr<void> {
-                    TRY(row_widget->try_load_from_gml(color_property_gml));
+                    TRY(row_widget->load_from_gml(color_property_gml));
 
                     auto& name_label = *row_widget->find_descendant_of_type_named<GUI::Label>("name");
                     name_label.set_text(to_string(role));
@@ -484,7 +484,7 @@ ErrorOr<void> MainWidget::add_property_tab(PropertyTab const& property_tab)
                     return {};
                 },
                 [&](Gfx::FlagRole role) -> ErrorOr<void> {
-                    TRY(row_widget->try_load_from_gml(flag_property_gml));
+                    TRY(row_widget->load_from_gml(flag_property_gml));
 
                     auto& checkbox = *row_widget->find_descendant_of_type_named<GUI::CheckBox>("checkbox");
                     checkbox.set_text(to_string(role));
@@ -498,7 +498,7 @@ ErrorOr<void> MainWidget::add_property_tab(PropertyTab const& property_tab)
                     return {};
                 },
                 [&](Gfx::MetricRole role) -> ErrorOr<void> {
-                    TRY(row_widget->try_load_from_gml(metric_property_gml));
+                    TRY(row_widget->load_from_gml(metric_property_gml));
 
                     auto& name_label = *row_widget->find_descendant_of_type_named<GUI::Label>("name");
                     name_label.set_text(to_string(role));
@@ -514,7 +514,7 @@ ErrorOr<void> MainWidget::add_property_tab(PropertyTab const& property_tab)
                     return {};
                 },
                 [&](Gfx::PathRole role) -> ErrorOr<void> {
-                    TRY(row_widget->try_load_from_gml(path_property_gml));
+                    TRY(row_widget->load_from_gml(path_property_gml));
 
                     auto& name_label = *row_widget->find_descendant_of_type_named<GUI::Label>("name");
                     name_label.set_text(to_string(role));

--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -29,7 +29,7 @@ public:
     static ErrorOr<NonnullRefPtr<MiniWidgetGallery>> try_create()
     {
         auto gallery = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) MiniWidgetGallery()));
-        TRY(gallery->try_load_from_gml(window_preview_gml));
+        TRY(gallery->load_from_gml(window_preview_gml));
 
         gallery->for_each_child_widget([](auto& child) {
             child.set_focus_policy(GUI::FocusPolicy::NoFocus);

--- a/Userland/Applications/Welcome/WelcomeWidget.cpp
+++ b/Userland/Applications/Welcome/WelcomeWidget.cpp
@@ -22,7 +22,7 @@
 
 WelcomeWidget::WelcomeWidget()
 {
-    load_from_gml(welcome_window_gml);
+    try_load_from_gml(welcome_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_web_view = find_descendant_of_type_named<WebView::OutOfProcessWebView>("web_view");
     m_web_view->load(URL::create_with_file_scheme(DeprecatedString::formatted("{}/README.md", Core::StandardPaths::home_directory())));

--- a/Userland/Applications/Welcome/WelcomeWidget.cpp
+++ b/Userland/Applications/Welcome/WelcomeWidget.cpp
@@ -22,7 +22,7 @@
 
 WelcomeWidget::WelcomeWidget()
 {
-    try_load_from_gml(welcome_window_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(welcome_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_web_view = find_descendant_of_type_named<WebView::OutOfProcessWebView>("web_view");
     m_web_view->load(URL::create_with_file_scheme(DeprecatedString::formatted("{}/README.md", Core::StandardPaths::home_directory())));

--- a/Userland/Demos/ModelGallery/GalleryWidget.cpp
+++ b/Userland/Demos/ModelGallery/GalleryWidget.cpp
@@ -26,7 +26,7 @@ GalleryWidget::GalleryWidget()
 ErrorOr<void> GalleryWidget::load_basic_model_tab()
 {
     auto tab = TRY(m_tab_widget->try_add_tab<GUI::Widget>("Basic Model"));
-    tab->load_from_gml(basic_model_tab_gml);
+    TRY(tab->try_load_from_gml(basic_model_tab_gml));
 
     m_basic_model = BasicModel::create();
     m_basic_model_table = *tab->find_descendant_of_type_named<GUI::TableView>("model_table");

--- a/Userland/Demos/ModelGallery/GalleryWidget.cpp
+++ b/Userland/Demos/ModelGallery/GalleryWidget.cpp
@@ -26,7 +26,7 @@ GalleryWidget::GalleryWidget()
 ErrorOr<void> GalleryWidget::load_basic_model_tab()
 {
     auto tab = TRY(m_tab_widget->try_add_tab<GUI::Widget>("Basic Model"));
-    TRY(tab->try_load_from_gml(basic_model_tab_gml));
+    TRY(tab->load_from_gml(basic_model_tab_gml));
 
     m_basic_model = BasicModel::create();
     m_basic_model_table = *tab->find_descendant_of_type_named<GUI::TableView>("model_table");

--- a/Userland/Demos/WidgetGallery/DemoWizardDialog.cpp
+++ b/Userland/Demos/WidgetGallery/DemoWizardDialog.cpp
@@ -28,7 +28,7 @@ DemoWizardDialog::DemoWizardDialog(GUI::Window* parent_window)
         "Installation location",
         "Choose where Demo Application is installed on your computer.")
                    .release_value_but_fixme_should_propagate_errors();
-    m_page_1->body_widget().try_load_from_gml(demo_wizard_page_1_gml).release_value_but_fixme_should_propagate_errors();
+    m_page_1->body_widget().load_from_gml(demo_wizard_page_1_gml).release_value_but_fixme_should_propagate_errors();
     m_page_1_location_text_box = m_page_1->body_widget().find_descendant_of_type_named<GUI::TextBox>("page_1_location_text_box");
     m_page_1->on_next_page = [&]() {
         return m_page_2;
@@ -39,7 +39,7 @@ DemoWizardDialog::DemoWizardDialog(GUI::Window* parent_window)
         "Installation in progress...",
         "Please wait. Do not turn off your computer.")
                    .release_value_but_fixme_should_propagate_errors();
-    m_page_2->body_widget().try_load_from_gml(demo_wizard_page_2_gml).release_value_but_fixme_should_propagate_errors();
+    m_page_2->body_widget().load_from_gml(demo_wizard_page_2_gml).release_value_but_fixme_should_propagate_errors();
     m_page_2_progressbar = m_page_2->body_widget().find_descendant_of_type_named<GUI::Progressbar>("page_2_progressbar");
     m_page_2_timer = Core::Timer::try_create(this).release_value_but_fixme_should_propagate_errors();
     m_page_2->on_page_enter = [&]() {

--- a/Userland/Demos/WidgetGallery/DemoWizardDialog.cpp
+++ b/Userland/Demos/WidgetGallery/DemoWizardDialog.cpp
@@ -28,7 +28,7 @@ DemoWizardDialog::DemoWizardDialog(GUI::Window* parent_window)
         "Installation location",
         "Choose where Demo Application is installed on your computer.")
                    .release_value_but_fixme_should_propagate_errors();
-    m_page_1->body_widget().load_from_gml(demo_wizard_page_1_gml);
+    m_page_1->body_widget().try_load_from_gml(demo_wizard_page_1_gml).release_value_but_fixme_should_propagate_errors();
     m_page_1_location_text_box = m_page_1->body_widget().find_descendant_of_type_named<GUI::TextBox>("page_1_location_text_box");
     m_page_1->on_next_page = [&]() {
         return m_page_2;
@@ -39,7 +39,7 @@ DemoWizardDialog::DemoWizardDialog(GUI::Window* parent_window)
         "Installation in progress...",
         "Please wait. Do not turn off your computer.")
                    .release_value_but_fixme_should_propagate_errors();
-    m_page_2->body_widget().load_from_gml(demo_wizard_page_2_gml);
+    m_page_2->body_widget().try_load_from_gml(demo_wizard_page_2_gml).release_value_but_fixme_should_propagate_errors();
     m_page_2_progressbar = m_page_2->body_widget().find_descendant_of_type_named<GUI::Progressbar>("page_2_progressbar");
     m_page_2_timer = Core::Timer::try_create(this).release_value_but_fixme_should_propagate_errors();
     m_page_2->on_page_enter = [&]() {

--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -32,12 +32,12 @@
 
 GalleryWidget::GalleryWidget()
 {
-    try_load_from_gml(window_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(window_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& tab_widget = *find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
 
     auto basics_tab = tab_widget.try_add_tab<GUI::Widget>("Basics").release_value_but_fixme_should_propagate_errors();
-    basics_tab->try_load_from_gml(basics_tab_gml).release_value_but_fixme_should_propagate_errors();
+    basics_tab->load_from_gml(basics_tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_enabled_label = basics_tab->find_descendant_of_type_named<GUI::Label>("enabled_label");
     m_label_frame = basics_tab->find_descendant_of_type_named<GUI::Frame>("label_frame");
@@ -170,7 +170,7 @@ GalleryWidget::GalleryWidget()
     };
 
     auto sliders_tab = tab_widget.try_add_tab<GUI::Widget>("Sliders").release_value_but_fixme_should_propagate_errors();
-    sliders_tab->try_load_from_gml(sliders_tab_gml).release_value_but_fixme_should_propagate_errors();
+    sliders_tab->load_from_gml(sliders_tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_vertical_progressbar_left = sliders_tab->find_descendant_of_type_named<GUI::VerticalProgressbar>("vertical_progressbar_left");
     m_vertical_progressbar_left->set_value(0);
@@ -231,7 +231,7 @@ GalleryWidget::GalleryWidget()
     };
 
     auto wizards_tab = tab_widget.try_add_tab<GUI::Widget>("Wizards").release_value_but_fixme_should_propagate_errors();
-    wizards_tab->try_load_from_gml(wizards_tab_gml).release_value_but_fixme_should_propagate_errors();
+    wizards_tab->load_from_gml(wizards_tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_wizard_button = wizards_tab->find_descendant_of_type_named<GUI::Button>("wizard_button");
     m_wizard_output = wizards_tab->find_descendant_of_type_named<GUI::TextEditor>("wizard_output");
@@ -287,7 +287,7 @@ GalleryWidget::GalleryWidget()
     };
 
     auto cursors_tab = tab_widget.try_add_tab<GUI::Widget>("Cursors").release_value_but_fixme_should_propagate_errors();
-    cursors_tab->try_load_from_gml(cursors_tab_gml).release_value_but_fixme_should_propagate_errors();
+    cursors_tab->load_from_gml(cursors_tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_cursors_tableview = cursors_tab->find_descendant_of_type_named<GUI::TableView>("cursors_tableview");
     m_cursors_tableview->set_highlight_selected_rows(true);
@@ -310,7 +310,7 @@ GalleryWidget::GalleryWidget()
     };
 
     auto icons_tab = tab_widget.try_add_tab<GUI::Widget>("Icons").release_value_but_fixme_should_propagate_errors();
-    icons_tab->try_load_from_gml(icons_tab_gml).release_value_but_fixme_should_propagate_errors();
+    icons_tab->load_from_gml(icons_tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_icons_tableview = icons_tab->find_descendant_of_type_named<GUI::TableView>("icons_tableview");
     m_icons_tableview->set_highlight_selected_rows(true);

--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -32,12 +32,12 @@
 
 GalleryWidget::GalleryWidget()
 {
-    load_from_gml(window_gml);
+    try_load_from_gml(window_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& tab_widget = *find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
 
     auto basics_tab = tab_widget.try_add_tab<GUI::Widget>("Basics").release_value_but_fixme_should_propagate_errors();
-    basics_tab->load_from_gml(basics_tab_gml);
+    basics_tab->try_load_from_gml(basics_tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_enabled_label = basics_tab->find_descendant_of_type_named<GUI::Label>("enabled_label");
     m_label_frame = basics_tab->find_descendant_of_type_named<GUI::Frame>("label_frame");
@@ -170,7 +170,7 @@ GalleryWidget::GalleryWidget()
     };
 
     auto sliders_tab = tab_widget.try_add_tab<GUI::Widget>("Sliders").release_value_but_fixme_should_propagate_errors();
-    sliders_tab->load_from_gml(sliders_tab_gml);
+    sliders_tab->try_load_from_gml(sliders_tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_vertical_progressbar_left = sliders_tab->find_descendant_of_type_named<GUI::VerticalProgressbar>("vertical_progressbar_left");
     m_vertical_progressbar_left->set_value(0);
@@ -231,7 +231,7 @@ GalleryWidget::GalleryWidget()
     };
 
     auto wizards_tab = tab_widget.try_add_tab<GUI::Widget>("Wizards").release_value_but_fixme_should_propagate_errors();
-    wizards_tab->load_from_gml(wizards_tab_gml);
+    wizards_tab->try_load_from_gml(wizards_tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_wizard_button = wizards_tab->find_descendant_of_type_named<GUI::Button>("wizard_button");
     m_wizard_output = wizards_tab->find_descendant_of_type_named<GUI::TextEditor>("wizard_output");
@@ -287,7 +287,7 @@ GalleryWidget::GalleryWidget()
     };
 
     auto cursors_tab = tab_widget.try_add_tab<GUI::Widget>("Cursors").release_value_but_fixme_should_propagate_errors();
-    cursors_tab->load_from_gml(cursors_tab_gml);
+    cursors_tab->try_load_from_gml(cursors_tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_cursors_tableview = cursors_tab->find_descendant_of_type_named<GUI::TableView>("cursors_tableview");
     m_cursors_tableview->set_highlight_selected_rows(true);
@@ -310,7 +310,7 @@ GalleryWidget::GalleryWidget()
     };
 
     auto icons_tab = tab_widget.try_add_tab<GUI::Widget>("Icons").release_value_but_fixme_should_propagate_errors();
-    icons_tab->load_from_gml(icons_tab_gml);
+    icons_tab->try_load_from_gml(icons_tab_gml).release_value_but_fixme_should_propagate_errors();
 
     m_icons_tableview = icons_tab->find_descendant_of_type_named<GUI::TableView>("icons_tableview");
     m_icons_tableview->set_highlight_selected_rows(true);

--- a/Userland/DevTools/GMLPlayground/main.cpp
+++ b/Userland/DevTools/GMLPlayground/main.cpp
@@ -119,7 +119,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     editor->on_change = [&] {
         preview->remove_all_children();
-        preview->load_from_gml(editor->text(), [](DeprecatedString const& class_name) -> ErrorOr<NonnullRefPtr<Core::Object>> {
+        // FIXME: Parsing errors happen while the user is typing. What should we do about them?
+        (void)preview->try_load_from_gml(editor->text(), [](DeprecatedString const& class_name) -> ErrorOr<NonnullRefPtr<Core::Object>> {
             return UnregisteredWidget::try_create(class_name);
         });
     };

--- a/Userland/DevTools/GMLPlayground/main.cpp
+++ b/Userland/DevTools/GMLPlayground/main.cpp
@@ -120,7 +120,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     editor->on_change = [&] {
         preview->remove_all_children();
         // FIXME: Parsing errors happen while the user is typing. What should we do about them?
-        (void)preview->try_load_from_gml(editor->text(), [](DeprecatedString const& class_name) -> ErrorOr<NonnullRefPtr<Core::Object>> {
+        (void)preview->load_from_gml(editor->text(), [](DeprecatedString const& class_name) -> ErrorOr<NonnullRefPtr<Core::Object>> {
             return UnregisteredWidget::try_create(class_name);
         });
     };

--- a/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.cpp
@@ -18,7 +18,7 @@ GitCommitDialog::GitCommitDialog(GUI::Window* parent)
     set_icon(parent->icon());
 
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    widget->try_load_from_gml(git_commit_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    widget->load_from_gml(git_commit_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_message_editor = widget->find_descendant_of_type_named<GUI::TextEditor>("message_editor");
     m_cancel_button = widget->find_descendant_of_type_named<GUI::Button>("cancel_button");

--- a/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.cpp
@@ -18,7 +18,7 @@ GitCommitDialog::GitCommitDialog(GUI::Window* parent)
     set_icon(parent->icon());
 
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    widget->load_from_gml(git_commit_dialog_gml);
+    widget->try_load_from_gml(git_commit_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_message_editor = widget->find_descendant_of_type_named<GUI::TextEditor>("message_editor");
     m_cancel_button = widget->find_descendant_of_type_named<GUI::Button>("cancel_button");

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
@@ -50,7 +50,7 @@ NewProjectDialog::NewProjectDialog(GUI::Window* parent)
     set_title("New project");
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(new_project_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(new_project_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_icon_view_container = *main_widget->find_descendant_of_type_named<GUI::Widget>("icon_view_container");
     m_icon_view = m_icon_view_container->add<GUI::IconView>();

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
@@ -50,7 +50,7 @@ NewProjectDialog::NewProjectDialog(GUI::Window* parent)
     set_title("New project");
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->load_from_gml(new_project_dialog_gml);
+    main_widget->try_load_from_gml(new_project_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_icon_view_container = *main_widget->find_descendant_of_type_named<GUI::Widget>("icon_view_container");
     m_icon_view = m_icon_view_container->add<GUI::IconView>();

--- a/Userland/DevTools/HackStudio/GMLPreviewWidget.cpp
+++ b/Userland/DevTools/HackStudio/GMLPreviewWidget.cpp
@@ -28,7 +28,7 @@ void GMLPreviewWidget::load_gml(DeprecatedString const& gml)
     }
 
     // FIXME: Parsing errors happen while the user is typing. What should we do about them?
-    (void)try_load_from_gml(gml, [](DeprecatedString const& name) -> ErrorOr<NonnullRefPtr<Core::Object>> {
+    (void)load_from_gml(gml, [](DeprecatedString const& name) -> ErrorOr<NonnullRefPtr<Core::Object>> {
         return GUI::Label::try_create(DeprecatedString::formatted("{} is not registered as a GML element!", name));
     });
 

--- a/Userland/DevTools/HackStudio/GMLPreviewWidget.cpp
+++ b/Userland/DevTools/HackStudio/GMLPreviewWidget.cpp
@@ -27,7 +27,8 @@ void GMLPreviewWidget::load_gml(DeprecatedString const& gml)
         return;
     }
 
-    load_from_gml(gml, [](DeprecatedString const& name) -> ErrorOr<NonnullRefPtr<Core::Object>> {
+    // FIXME: Parsing errors happen while the user is typing. What should we do about them?
+    (void)try_load_from_gml(gml, [](DeprecatedString const& name) -> ErrorOr<NonnullRefPtr<Core::Object>> {
         return GUI::Label::try_create(DeprecatedString::formatted("{} is not registered as a GML element!", name));
     });
 

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -61,8 +61,7 @@ static Vector<DeprecatedString> lookup_database_names()
 
 MainWidget::MainWidget()
 {
-    if (!load_from_gml(sql_studio_gml))
-        VERIFY_NOT_REACHED();
+    try_load_from_gml(sql_studio_gml).release_value_but_fixme_should_propagate_errors();
 
     m_new_action = GUI::Action::create("&New", { Mod_Ctrl, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
         open_new_script();

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -61,7 +61,7 @@ static Vector<DeprecatedString> lookup_database_names()
 
 MainWidget::MainWidget()
 {
-    try_load_from_gml(sql_studio_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(sql_studio_gml).release_value_but_fixme_should_propagate_errors();
 
     m_new_action = GUI::Action::create("&New", { Mod_Ctrl, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
         open_new_script();

--- a/Userland/Games/2048/GameSizeDialog.cpp
+++ b/Userland/Games/2048/GameSizeDialog.cpp
@@ -26,8 +26,7 @@ GameSizeDialog::GameSizeDialog(GUI::Window* parent, size_t board_size, size_t ta
     set_resizable(false);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    if (!main_widget->load_from_gml(game_size_dialog_gml))
-        VERIFY_NOT_REACHED();
+    main_widget->try_load_from_gml(game_size_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto board_size_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("board_size_spinbox");
     board_size_spinbox->set_value(m_board_size);

--- a/Userland/Games/2048/GameSizeDialog.cpp
+++ b/Userland/Games/2048/GameSizeDialog.cpp
@@ -26,7 +26,7 @@ GameSizeDialog::GameSizeDialog(GUI::Window* parent, size_t board_size, size_t ta
     set_resizable(false);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(game_size_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(game_size_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto board_size_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("board_size_spinbox");
     board_size_spinbox->set_value(m_board_size);

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -67,8 +67,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(315, 336);
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    if (!main_widget->load_from_gml(game_window_gml))
-        VERIFY_NOT_REACHED();
+    TRY(main_widget->try_load_from_gml(game_window_gml));
 
     Game game { board_size, target_tile, evil_ai };
 

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -67,7 +67,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(315, 336);
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(main_widget->try_load_from_gml(game_window_gml));
+    TRY(main_widget->load_from_gml(game_window_gml));
 
     Game game { board_size, target_tile, evil_ai };
 

--- a/Userland/Games/Flood/SettingsDialog.cpp
+++ b/Userland/Games/Flood/SettingsDialog.cpp
@@ -28,7 +28,7 @@ SettingsDialog::SettingsDialog(GUI::Window* parent, size_t board_rows, size_t bo
     set_resizable(false);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(settings_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(settings_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto board_rows_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("board_rows_spinbox");
     board_rows_spinbox->set_value(m_board_rows);

--- a/Userland/Games/Flood/SettingsDialog.cpp
+++ b/Userland/Games/Flood/SettingsDialog.cpp
@@ -28,8 +28,7 @@ SettingsDialog::SettingsDialog(GUI::Window* parent, size_t board_rows, size_t bo
     set_resizable(false);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    if (!main_widget->load_from_gml(settings_dialog_gml))
-        VERIFY_NOT_REACHED();
+    main_widget->try_load_from_gml(settings_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto board_rows_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("board_rows_spinbox");
     board_rows_spinbox->set_value(m_board_rows);

--- a/Userland/Games/Flood/main.cpp
+++ b/Userland/Games/Flood/main.cpp
@@ -83,7 +83,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(304, 325);
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(main_widget->try_load_from_gml(flood_window_gml));
+    TRY(main_widget->load_from_gml(flood_window_gml));
 
     auto board_widget = TRY(main_widget->find_descendant_of_type_named<GUI::Widget>("board_widget_container")->try_add<BoardWidget>(board_rows, board_columns));
     board_widget->board()->randomize();

--- a/Userland/Games/Flood/main.cpp
+++ b/Userland/Games/Flood/main.cpp
@@ -83,8 +83,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(304, 325);
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    if (!main_widget->load_from_gml(flood_window_gml))
-        VERIFY_NOT_REACHED();
+    TRY(main_widget->try_load_from_gml(flood_window_gml));
 
     auto board_widget = TRY(main_widget->find_descendant_of_type_named<GUI::Widget>("board_widget_container")->try_add<BoardWidget>(board_rows, board_columns));
     board_widget->board()->randomize();

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -53,7 +53,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Game Of Life");
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    main_widget->load_from_gml(game_of_life_gml);
+    TRY(main_widget->try_load_from_gml(game_of_life_gml));
     main_widget->set_fill_with_background_color(true);
 
     auto& main_toolbar = *main_widget->find_descendant_of_type_named<GUI::Toolbar>("toolbar");

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -53,7 +53,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Game Of Life");
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(main_widget->try_load_from_gml(game_of_life_gml));
+    TRY(main_widget->load_from_gml(game_of_life_gml));
     main_widget->set_fill_with_background_color(true);
 
     auto& main_toolbar = *main_widget->find_descendant_of_type_named<GUI::Toolbar>("toolbar");

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -51,7 +51,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Hearts");
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(widget->try_load_from_gml(hearts_gml));
+    TRY(widget->load_from_gml(hearts_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Hearts::Game>("game");
     game.set_focus(true);

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -51,7 +51,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Hearts");
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-    widget->load_from_gml(hearts_gml);
+    TRY(widget->try_load_from_gml(hearts_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Hearts::Game>("game");
     game.set_focus(true);

--- a/Userland/Games/MasterWord/main.cpp
+++ b/Userland/Games/MasterWord/main.cpp
@@ -47,7 +47,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_resizable(false);
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    main_widget->load_from_gml(master_word_gml);
+    TRY(main_widget->try_load_from_gml(master_word_gml));
     auto& game = *main_widget->find_descendant_of_type_named<MasterWord::WordGame>("word_game");
     auto& statusbar = *main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 

--- a/Userland/Games/MasterWord/main.cpp
+++ b/Userland/Games/MasterWord/main.cpp
@@ -47,7 +47,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_resizable(false);
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(main_widget->try_load_from_gml(master_word_gml));
+    TRY(main_widget->load_from_gml(master_word_gml));
     auto& game = *main_widget->find_descendant_of_type_named<MasterWord::WordGame>("word_game");
     auto& statusbar = *main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 

--- a/Userland/Games/Minesweeper/CustomGameDialog.cpp
+++ b/Userland/Games/Minesweeper/CustomGameDialog.cpp
@@ -46,7 +46,7 @@ CustomGameDialog::CustomGameDialog(Window* parent_window)
     set_title("Custom game");
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(minesweeper_custom_game_window_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(minesweeper_custom_game_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_columns_spinbox = *main_widget->find_descendant_of_type_named<GUI::SpinBox>("columns_spinbox");
     m_rows_spinbox = *main_widget->find_descendant_of_type_named<GUI::SpinBox>("rows_spinbox");

--- a/Userland/Games/Minesweeper/CustomGameDialog.cpp
+++ b/Userland/Games/Minesweeper/CustomGameDialog.cpp
@@ -46,8 +46,7 @@ CustomGameDialog::CustomGameDialog(Window* parent_window)
     set_title("Custom game");
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    if (!main_widget->load_from_gml(minesweeper_custom_game_window_gml))
-        VERIFY_NOT_REACHED();
+    main_widget->try_load_from_gml(minesweeper_custom_game_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_columns_spinbox = *main_widget->find_descendant_of_type_named<GUI::SpinBox>("columns_spinbox");
     m_rows_spinbox = *main_widget->find_descendant_of_type_named<GUI::SpinBox>("rows_spinbox");

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -50,7 +50,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(139, 177);
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(widget->try_load_from_gml(minesweeper_window_gml));
+    TRY(widget->load_from_gml(minesweeper_window_gml));
 
     auto& separator = *widget->find_descendant_of_type_named<GUI::HorizontalSeparator>("separator");
     auto& container = *widget->find_descendant_of_type_named<GUI::Widget>("container");

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -50,7 +50,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(139, 177);
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-    widget->load_from_gml(minesweeper_window_gml);
+    TRY(widget->try_load_from_gml(minesweeper_window_gml));
 
     auto& separator = *widget->find_descendant_of_type_named<GUI::HorizontalSeparator>("separator");
     auto& container = *widget->find_descendant_of_type_named<GUI::Widget>("container");

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -49,7 +49,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(324, 345);
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(widget->try_load_from_gml(snake_gml));
+    TRY(widget->load_from_gml(snake_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Snake::Game>("game");
     game.set_focus(true);

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -84,7 +84,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         update_mode(Solitaire::Mode::SingleCardDraw);
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(widget->try_load_from_gml(solitaire_gml));
+    TRY(widget->load_from_gml(solitaire_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Solitaire::Game>("game");
     game.set_focus(true);

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -118,7 +118,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         update_statistic_display(StatisticDisplay::HighScore);
 
     auto widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(widget->try_load_from_gml(spider_gml));
+    TRY(widget->load_from_gml(spider_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Spider::Game>("game");
     game.set_focus(true);

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -93,8 +93,7 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
     , m_category_action_group(make<ActionGroup>())
 {
     auto main_widget = set_main_widget<Frame>().release_value_but_fixme_should_propagate_errors();
-    if (!main_widget->load_from_gml(emoji_input_dialog_gml))
-        VERIFY_NOT_REACHED();
+    main_widget->try_load_from_gml(emoji_input_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     set_window_type(GUI::WindowType::Popup);
     set_window_mode(GUI::WindowMode::Modeless);

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -93,7 +93,7 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
     , m_category_action_group(make<ActionGroup>())
 {
     auto main_widget = set_main_widget<Frame>().release_value_but_fixme_should_propagate_errors();
-    main_widget->try_load_from_gml(emoji_input_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(emoji_input_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     set_window_type(GUI::WindowType::Popup);
     set_window_mode(GUI::WindowMode::Modeless);

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -85,7 +85,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
     resize(560, 320);
 
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    widget->try_load_from_gml(file_picker_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    widget->load_from_gml(file_picker_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& toolbar = *widget->find_descendant_of_type_named<GUI::Toolbar>("toolbar");
 

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -85,8 +85,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
     resize(560, 320);
 
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    if (!widget->load_from_gml(file_picker_dialog_gml))
-        VERIFY_NOT_REACHED();
+    widget->try_load_from_gml(file_picker_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& toolbar = *widget->find_descendant_of_type_named<GUI::Toolbar>("toolbar");
 

--- a/Userland/Libraries/LibGUI/FontPicker.cpp
+++ b/Userland/Libraries/LibGUI/FontPicker.cpp
@@ -27,7 +27,7 @@ FontPicker::FontPicker(Window* parent_window, Gfx::Font const* current_font, boo
     set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-font-editor.png"sv).release_value_but_fixme_should_propagate_errors());
 
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    widget->try_load_from_gml(font_picker_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    widget->load_from_gml(font_picker_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_family_list_view = *widget->find_descendant_of_type_named<ListView>("family_list_view");
     m_family_list_view->set_model(ItemListModel<DeprecatedString>::create(m_families));

--- a/Userland/Libraries/LibGUI/FontPicker.cpp
+++ b/Userland/Libraries/LibGUI/FontPicker.cpp
@@ -27,8 +27,7 @@ FontPicker::FontPicker(Window* parent_window, Gfx::Font const* current_font, boo
     set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-font-editor.png"sv).release_value_but_fixme_should_propagate_errors());
 
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    if (!widget->load_from_gml(font_picker_dialog_gml))
-        VERIFY_NOT_REACHED();
+    widget->try_load_from_gml(font_picker_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_family_list_view = *widget->find_descendant_of_type_named<ListView>("family_list_view");
     m_family_list_view->set_model(ItemListModel<DeprecatedString>::create(m_families));

--- a/Userland/Libraries/LibGUI/IncrementalSearchBanner.cpp
+++ b/Userland/Libraries/LibGUI/IncrementalSearchBanner.cpp
@@ -19,7 +19,7 @@ namespace GUI {
 IncrementalSearchBanner::IncrementalSearchBanner(TextEditor& editor)
     : m_editor(editor)
 {
-    load_from_gml(incremental_search_banner_gml);
+    try_load_from_gml(incremental_search_banner_gml).release_value_but_fixme_should_propagate_errors();
     m_index_label = find_descendant_of_type_named<Label>("incremental_search_banner_index_label");
 
     m_wrap_search_button = find_descendant_of_type_named<Button>("incremental_search_banner_wrap_search_button");

--- a/Userland/Libraries/LibGUI/IncrementalSearchBanner.cpp
+++ b/Userland/Libraries/LibGUI/IncrementalSearchBanner.cpp
@@ -19,7 +19,7 @@ namespace GUI {
 IncrementalSearchBanner::IncrementalSearchBanner(TextEditor& editor)
     : m_editor(editor)
 {
-    try_load_from_gml(incremental_search_banner_gml).release_value_but_fixme_should_propagate_errors();
+    load_from_gml(incremental_search_banner_gml).release_value_but_fixme_should_propagate_errors();
     m_index_label = find_descendant_of_type_named<Label>("incremental_search_banner_index_label");
 
     m_wrap_search_button = find_descendant_of_type_named<Button>("incremental_search_banner_wrap_search_button");

--- a/Userland/Libraries/LibGUI/PasswordInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/PasswordInputDialog.cpp
@@ -23,8 +23,7 @@ PasswordInputDialog::PasswordInputDialog(Window* parent_window, DeprecatedString
     set_title(move(title));
 
     auto widget = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
-
-    widget->load_from_gml(password_input_dialog_gml);
+    widget->try_load_from_gml(password_input_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& key_icon_label = *widget->find_descendant_of_type_named<GUI::Label>("key_icon_label");
 

--- a/Userland/Libraries/LibGUI/PasswordInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/PasswordInputDialog.cpp
@@ -23,7 +23,7 @@ PasswordInputDialog::PasswordInputDialog(Window* parent_window, DeprecatedString
     set_title(move(title));
 
     auto widget = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
-    widget->try_load_from_gml(password_input_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    widget->load_from_gml(password_input_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& key_icon_label = *widget->find_descendant_of_type_named<GUI::Label>("key_icon_label");
 

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -102,7 +102,7 @@ void ScrollableContainerWidget::set_widget(GUI::Widget* widget)
     update_widget_position();
 }
 
-ErrorOr<void> ScrollableContainerWidget::load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&))
+ErrorOr<void> ScrollableContainerWidget::load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, UnregisteredChildHandler unregistered_child_handler)
 {
     if (is<GUI::GML::GMLFile>(ast.ptr()))
         return load_from_gml_ast(static_ptr_cast<GUI::GML::GMLFile>(ast)->main_class(), unregistered_child_handler);

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
@@ -30,7 +30,7 @@ private:
     void update_widget_size();
     void update_widget_position();
     void update_widget_min_size();
-    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&)) override;
+    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, UnregisteredChildHandler) override;
 
     ScrollableContainerWidget();
 

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1145,15 +1145,15 @@ void Widget::set_override_cursor(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<
     }
 }
 
-ErrorOr<void> Widget::try_load_from_gml(StringView gml_string)
+ErrorOr<void> Widget::load_from_gml(StringView gml_string)
 {
-    return try_load_from_gml(gml_string, [](DeprecatedString const& class_name) -> ErrorOr<NonnullRefPtr<Core::Object>> {
+    return load_from_gml(gml_string, [](DeprecatedString const& class_name) -> ErrorOr<NonnullRefPtr<Core::Object>> {
         dbgln("Class '{}' not registered", class_name);
         return Error::from_string_literal("Class not registered");
     });
 }
 
-ErrorOr<void> Widget::try_load_from_gml(StringView gml_string, UnregisteredChildHandler unregistered_child_handler)
+ErrorOr<void> Widget::load_from_gml(StringView gml_string, UnregisteredChildHandler unregistered_child_handler)
 {
     auto value = TRY(GML::parse_gml(gml_string));
     return load_from_gml_ast(value, unregistered_child_handler);

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1159,16 +1159,6 @@ ErrorOr<void> Widget::try_load_from_gml(StringView gml_string, UnregisteredChild
     return load_from_gml_ast(value, unregistered_child_handler);
 }
 
-bool Widget::load_from_gml(StringView gml_string)
-{
-    return !try_load_from_gml(gml_string).is_error();
-}
-
-bool Widget::load_from_gml(StringView gml_string, UnregisteredChildHandler unregistered_child_handler)
-{
-    return !try_load_from_gml(gml_string, unregistered_child_handler).is_error();
-}
-
 ErrorOr<void> Widget::load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, UnregisteredChildHandler unregistered_child_handler)
 {
     if (is<GUI::GML::GMLFile>(ast.ptr()))

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1153,7 +1153,7 @@ ErrorOr<void> Widget::try_load_from_gml(StringView gml_string)
     });
 }
 
-ErrorOr<void> Widget::try_load_from_gml(StringView gml_string, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&))
+ErrorOr<void> Widget::try_load_from_gml(StringView gml_string, UnregisteredChildHandler unregistered_child_handler)
 {
     auto value = TRY(GML::parse_gml(gml_string));
     return load_from_gml_ast(value, unregistered_child_handler);
@@ -1164,12 +1164,12 @@ bool Widget::load_from_gml(StringView gml_string)
     return !try_load_from_gml(gml_string).is_error();
 }
 
-bool Widget::load_from_gml(StringView gml_string, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&))
+bool Widget::load_from_gml(StringView gml_string, UnregisteredChildHandler unregistered_child_handler)
 {
     return !try_load_from_gml(gml_string, unregistered_child_handler).is_error();
 }
 
-ErrorOr<void> Widget::load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&))
+ErrorOr<void> Widget::load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, UnregisteredChildHandler unregistered_child_handler)
 {
     if (is<GUI::GML::GMLFile>(ast.ptr()))
         return load_from_gml_ast(static_ptr_cast<GUI::GML::GMLFile>(ast)->main_class(), unregistered_child_handler);

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -357,10 +357,6 @@ public:
     ErrorOr<void> try_load_from_gml(StringView);
     ErrorOr<void> try_load_from_gml(StringView, UnregisteredChildHandler);
 
-    // FIXME: Replace all uses of load_from_gml() with try_load_from_gml()
-    bool load_from_gml(StringView gml_string);
-    bool load_from_gml(StringView, UnregisteredChildHandler);
-
     // FIXME: remove this when all uses of shrink_to_fit are eliminated
     void set_shrink_to_fit(bool);
     bool is_shrink_to_fit() const { return preferred_width().is_shrink() || preferred_height().is_shrink(); }

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -353,12 +353,13 @@ public:
     AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> const& override_cursor() const { return m_override_cursor; }
     void set_override_cursor(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>>);
 
+    using UnregisteredChildHandler = ErrorOr<NonnullRefPtr<Core::Object>>(DeprecatedString const&);
     ErrorOr<void> try_load_from_gml(StringView);
-    ErrorOr<void> try_load_from_gml(StringView, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&));
+    ErrorOr<void> try_load_from_gml(StringView, UnregisteredChildHandler);
 
     // FIXME: Replace all uses of load_from_gml() with try_load_from_gml()
     bool load_from_gml(StringView gml_string);
-    bool load_from_gml(StringView, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&));
+    bool load_from_gml(StringView, UnregisteredChildHandler);
 
     // FIXME: remove this when all uses of shrink_to_fit are eliminated
     void set_shrink_to_fit(bool);
@@ -367,7 +368,7 @@ public:
     bool has_pending_drop() const;
 
     // In order for others to be able to call this, it needs to be public.
-    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, ErrorOr<NonnullRefPtr<Core::Object>> (*unregistered_child_handler)(DeprecatedString const&));
+    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, UnregisteredChildHandler);
 
 protected:
     Widget();

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -354,8 +354,8 @@ public:
     void set_override_cursor(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>>);
 
     using UnregisteredChildHandler = ErrorOr<NonnullRefPtr<Core::Object>>(DeprecatedString const&);
-    ErrorOr<void> try_load_from_gml(StringView);
-    ErrorOr<void> try_load_from_gml(StringView, UnregisteredChildHandler);
+    ErrorOr<void> load_from_gml(StringView);
+    ErrorOr<void> load_from_gml(StringView, UnregisteredChildHandler);
 
     // FIXME: remove this when all uses of shrink_to_fit are eliminated
     void set_shrink_to_fit(bool);

--- a/Userland/Services/LoginServer/LoginWindow.cpp
+++ b/Userland/Services/LoginServer/LoginWindow.cpp
@@ -21,7 +21,7 @@ LoginWindow::LoginWindow(GUI::Window* parent)
     set_icon(GUI::Icon::default_icon("ladyball"sv).bitmap_for_size(16));
 
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    widget->load_from_gml(login_window_gml);
+    widget->try_load_from_gml(login_window_gml).release_value_but_fixme_should_propagate_errors();
     m_banner = *widget->find_descendant_of_type_named<GUI::ImageWidget>("banner");
     m_banner->load_from_file("/res/graphics/brand-banner.png"sv);
     m_banner->set_auto_resize(true);

--- a/Userland/Services/LoginServer/LoginWindow.cpp
+++ b/Userland/Services/LoginServer/LoginWindow.cpp
@@ -21,7 +21,7 @@ LoginWindow::LoginWindow(GUI::Window* parent)
     set_icon(GUI::Icon::default_icon("ladyball"sv).bitmap_for_size(16));
 
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    widget->try_load_from_gml(login_window_gml).release_value_but_fixme_should_propagate_errors();
+    widget->load_from_gml(login_window_gml).release_value_but_fixme_should_propagate_errors();
     m_banner = *widget->find_descendant_of_type_named<GUI::ImageWidget>("banner");
     m_banner->load_from_file("/res/graphics/brand-banner.png"sv);
     m_banner->set_auto_resize(true);


### PR DESCRIPTION
- Use `try_load_from_gml()` everywhere.
- Delete `load_from_gml()`.
- Rename `try_load_from_gml()` to `load_from_gml()`.
- Also, add an alias for `UnregisteredChildHandler` as suggested previously.