### PR TITLE
LibCore: On OpenBSD, handle anon_create() like on MacOS

### DIFF
--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -403,7 +403,7 @@ ErrorOr<int> anon_create([[maybe_unused]] size_t size, [[maybe_unused]] int opti
         TRY(close(fd));
         return Error::from_errno(saved_errno);
     }
-#elif defined(AK_OS_MACOS) || defined(AK_OS_EMSCRIPTEN)
+#elif defined(AK_OS_MACOS) || defined(AK_OS_EMSCRIPTEN) || defined(AK_OS_OPENBSD)
     struct timespec time;
     clock_gettime(CLOCK_REALTIME, &time);
     auto name = DeprecatedString::formatted("/shm-{}{}", (unsigned long)time.tv_sec, (unsigned long)time.tv_nsec);


### PR DESCRIPTION
Fix `assertion "!buffer_or_error.is_error()" failed: file "/home/my_name/serenity/Userland/Services/WebContent/PageHost.cpp", line 45, function "setup_palette"` on OpenBSD.
LibCore didn't have a way to deal with OpenBSD systems in anon_create() which lead to this error.
I found out that the handling for MacOS and Emscripten works on OpenBSD as well.