### PR TITLE
LibWeb: Fix clip of hidden overflow when translated boxes are involved

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -177,6 +177,7 @@ public:
     }
 
     IntRect clip_rect() const { return state().clip_rect; }
+    void set_clip_rect(IntRect const& rect) { state().clip_rect = rect; }
 
     int scale() const { return state().scale; }
 

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -88,6 +88,9 @@ public:
     virtual void before_children_paint(PaintContext&, PaintPhase) const { }
     virtual void after_children_paint(PaintContext&, PaintPhase) const { }
 
+    virtual void apply_clip_overflow_rect(PaintContext&, PaintPhase) const { }
+    virtual void clear_clip_overflow_rect(PaintContext&, PaintPhase) const { }
+
     virtual Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const;
 
     virtual bool wants_mouse_events() const { return false; }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -318,7 +318,7 @@ Optional<Gfx::IntRect> PaintableBox::clip_rect() const
     return m_clip_rect;
 }
 
-void PaintableBox::before_children_paint(PaintContext& context, PaintPhase phase) const
+void PaintableBox::apply_clip_overflow_rect(PaintContext& context, PaintPhase phase) const
 {
     if (!AK::first_is_one_of(phase, PaintPhase::Background, PaintPhase::Border, PaintPhase::Foreground))
         return;
@@ -364,7 +364,7 @@ void PaintableBox::before_children_paint(PaintContext& context, PaintPhase phase
     }
 }
 
-void PaintableBox::after_children_paint(PaintContext& context, PaintPhase phase) const
+void PaintableBox::clear_clip_overflow_rect(PaintContext& context, PaintPhase phase) const
 {
     if (!AK::first_is_one_of(phase, PaintPhase::Background, PaintPhase::Border, PaintPhase::Foreground))
         return;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -98,7 +98,7 @@ public:
         return m_overflow_data->scrollable_overflow_rect;
     }
 
-    Optional<CSSPixelRect> clip_rect() const;
+    Optional<Gfx::IntRect> clip_rect() const;
 
     void set_overflow_data(Optional<OverflowData> data) { m_overflow_data = move(data); }
     void set_containing_line_box_fragment(Optional<Layout::LineBoxFragmentCoordinate>);
@@ -157,7 +157,7 @@ private:
     Optional<CSSPixelRect> mutable m_absolute_rect;
     Optional<CSSPixelRect> mutable m_absolute_paint_rect;
 
-    Optional<CSSPixelRect> mutable m_clip_rect;
+    Gfx::IntRect mutable m_clip_rect;
 
     mutable bool m_clipping_overflow { false };
     Optional<BorderRadiusCornerClipper> mutable m_overflow_corner_radius_clipper;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -114,8 +114,8 @@ public:
     DOM::Document const& document() const { return layout_box().document(); }
     DOM::Document& document() { return layout_box().document(); }
 
-    virtual void before_children_paint(PaintContext&, PaintPhase) const override;
-    virtual void after_children_paint(PaintContext&, PaintPhase) const override;
+    virtual void apply_clip_overflow_rect(PaintContext&, PaintPhase) const override;
+    virtual void clear_clip_overflow_rect(PaintContext&, PaintPhase) const override;
 
     virtual Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const override;
 


### PR DESCRIPTION
There is a problem with current approach where overflow clip rectange is calculated by aggregating intersection of absolute padding boxes of boxes in containing block chain that resulting rectangle doesn't respect transform properties.

To solve this problem `PaintableBox` is changed to store clip rectangle saved from painter because it does respect transform properties of all previously applied clip rectangles.