### PR TITLE
AK+LibUnicode: Provide Unicode-aware String titlecase transformation

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -45,10 +45,10 @@ public:
     // Creates a new String from a sequence of UTF-8 encoded code points.
     static ErrorOr<String> from_utf8(StringView);
 
-    // Creates a new String by transforming this String to lower- or uppercase. Using these methods
-    // require linking LibUnicode into your application.
+    // Creates a new String by case-transforming this String. Using these methods require linking LibUnicode into your application.
     ErrorOr<String> to_lowercase(Optional<StringView> const& locale = {}) const;
     ErrorOr<String> to_uppercase(Optional<StringView> const& locale = {}) const;
+    ErrorOr<String> to_titlecase(Optional<StringView> const& locale = {}) const;
 
     // Creates a substring with a deep copy of the specified data window.
     ErrorOr<String> substring_from_byte_offset(size_t start, size_t byte_count) const;

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -113,6 +113,7 @@ struct UnicodeData {
 
     u32 simple_uppercase_mapping_size { 0 };
     u32 simple_lowercase_mapping_size { 0 };
+    u32 simple_titlecase_mapping_size { 0 };
 
     Vector<SpecialCasing> special_casing;
     u32 code_points_with_special_casing { 0 };
@@ -674,6 +675,7 @@ static ErrorOr<void> parse_unicode_data(Core::Stream::BufferedFile& file, Unicod
         unicode_data.code_points_with_non_zero_combining_class += data.canonical_combining_class != 0;
         unicode_data.simple_uppercase_mapping_size += data.simple_uppercase_mapping.has_value();
         unicode_data.simple_lowercase_mapping_size += data.simple_lowercase_mapping.has_value();
+        unicode_data.simple_titlecase_mapping_size += data.simple_titlecase_mapping.has_value();
         unicode_data.code_points_with_decomposition_mapping += data.decomposition_mapping.has_value();
 
         unicode_data.code_points_with_special_casing += has_special_casing;
@@ -978,6 +980,7 @@ static constexpr Array<@mapping_type@, @size@> s_@name@_mappings { {
         });
     append_code_point_mappings("uppercase"sv, "CodePointMapping"sv, unicode_data.simple_uppercase_mapping_size, [](auto const& data) { return data.simple_uppercase_mapping; });
     append_code_point_mappings("lowercase"sv, "CodePointMapping"sv, unicode_data.simple_lowercase_mapping_size, [](auto const& data) { return data.simple_lowercase_mapping; });
+    append_code_point_mappings("titlecase"sv, "CodePointMapping"sv, unicode_data.simple_titlecase_mapping_size, [](auto const& data) { return data.simple_titlecase_mapping; });
     append_code_point_mappings("special_case"sv, "SpecialCaseMapping"sv, unicode_data.code_points_with_special_casing, [](auto const& data) { return data.special_casing_indices; });
     append_code_point_mappings("abbreviation"sv, "CodePointAbbreviation"sv, unicode_data.code_point_abbreviations.size(), [](auto const& data) { return data.abbreviation; });
 
@@ -1138,6 +1141,7 @@ u32 @method@(u32 code_point)
     append_code_point_mapping_search("canonical_combining_class"sv, "s_combining_class_mappings"sv, "0"sv);
     append_code_point_mapping_search("to_unicode_uppercase"sv, "s_uppercase_mappings"sv, "code_point"sv);
     append_code_point_mapping_search("to_unicode_lowercase"sv, "s_lowercase_mappings"sv, "code_point"sv);
+    append_code_point_mapping_search("to_unicode_titlecase"sv, "s_titlecase_mappings"sv, "code_point"sv);
 
     generator.append(R"~~~(
 Span<SpecialCasing const* const> special_case_mapping(u32 code_point)

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -163,6 +163,30 @@ TEST_CASE(to_uppercase)
     }
 }
 
+TEST_CASE(to_titlecase)
+{
+    {
+        auto string = MUST(String::from_utf8("foo bar baz"sv));
+        auto result = MUST(string.to_titlecase());
+        EXPECT_EQ(result, "Foo Bar Baz"sv);
+    }
+    {
+        auto string = MUST(String::from_utf8("foo \n \r bar \t baz"sv));
+        auto result = MUST(string.to_titlecase());
+        EXPECT_EQ(result, "Foo \n \r Bar \t Baz"sv);
+    }
+    {
+        auto string = MUST(String::from_utf8("f\"oo\" b'ar'"sv));
+        auto result = MUST(string.to_titlecase());
+        EXPECT_EQ(result, "F\"Oo\" B'Ar'"sv);
+    }
+    {
+        auto string = MUST(String::from_utf8("123dollars"sv));
+        auto result = MUST(string.to_titlecase());
+        EXPECT_EQ(result, "123Dollars"sv);
+    }
+}
+
 TEST_CASE(is_one_of)
 {
     auto foo = MUST(String::from_utf8("foo"sv));

--- a/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
+++ b/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
@@ -74,6 +74,27 @@ TEST_CASE(to_unicode_titlecase)
     EXPECT_EQ(Unicode::to_unicode_titlecase(0x01c9u), 0x01c8u); // "ǉ" to "ǈ"
     EXPECT_EQ(Unicode::to_unicode_titlecase(0x01ccu), 0x01cbu); // "ǌ" to "ǋ"
     EXPECT_EQ(Unicode::to_unicode_titlecase(0x01f3u), 0x01f2u); // "ǳ" to "ǲ"
+
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full(""sv)), ""sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full(" "sv)), " "sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full(" - "sv)), " - "sv);
+
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full("a"sv)), "A"sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full("A"sv)), "A"sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full(" a"sv)), " A"sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full("a "sv)), "A "sv);
+
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full("ab"sv)), "Ab"sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full("Ab"sv)), "Ab"sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full("aB"sv)), "Ab"sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full("AB"sv)), "Ab"sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full(" ab"sv)), " Ab"sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full("ab "sv)), "Ab "sv);
+
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full("foo bar baz"sv)), "Foo Bar Baz"sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full("foo \n \r bar \t baz"sv)), "Foo \n \r Bar \t Baz"sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full("f\"oo\" b'ar'"sv)), "F\"Oo\" B'Ar'"sv);
+    EXPECT_EQ(MUST(Unicode::to_unicode_titlecase_full("123dollars"sv)), "123Dollars"sv);
 }
 
 TEST_CASE(to_unicode_lowercase_unconditional_special_casing)
@@ -380,6 +401,78 @@ TEST_CASE(to_unicode_uppercase_special_casing_soft_dotted)
 
     result = MUST(Unicode::to_unicode_uppercase_full("j\u0307"sv, "lt"sv));
     EXPECT_EQ(result, "J"sv);
+}
+
+TEST_CASE(to_unicode_titlecase_unconditional_special_casing)
+{
+    // LATIN SMALL LETTER SHARP S
+    auto result = MUST(Unicode::to_unicode_titlecase_full("\u00DF"sv));
+    EXPECT_EQ(result, "\u0053\u0073"sv);
+
+    // LATIN CAPITAL LETTER I WITH DOT ABOVE
+    result = MUST(Unicode::to_unicode_titlecase_full("\u0130"sv));
+    EXPECT_EQ(result, "\u0130"sv);
+
+    // LATIN SMALL LIGATURE FF
+    result = MUST(Unicode::to_unicode_titlecase_full("\uFB00"sv));
+    EXPECT_EQ(result, "\u0046\u0066"sv);
+
+    // LATIN SMALL LIGATURE FI
+    result = MUST(Unicode::to_unicode_titlecase_full("\uFB01"sv));
+    EXPECT_EQ(result, "\u0046\u0069"sv);
+
+    // LATIN SMALL LIGATURE FL
+    result = MUST(Unicode::to_unicode_titlecase_full("\uFB02"sv));
+    EXPECT_EQ(result, "\u0046\u006C"sv);
+
+    // LATIN SMALL LIGATURE FFI
+    result = MUST(Unicode::to_unicode_titlecase_full("\uFB03"sv));
+    EXPECT_EQ(result, "\u0046\u0066\u0069"sv);
+
+    // LATIN SMALL LIGATURE FFL
+    result = MUST(Unicode::to_unicode_titlecase_full("\uFB04"sv));
+    EXPECT_EQ(result, "\u0046\u0066\u006C"sv);
+
+    // LATIN SMALL LIGATURE LONG S T
+    result = MUST(Unicode::to_unicode_titlecase_full("\uFB05"sv));
+    EXPECT_EQ(result, "\u0053\u0074"sv);
+
+    // LATIN SMALL LIGATURE ST
+    result = MUST(Unicode::to_unicode_titlecase_full("\uFB06"sv));
+    EXPECT_EQ(result, "\u0053\u0074"sv);
+
+    // GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS
+    result = MUST(Unicode::to_unicode_titlecase_full("\u0390"sv));
+    EXPECT_EQ(result, "\u0399\u0308\u0301"sv);
+
+    // GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS
+    result = MUST(Unicode::to_unicode_titlecase_full("\u03B0"sv));
+    EXPECT_EQ(result, "\u03A5\u0308\u0301"sv);
+
+    // GREEK SMALL LETTER ALPHA WITH PERISPOMENI AND YPOGEGRAMMENI
+    result = MUST(Unicode::to_unicode_titlecase_full("\u1FB7"sv));
+    EXPECT_EQ(result, "\u0391\u0342\u0345"sv);
+
+    // GREEK SMALL LETTER ETA WITH PERISPOMENI AND YPOGEGRAMMENI
+    result = MUST(Unicode::to_unicode_titlecase_full("\u1FC7"sv));
+    EXPECT_EQ(result, "\u0397\u0342\u0345"sv);
+
+    // GREEK SMALL LETTER OMEGA WITH PERISPOMENI AND YPOGEGRAMMENI
+    result = MUST(Unicode::to_unicode_titlecase_full("\u1FF7"sv));
+    EXPECT_EQ(result, "\u03A9\u0342\u0345"sv);
+}
+
+TEST_CASE(to_unicode_titlecase_special_casing_i)
+{
+    // LATIN SMALL LETTER I
+    auto result = MUST(Unicode::to_unicode_titlecase_full("i"sv, "en"sv));
+    EXPECT_EQ(result, "I"sv);
+
+    result = MUST(Unicode::to_unicode_titlecase_full("i"sv, "az"sv));
+    EXPECT_EQ(result, "\u0130"sv);
+
+    result = MUST(Unicode::to_unicode_titlecase_full("i"sv, "tr"sv));
+    EXPECT_EQ(result, "\u0130"sv);
 }
 
 TEST_CASE(general_category)

--- a/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
+++ b/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
@@ -48,6 +48,32 @@ TEST_CASE(to_unicode_uppercase)
     EXPECT_EQ(Unicode::to_unicode_uppercase(0x3401u), 0x3401u);
     EXPECT_EQ(Unicode::to_unicode_uppercase(0x3402u), 0x3402u);
     EXPECT_EQ(Unicode::to_unicode_uppercase(0x4dbfu), 0x4dbfu);
+
+    // Code points whose uppercase and titlecase mappings actually differ.
+    EXPECT_EQ(Unicode::to_unicode_uppercase(0x01c6u), 0x01c4u); // "ǆ" to "Ǆ"
+    EXPECT_EQ(Unicode::to_unicode_uppercase(0x01c9u), 0x01c7u); // "ǉ" to "Ǉ"
+    EXPECT_EQ(Unicode::to_unicode_uppercase(0x01ccu), 0x01cau); // "ǌ" to "Ǌ"
+    EXPECT_EQ(Unicode::to_unicode_uppercase(0x01f3u), 0x01f1u); // "ǳ" to "Ǳ"
+}
+
+TEST_CASE(to_unicode_titlecase)
+{
+    compare_to_ascii(toupper, Unicode::to_unicode_titlecase);
+
+    EXPECT_EQ(Unicode::to_unicode_titlecase(0x03c9u), 0x03a9u); // "ω" to "Ω"
+    EXPECT_EQ(Unicode::to_unicode_titlecase(0x03a9u), 0x03a9u); // "Ω" to "Ω"
+
+    // Code points encoded by ranges in UnicodeData.txt
+    EXPECT_EQ(Unicode::to_unicode_titlecase(0x3400u), 0x3400u);
+    EXPECT_EQ(Unicode::to_unicode_titlecase(0x3401u), 0x3401u);
+    EXPECT_EQ(Unicode::to_unicode_titlecase(0x3402u), 0x3402u);
+    EXPECT_EQ(Unicode::to_unicode_titlecase(0x4dbfu), 0x4dbfu);
+
+    // Code points whose uppercase and titlecase mappings actually differ.
+    EXPECT_EQ(Unicode::to_unicode_titlecase(0x01c6u), 0x01c5u); // "ǆ" to "ǅ"
+    EXPECT_EQ(Unicode::to_unicode_titlecase(0x01c9u), 0x01c8u); // "ǉ" to "ǈ"
+    EXPECT_EQ(Unicode::to_unicode_titlecase(0x01ccu), 0x01cbu); // "ǌ" to "ǋ"
+    EXPECT_EQ(Unicode::to_unicode_titlecase(0x01f3u), 0x01f2u); // "ǳ" to "ǲ"
 }
 
 TEST_CASE(to_unicode_lowercase_unconditional_special_casing)

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -38,6 +38,11 @@ u32 __attribute__((weak)) to_unicode_uppercase(u32 code_point)
     return to_ascii_uppercase(code_point);
 }
 
+u32 __attribute__((weak)) to_unicode_titlecase(u32 code_point)
+{
+    return to_ascii_uppercase(code_point);
+}
+
 ErrorOr<DeprecatedString> to_unicode_lowercase_full(StringView string, Optional<StringView> const& locale)
 {
     StringBuilder builder;

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -57,6 +57,13 @@ ErrorOr<DeprecatedString> to_unicode_uppercase_full(StringView string, Optional<
     return builder.to_deprecated_string();
 }
 
+ErrorOr<String> to_unicode_titlecase_full(StringView string, Optional<StringView> const& locale)
+{
+    StringBuilder builder;
+    TRY(Detail::build_titlecase_string(Utf8View { string }, builder, locale));
+    return builder.to_string();
+}
+
 Optional<GeneralCategory> __attribute__((weak)) general_category_from_string(StringView) { return {}; }
 bool __attribute__((weak)) code_point_has_general_category(u32, GeneralCategory) { return {}; }
 Optional<Property> __attribute__((weak)) property_from_string(StringView) { return {}; }

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -11,6 +11,7 @@
 #include <AK/Optional.h>
 #include <AK/Span.h>
 #include <AK/Types.h>
+#include <AK/Vector.h>
 #include <LibUnicode/Forward.h>
 
 namespace Unicode {
@@ -60,6 +61,7 @@ bool code_point_has_word_break_property(u32 code_point, WordBreakProperty proper
 bool code_point_has_sentence_break_property(u32 code_point, SentenceBreakProperty property);
 
 Vector<size_t> find_grapheme_segmentation_boundaries(Utf16View const&);
+Vector<size_t> find_word_segmentation_boundaries(Utf8View const&);
 Vector<size_t> find_word_segmentation_boundaries(Utf16View const&);
 Vector<size_t> find_sentence_segmentation_boundaries(Utf16View const&);
 

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -38,6 +38,7 @@ u32 canonical_combining_class(u32 code_point);
 // Use the full-string transformations for full case folding.
 u32 to_unicode_lowercase(u32 code_point);
 u32 to_unicode_uppercase(u32 code_point);
+u32 to_unicode_titlecase(u32 code_point);
 
 ErrorOr<DeprecatedString> to_unicode_lowercase_full(StringView, Optional<StringView> const& locale = {});
 ErrorOr<DeprecatedString> to_unicode_uppercase_full(StringView, Optional<StringView> const& locale = {});

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -10,6 +10,7 @@
 #include <AK/Forward.h>
 #include <AK/Optional.h>
 #include <AK/Span.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <LibUnicode/Forward.h>
@@ -42,6 +43,7 @@ u32 to_unicode_titlecase(u32 code_point);
 
 ErrorOr<DeprecatedString> to_unicode_lowercase_full(StringView, Optional<StringView> const& locale = {});
 ErrorOr<DeprecatedString> to_unicode_uppercase_full(StringView, Optional<StringView> const& locale = {});
+ErrorOr<String> to_unicode_titlecase_full(StringView, Optional<StringView> const& locale = {});
 
 Optional<GeneralCategory> general_category_from_string(StringView);
 bool code_point_has_general_category(u32 code_point, GeneralCategory general_category);

--- a/Userland/Libraries/LibUnicode/String.cpp
+++ b/Userland/Libraries/LibUnicode/String.cpp
@@ -26,4 +26,11 @@ ErrorOr<String> String::to_uppercase(Optional<StringView> const& locale) const
     return builder.to_string();
 }
 
+ErrorOr<String> String::to_titlecase(Optional<StringView> const& locale) const
+{
+    StringBuilder builder;
+    TRY(Unicode::Detail::build_titlecase_string(code_points(), builder, locale));
+    return builder.to_string();
+}
+
 }

--- a/Userland/Libraries/LibUnicode/UnicodeUtils.h
+++ b/Userland/Libraries/LibUnicode/UnicodeUtils.h
@@ -16,5 +16,6 @@ namespace Unicode::Detail {
 
 ErrorOr<void> build_lowercase_string(Utf8View code_points, StringBuilder& builder, Optional<StringView> const& locale);
 ErrorOr<void> build_uppercase_string(Utf8View code_points, StringBuilder& builder, Optional<StringView> const& locale);
+ErrorOr<void> build_titlecase_string(Utf8View code_points, StringBuilder& builder, Optional<StringView> const& locale);
 
 }


### PR DESCRIPTION
This will be needed for some `String` porting. The current titlecase implementation on `StringView` is quite naive; this implementation is based on UCD data and the Unicode spec.