### PR TITLE
LibLine: Port most functions to `Core::Stream` and start propagating errors

### DIFF
--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -183,8 +183,8 @@ public:
 
 #undef __ENUMERATE_EDITOR_INTERNAL_FUNCTION
 
-    void interrupted();
-    void resized();
+    ErrorOr<void> interrupted();
+    ErrorOr<void> resized();
 
     size_t cursor() const { return m_cursor; }
     void set_cursor(size_t cursor)
@@ -252,7 +252,7 @@ public:
             [this, previous_value] {
                 m_prohibit_input_processing = previous_value;
                 if (!m_prohibit_input_processing && m_have_unprocessed_read_event)
-                    handle_read_event();
+                    handle_read_event().release_value_but_fixme_should_propagate_errors();
             }
         };
     }
@@ -270,10 +270,10 @@ private:
     // FIXME: Port to Core::Property
     void save_to(JsonObject&);
 
-    void try_update_once();
+    ErrorOr<void> try_update_once();
     void handle_interrupt_event();
-    void handle_read_event();
-    void handle_resize_event(bool reset_origin);
+    ErrorOr<void> handle_read_event();
+    ErrorOr<void> handle_resize_event(bool reset_origin);
 
     void ensure_free_lines_from_origin(size_t count);
 
@@ -326,10 +326,10 @@ private:
         m_paste_buffer.clear_with_capacity();
     }
 
-    void refresh_display();
-    void cleanup();
-    void cleanup_suggestions();
-    void really_quit_event_loop();
+    ErrorOr<void> refresh_display();
+    ErrorOr<void> cleanup();
+    ErrorOr<void> cleanup_suggestions();
+    ErrorOr<void> really_quit_event_loop();
 
     void restore()
     {
@@ -393,7 +393,7 @@ private:
     }
 
     void recalculate_origin();
-    void reposition_cursor(Core::Stream::Stream&, bool to_end = false);
+    ErrorOr<void> reposition_cursor(Core::Stream::Stream&, bool to_end = false);
 
     struct CodepointRange {
         size_t start { 0 };

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -23,6 +23,7 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/Object.h>
+#include <LibCore/Stream.h>
 #include <LibLine/KeyCallbackMachine.h>
 #include <LibLine/Span.h>
 #include <LibLine/StringMetrics.h>
@@ -392,7 +393,7 @@ private:
     }
 
     void recalculate_origin();
-    void reposition_cursor(OutputStream&, bool to_end = false);
+    void reposition_cursor(Core::Stream::Stream&, bool to_end = false);
 
     struct CodepointRange {
         size_t start { 0 };

--- a/Userland/Libraries/LibLine/SuggestionDisplay.h
+++ b/Userland/Libraries/LibLine/SuggestionDisplay.h
@@ -18,20 +18,22 @@ class Editor;
 class SuggestionDisplay {
 public:
     virtual ~SuggestionDisplay() = default;
-    virtual void display(SuggestionManager const&) = 0;
-    virtual bool cleanup() = 0;
+    virtual ErrorOr<void> display(SuggestionManager const&) = 0;
+    virtual ErrorOr<bool> cleanup() = 0;
     virtual void finish() = 0;
     virtual void set_initial_prompt_lines(size_t) = 0;
 
-    void redisplay(SuggestionManager const& manager, size_t lines, size_t columns)
+    ErrorOr<void> redisplay(SuggestionManager const& manager, size_t lines, size_t columns)
     {
         if (m_is_showing_suggestions) {
-            cleanup();
+            TRY(cleanup());
             set_vt_size(lines, columns);
-            display(manager);
+            TRY(display(manager));
         } else {
             set_vt_size(lines, columns);
         }
+
+        return {};
     }
 
     virtual void set_vt_size(size_t lines, size_t columns) = 0;
@@ -62,8 +64,8 @@ public:
     {
     }
     virtual ~XtermSuggestionDisplay() override = default;
-    virtual void display(SuggestionManager const&) override;
-    virtual bool cleanup() override;
+    virtual ErrorOr<void> display(SuggestionManager const&) override;
+    virtual ErrorOr<bool> cleanup() override;
     virtual void finish() override
     {
         m_pages.clear();

--- a/Userland/Libraries/LibLine/SuggestionManager.cpp
+++ b/Userland/Libraries/LibLine/SuggestionManager.cpp
@@ -182,13 +182,13 @@ SuggestionManager::CompletionAttemptResult SuggestionManager::attempt_completion
     return result;
 }
 
-size_t SuggestionManager::for_each_suggestion(Function<IterationDecision(CompletionSuggestion const&, size_t)> callback) const
+ErrorOr<size_t> SuggestionManager::for_each_suggestion(Function<ErrorOr<IterationDecision>(CompletionSuggestion const&, size_t)> callback) const
 {
     size_t start_index { 0 };
     for (auto& suggestion : m_suggestions) {
         if (start_index++ < m_last_displayed_suggestion_index)
             continue;
-        if (callback(suggestion, start_index - 1) == IterationDecision::Break)
+        if (TRY(callback(suggestion, start_index - 1)) == IterationDecision::Break)
             break;
     }
     return start_index;

--- a/Userland/Libraries/LibLine/SuggestionManager.h
+++ b/Userland/Libraries/LibLine/SuggestionManager.h
@@ -78,7 +78,7 @@ public:
     size_t next_index() const { return m_next_suggestion_index; }
     void set_start_index(size_t index) const { m_last_displayed_suggestion_index = index; }
 
-    size_t for_each_suggestion(Function<IterationDecision(CompletionSuggestion const&, size_t)>) const;
+    ErrorOr<size_t> for_each_suggestion(Function<ErrorOr<IterationDecision>(CompletionSuggestion const&, size_t)>) const;
 
     enum CompletionMode {
         DontComplete,

--- a/Userland/Libraries/LibLine/VT.h
+++ b/Userland/Libraries/LibLine/VT.h
@@ -13,13 +13,13 @@
 namespace Line {
 namespace VT {
 
-void save_cursor(Core::Stream::Stream&);
-void restore_cursor(Core::Stream::Stream&);
-void clear_to_end_of_line(Core::Stream::Stream&);
-void clear_lines(size_t count_above, size_t count_below, Core::Stream::Stream&);
-void move_relative(int x, int y, Core::Stream::Stream&);
-void move_absolute(u32 x, u32 y, Core::Stream::Stream&);
-void apply_style(Style const&, Core::Stream::Stream&, bool is_starting = true);
+ErrorOr<void> save_cursor(Core::Stream::Stream&);
+ErrorOr<void> restore_cursor(Core::Stream::Stream&);
+ErrorOr<void> clear_to_end_of_line(Core::Stream::Stream&);
+ErrorOr<void> clear_lines(size_t count_above, size_t count_below, Core::Stream::Stream&);
+ErrorOr<void> move_relative(int x, int y, Core::Stream::Stream&);
+ErrorOr<void> move_absolute(u32 x, u32 y, Core::Stream::Stream&);
+ErrorOr<void> apply_style(Style const&, Core::Stream::Stream&, bool is_starting = true);
 
 }
 }

--- a/Userland/Libraries/LibLine/VT.h
+++ b/Userland/Libraries/LibLine/VT.h
@@ -7,18 +7,19 @@
 #pragma once
 
 #include <AK/Types.h>
+#include <LibCore/Stream.h>
 #include <LibLine/Style.h>
 
 namespace Line {
 namespace VT {
 
-void save_cursor(OutputStream&);
-void restore_cursor(OutputStream&);
-void clear_to_end_of_line(OutputStream&);
-void clear_lines(size_t count_above, size_t count_below, OutputStream&);
-void move_relative(int x, int y, OutputStream&);
-void move_absolute(u32 x, u32 y, OutputStream&);
-void apply_style(Style const&, OutputStream&, bool is_starting = true);
+void save_cursor(Core::Stream::Stream&);
+void restore_cursor(Core::Stream::Stream&);
+void clear_to_end_of_line(Core::Stream::Stream&);
+void clear_lines(size_t count_above, size_t count_below, Core::Stream::Stream&);
+void move_relative(int x, int y, Core::Stream::Stream&);
+void move_absolute(u32 x, u32 y, Core::Stream::Stream&);
+void apply_style(Style const&, Core::Stream::Stream&, bool is_starting = true);
 
 }
 }


### PR DESCRIPTION
Separate simply because this are two very huge commits and because it still adds quite a number of `release_value_but_fixme_should_propagate_errors`.

Also, don't ask me what `clang-format` is doing.