### PR TITLE
LibWeb: Override width calculation for table wrappers 

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -347,6 +347,7 @@ set(SOURCES
     Layout/TableFormattingContext.cpp
     Layout/TableRowBox.cpp
     Layout/TableRowGroupBox.cpp
+    Layout/TableWrapper.cpp
     Layout/TextNode.cpp
     Layout/TreeBuilder.cpp
     Loader/ContentFilter.cpp

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -454,6 +454,7 @@ class NodeWithStyle;
 class NodeWithStyleAndBoxModelMetrics;
 class RadioButton;
 class ReplacedBox;
+class TableWrapper;
 class TextNode;
 }
 

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -59,6 +59,8 @@ private:
 
     void compute_width_for_block_level_replaced_element_in_normal_flow(ReplacedBox const&, AvailableSpace const&);
 
+    CSSPixels compute_width_for_table_wrapper(Box const&, AvailableSpace const&);
+
     void layout_initial_containing_block(LayoutMode, AvailableSpace const&);
 
     void layout_block_level_children(BlockContainer const&, LayoutMode, AvailableSpace const&);

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -90,6 +90,7 @@ public:
     virtual bool is_label() const { return false; }
     virtual bool is_replaced_box() const { return false; }
     virtual bool is_list_item_marker_box() const { return false; }
+    virtual bool is_table_wrapper() const { return false; }
 
     template<typename T>
     bool fast_is() const = delete;

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -127,7 +127,9 @@ void TableFormattingContext::compute_table_measures()
         if (!computed_values.min_width().is_auto())
             min_width = max(min_width, computed_values.min_width().resolved(cell.box, width_of_containing_block_as_length).to_px(cell.box));
 
-        CSSPixels max_width = computed_values.width().is_auto() ? max_content_width.value() : width;
+        // NOTE: percentage column width cannot be used because it cannot be resolved correctly
+        // when final table width is not known yet
+        CSSPixels max_width = !computed_values.width().is_length() ? max_content_width.value() : width;
         if (!computed_values.max_width().is_none())
             max_width = min(max_width, computed_values.max_width().resolved(cell.box, width_of_containing_block_as_length).to_px(cell.box));
 
@@ -140,7 +142,11 @@ void TableFormattingContext::compute_table_measures()
         }
 
         cell.min_width = min_width + cell_intrinsic_offsets;
-        cell.max_width = max(max(width, min_width), max_width) + cell_intrinsic_offsets;
+        if (!computed_values.width().is_percentage()) {
+            cell.max_width = max(max(width, min_width), max_width) + cell_intrinsic_offsets;
+        } else {
+            cell.max_width = max(min_width, max_width) + cell_intrinsic_offsets;
+        }
 
         max_cell_column_span = max(max_cell_column_span, cell.column_span);
     }

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -210,7 +210,9 @@ void TableFormattingContext::compute_table_width()
 
     auto& computed_values = table_box().computed_values();
 
-    CSSPixels width_of_table_containing_block = m_state.get(*table_box().containing_block()).content_width();
+    // Percentages on 'width' and 'height' on the table are relative to the table wrapper box's containing block,
+    // not the table wrapper box itself.
+    CSSPixels width_of_table_containing_block = m_state.get(*table_wrapper().containing_block()).content_width();
 
     // The row/column-grid width minimum (GRIDMIN) width is the sum of the min-content width
     // of all the columns plus cell spacing or borders.

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <LibWeb/Layout/FormattingContext.h>
+#include <LibWeb/Layout/TableWrapper.h>
 
 namespace Web::Layout {
 
@@ -20,6 +21,10 @@ public:
     virtual CSSPixels automatic_content_height() const override;
 
     TableBox const& table_box() const { return static_cast<TableBox const&>(context_box()); }
+    TableWrapper const& table_wrapper() const
+    {
+        return verify_cast<TableWrapper>(*table_box().containing_block());
+    }
 
 private:
     void calculate_row_column_grid(Box const&);

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -32,7 +32,7 @@ private:
     void compute_table_width();
     void distribute_width_to_columns();
     void determine_intrisic_size_of_table_container(AvailableSpace const& available_space);
-    void calculate_row_heights();
+    void calculate_row_heights(LayoutMode layout_mode);
     void position_row_boxes();
     void position_cell_boxes();
 

--- a/Userland/Libraries/LibWeb/Layout/TableWrapper.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableWrapper.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Layout/TableWrapper.h>
+
+namespace Web::Layout {
+
+TableWrapper::TableWrapper(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::StyleProperties> style)
+    : BlockContainer(document, node, move(style))
+{
+}
+
+TableWrapper::TableWrapper(DOM::Document& document, DOM::Node* node, CSS::ComputedValues computed_values)
+    : BlockContainer(document, node, move(computed_values))
+{
+}
+
+TableWrapper::~TableWrapper() = default;
+
+}

--- a/Userland/Libraries/LibWeb/Layout/TableWrapper.h
+++ b/Userland/Libraries/LibWeb/Layout/TableWrapper.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Layout/BlockContainer.h>
+
+namespace Web::Layout {
+
+class TableWrapper : public BlockContainer {
+    JS_CELL(TableWrapper, BlockContainer);
+
+public:
+    TableWrapper(DOM::Document&, DOM::Node*, NonnullRefPtr<CSS::StyleProperties>);
+    TableWrapper(DOM::Document&, DOM::Node*, CSS::ComputedValues);
+    virtual ~TableWrapper() override;
+
+private:
+    virtual bool is_table_wrapper() const final { return true; }
+};
+
+template<>
+inline bool Node::fast_is<TableWrapper>() const { return is_table_wrapper(); }
+
+}

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/Layout/TableBox.h>
 #include <LibWeb/Layout/TableCellBox.h>
 #include <LibWeb/Layout/TableRowBox.h>
+#include <LibWeb/Layout/TableWrapper.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/TreeBuilder.h>
 #include <LibWeb/SVG/SVGForeignObjectElement.h>
@@ -598,7 +599,7 @@ void TreeBuilder::generate_missing_parents(NodeWithStyle& root)
         mutable_wrapper_computed_values.set_margin(table_box->computed_values().margin());
         table_box->reset_table_box_computed_values_used_by_wrapper_to_init_values();
 
-        auto wrapper = parent.heap().allocate_without_realm<BlockContainer>(parent.document(), nullptr, move(wrapper_computed_values));
+        auto wrapper = parent.heap().allocate_without_realm<TableWrapper>(parent.document(), nullptr, move(wrapper_computed_values));
 
         parent.remove_child(*table_box);
         wrapper->append_child(*table_box);


### PR DESCRIPTION
These changes make tables on https://mirrors.kernel.org/ be displayed more correctly.