### PR TITLE
LibGUI: Allow strings to be uppercased, lowercased and snakecased

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1052,6 +1052,15 @@ void TextEditor::keydown_event(KeyEvent& event)
         }
     }
 
+    if (event.shift() && event.ctrl() && !event.alt() && event.key() == KeyCode::Key_U)
+        uppercase_selection();
+
+    if (event.shift() && event.ctrl() && !event.alt() && event.key() == KeyCode::Key_L)
+        lowercase_selection();
+
+    if (event.shift() && event.ctrl() && !event.alt() && event.key() == KeyCode::Key_N)
+        snakecase_selection();
+
     event.ignore();
 }
 
@@ -1109,6 +1118,36 @@ void TextEditor::unindent_line()
 
         set_cursor({ m_cursor.line(), temp_column <= unindent_size ? 0 : temp_column - unindent_size });
     }
+}
+
+void TextEditor::uppercase_selection()
+{
+    if (!has_selection())
+        return;
+
+    execute<ReplaceAllTextCommand>(selected_text().to_uppercase(), selection().normalized(), "Uppercase a selection");
+}
+
+void TextEditor::lowercase_selection()
+{
+    if (!has_selection())
+        return;
+
+    execute<ReplaceAllTextCommand>(selected_text().to_lowercase(), selection().normalized(), "Lowercase a selection");
+}
+
+void TextEditor::snakecase_selection()
+{
+    if (!has_selection())
+        return;
+
+    auto old_length = selected_text().length();
+    auto snake_text = selected_text().to_snakecase();
+    auto new_range_end = snake_text.length() - old_length;
+    execute<ReplaceAllTextCommand>(snake_text, selection().normalized(), "Snake case a selection");
+    auto new_range = selection().normalized();
+    new_range.end().set_column(new_range.end().column() + new_range_end);
+    set_selection(new_range);
 }
 
 void TextEditor::delete_previous_word()

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -163,6 +163,9 @@ public:
     void indent_selection();
     void unindent_selection();
     void unindent_line();
+    void uppercase_selection();
+    void lowercase_selection();
+    void snakecase_selection();
 
     Function<void()> on_change;
     Function<void(bool modified)> on_modified_change;


### PR DESCRIPTION
Added three shortcuts on TextEditor:
1) ctrl+shift+U will uppercase selected text
2) ctrl+shift+L will lowercase selected text
3) ctrl+shift+N will snake case selected text