### PR TITLE
Kernel+LibCore: Make %sid path parsing not take ages

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -81,6 +81,7 @@ enum class NeedsBigProcessLock {
     S(futex, NeedsBigProcessLock::Yes)                      \
     S(get_dir_entries, NeedsBigProcessLock::Yes)            \
     S(get_process_name, NeedsBigProcessLock::Yes)           \
+    S(get_root_session_id, NeedsBigProcessLock::No)         \
     S(get_stack_bounds, NeedsBigProcessLock::No)            \
     S(get_thread_name, NeedsBigProcessLock::Yes)            \
     S(getcwd, NeedsBigProcessLock::No)                      \

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -448,6 +448,7 @@ public:
     ErrorOr<FlatPtr> sys$map_time_page();
     ErrorOr<FlatPtr> sys$jail_create(Userspace<Syscall::SC_jail_create_params*> user_params);
     ErrorOr<FlatPtr> sys$jail_attach(Userspace<Syscall::SC_jail_attach_params const*> user_params);
+    ErrorOr<FlatPtr> sys$get_root_session_id(pid_t force_sid);
 
     template<bool sockname, typename Params>
     ErrorOr<void> get_sock_or_peer_name(Params const&);


### PR DESCRIPTION
Before this patch, Core::SessionManagement::parse_path_with_sid() would figure out the root session ID by sifting through /sys/kernel/processes.

That file can take quite a while to generate (sometimes up to 40ms on my machine, which is a problem on its own!) and with no caching, many of our programs were effectively doing this multiple times on startup when unveiling something in /tmp/session/%sid/

While we should find ways to make generating /sys/kernel/processes fast again, this patch addresses the specific problem by introducing a new syscall: sys$get_root_session_id(). This extracts the root session ID by looking directly at the process table and takes <1ms instead of 40ms.

This cuts WebContent process startup time by ~100ms on my machine. :^)