### PR TITLE
LibCore: Add support for non-trivial types to `Stream::*_value` (and add respective usages)

### DIFF
--- a/Userland/Libraries/LibDNS/Packet.cpp
+++ b/Userland/Libraries/LibDNS/Packet.cpp
@@ -53,19 +53,19 @@ ErrorOr<ByteBuffer> Packet::to_byte_buffer() const
 
     TRY(stream.write_value(header));
     for (auto& question : m_questions) {
-        TRY(question.name().write_to_stream(stream));
+        TRY(stream.write_value(question.name()));
         TRY(stream.write_value(htons((u16)question.record_type())));
         TRY(stream.write_value(htons(question.raw_class_code())));
     }
     for (auto& answer : m_answers) {
-        TRY(answer.name().write_to_stream(stream));
+        TRY(stream.write_value(answer.name()));
         TRY(stream.write_value(htons((u16)answer.type())));
         TRY(stream.write_value(htons(answer.raw_class_code())));
         TRY(stream.write_value(htonl(answer.ttl())));
         if (answer.type() == RecordType::PTR) {
             Name name { answer.record_data() };
             TRY(stream.write_value(htons(name.serialized_size())));
-            TRY(name.write_to_stream(stream));
+            TRY(stream.write_value(name));
         } else {
             TRY(stream.write_value(htons(answer.record_data().length())));
             TRY(stream.write_entire_buffer(answer.record_data().bytes()));

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -53,7 +53,7 @@ ErrorOr<void> DwarfInfo::populate_compilation_units()
     while (!debug_info_stream->is_eof()) {
         auto unit_offset = TRY(debug_info_stream->tell());
 
-        auto compilation_unit_header = TRY(CompilationUnitHeader::read_from_stream(*debug_info_stream));
+        auto compilation_unit_header = TRY(debug_info_stream->read_value<CompilationUnitHeader>());
         VERIFY(compilation_unit_header.common.version <= 5);
         VERIFY(compilation_unit_header.address_size() == sizeof(FlatPtr));
 

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -27,7 +27,7 @@ LineProgram::LineProgram(DwarfInfo& dwarf_info, Core::Stream::SeekableStream& st
 
 ErrorOr<void> LineProgram::parse_unit_header()
 {
-    m_unit_header = TRY(LineProgramUnitHeader32::read_from_stream(m_stream));
+    m_unit_header = TRY(m_stream.read_value<LineProgramUnitHeader32>());
 
     VERIFY(m_unit_header.version() >= MIN_DWARF_VERSION && m_unit_header.version() <= MAX_DWARF_VERSION);
     VERIFY(m_unit_header.opcode_base() <= sizeof(m_unit_header.std_opcode_lengths) / sizeof(m_unit_header.std_opcode_lengths[0]) + 1);


### PR DESCRIPTION
~~Looks like this is the last change (apart from locally staged stuff) before we have to start moving things to AK.~~