### PR TITLE
ImageDecoder: Actually set `is_animated` and `loop_count` variables

### DIFF
--- a/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -41,8 +41,6 @@ static void decode_image_to_details(Core::AnonymousBuffer const& encoded_buffer,
 {
     VERIFY(bitmaps.size() == 0);
     VERIFY(durations.size() == 0);
-    VERIFY(!is_animated);
-    VERIFY(loop_count == 0);
 
     auto decoder = Gfx::ImageDecoder::try_create_for_raw_bytes(ReadonlyBytes { encoded_buffer.data<u8>(), encoded_buffer.size() }, known_mime_type);
     if (!decoder) {
@@ -54,6 +52,8 @@ static void decode_image_to_details(Core::AnonymousBuffer const& encoded_buffer,
         dbgln_if(IMAGE_DECODER_DEBUG, "Could not decode image from encoded data");
         return;
     }
+    is_animated = decoder->is_animated();
+    loop_count = decoder->loop_count();
     decode_image_to_bitmaps_and_durations_with_decoder(*decoder, bitmaps, durations);
 }
 


### PR DESCRIPTION
Before https://github.com/SerenityOS/serenity/commit/649f78d0a4475a640ad353e1e879a7bb27db222b, the is_animated and loop_count objects were set directly when making a return object.

That commit moved the decode logic to a separate function but forgot to assign `is_animated` and `loop_count`. The compiler didn't throw an error about unused variables because we were also VERIFY()ing that these variables were zero-initialized at the beginning of the function.