### PR TITLE
3DFileViewer: Port to `Core::Stream`

### DIFF
--- a/Userland/Applications/3DFileViewer/MeshLoader.h
+++ b/Userland/Applications/3DFileViewer/MeshLoader.h
@@ -18,5 +18,5 @@ public:
     MeshLoader() = default;
     virtual ~MeshLoader() = default;
 
-    virtual ErrorOr<NonnullRefPtr<Mesh>> load(Core::DeprecatedFile& file) = 0;
+    virtual ErrorOr<NonnullRefPtr<Mesh>> load(String const& filename, NonnullOwnPtr<Core::File> file) = 0;
 };

--- a/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
+++ b/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
@@ -8,7 +8,9 @@
 
 #include "WavefrontOBJLoader.h"
 #include <AK/FixedArray.h>
+#include <AK/String.h>
 #include <LibCore/DeprecatedFile.h>
+#include <LibCore/File.h>
 #include <stdlib.h>
 
 static inline GLuint get_index_value(StringView& representation)
@@ -16,17 +18,22 @@ static inline GLuint get_index_value(StringView& representation)
     return representation.to_uint().value_or(1) - 1;
 }
 
-ErrorOr<NonnullRefPtr<Mesh>> WavefrontOBJLoader::load(Core::DeprecatedFile& file)
+ErrorOr<NonnullRefPtr<Mesh>> WavefrontOBJLoader::load(String const& filename, NonnullOwnPtr<Core::File> file)
 {
+    auto buffered_file = TRY(Core::BufferedFile::create(move(file)));
+
     Vector<Vertex> vertices;
     Vector<Vertex> normals;
     Vector<TexCoord> tex_coords;
     Vector<Triangle> triangles;
 
-    dbgln("Wavefront: Loading {}...", file.name());
+    dbgln("Wavefront: Loading {}...", filename);
 
     // Start reading file line by line
-    for (auto object_line : file.lines()) {
+    auto buffer = TRY(ByteBuffer::create_uninitialized(PAGE_SIZE));
+    while (TRY(buffered_file->can_read_line())) {
+        auto object_line = TRY(buffered_file->read_line(buffer));
+
         // Ignore file comments
         if (object_line.starts_with('#'))
             continue;

--- a/Userland/Applications/3DFileViewer/WavefrontOBJLoader.h
+++ b/Userland/Applications/3DFileViewer/WavefrontOBJLoader.h
@@ -18,5 +18,5 @@ public:
     WavefrontOBJLoader() = default;
     ~WavefrontOBJLoader() override = default;
 
-    ErrorOr<NonnullRefPtr<Mesh>> load(Core::DeprecatedFile& file) override;
+    ErrorOr<NonnullRefPtr<Mesh>> load(String const& filename, NonnullOwnPtr<Core::File> file) override;
 };

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -308,16 +308,6 @@ bool GLContextWidget::load_file(Core::DeprecatedFile& file)
         return false;
     }
 
-    if (file.is_device()) {
-        GUI::MessageBox::show(window(), DeprecatedString::formatted("Opening \"{}\" failed: Can't open device files", filename), "Error"sv, GUI::MessageBox::Type::Error);
-        return false;
-    }
-
-    if (file.is_directory()) {
-        GUI::MessageBox::show(window(), DeprecatedString::formatted("Opening \"{}\" failed: Can't open directories", filename), "Error"sv, GUI::MessageBox::Type::Error);
-        return false;
-    }
-
     auto new_mesh = m_mesh_loader->load(String::from_deprecated_string(file.filename()).release_value_but_fixme_should_propagate_errors(),
         Core::File::adopt_fd(file.leak_fd(), Core::File::OpenMode::Read).release_value_but_fixme_should_propagate_errors());
     if (new_mesh.is_error()) {

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -290,14 +290,14 @@ void GLContextWidget::timer_event(Core::TimerEvent&)
 
 bool GLContextWidget::load_path(DeprecatedString const& filename)
 {
-    auto file = Core::DeprecatedFile::construct(filename);
+    auto file = FileSystemAccessClient::Client::the().try_request_file_read_only_approved_deprecated(window(), filename);
 
-    if (!file->open(Core::OpenMode::ReadOnly) && file->error() != ENOENT) {
+    if (!file.is_error() && file.error().code() != ENOENT) {
         GUI::MessageBox::show(window(), DeprecatedString::formatted("Opening \"{}\" failed: {}", filename, strerror(errno)), "Error"sv, GUI::MessageBox::Type::Error);
         return false;
     }
 
-    return load_file(file);
+    return load_file(file.value());
 }
 
 bool GLContextWidget::load_file(Core::DeprecatedFile& file)

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -341,6 +341,8 @@ bool GLContextWidget::load_file(String const& filename, NonnullOwnPtr<Core::File
     m_mesh = new_mesh.release_value();
     dbgln("3DFileViewer: mesh has {} triangles.", m_mesh->triangle_count());
 
+    window()->set_title(DeprecatedString::formatted("{} - 3D File Viewer", filename));
+
     return true;
 }
 
@@ -382,10 +384,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return;
 
         auto file = response.release_value();
-        if (widget->load_file(file.filename(), file.release_stream())) {
-            auto canonical_path = Core::DeprecatedFile::absolute_path(file.filename().to_deprecated_string());
-            window->set_title(DeprecatedString::formatted("{} - 3D File Viewer", canonical_path));
-        }
+        widget->load_file(file.filename(), file.release_stream());
     }));
     file_menu.add_separator();
     file_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) {
@@ -571,10 +570,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
 
     auto filename = arguments.argc > 1 ? arguments.argv[1] : "/home/anon/Documents/3D Models/teapot.obj";
-    if (widget->load_path(filename)) {
-        auto canonical_path = Core::DeprecatedFile::absolute_path(filename);
-        window->set_title(DeprecatedString::formatted("{} - 3D File Viewer", canonical_path));
-    }
+    widget->load_path(filename);
 
     return app->exec();
 }

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -318,22 +318,14 @@ bool GLContextWidget::load_file(String const& filename, NonnullOwnPtr<Core::File
     builder.append(filename.bytes_as_string_view().split_view('.').at(0));
     builder.append(".bmp"sv);
 
-    DeprecatedString texture_path = Core::DeprecatedFile::absolute_path(builder.string_view());
-
     // Attempt to open the texture file from disk
     RefPtr<Gfx::Bitmap> texture_image;
-    if (Core::DeprecatedFile::exists(texture_path)) {
-        auto bitmap_or_error = Gfx::Bitmap::load_from_file(texture_path);
+    auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window(), builder.string_view());
+    if (!response.is_error()) {
+        auto texture_file = response.release_value();
+        auto bitmap_or_error = Gfx::Bitmap::load_from_file(texture_file.release_stream(), texture_file.filename());
         if (!bitmap_or_error.is_error())
             texture_image = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
-    } else {
-        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window(), builder.string_view());
-        if (!response.is_error()) {
-            auto texture_file = response.release_value();
-            auto bitmap_or_error = Gfx::Bitmap::load_from_file(texture_file.release_stream(), texture_file.filename());
-            if (!bitmap_or_error.is_error())
-                texture_image = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
-        }
     }
 
     GLuint tex;

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -318,7 +318,8 @@ bool GLContextWidget::load_file(Core::DeprecatedFile& file)
         return false;
     }
 
-    auto new_mesh = m_mesh_loader->load(file);
+    auto new_mesh = m_mesh_loader->load(String::from_deprecated_string(file.filename()).release_value_but_fixme_should_propagate_errors(),
+        Core::File::adopt_fd(file.leak_fd(), Core::File::OpenMode::Read).release_value_but_fixme_should_propagate_errors());
     if (new_mesh.is_error()) {
         GUI::MessageBox::show(window(), DeprecatedString::formatted("Reading \"{}\" failed: {}", filename, new_mesh.release_error()), "Error"sv, GUI::MessageBox::Type::Error);
         return false;

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -353,7 +353,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix prot_exec"));
 
     TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
-    TRY(Core::System::unveil("/home/anon/Documents/3D Models", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/usr/lib", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -12,6 +12,7 @@
 #include <AK/Noncopyable.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Stream.h>
+#include <LibCore/Forward.h>
 #include <LibIPC/Forward.h>
 
 namespace Core {
@@ -67,7 +68,8 @@ public:
     virtual ErrorOr<size_t> seek(i64 offset, SeekMode) override;
     virtual ErrorOr<void> truncate(size_t length) override;
 
-    int leak_fd(Badge<::IPC::File>)
+    template<OneOf<::IPC::File, ::Core::MappedFile> VIP>
+    int leak_fd(Badge<VIP>)
     {
         m_should_close_file_descriptor = ShouldCloseFileDescriptor::No;
         return m_fd;

--- a/Userland/Libraries/LibCore/Forward.h
+++ b/Userland/Libraries/LibCore/Forward.h
@@ -25,6 +25,7 @@ class File;
 class IODevice;
 class LocalServer;
 class LocalSocket;
+class MappedFile;
 class MimeData;
 class NetworkJob;
 class NetworkResponse;

--- a/Userland/Libraries/LibCore/MappedFile.cpp
+++ b/Userland/Libraries/LibCore/MappedFile.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/DeprecatedString.h>
 #include <AK/ScopeGuard.h>
+#include <LibCore/File.h>
 #include <LibCore/MappedFile.h>
 #include <LibCore/System.h>
 #include <fcntl.h>
@@ -18,6 +19,11 @@ ErrorOr<NonnullRefPtr<MappedFile>> MappedFile::map(StringView path)
 {
     auto fd = TRY(Core::System::open(path, O_RDONLY | O_CLOEXEC, 0));
     return map_from_fd_and_close(fd, path);
+}
+
+ErrorOr<NonnullRefPtr<MappedFile>> MappedFile::map_from_file(NonnullOwnPtr<Core::File> stream, StringView path)
+{
+    return map_from_fd_and_close(stream->leak_fd(Badge<MappedFile> {}), path);
 }
 
 ErrorOr<NonnullRefPtr<MappedFile>> MappedFile::map_from_fd_and_close(int fd, [[maybe_unused]] StringView path)

--- a/Userland/Libraries/LibCore/MappedFile.h
+++ b/Userland/Libraries/LibCore/MappedFile.h
@@ -10,7 +10,7 @@
 #include <AK/Noncopyable.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
-#include <AK/Result.h>
+#include <LibCore/Forward.h>
 
 namespace Core {
 
@@ -20,6 +20,7 @@ class MappedFile : public RefCounted<MappedFile> {
 
 public:
     static ErrorOr<NonnullRefPtr<MappedFile>> map(StringView path);
+    static ErrorOr<NonnullRefPtr<MappedFile>> map_from_file(NonnullOwnPtr<Core::File>, StringView path);
     static ErrorOr<NonnullRefPtr<MappedFile>> map_from_fd_and_close(int fd, StringView path);
     ~MappedFile();
 

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -11,6 +11,7 @@
 #include <AK/Function.h>
 #include <AK/RefCounted.h>
 #include <LibCore/AnonymousBuffer.h>
+#include <LibCore/Forward.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
@@ -97,6 +98,7 @@ public:
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_shareable(BitmapFormat, IntSize, int intrinsic_scale = 1);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_wrapper(BitmapFormat, IntSize, int intrinsic_scale, size_t pitch, void*);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> load_from_file(StringView path, int scale_factor = 1);
+    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> load_from_file(NonnullOwnPtr<Core::File>, StringView path);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> load_from_fd_and_close(int fd, StringView path);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_with_anonymous_buffer(BitmapFormat, Core::AnonymousBuffer, IntSize, int intrinsic_scale, Vector<ARGB32> const& palette);
     static ErrorOr<NonnullRefPtr<Bitmap>> create_from_serialized_bytes(ReadonlyBytes);


### PR DESCRIPTION
My initial will was to port 3DFileViewer to `Core::Stream`, but I gathered and shaved some yaks along the way:
- 3DFileViewer wasn't fully ported to LibFileSystemAccessClient
- 3DFileViewer wasn't fully unveil compatible (it was easy to make it try to open veiled path)
- 3DFileViewer unveiled some files under "/home/anon"

And I also added support for `Core::Stream` in two class:
- `Core::MappedFile`
- `Gfx::Bitmap`