### PR TITLE
PixelPaint: Preserve layer location when copying layers

### DIFF
--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -137,9 +137,9 @@ void Clipboard::set_data(ReadonlyBytes data, DeprecatedString const& type, HashM
     connection().async_set_clipboard_data(move(buffer), type, metadata);
 }
 
-void Clipboard::set_bitmap(Gfx::Bitmap const& bitmap)
+void Clipboard::set_bitmap(Gfx::Bitmap const& bitmap, HashMap<DeprecatedString, DeprecatedString> const& additional_metadata)
 {
-    HashMap<DeprecatedString, DeprecatedString> metadata;
+    HashMap<DeprecatedString, DeprecatedString> metadata(additional_metadata);
     metadata.set("width", DeprecatedString::number(bitmap.width()));
     metadata.set("height", DeprecatedString::number(bitmap.height()));
     metadata.set("scale", DeprecatedString::number(bitmap.scale()));

--- a/Userland/Libraries/LibGUI/Clipboard.h
+++ b/Userland/Libraries/LibGUI/Clipboard.h
@@ -44,7 +44,7 @@ public:
 
     void set_data(ReadonlyBytes data, DeprecatedString const& mime_type = "text/plain", HashMap<DeprecatedString, DeprecatedString> const& metadata = {});
     void set_plain_text(DeprecatedString const& text) { set_data(text.bytes()); }
-    void set_bitmap(Gfx::Bitmap const&);
+    void set_bitmap(Gfx::Bitmap const&, HashMap<DeprecatedString, DeprecatedString> const& additional_metadata = {});
     void clear();
 
     void clipboard_data_changed(Badge<ConnectionToClipboardServer>, DeprecatedString const& mime_type);


### PR DESCRIPTION
PixelPaint specific layer location metadata is now included when copying a layer to the clipboard. This allows a pasted layer to be placed in the location it was copied from. Previously, copied layers would be pasted to the top left of the canvas.

Video:

https://user-images.githubusercontent.com/2817754/212741953-0ad6f397-34af-469e-bf2c-62f37cbd36ec.mp4