### PR TITLE
PixelPaint: Make color picking with the Alt key behave the same as the picker tool

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -364,11 +364,6 @@ void ImageEditor::mousedown_event(GUI::MouseEvent& event)
         return;
     }
 
-    if (event.alt() && !m_active_tool->is_overriding_alt()) {
-        set_editor_color_to_color_at_mouse_position(event);
-        return; // Pick Color instead of acivating active tool when holding alt.
-    }
-
     if (!m_active_tool)
         return;
 
@@ -379,6 +374,11 @@ void ImageEditor::mousedown_event(GUI::MouseEvent& event)
     }
 
     auto layer_event = m_active_layer ? event_adjusted_for_layer(event, *m_active_layer) : event;
+    if (event.alt() && !m_active_tool->is_overriding_alt()) {
+        set_editor_color_to_color_at_mouse_position(layer_event);
+        return; // Pick Color instead of acivating active tool when holding alt.
+    }
+
     auto image_event = event_with_pan_and_scale_applied(event);
     Tool::MouseEvent tool_event(Tool::MouseEvent::Action::MouseDown, layer_event, image_event, event);
     m_active_tool->on_mousedown(m_active_layer.ptr(), tool_event);

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -412,10 +412,13 @@ void ImageEditor::mousemove_event(GUI::MouseEvent& event)
         on_image_mouse_position_change(image_event.position());
     }
 
-    if (!m_active_tool || (event.alt() && !m_active_tool->is_overriding_alt()))
-        return;
-
     auto layer_event = m_active_layer ? event_adjusted_for_layer(event, *m_active_layer) : event;
+    if (m_active_tool && event.alt() && !m_active_tool->is_overriding_alt()) {
+        set_override_cursor(Gfx::StandardCursor::Eyedropper);
+        set_editor_color_to_color_at_mouse_position(layer_event);
+        return;
+    }
+
     Tool::MouseEvent tool_event(Tool::MouseEvent::Action::MouseDown, layer_event, image_event, event);
     m_active_tool->on_mousemove(m_active_layer.ptr(), tool_event);
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -420,7 +420,9 @@ void ImageEditor::mousemove_event(GUI::MouseEvent& event)
 
 void ImageEditor::mouseup_event(GUI::MouseEvent& event)
 {
-    set_override_cursor(m_active_cursor);
+    if (!(m_active_tool && event.alt() && !m_active_tool->is_overriding_alt()))
+        set_override_cursor(m_active_cursor);
+
     if (event.button() == GUI::MouseButton::Middle) {
         stop_panning();
         return;
@@ -449,7 +451,13 @@ void ImageEditor::keydown_event(GUI::KeyEvent& event)
         return;
     }
 
-    if (m_active_tool && m_active_tool->on_keydown(event))
+    if (!m_active_tool)
+        return;
+
+    if (!m_active_tool->is_overriding_alt() && event.key() == Key_Alt)
+        set_override_cursor(Gfx::StandardCursor::Eyedropper);
+
+    if (m_active_tool->on_keydown(event))
         return;
 
     if (event.key() == Key_Escape && !m_image->selection().is_empty()) {
@@ -463,8 +471,13 @@ void ImageEditor::keydown_event(GUI::KeyEvent& event)
 
 void ImageEditor::keyup_event(GUI::KeyEvent& event)
 {
-    if (m_active_tool)
-        m_active_tool->on_keyup(event);
+    if (!m_active_tool)
+        return;
+
+    if (!m_active_tool->is_overriding_alt() && event.key() == Key_Alt)
+        update_tool_cursor();
+
+    m_active_tool->on_keyup(event);
 }
 
 void ImageEditor::enter_event(Core::Event&)

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -386,6 +386,8 @@ void ImageEditor::mousedown_event(GUI::MouseEvent& event)
 
 void ImageEditor::doubleclick_event(GUI::MouseEvent& event)
 {
+    if (!m_active_tool || (event.alt() && !m_active_tool->is_overriding_alt()))
+        return;
     auto layer_event = m_active_layer ? event_adjusted_for_layer(event, *m_active_layer) : event;
     auto image_event = event_with_pan_and_scale_applied(event);
     Tool::MouseEvent tool_event(Tool::MouseEvent::Action::DoubleClick, layer_event, image_event, event);
@@ -405,13 +407,13 @@ void ImageEditor::mousemove_event(GUI::MouseEvent& event)
         return;
     }
 
-    if (!m_active_tool)
-        return;
-
     auto image_event = event_with_pan_and_scale_applied(event);
     if (on_image_mouse_position_change) {
         on_image_mouse_position_change(image_event.position());
     }
+
+    if (!m_active_tool || (event.alt() && !m_active_tool->is_overriding_alt()))
+        return;
 
     auto layer_event = m_active_layer ? event_adjusted_for_layer(event, *m_active_layer) : event;
     Tool::MouseEvent tool_event(Tool::MouseEvent::Action::MouseDown, layer_event, image_event, event);
@@ -428,7 +430,7 @@ void ImageEditor::mouseup_event(GUI::MouseEvent& event)
         return;
     }
 
-    if (!m_active_tool)
+    if (!m_active_tool || (event.alt() && !m_active_tool->is_overriding_alt()))
         return;
     auto layer_event = m_active_layer ? event_adjusted_for_layer(event, *m_active_layer) : event;
     auto image_event = event_with_pan_and_scale_applied(event);


### PR DESCRIPTION
This set of commits makes color picking using the Alt key behave the same way as color picking with the picker tool.