### PR TITLE
LibGfx+icc: ICCProfile's primary_platform() should be optional

### DIFF
--- a/Userland/Libraries/LibGfx/ICCProfile.cpp
+++ b/Userland/Libraries/LibGfx/ICCProfile.cpp
@@ -243,9 +243,13 @@ ErrorOr<void> parse_file_signature(ICCHeader const& header)
     return {};
 }
 
-ErrorOr<PrimaryPlatform> parse_primary_platform(ICCHeader const& header)
+ErrorOr<Optional<PrimaryPlatform>> parse_primary_platform(ICCHeader const& header)
 {
     // ICC v4, 7.2.10 Primary platform field
+    // "If there is no primary platform identified, this field shall be set to zero (00000000h)."
+    if (header.primary_platform == PrimaryPlatform { 0 })
+        return OptionalNone {};
+
     switch (header.primary_platform) {
     case PrimaryPlatform::Apple:
     case PrimaryPlatform::Microsoft:

--- a/Userland/Libraries/LibGfx/ICCProfile.h
+++ b/Userland/Libraries/LibGfx/ICCProfile.h
@@ -572,7 +572,7 @@ public:
 
     u32 on_disk_size() const { return m_on_disk_size; }
     time_t creation_timestamp() const { return m_creation_timestamp; }
-    PrimaryPlatform primary_platform() const { return m_primary_platform; }
+    Optional<PrimaryPlatform> primary_platform() const { return m_primary_platform; }
     Flags flags() const { return m_flags; }
     Optional<DeviceManufacturer> device_manufacturer() const { return m_device_manufacturer; }
     Optional<DeviceModel> device_model() const { return m_device_model; }
@@ -609,7 +609,7 @@ private:
     ColorSpace m_data_color_space {};
     ColorSpace m_connection_space {};
     time_t m_creation_timestamp { 0 };
-    PrimaryPlatform m_primary_platform {};
+    Optional<PrimaryPlatform> m_primary_platform {};
     Flags m_flags;
     Optional<DeviceManufacturer> m_device_manufacturer;
     Optional<DeviceModel> m_device_model;

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -44,7 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     outln("      data color space: {}", Gfx::ICC::data_color_space_name(profile->data_color_space()));
     outln("      connection space: {}", Gfx::ICC::profile_connection_space_name(profile->connection_space()));
     outln("creation date and time: {}", Core::DateTime::from_timestamp(profile->creation_timestamp()));
-    outln("      primary platform: {}", Gfx::ICC::primary_platform_name(profile->primary_platform()));
+    out_optional("      primary platform", profile->primary_platform().map([](auto platform) { return primary_platform_name(platform); }));
 
     auto flags = profile->flags();
     outln("                 flags: 0x{:08x}", flags.bits());


### PR DESCRIPTION
Found by running `icc` on a jpeg file produced by a Pixel phone after #17195.