### PR TITLE
SQLServer: Unveil /etc/passwd

### DIFF
--- a/Userland/Services/SQLServer/main.cpp
+++ b/Userland/Services/SQLServer/main.cpp
@@ -19,6 +19,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto database_path = DeprecatedString::formatted("{}/sql", Core::StandardPaths::data_directory());
     TRY(Core::Directory::create(database_path, Core::Directory::CreateDirectories::Yes));
 
+    TRY(Core::System::unveil("/etc/passwd"sv, "r"sv));
     TRY(Core::System::unveil(database_path, "rwc"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
 


### PR DESCRIPTION
This is now required to launch the SQLServer for Browser (without this it now fails to launch).

I'm not sure what changed to make this a requirement, I just wanted to launch Browser :^) 