### PR TITLE
Let icc also dump ICC profiles embedded in jpeg files

### DIFF
--- a/Userland/Libraries/LibGfx/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/BMPLoader.cpp
@@ -1492,4 +1492,9 @@ ErrorOr<ImageFrameDescriptor> BMPImageDecoderPlugin::frame(size_t index)
     return ImageFrameDescriptor { m_context->bitmap, 0 };
 }
 
+ErrorOr<Optional<ReadonlyBytes>> BMPImageDecoderPlugin::icc_data()
+{
+    return OptionalNone {};
+}
+
 }

--- a/Userland/Libraries/LibGfx/BMPLoader.h
+++ b/Userland/Libraries/LibGfx/BMPLoader.h
@@ -36,6 +36,7 @@ public:
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) override;
+    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     BMPImageDecoderPlugin(u8 const*, size_t, IncludedInICO included_in_ico = IncludedInICO::No);

--- a/Userland/Libraries/LibGfx/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/DDSLoader.cpp
@@ -1024,4 +1024,9 @@ ErrorOr<ImageFrameDescriptor> DDSImageDecoderPlugin::frame(size_t index)
     return ImageFrameDescriptor { m_context->bitmap, 0 };
 }
 
+ErrorOr<Optional<ReadonlyBytes>> DDSImageDecoderPlugin::icc_data()
+{
+    return OptionalNone {};
+}
+
 }

--- a/Userland/Libraries/LibGfx/DDSLoader.h
+++ b/Userland/Libraries/LibGfx/DDSLoader.h
@@ -248,6 +248,7 @@ public:
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) override;
+    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     DDSImageDecoderPlugin(u8 const*, size_t);

--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -667,4 +667,9 @@ ErrorOr<ImageFrameDescriptor> GIFImageDecoderPlugin::frame(size_t index)
     return frame;
 }
 
+ErrorOr<Optional<ReadonlyBytes>> GIFImageDecoderPlugin::icc_data()
+{
+    return OptionalNone {};
+}
+
 }

--- a/Userland/Libraries/LibGfx/GIFLoader.h
+++ b/Userland/Libraries/LibGfx/GIFLoader.h
@@ -28,6 +28,7 @@ public:
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) override;
+    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     GIFImageDecoderPlugin(u8 const*, size_t);

--- a/Userland/Libraries/LibGfx/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ICOLoader.cpp
@@ -278,4 +278,9 @@ ErrorOr<ImageFrameDescriptor> ICOImageDecoderPlugin::frame(size_t index)
     return ImageFrameDescriptor { m_context->images[m_context->largest_index].bitmap, 0 };
 }
 
+ErrorOr<Optional<ReadonlyBytes>> ICOImageDecoderPlugin::icc_data()
+{
+    return OptionalNone {};
+}
+
 }

--- a/Userland/Libraries/LibGfx/ICOLoader.h
+++ b/Userland/Libraries/LibGfx/ICOLoader.h
@@ -27,6 +27,7 @@ public:
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) override;
+    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     ICOImageDecoderPlugin(u8 const*, size_t);

--- a/Userland/Libraries/LibGfx/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageDecoder.h
@@ -40,6 +40,7 @@ public:
     virtual size_t loop_count() = 0;
     virtual size_t frame_count() = 0;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) = 0;
+    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() = 0;
 
 protected:
     ImageDecoderPlugin() = default;
@@ -59,6 +60,7 @@ public:
     size_t loop_count() const { return m_plugin->loop_count(); }
     size_t frame_count() const { return m_plugin->frame_count(); }
     ErrorOr<ImageFrameDescriptor> frame(size_t index) const { return m_plugin->frame(index); }
+    ErrorOr<Optional<ReadonlyBytes>> icc_data() const { return m_plugin->icc_data(); }
 
 private:
     explicit ImageDecoder(NonnullOwnPtr<ImageDecoderPlugin>);

--- a/Userland/Libraries/LibGfx/JPGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPGLoader.cpp
@@ -1178,4 +1178,9 @@ ErrorOr<ImageFrameDescriptor> JPGImageDecoderPlugin::frame(size_t index)
     return ImageFrameDescriptor { m_context->bitmap, 0 };
 }
 
+ErrorOr<Optional<ReadonlyBytes>> JPGImageDecoderPlugin::icc_data()
+{
+    return OptionalNone {};
+}
+
 }

--- a/Userland/Libraries/LibGfx/JPGLoader.h
+++ b/Userland/Libraries/LibGfx/JPGLoader.h
@@ -26,10 +26,12 @@ public:
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) override;
+    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     JPGImageDecoderPlugin(u8 const*, size_t);
 
     OwnPtr<JPGLoadingContext> m_context;
 };
+
 }

--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -963,4 +963,9 @@ ErrorOr<ImageFrameDescriptor> PNGImageDecoderPlugin::frame(size_t index)
     return ImageFrameDescriptor { m_context->bitmap, 0 };
 }
 
+ErrorOr<Optional<ReadonlyBytes>> PNGImageDecoderPlugin::icc_data()
+{
+    return OptionalNone {};
+}
+
 }

--- a/Userland/Libraries/LibGfx/PNGLoader.h
+++ b/Userland/Libraries/LibGfx/PNGLoader.h
@@ -27,6 +27,7 @@ public:
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) override;
+    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     PNGImageDecoderPlugin(u8 const*, size_t);

--- a/Userland/Libraries/LibGfx/PortableImageMapLoader.h
+++ b/Userland/Libraries/LibGfx/PortableImageMapLoader.h
@@ -65,6 +65,7 @@ public:
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) override;
+    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     OwnPtr<TContext> m_context;
@@ -183,4 +184,11 @@ ErrorOr<ImageFrameDescriptor> PortableImageDecoderPlugin<TContext>::frame(size_t
     VERIFY(m_context->bitmap);
     return ImageFrameDescriptor { m_context->bitmap, 0 };
 }
+
+template<typename TContext>
+ErrorOr<Optional<ReadonlyBytes>> PortableImageDecoderPlugin<TContext>::icc_data()
+{
+    return OptionalNone {};
+}
+
 }

--- a/Userland/Libraries/LibGfx/QOILoader.cpp
+++ b/Userland/Libraries/LibGfx/QOILoader.cpp
@@ -262,4 +262,9 @@ ErrorOr<void> QOIImageDecoderPlugin::decode_image_and_update_context(Core::Strea
     return {};
 }
 
+ErrorOr<Optional<ReadonlyBytes>> QOIImageDecoderPlugin::icc_data()
+{
+    return OptionalNone {};
+}
+
 }

--- a/Userland/Libraries/LibGfx/QOILoader.h
+++ b/Userland/Libraries/LibGfx/QOILoader.h
@@ -53,6 +53,7 @@ public:
     virtual size_t loop_count() override { return 0; }
     virtual size_t frame_count() override { return 1; }
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) override;
+    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     ErrorOr<void> decode_header_and_update_context(Core::Stream::Stream&);

--- a/Userland/Libraries/LibGfx/TGALoader.cpp
+++ b/Userland/Libraries/LibGfx/TGALoader.cpp
@@ -359,4 +359,10 @@ ErrorOr<ImageFrameDescriptor> TGAImageDecoderPlugin::frame(size_t index)
     m_context->bitmap = bitmap;
     return ImageFrameDescriptor { m_context->bitmap, 0 };
 }
+
+ErrorOr<Optional<ReadonlyBytes>> TGAImageDecoderPlugin::icc_data()
+{
+    return OptionalNone {};
+}
+
 }

--- a/Userland/Libraries/LibGfx/TGALoader.h
+++ b/Userland/Libraries/LibGfx/TGALoader.h
@@ -28,6 +28,7 @@ public:
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) override;
+    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     bool decode_tga_header();


### PR DESCRIPTION
Adds a slightly rickety API to ImageDecoder for extracting ICC bytes from an image file.

Eventually the API should be fairly different. Eventually, all color data in the system should be tagged with some colorspace, so maybe Bitmap will just always contain a ref to a color space object or something.

---

Screenshot:

```
% time Build/lagom/icc ~/src/jpegfiles/DSC03136-exported.jpg
    preferred CMM type: 'Lino'
               version: 2.1.0
          device class: DisplayDevice
      data color space: RGB
      connection space: PCSXYZ
creation date and time: 1998-02-09 01:49:00
      primary platform: Microsoft
                 flags: 0x00000000
                        - not embedded in file
                        - can be used independently of embedded color data
   device manufacturer: 'IEC '
          device model: 'sRGB'
     device attributes: 0x0000000000000000
                        media is:
                        - reflective
                        - glossy
                        - of positive polarity
                        - colored
      rendering intent: Perceptual
        pcs illuminant: X = 0.964202, Y = 1, Z = 0.824905
               creator: 'HP  '
                    id: (not set)

tags:
copyrightTag ('cprt'): type 'text', offset 336, size 51
    text: "Copyright (c) 1998 Hewlett-Packard Company"
profileDescriptionTag ('desc'): type 'desc', offset 388, size 108
    ascii: "sRGB IEC61966-2.1"
    unicode: (not set)
    unicode language code: 0x0
    macintosh: "sRGB IEC61966-2.1"
mediaWhitePointTag ('wtpt'): type 'XYZ ', offset 496, size 20
    X = 0.950454, Y = 1, Z = 1.08905
Unknown tag ('bkpt'): type 'XYZ ', offset 516, size 20
    X = 0, Y = 0, Z = 0
redMatrixColumnTag ('rXYZ'): type 'XYZ ', offset 536, size 20
    X = 0.436065, Y = 0.222488, Z = 0.013916
greenMatrixColumnTag ('gXYZ'): type 'XYZ ', offset 556, size 20
    X = 0.385147, Y = 0.716873, Z = 0.097076
blueMatrixColumnTag ('bXYZ'): type 'XYZ ', offset 576, size 20
    X = 0.143066, Y = 0.060607, Z = 0.714096
deviceMfgDescTag ('dmnd'): type 'desc', offset 596, size 112
    ascii: "IEC http://www.iec.ch"
    unicode: (not set)
    unicode language code: 0x0
    macintosh: "IEC http://www.iec.ch"
deviceModelDescTag ('dmdd'): type 'desc', offset 708, size 136
    ascii: "IEC 61966-2.1 Default RGB colour space - sRGB"
    unicode: (not set)
    unicode language code: 0x0
    macintosh: "IEC 61966-2.1 Default RGB colour space - sRGB"
viewingCondDescTag ('vued'): type 'desc', offset 844, size 134
    ascii: "Reference Viewing Condition in IEC61966-2.1"
    unicode: (not set)
    unicode language code: 0x0
    macintosh: "Reference Viewing Condition in IEC61966-2.1"
viewingConditionsTag ('view'): type 'view', offset 980, size 36
luminanceTag ('lumi'): type 'XYZ ', offset 1016, size 20
    X = 76.036468, Y = 80, Z = 87.124618
measurementTag ('meas'): type 'meas', offset 1036, size 36
technologyTag ('tech'): type 'sig ', offset 1072, size 12
redTRCTag ('rTRC'): type 'curv', offset 1084, size 2060
    curve with 1024 points
greenTRCTag ('gTRC'): type 'curv', offset 1084, size 2060
    (see 'rTRC' above)
blueTRCTag ('bTRC'): type 'curv', offset 1084, size 2060
    (see 'rTRC' above)
```