### PR TITLE
LibGfx: Check the types of tags in ICCProfile

### DIFF
--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -291,6 +291,8 @@ struct XYZ {
     double x { 0 };
     double y { 0 };
     double z { 0 };
+
+    bool operator==(const XYZ&) const = default;
 };
 
 class TagData : public RefCounted<TagData> {
@@ -598,6 +600,7 @@ private:
     ErrorOr<NonnullRefPtr<TagData>> read_tag(ReadonlyBytes bytes, u32 offset_to_beginning_of_tag_data_element, u32 size_of_tag_data_element);
     ErrorOr<void> read_tag_table(ReadonlyBytes);
     ErrorOr<void> check_required_tags();
+    ErrorOr<void> check_tag_types();
 
     u32 m_on_disk_size { 0 };
     Optional<PreferredCMMType> m_preferred_cmm_type;

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -145,7 +145,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             case Gfx::ICC::ParametricCurveTagData::FunctionType::Type3:
                 outln("    Y = ({}*X + {})**{}   if X >= {}",
                     parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.d());
-                outln("    Y =  {}*X                        else", parametric_curve.c());
+                outln("    Y =  {}*X                         else", parametric_curve.c());
                 break;
             case Gfx::ICC::ParametricCurveTagData::FunctionType::Type4:
                 outln("    Y = ({}*X + {})**{} + {}   if X >= {}",

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -130,27 +130,27 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto& parametric_curve = static_cast<Gfx::ICC::ParametricCurveTagData&>(*tag_data);
             switch (parametric_curve.function_type()) {
             case Gfx::ICC::ParametricCurveTagData::FunctionType::Type0:
-                outln("  Y = X**{}", parametric_curve.g());
+                outln("    Y = X**{}", parametric_curve.g());
                 break;
             case Gfx::ICC::ParametricCurveTagData::FunctionType::Type1:
-                outln("  Y = ({}*X + {})**{}   if X >= -{}/{}",
+                outln("    Y = ({}*X + {})**{}   if X >= -{}/{}",
                     parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.b(), parametric_curve.a());
-                outln("  Y = 0                                else");
+                outln("    Y = 0                                else");
                 break;
             case Gfx::ICC::ParametricCurveTagData::FunctionType::Type2:
-                outln("  Y = ({}*X + {})**{} + {}   if X >= -{}/{}",
+                outln("    Y = ({}*X + {})**{} + {}   if X >= -{}/{}",
                     parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.c(), parametric_curve.b(), parametric_curve.a());
-                outln("  Y =  {}                                    else", parametric_curve.c());
+                outln("    Y =  {}                                    else", parametric_curve.c());
                 break;
             case Gfx::ICC::ParametricCurveTagData::FunctionType::Type3:
-                outln("  Y = ({}*X + {})**{}   if X >= {}",
+                outln("    Y = ({}*X + {})**{}   if X >= {}",
                     parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.d());
-                outln("  Y =  {}*X                        else", parametric_curve.c());
+                outln("    Y =  {}*X                        else", parametric_curve.c());
                 break;
             case Gfx::ICC::ParametricCurveTagData::FunctionType::Type4:
-                outln("  Y = ({}*X + {})**{} + {}   if X >= {}",
+                outln("    Y = ({}*X + {})**{} + {}   if X >= {}",
                     parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.e(), parametric_curve.d());
-                outln("  Y =  {}*X + {}                             else", parametric_curve.c(), parametric_curve.f());
+                outln("    Y =  {}*X + {}                             else", parametric_curve.c(), parametric_curve.f());
                 break;
             }
         } else if (tag_data->type() == Gfx::ICC::S15Fixed16ArrayTagData::Type) {


### PR DESCRIPTION
This adds checking for all tags where ICCProfile can parse the type.
Over time, more of this needs implementing -- at least lut8Type,
lut16Type, lutAToBType, and lutBToAType, since these are used by
required tags.

What _is_ checked for the most part matches the spec, but it's possible
that the spec text is aspirational and that profiles in the wild don't
fully match it.

I've run the current checks against these profiles:

    find \
        ~/src/Compact-ICC-Profiles \
        /{System/,}Library/ColorSync \
        -name '*.icc' \
        -exec echo {} \; \
        -exec Build/lagom/icc {} \;

...and against 3 hand-selected icc files I locally extracted from jpegs.

This identified 3 cases where the spec text is too strict for reality.
I added comments for these for now. Eventually, I'd like to try to still
enforce these types, and have a profile-id-based quirks list for which
they aren't enforced. It's possible that that won't be feasible, but
it's probably better to start out to strict and then relax over time
than the other way round.