### PR TITLE
Spreadsheet: Port to `Core::Stream`

### DIFF
--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -178,7 +178,7 @@ void CSVExportDialogPage::update_preview()
         m_data_preview_text_editor->set_text(DeprecatedString::formatted("Cannot update preview: {}", maybe_error.error()));
 }
 
-ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, NonnullOwnPtr<Core::Stream::File> file, DeprecatedString filename, Workbook& workbook)
+ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, Core::Stream::File& file, DeprecatedString filename, Workbook& workbook)
 {
     auto wizard = GUI::WizardDialog::construct(GUI::Application::the()->active_window());
     wizard->set_title("File Export Wizard");
@@ -195,7 +195,7 @@ ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, NonnullOwnPtr<Core
         if (wizard->exec() != GUI::Dialog::ExecResult::OK)
             return Error::from_string_literal("CSV Export was cancelled");
 
-        TRY(page.generate(*file, CSVExportDialogPage::GenerationType::Normal));
+        TRY(page.generate(file, CSVExportDialogPage::GenerationType::Normal));
         return {};
     };
 
@@ -205,7 +205,7 @@ ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, NonnullOwnPtr<Core
             array.append(sheet.to_json());
 
         auto file_content = array.to_deprecated_string();
-        return file->write_entire_buffer(file_content.bytes());
+        return file.write_entire_buffer(file_content.bytes());
     };
 
     if (mime == "text/csv") {

--- a/Userland/Applications/Spreadsheet/ExportDialog.h
+++ b/Userland/Applications/Spreadsheet/ExportDialog.h
@@ -58,7 +58,7 @@ private:
 };
 
 struct ExportDialog {
-    static ErrorOr<void> make_and_run_for(StringView mime, NonnullOwnPtr<Core::Stream::File>, DeprecatedString filename, Workbook&);
+    static ErrorOr<void> make_and_run_for(StringView mime, Core::Stream::File&, DeprecatedString filename, Workbook&);
 };
 
 }

--- a/Userland/Applications/Spreadsheet/ExportDialog.h
+++ b/Userland/Applications/Spreadsheet/ExportDialog.h
@@ -18,12 +18,16 @@ class Sheet;
 class Workbook;
 
 struct CSVExportDialogPage {
-    using XSV = Writer::XSV<Vector<Vector<DeprecatedString>>, Vector<DeprecatedString>>;
-
     explicit CSVExportDialogPage(Sheet const&);
 
     NonnullRefPtr<GUI::WizardPage> page() { return *m_page; }
-    ErrorOr<NonnullOwnPtr<XSV>> make_writer(Core::Stream::Handle<Core::Stream::Stream>);
+
+    enum class GenerationType {
+        Normal,
+        Preview
+    };
+
+    ErrorOr<void> generate(Core::Stream::Stream&, GenerationType);
 
 protected:
     void update_preview();

--- a/Userland/Applications/Spreadsheet/ImportDialog.h
+++ b/Userland/Applications/Spreadsheet/ImportDialog.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "Readers/XSV.h"
-#include <AK/Result.h>
 #include <AK/StringView.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Wizards/WizardPage.h>
@@ -56,7 +55,7 @@ private:
 };
 
 struct ImportDialog {
-    static Result<NonnullRefPtrVector<Sheet>, DeprecatedString> make_and_run_for(GUI::Window& parent, StringView mime, Core::File& file, Workbook&);
+    static ErrorOr<NonnullRefPtrVector<Sheet>, DeprecatedString> make_and_run_for(GUI::Window& parent, StringView mime, Core::File& file, Workbook&);
 };
 
 }

--- a/Userland/Applications/Spreadsheet/ImportDialog.h
+++ b/Userland/Applications/Spreadsheet/ImportDialog.h
@@ -55,7 +55,7 @@ private:
 };
 
 struct ImportDialog {
-    static ErrorOr<NonnullRefPtrVector<Sheet>, DeprecatedString> make_and_run_for(GUI::Window& parent, StringView mime, Core::File& file, Workbook&);
+    static ErrorOr<NonnullRefPtrVector<Sheet>, DeprecatedString> make_and_run_for(GUI::Window& parent, StringView mime, String const& filename, Core::Stream::File& file, Workbook&);
 };
 
 }

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -9,6 +9,7 @@
 #include "SpreadsheetView.h"
 #include "Workbook.h"
 #include <AK/NonnullRefPtrVector.h>
+#include <LibCore/Stream.h>
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGUI/Widget.h>
@@ -23,9 +24,9 @@ class SpreadsheetWidget final
 public:
     virtual ~SpreadsheetWidget() override = default;
 
-    void save(Core::File&);
-    void load_file(Core::File&);
-    void import_sheets(Core::File&);
+    void save(String const& filename, Core::Stream::File&);
+    void load_file(String const& filename, Core::Stream::File&);
+    void import_sheets(String const& filename, Core::Stream::File&);
     bool request_close();
     void add_sheet();
     void add_sheet(NonnullRefPtr<Sheet>&&);

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -52,7 +52,7 @@ bool Workbook::set_filename(DeprecatedString const& filename)
     return true;
 }
 
-Result<bool, DeprecatedString> Workbook::open_file(Core::File& file)
+ErrorOr<void, DeprecatedString> Workbook::open_file(Core::File& file)
 {
     auto mime = Core::guess_mime_type_based_on_filename(file.filename());
 
@@ -61,7 +61,7 @@ Result<bool, DeprecatedString> Workbook::open_file(Core::File& file)
 
     set_filename(file.filename());
 
-    return true;
+    return {};
 }
 
 ErrorOr<void> Workbook::write_to_file(Core::File& file)
@@ -78,7 +78,7 @@ ErrorOr<void> Workbook::write_to_file(Core::File& file)
     return {};
 }
 
-Result<bool, DeprecatedString> Workbook::import_file(Core::File& file)
+ErrorOr<bool, DeprecatedString> Workbook::import_file(Core::File& file)
 {
     auto mime = Core::guess_mime_type_based_on_filename(file.filename());
 

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -9,7 +9,6 @@
 #include "Forward.h"
 #include "Spreadsheet.h"
 #include <AK/NonnullOwnPtrVector.h>
-#include <AK/Result.h>
 
 namespace Spreadsheet {
 
@@ -17,10 +16,10 @@ class Workbook {
 public:
     Workbook(NonnullRefPtrVector<Sheet>&& sheets, GUI::Window& parent_window);
 
-    Result<bool, DeprecatedString> open_file(Core::File&);
+    ErrorOr<void, DeprecatedString> open_file(Core::File&);
     ErrorOr<void> write_to_file(Core::File&);
 
-    Result<bool, DeprecatedString> import_file(Core::File&);
+    ErrorOr<bool, DeprecatedString> import_file(Core::File&);
 
     DeprecatedString const& current_filename() const { return m_current_filename; }
     bool set_filename(DeprecatedString const& filename);

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -16,10 +16,10 @@ class Workbook {
 public:
     Workbook(NonnullRefPtrVector<Sheet>&& sheets, GUI::Window& parent_window);
 
-    ErrorOr<void, DeprecatedString> open_file(Core::File&);
-    ErrorOr<void> write_to_file(Core::File&);
+    ErrorOr<void, DeprecatedString> open_file(String const& filename, Core::Stream::File&);
+    ErrorOr<void> write_to_file(String const& filename, Core::Stream::File&);
 
-    ErrorOr<bool, DeprecatedString> import_file(Core::File&);
+    ErrorOr<bool, DeprecatedString> import_file(String const& filename, Core::Stream::File&);
 
     DeprecatedString const& current_filename() const { return m_current_filename; }
     bool set_filename(DeprecatedString const& filename);

--- a/Userland/Applications/Spreadsheet/Writers/CSV.h
+++ b/Userland/Applications/Spreadsheet/Writers/CSV.h
@@ -12,12 +12,18 @@
 
 namespace Writer {
 
-template<typename ContainerType>
-class CSV : public XSV<ContainerType> {
+class CSV {
 public:
-    CSV(Core::Stream::Handle<Core::Stream::Stream> output, ContainerType const& data, Vector<StringView> headers = {}, WriterBehavior behaviors = default_behaviors())
-        : XSV<ContainerType>(move(output), data, { ",", "\"", WriterTraits::Repeat }, move(headers), behaviors)
+    template<typename ContainerType>
+    static ErrorOr<void> generate(Core::Stream::Stream& output, ContainerType const& data, Vector<StringView> headers = {}, WriterBehavior behaviors = default_behaviors())
     {
+        return XSV<ContainerType>::generate(output, data, { ",", "\"", WriterTraits::Repeat }, move(headers), behaviors);
+    }
+
+    template<typename ContainerType>
+    static ErrorOr<void> generate_preview(Core::Stream::Stream& output, ContainerType const& data, Vector<StringView> headers = {}, WriterBehavior behaviors = default_behaviors())
+    {
+        return XSV<ContainerType>::generate_preview(output, data, { ",", "\"", WriterTraits::Repeat }, move(headers), behaviors);
     }
 };
 

--- a/Userland/Applications/Spreadsheet/Writers/Test/TestXSVWriter.cpp
+++ b/Userland/Applications/Spreadsheet/Writers/Test/TestXSVWriter.cpp
@@ -7,7 +7,6 @@
 #include <LibTest/TestCase.h>
 
 #include "../CSV.h"
-#include "../XSV.h"
 #include <LibCore/MemoryStream.h>
 
 TEST_CASE(can_write)
@@ -19,8 +18,7 @@ TEST_CASE(can_write)
     };
 
     Core::Stream::AllocatingMemoryStream stream;
-    auto csv = Writer::CSV(Core::Stream::Handle<Core::Stream::Stream>(stream), data);
-    MUST(csv.generate());
+    MUST(Writer::CSV::generate(stream, data));
 
     auto expected_output = R"~(1,2,3
 4,5,6
@@ -40,8 +38,7 @@ TEST_CASE(can_write_with_header)
     };
 
     Core::Stream::AllocatingMemoryStream stream;
-    auto csv = Writer::CSV(Core::Stream::Handle<Core::Stream::Stream>(stream), data, { "A"sv, "B\""sv, "C"sv });
-    MUST(csv.generate());
+    MUST(Writer::CSV::generate(stream, data, { "A"sv, "B\""sv, "C"sv }));
 
     auto expected_output = R"~(A,"B""",C
 1,2,3
@@ -61,8 +58,7 @@ TEST_CASE(can_write_with_different_behaviors)
     };
 
     Core::Stream::AllocatingMemoryStream stream;
-    auto csv = Writer::CSV(Core::Stream::Handle<Core::Stream::Stream>(stream), data, { "A"sv, "B\""sv, "C"sv }, Writer::WriterBehavior::QuoteOnlyInFieldStart | Writer::WriterBehavior::WriteHeaders);
-    MUST(csv.generate());
+    MUST(Writer::CSV::generate(stream, data, { "A"sv, "B\""sv, "C"sv }, Writer::WriterBehavior::QuoteOnlyInFieldStart | Writer::WriterBehavior::WriteHeaders));
 
     auto expected_output = R"~(A,B",C
 Well,Hello",Friends

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -14,15 +14,11 @@
 #include <LibCore/System.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Application.h>
-#include <LibGUI/Clipboard.h>
-#include <LibGUI/FilePicker.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
-#include <LibGUI/MessageBox.h>
 #include <LibGUI/Window.h>
 #include <LibMain/Main.h>
-#include <unistd.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -69,8 +65,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
 
     if (filename) {
-        auto file = TRY(FileSystemAccessClient::Client::the().try_request_file_read_only_approved_deprecated(window, filename));
-        spreadsheet_widget->load_file(file);
+        auto file = TRY(FileSystemAccessClient::Client::the().request_file_read_only_approved(window, filename));
+        spreadsheet_widget->load_file(file.filename(), file.stream());
     }
 
     return app->exec();


### PR DESCRIPTION
Some of the backend was already ported to `Core::Stream` but was using an owning model, it has been updated to take reference instead of `OwnPtr`.

Spreadsheet also contained a few remanent `Result`s, these have been converted into `ErrorOr`.
