### PR TITLE
icc: Tweak output to look nicer

### DIFF
--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Nico Weber <thakis@chromium.org>
+ * Copyright (c) 2022-2023, Nico Weber <thakis@chromium.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -31,41 +31,45 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto icc_file = TRY(Core::MappedFile::map(icc_path));
     auto profile = TRY(Gfx::ICC::Profile::try_load_from_externally_owned_memory(icc_file->bytes()));
 
-    out_optional("preferred CMM type", profile->preferred_cmm_type());
-    outln("version: {}", profile->version());
-    outln("device class: {}", Gfx::ICC::device_class_name(profile->device_class()));
-    outln("data color space: {}", Gfx::ICC::data_color_space_name(profile->data_color_space()));
-    outln("connection space: {}", Gfx::ICC::profile_connection_space_name(profile->connection_space()));
+    out_optional("    preferred CMM type", profile->preferred_cmm_type());
+    outln("               version: {}", profile->version());
+    outln("          device class: {}", Gfx::ICC::device_class_name(profile->device_class()));
+    outln("      data color space: {}", Gfx::ICC::data_color_space_name(profile->data_color_space()));
+    outln("      connection space: {}", Gfx::ICC::profile_connection_space_name(profile->connection_space()));
     outln("creation date and time: {}", Core::DateTime::from_timestamp(profile->creation_timestamp()).to_deprecated_string());
-    outln("primary platform: {}", Gfx::ICC::primary_platform_name(profile->primary_platform()));
+    outln("      primary platform: {}", Gfx::ICC::primary_platform_name(profile->primary_platform()));
 
     auto flags = profile->flags();
-    outln("flags: 0x{:08x}", flags.bits());
-    outln("  embedded in file: {}", flags.is_embedded_in_file() ? "yes" : "no");
-    outln("  can be used independently of embedded color data: {}", flags.can_be_used_independently_of_embedded_color_data() ? "yes" : "no");
+    outln("                 flags: 0x{:08x}", flags.bits());
+    outln("                        - {}embedded in file", flags.is_embedded_in_file() ? "" : "not ");
+    outln("                        - can{} be used independently of embedded color data", flags.can_be_used_independently_of_embedded_color_data() ? "" : "not");
     if (auto unknown_icc_bits = flags.icc_bits() & ~Gfx::ICC::Flags::KnownBitsMask)
-        outln("  other unknown ICC bits: 0x{:04x}", unknown_icc_bits);
+        outln("                        other unknown ICC bits: 0x{:04x}", unknown_icc_bits);
     if (auto color_management_module_bits = flags.color_management_module_bits())
-        outln("  CMM bits: 0x{:04x}", color_management_module_bits);
+        outln("                            CMM bits: 0x{:04x}", color_management_module_bits);
 
-    out_optional("device manufacturer", profile->device_manufacturer());
-    out_optional("device model", profile->device_model());
+    out_optional("   device manufacturer", profile->device_manufacturer());
+    out_optional("          device model", profile->device_model());
 
     auto device_attributes = profile->device_attributes();
-    outln("device attributes: 0x{:016x}", device_attributes.bits());
-    outln("  media is {}, {}, {}, {}",
-        device_attributes.media_reflectivity() == Gfx::ICC::DeviceAttributes::MediaReflectivity::Reflective ? "reflective" : "transparent",
-        device_attributes.media_glossiness() == Gfx::ICC::DeviceAttributes::MediaGlossiness::Glossy ? "glossy" : "matte",
-        device_attributes.media_polarity() == Gfx::ICC::DeviceAttributes::MediaPolarity::Positive ? "of positive polarity" : "of negative polarity",
+    outln("     device attributes: 0x{:016x}", device_attributes.bits());
+    outln("                        media is:");
+    outln("                        - {}",
+        device_attributes.media_reflectivity() == Gfx::ICC::DeviceAttributes::MediaReflectivity::Reflective ? "reflective" : "transparent");
+    outln("                        - {}",
+        device_attributes.media_glossiness() == Gfx::ICC::DeviceAttributes::MediaGlossiness::Glossy ? "glossy" : "matte");
+    outln("                        - {}",
+        device_attributes.media_polarity() == Gfx::ICC::DeviceAttributes::MediaPolarity::Positive ? "of positive polarity" : "of negative polarity");
+    outln("                        - {}",
         device_attributes.media_color() == Gfx::ICC::DeviceAttributes::MediaColor::Colored ? "colored" : "black and white");
     VERIFY((flags.icc_bits() & ~Gfx::ICC::DeviceAttributes::KnownBitsMask) == 0);
     if (auto vendor_bits = device_attributes.vendor_bits())
-        outln("  vendor bits: 0x{:08x}", vendor_bits);
+        outln("                        vendor bits: 0x{:08x}", vendor_bits);
 
-    outln("rendering intent: {}", Gfx::ICC::rendering_intent_name(profile->rendering_intent()));
-    outln("pcs illuminant: {}", profile->pcs_illuminant());
-    out_optional("creator", profile->creator());
-    out_optional("id", profile->id());
+    outln("      rendering intent: {}", Gfx::ICC::rendering_intent_name(profile->rendering_intent()));
+    outln("        pcs illuminant: {}", profile->pcs_illuminant());
+    out_optional("               creator", profile->creator());
+    out_optional("                    id", profile->id());
 
     size_t profile_disk_size = icc_file->size();
     if (profile_disk_size != profile->on_disk_size()) {

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -36,7 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     outln("          device class: {}", Gfx::ICC::device_class_name(profile->device_class()));
     outln("      data color space: {}", Gfx::ICC::data_color_space_name(profile->data_color_space()));
     outln("      connection space: {}", Gfx::ICC::profile_connection_space_name(profile->connection_space()));
-    outln("creation date and time: {}", Core::DateTime::from_timestamp(profile->creation_timestamp()).to_deprecated_string());
+    outln("creation date and time: {}", Core::DateTime::from_timestamp(profile->creation_timestamp()));
     outln("      primary platform: {}", Gfx::ICC::primary_platform_name(profile->primary_platform()));
 
     auto flags = profile->flags();


### PR DESCRIPTION
Align header on the `:`, and make bitmask output more structured.

---

Before:

```
% Build/lagom/icc ~/src/Compact-ICC-Profiles/profiles/sRGB-v2-magic.icc
preferred CMM type: 'lcms'
version: 2.1.0
device class: DisplayDevice
data color space: RGB
connection space: PCSXYZ
creation date and time: 2018-03-20 05:14:29
primary platform: Microsoft
flags: 0x00000000
  embedded in file: no
  can be used independently of embedded color data: yes
device manufacturer: 'saws'
device model: 'ctrl'
device attributes: 0x0000000000000000
  media is reflective, glossy, of positive polarity, colored
rendering intent: Perceptual
pcs illuminant: X = 0.964202, Y = 1, Z = 0.824905
creator: 'hand'
id: 93b234a9-0eb0228a-98fd9aaf-a367899b

tags:
'desc': 'desc', offset 240, size 95
'cprt': 'text', offset 268, size 12
'wtpt': 'XYZ ', offset 280, size 20
'rXYZ': 'XYZ ', offset 300, size 20
'gXYZ': 'XYZ ', offset 320, size 20
'bXYZ': 'XYZ ', offset 340, size 20
'rTRC': 'curv', offset 360, size 376
'gTRC': 'curv', offset 360, size 376
'bTRC': 'curv', offset 360, size 376
```

Now:
```
% Build/lagom/icc ~/src/Compact-ICC-Profiles/profiles/sRGB-v2-magic.icc
    preferred CMM type: 'lcms'
               version: 2.1.0
          device class: DisplayDevice
      data color space: RGB
      connection space: PCSXYZ
creation date and time: 2018-03-20 05:14:29
      primary platform: Microsoft
                 flags: 0x00000000
                        - not embedded in file
                        - can be used independently of embedded color data
   device manufacturer: 'saws'
          device model: 'ctrl'
     device attributes: 0x0000000000000000
                        media is:
                        - reflective
                        - glossy
                        - of positive polarity
                        - colored
      rendering intent: Perceptual
        pcs illuminant: X = 0.964202, Y = 1, Z = 0.824905
               creator: 'hand'
                    id: 93b234a9-0eb0228a-98fd9aaf-a367899b

tags:
'desc': 'desc', offset 240, size 95
'cprt': 'text', offset 268, size 12
'wtpt': 'XYZ ', offset 280, size 20
'rXYZ': 'XYZ ', offset 300, size 20
'gXYZ': 'XYZ ', offset 320, size 20
'bXYZ': 'XYZ ', offset 340, size 20
'rTRC': 'curv', offset 360, size 376
'gTRC': 'curv', offset 360, size 376
'bTRC': 'curv', offset 360, size 376
```