### PR TITLE
AK: Print leading zeroes after the dot for FixedPoint numbers

### DIFF
--- a/Tests/AK/TestFixedPoint.cpp
+++ b/Tests/AK/TestFixedPoint.cpp
@@ -150,4 +150,9 @@ TEST_CASE(formatter)
     EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<4>(123.456)), "123.4375"sv);
     EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<4>(-123.456)), "-123.4375"sv);
     EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16> {}), "0"sv);
+    EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(0.1)), "0.09999"sv);
+    EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(0.02)), "0.019989"sv);
+    EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(0.003)), "0.00299"sv);
+    EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(0.0004)), "0.000396"sv);
+    EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(0.0000000005)), "0"sv);
 }


### PR DESCRIPTION
As a nearby comment says, "This is a terrible approximation". This doesn't make things less terrible, but it does make things more correct in the given framework of terribleness.

Fixes #17156.