### PR TITLE
FuzzilliJs: Print the result of `JS::Value::to_string` using `AK::outln`

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/DeprecatedString.h>
+#include <AK/Format.h>
 #include <AK/Function.h>
 #include <AK/StringView.h>
 #include <LibJS/Forward.h>
@@ -160,7 +161,7 @@ JS_DEFINE_NATIVE_FUNCTION(TestRunnerGlobalObject::fuzzilli)
         }
 
         auto string = TRY(vm.argument(1).to_string(vm));
-        fprintf(fzliout, "%s\n", string.characters());
+        outln(fzliout, "{}", string);
         fflush(fzliout);
     }
 


### PR DESCRIPTION
`JS::Value::to_string` now returns a String, which does not have a null- terminated characters() accessor.