### PR TITLE
LibWeb: Correct logic in TreeWalker::next_node()

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
+++ b/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
@@ -187,7 +187,7 @@ JS::ThrowCompletionOr<JS::GCPtr<Node>> TreeWalker::next_node()
             node = *node->first_child();
 
             // 2. Set result to the result of filtering node within this.
-            auto result = TRY(filter(*node));
+            result = TRY(filter(*node));
 
             // 3. If result is FILTER_ACCEPT, then set this’s current to node and return node.
             if (result == NodeFilter::FILTER_ACCEPT) {


### PR DESCRIPTION
We were creating a new `result` variable here, when we should have been assigning to the original one.