### PR TITLE
Everywhere: Remove try prefixes from a bunch of fallible methods with no infallible variant

### DIFF
--- a/AK/DisjointChunks.h
+++ b/AK/DisjointChunks.h
@@ -226,12 +226,10 @@ FixedArray<T> shatter_chunk(FixedArray<T>& source_chunk, size_t start, size_t sl
     if constexpr (IsTriviallyConstructible<T>) {
         TypedTransfer<T>::move(new_chunk.data(), wanted_slice.data(), wanted_slice.size());
     } else {
-        // FIXME: propagate errors
-        auto copied_chunk = MUST(FixedArray<T>::try_create(wanted_slice));
+        auto copied_chunk = FixedArray<T>::create(wanted_slice).release_value_but_fixme_should_propagate_errors();
         new_chunk.swap(copied_chunk);
     }
-    // FIXME: propagate errors
-    auto rest_of_chunk = MUST(FixedArray<T>::try_create(source_chunk.span().slice(start)));
+    auto rest_of_chunk = FixedArray<T>::create(source_chunk.span().slice(start)).release_value_but_fixme_should_propagate_errors();
     source_chunk.swap(rest_of_chunk);
     return new_chunk;
 }

--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -22,9 +22,9 @@ class FixedArray {
 public:
     FixedArray() = default;
 
-    static ErrorOr<FixedArray<T>> try_create(std::initializer_list<T> initializer)
+    static ErrorOr<FixedArray<T>> create(std::initializer_list<T> initializer)
     {
-        auto array = TRY(try_create(initializer.size()));
+        auto array = TRY(create(initializer.size()));
         auto it = initializer.begin();
         for (size_t i = 0; i < array.size(); ++i) {
             array[i] = move(*it);
@@ -33,7 +33,7 @@ public:
         return array;
     }
 
-    static ErrorOr<FixedArray<T>> try_create(size_t size)
+    static ErrorOr<FixedArray<T>> create(size_t size)
     {
         if (size == 0)
             return FixedArray<T>();
@@ -48,17 +48,17 @@ public:
 
     static FixedArray<T> must_create_but_fixme_should_propagate_errors(size_t size)
     {
-        return MUST(try_create(size));
+        return MUST(create(size));
     }
 
     template<size_t N>
-    static ErrorOr<FixedArray<T>> try_create(T (&&array)[N])
+    static ErrorOr<FixedArray<T>> create(T (&&array)[N])
     {
-        return try_create(Span(array, N));
+        return create(Span(array, N));
     }
 
     template<typename U>
-    static ErrorOr<FixedArray<T>> try_create(Span<U> span)
+    static ErrorOr<FixedArray<T>> create(Span<U> span)
     {
         if (span.size() == 0)
             return FixedArray<T>();
@@ -71,9 +71,9 @@ public:
         return FixedArray<T>(new_storage);
     }
 
-    ErrorOr<FixedArray<T>> try_clone() const
+    ErrorOr<FixedArray<T>> clone() const
     {
-        return try_create(span());
+        return create(span());
     }
 
     static size_t storage_allocation_size(size_t size)

--- a/Kernel/Bus/USB/USBConfiguration.cpp
+++ b/Kernel/Bus/USB/USBConfiguration.cpp
@@ -15,7 +15,7 @@ namespace Kernel::USB {
 
 ErrorOr<void> USBConfiguration::enumerate_interfaces()
 {
-    auto descriptor_hierarchy_buffer = TRY(FixedArray<u8>::try_create(m_descriptor.total_length)); // Buffer for us to store the entire hierarchy into
+    auto descriptor_hierarchy_buffer = TRY(FixedArray<u8>::create(m_descriptor.total_length)); // Buffer for us to store the entire hierarchy into
 
     // The USB spec is a little bit janky here... Interface and Endpoint descriptors aren't fetched
     // through a `GET_DESCRIPTOR` request to the device. Instead, the _entire_ hierarchy is returned

--- a/Kernel/Credentials.cpp
+++ b/Kernel/Credentials.cpp
@@ -12,7 +12,7 @@ namespace Kernel {
 
 ErrorOr<NonnullRefPtr<Credentials>> Credentials::create(UserID uid, GroupID gid, UserID euid, GroupID egid, UserID suid, GroupID sgid, Span<GroupID const> extra_gids, SessionID sid, ProcessGroupID pgid)
 {
-    auto extra_gids_array = TRY(FixedArray<GroupID>::try_create(extra_gids));
+    auto extra_gids_array = TRY(FixedArray<GroupID>::create(extra_gids));
     return adopt_nonnull_ref_or_enomem(new (nothrow) Credentials(uid, gid, euid, egid, suid, sgid, move(extra_gids_array), sid, pgid));
 }
 

--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -92,7 +92,7 @@ ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_phys
 {
     auto contiguous_physical_pages = TRY(MM.allocate_contiguous_physical_pages(size));
 
-    auto new_physical_pages = TRY(FixedArray<RefPtr<PhysicalPage>>::try_create(contiguous_physical_pages.span()));
+    auto new_physical_pages = TRY(FixedArray<RefPtr<PhysicalPage>>::create(contiguous_physical_pages.span()));
 
     return adopt_nonnull_lock_ref_or_enomem(new (nothrow) AnonymousVMObject(move(new_physical_pages)));
 }
@@ -113,7 +113,7 @@ ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_purg
 
 ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_with_physical_pages(Span<NonnullRefPtr<PhysicalPage>> physical_pages)
 {
-    auto new_physical_pages = TRY(FixedArray<RefPtr<PhysicalPage>>::try_create(physical_pages));
+    auto new_physical_pages = TRY(FixedArray<RefPtr<PhysicalPage>>::create(physical_pages));
     return adopt_nonnull_lock_ref_or_enomem(new (nothrow) AnonymousVMObject(move(new_physical_pages)));
 }
 

--- a/Kernel/Memory/VMObject.cpp
+++ b/Kernel/Memory/VMObject.cpp
@@ -19,12 +19,12 @@ SpinlockProtected<VMObject::AllInstancesList, LockRank::None>& VMObject::all_ins
 
 ErrorOr<FixedArray<RefPtr<PhysicalPage>>> VMObject::try_clone_physical_pages() const
 {
-    return m_physical_pages.try_clone();
+    return m_physical_pages.clone();
 }
 
 ErrorOr<FixedArray<RefPtr<PhysicalPage>>> VMObject::try_create_physical_pages(size_t size)
 {
-    return FixedArray<RefPtr<PhysicalPage>>::try_create(ceil_div(size, static_cast<size_t>(PAGE_SIZE)));
+    return FixedArray<RefPtr<PhysicalPage>>::create(ceil_div(size, static_cast<size_t>(PAGE_SIZE)));
 }
 
 VMObject::VMObject(FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)

--- a/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
@@ -11,7 +11,7 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto flac_data = ByteBuffer::copy(data, size).release_value();
-    auto flac_or_error = Audio::FlacLoaderPlugin::try_create(flac_data.bytes());
+    auto flac_or_error = Audio::FlacLoaderPlugin::create(flac_data.bytes());
 
     if (flac_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
@@ -11,7 +11,7 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto flac_data = ByteBuffer::copy(data, size).release_value();
-    auto mp3_or_error = Audio::MP3LoaderPlugin::try_create(flac_data.bytes());
+    auto mp3_or_error = Audio::MP3LoaderPlugin::create(flac_data.bytes());
 
     if (mp3_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
@@ -13,7 +13,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
     if (!data)
         return 0;
     auto wav_data = ReadonlyBytes { data, size };
-    auto wav_or_error = Audio::WavLoaderPlugin::try_create(wav_data);
+    auto wav_or_error = Audio::WavLoaderPlugin::create(wav_data);
 
     if (wav_or_error.is_error())
         return 0;

--- a/Tests/AK/TestDisjointChunks.cpp
+++ b/Tests/AK/TestDisjointChunks.cpp
@@ -61,15 +61,15 @@ TEST_CASE(fixed_array)
     EXPECT(chunks.is_empty());
     chunks.append({});
     EXPECT(chunks.is_empty());
-    chunks.append(MUST(FixedArray<size_t>::try_create({ 0, 1 })));
+    chunks.append(MUST(FixedArray<size_t>::create({ 0, 1 })));
     EXPECT(!chunks.is_empty());
     chunks.append({});
-    chunks.append(MUST(FixedArray<size_t>::try_create(3)));
+    chunks.append(MUST(FixedArray<size_t>::create(3)));
     chunks.last_chunk()[0] = 2;
     chunks.last_chunk()[1] = 3;
     chunks.last_chunk()[2] = 4;
     chunks.append({});
-    chunks.append(MUST(FixedArray<size_t>::try_create(1)));
+    chunks.append(MUST(FixedArray<size_t>::create(1)));
     chunks.last_chunk()[0] = 5;
 
     for (size_t i = 0; i < 6u; ++i)

--- a/Tests/LibAudio/TestFLACSpec.cpp
+++ b/Tests/LibAudio/TestFLACSpec.cpp
@@ -21,7 +21,7 @@ struct FlacTest : Test::TestCase {
 
     void run() const
     {
-        auto result = Audio::FlacLoaderPlugin::try_create(m_path.string());
+        auto result = Audio::FlacLoaderPlugin::create(m_path.string());
         if (result.is_error()) {
             FAIL(DeprecatedString::formatted("{} (at {})", result.error().description, result.error().index));
             return;

--- a/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
+++ b/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
@@ -78,9 +78,9 @@ ErrorOr<NonnullRefPtr<Mesh>> WavefrontOBJLoader::load(Core::File& file)
                 return Error::from_string_literal("Wavefront: Malformed face line.");
             }
 
-            auto vertex_indices = TRY(FixedArray<GLuint>::try_create(number_of_vertices));
-            auto tex_coord_indices = TRY(FixedArray<GLuint>::try_create(number_of_vertices));
-            auto normal_indices = TRY(FixedArray<GLuint>::try_create(number_of_vertices));
+            auto vertex_indices = TRY(FixedArray<GLuint>::create(number_of_vertices));
+            auto tex_coord_indices = TRY(FixedArray<GLuint>::create(number_of_vertices));
+            auto normal_indices = TRY(FixedArray<GLuint>::create(number_of_vertices));
 
             for (size_t i = 0; i < number_of_vertices; ++i) {
                 auto vertex_parts = face_line.at(i).split_view('/', SplitBehavior::KeepEmpty);

--- a/Userland/Applications/PixelPaint/HistogramWidget.cpp
+++ b/Userland/Applications/PixelPaint/HistogramWidget.cpp
@@ -21,7 +21,7 @@ ErrorOr<void> HistogramWidget::rebuild_histogram_data()
     if (!m_image)
         return {};
 
-    auto full_bitmap = TRY(m_image->try_compose_bitmap(Gfx::BitmapFormat::BGRA8888));
+    auto full_bitmap = TRY(m_image->compose_bitmap(Gfx::BitmapFormat::BGRA8888));
 
     m_data.red.clear_with_capacity();
     m_data.green.clear_with_capacity();

--- a/Userland/Applications/PixelPaint/IconBag.cpp
+++ b/Userland/Applications/PixelPaint/IconBag.cpp
@@ -8,7 +8,7 @@
 #include <Applications/PixelPaint/IconBag.h>
 
 namespace PixelPaint {
-ErrorOr<IconBag> IconBag::try_create()
+ErrorOr<IconBag> IconBag::create()
 {
     IconBag icon_bag;
 

--- a/Userland/Applications/PixelPaint/IconBag.h
+++ b/Userland/Applications/PixelPaint/IconBag.h
@@ -11,7 +11,7 @@
 
 namespace PixelPaint {
 struct IconBag final {
-    static ErrorOr<IconBag> try_create();
+    static ErrorOr<IconBag> create();
 
     RefPtr<Gfx::Bitmap> filetype_pixelpaint { nullptr };
     RefPtr<Gfx::Bitmap> new_clipboard { nullptr };

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -75,7 +75,7 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Image::decode_bitmap(ReadonlyBytes bitmap_da
 ErrorOr<NonnullRefPtr<Image>> Image::create_from_bitmap(NonnullRefPtr<Gfx::Bitmap> const& bitmap)
 {
     auto image = TRY(create_with_size({ bitmap->width(), bitmap->height() }));
-    auto layer = TRY(Layer::try_create_with_bitmap(*image, *bitmap, "Background"));
+    auto layer = TRY(Layer::create_with_bitmap(*image, *bitmap, "Background"));
     image->add_layer(move(layer));
     return image;
 }
@@ -93,13 +93,13 @@ ErrorOr<NonnullRefPtr<Image>> Image::create_from_pixel_paint_json(JsonObject con
         auto bitmap_base64_encoded = layer_object.get_deprecated_string("bitmap"sv).value();
         auto bitmap_data = TRY(decode_base64(bitmap_base64_encoded));
         auto bitmap = TRY(decode_bitmap(bitmap_data));
-        auto layer = TRY(Layer::try_create_with_bitmap(*image, move(bitmap), name));
+        auto layer = TRY(Layer::create_with_bitmap(*image, move(bitmap), name));
 
         if (auto const& mask_object = layer_object.get_deprecated_string("mask"sv); mask_object.has_value()) {
             auto mask_base64_encoded = mask_object.value();
             auto mask_data = TRY(decode_base64(mask_base64_encoded));
             auto mask = TRY(decode_bitmap(mask_data));
-            TRY(layer->try_set_bitmaps(layer->content_bitmap(), mask));
+            TRY(layer->set_bitmaps(layer->content_bitmap(), mask));
         }
 
         auto width = layer_object.get_i32("width"sv).value_or(0);
@@ -219,7 +219,7 @@ ErrorOr<NonnullRefPtr<Image>> Image::take_snapshot() const
 {
     auto snapshot = TRY(create_with_size(m_size));
     for (auto const& layer : m_layers) {
-        auto layer_snapshot = TRY(Layer::try_create_snapshot(*snapshot, layer));
+        auto layer_snapshot = TRY(Layer::create_snapshot(*snapshot, layer));
         snapshot->add_layer(move(layer_snapshot));
     }
     snapshot->m_selection.set_mask(m_selection.mask());
@@ -233,7 +233,7 @@ ErrorOr<void> Image::restore_snapshot(Image const& snapshot)
 
     bool layer_selected = false;
     for (auto const& snapshot_layer : snapshot.m_layers) {
-        auto layer = TRY(Layer::try_create_snapshot(*this, snapshot_layer));
+        auto layer = TRY(Layer::create_snapshot(*this, snapshot_layer));
         if (layer->is_selected()) {
             select_layer(layer.ptr());
             layer_selected = true;
@@ -493,7 +493,7 @@ ErrorOr<void> Image::flip(Gfx::Orientation orientation)
     size_t selected_layer_index = 0;
     for (size_t i = 0; i < m_layers.size(); ++i) {
         auto& layer = m_layers[i];
-        auto new_layer = TRY(Layer::try_create_snapshot(*this, layer));
+        auto new_layer = TRY(Layer::create_snapshot(*this, layer));
 
         if (layer.is_selected())
             selected_layer_index = i;
@@ -524,7 +524,7 @@ ErrorOr<void> Image::rotate(Gfx::RotationDirection direction)
     size_t selected_layer_index = 0;
     for (size_t i = 0; i < m_layers.size(); ++i) {
         auto& layer = m_layers[i];
-        auto new_layer = TRY(Layer::try_create_snapshot(*this, layer));
+        auto new_layer = TRY(Layer::create_snapshot(*this, layer));
 
         if (layer.is_selected())
             selected_layer_index = i;
@@ -556,7 +556,7 @@ ErrorOr<void> Image::crop(Gfx::IntRect const& cropped_rect)
     size_t selected_layer_index = 0;
     for (size_t i = 0; i < m_layers.size(); ++i) {
         auto& layer = m_layers[i];
-        auto new_layer = TRY(Layer::try_create_snapshot(*this, layer));
+        auto new_layer = TRY(Layer::create_snapshot(*this, layer));
 
         if (layer.is_selected())
             selected_layer_index = i;
@@ -626,7 +626,7 @@ ErrorOr<void> Image::resize(Gfx::IntSize new_size, Gfx::Painter::ScalingMode sca
     size_t selected_layer_index = 0;
     for (size_t i = 0; i < m_layers.size(); ++i) {
         auto& layer = m_layers[i];
-        auto new_layer = TRY(Layer::try_create_snapshot(*this, layer));
+        auto new_layer = TRY(Layer::create_snapshot(*this, layer));
 
         if (layer.is_selected())
             selected_layer_index = i;

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -45,15 +45,15 @@ protected:
 
 class Image : public RefCounted<Image> {
 public:
-    static ErrorOr<NonnullRefPtr<Image>> try_create_with_size(Gfx::IntSize);
-    static ErrorOr<NonnullRefPtr<Image>> try_create_from_pixel_paint_json(JsonObject const&);
-    static ErrorOr<NonnullRefPtr<Image>> try_create_from_bitmap(NonnullRefPtr<Gfx::Bitmap> const&);
+    static ErrorOr<NonnullRefPtr<Image>> create_with_size(Gfx::IntSize);
+    static ErrorOr<NonnullRefPtr<Image>> create_from_pixel_paint_json(JsonObject const&);
+    static ErrorOr<NonnullRefPtr<Image>> create_from_bitmap(NonnullRefPtr<Gfx::Bitmap> const&);
 
-    static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> try_decode_bitmap(ReadonlyBytes);
+    static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> decode_bitmap(ReadonlyBytes);
 
     // This generates a new Bitmap with the final image (all layers composed according to their attributes.)
-    ErrorOr<NonnullRefPtr<Gfx::Bitmap>> try_compose_bitmap(Gfx::BitmapFormat format) const;
-    RefPtr<Gfx::Bitmap> try_copy_bitmap(Selection const&) const;
+    ErrorOr<NonnullRefPtr<Gfx::Bitmap>> compose_bitmap(Gfx::BitmapFormat format) const;
+    RefPtr<Gfx::Bitmap> copy_bitmap(Selection const&) const;
 
     Selection& selection() { return m_selection; }
     Selection const& selection() const { return m_selection; }

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -517,11 +517,11 @@ ErrorOr<void> ImageEditor::add_new_layer_from_selection()
     // save offsets of selection so we know where to place the new layer
     auto selection_offset = current_layer_selection.bounding_rect().location();
 
-    auto selection_bitmap = active_layer()->try_copy_bitmap(current_layer_selection);
+    auto selection_bitmap = active_layer()->copy_bitmap(current_layer_selection);
     if (selection_bitmap.is_null())
         return Error::from_string_literal("Unable to create bitmap from selection.");
 
-    auto layer_or_error = PixelPaint::Layer::try_create_with_bitmap(image(), selection_bitmap.release_nonnull(), "New Layer"sv);
+    auto layer_or_error = PixelPaint::Layer::create_with_bitmap(image(), selection_bitmap.release_nonnull(), "New Layer"sv);
     if (layer_or_error.is_error())
         return Error::from_string_literal("Unable to create layer from selection.");
 

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -16,7 +16,7 @@
 
 namespace PixelPaint {
 
-ErrorOr<NonnullRefPtr<Layer>> Layer::try_create_with_size(Image& image, Gfx::IntSize size, DeprecatedString name)
+ErrorOr<NonnullRefPtr<Layer>> Layer::create_with_size(Image& image, Gfx::IntSize size, DeprecatedString name)
 {
     VERIFY(!size.is_empty());
 
@@ -27,7 +27,7 @@ ErrorOr<NonnullRefPtr<Layer>> Layer::try_create_with_size(Image& image, Gfx::Int
     return adopt_nonnull_ref_or_enomem(new (nothrow) Layer(image, move(bitmap), move(name)));
 }
 
-ErrorOr<NonnullRefPtr<Layer>> Layer::try_create_with_bitmap(Image& image, NonnullRefPtr<Gfx::Bitmap> bitmap, DeprecatedString name)
+ErrorOr<NonnullRefPtr<Layer>> Layer::create_with_bitmap(Image& image, NonnullRefPtr<Gfx::Bitmap> bitmap, DeprecatedString name)
 {
     VERIFY(!bitmap->size().is_empty());
 
@@ -37,10 +37,10 @@ ErrorOr<NonnullRefPtr<Layer>> Layer::try_create_with_bitmap(Image& image, Nonnul
     return adopt_nonnull_ref_or_enomem(new (nothrow) Layer(image, bitmap, move(name)));
 }
 
-ErrorOr<NonnullRefPtr<Layer>> Layer::try_create_snapshot(Image& image, Layer const& layer)
+ErrorOr<NonnullRefPtr<Layer>> Layer::create_snapshot(Image& image, Layer const& layer)
 {
     auto bitmap = TRY(layer.content_bitmap().clone());
-    auto snapshot = TRY(try_create_with_bitmap(image, move(bitmap), layer.name()));
+    auto snapshot = TRY(create_with_bitmap(image, move(bitmap), layer.name()));
 
     /*
         We set these properties directly because calling the setters might
@@ -127,7 +127,7 @@ Gfx::Bitmap& Layer::get_scratch_edited_bitmap()
     return *m_scratch_edited_bitmap;
 }
 
-RefPtr<Gfx::Bitmap> Layer::try_copy_bitmap(Selection const& selection) const
+RefPtr<Gfx::Bitmap> Layer::copy_bitmap(Selection const& selection) const
 {
     if (selection.is_empty()) {
         return {};
@@ -185,7 +185,7 @@ void Layer::erase_selection(Selection const& selection)
     did_modify_bitmap(translated_to_layer_space);
 }
 
-ErrorOr<void> Layer::try_set_bitmaps(NonnullRefPtr<Gfx::Bitmap> content, RefPtr<Gfx::Bitmap> mask)
+ErrorOr<void> Layer::set_bitmaps(NonnullRefPtr<Gfx::Bitmap> content, RefPtr<Gfx::Bitmap> mask)
 {
     if (mask && content->size() != mask->size())
         return Error::from_string_literal("Layer content and mask must be same size");

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -29,9 +29,9 @@ class Layer
     AK_MAKE_NONMOVABLE(Layer);
 
 public:
-    static ErrorOr<NonnullRefPtr<Layer>> try_create_with_size(Image&, Gfx::IntSize, DeprecatedString name);
-    static ErrorOr<NonnullRefPtr<Layer>> try_create_with_bitmap(Image&, NonnullRefPtr<Gfx::Bitmap>, DeprecatedString name);
-    static ErrorOr<NonnullRefPtr<Layer>> try_create_snapshot(Image&, Layer const&);
+    static ErrorOr<NonnullRefPtr<Layer>> create_with_size(Image&, Gfx::IntSize, DeprecatedString name);
+    static ErrorOr<NonnullRefPtr<Layer>> create_with_bitmap(Image&, NonnullRefPtr<Gfx::Bitmap>, DeprecatedString name);
+    static ErrorOr<NonnullRefPtr<Layer>> create_snapshot(Image&, Layer const&);
 
     ~Layer() = default;
 
@@ -70,7 +70,7 @@ public:
 
     Optional<Gfx::IntRect> nonempty_content_bounding_rect() const;
 
-    ErrorOr<void> try_set_bitmaps(NonnullRefPtr<Gfx::Bitmap> content, RefPtr<Gfx::Bitmap> mask);
+    ErrorOr<void> set_bitmaps(NonnullRefPtr<Gfx::Bitmap> content, RefPtr<Gfx::Bitmap> mask);
 
     void did_modify_bitmap(Gfx::IntRect const& = {}, NotifyClients notify_clients = NotifyClients::Yes);
 
@@ -83,7 +83,7 @@ public:
     int opacity_percent() const { return m_opacity_percent; }
     void set_opacity_percent(int);
 
-    RefPtr<Gfx::Bitmap> try_copy_bitmap(Selection const&) const;
+    RefPtr<Gfx::Bitmap> copy_bitmap(Selection const&) const;
 
     Image const& image() const { return m_image; }
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1097,7 +1097,7 @@ void MainWidget::set_actions_enabled(bool enabled)
 
 void MainWidget::open_image(FileSystemAccessClient::File file)
 {
-    auto try_load = m_loader.try_load_from_file(file.release_stream());
+    auto try_load = m_loader.load_from_file(file.release_stream());
     if (try_load.is_error()) {
         GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Unable to open file: {}, {}", file.filename(), try_load.error()));
         return;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -158,7 +158,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                     return;
                 }
                 auto image = image_result.release_value();
-                auto bg_layer_result = PixelPaint::Layer::try_create_with_size(*image, image->size(), "Background");
+                auto bg_layer_result = PixelPaint::Layer::create_with_size(*image, image->size(), "Background");
                 if (bg_layer_result.is_error()) {
                     GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to create layer with size {}, error: {}", image->size(), bg_layer_result.error()));
                     return;
@@ -285,9 +285,9 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             dbgln("Cannot cut with no active layer selected");
             return;
         }
-        auto bitmap = editor->active_layer()->try_copy_bitmap(editor->image().selection());
+        auto bitmap = editor->active_layer()->copy_bitmap(editor->image().selection());
         if (!bitmap) {
-            dbgln("try_copy_bitmap() from Layer failed");
+            dbgln("copy_bitmap() from Layer failed");
             return;
         }
         GUI::Clipboard::the().set_bitmap(*bitmap);
@@ -302,9 +302,9 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             dbgln("Cannot copy with no active layer selected");
             return;
         }
-        auto bitmap = editor->active_layer()->try_copy_bitmap(editor->image().selection());
+        auto bitmap = editor->active_layer()->copy_bitmap(editor->image().selection());
         if (!bitmap) {
-            dbgln("try_copy_bitmap() from Layer failed");
+            dbgln("copy_bitmap() from Layer failed");
             return;
         }
         auto layer_rect = editor->active_layer()->relative_rect();
@@ -343,7 +343,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         if (!bitmap)
             return;
 
-        auto layer_result = PixelPaint::Layer::try_create_with_bitmap(editor->image(), *bitmap, "Pasted layer");
+        auto layer_result = PixelPaint::Layer::create_with_bitmap(editor->image(), *bitmap, "Pasted layer");
         if (layer_result.is_error()) {
             GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Could not create bitmap when pasting: {}", layer_result.error()));
             return;
@@ -701,7 +701,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             VERIFY(editor);
             auto dialog = PixelPaint::CreateNewLayerDialog::construct(editor->image().size(), &window);
             if (dialog->exec() == GUI::Dialog::ExecResult::OK) {
-                auto layer_or_error = PixelPaint::Layer::try_create_with_size(editor->image(), dialog->layer_size(), dialog->layer_name());
+                auto layer_or_error = PixelPaint::Layer::create_with_size(editor->image(), dialog->layer_size(), dialog->layer_name());
                 if (layer_or_error.is_error()) {
                     GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Unable to create layer with size {}", dialog->size()));
                     return;
@@ -825,7 +825,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 auto& next_active_layer = editor->image().layer(active_layer_index > 0 ? active_layer_index - 1 : 0);
                 editor->set_active_layer(&next_active_layer);
             } else {
-                auto layer_result = PixelPaint::Layer::try_create_with_size(editor->image(), editor->image().size(), "Background");
+                auto layer_result = PixelPaint::Layer::create_with_size(editor->image(), editor->image().size(), "Background");
                 if (layer_result.is_error()) {
                     GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to create layer with size {}, error: {}", editor->image().size(), layer_result.error()));
                     return;
@@ -1115,7 +1115,7 @@ ErrorOr<void> MainWidget::create_default_image()
 {
     auto image = TRY(Image::create_with_size({ 510, 356 }));
 
-    auto bg_layer = TRY(Layer::try_create_with_size(*image, image->size(), "Background"));
+    auto bg_layer = TRY(Layer::create_with_size(*image, image->size(), "Background"));
     image->add_layer(*bg_layer);
     bg_layer->content_bitmap().fill(Color::Transparent);
 
@@ -1137,7 +1137,7 @@ ErrorOr<void> MainWidget::create_image_from_clipboard()
     }
 
     auto image = TRY(PixelPaint::Image::create_with_size(bitmap->size()));
-    auto layer = TRY(PixelPaint::Layer::try_create_with_bitmap(image, *bitmap, "Pasted layer"));
+    auto layer = TRY(PixelPaint::Layer::create_with_bitmap(image, *bitmap, "Pasted layer"));
     image->add_layer(*layer);
 
     auto& editor = create_new_editor(*image);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -152,7 +152,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         "&New Image...", { Mod_Ctrl, Key_N }, g_icon_bag.filetype_pixelpaint, [&](auto&) {
             auto dialog = PixelPaint::CreateNewImageDialog::construct(&window);
             if (dialog->exec() == GUI::Dialog::ExecResult::OK) {
-                auto image_result = PixelPaint::Image::try_create_with_size(dialog->image_size());
+                auto image_result = PixelPaint::Image::create_with_size(dialog->image_size());
                 if (image_result.is_error()) {
                     GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to create image with size {}, error: {}", dialog->image_size(), image_result.error()));
                     return;
@@ -320,9 +320,9 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto* editor = current_image_editor();
             VERIFY(editor);
 
-            auto bitmap = editor->image().try_copy_bitmap(editor->image().selection());
+            auto bitmap = editor->image().copy_bitmap(editor->image().selection());
             if (!bitmap) {
-                dbgln("try_copy_bitmap() from Image failed");
+                dbgln("copy_bitmap() from Image failed");
                 return;
             }
             GUI::Clipboard::the().set_bitmap(*bitmap);
@@ -1113,7 +1113,7 @@ void MainWidget::open_image(FileSystemAccessClient::File file)
 
 ErrorOr<void> MainWidget::create_default_image()
 {
-    auto image = TRY(Image::try_create_with_size({ 510, 356 }));
+    auto image = TRY(Image::create_with_size({ 510, 356 }));
 
     auto bg_layer = TRY(Layer::try_create_with_size(*image, image->size(), "Background"));
     image->add_layer(*bg_layer);
@@ -1136,7 +1136,7 @@ ErrorOr<void> MainWidget::create_image_from_clipboard()
         return Error::from_string_view("There is no image in a clipboard to paste."sv);
     }
 
-    auto image = TRY(PixelPaint::Image::try_create_with_size(bitmap->size()));
+    auto image = TRY(PixelPaint::Image::create_with_size(bitmap->size()));
     auto layer = TRY(PixelPaint::Layer::try_create_with_bitmap(image, *bitmap, "Pasted layer"));
     image->add_layer(*layer);
 

--- a/Userland/Applications/PixelPaint/ProjectLoader.cpp
+++ b/Userland/Applications/PixelPaint/ProjectLoader.cpp
@@ -24,15 +24,15 @@ ErrorOr<void> ProjectLoader::try_load_from_file(NonnullOwnPtr<Core::Stream::File
         m_is_raw_image = true;
 
         // FIXME: Find a way to avoid the memory copy here.
-        auto bitmap = TRY(Image::try_decode_bitmap(contents));
-        auto image = TRY(Image::try_create_from_bitmap(move(bitmap)));
+        auto bitmap = TRY(Image::decode_bitmap(contents));
+        auto image = TRY(Image::create_from_bitmap(move(bitmap)));
 
         m_image = image;
         return {};
     }
 
     auto& json = json_or_error.value().as_object();
-    auto image = TRY(Image::try_create_from_pixel_paint_json(json));
+    auto image = TRY(Image::create_from_pixel_paint_json(json));
 
     if (json.has_array("guides"sv))
         m_json_metadata = json.get_array("guides"sv).value();

--- a/Userland/Applications/PixelPaint/ProjectLoader.cpp
+++ b/Userland/Applications/PixelPaint/ProjectLoader.cpp
@@ -15,7 +15,7 @@
 
 namespace PixelPaint {
 
-ErrorOr<void> ProjectLoader::try_load_from_file(NonnullOwnPtr<Core::Stream::File> file)
+ErrorOr<void> ProjectLoader::load_from_file(NonnullOwnPtr<Core::Stream::File> file)
 {
     auto contents = TRY(file->read_until_eof());
 

--- a/Userland/Applications/PixelPaint/ProjectLoader.h
+++ b/Userland/Applications/PixelPaint/ProjectLoader.h
@@ -18,7 +18,7 @@ public:
     ProjectLoader() = default;
     ~ProjectLoader() = default;
 
-    ErrorOr<void> try_load_from_file(NonnullOwnPtr<Core::Stream::File>);
+    ErrorOr<void> load_from_file(NonnullOwnPtr<Core::Stream::File>);
 
     bool is_raw_image() const { return m_is_raw_image; }
     bool has_image() const { return !m_image.is_null(); }

--- a/Userland/Applications/PixelPaint/VectorscopeWidget.cpp
+++ b/Userland/Applications/PixelPaint/VectorscopeWidget.cpp
@@ -36,7 +36,7 @@ ErrorOr<void> VectorscopeWidget::rebuild_vectorscope_data()
 
     m_vectorscope_data.fill({});
     VERIFY(AK::abs(m_vectorscope_data[0][0]) < 0.01f);
-    auto full_bitmap = TRY(m_image->try_compose_bitmap(Gfx::BitmapFormat::BGRA8888));
+    auto full_bitmap = TRY(m_image->compose_bitmap(Gfx::BitmapFormat::BGRA8888));
 
     for (size_t x = 0; x < static_cast<size_t>(full_bitmap->width()); ++x) {
         for (size_t y = 0; y < static_cast<size_t>(full_bitmap->height()); ++y) {

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -40,7 +40,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = GUI::Icon::default_icon("app-pixel-paint"sv);
 
-    PixelPaint::g_icon_bag = TRY(PixelPaint::IconBag::try_create());
+    PixelPaint::g_icon_bag = TRY(PixelPaint::IconBag::create());
 
     auto window = GUI::Window::construct();
     window->set_title("Pixel Paint");

--- a/Userland/Applications/SoundPlayer/PlaybackManager.cpp
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.cpp
@@ -124,7 +124,7 @@ void PlaybackManager::next_buffer()
 
         m_resampler->reset();
         // FIXME: Handle OOM better.
-        auto resampled = MUST(FixedArray<Audio::Sample>::try_create(m_resampler->resample(move(m_current_buffer)).span()));
+        auto resampled = MUST(FixedArray<Audio::Sample>::create(m_resampler->resample(move(m_current_buffer)).span()));
         m_current_buffer.swap(resampled);
         MUST(m_connection->async_enqueue(m_current_buffer));
     }

--- a/Userland/Applications/SoundPlayer/VisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/VisualizationWidget.h
@@ -70,7 +70,7 @@ public:
 
     ErrorOr<void> set_render_sample_count(size_t count)
     {
-        auto new_buffer = TRY(FixedArray<float>::try_create(count));
+        auto new_buffer = TRY(FixedArray<float>::create(count));
         m_render_buffer.swap(new_buffer);
         return {};
     }

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -159,7 +159,7 @@ static ErrorOr<void> run_command(DeprecatedString command, bool keep_open)
         arguments.append("-c"sv);
         arguments.append(command);
     }
-    auto env = TRY(FixedArray<StringView>::try_create({ "TERM=xterm"sv, "PAGER=more"sv, "PATH="sv DEFAULT_PATH_SV }));
+    auto env = TRY(FixedArray<StringView>::create({ "TERM=xterm"sv, "PAGER=more"sv, "PATH="sv DEFAULT_PATH_SV }));
     TRY(Core::System::exec(shell, arguments, Core::System::SearchInPath::No, env.span()));
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Demos/Tubes/Tubes.cpp
+++ b/Userland/Demos/Tubes/Tubes.cpp
@@ -75,7 +75,7 @@ static IntVector3 vector_for_direction(Direction direction)
 }
 
 Tubes::Tubes(int interval)
-    : m_grid(MUST(FixedArray<u8>::try_create(grid_resolution * grid_resolution * grid_resolution)))
+    : m_grid(MUST(FixedArray<u8>::create(grid_resolution * grid_resolution * grid_resolution)))
 {
     on_screensaver_exit = []() { GUI::Application::the()->quit(); };
     start_timer(interval);

--- a/Userland/Libraries/LibAudio/ConnectionToServer.h
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.h
@@ -36,7 +36,7 @@ public:
     template<ArrayLike<Sample> Samples>
     ErrorOr<void> async_enqueue(Samples&& samples)
     {
-        return async_enqueue(TRY(FixedArray<Sample>::try_create(samples.span())));
+        return async_enqueue(TRY(FixedArray<Sample>::create(samples.span())));
     }
 
     ErrorOr<void> async_enqueue(FixedArray<Sample>&& samples);

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -30,7 +30,7 @@ FlacLoaderPlugin::FlacLoaderPlugin(NonnullOwnPtr<Core::Stream::SeekableStream> s
 {
 }
 
-Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> FlacLoaderPlugin::try_create(StringView path)
+Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> FlacLoaderPlugin::create(StringView path)
 {
     auto stream = LOADER_TRY(Core::Stream::BufferedFile::create(LOADER_TRY(Core::Stream::File::open(path, Core::Stream::OpenMode::Read))));
     auto loader = make<FlacLoaderPlugin>(move(stream));
@@ -40,7 +40,7 @@ Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> FlacLoaderPlugin::try_creat
     return loader;
 }
 
-Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> FlacLoaderPlugin::try_create(Bytes buffer)
+Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> FlacLoaderPlugin::create(Bytes buffer)
 {
     auto stream = LOADER_TRY(Core::Stream::FixedMemoryStream::construct(buffer));
     auto loader = make<FlacLoaderPlugin>(move(stream));

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -50,8 +50,8 @@ public:
     explicit FlacLoaderPlugin(NonnullOwnPtr<Core::Stream::SeekableStream> stream);
     virtual ~FlacLoaderPlugin() override = default;
 
-    static Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> try_create(StringView path);
-    static Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> try_create(Bytes buffer);
+    static Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> create(StringView path);
+    static Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> create(Bytes buffer);
 
     virtual LoaderSamples get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB) override;
 

--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -21,7 +21,7 @@ Loader::Loader(NonnullOwnPtr<LoaderPlugin> plugin)
 {
 }
 
-Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::try_create(StringView path)
+Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::create_plugin(StringView path)
 {
     {
         auto plugin = WavLoaderPlugin::create(path);
@@ -44,7 +44,7 @@ Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::try_create(StringView p
     return LoaderError { "No loader plugin available" };
 }
 
-Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::try_create(Bytes buffer)
+Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::create_plugin(Bytes buffer)
 {
     {
         auto plugin = WavLoaderPlugin::create(buffer);

--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -24,19 +24,19 @@ Loader::Loader(NonnullOwnPtr<LoaderPlugin> plugin)
 Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::try_create(StringView path)
 {
     {
-        auto plugin = WavLoaderPlugin::try_create(path);
+        auto plugin = WavLoaderPlugin::create(path);
         if (!plugin.is_error())
             return NonnullOwnPtr<LoaderPlugin>(plugin.release_value());
     }
 
     {
-        auto plugin = FlacLoaderPlugin::try_create(path);
+        auto plugin = FlacLoaderPlugin::create(path);
         if (!plugin.is_error())
             return NonnullOwnPtr<LoaderPlugin>(plugin.release_value());
     }
 
     {
-        auto plugin = MP3LoaderPlugin::try_create(path);
+        auto plugin = MP3LoaderPlugin::create(path);
         if (!plugin.is_error())
             return NonnullOwnPtr<LoaderPlugin>(plugin.release_value());
     }
@@ -47,19 +47,19 @@ Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::try_create(StringView p
 Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::try_create(Bytes buffer)
 {
     {
-        auto plugin = WavLoaderPlugin::try_create(buffer);
+        auto plugin = WavLoaderPlugin::create(buffer);
         if (!plugin.is_error())
             return NonnullOwnPtr<LoaderPlugin>(plugin.release_value());
     }
 
     {
-        auto plugin = FlacLoaderPlugin::try_create(buffer);
+        auto plugin = FlacLoaderPlugin::create(buffer);
         if (!plugin.is_error())
             return NonnullOwnPtr<LoaderPlugin>(plugin.release_value());
     }
 
     {
-        auto plugin = MP3LoaderPlugin::try_create(buffer);
+        auto plugin = MP3LoaderPlugin::create(buffer);
         if (!plugin.is_error())
             return NonnullOwnPtr<LoaderPlugin>(plugin.release_value());
     }

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -65,8 +65,8 @@ protected:
 
 class Loader : public RefCounted<Loader> {
 public:
-    static Result<NonnullRefPtr<Loader>, LoaderError> create(StringView path) { return adopt_ref(*new Loader(TRY(try_create(path)))); }
-    static Result<NonnullRefPtr<Loader>, LoaderError> create(Bytes buffer) { return adopt_ref(*new Loader(TRY(try_create(buffer)))); }
+    static Result<NonnullRefPtr<Loader>, LoaderError> create(StringView path) { return adopt_ref(*new Loader(TRY(create_plugin(path)))); }
+    static Result<NonnullRefPtr<Loader>, LoaderError> create(Bytes buffer) { return adopt_ref(*new Loader(TRY(create_plugin(buffer)))); }
 
     LoaderSamples get_more_samples(size_t max_samples_to_read_from_input = 128 * KiB) const { return m_plugin->get_more_samples(max_samples_to_read_from_input); }
 
@@ -82,8 +82,8 @@ public:
     Vector<PictureData> const& pictures() const { return m_plugin->pictures(); };
 
 private:
-    static Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> try_create(StringView path);
-    static Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> try_create(Bytes buffer);
+    static Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> create_plugin(StringView path);
+    static Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> create_plugin(Bytes buffer);
 
     explicit Loader(NonnullOwnPtr<LoaderPlugin>);
 

--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -91,7 +91,7 @@ MaybeLoaderError MP3LoaderPlugin::seek(int const position)
 
 LoaderSamples MP3LoaderPlugin::get_more_samples(size_t max_samples_to_read_from_input)
 {
-    FixedArray<Sample> samples = LOADER_TRY(FixedArray<Sample>::try_create(max_samples_to_read_from_input));
+    FixedArray<Sample> samples = LOADER_TRY(FixedArray<Sample>::create(max_samples_to_read_from_input));
 
     size_t samples_to_read = max_samples_to_read_from_input;
     while (samples_to_read > 0) {

--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -19,7 +19,7 @@ MP3LoaderPlugin::MP3LoaderPlugin(NonnullOwnPtr<Core::Stream::SeekableStream> str
 {
 }
 
-Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> MP3LoaderPlugin::try_create(StringView path)
+Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> MP3LoaderPlugin::create(StringView path)
 {
     auto stream = LOADER_TRY(Core::Stream::BufferedFile::create(LOADER_TRY(Core::Stream::File::open(path, Core::Stream::OpenMode::Read))));
     auto loader = make<MP3LoaderPlugin>(move(stream));
@@ -29,7 +29,7 @@ Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> MP3LoaderPlugin::try_create(
     return loader;
 }
 
-Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> MP3LoaderPlugin::try_create(Bytes buffer)
+Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> MP3LoaderPlugin::create(Bytes buffer)
 {
     auto stream = LOADER_TRY(Core::Stream::FixedMemoryStream::construct(buffer));
     auto loader = make<MP3LoaderPlugin>(move(stream));

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -26,8 +26,8 @@ public:
     explicit MP3LoaderPlugin(NonnullOwnPtr<Core::Stream::SeekableStream> stream);
     virtual ~MP3LoaderPlugin() = default;
 
-    static Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> try_create(StringView path);
-    static Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> try_create(Bytes buffer);
+    static Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> create(StringView path);
+    static Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> create(Bytes buffer);
 
     virtual LoaderSamples get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB) override;
 

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -114,7 +114,7 @@ static ErrorOr<double> read_sample(Core::Stream::Stream& stream)
 
 LoaderSamples WavLoaderPlugin::samples_from_pcm_data(Bytes const& data, size_t samples_to_read) const
 {
-    FixedArray<Sample> samples = LOADER_TRY(FixedArray<Sample>::try_create(samples_to_read));
+    FixedArray<Sample> samples = LOADER_TRY(FixedArray<Sample>::create(samples_to_read));
     auto stream = LOADER_TRY(Core::Stream::FixedMemoryStream::construct(move(data)));
 
     switch (m_sample_format) {

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -23,7 +23,7 @@ WavLoaderPlugin::WavLoaderPlugin(NonnullOwnPtr<Core::Stream::SeekableStream> str
 {
 }
 
-Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> WavLoaderPlugin::try_create(StringView path)
+Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> WavLoaderPlugin::create(StringView path)
 {
     auto stream = LOADER_TRY(Core::Stream::BufferedFile::create(LOADER_TRY(Core::Stream::File::open(path, Core::Stream::OpenMode::Read))));
     auto loader = make<WavLoaderPlugin>(move(stream));
@@ -33,7 +33,7 @@ Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> WavLoaderPlugin::try_create(
     return loader;
 }
 
-Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> WavLoaderPlugin::try_create(Bytes buffer)
+Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> WavLoaderPlugin::create(Bytes buffer)
 {
     auto stream = LOADER_TRY(Core::Stream::FixedMemoryStream::construct(buffer));
     auto loader = make<WavLoaderPlugin>(move(stream));

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -30,8 +30,8 @@ static constexpr unsigned const WAVE_FORMAT_EXTENSIBLE = 0xFFFE; // Determined b
 class WavLoaderPlugin : public LoaderPlugin {
 public:
     explicit WavLoaderPlugin(NonnullOwnPtr<Core::Stream::SeekableStream> stream);
-    static Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> try_create(StringView path);
-    static Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> try_create(Bytes buffer);
+    static Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> create(StringView path);
+    static Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> create(Bytes buffer);
 
     virtual LoaderSamples get_more_samples(size_t max_samples_to_read_from_input = 128 * KiB) override;
 

--- a/Userland/Libraries/LibCompress/Brotli.h
+++ b/Userland/Libraries/LibCompress/Brotli.h
@@ -67,7 +67,7 @@ public:
     public:
         static ErrorOr<LookbackBuffer> try_create(size_t size)
         {
-            auto buffer = TRY(FixedArray<u8>::try_create(size));
+            auto buffer = TRY(FixedArray<u8>::create(size));
             return LookbackBuffer { buffer };
         }
 

--- a/Userland/Libraries/LibCore/MemoryStream.cpp
+++ b/Userland/Libraries/LibCore/MemoryStream.cpp
@@ -212,7 +212,7 @@ ErrorOr<Optional<size_t>> AllocatingMemoryStream::offset_of(ReadonlyBytes needle
     VERIFY(m_chunks.size() * chunk_size - m_write_offset < chunk_size);
 
     auto chunk_count = m_chunks.size();
-    auto search_spans = TRY(FixedArray<ReadonlyBytes>::try_create(chunk_count));
+    auto search_spans = TRY(FixedArray<ReadonlyBytes>::create(chunk_count));
 
     for (size_t i = 0; i < chunk_count; i++) {
         search_spans[i] = m_chunks[i].span();

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1118,7 +1118,7 @@ ErrorOr<void> exec(StringView filename, Span<StringView> arguments, SearchInPath
 #ifdef AK_OS_SERENITY
     Syscall::SC_execve_params params;
 
-    auto argument_strings = TRY(FixedArray<Syscall::StringArgument>::try_create(arguments.size()));
+    auto argument_strings = TRY(FixedArray<Syscall::StringArgument>::create(arguments.size()));
     for (size_t i = 0; i < arguments.size(); ++i) {
         argument_strings[i] = { arguments[i].characters_without_null_termination(), arguments[i].length() };
     }
@@ -1133,7 +1133,7 @@ ErrorOr<void> exec(StringView filename, Span<StringView> arguments, SearchInPath
             ++env_count;
     }
 
-    auto environment_strings = TRY(FixedArray<Syscall::StringArgument>::try_create(env_count));
+    auto environment_strings = TRY(FixedArray<Syscall::StringArgument>::create(env_count));
     if (environment.has_value()) {
         for (size_t i = 0; i < env_count; ++i) {
             environment_strings[i] = { environment->at(i).characters_without_null_termination(), environment->at(i).length() };
@@ -1172,8 +1172,8 @@ ErrorOr<void> exec(StringView filename, Span<StringView> arguments, SearchInPath
 #else
     DeprecatedString filename_string { filename };
 
-    auto argument_strings = TRY(FixedArray<DeprecatedString>::try_create(arguments.size()));
-    auto argv = TRY(FixedArray<char*>::try_create(arguments.size() + 1));
+    auto argument_strings = TRY(FixedArray<DeprecatedString>::create(arguments.size()));
+    auto argv = TRY(FixedArray<char*>::create(arguments.size() + 1));
     for (size_t i = 0; i < arguments.size(); ++i) {
         argument_strings[i] = arguments[i].to_deprecated_string();
         argv[i] = const_cast<char*>(argument_strings[i].characters());
@@ -1182,8 +1182,8 @@ ErrorOr<void> exec(StringView filename, Span<StringView> arguments, SearchInPath
 
     int rc = 0;
     if (environment.has_value()) {
-        auto environment_strings = TRY(FixedArray<DeprecatedString>::try_create(environment->size()));
-        auto envp = TRY(FixedArray<char*>::try_create(environment->size() + 1));
+        auto environment_strings = TRY(FixedArray<DeprecatedString>::create(environment->size()));
+        auto envp = TRY(FixedArray<char*>::create(environment->size() + 1));
         for (size_t i = 0; i < environment->size(); ++i) {
             environment_strings[i] = environment->at(i).to_deprecated_string();
             envp[i] = const_cast<char*>(environment_strings[i].characters());

--- a/Userland/Libraries/LibDSP/Track.cpp
+++ b/Userland/Libraries/LibDSP/Track.cpp
@@ -63,7 +63,7 @@ bool NoteTrack::check_processor_chain_valid() const
 
 ErrorOr<void> Track::resize_internal_buffers_to(size_t buffer_size)
 {
-    m_secondary_sample_buffer = TRY(FixedArray<Sample>::try_create(buffer_size));
+    m_secondary_sample_buffer = TRY(FixedArray<Sample>::create(buffer_size));
     return {};
 }
 

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -180,7 +180,7 @@ ErrorOr<Kern> Kern::from_slice(ReadonlyBytes slice)
         return Error::from_string_literal("Kern table does not contain any subtables");
 
     // Read all subtable offsets
-    auto subtable_offsets = TRY(FixedArray<size_t>::try_create(number_of_subtables));
+    auto subtable_offsets = TRY(FixedArray<size_t>::create(number_of_subtables));
     size_t offset = sizeof(Header);
     for (size_t i = 0; i < number_of_subtables; ++i) {
         if (slice.size() < offset + sizeof(SubtableHeader))

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -175,7 +175,7 @@ ErrorOr<void> PNGWriter::add_IDAT_chunk(Gfx::Bitmap const& bitmap)
     ByteBuffer uncompressed_block_data;
     TRY(uncompressed_block_data.try_ensure_capacity(bitmap.size_in_bytes() + bitmap.height()));
 
-    auto dummy_scanline = TRY(FixedArray<Pixel>::try_create(bitmap.width()));
+    auto dummy_scanline = TRY(FixedArray<Pixel>::create(bitmap.width()));
     auto const* scanline_minus_1 = dummy_scanline.data();
 
     for (int y = 0; y < bitmap.height(); ++y) {

--- a/Userland/Libraries/LibIPC/Decoder.h
+++ b/Userland/Libraries/LibIPC/Decoder.h
@@ -137,7 +137,7 @@ template<Concepts::SharedSingleProducerCircularQueue T>
 ErrorOr<T> decode(Decoder& decoder)
 {
     auto anon_file = TRY(decoder.decode<IPC::File>());
-    return T::try_create(anon_file.take_fd());
+    return T::create(anon_file.take_fd());
 }
 
 template<Concepts::Optional T>

--- a/Userland/Libraries/LibSoftGPU/Buffer/Typed3DBuffer.h
+++ b/Userland/Libraries/LibSoftGPU/Buffer/Typed3DBuffer.h
@@ -25,7 +25,7 @@ public:
     static ErrorOr<NonnullRefPtr<Typed3DBuffer<T>>> try_create(int width, int height, int depth)
     {
         VERIFY(width > 0 && height > 0 && depth > 0);
-        auto data = TRY(FixedArray<T>::try_create(width * height * depth));
+        auto data = TRY(FixedArray<T>::create(width * height * depth));
         return adopt_ref(*new Typed3DBuffer(width, height, depth, move(data)));
     }
 

--- a/Userland/Libraries/LibVideo/VP9/Context.h
+++ b/Userland/Libraries/LibVideo/VP9/Context.h
@@ -143,9 +143,9 @@ private:
 static ErrorOr<NonZeroTokens> create_non_zero_tokens(u32 size_in_sub_blocks, bool subsampling)
 {
     return NonZeroTokens {
-        TRY(FixedArray<bool>::try_create(size_in_sub_blocks)),
-        TRY(FixedArray<bool>::try_create(size_in_sub_blocks >>= subsampling)),
-        TRY(FixedArray<bool>::try_create(size_in_sub_blocks)),
+        TRY(FixedArray<bool>::create(size_in_sub_blocks)),
+        TRY(FixedArray<bool>::create(size_in_sub_blocks >>= subsampling)),
+        TRY(FixedArray<bool>::create(size_in_sub_blocks)),
     };
 }
 
@@ -191,9 +191,9 @@ public:
             above_partition_context,
             above_non_zero_tokens,
             above_segmentation_ids,
-            TRY(PartitionContext::try_create(superblocks_to_blocks(blocks_ceiled_to_superblocks(height)))),
+            TRY(PartitionContext::create(superblocks_to_blocks(blocks_ceiled_to_superblocks(height)))),
             TRY(create_non_zero_tokens(blocks_to_sub_blocks(height), frame_context.color_config.subsampling_y)),
-            TRY(SegmentationPredictionContext::try_create(height)),
+            TRY(SegmentationPredictionContext::create(height)),
         };
     }
 

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -153,9 +153,9 @@ DecoderErrorOr<void> Decoder::create_video_frame(FrameContext const& frame_conte
         output_y_size.height() >> frame_context.color_config.subsampling_y,
     };
     Array<FixedArray<u16>, 3> output_buffers = {
-        DECODER_TRY_ALLOC(FixedArray<u16>::try_create(output_y_size.width() * output_y_size.height())),
-        DECODER_TRY_ALLOC(FixedArray<u16>::try_create(output_uv_size.width() * output_uv_size.height())),
-        DECODER_TRY_ALLOC(FixedArray<u16>::try_create(output_uv_size.width() * output_uv_size.height())),
+        DECODER_TRY_ALLOC(FixedArray<u16>::create(output_y_size.width() * output_y_size.height())),
+        DECODER_TRY_ALLOC(FixedArray<u16>::create(output_uv_size.width() * output_uv_size.height())),
+        DECODER_TRY_ALLOC(FixedArray<u16>::create(output_uv_size.width() * output_uv_size.height())),
     };
     for (u8 plane = 0; plane < 3; plane++) {
         auto& buffer = output_buffers[plane];

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -858,9 +858,9 @@ DecoderErrorOr<void> Parser::decode_tiles(FrameContext& frame_context)
     auto tile_cols = 1 << log2_dimensions.width();
     auto tile_rows = 1 << log2_dimensions.height();
 
-    PartitionContext above_partition_context = DECODER_TRY_ALLOC(PartitionContext::try_create(superblocks_to_blocks(frame_context.superblock_columns())));
+    PartitionContext above_partition_context = DECODER_TRY_ALLOC(PartitionContext::create(superblocks_to_blocks(frame_context.superblock_columns())));
     NonZeroTokens above_non_zero_tokens = DECODER_TRY_ALLOC(create_non_zero_tokens(blocks_to_sub_blocks(frame_context.columns()), frame_context.color_config.subsampling_x));
-    SegmentationPredictionContext above_segmentation_ids = DECODER_TRY_ALLOC(SegmentationPredictionContext::try_create(frame_context.columns()));
+    SegmentationPredictionContext above_segmentation_ids = DECODER_TRY_ALLOC(SegmentationPredictionContext::create(frame_context.columns()));
 
     // FIXME: To implement tiled decoding, we'll need to pre-parse the tile positions and sizes into a 2D vector of ReadonlyBytes,
     //        then run through each column of tiles in top to bottom order afterward. Each column can be sent to a worker thread

--- a/Userland/Libraries/LibVideo/VideoFrame.cpp
+++ b/Userland/Libraries/LibVideo/VideoFrame.cpp
@@ -18,9 +18,9 @@ ErrorOr<NonnullOwnPtr<SubsampledYUVFrame>> SubsampledYUVFrame::try_create(
     bool subsampling_horizontal, bool subsampling_vertical,
     Span<u16> plane_y, Span<u16> plane_u, Span<u16> plane_v)
 {
-    auto plane_y_array = TRY(FixedArray<u16>::try_create(plane_y));
-    auto plane_u_array = TRY(FixedArray<u16>::try_create(plane_u));
-    auto plane_v_array = TRY(FixedArray<u16>::try_create(plane_v));
+    auto plane_y_array = TRY(FixedArray<u16>::create(plane_y));
+    auto plane_u_array = TRY(FixedArray<u16>::create(plane_u));
+    auto plane_v_array = TRY(FixedArray<u16>::create(plane_v));
     return adopt_nonnull_own_or_enomem(new (nothrow) SubsampledYUVFrame(size, bit_depth, cicp, subsampling_horizontal, subsampling_vertical, plane_y_array, plane_u_array, plane_v_array));
 }
 
@@ -28,8 +28,8 @@ DecoderErrorOr<void> SubsampledYUVFrame::output_to_bitmap(Gfx::Bitmap& bitmap)
 {
     size_t width = this->width();
     size_t height = this->height();
-    auto u_sample_row = DECODER_TRY_ALLOC(FixedArray<u16>::try_create(width));
-    auto v_sample_row = DECODER_TRY_ALLOC(FixedArray<u16>::try_create(width));
+    auto u_sample_row = DECODER_TRY_ALLOC(FixedArray<u16>::create(width));
+    auto v_sample_row = DECODER_TRY_ALLOC(FixedArray<u16>::create(width));
     size_t uv_width = width >> m_subsampling_horizontal;
 
     auto converter = TRY(ColorConverter::create(bit_depth(), cicp()));

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -47,7 +47,7 @@ public:
             return false;
 
         if (m_in_chunk_location >= m_current_audio_chunk.size()) {
-            auto result = m_buffer->try_dequeue();
+            auto result = m_buffer->dequeue();
             if (result.is_error()) {
                 if (result.error() == Audio::AudioQueue::QueueStatus::Empty) {
                     dbgln("Audio client {} can't keep up!", m_client->client_id());
@@ -79,7 +79,7 @@ public:
     {
         ErrorOr<Array<Audio::Sample, Audio::AUDIO_BUFFER_SIZE>, Audio::AudioQueue::QueueStatus> result = Audio::AudioQueue::QueueStatus::Invalid;
         do {
-            result = m_buffer->try_dequeue();
+            result = m_buffer->dequeue();
         } while (result.is_error() && result.error() != Audio::AudioQueue::QueueStatus::Empty);
     }
 


### PR DESCRIPTION
Not exhaustive.