### PR TITLE
PixelPaint: Let the move tool optionally select the active layer

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -372,10 +372,9 @@ void ImageEditor::mousedown_event(GUI::MouseEvent& event)
     if (!m_active_tool)
         return;
 
-    if (is<MoveTool>(*m_active_tool)) {
-        if (auto* other_layer = layer_at_editor_position(event.position())) {
-            set_active_layer(other_layer);
-        }
+    if (auto* tool = dynamic_cast<MoveTool*>(m_active_tool); tool && tool->layer_selection_mode() == MoveTool::LayerSelectionMode::ForegroundLayer) {
+        if (auto* foreground_layer = layer_at_editor_position(event.position()))
+            set_active_layer(foreground_layer);
     }
 
     auto layer_event = m_active_layer ? event_adjusted_for_layer(event, *m_active_layer) : event;

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022-2023, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,6 +9,7 @@
 
 #include "../Layer.h"
 #include "Tool.h"
+#include <LibGUI/RadioButton.h>
 
 namespace PixelPaint {
 
@@ -23,19 +24,29 @@ public:
     MoveTool() = default;
     virtual ~MoveTool() override = default;
 
+    enum class LayerSelectionMode {
+        ForegroundLayer,
+        ActiveLayer,
+    };
+
     virtual void on_mousedown(Layer*, MouseEvent&) override;
     virtual void on_mousemove(Layer*, MouseEvent&) override;
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual void on_keyup(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
+    virtual GUI::Widget* get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
+    virtual bool is_overriding_alt() override { return true; }
+    LayerSelectionMode layer_selection_mode() const { return m_layer_selection_mode; }
 
 private:
     virtual StringView tool_name() const override { return "Move Tool"sv; }
     ErrorOr<void> update_cached_preview_bitmap(Layer const* layer);
     Optional<ResizeAnchorLocation const> resize_anchor_location_from_cursor_position(Layer const*, MouseEvent&);
+    void toggle_selection_mode();
 
+    LayerSelectionMode m_layer_selection_mode { LayerSelectionMode::ForegroundLayer };
     RefPtr<Layer> m_layer_being_moved;
     Gfx::IntPoint m_event_origin;
     Gfx::IntPoint m_layer_origin;
@@ -43,6 +54,9 @@ private:
     bool m_scaling { false };
     Optional<ResizeAnchorLocation const> m_resize_anchor_location {};
     bool m_keep_aspect_ratio { false };
+    RefPtr<GUI::Widget> m_properties_widget;
+    RefPtr<GUI::RadioButton> m_selection_mode_foreground;
+    RefPtr<GUI::RadioButton> m_selection_mode_active;
 
     RefPtr<Gfx::Bitmap> m_cached_preview_bitmap { nullptr };
 };


### PR DESCRIPTION
Previously, the move tool would always select the topmost layer before performing a move operation. This commit adds an option to for the move tool to always select the active layer, even if it is behind another layer.

I'm not sure what the behavior should be in the new mode when clicking outside of the active layer. Currently it does nothing. Any feedback about what is reasonable here would be appreciated. 

Video:

https://user-images.githubusercontent.com/2817754/212568526-3b2b17fd-01a8-4c7a-bcd4-9bc6ce2f7e31.mp4

