### PR TITLE
AK+Everywhere: Return Optional from JsonObject::get() methods (PART 1)

### DIFF
--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -10,6 +10,7 @@ set(AK_SOURCES
     FuzzyMatch.cpp
     GenericLexer.cpp
     Hex.cpp
+    JsonObject.cpp
     JsonParser.cpp
     JsonPath.cpp
     JsonValue.cpp

--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -67,6 +67,111 @@ JsonValue const* JsonObject::get_ptr(StringView key) const
     return &(*it).value;
 }
 
+Optional<JsonValue const&> JsonObject::get(StringView key) const
+{
+    auto it = m_members.find(key);
+    if (it == m_members.end())
+        return {};
+    return it->value;
+}
+
+Optional<i8> JsonObject::get_i8(StringView key) const
+{
+    return get_integer<i8>(key);
+}
+
+Optional<u8> JsonObject::get_u8(StringView key) const
+{
+    return get_integer<u8>(key);
+}
+
+Optional<i16> JsonObject::get_i16(StringView key) const
+{
+    return get_integer<i16>(key);
+}
+
+Optional<u16> JsonObject::get_u16(StringView key) const
+{
+    return get_integer<u16>(key);
+}
+
+Optional<i32> JsonObject::get_i32(StringView key) const
+{
+    return get_integer<i32>(key);
+}
+
+Optional<u32> JsonObject::get_u32(StringView key) const
+{
+    return get_integer<u32>(key);
+}
+
+Optional<i64> JsonObject::get_i64(StringView key) const
+{
+    return get_integer<i64>(key);
+}
+
+Optional<u64> JsonObject::get_u64(StringView key) const
+{
+    return get_integer<u64>(key);
+}
+
+Optional<FlatPtr> JsonObject::get_addr(StringView key) const
+{
+    return get_integer<FlatPtr>(key);
+}
+
+Optional<bool> JsonObject::get_bool(StringView key) const
+{
+    auto maybe_value = get(key);
+    if (maybe_value.has_value() && maybe_value->is_bool())
+        return maybe_value->as_bool();
+    return {};
+}
+
+#if !defined(KERNEL)
+Optional<DeprecatedString> JsonObject::get_deprecated_string(StringView key) const
+{
+    auto maybe_value = get(key);
+    if (maybe_value.has_value() && maybe_value->is_string())
+        return maybe_value->as_string();
+    return {};
+}
+#endif
+
+Optional<JsonObject const&> JsonObject::get_object(StringView key) const
+{
+    auto maybe_value = get(key);
+    if (maybe_value.has_value() && maybe_value->is_object())
+        return maybe_value->as_object();
+    return {};
+}
+
+Optional<JsonArray const&> JsonObject::get_array(StringView key) const
+{
+    auto maybe_value = get(key);
+    if (maybe_value.has_value() && maybe_value->is_array())
+        return maybe_value->as_array();
+    return {};
+}
+
+#if !defined(KERNEL)
+Optional<double> JsonObject::get_double(StringView key) const
+{
+    auto maybe_value = get(key);
+    if (maybe_value.has_value() && maybe_value->is_double())
+        return maybe_value->as_double();
+    return {};
+}
+
+Optional<float> JsonObject::get_float(StringView key) const
+{
+    auto maybe_value = get(key);
+    if (maybe_value.has_value() && maybe_value->is_double())
+        return static_cast<float>(maybe_value->as_double());
+    return {};
+}
+#endif
+
 bool JsonObject::has(StringView key) const
 {
     return m_members.contains(key);
@@ -74,69 +179,93 @@ bool JsonObject::has(StringView key) const
 
 bool JsonObject::has_null(StringView key) const
 {
-    auto const* value = get_ptr(key);
-    return value && value->is_null();
+    auto value = get(key);
+    return value.has_value() && value->is_null();
 }
 
 bool JsonObject::has_bool(StringView key) const
 {
-    auto const* value = get_ptr(key);
-    return value && value->is_bool();
+    auto value = get(key);
+    return value.has_value() && value->is_bool();
 }
 
 bool JsonObject::has_string(StringView key) const
 {
-    auto const* value = get_ptr(key);
-    return value && value->is_string();
+    auto value = get(key);
+    return value.has_value() && value->is_string();
+}
+
+bool JsonObject::has_i8(StringView key) const
+{
+    auto value = get(key);
+    return value.has_value() && value->is_integer<i8>();
+}
+
+bool JsonObject::has_u8(StringView key) const
+{
+    auto value = get(key);
+    return value.has_value() && value->is_integer<u8>();
+}
+
+bool JsonObject::has_i16(StringView key) const
+{
+    auto value = get(key);
+    return value.has_value() && value->is_integer<i16>();
+}
+
+bool JsonObject::has_u16(StringView key) const
+{
+    auto value = get(key);
+    return value.has_value() && value->is_integer<u16>();
 }
 
 bool JsonObject::has_i32(StringView key) const
 {
-    auto const* value = get_ptr(key);
-    return value && value->is_i32();
+    auto value = get(key);
+    return value.has_value() && value->is_integer<i32>();
 }
 
 bool JsonObject::has_u32(StringView key) const
 {
-    auto const* value = get_ptr(key);
-    return value && value->is_u32();
+    auto value = get(key);
+    return value.has_value() && value->is_integer<u32>();
 }
 
 bool JsonObject::has_i64(StringView key) const
 {
-    auto const* value = get_ptr(key);
-    return value && value->is_i64();
+    auto value = get(key);
+    return value.has_value() && value->is_integer<i64>();
 }
 
 bool JsonObject::has_u64(StringView key) const
 {
-    auto const* value = get_ptr(key);
-    return value && value->is_u64();
+    auto value = get(key);
+    return value.has_value() && value->is_integer<u64>();
 }
 
 bool JsonObject::has_number(StringView key) const
 {
-    auto const* value = get_ptr(key);
-    return value && value->is_number();
+    auto value = get(key);
+    return value.has_value() && value->is_number();
 }
 
 bool JsonObject::has_array(StringView key) const
 {
-    auto const* value = get_ptr(key);
-    return value && value->is_array();
+    auto value = get(key);
+    return value.has_value() && value->is_array();
 }
 
 bool JsonObject::has_object(StringView key) const
 {
-    auto const* value = get_ptr(key);
-    return value && value->is_object();
+    auto value = get(key);
+    return value.has_value() && value->is_object();
 }
 
 #ifndef KERNEL
 bool JsonObject::has_double(StringView key) const
 {
-    auto const* value = get_ptr(key);
-    return value && value->is_double();
+    auto value = get(key);
+    return value.has_value() && value->is_double();
 }
 #endif
 

--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "JsonObject.h"
+
+namespace AK {
+
+JsonObject::JsonObject() = default;
+JsonObject::~JsonObject() = default;
+
+JsonObject::JsonObject(JsonObject const& other)
+    : m_members(other.m_members)
+{
+}
+
+JsonObject::JsonObject(JsonObject&& other)
+    : m_members(move(other.m_members))
+{
+}
+
+JsonObject& JsonObject::operator=(JsonObject const& other)
+{
+    if (this != &other)
+        m_members = other.m_members;
+    return *this;
+}
+
+JsonObject& JsonObject::operator=(JsonObject&& other)
+{
+    if (this != &other)
+        m_members = move(other.m_members);
+    return *this;
+}
+
+size_t JsonObject::size() const
+{
+    return m_members.size();
+}
+
+bool JsonObject::is_empty() const
+{
+    return m_members.is_empty();
+}
+
+JsonValue const& JsonObject::get_deprecated(StringView key) const
+{
+    auto const* value = get_ptr(key);
+    static JsonValue* s_null_value { nullptr };
+    if (!value) {
+        if (!s_null_value)
+            s_null_value = new JsonValue;
+        return *s_null_value;
+    }
+    return *value;
+}
+
+JsonValue const* JsonObject::get_ptr(StringView key) const
+{
+    auto it = m_members.find(key);
+    if (it == m_members.end())
+        return nullptr;
+    return &(*it).value;
+}
+
+bool JsonObject::has(StringView key) const
+{
+    return m_members.contains(key);
+}
+
+bool JsonObject::has_null(StringView key) const
+{
+    auto const* value = get_ptr(key);
+    return value && value->is_null();
+}
+
+bool JsonObject::has_bool(StringView key) const
+{
+    auto const* value = get_ptr(key);
+    return value && value->is_bool();
+}
+
+bool JsonObject::has_string(StringView key) const
+{
+    auto const* value = get_ptr(key);
+    return value && value->is_string();
+}
+
+bool JsonObject::has_i32(StringView key) const
+{
+    auto const* value = get_ptr(key);
+    return value && value->is_i32();
+}
+
+bool JsonObject::has_u32(StringView key) const
+{
+    auto const* value = get_ptr(key);
+    return value && value->is_u32();
+}
+
+bool JsonObject::has_i64(StringView key) const
+{
+    auto const* value = get_ptr(key);
+    return value && value->is_i64();
+}
+
+bool JsonObject::has_u64(StringView key) const
+{
+    auto const* value = get_ptr(key);
+    return value && value->is_u64();
+}
+
+bool JsonObject::has_number(StringView key) const
+{
+    auto const* value = get_ptr(key);
+    return value && value->is_number();
+}
+
+bool JsonObject::has_array(StringView key) const
+{
+    auto const* value = get_ptr(key);
+    return value && value->is_array();
+}
+
+bool JsonObject::has_object(StringView key) const
+{
+    auto const* value = get_ptr(key);
+    return value && value->is_object();
+}
+
+#ifndef KERNEL
+bool JsonObject::has_double(StringView key) const
+{
+    auto const* value = get_ptr(key);
+    return value && value->is_double();
+}
+#endif
+
+void JsonObject::set(DeprecatedString const& key, JsonValue value)
+{
+    m_members.set(key, move(value));
+}
+
+bool JsonObject::remove(StringView key)
+{
+    return m_members.remove(key);
+}
+
+DeprecatedString JsonObject::to_deprecated_string() const
+{
+    return serialized<StringBuilder>();
+}
+
+}

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -52,7 +52,7 @@ public:
     [[nodiscard]] size_t size() const { return m_members.size(); }
     [[nodiscard]] bool is_empty() const { return m_members.is_empty(); }
 
-    [[nodiscard]] JsonValue const& get(StringView key) const
+    [[nodiscard]] JsonValue const& get_deprecated(StringView key) const
     {
         auto const* value = get_ptr(key);
         static JsonValue* s_null_value { nullptr };

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -44,6 +44,10 @@ public:
     [[nodiscard]] bool has_null(StringView key) const;
     [[nodiscard]] bool has_bool(StringView key) const;
     [[nodiscard]] bool has_string(StringView key) const;
+    [[nodiscard]] bool has_i8(StringView key) const;
+    [[nodiscard]] bool has_u8(StringView key) const;
+    [[nodiscard]] bool has_i16(StringView key) const;
+    [[nodiscard]] bool has_u16(StringView key) const;
     [[nodiscard]] bool has_i32(StringView key) const;
     [[nodiscard]] bool has_u32(StringView key) const;
     [[nodiscard]] bool has_i64(StringView key) const;
@@ -53,6 +57,40 @@ public:
     [[nodiscard]] bool has_object(StringView key) const;
 #ifndef KERNEL
     [[nodiscard]] bool has_double(StringView key) const;
+#endif
+
+    Optional<JsonValue const&> get(StringView key) const;
+
+    template<Integral T>
+    Optional<T> get_integer(StringView key) const
+    {
+        auto maybe_value = get(key);
+        if (maybe_value.has_value() && maybe_value->is_integer<T>())
+            return maybe_value->as_integer<T>();
+        return {};
+    }
+
+    Optional<i8> get_i8(StringView key) const;
+    Optional<u8> get_u8(StringView key) const;
+    Optional<i16> get_i16(StringView key) const;
+    Optional<u16> get_u16(StringView key) const;
+    Optional<i32> get_i32(StringView key) const;
+    Optional<u32> get_u32(StringView key) const;
+    Optional<i64> get_i64(StringView key) const;
+    Optional<u64> get_u64(StringView key) const;
+    Optional<FlatPtr> get_addr(StringView key) const;
+    Optional<bool> get_bool(StringView key) const;
+
+#if !defined(KERNEL)
+    Optional<DeprecatedString> get_deprecated_string(StringView key) const;
+#endif
+
+    Optional<JsonObject const&> get_object(StringView key) const;
+    Optional<JsonArray const&> get_array(StringView key) const;
+
+#if !defined(KERNEL)
+    Optional<double> get_double(StringView key) const;
+    Optional<float> get_float(StringView key) const;
 #endif
 
     void set(DeprecatedString const& key, JsonValue value);

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -22,123 +23,39 @@ class JsonObject {
     using CallbackErrorType = decltype(declval<Callback>()(declval<DeprecatedString const&>(), declval<JsonValue const&>()).release_error());
 
 public:
-    JsonObject() = default;
-    ~JsonObject() = default;
+    JsonObject();
+    ~JsonObject();
 
-    JsonObject(JsonObject const& other)
-        : m_members(other.m_members)
-    {
-    }
+    JsonObject(JsonObject const& other);
+    JsonObject(JsonObject&& other);
 
-    JsonObject(JsonObject&& other)
-        : m_members(move(other.m_members))
-    {
-    }
+    JsonObject& operator=(JsonObject const& other);
+    JsonObject& operator=(JsonObject&& other);
 
-    JsonObject& operator=(JsonObject const& other)
-    {
-        if (this != &other)
-            m_members = other.m_members;
-        return *this;
-    }
+    [[nodiscard]] size_t size() const;
+    [[nodiscard]] bool is_empty() const;
 
-    JsonObject& operator=(JsonObject&& other)
-    {
-        if (this != &other)
-            m_members = move(other.m_members);
-        return *this;
-    }
+    [[nodiscard]] JsonValue const& get_deprecated(StringView key) const;
 
-    [[nodiscard]] size_t size() const { return m_members.size(); }
-    [[nodiscard]] bool is_empty() const { return m_members.is_empty(); }
+    [[nodiscard]] JsonValue const* get_ptr(StringView key) const;
 
-    [[nodiscard]] JsonValue const& get_deprecated(StringView key) const
-    {
-        auto const* value = get_ptr(key);
-        static JsonValue* s_null_value { nullptr };
-        if (!value) {
-            if (!s_null_value)
-                s_null_value = new JsonValue;
-            return *s_null_value;
-        }
-        return *value;
-    }
+    [[nodiscard]] bool has(StringView key) const;
 
-    [[nodiscard]] JsonValue const* get_ptr(StringView key) const
-    {
-        auto it = m_members.find(key);
-        if (it == m_members.end())
-            return nullptr;
-        return &(*it).value;
-    }
-
-    [[nodiscard]] [[nodiscard]] bool has(StringView key) const
-    {
-        return m_members.contains(key);
-    }
-
-    [[nodiscard]] bool has_null(StringView key) const
-    {
-        auto const* value = get_ptr(key);
-        return value && value->is_null();
-    }
-    [[nodiscard]] bool has_bool(StringView key) const
-    {
-        auto const* value = get_ptr(key);
-        return value && value->is_bool();
-    }
-    [[nodiscard]] bool has_string(StringView key) const
-    {
-        auto const* value = get_ptr(key);
-        return value && value->is_string();
-    }
-    [[nodiscard]] bool has_i32(StringView key) const
-    {
-        auto const* value = get_ptr(key);
-        return value && value->is_i32();
-    }
-    [[nodiscard]] bool has_u32(StringView key) const
-    {
-        auto const* value = get_ptr(key);
-        return value && value->is_u32();
-    }
-    [[nodiscard]] bool has_i64(StringView key) const
-    {
-        auto const* value = get_ptr(key);
-        return value && value->is_i64();
-    }
-    [[nodiscard]] bool has_u64(StringView key) const
-    {
-        auto const* value = get_ptr(key);
-        return value && value->is_u64();
-    }
-    [[nodiscard]] bool has_number(StringView key) const
-    {
-        auto const* value = get_ptr(key);
-        return value && value->is_number();
-    }
-    [[nodiscard]] bool has_array(StringView key) const
-    {
-        auto const* value = get_ptr(key);
-        return value && value->is_array();
-    }
-    [[nodiscard]] bool has_object(StringView key) const
-    {
-        auto const* value = get_ptr(key);
-        return value && value->is_object();
-    }
+    [[nodiscard]] bool has_null(StringView key) const;
+    [[nodiscard]] bool has_bool(StringView key) const;
+    [[nodiscard]] bool has_string(StringView key) const;
+    [[nodiscard]] bool has_i32(StringView key) const;
+    [[nodiscard]] bool has_u32(StringView key) const;
+    [[nodiscard]] bool has_i64(StringView key) const;
+    [[nodiscard]] bool has_u64(StringView key) const;
+    [[nodiscard]] bool has_number(StringView key) const;
+    [[nodiscard]] bool has_array(StringView key) const;
+    [[nodiscard]] bool has_object(StringView key) const;
 #ifndef KERNEL
-    [[nodiscard]] [[nodiscard]] bool has_double(StringView key) const
-    {
-        auto const* value = get_ptr(key);
-        return value && value->is_double();
-    }
+    [[nodiscard]] bool has_double(StringView key) const;
 #endif
 
-    void set(DeprecatedString const& key, JsonValue value)
-    {
-        m_members.set(key, move(value));
-    }
+    void set(DeprecatedString const& key, JsonValue value);
 
     template<typename Callback>
     void for_each_member(Callback callback) const
@@ -155,10 +72,7 @@ public:
         return {};
     }
 
-    bool remove(StringView key)
-    {
-        return m_members.remove(key);
-    }
+    bool remove(StringView key);
 
     template<typename Builder>
     typename Builder::OutputType serialized() const;
@@ -166,7 +80,7 @@ public:
     template<typename Builder>
     void serialize(Builder&) const;
 
-    [[nodiscard]] DeprecatedString to_deprecated_string() const { return serialized<StringBuilder>(); }
+    [[nodiscard]] DeprecatedString to_deprecated_string() const;
 
 private:
     OrderedHashMap<DeprecatedString, JsonValue> m_members;

--- a/AK/JsonPath.cpp
+++ b/AK/JsonPath.cpp
@@ -19,7 +19,7 @@ JsonValue JsonPath::resolve(JsonValue const& top_root) const
     for (auto const& element : *this) {
         switch (element.kind()) {
         case JsonPathElement::Kind::Key:
-            root = JsonValue { root.as_object().get_deprecated(element.key()) };
+            root = JsonValue { root.as_object().get(element.key()).value() };
             break;
         case JsonPathElement::Kind::Index:
             root = JsonValue { root.as_array().at(element.index()) };

--- a/AK/JsonPath.cpp
+++ b/AK/JsonPath.cpp
@@ -19,7 +19,7 @@ JsonValue JsonPath::resolve(JsonValue const& top_root) const
     for (auto const& element : *this) {
         switch (element.kind()) {
         case JsonPathElement::Kind::Key:
-            root = JsonValue { root.as_object().get(element.key()) };
+            root = JsonValue { root.as_object().get_deprecated(element.key()) };
             break;
         case JsonPathElement::Kind::Index:
             root = JsonValue { root.as_array().at(element.index()) };

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -103,7 +103,7 @@ bool JsonValue::equals(JsonValue const& other) const
     if (is_object() && other.is_object() && as_object().size() == other.as_object().size()) {
         bool result = true;
         as_object().for_each_member([&](auto& key, auto& value) {
-            result &= value.equals(other.as_object().get(key));
+            result &= value.equals(other.as_object().get_deprecated(key));
         });
         return result;
     }

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -103,7 +103,11 @@ bool JsonValue::equals(JsonValue const& other) const
     if (is_object() && other.is_object() && as_object().size() == other.as_object().size()) {
         bool result = true;
         as_object().for_each_member([&](auto& key, auto& value) {
-            result &= value.equals(other.as_object().get_deprecated(key));
+            auto other_value = other.as_object().get(key);
+            if (other_value.has_value())
+                result &= value.equals(*other_value);
+            else
+                result = false;
         });
         return result;
     }

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -261,6 +261,42 @@ public:
         return default_value;
     }
 
+    template<Integral T>
+    bool is_integer() const
+    {
+        switch (m_type) {
+        case Type::Int32:
+            return is_within_range<T>(m_value.as_i32);
+        case Type::UnsignedInt32:
+            return is_within_range<T>(m_value.as_u32);
+        case Type::Int64:
+            return is_within_range<T>(m_value.as_i64);
+        case Type::UnsignedInt64:
+            return is_within_range<T>(m_value.as_u64);
+        default:
+            return false;
+        }
+    }
+
+    template<Integral T>
+    T as_integer() const
+    {
+        VERIFY(is_integer<T>());
+
+        switch (m_type) {
+        case Type::Int32:
+            return static_cast<T>(m_value.as_i32);
+        case Type::UnsignedInt32:
+            return static_cast<T>(m_value.as_u32);
+        case Type::Int64:
+            return static_cast<T>(m_value.as_i64);
+        case Type::UnsignedInt64:
+            return static_cast<T>(m_value.as_u64);
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
     bool equals(JsonValue const& other) const;
 
 private:

--- a/Ladybird/InspectorWidget.cpp
+++ b/Ladybird/InspectorWidget.cpp
@@ -102,10 +102,10 @@ void InspectorWidget::set_selection(GUI::ModelIndex index)
 
     Selection selection {};
     if (json->has_u32("pseudo-element"sv)) {
-        selection.dom_node_id = json->get("parent-id"sv).to_i32();
-        selection.pseudo_element = static_cast<Web::CSS::Selector::PseudoElement>(json->get("pseudo-element"sv).to_u32());
+        selection.dom_node_id = json->get_deprecated("parent-id"sv).to_i32();
+        selection.pseudo_element = static_cast<Web::CSS::Selector::PseudoElement>(json->get_deprecated("pseudo-element"sv).to_u32());
     } else {
-        selection.dom_node_id = json->get("id"sv).to_i32();
+        selection.dom_node_id = json->get_deprecated("id"sv).to_i32();
     }
 
     if (selection == m_selection)

--- a/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
@@ -169,36 +169,36 @@ Variants read_variants_settings(JsonObject const& variants_obj)
 
     if (variants_obj.has("argument_counts"sv)) {
         variants.argument_counts.clear_with_capacity();
-        variants_obj.get("argument_counts"sv).as_array().for_each([&](auto const& argument_count_value) {
+        variants_obj.get_deprecated("argument_counts"sv).as_array().for_each([&](auto const& argument_count_value) {
             variants.argument_counts.append(argument_count_value.to_u32());
         });
     }
     if (variants_obj.has("argument_defaults"sv)) {
         variants.argument_defaults.clear_with_capacity();
-        variants_obj.get("argument_defaults"sv).as_array().for_each([&](auto const& argument_default_value) {
+        variants_obj.get_deprecated("argument_defaults"sv).as_array().for_each([&](auto const& argument_default_value) {
             variants.argument_defaults.append(argument_default_value.as_string());
         });
     }
     if (variants_obj.has("convert_range"sv)) {
-        variants.convert_range = variants_obj.get("convert_range"sv).to_bool();
+        variants.convert_range = variants_obj.get_deprecated("convert_range"sv).to_bool();
     }
     if (variants_obj.has("api_suffixes"sv)) {
         variants.api_suffixes.clear_with_capacity();
-        variants_obj.get("api_suffixes"sv).as_array().for_each([&](auto const& suffix_value) {
+        variants_obj.get_deprecated("api_suffixes"sv).as_array().for_each([&](auto const& suffix_value) {
             variants.api_suffixes.append(suffix_value.as_string());
         });
     }
     if (variants_obj.has("pointer_argument"sv)) {
-        variants.pointer_argument = variants_obj.get("pointer_argument"sv).as_string();
+        variants.pointer_argument = variants_obj.get_deprecated("pointer_argument"sv).as_string();
     }
     if (variants_obj.has("types"sv)) {
         variants.types.clear_with_capacity();
-        variants_obj.get("types"sv).as_object().for_each_member([&](auto const& key, auto const& type_value) {
+        variants_obj.get_deprecated("types"sv).as_object().for_each_member([&](auto const& key, auto const& type_value) {
             auto const& type = type_value.as_object();
             variants.types.append(VariantType {
                 .encoded_type = key,
-                .implementation = type.has("implementation"sv) ? type.get("implementation"sv).as_string() : Optional<DeprecatedString> {},
-                .unimplemented = type.get("unimplemented"sv).to_bool(false),
+                .implementation = type.has("implementation"sv) ? type.get_deprecated("implementation"sv).as_string() : Optional<DeprecatedString> {},
+                .unimplemented = type.get_deprecated("unimplemented"sv).to_bool(false),
             });
         });
     }
@@ -280,16 +280,16 @@ Vector<FunctionDefinition> create_function_definitions(DeprecatedString function
     // Parse base argument definitions first; these may later be modified by variants
     Vector<ArgumentDefinition> argument_definitions;
     JsonArray const& arguments = function_definition.has("arguments"sv)
-        ? function_definition.get("arguments"sv).as_array()
+        ? function_definition.get_deprecated("arguments"sv).as_array()
         : JsonArray {};
     arguments.for_each([&argument_definitions](auto const& argument_value) {
         VERIFY(argument_value.is_object());
         auto const& argument = argument_value.as_object();
 
-        auto type = argument.has("type"sv) ? argument.get("type"sv).as_string() : Optional<DeprecatedString> {};
-        auto argument_names = get_name_list(argument.get("name"sv));
-        auto expression = argument.get("expression"sv).as_string_or("@argument_name@");
-        auto cast_to = argument.has("cast_to"sv) ? argument.get("cast_to"sv).as_string() : Optional<DeprecatedString> {};
+        auto type = argument.has("type"sv) ? argument.get_deprecated("type"sv).as_string() : Optional<DeprecatedString> {};
+        auto argument_names = get_name_list(argument.get_deprecated("name"sv));
+        auto expression = argument.get_deprecated("expression"sv).as_string_or("@argument_name@");
+        auto cast_to = argument.has("cast_to"sv) ? argument.get_deprecated("cast_to"sv).as_string() : Optional<DeprecatedString> {};
 
         // Add an empty dummy name when all we have is an expression
         if (argument_names.is_empty() && !expression.is_empty())
@@ -306,9 +306,9 @@ Vector<FunctionDefinition> create_function_definitions(DeprecatedString function
     // Create functions for each name and/or variant
     Vector<FunctionDefinition> functions;
 
-    auto return_type = function_definition.get("return_type"sv).as_string_or("void"sv);
-    auto function_implementation = function_definition.get("implementation"sv).as_string_or(function_name.to_snakecase());
-    auto function_unimplemented = function_definition.get("unimplemented"sv).to_bool(false);
+    auto return_type = function_definition.get_deprecated("return_type"sv).as_string_or("void"sv);
+    auto function_implementation = function_definition.get_deprecated("implementation"sv).as_string_or(function_name.to_snakecase());
+    auto function_unimplemented = function_definition.get_deprecated("unimplemented"sv).to_bool(false);
 
     if (!function_definition.has("variants"sv)) {
         functions.append({
@@ -323,7 +323,7 @@ Vector<FunctionDefinition> create_function_definitions(DeprecatedString function
     }
 
     // Read variants settings for this function
-    auto variants_obj = function_definition.get("variants"sv).as_object();
+    auto variants_obj = function_definition.get_deprecated("variants"sv).as_object();
     auto variants = read_variants_settings(variants_obj);
 
     for (auto argument_count : variants.argument_counts) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
@@ -572,8 +572,8 @@ static ErrorOr<void> parse_hour_cycles(DeprecatedString core_path, CLDR& cldr)
     time_data_path = time_data_path.append("timeData.json"sv);
 
     auto time_data = TRY(read_json_file(time_data_path.string()));
-    auto const& supplemental_object = time_data.as_object().get("supplemental"sv);
-    auto const& time_data_object = supplemental_object.as_object().get("timeData"sv);
+    auto const& supplemental_object = time_data.as_object().get_deprecated("supplemental"sv);
+    auto const& time_data_object = supplemental_object.as_object().get_deprecated("timeData"sv);
 
     auto parse_hour_cycle = [](StringView hour_cycle) -> Optional<Locale::HourCycle> {
         if (hour_cycle == "h"sv)
@@ -588,7 +588,7 @@ static ErrorOr<void> parse_hour_cycles(DeprecatedString core_path, CLDR& cldr)
     };
 
     time_data_object.as_object().for_each_member([&](auto const& key, JsonValue const& value) {
-        auto allowed_hour_cycles_string = value.as_object().get("_allowed"sv).as_string();
+        auto allowed_hour_cycles_string = value.as_object().get_deprecated("_allowed"sv).as_string();
         auto allowed_hour_cycles = allowed_hour_cycles_string.split_view(' ');
 
         Vector<Locale::HourCycle> hour_cycles;
@@ -616,8 +616,8 @@ static ErrorOr<void> parse_week_data(DeprecatedString core_path, CLDR& cldr)
     week_data_path = week_data_path.append("weekData.json"sv);
 
     auto week_data = TRY(read_json_file(week_data_path.string()));
-    auto const& supplemental_object = week_data.as_object().get("supplemental"sv);
-    auto const& week_data_object = supplemental_object.as_object().get("weekData"sv);
+    auto const& supplemental_object = week_data.as_object().get_deprecated("supplemental"sv);
+    auto const& week_data_object = supplemental_object.as_object().get_deprecated("weekData"sv);
 
     auto parse_weekday = [](StringView day) -> Locale::Weekday {
         if (day == "sun"sv)
@@ -647,10 +647,10 @@ static ErrorOr<void> parse_week_data(DeprecatedString core_path, CLDR& cldr)
             weekday_regions.append(region);
     };
 
-    auto const& minimum_days_object = week_data_object.as_object().get("minDays"sv);
-    auto const& first_day_object = week_data_object.as_object().get("firstDay"sv);
-    auto const& weekend_start_object = week_data_object.as_object().get("weekendStart"sv);
-    auto const& weekend_end_object = week_data_object.as_object().get("weekendEnd"sv);
+    auto const& minimum_days_object = week_data_object.as_object().get_deprecated("minDays"sv);
+    auto const& first_day_object = week_data_object.as_object().get_deprecated("firstDay"sv);
+    auto const& weekend_start_object = week_data_object.as_object().get_deprecated("weekendStart"sv);
+    auto const& weekend_end_object = week_data_object.as_object().get_deprecated("weekendEnd"sv);
 
     minimum_days_object.as_object().for_each_member([&](auto const& region, auto const& value) {
         auto minimum_days = value.as_string().template to_uint<u8>();
@@ -681,14 +681,14 @@ static ErrorOr<void> parse_meta_zones(DeprecatedString core_path, CLDR& cldr)
     meta_zone_path = meta_zone_path.append("metaZones.json"sv);
 
     auto meta_zone = TRY(read_json_file(meta_zone_path.string()));
-    auto const& supplemental_object = meta_zone.as_object().get("supplemental"sv);
-    auto const& meta_zone_object = supplemental_object.as_object().get("metaZones"sv);
-    auto const& meta_zone_array = meta_zone_object.as_object().get("metazones"sv);
+    auto const& supplemental_object = meta_zone.as_object().get_deprecated("supplemental"sv);
+    auto const& meta_zone_object = supplemental_object.as_object().get_deprecated("metaZones"sv);
+    auto const& meta_zone_array = meta_zone_object.as_object().get_deprecated("metazones"sv);
 
     meta_zone_array.as_array().for_each([&](JsonValue const& value) {
-        auto const& mapping = value.as_object().get("mapZone"sv);
-        auto const& meta_zone = mapping.as_object().get("_other"sv);
-        auto const& golden_zone = mapping.as_object().get("_type"sv);
+        auto const& mapping = value.as_object().get_deprecated("mapZone"sv);
+        auto const& meta_zone = mapping.as_object().get_deprecated("_other"sv);
+        auto const& golden_zone = mapping.as_object().get_deprecated("_type"sv);
 
         if (auto time_zone = TimeZone::time_zone_from_string(golden_zone.as_string()); time_zone.has_value()) {
             auto& golden_zones = cldr.meta_zones.ensure(meta_zone.as_string());
@@ -1263,9 +1263,9 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
     };
 
     auto parse_era_symbols = [&](auto const& symbols_object) {
-        auto const& narrow_symbols = symbols_object.get("eraNarrow"sv).as_object();
-        auto const& short_symbols = symbols_object.get("eraAbbr"sv).as_object();
-        auto const& long_symbols = symbols_object.get("eraNames"sv).as_object();
+        auto const& narrow_symbols = symbols_object.get_deprecated("eraNarrow"sv).as_object();
+        auto const& short_symbols = symbols_object.get_deprecated("eraAbbr"sv).as_object();
+        auto const& long_symbols = symbols_object.get_deprecated("eraNames"sv).as_object();
         auto symbol_lists = create_symbol_lists(2);
 
         auto append_symbol = [&](auto& symbols, auto const& key, auto symbol) {
@@ -1287,9 +1287,9 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
     };
 
     auto parse_month_symbols = [&](auto const& symbols_object) {
-        auto const& narrow_symbols = symbols_object.get("narrow"sv).as_object();
-        auto const& short_symbols = symbols_object.get("abbreviated"sv).as_object();
-        auto const& long_symbols = symbols_object.get("wide"sv).as_object();
+        auto const& narrow_symbols = symbols_object.get_deprecated("narrow"sv).as_object();
+        auto const& short_symbols = symbols_object.get_deprecated("abbreviated"sv).as_object();
+        auto const& long_symbols = symbols_object.get_deprecated("wide"sv).as_object();
         auto symbol_lists = create_symbol_lists(12);
 
         auto append_symbol = [&](auto& symbols, auto const& key, auto symbol) {
@@ -1311,9 +1311,9 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
     };
 
     auto parse_weekday_symbols = [&](auto const& symbols_object) {
-        auto const& narrow_symbols = symbols_object.get("narrow"sv).as_object();
-        auto const& short_symbols = symbols_object.get("abbreviated"sv).as_object();
-        auto const& long_symbols = symbols_object.get("wide"sv).as_object();
+        auto const& narrow_symbols = symbols_object.get_deprecated("narrow"sv).as_object();
+        auto const& short_symbols = symbols_object.get_deprecated("abbreviated"sv).as_object();
+        auto const& long_symbols = symbols_object.get_deprecated("wide"sv).as_object();
         auto symbol_lists = create_symbol_lists(7);
 
         auto append_symbol = [&](auto& symbols, auto const& key, auto symbol) {
@@ -1347,9 +1347,9 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
     };
 
     auto parse_day_period_symbols = [&](auto const& symbols_object) {
-        auto const& narrow_symbols = symbols_object.get("narrow"sv).as_object();
-        auto const& short_symbols = symbols_object.get("abbreviated"sv).as_object();
-        auto const& long_symbols = symbols_object.get("wide"sv).as_object();
+        auto const& narrow_symbols = symbols_object.get_deprecated("narrow"sv).as_object();
+        auto const& short_symbols = symbols_object.get_deprecated("abbreviated"sv).as_object();
+        auto const& long_symbols = symbols_object.get_deprecated("wide"sv).as_object();
         auto symbol_lists = create_symbol_lists(11);
 
         auto append_symbol = [&](auto& symbols, auto const& key, auto symbol) {
@@ -1370,10 +1370,10 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
         store_symbol_lists(Locale::CalendarSymbol::DayPeriod, move(symbol_lists));
     };
 
-    parse_era_symbols(calendar_object.get("eras"sv).as_object());
-    parse_month_symbols(calendar_object.get("months"sv).as_object().get("format"sv).as_object());
-    parse_weekday_symbols(calendar_object.get("days"sv).as_object().get("format"sv).as_object());
-    parse_day_period_symbols(calendar_object.get("dayPeriods"sv).as_object().get("format"sv).as_object());
+    parse_era_symbols(calendar_object.get_deprecated("eras"sv).as_object());
+    parse_month_symbols(calendar_object.get_deprecated("months"sv).as_object().get_deprecated("format"sv).as_object());
+    parse_weekday_symbols(calendar_object.get_deprecated("days"sv).as_object().get_deprecated("format"sv).as_object());
+    parse_day_period_symbols(calendar_object.get_deprecated("dayPeriods"sv).as_object().get_deprecated("format"sv).as_object());
 
     calendar.symbols = cldr.unique_calendar_symbols_lists.ensure(move(symbols_list));
 }
@@ -1385,15 +1385,15 @@ static ErrorOr<void> parse_calendars(DeprecatedString locale_calendars_path, CLD
         return {};
 
     auto calendars = TRY(read_json_file(calendars_path.string()));
-    auto const& main_object = calendars.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(calendars_path.parent().basename());
-    auto const& dates_object = locale_object.as_object().get("dates"sv);
-    auto const& calendars_object = dates_object.as_object().get("calendars"sv);
+    auto const& main_object = calendars.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(calendars_path.parent().basename());
+    auto const& dates_object = locale_object.as_object().get_deprecated("dates"sv);
+    auto const& calendars_object = dates_object.as_object().get_deprecated("calendars"sv);
 
     auto parse_patterns = [&](auto const& patterns_object, auto const& skeletons_object, Vector<CalendarPattern>* patterns) {
         auto parse_pattern = [&](auto name) {
-            auto format = patterns_object.get(name);
-            auto skeleton = skeletons_object.get(name);
+            auto format = patterns_object.get_deprecated(name);
+            auto skeleton = skeletons_object.get_deprecated(name);
 
             auto format_index = parse_date_time_pattern(format.as_string(), skeleton.as_string_or(DeprecatedString::empty()), cldr).value();
 
@@ -1427,19 +1427,19 @@ static ErrorOr<void> parse_calendars(DeprecatedString locale_calendars_path, CLD
         Vector<CalendarPattern> date_formats;
         Vector<CalendarPattern> time_formats;
 
-        auto const& date_formats_object = value.as_object().get("dateFormats"sv);
-        auto const& date_skeletons_object = value.as_object().get("dateSkeletons"sv);
+        auto const& date_formats_object = value.as_object().get_deprecated("dateFormats"sv);
+        auto const& date_skeletons_object = value.as_object().get_deprecated("dateSkeletons"sv);
         calendar.date_formats = parse_patterns(date_formats_object.as_object(), date_skeletons_object.as_object(), &date_formats);
 
-        auto const& time_formats_object = value.as_object().get("timeFormats"sv);
-        auto const& time_skeletons_object = value.as_object().get("timeSkeletons"sv);
+        auto const& time_formats_object = value.as_object().get_deprecated("timeFormats"sv);
+        auto const& time_skeletons_object = value.as_object().get_deprecated("timeSkeletons"sv);
         calendar.time_formats = parse_patterns(time_formats_object.as_object(), time_skeletons_object.as_object(), &time_formats);
 
-        auto const& standard_date_time_formats_object = value.as_object().get("dateTimeFormats-atTime"sv).as_object().get("standard"sv);
+        auto const& standard_date_time_formats_object = value.as_object().get_deprecated("dateTimeFormats-atTime"sv).as_object().get_deprecated("standard"sv);
         calendar.date_time_formats = parse_patterns(standard_date_time_formats_object.as_object(), JsonObject {}, nullptr);
 
-        auto const& date_time_formats_object = value.as_object().get("dateTimeFormats"sv);
-        auto const& available_formats_object = date_time_formats_object.as_object().get("availableFormats"sv);
+        auto const& date_time_formats_object = value.as_object().get_deprecated("dateTimeFormats"sv);
+        auto const& available_formats_object = date_time_formats_object.as_object().get_deprecated("availableFormats"sv);
         available_formats_object.as_object().for_each_member([&](auto const& skeleton, JsonValue const& pattern) {
             auto pattern_index = parse_date_time_pattern(pattern.as_string(), skeleton, cldr);
             if (!pattern_index.has_value())
@@ -1455,7 +1455,7 @@ static ErrorOr<void> parse_calendars(DeprecatedString locale_calendars_path, CLD
                 available_formats.append(*pattern_index);
         });
 
-        auto const& interval_formats_object = date_time_formats_object.as_object().get("intervalFormats"sv);
+        auto const& interval_formats_object = date_time_formats_object.as_object().get_deprecated("intervalFormats"sv);
         parse_interval_patterns(calendar, interval_formats_object.as_object(), cldr);
 
         generate_default_patterns(available_formats, cldr);
@@ -1475,24 +1475,24 @@ static ErrorOr<void> parse_time_zone_names(DeprecatedString locale_time_zone_nam
     time_zone_names_path = time_zone_names_path.append("timeZoneNames.json"sv);
 
     auto time_zone_names = TRY(read_json_file(time_zone_names_path.string()));
-    auto const& main_object = time_zone_names.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(time_zone_names_path.parent().basename());
-    auto const& dates_object = locale_object.as_object().get("dates"sv);
-    auto const& time_zone_names_object = dates_object.as_object().get("timeZoneNames"sv);
-    auto const& meta_zone_object = time_zone_names_object.as_object().get("metazone"sv);
-    auto const& hour_format_string = time_zone_names_object.as_object().get("hourFormat"sv);
-    auto const& gmt_format_string = time_zone_names_object.as_object().get("gmtFormat"sv);
-    auto const& gmt_zero_format_string = time_zone_names_object.as_object().get("gmtZeroFormat"sv);
+    auto const& main_object = time_zone_names.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(time_zone_names_path.parent().basename());
+    auto const& dates_object = locale_object.as_object().get_deprecated("dates"sv);
+    auto const& time_zone_names_object = dates_object.as_object().get_deprecated("timeZoneNames"sv);
+    auto const& meta_zone_object = time_zone_names_object.as_object().get_deprecated("metazone"sv);
+    auto const& hour_format_string = time_zone_names_object.as_object().get_deprecated("hourFormat"sv);
+    auto const& gmt_format_string = time_zone_names_object.as_object().get_deprecated("gmtFormat"sv);
+    auto const& gmt_zero_format_string = time_zone_names_object.as_object().get_deprecated("gmtZeroFormat"sv);
 
     if (meta_zone_object.is_null())
         return {};
 
     auto parse_name = [&](StringView type, JsonObject const& meta_zone_object, StringView key) -> Optional<size_t> {
-        auto const& names = meta_zone_object.get(type);
+        auto const& names = meta_zone_object.get_deprecated(type);
         if (!names.is_object())
             return {};
 
-        auto const& name = names.as_object().get(key);
+        auto const& name = names.as_object().get_deprecated(key);
         if (name.is_string())
             return cldr.unique_strings.ensure(name.as_string());
 
@@ -1567,9 +1567,9 @@ static ErrorOr<void> parse_time_zone_names(DeprecatedString locale_time_zone_nam
     });
 
     // The long and short names for UTC are not under the "timeZoneNames/metazone" object, but are under "timeZoneNames/zone/Etc".
-    auto const& zone_object = time_zone_names_object.as_object().get("zone"sv);
-    auto const& etc_object = zone_object.as_object().get("Etc"sv);
-    auto const& utc_object = etc_object.as_object().get("UTC"sv);
+    auto const& zone_object = time_zone_names_object.as_object().get_deprecated("zone"sv);
+    auto const& etc_object = zone_object.as_object().get_deprecated("Etc"sv);
+    auto const& utc_object = etc_object.as_object().get_deprecated("UTC"sv);
     parse_time_zone("UTC"sv, utc_object.as_object());
 
     locale.time_zones = cldr.unique_time_zone_lists.ensure(move(time_zones));
@@ -1586,8 +1586,8 @@ static ErrorOr<void> parse_day_periods(DeprecatedString core_path, CLDR& cldr)
     day_periods_path = day_periods_path.append("dayPeriods.json"sv);
 
     auto locale_day_periods = TRY(read_json_file(day_periods_path.string()));
-    auto const& supplemental_object = locale_day_periods.as_object().get("supplemental"sv);
-    auto const& day_periods_object = supplemental_object.as_object().get("dayPeriodRuleSet"sv);
+    auto const& supplemental_object = locale_day_periods.as_object().get_deprecated("supplemental"sv);
+    auto const& day_periods_object = supplemental_object.as_object().get_deprecated("dayPeriodRuleSet"sv);
 
     auto parse_hour = [](auto const& time) {
         auto hour_end_index = time.find(':').value();
@@ -1608,8 +1608,8 @@ static ErrorOr<void> parse_day_periods(DeprecatedString core_path, CLDR& cldr)
         if (!day_period.has_value())
             return {};
 
-        auto begin = parse_hour(ranges.get("_from"sv).as_string());
-        auto end = parse_hour(ranges.get("_before"sv).as_string());
+        auto begin = parse_hour(ranges.get_deprecated("_from"sv).as_string());
+        auto end = parse_hour(ranges.get_deprecated("_before"sv).as_string());
 
         return DayPeriod { *day_period, begin, end };
     };

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
@@ -254,13 +254,13 @@ static ErrorOr<void> parse_core_aliases(DeprecatedString core_supplemental_path,
     core_aliases_path = core_aliases_path.append("aliases.json"sv);
 
     auto core_aliases = TRY(read_json_file(core_aliases_path.string()));
-    auto const& supplemental_object = core_aliases.as_object().get("supplemental"sv);
-    auto const& metadata_object = supplemental_object.as_object().get("metadata"sv);
-    auto const& alias_object = metadata_object.as_object().get("alias"sv);
+    auto const& supplemental_object = core_aliases.as_object().get_deprecated("supplemental"sv);
+    auto const& metadata_object = supplemental_object.as_object().get_deprecated("metadata"sv);
+    auto const& alias_object = metadata_object.as_object().get_deprecated("alias"sv);
 
     auto append_aliases = [&](auto& alias_object, auto& alias_map) {
         alias_object.as_object().for_each_member([&](auto const& key, JsonValue const& value) {
-            auto alias = value.as_object().get("_replacement"sv).as_string();
+            auto alias = value.as_object().get_deprecated("_replacement"sv).as_string();
 
             if (key.contains('-')) {
                 auto mapping = TRY_OR_DISCARD(parse_language_mapping(cldr, key, alias));
@@ -273,11 +273,11 @@ static ErrorOr<void> parse_core_aliases(DeprecatedString core_supplemental_path,
         });
     };
 
-    append_aliases(alias_object.as_object().get("languageAlias"sv), cldr.language_aliases);
-    append_aliases(alias_object.as_object().get("territoryAlias"sv), cldr.territory_aliases);
-    append_aliases(alias_object.as_object().get("scriptAlias"sv), cldr.script_aliases);
-    append_aliases(alias_object.as_object().get("variantAlias"sv), cldr.variant_aliases);
-    append_aliases(alias_object.as_object().get("subdivisionAlias"sv), cldr.subdivision_aliases);
+    append_aliases(alias_object.as_object().get_deprecated("languageAlias"sv), cldr.language_aliases);
+    append_aliases(alias_object.as_object().get_deprecated("territoryAlias"sv), cldr.territory_aliases);
+    append_aliases(alias_object.as_object().get_deprecated("scriptAlias"sv), cldr.script_aliases);
+    append_aliases(alias_object.as_object().get_deprecated("variantAlias"sv), cldr.variant_aliases);
+    append_aliases(alias_object.as_object().get_deprecated("subdivisionAlias"sv), cldr.subdivision_aliases);
 
     return {};
 }
@@ -288,8 +288,8 @@ static ErrorOr<void> parse_likely_subtags(DeprecatedString core_supplemental_pat
     likely_subtags_path = likely_subtags_path.append("likelySubtags.json"sv);
 
     auto likely_subtags = TRY(read_json_file(likely_subtags_path.string()));
-    auto const& supplemental_object = likely_subtags.as_object().get("supplemental"sv);
-    auto const& likely_subtags_object = supplemental_object.as_object().get("likelySubtags"sv);
+    auto const& supplemental_object = likely_subtags.as_object().get_deprecated("supplemental"sv);
+    auto const& likely_subtags_object = supplemental_object.as_object().get_deprecated("likelySubtags"sv);
 
     likely_subtags_object.as_object().for_each_member([&](auto const& key, JsonValue const& value) {
         auto mapping = TRY_OR_DISCARD(parse_language_mapping(cldr, key, value.as_string()));
@@ -307,13 +307,13 @@ static ErrorOr<void> parse_identity(DeprecatedString locale_path, CLDR& cldr, Lo
     languages_path = languages_path.append("languages.json"sv);
 
     auto languages = TRY(read_json_file(languages_path.string()));
-    auto const& main_object = languages.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(languages_path.parent().basename());
-    auto const& identity_object = locale_object.as_object().get("identity"sv);
-    auto const& language_string = identity_object.as_object().get("language"sv);
-    auto const& territory_string = identity_object.as_object().get("territory"sv);
-    auto const& script_string = identity_object.as_object().get("script"sv);
-    auto const& variant_string = identity_object.as_object().get("variant"sv);
+    auto const& main_object = languages.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(languages_path.parent().basename());
+    auto const& identity_object = locale_object.as_object().get_deprecated("identity"sv);
+    auto const& language_string = identity_object.as_object().get_deprecated("language"sv);
+    auto const& territory_string = identity_object.as_object().get_deprecated("territory"sv);
+    auto const& script_string = identity_object.as_object().get_deprecated("script"sv);
+    auto const& variant_string = identity_object.as_object().get_deprecated("variant"sv);
 
     locale.language = language_string.as_string();
 
@@ -344,12 +344,12 @@ static ErrorOr<void> parse_locale_display_patterns(DeprecatedString locale_path,
     locale_display_names_path = locale_display_names_path.append("localeDisplayNames.json"sv);
 
     auto locale_display_names = TRY(read_json_file(locale_display_names_path.string()));
-    auto const& main_object = locale_display_names.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(locale_display_names_path.parent().basename());
-    auto const& locale_display_names_object = locale_object.as_object().get("localeDisplayNames"sv);
-    auto const& locale_display_patterns_object = locale_display_names_object.as_object().get("localeDisplayPattern"sv);
-    auto const& locale_pattern = locale_display_patterns_object.as_object().get("localePattern"sv);
-    auto const& locale_separator = locale_display_patterns_object.as_object().get("localeSeparator"sv);
+    auto const& main_object = locale_display_names.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(locale_display_names_path.parent().basename());
+    auto const& locale_display_names_object = locale_object.as_object().get_deprecated("localeDisplayNames"sv);
+    auto const& locale_display_patterns_object = locale_display_names_object.as_object().get_deprecated("localeDisplayPattern"sv);
+    auto const& locale_pattern = locale_display_patterns_object.as_object().get_deprecated("localePattern"sv);
+    auto const& locale_separator = locale_display_patterns_object.as_object().get_deprecated("localeSeparator"sv);
 
     DisplayPattern patterns {};
     patterns.locale_pattern = cldr.unique_strings.ensure(locale_pattern.as_string());
@@ -365,10 +365,10 @@ static ErrorOr<void> preprocess_languages(DeprecatedString locale_path, CLDR& cl
     languages_path = languages_path.append("languages.json"sv);
 
     auto locale_languages = TRY(read_json_file(languages_path.string()));
-    auto const& main_object = locale_languages.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(languages_path.parent().basename());
-    auto const& locale_display_names_object = locale_object.as_object().get("localeDisplayNames"sv);
-    auto const& languages_object = locale_display_names_object.as_object().get("languages"sv);
+    auto const& main_object = locale_languages.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(languages_path.parent().basename());
+    auto const& locale_display_names_object = locale_object.as_object().get_deprecated("localeDisplayNames"sv);
+    auto const& languages_object = locale_display_names_object.as_object().get_deprecated("languages"sv);
 
     languages_object.as_object().for_each_member([&](auto const& key, auto const&) {
         if (!key.contains("-alt-"sv) && !cldr.languages.contains_slow(key))
@@ -383,8 +383,8 @@ static ErrorOr<void> parse_unicode_extension_keywords(DeprecatedString bcp47_pat
     constexpr auto desired_keywords = Array { "ca"sv, "co"sv, "hc"sv, "kf"sv, "kn"sv, "nu"sv };
     auto keywords = TRY(read_json_file(bcp47_path));
 
-    auto const& keyword_object = keywords.as_object().get("keyword"sv);
-    auto const& unicode_object = keyword_object.as_object().get("u"sv);
+    auto const& keyword_object = keywords.as_object().get_deprecated("keyword"sv);
+    auto const& unicode_object = keyword_object.as_object().get_deprecated("u"sv);
     if (unicode_object.is_null())
         return {};
 
@@ -392,7 +392,7 @@ static ErrorOr<void> parse_unicode_extension_keywords(DeprecatedString bcp47_pat
         if (!desired_keywords.span().contains_slow(key))
             return;
 
-        auto const& name = value.as_object().get("_alias"sv);
+        auto const& name = value.as_object().get_deprecated("_alias"sv);
         cldr.keyword_names.set(key, name.as_string());
 
         auto& keywords = cldr.keywords.ensure(key);
@@ -414,12 +414,12 @@ static ErrorOr<void> parse_unicode_extension_keywords(DeprecatedString bcp47_pat
             if (key == "nu"sv && keyword.is_one_of("finance"sv, "native"sv, "traditio"sv))
                 return;
 
-            if (auto const& preferred = properties.as_object().get("_preferred"sv); preferred.is_string()) {
+            if (auto const& preferred = properties.as_object().get_deprecated("_preferred"sv); preferred.is_string()) {
                 cldr.keyword_aliases.ensure(key).append({ preferred.as_string(), keyword });
                 return;
             }
 
-            if (auto const& alias = properties.as_object().get("_alias"sv); alias.is_string())
+            if (auto const& alias = properties.as_object().get_deprecated("_alias"sv); alias.is_string())
                 cldr.keyword_aliases.ensure(key).append({ keyword, alias.as_string() });
 
             keywords.append(keyword);
@@ -448,10 +448,10 @@ static ErrorOr<void> parse_locale_languages(DeprecatedString locale_path, CLDR& 
     languages_path = languages_path.append("languages.json"sv);
 
     auto locale_languages = TRY(read_json_file(languages_path.string()));
-    auto const& main_object = locale_languages.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(languages_path.parent().basename());
-    auto const& locale_display_names_object = locale_object.as_object().get("localeDisplayNames"sv);
-    auto const& languages_object = locale_display_names_object.as_object().get("languages"sv);
+    auto const& main_object = locale_languages.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(languages_path.parent().basename());
+    auto const& locale_display_names_object = locale_object.as_object().get_deprecated("localeDisplayNames"sv);
+    auto const& languages_object = locale_display_names_object.as_object().get_deprecated("languages"sv);
 
     LanguageList languages;
     languages.resize(cldr.languages.size());
@@ -474,10 +474,10 @@ static ErrorOr<void> parse_locale_territories(DeprecatedString locale_path, CLDR
     territories_path = territories_path.append("territories.json"sv);
 
     auto locale_territories = TRY(read_json_file(territories_path.string()));
-    auto const& main_object = locale_territories.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(territories_path.parent().basename());
-    auto const& locale_display_names_object = locale_object.as_object().get("localeDisplayNames"sv);
-    auto const& territories_object = locale_display_names_object.as_object().get("territories"sv);
+    auto const& main_object = locale_territories.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(territories_path.parent().basename());
+    auto const& locale_display_names_object = locale_object.as_object().get_deprecated("localeDisplayNames"sv);
+    auto const& territories_object = locale_display_names_object.as_object().get_deprecated("territories"sv);
 
     TerritoryList territories;
     territories.resize(cldr.territories.size());
@@ -497,10 +497,10 @@ static ErrorOr<void> parse_locale_scripts(DeprecatedString locale_path, CLDR& cl
     scripts_path = scripts_path.append("scripts.json"sv);
 
     auto locale_scripts = TRY(read_json_file(scripts_path.string()));
-    auto const& main_object = locale_scripts.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(scripts_path.parent().basename());
-    auto const& locale_display_names_object = locale_object.as_object().get("localeDisplayNames"sv);
-    auto const& scripts_object = locale_display_names_object.as_object().get("scripts"sv);
+    auto const& main_object = locale_scripts.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(scripts_path.parent().basename());
+    auto const& locale_display_names_object = locale_object.as_object().get_deprecated("localeDisplayNames"sv);
+    auto const& scripts_object = locale_display_names_object.as_object().get_deprecated("scripts"sv);
 
     ScriptList scripts;
     scripts.resize(cldr.scripts.size());
@@ -520,9 +520,9 @@ static ErrorOr<void> parse_locale_list_patterns(DeprecatedString misc_path, CLDR
     list_patterns_path = list_patterns_path.append("listPatterns.json"sv);
 
     auto locale_list_patterns = TRY(read_json_file(list_patterns_path.string()));
-    auto const& main_object = locale_list_patterns.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(list_patterns_path.parent().basename());
-    auto const& list_patterns_object = locale_object.as_object().get("listPatterns"sv);
+    auto const& main_object = locale_list_patterns.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(list_patterns_path.parent().basename());
+    auto const& list_patterns_object = locale_object.as_object().get_deprecated("listPatterns"sv);
 
     auto list_pattern_type = [](StringView key) {
         if (key.contains("type-standard"sv))
@@ -549,10 +549,10 @@ static ErrorOr<void> parse_locale_list_patterns(DeprecatedString misc_path, CLDR
         auto type = list_pattern_type(key);
         auto style = list_pattern_style(key);
 
-        auto start = cldr.unique_strings.ensure(value.as_object().get("start"sv).as_string());
-        auto middle = cldr.unique_strings.ensure(value.as_object().get("middle"sv).as_string());
-        auto end = cldr.unique_strings.ensure(value.as_object().get("end"sv).as_string());
-        auto pair = cldr.unique_strings.ensure(value.as_object().get("2"sv).as_string());
+        auto start = cldr.unique_strings.ensure(value.as_object().get_deprecated("start"sv).as_string());
+        auto middle = cldr.unique_strings.ensure(value.as_object().get_deprecated("middle"sv).as_string());
+        auto end = cldr.unique_strings.ensure(value.as_object().get_deprecated("end"sv).as_string());
+        auto pair = cldr.unique_strings.ensure(value.as_object().get_deprecated("2"sv).as_string());
 
         if (!cldr.list_pattern_types.contains_slow(type))
             cldr.list_pattern_types.append(type);
@@ -571,10 +571,10 @@ static ErrorOr<void> parse_locale_layout(DeprecatedString misc_path, CLDR& cldr,
     layout_path = layout_path.append("layout.json"sv);
 
     auto locale_layout = TRY(read_json_file(layout_path.string()));
-    auto const& main_object = locale_layout.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(layout_path.parent().basename());
-    auto const& layout_object = locale_object.as_object().get("layout"sv);
-    auto const& orientation_object = layout_object.as_object().get("orientation"sv);
+    auto const& main_object = locale_layout.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(layout_path.parent().basename());
+    auto const& layout_object = locale_object.as_object().get_deprecated("layout"sv);
+    auto const& orientation_object = layout_object.as_object().get_deprecated("orientation"sv);
 
     auto text_layout_character_order = [](StringView key) {
         if (key == "left-to-right"sv)
@@ -584,7 +584,7 @@ static ErrorOr<void> parse_locale_layout(DeprecatedString misc_path, CLDR& cldr,
         VERIFY_NOT_REACHED();
     };
 
-    auto const& character_order_string = orientation_object.as_object().get("characterOrder"sv);
+    auto const& character_order_string = orientation_object.as_object().get_deprecated("characterOrder"sv);
     auto const& character_order = character_order_string.as_string();
 
     TextLayout layout {};
@@ -603,10 +603,10 @@ static ErrorOr<void> parse_locale_currencies(DeprecatedString numbers_path, CLDR
     currencies_path = currencies_path.append("currencies.json"sv);
 
     auto locale_currencies = TRY(read_json_file(currencies_path.string()));
-    auto const& main_object = locale_currencies.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(currencies_path.parent().basename());
-    auto const& locale_numbers_object = locale_object.as_object().get("numbers"sv);
-    auto const& currencies_object = locale_numbers_object.as_object().get("currencies"sv);
+    auto const& main_object = locale_currencies.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(currencies_path.parent().basename());
+    auto const& locale_numbers_object = locale_object.as_object().get_deprecated("numbers"sv);
+    auto const& currencies_object = locale_numbers_object.as_object().get_deprecated("currencies"sv);
 
     currencies_object.as_object().for_each_member([&](auto const& key, JsonValue const&) {
         if (!cldr.currencies.contains_slow(key))
@@ -626,10 +626,10 @@ static ErrorOr<void> parse_locale_currencies(DeprecatedString numbers_path, CLDR
     numeric_currencies.resize(cldr.currencies.size());
 
     currencies_object.as_object().for_each_member([&](auto const& key, JsonValue const& value) {
-        auto const& long_name = value.as_object().get("displayName"sv);
-        auto const& short_name = value.as_object().get("symbol"sv);
-        auto const& narrow_name = value.as_object().get("symbol-alt-narrow"sv);
-        auto const& numeric_name = value.as_object().get("displayName-count-other"sv);
+        auto const& long_name = value.as_object().get_deprecated("displayName"sv);
+        auto const& short_name = value.as_object().get_deprecated("symbol"sv);
+        auto const& narrow_name = value.as_object().get_deprecated("symbol-alt-narrow"sv);
+        auto const& numeric_name = value.as_object().get_deprecated("displayName-count-other"sv);
 
         auto index = cldr.currencies.find_first_index(key).value();
         long_currencies[index] = cldr.unique_strings.ensure(long_name.as_string());
@@ -651,11 +651,11 @@ static ErrorOr<void> parse_locale_calendars(DeprecatedString locale_path, CLDR& 
     locale_display_names_path = locale_display_names_path.append("localeDisplayNames.json"sv);
 
     auto locale_display_names = TRY(read_json_file(locale_display_names_path.string()));
-    auto const& main_object = locale_display_names.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(locale_display_names_path.parent().basename());
-    auto const& locale_display_names_object = locale_object.as_object().get("localeDisplayNames"sv);
-    auto const& types_object = locale_display_names_object.as_object().get("types"sv);
-    auto const& calendar_object = types_object.as_object().get("calendar"sv);
+    auto const& main_object = locale_display_names.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(locale_display_names_path.parent().basename());
+    auto const& locale_display_names_object = locale_object.as_object().get_deprecated("localeDisplayNames"sv);
+    auto const& types_object = locale_display_names_object.as_object().get_deprecated("types"sv);
+    auto const& calendar_object = types_object.as_object().get_deprecated("calendar"sv);
 
     auto const& supported_calendars = cldr.keywords.find("ca"sv)->value;
 
@@ -682,10 +682,10 @@ static ErrorOr<void> parse_locale_date_fields(DeprecatedString dates_path, CLDR&
     date_fields_path = date_fields_path.append("dateFields.json"sv);
 
     auto locale_date_fields = TRY(read_json_file(date_fields_path.string()));
-    auto const& main_object = locale_date_fields.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(date_fields_path.parent().basename());
-    auto const& dates_object = locale_object.as_object().get("dates"sv);
-    auto const& fields_object = dates_object.as_object().get("fields"sv);
+    auto const& main_object = locale_date_fields.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(date_fields_path.parent().basename());
+    auto const& dates_object = locale_object.as_object().get_deprecated("dates"sv);
+    auto const& fields_object = dates_object.as_object().get_deprecated("fields"sv);
 
     auto is_sanctioned_field = [](StringView field) {
         // This is a copy of the units sanctioned for use within ECMA-402, with names adjusted for the names used by the CLDR.
@@ -716,9 +716,9 @@ static ErrorOr<void> parse_locale_date_fields(DeprecatedString dates_path, CLDR&
         if (!is_sanctioned_field(key))
             return;
 
-        auto const& long_name = value.as_object().get("displayName"sv);
-        auto const& short_name = fields_object.as_object().get(DeprecatedString::formatted("{}-short", key)).as_object().get("displayName"sv);
-        auto const& narrow_name = fields_object.as_object().get(DeprecatedString::formatted("{}-narrow", key)).as_object().get("displayName"sv);
+        auto const& long_name = value.as_object().get_deprecated("displayName"sv);
+        auto const& short_name = fields_object.as_object().get_deprecated(DeprecatedString::formatted("{}-short", key)).as_object().get_deprecated("displayName"sv);
+        auto const& narrow_name = fields_object.as_object().get_deprecated(DeprecatedString::formatted("{}-narrow", key)).as_object().get_deprecated("displayName"sv);
 
         auto index = cldr.date_fields.find_first_index(key).value();
         long_date_fields[index] = cldr.unique_strings.ensure(long_name.as_string());
@@ -738,11 +738,11 @@ static ErrorOr<void> parse_number_system_keywords(DeprecatedString locale_number
     numbers_path = numbers_path.append("numbers.json"sv);
 
     auto numbers = TRY(read_json_file(numbers_path.string()));
-    auto const& main_object = numbers.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(numbers_path.parent().basename());
-    auto const& locale_numbers_object = locale_object.as_object().get("numbers"sv);
-    auto const& default_numbering_system_object = locale_numbers_object.as_object().get("defaultNumberingSystem"sv);
-    auto const& other_numbering_systems_object = locale_numbers_object.as_object().get("otherNumberingSystems"sv);
+    auto const& main_object = numbers.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(numbers_path.parent().basename());
+    auto const& locale_numbers_object = locale_object.as_object().get_deprecated("numbers"sv);
+    auto const& default_numbering_system_object = locale_numbers_object.as_object().get_deprecated("defaultNumberingSystem"sv);
+    auto const& other_numbering_systems_object = locale_numbers_object.as_object().get_deprecated("otherNumberingSystems"sv);
 
     KeywordList keywords {};
 
@@ -784,10 +784,10 @@ static ErrorOr<void> parse_calendar_keywords(DeprecatedString locale_dates_path,
             continue;
 
         auto calendars = TRY(read_json_file(calendars_path.string()));
-        auto const& main_object = calendars.as_object().get("main"sv);
-        auto const& locale_object = main_object.as_object().get(calendars_path.parent().basename());
-        auto const& dates_object = locale_object.as_object().get("dates"sv);
-        auto const& calendars_object = dates_object.as_object().get("calendars"sv);
+        auto const& main_object = calendars.as_object().get_deprecated("main"sv);
+        auto const& locale_object = main_object.as_object().get_deprecated(calendars_path.parent().basename());
+        auto const& dates_object = locale_object.as_object().get_deprecated("dates"sv);
+        auto const& calendars_object = dates_object.as_object().get_deprecated("calendars"sv);
 
         calendars_object.as_object().for_each_member([&](auto calendar_name, JsonValue const&) {
             // The generic calendar is not a supported Unicode calendar key, so skip it:
@@ -842,7 +842,7 @@ static ErrorOr<void> parse_default_content_locales(DeprecatedString core_path, C
     default_content_path = default_content_path.append("defaultContent.json"sv);
 
     auto default_content = TRY(read_json_file(default_content_path.string()));
-    auto const& default_content_array = default_content.as_object().get("defaultContent"sv);
+    auto const& default_content_array = default_content.as_object().get_deprecated("defaultContent"sv);
 
     default_content_array.as_array().for_each([&](JsonValue const& value) {
         auto locale = value.as_string();

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
@@ -245,15 +245,15 @@ static ErrorOr<void> parse_number_system_digits(DeprecatedString core_supplement
     number_systems_path = number_systems_path.append("numberingSystems.json"sv);
 
     auto number_systems = TRY(read_json_file(number_systems_path.string()));
-    auto const& supplemental_object = number_systems.as_object().get("supplemental"sv);
-    auto const& number_systems_object = supplemental_object.as_object().get("numberingSystems"sv);
+    auto const& supplemental_object = number_systems.as_object().get_deprecated("supplemental"sv);
+    auto const& number_systems_object = supplemental_object.as_object().get_deprecated("numberingSystems"sv);
 
     number_systems_object.as_object().for_each_member([&](auto const& number_system, auto const& digits_object) {
-        auto type = digits_object.as_object().get("_type"sv).as_string();
+        auto type = digits_object.as_object().get_deprecated("_type"sv).as_string();
         if (type != "numeric"sv)
             return;
 
-        auto digits = digits_object.as_object().get("_digits"sv).as_string();
+        auto digits = digits_object.as_object().get_deprecated("_digits"sv).as_string();
 
         Utf8View utf8_digits { digits };
         VERIFY(utf8_digits.length() == 10);
@@ -415,10 +415,10 @@ static ErrorOr<void> parse_number_systems(DeprecatedString locale_numbers_path, 
     numbers_path = numbers_path.append("numbers.json"sv);
 
     auto numbers = TRY(read_json_file(numbers_path.string()));
-    auto const& main_object = numbers.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(numbers_path.parent().basename());
-    auto const& locale_numbers_object = locale_object.as_object().get("numbers"sv);
-    auto const& minimum_grouping_digits = locale_numbers_object.as_object().get("minimumGroupingDigits"sv);
+    auto const& main_object = numbers.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(numbers_path.parent().basename());
+    auto const& locale_numbers_object = locale_object.as_object().get_deprecated("numbers"sv);
+    auto const& minimum_grouping_digits = locale_numbers_object.as_object().get_deprecated("minimumGroupingDigits"sv);
 
     Vector<Optional<NumberSystem>> number_systems;
     number_systems.resize(cldr.number_systems.size());
@@ -523,8 +523,8 @@ static ErrorOr<void> parse_number_systems(DeprecatedString locale_numbers_path, 
             // The range separator does not appear in the symbols list, we have to extract it from
             // the range pattern.
             auto misc_patterns_key = DeprecatedString::formatted("{}{}", misc_patterns_prefix, system);
-            auto misc_patterns = locale_numbers_object.as_object().get(misc_patterns_key);
-            auto range_separator = misc_patterns.as_object().get("range"sv).as_string();
+            auto misc_patterns = locale_numbers_object.as_object().get_deprecated(misc_patterns_key);
+            auto range_separator = misc_patterns.as_object().get_deprecated("range"sv).as_string();
 
             auto begin_index = range_separator.find("{0}"sv).value() + "{0}"sv.length();
             auto end_index = range_separator.find("{1}"sv).value();
@@ -541,41 +541,41 @@ static ErrorOr<void> parse_number_systems(DeprecatedString locale_numbers_path, 
             auto system = key.substring(decimal_formats_prefix.length());
             auto& number_system = ensure_number_system(system);
 
-            auto format_object = value.as_object().get("standard"sv);
+            auto format_object = value.as_object().get_deprecated("standard"sv);
             parse_number_pattern(format_object.as_string().split(';'), cldr, NumberFormatType::Standard, number_system.decimal_format, &number_system);
 
-            auto const& long_format = value.as_object().get("long"sv).as_object().get("decimalFormat"sv);
+            auto const& long_format = value.as_object().get_deprecated("long"sv).as_object().get_deprecated("decimalFormat"sv);
             number_system.decimal_long_formats = parse_number_format(long_format.as_object());
 
-            auto const& short_format = value.as_object().get("short"sv).as_object().get("decimalFormat"sv);
+            auto const& short_format = value.as_object().get_deprecated("short"sv).as_object().get_deprecated("decimalFormat"sv);
             number_system.decimal_short_formats = parse_number_format(short_format.as_object());
         } else if (key.starts_with(currency_formats_prefix)) {
             auto system = key.substring(currency_formats_prefix.length());
             auto& number_system = ensure_number_system(system);
 
-            auto format_object = value.as_object().get("standard"sv);
+            auto format_object = value.as_object().get_deprecated("standard"sv);
             parse_number_pattern(format_object.as_string().split(';'), cldr, NumberFormatType::Standard, number_system.currency_format);
 
-            format_object = value.as_object().get("accounting"sv);
+            format_object = value.as_object().get_deprecated("accounting"sv);
             parse_number_pattern(format_object.as_string().split(';'), cldr, NumberFormatType::Standard, number_system.accounting_format);
 
             number_system.currency_unit_formats = parse_number_format(value.as_object());
 
             if (value.as_object().has("short"sv)) {
-                auto const& short_format = value.as_object().get("short"sv).as_object().get("standard"sv);
+                auto const& short_format = value.as_object().get_deprecated("short"sv).as_object().get_deprecated("standard"sv);
                 number_system.currency_short_formats = parse_number_format(short_format.as_object());
             }
         } else if (key.starts_with(percent_formats_prefix)) {
             auto system = key.substring(percent_formats_prefix.length());
             auto& number_system = ensure_number_system(system);
 
-            auto format_object = value.as_object().get("standard"sv);
+            auto format_object = value.as_object().get_deprecated("standard"sv);
             parse_number_pattern(format_object.as_string().split(';'), cldr, NumberFormatType::Standard, number_system.percent_format);
         } else if (key.starts_with(scientific_formats_prefix)) {
             auto system = key.substring(scientific_formats_prefix.length());
             auto& number_system = ensure_number_system(system);
 
-            auto format_object = value.as_object().get("standard"sv);
+            auto format_object = value.as_object().get_deprecated("standard"sv);
             parse_number_pattern(format_object.as_string().split(';'), cldr, NumberFormatType::Standard, number_system.scientific_format);
         }
     });
@@ -600,12 +600,12 @@ static ErrorOr<void> parse_units(DeprecatedString locale_units_path, CLDR& cldr,
     units_path = units_path.append("units.json"sv);
 
     auto locale_units = TRY(read_json_file(units_path.string()));
-    auto const& main_object = locale_units.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(units_path.parent().basename());
-    auto const& locale_units_object = locale_object.as_object().get("units"sv);
-    auto const& long_object = locale_units_object.as_object().get("long"sv);
-    auto const& short_object = locale_units_object.as_object().get("short"sv);
-    auto const& narrow_object = locale_units_object.as_object().get("narrow"sv);
+    auto const& main_object = locale_units.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(units_path.parent().basename());
+    auto const& locale_units_object = locale_object.as_object().get_deprecated("units"sv);
+    auto const& long_object = locale_units_object.as_object().get_deprecated("long"sv);
+    auto const& short_object = locale_units_object.as_object().get_deprecated("short"sv);
+    auto const& narrow_object = locale_units_object.as_object().get_deprecated("narrow"sv);
 
     HashMap<DeprecatedString, Unit> units;
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
@@ -330,7 +330,7 @@ static ErrorOr<void> parse_plural_rules(DeprecatedString core_supplemental_path,
     plurals_path = plurals_path.append(file_name);
 
     auto plurals = TRY(read_json_file(plurals_path.string()));
-    auto const& supplemental_object = plurals.as_object().get("supplemental"sv);
+    auto const& supplemental_object = plurals.as_object().get_deprecated("supplemental"sv);
 
     supplemental_object.as_object().for_each_member([&](auto const& key, auto const& plurals_object) {
         if (!key.starts_with(form_prefix))
@@ -365,8 +365,8 @@ static ErrorOr<void> parse_plural_ranges(DeprecatedString core_supplemental_path
     plural_ranges_path = plural_ranges_path.append("pluralRanges.json"sv);
 
     auto plural_ranges = TRY(read_json_file(plural_ranges_path.string()));
-    auto const& supplemental_object = plural_ranges.as_object().get("supplemental"sv);
-    auto const& plurals_object = supplemental_object.as_object().get("plurals"sv);
+    auto const& supplemental_object = plural_ranges.as_object().get_deprecated("supplemental"sv);
+    auto const& plurals_object = supplemental_object.as_object().get_deprecated("plurals"sv);
 
     plurals_object.as_object().for_each_member([&](auto const& loc, auto const& ranges_object) {
         auto locale = cldr.locales.get(loc);

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
@@ -83,10 +83,10 @@ static ErrorOr<void> parse_date_fields(DeprecatedString locale_dates_path, CLDR&
     date_fields_path = date_fields_path.append("dateFields.json"sv);
 
     auto date_fields = TRY(read_json_file(date_fields_path.string()));
-    auto const& main_object = date_fields.as_object().get("main"sv);
-    auto const& locale_object = main_object.as_object().get(date_fields_path.parent().basename());
-    auto const& dates_object = locale_object.as_object().get("dates"sv);
-    auto const& fields_object = dates_object.as_object().get("fields"sv);
+    auto const& main_object = date_fields.as_object().get_deprecated("main"sv);
+    auto const& locale_object = main_object.as_object().get_deprecated(date_fields_path.parent().basename());
+    auto const& dates_object = locale_object.as_object().get_deprecated("dates"sv);
+    auto const& fields_object = dates_object.as_object().get_deprecated("fields"sv);
 
     auto is_sanctioned_unit = [](auto unit) {
         // This is a copy of the time units sanctioned for use within ECMA-402.

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
@@ -138,7 +138,7 @@ bool media_feature_type_is_range(MediaFeatureID media_feature_id)
         auto member_generator = generator.fork();
         member_generator.set("name:titlecase", title_casify(name));
         VERIFY(feature.has("type"sv));
-        auto feature_type = feature.get("type"sv);
+        auto feature_type = feature.get_deprecated("type"sv);
         VERIFY(feature_type.is_string());
         member_generator.set("is_range", feature_type.as_string() == "range" ? "true" : "false");
         member_generator.append(R"~~~(
@@ -173,7 +173,7 @@ bool media_feature_accepts_type(MediaFeatureID media_feature_id, MediaFeatureVal
                 }
                 have_output_value_type_switch = true;
             };
-            auto& values = feature.get("values"sv);
+            auto& values = feature.get_deprecated("values"sv);
             VERIFY(values.is_array());
             auto& values_array = values.as_array();
             for (auto& type : values_array.values()) {
@@ -251,7 +251,7 @@ bool media_feature_accepts_identifier(MediaFeatureID media_feature_id, ValueID i
                 }
                 have_output_identifier_switch = true;
             };
-            auto& values = feature.get("values"sv);
+            auto& values = feature.get_deprecated("values"sv);
             VERIFY(values.is_array());
             auto& values_array = values.as_array();
             for (auto& identifier : values_array.values()) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -230,7 +230,7 @@ bool is_inherited_property(PropertyID property_id)
 
         bool inherited = false;
         if (value.as_object().has("inherited"sv)) {
-            auto& inherited_value = value.as_object().get("inherited"sv);
+            auto& inherited_value = value.as_object().get_deprecated("inherited"sv);
             VERIFY(inherited_value.is_bool());
             inherited = inherited_value.as_bool();
         }
@@ -261,7 +261,7 @@ bool property_affects_layout(PropertyID property_id)
 
         bool affects_layout = true;
         if (value.as_object().has("affects-layout"sv))
-            affects_layout = value.as_object().get("affects-layout"sv).to_bool();
+            affects_layout = value.as_object().get_deprecated("affects-layout"sv).to_bool();
 
         if (affects_layout) {
             auto member_generator = generator.fork();
@@ -289,7 +289,7 @@ bool property_affects_stacking_context(PropertyID property_id)
 
         bool affects_stacking_context = false;
         if (value.as_object().has("affects-stacking-context"sv))
-            affects_stacking_context = value.as_object().get("affects-stacking-context"sv).to_bool();
+            affects_stacking_context = value.as_object().get_deprecated("affects-stacking-context"sv).to_bool();
 
         if (affects_stacking_context) {
             auto member_generator = generator.fork();
@@ -326,7 +326,7 @@ NonnullRefPtr<StyleValue> property_initial_value(PropertyID property_id)
             dbgln("No initial value specified for property '{}'", name);
             VERIFY_NOT_REACHED();
         }
-        auto& initial_value = object.get("initial"sv);
+        auto& initial_value = object.get_deprecated("initial"sv);
         VERIFY(initial_value.is_string());
         auto initial_value_string = initial_value.as_string();
 
@@ -370,7 +370,7 @@ bool property_has_quirk(PropertyID property_id, Quirk quirk)
     properties.for_each_member([&](auto& name, auto& value) {
         VERIFY(value.is_object());
         if (value.as_object().has("quirks"sv)) {
-            auto& quirks_value = value.as_object().get("quirks"sv);
+            auto& quirks_value = value.as_object().get_deprecated("quirks"sv);
             VERIFY(quirks_value.is_array());
             auto& quirks = quirks_value.as_array();
 
@@ -461,7 +461,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
             };
 
             if (has_valid_types) {
-                auto valid_types_value = object.get("valid-types"sv);
+                auto valid_types_value = object.get_deprecated("valid-types"sv);
                 VERIFY(valid_types_value.is_array());
                 auto valid_types = valid_types_value.as_array();
                 if (!valid_types.is_empty()) {
@@ -536,7 +536,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
             }
 
             if (has_valid_identifiers) {
-                auto valid_identifiers_value = object.get("valid-identifiers"sv);
+                auto valid_identifiers_value = object.get_deprecated("valid-identifiers"sv);
                 VERIFY(valid_identifiers_value.is_array());
                 auto valid_identifiers = valid_identifiers_value.as_array();
                 if (!valid_identifiers.is_empty()) {
@@ -581,7 +581,7 @@ size_t property_maximum_value_count(PropertyID property_id)
     properties.for_each_member([&](auto& name, auto& value) {
         VERIFY(value.is_object());
         if (value.as_object().has("max-values"sv)) {
-            auto max_values = value.as_object().get("max-values"sv);
+            auto max_values = value.as_object().get_deprecated("max-values"sv);
             VERIFY(max_values.is_number() && !max_values.is_double());
             auto property_generator = generator.fork();
             property_generator.set("name:titlecase", title_casify(name));

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
@@ -166,10 +166,10 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
         return TransformFunctionMetadata {
             .parameters = {)~~~");
 
-        const JsonArray& parameters = value.as_object().get("parameters"sv).as_array();
+        const JsonArray& parameters = value.as_object().get_deprecated("parameters"sv).as_array();
         bool first = true;
         parameters.for_each([&](JsonValue const& value) {
-            GenericLexer lexer { value.as_object().get("type"sv).as_string() };
+            GenericLexer lexer { value.as_object().get_deprecated("type"sv).as_string() };
             VERIFY(lexer.consume_specific('<'));
             auto parameter_type_name = lexer.consume_until('>');
             VERIFY(lexer.consume_specific('>'));
@@ -189,7 +189,7 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
             member_generator.append(first ? " "sv : ", "sv);
             first = false;
 
-            member_generator.append(DeprecatedString::formatted("{{ TransformFunctionParameterType::{}, {}}}", parameter_type, value.as_object().get("required"sv).to_deprecated_string()));
+            member_generator.append(DeprecatedString::formatted("{{ TransformFunctionParameterType::{}, {}}}", parameter_type, value.as_object().get_deprecated("required"sv).to_deprecated_string()));
         });
 
         member_generator.append(R"~~~( }

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -40,15 +40,15 @@ TEST_CASE(load_form)
 
     EXPECT(form_json.is_object());
 
-    auto name = form_json.as_object().get("name"sv).to_deprecated_string();
+    auto name = form_json.as_object().get_deprecated("name"sv).to_deprecated_string();
 
     EXPECT_EQ(name, "Form1");
 
-    auto widgets = form_json.as_object().get("widgets"sv).as_array();
+    auto widgets = form_json.as_object().get_deprecated("widgets"sv).as_array();
 
     widgets.for_each([&](JsonValue const& widget_value) {
         auto& widget_object = widget_value.as_object();
-        auto widget_class = widget_object.get("class"sv).as_string();
+        auto widget_class = widget_object.get_deprecated("class"sv).as_string();
         widget_object.for_each_member([&]([[maybe_unused]] auto& property_name, [[maybe_unused]] const JsonValue& property_value) {
         });
     });

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -432,7 +432,7 @@ static bool verify_test(Result<void, TestError>& result, TestMetadata const& met
     }
 
     if (metadata.is_async && output.has("output"sv)) {
-        auto& output_messages = output.get("output"sv);
+        auto& output_messages = output.get_deprecated("output"sv);
         VERIFY(output_messages.is_string());
         if (output_messages.as_string().contains("AsyncTestFailure:InternalError: TODO("sv)) {
             output.set("todo_error", true);

--- a/Tests/LibMarkdown/TestCommonmark.cpp
+++ b/Tests/LibMarkdown/TestCommonmark.cpp
@@ -30,13 +30,13 @@ TEST_SETUP
         auto testcase = tests[i].as_object();
 
         auto name = DeprecatedString::formatted("{}_ex{}_{}..{}",
-            testcase.get("section"sv),
-            testcase.get("example"sv),
-            testcase.get("start_line"sv),
-            testcase.get("end_line"sv));
+            testcase.get_deprecated("section"sv),
+            testcase.get_deprecated("example"sv),
+            testcase.get_deprecated("start_line"sv),
+            testcase.get_deprecated("end_line"sv));
 
-        DeprecatedString markdown = testcase.get("markdown"sv).as_string();
-        DeprecatedString html = testcase.get("html"sv).as_string();
+        DeprecatedString markdown = testcase.get_deprecated("markdown"sv).as_string();
+        DeprecatedString html = testcase.get_deprecated("html"sv).as_string();
 
         Test::TestSuite::the().add_case(adopt_ref(*new Test::TestCase(
             name, [markdown, html]() {

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -127,10 +127,10 @@ private:
         int connected_adapters = 0;
         json.value().as_array().for_each([&adapter_info, &connected_adapters](auto& value) {
             auto& if_object = value.as_object();
-            auto ip_address = if_object.get("ipv4_address"sv).as_string_or("no IP");
-            auto ifname = if_object.get("name"sv).to_deprecated_string();
-            auto link_up = if_object.get("link_up"sv).as_bool();
-            auto link_speed = if_object.get("link_speed"sv).to_i32();
+            auto ip_address = if_object.get_deprecated("ipv4_address"sv).as_string_or("no IP");
+            auto ifname = if_object.get_deprecated("name"sv).to_deprecated_string();
+            auto link_up = if_object.get_deprecated("link_up"sv).as_bool();
+            auto link_speed = if_object.get_deprecated("link_speed"sv).to_i32();
 
             if (ifname == "loop")
                 return;

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -167,8 +167,8 @@ private:
             return false;
 
         auto const& obj = json.value().as_object();
-        total = obj.get("total_time"sv).to_u64();
-        idle = obj.get("idle_time"sv).to_u64();
+        total = obj.get_deprecated("total_time"sv).to_u64();
+        idle = obj.get_deprecated("idle_time"sv).to_u64();
         return true;
     }
 
@@ -179,11 +179,11 @@ private:
             return false;
 
         auto const& obj = json.value().as_object();
-        unsigned kmalloc_allocated = obj.get("kmalloc_allocated"sv).to_u32();
-        unsigned kmalloc_available = obj.get("kmalloc_available"sv).to_u32();
-        auto physical_allocated = obj.get("physical_allocated"sv).to_u64();
-        auto physical_committed = obj.get("physical_committed"sv).to_u64();
-        auto physical_uncommitted = obj.get("physical_uncommitted"sv).to_u64();
+        unsigned kmalloc_allocated = obj.get_deprecated("kmalloc_allocated"sv).to_u32();
+        unsigned kmalloc_available = obj.get_deprecated("kmalloc_available"sv).to_u32();
+        auto physical_allocated = obj.get_deprecated("physical_allocated"sv).to_u64();
+        auto physical_committed = obj.get_deprecated("physical_committed"sv).to_u64();
+        auto physical_uncommitted = obj.get_deprecated("physical_uncommitted"sv).to_u64();
         unsigned kmalloc_bytes_total = kmalloc_allocated + kmalloc_available;
         unsigned kmalloc_pages_total = (kmalloc_bytes_total + PAGE_SIZE - 1) / PAGE_SIZE;
         u64 total_userphysical_and_swappable_pages = kmalloc_pages_total + physical_allocated + physical_committed + physical_uncommitted;
@@ -203,13 +203,13 @@ private:
         auto const& array = json.value().as_array();
         for (auto const& adapter_value : array.values()) {
             auto const& adapter_obj = adapter_value.as_object();
-            if (!adapter_obj.has_string("ipv4_address"sv) || !adapter_obj.get("link_up"sv).as_bool())
+            if (!adapter_obj.has_string("ipv4_address"sv) || !adapter_obj.get_deprecated("link_up"sv).as_bool())
                 continue;
 
-            tx += adapter_obj.get("bytes_in"sv).to_u64();
-            rx += adapter_obj.get("bytes_out"sv).to_u64();
+            tx += adapter_obj.get_deprecated("bytes_in"sv).to_u64();
+            rx += adapter_obj.get_deprecated("bytes_out"sv).to_u64();
             // Link speed data is given in megabits, but we want all return values to be in bytes.
-            link_speed += adapter_obj.get("link_speed"sv).to_u64() * 8'000'000;
+            link_speed += adapter_obj.get_deprecated("link_speed"sv).to_u64() * 8'000'000;
         }
         link_speed /= 8;
         return tx != 0;

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -506,8 +506,8 @@ ErrorOr<void> BrowserWindow::load_search_engines(GUI::Menu& settings_menu)
                 if (!json_item.is_object())
                     continue;
                 auto search_engine = json_item.as_object();
-                auto name = search_engine.get("title"sv).to_deprecated_string();
-                auto url_format = search_engine.get("url_format"sv).to_deprecated_string();
+                auto name = search_engine.get_deprecated("title"sv).to_deprecated_string();
+                auto url_format = search_engine.get_deprecated("url_format"sv).to_deprecated_string();
 
                 auto action = GUI::Action::create_checkable(
                     name, [&, url_format](auto&) {

--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -52,10 +52,10 @@ void InspectorWidget::set_selection(GUI::ModelIndex const index)
 
     Selection selection {};
     if (json->has_u32("pseudo-element"sv)) {
-        selection.dom_node_id = json->get("parent-id"sv).to_i32();
-        selection.pseudo_element = static_cast<Web::CSS::Selector::PseudoElement>(json->get("pseudo-element"sv).to_u32());
+        selection.dom_node_id = json->get_deprecated("parent-id"sv).to_i32();
+        selection.pseudo_element = static_cast<Web::CSS::Selector::PseudoElement>(json->get_deprecated("pseudo-element"sv).to_u32());
     } else {
-        selection.dom_node_id = json->get("id"sv).to_i32();
+        selection.dom_node_id = json->get_deprecated("id"sv).to_i32();
     }
 
     if (selection == m_selection)
@@ -181,21 +181,21 @@ void InspectorWidget::update_node_box_model(StringView node_box_sizing_json)
     auto json_value = json_or_error.release_value();
     auto const& json_object = json_value.as_object();
 
-    m_node_box_sizing.margin.top = json_object.get("margin_top"sv).to_float();
-    m_node_box_sizing.margin.right = json_object.get("margin_right"sv).to_float();
-    m_node_box_sizing.margin.bottom = json_object.get("margin_bottom"sv).to_float();
-    m_node_box_sizing.margin.left = json_object.get("margin_left"sv).to_float();
-    m_node_box_sizing.padding.top = json_object.get("padding_top"sv).to_float();
-    m_node_box_sizing.padding.right = json_object.get("padding_right"sv).to_float();
-    m_node_box_sizing.padding.bottom = json_object.get("padding_bottom"sv).to_float();
-    m_node_box_sizing.padding.left = json_object.get("padding_left"sv).to_float();
-    m_node_box_sizing.border.top = json_object.get("border_top"sv).to_float();
-    m_node_box_sizing.border.right = json_object.get("border_right"sv).to_float();
-    m_node_box_sizing.border.bottom = json_object.get("border_bottom"sv).to_float();
-    m_node_box_sizing.border.left = json_object.get("border_left"sv).to_float();
+    m_node_box_sizing.margin.top = json_object.get_deprecated("margin_top"sv).to_float();
+    m_node_box_sizing.margin.right = json_object.get_deprecated("margin_right"sv).to_float();
+    m_node_box_sizing.margin.bottom = json_object.get_deprecated("margin_bottom"sv).to_float();
+    m_node_box_sizing.margin.left = json_object.get_deprecated("margin_left"sv).to_float();
+    m_node_box_sizing.padding.top = json_object.get_deprecated("padding_top"sv).to_float();
+    m_node_box_sizing.padding.right = json_object.get_deprecated("padding_right"sv).to_float();
+    m_node_box_sizing.padding.bottom = json_object.get_deprecated("padding_bottom"sv).to_float();
+    m_node_box_sizing.padding.left = json_object.get_deprecated("padding_left"sv).to_float();
+    m_node_box_sizing.border.top = json_object.get_deprecated("border_top"sv).to_float();
+    m_node_box_sizing.border.right = json_object.get_deprecated("border_right"sv).to_float();
+    m_node_box_sizing.border.bottom = json_object.get_deprecated("border_bottom"sv).to_float();
+    m_node_box_sizing.border.left = json_object.get_deprecated("border_left"sv).to_float();
 
-    m_element_size_view->set_node_content_width(json_object.get("content_width"sv).to_float());
-    m_element_size_view->set_node_content_height(json_object.get("content_height"sv).to_float());
+    m_element_size_view->set_node_content_width(json_object.get_deprecated("content_width"sv).to_float());
+    m_element_size_view->set_node_content_height(json_object.get_deprecated("content_height"sv).to_float());
     m_element_size_view->set_box_model(m_node_box_sizing);
 }
 

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -160,7 +160,7 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
     auto json = JsonValue::from_string(proc_keymap->read_all()).release_value_but_fixme_should_propagate_errors();
     auto const& keymap_object = json.as_object();
     VERIFY(keymap_object.has("keymap"sv));
-    m_initial_active_keymap = keymap_object.get("keymap"sv).to_deprecated_string();
+    m_initial_active_keymap = keymap_object.get_deprecated("keymap"sv).to_deprecated_string();
     dbgln("KeyboardSettings thinks the current keymap is: {}", m_initial_active_keymap);
 
     auto mapper_config(Core::ConfigFile::open("/etc/Keyboard.ini").release_value_but_fixme_should_propagate_errors());

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
@@ -78,7 +78,7 @@ NetworkSettingsWidget::NetworkSettingsWidget()
     size_t index = 0;
     proc_net_adapters_json.as_array().for_each([&](auto& value) {
         auto& if_object = value.as_object();
-        auto adapter_name = if_object.get("name"sv).to_deprecated_string();
+        auto adapter_name = if_object.get_deprecated("name"sv).to_deprecated_string();
         if (adapter_name == "loop")
             return;
 

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -82,37 +82,37 @@ ErrorOr<NonnullRefPtr<Image>> Image::try_create_from_bitmap(NonnullRefPtr<Gfx::B
 
 ErrorOr<NonnullRefPtr<Image>> Image::try_create_from_pixel_paint_json(JsonObject const& json)
 {
-    auto image = TRY(try_create_with_size({ json.get("width"sv).to_i32(), json.get("height"sv).to_i32() }));
+    auto image = TRY(try_create_with_size({ json.get_deprecated("width"sv).to_i32(), json.get_deprecated("height"sv).to_i32() }));
 
-    auto layers_value = json.get("layers"sv);
-    for (auto const& layer_value : layers_value.as_array().values()) {
+    auto layers_value = json.get_deprecated("layers"sv);
+    for (auto& layer_value : layers_value.as_array().values()) {
         auto const& layer_object = layer_value.as_object();
-        auto name = layer_object.get("name"sv).as_string();
+        auto name = layer_object.get_deprecated("name"sv).as_string();
 
-        auto bitmap_base64_encoded = layer_object.get("bitmap"sv).as_string();
+        auto bitmap_base64_encoded = layer_object.get_deprecated("bitmap"sv).as_string();
         auto bitmap_data = TRY(decode_base64(bitmap_base64_encoded));
         auto bitmap = TRY(try_decode_bitmap(bitmap_data));
         auto layer = TRY(Layer::try_create_with_bitmap(*image, move(bitmap), name));
 
-        if (auto const& mask_object = layer_object.get("mask"sv); !mask_object.is_null()) {
+        if (auto const& mask_object = layer_object.get_deprecated("mask"sv); !mask_object.is_null()) {
             auto mask_base64_encoded = mask_object.as_string();
             auto mask_data = TRY(decode_base64(mask_base64_encoded));
             auto mask = TRY(try_decode_bitmap(mask_data));
             TRY(layer->try_set_bitmaps(layer->content_bitmap(), mask));
         }
 
-        auto width = layer_object.get("width"sv).to_i32();
-        auto height = layer_object.get("height"sv).to_i32();
+        auto width = layer_object.get_deprecated("width"sv).to_i32();
+        auto height = layer_object.get_deprecated("height"sv).to_i32();
 
         if (width != layer->size().width() || height != layer->size().height())
             return Error::from_string_literal("Decoded layer bitmap has wrong size");
 
         image->add_layer(*layer);
 
-        layer->set_location({ layer_object.get("locationx"sv).to_i32(), layer_object.get("locationy"sv).to_i32() });
-        layer->set_opacity_percent(layer_object.get("opacity_percent"sv).to_i32());
-        layer->set_visible(layer_object.get("visible"sv).as_bool());
-        layer->set_selected(layer_object.get("selected"sv).as_bool());
+        layer->set_location({ layer_object.get_deprecated("locationx"sv).to_i32(), layer_object.get_deprecated("locationy"sv).to_i32() });
+        layer->set_opacity_percent(layer_object.get_deprecated("opacity_percent"sv).to_i32());
+        layer->set_visible(layer_object.get_deprecated("visible"sv).as_bool());
+        layer->set_selected(layer_object.get_deprecated("selected"sv).as_bool());
     }
 
     return image;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1210,11 +1210,11 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
             if (!value.is_object())
                 return;
             auto& json_object = value.as_object();
-            auto orientation_value = json_object.get("orientation"sv);
+            auto orientation_value = json_object.get_deprecated("orientation"sv);
             if (!orientation_value.is_string())
                 return;
 
-            auto offset_value = json_object.get("offset"sv);
+            auto offset_value = json_object.get_deprecated("offset"sv);
             if (!offset_value.is_number())
                 return;
 

--- a/Userland/Applications/PixelPaint/ProjectLoader.cpp
+++ b/Userland/Applications/PixelPaint/ProjectLoader.cpp
@@ -35,7 +35,7 @@ ErrorOr<void> ProjectLoader::try_load_from_file(NonnullOwnPtr<Core::Stream::File
     auto image = TRY(Image::try_create_from_pixel_paint_json(json));
 
     if (json.has("guides"sv))
-        m_json_metadata = json.get("guides"sv).as_array();
+        m_json_metadata = json.get_deprecated("guides"sv).as_array();
 
     m_image = image;
     return {};

--- a/Userland/Applications/Presenter/Presentation.cpp
+++ b/Userland/Applications/Presenter/Presentation.cpp
@@ -91,12 +91,12 @@ ErrorOr<NonnullOwnPtr<Presentation>> Presentation::load_from_file(StringView fil
     if (!global_object.has_number("version"sv))
         return Error::from_string_view("Presentation file is missing a version specification"sv);
 
-    auto const version = global_object.get("version"sv).to_int(-1);
+    auto const version = global_object.get_deprecated("version"sv).to_int(-1);
     if (version != PRESENTATION_FORMAT_VERSION)
         return Error::from_string_view("Presentation file has incompatible version"sv);
 
-    auto const& maybe_metadata = global_object.get("metadata"sv);
-    auto const& maybe_slides = global_object.get("slides"sv);
+    auto const& maybe_metadata = global_object.get_deprecated("metadata"sv);
+    auto const& maybe_slides = global_object.get_deprecated("slides"sv);
 
     if (maybe_metadata.is_null() || !maybe_metadata.is_object() || maybe_slides.is_null() || !maybe_slides.is_array())
         return Error::from_string_view("Metadata or slides in incorrect format"sv);
@@ -133,8 +133,8 @@ HashMap<DeprecatedString, DeprecatedString> Presentation::parse_metadata(JsonObj
 
 ErrorOr<Gfx::IntSize> Presentation::parse_presentation_size(JsonObject const& metadata_object)
 {
-    auto const& maybe_width = metadata_object.get("width"sv);
-    auto const& maybe_aspect = metadata_object.get("aspect"sv);
+    auto const& maybe_width = metadata_object.get_deprecated("width"sv);
+    auto const& maybe_aspect = metadata_object.get_deprecated("aspect"sv);
 
     if (maybe_width.is_null() || !maybe_width.is_number() || maybe_aspect.is_null() || !maybe_aspect.is_string())
         return Error::from_string_view("Width or aspect in incorrect format"sv);

--- a/Userland/Applications/Presenter/Slide.cpp
+++ b/Userland/Applications/Presenter/Slide.cpp
@@ -18,9 +18,9 @@ Slide::Slide(NonnullRefPtrVector<SlideObject> slide_objects, DeprecatedString ti
 ErrorOr<Slide> Slide::parse_slide(JsonObject const& slide_json)
 {
     // FIXME: Use the text with the "title" role for a title, if there is no title given.
-    auto title = slide_json.get("title"sv).as_string_or("Untitled slide");
+    auto title = slide_json.get_deprecated("title"sv).as_string_or("Untitled slide");
 
-    auto const& maybe_slide_objects = slide_json.get("objects"sv);
+    auto const& maybe_slide_objects = slide_json.get_deprecated("objects"sv);
     if (!maybe_slide_objects.is_array())
         return Error::from_string_view("Slide objects must be an array"sv);
 

--- a/Userland/Applications/Presenter/SlideObject.cpp
+++ b/Userland/Applications/Presenter/SlideObject.cpp
@@ -19,7 +19,7 @@ static DeprecatedString to_css_length(float design_value, Presentation const& pr
 
 ErrorOr<NonnullRefPtr<SlideObject>> SlideObject::parse_slide_object(JsonObject const& slide_object_json)
 {
-    auto const& maybe_type = slide_object_json.get("type"sv);
+    auto const& maybe_type = slide_object_json.get_deprecated("type"sv);
     if (!maybe_type.is_string())
         return Error::from_string_view("Slide object must have a type"sv);
 

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -46,8 +46,8 @@ static ErrorOr<void> fill_mounts(Vector<MountInfo>& output)
     TRY(json.as_array().try_for_each([&output](JsonValue const& value) -> ErrorOr<void> {
         auto& filesystem_object = value.as_object();
         MountInfo mount_info;
-        mount_info.mount_point = filesystem_object.get("mount_point"sv).to_deprecated_string();
-        mount_info.source = filesystem_object.get("source"sv).as_string_or("none"sv);
+        mount_info.mount_point = filesystem_object.get_deprecated("mount_point"sv).to_deprecated_string();
+        mount_info.source = filesystem_object.get_deprecated("source"sv).as_string_or("none"sv);
         TRY(output.try_append(mount_info));
         return {};
     }));

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -85,7 +85,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
         VERIFY(url.scheme() == "spreadsheet");
         if (url.host() == "example") {
             auto entry = LexicalPath::basename(url.path());
-            auto doc_option = m_docs.get(entry);
+            auto doc_option = m_docs.get_deprecated(entry);
             if (!doc_option.is_object()) {
                 GUI::MessageBox::show_error(this, DeprecatedString::formatted("No documentation entry found for '{}'", url.path()));
                 return;
@@ -104,7 +104,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
                 GUI::MessageBox::show_error(this, DeprecatedString::formatted("Example '{}' not found for '{}'", name, url.path()));
                 return;
             }
-            auto& value = example_data.get(name);
+            auto& value = example_data.get_deprecated(name);
 
             auto window = GUI::Window::construct(this);
             window->resize(size());
@@ -141,14 +141,14 @@ HelpWindow::HelpWindow(GUI::Window* parent)
 DeprecatedString HelpWindow::render(StringView key)
 {
     VERIFY(m_docs.has_object(key));
-    auto& doc = m_docs.get(key).as_object();
+    auto& doc = m_docs.get_deprecated(key).as_object();
 
-    auto name = doc.get("name"sv).to_deprecated_string();
-    auto argc = doc.get("argc"sv).to_u32(0);
+    auto name = doc.get_deprecated("name"sv).to_deprecated_string();
+    auto argc = doc.get_deprecated("argc"sv).to_u32(0);
     VERIFY(doc.has_array("argnames"sv));
-    auto& argnames = doc.get("argnames"sv).as_array();
+    auto& argnames = doc.get_deprecated("argnames"sv).as_array();
 
-    auto docstring = doc.get("doc"sv).to_deprecated_string();
+    auto docstring = doc.get_deprecated("doc"sv).to_deprecated_string();
 
     StringBuilder markdown_builder;
 
@@ -181,7 +181,7 @@ DeprecatedString HelpWindow::render(StringView key)
     markdown_builder.append("\n\n"sv);
 
     if (doc.has("examples"sv)) {
-        auto& examples = doc.get("examples"sv);
+        auto& examples = doc.get_deprecated("examples"sv);
         VERIFY(examples.is_object());
         markdown_builder.append("# EXAMPLES\n"sv);
         examples.as_object().for_each_member([&](auto& text, auto& description_value) {

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -112,14 +112,14 @@ void MemoryStatsWidget::refresh()
     auto json_result = JsonValue::from_string(file_contents).release_value_but_fixme_should_propagate_errors();
     auto const& json = json_result.as_object();
 
-    u32 kmalloc_allocated = json.get("kmalloc_allocated"sv).to_u32();
-    u32 kmalloc_available = json.get("kmalloc_available"sv).to_u32();
-    u64 physical_allocated = json.get("physical_allocated"sv).to_u64();
-    u64 physical_available = json.get("physical_available"sv).to_u64();
-    u64 physical_committed = json.get("physical_committed"sv).to_u64();
-    u64 physical_uncommitted = json.get("physical_uncommitted"sv).to_u64();
-    u32 kmalloc_call_count = json.get("kmalloc_call_count"sv).to_u32();
-    u32 kfree_call_count = json.get("kfree_call_count"sv).to_u32();
+    u32 kmalloc_allocated = json.get_deprecated("kmalloc_allocated"sv).to_u32();
+    u32 kmalloc_available = json.get_deprecated("kmalloc_available"sv).to_u32();
+    u64 physical_allocated = json.get_deprecated("physical_allocated"sv).to_u64();
+    u64 physical_available = json.get_deprecated("physical_available"sv).to_u64();
+    u64 physical_committed = json.get_deprecated("physical_committed"sv).to_u64();
+    u64 physical_uncommitted = json.get_deprecated("physical_uncommitted"sv).to_u64();
+    u32 kmalloc_call_count = json.get_deprecated("kmalloc_call_count"sv).to_u32();
+    u32 kfree_call_count = json.get_deprecated("kfree_call_count"sv).to_u32();
 
     u64 kmalloc_bytes_total = kmalloc_allocated + kmalloc_available;
     u64 physical_pages_total = physical_allocated + physical_available;

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -47,25 +47,25 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         Vector<GUI::JsonArrayModel::FieldSpec> net_adapters_fields;
         net_adapters_fields.empend("", Gfx::TextAlignment::CenterLeft,
             [this](JsonObject const& object) -> GUI::Variant {
-                if (!object.get("link_up"sv).as_bool())
+                if (!object.get_deprecated("link_up"sv).as_bool())
                     return *m_network_link_down_bitmap;
                 else
-                    return object.get("ipv4_address"sv).as_string_or(""sv).is_empty() ? *m_network_disconnected_bitmap : *m_network_connected_bitmap;
+                    return object.get_deprecated("ipv4_address"sv).as_string_or(""sv).is_empty() ? *m_network_disconnected_bitmap : *m_network_connected_bitmap;
             });
         net_adapters_fields.empend("name", "Name", Gfx::TextAlignment::CenterLeft);
         net_adapters_fields.empend("class_name", "Class", Gfx::TextAlignment::CenterLeft);
         net_adapters_fields.empend("mac_address", "MAC", Gfx::TextAlignment::CenterLeft);
         net_adapters_fields.empend("Link status", Gfx::TextAlignment::CenterLeft,
             [](JsonObject const& object) -> DeprecatedString {
-                if (!object.get("link_up"sv).as_bool())
+                if (!object.get_deprecated("link_up"sv).as_bool())
                     return "Down";
 
-                return DeprecatedString::formatted("{} Mb/s {}-duplex", object.get("link_speed"sv).to_i32(),
-                    object.get("link_full_duplex"sv).as_bool() ? "full"sv : "half"sv);
+                return DeprecatedString::formatted("{} Mb/s {}-duplex", object.get_deprecated("link_speed"sv).to_i32(),
+                    object.get_deprecated("link_full_duplex"sv).as_bool() ? "full"sv : "half"sv);
             });
         net_adapters_fields.empend("IPv4", Gfx::TextAlignment::CenterLeft,
             [](JsonObject const& object) -> DeprecatedString {
-                return object.get("ipv4_address"sv).as_string_or(""sv);
+                return object.get_deprecated("ipv4_address"sv).as_string_or(""sv);
             });
         net_adapters_fields.empend("packets_in", "Pkt In", Gfx::TextAlignment::CenterRight);
         net_adapters_fields.empend("packets_out", "Pkt Out", Gfx::TextAlignment::CenterRight);

--- a/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
@@ -27,19 +27,19 @@ ProcessFileDescriptorMapWidget::ProcessFileDescriptorMapWidget()
     pid_fds_fields.empend("offset", "Offset", Gfx::TextAlignment::CenterRight);
     pid_fds_fields.empend("absolute_path", "Path", Gfx::TextAlignment::CenterLeft);
     pid_fds_fields.empend("Access", Gfx::TextAlignment::CenterLeft, [](auto& object) {
-        return object.get("seekable"sv).to_bool() ? "Seekable" : "Sequential";
+        return object.get_deprecated("seekable"sv).to_bool() ? "Seekable" : "Sequential";
     });
     pid_fds_fields.empend("Blocking", Gfx::TextAlignment::CenterLeft, [](auto& object) {
-        return object.get("blocking"sv).to_bool() ? "Blocking" : "Nonblocking";
+        return object.get_deprecated("blocking"sv).to_bool() ? "Blocking" : "Nonblocking";
     });
     pid_fds_fields.empend("On exec", Gfx::TextAlignment::CenterLeft, [](auto& object) {
-        return object.get("cloexec"sv).to_bool() ? "Close" : "Keep";
+        return object.get_deprecated("cloexec"sv).to_bool() ? "Close" : "Keep";
     });
     pid_fds_fields.empend("Can read", Gfx::TextAlignment::CenterLeft, [](auto& object) {
-        return object.get("can_read"sv).to_bool() ? "Yes" : "No";
+        return object.get_deprecated("can_read"sv).to_bool() ? "Yes" : "No";
     });
     pid_fds_fields.empend("Can write", Gfx::TextAlignment::CenterLeft, [](auto& object) {
-        return object.get("can_write"sv).to_bool() ? "Yes" : "No";
+        return object.get_deprecated("can_write"sv).to_bool() ? "Yes" : "No";
     });
 
     m_model = GUI::JsonArrayModel::create({}, move(pid_fds_fields));

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
@@ -57,35 +57,35 @@ ProcessMemoryMapWidget::ProcessMemoryMapWidget()
     Vector<GUI::JsonArrayModel::FieldSpec> pid_vm_fields;
     pid_vm_fields.empend(
         "Address", Gfx::TextAlignment::CenterLeft,
-        [](auto& object) { return DeprecatedString::formatted("{:p}", object.get("address"sv).to_u64()); },
-        [](auto& object) { return object.get("address"sv).to_u64(); });
+        [](auto& object) { return DeprecatedString::formatted("{:p}", object.get_deprecated("address"sv).to_u64()); },
+        [](auto& object) { return object.get_deprecated("address"sv).to_u64(); });
     pid_vm_fields.empend("size", "Size", Gfx::TextAlignment::CenterRight);
     pid_vm_fields.empend("amount_resident", "Resident", Gfx::TextAlignment::CenterRight);
     pid_vm_fields.empend("amount_dirty", "Dirty", Gfx::TextAlignment::CenterRight);
     pid_vm_fields.empend("Access", Gfx::TextAlignment::CenterLeft, [](auto& object) {
         StringBuilder builder;
-        if (object.get("readable"sv).to_bool())
+        if (object.get_deprecated("readable"sv).to_bool())
             builder.append('R');
-        if (object.get("writable"sv).to_bool())
+        if (object.get_deprecated("writable"sv).to_bool())
             builder.append('W');
-        if (object.get("executable"sv).to_bool())
+        if (object.get_deprecated("executable"sv).to_bool())
             builder.append('X');
-        if (object.get("shared"sv).to_bool())
+        if (object.get_deprecated("shared"sv).to_bool())
             builder.append('S');
-        if (object.get("syscall"sv).to_bool())
+        if (object.get_deprecated("syscall"sv).to_bool())
             builder.append('C');
-        if (object.get("stack"sv).to_bool())
+        if (object.get_deprecated("stack"sv).to_bool())
             builder.append('T');
         return builder.to_deprecated_string();
     });
     pid_vm_fields.empend("VMObject type", Gfx::TextAlignment::CenterLeft, [](auto& object) {
-        auto type = object.get("vmobject"sv).to_deprecated_string();
+        auto type = object.get_deprecated("vmobject"sv).to_deprecated_string();
         if (type.ends_with("VMObject"sv))
             type = type.substring(0, type.length() - 8);
         return type;
     });
     pid_vm_fields.empend("Purgeable", Gfx::TextAlignment::CenterLeft, [](auto& object) {
-        if (object.get("volatile"sv).to_bool())
+        if (object.get_deprecated("volatile"sv).to_bool())
             return "Volatile";
         return "Non-volatile";
     });
@@ -98,7 +98,7 @@ ProcessMemoryMapWidget::ProcessMemoryMapWidget()
             return GUI::Variant(0);
         },
         [](JsonObject const& object) {
-            auto pagemap = object.get("pagemap"sv).as_string_or({});
+            auto pagemap = object.get_deprecated("pagemap"sv).as_string_or({});
             return pagemap;
         });
     pid_vm_fields.empend("cow_pages", "# CoW", Gfx::TextAlignment::CenterRight);

--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -39,7 +39,7 @@ ProcessModel::ProcessModel()
         auto cpuinfo_array = json.value().as_array();
         cpuinfo_array.for_each([&](auto& value) {
             auto& cpu_object = value.as_object();
-            auto cpu_id = cpu_object.get("processor"sv).as_u32();
+            auto cpu_id = cpu_object.get_deprecated("processor"sv).as_u32();
             m_cpus.append(make<CpuInfo>(cpu_id));
         });
     }

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -130,18 +130,18 @@ public:
                 [](const JsonObject& object) {
                     StringBuilder size_builder;
                     size_builder.append(' ');
-                    size_builder.append(human_readable_size(object.get("total_block_count"sv).to_u64() * object.get("block_size"sv).to_u64()));
+                    size_builder.append(human_readable_size(object.get_deprecated("total_block_count"sv).to_u64() * object.get_deprecated("block_size"sv).to_u64()));
                     size_builder.append(' ');
                     return size_builder.to_deprecated_string();
                 },
                 [](const JsonObject& object) {
-                    return object.get("total_block_count"sv).to_u64() * object.get("block_size"sv).to_u64();
+                    return object.get_deprecated("total_block_count"sv).to_u64() * object.get_deprecated("block_size"sv).to_u64();
                 },
                 [](const JsonObject& object) {
-                    auto total_blocks = object.get("total_block_count"sv).to_u64();
+                    auto total_blocks = object.get_deprecated("total_block_count"sv).to_u64();
                     if (total_blocks == 0)
                         return 0;
-                    auto free_blocks = object.get("free_block_count"sv).to_u64();
+                    auto free_blocks = object.get_deprecated("free_block_count"sv).to_u64();
                     auto used_blocks = total_blocks - free_blocks;
                     int percentage = (static_cast<double>(used_blocks) / static_cast<double>(total_blocks) * 100.0);
                     return percentage;
@@ -149,31 +149,31 @@ public:
             df_fields.empend(
                 "Used", Gfx::TextAlignment::CenterRight,
                 [](const JsonObject& object) {
-            auto total_blocks = object.get("total_block_count"sv).to_u64();
-            auto free_blocks = object.get("free_block_count"sv).to_u64();
+            auto total_blocks = object.get_deprecated("total_block_count"sv).to_u64();
+            auto free_blocks = object.get_deprecated("free_block_count"sv).to_u64();
             auto used_blocks = total_blocks - free_blocks;
-            return human_readable_size(used_blocks * object.get("block_size"sv).to_u64()); },
+            return human_readable_size(used_blocks * object.get_deprecated("block_size"sv).to_u64()); },
                 [](const JsonObject& object) {
-                    auto total_blocks = object.get("total_block_count"sv).to_u64();
-                    auto free_blocks = object.get("free_block_count"sv).to_u64();
+                    auto total_blocks = object.get_deprecated("total_block_count"sv).to_u64();
+                    auto free_blocks = object.get_deprecated("free_block_count"sv).to_u64();
                     auto used_blocks = total_blocks - free_blocks;
-                    return used_blocks * object.get("block_size"sv).to_u64();
+                    return used_blocks * object.get_deprecated("block_size"sv).to_u64();
                 });
             df_fields.empend(
                 "Available", Gfx::TextAlignment::CenterRight,
                 [](const JsonObject& object) {
-                    return human_readable_size(object.get("free_block_count"sv).to_u64() * object.get("block_size"sv).to_u64());
+                    return human_readable_size(object.get_deprecated("free_block_count"sv).to_u64() * object.get_deprecated("block_size"sv).to_u64());
                 },
                 [](const JsonObject& object) {
-                    return object.get("free_block_count"sv).to_u64() * object.get("block_size"sv).to_u64();
+                    return object.get_deprecated("free_block_count"sv).to_u64() * object.get_deprecated("block_size"sv).to_u64();
                 });
             df_fields.empend("Access", Gfx::TextAlignment::CenterLeft, [](const JsonObject& object) {
-                bool readonly = object.get("readonly"sv).to_bool();
-                int mount_flags = object.get("mount_flags"sv).to_int();
+                bool readonly = object.get_deprecated("readonly"sv).to_bool();
+                int mount_flags = object.get_deprecated("mount_flags"sv).to_int();
                 return readonly || (mount_flags & MS_RDONLY) ? "Read-only" : "Read/Write";
             });
             df_fields.empend("Mount flags", Gfx::TextAlignment::CenterLeft, [](const JsonObject& object) {
-                int mount_flags = object.get("mount_flags"sv).to_int();
+                int mount_flags = object.get_deprecated("mount_flags"sv).to_int();
                 StringBuilder builder;
                 bool first = true;
                 auto check = [&](int flag, StringView name) {

--- a/Userland/DevTools/HackStudio/ProjectConfig.cpp
+++ b/Userland/DevTools/HackStudio/ProjectConfig.cpp
@@ -35,7 +35,7 @@ NonnullOwnPtr<ProjectConfig> ProjectConfig::create_empty()
 
 Optional<DeprecatedString> ProjectConfig::read_key(DeprecatedString key_name) const
 {
-    auto const& value = m_config.get(key_name);
+    auto const& value = m_config.get_deprecated(key_name);
     if (!value.is_string())
         return {};
 

--- a/Userland/DevTools/Inspector/RemoteProcess.cpp
+++ b/Userland/DevTools/Inspector/RemoteProcess.cpp
@@ -28,10 +28,10 @@ RemoteProcess::RemoteProcess(pid_t pid)
 
 void RemoteProcess::handle_identify_response(JsonObject const& response)
 {
-    int pid = response.get("pid"sv).to_int();
+    int pid = response.get_deprecated("pid"sv).to_int();
     VERIFY(pid == m_pid);
 
-    m_process_name = response.get("process_name"sv).as_string_or({});
+    m_process_name = response.get_deprecated("process_name"sv).as_string_or({});
 
     if (on_update)
         on_update();
@@ -40,7 +40,7 @@ void RemoteProcess::handle_identify_response(JsonObject const& response)
 void RemoteProcess::handle_get_all_objects_response(JsonObject const& response)
 {
     // FIXME: It would be good if we didn't have to make a local copy of the array value here!
-    auto objects = response.get("objects"sv);
+    auto objects = response.get_deprecated("objects"sv);
     auto& object_array = objects.as_array();
 
     NonnullOwnPtrVector<RemoteObject> remote_objects;
@@ -50,10 +50,10 @@ void RemoteProcess::handle_get_all_objects_response(JsonObject const& response)
         VERIFY(value.is_object());
         auto& object = value.as_object();
         auto remote_object = make<RemoteObject>();
-        remote_object->address = object.get("address"sv).to_number<FlatPtr>();
-        remote_object->parent_address = object.get("parent"sv).to_number<FlatPtr>();
-        remote_object->name = object.get("name"sv).to_deprecated_string();
-        remote_object->class_name = object.get("class_name"sv).to_deprecated_string();
+        remote_object->address = object.get_deprecated("address"sv).to_number<FlatPtr>();
+        remote_object->parent_address = object.get_deprecated("parent"sv).to_number<FlatPtr>();
+        remote_object->name = object.get_deprecated("name"sv).to_deprecated_string();
+        remote_object->class_name = object.get_deprecated("class_name"sv).to_deprecated_string();
         remote_object->json = object;
         objects_by_address.set(remote_object->address, remote_object);
         remote_objects.append(move(remote_object));

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -281,34 +281,34 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
 
         event.serial = next_serial;
         next_serial.increment();
-        event.timestamp = perf_event.get("timestamp"sv).to_number<u64>();
-        event.lost_samples = perf_event.get("lost_samples"sv).to_number<u32>();
-        event.pid = perf_event.get("pid"sv).to_i32();
-        event.tid = perf_event.get("tid"sv).to_i32();
+        event.timestamp = perf_event.get_deprecated("timestamp"sv).to_number<u64>();
+        event.lost_samples = perf_event.get_deprecated("lost_samples"sv).to_number<u32>();
+        event.pid = perf_event.get_deprecated("pid"sv).to_i32();
+        event.tid = perf_event.get_deprecated("tid"sv).to_i32();
 
-        auto type_string = perf_event.get("type"sv).to_deprecated_string();
+        auto type_string = perf_event.get_deprecated("type"sv).to_deprecated_string();
 
         if (type_string == "sample"sv) {
             event.data = Event::SampleData {};
         } else if (type_string == "malloc"sv) {
             event.data = Event::MallocData {
-                .ptr = perf_event.get("ptr"sv).to_number<FlatPtr>(),
-                .size = perf_event.get("size"sv).to_number<size_t>(),
+                .ptr = perf_event.get_deprecated("ptr"sv).to_number<FlatPtr>(),
+                .size = perf_event.get_deprecated("size"sv).to_number<size_t>(),
             };
         } else if (type_string == "free"sv) {
             event.data = Event::FreeData {
-                .ptr = perf_event.get("ptr"sv).to_number<FlatPtr>(),
+                .ptr = perf_event.get_deprecated("ptr"sv).to_number<FlatPtr>(),
             };
         } else if (type_string == "signpost"sv) {
-            auto string_id = perf_event.get("arg1"sv).to_number<FlatPtr>();
+            auto string_id = perf_event.get_deprecated("arg1"sv).to_number<FlatPtr>();
             event.data = Event::SignpostData {
                 .string = profile_strings.get(string_id).value_or(DeprecatedString::formatted("Signpost #{}", string_id)),
-                .arg = perf_event.get("arg2"sv).to_number<FlatPtr>(),
+                .arg = perf_event.get_deprecated("arg2"sv).to_number<FlatPtr>(),
             };
         } else if (type_string == "mmap"sv) {
-            auto ptr = perf_event.get("ptr"sv).to_number<FlatPtr>();
-            auto size = perf_event.get("size"sv).to_number<size_t>();
-            auto name = perf_event.get("name"sv).to_deprecated_string();
+            auto ptr = perf_event.get_deprecated("ptr"sv).to_number<FlatPtr>();
+            auto size = perf_event.get_deprecated("size"sv).to_number<size_t>();
+            auto name = perf_event.get_deprecated("name"sv).to_deprecated_string();
 
             event.data = Event::MmapData {
                 .ptr = ptr,
@@ -322,13 +322,13 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
             continue;
         } else if (type_string == "munmap"sv) {
             event.data = Event::MunmapData {
-                .ptr = perf_event.get("ptr"sv).to_number<FlatPtr>(),
-                .size = perf_event.get("size"sv).to_number<size_t>(),
+                .ptr = perf_event.get_deprecated("ptr"sv).to_number<FlatPtr>(),
+                .size = perf_event.get_deprecated("size"sv).to_number<size_t>(),
             };
             continue;
         } else if (type_string == "process_create"sv) {
-            auto parent_pid = perf_event.get("parent_pid"sv).to_number<pid_t>();
-            auto executable = perf_event.get("executable"sv).to_deprecated_string();
+            auto parent_pid = perf_event.get_deprecated("parent_pid"sv).to_number<pid_t>();
+            auto executable = perf_event.get_deprecated("executable"sv).to_deprecated_string();
             event.data = Event::ProcessCreateData {
                 .parent_pid = parent_pid,
                 .executable = executable,
@@ -346,7 +346,7 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
             all_processes.append(move(sampled_process));
             continue;
         } else if (type_string == "process_exec"sv) {
-            auto executable = perf_event.get("executable"sv).to_deprecated_string();
+            auto executable = perf_event.get_deprecated("executable"sv).to_deprecated_string();
             event.data = Event::ProcessExecData {
                 .executable = executable,
             };
@@ -374,7 +374,7 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
             current_processes.remove(event.pid);
             continue;
         } else if (type_string == "thread_create"sv) {
-            auto parent_tid = perf_event.get("parent_tid"sv).to_number<pid_t>();
+            auto parent_tid = perf_event.get_deprecated("parent_tid"sv).to_number<pid_t>();
             event.data = Event::ThreadCreateData {
                 .parent_tid = parent_tid,
             };
@@ -388,13 +388,13 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
                 it->value->handle_thread_exit(event.tid, event.serial);
             continue;
         } else if (type_string == "read"sv) {
-            auto const string_index = perf_event.get("filename_index"sv).to_number<FlatPtr>();
+            auto const string_index = perf_event.get_deprecated("filename_index"sv).to_number<FlatPtr>();
             event.data = Event::ReadData {
-                .fd = perf_event.get("fd"sv).to_number<int>(),
-                .size = perf_event.get("size"sv).to_number<size_t>(),
+                .fd = perf_event.get_deprecated("fd"sv).to_number<int>(),
+                .size = perf_event.get_deprecated("size"sv).to_number<size_t>(),
                 .path = profile_strings.get(string_index).value(),
-                .start_timestamp = perf_event.get("start_timestamp"sv).to_number<size_t>(),
-                .success = perf_event.get("success"sv).to_bool()
+                .start_timestamp = perf_event.get_deprecated("start_timestamp"sv).to_number<size_t>(),
+                .success = perf_event.get_deprecated("success"sv).to_bool()
             };
         } else {
             dbgln("Unknown event type '{}'", type_string);

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -227,7 +227,7 @@ public:
 
     void handle_request(JsonObject const& request)
     {
-        auto type = request.get("type"sv).as_string_or({});
+        auto type = request.get_deprecated("type"sv).as_string_or({});
 
         if (type.is_null()) {
             dbgln("RPC client sent request without type field");
@@ -265,7 +265,7 @@ public:
         }
 
         if (type == "SetInspectedObject") {
-            auto address = request.get("address"sv).to_number<FlatPtr>();
+            auto address = request.get_deprecated("address"sv).to_number<FlatPtr>();
             for (auto& object : Object::all_objects()) {
                 if ((FlatPtr)&object == address) {
                     if (auto inspected_object = m_inspected_object.strong_ref())
@@ -279,10 +279,10 @@ public:
         }
 
         if (type == "SetProperty") {
-            auto address = request.get("address"sv).to_number<FlatPtr>();
+            auto address = request.get_deprecated("address"sv).to_number<FlatPtr>();
             for (auto& object : Object::all_objects()) {
                 if ((FlatPtr)&object == address) {
-                    bool success = object.set_property(request.get("name"sv).to_deprecated_string(), request.get("value"sv));
+                    bool success = object.set_property(request.get_deprecated("name"sv).to_deprecated_string(), request.get_deprecated("value"sv));
                     JsonObject response;
                     response.set("type", "SetProperty");
                     response.set("success", success);

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -332,36 +332,36 @@ requires IsBaseOf<Object, T>
         },                                                     \
         {});
 
-#define REGISTER_RECT_PROPERTY(property_name, getter, setter)                \
-    register_property(                                                       \
-        property_name,                                                       \
-        [this] {                                                             \
-            auto rect = this->getter();                                      \
-            JsonObject rect_object;                                          \
-            rect_object.set("x"sv, rect.x());                                \
-            rect_object.set("y"sv, rect.y());                                \
-            rect_object.set("width"sv, rect.width());                        \
-            rect_object.set("height"sv, rect.height());                      \
-            return rect_object;                                              \
-        },                                                                   \
-        [this](auto& value) {                                                \
-            Gfx::IntRect rect;                                               \
-            if (value.is_object()) {                                         \
-                rect.set_x(value.as_object().get("x"sv).to_i32());           \
-                rect.set_y(value.as_object().get("y"sv).to_i32());           \
-                rect.set_width(value.as_object().get("width"sv).to_i32());   \
-                rect.set_height(value.as_object().get("height"sv).to_i32()); \
-            } else if (value.is_array() && value.as_array().size() == 4) {   \
-                rect.set_x(value.as_array()[0].to_i32());                    \
-                rect.set_y(value.as_array()[1].to_i32());                    \
-                rect.set_width(value.as_array()[2].to_i32());                \
-                rect.set_height(value.as_array()[3].to_i32());               \
-            } else {                                                         \
-                return false;                                                \
-            }                                                                \
-            setter(rect);                                                    \
-                                                                             \
-            return true;                                                     \
+#define REGISTER_RECT_PROPERTY(property_name, getter, setter)                           \
+    register_property(                                                                  \
+        property_name,                                                                  \
+        [this] {                                                                        \
+            auto rect = this->getter();                                                 \
+            JsonObject rect_object;                                                     \
+            rect_object.set("x"sv, rect.x());                                           \
+            rect_object.set("y"sv, rect.y());                                           \
+            rect_object.set("width"sv, rect.width());                                   \
+            rect_object.set("height"sv, rect.height());                                 \
+            return rect_object;                                                         \
+        },                                                                              \
+        [this](auto& value) {                                                           \
+            Gfx::IntRect rect;                                                          \
+            if (value.is_object()) {                                                    \
+                rect.set_x(value.as_object().get_deprecated("x"sv).to_i32());           \
+                rect.set_y(value.as_object().get_deprecated("y"sv).to_i32());           \
+                rect.set_width(value.as_object().get_deprecated("width"sv).to_i32());   \
+                rect.set_height(value.as_object().get_deprecated("height"sv).to_i32()); \
+            } else if (value.is_array() && value.as_array().size() == 4) {              \
+                rect.set_x(value.as_array()[0].to_i32());                               \
+                rect.set_y(value.as_array()[1].to_i32());                               \
+                rect.set_width(value.as_array()[2].to_i32());                           \
+                rect.set_height(value.as_array()[3].to_i32());                          \
+            } else {                                                                    \
+                return false;                                                           \
+            }                                                                           \
+            setter(rect);                                                               \
+                                                                                        \
+            return true;                                                                \
         });
 
 #define REGISTER_SIZE_PROPERTY(property_name, getter, setter) \

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -23,56 +23,56 @@ ErrorOr<AllProcessesStatistics> ProcessStatisticsReader::get_all(Core::Stream::S
 
     auto file_contents = TRY(proc_all_file.read_until_eof());
     auto json_obj = TRY(JsonValue::from_string(file_contents)).as_object();
-    json_obj.get("processes"sv).as_array().for_each([&](auto& value) {
+    json_obj.get_deprecated("processes"sv).as_array().for_each([&](auto& value) {
         const JsonObject& process_object = value.as_object();
         Core::ProcessStatistics process;
 
         // kernel data first
-        process.pid = process_object.get("pid"sv).to_u32();
-        process.pgid = process_object.get("pgid"sv).to_u32();
-        process.pgp = process_object.get("pgp"sv).to_u32();
-        process.sid = process_object.get("sid"sv).to_u32();
-        process.uid = process_object.get("uid"sv).to_u32();
-        process.gid = process_object.get("gid"sv).to_u32();
-        process.ppid = process_object.get("ppid"sv).to_u32();
-        process.nfds = process_object.get("nfds"sv).to_u32();
-        process.kernel = process_object.get("kernel"sv).to_bool();
-        process.name = process_object.get("name"sv).to_deprecated_string();
-        process.executable = process_object.get("executable"sv).to_deprecated_string();
-        process.tty = process_object.get("tty"sv).to_deprecated_string();
-        process.pledge = process_object.get("pledge"sv).to_deprecated_string();
-        process.veil = process_object.get("veil"sv).to_deprecated_string();
-        process.amount_virtual = process_object.get("amount_virtual"sv).to_u32();
-        process.amount_resident = process_object.get("amount_resident"sv).to_u32();
-        process.amount_shared = process_object.get("amount_shared"sv).to_u32();
-        process.amount_dirty_private = process_object.get("amount_dirty_private"sv).to_u32();
-        process.amount_clean_inode = process_object.get("amount_clean_inode"sv).to_u32();
-        process.amount_purgeable_volatile = process_object.get("amount_purgeable_volatile"sv).to_u32();
-        process.amount_purgeable_nonvolatile = process_object.get("amount_purgeable_nonvolatile"sv).to_u32();
+        process.pid = process_object.get_deprecated("pid"sv).to_u32();
+        process.pgid = process_object.get_deprecated("pgid"sv).to_u32();
+        process.pgp = process_object.get_deprecated("pgp"sv).to_u32();
+        process.sid = process_object.get_deprecated("sid"sv).to_u32();
+        process.uid = process_object.get_deprecated("uid"sv).to_u32();
+        process.gid = process_object.get_deprecated("gid"sv).to_u32();
+        process.ppid = process_object.get_deprecated("ppid"sv).to_u32();
+        process.nfds = process_object.get_deprecated("nfds"sv).to_u32();
+        process.kernel = process_object.get_deprecated("kernel"sv).to_bool();
+        process.name = process_object.get_deprecated("name"sv).to_deprecated_string();
+        process.executable = process_object.get_deprecated("executable"sv).to_deprecated_string();
+        process.tty = process_object.get_deprecated("tty"sv).to_deprecated_string();
+        process.pledge = process_object.get_deprecated("pledge"sv).to_deprecated_string();
+        process.veil = process_object.get_deprecated("veil"sv).to_deprecated_string();
+        process.amount_virtual = process_object.get_deprecated("amount_virtual"sv).to_u32();
+        process.amount_resident = process_object.get_deprecated("amount_resident"sv).to_u32();
+        process.amount_shared = process_object.get_deprecated("amount_shared"sv).to_u32();
+        process.amount_dirty_private = process_object.get_deprecated("amount_dirty_private"sv).to_u32();
+        process.amount_clean_inode = process_object.get_deprecated("amount_clean_inode"sv).to_u32();
+        process.amount_purgeable_volatile = process_object.get_deprecated("amount_purgeable_volatile"sv).to_u32();
+        process.amount_purgeable_nonvolatile = process_object.get_deprecated("amount_purgeable_nonvolatile"sv).to_u32();
 
         auto& thread_array = process_object.get_ptr("threads"sv)->as_array();
         process.threads.ensure_capacity(thread_array.size());
         thread_array.for_each([&](auto& value) {
             auto& thread_object = value.as_object();
             Core::ThreadStatistics thread;
-            thread.tid = thread_object.get("tid"sv).to_u32();
-            thread.times_scheduled = thread_object.get("times_scheduled"sv).to_u32();
-            thread.name = thread_object.get("name"sv).to_deprecated_string();
-            thread.state = thread_object.get("state"sv).to_deprecated_string();
-            thread.time_user = thread_object.get("time_user"sv).to_u64();
-            thread.time_kernel = thread_object.get("time_kernel"sv).to_u64();
-            thread.cpu = thread_object.get("cpu"sv).to_u32();
-            thread.priority = thread_object.get("priority"sv).to_u32();
-            thread.syscall_count = thread_object.get("syscall_count"sv).to_u32();
-            thread.inode_faults = thread_object.get("inode_faults"sv).to_u32();
-            thread.zero_faults = thread_object.get("zero_faults"sv).to_u32();
-            thread.cow_faults = thread_object.get("cow_faults"sv).to_u32();
-            thread.unix_socket_read_bytes = thread_object.get("unix_socket_read_bytes"sv).to_u32();
-            thread.unix_socket_write_bytes = thread_object.get("unix_socket_write_bytes"sv).to_u32();
-            thread.ipv4_socket_read_bytes = thread_object.get("ipv4_socket_read_bytes"sv).to_u32();
-            thread.ipv4_socket_write_bytes = thread_object.get("ipv4_socket_write_bytes"sv).to_u32();
-            thread.file_read_bytes = thread_object.get("file_read_bytes"sv).to_u32();
-            thread.file_write_bytes = thread_object.get("file_write_bytes"sv).to_u32();
+            thread.tid = thread_object.get_deprecated("tid"sv).to_u32();
+            thread.times_scheduled = thread_object.get_deprecated("times_scheduled"sv).to_u32();
+            thread.name = thread_object.get_deprecated("name"sv).to_deprecated_string();
+            thread.state = thread_object.get_deprecated("state"sv).to_deprecated_string();
+            thread.time_user = thread_object.get_deprecated("time_user"sv).to_u64();
+            thread.time_kernel = thread_object.get_deprecated("time_kernel"sv).to_u64();
+            thread.cpu = thread_object.get_deprecated("cpu"sv).to_u32();
+            thread.priority = thread_object.get_deprecated("priority"sv).to_u32();
+            thread.syscall_count = thread_object.get_deprecated("syscall_count"sv).to_u32();
+            thread.inode_faults = thread_object.get_deprecated("inode_faults"sv).to_u32();
+            thread.zero_faults = thread_object.get_deprecated("zero_faults"sv).to_u32();
+            thread.cow_faults = thread_object.get_deprecated("cow_faults"sv).to_u32();
+            thread.unix_socket_read_bytes = thread_object.get_deprecated("unix_socket_read_bytes"sv).to_u32();
+            thread.unix_socket_write_bytes = thread_object.get_deprecated("unix_socket_write_bytes"sv).to_u32();
+            thread.ipv4_socket_read_bytes = thread_object.get_deprecated("ipv4_socket_read_bytes"sv).to_u32();
+            thread.ipv4_socket_write_bytes = thread_object.get_deprecated("ipv4_socket_write_bytes"sv).to_u32();
+            thread.file_read_bytes = thread_object.get_deprecated("file_read_bytes"sv).to_u32();
+            thread.file_write_bytes = thread_object.get_deprecated("file_write_bytes"sv).to_u32();
             process.threads.append(move(thread));
         });
 
@@ -83,8 +83,8 @@ ErrorOr<AllProcessesStatistics> ProcessStatisticsReader::get_all(Core::Stream::S
         all_processes_statistics.processes.append(move(process));
     });
 
-    all_processes_statistics.total_time_scheduled = json_obj.get("total_time"sv).to_u64();
-    all_processes_statistics.total_time_scheduled_kernel = json_obj.get("total_time_kernel"sv).to_u64();
+    all_processes_statistics.total_time_scheduled = json_obj.get_deprecated("total_time"sv).to_u64();
+    all_processes_statistics.total_time_scheduled_kernel = json_obj.get_deprecated("total_time_kernel"sv).to_u64();
     return all_processes_statistics;
 }
 

--- a/Userland/Libraries/LibCoredump/Reader.cpp
+++ b/Userland/Libraries/LibCoredump/Reader.cpp
@@ -196,14 +196,14 @@ Optional<MemoryRegionInfo> Reader::region_containing(FlatPtr address) const
 int Reader::process_pid() const
 {
     auto process_info = this->process_info();
-    auto pid = process_info.get("pid"sv);
+    auto pid = process_info.get_deprecated("pid"sv);
     return pid.to_number<int>();
 }
 
 u8 Reader::process_termination_signal() const
 {
     auto process_info = this->process_info();
-    auto termination_signal = process_info.get("termination_signal"sv);
+    auto termination_signal = process_info.get_deprecated("termination_signal"sv);
     auto signal_number = termination_signal.to_number<u8>();
     if (signal_number <= SIGINVAL || signal_number >= NSIG)
         return SIGINVAL;
@@ -213,14 +213,14 @@ u8 Reader::process_termination_signal() const
 DeprecatedString Reader::process_executable_path() const
 {
     auto process_info = this->process_info();
-    auto executable_path = process_info.get("executable_path"sv);
+    auto executable_path = process_info.get_deprecated("executable_path"sv);
     return executable_path.as_string_or({});
 }
 
 Vector<DeprecatedString> Reader::process_arguments() const
 {
     auto process_info = this->process_info();
-    auto arguments = process_info.get("arguments"sv);
+    auto arguments = process_info.get_deprecated("arguments"sv);
     if (!arguments.is_array())
         return {};
     Vector<DeprecatedString> vector;
@@ -234,7 +234,7 @@ Vector<DeprecatedString> Reader::process_arguments() const
 Vector<DeprecatedString> Reader::process_environment() const
 {
     auto process_info = this->process_info();
-    auto environment = process_info.get("environment"sv);
+    auto environment = process_info.get_deprecated("environment"sv);
     if (!environment.is_array())
         return {};
     Vector<DeprecatedString> vector;

--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -449,7 +449,7 @@ void DebugSession::update_loaded_libs()
 
     vm_entries.for_each([&](auto& entry) {
         // TODO: check that region is executable
-        auto vm_name = entry.as_object().get("name"sv).as_string();
+        auto vm_name = entry.as_object().get_deprecated("name"sv).as_string();
 
         auto object_path = get_path_to_object(vm_name);
         if (!object_path.has_value())
@@ -459,7 +459,7 @@ void DebugSession::update_loaded_libs()
         if (Core::File::looks_like_shared_library(lib_name))
             lib_name = LexicalPath::basename(object_path.value());
 
-        FlatPtr base_address = entry.as_object().get("address"sv).to_addr();
+        FlatPtr base_address = entry.as_object().get_deprecated("address"sv).to_addr();
         if (auto it = m_loaded_libraries.find(lib_name); it != m_loaded_libraries.end()) {
             // We expect the VM regions to be sorted by address.
             VERIFY(base_address >= it->value->base_address);

--- a/Userland/Libraries/LibDesktop/Launcher.cpp
+++ b/Userland/Libraries/LibDesktop/Launcher.cpp
@@ -18,8 +18,8 @@ auto Launcher::Details::from_details_str(DeprecatedString const& details_str) ->
     auto details = adopt_ref(*new Details);
     auto json = JsonValue::from_string(details_str).release_value_but_fixme_should_propagate_errors();
     auto const& obj = json.as_object();
-    details->executable = obj.get("executable"sv).to_deprecated_string();
-    details->name = obj.get("name"sv).to_deprecated_string();
+    details->executable = obj.get_deprecated("executable"sv).to_deprecated_string();
+    details->name = obj.get_deprecated("name"sv).to_deprecated_string();
     if (auto type_value = obj.get_ptr("type"sv)) {
         auto type_str = type_value->to_deprecated_string();
         if (type_str == "app")

--- a/Userland/Libraries/LibGUI/CommonLocationsProvider.cpp
+++ b/Userland/Libraries/LibGUI/CommonLocationsProvider.cpp
@@ -56,8 +56,8 @@ ErrorOr<void> CommonLocationsProvider::load_from_json(StringView json_path)
         if (!entry_value.is_object())
             continue;
         auto entry = entry_value.as_object();
-        auto name = entry.get("name"sv).to_deprecated_string();
-        auto path = entry.get("path"sv).to_deprecated_string();
+        auto name = entry.get_deprecated("name"sv).to_deprecated_string();
+        auto path = entry.get_deprecated("path"sv).to_deprecated_string();
         TRY(s_common_locations.try_append({ name, path }));
     }
 

--- a/Userland/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.cpp
@@ -119,12 +119,12 @@ Variant JsonArrayModel::data(ModelIndex const& index, ModelRole role) const
 
     if (role == ModelRole::Display) {
         auto& json_field_name = field_spec.json_field_name;
-        auto data = object.get(json_field_name);
+        auto data = object.get_deprecated(json_field_name);
         if (field_spec.massage_for_display)
             return field_spec.massage_for_display(object);
         if (data.is_number())
             return data;
-        return object.get(json_field_name).to_deprecated_string();
+        return object.get_deprecated(json_field_name).to_deprecated_string();
     }
 
     if (role == ModelRole::Sort) {

--- a/Userland/Libraries/LibGUI/UIDimensions.h
+++ b/Userland/Libraries/LibGUI/UIDimensions.h
@@ -306,9 +306,9 @@ inline auto clamp<GUI::UIDimension>(GUI::UIDimension const& input, GUI::UIDimens
             if (!value.is_object())                                            \
                 return false;                                                  \
             auto result_width = GUI::UIDimension::construct_from_json_value(   \
-                value.as_object().get("width"sv));                             \
+                value.as_object().get_deprecated("width"sv));                  \
             auto result_height = GUI::UIDimension::construct_from_json_value(  \
-                value.as_object().get("height"sv));                            \
+                value.as_object().get_deprecated("height"sv));                 \
             if (result_width.has_value() && result_height.has_value()) {       \
                 GUI::UISize size(result_width.value(), result_height.value()); \
                 setter(size);                                                  \

--- a/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
+++ b/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
@@ -63,7 +63,7 @@ Vector<u32> CharacterMapFile::read_map(JsonObject const& json, DeprecatedString 
     Vector<u32> buffer;
     buffer.resize(CHAR_MAP_SIZE);
 
-    auto map_arr = json.get(name).as_array();
+    auto map_arr = json.get_deprecated(name).as_array();
     for (size_t i = 0; i < map_arr.size(); i++) {
         auto key_value = map_arr.at(i).as_string();
         if (key_value.length() == 0) {

--- a/Userland/Libraries/LibSymbolication/Symbolication.cpp
+++ b/Userland/Libraries/LibSymbolication/Symbolication.cpp
@@ -181,9 +181,9 @@ Vector<Symbol> symbolicate_thread(pid_t pid, pid_t tid, IncludeSourcePosition in
 
         for (auto& region_value : json.value().as_array().values()) {
             auto& region = region_value.as_object();
-            auto name = region.get("name"sv).to_deprecated_string();
-            auto address = region.get("address"sv).to_addr();
-            auto size = region.get("size"sv).to_addr();
+            auto name = region.get_deprecated("name"sv).to_deprecated_string();
+            auto address = region.get_deprecated("address"sv).to_addr();
+            auto size = region.get_deprecated("size"sv).to_addr();
 
             DeprecatedString path;
             if (name == "/usr/lib/Loader.so") {

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -422,7 +422,7 @@ inline JSFileResult TestRunner::run_file_test(DeprecatedString const& test_path)
             VERIFY(test_value.is_object());
             VERIFY(test_value.as_object().has("result"sv));
 
-            auto result = test_value.as_object().get("result"sv);
+            auto result = test_value.as_object().get_deprecated("result"sv);
             VERIFY(result.is_string());
             auto result_string = result.as_string();
             if (result_string == "pass") {
@@ -433,7 +433,7 @@ inline JSFileResult TestRunner::run_file_test(DeprecatedString const& test_path)
                 m_counts.tests_failed++;
                 suite.most_severe_test_result = Test::Result::Fail;
                 VERIFY(test_value.as_object().has("details"sv));
-                auto details = test_value.as_object().get("details"sv);
+                auto details = test_value.as_object().get_deprecated("details"sv);
                 VERIFY(result.is_string());
                 test.details = details.as_string();
             } else {
@@ -443,7 +443,7 @@ inline JSFileResult TestRunner::run_file_test(DeprecatedString const& test_path)
                 m_counts.tests_skipped++;
             }
 
-            test.duration_us = test_value.as_object().get("duration"sv).to_u64(0);
+            test.duration_us = test_value.as_object().get_deprecated("duration"sv).to_u64(0);
 
             suite.tests.append(test);
         });

--- a/Userland/Libraries/LibWeb/WebDriver/Capabilities.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Capabilities.cpp
@@ -267,20 +267,20 @@ static JsonValue match_capabilities(JsonObject const& capabilities)
         // -> "browserName"
         if (name == "browserName"sv) {
             // If value is not a string equal to the "browserName" entry in matched capabilities, return success with data null.
-            if (value.as_string() != matched_capabilities.get(name).as_string())
+            if (value.as_string() != matched_capabilities.get_deprecated(name).as_string())
                 return AK::Error::from_string_view("browserName"sv);
         }
         // -> "browserVersion"
         else if (name == "browserVersion"sv) {
             // Compare value to the "browserVersion" entry in matched capabilities using an implementation-defined comparison algorithm. The comparison is to accept a value that places constraints on the version using the "<", "<=", ">", and ">=" operators.
             // If the two values do not match, return success with data null.
-            if (!matches_browser_version(value.as_string(), matched_capabilities.get(name).as_string()))
+            if (!matches_browser_version(value.as_string(), matched_capabilities.get_deprecated(name).as_string()))
                 return AK::Error::from_string_view("browserVersion"sv);
         }
         // -> "platformName"
         else if (name == "platformName"sv) {
             // If value is not a string equal to the "platformName" entry in matched capabilities, return success with data null.
-            if (!matches_platform_name(value.as_string(), matched_capabilities.get(name).as_string()))
+            if (!matches_platform_name(value.as_string(), matched_capabilities.get_deprecated(name).as_string()))
                 return AK::Error::from_string_view("platformName"sv);
         }
         // -> "acceptInsecureCerts"

--- a/Userland/Libraries/LibWeb/WebDriver/TimeoutsConfiguration.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/TimeoutsConfiguration.cpp
@@ -48,7 +48,7 @@ ErrorOr<TimeoutsConfiguration, Error> json_deserialize_as_a_timeouts_configurati
     // 3. If value has a property with the key "script":
     if (value.as_object().has("script"sv)) {
         // 1. Let script duration be the value of property "script".
-        auto const& script_duration = value.as_object().get("script"sv);
+        auto const& script_duration = value.as_object().get_deprecated("script"sv);
 
         // 2. If script duration is a number and less than 0 or greater than maximum safe integer, or it is not null, return error with error code invalid argument.
         if (script_duration.is_number() && (script_duration.to_i64() < 0 || script_duration.to_i64() > max_safe_integer))
@@ -63,7 +63,7 @@ ErrorOr<TimeoutsConfiguration, Error> json_deserialize_as_a_timeouts_configurati
     // 4. If value has a property with the key "pageLoad":
     if (value.as_object().has("pageLoad"sv)) {
         // 1. Let page load duration be the value of property "pageLoad".
-        auto const& page_load_duration = value.as_object().get("pageLoad"sv);
+        auto const& page_load_duration = value.as_object().get_deprecated("pageLoad"sv);
 
         // 2. If page load duration is less than 0 or greater than maximum safe integer, return error with error code invalid argument.
         if (!page_load_duration.is_number() || page_load_duration.to_i64() < 0 || page_load_duration.to_i64() > max_safe_integer)
@@ -76,7 +76,7 @@ ErrorOr<TimeoutsConfiguration, Error> json_deserialize_as_a_timeouts_configurati
     // 5. If value has a property with the key "implicit":
     if (value.as_object().has("implicit"sv)) {
         // 1. Let implicit duration be the value of property "implicit".
-        auto const& implicit_duration = value.as_object().get("implicit"sv);
+        auto const& implicit_duration = value.as_object().get_deprecated("implicit"sv);
 
         // 2. If implicit duration is less than 0 or greater than maximum safe integer, return error with error code invalid argument.
         if (!implicit_duration.is_number() || implicit_duration.to_i64() < 0 || implicit_duration.to_i64() > max_safe_integer)

--- a/Userland/Libraries/LibWebView/AccessibilityTreeModel.cpp
+++ b/Userland/Libraries/LibWebView/AccessibilityTreeModel.cpp
@@ -83,13 +83,13 @@ int AccessibilityTreeModel::column_count(const GUI::ModelIndex&) const
 GUI::Variant AccessibilityTreeModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
 {
     auto const& node = *static_cast<JsonObject const*>(index.internal_data());
-    auto type = node.get("type"sv).as_string_or("unknown"sv);
+    auto type = node.get_deprecated("type"sv).as_string_or("unknown"sv);
 
     if (role == GUI::ModelRole::Display) {
         if (type == "text")
-            return node.get("text"sv).as_string();
+            return node.get_deprecated("text"sv).as_string();
 
-        auto node_role = node.get("role"sv).as_string();
+        auto node_role = node.get_deprecated("role"sv).as_string();
         if (type != "element")
             return node_role;
 

--- a/Userland/Libraries/LibWebView/DOMTreeModel.cpp
+++ b/Userland/Libraries/LibWebView/DOMTreeModel.cpp
@@ -119,8 +119,8 @@ static DeprecatedString with_whitespace_collapsed(StringView string)
 GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
 {
     auto const& node = *static_cast<JsonObject const*>(index.internal_data());
-    auto node_name = node.get("name"sv).as_string();
-    auto type = node.get("type"sv).as_string_or("unknown"sv);
+    auto node_name = node.get_deprecated("name"sv).as_string();
+    auto type = node.get_deprecated("type"sv).as_string_or("unknown"sv);
 
     // FIXME: This FIXME can go away when we fix the one below.
 #ifdef AK_OS_SERENITY
@@ -131,7 +131,7 @@ GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
             return m_tree_view->palette().syntax_comment();
         if (type == "pseudo-element"sv)
             return m_tree_view->palette().syntax_type();
-        if (!node.get("visible"sv).to_bool(true))
+        if (!node.get_deprecated("visible"sv).to_bool(true))
             return m_tree_view->palette().syntax_comment();
         return {};
     }
@@ -151,9 +151,9 @@ GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
 
     if (role == GUI::ModelRole::Display) {
         if (type == "text")
-            return with_whitespace_collapsed(node.get("text"sv).as_string());
+            return with_whitespace_collapsed(node.get_deprecated("text"sv).as_string());
         if (type == "comment"sv)
-            return DeprecatedString::formatted("<!--{}-->", node.get("data"sv).as_string());
+            return DeprecatedString::formatted("<!--{}-->", node.get_deprecated("data"sv).as_string());
         if (type != "element")
             return node_name;
 
@@ -161,7 +161,7 @@ GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
         builder.append('<');
         builder.append(node_name.to_lowercase());
         if (node.has("attributes"sv)) {
-            auto attributes = node.get("attributes"sv).as_object();
+            auto attributes = node.get_deprecated("attributes"sv).as_object();
             attributes.for_each_member([&builder](auto& name, JsonValue const& value) {
                 builder.append(' ');
                 builder.append(name);
@@ -180,7 +180,7 @@ GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
 void DOMTreeModel::map_dom_nodes_to_parent(JsonObject const* parent, JsonObject const* node)
 {
     m_dom_node_to_parent_map.set(node, parent);
-    m_node_id_to_dom_node_map.set(node->get("id"sv).to_i32(), node);
+    m_node_id_to_dom_node_map.set(node->get_deprecated("id"sv).to_i32(), node);
 
     auto const* children = get_children(*node);
     if (!children)
@@ -204,7 +204,7 @@ GUI::ModelIndex DOMTreeModel::index_for_node(i32 node_id, Optional<Web::CSS::Sel
                 if (!child.has("pseudo-element"sv))
                     continue;
 
-                auto child_pseudo_element = child.get("pseudo-element"sv);
+                auto child_pseudo_element = child.get_deprecated("pseudo-element"sv);
                 if (!child_pseudo_element.is_i32())
                     continue;
 

--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -193,13 +193,13 @@ ErrorOr<DHCPv4Client::Interfaces> DHCPv4Client::get_discoverable_interfaces()
     json.value().as_array().for_each([&ifnames_to_immediately_discover, &ifnames_to_attempt_later](auto& value) {
         auto if_object = value.as_object();
 
-        if (if_object.get("class_name"sv).to_deprecated_string() == "LoopbackAdapter")
+        if (if_object.get_deprecated("class_name"sv).to_deprecated_string() == "LoopbackAdapter")
             return;
 
-        auto name = if_object.get("name"sv).to_deprecated_string();
-        auto mac = if_object.get("mac_address"sv).to_deprecated_string();
-        auto is_up = if_object.get("link_up"sv).to_bool();
-        auto ipv4_addr_maybe = IPv4Address::from_string(if_object.get("ipv4_address"sv).to_deprecated_string());
+        auto name = if_object.get_deprecated("name"sv).to_deprecated_string();
+        auto mac = if_object.get_deprecated("mac_address"sv).to_deprecated_string();
+        auto is_up = if_object.get_deprecated("link_up"sv).to_bool();
+        auto ipv4_addr_maybe = IPv4Address::from_string(if_object.get_deprecated("ipv4_address"sv).to_deprecated_string());
         auto ipv4_addr = ipv4_addr_maybe.has_value() ? ipv4_addr_maybe.value() : IPv4Address { 0, 0, 0, 0 };
         if (is_up) {
             dbgln_if(DHCPV4_DEBUG, "Found adapter '{}' with mac {}, and it was up!", name, mac);

--- a/Userland/Services/LookupServer/MulticastDNS.cpp
+++ b/Userland/Services/LookupServer/MulticastDNS.cpp
@@ -132,7 +132,7 @@ Vector<IPv4Address> MulticastDNS::local_addresses() const
 
     json.as_array().for_each([&addresses](auto& value) {
         auto if_object = value.as_object();
-        auto address = if_object.get("ipv4_address"sv).to_deprecated_string();
+        auto address = if_object.get_deprecated("ipv4_address"sv).to_deprecated_string();
         auto ipv4_address = IPv4Address::from_string(address);
         // Skip unconfigured interfaces.
         if (!ipv4_address.has_value())

--- a/Userland/Services/NetworkServer/main.cpp
+++ b/Userland/Services/NetworkServer/main.cpp
@@ -51,7 +51,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     Vector<DeprecatedString> interfaces_with_dhcp_enabled;
     proc_net_adapters_json.as_array().for_each([&](auto& value) {
         auto& if_object = value.as_object();
-        auto ifname = if_object.get("name"sv).to_deprecated_string();
+        auto ifname = if_object.get_deprecated("name"sv).to_deprecated_string();
 
         if (ifname == "loop"sv)
             return;

--- a/Userland/Services/WindowServer/KeymapSwitcher.cpp
+++ b/Userland/Services/WindowServer/KeymapSwitcher.cpp
@@ -97,7 +97,7 @@ DeprecatedString KeymapSwitcher::get_current_keymap() const
     auto json = JsonValue::from_string(proc_keymap->read_all()).release_value_but_fixme_should_propagate_errors();
     auto const& keymap_object = json.as_object();
     VERIFY(keymap_object.has("keymap"sv));
-    return keymap_object.get("keymap"sv).to_deprecated_string();
+    return keymap_object.get_deprecated("keymap"sv).to_deprecated_string();
 }
 
 void KeymapSwitcher::set_keymap(const AK::DeprecatedString& keymap)

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1880,32 +1880,32 @@ ErrorOr<Vector<Line::CompletionSuggestion>> Shell::complete_via_program_itself(s
             auto parsed = parsed_result.release_value();
             if (parsed.is_object()) {
                 auto& object = parsed.as_object();
-                auto kind = object.get("kind"sv).as_string_or("plain");
+                auto kind = object.get_deprecated("kind"sv).as_string_or("plain");
                 if (kind == "path") {
-                    auto base = object.get("base"sv).as_string_or("");
-                    auto part = object.get("part"sv).as_string_or("");
-                    auto executable_only = object.get("executable_only"sv).to_bool(false) ? ExecutableOnly::Yes : ExecutableOnly::No;
+                    auto base = object.get_deprecated("base"sv).as_string_or("");
+                    auto part = object.get_deprecated("part"sv).as_string_or("");
+                    auto executable_only = object.get_deprecated("executable_only"sv).to_bool(false) ? ExecutableOnly::Yes : ExecutableOnly::No;
                     suggestions.extend(complete_path(base, part, part.length(), executable_only, nullptr, nullptr));
                 } else if (kind == "program") {
-                    auto name = object.get("name"sv).as_string_or("");
+                    auto name = object.get_deprecated("name"sv).as_string_or("");
                     suggestions.extend(complete_program_name(name, name.length()));
                 } else if (kind == "proxy") {
                     if (m_completion_stack_info.size_free() < 4 * KiB) {
                         dbgln("Not enough stack space, recursion?");
                         return IterationDecision::Continue;
                     }
-                    auto argv = object.get("argv"sv).as_string_or("");
+                    auto argv = object.get_deprecated("argv"sv).as_string_or("");
                     dbgln("Proxy completion for {}", argv);
                     suggestions.extend(complete(argv));
                 } else if (kind == "plain") {
                     Line::CompletionSuggestion suggestion {
-                        object.get("completion"sv).as_string_or(""),
-                        object.get("trailing_trivia"sv).as_string_or(""),
-                        object.get("display_trivia"sv).as_string_or(""),
+                        object.get_deprecated("completion"sv).as_string_or(""),
+                        object.get_deprecated("trailing_trivia"sv).as_string_or(""),
+                        object.get_deprecated("display_trivia"sv).as_string_or(""),
                     };
-                    suggestion.static_offset = object.get("static_offset"sv).to_u64(0);
-                    suggestion.invariant_offset = object.get("invariant_offset"sv).to_u64(0);
-                    suggestion.allow_commit_without_listing = object.get("allow_commit_without_listing"sv).to_bool(true);
+                    suggestion.static_offset = object.get_deprecated("static_offset"sv).to_u64(0);
+                    suggestion.invariant_offset = object.get_deprecated("invariant_offset"sv).to_u64(0);
+                    suggestion.allow_commit_without_listing = object.get_deprecated("allow_commit_without_listing"sv).to_bool(true);
                     suggestions.append(move(suggestion));
                 } else {
                     dbgln("LibLine: Unhandled completion kind: {}", kind);

--- a/Userland/Utilities/arp.cpp
+++ b/Userland/Utilities/arp.cpp
@@ -95,13 +95,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         Vector<JsonValue> sorted_regions = json.as_array().values();
         quick_sort(sorted_regions, [](auto& a, auto& b) {
-            return a.as_object().get("ip_address"sv).to_deprecated_string() < b.as_object().get("ip_address"sv).to_deprecated_string();
+            return a.as_object().get_deprecated("ip_address"sv).to_deprecated_string() < b.as_object().get_deprecated("ip_address"sv).to_deprecated_string();
         });
 
         for (auto& value : sorted_regions) {
             auto& if_object = value.as_object();
 
-            auto ip_address = if_object.get("ip_address"sv).to_deprecated_string();
+            auto ip_address = if_object.get_deprecated("ip_address"sv).to_deprecated_string();
 
             if (!flag_numeric) {
                 auto from_string = IPv4Address::from_string(ip_address);
@@ -114,7 +114,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto mac_address = if_object.get("mac_address"sv).to_deprecated_string();
+            auto mac_address = if_object.get_deprecated("mac_address"sv).to_deprecated_string();
 
             if (proto_address_column != -1)
                 columns[proto_address_column].buffer = ip_address;

--- a/Userland/Utilities/df.cpp
+++ b/Userland/Utilities/df.cpp
@@ -62,15 +62,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto const& json = json_result.as_array();
     json.for_each([&](auto& value) {
         auto& fs_object = value.as_object();
-        auto fs = fs_object.get("class_name"sv).to_deprecated_string();
-        auto total_block_count = fs_object.get("total_block_count"sv).to_u64();
-        auto free_block_count = fs_object.get("free_block_count"sv).to_u64();
+        auto fs = fs_object.get_deprecated("class_name"sv).to_deprecated_string();
+        auto total_block_count = fs_object.get_deprecated("total_block_count"sv).to_u64();
+        auto free_block_count = fs_object.get_deprecated("free_block_count"sv).to_u64();
         auto used_block_count = total_block_count - free_block_count;
-        auto total_inode_count = fs_object.get("total_inode_count"sv).to_u64();
-        auto free_inode_count = fs_object.get("free_inode_count"sv).to_u64();
+        auto total_inode_count = fs_object.get_deprecated("total_inode_count"sv).to_u64();
+        auto free_inode_count = fs_object.get_deprecated("free_inode_count"sv).to_u64();
         auto used_inode_count = total_inode_count - free_inode_count;
-        auto block_size = fs_object.get("block_size"sv).to_u64();
-        auto mount_point = fs_object.get("mount_point"sv).to_deprecated_string();
+        auto block_size = fs_object.get_deprecated("block_size"sv).to_u64();
+        auto mount_point = fs_object.get_deprecated("mount_point"sv).to_deprecated_string();
 
         auto used_percentage = 100;
         if (total_block_count != 0)

--- a/Userland/Utilities/fortune.cpp
+++ b/Userland/Utilities/fortune.cpp
@@ -30,13 +30,13 @@ public:
         if (!entry.has("quote"sv) || !entry.has("author"sv) || !entry.has("utc_time"sv) || !entry.has("url"sv))
             return {};
         // From here on, trust that it's probably fine.
-        q.m_quote = entry.get("quote"sv).as_string();
-        q.m_author = entry.get("author"sv).as_string();
+        q.m_quote = entry.get_deprecated("quote"sv).as_string();
+        q.m_author = entry.get_deprecated("author"sv).as_string();
         // It is sometimes parsed as u32, sometimes as u64, depending on how large the number is.
-        q.m_utc_time = entry.get("utc_time"sv).to_number<u64>();
-        q.m_url = entry.get("url"sv).as_string();
+        q.m_utc_time = entry.get_deprecated("utc_time"sv).to_number<u64>();
+        q.m_url = entry.get_deprecated("url"sv).as_string();
         if (entry.has("context"sv))
-            q.m_context = entry.get("context"sv).as_string();
+            q.m_context = entry.get_deprecated("context"sv).as_string();
 
         return q;
     }

--- a/Userland/Utilities/ifconfig.cpp
+++ b/Userland/Utilities/ifconfig.cpp
@@ -38,16 +38,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         json.as_array().for_each([](auto& value) {
             auto& if_object = value.as_object();
 
-            auto name = if_object.get("name"sv).to_deprecated_string();
-            auto class_name = if_object.get("class_name"sv).to_deprecated_string();
-            auto mac_address = if_object.get("mac_address"sv).to_deprecated_string();
-            auto ipv4_address = if_object.get("ipv4_address"sv).to_deprecated_string();
-            auto netmask = if_object.get("ipv4_netmask"sv).to_deprecated_string();
-            auto packets_in = if_object.get("packets_in"sv).to_u32();
-            auto bytes_in = if_object.get("bytes_in"sv).to_u32();
-            auto packets_out = if_object.get("packets_out"sv).to_u32();
-            auto bytes_out = if_object.get("bytes_out"sv).to_u32();
-            auto mtu = if_object.get("mtu"sv).to_u32();
+            auto name = if_object.get_deprecated("name"sv).to_deprecated_string();
+            auto class_name = if_object.get_deprecated("class_name"sv).to_deprecated_string();
+            auto mac_address = if_object.get_deprecated("mac_address"sv).to_deprecated_string();
+            auto ipv4_address = if_object.get_deprecated("ipv4_address"sv).to_deprecated_string();
+            auto netmask = if_object.get_deprecated("ipv4_netmask"sv).to_deprecated_string();
+            auto packets_in = if_object.get_deprecated("packets_in"sv).to_u32();
+            auto bytes_in = if_object.get_deprecated("bytes_in"sv).to_u32();
+            auto packets_out = if_object.get_deprecated("packets_out"sv).to_u32();
+            auto bytes_out = if_object.get_deprecated("bytes_out"sv).to_u32();
+            auto mtu = if_object.get_deprecated("mtu"sv).to_u32();
 
             outln("{}:", name);
             outln("\tmac: {}", mac_address);

--- a/Userland/Utilities/json.cpp
+++ b/Userland/Utilities/json.cpp
@@ -139,7 +139,7 @@ JsonValue query(JsonValue const& value, Vector<StringView>& key_parts, size_t ke
 
     JsonValue result {};
     if (value.is_object()) {
-        result = value.as_object().get(key);
+        result = value.as_object().get_deprecated(key);
     } else if (value.is_array()) {
         auto key_as_index = key.to_int();
         if (key_as_index.has_value())

--- a/Userland/Utilities/lscpu.cpp
+++ b/Userland/Utilities/lscpu.cpp
@@ -16,35 +16,35 @@
 static void print_cache_info(StringView description, JsonObject const& cache_object)
 {
     outln("\t{}:", description);
-    outln("\t\tSize: {}", human_readable_size(cache_object.get("size"sv).as_u32()));
-    outln("\t\tLine size: {}", human_readable_size(cache_object.get("line_size"sv).as_u32()));
+    outln("\t\tSize: {}", human_readable_size(cache_object.get_deprecated("size"sv).as_u32()));
+    outln("\t\tLine size: {}", human_readable_size(cache_object.get_deprecated("line_size"sv).as_u32()));
 };
 
 static void print_cpu_info(JsonObject const& value)
 {
-    outln("CPU {}:", value.get("processor"sv).as_u32());
-    outln("\tVendor ID: {}", value.get("vendor_id"sv).as_string());
+    outln("CPU {}:", value.get_deprecated("processor"sv).as_u32());
+    outln("\tVendor ID: {}", value.get_deprecated("vendor_id"sv).as_string());
     if (value.has("hypervisor_vendor_id"sv))
-        outln("\tHypervisor Vendor ID: {}", value.get("hypervisor_vendor_id"sv).as_string());
-    outln("\tBrand: {}", value.get("brand"sv).as_string());
-    outln("\tFamily: {}", value.get("family"sv).as_u32());
-    outln("\tModel: {}", value.get("model"sv).as_u32());
-    outln("\tStepping: {}", value.get("stepping"sv).as_u32());
-    outln("\tType: {}", value.get("type"sv).as_u32());
+        outln("\tHypervisor Vendor ID: {}", value.get_deprecated("hypervisor_vendor_id"sv).as_string());
+    outln("\tBrand: {}", value.get_deprecated("brand"sv).as_string());
+    outln("\tFamily: {}", value.get_deprecated("family"sv).as_u32());
+    outln("\tModel: {}", value.get_deprecated("model"sv).as_u32());
+    outln("\tStepping: {}", value.get_deprecated("stepping"sv).as_u32());
+    outln("\tType: {}", value.get_deprecated("type"sv).as_u32());
 
-    auto& caches = value.get("caches"sv).as_object();
+    auto& caches = value.get_deprecated("caches"sv).as_object();
     if (caches.has("l1_data"sv))
-        print_cache_info("L1 data cache"sv, caches.get("l1_data"sv).as_object());
+        print_cache_info("L1 data cache"sv, caches.get_deprecated("l1_data"sv).as_object());
     if (caches.has("l1_instruction"sv))
-        print_cache_info("L1 instruction cache"sv, caches.get("l1_instruction"sv).as_object());
+        print_cache_info("L1 instruction cache"sv, caches.get_deprecated("l1_instruction"sv).as_object());
     if (caches.has("l2"sv))
-        print_cache_info("L2 cache"sv, caches.get("l2"sv).as_object());
+        print_cache_info("L2 cache"sv, caches.get_deprecated("l2"sv).as_object());
     if (caches.has("l3"sv))
-        print_cache_info("L3 cache"sv, caches.get("l3"sv).as_object());
+        print_cache_info("L3 cache"sv, caches.get_deprecated("l3"sv).as_object());
 
     out("\tFeatures: ");
 
-    auto& features = value.get("features"sv).as_array();
+    auto& features = value.get_deprecated("features"sv).as_array();
 
     for (auto const& feature : features.values())
         out("{} ", feature.as_string());

--- a/Userland/Utilities/lsirq.cpp
+++ b/Userland/Utilities/lsirq.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto file_contents = TRY(proc_interrupts->read_until_eof());
     auto json = TRY(JsonValue::from_string(file_contents));
 
-    auto cpu_count = json.as_array().at(0).as_object().get("per_cpu_call_counts"sv).as_array().size();
+    auto cpu_count = json.as_array().at(0).as_object().get_deprecated("per_cpu_call_counts"sv).as_array().size();
 
     out("      "sv);
     for (size_t i = 0; i < cpu_count; ++i) {
@@ -34,10 +34,10 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     json.as_array().for_each([cpu_count](JsonValue const& value) {
         auto& handler = value.as_object();
-        auto purpose = handler.get("purpose"sv).to_deprecated_string();
-        auto interrupt = handler.get("interrupt_line"sv).to_deprecated_string();
-        auto controller = handler.get("controller"sv).to_deprecated_string();
-        auto call_counts = handler.get("per_cpu_call_counts"sv).as_array();
+        auto purpose = handler.get_deprecated("purpose"sv).to_deprecated_string();
+        auto interrupt = handler.get_deprecated("interrupt_line"sv).to_deprecated_string();
+        auto controller = handler.get_deprecated("controller"sv).to_deprecated_string();
+        auto call_counts = handler.get_deprecated("per_cpu_call_counts"sv).as_array();
 
         out("{:>4}: ", interrupt);
 

--- a/Userland/Utilities/lsjails.cpp
+++ b/Userland/Utilities/lsjails.cpp
@@ -25,8 +25,8 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto json = TRY(JsonValue::from_string(file_contents));
     json.as_array().for_each([](auto& value) {
         auto& jail = value.as_object();
-        auto index = jail.get("index"sv).to_deprecated_string();
-        auto name = jail.get("name"sv).to_deprecated_string();
+        auto index = jail.get_deprecated("index"sv).to_deprecated_string();
+        auto name = jail.get_deprecated("name"sv).to_deprecated_string();
 
         outln("{:4}     {:10}", index, name);
     });

--- a/Userland/Utilities/lsof.cpp
+++ b/Userland/Utilities/lsof.cpp
@@ -87,9 +87,9 @@ static Vector<OpenFile> get_open_files_by_pid(pid_t pid)
     json.as_array().for_each([pid, &files](JsonValue const& object) {
         OpenFile open_file;
         open_file.pid = pid;
-        open_file.fd = object.as_object().get("fd"sv).to_int();
+        open_file.fd = object.as_object().get_deprecated("fd"sv).to_int();
 
-        DeprecatedString name = object.as_object().get("absolute_path"sv).to_deprecated_string();
+        DeprecatedString name = object.as_object().get_deprecated("absolute_path"sv).to_deprecated_string();
         VERIFY(parse_name(name, open_file));
         open_file.full_name = name;
 

--- a/Userland/Utilities/lsusb.cpp
+++ b/Userland/Utilities/lsusb.cpp
@@ -70,9 +70,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         json.as_array().for_each([usb_db, print_verbose](auto& value) {
             auto& device_descriptor = value.as_object();
 
-            auto device_address = device_descriptor.get("device_address"sv).to_u32();
-            auto vendor_id = device_descriptor.get("vendor_id"sv).to_u32();
-            auto product_id = device_descriptor.get("product_id"sv).to_u32();
+            auto device_address = device_descriptor.get_deprecated("device_address"sv).to_u32();
+            auto vendor_id = device_descriptor.get_deprecated("vendor_id"sv).to_u32();
+            auto product_id = device_descriptor.get_deprecated("product_id"sv).to_u32();
 
             if (usb_db) {
                 StringView vendor_string = usb_db->get_vendor(vendor_id);
@@ -87,52 +87,52 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
             if (print_verbose) {
                 outln("Device Descriptor");
-                outln("  bLength            {}", device_descriptor.get("length"sv).to_u32());
-                outln("  bDescriptorType    {}", device_descriptor.get("descriptor_type"sv).to_u32());
-                outln("  bcdUSB             {}", device_descriptor.get("usb_spec_compliance_bcd"sv).to_u32());
-                outln("  bDeviceClass       {}", device_descriptor.get("device_class"sv).to_u32());
-                outln("  bDeviceSubClass    {}", device_descriptor.get("device_sub_class"sv).to_u32());
-                outln("  bDeviceProtocol    {}", device_descriptor.get("device_protocol"sv).to_u32());
-                outln("  bMaxPacketSize     {}", device_descriptor.get("max_packet_size"sv).to_u32());
+                outln("  bLength            {}", device_descriptor.get_deprecated("length"sv).to_u32());
+                outln("  bDescriptorType    {}", device_descriptor.get_deprecated("descriptor_type"sv).to_u32());
+                outln("  bcdUSB             {}", device_descriptor.get_deprecated("usb_spec_compliance_bcd"sv).to_u32());
+                outln("  bDeviceClass       {}", device_descriptor.get_deprecated("device_class"sv).to_u32());
+                outln("  bDeviceSubClass    {}", device_descriptor.get_deprecated("device_sub_class"sv).to_u32());
+                outln("  bDeviceProtocol    {}", device_descriptor.get_deprecated("device_protocol"sv).to_u32());
+                outln("  bMaxPacketSize     {}", device_descriptor.get_deprecated("max_packet_size"sv).to_u32());
                 if (usb_db) {
                     StringView vendor_string = usb_db->get_vendor(vendor_id);
                     StringView device_string = usb_db->get_device(vendor_id, product_id);
-                    outln("  idVendor           0x{:04x} {}", device_descriptor.get("vendor_id"sv).to_u32(), vendor_string);
-                    outln("  idProduct          0x{:04x} {}", device_descriptor.get("product_id"sv).to_u32(), device_string);
+                    outln("  idVendor           0x{:04x} {}", device_descriptor.get_deprecated("vendor_id"sv).to_u32(), vendor_string);
+                    outln("  idProduct          0x{:04x} {}", device_descriptor.get_deprecated("product_id"sv).to_u32(), device_string);
                 } else {
-                    outln("  idVendor           0x{:04x}", device_descriptor.get("vendor_id"sv).to_u32());
-                    outln("  idProduct          0x{:04x}", device_descriptor.get("product_id"sv).to_u32());
+                    outln("  idVendor           0x{:04x}", device_descriptor.get_deprecated("vendor_id"sv).to_u32());
+                    outln("  idProduct          0x{:04x}", device_descriptor.get_deprecated("product_id"sv).to_u32());
                 }
-                outln("  bcdDevice          {}", device_descriptor.get("device_release_bcd"sv).to_u32());
-                outln("  iManufacturer      {}", device_descriptor.get("manufacturer_id_descriptor_index"sv).to_u32());
-                outln("  iProduct           {}", device_descriptor.get("product_string_descriptor_index"sv).to_u32());
-                outln("  iSerial            {}", device_descriptor.get("serial_number_descriptor_index"sv).to_u32());
-                outln("  bNumConfigurations {}", device_descriptor.get("num_configurations"sv).to_u32());
+                outln("  bcdDevice          {}", device_descriptor.get_deprecated("device_release_bcd"sv).to_u32());
+                outln("  iManufacturer      {}", device_descriptor.get_deprecated("manufacturer_id_descriptor_index"sv).to_u32());
+                outln("  iProduct           {}", device_descriptor.get_deprecated("product_string_descriptor_index"sv).to_u32());
+                outln("  iSerial            {}", device_descriptor.get_deprecated("serial_number_descriptor_index"sv).to_u32());
+                outln("  bNumConfigurations {}", device_descriptor.get_deprecated("num_configurations"sv).to_u32());
 
-                auto const& configuration_descriptors = value.as_object().get("configurations"sv);
+                auto const& configuration_descriptors = value.as_object().get_deprecated("configurations"sv);
                 configuration_descriptors.as_array().for_each([&](auto& config_value) {
                     auto const& configuration_descriptor = config_value.as_object();
                     outln("  Configuration Descriptor:");
-                    outln("    bLength          {}", configuration_descriptor.get("length"sv).as_u32());
-                    outln("    bDescriptorType  {}", configuration_descriptor.get("descriptor_type"sv).as_u32());
-                    outln("    wTotalLength     {}", configuration_descriptor.get("total_length"sv).as_u32());
-                    outln("    bNumInterfaces   {}", configuration_descriptor.get("number_of_interfaces"sv).as_u32());
-                    outln("    bmAttributes     0x{:02x}", configuration_descriptor.get("attributes_bitmap"sv).as_u32());
-                    outln("    MaxPower         {}mA", configuration_descriptor.get("max_power"sv).as_u32() * 2u);
+                    outln("    bLength          {}", configuration_descriptor.get_deprecated("length"sv).as_u32());
+                    outln("    bDescriptorType  {}", configuration_descriptor.get_deprecated("descriptor_type"sv).as_u32());
+                    outln("    wTotalLength     {}", configuration_descriptor.get_deprecated("total_length"sv).as_u32());
+                    outln("    bNumInterfaces   {}", configuration_descriptor.get_deprecated("number_of_interfaces"sv).as_u32());
+                    outln("    bmAttributes     0x{:02x}", configuration_descriptor.get_deprecated("attributes_bitmap"sv).as_u32());
+                    outln("    MaxPower         {}mA", configuration_descriptor.get_deprecated("max_power"sv).as_u32() * 2u);
 
-                    auto const& interface_descriptors = config_value.as_object().get("interfaces"sv);
+                    auto const& interface_descriptors = config_value.as_object().get_deprecated("interfaces"sv);
                     interface_descriptors.as_array().for_each([&](auto& interface_value) {
                         auto const& interface_descriptor = interface_value.as_object();
-                        auto const interface_class_code = interface_descriptor.get("interface_class_code"sv).to_u32();
-                        auto const interface_subclass_code = interface_descriptor.get("interface_sub_class_code"sv).to_u32();
-                        auto const interface_protocol_code = interface_descriptor.get("interface_protocol"sv).to_u32();
+                        auto const interface_class_code = interface_descriptor.get_deprecated("interface_class_code"sv).to_u32();
+                        auto const interface_subclass_code = interface_descriptor.get_deprecated("interface_sub_class_code"sv).to_u32();
+                        auto const interface_protocol_code = interface_descriptor.get_deprecated("interface_protocol"sv).to_u32();
 
                         outln("    Interface Descriptor:");
-                        outln("      bLength            {}", interface_descriptor.get("length"sv).to_u32());
-                        outln("      bDescriptorType    {}", interface_descriptor.get("descriptor_type"sv).to_u32());
-                        outln("      bInterfaceNumber   {}", interface_descriptor.get("interface_number"sv).to_u32());
-                        outln("      bAlternateSetting  {}", interface_descriptor.get("alternate_setting"sv).to_u32());
-                        outln("      bNumEndpoints      {}", interface_descriptor.get("num_endpoints"sv).to_u32());
+                        outln("      bLength            {}", interface_descriptor.get_deprecated("length"sv).to_u32());
+                        outln("      bDescriptorType    {}", interface_descriptor.get_deprecated("descriptor_type"sv).to_u32());
+                        outln("      bInterfaceNumber   {}", interface_descriptor.get_deprecated("interface_number"sv).to_u32());
+                        outln("      bAlternateSetting  {}", interface_descriptor.get_deprecated("alternate_setting"sv).to_u32());
+                        outln("      bNumEndpoints      {}", interface_descriptor.get_deprecated("num_endpoints"sv).to_u32());
                         if (usb_db) {
                             auto const interface_class = usb_db->get_class(interface_class_code);
                             auto const interface_subclass = usb_db->get_subclass(interface_class_code, interface_subclass_code);
@@ -145,19 +145,19 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                             outln("      bInterfaceSubClass {}", interface_subclass_code);
                             outln("      bInterfaceProtocol {}", interface_protocol_code);
                         }
-                        outln("      iInterface         {}", interface_descriptor.get("interface_string_desc_index"sv).to_u32());
+                        outln("      iInterface         {}", interface_descriptor.get_deprecated("interface_string_desc_index"sv).to_u32());
 
-                        auto const& endpoint_descriptors = interface_value.as_object().get("endpoints"sv);
+                        auto const& endpoint_descriptors = interface_value.as_object().get_deprecated("endpoints"sv);
                         endpoint_descriptors.as_array().for_each([&](auto& endpoint_value) {
                             auto const& endpoint_descriptor = endpoint_value.as_object();
-                            auto const endpoint_address = endpoint_descriptor.get("endpoint_address"sv).to_u32();
+                            auto const endpoint_address = endpoint_descriptor.get_deprecated("endpoint_address"sv).to_u32();
                             outln("      Endpoint Descriptor:");
-                            outln("        bLength            {}", endpoint_descriptor.get("length"sv).to_u32());
-                            outln("        bDescriptorType    {}", endpoint_descriptor.get("descriptor_type"sv).to_u32());
+                            outln("        bLength            {}", endpoint_descriptor.get_deprecated("length"sv).to_u32());
+                            outln("        bDescriptorType    {}", endpoint_descriptor.get_deprecated("descriptor_type"sv).to_u32());
                             outln("        bEndpointAddress   0x{:02x} EP {} {}", endpoint_address, (endpoint_address & 0xFu), ((endpoint_address & 0x80u) ? "IN" : "OUT"));
-                            outln("        bmAttributes       0x{:02x}", endpoint_descriptor.get("attribute_bitmap"sv).to_u32());
-                            outln("        wMaxPacketSize     0x{:04x}", endpoint_descriptor.get("max_packet_size"sv).to_u32());
-                            outln("        bInterval          {}", endpoint_descriptor.get("polling_interval"sv).to_u32());
+                            outln("        bmAttributes       0x{:02x}", endpoint_descriptor.get_deprecated("attribute_bitmap"sv).to_u32());
+                            outln("        wMaxPacketSize     0x{:04x}", endpoint_descriptor.get_deprecated("max_packet_size"sv).to_u32());
+                            outln("        bInterval          {}", endpoint_descriptor.get_deprecated("polling_interval"sv).to_u32());
                         });
                     });
                 });

--- a/Userland/Utilities/mount.cpp
+++ b/Userland/Utilities/mount.cpp
@@ -155,11 +155,11 @@ static ErrorOr<void> print_mounts()
 
     json.as_array().for_each([](auto& value) {
         auto& fs_object = value.as_object();
-        auto class_name = fs_object.get("class_name"sv).to_deprecated_string();
-        auto mount_point = fs_object.get("mount_point"sv).to_deprecated_string();
-        auto source = fs_object.get("source"sv).as_string_or("none");
-        auto readonly = fs_object.get("readonly"sv).to_bool();
-        auto mount_flags = fs_object.get("mount_flags"sv).to_int();
+        auto class_name = fs_object.get_deprecated("class_name"sv).to_deprecated_string();
+        auto mount_point = fs_object.get_deprecated("mount_point"sv).to_deprecated_string();
+        auto source = fs_object.get_deprecated("source"sv).as_string_or("none");
+        auto readonly = fs_object.get_deprecated("readonly"sv).to_bool();
+        auto mount_flags = fs_object.get_deprecated("mount_flags"sv).to_int();
 
         out("{} on {} type {} (", source, mount_point, class_name);
 

--- a/Userland/Utilities/netstat.cpp
+++ b/Userland/Utilities/netstat.cpp
@@ -163,16 +163,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         Vector<JsonValue> sorted_regions = json.as_array().values();
         quick_sort(sorted_regions, [](auto& a, auto& b) {
-            return a.as_object().get("local_port"sv).to_u32() < b.as_object().get("local_port"sv).to_u32();
+            return a.as_object().get_deprecated("local_port"sv).to_u32() < b.as_object().get_deprecated("local_port"sv).to_u32();
         });
 
         for (auto& value : sorted_regions) {
             auto& if_object = value.as_object();
 
-            auto bytes_in = if_object.get("bytes_in"sv).to_deprecated_string();
-            auto bytes_out = if_object.get("bytes_out"sv).to_deprecated_string();
+            auto bytes_in = if_object.get_deprecated("bytes_in"sv).to_deprecated_string();
+            auto bytes_out = if_object.get_deprecated("bytes_out"sv).to_deprecated_string();
 
-            auto peer_address = if_object.get("peer_address"sv).to_deprecated_string();
+            auto peer_address = if_object.get_deprecated("peer_address"sv).to_deprecated_string();
             if (!flag_numeric) {
                 auto from_string = IPv4Address::from_string(peer_address);
                 auto addr = from_string.value().to_in_addr_t();
@@ -184,9 +184,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto peer_port = if_object.get("peer_port"sv).to_deprecated_string();
+            auto peer_port = if_object.get_deprecated("peer_port"sv).to_deprecated_string();
             if (!flag_numeric) {
-                auto service = getservbyport(htons(if_object.get("peer_port"sv).to_u32()), "tcp");
+                auto service = getservbyport(htons(if_object.get_deprecated("peer_port"sv).to_u32()), "tcp");
                 if (service != nullptr) {
                     auto s_name = StringView { service->s_name, strlen(service->s_name) };
                     if (!s_name.is_empty())
@@ -194,7 +194,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto local_address = if_object.get("local_address"sv).to_deprecated_string();
+            auto local_address = if_object.get_deprecated("local_address"sv).to_deprecated_string();
             if (!flag_numeric) {
                 auto from_string = IPv4Address::from_string(local_address);
                 auto addr = from_string.value().to_in_addr_t();
@@ -206,9 +206,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto local_port = if_object.get("local_port"sv).to_deprecated_string();
+            auto local_port = if_object.get_deprecated("local_port"sv).to_deprecated_string();
             if (!flag_numeric) {
-                auto service = getservbyport(htons(if_object.get("local_port"sv).to_u32()), "tcp");
+                auto service = getservbyport(htons(if_object.get_deprecated("local_port"sv).to_u32()), "tcp");
                 if (service != nullptr) {
                     auto s_name = StringView { service->s_name, strlen(service->s_name) };
                     if (!s_name.is_empty())
@@ -216,8 +216,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto state = if_object.get("state"sv).to_deprecated_string();
-            auto origin_pid = (if_object.has("origin_pid"sv)) ? if_object.get("origin_pid"sv).to_u32() : -1;
+            auto state = if_object.get_deprecated("state"sv).to_deprecated_string();
+            auto origin_pid = (if_object.has("origin_pid"sv)) ? if_object.get_deprecated("origin_pid"sv).to_u32() : -1;
 
             if (!flag_all && ((state == "Listen" && !flag_list) || (state != "Listen" && flag_list)))
                 continue;
@@ -250,13 +250,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         Vector<JsonValue> sorted_regions = json.as_array().values();
         quick_sort(sorted_regions, [](auto& a, auto& b) {
-            return a.as_object().get("local_port"sv).to_u32() < b.as_object().get("local_port"sv).to_u32();
+            return a.as_object().get_deprecated("local_port"sv).to_u32() < b.as_object().get_deprecated("local_port"sv).to_u32();
         });
 
         for (auto& value : sorted_regions) {
             auto& if_object = value.as_object();
 
-            auto local_address = if_object.get("local_address"sv).to_deprecated_string();
+            auto local_address = if_object.get_deprecated("local_address"sv).to_deprecated_string();
             if (!flag_numeric) {
                 auto from_string = IPv4Address::from_string(local_address);
                 auto addr = from_string.value().to_in_addr_t();
@@ -268,9 +268,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto local_port = if_object.get("local_port"sv).to_deprecated_string();
+            auto local_port = if_object.get_deprecated("local_port"sv).to_deprecated_string();
             if (!flag_numeric) {
-                auto service = getservbyport(htons(if_object.get("local_port"sv).to_u32()), "udp");
+                auto service = getservbyport(htons(if_object.get_deprecated("local_port"sv).to_u32()), "udp");
                 if (service != nullptr) {
                     auto s_name = StringView { service->s_name, strlen(service->s_name) };
                     if (!s_name.is_empty())
@@ -278,7 +278,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto peer_address = if_object.get("peer_address"sv).to_deprecated_string();
+            auto peer_address = if_object.get_deprecated("peer_address"sv).to_deprecated_string();
             if (!flag_numeric) {
                 auto from_string = IPv4Address::from_string(peer_address);
                 auto addr = from_string.value().to_in_addr_t();
@@ -290,9 +290,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto peer_port = if_object.get("peer_port"sv).to_deprecated_string();
+            auto peer_port = if_object.get_deprecated("peer_port"sv).to_deprecated_string();
             if (!flag_numeric) {
-                auto service = getservbyport(htons(if_object.get("peer_port"sv).to_u32()), "udp");
+                auto service = getservbyport(htons(if_object.get_deprecated("peer_port"sv).to_u32()), "udp");
                 if (service != nullptr) {
                     auto s_name = StringView { service->s_name, strlen(service->s_name) };
                     if (!s_name.is_empty())
@@ -300,7 +300,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
             }
 
-            auto origin_pid = (if_object.has("origin_pid"sv)) ? if_object.get("origin_pid"sv).to_u32() : -1;
+            auto origin_pid = (if_object.has("origin_pid"sv)) ? if_object.get_deprecated("origin_pid"sv).to_u32() : -1;
 
             if (protocol_column != -1)
                 columns[protocol_column].buffer = "udp";

--- a/Userland/Utilities/pmap.cpp
+++ b/Userland/Utilities/pmap.cpp
@@ -43,31 +43,31 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Vector<JsonValue> sorted_regions = json.as_array().values();
     quick_sort(sorted_regions, [](auto& a, auto& b) {
-        return a.as_object().get("address"sv).to_addr() < b.as_object().get("address"sv).to_addr();
+        return a.as_object().get_deprecated("address"sv).to_addr() < b.as_object().get_deprecated("address"sv).to_addr();
     });
 
     for (auto& value : sorted_regions) {
         auto& map = value.as_object();
-        auto address = map.get("address"sv).to_addr();
-        auto size = map.get("size"sv).to_deprecated_string();
+        auto address = map.get_deprecated("address"sv).to_addr();
+        auto size = map.get_deprecated("size"sv).to_deprecated_string();
 
         auto access = DeprecatedString::formatted("{}{}{}{}{}",
-            (map.get("readable"sv).to_bool() ? "r" : "-"),
-            (map.get("writable"sv).to_bool() ? "w" : "-"),
-            (map.get("executable"sv).to_bool() ? "x" : "-"),
-            (map.get("shared"sv).to_bool() ? "s" : "-"),
-            (map.get("syscall"sv).to_bool() ? "c" : "-"));
+            (map.get_deprecated("readable"sv).to_bool() ? "r" : "-"),
+            (map.get_deprecated("writable"sv).to_bool() ? "w" : "-"),
+            (map.get_deprecated("executable"sv).to_bool() ? "x" : "-"),
+            (map.get_deprecated("shared"sv).to_bool() ? "s" : "-"),
+            (map.get_deprecated("syscall"sv).to_bool() ? "c" : "-"));
 
         out("{:p}  ", address);
         out("{:>10} ", size);
         if (extended) {
-            auto resident = map.get("amount_resident"sv).to_deprecated_string();
-            auto dirty = map.get("amount_dirty"sv).to_deprecated_string();
-            auto vmobject = map.get("vmobject"sv).to_deprecated_string();
+            auto resident = map.get_deprecated("amount_resident"sv).to_deprecated_string();
+            auto dirty = map.get_deprecated("amount_dirty"sv).to_deprecated_string();
+            auto vmobject = map.get_deprecated("vmobject"sv).to_deprecated_string();
             if (vmobject.ends_with("VMObject"sv))
                 vmobject = vmobject.substring(0, vmobject.length() - 8);
-            auto purgeable = map.get("purgeable"sv).to_deprecated_string();
-            auto cow_pages = map.get("cow_pages"sv).to_deprecated_string();
+            auto purgeable = map.get_deprecated("purgeable"sv).to_deprecated_string();
+            auto cow_pages = map.get_deprecated("cow_pages"sv).to_deprecated_string();
             out("{:>10} ", resident);
             out("{:>10} ", dirty);
             out("{:6} ", access);
@@ -77,7 +77,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         } else {
             out("{:6} ", access);
         }
-        auto name = map.get("name"sv).to_deprecated_string();
+        auto name = map.get_deprecated("name"sv).to_deprecated_string();
         out("{:20}", name);
         outln();
     }

--- a/Userland/Utilities/route.cpp
+++ b/Userland/Utilities/route.cpp
@@ -101,17 +101,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         Vector<JsonValue> sorted_regions = json.as_array().values();
         quick_sort(sorted_regions, [](auto& a, auto& b) {
-            return a.as_object().get("destination"sv).to_deprecated_string() < b.as_object().get("destination"sv).to_deprecated_string();
+            return a.as_object().get_deprecated("destination"sv).to_deprecated_string() < b.as_object().get_deprecated("destination"sv).to_deprecated_string();
         });
 
         for (auto& value : sorted_regions) {
             auto& if_object = value.as_object();
 
-            auto destination = if_object.get("destination"sv).to_deprecated_string();
-            auto gateway = if_object.get("gateway"sv).to_deprecated_string();
-            auto genmask = if_object.get("genmask"sv).to_deprecated_string();
-            auto interface = if_object.get("interface"sv).to_deprecated_string();
-            auto flags = if_object.get("flags"sv).to_u32();
+            auto destination = if_object.get_deprecated("destination"sv).to_deprecated_string();
+            auto gateway = if_object.get_deprecated("gateway"sv).to_deprecated_string();
+            auto genmask = if_object.get_deprecated("genmask"sv).to_deprecated_string();
+            auto interface = if_object.get_deprecated("interface"sv).to_deprecated_string();
+            auto flags = if_object.get_deprecated("flags"sv).to_u32();
 
             StringBuilder flags_builder;
             if (flags & RTF_UP)

--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -40,10 +40,10 @@ ErrorOr<int> serenity_main(Main::Arguments)
     outln("\033[1m{:10} {:12} {:16} {:6} {}\033[0m", "USER", "TTY", "LOGIN@", "IDLE", "WHAT");
     json.as_object().for_each_member([&](auto& tty, auto& value) {
         const JsonObject& entry = value.as_object();
-        auto uid = entry.get("uid"sv).to_u32();
-        [[maybe_unused]] auto pid = entry.get("pid"sv).to_i32();
+        auto uid = entry.get_deprecated("uid"sv).to_u32();
+        [[maybe_unused]] auto pid = entry.get_deprecated("pid"sv).to_i32();
 
-        auto login_time = Core::DateTime::from_timestamp(entry.get("login_at"sv).to_number<time_t>());
+        auto login_time = Core::DateTime::from_timestamp(entry.get_deprecated("login_at"sv).to_number<time_t>());
         auto login_at = login_time.to_deprecated_string("%b%d %H:%M:%S"sv);
 
         auto* pw = getpwuid(uid);


### PR DESCRIPTION
I foolishly decided to put the whole chonky change in one PR, so let's try again in smaller steps. :sweat_smile: 

Not much smaller though, because most of it still happens in this PR. :grimacing: It's not complicated, most of the line changes are the `get()` -> `get_deprecated()` rename.