### PR TITLE
LibPDF: Initial support for Type1C fonts

### DIFF
--- a/Userland/Libraries/LibPDF/CMakeLists.txt
+++ b/Userland/Libraries/LibPDF/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     Encoding.cpp
     Encryption.cpp
     Filter.cpp
+    Fonts/CFF.cpp
     Fonts/PDFFont.cpp
     Fonts/PS1FontProgram.cpp
     Fonts/TrueTypeFont.cpp

--- a/Userland/Libraries/LibPDF/CMakeLists.txt
+++ b/Userland/Libraries/LibPDF/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     Fonts/TrueTypeFont.cpp
     Fonts/Type0Font.cpp
     Fonts/Type1Font.cpp
+    Fonts/Type1FontProgram.cpp
     Interpolation.cpp
     ObjectDerivatives.cpp
     Parser.cpp

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -132,6 +132,7 @@
     A(Title)                      \
     A(ToUnicode)                  \
     A(Type)                       \
+    A(Type1C)                     \
     A(U)                          \
     A(UCR)                        \
     A(UseBlackPTComp)             \

--- a/Userland/Libraries/LibPDF/Encoding.cpp
+++ b/Userland/Libraries/LibPDF/Encoding.cpp
@@ -171,6 +171,14 @@ CharDescriptor const& Encoding::get_char_code_descriptor(u16 char_code) const
     return const_cast<Encoding*>(this)->m_descriptors.ensure(char_code);
 }
 
+u16 Encoding::get_char_code(DeprecatedString const& name) const
+{
+    auto code_iterator = m_name_mapping.find(name);
+    if (code_iterator != m_name_mapping.end())
+        return code_iterator->value;
+    return 0;
+}
+
 bool Encoding::should_map_to_bullet(u16 char_code) const
 {
     // PDF Annex D table D.2, note 3:

--- a/Userland/Libraries/LibPDF/Encoding.h
+++ b/Userland/Libraries/LibPDF/Encoding.h
@@ -645,6 +645,7 @@ public:
     HashMap<u16, CharDescriptor> const& descriptors() const { return m_descriptors; }
     HashMap<DeprecatedString, u16> const& name_mapping() const { return m_name_mapping; }
 
+    u16 get_char_code(DeprecatedString const&) const;
     CharDescriptor const& get_char_code_descriptor(u16 char_code) const;
 
     bool should_map_to_bullet(u16 char_code) const;

--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2023, Rodrigo Tobar <rtobarc@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/String.h>
+#include <LibGfx/Forward.h>
+#include <LibPDF/Encoding.h>
+#include <LibPDF/Error.h>
+#include <LibPDF/Fonts/CFF.h>
+#include <LibPDF/Reader.h>
+
+namespace PDF {
+
+PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPtr<Encoding> encoding)
+{
+    Reader reader(cff_bytes);
+
+    // Header
+    // skip major, minor version
+    reader.consume(2);
+    auto header_size = TRY(reader.try_read<Card8>());
+    // skip offset size
+    reader.consume(1);
+    reader.move_to(header_size);
+
+    // Name INDEX
+    Vector<String> font_names;
+    TRY(parse_index(reader, [&](ReadonlyBytes const& data) -> PDFErrorOr<void> {
+        auto string = TRY(String::from_utf8(data));
+        return TRY(font_names.try_append(string));
+    }));
+
+    auto cff = adopt_ref(*new CFF());
+    cff->set_font_matrix({ 0.001f, 0.0f, 0.0f, 0.001f, 0.0f, 0.0f });
+
+    // Top DICT INDEX
+    int charset_offset = 0;
+    Vector<u8> encoding_codes;
+    auto charstrings_offset = 0;
+    Vector<ByteBuffer> subroutines;
+    int defaultWidthX = 0;
+    int nominalWidthX = 0;
+    TRY(parse_index(reader, [&](ReadonlyBytes const& element_data) {
+        Reader element_reader { element_data };
+        return parse_dict<TopDictOperator>(element_reader, [&](TopDictOperator op, Vector<DictOperand> const& operands) -> PDFErrorOr<void> {
+            switch (op) {
+            case TopDictOperator::Encoding: {
+                auto encoding_offset = 0;
+                if (!operands.is_empty())
+                    encoding_offset = operands[0].get<int>();
+                encoding_codes = TRY(parse_encoding(Reader(cff_bytes.slice(encoding_offset))));
+                break;
+            }
+            case TopDictOperator::Charset: {
+                if (!operands.is_empty())
+                    charset_offset = operands[0].get<int>();
+                break;
+            }
+            case TopDictOperator::CharStrings: {
+                if (!operands.is_empty())
+                    charstrings_offset = operands[0].get<int>();
+                break;
+            }
+            case TopDictOperator::Private: {
+                auto private_dict_size = operands[0].get<int>();
+                auto private_dict_offset = operands[1].get<int>();
+                Reader priv_dict_reader { cff_bytes.slice(private_dict_offset, private_dict_size) };
+                TRY(parse_dict<PrivDictOperator>(priv_dict_reader, [&](PrivDictOperator op, Vector<DictOperand> const& operands) -> PDFErrorOr<void> {
+                    switch (op) {
+                    case PrivDictOperator::Subrs: {
+                        auto subrs_offset = operands[0].get<int>();
+                        Reader subrs_reader { cff_bytes.slice(private_dict_offset + subrs_offset) };
+                        dbgln("Parsing Subrs INDEX");
+                        TRY(parse_index(subrs_reader, [&](ReadonlyBytes const& subroutine_bytes) -> PDFErrorOr<void> {
+                            return TRY(subroutines.try_append(TRY(ByteBuffer::copy(subroutine_bytes))));
+                        }));
+                        break;
+                    }
+                    case PrivDictOperator::DefaultWidthX:
+                        defaultWidthX = operands[0].get<int>();
+                        break;
+                    case PrivDictOperator::NominalWidthX:
+                        nominalWidthX = operands[0].get<int>();
+                        break;
+                    }
+                    return {};
+                }));
+                break;
+            }
+            default:;
+            }
+            return {};
+        });
+    }));
+
+    // Create glpyhs (now that we have the subroutines) and associate missing information to store them and their encoding
+    auto glyphs = TRY(parse_charstrings(Reader(cff_bytes.slice(charstrings_offset)), subroutines));
+    auto charset = TRY(parse_charset(Reader { cff_bytes.slice(charset_offset) }, glyphs.size()));
+
+    // Adjust glyphs' widths as they are deltas from nominalWidthX
+    for (auto& glyph : glyphs) {
+        if (!glyph.width_specified)
+            glyph.width = float(defaultWidthX);
+        else
+            glyph.width += float(nominalWidthX);
+    }
+
+    // Encoding given or read
+    if (encoding) {
+        for (size_t i = 0; i < glyphs.size(); i++) {
+            if (i == 0) {
+                TRY(cff->add_glyph(0, move(glyphs[0])));
+                continue;
+            }
+            auto const& name = charset[i - 1];
+            u16 code = encoding->get_char_code(name);
+            TRY(cff->add_glyph(code, move(glyphs[i])));
+        }
+        cff->set_encoding(move(encoding));
+    } else {
+        HashMap<u16, CharDescriptor> descriptors;
+        for (size_t i = 0; i < glyphs.size(); i++) {
+            if (i == 0) {
+                TRY(cff->add_glyph(0, move(glyphs[0])));
+                descriptors.set(0, CharDescriptor { ".notdef", 0 });
+                continue;
+            }
+            auto code = encoding_codes[i - 1];
+            auto char_name = charset[i - 1];
+            TRY(cff->add_glyph(code, move(glyphs[i])));
+            descriptors.set(code, CharDescriptor { char_name, code });
+        }
+        cff->set_encoding(TRY(Encoding::create(descriptors)));
+    }
+
+    return cff;
+}
+
+HashMap<CFF::SID, DeprecatedFlyString> CFF::builtin_names {
+    { 0, ".notdef" },
+    { 1, "space" },
+    { 9, "parenleft" },
+    { 10, "parenright" },
+    { 13, "comma" },
+    { 14, "hyphen" },
+    { 15, "period" },
+
+    { 17, "zero" },
+    { 18, "one" },
+    { 19, "two" },
+    { 20, "three" },
+    { 21, "four" },
+    { 22, "five" },
+    { 23, "six" },
+    { 24, "seven" },
+    { 25, "eight" },
+    { 26, "nine" },
+    { 27, "colon" },
+    { 28, "semicolon" },
+
+    { 34, "A" },
+    { 35, "B" },
+    { 36, "C" },
+    { 37, "D" },
+    { 38, "E" },
+    { 39, "F" },
+    { 40, "G" },
+    { 41, "H" },
+    { 42, "I" },
+    { 43, "J" },
+    { 44, "K" },
+    { 45, "L" },
+    { 46, "M" },
+    { 47, "N" },
+    { 48, "O" },
+    { 49, "P" },
+    { 50, "Q" },
+    { 51, "R" },
+    { 52, "S" },
+    { 53, "T" },
+    { 54, "U" },
+    { 55, "V" },
+    { 56, "W" },
+    { 57, "X" },
+    { 58, "Y" },
+    { 59, "Z" },
+    { 66, "a" },
+    { 67, "b" },
+    { 68, "c" },
+    { 69, "d" },
+    { 70, "e" },
+    { 71, "f" },
+    { 72, "g" },
+    { 73, "h" },
+    { 74, "i" },
+    { 75, "j" },
+    { 76, "k" },
+    { 77, "l" },
+    { 78, "m" },
+    { 79, "n" },
+    { 80, "o" },
+    { 81, "p" },
+    { 82, "q" },
+    { 83, "r" },
+    { 84, "s" },
+    { 85, "t" },
+    { 86, "u" },
+    { 87, "v" },
+    { 88, "w" },
+    { 89, "x" },
+    { 90, "y" },
+    { 91, "z" },
+
+    { 104, "quotesingle" },
+    { 105, "quotedblleft" },
+
+    { 111, "endash" },
+
+    { 116, "bullet" },
+
+    { 119, "quotedblright" },
+
+    { 137, "emdash" },
+
+    { 170, "copyright" },
+};
+
+PDFErrorOr<Vector<DeprecatedFlyString>> CFF::parse_charset(Reader&& reader, size_t glyph_count)
+{
+    Vector<DeprecatedFlyString> names;
+    auto resolve = [](SID sid) {
+        auto x = builtin_names.find(sid);
+        if (x == builtin_names.end()) {
+            dbgln("Cound't find string for SID {}, going with space", sid);
+            return DeprecatedFlyString("space");
+        }
+        return x->value;
+    };
+
+    auto format = TRY(reader.try_read<Card8>());
+    if (format == 0) {
+        for (u8 i = 0; i < glyph_count - 1; i++) {
+            SID sid = TRY(reader.try_read<BigEndian<SID>>());
+            TRY(names.try_append(resolve(sid)));
+        }
+    } else if (format == 1) {
+        while (names.size() < glyph_count - 1) {
+            auto first_sid = TRY(reader.try_read<BigEndian<SID>>());
+            int left = TRY(reader.try_read<Card8>());
+            for (u8 sid = first_sid; left >= 0; left--, sid++)
+                TRY(names.try_append(resolve(sid)));
+        }
+    }
+    return names;
+}
+
+PDFErrorOr<Vector<CFF::Glyph>> CFF::parse_charstrings(Reader&& reader, Vector<ByteBuffer> const& subroutines)
+{
+    Vector<Glyph> glyphs;
+    TRY(parse_index(reader, [&](ReadonlyBytes const& charstring_data) -> PDFErrorOr<void> {
+        GlyphParserState state;
+        auto glyph = TRY(parse_glyph(charstring_data, subroutines, state, true));
+        return TRY(glyphs.try_append(glyph));
+    }));
+    return glyphs;
+}
+
+PDFErrorOr<Vector<u8>> CFF::parse_encoding(Reader&& reader)
+{
+    Vector<u8> encoding_codes;
+    auto format = TRY(reader.try_read<Card8>());
+    if (format == 0) {
+        auto n_codes = TRY(reader.try_read<Card8>());
+        for (u8 i = 0; i < n_codes; i++) {
+            TRY(encoding_codes.try_append(TRY(reader.try_read<Card8>())));
+        }
+    } else if (format == 1) {
+        auto n_ranges = TRY(reader.try_read<Card8>());
+        for (u8 i = 0; i < n_ranges; i++) {
+            auto first_code = TRY(reader.try_read<Card8>());
+            int left = TRY(reader.try_read<Card8>());
+            for (u8 code = first_code; left >= 0; left--, code++)
+                TRY(encoding_codes.try_append(code));
+        }
+    } else
+        return error(DeprecatedString::formatted("Invalid encoding format: {}", format));
+    return encoding_codes;
+}
+
+template<typename OperatorT>
+PDFErrorOr<void> CFF::parse_dict(Reader& reader, DictEntryHandler<OperatorT>&& handler)
+{
+    Vector<DictOperand> operands;
+    while (reader.remaining() > 0) {
+        auto b0 = reader.read<u8>();
+        // A command
+        if (b0 <= 21) {
+            auto op = TRY(parse_dict_operator<OperatorT>(b0, reader));
+            TRY(handler(op, operands));
+            operands.clear();
+            continue;
+        }
+        // An operand
+        TRY(operands.try_append(TRY(load_dict_operand(b0, reader))));
+    }
+    return {};
+}
+
+template PDFErrorOr<void> CFF::parse_dict<CFF::TopDictOperator>(Reader&, DictEntryHandler<TopDictOperator>&&);
+template PDFErrorOr<void> CFF::parse_dict<CFF::PrivDictOperator>(Reader&, DictEntryHandler<PrivDictOperator>&&);
+
+template<typename OperatorT>
+PDFErrorOr<OperatorT> CFF::parse_dict_operator(u8 b0, Reader& reader)
+{
+    VERIFY(b0 <= 21);
+    if (b0 != 12)
+        return OperatorT { (int)b0 };
+    auto b1 = TRY(reader.try_read<u8>());
+    return OperatorT { b0 << 8 | b1 };
+}
+
+template PDFErrorOr<CFF::TopDictOperator> CFF::parse_dict_operator(u8, Reader&);
+
+PDFErrorOr<void> CFF::parse_index(Reader& reader, IndexDataHandler&& data_handler)
+{
+    Card16 count = TRY(reader.try_read<BigEndian<Card16>>());
+    if (count == 0)
+        return {};
+    auto offset_size = TRY(reader.try_read<OffSize>());
+    if (offset_size == 1)
+        return parse_index_data<u8>(count, reader, data_handler);
+    if (offset_size == 2)
+        return parse_index_data<u16>(count, reader, data_handler);
+    if (offset_size == 4)
+        return parse_index_data<u32>(count, reader, data_handler);
+    VERIFY_NOT_REACHED();
+}
+
+template<typename OffsetType>
+PDFErrorOr<void> CFF::parse_index_data(Card16 count, Reader& reader, IndexDataHandler& handler)
+{
+    OffsetType last_data_end = 1;
+    auto offset_refpoint = reader.offset() + sizeof(OffsetType) * (count + 1) - 1;
+    for (u16 i = 0; i < count; i++) {
+        reader.save();
+        reader.move_by(sizeof(OffsetType) * i);
+        OffsetType data_start = reader.read<BigEndian<OffsetType>>();
+        last_data_end = reader.read<BigEndian<OffsetType>>();
+        auto data_size = last_data_end - data_start;
+        reader.move_to(offset_refpoint + data_start);
+        TRY(handler(reader.bytes().slice(reader.offset(), data_size)));
+        reader.load();
+    }
+    reader.move_to(offset_refpoint + last_data_end);
+    return {};
+}
+
+template PDFErrorOr<void> CFF::parse_index_data<u8>(Card16, Reader&, IndexDataHandler&);
+template PDFErrorOr<void> CFF::parse_index_data<u16>(Card16, Reader&, IndexDataHandler&);
+template PDFErrorOr<void> CFF::parse_index_data<u32>(Card16, Reader&, IndexDataHandler&);
+
+// 4 DICT DATA, Table 3 Operand Encoding
+int CFF::load_int_dict_operand(u8 b0, Reader& reader)
+{
+    if (b0 >= 32 && b0 <= 246) {
+        return b0 - 139;
+    }
+    if (b0 >= 247 && b0 <= 250) {
+        auto b1 = reader.read<u8>();
+        return (b0 - 247) * 256 + b1 + 108;
+    }
+    if (b0 >= 251 && b0 <= 254) {
+        auto b1 = reader.read<u8>();
+        return -(b0 - 251) * 256 - b1 - 108;
+    }
+    if (b0 == 28) {
+        auto b1 = reader.read<u8>();
+        auto b2 = reader.read<u8>();
+        return b1 << 8 | b2;
+    }
+    if (b0 == 29) {
+        auto b1 = reader.read<u8>();
+        auto b2 = reader.read<u8>();
+        auto b3 = reader.read<u8>();
+        auto b4 = reader.read<u8>();
+        return b1 << 24 | b2 << 16 | b3 << 8 | b4;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+float CFF::load_float_dict_operand(Reader& reader)
+{
+    StringBuilder sb;
+    auto add_nibble = [&](char nibble) {
+        if (nibble < 0xa)
+            sb.append('0' + nibble);
+        else if (nibble == 0xa)
+            sb.append('.');
+        else if (nibble == 0xb)
+            sb.append('E');
+        else if (nibble == 0xc)
+            sb.append("E-"sv);
+        else if (nibble == 0xe)
+            sb.append('-');
+    };
+    while (true) {
+        auto byte = reader.read<u8>();
+        char nibble1 = (byte & 0xf0) >> 4;
+        char nibble2 = byte & 0x0f;
+        if (nibble1 == 0xf)
+            break;
+        add_nibble(nibble1);
+        if (nibble2 == 0xf)
+            break;
+        add_nibble(nibble2);
+    }
+    auto result = AK::StringUtils::convert_to_floating_point<float>(sb.string_view());
+    return result.release_value();
+}
+
+PDFErrorOr<CFF::DictOperand> CFF::load_dict_operand(u8 b0, Reader& reader)
+{
+    if (b0 == 30)
+        return load_float_dict_operand(reader);
+    if (b0 >= 28)
+        return load_int_dict_operand(b0, reader);
+    return Error { Error::Type::MalformedPDF, DeprecatedString::formatted("Unknown CFF dict element prefix: {}", b0) };
+}
+}

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, Rodrigo Tobar <rtobarc@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Tuple.h>
+#include <AK/Types.h>
+#include <LibPDF/Error.h>
+#include <LibPDF/Fonts/Type1FontProgram.h>
+
+namespace PDF {
+
+class Reader;
+
+class CFF : public Type1FontProgram {
+
+private:
+    // Table 9: Top DICT Operator Entries
+    enum class TopDictOperator {
+        Version = 0,
+        Notice,
+        FullName,
+        FamilyName,
+        Weight,
+        FontBBox,
+        // UniqueID = 13,
+        // XUID,
+        Charset = 15,
+        Encoding,
+        CharStrings,
+        Private,
+        // IsFixedPitch = (12 << 8 | 1),
+        // ItalicAngle,
+        // UnderlinePosition,
+        // UnderlineThickness,
+        // PaintType,
+    };
+
+    enum class PrivDictOperator {
+        Subrs = 19,
+        DefaultWidthX,
+        NominalWidthX,
+    };
+
+public:
+    static PDFErrorOr<NonnullRefPtr<CFF>> create(ReadonlyBytes const&, RefPtr<Encoding> encoding);
+
+    // to private
+    using Card8 = u8;
+    using Card16 = u16;
+    using Offset = i32;
+    using OffSize = u8;
+    using SID = u16;
+    using DictOperand = Variant<int, float>;
+
+    static int load_int_dict_operand(u8 b0, Reader&);
+    static float load_float_dict_operand(Reader&);
+    static PDFErrorOr<DictOperand> load_dict_operand(u8, Reader&);
+
+    using IndexDataHandler = Function<PDFErrorOr<void>(ReadonlyBytes const&)>;
+    static PDFErrorOr<void> parse_index(Reader& reader, IndexDataHandler&&);
+
+    template<typename OffsetType>
+    static PDFErrorOr<void> parse_index_data(Card16 count, Reader& reader, IndexDataHandler&);
+
+    template<typename OperatorT>
+    using DictEntryHandler = Function<PDFErrorOr<void>(OperatorT, Vector<DictOperand> const&)>;
+
+    template<typename OperatorT>
+    static PDFErrorOr<void> parse_dict(Reader& reader, DictEntryHandler<OperatorT>&& handler);
+
+    template<typename OperatorT>
+    static PDFErrorOr<OperatorT> parse_dict_operator(u8, Reader&);
+
+    static PDFErrorOr<Vector<CFF::Glyph>> parse_charstrings(Reader&&, Vector<ByteBuffer> const& subroutines);
+
+    static PDFErrorOr<Vector<DeprecatedFlyString>> parse_charset(Reader&&, size_t);
+    static PDFErrorOr<Vector<u8>> parse_encoding(Reader&&);
+
+    static HashMap<SID, DeprecatedFlyString> builtin_names;
+};
+
+}

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
@@ -33,9 +33,9 @@ static bool is_standard_latin_font(DeprecatedFlyString const& font)
 
 PDFErrorOr<void> PDFFont::CommonData::load_from_dict(Document* document, NonnullRefPtr<DictObject> dict, float font_size)
 {
-    auto base_font = TRY(dict->get_name(document, CommonNames::BaseFont))->name();
-    if ((is_standard_font = is_standard_latin_font(base_font))) {
-        auto replacement = replacement_for_standard_latin_font(base_font.to_lowercase());
+    base_font_name = TRY(dict->get_name(document, CommonNames::BaseFont))->name();
+    if ((is_standard_font = is_standard_latin_font(base_font_name))) {
+        auto replacement = replacement_for_standard_latin_font(base_font_name.to_lowercase());
         font = Gfx::FontDatabase::the().get(replacement.get<0>(), replacement.get<1>(), font_size);
         VERIFY(font);
     }

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -24,6 +24,7 @@ public:
 
     // This is used both by Type 1 and TrueType fonts.
     struct CommonData {
+        DeprecatedFlyString base_font_name;
         RefPtr<Gfx::Font> font;
         RefPtr<StreamObject> to_unicode;
         RefPtr<Encoding> encoding;
@@ -45,6 +46,7 @@ public:
 
     virtual bool is_standard_font() const { return m_is_standard_font; }
     virtual Type type() const = 0;
+    virtual DeprecatedFlyString base_font_name() const = 0;
 
 protected:
     static Tuple<DeprecatedString, DeprecatedString> replacement_for_standard_latin_font(StringView);

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -14,38 +14,7 @@
 
 namespace PDF {
 
-enum Command {
-    HStem = 1,
-    VStem = 3,
-    VMoveTo,
-    RLineTo,
-    HLineTo,
-    VLineTo,
-    RRCurveTo,
-    ClosePath,
-    CallSubr,
-    Return,
-    Extended,
-    HSbW,
-    EndChar,
-    RMoveTo = 21,
-    HMoveTo,
-    VHCurveTo = 30,
-    HVCurveTo
-};
-
-enum ExtendedCommand {
-    DotSection,
-    VStem3,
-    HStem3,
-    Seac = 6,
-    Div = 12,
-    CallOtherSubr = 16,
-    Pop,
-    SetCurrentPoint = 33,
-};
-
-PDFErrorOr<void> PS1FontProgram::create(ReadonlyBytes const& bytes, RefPtr<Encoding> encoding, size_t cleartext_length, size_t encrypted_length)
+PDFErrorOr<NonnullRefPtr<Type1FontProgram>> PS1FontProgram::create(ReadonlyBytes const& bytes, RefPtr<Encoding> encoding, size_t cleartext_length, size_t encrypted_length)
 {
     Reader reader(bytes);
     if (reader.remaining() == 0)
@@ -58,13 +27,14 @@ PDFErrorOr<void> PS1FontProgram::create(ReadonlyBytes const& bytes, RefPtr<Encod
     if (!seek_name(reader, CommonNames::Encoding))
         return error("Missing encoding array");
 
+    auto font_program = adopt_ref(*new PS1FontProgram());
     if (encoding) {
         // 9.6.6.2 Encodings for Type 1 Fonts:
         // An Encoding entry may override a Type 1 font’s mapping from character codes to character names.
-        m_encoding = encoding;
+        font_program->set_encoding(move(encoding));
     } else {
         if (TRY(parse_word(reader)) == "StandardEncoding") {
-            m_encoding = Encoding::standard_encoding();
+            font_program->set_encoding(Encoding::standard_encoding());
         } else {
             HashMap<u16, CharDescriptor> descriptors;
 
@@ -78,385 +48,21 @@ PDFErrorOr<void> PS1FontProgram::create(ReadonlyBytes const& bytes, RefPtr<Encod
                     descriptors.set(char_code, { name.starts_with('/') ? name.substring_view(1) : name.view(), char_code });
                 }
             }
-            m_encoding = TRY(Encoding::create(descriptors));
+            font_program->set_encoding(TRY(Encoding::create(descriptors)));
         }
     }
 
     bool found_font_matrix = seek_name(reader, "FontMatrix");
     if (found_font_matrix) {
         auto array = TRY(parse_number_array(reader, 6));
-        m_font_matrix = { array[0], array[1], array[2], array[3], array[4], array[5] };
+        font_program->set_font_matrix({ array[0], array[1], array[2], array[3], array[4], array[5] });
     } else {
-        m_font_matrix = { 0.001f, 0.0f, 0.0f, 0.001f, 0.0f, 0.0f };
+        font_program->set_font_matrix({ 0.001f, 0.0f, 0.0f, 0.001f, 0.0f, 0.0f });
     }
 
     auto decrypted = TRY(decrypt(reader.bytes().slice(cleartext_length, encrypted_length), 55665, 4));
-    return parse_encrypted_portion(decrypted);
-}
-
-RefPtr<Gfx::Bitmap> PS1FontProgram::rasterize_glyph(u32 char_code, float width, Gfx::GlyphSubpixelOffset subpixel_offset)
-{
-    auto path = build_char(char_code, width, subpixel_offset);
-    auto bounding_box = path.bounding_box().size();
-
-    u32 w = (u32)ceilf(bounding_box.width()) + 2;
-    u32 h = (u32)ceilf(bounding_box.height()) + 2;
-
-    Gfx::PathRasterizer rasterizer(Gfx::IntSize(w, h));
-    rasterizer.draw_path(path);
-    return rasterizer.accumulate();
-}
-
-Gfx::Path PS1FontProgram::build_char(u32 char_code, float width, Gfx::GlyphSubpixelOffset subpixel_offset)
-{
-    auto maybe_glyph = m_glyph_map.get(char_code);
-    if (!maybe_glyph.has_value())
-        return {};
-
-    auto& glyph = maybe_glyph.value();
-    auto transform = Gfx::AffineTransform()
-                         .translate(subpixel_offset.to_float_point())
-                         .multiply(glyph_transform_to_device_space(glyph, width));
-
-    // Translate such that the top-left point is at [0, 0].
-    auto bounding_box = glyph.path.bounding_box();
-    Gfx::FloatPoint translation(-bounding_box.x(), -(bounding_box.y() + bounding_box.height()));
-    transform.translate(translation);
-
-    return glyph.path.copy_transformed(transform);
-}
-
-Gfx::FloatPoint PS1FontProgram::glyph_translation(u32 char_code, float width) const
-{
-    auto maybe_glyph = m_glyph_map.get(char_code);
-    if (!maybe_glyph.has_value())
-        return {};
-
-    auto& glyph = maybe_glyph.value();
-    auto transform = glyph_transform_to_device_space(glyph, width);
-
-    // Undo the translation we applied earlier.
-    auto bounding_box = glyph.path.bounding_box();
-    Gfx::FloatPoint translation(bounding_box.x(), bounding_box.y() + bounding_box.height());
-
-    return transform.map(translation);
-}
-
-Gfx::AffineTransform PS1FontProgram::glyph_transform_to_device_space(Glyph const& glyph, float width) const
-{
-    auto scale = width / (m_font_matrix.a() * glyph.width + m_font_matrix.e());
-    auto transform = m_font_matrix;
-
-    // Convert character space to device space.
-    transform.scale(scale, -scale);
-
-    return transform;
-}
-
-PDFErrorOr<PS1FontProgram::Glyph> PS1FontProgram::parse_glyph(ReadonlyBytes const& data, GlyphParserState& state)
-{
-    auto push = [&](float value) -> PDFErrorOr<void> {
-        if (state.sp >= state.stack.size())
-            return error("Operand stack overflow");
-        state.stack[state.sp++] = value;
-        return {};
-    };
-
-    auto pop = [&]() -> float {
-        return state.sp ? state.stack[--state.sp] : 0.0f;
-    };
-
-    auto& path = state.glyph.path;
-
-    // Parse the stream of parameters and commands that make up a glyph outline.
-    for (size_t i = 0; i < data.size(); ++i) {
-        auto require = [&](unsigned num) -> PDFErrorOr<void> {
-            if (i + num >= data.size())
-                return error("Malformed glyph outline definition");
-            return {};
-        };
-
-        int v = data[i];
-        if (v == 255) {
-            TRY(require(4));
-            int a = data[++i];
-            int b = data[++i];
-            int c = data[++i];
-            int d = data[++i];
-            TRY(push((a << 24) + (b << 16) + (c << 8) + d));
-        } else if (v >= 251) {
-            TRY(require(1));
-            auto w = data[++i];
-            TRY(push(-((v - 251) * 256) - w - 108));
-        } else if (v >= 247) {
-            TRY(require(1));
-            auto w = data[++i];
-            TRY(push(((v - 247) * 256) + w + 108));
-        } else if (v >= 32) {
-            TRY(push(v - 139));
-        } else {
-            // Not a parameter but a command byte.
-            switch (v) {
-            case HStem:
-            case VStem:
-                state.sp = 0;
-                break;
-
-            case VMoveTo: {
-                auto dy = pop();
-
-                state.point.translate_by(0.0f, dy);
-
-                if (state.flex_feature) {
-                    state.flex_sequence[state.flex_index++] = state.point.x();
-                    state.flex_sequence[state.flex_index++] = state.point.y();
-                } else {
-                    path.move_to(state.point);
-                }
-                state.sp = 0;
-                break;
-            }
-
-            case RLineTo: {
-                auto dy = pop();
-                auto dx = pop();
-
-                state.point.translate_by(dx, dy);
-                path.line_to(state.point);
-                state.sp = 0;
-                break;
-            }
-
-            case HLineTo: {
-                auto dx = pop();
-
-                state.point.translate_by(dx, 0.0f);
-                path.line_to(state.point);
-                state.sp = 0;
-                break;
-            }
-
-            case VLineTo: {
-                auto dy = pop();
-
-                state.point.translate_by(0.0f, dy);
-                path.line_to(state.point);
-                state.sp = 0;
-                break;
-            }
-
-            case RRCurveTo: {
-                auto dy3 = pop();
-                auto dx3 = pop();
-                auto dy2 = pop();
-                auto dx2 = pop();
-                auto dy1 = pop();
-                auto dx1 = pop();
-
-                auto& point = state.point;
-
-                path.cubic_bezier_curve_to(
-                    point + Gfx::FloatPoint(dx1, dy1),
-                    point + Gfx::FloatPoint(dx1 + dx2, dy1 + dy2),
-                    point + Gfx::FloatPoint(dx1 + dx2 + dx3, dy1 + dy2 + dy3));
-
-                point.translate_by(dx1 + dx2 + dx3, dy1 + dy2 + dy3);
-                state.sp = 0;
-                break;
-            }
-
-            case ClosePath:
-                path.close();
-                state.sp = 0;
-                break;
-
-            case CallSubr: {
-                auto subr_number = pop();
-                if (static_cast<size_t>(subr_number) >= m_subroutines.size())
-                    return error("Subroutine index out of range");
-
-                // Subroutines 0-2 handle the flex feature.
-                if (subr_number == 0) {
-                    if (state.flex_index != 14)
-                        break;
-
-                    auto& flex = state.flex_sequence;
-
-                    path.cubic_bezier_curve_to(
-                        { flex[2], flex[3] },
-                        { flex[4], flex[5] },
-                        { flex[6], flex[7] });
-                    path.cubic_bezier_curve_to(
-                        { flex[8], flex[9] },
-                        { flex[10], flex[11] },
-                        { flex[12], flex[13] });
-
-                    state.flex_feature = false;
-                    state.sp = 0;
-                } else if (subr_number == 1) {
-                    state.flex_feature = true;
-                    state.flex_index = 0;
-                    state.sp = 0;
-                } else if (subr_number == 2) {
-                    state.sp = 0;
-                } else {
-                    auto subr = m_subroutines[subr_number];
-                    if (subr.is_empty())
-                        return error("Empty subroutine");
-
-                    TRY(parse_glyph(subr, state));
-                }
-                break;
-            }
-
-            case Return:
-                break;
-
-            case Extended: {
-                TRY(require(1));
-                switch (data[++i]) {
-                case DotSection:
-                case VStem3:
-                case HStem3:
-                case Seac:
-                    // FIXME: Do something with these?
-                    state.sp = 0;
-                    break;
-
-                case Div: {
-                    auto num2 = pop();
-                    auto num1 = pop();
-
-                    TRY(push(num2 ? num1 / num2 : 0.0f));
-                    break;
-                }
-
-                case CallOtherSubr: {
-                    auto othersubr_number = pop();
-                    auto n = static_cast<int>(pop());
-
-                    if (othersubr_number == 0) {
-                        state.postscript_stack[state.postscript_sp++] = pop();
-                        state.postscript_stack[state.postscript_sp++] = pop();
-                        pop();
-                    } else if (othersubr_number == 3) {
-                        state.postscript_stack[state.postscript_sp++] = 3;
-                    } else {
-                        for (int i = 0; i < n; ++i)
-                            state.postscript_stack[state.postscript_sp++] = pop();
-                    }
-
-                    (void)othersubr_number;
-                    break;
-                }
-
-                case Pop:
-                    TRY(push(state.postscript_stack[--state.postscript_sp]));
-                    break;
-
-                case SetCurrentPoint: {
-                    auto y = pop();
-                    auto x = pop();
-
-                    state.point = { x, y };
-                    path.move_to(state.point);
-                    state.sp = 0;
-                    break;
-                }
-
-                default:
-                    return error(DeprecatedString::formatted("Unhandled command: 12 {}", data[i]));
-                }
-                break;
-            }
-
-            case HSbW: {
-                auto wx = pop();
-                auto sbx = pop();
-
-                state.glyph.width = wx;
-                state.point = { sbx, 0.0f };
-                state.sp = 0;
-                break;
-            }
-
-            case EndChar:
-                break;
-
-            case RMoveTo: {
-                auto dy = pop();
-                auto dx = pop();
-
-                state.point.translate_by(dx, dy);
-
-                if (state.flex_feature) {
-                    state.flex_sequence[state.flex_index++] = state.point.x();
-                    state.flex_sequence[state.flex_index++] = state.point.y();
-                } else {
-                    path.move_to(state.point);
-                }
-                state.sp = 0;
-                break;
-            }
-
-            case HMoveTo: {
-                auto dx = pop();
-
-                state.point.translate_by(dx, 0.0f);
-
-                if (state.flex_feature) {
-                    state.flex_sequence[state.flex_index++] = state.point.x();
-                    state.flex_sequence[state.flex_index++] = state.point.y();
-                } else {
-                    path.move_to(state.point);
-                }
-                state.sp = 0;
-                break;
-            }
-
-            case VHCurveTo: {
-                auto dx3 = pop();
-                auto dy2 = pop();
-                auto dx2 = pop();
-                auto dy1 = pop();
-
-                auto& point = state.point;
-
-                path.cubic_bezier_curve_to(
-                    point + Gfx::FloatPoint(0.0f, dy1),
-                    point + Gfx::FloatPoint(dx2, dy1 + dy2),
-                    point + Gfx::FloatPoint(dx2 + dx3, dy1 + dy2));
-
-                point.translate_by(dx2 + dx3, dy1 + dy2);
-                state.sp = 0;
-                break;
-            }
-
-            case HVCurveTo: {
-                auto dy3 = pop();
-                auto dy2 = pop();
-                auto dx2 = pop();
-                auto dx1 = pop();
-
-                auto& point = state.point;
-
-                path.cubic_bezier_curve_to(
-                    point + Gfx::FloatPoint(dx1, 0.0f),
-                    point + Gfx::FloatPoint(dx1 + dx2, dy2),
-                    point + Gfx::FloatPoint(dx1 + dx2, dy2 + dy3));
-
-                point.translate_by(dx1 + dx2, dy2 + dy3);
-                state.sp = 0;
-                break;
-            }
-
-            default:
-                return error(DeprecatedString::formatted("Unhandled command: {}", v));
-            }
-        }
-    }
-
-    return state.glyph;
+    TRY(font_program->parse_encrypted_portion(decrypted));
+    return font_program;
 }
 
 PDFErrorOr<void> PS1FontProgram::parse_encrypted_portion(ByteBuffer const& buffer)
@@ -468,7 +74,7 @@ PDFErrorOr<void> PS1FontProgram::parse_encrypted_portion(ByteBuffer const& buffe
 
     if (!seek_name(reader, "Subrs"))
         return error("Missing subroutine array");
-    m_subroutines = TRY(parse_subroutines(reader));
+    auto subroutines = TRY(parse_subroutines(reader));
 
     if (!seek_name(reader, "CharStrings"))
         return error("Missing char strings array");
@@ -486,10 +92,10 @@ PDFErrorOr<void> PS1FontProgram::parse_encrypted_portion(ByteBuffer const& buffe
             if (rd == "-|" || rd == "RD") {
                 auto line = TRY(decrypt(reader.bytes().slice(reader.offset(), encrypted_size), m_encryption_key, m_lenIV));
                 reader.move_by(encrypted_size);
-                auto name_mapping = m_encoding->name_mapping();
+                auto name_mapping = encoding()->name_mapping();
                 auto char_code = name_mapping.ensure(word.substring_view(1));
                 GlyphParserState state;
-                m_glyph_map.set(char_code, TRY(parse_glyph(line, state)));
+                TRY(add_glyph(char_code, TRY(parse_glyph(line, subroutines, state))));
             }
         }
     }
@@ -497,7 +103,7 @@ PDFErrorOr<void> PS1FontProgram::parse_encrypted_portion(ByteBuffer const& buffe
     return {};
 }
 
-PDFErrorOr<Vector<ByteBuffer>> PS1FontProgram::parse_subroutines(Reader& reader)
+PDFErrorOr<Vector<ByteBuffer>> PS1FontProgram::parse_subroutines(Reader& reader) const
 {
     if (!reader.matches_number())
         return error("Expected array length");
@@ -634,18 +240,4 @@ bool PS1FontProgram::seek_name(Reader& reader, DeprecatedString const& name)
     return false;
 }
 
-Error PS1FontProgram::error(
-    DeprecatedString const& message
-#ifdef PDF_DEBUG
-    ,
-    SourceLocation loc
-#endif
-)
-{
-#ifdef PDF_DEBUG
-    dbgln("\033[31m{} Type 1 font error: {}\033[0m", loc, message);
-#endif
-
-    return Error { Error::Type::MalformedPDF, message };
-}
 }

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -95,7 +95,7 @@ PDFErrorOr<void> PS1FontProgram::parse_encrypted_portion(ByteBuffer const& buffe
                 auto name_mapping = encoding()->name_mapping();
                 auto char_code = name_mapping.ensure(word.substring_view(1));
                 GlyphParserState state;
-                TRY(add_glyph(char_code, TRY(parse_glyph(line, subroutines, state))));
+                TRY(add_glyph(char_code, TRY(parse_glyph(line, subroutines, state, false))));
             }
         }
     }

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -92,8 +92,8 @@ PDFErrorOr<void> PS1FontProgram::parse_encrypted_portion(ByteBuffer const& buffe
             if (rd == "-|" || rd == "RD") {
                 auto line = TRY(decrypt(reader.bytes().slice(reader.offset(), encrypted_size), m_encryption_key, m_lenIV));
                 reader.move_by(encrypted_size);
-                auto name_mapping = encoding()->name_mapping();
-                auto char_code = name_mapping.ensure(word.substring_view(1));
+                auto glyph_name = word.substring_view(1);
+                auto char_code = encoding()->get_char_code(glyph_name);
                 GlyphParserState state;
                 TRY(add_glyph(char_code, TRY(parse_glyph(line, subroutines, state, false))));
             }

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
@@ -35,8 +35,6 @@ private:
     static PDFErrorOr<ByteBuffer> decrypt(ReadonlyBytes const&, u16 key, size_t skip);
     static bool seek_name(Reader&, DeprecatedString const&);
 
-    Vector<ByteBuffer> m_character_names;
-
     u16 m_encryption_key { 4330 };
     int m_lenIV { 4 };
 };

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
@@ -11,72 +11,31 @@
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Path.h>
 #include <LibPDF/Error.h>
+#include <LibPDF/Fonts/Type1FontProgram.h>
 
 namespace PDF {
 
 class Reader;
 class Encoding;
 
-class PS1FontProgram : public RefCounted<PS1FontProgram> {
+class PS1FontProgram : public Type1FontProgram {
 public:
-    PDFErrorOr<void> create(ReadonlyBytes const&, RefPtr<Encoding>, size_t cleartext_length, size_t encrypted_length);
-
-    RefPtr<Gfx::Bitmap> rasterize_glyph(u32 char_code, float width, Gfx::GlyphSubpixelOffset);
-    Gfx::Path build_char(u32 char_code, float width, Gfx::GlyphSubpixelOffset);
-
-    RefPtr<Encoding> encoding() const { return m_encoding; }
-    Gfx::FloatPoint glyph_translation(u32 char_code, float width) const;
+    static PDFErrorOr<NonnullRefPtr<Type1FontProgram>> create(ReadonlyBytes const&, RefPtr<Encoding>, size_t cleartext_length, size_t encrypted_length);
 
 private:
-    struct Glyph {
-        Gfx::Path path;
-        float width;
-    };
-
-    struct GlyphParserState {
-        Glyph glyph;
-
-        Gfx::FloatPoint point;
-
-        bool flex_feature { false };
-        size_t flex_index;
-        Array<float, 14> flex_sequence;
-
-        size_t sp { 0 };
-        Array<float, 24> stack;
-
-        size_t postscript_sp { 0 };
-        Array<float, 24> postscript_stack;
-    };
-
     Gfx::AffineTransform glyph_transform_to_device_space(Glyph const&, float width) const;
 
-    PDFErrorOr<Glyph> parse_glyph(ReadonlyBytes const&, GlyphParserState&);
     PDFErrorOr<void> parse_encrypted_portion(ByteBuffer const&);
-    PDFErrorOr<Vector<ByteBuffer>> parse_subroutines(Reader&);
-    PDFErrorOr<Vector<float>> parse_number_array(Reader&, size_t length);
-    PDFErrorOr<DeprecatedString> parse_word(Reader&);
-    PDFErrorOr<float> parse_float(Reader&);
-    PDFErrorOr<int> parse_int(Reader&);
+    PDFErrorOr<Vector<ByteBuffer>> parse_subroutines(Reader&) const;
+    static PDFErrorOr<Vector<float>> parse_number_array(Reader&, size_t length);
+    static PDFErrorOr<DeprecatedString> parse_word(Reader&);
+    static PDFErrorOr<float> parse_float(Reader&);
+    static PDFErrorOr<int> parse_int(Reader&);
 
-    PDFErrorOr<ByteBuffer> decrypt(ReadonlyBytes const&, u16 key, size_t skip);
-    bool seek_name(Reader&, DeprecatedString const&);
+    static PDFErrorOr<ByteBuffer> decrypt(ReadonlyBytes const&, u16 key, size_t skip);
+    static bool seek_name(Reader&, DeprecatedString const&);
 
-    static Error error(
-        DeprecatedString const& message
-#ifdef PDF_DEBUG
-        ,
-        SourceLocation loc = SourceLocation::current()
-#endif
-    );
-
-    Vector<ByteBuffer> m_subroutines;
     Vector<ByteBuffer> m_character_names;
-    HashMap<u16, Glyph> m_glyph_map;
-
-    Gfx::AffineTransform m_font_matrix;
-
-    RefPtr<Encoding> m_encoding;
 
     u16 m_encryption_key { 4330 };
     int m_lenIV { 4 };

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -40,7 +40,7 @@ PDFErrorOr<NonnullRefPtr<PDFFont>> TrueTypeFont::create(Document* document, Nonn
 TrueTypeFont::TrueTypeFont(PDFFont::CommonData data)
     : m_data(data)
 {
-    m_is_standard_font = data.is_standard_font;
+    m_is_standard_font = m_data.is_standard_font;
 }
 
 u32 TrueTypeFont::char_code_to_code_point(u16 char_code) const

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -27,6 +27,7 @@ public:
     void draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u32, Color) override;
 
     Type type() const override { return PDFFont::Type::TrueType; }
+    DeprecatedFlyString base_font_name() const override { return m_data.base_font_name; }
 
 private:
     PDFFont::CommonData m_data;

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -30,6 +30,7 @@ public:
     void draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u32, Color) override {};
 
     Type type() const override { return PDFFont::Type::Type0; }
+    DeprecatedFlyString base_font_name() const override { return ""; }
 
 private:
     CIDSystemInfo m_system_info;

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -7,6 +7,7 @@
 
 #include <LibGfx/Painter.h>
 #include <LibPDF/CommonNames.h>
+#include <LibPDF/Fonts/PS1FontProgram.h>
 #include <LibPDF/Fonts/Type1Font.h>
 
 namespace PDF {
@@ -30,8 +31,7 @@ PDFErrorOr<Type1Font::Data> Type1Font::parse_data(Document* document, NonnullRef
         auto length1 = TRY(document->resolve(font_file_dict->get_value(CommonNames::Length1))).get<int>();
         auto length2 = TRY(document->resolve(font_file_dict->get_value(CommonNames::Length2))).get<int>();
 
-        data.font_program = adopt_ref(*new PS1FontProgram());
-        TRY(data.font_program->create(font_file_stream->bytes(), data.encoding, length1, length2));
+        data.font_program = TRY(PS1FontProgram::create(font_file_stream->bytes(), data.encoding, length1, length2));
 
         if (!data.encoding)
             data.encoding = data.font_program->encoding();

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -49,7 +49,7 @@ PDFErrorOr<NonnullRefPtr<Type1Font>> Type1Font::create(Document* document, Nonnu
 Type1Font::Type1Font(Data data)
     : m_data(move(data))
 {
-    m_is_standard_font = data.is_standard_font;
+    m_is_standard_font = m_data.is_standard_font;
 }
 
 u32 Type1Font::char_code_to_code_point(u16 char_code) const

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -31,6 +31,7 @@ public:
     void draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u32 char_code, Color color) override;
 
     Type type() const override { return PDFFont::Type::Type1; }
+    DeprecatedFlyString base_font_name() const override { return m_data.base_font_name; };
 
 private:
     Data m_data;

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -8,14 +8,14 @@
 
 #include <LibGfx/Font/ScaledFont.h>
 #include <LibPDF/Fonts/PDFFont.h>
-#include <LibPDF/Fonts/PS1FontProgram.h>
+#include <LibPDF/Fonts/Type1FontProgram.h>
 
 namespace PDF {
 
 class Type1Font : public PDFFont {
 public:
     struct Data : PDFFont::CommonData {
-        RefPtr<PS1FontProgram> font_program;
+        RefPtr<Type1FontProgram> font_program;
     };
 
     static PDFErrorOr<Data> parse_data(Document*, NonnullRefPtr<DictObject> font_dict, float font_size);

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) 2023, Rodrigo Tobar <rtobarc@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Font/PathRasterizer.h>
+#include <LibPDF/Fonts/Type1FontProgram.h>
+
+namespace PDF {
+
+enum Command {
+    HStem = 1,
+    VStem = 3,
+    VMoveTo,
+    RLineTo,
+    HLineTo,
+    VLineTo,
+    RRCurveTo,
+    ClosePath,
+    CallSubr,
+    Return,
+    Extended,
+    HSbW,
+    EndChar,
+    RMoveTo = 21,
+    HMoveTo,
+    VHCurveTo = 30,
+    HVCurveTo
+};
+
+enum ExtendedCommand {
+    DotSection,
+    VStem3,
+    HStem3,
+    Seac = 6,
+    Div = 12,
+    CallOtherSubr = 16,
+    Pop,
+    SetCurrentPoint = 33,
+};
+
+RefPtr<Gfx::Bitmap> Type1FontProgram::rasterize_glyph(u32 char_code, float width, Gfx::GlyphSubpixelOffset subpixel_offset)
+{
+    auto path = build_char(char_code, width, subpixel_offset);
+    auto bounding_box = path.bounding_box().size();
+
+    u32 w = (u32)ceilf(bounding_box.width()) + 2;
+    u32 h = (u32)ceilf(bounding_box.height()) + 2;
+
+    Gfx::PathRasterizer rasterizer(Gfx::IntSize(w, h));
+    rasterizer.draw_path(path);
+    return rasterizer.accumulate();
+}
+
+Gfx::Path Type1FontProgram::build_char(u32 char_code, float width, Gfx::GlyphSubpixelOffset subpixel_offset)
+{
+    auto maybe_glyph = m_glyph_map.get(char_code);
+    if (!maybe_glyph.has_value())
+        return {};
+
+    auto& glyph = maybe_glyph.value();
+    auto transform = Gfx::AffineTransform()
+                         .translate(subpixel_offset.to_float_point())
+                         .multiply(glyph_transform_to_device_space(glyph, width));
+
+    // Translate such that the top-left point is at [0, 0].
+    auto bounding_box = glyph.path.bounding_box();
+    Gfx::FloatPoint translation(-bounding_box.x(), -(bounding_box.y() + bounding_box.height()));
+    transform.translate(translation);
+
+    return glyph.path.copy_transformed(transform);
+}
+
+Gfx::FloatPoint Type1FontProgram::glyph_translation(u32 char_code, float width) const
+{
+    auto maybe_glyph = m_glyph_map.get(char_code);
+    if (!maybe_glyph.has_value())
+        return {};
+
+    auto& glyph = maybe_glyph.value();
+    auto transform = glyph_transform_to_device_space(glyph, width);
+
+    // Undo the translation we applied earlier.
+    auto bounding_box = glyph.path.bounding_box();
+    Gfx::FloatPoint translation(bounding_box.x(), bounding_box.y() + bounding_box.height());
+
+    return transform.map(translation);
+}
+
+Gfx::AffineTransform Type1FontProgram::glyph_transform_to_device_space(Glyph const& glyph, float width) const
+{
+    auto scale = width / (m_font_matrix.a() * glyph.width + m_font_matrix.e());
+    auto transform = m_font_matrix;
+
+    // Convert character space to device space.
+    transform.scale(scale, -scale);
+
+    return transform;
+}
+
+PDFErrorOr<Type1FontProgram::Glyph> Type1FontProgram::parse_glyph(ReadonlyBytes const& data, Vector<ByteBuffer> const& subroutines, GlyphParserState& state)
+{
+    auto push = [&](float value) -> PDFErrorOr<void> {
+        if (state.sp >= state.stack.size())
+            return error("Operand stack overflow");
+        state.stack[state.sp++] = value;
+        return {};
+    };
+
+    auto pop = [&]() -> float {
+        return state.sp ? state.stack[--state.sp] : 0.0f;
+    };
+
+    auto& path = state.glyph.path;
+
+    // Parse the stream of parameters and commands that make up a glyph outline.
+    for (size_t i = 0; i < data.size(); ++i) {
+        auto require = [&](unsigned num) -> PDFErrorOr<void> {
+            if (i + num >= data.size())
+                return error("Malformed glyph outline definition");
+            return {};
+        };
+
+        int v = data[i];
+        if (v == 255) {
+            TRY(require(4));
+            int a = data[++i];
+            int b = data[++i];
+            int c = data[++i];
+            int d = data[++i];
+            TRY(push((a << 24) + (b << 16) + (c << 8) + d));
+        } else if (v >= 251) {
+            TRY(require(1));
+            auto w = data[++i];
+            TRY(push(-((v - 251) * 256) - w - 108));
+        } else if (v >= 247) {
+            TRY(require(1));
+            auto w = data[++i];
+            TRY(push(((v - 247) * 256) + w + 108));
+        } else if (v >= 32) {
+            TRY(push(v - 139));
+        } else {
+            // Not a parameter but a command byte.
+            switch (v) {
+            case HStem:
+            case VStem:
+                state.sp = 0;
+                break;
+
+            case VMoveTo: {
+                auto dy = pop();
+
+                state.point.translate_by(0.0f, dy);
+
+                if (state.flex_feature) {
+                    state.flex_sequence[state.flex_index++] = state.point.x();
+                    state.flex_sequence[state.flex_index++] = state.point.y();
+                } else {
+                    path.move_to(state.point);
+                }
+                state.sp = 0;
+                break;
+            }
+
+            case RLineTo: {
+                auto dy = pop();
+                auto dx = pop();
+
+                state.point.translate_by(dx, dy);
+                path.line_to(state.point);
+                state.sp = 0;
+                break;
+            }
+
+            case HLineTo: {
+                auto dx = pop();
+
+                state.point.translate_by(dx, 0.0f);
+                path.line_to(state.point);
+                state.sp = 0;
+                break;
+            }
+
+            case VLineTo: {
+                auto dy = pop();
+
+                state.point.translate_by(0.0f, dy);
+                path.line_to(state.point);
+                state.sp = 0;
+                break;
+            }
+
+            case RRCurveTo: {
+                auto dy3 = pop();
+                auto dx3 = pop();
+                auto dy2 = pop();
+                auto dx2 = pop();
+                auto dy1 = pop();
+                auto dx1 = pop();
+
+                auto& point = state.point;
+
+                path.cubic_bezier_curve_to(
+                    point + Gfx::FloatPoint(dx1, dy1),
+                    point + Gfx::FloatPoint(dx1 + dx2, dy1 + dy2),
+                    point + Gfx::FloatPoint(dx1 + dx2 + dx3, dy1 + dy2 + dy3));
+
+                point.translate_by(dx1 + dx2 + dx3, dy1 + dy2 + dy3);
+                state.sp = 0;
+                break;
+            }
+
+            case ClosePath:
+                path.close();
+                state.sp = 0;
+                break;
+
+            case CallSubr: {
+                auto subr_number = pop();
+                if (static_cast<size_t>(subr_number) >= subroutines.size())
+                    return error("Subroutine index out of range");
+
+                // Subroutines 0-2 handle the flex feature.
+                if (subr_number == 0) {
+                    if (state.flex_index != 14)
+                        break;
+
+                    auto& flex = state.flex_sequence;
+
+                    path.cubic_bezier_curve_to(
+                        { flex[2], flex[3] },
+                        { flex[4], flex[5] },
+                        { flex[6], flex[7] });
+                    path.cubic_bezier_curve_to(
+                        { flex[8], flex[9] },
+                        { flex[10], flex[11] },
+                        { flex[12], flex[13] });
+
+                    state.flex_feature = false;
+                    state.sp = 0;
+                } else if (subr_number == 1) {
+                    state.flex_feature = true;
+                    state.flex_index = 0;
+                    state.sp = 0;
+                } else if (subr_number == 2) {
+                    state.sp = 0;
+                } else {
+                    auto subr = subroutines[subr_number];
+                    if (subr.is_empty())
+                        return error("Empty subroutine");
+
+                    TRY(parse_glyph(subr, subroutines, state));
+                }
+                break;
+            }
+
+            case Return:
+                break;
+
+            case Extended: {
+                TRY(require(1));
+                switch (data[++i]) {
+                case DotSection:
+                case VStem3:
+                case HStem3:
+                case Seac:
+                    // FIXME: Do something with these?
+                    state.sp = 0;
+                    break;
+
+                case Div: {
+                    auto num2 = pop();
+                    auto num1 = pop();
+
+                    TRY(push(num2 ? num1 / num2 : 0.0f));
+                    break;
+                }
+
+                case CallOtherSubr: {
+                    auto othersubr_number = pop();
+                    auto n = static_cast<int>(pop());
+
+                    if (othersubr_number == 0) {
+                        state.postscript_stack[state.postscript_sp++] = pop();
+                        state.postscript_stack[state.postscript_sp++] = pop();
+                        pop();
+                    } else if (othersubr_number == 3) {
+                        state.postscript_stack[state.postscript_sp++] = 3;
+                    } else {
+                        for (int i = 0; i < n; ++i)
+                            state.postscript_stack[state.postscript_sp++] = pop();
+                    }
+
+                    (void)othersubr_number;
+                    break;
+                }
+
+                case Pop:
+                    TRY(push(state.postscript_stack[--state.postscript_sp]));
+                    break;
+
+                case SetCurrentPoint: {
+                    auto y = pop();
+                    auto x = pop();
+
+                    state.point = { x, y };
+                    path.move_to(state.point);
+                    state.sp = 0;
+                    break;
+                }
+
+                default:
+                    return error(DeprecatedString::formatted("Unhandled command: 12 {}", data[i]));
+                }
+                break;
+            }
+
+            case HSbW: {
+                auto wx = pop();
+                auto sbx = pop();
+
+                state.glyph.width = wx;
+                state.point = { sbx, 0.0f };
+                state.sp = 0;
+                break;
+            }
+
+            case EndChar:
+                break;
+
+            case RMoveTo: {
+                auto dy = pop();
+                auto dx = pop();
+
+                state.point.translate_by(dx, dy);
+
+                if (state.flex_feature) {
+                    state.flex_sequence[state.flex_index++] = state.point.x();
+                    state.flex_sequence[state.flex_index++] = state.point.y();
+                } else {
+                    path.move_to(state.point);
+                }
+                state.sp = 0;
+                break;
+            }
+
+            case HMoveTo: {
+                auto dx = pop();
+
+                state.point.translate_by(dx, 0.0f);
+
+                if (state.flex_feature) {
+                    state.flex_sequence[state.flex_index++] = state.point.x();
+                    state.flex_sequence[state.flex_index++] = state.point.y();
+                } else {
+                    path.move_to(state.point);
+                }
+                state.sp = 0;
+                break;
+            }
+
+            case VHCurveTo: {
+                auto dx3 = pop();
+                auto dy2 = pop();
+                auto dx2 = pop();
+                auto dy1 = pop();
+
+                auto& point = state.point;
+
+                path.cubic_bezier_curve_to(
+                    point + Gfx::FloatPoint(0.0f, dy1),
+                    point + Gfx::FloatPoint(dx2, dy1 + dy2),
+                    point + Gfx::FloatPoint(dx2 + dx3, dy1 + dy2));
+
+                point.translate_by(dx2 + dx3, dy1 + dy2);
+                state.sp = 0;
+                break;
+            }
+
+            case HVCurveTo: {
+                auto dy3 = pop();
+                auto dy2 = pop();
+                auto dx2 = pop();
+                auto dx1 = pop();
+
+                auto& point = state.point;
+
+                path.cubic_bezier_curve_to(
+                    point + Gfx::FloatPoint(dx1, 0.0f),
+                    point + Gfx::FloatPoint(dx1 + dx2, dy2),
+                    point + Gfx::FloatPoint(dx1 + dx2, dy2 + dy3));
+
+                point.translate_by(dx1 + dx2, dy2 + dy3);
+                state.sp = 0;
+                break;
+            }
+
+            default:
+                return error(DeprecatedString::formatted("Unhandled command: {}", v));
+            }
+        }
+    }
+
+    return state.glyph;
+}
+
+Error Type1FontProgram::error(
+    DeprecatedString const& message
+#ifdef PDF_DEBUG
+    ,
+    SourceLocation loc
+#endif
+)
+{
+#ifdef PDF_DEBUG
+    dbgln("\033[31m{} Type 1 font error: {}\033[0m", loc, message);
+#endif
+
+    return Error { Error::Type::MalformedPDF, message };
+}
+
+}

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023, Rodrigo Tobar <rtobarc@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Debug.h>
+#include <AK/SourceLocation.h>
+#include <LibGfx/Font/Font.h>
+#include <LibGfx/Path.h>
+#include <LibPDF/Encoding.h>
+#include <LibPDF/Error.h>
+
+namespace PDF {
+
+class Encoding;
+
+class Type1FontProgram : public RefCounted<Type1FontProgram> {
+
+public:
+    RefPtr<Gfx::Bitmap> rasterize_glyph(u32 char_code, float width, Gfx::GlyphSubpixelOffset subpixel_offset);
+    Gfx::FloatPoint glyph_translation(u32 char_code, float width) const;
+    RefPtr<Encoding> encoding() const { return m_encoding; }
+
+protected:
+    struct Glyph {
+        Gfx::Path path;
+        float width;
+    };
+
+    struct GlyphParserState {
+        Glyph glyph;
+
+        Gfx::FloatPoint point;
+
+        bool flex_feature { false };
+        size_t flex_index;
+        Array<float, 14> flex_sequence;
+
+        size_t sp { 0 };
+        Array<float, 24> stack;
+
+        size_t postscript_sp { 0 };
+        Array<float, 24> postscript_stack;
+    };
+
+    static PDFErrorOr<Glyph> parse_glyph(ReadonlyBytes const&, Vector<ByteBuffer> const&, GlyphParserState&);
+
+    static Error error(
+        DeprecatedString const& message
+#ifdef PDF_DEBUG
+        ,
+        SourceLocation loc = SourceLocation::current()
+#endif
+    );
+
+    void set_encoding(RefPtr<Encoding>&& encoding)
+    {
+        m_encoding = move(encoding);
+    }
+
+    void set_font_matrix(Gfx::AffineTransform&& font_matrix)
+    {
+        m_font_matrix = move(font_matrix);
+    }
+
+    PDFErrorOr<void> add_glyph(u16 char_code, Glyph&& glyph)
+    {
+        TRY(m_glyph_map.try_set(char_code, glyph));
+        return {};
+    }
+
+private:
+    HashMap<u16, Glyph> m_glyph_map;
+    Gfx::AffineTransform m_font_matrix;
+    RefPtr<Encoding> m_encoding;
+
+    Gfx::Path build_char(u32 char_code, float width, Gfx::GlyphSubpixelOffset subpixel_offset);
+    Gfx::AffineTransform glyph_transform_to_device_space(Glyph const& glyph, float width) const;
+};
+
+}

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
@@ -27,7 +27,8 @@ public:
 protected:
     struct Glyph {
         Gfx::Path path;
-        float width;
+        float width { 0 };
+        bool width_specified { false };
     };
 
     struct GlyphParserState {
@@ -41,12 +42,13 @@ protected:
 
         size_t sp { 0 };
         Array<float, 24> stack;
+        u8 n_hints { 0 };
 
         size_t postscript_sp { 0 };
         Array<float, 24> postscript_stack;
     };
 
-    static PDFErrorOr<Glyph> parse_glyph(ReadonlyBytes const&, Vector<ByteBuffer> const&, GlyphParserState&);
+    static PDFErrorOr<Glyph> parse_glyph(ReadonlyBytes const&, Vector<ByteBuffer> const&, GlyphParserState&, bool is_type2);
 
     static Error error(
         DeprecatedString const& message

--- a/Userland/Libraries/LibPDF/Reader.h
+++ b/Userland/Libraries/LibPDF/Reader.h
@@ -12,6 +12,7 @@
 #include <AK/ScopeGuard.h>
 #include <AK/Span.h>
 #include <AK/Vector.h>
+#include <LibPDF/Error.h>
 
 namespace PDF {
 
@@ -57,6 +58,16 @@ public:
         T value = reinterpret_cast<T const*>(m_bytes.offset(m_offset))[0];
         move_by(sizeof(T));
         return value;
+    }
+
+    template<typename T = char>
+    PDFErrorOr<T> try_read()
+    {
+        if (sizeof(T) + m_offset >= m_bytes.size()) {
+            auto message = DeprecatedString::formatted("Cannot read {} bytes at offset {} of ReadonlyBytes of size {}", sizeof(T), m_offset, m_bytes.size());
+            return Error { Error::Type::Parse, message };
+        }
+        return read<T>();
     }
 
     char peek(size_t shift = 0) const


### PR DESCRIPTION
PDF documents have different types of fonts embedded in them. Type 1 fonts are fairly common, and we have supported some of them for a while. However, the embedded font programs Type 1 fonts can be in different formats. The one we have supported so far is the original Adobe Type 1 Font Format (based on PostScript), but many others are in Compact Font Format (CFF). These latter Type 1 fonts are called "Type1C" fonts.

This PR adds the initial support for rendering Type1C fonts. It includes a basic CFF parser that we use to read the required definitions from the CFF stream. The contents of a CFF program are very similar to those in the original PostScript Type 1 programs, to the degree that in CFF the charstring definitions (i.e., the path traces that make up each individual glyph) are a superset of PS's. To avoid repeating ourselves, I've thus refactored the PS Type 1 font program logic to be able to use the charstring parsing, and enhance it to support the modifications required to read CFF's charstrings.

An example document that uses Type1C fonts is, well, the PDF standard document. This is how the cover looked before these changes:

![PDF32000_2008.pdf_p1_before](https://user-images.githubusercontent.com/620848/213249937-68d777be-11f6-4886-8359-276113260161.png)

And after:

![PDF32000_2008.pdf_p1_after](https://user-images.githubusercontent.com/620848/213249539-1fc9854f-bc10-47c1-a69f-adf78b013ada.png)

For reference, this is with evince:

![PDF32000_2008.pdf_p1_ref_evince](https://user-images.githubusercontent.com/620848/213250283-b7e39447-e6b6-4d0c-a5a6-02e06b04ad86.png)

Notes after those images:
 * You will note that some glyphs have a size different from the one they should have. This is a fault in our Type1 cache implementation, not a problem that is specific to Type1C fonts. I didn't want to include those changes here, but I've identified the problem and will provide a solution.
 * (See #17149) You'll note that some emdash glyphs are missing. After some more code and standard reading, I believe this is because the way we implement and use encodings is wrong, and unnecessarily complex. After some minor experiments locally I *can* get the emdashes to display, but again I held back from including these changes in favour of tackling these encoding issues more broadly separately.