### PR TITLE
AK: Ensure a correct return type when creating a `Function`

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -36,6 +36,9 @@ concept Enum = IsEnum<T>;
 template<typename T, typename U>
 concept SameAs = IsSame<T, U>;
 
+template<class From, class To>
+concept ConvertibleTo = IsConvertible<From, To>;
+
 template<typename U, typename... Ts>
 concept OneOf = IsOneOf<U, Ts...>;
 
@@ -139,6 +142,7 @@ namespace AK {
 #endif
 using AK::Concepts::Arithmetic;
 using AK::Concepts::ArrayLike;
+using AK::Concepts::ConvertibleTo;
 using AK::Concepts::DerivedFrom;
 using AK::Concepts::Enum;
 using AK::Concepts::FallibleFunction;

--- a/AK/Function.h
+++ b/AK/Function.h
@@ -36,6 +36,16 @@
 
 namespace AK {
 
+namespace Detail {
+
+template<typename T, typename... Args>
+inline constexpr bool IsCallableWithArguments = requires(T t) {
+                                                    t(declval<Args>()...);
+                                                };
+}
+
+using Detail::IsCallableWithArguments;
+
 template<typename>
 class Function;
 
@@ -271,4 +281,5 @@ private:
 
 #if USING_AK_GLOBALLY
 using AK::Function;
+using AK::IsCallableWithArguments;
 #endif

--- a/AK/Function.h
+++ b/AK/Function.h
@@ -38,10 +38,16 @@ namespace AK {
 
 namespace Detail {
 
-template<typename T, typename... Args>
+template<typename T, typename Out, typename... Args>
 inline constexpr bool IsCallableWithArguments = requires(T t) {
-                                                    t(declval<Args>()...);
-                                                };
+                                                    {
+                                                        t(declval<Args>()...)
+                                                        } -> ConvertibleTo<Out>;
+                                                } || requires(T t) {
+                                                         {
+                                                             t(declval<Args>()...)
+                                                             } -> SameAs<Out>;
+                                                     };
 }
 
 using Detail::IsCallableWithArguments;
@@ -75,14 +81,14 @@ public:
 
     template<typename CallableType>
     Function(CallableType&& callable)
-    requires((IsFunctionObject<CallableType> && IsCallableWithArguments<CallableType, In...> && !IsSame<RemoveCVReference<CallableType>, Function>))
+    requires((IsFunctionObject<CallableType> && IsCallableWithArguments<CallableType, Out, In...> && !IsSame<RemoveCVReference<CallableType>, Function>))
     {
         init_with_callable(forward<CallableType>(callable));
     }
 
     template<typename FunctionType>
     Function(FunctionType f)
-    requires((IsFunctionPointer<FunctionType> && IsCallableWithArguments<RemovePointer<FunctionType>, In...> && !IsSame<RemoveCVReference<FunctionType>, Function>))
+    requires((IsFunctionPointer<FunctionType> && IsCallableWithArguments<RemovePointer<FunctionType>, Out, In...> && !IsSame<RemoveCVReference<FunctionType>, Function>))
     {
         init_with_callable(move(f));
     }
@@ -109,7 +115,7 @@ public:
 
     template<typename CallableType>
     Function& operator=(CallableType&& callable)
-    requires((IsFunctionObject<CallableType> && IsCallableWithArguments<CallableType, In...>))
+    requires((IsFunctionObject<CallableType> && IsCallableWithArguments<CallableType, Out, In...>))
     {
         clear();
         init_with_callable(forward<CallableType>(callable));
@@ -118,7 +124,7 @@ public:
 
     template<typename FunctionType>
     Function& operator=(FunctionType f)
-    requires((IsFunctionPointer<FunctionType> && IsCallableWithArguments<RemovePointer<FunctionType>, In...>))
+    requires((IsFunctionPointer<FunctionType> && IsCallableWithArguments<RemovePointer<FunctionType>, Out, In...>))
     {
         clear();
         if (f)

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -523,9 +523,6 @@ template<typename T>
 inline constexpr bool IsTriviallyCopyable = __is_trivially_copyable(T);
 
 template<typename T, typename... Args>
-inline constexpr bool IsCallableWithArguments = requires(T t) { t(declval<Args>()...); };
-
-template<typename T, typename... Args>
 inline constexpr bool IsConstructible = requires { ::new T(declval<Args>()...); };
 
 template<typename T, typename... Args>
@@ -635,7 +632,6 @@ using AK::Detail::IntegerSequence;
 using AK::Detail::IsArithmetic;
 using AK::Detail::IsAssignable;
 using AK::Detail::IsBaseOf;
-using AK::Detail::IsCallableWithArguments;
 using AK::Detail::IsClass;
 using AK::Detail::IsConst;
 using AK::Detail::IsConstructible;

--- a/Userland/Libraries/LibJS/SafeFunction.h
+++ b/Userland/Libraries/LibJS/SafeFunction.h
@@ -51,14 +51,14 @@ public:
 
     template<typename CallableType>
     SafeFunction(CallableType&& callable)
-    requires((AK::IsFunctionObject<CallableType> && IsCallableWithArguments<CallableType, In...> && !IsSame<RemoveCVReference<CallableType>, SafeFunction>))
+    requires((AK::IsFunctionObject<CallableType> && IsCallableWithArguments<CallableType, Out, In...> && !IsSame<RemoveCVReference<CallableType>, SafeFunction>))
     {
         init_with_callable(forward<CallableType>(callable), CallableKind::FunctionObject);
     }
 
     template<typename FunctionType>
     SafeFunction(FunctionType f)
-    requires((AK::IsFunctionPointer<FunctionType> && IsCallableWithArguments<RemovePointer<FunctionType>, In...> && !IsSame<RemoveCVReference<FunctionType>, SafeFunction>))
+    requires((AK::IsFunctionPointer<FunctionType> && IsCallableWithArguments<RemovePointer<FunctionType>, Out, In...> && !IsSame<RemoveCVReference<FunctionType>, SafeFunction>))
     {
         init_with_callable(move(f), CallableKind::FunctionPointer);
     }
@@ -85,7 +85,7 @@ public:
 
     template<typename CallableType>
     SafeFunction& operator=(CallableType&& callable)
-    requires((AK::IsFunctionObject<CallableType> && IsCallableWithArguments<CallableType, In...>))
+    requires((AK::IsFunctionObject<CallableType> && IsCallableWithArguments<CallableType, Out, In...>))
     {
         clear();
         init_with_callable(forward<CallableType>(callable));
@@ -94,7 +94,7 @@ public:
 
     template<typename FunctionType>
     SafeFunction& operator=(FunctionType f)
-    requires((AK::IsFunctionPointer<FunctionType> && IsCallableWithArguments<RemovePointer<FunctionType>, In...>))
+    requires((AK::IsFunctionPointer<FunctionType> && IsCallableWithArguments<RemovePointer<FunctionType>, Out, In...>))
     {
         clear();
         if (f)

--- a/Userland/Libraries/LibXML/Parser/Parser.cpp
+++ b/Userland/Libraries/LibXML/Parser/Parser.cpp
@@ -242,7 +242,7 @@ ErrorOr<void, ParseError> Parser::expect(StringView expected)
 }
 
 template<typename Pred>
-requires(IsCallableWithArguments<Pred, char>) ErrorOr<StringView, ParseError> Parser::expect(Pred predicate, StringView description)
+requires(IsCallableWithArguments<Pred, bool, char>) ErrorOr<StringView, ParseError> Parser::expect(Pred predicate, StringView description)
 {
     auto rollback = rollback_point();
     auto start = m_lexer.tell();
@@ -257,7 +257,7 @@ requires(IsCallableWithArguments<Pred, char>) ErrorOr<StringView, ParseError> Pa
 }
 
 template<typename Pred>
-requires(IsCallableWithArguments<Pred, char>) ErrorOr<StringView, ParseError> Parser::expect_many(Pred predicate, StringView description)
+requires(IsCallableWithArguments<Pred, bool, char>) ErrorOr<StringView, ParseError> Parser::expect_many(Pred predicate, StringView description)
 {
     auto rollback = rollback_point();
     auto start = m_lexer.tell();

--- a/Userland/Libraries/LibXML/Parser/Parser.h
+++ b/Userland/Libraries/LibXML/Parser/Parser.h
@@ -140,9 +140,9 @@ private:
 
     ErrorOr<void, ParseError> expect(StringView);
     template<typename Pred>
-    requires(IsCallableWithArguments<Pred, char>) ErrorOr<StringView, ParseError> expect(Pred, StringView description);
+    requires(IsCallableWithArguments<Pred, bool, char>) ErrorOr<StringView, ParseError> expect(Pred, StringView description);
     template<typename Pred>
-    requires(IsCallableWithArguments<Pred, char>) ErrorOr<StringView, ParseError> expect_many(Pred, StringView description);
+    requires(IsCallableWithArguments<Pred, bool, char>) ErrorOr<StringView, ParseError> expect_many(Pred, StringView description);
 
     static size_t s_debug_indent_level;
     [[nodiscard]] auto rollback_point(SourceLocation location = SourceLocation::current())


### PR DESCRIPTION
Template argument are checked to ensure that the `Out` type is equal or
convertible to the type returned by the invokee.

Compilation now fails on:
`Function<void()> f = []() -> int { return 0; };`

But this is allowed:
`Function<ErrorOr<int>()> f = []() -> int { return 0; };`