### PR TITLE
AK: Use constexpr instead of consteval on OpenBSD

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -27,8 +27,8 @@ namespace Detail {
 class StringData;
 }
 
-// FIXME: Remove this when Apple Clang fully supports consteval.
-#if defined(AK_OS_MACOS)
+// FIXME: Remove this when Apple Clang and OpenBSD Clang fully supports consteval.
+#if defined(AK_OS_MACOS) || defined(AK_OS_OPENBSD)
 #    define AK_SHORT_STRING_CONSTEVAL constexpr
 #else
 #    define AK_SHORT_STRING_CONSTEVAL consteval


### PR DESCRIPTION
Since the use of String::from_utf8_short_string, Ladybird fails to build on OpenBSD.
Using constexpr instead of consteval, just like on MacOS, fixes that for me.