### PR TITLE
LibGUI: Mimic a user click when calling `Button::click()`

### DIFF
--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -144,7 +144,7 @@ void CalculatorWidget::set_entry(Crypto::BigFraction value)
 
 void CalculatorWidget::mimic_pressed_button(RefPtr<GUI::Button> button)
 {
-    button->set_mimic_pressed(true);
+    button->mimic_pressed();
 }
 
 void CalculatorWidget::update_display()

--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -142,11 +142,6 @@ void CalculatorWidget::set_entry(Crypto::BigFraction value)
     update_display();
 }
 
-void CalculatorWidget::mimic_pressed_button(RefPtr<GUI::Button> button)
-{
-    button->mimic_pressed();
-}
-
 void CalculatorWidget::update_display()
 {
     m_entry->set_text(m_keypad.to_deprecated_string());
@@ -158,51 +153,34 @@ void CalculatorWidget::update_display()
 
 void CalculatorWidget::keydown_event(GUI::KeyEvent& event)
 {
-    if (event.key() == KeyCode::Key_Return || event.key() == KeyCode::Key_Equal) {
-        perform_operation(Calculator::Operation::Equals);
-        mimic_pressed_button(m_equals_button);
-    } else if (event.code_point() >= '0' && event.code_point() <= '9') {
-        auto const digit = event.code_point() - '0';
-        m_keypad.type_digit(digit);
-        mimic_pressed_button(m_digit_button[digit]);
-    } else if (event.code_point() == '.') {
-        m_keypad.type_decimal_point();
-        mimic_pressed_button(m_decimal_point_button);
-    } else if (event.key() == KeyCode::Key_Escape || event.key() == KeyCode::Key_Delete) {
-        m_keypad.set_to_0();
-        m_calculator.clear_operation();
-        mimic_pressed_button(m_clear_button);
-    } else if (event.key() == KeyCode::Key_Backspace) {
-        m_keypad.type_backspace();
-        mimic_pressed_button(m_backspace_button);
-    } else if (event.key() == KeyCode::Key_Backslash) {
-        perform_operation(Calculator::Operation::ToggleSign);
-        mimic_pressed_button(m_sign_button);
-    } else if (event.key() == KeyCode::Key_S) {
-        perform_operation(Calculator::Operation::Sqrt);
-        mimic_pressed_button(m_sqrt_button);
-    } else if (event.key() == KeyCode::Key_Percent) {
-        perform_operation(Calculator::Operation::Percent);
-        mimic_pressed_button(m_percent_button);
-    } else if (event.key() == KeyCode::Key_I) {
-        perform_operation(Calculator::Operation::Inverse);
-        mimic_pressed_button(m_inverse_button);
-    } else if (event.code_point() == '+') {
-        perform_operation(Calculator::Operation::Add);
-        mimic_pressed_button(m_add_button);
-    } else if (event.code_point() == '-') {
-        perform_operation(Calculator::Operation::Subtract);
-        mimic_pressed_button(m_subtract_button);
-    } else if (event.code_point() == '*') {
-        perform_operation(Calculator::Operation::Multiply);
-        mimic_pressed_button(m_multiply_button);
-    } else if (event.code_point() == '/') {
-        perform_operation(Calculator::Operation::Divide);
-        mimic_pressed_button(m_divide_button);
-    } else if (event.code_point() == '%') {
-        perform_operation(Calculator::Operation::Percent);
-        mimic_pressed_button(m_percent_button);
-    }
+    if (event.key() == KeyCode::Key_Return || event.key() == KeyCode::Key_Equal)
+        m_equals_button->click();
+    else if (event.code_point() >= '0' && event.code_point() <= '9')
+        m_digit_button[event.code_point() - '0']->click();
+    else if (event.code_point() == '.')
+        m_decimal_point_button->click();
+    else if (event.key() == KeyCode::Key_Escape || event.key() == KeyCode::Key_Delete)
+        m_clear_button->click();
+    else if (event.key() == KeyCode::Key_Backspace)
+        m_backspace_button->click();
+    else if (event.key() == KeyCode::Key_Backslash)
+        m_sign_button->click();
+    else if (event.key() == KeyCode::Key_S)
+        m_sqrt_button->click();
+    else if (event.key() == KeyCode::Key_Percent)
+        m_percent_button->click();
+    else if (event.key() == KeyCode::Key_I)
+        m_inverse_button->click();
+    else if (event.code_point() == '+')
+        m_add_button->click();
+    else if (event.code_point() == '-')
+        m_subtract_button->click();
+    else if (event.code_point() == '*')
+        m_multiply_button->click();
+    else if (event.code_point() == '/')
+        m_divide_button->click();
+    else if (event.code_point() == '%')
+        m_percent_button->click();
 
     update_display();
 }

--- a/Userland/Applications/Calculator/CalculatorWidget.h
+++ b/Userland/Applications/Calculator/CalculatorWidget.h
@@ -33,7 +33,6 @@ private:
     void add_operation_button(GUI::Button&, Calculator::Operation);
     void add_digit_button(GUI::Button&, int digit);
 
-    void mimic_pressed_button(RefPtr<GUI::Button>);
     void perform_operation(Calculator::Operation operation);
     void update_display();
 

--- a/Userland/Libraries/LibGUI/AbstractButton.cpp
+++ b/Userland/Libraries/LibGUI/AbstractButton.cpp
@@ -131,12 +131,13 @@ void AbstractButton::mouseup_event(MouseEvent& event)
     if (event.button() == m_pressed_mouse_button && m_being_pressed) {
         bool was_auto_repeating = m_auto_repeat_timer->is_active();
         m_auto_repeat_timer->stop();
-        bool was_being_pressed = m_being_pressed;
+        m_was_being_pressed = m_being_pressed;
+        ScopeGuard update_was_being_pressed { [this] { m_was_being_pressed = m_being_pressed; } };
         m_being_pressed = false;
         m_pressed_mouse_button = MouseButton::None;
         if (!is_checkable() || is_checked())
             repaint();
-        if (was_being_pressed && !was_auto_repeating) {
+        if (m_was_being_pressed && !was_auto_repeating) {
             switch (event.button()) {
             case MouseButton::Primary:
                 click(event.modifiers());

--- a/Userland/Libraries/LibGUI/AbstractButton.h
+++ b/Userland/Libraries/LibGUI/AbstractButton.h
@@ -34,6 +34,7 @@ public:
 
     bool is_hovered() const { return m_hovered; }
     bool is_being_pressed() const { return m_being_pressed; }
+    bool was_being_pressed() const { return m_was_being_pressed; }
 
     unsigned allowed_mouse_buttons_for_pressing() const { return m_allowed_mouse_buttons_for_pressing; }
     void set_allowed_mouse_buttons_for_pressing(unsigned allowed_buttons) { m_allowed_mouse_buttons_for_pressing = allowed_buttons; }
@@ -66,6 +67,7 @@ private:
     bool m_checkable { false };
     bool m_hovered { false };
     bool m_being_pressed { false };
+    bool m_was_being_pressed { false };
     bool m_being_keyboard_pressed { false };
     bool m_exclusive { false };
 

--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -167,7 +167,7 @@ void Action::activate(Core::Object* activator)
 
     if (activator == nullptr) {
         for_each_toolbar_button([](auto& button) {
-            button.set_mimic_pressed(true);
+            button.mimic_pressed();
         });
     }
 

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -246,10 +246,10 @@ void Button::set_default(bool default_button)
     });
 }
 
-void Button::set_mimic_pressed(bool mimic_pressed)
+void Button::mimic_pressed()
 {
     if (!is_being_pressed()) {
-        m_mimic_pressed = mimic_pressed;
+        m_mimic_pressed = true;
 
         stop_timer();
         start_timer(80, Core::TimerShouldFireWhenNotVisible::Yes);

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -57,7 +57,7 @@ void Button::paint_event(PaintEvent& event)
     Painter painter(*this);
     painter.add_clip_rect(event.rect());
 
-    bool paint_pressed = is_being_pressed() || is_mimic_pressed() || (m_menu && m_menu->is_visible());
+    bool paint_pressed = is_being_pressed() || m_mimic_pressed || (m_menu && m_menu->is_visible());
 
     Gfx::StylePainter::paint_button(painter, rect(), palette(), m_button_style, paint_pressed, is_hovered(), is_checked(), is_enabled(), is_focused(), is_default() && !another_button_has_focus());
 
@@ -260,7 +260,7 @@ void Button::set_mimic_pressed(bool mimic_pressed)
 
 void Button::timer_event(Core::TimerEvent&)
 {
-    if (is_mimic_pressed()) {
+    if (m_mimic_pressed) {
         m_mimic_pressed = false;
 
         update();

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -136,6 +136,9 @@ void Button::click(unsigned modifiers)
             return;
         set_checked(!is_checked());
     }
+
+    mimic_pressed();
+
     if (on_click)
         on_click(modifiers);
     if (m_action)
@@ -248,7 +251,7 @@ void Button::set_default(bool default_button)
 
 void Button::mimic_pressed()
 {
-    if (!is_being_pressed()) {
+    if (!is_being_pressed() && !was_being_pressed()) {
         m_mimic_pressed = true;
 
         stop_timer();

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -64,7 +64,6 @@ public:
     bool another_button_has_focus() const { return m_another_button_has_focus; }
 
     void set_mimic_pressed(bool mimic_pressed);
-    bool is_mimic_pressed() const { return m_mimic_pressed; };
 
     virtual Optional<UISize> calculated_min_size() const override;
 

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -63,7 +63,7 @@ public:
 
     bool another_button_has_focus() const { return m_another_button_has_focus; }
 
-    void set_mimic_pressed(bool mimic_pressed);
+    void mimic_pressed();
 
     virtual Optional<UISize> calculated_min_size() const override;
 


### PR DESCRIPTION
As an example: pressing Enter or Shift+Enter in Terminal's search dialog now triggers the related button.

[WellHelloFriends.webm](https://user-images.githubusercontent.com/26030965/213027612-007efb7e-1747-4f3c-8683-d79490a8c125.webm)
