### PR TITLE
ImageViewer: Make arrow key shortcuts work

### DIFF
--- a/Userland/Applications/ImageViewer/CMakeLists.txt
+++ b/Userland/Applications/ImageViewer/CMakeLists.txt
@@ -7,6 +7,7 @@ serenity_component(
 
 set(SOURCES
     main.cpp
+        MainWidget.cpp
         ViewWidget.cpp
 )
 

--- a/Userland/Applications/ImageViewer/MainWidget.cpp
+++ b/Userland/Applications/ImageViewer/MainWidget.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "MainWidget.h"
+
+namespace ImageViewer {
+
+MainWidget::MainWidget()
+{
+    set_fill_with_background_color(true);
+    set_layout<GUI::VerticalBoxLayout>();
+    layout()->set_spacing(2);
+}
+
+void MainWidget::keydown_event(GUI::KeyEvent& event)
+{
+    event.ignore();
+}
+
+}

--- a/Userland/Applications/ImageViewer/MainWidget.h
+++ b/Userland/Applications/ImageViewer/MainWidget.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Widget.h>
+
+namespace ImageViewer {
+
+class MainWidget final : public GUI::Widget {
+    C_OBJECT(MainWidget)
+
+public:
+    virtual ~MainWidget() override = default;
+
+private:
+    MainWidget();
+    virtual void keydown_event(GUI::KeyEvent& event) final;
+};
+
+}

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -180,12 +180,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             widget->navigate(ViewWidget::Directions::First);
         });
 
-    auto go_back_action = GUI::Action::create("Go &Back", { Mod_None, Key_Left }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/go-back.png"sv)),
+    auto go_back_action = GUI::Action::create("Go to &Previous", { Mod_None, Key_Left }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/go-back.png"sv)),
         [&](auto&) {
             widget->navigate(ViewWidget::Directions::Back);
         });
 
-    auto go_forward_action = GUI::Action::create("Go &Forward", { Mod_None, Key_Right }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/go-forward.png"sv)),
+    auto go_forward_action = GUI::Action::create("Go to &Next", { Mod_None, Key_Right }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/go-forward.png"sv)),
         [&](auto&) {
             widget->navigate(ViewWidget::Directions::Forward);
         });

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "MainWidget.h"
 #include "ViewWidget.h"
 #include <AK/URL.h>
 #include <LibCore/ArgsParser.h>
@@ -56,10 +57,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("Image Viewer");
 
-    auto root_widget = TRY(window->set_main_widget<GUI::Widget>());
-    root_widget->set_fill_with_background_color(true);
-    root_widget->set_layout<GUI::VerticalBoxLayout>();
-    root_widget->layout()->set_spacing(2);
+    auto root_widget = TRY(window->set_main_widget<MainWidget>());
 
     auto toolbar_container = TRY(root_widget->try_add<GUI::ToolbarContainer>());
     auto main_toolbar = TRY(toolbar_container->try_add<GUI::Toolbar>());


### PR DESCRIPTION
The user can now navigate to the previous and next image using the left and right arrow keys respectively. These shortcuts were previously not working.

I've also renamed the actions from "Go Back" to "Go to Previous" and "Go Forward" to "Go to Next".