### PR TITLE
LibXML+LibWeb: Avoid implicit cast from StringView{}->DeprecatedString

### DIFF
--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -123,7 +123,7 @@ void XMLDocumentBuilder::element_end(const XML::Name& name)
     m_current_node = m_current_node->parent_node();
 }
 
-void XMLDocumentBuilder::text(DeprecatedString const& data)
+void XMLDocumentBuilder::text(StringView data)
 {
     if (m_has_error)
         return;
@@ -135,16 +135,22 @@ void XMLDocumentBuilder::text(DeprecatedString const& data)
         text_node.set_data(text_builder.to_deprecated_string());
         text_builder.clear();
     } else {
-        auto node = m_document.create_text_node(data);
+        auto string = DeprecatedString::empty();
+        if (!data.is_null())
+            string = data.to_deprecated_string();
+        auto node = m_document.create_text_node(string);
         MUST(m_current_node->append_child(node));
     }
 }
 
-void XMLDocumentBuilder::comment(DeprecatedString const& data)
+void XMLDocumentBuilder::comment(StringView data)
 {
     if (m_has_error)
         return;
-    MUST(m_document.append_child(m_document.create_comment(data)));
+    auto string = DeprecatedString::empty();
+    if (!data.is_null())
+        string = data.to_deprecated_string();
+    MUST(m_document.append_child(m_document.create_comment(string)));
 }
 
 void XMLDocumentBuilder::document_end()

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.h
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.h
@@ -32,8 +32,8 @@ private:
     virtual void set_source(DeprecatedString) override;
     virtual void element_start(XML::Name const& name, HashMap<XML::Name, DeprecatedString> const& attributes) override;
     virtual void element_end(XML::Name const& name) override;
-    virtual void text(DeprecatedString const& data) override;
-    virtual void comment(DeprecatedString const& data) override;
+    virtual void text(StringView data) override;
+    virtual void comment(StringView data) override;
     virtual void document_end() override;
 
     DOM::Document& m_document;

--- a/Userland/Libraries/LibXML/Parser/Parser.cpp
+++ b/Userland/Libraries/LibXML/Parser/Parser.cpp
@@ -78,7 +78,7 @@ void Parser::append_node(NonnullOwnPtr<Node> node)
     }
 }
 
-void Parser::append_text(DeprecatedString text)
+void Parser::append_text(StringView text)
 {
     if (m_listener) {
         m_listener->text(text);
@@ -111,7 +111,7 @@ void Parser::append_text(DeprecatedString text)
         });
 }
 
-void Parser::append_comment(DeprecatedString text)
+void Parser::append_comment(StringView text)
 {
     if (m_listener) {
         m_listener->comment(text);
@@ -125,7 +125,7 @@ void Parser::append_comment(DeprecatedString text)
 
     m_entered_node->content.visit(
         [&](Node::Element& node) {
-            node.children.append(make<Node>(Node::Comment { move(text) }));
+            node.children.append(make<Node>(Node::Comment { text }));
         },
         [&](auto&) {
             // Can't enter a text or comment node.

--- a/Userland/Libraries/LibXML/Parser/Parser.h
+++ b/Userland/Libraries/LibXML/Parser/Parser.h
@@ -34,8 +34,8 @@ struct Listener {
     virtual void document_end() { }
     virtual void element_start(Name const&, HashMap<Name, DeprecatedString> const&) { }
     virtual void element_end(Name const&) { }
-    virtual void text(DeprecatedString const&) { }
-    virtual void comment(DeprecatedString const&) { }
+    virtual void text(StringView) { }
+    virtual void comment(StringView) { }
     virtual void error(ParseError const&) { }
 };
 
@@ -73,8 +73,8 @@ private:
 
     ErrorOr<void, ParseError> parse_internal();
     void append_node(NonnullOwnPtr<Node>);
-    void append_text(DeprecatedString);
-    void append_comment(DeprecatedString);
+    void append_text(StringView);
+    void append_comment(StringView);
     void enter_node(Node&);
     void leave_node();
 


### PR DESCRIPTION
This produces a (truly) null DeprecatedString, which is not expected to occur by CharacterData (where this string ends up). Simply pass an "empty" DeprecatedString manually instead.