### PR TITLE
Tests: Make LibGfx tests not depend on LibGUI

### DIFF
--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TEST_SOURCES
 )
 
 foreach(source IN LISTS TEST_SOURCES)
-    serenity_test("${source}" LibGfx LIBS LibGfx LibGUI)
+    serenity_test("${source}" LibGfx LIBS LibGfx)
 endforeach()
 
 install(FILES TestFont.font DESTINATION usr/Tests/LibGfx)


### PR DESCRIPTION
As far as I can tell, that's not needed and never was.