### PR TITLE
LibGfx+icc: Add ICCProfile support for s15Fixed16ArrayType and print it

### DIFF
--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -74,6 +74,13 @@ public:
         return value;
     }
 
+    static constexpr This create_raw(Underlying value)
+    {
+        This t {};
+        t.raw() = value;
+        return t;
+    }
+
     constexpr Underlying raw() const
     {
         return m_value;
@@ -377,13 +384,6 @@ private:
             raw_value |= m_value & radix_mask;
 
         return FixedPoint<P, U>::create_raw(raw_value);
-    }
-
-    static This create_raw(Underlying value)
-    {
-        This t {};
-        t.raw() = value;
-        return t;
     }
 
     Underlying m_value;

--- a/Userland/Libraries/LibGfx/ICCProfile.cpp
+++ b/Userland/Libraries/LibGfx/ICCProfile.cpp
@@ -813,7 +813,7 @@ ErrorOr<NonnullRefPtr<XYZTagData>> XYZTagData::from_bytes(ReadonlyBytes bytes, u
     //  number of sets of values is determined from the size of the tag."
     size_t byte_size = bytes.size() - 8;
     if (byte_size % sizeof(XYZNumber) != 0)
-        return Error::from_string_literal("ICC::Profile: XYZType wrong size");
+        return Error::from_string_literal("ICC::Profile: XYZType has wrong size");
 
     size_t xyz_count = byte_size / sizeof(XYZNumber);
     XYZNumber const* raw_xyzs = bit_cast<XYZNumber const*>(bytes.data() + 8);

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <AK/FixedPoint.h>
 #include <AK/Format.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullRefPtr.h>
@@ -280,6 +281,27 @@ public:
 
 private:
     Vector<Record> m_records;
+};
+
+// ICC v4, 10.22 s15Fixed16ArrayType
+class S15Fixed16ArrayTagData : public TagData {
+public:
+    static constexpr TagTypeSignature Type { 0x73663332 }; // 'sf32'
+
+    using S15Fixed16 = FixedPoint<16, i32>;
+
+    static ErrorOr<NonnullRefPtr<S15Fixed16ArrayTagData>> from_bytes(ReadonlyBytes, u32 offset, u32 size);
+
+    S15Fixed16ArrayTagData(u32 offset, u32 size, Vector<S15Fixed16, 9> values)
+        : TagData(offset, size, Type)
+        , m_values(move(values))
+    {
+    }
+
+    Vector<S15Fixed16, 9> const& values() const { return m_values; }
+
+private:
+    Vector<S15Fixed16, 9> m_values;
 };
 
 // ICC v2, 6.5.17 textDescriptionType

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -102,6 +102,25 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     record.iso_3166_1_country_code >> 8, record.iso_3166_1_country_code & 0xff,
                     record.text);
             }
+        } else if (tag_data->type() == Gfx::ICC::S15Fixed16ArrayTagData::Type) {
+            // This tag can contain arbitrarily many fixed-point numbers, but in practice it's
+            // exclusively used for the 'chad' tag, where it always contains 9 values that
+            // represent a 3x3 matrix.  So print the values in groups of 3.
+            auto& fixed_array = static_cast<Gfx::ICC::S15Fixed16ArrayTagData&>(*tag_data);
+            out("    [");
+            int i = 0;
+            for (auto value : fixed_array.values()) {
+                if (i > 0) {
+                    out(",");
+                    if (i % 3 == 0) {
+                        outln();
+                        out("     ");
+                    }
+                }
+                out(" {}", value);
+                i++;
+            }
+            outln(" ]");
         } else if (tag_data->type() == Gfx::ICC::TextDescriptionTagData::Type) {
             auto& text_description = static_cast<Gfx::ICC::TextDescriptionTagData&>(*tag_data);
             outln("    ascii: \"{}\"", text_description.ascii_description());


### PR DESCRIPTION
This is the type of the chromaticAdaptationTag, which is a required tag
in v4 profiles for all non-DeviceLink profiles.

---

```
% Build/lagom/icc ~/src/Compact-ICC-Profiles/profiles/sRGB-v4.icc
...
'chad': 'sf32', offset 344, size 44
    [ 1.47836, 0.22903, 0.949798,
      0.29541, 0.990509, 0.982925,
      0.990753, 0.15075, 0.751724 ]
...
```