### PR TITLE
LibGfx+icc: Print primary platform

### DIFF
--- a/Userland/Libraries/LibGfx/ICCProfile.cpp
+++ b/Userland/Libraries/LibGfx/ICCProfile.cpp
@@ -217,17 +217,6 @@ ErrorOr<time_t> parse_creation_date_time(ICCHeader const& header)
     return parse_date_time_number(header.profile_creation_time);
 }
 
-ErrorOr<DeviceAttributes> parse_device_attributes(ICCHeader const& header)
-{
-    // ICC v4, 7.2.14 Device attributes field
-
-    // "4 to 31": "Reserved (set to binary zero)"
-    if (header.device_attributes & 0xffff'fff0)
-        return Error::from_string_literal("ICC::Profile: Device attributes reserved bits not set to 0");
-
-    return DeviceAttributes { header.device_attributes };
-}
-
 ErrorOr<void> parse_file_signature(ICCHeader const& header)
 {
     // ICC v4, 7.2.9 Profile file signature field
@@ -267,6 +256,17 @@ Optional<DeviceModel> parse_device_model(ICCHeader const& header)
     if (header.device_model == 0)
         return {};
     return DeviceModel { header.device_model };
+}
+
+ErrorOr<DeviceAttributes> parse_device_attributes(ICCHeader const& header)
+{
+    // ICC v4, 7.2.14 Device attributes field
+
+    // "4 to 31": "Reserved (set to binary zero)"
+    if (header.device_attributes & 0xffff'fff0)
+        return Error::from_string_literal("ICC::Profile: Device attributes reserved bits not set to 0");
+
+    return DeviceAttributes { header.device_attributes };
 }
 
 ErrorOr<RenderingIntent> parse_rendering_intent(ICCHeader const& header)

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -104,6 +104,15 @@ enum class ColorSpace : u32 {
 StringView data_color_space_name(ColorSpace);
 StringView profile_connection_space_name(ColorSpace);
 
+// ICC v4, 7.2.10 Primary platform field, Table 20 — Primary platforms
+enum class PrimaryPlatform : u32 {
+    Apple = 0x4150504C,           // 'APPL'
+    Microsoft = 0x4D534654,       // 'MSFT'
+    SiliconGraphics = 0x53474920, // 'SGI '
+    Sun = 0x53554E57,             // 'SUNW'
+};
+StringView primary_platform_name(PrimaryPlatform);
+
 // ICC v4, 7.2.15 Rendering intent field
 enum class RenderingIntent {
     Perceptual,
@@ -215,6 +224,7 @@ public:
     ColorSpace connection_space() const { return m_connection_space; }
 
     time_t creation_timestamp() const { return m_creation_timestamp; }
+    PrimaryPlatform primary_platform() const { return m_primary_platform; }
     Flags flags() const { return m_flags; }
     Optional<DeviceManufacturer> device_manufacturer() const { return m_device_manufacturer; }
     Optional<DeviceModel> device_model() const { return m_device_model; }
@@ -233,6 +243,7 @@ private:
     ColorSpace m_data_color_space;
     ColorSpace m_connection_space;
     time_t m_creation_timestamp;
+    PrimaryPlatform m_primary_platform;
     Flags m_flags;
     Optional<DeviceManufacturer> m_device_manufacturer;
     Optional<DeviceModel> m_device_model;

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -37,6 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     outln("data color space: {}", Gfx::ICC::data_color_space_name(profile->data_color_space()));
     outln("connection space: {}", Gfx::ICC::profile_connection_space_name(profile->connection_space()));
     outln("creation date and time: {}", Core::DateTime::from_timestamp(profile->creation_timestamp()).to_deprecated_string());
+    outln("primary platform: {}", Gfx::ICC::primary_platform_name(profile->primary_platform()));
 
     auto flags = profile->flags();
     outln("flags: 0x{:08x}", flags.bits());


### PR DESCRIPTION
There's a small, old-timey list of platforms in the spec, but as far
as I can tell nobody is using additional platforms on Linux or Android
or what. So let's try going with an enum class instead of the FourCC
machinery for now.