### PR TITLE
PixelPaint+ImageDecoder+Base: Open TGA and ICO files with ImageViewer and PixelPaint

### DIFF
--- a/Base/res/apps/ImageViewer.af
+++ b/Base/res/apps/ImageViewer.af
@@ -4,4 +4,4 @@ Executable=/bin/ImageViewer
 Category=Graphics
 
 [Launcher]
-FileTypes=bmp,pbm,pgm,png,ppm,gif,jpg,jpeg,dds,qoi,tga
+FileTypes=bmp,dds,gif,ico,jpeg,jpg,pbm,pgm,png,ppm,qoi,tga

--- a/Base/res/apps/PixelPaint.af
+++ b/Base/res/apps/PixelPaint.af
@@ -4,4 +4,4 @@ Executable=/bin/PixelPaint
 Category=Graphics
 
 [Launcher]
-FileTypes=pp,bmp,pbm,pgm,png,ppm,gif,jpg,jpeg,dds,qoi
+FileTypes=bmp,dds,gif,ico,jpeg,jpg,pbm,pgm,png,pp,ppm,qoi,tga

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -15,6 +15,7 @@
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/Result.h>
+#include <AK/StringView.h>
 #include <LibGUI/Command.h>
 #include <LibGUI/Forward.h>
 #include <LibGfx/Bitmap.h>
@@ -49,7 +50,7 @@ public:
     static ErrorOr<NonnullRefPtr<Image>> try_create_from_pixel_paint_json(JsonObject const&);
     static ErrorOr<NonnullRefPtr<Image>> try_create_from_bitmap(NonnullRefPtr<Gfx::Bitmap> const&);
 
-    static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> try_decode_bitmap(ReadonlyBytes);
+    static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> try_decode_bitmap(StringView path, ReadonlyBytes);
 
     // This generates a new Bitmap with the final image (all layers composed according to their attributes.)
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> try_compose_bitmap(Gfx::BitmapFormat format) const;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1097,7 +1097,7 @@ void MainWidget::set_actions_enabled(bool enabled)
 
 void MainWidget::open_image(FileSystemAccessClient::File file)
 {
-    auto try_load = m_loader.try_load_from_file(file.release_stream());
+    auto try_load = m_loader.try_load_from_file(file.filename(), file.release_stream());
     if (try_load.is_error()) {
         GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Unable to open file: {}, {}", file.filename(), try_load.error()));
         return;

--- a/Userland/Applications/PixelPaint/ProjectLoader.cpp
+++ b/Userland/Applications/PixelPaint/ProjectLoader.cpp
@@ -15,7 +15,7 @@
 
 namespace PixelPaint {
 
-ErrorOr<void> ProjectLoader::try_load_from_file(NonnullOwnPtr<Core::Stream::File> file)
+ErrorOr<void> ProjectLoader::try_load_from_file(StringView path, NonnullOwnPtr<Core::Stream::File> file)
 {
     auto contents = TRY(file->read_until_eof());
 
@@ -24,7 +24,7 @@ ErrorOr<void> ProjectLoader::try_load_from_file(NonnullOwnPtr<Core::Stream::File
         m_is_raw_image = true;
 
         // FIXME: Find a way to avoid the memory copy here.
-        auto bitmap = TRY(Image::try_decode_bitmap(contents));
+        auto bitmap = TRY(Image::try_decode_bitmap(path, contents));
         auto image = TRY(Image::try_create_from_bitmap(move(bitmap)));
 
         m_image = image;

--- a/Userland/Applications/PixelPaint/ProjectLoader.h
+++ b/Userland/Applications/PixelPaint/ProjectLoader.h
@@ -18,7 +18,7 @@ public:
     ProjectLoader() = default;
     ~ProjectLoader() = default;
 
-    ErrorOr<void> try_load_from_file(NonnullOwnPtr<Core::Stream::File>);
+    ErrorOr<void> try_load_from_file(StringView path, NonnullOwnPtr<Core::Stream::File>);
 
     bool is_raw_image() const { return m_is_raw_image; }
     bool has_image() const { return !m_image.is_null(); }

--- a/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -73,7 +73,7 @@ Messages::ImageDecoderServer::DecodeImageWithKnownPathResponse ConnectionFromCli
     u32 loop_count = 0;
     Vector<Gfx::ShareableBitmap> bitmaps;
     Vector<u32> durations;
-    decode_image_to_details(encoded_buffer, path.substring_view(0), is_animated, loop_count, bitmaps, durations);
+    decode_image_to_details(encoded_buffer, path, is_animated, loop_count, bitmaps, durations);
     return { is_animated, loop_count, bitmaps, durations };
 }
 


### PR DESCRIPTION
Both TGA and ICO images can now easily be opened in either ImageViewer or PixelPaint.

![image](https://user-images.githubusercontent.com/3210731/213295841-e85e3a0f-a81a-4162-bc98-12c51f872d7b.png)
