### PR TITLE
LibGfx: Add some missing Cmap formats to OpenType

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Cmap.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Cmap.cpp
@@ -75,10 +75,12 @@ Optional<Cmap::Subtable> Cmap::subtable(u32 index) const
     return Subtable(subtable_slice, platform_id, encoding_id);
 }
 
-// FIXME: This only handles formats 4 (SegmentToDelta) and 12 (SegmentedCoverage) for now.
+// FIXME: Implement the missing formats.
 u32 Cmap::Subtable::glyph_id_for_code_point(u32 code_point) const
 {
     switch (format()) {
+    case Format::ByteEncoding:
+        return glyph_id_for_code_point_table_0(code_point);
     case Format::SegmentToDelta:
         return glyph_id_for_code_point_table_4(code_point);
     case Format::SegmentedCoverage:
@@ -86,6 +88,14 @@ u32 Cmap::Subtable::glyph_id_for_code_point(u32 code_point) const
     default:
         return 0;
     }
+}
+
+u32 Cmap::Subtable::glyph_id_for_code_point_table_0(u32 code_point) const
+{
+    if (code_point > 255)
+        return 0;
+
+    return m_slice.at((u32)Table0Offsets::GlyphIdArray + code_point);
 }
 
 u32 Cmap::Subtable::glyph_id_for_code_point_table_4(u32 code_point) const

--- a/Userland/Libraries/LibGfx/Font/OpenType/Cmap.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Cmap.cpp
@@ -83,6 +83,8 @@ u32 Cmap::Subtable::glyph_id_for_code_point(u32 code_point) const
         return glyph_id_for_code_point_table_0(code_point);
     case Format::SegmentToDelta:
         return glyph_id_for_code_point_table_4(code_point);
+    case Format::TrimmedTable:
+        return glyph_id_for_code_point_table_6(code_point);
     case Format::SegmentedCoverage:
         return glyph_id_for_code_point_table_12(code_point);
     default:
@@ -127,6 +129,20 @@ u32 Cmap::Subtable::glyph_id_for_code_point_table_4(u32 code_point) const
     u32 glyph_offset = (u32)Table4Offsets::GlyphOffsetConstBase + segcount_x2 * 3 + offset + range + (code_point - start_code_point) * 2;
     VERIFY(glyph_offset + 2 <= m_slice.size());
     return (be_u16(m_slice.offset_pointer(glyph_offset)) + delta) & 0xffff;
+}
+
+u32 Cmap::Subtable::glyph_id_for_code_point_table_6(u32 code_point) const
+{
+    u32 first_code = be_u16(m_slice.offset_pointer((u32)Table6Offsets::FirstCode));
+    if (code_point < first_code)
+        return 0;
+
+    u32 entry_count = be_u16(m_slice.offset_pointer((u32)Table6Offsets::EntryCount));
+    u32 code_offset = code_point - first_code;
+    if (code_offset > entry_count)
+        return 0;
+
+    return be_u16(m_slice.offset_pointer((u32)Table6Offsets::GlyphIdArray + code_offset * 2));
 }
 
 u32 Cmap::Subtable::glyph_id_for_code_point_table_12(u32 code_point) const

--- a/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
@@ -67,6 +67,11 @@ public:
             Constant = 16,
             NonConstMultiplier = 4,
         };
+        enum class Table6Offsets {
+            FirstCode = 6,
+            EntryCount = 8,
+            GlyphIdArray = 10
+        };
         enum class Table12Offsets {
             NumGroups = 12,
             Record_StartCode = 16,
@@ -80,6 +85,7 @@ public:
 
         u32 glyph_id_for_code_point_table_0(u32 code_point) const;
         u32 glyph_id_for_code_point_table_4(u32 code_point) const;
+        u32 glyph_id_for_code_point_table_6(u32 code_point) const;
         u32 glyph_id_for_code_point_table_12(u32 code_point) const;
 
         ReadonlyBytes m_slice;

--- a/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
@@ -52,6 +52,9 @@ public:
         Format format() const;
 
     private:
+        enum class Table0Offsets {
+            GlyphIdArray = 6
+        };
         enum class Table4Offsets {
             SegCountX2 = 6,
             EndConstBase = 14,
@@ -75,6 +78,7 @@ public:
             Record = 12,
         };
 
+        u32 glyph_id_for_code_point_table_0(u32 code_point) const;
         u32 glyph_id_for_code_point_table_4(u32 code_point) const;
         u32 glyph_id_for_code_point_table_12(u32 code_point) const;
 

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -510,6 +510,9 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_offset(ReadonlyBytes buffer, u3
                 cmap.set_active_index(i);
                 break;
             }
+        } else if (platform.value() == Cmap::Subtable::Platform::Macintosh) {
+            cmap.set_active_index(i);
+            break;
         }
     }
 


### PR DESCRIPTION
I came across these unimplemented paths while working on embedded fonts in PDFs. These also commonly use the otherwise obscure "Macintosh" platform ID, for which we need to pick a Cmap table. While we are still not good at picking the right one, this should work for a lot of cases.