### PR TITLE
LibWeb: Fix y position calculation for blocks with clearance

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -470,7 +470,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         margin_top = 0;
     }
 
-    place_block_level_element_in_normal_flow_vertically(box, current_y + box_state.border_box_top() + margin_top);
+    place_block_level_element_in_normal_flow_vertically(box, current_y + margin_top);
     place_block_level_element_in_normal_flow_horizontally(box, available_space);
 
     OwnPtr<FormattingContext> independent_formatting_context;
@@ -625,6 +625,8 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_vertically
     if ((computed_values.clear() == CSS::Clear::Right || computed_values.clear() == CSS::Clear::Both) && !child_box.is_flex_item())
         clear_floating_boxes(m_right_floats);
 
+    y += box_state.border_box_top();
+
     box_state.set_content_offset(CSSPixelPoint { box_state.offset.x(), y.value() });
 }
 
@@ -712,7 +714,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
         auto y = line_builder->y_for_float_to_be_inserted_here(box);
         box_state.set_content_y(y + box_state.margin_box_top());
     } else {
-        place_block_level_element_in_normal_flow_vertically(box, y + box_state.margin_box_top());
+        place_block_level_element_in_normal_flow_vertically(box, y + box_state.margin_top);
         place_block_level_element_in_normal_flow_horizontally(box, available_space);
     }
 


### PR DESCRIPTION
This change fixes problem that y position of blocks with clearance might not include border_top and padding_top by changing `place_block_level_element_in_normal_flow_vertically` to accept y position without `border_box_top` and adding it on the last step when clearance is already taken in account.

Bug reproducer:
```html
<style>
.a {
    border: 10px salmon solid;
    width: 50px;
    height: 50px;
    float: left;
}
.b {
    clear: both;
    border: 20px slateblue solid;
    width: 50px;
    height: 50px;
}
</style>
<div class="a"></div><div class="b"></div><div class="c"></div>
```