### PR TITLE
LibWasm: The `Core::Stream`ening

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzWasmParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWasmParser.cpp
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/MemoryStream.h>
-#include <AK/Stream.h>
+#include <LibCore/MemoryStream.h>
 #include <LibWasm/Types.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -13,8 +12,10 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     ReadonlyBytes bytes { data, size };
-    InputMemoryStream stream { bytes };
-    [[maybe_unused]] auto result = Wasm::Module::parse(stream);
-    stream.handle_any_error();
+    auto stream_or_error = Core::Stream::FixedMemoryStream::construct(bytes);
+    if (stream_or_error.is_error())
+        return 0;
+    auto stream = stream_or_error.release_value();
+    [[maybe_unused]] auto result = Wasm::Module::parse(*stream);
     return 0;
 }

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/MemoryStream.h>
 #include <LibCore/Stream.h>
 #include <LibTest/JavaScriptTestRunner.h>
 #include <LibWasm/AbstractMachine/BytecodeInterpreter.h>
@@ -105,18 +106,10 @@ TESTJS_GLOBAL_FUNCTION(parse_webassembly_module, parseWebAssemblyModule)
     if (!is<JS::Uint8Array>(object))
         return vm.throw_completion<JS::TypeError>("Expected a Uint8Array argument to parse_webassembly_module");
     auto& array = static_cast<JS::Uint8Array&>(*object);
-    InputMemoryStream stream { array.data() };
-    ScopeGuard handle_stream_error {
-        [&] {
-            stream.handle_any_error();
-        }
-    };
-    auto result = Wasm::Module::parse(stream);
+    auto stream = Core::Stream::FixedMemoryStream::construct(array.data()).release_value_but_fixme_should_propagate_errors();
+    auto result = Wasm::Module::parse(*stream);
     if (result.is_error())
         return vm.throw_completion<JS::SyntaxError>(Wasm::parse_error_to_deprecated_string(result.error()));
-
-    if (stream.handle_any_error())
-        return vm.throw_completion<JS::SyntaxError>("Binary stream contained errors");
 
     HashMap<Wasm::Linker::Name, Wasm::ExternValue> imports;
     auto import_value = vm.argument(1);

--- a/Userland/Libraries/LibWasm/AbstractMachine/Configuration.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Configuration.cpp
@@ -87,8 +87,7 @@ void Configuration::dump_stack()
 {
     auto print_value = []<typename... Ts>(CheckedFormatString<Ts...> format, Ts... vs) {
         Core::Stream::AllocatingMemoryStream memory_stream;
-        Core::Stream::WrapInAKOutputStream wrapped_memory_stream { memory_stream };
-        Printer { wrapped_memory_stream }.print(vs...);
+        Printer { memory_stream }.print(vs...);
         auto buffer = ByteBuffer::create_uninitialized(memory_stream.used_buffer_size()).release_value_but_fixme_should_propagate_errors();
         memory_stream.read_entire_buffer(buffer).release_value_but_fixme_should_propagate_errors();
         dbgln(format.view(), StringView(buffer).trim_whitespace());

--- a/Userland/Libraries/LibWasm/Printer/Printer.cpp
+++ b/Userland/Libraries/LibWasm/Printer/Printer.cpp
@@ -34,7 +34,7 @@ Optional<OpCode> instruction_from_name(StringView name)
 void Printer::print_indent()
 {
     for (size_t i = 0; i < m_indent; ++i)
-        m_stream.write_or_error("  "sv.bytes());
+        m_stream.write_entire_buffer("  "sv.bytes()).release_value_but_fixme_should_propagate_errors();
 }
 
 void Printer::print(Wasm::BlockType const& type)

--- a/Userland/Libraries/LibWasm/Printer/Printer.h
+++ b/Userland/Libraries/LibWasm/Printer/Printer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibCore/Stream.h>
 #include <LibWasm/Types.h>
 
 namespace Wasm {
@@ -17,7 +18,7 @@ DeprecatedString instruction_name(OpCode const& opcode);
 Optional<OpCode> instruction_from_name(StringView name);
 
 struct Printer {
-    explicit Printer(OutputStream& stream, size_t initial_indent = 0)
+    explicit Printer(Core::Stream::Stream& stream, size_t initial_indent = 0)
         : m_stream(stream)
         , m_indent(initial_indent)
     {
@@ -68,10 +69,10 @@ private:
     {
         StringBuilder builder;
         builder.appendff(fmt.view(), forward<Args>(args)...);
-        m_stream.write_or_error(builder.string_view().bytes());
+        m_stream.write_entire_buffer(builder.string_view().bytes()).release_value_but_fixme_should_propagate_errors();
     }
 
-    OutputStream& m_stream;
+    Core::Stream::Stream& m_stream;
     size_t m_indent { 0 };
 };
 

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -252,8 +252,8 @@ static Optional<Wasm::Module> parse(StringView filename)
         return {};
     }
 
-    InputMemoryStream stream { ReadonlyBytes { result.value()->data(), result.value()->size() } };
-    auto parse_result = Wasm::Module::parse(stream);
+    auto stream = Core::Stream::FixedMemoryStream::construct(ReadonlyBytes { result.value()->data(), result.value()->size() }).release_value_but_fixme_should_propagate_errors();
+    auto parse_result = Wasm::Module::parse(*stream);
     if (parse_result.is_error()) {
         warnln("Something went wrong, either the file is invalid, or there's a bug with LibWasm!");
         warnln("The parse error was {}", Wasm::parse_error_to_deprecated_string(parse_result.error()));


### PR DESCRIPTION
This was probably the worst offender from the list (narrator: "It wasn't"). Not sure if we should try and fix the new `release_value_but_fixme_should_propagate_errors` right away, but in either case I'm too unfamiliar with how LibWasm propagates errors to integrate it into that.