### PR TITLE
LibJS+Everywhere: Make PrimitiveString and Utf16String fallible

### DIFF
--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -141,7 +141,7 @@ void StringBuilder::clear()
 
 ErrorOr<void> StringBuilder::try_append_code_point(u32 code_point)
 {
-    auto nwritten = AK::UnicodeUtils::code_point_to_utf8(code_point, [this](char c) { append(c); });
+    auto nwritten = TRY(AK::UnicodeUtils::try_code_point_to_utf8(code_point, [this](char c) { return try_append(c); }));
     if (nwritten < 0) {
         TRY(try_append(0xef));
         TRY(try_append(0xbf));

--- a/AK/UnicodeUtils.h
+++ b/AK/UnicodeUtils.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
+#include <AK/Error.h>
 #include <AK/Forward.h>
 
 namespace AK::UnicodeUtils {
@@ -30,6 +32,34 @@ template<typename Callback>
         callback((char)(((code_point >> 12) & 0x3f) | 0x80));
         callback((char)(((code_point >> 6) & 0x3f) | 0x80));
         callback((char)(((code_point >> 0) & 0x3f) | 0x80));
+        return 4;
+    }
+    return -1;
+}
+
+template<FallibleFunction<char> Callback>
+[[nodiscard]] ErrorOr<int> try_code_point_to_utf8(u32 code_point, Callback&& callback)
+{
+    if (code_point <= 0x7f) {
+        TRY(callback(static_cast<char>(code_point)));
+        return 1;
+    }
+    if (code_point <= 0x07ff) {
+        TRY(callback(static_cast<char>((((code_point >> 6) & 0x1f) | 0xc0))));
+        TRY(callback(static_cast<char>((((code_point >> 0) & 0x3f) | 0x80))));
+        return 2;
+    }
+    if (code_point <= 0xffff) {
+        TRY(callback(static_cast<char>((((code_point >> 12) & 0x0f) | 0xe0))));
+        TRY(callback(static_cast<char>((((code_point >> 6) & 0x3f) | 0x80))));
+        TRY(callback(static_cast<char>((((code_point >> 0) & 0x3f) | 0x80))));
+        return 3;
+    }
+    if (code_point <= 0x10ffff) {
+        TRY(callback(static_cast<char>((((code_point >> 18) & 0x07) | 0xf0))));
+        TRY(callback(static_cast<char>((((code_point >> 12) & 0x3f) | 0x80))));
+        TRY(callback(static_cast<char>((((code_point >> 6) & 0x3f) | 0x80))));
+        TRY(callback(static_cast<char>((((code_point >> 0) & 0x3f) | 0x80))));
         return 4;
     }
     return -1;

--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/CharacterTypes.h>
+#include <AK/Concepts.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Utf16View.h>
@@ -20,45 +21,46 @@ static constexpr u16 low_surrogate_max = 0xdfff;
 static constexpr u32 replacement_code_point = 0xfffd;
 static constexpr u32 first_supplementary_plane_code_point = 0x10000;
 
-template<typename UtfViewType>
-static Utf16Data to_utf16_impl(UtfViewType const& view)
-requires(IsSame<UtfViewType, Utf8View> || IsSame<UtfViewType, Utf32View>)
+template<OneOf<Utf8View, Utf32View> UtfViewType>
+static ErrorOr<Utf16Data> to_utf16_impl(UtfViewType const& view)
 {
     Utf16Data utf16_data;
-    utf16_data.ensure_capacity(view.length());
+    TRY(utf16_data.try_ensure_capacity(view.length()));
 
     for (auto code_point : view)
-        code_point_to_utf16(utf16_data, code_point);
+        TRY(code_point_to_utf16(utf16_data, code_point));
 
     return utf16_data;
 }
 
-Utf16Data utf8_to_utf16(StringView utf8_view)
+ErrorOr<Utf16Data> utf8_to_utf16(StringView utf8_view)
 {
     return to_utf16_impl(Utf8View { utf8_view });
 }
 
-Utf16Data utf8_to_utf16(Utf8View const& utf8_view)
+ErrorOr<Utf16Data> utf8_to_utf16(Utf8View const& utf8_view)
 {
     return to_utf16_impl(utf8_view);
 }
 
-Utf16Data utf32_to_utf16(Utf32View const& utf32_view)
+ErrorOr<Utf16Data> utf32_to_utf16(Utf32View const& utf32_view)
 {
     return to_utf16_impl(utf32_view);
 }
 
-void code_point_to_utf16(Utf16Data& string, u32 code_point)
+ErrorOr<void> code_point_to_utf16(Utf16Data& string, u32 code_point)
 {
     VERIFY(is_unicode(code_point));
 
     if (code_point < first_supplementary_plane_code_point) {
-        string.append(static_cast<u16>(code_point));
+        TRY(string.try_append(static_cast<u16>(code_point)));
     } else {
         code_point -= first_supplementary_plane_code_point;
-        string.append(static_cast<u16>(high_surrogate_min | (code_point >> 10)));
-        string.append(static_cast<u16>(low_surrogate_min | (code_point & 0x3ff)));
+        TRY(string.try_append(static_cast<u16>(high_surrogate_min | (code_point >> 10))));
+        TRY(string.try_append(static_cast<u16>(low_surrogate_min | (code_point & 0x3ff))));
     }
+
+    return {};
 }
 
 bool Utf16View::is_high_surrogate(u16 code_unit)

--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -81,7 +81,7 @@ u32 Utf16View::decode_surrogate_pair(u16 high_surrogate, u16 low_surrogate)
     return ((high_surrogate - high_surrogate_min) << 10) + (low_surrogate - low_surrogate_min) + first_supplementary_plane_code_point;
 }
 
-DeprecatedString Utf16View::to_utf8(AllowInvalidCodeUnits allow_invalid_code_units) const
+ErrorOr<DeprecatedString> Utf16View::to_utf8(AllowInvalidCodeUnits allow_invalid_code_units) const
 {
     StringBuilder builder;
 
@@ -92,17 +92,17 @@ DeprecatedString Utf16View::to_utf8(AllowInvalidCodeUnits allow_invalid_code_uni
 
                 if ((next < end_ptr()) && is_low_surrogate(*next)) {
                     auto code_point = decode_surrogate_pair(*ptr, *next);
-                    builder.append_code_point(code_point);
+                    TRY(builder.try_append_code_point(code_point));
                     ++ptr;
                     continue;
                 }
             }
 
-            builder.append_code_point(static_cast<u32>(*ptr));
+            TRY(builder.try_append_code_point(static_cast<u32>(*ptr)));
         }
     } else {
         for (auto code_point : *this)
-            builder.append_code_point(code_point);
+            TRY(builder.try_append_code_point(code_point));
     }
 
     return builder.build();

--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -21,10 +21,10 @@ static constexpr u32 replacement_code_point = 0xfffd;
 static constexpr u32 first_supplementary_plane_code_point = 0x10000;
 
 template<typename UtfViewType>
-static Vector<u16, 1> to_utf16_impl(UtfViewType const& view)
+static Utf16Data to_utf16_impl(UtfViewType const& view)
 requires(IsSame<UtfViewType, Utf8View> || IsSame<UtfViewType, Utf32View>)
 {
-    Vector<u16, 1> utf16_data;
+    Utf16Data utf16_data;
     utf16_data.ensure_capacity(view.length());
 
     for (auto code_point : view)
@@ -33,22 +33,22 @@ requires(IsSame<UtfViewType, Utf8View> || IsSame<UtfViewType, Utf32View>)
     return utf16_data;
 }
 
-Vector<u16, 1> utf8_to_utf16(StringView utf8_view)
+Utf16Data utf8_to_utf16(StringView utf8_view)
 {
     return to_utf16_impl(Utf8View { utf8_view });
 }
 
-Vector<u16, 1> utf8_to_utf16(Utf8View const& utf8_view)
+Utf16Data utf8_to_utf16(Utf8View const& utf8_view)
 {
     return to_utf16_impl(utf8_view);
 }
 
-Vector<u16, 1> utf32_to_utf16(Utf32View const& utf32_view)
+Utf16Data utf32_to_utf16(Utf32View const& utf32_view)
 {
     return to_utf16_impl(utf32_view);
 }
 
-void code_point_to_utf16(Vector<u16, 1>& string, u32 code_point)
+void code_point_to_utf16(Utf16Data& string, u32 code_point)
 {
     VERIFY(is_unicode(code_point));
 

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -75,7 +75,7 @@ public:
         No,
     };
 
-    DeprecatedString to_utf8(AllowInvalidCodeUnits = AllowInvalidCodeUnits::No) const;
+    ErrorOr<DeprecatedString> to_utf8(AllowInvalidCodeUnits = AllowInvalidCodeUnits::No) const;
 
     bool is_null() const { return m_code_units.is_null(); }
     bool is_empty() const { return m_code_units.is_empty(); }

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <AK/Error.h>
 #include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/Optional.h>
@@ -18,10 +19,10 @@ namespace AK {
 
 using Utf16Data = Vector<u16, 1>;
 
-Utf16Data utf8_to_utf16(StringView);
-Utf16Data utf8_to_utf16(Utf8View const&);
-Utf16Data utf32_to_utf16(Utf32View const&);
-void code_point_to_utf16(Utf16Data&, u32);
+ErrorOr<Utf16Data> utf8_to_utf16(StringView);
+ErrorOr<Utf16Data> utf8_to_utf16(Utf8View const&);
+ErrorOr<Utf16Data> utf32_to_utf16(Utf32View const&);
+ErrorOr<void> code_point_to_utf16(Utf16Data&, u32);
 
 class Utf16View;
 

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -16,10 +16,12 @@
 
 namespace AK {
 
-Vector<u16, 1> utf8_to_utf16(StringView);
-Vector<u16, 1> utf8_to_utf16(Utf8View const&);
-Vector<u16, 1> utf32_to_utf16(Utf32View const&);
-void code_point_to_utf16(Vector<u16, 1>&, u32);
+using Utf16Data = Vector<u16, 1>;
+
+Utf16Data utf8_to_utf16(StringView);
+Utf16Data utf8_to_utf16(Utf8View const&);
+Utf16Data utf32_to_utf16(Utf32View const&);
+void code_point_to_utf16(Utf16Data&, u32);
 
 class Utf16View;
 
@@ -126,5 +128,6 @@ struct AK::Formatter<AK::Utf16View> : Formatter<FormatString> {
 };
 
 #if USING_AK_GLOBALLY
+using AK::Utf16Data;
 using AK::Utf16View;
 #endif

--- a/Tests/AK/TestUtf16.cpp
+++ b/Tests/AK/TestUtf16.cpp
@@ -14,7 +14,7 @@
 
 TEST_CASE(decode_ascii)
 {
-    auto string = AK::utf8_to_utf16("Hello World!11"sv);
+    auto string = MUST(AK::utf8_to_utf16("Hello World!11"sv));
     Utf16View view { string };
 
     size_t valid_code_units = 0;
@@ -33,7 +33,7 @@ TEST_CASE(decode_ascii)
 
 TEST_CASE(decode_utf8)
 {
-    auto string = AK::utf8_to_utf16("Привет, мир! 😀 γειά σου κόσμος こんにちは世界"sv);
+    auto string = MUST(AK::utf8_to_utf16("Привет, мир! 😀 γειά σου κόσμος こんにちは世界"sv));
     Utf16View view { string };
 
     size_t valid_code_units = 0;
@@ -54,7 +54,7 @@ TEST_CASE(encode_utf8)
 {
     {
         DeprecatedString utf8_string("Привет, мир! 😀 γειά σου κόσμος こんにちは世界");
-        auto string = AK::utf8_to_utf16(utf8_string);
+        auto string = MUST(AK::utf8_to_utf16(utf8_string));
         Utf16View view { string };
         EXPECT_EQ(view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes), utf8_string);
         EXPECT_EQ(view.to_utf8(Utf16View::AllowInvalidCodeUnits::No), utf8_string);
@@ -91,7 +91,7 @@ TEST_CASE(decode_utf16)
 
 TEST_CASE(iterate_utf16)
 {
-    auto string = AK::utf8_to_utf16("Привет 😀"sv);
+    auto string = MUST(AK::utf8_to_utf16("Привет 😀"sv));
     Utf16View view { string };
     auto iterator = view.begin();
 
@@ -263,7 +263,7 @@ TEST_CASE(decode_invalid_utf16)
 
 TEST_CASE(substring_view)
 {
-    auto string = AK::utf8_to_utf16("Привет 😀"sv);
+    auto string = MUST(AK::utf8_to_utf16("Привет 😀"sv));
     {
         Utf16View view { string };
         view = view.substring_view(7, 2);

--- a/Tests/AK/TestUtf16.cpp
+++ b/Tests/AK/TestUtf16.cpp
@@ -56,14 +56,14 @@ TEST_CASE(encode_utf8)
         DeprecatedString utf8_string("Привет, мир! 😀 γειά σου κόσμος こんにちは世界");
         auto string = MUST(AK::utf8_to_utf16(utf8_string));
         Utf16View view { string };
-        EXPECT_EQ(view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes), utf8_string);
-        EXPECT_EQ(view.to_utf8(Utf16View::AllowInvalidCodeUnits::No), utf8_string);
+        EXPECT_EQ(MUST(view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes)), utf8_string);
+        EXPECT_EQ(MUST(view.to_utf8(Utf16View::AllowInvalidCodeUnits::No)), utf8_string);
     }
     {
         auto encoded = Array { (u16)0xd83d };
         Utf16View view { encoded };
-        EXPECT_EQ(view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes), "\xed\xa0\xbd"sv);
-        EXPECT_EQ(view.to_utf8(Utf16View::AllowInvalidCodeUnits::No), "\ufffd"sv);
+        EXPECT_EQ(MUST(view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes)), "\xed\xa0\xbd"sv);
+        EXPECT_EQ(MUST(view.to_utf8(Utf16View::AllowInvalidCodeUnits::No)), "\ufffd"sv);
     }
 }
 
@@ -269,14 +269,14 @@ TEST_CASE(substring_view)
         view = view.substring_view(7, 2);
 
         EXPECT(view.length_in_code_units() == 2);
-        EXPECT_EQ(view.to_utf8(), "😀"sv);
+        EXPECT_EQ(MUST(view.to_utf8()), "😀"sv);
     }
     {
         Utf16View view { string };
         view = view.substring_view(7, 1);
 
         EXPECT(view.length_in_code_units() == 1);
-        EXPECT_EQ(view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes), "\xed\xa0\xbd"sv);
-        EXPECT_EQ(view.to_utf8(Utf16View::AllowInvalidCodeUnits::No), "\ufffd"sv);
+        EXPECT_EQ(MUST(view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes)), "\xed\xa0\xbd"sv);
+        EXPECT_EQ(MUST(view.to_utf8(Utf16View::AllowInvalidCodeUnits::No)), "\ufffd"sv);
     }
 }

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -62,14 +62,14 @@ TESTJS_GLOBAL_FUNCTION(mark_as_garbage, markAsGarbage)
         return execution_context->lexical_environment != nullptr;
     });
     if (!outer_environment.has_value())
-        return vm.throw_completion<JS::ReferenceError>(JS::ErrorType::UnknownIdentifier, variable_name.deprecated_string());
+        return vm.throw_completion<JS::ReferenceError>(JS::ErrorType::UnknownIdentifier, TRY(variable_name.deprecated_string()));
 
-    auto reference = TRY(vm.resolve_binding(variable_name.deprecated_string(), outer_environment.value()->lexical_environment));
+    auto reference = TRY(vm.resolve_binding(TRY(variable_name.deprecated_string()), outer_environment.value()->lexical_environment));
 
     auto value = TRY(reference.get_value(vm));
 
     if (!can_be_held_weakly(value))
-        return vm.throw_completion<JS::TypeError>(JS::ErrorType::CannotBeHeldWeakly, DeprecatedString::formatted("Variable with name {}", variable_name.deprecated_string()));
+        return vm.throw_completion<JS::TypeError>(JS::ErrorType::CannotBeHeldWeakly, DeprecatedString::formatted("Variable with name {}", TRY(variable_name.deprecated_string())));
 
     vm.heap().uproot_cell(&value.as_cell());
     TRY(reference.delete_(vm));

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -754,7 +754,7 @@ TEST_CASE(ECMA262_unicode_match)
     for (auto& test : tests) {
         Regex<ECMA262> re(test.pattern, (ECMAScriptFlags)regex::AllFlags::Global | test.options);
 
-        auto subject = AK::utf8_to_utf16(test.subject);
+        auto subject = MUST(AK::utf8_to_utf16(test.subject));
         Utf16View view { subject };
 
         if constexpr (REGEX_DEBUG) {
@@ -868,7 +868,7 @@ TEST_CASE(ECMA262_property_match)
     for (auto& test : tests) {
         Regex<ECMA262> re(test.pattern, (ECMAScriptFlags)regex::AllFlags::Global | regex::ECMAScriptFlags::BrowserExtended | test.options);
 
-        auto subject = AK::utf8_to_utf16(test.subject);
+        auto subject = MUST(AK::utf8_to_utf16(test.subject));
         Utf16View view { subject };
 
         if constexpr (REGEX_DEBUG) {

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -372,7 +372,7 @@ void HexEditorWidget::update_inspector_values(size_t position)
         if (valid_code_units == 0)
             value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::UTF16, "");
         else
-            value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::UTF16, utf16_view.unicode_substring_view(0, 1).to_utf8());
+            value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::UTF16, utf16_view.unicode_substring_view(0, 1).to_utf8().release_value_but_fixme_should_propagate_errors());
     } else {
         value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::UTF16, "");
     }

--- a/Userland/Applications/HexEditor/ValueInspectorModel.h
+++ b/Userland/Applications/HexEditor/ValueInspectorModel.h
@@ -142,8 +142,8 @@ public:
                 return 0;
             }
             case UTF16: {
-                auto utf16_view = Utf16View(utf8_to_utf16(m_values.at(index.row())));
-                if (utf16_view.validate())
+                auto utf16_data = utf8_to_utf16(m_values.at(index.row())).release_value_but_fixme_should_propagate_errors();
+                if (Utf16View utf16_view { utf16_data }; utf16_view.validate())
                     return static_cast<i32>(utf16_view.length_in_code_units() * 2);
                 return 0;
             }

--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -196,7 +196,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::get_real_cell_contents)
     auto name_value = vm.argument(0);
     if (!name_value.is_string())
         return vm.throw_completion<JS::TypeError>("Expected a String argument to get_real_cell_contents()");
-    auto position = sheet_object->m_sheet.parse_cell_name(name_value.as_string().deprecated_string());
+    auto position = sheet_object->m_sheet.parse_cell_name(TRY(name_value.as_string().deprecated_string()));
     if (!position.has_value())
         return vm.throw_completion<JS::TypeError>("Invalid cell name");
 
@@ -225,7 +225,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::set_real_cell_contents)
     auto name_value = vm.argument(0);
     if (!name_value.is_string())
         return vm.throw_completion<JS::TypeError>("Expected the first argument of set_real_cell_contents() to be a String");
-    auto position = sheet_object->m_sheet.parse_cell_name(name_value.as_string().deprecated_string());
+    auto position = sheet_object->m_sheet.parse_cell_name(TRY(name_value.as_string().deprecated_string()));
     if (!position.has_value())
         return vm.throw_completion<JS::TypeError>("Invalid cell name");
 
@@ -234,7 +234,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::set_real_cell_contents)
         return vm.throw_completion<JS::TypeError>("Expected the second argument of set_real_cell_contents() to be a String");
 
     auto& cell = sheet_object->m_sheet.ensure(position.value());
-    auto& new_contents = new_contents_value.as_string().deprecated_string();
+    auto const& new_contents = TRY(new_contents_value.as_string().deprecated_string());
     cell.set_data(new_contents);
     return JS::js_null();
 }
@@ -255,7 +255,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::parse_cell_name)
     auto name_value = vm.argument(0);
     if (!name_value.is_string())
         return vm.throw_completion<JS::TypeError>("Expected a String argument to parse_cell_name()");
-    auto position = sheet_object->m_sheet.parse_cell_name(name_value.as_string().deprecated_string());
+    auto position = sheet_object->m_sheet.parse_cell_name(TRY(name_value.as_string().deprecated_string()));
     if (!position.has_value())
         return JS::js_undefined();
 
@@ -301,7 +301,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::column_index)
     if (!column_name.is_string())
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "String");
 
-    auto& column_name_str = column_name.as_string().deprecated_string();
+    auto const& column_name_str = TRY(column_name.as_string().deprecated_string());
 
     auto* this_object = TRY(vm.this_value().to_object(vm));
 
@@ -326,7 +326,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::column_arithmetic)
     if (!column_name.is_string())
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "String");
 
-    auto& column_name_str = column_name.as_string().deprecated_string();
+    auto const& column_name_str = TRY(column_name.as_string().deprecated_string());
 
     auto offset = TRY(vm.argument(1).to_number(vm));
     auto offset_number = static_cast<i32>(offset.as_double());
@@ -354,7 +354,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::get_column_bound)
     if (!column_name.is_string())
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "String");
 
-    auto& column_name_str = column_name.as_string().deprecated_string();
+    auto const& column_name_str = TRY(column_name.as_string().deprecated_string());
     auto* this_object = TRY(vm.this_value().to_object(vm));
 
     if (!is<SheetGlobalObject>(this_object))
@@ -405,7 +405,7 @@ JS_DEFINE_NATIVE_FUNCTION(WorkbookObject::sheet)
     auto& workbook = static_cast<WorkbookObject*>(this_object)->m_workbook;
 
     if (name_value.is_string()) {
-        auto& name = name_value.as_string().deprecated_string();
+        auto const& name = TRY(name_value.as_string().deprecated_string());
         for (auto& sheet : workbook.sheets()) {
             if (sheet.name() == name)
                 return JS::Value(&sheet.global_object());

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -3446,7 +3446,7 @@ Completion ImportCall::execute(Interpreter& interpreter) const
                 // 4. If supportedAssertions contains key, then
                 if (supported_assertions.contains_slow(property_key.to_string())) {
                     // a. Append { [[Key]]: key, [[Value]]: value } to assertions.
-                    assertions.empend(property_key.to_string(), value.as_string().deprecated_string());
+                    assertions.empend(property_key.to_string(), TRY(value.as_string().deprecated_string()));
                 }
             }
         }

--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -212,7 +212,7 @@ ThrowCompletionOr<Value> Console::assert_()
         // 3. Otherwise:
         else {
             // 1. Let concat be the concatenation of message, U+003A (:), U+0020 SPACE, and first.
-            auto concat = PrimitiveString::create(vm, DeprecatedString::formatted("{}: {}", message->deprecated_string(), first.to_string(vm).value()));
+            auto concat = PrimitiveString::create(vm, DeprecatedString::formatted("{}: {}", TRY(message->deprecated_string()), first.to_string(vm).value()));
             // 2. Set data[0] to concat.
             data[0] = concat;
         }

--- a/Userland/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.cpp
+++ b/Userland/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.cpp
@@ -20,7 +20,7 @@ ThrowCompletionOr<Value> IsHTMLDDA::call()
     auto& vm = this->vm();
     if (vm.argument_count() == 0)
         return js_null();
-    if (vm.argument(0).is_string() && vm.argument(0).as_string().deprecated_string().is_empty())
+    if (vm.argument(0).is_string() && TRY(vm.argument(0).as_string().deprecated_string()).is_empty())
         return js_null();
     // Not sure if this really matters, INTERPRETING.md simply says:
     // * IsHTMLDDA - (present only in implementations that can provide it) an object that:

--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -777,9 +777,13 @@ ErrorOr<void> print_intl_segmenter(JS::PrintContext& print_context, JS::Intl::Se
 
 ErrorOr<void> print_intl_segments(JS::PrintContext& print_context, JS::Intl::Segments const& segments, HashTable<JS::Object*>& seen_objects)
 {
+    auto segments_string = JS::Utf16String::create(segments.vm(), segments.segments_string());
+    if (segments_string.is_error())
+        return Error::from_errno(ENOMEM);
+
     TRY(print_type(print_context, "Segments"));
     out("\n  string: ");
-    TRY(print_value(print_context, JS::PrimitiveString::create(segments.vm(), segments.segments_string()), seen_objects));
+    TRY(print_value(print_context, JS::PrimitiveString::create(segments.vm(), segments_string.release_value()), seen_objects));
     out("\n  segmenter: ");
     TRY(print_value(print_context, &segments.segments_segmenter(), seen_objects));
     return {};

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -1265,7 +1265,7 @@ ThrowCompletionOr<DeprecatedString> get_substitution(VM& vm, Utf16View const& ma
         } else if (is_ascii_digit(next)) {
             bool is_two_digits = (i + 2 < replace_view.length_in_code_units()) && is_ascii_digit(replace_view.code_unit_at(i + 2));
 
-            auto capture_position_string = replace_view.substring_view(i + 1, is_two_digits ? 2 : 1).to_utf8();
+            auto capture_position_string = TRY_OR_THROW_OOM(vm, replace_view.substring_view(i + 1, is_two_digits ? 2 : 1).to_utf8());
             auto capture_position = capture_position_string.to_uint();
 
             if (capture_position.has_value() && (*capture_position > 0) && (*capture_position <= captures.size())) {
@@ -1295,7 +1295,7 @@ ThrowCompletionOr<DeprecatedString> get_substitution(VM& vm, Utf16View const& ma
                 result.append(curr);
             } else {
                 auto group_name_view = replace_view.substring_view(start_position, *end_position - start_position);
-                auto group_name = group_name_view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes);
+                auto group_name = TRY_OR_THROW_OOM(vm, group_name_view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes));
 
                 auto capture = TRY(named_captures.as_object().get(group_name));
 
@@ -1311,7 +1311,7 @@ ThrowCompletionOr<DeprecatedString> get_substitution(VM& vm, Utf16View const& ma
         }
     }
 
-    return Utf16String(move(result)).to_utf8();
+    return TRY_OR_THROW_OOM(vm, Utf16View { result }.to_utf8());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -1233,7 +1233,7 @@ ThrowCompletionOr<DeprecatedString> get_substitution(VM& vm, Utf16View const& ma
     auto replace_string = TRY(replacement_template.to_utf16_string(vm));
     auto replace_view = replace_string.view();
 
-    Vector<u16, 1> result;
+    Utf16Data result;
 
     for (size_t i = 0; i < replace_view.length_in_code_units(); ++i) {
         u16 curr = replace_view.code_unit_at(i);

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -594,7 +594,7 @@ ThrowCompletionOr<Value> perform_eval(VM& vm, Value x, CallerMode strict_caller,
         .in_class_field_initializer = in_class_field_initializer,
     };
 
-    Parser parser { Lexer { code_string.deprecated_string() }, Program::Type::Script, move(initial_state) };
+    Parser parser { Lexer { TRY(code_string.deprecated_string()) }, Program::Type::Script, move(initial_state) };
     auto program = parser.parse_program(strict_caller == CallerMode::Strict);
 
     //     b. If script is a List of errors, throw a SyntaxError exception.

--- a/Userland/Libraries/LibJS/Runtime/Completion.h
+++ b/Userland/Libraries/LibJS/Runtime/Completion.h
@@ -140,7 +140,7 @@ public:
     }
 
     Optional(Optional&& other)
-        : m_value(other.m_value)
+        : m_value(move(other.m_value))
     {
     }
 

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -241,7 +241,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DateConstructor::construct(FunctionObjec
             if (primitive.is_string()) {
                 // 1. Assert: The next step never returns an abrupt completion because Type(v) is String.
                 // 2. Let tv be the result of parsing v as a date, in exactly the same manner as for the parse method (21.4.3.2).
-                time_value = parse_date_string(primitive.as_string().deprecated_string());
+                time_value = parse_date_string(TRY(primitive.as_string().deprecated_string()));
             }
             // iii. Else,
             else {

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -1257,7 +1257,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::symbol_to_primitive)
     auto hint_value = vm.argument(0);
     if (!hint_value.is_string())
         return vm.throw_completion<TypeError>(ErrorType::InvalidHint, hint_value.to_string_without_side_effects());
-    auto& hint = hint_value.as_string().deprecated_string();
+    auto const& hint = TRY(hint_value.as_string().deprecated_string());
     Value::PreferredType try_first;
     if (hint == "string" || hint == "default")
         try_first = Value::PreferredType::String;

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -110,6 +110,7 @@
         "Object prototype must not be {} on a super property access")                                                                   \
     M(ObjectPrototypeWrongType, "Prototype must be an object or null")                                                                  \
     M(OptionIsNotValidValue, "{} is not a valid value for option {}")                                                                   \
+    M(OutOfMemory, "Out of memory")                                                                                                     \
     M(OverloadResolutionFailed, "Overload resolution failed")                                                                           \
     M(PrivateFieldAlreadyDeclared, "Private field '{}' has already been declared")                                                      \
     M(PrivateFieldDoesNotExistOnObject, "Private field '{}' does not exist on object")                                                  \

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -490,7 +490,7 @@ JS_DEFINE_NATIVE_FUNCTION(GlobalObject::escape)
 {
     auto string = TRY(vm.argument(0).to_string(vm));
     StringBuilder escaped;
-    for (auto code_point : utf8_to_utf16(string)) {
+    for (auto code_point : TRY_OR_THROW_OOM(vm, utf8_to_utf16(string))) {
         if (code_point < 256) {
             if ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@*_+-./"sv.contains(static_cast<char>(code_point)))
                 escaped.append(code_point);

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -343,7 +343,7 @@ JS_DEFINE_NATIVE_FUNCTION(GlobalObject::eval)
 // 19.2.6.1.1 Encode ( string, unescapedSet ), https://tc39.es/ecma262/#sec-encode
 static ThrowCompletionOr<DeprecatedString> encode(VM& vm, DeprecatedString const& string, StringView unescaped_set)
 {
-    auto utf16_string = Utf16String(string);
+    auto utf16_string = TRY(Utf16String::create(vm, string));
 
     // 1. Let strLen be the length of string.
     auto string_length = utf16_string.length_in_code_units();

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -376,14 +376,14 @@ static auto& find_key_in_value(T& value, StringView key)
 }
 
 // 9.2.7 ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData ), https://tc39.es/ecma402/#sec-resolvelocale
-LocaleResult resolve_locale(Vector<DeprecatedString> const& requested_locales, LocaleOptions const& options, Span<StringView const> relevant_extension_keys)
+ThrowCompletionOr<LocaleResult> resolve_locale(Vector<DeprecatedString> const& requested_locales, LocaleOptions const& options, Span<StringView const> relevant_extension_keys)
 {
     // 1. Let matcher be options.[[localeMatcher]].
     auto const& matcher = options.locale_matcher;
     MatcherResult matcher_result;
 
     // 2. If matcher is "lookup", then
-    if (matcher.is_string() && (matcher.as_string().deprecated_string() == "lookup"sv)) {
+    if (matcher.is_string() && (TRY(matcher.as_string().deprecated_string()) == "lookup"sv)) {
         // a. Let r be ! LookupMatcher(availableLocales, requestedLocales).
         matcher_result = lookup_matcher(requested_locales);
     }
@@ -578,7 +578,7 @@ ThrowCompletionOr<Array*> supported_locales(VM& vm, Vector<DeprecatedString> con
     Vector<DeprecatedString> supported_locales;
 
     // 3. If matcher is "best fit", then
-    if (matcher.as_string().deprecated_string() == "best fit"sv) {
+    if (TRY(matcher.as_string().deprecated_string()) == "best fit"sv) {
         // a. Let supportedLocales be BestFitSupportedLocales(availableLocales, requestedLocales).
         supported_locales = best_fit_supported_locales(requested_locales);
     }

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -86,7 +86,7 @@ bool is_well_formed_unit_identifier(StringView unit_identifier);
 ThrowCompletionOr<Vector<DeprecatedString>> canonicalize_locale_list(VM&, Value locales);
 Optional<DeprecatedString> best_available_locale(StringView locale);
 DeprecatedString insert_unicode_extension_and_canonicalize(::Locale::LocaleID locale_id, ::Locale::LocaleExtension extension);
-LocaleResult resolve_locale(Vector<DeprecatedString> const& requested_locales, LocaleOptions const& options, Span<StringView const> relevant_extension_keys);
+ThrowCompletionOr<LocaleResult> resolve_locale(Vector<DeprecatedString> const& requested_locales, LocaleOptions const& options, Span<StringView const> relevant_extension_keys);
 Vector<DeprecatedString> lookup_supported_locales(Vector<DeprecatedString> const& requested_locales);
 Vector<DeprecatedString> best_fit_supported_locales(Vector<DeprecatedString> const& requested_locales);
 ThrowCompletionOr<Array*> supported_locales(VM&, Vector<DeprecatedString> const& requested_locales, Value options);

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -27,7 +27,7 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
     auto usage = TRY(get_option(vm, *options, vm.names.usage, OptionType::String, { "sort"sv, "search"sv }, "sort"sv));
 
     // 4. Set collator.[[Usage]] to usage.
-    collator.set_usage(usage.as_string().deprecated_string());
+    collator.set_usage(TRY(usage.as_string().deprecated_string()));
 
     // 5. If usage is "sort", then
     //     a. Let localeData be %Collator%.[[SortLocaleData]].
@@ -49,11 +49,11 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
     // 11. If collation is not undefined, then
     if (!collation.is_undefined()) {
         // a. If collation does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
-        if (!::Locale::is_type_identifier(collation.as_string().deprecated_string()))
+        if (!::Locale::is_type_identifier(TRY(collation.as_string().deprecated_string())))
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, collation, "collation"sv);
 
         // 12. Set opt.[[co]] to collation.
-        opt.co = collation.as_string().deprecated_string();
+        opt.co = TRY(collation.as_string().deprecated_string());
     }
 
     // 13. Let numeric be ? GetOption(options, "numeric", "boolean", undefined, undefined).
@@ -69,13 +69,13 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
     // 17. Set opt.[[kf]] to caseFirst.
     auto case_first = TRY(get_option(vm, *options, vm.names.caseFirst, OptionType::String, { "upper"sv, "lower"sv, "false"sv }, Empty {}));
     if (!case_first.is_undefined())
-        opt.kf = case_first.as_string().deprecated_string();
+        opt.kf = TRY(case_first.as_string().deprecated_string());
 
     // 18. Let relevantExtensionKeys be %Collator%.[[RelevantExtensionKeys]].
     auto relevant_extension_keys = Collator::relevant_extension_keys();
 
     // 19. Let r be ResolveLocale(%Collator%.[[AvailableLocales]], requestedLocales, opt, relevantExtensionKeys, localeData).
-    auto result = resolve_locale(requested_locales, opt, relevant_extension_keys);
+    auto result = TRY(resolve_locale(requested_locales, opt, relevant_extension_keys));
 
     // 20. Set collator.[[Locale]] to r.[[locale]].
     collator.set_locale(move(result.locale));
@@ -117,7 +117,7 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
     }
 
     // 28. Set collator.[[Sensitivity]] to sensitivity.
-    collator.set_sensitivity(sensitivity.as_string().deprecated_string());
+    collator.set_sensitivity(TRY(sensitivity.as_string().deprecated_string()));
 
     // 29. Let ignorePunctuation be ? GetOption(options, "ignorePunctuation", "boolean", undefined, false).
     auto ignore_punctuation = TRY(get_option(vm, *options, vm.names.ignorePunctuation, OptionType::Boolean, {}, false));

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -716,7 +716,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(VM& vm, Dat
                 // 2. If the "length" property of fv is greater than 2, let fv be the substring of fv containing the last two characters.
                 // NOTE: The first length check here isn't enough, but lets us avoid UTF-16 transcoding when the formatted value is ASCII.
                 if (formatted_value.length() > 2) {
-                    Utf16String utf16_formatted_value { formatted_value };
+                    auto utf16_formatted_value = TRY(Utf16String::create(vm, formatted_value));
                     if (utf16_formatted_value.length_in_code_units() > 2)
                         formatted_value = TRY_OR_THROW_OOM(vm, utf16_formatted_value.substring_view(utf16_formatted_value.length_in_code_units() - 2).to_utf8());
                 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -718,7 +718,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(VM& vm, Dat
                 if (formatted_value.length() > 2) {
                     Utf16String utf16_formatted_value { formatted_value };
                     if (utf16_formatted_value.length_in_code_units() > 2)
-                        formatted_value = utf16_formatted_value.substring_view(utf16_formatted_value.length_in_code_units() - 2).to_utf8();
+                        formatted_value = TRY_OR_THROW_OOM(vm, utf16_formatted_value.substring_view(utf16_formatted_value.length_in_code_units() - 2).to_utf8());
                 }
 
                 break;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -106,11 +106,11 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
     // 7. If calendar is not undefined, then
     if (!calendar.is_undefined()) {
         // a. If calendar does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
-        if (!::Locale::is_type_identifier(calendar.as_string().deprecated_string()))
+        if (!::Locale::is_type_identifier(TRY(calendar.as_string().deprecated_string())))
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, calendar, "calendar"sv);
 
         // 8. Set opt.[[ca]] to calendar.
-        opt.ca = calendar.as_string().deprecated_string();
+        opt.ca = TRY(calendar.as_string().deprecated_string());
     }
 
     // 9. Let numberingSystem be ? GetOption(options, "numberingSystem", "string", undefined, undefined).
@@ -119,11 +119,11 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
     // 10. If numberingSystem is not undefined, then
     if (!numbering_system.is_undefined()) {
         // a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
-        if (!::Locale::is_type_identifier(numbering_system.as_string().deprecated_string()))
+        if (!::Locale::is_type_identifier(TRY(numbering_system.as_string().deprecated_string())))
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, numbering_system, "numberingSystem"sv);
 
         // 11. Set opt.[[nu]] to numberingSystem.
-        opt.nu = numbering_system.as_string().deprecated_string();
+        opt.nu = TRY(numbering_system.as_string().deprecated_string());
     }
 
     // 12. Let hour12 be ? GetOption(options, "hour12", "boolean", undefined, undefined).
@@ -140,11 +140,11 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
 
     // 15. Set opt.[[hc]] to hourCycle.
     if (!hour_cycle.is_nullish())
-        opt.hc = hour_cycle.as_string().deprecated_string();
+        opt.hc = TRY(hour_cycle.as_string().deprecated_string());
 
     // 16. Let localeData be %DateTimeFormat%.[[LocaleData]].
     // 17. Let r be ResolveLocale(%DateTimeFormat%.[[AvailableLocales]], requestedLocales, opt, %DateTimeFormat%.[[RelevantExtensionKeys]], localeData).
-    auto result = resolve_locale(requested_locales, opt, DateTimeFormat::relevant_extension_keys());
+    auto result = TRY(resolve_locale(requested_locales, opt, DateTimeFormat::relevant_extension_keys()));
 
     // 18. Set dateTimeFormat.[[Locale]] to r.[[locale]].
     date_time_format.set_locale(move(result.locale));
@@ -277,7 +277,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
 
             // d. Set formatOptions.[[<prop>]] to value.
             if (!value.is_undefined()) {
-                option = ::Locale::calendar_pattern_style_from_string(value.as_string().deprecated_string());
+                option = ::Locale::calendar_pattern_style_from_string(TRY(value.as_string().deprecated_string()));
 
                 // e. If value is not undefined, then
                 //     i. Set hasExplicitFormatComponents to true.
@@ -296,14 +296,14 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
 
     // 39. Set dateTimeFormat.[[DateStyle]] to dateStyle.
     if (!date_style.is_undefined())
-        date_time_format.set_date_style(date_style.as_string().deprecated_string());
+        date_time_format.set_date_style(TRY(date_style.as_string().deprecated_string()));
 
     // 40. Let timeStyle be ? GetOption(options, "timeStyle", "string", « "full", "long", "medium", "short" », undefined).
     auto time_style = TRY(get_option(vm, *options, vm.names.timeStyle, OptionType::String, AK::Array { "full"sv, "long"sv, "medium"sv, "short"sv }, Empty {}));
 
     // 41. Set dateTimeFormat.[[TimeStyle]] to timeStyle.
     if (!time_style.is_undefined())
-        date_time_format.set_time_style(time_style.as_string().deprecated_string());
+        date_time_format.set_time_style(TRY(time_style.as_string().deprecated_string()));
 
     Optional<::Locale::CalendarPattern> best_format {};
 
@@ -325,7 +325,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
         auto formats = ::Locale::get_calendar_available_formats(data_locale, date_time_format.calendar());
 
         // b. If matcher is "basic", then
-        if (matcher.as_string().deprecated_string() == "basic"sv) {
+        if (TRY(matcher.as_string().deprecated_string()) == "basic"sv) {
             // i. Let bestFormat be BasicFormatMatcher(formatOptions, formats).
             best_format = basic_format_matcher(format_options, move(formats));
         }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
@@ -76,13 +76,13 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DisplayNamesConstructor::construct(Funct
     opt.locale_matcher = matcher;
 
     // 10. Let r be ResolveLocale(%DisplayNames%.[[AvailableLocales]], requestedLocales, opt, %DisplayNames%.[[RelevantExtensionKeys]]).
-    auto result = resolve_locale(requested_locales, opt, {});
+    auto result = TRY(resolve_locale(requested_locales, opt, {}));
 
     // 11. Let style be ? GetOption(options, "style", "string", « "narrow", "short", "long" », "long").
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "narrow"sv, "short"sv, "long"sv }, "long"sv));
 
     // 12. Set displayNames.[[Style]] to style.
-    display_names->set_style(style.as_string().deprecated_string());
+    display_names->set_style(TRY(style.as_string().deprecated_string()));
 
     // 13. Let type be ? GetOption(options, "type", "string", « "language", "region", "script", "currency", "calendar", "dateTimeField" », undefined).
     auto type = TRY(get_option(vm, *options, vm.names.type, OptionType::String, { "language"sv, "region"sv, "script"sv, "currency"sv, "calendar"sv, "dateTimeField"sv }, Empty {}));
@@ -92,13 +92,13 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DisplayNamesConstructor::construct(Funct
         return vm.throw_completion<TypeError>(ErrorType::IsUndefined, "options.type"sv);
 
     // 15. Set displayNames.[[Type]] to type.
-    display_names->set_type(type.as_string().deprecated_string());
+    display_names->set_type(TRY(type.as_string().deprecated_string()));
 
     // 16. Let fallback be ? GetOption(options, "fallback", "string", « "code", "none" », "code").
     auto fallback = TRY(get_option(vm, *options, vm.names.fallback, OptionType::String, { "code"sv, "none"sv }, "code"sv));
 
     // 17. Set displayNames.[[Fallback]] to fallback.
-    display_names->set_fallback(fallback.as_string().deprecated_string());
+    display_names->set_fallback(TRY(fallback.as_string().deprecated_string()));
 
     // 18. Set displayNames.[[Locale]] to r.[[locale]].
     display_names->set_locale(move(result.locale));
@@ -119,7 +119,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DisplayNamesConstructor::construct(Funct
     // 26. If type is "language", then
     if (display_names->type() == DisplayNames::Type::Language) {
         // a. Set displayNames.[[LanguageDisplay]] to languageDisplay.
-        display_names->set_language_display(language_display.as_string().deprecated_string());
+        display_names->set_language_display(TRY(language_display.as_string().deprecated_string()));
 
         // b. Let typeFields be typeFields.[[<languageDisplay>]].
         // c. Assert: typeFields is a Record (see 12.4.3).

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -47,7 +47,7 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
     code = PrimitiveString::create(vm, move(code_string));
 
     // 4. Let code be ? CanonicalCodeForDisplayNames(displayNames.[[Type]], code).
-    code = TRY(canonical_code_for_display_names(vm, display_names->type(), code.as_string().deprecated_string()));
+    code = TRY(canonical_code_for_display_names(vm, display_names->type(), TRY(code.as_string().deprecated_string())));
 
     // 5. Let fields be displayNames.[[Fields]].
     // 6. If fields has a field [[<code>]], return fields.[[<code>]].
@@ -57,48 +57,48 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
     switch (display_names->type()) {
     case DisplayNames::Type::Language:
         if (display_names->language_display() == DisplayNames::LanguageDisplay::Dialect) {
-            result = ::Locale::get_locale_language_mapping(display_names->locale(), code.as_string().deprecated_string());
+            result = ::Locale::get_locale_language_mapping(display_names->locale(), TRY(code.as_string().deprecated_string()));
             if (result.has_value())
                 break;
         }
 
-        if (auto locale = is_structurally_valid_language_tag(code.as_string().deprecated_string()); locale.has_value())
+        if (auto locale = is_structurally_valid_language_tag(TRY(code.as_string().deprecated_string())); locale.has_value())
             formatted_result = ::Locale::format_locale_for_display(display_names->locale(), locale.release_value());
         break;
     case DisplayNames::Type::Region:
-        result = ::Locale::get_locale_territory_mapping(display_names->locale(), code.as_string().deprecated_string());
+        result = ::Locale::get_locale_territory_mapping(display_names->locale(), TRY(code.as_string().deprecated_string()));
         break;
     case DisplayNames::Type::Script:
-        result = ::Locale::get_locale_script_mapping(display_names->locale(), code.as_string().deprecated_string());
+        result = ::Locale::get_locale_script_mapping(display_names->locale(), TRY(code.as_string().deprecated_string()));
         break;
     case DisplayNames::Type::Currency:
         switch (display_names->style()) {
         case ::Locale::Style::Long:
-            result = ::Locale::get_locale_long_currency_mapping(display_names->locale(), code.as_string().deprecated_string());
+            result = ::Locale::get_locale_long_currency_mapping(display_names->locale(), TRY(code.as_string().deprecated_string()));
             break;
         case ::Locale::Style::Short:
-            result = ::Locale::get_locale_short_currency_mapping(display_names->locale(), code.as_string().deprecated_string());
+            result = ::Locale::get_locale_short_currency_mapping(display_names->locale(), TRY(code.as_string().deprecated_string()));
             break;
         case ::Locale::Style::Narrow:
-            result = ::Locale::get_locale_narrow_currency_mapping(display_names->locale(), code.as_string().deprecated_string());
+            result = ::Locale::get_locale_narrow_currency_mapping(display_names->locale(), TRY(code.as_string().deprecated_string()));
             break;
         default:
             VERIFY_NOT_REACHED();
         }
         break;
     case DisplayNames::Type::Calendar:
-        result = ::Locale::get_locale_calendar_mapping(display_names->locale(), code.as_string().deprecated_string());
+        result = ::Locale::get_locale_calendar_mapping(display_names->locale(), TRY(code.as_string().deprecated_string()));
         break;
     case DisplayNames::Type::DateTimeField:
         switch (display_names->style()) {
         case ::Locale::Style::Long:
-            result = ::Locale::get_locale_long_date_field_mapping(display_names->locale(), code.as_string().deprecated_string());
+            result = ::Locale::get_locale_long_date_field_mapping(display_names->locale(), TRY(code.as_string().deprecated_string()));
             break;
         case ::Locale::Style::Short:
-            result = ::Locale::get_locale_short_date_field_mapping(display_names->locale(), code.as_string().deprecated_string());
+            result = ::Locale::get_locale_short_date_field_mapping(display_names->locale(), TRY(code.as_string().deprecated_string()));
             break;
         case ::Locale::Style::Narrow:
-            result = ::Locale::get_locale_narrow_date_field_mapping(display_names->locale(), code.as_string().deprecated_string());
+            result = ::Locale::get_locale_narrow_date_field_mapping(display_names->locale(), TRY(code.as_string().deprecated_string()));
             break;
         default:
             VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -308,7 +308,7 @@ ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM& vm, Depreca
             }
         }
     } else {
-        style = style_value.as_string().deprecated_string();
+        style = TRY(style_value.as_string().deprecated_string());
     }
 
     // 4. Let displayField be the string-concatenation of unit and "Display".
@@ -332,7 +332,7 @@ ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM& vm, Depreca
     }
 
     // 7. Return the Record { [[Style]]: style, [[Display]]: display }.
-    return DurationUnitOptions { .style = move(style), .display = display.as_string().deprecated_string() };
+    return DurationUnitOptions { .style = move(style), .display = TRY(display.as_string().deprecated_string()) };
 }
 
 // 1.1.7 PartitionDurationFormatPattern ( durationFormat, duration ), https://tc39.es/proposal-intl-duration-format/#sec-partitiondurationformatpattern

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
@@ -67,17 +67,17 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DurationFormatConstructor::construct(Fun
     // 7. If numberingSystem is not undefined, then
     if (!numbering_system.is_undefined()) {
         // a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
-        if (!::Locale::is_type_identifier(numbering_system.as_string().deprecated_string()))
+        if (!::Locale::is_type_identifier(TRY(numbering_system.as_string().deprecated_string())))
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, numbering_system, "numberingSystem"sv);
     }
 
     // 8. Let opt be the Record { [[localeMatcher]]: matcher, [[nu]]: numberingSystem }.
     LocaleOptions opt {};
     opt.locale_matcher = matcher;
-    opt.nu = numbering_system.is_undefined() ? Optional<DeprecatedString>() : numbering_system.as_string().deprecated_string();
+    opt.nu = numbering_system.is_undefined() ? Optional<DeprecatedString>() : TRY(numbering_system.as_string().deprecated_string());
 
     // 9. Let r be ResolveLocale(%DurationFormat%.[[AvailableLocales]], requestedLocales, opt, %DurationFormat%.[[RelevantExtensionKeys]], %DurationFormat%.[[LocaleData]]).
-    auto result = resolve_locale(requested_locales, opt, DurationFormat::relevant_extension_keys());
+    auto result = TRY(resolve_locale(requested_locales, opt, DurationFormat::relevant_extension_keys()));
 
     // 10. Let locale be r.[[locale]].
     auto locale = move(result.locale);
@@ -93,7 +93,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DurationFormatConstructor::construct(Fun
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "long"sv, "short"sv, "narrow"sv, "digital"sv }, "short"sv));
 
     // 14. Set durationFormat.[[Style]] to style.
-    duration_format->set_style(style.as_string().deprecated_string());
+    duration_format->set_style(TRY(style.as_string().deprecated_string()));
 
     // 15. Set durationFormat.[[DataLocale]] to r.[[dataLocale]].
     duration_format->set_data_locale(move(result.data_locale));
@@ -119,7 +119,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DurationFormatConstructor::construct(Fun
         auto digital_base = duration_instances_component.digital_default;
 
         // f. Let unitOptions be ? GetDurationUnitOptions(unit, options, style, valueList, digitalBase, prevStyle).
-        auto unit_options = TRY(get_duration_unit_options(vm, unit, *options, style.as_string().deprecated_string(), value_list, digital_base, previous_style));
+        auto unit_options = TRY(get_duration_unit_options(vm, unit, *options, TRY(style.as_string().deprecated_string()), value_list, digital_base, previous_style));
 
         // g. Set the value of the styleSlot slot of durationFormat to unitOptions.[[Style]].
         (duration_format->*style_slot)(unit_options.style);

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
@@ -274,7 +274,7 @@ ThrowCompletionOr<Vector<DeprecatedString>> string_list_from_iterable(VM& vm, Va
             }
 
             // iii. Append nextValue to the end of the List list.
-            list.append(next_value.as_string().deprecated_string());
+            list.append(TRY(next_value.as_string().deprecated_string()));
         }
     } while (next != nullptr);
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
@@ -71,7 +71,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ListFormatConstructor::construct(Functio
     // 8. Let localeData be %ListFormat%.[[LocaleData]].
 
     // 9. Let r be ResolveLocale(%ListFormat%.[[AvailableLocales]], requestedLocales, opt, %ListFormat%.[[RelevantExtensionKeys]], localeData).
-    auto result = resolve_locale(requested_locales, opt, {});
+    auto result = TRY(resolve_locale(requested_locales, opt, {}));
 
     // 10. Set listFormat.[[Locale]] to r.[[locale]].
     list_format->set_locale(move(result.locale));
@@ -80,13 +80,13 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ListFormatConstructor::construct(Functio
     auto type = TRY(get_option(vm, *options, vm.names.type, OptionType::String, { "conjunction"sv, "disjunction"sv, "unit"sv }, "conjunction"sv));
 
     // 12. Set listFormat.[[Type]] to type.
-    list_format->set_type(type.as_string().deprecated_string());
+    list_format->set_type(TRY(type.as_string().deprecated_string()));
 
     // 13. Let style be ? GetOption(options, "style", "string", « "long", "short", "narrow" », "long").
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "long"sv, "short"sv, "narrow"sv }, "long"sv));
 
     // 14. Set listFormat.[[Style]] to style.
-    list_format->set_style(style.as_string().deprecated_string());
+    list_format->set_style(TRY(style.as_string().deprecated_string()));
 
     // Note: The remaining steps are skipped in favor of deferring to LibUnicode.
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -33,10 +33,10 @@ static ThrowCompletionOr<Optional<DeprecatedString>> get_string_option(VM& vm, O
     if (option.is_undefined())
         return Optional<DeprecatedString> {};
 
-    if (validator && !validator(option.as_string().deprecated_string()))
+    if (validator && !validator(TRY(option.as_string().deprecated_string())))
         return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, option, property);
 
-    return option.as_string().deprecated_string();
+    return TRY(option.as_string().deprecated_string());
 }
 
 // 14.1.2 ApplyOptionsToTag ( tag, options ), https://tc39.es/ecma402/#sec-apply-options-to-tag

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -1604,7 +1604,7 @@ ThrowCompletionOr<MathematicalValue> to_intl_mathematical_value(VM& vm, Value va
 
     // 3. If Type(primValue) is String,
     // a.     Let str be primValue.
-    auto const& string = primitive_value.as_string().deprecated_string();
+    auto const& string = TRY(primitive_value.as_string().deprecated_string());
 
     // Step 4 handled separately by the FIXME above.
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
@@ -103,16 +103,16 @@ ThrowCompletionOr<NumberFormat*> initialize_number_format(VM& vm, NumberFormat& 
     // 7. If numberingSystem is not undefined, then
     if (!numbering_system.is_undefined()) {
         // a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
-        if (!::Locale::is_type_identifier(numbering_system.as_string().deprecated_string()))
+        if (!::Locale::is_type_identifier(TRY(numbering_system.as_string().deprecated_string())))
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, numbering_system, "numberingSystem"sv);
 
         // 8. Set opt.[[nu]] to numberingSystem.
-        opt.nu = numbering_system.as_string().deprecated_string();
+        opt.nu = TRY(numbering_system.as_string().deprecated_string());
     }
 
     // 9. Let localeData be %NumberFormat%.[[LocaleData]].
     // 10. Let r be ResolveLocale(%NumberFormat%.[[AvailableLocales]], requestedLocales, opt, %NumberFormat%.[[RelevantExtensionKeys]], localeData).
-    auto result = resolve_locale(requested_locales, opt, NumberFormat::relevant_extension_keys());
+    auto result = TRY(resolve_locale(requested_locales, opt, NumberFormat::relevant_extension_keys()));
 
     // 11. Set numberFormat.[[Locale]] to r.[[locale]].
     number_format.set_locale(move(result.locale));
@@ -176,7 +176,7 @@ ThrowCompletionOr<NumberFormat*> initialize_number_format(VM& vm, NumberFormat& 
     auto notation = TRY(get_option(vm, *options, vm.names.notation, OptionType::String, { "standard"sv, "scientific"sv, "engineering"sv, "compact"sv }, "standard"sv));
 
     // 22. Set numberFormat.[[Notation]] to notation.
-    number_format.set_notation(notation.as_string().deprecated_string());
+    number_format.set_notation(TRY(notation.as_string().deprecated_string()));
 
     // 23. Perform ? SetNumberFormatDigitOptions(numberFormat, options, mnfdDefault, mxfdDefault, notation).
     TRY(set_number_format_digit_options(vm, number_format, *options, default_min_fraction_digits, default_max_fraction_digits, number_format.notation()));
@@ -199,7 +199,7 @@ ThrowCompletionOr<NumberFormat*> initialize_number_format(VM& vm, NumberFormat& 
     auto trailing_zero_display = TRY(get_option(vm, *options, vm.names.trailingZeroDisplay, OptionType::String, { "auto"sv, "stripIfInteger"sv }, "auto"sv));
 
     // 27. Set numberFormat.[[TrailingZeroDisplay]] to trailingZeroDisplay.
-    number_format.set_trailing_zero_display(trailing_zero_display.as_string().deprecated_string());
+    number_format.set_trailing_zero_display(TRY(trailing_zero_display.as_string().deprecated_string()));
 
     // 28. Let compactDisplay be ? GetOption(options, "compactDisplay", "string", « "short", "long" », "short").
     auto compact_display = TRY(get_option(vm, *options, vm.names.compactDisplay, OptionType::String, { "short"sv, "long"sv }, "short"sv));
@@ -210,7 +210,7 @@ ThrowCompletionOr<NumberFormat*> initialize_number_format(VM& vm, NumberFormat& 
     // 30. If notation is "compact", then
     if (number_format.notation() == NumberFormat::Notation::Compact) {
         // a. Set numberFormat.[[CompactDisplay]] to compactDisplay.
-        number_format.set_compact_display(compact_display.as_string().deprecated_string());
+        number_format.set_compact_display(TRY(compact_display.as_string().deprecated_string()));
 
         // b. Set defaultUseGrouping to "min2".
         default_use_grouping = "min2"sv;
@@ -226,13 +226,13 @@ ThrowCompletionOr<NumberFormat*> initialize_number_format(VM& vm, NumberFormat& 
     auto sign_display = TRY(get_option(vm, *options, vm.names.signDisplay, OptionType::String, { "auto"sv, "never"sv, "always"sv, "exceptZero"sv, "negative"sv }, "auto"sv));
 
     // 34. Set numberFormat.[[SignDisplay]] to signDisplay.
-    number_format.set_sign_display(sign_display.as_string().deprecated_string());
+    number_format.set_sign_display(TRY(sign_display.as_string().deprecated_string()));
 
     // 35. Let roundingMode be ? GetOption(options, "roundingMode", "string", « "ceil", "floor", "expand", "trunc", "halfCeil", "halfFloor", "halfExpand", "halfTrunc", "halfEven" », "halfExpand").
     auto rounding_mode = TRY(get_option(vm, *options, vm.names.roundingMode, OptionType::String, { "ceil"sv, "floor"sv, "expand"sv, "trunc"sv, "halfCeil"sv, "halfFloor"sv, "halfExpand"sv, "halfTrunc"sv, "halfEven"sv }, "halfExpand"sv));
 
     // 36. Set numberFormat.[[RoundingMode]] to roundingMode.
-    number_format.set_rounding_mode(rounding_mode.as_string().deprecated_string());
+    number_format.set_rounding_mode(TRY(rounding_mode.as_string().deprecated_string()));
 
     // 37. Return numberFormat.
     return &number_format;
@@ -282,7 +282,7 @@ ThrowCompletionOr<void> set_number_format_digit_options(VM& vm, NumberFormatBase
     bool need_fraction_digits = true;
 
     // 14. If roundingPriority is "auto", then
-    if (rounding_priority.as_string().deprecated_string() == "auto"sv) {
+    if (TRY(rounding_priority.as_string().deprecated_string()) == "auto"sv) {
         // a. Set needSd to hasSd.
         need_significant_digits = has_significant_digits;
 
@@ -358,12 +358,12 @@ ThrowCompletionOr<void> set_number_format_digit_options(VM& vm, NumberFormatBase
     // 17. If needSd is true or needFd is true, then
     if (need_significant_digits || need_fraction_digits) {
         // a. If roundingPriority is "morePrecision", then
-        if (rounding_priority.as_string().deprecated_string() == "morePrecision"sv) {
+        if (TRY(rounding_priority.as_string().deprecated_string()) == "morePrecision"sv) {
             // i. Set intlObj.[[RoundingType]] to morePrecision.
             intl_object.set_rounding_type(NumberFormatBase::RoundingType::MorePrecision);
         }
         // b. Else if roundingPriority is "lessPrecision", then
-        else if (rounding_priority.as_string().deprecated_string() == "lessPrecision"sv) {
+        else if (TRY(rounding_priority.as_string().deprecated_string()) == "lessPrecision"sv) {
             // i. Set intlObj.[[RoundingType]] to lessPrecision.
             intl_object.set_rounding_type(NumberFormatBase::RoundingType::LessPrecision);
         }
@@ -410,7 +410,7 @@ ThrowCompletionOr<void> set_number_format_unit_options(VM& vm, NumberFormat& int
     auto style = TRY(get_option(vm, options, vm.names.style, OptionType::String, { "decimal"sv, "percent"sv, "currency"sv, "unit"sv }, "decimal"sv));
 
     // 4. Set intlObj.[[Style]] to style.
-    intl_object.set_style(style.as_string().deprecated_string());
+    intl_object.set_style(TRY(style.as_string().deprecated_string()));
 
     // 5. Let currency be ? GetOption(options, "currency", "string", undefined, undefined).
     auto currency = TRY(get_option(vm, options, vm.names.currency, OptionType::String, {}, Empty {}));
@@ -423,7 +423,7 @@ ThrowCompletionOr<void> set_number_format_unit_options(VM& vm, NumberFormat& int
     }
     // 7. Else,
     //     a. If ! IsWellFormedCurrencyCode(currency) is false, throw a RangeError exception.
-    else if (!is_well_formed_currency_code(currency.as_string().deprecated_string()))
+    else if (!is_well_formed_currency_code(TRY(currency.as_string().deprecated_string())))
         return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, currency, "currency"sv);
 
     // 8. Let currencyDisplay be ? GetOption(options, "currencyDisplay", "string", « "code", "symbol", "narrowSymbol", "name" », "symbol").
@@ -443,7 +443,7 @@ ThrowCompletionOr<void> set_number_format_unit_options(VM& vm, NumberFormat& int
     }
     // 12. Else,
     //     a. If ! IsWellFormedUnitIdentifier(unit) is false, throw a RangeError exception.
-    else if (!is_well_formed_unit_identifier(unit.as_string().deprecated_string()))
+    else if (!is_well_formed_unit_identifier(TRY(unit.as_string().deprecated_string())))
         return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, unit, "unit"sv);
 
     // 13. Let unitDisplay be ? GetOption(options, "unitDisplay", "string", « "short", "narrow", "long" », "short").
@@ -452,22 +452,22 @@ ThrowCompletionOr<void> set_number_format_unit_options(VM& vm, NumberFormat& int
     // 14. If style is "currency", then
     if (intl_object.style() == NumberFormat::Style::Currency) {
         // a. Set intlObj.[[Currency]] to the ASCII-uppercase of currency.
-        intl_object.set_currency(currency.as_string().deprecated_string().to_uppercase());
+        intl_object.set_currency(TRY(currency.as_string().deprecated_string()).to_uppercase());
 
         // c. Set intlObj.[[CurrencyDisplay]] to currencyDisplay.
-        intl_object.set_currency_display(currency_display.as_string().deprecated_string());
+        intl_object.set_currency_display(TRY(currency_display.as_string().deprecated_string()));
 
         // d. Set intlObj.[[CurrencySign]] to currencySign.
-        intl_object.set_currency_sign(currency_sign.as_string().deprecated_string());
+        intl_object.set_currency_sign(TRY(currency_sign.as_string().deprecated_string()));
     }
 
     // 15. If style is "unit", then
     if (intl_object.style() == NumberFormat::Style::Unit) {
         // a. Set intlObj.[[Unit]] to unit.
-        intl_object.set_unit(unit.as_string().deprecated_string());
+        intl_object.set_unit(TRY(unit.as_string().deprecated_string()));
 
         // b. Set intlObj.[[UnitDisplay]] to unitDisplay.
-        intl_object.set_unit_display(unit_display.as_string().deprecated_string());
+        intl_object.set_unit_display(TRY(unit_display.as_string().deprecated_string()));
     }
 
     return {};

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
@@ -94,14 +94,14 @@ ThrowCompletionOr<PluralRules*> initialize_plural_rules(VM& vm, PluralRules& plu
     auto type = TRY(get_option(vm, *options, vm.names.type, OptionType::String, AK::Array { "cardinal"sv, "ordinal"sv }, "cardinal"sv));
 
     // 7. Set pluralRules.[[Type]] to t.
-    plural_rules.set_type(type.as_string().deprecated_string());
+    plural_rules.set_type(TRY(type.as_string().deprecated_string()));
 
     // 8. Perform ? SetNumberFormatDigitOptions(pluralRules, options, +0𝔽, 3𝔽, "standard").
     TRY(set_number_format_digit_options(vm, plural_rules, *options, 0, 3, NumberFormat::Notation::Standard));
 
     // 9. Let localeData be %PluralRules%.[[LocaleData]].
     // 10. Let r be ResolveLocale(%PluralRules%.[[AvailableLocales]], requestedLocales, opt, %PluralRules%.[[RelevantExtensionKeys]], localeData).
-    auto result = resolve_locale(requested_locales, opt, {});
+    auto result = TRY(resolve_locale(requested_locales, opt, {}));
 
     // 11. Set pluralRules.[[Locale]] to r.[[locale]].
     plural_rules.set_locale(move(result.locale));

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -101,16 +101,16 @@ ThrowCompletionOr<RelativeTimeFormat*> initialize_relative_time_format(VM& vm, R
     // 7. If numberingSystem is not undefined, then
     if (!numbering_system.is_undefined()) {
         // a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
-        if (!::Locale::is_type_identifier(numbering_system.as_string().deprecated_string()))
+        if (!::Locale::is_type_identifier(TRY(numbering_system.as_string().deprecated_string())))
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, numbering_system, "numberingSystem"sv);
 
         // 8. Set opt.[[nu]] to numberingSystem.
-        opt.nu = numbering_system.as_string().deprecated_string();
+        opt.nu = TRY(numbering_system.as_string().deprecated_string());
     }
 
     // 9. Let localeData be %RelativeTimeFormat%.[[LocaleData]].
     // 10. Let r be ResolveLocale(%RelativeTimeFormat%.[[AvailableLocales]], requestedLocales, opt, %RelativeTimeFormat%.[[RelevantExtensionKeys]], localeData).
-    auto result = resolve_locale(requested_locales, opt, RelativeTimeFormat::relevant_extension_keys());
+    auto result = TRY(resolve_locale(requested_locales, opt, RelativeTimeFormat::relevant_extension_keys()));
 
     // 11. Let locale be r.[[locale]].
     auto locale = move(result.locale);
@@ -129,13 +129,13 @@ ThrowCompletionOr<RelativeTimeFormat*> initialize_relative_time_format(VM& vm, R
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "long"sv, "short"sv, "narrow"sv }, "long"sv));
 
     // 16. Set relativeTimeFormat.[[Style]] to style.
-    relative_time_format.set_style(style.as_string().deprecated_string());
+    relative_time_format.set_style(TRY(style.as_string().deprecated_string()));
 
     // 17. Let numeric be ? GetOption(options, "numeric", "string", « "always", "auto" », "always").
     auto numeric = TRY(get_option(vm, *options, vm.names.numeric, OptionType::String, { "always"sv, "auto"sv }, "always"sv));
 
     // 18. Set relativeTimeFormat.[[Numeric]] to numeric.
-    relative_time_format.set_numeric(numeric.as_string().deprecated_string());
+    relative_time_format.set_numeric(TRY(numeric.as_string().deprecated_string()));
 
     // 19. Let relativeTimeFormat.[[NumberFormat]] be ! Construct(%NumberFormat%, « locale »).
     auto number_format = MUST(construct(vm, *realm.intrinsics().intl_number_format_constructor(), PrimitiveString::create(vm, locale)));

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.cpp
@@ -60,7 +60,7 @@ JS_DEFINE_NATIVE_FUNCTION(SegmentIteratorPrototype::next)
     iterator->set_iterated_string_next_segment_code_unit_index(end_index);
 
     // 9. Let segmentData be ! CreateSegmentDataObject(segmenter, string, startIndex, endIndex).
-    auto* segment_data = create_segment_data_object(vm, segmenter, string, start_index, end_index);
+    auto segment_data = TRY(create_segment_data_object(vm, segmenter, string, start_index, end_index));
 
     // 10. Return CreateIterResultObject(segmentData, false).
     return create_iterator_result_object(vm, segment_data, false);

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segmenter.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segmenter.cpp
@@ -45,7 +45,7 @@ StringView Segmenter::segmenter_granularity_string() const
 }
 
 // 18.7.1 CreateSegmentDataObject ( segmenter, string, startIndex, endIndex ), https://tc39.es/ecma402/#sec-createsegmentdataobject
-Object* create_segment_data_object(VM& vm, Segmenter const& segmenter, Utf16View const& string, double start_index, double end_index)
+ThrowCompletionOr<NonnullGCPtr<Object>> create_segment_data_object(VM& vm, Segmenter const& segmenter, Utf16View const& string, double start_index, double end_index)
 {
     auto& realm = *vm.current_realm();
 
@@ -68,13 +68,13 @@ Object* create_segment_data_object(VM& vm, Segmenter const& segmenter, Utf16View
     auto segment = string.substring_view(start_index, end_index - start_index);
 
     // 7. Perform ! CreateDataPropertyOrThrow(result, "segment", segment).
-    MUST(result->create_data_property_or_throw(vm.names.segment, PrimitiveString::create(vm, segment)));
+    MUST(result->create_data_property_or_throw(vm.names.segment, PrimitiveString::create(vm, TRY(Utf16String::create(vm, segment)))));
 
     // 8. Perform ! CreateDataPropertyOrThrow(result, "index", 𝔽(startIndex)).
     MUST(result->create_data_property_or_throw(vm.names.index, Value(start_index)));
 
     // 9. Perform ! CreateDataPropertyOrThrow(result, "input", string).
-    MUST(result->create_data_property_or_throw(vm.names.input, PrimitiveString::create(vm, string)));
+    MUST(result->create_data_property_or_throw(vm.names.input, PrimitiveString::create(vm, TRY(Utf16String::create(vm, string)))));
 
     // 10. Let granularity be segmenter.[[SegmenterGranularity]].
     auto granularity = segmenter.segmenter_granularity();

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segmenter.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segmenter.h
@@ -37,7 +37,7 @@ private:
     SegmenterGranularity m_segmenter_granularity { SegmenterGranularity::Grapheme }; // [[SegmenterGranularity]]
 };
 
-Object* create_segment_data_object(VM&, Segmenter const&, Utf16View const&, double start_index, double end_index);
+ThrowCompletionOr<NonnullGCPtr<Object>> create_segment_data_object(VM&, Segmenter const&, Utf16View const&, double start_index, double end_index);
 enum class Direction {
     Before,
     After,

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
@@ -71,7 +71,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> SegmenterConstructor::construct(Function
     // 9. Let localeData be %Segmenter%.[[LocaleData]].
 
     // 10. Let r be ResolveLocale(%Segmenter%.[[AvailableLocales]], requestedLocales, opt, %Segmenter%.[[RelevantExtensionKeys]], localeData).
-    auto result = resolve_locale(requested_locales, opt, {});
+    auto result = TRY(resolve_locale(requested_locales, opt, {}));
 
     // 11. Set segmenter.[[Locale]] to r.[[locale]].
     segmenter->set_locale(move(result.locale));
@@ -80,7 +80,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> SegmenterConstructor::construct(Function
     auto granularity = TRY(get_option(vm, *options, vm.names.granularity, OptionType::String, { "grapheme"sv, "word"sv, "sentence"sv }, "grapheme"sv));
 
     // 13. Set segmenter.[[SegmenterGranularity]] to granularity.
-    segmenter->set_segmenter_granularity(granularity.as_string().deprecated_string());
+    segmenter->set_segmenter_granularity(TRY(granularity.as_string().deprecated_string()));
 
     // 14. Return segmenter.
     return segmenter;

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.cpp
@@ -58,7 +58,7 @@ JS_DEFINE_NATIVE_FUNCTION(SegmentsPrototype::containing)
     auto end_index = find_boundary(segmenter, string, n, Direction::After, segments->boundaries_cache());
 
     // 10. Return ! CreateSegmentDataObject(segmenter, string, startIndex, endIndex).
-    return create_segment_data_object(vm, segmenter, string, start_index, end_index);
+    return TRY(create_segment_data_object(vm, segmenter, string, start_index, end_index));
 }
 
 // 18.5.2.2 %SegmentsPrototype% [ @@iterator ] ( ), https://tc39.es/ecma402/#sec-%segmentsprototype%-@@iterator

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -63,7 +63,7 @@ ThrowCompletionOr<DeprecatedString> JSONObject::stringify_impl(VM& vm, Value val
                     auto replacer_value = TRY(replacer_object.get(i));
                     DeprecatedString item;
                     if (replacer_value.is_string()) {
-                        item = replacer_value.as_string().deprecated_string();
+                        item = TRY(replacer_value.as_string().deprecated_string());
                     } else if (replacer_value.is_number()) {
                         item = MUST(replacer_value.to_string(vm));
                     } else if (replacer_value.is_object()) {
@@ -93,7 +93,7 @@ ThrowCompletionOr<DeprecatedString> JSONObject::stringify_impl(VM& vm, Value val
         space_mv = min(10, space_mv);
         state.gap = space_mv < 1 ? DeprecatedString::empty() : DeprecatedString::repeated(' ', space_mv);
     } else if (space.is_string()) {
-        auto string = space.as_string().deprecated_string();
+        auto string = TRY(space.as_string().deprecated_string());
         if (string.length() <= 10)
             state.gap = string;
         else
@@ -185,7 +185,7 @@ ThrowCompletionOr<DeprecatedString> JSONObject::serialize_json_property(VM& vm, 
 
     // 8. If Type(value) is String, return QuoteJSONString(value).
     if (value.is_string())
-        return quote_json_string(value.as_string().deprecated_string());
+        return quote_json_string(TRY(value.as_string().deprecated_string()));
 
     // 9. If Type(value) is Number, then
     if (value.is_number()) {
@@ -250,7 +250,7 @@ ThrowCompletionOr<DeprecatedString> JSONObject::serialize_json_object(VM& vm, St
     } else {
         auto property_list = TRY(object.enumerable_own_property_names(PropertyKind::Key));
         for (auto& property : property_list)
-            TRY(process_property(property.as_string().deprecated_string()));
+            TRY(process_property(TRY(property.as_string().deprecated_string())));
     }
     StringBuilder builder;
     if (property_strings.is_empty()) {
@@ -473,7 +473,7 @@ ThrowCompletionOr<Value> JSONObject::internalize_json_property(VM& vm, Object* h
         } else {
             auto property_list = TRY(value_object.enumerable_own_property_names(Object::PropertyKind::Key));
             for (auto& property_key : property_list)
-                TRY(process_property(property_key.as_string().deprecated_string()));
+                TRY(process_property(TRY(property_key.as_string().deprecated_string())));
         }
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -1267,7 +1267,7 @@ Optional<Completion> Object::enumerate_object_properties(Function<Optional<Compl
         for (auto& key : own_keys) {
             if (!key.is_string())
                 continue;
-            FlyString property_key = key.as_string().deprecated_string();
+            FlyString property_key = TRY(key.as_string().deprecated_string());
             if (visited.contains(property_key))
                 continue;
             auto descriptor = TRY(target->internal_get_own_property(property_key));

--- a/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -125,7 +125,7 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectPrototype::to_string)
     if (!to_string_tag.is_string())
         tag = move(builtin_tag);
     else
-        tag = to_string_tag.as_string().deprecated_string();
+        tag = TRY(to_string_tag.as_string().deprecated_string());
 
     // 17. Return the string-concatenation of "[object ", tag, and "]".
     return PrimitiveString::create(vm, DeprecatedString::formatted("[object {}]", tag));

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -180,7 +180,7 @@ void PrimitiveString::resolve_rope_if_needed() const
         auto const& lhs_string = m_lhs->utf16_string();
         auto const& rhs_string = m_rhs->utf16_string();
 
-        Vector<u16, 1> combined;
+        Utf16Data combined;
         combined.ensure_capacity(lhs_string.length_in_code_units() + rhs_string.length_in_code_units());
         combined.extend(lhs_string.string());
         combined.extend(rhs_string.string());

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -68,7 +68,8 @@ DeprecatedString const& PrimitiveString::deprecated_string() const
 {
     resolve_rope_if_needed();
     if (!m_has_utf8_string) {
-        m_utf8_string = m_utf16_string.to_utf8();
+        // FIXME: Propagate this error.
+        m_utf8_string = MUST(m_utf16_string.to_utf8(vm()));
         m_has_utf8_string = true;
     }
     return m_utf8_string;

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -8,9 +8,11 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <AK/Optional.h>
 #include <AK/StringView.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Utf16String.h>
 #include <LibJS/Runtime/Value.h>
 
@@ -20,7 +22,6 @@ class PrimitiveString final : public Cell {
     JS_CELL(PrimitiveString, Cell);
 
 public:
-    [[nodiscard]] static NonnullGCPtr<PrimitiveString> create(VM&, Utf16View const&);
     [[nodiscard]] static NonnullGCPtr<PrimitiveString> create(VM&, Utf16String);
     [[nodiscard]] static NonnullGCPtr<PrimitiveString> create(VM&, DeprecatedString);
     [[nodiscard]] static NonnullGCPtr<PrimitiveString> create(VM&, PrimitiveString&, PrimitiveString&);
@@ -31,15 +32,16 @@ public:
     PrimitiveString& operator=(PrimitiveString const&) = delete;
 
     bool is_empty() const;
+    u32 hash() const;
 
-    DeprecatedString const& deprecated_string() const;
-    bool has_utf8_string() const { return m_has_utf8_string; }
+    ThrowCompletionOr<DeprecatedString const&> deprecated_string() const;
+    bool has_utf8_string() const { return m_utf8_string.has_value(); }
 
-    Utf16String const& utf16_string() const;
-    Utf16View utf16_string_view() const;
-    bool has_utf16_string() const { return m_has_utf16_string; }
+    ThrowCompletionOr<Utf16String const&> utf16_string() const;
+    ThrowCompletionOr<Utf16View> utf16_string_view() const;
+    bool has_utf16_string() const { return m_utf16_string.has_value(); }
 
-    Optional<Value> get(VM&, PropertyKey const&) const;
+    ThrowCompletionOr<Optional<Value>> get(VM&, PropertyKey const&) const;
 
 private:
     explicit PrimitiveString(PrimitiveString&, PrimitiveString&);
@@ -48,18 +50,15 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    void resolve_rope_if_needed() const;
+    ThrowCompletionOr<void> resolve_rope_if_needed() const;
 
     mutable bool m_is_rope { false };
-    mutable bool m_has_utf8_string { false };
-    mutable bool m_has_utf16_string { false };
 
     mutable PrimitiveString* m_lhs { nullptr };
     mutable PrimitiveString* m_rhs { nullptr };
 
-    mutable DeprecatedString m_utf8_string;
-
-    mutable Utf16String m_utf16_string;
+    mutable Optional<DeprecatedString> m_utf8_string;
+    mutable Optional<Utf16String> m_utf16_string;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Reference.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Reference.cpp
@@ -114,7 +114,7 @@ ThrowCompletionOr<Value> Reference::get_value(VM& vm) const
         // OPTIMIZATION: For various primitives we can avoid actually creating a new object for them.
         Object* base_obj = nullptr;
         if (m_base_value.is_string()) {
-            auto string_value = m_base_value.as_string().get(vm, m_name);
+            auto string_value = TRY(m_base_value.as_string().get(vm, m_name));
             if (string_value.has_value())
                 return *string_value;
             base_obj = realm.intrinsics().string_prototype();

--- a/Userland/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.cpp
@@ -68,7 +68,7 @@ ThrowCompletionOr<void> set_legacy_regexp_static_property(VM& vm, RegExpConstruc
 }
 
 // UpdateLegacyRegExpStaticProperties ( C, S, startIndex, endIndex, capturedValues ), https://github.com/tc39/proposal-regexp-legacy-features#updatelegacyregexpstaticproperties--c-s-startindex-endindex-capturedvalues-
-void update_legacy_regexp_static_properties(RegExpConstructor& constructor, Utf16String const& string, size_t start_index, size_t end_index, Vector<Utf16String> const& captured_values)
+ThrowCompletionOr<void> update_legacy_regexp_static_properties(VM& vm, RegExpConstructor& constructor, Utf16String const& string, size_t start_index, size_t end_index, Vector<Utf16String> const& captured_values)
 {
     auto& legacy_static_properties = constructor.legacy_static_properties();
 
@@ -92,7 +92,7 @@ void update_legacy_regexp_static_properties(RegExpConstructor& constructor, Utf1
 
     // 8. Set the value of C’s [[RegExpLastMatch]] internal slot to a String whose length is endIndex - startIndex and containing the code units from S with indices startIndex through endIndex - 1, in ascending order.
     auto last_match = string.view().substring_view(start_index, end_index - start_index);
-    legacy_static_properties.set_last_match(Utf16String(last_match));
+    legacy_static_properties.set_last_match(TRY(Utf16String::create(vm, last_match)));
 
     // 9. If n > 0, set the value of C’s [[RegExpLastParen]] internal slot to the last element of capturedValues.
     if (group_count > 0) {
@@ -101,49 +101,45 @@ void update_legacy_regexp_static_properties(RegExpConstructor& constructor, Utf1
     }
     // 10. Else, set the value of C’s [[RegExpLastParen]] internal slot to the empty String.
     else {
-        legacy_static_properties.set_last_paren(Utf16String(""sv));
+        legacy_static_properties.set_last_paren(TRY(Utf16String::create(vm)));
     }
 
     // 11. Set the value of C’s [[RegExpLeftContext]] internal slot to a String whose length is startIndex and containing the code units from S with indices 0 through startIndex - 1, in ascending order.
     auto left_context = string.view().substring_view(0, start_index);
-    legacy_static_properties.set_left_context(Utf16String(left_context));
+    legacy_static_properties.set_left_context(TRY(Utf16String::create(vm, left_context)));
 
     // 12. Set the value of C’s [[RegExpRightContext]] internal slot to a String whose length is len - endIndex and containing the code units from S with indices endIndex through len - 1, in ascending order.
     auto right_context = string.view().substring_view(end_index, len - end_index);
-    legacy_static_properties.set_right_context(Utf16String(right_context));
+    legacy_static_properties.set_right_context(TRY(Utf16String::create(vm, right_context)));
 
     // 13. For each integer i such that 1 ≤ i ≤ 9
     for (size_t i = 1; i <= 9; i++) {
-        auto value = Utf16String(""sv);
-        // If i ≤ n, set the value of C’s [[RegExpPareni]] internal slot to the ith element of capturedValues.
-        if (i <= group_count) {
-            value = captured_values[i - 1];
-        }
-        // Else, set the value of C’s [[RegExpPareni]] internal slot to the empty String.
-        else {
-            // It's already an empty string
-        }
+        // i. If i ≤ n, set the value of C’s [[RegExpPareni]] internal slot to the ith element of capturedValues.
+        // ii. Else, set the value of C’s [[RegExpPareni]] internal slot to the empty String.
+        auto value = (i <= group_count) ? captured_values[i - 1] : TRY(Utf16String::create(vm));
 
         if (i == 1) {
-            legacy_static_properties.set_$1(Utf16String(value));
+            legacy_static_properties.set_$1(move(value));
         } else if (i == 2) {
-            legacy_static_properties.set_$2(Utf16String(value));
+            legacy_static_properties.set_$2(move(value));
         } else if (i == 3) {
-            legacy_static_properties.set_$3(Utf16String(value));
+            legacy_static_properties.set_$3(move(value));
         } else if (i == 4) {
-            legacy_static_properties.set_$4(Utf16String(value));
+            legacy_static_properties.set_$4(move(value));
         } else if (i == 5) {
-            legacy_static_properties.set_$5(Utf16String(value));
+            legacy_static_properties.set_$5(move(value));
         } else if (i == 6) {
-            legacy_static_properties.set_$6(Utf16String(value));
+            legacy_static_properties.set_$6(move(value));
         } else if (i == 7) {
-            legacy_static_properties.set_$7(Utf16String(value));
+            legacy_static_properties.set_$7(move(value));
         } else if (i == 8) {
-            legacy_static_properties.set_$8(Utf16String(value));
+            legacy_static_properties.set_$8(move(value));
         } else if (i == 9) {
-            legacy_static_properties.set_$9(Utf16String(value));
+            legacy_static_properties.set_$9(move(value));
         }
     }
+
+    return {};
 }
 
 // InvalidateLegacyRegExpStaticProperties ( C ), https://github.com/tc39/proposal-regexp-legacy-features#invalidatelegacyregexpstaticproperties--c

--- a/Userland/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.h
@@ -73,7 +73,7 @@ private:
 
 ThrowCompletionOr<void> set_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, void (RegExpLegacyStaticProperties::*property_setter)(Utf16String), Value value);
 ThrowCompletionOr<Value> get_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, Optional<Utf16String> const& (RegExpLegacyStaticProperties::*property_getter)() const);
-void update_legacy_regexp_static_properties(RegExpConstructor& constructor, Utf16String const& string, size_t start_index, size_t end_index, Vector<Utf16String> const& captured_values);
+ThrowCompletionOr<void> update_legacy_regexp_static_properties(VM& vm, RegExpConstructor& constructor, Utf16String const& string, size_t start_index, size_t end_index, Vector<Utf16String> const& captured_values);
 void invalidate_legacy_regexp_static_properties(RegExpConstructor& constructor);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -89,7 +89,11 @@ ErrorOr<DeprecatedString, ParseRegexPatternError> parse_regex_pattern(StringView
     if (unicode && unicode_sets)
         return ParseRegexPatternError { DeprecatedString::formatted(ErrorType::RegExpObjectIncompatibleFlags.message(), 'u', 'v') };
 
-    auto utf16_pattern = AK::utf8_to_utf16(pattern);
+    auto utf16_pattern_result = AK::utf8_to_utf16(pattern);
+    if (utf16_pattern_result.is_error())
+        return ParseRegexPatternError { "Out of memory"sv };
+
+    auto utf16_pattern = utf16_pattern_result.release_value();
     Utf16View utf16_pattern_view { utf16_pattern };
     StringBuilder builder;
 

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -275,7 +275,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
 
     // 27. Let matchedValue be ! GetMatchString(S, match).
     // 28. Perform ! CreateDataPropertyOrThrow(A, "0", matchedValue).
-    MUST(array->create_data_property_or_throw(0, PrimitiveString::create(vm, match.view.u16_view())));
+    MUST(array->create_data_property_or_throw(0, PrimitiveString::create(vm, TRY(Utf16String::create(vm, match.view.u16_view())))));
 
     // 29. If R contains any GroupName, then
     //     a. Let groups be OrdinaryObjectCreate(null).
@@ -300,7 +300,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
             // ii. Append undefined to indices.
             indices.append({});
             // iii. Append capture to indices.
-            captured_values.append(Utf16String(""sv));
+            captured_values.append(TRY(Utf16String::create(vm)));
         }
         // c. Else,
         else {
@@ -311,7 +311,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
             //     2. Set captureEnd to ! GetStringIndex(S, Input, captureEnd).
             // iv. Let capture be the Match { [[StartIndex]]: captureStart, [[EndIndex]: captureEnd }.
             // v. Let capturedValue be ! GetMatchString(S, capture).
-            auto capture_as_utf16_string = Utf16String(capture.view.u16_view());
+            auto capture_as_utf16_string = TRY(Utf16String::create(vm, capture.view.u16_view()));
             captured_value = PrimitiveString::create(vm, capture_as_utf16_string);
             // vi. Append capture to indices.
             indices.append(Match::create(capture));
@@ -351,7 +351,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
         if (regexp_object.legacy_features_enabled()) {
             // a. Perform UpdateLegacyRegExpStaticProperties(%RegExp%, S, lastIndex, e, capturedValues).
             auto* regexp_constructor = realm.intrinsics().regexp_constructor();
-            update_legacy_regexp_static_properties(*regexp_constructor, string, match_indices.start_index, match_indices.end_index, captured_values);
+            TRY(update_legacy_regexp_static_properties(vm, *regexp_constructor, string, match_indices.start_index, match_indices.end_index, captured_values));
         }
         // ii. Else,
         else {
@@ -998,7 +998,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_split)
         auto substring = string.substring_view(last_match_end, next_search_from - last_match_end);
 
         // 2. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
-        MUST(array->create_data_property_or_throw(array_length, PrimitiveString::create(vm, substring)));
+        MUST(array->create_data_property_or_throw(array_length, PrimitiveString::create(vm, TRY(Utf16String::create(vm, substring)))));
 
         // 3. Set lengthA to lengthA + 1.
         ++array_length;
@@ -1045,7 +1045,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_split)
     auto substring = string.substring_view(last_match_end);
 
     // 21. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
-    MUST(array->create_data_property_or_throw(array_length, PrimitiveString::create(vm, substring)));
+    MUST(array->create_data_property_or_throw(array_length, PrimitiveString::create(vm, TRY(Utf16String::create(vm, substring)))));
 
     // 22. Return A.
     return array;

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -86,7 +86,7 @@ ThrowCompletionOr<void> copy_name_and_length(VM& vm, FunctionObject& function, F
         target_name = PrimitiveString::create(vm, DeprecatedString::empty());
 
     // 8. Perform SetFunctionName(F, targetName, prefix).
-    function.set_function_name({ target_name.as_string().deprecated_string() }, move(prefix));
+    function.set_function_name({ TRY(target_name.as_string().deprecated_string()) }, move(prefix));
 
     return {};
 }
@@ -272,7 +272,7 @@ ThrowCompletionOr<Value> shadow_realm_import_value(VM& vm, DeprecatedString spec
     // NOTE: Even though the spec tells us to use %ThrowTypeError%, it's not observable if we actually do.
     // Throw a nicer TypeError forwarding the import error message instead (we know the argument is an Error object).
     auto throw_type_error = NativeFunction::create(realm, {}, [](auto& vm) -> ThrowCompletionOr<Value> {
-        return vm.template throw_completion<TypeError>(vm.argument(0).as_object().get_without_side_effects(vm.names.message).as_string().deprecated_string());
+        return vm.template throw_completion<TypeError>(TRY(vm.argument(0).as_object().get_without_side_effects(vm.names.message).as_string().deprecated_string()));
     });
 
     // 13. Return PerformPromiseThen(innerCapability.[[Promise]], onFulfilled, callerRealm.[[Intrinsics]].[[%ThrowTypeError%]], promiseCapability).

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealmPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealmPrototype.cpp
@@ -49,7 +49,7 @@ JS_DEFINE_NATIVE_FUNCTION(ShadowRealmPrototype::evaluate)
     auto& eval_realm = object->shadow_realm();
 
     // 6. Return ? PerformShadowRealmEval(sourceText, callerRealm, evalRealm).
-    return perform_shadow_realm_eval(vm, source_text.as_string().deprecated_string(), *caller_realm, eval_realm);
+    return perform_shadow_realm_eval(vm, TRY(source_text.as_string().deprecated_string()), *caller_realm, eval_realm);
 }
 
 // 3.4.2 ShadowRealm.prototype.importValue ( specifier, exportName ), https://tc39.es/proposal-shadowrealm/#sec-shadowrealm.prototype.importvalue
@@ -79,7 +79,7 @@ JS_DEFINE_NATIVE_FUNCTION(ShadowRealmPrototype::import_value)
     auto& eval_context = object->execution_context();
 
     // 8. Return ? ShadowRealmImportValue(specifierString, exportNameString, callerRealm, evalRealm, evalContext).
-    return shadow_realm_import_value(vm, move(specifier_string), export_name.as_string().deprecated_string(), *caller_realm, eval_realm, eval_context);
+    return shadow_realm_import_value(vm, move(specifier_string), TRY(export_name.as_string().deprecated_string()), *caller_realm, eval_realm, eval_context);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -100,7 +100,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringConstructor::raw)
 // 22.1.2.1 String.fromCharCode ( ...codeUnits ), https://tc39.es/ecma262/#sec-string.fromcharcode
 JS_DEFINE_NATIVE_FUNCTION(StringConstructor::from_char_code)
 {
-    Vector<u16, 1> string;
+    Utf16Data string;
     string.ensure_capacity(vm.argument_count());
 
     for (size_t i = 0; i < vm.argument_count(); ++i)
@@ -112,7 +112,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringConstructor::from_char_code)
 // 22.1.2.2 String.fromCodePoint ( ...codePoints ), https://tc39.es/ecma262/#sec-string.fromcodepoint
 JS_DEFINE_NATIVE_FUNCTION(StringConstructor::from_code_point)
 {
-    Vector<u16, 1> string;
+    Utf16Data string;
     string.ensure_capacity(vm.argument_count()); // This will be an under-estimate if any code point is > 0xffff.
 
     for (size_t i = 0; i < vm.argument_count(); ++i) {

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -123,7 +123,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringConstructor::from_code_point)
         if (code_point < 0 || code_point > 0x10FFFF)
             return vm.throw_completion<RangeError>(ErrorType::InvalidCodePoint, next_code_point.to_string_without_side_effects());
 
-        AK::code_point_to_utf16(string, static_cast<u32>(code_point));
+        TRY_OR_THROW_OOM(vm, code_point_to_utf16(string, static_cast<u32>(code_point)));
     }
 
     return PrimitiveString::create(vm, Utf16String(move(string)));

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -106,7 +106,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringConstructor::from_char_code)
     for (size_t i = 0; i < vm.argument_count(); ++i)
         string.append(TRY(vm.argument(i).to_u16(vm)));
 
-    return PrimitiveString::create(vm, Utf16String(move(string)));
+    return PrimitiveString::create(vm, TRY(Utf16String::create(vm, move(string))));
 }
 
 // 22.1.2.2 String.fromCodePoint ( ...codePoints ), https://tc39.es/ecma262/#sec-string.fromcodepoint
@@ -126,7 +126,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringConstructor::from_code_point)
         TRY_OR_THROW_OOM(vm, code_point_to_utf16(string, static_cast<u32>(code_point)));
     }
 
-    return PrimitiveString::create(vm, Utf16String(move(string)));
+    return PrimitiveString::create(vm, TRY(Utf16String::create(vm, move(string))));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -518,7 +518,7 @@ static ThrowCompletionOr<Value> pad_string(VM& vm, Utf16String string, PadPlacem
     if (max_length <= string_length)
         return PrimitiveString::create(vm, move(string));
 
-    Utf16String fill_string(Vector<u16, 1> { 0x20 });
+    Utf16String fill_string(Utf16Data { 0x20 });
     if (!vm.argument(1).is_undefined()) {
         fill_string = TRY(vm.argument(1).to_utf16_string(vm));
         if (fill_string.is_empty())

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -23,6 +23,7 @@
 #include <LibJS/Runtime/StringIterator.h>
 #include <LibJS/Runtime/StringObject.h>
 #include <LibJS/Runtime/StringPrototype.h>
+#include <LibJS/Runtime/ThrowableFormat.h>
 #include <LibJS/Runtime/ThrowableStringBuilder.h>
 #include <LibJS/Runtime/Utf16String.h>
 #include <LibJS/Runtime/Value.h>
@@ -536,8 +537,8 @@ static ThrowCompletionOr<Value> pad_string(VM& vm, Utf16String string, PadPlacem
     auto filler = filler_builder.build();
 
     auto formatted = placement == PadPlacement::Start
-        ? DeprecatedString::formatted("{}{}", filler, string.view())
-        : DeprecatedString::formatted("{}{}", string.view(), filler);
+        ? TRY(deprecated_format(vm, "{}{}", filler, string.view()))
+        : TRY(deprecated_format(vm, "{}{}", string.view(), filler));
     return PrimitiveString::create(vm, move(formatted));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -237,7 +237,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::at)
         return js_undefined();
 
     // 7. Return ? Get(O, ! ToString(𝔽(k))).
-    return PrimitiveString::create(vm, string.substring_view(index.value(), 1));
+    return PrimitiveString::create(vm, TRY(Utf16String::create(vm, string.substring_view(index.value(), 1))));
 }
 
 // 22.1.3.2 String.prototype.charAt ( pos ), https://tc39.es/ecma262/#sec-string.prototype.charat
@@ -248,7 +248,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::char_at)
     if (position < 0 || position >= string.length_in_code_units())
         return PrimitiveString::create(vm, DeprecatedString::empty());
 
-    return PrimitiveString::create(vm, string.substring_view(position, 1));
+    return PrimitiveString::create(vm, TRY(Utf16String::create(vm, string.substring_view(position, 1))));
 }
 
 // 22.1.3.3 String.prototype.charCodeAt ( pos ), https://tc39.es/ecma262/#sec-string.prototype.charcodeat
@@ -518,7 +518,7 @@ static ThrowCompletionOr<Value> pad_string(VM& vm, Utf16String string, PadPlacem
     if (max_length <= string_length)
         return PrimitiveString::create(vm, move(string));
 
-    Utf16String fill_string(Utf16Data { 0x20 });
+    auto fill_string = TRY(Utf16String::create(vm, Utf16Data { 0x20 }));
     if (!vm.argument(1).is_undefined()) {
         fill_string = TRY(vm.argument(1).to_utf16_string(vm));
         if (fill_string.is_empty())
@@ -736,7 +736,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::slice)
     if (int_start >= int_end)
         return PrimitiveString::create(vm, DeprecatedString::empty());
 
-    return PrimitiveString::create(vm, string.substring_view(int_start, int_end - int_start));
+    return PrimitiveString::create(vm, TRY(Utf16String::create(vm, string.substring_view(int_start, int_end - int_start))));
 }
 
 // 22.1.3.22 String.prototype.split ( separator, limit ), https://tc39.es/ecma262/#sec-string.prototype.split
@@ -793,7 +793,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::split)
         }
 
         auto segment = string.substring_view(start, position - start);
-        MUST(array->create_data_property_or_throw(array_length, PrimitiveString::create(vm, segment)));
+        MUST(array->create_data_property_or_throw(array_length, PrimitiveString::create(vm, TRY(Utf16String::create(vm, segment)))));
         ++array_length;
         if (array_length == limit)
             return array;
@@ -802,7 +802,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::split)
     }
 
     auto rest = string.substring_view(start);
-    MUST(array->create_data_property_or_throw(array_length, PrimitiveString::create(vm, rest)));
+    MUST(array->create_data_property_or_throw(array_length, PrimitiveString::create(vm, TRY(Utf16String::create(vm, rest)))));
 
     return array;
 }
@@ -867,7 +867,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::substring)
     size_t to = max(final_start, final_end);
 
     // 10. Return the substring of S from from to to.
-    return PrimitiveString::create(vm, string.substring_view(from, to - from));
+    return PrimitiveString::create(vm, TRY(Utf16String::create(vm, string.substring_view(from, to - from))));
 }
 
 enum class TargetCase {
@@ -1111,7 +1111,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::substr)
         return PrimitiveString::create(vm, DeprecatedString::empty());
 
     // 11. Return the substring of S from intStart to intEnd.
-    return PrimitiveString::create(vm, string.substring_view(int_start, int_end - int_start));
+    return PrimitiveString::create(vm, TRY(Utf16String::create(vm, string.substring_view(int_start, int_end - int_start))));
 }
 
 // B.2.2.2.1 CreateHTML ( string, tag, attribute, value ), https://tc39.es/ecma262/#sec-createhtml

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -146,8 +146,8 @@ ThrowCompletionOr<Value> get_option(VM& vm, Object const& options, PropertyKey c
     if (!values.is_empty()) {
         // NOTE: Every location in the spec that invokes GetOption with type=boolean also has values=undefined.
         VERIFY(value.is_string());
-        if (!values.contains_slow(value.as_string().deprecated_string()))
-            return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, value.as_string().deprecated_string(), property.as_string());
+        if (auto const& value_string = TRY(value.as_string().deprecated_string()); !values.contains_slow(value_string))
+            return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, value_string, property.as_string());
     }
 
     // 9. Return value.
@@ -165,7 +165,7 @@ ThrowCompletionOr<DeprecatedString> to_temporal_overflow(VM& vm, Object const* o
     auto option = TRY(get_option(vm, *options, vm.names.overflow, OptionType::String, { "constrain"sv, "reject"sv }, "constrain"sv));
 
     VERIFY(option.is_string());
-    return option.as_string().deprecated_string();
+    return TRY(option.as_string().deprecated_string());
 }
 
 // 13.5 ToTemporalDisambiguation ( options ), https://tc39.es/proposal-temporal/#sec-temporal-totemporaldisambiguation
@@ -179,7 +179,7 @@ ThrowCompletionOr<DeprecatedString> to_temporal_disambiguation(VM& vm, Object co
     auto option = TRY(get_option(vm, *options, vm.names.disambiguation, OptionType::String, { "compatible"sv, "earlier"sv, "later"sv, "reject"sv }, "compatible"sv));
 
     VERIFY(option.is_string());
-    return option.as_string().deprecated_string();
+    return TRY(option.as_string().deprecated_string());
 }
 
 // 13.6 ToTemporalRoundingMode ( normalizedOptions, fallback ), https://tc39.es/proposal-temporal/#sec-temporal-totemporalroundingmode
@@ -202,7 +202,7 @@ ThrowCompletionOr<DeprecatedString> to_temporal_rounding_mode(VM& vm, Object con
         fallback.view()));
 
     VERIFY(option.is_string());
-    return option.as_string().deprecated_string();
+    return TRY(option.as_string().deprecated_string());
 }
 
 // 13.7 NegateTemporalRoundingMode ( roundingMode ), https://tc39.es/proposal-temporal/#sec-temporal-negatetemporalroundingmode
@@ -239,7 +239,7 @@ ThrowCompletionOr<DeprecatedString> to_temporal_offset(VM& vm, Object const* opt
     auto option = TRY(get_option(vm, *options, vm.names.offset, OptionType::String, { "prefer"sv, "use"sv, "ignore"sv, "reject"sv }, fallback.view()));
 
     VERIFY(option.is_string());
-    return option.as_string().deprecated_string();
+    return TRY(option.as_string().deprecated_string());
 }
 
 // 13.9 ToCalendarNameOption ( normalizedOptions ), https://tc39.es/proposal-temporal/#sec-temporal-tocalendarnameoption
@@ -249,7 +249,7 @@ ThrowCompletionOr<DeprecatedString> to_calendar_name_option(VM& vm, Object const
     auto option = TRY(get_option(vm, normalized_options, vm.names.calendarName, OptionType::String, { "auto"sv, "always"sv, "never"sv, "critical"sv }, "auto"sv));
 
     VERIFY(option.is_string());
-    return option.as_string().deprecated_string();
+    return TRY(option.as_string().deprecated_string());
 }
 
 // 13.10 ToTimeZoneNameOption ( normalizedOptions ), https://tc39.es/proposal-temporal/#sec-temporal-totimezonenameoption
@@ -259,7 +259,7 @@ ThrowCompletionOr<DeprecatedString> to_time_zone_name_option(VM& vm, Object cons
     auto option = TRY(get_option(vm, normalized_options, vm.names.timeZoneName, OptionType::String, { "auto"sv, "never"sv, "critical"sv }, "auto"sv));
 
     VERIFY(option.is_string());
-    return option.as_string().deprecated_string();
+    return TRY(option.as_string().deprecated_string());
 }
 
 // 13.11 ToShowOffsetOption ( normalizedOptions ), https://tc39.es/proposal-temporal/#sec-temporal-toshowoffsetoption
@@ -269,7 +269,7 @@ ThrowCompletionOr<DeprecatedString> to_show_offset_option(VM& vm, Object const& 
     auto option = TRY(get_option(vm, normalized_options, vm.names.offset, OptionType::String, { "auto"sv, "never"sv }, "auto"sv));
 
     VERIFY(option.is_string());
-    return option.as_string().deprecated_string();
+    return TRY(option.as_string().deprecated_string());
 }
 
 // 13.12 ToTemporalRoundingIncrement ( normalizedOptions, dividend, inclusive ), https://tc39.es/proposal-temporal/#sec-temporal-totemporalroundingincrement
@@ -530,7 +530,7 @@ ThrowCompletionOr<Optional<DeprecatedString>> get_temporal_unit(VM& vm, Object c
 
     Optional<DeprecatedString> value = option_value.is_undefined()
         ? Optional<DeprecatedString> {}
-        : option_value.as_string().deprecated_string();
+        : TRY(option_value.as_string().deprecated_string());
 
     // 11. If value is listed in the Plural column of Table 13, then
     for (auto const& row : temporal_units) {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -126,7 +126,7 @@ ThrowCompletionOr<Vector<DeprecatedString>> calendar_fields(VM& vm, Object& cale
 
     Vector<DeprecatedString> result;
     for (auto& value : list)
-        result.append(value.as_string().deprecated_string());
+        result.append(TRY(value.as_string().deprecated_string()));
     return result;
 }
 
@@ -781,7 +781,7 @@ ThrowCompletionOr<double> resolve_iso_month(VM& vm, Object const& fields)
 
     // 6. Assert: Type(monthCode) is String.
     VERIFY(month_code.is_string());
-    auto& month_code_string = month_code.as_string().deprecated_string();
+    auto const& month_code_string = TRY(month_code.as_string().deprecated_string());
 
     // 7. If the length of monthCode is not 3, throw a RangeError exception.
     auto month_length = month_code_string.length();
@@ -943,7 +943,7 @@ ThrowCompletionOr<Object*> default_merge_calendar_fields(VM& vm, Object const& f
     // 3. For each element key of fieldsKeys, do
     for (auto& key : fields_keys) {
         // a. If key is not "month" or "monthCode", then
-        if (key.as_string().deprecated_string() != vm.names.month.as_string() && key.as_string().deprecated_string() != vm.names.monthCode.as_string()) {
+        if (!TRY(key.as_string().deprecated_string()).is_one_of(vm.names.month.as_string(), vm.names.monthCode.as_string())) {
             auto property_key = MUST(PropertyKey::from_value(vm, key));
 
             // i. Let propValue be ? Get(fields, key).
@@ -977,7 +977,7 @@ ThrowCompletionOr<Object*> default_merge_calendar_fields(VM& vm, Object const& f
         }
 
         // See comment above.
-        additional_fields_keys_contains_month_or_month_code_property |= key.as_string().deprecated_string() == vm.names.month.as_string() || key.as_string().deprecated_string() == vm.names.monthCode.as_string();
+        additional_fields_keys_contains_month_or_month_code_property |= TRY(key.as_string().deprecated_string()) == vm.names.month.as_string() || TRY(key.as_string().deprecated_string()) == vm.names.monthCode.as_string();
     }
 
     // 6. If additionalFieldsKeys does not contain either "month" or "monthCode", then

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
@@ -559,19 +559,21 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::fields)
             return TRY(iterator_close(vm, iterator_record, move(completion)));
         }
 
+        auto const& next_value_string = TRY(next_value.as_string().deprecated_string());
+
         // iii. If fieldNames contains nextValue, then
         if (field_names.contains_slow(next_value)) {
             // 1. Let completion be ThrowCompletion(a newly created RangeError object).
-            auto completion = vm.throw_completion<RangeError>(ErrorType::TemporalDuplicateCalendarField, next_value.as_string().deprecated_string());
+            auto completion = vm.throw_completion<RangeError>(ErrorType::TemporalDuplicateCalendarField, next_value_string);
 
             // 2. Return ? IteratorClose(iteratorRecord, completion).
             return TRY(iterator_close(vm, iterator_record, move(completion)));
         }
 
         // iv. If nextValue is not one of "year", "month", "monthCode", "day", "hour", "minute", "second", "millisecond", "microsecond", "nanosecond", then
-        if (!next_value.as_string().deprecated_string().is_one_of("year"sv, "month"sv, "monthCode"sv, "day"sv, "hour"sv, "minute"sv, "second"sv, "millisecond"sv, "microsecond"sv, "nanosecond"sv)) {
+        if (!next_value_string.is_one_of("year"sv, "month"sv, "monthCode"sv, "day"sv, "hour"sv, "minute"sv, "second"sv, "millisecond"sv, "microsecond"sv, "nanosecond"sv)) {
             // 1. Let completion be ThrowCompletion(a newly created RangeError object).
-            auto completion = vm.throw_completion<RangeError>(ErrorType::TemporalInvalidCalendarFieldName, next_value.as_string().deprecated_string());
+            auto completion = vm.throw_completion<RangeError>(ErrorType::TemporalInvalidCalendarFieldName, next_value_string);
 
             // 2. Return ? IteratorClose(iteratorRecord, completion).
             return TRY(iterator_close(vm, iterator_record, move(completion)));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -801,7 +801,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::with)
 
     // 18. Assert: Type(offsetString) is String.
     VERIFY(offset_string_value.is_string());
-    auto const& offset_string = offset_string_value.as_string().deprecated_string();
+    auto const& offset_string = TRY(offset_string_value.as_string().deprecated_string());
 
     // 19. Let dateTimeResult be ? InterpretTemporalDateTimeFields(calendar, fields, options).
     auto date_time_result = TRY(interpret_temporal_date_time_fields(vm, calendar, *fields, *options));

--- a/Userland/Libraries/LibJS/Runtime/ThrowableFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/ThrowableFormat.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/CheckedFormatString.h>
+#include <AK/DeprecatedString.h>
+#include <AK/Format.h>
+#include <LibJS/Runtime/Completion.h>
+#include <LibJS/Runtime/ErrorTypes.h>
+#include <LibJS/Runtime/VM.h>
+
+namespace JS {
+
+template<typename... Args>
+ThrowCompletionOr<DeprecatedString> deprecated_format(VM& vm, CheckedFormatString<Args...>&& fmtstr, Args const&... args)
+{
+    StringBuilder builder;
+    AK::VariadicFormatParams parameters { args... };
+
+    TRY_OR_THROW_OOM(vm, vformat(builder, fmtstr.view(), parameters));
+    return builder.to_deprecated_string();
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Utf16String.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Utf16String.cpp
@@ -33,7 +33,7 @@ NonnullRefPtr<Utf16StringImpl> Utf16StringImpl::create(Utf16Data string)
 
 NonnullRefPtr<Utf16StringImpl> Utf16StringImpl::create(StringView string)
 {
-    return create(AK::utf8_to_utf16(string));
+    return create(AK::utf8_to_utf16(string).release_value_but_fixme_should_propagate_errors());
 }
 
 NonnullRefPtr<Utf16StringImpl> Utf16StringImpl::create(Utf16View const& view)

--- a/Userland/Libraries/LibJS/Runtime/Utf16String.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Utf16String.cpp
@@ -1,11 +1,10 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/StringView.h>
-#include <AK/Utf16View.h>
 #include <LibJS/Runtime/Utf16String.h>
 
 namespace JS {
@@ -17,7 +16,7 @@ static NonnullRefPtr<Utf16StringImpl> the_empty_utf16_string()
     return empty_string;
 }
 
-Utf16StringImpl::Utf16StringImpl(Vector<u16, 1> string)
+Utf16StringImpl::Utf16StringImpl(Utf16Data string)
     : m_string(move(string))
 {
 }
@@ -27,7 +26,7 @@ NonnullRefPtr<Utf16StringImpl> Utf16StringImpl::create()
     return adopt_ref(*new Utf16StringImpl());
 }
 
-NonnullRefPtr<Utf16StringImpl> Utf16StringImpl::create(Vector<u16, 1> string)
+NonnullRefPtr<Utf16StringImpl> Utf16StringImpl::create(Utf16Data string)
 {
     return adopt_ref(*new Utf16StringImpl(move(string)));
 }
@@ -39,13 +38,13 @@ NonnullRefPtr<Utf16StringImpl> Utf16StringImpl::create(StringView string)
 
 NonnullRefPtr<Utf16StringImpl> Utf16StringImpl::create(Utf16View const& view)
 {
-    Vector<u16, 1> string;
+    Utf16Data string;
     string.ensure_capacity(view.length_in_code_units());
     string.append(view.data(), view.length_in_code_units());
     return create(move(string));
 }
 
-Vector<u16, 1> const& Utf16StringImpl::string() const
+Utf16Data const& Utf16StringImpl::string() const
 {
     return m_string;
 }
@@ -62,7 +61,7 @@ Utf16String::Utf16String()
 {
 }
 
-Utf16String::Utf16String(Vector<u16, 1> string)
+Utf16String::Utf16String(Utf16Data string)
     : m_string(Detail::Utf16StringImpl::create(move(string)))
 {
 }
@@ -77,7 +76,7 @@ Utf16String::Utf16String(Utf16View const& string)
 {
 }
 
-Vector<u16, 1> const& Utf16String::string() const
+Utf16Data const& Utf16String::string() const
 {
     return m_string->string();
 }

--- a/Userland/Libraries/LibJS/Runtime/Utf16String.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Utf16String.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/StringView.h>
 #include <LibJS/Runtime/Utf16String.h>
+#include <LibJS/Runtime/VM.h>
 
 namespace JS {
 namespace Detail {
@@ -96,9 +97,9 @@ Utf16View Utf16String::substring_view(size_t code_unit_offset) const
     return view().substring_view(code_unit_offset);
 }
 
-DeprecatedString Utf16String::to_utf8() const
+ThrowCompletionOr<DeprecatedString> Utf16String::to_utf8(VM& vm) const
 {
-    return view().to_utf8(Utf16View::AllowInvalidCodeUnits::Yes);
+    return TRY_OR_THROW_OOM(vm, view().to_utf8(Utf16View::AllowInvalidCodeUnits::Yes));
 }
 
 u16 Utf16String::code_unit_at(size_t index) const

--- a/Userland/Libraries/LibJS/Runtime/Utf16String.h
+++ b/Userland/Libraries/LibJS/Runtime/Utf16String.h
@@ -12,6 +12,7 @@
 #include <AK/Types.h>
 #include <AK/Utf16View.h>
 #include <AK/Vector.h>
+#include <LibJS/Runtime/Completion.h>
 
 namespace JS {
 namespace Detail {
@@ -49,7 +50,7 @@ public:
     Utf16View substring_view(size_t code_unit_offset, size_t code_unit_length) const;
     Utf16View substring_view(size_t code_unit_offset) const;
 
-    DeprecatedString to_utf8() const;
+    ThrowCompletionOr<DeprecatedString> to_utf8(VM&) const;
     u16 code_unit_at(size_t index) const;
 
     size_t length_in_code_units() const;

--- a/Userland/Libraries/LibJS/Runtime/Utf16String.h
+++ b/Userland/Libraries/LibJS/Runtime/Utf16String.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,6 +10,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/Types.h>
+#include <AK/Utf16View.h>
 #include <AK/Vector.h>
 
 namespace JS {
@@ -20,18 +21,18 @@ public:
     ~Utf16StringImpl() = default;
 
     static NonnullRefPtr<Utf16StringImpl> create();
-    static NonnullRefPtr<Utf16StringImpl> create(Vector<u16, 1>);
+    static NonnullRefPtr<Utf16StringImpl> create(Utf16Data);
     static NonnullRefPtr<Utf16StringImpl> create(StringView);
     static NonnullRefPtr<Utf16StringImpl> create(Utf16View const&);
 
-    Vector<u16, 1> const& string() const;
+    Utf16Data const& string() const;
     Utf16View view() const;
 
 private:
     Utf16StringImpl() = default;
-    explicit Utf16StringImpl(Vector<u16, 1> string);
+    explicit Utf16StringImpl(Utf16Data string);
 
-    Vector<u16, 1> m_string;
+    Utf16Data m_string;
 };
 
 }
@@ -39,11 +40,11 @@ private:
 class Utf16String {
 public:
     Utf16String();
-    explicit Utf16String(Vector<u16, 1>);
+    explicit Utf16String(Utf16Data);
     explicit Utf16String(StringView);
     explicit Utf16String(Utf16View const&);
 
-    Vector<u16, 1> const& string() const;
+    Utf16Data const& string() const;
     Utf16View view() const;
     Utf16View substring_view(size_t code_unit_offset, size_t code_unit_length) const;
     Utf16View substring_view(size_t code_unit_offset) const;

--- a/Userland/Libraries/LibJS/Runtime/Utf16String.h
+++ b/Userland/Libraries/LibJS/Runtime/Utf16String.h
@@ -21,10 +21,10 @@ class Utf16StringImpl : public RefCounted<Utf16StringImpl> {
 public:
     ~Utf16StringImpl() = default;
 
-    static NonnullRefPtr<Utf16StringImpl> create();
-    static NonnullRefPtr<Utf16StringImpl> create(Utf16Data);
-    static NonnullRefPtr<Utf16StringImpl> create(StringView);
-    static NonnullRefPtr<Utf16StringImpl> create(Utf16View const&);
+    static ThrowCompletionOr<NonnullRefPtr<Utf16StringImpl>> create(VM&);
+    static ThrowCompletionOr<NonnullRefPtr<Utf16StringImpl>> create(VM&, Utf16Data);
+    static ThrowCompletionOr<NonnullRefPtr<Utf16StringImpl>> create(VM&, StringView);
+    static ThrowCompletionOr<NonnullRefPtr<Utf16StringImpl>> create(VM&, Utf16View const&);
 
     Utf16Data const& string() const;
     Utf16View view() const;
@@ -40,10 +40,10 @@ private:
 
 class Utf16String {
 public:
-    Utf16String();
-    explicit Utf16String(Utf16Data);
-    explicit Utf16String(StringView);
-    explicit Utf16String(Utf16View const&);
+    static ThrowCompletionOr<Utf16String> create(VM&);
+    static ThrowCompletionOr<Utf16String> create(VM&, Utf16Data);
+    static ThrowCompletionOr<Utf16String> create(VM&, StringView);
+    static ThrowCompletionOr<Utf16String> create(VM&, Utf16View const&);
 
     Utf16Data const& string() const;
     Utf16View view() const;
@@ -57,6 +57,8 @@ public:
     bool is_empty() const;
 
 private:
+    explicit Utf16String(NonnullRefPtr<Detail::Utf16StringImpl>);
+
     NonnullRefPtr<Detail::Utf16StringImpl> m_string;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -36,6 +36,7 @@
 #include <LibJS/Runtime/StringObject.h>
 #include <LibJS/Runtime/StringPrototype.h>
 #include <LibJS/Runtime/SymbolObject.h>
+#include <LibJS/Runtime/Utf16String.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibJS/Runtime/Value.h>
 #include <math.h>

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -19,7 +19,6 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibJS/Runtime/BigInt.h>
-#include <LibJS/Runtime/Utf16String.h>
 #include <math.h>
 
 // 2 ** 53 - 1

--- a/Userland/Libraries/LibJS/Runtime/ValueTraits.h
+++ b/Userland/Libraries/LibJS/Runtime/ValueTraits.h
@@ -16,8 +16,10 @@ struct ValueTraits : public Traits<Value> {
     static unsigned hash(Value value)
     {
         VERIFY(!value.is_empty());
-        if (value.is_string())
-            return value.as_string().deprecated_string().hash();
+        if (value.is_string()) {
+            // FIXME: Propagate this error.
+            return value.as_string().deprecated_string().release_value().hash();
+        }
 
         if (value.is_bigint())
             return value.as_bigint().big_integer().hash();

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -517,7 +517,7 @@ ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, M
                 return ExecutionResult::Failed_ExecuteLowPrioForks;
 
             Optional<DeprecatedString> str;
-            Vector<u16, 1> utf16;
+            Utf16Data utf16;
             Vector<u32> data;
             data.ensure_capacity(length);
             for (size_t i = offset; i < offset + length; ++i)

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -266,7 +266,7 @@ public:
         return view;
     }
 
-    RegexStringView construct_as_same(Span<u32> data, Optional<DeprecatedString>& optional_string_storage, Vector<u16, 1>& optional_utf16_storage) const
+    RegexStringView construct_as_same(Span<u32> data, Optional<DeprecatedString>& optional_string_storage, Utf16Data& optional_utf16_storage) const
     {
         auto view = m_view.visit(
             [&]<typename T>(T const&) {

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -280,7 +280,7 @@ public:
                 return RegexStringView { Utf32View { data.data(), data.size() } };
             },
             [&](Utf16View) {
-                optional_utf16_storage = AK::utf32_to_utf16(Utf32View { data.data(), data.size() });
+                optional_utf16_storage = AK::utf32_to_utf16(Utf32View { data.data(), data.size() }).release_value_but_fixme_should_propagate_errors();
                 return RegexStringView { Utf16View { optional_utf16_storage } };
             });
 

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -385,7 +385,7 @@ public:
     {
         return m_view.visit(
             [](StringView view) { return view.to_deprecated_string(); },
-            [](Utf16View view) { return view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes); },
+            [](Utf16View view) { return view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes).release_value_but_fixme_should_propagate_errors(); },
             [](auto& view) {
                 StringBuilder builder;
                 for (auto it = view.begin(); it != view.end(); ++it)

--- a/Userland/Libraries/LibWeb/Fetch/Body.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Body.cpp
@@ -163,7 +163,7 @@ JS::NonnullGCPtr<JS::Promise> consume_body(JS::Realm& realm, BodyMixin const& ob
     // 4. Let steps be to return the result of package data with the first argument given, type, and object’s MIME type.
     auto steps = [&vm, &realm, &object, type](JS::Value value) -> WebIDL::ExceptionOr<JS::Value> {
         VERIFY(value.is_string());
-        auto bytes = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(value.as_string().deprecated_string().bytes()));
+        auto bytes = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(TRY(value.as_string().deprecated_string()).bytes()));
         return package_data(realm, move(bytes), type, object.mime_type_impl());
     };
 

--- a/Userland/Libraries/LibWeb/Fetch/Body.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Body.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/PromiseCapability.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -160,9 +161,9 @@ JS::NonnullGCPtr<JS::Promise> consume_body(JS::Realm& realm, BodyMixin const& ob
         promise = body->fully_read_as_promise();
 
     // 4. Let steps be to return the result of package data with the first argument given, type, and object’s MIME type.
-    auto steps = [&realm, &object, type](JS::Value value) -> WebIDL::ExceptionOr<JS::Value> {
+    auto steps = [&vm, &realm, &object, type](JS::Value value) -> WebIDL::ExceptionOr<JS::Value> {
         VERIFY(value.is_string());
-        auto bytes = TRY_OR_RETURN_OOM(realm, ByteBuffer::copy(value.as_string().deprecated_string().bytes()));
+        auto bytes = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(value.as_string().deprecated_string().bytes()));
         return package_data(realm, move(bytes), type, object.mime_type_impl());
     };
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -8,6 +8,7 @@
 #include <AK/TypeCasts.h>
 #include <AK/URLParser.h>
 #include <LibJS/Heap/Heap.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Fetch/Infrastructure/FetchParams.h>
@@ -126,15 +127,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::clone(JS::VM& vm) cons
 {
     // To clone a response response, run these steps:
 
-    auto& realm = *vm.current_realm();
-
     // 1. If response is a filtered response, then return a new identical filtered response whose internal response is a clone of response’s internal response.
     if (is<FilteredResponse>(*this)) {
         auto internal_response = TRY(static_cast<FilteredResponse const&>(*this).internal_response()->clone(vm));
         if (is<BasicFilteredResponse>(*this))
-            return TRY_OR_RETURN_OOM(realm, BasicFilteredResponse::create(vm, internal_response));
+            return TRY_OR_THROW_OOM(vm, BasicFilteredResponse::create(vm, internal_response));
         if (is<CORSFilteredResponse>(*this))
-            return TRY_OR_RETURN_OOM(realm, CORSFilteredResponse::create(vm, internal_response));
+            return TRY_OR_THROW_OOM(vm, CORSFilteredResponse::create(vm, internal_response));
         if (is<OpaqueFilteredResponse>(*this))
             return OpaqueFilteredResponse::create(vm, internal_response);
         if (is<OpaqueRedirectFilteredResponse>(*this))

--- a/Userland/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Request.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/URLParser.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/RequestPrototype.h>
 #include <LibWeb/DOM/AbortSignal.h>
@@ -174,13 +175,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
 
     // method
     //     request’s method.
-    request->set_method(TRY_OR_RETURN_OOM(realm, ByteBuffer::copy(input_request->method())));
+    request->set_method(TRY_OR_THROW_OOM(vm, ByteBuffer::copy(input_request->method())));
 
     // header list
     //     A copy of request’s header list.
     auto header_list_copy = Infrastructure::HeaderList::create(vm);
     for (auto& header : *input_request->header_list())
-        TRY_OR_RETURN_OOM(realm, header_list_copy->append(header));
+        TRY_OR_THROW_OOM(vm, header_list_copy->append(header));
     request->set_header_list(header_list_copy);
 
     // unsafe-request flag
@@ -365,7 +366,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
             return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Method must not be one of CONNECT, TRACE, or TRACK"sv };
 
         // 3. Normalize method.
-        method = TRY_OR_RETURN_OOM(realm, Infrastructure::normalize_method(method.bytes()));
+        method = TRY_OR_THROW_OOM(vm, Infrastructure::normalize_method(method.bytes()));
 
         // 4. Set request’s method to method.
         request->set_method(MUST(ByteBuffer::copy(method.bytes())));

--- a/Userland/Libraries/LibWeb/Fetch/Response.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Response.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/URLParser.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Fetch/Enums.h>
@@ -82,6 +83,8 @@ JS::NonnullGCPtr<Response> Response::create(JS::Realm& realm, JS::NonnullGCPtr<I
 // https://fetch.spec.whatwg.org/#initialize-a-response
 WebIDL::ExceptionOr<void> Response::initialize_response(ResponseInit const& init, Optional<Infrastructure::BodyWithType> const& body)
 {
+    auto& vm = this->vm();
+
     // 1. If init["status"] is not in the range 200 to 599, inclusive, then throw a RangeError.
     if (init.status < 200 || init.status > 599)
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "Status must be in range 200-599"sv };
@@ -92,7 +95,7 @@ WebIDL::ExceptionOr<void> Response::initialize_response(ResponseInit const& init
     m_response->set_status(init.status);
 
     // 4. Set response’s response’s status message to init["statusText"].
-    m_response->set_status_message(TRY_OR_RETURN_OOM(realm(), ByteBuffer::copy(init.status_text.bytes())));
+    m_response->set_status_message(TRY_OR_THROW_OOM(vm, ByteBuffer::copy(init.status_text.bytes())));
 
     // 5. If init["headers"] exists, then fill response’s headers with init["headers"].
     if (init.headers.has_value())
@@ -111,9 +114,9 @@ WebIDL::ExceptionOr<void> Response::initialize_response(ResponseInit const& init
         if (body->type.has_value() && m_response->header_list()->contains("Content-Type"sv.bytes())) {
             auto header = Infrastructure::Header {
                 .name = MUST(ByteBuffer::copy("Content-Type"sv.bytes())),
-                .value = TRY_OR_RETURN_OOM(realm(), ByteBuffer::copy(body->type->span())),
+                .value = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(body->type->span())),
             };
-            TRY_OR_RETURN_OOM(realm(), m_response->header_list()->append(move(header)));
+            TRY_OR_THROW_OOM(vm, m_response->header_list()->append(move(header)));
         }
     }
 
@@ -185,8 +188,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::redirect(JS::VM& vm, D
     auto value = parsed_url.serialize();
 
     // 7. Append (`Location`, value) to responseObject’s response’s header list.
-    auto header = TRY_OR_RETURN_OOM(realm, Infrastructure::Header::from_string_pair("Location"sv, value));
-    TRY_OR_RETURN_OOM(realm, response_object->response()->header_list()->append(move(header)));
+    auto header = TRY_OR_THROW_OOM(vm, Infrastructure::Header::from_string_pair("Location"sv, value));
+    TRY_OR_THROW_OOM(vm, response_object->response()->header_list()->append(move(header)));
 
     // 8. Return responseObject.
     return response_object;
@@ -210,7 +213,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::json(JS::VM& vm, JS::V
     // 4. Perform initialize a response given responseObject, init, and (body, "application/json").
     auto body_with_type = Infrastructure::BodyWithType {
         .body = move(body),
-        .type = TRY_OR_RETURN_OOM(realm, ByteBuffer::copy("application/json"sv.bytes()))
+        .type = TRY_OR_THROW_OOM(vm, ByteBuffer::copy("application/json"sv.bytes()))
     };
     TRY(response_object->initialize_response(init, move(body_with_type)));
 

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -7,6 +7,7 @@
 #include <AK/GenericLexer.h>
 #include <AK/StdLibExtras.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibWeb/Bindings/BlobPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/FileAPI/Blob.h>
@@ -144,7 +145,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::create(JS::Realm& realm, Optio
     ByteBuffer byte_buffer {};
     // 2. Let bytes be the result of processing blob parts given blobParts and options.
     if (blob_parts.has_value()) {
-        byte_buffer = TRY_OR_RETURN_OOM(realm, process_blob_parts(blob_parts.value(), options));
+        byte_buffer = TRY_OR_THROW_OOM(realm.vm(), process_blob_parts(blob_parts.value(), options));
     }
 
     auto type = DeprecatedString::empty();
@@ -232,7 +233,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::slice(Optional<i64> start, Opt
     // a. S refers to span consecutive bytes from this, beginning with the byte at byte-order position relativeStart.
     // b. S.size = span.
     // c. S.type = relativeContentType.
-    auto byte_buffer = TRY_OR_RETURN_OOM(realm(), m_byte_buffer.slice(relative_start, span));
+    auto byte_buffer = TRY_OR_THROW_OOM(realm().vm(), m_byte_buffer.slice(relative_start, span));
     return heap().allocate<Blob>(realm(), realm(), move(byte_buffer), move(relative_content_type));
 }
 

--- a/Userland/Libraries/LibWeb/FileAPI/File.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/File.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Time.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/FileAPI/File.h>
 
@@ -24,7 +25,7 @@ File::~File() = default;
 WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> File::create(JS::Realm& realm, Vector<BlobPart> const& file_bits, DeprecatedString const& file_name, Optional<FilePropertyBag> const& options)
 {
     // 1. Let bytes be the result of processing blob parts given fileBits and options.
-    auto bytes = TRY_OR_RETURN_OOM(realm, process_blob_parts(file_bits, options.has_value() ? static_cast<BlobPropertyBag const&>(*options) : Optional<BlobPropertyBag> {}));
+    auto bytes = TRY_OR_THROW_OOM(realm.vm(), process_blob_parts(file_bits, options.has_value() ? static_cast<BlobPropertyBag const&>(*options) : Optional<BlobPropertyBag> {}));
 
     // 2. Let n be the fileName argument to the constructor.
     //    NOTE: Underlying OS filesystems use differing conventions for file name; with constructed files, mandating UTF-16 lessens ambiquity when file names are converted to byte sequences.

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -8,6 +8,7 @@
 #include <AK/DeprecatedString.h>
 #include <AK/Utf8View.h>
 #include <AK/Vector.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/Bindings/WorkerGlobalScopePrototype.h>
 #include <LibWeb/Forward.h>
@@ -137,7 +138,7 @@ WebIDL::ExceptionOr<DeprecatedString> WorkerGlobalScope::btoa(DeprecatedString c
 
     // Otherwise, the user agent must convert data to a byte sequence whose nth byte is the eight-bit representation of the nth code point of data,
     // and then must apply forgiving-base64 encode to that byte sequence and return the result.
-    return TRY_OR_RETURN_OOM(realm(), encode_base64(byte_string.span())).to_deprecated_string();
+    return TRY_OR_THROW_OOM(vm(), encode_base64(byte_string.span())).to_deprecated_string();
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#dom-atob

--- a/Userland/Libraries/LibWeb/Infra/JSON.cpp
+++ b/Userland/Libraries/LibWeb/Infra/JSON.cpp
@@ -49,7 +49,7 @@ WebIDL::ExceptionOr<DeprecatedString> serialize_javascript_value_to_json_string(
     VERIFY(result.is_string());
 
     // 4. Return result.
-    return result.as_string().deprecated_string();
+    return TRY(result.as_string().deprecated_string());
 }
 
 // https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-json-bytes

--- a/Userland/Libraries/LibWeb/Infra/JSON.cpp
+++ b/Userland/Libraries/LibWeb/Infra/JSON.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Value.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/Infra/JSON.h>
@@ -54,14 +55,12 @@ WebIDL::ExceptionOr<DeprecatedString> serialize_javascript_value_to_json_string(
 // https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-json-bytes
 WebIDL::ExceptionOr<ByteBuffer> serialize_javascript_value_to_json_bytes(JS::VM& vm, JS::Value value)
 {
-    auto& realm = *vm.current_realm();
-
     // 1. Let string be the result of serializing a JavaScript value to a JSON string given value.
     auto string = TRY(serialize_javascript_value_to_json_string(vm, value));
 
     // 2. Return the result of running UTF-8 encode on string.
     // NOTE: LibJS strings are stored as UTF-8.
-    return TRY_OR_RETURN_OOM(realm, ByteBuffer::copy(string.bytes()));
+    return TRY_OR_THROW_OOM(vm, ByteBuffer::copy(string.bytes()));
 }
 
 }

--- a/Userland/Libraries/LibWeb/Infra/Strings.cpp
+++ b/Userland/Libraries/LibWeb/Infra/Strings.cpp
@@ -34,8 +34,8 @@ DeprecatedString strip_and_collapse_whitespace(StringView string)
 // https://infra.spec.whatwg.org/#code-unit-prefix
 bool is_code_unit_prefix(StringView potential_prefix, StringView input)
 {
-    auto potential_prefix_utf16 = utf8_to_utf16(potential_prefix);
-    auto input_utf16 = utf8_to_utf16(input);
+    auto potential_prefix_utf16 = utf8_to_utf16(potential_prefix).release_value_but_fixme_should_propagate_errors();
+    auto input_utf16 = utf8_to_utf16(input).release_value_but_fixme_should_propagate_errors();
 
     // 1. Let i be 0.
     size_t i = 0;

--- a/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <AK/Utf16View.h>
+#include <LibJS/Runtime/Completion.h>
+#include <LibJS/Runtime/Utf16String.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/SVG/SVGTextContentElement.h>
 
@@ -17,9 +19,10 @@ SVGTextContentElement::SVGTextContentElement(DOM::Document& document, DOM::Quali
 }
 
 // https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getNumberOfChars
-int SVGTextContentElement::get_number_of_chars() const
+WebIDL::ExceptionOr<int> SVGTextContentElement::get_number_of_chars() const
 {
-    return AK::utf8_to_utf16(child_text_content()).size();
+    auto chars = TRY_OR_THROW_OOM(vm(), utf8_to_utf16(child_text_content()));
+    return static_cast<int>(chars.size());
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibWeb/SVG/SVGGraphicsElement.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::SVG {
 
@@ -15,7 +16,7 @@ class SVGTextContentElement : public SVGGraphicsElement {
     WEB_PLATFORM_OBJECT(SVGTextContentElement, SVGGraphicsElement);
 
 public:
-    int get_number_of_chars() const;
+    WebIDL::ExceptionOr<int> get_number_of_chars() const;
 
 protected:
     SVGTextContentElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyTableConstructor.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyTableConstructor.cpp
@@ -35,7 +35,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> WebAssemblyTableConstructor:
     auto element_value = TRY(descriptor->get("element"));
     if (!element_value.is_string())
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::InvalidHint, element_value.to_string_without_side_effects());
-    auto& element = element_value.as_string().deprecated_string();
+    auto const& element = TRY(element_value.as_string().deprecated_string());
 
     Optional<Wasm::ValueType> reference_type;
     if (element == "anyfunc"sv)

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -95,7 +95,7 @@ static ErrorOr<JsonValue, ExecuteScriptResultType> internal_json_clone_algorithm
     if (value.is_number())
         return JsonValue { value.as_double() };
     if (value.is_string())
-        return JsonValue { value.as_string().deprecated_string() };
+        return JsonValue { TRY_OR_JS_ERROR(value.as_string().deprecated_string()) };
 
     // NOTE: BigInt and Symbol not mentioned anywhere in the WebDriver spec, as it references ES5.
     //       It assumes that all primitives are handled above, and the value is an object for the remaining steps.
@@ -114,7 +114,7 @@ static ErrorOr<JsonValue, ExecuteScriptResultType> internal_json_clone_algorithm
         auto to_json_result = TRY_OR_JS_ERROR(to_json.as_function().internal_call(value, JS::MarkedVector<JS::Value> { vm.heap() }));
         if (!to_json_result.is_string())
             return ExecuteScriptResultType::JavaScriptError;
-        return to_json_result.as_string().deprecated_string();
+        return TRY_OR_JS_ERROR(to_json_result.as_string().deprecated_string());
     }
 
     // -> Otherwise

--- a/Userland/Libraries/LibWeb/WebIDL/DOMException.h
+++ b/Userland/Libraries/LibWeb/WebIDL/DOMException.h
@@ -14,18 +14,6 @@
 
 namespace Web::WebIDL {
 
-#define TRY_OR_RETURN_OOM(realm, expression)                                \
-    ({                                                                      \
-        /* Ignore -Wshadow to allow nesting the macro. */                   \
-        AK_IGNORE_DIAGNOSTIC("-Wshadow",                                    \
-            auto _temporary_result = (expression));                         \
-        if (_temporary_result.is_error()) {                                 \
-            VERIFY(_temporary_result.error().code() == ENOMEM);             \
-            return WebIDL::UnknownError::create(realm, "Out of memory."sv); \
-        }                                                                   \
-        _temporary_result.release_value();                                  \
-    })
-
 // The following have a legacy code value but *don't* produce it as
 // DOMException.code value when used as name (and are therefore omitted here):
 // - DOMStringSizeError (DOMSTRING_SIZE_ERR = 2)

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -12,6 +12,7 @@
 #include <AK/GenericLexer.h>
 #include <AK/QuickSort.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibTextCodec/Decoder.h>
@@ -290,6 +291,8 @@ Optional<StringView> XMLHttpRequest::get_final_encoding() const
 WebIDL::ExceptionOr<void> XMLHttpRequest::set_request_header(DeprecatedString const& name_string, DeprecatedString const& value_string)
 {
     auto& realm = this->realm();
+    auto& vm = realm.vm();
+
     auto name = name_string.to_byte_buffer();
     auto value = value_string.to_byte_buffer();
 
@@ -316,11 +319,11 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::set_request_header(DeprecatedString co
     };
 
     // 5. If (name, value) is a forbidden request-header, then return.
-    if (TRY_OR_RETURN_OOM(realm, Fetch::Infrastructure::is_forbidden_request_header(header)))
+    if (TRY_OR_THROW_OOM(vm, Fetch::Infrastructure::is_forbidden_request_header(header)))
         return {};
 
     // 6. Combine (name, value) in this’s author request headers.
-    TRY_OR_RETURN_OOM(realm, m_author_request_headers->combine(move(header)));
+    TRY_OR_THROW_OOM(vm, m_author_request_headers->combine(move(header)));
 
     return {};
 }
@@ -465,12 +468,12 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
     } else if (body_with_type.has_value()) {
         TRY(body_with_type->body.source().visit(
             [&](ByteBuffer const& buffer) -> WebIDL::ExceptionOr<void> {
-                auto byte_buffer = TRY_OR_RETURN_OOM(realm, ByteBuffer::copy(buffer));
+                auto byte_buffer = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(buffer));
                 request.set_body(move(byte_buffer));
                 return {};
             },
             [&](JS::Handle<FileAPI::Blob> const& blob) -> WebIDL::ExceptionOr<void> {
-                auto byte_buffer = TRY_OR_RETURN_OOM(realm, ByteBuffer::copy(blob->bytes()));
+                auto byte_buffer = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(blob->bytes()));
                 request.set_body(move(byte_buffer));
                 return {};
             },


### PR DESCRIPTION
![Screenshot from 2023-01-07 14-22-26](https://user-images.githubusercontent.com/5600524/211168507-0a7293a8-c2c7-441c-b120-b9f39b3e5016.png)

![Screenshot from 2023-01-07 15-38-35](https://user-images.githubusercontent.com/5600524/211169536-cffeadd0-a79f-4296-84a4-78259f795305.png)


I reckon this will help with the `DeprecatedString` -> `String` conversion in LibJS, now that callers to `PrimitiveString` have to be fallible.