### PR TITLE
LibWeb: Fix parsing/to_string for "switch" ARIA role

### DIFF
--- a/Userland/Libraries/LibWeb/ARIA/Roles.cpp
+++ b/Userland/Libraries/LibWeb/ARIA/Roles.cpp
@@ -11,9 +11,12 @@ namespace Web::ARIA {
 
 StringView role_name(Role role)
 {
+    // Note: Role::switch_ is mapped to "switch" (due to C++ keyword clash)
     switch (role) {
-#define __ENUMERATE_ARIA_ROLE(name) \
-    case Role::name:                \
+#define __ENUMERATE_ARIA_ROLE(name)                \
+    case Role::name:                               \
+        if constexpr (Role::name == Role::switch_) \
+            return "switch"sv;                     \
         return #name##sv;
         ENUMERATE_ARIA_ROLES
 #undef __ENUMERATE_ARIA_ROLE
@@ -24,9 +27,15 @@ StringView role_name(Role role)
 
 Optional<Role> role_from_string(StringView role_name)
 {
-#define __ENUMERATE_ARIA_ROLE(name)                \
-    if (role_name.equals_ignoring_case(#name##sv)) \
-        return Role::name;
+    // Note: "switch" is mapped to Role::switch_ (due to C++ keyword clash)
+#define __ENUMERATE_ARIA_ROLE(name)                     \
+    if constexpr (Role::name == Role::switch_) {        \
+        if (role_name.equals_ignoring_case("switch"sv)) \
+            return Role::switch_;                       \
+    } else {                                            \
+        if (role_name.equals_ignoring_case(#name##sv))  \
+            return Role::name;                          \
+    }
     ENUMERATE_ARIA_ROLES
 #undef __ENUMERATE_ARIA_ROLE
     return {};


### PR DESCRIPTION
I accidentally regressed this in 890b4d7, this role needs to be handled specially due to the clash with the C++ 'switch' keyword.