### PR TITLE
LibIPC+LibCore+AK: Decode messages using `Core::Stream` internally

### DIFF
--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -20,6 +20,7 @@ struct GenericTraits {
     using PeekType = T&;
     using ConstPeekType = T const&;
     static constexpr bool is_trivial() { return false; }
+    static constexpr bool is_trivially_serializable() { return false; }
     static constexpr bool equals(T const& a, T const& b) { return a == b; }
     template<Concepts::HashCompatible<T> U>
     static bool equals(U const& a, T const& b) { return a == b; }
@@ -32,6 +33,7 @@ struct Traits : public GenericTraits<T> {
 template<Integral T>
 struct Traits<T> : public GenericTraits<T> {
     static constexpr bool is_trivial() { return true; }
+    static constexpr bool is_trivially_serializable() { return true; }
     static constexpr unsigned hash(T value)
     {
         if constexpr (sizeof(T) < 8)
@@ -45,6 +47,7 @@ struct Traits<T> : public GenericTraits<T> {
 template<FloatingPoint T>
 struct Traits<T> : public GenericTraits<T> {
     static constexpr bool is_trivial() { return true; }
+    static constexpr bool is_trivially_serializable() { return true; }
     static constexpr unsigned hash(T value)
     {
         if constexpr (sizeof(T) < 8)
@@ -65,6 +68,7 @@ template<Enum T>
 struct Traits<T> : public GenericTraits<T> {
     static unsigned hash(T value) { return Traits<UnderlyingType<T>>::hash(to_underlying(value)); }
     static constexpr bool is_trivial() { return Traits<UnderlyingType<T>>::is_trivial(); }
+    static constexpr bool is_trivially_serializable() { return Traits<UnderlyingType<T>>::is_trivially_serializable(); }
 };
 
 template<typename T>

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -293,21 +293,6 @@ DeprecatedString constructor_for_message(DeprecatedString const& name, Vector<Pa
     return builder.to_deprecated_string();
 }
 
-static void append_handle_stream_error(SourceGenerator& generator, StringView error_message)
-{
-    if constexpr (GENERATE_DEBUG) {
-        generator.set("error_message"sv, error_message);
-        generator.append(R"~~~(
-        if (stream.handle_any_error()) {
-            dbgln("@error_message@");
-            return Error::from_string_literal("@error_message@");
-        })~~~");
-    } else {
-        generator.append(R"~~~(
-        TRY(stream.try_handle_any_error());)~~~");
-    }
-}
-
 void do_message(SourceGenerator message_generator, DeprecatedString const& name, Vector<Parameter> const& parameters, DeprecatedString const& response_type = {})
 {
     auto pascal_name = pascal_case(name);
@@ -353,7 +338,7 @@ public:)~~~");
     static i32 static_message_id() { return (int)MessageID::@message.pascal_name@; }
     virtual const char* message_name() const override { return "@endpoint.name@::@message.pascal_name@"; }
 
-    static ErrorOr<NonnullOwnPtr<@message.pascal_name@>> decode(InputMemoryStream& stream, Core::Stream::LocalSocket& socket)
+    static ErrorOr<NonnullOwnPtr<@message.pascal_name@>> decode(Core::Stream::Stream& stream, Core::Stream::LocalSocket& socket)
     {
         IPC::Decoder decoder { stream, socket };)~~~");
 
@@ -387,7 +372,6 @@ public:)~~~");
     }
 
     message_generator.set("message.constructor_call_parameters", builder.build());
-    append_handle_stream_error(message_generator, "Failed to read the message"sv);
     message_generator.appendln(R"~~~(
         return make<@message.pascal_name@>(@message.constructor_call_parameters@);
     })~~~");
@@ -602,10 +586,8 @@ public:
 
     static ErrorOr<NonnullOwnPtr<IPC::Message>> decode_message(ReadonlyBytes buffer, [[maybe_unused]] Core::Stream::LocalSocket& socket)
     {
-        InputMemoryStream stream { buffer };
-        u32 message_endpoint_magic = 0;
-        stream >> message_endpoint_magic;)~~~");
-    append_handle_stream_error(generator, "Failed to read message endpoint magic"sv);
+        auto stream = TRY(Core::Stream::FixedMemoryStream::construct(buffer));
+        auto message_endpoint_magic = TRY(stream->read_value<u32>());)~~~");
     generator.append(R"~~~(
 
         if (message_endpoint_magic != @endpoint.magic@) {)~~~");
@@ -617,9 +599,7 @@ public:
             return Error::from_string_literal("Endpoint magic number mismatch, not my message!");
         }
 
-        i32 message_id = 0;
-        stream >> message_id;)~~~");
-    append_handle_stream_error(generator, "Failed to read message ID"sv);
+        auto message_id = TRY(stream->read_value<i32>());)~~~");
     generator.appendln(R"~~~(
 
         switch (message_id) {)~~~");
@@ -633,7 +613,7 @@ public:
 
             message_generator.append(R"~~~(
         case (int)Messages::@endpoint.name@::MessageID::@message.pascal_name@:
-            return TRY(Messages::@endpoint.name@::@message.pascal_name@::decode(stream, socket));)~~~");
+            return TRY(Messages::@endpoint.name@::@message.pascal_name@::decode(*stream, socket));)~~~");
         };
 
         do_decode_message(message.name);
@@ -787,11 +767,11 @@ void build(StringBuilder& builder, Vector<Endpoint> const& endpoints)
         }
     }
 
-    generator.appendln(R"~~~(#include <AK/MemoryStream.h>
-#include <AK/Error.h>
+    generator.appendln(R"~~~(#include <AK/Error.h>
 #include <AK/OwnPtr.h>
 #include <AK/Result.h>
 #include <AK/Utf8View.h>
+#include <LibCore/MemoryStream.h>
 #include <LibIPC/Connection.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Dictionary.h>

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -109,8 +109,8 @@ public:
     }
 
     template<typename T>
-    requires(IsTriviallyDestructible<T>)
-    ErrorOr<T> read_trivial_value()
+    requires(Traits<T>::is_trivially_serializable())
+    ErrorOr<T> read_value()
     {
         alignas(T) u8 buffer[sizeof(T)] = {};
         TRY(read_entire_buffer({ &buffer, sizeof(buffer) }));
@@ -118,8 +118,8 @@ public:
     }
 
     template<typename T>
-    requires(IsTriviallyDestructible<T>)
-    ErrorOr<void> write_trivial_value(T const& value)
+    requires(Traits<T>::is_trivially_serializable())
+    ErrorOr<void> write_value(T const& value)
     {
         return write_entire_buffer({ &value, sizeof(value) });
     }

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -113,8 +113,8 @@ public:
     ErrorOr<T> read_trivial_value()
     {
         alignas(T) u8 buffer[sizeof(T)] = {};
-        TRY(read_entire_buffer(buffer));
-        return *bit_cast<T>(buffer);
+        TRY(read_entire_buffer({ &buffer, sizeof(buffer) }));
+        return bit_cast<T>(buffer);
     }
 
     template<typename T>

--- a/Userland/Libraries/LibDNS/Name.cpp
+++ b/Userland/Libraries/LibDNS/Name.cpp
@@ -79,10 +79,10 @@ ErrorOr<void> Name::write_to_stream(Core::Stream::Stream& stream) const
 {
     auto parts = as_string().split_view('.');
     for (auto& part : parts) {
-        TRY(stream.write_trivial_value<u8>(part.length()));
+        TRY(stream.write_value<u8>(part.length()));
         TRY(stream.write_entire_buffer(part.bytes()));
     }
-    TRY(stream.write_trivial_value('\0'));
+    TRY(stream.write_value('\0'));
     return {};
 }
 

--- a/Userland/Libraries/LibDNS/Packet.cpp
+++ b/Userland/Libraries/LibDNS/Packet.cpp
@@ -51,23 +51,23 @@ ErrorOr<ByteBuffer> Packet::to_byte_buffer() const
 
     Core::Stream::AllocatingMemoryStream stream;
 
-    TRY(stream.write_trivial_value(header));
+    TRY(stream.write_value(header));
     for (auto& question : m_questions) {
         TRY(question.name().write_to_stream(stream));
-        TRY(stream.write_trivial_value(htons((u16)question.record_type())));
-        TRY(stream.write_trivial_value(htons(question.raw_class_code())));
+        TRY(stream.write_value(htons((u16)question.record_type())));
+        TRY(stream.write_value(htons(question.raw_class_code())));
     }
     for (auto& answer : m_answers) {
         TRY(answer.name().write_to_stream(stream));
-        TRY(stream.write_trivial_value(htons((u16)answer.type())));
-        TRY(stream.write_trivial_value(htons(answer.raw_class_code())));
-        TRY(stream.write_trivial_value(htonl(answer.ttl())));
+        TRY(stream.write_value(htons((u16)answer.type())));
+        TRY(stream.write_value(htons(answer.raw_class_code())));
+        TRY(stream.write_value(htonl(answer.ttl())));
         if (answer.type() == RecordType::PTR) {
             Name name { answer.record_data() };
-            TRY(stream.write_trivial_value(htons(name.serialized_size())));
+            TRY(stream.write_value(htons(name.serialized_size())));
             TRY(name.write_to_stream(stream));
         } else {
-            TRY(stream.write_trivial_value(htons(answer.record_data().length())));
+            TRY(stream.write_value(htons(answer.record_data().length())));
             TRY(stream.write_entire_buffer(answer.record_data().bytes()));
         }
     }

--- a/Userland/Libraries/LibDNS/PacketHeader.h
+++ b/Userland/Libraries/LibDNS/PacketHeader.h
@@ -97,3 +97,8 @@ private:
 static_assert(sizeof(PacketHeader) == 12);
 
 }
+
+template<>
+struct AK::Traits<DNS::PacketHeader> : public AK::GenericTraits<DNS::PacketHeader> {
+    static constexpr bool is_trivially_serializable() { return true; }
+};

--- a/Userland/Libraries/LibIPC/Decoder.h
+++ b/Userland/Libraries/LibIPC/Decoder.h
@@ -33,7 +33,7 @@ inline ErrorOr<T> decode(Decoder&)
 
 class Decoder {
 public:
-    Decoder(InputMemoryStream& stream, Core::Stream::LocalSocket& socket)
+    Decoder(Core::Stream::Stream& stream, Core::Stream::LocalSocket& socket)
         : m_stream(stream)
         , m_socket(socket)
     {
@@ -45,8 +45,13 @@ public:
     template<typename T>
     ErrorOr<void> decode_into(T& value)
     {
-        m_stream >> value;
-        TRY(m_stream.try_handle_any_error());
+        value = TRY(m_stream.read_value<T>());
+        return {};
+    }
+
+    ErrorOr<void> decode_into(Bytes bytes)
+    {
+        TRY(m_stream.read_entire_buffer(bytes));
         return {};
     }
 
@@ -55,7 +60,7 @@ public:
     Core::Stream::LocalSocket& socket() { return m_socket; }
 
 private:
-    InputMemoryStream& m_stream;
+    Core::Stream::Stream& m_stream;
     Core::Stream::LocalSocket& m_socket;
 };
 


### PR DESCRIPTION
Also included is a compile fix for `read_trivial_value` (which, apparently, I have accidentally never added any usages for in my last PR).