### PR TITLE
HexEditor: Port to `Core::Stream` + More error propagation

### DIFF
--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -70,10 +70,18 @@ bool HexDocumentMemory::write_to_file(NonnullRefPtr<Core::File> file)
     return true;
 }
 
+ErrorOr<NonnullOwnPtr<HexDocumentFile>> HexDocumentFile::create(NonnullRefPtr<Core::File> file)
+{
+    auto document = TRY(adopt_nonnull_own_or_enomem(new HexDocumentFile(move(file))));
+    // FIXME: Remove this hackery
+    document->set_file(move(document->m_file));
+
+    return document;
+}
+
 HexDocumentFile::HexDocumentFile(NonnullRefPtr<Core::File> file)
     : m_file(file)
 {
-    set_file(file);
 }
 
 void HexDocumentFile::write_to_file()

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -73,7 +73,7 @@ ErrorOr<NonnullOwnPtr<HexDocumentFile>> HexDocumentFile::create(NonnullOwnPtr<Co
 {
     auto document = TRY(adopt_nonnull_own_or_enomem(new HexDocumentFile(move(file))));
     // FIXME: Remove this hackery
-    document->set_file(move(document->m_file));
+    TRY(document->set_file(move(document->m_file)));
 
     return document;
 }
@@ -150,7 +150,7 @@ void HexDocumentFile::clear_changes()
     m_changes.clear();
 }
 
-void HexDocumentFile::set_file(NonnullOwnPtr<Core::Stream::File> file)
+ErrorOr<void> HexDocumentFile::set_file(NonnullOwnPtr<Core::Stream::File> file)
 {
     m_file = move(file);
 
@@ -159,11 +159,12 @@ void HexDocumentFile::set_file(NonnullOwnPtr<Core::Stream::File> file)
     else
         m_file_size = result.value();
 
-    m_file->seek(0, SeekMode::SetPosition).release_value_but_fixme_should_propagate_errors();
+    TRY(m_file->seek(0, SeekMode::SetPosition));
 
     clear_changes();
     // make sure the next get operation triggers a read
     m_buffer_file_pos = m_file_size + 1;
+    return {};
 }
 
 NonnullOwnPtr<Core::Stream::File> const& HexDocumentFile::file() const

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -72,8 +72,7 @@ ErrorOr<void> HexDocumentMemory::write_to_file(Core::Stream::File& file)
 ErrorOr<NonnullOwnPtr<HexDocumentFile>> HexDocumentFile::create(NonnullOwnPtr<Core::Stream::File> file)
 {
     auto document = TRY(adopt_nonnull_own_or_enomem(new HexDocumentFile(move(file))));
-    // FIXME: Remove this hackery
-    TRY(document->set_file(move(document->m_file)));
+    TRY(document->initialize_internal_state());
 
     return document;
 }
@@ -153,7 +152,12 @@ void HexDocumentFile::clear_changes()
 ErrorOr<void> HexDocumentFile::set_file(NonnullOwnPtr<Core::Stream::File> file)
 {
     m_file = move(file);
+    TRY(initialize_internal_state());
+    return {};
+}
 
+ErrorOr<void> HexDocumentFile::initialize_internal_state()
+{
     if (auto result = m_file->seek(0, SeekMode::FromEndPosition); result.is_error())
         m_file_size = 0;
     else

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -83,15 +83,16 @@ HexDocumentFile::HexDocumentFile(NonnullOwnPtr<Core::Stream::File> file)
 {
 }
 
-void HexDocumentFile::write_to_file()
+ErrorOr<void> HexDocumentFile::write_to_file()
 {
     for (auto& change : m_changes) {
-        m_file->seek(change.key, SeekMode::SetPosition).release_value_but_fixme_should_propagate_errors();
-        m_file->write({ &change.value, 1 }).release_value_but_fixme_should_propagate_errors();
+        TRY(m_file->seek(change.key, SeekMode::SetPosition));
+        TRY(m_file->write({ &change.value, 1 }));
     }
     clear_changes();
     // make sure the next get operation triggers a read
     m_buffer_file_pos = m_file_size + 1;
+    return {};
 }
 
 ErrorOr<void> HexDocumentFile::write_to_file(Core::Stream::File& file)

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -64,7 +64,7 @@ public:
     HexDocumentFile(HexDocumentFile&&) = default;
     HexDocumentFile(HexDocumentFile const&) = delete;
 
-    void set_file(NonnullOwnPtr<Core::Stream::File> file);
+    ErrorOr<void> set_file(NonnullOwnPtr<Core::Stream::File> file);
     NonnullOwnPtr<Core::Stream::File> const& file() const;
     ErrorOr<void> write_to_file();
     ErrorOr<void> write_to_file(Core::Stream::File& file);

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -61,6 +61,7 @@ public:
     explicit HexDocumentFile(NonnullRefPtr<Core::File> file);
     virtual ~HexDocumentFile() = default;
 
+    HexDocumentFile(HexDocumentFile&&) = default;
     HexDocumentFile(HexDocumentFile const&) = delete;
 
     void set_file(NonnullRefPtr<Core::File> file);

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -50,7 +50,7 @@ public:
     size_t size() const override;
     Type type() const override;
     void clear_changes() override;
-    bool write_to_file(NonnullRefPtr<Core::File> file);
+    bool write_to_file(Core::Stream::File& file);
 
 private:
     ByteBuffer m_buffer;
@@ -58,16 +58,16 @@ private:
 
 class HexDocumentFile final : public HexDocument {
 public:
-    static ErrorOr<NonnullOwnPtr<HexDocumentFile>> create(NonnullRefPtr<Core::File> file);
+    static ErrorOr<NonnullOwnPtr<HexDocumentFile>> create(NonnullOwnPtr<Core::Stream::File> file);
     virtual ~HexDocumentFile() = default;
 
     HexDocumentFile(HexDocumentFile&&) = default;
     HexDocumentFile(HexDocumentFile const&) = delete;
 
-    void set_file(NonnullRefPtr<Core::File> file);
-    NonnullRefPtr<Core::File> file() const;
+    void set_file(NonnullOwnPtr<Core::Stream::File> file);
+    NonnullOwnPtr<Core::Stream::File> const& file() const;
     void write_to_file();
-    bool write_to_file(NonnullRefPtr<Core::File> file);
+    bool write_to_file(Core::Stream::File& file);
     Cell get(size_t position) override;
     u8 get_unchanged(size_t position) override;
     size_t size() const override;
@@ -75,10 +75,10 @@ public:
     void clear_changes() override;
 
 private:
-    explicit HexDocumentFile(NonnullRefPtr<Core::File> file);
+    explicit HexDocumentFile(NonnullOwnPtr<Core::Stream::File> file);
     void ensure_position_in_buffer(size_t position);
 
-    NonnullRefPtr<Core::File> m_file;
+    NonnullOwnPtr<Core::Stream::File> m_file;
     size_t m_file_size;
 
     Array<u8, 2048> m_buffer;

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -76,6 +76,8 @@ public:
 
 private:
     explicit HexDocumentFile(NonnullOwnPtr<Core::Stream::File> file);
+    ErrorOr<void> initialize_internal_state();
+
     void ensure_position_in_buffer(size_t position);
 
     NonnullOwnPtr<Core::Stream::File> m_file;

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -58,7 +58,7 @@ private:
 
 class HexDocumentFile final : public HexDocument {
 public:
-    explicit HexDocumentFile(NonnullRefPtr<Core::File> file);
+    static ErrorOr<NonnullOwnPtr<HexDocumentFile>> create(NonnullRefPtr<Core::File> file);
     virtual ~HexDocumentFile() = default;
 
     HexDocumentFile(HexDocumentFile&&) = default;
@@ -75,6 +75,7 @@ public:
     void clear_changes() override;
 
 private:
+    explicit HexDocumentFile(NonnullRefPtr<Core::File> file);
     void ensure_position_in_buffer(size_t position);
 
     NonnullRefPtr<Core::File> m_file;

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -66,7 +66,7 @@ public:
 
     void set_file(NonnullOwnPtr<Core::Stream::File> file);
     NonnullOwnPtr<Core::Stream::File> const& file() const;
-    void write_to_file();
+    ErrorOr<void> write_to_file();
     ErrorOr<void> write_to_file(Core::Stream::File& file);
     Cell get(size_t position) override;
     u8 get_unchanged(size_t position) override;

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -50,7 +50,7 @@ public:
     size_t size() const override;
     Type type() const override;
     void clear_changes() override;
-    bool write_to_file(Core::Stream::File& file);
+    ErrorOr<void> write_to_file(Core::Stream::File& file);
 
 private:
     ByteBuffer m_buffer;
@@ -67,7 +67,7 @@ public:
     void set_file(NonnullOwnPtr<Core::Stream::File> file);
     NonnullOwnPtr<Core::Stream::File> const& file() const;
     void write_to_file();
-    bool write_to_file(Core::Stream::File& file);
+    ErrorOr<void> write_to_file(Core::Stream::File& file);
     Cell get(size_t position) override;
     u8 get_unchanged(size_t position) override;
     size_t size() const override;

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -135,23 +135,22 @@ void HexEditor::set_selection(size_t position, size_t length)
     scroll_position_into_view(position);
     update_status();
 }
-bool HexEditor::save_as(NonnullOwnPtr<Core::Stream::File> new_file)
+
+ErrorOr<void> HexEditor::save_as(NonnullOwnPtr<Core::Stream::File> new_file)
 {
     if (m_document->type() == HexDocument::Type::File) {
         auto& file_document = static_cast<HexDocumentFile&>(*m_document);
-        if (!file_document.write_to_file(*new_file))
-            return false;
+        TRY(file_document.write_to_file(*new_file));
         file_document.set_file(move(new_file));
     } else {
         auto& memory_document = static_cast<HexDocumentMemory&>(*m_document);
-        if (!memory_document.write_to_file(*new_file))
-            return false;
+        TRY(memory_document.write_to_file(*new_file));
         m_document = HexDocumentFile::create(move(new_file)).release_value_but_fixme_should_propagate_errors();
     }
 
     update();
 
-    return true;
+    return {};
 }
 
 bool HexEditor::save()

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -141,7 +141,7 @@ ErrorOr<void> HexEditor::save_as(NonnullOwnPtr<Core::Stream::File> new_file)
     if (m_document->type() == HexDocument::Type::File) {
         auto& file_document = static_cast<HexDocumentFile&>(*m_document);
         TRY(file_document.write_to_file(*new_file));
-        file_document.set_file(move(new_file));
+        TRY(file_document.set_file(move(new_file)));
     } else {
         auto& memory_document = static_cast<HexDocumentMemory&>(*m_document);
         TRY(memory_document.write_to_file(*new_file));

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -65,7 +65,7 @@ ErrorOr<void> HexEditor::open_new_file(size_t size)
 
 void HexEditor::open_file(NonnullRefPtr<Core::File> file)
 {
-    m_document = make<HexDocumentFile>(file);
+    m_document = HexDocumentFile::create(move(file)).release_value_but_fixme_should_propagate_errors();
     set_content_length(m_document->size());
     m_position = 0;
     m_cursor_at_low_nibble = false;
@@ -146,7 +146,7 @@ bool HexEditor::save_as(NonnullRefPtr<Core::File> new_file)
         auto& memory_document = static_cast<HexDocumentMemory&>(*m_document);
         if (!memory_document.write_to_file(new_file))
             return false;
-        m_document = make<HexDocumentFile>(new_file);
+        m_document = HexDocumentFile::create(move(new_file)).release_value_but_fixme_should_propagate_errors();
     }
 
     update();

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -63,7 +63,7 @@ ErrorOr<void> HexEditor::open_new_file(size_t size)
     return {};
 }
 
-void HexEditor::open_file(NonnullRefPtr<Core::File> file)
+void HexEditor::open_file(NonnullOwnPtr<Core::Stream::File> file)
 {
     m_document = HexDocumentFile::create(move(file)).release_value_but_fixme_should_propagate_errors();
     set_content_length(m_document->size());
@@ -135,16 +135,16 @@ void HexEditor::set_selection(size_t position, size_t length)
     scroll_position_into_view(position);
     update_status();
 }
-bool HexEditor::save_as(NonnullRefPtr<Core::File> new_file)
+bool HexEditor::save_as(NonnullOwnPtr<Core::Stream::File> new_file)
 {
     if (m_document->type() == HexDocument::Type::File) {
         auto& file_document = static_cast<HexDocumentFile&>(*m_document);
-        if (!file_document.write_to_file(new_file))
+        if (!file_document.write_to_file(*new_file))
             return false;
-        file_document.set_file(new_file);
+        file_document.set_file(move(new_file));
     } else {
         auto& memory_document = static_cast<HexDocumentMemory&>(*m_document);
-        if (!memory_document.write_to_file(new_file))
+        if (!memory_document.write_to_file(*new_file))
             return false;
         m_document = HexDocumentFile::create(move(new_file)).release_value_but_fixme_should_propagate_errors();
     }

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -153,14 +153,13 @@ ErrorOr<void> HexEditor::save_as(NonnullOwnPtr<Core::Stream::File> new_file)
     return {};
 }
 
-bool HexEditor::save()
+ErrorOr<void> HexEditor::save()
 {
-    if (m_document->type() != HexDocument::Type::File) {
-        return false;
-    }
+    if (m_document->type() != HexDocument::Type::File)
+        return Error::from_string_literal("Unable to save from a memory document");
 
-    static_cast<HexDocumentFile*>(m_document.ptr())->write_to_file();
-    return true;
+    TRY(static_cast<HexDocumentFile*>(m_document.ptr())->write_to_file());
+    return {};
 }
 
 size_t HexEditor::selection_size()

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -38,7 +38,7 @@ public:
     void open_file(NonnullOwnPtr<Core::Stream::File> file);
     ErrorOr<void> fill_selection(u8 fill_byte);
     Optional<u8> get_byte(size_t position);
-    bool save_as(NonnullOwnPtr<Core::Stream::File>);
+    ErrorOr<void> save_as(NonnullOwnPtr<Core::Stream::File>);
     bool save();
 
     bool undo();

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -39,7 +39,7 @@ public:
     ErrorOr<void> fill_selection(u8 fill_byte);
     Optional<u8> get_byte(size_t position);
     ErrorOr<void> save_as(NonnullOwnPtr<Core::Stream::File>);
-    bool save();
+    ErrorOr<void> save();
 
     bool undo();
     bool redo();

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -35,10 +35,10 @@ public:
 
     size_t buffer_size() const { return m_document->size(); }
     ErrorOr<void> open_new_file(size_t size);
-    void open_file(NonnullRefPtr<Core::File> file);
+    void open_file(NonnullOwnPtr<Core::Stream::File> file);
     ErrorOr<void> fill_selection(u8 fill_byte);
     Optional<u8> get_byte(size_t position);
-    bool save_as(NonnullRefPtr<Core::File>);
+    bool save_as(NonnullOwnPtr<Core::Stream::File>);
     bool save();
 
     bool undo();

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -146,8 +146,8 @@ HexEditorWidget::HexEditorWidget()
         if (response.is_error())
             return;
         auto file = response.release_value();
-        if (!m_editor->save_as(file.release_stream())) {
-            GUI::MessageBox::show(window(), "Unable to save file.\n"sv, "Error"sv, GUI::MessageBox::Type::Error);
+        if (auto result = m_editor->save_as(file.release_stream()); result.is_error()) {
+            GUI::MessageBox::show(window(), DeprecatedString::formatted("Unable to save file: {}\n"sv, result.error()), "Error"sv, GUI::MessageBox::Type::Error);
             return;
         }
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -132,8 +132,8 @@ HexEditorWidget::HexEditorWidget()
         if (m_path.is_empty())
             return m_save_as_action->activate();
 
-        if (!m_editor->save()) {
-            GUI::MessageBox::show(window(), "Unable to save file.\n"sv, "Error"sv, GUI::MessageBox::Type::Error);
+        if (auto result = m_editor->save(); result.is_error()) {
+            GUI::MessageBox::show(window(), DeprecatedString::formatted("Unable to save file: {}\n"sv, result.error()), "Error"sv, GUI::MessageBox::Type::Error);
         } else {
             window()->set_modified(false);
             m_editor->update();

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -25,7 +25,7 @@ class HexEditorWidget final : public GUI::Widget {
     C_OBJECT(HexEditorWidget)
 public:
     virtual ~HexEditorWidget() override = default;
-    void open_file(NonnullRefPtr<Core::File>);
+    void open_file(String const& filename, NonnullOwnPtr<Core::Stream::File>);
     void initialize_menubar(GUI::Window&);
     bool request_close();
 

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -53,10 +53,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (arguments.argc > 1) {
         // FIXME: Using `try_request_file_read_only_approved` doesn't work here since the file stored in the editor is only readable.
-        auto response = FileSystemAccessClient::Client::the().try_request_file_deprecated(window, arguments.strings[1], Core::OpenMode::ReadWrite);
+        auto response = FileSystemAccessClient::Client::the().request_file(window, arguments.strings[1], Core::Stream::OpenMode::ReadWrite);
         if (response.is_error())
             return 1;
-        hex_editor_widget->open_file(response.value());
+        hex_editor_widget->open_file(response.value().filename(), response.value().release_stream());
     }
 
     return app->exec();


### PR DESCRIPTION
How it was written:
 - Port to `Core::Stream` and add a lot of `release_value_but_fixme_should_propagate_errors()`
 - Remove some of them