### PR TITLE
LibWeb: Implement grid-template-areas and min/max-content

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -256,6 +256,36 @@ ErrorOr<String> String::vformatted(StringView fmtstr, TypeErasedFormatParams& pa
     return builder.to_string();
 }
 
+ErrorOr<Vector<String>> String::split(u32 separator, SplitBehavior split_behavior) const
+{
+    return split_limit(separator, 0, split_behavior);
+}
+
+ErrorOr<Vector<String>> String::split_limit(u32 separator, size_t limit, SplitBehavior split_behavior) const
+{
+    Vector<String> result;
+
+    if (is_empty())
+        return result;
+
+    bool keep_empty = has_flag(split_behavior, SplitBehavior::KeepEmpty);
+
+    size_t substring_start = 0;
+    for (auto it = code_points().begin(); it != code_points().end() && (result.size() + 1) != limit; ++it) {
+        u32 code_point = *it;
+        if (code_point == separator) {
+            size_t substring_length = code_points().iterator_offset(it) - substring_start;
+            if (substring_length != 0 || keep_empty)
+                TRY(result.try_append(TRY(substring_from_byte_offset_with_shared_superstring(substring_start, substring_length))));
+            substring_start = code_points().iterator_offset(it) + it.underlying_code_point_length_in_bytes();
+        }
+    }
+    size_t tail_length = code_points().byte_length() - substring_start;
+    if (tail_length != 0 || keep_empty)
+        TRY(result.try_append(TRY(substring_from_byte_offset_with_shared_superstring(substring_start, tail_length))));
+    return result;
+}
+
 bool String::operator==(String const& other) const
 {
     if (is_short_string())

--- a/AK/String.h
+++ b/AK/String.h
@@ -16,6 +16,7 @@
 #include <AK/StringView.h>
 #include <AK/Traits.h>
 #include <AK/Types.h>
+#include <AK/Vector.h>
 
 namespace AK {
 
@@ -71,6 +72,9 @@ public:
 
     ErrorOr<String> replace(StringView needle, StringView replacement, ReplaceMode replace_mode) const;
     ErrorOr<String> reverse() const;
+
+    [[nodiscard]] ErrorOr<Vector<String>> split_limit(u32 separator, size_t limit, SplitBehavior = SplitBehavior::Nothing) const;
+    [[nodiscard]] ErrorOr<Vector<String>> split(u32 separator, SplitBehavior = SplitBehavior::Nothing) const;
 
     [[nodiscard]] bool operator==(String const&) const;
     [[nodiscard]] bool operator!=(String const& other) const { return !(*this == other); }

--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -518,3 +518,73 @@ length value, and as a minimum two lengths with an auto. -->
     ">1</div>
     <div class="grid-item">1</div>
 </div>
+
+<p>Grid template areas basics</p>
+<div
+  class="grid-container"
+  style="
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      'left right-top'
+      'left right-bottom';
+  ">
+  <div style="background-color: lightpink; grid-area: right-bottom / right-bottom / right-bottom / right-bottom;">right-bottom</div>
+  <div style="background-color: lightgreen; grid-area: left;">left</div>
+  <div style="background-color: lightgrey; grid-column-end: right-top;">right-top</div>
+</div>
+
+<!-- Grid-lines vs. Grid template areas -->
+<p>There should be a left-aligned column taking up 1 / 3 of the grid</p>
+<div
+class="grid-container"
+  style="
+    grid-template-columns: [c] 1fr [b] 1fr [a] 1fr;
+    grid-template-areas: 'a b c';
+    ">
+  <div class="grid-item" style="grid-column-start: a; grid-column-end: a;">1fr</div>
+</div>
+
+<!-- Valid grid areas -->
+<p>Column taking up 50% width</p>
+<div
+class="grid-container"
+  style="
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-template-areas: 'one one three two' 'one one four two' 'one one four two';
+    ">
+  <div class="grid-item" style="grid-column-start: one; grid-column-end: one;">1fr</div>
+</div>
+
+<!-- Valid grid areas. This test should ideally fail differently FIXME -->
+<p>Left-aligned column taking up 25% width</p>
+<div
+class="grid-container"
+  style="
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-template-areas: 'one one three two' 'one one four one';
+    ">
+  <div class="grid-item" style="grid-column-start: two; grid-column-end: two;">1fr</div>
+</div>
+
+<!-- Valid grid areas. This test should ideally fail differently FIXME -->
+<p>Left-aligned column taking up 25% width</p>
+<div
+class="grid-container"
+  style="
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-template-areas: 'one one three two' 'one one four five' 'one one four two';
+    ">
+  <div class="grid-item" style="grid-column-start: two; grid-column-end: two;">1fr</div>
+</div>
+
+<p>Min-content / Max-content / 1fr column widths</p>
+<div
+class="grid-container"
+  style="
+    grid-template-columns: min-content max-content 1fr;
+    grid-template-areas: 'one two three';
+    ">
+  <div class="grid-item" style="grid-area: one; min-width: 25%; max-width: 50%;">min-content</div>
+  <div class="grid-item" style="grid-area: two;">max-content</div>
+  <div class="grid-item" style="grid-area: three;">1fr</div>
+</div>

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -178,3 +178,23 @@ TEST_CASE(is_one_of)
     EXPECT(bar.is_one_of("bar"sv, "foo"sv));
     EXPECT(bar.is_one_of("bar"sv));
 }
+
+TEST_CASE(split)
+{
+    {
+        auto test = MUST(String::from_utf8("foo bar baz"sv));
+        auto parts = MUST(test.split(' '));
+        EXPECT_EQ(parts.size(), 3u);
+        EXPECT_EQ(parts[0], "foo");
+        EXPECT_EQ(parts[1], "bar");
+        EXPECT_EQ(parts[2], "baz");
+    }
+    {
+        auto test = MUST(String::from_utf8("ωΣ2ωΣω"sv));
+        auto parts = MUST(test.split(0x03A3u));
+        EXPECT_EQ(parts.size(), 3u);
+        EXPECT_EQ(parts[0], "ω"sv);
+        EXPECT_EQ(parts[1], "2ω"sv);
+        EXPECT_EQ(parts[2], "ω"sv);
+    }
+}

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -73,6 +73,7 @@ public:
     static CSS::Size column_gap() { return CSS::Size::make_auto(); }
     static CSS::Size row_gap() { return CSS::Size::make_auto(); }
     static CSS::BorderCollapse border_collapse() { return CSS::BorderCollapse::Separate; }
+    static Vector<Vector<String>> grid_template_areas() { return {}; }
 };
 
 struct BackgroundLayerData {
@@ -194,6 +195,7 @@ public:
     CSS::Size const& column_gap() const { return m_noninherited.column_gap; }
     CSS::Size const& row_gap() const { return m_noninherited.row_gap; }
     CSS::BorderCollapse border_collapse() const { return m_noninherited.border_collapse; }
+    Vector<Vector<String>> const& grid_template_areas() const { return m_noninherited.grid_template_areas; }
 
     CSS::LengthBox const& inset() const { return m_noninherited.inset; }
     const CSS::LengthBox& margin() const { return m_noninherited.margin; }
@@ -319,6 +321,7 @@ protected:
         CSS::Size column_gap { InitialValues::column_gap() };
         CSS::Size row_gap { InitialValues::row_gap() };
         CSS::BorderCollapse border_collapse { InitialValues::border_collapse() };
+        Vector<Vector<String>> grid_template_areas { InitialValues::grid_template_areas() };
     } m_noninherited;
 };
 
@@ -400,6 +403,7 @@ public:
     void set_column_gap(CSS::Size const& column_gap) { m_noninherited.column_gap = column_gap; }
     void set_row_gap(CSS::Size const& row_gap) { m_noninherited.row_gap = row_gap; }
     void set_border_collapse(CSS::BorderCollapse const& border_collapse) { m_noninherited.border_collapse = border_collapse; }
+    void set_grid_template_areas(Vector<Vector<String>> const& grid_template_areas) { m_noninherited.grid_template_areas = grid_template_areas; }
 
     void set_fill(Color value) { m_inherited.fill = value; }
     void set_stroke(Color value) { m_inherited.stroke = value; }

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "GridTrackPlacement.h"
-#include <AK/DeprecatedString.h>
+#include <AK/StringBuilder.h>
 
 namespace Web::CSS {
 
@@ -15,14 +15,14 @@ GridTrackPlacement::GridTrackPlacement(int span_count_or_position, bool has_span
 {
 }
 
-GridTrackPlacement::GridTrackPlacement(DeprecatedString line_name, int span_count_or_position, bool has_span)
+GridTrackPlacement::GridTrackPlacement(String line_name, int span_count_or_position, bool has_span)
     : m_type(has_span ? Type::Span : Type::Position)
     , m_span_count_or_position(span_count_or_position)
     , m_line_name(line_name)
 {
 }
 
-GridTrackPlacement::GridTrackPlacement(DeprecatedString line_name, bool has_span)
+GridTrackPlacement::GridTrackPlacement(String line_name, bool has_span)
     : m_type(has_span ? Type::Span : Type::Position)
     , m_line_name(line_name)
 {

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/String.h>
 
 namespace Web::CSS {
@@ -19,9 +18,9 @@ public:
         Auto
     };
 
-    GridTrackPlacement(DeprecatedString line_name, int span_count_or_position, bool has_span = false);
+    GridTrackPlacement(String line_name, int span_count_or_position, bool has_span = false);
     GridTrackPlacement(int span_count_or_position, bool has_span = false);
-    GridTrackPlacement(DeprecatedString line_name, bool has_span = false);
+    GridTrackPlacement(String line_name, bool has_span = false);
     GridTrackPlacement();
 
     static GridTrackPlacement make_auto() { return GridTrackPlacement(); };
@@ -35,7 +34,7 @@ public:
 
     int raw_value() const { return m_span_count_or_position; }
     Type type() const { return m_type; }
-    DeprecatedString line_name() const { return m_line_name; }
+    String line_name() const { return m_line_name; }
 
     ErrorOr<String> to_string() const;
     bool operator==(GridTrackPlacement const& other) const
@@ -46,7 +45,7 @@ public:
 private:
     Type m_type;
     int m_span_count_or_position { 0 };
-    DeprecatedString m_line_name;
+    String m_line_name;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -33,6 +33,13 @@ GridSize::GridSize(float flexible_length)
 {
 }
 
+GridSize::GridSize(Type type)
+    : m_length { Length::make_auto() }
+{
+    VERIFY(type == Type::MinContent || type == Type::MaxContent);
+    m_type = type;
+}
+
 GridSize::GridSize()
     : m_length { Length::make_auto() }
 {
@@ -54,6 +61,10 @@ ErrorOr<String> GridSize::to_string() const
         return m_percentage.to_string();
     case Type::FlexibleLength:
         return String::formatted("{}fr", m_flexible_length);
+    case Type::MaxContent:
+        return String::from_utf8("max-content"sv);
+    case Type::MinContent:
+        return String::from_utf8("min-content"sv);
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -152,7 +152,7 @@ ErrorOr<String> ExplicitGridTrack::to_string() const
     }
 }
 
-GridTrackSizeList::GridTrackSizeList(Vector<CSS::ExplicitGridTrack> track_list, Vector<Vector<DeprecatedString>> line_names)
+GridTrackSizeList::GridTrackSizeList(Vector<CSS::ExplicitGridTrack> track_list, Vector<Vector<String>> line_names)
     : m_track_list(track_list)
     , m_line_names(line_names)
 {

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
@@ -92,13 +92,13 @@ private:
 
 class GridTrackSizeList {
 public:
-    GridTrackSizeList(Vector<CSS::ExplicitGridTrack> track_list, Vector<Vector<DeprecatedString>> line_names);
+    GridTrackSizeList(Vector<CSS::ExplicitGridTrack> track_list, Vector<Vector<String>> line_names);
     GridTrackSizeList();
 
     static GridTrackSizeList make_auto();
 
     Vector<CSS::ExplicitGridTrack> track_list() const { return m_track_list; }
-    Vector<Vector<DeprecatedString>> line_names() const { return m_line_names; }
+    Vector<Vector<String>> line_names() const { return m_line_names; }
 
     ErrorOr<String> to_string() const;
     bool operator==(GridTrackSizeList const& other) const
@@ -108,7 +108,7 @@ public:
 
 private:
     Vector<CSS::ExplicitGridTrack> m_track_list;
-    Vector<Vector<DeprecatedString>> m_line_names;
+    Vector<Vector<String>> m_line_names;
 };
 
 class GridRepeat {

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
@@ -18,12 +18,14 @@ public:
         Length,
         Percentage,
         FlexibleLength,
-        // TODO: Max-Content
+        MaxContent,
+        MinContent,
     };
 
     GridSize(Length);
     GridSize(Percentage);
     GridSize(float);
+    GridSize(Type);
     GridSize();
     ~GridSize();
 
@@ -34,17 +36,19 @@ public:
     bool is_length() const { return m_type == Type::Length; }
     bool is_percentage() const { return m_type == Type::Percentage; }
     bool is_flexible_length() const { return m_type == Type::FlexibleLength; }
+    bool is_max_content() const { return m_type == Type::MaxContent; }
+    bool is_min_content() const { return m_type == Type::MinContent; }
 
     Length length() const;
     Percentage percentage() const { return m_percentage; }
     float flexible_length() const { return m_flexible_length; }
 
-    // https://drafts.csswg.org/css-grid/#layout-algorithm
-    // Intrinsic sizing function - min-content, max-content, auto, fit-content()
+    // https://www.w3.org/TR/css-grid-2/#layout-algorithm
+    // An intrinsic sizing function (min-content, max-content, auto, fit-content()).
     // FIXME: Add missing properties once implemented.
     bool is_intrinsic_track_sizing() const
     {
-        return (m_type == Type::Length && m_length.is_auto());
+        return (m_type == Type::Length && m_length.is_auto()) || m_type == Type::MaxContent || m_type == Type::MinContent;
     }
 
     bool is_definite() const

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5934,6 +5934,10 @@ Optional<CSS::GridSize> Parser::parse_grid_size(ComponentValue const& component_
     }
     if (token.is(Token::Type::Ident) && token.ident().equals_ignoring_case("auto"sv))
         return GridSize::make_auto();
+    if (token.is(Token::Type::Ident) && token.ident().equals_ignoring_case("max-content"sv))
+        return GridSize(GridSize::Type::MaxContent);
+    if (token.is(Token::Type::Ident) && token.ident().equals_ignoring_case("min-content"sv))
+        return GridSize(GridSize::Type::MinContent);
     auto dimension = parse_dimension(token);
     if (!dimension.has_value())
         return {};

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -6292,6 +6292,22 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement_shorthand_value(Vector<Com
     return {};
 }
 
+RefPtr<StyleValue> Parser::parse_grid_template_areas_value(Vector<ComponentValue> const& component_values)
+{
+    Vector<Vector<String>> grid_area_rows;
+    for (auto& component_value : component_values) {
+        Vector<String> grid_area_columns;
+        if (component_value.is(Token::Type::String)) {
+            auto const parts = String::from_utf8(component_value.token().string()).release_value_but_fixme_should_propagate_errors().split(' ').release_value_but_fixme_should_propagate_errors();
+            for (auto& part : parts) {
+                grid_area_columns.append(part);
+            }
+        }
+        grid_area_rows.append(move(grid_area_columns));
+    }
+    return GridTemplateAreaStyleValue::create(grid_area_rows);
+}
+
 Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(PropertyID property_id, TokenStream<ComponentValue>& tokens)
 {
     auto function_contains_var_or_attr = [](Function const& function, auto&& recurse) -> bool {
@@ -6428,6 +6444,10 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
         return ParseError::SyntaxError;
     case PropertyID::GridColumn:
         if (auto parsed_value = parse_grid_track_placement_shorthand_value(component_values))
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
+    case PropertyID::GridTemplateAreas:
+        if (auto parsed_value = parse_grid_template_areas_value(component_values))
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::GridColumnEnd:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -315,6 +315,7 @@ private:
     RefPtr<StyleValue> parse_grid_track_sizes(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_placement(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_placement_shorthand_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_template_areas_value(Vector<ComponentValue> const&);
 
     // calc() parsing, according to https://www.w3.org/TR/css-values-3/#calc-syntax
     OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -316,6 +316,7 @@ private:
     RefPtr<StyleValue> parse_grid_track_placement(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_placement_shorthand_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_template_areas_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_area_shorthand_value(Vector<ComponentValue> const&);
 
     // calc() parsing, according to https://www.w3.org/TR/css-values-3/#calc-syntax
     OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -855,6 +855,16 @@
       "string"
     ]
   },
+  "grid-template-areas": {
+    "inherited": false,
+    "initial": "auto",
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "string"
+    ]
+  },
   "grid-template-columns": {
     "inherited": false,
     "initial": "auto",

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -740,6 +740,22 @@
       "column-gap"
     ]
   },
+  "grid-area": {
+    "inherited": false,
+    "initial": "auto",
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "string"
+    ],
+    "longhands": [
+      "grid-column-end",
+      "grid-column-start",
+      "grid-row-end",
+      "grid-row-start"
+    ]
+  },
   "grid-column": {
     "inherited": false,
     "initial": "auto",

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -332,6 +332,34 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_wrap()));
     case CSS::PropertyID::Float:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().float_()));
+    case CSS::PropertyID::GridArea: {
+        auto maybe_grid_row_start = property(CSS::PropertyID::GridRowStart);
+        auto maybe_grid_column_start = property(CSS::PropertyID::GridColumnStart);
+        auto maybe_grid_row_end = property(CSS::PropertyID::GridRowEnd);
+        auto maybe_grid_column_end = property(CSS::PropertyID::GridColumnEnd);
+        RefPtr<GridTrackPlacementStyleValue> grid_row_start, grid_column_start, grid_row_end, grid_column_end;
+        if (maybe_grid_row_start.has_value()) {
+            VERIFY(maybe_grid_row_start.value().value->is_grid_track_placement());
+            grid_row_start = maybe_grid_row_start.value().value->as_grid_track_placement();
+        }
+        if (maybe_grid_column_start.has_value()) {
+            VERIFY(maybe_grid_column_start.value().value->is_grid_track_placement());
+            grid_column_start = maybe_grid_column_start.value().value->as_grid_track_placement();
+        }
+        if (maybe_grid_row_end.has_value()) {
+            VERIFY(maybe_grid_row_end.value().value->is_grid_track_placement());
+            grid_row_end = maybe_grid_row_end.value().value->as_grid_track_placement();
+        }
+        if (maybe_grid_column_end.has_value()) {
+            VERIFY(maybe_grid_column_end.value().value->is_grid_track_placement());
+            grid_column_end = maybe_grid_column_end.value().value->as_grid_track_placement();
+        }
+        return GridAreaShorthandStyleValue::create(
+            grid_row_start.release_nonnull(),
+            grid_column_start.release_nonnull(),
+            grid_row_end.release_nonnull(),
+            grid_column_end.release_nonnull());
+    }
     case CSS::PropertyID::GridColumn: {
         auto maybe_grid_column_end = property(CSS::PropertyID::GridColumnEnd);
         auto maybe_grid_column_start = property(CSS::PropertyID::GridColumnStart);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -520,6 +520,22 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         return;
     }
 
+    if (property_id == CSS::PropertyID::GridArea) {
+        if (value.is_grid_area_shorthand()) {
+            auto const& shorthand = value.as_grid_area_shorthand();
+            style.set_property(CSS::PropertyID::GridRowStart, shorthand.row_start());
+            style.set_property(CSS::PropertyID::GridColumnStart, shorthand.column_start());
+            style.set_property(CSS::PropertyID::GridRowEnd, shorthand.row_end());
+            style.set_property(CSS::PropertyID::GridColumnEnd, shorthand.column_end());
+            return;
+        }
+        style.set_property(CSS::PropertyID::GridRowStart, value);
+        style.set_property(CSS::PropertyID::GridColumnStart, value);
+        style.set_property(CSS::PropertyID::GridRowEnd, value);
+        style.set_property(CSS::PropertyID::GridColumnEnd, value);
+        return;
+    }
+
     if (property_id == CSS::PropertyID::GridColumn) {
         if (value.is_grid_track_placement_shorthand()) {
             auto const& shorthand = value.as_grid_track_placement_shorthand();

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -743,4 +743,10 @@ Optional<CSS::BorderCollapse> StyleProperties::border_collapse() const
     return value_id_to_border_collapse(value->to_identifier());
 }
 
+Vector<Vector<String>> StyleProperties::grid_template_areas() const
+{
+    auto value = property(CSS::PropertyID::GridTemplateAreas);
+    return value->as_grid_template_area().grid_template_area();
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -749,4 +749,10 @@ Vector<Vector<String>> StyleProperties::grid_template_areas() const
     return value->as_grid_template_area().grid_template_area();
 }
 
+String StyleProperties::grid_area() const
+{
+    auto value = property(CSS::PropertyID::GridArea);
+    return value->as_string().to_string().release_value_but_fixme_should_propagate_errors();
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -91,6 +91,7 @@ public:
     CSS::GridTrackPlacement grid_row_end() const;
     CSS::GridTrackPlacement grid_row_start() const;
     Optional<CSS::BorderCollapse> border_collapse() const;
+    Vector<Vector<String>> grid_template_areas() const;
 
     Vector<CSS::Transformation> transformations() const;
     CSS::TransformOrigin transform_origin() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -92,6 +92,7 @@ public:
     CSS::GridTrackPlacement grid_row_start() const;
     Optional<CSS::BorderCollapse> border_collapse() const;
     Vector<Vector<String>> grid_template_areas() const;
+    String grid_area() const;
 
     Vector<CSS::Transformation> transformations() const;
     CSS::TransformOrigin transform_origin() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -140,6 +140,12 @@ GridTrackPlacementShorthandStyleValue const& StyleValue::as_grid_track_placement
     return static_cast<GridTrackPlacementShorthandStyleValue const&>(*this);
 }
 
+GridTemplateAreaStyleValue const& StyleValue::as_grid_template_area() const
+{
+    VERIFY(is_grid_template_area());
+    return static_cast<GridTemplateAreaStyleValue const&>(*this);
+}
+
 GridTrackPlacementStyleValue const& StyleValue::as_grid_track_placement() const
 {
     VERIFY(is_grid_track_placement());
@@ -1434,6 +1440,29 @@ bool GridTrackPlacementStyleValue::equals(StyleValue const& other) const
     return m_grid_track_placement == typed_other.grid_track_placement();
 }
 
+ErrorOr<String> GridTemplateAreaStyleValue::to_string() const
+{
+    StringBuilder builder;
+    for (size_t y = 0; y < m_grid_template_area.size(); ++y) {
+        for (size_t x = 0; x < m_grid_template_area[y].size(); ++x) {
+            builder.appendff("{}", m_grid_template_area[y][x]);
+            if (x < m_grid_template_area[y].size() - 1)
+                builder.append(" "sv);
+        }
+        if (y < m_grid_template_area.size() - 1)
+            builder.append(", "sv);
+    }
+    return builder.to_string();
+}
+
+bool GridTemplateAreaStyleValue::equals(StyleValue const& other) const
+{
+    if (type() != other.type())
+        return false;
+    auto const& typed_other = other.as_grid_template_area();
+    return m_grid_template_area == typed_other.grid_template_area();
+}
+
 ErrorOr<String> GridTrackSizeStyleValue::to_string() const
 {
     return m_grid_track_size_list.to_string();
@@ -2526,6 +2555,11 @@ NonnullRefPtr<ColorStyleValue> ColorStyleValue::create(Color color)
     }
 
     return adopt_ref(*new ColorStyleValue(color));
+}
+
+NonnullRefPtr<GridTemplateAreaStyleValue> GridTemplateAreaStyleValue::create(Vector<Vector<String>> grid_template_area)
+{
+    return adopt_ref(*new GridTemplateAreaStyleValue(grid_template_area));
 }
 
 NonnullRefPtr<GridTrackPlacementStyleValue> GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement grid_track_placement)

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -140,6 +140,12 @@ GridTrackPlacementShorthandStyleValue const& StyleValue::as_grid_track_placement
     return static_cast<GridTrackPlacementShorthandStyleValue const&>(*this);
 }
 
+GridAreaShorthandStyleValue const& StyleValue::as_grid_area_shorthand() const
+{
+    VERIFY(is_grid_area_shorthand());
+    return static_cast<GridAreaShorthandStyleValue const&>(*this);
+}
+
 GridTemplateAreaStyleValue const& StyleValue::as_grid_template_area() const
 {
     VERIFY(is_grid_template_area());
@@ -1425,6 +1431,31 @@ bool GridTrackPlacementShorthandStyleValue::equals(StyleValue const& other) cons
     auto const& typed_other = other.as_grid_track_placement_shorthand();
     return m_start->equals(typed_other.m_start)
         && m_end->equals(typed_other.m_end);
+}
+
+ErrorOr<String> GridAreaShorthandStyleValue::to_string() const
+{
+    StringBuilder builder;
+    if (!m_row_start->as_grid_track_placement().grid_track_placement().is_auto())
+        builder.appendff("{}", m_row_start->as_grid_track_placement().grid_track_placement().to_string().value());
+    if (!m_column_start->as_grid_track_placement().grid_track_placement().is_auto())
+        builder.appendff(" / {}", m_column_start->as_grid_track_placement().grid_track_placement().to_string().value());
+    if (!m_row_end->as_grid_track_placement().grid_track_placement().is_auto())
+        builder.appendff(" / {}", m_row_end->as_grid_track_placement().grid_track_placement().to_string().value());
+    if (!m_column_end->as_grid_track_placement().grid_track_placement().is_auto())
+        builder.appendff(" / {}", m_column_end->as_grid_track_placement().grid_track_placement().to_string().value());
+    return builder.to_string();
+}
+
+bool GridAreaShorthandStyleValue::equals(StyleValue const& other) const
+{
+    if (type() != other.type())
+        return false;
+    auto const& typed_other = other.as_grid_area_shorthand();
+    return m_row_start->equals(typed_other.m_row_start)
+        && m_column_start->equals(typed_other.m_column_start)
+        && m_row_end->equals(typed_other.m_row_end)
+        && m_column_end->equals(typed_other.m_column_end);
 }
 
 ErrorOr<String> GridTrackPlacementStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -228,6 +228,7 @@ public:
         FlexFlow,
         Font,
         Frequency,
+        GridAreaShorthand,
         GridTemplateArea,
         GridTrackPlacement,
         GridTrackPlacementShorthand,
@@ -276,6 +277,7 @@ public:
     bool is_flex_flow() const { return type() == Type::FlexFlow; }
     bool is_font() const { return type() == Type::Font; }
     bool is_frequency() const { return type() == Type::Frequency; }
+    bool is_grid_area_shorthand() const { return type() == Type::GridAreaShorthand; }
     bool is_grid_template_area() const { return type() == Type::GridTemplateArea; }
     bool is_grid_track_placement() const { return type() == Type::GridTrackPlacement; }
     bool is_grid_track_placement_shorthand() const { return type() == Type::GridTrackPlacementShorthand; }
@@ -322,6 +324,7 @@ public:
     FlexStyleValue const& as_flex() const;
     FontStyleValue const& as_font() const;
     FrequencyStyleValue const& as_frequency() const;
+    GridAreaShorthandStyleValue const& as_grid_area_shorthand() const;
     GridTemplateAreaStyleValue const& as_grid_template_area() const;
     GridTrackPlacementShorthandStyleValue const& as_grid_track_placement_shorthand() const;
     GridTrackPlacementStyleValue const& as_grid_track_placement() const;
@@ -366,6 +369,7 @@ public:
     FlexStyleValue& as_flex() { return const_cast<FlexStyleValue&>(const_cast<StyleValue const&>(*this).as_flex()); }
     FontStyleValue& as_font() { return const_cast<FontStyleValue&>(const_cast<StyleValue const&>(*this).as_font()); }
     FrequencyStyleValue& as_frequency() { return const_cast<FrequencyStyleValue&>(const_cast<StyleValue const&>(*this).as_frequency()); }
+    GridAreaShorthandStyleValue& as_grid_area_shorthand() { return const_cast<GridAreaShorthandStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_area_shorthand()); }
     GridTemplateAreaStyleValue& as_grid_template_area() { return const_cast<GridTemplateAreaStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_template_area()); }
     GridTrackPlacementShorthandStyleValue& as_grid_track_placement_shorthand() { return const_cast<GridTrackPlacementShorthandStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_track_placement_shorthand()); }
     GridTrackPlacementStyleValue& as_grid_track_placement() { return const_cast<GridTrackPlacementStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_track_placement()); }
@@ -1122,6 +1126,42 @@ private:
 
     NonnullRefPtr<GridTrackPlacementStyleValue> m_start;
     NonnullRefPtr<GridTrackPlacementStyleValue> m_end;
+};
+
+class GridAreaShorthandStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<GridAreaShorthandStyleValue> create(NonnullRefPtr<GridTrackPlacementStyleValue> row_start, NonnullRefPtr<GridTrackPlacementStyleValue> column_start, NonnullRefPtr<GridTrackPlacementStyleValue> row_end, NonnullRefPtr<GridTrackPlacementStyleValue> column_end)
+    {
+        return adopt_ref(*new GridAreaShorthandStyleValue(row_start, column_start, row_end, column_end));
+    }
+    static NonnullRefPtr<GridAreaShorthandStyleValue> create(GridTrackPlacement row_start, GridTrackPlacement column_start, GridTrackPlacement row_end, GridTrackPlacement column_end)
+    {
+        return adopt_ref(*new GridAreaShorthandStyleValue(GridTrackPlacementStyleValue::create(row_start), GridTrackPlacementStyleValue::create(column_start), GridTrackPlacementStyleValue::create(row_end), GridTrackPlacementStyleValue::create(column_end)));
+    }
+    virtual ~GridAreaShorthandStyleValue() override = default;
+
+    NonnullRefPtr<GridTrackPlacementStyleValue> row_start() const { return m_row_start; }
+    NonnullRefPtr<GridTrackPlacementStyleValue> column_start() const { return m_column_start; }
+    NonnullRefPtr<GridTrackPlacementStyleValue> row_end() const { return m_row_end; }
+    NonnullRefPtr<GridTrackPlacementStyleValue> column_end() const { return m_column_end; }
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual bool equals(StyleValue const& other) const override;
+
+private:
+    GridAreaShorthandStyleValue(NonnullRefPtr<GridTrackPlacementStyleValue> row_start, NonnullRefPtr<GridTrackPlacementStyleValue> column_start, NonnullRefPtr<GridTrackPlacementStyleValue> row_end, NonnullRefPtr<GridTrackPlacementStyleValue> column_end)
+        : StyleValue(Type::GridAreaShorthand)
+        , m_row_start(row_start)
+        , m_column_start(column_start)
+        , m_row_end(row_end)
+        , m_column_end(column_end)
+    {
+    }
+
+    NonnullRefPtr<GridTrackPlacementStyleValue> m_row_start;
+    NonnullRefPtr<GridTrackPlacementStyleValue> m_column_start;
+    NonnullRefPtr<GridTrackPlacementStyleValue> m_row_end;
+    NonnullRefPtr<GridTrackPlacementStyleValue> m_column_end;
 };
 
 class GridTrackSizeStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -228,6 +228,7 @@ public:
         FlexFlow,
         Font,
         Frequency,
+        GridTemplateArea,
         GridTrackPlacement,
         GridTrackPlacementShorthand,
         GridTrackSizeList,
@@ -275,6 +276,7 @@ public:
     bool is_flex_flow() const { return type() == Type::FlexFlow; }
     bool is_font() const { return type() == Type::Font; }
     bool is_frequency() const { return type() == Type::Frequency; }
+    bool is_grid_template_area() const { return type() == Type::GridTemplateArea; }
     bool is_grid_track_placement() const { return type() == Type::GridTrackPlacement; }
     bool is_grid_track_placement_shorthand() const { return type() == Type::GridTrackPlacementShorthand; }
     bool is_grid_track_size_list() const { return type() == Type::GridTrackSizeList; }
@@ -320,6 +322,7 @@ public:
     FlexStyleValue const& as_flex() const;
     FontStyleValue const& as_font() const;
     FrequencyStyleValue const& as_frequency() const;
+    GridTemplateAreaStyleValue const& as_grid_template_area() const;
     GridTrackPlacementShorthandStyleValue const& as_grid_track_placement_shorthand() const;
     GridTrackPlacementStyleValue const& as_grid_track_placement() const;
     GridTrackSizeStyleValue const& as_grid_track_size_list() const;
@@ -363,6 +366,7 @@ public:
     FlexStyleValue& as_flex() { return const_cast<FlexStyleValue&>(const_cast<StyleValue const&>(*this).as_flex()); }
     FontStyleValue& as_font() { return const_cast<FontStyleValue&>(const_cast<StyleValue const&>(*this).as_font()); }
     FrequencyStyleValue& as_frequency() { return const_cast<FrequencyStyleValue&>(const_cast<StyleValue const&>(*this).as_frequency()); }
+    GridTemplateAreaStyleValue& as_grid_template_area() { return const_cast<GridTemplateAreaStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_template_area()); }
     GridTrackPlacementShorthandStyleValue& as_grid_track_placement_shorthand() { return const_cast<GridTrackPlacementShorthandStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_track_placement_shorthand()); }
     GridTrackPlacementStyleValue& as_grid_track_placement() { return const_cast<GridTrackPlacementStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_track_placement()); }
     GridTrackSizeStyleValue& as_grid_track_size_list() { return const_cast<GridTrackSizeStyleValue&>(const_cast<StyleValue const&>(*this).as_grid_track_size_list()); }
@@ -1050,6 +1054,25 @@ private:
     }
 
     Frequency m_frequency;
+};
+
+class GridTemplateAreaStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<GridTemplateAreaStyleValue> create(Vector<Vector<String>> grid_template_area);
+    virtual ~GridTemplateAreaStyleValue() override = default;
+
+    Vector<Vector<String>> const& grid_template_area() const { return m_grid_template_area; }
+    virtual ErrorOr<String> to_string() const override;
+    virtual bool equals(StyleValue const& other) const override;
+
+private:
+    explicit GridTemplateAreaStyleValue(Vector<Vector<String>> grid_template_area)
+        : StyleValue(Type::GridTemplateArea)
+        , m_grid_template_area(grid_template_area)
+    {
+    }
+
+    Vector<Vector<String>> m_grid_template_area;
 };
 
 class GridTrackPlacementStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -65,6 +65,7 @@ class FrequencyStyleValue;
 class GridMinMax;
 class GridRepeat;
 class GridSize;
+class GridTemplateAreaStyleValue;
 class GridTrackPlacement;
 class GridTrackPlacementShorthandStyleValue;
 class GridTrackPlacementStyleValue;

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -62,6 +62,7 @@ class FontStyleValue;
 class Frequency;
 class FrequencyPercentage;
 class FrequencyStyleValue;
+class GridAreaShorthandStyleValue;
 class GridMinMax;
 class GridRepeat;
 class GridSize;

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1820,7 +1820,7 @@ CSSPixels GridFormattingContext::get_free_space_y(Box const& box)
     return -1;
 }
 
-int GridFormattingContext::get_line_index_by_line_name(DeprecatedString const& needle, CSS::GridTrackSizeList grid_track_size_list)
+int GridFormattingContext::get_line_index_by_line_name(String const& needle, CSS::GridTrackSizeList grid_track_size_list)
 {
     if (grid_track_size_list.track_list().size() == 0)
         return -1;

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -136,10 +136,10 @@ int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(Vector<CSS:
 
 void GridFormattingContext::place_item_with_row_and_column_position(Box const& box, Box const& child_box)
 {
-    int row_start = child_box.computed_values().grid_row_start().raw_value();
-    int row_end = child_box.computed_values().grid_row_end().raw_value();
-    int column_start = child_box.computed_values().grid_column_start().raw_value();
-    int column_end = child_box.computed_values().grid_column_end().raw_value();
+    int row_start = child_box.computed_values().grid_row_start().raw_value() - 1;
+    int row_end = child_box.computed_values().grid_row_end().raw_value() - 1;
+    int column_start = child_box.computed_values().grid_column_start().raw_value() - 1;
+    int column_end = child_box.computed_values().grid_column_end().raw_value() - 1;
 
     // https://www.w3.org/TR/css-grid-2/#line-placement
     // 8.3. Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
@@ -199,37 +199,37 @@ void GridFormattingContext::place_item_with_row_and_column_position(Box const& b
     if (child_box.computed_values().grid_column_start().has_line_name()) {
         auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_column_start().line_name(), box.computed_values().grid_template_columns());
         if (found_flag_and_index > -1)
-            column_start = 1 + found_flag_and_index;
+            column_start = found_flag_and_index;
         else
-            column_start = 1; // FIXME
+            column_start = 0;
     }
     if (child_box.computed_values().grid_column_end().has_line_name()) {
         auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_column_end().line_name(), box.computed_values().grid_template_columns());
         if (found_flag_and_index > -1) {
-            column_end = 1 + found_flag_and_index;
+            column_end = found_flag_and_index;
             if (!child_box.computed_values().grid_column_start().is_position())
                 column_start = column_end - column_span;
         } else {
-            column_end = 2;   // FIXME
-            column_start = 1; // FIXME
+            column_end = 1;
+            column_start = 0;
         }
     }
     if (child_box.computed_values().grid_row_start().has_line_name()) {
         auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_row_start().line_name(), box.computed_values().grid_template_rows());
         if (found_flag_and_index > -1)
-            row_start = 1 + found_flag_and_index;
+            row_start = found_flag_and_index;
         else
-            row_start = 1; // FIXME
+            row_start = 0;
     }
     if (child_box.computed_values().grid_row_end().has_line_name()) {
         auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_row_end().line_name(), box.computed_values().grid_template_rows());
         if (found_flag_and_index > -1) {
-            row_end = 1 + found_flag_and_index;
+            row_end = found_flag_and_index;
             if (!child_box.computed_values().grid_row_start().is_position())
                 row_start = row_end - row_span;
         } else {
-            row_end = 2;   // FIXME
-            row_start = 1; // FIXME
+            row_end = 1;
+            row_start = 0;
         }
     }
 
@@ -263,8 +263,6 @@ void GridFormattingContext::place_item_with_row_and_column_position(Box const& b
 
     // FIXME: If the placement contains only a span for a named line, replace it with a span of 1.
 
-    row_start -= 1;
-    column_start -= 1;
     m_positioned_boxes.append({ child_box, row_start, row_span, column_start, column_span });
 
     m_occupation_grid.maybe_add_row(row_start + 1);
@@ -274,8 +272,8 @@ void GridFormattingContext::place_item_with_row_and_column_position(Box const& b
 
 void GridFormattingContext::place_item_with_row_position(Box const& box, Box const& child_box)
 {
-    int row_start = child_box.computed_values().grid_row_start().raw_value();
-    int row_end = child_box.computed_values().grid_row_end().raw_value();
+    int row_start = child_box.computed_values().grid_row_start().raw_value() - 1;
+    int row_end = child_box.computed_values().grid_row_end().raw_value() - 1;
 
     // https://www.w3.org/TR/css-grid-2/#line-placement
     // 8.3. Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
@@ -310,7 +308,7 @@ void GridFormattingContext::place_item_with_row_position(Box const& box, Box con
         row_start = row_end - row_span;
         // FIXME: Remove me once have implemented spans overflowing into negative indexes, e.g., grid-row: span 2 / 1
         if (row_start < 0)
-            row_start = 1;
+            row_start = 0;
     }
 
     // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
@@ -329,19 +327,19 @@ void GridFormattingContext::place_item_with_row_position(Box const& box, Box con
     if (child_box.computed_values().grid_row_start().has_line_name()) {
         auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_row_start().line_name(), box.computed_values().grid_template_rows());
         if (found_flag_and_index > -1)
-            row_start = 1 + found_flag_and_index;
+            row_start = found_flag_and_index;
         else
-            row_start = 1; // FIXME
+            row_start = 0;
     }
     if (child_box.computed_values().grid_row_end().has_line_name()) {
         auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_row_end().line_name(), box.computed_values().grid_template_rows());
         if (found_flag_and_index > -1) {
-            row_end = 1 + found_flag_and_index;
+            row_end = found_flag_and_index;
             if (!child_box.computed_values().grid_row_start().is_position())
                 row_start = row_end - row_span;
         } else {
-            row_start = 1; // FIXME
-            row_end = 2;   // FIXME
+            row_start = 0;
+            row_end = 1;
         }
     }
 
@@ -360,8 +358,8 @@ void GridFormattingContext::place_item_with_row_position(Box const& box, Box con
             row_span = row_end - row_start;
     }
     // FIXME: Have yet to find the spec for this.
-    if (!child_box.computed_values().grid_row_start().is_position() && child_box.computed_values().grid_row_end().is_position() && row_end == 1)
-        row_start = 1;
+    if (!child_box.computed_values().grid_row_start().is_position() && child_box.computed_values().grid_row_end().is_position() && row_end == 0)
+        row_start = 0;
 
     // If the placement contains two spans, remove the one contributed by the end grid-placement
     // property.
@@ -370,7 +368,6 @@ void GridFormattingContext::place_item_with_row_position(Box const& box, Box con
 
     // FIXME: If the placement contains only a span for a named line, replace it with a span of 1.
 
-    row_start -= 1;
     m_occupation_grid.maybe_add_row(row_start + row_span);
 
     int column_start = 0;
@@ -400,8 +397,8 @@ void GridFormattingContext::place_item_with_row_position(Box const& box, Box con
 
 void GridFormattingContext::place_item_with_column_position(Box const& box, Box const& child_box, int& auto_placement_cursor_x, int& auto_placement_cursor_y)
 {
-    int column_start = child_box.computed_values().grid_column_start().raw_value();
-    int column_end = child_box.computed_values().grid_column_end().raw_value();
+    int column_start = child_box.computed_values().grid_column_start().raw_value() - 1;
+    int column_end = child_box.computed_values().grid_column_end().raw_value() - 1;
 
     // https://www.w3.org/TR/css-grid-2/#line-placement
     // 8.3. Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
@@ -437,11 +434,11 @@ void GridFormattingContext::place_item_with_column_position(Box const& box, Box 
         column_start = column_end - column_span;
         // FIXME: Remove me once have implemented spans overflowing into negative indexes, e.g., grid-column: span 2 / 1
         if (column_start < 0)
-            column_start = 1;
+            column_start = 0;
     }
     // FIXME: Have yet to find the spec for this.
-    if (!child_box.computed_values().grid_column_start().is_position() && child_box.computed_values().grid_column_end().is_position() && column_end == 1)
-        column_start = 1;
+    if (!child_box.computed_values().grid_column_start().is_position() && child_box.computed_values().grid_column_end().is_position() && column_end == 0)
+        column_start = 0;
 
     // If a name is given as a <custom-ident>, only lines with that name are counted. If not enough
     // lines with that name exist, all implicit grid lines on the side of the explicit grid
@@ -459,19 +456,19 @@ void GridFormattingContext::place_item_with_column_position(Box const& box, Box 
     if (child_box.computed_values().grid_column_start().has_line_name()) {
         auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_column_start().line_name(), box.computed_values().grid_template_columns());
         if (found_flag_and_index > -1)
-            column_start = 1 + found_flag_and_index;
+            column_start = found_flag_and_index;
         else
-            column_start = 1; // FIXME
+            column_start = 0;
     }
     if (child_box.computed_values().grid_column_end().has_line_name()) {
         auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_column_end().line_name(), box.computed_values().grid_template_columns());
         if (found_flag_and_index > -1) {
-            column_end = 1 + found_flag_and_index;
+            column_end = found_flag_and_index;
             if (!child_box.computed_values().grid_column_start().is_position())
                 column_start = column_end - column_span;
         } else {
-            column_end = 2;   // FIXME
-            column_start = 1; // FIXME
+            column_end = 1;
+            column_start = 0;
         }
     }
 
@@ -496,8 +493,6 @@ void GridFormattingContext::place_item_with_column_position(Box const& box, Box 
         column_span = child_box.computed_values().grid_column_start().raw_value();
 
     // FIXME: If the placement contains only a span for a named line, replace it with a span of 1.
-
-    column_start -= 1;
 
     // 4.1.1.1. Set the column position of the cursor to the grid item's column-start line. If this is
     // less than the previous column position of the cursor, increment the row position by 1.

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -196,41 +196,39 @@ void GridFormattingContext::place_item_with_row_and_column_position(Box const& b
     // https://www.w3.org/TR/css-grid-2/#common-uses-named-lines
     // 8.1.3. Named Lines and Spans
     // Instead of counting lines by number, lines can be referenced by their line name:
-    if (child_box.computed_values().grid_column_start().has_line_name()) {
-        auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_column_start().line_name(), box.computed_values().grid_template_columns());
-        if (found_flag_and_index > -1)
-            column_start = found_flag_and_index;
-        else
-            column_start = 0;
-    }
     if (child_box.computed_values().grid_column_end().has_line_name()) {
-        auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_column_end().line_name(), box.computed_values().grid_template_columns());
-        if (found_flag_and_index > -1) {
-            column_end = found_flag_and_index;
-            if (!child_box.computed_values().grid_column_start().is_position())
-                column_start = column_end - column_span;
-        } else {
-            column_end = 1;
-            column_start = 0;
-        }
-    }
-    if (child_box.computed_values().grid_row_start().has_line_name()) {
-        auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_row_start().line_name(), box.computed_values().grid_template_rows());
-        if (found_flag_and_index > -1)
-            row_start = found_flag_and_index;
+        if (auto grid_area_index = find_valid_grid_area(child_box.computed_values().grid_column_end().line_name()); grid_area_index > -1)
+            column_end = m_valid_grid_areas[grid_area_index].column_end;
+        else if (auto line_name_index = get_line_index_by_line_name(child_box.computed_values().grid_column_end().line_name(), box.computed_values().grid_template_columns()); line_name_index > -1)
+            column_end = line_name_index;
         else
-            row_start = 0;
+            column_end = 1;
+        column_start = column_end - 1;
+    }
+    if (child_box.computed_values().grid_column_start().has_line_name()) {
+        if (auto grid_area_index = find_valid_grid_area(child_box.computed_values().grid_column_end().line_name()); grid_area_index > -1)
+            column_start = m_valid_grid_areas[grid_area_index].column_start;
+        else if (auto line_name_index = get_line_index_by_line_name(child_box.computed_values().grid_column_start().line_name(), box.computed_values().grid_template_columns()); line_name_index > -1)
+            column_start = line_name_index;
+        else
+            column_start = 0;
     }
     if (child_box.computed_values().grid_row_end().has_line_name()) {
-        auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_row_end().line_name(), box.computed_values().grid_template_rows());
-        if (found_flag_and_index > -1) {
-            row_end = found_flag_and_index;
-            if (!child_box.computed_values().grid_row_start().is_position())
-                row_start = row_end - row_span;
-        } else {
+        if (auto grid_area_index = find_valid_grid_area(child_box.computed_values().grid_row_end().line_name()); grid_area_index > -1)
+            row_end = m_valid_grid_areas[grid_area_index].row_end;
+        else if (auto line_name_index = get_line_index_by_line_name(child_box.computed_values().grid_row_end().line_name(), box.computed_values().grid_template_rows()); line_name_index > -1)
+            row_end = line_name_index;
+        else
             row_end = 1;
+        row_start = row_end - 1;
+    }
+    if (child_box.computed_values().grid_row_start().has_line_name()) {
+        if (auto grid_area_index = find_valid_grid_area(child_box.computed_values().grid_row_end().line_name()); grid_area_index > -1)
+            row_start = m_valid_grid_areas[grid_area_index].row_start;
+        else if (auto line_name_index = get_line_index_by_line_name(child_box.computed_values().grid_row_start().line_name(), box.computed_values().grid_template_rows()); line_name_index > -1)
+            row_start = line_name_index;
+        else
             row_start = 0;
-        }
     }
 
     // If there are multiple lines of the same name, they effectively establish a named set of grid
@@ -324,23 +322,22 @@ void GridFormattingContext::place_item_with_row_position(Box const& box, Box con
     // https://www.w3.org/TR/css-grid-2/#common-uses-named-lines
     // 8.1.3. Named Lines and Spans
     // Instead of counting lines by number, lines can be referenced by their line name:
+    if (child_box.computed_values().grid_row_end().has_line_name()) {
+        if (auto grid_area_index = find_valid_grid_area(child_box.computed_values().grid_row_end().line_name()); grid_area_index > -1)
+            row_end = m_valid_grid_areas[grid_area_index].row_end;
+        else if (auto line_name_index = get_line_index_by_line_name(child_box.computed_values().grid_row_end().line_name(), box.computed_values().grid_template_rows()); line_name_index > -1)
+            row_end = line_name_index;
+        else
+            row_end = 1;
+        row_start = row_end - 1;
+    }
     if (child_box.computed_values().grid_row_start().has_line_name()) {
-        auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_row_start().line_name(), box.computed_values().grid_template_rows());
-        if (found_flag_and_index > -1)
-            row_start = found_flag_and_index;
+        if (auto grid_area_index = find_valid_grid_area(child_box.computed_values().grid_row_end().line_name()); grid_area_index > -1)
+            row_start = m_valid_grid_areas[grid_area_index].row_start;
+        else if (auto line_name_index = get_line_index_by_line_name(child_box.computed_values().grid_row_start().line_name(), box.computed_values().grid_template_rows()); line_name_index > -1)
+            row_start = line_name_index;
         else
             row_start = 0;
-    }
-    if (child_box.computed_values().grid_row_end().has_line_name()) {
-        auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_row_end().line_name(), box.computed_values().grid_template_rows());
-        if (found_flag_and_index > -1) {
-            row_end = found_flag_and_index;
-            if (!child_box.computed_values().grid_row_start().is_position())
-                row_start = row_end - row_span;
-        } else {
-            row_start = 0;
-            row_end = 1;
-        }
     }
 
     // If there are multiple lines of the same name, they effectively establish a named set of grid
@@ -453,23 +450,22 @@ void GridFormattingContext::place_item_with_column_position(Box const& box, Box 
     // https://www.w3.org/TR/css-grid-2/#common-uses-named-lines
     // 8.1.3. Named Lines and Spans
     // Instead of counting lines by number, lines can be referenced by their line name:
+    if (child_box.computed_values().grid_column_end().has_line_name()) {
+        if (auto grid_area_index = find_valid_grid_area(child_box.computed_values().grid_column_end().line_name()); grid_area_index > -1)
+            column_end = m_valid_grid_areas[grid_area_index].column_end;
+        else if (auto line_name_index = get_line_index_by_line_name(child_box.computed_values().grid_column_end().line_name(), box.computed_values().grid_template_columns()); line_name_index > -1)
+            column_end = line_name_index;
+        else
+            column_end = 1;
+        column_start = column_end - 1;
+    }
     if (child_box.computed_values().grid_column_start().has_line_name()) {
-        auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_column_start().line_name(), box.computed_values().grid_template_columns());
-        if (found_flag_and_index > -1)
-            column_start = found_flag_and_index;
+        if (auto grid_area_index = find_valid_grid_area(child_box.computed_values().grid_column_end().line_name()); grid_area_index > -1)
+            column_start = m_valid_grid_areas[grid_area_index].column_start;
+        else if (auto line_name_index = get_line_index_by_line_name(child_box.computed_values().grid_column_start().line_name(), box.computed_values().grid_template_columns()); line_name_index > -1)
+            column_start = line_name_index;
         else
             column_start = 0;
-    }
-    if (child_box.computed_values().grid_column_end().has_line_name()) {
-        auto found_flag_and_index = get_line_index_by_line_name(child_box.computed_values().grid_column_end().line_name(), box.computed_values().grid_template_columns());
-        if (found_flag_and_index > -1) {
-            column_end = found_flag_and_index;
-            if (!child_box.computed_values().grid_column_start().is_position())
-                column_start = column_end - column_span;
-        } else {
-            column_end = 1;
-            column_start = 0;
-        }
     }
 
     // If there are multiple lines of the same name, they effectively establish a named set of grid
@@ -1636,6 +1632,15 @@ void GridFormattingContext::build_valid_grid_areas(Box const& box)
 
     for (auto const& checked_grid_area : found_grid_areas)
         m_valid_grid_areas.append(checked_grid_area);
+}
+
+int GridFormattingContext::find_valid_grid_area(String const& needle)
+{
+    for (size_t x = 0; x < m_valid_grid_areas.size(); x++) {
+        if (m_valid_grid_areas[x].name == needle)
+            return static_cast<int>(x);
+    }
+    return -1;
 }
 
 void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const& available_space)

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -99,7 +99,7 @@ private:
     CSSPixels get_free_space_x(AvailableSpace const& available_space);
     CSSPixels get_free_space_y(Box const&);
 
-    int get_line_index_by_line_name(DeprecatedString const& line_name, CSS::GridTrackSizeList);
+    int get_line_index_by_line_name(String const& line_name, CSS::GridTrackSizeList);
     CSSPixels resolve_definite_track_size(CSS::GridSize const&, AvailableSpace const&, Box const&);
     size_t count_of_gap_columns();
     size_t count_of_gap_rows();

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -117,6 +117,7 @@ private:
     int get_count_of_tracks(Vector<CSS::ExplicitGridTrack> const&, AvailableSpace const&, Box const&);
 
     void build_valid_grid_areas(Box const&);
+    int find_valid_grid_area(String const& needle);
 
     void place_item_with_row_and_column_position(Box const& box, Box const& child_box);
     void place_item_with_row_position(Box const& box, Box const& child_box);

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -89,6 +89,15 @@ private:
         }
     };
 
+    struct GridArea {
+        String name;
+        int row_start { 0 };
+        int row_end { 1 };
+        int column_start { 0 };
+        int column_end { 1 };
+    };
+    Vector<GridArea> m_valid_grid_areas;
+
     Vector<TemporaryTrack> m_grid_rows;
     Vector<TemporaryTrack> m_grid_columns;
 
@@ -106,6 +115,8 @@ private:
     CSSPixels resolve_size(CSS::Size const&, AvailableSize const&, Box const&);
     int count_of_repeated_auto_fill_or_fit_tracks(Vector<CSS::ExplicitGridTrack> const& track_list, AvailableSpace const&, Box const&);
     int get_count_of_tracks(Vector<CSS::ExplicitGridTrack> const&, AvailableSpace const&, Box const&);
+
+    void build_valid_grid_areas(Box const&);
 
     void place_item_with_row_and_column_position(Box const& box, Box const& child_box);
     void place_item_with_row_position(Box const& box, Box const& child_box);

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -592,6 +592,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     computed_values.set_grid_column_start(computed_style.grid_column_start());
     computed_values.set_grid_row_end(computed_style.grid_row_end());
     computed_values.set_grid_row_start(computed_style.grid_row_start());
+    computed_values.set_grid_template_areas(computed_style.grid_template_areas());
 
     if (auto fill = computed_style.property(CSS::PropertyID::Fill); fill->has_color())
         computed_values.set_fill(fill->to_color(*this));


### PR DESCRIPTION
Implement grid-template-areas, grid-area and min/max-content sized grid tracks.

Here's a site that improved as a result of this PR:

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/45781926/212921666-dc8a3764-e216-4f43-a8e0-c7d0786188d3.png"></td>
<td><img src="https://user-images.githubusercontent.com/45781926/212921603-d12f0b76-b5c9-4953-8314-6c8b2d3030dc.png"></td>
</tr>
</table>