### PR TITLE
LibWeb: Speed up CSS ValueID parsing by factor 20

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -348,6 +348,7 @@ struct CaseInsensitiveStringViewTraits : public Traits<StringView> {
             return 0;
         return case_insensitive_string_hash(s.characters_without_null_termination(), s.length());
     }
+    static bool equals(StringView const& a, StringView const& b) { return a.equals_ignoring_case(b); }
 };
 
 }

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -657,6 +657,16 @@ if (BUILD_LAGOM)
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../Tests/LibVideo)
         endforeach()
 
+        # Web
+        if (ENABLE_LAGOM_LIBWEB)
+            file(COPY "${SERENITY_PROJECT_ROOT}/Tests/LibWeb/tokenizer-test.html" DESTINATION "./")
+            file(GLOB LIBWEB_TEST_SOURCES CONFIGURE_DEPENDS "../../Tests/LibWeb/*.cpp")
+            foreach(source ${LIBWEB_TEST_SOURCES})
+                lagom_test(${source} LIBS LibWeb
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../Tests/LibWeb)
+            endforeach()
+        endif()
+
         # JavaScriptTestRunner + LibTest tests
         # test-js
         add_executable(test-js

--- a/Tests/AK/TestHashMap.cpp
+++ b/Tests/AK/TestHashMap.cpp
@@ -108,6 +108,14 @@ TEST_CASE(case_insensitive)
     EXPECT_EQ(casemap.size(), 1u);
 }
 
+TEST_CASE(case_insensitive_stringview)
+{
+    HashMap<StringView, int, CaseInsensitiveStringViewTraits> casemap;
+    EXPECT_EQ(casemap.set("nickserv"sv, 3), AK::HashSetResult::InsertedNewEntry);
+    EXPECT_EQ(casemap.set("NickServ"sv, 3), AK::HashSetResult::ReplacedExistingEntry);
+    EXPECT_EQ(casemap.size(), 1u);
+}
+
 TEST_CASE(hashmap_of_nonnullownptr_get)
 {
     struct Object {

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    TestCSSIDSpeed.cpp
     TestHTMLTokenizer.cpp
 )
 

--- a/Tests/LibWeb/TestCSSIDSpeed.cpp
+++ b/Tests/LibWeb/TestCSSIDSpeed.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <LibWeb/CSS/ValueID.h>
+
+TEST_CASE(basic)
+{
+    EXPECT_EQ(Web::CSS::value_id_from_string("italic"sv), Web::CSS::ValueID::Italic);
+    EXPECT_EQ(Web::CSS::value_id_from_string("inline"sv), Web::CSS::ValueID::Inline);
+    EXPECT_EQ(Web::CSS::value_id_from_string("small"sv), Web::CSS::ValueID::Small);
+    EXPECT_EQ(Web::CSS::value_id_from_string("smalL"sv), Web::CSS::ValueID::Small);
+    EXPECT_EQ(Web::CSS::value_id_from_string("SMALL"sv), Web::CSS::ValueID::Small);
+    EXPECT_EQ(Web::CSS::value_id_from_string("Small"sv), Web::CSS::ValueID::Small);
+    EXPECT_EQ(Web::CSS::value_id_from_string("smALl"sv), Web::CSS::ValueID::Small);
+}
+
+BENCHMARK_CASE(value_id_from_string)
+{
+    for (size_t i = 0; i < 10'000'000; ++i) {
+        EXPECT_EQ(Web::CSS::value_id_from_string("inline"sv), Web::CSS::ValueID::Inline);
+    }
+}

--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -201,7 +201,14 @@ TEST_CASE(doctype)
 //       If that changes, or something is added to the test HTML, the hash needs to be adjusted.
 TEST_CASE(regression)
 {
-    auto file = MUST(Core::Stream::File::open("/usr/Tests/LibWeb/tokenizer-test.html"sv, Core::Stream::OpenMode::Read));
+    // This makes sure that the tests will run both on target and in Lagom.
+#ifdef AK_OS_SERENITY
+    StringView path = "/usr/Tests/LibWeb/tokenizer-test.html"sv;
+#else
+    StringView path = "tokenizer-test.html"sv;
+#endif
+
+    auto file = MUST(Core::Stream::File::open(path, Core::Stream::OpenMode::Read));
     auto file_size = MUST(file->size());
     auto content = MUST(ByteBuffer::create_uninitialized(file_size));
     MUST(file->read(content.bytes()));


### PR DESCRIPTION
The old approach was basically a linear scan, which is slower than a hash map for the currently 303 elements. In the course of doing so, this also uncovers and fixes a bug in AK::CaseInsensitiveStringViewTraits.