### PR TITLE
LibCards+Games: Propagate some errors!

### DIFF
--- a/AK/Random.h
+++ b/AK/Random.h
@@ -63,6 +63,19 @@ inline void shuffle(Collection& collection)
     }
 }
 
+// shuffle() implementation for NonnullPtrVector, since its operator[] returns a reference to the pointed-at value
+// instead of the pointer itself.
+template<typename Collection>
+requires(requires(Collection collection) { collection.ptr_at(0); })
+inline void shuffle(Collection& collection)
+{
+    // Fisher-Yates shuffle
+    for (size_t i = collection.size() - 1; i >= 1; --i) {
+        size_t j = get_random_uniform(i + 1);
+        AK::swap(collection.ptr_at(i), collection.ptr_at(j));
+    }
+}
+
 }
 
 #if USING_AK_GLOBALLY

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
@@ -39,10 +39,10 @@ public:
         TRY(preview->add_stack(point, Cards::CardStack::Type::Normal));
 
         for (size_t i = 0; i < Cards::Card::card_count; ++i)
-            preview->stack_at_location(0).push(TRY(Cards::Card::try_create(Cards::Suit::Diamonds, static_cast<Cards::Rank>(i))));
-        preview->stack_at_location(1).push(TRY(Cards::Card::try_create(Cards::Suit::Spades, Cards::Rank::Ace)));
-        preview->stack_at_location(2).push(TRY(Cards::Card::try_create(Cards::Suit::Hearts, Cards::Rank::Queen)));
-        preview->stack_at_location(3).push(TRY(Cards::Card::try_create(Cards::Suit::Clubs, Cards::Rank::Jack)));
+            TRY(preview->stack_at_location(0).push(TRY(Cards::Card::try_create(Cards::Suit::Diamonds, static_cast<Cards::Rank>(i)))));
+        TRY(preview->stack_at_location(1).push(TRY(Cards::Card::try_create(Cards::Suit::Spades, Cards::Rank::Ace))));
+        TRY(preview->stack_at_location(2).push(TRY(Cards::Card::try_create(Cards::Suit::Hearts, Cards::Rank::Queen))));
+        TRY(preview->stack_at_location(3).push(TRY(Cards::Card::try_create(Cards::Suit::Clubs, Cards::Rank::Jack))));
 
         preview->stack_at_location(0).peek().set_upside_down(true);
         preview->stack_at_location(2).set_highlighted(true);

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -199,7 +199,7 @@ void Game::setup(DeprecatedString player_name, int hand_number)
         m_passing_button->set_focus(false);
     }
 
-    NonnullRefPtrVector<Card> deck = Cards::create_standard_deck(Cards::Shuffle::Yes);
+    NonnullRefPtrVector<Card> deck = Cards::create_standard_deck(Cards::Shuffle::Yes).release_value_but_fixme_should_propagate_errors();
 
     for (auto& player : m_players) {
         player.hand.ensure_capacity(Card::card_count);

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -297,7 +297,7 @@ void Game::mouseup_event(GUI::MouseEvent& event)
         auto& stack = *target_stack;
         remember_move_for_undo(*moving_cards_source_stack(), stack, moving_cards());
 
-        drop_cards_on_stack(stack, Cards::CardStack::MovementRule::Alternating);
+        drop_cards_on_stack(stack, Cards::CardStack::MovementRule::Alternating).release_value_but_fixme_should_propagate_errors();
 
         if (moving_cards_source_stack()->type() == CardStack::Type::Play)
             pop_waste_to_play_stack();

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -266,7 +266,7 @@ void Game::mousedown_event(GUI::MouseEvent& event)
                     if (event.button() == GUI::MouseButton::Secondary) {
                         preview_card(to_check, click_location);
                     } else {
-                        pick_up_cards_from_stack(to_check, click_location, Cards::CardStack::MovementRule::Alternating);
+                        pick_up_cards_from_stack(to_check, click_location, Cards::CardStack::MovementRule::Alternating).release_value_but_fixme_should_propagate_errors();
                         m_mouse_down_location = click_location;
                         m_mouse_down = true;
                     }

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -70,9 +70,9 @@ void Game::timer_event(Core::TimerEvent&)
             if (current_pile.count() < m_new_game_animation_pile) {
                 auto card = m_new_deck.take_last();
                 card->set_upside_down(true);
-                current_pile.push(card);
+                current_pile.push(card).release_value_but_fixme_should_propagate_errors();
             } else {
-                current_pile.push(m_new_deck.take_last());
+                current_pile.push(m_new_deck.take_last()).release_value_but_fixme_should_propagate_errors();
                 ++m_new_game_animation_pile;
             }
 
@@ -81,7 +81,7 @@ void Game::timer_event(Core::TimerEvent&)
             if (m_new_game_animation_pile == piles.size()) {
                 auto& stock_pile = stack_at_location(Stock);
                 while (!m_new_deck.is_empty())
-                    stock_pile.push(m_new_deck.take_last());
+                    stock_pile.push(m_new_deck.take_last()).release_value_but_fixme_should_propagate_errors();
 
                 update(stock_pile.bounding_box());
 
@@ -404,13 +404,13 @@ void Game::draw_cards()
         NonnullRefPtrVector<Card> moved_cards;
         while (!play.is_empty()) {
             auto card = play.pop();
-            stock.push(card);
+            stock.push(card).release_value_but_fixme_should_propagate_errors();
             moved_cards.prepend(card);
         }
 
         while (!waste.is_empty()) {
             auto card = waste.pop();
-            stock.push(card);
+            stock.push(card).release_value_but_fixme_should_propagate_errors();
             moved_cards.prepend(card);
         }
 
@@ -424,7 +424,7 @@ void Game::draw_cards()
         update(stock.bounding_box());
     } else {
         auto play_bounding_box = play.bounding_box();
-        play.take_all(waste);
+        play.take_all(waste).release_value_but_fixme_should_propagate_errors();
 
         size_t cards_to_draw = 0;
         switch (m_mode) {
@@ -445,7 +445,7 @@ void Game::draw_cards()
         for (size_t i = 0; (i < cards_to_draw) && !stock.is_empty(); ++i) {
             auto card = stock.pop();
             cards_drawn.prepend(card);
-            play.push(move(card));
+            play.push(move(card)).release_value_but_fixme_should_propagate_errors();
         }
 
         remember_move_for_undo(stock, play, cards_drawn);
@@ -466,7 +466,7 @@ void Game::pop_waste_to_play_stack()
     if (play.is_empty() && !waste.is_empty()) {
         auto card = waste.pop();
         moving_cards().append(card);
-        play.push(move(card));
+        play.push(move(card)).release_value_but_fixme_should_propagate_errors();
     }
 }
 
@@ -490,7 +490,7 @@ bool Game::attempt_to_move_card_to_foundations(CardStack& from)
             auto card = from.pop();
 
             mark_intersecting_stacks_dirty(card);
-            foundation.push(card);
+            foundation.push(card).release_value_but_fixme_should_propagate_errors();
 
             NonnullRefPtrVector<Card> moved_card;
             moved_card.append(card);
@@ -612,12 +612,12 @@ void Game::perform_undo()
     if (m_last_move.from->type() == CardStack::Type::Play && m_mode == Mode::SingleCardDraw) {
         auto& waste = stack_at_location(Waste);
         if (!m_last_move.from->is_empty())
-            waste.push(m_last_move.from->pop());
+            waste.push(m_last_move.from->pop()).release_value_but_fixme_should_propagate_errors();
     }
 
     for (auto& to_intersect : m_last_move.cards) {
         mark_intersecting_stacks_dirty(to_intersect);
-        m_last_move.from->push(to_intersect);
+        m_last_move.from->push(to_intersect).release_value_but_fixme_should_propagate_errors();
         (void)m_last_move.to->pop();
     }
 
@@ -632,7 +632,7 @@ void Game::perform_undo()
             }
         }
         for (auto& card : cards_popped) {
-            play.push(card);
+            play.push(card).release_value_but_fixme_should_propagate_errors();
         }
     }
 

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -424,7 +424,7 @@ void Game::draw_cards()
         update(stock.bounding_box());
     } else {
         auto play_bounding_box = play.bounding_box();
-        play.move_to_stack(waste);
+        play.take_all(waste);
 
         size_t cards_to_draw = 0;
         switch (m_mode) {

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -168,7 +168,7 @@ void Game::setup(Mode mode)
     if (on_undo_availability_change)
         on_undo_availability_change(false);
 
-    m_new_deck = Cards::create_standard_deck(Cards::Shuffle::Yes);
+    m_new_deck = Cards::create_standard_deck(Cards::Shuffle::Yes).release_value_but_fixme_should_propagate_errors();
 
     clear_moving_cards();
 

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -95,7 +95,7 @@ void Game::perform_undo()
     for (size_t i = 0; i < m_last_move.card_count; i++)
         cards.append(m_last_move.to->pop());
     for (ssize_t i = m_last_move.card_count - 1; i >= 0; i--)
-        m_last_move.from->push(cards[i]);
+        m_last_move.from->push(cards[i]).release_value_but_fixme_should_propagate_errors();
 
     update_score(-1);
 
@@ -162,7 +162,7 @@ void Game::detect_full_stacks()
                 auto original_current_rect = current_pile.bounding_box();
 
                 for (size_t j = 0; j < Card::card_count; j++) {
-                    completed_stack.push(current_pile.pop());
+                    completed_stack.push(current_pile.pop()).release_value_but_fixme_should_propagate_errors();
                 }
 
                 update(original_current_rect);
@@ -384,9 +384,9 @@ void Game::timer_event(Core::TimerEvent&)
             if (current_pile.count() < (cards_to_draw - 1)) {
                 auto card = m_new_deck.take_last();
                 card->set_upside_down(true);
-                current_pile.push(card);
+                current_pile.push(card).release_value_but_fixme_should_propagate_errors();
             } else {
-                current_pile.push(m_new_deck.take_last());
+                current_pile.push(m_new_deck.take_last()).release_value_but_fixme_should_propagate_errors();
                 ++m_new_game_animation_pile;
             }
 
@@ -397,7 +397,7 @@ void Game::timer_event(Core::TimerEvent&)
 
                 auto& stock_pile = stack_at_location(Stock);
                 while (!m_new_deck.is_empty())
-                    stock_pile.push(m_new_deck.take_last());
+                    stock_pile.push(m_new_deck.take_last()).release_value_but_fixme_should_propagate_errors();
 
                 update(stock_pile.bounding_box());
 
@@ -414,7 +414,7 @@ void Game::timer_event(Core::TimerEvent&)
             auto& current_pile = stack_at_location(piles.at(m_draw_animation_pile));
             auto card = stock_pile.pop();
             card->set_upside_down(false);
-            current_pile.push(card);
+            current_pile.push(card).release_value_but_fixme_should_propagate_errors();
             update(current_pile.bounding_box());
             ++m_draw_animation_pile;
 

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -272,7 +272,7 @@ void Game::mousedown_event(GUI::MouseEvent& event)
                         update(top_card.rect());
                     }
                 } else if (!is_moving_cards()) {
-                    pick_up_cards_from_stack(to_check, click_location, Cards::CardStack::MovementRule::Same);
+                    pick_up_cards_from_stack(to_check, click_location, Cards::CardStack::MovementRule::Same).release_value_but_fixme_should_propagate_errors();
                     m_mouse_down_location = click_location;
                     // When the user wants to automatically move cards, do not go into the drag mode.
                     if (event.button() != GUI::MouseButton::Secondary)

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -288,7 +288,7 @@ void Game::mousedown_event(GUI::MouseEvent& event)
 void Game::move_focused_cards(CardStack& stack)
 {
     auto card_count = moving_cards().size();
-    drop_cards_on_stack(stack, Cards::CardStack::MovementRule::Any);
+    drop_cards_on_stack(stack, Cards::CardStack::MovementRule::Any).release_value_but_fixme_should_propagate_errors();
     bool was_visible = moving_cards_source_stack()->is_empty() || !moving_cards_source_stack()->peek().is_upside_down();
     remember_move_for_undo(*moving_cards_source_stack(), stack, card_count, was_visible);
     update_score(-1);

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -74,7 +74,7 @@ void Game::setup(Mode mode)
         break;
     }
 
-    m_new_deck = Cards::create_deck(0, 0, heart_suits, spade_suits, Cards::Shuffle::Yes);
+    m_new_deck = Cards::create_deck(0, 0, heart_suits, spade_suits, Cards::Shuffle::Yes).release_value_but_fixme_should_propagate_errors();
 
     clear_moving_cards();
 

--- a/Userland/Libraries/LibCards/Card.cpp
+++ b/Userland/Libraries/LibCards/Card.cpp
@@ -55,28 +55,29 @@ void Card::clear_and_paint(GUI::Painter& painter, Color background_color, bool h
     save_old_position();
 }
 
-NonnullRefPtrVector<Card> create_standard_deck(Shuffle shuffle)
+ErrorOr<NonnullRefPtrVector<Card>> create_standard_deck(Shuffle shuffle)
 {
     return create_deck(1, 1, 1, 1, shuffle);
 }
 
-NonnullRefPtrVector<Card> create_deck(unsigned full_club_suit_count, unsigned full_diamond_suit_count, unsigned full_heart_suit_count, unsigned full_spade_suit_count, Shuffle shuffle)
+ErrorOr<NonnullRefPtrVector<Card>> create_deck(unsigned full_club_suit_count, unsigned full_diamond_suit_count, unsigned full_heart_suit_count, unsigned full_spade_suit_count, Shuffle shuffle)
 {
     NonnullRefPtrVector<Card> deck;
-    deck.ensure_capacity(Card::card_count * (full_club_suit_count + full_diamond_suit_count + full_heart_suit_count + full_spade_suit_count));
+    TRY(deck.try_ensure_capacity(Card::card_count * (full_club_suit_count + full_diamond_suit_count + full_heart_suit_count + full_spade_suit_count)));
 
-    auto add_cards_for_suit = [&deck](Cards::Suit suit, unsigned number_of_suits) {
+    auto add_cards_for_suit = [&deck](Cards::Suit suit, unsigned number_of_suits) -> ErrorOr<void> {
         for (auto i = 0u; i < number_of_suits; ++i) {
             for (auto rank = 0; rank < Card::card_count; ++rank) {
-                deck.append(Card::construct(suit, static_cast<Cards::Rank>(rank)));
+                deck.unchecked_append(TRY(Card::try_create(suit, static_cast<Cards::Rank>(rank))));
             }
         }
+        return {};
     };
 
-    add_cards_for_suit(Cards::Suit::Clubs, full_club_suit_count);
-    add_cards_for_suit(Cards::Suit::Diamonds, full_diamond_suit_count);
-    add_cards_for_suit(Cards::Suit::Hearts, full_heart_suit_count);
-    add_cards_for_suit(Cards::Suit::Spades, full_spade_suit_count);
+    TRY(add_cards_for_suit(Cards::Suit::Clubs, full_club_suit_count));
+    TRY(add_cards_for_suit(Cards::Suit::Diamonds, full_diamond_suit_count));
+    TRY(add_cards_for_suit(Cards::Suit::Hearts, full_heart_suit_count));
+    TRY(add_cards_for_suit(Cards::Suit::Spades, full_spade_suit_count));
 
     if (shuffle == Shuffle::Yes)
         shuffle_deck(deck);

--- a/Userland/Libraries/LibCards/Card.cpp
+++ b/Userland/Libraries/LibCards/Card.cpp
@@ -80,16 +80,9 @@ ErrorOr<NonnullRefPtrVector<Card>> create_deck(unsigned full_club_suit_count, un
     TRY(add_cards_for_suit(Cards::Suit::Spades, full_spade_suit_count));
 
     if (shuffle == Shuffle::Yes)
-        shuffle_deck(deck);
+        AK::shuffle(deck);
 
     return deck;
-}
-
-void shuffle_deck(NonnullRefPtrVector<Card>& deck)
-{
-    auto iteration_count = deck.size() * 4;
-    for (auto i = 0u; i < iteration_count; ++i)
-        deck.append(deck.take(get_random_uniform(deck.size())));
 }
 
 }

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -131,8 +131,8 @@ enum class Shuffle {
     No,
     Yes,
 };
-NonnullRefPtrVector<Card> create_standard_deck(Shuffle);
-NonnullRefPtrVector<Card> create_deck(unsigned full_club_suit_count, unsigned full_diamond_suit_count, unsigned full_heart_suit_count, unsigned full_spade_suit_count, Shuffle);
+ErrorOr<NonnullRefPtrVector<Card>> create_standard_deck(Shuffle);
+ErrorOr<NonnullRefPtrVector<Card>> create_deck(unsigned full_club_suit_count, unsigned full_diamond_suit_count, unsigned full_heart_suit_count, unsigned full_spade_suit_count, Shuffle);
 void shuffle_deck(NonnullRefPtrVector<Card>&);
 
 }

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -133,7 +133,6 @@ enum class Shuffle {
 };
 ErrorOr<NonnullRefPtrVector<Card>> create_standard_deck(Shuffle);
 ErrorOr<NonnullRefPtrVector<Card>> create_deck(unsigned full_club_suit_count, unsigned full_diamond_suit_count, unsigned full_heart_suit_count, unsigned full_spade_suit_count, Shuffle);
-void shuffle_deck(NonnullRefPtrVector<Card>&);
 
 }
 

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -83,17 +83,19 @@ RefPtr<CardStack> CardGame::find_stack_to_drop_on(CardStack::MovementRule moveme
     return closest_stack;
 }
 
-void CardGame::drop_cards_on_stack(Cards::CardStack& stack, CardStack::MovementRule movement_rule)
+ErrorOr<void> CardGame::drop_cards_on_stack(Cards::CardStack& stack, CardStack::MovementRule movement_rule)
 {
     VERIFY(stack.is_allowed_to_push(m_moving_cards.at(0), m_moving_cards.size(), movement_rule));
     for (auto& to_intersect : moving_cards()) {
         mark_intersecting_stacks_dirty(to_intersect);
-        stack.push(to_intersect).release_value_but_fixme_should_propagate_errors();
+        TRY(stack.push(to_intersect));
         (void)moving_cards_source_stack()->pop();
     }
 
     update(moving_cards_source_stack()->bounding_box());
     update(stack.bounding_box());
+
+    return {};
 }
 
 void CardGame::clear_moving_cards()

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -52,10 +52,11 @@ Gfx::IntRect CardGame::moving_cards_bounds() const
     return m_moving_cards.first().rect().united(m_moving_cards.last().rect());
 }
 
-void CardGame::pick_up_cards_from_stack(Cards::CardStack& stack, Gfx::IntPoint click_location, CardStack::MovementRule movement_rule)
+ErrorOr<void> CardGame::pick_up_cards_from_stack(Cards::CardStack& stack, Gfx::IntPoint click_location, CardStack::MovementRule movement_rule)
 {
-    stack.add_all_grabbed_cards(click_location, m_moving_cards, movement_rule);
+    TRY(stack.add_all_grabbed_cards(click_location, m_moving_cards, movement_rule));
     m_moving_cards_source_stack = stack;
+    return {};
 }
 
 RefPtr<CardStack> CardGame::find_stack_to_drop_on(CardStack::MovementRule movement_rule) const

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -88,7 +88,7 @@ void CardGame::drop_cards_on_stack(Cards::CardStack& stack, CardStack::MovementR
     VERIFY(stack.is_allowed_to_push(m_moving_cards.at(0), m_moving_cards.size(), movement_rule));
     for (auto& to_intersect : moving_cards()) {
         mark_intersecting_stacks_dirty(to_intersect);
-        stack.push(to_intersect);
+        stack.push(to_intersect).release_value_but_fixme_should_propagate_errors();
         (void)moving_cards_source_stack()->pop();
     }
 

--- a/Userland/Libraries/LibCards/CardGame.h
+++ b/Userland/Libraries/LibCards/CardGame.h
@@ -42,7 +42,7 @@ public:
     NonnullRefPtrVector<Card> const& moving_cards() const { return m_moving_cards; }
     Gfx::IntRect moving_cards_bounds() const;
     RefPtr<CardStack> moving_cards_source_stack() const { return m_moving_cards_source_stack; }
-    void pick_up_cards_from_stack(CardStack&, Gfx::IntPoint click_location, CardStack::MovementRule);
+    ErrorOr<void> pick_up_cards_from_stack(CardStack&, Gfx::IntPoint click_location, CardStack::MovementRule);
     RefPtr<CardStack> find_stack_to_drop_on(CardStack::MovementRule) const;
     ErrorOr<void> drop_cards_on_stack(CardStack&, CardStack::MovementRule);
     void clear_moving_cards();

--- a/Userland/Libraries/LibCards/CardGame.h
+++ b/Userland/Libraries/LibCards/CardGame.h
@@ -44,7 +44,7 @@ public:
     RefPtr<CardStack> moving_cards_source_stack() const { return m_moving_cards_source_stack; }
     void pick_up_cards_from_stack(CardStack&, Gfx::IntPoint click_location, CardStack::MovementRule);
     RefPtr<CardStack> find_stack_to_drop_on(CardStack::MovementRule) const;
-    void drop_cards_on_stack(CardStack&, CardStack::MovementRule);
+    ErrorOr<void> drop_cards_on_stack(CardStack&, CardStack::MovementRule);
     void clear_moving_cards();
 
     bool is_previewing_card() const { return !m_previewed_card_stack.is_null(); }

--- a/Userland/Libraries/LibCards/CardStack.cpp
+++ b/Userland/Libraries/LibCards/CardStack.cpp
@@ -323,7 +323,7 @@ NonnullRefPtr<Card> CardStack::pop()
     return card;
 }
 
-void CardStack::move_to_stack(CardStack& stack)
+void CardStack::take_all(CardStack& stack)
 {
     while (!m_stack.is_empty()) {
         auto card = m_stack.take_first();

--- a/Userland/Libraries/LibCards/CardStack.cpp
+++ b/Userland/Libraries/LibCards/CardStack.cpp
@@ -290,7 +290,7 @@ bool CardStack::make_top_card_visible()
     return false;
 }
 
-void CardStack::push(NonnullRefPtr<Card> card)
+ErrorOr<void> CardStack::push(NonnullRefPtr<Card> card)
 {
     auto top_most_position = m_stack_positions.is_empty() ? m_position : m_stack_positions.last();
 
@@ -306,9 +306,10 @@ void CardStack::push(NonnullRefPtr<Card> card)
 
     card->set_position(top_most_position);
 
-    m_stack.append(card);
-    m_stack_positions.append(top_most_position);
+    TRY(m_stack.try_append(card));
+    TRY(m_stack_positions.try_append(top_most_position));
     calculate_bounding_box();
+    return {};
 }
 
 NonnullRefPtr<Card> CardStack::pop()
@@ -323,15 +324,16 @@ NonnullRefPtr<Card> CardStack::pop()
     return card;
 }
 
-void CardStack::take_all(CardStack& stack)
+ErrorOr<void> CardStack::take_all(CardStack& stack)
 {
     while (!m_stack.is_empty()) {
         auto card = m_stack.take_first();
         m_stack_positions.take_first();
-        stack.push(move(card));
+        TRY(stack.push(move(card)));
     }
 
     calculate_bounding_box();
+    return {};
 }
 
 void CardStack::calculate_bounding_box()

--- a/Userland/Libraries/LibCards/CardStack.cpp
+++ b/Userland/Libraries/LibCards/CardStack.cpp
@@ -121,7 +121,7 @@ void CardStack::rebound_cards()
         card.set_position(m_stack_positions.at(card_index++));
 }
 
-void CardStack::add_all_grabbed_cards(Gfx::IntPoint click_location, NonnullRefPtrVector<Card>& grabbed, MovementRule movement_rule)
+ErrorOr<void> CardStack::add_all_grabbed_cards(Gfx::IntPoint click_location, NonnullRefPtrVector<Card>& grabbed, MovementRule movement_rule)
 {
     VERIFY(grabbed.is_empty());
 
@@ -129,9 +129,9 @@ void CardStack::add_all_grabbed_cards(Gfx::IntPoint click_location, NonnullRefPt
         auto& top_card = peek();
         if (top_card.rect().contains(click_location)) {
             top_card.set_moving(true);
-            grabbed.append(top_card);
+            TRY(grabbed.try_append(top_card));
         }
-        return;
+        return {};
     }
 
     RefPtr<Card> last_intersect;
@@ -144,22 +144,22 @@ void CardStack::add_all_grabbed_cards(Gfx::IntPoint click_location, NonnullRefPt
             last_intersect = card;
         } else if (!last_intersect.is_null()) {
             if (grabbed.is_empty()) {
-                grabbed.append(*last_intersect);
+                TRY(grabbed.try_append(*last_intersect));
                 last_intersect->set_moving(true);
             }
 
             if (card.is_upside_down()) {
                 grabbed.clear();
-                return;
+                return {};
             }
 
             card.set_moving(true);
-            grabbed.append(card);
+            TRY(grabbed.try_append(card));
         }
     }
 
     if (grabbed.is_empty() && !last_intersect.is_null()) {
-        grabbed.append(*last_intersect);
+        TRY(grabbed.try_append(*last_intersect));
         last_intersect->set_moving(true);
     }
 
@@ -198,6 +198,8 @@ void CardStack::add_all_grabbed_cards(Gfx::IntPoint click_location, NonnullRefPt
         }
         grabbed.clear();
     }
+
+    return {};
 }
 
 bool CardStack::is_allowed_to_push(Card const& card, size_t stack_size, MovementRule movement_rule) const

--- a/Userland/Libraries/LibCards/CardStack.h
+++ b/Userland/Libraries/LibCards/CardStack.h
@@ -45,7 +45,7 @@ public:
 
     void push(NonnullRefPtr<Card> card);
     NonnullRefPtr<Card> pop();
-    void move_to_stack(CardStack&);
+    void take_all(CardStack&);
     void rebound_cards();
 
     bool is_allowed_to_push(Card const&, size_t stack_size = 1, MovementRule movement_rule = MovementRule::Alternating) const;

--- a/Userland/Libraries/LibCards/CardStack.h
+++ b/Userland/Libraries/LibCards/CardStack.h
@@ -49,7 +49,7 @@ public:
     void rebound_cards();
 
     bool is_allowed_to_push(Card const&, size_t stack_size = 1, MovementRule movement_rule = MovementRule::Alternating) const;
-    void add_all_grabbed_cards(Gfx::IntPoint click_location, NonnullRefPtrVector<Card>& grabbed, MovementRule movement_rule = MovementRule::Alternating);
+    ErrorOr<void> add_all_grabbed_cards(Gfx::IntPoint click_location, NonnullRefPtrVector<Card>& grabbed, MovementRule movement_rule = MovementRule::Alternating);
 
     bool preview_card(Gfx::IntPoint click_location);
     void clear_card_preview();

--- a/Userland/Libraries/LibCards/CardStack.h
+++ b/Userland/Libraries/LibCards/CardStack.h
@@ -43,9 +43,9 @@ public:
 
     bool make_top_card_visible(); // Returns true if the card was flipped.
 
-    void push(NonnullRefPtr<Card> card);
+    ErrorOr<void> push(NonnullRefPtr<Card>);
     NonnullRefPtr<Card> pop();
-    void take_all(CardStack&);
+    ErrorOr<void> take_all(CardStack&);
     void rebound_cards();
 
     bool is_allowed_to_push(Card const&, size_t stack_size = 1, MovementRule movement_rule = MovementRule::Alternating) const;


### PR DESCRIPTION
The card games themselves mostly don't propagate them, but at least we can do so on the library side.

As a bonus: Make `AK::shuffle()` work on `NonnullPtrVector`s. :partying_face: 