### PR TITLE
LibCore+Userland: Make Core::Timer::create_repeating() and create_single_shot() return ErrorOr

### DIFF
--- a/Tests/LibCore/TestLibCoreDeferredInvoke.cpp
+++ b/Tests/LibCore/TestLibCoreDeferredInvoke.cpp
@@ -12,10 +12,10 @@
 TEST_CASE(deferred_invoke)
 {
     Core::EventLoop event_loop;
-    auto reaper = Core::Timer::create_single_shot(250, [] {
+    auto reaper = MUST(Core::Timer::create_single_shot(250, [] {
         warnln("I waited for the deferred_invoke to happen, but it never did!");
         VERIFY_NOT_REACHED();
-    });
+    }));
 
     Core::deferred_invoke([&event_loop] {
         event_loop.quit(0);

--- a/Tests/LibCore/TestLibCoreFileWatcher.cpp
+++ b/Tests/LibCore/TestLibCoreFileWatcher.cpp
@@ -39,21 +39,21 @@ TEST_CASE(file_watcher_child_events)
         event_count++;
     };
 
-    auto timer1 = Core::Timer::create_single_shot(500, [&] {
+    auto timer1 = MUST(Core::Timer::create_single_shot(500, [&] {
         int rc = creat("/tmp/testfile", 0777);
         EXPECT_NE(rc, -1);
-    });
+    }));
     timer1->start();
 
-    auto timer2 = Core::Timer::create_single_shot(1000, [&] {
+    auto timer2 = MUST(Core::Timer::create_single_shot(1000, [&] {
         int rc = unlink("/tmp/testfile");
         EXPECT_NE(rc, -1);
-    });
+    }));
     timer2->start();
 
-    auto catchall_timer = Core::Timer::create_single_shot(2000, [&] {
+    auto catchall_timer = MUST(Core::Timer::create_single_shot(2000, [&] {
         VERIFY_NOT_REACHED();
-    });
+    }));
     catchall_timer->start();
 
     event_loop.exec();

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -233,7 +233,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             GUI::Application::the()->quit();
     };
 
-    auto update_ui_timer = Core::Timer::create_single_shot(10, [&] {
+    auto update_ui_timer = TRY(Core::Timer::create_single_shot(10, [&] {
         results_container.remove_all_children();
         results_layout.set_margins(app_state.visible_result_count ? GUI::Margins { 4, 0, 0, 0 } : GUI::Margins { 0 });
 
@@ -251,7 +251,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         mark_selected_item();
         Core::deferred_invoke([&] { window->resize(GUI::Desktop::the().rect().width() / 3, {}); });
-    });
+    }));
 
     db.on_new_results = [&](auto results) {
         if (results.is_empty())

--- a/Userland/Applications/ClockSettings/ClockSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/ClockSettingsWidget.cpp
@@ -89,7 +89,7 @@ ClockSettingsWidget::ClockSettingsWidget()
 
     m_clock_preview_update_timer = Core::Timer::create_repeating(1000, [&]() {
         update_clock_preview();
-    });
+    }).release_value_but_fixme_should_propagate_errors();
     m_clock_preview_update_timer->start();
     update_clock_preview();
 }

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -250,7 +250,7 @@ void MonitorSettingsWidget::apply_settings()
                 if (seconds_until_revert <= 0) {
                     box->close();
                 }
-            });
+            }).release_value_but_fixme_should_propagate_errors();
             revert_timer->start();
 
             // If the user selects "No", closes the window or the window gets closed by the 10 seconds timer, revert the changes.

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -31,8 +31,7 @@
 #include <unistd.h>
 
 HexEditor::HexEditor()
-    : m_blink_timer(Core::Timer::construct())
-    , m_document(make<HexDocumentMemory>(ByteBuffer::create_zeroed(0).release_value_but_fixme_should_propagate_errors()))
+    : m_document(make<HexDocumentMemory>(ByteBuffer::create_zeroed(0).release_value_but_fixme_should_propagate_errors()))
 {
     set_should_hide_unnecessary_scrollbars(true);
     set_focus_policy(GUI::FocusPolicy::StrongFocus);
@@ -42,11 +41,10 @@ HexEditor::HexEditor()
     set_foreground_role(ColorRole::BaseText);
     vertical_scrollbar().set_step(line_height());
 
-    m_blink_timer->set_interval(500);
-    m_blink_timer->on_timeout = [this]() {
+    m_blink_timer = Core::Timer::create_repeating(500, [this]() {
         m_cursor_blink_active = !m_cursor_blink_active;
         update();
-    };
+    }).release_value_but_fixme_should_propagate_errors();
     m_blink_timer->start();
 }
 

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -85,7 +85,7 @@ private:
     size_t m_position { 0 };
     bool m_cursor_at_low_nibble { false };
     EditMode m_edit_mode { Hex };
-    NonnullRefPtr<Core::Timer> m_blink_timer;
+    RefPtr<Core::Timer> m_blink_timer;
     bool m_cursor_blink_active { false };
     NonnullOwnPtr<HexDocument> m_document;
     GUI::UndoStack m_undo_stack;

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -24,7 +24,7 @@
 namespace ImageViewer {
 
 ViewWidget::ViewWidget()
-    : m_timer(Core::Timer::construct())
+    : m_timer(Core::Timer::try_create().release_value_but_fixme_should_propagate_errors())
 {
     set_fill_with_background_color(false);
 }

--- a/Userland/Applications/MouseSettings/HighlightPreviewWidget.cpp
+++ b/Userland/Applications/MouseSettings/HighlightPreviewWidget.cpp
@@ -37,10 +37,10 @@ ErrorOr<void> HighlightPreviewWidget::reload_cursor()
     m_cursor_params = Gfx::CursorParams::parse_from_filename(cursor_path, m_cursor_bitmap->rect().center()).constrained(*m_cursor_bitmap);
     // Setup cursor animation:
     if (m_cursor_params.frames() > 1 && m_cursor_params.frame_ms() > 0) {
-        m_frame_timer = Core::Timer::create_repeating(m_cursor_params.frame_ms(), [&] {
+        m_frame_timer = TRY(Core::Timer::create_repeating(m_cursor_params.frame_ms(), [&] {
             m_cursor_frame = (m_cursor_frame + 1) % m_cursor_params.frames();
             update();
-        });
+        }));
         m_frame_timer->start();
     } else {
         m_frame_timer = nullptr;

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -47,10 +47,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(840, 600);
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto main_widget_updater = Core::Timer::construct(static_cast<int>((1 / 30.0) * 1000), [&] {
+    auto main_widget_updater = TRY(Core::Timer::create_repeating(static_cast<int>((1 / 30.0) * 1000), [&] {
         if (window->is_active())
             Core::EventLoop::current().post_event(main_widget, make<Core::CustomEvent>(0));
-    });
+    }));
     main_widget_updater->start();
 
     auto& file_menu = window->add_menu("&File");

--- a/Userland/Applications/PixelPaint/Filters/Filter.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Filter.cpp
@@ -17,7 +17,7 @@ Filter::Filter(ImageEditor* editor)
     , m_update_timer(Core::Timer::create_single_shot(100, [&] {
         if (on_settings_change)
             on_settings_change();
-    }))
+    }).release_value_but_fixme_should_propagate_errors())
 {
     m_update_timer->set_active(false);
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -51,7 +51,7 @@ ImageEditor::ImageEditor(NonnullRefPtr<Image> image)
         m_marching_ants_offset %= (marching_ant_length * 2);
         if (!m_image->selection().is_empty() || m_image->selection().in_interactive_selection())
             update();
-    });
+    }).release_value_but_fixme_should_propagate_errors();
     m_marching_ants_timer->start();
 }
 

--- a/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
@@ -22,11 +22,9 @@ namespace PixelPaint {
 
 SprayTool::SprayTool()
 {
-    m_timer = Core::Timer::construct();
-    m_timer->on_timeout = [&]() {
+    m_timer = Core::Timer::create_repeating(200, [&]() {
         paint_it();
-    };
-    m_timer->set_interval(200);
+    }).release_value_but_fixme_should_propagate_errors();
 }
 
 static double nrand()

--- a/Userland/Applications/PixelPaint/Tools/TextTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.cpp
@@ -36,11 +36,9 @@ TextTool::TextTool()
     m_text_editor->set_wrapping_mode(GUI::TextEditor::WrappingMode::NoWrap);
     m_selected_font = Gfx::FontDatabase::default_font();
     m_text_editor->set_font(m_selected_font);
-    m_cursor_blink_timer = Core::Timer::construct();
-    m_cursor_blink_timer->on_timeout = [&]() {
+    m_cursor_blink_timer = Core::Timer::create_repeating(500, [&]() {
         m_cursor_blink_state = !m_cursor_blink_state;
-    };
-    m_cursor_blink_timer->set_interval(500);
+    }).release_value_but_fixme_should_propagate_errors();
 }
 
 void TextTool::on_tool_deactivation()

--- a/Userland/Applications/SoundPlayer/PlaybackManager.cpp
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.cpp
@@ -11,11 +11,11 @@ PlaybackManager::PlaybackManager(NonnullRefPtr<Audio::ConnectionToServer> connec
     : m_connection(connection)
 {
     // FIXME: The buffer enqueuing should happen on a wholly independent second thread.
-    m_timer = Core::Timer::construct(PlaybackManager::update_rate_ms, [&]() {
+    m_timer = Core::Timer::create_repeating(PlaybackManager::update_rate_ms, [&]() {
         if (!m_loader)
             return;
         next_buffer();
-    });
+    }).release_value_but_fixme_should_propagate_errors();
     m_device_sample_rate = connection->get_sample_rate();
 }
 

--- a/Userland/Applications/SoundPlayer/PlaybackManager.cpp
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.cpp
@@ -16,7 +16,6 @@ PlaybackManager::PlaybackManager(NonnullRefPtr<Audio::ConnectionToServer> connec
             return;
         next_buffer();
     });
-    m_timer->stop();
     m_device_sample_rate = connection->get_sample_rate();
 }
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -64,8 +64,8 @@ public:
 
 private:
     InfinitelyScrollableTableView()
-        : m_horizontal_scroll_end_timer(Core::Timer::construct())
-        , m_vertical_scroll_end_timer(Core::Timer::construct())
+        : m_horizontal_scroll_end_timer(Core::Timer::try_create().release_value_but_fixme_should_propagate_errors())
+        , m_vertical_scroll_end_timer(Core::Timer::try_create().release_value_but_fixme_should_propagate_errors())
     {
     }
     virtual void did_scroll() override;

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -132,6 +132,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
             1000, [this] {
                 update_models();
             });
+        m_update_timer->start();
 
         update_models();
     };

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
@@ -110,6 +110,7 @@ ProcessMemoryMapWidget::ProcessMemoryMapWidget()
 
     m_table_view->set_key_column_and_sort_order(0, GUI::SortOrder::Ascending);
     m_timer = add<Core::Timer>(1000, [this] { refresh(); });
+    m_timer->start();
 }
 
 void ProcessMemoryMapWidget::set_pid(pid_t pid)

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -82,8 +82,10 @@ ThreadStackWidget::ThreadStackWidget()
 void ThreadStackWidget::show_event(GUI::ShowEvent&)
 {
     refresh();
-    if (!m_timer)
+    if (!m_timer) {
         m_timer = add<Core::Timer>(1000, [this] { refresh(); });
+        m_timer->start();
+    }
 }
 
 void ThreadStackWidget::hide_event(GUI::HideEvent&)

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -328,6 +328,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
     update_stats();
     auto& refresh_timer = window->add<Core::Timer>(frequency * 1000, move(update_stats));
+    refresh_timer.start();
 
     auto selected_id = [&](ProcessModel::Column column) -> pid_t {
         if (process_table_view.selection().is_empty())

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -453,9 +453,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/tmp/session/%sid/portal/config", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto modified_state_check_timer = Core::Timer::create_repeating(500, [&] {
+    auto modified_state_check_timer = TRY(Core::Timer::create_repeating(500, [&] {
         window->set_modified(tty_has_foreground_process() || shell_child_process_count() > 0);
-    });
+    }));
 
     listener.on_confirm_close_changed = [&](bool confirm_close) {
         if (confirm_close) {

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -66,17 +66,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     (void)TRY(advice_widget->try_set_layout<GUI::VerticalBoxLayout>());
     advice_widget->layout()->set_spacing(0);
 
-    auto advice_timer = TRY(Core::Timer::try_create());
-    advice_timer->set_interval(15'000);
-    advice_timer->set_single_shot(true);
-    advice_timer->on_timeout = [&] {
+    auto advice_timer = TRY(Core::Timer::create_single_shot(15'000, [&] {
         window->move_to_front();
         advice_window->move_to_front();
         catdog_widget->set_roaming(false);
         advice_window->move_to(window->x() - advice_window->width() / 2, window->y() - advice_window->height());
         advice_window->show();
         advice_window->set_always_on_top();
-    };
+    }));
     advice_timer->start();
 
     advice_widget->on_dismiss = [&] {

--- a/Userland/Demos/WidgetGallery/DemoWizardDialog.cpp
+++ b/Userland/Demos/WidgetGallery/DemoWizardDialog.cpp
@@ -41,25 +41,27 @@ DemoWizardDialog::DemoWizardDialog(GUI::Window* parent_window)
                    .release_value_but_fixme_should_propagate_errors();
     m_page_2->body_widget().load_from_gml(demo_wizard_page_2_gml).release_value_but_fixme_should_propagate_errors();
     m_page_2_progressbar = m_page_2->body_widget().find_descendant_of_type_named<GUI::Progressbar>("page_2_progressbar");
-    m_page_2_timer = Core::Timer::try_create(this).release_value_but_fixme_should_propagate_errors();
+    m_page_2_timer = Core::Timer::create_repeating(
+        100, [&]() {
+            if (m_page_2_progress_value < 100)
+                m_page_2_progress_value++;
+            m_page_2_progressbar->set_value(m_page_2_progress_value);
+
+            // Go to final page on progress completion
+            if (m_page_2_progress_value == 100) {
+                m_page_2_progress_value = 0;
+                replace_page(*m_back_page);
+            }
+        },
+        this)
+                         .release_value_but_fixme_should_propagate_errors();
     m_page_2->on_page_enter = [&]() {
         m_page_2_progress_value = 0;
-        m_page_2_timer->restart(100);
+        m_page_2_timer->restart();
     };
     m_page_2->on_page_leave = [&]() {
         m_page_2_progress_value = 0;
         m_page_2_timer->stop();
-    };
-    m_page_2_timer->on_timeout = [&]() {
-        if (m_page_2_progress_value < 100)
-            m_page_2_progress_value++;
-        m_page_2_progressbar->set_value(m_page_2_progress_value);
-
-        // Go to final page on progress completion
-        if (m_page_2_progress_value == 100) {
-            m_page_2_progress_value = 0;
-            replace_page(*m_back_page);
-        }
     };
     // Don't set a on_next_page handler for page 2 as we automatically navigate to the final page on progress completion
 

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -786,7 +786,7 @@ void Editor::create_tokens_info_timer()
     m_tokens_info_timer = Core::Timer::create_repeating((int)token_info_timer_interval_ms, [this] {
         on_token_info_timer_tick();
         m_tokens_info_timer->stop();
-    });
+    }).release_value_but_fixme_should_propagate_errors();
     m_tokens_info_timer->start();
 }
 

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -329,6 +329,7 @@ static bool prompt_to_stop_profiling(pid_t pid, DeprecatedString const& process_
     auto update_timer = Core::Timer::construct(100, [&] {
         timer_label.set_text(DeprecatedString::formatted("{:.1} seconds", static_cast<float>(clock.elapsed()) / 1000.0f));
     });
+    update_timer->start();
 
     auto& stop_button = widget->add<GUI::Button>("Stop");
     stop_button.set_fixed_size(140, 22);

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -326,9 +326,9 @@ static bool prompt_to_stop_profiling(pid_t pid, DeprecatedString const& process_
     auto& timer_label = widget->add<GUI::Label>("...");
     Core::ElapsedTimer clock;
     clock.start();
-    auto update_timer = Core::Timer::construct(100, [&] {
+    auto update_timer = Core::Timer::create_repeating(100, [&] {
         timer_label.set_text(DeprecatedString::formatted("{:.1} seconds", static_cast<float>(clock.elapsed()) / 1000.0f));
-    });
+    }).release_value_but_fixme_should_propagate_errors();
     update_timer->start();
 
     auto& stop_button = widget->add<GUI::Button>("Stop");

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -28,7 +28,7 @@ Game::Game()
     m_delay_timer = Core::Timer::create_single_shot(0, [this] {
         dbgln_if(HEARTS_DEBUG, "Continuing game after delay...");
         advance_game();
-    });
+    }).release_value_but_fixme_should_propagate_errors();
 
     constexpr int card_overlap = 20;
     constexpr int outer_border_size = 15;
@@ -155,7 +155,7 @@ void Game::show_score_card(bool game_over)
     if (!m_players[0].is_human) {
         close_timer = Core::Timer::create_single_shot(2000, [&] {
             score_dialog->close();
-        });
+        }).release_value_but_fixme_should_propagate_errors();
         close_timer->start();
     }
 
@@ -236,7 +236,7 @@ void Game::start_animation(NonnullRefPtrVector<Card> cards, Gfx::IntPoint end, F
     m_animation_delay_timer = Core::Timer::create_single_shot(initial_delay_ms, [&] {
         m_animation_playing = true;
         start_timer(10);
-    });
+    }).release_value_but_fixme_should_propagate_errors();
     m_animation_delay_timer->start();
 }
 

--- a/Userland/Games/MasterWord/WordGame.cpp
+++ b/Userland/Games/MasterWord/WordGame.cpp
@@ -25,7 +25,7 @@ REGISTER_WIDGET(MasterWord, WordGame)
 namespace MasterWord {
 
 WordGame::WordGame()
-    : m_clear_message_timer(Core::Timer::create_single_shot(5000, [this] { clear_message(); }))
+    : m_clear_message_timer(Core::Timer::create_single_shot(5000, [this] { clear_message(); }).release_value_but_fixme_should_propagate_errors())
 {
     read_words();
     m_num_letters = Config::read_i32("MasterWord"sv, ""sv, "word_length"sv, 5);

--- a/Userland/Games/Minesweeper/Field.cpp
+++ b/Userland/Games/Minesweeper/Field.cpp
@@ -140,7 +140,8 @@ void Field::initialize()
             ++m_time_elapsed;
             m_time_label.set_text(human_readable_digital_time(m_time_elapsed));
         },
-        this);
+        this)
+                  .release_value_but_fixme_should_propagate_errors();
 
     // Square with mine will be filled with background color later, i.e. red
     m_mine_palette.set_color(Gfx::ColorRole::Base, Color::from_rgb(0xff4040));

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -111,7 +111,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     uint64_t seconds_elapsed = 0;
 
-    auto timer = Core::Timer::create_repeating(1000, [&]() {
+    auto timer = TRY(Core::Timer::create_repeating(1000, [&]() {
         ++seconds_elapsed;
 
         uint64_t hours = seconds_elapsed / 3600;
@@ -119,7 +119,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         uint64_t seconds = seconds_elapsed % 60;
 
         statusbar.set_text(2, DeprecatedString::formatted("Time: {:02}:{:02}:{:02}", hours, minutes, seconds));
-    });
+    }));
 
     game.on_game_start = [&]() {
         seconds_elapsed = 0;

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -158,11 +158,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     uint64_t seconds_elapsed = 0;
 
-    auto timer = Core::Timer::create_repeating(1000, [&]() {
+    auto timer = TRY(Core::Timer::create_repeating(1000, [&]() {
         ++seconds_elapsed;
 
         statusbar.set_text(2, DeprecatedString::formatted("Time: {}", format_seconds(seconds_elapsed)));
-    });
+    }));
 
     game.on_game_start = [&]() {
         seconds_elapsed = 0;

--- a/Userland/Libraries/LibCore/Debounce.h
+++ b/Userland/Libraries/LibCore/Debounce.h
@@ -20,7 +20,7 @@ auto debounce(TFunction function, int timeout)
             timer->stop();
             timer->on_timeout = move(apply_function);
         } else {
-            timer = Core::Timer::create_single_shot(timeout, move(apply_function));
+            timer = Core::Timer::create_single_shot(timeout, move(apply_function)).release_value_but_fixme_should_propagate_errors();
         }
         timer->start();
     };

--- a/Userland/Libraries/LibCore/Timer.cpp
+++ b/Userland/Libraries/LibCore/Timer.cpp
@@ -17,8 +17,8 @@ Timer::Timer(Object* parent)
 Timer::Timer(int interval_ms, Function<void()>&& timeout_handler, Object* parent)
     : Object(parent)
     , on_timeout(move(timeout_handler))
+    , m_interval_ms(interval_ms)
 {
-    start(interval_ms);
 }
 
 void Timer::start()

--- a/Userland/Libraries/LibCore/Timer.h
+++ b/Userland/Libraries/LibCore/Timer.h
@@ -16,9 +16,9 @@ class Timer final : public Object {
     C_OBJECT(Timer);
 
 public:
-    static NonnullRefPtr<Timer> create_repeating(int interval_ms, Function<void()>&& timeout_handler, Object* parent = nullptr)
+    static ErrorOr<NonnullRefPtr<Timer>> create_repeating(int interval_ms, Function<void()>&& timeout_handler, Object* parent = nullptr)
     {
-        auto timer = adopt_ref(*new Timer(interval_ms, move(timeout_handler), parent));
+        auto timer = TRY(adopt_nonnull_ref_or_enomem(new Timer(interval_ms, move(timeout_handler), parent)));
         timer->stop();
         return timer;
     }

--- a/Userland/Libraries/LibCore/Timer.h
+++ b/Userland/Libraries/LibCore/Timer.h
@@ -22,9 +22,9 @@ public:
         timer->stop();
         return timer;
     }
-    static NonnullRefPtr<Timer> create_single_shot(int interval_ms, Function<void()>&& timeout_handler, Object* parent = nullptr)
+    static ErrorOr<NonnullRefPtr<Timer>> create_single_shot(int interval_ms, Function<void()>&& timeout_handler, Object* parent = nullptr)
     {
-        auto timer = adopt_ref(*new Timer(interval_ms, move(timeout_handler), parent));
+        auto timer = TRY(adopt_nonnull_ref_or_enomem(new Timer(interval_ms, move(timeout_handler), parent)));
         timer->set_single_shot(true);
         timer->stop();
         return timer;

--- a/Userland/Libraries/LibCore/Timer.h
+++ b/Userland/Libraries/LibCore/Timer.h
@@ -18,15 +18,12 @@ class Timer final : public Object {
 public:
     static ErrorOr<NonnullRefPtr<Timer>> create_repeating(int interval_ms, Function<void()>&& timeout_handler, Object* parent = nullptr)
     {
-        auto timer = TRY(adopt_nonnull_ref_or_enomem(new Timer(interval_ms, move(timeout_handler), parent)));
-        timer->stop();
-        return timer;
+        return adopt_nonnull_ref_or_enomem(new Timer(interval_ms, move(timeout_handler), parent));
     }
     static ErrorOr<NonnullRefPtr<Timer>> create_single_shot(int interval_ms, Function<void()>&& timeout_handler, Object* parent = nullptr)
     {
         auto timer = TRY(adopt_nonnull_ref_or_enomem(new Timer(interval_ms, move(timeout_handler), parent)));
         timer->set_single_shot(true);
-        timer->stop();
         return timer;
     }
 

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -95,11 +95,11 @@ Application::Application(int argc, char** argv, Core::EventLoop::MakeInspectable
 
     m_tooltip_show_timer = Core::Timer::create_single_shot(700, [this] {
         request_tooltip_show();
-    });
+    }).release_value_but_fixme_should_propagate_errors();
 
     m_tooltip_hide_timer = Core::Timer::create_single_shot(50, [this] {
         tooltip_hide_timer_did_fire();
-    });
+    }).release_value_but_fixme_should_propagate_errors();
 }
 
 static bool s_in_teardown;

--- a/Userland/Libraries/LibGUI/ImageWidget.cpp
+++ b/Userland/Libraries/LibGUI/ImageWidget.cpp
@@ -16,7 +16,7 @@ REGISTER_WIDGET(GUI, ImageWidget)
 namespace GUI {
 
 ImageWidget::ImageWidget(StringView)
-    : m_timer(Core::Timer::construct())
+    : m_timer(Core::Timer::try_create().release_value_but_fixme_should_propagate_errors())
 
 {
     set_frame_thickness(0);

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -2265,7 +2265,7 @@ void TextEditor::set_should_autocomplete_automatically(bool value)
         m_autocomplete_timer = Core::Timer::create_single_shot(m_automatic_autocomplete_delay_ms, [this] {
             if (m_autocomplete_box && !m_autocomplete_box->is_visible())
                 try_show_autocomplete(UserRequestedAutocomplete::No);
-        });
+        }).release_value_but_fixme_should_propagate_errors();
         return;
     }
 

--- a/Userland/Libraries/LibIPC/Connection.cpp
+++ b/Userland/Libraries/LibIPC/Connection.cpp
@@ -27,7 +27,7 @@ ConnectionBase::ConnectionBase(IPC::Stub& local_stub, NonnullOwnPtr<Core::Stream
     , m_local_endpoint_magic(local_endpoint_magic)
     , m_deferred_invoker(make<CoreEventLoopDeferredInvoker>())
 {
-    m_responsiveness_timer = Core::Timer::create_single_shot(3000, [this] { may_have_become_unresponsive(); });
+    m_responsiveness_timer = Core::Timer::create_single_shot(3000, [this] { may_have_become_unresponsive(); }).release_value_but_fixme_should_propagate_errors();
 }
 
 void ConnectionBase::set_deferred_invoker(NonnullOwnPtr<DeferredInvoker> deferred_invoker)

--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -144,7 +144,7 @@ void TLSv12::setup_connection()
                     // Extend the timer, we are too slow.
                     m_handshake_timeout_timer->restart(m_max_wait_time_for_handshake_in_seconds * 1000);
                 }
-            });
+            }).release_value_but_fixme_should_propagate_errors();
         auto packet = build_hello();
         write_packet(packet);
         write_into_socket();

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -33,16 +33,9 @@ PlaybackManager::PlaybackManager(Core::Object& event_handler, NonnullOwnPtr<Demu
     , m_selected_video_track(video_track)
     , m_decoder(move(decoder))
     , m_frame_queue(make<VideoFrameQueue>())
-    , m_present_timer(Core::Timer::construct())
-    , m_decode_timer(Core::Timer::construct())
 {
-    m_present_timer->set_single_shot(true);
-    m_present_timer->set_interval(0);
-    m_present_timer->on_timeout = [&] { update_presented_frame(); };
-
-    m_decode_timer->set_single_shot(true);
-    m_decode_timer->set_interval(0);
-    m_decode_timer->on_timeout = [&] { on_decode_timer(); };
+    m_present_timer = Core::Timer::create_single_shot(0, [&] { update_presented_frame(); }).release_value_but_fixme_should_propagate_errors();
+    m_decode_timer = Core::Timer::create_single_shot(0, [&] { on_decode_timer(); }).release_value_but_fixme_should_propagate_errors();
 }
 
 void PlaybackManager::set_playback_status(PlaybackStatus status)

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -155,10 +155,10 @@ private:
     NonnullOwnPtr<VideoFrameQueue> m_frame_queue;
     Optional<FrameQueueItem> m_next_frame;
 
-    NonnullRefPtr<Core::Timer> m_present_timer;
+    RefPtr<Core::Timer> m_present_timer;
     unsigned m_decoding_buffer_time_ms = 16;
 
-    NonnullRefPtr<Core::Timer> m_decode_timer;
+    RefPtr<Core::Timer> m_decode_timer;
 
     u64 m_skipped_frames;
 };

--- a/Userland/Libraries/LibWeb/Platform/TimerSerenity.cpp
+++ b/Userland/Libraries/LibWeb/Platform/TimerSerenity.cpp
@@ -16,7 +16,7 @@ NonnullRefPtr<TimerSerenity> TimerSerenity::create()
 }
 
 TimerSerenity::TimerSerenity()
-    : m_timer(Core::Timer::construct())
+    : m_timer(Core::Timer::try_create().release_value_but_fixme_should_propagate_errors())
 {
     m_timer->on_timeout = [this] {
         if (on_timeout)

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -177,7 +177,8 @@ void Mixer::request_setting_sync()
                 if (auto result = m_config->sync(); result.is_error())
                     dbgln("Failed to write audio mixer config: {}", result.error());
             },
-            this);
+            this)
+                                   .release_value_but_fixme_should_propagate_errors();
         m_config_write_timer->start();
     }
 }

--- a/Userland/Services/ConfigServer/ConnectionFromClient.cpp
+++ b/Userland/Services/ConfigServer/ConnectionFromClient.cpp
@@ -76,7 +76,7 @@ static Core::ConfigFile& ensure_domain_config(DeprecatedString const& domain)
 
 ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<Core::Stream::LocalSocket> client_socket, int client_id)
     : IPC::ConnectionFromClient<ConfigClientEndpoint, ConfigServerEndpoint>(*this, move(client_socket), client_id)
-    , m_sync_timer(Core::Timer::create_single_shot(s_disk_sync_delay_ms, [this]() { sync_dirty_domains_to_disk(); }))
+    , m_sync_timer(Core::Timer::create_single_shot(s_disk_sync_delay_ms, [this]() { sync_dirty_domains_to_disk(); }).release_value_but_fixme_should_propagate_errors())
 {
     s_connections.set(client_id, *this);
 }

--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -139,7 +139,8 @@ DHCPv4Client::DHCPv4Client(Vector<DeprecatedString> interfaces_with_dhcp_enabled
     }
 
     m_check_timer = Core::Timer::create_repeating(
-        1000, [this] { try_discover_ifs(); }, this);
+        1000, [this] { try_discover_ifs(); }, this)
+                        .release_value_but_fixme_should_propagate_errors();
 
     m_check_timer->start();
 

--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -261,7 +261,8 @@ void DHCPv4Client::handle_ack(DHCPv4Packet const& packet, ParsedDHCPv4Options co
             transaction->has_ip = false;
             dhcp_discover(interface);
         },
-        this);
+        this)
+        .release_value_but_fixme_should_propagate_errors();
 
     Optional<IPv4Address> gateway;
     if (auto routers = options.get_many<IPv4Address>(DHCPOption::Router, 1); !routers.is_empty())
@@ -288,7 +289,8 @@ void DHCPv4Client::handle_nak(DHCPv4Packet const& packet, ParsedDHCPv4Options co
         [this, iface = InterfaceDescriptor { iface }] {
             dhcp_discover(iface);
         },
-        this);
+        this)
+        .release_value_but_fixme_should_propagate_errors();
 }
 
 void DHCPv4Client::process_incoming(DHCPv4Packet const& packet)

--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -203,7 +203,7 @@ decltype(auto) get_or_create_connection(auto& cache, URL const& url, auto& job, 
         sockets_for_url.append(make<ConnectionType>(
             socket_result.release_value(),
             typename ConnectionType::QueueType {},
-            Core::Timer::create_single_shot(ConnectionKeepAliveTimeMilliseconds, nullptr)));
+            Core::Timer::create_single_shot(ConnectionKeepAliveTimeMilliseconds, nullptr).release_value_but_fixme_should_propagate_errors()));
         sockets_for_url.last().proxy = move(proxy);
         did_add_new_connection = true;
     }

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -35,6 +35,7 @@ ClockWidget::ClockWidget()
             set_tooltip(Core::DateTime::now().to_deprecated_string("%Y-%m-%d"sv));
         }
     });
+    m_timer->start();
 
     m_calendar_window = add<GUI::Window>(window());
     m_calendar_window->set_window_type(GUI::WindowType::Popup);

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -55,14 +55,16 @@ Compositor::Compositor()
         [this] {
             compose();
         },
-        this);
+        this)
+                          .release_value_but_fixme_should_propagate_errors();
 
     m_immediate_compose_timer = Core::Timer::create_single_shot(
         0,
         [this] {
             compose();
         },
-        this);
+        this)
+                                    .release_value_but_fixme_should_propagate_errors();
 
     init_bitmaps();
 }
@@ -1589,7 +1591,8 @@ void Compositor::start_window_stack_switch_overlay_timer()
         [this] {
             remove_window_stack_switch_overlays();
         },
-        this);
+        this)
+                                       .release_value_but_fixme_should_propagate_errors();
     m_stack_switch_overlay_timer->start();
 }
 

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -48,7 +48,6 @@ Compositor::Compositor()
         1000 / 60, [this] {
             notify_display_links();
         });
-    m_display_link_notify_timer->stop();
 
     m_compose_timer = Core::Timer::create_single_shot(
         1000 / 60,
@@ -57,6 +56,7 @@ Compositor::Compositor()
         },
         this)
                           .release_value_but_fixme_should_propagate_errors();
+    m_compose_timer->start();
 
     m_immediate_compose_timer = Core::Timer::create_single_shot(
         0,
@@ -65,6 +65,7 @@ Compositor::Compositor()
         },
         this)
                                     .release_value_but_fixme_should_propagate_errors();
+    m_compose_timer->start();
 
     init_bitmaps();
 }

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -240,7 +240,7 @@ void ConnectionFromClient::flash_menubar_menu(i32 window_id, i32 menu_id)
                 return;
             weak_window->menubar().flash_menu(nullptr);
             weak_window->frame().invalidate_menubar();
-        });
+        }).release_value_but_fixme_should_propagate_errors();
         m_flashed_menu_timer->start();
     } else if (m_flashed_menu_timer) {
         m_flashed_menu_timer->restart();
@@ -1134,7 +1134,7 @@ void ConnectionFromClient::may_have_become_unresponsive()
     async_ping();
     m_ping_timer = Core::Timer::create_single_shot(1000, [this] {
         set_unresponsive(true);
-    });
+    }).release_value_but_fixme_should_propagate_errors();
     m_ping_timer->start();
 }
 

--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -537,7 +537,7 @@ void Menu::start_activation_animation(MenuItem& item)
 
         float opacity = (float)animation->step / 10.0f;
         animation->window->set_opacity(opacity);
-    });
+    }).release_value_but_fixme_should_propagate_errors();
     timer->start();
 }
 

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -948,12 +948,12 @@ void WindowFrame::handle_menu_mouse_event(Menu& menu, MouseEvent const& event)
 void WindowFrame::start_flash_animation()
 {
     if (!m_flash_timer) {
-        m_flash_timer = Core::Timer::construct(100, [this] {
+        m_flash_timer = Core::Timer::create_repeating(100, [this] {
             VERIFY(m_flash_counter);
             invalidate_titlebar();
             if (!--m_flash_counter)
                 m_flash_timer->stop();
-        });
+        }).release_value_but_fixme_should_propagate_errors();
     }
     m_flash_counter = 8;
     m_flash_timer->start();

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1857,9 +1857,9 @@ ErrorOr<Vector<Line::CompletionSuggestion>> Shell::complete_via_program_itself(s
         true);
 
     Vector<Line::CompletionSuggestion> suggestions;
-    auto timer = Core::Timer::create_single_shot(300, [&] {
+    auto timer = TRY(Core::Timer::create_single_shot(300, [&] {
         Core::EventLoop::current().quit(1);
-    });
+    }));
     timer->start();
 
     // Restrict the process to effectively readonly access to the FS.

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -700,7 +700,7 @@ static void load_page_for_screenshot_and_exit(HeadlessBrowserPageClient& page_cl
             MUST(output_file->write(image_buffer.bytes()));
 
             exit(0);
-        });
+        }).release_value_but_fixme_should_propagate_errors();
 
     timer->start();
 }


### PR DESCRIPTION
_Yay for ErrorOr!_

The main change here is that in the title: making `Core::Timer::create_foo()` return ErrorOr. Then, make use of those wherever possible.

While doing this, I noticed that auto-starting a Timer wasn't wanted in the majority of cases, and those that did want it often manually started it anyway. So, they now don't start unless you tell them to. This seems a lot more intuitive to me, hopefully it is to other people as well. :sweat_smile:

Oh and this adds a bunch of FIXMEs so Andreas won't get bored. :wink: 