### PR TITLE
LibCore: More small Stream API updates

### DIFF
--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -36,7 +36,7 @@ TEST_CASE(file_open)
 
     auto maybe_size = file->size();
     EXPECT(!maybe_size.is_error());
-    EXPECT_EQ(maybe_size.value(), 0);
+    EXPECT_EQ(maybe_size.value(), 0ul);
 }
 
 TEST_CASE(file_write_bytes)
@@ -80,7 +80,7 @@ TEST_CASE(file_seeking_around)
     EXPECT(!maybe_file.is_error());
     auto file = maybe_file.release_value();
 
-    EXPECT_EQ(file->size().release_value(), 8702);
+    EXPECT_EQ(file->size().release_value(), 8702ul);
 
     auto maybe_buffer = ByteBuffer::create_uninitialized(16);
     EXPECT(!maybe_buffer.is_error());
@@ -89,17 +89,17 @@ TEST_CASE(file_seeking_around)
     StringView buffer_contents { buffer.bytes() };
 
     EXPECT(!file->seek(500, Core::Stream::SeekMode::SetPosition).is_error());
-    EXPECT_EQ(file->tell().release_value(), 500);
+    EXPECT_EQ(file->tell().release_value(), 500ul);
     EXPECT(!file->read_entire_buffer(buffer).is_error());
     EXPECT_EQ(buffer_contents, expected_seek_contents1);
 
     EXPECT(!file->seek(234, Core::Stream::SeekMode::FromCurrentPosition).is_error());
-    EXPECT_EQ(file->tell().release_value(), 750);
+    EXPECT_EQ(file->tell().release_value(), 750ul);
     EXPECT(!file->read_entire_buffer(buffer).is_error());
     EXPECT_EQ(buffer_contents, expected_seek_contents2);
 
     EXPECT(!file->seek(-105, Core::Stream::SeekMode::FromEndPosition).is_error());
-    EXPECT_EQ(file->tell().release_value(), 8597);
+    EXPECT_EQ(file->tell().release_value(), 8597ul);
     EXPECT(!file->read_entire_buffer(buffer).is_error());
     EXPECT_EQ(buffer_contents, expected_seek_contents3);
 }
@@ -113,7 +113,7 @@ TEST_CASE(file_adopt_fd)
     EXPECT(!maybe_file.is_error());
     auto file = maybe_file.release_value();
 
-    EXPECT_EQ(file->size().release_value(), 8702);
+    EXPECT_EQ(file->size().release_value(), 8702ul);
 
     auto maybe_buffer = ByteBuffer::create_uninitialized(16);
     EXPECT(!maybe_buffer.is_error());
@@ -122,7 +122,7 @@ TEST_CASE(file_adopt_fd)
     StringView buffer_contents { buffer.bytes() };
 
     EXPECT(!file->seek(500, Core::Stream::SeekMode::SetPosition).is_error());
-    EXPECT_EQ(file->tell().release_value(), 500);
+    EXPECT_EQ(file->tell().release_value(), 500ul);
     EXPECT(!file->read_entire_buffer(buffer).is_error());
     EXPECT_EQ(buffer_contents, expected_seek_contents1);
 
@@ -142,10 +142,10 @@ TEST_CASE(file_truncate)
     auto file = maybe_file.release_value();
 
     EXPECT(!file->truncate(999).is_error());
-    EXPECT_EQ(file->size().release_value(), 999);
+    EXPECT_EQ(file->size().release_value(), 999ul);
 
     EXPECT(!file->truncate(42).is_error());
-    EXPECT_EQ(file->size().release_value(), 42);
+    EXPECT_EQ(file->size().release_value(), 42ul);
 }
 
 // TCPSocket tests
@@ -477,7 +477,7 @@ TEST_CASE(buffered_file_tell_and_seek)
     // Initial state.
     {
         auto current_offset = buffered_file->tell().release_value();
-        EXPECT_EQ(current_offset, 0);
+        EXPECT_EQ(current_offset, 0ul);
     }
 
     // Read a character.
@@ -485,7 +485,7 @@ TEST_CASE(buffered_file_tell_and_seek)
         auto character = buffered_file->read_value<char>().release_value();
         EXPECT_EQ(character, 'W');
         auto current_offset = buffered_file->tell().release_value();
-        EXPECT_EQ(current_offset, 1);
+        EXPECT_EQ(current_offset, 1ul);
     }
 
     // Read one more character.
@@ -493,13 +493,13 @@ TEST_CASE(buffered_file_tell_and_seek)
         auto character = buffered_file->read_value<char>().release_value();
         EXPECT_EQ(character, 'e');
         auto current_offset = buffered_file->tell().release_value();
-        EXPECT_EQ(current_offset, 2);
+        EXPECT_EQ(current_offset, 2ul);
     }
 
     // Seek seven characters forward.
     {
         auto current_offset = buffered_file->seek(7, Core::Stream::SeekMode::FromCurrentPosition).release_value();
-        EXPECT_EQ(current_offset, 9);
+        EXPECT_EQ(current_offset, 9ul);
     }
 
     // Read a character again.
@@ -507,13 +507,13 @@ TEST_CASE(buffered_file_tell_and_seek)
         auto character = buffered_file->read_value<char>().release_value();
         EXPECT_EQ(character, 'o');
         auto current_offset = buffered_file->tell().release_value();
-        EXPECT_EQ(current_offset, 10);
+        EXPECT_EQ(current_offset, 10ul);
     }
 
     // Seek five characters backwards.
     {
         auto current_offset = buffered_file->seek(-5, Core::Stream::SeekMode::FromCurrentPosition).release_value();
-        EXPECT_EQ(current_offset, 5);
+        EXPECT_EQ(current_offset, 5ul);
     }
 
     // Read a character.
@@ -521,13 +521,13 @@ TEST_CASE(buffered_file_tell_and_seek)
         auto character = buffered_file->read_value<char>().release_value();
         EXPECT_EQ(character, 'h');
         auto current_offset = buffered_file->tell().release_value();
-        EXPECT_EQ(current_offset, 6);
+        EXPECT_EQ(current_offset, 6ul);
     }
 
     // Seek back to the beginning.
     {
         auto current_offset = buffered_file->seek(0, Core::Stream::SeekMode::SetPosition).release_value();
-        EXPECT_EQ(current_offset, 0);
+        EXPECT_EQ(current_offset, 0ul);
     }
 
     // Read the first character. This should prime the buffer if it hasn't happened already.
@@ -535,13 +535,13 @@ TEST_CASE(buffered_file_tell_and_seek)
         auto character = buffered_file->read_value<char>().release_value();
         EXPECT_EQ(character, 'W');
         auto current_offset = buffered_file->tell().release_value();
-        EXPECT_EQ(current_offset, 1);
+        EXPECT_EQ(current_offset, 1ul);
     }
 
     // Seek beyond the buffer size, which should invalidate the buffer.
     {
         auto current_offset = buffered_file->seek(12, Core::Stream::SeekMode::SetPosition).release_value();
-        EXPECT_EQ(current_offset, 12);
+        EXPECT_EQ(current_offset, 12ul);
     }
 
     // Ensure that we still read the correct contents from the new offset with a (presumably) freshly filled buffer.
@@ -549,7 +549,7 @@ TEST_CASE(buffered_file_tell_and_seek)
         auto character = buffered_file->read_value<char>().release_value();
         EXPECT_EQ(character, 'r');
         auto current_offset = buffered_file->tell().release_value();
-        EXPECT_EQ(current_offset, 13);
+        EXPECT_EQ(current_offset, 13ul);
     }
 }
 

--- a/Userland/Libraries/LibArchive/TarStream.cpp
+++ b/Userland/Libraries/LibArchive/TarStream.cpp
@@ -48,8 +48,7 @@ bool TarFileStream::is_eof() const
 
 ErrorOr<size_t> TarFileStream::write(ReadonlyBytes)
 {
-    // This is purely for wrapping and representing file contents in an archive.
-    VERIFY_NOT_REACHED();
+    return Error::from_errno(EBADF);
 }
 
 ErrorOr<NonnullOwnPtr<TarInputStream>> TarInputStream::construct(NonnullOwnPtr<Core::Stream::Stream> stream)

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -302,7 +302,7 @@ bool DeflateDecompressor::is_eof() const { return m_state == State::Idle && m_re
 
 ErrorOr<size_t> DeflateDecompressor::write(ReadonlyBytes)
 {
-    VERIFY_NOT_REACHED();
+    return Error::from_errno(EBADF);
 }
 
 bool DeflateDecompressor::is_open() const

--- a/Userland/Libraries/LibCompress/Gzip.cpp
+++ b/Userland/Libraries/LibCompress/Gzip.cpp
@@ -183,7 +183,7 @@ bool GzipDecompressor::is_eof() const { return m_input_stream->is_eof(); }
 
 ErrorOr<size_t> GzipDecompressor::write(ReadonlyBytes)
 {
-    VERIFY_NOT_REACHED();
+    return Error::from_errno(EBADF);
 }
 
 GzipCompressor::GzipCompressor(Core::Stream::Handle<Core::Stream::Stream> stream)

--- a/Userland/Libraries/LibCore/MemoryStream.cpp
+++ b/Userland/Libraries/LibCore/MemoryStream.cpp
@@ -49,7 +49,7 @@ void FixedMemoryStream::close()
 
 ErrorOr<void> FixedMemoryStream::truncate(off_t)
 {
-    return Error::from_errno(ENOTSUP);
+    return Error::from_errno(EBADF);
 }
 
 ErrorOr<Bytes> FixedMemoryStream::read(Bytes bytes)

--- a/Userland/Libraries/LibCore/MemoryStream.cpp
+++ b/Userland/Libraries/LibCore/MemoryStream.cpp
@@ -63,7 +63,7 @@ ErrorOr<Bytes> FixedMemoryStream::read(Bytes bytes)
     return bytes.trim(to_read);
 }
 
-ErrorOr<off_t> FixedMemoryStream::seek(i64 offset, SeekMode seek_mode)
+ErrorOr<size_t> FixedMemoryStream::seek(i64 offset, SeekMode seek_mode)
 {
     switch (seek_mode) {
     case SeekMode::SetPosition:
@@ -85,7 +85,7 @@ ErrorOr<off_t> FixedMemoryStream::seek(i64 offset, SeekMode seek_mode)
         m_offset = m_bytes.size() - offset;
         break;
     }
-    return static_cast<off_t>(m_offset);
+    return m_offset;
 }
 
 ErrorOr<size_t> FixedMemoryStream::write(ReadonlyBytes bytes)

--- a/Userland/Libraries/LibCore/MemoryStream.h
+++ b/Userland/Libraries/LibCore/MemoryStream.h
@@ -28,7 +28,7 @@ public:
     virtual ErrorOr<void> truncate(off_t) override;
     virtual ErrorOr<Bytes> read(Bytes bytes) override;
 
-    virtual ErrorOr<off_t> seek(i64 offset, SeekMode seek_mode = SeekMode::SetPosition) override;
+    virtual ErrorOr<size_t> seek(i64 offset, SeekMode seek_mode = SeekMode::SetPosition) override;
 
     virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override;
     virtual ErrorOr<void> write_entire_buffer(ReadonlyBytes bytes) override;

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -729,7 +729,7 @@ ErrorOr<void> WrappedAKInputStream::discard(size_t discarded_bytes)
 
 ErrorOr<size_t> WrappedAKInputStream::write(ReadonlyBytes)
 {
-    VERIFY_NOT_REACHED();
+    return Error::from_errno(EBADF);
 }
 
 bool WrappedAKInputStream::is_eof() const
@@ -753,7 +753,7 @@ WrappedAKOutputStream::WrappedAKOutputStream(NonnullOwnPtr<OutputStream> stream)
 
 ErrorOr<Bytes> WrappedAKOutputStream::read(Bytes)
 {
-    VERIFY_NOT_REACHED();
+    return Error::from_errno(EBADF);
 }
 
 ErrorOr<size_t> WrappedAKOutputStream::write(ReadonlyBytes bytes)
@@ -768,7 +768,7 @@ ErrorOr<size_t> WrappedAKOutputStream::write(ReadonlyBytes bytes)
 
 bool WrappedAKOutputStream::is_eof() const
 {
-    VERIFY_NOT_REACHED();
+    return true;
 }
 
 bool WrappedAKOutputStream::is_open() const

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -108,14 +108,14 @@ ErrorOr<void> Stream::write_entire_buffer(ReadonlyBytes buffer)
     return {};
 }
 
-ErrorOr<off_t> SeekableStream::tell() const
+ErrorOr<size_t> SeekableStream::tell() const
 {
     // Seek with 0 and SEEK_CUR does not modify anything despite the const_cast,
     // so it's safe to do this.
     return const_cast<SeekableStream*>(this)->seek(0, SeekMode::FromCurrentPosition);
 }
 
-ErrorOr<off_t> SeekableStream::size()
+ErrorOr<size_t> SeekableStream::size()
 {
     auto original_position = TRY(tell());
 
@@ -280,7 +280,7 @@ void File::close()
     m_fd = -1;
 }
 
-ErrorOr<off_t> File::seek(i64 offset, SeekMode mode)
+ErrorOr<size_t> File::seek(i64 offset, SeekMode mode)
 {
     int syscall_mode;
     switch (mode) {
@@ -297,7 +297,7 @@ ErrorOr<off_t> File::seek(i64 offset, SeekMode mode)
         VERIFY_NOT_REACHED();
     }
 
-    off_t seek_result = TRY(System::lseek(m_fd, offset, syscall_mode));
+    size_t seek_result = TRY(System::lseek(m_fd, offset, syscall_mode));
     m_last_read_was_eof = false;
     return seek_result;
 }

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -152,13 +152,13 @@ class SeekableStream : public Stream {
 public:
     /// Seeks to the given position in the given mode. Returns either the
     /// current position of the file, or an errno in the case of an error.
-    virtual ErrorOr<off_t> seek(i64 offset, SeekMode) = 0;
+    virtual ErrorOr<size_t> seek(i64 offset, SeekMode) = 0;
     /// Returns the current position of the file, or an errno in the case of
     /// an error.
-    virtual ErrorOr<off_t> tell() const;
+    virtual ErrorOr<size_t> tell() const;
     /// Returns the total size of the stream, or an errno in the case of an
     /// error. May not preserve the original position on the stream on failure.
-    virtual ErrorOr<off_t> size();
+    virtual ErrorOr<size_t> size();
     /// Shrinks or extends the stream to the given size. Returns an errno in
     /// the case of an error.
     virtual ErrorOr<void> truncate(off_t length) = 0;
@@ -306,7 +306,7 @@ public:
     virtual bool is_eof() const override;
     virtual bool is_open() const override;
     virtual void close() override;
-    virtual ErrorOr<off_t> seek(i64 offset, SeekMode) override;
+    virtual ErrorOr<size_t> seek(i64 offset, SeekMode) override;
     virtual ErrorOr<void> truncate(off_t length) override;
 
     int leak_fd(Badge<::IPC::File>)
@@ -871,7 +871,7 @@ public:
     virtual bool is_eof() const override { return m_helper.is_eof(); }
     virtual bool is_open() const override { return m_helper.stream().is_open(); }
     virtual void close() override { m_helper.stream().close(); }
-    virtual ErrorOr<off_t> seek(i64 offset, SeekMode mode) override
+    virtual ErrorOr<size_t> seek(i64 offset, SeekMode mode) override
     {
         if (mode == SeekMode::FromCurrentPosition) {
             // If possible, seek using the buffer alone.

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -70,6 +70,8 @@ private:
 
 /// The base, abstract class for stream operations. This class defines the
 /// operations one can perform on every stream in LibCore.
+/// Operations without a sensible default that are unsupported by an implementation
+/// of a Stream should return EBADF as an error.
 class Stream {
 public:
     /// Reads into a buffer, with the maximum size being the size of the buffer.


### PR DESCRIPTION
The `EBADF` change was already discussed a few weeks ago, the `size_t` thing I just noticed randomly along the way. Standardizing `close` behavior and everything else that I may have forgotten will have to wait until next time.