### PR TITLE
LibJS: Updates to ECMA-402 and Intl.NumberFormat v3

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -489,32 +489,29 @@ ThrowCompletionOr<LocaleResult> resolve_locale(Vector<DeprecatedString> const& r
             }
         }
 
-        // iv. If keyLocaleData contains optionsValue, then
-        if (options_value.has_value() && key_locale_data.contains_slow(*options_value)) {
-            // 1. If SameValue(optionsValue, value) is false, then
-            if (options_value != value) {
-                // a. Let value be optionsValue.
-                value = move(options_value);
+        // iv. If SameValue(optionsValue, value) is false and keyLocaleData contains optionsValue, then
+        if (options_value.has_value() && (options_value != value) && key_locale_data.contains_slow(*options_value)) {
+            // 1. Let value be optionsValue.
+            value = move(options_value);
 
-                // b. Let supportedExtensionAddition be "".
-                supported_extension_addition.clear();
-            }
+            // 2. Let supportedExtensionAddition be "".
+            supported_extension_addition.clear();
         }
 
         // j. Set result.[[<key>]] to value.
         find_key_in_value(result, key) = move(value);
 
-        // k. Append supportedExtensionAddition to supportedExtension.
+        // k. Set supportedExtension to the string-concatenation of supportedExtension and supportedExtensionAddition.
         if (supported_extension_addition.has_value())
             supported_extension.keywords.append(supported_extension_addition.release_value());
     }
 
-    // 10. If the number of elements in supportedExtension is greater than 2, then
+    // 10. If supportedExtension is not "-u", then
     if (!supported_extension.keywords.is_empty()) {
         auto locale_id = ::Locale::parse_unicode_locale_id(found_locale);
         VERIFY(locale_id.has_value());
 
-        // a. Let foundLocale be InsertUnicodeExtensionAndCanonicalize(foundLocale, supportedExtension).
+        // a. Set foundLocale to InsertUnicodeExtensionAndCanonicalize(foundLocale, supportedExtension).
         found_locale = insert_unicode_extension_and_canonicalize(locale_id.release_value(), move(supported_extension));
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -572,7 +572,7 @@ ThrowCompletionOr<Array*> supported_locales(VM& vm, Vector<DeprecatedString> con
     // 1. Set options to ? CoerceOptionsToObject(options).
     auto* options_object = TRY(coerce_options_to_object(vm, options));
 
-    // 2. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    // 2. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options_object, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
 
     Vector<DeprecatedString> supported_locales;

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -23,7 +23,7 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
     // 2. Set options to ? CoerceOptionsToObject(options).
     auto* options = TRY(coerce_options_to_object(vm, options_value));
 
-    // 3. Let usage be ? GetOption(options, "usage", "string", « "sort", "search" », "sort").
+    // 3. Let usage be ? GetOption(options, "usage", string, « "sort", "search" », "sort").
     auto usage = TRY(get_option(vm, *options, vm.names.usage, OptionType::String, { "sort"sv, "search"sv }, "sort"sv));
 
     // 4. Set collator.[[Usage]] to usage.
@@ -37,13 +37,13 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
     // 7. Let opt be a new Record.
     LocaleOptions opt {};
 
-    // 8. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    // 8. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
 
     // 9. Set opt.[[localeMatcher]] to matcher.
     opt.locale_matcher = matcher;
 
-    // 10. Let collation be ? GetOption(options, "collation", "string", undefined, undefined).
+    // 10. Let collation be ? GetOption(options, "collation", string, empty, undefined).
     auto collation = TRY(get_option(vm, *options, vm.names.collation, OptionType::String, {}, Empty {}));
 
     // 11. If collation is not undefined, then
@@ -56,7 +56,7 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
         opt.co = TRY(collation.as_string().deprecated_string());
     }
 
-    // 13. Let numeric be ? GetOption(options, "numeric", "boolean", undefined, undefined).
+    // 13. Let numeric be ? GetOption(options, "numeric", boolean, empty, undefined).
     auto numeric = TRY(get_option(vm, *options, vm.names.numeric, OptionType::Boolean, {}, Empty {}));
 
     // 14. If numeric is not undefined, then
@@ -65,7 +65,7 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
     if (!numeric.is_undefined())
         opt.kn = MUST(numeric.to_string(vm));
 
-    // 16. Let caseFirst be ? GetOption(options, "caseFirst", "string", « "upper", "lower", "false" », undefined).
+    // 16. Let caseFirst be ? GetOption(options, "caseFirst", string, « "upper", "lower", "false" », undefined).
     // 17. Set opt.[[kf]] to caseFirst.
     auto case_first = TRY(get_option(vm, *options, vm.names.caseFirst, OptionType::String, { "upper"sv, "lower"sv, "false"sv }, Empty {}));
     if (!case_first.is_undefined())
@@ -97,7 +97,7 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
         collator.set_case_first(result.kf.release_value());
     }
 
-    // 26. Let sensitivity be ? GetOption(options, "sensitivity", "string", « "base", "accent", "case", "variant" », undefined).
+    // 26. Let sensitivity be ? GetOption(options, "sensitivity", string, « "base", "accent", "case", "variant" », undefined).
     auto sensitivity = TRY(get_option(vm, *options, vm.names.sensitivity, OptionType::String, { "base"sv, "accent"sv, "case"sv, "variant"sv }, Empty {}));
 
     // 27. If sensitivity is undefined, then
@@ -119,7 +119,7 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
     // 28. Set collator.[[Sensitivity]] to sensitivity.
     collator.set_sensitivity(TRY(sensitivity.as_string().deprecated_string()));
 
-    // 29. Let ignorePunctuation be ? GetOption(options, "ignorePunctuation", "boolean", undefined, false).
+    // 29. Let ignorePunctuation be ? GetOption(options, "ignorePunctuation", boolean, empty, false).
     auto ignore_punctuation = TRY(get_option(vm, *options, vm.names.ignorePunctuation, OptionType::Boolean, {}, false));
 
     // 30. Set collator.[[IgnorePunctuation]] to ignorePunctuation.

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -94,13 +94,13 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
     // 3. Let opt be a new Record.
     LocaleOptions opt {};
 
-    // 4. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    // 4. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, AK::Array { "lookup"sv, "best fit"sv }, "best fit"sv));
 
     // 5. Set opt.[[localeMatcher]] to matcher.
     opt.locale_matcher = matcher;
 
-    // 6. Let calendar be ? GetOption(options, "calendar", "string", undefined, undefined).
+    // 6. Let calendar be ? GetOption(options, "calendar", string, empty, undefined).
     auto calendar = TRY(get_option(vm, *options, vm.names.calendar, OptionType::String, {}, Empty {}));
 
     // 7. If calendar is not undefined, then
@@ -113,7 +113,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
         opt.ca = TRY(calendar.as_string().deprecated_string());
     }
 
-    // 9. Let numberingSystem be ? GetOption(options, "numberingSystem", "string", undefined, undefined).
+    // 9. Let numberingSystem be ? GetOption(options, "numberingSystem", string, empty, undefined).
     auto numbering_system = TRY(get_option(vm, *options, vm.names.numberingSystem, OptionType::String, {}, Empty {}));
 
     // 10. If numberingSystem is not undefined, then
@@ -126,10 +126,10 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
         opt.nu = TRY(numbering_system.as_string().deprecated_string());
     }
 
-    // 12. Let hour12 be ? GetOption(options, "hour12", "boolean", undefined, undefined).
+    // 12. Let hour12 be ? GetOption(options, "hour12", boolean, empty, undefined).
     auto hour12 = TRY(get_option(vm, *options, vm.names.hour12, OptionType::Boolean, {}, Empty {}));
 
-    // 13. Let hourCycle be ? GetOption(options, "hourCycle", "string", « "h11", "h12", "h23", "h24" », undefined).
+    // 13. Let hourCycle be ? GetOption(options, "hourCycle", string, « "h11", "h12", "h23", "h24" », undefined).
     auto hour_cycle = TRY(get_option(vm, *options, vm.names.hourCycle, OptionType::String, AK::Array { "h11"sv, "h12"sv, "h23"sv, "h24"sv }, Empty {}));
 
     // 14. If hour12 is not undefined, then
@@ -272,7 +272,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
         // c. Else,
         else {
             // i. Let values be a List whose elements are the strings given in the Values column of the row.
-            // ii. Let value be ? GetOption(options, prop, "string", values, undefined).
+            // ii. Let value be ? GetOption(options, prop, string, values, undefined).
             auto value = TRY(get_option(vm, *options, property, OptionType::String, values, Empty {}));
 
             // d. Set formatOptions.[[<prop>]] to value.
@@ -288,17 +288,17 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(VM& vm, DateTimeF
         return {};
     }));
 
-    // 37. Let matcher be ? GetOption(options, "formatMatcher", "string", « "basic", "best fit" », "best fit").
+    // 37. Let matcher be ? GetOption(options, "formatMatcher", string, « "basic", "best fit" », "best fit").
     matcher = TRY(get_option(vm, *options, vm.names.formatMatcher, OptionType::String, AK::Array { "basic"sv, "best fit"sv }, "best fit"sv));
 
-    // 38. Let dateStyle be ? GetOption(options, "dateStyle", "string", « "full", "long", "medium", "short" », undefined).
+    // 38. Let dateStyle be ? GetOption(options, "dateStyle", string, « "full", "long", "medium", "short" », undefined).
     auto date_style = TRY(get_option(vm, *options, vm.names.dateStyle, OptionType::String, AK::Array { "full"sv, "long"sv, "medium"sv, "short"sv }, Empty {}));
 
     // 39. Set dateTimeFormat.[[DateStyle]] to dateStyle.
     if (!date_style.is_undefined())
         date_time_format.set_date_style(TRY(date_style.as_string().deprecated_string()));
 
-    // 40. Let timeStyle be ? GetOption(options, "timeStyle", "string", « "full", "long", "medium", "short" », undefined).
+    // 40. Let timeStyle be ? GetOption(options, "timeStyle", string, « "full", "long", "medium", "short" », undefined).
     auto time_style = TRY(get_option(vm, *options, vm.names.timeStyle, OptionType::String, AK::Array { "full"sv, "long"sv, "medium"sv, "short"sv }, Empty {}));
 
     // 41. Set dateTimeFormat.[[TimeStyle]] to timeStyle.

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -69,7 +69,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DisplayNamesConstructor::construct(Funct
 
     // 7. Let localeData be %DisplayNames%.[[LocaleData]].
 
-    // 8. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    // 8. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
 
     // 9. Set opt.[[localeMatcher]] to matcher.
@@ -78,13 +78,13 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DisplayNamesConstructor::construct(Funct
     // 10. Let r be ResolveLocale(%DisplayNames%.[[AvailableLocales]], requestedLocales, opt, %DisplayNames%.[[RelevantExtensionKeys]]).
     auto result = TRY(resolve_locale(requested_locales, opt, {}));
 
-    // 11. Let style be ? GetOption(options, "style", "string", « "narrow", "short", "long" », "long").
+    // 11. Let style be ? GetOption(options, "style", string, « "narrow", "short", "long" », "long").
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "narrow"sv, "short"sv, "long"sv }, "long"sv));
 
     // 12. Set displayNames.[[Style]] to style.
     display_names->set_style(TRY(style.as_string().deprecated_string()));
 
-    // 13. Let type be ? GetOption(options, "type", "string", « "language", "region", "script", "currency", "calendar", "dateTimeField" », undefined).
+    // 13. Let type be ? GetOption(options, "type", string, « "language", "region", "script", "currency", "calendar", "dateTimeField" », undefined).
     auto type = TRY(get_option(vm, *options, vm.names.type, OptionType::String, { "language"sv, "region"sv, "script"sv, "currency"sv, "calendar"sv, "dateTimeField"sv }, Empty {}));
 
     // 14. If type is undefined, throw a TypeError exception.
@@ -94,7 +94,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DisplayNamesConstructor::construct(Funct
     // 15. Set displayNames.[[Type]] to type.
     display_names->set_type(TRY(type.as_string().deprecated_string()));
 
-    // 16. Let fallback be ? GetOption(options, "fallback", "string", « "code", "none" », "code").
+    // 16. Let fallback be ? GetOption(options, "fallback", string, « "code", "none" », "code").
     auto fallback = TRY(get_option(vm, *options, vm.names.fallback, OptionType::String, { "code"sv, "none"sv }, "code"sv));
 
     // 17. Set displayNames.[[Fallback]] to fallback.
@@ -110,7 +110,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DisplayNamesConstructor::construct(Funct
     // 21. Let types be dataLocaleData.[[types]].
     // 22. Assert: types is a Record (see 12.4.3).
 
-    // 23. Let languageDisplay be ? GetOption(options, "languageDisplay", "string", « "dialect", "standard" », "dialect").
+    // 23. Let languageDisplay be ? GetOption(options, "languageDisplay", string, « "dialect", "standard" », "dialect").
     auto language_display = TRY(get_option(vm, *options, vm.names.languageDisplay, OptionType::String, { "dialect"sv, "standard"sv }, "dialect"sv));
 
     // 24. Let typeFields be types.[[<type>]].

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Idan Horowitz <idan.horowitz@serenityos.org>
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -270,7 +270,7 @@ bool is_valid_duration_record(Temporal::DurationRecord const& record)
 // 1.1.6 GetDurationUnitOptions ( unit, options, baseStyle, stylesList, digitalBase, prevStyle ), https://tc39.es/proposal-intl-duration-format/#sec-getdurationunitoptions
 ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM& vm, DeprecatedString const& unit, Object const& options, StringView base_style, Span<StringView const> styles_list, StringView digital_base, StringView previous_style)
 {
-    // 1. Let style be ? GetOption(options, unit, "string", stylesList, undefined).
+    // 1. Let style be ? GetOption(options, unit, string, stylesList, undefined).
     auto style_value = TRY(get_option(vm, options, unit, OptionType::String, styles_list, Empty {}));
 
     // 2. Let displayDefault be "always".
@@ -314,7 +314,7 @@ ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM& vm, Depreca
     // 4. Let displayField be the string-concatenation of unit and "Display".
     auto display_field = DeprecatedString::formatted("{}Display", unit);
 
-    // 5. Let display be ? GetOption(options, displayField, "string", « "auto", "always" », displayDefault).
+    // 5. Let display be ? GetOption(options, displayField, string, « "auto", "always" », displayDefault).
     auto display = TRY(get_option(vm, options, display_field, OptionType::String, { "auto"sv, "always"sv }, display_default));
 
     // 6. If prevStyle is "numeric" or "2-digit", then

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Idan Horowitz <idan.horowitz@serenityos.org>
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -58,10 +58,10 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DurationFormatConstructor::construct(Fun
     // 4. Let options be ? GetOptionsObject(options).
     auto* options = TRY(Temporal::get_options_object(vm, options_value));
 
-    // 5. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    // 5. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
 
-    // 6. Let numberingSystem be ? GetOption(options, "numberingSystem", "string", undefined, undefined).
+    // 6. Let numberingSystem be ? GetOption(options, "numberingSystem", string, empty, undefined).
     auto numbering_system = TRY(get_option(vm, *options, vm.names.numberingSystem, OptionType::String, {}, Empty {}));
 
     // 7. If numberingSystem is not undefined, then
@@ -89,7 +89,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DurationFormatConstructor::construct(Fun
     if (result.nu.has_value())
         duration_format->set_numbering_system(result.nu.release_value());
 
-    // 13. Let style be ? GetOption(options, "style", "string", « "long", "short", "narrow", "digital" », "short").
+    // 13. Let style be ? GetOption(options, "style", string, « "long", "short", "narrow", "digital" », "short").
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "long"sv, "short"sv, "narrow"sv, "digital"sv }, "short"sv));
 
     // 14. Set durationFormat.[[Style]] to style.

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -62,7 +62,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ListFormatConstructor::construct(Functio
     // 5. Let opt be a new Record.
     LocaleOptions opt {};
 
-    // 6. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    // 6. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
 
     // 7. Set opt.[[localeMatcher]] to matcher.
@@ -76,13 +76,13 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ListFormatConstructor::construct(Functio
     // 10. Set listFormat.[[Locale]] to r.[[locale]].
     list_format->set_locale(move(result.locale));
 
-    // 11. Let type be ? GetOption(options, "type", "string", « "conjunction", "disjunction", "unit" », "conjunction").
+    // 11. Let type be ? GetOption(options, "type", string, « "conjunction", "disjunction", "unit" », "conjunction").
     auto type = TRY(get_option(vm, *options, vm.names.type, OptionType::String, { "conjunction"sv, "disjunction"sv, "unit"sv }, "conjunction"sv));
 
     // 12. Set listFormat.[[Type]] to type.
     list_format->set_type(TRY(type.as_string().deprecated_string()));
 
-    // 13. Let style be ? GetOption(options, "style", "string", « "long", "short", "narrow" », "long").
+    // 13. Let style be ? GetOption(options, "style", string, « "long", "short", "narrow" », "long").
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "long"sv, "short"sv, "narrow"sv }, "long"sv));
 
     // 14. Set listFormat.[[Style]] to style.

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -50,17 +50,17 @@ static ThrowCompletionOr<DeprecatedString> apply_options_to_tag(VM& vm, StringVi
     if (!locale_id.has_value())
         return vm.throw_completion<RangeError>(ErrorType::IntlInvalidLanguageTag, tag);
 
-    // 4. Let language be ? GetOption(options, "language", "string", undefined, undefined).
+    // 4. Let language be ? GetOption(options, "language", string, empty, undefined).
     // 5. If language is not undefined, then
     //     a. If language does not match the unicode_language_subtag production, throw a RangeError exception.
     auto language = TRY(get_string_option(vm, options, vm.names.language, ::Locale::is_unicode_language_subtag));
 
-    // 6. Let script be ? GetOption(options, "script", "string", undefined, undefined).
+    // 6. Let script be ? GetOption(options, "script", string, empty, undefined).
     // 7. If script is not undefined, then
     //     a. If script does not match the unicode_script_subtag production, throw a RangeError exception.
     auto script = TRY(get_string_option(vm, options, vm.names.script, ::Locale::is_unicode_script_subtag));
 
-    // 8. Let region be ? GetOption(options, "region", "string", undefined, undefined).
+    // 8. Let region be ? GetOption(options, "region", string, empty, undefined).
     // 9. If region is not undefined, then
     //     a. If region does not match the unicode_region_subtag production, throw a RangeError exception.
     auto region = TRY(get_string_option(vm, options, vm.names.region, ::Locale::is_unicode_region_subtag));
@@ -287,27 +287,27 @@ ThrowCompletionOr<NonnullGCPtr<Object>> LocaleConstructor::construct(FunctionObj
     // 12. Let opt be a new Record.
     LocaleAndKeys opt {};
 
-    // 13. Let calendar be ? GetOption(options, "calendar", "string", undefined, undefined).
+    // 13. Let calendar be ? GetOption(options, "calendar", string, empty, undefined).
     // 14. If calendar is not undefined, then
     //     a. If calendar does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
     // 15. Set opt.[[ca]] to calendar.
     opt.ca = TRY(get_string_option(vm, *options, vm.names.calendar, ::Locale::is_type_identifier));
 
-    // 16. Let collation be ? GetOption(options, "collation", "string", undefined, undefined).
+    // 16. Let collation be ? GetOption(options, "collation", string, empty, undefined).
     // 17. If collation is not undefined, then
     //     a. If collation does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
     // 18. Set opt.[[co]] to collation.
     opt.co = TRY(get_string_option(vm, *options, vm.names.collation, ::Locale::is_type_identifier));
 
-    // 19. Let hc be ? GetOption(options, "hourCycle", "string", « "h11", "h12", "h23", "h24" », undefined).
+    // 19. Let hc be ? GetOption(options, "hourCycle", string, « "h11", "h12", "h23", "h24" », undefined).
     // 20. Set opt.[[hc]] to hc.
     opt.hc = TRY(get_string_option(vm, *options, vm.names.hourCycle, nullptr, AK::Array { "h11"sv, "h12"sv, "h23"sv, "h24"sv }));
 
-    // 21. Let kf be ? GetOption(options, "caseFirst", "string", « "upper", "lower", "false" », undefined).
+    // 21. Let kf be ? GetOption(options, "caseFirst", string, « "upper", "lower", "false" », undefined).
     // 22. Set opt.[[kf]] to kf.
     opt.kf = TRY(get_string_option(vm, *options, vm.names.caseFirst, nullptr, AK::Array { "upper"sv, "lower"sv, "false"sv }));
 
-    // 23. Let kn be ? GetOption(options, "numeric", "boolean", undefined, undefined).
+    // 23. Let kn be ? GetOption(options, "numeric", boolean, empty, undefined).
     auto kn = TRY(get_option(vm, *options, vm.names.numeric, OptionType::Boolean, {}, Empty {}));
 
     // 24. If kn is not undefined, set kn to ! ToString(kn).
@@ -315,7 +315,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> LocaleConstructor::construct(FunctionObj
     if (!kn.is_undefined())
         opt.kn = TRY(kn.to_string(vm));
 
-    // 26. Let numberingSystem be ? GetOption(options, "numberingSystem", "string", undefined, undefined).
+    // 26. Let numberingSystem be ? GetOption(options, "numberingSystem", string, empty, undefined).
     // 27. If numberingSystem is not undefined, then
     //     a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
     // 28. Set opt.[[nu]] to numberingSystem.

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -494,7 +494,7 @@ FormatResult format_numeric_to_string(NumberFormatBase const& intl_object, Mathe
 
     // 12. If int < minInteger, then
     if (digits < min_integer) {
-        // a. Let forwardZeros be the String consisting of minInteger–int occurrences of the character "0".
+        // a. Let forwardZeros be the String consisting of minInteger - int occurrences of the code unit 0x0030 (DIGIT ZERO).
         auto forward_zeros = DeprecatedString::repeated('0', min_integer - digits);
 
         // b. Set string to the string-concatenation of forwardZeros and string.
@@ -958,18 +958,18 @@ static DeprecatedString cut_trailing_zeroes(StringView string, int cut)
 {
     // These steps are exactly the same between ToRawPrecision and ToRawFixed.
 
-    // Repeat, while cut > 0 and the last character of m is "0",
+    // Repeat, while cut > 0 and the last code unit of m is 0x0030 (DIGIT ZERO),
     while ((cut > 0) && string.ends_with('0')) {
-        // Remove the last character from m.
+        // Remove the last code unit from m.
         string = string.substring_view(0, string.length() - 1);
 
         // Decrease cut by 1.
         --cut;
     }
 
-    // If the last character of m is ".", then
+    // If the last code unit of m is 0x002E (FULL STOP), then
     if (string.ends_with('.')) {
-        // Remove the last character from m.
+        // Remove the last code unit from m.
         string = string.substring_view(0, string.length() - 1);
     }
 
@@ -1034,7 +1034,7 @@ RawFormatResult to_raw_precision(MathematicalValue const& number, int min_precis
 
     // 2. If x = 0, then
     if (number.is_zero()) {
-        // a. Let m be the String consisting of p occurrences of the character "0".
+        // a. Let m be the String consisting of p occurrences of the code unit 0x0030 (DIGIT ZERO).
         result.formatted_string = DeprecatedString::repeated('0', precision);
 
         // b. Let e be 0.
@@ -1085,7 +1085,7 @@ RawFormatResult to_raw_precision(MathematicalValue const& number, int min_precis
 
     // 4. If e ≥ p–1, then
     if (exponent >= (precision - 1)) {
-        // a. Let m be the string-concatenation of m and e–p+1 occurrences of the character "0".
+        // a. Set m to the string-concatenation of m and e - p + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
         result.formatted_string = DeprecatedString::formatted(
             "{}{}",
             result.formatted_string,
@@ -1096,7 +1096,7 @@ RawFormatResult to_raw_precision(MathematicalValue const& number, int min_precis
     }
     // 5. Else if e ≥ 0, then
     else if (exponent >= 0) {
-        // a. Let m be the string-concatenation of the first e+1 characters of m, the character ".", and the remaining p–(e+1) characters of m.
+        // a. Set m to the string-concatenation of the first e + 1 code units of m, the code unit 0x002E (FULL STOP), and the remaining p - (e + 1) code units of m.
         result.formatted_string = DeprecatedString::formatted(
             "{}.{}",
             result.formatted_string.substring_view(0, exponent + 1),
@@ -1108,7 +1108,7 @@ RawFormatResult to_raw_precision(MathematicalValue const& number, int min_precis
     // 6. Else,
     else {
         // a. Assert: e < 0.
-        // b. Let m be the string-concatenation of "0.", –(e+1) occurrences of the character "0", and m.
+        // b. Set m to the string-concatenation of "0.", -(e + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and m.
         result.formatted_string = DeprecatedString::formatted(
             "0.{}{}",
             DeprecatedString::repeated('0', -1 * (exponent + 1)),
@@ -1118,7 +1118,7 @@ RawFormatResult to_raw_precision(MathematicalValue const& number, int min_precis
         result.digits = 1;
     }
 
-    // 7. If m contains the character ".", and maxPrecision > minPrecision, then
+    // 7. If m contains the code unit 0x002E (FULL STOP) and maxPrecision > minPrecision, then
     if (result.formatted_string.contains('.') && (max_precision > min_precision)) {
         // a. Let cut be maxPrecision – minPrecision.
         int cut = max_precision - min_precision;
@@ -1223,12 +1223,12 @@ RawFormatResult to_raw_fixed(MathematicalValue const& number, int min_fraction, 
 
     // 8. If f ≠ 0, then
     if (fraction != 0) {
-        // a. Let k be the number of characters in m.
+        // a. Let k be the length of m.
         auto decimals = result.formatted_string.length();
 
         // b. If k ≤ f, then
         if (decimals <= static_cast<size_t>(fraction)) {
-            // i. Let z be the String value consisting of f+1–k occurrences of the character "0".
+            // i. Let z be the String value consisting of f + 1 - k occurrences of the code unit 0x0030 (DIGIT ZERO).
             auto zeroes = DeprecatedString::repeated('0', fraction + 1 - decimals);
 
             // ii. Let m be the string-concatenation of z and m.
@@ -1238,17 +1238,17 @@ RawFormatResult to_raw_fixed(MathematicalValue const& number, int min_fraction, 
             decimals = fraction + 1;
         }
 
-        // c. Let a be the first k–f characters of m, and let b be the remaining f characters of m.
+        // c. Let a be the first k - f code units of m, and let b be the remaining f code units of m.
         auto a = result.formatted_string.substring_view(0, decimals - fraction);
         auto b = result.formatted_string.substring_view(decimals - fraction, fraction);
 
         // d. Let m be the string-concatenation of a, ".", and b.
         result.formatted_string = DeprecatedString::formatted("{}.{}", a, b);
 
-        // e. Let int be the number of characters in a.
+        // e. Let int be the length of a.
         result.digits = a.length();
     }
-    // 9. Else, let int be the number of characters in m.
+    // 9. Else, let int be the length of m.
     else {
         result.digits = result.formatted_string.length();
     }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -1083,7 +1083,7 @@ RawFormatResult to_raw_precision(MathematicalValue const& number, int min_precis
         result.formatted_string = n.to_deprecated_string();
     }
 
-    // 4. If e ≥ p–1, then
+    // 4. If e ≥ (p – 1), then
     if (exponent >= (precision - 1)) {
         // a. Set m to the string-concatenation of m and e - p + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
         result.formatted_string = DeprecatedString::formatted(
@@ -1091,7 +1091,7 @@ RawFormatResult to_raw_precision(MathematicalValue const& number, int min_precis
             result.formatted_string,
             DeprecatedString::repeated('0', exponent - precision + 1));
 
-        // b. Let int be e+1.
+        // b. Let int be e + 1.
         result.digits = exponent + 1;
     }
     // 5. Else if e ≥ 0, then
@@ -1102,7 +1102,7 @@ RawFormatResult to_raw_precision(MathematicalValue const& number, int min_precis
             result.formatted_string.substring_view(0, exponent + 1),
             result.formatted_string.substring_view(exponent + 1));
 
-        // b. Let int be e+1.
+        // b. Let int be e + 1.
         result.digits = exponent + 1;
     }
     // 6. Else,
@@ -1234,7 +1234,7 @@ RawFormatResult to_raw_fixed(MathematicalValue const& number, int min_fraction, 
             // ii. Let m be the string-concatenation of z and m.
             result.formatted_string = DeprecatedString::formatted("{}{}", zeroes, result.formatted_string);
 
-            // iii. Let k be f+1.
+            // iii. Let k be f + 1.
             decimals = fraction + 1;
         }
 
@@ -1514,7 +1514,7 @@ int compute_exponent(NumberFormat& number_format, MathematicalValue number)
     // 8. Let newMagnitude be the base 10 logarithm of formatNumberResult.[[RoundedNumber]] rounded down to the nearest integer.
     int new_magnitude = format_number_result.rounded_number.logarithmic_floor();
 
-    // 9. If newMagnitude is magnitude – exponent, then
+    // 9. If newMagnitude is magnitude - exponent, then
     if (new_magnitude == magnitude - exponent) {
         // a. Return exponent.
         return exponent;

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -1744,9 +1744,20 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_number_range_pat
     auto raw_end_result = partition_number_pattern(vm, number_format, move(end));
     auto end_result = PatternPartitionWithSource::create_from_parent_list(move(raw_end_result));
 
-    // 5. If xResult is equal to yResult, return FormatApproximately(numberFormat, xResult).
-    if (start_result == end_result)
-        return format_approximately(number_format, move(start_result));
+    // 5. If xResult is equal to yResult, then
+    if (start_result == end_result) {
+        // a. Let appxResult be ? FormatApproximately(numberFormat, xResult).
+        auto approximate_result = format_approximately(number_format, move(start_result));
+
+        // b. For each r in appxResult, do
+        for (auto& result : approximate_result) {
+            // i. Set r.[[Source]] to "shared".
+            result.source = "shared"sv;
+        }
+
+        // c. Return appxResult.
+        return approximate_result;
+    }
 
     // 6. For each r in xResult, do
     for (auto& part : start_result) {

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -376,7 +376,7 @@ int currency_digits(StringView currency)
 }
 
 // 15.5.3 FormatNumericToString ( intlObject, x ), https://tc39.es/ecma402/#sec-formatnumberstring
-// 1.1.5 FormatNumericToString ( intlObject, x ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-formatnumberstring
+// 1.5.3 FormatNumericToString ( intlObject, x ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-formatnumberstring
 FormatResult format_numeric_to_string(NumberFormatBase const& intl_object, MathematicalValue number)
 {
     bool is_negative = false;
@@ -516,7 +516,7 @@ FormatResult format_numeric_to_string(NumberFormatBase const& intl_object, Mathe
 }
 
 // 15.5.4 PartitionNumberPattern ( numberFormat, x ), https://tc39.es/ecma402/#sec-partitionnumberpattern
-// 1.1.6 PartitionNumberPattern ( numberFormat, x ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-partitionnumberpattern
+// 1.5.4 PartitionNumberPattern ( numberFormat, x ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-partitionnumberpattern
 Vector<PatternPartition> partition_number_pattern(VM& vm, NumberFormat& number_format, MathematicalValue number)
 {
     // 1. Let exponent be 0.
@@ -713,7 +713,7 @@ static Vector<StringView> separate_integer_into_groups(::Locale::NumberGroupings
 }
 
 // 15.5.5 PartitionNotationSubPattern ( numberFormat, x, n, exponent ), https://tc39.es/ecma402/#sec-partitionnotationsubpattern
-// 1.1.7 PartitionNotationSubPattern ( numberFormat, x, n, exponent ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-partitionnotationsubpattern
+// 1.5.5 PartitionNotationSubPattern ( numberFormat, x, n, exponent ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-partitionnotationsubpattern
 Vector<PatternPartition> partition_notation_sub_pattern(NumberFormat& number_format, MathematicalValue const& number, DeprecatedString formatted_string, int exponent)
 {
     // 1. Let result be a new empty List.
@@ -1022,7 +1022,7 @@ static auto to_raw_precision_function(MathematicalValue const& number, int preci
 }
 
 // 15.5.8 ToRawPrecision ( x, minPrecision, maxPrecision ), https://tc39.es/ecma402/#sec-torawprecision
-// 1.1.10 ToRawPrecision ( x, minPrecision, maxPrecision, unsignedRoundingMode ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-torawprecision
+// 1.5.8 ToRawPrecision ( x, minPrecision, maxPrecision, unsignedRoundingMode ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-torawprecision
 RawFormatResult to_raw_precision(MathematicalValue const& number, int min_precision, int max_precision, Optional<NumberFormat::UnsignedRoundingMode> const& unsigned_rounding_mode)
 {
     RawFormatResult result {};
@@ -1181,7 +1181,7 @@ static auto to_raw_fixed_function(MathematicalValue const& number, int fraction,
 }
 
 // 15.5.9 ToRawFixed ( x, minInteger, minFraction, maxFraction ), https://tc39.es/ecma402/#sec-torawfixed
-// 1.1.11 ToRawFixed ( x, minFraction, maxFraction, roundingIncrement, unsignedRoundingMode ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-torawfixed
+// 1.5.9 ToRawFixed ( x, minFraction, maxFraction, roundingIncrement, unsignedRoundingMode ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-torawfixed
 RawFormatResult to_raw_fixed(MathematicalValue const& number, int min_fraction, int max_fraction, int rounding_increment, Optional<NumberFormat::UnsignedRoundingMode> const& unsigned_rounding_mode)
 {
     RawFormatResult result {};
@@ -1264,7 +1264,7 @@ RawFormatResult to_raw_fixed(MathematicalValue const& number, int min_fraction, 
 }
 
 // 15.5.11 GetNumberFormatPattern ( numberFormat, x ), https://tc39.es/ecma402/#sec-getnumberformatpattern
-// 1.1.14 GetNumberFormatPattern ( numberFormat, x ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-getnumberformatpattern
+// 1.5.11 GetNumberFormatPattern ( numberFormat, x ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-getnumberformatpattern
 Optional<Variant<StringView, DeprecatedString>> get_number_format_pattern(VM& vm, NumberFormat& number_format, MathematicalValue const& number, ::Locale::NumberFormat& found_pattern)
 {
     // 1. Let localeData be %NumberFormat%.[[LocaleData]].
@@ -1583,7 +1583,7 @@ int compute_exponent_for_magnitude(NumberFormat& number_format, int magnitude)
     }
 }
 
-// 1.1.18 ToIntlMathematicalValue ( value ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-tointlmathematicalvalue
+// 1.5.16 ToIntlMathematicalValue ( value ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-tointlmathematicalvalue
 ThrowCompletionOr<MathematicalValue> to_intl_mathematical_value(VM& vm, Value value)
 {
 
@@ -1628,7 +1628,7 @@ ThrowCompletionOr<MathematicalValue> to_intl_mathematical_value(VM& vm, Value va
     return mathematical_value;
 }
 
-// 1.1.19 GetUnsignedRoundingMode ( roundingMode, isNegative ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-getunsignedroundingmode
+// 1.5.17 GetUnsignedRoundingMode ( roundingMode, isNegative ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-getunsignedroundingmode
 NumberFormat::UnsignedRoundingMode get_unsigned_rounding_mode(NumberFormat::RoundingMode rounding_mode, bool is_negative)
 {
     // 1. If isNegative is true, return the specification type in the third column of Table 2 where the first column is roundingMode and the second column is "negative".
@@ -1659,7 +1659,7 @@ NumberFormat::UnsignedRoundingMode get_unsigned_rounding_mode(NumberFormat::Roun
     };
 }
 
-// 1.1.20 ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-applyunsignedroundingmode
+// 1.5.18 ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-applyunsignedroundingmode
 RoundingDecision apply_unsigned_rounding_mode(MathematicalValue const& x, MathematicalValue const& r1, MathematicalValue const& r2, Optional<NumberFormat::UnsignedRoundingMode> const& unsigned_rounding_mode)
 {
     // 1. If x is equal to r1, return r1.
@@ -1724,7 +1724,7 @@ RoundingDecision apply_unsigned_rounding_mode(MathematicalValue const& x, Mathem
     return RoundingDecision::HigherValue;
 }
 
-// 1.1.21 PartitionNumberRangePattern ( numberFormat, x, y ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-partitionnumberrangepattern
+// 1.5.19 PartitionNumberRangePattern ( numberFormat, x, y ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-partitionnumberrangepattern
 ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_number_range_pattern(VM& vm, NumberFormat& number_format, MathematicalValue start, MathematicalValue end)
 {
     // 1. If x is NaN or y is NaN, throw a RangeError exception.
@@ -1792,7 +1792,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_number_range_pat
     return collapse_number_range(move(result));
 }
 
-// 1.1.22 FormatApproximately ( numberFormat, result ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-formatapproximately
+// 1.5.20 FormatApproximately ( numberFormat, result ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-formatapproximately
 Vector<PatternPartitionWithSource> format_approximately(NumberFormat& number_format, Vector<PatternPartitionWithSource> result)
 {
     // 1. Let i be an index into result, determined by an implementation-defined algorithm based on numberFormat and result.
@@ -1812,14 +1812,14 @@ Vector<PatternPartitionWithSource> format_approximately(NumberFormat& number_for
     return result;
 }
 
-// 1.1.23 CollapseNumberRange ( result ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-collapsenumberrange
+// 1.5.21 CollapseNumberRange ( result ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-collapsenumberrange
 Vector<PatternPartitionWithSource> collapse_number_range(Vector<PatternPartitionWithSource> result)
 {
     // Returning result unmodified is guaranteed to be a correct implementation of CollapseNumberRange.
     return result;
 }
 
-// 1.1.24 FormatNumericRange( numberFormat, x, y ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-formatnumericrange
+// 1.5.22 FormatNumericRange( numberFormat, x, y ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-formatnumericrange
 ThrowCompletionOr<DeprecatedString> format_numeric_range(VM& vm, NumberFormat& number_format, MathematicalValue start, MathematicalValue end)
 {
     // 1. Let parts be ? PartitionNumberRangePattern(numberFormat, x, y).
@@ -1838,7 +1838,7 @@ ThrowCompletionOr<DeprecatedString> format_numeric_range(VM& vm, NumberFormat& n
     return result.build();
 }
 
-// 1.1.25 FormatNumericRangeToParts( numberFormat, x, y ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-formatnumericrangetoparts
+// 1.5.23 FormatNumericRangeToParts( numberFormat, x, y ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-formatnumericrangetoparts
 ThrowCompletionOr<Array*> format_numeric_range_to_parts(VM& vm, NumberFormat& number_format, MathematicalValue start, MathematicalValue end)
 {
     auto& realm = *vm.current_realm();

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -91,13 +91,13 @@ ThrowCompletionOr<NumberFormat*> initialize_number_format(VM& vm, NumberFormat& 
     // 3. Let opt be a new Record.
     LocaleOptions opt {};
 
-    // 4. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    // 4. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
 
     // 5. Set opt.[[localeMatcher]] to matcher.
     opt.locale_matcher = matcher;
 
-    // 6. Let numberingSystem be ? GetOption(options, "numberingSystem", "string", undefined, undefined).
+    // 6. Let numberingSystem be ? GetOption(options, "numberingSystem", string, empty, undefined).
     auto numbering_system = TRY(get_option(vm, *options, vm.names.numberingSystem, OptionType::String, {}, Empty {}));
 
     // 7. If numberingSystem is not undefined, then
@@ -172,7 +172,7 @@ ThrowCompletionOr<NumberFormat*> initialize_number_format(VM& vm, NumberFormat& 
     if (rounding_increment != 1)
         default_max_fraction_digits = default_min_fraction_digits;
 
-    // 21. Let notation be ? GetOption(options, "notation", "string", « "standard", "scientific", "engineering", "compact" », "standard").
+    // 21. Let notation be ? GetOption(options, "notation", string, « "standard", "scientific", "engineering", "compact" », "standard").
     auto notation = TRY(get_option(vm, *options, vm.names.notation, OptionType::String, { "standard"sv, "scientific"sv, "engineering"sv, "compact"sv }, "standard"sv));
 
     // 22. Set numberFormat.[[Notation]] to notation.
@@ -195,13 +195,13 @@ ThrowCompletionOr<NumberFormat*> initialize_number_format(VM& vm, NumberFormat& 
     // 25. Set numberFormat.[[RoundingIncrement]] to roundingIncrement.
     number_format.set_rounding_increment(*rounding_increment);
 
-    // 26. Let trailingZeroDisplay be ? GetOption(options, "trailingZeroDisplay", "string", « "auto", "stripIfInteger" », "auto").
+    // 26. Let trailingZeroDisplay be ? GetOption(options, "trailingZeroDisplay", string, « "auto", "stripIfInteger" », "auto").
     auto trailing_zero_display = TRY(get_option(vm, *options, vm.names.trailingZeroDisplay, OptionType::String, { "auto"sv, "stripIfInteger"sv }, "auto"sv));
 
     // 27. Set numberFormat.[[TrailingZeroDisplay]] to trailingZeroDisplay.
     number_format.set_trailing_zero_display(TRY(trailing_zero_display.as_string().deprecated_string()));
 
-    // 28. Let compactDisplay be ? GetOption(options, "compactDisplay", "string", « "short", "long" », "short").
+    // 28. Let compactDisplay be ? GetOption(options, "compactDisplay", string, « "short", "long" », "short").
     auto compact_display = TRY(get_option(vm, *options, vm.names.compactDisplay, OptionType::String, { "short"sv, "long"sv }, "short"sv));
 
     // 29. Let defaultUseGrouping be "auto".
@@ -222,13 +222,13 @@ ThrowCompletionOr<NumberFormat*> initialize_number_format(VM& vm, NumberFormat& 
     // 32. Set numberFormat.[[UseGrouping]] to useGrouping.
     number_format.set_use_grouping(use_grouping);
 
-    // 33. Let signDisplay be ? GetOption(options, "signDisplay", "string", « "auto", "never", "always", "exceptZero, "negative" », "auto").
+    // 33. Let signDisplay be ? GetOption(options, "signDisplay", string, « "auto", "never", "always", "exceptZero, "negative" », "auto").
     auto sign_display = TRY(get_option(vm, *options, vm.names.signDisplay, OptionType::String, { "auto"sv, "never"sv, "always"sv, "exceptZero"sv, "negative"sv }, "auto"sv));
 
     // 34. Set numberFormat.[[SignDisplay]] to signDisplay.
     number_format.set_sign_display(TRY(sign_display.as_string().deprecated_string()));
 
-    // 35. Let roundingMode be ? GetOption(options, "roundingMode", "string", « "ceil", "floor", "expand", "trunc", "halfCeil", "halfFloor", "halfExpand", "halfTrunc", "halfEven" », "halfExpand").
+    // 35. Let roundingMode be ? GetOption(options, "roundingMode", string, « "ceil", "floor", "expand", "trunc", "halfCeil", "halfFloor", "halfExpand", "halfTrunc", "halfEven" », "halfExpand").
     auto rounding_mode = TRY(get_option(vm, *options, vm.names.roundingMode, OptionType::String, { "ceil"sv, "floor"sv, "expand"sv, "trunc"sv, "halfCeil"sv, "halfFloor"sv, "halfExpand"sv, "halfTrunc"sv, "halfEven"sv }, "halfExpand"sv));
 
     // 36. Set numberFormat.[[RoundingMode]] to roundingMode.
@@ -260,7 +260,7 @@ ThrowCompletionOr<void> set_number_format_digit_options(VM& vm, NumberFormatBase
     // 6. Set intlObj.[[MinimumIntegerDigits]] to mnid.
     intl_object.set_min_integer_digits(*min_integer_digits);
 
-    // 7. Let roundingPriority be ? GetOption(options, "roundingPriority", "string", « "auto", "morePrecision", "lessPrecision" », "auto").
+    // 7. Let roundingPriority be ? GetOption(options, "roundingPriority", string, « "auto", "morePrecision", "lessPrecision" », "auto").
     auto rounding_priority = TRY(get_option(vm, options, vm.names.roundingPriority, OptionType::String, { "auto"sv, "morePrecision"sv, "lessPrecision"sv }, "auto"sv));
 
     // 8. If mnsd is not undefined or mxsd is not undefined, then
@@ -406,13 +406,13 @@ ThrowCompletionOr<void> set_number_format_unit_options(VM& vm, NumberFormat& int
     // 1. Assert: Type(intlObj) is Object.
     // 2. Assert: Type(options) is Object.
 
-    // 3. Let style be ? GetOption(options, "style", "string", « "decimal", "percent", "currency", "unit" », "decimal").
+    // 3. Let style be ? GetOption(options, "style", string, « "decimal", "percent", "currency", "unit" », "decimal").
     auto style = TRY(get_option(vm, options, vm.names.style, OptionType::String, { "decimal"sv, "percent"sv, "currency"sv, "unit"sv }, "decimal"sv));
 
     // 4. Set intlObj.[[Style]] to style.
     intl_object.set_style(TRY(style.as_string().deprecated_string()));
 
-    // 5. Let currency be ? GetOption(options, "currency", "string", undefined, undefined).
+    // 5. Let currency be ? GetOption(options, "currency", string, empty, undefined).
     auto currency = TRY(get_option(vm, options, vm.names.currency, OptionType::String, {}, Empty {}));
 
     // 6. If currency is undefined, then
@@ -426,13 +426,13 @@ ThrowCompletionOr<void> set_number_format_unit_options(VM& vm, NumberFormat& int
     else if (!is_well_formed_currency_code(TRY(currency.as_string().deprecated_string())))
         return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, currency, "currency"sv);
 
-    // 8. Let currencyDisplay be ? GetOption(options, "currencyDisplay", "string", « "code", "symbol", "narrowSymbol", "name" », "symbol").
+    // 8. Let currencyDisplay be ? GetOption(options, "currencyDisplay", string, « "code", "symbol", "narrowSymbol", "name" », "symbol").
     auto currency_display = TRY(get_option(vm, options, vm.names.currencyDisplay, OptionType::String, { "code"sv, "symbol"sv, "narrowSymbol"sv, "name"sv }, "symbol"sv));
 
-    // 9. Let currencySign be ? GetOption(options, "currencySign", "string", « "standard", "accounting" », "standard").
+    // 9. Let currencySign be ? GetOption(options, "currencySign", string, « "standard", "accounting" », "standard").
     auto currency_sign = TRY(get_option(vm, options, vm.names.currencySign, OptionType::String, { "standard"sv, "accounting"sv }, "standard"sv));
 
-    // 10. Let unit be ? GetOption(options, "unit", "string", undefined, undefined).
+    // 10. Let unit be ? GetOption(options, "unit", string, empty, undefined).
     auto unit = TRY(get_option(vm, options, vm.names.unit, OptionType::String, {}, Empty {}));
 
     // 11. If unit is undefined, then
@@ -446,7 +446,7 @@ ThrowCompletionOr<void> set_number_format_unit_options(VM& vm, NumberFormat& int
     else if (!is_well_formed_unit_identifier(TRY(unit.as_string().deprecated_string())))
         return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, unit, "unit"sv);
 
-    // 13. Let unitDisplay be ? GetOption(options, "unitDisplay", "string", « "short", "narrow", "long" », "short").
+    // 13. Let unitDisplay be ? GetOption(options, "unitDisplay", string, « "short", "narrow", "long" », "short").
     auto unit_display = TRY(get_option(vm, options, vm.names.unitDisplay, OptionType::String, { "short"sv, "narrow"sv, "long"sv }, "short"sv));
 
     // 14. If style is "currency", then

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,7 +11,7 @@
 namespace JS::Intl {
 
 // 15.5.2 Number Format Functions, https://tc39.es/ecma402/#sec-number-format-functions
-// 1.1.4 Number Format Functions, https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-number-format-functions
+// 1.5.2 Number Format Functions, https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-number-format-functions
 NonnullGCPtr<NumberFormatFunction> NumberFormatFunction::create(Realm& realm, NumberFormat& number_format)
 {
     return realm.heap().allocate<NumberFormatFunction>(realm, number_format, *realm.intrinsics().function_prototype());

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -63,7 +63,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format)
 }
 
 // 15.3.4 Intl.NumberFormat.prototype.formatToParts ( value ), https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formattoparts
-// 1.4.4 Intl.NumberFormat.prototype.formatToParts ( value ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-intl.numberformat.prototype.formattoparts
+// 1.3.4 Intl.NumberFormat.prototype.formatToParts ( value ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-intl.numberformat.prototype.formattoparts
 JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_to_parts)
 {
     auto value = vm.argument(0);
@@ -80,7 +80,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_to_parts)
     return format_numeric_to_parts(vm, *number_format, move(mathematical_value));
 }
 
-// 1.4.5 Intl.NumberFormat.prototype.formatRange ( start, end ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-intl.numberformat.prototype.formatrange
+// 1.3.5 Intl.NumberFormat.prototype.formatRange ( start, end ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-intl.numberformat.prototype.formatrange
 JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_range)
 {
     auto start = vm.argument(0);
@@ -107,7 +107,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_range)
     return PrimitiveString::create(vm, move(formatted));
 }
 
-// 1.4.6 Intl.NumberFormat.prototype.formatRangeToParts ( start, end ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-intl.numberformat.prototype.formatrangetoparts
+// 1.3.6 Intl.NumberFormat.prototype.formatRangeToParts ( start, end ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-intl.numberformat.prototype.formatrangetoparts
 JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_range_to_parts)
 {
     auto start = vm.argument(0);
@@ -134,6 +134,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_range_to_parts)
 }
 
 // 15.3.5 Intl.NumberFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.numberformat.prototype.resolvedoptions
+// 1.3.7 Intl.NumberFormat.prototype.resolvedOptions ( ), https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html#sec-number-format-functions
 JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::resolved_options)
 {
     auto& realm = *vm.current_realm();

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -128,13 +128,13 @@ PluralRules::PluralRules(Object& prototype)
     return plural_rule_select(locale, type, number, move(operands));
 }
 
-// 1.1.5 PluralRuleSelectRange ( locale, type, xp, yp ), https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html#sec-pluralruleselectrange
+// 1.5.4 PluralRuleSelectRange ( locale, type, xp, yp ), https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html#sec-pluralruleselectrange
 ::Locale::PluralCategory plural_rule_select_range(StringView locale, ::Locale::PluralForm, ::Locale::PluralCategory start, ::Locale::PluralCategory end)
 {
     return ::Locale::determine_plural_range(locale, start, end);
 }
 
-// 1.1.6 ResolvePluralRange ( pluralRules, x, y ), https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html#sec-resolvepluralrange
+// 1.5.5 ResolvePluralRange ( pluralRules, x, y ), https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html#sec-resolvepluralrange
 ThrowCompletionOr<::Locale::PluralCategory> resolve_plural_range(VM& vm, PluralRules const& plural_rules, Value start, Value end)
 {
     // 1. Assert: Type(pluralRules) is Object.

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -84,13 +84,13 @@ ThrowCompletionOr<PluralRules*> initialize_plural_rules(VM& vm, PluralRules& plu
     // 3. Let opt be a new Record.
     LocaleOptions opt {};
 
-    // 4. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    // 4. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, AK::Array { "lookup"sv, "best fit"sv }, "best fit"sv));
 
     // 5. Set opt.[[localeMatcher]] to matcher.
     opt.locale_matcher = matcher;
 
-    // 6. Let t be ? GetOption(options, "type", "string", « "cardinal", "ordinal" », "cardinal").
+    // 6. Let t be ? GetOption(options, "type", string, « "cardinal", "ordinal" », "cardinal").
     auto type = TRY(get_option(vm, *options, vm.names.type, OptionType::String, AK::Array { "cardinal"sv, "ordinal"sv }, "cardinal"sv));
 
     // 7. Set pluralRules.[[Type]] to t.

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -48,7 +48,7 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::select)
     return PrimitiveString::create(vm, ::Locale::plural_category_to_string(plurality));
 }
 
-// 1.4.4 Intl.PluralRules.prototype.selectRange ( start, end ), https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html#sec-intl.pluralrules.prototype.selectrange
+// 1.3.4 Intl.PluralRules.prototype.selectRange ( start, end ), https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html#sec-intl.pluralrules.prototype.selectrange
 JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::select_range)
 {
     auto start = vm.argument(0);
@@ -76,7 +76,7 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::select_range)
 }
 
 // 16.3.4 Intl.PluralRules.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.resolvedoptions
-// 1.4.5 Intl.PluralRules.prototype.resolvedOptions ( ), https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html#sec-intl.pluralrules.prototype.resolvedoptions
+// 1.3.5 Intl.PluralRules.prototype.resolvedOptions ( ), https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html#sec-intl.pluralrules.prototype.resolvedoptions
 JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::resolved_options)
 {
     auto& realm = *vm.current_realm();

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -89,13 +89,13 @@ ThrowCompletionOr<RelativeTimeFormat*> initialize_relative_time_format(VM& vm, R
     // 3. Let opt be a new Record.
     LocaleOptions opt {};
 
-    // 4. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    // 4. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, AK::Array { "lookup"sv, "best fit"sv }, "best fit"sv));
 
     // 5. Set opt.[[LocaleMatcher]] to matcher.
     opt.locale_matcher = matcher;
 
-    // 6. Let numberingSystem be ? GetOption(options, "numberingSystem", "string", undefined, undefined).
+    // 6. Let numberingSystem be ? GetOption(options, "numberingSystem", string, empty, undefined).
     auto numbering_system = TRY(get_option(vm, *options, vm.names.numberingSystem, OptionType::String, {}, Empty {}));
 
     // 7. If numberingSystem is not undefined, then
@@ -125,13 +125,13 @@ ThrowCompletionOr<RelativeTimeFormat*> initialize_relative_time_format(VM& vm, R
     if (result.nu.has_value())
         relative_time_format.set_numbering_system(result.nu.release_value());
 
-    // 15. Let style be ? GetOption(options, "style", "string", « "long", "short", "narrow" », "long").
+    // 15. Let style be ? GetOption(options, "style", string, « "long", "short", "narrow" », "long").
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "long"sv, "short"sv, "narrow"sv }, "long"sv));
 
     // 16. Set relativeTimeFormat.[[Style]] to style.
     relative_time_format.set_style(TRY(style.as_string().deprecated_string()));
 
-    // 17. Let numeric be ? GetOption(options, "numeric", "string", « "always", "auto" », "always").
+    // 17. Let numeric be ? GetOption(options, "numeric", string, « "always", "auto" », "always").
     auto numeric = TRY(get_option(vm, *options, vm.names.numeric, OptionType::String, { "always"sv, "auto"sv }, "always"sv));
 
     // 18. Set relativeTimeFormat.[[Numeric]] to numeric.

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Idan Horowitz <idan.horowitz@serenityos.org>
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -62,7 +63,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> SegmenterConstructor::construct(Function
     // 6. Let opt be a new Record.
     LocaleOptions opt {};
 
-    // 7. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    // 7. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
 
     // 8. Set opt.[[localeMatcher]] to matcher.
@@ -76,7 +77,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> SegmenterConstructor::construct(Function
     // 11. Set segmenter.[[Locale]] to r.[[locale]].
     segmenter->set_locale(move(result.locale));
 
-    // 12. Let granularity be ? GetOption(options, "granularity", "string", « "grapheme", "word", "sentence" », "grapheme").
+    // 12. Let granularity be ? GetOption(options, "granularity", string, « "grapheme", "word", "sentence" », "grapheme").
     auto granularity = TRY(get_option(vm, *options, vm.names.granularity, OptionType::String, { "grapheme"sv, "word"sv, "sentence"sv }, "grapheme"sv));
 
     // 13. Set segmenter.[[SegmenterGranularity]] to granularity.

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatRangeToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatRangeToParts.js
@@ -56,8 +56,8 @@ describe("correct behavior", () => {
     test("approximately formatting", () => {
         const en1 = new Intl.NumberFormat("en", { maximumFractionDigits: 0 });
         expect(en1.formatRangeToParts(2.9, 3.1)).toEqual([
-            { type: "approximatelySign", value: "~", source: "" },
-            { type: "integer", value: "3", source: "" },
+            { type: "approximatelySign", value: "~", source: "shared" },
+            { type: "integer", value: "3", source: "shared" },
         ]);
 
         const en2 = new Intl.NumberFormat("en", {
@@ -66,15 +66,15 @@ describe("correct behavior", () => {
             maximumFractionDigits: 0,
         });
         expect(en2.formatRangeToParts(2.9, 3.1)).toEqual([
-            { type: "approximatelySign", value: "~", source: "" },
-            { type: "currency", value: "$", source: "" },
-            { type: "integer", value: "3", source: "" },
+            { type: "approximatelySign", value: "~", source: "shared" },
+            { type: "currency", value: "$", source: "shared" },
+            { type: "integer", value: "3", source: "shared" },
         ]);
 
         const ja1 = new Intl.NumberFormat("ja", { maximumFractionDigits: 0 });
         expect(ja1.formatRangeToParts(2.9, 3.1)).toEqual([
-            { type: "approximatelySign", value: "約", source: "" },
-            { type: "integer", value: "3", source: "" },
+            { type: "approximatelySign", value: "約", source: "shared" },
+            { type: "integer", value: "3", source: "shared" },
         ]);
 
         const ja2 = new Intl.NumberFormat("ja", {
@@ -83,9 +83,9 @@ describe("correct behavior", () => {
             maximumFractionDigits: 0,
         });
         expect(ja2.formatRangeToParts(2.9, 3.1)).toEqual([
-            { type: "approximatelySign", value: "約", source: "" },
-            { type: "currency", value: "￥", source: "" },
-            { type: "integer", value: "3", source: "" },
+            { type: "approximatelySign", value: "約", source: "shared" },
+            { type: "currency", value: "￥", source: "shared" },
+            { type: "integer", value: "3", source: "shared" },
         ]);
     });
 


### PR DESCRIPTION
The last several commits are older ECMA-402 editorial changes (mostly just spec text) that would've help figure out what actually changed in the monster NF v3 rebase on top of 402.