### PR TITLE
LibGfx+icc: Read and display lut16Type and lut8Type ICC tag types

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -115,7 +115,7 @@ struct ICCHeader {
     u8 profile_id[16];
     u8 reserved[28];
 };
-static_assert(sizeof(ICCHeader) == 128);
+static_assert(AssertSize<ICCHeader, 128>());
 
 ErrorOr<u32> parse_size(ICCHeader const& header, ReadonlyBytes icc_bytes)
 {
@@ -623,7 +623,7 @@ ErrorOr<void> Profile::read_tag_table(ReadonlyBytes bytes)
         BigEndian<u32> offset_to_beginning_of_tag_data_element;
         BigEndian<u32> size_of_tag_data_element;
     };
-    static_assert(sizeof(TagTableEntry) == 12);
+    static_assert(AssertSize<TagTableEntry, 12>());
 
     tag_table_bytes = tag_table_bytes.slice(sizeof(u32));
     if (tag_table_bytes.size() < tag_count * sizeof(TagTableEntry))

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -574,6 +574,10 @@ ErrorOr<NonnullRefPtr<TagData>> Profile::read_tag(ReadonlyBytes bytes, u32 offse
     switch (type) {
     case CurveTagData::Type:
         return CurveTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
+    case Lut16TagData::Type:
+        return Lut16TagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
+    case Lut8TagData::Type:
+        return Lut8TagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case MultiLocalizedUnicodeTagData::Type:
         return MultiLocalizedUnicodeTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case ParametricCurveTagData::Type:

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -86,6 +86,124 @@ private:
     Vector<u16> m_values;
 };
 
+struct EMatrix {
+    S15Fixed16 e[9];
+
+    S15Fixed16 const& operator[](int i) const
+    {
+        VERIFY(i >= 0 && i < 9);
+        return e[i];
+    }
+};
+
+// ICC v4, 10.10 lut16Type
+class Lut16TagData : public TagData {
+public:
+    static constexpr TagTypeSignature Type { 0x6D667432 }; // 'mft2'
+
+    static ErrorOr<NonnullRefPtr<Lut16TagData>> from_bytes(ReadonlyBytes, u32 offset, u32 size);
+
+    Lut16TagData(u32 offset, u32 size, EMatrix e,
+        u8 number_of_input_channels, u8 number_of_output_channels, u8 number_of_clut_grid_points,
+        u16 number_of_input_table_entries, u16 number_of_output_table_entries,
+        Vector<u16> input_tables, Vector<u16> clut_values, Vector<u16> output_tables)
+        : TagData(offset, size, Type)
+        , m_e(e)
+        , m_number_of_input_channels(number_of_input_channels)
+        , m_number_of_output_channels(number_of_output_channels)
+        , m_number_of_clut_grid_points(number_of_clut_grid_points)
+        , m_number_of_input_table_entries(number_of_input_table_entries)
+        , m_number_of_output_table_entries(number_of_output_table_entries)
+        , m_input_tables(move(input_tables))
+        , m_clut_values(move(clut_values))
+        , m_output_tables(move(output_tables))
+    {
+        VERIFY(m_input_tables.size() == number_of_input_channels * number_of_input_table_entries);
+        VERIFY(m_output_tables.size() == number_of_output_channels * number_of_output_table_entries);
+    }
+
+    EMatrix const& e_matrix() const { return m_e; }
+
+    u8 number_of_input_channels() const { return m_number_of_input_channels; }
+    u8 number_of_output_channels() const { return m_number_of_output_channels; }
+    u8 number_of_clut_grid_points() const { return m_number_of_clut_grid_points; }
+
+    u16 number_of_input_table_entries() const { return m_number_of_input_table_entries; }
+    u16 number_of_output_table_entries() const { return m_number_of_output_table_entries; }
+
+    Vector<u16> const& input_tables() const { return m_input_tables; }
+    Vector<u16> const& clut_values() const { return m_clut_values; }
+    Vector<u16> const& output_tables() const { return m_output_tables; }
+
+private:
+    EMatrix m_e;
+
+    u8 m_number_of_input_channels;
+    u8 m_number_of_output_channels;
+    u8 m_number_of_clut_grid_points;
+
+    u16 m_number_of_input_table_entries;
+    u16 m_number_of_output_table_entries;
+
+    Vector<u16> m_input_tables;
+    Vector<u16> m_clut_values;
+    Vector<u16> m_output_tables;
+};
+
+// ICC v4, 10.11 lut8Type
+class Lut8TagData : public TagData {
+public:
+    static constexpr TagTypeSignature Type { 0x6D667431 }; // 'mft1'
+
+    static ErrorOr<NonnullRefPtr<Lut8TagData>> from_bytes(ReadonlyBytes, u32 offset, u32 size);
+
+    Lut8TagData(u32 offset, u32 size, EMatrix e,
+        u8 number_of_input_channels, u8 number_of_output_channels, u8 number_of_clut_grid_points,
+        u16 number_of_input_table_entries, u16 number_of_output_table_entries,
+        Vector<u8> input_tables, Vector<u8> clut_values, Vector<u8> output_tables)
+        : TagData(offset, size, Type)
+        , m_e(e)
+        , m_number_of_input_channels(number_of_input_channels)
+        , m_number_of_output_channels(number_of_output_channels)
+        , m_number_of_clut_grid_points(number_of_clut_grid_points)
+        , m_number_of_input_table_entries(number_of_input_table_entries)
+        , m_number_of_output_table_entries(number_of_output_table_entries)
+        , m_input_tables(move(input_tables))
+        , m_clut_values(move(clut_values))
+        , m_output_tables(move(output_tables))
+    {
+        VERIFY(m_input_tables.size() == number_of_input_channels * number_of_input_table_entries);
+        VERIFY(m_output_tables.size() == number_of_output_channels * number_of_output_table_entries);
+    }
+
+    EMatrix const& e_matrix() const { return m_e; }
+
+    u8 number_of_input_channels() const { return m_number_of_input_channels; }
+    u8 number_of_output_channels() const { return m_number_of_output_channels; }
+    u8 number_of_clut_grid_points() const { return m_number_of_clut_grid_points; }
+
+    u16 number_of_input_table_entries() const { return m_number_of_input_table_entries; }
+    u16 number_of_output_table_entries() const { return m_number_of_output_table_entries; }
+
+    Vector<u8> const& input_tables() const { return m_input_tables; }
+    Vector<u8> const& clut_values() const { return m_clut_values; }
+    Vector<u8> const& output_tables() const { return m_output_tables; }
+
+private:
+    EMatrix m_e;
+
+    u8 m_number_of_input_channels;
+    u8 m_number_of_output_channels;
+    u8 m_number_of_clut_grid_points;
+
+    u16 m_number_of_input_table_entries;
+    u16 m_number_of_output_table_entries;
+
+    Vector<u8> m_input_tables;
+    Vector<u8> m_clut_values;
+    Vector<u8> m_output_tables;
+};
+
 // ICC v4, 10.15 multiLocalizedUnicodeType
 class MultiLocalizedUnicodeTagData : public TagData {
 public:

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -135,6 +135,26 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 // FIXME: Maybe print the actual points if -v is passed?
                 outln("    curve with {} points", curve.values().size());
             }
+        } else if (tag_data->type() == Gfx::ICC::Lut16TagData::Type) {
+            auto& lut16 = static_cast<Gfx::ICC::Lut16TagData&>(*tag_data);
+            outln("    input table: {} channels x {} entries", lut16.number_of_input_channels(), lut16.number_of_input_table_entries());
+            outln("    output table: {} channels x {} entries", lut16.number_of_output_channels(), lut16.number_of_output_table_entries());
+            outln("    color lookup table: {} grid points, {} total entries", lut16.number_of_clut_grid_points(), lut16.clut_values().size());
+
+            auto const& e = lut16.e_matrix();
+            outln("    e = [ {}, {}, {},", e[0], e[1], e[2]);
+            outln("          {}, {}, {},", e[3], e[4], e[5]);
+            outln("          {}, {}, {} ]", e[6], e[7], e[8]);
+        } else if (tag_data->type() == Gfx::ICC::Lut8TagData::Type) {
+            auto& lut8 = static_cast<Gfx::ICC::Lut8TagData&>(*tag_data);
+            outln("    input table: {} channels x {} entries", lut8.number_of_input_channels(), lut8.number_of_input_table_entries());
+            outln("    output table: {} channels x {} entries", lut8.number_of_output_channels(), lut8.number_of_output_table_entries());
+            outln("    color lookup table: {} grid points, {} total entries", lut8.number_of_clut_grid_points(), lut8.clut_values().size());
+
+            auto const& e = lut8.e_matrix();
+            outln("    e = [ {}, {}, {},", e[0], e[1], e[2]);
+            outln("          {}, {}, {},", e[3], e[4], e[5]);
+            outln("          {}, {}, {} ]", e[6], e[7], e[8]);
         } else if (tag_data->type() == Gfx::ICC::MultiLocalizedUnicodeTagData::Type) {
             auto& multi_localized_unicode = static_cast<Gfx::ICC::MultiLocalizedUnicodeTagData&>(*tag_data);
             for (auto& record : multi_localized_unicode.records()) {


### PR DESCRIPTION
Screenshot:

```
% Build/lagom/icc /Users/thakis/Downloads/libjpeg-turbo-2.1.4/testimages/test1.icc
                  size: 557536 bytes
    preferred CMM type: 'lcms'
               version: 2.1.0
          device class: OutputDevice
      data color space: CMYK
      connection space: PCSLAB
creation date and time: 2000-07-26 01:41:53
      primary platform: Microsoft
                 flags: 0x00000000
                        - not embedded in file
                        - can be used independently of embedded color data
   device manufacturer: (not set)
          device model: (not set)
     device attributes: 0x0000000000000000
                        media is:
                        - reflective
                        - glossy
                        - of positive polarity
                        - colored
      rendering intent: Perceptual
        pcs illuminant: X = 0.964202, Y = 1, Z = 0.824905
               creator: 'lcms'
                    id: (not set)

tags:
profileDescriptionTag ('desc'): type 'desc', offset 276, size 224
    ascii: "Test profile, not suitable for real use"
    unicode: "Test profile, not suitable for real use"
    unicode language code: 0x0
    macintosh: (not set)
copyrightTag ('cprt'): type 'text', offset 500, size 35
    text: "Not suitable for real use"
mediaWhitePointTag ('wtpt'): type 'XYZ ', offset 536, size 20
    X = 0.708404, Y = 0.735946, Z = 0.571044
AToB0Tag ('A2B0'): type 'mft2', offset 556, size 41478
    input table: 4 channels x 256 entries
    output table: 3 channels x 2 entries
    color lookup table: 9 grid points, 19683 total entries
    e = [ 1, 0, 0,
          0, 1, 0,
          0, 0, 1 ]
AToB2Tag ('A2B2'): type 'mft2', offset 556, size 41478
    (see 'A2B0' above)
AToB1Tag ('A2B1'): type 'mft2', offset 42036, size 41478
    input table: 4 channels x 256 entries
    output table: 3 channels x 2 entries
    color lookup table: 9 grid points, 19683 total entries
    e = [ 1, 0, 0,
          0, 1, 0,
          0, 0, 1 ]
BToA0Tag ('B2A0'): type 'mft1', offset 83516, size 145588
    input table: 3 channels x 256 entries
    output table: 4 channels x 256 entries
    color lookup table: 33 grid points, 143748 total entries
    e = [ 1, 0, 0,
          0, 1, 0,
          0, 0, 1 ]
BToA1Tag ('B2A1'): type 'mft1', offset 229104, size 145588
    input table: 3 channels x 256 entries
    output table: 4 channels x 256 entries
    color lookup table: 33 grid points, 143748 total entries
    e = [ 1, 0, 0,
          0, 1, 0,
          0, 0, 1 ]
BToA2Tag ('B2A2'): type 'mft1', offset 374692, size 145588
    input table: 3 channels x 256 entries
    output table: 4 channels x 256 entries
    color lookup table: 33 grid points, 143748 total entries
    e = [ 1, 0, 0,
          0, 1, 0,
          0, 0, 1 ]
gamutTag ('gamt'): type 'mft1', offset 520280, size 37009
    input table: 3 channels x 256 entries
    output table: 1 channels x 256 entries
    color lookup table: 33 grid points, 35937 total entries
    e = [ 1, 0, 0,
          0, 1, 0,
          0, 0, 1 ]
deviceMfgDescTag ('dmnd'): type 'desc', offset 557292, size 128
    ascii: "Little CMS"
    unicode: "Little CMS"
    unicode language code: 0x0
    macintosh: (not set)
deviceModelDescTag ('dmdd'): type 'desc', offset 557420, size 116
    ascii: "2.x"
    unicode: "2.x"
    unicode language code: 0x0
    macintosh: (not set)
```

After this, only the `'mAB '` and `'mBA '` tag types are missing and we have all types used by required tags in all ICC profile types except for NamedColor.