### PR TITLE
SoundPlayer: Specify the total sample count in playback device samples

### DIFF
--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -64,7 +64,8 @@ void Player::play_file_path(DeprecatedString const& path)
 
     m_loaded_filename = path;
 
-    total_samples_changed(loader->total_samples());
+    // TODO: The combination of sample count, sample rate, and sample data should be properly abstracted for the source and the playback device.
+    total_samples_changed(loader->total_samples() * (static_cast<float>(loader->sample_rate()) / m_playback_manager.device_sample_rate()));
     m_playback_manager.set_loader(move(loader));
     file_name_changed(path);
 


### PR DESCRIPTION
The current sample count is already reported like that, so this fixes a mismatch between current and total. In the future, we should look into abstracting this away properly instead of requiring the user to think of converting it manually everywhere.

This needs #17042 for full effect and seeking is still broken as well, but it gets us a little bit closer towards having the end of the seek bar match up with the actual end of the audio stream.