### PR TITLE
passwd: Use StringView instead of DeprecatedString

### DIFF
--- a/Userland/Utilities/passwd.cpp
+++ b/Userland/Utilities/passwd.cpp
@@ -30,8 +30,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool del = false;
     bool lock = false;
     bool unlock = false;
-    // FIXME: Replace with StringView once Core::Account::from_name stops taking a char const*.
-    DeprecatedString username {};
+    StringView username {};
 
     auto args_parser = Core::ArgsParser();
     args_parser.set_general_help("Modify an account password.");


### PR DESCRIPTION
This can now be declared as a StringView, since commit 507cb411 Core::Account::from_name() takes a StringView as a input.

This removes one FIXME.