### PR TITLE
PixelPaint: Increase default window height by 10px

### DIFF
--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -44,7 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = GUI::Window::construct();
     window->set_title("Pixel Paint");
-    window->resize(800, 510);
+    window->resize(800, 520);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto main_widget = TRY(window->set_main_widget<PixelPaint::MainWidget>());


### PR DESCRIPTION
This stops the clone and gradient tools from being cut off the side bar.