### PR TITLE
LibWeb: Table wrappers should not be ignored in auto height calculation

### DIFF
--- a/Tests/LibWeb/Layout/expected/table-auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/table-auto-height.txt
@@ -1,0 +1,23 @@
+InitialContainingBlock <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x60.9375 children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x42.9375 children: not-inline
+      BlockContainer <div> at (11,11) content-size 778x19.46875 children: not-inline
+        TableWrapper <(anonymous)> at (11,11) content-size 29.15625x19.46875 children: not-inline
+          TableBox <(anonymous)> at (11,11) content-size 29.15625x19.46875 children: not-inline
+            TableRowBox <(anonymous)> at (11,11) content-size 29.15625x19.46875 children: not-inline
+              TableCellBox <span> at (12,12) content-size 27.15625x17.46875 children: inline
+                line 0 width: 27.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 3, rect: [12,12 27.15625x17.46875]
+                    "foo"
+                TextNode <#text>
+      BlockContainer <div> at (11,32.46875) content-size 778x19.46875 children: not-inline
+        TableWrapper <(anonymous)> at (11,32.46875) content-size 29.640625x19.46875 children: not-inline
+          TableBox <(anonymous)> at (11,32.46875) content-size 29.640625x19.46875 children: not-inline
+            TableRowBox <(anonymous)> at (11,32.46875) content-size 29.640625x19.46875 children: not-inline
+              TableCellBox <span> at (12,33.46875) content-size 27.640625x17.46875 children: inline
+                line 0 width: 27.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 3, rect: [12,33.46875 27.640625x17.46875]
+                    "bar"
+                TextNode <#text>
+      BlockContainer <(anonymous)> at (10,52.9375) content-size 780x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/table-auto-height.html
+++ b/Tests/LibWeb/Layout/input/table-auto-height.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html><html><head><style>
+body {
+    font-family: 'SerenitySans';
+}
+* {
+    border: 1px solid black;
+}
+span {
+    display: table-cell;
+}
+</style></head><body><div><span>foo</span></div><div><span>bar</span></div>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -433,7 +433,7 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
             auto const& child_box_state = m_state.get(*child_box);
 
             // Ignore anonymous block containers with no lines. These don't count as in-flow block boxes.
-            if (child_box->is_anonymous() && child_box->is_block_container() && child_box_state.line_boxes.is_empty())
+            if (!child_box->is_table_wrapper() && child_box->is_anonymous() && child_box->is_block_container() && child_box_state.line_boxes.is_empty())
                 continue;
 
             auto margin_bottom = m_margin_state.current_collapsed_margin();

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -606,7 +606,11 @@ void TreeBuilder::generate_missing_parents(NodeWithStyle& root)
 
         parent.remove_child(*table_box);
         wrapper->append_child(*table_box);
-        parent.insert_before(*wrapper, *nearest_sibling);
+
+        if (nearest_sibling)
+            parent.insert_before(*wrapper, *nearest_sibling);
+        else
+            parent.append_child(*wrapper);
     }
 }
 


### PR DESCRIPTION
Though table wrappers are anonymous block containers (because TableWrapper is inherited from BlockContainer) with no lines they should not be skipped in block auto height calculation.

Fixes regression of https://kernel.org/