### PR TITLE
LibCore: Enable file descriptor passing on FreeBSD

### DIFF
--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -583,7 +583,7 @@ ErrorOr<int> LocalSocket::receive_fd(int flags)
 {
 #if defined(AK_OS_SERENITY)
     return Core::System::recvfd(m_helper.fd(), flags);
-#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS)
+#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS) || defined(AK_OS_FREEBSD)
     union {
         struct cmsghdr cmsghdr;
         char control[CMSG_SPACE(sizeof(int))];
@@ -624,7 +624,7 @@ ErrorOr<void> LocalSocket::send_fd(int fd)
 {
 #if defined(AK_OS_SERENITY)
     return Core::System::sendfd(m_helper.fd(), fd);
-#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS)
+#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS) || defined(AK_OS_FREEBSD)
     char c = 'F';
     struct iovec iov {
         .iov_base = &c,


### PR DESCRIPTION
Ladybird currently doesn't render any webpages on FreeBSD and throws hundreds of errors,beginning with this: IPC::ConnectionBase (0x0000000805bf2b00) had an error (File descriptor passing not supported on this platform), disconnecting. WebContent process crashed!
Changing those two lines makes Ladybird work perfectly fine on my FreeBSD computer.