### PR TITLE
LibWeb: Throw exception if any canvas radial gradient radius is < 0 

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h
@@ -55,7 +55,7 @@ public:
         return my_drawing_state().stroke_style.to_js_fill_or_stoke_style();
     }
 
-    JS::NonnullGCPtr<CanvasGradient> create_radial_gradient(double x0, double y0, double r0, double x1, double y1, double r1)
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasGradient>> create_radial_gradient(double x0, double y0, double r0, double x1, double y1, double r1)
     {
         auto& realm = static_cast<IncludingClass&>(*this).realm();
         return CanvasGradient::create_radial(realm, x0, y0, r0, x1, y1, r1);

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
@@ -25,12 +25,14 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasGradient>> CanvasGradient::create_rad
     return realm.heap().allocate<CanvasGradient>(realm, realm, *radial_gradient);
 }
 
+// https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createlineargradient
 JS::NonnullGCPtr<CanvasGradient> CanvasGradient::create_linear(JS::Realm& realm, double x0, double y0, double x1, double y1)
 {
     auto linear_gradient = Gfx::CanvasLinearGradientPaintStyle::create(Gfx::FloatPoint { x0, y0 }, Gfx::FloatPoint { x1, y1 });
     return realm.heap().allocate<CanvasGradient>(realm, realm, *linear_gradient);
 }
 
+// https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createconicgradient
 JS::NonnullGCPtr<CanvasGradient> CanvasGradient::create_conic(JS::Realm& realm, double start_angle, double x, double y)
 {
     auto conic_gradient = Gfx::CanvasConicGradientPaintStyle::create(Gfx::FloatPoint { x, y }, start_angle);

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
@@ -12,8 +12,15 @@
 
 namespace Web::HTML {
 
-JS::NonnullGCPtr<CanvasGradient> CanvasGradient::create_radial(JS::Realm& realm, double x0, double y0, double r0, double x1, double y1, double r1)
+// https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createradialgradient
+WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasGradient>> CanvasGradient::create_radial(JS::Realm& realm, double x0, double y0, double r0, double x1, double y1, double r1)
 {
+    // If either of r0 or r1 are negative, then an "IndexSizeError" DOMException must be thrown.
+    if (r0 < 0)
+        return WebIDL::IndexSizeError::create(realm, "The r0 passed is less than 0");
+    if (r1 < 0)
+        return WebIDL::IndexSizeError::create(realm, "The r1 passed is less than 0");
+
     auto radial_gradient = Gfx::CanvasRadialGradientPaintStyle::create(Gfx::FloatPoint { x0, y0 }, r0, Gfx::FloatPoint { x1, y1 }, r1);
     return realm.heap().allocate<CanvasGradient>(realm, realm, *radial_gradient);
 }

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.h
@@ -16,7 +16,7 @@ class CanvasGradient final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(CanvasGradient, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<CanvasGradient> create_radial(JS::Realm&, double x0, double y0, double r0, double x1, double y1, double r1);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasGradient>> create_radial(JS::Realm&, double x0, double y0, double r0, double x1, double y1, double r1);
     static JS::NonnullGCPtr<CanvasGradient> create_linear(JS::Realm&, double x0, double y0, double x1, double y1);
     static JS::NonnullGCPtr<CanvasGradient> create_conic(JS::Realm&, double start_angle, double x, double y);
 


### PR DESCRIPTION
This is required in the [spec](https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createradialgradient), but was missed out initially.