### PR TITLE
PixelPaint: Scale lasso tool preview path on zoom level change

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/LassoSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/LassoSelectTool.h
@@ -37,7 +37,7 @@ private:
     Gfx::IntPoint m_start_position;
     Gfx::IntPoint m_most_recent_position;
     RefPtr<Gfx::Bitmap> m_selection_bitmap;
-    Gfx::Path m_preview_path;
+    Vector<Gfx::IntPoint> m_preview_coords;
 
     Gfx::IntPoint m_top_left;
     Gfx::IntPoint m_bottom_right;


### PR DESCRIPTION
The size of the preview shown by the lasso tool now scales with the current zoom level.

Before:

https://user-images.githubusercontent.com/2817754/211935251-a5168ba1-387c-419d-aa15-f99206852844.mp4

After:

https://user-images.githubusercontent.com/2817754/211935362-ce0191bd-4586-4035-84db-a390a37f3de4.mp4


