### PR TITLE
LibWeb: Move clear property from table-root to table-wrapper

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -674,6 +674,7 @@ void NodeWithStyle::reset_table_box_computed_values_used_by_wrapper_to_init_valu
     CSS::MutableComputedValues& mutable_computed_values = static_cast<CSS::MutableComputedValues&>(m_computed_values);
     mutable_computed_values.set_position(CSS::Position::Static);
     mutable_computed_values.set_float(CSS::Float::None);
+    mutable_computed_values.set_clear(CSS::Clear::None);
     mutable_computed_values.set_inset({ CSS::Length::make_auto(), CSS::Length::make_auto(), CSS::Length::make_auto(), CSS::Length::make_auto() });
     mutable_computed_values.set_margin({ CSS::Length::make_px(0), CSS::Length::make_px(0), CSS::Length::make_px(0), CSS::Length::make_px(0) });
 }

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -594,6 +594,7 @@ void TreeBuilder::generate_missing_parents(NodeWithStyle& root)
         mutable_wrapper_computed_values.set_position(table_box->computed_values().position());
         mutable_wrapper_computed_values.set_inset(table_box->computed_values().inset());
         mutable_wrapper_computed_values.set_float(table_box->computed_values().float_());
+        mutable_wrapper_computed_values.set_clear(table_box->computed_values().clear());
         mutable_wrapper_computed_values.set_margin(table_box->computed_values().margin());
         table_box->reset_table_box_computed_values_used_by_wrapper_to_init_values();
 


### PR DESCRIPTION
CSS 2.2 only mentions that float property need to be moved but in practice clear property also need to be moved to produce correct layout.