### PR TITLE
LibGfx+icc: Add ICCProfile support for parametricCurveType and print it

### DIFF
--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -112,6 +112,33 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     record.iso_3166_1_country_code >> 8, record.iso_3166_1_country_code & 0xff,
                     record.text);
             }
+        } else if (tag_data->type() == Gfx::ICC::ParametricCurveTagData::Type) {
+            auto& parametric_curve = static_cast<Gfx::ICC::ParametricCurveTagData&>(*tag_data);
+            switch (parametric_curve.function_type()) {
+            case Gfx::ICC::ParametricCurveTagData::FunctionType::Type0:
+                outln("  Y = X**{}", parametric_curve.g());
+                break;
+            case Gfx::ICC::ParametricCurveTagData::FunctionType::Type1:
+                outln("  Y = ({}*X + {})**{}   if X >= -{}/{}",
+                    parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.b(), parametric_curve.a());
+                outln("  Y = 0                                else");
+                break;
+            case Gfx::ICC::ParametricCurveTagData::FunctionType::Type2:
+                outln("  Y = ({}*X + {})**{} + {}   if X >= -{}/{}",
+                    parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.c(), parametric_curve.b(), parametric_curve.a());
+                outln("  Y =  {}                                    else", parametric_curve.c());
+                break;
+            case Gfx::ICC::ParametricCurveTagData::FunctionType::Type3:
+                outln("  Y = ({}*X + {})**{}   if X >= {}",
+                    parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.d());
+                outln("  Y =  {}*X                        else", parametric_curve.c());
+                break;
+            case Gfx::ICC::ParametricCurveTagData::FunctionType::Type4:
+                outln("  Y = ({}*X + {})**{} + {}   if X >= {}",
+                    parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.e(), parametric_curve.d());
+                outln("  Y =  {}*X + {}                             else", parametric_curve.c(), parametric_curve.f());
+                break;
+            }
         } else if (tag_data->type() == Gfx::ICC::S15Fixed16ArrayTagData::Type) {
             // This tag can contain arbitrarily many fixed-point numbers, but in practice it's
             // exclusively used for the 'chad' tag, where it always contains 9 values that


### PR DESCRIPTION
With this, we can parse all types required in v4
"Three-component matrix-based Input profiles".