### PR TITLE
PixelPaint: Fix gradient tool clipping issues

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -134,6 +134,16 @@ void ImageEditor::update_modified()
         on_modified_change(is_modified());
 }
 
+Gfx::IntRect ImageEditor::subtract_rulers_from_rect(Gfx::IntRect const& rect) const
+{
+    Gfx::IntRect clipped_rect {};
+    clipped_rect.set_top(max(rect.y(), m_ruler_thickness + 1));
+    clipped_rect.set_left(max(rect.x(), m_ruler_thickness + 1));
+    clipped_rect.set_bottom(rect.bottom());
+    clipped_rect.set_right(rect.right());
+    return clipped_rect;
+}
+
 void ImageEditor::paint_event(GUI::PaintEvent& event)
 {
     GUI::Frame::paint_event(event);
@@ -282,11 +292,7 @@ void ImageEditor::second_paint_event(GUI::PaintEvent& event)
 {
     if (m_active_tool) {
         if (m_show_rulers) {
-            auto clipped_event = GUI::PaintEvent(Gfx::IntRect { event.rect().x() + m_ruler_thickness,
-                                                     event.rect().y() + m_ruler_thickness,
-                                                     event.rect().width() - m_ruler_thickness,
-                                                     event.rect().height() - m_ruler_thickness },
-                event.window_size());
+            auto clipped_event = GUI::PaintEvent(subtract_rulers_from_rect(event.rect()), event.window_size());
             m_active_tool->on_second_paint(m_active_layer, clipped_event);
         } else {
             m_active_tool->on_second_paint(m_active_layer, event);

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -148,6 +148,8 @@ private:
 
     virtual void selection_did_change() override;
 
+    Gfx::IntRect subtract_rulers_from_rect(Gfx::IntRect const& rect) const;
+
     GUI::MouseEvent event_adjusted_for_layer(GUI::MouseEvent const&, Layer const&) const;
     GUI::MouseEvent event_with_pan_and_scale_applied(GUI::MouseEvent const&) const;
 

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -153,16 +153,14 @@ void GradientTool::on_keyup(GUI::KeyEvent& event)
     }
 }
 
-void GradientTool::on_second_paint(Layer const* layer, GUI::PaintEvent&)
+void GradientTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 {
     if (!layer || !has_gradient_start_end())
         return;
 
-    // FIXME: Clipping still does overwrite the ruler if we are zoomed in.
-    auto clipping_rect = m_editor->rect().contains(m_editor->content_rect()) ? m_editor->content_rect() : m_editor->rect();
     GUI::Painter painter(*m_editor);
-    painter.add_clip_rect(clipping_rect);
-    draw_gradient(painter, true, m_editor->content_to_frame_position(Gfx::IntPoint(0, 0)), m_editor->scale());
+    painter.add_clip_rect(event.rect());
+    draw_gradient(painter, true, m_editor->content_to_frame_position(Gfx::IntPoint(0, 0)), m_editor->scale(), m_editor->content_rect());
 }
 
 void GradientTool::on_tool_activation()
@@ -250,7 +248,7 @@ void GradientTool::calculate_gradient_lines()
     m_editor->update();
 }
 
-void GradientTool::draw_gradient(GUI::Painter& painter, bool with_guidelines, const Gfx::FloatPoint drawing_offset, float scale)
+void GradientTool::draw_gradient(GUI::Painter& painter, bool with_guidelines, const Gfx::FloatPoint drawing_offset, float scale, Optional<Gfx::IntRect const&> gradient_clip)
 {
     auto t_gradient_begin_line = m_gradient_begin_line.scaled(scale, scale).translated(drawing_offset);
     auto t_gradient_center_line = m_gradient_center_line.scaled(scale, scale).translated(drawing_offset);
@@ -288,7 +286,12 @@ void GradientTool::draw_gradient(GUI::Painter& painter, bool with_guidelines, co
     auto gradient_start_color = color_to_use;
     gradient_start_color.set_alpha(0);
 
-    painter.fill_rect_with_linear_gradient(gradient_rect, Array { Gfx::ColorStop { gradient_start_color, 0.5f - gradient_half_width_percentage_offset }, Gfx::ColorStop { color_to_use, 0.5f + gradient_half_width_percentage_offset } }, rotation_degrees);
+    {
+        Gfx::PainterStateSaver saver(painter);
+        if (gradient_clip.has_value())
+            painter.add_clip_rect(*gradient_clip);
+        painter.fill_rect_with_linear_gradient(gradient_rect, Array { Gfx::ColorStop { gradient_start_color, 0.5f - gradient_half_width_percentage_offset }, Gfx::ColorStop { color_to_use, 0.5f + gradient_half_width_percentage_offset } }, rotation_degrees);
+    }
 
     if (with_guidelines) {
         Gfx::AntiAliasingPainter aa_painter = Gfx::AntiAliasingPainter(painter);

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -216,12 +216,14 @@ void GradientTool::rasterize_gradient()
 {
     if (!has_gradient_start_end())
         return;
+    auto layer = m_editor->active_layer();
+    if (!layer)
+        return;
 
-    GUI::Painter painter(m_editor->active_layer()->get_scratch_edited_bitmap());
+    GUI::Painter painter(layer->get_scratch_edited_bitmap());
     draw_gradient(painter);
-
-    m_editor->did_complete_action("Gradient Tool"sv);
-
+    layer->did_modify_bitmap(layer->get_scratch_edited_bitmap().rect());
+    m_editor->did_complete_action(tool_name());
     reset();
 }
 

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.h
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.h
@@ -49,7 +49,7 @@ private:
     Gfx::FloatLine m_gradient_end_line;
 
     void reset();
-    void draw_gradient(GUI::Painter&, bool with_guidelines = false, const Gfx::FloatPoint drawing_offset = { 0.0f, 0.0f }, float scale = 1);
+    void draw_gradient(GUI::Painter&, bool with_guidelines = false, const Gfx::FloatPoint drawing_offset = { 0.0f, 0.0f }, float scale = 1, Optional<Gfx::IntRect const&> gradient_clip = {});
     void rasterize_gradient();
     void calculate_gradient_lines();
     void update_gradient_end_and_derive_start(Gfx::IntPoint const);


### PR DESCRIPTION
This is just a small tweak that stops that gradient tool from painting over the rulers.
At the same time I also prevent the guidelines/handles from being clipped outside the content rect (since you kinda still want to see those even when they're not on the canvas). 

[screen-capture - 2023-01-26T204709.374.webm](https://user-images.githubusercontent.com/11597044/214947022-b1450036-def2-49dc-a983-ea24554bcd31.webm)

This also now gets the gradient tool working with selections.
