### PR TITLE
LibJS: Format the era of ISO year 0 as BC

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -1235,8 +1235,8 @@ ThrowCompletionOr<LocalTime> to_local_time(VM& vm, Crypto::SignedBigInteger cons
         return LocalTime {
             // WeekDay(𝔽(floor(tz / 10^6)))
             .weekday = week_day(zoned_time),
-            // Let year be YearFromTime(𝔽(floor(tz / 10^6))). If year < -0𝔽, return "BC", else return "AD".
-            .era = year < 0 ? ::Locale::Era::BC : ::Locale::Era::AD,
+            // Let year be YearFromTime(𝔽(floor(tz / 10^6))). If year < 1𝔽, return "BC", else return "AD".
+            .era = year < 1 ? ::Locale::Era::BC : ::Locale::Era::AD,
             // YearFromTime(𝔽(floor(tz / 10^6)))
             .year = year,
             // undefined.

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -161,6 +161,17 @@ describe("era", () => {
             expect(ar.format(d1)).toBe(d.ar1);
         });
     });
+
+    test("Year 1 BC (ISO year 0)", () => {
+        let year1BC = new Date(Date.UTC(0));
+        year1BC.setUTCFullYear(0);
+
+        const en = new Intl.DateTimeFormat("en", { era: "short", timeZone: "UTC" });
+        expect(en.format(year1BC)).toBe("1/1/1 BC");
+
+        const ar = new Intl.DateTimeFormat("ar", { era: "short", timeZone: "UTC" });
+        expect(ar.format(year1BC)).toBe("١ ١ ١ ق.م");
+    });
 });
 
 describe("year", () => {


### PR DESCRIPTION
This is a normative change in the ECMA-402 spec. See:
https://github.com/tc39/ecma402/commit/2034315