### PR TITLE
PixelPaint: Hold shift to increase move tool speed with the arrow keys

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -141,7 +141,7 @@ bool MoveTool::on_keydown(GUI::KeyEvent& event)
     if (m_scaling)
         return true;
 
-    if (event.modifiers() != 0)
+    if (!(event.modifiers() == Mod_None || event.modifiers() == Mod_Shift))
         return false;
 
     auto* layer = m_editor->active_layer();
@@ -149,19 +149,19 @@ bool MoveTool::on_keydown(GUI::KeyEvent& event)
         return false;
 
     auto new_location = layer->location();
-
+    auto speed = event.shift() ? 10 : 1;
     switch (event.key()) {
     case Key_Up:
-        new_location.translate_by(0, -1);
+        new_location.translate_by(0, -speed);
         break;
     case Key_Down:
-        new_location.translate_by(0, 1);
+        new_location.translate_by(0, speed);
         break;
     case Key_Left:
-        new_location.translate_by(-1, 0);
+        new_location.translate_by(-speed, 0);
         break;
     case Key_Right:
-        new_location.translate_by(1, 0);
+        new_location.translate_by(speed, 0);
         break;
     default:
         return false;


### PR DESCRIPTION
Holding shift while using the move tool with the arrow keys moves the selected layer in 10 pixel increments.

I wasn't sure what factor to increase the speed by. Photoshop uses 10. GIMP uses 25. I went with 10 because I personally found it more useful during testing, although that may be because I use relatively small images.

Video:

https://user-images.githubusercontent.com/2817754/212407031-78c3567c-c8f1-44d3-b52e-4004b42b9e88.mp4

