### PR TITLE
LibJS+LibUnicode: Some more OOM handling in `String.prototype`

### DIFF
--- a/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
+++ b/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
@@ -53,306 +53,306 @@ TEST_CASE(to_unicode_uppercase)
 TEST_CASE(to_unicode_lowercase_unconditional_special_casing)
 {
     // LATIN SMALL LETTER SHARP S
-    auto result = Unicode::to_unicode_lowercase_full("\u00DF"sv);
+    auto result = MUST(Unicode::to_unicode_lowercase_full("\u00DF"sv));
     EXPECT_EQ(result, "\u00DF");
 
     // LATIN CAPITAL LETTER I WITH DOT ABOVE
-    result = Unicode::to_unicode_lowercase_full("\u0130"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u0130"sv));
     EXPECT_EQ(result, "\u0069\u0307");
 
     // LATIN SMALL LIGATURE FF
-    result = Unicode::to_unicode_lowercase_full("\uFB00"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\uFB00"sv));
     EXPECT_EQ(result, "\uFB00");
 
     // LATIN SMALL LIGATURE FI
-    result = Unicode::to_unicode_lowercase_full("\uFB01"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\uFB01"sv));
     EXPECT_EQ(result, "\uFB01");
 
     // LATIN SMALL LIGATURE FL
-    result = Unicode::to_unicode_lowercase_full("\uFB02"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\uFB02"sv));
     EXPECT_EQ(result, "\uFB02");
 
     // LATIN SMALL LIGATURE FFI
-    result = Unicode::to_unicode_lowercase_full("\uFB03"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\uFB03"sv));
     EXPECT_EQ(result, "\uFB03");
 
     // LATIN SMALL LIGATURE FFL
-    result = Unicode::to_unicode_lowercase_full("\uFB04"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\uFB04"sv));
     EXPECT_EQ(result, "\uFB04");
 
     // LATIN SMALL LIGATURE LONG S T
-    result = Unicode::to_unicode_lowercase_full("\uFB05"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\uFB05"sv));
     EXPECT_EQ(result, "\uFB05");
 
     // LATIN SMALL LIGATURE ST
-    result = Unicode::to_unicode_lowercase_full("\uFB06"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\uFB06"sv));
     EXPECT_EQ(result, "\uFB06");
 
     // GREEK SMALL LETTER ALPHA WITH PERISPOMENI AND YPOGEGRAMMENI
-    result = Unicode::to_unicode_lowercase_full("\u1FB7"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u1FB7"sv));
     EXPECT_EQ(result, "\u1FB7");
 
     // GREEK SMALL LETTER ETA WITH PERISPOMENI AND YPOGEGRAMMENI
-    result = Unicode::to_unicode_lowercase_full("\u1FC7"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u1FC7"sv));
     EXPECT_EQ(result, "\u1FC7");
 
     // GREEK SMALL LETTER OMEGA WITH PERISPOMENI AND YPOGEGRAMMENI
-    result = Unicode::to_unicode_lowercase_full("\u1FF7"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u1FF7"sv));
     EXPECT_EQ(result, "\u1FF7");
 }
 
 TEST_CASE(to_unicode_lowercase_special_casing_sigma)
 {
-    auto result = Unicode::to_unicode_lowercase_full("ABCI"sv);
+    auto result = MUST(Unicode::to_unicode_lowercase_full("ABCI"sv));
     EXPECT_EQ(result, "abci");
 
     // Sigma preceded by A
-    result = Unicode::to_unicode_lowercase_full("A\u03A3"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("A\u03A3"sv));
     EXPECT_EQ(result, "a\u03C2");
 
     // Sigma preceded by FEMININE ORDINAL INDICATOR
-    result = Unicode::to_unicode_lowercase_full("\u00AA\u03A3"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u00AA\u03A3"sv));
     EXPECT_EQ(result, "\u00AA\u03C2");
 
     // Sigma preceded by ROMAN NUMERAL ONE
-    result = Unicode::to_unicode_lowercase_full("\u2160\u03A3"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u2160\u03A3"sv));
     EXPECT_EQ(result, "\u2170\u03C2");
 
     // Sigma preceded by COMBINING GREEK YPOGEGRAMMENI
-    result = Unicode::to_unicode_lowercase_full("\u0345\u03A3"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u0345\u03A3"sv));
     EXPECT_EQ(result, "\u0345\u03C3");
 
     // Sigma preceded by A and FULL STOP
-    result = Unicode::to_unicode_lowercase_full("A.\u03A3"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("A.\u03A3"sv));
     EXPECT_EQ(result, "a.\u03C2");
 
     // Sigma preceded by A and MONGOLIAN VOWEL SEPARATOR
-    result = Unicode::to_unicode_lowercase_full("A\u180E\u03A3"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("A\u180E\u03A3"sv));
     EXPECT_EQ(result, "a\u180E\u03C2");
 
     // Sigma preceded by A and MONGOLIAN VOWEL SEPARATOR, followed by B
-    result = Unicode::to_unicode_lowercase_full("A\u180E\u03A3B"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("A\u180E\u03A3B"sv));
     EXPECT_EQ(result, "a\u180E\u03C3b");
 
     // Sigma followed by A
-    result = Unicode::to_unicode_lowercase_full("\u03A3A"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u03A3A"sv));
     EXPECT_EQ(result, "\u03C3a");
 
     // Sigma preceded by A, followed by MONGOLIAN VOWEL SEPARATOR
-    result = Unicode::to_unicode_lowercase_full("A\u03A3\u180E"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("A\u03A3\u180E"sv));
     EXPECT_EQ(result, "a\u03C2\u180E");
 
     // Sigma preceded by A, followed by MONGOLIAN VOWEL SEPARATOR and B
-    result = Unicode::to_unicode_lowercase_full("A\u03A3\u180EB"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("A\u03A3\u180EB"sv));
     EXPECT_EQ(result, "a\u03C3\u180Eb");
 
     // Sigma preceded by A and MONGOLIAN VOWEL SEPARATOR, followed by MONGOLIAN VOWEL SEPARATOR
-    result = Unicode::to_unicode_lowercase_full("A\u180E\u03A3\u180E"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("A\u180E\u03A3\u180E"sv));
     EXPECT_EQ(result, "a\u180E\u03C2\u180E");
 
     // Sigma preceded by A and MONGOLIAN VOWEL SEPARATOR, followed by MONGOLIAN VOWEL SEPARATOR and B
-    result = Unicode::to_unicode_lowercase_full("A\u180E\u03A3\u180EB"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("A\u180E\u03A3\u180EB"sv));
     EXPECT_EQ(result, "a\u180E\u03C3\u180Eb");
 }
 
 TEST_CASE(to_unicode_lowercase_special_casing_i)
 {
     // LATIN CAPITAL LETTER I
-    auto result = Unicode::to_unicode_lowercase_full("I"sv, "en"sv);
+    auto result = MUST(Unicode::to_unicode_lowercase_full("I"sv, "en"sv));
     EXPECT_EQ(result, "i"sv);
 
-    result = Unicode::to_unicode_lowercase_full("I"sv, "az"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I"sv, "az"sv));
     EXPECT_EQ(result, "\u0131"sv);
 
-    result = Unicode::to_unicode_lowercase_full("I"sv, "tr"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I"sv, "tr"sv));
     EXPECT_EQ(result, "\u0131"sv);
 
     // LATIN CAPITAL LETTER I WITH DOT ABOVE
-    result = Unicode::to_unicode_lowercase_full("\u0130"sv, "en"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u0130"sv, "en"sv));
     EXPECT_EQ(result, "\u0069\u0307"sv);
 
-    result = Unicode::to_unicode_lowercase_full("\u0130"sv, "az"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u0130"sv, "az"sv));
     EXPECT_EQ(result, "i"sv);
 
-    result = Unicode::to_unicode_lowercase_full("\u0130"sv, "tr"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u0130"sv, "tr"sv));
     EXPECT_EQ(result, "i"sv);
 
     // LATIN CAPITAL LETTER I followed by COMBINING DOT ABOVE
-    result = Unicode::to_unicode_lowercase_full("I\u0307"sv, "en"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I\u0307"sv, "en"sv));
     EXPECT_EQ(result, "i\u0307"sv);
 
-    result = Unicode::to_unicode_lowercase_full("I\u0307"sv, "az"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I\u0307"sv, "az"sv));
     EXPECT_EQ(result, "i"sv);
 
-    result = Unicode::to_unicode_lowercase_full("I\u0307"sv, "tr"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I\u0307"sv, "tr"sv));
     EXPECT_EQ(result, "i"sv);
 
     // LATIN CAPITAL LETTER I followed by combining class 0 and COMBINING DOT ABOVE
-    result = Unicode::to_unicode_lowercase_full("IA\u0307"sv, "en"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("IA\u0307"sv, "en"sv));
     EXPECT_EQ(result, "ia\u0307"sv);
 
-    result = Unicode::to_unicode_lowercase_full("IA\u0307"sv, "az"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("IA\u0307"sv, "az"sv));
     EXPECT_EQ(result, "\u0131a\u0307"sv);
 
-    result = Unicode::to_unicode_lowercase_full("IA\u0307"sv, "tr"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("IA\u0307"sv, "tr"sv));
     EXPECT_EQ(result, "\u0131a\u0307"sv);
 }
 
 TEST_CASE(to_unicode_lowercase_special_casing_more_above)
 {
     // LATIN CAPITAL LETTER I
-    auto result = Unicode::to_unicode_lowercase_full("I"sv, "en"sv);
+    auto result = MUST(Unicode::to_unicode_lowercase_full("I"sv, "en"sv));
     EXPECT_EQ(result, "i"sv);
 
-    result = Unicode::to_unicode_lowercase_full("I"sv, "lt"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I"sv, "lt"sv));
     EXPECT_EQ(result, "i"sv);
 
     // LATIN CAPITAL LETTER J
-    result = Unicode::to_unicode_lowercase_full("J"sv, "en"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("J"sv, "en"sv));
     EXPECT_EQ(result, "j"sv);
 
-    result = Unicode::to_unicode_lowercase_full("J"sv, "lt"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("J"sv, "lt"sv));
     EXPECT_EQ(result, "j"sv);
 
     // LATIN CAPITAL LETTER I WITH OGONEK
-    result = Unicode::to_unicode_lowercase_full("\u012e"sv, "en"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u012e"sv, "en"sv));
     EXPECT_EQ(result, "\u012f"sv);
 
-    result = Unicode::to_unicode_lowercase_full("\u012e"sv, "lt"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u012e"sv, "lt"sv));
     EXPECT_EQ(result, "\u012f"sv);
 
     // LATIN CAPITAL LETTER I followed by COMBINING GRAVE ACCENT
-    result = Unicode::to_unicode_lowercase_full("I\u0300"sv, "en"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I\u0300"sv, "en"sv));
     EXPECT_EQ(result, "i\u0300"sv);
 
-    result = Unicode::to_unicode_lowercase_full("I\u0300"sv, "lt"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I\u0300"sv, "lt"sv));
     EXPECT_EQ(result, "i\u0307\u0300"sv);
 
     // LATIN CAPITAL LETTER J followed by COMBINING GRAVE ACCENT
-    result = Unicode::to_unicode_lowercase_full("J\u0300"sv, "en"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("J\u0300"sv, "en"sv));
     EXPECT_EQ(result, "j\u0300"sv);
 
-    result = Unicode::to_unicode_lowercase_full("J\u0300"sv, "lt"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("J\u0300"sv, "lt"sv));
     EXPECT_EQ(result, "j\u0307\u0300"sv);
 
     // LATIN CAPITAL LETTER I WITH OGONEK followed by COMBINING GRAVE ACCENT
-    result = Unicode::to_unicode_lowercase_full("\u012e\u0300"sv, "en"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u012e\u0300"sv, "en"sv));
     EXPECT_EQ(result, "\u012f\u0300"sv);
 
-    result = Unicode::to_unicode_lowercase_full("\u012e\u0300"sv, "lt"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("\u012e\u0300"sv, "lt"sv));
     EXPECT_EQ(result, "\u012f\u0307\u0300"sv);
 }
 
 TEST_CASE(to_unicode_lowercase_special_casing_not_before_dot)
 {
     // LATIN CAPITAL LETTER I
-    auto result = Unicode::to_unicode_lowercase_full("I"sv, "en"sv);
+    auto result = MUST(Unicode::to_unicode_lowercase_full("I"sv, "en"sv));
     EXPECT_EQ(result, "i"sv);
 
-    result = Unicode::to_unicode_lowercase_full("I"sv, "az"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I"sv, "az"sv));
     EXPECT_EQ(result, "\u0131"sv);
 
-    result = Unicode::to_unicode_lowercase_full("I"sv, "tr"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I"sv, "tr"sv));
     EXPECT_EQ(result, "\u0131"sv);
 
     // LATIN CAPITAL LETTER I followed by COMBINING DOT ABOVE
-    result = Unicode::to_unicode_lowercase_full("I\u0307"sv, "en"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I\u0307"sv, "en"sv));
     EXPECT_EQ(result, "i\u0307"sv);
 
-    result = Unicode::to_unicode_lowercase_full("I\u0307"sv, "az"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I\u0307"sv, "az"sv));
     EXPECT_EQ(result, "i"sv);
 
-    result = Unicode::to_unicode_lowercase_full("I\u0307"sv, "tr"sv);
+    result = MUST(Unicode::to_unicode_lowercase_full("I\u0307"sv, "tr"sv));
     EXPECT_EQ(result, "i"sv);
 }
 
 TEST_CASE(to_unicode_uppercase_unconditional_special_casing)
 {
     // LATIN SMALL LETTER SHARP S
-    auto result = Unicode::to_unicode_uppercase_full("\u00DF"sv);
+    auto result = MUST(Unicode::to_unicode_uppercase_full("\u00DF"sv));
     EXPECT_EQ(result, "\u0053\u0053");
 
     // LATIN CAPITAL LETTER I WITH DOT ABOVE
-    result = Unicode::to_unicode_uppercase_full("\u0130"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\u0130"sv));
     EXPECT_EQ(result, "\u0130");
 
     // LATIN SMALL LIGATURE FF
-    result = Unicode::to_unicode_uppercase_full("\uFB00"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\uFB00"sv));
     EXPECT_EQ(result, "\u0046\u0046");
 
     // LATIN SMALL LIGATURE FI
-    result = Unicode::to_unicode_uppercase_full("\uFB01"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\uFB01"sv));
     EXPECT_EQ(result, "\u0046\u0049");
 
     // LATIN SMALL LIGATURE FL
-    result = Unicode::to_unicode_uppercase_full("\uFB02"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\uFB02"sv));
     EXPECT_EQ(result, "\u0046\u004C");
 
     // LATIN SMALL LIGATURE FFI
-    result = Unicode::to_unicode_uppercase_full("\uFB03"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\uFB03"sv));
     EXPECT_EQ(result, "\u0046\u0046\u0049");
 
     // LATIN SMALL LIGATURE FFL
-    result = Unicode::to_unicode_uppercase_full("\uFB04"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\uFB04"sv));
     EXPECT_EQ(result, "\u0046\u0046\u004C");
 
     // LATIN SMALL LIGATURE LONG S T
-    result = Unicode::to_unicode_uppercase_full("\uFB05"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\uFB05"sv));
     EXPECT_EQ(result, "\u0053\u0054");
 
     // LATIN SMALL LIGATURE ST
-    result = Unicode::to_unicode_uppercase_full("\uFB06"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\uFB06"sv));
     EXPECT_EQ(result, "\u0053\u0054");
 
     // GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS
-    result = Unicode::to_unicode_uppercase_full("\u0390"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\u0390"sv));
     EXPECT_EQ(result, "\u0399\u0308\u0301");
 
     // GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS
-    result = Unicode::to_unicode_uppercase_full("\u03B0"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\u03B0"sv));
     EXPECT_EQ(result, "\u03A5\u0308\u0301");
 
     // GREEK SMALL LETTER ALPHA WITH PERISPOMENI AND YPOGEGRAMMENI
-    result = Unicode::to_unicode_uppercase_full("\u1FB7"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\u1FB7"sv));
     EXPECT_EQ(result, "\u0391\u0342\u0399");
 
     // GREEK SMALL LETTER ETA WITH PERISPOMENI AND YPOGEGRAMMENI
-    result = Unicode::to_unicode_uppercase_full("\u1FC7"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\u1FC7"sv));
     EXPECT_EQ(result, "\u0397\u0342\u0399");
 
     // GREEK SMALL LETTER OMEGA WITH PERISPOMENI AND YPOGEGRAMMENI
-    result = Unicode::to_unicode_uppercase_full("\u1FF7"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("\u1FF7"sv));
     EXPECT_EQ(result, "\u03A9\u0342\u0399");
 }
 
 TEST_CASE(to_unicode_uppercase_special_casing_soft_dotted)
 {
     // LATIN SMALL LETTER I
-    auto result = Unicode::to_unicode_uppercase_full("i"sv, "en"sv);
+    auto result = MUST(Unicode::to_unicode_uppercase_full("i"sv, "en"sv));
     EXPECT_EQ(result, "I"sv);
 
-    result = Unicode::to_unicode_uppercase_full("i"sv, "lt"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("i"sv, "lt"sv));
     EXPECT_EQ(result, "I"sv);
 
     // LATIN SMALL LETTER J
-    result = Unicode::to_unicode_uppercase_full("j"sv, "en"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("j"sv, "en"sv));
     EXPECT_EQ(result, "J"sv);
 
-    result = Unicode::to_unicode_uppercase_full("j"sv, "lt"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("j"sv, "lt"sv));
     EXPECT_EQ(result, "J"sv);
 
     // LATIN SMALL LETTER I followed by COMBINING DOT ABOVE
-    result = Unicode::to_unicode_uppercase_full("i\u0307"sv, "en"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("i\u0307"sv, "en"sv));
     EXPECT_EQ(result, "I\u0307"sv);
 
-    result = Unicode::to_unicode_uppercase_full("i\u0307"sv, "lt"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("i\u0307"sv, "lt"sv));
     EXPECT_EQ(result, "I"sv);
 
     // LATIN SMALL LETTER J followed by COMBINING DOT ABOVE
-    result = Unicode::to_unicode_uppercase_full("j\u0307"sv, "en"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("j\u0307"sv, "en"sv));
     EXPECT_EQ(result, "J\u0307"sv);
 
-    result = Unicode::to_unicode_uppercase_full("j\u0307"sv, "lt"sv);
+    result = MUST(Unicode::to_unicode_uppercase_full("j\u0307"sv, "lt"sv));
     EXPECT_EQ(result, "J"sv);
 }
 

--- a/Tests/LibUnicode/TestUnicodeNormalization.cpp
+++ b/Tests/LibUnicode/TestUnicodeNormalization.cpp
@@ -12,84 +12,84 @@ using namespace Unicode;
 
 TEST_CASE(normalize_nfd)
 {
-    EXPECT_EQ(normalize(""sv, NormalizationForm::NFD), ""sv);
+    EXPECT_EQ(MUST(normalize(""sv, NormalizationForm::NFD)), ""sv);
 
-    EXPECT_EQ(normalize("Hello"sv, NormalizationForm::NFD), "Hello"sv);
+    EXPECT_EQ(MUST(normalize("Hello"sv, NormalizationForm::NFD)), "Hello"sv);
 
-    EXPECT_EQ(normalize("Amélie"sv, NormalizationForm::NFD), "Ame\u0301lie"sv);
+    EXPECT_EQ(MUST(normalize("Amélie"sv, NormalizationForm::NFD)), "Ame\u0301lie"sv);
 
-    EXPECT_EQ(normalize("Oﬀice"sv, NormalizationForm::NFD), "Oﬀice"sv);
+    EXPECT_EQ(MUST(normalize("Oﬀice"sv, NormalizationForm::NFD)), "Oﬀice"sv);
 
-    EXPECT_EQ(normalize("\u1E9B\u0323"sv, NormalizationForm::NFD), "\u017F\u0323\u0307"sv);
+    EXPECT_EQ(MUST(normalize("\u1E9B\u0323"sv, NormalizationForm::NFD)), "\u017F\u0323\u0307"sv);
 
-    EXPECT_EQ(normalize("\u0112\u0300"sv, NormalizationForm::NFD), "\u0045\u0304\u0300"sv);
+    EXPECT_EQ(MUST(normalize("\u0112\u0300"sv, NormalizationForm::NFD)), "\u0045\u0304\u0300"sv);
 
-    EXPECT_EQ(normalize("\u03D3"sv, NormalizationForm::NFD), "\u03D2\u0301"sv);
-    EXPECT_EQ(normalize("\u03D4"sv, NormalizationForm::NFD), "\u03D2\u0308"sv);
+    EXPECT_EQ(MUST(normalize("\u03D3"sv, NormalizationForm::NFD)), "\u03D2\u0301"sv);
+    EXPECT_EQ(MUST(normalize("\u03D4"sv, NormalizationForm::NFD)), "\u03D2\u0308"sv);
 
-    EXPECT_EQ(normalize("닭"sv, NormalizationForm::NFD), "\u1103\u1161\u11B0"sv);
-    EXPECT_EQ(normalize("\u1100\uAC00\u11A8"sv, NormalizationForm::NFD), "\u1100\u1100\u1161\u11A8"sv);
+    EXPECT_EQ(MUST(normalize("닭"sv, NormalizationForm::NFD)), "\u1103\u1161\u11B0"sv);
+    EXPECT_EQ(MUST(normalize("\u1100\uAC00\u11A8"sv, NormalizationForm::NFD)), "\u1100\u1100\u1161\u11A8"sv);
 
     // Composition exclusions.
-    EXPECT_EQ(normalize("\u0958"sv, NormalizationForm::NFD), "\u0915\u093C"sv);
-    EXPECT_EQ(normalize("\u2126"sv, NormalizationForm::NFD), "\u03A9"sv);
+    EXPECT_EQ(MUST(normalize("\u0958"sv, NormalizationForm::NFD)), "\u0915\u093C"sv);
+    EXPECT_EQ(MUST(normalize("\u2126"sv, NormalizationForm::NFD)), "\u03A9"sv);
 }
 
 TEST_CASE(normalize_nfc)
 {
-    EXPECT_EQ(normalize(""sv, NormalizationForm::NFC), ""sv);
+    EXPECT_EQ(MUST(normalize(""sv, NormalizationForm::NFC)), ""sv);
 
-    EXPECT_EQ(normalize("Hello"sv, NormalizationForm::NFC), "Hello"sv);
+    EXPECT_EQ(MUST(normalize("Hello"sv, NormalizationForm::NFC)), "Hello"sv);
 
-    EXPECT_EQ(normalize("Office"sv, NormalizationForm::NFC), "Office"sv);
+    EXPECT_EQ(MUST(normalize("Office"sv, NormalizationForm::NFC)), "Office"sv);
 
-    EXPECT_EQ(normalize("\u1E9B\u0323"sv, NormalizationForm::NFC), "\u1E9B\u0323"sv);
-    EXPECT_EQ(normalize("\u0044\u0307"sv, NormalizationForm::NFC), "\u1E0A"sv);
+    EXPECT_EQ(MUST(normalize("\u1E9B\u0323"sv, NormalizationForm::NFC)), "\u1E9B\u0323"sv);
+    EXPECT_EQ(MUST(normalize("\u0044\u0307"sv, NormalizationForm::NFC)), "\u1E0A"sv);
 
-    EXPECT_EQ(normalize("\u0044\u0307\u0323"sv, NormalizationForm::NFC), "\u1E0C\u0307"sv);
-    EXPECT_EQ(normalize("\u0044\u0323\u0307"sv, NormalizationForm::NFC), "\u1E0C\u0307"sv);
+    EXPECT_EQ(MUST(normalize("\u0044\u0307\u0323"sv, NormalizationForm::NFC)), "\u1E0C\u0307"sv);
+    EXPECT_EQ(MUST(normalize("\u0044\u0323\u0307"sv, NormalizationForm::NFC)), "\u1E0C\u0307"sv);
 
-    EXPECT_EQ(normalize("\u0112\u0300"sv, NormalizationForm::NFC), "\u1E14"sv);
-    EXPECT_EQ(normalize("\u1E14\u0304"sv, NormalizationForm::NFC), "\u1E14\u0304"sv);
+    EXPECT_EQ(MUST(normalize("\u0112\u0300"sv, NormalizationForm::NFC)), "\u1E14"sv);
+    EXPECT_EQ(MUST(normalize("\u1E14\u0304"sv, NormalizationForm::NFC)), "\u1E14\u0304"sv);
 
-    EXPECT_EQ(normalize("\u05B8\u05B9\u05B1\u0591\u05C3\u05B0\u05AC\u059F"sv, NormalizationForm::NFC), "\u05B1\u05B8\u05B9\u0591\u05C3\u05B0\u05AC\u059F"sv);
-    EXPECT_EQ(normalize("\u0592\u05B7\u05BC\u05A5\u05B0\u05C0\u05C4\u05AD"sv, NormalizationForm::NFC), "\u05B0\u05B7\u05BC\u05A5\u0592\u05C0\u05AD\u05C4"sv);
+    EXPECT_EQ(MUST(normalize("\u05B8\u05B9\u05B1\u0591\u05C3\u05B0\u05AC\u059F"sv, NormalizationForm::NFC)), "\u05B1\u05B8\u05B9\u0591\u05C3\u05B0\u05AC\u059F"sv);
+    EXPECT_EQ(MUST(normalize("\u0592\u05B7\u05BC\u05A5\u05B0\u05C0\u05C4\u05AD"sv, NormalizationForm::NFC)), "\u05B0\u05B7\u05BC\u05A5\u0592\u05C0\u05AD\u05C4"sv);
 
-    EXPECT_EQ(normalize("\u03D3"sv, NormalizationForm::NFC), "\u03D3"sv);
-    EXPECT_EQ(normalize("\u03D4"sv, NormalizationForm::NFC), "\u03D4"sv);
+    EXPECT_EQ(MUST(normalize("\u03D3"sv, NormalizationForm::NFC)), "\u03D3"sv);
+    EXPECT_EQ(MUST(normalize("\u03D4"sv, NormalizationForm::NFC)), "\u03D4"sv);
 
-    EXPECT_EQ(normalize("\u0958"sv, NormalizationForm::NFC), "\u0915\u093C"sv);
-    EXPECT_EQ(normalize("\u2126"sv, NormalizationForm::NFC), "\u03A9"sv);
+    EXPECT_EQ(MUST(normalize("\u0958"sv, NormalizationForm::NFC)), "\u0915\u093C"sv);
+    EXPECT_EQ(MUST(normalize("\u2126"sv, NormalizationForm::NFC)), "\u03A9"sv);
 
-    EXPECT_EQ(normalize("\u1103\u1161\u11B0"sv, NormalizationForm::NFC), "닭"sv);
-    EXPECT_EQ(normalize("\u1100\uAC00\u11A8"sv, NormalizationForm::NFC), "\u1100\uAC01"sv);
-    EXPECT_EQ(normalize("\u1103\u1161\u11B0\u11B0"sv, NormalizationForm::NFC), "닭\u11B0");
+    EXPECT_EQ(MUST(normalize("\u1103\u1161\u11B0"sv, NormalizationForm::NFC)), "닭"sv);
+    EXPECT_EQ(MUST(normalize("\u1100\uAC00\u11A8"sv, NormalizationForm::NFC)), "\u1100\uAC01"sv);
+    EXPECT_EQ(MUST(normalize("\u1103\u1161\u11B0\u11B0"sv, NormalizationForm::NFC)), "닭\u11B0");
 }
 
 TEST_CASE(normalize_nfkd)
 {
-    EXPECT_EQ(normalize(""sv, NormalizationForm::NFKD), ""sv);
+    EXPECT_EQ(MUST(normalize(""sv, NormalizationForm::NFKD)), ""sv);
 
-    EXPECT_EQ(normalize("Oﬀice"sv, NormalizationForm::NFKD), "Office"sv);
+    EXPECT_EQ(MUST(normalize("Oﬀice"sv, NormalizationForm::NFKD)), "Office"sv);
 
-    EXPECT_EQ(normalize("¼"sv, NormalizationForm::NFKD), "1\u20444"sv);
+    EXPECT_EQ(MUST(normalize("¼"sv, NormalizationForm::NFKD)), "1\u20444"sv);
 
-    EXPECT_EQ(normalize("\u03D3"sv, NormalizationForm::NFKD), "\u03A5\u0301"sv);
-    EXPECT_EQ(normalize("\u03D4"sv, NormalizationForm::NFKD), "\u03A5\u0308"sv);
+    EXPECT_EQ(MUST(normalize("\u03D3"sv, NormalizationForm::NFKD)), "\u03A5\u0301"sv);
+    EXPECT_EQ(MUST(normalize("\u03D4"sv, NormalizationForm::NFKD)), "\u03A5\u0308"sv);
 
-    EXPECT_EQ(normalize("\u0958"sv, NormalizationForm::NFKD), "\u0915\u093C"sv);
-    EXPECT_EQ(normalize("\u2126"sv, NormalizationForm::NFKD), "\u03A9"sv);
+    EXPECT_EQ(MUST(normalize("\u0958"sv, NormalizationForm::NFKD)), "\u0915\u093C"sv);
+    EXPECT_EQ(MUST(normalize("\u2126"sv, NormalizationForm::NFKD)), "\u03A9"sv);
 
-    EXPECT_EQ(normalize("\uFDFA"sv, NormalizationForm::NFKD), "\u0635\u0644\u0649\u0020\u0627\u0644\u0644\u0647\u0020\u0639\u0644\u064A\u0647\u0020\u0648\u0633\u0644\u0645"sv);
+    EXPECT_EQ(MUST(normalize("\uFDFA"sv, NormalizationForm::NFKD)), "\u0635\u0644\u0649\u0020\u0627\u0644\u0644\u0647\u0020\u0639\u0644\u064A\u0647\u0020\u0648\u0633\u0644\u0645"sv);
 }
 
 TEST_CASE(normalize_nfkc)
 {
-    EXPECT_EQ(normalize(""sv, NormalizationForm::NFKC), ""sv);
+    EXPECT_EQ(MUST(normalize(""sv, NormalizationForm::NFKC)), ""sv);
 
-    EXPECT_EQ(normalize("\u03D3"sv, NormalizationForm::NFKC), "\u038E"sv);
-    EXPECT_EQ(normalize("\u03D4"sv, NormalizationForm::NFKC), "\u03AB"sv);
+    EXPECT_EQ(MUST(normalize("\u03D3"sv, NormalizationForm::NFKC)), "\u038E"sv);
+    EXPECT_EQ(MUST(normalize("\u03D4"sv, NormalizationForm::NFKC)), "\u03AB"sv);
 
-    EXPECT_EQ(normalize("\u0958"sv, NormalizationForm::NFKC), "\u0915\u093C"sv);
-    EXPECT_EQ(normalize("\u2126"sv, NormalizationForm::NFKC), "\u03A9"sv);
+    EXPECT_EQ(MUST(normalize("\u0958"sv, NormalizationForm::NFKC)), "\u0915\u093C"sv);
+    EXPECT_EQ(MUST(normalize("\u2126"sv, NormalizationForm::NFKC)), "\u03A9"sv);
 }

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -1239,27 +1239,27 @@ ThrowCompletionOr<DeprecatedString> get_substitution(VM& vm, Utf16View const& ma
         u16 curr = replace_view.code_unit_at(i);
 
         if ((curr != '$') || (i + 1 >= replace_view.length_in_code_units())) {
-            result.append(curr);
+            TRY_OR_THROW_OOM(vm, result.try_append(curr));
             continue;
         }
 
         u16 next = replace_view.code_unit_at(i + 1);
 
         if (next == '$') {
-            result.append('$');
+            TRY_OR_THROW_OOM(vm, result.try_append('$'));
             ++i;
         } else if (next == '&') {
-            result.append(matched.data(), matched.length_in_code_units());
+            TRY_OR_THROW_OOM(vm, result.try_append(matched.data(), matched.length_in_code_units()));
             ++i;
         } else if (next == '`') {
             auto substring = str.substring_view(0, position);
-            result.append(substring.data(), substring.length_in_code_units());
+            TRY_OR_THROW_OOM(vm, result.try_append(substring.data(), substring.length_in_code_units()));
             ++i;
         } else if (next == '\'') {
             auto tail_pos = position + matched.length_in_code_units();
             if (tail_pos < str.length_in_code_units()) {
                 auto substring = str.substring_view(tail_pos);
-                result.append(substring.data(), substring.length_in_code_units());
+                TRY_OR_THROW_OOM(vm, result.try_append(substring.data(), substring.length_in_code_units()));
             }
             ++i;
         } else if (is_ascii_digit(next)) {
@@ -1273,12 +1273,12 @@ ThrowCompletionOr<DeprecatedString> get_substitution(VM& vm, Utf16View const& ma
 
                 if (!value.is_undefined()) {
                     auto value_string = TRY(value.to_utf16_string(vm));
-                    result.append(value_string.view().data(), value_string.length_in_code_units());
+                    TRY_OR_THROW_OOM(vm, result.try_append(value_string.view().data(), value_string.length_in_code_units()));
                 }
 
                 i += is_two_digits ? 2 : 1;
             } else {
-                result.append(curr);
+                TRY_OR_THROW_OOM(vm, result.try_append(curr));
             }
         } else if (next == '<') {
             auto start_position = i + 2;
@@ -1292,7 +1292,7 @@ ThrowCompletionOr<DeprecatedString> get_substitution(VM& vm, Utf16View const& ma
             }
 
             if (named_captures.is_undefined() || !end_position.has_value()) {
-                result.append(curr);
+                TRY_OR_THROW_OOM(vm, result.try_append(curr));
             } else {
                 auto group_name_view = replace_view.substring_view(start_position, *end_position - start_position);
                 auto group_name = TRY_OR_THROW_OOM(vm, group_name_view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes));
@@ -1301,13 +1301,13 @@ ThrowCompletionOr<DeprecatedString> get_substitution(VM& vm, Utf16View const& ma
 
                 if (!capture.is_undefined()) {
                     auto capture_string = TRY(capture.to_utf16_string(vm));
-                    result.append(capture_string.view().data(), capture_string.length_in_code_units());
+                    TRY_OR_THROW_OOM(vm, result.try_append(capture_string.view().data(), capture_string.length_in_code_units()));
                 }
 
                 i = *end_position;
             }
         } else {
-            result.append(curr);
+            TRY_OR_THROW_OOM(vm, result.try_append(curr));
         }
     }
 

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -916,13 +916,13 @@ static ThrowCompletionOr<DeprecatedString> transform_case(VM& vm, StringView str
     // 9. If targetCase is lower, then
     case TargetCase::Lower:
         // a. Let newCodePoints be a List whose elements are the result of a lowercase transformation of codePoints according to an implementation-derived algorithm using locale or the Unicode Default Case Conversion algorithm.
-        new_code_points = Unicode::to_unicode_lowercase_full(string, *locale);
+        new_code_points = TRY_OR_THROW_OOM(vm, Unicode::to_unicode_lowercase_full(string, *locale));
         break;
     // 10. Else,
     case TargetCase::Upper:
         // a. Assert: targetCase is upper.
         // b. Let newCodePoints be a List whose elements are the result of an uppercase transformation of codePoints according to an implementation-derived algorithm using locale or the Unicode Default Case Conversion algorithm.
-        new_code_points = Unicode::to_unicode_uppercase_full(string, *locale);
+        new_code_points = TRY_OR_THROW_OOM(vm, Unicode::to_unicode_uppercase_full(string, *locale));
         break;
     default:
         VERIFY_NOT_REACHED();
@@ -964,7 +964,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::to_locale_uppercase)
 JS_DEFINE_NATIVE_FUNCTION(StringPrototype::to_lowercase)
 {
     auto string = TRY(ak_string_from(vm));
-    auto lowercase = Unicode::to_unicode_lowercase_full(string);
+    auto lowercase = TRY_OR_THROW_OOM(vm, Unicode::to_unicode_lowercase_full(string));
     return PrimitiveString::create(vm, move(lowercase));
 }
 
@@ -978,7 +978,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::to_string)
 JS_DEFINE_NATIVE_FUNCTION(StringPrototype::to_uppercase)
 {
     auto string = TRY(ak_string_from(vm));
-    auto uppercase = Unicode::to_unicode_uppercase_full(string);
+    auto uppercase = TRY_OR_THROW_OOM(vm, Unicode::to_unicode_uppercase_full(string));
     return PrimitiveString::create(vm, move(uppercase));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -499,7 +499,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::normalize)
 
     // 6. Let ns be the String value that is the result of normalizing S into the normalization form named by f as specified in https://unicode.org/reports/tr15/.
     auto unicode_form = Unicode::normalization_form_from_string(form);
-    auto ns = Unicode::normalize(string, unicode_form);
+    auto ns = TRY_OR_THROW_OOM(vm, Unicode::normalize(string, unicode_form));
 
     // 7. return ns.
     return PrimitiveString::create(vm, move(ns));

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -663,7 +663,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace_all)
     auto position = string_index_of(string.view(), search_string.view(), 0);
 
     while (position.has_value()) {
-        match_positions.append(*position);
+        TRY_OR_THROW_OOM(vm, match_positions.try_append(*position));
         position = string_index_of(string.view(), search_string.view(), *position + advance_by);
     }
 

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -221,7 +221,7 @@ u32 __attribute__((weak)) to_unicode_uppercase(u32 code_point)
     return to_ascii_uppercase(code_point);
 }
 
-DeprecatedString to_unicode_lowercase_full(StringView string, [[maybe_unused]] Optional<StringView> locale)
+ErrorOr<DeprecatedString> to_unicode_lowercase_full(StringView string, [[maybe_unused]] Optional<StringView> locale)
 {
 #if ENABLE_UNICODE_DATA
     Utf8View view { string };
@@ -236,12 +236,12 @@ DeprecatedString to_unicode_lowercase_full(StringView string, [[maybe_unused]] O
 
         auto const* special_casing = find_matching_special_case(code_point, view, locale, index, byte_length);
         if (!special_casing) {
-            builder.append_code_point(to_unicode_lowercase(code_point));
+            TRY(builder.try_append_code_point(to_unicode_lowercase(code_point)));
             continue;
         }
 
         for (size_t i = 0; i < special_casing->lowercase_mapping_size; ++i)
-            builder.append_code_point(special_casing->lowercase_mapping[i]);
+            TRY(builder.try_append_code_point(special_casing->lowercase_mapping[i]));
     }
 
     return builder.build();
@@ -250,7 +250,7 @@ DeprecatedString to_unicode_lowercase_full(StringView string, [[maybe_unused]] O
 #endif
 }
 
-DeprecatedString to_unicode_uppercase_full(StringView string, [[maybe_unused]] Optional<StringView> locale)
+ErrorOr<DeprecatedString> to_unicode_uppercase_full(StringView string, [[maybe_unused]] Optional<StringView> locale)
 {
 #if ENABLE_UNICODE_DATA
     Utf8View view { string };
@@ -265,12 +265,12 @@ DeprecatedString to_unicode_uppercase_full(StringView string, [[maybe_unused]] O
 
         auto const* special_casing = find_matching_special_case(code_point, view, locale, index, byte_length);
         if (!special_casing) {
-            builder.append_code_point(to_unicode_uppercase(code_point));
+            TRY(builder.try_append_code_point(to_unicode_uppercase(code_point)));
             continue;
         }
 
         for (size_t i = 0; i < special_casing->uppercase_mapping_size; ++i)
-            builder.append_code_point(special_casing->uppercase_mapping[i]);
+            TRY(builder.try_append_code_point(special_casing->uppercase_mapping[i]));
     }
 
     return builder.build();

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -39,8 +39,8 @@ Span<SpecialCasing const* const> special_case_mapping(u32 code_point);
 u32 to_unicode_lowercase(u32 code_point);
 u32 to_unicode_uppercase(u32 code_point);
 
-DeprecatedString to_unicode_lowercase_full(StringView, Optional<StringView> locale = {});
-DeprecatedString to_unicode_uppercase_full(StringView, Optional<StringView> locale = {});
+ErrorOr<DeprecatedString> to_unicode_lowercase_full(StringView, Optional<StringView> locale = {});
+ErrorOr<DeprecatedString> to_unicode_uppercase_full(StringView, Optional<StringView> locale = {});
 
 Optional<GeneralCategory> general_category_from_string(StringView);
 bool code_point_has_general_category(u32 code_point, GeneralCategory general_category);

--- a/Userland/Libraries/LibUnicode/Normalize.h
+++ b/Userland/Libraries/LibUnicode/Normalize.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <AK/Error.h>
 #include <AK/Forward.h>
 #include <AK/Optional.h>
 #include <AK/Span.h>
@@ -28,6 +29,6 @@ enum class NormalizationForm {
 NormalizationForm normalization_form_from_string(StringView form);
 StringView normalization_form_to_string(NormalizationForm form);
 
-[[nodiscard]] DeprecatedString normalize(StringView string, NormalizationForm form);
+ErrorOr<DeprecatedString> normalize(StringView string, NormalizationForm form);
 
 }

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -32,7 +32,7 @@ static bool is_all_whitespace(StringView string)
     return true;
 }
 
-static DeprecatedString apply_text_transform(DeprecatedString const& string, CSS::TextTransform text_transform)
+static ErrorOr<DeprecatedString> apply_text_transform(DeprecatedString const& string, CSS::TextTransform text_transform)
 {
     if (text_transform == CSS::TextTransform::Uppercase)
         return Unicode::to_unicode_uppercase_full(string);
@@ -44,7 +44,7 @@ static DeprecatedString apply_text_transform(DeprecatedString const& string, CSS
 // NOTE: This collapses whitespace into a single ASCII space if collapse is true.
 void TextNode::compute_text_for_rendering(bool collapse)
 {
-    auto data = apply_text_transform(dom_node().data(), computed_values().text_transform());
+    auto data = apply_text_transform(dom_node().data(), computed_values().text_transform()).release_value_but_fixme_should_propagate_errors();
 
     if (dom_node().is_password_input()) {
         m_text_for_rendering = DeprecatedString::repeated('*', data.length());


### PR DESCRIPTION
This covers *most* of the remaining OOM cases in `String.prototype`. There's a couple places were we yolo convert a `StringView` to a `DeprecatedString`, and `DeprecatedString` has an internal `VERIFY` that the allocation succeeds. Rather than working around that, we'll be better served by migrating to the new `String`.

![Screenshot from 2023-01-08 10-17-09](https://user-images.githubusercontent.com/5600524/211207423-d0c63c63-0fb1-4551-9cbd-e0030722c718.png)
![Screenshot from 2023-01-08 10-32-15](https://user-images.githubusercontent.com/5600524/211207425-1118f5ae-254a-4785-8e06-726dd0a940b4.png)
