### PR TITLE
icc: Dump contents of `textType` and `multiLocalizedUnicodeType` tag types

### DIFF
--- a/Userland/Libraries/LibGfx/ICCProfile.cpp
+++ b/Userland/Libraries/LibGfx/ICCProfile.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Endian.h>
 #include <LibGfx/ICCProfile.h>
+#include <LibTextCodec/Decoder.h>
 #include <math.h>
 #include <time.h>
 
@@ -549,6 +550,68 @@ static ErrorOr<void> check_reserved(ReadonlyBytes tag_bytes)
     return {};
 }
 
+ErrorOr<NonnullRefPtr<MultiLocalizedUnicodeTagData>> MultiLocalizedUnicodeTagData::from_bytes(ReadonlyBytes bytes, u32 offset, u32 size)
+{
+    // ICC v4, 10.15 multiLocalizedUnicodeType
+    VERIFY(tag_type(bytes) == MultiLocalizedUnicodeTagData::Type);
+    TRY(check_reserved(bytes));
+
+    // "Multiple strings within this tag may share storage locations. For example, en/US and en/UK can refer to the
+    //  same string data."
+    // This implementation makes redudant string copies in that case.
+    // Most of the time, this costs just a few bytes, so that seems ok.
+
+    if (bytes.size() < 4 * sizeof(u32))
+        return Error::from_string_literal("ICC::Profile: multiLocalizedUnicodeType has not enough data");
+
+    // Table 54 — multiLocalizedUnicodeType
+    u32 number_of_records = *bit_cast<BigEndian<u32> const*>(bytes.data() + 8);
+    u32 record_size = *bit_cast<BigEndian<u32> const*>(bytes.data() + 12);
+
+    // "The fourth field of this tag, the record size, should contain the value 12, which corresponds to the size in bytes
+    // of each record. Any code that needs to access the nth record should determine the record’s offset by multiplying
+    // n by the contents of this size field and adding 16. This minor extra effort allows for future expansion of the record
+    // encoding, should the need arise, without having to define a new tag type."
+    if (record_size < 12)
+        return Error::from_string_literal("ICC::Profile: multiLocalizedUnicodeType record size too small");
+    if (bytes.size() < 16 + number_of_records * record_size)
+        return Error::from_string_literal("ICC::Profile: multiLocalizedUnicodeType not enough data for records");
+
+    Vector<Record> records;
+    TRY(records.try_resize(number_of_records));
+
+    // "For the definition of language codes and country codes, see respectively
+    //  ISO 639-1 and ISO 3166-1. The Unicode strings in storage should be encoded as 16-bit big-endian, UTF-16BE,
+    //  and should not be NULL terminated."
+    auto& utf_16be_decoder = *TextCodec::decoder_for("utf-16be");
+
+    struct RawRecord {
+        BigEndian<u16> language_code;
+        BigEndian<u16> country_code;
+        BigEndian<u32> string_length_in_bytes;
+        BigEndian<u32> string_offset_in_bytes;
+    };
+
+    for (u32 i = 0; i < number_of_records; ++i) {
+        size_t offset = 16 + i * record_size;
+        RawRecord record = *bit_cast<RawRecord const*>(bytes.data() + offset);
+
+        records[i].iso_639_1_language_code = record.language_code;
+        records[i].iso_3166_1_country_code = record.country_code;
+
+        if (record.string_length_in_bytes % 2 != 0)
+            return Error::from_string_literal("ICC::Profile: multiLocalizedUnicodeType odd UTF-16 byte length");
+
+        if (record.string_offset_in_bytes + record.string_length_in_bytes > bytes.size())
+            return Error::from_string_literal("ICC::Profile: multiLocalizedUnicodeType string offset out of bounds");
+
+        StringView utf_16be_data { bytes.data() + record.string_offset_in_bytes, record.string_length_in_bytes };
+        records[i].text = TRY(String::from_deprecated_string(utf_16be_decoder.to_utf8(utf_16be_data)));
+    }
+
+    return adopt_ref(*new MultiLocalizedUnicodeTagData(offset, size, move(records)));
+}
+
 ErrorOr<NonnullRefPtr<TextTagData>> TextTagData::from_bytes(ReadonlyBytes bytes, u32 offset, u32 size)
 {
     // ICC v4, 10.24 textType
@@ -619,6 +682,8 @@ ErrorOr<NonnullRefPtr<TagData>> Profile::read_tag(ReadonlyBytes bytes, Detail::T
 
     auto type = tag_type(tag_bytes);
     switch (type) {
+    case MultiLocalizedUnicodeTagData::Type:
+        return MultiLocalizedUnicodeTagData::from_bytes(tag_bytes, entry.offset_to_beginning_of_tag_data_element, entry.size_of_tag_data_element);
     case TextTagData::Type:
         return TextTagData::from_bytes(tag_bytes, entry.offset_to_beginning_of_tag_data_element, entry.size_of_tag_data_element);
     default:

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -257,6 +257,29 @@ public:
     }
 };
 
+// ICC v4, 10.15 multiLocalizedUnicodeType
+class MultiLocalizedUnicodeTagData : public TagData {
+public:
+    static constexpr TagTypeSignature Type { 0x6D6C7563 }; // 'mluc'
+
+    static ErrorOr<NonnullRefPtr<MultiLocalizedUnicodeTagData>> from_bytes(ReadonlyBytes, u32 offset, u32 size);
+
+    struct Record {
+        u16 iso_639_1_language_code;
+        u16 iso_3166_1_country_code;
+        String text;
+    };
+
+    MultiLocalizedUnicodeTagData(u32 offset, u32 size, Vector<Record> records)
+        : TagData(offset, size, Type)
+        , m_records(move(records))
+    {
+    }
+
+private:
+    Vector<Record> m_records;
+};
+
 // ICC v4, 10.24 textType
 class TextTagData : public TagData {
 public:

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -276,6 +276,8 @@ public:
     {
     }
 
+    Vector<Record> const& records() const { return m_records; }
+
 private:
     Vector<Record> m_records;
 };

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -93,6 +93,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     outln("tags:");
     profile->for_each_tag([](auto tag_signature, auto tag_data) {
         outln("{}: {}, offset {}, size {}", tag_signature, tag_data->type(), tag_data->offset(), tag_data->size());
+
+        if (tag_data->type() == Gfx::ICC::TextTagData::Type) {
+            outln("    text: \"{}\"", static_cast<Gfx::ICC::TextTagData&>(*tag_data).text());
+        }
     });
 
     return 0;

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -94,7 +94,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     profile->for_each_tag([](auto tag_signature, auto tag_data) {
         outln("{}: {}, offset {}, size {}", tag_signature, tag_data->type(), tag_data->offset(), tag_data->size());
 
-        if (tag_data->type() == Gfx::ICC::TextTagData::Type) {
+        if (tag_data->type() == Gfx::ICC::MultiLocalizedUnicodeTagData::Type) {
+            auto& multi_localized_unicode = static_cast<Gfx::ICC::MultiLocalizedUnicodeTagData&>(*tag_data);
+            for (auto& record : multi_localized_unicode.records()) {
+                outln("    {:c}{:c}/{:c}{:c}: \"{}\"",
+                    record.iso_639_1_language_code >> 8, record.iso_639_1_language_code & 0xff,
+                    record.iso_3166_1_country_code >> 8, record.iso_3166_1_country_code & 0xff,
+                    record.text);
+            }
+        } else if (tag_data->type() == Gfx::ICC::TextTagData::Type) {
             outln("    text: \"{}\"", static_cast<Gfx::ICC::TextTagData&>(*tag_data).text());
         }
     });


### PR DESCRIPTION
Screenshot:

```
% Build/lagom/icc /Library/ColorSync/Profiles/WebSafeColors.icc
    preferred CMM type: 'appl'
               version: 2.2.0
          device class: NamedColor
      data color space: RGB
      connection space: PCSLAB
creation date and time: 2003-06-30 20:00:00
      primary platform: Apple
                 flags: 0x00000000
                        - not embedded in file
                        - can be used independently of embedded color data
   device manufacturer: (not set)
          device model: (not set)
     device attributes: 0x0000000000000000
                        media is:
                        - reflective
                        - glossy
                        - of positive polarity
                        - colored
      rendering intent: Perceptual
        pcs illuminant: X = 0.964202, Y = 1, Z = 0.824905
               creator: 'appl'
                    id: (not set)

tags:
'desc': 'desc', offset 204, size 107
'dscm': 'mluc', offset 312, size 1490
    sk/SK: "Web Safe farby"
    da/DK: "Websikre farver"
    ca/ES: "Colors segurs per al web"
    vi/VN: "M￠u sﾯc Ph￹ h￣p cho Web"
    pt/BR: "Cores Seguras para a Web"
    uk/UA: "Веб-безпечні кольори"
    fr/FU: "Couleurs s￩curis￩es web"
    hu/HU: "Weben haszn￡lhat￳ sz￭nek"
    zh/TW: "ﾲ頁ﾉ全色"
    nb/NO: "Nettsikre farger"
    ko/KR: "￹ 전ﾩ ￉￁"
    cs/CZ: "Bezpečn￩ webov￩ barvy"
    he/IL: "￦￑￢￙￝ ￜ￩￙￞ￕ￩ ￑￐￙￠￘￨￠￘"
    ro/RO: "Culori sigure pentru web"
    de/DE: "Websichere Farben"
    it/IT: "Colori Web"
    sv/SE: "Webbs￤kra f￤rger"
    zh/CN: "Webﾉ全色"
    ja/JP: "Web ﾻ￼ￕﾫ￩￼"
    el/GR: "ﾑￃￆﾱﾻﾮ ￇ￁ￎﾼﾱￄﾱ ﾙￃￄ﾿ￍ"
    pt/PO: "Cores seguras para a web"
    nl/NL: "Webveilige kleuren"
    es/ES: "Colores web seguros"
    th/TH: "สีที่ใช้ได้บนเว็บ"
    tr/TR: "G￼venli Web Renkleri"
    fi/FI: "Selainvarmat v￤rit"
    hr/HR: "Boje sigurne za web"
    pl/PL: "Kolory właściwe dla WWW"
    ar/EG: "ألوان الويب الآمنة"
    ru/RU: "Web-безопасные цвета"
    en/US: "Web Safe Colors"
'cprt': 'text', offset 1804, size 56
    text: "Copyright 2007 Apple Inc., All rights reserved."
'wtpt': 'XYZ ', offset 1860, size 20
'ncl2': 'ncl2', offset 1880, size 9588
'ncpi': 'ncpi', offset 11468, size 36
```

Note that the text is incorrect. That's because https://github.com/SerenityOS/serenity/blob/master/Userland/Libraries/LibTextCodec/Decoder.cpp#L239 doesn't actually decode UTF-16BE but UCS-2BE. But once that's fixed, it'll fix that problem in `icc` and everywhere else across the system.