### PR TITLE
Documentation: Add a link list

### DIFF
--- a/Documentation/Links.md
+++ b/Documentation/Links.md
@@ -1,0 +1,75 @@
+# SerenityOS-related pages across the web
+
+This is a roughly categorized list of pages relating to SerenityOS and its subprojects across the web. Many of these pages are "unofficial" in that some single person created them and/or maintains them independently; but we only list pages here that are widely recognized and of good quality. If you want your Serenity related page to be listed, just create a pull request adding it and we can discuss.
+
+## General
+
+-   **[serenityos.org](https://serenityos.org)**
+    -   [Manpages](https://man.serenityos.org/)
+    -   Birthday Posts
+        -   [1st](https://www.serenityos.org/happy/1st/)
+        -   [2nd](https://www.serenityos.org/happy/2nd/)
+        -   [3rd](https://www.serenityos.org/happy/3rd/)
+        -   [4th](https://www.serenityos.org/happy/4th/)
+    -   [Emoji](https://emoji.serenityos.org/)
+-   [Try it out Online!](https://copy.sh/v86/?profile=serenity) (This is an old i686 build which will never be updated as [i686 support is removed](https://github.com/SerenityOS/serenity/pull/15467).)
+-   [SerenityOS on English Wikipedia](https://en.wikipedia.org/wiki/SerenityOS). This page also links to the SerenityOS articles in many other languages.
+
+## Development
+
+-   [GitHub Organization](https://github.com/SerenityOS) and [GitHub Repositories](https://github.com/orgs/SerenityOS/repositories)
+-   [Changelog](https://changelog.serenityos.org/)
+-   [Issues Found by OSS-Fuzz Continous Fuzzing](https://bugs.chromium.org/p/oss-fuzz/issues/list?q=label:Proj-serenity)
+-   [Azure CI Overview](https://dev.azure.com/SerenityOS/SerenityOS/_build)
+-   [SonarCloud Static Analysis](https://sonarcloud.io/project/overview?id=SerenityOS_serenity)
+-   [libjs.dev](https://libjs.dev/)
+    -   [Try LibJS Online!](https://libjs.dev/repl/)
+-   [Compiler Explorer](https://serenity.godbolt.org/): Select "Lagom trunk" under "Libraries" and add the compiler option `-std=c++20`
+
+## Related Projects
+
+-   [LibFont.js](https://macdue.github.io/LibFont.js/)
+
+## Social
+
+-   [Discord Server](https://discord.gg/serenityos)
+-   [serenityos.social](https://serenityos.social/), unofficial Mastodon instance run by [networkException](https://serenityos.social/@networkexception) and [Linus Groh](https://serenityos.social/@linusg)
+-   [Map of Developers and Users](https://usermap.serenityos.org/)
+-   YouTube Channels
+    -   [Andreas Kling](https://www.youtube.com/@awesomekling)
+    -   [Linus Groh](https://www.youtube.com/@linusgroh)
+    -   [kleines Filmröllchen](https://www.youtube.com/@kleinesfilmroellchen)
+    -   [davidot](https://www.youtube.com/@davidot4475)
+-   Personal Blogs
+    -   [Andreas Kling](https://awesomekling.github.io/)
+    -   [Linus Groh](https://linus.dev/posts/)
+    -   [Andrew Kaster](https://adkaster.github.io/)
+    -   [Jesse Buhagiar](https://quaker762.github.io/)
+    -   [Sam Atkins](https://atkinssj.github.io/)
+
+## Statistics and Lists
+
+-   [Ports](https://ports.serenityos.net/)
+-   [:^) Tracker](https://happy-serenityos.linus.dev/)
+-   [FIXMEs](https://benwiederhake.github.io/serenity-fixmes/)
+    -   [Flamegraph Distribution](https://benwiederhake.github.io/serenity-fixmes/flamegraph.html)
+-   [Lines of Code vs. Commits](https://github.com/alimpfard/random-serenity-statistics#random-serenityos-statistics)
+-   [CSS Conformance](https://css.tobyase.de/)
+-   [Fonts](https://fonts.serenityos.net/)
+-   [Emoji Table](https://emoji.serenityos.net/)
+    -   [Emoji Statistics](https://emoji.serenityos.net/chart.emoji.serenityos)
+-   [Flags](https://flags.serenityos.net/)
+-   [test262](https://libjs.dev/test262/) (JavaScript Spec Tests)
+-   [Wasm Spec Tests](https://libjs.dev/wasm/)
+-   [Test Performance](https://github.com/alimpfard/random-serenity-statistics/tree/main/view/benchmarks/x86_64)
+-   [serenityos.social Statistics](https://grafana.serenityos.social/public)
+
+## Miscellaneous
+
+-   [Merch](https://store.serenityos.org)
+-   [Yaksplained](https://yaksplained.org/)
+-   [serenityos.net](https://serenityos.net), [Xexxa](https://github.com/xexxa)'s site for various pages listed here
+    -   [Font Wishlist & Useful Links for Font Developers](https://serenityos.net/~xexxa/)
+    -   [Emoji Wall Of Awesome](https://emoji.serenityos.net/wall-of-awesome)
+    -   [Unofficial Wiki](https://wiki.serenityos.net/)
+-   [Spinning Ladyball Shadertoy](https://www.shadertoy.com/view/7lVXWd)

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -2,6 +2,8 @@
 
 Serenity development moves quickly, so some of these might be out of date. Please let us know if something here is wrong, or submit a PR with any additions or corrections! If you have any questions that are not answered here or in the [FAQ](FAQ.md), you are welcome to ask on [Discord](../README.md#get-in-touch-and-participate).
 
+A list of useful pages across the web can be found on [the link list](Links.md).
+
 ## Building and Running
 * [Build Instructions](BuildInstructions.md)
 * [Advanced Build Instructions](AdvancedBuildInstructions.md)


### PR DESCRIPTION
The link list tries to collect all links from the website, BenW's link
list <https://benwiederhake.github.io/serenity-fixmes/index.html#links>
and the unofficial wiki <https://wiki.serenityos.net/links.html> into
one sorted and expanded list, so that hopefully noone has difficulty
searching for serenity pages in the future :^)