### PR TITLE
Assistant: Allow arguments in AppProvider queries

### DIFF
--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -34,7 +34,8 @@ void AppResult::activate() const
         exit(1);
     }
 
-    m_app_file->spawn();
+    auto arguments_list = m_arguments.split_view(' ');
+    m_app_file->spawn(arguments_list.span());
 }
 
 void CalculatorResult::activate() const
@@ -68,12 +69,15 @@ void AppProvider::query(DeprecatedString const& query, Function<void(NonnullRefP
     NonnullRefPtrVector<Result> results;
 
     Desktop::AppFile::for_each([&](NonnullRefPtr<Desktop::AppFile> app_file) {
-        auto match_result = fuzzy_match(query, app_file->name());
+        auto query_and_arguments = query.split_limit(' ', 2);
+        auto app_name = query_and_arguments.is_empty() ? query : query_and_arguments[0];
+        auto arguments = query_and_arguments.size() < 2 ? DeprecatedString::empty() : query_and_arguments[1];
+        auto match_result = fuzzy_match(app_name, app_file->name());
         if (!match_result.matched)
             return;
 
         auto icon = GUI::FileIconProvider::icon_for_executable(app_file->executable());
-        results.append(adopt_ref(*new AppResult(icon.bitmap_for_size(16), app_file->name(), {}, app_file, match_result.score)));
+        results.append(adopt_ref(*new AppResult(icon.bitmap_for_size(16), app_file->name(), {}, app_file, arguments, match_result.score)));
     });
 
     on_complete(move(results));

--- a/Userland/Applications/Assistant/Providers.h
+++ b/Userland/Applications/Assistant/Providers.h
@@ -52,9 +52,10 @@ private:
 
 class AppResult final : public Result {
 public:
-    AppResult(RefPtr<Gfx::Bitmap> bitmap, DeprecatedString title, DeprecatedString tooltip, NonnullRefPtr<Desktop::AppFile> af, int score)
+    AppResult(RefPtr<Gfx::Bitmap> bitmap, DeprecatedString title, DeprecatedString tooltip, NonnullRefPtr<Desktop::AppFile> af, DeprecatedString arguments, int score)
         : Result(move(title), move(tooltip), score)
         , m_app_file(move(af))
+        , m_arguments(move(arguments))
         , m_bitmap(move(bitmap))
     {
     }
@@ -65,6 +66,7 @@ public:
 
 private:
     NonnullRefPtr<Desktop::AppFile> m_app_file;
+    DeprecatedString m_arguments;
     RefPtr<Gfx::Bitmap> m_bitmap;
 };
 

--- a/Userland/Libraries/LibDesktop/AppFile.cpp
+++ b/Userland/Libraries/LibDesktop/AppFile.cpp
@@ -150,12 +150,12 @@ Vector<DeprecatedString> AppFile::launcher_protocols() const
     return protocols;
 }
 
-bool AppFile::spawn() const
+bool AppFile::spawn(ReadonlySpan<StringView> arguments) const
 {
     if (!is_valid())
         return false;
 
-    auto pid = Core::Process::spawn(executable(), ReadonlySpan<StringView> {}, working_directory());
+    auto pid = Core::Process::spawn(executable(), arguments, working_directory());
     if (pid.is_error())
         return false;
 

--- a/Userland/Libraries/LibDesktop/AppFile.h
+++ b/Userland/Libraries/LibDesktop/AppFile.h
@@ -38,7 +38,7 @@ public:
     Vector<DeprecatedString> launcher_mime_types() const;
     Vector<DeprecatedString> launcher_file_types() const;
     Vector<DeprecatedString> launcher_protocols() const;
-    bool spawn() const;
+    bool spawn(ReadonlySpan<StringView> arguments = {}) const;
 
 private:
     explicit AppFile(StringView path);


### PR DESCRIPTION
This simple PR allows AppFiles to be launched from Assistant with an optional set of arguments.

Video:

https://user-images.githubusercontent.com/2817754/213814168-fcb4a4cd-2b01-4704-8b1b-b962a02c7f75.mp4