### PR TITLE
LibWeb: Prevent floats from being positioned higher than preceding blocks

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -538,6 +538,8 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
     });
 
     m_margin_state.block_container_y_position_update_callback = {};
+    m_left_floats.clear();
+    m_right_floats.clear();
 
     if (layout_mode == LayoutMode::IntrinsicSizing) {
         auto& block_container_state = m_state.get_mutable(block_container);


### PR DESCRIPTION
CSS 2.2 section 9.5.1:
The outer top of a floating box may not be higher than the outer top of any _block_ or floated box generated by an element earlier in the source document.

Where block is `BlockContainer` in LibWeb type system. Which means `current_boxes` need to be cleared before leaving block container.

```html
<style>
.wrapper {
  width: 100px;
  height: 300px;
  background-color: lightgray;
}

.box {
  margin: 10px;
  width: 50px;
  height: 50px;
  float: left;
}

.a { background-color: salmon; }
.b { background-color: slateblue; }
.c { background-color: green; }
</style>
<div class="wrapper">
	<div class="box a"></div>
	<div class="box b"></div>
</div>
<div class="box c">
</div>
```