### PR TITLE
LibCompress: Remove the remaining `AK::Stream`-ness

### DIFF
--- a/AK/CircularBuffer.h
+++ b/AK/CircularBuffer.h
@@ -42,6 +42,10 @@ public:
     Bytes read(Bytes bytes);
     ErrorOr<void> discard(size_t discarded_bytes);
 
+    /// Compared to `read()`, this starts reading from an offset that is `distance` bytes
+    /// before the current write pointer and allows for reading already-read data.
+    ErrorOr<Bytes> read_with_seekback(Bytes bytes, size_t distance);
+
     [[nodiscard]] size_t empty_space() const;
     [[nodiscard]] size_t used_space() const;
     [[nodiscard]] size_t capacity() const;
@@ -57,11 +61,13 @@ private:
 
     [[nodiscard]] Bytes next_write_span();
     [[nodiscard]] ReadonlyBytes next_read_span() const;
+    [[nodiscard]] ReadonlyBytes next_read_span_with_seekback(size_t distance) const;
 
     ByteBuffer m_buffer {};
 
     size_t m_reading_head {};
     size_t m_used_space {};
+    size_t m_seekback_limit {};
 };
 
 }

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -76,7 +76,7 @@ public:
     friend CompressedBlock;
     friend UncompressedBlock;
 
-    DeflateDecompressor(Core::Stream::Handle<Core::Stream::Stream> stream);
+    static ErrorOr<NonnullOwnPtr<DeflateDecompressor>> construct(Core::Stream::Handle<Core::Stream::Stream> stream);
     ~DeflateDecompressor();
 
     virtual ErrorOr<Bytes> read(Bytes) override;
@@ -88,6 +88,8 @@ public:
     static ErrorOr<ByteBuffer> decompress_all(ReadonlyBytes);
 
 private:
+    DeflateDecompressor(Core::Stream::Handle<Core::Stream::Stream> stream);
+
     ErrorOr<u32> decode_length(u32);
     ErrorOr<u32> decode_distance(u32);
     ErrorOr<void> decode_codes(CanonicalCode& literal_code, Optional<CanonicalCode>& distance_code);

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -7,9 +7,7 @@
 
 #pragma once
 
-#include <AK/BitStream.h>
 #include <AK/ByteBuffer.h>
-#include <AK/CircularDuplexStream.h>
 #include <AK/Endian.h>
 #include <AK/Vector.h>
 #include <LibCompress/DeflateTables.h>

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -88,7 +88,7 @@ public:
     static ErrorOr<ByteBuffer> decompress_all(ReadonlyBytes);
 
 private:
-    DeflateDecompressor(Core::Stream::Handle<Core::Stream::Stream> stream);
+    DeflateDecompressor(Core::Stream::Handle<Core::Stream::Stream> stream, CircularBuffer buffer);
 
     ErrorOr<u32> decode_length(u32);
     ErrorOr<u32> decode_distance(u32);
@@ -103,7 +103,7 @@ private:
     };
 
     Core::Stream::Handle<Core::Stream::LittleEndianInputBitStream> m_input_stream;
-    CircularDuplexStream<32 * KiB> m_output_stream;
+    CircularBuffer m_output_buffer;
 };
 
 class DeflateCompressor final : public Core::Stream::Stream {

--- a/Userland/Libraries/LibCompress/Gzip.h
+++ b/Userland/Libraries/LibCompress/Gzip.h
@@ -56,25 +56,24 @@ public:
 private:
     class Member {
     public:
-        Member(BlockHeader header, Core::Stream::Stream& stream)
-            : m_header(header)
-            , m_stream(Core::Stream::Handle<Core::Stream::Stream>(stream))
-        {
-        }
+        static ErrorOr<NonnullOwnPtr<Member>> construct(BlockHeader header, Core::Stream::Stream&);
 
         BlockHeader m_header;
-        DeflateDecompressor m_stream;
+        NonnullOwnPtr<DeflateDecompressor> m_stream;
         Crypto::Checksum::CRC32 m_checksum;
         size_t m_nread { 0 };
+
+    private:
+        Member(BlockHeader, NonnullOwnPtr<DeflateDecompressor>);
     };
 
-    Member const& current_member() const { return m_current_member.value(); }
-    Member& current_member() { return m_current_member.value(); }
+    Member const& current_member() const { return *m_current_member; }
+    Member& current_member() { return *m_current_member; }
 
     NonnullOwnPtr<Core::Stream::Stream> m_input_stream;
     u8 m_partial_header[sizeof(BlockHeader)];
     size_t m_partial_header_offset { 0 };
-    Optional<Member> m_current_member;
+    OwnPtr<Member> m_current_member {};
 
     bool m_eof { false };
 };

--- a/Userland/Libraries/LibCompress/Zlib.cpp
+++ b/Userland/Libraries/LibCompress/Zlib.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/MemoryStream.h>
 #include <AK/Span.h>
 #include <AK/TypeCasts.h>
 #include <AK/Types.h>

--- a/Userland/Libraries/LibCompress/Zlib.h
+++ b/Userland/Libraries/LibCompress/Zlib.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/BitStream.h>
 #include <AK/ByteBuffer.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -24,10 +24,8 @@ namespace Core::Stream {
 
 ErrorOr<void> Stream::read_entire_buffer(Bytes buffer)
 {
-    VERIFY(buffer.size());
-
     size_t nread = 0;
-    do {
+    while (nread < buffer.size()) {
         if (is_eof())
             return Error::from_string_literal("Reached end-of-file before filling the entire buffer");
 
@@ -41,7 +39,7 @@ ErrorOr<void> Stream::read_entire_buffer(Bytes buffer)
         }
 
         nread += result.value().size();
-    } while (nread < buffer.size());
+    }
 
     return {};
 }
@@ -93,10 +91,8 @@ ErrorOr<void> Stream::discard(size_t discarded_bytes)
 
 ErrorOr<void> Stream::write_entire_buffer(ReadonlyBytes buffer)
 {
-    VERIFY(buffer.size());
-
     size_t nwritten = 0;
-    do {
+    while (nwritten < buffer.size()) {
         auto result = write(buffer.slice(nwritten));
         if (result.is_error()) {
             if (result.error().is_errno() && result.error().code() == EINTR) {
@@ -107,7 +103,7 @@ ErrorOr<void> Stream::write_entire_buffer(ReadonlyBytes buffer)
         }
 
         nwritten += result.value();
-    } while (nwritten < buffer.size());
+    }
 
     return {};
 }


### PR DESCRIPTION
The last one for LibCompress, as far as I can tell! I think I handled all the remaining feedback from previous PRs, but if anything Stream-related in LibCompress remains that should be fixed as soon as possible, now is the time.