### PR TITLE
Let `icc` read embedded profiles in PNG files

### DIFF
--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -54,6 +54,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto profile = TRY(Gfx::ICC::Profile::try_load_from_externally_owned_memory(icc_bytes));
 
+    outln("                  size: {} bytes", profile->on_disk_size());
     out_optional("    preferred CMM type", profile->preferred_cmm_type());
     outln("               version: {}", profile->version());
     outln("          device class: {}", Gfx::ICC::device_class_name(profile->device_class()));


### PR DESCRIPTION
PNG files have several mechanisms for communicating color profiles.

This adds chunk reading for all of them, but only uses the ICC profile for now.
(The others can inform the design of a future ColorSpace class.)

According to https://exiftool.org/TagNames/PNG.html, ICC profiles used
to be stored in text chunks with special names. This doesn't add support
for that yet.

ICC profiles in png files are somewhat uncommon.
https://displaycal.net/icc-color-management-test/sRGB_Gray.png
is one test image.

There are also ICC profiles in a few png files checked in to the
serenity repo, see

    find . -name '*.png' -exec echo {} \; -exec Build/lagom/icc {} \

For example, ./Documentation/WebServer_localhost.png contains
an Apple color profile. Most of the others are `"GIMP built-in sRGB"`.