### PR TITLE
LibJS+LibLocale: Port the rest of Intl and LibLocale to String

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -268,10 +268,10 @@ bool is_valid_duration_record(Temporal::DurationRecord const& record)
 }
 
 // 1.1.6 GetDurationUnitOptions ( unit, options, baseStyle, stylesList, digitalBase, prevStyle ), https://tc39.es/proposal-intl-duration-format/#sec-getdurationunitoptions
-ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM& vm, DeprecatedString const& unit, Object const& options, StringView base_style, Span<StringView const> styles_list, StringView digital_base, StringView previous_style)
+ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM& vm, String const& unit, Object const& options, StringView base_style, Span<StringView const> styles_list, StringView digital_base, StringView previous_style)
 {
     // 1. Let style be ? GetOption(options, unit, string, stylesList, undefined).
-    auto style_value = TRY(get_option(vm, options, unit, OptionType::String, styles_list, Empty {}));
+    auto style_value = TRY(get_option(vm, options, unit.to_deprecated_string(), OptionType::String, styles_list, Empty {}));
 
     // 2. Let displayDefault be "always".
     auto display_default = "always"sv;
@@ -312,10 +312,10 @@ ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM& vm, Depreca
     }
 
     // 4. Let displayField be the string-concatenation of unit and "Display".
-    auto display_field = DeprecatedString::formatted("{}Display", unit);
+    auto display_field = TRY_OR_THROW_OOM(vm, String::formatted("{}Display", unit));
 
     // 5. Let display be ? GetOption(options, displayField, string, « "auto", "always" », displayDefault).
-    auto display = TRY(get_option(vm, options, display_field, OptionType::String, { "auto"sv, "always"sv }, display_default));
+    auto display = TRY(get_option(vm, options, display_field.to_deprecated_string(), OptionType::String, { "auto"sv, "always"sv }, display_default));
 
     // 6. If prevStyle is "numeric" or "2-digit", then
     if (previous_style == "numeric"sv || previous_style == "2-digit"sv) {
@@ -332,7 +332,7 @@ ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM& vm, Depreca
     }
 
     // 7. Return the Record { [[Style]]: style, [[Display]]: display }.
-    return DurationUnitOptions { .style = move(style), .display = TRY(display.as_string().deprecated_string()) };
+    return DurationUnitOptions { .style = TRY_OR_THROW_OOM(vm, String::from_utf8(style)), .display = TRY(display.as_string().utf8_string()) };
 }
 
 // 1.1.7 PartitionDurationFormatPattern ( durationFormat, duration ), https://tc39.es/proposal-intl-duration-format/#sec-partitiondurationformatpattern

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <AK/Array.h>
-#include <AK/DeprecatedString.h>
 #include <AK/String.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Object.h>
@@ -218,14 +217,14 @@ static constexpr AK::Array<DurationInstanceComponent, 10> duration_instances_com
 };
 
 struct DurationUnitOptions {
-    DeprecatedString style;
-    DeprecatedString display;
+    String style;
+    String display;
 };
 
 ThrowCompletionOr<Temporal::DurationRecord> to_duration_record(VM&, Value input);
 i8 duration_record_sign(Temporal::DurationRecord const&);
 bool is_valid_duration_record(Temporal::DurationRecord const&);
-ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM&, DeprecatedString const& unit, Object const& options, StringView base_style, Span<StringView const> styles_list, StringView digital_base, StringView previous_style);
+ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM&, String const& unit, Object const& options, StringView base_style, Span<StringView const> styles_list, StringView digital_base, StringView previous_style);
 ThrowCompletionOr<Vector<PatternPartition>> partition_duration_format_pattern(VM&, DurationFormat const&, Temporal::DurationRecord const& duration);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
@@ -99,7 +99,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DurationFormatConstructor::construct(Fun
     duration_format->set_data_locale(move(result.data_locale));
 
     // 16. Let prevStyle be the empty String.
-    auto previous_style = DeprecatedString::empty();
+    String previous_style {};
 
     // 17. For each row of Table 1, except the header row, in table order, do
     for (auto const& duration_instances_component : duration_instances_components) {
@@ -110,7 +110,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DurationFormatConstructor::construct(Fun
         auto display_slot = duration_instances_component.set_display_slot;
 
         // c. Let unit be the Unit value.
-        auto unit = duration_instances_component.unit;
+        auto unit = TRY_OR_THROW_OOM(vm, String::from_utf8(duration_instances_component.unit));
 
         // d. Let valueList be the Values value.
         auto value_list = duration_instances_component.values;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/DurationFormatPrototype.h>
+#include <LibJS/Runtime/ThrowableStringBuilder.h>
 
 namespace JS::Intl {
 
@@ -46,16 +47,16 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::format)
     auto parts = MUST_OR_THROW_OOM(partition_duration_format_pattern(vm, *duration_format, record));
 
     // 5. Let result be a new empty String.
-    StringBuilder result;
+    ThrowableStringBuilder result(vm);
 
     // 6. For each Record { [[Type]], [[Value]] } part in parts, do
     for (auto const& part : parts) {
         // a. Set result to the string-concatenation of result and part.[[Value]].
-        result.append(part.value);
+        MUST_OR_THROW_OOM(result.append(part.value));
     }
 
     // 7. Return result.
-    return PrimitiveString::create(vm, result.to_deprecated_string());
+    return PrimitiveString::create(vm, MUST_OR_THROW_OOM(result.to_string()));
 }
 
 // 1.4.4 Intl.DurationFormat.prototype.formatToParts ( duration ), https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.prototype.formatToParts

--- a/Userland/Libraries/LibJS/Runtime/Intl/MathematicalValue.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/MathematicalValue.h
@@ -79,7 +79,7 @@ public:
 
     bool modulo_is_zero(Checked<i32> mod) const;
 
-    int logarithmic_floor() const;
+    ThrowCompletionOr<int> logarithmic_floor(VM&) const;
 
     bool is_equal_to(MathematicalValue const&) const;
     bool is_less_than(MathematicalValue const&) const;

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -995,7 +995,7 @@ struct RawPrecisionResult {
 static ThrowCompletionOr<RawPrecisionResult> to_raw_precision_function(VM& vm, MathematicalValue const& number, int precision, PreferredResult mode)
 {
     RawPrecisionResult result {};
-    result.exponent = number.logarithmic_floor();
+    result.exponent = MUST_OR_THROW_OOM(number.logarithmic_floor(vm));
 
     if (number.is_number()) {
         result.number = number.divided_by_power(result.exponent - precision + 1);
@@ -1506,7 +1506,7 @@ ThrowCompletionOr<int> compute_exponent(VM& vm, NumberFormat& number_format, Mat
     }
 
     // 3. Let magnitude be the base 10 logarithm of x rounded down to the nearest integer.
-    int magnitude = number.logarithmic_floor();
+    int magnitude = MUST_OR_THROW_OOM(number.logarithmic_floor(vm));
 
     // 4. Let exponent be ComputeExponentForMagnitude(numberFormat, magnitude).
     int exponent = MUST_OR_THROW_OOM(compute_exponent_for_magnitude(vm, number_format, magnitude));
@@ -1524,7 +1524,7 @@ ThrowCompletionOr<int> compute_exponent(VM& vm, NumberFormat& number_format, Mat
     }
 
     // 8. Let newMagnitude be the base 10 logarithm of formatNumberResult.[[RoundedNumber]] rounded down to the nearest integer.
-    int new_magnitude = format_number_result.rounded_number.logarithmic_floor();
+    int new_magnitude = MUST_OR_THROW_OOM(format_number_result.rounded_number.logarithmic_floor(vm));
 
     // 9. If newMagnitude is magnitude - exponent, then
     if (new_magnitude == magnitude - exponent) {

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -12,6 +12,7 @@
 #include <LibJS/Runtime/Intl/NumberFormatConstructor.h>
 #include <LibJS/Runtime/Intl/PluralRules.h>
 #include <LibJS/Runtime/Intl/RelativeTimeFormat.h>
+#include <LibJS/Runtime/ThrowableStringBuilder.h>
 
 namespace JS::Intl {
 
@@ -222,22 +223,22 @@ ThrowCompletionOr<Vector<PatternPartitionWithUnit>> make_parts_list(VM& vm, Stri
 }
 
 // 17.5.4 FormatRelativeTime ( relativeTimeFormat, value, unit ), https://tc39.es/ecma402/#sec-FormatRelativeTime
-ThrowCompletionOr<DeprecatedString> format_relative_time(VM& vm, RelativeTimeFormat& relative_time_format, double value, StringView unit)
+ThrowCompletionOr<String> format_relative_time(VM& vm, RelativeTimeFormat& relative_time_format, double value, StringView unit)
 {
     // 1. Let parts be ? PartitionRelativeTimePattern(relativeTimeFormat, value, unit).
     auto parts = TRY(partition_relative_time_pattern(vm, relative_time_format, value, unit));
 
     // 2. Let result be an empty String.
-    StringBuilder result;
+    ThrowableStringBuilder result(vm);
 
     // 3. For each Record { [[Type]], [[Value]], [[Unit]] } part in parts, do
     for (auto& part : parts) {
         // a. Set result to the string-concatenation of result and part.[[Value]].
-        result.append(move(part.value));
+        MUST_OR_THROW_OOM(result.append(part.value));
     }
 
     // 4. Return result.
-    return result.to_deprecated_string();
+    return result.to_string();
 }
 
 // 17.5.5 FormatRelativeTimeToParts ( relativeTimeFormat, value, unit ), https://tc39.es/ecma402/#sec-FormatRelativeTimeToParts

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Array.h>
-#include <AK/DeprecatedString.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibJS/Runtime/Completion.h>
@@ -86,7 +85,7 @@ struct PatternPartitionWithUnit : public PatternPartition {
 ThrowCompletionOr<::Locale::TimeUnit> singular_relative_time_unit(VM&, StringView unit);
 ThrowCompletionOr<Vector<PatternPartitionWithUnit>> partition_relative_time_pattern(VM&, RelativeTimeFormat&, double value, StringView unit);
 ThrowCompletionOr<Vector<PatternPartitionWithUnit>> make_parts_list(VM&, StringView pattern, StringView unit, Vector<PatternPartition> parts);
-ThrowCompletionOr<DeprecatedString> format_relative_time(VM&, RelativeTimeFormat&, double value, StringView unit);
+ThrowCompletionOr<String> format_relative_time(VM&, RelativeTimeFormat&, double value, StringView unit);
 ThrowCompletionOr<Array*> format_relative_time_to_parts(VM&, RelativeTimeFormat&, double value, StringView unit);
 
 }

--- a/Userland/Libraries/LibLocale/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibLocale/DateTimeFormat.cpp
@@ -265,23 +265,23 @@ static ErrorOr<Optional<String>> format_time_zone_offset(StringView locale, Cale
     offset_seconds %= 60;
 
     StringBuilder builder;
-    builder.append(sign);
+    TRY(builder.try_append(sign));
 
     switch (style) {
     // The long format always uses 2-digit hours field and minutes field, with optional 2-digit seconds field.
     case CalendarPatternStyle::LongOffset:
-        builder.appendff("{:02}{}{:02}", offset_hours, separator, offset_minutes);
+        TRY(builder.try_appendff("{:02}{}{:02}", offset_hours, separator, offset_minutes));
         if (offset_seconds > 0)
-            builder.appendff("{}{:02}", separator, offset_seconds);
+            TRY(builder.try_appendff("{}{:02}", separator, offset_seconds));
         break;
 
     // The short format is intended for the shortest representation and uses hour fields without leading zero, with optional 2-digit minutes and seconds fields.
     case CalendarPatternStyle::ShortOffset:
-        builder.appendff("{}", offset_hours);
+        TRY(builder.try_appendff("{}", offset_hours));
         if (offset_minutes > 0) {
-            builder.appendff("{}{:02}", separator, offset_minutes);
+            TRY(builder.try_appendff("{}{:02}", separator, offset_minutes));
             if (offset_seconds > 0)
-                builder.appendff("{}{:02}", separator, offset_seconds);
+                TRY(builder.try_appendff("{}{:02}", separator, offset_seconds));
         }
         break;
 
@@ -290,7 +290,7 @@ static ErrorOr<Optional<String>> format_time_zone_offset(StringView locale, Cale
     }
 
     // The digits used for hours, minutes and seconds fields in this format are the locale's default decimal digits.
-    auto result = TRY(replace_digits_for_number_system(*number_system, builder.to_deprecated_string()));
+    auto result = TRY(replace_digits_for_number_system(*number_system, TRY(builder.to_string())));
     return TRY(String::from_utf8(formats->gmt_format)).replace("{0}"sv, result, ReplaceMode::FirstOnly);
 }
 


### PR DESCRIPTION
The only remaining uses of `DeprecatedString` in Intl is dealing with `PropertyKey`s