### PR TITLE
CI: Add GitHub author presence check in commit linter

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -66,7 +66,7 @@ jobs:
 
             const errors = [];
             for (const { sha, commit: { message }, author } of commits) {
-              if (excludedBotIds.includes(author.id)) {
+              if (author !== null && excludedBotIds.includes(author.id)) {
                 continue;
               }
               const commitErrors = [];


### PR DESCRIPTION
If GitHub is unable to match a commit's author to a GitHub user, the `.author` object is set to `null` in the API's response.