### PR TITLE
LibGfx+ImageViewer: Add option to load raw bitmap binary files as pictures

### DIFF
--- a/Base/usr/share/man/man1/Applications/ImageViewer.md
+++ b/Base/usr/share/man/man1/Applications/ImageViewer.md
@@ -7,7 +7,7 @@
 ## Synopsis
 
 ```**sh
-$ ImageViewer [file]
+$ ImageViewer [file] [-f] [-h Height] [-w Width] [-b bitmap_format]
 ```
 
 ## Description
@@ -20,6 +20,13 @@ File manipulation has no effect on the image. Flip or rotate actions are not sav
 
 ImageViewer is even smart enough to detect other images and display them when clicking on the navigation buttons or when using direction arrows. ImageViewer can even set the currently loaded image as a Desktop Wallpaper.
 
+## Options
+
+* `-f`, `--fallback-binary`: Try to decode a file as an image of a known format, otherwise fallback to use it as a raw binary bitmap data
+* `-w Width`, `--width Width`: Force width when displaying an image
+* `-h Height`, `--height Height`: Force height when displaying an image
+* `-b [bgrx, bgra, rgbx, rgba]`, `--bitmap-format [bgrx, bgra, rgbx, rgba]`: Force bitmap format when decoding as a raw binary bitmap file
+
 ## Arguments
 
 * `file`: The image file to be displayed.
@@ -27,6 +34,9 @@ ImageViewer is even smart enough to detect other images and display them when cl
 ## Examples
 
 ```sh
+# Display the known Buggie picture
 $ ImageViewer /res/graphics/buggie.png
+# Display a raw bitmap binary file, with width of 220 pixels and height of 100, encoded in RGBA8888 format.
+$ ImageViewer -f -w 220 -h 100 -b rgba example.bin
 ```
 

--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -36,6 +36,8 @@ public:
     bool scaled_for_first_image() { return m_scaled_for_first_image; }
     void set_scaled_for_first_image(bool val) { m_scaled_for_first_image = val; }
     void set_path(DeprecatedString const& path);
+    void set_forced_dimensions(Gfx::IntSize dimensions);
+    void set_forced_bitmap_format(Gfx::BitmapFormat dimensions);
     void resize_window();
     void set_scaling_mode(Gfx::Painter::ScalingMode);
 
@@ -78,6 +80,8 @@ private:
     Vector<DeprecatedString> m_files_in_same_dir;
     Optional<size_t> m_current_index;
     Gfx::Painter::ScalingMode m_scaling_mode { Gfx::Painter::ScalingMode::NearestNeighbor };
+    Optional<Gfx::IntSize> m_forced_dimensions;
+    Optional<Gfx::BitmapFormat> m_forced_bitmap_format;
 };
 
 }

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -102,6 +102,7 @@ public:
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_load_from_fd_and_close(int fd, StringView path);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_create_with_anonymous_buffer(BitmapFormat, Core::AnonymousBuffer, IntSize, int intrinsic_scale, Vector<ARGB32> const& palette);
     static ErrorOr<NonnullRefPtr<Bitmap>> try_create_from_serialized_bytes(ReadonlyBytes);
+    static ErrorOr<NonnullRefPtr<Bitmap>> try_create_from_raw_bytes(BitmapFormat, IntSize dimensions, int scale_factor, ReadonlyBytes);
     static ErrorOr<NonnullRefPtr<Bitmap>> try_create_from_serialized_byte_buffer(ByteBuffer&&);
 
     static bool is_path_a_supported_image_format(StringView path)

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -38,6 +38,7 @@ enum class BitmapFormat {
     Indexed8,
     BGRx8888,
     BGRA8888,
+    RGBx8888,
     RGBA8888,
 };
 
@@ -51,6 +52,7 @@ inline bool is_valid_bitmap_format(unsigned format)
     case (unsigned)BitmapFormat::Indexed8:
     case (unsigned)BitmapFormat::BGRx8888:
     case (unsigned)BitmapFormat::BGRA8888:
+    case (unsigned)BitmapFormat::RGBx8888:
     case (unsigned)BitmapFormat::RGBA8888:
         return true;
     }
@@ -61,6 +63,7 @@ enum class StorageFormat {
     Indexed8,
     BGRx8888,
     BGRA8888,
+    RGBx8888,
     RGBA8888,
 };
 
@@ -308,6 +311,32 @@ inline Color Bitmap::get_pixel<StorageFormat::BGRA8888>(int x, int y) const
 }
 
 template<>
+inline Color Bitmap::get_pixel<StorageFormat::RGBA8888>(int x, int y) const
+{
+    VERIFY(x >= 0);
+    VERIFY(x < physical_width());
+    auto color = Color::from_rgb(scanline(y)[x]);
+    auto red = color.red();
+    auto blue = color.blue();
+    color.set_blue(red);
+    color.set_red(blue);
+    return color;
+}
+
+template<>
+inline Color Bitmap::get_pixel<StorageFormat::RGBx8888>(int x, int y) const
+{
+    VERIFY(x >= 0);
+    VERIFY(x < physical_width());
+    auto color = Color::from_rgb(scanline(y)[x]);
+    auto red = color.red();
+    auto blue = color.blue();
+    color.set_blue(red);
+    color.set_red(blue);
+    return color;
+}
+
+template<>
 inline Color Bitmap::get_pixel<StorageFormat::Indexed8>(int x, int y) const
 {
     VERIFY(x >= 0);
@@ -322,6 +351,10 @@ inline Color Bitmap::get_pixel(int x, int y) const
         return get_pixel<StorageFormat::BGRx8888>(x, y);
     case StorageFormat::BGRA8888:
         return get_pixel<StorageFormat::BGRA8888>(x, y);
+    case StorageFormat::RGBA8888:
+        return get_pixel<StorageFormat::RGBA8888>(x, y);
+    case StorageFormat::RGBx8888:
+        return get_pixel<StorageFormat::RGBx8888>(x, y);
     case StorageFormat::Indexed8:
         return get_pixel<StorageFormat::Indexed8>(x, y);
     default:


### PR DESCRIPTION
Related to #16574. This could be merged right away, but I rather wait until that PR is merged first
because it's more relevant after those changes are in the tree first.
When generating a binary file containing the raw bitmap data of a picture, we could now view it in the `ImageViewer` application without a problem :)