### PR TITLE
LibSQL: Don't do fchmod on FreeBSD

### DIFF
--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -37,7 +37,7 @@ static ErrorOr<int> create_database_socket(DeprecatedString const& socket_path)
     TRY(Core::System::fcntl(socket_fd, F_SETFD, FD_CLOEXEC));
 #    endif
 
-#    ifndef AK_OS_MACOS
+#    if !defined(AK_OS_MACOS) && !defined(AK_OS_FREEBSD)
     TRY(Core::System::fchmod(socket_fd, 0600));
 #    endif
 


### PR DESCRIPTION
Ladybird instantly crashes on FreeBSD with the following error:
Failed to create a database socket at /var/run/user/1001/SQLServer.socket: fchmod: Invalid argument (errno=22)
Disabling the fchmod command on FreeBSD,just like on MacOS,fixes that.
Generally,FreeBSD and MacOS often behave very similar as MacOS is partially based on FreeBSD source code.