### PR TITLE
HackStudio: Hide autocomplete popup when switching tabs

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1178,6 +1178,9 @@ void HackStudioWidget::set_current_editor_tab_widget(RefPtr<GUI::TabWidget> tab_
 
 void HackStudioWidget::set_current_editor_wrapper(RefPtr<EditorWrapper> editor_wrapper)
 {
+    if (m_current_editor_wrapper)
+        m_current_editor_wrapper->editor().hide_autocomplete();
+
     m_current_editor_wrapper = editor_wrapper;
     update_window_title();
     update_current_editor_title();

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -203,6 +203,7 @@ public:
 
     bool should_autocomplete_automatically() const { return m_autocomplete_timer; }
     void set_should_autocomplete_automatically(bool);
+    void hide_autocomplete();
 
     Optional<u32> const& substitution_code_point() const { return m_substitution_code_point; }
     void set_substitution_code_point(Optional<u32> code_point);
@@ -320,7 +321,6 @@ private:
     void try_update_autocomplete(Function<void()> callback = {});
     void force_update_autocomplete(Function<void()> callback = {});
     void hide_autocomplete_if_needed();
-    void hide_autocomplete();
 
     int icon_size() const { return 16; }
     int icon_padding() const { return 2; }


### PR DESCRIPTION
The bug in question:
![Peek 2023-01-10 20-10](https://user-images.githubusercontent.com/28801118/211709479-259aa43d-c5a9-431c-8c0a-397cf2c6f66b.gif)
