### PR TITLE
TextEditor: Convert DeprecatedString to String

### DIFF
--- a/Userland/Applications/TextEditor/FileArgument.cpp
+++ b/Userland/Applications/TextEditor/FileArgument.cpp
@@ -10,14 +10,16 @@
 
 namespace TextEditor {
 
-FileArgument::FileArgument(DeprecatedString file_argument)
+FileArgument::FileArgument(String file_argument)
 {
     m_line = {};
     m_column = {};
 
-    // A file doesn't exist with the full specified name, maybe the user entered line/column coordinates?
+    // A file doesn't exist with the full specified name, maybe the user entered
+    // line/column coordinates?
     Regex<PosixExtended> re("^(.+?)(?::([0-9]+))?(?::([0-9]+))?$");
-    RegexResult result = match(file_argument, re, PosixFlags::Global | PosixFlags::Multiline | PosixFlags::Ungreedy);
+    RegexResult result = match(file_argument, re,
+        PosixFlags::Global | PosixFlags::Multiline | PosixFlags::Ungreedy);
     auto& groups = result.capture_group_matches.at(0);
 
     // Match 0 group 0: file name
@@ -25,9 +27,9 @@ FileArgument::FileArgument(DeprecatedString file_argument)
     // Match 0 group 2: column number
     if (groups.size() > 2) {
         // Both a line and column number were specified.
-        auto filename = groups.at(0).view.to_deprecated_string();
-        auto initial_line_number = groups.at(1).view.to_deprecated_string().to_int();
-        auto initial_column_number = groups.at(2).view.to_deprecated_string().to_int();
+        auto filename = groups.at(0).view.to_string().release_value_but_fixme_should_propagate_errors();
+        auto initial_line_number = groups.at(1).view.to_string().release_value_but_fixme_should_propagate_errors().to_number<int>();
+        auto initial_column_number = groups.at(2).view.to_string().release_value_but_fixme_should_propagate_errors().to_number<int>();
 
         m_filename = filename;
         if (initial_line_number.has_value() && initial_line_number.value() > 0)
@@ -36,15 +38,16 @@ FileArgument::FileArgument(DeprecatedString file_argument)
             m_column = initial_column_number.value();
     } else if (groups.size() == 2) {
         // Only a line number was specified.
-        auto filename = groups.at(0).view.to_deprecated_string();
-        auto initial_line_number = groups.at(1).view.to_deprecated_string().to_int();
+        auto filename = groups.at(0).view.to_string().release_value_but_fixme_should_propagate_errors();
+        auto initial_line_number = groups.at(1).view.to_string().release_value_but_fixme_should_propagate_errors().to_number<int>();
 
         m_filename = filename;
         if (initial_line_number.has_value() && initial_line_number.value() > 0)
             m_line = initial_line_number.value();
     } else {
-        // A colon was found at the end of the file name but no values were found after it.
-        m_filename = groups.at(0).view.to_deprecated_string();
+        // A colon was found at the end of the file name but no values were found
+        // after it.
+        m_filename = groups.at(0).view.to_string().release_value_but_fixme_should_propagate_errors();
     }
 }
 }

--- a/Userland/Applications/TextEditor/FileArgument.h
+++ b/Userland/Applications/TextEditor/FileArgument.h
@@ -7,21 +7,21 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 
 namespace TextEditor {
 
 class FileArgument final {
 public:
-    explicit FileArgument(DeprecatedString);
+    explicit FileArgument(String);
     ~FileArgument() = default;
 
-    DeprecatedString filename() { return m_filename; }
+    String filename() { return m_filename; }
     Optional<size_t> line() { return m_line; }
     Optional<size_t> column() { return m_column; }
 
 private:
-    DeprecatedString m_filename;
+    String m_filename;
     Optional<size_t> m_line;
     Optional<size_t> m_column;
 };

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -72,12 +72,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     if (file_to_edit) {
-        FileArgument parsed_argument(file_to_edit);
-        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window, parsed_argument.filename());
+        auto filename = TRY(String::from_utf8(StringView(file_to_edit, strlen(file_to_edit))));
+        FileArgument parsed_argument(filename);
+        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window, parsed_argument.filename().to_deprecated_string());
 
         if (response.is_error()) {
             if (response.error().code() == ENOENT)
-                text_widget->open_nonexistent_file(parsed_argument.filename());
+                text_widget->open_nonexistent_file(parsed_argument.filename().to_deprecated_string());
             else
                 return 1;
         } else {


### PR DESCRIPTION
Some instances of DeprecatedString were changed to String within TextEditor, then the dependencies were changed to accomodate the change. Some additional uses of `to_deprecated_string()` were used to prevent widespread changes

Addresses part of Issue #17128