### PR TITLE
LibSQL: Use `kill` to exit forked SQLServer processes to avoid Qt issues

### DIFF
--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -69,7 +69,7 @@ static ErrorOr<void> launch_server(DeprecatedString const& socket_path, Deprecat
             auto server_pid_file = TRY(Core::Stream::File::open(pid_path, Core::Stream::OpenMode::Write));
             TRY(server_pid_file->write(DeprecatedString::number(server_pid).bytes()));
 
-            exit(0);
+            TRY(Core::System::kill(getpid(), SIGTERM));
         }
 
         server_fd = TRY(Core::System::dup(server_fd));


### PR DESCRIPTION
In order to daemonize the SQLServer process for Ladybird, we double-fork and exit the first child process to ensure the grandchild process is in a detached state to become SQLServer. After commit c05fcd5, this happens after Ladybird's QApplication is created. QApplication seems to hook up some `exit` handling that makes the call to `exit(0)` here not actually exit the child process.

Instead, using `kill` with SIGTERM will actually terminate the child process.