### PR TITLE
LibJS: Remove DeprecatedString usage from SourceCode

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -4962,9 +4962,9 @@ ModuleRequest::ModuleRequest(DeprecatedFlyString module_specifier_, Vector<Asser
     });
 }
 
-DeprecatedString const& SourceRange::filename() const
+DeprecatedString SourceRange::filename() const
 {
-    return code->filename();
+    return code->filename().to_deprecated_string();
 }
 
 NonnullRefPtr<CallExpression> CallExpression::create(SourceRange source_range, NonnullRefPtr<Expression> callee, Span<Argument const> arguments)

--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -24,7 +24,7 @@ HashMap<char, TokenType> Lexer::s_single_char_tokens;
 Lexer::Lexer(StringView source, StringView filename, size_t line_number, size_t line_column)
     : m_source(source)
     , m_current_token(TokenType::Eof, {}, {}, {}, filename, 0, 0, 0)
-    , m_filename(filename)
+    , m_filename(String::from_utf8(filename).release_value_but_fixme_should_propagate_errors())
     , m_line_number(line_number)
     , m_line_column(line_column)
     , m_parsed_identifiers(adopt_ref(*new ParsedIdentifiers))

--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -836,7 +836,7 @@ Token Lexer::next()
 
     if (m_hit_invalid_unicode.has_value()) {
         value_start = m_hit_invalid_unicode.value() - 1;
-        m_current_token = Token(TokenType::Invalid, "Invalid unicode codepoint in source",
+        m_current_token = Token(TokenType::Invalid, String::from_utf8("Invalid unicode codepoint in source"sv).release_value_but_fixme_should_propagate_errors(),
             ""sv, // Since the invalid unicode can occur anywhere in the current token the trivia is not correct
             m_source.substring_view(value_start + 1, min(4u, m_source.length() - value_start - 2)),
             m_filename,
@@ -849,7 +849,7 @@ Token Lexer::next()
     } else {
         m_current_token = Token(
             token_type,
-            token_message,
+            String::from_deprecated_string(token_message).release_value_but_fixme_should_propagate_errors(),
             m_source.substring_view(trivia_start - 1, value_start - trivia_start),
             m_source.substring_view(value_start - 1, m_position - value_start),
             m_filename,
@@ -893,7 +893,7 @@ Token Lexer::force_slash_as_regex()
 
     m_current_token = Token(
         token_type,
-        "",
+        String {},
         m_current_token.trivia(),
         m_source.substring_view(value_start - 1, m_position - value_start),
         m_filename,

--- a/Userland/Libraries/LibJS/Lexer.h
+++ b/Userland/Libraries/LibJS/Lexer.h
@@ -10,6 +10,7 @@
 
 #include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 
 namespace JS {
@@ -21,7 +22,7 @@ public:
     Token next();
 
     DeprecatedString const& source() const { return m_source; };
-    DeprecatedString const& filename() const { return m_filename; };
+    String const& filename() const { return m_filename; };
 
     void disallow_html_comments() { m_allow_html_comments = false; };
 
@@ -63,7 +64,7 @@ private:
     char m_current_char { 0 };
     bool m_eof { false };
 
-    DeprecatedString m_filename;
+    String m_filename;
     size_t m_line_number { 1 };
     size_t m_line_column { 0 };
 

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -409,7 +409,7 @@ Parser::ParserState::ParserState(Lexer l, Program::Type program_type)
 }
 
 Parser::Parser(Lexer lexer, Program::Type program_type, Optional<EvalInitialState> initial_state_for_eval)
-    : m_source_code(SourceCode::create(lexer.filename(), lexer.source()))
+    : m_source_code(SourceCode::create(String::from_deprecated_string(lexer.filename()).release_value_but_fixme_should_propagate_errors(), String::from_deprecated_string(lexer.source()).release_value_but_fixme_should_propagate_errors()))
     , m_state(move(lexer), program_type)
     , m_program_type(program_type)
 {

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -409,7 +409,7 @@ Parser::ParserState::ParserState(Lexer l, Program::Type program_type)
 }
 
 Parser::Parser(Lexer lexer, Program::Type program_type, Optional<EvalInitialState> initial_state_for_eval)
-    : m_source_code(SourceCode::create(String::from_deprecated_string(lexer.filename()).release_value_but_fixme_should_propagate_errors(), String::from_deprecated_string(lexer.source()).release_value_but_fixme_should_propagate_errors()))
+    : m_source_code(SourceCode::create(lexer.filename(), String::from_deprecated_string(lexer.source()).release_value_but_fixme_should_propagate_errors()))
     , m_state(move(lexer), program_type)
     , m_program_type(program_type)
 {

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -4133,7 +4133,7 @@ Token Parser::consume_and_validate_numeric_literal()
 
 void Parser::expected(char const* what)
 {
-    auto message = m_state.current_token.message();
+    auto message = m_state.current_token.message().to_deprecated_string();
     if (message.is_empty())
         message = DeprecatedString::formatted("Unexpected token {}. Expected {}", m_state.current_token.name(), what);
     syntax_error(message);

--- a/Userland/Libraries/LibJS/Runtime/Error.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Error.cpp
@@ -54,7 +54,7 @@ ThrowCompletionOr<void> Error::install_error_cause(Value options)
 
 void Error::populate_stack()
 {
-    static auto dummy_source_range = SourceRange { .code = SourceCode::create("", ""), .start = {}, .end = {} };
+    static auto dummy_source_range = SourceRange { .code = SourceCode::create(String {}, String {}), .start = {}, .end = {} };
 
     auto& vm = this->vm();
     m_traceback.ensure_capacity(vm.execution_context_stack().size());
@@ -84,7 +84,7 @@ DeprecatedString Error::stack_string() const
         auto const& frame = m_traceback[i];
         auto function_name = frame.function_name;
         // Note: Since we don't know whether we have a valid SourceRange here we just check for some default values.
-        if (!frame.source_range.filename().is_null() || frame.source_range.start.offset != 0 || frame.source_range.end.offset != 0) {
+        if (!frame.source_range.filename().is_empty() || frame.source_range.start.offset != 0 || frame.source_range.end.offset != 0) {
 
             if (function_name == "<unknown>"sv)
                 stack_string_builder.appendff("    at {}:{}:{}\n", frame.source_range.filename(), frame.source_range.start.line, frame.source_range.start.column);

--- a/Userland/Libraries/LibJS/SourceCode.cpp
+++ b/Userland/Libraries/LibJS/SourceCode.cpp
@@ -12,23 +12,23 @@
 
 namespace JS {
 
-NonnullRefPtr<SourceCode> SourceCode::create(DeprecatedString filename, DeprecatedString code)
+NonnullRefPtr<SourceCode> SourceCode::create(String filename, String code)
 {
     return adopt_ref(*new SourceCode(move(filename), move(code)));
 }
 
-SourceCode::SourceCode(DeprecatedString filename, DeprecatedString code)
+SourceCode::SourceCode(String filename, String code)
     : m_filename(move(filename))
     , m_code(move(code))
 {
 }
 
-DeprecatedString const& SourceCode::filename() const
+String const& SourceCode::filename() const
 {
     return m_filename;
 }
 
-DeprecatedString const& SourceCode::code() const
+String const& SourceCode::code() const
 {
     return m_code;
 }
@@ -41,7 +41,7 @@ void SourceCode::compute_line_break_offsets() const
         return;
 
     bool previous_code_point_was_carriage_return = false;
-    Utf8View view(m_code.view());
+    Utf8View view(m_code);
     for (auto it = view.begin(); it != view.end(); ++it) {
         u32 code_point = *it;
         bool is_line_terminator = code_point == '\r' || (code_point == '\n' && !previous_code_point_was_carriage_return) || code_point == LINE_SEPARATOR || code_point == PARAGRAPH_SEPARATOR;
@@ -78,7 +78,7 @@ SourceRange SourceCode::range_from_offsets(u32 start_offset, u32 end_offset) con
 
     bool previous_code_point_was_carriage_return = false;
 
-    Utf8View view(m_code.view());
+    Utf8View view(m_code);
     for (auto it = view.iterator_at_byte_offset_without_validation(nearest_preceding_line_break_offset); it != view.end(); ++it) {
 
         // If we're on or after the start offset, this is the start position.

--- a/Userland/Libraries/LibJS/SourceCode.h
+++ b/Userland/Libraries/LibJS/SourceCode.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
 
@@ -14,20 +14,20 @@ namespace JS {
 
 class SourceCode : public RefCounted<SourceCode> {
 public:
-    static NonnullRefPtr<SourceCode> create(DeprecatedString filename, DeprecatedString code);
+    static NonnullRefPtr<SourceCode> create(String filename, String code);
 
-    DeprecatedString const& filename() const;
-    DeprecatedString const& code() const;
+    String const& filename() const;
+    String const& code() const;
 
     SourceRange range_from_offsets(u32 start_offset, u32 end_offset) const;
 
 private:
-    SourceCode(DeprecatedString filename, DeprecatedString code);
+    SourceCode(String filename, String code);
 
     void compute_line_break_offsets() const;
 
-    DeprecatedString m_filename;
-    DeprecatedString m_code;
+    String m_filename;
+    String m_code;
 
     Optional<Vector<size_t>> mutable m_line_break_offsets;
 };

--- a/Userland/Libraries/LibJS/SourceRange.h
+++ b/Userland/Libraries/LibJS/SourceRange.h
@@ -25,7 +25,7 @@ struct SourceRange {
     Position start;
     Position end;
 
-    DeprecatedString const& filename() const;
+    DeprecatedString filename() const;
 };
 
 }

--- a/Userland/Libraries/LibJS/Token.h
+++ b/Userland/Libraries/LibJS/Token.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/DeprecatedFlyString.h>
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Variant.h>
 
@@ -181,9 +181,9 @@ class Token {
 public:
     Token() = default;
 
-    Token(TokenType type, DeprecatedString message, StringView trivia, StringView value, StringView filename, size_t line_number, size_t line_column, size_t offset)
+    Token(TokenType type, String message, StringView trivia, StringView value, StringView filename, size_t line_number, size_t line_column, size_t offset)
         : m_type(type)
-        , m_message(message)
+        , m_message(move(message))
         , m_trivia(trivia)
         , m_original_value(value)
         , m_value(value)
@@ -200,7 +200,7 @@ public:
     char const* name() const;
     static char const* name(TokenType);
 
-    DeprecatedString const& message() const { return m_message; }
+    String const& message() const { return m_message; }
     StringView trivia() const { return m_trivia; }
     StringView original_value() const { return m_original_value; }
     StringView value() const
@@ -246,7 +246,7 @@ public:
 
 private:
     TokenType m_type { TokenType::Invalid };
-    DeprecatedString m_message;
+    String m_message;
     StringView m_trivia;
     StringView m_original_value;
     Variant<Empty, StringView, DeprecatedFlyString> m_value {};


### PR DESCRIPTION
This change removes usage of DeprecatedString from the LibJS parsing code. The main changes are in Token, SourceCode, and Lexer but some other small modifications were required to meet their updated interfaces. 