### PR TITLE
AK: Remove empty fallible constructors from various Stream implementations

### DIFF
--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -17,9 +17,9 @@ namespace AK {
 /// in big-endian order from another stream.
 class BigEndianInputBitStream : public Stream {
 public:
-    static ErrorOr<NonnullOwnPtr<BigEndianInputBitStream>> construct(MaybeOwned<Stream> stream)
+    explicit BigEndianInputBitStream(MaybeOwned<Stream> stream)
+        : m_stream(move(stream))
     {
-        return adopt_nonnull_own_or_enomem<BigEndianInputBitStream>(new BigEndianInputBitStream(move(stream)));
     }
 
     // ^Stream
@@ -112,11 +112,6 @@ public:
     ALWAYS_INLINE bool is_aligned_to_byte_boundary() const { return m_bit_offset == 0; }
 
 private:
-    BigEndianInputBitStream(MaybeOwned<Stream> stream)
-        : m_stream(move(stream))
-    {
-    }
-
     Optional<u8> m_current_byte;
     size_t m_bit_offset { 0 };
     MaybeOwned<Stream> m_stream;

--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -121,12 +121,7 @@ private:
 /// in little-endian order from another stream.
 class LittleEndianInputBitStream : public Stream {
 public:
-    static ErrorOr<NonnullOwnPtr<LittleEndianInputBitStream>> construct(MaybeOwned<Stream> stream)
-    {
-        return adopt_nonnull_own_or_enomem<LittleEndianInputBitStream>(new LittleEndianInputBitStream(move(stream)));
-    }
-
-    LittleEndianInputBitStream(MaybeOwned<Stream> stream)
+    explicit LittleEndianInputBitStream(MaybeOwned<Stream> stream)
         : m_stream(move(stream))
     {
     }

--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -225,9 +225,9 @@ private:
 /// in big-endian order to another stream.
 class BigEndianOutputBitStream : public Stream {
 public:
-    static ErrorOr<NonnullOwnPtr<BigEndianOutputBitStream>> construct(MaybeOwned<Stream> stream)
+    explicit BigEndianOutputBitStream(MaybeOwned<Stream> stream)
+        : m_stream(move(stream))
     {
-        return adopt_nonnull_own_or_enomem<BigEndianOutputBitStream>(new BigEndianOutputBitStream(move(stream)));
     }
 
     virtual ErrorOr<Bytes> read(Bytes) override
@@ -294,11 +294,6 @@ public:
     }
 
 private:
-    BigEndianOutputBitStream(MaybeOwned<Stream> stream)
-        : m_stream(move(stream))
-    {
-    }
-
     MaybeOwned<Stream> m_stream;
     u8 m_current_byte { 0 };
     size_t m_bit_offset { 0 };

--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -303,9 +303,9 @@ private:
 /// in little-endian order to another stream.
 class LittleEndianOutputBitStream : public Stream {
 public:
-    static ErrorOr<NonnullOwnPtr<LittleEndianOutputBitStream>> construct(MaybeOwned<Stream> stream)
+    explicit LittleEndianOutputBitStream(MaybeOwned<Stream> stream)
+        : m_stream(move(stream))
     {
-        return adopt_nonnull_own_or_enomem<LittleEndianOutputBitStream>(new LittleEndianOutputBitStream(move(stream)));
     }
 
     virtual ErrorOr<Bytes> read(Bytes) override
@@ -372,11 +372,6 @@ public:
     }
 
 private:
-    LittleEndianOutputBitStream(MaybeOwned<Stream> stream)
-        : m_stream(move(stream))
-    {
-    }
-
     MaybeOwned<Stream> m_stream;
     u8 m_current_byte { 0 };
     size_t m_bit_offset { 0 };

--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -23,16 +23,6 @@ FixedMemoryStream::FixedMemoryStream(ReadonlyBytes bytes)
 {
 }
 
-ErrorOr<NonnullOwnPtr<FixedMemoryStream>> FixedMemoryStream::construct(Bytes bytes)
-{
-    return adopt_nonnull_own_or_enomem<FixedMemoryStream>(new (nothrow) FixedMemoryStream(bytes));
-}
-
-ErrorOr<NonnullOwnPtr<FixedMemoryStream>> FixedMemoryStream::construct(ReadonlyBytes bytes)
-{
-    return adopt_nonnull_own_or_enomem<FixedMemoryStream>(new (nothrow) FixedMemoryStream(bytes));
-}
-
 bool FixedMemoryStream::is_eof() const
 {
     return m_offset >= m_bytes.size();

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -16,8 +16,8 @@ namespace AK {
 /// using a single read/write head.
 class FixedMemoryStream final : public SeekableStream {
 public:
-    static ErrorOr<NonnullOwnPtr<FixedMemoryStream>> construct(Bytes bytes);
-    static ErrorOr<NonnullOwnPtr<FixedMemoryStream>> construct(ReadonlyBytes bytes);
+    explicit FixedMemoryStream(Bytes bytes);
+    explicit FixedMemoryStream(ReadonlyBytes bytes);
 
     virtual bool is_eof() const override;
     virtual bool is_open() const override;
@@ -36,9 +36,6 @@ public:
     size_t remaining() const;
 
 private:
-    explicit FixedMemoryStream(Bytes bytes);
-    explicit FixedMemoryStream(ReadonlyBytes bytes);
-
     Bytes m_bytes;
     size_t m_offset { 0 };
     bool m_writing_enabled { true };

--- a/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
@@ -10,14 +10,9 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto bufstream_result = FixedMemoryStream::construct({ data, size });
-    if (bufstream_result.is_error()) {
-        dbgln("MemoryStream::construct() failed.");
-        return 0;
-    }
-    auto bufstream = bufstream_result.release_value();
+    FixedMemoryStream bufstream { { data, size } };
 
-    auto brotli_stream = Compress::BrotliDecompressionStream { *bufstream };
+    auto brotli_stream = Compress::BrotliDecompressionStream { bufstream };
 
     (void)brotli_stream.read_until_eof();
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzTar.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTar.cpp
@@ -12,7 +12,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto input_stream_or_error = FixedMemoryStream::construct({ data, size });
+    auto input_stream_or_error = try_make<FixedMemoryStream>(ReadonlyBytes { data, size });
 
     if (input_stream_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzWasmParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWasmParser.cpp
@@ -12,10 +12,7 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     ReadonlyBytes bytes { data, size };
-    auto stream_or_error = FixedMemoryStream::construct(bytes);
-    if (stream_or_error.is_error())
-        return 0;
-    auto stream = stream_or_error.release_value();
-    [[maybe_unused]] auto result = Wasm::Module::parse(*stream);
+    FixedMemoryStream stream { bytes };
+    [[maybe_unused]] auto result = Wasm::Module::parse(stream);
     return 0;
 }

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -586,8 +586,8 @@ public:
 
     static ErrorOr<NonnullOwnPtr<IPC::Message>> decode_message(ReadonlyBytes buffer, [[maybe_unused]] Core::Stream::LocalSocket& socket)
     {
-        auto stream = TRY(FixedMemoryStream::construct(buffer));
-        auto message_endpoint_magic = TRY(stream->read_value<u32>());)~~~");
+        FixedMemoryStream stream { buffer };
+        auto message_endpoint_magic = TRY(stream.read_value<u32>());)~~~");
     generator.append(R"~~~(
 
         if (message_endpoint_magic != @endpoint.magic@) {)~~~");
@@ -599,7 +599,7 @@ public:
             return Error::from_string_literal("Endpoint magic number mismatch, not my message!");
         }
 
-        auto message_id = TRY(stream->read_value<i32>());)~~~");
+        auto message_id = TRY(stream.read_value<i32>());)~~~");
     generator.appendln(R"~~~(
 
         switch (message_id) {)~~~");
@@ -613,7 +613,7 @@ public:
 
             message_generator.append(R"~~~(
         case (int)Messages::@endpoint.name@::MessageID::@message.pascal_name@:
-            return TRY(Messages::@endpoint.name@::@message.pascal_name@::decode(*stream, socket));)~~~");
+            return TRY(Messages::@endpoint.name@::@message.pascal_name@::decode(stream, socket));)~~~");
         };
 
         do_decode_message(message.name);

--- a/Tests/AK/TestBitStream.cpp
+++ b/Tests/AK/TestBitStream.cpp
@@ -15,21 +15,21 @@ TEST_CASE(little_endian_bit_stream_input_output_match)
 
     // Note: The bit stream only ever reads from/writes to the underlying stream in one byte chunks,
     // so testing with sizes that will not trigger a write will yield unexpected results.
-    auto bit_write_stream = MUST(LittleEndianOutputBitStream::construct(MaybeOwned<AK::Stream>(*memory_stream)));
+    LittleEndianOutputBitStream bit_write_stream { MaybeOwned<AK::Stream>(*memory_stream) };
     LittleEndianInputBitStream bit_read_stream { MaybeOwned<AK::Stream>(*memory_stream) };
 
     // Test two mirrored chunks of a fully mirrored pattern to check that we are not dropping bits.
     {
-        MUST(bit_write_stream->write_bits(0b1111u, 4));
-        MUST(bit_write_stream->write_bits(0b1111u, 4));
+        MUST(bit_write_stream.write_bits(0b1111u, 4));
+        MUST(bit_write_stream.write_bits(0b1111u, 4));
         auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1111u, result);
         result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1111u, result);
     }
     {
-        MUST(bit_write_stream->write_bits(0b0000u, 4));
-        MUST(bit_write_stream->write_bits(0b0000u, 4));
+        MUST(bit_write_stream.write_bits(0b0000u, 4));
+        MUST(bit_write_stream.write_bits(0b0000u, 4));
         auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b0000u, result);
         result = MUST(bit_read_stream.read_bits(4));
@@ -38,8 +38,8 @@ TEST_CASE(little_endian_bit_stream_input_output_match)
 
     // Test two mirrored chunks of a non-mirrored pattern to check that we are writing bits within a pattern in the correct order.
     {
-        MUST(bit_write_stream->write_bits(0b1000u, 4));
-        MUST(bit_write_stream->write_bits(0b1000u, 4));
+        MUST(bit_write_stream.write_bits(0b1000u, 4));
+        MUST(bit_write_stream.write_bits(0b1000u, 4));
         auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1000u, result);
         result = MUST(bit_read_stream.read_bits(4));
@@ -48,8 +48,8 @@ TEST_CASE(little_endian_bit_stream_input_output_match)
 
     // Test two different chunks to check that we are not confusing their order.
     {
-        MUST(bit_write_stream->write_bits(0b1000u, 4));
-        MUST(bit_write_stream->write_bits(0b0100u, 4));
+        MUST(bit_write_stream.write_bits(0b1000u, 4));
+        MUST(bit_write_stream.write_bits(0b0100u, 4));
         auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1000u, result);
         result = MUST(bit_read_stream.read_bits(4));
@@ -58,7 +58,7 @@ TEST_CASE(little_endian_bit_stream_input_output_match)
 
     // Test a pattern that spans multiple bytes.
     {
-        MUST(bit_write_stream->write_bits(0b1101001000100001u, 16));
+        MUST(bit_write_stream.write_bits(0b1101001000100001u, 16));
         auto result = MUST(bit_read_stream.read_bits(16));
         EXPECT_EQ(0b1101001000100001u, result);
     }

--- a/Tests/AK/TestBitStream.cpp
+++ b/Tests/AK/TestBitStream.cpp
@@ -16,23 +16,23 @@ TEST_CASE(little_endian_bit_stream_input_output_match)
     // Note: The bit stream only ever reads from/writes to the underlying stream in one byte chunks,
     // so testing with sizes that will not trigger a write will yield unexpected results.
     auto bit_write_stream = MUST(LittleEndianOutputBitStream::construct(MaybeOwned<AK::Stream>(*memory_stream)));
-    auto bit_read_stream = MUST(LittleEndianInputBitStream::construct(MaybeOwned<AK::Stream>(*memory_stream)));
+    LittleEndianInputBitStream bit_read_stream { MaybeOwned<AK::Stream>(*memory_stream) };
 
     // Test two mirrored chunks of a fully mirrored pattern to check that we are not dropping bits.
     {
         MUST(bit_write_stream->write_bits(0b1111u, 4));
         MUST(bit_write_stream->write_bits(0b1111u, 4));
-        auto result = MUST(bit_read_stream->read_bits(4));
+        auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1111u, result);
-        result = MUST(bit_read_stream->read_bits(4));
+        result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1111u, result);
     }
     {
         MUST(bit_write_stream->write_bits(0b0000u, 4));
         MUST(bit_write_stream->write_bits(0b0000u, 4));
-        auto result = MUST(bit_read_stream->read_bits(4));
+        auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b0000u, result);
-        result = MUST(bit_read_stream->read_bits(4));
+        result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b0000u, result);
     }
 
@@ -40,9 +40,9 @@ TEST_CASE(little_endian_bit_stream_input_output_match)
     {
         MUST(bit_write_stream->write_bits(0b1000u, 4));
         MUST(bit_write_stream->write_bits(0b1000u, 4));
-        auto result = MUST(bit_read_stream->read_bits(4));
+        auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1000u, result);
-        result = MUST(bit_read_stream->read_bits(4));
+        result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1000u, result);
     }
 
@@ -50,16 +50,16 @@ TEST_CASE(little_endian_bit_stream_input_output_match)
     {
         MUST(bit_write_stream->write_bits(0b1000u, 4));
         MUST(bit_write_stream->write_bits(0b0100u, 4));
-        auto result = MUST(bit_read_stream->read_bits(4));
+        auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1000u, result);
-        result = MUST(bit_read_stream->read_bits(4));
+        result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b0100u, result);
     }
 
     // Test a pattern that spans multiple bytes.
     {
         MUST(bit_write_stream->write_bits(0b1101001000100001u, 16));
-        auto result = MUST(bit_read_stream->read_bits(16));
+        auto result = MUST(bit_read_stream.read_bits(16));
         EXPECT_EQ(0b1101001000100001u, result);
     }
 }

--- a/Tests/AK/TestBitStream.cpp
+++ b/Tests/AK/TestBitStream.cpp
@@ -72,23 +72,23 @@ TEST_CASE(big_endian_bit_stream_input_output_match)
     // Note: The bit stream only ever reads from/writes to the underlying stream in one byte chunks,
     // so testing with sizes that will not trigger a write will yield unexpected results.
     auto bit_write_stream = MUST(BigEndianOutputBitStream::construct(MaybeOwned<AK::Stream>(*memory_stream)));
-    auto bit_read_stream = MUST(BigEndianInputBitStream::construct(MaybeOwned<AK::Stream>(*memory_stream)));
+    BigEndianInputBitStream bit_read_stream { MaybeOwned<AK::Stream>(*memory_stream) };
 
     // Test two mirrored chunks of a fully mirrored pattern to check that we are not dropping bits.
     {
         MUST(bit_write_stream->write_bits(0b1111u, 4));
         MUST(bit_write_stream->write_bits(0b1111u, 4));
-        auto result = MUST(bit_read_stream->read_bits(4));
+        auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1111u, result);
-        result = MUST(bit_read_stream->read_bits(4));
+        result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1111u, result);
     }
     {
         MUST(bit_write_stream->write_bits(0b0000u, 4));
         MUST(bit_write_stream->write_bits(0b0000u, 4));
-        auto result = MUST(bit_read_stream->read_bits(4));
+        auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b0000u, result);
-        result = MUST(bit_read_stream->read_bits(4));
+        result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b0000u, result);
     }
 
@@ -96,9 +96,9 @@ TEST_CASE(big_endian_bit_stream_input_output_match)
     {
         MUST(bit_write_stream->write_bits(0b1000u, 4));
         MUST(bit_write_stream->write_bits(0b1000u, 4));
-        auto result = MUST(bit_read_stream->read_bits(4));
+        auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1000u, result);
-        result = MUST(bit_read_stream->read_bits(4));
+        result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1000u, result);
     }
 
@@ -106,16 +106,16 @@ TEST_CASE(big_endian_bit_stream_input_output_match)
     {
         MUST(bit_write_stream->write_bits(0b1000u, 4));
         MUST(bit_write_stream->write_bits(0b0100u, 4));
-        auto result = MUST(bit_read_stream->read_bits(4));
+        auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1000u, result);
-        result = MUST(bit_read_stream->read_bits(4));
+        result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b0100u, result);
     }
 
     // Test a pattern that spans multiple bytes.
     {
         MUST(bit_write_stream->write_bits(0b1101001000100001u, 16));
-        auto result = MUST(bit_read_stream->read_bits(16));
+        auto result = MUST(bit_read_stream.read_bits(16));
         EXPECT_EQ(0b1101001000100001u, result);
     }
 }

--- a/Tests/AK/TestBitStream.cpp
+++ b/Tests/AK/TestBitStream.cpp
@@ -71,21 +71,21 @@ TEST_CASE(big_endian_bit_stream_input_output_match)
 
     // Note: The bit stream only ever reads from/writes to the underlying stream in one byte chunks,
     // so testing with sizes that will not trigger a write will yield unexpected results.
-    auto bit_write_stream = MUST(BigEndianOutputBitStream::construct(MaybeOwned<AK::Stream>(*memory_stream)));
+    BigEndianOutputBitStream bit_write_stream { MaybeOwned<AK::Stream>(*memory_stream) };
     BigEndianInputBitStream bit_read_stream { MaybeOwned<AK::Stream>(*memory_stream) };
 
     // Test two mirrored chunks of a fully mirrored pattern to check that we are not dropping bits.
     {
-        MUST(bit_write_stream->write_bits(0b1111u, 4));
-        MUST(bit_write_stream->write_bits(0b1111u, 4));
+        MUST(bit_write_stream.write_bits(0b1111u, 4));
+        MUST(bit_write_stream.write_bits(0b1111u, 4));
         auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1111u, result);
         result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1111u, result);
     }
     {
-        MUST(bit_write_stream->write_bits(0b0000u, 4));
-        MUST(bit_write_stream->write_bits(0b0000u, 4));
+        MUST(bit_write_stream.write_bits(0b0000u, 4));
+        MUST(bit_write_stream.write_bits(0b0000u, 4));
         auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b0000u, result);
         result = MUST(bit_read_stream.read_bits(4));
@@ -94,8 +94,8 @@ TEST_CASE(big_endian_bit_stream_input_output_match)
 
     // Test two mirrored chunks of a non-mirrored pattern to check that we are writing bits within a pattern in the correct order.
     {
-        MUST(bit_write_stream->write_bits(0b1000u, 4));
-        MUST(bit_write_stream->write_bits(0b1000u, 4));
+        MUST(bit_write_stream.write_bits(0b1000u, 4));
+        MUST(bit_write_stream.write_bits(0b1000u, 4));
         auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1000u, result);
         result = MUST(bit_read_stream.read_bits(4));
@@ -104,8 +104,8 @@ TEST_CASE(big_endian_bit_stream_input_output_match)
 
     // Test two different chunks to check that we are not confusing their order.
     {
-        MUST(bit_write_stream->write_bits(0b1000u, 4));
-        MUST(bit_write_stream->write_bits(0b0100u, 4));
+        MUST(bit_write_stream.write_bits(0b1000u, 4));
+        MUST(bit_write_stream.write_bits(0b0100u, 4));
         auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1000u, result);
         result = MUST(bit_read_stream.read_bits(4));
@@ -114,7 +114,7 @@ TEST_CASE(big_endian_bit_stream_input_output_match)
 
     // Test a pattern that spans multiple bytes.
     {
-        MUST(bit_write_stream->write_bits(0b1101001000100001u, 16));
+        MUST(bit_write_stream.write_bits(0b1101001000100001u, 16));
         auto result = MUST(bit_read_stream.read_bits(16));
         EXPECT_EQ(0b1101001000100001u, result);
     }

--- a/Tests/AK/TestLEB128.cpp
+++ b/Tests/AK/TestLEB128.cpp
@@ -14,18 +14,18 @@ TEST_CASE(single_byte)
     u32 output = {};
     i32 output_signed = {};
     u8 buf[] = { 0x00 };
-    auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { buf, sizeof(buf) }));
+    FixedMemoryStream stream { ReadonlyBytes { buf, sizeof(buf) } };
 
     // less than/eq 0b0011_1111, signed == unsigned == raw byte
     for (u8 i = 0u; i <= 0x3F; ++i) {
         buf[0] = i;
 
-        MUST(stream->seek(0));
-        output = MUST(stream->read_value<LEB128<u32>>());
+        MUST(stream.seek(0));
+        output = MUST(stream.read_value<LEB128<u32>>());
         EXPECT_EQ(output, i);
 
-        MUST(stream->seek(0));
-        output_signed = MUST(stream->read_value<LEB128<i32>>());
+        MUST(stream.seek(0));
+        output_signed = MUST(stream.read_value<LEB128<i32>>());
         EXPECT_EQ(output_signed, i);
     }
 
@@ -33,23 +33,23 @@ TEST_CASE(single_byte)
     for (u8 i = 0x40u; i < 0x80; ++i) {
         buf[0] = i;
 
-        MUST(stream->seek(0));
-        output = MUST(stream->read_value<LEB128<u32>>());
+        MUST(stream.seek(0));
+        output = MUST(stream.read_value<LEB128<u32>>());
         EXPECT_EQ(output, i);
 
-        MUST(stream->seek(0));
-        output_signed = MUST(stream->read_value<LEB128<i32>>());
+        MUST(stream.seek(0));
+        output_signed = MUST(stream.read_value<LEB128<i32>>());
         EXPECT_EQ(output_signed, (i | (-1 & (~0x3F))));
     }
     // MSB set, but input too short
     for (u16 i = 0x80; i <= 0xFF; ++i) {
         buf[0] = static_cast<u8>(i);
 
-        MUST(stream->seek(0));
-        EXPECT(stream->read_value<LEB128<u32>>().is_error());
+        MUST(stream.seek(0));
+        EXPECT(stream.read_value<LEB128<u32>>().is_error());
 
-        MUST(stream->seek(0));
-        EXPECT(stream->read_value<LEB128<i32>>().is_error());
+        MUST(stream.seek(0));
+        EXPECT(stream.read_value<LEB128<i32>>().is_error());
     }
 }
 
@@ -58,7 +58,7 @@ TEST_CASE(two_bytes)
     u32 output = {};
     i32 output_signed = {};
     u8 buf[] = { 0x00, 0x1 };
-    auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { buf, sizeof(buf) }));
+    FixedMemoryStream stream { ReadonlyBytes { buf, sizeof(buf) } };
 
     // Only test with first byte expecting more, otherwise equivalent to single byte case
     for (u16 i = 0x80; i <= 0xFF; ++i) {
@@ -68,12 +68,12 @@ TEST_CASE(two_bytes)
         for (u8 j = 0u; j <= 0x3F; ++j) {
             buf[1] = j;
 
-            MUST(stream->seek(0));
-            output = MUST(stream->read_value<LEB128<u32>>());
+            MUST(stream.seek(0));
+            output = MUST(stream.read_value<LEB128<u32>>());
             EXPECT_EQ(output, (static_cast<u32>(j) << 7) + (i & 0x7F));
 
-            MUST(stream->seek(0));
-            output_signed = MUST(stream->read_value<LEB128<i32>>());
+            MUST(stream.seek(0));
+            output_signed = MUST(stream.read_value<LEB128<i32>>());
             EXPECT_EQ(output_signed, (static_cast<i32>(j) << 7) + (i & 0x7F));
         }
 
@@ -81,12 +81,12 @@ TEST_CASE(two_bytes)
         for (u8 j = 0x40u; j < 0x80; ++j) {
             buf[1] = j;
 
-            MUST(stream->seek(0));
-            output = MUST(stream->read_value<LEB128<u32>>());
+            MUST(stream.seek(0));
+            output = MUST(stream.read_value<LEB128<u32>>());
             EXPECT_EQ(output, (static_cast<u32>(j) << 7) + (i & 0x7F));
 
-            MUST(stream->seek(0));
-            output_signed = MUST(stream->read_value<LEB128<i32>>());
+            MUST(stream.seek(0));
+            output_signed = MUST(stream.read_value<LEB128<i32>>());
             EXPECT_EQ(output_signed, ((static_cast<i32>(j) << 7) + (i & 0x7F)) | (-1 & (~0x3FFF)));
         }
 
@@ -94,11 +94,11 @@ TEST_CASE(two_bytes)
         for (u16 j = 0x80; j <= 0xFF; ++j) {
             buf[1] = static_cast<u8>(j);
 
-            MUST(stream->seek(0));
-            EXPECT(stream->read_value<LEB128<u32>>().is_error());
+            MUST(stream.seek(0));
+            EXPECT(stream.read_value<LEB128<u32>>().is_error());
 
-            MUST(stream->seek(0));
-            EXPECT(stream->read_value<LEB128<i32>>().is_error());
+            MUST(stream.seek(0));
+            EXPECT(stream.read_value<LEB128<i32>>().is_error());
         }
     }
 }
@@ -107,22 +107,22 @@ TEST_CASE(overflow_sizeof_output_unsigned)
 {
     u8 u32_max_plus_one[] = { 0x80, 0x80, 0x80, 0x80, 0x10 };
     {
-        auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { u32_max_plus_one, sizeof(u32_max_plus_one) }));
-        EXPECT(stream->read_value<LEB128<u32>>().is_error());
+        FixedMemoryStream stream { ReadonlyBytes { u32_max_plus_one, sizeof(u32_max_plus_one) } };
+        EXPECT(stream.read_value<LEB128<u32>>().is_error());
 
-        MUST(stream->seek(0));
-        u64 out64 = MUST(stream->read_value<LEB128<u64>>());
+        MUST(stream.seek(0));
+        u64 out64 = MUST(stream.read_value<LEB128<u64>>());
         EXPECT_EQ(out64, static_cast<u64>(NumericLimits<u32>::max()) + 1);
     }
 
     u8 u32_max[] = { 0xFF, 0xFF, 0xFF, 0xFF, 0x0F };
     {
-        auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { u32_max, sizeof(u32_max) }));
-        u32 out = MUST(stream->read_value<LEB128<u32>>());
+        FixedMemoryStream stream { ReadonlyBytes { u32_max, sizeof(u32_max) } };
+        u32 out = MUST(stream.read_value<LEB128<u32>>());
         EXPECT_EQ(out, NumericLimits<u32>::max());
 
-        MUST(stream->seek(0));
-        u64 out64 = MUST(stream->read_value<LEB128<u64>>());
+        MUST(stream.seek(0));
+        u64 out64 = MUST(stream.read_value<LEB128<u64>>());
         EXPECT_EQ(out64, NumericLimits<u32>::max());
     }
 }
@@ -131,43 +131,43 @@ TEST_CASE(overflow_sizeof_output_signed)
 {
     u8 i32_max_plus_one[] = { 0x80, 0x80, 0x80, 0x80, 0x08 };
     {
-        auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { i32_max_plus_one, sizeof(i32_max_plus_one) }));
-        EXPECT(stream->read_value<LEB128<i32>>().is_error());
+        FixedMemoryStream stream { ReadonlyBytes { i32_max_plus_one, sizeof(i32_max_plus_one) } };
+        EXPECT(stream.read_value<LEB128<i32>>().is_error());
 
-        MUST(stream->seek(0));
-        i64 out64 = MUST(stream->read_value<LEB128<i64>>());
+        MUST(stream.seek(0));
+        i64 out64 = MUST(stream.read_value<LEB128<i64>>());
         EXPECT_EQ(out64, static_cast<i64>(NumericLimits<i32>::max()) + 1);
     }
 
     u8 i32_max[] = { 0xFF, 0xFF, 0xFF, 0xFF, 0x07 };
     {
-        auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { i32_max, sizeof(i32_max) }));
-        i32 out = MUST(stream->read_value<LEB128<i32>>());
+        FixedMemoryStream stream { ReadonlyBytes { i32_max, sizeof(i32_max) } };
+        i32 out = MUST(stream.read_value<LEB128<i32>>());
         EXPECT_EQ(out, NumericLimits<i32>::max());
 
-        MUST(stream->seek(0));
-        i64 out64 = MUST(stream->read_value<LEB128<i64>>());
+        MUST(stream.seek(0));
+        i64 out64 = MUST(stream.read_value<LEB128<i64>>());
         EXPECT_EQ(out64, NumericLimits<i32>::max());
     }
 
     u8 i32_min_minus_one[] = { 0xFF, 0xFF, 0xFF, 0xFF, 0x77 };
     {
-        auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { i32_min_minus_one, sizeof(i32_min_minus_one) }));
-        EXPECT(stream->read_value<LEB128<i32>>().is_error());
+        FixedMemoryStream stream { ReadonlyBytes { i32_min_minus_one, sizeof(i32_min_minus_one) } };
+        EXPECT(stream.read_value<LEB128<i32>>().is_error());
 
-        MUST(stream->seek(0));
-        i64 out64 = MUST(stream->read_value<LEB128<i64>>());
+        MUST(stream.seek(0));
+        i64 out64 = MUST(stream.read_value<LEB128<i64>>());
         EXPECT_EQ(out64, static_cast<i64>(NumericLimits<i32>::min()) - 1);
     }
 
     u8 i32_min[] = { 0x80, 0x80, 0x80, 0x80, 0x78 };
     {
-        auto stream = MUST(FixedMemoryStream::construct(ReadonlyBytes { i32_min, sizeof(i32_min) }));
-        i32 out = MUST(stream->read_value<LEB128<i32>>());
+        FixedMemoryStream stream { ReadonlyBytes { i32_min, sizeof(i32_min) } };
+        i32 out = MUST(stream.read_value<LEB128<i32>>());
         EXPECT_EQ(out, NumericLimits<i32>::min());
 
-        MUST(stream->seek(0));
-        i64 out64 = MUST(stream->read_value<LEB128<i64>>());
+        MUST(stream.seek(0));
+        i64 out64 = MUST(stream.read_value<LEB128<i64>>());
         EXPECT_EQ(out64, NumericLimits<i32>::min());
     }
 }

--- a/Tests/LibCompress/TestDeflate.cpp
+++ b/Tests/LibCompress/TestDeflate.cpp
@@ -29,10 +29,10 @@ TEST_CASE(canonical_code_simple)
 
     auto const huffman = Compress::CanonicalCode::from_bytes(code).value();
     auto memory_stream = MUST(FixedMemoryStream::construct(input));
-    auto bit_stream = MUST(LittleEndianInputBitStream::construct(move(memory_stream)));
+    LittleEndianInputBitStream bit_stream { move(memory_stream) };
 
     for (size_t idx = 0; idx < 9; ++idx)
-        EXPECT_EQ(MUST(huffman.read_symbol(*bit_stream)), output[idx]);
+        EXPECT_EQ(MUST(huffman.read_symbol(bit_stream)), output[idx]);
 }
 
 TEST_CASE(canonical_code_complex)
@@ -49,10 +49,10 @@ TEST_CASE(canonical_code_complex)
 
     auto const huffman = Compress::CanonicalCode::from_bytes(code).value();
     auto memory_stream = MUST(FixedMemoryStream::construct(input));
-    auto bit_stream = MUST(LittleEndianInputBitStream::construct(move(memory_stream)));
+    LittleEndianInputBitStream bit_stream { move(memory_stream) };
 
     for (size_t idx = 0; idx < 12; ++idx)
-        EXPECT_EQ(MUST(huffman.read_symbol(*bit_stream)), output[idx]);
+        EXPECT_EQ(MUST(huffman.read_symbol(bit_stream)), output[idx]);
 }
 
 TEST_CASE(deflate_decompress_compressed_block)

--- a/Tests/LibCompress/TestDeflate.cpp
+++ b/Tests/LibCompress/TestDeflate.cpp
@@ -28,7 +28,7 @@ TEST_CASE(canonical_code_simple)
     };
 
     auto const huffman = Compress::CanonicalCode::from_bytes(code).value();
-    auto memory_stream = MUST(FixedMemoryStream::construct(input));
+    auto memory_stream = MUST(try_make<FixedMemoryStream>(input));
     LittleEndianInputBitStream bit_stream { move(memory_stream) };
 
     for (size_t idx = 0; idx < 9; ++idx)
@@ -48,7 +48,7 @@ TEST_CASE(canonical_code_complex)
     };
 
     auto const huffman = Compress::CanonicalCode::from_bytes(code).value();
-    auto memory_stream = MUST(FixedMemoryStream::construct(input));
+    auto memory_stream = MUST(try_make<FixedMemoryStream>(input));
     LittleEndianInputBitStream bit_stream { move(memory_stream) };
 
     for (size_t idx = 0; idx < 12; ++idx)

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -106,8 +106,8 @@ TESTJS_GLOBAL_FUNCTION(parse_webassembly_module, parseWebAssemblyModule)
     if (!is<JS::Uint8Array>(object))
         return vm.throw_completion<JS::TypeError>("Expected a Uint8Array argument to parse_webassembly_module");
     auto& array = static_cast<JS::Uint8Array&>(*object);
-    auto stream = FixedMemoryStream::construct(array.data()).release_value_but_fixme_should_propagate_errors();
-    auto result = Wasm::Module::parse(*stream);
+    FixedMemoryStream stream { array.data() };
+    auto result = Wasm::Module::parse(stream);
     if (result.is_error())
         return vm.throw_completion<JS::SyntaxError>(Wasm::parse_error_to_deprecated_string(result.error()));
 

--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -31,7 +31,7 @@ Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> MP3LoaderPlugin::create(Stri
 
 Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> MP3LoaderPlugin::create(Bytes buffer)
 {
-    auto stream = LOADER_TRY(FixedMemoryStream::construct(buffer));
+    auto stream = LOADER_TRY(try_make<FixedMemoryStream>(buffer));
     auto loader = make<MP3LoaderPlugin>(move(stream));
 
     LOADER_TRY(loader->initialize());

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -35,7 +35,7 @@ Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> WavLoaderPlugin::create(Stri
 
 Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> WavLoaderPlugin::create(Bytes buffer)
 {
-    auto stream = LOADER_TRY(FixedMemoryStream::construct(buffer));
+    auto stream = LOADER_TRY(try_make<FixedMemoryStream>(buffer));
     auto loader = make<WavLoaderPlugin>(move(stream));
 
     LOADER_TRY(loader->initialize());
@@ -115,23 +115,23 @@ static ErrorOr<double> read_sample(AK::Stream& stream)
 LoaderSamples WavLoaderPlugin::samples_from_pcm_data(Bytes const& data, size_t samples_to_read) const
 {
     FixedArray<Sample> samples = LOADER_TRY(FixedArray<Sample>::create(samples_to_read));
-    auto stream = LOADER_TRY(FixedMemoryStream::construct(move(data)));
+    FixedMemoryStream stream { data };
 
     switch (m_sample_format) {
     case PcmSampleFormat::Uint8:
-        TRY(read_samples_from_stream(*stream, read_sample<u8>, samples));
+        TRY(read_samples_from_stream(stream, read_sample<u8>, samples));
         break;
     case PcmSampleFormat::Int16:
-        TRY(read_samples_from_stream(*stream, read_sample<i16>, samples));
+        TRY(read_samples_from_stream(stream, read_sample<i16>, samples));
         break;
     case PcmSampleFormat::Int24:
-        TRY(read_samples_from_stream(*stream, read_sample_int24, samples));
+        TRY(read_samples_from_stream(stream, read_sample_int24, samples));
         break;
     case PcmSampleFormat::Float32:
-        TRY(read_samples_from_stream(*stream, read_sample<float>, samples));
+        TRY(read_samples_from_stream(stream, read_sample<float>, samples));
         break;
     case PcmSampleFormat::Float64:
-        TRY(read_samples_from_stream(*stream, read_sample<double>, samples));
+        TRY(read_samples_from_stream(stream, read_sample<double>, samples));
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -449,7 +449,7 @@ ErrorOr<void> DeflateDecompressor::decode_codes(CanonicalCode& literal_code, Opt
 
 ErrorOr<NonnullOwnPtr<DeflateCompressor>> DeflateCompressor::construct(MaybeOwned<AK::Stream> stream, CompressionLevel compression_level)
 {
-    auto bit_stream = TRY(LittleEndianOutputBitStream::construct(move(stream)));
+    auto bit_stream = TRY(try_make<LittleEndianOutputBitStream>(move(stream)));
     auto deflate_compressor = TRY(adopt_nonnull_own_or_enomem(new (nothrow) DeflateCompressor(move(bit_stream), compression_level)));
     return deflate_compressor;
 }

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -317,7 +317,7 @@ void DeflateDecompressor::close()
 
 ErrorOr<ByteBuffer> DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
 {
-    auto memory_stream = TRY(FixedMemoryStream::construct(bytes));
+    auto memory_stream = TRY(try_make<FixedMemoryStream>(bytes));
     auto deflate_stream = TRY(DeflateDecompressor::construct(move(memory_stream)));
     AllocatingMemoryStream output_stream;
 

--- a/Userland/Libraries/LibCompress/Gzip.cpp
+++ b/Userland/Libraries/LibCompress/Gzip.cpp
@@ -164,7 +164,7 @@ Optional<DeprecatedString> GzipDecompressor::describe_header(ReadonlyBytes bytes
 
 ErrorOr<ByteBuffer> GzipDecompressor::decompress_all(ReadonlyBytes bytes)
 {
-    auto memory_stream = TRY(FixedMemoryStream::construct(bytes));
+    auto memory_stream = TRY(try_make<FixedMemoryStream>(bytes));
     auto gzip_stream = make<GzipDecompressor>(move(memory_stream));
     AllocatingMemoryStream output_stream;
 

--- a/Userland/Libraries/LibDebug/Dwarf/AddressRanges.h
+++ b/Userland/Libraries/LibDebug/Dwarf/AddressRanges.h
@@ -24,6 +24,7 @@ class AddressRangesV5 {
     AK_MAKE_NONMOVABLE(AddressRangesV5);
 
 public:
+    // FIXME: This should be fine with using a non-owned stream.
     AddressRangesV5(NonnullOwnPtr<AK::Stream> range_lists_stream, CompilationUnit const& compilation_unit);
 
     ErrorOr<void> for_each_range(Function<void(Range)>);

--- a/Userland/Libraries/LibDebug/Dwarf/Expression.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/Expression.cpp
@@ -14,10 +14,10 @@ namespace Debug::Dwarf::Expression {
 
 ErrorOr<Value> evaluate(ReadonlyBytes bytes, [[maybe_unused]] PtraceRegisters const& regs)
 {
-    auto stream = TRY(FixedMemoryStream::construct(bytes));
+    FixedMemoryStream stream { bytes };
 
-    while (!stream->is_eof()) {
-        auto opcode = TRY(stream->read_value<u8>());
+    while (!stream.is_eof()) {
+        auto opcode = TRY(stream.read_value<u8>());
 
         switch (static_cast<Operations>(opcode)) {
 

--- a/Userland/Libraries/LibGfx/JPGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPGLoader.cpp
@@ -1202,7 +1202,7 @@ static ErrorOr<void> scan_huffman_stream(AK::SeekableStream& stream, JPGLoadingC
 static ErrorOr<void> decode_header(JPGLoadingContext& context)
 {
     if (context.state < JPGLoadingContext::State::HeaderDecoded) {
-        context.stream = TRY(FixedMemoryStream::construct({ context.data, context.data_size }));
+        context.stream = TRY(try_make<FixedMemoryStream>(ReadonlyBytes { context.data, context.data_size }));
 
         if (auto result = parse_header(*context.stream, context); result.is_error()) {
             context.state = JPGLoadingContext::State::Error;

--- a/Userland/Libraries/LibGfx/QOILoader.cpp
+++ b/Userland/Libraries/LibGfx/QOILoader.cpp
@@ -202,13 +202,13 @@ bool QOIImageDecoderPlugin::initialize()
 
 ErrorOr<bool> QOIImageDecoderPlugin::sniff(ReadonlyBytes data)
 {
-    auto stream = TRY(FixedMemoryStream::construct({ data.data(), data.size() }));
-    return !decode_qoi_header(*stream).is_error();
+    FixedMemoryStream stream { { data.data(), data.size() } };
+    return !decode_qoi_header(stream).is_error();
 }
 
 ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> QOIImageDecoderPlugin::create(ReadonlyBytes data)
 {
-    auto stream = TRY(FixedMemoryStream::construct(data));
+    auto stream = TRY(try_make<FixedMemoryStream>(data));
     return adopt_nonnull_own_or_enomem(new (nothrow) QOIImageDecoderPlugin(move(stream)));
 }
 

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -70,8 +70,8 @@ static ErrorOr<ByteBuffer> handle_content_encoding(ByteBuffer const& buf, Deprec
     } else if (content_encoding == "br") {
         dbgln_if(JOB_DEBUG, "Job::handle_content_encoding: buf is brotli compressed!");
 
-        auto bufstream = TRY(FixedMemoryStream::construct({ buf.data(), buf.size() }));
-        auto brotli_stream = Compress::BrotliDecompressionStream { *bufstream };
+        FixedMemoryStream bufstream { buf };
+        auto brotli_stream = Compress::BrotliDecompressionStream { bufstream };
 
         auto uncompressed = TRY(brotli_stream.read_until_eof());
         if constexpr (JOB_DEBUG) {

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -599,7 +599,7 @@ PDFErrorOr<Vector<DocumentParser::PageOffsetHintTableEntry>> DocumentParser::par
     auto input_stream = TRY(FixedMemoryStream::construct(hint_stream_bytes));
     TRY(input_stream->seek(sizeof(PageOffsetHintTable)));
 
-    auto bit_stream = TRY(LittleEndianInputBitStream::construct(move(input_stream)));
+    LittleEndianInputBitStream bit_stream { move(input_stream) };
 
     auto number_of_pages = m_linearization_dictionary.value().number_of_pages;
     Vector<PageOffsetHintTableEntry> entries;
@@ -620,7 +620,7 @@ PDFErrorOr<Vector<DocumentParser::PageOffsetHintTableEntry>> DocumentParser::par
 
         for (int i = 0; i < number_of_pages; i++) {
             auto& entry = entries[i];
-            entry.*field = TRY(bit_stream->read_bits(bit_size));
+            entry.*field = TRY(bit_stream.read_bits(bit_size));
         }
 
         return {};
@@ -636,7 +636,7 @@ PDFErrorOr<Vector<DocumentParser::PageOffsetHintTableEntry>> DocumentParser::par
             items.ensure_capacity(number_of_shared_objects);
 
             for (size_t i = 0; i < number_of_shared_objects; i++)
-                items.unchecked_append(TRY(bit_stream->read_bits(bit_size)));
+                items.unchecked_append(TRY(bit_stream.read_bits(bit_size)));
 
             entries[page].*field = move(items);
         }

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -596,7 +596,7 @@ PDFErrorOr<DocumentParser::PageOffsetHintTable> DocumentParser::parse_page_offse
 
 PDFErrorOr<Vector<DocumentParser::PageOffsetHintTableEntry>> DocumentParser::parse_all_page_offset_hint_table_entries(PageOffsetHintTable const& hint_table, ReadonlyBytes hint_stream_bytes)
 {
-    auto input_stream = TRY(FixedMemoryStream::construct(hint_stream_bytes));
+    auto input_stream = TRY(try_make<FixedMemoryStream>(hint_stream_bytes));
     TRY(input_stream->seek(sizeof(PageOffsetHintTable)));
 
     LittleEndianInputBitStream bit_stream { move(input_stream) };

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -203,8 +203,8 @@ struct ConvertToRaw<float> {
     {
         LittleEndian<u32> res;
         ReadonlyBytes bytes { &value, sizeof(float) };
-        auto stream = FixedMemoryStream::construct(bytes).release_value_but_fixme_should_propagate_errors();
-        stream->read_entire_buffer(res.bytes()).release_value_but_fixme_should_propagate_errors();
+        FixedMemoryStream stream { bytes };
+        stream.read_entire_buffer(res.bytes()).release_value_but_fixme_should_propagate_errors();
         return static_cast<u32>(res);
     }
 };
@@ -215,8 +215,8 @@ struct ConvertToRaw<double> {
     {
         LittleEndian<u64> res;
         ReadonlyBytes bytes { &value, sizeof(double) };
-        auto stream = FixedMemoryStream::construct(bytes).release_value_but_fixme_should_propagate_errors();
-        stream->read_entire_buffer(res.bytes()).release_value_but_fixme_should_propagate_errors();
+        FixedMemoryStream stream { bytes };
+        stream.read_entire_buffer(res.bytes()).release_value_but_fixme_should_propagate_errors();
         return static_cast<u64>(res);
     }
 };
@@ -253,8 +253,8 @@ template<typename T>
 T BytecodeInterpreter::read_value(ReadonlyBytes data)
 {
     LittleEndian<T> value;
-    auto stream = FixedMemoryStream::construct(data).release_value_but_fixme_should_propagate_errors();
-    auto maybe_error = stream->read_entire_buffer(value.bytes());
+    FixedMemoryStream stream { data };
+    auto maybe_error = stream.read_entire_buffer(value.bytes());
     if (maybe_error.is_error()) {
         dbgln("Read from {} failed", data.data());
         m_trap = Trap { "Read from memory failed" };
@@ -266,8 +266,8 @@ template<>
 float BytecodeInterpreter::read_value<float>(ReadonlyBytes data)
 {
     LittleEndian<u32> raw_value;
-    auto stream = FixedMemoryStream::construct(data).release_value_but_fixme_should_propagate_errors();
-    auto maybe_error = stream->read_entire_buffer(raw_value.bytes());
+    FixedMemoryStream stream { data };
+    auto maybe_error = stream.read_entire_buffer(raw_value.bytes());
     if (maybe_error.is_error())
         m_trap = Trap { "Read from memory failed" };
     return bit_cast<float>(static_cast<u32>(raw_value));
@@ -277,8 +277,8 @@ template<>
 double BytecodeInterpreter::read_value<double>(ReadonlyBytes data)
 {
     LittleEndian<u64> raw_value;
-    auto stream = FixedMemoryStream::construct(data).release_value_but_fixme_should_propagate_errors();
-    auto maybe_error = stream->read_entire_buffer(raw_value.bytes());
+    FixedMemoryStream stream { data };
+    auto maybe_error = stream.read_entire_buffer(raw_value.bytes());
     if (maybe_error.is_error())
         m_trap = Trap { "Read from memory failed" };
     return bit_cast<double>(static_cast<u64>(raw_value));

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -260,8 +260,8 @@ ParseResult<BlockType> BlockType::parse(AK::Stream& stream)
         return BlockType {};
 
     {
-        auto value_stream = FixedMemoryStream::construct(ReadonlyBytes { &kind, 1 }).release_value_but_fixme_should_propagate_errors();
-        if (auto value_type = ValueType::parse(*value_stream); !value_type.is_error())
+        FixedMemoryStream value_stream { ReadonlyBytes { &kind, 1 } };
+        if (auto value_type = ValueType::parse(value_stream); !value_type.is_error())
             return BlockType { value_type.release_value() };
     }
 

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
@@ -121,8 +121,8 @@ JS::ThrowCompletionOr<size_t> parse_module(JS::VM& vm, JS::Object* buffer_object
     } else {
         return vm.throw_completion<JS::TypeError>("Not a BufferSource");
     }
-    auto stream = FixedMemoryStream::construct(data).release_value_but_fixme_should_propagate_errors();
-    auto module_result = Wasm::Module::parse(*stream);
+    FixedMemoryStream stream { data };
+    auto module_result = Wasm::Module::parse(stream);
     if (module_result.is_error()) {
         // FIXME: Throw CompileError instead.
         return vm.throw_completion<JS::TypeError>(Wasm::parse_error_to_deprecated_string(module_result.error()));

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -336,8 +336,8 @@ ErrorOr<void> Client::handle_directory_listing(String const& requested_path, Str
     builder.append("</html>\n"sv);
 
     auto response = builder.to_deprecated_string();
-    auto stream = TRY(FixedMemoryStream::construct(response.bytes()));
-    return send_response(*stream, request, { .type = TRY(String::from_utf8("text/html"sv)), .length = response.length() });
+    FixedMemoryStream stream { response.bytes() };
+    return send_response(stream, request, { .type = TRY(String::from_utf8("text/html"sv)), .length = response.length() });
 }
 
 ErrorOr<void> Client::send_error_response(unsigned code, HTTP::HttpRequest const& request, Vector<String> const& headers)

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -342,7 +342,7 @@ public:
     private:
         HTTPHeadlessRequest(HTTP::HttpRequest&& request, NonnullOwnPtr<Core::Stream::BufferedSocketBase> socket, ByteBuffer&& stream_backing_buffer)
             : m_stream_backing_buffer(move(stream_backing_buffer))
-            , m_output_stream(FixedMemoryStream::construct(m_stream_backing_buffer.bytes()).release_value_but_fixme_should_propagate_errors())
+            , m_output_stream(try_make<FixedMemoryStream>(m_stream_backing_buffer.bytes()).release_value_but_fixme_should_propagate_errors())
             , m_socket(move(socket))
             , m_job(HTTP::Job::construct(move(request), *m_output_stream))
         {
@@ -421,7 +421,7 @@ public:
     private:
         HTTPSHeadlessRequest(HTTP::HttpRequest&& request, NonnullOwnPtr<Core::Stream::BufferedSocketBase> socket, ByteBuffer&& stream_backing_buffer)
             : m_stream_backing_buffer(move(stream_backing_buffer))
-            , m_output_stream(FixedMemoryStream::construct(m_stream_backing_buffer.bytes()).release_value_but_fixme_should_propagate_errors())
+            , m_output_stream(try_make<FixedMemoryStream>(m_stream_backing_buffer.bytes()).release_value_but_fixme_should_propagate_errors())
             , m_socket(move(socket))
             , m_job(HTTP::HttpsJob::construct(move(request), *m_output_stream))
         {
@@ -490,7 +490,7 @@ public:
     private:
         GeminiHeadlessRequest(Gemini::GeminiRequest&& request, NonnullOwnPtr<Core::Stream::BufferedSocketBase> socket, ByteBuffer&& stream_backing_buffer)
             : m_stream_backing_buffer(move(stream_backing_buffer))
-            , m_output_stream(FixedMemoryStream::construct(m_stream_backing_buffer.bytes()).release_value_but_fixme_should_propagate_errors())
+            , m_output_stream(try_make<FixedMemoryStream>(m_stream_backing_buffer.bytes()).release_value_but_fixme_should_propagate_errors())
             , m_socket(move(socket))
             , m_job(Gemini::Job::construct(move(request), *m_output_stream))
         {

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -252,8 +252,8 @@ static Optional<Wasm::Module> parse(StringView filename)
         return {};
     }
 
-    auto stream = FixedMemoryStream::construct(ReadonlyBytes { result.value()->data(), result.value()->size() }).release_value_but_fixme_should_propagate_errors();
-    auto parse_result = Wasm::Module::parse(*stream);
+    FixedMemoryStream stream { ReadonlyBytes { result.value()->data(), result.value()->size() } };
+    auto parse_result = Wasm::Module::parse(stream);
     if (parse_result.is_error()) {
         warnln("Something went wrong, either the file is invalid, or there's a bug with LibWasm!");
         warnln("The parse error was {}", Wasm::parse_error_to_deprecated_string(parse_result.error()));


### PR DESCRIPTION
No need to force users to allocate them on the heap, if they need a `NonnullOwnPtr` they can still obtain one through `try_make`.