### PR TITLE
LibJS: Use a work queue instead of the C++ stack for the GC mark phase

### DIFF
--- a/Userland/Libraries/LibJS/Tests/gc-deeply-nested-object-graph.js
+++ b/Userland/Libraries/LibJS/Tests/gc-deeply-nested-object-graph.js
@@ -1,0 +1,11 @@
+test("garbage collection of a deeply-nested object graph", () => {
+    let root = {};
+    let o = root;
+
+    for (let i = 0; i < 200_000; ++i) {
+        o.next = {};
+        o = o.next;
+    }
+
+    gc();
+});


### PR DESCRIPTION
This fixes an issue where we'd run out of C++ stack while traversing large GC heap graphs.