### PR TITLE
LibTextCodec: Make utf-16be and utf-16le codecs actually work

### DIFF
--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -276,6 +276,20 @@ u32 Utf16CodePointIterator::operator*() const
 {
     VERIFY(m_remaining_code_units > 0);
 
+    // rfc2781, 2.2 Decoding UTF-16
+    // 1) If W1 < 0xD800 or W1 > 0xDFFF, the character value U is the value
+    //    of W1. Terminate.
+    // 2) Determine if W1 is between 0xD800 and 0xDBFF. If not, the sequence
+    //    is in error and no valid character can be obtained using W1.
+    //    Terminate.
+    // 3) If there is no W2 (that is, the sequence ends with W1), or if W2
+    //    is not between 0xDC00 and 0xDFFF, the sequence is in error.
+    //    Terminate.
+    // 4) Construct a 20-bit unsigned integer U', taking the 10 low-order
+    //    bits of W1 as its 10 high-order bits and the 10 low-order bits of
+    //    W2 as its 10 low-order bits.
+    // 5) Add 0x10000 to U' to obtain the character value U. Terminate.
+
     if (Utf16View::is_high_surrogate(*m_ptr)) {
         if ((m_remaining_code_units > 1) && Utf16View::is_low_surrogate(*(m_ptr + 1)))
             return Utf16View::decode_surrogate_pair(*m_ptr, *(m_ptr + 1));

--- a/Tests/LibTextCodec/TestTextDecoders.cpp
+++ b/Tests/LibTextCodec/TestTextDecoders.cpp
@@ -23,3 +23,37 @@ TEST_CASE(test_utf8_decode)
 
     EXPECT(decoder.to_utf8(test_string) == test_string);
 }
+
+TEST_CASE(test_utf16be_decode)
+{
+    auto decoder = TextCodec::UTF16BEDecoder();
+    // This is the output of `python3 -c "print('säk😀'.encode('utf-16be'))"`.
+    auto test_string = "\x00s\x00\xe4\x00k\xd8=\xde\x00"sv;
+
+    Vector<u32> processed_code_points;
+    decoder.process(test_string, [&](u32 code_point) {
+        processed_code_points.append(code_point);
+    });
+    EXPECT(processed_code_points.size() == 4);
+    EXPECT(processed_code_points[0] == 0x73);
+    EXPECT(processed_code_points[1] == 0xE4);
+    EXPECT(processed_code_points[2] == 0x6B);
+    EXPECT(processed_code_points[3] == 0x1F600);
+}
+
+TEST_CASE(test_utf16le_decode)
+{
+    auto decoder = TextCodec::UTF16LEDecoder();
+    // This is the output of `python3 -c "print('säk😀'.encode('utf-16le'))"`.
+    auto test_string = "s\x00\xe4\x00k\x00=\xd8\x00\xde"sv;
+
+    Vector<u32> processed_code_points;
+    decoder.process(test_string, [&](u32 code_point) {
+        processed_code_points.append(code_point);
+    });
+    EXPECT(processed_code_points.size() == 4);
+    EXPECT(processed_code_points[0] == 0x73);
+    EXPECT(processed_code_points[1] == 0xE4);
+    EXPECT(processed_code_points[2] == 0x6B);
+    EXPECT(processed_code_points[3] == 0x1F600);
+}


### PR DESCRIPTION
There were two problems:

1. They didn't handle surrogates
2. They used signed chars, leading to e.g. 0x00e4 being treated as 0xffe4

Also add a basic test that catches both issues.
There's some code duplication with Utf16CodePointIterator::operator*(),
but let's get things working first.

----

Effect on the most important serenity application:

Before:

```
% Build/lagom/icc /Library/ColorSync/Profiles/WebSafeColors.icc
    preferred CMM type: 'appl'
               version: 2.2.0
          device class: NamedColor
      data color space: RGB
      connection space: PCSLAB
creation date and time: 2003-06-30 20:00:00
      primary platform: Apple
                 flags: 0x00000000
                        - not embedded in file
                        - can be used independently of embedded color data
   device manufacturer: (not set)
          device model: (not set)
     device attributes: 0x0000000000000000
                        media is:
                        - reflective
                        - glossy
                        - of positive polarity
                        - colored
      rendering intent: Perceptual
        pcs illuminant: X = 0.964202, Y = 1, Z = 0.824905
               creator: 'appl'
                    id: (not set)

tags:
'desc': 'desc', offset 204, size 107
'dscm': 'mluc', offset 312, size 1490
    sk/SK: "Web Safe farby"
    da/DK: "Websikre farver"
    ca/ES: "Colors segurs per al web"
    vi/VN: "M￠u sﾯc Ph￹ h￣p cho Web"
    pt/BR: "Cores Seguras para a Web"
    uk/UA: "Веб-безпечні кольори"
    fr/FU: "Couleurs s￩curis￩es web"
    hu/HU: "Weben haszn￡lhat￳ sz￭nek"
    zh/TW: "ﾲ頁ﾉ全色"
    nb/NO: "Nettsikre farger"
    ko/KR: "￹ 전ﾩ ￉￁"
    cs/CZ: "Bezpečn￩ webov￩ barvy"
    he/IL: "￦￑￢￙￝ ￜ￩￙￞ￕ￩ ￑￐￙￠￘￨￠￘"
    ro/RO: "Culori sigure pentru web"
    de/DE: "Websichere Farben"
    it/IT: "Colori Web"
    sv/SE: "Webbs￤kra f￤rger"
    zh/CN: "Webﾉ全色"
    ja/JP: "Web ﾻ￼ￕﾫ￩￼"
    el/GR: "ﾑￃￆﾱﾻﾮ ￇ￁ￎﾼﾱￄﾱ ﾙￃￄ﾿ￍ"
    pt/PO: "Cores seguras para a web"
    nl/NL: "Webveilige kleuren"
    es/ES: "Colores web seguros"
    th/TH: "สีที่ใช้ได้บนเว็บ"
    tr/TR: "G￼venli Web Renkleri"
    fi/FI: "Selainvarmat v￤rit"
    hr/HR: "Boje sigurne za web"
    pl/PL: "Kolory właściwe dla WWW"
    ar/EG: "ألوان الويب الآمنة"
    ru/RU: "Web-безопасные цвета"
    en/US: "Web Safe Colors"
'cprt': 'text', offset 1804, size 56
    text: "Copyright 2007 Apple Inc., All rights reserved."
'wtpt': 'XYZ ', offset 1860, size 20
'ncl2': 'ncl2', offset 1880, size 9588
'ncpi': 'ncpi', offset 11468, size 36
```

After:

```
% Build/lagom/icc /Library/ColorSync/Profiles/WebSafeColors.icc
    preferred CMM type: 'appl'
               version: 2.2.0
          device class: NamedColor
      data color space: RGB
      connection space: PCSLAB
creation date and time: 2003-06-30 20:00:00
      primary platform: Apple
                 flags: 0x00000000
                        - not embedded in file
                        - can be used independently of embedded color data
   device manufacturer: (not set)
          device model: (not set)
     device attributes: 0x0000000000000000
                        media is:
                        - reflective
                        - glossy
                        - of positive polarity
                        - colored
      rendering intent: Perceptual
        pcs illuminant: X = 0.964202, Y = 1, Z = 0.824905
               creator: 'appl'
                    id: (not set)

tags:
'desc': 'desc', offset 204, size 107
'dscm': 'mluc', offset 312, size 1490
    sk/SK: "Web Safe farby"
    da/DK: "Websikre farver"
    ca/ES: "Colors segurs per al web"
    vi/VN: "Màu sắc Phù hợp cho Web"
    pt/BR: "Cores Seguras para a Web"
    uk/UA: "Веб-безпечні кольори"
    fr/FU: "Couleurs sécurisées web"
    hu/HU: "Weben használható színek"
    zh/TW: "網頁安全色"
    nb/NO: "Nettsikre farger"
    ko/KR: "웹 전용 색상"
    cs/CZ: "Bezpečné webové barvy"
    he/IL: "צבעים לשימוש באינטרנט"
    ro/RO: "Culori sigure pentru web"
    de/DE: "Websichere Farben"
    it/IT: "Colori Web"
    sv/SE: "Webbsäkra färger"
    zh/CN: "Web安全色"
    ja/JP: "Web セーフカラー"
    el/GR: "Ασφαλή χρώματα Ιστού"
    pt/PO: "Cores seguras para a web"
    nl/NL: "Webveilige kleuren"
    es/ES: "Colores web seguros"
    th/TH: "สีที่ใช้ได้บนเว็บ"
    tr/TR: "Güvenli Web Renkleri"
    fi/FI: "Selainvarmat värit"
    hr/HR: "Boje sigurne za web"
    pl/PL: "Kolory właściwe dla WWW"
    ar/EG: "ألوان الويب الآمنة"
    ru/RU: "Web-безопасные цвета"
    en/US: "Web Safe Colors"
'cprt': 'text', offset 1804, size 56
    text: "Copyright 2007 Apple Inc., All rights reserved."
'wtpt': 'XYZ ', offset 1860, size 20
'ncl2': 'ncl2', offset 1880, size 9588
'ncpi': 'ncpi', offset 11468, size 36
```