### PR TITLE
LibGfx: Scaffolding for reading ICC tag table

### DIFF
--- a/Userland/Libraries/LibGfx/ICCProfile.cpp
+++ b/Userland/Libraries/LibGfx/ICCProfile.cpp
@@ -86,7 +86,7 @@ ErrorOr<time_t> parse_date_time_number(DateTimeNumber const& date_time)
 // ICC V4, 7.2 Profile header
 struct ICCHeader {
     BigEndian<u32> profile_size;
-    BigEndian<u32> preferred_cmm_type;
+    BigEndian<PreferredCMMType> preferred_cmm_type;
 
     u8 profile_version_major;
     u8 profile_version_minor_bugfix;
@@ -102,14 +102,14 @@ struct ICCHeader {
     BigEndian<PrimaryPlatform> primary_platform;
 
     BigEndian<u32> profile_flags;
-    BigEndian<u32> device_manufacturer;
-    BigEndian<u32> device_model;
+    BigEndian<DeviceManufacturer> device_manufacturer;
+    BigEndian<DeviceModel> device_model;
     BigEndian<u64> device_attributes;
     BigEndian<u32> rendering_intent;
 
     XYZNumber pcs_illuminant;
 
-    BigEndian<u32> profile_creator;
+    BigEndian<Creator> profile_creator;
 
     u8 profile_id[16];
     u8 reserved[28];
@@ -146,9 +146,9 @@ Optional<PreferredCMMType> parse_preferred_cmm_type(ICCHeader const& header)
     // which is not present in the "CMM Signatures" table in that PDF.
 
     // "If no preferred CMM is identified, this field shall be set to zero (00000000h)."
-    if (header.preferred_cmm_type == 0)
+    if (header.preferred_cmm_type == PreferredCMMType { 0 })
         return {};
-    return PreferredCMMType { header.preferred_cmm_type };
+    return header.preferred_cmm_type;
 }
 
 ErrorOr<Version> parse_version(ICCHeader const& header)
@@ -266,9 +266,9 @@ Optional<DeviceManufacturer> parse_device_manufacturer(ICCHeader const& header)
     // has its device manufacturer set to 'none', but https://www.color.org/signatureRegistry/?entityEntry=none-6E6F6E65 does not exist.
 
     // "If not used this field shall be set to zero (00000000h)."
-    if (header.device_manufacturer == 0)
+    if (header.device_manufacturer == DeviceManufacturer { 0 })
         return {};
-    return DeviceManufacturer { header.device_manufacturer };
+    return header.device_manufacturer;
 }
 
 Optional<DeviceModel> parse_device_model(ICCHeader const& header)
@@ -282,9 +282,9 @@ Optional<DeviceModel> parse_device_model(ICCHeader const& header)
     // has its device model set to 'none', but https://www.color.org/signatureRegistry/deviceRegistry?entityEntry=none-6E6F6E65 does not exist.
 
     // "If not used this field shall be set to zero (00000000h)."
-    if (header.device_model == 0)
+    if (header.device_model == DeviceModel { 0 })
         return {};
-    return DeviceModel { header.device_model };
+    return header.device_model;
 }
 
 ErrorOr<DeviceAttributes> parse_device_attributes(ICCHeader const& header)
@@ -335,9 +335,9 @@ Optional<Creator> parse_profile_creator(ICCHeader const& header)
     // For example, .icc files in /System/ColorSync/Profiles on macOS 12.6 set this to 'appl', which is a CMM signature, not a device signature (that one would be 'APPL').
 
     // "If not used this field shall be set to zero (00000000h)."
-    if (header.profile_creator == 0)
+    if (header.profile_creator == Creator { 0 })
         return {};
-    return Creator { header.profile_creator };
+    return header.profile_creator;
 }
 
 template<size_t N>

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -246,6 +246,8 @@ public:
     static Crypto::Hash::MD5::DigestType compute_id(ReadonlyBytes);
 
 private:
+    ErrorOr<void> read_header(ReadonlyBytes);
+
     u32 m_on_disk_size { 0 };
     Optional<PreferredCMMType> m_preferred_cmm_type;
     Version m_version;

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -38,6 +38,8 @@ struct [[gnu::packed]] DistinctFourCC {
     char c2() const { return (value >> 8) & 0xff; }
     char c3() const { return value & 0xff; }
 
+    bool operator==(DistinctFourCC b) const { return value == b.value; }
+
     u32 value { 0 };
 };
 

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -26,13 +26,19 @@ enum class FourCCType {
 };
 
 template<FourCCType type>
-struct DistinctFourCC {
-    u32 value { 0 };
+struct [[gnu::packed]] DistinctFourCC {
+    explicit DistinctFourCC(u32 value)
+        : value(value)
+    {
+    }
+    explicit operator u32() const { return value; }
 
     char c0() const { return value >> 24; }
     char c1() const { return (value >> 16) & 0xff; }
     char c2() const { return (value >> 8) & 0xff; }
     char c3() const { return value & 0xff; }
+
+    u32 value { 0 };
 };
 
 using PreferredCMMType = DistinctFourCC<FourCCType::PreferredCMMType>;     // ICC v4, "7.2.3 Preferred CMM type field"

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -73,5 +73,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         outln("{} trailing bytes after profile data", profile_disk_size - profile->on_disk_size());
     }
 
+    outln("");
+
+    outln("tags:");
+    profile->for_each_tag([](auto tag_signature, auto tag_data) {
+        outln("{}: {}, offset {}, size {}", tag_signature, tag_data->type(), tag_data->offset(), tag_data->size());
+    });
+
     return 0;
 }


### PR DESCRIPTION
The idea is that we'll have one type for each tag type.
For now, this treats all tag types as unknown, but it puts most
of the infrastructure for reading tags in place.

---

Pretty underwhelming screenshot:

```
% Build/lagom/icc ~/src/Compact-ICC-Profiles/profiles/sRGB-v2-nano.icc
preferred CMM type: 'lcms'
version: 2.1.0
device class: DisplayDevice
data color space: RGB
connection space: PCSXYZ
creation date and time: 2018-03-20 05:14:29
primary platform: Microsoft
flags: 0x00000000
  embedded in file: no
  can be used independently of embedded color data: yes
device manufacturer: 'saws'
device model: 'ctrl'
device attributes: 0x0000000000000000
  media is reflective, glossy, of positive polarity, colored
rendering intent: Perceptual
pcs illuminant: X = 0.964202, Y = 1, Z = 0.824905
creator: 'hand'
id: eb771f3c-aa535102-e93e286c-9146ae57

tags:
'desc': 'desc', offset 240, size 95
'wtpt': 'XYZ ', offset 268, size 20
'rXYZ': 'XYZ ', offset 288, size 20
'gXYZ': 'XYZ ', offset 308, size 20
'bXYZ': 'XYZ ', offset 328, size 20
'rTRC': 'curv', offset 348, size 52
'gTRC': 'curv', offset 348, size 52
'bTRC': 'curv', offset 348, size 52
'cprt': 'text', offset 400, size 10
```

(The `tags:` part at the bottom is new in this PR.)

Future patches will extract actual data from the tag types and show that.