### PR TITLE
AK: Delete the StringView move-assignment operator for various types

### DIFF
--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -15,6 +15,7 @@
 #ifndef KERNEL
 #    include <AK/DeprecatedFlyString.h>
 #    include <AK/DeprecatedString.h>
+#    include <AK/FlyString.h>
 #    include <AK/String.h>
 #endif
 
@@ -22,6 +23,12 @@ namespace AK {
 
 #ifndef KERNEL
 StringView::StringView(String const& string)
+    : m_characters(reinterpret_cast<char const*>(string.bytes().data()))
+    , m_length(string.bytes().size())
+{
+}
+
+StringView::StringView(FlyString const& string)
     : m_characters(reinterpret_cast<char const*>(string.bytes().data()))
     , m_length(string.bytes().size())
 {

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -49,6 +49,7 @@ public:
     StringView(ByteBuffer const&);
 #ifndef KERNEL
     StringView(String const&);
+    StringView(FlyString const&);
     StringView(DeprecatedString const&);
     StringView(DeprecatedFlyString const&);
 #endif
@@ -56,11 +57,12 @@ public:
     explicit StringView(ByteBuffer&&) = delete;
 #ifndef KERNEL
     explicit StringView(String&&) = delete;
+    explicit StringView(FlyString&&) = delete;
     explicit StringView(DeprecatedString&&) = delete;
     explicit StringView(DeprecatedFlyString&&) = delete;
 #endif
 
-    template<OneOf<String, DeprecatedString, DeprecatedFlyString, ByteBuffer> StringType>
+    template<OneOf<String, FlyString, DeprecatedString, DeprecatedFlyString, ByteBuffer> StringType>
     StringView& operator=(StringType&&) = delete;
 
     [[nodiscard]] constexpr bool is_null() const

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -60,6 +60,9 @@ public:
     explicit StringView(DeprecatedFlyString&&) = delete;
 #endif
 
+    template<OneOf<String, DeprecatedString, DeprecatedFlyString, ByteBuffer> StringType>
+    StringView& operator=(StringType&&) = delete;
+
     [[nodiscard]] constexpr bool is_null() const
     {
         return m_characters == nullptr;


### PR DESCRIPTION
Luckily this didn't catch anything in existing code, but would have caught a UAF I made locally the other day:

```
Build/lagom/Userland/Libraries/LibLocale/DateTimeFormatData.cpp: In member function ‘AK::ErrorOr<Locale::CalendarRangePattern> Locale::CalendarRangePatternImpl::to_unicode_calendar_range_pattern() const’:
Meta/Lagom/../../AK/Try.h:34:6: error: use of deleted function ‘AK::StringView& AK::StringView::operator=(StringType&&) [with StringType = AK::String]’
   34 |     })
      |      ^
Build/lagom/Userland/Libraries/LibLocale/DateTimeFormatData.cpp:9691:44: note: in expansion of macro ‘TRY’
 9691 |         calendar_range_pattern.separator = TRY(String::from_utf8(decode_string(separator)));
      |                                            ^~~
Meta/Lagom/../../AK/StringView.h:64:17: note: declared here
   64 |     StringView& operator=(StringType&&) = delete;
```

This has to be a template because otherwise the compiler thinks invoking `operator=(const AK::StringView&)` is ambiguous with `operator=(String&&)`, even though the latter is deleted.