### PR TITLE
Kernel: Add CPU randomness support for Aarch64

### DIFF
--- a/Kernel/Arch/aarch64/ASM_wrapper.h
+++ b/Kernel/Arch/aarch64/ASM_wrapper.h
@@ -91,6 +91,19 @@ inline void enter_el1_from_el2()
                      : "x0");
 }
 
+inline u64 read_rndrrs()
+{
+    u64 value = 0;
+
+    asm volatile(
+        "retry:\n"
+        "mrs %[value], s3_3_c2_c4_1 \n" // encoded RNDRRS register
+        "b.eq retry\n"
+        : [value] "=r"(value));
+
+    return value;
+}
+
 }
 
 namespace Kernel {

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -46,6 +46,8 @@ void Processor::initialize()
     dmesgln("CPU[{}]: Supports {}", m_cpu, build_cpu_feature_names(m_features));
     dmesgln("CPU[{}]: Physical address bit width: {}", m_cpu, m_physical_address_bit_width);
     dmesgln("CPU[{}]: Virtual address bit width: {}", m_cpu, m_virtual_address_bit_width);
+    if (!has_feature(CPUFeature::RNG))
+        dmesgln("CPU[{}]: {} not detected, randomness will be poor", m_cpu, cpu_feature_to_description(CPUFeature::RNG));
 }
 
 [[noreturn]] void Processor::halt()

--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -174,7 +174,6 @@ extern "C" [[noreturn]] void init()
 
     dmesgln("Starting SerenityOS...");
 
-    dmesgln("Initialize MMU");
     Memory::MemoryManager::initialize(0);
     DeviceManagement::initialize();
     SysFSComponentRegistry::initialize();

--- a/Kernel/Arch/x86_64/ASM_wrapper.h
+++ b/Kernel/Arch/x86_64/ASM_wrapper.h
@@ -128,7 +128,7 @@ ALWAYS_INLINE u64 read_tsc()
     return ((u64)msw << 32) | lsw;
 }
 
-ALWAYS_INLINE u32 rdrand()
+ALWAYS_INLINE u32 read_rdrand()
 {
     u32 value;
     asm volatile(
@@ -139,7 +139,7 @@ ALWAYS_INLINE u32 rdrand()
     return value;
 }
 
-ALWAYS_INLINE u32 rdseed()
+ALWAYS_INLINE u32 read_rdseed()
 {
     u32 value;
     asm volatile(

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -652,6 +652,7 @@ void MemoryManager::release_pte(PageDirectory& page_directory, VirtualAddress va
 
 UNMAP_AFTER_INIT void MemoryManager::initialize(u32 cpu)
 {
+    dmesgln("Initialize MMU");
     ProcessorSpecific<MemoryManagerData>::initialize();
 
     if (cpu == 0) {

--- a/Kernel/Prekernel/init.cpp
+++ b/Kernel/Prekernel/init.cpp
@@ -238,11 +238,11 @@ u64 generate_secure_seed()
         seed ^= read_tsc();
 
     if (processor_info.ecx() & (1 << 30)) // RDRAND
-        seed ^= rdrand();
+        seed ^= read_rdrand();
 
     CPUID extended_features(0x7);
     if (extended_features.ebx() & (1 << 18)) // RDSEED
-        seed ^= rdseed();
+        seed ^= read_rdseed();
 #else
 #    warning No native randomness source available for this architecture
 #endif

--- a/Kernel/Random.cpp
+++ b/Kernel/Random.cpp
@@ -33,13 +33,13 @@ UNMAP_AFTER_INIT KernelRng::KernelRng()
         dmesgln("KernelRng: Using RDSEED as entropy source");
 
         for (size_t i = 0; i < pool_count * reseed_threshold; ++i) {
-            add_random_event(Kernel::rdseed(), i % 32);
+            add_random_event(Kernel::read_rdseed(), i % 32);
         }
     } else if (Processor::current().has_feature(CPUFeature::RDRAND)) {
         dmesgln("KernelRng: Using RDRAND as entropy source");
 
         for (size_t i = 0; i < pool_count * reseed_threshold; ++i) {
-            add_random_event(Kernel::rdrand(), i % 32);
+            add_random_event(Kernel::read_rdrand(), i % 32);
         }
     } else if (TimeManagement::the().can_query_precise_time()) {
         // Add HPET as entropy source if we don't have anything better.


### PR DESCRIPTION
This does not touch undocumented RNG of Raspberry Pi’s in any way—just relies on `RNG` CPU feature providing two registers: `RNDR` and `RNDRRS`—only the latter one has accessor implemented and used to as an entropy source during `KernelRng` initialization).

Additionally small unifications for respective x86-64 code are made.