### PR TITLE
Make `Meta/serenity.sh rebuild-world` work on macOS without requiring stuff from brew

### DIFF
--- a/Toolchain/BuildCMake.sh
+++ b/Toolchain/BuildCMake.sh
@@ -22,6 +22,23 @@ fi
 
 [ -z "$MAKEJOBS" ] && MAKEJOBS=$($NPROC)
 
+check_sha() {
+    if [ $# -ne 2 ]; then
+        error "Usage: check_sha FILE EXPECTED_HASH"
+        return 1
+    fi
+
+    FILE="${1}"
+    EXPECTED_HASH="${2}"
+
+    if [ "$SYSTEM_NAME" = "Darwin" ]; then
+        SEEN_HASH="$(shasum -a 256 "${FILE}" | cut -d " " -f 1)"
+    else
+        SEEN_HASH="$(sha256sum "${FILE}" | cut -d " " -f 1)"
+    fi
+    test "${EXPECTED_HASH}" = "${SEEN_HASH}"
+}
+
 # Note: Update this alongside Meta/CMake/cmake-version.cmake
 CMAKE_VERSION=3.25.1
 CMAKE_ARCHIVE_SHA256=1c511d09516af493694ed9baf13c55947a36389674d657a2d5e0ccedc6b291d8
@@ -37,7 +54,7 @@ pushd "$DIR"/Tarballs
         echo "${CMAKE_ARCHIVE} already exists, not downloading archive"
     fi
 
-    if ! sha256sum --status -c <(echo "${CMAKE_ARCHIVE_SHA256}" "${CMAKE_ARCHIVE}"); then
+    if ! check_sha "${CMAKE_ARCHIVE}" "${CMAKE_ARCHIVE_SHA256}"; then
         echo "CMake archive SHA256 sum mismatch, please run script again"
         rm -f "${CMAKE_ARCHIVE}"
         exit 1

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -49,6 +49,9 @@ elif [ "$SYSTEM_NAME" = "FreeBSD" ]; then
     NPROC="sysctl -n hw.ncpu"
     export with_gmp=/usr/local
     export with_mpfr=/usr/local
+elif [ "$SYSTEM_NAME" = "Darwin" ]; then
+    MD5SUM="md5 -q"
+    NPROC="sysctl -n hw.ncpu"
 fi
 
 # On at least OpenBSD, the path must exist to call realpath(3) on it

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -400,7 +400,8 @@ pushd "$DIR/Build/$ARCH"
                 -e "s@$SRC_ROOT/AK/@AK/@" \
                 -e "s@$SRC_ROOT/Userland/Libraries/LibC@@" \
                 -e "s@$SRC_ROOT/Kernel/@Kernel/@")
-            buildstep "system_headers" $INSTALL -D "$header" "Root/usr/include/$target"
+            buildstep "system_headers" mkdir -p "$(dirname "Root/usr/include/$target")"
+            buildstep "system_headers" $INSTALL "$header" "Root/usr/include/$target"
         done
         unset SRC_ROOT
     popd


### PR DESCRIPTION
With these small changes, having just ninja and cmake on the path is enough to get the system built.