### PR TITLE
LibSQL: Don't do fchmod on OpenBSD

### DIFF
--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -37,7 +37,7 @@ static ErrorOr<int> create_database_socket(DeprecatedString const& socket_path)
     TRY(Core::System::fcntl(socket_fd, F_SETFD, FD_CLOEXEC));
 #    endif
 
-#    if !defined(AK_OS_MACOS) && !defined(AK_OS_FREEBSD)
+#    if !defined(AK_OS_MACOS) && !defined(AK_OS_FREEBSD) && !defined(AK_OS_OPENBSD)
     TRY(Core::System::fchmod(socket_fd, 0600));
 #    endif
 


### PR DESCRIPTION
The same fix that I already did in #17007 for FreeBSD also works for OpenBSD.
Now there are still other things in Ladybird broken on OpenBSD,but this is the first step to make it work.