### PR TITLE
PixelPaint: Don't allow the move tool to resize to zero pixels

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -93,7 +93,10 @@ void MoveTool::on_mousemove(Layer* layer, MouseEvent& event)
             auto aspect_ratio = m_layer_being_moved->size().aspect_ratio();
             scaling_origin = opposite_corner.end_point_for_aspect_ratio(scaling_origin, aspect_ratio);
         }
-        m_new_layer_rect = Gfx::IntRect::from_two_points(scaling_origin, opposite_corner);
+
+        auto scaled_rect = Gfx::IntRect::from_two_points(scaling_origin, opposite_corner);
+        if (!scaled_rect.is_empty())
+            m_new_layer_rect = scaled_rect;
     } else {
         m_layer_being_moved->set_location(m_layer_origin.translated(delta));
     }


### PR DESCRIPTION
This prevents an error message appearing when we attempt to scale a layer to zero pixels using the move tool.

Here's a video of the issue:

https://user-images.githubusercontent.com/2817754/212198129-3a0923d2-a5ef-47ce-b751-ee7242c0c7e3.mp4


