### PR TITLE
AK+Everywhere: Prevent accidentally hidden .to_string() errors

### DIFF
--- a/AK/DeprecatedString.h
+++ b/AK/DeprecatedString.h
@@ -284,7 +284,7 @@ public:
     template<typename... Parameters>
     [[nodiscard]] static DeprecatedString formatted(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
     {
-        VariadicFormatParams variadic_format_parameters { parameters... };
+        VariadicFormatParams<AllowDebugOnlyFormatters::No, Parameters...> variadic_format_parameters { parameters... };
         return vformatted(fmtstr.view(), variadic_format_parameters);
     }
 

--- a/AK/IPv4Address.h
+++ b/AK/IPv4Address.h
@@ -158,18 +158,18 @@ struct Traits<IPv4Address> : public GenericTraits<IPv4Address> {
 
 #ifdef KERNEL
 template<>
-struct Formatter<IPv4Address> : Formatter<ErrorOr<NonnullOwnPtr<Kernel::KString>>> {
+struct Formatter<IPv4Address> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, IPv4Address value)
     {
-        return Formatter<ErrorOr<NonnullOwnPtr<Kernel::KString>>>::format(builder, TRY(value.to_string()));
+        return Formatter<StringView>::format(builder, TRY(value.to_string())->view());
     }
 };
 #else
 template<>
-struct Formatter<IPv4Address> : Formatter<DeprecatedString> {
+struct Formatter<IPv4Address> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, IPv4Address value)
     {
-        return Formatter<DeprecatedString>::format(builder, value.to_deprecated_string());
+        return Formatter<StringView>::format(builder, value.to_deprecated_string());
     }
 };
 #endif

--- a/AK/IPv6Address.h
+++ b/AK/IPv6Address.h
@@ -281,18 +281,18 @@ struct Traits<IPv6Address> : public GenericTraits<IPv6Address> {
 
 #ifdef KERNEL
 template<>
-struct Formatter<IPv6Address> : Formatter<ErrorOr<NonnullOwnPtr<Kernel::KString>>> {
+struct Formatter<IPv6Address> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, IPv6Address const& value)
     {
-        return Formatter<ErrorOr<NonnullOwnPtr<Kernel::KString>>>::format(builder, TRY(value.to_string()));
+        return Formatter<StringView>::format(builder, TRY(value.to_string())->view());
     }
 };
 #else
 template<>
-struct Formatter<IPv6Address> : Formatter<DeprecatedString> {
+struct Formatter<IPv6Address> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, IPv6Address const& value)
     {
-        return Formatter<DeprecatedString>::format(builder, value.to_deprecated_string());
+        return Formatter<StringView>::format(builder, value.to_deprecated_string());
     }
 };
 #endif

--- a/AK/String.h
+++ b/AK/String.h
@@ -98,7 +98,7 @@ public:
     template<typename... Parameters>
     static ErrorOr<String> formatted(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
     {
-        VariadicFormatParams variadic_format_parameters { parameters... };
+        VariadicFormatParams<AllowDebugOnlyFormatters::No, Parameters...> variadic_format_parameters { parameters... };
         return vformatted(fmtstr.view(), variadic_format_parameters);
     }
 

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -33,7 +33,7 @@ public:
     template<typename... Parameters>
     ErrorOr<void> try_appendff(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
     {
-        VariadicFormatParams variadic_format_params { parameters... };
+        VariadicFormatParams<AllowDebugOnlyFormatters::No, Parameters...> variadic_format_params { parameters... };
         return vformat(*this, fmtstr.view(), variadic_format_params);
     }
     ErrorOr<void> try_append(char const*, size_t);
@@ -57,7 +57,7 @@ public:
     template<typename... Parameters>
     void appendff(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
     {
-        VariadicFormatParams variadic_format_params { parameters... };
+        VariadicFormatParams<AllowDebugOnlyFormatters::No, Parameters...> variadic_format_params { parameters... };
         MUST(vformat(*this, fmtstr.view(), variadic_format_params));
     }
 

--- a/Kernel/Bus/PCI/Device.h
+++ b/Kernel/Bus/PCI/Device.h
@@ -48,7 +48,7 @@ void dmesgln_pci(Device const& device, AK::CheckedFormatString<Parameters...>&& 
         return;
     if (builder.try_append(fmt.view()).is_error())
         return;
-    AK::VariadicFormatParams variadic_format_params { device.device_name(), device.pci_address(), parameters... };
+    AK::VariadicFormatParams<AK::AllowDebugOnlyFormatters::Yes, StringView, Address, Parameters...> variadic_format_params { device.device_name(), device.pci_address(), parameters... };
     vdmesgln(builder.string_view(), variadic_format_params);
 }
 

--- a/Kernel/KBufferBuilder.h
+++ b/Kernel/KBufferBuilder.h
@@ -37,7 +37,7 @@ public:
     {
         // FIXME: This really not ideal, but vformat expects StringBuilder.
         StringBuilder builder;
-        AK::VariadicFormatParams variadic_format_params { parameters... };
+        AK::VariadicFormatParams<AK::AllowDebugOnlyFormatters::No, Parameters...> variadic_format_params { parameters... };
         TRY(vformat(builder, fmtstr.view(), variadic_format_params));
         return append_bytes(builder.string_view().bytes());
     }

--- a/Kernel/KString.h
+++ b/Kernel/KString.h
@@ -26,7 +26,7 @@ public:
     template<typename... Parameters>
     [[nodiscard]] static ErrorOr<NonnullOwnPtr<KString>> formatted(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
     {
-        AK::VariadicFormatParams variadic_format_parameters { parameters... };
+        AK::VariadicFormatParams<AK::AllowDebugOnlyFormatters::No, Parameters...> variadic_format_parameters { parameters... };
         return vformatted(fmtstr.view(), variadic_format_parameters);
     }
 

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -73,7 +73,7 @@ ErrorOr<RefPtr<GUI::Window>> MainWidget::create_preview_window()
 
     m_preview_textbox = find_descendant_of_type_named<GUI::TextBox>("preview_textbox");
     m_preview_textbox->on_change = [&] {
-        auto preview = DeprecatedString::formatted("{}\n{}", m_preview_textbox->text(), Unicode::to_unicode_uppercase_full(m_preview_textbox->text()));
+        auto preview = DeprecatedString::formatted("{}\n{}", m_preview_textbox->text(), Unicode::to_unicode_uppercase_full(m_preview_textbox->text()).release_value_but_fixme_should_propagate_errors());
         m_preview_label->set_text(preview);
     };
     m_preview_textbox->set_text(pangrams[0]);

--- a/Userland/DevTools/UserspaceEmulator/Report.h
+++ b/Userland/DevTools/UserspaceEmulator/Report.h
@@ -14,7 +14,7 @@ template<typename... Ts>
 void reportln(StringView format, Ts... args)
 {
     if (g_report_to_debug) {
-        AK::VariadicFormatParams variadic_format_params { args... };
+        AK::VariadicFormatParams<AK::AllowDebugOnlyFormatters::Yes, Ts...> variadic_format_params { args... };
         AK::vdbgln(format, variadic_format_params);
     } else {
         warnln(format, args...);

--- a/Userland/Libraries/LibJS/Runtime/ThrowableFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/ThrowableFormat.h
@@ -19,7 +19,7 @@ template<typename... Args>
 ThrowCompletionOr<DeprecatedString> deprecated_format(VM& vm, CheckedFormatString<Args...>&& fmtstr, Args const&... args)
 {
     StringBuilder builder;
-    AK::VariadicFormatParams parameters { args... };
+    AK::VariadicFormatParams<AK::AllowDebugOnlyFormatters::No, Args...> parameters { args... };
 
     TRY_OR_THROW_OOM(vm, vformat(builder, fmtstr.view(), parameters));
     return builder.to_deprecated_string();

--- a/Userland/Libraries/LibVideo/DecoderError.h
+++ b/Userland/Libraries/LibVideo/DecoderError.h
@@ -43,7 +43,7 @@ public:
     template<typename... Parameters>
     static DecoderError format(DecoderErrorCategory category, CheckedFormatString<Parameters...>&& format_string, Parameters const&... parameters)
     {
-        AK::VariadicFormatParams variadic_format_params { parameters... };
+        AK::VariadicFormatParams<AK::AllowDebugOnlyFormatters::No, Parameters...> variadic_format_params { parameters... };
         return DecoderError::with_description(category, DeprecatedString::vformatted(format_string.view(), variadic_format_params));
     }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -631,16 +631,16 @@ bool CalculatedStyleValue::equals(StyleValue const& other) const
 ErrorOr<String> CalculatedStyleValue::CalcNumberValue::to_string() const
 {
     return value.visit(
-        [](Number const& number) { return String::number(number.value()); },
-        [](NonnullOwnPtr<CalcNumberSum> const& sum) { return String::formatted("({})", sum->to_string()); });
+        [](Number const& number) -> ErrorOr<String> { return String::number(number.value()); },
+        [](NonnullOwnPtr<CalcNumberSum> const& sum) -> ErrorOr<String> { return String::formatted("({})", TRY(sum->to_string())); });
 }
 
 ErrorOr<String> CalculatedStyleValue::CalcValue::to_string() const
 {
     return value.visit(
-        [](Number const& number) { return String::number(number.value()); },
-        [](NonnullOwnPtr<CalcSum> const& sum) { return String::formatted("({})", sum->to_string()); },
-        [](auto const& v) { return v.to_string(); });
+        [](Number const& number) -> ErrorOr<String> { return String::number(number.value()); },
+        [](NonnullOwnPtr<CalcSum> const& sum) -> ErrorOr<String> { return String::formatted("({})", TRY(sum->to_string())); },
+        [](auto const& v) -> ErrorOr<String> { return v.to_string(); });
 }
 
 ErrorOr<String> CalculatedStyleValue::CalcSum::to_string() const
@@ -677,9 +677,9 @@ ErrorOr<String> CalculatedStyleValue::CalcSumPartWithOperator::to_string() const
 
 ErrorOr<String> CalculatedStyleValue::CalcProductPartWithOperator::to_string() const
 {
-    auto value_string = value.visit(
+    auto value_string = TRY(value.visit(
         [](CalcValue const& v) { return v.to_string(); },
-        [](CalcNumberValue const& v) { return v.to_string(); });
+        [](CalcNumberValue const& v) { return v.to_string(); }));
     return String::formatted(" {} {}", op == ProductOperation::Multiply ? "*"sv : "/"sv, value_string);
 }
 
@@ -2347,7 +2347,7 @@ ErrorOr<String> PositionStyleValue::to_string() const
         VERIFY_NOT_REACHED();
     };
 
-    return String::formatted("{} {} {} {}", to_string(m_edge_x), m_offset_x.to_string(), to_string(m_edge_y), TRY(m_offset_y.to_string()));
+    return String::formatted("{} {} {} {}", to_string(m_edge_x), TRY(m_offset_x.to_string()), to_string(m_edge_y), TRY(m_offset_y.to_string()));
 }
 
 bool PositionStyleValue::equals(StyleValue const& other) const
@@ -2384,7 +2384,7 @@ bool ResolutionStyleValue::equals(StyleValue const& other) const
 ErrorOr<String> ShadowStyleValue::to_string() const
 {
     StringBuilder builder;
-    builder.appendff("{} {} {} {} {}", String::from_deprecated_string(m_color.to_deprecated_string()), TRY(m_offset_x.to_string()), TRY(m_offset_y.to_string()), TRY(m_blur_radius.to_string()), TRY(m_spread_distance.to_string()));
+    builder.appendff("{} {} {} {} {}", m_color.to_deprecated_string(), TRY(m_offset_x.to_string()), TRY(m_offset_y.to_string()), TRY(m_blur_radius.to_string()), TRY(m_spread_distance.to_string()));
     if (m_placement == ShadowPlacement::Inner)
         builder.append(" inset"sv);
     return builder.to_string();


### PR DESCRIPTION
This adds support for "debug only" formatters and makes `Formatter<ErrorOr<T>>` one. The idea here is this lets you debug
print `ErrorOr<T>` values (which I've always found handy), but if you try to use them in a `String::formatted()` call you'll get a compile-time error: 
![image](https://user-images.githubusercontent.com/11597044/212222867-4e6e8d21-d3df-4820-b99c-5f5d2174ae97.png)

This is to prevent accidentally hidden `.to_string()` errors when passing the new AK strings to formatters (which is pretty easy to do), without making printf debugging more annoying :^) 

cc @linusg 