### PR TITLE
LibGfx: Dedupe ICC TagData objects

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -228,8 +228,13 @@ public:
         auto it = find(key);
         if (it != end())
             return it->value;
-        auto result = TRY(try_set(key, initialization_callback()));
-        VERIFY(result == HashSetResult::InsertedNewEntry);
+        if constexpr (FallibleFunction<Callback>) {
+            auto result = TRY(try_set(key, TRY(initialization_callback())));
+            VERIFY(result == HashSetResult::InsertedNewEntry);
+        } else {
+            auto result = TRY(try_set(key, initialization_callback()));
+            VERIFY(result == HashSetResult::InsertedNewEntry);
+        }
         return find(key)->value;
     }
 

--- a/Userland/Libraries/LibGfx/ICCProfile.cpp
+++ b/Userland/Libraries/LibGfx/ICCProfile.cpp
@@ -116,17 +116,7 @@ struct ICCHeader {
     u8 reserved[28];
 };
 static_assert(sizeof(ICCHeader) == 128);
-}
 
-// ICC V4, 7.3 Tag table, Table 24 - Tag table structure
-struct Detail::TagTableEntry {
-    BigEndian<TagSignature> tag_signature;
-    BigEndian<u32> offset_to_beginning_of_tag_data_element;
-    BigEndian<u32> size_of_tag_data_element;
-};
-static_assert(sizeof(Detail::TagTableEntry) == 12);
-
-namespace {
 ErrorOr<u32> parse_size(ICCHeader const& header, ReadonlyBytes icc_bytes)
 {
     // ICC v4, 7.2.2 Profile size field
@@ -993,10 +983,18 @@ ErrorOr<void> Profile::read_tag_table(ReadonlyBytes bytes)
         return Error::from_string_literal("ICC::Profile: Not enough data for tag count");
     auto tag_count = *bit_cast<BigEndian<u32> const*>(tag_table_bytes.data());
 
+    // ICC V4, 7.3 Tag table, Table 24 - Tag table structure
+    struct TagTableEntry {
+        BigEndian<TagSignature> tag_signature;
+        BigEndian<u32> offset_to_beginning_of_tag_data_element;
+        BigEndian<u32> size_of_tag_data_element;
+    };
+    static_assert(sizeof(TagTableEntry) == 12);
+
     tag_table_bytes = tag_table_bytes.slice(sizeof(u32));
-    if (tag_table_bytes.size() < tag_count * sizeof(Detail::TagTableEntry))
+    if (tag_table_bytes.size() < tag_count * sizeof(TagTableEntry))
         return Error::from_string_literal("ICC::Profile: Not enough data for tag table entries");
-    auto tag_table_entries = bit_cast<Detail::TagTableEntry const*>(tag_table_bytes.data());
+    auto tag_table_entries = bit_cast<TagTableEntry const*>(tag_table_bytes.data());
 
     for (u32 i = 0; i < tag_count; ++i) {
         // FIXME: optionally ignore tags with unknown signature

--- a/Userland/Libraries/LibGfx/ICCProfile.cpp
+++ b/Userland/Libraries/LibGfx/ICCProfile.cpp
@@ -972,10 +972,7 @@ ErrorOr<void> Profile::read_tag_table(ReadonlyBytes bytes)
     //  to reach a four-byte boundary) and the byte offset of the following tag element, or the end of the file.
     //  Duplicate tag signatures shall not be included in the tag table.
     //  Tag data elements shall not partially overlap, so there shall be no part of any tag data element that falls within
-    //  the range defined for another tag in the tag table.
-    //  The tag table may contain multiple tags signatures that all reference the same tag data element offset, allowing
-    //  efficient reuse of tag data elements. In such cases, both the offset and size of the tag data elements in the tag
-    //  table shall be the same."
+    //  the range defined for another tag in the tag table."
 
     ReadonlyBytes tag_table_bytes = bytes.slice(sizeof(ICCHeader));
 
@@ -996,10 +993,22 @@ ErrorOr<void> Profile::read_tag_table(ReadonlyBytes bytes)
         return Error::from_string_literal("ICC::Profile: Not enough data for tag table entries");
     auto tag_table_entries = bit_cast<TagTableEntry const*>(tag_table_bytes.data());
 
+    // "The tag table may contain multiple tags signatures that all reference the same tag data element offset, allowing
+    //  efficient reuse of tag data elements."
+    HashMap<u32, NonnullRefPtr<TagData>> offset_to_tag_data;
+
     for (u32 i = 0; i < tag_count; ++i) {
         // FIXME: optionally ignore tags with unknown signature
-        // FIXME: dedupe identical offset/sizes
-        auto tag_data = TRY(read_tag(bytes, tag_table_entries[i].offset_to_beginning_of_tag_data_element, tag_table_entries[i].size_of_tag_data_element));
+
+        // Dedupe identical offset/sizes.
+        NonnullRefPtr<TagData> tag_data = TRY(offset_to_tag_data.try_ensure(tag_table_entries[i].offset_to_beginning_of_tag_data_element, [=, this]() {
+            return read_tag(bytes, tag_table_entries[i].offset_to_beginning_of_tag_data_element, tag_table_entries[i].size_of_tag_data_element);
+        }));
+
+        // "In such cases, both the offset and size of the tag data elements in the tag table shall be the same."
+        if (tag_data->size() != tag_table_entries[i].size_of_tag_data_element)
+            return Error::from_string_literal("ICC::Profile: two tags have same offset but different sizes");
+
         // "Duplicate tag signatures shall not be included in the tag table."
         if (TRY(m_tag_table.try_set(tag_table_entries[i].tag_signature, move(tag_data))) != AK::HashSetResult::InsertedNewEntry)
             return Error::from_string_literal("ICC::Profile: duplicate tag signature");

--- a/Userland/Libraries/LibGfx/ICCProfile.cpp
+++ b/Userland/Libraries/LibGfx/ICCProfile.cpp
@@ -929,12 +929,12 @@ ErrorOr<void> Profile::read_header(ReadonlyBytes bytes)
     return {};
 }
 
-ErrorOr<NonnullRefPtr<TagData>> Profile::read_tag(ReadonlyBytes bytes, Detail::TagTableEntry const& entry)
+ErrorOr<NonnullRefPtr<TagData>> Profile::read_tag(ReadonlyBytes bytes, u32 offset_to_beginning_of_tag_data_element, u32 size_of_tag_data_element)
 {
-    if (entry.offset_to_beginning_of_tag_data_element + entry.size_of_tag_data_element > bytes.size())
+    if (offset_to_beginning_of_tag_data_element + size_of_tag_data_element > bytes.size())
         return Error::from_string_literal("ICC::Profile: Tag data out of bounds");
 
-    auto tag_bytes = bytes.slice(entry.offset_to_beginning_of_tag_data_element, entry.size_of_tag_data_element);
+    auto tag_bytes = bytes.slice(offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
 
     // ICC v4, 9 Tag definitions
     // ICC v4, 9.1 General
@@ -946,22 +946,22 @@ ErrorOr<NonnullRefPtr<TagData>> Profile::read_tag(ReadonlyBytes bytes, Detail::T
     auto type = tag_type(tag_bytes);
     switch (type) {
     case CurveTagData::Type:
-        return CurveTagData::from_bytes(tag_bytes, entry.offset_to_beginning_of_tag_data_element, entry.size_of_tag_data_element);
+        return CurveTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case MultiLocalizedUnicodeTagData::Type:
-        return MultiLocalizedUnicodeTagData::from_bytes(tag_bytes, entry.offset_to_beginning_of_tag_data_element, entry.size_of_tag_data_element);
+        return MultiLocalizedUnicodeTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case ParametricCurveTagData::Type:
-        return ParametricCurveTagData::from_bytes(tag_bytes, entry.offset_to_beginning_of_tag_data_element, entry.size_of_tag_data_element);
+        return ParametricCurveTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case S15Fixed16ArrayTagData::Type:
-        return S15Fixed16ArrayTagData::from_bytes(tag_bytes, entry.offset_to_beginning_of_tag_data_element, entry.size_of_tag_data_element);
+        return S15Fixed16ArrayTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case TextDescriptionTagData::Type:
-        return TextDescriptionTagData::from_bytes(tag_bytes, entry.offset_to_beginning_of_tag_data_element, entry.size_of_tag_data_element);
+        return TextDescriptionTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case TextTagData::Type:
-        return TextTagData::from_bytes(tag_bytes, entry.offset_to_beginning_of_tag_data_element, entry.size_of_tag_data_element);
+        return TextTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case XYZTagData::Type:
-        return XYZTagData::from_bytes(tag_bytes, entry.offset_to_beginning_of_tag_data_element, entry.size_of_tag_data_element);
+        return XYZTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     default:
         // FIXME: optionally ignore tags of unknown type
-        return adopt_ref(*new UnknownTagData(entry.offset_to_beginning_of_tag_data_element, entry.size_of_tag_data_element, type));
+        return adopt_ref(*new UnknownTagData(offset_to_beginning_of_tag_data_element, size_of_tag_data_element, type));
     }
 }
 
@@ -1001,7 +1001,7 @@ ErrorOr<void> Profile::read_tag_table(ReadonlyBytes bytes)
     for (u32 i = 0; i < tag_count; ++i) {
         // FIXME: optionally ignore tags with unknown signature
         // FIXME: dedupe identical offset/sizes
-        auto tag_data = TRY(read_tag(bytes, tag_table_entries[i]));
+        auto tag_data = TRY(read_tag(bytes, tag_table_entries[i].offset_to_beginning_of_tag_data_element, tag_table_entries[i].size_of_tag_data_element));
         // "Duplicate tag signatures shall not be included in the tag table."
         if (TRY(m_tag_table.try_set(tag_table_entries[i].tag_signature, move(tag_data))) != AK::HashSetResult::InsertedNewEntry)
             return Error::from_string_literal("ICC::Profile: duplicate tag signature");

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -495,10 +495,6 @@ private:
     Vector<XYZ, 1> m_xyzs;
 };
 
-namespace Detail {
-struct TagTableEntry;
-}
-
 class Profile : public RefCounted<Profile> {
 public:
     static ErrorOr<NonnullRefPtr<Profile>> try_load_from_externally_owned_memory(ReadonlyBytes);

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -534,7 +534,7 @@ public:
 
 private:
     ErrorOr<void> read_header(ReadonlyBytes);
-    ErrorOr<NonnullRefPtr<TagData>> read_tag(ReadonlyBytes, Detail::TagTableEntry const&);
+    ErrorOr<NonnullRefPtr<TagData>> read_tag(ReadonlyBytes bytes, u32 offset_to_beginning_of_tag_data_element, u32 size_of_tag_data_element);
     ErrorOr<void> read_tag_table(ReadonlyBytes);
 
     u32 m_on_disk_size { 0 };

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -91,8 +91,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     outln("");
 
     outln("tags:");
-    profile->for_each_tag([](auto tag_signature, auto tag_data) {
+    HashMap<Gfx::ICC::TagData*, Gfx::ICC::TagSignature> tag_data_to_first_signature;
+    profile->for_each_tag([&tag_data_to_first_signature](auto tag_signature, auto tag_data) {
         outln("{}: {}, offset {}, size {}", tag_signature, tag_data->type(), tag_data->offset(), tag_data->size());
+
+        // Print tag data only the first time it's seen.
+        // (Different sigatures can refer to the same data.)
+        auto it = tag_data_to_first_signature.find(tag_data);
+        if (it != tag_data_to_first_signature.end()) {
+            outln("    (see {} above)", it->value);
+            return;
+        }
+        tag_data_to_first_signature.set(tag_data, tag_signature);
 
         if (tag_data->type() == Gfx::ICC::CurveTagData::Type) {
             auto& curve = static_cast<Gfx::ICC::CurveTagData&>(*tag_data);


### PR DESCRIPTION
```
% Build/lagom/icc ~/src/Compact-ICC-Profiles/profiles/sRGB-v4.icc
...
'rTRC': 'para', offset 448, size 32
  Y = (0.94786*X + 0.52139)**2.400039   if X >= 0.40451
  Y =  0.77392*X                        else
'gTRC': 'para', offset 448, size 32
    (see 'rTRC' above)
'bTRC': 'para', offset 448, size 32
    (see 'rTRC' above)
```