### PR TITLE
Meta: Add Flake for NixOS dev environment

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -69,6 +69,21 @@ sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs ninja qe
 ```
 Optional: `fuse2fs` for [building images without root](https://github.com/SerenityOS/serenity/pull/11224).
 
+### NixOS
+
+If `nix-command` and `flakes` are enabled on your system, you can enter a development shell with all
+dependencies installed with:
+
+```console
+nix develop
+```
+
+You can enable these features as follows: 
+
+```console
+echo "experimental-features = nix-command flakes" | sudo tee -a /etc/nix/nix.conf
+```
+
 ### Other systems
 
 There is also documentation for installing the build prerequisites for some less commonly used systems:

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -146,12 +146,15 @@ else
     echo "done"
 fi
 
+[ -z "${FUSERMOUNT_PATH:-}" ] && \
+    FUSERMOUNT_PATH="fusermount"
+
 cleanup() {
     if [ -d mnt ]; then
         if [ $use_genext2fs = 0 ] ; then
             printf "unmounting filesystem... "
             if [ $USE_FUSE2FS -eq 1 ]; then
-                fusermount -u mnt || (sleep 1 && sync && fusermount -u mnt)
+                "$FUSERMOUNT_PATH" -u mnt || (sleep 1 && sync && "$FUSERMOUNT_PATH" -u mnt)
             else
                 umount mnt || ( sleep 1 && sync && umount mnt )
             fi

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -94,7 +94,7 @@ else
     TARGET="${SERENITY_ARCH:-"x86_64"}"
 fi
 
-CMAKE_ARGS=()
+readarray -t CMAKE_ARGS <<< "${SERENITY_CMAKE_ARGS:-}"
 HOST_COMPILER=""
 
 # Toolchain selection only applies to non-lagom targets.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1673345971,
+        "narHash": "sha256-4DfFcKLRfVUTyuGrGNNmw37IeIZSoku9tgTVmu/iD98=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "54644f409ab471e87014bb305eac8c50190bcf48",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-22.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        nativeBuildInputs = with pkgs; [
+          pkg-config
+          curl
+          cmake
+          qemu
+          ninja
+          qemu-utils
+          ccache
+          rsync
+          unzip
+          texinfo
+          gcc12
+          e2fsprogs.fuse2fs
+          genext2fs
+          fuse
+          autoconf
+        ];
+        buildInputs = with pkgs; [
+          mpfr.dev
+          libmpc
+          gmp.dev
+          libxcrypt
+        ];
+      in {
+        formatter = pkgs.alejandra;
+        devShell = pkgs.mkShell {
+          inherit nativeBuildInputs buildInputs;
+
+          # Some hardening flags currently cause the build to fail.
+          NIX_HARDENING_ENABLE = "";
+
+          # CMake fails and suggests this variable as a fix, which works.
+          # I assume it's needed because NixOS doesn't have a standard FHS.
+          SERENITY_CMAKE_ARGS = "-DCMAKE_BUILD_WITH_INSTALL_RPATH=true";
+
+          shellHook = ''
+            # The default fusermount does not have setuid.
+            if [ -x '/run/wrappers/bin/fusermount3' ]; then
+                export FUSERMOUNT_PATH='/run/wrappers/bin/fusermount3'
+            fi
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
Add a Flake (https://nixos.wiki/wiki/Flakes) so that people using NixOS can establish a working dev environment with `nix develop`. Two overrides were added for the build process:

* SERENITY_CMAKE_ARGS is an environment variable that allows additional CMAKE arguments. This is required because CMAKE_BUILD_WITH_INSTALL_RPATH=true is needed to successfully build on NixOS.
* FUSERMOUNT_PATH is an environment variable that overrides which fusermount executable to use while building the qemu image. This is required because fusermount3 has setuid on NixOS, but not fusermount.

Both of these environment variables are set by the flake.