### PR TITLE
LibWeb: Propagate all StringBuilder errors out of StyleValue

### DIFF
--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -79,14 +79,20 @@ public:
     template<class SeparatorType, class CollectionType>
     void join(SeparatorType const& separator, CollectionType const& collection, StringView fmtstr = "{}"sv)
     {
+        MUST(try_join(separator, collection, fmtstr));
+    }
+
+    template<class SeparatorType, class CollectionType>
+    ErrorOr<void> try_join(SeparatorType const& separator, CollectionType const& collection, StringView fmtstr = "{}"sv)
+    {
         bool first = true;
         for (auto& item : collection) {
-            if (first)
-                first = false;
-            else
-                append(separator);
-            appendff(fmtstr, item);
+            if (!first)
+                TRY(try_append(separator));
+            TRY(try_appendff(fmtstr, item));
+            first = false;
         }
+        return {};
     }
 
 private:

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -132,7 +133,7 @@ struct PositionValue {
     VerticalEdge y_relative_to { VerticalEdge::Top };
 
     CSSPixelPoint resolved(Layout::Node const& node, CSSPixelRect const& rect) const;
-    void serialize(StringBuilder&) const;
+    ErrorOr<void> serialize(StringBuilder&) const;
     bool operator==(PositionValue const&) const;
 };
 


### PR DESCRIPTION
Now that all the `.to_string()` functions return `ErrorOr<String>` it's easy to switch these over to the failable StringBuilder methods. It is a little verbose, but those errors have places to be and can't stick around in StyleValue.