### PR TITLE
LibJS: Add a special ThrowCompletionOr constructor for OptionalNone

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Completion.h
+++ b/Userland/Libraries/LibJS/Runtime/Completion.h
@@ -277,6 +277,11 @@ public:
     ThrowCompletionOr(ThrowCompletionOr&&) = default;
     ThrowCompletionOr& operator=(ThrowCompletionOr&&) = default;
 
+    ThrowCompletionOr(OptionalNone value)
+        : m_value(ValueType { value })
+    {
+    }
+
     // Allows implicit construction of ThrowCompletionOr<T> from a type U if T(U) is a supported constructor.
     // Most commonly: Value from Object* or similar, so we can omit the curly braces from "return { TRY(...) };".
     // Disabled for POD types to avoid weird conversion shenanigans.

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -41,16 +41,16 @@ ThrowCompletionOr<Optional<::Locale::LocaleID>> is_structurally_valid_language_t
     // locale can be generated from the EBNF grammar for unicode_locale_id in Unicode Technical Standard #35 LDML § 3.2 Unicode Locale Identifier;
     auto locale_id = TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale));
     if (!locale_id.has_value())
-        return Optional<::Locale::LocaleID> {};
+        return OptionalNone {};
 
     // locale does not use any of the backwards compatibility syntax described in Unicode Technical Standard #35 LDML § 3.3 BCP 47 Conformance;
     // https://unicode.org/reports/tr35/#BCP_47_Conformance
     if (locale.contains('_') || locale_id->language_id.is_root || !locale_id->language_id.language.has_value())
-        return Optional<::Locale::LocaleID> {};
+        return OptionalNone {};
 
     // the unicode_language_id within locale contains no duplicate unicode_variant_subtag subtags; and
     if (TRY(contains_duplicate_variant(locale_id->language_id.variants)))
-        return Optional<::Locale::LocaleID> {};
+        return OptionalNone {};
 
     // if locale contains an extensions* component, that component
     Vector<char> unique_keys;
@@ -64,7 +64,8 @@ ThrowCompletionOr<Optional<::Locale::LocaleID>> is_structurally_valid_language_t
             [](::Locale::OtherExtension const& ext) { return static_cast<char>(to_ascii_lowercase(ext.key)); });
 
         if (unique_keys.contains_slow(key))
-            return Optional<::Locale::LocaleID> {};
+            return OptionalNone {};
+
         TRY_OR_THROW_OOM(vm, unique_keys.try_append(key));
 
         // if a transformed_extensions component that contains a tlang component is present, then

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -32,7 +32,7 @@ static ThrowCompletionOr<Optional<String>> get_string_option(VM& vm, Object cons
 {
     auto option = TRY(get_option(vm, options, property, OptionType::String, values, Empty {}));
     if (option.is_undefined())
-        return Optional<String> {};
+        return OptionalNone {};
 
     if (validator && !validator(TRY(option.as_string().utf8_string_view())))
         return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, option, property);


### PR DESCRIPTION
Currently, if you have a fallible function with an `Optional` return type
and try to return `OptionalNone` like this:

```c++
ThrowCompletionOr<Optional<SomeType>> { return OptionalNone {}; }
```

Then `ThrowCompletionOr`'s `m_value` (whose type is an `Optional<ValueType>`)
will be set to empty, rather than containing an empty `Optional`. This is
due to the `ThrowCompletionOr`'s `WrappedValueType` constructor.

This patch adds a constructor specifically for `OptionalNone`. If someone
attempts to construct a `ThrowCompletionOr` with `OptionalNone`, but the
`ValueType` is not an `Optional`, a compile error like the following will
occur:

```c++
ThrowCompletionOr<String> foo() { return OptionalNone {}; }

error: no matching constructor for initialization of 'AK::String'
```

Otherwise, it will fill `ThrowCompletionOr`'s `m_value` with an empty
`Optional`.