### PR TITLE
Kernel+Utilities: Thread-related syscalls amendments

### DIFF
--- a/Kernel/Arch/x86_64/RegisterState.h
+++ b/Kernel/Arch/x86_64/RegisterState.h
@@ -62,7 +62,7 @@ struct [[gnu::packed]] RegisterState {
 
     void capture_syscall_params(FlatPtr& function, FlatPtr& arg1, FlatPtr& arg2, FlatPtr& arg3, FlatPtr& arg4) const
     {
-        // The syscall instruction clobbers rcx, so we must use a different calling convention to 32-bit.
+        // The syscall instruction clobbers rcx, so it cannot be used here, cf. `invoke` functions in Syscall.h.
         function = rax;
         arg1 = rdx;
         arg2 = rdi;

--- a/Kernel/Arch/x86_64/SafeMem.cpp
+++ b/Kernel/Arch/x86_64/SafeMem.cpp
@@ -70,7 +70,7 @@ NEVER_INLINE bool safe_memcpy(void* dest_ptr, void const* src_ptr, size_t n, voi
             "safe_memcpy_ins_1: \n"
             "rep movsq \n"
             ".globl safe_memcpy_1_faulted \n"
-            "safe_memcpy_1_faulted: \n" // handle_safe_access_fault() set edx/rdx to the fault address!
+            "safe_memcpy_1_faulted: \n" // handle_safe_access_fault() set rdx to the fault address!
             : "=S"(src),
             "=D"(dest),
             "=c"(remainder),
@@ -92,7 +92,7 @@ NEVER_INLINE bool safe_memcpy(void* dest_ptr, void const* src_ptr, size_t n, voi
         "safe_memcpy_ins_2: \n"
         "rep movsb \n"
         ".globl safe_memcpy_2_faulted \n"
-        "safe_memcpy_2_faulted: \n" // handle_safe_access_fault() set edx/rdx to the fault address!
+        "safe_memcpy_2_faulted: \n" // handle_safe_access_fault() set rdx to the fault address!
         : "=c"(remainder),
         [fault_at] "=d"(fault_at)
         : "S"(src),
@@ -126,7 +126,7 @@ NEVER_INLINE ssize_t safe_strnlen(char const* str, size_t max_n, void*& fault_at
         "inc %[count] \n"
         "jmp 1b \n"
         ".globl safe_strnlen_faulted \n"
-        "safe_strnlen_faulted: \n" // handle_safe_access_fault() set edx/rdx to the fault address!
+        "safe_strnlen_faulted: \n" // handle_safe_access_fault() set rdx to the fault address!
         "xor %[count_on_error], %[count_on_error] \n"
         "dec %[count_on_error] \n" // return -1 on fault
         "2:"
@@ -161,7 +161,7 @@ NEVER_INLINE bool safe_memset(void* dest_ptr, int c, size_t n, void*& fault_at)
             "safe_memset_ins_1: \n"
             "rep stosq \n"
             ".globl safe_memset_1_faulted \n"
-            "safe_memset_1_faulted: \n" // handle_safe_access_fault() set edx/rdx to the fault address!
+            "safe_memset_1_faulted: \n" // handle_safe_access_fault() set rdx to the fault address!
             : "=D"(dest),
             "=c"(remainder),
             [fault_at] "=d"(fault_at)
@@ -182,7 +182,7 @@ NEVER_INLINE bool safe_memset(void* dest_ptr, int c, size_t n, void*& fault_at)
         "safe_memset_ins_2: \n"
         "rep stosb \n"
         ".globl safe_memset_2_faulted \n"
-        "safe_memset_2_faulted: \n" // handle_safe_access_fault() set edx/rdx to the fault address!
+        "safe_memset_2_faulted: \n" // handle_safe_access_fault() set rdx to the fault address!
         : "=D"(dest),
         "=c"(remainder),
         [fault_at] "=d"(fault_at)
@@ -322,7 +322,7 @@ bool handle_safe_access_fault(RegisterState& regs, FlatPtr fault_address)
     if (ip >= (FlatPtr)&start_of_safemem_atomic_text && ip < (FlatPtr)&end_of_safemem_atomic_text) {
         // If we detect that a fault happened in one of the atomic safe_
         // functions, resume at the appropriate _faulted label and set
-        // the edx/rdx register to 1 to indicate an error
+        // the rdx register to 1 to indicate an error
         if (ip == (FlatPtr)safe_atomic_fetch_add_relaxed_ins)
             ip = (FlatPtr)safe_atomic_fetch_add_relaxed_faulted;
         else if (ip == (FlatPtr)safe_atomic_exchange_relaxed_ins)

--- a/Kernel/Arch/x86_64/TSS.h
+++ b/Kernel/Arch/x86_64/TSS.h
@@ -14,27 +14,7 @@ VALIDATE_IS_X86()
 
 namespace Kernel {
 
-struct [[gnu::packed]] TSS32 {
-    u16 backlink, __blh;
-    u32 esp0;
-    u16 ss0, __ss0h;
-    u32 esp1;
-    u16 ss1, __ss1h;
-    u32 esp2;
-    u16 ss2, __ss2h;
-    u32 cr3, eip, eflags;
-    u32 eax, ecx, edx, ebx, esp, ebp, esi, edi;
-    u16 es, __esh;
-    u16 cs, __csh;
-    u16 ss, __ssh;
-    u16 ds, __dsh;
-    u16 fs, __fsh;
-    u16 gs, __gsh;
-    u16 ldt, __ldth;
-    u16 trace, iomapbase;
-};
-
-struct [[gnu::packed]] TSS64 {
+struct [[gnu::packed]] TSS {
     u32 __1; // Link?
     u32 rsp0l;
     u32 rsp0h;
@@ -61,7 +41,5 @@ struct [[gnu::packed]] TSS64 {
     u16 __4;
     u16 iomapbase;
 };
-
-using TSS = TSS64;
 
 }

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -401,7 +401,7 @@ void signal_trampoline_dummy()
         // Note that the stack is currently aligned to 16 bytes as we popped the extra entries above.
         // call the signal handler
         "call rcx\n"
-        // Current stack state is just saved_rax, ucontext, signal_info, fpu_state.
+        // Current stack state is just saved_result, ucontext, signal_info, fpu_state.
         // syscall SC_sigreturn
         "mov rax, %P0\n"
         "syscall\n"

--- a/Kernel/Syscalls/fallocate.cpp
+++ b/Kernel/Syscalls/fallocate.cpp
@@ -13,6 +13,7 @@
 namespace Kernel {
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_fallocate.html
+// TODO: The offset and length could be passed by value instead of a pointer
 ErrorOr<FlatPtr> Process::sys$posix_fallocate(int fd, Userspace<off_t const*> userspace_offset, Userspace<off_t const*> userspace_length)
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);

--- a/Kernel/Syscalls/ftruncate.cpp
+++ b/Kernel/Syscalls/ftruncate.cpp
@@ -9,8 +9,7 @@
 
 namespace Kernel {
 
-// NOTE: The length is passed by pointer because off_t is 64bit,
-// hence it can't be passed by register on 32bit platforms.
+// TODO: The length could be passed by value instead of a pointer
 ErrorOr<FlatPtr> Process::sys$ftruncate(int fd, Userspace<off_t const*> userspace_length)
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);

--- a/Kernel/Syscalls/lseek.cpp
+++ b/Kernel/Syscalls/lseek.cpp
@@ -9,6 +9,7 @@
 
 namespace Kernel {
 
+// TODO: The offset could be passed by value instead of a pointer
 ErrorOr<FlatPtr> Process::sys$lseek(int fd, Userspace<off_t*> userspace_offset, int whence)
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);

--- a/Kernel/Syscalls/profiling.cpp
+++ b/Kernel/Syscalls/profiling.cpp
@@ -18,6 +18,8 @@ u64 g_profiling_event_mask;
 
 // NOTE: event_mask needs to be passed as a pointer as u64
 //       does not fit into a register on 32bit architectures.
+// TODO: thatʼs not the case anymore as we support 64-bit architectures only,
+//       so this can be simplified a little
 ErrorOr<FlatPtr> Process::sys$profiling_enable(pid_t pid, Userspace<u64 const*> userspace_event_mask)
 {
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);

--- a/Kernel/Syscalls/read.cpp
+++ b/Kernel/Syscalls/read.cpp
@@ -101,8 +101,7 @@ ErrorOr<FlatPtr> Process::read_impl(int fd, Userspace<u8*> buffer, size_t size)
     return TRY(description->read(user_buffer, size));
 }
 
-// NOTE: The offset is passed by pointer because off_t is 64bit,
-// hence it can't be passed by register on 32bit platforms.
+// TODO: The offset could be passed by value instead of a pointer
 ErrorOr<FlatPtr> Process::sys$pread(int fd, Userspace<u8*> buffer, size_t size, Userspace<off_t const*> userspace_offset)
 {
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);

--- a/Kernel/Syscalls/sigaction.cpp
+++ b/Kernel/Syscalls/sigaction.cpp
@@ -85,7 +85,7 @@ ErrorOr<FlatPtr> Process::sys$sigreturn(RegisterState& registers)
     auto stack_ptr = registers.userspace_sp();
 
     // Stack state (created by the signal trampoline):
-    // saved_ax, ucontext, signal_info, fpu_state?.
+    // saved_result, ucontext, signal_info, fpu_state?.
 
     // The FPU state is at the top here, pop it off and restore it.
     // FIXME: The stack alignment is off by 8 bytes here, figure this out and remove this excessively aligned object.
@@ -99,7 +99,7 @@ ErrorOr<FlatPtr> Process::sys$sigreturn(RegisterState& registers)
     auto ucontext = TRY(copy_typed_from_user<__ucontext>(stack_ptr));
     stack_ptr += sizeof(__ucontext);
 
-    auto saved_ax = TRY(copy_typed_from_user<FlatPtr>(stack_ptr));
+    auto saved_result = TRY(copy_typed_from_user<FlatPtr>(stack_ptr));
 
     Thread::current()->m_signal_mask = ucontext.uc_sigmask;
     Thread::current()->m_currently_handled_signal = 0;
@@ -114,7 +114,7 @@ ErrorOr<FlatPtr> Process::sys$sigreturn(RegisterState& registers)
     registers.rsp = sp;
 #endif
 
-    return saved_ax;
+    return saved_result;
 }
 
 ErrorOr<void> Process::remap_range_as_stack(FlatPtr address, size_t size)

--- a/Kernel/Syscalls/times.cpp
+++ b/Kernel/Syscalls/times.cpp
@@ -23,6 +23,7 @@ ErrorOr<FlatPtr> Process::sys$times(Userspace<tms*> user_times)
     times.tms_cstime = m_ticks_in_kernel_for_dead_children;
 
     TRY(copy_to_user(user_times, &times));
+    // TODO: applying positive mask seems to be unnecessary…?
     return TimeManagement::the().uptime_ms() & 0x7fffffff;
 }
 

--- a/Kernel/Syscalls/uname.cpp
+++ b/Kernel/Syscalls/uname.cpp
@@ -6,8 +6,10 @@
  */
 
 #include <AK/TypedTransfer.h>
+#include <Kernel/Arch/Processor.h>
 #include <Kernel/Process.h>
 #include <Kernel/Version.h>
+#include <string.h>
 
 namespace Kernel {
 
@@ -16,25 +18,22 @@ ErrorOr<FlatPtr> Process::sys$uname(Userspace<utsname*> user_buf)
     VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::stdio));
 
-    utsname buf
-    {
+    utsname buf {
         "SerenityOS",
-            {}, // Hostname, filled in below.
-            {}, // "Release" (1.0-dev), filled in below.
-            {}, // "Revision" (git commit hash), filled in below.
-#if ARCH(X86_64)
-            "x86_64",
-#elif ARCH(AARCH64)
-            "AArch64",
-#else
-#    error Unknown architecture
-#endif
+        {}, // Hostname, filled in below.
+        {}, // "Release" (1.0-dev), filled in below.
+        {}, // "Revision" (git commit hash), filled in below.
+        {}, // "Machine" (platform/architecture), filled in below.
     };
 
     auto version_string = TRY(KString::formatted("{}.{}-dev", SERENITY_MAJOR_REVISION, SERENITY_MINOR_REVISION));
     AK::TypedTransfer<u8>::copy(reinterpret_cast<u8*>(buf.release), version_string->bytes().data(), min(version_string->length(), UTSNAME_ENTRY_LEN - 1));
 
     AK::TypedTransfer<u8>::copy(reinterpret_cast<u8*>(buf.version), SERENITY_VERSION.bytes().data(), min(SERENITY_VERSION.length(), UTSNAME_ENTRY_LEN - 1));
+
+    if (!Processor::platform_string().copy_characters_to_buffer(buf.machine, UTSNAME_ENTRY_LEN - 1)) {
+        return EILSEQ;
+    }
 
     hostname().with_shared([&](auto const& name) {
         auto length = min(name->length(), UTSNAME_ENTRY_LEN - 1);

--- a/Kernel/Syscalls/write.cpp
+++ b/Kernel/Syscalls/write.cpp
@@ -11,8 +11,7 @@
 
 namespace Kernel {
 
-// NOTE: The offset is passed by pointer because off_t is 64bit,
-// hence it can't be passed by register on 32bit platforms.
+// TODO: The offset could be passed by value instead of a pointer
 ErrorOr<FlatPtr> Process::sys$pwritev(int fd, Userspace<const struct iovec*> iov, int iov_count, Userspace<off_t const*> userspace_offset)
 {
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);

--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -725,7 +725,7 @@ NEVER_INLINE void signal_trampoline_dummy()
         "call ecx\n"
         // drop the 4 arguments
         "add esp, 16\n"
-        // Current stack state is just saved_eax, ucontext, signal_info, fpu_state?.
+        // Current stack state is just saved_result, ucontext, signal_info, fpu_state?.
         // syscall SC_sigreturn
         "mov eax, %P0\n"
         "int 0x82\n"

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1352,7 +1352,7 @@ int Emulator::virt$sigreturn()
     };
 
     // State from signal trampoline (note that we're assuming i386 here):
-    // saved_ax, ucontext, signal_info, fpu_state.
+    // saved_result, ucontext, signal_info, fpu_state.
 
     // Drop the FPU state
     // FIXME: Read and restore from this.

--- a/Userland/Utilities/functrace.cpp
+++ b/Userland/Utilities/functrace.cpp
@@ -50,18 +50,23 @@ static void print_syscall(PtraceRegisters& regs, size_t depth)
     StringView begin_color = g_should_output_color ? "\033[34;1m"sv : ""sv;
     StringView end_color = g_should_output_color ? "\033[0m"sv : ""sv;
 #if ARCH(X86_64)
-    outln("=> {}SC_{}({:#x}, {:#x}, {:#x}){}",
+    outln("=> {}SC_{}({:#x}, {:#x}, {:#x}, {:#x}){}",
         begin_color,
         Syscall::to_string((Syscall::Function)regs.rax),
         regs.rdx,
-        regs.rcx,
+        regs.rdi,
         regs.rbx,
+        regs.rsi,
         end_color);
 #elif ARCH(AARCH64)
-    (void)regs;
-    (void)begin_color;
-    (void)end_color;
-    TODO_AARCH64();
+    outln("=> {}SC_{}({:#x}, {:#x}, {:#x}, {:#x}){}",
+        begin_color,
+        Syscall::to_string((Syscall::Function)regs.x[8]),
+        regs.x[1],
+        regs.x[2],
+        regs.x[3],
+        regs.x[4],
+        end_color);
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -703,86 +703,505 @@ static ErrorOr<void> format_syscall(FormattedSyscallBuilder& builder, Syscall::F
 
     ResultType result_type { Int };
     switch (syscall_function) {
-    case SC_clock_gettime:
-        format_clock_gettime(builder, (clockid_t)arg1, (struct timespec*)arg2);
+    case SC_emuctl:
+        // () → ENOSYS
         break;
-    case SC_close:
-        format_close(builder, (int)arg1);
+    case SC_yield:
+        // () → 0
         break;
-    case SC_connect:
-        format_connect(builder, (int)arg1, (const struct sockaddr*)arg2, (socklen_t)arg3);
+    case SC_sync:
+        // () → 0
+        break;
+    case SC_beep:
+        // () → 0
+        break;
+    case SC_create_inode_watcher:
+        // (u32 flags) → (int fd)
+        break;
+    case SC_inode_watcher_add_watch:
+        // (Userspace<Syscall::SC_inode_watcher_add_watch_params const*> user_params) → (int wd)
+        break;
+    case SC_inode_watcher_remove_watch:
+        // (int fd, int wd) → 0
         break;
     case SC_dbgputstr:
+        // (Userspace<char const*> characters, size_t size) → (size_t string_length)
         format_dbgputstr(builder, (char*)arg1, (size_t)arg2);
         break;
-    case SC_exit:
-        format_exit(builder, (int)arg1);
-        result_type = Void;
+    case SC_dump_backtrace:
+        // () → 0
         break;
-    case SC_fstat:
-        format_fstat(builder, (int)arg1, (struct stat*)arg2);
-        result_type = Ssize;
+    case SC_gettid:
+        // () → (pid_t tid)
         break;
-    case SC_chdir:
-        format_chdir(builder, (char const*)arg1, (size_t)arg2);
-        result_type = Int;
+    case SC_setsid:
+        // () → (pid_t sid)
         break;
-    case SC_getrandom:
-        format_getrandom(builder, (void*)arg1, (size_t)arg2, (unsigned)arg3);
+    case SC_getsid:
+        // (pid_t pid) → (pid_t sid)
         break;
-    case SC_ioctl:
-        format_ioctl(builder, (int)arg1, (unsigned)arg2, (void*)arg3);
+    case SC_setpgid:
+        // (pid_t pid, pid_t pgid) → 0
         break;
-    case SC_lseek:
-        format_lseek(builder, (int)arg1, (off_t)arg2, (int)arg3);
+    case SC_getpgrp:
+        // () → (pid_t pgid)
         break;
-    case SC_mmap:
-        TRY(format_mmap(builder, (Syscall::SC_mmap_params*)arg1));
-        result_type = VoidP;
+    case SC_getpgid:
+        // (pid_t pid) → (pid_t pgid)
         break;
-    case SC_mprotect:
-        format_mprotect(builder, (void*)arg1, (size_t)arg2, (int)arg3);
+    case SC_getuid:
+        // () → (uid_t uid)
         break;
-    case SC_munmap:
-        format_munmap(builder, (void*)arg1, (size_t)arg2);
+    case SC_getgid:
+        // () → (gid_t uid)
+        break;
+    case SC_geteuid:
+        // () → (uid_t euid)
+        break;
+    case SC_getegid:
+        // () → (gid_t egid)
+        break;
+    case SC_getpid:
+        // () → (pid_t pid)
+        break;
+    case SC_getppid:
+        // () → (pid_t pid)
+        break;
+    case SC_getresuid:
+        // (Userspace<UserID*> user_ruid, Userspace<UserID*> user_euid, Userspace<UserID*> user_suid) → 0
+        break;
+    case SC_getresgid:
+        // (Userspace<GroupID*> user_rgid, Userspace<GroupID*> user_egid, Userspace<GroupID*> user_sgid) → 0
+        break;
+    case SC_getrusage:
+        // (int who, Userspace<rusage*> user_usage) → 0
+        break;
+    case SC_umask:
+        // (mode_t mask) → (mode_t old_mask)
         break;
     case SC_open:
+        // (Userspace<Syscall::SC_open_params const*> user_params) → (int fd)
         TRY(format_open(builder, (Syscall::SC_open_params*)arg1));
         break;
-    case SC_poll:
-        TRY(format_poll(builder, (Syscall::SC_poll_params*)arg1));
+    case SC_close:
+        // (int fd) → 0
+        format_close(builder, (int)arg1);
         break;
     case SC_read:
+        // (int fd, Userspace<u8*> buffer, size_t size) → (size_t read_count)
         format_read(builder, (int)arg1, (void*)arg2, (size_t)arg3);
         result_type = Ssize;
         break;
-    case SC_realpath:
-        TRY(format_realpath(builder, (Syscall::SC_realpath_params*)arg1, (size_t)res));
+    case SC_pread:
+        // (int fd, Userspace<u8*> buffer, size_t size, Userspace<off_t const*> userspace_offset) → (size_t read_count)
         break;
-    case SC_recvmsg:
-        format_recvmsg(builder, (int)arg1, (struct msghdr*)arg2, (int)arg3);
-        result_type = Ssize;
-        break;
-    case SC_set_mmap_name:
-        TRY(format_set_mmap_name(builder, (Syscall::SC_set_mmap_name_params*)arg1));
-        break;
-    case SC_socket:
-        format_socket(builder, (int)arg1, (int)arg2, (int)arg3);
-        break;
-    case SC_stat:
-        TRY(format_stat(builder, (Syscall::SC_stat_params*)arg1));
+    case SC_readv:
+        // (int fd, Userspace<const struct iovec*> iov, int iov_count) → (int read_count)
         break;
     case SC_write:
+        // (int fd, Userspace<u8 const*> data, size_t size) → (size_t write_count)
         format_write(builder, (int)arg1, (void*)arg2, (size_t)arg3);
         result_type = Ssize;
         break;
-    case SC_getuid:
-    case SC_geteuid:
-    case SC_getgid:
-    case SC_getegid:
-    case SC_getpid:
-    case SC_getppid:
-    case SC_gettid:
+    case SC_pwritev:
+        // (int fd, Userspace<const struct iovec*> iov, int iov_count, Userspace<off_t const*> userspace_offset) → (int write_count)
+        break;
+    case SC_fstat:
+        // (int fd, Userspace<stat*> user_statbuf) → 0
+        format_fstat(builder, (int)arg1, (struct stat*)arg2);
+        result_type = Ssize;
+        break;
+    case SC_stat:
+        // (Userspace<Syscall::SC_stat_params const*> user_params) → 0
+        TRY(format_stat(builder, (Syscall::SC_stat_params*)arg1));
+        break;
+    case SC_annotate_mapping:
+        // (Userspace<void*> address, int flags) → 0
+        break;
+    case SC_lseek:
+        // (int fd, Userspace<off_t*> userspace_offset, int whence) → 0
+        format_lseek(builder, (int)arg1, (off_t)arg2, (int)arg3);
+        break;
+    case SC_ftruncate:
+        // (int fd, Userspace<off_t const*> userspace_length) → 0
+        break;
+    case SC_posix_fallocate:
+        // (int fd, Userspace<off_t const*> userspace_offset, Userspace<off_t const*> userspace_length) → 0
+        break;
+    case SC_kill:
+        // (pid_t pid_or_pgid, int sig) → 0
+        break;
+    case SC_exit:
+        // (int status) → UNREACHABLE
+        format_exit(builder, (int)arg1);
+        result_type = Void;
+        break;
+    case SC_sigreturn:
+        // (RegisterState& registers) → (FlatPtr return_value)
+        break;
+    case SC_waitid:
+        // (Userspace<Syscall::SC_waitid_params const*> user_params) → 0
+        break;
+    case SC_mmap:
+        // (Userspace<Syscall::SC_mmap_params const*> user_params) → (FlatPtr address)
+        TRY(format_mmap(builder, (Syscall::SC_mmap_params*)arg1));
+        result_type = VoidP;
+        break;
+    case SC_mremap:
+        // (Userspace<Syscall::SC_mremap_params const*> user_params) → (FlatPtr new_region)
+        break;
+    case SC_munmap:
+        // (Userspace<void*> addres, size_t size) → 0
+        format_munmap(builder, (void*)arg1, (size_t)arg2);
+        break;
+    case SC_set_mmap_name:
+        // (Userspace<Syscall::SC_set_mmap_name_params const*> user_params) → 0
+        TRY(format_set_mmap_name(builder, (Syscall::SC_set_mmap_name_params*)arg1));
+        break;
+    case SC_mprotect:
+        // (Userspace<void*> addr, size_t size, int prot) → 0
+        format_mprotect(builder, (void*)arg1, (size_t)arg2, (int)arg3);
+        break;
+    case SC_madvise:
+        // (Userspace<void*> address, size_t size, int advice) → (1|0 was_purged)
+        break;
+    case SC_msync:
+        // (Userspace<void*> address, size_t size, int flags) → 0
+        break;
+    case SC_purge:
+        // (int mode) → (size_t purged_page_count)
+        break;
+    case SC_poll:
+        // (Userspace<Syscall::SC_poll_params const*> user_params) → (int fds_with_revents)
+        TRY(format_poll(builder, (Syscall::SC_poll_params*)arg1));
+        break;
+    case SC_get_dir_entries:
+        // s(int fd, Userspace<void*> user_buffer, size_t user_size) → (size_t count)
+        break;
+    case SC_getcwd:
+        // (Userspace<char*> buffer, size_t size) → (size_t ideal_size)
+        break;
+    case SC_chdir:
+        // (Userspace<char const*> user_path, size_t path_length) → 0
+        format_chdir(builder, (char const*)arg1, (size_t)arg2);
+        result_type = Int;
+        break;
+    case SC_fchdir:
+        // (int fd) → 0
+        break;
+    case SC_adjtime:
+        // (Userspace<timeval const*> user_delta, Userspace<timeval*> user_old_delta) → 0
+        break;
+    case SC_clock_gettime:
+        // (clockid_t clock_id, Userspace<timespec*> user_ts) → 0
+        format_clock_gettime(builder, (clockid_t)arg1, (struct timespec*)arg2);
+        break;
+    case SC_clock_settime:
+        // (clockid_t clock_id, Userspace<timespec const*> user_ts) → 0
+        break;
+    case SC_clock_nanosleep:
+        // (Userspace<Syscall::SC_clock_nanosleep_params const*> user_params) → 0
+        break;
+    case SC_clock_getres:
+        // (Userspace<Syscall::SC_clock_getres_params const*> user_params) → 0
+        break;
+    case SC_gethostname:
+        // e(Userspace<char*> buffer, size_t size) → 0
+        break;
+    case SC_sethostname:
+        // (Userspace<char const*> buffer, size_t length) → 0
+        break;
+    case SC_uname:
+        // (Userspace<utsname*> user_buf) → 0
+        break;
+    case SC_readlink:
+        // (Userspace<Syscall::SC_readlink_params const*> user_params) → (size_t link_target_size)
+        break;
+    case SC_fork:
+        // (RegisterState& regs) → (pid_t child_pid)
+        break;
+    case SC_execve:
+        // (Userspace<Syscall::SC_execve_params const*> user_params) → 0
+        break;
+    case SC_dup2:
+        // (int old_fd, int new_fd) → (int new_fd)
+        break;
+    case SC_sigaction:
+        // (int signum, Userspace<sigaction const*> act, Userspace<sigaction*> old_act) → 0
+        break;
+    case SC_sigaltstack:
+        // (Userspace<stack_t const*> ss, Userspace<stack_t*> old_ss) → 0
+        break;
+    case SC_sigprocmask:
+        // (int how, Userspace<sigset_t const*> set, Userspace<sigset_t*> old_set) → 0
+        break;
+    case SC_sigpending:
+        // (Userspace<sigset_t*> set) → 0
+        break;
+    case SC_sigsuspend:
+        // (Userspace<sigset_t const*> mask) → 0
+        break;
+    case SC_sigtimedwait:
+        // (Userspace<sigset_t const*> set, Userspace<siginfo_t*> info, Userspace<timespec const*> timeout) → (int signal_number)
+        break;
+    case SC_getgroups:
+        // (size_t count, Userspace<GroupID*> user_gids) → 0
+        break;
+    case SC_setgroups:
+        // (size_t count, Userspace<GroupID const*> user_gids) → 0
+        break;
+    case SC_pipe:
+        // (Userspace<int*> pipefd, int flags) → 0
+        break;
+    case SC_killpg:
+        // (pid_t pgrp, int sig) → 0
+        break;
+    case SC_seteuid:
+        // (UserID new_euid) → 0
+        break;
+    case SC_setegid:
+        // (GroupID new_egid) → 0
+        break;
+    case SC_setuid:
+        // (UserID new_uid) → 0
+        break;
+    case SC_setgid:
+        // (GroupID new_gid) → 0
+        break;
+    case SC_setreuid:
+        // (UserID new_ruid, UserID new_euid) → 0
+        break;
+    case SC_setresuid:
+        // (UserID new_ruid, UserID new_euid, UserID new_suid) → 0
+        break;
+    case SC_setregid:
+        // (GroupID new_rgid, GroupID new_egid) → 0
+        break;
+    case SC_setresgid:
+        // (GroupID new_rgid, GroupID new_egid, GroupID new_sgid) → 0
+        break;
+    case SC_alarm:
+        // (unsigned seconds) → (unsigned previous_alarm_remaining)
+        break;
+    case SC_faccessat:
+        // (Userspace<Syscall::SC_faccessat_params const*> user_params) → 0
+        break;
+    case SC_fcntl:
+        // (int fd, int cmd, uintptr_t extra_arg) → 0
+        break;
+    case SC_ioctl:
+        // (int fd, unsigned request, FlatPtr arg) → 0
+        format_ioctl(builder, (int)arg1, (unsigned)arg2, (void*)arg3);
+        break;
+    case SC_mkdir:
+        // (int dirfd, Userspace<char const*> pathname, size_t path_length, mode_t mode) → 0
+        break;
+    case SC_times:
+        // (Userspace<tms*> user_times) → (u64 ms)
+        break;
+    case SC_utime:
+        // (Userspace<char const*> pathname, size_t path_length, Userspace<const struct utimbuf*>) → 0
+        break;
+    case SC_utimensat:
+        // (Userspace<Syscall::SC_utimensat_params const*> user_params) → 0
+        break;
+    case SC_link:
+        // (Userspace<Syscall::SC_link_params const*> user_params) → 0
+        break;
+    case SC_unlink:
+        // (int dirfd, Userspace<char const*> pathname, size_t path_length, int flags) → 0
+        break;
+    case SC_symlink:
+        // (Userspace<Syscall::SC_symlink_params const*> user_params) → 0
+        break;
+    case SC_rmdir:
+        // (Userspace<char const*> pathname, size_t path_length) → 0
+        break;
+    case SC_mount:
+        // (Userspace<Syscall::SC_mount_params const*> user_params) → 0
+        break;
+    case SC_umount:
+        // (Userspace<char const*> mountpoint, size_t mountpoint_length) → 0
+        break;
+    case SC_chmod:
+        // (Userspace<Syscall::SC_chmod_params const*> user_params) → 0
+        break;
+    case SC_fchmod:
+        // (int fd, mode_t mode) → 0
+        break;
+    case SC_chown:
+        // (Userspace<Syscall::SC_chown_params const*> user_params) → 0
+        break;
+    case SC_fchown:
+        // (int fd, UserID uid, GroupID gid) → 0
+        break;
+    case SC_fsync:
+        // (int fd) → 0
+        break;
+    case SC_socket:
+        // (int domain, int type, int protocol) → (int fd)
+        format_socket(builder, (int)arg1, (int)arg2, (int)arg3);
+        break;
+    case SC_bind:
+        // (int sockfd, Userspace<sockaddr const*> addr, socklen_t address_length) → 0
+        break;
+    case SC_listen:
+        // (int sockfd, int backlog) → 0
+        break;
+    case SC_accept4:
+        // (Userspace<Syscall::SC_accept4_params const*> user_params) → (int fd)
+        break;
+    case SC_connect:
+        // (int sockfd, Userspace<sockaddr const*> user_address, socklen_t user_address_size) → 0
+        format_connect(builder, (int)arg1, (const struct sockaddr*)arg2, (socklen_t)arg3);
+        break;
+    case SC_shutdown:
+        // (int sockfd, int how) → 0;  typeof ‘howʼ = SHUT_RD | SHUT_WD | SHUT_RDWR
+        break;
+    case SC_sendmsg:
+        // (int sockfd, Userspace<const struct msghdr*> user_msg, int flags) → (size_t write_count)
+        break;
+    case SC_recvmsg:
+        // (int sockfd, Userspace<struct msghdr*>, int flags) → (size_t read_count)
+        format_recvmsg(builder, (int)arg1, (struct msghdr*)arg2, (int)arg3);
+        result_type = Ssize;
+        break;
+    case SC_getsockopt:
+        // (Userspace<Syscall::SC_getsockopt_params const*> user_params) → 0
+        break;
+    case SC_setsockopt:
+        // (Userspace<Syscall::SC_setsockopt_params const*> user_params) → 0
+        break;
+    case SC_getsockname:
+        // (Userspace<Syscall::SC_getsockname_params const*> user_params) → 0
+        break;
+    case SC_getpeername:
+        // (Userspace<Syscall::SC_getpeername_params const*> user_params) → 0
+        break;
+    case SC_socketpair:
+        // (Userspace<Syscall::SC_socketpair_params const*> user_params) → 0
+        break;
+    case SC_scheduler_set_parameters:
+        // (Userspace<Syscall::SC_scheduler_parameters_params const*> user_params) → 0
+        break;
+    case SC_scheduler_get_parameters:
+        // (Userspace<Syscall::SC_scheduler_parameters_params*> user_params) → 0
+        break;
+    case SC_create_thread:
+        // (void* (*entry)(void*), Userspace<Syscall::SC_create_thread_params const*> user_params) → (pid_t tid)
+        break;
+    case SC_exit_thread:
+        // (Userspace<void*> exit_value, Userspace<void*> stack_location, size_t stack_size) → UNREACHABLE
+        result_type = Void;
+        break;
+    case SC_join_thread:
+        // (pid_t tid, Userspace<void**> exit_value) → 0
+        break;
+    case SC_detach_thread:
+        // (pid_t tid) → 0
+        break;
+    case SC_set_thread_name:
+        // (pid_t tid, Userspace<char const*> buffer, size_t buffer_size) → 0
+        break;
+    case SC_get_thread_name:
+        // (pid_t tid, Userspace<char*> buffer, size_t buffer_size) → 0
+        break;
+    case SC_kill_thread:
+        // (pid_t tid, int signal) → 0
+        break;
+    case SC_rename:
+        // (Userspace<Syscall::SC_rename_params const*> user_params) → 0
+        break;
+    case SC_mknod:
+        // (Userspace<Syscall::SC_mknod_params const*> user_params) → 0
+        break;
+    case SC_realpath:
+        // (Userspace<Syscall::SC_realpath_params const*> user_params) → (size_t ideal_size)
+        TRY(format_realpath(builder, (Syscall::SC_realpath_params*)arg1, (size_t)res));
+        break;
+    case SC_getrandom:
+        // (Userspace<void*> buffer, size_t buffer_size, unsigned int flags) → (size_t count)
+        format_getrandom(builder, (void*)arg1, (size_t)arg2, (unsigned)arg3);
+        break;
+    case SC_getkeymap:
+        // (Userspace<Syscall::SC_getkeymap_params const*> user_params) → 0
+        break;
+    case SC_setkeymap:
+        // (Userspace<Syscall::SC_setkeymap_params const*> user_params) → 0
+        break;
+    case SC_profiling_enable:
+        // (pid_t, Userspace<u64 const*>) → 0
+        break;
+    case SC_profiling_disable:
+        // (pid_t) → 0
+        break;
+    case SC_profiling_free_buffer:
+        // (pid_t) → 0
+        break;
+    case SC_futex:
+        // (Userspace<Syscall::SC_futex_params const*> user_params) → (…)
+        break;
+    case SC_pledge:
+        // (Userspace<Syscall::SC_pledge_params const*> user_params) → 0
+        break;
+    case SC_unveil:
+        // (Userspace<Syscall::SC_unveil_params const*> user_params) → 0
+        break;
+    case SC_perf_event:
+        // (int type, FlatPtr arg1, FlatPtr arg2) → 0
+        break;
+    case SC_perf_register_string:
+        // (Userspace<char const*> user_string, size_t user_string_length) → (FlatPtr string_index) | 0
+        break;
+    case SC_get_stack_bounds:
+        // (Userspace<FlatPtr*> stack_base, Userspace<size_t*> stack_size) → 0
+        break;
+    case SC_ptrace:
+        // (Userspace<Syscall::SC_ptrace_params const*> user_params) → 0
+        break;
+    case SC_sendfd:
+        // (int sockfd, int fd) → 0
+        break;
+    case SC_recvfd:
+        // (int sockfd, int options) → (int fd)
+        break;
+    case SC_sysconf:
+        // (int name) → (…);  typeof ‘nameʼ =
+        //   | _SC_MONOTONIC_CLOCK | _SC_NPROCESSORS_CONF | _SC_NPROCESSORS_ONLN | _SC_OPEN_MAX | _SC_HOST_NAME_MAX
+        //   | _SC_TTY_NAME_MAX | _SC_PAGESIZE | _SC_GETPW_R_SIZE_MAX | _SC_CLK_TCK | _SC_SYMLOOP_MAX | _SC_MAPPED_FILES
+        //   | _SC_ARG_MAX | _SC_IOV_MAX
+        break;
+    case SC_disown:
+        // (ProcessID pid) → 0
+        break;
+    case SC_allocate_tls:
+        // (Userspace<char const*> initial_data, size_t size) → (FlatPtr master_tls_region)
+        break;
+    case SC_prctl:
+        // (int option, FlatPtr arg1, FlatPtr arg2) → bool | 0;  typeof ‘optionʼ = PR_GET_DUMPABLE | PR_SET_DUMPABLE
+        // (PR_GET_DUMPABLE option, FlatPtr arg1, FlatPtr arg2) → (bool is_dumpable)
+        // (PR_SET_DUMPABLE option, FlatPtr arg1, FlatPtr arg2) → 0
+        break;
+    case SC_anon_create:
+        // (size_t size, int options) → (int new_fd)
+        break;
+    case SC_statvfs:
+        // (Userspace<Syscall::SC_statvfs_params const*> user_params) → 0
+        break;
+    case SC_fstatvfs:
+        // (int fd, statvfs* buf) → 0
+        break;
+    case SC_map_time_page:
+        // () → (FlatPtr new_region)
+        break;
+    case SC_jail_create:
+        // (Userspace<Syscall::SC_jail_create_params*> user_params) → 0
+        break;
+    case SC_jail_attach:
+        // (Userspace<Syscall::SC_jail_attach_params const*> user_params) → 0
+        break;
+    case SC_get_root_session_id:
+        // (pid_t force_sid) → (pid_t sid)
         break;
     default:
         builder.add_arguments((void*)arg1, (void*)arg2, (void*)arg3, (void*)arg4);


### PR DESCRIPTION
Changes are mostly related to passing the registers between kernel and user space during thread-related syscalls. Refreshed also `strace` and `functrace` utilities as these are dealing with syscalls invocations too.

As a bonus:
* `strace` got ported an almost complete list of syscalls with their signatures left in comments for easier patching;
* `uname` uses `Processor::platform_string()` now; changes the casing for Aarch64 but is unified across the system;
* few comments got stale, so Iʼve updated them – sadly those are mostly `FIXME`s.