### PR TITLE
Help: Update browse view when opening a new help page

### DIFF
--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -250,7 +250,10 @@ void MainWidget::open_url(URL const& url)
         GUI::Application::the()->deferred_invoke([&, path = url.path()] {
             auto browse_view_index = m_manual_model->index_from_path(path);
             if (browse_view_index.has_value()) {
-                m_browse_view->expand_all_parents_of(browse_view_index.value());
+                if (browse_view_index.value() != m_browse_view->selection_start_index()) {
+                    m_browse_view->expand_all_parents_of(browse_view_index.value());
+                    m_browse_view->set_cursor(browse_view_index.value(), GUI::AbstractView::SelectionUpdate::Set);
+                }
 
                 auto page_and_section = m_manual_model->page_and_section(browse_view_index.value());
                 if (!page_and_section.has_value())


### PR DESCRIPTION
Previously the browse view would not track the currently open help page.

Here is a video showing a help page being loaded by an external program, the back and forward buttons being used and the search view being used:

https://user-images.githubusercontent.com/2817754/211221930-7d692191-e1fb-4334-bce3-52817119ef01.mp4



