### PR TITLE
LibGUI: Lex INI files as Utf8

### DIFF
--- a/Userland/Libraries/LibGUI/INILexer.h
+++ b/Userland/Libraries/LibGUI/INILexer.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/StringView.h>
+#include <AK/Utf8View.h>
 
 namespace GUI {
 
@@ -57,11 +57,11 @@ public:
     Vector<IniToken> lex();
 
 private:
-    char peek(size_t offset = 0) const;
-    char consume();
+    u32 peek(size_t offset = 0) const;
+    u32 consume();
 
-    StringView m_input;
-    size_t m_index { 0 };
+    Utf8View m_input;
+    Utf8CodePointIterator m_iterator;
     IniPosition m_position { 0, 0 };
 };
 


### PR DESCRIPTION
Iterating byte by byte meant that the column positions assigned to INI tokens would be off if there were any multi-byte codepoints. Using a Utf8View means these positions refer to whole codepoints instead, and the column positions match what GUI::TextEditor expects. :^)

Fixes #12706.

![image](https://user-images.githubusercontent.com/222642/211680747-c17fd25f-7f94-4eed-9f90-df8c21a9bda6.png)
