### PR TITLE
LibProtocol+pro(+LibCore): Remove the ability to stream request responses into `AK::OutputStream`

### DIFF
--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -99,15 +99,6 @@ public:
     /// contents are written or an error occurs.
     virtual ErrorOr<void> write_entire_buffer(ReadonlyBytes);
 
-    // This is a wrapper around `write_entire_buffer` that is compatible with
-    // `write_or_error`. This is required by some templated code in LibProtocol
-    // that needs to work with either type of stream.
-    // TODO: Fully port or wrap `Request::stream_into_impl` into `Core::Stream` and remove this.
-    bool write_or_error(ReadonlyBytes buffer)
-    {
-        return !write_entire_buffer(buffer).is_error();
-    }
-
     template<typename T>
     requires(IsTriviallyDestructible<T>)
     ErrorOr<T> read_trivial_value()

--- a/Userland/Libraries/LibProtocol/Request.cpp
+++ b/Userland/Libraries/LibProtocol/Request.cpp
@@ -20,8 +20,7 @@ bool Request::stop()
     return m_client->stop_request({}, *this);
 }
 
-template<typename T>
-void Request::stream_into_impl(T& stream)
+void Request::stream_into(Core::Stream::Stream& stream)
 {
     VERIFY(!m_internal_stream_data);
 
@@ -54,10 +53,8 @@ void Request::stream_into_impl(T& stream)
             auto read_bytes = result.release_value();
             if (read_bytes.is_empty())
                 break;
-            if (!stream.write_or_error(read_bytes)) {
-                // FIXME: What do we do here?
-                TODO();
-            }
+            // FIXME: What do we do if this fails?
+            stream.write_entire_buffer(read_bytes).release_value_but_fixme_should_propagate_errors();
             break;
         } while (true);
 
@@ -67,16 +64,6 @@ void Request::stream_into_impl(T& stream)
         if (m_internal_stream_data->request_done)
             m_internal_stream_data->on_finish();
     };
-}
-
-void Request::stream_into(Core::Stream::Stream& stream)
-{
-    stream_into_impl(stream);
-}
-
-void Request::stream_into(OutputStream& stream)
-{
-    stream_into_impl(stream);
 }
 
 void Request::set_should_buffer_all_input(bool value)

--- a/Userland/Libraries/LibProtocol/Request.cpp
+++ b/Userland/Libraries/LibProtocol/Request.cpp
@@ -102,7 +102,8 @@ void Request::set_should_buffer_all_input(bool value)
     };
 
     on_finish = [this](auto success, u32 total_size) {
-        auto output_buffer = m_internal_buffered_data->payload_stream.copy_into_contiguous_buffer();
+        auto output_buffer = ByteBuffer::create_uninitialized(m_internal_buffered_data->payload_stream.used_buffer_size()).release_value_but_fixme_should_propagate_errors();
+        m_internal_buffered_data->payload_stream.read_entire_buffer(output_buffer).release_value_but_fixme_should_propagate_errors();
         on_buffered_request_finish(
             success,
             total_size,

--- a/Userland/Libraries/LibProtocol/Request.h
+++ b/Userland/Libraries/LibProtocol/Request.h
@@ -39,7 +39,6 @@ public:
     int fd() const { return m_fd; }
     bool stop();
 
-    void stream_into(OutputStream&);
     void stream_into(Core::Stream::Stream&);
 
     bool should_buffer_all_input() const { return m_should_buffer_all_input; }
@@ -63,8 +62,6 @@ public:
 
 private:
     explicit Request(RequestClient&, i32 request_id);
-    template<typename T>
-    void stream_into_impl(T&);
 
     WeakPtr<RequestClient> m_client;
     int m_request_id { -1 };

--- a/Userland/Libraries/LibProtocol/Request.h
+++ b/Userland/Libraries/LibProtocol/Request.h
@@ -14,6 +14,7 @@
 #include <AK/MemoryStream.h>
 #include <AK/RefCounted.h>
 #include <AK/WeakPtr.h>
+#include <LibCore/MemoryStream.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/Stream.h>
 #include <LibIPC/Forward.h>
@@ -72,7 +73,7 @@ private:
     bool m_should_buffer_all_input { false };
 
     struct InternalBufferedData {
-        DuplexMemoryStream payload_stream;
+        Core::Stream::AllocatingMemoryStream payload_stream;
         HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> response_headers;
         Optional<u32> response_code;
     };


### PR DESCRIPTION
This removes the need for the `write_or_error` function that we added to `Core::Stream::Stream` a while back for compatibility purposes.