### PR TITLE
Ports: Make `sed` work on macOS

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -142,6 +142,14 @@ run_replace_in_file() {
     fi
 }
 
+sed_in_place() {
+    if [ "$(uname -s)" = "Darwin" ]; then
+        sed -i '' "${@}"
+    else
+        sed -i "${@}"
+    fi
+}
+
 get_new_config_sub() {
     config_sub="${1:-config.sub}"
     if [ ! -f "$workdir/$config_sub" ]; then

--- a/Ports/libvorbis/package.sh
+++ b/Ports/libvorbis/package.sh
@@ -11,5 +11,5 @@ depends=("libogg")
 post_install() {
     # Fix up broken libtool paths
     # FIXME: apply a proper libtool fix
-    sed -i "s# /usr/local# ${SERENITY_INSTALL_ROOT}/usr/local#g" "${SERENITY_INSTALL_ROOT}"/usr/local/lib/libvorbis*.la
+    sed_in_place "s# /usr/local# ${SERENITY_INSTALL_ROOT}/usr/local#g" "${SERENITY_INSTALL_ROOT}"/usr/local/lib/libvorbis*.la
 }

--- a/Ports/readline/package.sh
+++ b/Ports/readline/package.sh
@@ -15,5 +15,5 @@ configopts=(
 post_install() {
     # readline specifies termcap as a dependency in its pkgconfig file, without checking if it exists.
     # Remove it manually to keep other ports from discarding readline because termcap is supposedly missing.
-    sed -i -e '/^Requires.private:/s/termcap//' "${SERENITY_INSTALL_ROOT}/usr/local/lib/pkgconfig/readline.pc"
+    sed_in_place '/^Requires.private:/s/termcap//' "${SERENITY_INSTALL_ROOT}/usr/local/lib/pkgconfig/readline.pc"
 }

--- a/Ports/timidity/package.sh
+++ b/Ports/timidity/package.sh
@@ -32,5 +32,5 @@ post_install() {
     timidity_cfg_path="${SERENITY_INSTALL_ROOT}/etc/timidity.cfg"
     mkdir -p "$(dirname ${timidity_cfg_path})"
     cp "${eaw_pats_host_dir}/timidity.cfg" "${timidity_cfg_path}"
-    sed -i "s#^dir .*#dir ${eaw_pats_dir}#g" "${timidity_cfg_path}"
+    sed_in_place "s#^dir .*#dir ${eaw_pats_dir}#g" "${timidity_cfg_path}"
 }


### PR DESCRIPTION
The ports `libvorbis`, `readline` and `timidity` would not install on macOS as a result of using `sed -i` without an extension provided. GNU sed is available through Homebrew, but it does not replace `sed` by default.

Instead, use the cross-platform version of `sed -i` and remove the backup files afterwards.