### PR TITLE
Toolchain/aarch64: Road to Userland [3/N] (libgcc SONAME)

### DIFF
--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -50,9 +50,8 @@ if [ "$SERENITY_TOOLCHAIN" = "Clang" ]; then
     mkdir -p mnt/usr/include/"$SERENITY_ARCH"-pc-serenity
     $CP --preserve=timestamps -r "$TOOLCHAIN_DIR"/include/c++ mnt/usr/include
     $CP --preserve=timestamps -r "$TOOLCHAIN_DIR"/include/"$SERENITY_ARCH"-pc-serenity/c++ mnt/usr/include/"$SERENITY_ARCH"-pc-serenity
-elif [ "$SERENITY_ARCH" != "aarch64" ]; then
-    $CP --preserve=timestamps "$SERENITY_SOURCE_DIR"/Toolchain/Local/"$SERENITY_ARCH"/"$SERENITY_ARCH"-pc-serenity/lib/libgcc_s.so mnt/usr/lib
-    $CP --preserve=timestamps "$SERENITY_SOURCE_DIR"/Toolchain/Local/"$SERENITY_ARCH"/"$SERENITY_ARCH"-pc-serenity/lib/libstdc++.a mnt/usr/lib
+else
+    $CP --preserve=timestamps -r "$SERENITY_SOURCE_DIR"/Toolchain/Local/"$SERENITY_ARCH"/"$SERENITY_ARCH"-pc-serenity/lib/* mnt/usr/lib
     $CP --preserve=timestamps -r "$SERENITY_SOURCE_DIR"/Toolchain/Local/"$SERENITY_ARCH"/"$SERENITY_ARCH"-pc-serenity/include/c++ mnt/usr/include
 fi
 

--- a/Toolchain/Patches/gcc/0003-libgcc-Build-for-SerenityOS.patch
+++ b/Toolchain/Patches/gcc/0003-libgcc-Build-for-SerenityOS.patch
@@ -53,7 +53,7 @@ index 8c56fcae5d2fdfcc8d1f9b2614f0c41ad44f258f..f5855cfa66d7950c3d7565ad938b4e47
 +	extra_parts="$extra_parts crti.o crtbegin.o crtend.o crtn.o"
 +	extra_parts="$extra_parts crtfastmath.o"
 +	tmake_file="$tmake_file ${cpu_type}/t-aarch64"
-+	tmake_file="$tmake_file ${cpu_type}/t-lse t-slibgcc t-slibgcc-libgcc"
++	tmake_file="$tmake_file ${cpu_type}/t-lse t-slibgcc t-slibgcc-libgcc t-slibgcc-gld-nover"
 +	tmake_file="$tmake_file ${cpu_type}/t-softfp t-softfp t-crtfm"
 +	md_unwind_header=aarch64/aarch64-unwind.h
 +	;;


### PR DESCRIPTION
These 2 commits bring us closer to aarch64 userspace!

**Toolchain: Ensure aarch64 libgcc_s.so.1 includes DT_SONAME tag**
Without this tag, executables that link libgcc_s.so.1, which is every
executable, end up with the host path to libgcc_s.so.1 as the path for
the dynamic dependency (DT_NEEDED) of the executable. By making sure
that the libgcc_s.so.1 shared object includes the DT_SONAME tag, the
path to libgcc_s.so.1 dynamic dependency will only contain the basename,
instead of the absolute host path.

~~**Meta: Install libgcc_s.so.1 in disk image for aarch64 build**
This file is a dynamic shared object dependency of aarch64 executables.~~

**Meta: Unify installing GCC dependencies in disk image**
This makes sure that the aarch64 disk image also contains the correct
dynamic shared objects, specifically libgcc_s.so.1, as that one is a
dynamic dependency of every aarch64 executable.

To unify the x86_64 and aarch64 code paths, this commit just installs
everything from the compilers lib directory into the disk image lib
directory. This also happens for the Clang toolchain. This copies a few
extra files related to libsupc++ and libstdc++, increasing the size of
the disk image by 1.6MB. However, we were already copying libstdc++.a
manually anyway.

