### PR TITLE
Ports: Install all dependencies instead of just one

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -527,19 +527,21 @@ package_install_state() {
 }
 installdepends() {
     for depend in "${depends[@]}"; do
-        if [ -z "$(package_install_state $depend)" ]; then
-            # Split colon seperated string into a list
-            IFS=':' read -ra port_directories <<< "$SERENITY_PORT_DIRS"
-            for port_dir in "${port_directories[@]}"; do
-                if [ -d "${port_dir}/$depend" ]; then
-                    (cd "${port_dir}/$depend" && ./package.sh --auto)
-                    return
-                fi
-            done
-
-            >&2 echo "Error: Dependency $depend could not be found."
-            exit 1
+        if [ -n "$(package_install_state $depend)" ]; then
+            continue
         fi
+
+        # Split colon separated string into a list
+        IFS=':' read -ra port_directories <<< "$SERENITY_PORT_DIRS"
+        for port_dir in "${port_directories[@]}"; do
+            if [ -d "${port_dir}/$depend" ]; then
+                (cd "${port_dir}/$depend" && ./package.sh --auto)
+                continue 2
+            fi
+        done
+
+        >&2 echo "Error: Dependency $depend could not be found."
+        exit 1
     done
 }
 uninstall() {


### PR DESCRIPTION
Commit 9b7e217dda0c45 broke installation of port dependencies by `return`ing as soon as the first dependency was found.

CC @Jan200101 