### PR TITLE
LibAudio: Don't assume that a non-full span means EOF

### DIFF
--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -233,8 +233,7 @@ ErrorOr<MP3::MP3Frame, LoaderError> MP3LoaderPlugin::read_frame_data(MP3::Header
     auto& buffer = maybe_buffer.value();
 
     size_t old_reservoir_size = m_bit_reservoir.size();
-    if (LOADER_TRY(m_bitstream->read(buffer)).size() != buffer.size())
-        return LoaderError { LoaderError::Category::IO, m_loaded_samples, "Could not find another whole frame." };
+    LOADER_TRY(m_bitstream->read_entire_buffer(buffer));
     if (m_bit_reservoir.write(buffer) != header.slot_count)
         return LoaderError { LoaderError::Category::IO, m_loaded_samples, "Could not write frame into bit reservoir." };
 


### PR DESCRIPTION
Especially if buffered streams are involved, not filling the span completely can also mean that we just ran out of filled buffer space and we need to refill it on the beginning of the next read call.

This fixes the current MP3 playback issues if file buffering is enabled.