### PR TITLE
Kernel+LibC: Support monotonic clock in clock_getres()

### DIFF
--- a/Kernel/Syscalls/clock.cpp
+++ b/Kernel/Syscalls/clock.cpp
@@ -98,16 +98,11 @@ ErrorOr<FlatPtr> Process::sys$clock_getres(Userspace<Syscall::SC_clock_getres_pa
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);
     auto params = TRY(copy_typed_from_user(user_params));
-    timespec ts {};
-    switch (params.clock_id) {
-    case CLOCK_REALTIME:
-        ts.tv_sec = 0;
-        ts.tv_nsec = 1000000000 / _SC_CLK_TCK;
-        TRY(copy_to_user(params.result, &ts));
-        break;
-    default:
-        return EINVAL;
-    }
+
+    TRY(TimeManagement::validate_clock_id(params.clock_id));
+
+    auto ts = TimeManagement::the().clock_resolution().to_timespec();
+    TRY(copy_to_user(params.result, &ts));
     return 0;
 }
 

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -237,6 +237,12 @@ Time TimeManagement::boot_time()
 #endif
 }
 
+Time TimeManagement::clock_resolution() const
+{
+    long nanoseconds_per_tick = 1'000'000'000 / m_time_keeper_timer->ticks_per_second();
+    return Time::from_nanoseconds(nanoseconds_per_tick);
+}
+
 UNMAP_AFTER_INIT TimeManagement::TimeManagement()
     : m_time_page_region(MM.allocate_kernel_region(PAGE_SIZE, "Time page"sv, Memory::Region::Access::ReadWrite, AllocationStrategy::AllocateNow).release_value_but_fixme_should_propagate_errors())
 {

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -52,6 +52,7 @@ public:
     void set_epoch_time(Time);
     time_t ticks_per_second() const;
     static Time boot_time();
+    Time clock_resolution() const;
 
     bool is_system_timer(HardwareTimerBase const&) const;
 


### PR DESCRIPTION
Add `CLOCK_MONOTONIC` as a supported clock_id. Also, fix this function to use the actual ticks per second value, not the constant `_SC_CLK_TCK`, which is always equal to 8.

This enables functionality in certain ports, such as the use of asyncio in Python.

Before fix:

![before-fix](https://user-images.githubusercontent.com/2660905/214181659-dbace87b-4553-45e0-89f6-06977653bea4.png)

After fix:

![after-fix](https://user-images.githubusercontent.com/2660905/214181700-4842bae1-ea0e-44a1-8ee3-bcc2c5a10fe1.png)
