### PR TITLE
LibCore: Avoid a build error when calling Stream::read_trivial_value

### DIFF
--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -113,8 +113,8 @@ public:
     ErrorOr<T> read_trivial_value()
     {
         alignas(T) u8 buffer[sizeof(T)] = {};
-        TRY(read_entire_buffer(buffer));
-        return *bit_cast<T>(buffer);
+        TRY(read_entire_buffer({ buffer, sizeof(T) }));
+        return *reinterpret_cast<T*>(buffer);
     }
 
     template<typename T>


### PR DESCRIPTION
Previously, calling read_trivial_value from anywhere else in the code would cause a build error in the call site.