### PR TITLE
PixelPaint: Enable more text tool keyboard shortcuts

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/TextTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.cpp
@@ -30,6 +30,12 @@ void TextToolEditor::handle_keyevent(Badge<TextTool>, GUI::KeyEvent& event)
     TextEditor::keydown_event(event);
 }
 
+NonnullRefPtrVector<GUI::Action> TextToolEditor::actions()
+{
+    static NonnullRefPtrVector<GUI::Action> actions = { cut_action(), copy_action(), paste_action(), undo_action(), redo_action(), select_all_action() };
+    return actions;
+}
+
 TextTool::TextTool()
 {
     m_text_editor = TextToolEditor::construct();
@@ -280,6 +286,15 @@ bool TextTool::on_keydown(GUI::KeyEvent& event)
         apply_text_to_layer();
         reset_tool();
         return true;
+    }
+
+    // Pass key events that would normally be handled by menu shortcuts to our TextEditor subclass.
+    for (auto& action : m_text_editor->actions()) {
+        auto const& shortcut = action.shortcut();
+        if (event.key() == shortcut.key() && event.modifiers() == shortcut.modifiers()) {
+            action.activate(m_text_editor);
+            return true;
+        }
     }
 
     // Pass the key event off to our TextEditor subclass which handles all text entry features like

--- a/Userland/Applications/PixelPaint/Tools/TextTool.h
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.h
@@ -22,6 +22,7 @@ class TextToolEditor : public GUI::TextEditor {
 public:
     virtual ~TextToolEditor() override = default;
     virtual void handle_keyevent(Badge<TextTool>, GUI::KeyEvent&);
+    NonnullRefPtrVector<GUI::Action> actions();
 
 protected:
     TextToolEditor();


### PR DESCRIPTION
This commit allows the text tools internal TextEditor component to handle keyboard shortcuts that would normally be handled by menu actions.

The shortcuts that can now be used are: 
* Cut (Ctrl+X)
* Copy (Ctrl+C)
* Paste (Ctrl+V)
* Undo (Ctrl+Z)
* Redo  (Ctrl+Shift+Z)
* Select all (Ctrl+A)

Some limitations of this PR include:
* Text tool shortcuts are not currently integrated with PixelPaint menu actions
* The Insert Emoji shortcut doesn't currently work, as that would require the text tool to have a reference to its parent window

Video, showing the text editor shortcuts in action:

https://user-images.githubusercontent.com/2817754/215252471-dbdaa697-689e-436a-80ac-06ebcf8e96e9.mp4




