### PR TITLE
CI: Ignore dependabot in commit linter for PRs

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -15,6 +15,9 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            const excludedBotIds = [
+              49699333,  // dependabot[bot]
+            ];
             const rules = [
               {
                 pattern: /^[^\r]*$/,
@@ -62,7 +65,10 @@ jobs:
             const commits = await github.paginate(opts);
 
             const errors = [];
-            for (const { sha, commit: { message } } of commits) {
+            for (const { sha, commit: { message }, author } of commits) {
+              if (excludedBotIds.includes(author.id)) {
+                continue;
+              }
               const commitErrors = [];
               for (const { pattern, error } of rules) {
                 if (!pattern.test(message)) {


### PR DESCRIPTION
Dependabot cannot be configured to significantly change the way it formats its commit message, and it currently includes a "Signed-Off-By" tag which is not allowed by our linter.

This updates our CI commit linter to exclude bots from the checks.

This fixes PRs such as https://github.com/SerenityOS/serenity/pull/17050