### PR TITLE
Presenter: Rearchitect on top of LibWeb

### DIFF
--- a/Userland/Applications/Presenter/CMakeLists.txt
+++ b/Userland/Applications/Presenter/CMakeLists.txt
@@ -2,7 +2,7 @@ serenity_component(
     Presenter
     RECOMMENDED
     TARGETS Presenter
-    DEPENDS ImageDecoder FileSystemAccessServer
+    DEPENDS FileSystemAccessServer
 )
 
 
@@ -14,4 +14,4 @@ set(SOURCES
     SlideObject.cpp
 )
 serenity_app(Presenter ICON app-display-settings)
-target_link_libraries(Presenter PRIVATE LibImageDecoderClient LibGUI LibGfx LibFileSystemAccessClient LibCore LibMain)
+target_link_libraries(Presenter PRIVATE LibWebView LibGUI LibGfx LibFileSystemAccessClient LibCore LibMain)

--- a/Userland/Applications/Presenter/Presentation.h
+++ b/Userland/Applications/Presenter/Presentation.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,11 +9,9 @@
 
 #include "Slide.h"
 #include <AK/DeprecatedString.h>
-#include <AK/Forward.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Vector.h>
-#include <LibGfx/Painter.h>
 #include <LibGfx/Size.h>
 
 static constexpr int const PRESENTATION_FORMAT_VERSION = 1;
@@ -23,8 +22,7 @@ class Presentation {
 public:
     ~Presentation() = default;
 
-    // We can't pass this class directly in an ErrorOr because some of the components are not properly moveable under these conditions.
-    static ErrorOr<NonnullOwnPtr<Presentation>> load_from_file(StringView file_name, NonnullRefPtr<GUI::Window> window);
+    static ErrorOr<NonnullOwnPtr<Presentation>> load_from_file(StringView file_name);
 
     StringView title() const;
     StringView author() const;
@@ -38,8 +36,7 @@ public:
     void previous_frame();
     void go_to_first_slide();
 
-    // This assumes that the caller has clipped the painter to exactly the display area.
-    void paint(Gfx::Painter& painter) const;
+    ErrorOr<DeprecatedString> render();
 
 private:
     static HashMap<DeprecatedString, DeprecatedString> parse_metadata(JsonObject const& metadata_object);

--- a/Userland/Applications/Presenter/PresenterWidget.cpp
+++ b/Userland/Applications/Presenter/PresenterWidget.cpp
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "PresenterWidget.h"
 #include "Presentation.h"
-#include <AK/Format.h>
 #include <LibCore/MimeData.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Action.h>
@@ -15,13 +15,39 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Window.h>
-#include <LibGfx/Forward.h>
-#include <LibGfx/Orientation.h>
 
 PresenterWidget::PresenterWidget()
 {
     set_min_size(100, 100);
+    set_fill_with_background_color(true);
+    m_web_view = add<WebView::OutOfProcessWebView>();
+    m_web_view->set_frame_thickness(0);
+    m_web_view->set_scrollbars_enabled(false);
+    m_web_view->set_focus_policy(GUI::FocusPolicy::NoFocus);
+    m_web_view->set_content_scales_to_viewport(true);
+}
+
+void PresenterWidget::resize_event(GUI::ResizeEvent& event)
+{
+    Widget::resize_event(event);
+
+    if (!m_current_presentation)
+        return;
+
+    auto normative_size = m_current_presentation->normative_size().to_type<float>();
+    float widget_ratio = static_cast<float>(event.size().width()) / static_cast<float>(event.size().height());
+    float wh_ratio = normative_size.width() / normative_size.height();
+
+    Gfx::IntRect rect;
+    if (widget_ratio >= wh_ratio) {
+        rect.set_width(static_cast<int>(ceilf(static_cast<float>(event.size().height()) * wh_ratio)));
+        rect.set_height(event.size().height());
+    } else {
+        float hw_ratio = normative_size.height() / normative_size.width();
+        rect.set_width(event.size().width());
+        rect.set_height(static_cast<int>(ceilf(static_cast<float>(event.size().width()) * hw_ratio)));
+    }
+    m_web_view->set_relative_rect(rect.centered_within(this->rect()));
 }
 
 ErrorOr<void> PresenterWidget::initialize_menubar()
@@ -44,15 +70,13 @@ ErrorOr<void> PresenterWidget::initialize_menubar()
     auto next_slide_action = GUI::Action::create("&Next", { KeyCode::Key_Right }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-forward.png"sv)), [this](auto&) {
         if (m_current_presentation) {
             m_current_presentation->next_frame();
-            outln("Switched forward to slide {} frame {}", m_current_presentation->current_slide_number(), m_current_presentation->current_frame_in_slide_number());
-            update();
+            update_web_view();
         }
     });
     auto previous_slide_action = GUI::Action::create("&Previous", { KeyCode::Key_Left }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-back.png"sv)), [this](auto&) {
         if (m_current_presentation) {
             m_current_presentation->previous_frame();
-            outln("Switched backward to slide {} frame {}", m_current_presentation->current_slide_number(), m_current_presentation->current_frame_in_slide_number());
-            update();
+            update_web_view();
         }
     });
     TRY(presentation_menu.try_add_action(next_slide_action));
@@ -64,25 +88,31 @@ ErrorOr<void> PresenterWidget::initialize_menubar()
         this->window()->set_fullscreen(true);
     })));
     TRY(presentation_menu.try_add_action(GUI::Action::create("Present From First &Slide", { KeyCode::Key_F5 }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/play.png"sv)), [this](auto&) {
-        if (m_current_presentation)
+        if (m_current_presentation) {
             m_current_presentation->go_to_first_slide();
+            update_web_view();
+        }
         this->window()->set_fullscreen(true);
     })));
 
     return {};
 }
 
+void PresenterWidget::update_web_view()
+{
+    m_web_view->run_javascript(DeprecatedString::formatted("goto({}, {})", m_current_presentation->current_slide_number(), m_current_presentation->current_frame_in_slide_number()));
+}
+
 void PresenterWidget::set_file(StringView file_name)
 {
-    auto presentation = Presentation::load_from_file(file_name, *window());
+    auto presentation = Presentation::load_from_file(file_name);
     if (presentation.is_error()) {
         GUI::MessageBox::show_error(window(), DeprecatedString::formatted("The presentation \"{}\" could not be loaded.\n{}", file_name, presentation.error()));
     } else {
         m_current_presentation = presentation.release_value();
         window()->set_title(DeprecatedString::formatted(title_template, m_current_presentation->title(), m_current_presentation->author()));
         set_min_size(m_current_presentation->normative_size());
-        // This will apply the new minimum size.
-        update();
+        m_web_view->load_html(MUST(m_current_presentation->render()), "presenter://slide.html"sv);
     }
 }
 
@@ -114,24 +144,19 @@ void PresenterWidget::keydown_event(GUI::KeyEvent& event)
     }
 }
 
-void PresenterWidget::paint_event([[maybe_unused]] GUI::PaintEvent& event)
+void PresenterWidget::paint_event(GUI::PaintEvent& event)
+{
+    GUI::Painter painter(*this);
+    painter.clear_rect(event.rect(), Gfx::Color::Black);
+}
+
+void PresenterWidget::second_paint_event(GUI::PaintEvent& event)
 {
     if (!m_current_presentation)
         return;
-    auto normative_size = m_current_presentation->normative_size();
-    // Choose an aspect-correct size which doesn't exceed actual widget dimensions.
-    auto width_corresponding_to_height = height() * normative_size.aspect_ratio();
-    auto dimension_to_preserve = (width_corresponding_to_height > width()) ? Orientation::Horizontal : Orientation::Vertical;
-    auto display_size = size().match_aspect_ratio(normative_size.aspect_ratio(), dimension_to_preserve);
-
-    GUI::Painter painter { *this };
-    auto clip_rect = Gfx::IntRect::centered_at({ width() / 2, height() / 2 }, display_size);
-    painter.clear_clip_rect();
-    // FIXME: This currently leaves a black border when the window aspect ratio doesn't match.
-    // Figure out a way to apply the background color here as well.
-    painter.add_clip_rect(clip_rect);
-
-    m_current_presentation->paint(painter);
+    GUI::Painter painter(*this);
+    painter.add_clip_rect(event.rect());
+    painter.draw_text(m_web_view->relative_rect(), m_current_presentation->current_slide().title(), Gfx::TextAlignment::BottomCenter);
 }
 
 void PresenterWidget::drag_enter_event(GUI::DragEvent& event)

--- a/Userland/Applications/Presenter/PresenterWidget.h
+++ b/Userland/Applications/Presenter/PresenterWidget.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,6 +12,7 @@
 #include <LibGUI/Event.h>
 #include <LibGUI/UIDimensions.h>
 #include <LibGUI/Widget.h>
+#include <LibWebView/OutOfProcessWebView.h>
 
 // Title, Author
 constexpr StringView const title_template = "{} ({}) — Presenter"sv;
@@ -29,11 +31,17 @@ public:
 
 protected:
     virtual void paint_event(GUI::PaintEvent&) override;
+    virtual void second_paint_event(GUI::PaintEvent&) override;
     virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
+    virtual void resize_event(GUI::ResizeEvent&) override;
 
 private:
+    void update_web_view();
+
+    RefPtr<WebView::OutOfProcessWebView> m_web_view;
+
     OwnPtr<Presentation> m_current_presentation;
     RefPtr<GUI::Action> m_next_slide_action;
     RefPtr<GUI::Action> m_previous_slide_action;

--- a/Userland/Applications/Presenter/Slide.h
+++ b/Userland/Applications/Presenter/Slide.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,19 +10,18 @@
 #include "SlideObject.h"
 #include <AK/DeprecatedString.h>
 #include <AK/Forward.h>
-#include <AK/NonnullOwnPtrVector.h>
-#include <LibGfx/Forward.h>
+#include <AK/NonnullRefPtrVector.h>
 
 // A single slide of a presentation.
 class Slide final {
 public:
-    static ErrorOr<Slide> parse_slide(JsonObject const& slide_json, NonnullRefPtr<GUI::Window> window);
+    static ErrorOr<Slide> parse_slide(JsonObject const& slide_json);
 
     // FIXME: shouldn't be hard-coded to 1.
     unsigned frame_count() const { return 1; }
     StringView title() const { return m_title; }
 
-    void paint(Gfx::Painter&, unsigned current_frame, Gfx::FloatSize display_scale) const;
+    ErrorOr<HTMLElement> render(Presentation const&) const;
 
 private:
     Slide(NonnullRefPtrVector<SlideObject> slide_objects, DeprecatedString title);

--- a/Userland/Applications/Presenter/SlideObject.h
+++ b/Userland/Applications/Presenter/SlideObject.h
@@ -6,133 +6,76 @@
 
 #pragma once
 
-#include <AK/Forward.h>
-#include <AK/NonnullOwnPtr.h>
-#include <AK/NonnullRefPtr.h>
-#include <LibCore/Object.h>
-#include <LibGUI/MessageBox.h>
-#include <LibGUI/Window.h>
-#include <LibGfx/Bitmap.h>
 #include <LibGfx/Color.h>
-#include <LibGfx/Font/Font.h>
-#include <LibGfx/Forward.h>
-#include <LibGfx/Painter.h>
+#include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Rect.h>
-#include <LibGfx/TextAlignment.h>
-#include <LibImageDecoderClient/Client.h>
+
+class Presentation;
+
+struct HTMLElement {
+    StringView tag_name;
+    HashMap<StringView, DeprecatedString> attributes;
+    HashMap<StringView, DeprecatedString> style;
+    DeprecatedString inner_text;
+    Vector<HTMLElement> children;
+
+    ErrorOr<void> serialize(StringBuilder&) const;
+};
 
 // Anything that can be on a slide.
-// For properties set in the file, we re-use the Core::Object property facility.
-class SlideObject : public Core::Object {
-    C_OBJECT_ABSTRACT(SlideObject);
-
+class SlideObject : public RefCounted<SlideObject> {
 public:
     virtual ~SlideObject() = default;
-
-    static ErrorOr<NonnullRefPtr<SlideObject>> parse_slide_object(JsonObject const& slide_object_json, NonnullRefPtr<GUI::Window> window);
-
-    // FIXME: Actually determine this from the file data.
-    bool is_visible_during_frame([[maybe_unused]] unsigned frame_number) const { return true; }
-
-    virtual void paint(Gfx::Painter&, Gfx::FloatSize display_scale) const;
-    ALWAYS_INLINE Gfx::IntRect transformed_bounding_box(Gfx::IntRect clip_rect, Gfx::FloatSize display_scale) const;
-
-    void set_rect(Gfx::IntRect rect) { m_rect = rect; }
-    Gfx::IntRect rect() const { return m_rect; }
+    static ErrorOr<NonnullRefPtr<SlideObject>> parse_slide_object(JsonObject const& slide_object_json);
+    virtual ErrorOr<HTMLElement> render(Presentation const&) const = 0;
 
 protected:
-    SlideObject();
+    SlideObject() = default;
 
+    virtual void set_property(StringView name, JsonValue);
+
+    HashMap<DeprecatedString, JsonValue> m_properties;
     Gfx::IntRect m_rect;
 };
 
 // Objects with a foreground color.
 class GraphicsObject : public SlideObject {
-    C_OBJECT_ABSTRACT(SlideObject);
-
 public:
     virtual ~GraphicsObject() = default;
 
-    void set_color(Gfx::Color color) { m_color = color; }
-    Gfx::Color color() const { return m_color; }
-
 protected:
-    GraphicsObject();
+    GraphicsObject() = default;
+    virtual void set_property(StringView name, JsonValue) override;
 
     // FIXME: Change the default color based on the color scheme
     Gfx::Color m_color { Gfx::Color::Black };
 };
 
-class Text : public GraphicsObject {
-    C_OBJECT(SlideObject);
-
+class Text final : public GraphicsObject {
 public:
-    Text();
+    Text() = default;
     virtual ~Text() = default;
 
-    virtual void paint(Gfx::Painter&, Gfx::FloatSize display_scale) const override;
+private:
+    virtual ErrorOr<HTMLElement> render(Presentation const&) const override;
+    virtual void set_property(StringView name, JsonValue) override;
 
-    void set_font(DeprecatedString font) { m_font = move(font); }
-    StringView font() const { return m_font; }
-    void set_font_size(int font_size) { m_font_size = font_size; }
-    int font_size() const { return m_font_size; }
-    void set_font_weight(unsigned font_weight) { m_font_weight = font_weight; }
-    unsigned font_weight() const { return m_font_weight; }
-    void set_text_alignment(Gfx::TextAlignment text_alignment) { m_text_alignment = text_alignment; }
-    Gfx::TextAlignment text_alignment() const { return m_text_alignment; }
-    void set_text(DeprecatedString text) { m_text = move(text); }
-    StringView text() const { return m_text; }
-
-protected:
     DeprecatedString m_text;
-    // The font family, technically speaking.
-    DeprecatedString m_font;
-    int m_font_size { 18 };
+    DeprecatedString m_font_family;
+    DeprecatedString m_text_align;
+    float m_font_size_in_pt { 18 };
     unsigned m_font_weight { Gfx::FontWeight::Regular };
-    Gfx::TextAlignment m_text_alignment { Gfx::TextAlignment::CenterLeft };
 };
 
-// How to scale an image object.
-enum class ImageScaling {
-    // Fit the image into the bounding box, preserving its aspect ratio.
-    FitSmallest,
-    // Match the bounding box in width and height exactly; this will change the image's aspect ratio if the aspect ratio of the bounding box is not exactly the same.
-    Stretch,
-    // Make the image fill the bounding box, preserving its aspect ratio. This means that the image will be cut off on the top and bottom or left and right, depending on which dimension is "too large".
-    FitLargest,
-};
-
-class Image : public SlideObject {
-    C_OBJECT(Image);
-
+class Image final : public SlideObject {
 public:
-    Image(NonnullRefPtr<ImageDecoderClient::Client>, NonnullRefPtr<GUI::Window>);
+    Image() = default;
     virtual ~Image() = default;
 
-    virtual void paint(Gfx::Painter&, Gfx::FloatSize display_scale) const override;
-
-    void set_image_path(DeprecatedString image_path)
-    {
-        m_image_path = move(image_path);
-        auto result = reload_image();
-        if (result.is_error())
-            GUI::MessageBox::show_error(m_window, DeprecatedString::formatted("Loading image {} failed: {}", m_image_path, result.error()));
-    }
-    StringView image_path() const { return m_image_path; }
-    void set_scaling(ImageScaling scaling) { m_scaling = scaling; }
-    ImageScaling scaling() const { return m_scaling; }
-    void set_scaling_mode(Gfx::Painter::ScalingMode scaling_mode) { m_scaling_mode = scaling_mode; }
-    Gfx::Painter::ScalingMode scaling_mode() const { return m_scaling_mode; }
-
-protected:
-    DeprecatedString m_image_path;
-    ImageScaling m_scaling { ImageScaling::FitSmallest };
-    Gfx::Painter::ScalingMode m_scaling_mode { Gfx::Painter::ScalingMode::SmoothPixels };
-
 private:
-    ErrorOr<void> reload_image();
+    DeprecatedString m_src;
+    StringView m_image_rendering;
 
-    RefPtr<Gfx::Bitmap> m_currently_loaded_image;
-    NonnullRefPtr<ImageDecoderClient::Client> m_client;
-    NonnullRefPtr<GUI::Window> m_window;
+    virtual ErrorOr<HTMLElement> render(Presentation const&) const override;
+    virtual void set_property(StringView name, JsonValue) override;
 };

--- a/Userland/Applications/Presenter/main.cpp
+++ b/Userland/Applications/Presenter/main.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,7 +15,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    // rpath is required to load .presenter files, unix, sendfd and recvfd are required to talk to ImageDecoder and WindowServer.
+    // rpath is required to load .presenter files, unix, sendfd and recvfd are required to talk to WindowServer and WebContent.
     TRY(Core::System::pledge("stdio rpath unix sendfd recvfd"));
 
     DeprecatedString file_to_load;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -106,7 +106,10 @@ void OutOfProcessWebView::paint_event(GUI::PaintEvent& event)
     if (auto* bitmap = m_client_state.has_usable_bitmap ? m_client_state.front_bitmap.bitmap.ptr() : m_backup_bitmap.ptr()) {
         painter.add_clip_rect(frame_inner_rect());
         painter.translate(frame_thickness(), frame_thickness());
-        painter.blit({ 0, 0 }, *bitmap, bitmap->rect());
+        if (m_content_scales_to_viewport)
+            painter.draw_scaled_bitmap(rect(), *bitmap, bitmap->rect());
+        else
+            painter.blit({ 0, 0 }, *bitmap, bitmap->rect());
         return;
     }
 
@@ -839,6 +842,11 @@ void OutOfProcessWebView::notify_server_did_get_accessibility_tree(DeprecatedStr
 {
     if (on_get_accessibility_tree)
         on_get_accessibility_tree(accessibility_tree);
+}
+
+void OutOfProcessWebView::set_content_scales_to_viewport(bool b)
+{
+    m_content_scales_to_viewport = b;
 }
 
 }

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -80,6 +80,10 @@ public:
     Gfx::ShareableBitmap take_screenshot() const;
     Gfx::ShareableBitmap take_document_screenshot();
 
+    // This is a hint that tells OOPWV that the content will scale to the viewport size.
+    // In practice, this means that OOPWV may render scaled stale versions of the content while resizing.
+    void set_content_scales_to_viewport(bool);
+
     Function<void(Gfx::IntPoint screen_position)> on_context_menu_request;
     Function<void(const AK::URL&, DeprecatedString const& target, unsigned modifiers)> on_link_click;
     Function<void(const AK::URL&, Gfx::IntPoint screen_position)> on_link_context_menu_request;
@@ -225,6 +229,8 @@ private:
 
     bool m_is_awaiting_response_for_input_event { false };
     Queue<InputEvent> m_pending_input_events;
+
+    bool m_content_scales_to_viewport { false };
 };
 
 }


### PR DESCRIPTION
This patch replaces the bespoke rendering engine in Presenter with a
simple pipeline that turns presentations into single-page HTML files.
The HTML is then loaded into an `OutOfProcessWebView`.
    
This achieves a number of things, most importantly:
- Access to all the CSS features supported by LibWeb
- Sandboxed, multi-process rendering
    
The code could be simplified a lot further, but I wanted to get the new
architecture in place without changing anything about the file format.

https://user-images.githubusercontent.com/5954907/211388189-01261489-d414-447a-a3f5-5af1399fdc1b.mp4

