### PR TITLE
LibWeb: Prevent margin collapsing if box has clearance

### DIFF
--- a/Tests/LibWeb/Layout/expected/clearfix.txt
+++ b/Tests/LibWeb/Layout/expected/clearfix.txt
@@ -1,0 +1,16 @@
+InitialContainingBlock <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x157 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x100 children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+          TextNode <#text>
+          BlockContainer <div.square.white> at (8,8) content-size 100x100 floating children: not-inline
+          TextNode <#text>
+        BlockContainer <div.clearfix> at (8,108) content-size 784x0 children: not-inline
+        BlockContainer <(anonymous)> at (8,108) content-size 784x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.square.black> at (8,108) content-size 49x49 floating children: not-inline
+        BlockContainer <(anonymous)> at (8,108) content-size 784x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,108) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/clearfix.html
+++ b/Tests/LibWeb/Layout/input/clearfix.html
@@ -1,0 +1,23 @@
+<style>
+    .clearfix {
+        clear: both;
+    }
+    .square {
+        float: left;
+        width: 49px;
+        height: 49px;
+    }
+    .white {
+        background-color: salmon;
+        width: 100px;
+        height: 100px;
+    }
+    .black {
+        background-color: slateblue;
+    }
+</style>
+<div>
+    <div class="square white"></div>
+    <div class="clearfix"></div>
+    <div class="square black"></div>
+</div>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -636,6 +636,8 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_vertically
             for (auto* containing_block = child_box.containing_block(); containing_block && containing_block != &root(); containing_block = containing_block->containing_block())
                 clearance_y_in_containing_block -= m_state.get(*containing_block).offset.y();
 
+            if (clearance_y_in_containing_block > y)
+                m_y_offset_of_current_block_container = clearance_y_in_containing_block;
             y = max(y, clearance_y_in_containing_block);
             float_side.clear();
         }

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -46,7 +46,7 @@ public:
 
     void layout_floating_box(Box const& child, BlockContainer const& containing_block, LayoutMode, AvailableSpace const&, CSSPixels y, LineBuilder* = nullptr);
 
-    void layout_block_level_box(Box const&, BlockContainer const&, LayoutMode, CSSPixels& bottom_of_lowest_margin_box, AvailableSpace const&, CSSPixels& current_y);
+    void layout_block_level_box(Box const&, BlockContainer const&, LayoutMode, CSSPixels& bottom_of_lowest_margin_box, AvailableSpace const&);
 
     virtual bool can_determine_size_of_child() const override { return true; }
     virtual void determine_width_of_child(Box const&, AvailableSpace const&) override;
@@ -149,6 +149,8 @@ private:
             current_collapsible_margins.clear();
         }
     };
+
+    Optional<CSSPixels> m_y_offset_of_current_block_container;
 
     BlockMarginState m_margin_state;
 


### PR DESCRIPTION
Margin top should not collapse with margin bottom if box has clearance.

Fix for #17120