### PR TITLE
LibCore: Add nice get/set_process_name() wrappers in Core::Process

### DIFF
--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  * Copyright (c) 2022, the SerenityOS developers.
  *
@@ -20,6 +20,7 @@
 #include <LibConfig/Listener.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
+#include <LibCore/Process.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibDesktop/Launcher.h>
@@ -342,9 +343,7 @@ bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView c
 
 ErrorOr<int> run_in_desktop_mode()
 {
-    constexpr char const* process_name = "FileManager (Desktop)";
-    set_process_name(process_name, strlen(process_name));
-    pthread_setname_np(pthread_self(), process_name);
+    (void)Core::Process::set_name("FileManager (Desktop)"sv, Core::Process::SetThreadName::Yes);
 
     auto window = TRY(GUI::Window::try_create());
     window->set_title("Desktop Manager");

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -17,6 +18,13 @@ public:
     static ErrorOr<pid_t> spawn(StringView path, Span<DeprecatedString const> arguments, DeprecatedString working_directory = {});
     static ErrorOr<pid_t> spawn(StringView path, Span<StringView const> arguments, DeprecatedString working_directory = {});
     static ErrorOr<pid_t> spawn(StringView path, Span<char const* const> arguments = {}, DeprecatedString working_directory = {});
+
+    static ErrorOr<String> get_name();
+    enum class SetThreadName {
+        No,
+        Yes,
+    };
+    static ErrorOr<void> set_name(StringView, SetThreadName = SetThreadName::No);
 };
 
 }


### PR DESCRIPTION
`Process::get_name()` and `Process::set_name()` are basically the same
as `get_process_name()` and `set_process_name()`, except making use of
convenient Serenity standard types and returning ErrorOr, instead of
char* and errno shenanigans.

`Process::set_name()` has an optional `SetThreadName` parameter, for
when you also want to set the thread's name to the same thing. That's
true for the two places that use `set_process_name()`.