### PR TITLE
LibGUI: Fix Text editor to properly delete emoji

### DIFF
--- a/AK/Utf32View.h
+++ b/AK/Utf32View.h
@@ -105,6 +105,24 @@ public:
         return Utf32View(m_code_points + offset, length);
     }
 
+    size_t code_unit_offset_of(Utf32CodePointIterator const& it) const
+    {
+        VERIFY(it.m_ptr >= begin_ptr());
+        VERIFY(it.m_ptr <= end_ptr());
+
+        return it.m_ptr - begin_ptr();
+    }
+
+    constexpr size_t length_in_code_points() const
+    {
+        return m_length;
+    }
+
+    constexpr size_t length_in_code_units() const
+    {
+        return m_length;
+    }
+
 private:
     u32 const* begin_ptr() const
     {

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "AK/Format.h"
+#include "LibGUI/TextPosition.h"
 #include <AK/HashTable.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/NonnullRefPtr.h>
@@ -92,6 +94,12 @@ public:
 
     DeprecatedString text() const;
     DeprecatedString text_in_range(TextRange const&) const;
+
+    size_t get_next_grapheme_cluser_boundary(TextPosition const& cursor) const;
+    size_t get_prev_grapheme_cluser_boundary(TextPosition const& cursor) const;
+
+    size_t get_code_points_after_cursor(TextPosition const& cursor) const;
+    size_t get_code_points_before_cursor(TextPosition const& cursor) const;
 
     Vector<TextRange> find_all(StringView needle, bool regmatch = false, bool match_case = true);
 
@@ -183,6 +191,8 @@ public:
 
     size_t first_non_whitespace_column() const;
     Optional<size_t> last_non_whitespace_column() const;
+    TextPosition next_whitespace_column(TextPosition const& cursor) const; // if there is no whitespace before end   then the TextPosition will be begin/end rather than empty/null
+    TextPosition prev_whitespace_column(TextPosition const& cursor) const; // if there is no whitespace before begin then the TextPosition will be begin/end rather than empty/null
     bool ends_in_whitespace() const;
     bool can_select() const;
     bool is_empty() const { return length() == 0; }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -36,6 +36,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include <LibUnicode/GraphemeCluster.h>
 REGISTER_WIDGET(GUI, TextEditor)
 
 namespace GUI {
@@ -964,6 +965,12 @@ void TextEditor::keydown_event(KeyEvent& event)
                 auto word_break_pos = document().first_word_break_after(m_cursor);
                 erase_count = word_break_pos.column() - m_cursor.column();
             }
+
+            auto const new_cursor = TextPosition(m_cursor.line(), m_cursor.column());
+
+            // If we are not deleting a selection, then lets check if there is an emoji or glyph with multiple code points.
+            erase_count = document().get_code_points_after_cursor(new_cursor);
+
             TextRange erased_range(m_cursor, { m_cursor.line(), m_cursor.column() + erase_count });
             execute<RemoveTextCommand>(document().text_in_range(erased_range), erased_range);
             return;
@@ -1004,6 +1011,11 @@ void TextEditor::keydown_event(KeyEvent& event)
                     new_column = (m_cursor.column() / m_soft_tab_width) * m_soft_tab_width;
                 erase_count = m_cursor.column() - new_column;
             }
+
+            TextPosition const new_cursor = TextPosition(m_cursor.line(), m_cursor.column());
+
+            // If we are not deleting a selection, then lets check if there is an emoji or glyph with multiple code points.
+            erase_count = document().get_code_points_before_cursor(new_cursor);
 
             // Backspace within line
             TextRange erased_range({ m_cursor.line(), m_cursor.column() - erase_count }, m_cursor);

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "AK/Utf32View.h"
 #include <AK/CharacterTypes.h>
 #include <AK/Platform.h>
 #include <AK/StringBuilder.h>
@@ -151,7 +152,8 @@ bool __attribute__((weak)) code_point_has_grapheme_break_property(u32, GraphemeB
 bool __attribute__((weak)) code_point_has_word_break_property(u32, WordBreakProperty) { return {}; }
 bool __attribute__((weak)) code_point_has_sentence_break_property(u32, SentenceBreakProperty) { return {}; }
 
-Vector<size_t> find_grapheme_segmentation_boundaries([[maybe_unused]] Utf16View const& view)
+template<typename ViewType>
+Vector<size_t> find_grapheme_segmentation_boundaries_impl([[maybe_unused]] ViewType const& view)
 {
 #if ENABLE_UNICODE_DATA
     using GBP = GraphemeBreakProperty;
@@ -241,6 +243,16 @@ Vector<size_t> find_grapheme_segmentation_boundaries([[maybe_unused]] Utf16View 
 #else
     return {};
 #endif
+}
+
+Vector<size_t> find_grapheme_segmentation_boundaries([[maybe_unused]] Utf32View const& view)
+{
+    return find_grapheme_segmentation_boundaries_impl(view);
+}
+
+Vector<size_t> find_grapheme_segmentation_boundaries([[maybe_unused]] Utf16View const& view)
+{
+    return find_grapheme_segmentation_boundaries_impl(view);
 }
 
 template<typename ViewType>

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -64,6 +64,7 @@ bool code_point_has_grapheme_break_property(u32 code_point, GraphemeBreakPropert
 bool code_point_has_word_break_property(u32 code_point, WordBreakProperty property);
 bool code_point_has_sentence_break_property(u32 code_point, SentenceBreakProperty property);
 
+Vector<size_t> find_grapheme_segmentation_boundaries(Utf32View const&);
 Vector<size_t> find_grapheme_segmentation_boundaries(Utf16View const&);
 Vector<size_t> find_word_segmentation_boundaries(Utf8View const&);
 Vector<size_t> find_word_segmentation_boundaries(Utf16View const&);


### PR DESCRIPTION
Added some checks to Backspace and Delete Event handlers in Text editor to look for emoji and delete the appropriate amount of codepoints so that emoji of varying codepoint sizes are deleted. If no emoji is found then only a single codepoint is deleted

Fix #15261