### PR TITLE
ClipboardHistory: Add clear history action

### DIFF
--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -136,6 +136,12 @@ void ClipboardHistoryModel::remove_item(int index)
     invalidate();
 }
 
+void ClipboardHistoryModel::clear()
+{
+    m_history_items.clear();
+    invalidate();
+}
+
 void ClipboardHistoryModel::config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value_string)
 {
     if (domain != "ClipboardHistory" || group != "ClipboardHistory")

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
- * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022-2023, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -108,6 +108,13 @@ GUI::Variant ClipboardHistoryModel::data(const GUI::ModelIndex& index, GUI::Mode
     default:
         VERIFY_NOT_REACHED();
     }
+}
+
+void ClipboardHistoryModel::clipboard_content_did_change(DeprecatedString const&)
+{
+    auto data_and_type = GUI::Clipboard::the().fetch_data_and_type();
+    if (!(data_and_type.data.is_empty() && data_and_type.mime_type.is_empty() && data_and_type.metadata.is_empty()))
+        add_item(data_and_type);
 }
 
 void ClipboardHistoryModel::add_item(const GUI::Clipboard::DataAndType& item)

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -126,6 +126,7 @@ void ClipboardHistoryModel::add_item(const GUI::Clipboard::DataAndType& item)
 void ClipboardHistoryModel::remove_item(int index)
 {
     m_history_items.remove(index);
+    invalidate();
 }
 
 void ClipboardHistoryModel::config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value_string)

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
- * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022-2023, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -37,6 +37,7 @@ public:
 
     ClipboardItem const& item_at(int index) const { return m_history_items[index]; }
     void remove_item(int index);
+    bool is_empty() { return m_history_items.is_empty(); }
 
     // ^GUI::Model
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
@@ -54,7 +55,7 @@ private:
     virtual int column_count(const GUI::ModelIndex&) const override { return Column::__Count; }
 
     // ^GUI::Clipboard::ClipboardClient
-    virtual void clipboard_content_did_change(DeprecatedString const&) override { add_item(GUI::Clipboard::the().fetch_data_and_type()); }
+    virtual void clipboard_content_did_change(DeprecatedString const&) override;
 
     Vector<ClipboardItem> m_history_items;
     size_t m_history_limit;

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -38,6 +38,7 @@ public:
     ClipboardItem const& item_at(int index) const { return m_history_items[index]; }
     void add_item(const GUI::Clipboard::DataAndType& item);
     void remove_item(int index);
+    void clear();
     bool is_empty() { return m_history_items.is_empty(); }
 
     // ^GUI::Model

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -36,6 +36,7 @@ public:
     virtual ~ClipboardHistoryModel() override = default;
 
     ClipboardItem const& item_at(int index) const { return m_history_items[index]; }
+    void add_item(const GUI::Clipboard::DataAndType& item);
     void remove_item(int index);
     bool is_empty() { return m_history_items.is_empty(); }
 
@@ -47,7 +48,6 @@ public:
 
 private:
     ClipboardHistoryModel();
-    void add_item(const GUI::Clipboard::DataAndType& item);
 
     // ^GUI::Model
     virtual int row_count(const GUI::ModelIndex&) const override { return m_history_items.size(); }

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -35,6 +35,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto table_view = TRY(main_window->set_main_widget<GUI::TableView>());
     auto model = ClipboardHistoryModel::create();
+
+    auto data_and_type = GUI::Clipboard::the().fetch_data_and_type();
+    if (!(data_and_type.data.is_empty() && data_and_type.mime_type.is_empty() && data_and_type.metadata.is_empty()))
+        model->add_item(data_and_type);
+
     table_view->set_model(model);
 
     table_view->on_activation = [&](GUI::ModelIndex const& index) {

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -46,7 +46,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (table_view->selection().is_empty())
             return;
 
-        model->remove_item(table_view->selection().first().row());
+        auto index = table_view->selection().first();
+        model->remove_item(index.row());
+        if (model->is_empty()) {
+            GUI::Clipboard::the().clear();
+        } else if (index.row() == 0) {
+            auto const& data_and_type = model->item_at(index.row()).data_and_type;
+            GUI::Clipboard::the().set_data(data_and_type.data, data_and_type.mime_type, data_and_type.metadata);
+        }
     });
 
     auto debug_dump_action = GUI::Action::create("Dump to debug console", [&](const GUI::Action&) {

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -67,12 +67,20 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         });
     });
 
+    auto clear_action = GUI::Action::create("Clear history", TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/trash-can.png"sv)), [&](const GUI::Action&) {
+        model->clear();
+        GUI::Clipboard::the().clear();
+    });
+
     auto entry_context_menu = TRY(GUI::Menu::try_create());
     TRY(entry_context_menu->try_add_action(delete_action));
     TRY(entry_context_menu->try_add_action(debug_dump_action));
+    entry_context_menu->add_separator();
+    TRY(entry_context_menu->try_add_action(clear_action));
     table_view->on_context_menu_request = [&](GUI::ModelIndex const&, GUI::ContextMenuEvent const& event) {
         delete_action->set_enabled(!table_view->selection().is_empty());
         debug_dump_action->set_enabled(!table_view->selection().is_empty());
+        clear_action->set_enabled(!model->is_empty());
         entry_context_menu->popup(event.screen_position());
     };
 

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -43,6 +43,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     auto delete_action = GUI::CommonActions::make_delete_action([&](const GUI::Action&) {
+        if (table_view->selection().is_empty())
+            return;
+
         model->remove_item(table_view->selection().first().row());
     });
 


### PR DESCRIPTION
This patch adds a clear history button to the ClipboardHistory applet context menu, which clears all the ClipboardHistoryModel items and clears the clipboard itself. 

This patch also changes the behavior of the delete button, such that when the topmost item on the ClipboardHistory is deleted, the contents of the clipboard will be updated to reflect the change.

Video:

https://user-images.githubusercontent.com/2817754/212488483-1b0e71f1-67d2-49fe-ba79-b6bbb321a8c3.mp4
