### PR TITLE
LibWasm: Implement `memory.fill`, `memory.copy`, and `data.drop` instructions

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -696,6 +696,13 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
         }
         return;
     }
+    // https://webassembly.github.io/spec/core/bikeshed/#exec-data-drop
+    case Instructions::data_drop.value(): {
+        auto data_index = instruction.arguments().get<DataIndex>();
+        auto data_address = configuration.frame().module().datas()[data_index.value()];
+        *configuration.store().get(data_address) = DataInstance({});
+        return;
+    }
     case Instructions::table_get.value():
     case Instructions::table_set.value():
         goto unimplemented;
@@ -1006,7 +1013,6 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
         return unary_operation<double, i64, Operators::SaturatingTruncate<i64>>(configuration);
     case Instructions::i64_trunc_sat_f64_u.value():
         return unary_operation<double, i64, Operators::SaturatingTruncate<u64>>(configuration);
-    case Instructions::data_drop.value():
     case Instructions::table_init.value():
     case Instructions::elem_drop.value():
     case Instructions::table_copy.value():


### PR DESCRIPTION
Chances are I'm doing a few things wrong, but we pass **57** more tests this way. :partying_face: 

`test-wasm` before:
![image](https://user-images.githubusercontent.com/222642/215275747-4c278e0c-f986-45ab-96be-29a9ac596e07.png)

`test-wasm` after:
![image](https://user-images.githubusercontent.com/222642/215275645-bcc3f280-9261-427b-8909-3f149d66b159.png)
