### PR TITLE
LibGfx: Make glyph ID lookup faster with a cache

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <AK/Noncopyable.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/StringView.h>
 #include <LibGfx/Bitmap.h>
@@ -31,7 +33,7 @@ public:
     virtual RefPtr<Gfx::Bitmap> rasterize_glyph(u32 glyph_id, float x_scale, float y_scale, Gfx::GlyphSubpixelOffset) const override;
     virtual u32 glyph_count() const override;
     virtual u16 units_per_em() const override;
-    virtual u32 glyph_id_for_code_point(u32 code_point) const override { return m_cmap.glyph_id_for_code_point(code_point); }
+    virtual u32 glyph_id_for_code_point(u32 code_point) const override;
     virtual DeprecatedString family() const override;
     virtual DeprecatedString variant() const override;
     virtual u16 weight() const override;
@@ -90,6 +92,22 @@ private:
     Optional<Kern> m_kern;
     Optional<Fpgm> m_fpgm;
     Optional<Prep> m_prep;
+
+    // This cache stores information per code point.
+    // It's segmented into pages with data about 256 code points each.
+    struct GlyphPage {
+        static constexpr size_t glyphs_per_page = 256;
+
+        u32 glyph_ids[glyphs_per_page];
+    };
+
+    // Fast cache for GlyphPage #0 (code points 0-255) to avoid hash lookups for all of ASCII and Latin-1.
+    mutable OwnPtr<GlyphPage> m_glyph_page_zero;
+
+    mutable HashMap<size_t, NonnullOwnPtr<GlyphPage>> m_glyph_pages;
+
+    GlyphPage const& glyph_page(size_t page_index) const;
+    void populate_glyph_page(GlyphPage&, size_t page_index) const;
 };
 
 }


### PR DESCRIPTION
This patch adds a `GlyphPage` cache which stores the mapping between code points and glyph IDs in a segmented table of "pages".

This makes `Font::glyph_id_for_code_point()` significantly faster by not reparsing the font tables every time you call it.

In the future, we can add more information to `GlyphPage` (such as horizontal metrics for each glyph) to further reduce time spent in text layout and painting.

This makes scrolling around in a huge text file significantly faster.