### PR TITLE
LibFileSystemAccessClient: Remove the deprecated API

### DIFF
--- a/Userland/Applications/3DFileViewer/MeshLoader.h
+++ b/Userland/Applications/3DFileViewer/MeshLoader.h
@@ -18,5 +18,5 @@ public:
     MeshLoader() = default;
     virtual ~MeshLoader() = default;
 
-    virtual ErrorOr<NonnullRefPtr<Mesh>> load(Core::File& file) = 0;
+    virtual ErrorOr<NonnullRefPtr<Mesh>> load(String const& filename, NonnullOwnPtr<Core::Stream::File> file) = 0;
 };

--- a/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
+++ b/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
@@ -8,7 +8,8 @@
 
 #include "WavefrontOBJLoader.h"
 #include <AK/FixedArray.h>
-#include <LibCore/File.h>
+#include <AK/String.h>
+#include <LibCore/Stream.h>
 #include <stdlib.h>
 
 static inline GLuint get_index_value(StringView& representation)
@@ -16,17 +17,22 @@ static inline GLuint get_index_value(StringView& representation)
     return representation.to_uint().value_or(1) - 1;
 }
 
-ErrorOr<NonnullRefPtr<Mesh>> WavefrontOBJLoader::load(Core::File& file)
+ErrorOr<NonnullRefPtr<Mesh>> WavefrontOBJLoader::load(String const& filename, NonnullOwnPtr<Core::Stream::File> file)
 {
+    auto buffered_file = TRY(Core::Stream::BufferedFile::create(move(file)));
+
     Vector<Vertex> vertices;
     Vector<Vertex> normals;
     Vector<TexCoord> tex_coords;
     Vector<Triangle> triangles;
 
-    dbgln("Wavefront: Loading {}...", file.name());
+    dbgln("Wavefront: Loading {}...", filename);
 
     // Start reading file line by line
-    for (auto object_line : file.lines()) {
+    auto buffer = TRY(ByteBuffer::create_uninitialized(PAGE_SIZE));
+    while (TRY(buffered_file->can_read_line())) {
+        auto object_line = TRY(buffered_file->read_line(buffer));
+
         // Ignore file comments
         if (object_line.starts_with('#'))
             continue;

--- a/Userland/Applications/3DFileViewer/WavefrontOBJLoader.h
+++ b/Userland/Applications/3DFileViewer/WavefrontOBJLoader.h
@@ -18,5 +18,5 @@ public:
     WavefrontOBJLoader() = default;
     ~WavefrontOBJLoader() override = default;
 
-    ErrorOr<NonnullRefPtr<Mesh>> load(Core::File& file) override;
+    ErrorOr<NonnullRefPtr<Mesh>> load(String const& filename, NonnullOwnPtr<Core::Stream::File> file) override;
 };

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -319,7 +319,7 @@ bool GLContextWidget::load_file(Core::File& file)
         return false;
     }
 
-    auto new_mesh = m_mesh_loader->load(file);
+    auto new_mesh = m_mesh_loader->load(MUST(String::from_deprecated_string(file.filename())), MUST(Core::Stream::File::adopt_fd(file.leak_fd(), Core::Stream::OpenMode::Read)));
     if (new_mesh.is_error()) {
         GUI::MessageBox::show(window(), DeprecatedString::formatted("Reading \"{}\" failed: {}", filename, new_mesh.release_error()), "Error"sv, GUI::MessageBox::Type::Error);
         return false;

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -291,14 +291,14 @@ void GLContextWidget::timer_event(Core::TimerEvent&)
 
 bool GLContextWidget::load_path(DeprecatedString const& filename)
 {
-    auto file = Core::File::construct(filename);
+    auto file = FileSystemAccessClient::Client::the().try_request_file_read_only_approved_deprecated(window(), filename);
 
-    if (!file->open(Core::OpenMode::ReadOnly) && file->error() != ENOENT) {
+    if (!file.is_error() && file.error().code() != ENOENT) {
         GUI::MessageBox::show(window(), DeprecatedString::formatted("Opening \"{}\" failed: {}", filename, strerror(errno)), "Error"sv, GUI::MessageBox::Type::Error);
         return false;
     }
 
-    return load_file(file);
+    return load_file(file.value());
 }
 
 bool GLContextWidget::load_file(Core::File& file)

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -309,16 +309,6 @@ bool GLContextWidget::load_file(Core::File& file)
         return false;
     }
 
-    if (file.is_device()) {
-        GUI::MessageBox::show(window(), DeprecatedString::formatted("Opening \"{}\" failed: Can't open device files", filename), "Error"sv, GUI::MessageBox::Type::Error);
-        return false;
-    }
-
-    if (file.is_directory()) {
-        GUI::MessageBox::show(window(), DeprecatedString::formatted("Opening \"{}\" failed: Can't open directories", filename), "Error"sv, GUI::MessageBox::Type::Error);
-        return false;
-    }
-
     auto new_mesh = m_mesh_loader->load(MUST(String::from_deprecated_string(file.filename())), MUST(Core::Stream::File::adopt_fd(file.leak_fd(), Core::Stream::OpenMode::Read)));
     if (new_mesh.is_error()) {
         GUI::MessageBox::show(window(), DeprecatedString::formatted("Reading \"{}\" failed: {}", filename, new_mesh.release_error()), "Error"sv, GUI::MessageBox::Type::Error);

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -342,6 +342,8 @@ bool GLContextWidget::load_file(String const& filename, NonnullOwnPtr<Core::Stre
     m_mesh = new_mesh.release_value();
     dbgln("3DFileViewer: mesh has {} triangles.", m_mesh->triangle_count());
 
+    window()->set_title(DeprecatedString::formatted("{} - 3D File Viewer", filename));
+
     return true;
 }
 
@@ -383,10 +385,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return;
 
         auto file = response.release_value();
-        if (widget->load_file(file.filename(), file.release_stream())) {
-            auto canonical_path = Core::File::absolute_path(file.filename().to_deprecated_string());
-            window->set_title(DeprecatedString::formatted("{} - 3D File Viewer", canonical_path));
-        }
+        widget->load_file(file.filename(), file.release_stream());
     }));
     file_menu.add_separator();
     file_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) {
@@ -572,10 +571,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
 
     auto filename = arguments.argc > 1 ? arguments.argv[1] : "/home/anon/Documents/3D Models/teapot.obj";
-    if (widget->load_path(filename)) {
-        auto canonical_path = Core::File::absolute_path(filename);
-        window->set_title(DeprecatedString::formatted("{} - 3D File Viewer", canonical_path));
-    }
+    widget->load_path(filename);
 
     return app->exec();
 }

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -354,7 +354,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix prot_exec"));
 
     TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
-    TRY(Core::System::unveil("/home/anon/Documents/3D Models", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/usr/lib", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -34,7 +34,7 @@ class GLContextWidget final : public GUI::Frame {
 
 public:
     bool load_path(DeprecatedString const& fname);
-    bool load_file(Core::File& file);
+    bool load_file(String const& filename, NonnullOwnPtr<Core::Stream::File> file);
     void toggle_rotate_x() { m_rotate_x = !m_rotate_x; }
     void toggle_rotate_y() { m_rotate_y = !m_rotate_y; }
     void toggle_rotate_z() { m_rotate_z = !m_rotate_z; }
@@ -147,10 +147,10 @@ void GLContextWidget::drop_event(GUI::DropEvent& event)
         if (url.scheme() != "file")
             continue;
 
-        auto response = FileSystemAccessClient::Client::the().try_request_file_deprecated(window(), url.path(), Core::OpenMode::ReadOnly);
+        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window(), url.path());
         if (response.is_error())
             return;
-        load_file(response.value());
+        load_file(response.value().filename(), response.value().release_stream());
     }
 }
 
@@ -291,25 +291,24 @@ void GLContextWidget::timer_event(Core::TimerEvent&)
 
 bool GLContextWidget::load_path(DeprecatedString const& filename)
 {
-    auto file = FileSystemAccessClient::Client::the().try_request_file_read_only_approved_deprecated(window(), filename);
+    auto file = FileSystemAccessClient::Client::the().request_file_read_only_approved(window(), filename);
 
-    if (!file.is_error() && file.error().code() != ENOENT) {
+    if (file.is_error() && file.error().code() != ENOENT) {
         GUI::MessageBox::show(window(), DeprecatedString::formatted("Opening \"{}\" failed: {}", filename, strerror(errno)), "Error"sv, GUI::MessageBox::Type::Error);
         return false;
     }
 
-    return load_file(file.value());
+    return load_file(file.value().filename(), file.value().release_stream());
 }
 
-bool GLContextWidget::load_file(Core::File& file)
+bool GLContextWidget::load_file(String const& filename, NonnullOwnPtr<Core::Stream::File> file)
 {
-    auto const& filename = file.filename();
-    if (!filename.ends_with(".obj"sv)) {
+    if (!filename.bytes_as_string_view().ends_with(".obj"sv)) {
         GUI::MessageBox::show(window(), DeprecatedString::formatted("Opening \"{}\" failed: invalid file type", filename), "Error"sv, GUI::MessageBox::Type::Error);
         return false;
     }
 
-    auto new_mesh = m_mesh_loader->load(MUST(String::from_deprecated_string(file.filename())), MUST(Core::Stream::File::adopt_fd(file.leak_fd(), Core::Stream::OpenMode::Read)));
+    auto new_mesh = m_mesh_loader->load(filename, move(file));
     if (new_mesh.is_error()) {
         GUI::MessageBox::show(window(), DeprecatedString::formatted("Reading \"{}\" failed: {}", filename, new_mesh.release_error()), "Error"sv, GUI::MessageBox::Type::Error);
         return false;
@@ -317,7 +316,7 @@ bool GLContextWidget::load_file(Core::File& file)
 
     // Determine whether or not a texture for this model resides within the same directory
     StringBuilder builder;
-    builder.append(filename.split('.').at(0));
+    builder.append(filename.bytes_as_string_view().split_view('.').at(0));
     builder.append(".bmp"sv);
 
     DeprecatedString texture_path = Core::File::absolute_path(builder.string_view());
@@ -329,10 +328,10 @@ bool GLContextWidget::load_file(Core::File& file)
         if (!bitmap_or_error.is_error())
             texture_image = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
     } else {
-        auto response = FileSystemAccessClient::Client::the().try_request_file_deprecated(window(), builder.string_view(), Core::OpenMode::ReadOnly);
+        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window(), builder.string_view());
         if (!response.is_error()) {
-            auto texture_file = response.value();
-            auto bitmap_or_error = Gfx::Bitmap::try_load_from_fd_and_close(texture_file->leak_fd(), texture_file->filename());
+            auto texture_file = response.release_value();
+            auto bitmap_or_error = Gfx::Bitmap::try_load_from_stream(texture_file.release_stream(), texture_file.filename());
             if (!bitmap_or_error.is_error())
                 texture_image = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
         }
@@ -387,13 +386,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& file_menu = window->add_menu("&File");
 
     file_menu.add_action(GUI::CommonActions::make_open_action([&](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_open_file_deprecated(window);
+        auto response = FileSystemAccessClient::Client::the().open_file(window);
         if (response.is_error())
             return;
 
-        auto file = response.value();
-        if (widget->load_file(*file)) {
-            auto canonical_path = Core::File::absolute_path(file->filename());
+        auto file = response.release_value();
+        if (widget->load_file(file.filename(), file.release_stream())) {
+            auto canonical_path = Core::File::absolute_path(file.filename().to_deprecated_string());
             window->set_title(DeprecatedString::formatted("{} - 3D File Viewer", canonical_path));
         }
     }));

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -70,10 +70,18 @@ bool HexDocumentMemory::write_to_file(NonnullRefPtr<Core::File> file)
     return true;
 }
 
+ErrorOr<NonnullOwnPtr<HexDocumentFile>> HexDocumentFile::create(NonnullRefPtr<Core::File> file)
+{
+    auto document = TRY(adopt_nonnull_own_or_enomem(new HexDocumentFile(move(file))));
+    // FIXME: Remove this hackery
+    document->set_file(move(document->m_file));
+
+    return document;
+}
+
 HexDocumentFile::HexDocumentFile(NonnullRefPtr<Core::File> file)
     : m_file(file)
 {
-    set_file(file);
 }
 
 void HexDocumentFile::write_to_file()

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -74,7 +74,7 @@ ErrorOr<NonnullOwnPtr<HexDocumentFile>> HexDocumentFile::create(NonnullOwnPtr<Co
 {
     auto document = TRY(adopt_nonnull_own_or_enomem(new HexDocumentFile(move(file))));
     // FIXME: Remove this hackery
-    document->set_file(move(document->m_file));
+    TRY(document->set_file(move(document->m_file)));
 
     return document;
 }
@@ -151,7 +151,7 @@ void HexDocumentFile::clear_changes()
     m_changes.clear();
 }
 
-void HexDocumentFile::set_file(NonnullOwnPtr<Core::Stream::File> file)
+ErrorOr<void> HexDocumentFile::set_file(NonnullOwnPtr<Core::Stream::File> file)
 {
     m_file = move(file);
 
@@ -160,11 +160,12 @@ void HexDocumentFile::set_file(NonnullOwnPtr<Core::Stream::File> file)
     else
         m_file_size = result.value();
 
-    m_file->seek(0, Core::Stream::SeekMode::SetPosition).release_value_but_fixme_should_propagate_errors();
+    TRY(m_file->seek(0, Core::Stream::SeekMode::SetPosition));
 
     clear_changes();
     // make sure the next get operation triggers a read
     m_buffer_file_pos = m_file_size + 1;
+    return {};
 }
 
 NonnullOwnPtr<Core::Stream::File> const& HexDocumentFile::file() const

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "HexDocument.h"
+#include <LibCore/Stream.h>
 
 void HexDocument::set(size_t position, u8 value)
 {
@@ -57,20 +58,20 @@ void HexDocumentMemory::clear_changes()
     m_changes.clear();
 }
 
-bool HexDocumentMemory::write_to_file(NonnullRefPtr<Core::File> file)
+bool HexDocumentMemory::write_to_file(Core::Stream::File& file)
 {
-    if (!file->seek(0))
+    if (file.seek(0, Core::Stream::SeekMode::SetPosition).is_error())
         return false;
-    if (!file->write(m_buffer.data(), m_buffer.size()))
+    if (file.write(m_buffer).is_error())
         return false;
     for (auto& change : m_changes) {
-        file->seek(change.key, Core::SeekMode::SetPosition);
-        file->write(&change.value, 1);
+        file.seek(change.key, Core::Stream::SeekMode::SetPosition).release_value_but_fixme_should_propagate_errors();
+        file.write({ &change.value, 1 }).release_value_but_fixme_should_propagate_errors();
     }
     return true;
 }
 
-ErrorOr<NonnullOwnPtr<HexDocumentFile>> HexDocumentFile::create(NonnullRefPtr<Core::File> file)
+ErrorOr<NonnullOwnPtr<HexDocumentFile>> HexDocumentFile::create(NonnullOwnPtr<Core::Stream::File> file)
 {
     auto document = TRY(adopt_nonnull_own_or_enomem(new HexDocumentFile(move(file))));
     // FIXME: Remove this hackery
@@ -79,42 +80,43 @@ ErrorOr<NonnullOwnPtr<HexDocumentFile>> HexDocumentFile::create(NonnullRefPtr<Co
     return document;
 }
 
-HexDocumentFile::HexDocumentFile(NonnullRefPtr<Core::File> file)
-    : m_file(file)
+HexDocumentFile::HexDocumentFile(NonnullOwnPtr<Core::Stream::File> file)
+    : m_file(move(file))
 {
 }
 
 void HexDocumentFile::write_to_file()
 {
     for (auto& change : m_changes) {
-        m_file->seek(change.key, Core::SeekMode::SetPosition);
-        m_file->write(&change.value, 1);
+        m_file->seek(change.key, Core::Stream::SeekMode::SetPosition).release_value_but_fixme_should_propagate_errors();
+        m_file->write({ &change.value, 1 }).release_value_but_fixme_should_propagate_errors();
     }
     clear_changes();
     // make sure the next get operation triggers a read
     m_buffer_file_pos = m_file_size + 1;
 }
 
-bool HexDocumentFile::write_to_file(NonnullRefPtr<Core::File> file)
+bool HexDocumentFile::write_to_file(Core::Stream::File& file)
 {
-    if (!file->truncate(size())) {
+    if (file.truncate(size()).is_error()) {
         return false;
     }
 
-    if (!file->seek(0) || !m_file->seek(0)) {
+    if (file.seek(0, Core::Stream::SeekMode::SetPosition).is_error() || m_file->seek(0, Core::Stream::SeekMode::SetPosition).is_error()) {
         return false;
     }
 
     while (true) {
-        auto copy_buffer = m_file->read(64 * KiB);
+        Array<u8, 64 * KiB> buffer;
+        auto copy_buffer = m_file->read(buffer).release_value_but_fixme_should_propagate_errors();
         if (copy_buffer.size() == 0)
             break;
-        file->write(copy_buffer.data(), copy_buffer.size());
+        file.write(copy_buffer).release_value_but_fixme_should_propagate_errors();
     }
 
     for (auto& change : m_changes) {
-        file->seek(change.key, Core::SeekMode::SetPosition);
-        file->write(&change.value, 1);
+        file.seek(change.key, Core::Stream::SeekMode::SetPosition).release_value_but_fixme_should_propagate_errors();
+        file.write({ &change.value, 1 }).release_value_but_fixme_should_propagate_errors();
     }
 
     return true;
@@ -152,24 +154,23 @@ void HexDocumentFile::clear_changes()
     m_changes.clear();
 }
 
-void HexDocumentFile::set_file(NonnullRefPtr<Core::File> file)
+void HexDocumentFile::set_file(NonnullOwnPtr<Core::Stream::File> file)
 {
-    m_file = file;
+    m_file = move(file);
 
-    off_t size = 0;
-    if (!file->seek(0, Core::SeekMode::FromEndPosition, &size)) {
+    if (auto result = m_file->seek(0, Core::Stream::SeekMode::FromEndPosition); result.is_error())
         m_file_size = 0;
-    } else {
-        m_file_size = size;
-    }
-    file->seek(0, Core::SeekMode::SetPosition);
+    else
+        m_file_size = result.value();
+
+    m_file->seek(0, Core::Stream::SeekMode::SetPosition).release_value_but_fixme_should_propagate_errors();
 
     clear_changes();
     // make sure the next get operation triggers a read
     m_buffer_file_pos = m_file_size + 1;
 }
 
-NonnullRefPtr<Core::File> HexDocumentFile::file() const
+NonnullOwnPtr<Core::Stream::File> const& HexDocumentFile::file() const
 {
     return m_file;
 }
@@ -177,8 +178,8 @@ NonnullRefPtr<Core::File> HexDocumentFile::file() const
 void HexDocumentFile::ensure_position_in_buffer(size_t position)
 {
     if (position < m_buffer_file_pos || position >= m_buffer_file_pos + m_buffer.size()) {
-        m_file->seek(position, Core::SeekMode::SetPosition);
-        m_file->read(m_buffer.data(), m_buffer.size());
+        m_file->seek(position, Core::Stream::SeekMode::SetPosition).release_value_but_fixme_should_propagate_errors();
+        m_file->read(m_buffer).release_value_but_fixme_should_propagate_errors();
         m_buffer_file_pos = position;
     }
 }

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -84,15 +84,16 @@ HexDocumentFile::HexDocumentFile(NonnullOwnPtr<Core::Stream::File> file)
 {
 }
 
-void HexDocumentFile::write_to_file()
+ErrorOr<void> HexDocumentFile::write_to_file()
 {
     for (auto& change : m_changes) {
-        m_file->seek(change.key, Core::Stream::SeekMode::SetPosition).release_value_but_fixme_should_propagate_errors();
-        m_file->write({ &change.value, 1 }).release_value_but_fixme_should_propagate_errors();
+        TRY(m_file->seek(change.key, Core::Stream::SeekMode::SetPosition));
+        TRY(m_file->write({ &change.value, 1 }));
     }
     clear_changes();
     // make sure the next get operation triggers a read
     m_buffer_file_pos = m_file_size + 1;
+    return {};
 }
 
 ErrorOr<void> HexDocumentFile::write_to_file(Core::Stream::File& file)

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -58,17 +58,16 @@ void HexDocumentMemory::clear_changes()
     m_changes.clear();
 }
 
-bool HexDocumentMemory::write_to_file(Core::Stream::File& file)
+ErrorOr<void> HexDocumentMemory::write_to_file(Core::Stream::File& file)
 {
-    if (file.seek(0, Core::Stream::SeekMode::SetPosition).is_error())
-        return false;
-    if (file.write(m_buffer).is_error())
-        return false;
+    TRY(file.seek(0, Core::Stream::SeekMode::SetPosition));
+    TRY(file.write(m_buffer));
+
     for (auto& change : m_changes) {
-        file.seek(change.key, Core::Stream::SeekMode::SetPosition).release_value_but_fixme_should_propagate_errors();
-        file.write({ &change.value, 1 }).release_value_but_fixme_should_propagate_errors();
+        TRY(file.seek(change.key, Core::Stream::SeekMode::SetPosition));
+        TRY(file.write({ &change.value, 1 }));
     }
-    return true;
+    return {};
 }
 
 ErrorOr<NonnullOwnPtr<HexDocumentFile>> HexDocumentFile::create(NonnullOwnPtr<Core::Stream::File> file)
@@ -96,30 +95,27 @@ void HexDocumentFile::write_to_file()
     m_buffer_file_pos = m_file_size + 1;
 }
 
-bool HexDocumentFile::write_to_file(Core::Stream::File& file)
+ErrorOr<void> HexDocumentFile::write_to_file(Core::Stream::File& file)
 {
-    if (file.truncate(size()).is_error()) {
-        return false;
-    }
+    TRY(file.truncate(size()));
 
-    if (file.seek(0, Core::Stream::SeekMode::SetPosition).is_error() || m_file->seek(0, Core::Stream::SeekMode::SetPosition).is_error()) {
-        return false;
-    }
+    TRY(file.seek(0, Core::Stream::SeekMode::SetPosition));
+    TRY(m_file->seek(0, Core::Stream::SeekMode::SetPosition));
 
     while (true) {
         Array<u8, 64 * KiB> buffer;
-        auto copy_buffer = m_file->read(buffer).release_value_but_fixme_should_propagate_errors();
+        auto copy_buffer = TRY(m_file->read(buffer));
         if (copy_buffer.size() == 0)
             break;
-        file.write(copy_buffer).release_value_but_fixme_should_propagate_errors();
+        TRY(file.write(copy_buffer));
     }
 
     for (auto& change : m_changes) {
-        file.seek(change.key, Core::Stream::SeekMode::SetPosition).release_value_but_fixme_should_propagate_errors();
-        file.write({ &change.value, 1 }).release_value_but_fixme_should_propagate_errors();
+        TRY(file.seek(change.key, Core::Stream::SeekMode::SetPosition));
+        TRY(file.write({ &change.value, 1 }));
     }
 
-    return true;
+    return {};
 }
 
 HexDocument::Cell HexDocumentFile::get(size_t position)

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -73,8 +73,7 @@ ErrorOr<void> HexDocumentMemory::write_to_file(Core::Stream::File& file)
 ErrorOr<NonnullOwnPtr<HexDocumentFile>> HexDocumentFile::create(NonnullOwnPtr<Core::Stream::File> file)
 {
     auto document = TRY(adopt_nonnull_own_or_enomem(new HexDocumentFile(move(file))));
-    // FIXME: Remove this hackery
-    TRY(document->set_file(move(document->m_file)));
+    TRY(document->initialize_internal_state());
 
     return document;
 }
@@ -154,7 +153,12 @@ void HexDocumentFile::clear_changes()
 ErrorOr<void> HexDocumentFile::set_file(NonnullOwnPtr<Core::Stream::File> file)
 {
     m_file = move(file);
+    TRY(initialize_internal_state());
+    return {};
+}
 
+ErrorOr<void> HexDocumentFile::initialize_internal_state()
+{
     if (auto result = m_file->seek(0, Core::Stream::SeekMode::FromEndPosition); result.is_error())
         m_file_size = 0;
     else

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -64,7 +64,7 @@ public:
     HexDocumentFile(HexDocumentFile&&) = default;
     HexDocumentFile(HexDocumentFile const&) = delete;
 
-    void set_file(NonnullOwnPtr<Core::Stream::File> file);
+    ErrorOr<void> set_file(NonnullOwnPtr<Core::Stream::File> file);
     NonnullOwnPtr<Core::Stream::File> const& file() const;
     ErrorOr<void> write_to_file();
     ErrorOr<void> write_to_file(Core::Stream::File& file);

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -61,6 +61,7 @@ public:
     explicit HexDocumentFile(NonnullRefPtr<Core::File> file);
     virtual ~HexDocumentFile() = default;
 
+    HexDocumentFile(HexDocumentFile&&) = default;
     HexDocumentFile(HexDocumentFile const&) = delete;
 
     void set_file(NonnullRefPtr<Core::File> file);

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -50,7 +50,7 @@ public:
     size_t size() const override;
     Type type() const override;
     void clear_changes() override;
-    bool write_to_file(NonnullRefPtr<Core::File> file);
+    bool write_to_file(Core::Stream::File& file);
 
 private:
     ByteBuffer m_buffer;
@@ -58,16 +58,16 @@ private:
 
 class HexDocumentFile final : public HexDocument {
 public:
-    static ErrorOr<NonnullOwnPtr<HexDocumentFile>> create(NonnullRefPtr<Core::File> file);
+    static ErrorOr<NonnullOwnPtr<HexDocumentFile>> create(NonnullOwnPtr<Core::Stream::File> file);
     virtual ~HexDocumentFile() = default;
 
     HexDocumentFile(HexDocumentFile&&) = default;
     HexDocumentFile(HexDocumentFile const&) = delete;
 
-    void set_file(NonnullRefPtr<Core::File> file);
-    NonnullRefPtr<Core::File> file() const;
+    void set_file(NonnullOwnPtr<Core::Stream::File> file);
+    NonnullOwnPtr<Core::Stream::File> const& file() const;
     void write_to_file();
-    bool write_to_file(NonnullRefPtr<Core::File> file);
+    bool write_to_file(Core::Stream::File& file);
     Cell get(size_t position) override;
     u8 get_unchanged(size_t position) override;
     size_t size() const override;
@@ -75,10 +75,10 @@ public:
     void clear_changes() override;
 
 private:
-    explicit HexDocumentFile(NonnullRefPtr<Core::File> file);
+    explicit HexDocumentFile(NonnullOwnPtr<Core::Stream::File> file);
     void ensure_position_in_buffer(size_t position);
 
-    NonnullRefPtr<Core::File> m_file;
+    NonnullOwnPtr<Core::Stream::File> m_file;
     size_t m_file_size;
 
     Array<u8, 2048> m_buffer;

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -76,6 +76,8 @@ public:
 
 private:
     explicit HexDocumentFile(NonnullOwnPtr<Core::Stream::File> file);
+    ErrorOr<void> initialize_internal_state();
+
     void ensure_position_in_buffer(size_t position);
 
     NonnullOwnPtr<Core::Stream::File> m_file;

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -58,7 +58,7 @@ private:
 
 class HexDocumentFile final : public HexDocument {
 public:
-    explicit HexDocumentFile(NonnullRefPtr<Core::File> file);
+    static ErrorOr<NonnullOwnPtr<HexDocumentFile>> create(NonnullRefPtr<Core::File> file);
     virtual ~HexDocumentFile() = default;
 
     HexDocumentFile(HexDocumentFile&&) = default;
@@ -75,6 +75,7 @@ public:
     void clear_changes() override;
 
 private:
+    explicit HexDocumentFile(NonnullRefPtr<Core::File> file);
     void ensure_position_in_buffer(size_t position);
 
     NonnullRefPtr<Core::File> m_file;

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -66,7 +66,7 @@ public:
 
     void set_file(NonnullOwnPtr<Core::Stream::File> file);
     NonnullOwnPtr<Core::Stream::File> const& file() const;
-    void write_to_file();
+    ErrorOr<void> write_to_file();
     ErrorOr<void> write_to_file(Core::Stream::File& file);
     Cell get(size_t position) override;
     u8 get_unchanged(size_t position) override;

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -50,7 +50,7 @@ public:
     size_t size() const override;
     Type type() const override;
     void clear_changes() override;
-    bool write_to_file(Core::Stream::File& file);
+    ErrorOr<void> write_to_file(Core::Stream::File& file);
 
 private:
     ByteBuffer m_buffer;
@@ -67,7 +67,7 @@ public:
     void set_file(NonnullOwnPtr<Core::Stream::File> file);
     NonnullOwnPtr<Core::Stream::File> const& file() const;
     void write_to_file();
-    bool write_to_file(Core::Stream::File& file);
+    ErrorOr<void> write_to_file(Core::Stream::File& file);
     Cell get(size_t position) override;
     u8 get_unchanged(size_t position) override;
     size_t size() const override;

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -135,23 +135,22 @@ void HexEditor::set_selection(size_t position, size_t length)
     scroll_position_into_view(position);
     update_status();
 }
-bool HexEditor::save_as(NonnullOwnPtr<Core::Stream::File> new_file)
+
+ErrorOr<void> HexEditor::save_as(NonnullOwnPtr<Core::Stream::File> new_file)
 {
     if (m_document->type() == HexDocument::Type::File) {
         auto& file_document = static_cast<HexDocumentFile&>(*m_document);
-        if (!file_document.write_to_file(*new_file))
-            return false;
+        TRY(file_document.write_to_file(*new_file));
         file_document.set_file(move(new_file));
     } else {
         auto& memory_document = static_cast<HexDocumentMemory&>(*m_document);
-        if (!memory_document.write_to_file(*new_file))
-            return false;
+        TRY(memory_document.write_to_file(*new_file));
         m_document = HexDocumentFile::create(move(new_file)).release_value_but_fixme_should_propagate_errors();
     }
 
     update();
 
-    return true;
+    return {};
 }
 
 bool HexEditor::save()

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -141,7 +141,7 @@ ErrorOr<void> HexEditor::save_as(NonnullOwnPtr<Core::Stream::File> new_file)
     if (m_document->type() == HexDocument::Type::File) {
         auto& file_document = static_cast<HexDocumentFile&>(*m_document);
         TRY(file_document.write_to_file(*new_file));
-        file_document.set_file(move(new_file));
+        TRY(file_document.set_file(move(new_file)));
     } else {
         auto& memory_document = static_cast<HexDocumentMemory&>(*m_document);
         TRY(memory_document.write_to_file(*new_file));

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -65,7 +65,7 @@ ErrorOr<void> HexEditor::open_new_file(size_t size)
 
 void HexEditor::open_file(NonnullRefPtr<Core::File> file)
 {
-    m_document = make<HexDocumentFile>(file);
+    m_document = HexDocumentFile::create(move(file)).release_value_but_fixme_should_propagate_errors();
     set_content_length(m_document->size());
     m_position = 0;
     m_cursor_at_low_nibble = false;
@@ -146,7 +146,7 @@ bool HexEditor::save_as(NonnullRefPtr<Core::File> new_file)
         auto& memory_document = static_cast<HexDocumentMemory&>(*m_document);
         if (!memory_document.write_to_file(new_file))
             return false;
-        m_document = make<HexDocumentFile>(new_file);
+        m_document = HexDocumentFile::create(move(new_file)).release_value_but_fixme_should_propagate_errors();
     }
 
     update();

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -63,7 +63,7 @@ ErrorOr<void> HexEditor::open_new_file(size_t size)
     return {};
 }
 
-void HexEditor::open_file(NonnullRefPtr<Core::File> file)
+void HexEditor::open_file(NonnullOwnPtr<Core::Stream::File> file)
 {
     m_document = HexDocumentFile::create(move(file)).release_value_but_fixme_should_propagate_errors();
     set_content_length(m_document->size());
@@ -135,16 +135,16 @@ void HexEditor::set_selection(size_t position, size_t length)
     scroll_position_into_view(position);
     update_status();
 }
-bool HexEditor::save_as(NonnullRefPtr<Core::File> new_file)
+bool HexEditor::save_as(NonnullOwnPtr<Core::Stream::File> new_file)
 {
     if (m_document->type() == HexDocument::Type::File) {
         auto& file_document = static_cast<HexDocumentFile&>(*m_document);
-        if (!file_document.write_to_file(new_file))
+        if (!file_document.write_to_file(*new_file))
             return false;
-        file_document.set_file(new_file);
+        file_document.set_file(move(new_file));
     } else {
         auto& memory_document = static_cast<HexDocumentMemory&>(*m_document);
-        if (!memory_document.write_to_file(new_file))
+        if (!memory_document.write_to_file(*new_file))
             return false;
         m_document = HexDocumentFile::create(move(new_file)).release_value_but_fixme_should_propagate_errors();
     }

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -153,14 +153,13 @@ ErrorOr<void> HexEditor::save_as(NonnullOwnPtr<Core::Stream::File> new_file)
     return {};
 }
 
-bool HexEditor::save()
+ErrorOr<void> HexEditor::save()
 {
-    if (m_document->type() != HexDocument::Type::File) {
-        return false;
-    }
+    if (m_document->type() != HexDocument::Type::File)
+        return Error::from_string_literal("Unable to save from a memory document");
 
-    static_cast<HexDocumentFile*>(m_document.ptr())->write_to_file();
-    return true;
+    TRY(static_cast<HexDocumentFile*>(m_document.ptr())->write_to_file());
+    return {};
 }
 
 size_t HexEditor::selection_size()

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -38,7 +38,7 @@ public:
     void open_file(NonnullOwnPtr<Core::Stream::File> file);
     ErrorOr<void> fill_selection(u8 fill_byte);
     Optional<u8> get_byte(size_t position);
-    bool save_as(NonnullOwnPtr<Core::Stream::File>);
+    ErrorOr<void> save_as(NonnullOwnPtr<Core::Stream::File>);
     bool save();
 
     bool undo();

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -39,7 +39,7 @@ public:
     ErrorOr<void> fill_selection(u8 fill_byte);
     Optional<u8> get_byte(size_t position);
     ErrorOr<void> save_as(NonnullOwnPtr<Core::Stream::File>);
-    bool save();
+    ErrorOr<void> save();
 
     bool undo();
     bool redo();

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -35,10 +35,10 @@ public:
 
     size_t buffer_size() const { return m_document->size(); }
     ErrorOr<void> open_new_file(size_t size);
-    void open_file(NonnullRefPtr<Core::File> file);
+    void open_file(NonnullOwnPtr<Core::Stream::File> file);
     ErrorOr<void> fill_selection(u8 fill_byte);
     Optional<u8> get_byte(size_t position);
-    bool save_as(NonnullRefPtr<Core::File>);
+    bool save_as(NonnullOwnPtr<Core::Stream::File>);
     bool save();
 
     bool undo();

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -146,8 +146,8 @@ HexEditorWidget::HexEditorWidget()
         if (response.is_error())
             return;
         auto file = response.release_value();
-        if (!m_editor->save_as(file.release_stream())) {
-            GUI::MessageBox::show(window(), "Unable to save file.\n"sv, "Error"sv, GUI::MessageBox::Type::Error);
+        if (auto result = m_editor->save_as(file.release_stream()); result.is_error()) {
+            GUI::MessageBox::show(window(), DeprecatedString::formatted("Unable to save file: {}\n"sv, result.error()), "Error"sv, GUI::MessageBox::Type::Error);
             return;
         }
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -132,8 +132,8 @@ HexEditorWidget::HexEditorWidget()
         if (m_path.is_empty())
             return m_save_as_action->activate();
 
-        if (!m_editor->save()) {
-            GUI::MessageBox::show(window(), "Unable to save file.\n"sv, "Error"sv, GUI::MessageBox::Type::Error);
+        if (auto result = m_editor->save(); result.is_error()) {
+            GUI::MessageBox::show(window(), DeprecatedString::formatted("Unable to save file: {}\n"sv, result.error()), "Error"sv, GUI::MessageBox::Type::Error);
         } else {
             window()->set_modified(false);
             m_editor->update();

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -25,7 +25,7 @@ class HexEditorWidget final : public GUI::Widget {
     C_OBJECT(HexEditorWidget)
 public:
     virtual ~HexEditorWidget() override = default;
-    void open_file(NonnullRefPtr<Core::File>);
+    void open_file(String const& filename, NonnullOwnPtr<Core::Stream::File>);
     void initialize_menubar(GUI::Window&);
     bool request_close();
 

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -53,10 +53,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (arguments.argc > 1) {
         // FIXME: Using `try_request_file_read_only_approved` doesn't work here since the file stored in the editor is only readable.
-        auto response = FileSystemAccessClient::Client::the().try_request_file_deprecated(window, arguments.strings[1], Core::OpenMode::ReadWrite);
+        auto response = FileSystemAccessClient::Client::the().request_file(window, arguments.strings[1], Core::Stream::OpenMode::ReadWrite);
         if (response.is_error())
             return 1;
-        hex_editor_widget->open_file(response.value());
+        hex_editor_widget->open_file(response.value().filename(), response.value().release_stream());
     }
 
     return app->exec();

--- a/Userland/Applications/Presenter/PresenterWidget.cpp
+++ b/Userland/Applications/Presenter/PresenterWidget.cpp
@@ -56,10 +56,10 @@ ErrorOr<void> PresenterWidget::initialize_menubar()
     // Set up the menu bar.
     auto& file_menu = window->add_menu("&File");
     auto open_action = GUI::CommonActions::make_open_action([this](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_open_file_deprecated(this->window());
+        auto response = FileSystemAccessClient::Client::the().open_file(this->window());
         if (response.is_error())
             return;
-        this->set_file(response.value()->filename());
+        this->set_file(response.value().filename());
     });
     auto about_action = GUI::CommonActions::make_about_action("Presenter", GUI::Icon::default_icon("app-display-settings"sv));
 

--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -178,7 +178,7 @@ void CSVExportDialogPage::update_preview()
         m_data_preview_text_editor->set_text(DeprecatedString::formatted("Cannot update preview: {}", maybe_error.error()));
 }
 
-ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, NonnullOwnPtr<Core::Stream::File> file, DeprecatedString filename, Workbook& workbook)
+ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, Core::Stream::File& file, DeprecatedString filename, Workbook& workbook)
 {
     auto wizard = GUI::WizardDialog::construct(GUI::Application::the()->active_window());
     wizard->set_title("File Export Wizard");
@@ -195,7 +195,7 @@ ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, NonnullOwnPtr<Core
         if (wizard->exec() != GUI::Dialog::ExecResult::OK)
             return Error::from_string_literal("CSV Export was cancelled");
 
-        TRY(page.generate(*file, CSVExportDialogPage::GenerationType::Normal));
+        TRY(page.generate(file, CSVExportDialogPage::GenerationType::Normal));
         return {};
     };
 
@@ -205,7 +205,7 @@ ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, NonnullOwnPtr<Core
             array.append(sheet.to_json());
 
         auto file_content = array.to_deprecated_string();
-        return file->write_entire_buffer(file_content.bytes());
+        return file.write_entire_buffer(file_content.bytes());
     };
 
     if (mime == "text/csv") {

--- a/Userland/Applications/Spreadsheet/ExportDialog.h
+++ b/Userland/Applications/Spreadsheet/ExportDialog.h
@@ -58,7 +58,7 @@ private:
 };
 
 struct ExportDialog {
-    static ErrorOr<void> make_and_run_for(StringView mime, NonnullOwnPtr<Core::Stream::File>, DeprecatedString filename, Workbook&);
+    static ErrorOr<void> make_and_run_for(StringView mime, Core::Stream::File&, DeprecatedString filename, Workbook&);
 };
 
 }

--- a/Userland/Applications/Spreadsheet/ExportDialog.h
+++ b/Userland/Applications/Spreadsheet/ExportDialog.h
@@ -18,12 +18,16 @@ class Sheet;
 class Workbook;
 
 struct CSVExportDialogPage {
-    using XSV = Writer::XSV<Vector<Vector<DeprecatedString>>, Vector<DeprecatedString>>;
-
     explicit CSVExportDialogPage(Sheet const&);
 
     NonnullRefPtr<GUI::WizardPage> page() { return *m_page; }
-    ErrorOr<NonnullOwnPtr<XSV>> make_writer(Core::Stream::Handle<Core::Stream::Stream>);
+
+    enum class GenerationType {
+        Normal,
+        Preview
+    };
+
+    ErrorOr<void> generate(Core::Stream::Stream&, GenerationType);
 
 protected:
     void update_preview();

--- a/Userland/Applications/Spreadsheet/ImportDialog.h
+++ b/Userland/Applications/Spreadsheet/ImportDialog.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "Readers/XSV.h"
-#include <AK/Result.h>
 #include <AK/StringView.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Wizards/WizardPage.h>
@@ -56,7 +55,7 @@ private:
 };
 
 struct ImportDialog {
-    static Result<NonnullRefPtrVector<Sheet>, DeprecatedString> make_and_run_for(GUI::Window& parent, StringView mime, Core::File& file, Workbook&);
+    static ErrorOr<NonnullRefPtrVector<Sheet>, DeprecatedString> make_and_run_for(GUI::Window& parent, StringView mime, Core::File& file, Workbook&);
 };
 
 }

--- a/Userland/Applications/Spreadsheet/ImportDialog.h
+++ b/Userland/Applications/Spreadsheet/ImportDialog.h
@@ -55,7 +55,7 @@ private:
 };
 
 struct ImportDialog {
-    static ErrorOr<NonnullRefPtrVector<Sheet>, DeprecatedString> make_and_run_for(GUI::Window& parent, StringView mime, Core::File& file, Workbook&);
+    static ErrorOr<NonnullRefPtrVector<Sheet>, DeprecatedString> make_and_run_for(GUI::Window& parent, StringView mime, String const& filename, Core::Stream::File& file, Workbook&);
 };
 
 }

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -9,6 +9,7 @@
 #include "SpreadsheetView.h"
 #include "Workbook.h"
 #include <AK/NonnullRefPtrVector.h>
+#include <LibCore/Stream.h>
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGUI/Widget.h>
@@ -23,9 +24,9 @@ class SpreadsheetWidget final
 public:
     virtual ~SpreadsheetWidget() override = default;
 
-    void save(Core::File&);
-    void load_file(Core::File&);
-    void import_sheets(Core::File&);
+    void save(String const& filename, Core::Stream::File&);
+    void load_file(String const& filename, Core::Stream::File&);
+    void import_sheets(String const& filename, Core::Stream::File&);
     bool request_close();
     void add_sheet();
     void add_sheet(NonnullRefPtr<Sheet>&&);

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -52,7 +52,7 @@ bool Workbook::set_filename(DeprecatedString const& filename)
     return true;
 }
 
-Result<bool, DeprecatedString> Workbook::open_file(Core::File& file)
+ErrorOr<void, DeprecatedString> Workbook::open_file(Core::File& file)
 {
     auto mime = Core::guess_mime_type_based_on_filename(file.filename());
 
@@ -61,7 +61,7 @@ Result<bool, DeprecatedString> Workbook::open_file(Core::File& file)
 
     set_filename(file.filename());
 
-    return true;
+    return {};
 }
 
 ErrorOr<void> Workbook::write_to_file(Core::File& file)
@@ -78,7 +78,7 @@ ErrorOr<void> Workbook::write_to_file(Core::File& file)
     return {};
 }
 
-Result<bool, DeprecatedString> Workbook::import_file(Core::File& file)
+ErrorOr<bool, DeprecatedString> Workbook::import_file(Core::File& file)
 {
     auto mime = Core::guess_mime_type_based_on_filename(file.filename());
 

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -9,7 +9,6 @@
 #include "Forward.h"
 #include "Spreadsheet.h"
 #include <AK/NonnullOwnPtrVector.h>
-#include <AK/Result.h>
 
 namespace Spreadsheet {
 
@@ -17,10 +16,10 @@ class Workbook {
 public:
     Workbook(NonnullRefPtrVector<Sheet>&& sheets, GUI::Window& parent_window);
 
-    Result<bool, DeprecatedString> open_file(Core::File&);
+    ErrorOr<void, DeprecatedString> open_file(Core::File&);
     ErrorOr<void> write_to_file(Core::File&);
 
-    Result<bool, DeprecatedString> import_file(Core::File&);
+    ErrorOr<bool, DeprecatedString> import_file(Core::File&);
 
     DeprecatedString const& current_filename() const { return m_current_filename; }
     bool set_filename(DeprecatedString const& filename);

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -16,10 +16,10 @@ class Workbook {
 public:
     Workbook(NonnullRefPtrVector<Sheet>&& sheets, GUI::Window& parent_window);
 
-    ErrorOr<void, DeprecatedString> open_file(Core::File&);
-    ErrorOr<void> write_to_file(Core::File&);
+    ErrorOr<void, DeprecatedString> open_file(String const& filename, Core::Stream::File&);
+    ErrorOr<void> write_to_file(String const& filename, Core::Stream::File&);
 
-    ErrorOr<bool, DeprecatedString> import_file(Core::File&);
+    ErrorOr<bool, DeprecatedString> import_file(String const& filename, Core::Stream::File&);
 
     DeprecatedString const& current_filename() const { return m_current_filename; }
     bool set_filename(DeprecatedString const& filename);

--- a/Userland/Applications/Spreadsheet/Writers/CSV.h
+++ b/Userland/Applications/Spreadsheet/Writers/CSV.h
@@ -12,12 +12,18 @@
 
 namespace Writer {
 
-template<typename ContainerType>
-class CSV : public XSV<ContainerType> {
+class CSV {
 public:
-    CSV(Core::Stream::Handle<Core::Stream::Stream> output, ContainerType const& data, Vector<StringView> headers = {}, WriterBehavior behaviors = default_behaviors())
-        : XSV<ContainerType>(move(output), data, { ",", "\"", WriterTraits::Repeat }, move(headers), behaviors)
+    template<typename ContainerType>
+    static ErrorOr<void> generate(Core::Stream::Stream& output, ContainerType const& data, Vector<StringView> headers = {}, WriterBehavior behaviors = default_behaviors())
     {
+        return XSV<ContainerType>::generate(output, data, { ",", "\"", WriterTraits::Repeat }, move(headers), behaviors);
+    }
+
+    template<typename ContainerType>
+    static ErrorOr<void> generate_preview(Core::Stream::Stream& output, ContainerType const& data, Vector<StringView> headers = {}, WriterBehavior behaviors = default_behaviors())
+    {
+        return XSV<ContainerType>::generate_preview(output, data, { ",", "\"", WriterTraits::Repeat }, move(headers), behaviors);
     }
 };
 

--- a/Userland/Applications/Spreadsheet/Writers/Test/TestXSVWriter.cpp
+++ b/Userland/Applications/Spreadsheet/Writers/Test/TestXSVWriter.cpp
@@ -7,7 +7,6 @@
 #include <LibTest/TestCase.h>
 
 #include "../CSV.h"
-#include "../XSV.h"
 #include <LibCore/MemoryStream.h>
 
 TEST_CASE(can_write)
@@ -19,8 +18,7 @@ TEST_CASE(can_write)
     };
 
     Core::Stream::AllocatingMemoryStream stream;
-    auto csv = Writer::CSV(Core::Stream::Handle<Core::Stream::Stream>(stream), data);
-    MUST(csv.generate());
+    MUST(Writer::CSV::generate(stream, data));
 
     auto expected_output = R"~(1,2,3
 4,5,6
@@ -40,8 +38,7 @@ TEST_CASE(can_write_with_header)
     };
 
     Core::Stream::AllocatingMemoryStream stream;
-    auto csv = Writer::CSV(Core::Stream::Handle<Core::Stream::Stream>(stream), data, { "A"sv, "B\""sv, "C"sv });
-    MUST(csv.generate());
+    MUST(Writer::CSV::generate(stream, data, { "A"sv, "B\""sv, "C"sv }));
 
     auto expected_output = R"~(A,"B""",C
 1,2,3
@@ -61,8 +58,7 @@ TEST_CASE(can_write_with_different_behaviors)
     };
 
     Core::Stream::AllocatingMemoryStream stream;
-    auto csv = Writer::CSV(Core::Stream::Handle<Core::Stream::Stream>(stream), data, { "A"sv, "B\""sv, "C"sv }, Writer::WriterBehavior::QuoteOnlyInFieldStart | Writer::WriterBehavior::WriteHeaders);
-    MUST(csv.generate());
+    MUST(Writer::CSV::generate(stream, data, { "A"sv, "B\""sv, "C"sv }, Writer::WriterBehavior::QuoteOnlyInFieldStart | Writer::WriterBehavior::WriteHeaders));
 
     auto expected_output = R"~(A,B",C
 Well,Hello",Friends

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -14,15 +14,11 @@
 #include <LibCore/System.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Application.h>
-#include <LibGUI/Clipboard.h>
-#include <LibGUI/FilePicker.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
-#include <LibGUI/MessageBox.h>
 #include <LibGUI/Window.h>
 #include <LibMain/Main.h>
-#include <unistd.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -69,8 +65,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
 
     if (filename) {
-        auto file = TRY(FileSystemAccessClient::Client::the().try_request_file_read_only_approved_deprecated(window, filename));
-        spreadsheet_widget->load_file(file);
+        auto file = TRY(FileSystemAccessClient::Client::the().request_file_read_only_approved(window, filename));
+        spreadsheet_widget->load_file(file.filename(), file.stream());
     }
 
     return app->exec();

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -806,8 +806,7 @@ void MainWidget::drop_event(GUI::DropEvent& event)
         if (!request_close())
             return;
 
-        // TODO: A drop event should be considered user consent for opening a file
-        auto response = FileSystemAccessClient::Client::the().request_file(window(), urls.first().path(), Core::Stream::OpenMode::Read);
+        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window(), urls.first().path());
         if (response.is_error())
             return;
         read_file(response.value().filename(), response.value().stream());

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -25,7 +25,7 @@ class MainWidget final : public GUI::Widget {
 
 public:
     virtual ~MainWidget() override = default;
-    bool read_file(Core::File&);
+    bool read_file(String const& filename, Core::Stream::File&);
     void open_nonexistent_file(DeprecatedString const& path);
     bool request_close();
 

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -25,7 +25,7 @@ class MainWidget final : public GUI::Widget {
 
 public:
     virtual ~MainWidget() override = default;
-    bool read_file(String const& filename, Core::Stream::File&);
+    ErrorOr<void> read_file(String const& filename, Core::Stream::File&);
     void open_nonexistent_file(DeprecatedString const& path);
     bool request_close();
 

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -73,7 +73,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (file_to_edit) {
         FileArgument parsed_argument(file_to_edit);
-        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved_deprecated(window, parsed_argument.filename());
+        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window, parsed_argument.filename());
 
         if (response.is_error()) {
             if (response.error().code() == ENOENT)
@@ -81,7 +81,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             else
                 return 1;
         } else {
-            if (!text_widget->read_file(*response.value()))
+            if (!text_widget->read_file(response.value().filename(), response.value().stream()))
                 return 1;
             text_widget->editor().set_cursor_and_focus_line(parsed_argument.line().value_or(1) - 1, parsed_argument.column().value_or(0));
         }

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -81,8 +81,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             else
                 return 1;
         } else {
-            if (!text_widget->read_file(response.value().filename(), response.value().stream()))
-                return 1;
+            TRY(text_widget->read_file(response.value().filename(), response.value().stream()));
             text_widget->editor().set_cursor_and_focus_line(parsed_argument.line().value_or(1) - 1, parsed_argument.column().value_or(0));
         }
 

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -15,6 +15,7 @@
 #include <Applications/ThemeEditor/MetricPropertyGML.h>
 #include <Applications/ThemeEditor/PathPropertyGML.h>
 #include <Applications/ThemeEditor/ThemeEditorGML.h>
+#include <LibCore/File.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/BoxLayout.h>

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -9,8 +9,8 @@
  */
 
 #include "MainWidget.h"
-#include "PreviewWidget.h"
 #include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Application.h>

--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -108,10 +108,10 @@ GalleryWidget::GalleryWidget()
     m_file_button->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors());
 
     m_file_button->on_click = [&](auto) {
-        auto response = FileSystemAccessClient::Client::the().try_open_file_deprecated(window());
+        auto response = FileSystemAccessClient::Client::the().open_file(window());
         if (response.is_error())
             return;
-        m_text_editor->set_text(response.release_value()->filename());
+        m_text_editor->set_text(response.release_value().filename());
     };
 
     m_input_button = basics_tab->find_descendant_of_type_named<GUI::Button>("input_button");

--- a/Userland/Libraries/LibCore/Forward.h
+++ b/Userland/Libraries/LibCore/Forward.h
@@ -22,6 +22,7 @@ class EventLoop;
 class File;
 class IODevice;
 class LocalServer;
+class MappedFile;
 class MimeData;
 class NetworkJob;
 class NetworkResponse;

--- a/Userland/Libraries/LibCore/MappedFile.h
+++ b/Userland/Libraries/LibCore/MappedFile.h
@@ -10,7 +10,7 @@
 #include <AK/Noncopyable.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
-#include <AK/Result.h>
+#include <LibCore/Forward.h>
 
 namespace Core {
 
@@ -20,6 +20,7 @@ class MappedFile : public RefCounted<MappedFile> {
 
 public:
     static ErrorOr<NonnullRefPtr<MappedFile>> map(StringView path);
+    static ErrorOr<NonnullRefPtr<MappedFile>> map_from_stream(NonnullOwnPtr<Core::Stream::File>, StringView path);
     static ErrorOr<NonnullRefPtr<MappedFile>> map_from_fd_and_close(int fd, StringView path);
     ~MappedFile();
 

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -316,7 +316,8 @@ public:
     virtual ErrorOr<off_t> seek(i64 offset, SeekMode) override;
     virtual ErrorOr<void> truncate(off_t length) override;
 
-    int leak_fd(Badge<::IPC::File>)
+    template<OneOf<::IPC::File, ::Core::MappedFile> VIP>
+    int leak_fd(Badge<VIP>)
     {
         m_should_close_file_descriptor = ShouldCloseFileDescriptor::No;
         return m_fd;

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -23,31 +23,6 @@ Client& Client::the()
     return *s_the;
 }
 
-DeprecatedResult Client::try_request_file_read_only_approved_deprecated(GUI::Window* parent_window, DeprecatedString const& path)
-{
-    auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { { Core::Promise<DeprecatedResult>::construct() }, parent_window });
-
-    auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
-    auto child_window_server_client_id = expose_window_server_client_id();
-    auto parent_window_id = parent_window->window_id();
-
-    GUI::ConnectionToWindowServer::the().add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-
-    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
-        GUI::ConnectionToWindowServer::the().remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-    });
-
-    if (path.starts_with('/')) {
-        async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, path);
-    } else {
-        auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
-        async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, full_path);
-    }
-
-    return handle_promise<DeprecatedResult>(id);
-}
-
 Result Client::request_file_read_only_approved(GUI::Window* parent_window, DeprecatedString const& path)
 {
     auto const id = get_new_id();
@@ -70,55 +45,7 @@ Result Client::request_file_read_only_approved(GUI::Window* parent_window, Depre
         async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, full_path);
     }
 
-    return handle_promise<Result>(id);
-}
-
-static Core::Stream::OpenMode to_stream_open_mode(Core::OpenMode open_mode)
-{
-    Core::Stream::OpenMode result {};
-    if ((open_mode & Core::OpenMode::ReadOnly) == Core::OpenMode::ReadOnly)
-        result |= Core::Stream::OpenMode::Read;
-    if ((open_mode & Core::OpenMode::WriteOnly) == Core::OpenMode::WriteOnly)
-        result |= Core::Stream::OpenMode::Write;
-    if ((open_mode & Core::OpenMode::ReadWrite) == Core::OpenMode::ReadWrite)
-        result |= Core::Stream::OpenMode::ReadWrite;
-    if ((open_mode & Core::OpenMode::Append) == Core::OpenMode::Append)
-        result |= Core::Stream::OpenMode::Append;
-    if ((open_mode & Core::OpenMode::Truncate) == Core::OpenMode::Truncate)
-        result |= Core::Stream::OpenMode::Truncate;
-    if ((open_mode & Core::OpenMode::MustBeNew) == Core::OpenMode::MustBeNew)
-        result |= Core::Stream::OpenMode::MustBeNew;
-    if ((open_mode & Core::OpenMode::KeepOnExec) == Core::OpenMode::KeepOnExec)
-        result |= Core::Stream::OpenMode::KeepOnExec;
-
-    return result;
-}
-
-DeprecatedResult Client::try_request_file_deprecated(GUI::Window* parent_window, DeprecatedString const& path, Core::OpenMode deprecated_mode)
-{
-    auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { { Core::Promise<DeprecatedResult>::construct() }, parent_window });
-
-    auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
-    auto child_window_server_client_id = expose_window_server_client_id();
-    auto parent_window_id = parent_window->window_id();
-
-    GUI::ConnectionToWindowServer::the().add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-
-    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
-        GUI::ConnectionToWindowServer::the().remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-    });
-
-    auto const mode = to_stream_open_mode(deprecated_mode);
-
-    if (path.starts_with('/')) {
-        async_request_file(id, parent_window_server_client_id, parent_window_id, path, mode);
-    } else {
-        auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
-        async_request_file(id, parent_window_server_client_id, parent_window_id, full_path, mode);
-    }
-
-    return handle_promise<DeprecatedResult>(id);
+    return handle_promise(id);
 }
 
 Result Client::request_file(GUI::Window* parent_window, DeprecatedString const& path, Core::Stream::OpenMode mode)
@@ -143,29 +70,7 @@ Result Client::request_file(GUI::Window* parent_window, DeprecatedString const& 
         async_request_file(id, parent_window_server_client_id, parent_window_id, full_path, mode);
     }
 
-    return handle_promise<Result>(id);
-}
-
-DeprecatedResult Client::try_open_file_deprecated(GUI::Window* parent_window, DeprecatedString const& window_title, StringView path, Core::OpenMode deprecated_requested_access)
-{
-    auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { { Core::Promise<DeprecatedResult>::construct() }, parent_window });
-
-    auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
-    auto child_window_server_client_id = expose_window_server_client_id();
-    auto parent_window_id = parent_window->window_id();
-
-    GUI::ConnectionToWindowServer::the().add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-
-    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
-        GUI::ConnectionToWindowServer::the().remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-    });
-
-    auto const requested_access = to_stream_open_mode(deprecated_requested_access);
-
-    async_prompt_open_file(id, parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
-
-    return handle_promise<DeprecatedResult>(id);
+    return handle_promise(id);
 }
 
 Result Client::open_file(GUI::Window* parent_window, DeprecatedString const& window_title, StringView path, Core::Stream::OpenMode requested_access)
@@ -185,29 +90,7 @@ Result Client::open_file(GUI::Window* parent_window, DeprecatedString const& win
 
     async_prompt_open_file(id, parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
 
-    return handle_promise<Result>(id);
-}
-
-DeprecatedResult Client::try_save_file_deprecated(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode deprecated_requested_access)
-{
-    auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { { Core::Promise<DeprecatedResult>::construct() }, parent_window });
-
-    auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
-    auto child_window_server_client_id = expose_window_server_client_id();
-    auto parent_window_id = parent_window->window_id();
-
-    GUI::ConnectionToWindowServer::the().add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-
-    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
-        GUI::ConnectionToWindowServer::the().remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-    });
-
-    auto const requested_access = to_stream_open_mode(deprecated_requested_access);
-
-    async_prompt_save_file(id, parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
-
-    return handle_promise<DeprecatedResult>(id);
+    return handle_promise(id);
 }
 
 Result Client::save_file(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::Stream::OpenMode requested_access)
@@ -227,7 +110,7 @@ Result Client::save_file(GUI::Window* parent_window, DeprecatedString const& nam
 
     async_prompt_save_file(id, parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
 
-    return handle_promise<Result>(id);
+    return handle_promise(id);
 }
 
 void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> const& ipc_file, Optional<DeprecatedString> const& chosen_file)
@@ -236,42 +119,24 @@ void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> co
     VERIFY(potential_data.has_value());
     auto& request_data = potential_data.value();
 
-    auto const resolve_any_promise = [&promise = request_data.promise](Error&& error) {
-        if (promise.has<PromiseType<DeprecatedResult>>()) {
-            promise.get<PromiseType<DeprecatedResult>>()->resolve(move(error));
-            return;
-        }
-        promise.get<PromiseType<Result>>()->resolve(move(error));
-    };
-
     if (error != 0) {
         // We don't want to show an error message for non-existent files since some applications may want
         // to handle it as opening a new, named file.
         if (error != -1 && error != ENOENT)
             GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
-        resolve_any_promise(Error::from_errno(error));
+        request_data.promise->resolve(Error::from_errno(error));
         return;
     }
 
     if (Core::File::is_device(ipc_file->fd())) {
         GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: Cannot open device files", *chosen_file));
-        resolve_any_promise(Error::from_string_literal("Cannot open device files"));
+        request_data.promise->resolve(Error::from_string_literal("Cannot open device files"));
         return;
     }
 
     if (Core::File::is_directory(ipc_file->fd())) {
         GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: Cannot open directory", *chosen_file));
-        resolve_any_promise(Error::from_errno(EISDIR));
-        return;
-    }
-
-    if (request_data.promise.has<PromiseType<DeprecatedResult>>()) {
-        auto file = Core::File::construct();
-        auto fd = ipc_file->take_fd();
-        file->open(fd, Core::OpenMode::ReadWrite, Core::File::ShouldCloseFileDescriptor::Yes);
-        file->set_filename(*chosen_file);
-
-        request_data.promise.get<PromiseType<DeprecatedResult>>()->resolve(file);
+        request_data.promise->resolve(Error::from_errno(EISDIR));
         return;
     }
 
@@ -281,11 +146,11 @@ void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> co
         return File({}, move(stream), filename);
     }();
     if (file_or_error.is_error()) {
-        resolve_any_promise(file_or_error.release_error());
+        request_data.promise->resolve(file_or_error.release_error());
         return;
     }
 
-    request_data.promise.get<PromiseType<Result>>()->resolve(file_or_error.release_value());
+    request_data.promise->resolve(file_or_error.release_value());
 }
 
 void Client::die()
@@ -303,10 +168,9 @@ int Client::get_new_id()
     return new_id;
 }
 
-template<typename AnyResult>
-AnyResult Client::handle_promise(int id)
+Result Client::handle_promise(int id)
 {
-    auto result = m_promises.get(id)->promise.get<PromiseType<AnyResult>>()->await();
+    auto result = m_promises.get(id)->promise->await();
     m_promises.remove(id);
     return result;
 }

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -11,7 +11,6 @@
 #include <AK/String.h>
 #include <FileSystemAccessServer/FileSystemAccessClientEndpoint.h>
 #include <FileSystemAccessServer/FileSystemAccessServerEndpoint.h>
-#include <LibCore/File.h>
 #include <LibCore/Promise.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/Window.h>
@@ -37,7 +36,6 @@ private:
     String m_filename;
 };
 
-using DeprecatedResult = ErrorOr<NonnullRefPtr<Core::File>>;
 using Result = ErrorOr<File>;
 
 class Client final
@@ -46,11 +44,6 @@ class Client final
     IPC_CLIENT_CONNECTION(Client, "/tmp/session/%sid/portal/filesystemaccess"sv)
 
 public:
-    DeprecatedResult try_request_file_read_only_approved_deprecated(GUI::Window* parent_window, DeprecatedString const& path);
-    DeprecatedResult try_request_file_deprecated(GUI::Window* parent_window, DeprecatedString const& path, Core::OpenMode mode);
-    DeprecatedResult try_open_file_deprecated(GUI::Window* parent_window, DeprecatedString const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
-    DeprecatedResult try_save_file_deprecated(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
-
     Result request_file_read_only_approved(GUI::Window* parent_window, DeprecatedString const& path);
     Result request_file(GUI::Window* parent_window, DeprecatedString const& path, Core::Stream::OpenMode requested_access);
     Result open_file(GUI::Window* parent_window, DeprecatedString const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::Stream::OpenMode requested_access = Core::Stream::OpenMode::Read);
@@ -70,14 +63,13 @@ private:
     virtual void handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> const& fd, Optional<DeprecatedString> const& chosen_file) override;
 
     int get_new_id();
-    template<typename AnyResult>
-    AnyResult handle_promise(int);
+    Result handle_promise(int);
 
     template<typename T>
     using PromiseType = RefPtr<Core::Promise<T>>;
 
     struct PromiseAndWindow {
-        Variant<PromiseType<DeprecatedResult>, PromiseType<Result>> promise;
+        PromiseType<Result> promise;
         GUI::Window* parent_window { nullptr };
     };
 

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -11,6 +11,7 @@
 #include <AK/Function.h>
 #include <AK/RefCounted.h>
 #include <LibCore/AnonymousBuffer.h>
+#include <LibCore/Forward.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
@@ -96,6 +97,7 @@ public:
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_create_shareable(BitmapFormat, IntSize, int intrinsic_scale = 1);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_create_wrapper(BitmapFormat, IntSize, int intrinsic_scale, size_t pitch, void*);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_load_from_file(StringView path, int scale_factor = 1);
+    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_load_from_stream(NonnullOwnPtr<Core::Stream::File>, StringView path);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_load_from_fd_and_close(int fd, StringView path);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_create_with_anonymous_buffer(BitmapFormat, Core::AnonymousBuffer, IntSize, int intrinsic_scale, Vector<ARGB32> const& palette);
     static ErrorOr<NonnullRefPtr<Bitmap>> try_create_from_serialized_bytes(ReadonlyBytes);


### PR DESCRIPTION
Concerned functions are:
 - try_request_file_read_only_approved_deprecated
 - try_request_file_deprecated
 - try_open_file_deprecated
 - try_save_file_deprecated

It also allows a lot of simplifications in the implementation of the client, and we don't need to include <LibCore/File.h> in "Client.h" anymore.

This patch depends on many PRs:
1. #17018 
2. #17021 
3. #17023 
5. #17024 
6. #17025
7. #17045 