### PR TITLE
Meta: Fix copyright header in Kernel/Syscalls/jail.cpp file

### DIFF
--- a/Kernel/Syscalls/jail.cpp
+++ b/Kernel/Syscalls/jail.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */


### PR DESCRIPTION
I wrote that file in 2022, not Andreas in 2018.