### PR TITLE
base64: TRY() the fallible function encode_base64()

### DIFF
--- a/Userland/Utilities/base64.cpp
+++ b/Userland/Utilities/base64.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 0;
     }
 
-    auto encoded = encode_base64(buffer);
+    auto encoded = TRY(encode_base64(buffer));
     outln("{}", encoded);
     return 0;
 }


### PR DESCRIPTION
This seems to have been forgotten in commit 25f2e498.

Before:
![image](https://user-images.githubusercontent.com/248795/211216848-b456a4b0-3cff-4f51-9ea3-f2dc890a3078.png)

After:
![image](https://user-images.githubusercontent.com/248795/211216799-3134920c-1909-40ca-a6e2-a2568e6e1d63.png)
