### PR TITLE
LibVirtGPU: Port to `Core::Stream`

### DIFF
--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -322,6 +322,11 @@ public:
         return m_fd;
     }
 
+    int fd() const
+    {
+        return m_fd;
+    }
+
     virtual ~File() override
     {
         if (m_should_close_file_descriptor == ShouldCloseFileDescriptor::Yes)

--- a/Userland/Libraries/LibVirtGPU/Device.cpp
+++ b/Userland/Libraries/LibVirtGPU/Device.cpp
@@ -38,15 +38,15 @@ static constexpr auto vert_shader = "VERT\n"
                                     "  4: MOV_SAT OUT[1], IN[1]\n"
                                     "  5: END\n"sv;
 
-Device::Device(NonnullRefPtr<Core::File> gpu_file)
-    : m_gpu_file { gpu_file }
+Device::Device(NonnullOwnPtr<Core::Stream::File> gpu_file)
+    : m_gpu_file { move(gpu_file) }
 {
 }
 
 ErrorOr<NonnullOwnPtr<Device>> Device::create(Gfx::IntSize min_size)
 {
-    auto file = TRY(Core::File::open("/dev/gpu/render0", Core::OpenMode::ReadWrite));
-    auto device = make<Device>(file);
+    auto file = TRY(Core::Stream::File::open("/dev/gpu/render0"sv, Core::Stream::OpenMode::ReadWrite));
+    auto device = make<Device>(move(file));
     TRY(device->initialize_context(min_size));
     return device;
 }

--- a/Userland/Libraries/LibVirtGPU/Device.h
+++ b/Userland/Libraries/LibVirtGPU/Device.h
@@ -10,7 +10,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Vector.h>
 #include <Kernel/API/VirGL.h>
-#include <LibCore/File.h>
+#include <LibCore/Stream.h>
 #include <LibGPU/Device.h>
 #include <LibVirtGPU/VirGLProtocol.h>
 
@@ -18,7 +18,7 @@ namespace VirtGPU {
 
 class Device final : public GPU::Device {
 public:
-    Device(NonnullRefPtr<Core::File>);
+    Device(NonnullOwnPtr<Core::Stream::File>);
 
     static ErrorOr<NonnullOwnPtr<Device>> create(Gfx::IntSize min_size);
 
@@ -66,7 +66,7 @@ private:
     ErrorOr<Protocol::ResourceID> create_virgl_resource(VirGL3DResourceSpec&);
     ErrorOr<void> upload_command_buffer(Vector<u32> const&);
 
-    NonnullRefPtr<Core::File> m_gpu_file;
+    NonnullOwnPtr<Core::Stream::File> m_gpu_file;
 
     Protocol::ResourceID m_vbo_resource_id { 0 };
     Protocol::ResourceID m_drawtarget { 0 };


### PR DESCRIPTION
Unlike `leak_fd()` the stream is still owning the file descriptor after
the call.