### PR TITLE
LibWeb+LibGfx: Implement paint styles and all canvas gradients! 

### DIFF
--- a/Base/res/html/misc/canvas-gradients.html
+++ b/Base/res/html/misc/canvas-gradients.html
@@ -1,0 +1,138 @@
+
+<h1>Canvas Gradients</h1>
+<h2>Radial Gradients</h2>
+<em>MDN example</em><br>
+<canvas id="mdnRadial" width="200" height="200"></canvas>
+<h3>Interactive Radial Gradients (mouse over)</h3>
+<hr>
+<em>A radial gradient</em><br>
+<canvas id="radialHell1" width="400" height="300"></canvas>
+<br>
+<hr>
+<em>An inverted radial gradient (start circle larger than end circle)</em><br>
+<canvas id="radialHell2" width="400" height="300"></canvas>
+
+<h2>Conic Gradients</h2>
+<canvas id="conic" width="200" height="200"></canvas>
+<h2>Linear Gradients</h2>
+<em>This time in a path to spice things up!</em><br>
+<canvas id="linear" width="200" height="200"></canvas>
+
+<script>
+{
+  // MDN radial gradient example
+  const canvas = document.getElementById("mdnRadial");
+  const ctx = canvas.getContext("2d");
+
+  const gradient = ctx.createRadialGradient(110, 90, 30, 100, 100, 70);
+
+  gradient.addColorStop(0, "pink");
+  gradient.addColorStop(0.9, "white");
+  gradient.addColorStop(1, "green");
+
+  ctx.fillStyle = gradient;
+  ctx.fillRect(20, 20, 160, 160);
+}
+</script>
+
+<script>
+// Interactive radial gradients... The MacDue debugging experience live!
+
+const makeMouseDemo = (canvasId, body) => {
+  const canvas = document.getElementById(canvasId);
+  const ctx = canvas.getContext("2d");
+  const mouse = { x: 0, y: 0 };
+  let lastMouse = mouse;
+  const mouseEvent = (e) => { mouse.x = e.offsetX; mouse.y = e.offsetY }
+  canvas.addEventListener("mousemove", mouseEvent);
+  body(canvas, ctx, canvas.width/2, canvas.height/2);
+  const loop = () => {
+    if (mouse.x != lastMouse.x || mouse.y != lastMouse.y)
+      body(canvas, ctx, mouse.x, mouse.y);
+    lastMouse = { ...mouse };
+    requestAnimationFrame(loop);
+  };
+  requestAnimationFrame(loop);
+}
+
+makeMouseDemo("radialHell1", (canvas, ctx, mX, mY) => {
+  var grd = ctx.createRadialGradient(mX, mY, 10, canvas.width/2, canvas.height/2, 100);
+  grd.addColorStop(0, "red");
+  grd.addColorStop(0.4, "purple");
+  grd.addColorStop(1, "cyan");
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = grd;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+})
+
+makeMouseDemo("radialHell2", (canvas, ctx, mX, mY) => {
+  var grd = ctx.createRadialGradient(mX, mY, 100, canvas.width/2, canvas.height/2, 10);
+  grd.addColorStop(0, "pink");
+  grd.addColorStop(0.6, "blue");
+  grd.addColorStop(1, "orange");
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = grd;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+})
+</script>
+<script>
+{
+  const canvas = document.getElementById("conic");
+  const ctx = canvas.getContext("2d");
+
+  const gradient = ctx.createConicGradient(0, 100, 100);
+
+  gradient.addColorStop(0, "red");
+  gradient.addColorStop(0.25, "orange");
+  gradient.addColorStop(0.5, "yellow");
+  gradient.addColorStop(0.75, "green");
+  gradient.addColorStop(1, "blue");
+
+  ctx.fillStyle = gradient;
+  ctx.fillRect(20, 20, 200, 200);
+}
+</script>
+<script>
+{
+  const canvas = document.getElementById("linear");
+  const ctx = canvas.getContext("2d");
+
+  const gradient = ctx.createLinearGradient(20, 20, 220, 120);
+  ctx.createLinearGradient(0,0,200,50);
+  gradient.addColorStop(0,"red");
+  gradient.addColorStop(0.15,"yellow");
+  gradient.addColorStop(0.3,"green");
+  gradient.addColorStop(0.45,"aqua");
+  gradient.addColorStop(0.6,"blue");
+  gradient.addColorStop(0.7,"fuchsia");
+  gradient.addColorStop(1,"red");
+
+  ctx.fillStyle = gradient;
+
+  const starPath = (cx, cy, spikes, outerRadius, innerRadius) => {
+    let x = cx;
+    let y = cy;
+    let rot = Math.PI / 2 * 3;
+    const step = Math.PI / spikes;
+
+    ctx.beginPath();
+    ctx.moveTo(cx, cy - outerRadius)
+    for (i = 0; i < spikes; i++) {
+      x = cx + Math.cos(rot) * outerRadius;
+      y = cy + Math.sin(rot) * outerRadius;
+      ctx.lineTo(x, y)
+      rot += step
+
+      x = cx + Math.cos(rot) * innerRadius;
+      y = cy + Math.sin(rot) * innerRadius;
+      ctx.lineTo(x, y)
+      rot += step
+    }
+    ctx.lineTo(cx, cy - outerRadius);
+    ctx.closePath();
+  }
+
+  starPath(canvas.width/2,canvas.height/2,5,100,60);
+  ctx.fill();
+}
+</script>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -185,6 +185,7 @@
             <li><a href="exceptions.html">Exceptions</a></li>
             <li><h3>Canvas</h3></li>
             <li><a href="canvas.html">canvas 2D test</a></li>
+            <li><a href="canvas-gradients.html">canvas gradients!</a></li>
             <li><a href="canvas-rotate.html">canvas rotate()</a></li>
             <li><a href="canvas-path-rect.html">canvas path rect test</a></li>
             <li><a href="canvas-path-quadratic-curve.html">canvas path quadratic curve test</a></li>

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -27,6 +27,7 @@ static bool is_platform_object(Type const& type)
         "AbortSignal"sv,
         "Attr"sv,
         "Blob"sv,
+        "CanvasGradient"sv,
         "CanvasRenderingContext2D"sv,
         "Document"sv,
         "DocumentType"sv,

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -50,11 +50,6 @@ void AntiAliasingPainter::draw_anti_aliased_line(FloatPoint actual_from, FloatPo
     // Axis-aligned lines:
     if (mapped_from.y() == mapped_to.y()) {
         auto start_point = (mapped_from.x() < mapped_to.x() ? mapped_from : mapped_to).translated(0, -int_thickness / 2);
-        if constexpr (path_hacks == FixmeEnableHacksForBetterPathPainting::Yes) {
-            // FIXME: SVG fill_path() hack:
-            // SVG asks for 1px scanlines at floating point y values, if they're not snapped to a pixel they look faint.
-            start_point.set_y(floorf(start_point.y()));
-        }
         return fill_rect(Gfx::FloatRect(start_point, { length, thickness }), color);
     }
     if (mapped_from.x() == mapped_to.x()) {
@@ -213,9 +208,20 @@ void AntiAliasingPainter::draw_line(FloatPoint actual_from, FloatPoint actual_to
     draw_anti_aliased_line<FixmeEnableHacksForBetterPathPainting::No>(actual_from, actual_to, color, thickness, style, alternate_color, line_length_mode);
 }
 
-void AntiAliasingPainter::fill_path(Path& path, Color color, Painter::WindingRule rule)
+// FIXME: In the fill_paths() m_transform.translation() throws away any other transforms
+// this currently does not matter -- but may in future.
+
+void AntiAliasingPainter::fill_path(Path const& path, Color color, Painter::WindingRule rule)
 {
-    Detail::fill_path<Detail::FillPathMode::AllowFloatingPoints>(*this, path, color, rule);
+    Detail::fill_path<Detail::FillPathMode::AllowFloatingPoints>(
+        m_underlying_painter, path, [=](IntPoint) { return color; }, rule, m_transform.translation());
+}
+
+void AntiAliasingPainter::fill_path(Path const& path, PaintStyle const& paint_style, Painter::WindingRule rule)
+{
+    paint_style.paint(enclosing_int_rect(path.bounding_box()), [&](PaintStyle::SamplerFunction sampler) {
+        Detail::fill_path<Detail::FillPathMode::AllowFloatingPoints>(m_underlying_painter, path, move(sampler), rule, m_transform.translation());
+    });
 }
 
 void AntiAliasingPainter::stroke_path(Path const& path, Color color, float thickness)

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -29,12 +29,10 @@ public:
     void draw_line(IntPoint, IntPoint, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid, Color alternate_color = Color::Transparent, LineLengthMode line_length_mode = LineLengthMode::PointToPoint);
     void draw_line(FloatPoint, FloatPoint, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid, Color alternate_color = Color::Transparent, LineLengthMode line_length_mode = LineLengthMode::PointToPoint);
     void draw_line_for_path(FloatPoint, FloatPoint, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid, Color alternate_color = Color::Transparent, LineLengthMode line_length_mode = LineLengthMode::PointToPoint);
-    void draw_line_for_fill_path(FloatPoint from, FloatPoint to, Color color, float thickness = 1)
-    {
-        draw_line_for_path(from, to, color, thickness, Painter::LineStyle::Solid, Color {}, LineLengthMode::Distance);
-    }
 
-    void fill_path(Path&, Color, Painter::WindingRule rule = Painter::WindingRule::Nonzero);
+    void fill_path(Path const&, Color, Painter::WindingRule rule = Painter::WindingRule::Nonzero);
+    void fill_path(Path const&, PaintStyle const& paint_style, Painter::WindingRule rule = Painter::WindingRule::Nonzero);
+
     void stroke_path(Path const&, Color, float thickness);
     void draw_quadratic_bezier_curve(FloatPoint control_point, FloatPoint, FloatPoint, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid);
     void draw_cubic_bezier_curve(FloatPoint control_point_0, FloatPoint control_point_1, FloatPoint, FloatPoint, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid);
@@ -74,6 +72,8 @@ public:
     };
 
     void fill_rect_with_rounded_corners(IntRect const&, Color, CornerRadius top_left, CornerRadius top_right, CornerRadius bottom_right, CornerRadius bottom_left, BlendMode blend_mode = BlendMode::Normal);
+
+    Gfx::Painter& underlying_painter() { return m_underlying_painter; }
 
 private:
     struct Range {

--- a/Userland/Libraries/LibGfx/Forward.h
+++ b/Userland/Libraries/LibGfx/Forward.h
@@ -24,6 +24,7 @@ struct FontPixelMetrics;
 template<typename T>
 class Line;
 
+class AntiAliasingPainter;
 class Painter;
 class Palette;
 class PaletteImpl;

--- a/Userland/Libraries/LibGfx/GradientPainting.cpp
+++ b/Userland/Libraries/LibGfx/GradientPainting.cpp
@@ -6,11 +6,13 @@
 
 #include <AK/Math.h>
 #include <LibGfx/Gradients.h>
+#include <LibGfx/PaintStyle.h>
 #include <LibGfx/Painter.h>
 
 #if defined(AK_COMPILER_GCC)
 #    pragma GCC optimize("O3")
 #endif
+
 namespace Gfx {
 
 // Note: This file implements the CSS gradients for LibWeb according to the spec.
@@ -43,9 +45,14 @@ static float color_stop_step(ColorStop const& previous_stop, ColorStop const& ne
     return c;
 }
 
+enum class UsePremultipliedAlpha {
+    Yes,
+    No
+};
+
 class GradientLine {
 public:
-    GradientLine(int gradient_length, Span<ColorStop const> color_stops, Optional<float> repeat_length)
+    GradientLine(int gradient_length, Span<ColorStop const> color_stops, Optional<float> repeat_length, UsePremultipliedAlpha use_premultiplied_alpha = UsePremultipliedAlpha::Yes)
         : m_repeating { repeat_length.has_value() }
         , m_start_offset { round_to<int>((m_repeating ? color_stops.first().position : 0.0f) * gradient_length) }
     {
@@ -55,16 +62,21 @@ public:
         // Note: color_count will be < gradient_length for repeating gradients.
         auto color_count = round_to<int>(repeat_length.value_or(1.0f) * necessary_length);
         m_gradient_line_colors.resize(color_count);
-        // Note: color.mixed_with() performs premultiplied alpha mixing when necessary as defined in:
-        // https://drafts.csswg.org/css-images/#coloring-gradient-line
+
+        auto color_blend = [&](Color a, Color b, float amount) {
+            // Note: color.mixed_with() performs premultiplied alpha mixing when necessary as defined in:
+            // https://drafts.csswg.org/css-images/#coloring-gradient-line
+            if (use_premultiplied_alpha == UsePremultipliedAlpha::Yes)
+                return a.mixed_with(b, amount);
+            return a.interpolate(b, amount);
+        };
+
         for (int loc = 0; loc < color_count; loc++) {
             auto relative_loc = float(loc + m_start_offset) / necessary_length;
-            Color gradient_color = color_stops[0].color.mixed_with(
-                color_stops[1].color,
+            Color gradient_color = color_blend(color_stops[0].color, color_stops[1].color,
                 color_stop_step(color_stops[0], color_stops[1], relative_loc));
             for (size_t i = 1; i < color_stops.size() - 1; i++) {
-                gradient_color = gradient_color.mixed_with(
-                    color_stops[i + 1].color,
+                gradient_color = color_blend(gradient_color, color_stops[i + 1].color,
                     color_stop_step(color_stops[i], color_stops[i + 1], relative_loc));
             }
             m_gradient_line_colors[loc] = gradient_color;
@@ -117,41 +129,59 @@ private:
     bool m_requires_blending = false;
 };
 
-void Painter::fill_rect_with_linear_gradient(IntRect const& rect, Span<ColorStop const> const& color_stops, float angle, Optional<float> repeat_length)
-{
-    auto a_rect = to_physical(rect);
-    if (a_rect.intersected(clip_rect() * scale()).is_empty())
-        return;
+template<typename TransformFunction>
+struct Gradient {
+    Gradient(GradientLine gradient_line, TransformFunction transform_function)
+        : m_gradient_line(move(gradient_line))
+        , m_transform_function(move(transform_function))
+    {
+    }
 
+    void paint(Painter& painter, IntRect rect)
+    {
+        m_gradient_line.paint_into_physical_rect(painter, rect, m_transform_function);
+    }
+
+    PaintStyle::SamplerFunction sample_function()
+    {
+        return [this](IntPoint point) {
+            return m_gradient_line.sample_color(m_transform_function(point.x(), point.y()));
+        };
+    }
+
+private:
+    GradientLine m_gradient_line;
+    TransformFunction m_transform_function;
+};
+
+static auto create_linear_gradient(IntRect const& physical_rect, Span<ColorStop const> const& color_stops, float angle, Optional<float> repeat_length)
+{
     float normalized_angle = normalized_gradient_angle_radians(angle);
     float sin_angle, cos_angle;
     AK::sincos(normalized_angle, sin_angle, cos_angle);
 
     // Full length of the gradient
-    auto gradient_length = calculate_gradient_length(a_rect.size(), sin_angle, cos_angle);
+    auto gradient_length = calculate_gradient_length(physical_rect.size(), sin_angle, cos_angle);
     IntPoint offset { cos_angle * (gradient_length / 2), sin_angle * (gradient_length / 2) };
-    auto center = a_rect.translated(-a_rect.location()).center();
+    auto center = physical_rect.translated(-physical_rect.location()).center();
     auto start_point = center - offset;
     // Rotate gradient line to be horizontal
     auto rotated_start_point_x = start_point.x() * cos_angle - start_point.y() * -sin_angle;
 
     GradientLine gradient_line(gradient_length, color_stops, repeat_length);
-    gradient_line.paint_into_physical_rect(*this, a_rect, [&](int x, int y) {
-        return (x * cos_angle - (a_rect.height() - y) * -sin_angle) - rotated_start_point_x;
-    });
+    return Gradient {
+        move(gradient_line),
+        [=](int x, int y) {
+            return (x * cos_angle - (physical_rect.height() - y) * -sin_angle) - rotated_start_point_x;
+        }
+    };
 }
 
-void Painter::fill_rect_with_conic_gradient(IntRect const& rect, Span<ColorStop const> const& color_stops, IntPoint center, float start_angle, Optional<float> repeat_length)
+static auto create_conic_gradient(Span<ColorStop const> const& color_stops, FloatPoint center_point, float start_angle, Optional<float> repeat_length, UsePremultipliedAlpha use_premultiplied_alpha = UsePremultipliedAlpha::Yes)
 {
-    auto a_rect = to_physical(rect);
-    if (a_rect.intersected(clip_rect() * scale()).is_empty())
-        return;
-
     // FIXME: Do we need/want sub-degree accuracy for the gradient line?
-    GradientLine gradient_line(360, color_stops, repeat_length);
+    GradientLine gradient_line(360, color_stops, repeat_length, use_premultiplied_alpha);
     float normalized_start_angle = (360.0f - start_angle) + 90.0f;
-    // Translate position/center to the center of the pixel (avoids some funky painting)
-    auto center_point = FloatPoint { center * scale() }.translated(0.5, 0.5);
     // The flooring can make gradients that want soft edges look worse, so only floor if we have hard edges.
     // Which makes sure the hard edge stay hard edges :^)
     bool should_floor_angles = false;
@@ -161,12 +191,59 @@ void Painter::fill_rect_with_conic_gradient(IntRect const& rect, Span<ColorStop 
             break;
         }
     }
-    gradient_line.paint_into_physical_rect(*this, a_rect, [&](int x, int y) {
-        auto point = FloatPoint { x, y } - center_point;
-        // FIXME: We could probably get away with some approximation here:
-        auto loc = fmod((AK::atan2(point.y(), point.x()) * 180.0f / AK::Pi<float> + 360.0f + normalized_start_angle), 360.0f);
-        return should_floor_angles ? floor(loc) : loc;
-    });
+    return Gradient {
+        move(gradient_line),
+        [=](int x, int y) {
+            auto point = FloatPoint { x, y } - center_point;
+            // FIXME: We could probably get away with some approximation here:
+            auto loc = fmod((AK::atan2(point.y(), point.x()) * 180.0f / AK::Pi<float> + 360.0f + normalized_start_angle), 360.0f);
+            return should_floor_angles ? floor(loc) : loc;
+        }
+    };
+}
+
+static auto create_radial_gradient(IntRect const& physical_rect, Span<ColorStop const> const& color_stops, IntPoint center, IntSize size, Optional<float> repeat_length)
+{
+    // A conservative guesstimate on how many colors we need to generate:
+    auto max_dimension = max(physical_rect.width(), physical_rect.height());
+    auto max_visible_gradient = max(max_dimension / 2, min(size.width(), max_dimension));
+    GradientLine gradient_line(max_visible_gradient, color_stops, repeat_length);
+    auto center_point = FloatPoint { center }.translated(0.5, 0.5);
+    return Gradient {
+        move(gradient_line),
+        [=](int x, int y) {
+            // FIXME: See if there's a more efficient calculation we do there :^)
+            auto point = FloatPoint(x, y) - center_point;
+            auto gradient_x = point.x() / size.width();
+            auto gradient_y = point.y() / size.height();
+            return AK::sqrt(gradient_x * gradient_x + gradient_y * gradient_y) * max_visible_gradient;
+        }
+    };
+}
+
+void Painter::fill_rect_with_linear_gradient(IntRect const& rect, Span<ColorStop const> const& color_stops, float angle, Optional<float> repeat_length)
+{
+    auto a_rect = to_physical(rect);
+    if (a_rect.intersected(clip_rect() * scale()).is_empty())
+        return;
+    auto linear_gradient = create_linear_gradient(a_rect, color_stops, angle, repeat_length);
+    linear_gradient.paint(*this, a_rect);
+}
+
+static FloatPoint pixel_center(IntPoint point)
+{
+    return point.to_type<float>().translated(0.5f, 0.5f);
+}
+
+void Painter::fill_rect_with_conic_gradient(IntRect const& rect, Span<ColorStop const> const& color_stops, IntPoint center, float start_angle, Optional<float> repeat_length)
+{
+    auto a_rect = to_physical(rect);
+    if (a_rect.intersected(clip_rect() * scale()).is_empty())
+        return;
+    // Translate position/center to the center of the pixel (avoids some funky painting)
+    auto center_point = pixel_center(center * scale());
+    auto conic_gradient = create_conic_gradient(color_stops, center_point, start_angle, repeat_length);
+    conic_gradient.paint(*this, a_rect);
 }
 
 void Painter::fill_rect_with_radial_gradient(IntRect const& rect, Span<ColorStop const> const& color_stops, IntPoint center, IntSize size, Optional<float> repeat_length)
@@ -174,19 +251,32 @@ void Painter::fill_rect_with_radial_gradient(IntRect const& rect, Span<ColorStop
     auto a_rect = to_physical(rect);
     if (a_rect.intersected(clip_rect() * scale()).is_empty())
         return;
+    auto radial_gradient = create_radial_gradient(a_rect, color_stops, center * scale(), size * scale(), repeat_length);
+    radial_gradient.paint(*this, a_rect);
+}
 
-    // A conservative guesstimate on how many colors we need to generate:
-    auto max_dimension = max(a_rect.width(), a_rect.height());
-    auto max_visible_gradient = max(max_dimension / 2, min(size.width(), max_dimension));
-    GradientLine gradient_line(max_visible_gradient, color_stops, repeat_length);
-    auto center_point = FloatPoint { center * scale() }.translated(0.5, 0.5);
-    gradient_line.paint_into_physical_rect(*this, a_rect, [&](int x, int y) {
-        // FIXME: See if there's a more efficient calculation we do there :^)
-        auto point = FloatPoint(x, y) - center_point;
-        auto gradient_x = point.x() / size.width();
-        auto gradient_y = point.y() / size.height();
-        return AK::sqrt(gradient_x * gradient_x + gradient_y * gradient_y) * max_visible_gradient;
-    });
+// TODO: Figure out how to handle scale() here... Not important while not supported by fill_path()
+
+void LinearGradientPaintStyle::paint(IntRect physical_bounding_box, PaintFunction paint) const
+{
+    VERIFY(color_stops().size() > 2);
+    auto linear_gradient = create_linear_gradient(physical_bounding_box, color_stops(), m_angle, repeat_length());
+    paint(linear_gradient.sample_function());
+}
+
+void ConicGradientPaintStyle::paint(IntRect physical_bounding_box, PaintFunction paint) const
+{
+    VERIFY(color_stops().size() > 2);
+    (void)physical_bounding_box;
+    auto conic_gradient = create_conic_gradient(color_stops(), pixel_center(m_center), m_start_angle, repeat_length());
+    paint(conic_gradient.sample_function());
+}
+
+void RadialGradientPaintStyle::paint(IntRect physical_bounding_box, PaintFunction paint) const
+{
+    VERIFY(color_stops().size() > 2);
+    auto radial_gradient = create_radial_gradient(physical_bounding_box, color_stops(), m_center, m_size, repeat_length());
+    paint(radial_gradient.sample_function());
 }
 
 }

--- a/Userland/Libraries/LibGfx/PaintStyle.h
+++ b/Userland/Libraries/LibGfx/PaintStyle.h
@@ -147,4 +147,72 @@ private:
     IntSize m_size;
 };
 
+// The following paint styles implement the gradients required for the HTML canvas.
+// These gradients are (unlike CSS ones) not relative to the painted shape, and do not
+// support premultiplied alpha.
+
+class CanvasLinearGradientPaintStyle final : public GradientPaintStyle {
+public:
+    static NonnullRefPtr<CanvasLinearGradientPaintStyle> create(FloatPoint p0, FloatPoint p1)
+    {
+        return adopt_ref(*new CanvasLinearGradientPaintStyle(p0, p1));
+    }
+
+private:
+    virtual void paint(IntRect physical_bounding_box, PaintFunction paint) const override;
+
+    CanvasLinearGradientPaintStyle(FloatPoint p0, FloatPoint p1)
+        : m_p0(p0)
+        , m_p1(p1)
+    {
+    }
+
+    FloatPoint m_p0;
+    FloatPoint m_p1;
+};
+
+class CanvasConicGradientPaintStyle final : public GradientPaintStyle {
+public:
+    static NonnullRefPtr<CanvasConicGradientPaintStyle> create(FloatPoint center, float start_angle = 0.0f)
+    {
+        return adopt_ref(*new CanvasConicGradientPaintStyle(center, start_angle));
+    }
+
+private:
+    virtual void paint(IntRect physical_bounding_box, PaintFunction paint) const override;
+
+    CanvasConicGradientPaintStyle(FloatPoint center, float start_angle)
+        : m_center(center)
+        , m_start_angle(start_angle)
+    {
+    }
+
+    FloatPoint m_center;
+    float m_start_angle { 0.0f };
+};
+
+class CanvasRadialGradientPaintStyle final : public GradientPaintStyle {
+public:
+    static NonnullRefPtr<CanvasRadialGradientPaintStyle> create(FloatPoint start_center, float start_radius, FloatPoint end_center, float end_radius)
+    {
+        return adopt_ref(*new CanvasRadialGradientPaintStyle(start_center, start_radius, end_center, end_radius));
+    }
+
+private:
+    virtual void paint(IntRect physical_bounding_box, PaintFunction paint) const override;
+
+    CanvasRadialGradientPaintStyle(FloatPoint start_center, float start_radius, FloatPoint end_center, float end_radius)
+        : m_start_center(start_center)
+        , m_start_radius(start_radius)
+        , m_end_center(end_center)
+        , m_end_radius(end_radius)
+    {
+    }
+
+    FloatPoint m_start_center;
+    float m_start_radius { 0.0f };
+    FloatPoint m_end_center;
+    float m_end_radius { 0.0f };
+};
+
 }

--- a/Userland/Libraries/LibGfx/PaintStyle.h
+++ b/Userland/Libraries/LibGfx/PaintStyle.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/QuickSort.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <AK/Vector.h>
+#include <LibGfx/Color.h>
+#include <LibGfx/Forward.h>
+#include <LibGfx/Gradients.h>
+#include <LibGfx/Rect.h>
+
+namespace Gfx {
+
+class PaintStyle : public RefCounted<PaintStyle> {
+public:
+    virtual ~PaintStyle() = default;
+    using SamplerFunction = Function<Color(IntPoint)>;
+    using PaintFunction = Function<void(SamplerFunction)>;
+
+    friend Painter;
+    friend AntiAliasingPainter;
+
+private:
+    // Simple paint styles can simply override sample_color() if they can easily generate a color from a coordinate.
+    virtual Color sample_color(IntPoint) const { return Color(); };
+
+    // Paint styles that have paint time dependent state (e.g. based on the paint size) may find it easier to override paint().
+    // If paint() is overridden sample_color() is unused.
+    virtual void paint(IntRect physical_bounding_box, PaintFunction paint) const
+    {
+        (void)physical_bounding_box;
+        paint([this](IntPoint point) { return sample_color(point); });
+    }
+};
+
+class SolidColorPaintStyle final : public PaintStyle {
+public:
+    static NonnullRefPtr<SolidColorPaintStyle> create(Color color)
+    {
+        return adopt_ref(*new SolidColorPaintStyle(color));
+    }
+
+    virtual Color sample_color(IntPoint) const override { return m_color; }
+
+private:
+    SolidColorPaintStyle(Color color)
+        : m_color(color)
+    {
+    }
+
+    Color m_color;
+};
+
+class GradientPaintStyle : public PaintStyle {
+public:
+    void add_color_stop(float position, Color color, Optional<float> transition_hint = {})
+    {
+        add_color_stop(ColorStop { color, position, transition_hint });
+    }
+
+    void add_color_stop(ColorStop stop, bool sort = true)
+    {
+        m_color_stops.append(stop);
+        if (sort)
+            quick_sort(m_color_stops, [](auto& a, auto& b) { return a.position < b.position; });
+    }
+
+    void set_repeat_length(float repeat_length)
+    {
+        m_repeat_length = repeat_length;
+    }
+
+    Span<ColorStop const> color_stops() const { return m_color_stops; }
+    Optional<float> repeat_length() const { return m_repeat_length; }
+
+private:
+    Vector<ColorStop, 4> m_color_stops;
+    Optional<float> m_repeat_length;
+};
+
+// These paint styles are based on the CSS gradients. They are relative to the painted
+// shape and support premultiplied alpha.
+
+class LinearGradientPaintStyle final : public GradientPaintStyle {
+public:
+    static NonnullRefPtr<LinearGradientPaintStyle> create(float angle = 0.0f)
+    {
+        return adopt_ref(*new LinearGradientPaintStyle(angle));
+    }
+
+private:
+    virtual void paint(IntRect physical_bounding_box, PaintFunction paint) const override;
+
+    LinearGradientPaintStyle(float angle)
+        : m_angle(angle)
+    {
+    }
+
+    float m_angle { 0.0f };
+};
+
+class ConicGradientPaintStyle final : public GradientPaintStyle {
+public:
+    static NonnullRefPtr<ConicGradientPaintStyle> create(IntPoint center, float start_angle = 0.0f)
+    {
+        return adopt_ref(*new ConicGradientPaintStyle(center, start_angle));
+    }
+
+private:
+    virtual void paint(IntRect physical_bounding_box, PaintFunction paint) const override;
+
+    ConicGradientPaintStyle(IntPoint center, float start_angle)
+        : m_center(center)
+        , m_start_angle(start_angle)
+    {
+    }
+
+    IntPoint m_center;
+    float m_start_angle { 0.0f };
+};
+
+class RadialGradientPaintStyle final : public GradientPaintStyle {
+public:
+    static NonnullRefPtr<RadialGradientPaintStyle> create(IntPoint center, IntSize size)
+    {
+        return adopt_ref(*new RadialGradientPaintStyle(center, size));
+    }
+
+private:
+    virtual void paint(IntRect physical_bounding_box, PaintFunction paint) const override;
+
+    RadialGradientPaintStyle(IntPoint center, IntSize size)
+        : m_center(center)
+        , m_size(size)
+    {
+    }
+
+    IntPoint m_center;
+    IntSize m_size;
+};
+
+}

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -151,6 +151,25 @@ void Painter::fill_rect(IntRect const& a_rect, Color color)
     fill_physical_rect(rect * scale(), color);
 }
 
+void Painter::fill_rect(IntRect const& rect, PaintStyle const& paint_style)
+{
+    auto a_rect = rect.translated(translation());
+    auto clipped_rect = a_rect.intersected(clip_rect());
+    if (clipped_rect.is_empty())
+        return;
+    a_rect *= scale();
+    clipped_rect *= scale();
+    auto start_offset = clipped_rect.location() - a_rect.location();
+    paint_style.paint(a_rect, [&](PaintStyle::SamplerFunction sample) {
+        for (int y = 0; y < clipped_rect.height(); ++y) {
+            for (int x = 0; x < clipped_rect.width(); ++x) {
+                IntPoint point(x, y);
+                set_physical_pixel(point + clipped_rect.location(), sample(point + start_offset), true);
+            }
+        }
+    });
+}
+
 void Painter::fill_rect_with_dither_pattern(IntRect const& a_rect, Color color_a, Color color_b)
 {
     VERIFY(scale() == 1); // FIXME: Add scaling support.

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2373,7 +2373,16 @@ void Painter::stroke_path(Path const& path, Color color, int thickness)
 void Painter::fill_path(Path const& path, Color color, WindingRule winding_rule)
 {
     VERIFY(scale() == 1); // FIXME: Add scaling support.
-    Detail::fill_path<Detail::FillPathMode::PlaceOnIntGrid>(*this, path, color, winding_rule);
+    Detail::fill_path<Detail::FillPathMode::PlaceOnIntGrid>(
+        *this, path, [=](IntPoint) { return color; }, winding_rule);
+}
+
+void Painter::fill_path(Path const& path, PaintStyle const& paint_style, Painter::WindingRule rule)
+{
+    VERIFY(scale() == 1); // FIXME: Add scaling support.
+    paint_style.paint(enclosing_int_rect(path.bounding_box()), [&](PaintStyle::SamplerFunction sampler) {
+        Detail::fill_path<Detail::FillPathMode::PlaceOnIntGrid>(*this, path, move(sampler), rule);
+    });
 }
 
 void Painter::blit_disabled(IntPoint location, Gfx::Bitmap const& bitmap, IntRect const& rect, Palette const& palette)

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -48,6 +48,7 @@ public:
 
     void clear_rect(IntRect const&, Color);
     void fill_rect(IntRect const&, Color);
+    void fill_rect(IntRect const&, PaintStyle const&);
     void fill_rect_with_dither_pattern(IntRect const&, Color, Color);
     void fill_rect_with_checkerboard(IntRect const&, IntSize, Color color_dark, Color color_light);
     void fill_rect_with_gradient(Orientation, IntRect const&, Color gradient_start, Color gradient_end);

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -14,6 +14,7 @@
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Gradients.h>
+#include <LibGfx/PaintStyle.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/Size.h>
@@ -21,6 +22,7 @@
 #include <LibGfx/TextDirection.h>
 #include <LibGfx/TextElision.h>
 #include <LibGfx/TextWrapping.h>
+
 namespace Gfx {
 
 class Painter {
@@ -138,6 +140,7 @@ public:
         EvenOdd,
     };
     void fill_path(Path const&, Color, WindingRule rule = WindingRule::Nonzero);
+    void fill_path(Path const&, PaintStyle const& paint_style, WindingRule rule = WindingRule::Nonzero);
 
     Font const& font() const
     {

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2020-2022, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2022, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,27 +20,39 @@ template<typename IncludingClass>
 class CanvasFillStrokeStyles {
 public:
     ~CanvasFillStrokeStyles() = default;
+    using FillOrStrokeStyleVariant = Variant<DeprecatedString, JS::Handle<CanvasGradient>>;
 
-    void set_fill_style(DeprecatedString style)
+    static CanvasState::FillOrStrokeStyle to_canvas_state_fill_or_stoke_style(auto const& style)
+    {
+        return style.visit(
+            [&](DeprecatedString const& string) -> CanvasState::FillOrStrokeStyle {
+                return Gfx::Color::from_string(string).value_or(Color::Black);
+            },
+            [&](JS::Handle<CanvasGradient> gradient) -> CanvasState::FillOrStrokeStyle {
+                return gradient;
+            });
+    }
+
+    void set_fill_style(FillOrStrokeStyleVariant style)
     {
         // FIXME: 2. If the given value is a CanvasPattern object that is marked as not origin-clean, then set this's origin-clean flag to false.
-        my_drawing_state().fill_style = Gfx::Color::from_string(style).value_or(Color::Black);
+        my_drawing_state().fill_style = to_canvas_state_fill_or_stoke_style(style);
     }
 
-    DeprecatedString fill_style() const
+    FillOrStrokeStyleVariant fill_style() const
     {
-        return my_drawing_state().fill_style.to_deprecated_string();
+        return my_drawing_state().fill_style.to_js_fill_or_stoke_style();
     }
 
-    void set_stroke_style(DeprecatedString style)
+    void set_stroke_style(FillOrStrokeStyleVariant style)
     {
         // FIXME: 2. If the given value is a CanvasPattern object that is marked as not origin-clean, then set this's origin-clean flag to false.
-        my_drawing_state().stroke_style = Gfx::Color::from_string(style).value_or(Color::Black);
+        my_drawing_state().stroke_style = to_canvas_state_fill_or_stoke_style(style);
     }
 
-    DeprecatedString stroke_style() const
+    FillOrStrokeStyleVariant stroke_style() const
     {
-        return my_drawing_state().stroke_style.to_deprecated_string();
+        return my_drawing_state().stroke_style.to_js_fill_or_stoke_style();
     }
 
     JS::NonnullGCPtr<CanvasGradient> create_radial_gradient(double x0, double y0, double r0, double x1, double y1, double r1)

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.idl
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.idl
@@ -3,9 +3,9 @@
 // https://html.spec.whatwg.org/multipage/canvas.html#canvasfillstrokestyles
 interface mixin CanvasFillStrokeStyles {
     // FIXME: Should be `(DOMString or CanvasGradient or CanvasPattern)`
-    attribute DOMString strokeStyle;
+    attribute (DOMString or CanvasGradient) strokeStyle;
     // FIXME: Should be `(DOMString or CanvasGradient or CanvasPattern)`
-    attribute DOMString fillStyle;
+    attribute (DOMString or CanvasGradient) fillStyle;
     CanvasGradient createLinearGradient(double x0, double y0, double x1, double y1);
     CanvasGradient createRadialGradient(double x0, double y0, double r0, double x1, double y1, double r1);
     CanvasGradient createConicGradient(double startAngle, double x, double y);

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021-2022, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -37,6 +38,23 @@ bool CanvasState::is_context_lost()
 {
     // The isContextLost() method steps are to return this's context lost.
     return m_context_lost;
+}
+
+NonnullRefPtr<Gfx::PaintStyle> CanvasState::FillOrStrokeStyle::to_gfx_paint_style()
+{
+    VERIFY_NOT_REACHED();
+}
+
+Gfx::Color CanvasState::FillOrStrokeStyle::to_color_but_fixme_should_accept_any_paint_style() const
+{
+    return as_color().value_or(Gfx::Color::Black);
+}
+
+Optional<Gfx::Color> CanvasState::FillOrStrokeStyle::as_color() const
+{
+    if (auto* color = m_fill_or_stoke_style.get_pointer<Gfx::Color>())
+        return *color;
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.cpp
@@ -42,7 +42,15 @@ bool CanvasState::is_context_lost()
 
 NonnullRefPtr<Gfx::PaintStyle> CanvasState::FillOrStrokeStyle::to_gfx_paint_style()
 {
-    VERIFY_NOT_REACHED();
+    return m_fill_or_stoke_style.visit(
+        [&](Gfx::Color color) -> NonnullRefPtr<Gfx::PaintStyle> {
+            if (!m_color_paint_style)
+                m_color_paint_style = Gfx::SolidColorPaintStyle::create(color);
+            return m_color_paint_style.release_nonnull();
+        },
+        [&](JS::Handle<CanvasGradient> gradient) {
+            return gradient->to_gfx_paint_style();
+        });
 }
 
 Gfx::Color CanvasState::FillOrStrokeStyle::to_color_but_fixme_should_accept_any_paint_style() const

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -1,14 +1,18 @@
 /*
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Color.h>
+#include <LibGfx/PaintStyle.h>
+#include <LibWeb/HTML/CanvasGradient.h>
 
 namespace Web::HTML {
 
@@ -22,11 +26,41 @@ public:
     void reset();
     bool is_context_lost();
 
+    using FillOrStrokeVariant = Variant<Gfx::Color, JS::Handle<CanvasGradient>>;
+
+    struct FillOrStrokeStyle {
+        FillOrStrokeStyle(Gfx::Color color)
+            : m_fill_or_stoke_style(color)
+        {
+        }
+
+        FillOrStrokeStyle(JS::Handle<CanvasGradient> gradient)
+            : m_fill_or_stoke_style(gradient)
+        {
+        }
+
+        NonnullRefPtr<Gfx::PaintStyle> to_gfx_paint_style();
+
+        Optional<Gfx::Color> as_color() const;
+        Gfx::Color to_color_but_fixme_should_accept_any_paint_style() const;
+
+        Variant<DeprecatedString, JS::Handle<CanvasGradient>> to_js_fill_or_stoke_style() const
+        {
+            if (auto* handle = m_fill_or_stoke_style.get_pointer<JS::Handle<CanvasGradient>>())
+                return *handle;
+            return m_fill_or_stoke_style.get<Gfx::Color>().to_deprecated_string();
+        }
+
+    private:
+        FillOrStrokeVariant m_fill_or_stoke_style;
+        RefPtr<Gfx::PaintStyle> m_color_fill_style { nullptr };
+    };
+
     // https://html.spec.whatwg.org/multipage/canvas.html#drawing-state
     struct DrawingState {
         Gfx::AffineTransform transform;
-        Gfx::Color fill_style { Gfx::Color::Black };
-        Gfx::Color stroke_style { Gfx::Color::Black };
+        FillOrStrokeStyle fill_style { Gfx::Color::Black };
+        FillOrStrokeStyle stroke_style { Gfx::Color::Black };
         float line_width { 1 };
     };
     DrawingState& drawing_state() { return m_drawing_state; }

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -53,7 +53,7 @@ public:
 
     private:
         FillOrStrokeVariant m_fill_or_stoke_style;
-        RefPtr<Gfx::PaintStyle> m_color_fill_style { nullptr };
+        RefPtr<Gfx::PaintStyle> m_color_paint_style { nullptr };
     };
 
     // https://html.spec.whatwg.org/multipage/canvas.html#drawing-state

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.h
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <LibGfx/Color.h>
+#include <LibGfx/PaintStyle.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 
 namespace Web::HTML {
@@ -15,12 +16,6 @@ class CanvasGradient final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(CanvasGradient, Bindings::PlatformObject);
 
 public:
-    enum class Type {
-        Linear,
-        Radial,
-        Conic,
-    };
-
     static JS::NonnullGCPtr<CanvasGradient> create_radial(JS::Realm&, double x0, double y0, double r0, double x1, double y1, double r1);
     static JS::NonnullGCPtr<CanvasGradient> create_linear(JS::Realm&, double x0, double y0, double x1, double y1);
     static JS::NonnullGCPtr<CanvasGradient> create_conic(JS::Realm&, double start_angle, double x, double y);
@@ -29,19 +24,14 @@ public:
 
     ~CanvasGradient();
 
+    NonnullRefPtr<Gfx::PaintStyle> to_gfx_paint_style() { return m_gradient; }
+
 private:
-    CanvasGradient(JS::Realm&, Type);
+    CanvasGradient(JS::Realm&, Gfx::GradientPaintStyle& gradient);
 
     virtual void initialize(JS::Realm&) override;
 
-    Type m_type {};
-
-    struct ColorStop {
-        double offset { 0 };
-        Gfx::Color color;
-    };
-
-    Vector<ColorStop> m_color_stops;
+    NonnullRefPtr<Gfx::GradientPaintStyle> m_gradient;
 };
 
 }


### PR DESCRIPTION
This PR implements paint styles in LibGfx which can be used for filling rects or paths (currently), then uses these to implement _all of_ the HTML5 Canvas gradients :^)

Currently, the paint styles can only be used to fill things, I've not yet got them working for strokes (which is may be a bit trickier).  

(This PR was a little bit of a yak hole as I made the classic blunder of assuming the canvas gradients were the same as the CSS ones...  They're not, but they were all easy, except the canvas radial gradient.. which was a bit of a pain).

**LibWeb:**

[screen-capture - 2023-01-16T234712.210.webm](https://user-images.githubusercontent.com/11597044/212781259-481c1552-b7c2-42e4-9dfe-fafaf9ec9bae.webm)

**Chrome (for context):**

[screen-capture - 2023-01-16T234844.448.webm](https://user-images.githubusercontent.com/11597044/212781423-c52ccbea-fc24-41b8-b04b-f117e912e480.webm)

You can see we render things the same (albeit a little slower :stuck_out_tongue:)
