### PR TITLE
LibDebug: Fix crashes when inspecting crashdumps of GUI programs

### DIFF
--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -65,7 +65,7 @@ void DwarfInfo::populate_compilation_units()
         // Meaning that for graphical applications, some line info data would be unread, triggering the assertion below.
         // As a fix, we don't create compilation units for line programs that come from resource files.
 #if defined(AK_COMPILER_CLANG)
-        if (line_program->source_files().size() == 1 && line_program->source_files()[0].name.view().contains("serenity_icon_"sv)) {
+        if (line_program->looks_like_embedded_resource()) {
             debug_info_stream.seek(unit_offset);
         } else
 #endif

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -308,7 +308,13 @@ LineProgram::DirectoryAndFile LineProgram::get_directory_and_file(size_t file_in
 
 bool LineProgram::looks_like_embedded_resource() const
 {
-    return source_files().size() == 1 && source_files()[0].name.view().contains("serenity_icon_"sv);
+    if (source_files().size() == 1)
+        return source_files()[0].name.view().contains("serenity_icon_"sv);
+
+    if (source_files().size() == 2 && source_files()[0].name.view() == "."sv)
+        return source_files()[1].name.view().contains("serenity_icon_"sv);
+
+    return false;
 }
 
 }

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -306,4 +306,9 @@ LineProgram::DirectoryAndFile LineProgram::get_directory_and_file(size_t file_in
     return { directory_entry, file_entry.name };
 }
 
+bool LineProgram::looks_like_embedded_resource() const
+{
+    return source_files().size() == 1 && source_files()[0].name.view().contains("serenity_icon_"sv);
+}
+
 }

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
@@ -130,6 +130,8 @@ public:
     };
     Vector<FileEntry> const& source_files() const { return m_source_files; }
 
+    bool looks_like_embedded_resource() const;
+
 private:
     void parse_unit_header();
     void parse_source_directories();


### PR DESCRIPTION
Our coredump format changed slightly when we started forcing `-gdwarf-4`, and line programs that are attached to embedded resources now appear to have `.` as the first source file, and the actual file as the second.

Factor out and update the "this looks like an embedded resource" condition to account for that.

cc @BertalanD, since I'm not all too familiar with DWARF and the significance of `.`. We can probably change the condition some more to have it make more sense.

cc @kleinesfilmroellchen, since you originally reported the issue, but I'm 99% sure that it's fixed.