### PR TITLE
HexEditor: Add strings to the value inspector

### DIFF
--- a/Userland/Applications/HexEditor/CMakeLists.txt
+++ b/Userland/Applications/HexEditor/CMakeLists.txt
@@ -24,4 +24,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_app(HexEditor ICON app-hex-editor)
-target_link_libraries(HexEditor PRIVATE LibCore LibGfx LibGUI LibConfig LibDesktop LibFileSystemAccessClient LibMain)
+target_link_libraries(HexEditor PRIVATE LibCore LibGfx LibGUI LibConfig LibDesktop LibFileSystemAccessClient LibMain LibTextCodec)

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -245,6 +245,18 @@ Optional<u8> HexEditor::get_byte(size_t position)
     return {};
 }
 
+ByteBuffer HexEditor::get_selected_bytes()
+{
+    auto num_selected_bytes = m_selection_end - m_selection_start;
+    ByteBuffer data;
+    data.ensure_capacity(num_selected_bytes);
+
+    for (size_t i = m_selection_start; i < m_selection_end; i++)
+        data.append(m_document->get(i).value);
+
+    return data;
+}
+
 void HexEditor::mousedown_event(GUI::MouseEvent& event)
 {
     if (event.button() != GUI::MouseButton::Primary) {

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -38,6 +38,7 @@ public:
     void open_file(NonnullOwnPtr<Core::File> file);
     ErrorOr<void> fill_selection(u8 fill_byte);
     Optional<u8> get_byte(size_t position);
+    ByteBuffer get_selected_bytes();
     ErrorOr<void> save_as(NonnullOwnPtr<Core::File>);
     ErrorOr<void> save();
 

--- a/Userland/Applications/HexEditor/ValueInspectorModel.h
+++ b/Userland/Applications/HexEditor/ValueInspectorModel.h
@@ -30,6 +30,9 @@ public:
         ASCII,
         UTF8,
         UTF16,
+        ASCIIString,
+        UTF8String,
+        UTF16String,
         __Count
     };
 
@@ -100,6 +103,12 @@ public:
             return "UTF-8";
         case UTF16:
             return "UTF-16";
+        case ASCIIString:
+            return "ASCII String";
+        case UTF8String:
+            return "UTF-8 String";
+        case UTF16String:
+            return "UTF-16 String";
         default:
             return "";
         }


### PR DESCRIPTION
Implements https://github.com/SerenityOS/serenity/issues/13655

Continuing work done by @MetallicSquid and @hamburger1984  in https://github.com/SerenityOS/serenity/pull/13809 and https://github.com/SerenityOS/serenity/pull/15590

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/2068912/213018311-89009642-92ee-4585-8bca-9d2f732d4d62.png">