### PR TITLE
LibWeb: Fix floats y offset calculation

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -770,7 +770,11 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
 
             if (fits_on_line) {
                 auto const previous_rect = margin_box_rect_in_ancestor_coordinate_space(previous_box.box, root(), m_state);
-                if (previous_rect.contains_vertically(y_in_root + side_data.y_offset)) {
+                // NOTE: If we're in inline layout, the LineBuilder has already provided the right Y offset.
+                //       In block layout, we adjust by the side's current Y offset here.
+                if (!line_builder)
+                    y_in_root += side_data.y_offset;
+                if (previous_rect.contains_vertically(y_in_root)) {
                     // This box touches another already floating box. Stack after others.
                     offset_from_edge = wanted_offset_from_edge;
                 } else {


### PR DESCRIPTION
There is a difference in y offset position calculation for floats when LineBuilder provides final y position while for blocks it needs to be adjusted by `y_offset`. This difference already accounted in floating box position calculation and this patch also makes it accounted in check whether a floating boxes on the same line intersect between each other.

Example that got fixed by this patch:
```html
<style>
.wrapper {
width: 400px;
}
.list-item {
width: 200px;
float: left;
}
</style>
<div class="wrapper">
    <div class="list-item a">Git Trees</div>
    <div class="list-item b">Documentation</div>
    <div class="list-item c">Kernel Mailing Lists</div>
    <div class="list-item d">Patchwork</div>
    <div class="list-item e">Mirrors</div>
    <div class="list-item f">Wikis</div>
</div>
```