### PR TITLE
icc: Print each tag signature's spec name

### DIFF
--- a/Userland/Libraries/LibGfx/ICCProfile.cpp
+++ b/Userland/Libraries/LibGfx/ICCProfile.cpp
@@ -391,6 +391,18 @@ URL device_model_url(DeviceModel device_model)
         device_model.c0(), device_model.c1(), device_model.c2(), device_model.c3(), device_model.value));
 }
 
+Optional<StringView> tag_signature_spec_name(TagSignature tag_signature)
+{
+    switch (tag_signature) {
+#define TAG(name, id) \
+    case name:        \
+        return #name##sv;
+        ENUMERATE_TAG_SIGNATURES(TAG)
+#undef TAG
+    }
+    return {};
+}
+
 StringView device_class_name(DeviceClass device_class)
 {
     switch (device_class) {

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -114,7 +114,7 @@ URL device_model_url(DeviceModel);
     TAG(viewingCondDescTag, 0x76756564 /* 'vued' */)                \
     TAG(viewingConditionsTag, 0x76696577 /* 'view' */)
 
-#define TAG(name, id) constexpr TagSignature name { id };
+#define TAG(name, id) constexpr inline TagSignature name { id };
 ENUMERATE_TAG_SIGNATURES(TAG)
 #undef TAG
 

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -59,6 +59,67 @@ using TagTypeSignature = DistinctFourCC<FourCCType::TagTypeSignature>;     // IC
 URL device_manufacturer_url(DeviceManufacturer);
 URL device_model_url(DeviceModel);
 
+// ICC v4, 9.2 Tag listing
+// FIXME: Add v2-only tags too.
+#define ENUMERATE_TAG_SIGNATURES(TAG)                               \
+    TAG(AToB0Tag, 0x41324230 /* 'A2B0' */)                          \
+    TAG(AToB1Tag, 0x41324231 /* 'A2B1' */)                          \
+    TAG(AToB2Tag, 0x41324232 /* 'A2B2' */)                          \
+    TAG(blueMatrixColumnTag, 0x6258595A /* 'bXYZ' */)               \
+    TAG(blueTRCTag, 0x62545243 /* 'bTRC' */)                        \
+    TAG(BToA0Tag, 0x42324130 /* 'B2A0' */)                          \
+    TAG(BToA1Tag, 0x42324131 /* 'B2A1' */)                          \
+    TAG(BToA2Tag, 0x42324132 /* 'B2A2' */)                          \
+    TAG(BToD0Tag, 0x42324430 /* 'B2D0' */)                          \
+    TAG(BToD1Tag, 0x42324431 /* 'B2D1' */)                          \
+    TAG(BToD2Tag, 0x42324432 /* 'B2D2' */)                          \
+    TAG(BToD3Tag, 0x42324433 /* 'B2D3' */)                          \
+    TAG(calibrationDateTimeTag, 0x63616C74 /* 'calt' */)            \
+    TAG(charTargetTag, 0x74617267 /* 'targ' */)                     \
+    TAG(chromaticAdaptationTag, 0x63686164 /* 'chad' */)            \
+    TAG(chromaticityTag, 0x6368726D /* 'chrm' */)                   \
+    TAG(cicpTag, 0x63696370 /* 'cicp' */)                           \
+    TAG(colorantOrderTag, 0x636C726F /* 'clro' */)                  \
+    TAG(colorantTableTag, 0x636C7274 /* 'clrt' */)                  \
+    TAG(colorantTableOutTag, 0x636C6F74 /* 'clot' */)               \
+    TAG(colorimetricIntentImageStateTag, 0x63696973 /* 'ciis' */)   \
+    TAG(copyrightTag, 0x63707274 /* 'cprt' */)                      \
+    TAG(deviceMfgDescTag, 0x646D6E64 /* 'dmnd' */)                  \
+    TAG(deviceModelDescTag, 0x646D6464 /* 'dmdd' */)                \
+    TAG(DToB0Tag, 0x44324230 /* 'D2B0' */)                          \
+    TAG(DToB1Tag, 0x44324231 /* 'D2B1' */)                          \
+    TAG(DToB2Tag, 0x44324232 /* 'D2B2' */)                          \
+    TAG(DToB3Tag, 0x44324233 /* 'D2B3' */)                          \
+    TAG(gamutTag, 0x67616D74 /* 'gamt' */)                          \
+    TAG(grayTRCTag, 0x6B545243 /* 'kTRC' */)                        \
+    TAG(greenMatrixColumnTag, 0x6758595A /* 'gXYZ' */)              \
+    TAG(greenTRCTag, 0x67545243 /* 'gTRC' */)                       \
+    TAG(luminanceTag, 0x6C756D69 /* 'lumi' */)                      \
+    TAG(measurementTag, 0x6D656173 /* 'meas' */)                    \
+    TAG(metadataTag, 0x6D657461 /* 'meta' */)                       \
+    TAG(mediaWhitePointTag, 0x77747074 /* 'wtpt' */)                \
+    TAG(namedColor2Tag, 0x6E636C32 /* 'ncl2' */)                    \
+    TAG(outputResponseTag, 0x72657370 /* 'resp' */)                 \
+    TAG(perceptualRenderingIntentGamutTag, 0x72696730 /* 'rig0' */) \
+    TAG(preview0Tag, 0x70726530 /* 'pre0' */)                       \
+    TAG(preview1Tag, 0x70726531 /* 'pre1' */)                       \
+    TAG(preview2Tag, 0x70726532 /* 'pre2' */)                       \
+    TAG(profileDescriptionTag, 0x64657363 /* 'desc' */)             \
+    TAG(profileSequenceDescTag, 0x70736571 /* 'pseq' */)            \
+    TAG(profileSequenceIdentifierTag, 0x70736964 /* 'psid' */)      \
+    TAG(redMatrixColumnTag, 0x7258595A /* 'rXYZ' */)                \
+    TAG(redTRCTag, 0x72545243 /* 'rTRC' */)                         \
+    TAG(saturationRenderingIntentGamutTag, 0x72696732 /* 'rig2' */) \
+    TAG(technologyTag, 0x74656368 /* 'tech' */)                     \
+    TAG(viewingCondDescTag, 0x76756564 /* 'vued' */)                \
+    TAG(viewingConditionsTag, 0x76696577 /* 'view' */)
+
+#define TAG(name, id) constexpr TagSignature name { id };
+ENUMERATE_TAG_SIGNATURES(TAG)
+#undef TAG
+
+Optional<StringView> tag_signature_spec_name(TagSignature);
+
 // ICC v4, 7.2.4 Profile version field
 class Version {
 public:

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -93,7 +93,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     outln("tags:");
     HashMap<Gfx::ICC::TagData*, Gfx::ICC::TagSignature> tag_data_to_first_signature;
     profile->for_each_tag([&tag_data_to_first_signature](auto tag_signature, auto tag_data) {
-        outln("{}: {}, offset {}, size {}", tag_signature, tag_data->type(), tag_data->offset(), tag_data->size());
+        if (auto name = tag_signature_spec_name(tag_signature); name.has_value())
+            out("{} ({}): ", *name, tag_signature);
+        else
+            out("Unknown tag ({}): ", tag_signature);
+        outln("type {}, offset {}, size {}", tag_data->type(), tag_data->offset(), tag_data->size());
 
         // Print tag data only the first time it's seen.
         // (Different sigatures can refer to the same data.)


### PR DESCRIPTION
The main motivation is to add symbolic names for all tags, since I want to use these names in a later patch that will type-check all tag signatures, and check that all required tags are present.

---

Screenshot:

```
 % Build/lagom/icc ~/src/hack/lightroom.icc
...
tags:
copyrightTag ('cprt'): type 'text', offset 336, size 51
    text: "Copyright (c) 1998 Hewlett-Packard Company"
profileDescriptionTag ('desc'): type 'desc', offset 388, size 108
    ascii: "sRGB IEC61966-2.1"
    unicode: (not set)
    unicode language code: 0x0
    macintosh: "sRGB IEC61966-2.1"
mediaWhitePointTag ('wtpt'): type 'XYZ ', offset 496, size 20
    X = 0.950454, Y = 1, Z = 1.08905
Unknown tag ('bkpt'): type 'XYZ ', offset 516, size 20
    X = 0, Y = 0, Z = 0
redMatrixColumnTag ('rXYZ'): type 'XYZ ', offset 536, size 20
    X = 0.436065, Y = 0.222488, Z = 0.013916
greenMatrixColumnTag ('gXYZ'): type 'XYZ ', offset 556, size 20
    X = 0.385147, Y = 0.716873, Z = 0.097076
blueMatrixColumnTag ('bXYZ'): type 'XYZ ', offset 576, size 20
    X = 0.143066, Y = 0.060607, Z = 0.714096
deviceMfgDescTag ('dmnd'): type 'desc', offset 596, size 112
    ascii: "IEC http://www.iec.ch"
    unicode: (not set)
    unicode language code: 0x0
    macintosh: "IEC http://www.iec.ch"
deviceModelDescTag ('dmdd'): type 'desc', offset 708, size 136
    ascii: "IEC 61966-2.1 Default RGB colour space - sRGB"
    unicode: (not set)
    unicode language code: 0x0
    macintosh: "IEC 61966-2.1 Default RGB colour space - sRGB"
viewingCondDescTag ('vued'): type 'desc', offset 844, size 134
    ascii: "Reference Viewing Condition in IEC61966-2.1"
    unicode: (not set)
    unicode language code: 0x0
    macintosh: "Reference Viewing Condition in IEC61966-2.1"
viewingConditionsTag ('view'): type 'view', offset 980, size 36
luminanceTag ('lumi'): type 'XYZ ', offset 1016, size 20
    X = 76.036468, Y = 80, Z = 87.124618
measurementTag ('meas'): type 'meas', offset 1036, size 36
technologyTag ('tech'): type 'sig ', offset 1072, size 12
redTRCTag ('rTRC'): type 'curv', offset 1084, size 2060
    curve with 1024 points
greenTRCTag ('gTRC'): type 'curv', offset 1084, size 2060
    (see 'rTRC' above)
blueTRCTag ('bTRC'): type 'curv', offset 1084, size 2060
    (see 'rTRC' above)
```