### PR TITLE
LibDNS(+LibCore): Use `AllocatingMemoryStream` in DNS package construction

### DIFF
--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -108,6 +108,22 @@ public:
         return !write_entire_buffer(buffer).is_error();
     }
 
+    template<typename T>
+    requires(IsTriviallyDestructible<T>)
+    ErrorOr<T> read_trivial_value()
+    {
+        alignas(T) u8 buffer[sizeof(T)] = {};
+        TRY(read_entire_buffer(buffer));
+        return *bit_cast<T>(buffer);
+    }
+
+    template<typename T>
+    requires(IsTriviallyDestructible<T>)
+    ErrorOr<void> write_trivial_value(T const& value)
+    {
+        return write_entire_buffer({ &value, sizeof(value) });
+    }
+
     /// Returns whether the stream has reached the end of file. For sockets,
     /// this most likely means that the protocol has disconnected (in the case
     /// of TCP). For seekable streams, this means the end of the file. Note that

--- a/Userland/Libraries/LibDNS/CMakeLists.txt
+++ b/Userland/Libraries/LibDNS/CMakeLists.txt
@@ -5,4 +5,4 @@ set(SOURCES
 )
 
 serenity_lib(LibDNS dns)
-target_link_libraries(LibDNS PRIVATE LibIPC)
+target_link_libraries(LibDNS PRIVATE LibCore LibIPC)

--- a/Userland/Libraries/LibDNS/Name.cpp
+++ b/Userland/Libraries/LibDNS/Name.cpp
@@ -75,15 +75,15 @@ void Name::randomize_case()
     m_name = builder.to_deprecated_string();
 }
 
-OutputStream& operator<<(OutputStream& stream, Name const& name)
+ErrorOr<void> Name::write_to_stream(Core::Stream::Stream& stream) const
 {
-    auto parts = name.as_string().split_view('.');
+    auto parts = as_string().split_view('.');
     for (auto& part : parts) {
-        stream << (u8)part.length();
-        stream << part.bytes();
+        TRY(stream.write_trivial_value<u8>(part.length()));
+        TRY(stream.write_entire_buffer(part.bytes()));
     }
-    stream << '\0';
-    return stream;
+    TRY(stream.write_trivial_value('\0'));
+    return {};
 }
 
 unsigned Name::Traits::hash(Name const& name)

--- a/Userland/Libraries/LibDNS/Name.h
+++ b/Userland/Libraries/LibDNS/Name.h
@@ -9,6 +9,7 @@
 
 #include <AK/DeprecatedString.h>
 #include <AK/Forward.h>
+#include <LibCore/Stream.h>
 
 namespace DNS {
 
@@ -21,6 +22,7 @@ public:
 
     size_t serialized_size() const;
     DeprecatedString const& as_string() const { return m_name; }
+    ErrorOr<void> write_to_stream(Core::Stream::Stream&) const;
 
     void randomize_case();
 
@@ -35,8 +37,6 @@ public:
 private:
     DeprecatedString m_name;
 };
-
-OutputStream& operator<<(OutputStream& stream, Name const&);
 
 }
 

--- a/Userland/Libraries/LibDNS/Packet.h
+++ b/Userland/Libraries/LibDNS/Packet.h
@@ -25,7 +25,7 @@ public:
     Packet() = default;
 
     static Optional<Packet> from_raw_packet(u8 const*, size_t);
-    ByteBuffer to_byte_buffer() const;
+    ErrorOr<ByteBuffer> to_byte_buffer() const;
 
     bool is_query() const { return !m_query_or_response; }
     bool is_response() const { return m_query_or_response; }

--- a/Userland/Services/LookupServer/DNSServer.cpp
+++ b/Userland/Services/LookupServer/DNSServer.cpp
@@ -62,7 +62,7 @@ ErrorOr<void> DNSServer::handle_client()
     else
         response.set_code(Packet::Code::NOERROR);
 
-    buffer = response.to_byte_buffer();
+    buffer = TRY(response.to_byte_buffer());
 
     TRY(send(buffer, client_address));
     return {};

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -234,7 +234,7 @@ ErrorOr<Vector<Answer>> LookupServer::lookup(Name const& name, DeprecatedString 
         name_in_question.randomize_case();
     request.add_question({ name_in_question, record_type, RecordClass::IN, false });
 
-    auto buffer = request.to_byte_buffer();
+    auto buffer = TRY(request.to_byte_buffer());
 
     auto udp_socket = TRY(Core::Stream::UDPSocket::connect(nameserver, 53, Time::from_seconds(1)));
     TRY(udp_socket->set_blocking(true));

--- a/Userland/Services/LookupServer/MulticastDNS.cpp
+++ b/Userland/Services/LookupServer/MulticastDNS.cpp
@@ -110,7 +110,7 @@ void MulticastDNS::announce()
 
 ErrorOr<size_t> MulticastDNS::emit_packet(Packet const& packet, sockaddr_in const* destination)
 {
-    auto buffer = packet.to_byte_buffer();
+    auto buffer = TRY(packet.to_byte_buffer());
     if (!destination)
         destination = &mdns_addr;
 


### PR DESCRIPTION
This adds some helpers for reading and writing trivial types to `Core::Stream` and then uses them to get rid of `DuplexMemoryStream` in favor of `AllocatingMemoryStream` in LibDNS package construction.