### PR TITLE
GMLPlayground: Port to Core::Stream

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -131,6 +131,7 @@ public:
     void replace_all_text_without_resetting_undo_stack(StringView text);
     bool write_to_file(DeprecatedString const& path);
     bool write_to_file(Core::File&);
+    ErrorOr<void> write_to_file(Core::Stream::File&);
     bool has_selection() const { return m_selection.is_valid(); }
     DeprecatedString selected_text() const;
     size_t number_of_words() const;


### PR DESCRIPTION
This PR also adds a `Stream`-friendly overload of `LibGUI::TextEditor::write_to_file()`