### PR TITLE
WindowServer: Double click a window frame's edge to latch onto screen edge

### DIFF
--- a/Userland/Services/WindowServer/MenuManager.cpp
+++ b/Userland/Services/WindowServer/MenuManager.cpp
@@ -168,7 +168,7 @@ void MenuManager::handle_mouse_event(MouseEvent& mouse_event)
     bool event_is_inside_current_menu = window->rect().contains(mouse_event.position());
     if (event_is_inside_current_menu) {
         WindowManager::the().set_hovered_window(window);
-        WindowManager::the().deliver_mouse_event(*window, mouse_event, true);
+        WindowManager::the().deliver_mouse_event(*window, mouse_event);
         return;
     }
 
@@ -204,7 +204,7 @@ void MenuManager::handle_mouse_event(MouseEvent& mouse_event)
             if (!menu->menu_window()->rect().contains(mouse_event.position()))
                 continue;
             WindowManager::the().set_hovered_window(menu->menu_window());
-            WindowManager::the().deliver_mouse_event(*menu->menu_window(), mouse_event, true);
+            WindowManager::the().deliver_mouse_event(*menu->menu_window(), mouse_event);
             break;
         }
     }

--- a/Userland/Services/WindowServer/WindowFrame.h
+++ b/Userland/Services/WindowServer/WindowFrame.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
-#include "HitTestResult.h"
 #include <AK/Forward.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/RefPtr.h>
 #include <LibCore/Forward.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/WindowTheme.h>
+#include <WindowServer/HitTestResult.h>
+#include <WindowServer/ResizeDirection.h>
 
 namespace WindowServer {
 
@@ -125,6 +126,7 @@ private:
     void paint_menubar(Gfx::Painter&);
     MultiScaleBitmaps const* shadow_bitmap() const;
     Gfx::IntRect inflated_for_shadow(Gfx::IntRect const&) const;
+    void latch_window_to_screen_edge(ResizeDirection);
 
     void handle_menubar_mouse_event(MouseEvent const&);
     void handle_menu_mouse_event(Menu&, MouseEvent const&);

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -860,6 +860,15 @@ bool WindowManager::process_ongoing_window_resize(MouseEvent const& event)
     if (!m_resize_window)
         return false;
 
+    // Deliver MouseDoubleClick events to the frame
+    if (event.type() == Event::MouseUp) {
+        auto& frame = m_resize_window->frame();
+        auto frame_event = event.translated(-frame.rect().location());
+        process_event_for_doubleclick(*m_resize_window, frame_event);
+        if (frame_event.type() == Event::MouseDoubleClick)
+            frame.handle_mouse_event(frame_event);
+    }
+
     if (event.type() == Event::MouseUp && event.button() == m_resizing_mouse_button) {
         dbgln_if(RESIZE_DEBUG, "[WM] Finish resizing Window({})", m_resize_window);
 

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1020,7 +1020,7 @@ bool WindowManager::process_ongoing_drag(MouseEvent& event)
         if (auto* window = hovered_window()) {
             event.set_drag(true);
             event.set_mime_data(*m_dnd_mime_data);
-            deliver_mouse_event(*window, event, false);
+            deliver_mouse_event(*window, event);
         } else {
             set_accepts_drag(false);
         }
@@ -1171,11 +1171,11 @@ void WindowManager::process_event_for_doubleclick(Window& window, MouseEvent& ev
     metadata.last_position = event.position();
 }
 
-void WindowManager::deliver_mouse_event(Window& window, MouseEvent const& event, bool process_double_click)
+void WindowManager::deliver_mouse_event(Window& window, MouseEvent const& event)
 {
     auto translated_event = event.translated(-window.position());
     window.dispatch_event(translated_event);
-    if (process_double_click && translated_event.type() == Event::MouseUp) {
+    if (translated_event.type() == Event::MouseUp) {
         process_event_for_doubleclick(window, translated_event);
         if (translated_event.type() == Event::MouseDoubleClick)
             window.dispatch_event(translated_event);
@@ -1194,7 +1194,7 @@ bool WindowManager::process_ongoing_active_input_mouse_event(MouseEvent const& e
     //
     // This prevents e.g. moving on one window out of the bounds starting
     // a move in that other unrelated window, and other silly shenanigans.
-    deliver_mouse_event(*input_tracking_window, event, true);
+    deliver_mouse_event(*input_tracking_window, event);
 
     if (event.type() == Event::MouseUp && event.buttons() == 0)
         set_automatic_cursor_tracking_window(nullptr);
@@ -1278,9 +1278,8 @@ void WindowManager::process_mouse_event_for_window(HitTestResult& result, MouseE
         return;
     }
 
-    if (!window.is_automatic_cursor_tracking()) {
-        deliver_mouse_event(window, event, true);
-    }
+    if (!window.is_automatic_cursor_tracking())
+        deliver_mouse_event(window, event);
 
     if (event.type() == Event::MouseDown)
         set_automatic_cursor_tracking_window(&window);
@@ -1306,7 +1305,7 @@ void WindowManager::process_mouse_event(MouseEvent& event)
     // in the next step.
     for_each_visible_window_from_front_to_back([&](Window& window) {
         if (window.is_automatic_cursor_tracking() && &window != automatic_cursor_tracking_window())
-            deliver_mouse_event(window, event, false);
+            deliver_mouse_event(window, event);
         return IterationDecision::Continue;
     });
 

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -210,7 +210,7 @@ public:
     bool is_theme_overridden() { return m_theme_overridden; }
 
     bool set_hovered_window(Window*);
-    void deliver_mouse_event(Window&, MouseEvent const&, bool process_double_click);
+    void deliver_mouse_event(Window&, MouseEvent const&);
 
     void did_popup_a_menu(Badge<Menu>);
 


### PR DESCRIPTION
And a bonus: somewhat simplified double click event processing in `WindowServer`. :^)

![screen-latch](https://user-images.githubusercontent.com/3210731/213319375-1cc46063-1b4b-430f-bf2f-a27086c08aea.gif)
