### PR TITLE
LibWeb: Fix reset of floats y offset

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -432,9 +432,9 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
 
             auto const& child_box_state = m_state.get(*child_box);
 
-            if (margins_collapse_through(*child_box, m_state)) {
+            // Ignore anonymous block containers with no lines. These don't count as in-flow block boxes.
+            if (child_box->is_anonymous() && child_box->is_block_container() && child_box_state.line_boxes.is_empty())
                 continue;
-            }
 
             auto margin_bottom = m_margin_state.current_collapsed_margin();
             if (box_state.padding_bottom == 0 && box_state.border_bottom == 0) {

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -557,8 +557,6 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
     });
 
     m_margin_state.block_container_y_position_update_callback = {};
-    m_left_floats.clear();
-    m_right_floats.clear();
 
     if (layout_mode == LayoutMode::IntrinsicSizing) {
         auto& block_container_state = m_state.get_mutable(block_container);


### PR DESCRIPTION
Commit 7dc0edcb8625deae09317a1861d3c8d6ad9bca61 was supposed to prevent floats from being placed higher than preceding boxes but the change turned out to be completely wrong and caused regressions because:
1. Call to `clear()` in `layout_block_level_children` would reset floating boxes only after layout of box with _not_ inline children although the same should happen after layout of IFC.
2. `clear()` causes offset y of floats to be reset but it also clears all currently enocuntered floating boxes which means the next box that has actual clearance will get wrong y position.