### PR TITLE
LibWeb: Remove inheritance of TableBox from BlockContainer 

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -413,10 +413,6 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
 
             auto const& child_box_state = m_state.get(*child_box);
 
-            // Ignore anonymous block containers with no lines. These don't count as in-flow block boxes.
-            if (child_box->is_anonymous() && child_box->is_block_container() && child_box_state.line_boxes.is_empty())
-                continue;
-
             if (margins_collapse_through(*child_box, m_state)) {
                 continue;
             }

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/Layout/FormattingContext.h>
 #include <LibWeb/Layout/InitialContainingBlock.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Layout/TableBox.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Platform/FontPlugin.h>
 
@@ -664,6 +665,17 @@ JS::NonnullGCPtr<NodeWithStyle> NodeWithStyle::create_anonymous_wrapper() const
     wrapper->m_font = m_font;
     wrapper->m_line_height = m_line_height;
     return *wrapper;
+}
+
+void NodeWithStyle::reset_table_box_computed_values_used_by_wrapper_to_init_values()
+{
+    VERIFY(is<TableBox>(*this));
+
+    CSS::MutableComputedValues& mutable_computed_values = static_cast<CSS::MutableComputedValues&>(m_computed_values);
+    mutable_computed_values.set_position(CSS::Position::Static);
+    mutable_computed_values.set_float(CSS::Float::None);
+    mutable_computed_values.set_inset({ CSS::Length::make_auto(), CSS::Length::make_auto(), CSS::Length::make_auto(), CSS::Length::make_auto() });
+    mutable_computed_values.set_margin({ CSS::Length::make_px(0), CSS::Length::make_px(0), CSS::Length::make_px(0), CSS::Length::make_px(0) });
 }
 
 void Node::set_paintable(RefPtr<Painting::Paintable> paintable)

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -183,6 +183,8 @@ public:
 
     JS::NonnullGCPtr<NodeWithStyle> create_anonymous_wrapper() const;
 
+    void reset_table_box_computed_values_used_by_wrapper_to_init_values();
+
 protected:
     NodeWithStyle(DOM::Document&, DOM::Node*, NonnullRefPtr<CSS::StyleProperties>);
     NodeWithStyle(DOM::Document&, DOM::Node*, CSS::ComputedValues);

--- a/Userland/Libraries/LibWeb/Layout/TableBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableBox.cpp
@@ -10,12 +10,12 @@
 namespace Web::Layout {
 
 TableBox::TableBox(DOM::Document& document, DOM::Element* element, NonnullRefPtr<CSS::StyleProperties> style)
-    : Layout::BlockContainer(document, element, move(style))
+    : Layout::Box(document, element, move(style))
 {
 }
 
 TableBox::TableBox(DOM::Document& document, DOM::Element* element, CSS::ComputedValues computed_values)
-    : Layout::BlockContainer(document, element, move(computed_values))
+    : Layout::Box(document, element, move(computed_values))
 {
 }
 

--- a/Userland/Libraries/LibWeb/Layout/TableBox.h
+++ b/Userland/Libraries/LibWeb/Layout/TableBox.h
@@ -6,12 +6,12 @@
 
 #pragma once
 
-#include <LibWeb/Layout/BlockContainer.h>
+#include <LibWeb/Layout/Box.h>
 
 namespace Web::Layout {
 
-class TableBox final : public Layout::BlockContainer {
-    JS_CELL(TableBox, BlockContainer);
+class TableBox final : public Layout::Box {
+    JS_CELL(TableBox, Box);
 
 public:
     TableBox(DOM::Document&, DOM::Element*, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/TableCellBox.h
+++ b/Userland/Libraries/LibWeb/Layout/TableCellBox.h
@@ -18,9 +18,6 @@ public:
     TableCellBox(DOM::Document&, DOM::Element*, CSS::ComputedValues);
     virtual ~TableCellBox() override;
 
-    TableCellBox* next_cell() { return next_sibling_of_type<TableCellBox>(); }
-    TableCellBox const* next_cell() const { return next_sibling_of_type<TableCellBox>(); }
-
     size_t colspan() const;
     size_t rowspan() const;
 

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -36,7 +36,7 @@ struct Traits<GridPosition> : public GenericTraits<GridPosition> {
 
 namespace Web::Layout {
 
-TableFormattingContext::TableFormattingContext(LayoutState& state, BlockContainer const& root, FormattingContext* parent)
+TableFormattingContext::TableFormattingContext(LayoutState& state, TableBox const& root, FormattingContext* parent)
     : FormattingContext(Type::Table, state, root, parent)
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -457,19 +457,16 @@ void TableFormattingContext::run(Box const& box, LayoutMode, AvailableSpace cons
         auto& row_group_box_state = m_state.get_mutable(row_group_box);
         row_group_box_state.set_content_y(row_group_top_offset);
 
-        CSSPixels row_top_offset = 0.0f;
         row_group_box.template for_each_child_of_type<TableRowBox>([&](auto& row) {
-            auto& row_state = m_state.get_mutable(row);
-            row_state.set_content_y(row_top_offset);
+            auto const& row_state = m_state.get(row);
             row_group_height += row_state.border_box_height();
             row_group_width = max(row_group_width, row_state.border_box_width());
-            row_top_offset += row_state.border_box_height();
         });
-
-        row_group_top_offset += row_top_offset;
 
         row_group_box_state.set_content_height(row_group_height);
         row_group_box_state.set_content_width(row_group_width);
+
+        row_group_top_offset += row_group_height;
     });
 
     for (auto& cell : m_cells) {

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -13,7 +13,7 @@ namespace Web::Layout {
 
 class TableFormattingContext final : public FormattingContext {
 public:
-    explicit TableFormattingContext(LayoutState&, BlockContainer const&, FormattingContext* parent);
+    explicit TableFormattingContext(LayoutState&, TableBox const&, FormattingContext* parent);
     ~TableFormattingContext();
 
     virtual void run(Box const&, LayoutMode, AvailableSpace const&) override;

--- a/Userland/Libraries/LibWeb/Layout/TableRowGroupBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableRowGroupBox.cpp
@@ -12,7 +12,7 @@
 namespace Web::Layout {
 
 TableRowGroupBox::TableRowGroupBox(DOM::Document& document, DOM::Element* element, NonnullRefPtr<CSS::StyleProperties> style)
-    : Layout::BlockContainer(document, element, move(style))
+    : Layout::Box(document, element, move(style))
 {
 }
 

--- a/Userland/Libraries/LibWeb/Layout/TableRowGroupBox.h
+++ b/Userland/Libraries/LibWeb/Layout/TableRowGroupBox.h
@@ -6,12 +6,12 @@
 
 #pragma once
 
-#include <LibWeb/Layout/BlockContainer.h>
+#include <LibWeb/Layout/Box.h>
 
 namespace Web::Layout {
 
-class TableRowGroupBox final : public BlockContainer {
-    JS_CELL(TableRowGroupBox, BlockContainer);
+class TableRowGroupBox final : public Box {
+    JS_CELL(TableRowGroupBox, Box);
 
 public:
     TableRowGroupBox(DOM::Document&, DOM::Element*, NonnullRefPtr<CSS::StyleProperties>);


### PR DESCRIPTION
This change will make table boxes not to be skipped during context root height calculation in
`compute_auto_height_for_block_level_element`.