### PR TITLE
LibWeb+LibJS: Format Console arguments with JS::Print

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -64,6 +64,9 @@ public:
     // Creates a new String from a sequence of UTF-8 encoded code points.
     static ErrorOr<String> from_utf8(StringView);
 
+    // Creates a new String by reading byte_count bytes from a UTF-8 encoded Stream.
+    static ErrorOr<String> from_stream(Stream&, size_t byte_count);
+
     // Creates a new String from a short sequence of UTF-8 encoded code points. If the provided string
     // does not fit in the short string storage, a compilation error will be emitted.
     static AK_SHORT_STRING_CONSTEVAL String from_utf8_short_string(StringView string)

--- a/Ladybird/ConsoleClient.cpp
+++ b/Ladybird/ConsoleClient.cpp
@@ -168,7 +168,7 @@ JS::ThrowCompletionOr<JS::Value> ConsoleClient::printer(JS::Console::LogLevel lo
         return JS::js_undefined();
     }
 
-    auto output = DeprecatedString::join(' ', arguments.get<JS::MarkedVector<JS::Value>>());
+    auto output = TRY(generically_format_values(arguments.get<JS::MarkedVector<JS::Value>>()));
     m_console.output_debug_message(log_level, output);
 
     StringBuilder html;

--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -6,8 +6,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/MemoryStream.h>
 #include <LibJS/Console.h>
+#include <LibJS/Print.h>
 #include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/StringConstructor.h>
 #include <LibJS/Runtime/Temporal/Duration.h>
 #include <LibJS/Runtime/ThrowableStringBuilder.h>
@@ -667,6 +670,22 @@ ThrowCompletionOr<MarkedVector<Value>> ConsoleClient::formatter(MarkedVector<Val
 
     // 8. Return Formatter(result).
     return formatter(result);
+}
+
+ThrowCompletionOr<String> ConsoleClient::generically_format_values(MarkedVector<Value> const& values)
+{
+    AllocatingMemoryStream stream;
+    auto& vm = m_console.realm().vm();
+    PrintContext ctx { vm, stream, true };
+    bool first = true;
+    for (auto const& value : values) {
+        if (!first)
+            TRY_OR_THROW_OOM(vm, stream.write(" "sv.bytes()));
+        TRY_OR_THROW_OOM(vm, JS::print(value, ctx));
+        first = false;
+    }
+    // FIXME: Is it possible we could end up serializing objects to invalid UTF-8?
+    return TRY_OR_THROW_OOM(vm, String::from_stream(stream, stream.used_buffer_size()));
 }
 
 }

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -116,6 +116,8 @@ public:
     virtual void clear() = 0;
     virtual void end_group() = 0;
 
+    ThrowCompletionOr<String> generically_format_values(MarkedVector<Value> const&);
+
 protected:
     virtual ~ConsoleClient() = default;
 

--- a/Userland/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.cpp
@@ -58,7 +58,7 @@ JS::ThrowCompletionOr<JS::Value> WorkerDebugConsoleClient::printer(JS::Console::
         return JS::js_undefined();
     }
 
-    auto output = TRY_OR_THROW_OOM(vm, String::join(' ', arguments.get<JS::MarkedVector<JS::Value>>()));
+    auto output = TRY(generically_format_values(arguments.get<JS::MarkedVector<JS::Value>>()));
     m_console.output_debug_message(log_level, output);
 
     switch (log_level) {

--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -158,7 +158,7 @@ JS::ThrowCompletionOr<JS::Value> WebContentConsoleClient::printer(JS::Console::L
         return JS::js_undefined();
     }
 
-    auto output = TRY_OR_THROW_OOM(vm, String::join(' ', arguments.get<JS::MarkedVector<JS::Value>>()));
+    auto output = TRY(generically_format_values(arguments.get<JS::MarkedVector<JS::Value>>()));
     m_console.output_debug_message(log_level, output);
 
     JS::ThrowableStringBuilder html(vm);

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -558,7 +558,7 @@ public:
             return JS::js_undefined();
         }
 
-        auto output = TRY_OR_THROW_OOM(*g_vm, String::join(' ', arguments.get<JS::MarkedVector<JS::Value>>()));
+        auto output = TRY(generically_format_values(arguments.get<JS::MarkedVector<JS::Value>>()));
 #ifdef AK_OS_SERENITY
         m_console.output_debug_message(log_level, output);
 #endif


### PR DESCRIPTION
Instead of just calling JS::Value::to_string_without_side_effects() when
printing values to the console, have all the console clients use
the same JS::Print that the REPL does to print values.

This method leaves some things to be desired as far as OOM hardening
goes, however. We should be able to create a String in a way that
doesn't OOM on failure so hard.

Before: 
![Screenshot from 2023-01-08 11-25-05](https://user-images.githubusercontent.com/8388494/211214694-07b1a4a5-2079-44b3-90ea-d8902dbe02f2.png)

After:

![Screenshot from 2023-01-08 11-04-04](https://user-images.githubusercontent.com/8388494/211214703-eafc3ec1-3c99-4307-b2c8-9b79d4be7d57.png)

