### PR TITLE
LibCore: Enable file descriptor passing on OpenBSD

### DIFF
--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -579,7 +579,7 @@ ErrorOr<int> LocalSocket::receive_fd(int flags)
 {
 #if defined(AK_OS_SERENITY)
     return Core::System::recvfd(m_helper.fd(), flags);
-#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS) || defined(AK_OS_FREEBSD)
+#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS) || defined(AK_OS_FREEBSD) || defined(AK_OS_OPENBSD)
     union {
         struct cmsghdr cmsghdr;
         char control[CMSG_SPACE(sizeof(int))];
@@ -620,7 +620,7 @@ ErrorOr<void> LocalSocket::send_fd(int fd)
 {
 #if defined(AK_OS_SERENITY)
     return Core::System::sendfd(m_helper.fd(), fd);
-#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS) || defined(AK_OS_FREEBSD)
+#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS) || defined(AK_OS_FREEBSD) || defined(AK_OS_OPENBSD)
     char c = 'F';
     struct iovec iov {
         .iov_base = &c,


### PR DESCRIPTION
This is basically the same I already did in #16997 ,but now for OpenBSD.
OpenBSD showed the same error: `IPC::ConnectionBase (0x0000000805bf2b00) had an error (File descriptor passing not supported on this platform), disconnecting. WebContent process crashed!` but instead of showing a blank page,Ladybird completely crashed here.
The same code for Linux,MacOS and FreeBSD also works on OpenBSD,so I enabled it.
Ladybird now mostly works on OpenBSD.
Sometimes webpages crash which work on FreeBSD,but that may also be my laptop having too few cpu power.