### PR TITLE
AK: Fix all quadratic-time append-loops over ByteBuffer

### DIFF
--- a/Tests/AK/TestByteBuffer.cpp
+++ b/Tests/AK/TestByteBuffer.cpp
@@ -33,6 +33,14 @@ TEST_CASE(equality_operator)
     EXPECT_EQ(d == d, true);
 }
 
+BENCHMARK_CASE(append)
+{
+    ByteBuffer bb;
+    for (size_t i = 0; i < 1000000; ++i) {
+        bb.append(static_cast<u8>(i));
+    }
+}
+
 /*
  * FIXME: These `negative_*` tests should cause precisely one compilation error
  * each, and always for the specified reason. Currently we do not have a harness


### PR DESCRIPTION
In many places throughout Serenity, we build up a ByteBuffer little by little, causing many calls to `try_append`. One such case is `LibCrypto/ASN1/PEM.cpp`. However, ByteBuffer does not have any mechanism for exponential growth steps, so every call to `append` causes an entirely new buffer to be allocated, all the data copied over, and then the new byte(s) be actually added. This results in an overall quadratic runtime.

To avoid that problem, this PR introduces a simple exponential growth patter using the factor 1.5. This means that, for example, if the ByteBuffer has a capacity of 1000 and we are asked to raise it to something only slightly above 1000, the capacity is instead increased to 1500. This seems like a good trade-off between time and space to me. Of course, we can bikeshed that number all day long.

This problem mostly occurs on Lagom, where kmalloc_good_size just returns the number as-is. On Serenity, it rounds up to the next page-size, which does not actually fix the problem (because we still have to reallocate and copy on every single page write, which means appending n individual pages means n^2 writes to memory). Therefore, it is good that this mechanism applies to all platforms.

This PR also introduces a small benchmark to verify the issue and the fix.
- `TestByteBuffer::append` speeds up from 35.8 seconds to 0.1 seconds.
- `TestPEM clusterfuzz-testcase-minimized-FuzzPEM-4952911654813696` speeds up from 7.1 seconds to 0.2 seconds, and therefore solves https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41035&q=label%3AProj-serenity