### PR TITLE
Kernel/aarch64: Road to Userland [4/N] (Build syscall files)

### DIFF
--- a/Kernel/Arch/aarch64/Dummy.cpp
+++ b/Kernel/Arch/aarch64/Dummy.cpp
@@ -16,11 +16,6 @@ namespace Kernel {
 
 ProcessID g_init_pid { 0 };
 
-ErrorOr<void> Process::exec(NonnullOwnPtr<KString>, NonnullOwnPtrVector<KString>, NonnullOwnPtrVector<KString>, Thread*&, u32&, int)
-{
-    TODO_AARCH64();
-}
-
 }
 
 // Delay.cpp

--- a/Kernel/Arch/aarch64/Dummy.cpp
+++ b/Kernel/Arch/aarch64/Dummy.cpp
@@ -16,11 +16,6 @@ namespace Kernel {
 
 ProcessID g_init_pid { 0 };
 
-bool Process::has_tracee_thread(ProcessID)
-{
-    TODO_AARCH64();
-}
-
 ErrorOr<void> Process::exec(NonnullOwnPtr<KString>, NonnullOwnPtrVector<KString>, NonnullOwnPtrVector<KString>, Thread*&, u32&, int)
 {
     TODO_AARCH64();

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -421,4 +421,9 @@ extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread)
     Processor::restore_critical(in_critical);
 }
 
+StringView Processor::platform_string()
+{
+    return "aarch64"sv;
+}
+
 }

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -279,6 +279,8 @@ public:
     void enter_trap(TrapFrame& trap, bool raise_irq);
     void exit_trap(TrapFrame& trap);
 
+    static StringView platform_string();
+
 private:
     Processor(Processor const&) = delete;
 

--- a/Kernel/Arch/aarch64/RegisterState.h
+++ b/Kernel/Arch/aarch64/RegisterState.h
@@ -40,6 +40,16 @@ struct RegisterState {
     {
         return ((spsr_el1 & 0b1111) == 0) ? ExecutionMode::User : ExecutionMode::Kernel;
     }
+
+    void set_return_reg(FlatPtr value) { x[0] = value; }
+    void capture_syscall_params(FlatPtr& function, FlatPtr& arg1, FlatPtr& arg2, FlatPtr& arg3, FlatPtr& arg4) const
+    {
+        function = x[8];
+        arg1 = x[1];
+        arg2 = x[2];
+        arg3 = x[3];
+        arg4 = x[4];
+    }
 };
 
 inline void copy_kernel_registers_into_ptrace_registers(PtraceRegisters& ptrace_regs, RegisterState const& kernel_regs)

--- a/Kernel/Arch/aarch64/RegisterState.h
+++ b/Kernel/Arch/aarch64/RegisterState.h
@@ -49,6 +49,13 @@ inline void copy_kernel_registers_into_ptrace_registers(PtraceRegisters& ptrace_
     TODO_AARCH64();
 }
 
+inline void copy_ptrace_registers_into_kernel_registers(RegisterState& kernel_regs, PtraceRegisters const& ptrace_regs)
+{
+    (void)kernel_regs;
+    (void)ptrace_regs;
+    TODO_AARCH64();
+}
+
 struct DebugRegisterState {
 };
 

--- a/Kernel/Arch/aarch64/ThreadRegisters.h
+++ b/Kernel/Arch/aarch64/ThreadRegisters.h
@@ -33,6 +33,14 @@ struct ThreadRegisters {
         set_ip(entry_ip);
         x[0] = entry_data;
     }
+
+    void set_exec_state(FlatPtr entry_ip, FlatPtr userspace_sp, Memory::AddressSpace& space)
+    {
+        (void)entry_ip;
+        (void)userspace_sp;
+        (void)space;
+        TODO_AARCH64();
+    }
 };
 
 }

--- a/Kernel/Arch/x86_64/ThreadRegisters.h
+++ b/Kernel/Arch/x86_64/ThreadRegisters.h
@@ -79,6 +79,14 @@ struct ThreadRegisters {
         set_ip(entry_ip);
         rdi = entry_data; // entry function argument is expected to be in regs.rdi
     }
+
+    void set_exec_state(FlatPtr entry_ip, FlatPtr userspace_sp, Memory::AddressSpace& space)
+    {
+        cs = GDT_SELECTOR_CODE3 | 3;
+        rip = entry_ip;
+        rsp = userspace_sp;
+        cr3 = space.page_directory().cr3();
+    }
 };
 
 }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -301,6 +301,7 @@ set(KERNEL_SOURCES
     Syscalls/prctl.cpp
     Syscalls/process.cpp
     Syscalls/profiling.cpp
+    Syscalls/ptrace.cpp
     Syscalls/purge.cpp
     Syscalls/read.cpp
     Syscalls/readlink.cpp
@@ -401,7 +402,6 @@ if ("${SERENITY_ARCH}" STREQUAL "x86_64")
         Syscalls/execve.cpp
         Syscalls/fork.cpp
         Syscalls/mmap.cpp
-        Syscalls/ptrace.cpp
         Syscalls/sigaction.cpp
     )
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -292,6 +292,7 @@ set(KERNEL_SOURCES
     Syscalls/lseek.cpp
     Syscalls/mkdir.cpp
     Syscalls/mknod.cpp
+    Syscalls/mmap.cpp
     Syscalls/mount.cpp
     Syscalls/open.cpp
     Syscalls/perf_event.cpp
@@ -401,7 +402,6 @@ if ("${SERENITY_ARCH}" STREQUAL "x86_64")
         Syscall.cpp
         Syscalls/execve.cpp
         Syscalls/fork.cpp
-        Syscalls/mmap.cpp
         Syscalls/sigaction.cpp
     )
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -261,6 +261,7 @@ set(KERNEL_SOURCES
     Scheduler.cpp
     ScopedCritical.cpp
     StdLib.cpp
+    Syscall.cpp
     Syscalls/anon_create.cpp
     Syscalls/alarm.cpp
     Syscalls/beep.cpp
@@ -402,7 +403,6 @@ if ("${SERENITY_ARCH}" STREQUAL "x86_64")
         Interrupts/SpuriousInterruptHandler.cpp
         kprintf.cpp
         Panic.cpp
-        Syscall.cpp
     )
 
     set(KERNEL_SOURCES

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -272,6 +272,7 @@ set(KERNEL_SOURCES
     Syscalls/disown.cpp
     Syscalls/dup2.cpp
     Syscalls/emuctl.cpp
+    Syscalls/execve.cpp
     Syscalls/exit.cpp
     Syscalls/faccessat.cpp
     Syscalls/fallocate.cpp
@@ -402,7 +403,6 @@ if ("${SERENITY_ARCH}" STREQUAL "x86_64")
         kprintf.cpp
         Panic.cpp
         Syscall.cpp
-        Syscalls/execve.cpp
     )
 
     set(KERNEL_SOURCES

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -314,6 +314,7 @@ set(KERNEL_SOURCES
     Syscalls/sendfd.cpp
     Syscalls/setpgid.cpp
     Syscalls/setuid.cpp
+    Syscalls/sigaction.cpp
     Syscalls/socket.cpp
     Syscalls/stat.cpp
     Syscalls/statvfs.cpp
@@ -402,7 +403,6 @@ if ("${SERENITY_ARCH}" STREQUAL "x86_64")
         Syscall.cpp
         Syscalls/execve.cpp
         Syscalls/fork.cpp
-        Syscalls/sigaction.cpp
     )
 
     set(KERNEL_SOURCES

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -276,6 +276,7 @@ set(KERNEL_SOURCES
     Syscalls/faccessat.cpp
     Syscalls/fallocate.cpp
     Syscalls/fcntl.cpp
+    Syscalls/fork.cpp
     Syscalls/fsync.cpp
     Syscalls/ftruncate.cpp
     Syscalls/futex.cpp
@@ -402,7 +403,6 @@ if ("${SERENITY_ARCH}" STREQUAL "x86_64")
         Panic.cpp
         Syscall.cpp
         Syscalls/execve.cpp
-        Syscalls/fork.cpp
     )
 
     set(KERNEL_SOURCES

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -63,7 +63,7 @@ UNMAP_AFTER_INIT ErrorOr<void> BochsGraphicsAdapter::initialize_adapter(PCI::Dev
         m_display_connector = QEMUDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR0(pci_device_identifier) & 0xfffffff0), bar0_space_size, move(registers_mapping));
     }
 #else
-    auto registers_mapping = TRY(Memory::map_typed_writable<BochsDisplayMMIORegisters volatile>(PhysicalAddress(PCI::get_BAR2(pci_device_identifier.address()) & 0xfffffff0)));
+    auto registers_mapping = TRY(Memory::map_typed_writable<BochsDisplayMMIORegisters volatile>(PhysicalAddress(PCI::get_BAR2(pci_device_identifier) & 0xfffffff0)));
     VERIFY(registers_mapping.region);
     m_display_connector = QEMUDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR0(pci_device_identifier) & 0xfffffff0), bar0_space_size, move(registers_mapping));
 #endif

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -246,8 +246,8 @@ ErrorOr<NonnullLockRefPtr<Process>> Process::try_create_user_process(LockRefPtr<
     }));
 
     Thread* new_main_thread = nullptr;
-    u32 prev_flags = 0;
-    if (auto result = process->exec(move(path_string), move(arguments), move(environment), new_main_thread, prev_flags); result.is_error()) {
+    InterruptsState previous_interrupts_state = InterruptsState::Enabled;
+    if (auto result = process->exec(move(path_string), move(arguments), move(environment), new_main_thread, previous_interrupts_state); result.is_error()) {
         dbgln("Failed to exec {}: {}", path, result.error());
         first_thread = nullptr;
         return result.release_error();

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -476,7 +476,7 @@ public:
     NonnullOwnPtrVector<KString> const& arguments() const { return m_arguments; };
     NonnullOwnPtrVector<KString> const& environment() const { return m_environment; };
 
-    ErrorOr<void> exec(NonnullOwnPtr<KString> path, NonnullOwnPtrVector<KString> arguments, NonnullOwnPtrVector<KString> environment, Thread*& new_main_thread, u32& prev_flags, int recursion_depth = 0);
+    ErrorOr<void> exec(NonnullOwnPtr<KString> path, NonnullOwnPtrVector<KString> arguments, NonnullOwnPtrVector<KString> environment, Thread*& new_main_thread, InterruptsState& previous_interrupts_state, int recursion_depth = 0);
 
     ErrorOr<LoadResult> load(NonnullLockRefPtr<OpenFileDescription> main_program_description, LockRefPtr<OpenFileDescription> interpreter_description, const ElfW(Ehdr) & main_program_header);
 
@@ -608,7 +608,7 @@ private:
     bool create_perf_events_buffer_if_needed();
     void delete_perf_events_buffer();
 
-    ErrorOr<void> do_exec(NonnullLockRefPtr<OpenFileDescription> main_program_description, NonnullOwnPtrVector<KString> arguments, NonnullOwnPtrVector<KString> environment, LockRefPtr<OpenFileDescription> interpreter_description, Thread*& new_main_thread, u32& prev_flags, const ElfW(Ehdr) & main_program_header);
+    ErrorOr<void> do_exec(NonnullLockRefPtr<OpenFileDescription> main_program_description, NonnullOwnPtrVector<KString> arguments, NonnullOwnPtrVector<KString> environment, LockRefPtr<OpenFileDescription> interpreter_description, Thread*& new_main_thread, InterruptsState& previous_interrupts_state, const ElfW(Ehdr) & main_program_header);
     ErrorOr<FlatPtr> do_write(OpenFileDescription&, UserOrKernelBuffer const&, size_t, Optional<off_t> = {});
 
     ErrorOr<FlatPtr> do_statvfs(FileSystem const& path, Custody const*, statvfs* buf);

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -7,7 +7,6 @@
 
 #include <Kernel/API/Syscall.h>
 #include <Kernel/Arch/TrapFrame.h>
-#include <Kernel/Arch/x86_64/Interrupts.h>
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Panic.h>
 #include <Kernel/PerformanceManager.h>
@@ -15,6 +14,10 @@
 #include <Kernel/Scheduler.h>
 #include <Kernel/Sections.h>
 #include <Kernel/ThreadTracer.h>
+
+#if ARCH(X86_64)
+#    include <Kernel/Arch/x86_64/Interrupts.h>
+#endif
 
 namespace Kernel {
 
@@ -61,7 +64,9 @@ static ErrorOr<FlatPtr> handle(RegisterState&, FlatPtr function, FlatPtr arg1, F
 
 UNMAP_AFTER_INIT void initialize()
 {
+#if ARCH(X86_64)
     register_user_callable_interrupt_handler(syscall_vector, syscall_asm_entry);
+#endif
 }
 
 using Handler = auto(Process::*)(FlatPtr, FlatPtr, FlatPtr, FlatPtr) -> ErrorOr<FlatPtr>;
@@ -140,8 +145,14 @@ ErrorOr<FlatPtr> handle(RegisterState& regs, FlatPtr function, FlatPtr arg1, Fla
 
 NEVER_INLINE void syscall_handler(TrapFrame* trap)
 {
+#if ARCH(X86_64)
     // Make sure SMAP protection is enabled on syscall entry.
     clac();
+#elif ARCH(AARCH64)
+    // FIXME: Implement the security mechanism for aarch64
+#else
+#    error Unknown architecture
+#endif
 
     auto& regs = *trap->regs;
     auto* current_thread = Thread::current();
@@ -161,6 +172,7 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
 
     current_thread->yield_if_stopped();
 
+#if ARCH(X86_64)
     // Apply a random offset in the range 0-255 to the stack pointer,
     // to make kernel stacks a bit less deterministic.
     u32 lsw;
@@ -177,6 +189,11 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
     if ((flags & (iopl_mask)) != 0) {
         PANIC("Syscall from process with IOPL != 0");
     }
+#elif ARCH(AARCH64)
+    // FIXME: Implement the security mechanism for aarch64
+#else
+#    error Unknown architecture
+#endif
 
     Memory::MemoryManager::validate_syscall_preconditions(process, regs);
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -685,10 +685,9 @@ ErrorOr<void> Process::do_exec(NonnullLockRefPtr<OpenFileDescription> main_progr
     new_main_thread->reset_fpu_state();
 
     auto& regs = new_main_thread->m_regs;
-    regs.cs = GDT_SELECTOR_CODE3 | 3;
-    regs.rip = load_result.entry_eip;
-    regs.rsp = new_userspace_sp;
-    regs.cr3 = address_space().with([](auto& space) { return space->page_directory().cr3(); });
+    address_space().with([&](auto& space) {
+        regs.set_exec_state(load_result.entry_eip, new_userspace_sp, *space);
+    });
 
     {
         TemporaryChange profiling_disabler(m_profiling, was_profiling);

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -125,6 +125,9 @@ ErrorOr<FlatPtr> Process::sys$fork(RegisterState& regs)
 
     dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:#04x}:{:p} with stack {:p}, kstack {:p}",
         child_regs.cs, child_regs.rip, child_regs.rsp, child_regs.rsp0);
+#elif ARCH(AARCH64)
+    (void)regs;
+    TODO_AARCH64();
 #else
 #    error Unknown architecture
 #endif

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -6,10 +6,10 @@
  */
 
 #include <Kernel/API/VirtualMemoryAnnotations.h>
+#include <Kernel/Arch/CPU.h>
 #include <Kernel/Arch/PageDirectory.h>
 #include <Kernel/Arch/SafeMem.h>
 #include <Kernel/Arch/SmapDisabler.h>
-#include <Kernel/Arch/x86_64/MSR.h>
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/OpenFileDescription.h>
 #include <Kernel/Memory/AnonymousVMObject.h>
@@ -21,6 +21,10 @@
 #include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
 #include <LibELF/Validation.h>
+
+#if ARCH(X86_64)
+#    include <Kernel/Arch/x86_64/MSR.h>
+#endif
 
 namespace Kernel {
 
@@ -562,8 +566,10 @@ ErrorOr<FlatPtr> Process::sys$allocate_tls(Userspace<char const*> initial_data, 
 
         TRY(main_thread->make_thread_specific_region({}));
 
+#if ARCH(X86_64)
         MSR fs_base_msr(MSR_FS_BASE);
         fs_base_msr.set(main_thread->thread_specific_data().get());
+#endif
 
         return m_master_tls_region.unsafe_ptr()->vaddr().get();
     });

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -107,7 +107,7 @@ static ErrorOr<FlatPtr> handle_ptrace(Kernel::Syscall::SC_ptrace_params const& p
 
         auto& peer_saved_registers = peer->get_register_dump_from_stack();
         // Verify that the saved registers are in usermode context
-        if ((peer_saved_registers.cs & 0x03) != 3)
+        if (peer_saved_registers.previous_mode() == ExecutionMode::User)
             return EFAULT;
 
         tracer->set_regs(regs);
@@ -229,6 +229,7 @@ ErrorOr<void> Process::poke_user_data(Userspace<FlatPtr*> address, FlatPtr data)
 
 ErrorOr<FlatPtr> Thread::peek_debug_register(u32 register_index)
 {
+#if ARCH(X86_64)
     FlatPtr data;
     switch (register_index) {
     case 0:
@@ -253,10 +254,17 @@ ErrorOr<FlatPtr> Thread::peek_debug_register(u32 register_index)
         return EINVAL;
     }
     return data;
+#elif ARCH(AARCH64)
+    (void)register_index;
+    TODO_AARCH64();
+#else
+#    error "Unknown architecture"
+#endif
 }
 
 ErrorOr<void> Thread::poke_debug_register(u32 register_index, FlatPtr data)
 {
+#if ARCH(X86_64)
     switch (register_index) {
     case 0:
         m_debug_register_state.dr0 = data;
@@ -277,6 +285,13 @@ ErrorOr<void> Thread::poke_debug_register(u32 register_index, FlatPtr data)
         return EINVAL;
     }
     return {};
+#elif ARCH(AARCH64)
+    (void)register_index;
+    (void)data;
+    TODO_AARCH64();
+#else
+#    error "Unknown architecture"
+#endif
 }
 
 }


### PR DESCRIPTION
# Build Syscall Files

This PR implements enough to be able to build all the syscall files for the aarch64 build. The only files that are not shared yet are: `Interrupts/SpuriousInterruptHandler.cpp`, `kprintf.cpp` and `Panic.cpp`, but these can be shared later.

This brings us closer to aarch64 userspace, as these files are needed for a correct syscall functionality, and most importantly adds `Syscalls/execve.cpp` to the build as that file is necessary for executing the first userspace program.

This PR is ready for review, but needs to be applied on top of #16911. (Current build failure is related to missing changes that are only part of #16911.) 