### PR TITLE
PixelPaint: Scale the clone tool sample marker size with zoom level

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
@@ -176,7 +176,7 @@ Optional<Gfx::IntRect> CloneTool::sample_marker_rect()
     if (!m_sample_location.has_value())
         return {};
 
-    auto offset = AK::max(2, size() / 2);
+    auto offset = AK::max(2, size());
     Gfx::IntRect content_rect = {
         m_sample_location.value().x() - offset,
         m_sample_location.value().y() - offset,

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
@@ -144,7 +144,9 @@ ErrorOr<GUI::Widget*> CloneTool::get_properties_widget()
         size_slider->set_value(size());
 
         size_slider->on_change = [this](int value) {
+            auto old_sample_marker_rect = sample_marker_rect();
             set_size(value);
+            update_sample_marker(old_sample_marker_rect);
         };
         set_primary_slider(size_slider);
 

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
@@ -176,15 +176,14 @@ Optional<Gfx::IntRect> CloneTool::sample_marker_rect()
     if (!m_sample_location.has_value())
         return {};
 
-    auto sample_pos = m_editor->content_to_frame_position(m_sample_location.value());
-    // We don't want the marker to be a single pixel and hide the color.
     auto offset = AK::max(2, size() / 2);
-    return Gfx::IntRect {
-        (int)sample_pos.x() - offset,
-        (int)sample_pos.y() - offset,
+    Gfx::IntRect content_rect = {
+        m_sample_location.value().x() - offset,
+        m_sample_location.value().y() - offset,
         offset * 2,
         offset * 2
     };
+    return m_editor->content_to_frame_rect(content_rect).to_type<int>();
 }
 
 void CloneTool::update_sample_marker(Optional<Gfx::IntRect> old_rect)

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.h
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.h
@@ -32,6 +32,8 @@ protected:
 
 private:
     virtual StringView tool_name() const override { return "Clone Tool"sv; }
+    Optional<Gfx::IntRect> sample_marker_rect();
+    void update_sample_marker(Optional<Gfx::IntRect> old_rect);
 
     RefPtr<GUI::Widget> m_properties_widget;
 


### PR DESCRIPTION
This PR  ensures that the sample marker size scales correctly when zooming in and out and that the brush size is consistent with all other brush tools. 

The sample marker is also redrawn when the brush size is updated.

