### PR TITLE
LibSQL: Don't interpret AK::Error codes as SQL error codes

### DIFF
--- a/Userland/Libraries/LibSQL/Result.h
+++ b/Userland/Libraries/LibSQL/Result.h
@@ -94,7 +94,7 @@ public:
     }
 
     ALWAYS_INLINE Result(Error error)
-        : m_error(static_cast<SQLErrorCode>(error.code()))
+        : m_error(SQLErrorCode::InternalError)
         , m_error_message(error.string_literal())
     {
     }


### PR DESCRIPTION
This makes error invocations such as Error::from_string_literal become associated with a SQLErrorCode (typically 0, AmbiguousColumnName). The result, when displayed to the user, is quite confusing, e.g.:

    Column name 'Heap()::write_block(): Oversized block' is ambiguous

Instead, just interpret these as internal errors, so the error message is displayed as-is.