### PR TITLE
PixelPaint: Update text tool font color on primary color change

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/TextTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.cpp
@@ -41,6 +41,13 @@ TextTool::TextTool()
     }).release_value_but_fixme_should_propagate_errors();
 }
 
+void TextTool::on_tool_activation()
+{
+    m_editor->on_primary_color_change = [this](auto color) {
+        m_text_color = color;
+    };
+}
+
 void TextTool::on_tool_deactivation()
 {
     reset_tool();

--- a/Userland/Applications/PixelPaint/Tools/TextTool.h
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.h
@@ -37,6 +37,7 @@ public:
     virtual void on_mousedown(Layer*, MouseEvent&) override;
     virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
+    virtual void on_tool_activation() override;
     virtual void on_tool_deactivation() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
     virtual GUI::Widget* get_properties_widget() override;


### PR DESCRIPTION
This PR ensures that the text tool font color always matches the currently selected primary color.

NB: The changes here only allow you to set all of the text is set to the same color, regardless of the current text selection.

Video:

https://user-images.githubusercontent.com/2817754/215361388-f551b285-c6f8-46a4-a685-73829c401235.mp4
