### PR TITLE
Ladybird: Left-align long url in address bar

### DIFF
--- a/Ladybird/Tab.cpp
+++ b/Ladybird/Tab.cpp
@@ -89,6 +89,7 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path)
         }
 
         m_location_edit->setText(url.to_deprecated_string().characters());
+        m_location_edit->setCursorPosition(0);
 
         // Don't add to history if back or forward is pressed
         if (!m_is_history_navigation) {


### PR DESCRIPTION
Fixes the color highlighting which previously would grey out `file://` of `file:///`. Now, the whole scheme is captured.

Also fixes the case when the url is very long, which previously wouldn't be 'home-aligned' and so you would see the end of the url instead of the domain name.