### PR TITLE
AK: Port `LEB128` to `AK::Stream` and make it useable with `read_value`

### DIFF
--- a/AK/BufferedStream.h
+++ b/AK/BufferedStream.h
@@ -295,7 +295,7 @@ public:
 
         return result;
     }
-    virtual ErrorOr<void> truncate(off_t length) override
+    virtual ErrorOr<void> truncate(size_t length) override
     {
         return m_helper.stream().truncate(length);
     }

--- a/AK/DeprecatedMemoryStream.h
+++ b/AK/DeprecatedMemoryStream.h
@@ -8,7 +8,6 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/DeprecatedStream.h>
-#include <AK/LEB128.h>
 #include <AK/MemMem.h>
 #include <AK/Vector.h>
 
@@ -73,12 +72,6 @@ public:
 
         return m_bytes[m_offset];
     }
-
-    template<typename ValueType>
-    bool read_LEB128_unsigned(ValueType& result) { return LEB128::read_unsigned(*this, result); }
-
-    template<typename ValueType>
-    bool read_LEB128_signed(ValueType& result) { return LEB128::read_signed(*this, result); }
 
     ReadonlyBytes bytes() const { return m_bytes; }
     size_t offset() const { return m_offset; }

--- a/AK/LEB128.h
+++ b/AK/LEB128.h
@@ -6,36 +6,32 @@
 
 #pragma once
 
-#include <AK/DeprecatedStream.h>
 #include <AK/NumericLimits.h>
+#include <AK/Stream.h>
 #include <AK/Types.h>
 
 namespace AK {
 
 struct LEB128 {
     template<typename ValueType = size_t>
-    static bool read_unsigned(DeprecatedInputStream& stream, ValueType& result)
+    static ErrorOr<void> read_unsigned(AK::Stream& stream, ValueType& result)
     {
         result = 0;
         size_t num_bytes = 0;
         while (true) {
-            if (stream.unreliable_eof()) {
-                stream.set_fatal_error();
-                return false;
-            }
-            u8 byte = 0;
-            stream >> byte;
-            if (stream.has_any_error())
-                return false;
+            if (stream.is_eof())
+                return Error::from_string_literal("Stream reached end-of-file while reading LEB128 value");
+
+            auto byte = TRY(stream.read_value<u8>());
 
             ValueType masked_byte = byte & ~(1 << 7);
             bool const shift_too_large_for_result = num_bytes * 7 > sizeof(ValueType) * 8;
             if (shift_too_large_for_result)
-                return false;
+                return Error::from_string_literal("Read value contains more bits than fit the chosen ValueType");
 
             bool const shift_too_large_for_byte = ((masked_byte << (num_bytes * 7)) >> (num_bytes * 7)) != masked_byte;
             if (shift_too_large_for_byte)
-                return false;
+                return Error::from_string_literal("Read byte is too large to fit the chosen ValueType");
 
             result = (result) | (masked_byte << (num_bytes * 7));
             if (!(byte & (1 << 7)))
@@ -43,11 +39,11 @@ struct LEB128 {
             ++num_bytes;
         }
 
-        return true;
+        return {};
     }
 
     template<typename ValueType = ssize_t>
-    static bool read_signed(DeprecatedInputStream& stream, ValueType& result)
+    static ErrorOr<void> read_signed(AK::Stream& stream, ValueType& result)
     {
         // Note: We read into a u64 to simplify the parsing logic;
         //    result is range checked into ValueType after parsing.
@@ -59,24 +55,20 @@ struct LEB128 {
         result = 0;
 
         do {
-            if (stream.unreliable_eof()) {
-                stream.set_fatal_error();
-                return false;
-            }
+            if (stream.is_eof())
+                return Error::from_string_literal("Stream reached end-of-file while reading LEB128 value");
 
-            stream >> byte;
-            if (stream.has_any_error())
-                return false;
+            byte = TRY(stream.read_value<u8>());
 
             // note: 64 bit assumptions!
             u64 masked_byte = byte & ~(1 << 7);
             bool const shift_too_large_for_result = num_bytes * 7 >= 64;
             if (shift_too_large_for_result)
-                return false;
+                return Error::from_string_literal("Read value contains more bits than fit the chosen ValueType");
 
             bool const shift_too_large_for_byte = (num_bytes * 7) == 63 && masked_byte != 0x00 && masked_byte != 0x7Fu;
             if (shift_too_large_for_byte)
-                return false;
+                return Error::from_string_literal("Read byte is too large to fit the chosen ValueType");
 
             temp = (temp) | (masked_byte << (num_bytes * 7));
             ++num_bytes;
@@ -90,12 +82,12 @@ struct LEB128 {
         // Now that we've accumulated into an i64, make sure it fits into result
         if constexpr (sizeof(ValueType) < sizeof(u64)) {
             if (temp > NumericLimits<ValueType>::max() || temp < NumericLimits<ValueType>::min())
-                return false;
+                return Error::from_string_literal("Temporary value does not fit the result type");
         }
 
         result = static_cast<ValueType>(temp);
 
-        return true;
+        return {};
     }
 };
 

--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -48,7 +48,7 @@ void FixedMemoryStream::close()
     // FIXME: It doesn't make sense to close a memory stream. Therefore, we don't do anything here. Is that fine?
 }
 
-ErrorOr<void> FixedMemoryStream::truncate(off_t)
+ErrorOr<void> FixedMemoryStream::truncate(size_t)
 {
     return Error::from_errno(EBADF);
 }

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -22,7 +22,7 @@ public:
     virtual bool is_eof() const override;
     virtual bool is_open() const override;
     virtual void close() override;
-    virtual ErrorOr<void> truncate(off_t) override;
+    virtual ErrorOr<void> truncate(size_t) override;
     virtual ErrorOr<Bytes> read(Bytes bytes) override;
 
     virtual ErrorOr<size_t> seek(i64 offset, SeekMode seek_mode = SeekMode::SetPosition) override;

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -120,7 +120,7 @@ public:
     virtual ErrorOr<size_t> size();
     /// Shrinks or extends the stream to the given size. Returns an errno in
     /// the case of an error.
-    virtual ErrorOr<void> truncate(off_t length) = 0;
+    virtual ErrorOr<void> truncate(size_t length) = 0;
     /// Seeks until after the given amount of bytes to be discarded instead of
     /// reading and discarding everything manually;
     virtual ErrorOr<void> discard(size_t discarded_bytes) override;

--- a/Tests/AK/TestLEB128.cpp
+++ b/Tests/AK/TestLEB128.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedMemoryStream.h>
 #include <AK/LEB128.h>
+#include <AK/MemoryStream.h>
 #include <AK/NumericLimits.h>
 #include <LibTest/TestCase.h>
 
@@ -14,48 +14,42 @@ TEST_CASE(single_byte)
     u32 output = {};
     i32 output_signed = {};
     u8 buf[] = { 0x00 };
-    DeprecatedInputMemoryStream stream({ buf, sizeof(buf) });
+    auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { buf, sizeof(buf) }));
 
     // less than/eq 0b0011_1111, signed == unsigned == raw byte
     for (u8 i = 0u; i <= 0x3F; ++i) {
         buf[0] = i;
 
-        stream.seek(0);
-        EXPECT(LEB128::read_unsigned(stream, output));
+        MUST(stream->seek(0));
+        EXPECT(!LEB128::read_unsigned(*stream, output).is_error());
         EXPECT_EQ(output, i);
-        EXPECT(!stream.handle_any_error());
 
-        stream.seek(0);
-        EXPECT(LEB128::read_signed(stream, output_signed));
+        MUST(stream->seek(0));
+        EXPECT(!LEB128::read_signed(*stream, output_signed).is_error());
         EXPECT_EQ(output_signed, i);
-        EXPECT(!stream.handle_any_error());
     }
 
     // 0b0100_0000 to 0b0111_1111 unsigned == byte, signed = {{ 26'b(-1), 6'b(byte) }}
     for (u8 i = 0x40u; i < 0x80; ++i) {
         buf[0] = i;
 
-        stream.seek(0);
-        EXPECT(LEB128::read_unsigned(stream, output));
+        MUST(stream->seek(0));
+        EXPECT(!LEB128::read_unsigned(*stream, output).is_error());
         EXPECT_EQ(output, i);
-        EXPECT(!stream.handle_any_error());
 
-        stream.seek(0);
-        EXPECT(LEB128::read_signed(stream, output_signed));
+        MUST(stream->seek(0));
+        EXPECT(!LEB128::read_signed(*stream, output_signed).is_error());
         EXPECT_EQ(output_signed, (i | (-1 & (~0x3F))));
-        EXPECT(!stream.handle_any_error());
     }
     // MSB set, but input too short
     for (u16 i = 0x80; i <= 0xFF; ++i) {
         buf[0] = static_cast<u8>(i);
 
-        stream.seek(0);
-        EXPECT(!LEB128::read_unsigned(stream, output));
-        EXPECT(stream.handle_any_error());
+        MUST(stream->seek(0));
+        EXPECT(LEB128::read_unsigned(*stream, output).is_error());
 
-        stream.seek(0);
-        EXPECT(!LEB128::read_signed(stream, output_signed));
-        EXPECT(stream.handle_any_error());
+        MUST(stream->seek(0));
+        EXPECT(LEB128::read_signed(*stream, output_signed).is_error());
     }
 }
 
@@ -64,7 +58,7 @@ TEST_CASE(two_bytes)
     u32 output = {};
     i32 output_signed = {};
     u8 buf[] = { 0x00, 0x1 };
-    DeprecatedInputMemoryStream stream({ buf, sizeof(buf) });
+    auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { buf, sizeof(buf) }));
 
     // Only test with first byte expecting more, otherwise equivalent to single byte case
     for (u16 i = 0x80; i <= 0xFF; ++i) {
@@ -74,43 +68,37 @@ TEST_CASE(two_bytes)
         for (u8 j = 0u; j <= 0x3F; ++j) {
             buf[1] = j;
 
-            stream.seek(0);
-            EXPECT(LEB128::read_unsigned(stream, output));
+            MUST(stream->seek(0));
+            EXPECT(!LEB128::read_unsigned(*stream, output).is_error());
             EXPECT_EQ(output, (static_cast<u32>(j) << 7) + (i & 0x7F));
-            EXPECT(!stream.handle_any_error());
 
-            stream.seek(0);
-            EXPECT(LEB128::read_signed(stream, output_signed));
+            MUST(stream->seek(0));
+            EXPECT(!LEB128::read_signed(*stream, output_signed).is_error());
             EXPECT_EQ(output_signed, (static_cast<i32>(j) << 7) + (i & 0x7F));
-            EXPECT(!stream.handle_any_error());
         }
 
         // 0b0100_0000 to 0b0111_1111: unsigned == (j << 7) + (7 MSB of i), signed == {{ 19'b(-1), 6'b(j), 7'b(i) }}
         for (u8 j = 0x40u; j < 0x80; ++j) {
             buf[1] = j;
 
-            stream.seek(0);
-            EXPECT(LEB128::read_unsigned(stream, output));
+            MUST(stream->seek(0));
+            EXPECT(!LEB128::read_unsigned(*stream, output).is_error());
             EXPECT_EQ(output, (static_cast<u32>(j) << 7) + (i & 0x7F));
-            EXPECT(!stream.handle_any_error());
 
-            stream.seek(0);
-            EXPECT(LEB128::read_signed(stream, output_signed));
+            MUST(stream->seek(0));
+            EXPECT(!LEB128::read_signed(*stream, output_signed).is_error());
             EXPECT_EQ(output_signed, ((static_cast<i32>(j) << 7) + (i & 0x7F)) | (-1 & (~0x3FFF)));
-            EXPECT(!stream.handle_any_error());
         }
 
         // MSB set on last byte, but input too short
         for (u16 j = 0x80; j <= 0xFF; ++j) {
             buf[1] = static_cast<u8>(j);
 
-            stream.seek(0);
-            EXPECT(!LEB128::read_unsigned(stream, output));
-            EXPECT(stream.handle_any_error());
+            MUST(stream->seek(0));
+            EXPECT(LEB128::read_unsigned(*stream, output).is_error());
 
-            stream.seek(0);
-            EXPECT(!LEB128::read_signed(stream, output_signed));
-            EXPECT(stream.handle_any_error());
+            MUST(stream->seek(0));
+            EXPECT(LEB128::read_signed(*stream, output_signed).is_error());
         }
     }
 }
@@ -120,31 +108,27 @@ TEST_CASE(overflow_sizeof_output_unsigned)
     u8 u32_max_plus_one[] = { 0x80, 0x80, 0x80, 0x80, 0x10 };
     {
         u32 out = 0;
-        DeprecatedInputMemoryStream stream({ u32_max_plus_one, sizeof(u32_max_plus_one) });
-        EXPECT(!LEB128::read_unsigned(stream, out));
+        auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { u32_max_plus_one, sizeof(u32_max_plus_one) }));
+        EXPECT(LEB128::read_unsigned(*stream, out).is_error());
         EXPECT_EQ(out, 0u);
-        EXPECT(!stream.handle_any_error());
 
         u64 out64 = 0;
-        stream.seek(0);
-        EXPECT(LEB128::read_unsigned(stream, out64));
+        MUST(stream->seek(0));
+        EXPECT(!LEB128::read_unsigned(*stream, out64).is_error());
         EXPECT_EQ(out64, static_cast<u64>(NumericLimits<u32>::max()) + 1);
-        EXPECT(!stream.handle_any_error());
     }
 
     u8 u32_max[] = { 0xFF, 0xFF, 0xFF, 0xFF, 0x0F };
     {
         u32 out = 0;
-        DeprecatedInputMemoryStream stream({ u32_max, sizeof(u32_max) });
-        EXPECT(LEB128::read_unsigned(stream, out));
+        auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { u32_max, sizeof(u32_max) }));
+        EXPECT(!LEB128::read_unsigned(*stream, out).is_error());
         EXPECT_EQ(out, NumericLimits<u32>::max());
-        EXPECT(!stream.handle_any_error());
 
         u64 out64 = 0;
-        stream.seek(0);
-        EXPECT(LEB128::read_unsigned(stream, out64));
+        MUST(stream->seek(0));
+        EXPECT(!LEB128::read_unsigned(*stream, out64).is_error());
         EXPECT_EQ(out64, NumericLimits<u32>::max());
-        EXPECT(!stream.handle_any_error());
     }
 }
 
@@ -153,60 +137,52 @@ TEST_CASE(overflow_sizeof_output_signed)
     u8 i32_max_plus_one[] = { 0x80, 0x80, 0x80, 0x80, 0x08 };
     {
         i32 out = 0;
-        DeprecatedInputMemoryStream stream({ i32_max_plus_one, sizeof(i32_max_plus_one) });
-        EXPECT(!LEB128::read_signed(stream, out));
+        auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { i32_max_plus_one, sizeof(i32_max_plus_one) }));
+        EXPECT(LEB128::read_signed(*stream, out).is_error());
         EXPECT_EQ(out, 0);
-        EXPECT(!stream.handle_any_error());
 
         i64 out64 = 0;
-        stream.seek(0);
-        EXPECT(LEB128::read_signed(stream, out64));
+        MUST(stream->seek(0));
+        EXPECT(!LEB128::read_signed(*stream, out64).is_error());
         EXPECT_EQ(out64, static_cast<i64>(NumericLimits<i32>::max()) + 1);
-        EXPECT(!stream.handle_any_error());
     }
 
     u8 i32_max[] = { 0xFF, 0xFF, 0xFF, 0xFF, 0x07 };
     {
         i32 out = 0;
-        DeprecatedInputMemoryStream stream({ i32_max, sizeof(i32_max) });
-        EXPECT(LEB128::read_signed(stream, out));
+        auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { i32_max, sizeof(i32_max) }));
+        EXPECT(!LEB128::read_signed(*stream, out).is_error());
         EXPECT_EQ(out, NumericLimits<i32>::max());
-        EXPECT(!stream.handle_any_error());
 
         i64 out64 = 0;
-        stream.seek(0);
-        EXPECT(LEB128::read_signed(stream, out64));
+        MUST(stream->seek(0));
+        EXPECT(!LEB128::read_signed(*stream, out64).is_error());
         EXPECT_EQ(out64, NumericLimits<i32>::max());
-        EXPECT(!stream.handle_any_error());
     }
 
     u8 i32_min_minus_one[] = { 0xFF, 0xFF, 0xFF, 0xFF, 0x77 };
     {
         i32 out = 0;
-        DeprecatedInputMemoryStream stream({ i32_min_minus_one, sizeof(i32_min_minus_one) });
-        EXPECT(!LEB128::read_signed(stream, out));
+        auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { i32_min_minus_one, sizeof(i32_min_minus_one) }));
+        EXPECT(LEB128::read_signed(*stream, out).is_error());
         EXPECT_EQ(out, 0);
-        EXPECT(!stream.handle_any_error());
 
         i64 out64 = 0;
-        stream.seek(0);
-        EXPECT(LEB128::read_signed(stream, out64));
+        MUST(stream->seek(0));
+        EXPECT(!LEB128::read_signed(*stream, out64).is_error());
         EXPECT_EQ(out64, static_cast<i64>(NumericLimits<i32>::min()) - 1);
-        EXPECT(!stream.handle_any_error());
     }
 
     u8 i32_min[] = { 0x80, 0x80, 0x80, 0x80, 0x78 };
     {
         i32 out = 0;
-        DeprecatedInputMemoryStream stream({ i32_min, sizeof(i32_min) });
-        EXPECT(LEB128::read_signed(stream, out));
+        auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { i32_min, sizeof(i32_min) }));
+        EXPECT(!LEB128::read_signed(*stream, out).is_error());
         EXPECT_EQ(out, NumericLimits<i32>::min());
-        EXPECT(!stream.handle_any_error());
 
         i64 out64 = 0;
-        stream.seek(0);
-        EXPECT(LEB128::read_signed(stream, out64));
+        MUST(stream->seek(0));
+        EXPECT(!LEB128::read_signed(*stream, out64).is_error());
         EXPECT_EQ(out64, NumericLimits<i32>::min());
-        EXPECT(!stream.handle_any_error());
     }
 }

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -184,8 +184,11 @@ ErrorOr<size_t> File::seek(i64 offset, SeekMode mode)
     return seek_result;
 }
 
-ErrorOr<void> File::truncate(off_t length)
+ErrorOr<void> File::truncate(size_t length)
 {
+    if (length > static_cast<size_t>(NumericLimits<off_t>::max()))
+        return Error::from_string_literal("Length is larger than the maximum supported length");
+
     return System::ftruncate(m_fd, length);
 }
 

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -169,7 +169,7 @@ public:
     virtual bool is_open() const override;
     virtual void close() override;
     virtual ErrorOr<size_t> seek(i64 offset, SeekMode) override;
-    virtual ErrorOr<void> truncate(off_t length) override;
+    virtual ErrorOr<void> truncate(size_t length) override;
 
     int leak_fd(Badge<::IPC::File>)
     {

--- a/Userland/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
@@ -23,18 +23,17 @@ ErrorOr<void> AbbreviationsMap::populate_map()
 {
     auto abbreviation_stream = TRY(FixedMemoryStream::construct(m_dwarf_info.abbreviation_data()));
     TRY(abbreviation_stream->discard(m_offset));
-    Core::Stream::WrapInAKInputStream wrapped_abbreviation_stream { *abbreviation_stream };
 
     while (!abbreviation_stream->is_eof()) {
         size_t abbreviation_code = 0;
-        LEB128::read_unsigned(wrapped_abbreviation_stream, abbreviation_code);
+        TRY(LEB128::read_unsigned(*abbreviation_stream, abbreviation_code));
         // An abbreviation code of 0 marks the end of the
         // abbreviations for a given compilation unit
         if (abbreviation_code == 0)
             break;
 
         size_t tag {};
-        LEB128::read_unsigned(wrapped_abbreviation_stream, tag);
+        TRY(LEB128::read_unsigned(*abbreviation_stream, tag));
 
         auto has_children = TRY(abbreviation_stream->read_value<u8>());
 
@@ -46,15 +45,15 @@ ErrorOr<void> AbbreviationsMap::populate_map()
         do {
             size_t attribute_value = 0;
             size_t form_value = 0;
-            LEB128::read_unsigned(wrapped_abbreviation_stream, attribute_value);
-            LEB128::read_unsigned(wrapped_abbreviation_stream, form_value);
+            TRY(LEB128::read_unsigned(*abbreviation_stream, attribute_value));
+            TRY(LEB128::read_unsigned(*abbreviation_stream, form_value));
 
             current_attribute_specification.attribute = static_cast<Attribute>(attribute_value);
             current_attribute_specification.form = static_cast<AttributeDataForm>(form_value);
 
             if (current_attribute_specification.form == AttributeDataForm::ImplicitConst) {
                 ssize_t data_value;
-                LEB128::read_signed(wrapped_abbreviation_stream, data_value);
+                TRY(LEB128::read_signed(*abbreviation_stream, data_value));
                 current_attribute_specification.value = data_value;
             }
 

--- a/Userland/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
@@ -25,15 +25,13 @@ ErrorOr<void> AbbreviationsMap::populate_map()
     TRY(abbreviation_stream->discard(m_offset));
 
     while (!abbreviation_stream->is_eof()) {
-        size_t abbreviation_code = 0;
-        TRY(LEB128::read_unsigned(*abbreviation_stream, abbreviation_code));
+        size_t abbreviation_code = TRY(abbreviation_stream->read_value<LEB128<size_t>>());
         // An abbreviation code of 0 marks the end of the
         // abbreviations for a given compilation unit
         if (abbreviation_code == 0)
             break;
 
-        size_t tag {};
-        TRY(LEB128::read_unsigned(*abbreviation_stream, tag));
+        size_t tag = TRY(abbreviation_stream->read_value<LEB128<size_t>>());
 
         auto has_children = TRY(abbreviation_stream->read_value<u8>());
 
@@ -43,17 +41,14 @@ ErrorOr<void> AbbreviationsMap::populate_map()
 
         AttributeSpecification current_attribute_specification {};
         do {
-            size_t attribute_value = 0;
-            size_t form_value = 0;
-            TRY(LEB128::read_unsigned(*abbreviation_stream, attribute_value));
-            TRY(LEB128::read_unsigned(*abbreviation_stream, form_value));
+            size_t attribute_value = TRY(abbreviation_stream->read_value<LEB128<size_t>>());
+            size_t form_value = TRY(abbreviation_stream->read_value<LEB128<size_t>>());
 
             current_attribute_specification.attribute = static_cast<Attribute>(attribute_value);
             current_attribute_specification.form = static_cast<AttributeDataForm>(form_value);
 
             if (current_attribute_specification.form == AttributeDataForm::ImplicitConst) {
-                ssize_t data_value;
-                TRY(LEB128::read_signed(*abbreviation_stream, data_value));
+                ssize_t data_value = TRY(abbreviation_stream->read_value<LEB128<ssize_t>>());
                 current_attribute_specification.value = data_value;
             }
 

--- a/Userland/Libraries/LibDebug/Dwarf/AddressRanges.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/AddressRanges.cpp
@@ -30,8 +30,7 @@ ErrorOr<void> AddressRangesV5::for_each_range(Function<void(Range)> callback)
             break;
         }
         case RangeListEntryType::BaseAddressX: {
-            FlatPtr index;
-            TRY(LEB128::read_unsigned(*m_range_lists_stream, index));
+            FlatPtr index = TRY(m_range_lists_stream->read_value<LEB128<FlatPtr>>());
             current_base_address = TRY(m_compilation_unit.get_address(index));
             break;
         }
@@ -44,30 +43,26 @@ ErrorOr<void> AddressRangesV5::for_each_range(Function<void(Range)> callback)
             if (!base_address.has_value())
                 return Error::from_string_literal("Expected base_address for rangelist");
 
-            size_t start_offset, end_offset;
-            TRY(LEB128::read_unsigned(*m_range_lists_stream, start_offset));
-            TRY(LEB128::read_unsigned(*m_range_lists_stream, end_offset));
+            size_t start_offset = TRY(m_range_lists_stream->read_value<LEB128<size_t>>());
+            size_t end_offset = TRY(m_range_lists_stream->read_value<LEB128<size_t>>());
             callback(Range { start_offset + *base_address, end_offset + *base_address });
             break;
         }
         case RangeListEntryType::StartLength: {
             auto start = TRY(m_range_lists_stream->read_value<FlatPtr>());
-            size_t length;
-            TRY(LEB128::read_unsigned(*m_range_lists_stream, length));
+            size_t length = TRY(m_range_lists_stream->read_value<LEB128<size_t>>());
             callback(Range { start, start + length });
             break;
         }
         case RangeListEntryType::StartXEndX: {
-            size_t start, end;
-            TRY(LEB128::read_unsigned(*m_range_lists_stream, start));
-            TRY(LEB128::read_unsigned(*m_range_lists_stream, end));
+            size_t start = TRY(m_range_lists_stream->read_value<LEB128<size_t>>());
+            size_t end = TRY(m_range_lists_stream->read_value<LEB128<size_t>>());
             callback(Range { TRY(m_compilation_unit.get_address(start)), TRY(m_compilation_unit.get_address(end)) });
             break;
         }
         case RangeListEntryType::StartXLength: {
-            size_t start, length;
-            TRY(LEB128::read_unsigned(*m_range_lists_stream, start));
-            TRY(LEB128::read_unsigned(*m_range_lists_stream, length));
+            size_t start = TRY(m_range_lists_stream->read_value<LEB128<size_t>>());
+            size_t length = TRY(m_range_lists_stream->read_value<LEB128<size_t>>());
             auto start_addr = TRY(m_compilation_unit.get_address(start));
             callback(Range { start_addr, start_addr + length });
             break;

--- a/Userland/Libraries/LibDebug/Dwarf/DIE.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DIE.cpp
@@ -26,8 +26,7 @@ ErrorOr<void> DIE::rehydrate_from(u32 offset, Optional<u32> parent_offset)
     auto stream = TRY(FixedMemoryStream::construct(m_compilation_unit.dwarf_info().debug_info_data()));
     // Note: We can't just slice away from the input data here, since get_attribute_value will try to recover the original offset using seek().
     TRY(stream->seek(m_offset));
-    Core::Stream::WrapInAKInputStream wrapped_stream { *stream };
-    LEB128::read_unsigned(wrapped_stream, m_abbreviation_code);
+    TRY(LEB128::read_unsigned(*stream, m_abbreviation_code));
     m_data_offset = TRY(stream->tell());
 
     if (m_abbreviation_code == 0) {

--- a/Userland/Libraries/LibDebug/Dwarf/DIE.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DIE.cpp
@@ -26,7 +26,7 @@ ErrorOr<void> DIE::rehydrate_from(u32 offset, Optional<u32> parent_offset)
     auto stream = TRY(FixedMemoryStream::construct(m_compilation_unit.dwarf_info().debug_info_data()));
     // Note: We can't just slice away from the input data here, since get_attribute_value will try to recover the original offset using seek().
     TRY(stream->seek(m_offset));
-    TRY(LEB128::read_unsigned(*stream, m_abbreviation_code));
+    m_abbreviation_code = TRY(stream->read_value<LEB128<size_t>>());
     m_data_offset = TRY(stream->tell());
 
     if (m_abbreviation_code == 0) {

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -121,18 +121,14 @@ ErrorOr<AttributeValue> DwarfInfo::get_attribute_value(AttributeDataForm form, s
     }
     case AttributeDataForm::SData: {
         i64 data;
-        Core::Stream::WrapInAKInputStream wrapped_debug_info_stream { debug_info_stream };
-        LEB128::read_signed(wrapped_debug_info_stream, data);
-        VERIFY(!wrapped_debug_info_stream.has_any_error());
+        TRY(LEB128::read_signed(debug_info_stream, data));
         value.m_type = AttributeValue::Type::SignedNumber;
         value.m_data.as_signed = data;
         break;
     }
     case AttributeDataForm::UData: {
         u64 data;
-        Core::Stream::WrapInAKInputStream wrapped_debug_info_stream { debug_info_stream };
-        LEB128::read_unsigned(wrapped_debug_info_stream, data);
-        VERIFY(!wrapped_debug_info_stream.has_any_error());
+        TRY(LEB128::read_unsigned(debug_info_stream, data));
         value.m_type = AttributeValue::Type::UnsignedNumber;
         value.m_data.as_unsigned = data;
         break;
@@ -174,9 +170,7 @@ ErrorOr<AttributeValue> DwarfInfo::get_attribute_value(AttributeDataForm form, s
     }
     case AttributeDataForm::ExprLoc: {
         size_t length;
-        Core::Stream::WrapInAKInputStream wrapped_debug_info_stream { debug_info_stream };
-        LEB128::read_unsigned(wrapped_debug_info_stream, length);
-        VERIFY(!wrapped_debug_info_stream.has_any_error());
+        TRY(LEB128::read_unsigned(debug_info_stream, length));
         value.m_type = AttributeValue::Type::DwarfExpression;
         TRY(assign_raw_bytes_value(length));
         break;
@@ -209,9 +203,7 @@ ErrorOr<AttributeValue> DwarfInfo::get_attribute_value(AttributeDataForm form, s
     case AttributeDataForm::Block: {
         value.m_type = AttributeValue::Type::RawBytes;
         size_t length;
-        Core::Stream::WrapInAKInputStream wrapped_debug_info_stream { debug_info_stream };
-        LEB128::read_unsigned(wrapped_debug_info_stream, length);
-        VERIFY(!wrapped_debug_info_stream.has_any_error());
+        TRY(LEB128::read_unsigned(debug_info_stream, length));
         TRY(assign_raw_bytes_value(length));
         break;
     }
@@ -249,9 +241,7 @@ ErrorOr<AttributeValue> DwarfInfo::get_attribute_value(AttributeDataForm form, s
     }
     case AttributeDataForm::StrX: {
         size_t index;
-        Core::Stream::WrapInAKInputStream wrapped_debug_info_stream { debug_info_stream };
-        LEB128::read_unsigned(wrapped_debug_info_stream, index);
-        VERIFY(!wrapped_debug_info_stream.has_any_error());
+        TRY(LEB128::read_unsigned(debug_info_stream, index));
         value.m_type = AttributeValue::Type::String;
         value.m_data.as_unsigned = index;
         break;
@@ -276,18 +266,14 @@ ErrorOr<AttributeValue> DwarfInfo::get_attribute_value(AttributeDataForm form, s
     }
     case AttributeDataForm::AddrX: {
         size_t index;
-        Core::Stream::WrapInAKInputStream wrapped_debug_info_stream { debug_info_stream };
-        LEB128::read_unsigned(wrapped_debug_info_stream, index);
-        VERIFY(!wrapped_debug_info_stream.has_any_error());
+        TRY(LEB128::read_unsigned(debug_info_stream, index));
         value.m_type = AttributeValue::Type::Address;
         value.m_data.as_unsigned = index;
         break;
     }
     case AttributeDataForm::RngListX: {
         size_t index;
-        Core::Stream::WrapInAKInputStream wrapped_debug_info_stream { debug_info_stream };
-        LEB128::read_unsigned(wrapped_debug_info_stream, index);
-        VERIFY(!wrapped_debug_info_stream.has_any_error());
+        TRY(LEB128::read_unsigned(debug_info_stream, index));
         value.m_type = AttributeValue::Type::UnsignedNumber;
         value.m_data.as_unsigned = index;
         break;

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -120,15 +120,13 @@ ErrorOr<AttributeValue> DwarfInfo::get_attribute_value(AttributeDataForm form, s
         break;
     }
     case AttributeDataForm::SData: {
-        i64 data;
-        TRY(LEB128::read_signed(debug_info_stream, data));
+        i64 data = TRY(debug_info_stream.read_value<LEB128<i64>>());
         value.m_type = AttributeValue::Type::SignedNumber;
         value.m_data.as_signed = data;
         break;
     }
     case AttributeDataForm::UData: {
-        u64 data;
-        TRY(LEB128::read_unsigned(debug_info_stream, data));
+        u64 data = TRY(debug_info_stream.read_value<LEB128<u64>>());
         value.m_type = AttributeValue::Type::UnsignedNumber;
         value.m_data.as_unsigned = data;
         break;
@@ -169,8 +167,7 @@ ErrorOr<AttributeValue> DwarfInfo::get_attribute_value(AttributeDataForm form, s
         break;
     }
     case AttributeDataForm::ExprLoc: {
-        size_t length;
-        TRY(LEB128::read_unsigned(debug_info_stream, length));
+        size_t length = TRY(debug_info_stream.read_value<LEB128<size_t>>());
         value.m_type = AttributeValue::Type::DwarfExpression;
         TRY(assign_raw_bytes_value(length));
         break;
@@ -202,8 +199,7 @@ ErrorOr<AttributeValue> DwarfInfo::get_attribute_value(AttributeDataForm form, s
     }
     case AttributeDataForm::Block: {
         value.m_type = AttributeValue::Type::RawBytes;
-        size_t length;
-        TRY(LEB128::read_unsigned(debug_info_stream, length));
+        size_t length = TRY(debug_info_stream.read_value<LEB128<size_t>>());
         TRY(assign_raw_bytes_value(length));
         break;
     }
@@ -240,8 +236,7 @@ ErrorOr<AttributeValue> DwarfInfo::get_attribute_value(AttributeDataForm form, s
         break;
     }
     case AttributeDataForm::StrX: {
-        size_t index;
-        TRY(LEB128::read_unsigned(debug_info_stream, index));
+        size_t index = TRY(debug_info_stream.read_value<LEB128<size_t>>());
         value.m_type = AttributeValue::Type::String;
         value.m_data.as_unsigned = index;
         break;
@@ -265,15 +260,13 @@ ErrorOr<AttributeValue> DwarfInfo::get_attribute_value(AttributeDataForm form, s
         break;
     }
     case AttributeDataForm::AddrX: {
-        size_t index;
-        TRY(LEB128::read_unsigned(debug_info_stream, index));
+        size_t index = TRY(debug_info_stream.read_value<LEB128<size_t>>());
         value.m_type = AttributeValue::Type::Address;
         value.m_data.as_unsigned = index;
         break;
     }
     case AttributeDataForm::RngListX: {
-        size_t index;
-        TRY(LEB128::read_unsigned(debug_info_stream, index));
+        size_t index = TRY(debug_info_stream.read_value<LEB128<size_t>>());
         value.m_type = AttributeValue::Type::UnsignedNumber;
         value.m_data.as_unsigned = index;
         break;

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -44,17 +44,14 @@ ErrorOr<void> LineProgram::parse_path_entries(Function<void(PathEntry& entry)> c
         Vector<PathEntryFormat> format_descriptions;
 
         for (u8 i = 0; i < path_entry_format_count; i++) {
-            UnderlyingType<ContentType> content_type;
-            TRY(LEB128::read_unsigned(m_stream, content_type));
+            UnderlyingType<ContentType> content_type = TRY(m_stream.read_value<LEB128<UnderlyingType<ContentType>>>());
 
-            UnderlyingType<AttributeDataForm> data_form;
-            TRY(LEB128::read_unsigned(m_stream, data_form));
+            UnderlyingType<AttributeDataForm> data_form = TRY(m_stream.read_value<LEB128<UnderlyingType<AttributeDataForm>>>());
 
             format_descriptions.empend(static_cast<ContentType>(content_type), static_cast<AttributeDataForm>(data_form));
         }
 
-        size_t paths_count = 0;
-        TRY(LEB128::read_unsigned(m_stream, paths_count));
+        size_t paths_count = TRY(m_stream.read_value<LEB128<size_t>>());
 
         for (size_t i = 0; i < paths_count; i++) {
             PathEntry entry;
@@ -85,11 +82,9 @@ ErrorOr<void> LineProgram::parse_path_entries(Function<void(PathEntry& entry)> c
             PathEntry entry;
             entry.path = path;
             if (list_type == PathListType::Filenames) {
-                size_t directory_index = 0;
-                TRY(LEB128::read_unsigned(m_stream, directory_index));
-                size_t _unused = 0;
-                TRY(LEB128::read_unsigned(m_stream, _unused)); // skip modification time
-                TRY(LEB128::read_unsigned(m_stream, _unused)); // skip file size
+                size_t directory_index = TRY(m_stream.read_value<LEB128<size_t>>());
+                TRY(m_stream.read_value<LEB128<size_t>>()); // skip modification time
+                TRY(m_stream.read_value<LEB128<size_t>>()); // skip file size
                 entry.directory_index = directory_index;
                 dbgln_if(DWARF_DEBUG, "file: {}, directory index: {}", path, directory_index);
             }
@@ -157,8 +152,7 @@ void LineProgram::reset_registers()
 
 ErrorOr<void> LineProgram::handle_extended_opcode()
 {
-    size_t length = 0;
-    TRY(LEB128::read_unsigned(m_stream, length));
+    size_t length = TRY(m_stream.read_value<LEB128<size_t>>());
 
     auto sub_opcode = TRY(m_stream.read_value<u8>());
 
@@ -176,8 +170,7 @@ ErrorOr<void> LineProgram::handle_extended_opcode()
     }
     case ExtendedOpcodes::SetDiscriminator: {
         dbgln_if(DWARF_DEBUG, "SetDiscriminator");
-        size_t discriminator;
-        TRY(LEB128::read_unsigned(m_stream, discriminator));
+        [[maybe_unused]] size_t discriminator = TRY(m_stream.read_value<LEB128<size_t>>());
         break;
     }
     default:
@@ -195,16 +188,14 @@ ErrorOr<void> LineProgram::handle_standard_opcode(u8 opcode)
         break;
     }
     case StandardOpcodes::AdvancePc: {
-        size_t operand = 0;
-        TRY(LEB128::read_unsigned(m_stream, operand));
+        size_t operand = TRY(m_stream.read_value<LEB128<size_t>>());
         size_t delta = operand * m_unit_header.min_instruction_length();
         dbgln_if(DWARF_DEBUG, "AdvancePC by: {} to: {:p}", delta, m_address + delta);
         m_address += delta;
         break;
     }
     case StandardOpcodes::SetFile: {
-        size_t new_file_index = 0;
-        TRY(LEB128::read_unsigned(m_stream, new_file_index));
+        size_t new_file_index = TRY(m_stream.read_value<LEB128<size_t>>());
         dbgln_if(DWARF_DEBUG, "SetFile: new file index: {}", new_file_index);
         m_file_index = new_file_index;
         break;
@@ -212,14 +203,12 @@ ErrorOr<void> LineProgram::handle_standard_opcode(u8 opcode)
     case StandardOpcodes::SetColumn: {
         // not implemented
         dbgln_if(DWARF_DEBUG, "SetColumn");
-        size_t new_column;
-        TRY(LEB128::read_unsigned(m_stream, new_column));
+        [[maybe_unused]] size_t new_column = TRY(m_stream.read_value<LEB128<size_t>>());
 
         break;
     }
     case StandardOpcodes::AdvanceLine: {
-        ssize_t line_delta;
-        TRY(LEB128::read_signed(m_stream, line_delta));
+        ssize_t line_delta = TRY(m_stream.read_value<LEB128<ssize_t>>());
         VERIFY(line_delta >= 0 || m_line >= (size_t)(-line_delta));
         m_line += line_delta;
         dbgln_if(DWARF_DEBUG, "AdvanceLine: {}", m_line);
@@ -239,8 +228,7 @@ ErrorOr<void> LineProgram::handle_standard_opcode(u8 opcode)
         break;
     }
     case StandardOpcodes::SetIsa: {
-        size_t isa;
-        TRY(LEB128::read_unsigned(m_stream, isa));
+        size_t isa = TRY(m_stream.read_value<LEB128<size_t>>());
         dbgln_if(DWARF_DEBUG, "SetIsa: {}", isa);
         break;
     }

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -65,9 +65,10 @@ template<typename T>
 struct GenericIndexParser {
     static ParseResult<T> parse(AK::Stream& stream)
     {
-        size_t value;
-        if (LEB128::read_unsigned(stream, value).is_error())
+        auto value_or_error = stream.read_value<LEB128<size_t>>();
+        if (value_or_error.is_error())
             return with_eof_check(stream, ParseError::ExpectedIndex);
+        size_t value = value_or_error.release_value();
         return T { value };
     }
 };

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -66,8 +66,7 @@ struct GenericIndexParser {
     static ParseResult<T> parse(AK::Stream& stream)
     {
         size_t value;
-        Core::Stream::WrapInAKInputStream wrapped_stream { stream };
-        if (!LEB128::read_unsigned(wrapped_stream, value))
+        if (LEB128::read_unsigned(stream, value).is_error())
             return with_eof_check(stream, ParseError::ExpectedIndex);
         return T { value };
     }


### PR DESCRIPTION
I'm not too happy with having to repeat the type twice in every `T value = TRY(stream.read_value<LEB128<T>>());`, but that was the only reliable way I found to get it to "unpack" the value.

The change for `truncate` isn't strictly related, but removing the include for `LEB128.h` in `DeprecatedMemoryStream.h` threw some errors about `off_t` being missing in the Kernel, so I figured I'd replace it with a better matching type right away instead of looking for how to get `off_t`.