### PR TITLE
PixelPaint: Show resize anchors when using the move tool

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -21,6 +21,9 @@
 
 namespace PixelPaint {
 
+constexpr int resize_anchor_min_size = 5;
+constexpr int resize_anchor_max_size = 20;
+
 void MoveTool::on_mousedown(Layer* layer, MouseEvent& event)
 {
     if (event.image_event().button() == GUI::MouseButton::Secondary) {
@@ -200,27 +203,39 @@ void MoveTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
     }
     painter.draw_rect_with_thickness(rect_in_editor, Color::Black, 3);
     painter.draw_rect_with_thickness(rect_in_editor, Color::White, 1);
-    auto resize_anchors = resize_anchor_rects(rect_in_editor);
+    auto size = resize_anchor_size(rect_in_editor);
+    if (size < resize_anchor_min_size)
+        return;
+
+    auto resize_anchors = resize_anchor_rects(rect_in_editor, size);
     for (auto const& resize_anchor_rect : resize_anchors) {
         painter.draw_rect_with_thickness(resize_anchor_rect, Color::Black, 3);
         painter.draw_rect_with_thickness(resize_anchor_rect, Color::White, 1);
     }
 }
 
-Gfx::IntRect MoveTool::resize_anchor_rect_from_position(Gfx::IntPoint position)
+Gfx::IntRect MoveTool::resize_anchor_rect_from_position(Gfx::IntPoint position, int size)
 {
-    constexpr int resize_anchor_size = 20;
-    auto resize_anchor_rect_top_left = position.translated(-resize_anchor_size / 2);
-    return Gfx::IntRect(resize_anchor_rect_top_left, Gfx::IntSize(resize_anchor_size, resize_anchor_size));
+    auto resize_anchor_rect_top_left = position.translated(-size / 2);
+    return Gfx::IntRect(resize_anchor_rect_top_left, Gfx::IntSize(size, size));
 }
 
-Array<Gfx::IntRect, 4> MoveTool::resize_anchor_rects(Gfx::IntRect layer_rect_in_frame_coordinates)
+int MoveTool::resize_anchor_size(Gfx::IntRect layer_rect_in_frame_coordinates)
+{
+    auto shortest_side = min(layer_rect_in_frame_coordinates.width(), layer_rect_in_frame_coordinates.height());
+    if (shortest_side <= 1)
+        return 1;
+    int x = ceilf(shortest_side / 3.0f);
+    return min(resize_anchor_max_size, x);
+}
+
+Array<Gfx::IntRect, 4> MoveTool::resize_anchor_rects(Gfx::IntRect layer_rect_in_frame_coordinates, int resize_anchor_size)
 {
     return Array {
-        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.top_left()),
-        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.top_right().translated(1, 0)),
-        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.bottom_left().translated(0, 1)),
-        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.bottom_right().translated(1))
+        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.top_left(), resize_anchor_size),
+        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.top_right().translated(1, 0), resize_anchor_size),
+        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.bottom_left().translated(0, 1), resize_anchor_size),
+        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.bottom_right().translated(1), resize_anchor_size)
     };
 }
 
@@ -240,11 +255,14 @@ ErrorOr<void> MoveTool::update_cached_preview_bitmap(Layer const* layer)
 
 Optional<ResizeAnchorLocation const> MoveTool::resize_anchor_location_from_cursor_position(Layer const* layer, MouseEvent& event)
 {
-    auto cursor_within_resize_anchor_rect = [&](Gfx::IntPoint layer_position_in_frame_coordinates) {
-        auto resize_anchor_rect = resize_anchor_rect_from_position(layer_position_in_frame_coordinates);
+    auto layer_rect = m_editor->content_to_frame_rect(layer->relative_rect()).to_rounded<int>();
+    auto size = max(resize_anchor_min_size, resize_anchor_size(layer_rect));
+
+    auto cursor_within_resize_anchor_rect = [&event, size](Gfx::IntPoint layer_position_in_frame_coordinates) {
+        auto resize_anchor_rect = resize_anchor_rect_from_position(layer_position_in_frame_coordinates, size);
         return resize_anchor_rect.contains(event.raw_event().position());
     };
-    auto layer_rect = m_editor->content_to_frame_rect(layer->relative_rect()).to_rounded<int>();
+
     if (cursor_within_resize_anchor_rect(layer_rect.top_left()))
         return ResizeAnchorLocation::TopLeft;
     if (cursor_within_resize_anchor_rect(layer_rect.top_right().translated(1, 0)))

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022-2023, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -41,7 +41,7 @@ void MoveTool::on_mousedown(Layer* layer, MouseEvent& event)
     m_layer_being_moved = *layer;
     m_event_origin = image_event.position();
     m_layer_origin = layer->location();
-    m_new_layer_rect = m_editor->active_layer()->rect();
+    m_new_layer_rect = m_editor->active_layer()->relative_rect();
 }
 
 void MoveTool::on_mousemove(Layer* layer, MouseEvent& event)

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -188,17 +188,18 @@ void MoveTool::on_keyup(GUI::KeyEvent& event)
 
 void MoveTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 {
-    if (layer != m_layer_being_moved.ptr() || !m_scaling)
-        return;
-
+    VERIFY(m_editor);
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
-    auto rect_in_editor = m_editor->content_to_frame_rect(m_new_layer_rect).to_rounded<int>();
-    painter.draw_rect(rect_in_editor, Color::Black);
-    if (!m_cached_preview_bitmap.is_null() || !update_cached_preview_bitmap(layer).is_error()) {
+    auto content_rect = m_scaling ? m_new_layer_rect : m_editor->active_layer()->relative_rect();
+    auto rect_in_editor = m_editor->content_to_frame_rect(content_rect).to_rounded<int>();
+    if (m_scaling && (!m_cached_preview_bitmap.is_null() || !update_cached_preview_bitmap(layer).is_error())) {
+        Gfx::PainterStateSaver saver(painter);
         painter.add_clip_rect(m_editor->content_rect());
         painter.draw_scaled_bitmap(rect_in_editor, *m_cached_preview_bitmap, m_cached_preview_bitmap->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
     }
+    painter.draw_rect_with_thickness(rect_in_editor, Color::Black, 3);
+    painter.draw_rect_with_thickness(rect_in_editor, Color::White, 1);
 }
 
 ErrorOr<void> MoveTool::update_cached_preview_bitmap(Layer const* layer)

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -41,8 +41,9 @@ public:
     LayerSelectionMode layer_selection_mode() const { return m_layer_selection_mode; }
 
 private:
-    static Gfx::IntRect resize_anchor_rect_from_position(Gfx::IntPoint);
-    static Array<Gfx::IntRect, 4> resize_anchor_rects(Gfx::IntRect layer_rect_in_frame_coordinates);
+    static int resize_anchor_size(Gfx::IntRect layer_rect_in_frame_coordinates);
+    static Gfx::IntRect resize_anchor_rect_from_position(Gfx::IntPoint, int resize_anchor_size);
+    static Array<Gfx::IntRect, 4> resize_anchor_rects(Gfx::IntRect layer_rect_in_frame_coordinates, int resize_anchor_size);
     virtual StringView tool_name() const override { return "Move Tool"sv; }
     ErrorOr<void> update_cached_preview_bitmap(Layer const* layer);
     Optional<ResizeAnchorLocation const> resize_anchor_location_from_cursor_position(Layer const*, MouseEvent&);

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -41,6 +41,8 @@ public:
     LayerSelectionMode layer_selection_mode() const { return m_layer_selection_mode; }
 
 private:
+    static Gfx::IntRect resize_anchor_rect_from_position(Gfx::IntPoint);
+    static Array<Gfx::IntRect, 4> resize_anchor_rects(Gfx::IntRect layer_rect_in_frame_coordinates);
     virtual StringView tool_name() const override { return "Move Tool"sv; }
     ErrorOr<void> update_cached_preview_bitmap(Layer const* layer);
     Optional<ResizeAnchorLocation const> resize_anchor_location_from_cursor_position(Layer const*, MouseEvent&);


### PR DESCRIPTION
This PR adds a two color border around the layer boundary and the resize anchors, when using the move tool. The resize anchors are now scaled, to ensure that they cannot overlap. This allows the correct cursor to be displayed when zoomed out.

I've also included a drive-by fix for bug I introduced, where single clicking on one of the resize anchors without moving it would cause the layer to jump to the top left of the canvas.

Video:

https://user-images.githubusercontent.com/2817754/215227219-00d3c78c-c5e7-45e1-b9dd-e754a7593d83.mp4

