### PR TITLE
Kernel: Remove trap based syscall handling

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -9,6 +9,7 @@
 #include <AK/Types.h>
 #include <AK/Userspace.h>
 #include <Kernel/API/POSIX/sched.h>
+#include <Kernel/Arch/RegisterState.h>
 
 constexpr int syscall_vector = 0x82;
 
@@ -200,6 +201,8 @@ enum class NeedsBigProcessLock {
     S(yield, NeedsBigProcessLock::No)
 
 namespace Syscall {
+
+ErrorOr<FlatPtr> handle(RegisterState&, FlatPtr function, FlatPtr arg1, FlatPtr arg2, FlatPtr arg3, FlatPtr arg4);
 
 enum Function {
 #undef __ENUMERATE_SYSCALL

--- a/Kernel/Arch/x86_64/SyscallEntry.cpp
+++ b/Kernel/Arch/x86_64/SyscallEntry.cpp
@@ -4,9 +4,18 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/API/Syscall.h>
 #include <Kernel/Arch/TrapFrame.h>
 #include <Kernel/Arch/x86_64/DescriptorTable.h>
 #include <Kernel/Arch/x86_64/Processor.h>
+#include <Kernel/Assertions.h>
+#include <Kernel/Panic.h>
+#include <Kernel/Process.h>
+#include <Kernel/Scheduler.h>
+#include <Kernel/Thread.h>
+#include <Kernel/ThreadTracer.h>
+
+using namespace Kernel;
 
 extern "C" void syscall_entry();
 extern "C" [[gnu::naked]] void syscall_entry()

--- a/Kernel/Arch/x86_64/init.cpp
+++ b/Kernel/Arch/x86_64/init.cpp
@@ -341,7 +341,6 @@ void init_stage2(void*)
     }
 
     NetworkingManagement::the().initialize();
-    Syscall::initialize();
 
 #ifdef ENABLE_KERNEL_COVERAGE_COLLECTION
     (void)KCOVDevice::must_create().leak_ref();

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -413,7 +413,7 @@ void signal_trampoline_dummy()
         // Current stack state is just saved_rax, ucontext, signal_info, fpu_state.
         // syscall SC_sigreturn
         "mov rax, %P0\n"
-        "int 0x82\n"
+        "syscall\n"
         ".globl asm_signal_trampoline_end\n"
         "asm_signal_trampoline_end:\n"
         ".att_syntax"


### PR DESCRIPTION
This patch removes the x86 mechanism for calling syscalls, favoring the more modern syscall instruction. It also moves architecture dependent code from functions that are meant to be architecture agnostic therefore paving the way for adding more architectures.