### PR TITLE
Zip: Add support for modification time and date

### DIFF
--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -4,6 +4,7 @@ set(AK_SOURCES
     CircularBuffer.cpp
     DeprecatedFlyString.cpp
     DeprecatedString.cpp
+    DOSPackedTime.cpp
     Error.cpp
     FloatingPointStringConversions.cpp
     FlyString.cpp

--- a/AK/DOSPackedTime.cpp
+++ b/AK/DOSPackedTime.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, Undefine <undefine@undefine.pl>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/DOSPackedTime.h>
+
+namespace AK {
+
+Time time_from_packed_dos(DOSPackedDate date, DOSPackedTime time)
+{
+    if (date.value == 0)
+        return Time();
+
+    return Time::from_timestamp(first_dos_year + date.year, date.month, date.day, time.hour, time.minute, time.second * 2, 0);
+}
+
+DOSPackedDate to_packed_dos_date(unsigned year, unsigned month, unsigned day)
+{
+    DOSPackedDate date;
+    date.year = year - first_dos_year;
+    date.month = month;
+    date.day = day;
+
+    return date;
+}
+
+DOSPackedTime to_packed_dos_time(unsigned hour, unsigned minute, unsigned second)
+{
+    DOSPackedTime time;
+    time.hour = hour;
+    time.minute = minute;
+    time.second = second / 2;
+
+    return time;
+}
+
+}

--- a/AK/DOSPackedTime.h
+++ b/AK/DOSPackedTime.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022, Undefine <undefine@undefine.pl>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Time.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+union DOSPackedTime {
+    u16 value;
+    struct {
+        u16 second : 5;
+        u16 minute : 6;
+        u16 hour : 5;
+    };
+};
+static_assert(sizeof(DOSPackedTime) == 2);
+
+union DOSPackedDate {
+    u16 value;
+    struct {
+        u16 day : 5;
+        u16 month : 4;
+        u16 year : 7;
+    };
+};
+static_assert(sizeof(DOSPackedDate) == 2);
+
+inline constexpr u16 first_dos_year = 1980;
+
+Time time_from_packed_dos(DOSPackedDate, DOSPackedTime);
+DOSPackedDate to_packed_dos_date(unsigned year, unsigned month, unsigned day);
+DOSPackedTime to_packed_dos_time(unsigned hour, unsigned minute, unsigned second);
+
+}
+
+#if USING_AK_GLOBALLY
+using AK::DOSPackedDate;
+using AK::DOSPackedTime;
+using AK::time_from_packed_dos;
+using AK::to_packed_dos_date;
+using AK::to_packed_dos_time;
+#endif

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -481,6 +481,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
 endif()
 
 set(AK_SOURCES
+    ../AK/DOSPackedTime.cpp
     ../AK/GenericLexer.cpp
     ../AK/Hex.cpp
     ../AK/MemoryStream.cpp

--- a/Kernel/FileSystem/FATFS/Definitions.h
+++ b/Kernel/FileSystem/FATFS/Definitions.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/DOSPackedTime.h>
 #include <AK/EnumBits.h>
 #include <AK/Types.h>
 
@@ -54,38 +55,18 @@ enum class FATAttributes : u8 {
 
 AK_ENUM_BITWISE_OPERATORS(FATAttributes);
 
-union FATPackedTime {
-    u16 value;
-    struct {
-        u16 second : 5;
-        u16 minute : 6;
-        u16 hour : 5;
-    };
-};
-static_assert(sizeof(FATPackedTime) == 2);
-
-union FATPackedDate {
-    u16 value;
-    struct {
-        u16 day : 5;
-        u16 month : 4;
-        u16 year : 7;
-    };
-};
-static_assert(sizeof(FATPackedDate) == 2);
-
 struct [[gnu::packed]] FATEntry {
     char filename[8];
     char extension[3];
     FATAttributes attributes;
     u8 unused1;
     u8 creation_time_seconds;
-    FATPackedTime creation_time;
-    FATPackedDate creation_date;
-    FATPackedDate last_accessed_date;
+    DOSPackedTime creation_time;
+    DOSPackedDate creation_date;
+    DOSPackedDate last_accessed_date;
     u16 first_cluster_high;
-    FATPackedTime modification_time;
-    FATPackedDate modification_date;
+    DOSPackedTime modification_time;
+    DOSPackedDate modification_date;
     u16 first_cluster_low;
     u32 file_size;
 };

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -31,9 +31,9 @@ FATInode::FATInode(FATFS& fs, FATEntry entry, NonnullOwnPtr<KString> filename)
         .uid = 0,
         .gid = 0,
         .link_count = 0,
-        .atime = fat_date_time(m_entry.last_accessed_date, { 0 }),
-        .ctime = fat_date_time(m_entry.creation_date, m_entry.creation_time),
-        .mtime = fat_date_time(m_entry.modification_date, m_entry.modification_time),
+        .atime = time_from_packed_dos(m_entry.last_accessed_date, { 0 }),
+        .ctime = time_from_packed_dos(m_entry.creation_date, m_entry.creation_time),
+        .mtime = time_from_packed_dos(m_entry.modification_date, m_entry.modification_time),
         .dtime = {},
         .block_count = 0,
         .block_size = 0,
@@ -184,14 +184,6 @@ ErrorOr<NonnullOwnPtr<KString>> FATInode::compute_filename(FATEntry& entry, Vect
     }
 
     VERIFY_NOT_REACHED();
-}
-
-Time FATInode::fat_date_time(FATPackedDate date, FATPackedTime time)
-{
-    if (date.value == 0)
-        return Time();
-
-    return Time::from_timestamp(first_fat_year + date.year, date.month, date.day, time.hour, time.minute, time.second * 2, 0);
 }
 
 StringView FATInode::byte_terminated_string(StringView string, u8 fill_byte)

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -39,14 +39,11 @@ private:
     static constexpr u8 lfn_entry_character_termination = 0x00;
     static constexpr u8 lfn_entry_unused_byte = 0xFF;
 
-    static constexpr u16 first_fat_year = 1980;
-
     static constexpr u8 normal_filename_length = 8;
     static constexpr u8 normal_extension_length = 3;
 
     static ErrorOr<NonnullOwnPtr<KString>> compute_filename(FATEntry&, Vector<FATLongFileNameEntry> const& = {});
     static StringView byte_terminated_string(StringView, u8);
-    static Time fat_date_time(FATPackedDate, FATPackedTime);
 
     ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> compute_block_list();
     ErrorOr<NonnullOwnPtr<KBuffer>> read_block_list();

--- a/Userland/Libraries/LibArchive/Zip.cpp
+++ b/Userland/Libraries/LibArchive/Zip.cpp
@@ -90,6 +90,8 @@ ErrorOr<bool> Zip::for_each_member(Function<IterationDecision(ZipMember const&)>
         member.compression_method = central_directory_record.compression_method;
         member.uncompressed_size = central_directory_record.uncompressed_size;
         member.crc32 = central_directory_record.crc32;
+        member.modification_time = central_directory_record.modification_time;
+        member.modification_date = central_directory_record.modification_date;
         member.is_directory = central_directory_record.external_attributes & zip_directory_external_attribute || member.name.bytes_as_string_view().ends_with('/'); // FIXME: better directory detection
 
         if (callback(member) == IterationDecision::Break)
@@ -122,8 +124,8 @@ ErrorOr<void> ZipOutputStream::add_member(ZipMember const& member)
         .minimum_version = minimum_version_needed(member.compression_method),
         .general_purpose_flags = { .flags = 0 },
         .compression_method = static_cast<u16>(member.compression_method),
-        .modification_time = 0, // TODO: support modification time
-        .modification_date = 0,
+        .modification_time = member.modification_time,
+        .modification_date = member.modification_date,
         .crc32 = member.crc32,
         .compressed_size = static_cast<u32>(member.compressed_data.size()),
         .uncompressed_size = member.uncompressed_size,
@@ -150,8 +152,8 @@ ErrorOr<void> ZipOutputStream::finish()
             .minimum_version = zip_version,
             .general_purpose_flags = { .flags = 0 },
             .compression_method = member.compression_method,
-            .modification_time = 0, // TODO: support modification time
-            .modification_date = 0,
+            .modification_time = member.modification_time,
+            .modification_date = member.modification_date,
             .crc32 = member.crc32,
             .compressed_size = static_cast<u32>(member.compressed_data.size()),
             .uncompressed_size = member.uncompressed_size,

--- a/Userland/Libraries/LibArchive/Zip.h
+++ b/Userland/Libraries/LibArchive/Zip.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Array.h>
+#include <AK/DOSPackedTime.h>
 #include <AK/Function.h>
 #include <AK/IterationDecision.h>
 #include <AK/String.h>
@@ -112,8 +113,8 @@ struct [[gnu::packed]] CentralDirectoryRecord {
     u16 minimum_version;
     ZipGeneralPurposeFlags general_purpose_flags;
     ZipCompressionMethod compression_method;
-    u16 modification_time;
-    u16 modification_date;
+    DOSPackedTime modification_time;
+    DOSPackedDate modification_date;
     u32 crc32;
     u32 compressed_size;
     u32 uncompressed_size;
@@ -186,8 +187,8 @@ struct [[gnu::packed]] LocalFileHeader {
     u16 minimum_version;
     ZipGeneralPurposeFlags general_purpose_flags;
     u16 compression_method;
-    u16 modification_time;
-    u16 modification_date;
+    DOSPackedTime modification_time;
+    DOSPackedDate modification_date;
     u32 crc32;
     u32 compressed_size;
     u32 uncompressed_size;
@@ -244,6 +245,8 @@ struct ZipMember {
     u32 uncompressed_size;
     u32 crc32;
     bool is_directory;
+    DOSPackedTime modification_time;
+    DOSPackedDate modification_date;
 };
 
 class Zip {


### PR DESCRIPTION
This PR adds support for the modification date and time in zip archives. This means that after extracting the archive the file modification times are the same as the ones of the original files.