### PR TITLE
LibWeb: Fix Error Page

### DIFF
--- a/Base/res/html/error.html
+++ b/Base/res/html/error.html
@@ -13,7 +13,7 @@
     </head>
     <body>
         <header>
-            <img src="file:///res/icons/32x32/msgbox-warning.png" alt="Warning" width="24" height="24">
+            <img src="../icons/32x32/msgbox-warning.png" alt="Warning" width="24" height="24">
             <h1>Failed to load @failed_url@</h1>
         </header>
         <p>Error: @error@</p>

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -335,8 +335,10 @@ void FrameLoader::set_error_page_url(DeprecatedString error_page_url)
 
 void FrameLoader::load_error_page(const AK::URL& failed_url, DeprecatedString const& error)
 {
+    LoadRequest request = LoadRequest::create_for_url_on_page(s_error_page_url, browsing_context().page());
+
     ResourceLoader::the().load(
-        s_error_page_url,
+        request,
         [this, failed_url, error](auto data, auto&, auto) {
             VERIFY(!data.is_null());
             StringBuilder builder;

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -344,7 +344,7 @@ void FrameLoader::load_error_page(const AK::URL& failed_url, DeprecatedString co
             generator.set("failed_url", escape_html_entities(failed_url.to_deprecated_string()));
             generator.set("error", escape_html_entities(error));
             generator.append(data);
-            load_html(generator.as_string_view(), failed_url);
+            load_html(generator.as_string_view(), s_error_page_url);
         },
         [](auto& error, auto) {
             dbgln("Failed to load error page: {}", error);


### PR DESCRIPTION
This PR has two fixes:

LibWeb: Fix error page icon outside of serenity
![Screenshot 2023-01-18 214248](https://user-images.githubusercontent.com/36214028/213159185-e7962566-9e50-4b0a-aa96-debf7f899754.png)

LibWeb: Fix `FrameLoader::load_error_page`
![Screenshot 2023-01-18 214219](https://user-images.githubusercontent.com/36214028/213159218-355dc16b-74be-45bc-9629-f01b6715b8b3.png)

