### PR TITLE
Documentation: Document the "Fallible Constructor" pattern

### DIFF
--- a/Documentation/Patterns.md
+++ b/Documentation/Patterns.md
@@ -79,6 +79,45 @@ void log_that_can_not_fail(StringView fmtstr, TypeErasedFormatParams& params)
 }
 ```
 
+## Fallible Constructors
+
+The usual C++ constructors are incompatible with SerenityOS' method of handling errors,
+as potential errors are passed using the `ErrorOr` return type. As a replacement, classes
+that require fallible operations during their construction define a static function that
+is fallible instead.
+
+This fallible function (which should usually be named `create`) will handle any errors while
+preparing arguments for the internal constructor and run any required fallible operations after
+the object has been initialized. The resulting object is then returned as `ErrorOr<T>` or
+`ErrorOr<NonnullOwnPtr<T>>`.
+
+### Example:
+
+```cpp
+class Decompressor {
+public:
+    static ErrorOr<NonnullOwnPtr<Decompressor>> create(NonnullOwnPtr<Core::Stream::Stream> stream)
+    {
+        auto buffer = TRY(CircularBuffer::create_empty(32 * KiB));
+        auto decompressor = TRY(adopt_nonnull_own_or_enomem(new (nothrow) Decompressor(move(stream), move(buffer))));
+        TRY(decompressor->initialize_settings_from_header());
+        return decompressor;
+    }
+
+... snip ...
+
+private:
+    Decompressor(NonnullOwnPtr<Core::Stream::Stream> stream, CircularBuffer buffer)
+        : m_stream(move(stream))
+        , m_buffer(move(buffer))
+    {
+    }
+
+    CircularBuffer m_buffer;
+    NonnullOwnPtr<Core::Stream::Stream> m_stream;
+}
+```
+
 ## The `serenity_main(..)` program entry point
 
 Serenity has moved to a pattern where executables do not expose a normal C


### PR DESCRIPTION
The example is specifically made for this and doesn't have a direct equivalent in the source tree. However, it's generally very similar to how a Core::Stream-based decompressor is implemented if it needs an additional lookback buffer and needs to do I/O-operations on the stream before the user is allowed to call a function.