### PR TITLE
ColorLines+Tests: Use AK::shuffle() for shuffling

### DIFF
--- a/Tests/LibC/TestQsort.cpp
+++ b/Tests/LibC/TestQsort.cpp
@@ -38,15 +38,6 @@ static int calc_payload_for_pos(size_t pos)
     return pos ^ (pos << 8) ^ (pos << 16) ^ (pos << 24);
 }
 
-static void shuffle_vec(Vector<SortableObject>& test_objects)
-{
-    for (size_t i = 0; i < test_objects.size() * 3; ++i) {
-        auto i1 = get_random_uniform(test_objects.size());
-        auto i2 = get_random_uniform(test_objects.size());
-        swap(test_objects[i1], test_objects[i2]);
-    }
-}
-
 TEST_CASE(quick_sort)
 {
     // Generate vector of SortableObjects in sorted order, with payloads determined by their sorted positions
@@ -56,7 +47,7 @@ TEST_CASE(quick_sort)
     }
     for (size_t i = 0; i < NUM_RUNS; i++) {
         // Shuffle the vector, then sort it again
-        shuffle_vec(test_objects);
+        shuffle(test_objects);
         qsort(test_objects.data(), test_objects.size(), sizeof(SortableObject), compare_sortable_object);
         // Check that the objects are sorted by key
         for (auto i = 0u; i + 1 < test_objects.size(); ++i) {

--- a/Userland/Games/ColorLines/MarbleBoard.h
+++ b/Userland/Games/ColorLines/MarbleBoard.h
@@ -62,7 +62,7 @@ public:
                 result.append(point);
             return IterationDecision::Continue;
         });
-        random_shuffle(result);
+        shuffle(result);
         return result;
     }
 
@@ -334,14 +334,6 @@ private:
             return false;
         set_color_at(marble.position(), marble.color());
         return true;
-    }
-
-    static void random_shuffle(PointArray& points)
-    {
-        // Using Fisher–Yates in-place shuffle
-        if (points.size() > 1)
-            for (size_t i = points.size() - 1; i > 1; --i)
-                swap(points[i], points[get_random_uniform(i + 1)]);
     }
 
     static constexpr int number_of_marbles_to_remove { 5 };


### PR DESCRIPTION
Noticed a couple of places that implemented their own shuffles, which could just use `AK::shuffle()` instead.