### PR TITLE
Everywhere: Fully qualify IsLvalueReference in TRY() macros

### DIFF
--- a/AK/Try.h
+++ b/AK/Try.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Diagnostics.h>
+#include <AK/StdLibExtras.h>
 
 // NOTE: This macro works with any result type that has the expected APIs.
 //       It's designed with AK::Result and AK::Error in mind.
@@ -20,25 +21,25 @@
 //       from a fallible expression. This will not do what you want; the statement expression
 //       will create a copy regardless, so it is explicitly disallowed.
 
-#define TRY(expression)                                                                \
-    ({                                                                                 \
-        /* Ignore -Wshadow to allow nesting the macro. */                              \
-        AK_IGNORE_DIAGNOSTIC("-Wshadow",                                               \
-            auto _temporary_result = (expression));                                    \
-        static_assert(!IsLvalueReference<decltype(_temporary_result.release_value())>, \
-            "Do not return a reference from a fallible expression");                   \
-        if (_temporary_result.is_error()) [[unlikely]]                                 \
-            return _temporary_result.release_error();                                  \
-        _temporary_result.release_value();                                             \
+#define TRY(expression)                                                                              \
+    ({                                                                                               \
+        /* Ignore -Wshadow to allow nesting the macro. */                                            \
+        AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                             \
+            auto _temporary_result = (expression));                                                  \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \
+            "Do not return a reference from a fallible expression");                                 \
+        if (_temporary_result.is_error()) [[unlikely]]                                               \
+            return _temporary_result.release_error();                                                \
+        _temporary_result.release_value();                                                           \
     })
 
-#define MUST(expression)                                                               \
-    ({                                                                                 \
-        /* Ignore -Wshadow to allow nesting the macro. */                              \
-        AK_IGNORE_DIAGNOSTIC("-Wshadow",                                               \
-            auto _temporary_result = (expression));                                    \
-        static_assert(!IsLvalueReference<decltype(_temporary_result.release_value())>, \
-            "Do not return a reference from a fallible expression");                   \
-        VERIFY(!_temporary_result.is_error());                                         \
-        _temporary_result.release_value();                                             \
+#define MUST(expression)                                                                             \
+    ({                                                                                               \
+        /* Ignore -Wshadow to allow nesting the macro. */                                            \
+        AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                             \
+            auto _temporary_result = (expression));                                                  \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \
+            "Do not return a reference from a fallible expression");                                 \
+        VERIFY(!_temporary_result.is_error());                                                       \
+        _temporary_result.release_value();                                                           \
     })

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -184,14 +184,14 @@ private:
 };
 
 // This is a special variant of TRY() that also updates the socket's SO_ERROR field on error.
-#define SOCKET_TRY(expression)                                              \
-    ({                                                                      \
-        auto result = (expression);                                         \
-        if (result.is_error())                                              \
-            return set_so_error(result.release_error());                    \
-        static_assert(!IsLvalueReference<decltype(result.release_value())>, \
-            "Do not return a reference from a fallible expression");        \
-        result.release_value();                                             \
+#define SOCKET_TRY(expression)                                                            \
+    ({                                                                                    \
+        auto result = (expression);                                                       \
+        if (result.is_error())                                                            \
+            return set_so_error(result.release_error());                                  \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(result.release_value())>, \
+            "Do not return a reference from a fallible expression");                      \
+        result.release_value();                                                           \
     })
 
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
@@ -231,14 +231,14 @@ struct CLDR {
 
 // Some parsing is expected to fail. For example, the CLDR contains language mappings
 // with locales such as "en-GB-oed" that are canonically invalid locale IDs.
-#define TRY_OR_DISCARD(expression)                                                     \
-    ({                                                                                 \
-        auto _temporary_result = (expression);                                         \
-        if (_temporary_result.is_error())                                              \
-            return;                                                                    \
-        static_assert(!IsLvalueReference<decltype(_temporary_result.release_value())>, \
-            "Do not return a reference from a fallible expression");                   \
-        _temporary_result.release_value();                                             \
+#define TRY_OR_DISCARD(expression)                                                                   \
+    ({                                                                                               \
+        auto _temporary_result = (expression);                                                       \
+        if (_temporary_result.is_error())                                                            \
+            return;                                                                                  \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \
+            "Do not return a reference from a fallible expression");                                 \
+        _temporary_result.release_value();                                                           \
     })
 
 static ErrorOr<LanguageMapping> parse_language_mapping(CLDR& cldr, StringView key, StringView alias)

--- a/Userland/Libraries/LibAudio/LoaderError.h
+++ b/Userland/Libraries/LibAudio/LoaderError.h
@@ -66,12 +66,12 @@ struct LoaderError {
 }
 
 // Convenience TRY-like macro to convert an Error to a LoaderError
-#define LOADER_TRY(expression)                                                         \
-    ({                                                                                 \
-        auto _temporary_result = (expression);                                         \
-        if (_temporary_result.is_error())                                              \
-            return LoaderError(_temporary_result.release_error());                     \
-        static_assert(!IsLvalueReference<decltype(_temporary_result.release_value())>, \
-            "Do not return a reference from a fallible expression");                   \
-        _temporary_result.release_value();                                             \
+#define LOADER_TRY(expression)                                                                       \
+    ({                                                                                               \
+        auto _temporary_result = (expression);                                                       \
+        if (_temporary_result.is_error())                                                            \
+            return LoaderError(_temporary_result.release_error());                                   \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \
+            "Do not return a reference from a fallible expression");                                 \
+        _temporary_result.release_value();                                                           \
     })

--- a/Userland/Libraries/LibJS/Runtime/Completion.h
+++ b/Userland/Libraries/LibJS/Runtime/Completion.h
@@ -16,18 +16,18 @@
 
 namespace JS {
 
-#define TRY_OR_THROW_OOM(vm, expression)                                               \
-    ({                                                                                 \
-        /* Ignore -Wshadow to allow nesting the macro. */                              \
-        AK_IGNORE_DIAGNOSTIC("-Wshadow",                                               \
-            auto _temporary_result = (expression));                                    \
-        if (_temporary_result.is_error()) {                                            \
-            VERIFY(_temporary_result.error().code() == ENOMEM);                        \
-            return vm.throw_completion<JS::InternalError>(JS::ErrorType::OutOfMemory); \
-        }                                                                              \
-        static_assert(!IsLvalueReference<decltype(_temporary_result.release_value())>, \
-            "Do not return a reference from a fallible expression");                   \
-        _temporary_result.release_value();                                             \
+#define TRY_OR_THROW_OOM(vm, expression)                                                             \
+    ({                                                                                               \
+        /* Ignore -Wshadow to allow nesting the macro. */                                            \
+        AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                             \
+            auto _temporary_result = (expression));                                                  \
+        if (_temporary_result.is_error()) {                                                          \
+            VERIFY(_temporary_result.error().code() == ENOMEM);                                      \
+            return vm.throw_completion<JS::InternalError>(JS::ErrorType::OutOfMemory);               \
+        }                                                                                            \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \
+            "Do not return a reference from a fallible expression");                                 \
+        _temporary_result.release_value();                                                           \
     })
 
 // 6.2.3 The Completion Record Specification Type, https://tc39.es/ecma262/#sec-completion-record-specification-type

--- a/Userland/Libraries/LibJS/Runtime/PromiseCapability.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseCapability.h
@@ -53,7 +53,7 @@ private:
             return (capability)->promise();                                                                                              \
         }                                                                                                                                \
                                                                                                                                          \
-        static_assert(!IsLvalueReference<decltype(_temporary_try_or_reject_result.release_value())>,                                     \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_try_or_reject_result.release_value())>,                       \
             "Do not return a reference from a fallible expression");                                                                     \
                                                                                                                                          \
         /* 2. Else if value is a Completion Record, set value to value.[[Value]]. */                                                     \
@@ -79,7 +79,7 @@ private:
             return Value { (capability)->promise() };                                                                             \
         }                                                                                                                         \
                                                                                                                                   \
-        static_assert(!IsLvalueReference<decltype(_temporary_try_or_reject_result.release_value())>,                              \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_try_or_reject_result.release_value())>,                \
             "Do not return a reference from a fallible expression");                                                              \
                                                                                                                                   \
         /* 2. Else if value is a Completion Record, set value to value.[[Value]]. */                                              \

--- a/Userland/Libraries/LibVideo/DecoderError.h
+++ b/Userland/Libraries/LibVideo/DecoderError.h
@@ -77,17 +77,17 @@ private:
     DeprecatedString m_description;
 };
 
-#define DECODER_TRY(category, expression)                                    \
-    ({                                                                       \
-        auto _result = ((expression));                                       \
-        if (_result.is_error()) [[unlikely]] {                               \
-            auto _error_string = _result.release_error().string_literal();   \
-            return DecoderError::from_source_location(                       \
-                ((category)), _error_string, SourceLocation::current());     \
-        }                                                                    \
-        static_assert(!IsLvalueReference<decltype(_result.release_value())>, \
-            "Do not return a reference from a fallible expression");         \
-        _result.release_value();                                             \
+#define DECODER_TRY(category, expression)                                                  \
+    ({                                                                                     \
+        auto _result = ((expression));                                                     \
+        if (_result.is_error()) [[unlikely]] {                                             \
+            auto _error_string = _result.release_error().string_literal();                 \
+            return DecoderError::from_source_location(                                     \
+                ((category)), _error_string, SourceLocation::current());                   \
+        }                                                                                  \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_result.release_value())>, \
+            "Do not return a reference from a fallible expression");                       \
+        _result.release_value();                                                           \
     })
 
 #define DECODER_TRY_ALLOC(expression) DECODER_TRY(DecoderErrorCategory::Memory, expression)

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -273,7 +273,7 @@ bool PlaybackManager::decode_and_queue_one_sample()
             m_present_timer->start(0);                                                                                  \
             return false;                                                                                               \
         }                                                                                                               \
-        static_assert(!IsLvalueReference<decltype(_temporary_result.release_value())>,                                  \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>,                    \
             "Do not return a reference from a fallible expression");                                                    \
         _temporary_result.release_value();                                                                              \
     })

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -42,14 +42,14 @@
 
 namespace Web::Fetch::Fetching {
 
-#define TRY_OR_IGNORE(expression)                                                      \
-    ({                                                                                 \
-        auto _temporary_result = (expression);                                         \
-        if (_temporary_result.is_error())                                              \
-            return;                                                                    \
-        static_assert(!IsLvalueReference<decltype(_temporary_result.release_value())>, \
-            "Do not return a reference from a fallible expression");                   \
-        _temporary_result.release_value();                                             \
+#define TRY_OR_IGNORE(expression)                                                                    \
+    ({                                                                                               \
+        auto _temporary_result = (expression);                                                       \
+        if (_temporary_result.is_error())                                                            \
+            return;                                                                                  \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \
+            "Do not return a reference from a fallible expression");                                 \
+        _temporary_result.release_value();                                                           \
     })
 
 // https://fetch.spec.whatwg.org/#concept-fetch

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -31,14 +31,14 @@
 
 namespace Web::WebDriver {
 
-#define TRY_OR_JS_ERROR(expression)                                                    \
-    ({                                                                                 \
-        auto _temporary_result = (expression);                                         \
-        if (_temporary_result.is_error()) [[unlikely]]                                 \
-            return ExecuteScriptResultType::JavaScriptError;                           \
-        static_assert(!IsLvalueReference<decltype(_temporary_result.release_value())>, \
-            "Do not return a reference from a fallible expression");                   \
-        _temporary_result.release_value();                                             \
+#define TRY_OR_JS_ERROR(expression)                                                                  \
+    ({                                                                                               \
+        auto _temporary_result = (expression);                                                       \
+        if (_temporary_result.is_error()) [[unlikely]]                                               \
+            return ExecuteScriptResultType::JavaScriptError;                                         \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \
+            "Do not return a reference from a fallible expression");                                 \
+        _temporary_result.release_value();                                                           \
     })
 
 static ErrorOr<JsonValue, ExecuteScriptResultType> internal_json_clone_algorithm(JS::Realm&, JS::Value, HashTable<JS::Object*>& seen);

--- a/Userland/Utilities/matroska.cpp
+++ b/Userland/Utilities/matroska.cpp
@@ -10,16 +10,16 @@
 #include <LibMain/Main.h>
 #include <LibVideo/Containers/Matroska/Reader.h>
 
-#define TRY_PARSE(expression)                                                                     \
-    ({                                                                                            \
-        auto _temporary_result = ((expression));                                                  \
-        if (_temporary_result.is_error()) [[unlikely]] {                                          \
-            outln("Encountered a parsing error: {}", _temporary_result.error().string_literal()); \
-            return Error::from_string_literal("Failed to parse :(");                              \
-        }                                                                                         \
-        static_assert(!IsLvalueReference<decltype(_temporary_result.release_value())>,            \
-            "Do not return a reference from a fallible expression");                              \
-        _temporary_result.release_value();                                                        \
+#define TRY_PARSE(expression)                                                                        \
+    ({                                                                                               \
+        auto _temporary_result = ((expression));                                                     \
+        if (_temporary_result.is_error()) [[unlikely]] {                                             \
+            outln("Encountered a parsing error: {}", _temporary_result.error().string_literal());    \
+            return Error::from_string_literal("Failed to parse :(");                                 \
+        }                                                                                            \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \
+            "Do not return a reference from a fallible expression");                                 \
+        _temporary_result.release_value();                                                           \
     })
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)


### PR DESCRIPTION
If USING_AK_GLOBALLY is not defined, the name IsLvalueReference might not be available in the global namespace. Follow the pattern established in LibTest to fully qualify AK types in macros to avoid this problem.