### PR TITLE
Ladybird: Abstract spawning helper processes into separate methods

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SOURCES
     ${BROWSER_SOURCE_DIR}/History.cpp
     BrowserWindow.cpp
     ConsoleWidget.cpp
+    HelperProcess.cpp
     InspectorWidget.cpp
     LocationEdit.cpp
     ModelTranslator.cpp

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "HelperProcess.h"
+#include "Utilities.h"
+#include <AK/String.h>
+#include <QCoreApplication>
+
+ErrorOr<void> spawn_helper_process(StringView process_name, Span<StringView> arguments, Core::System::SearchInPath search_in_path, Optional<Span<StringView>> environment)
+{
+    auto paths = TRY(get_paths_for_helper_process(process_name));
+    VERIFY(!paths.is_empty());
+    ErrorOr<void> result;
+    for (auto const& path : paths) {
+        arguments[0] = path.bytes_as_string_view();
+        result = Core::System::exec(path, arguments, search_in_path, environment);
+        if (!result.is_error())
+            break;
+    }
+
+    return result;
+}
+
+ErrorOr<Vector<String>> get_paths_for_helper_process(StringView process_name)
+{
+    Vector<String> paths;
+    TRY(paths.try_append(TRY(String::formatted("./{}/{}", process_name, process_name))));
+    TRY(paths.try_append(TRY(String::formatted("{}/{}", TRY(ak_string_from_qstring(QCoreApplication::applicationDirPath())), process_name))));
+    TRY(paths.try_append(TRY(String::formatted("./{}", process_name))));
+    // NOTE: Add platform-specific paths here
+    return paths;
+}

--- a/Ladybird/HelperProcess.h
+++ b/Ladybird/HelperProcess.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define AK_DONT_REPLACE_STD
+
+#include <AK/Error.h>
+#include <AK/Optional.h>
+#include <AK/Span.h>
+#include <AK/StringView.h>
+#include <LibCore/System.h>
+
+ErrorOr<void> spawn_helper_process(StringView process_name, Span<StringView> arguments, Core::System::SearchInPath, Optional<Span<StringView>> environment = {});
+ErrorOr<Vector<String>> get_paths_for_helper_process(StringView process_name);

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -9,6 +9,7 @@
 
 #include "WebContentView.h"
 #include "ConsoleWidget.h"
+#include "HelperProcess.h"
 #include "InspectorWidget.h"
 #include "Utilities.h"
 #include <AK/Assertions.h>
@@ -586,12 +587,7 @@ void WebContentView::create_client()
             arguments.append(m_webdriver_content_ipc_path);
         }
 
-        auto result = Core::System::exec("./WebContent/WebContent"sv, arguments, Core::System::SearchInPath::Yes);
-        if (result.is_error()) {
-            auto web_content_path = ak_deprecated_string_from_qstring(QCoreApplication::applicationDirPath() + "/WebContent");
-            result = Core::System::exec(web_content_path, arguments, Core::System::SearchInPath::Yes);
-        }
-
+        auto result = spawn_helper_process("WebContent"sv, arguments, Core::System::SearchInPath::Yes);
         if (result.is_error())
             warnln("Could not launch WebContent: {}", result.error());
         VERIFY_NOT_REACHED();

--- a/Ladybird/WebDriver/CMakeLists.txt
+++ b/Ladybird/WebDriver/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     ${WEBDRIVER_SOURCE_DIR}/Session.cpp
     ${WEBDRIVER_SOURCE_DIR}/WebContentConnection.cpp
     ../Utilities.cpp
+    ../HelperProcess.cpp
     main.cpp
 )
 

--- a/Ladybird/cmake/InstallRules.cmake
+++ b/Ladybird/cmake/InstallRules.cmake
@@ -4,7 +4,9 @@ include(GNUInstallDirs)
 
 set(package ladybird)
 
-install(TARGETS ladybird
+set(ladybird_applications ladybird SQLServer WebContent WebDriver headless-browser)
+
+install(TARGETS ${ladybird_applications}
   EXPORT ladybirdTargets
   RUNTIME
     COMPONENT ladybird_Runtime
@@ -18,31 +20,11 @@ install(TARGETS ladybird
     DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-install(TARGETS SQLServer
-  EXPORT ladybirdTargets
-  RUNTIME
-    COMPONENT ladybird_Runtime
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-  BUNDLE
-    COMPONENT ladybird_Runtime
-    DESTINATION bundle
-)
-
-install(TARGETS WebContent
-  EXPORT ladybirdTargets
-  RUNTIME
-    COMPONENT ladybird_Runtime
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-  BUNDLE
-    COMPONENT ladybird_Runtime
-    DESTINATION bundle
-)
-
 include("${SERENITY_SOURCE_DIR}/Meta/Lagom/get_linked_lagom_libraries.cmake")
-get_linked_lagom_libraries(ladybird ladybird_lagom_libraries)
-get_linked_lagom_libraries(SQLServer sqlserver_lagom_libraries)
-get_linked_lagom_libraries(WebContent webcontent_lagom_libraries)
-list(APPEND all_required_lagom_libraries ${ladybird_lagom_libraries} ${sqlserver_lagom_libraries} ${webcontent_lagom_libraries})
+foreach (application IN LISTS ladybird_applications)
+  get_linked_lagom_libraries("${application}" "${application}_lagom_libraries")
+  list(APPEND all_required_lagom_libraries "${${application}_lagom_libraries}")
+endforeach()
 list(REMOVE_DUPLICATES all_required_lagom_libraries)
 
 install(TARGETS ${all_required_lagom_libraries}

--- a/Ladybird/main.cpp
+++ b/Ladybird/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "BrowserWindow.h"
+#include "HelperProcess.h"
 #include "Settings.h"
 #include "Utilities.h"
 #include "WebContentView.h"
@@ -99,7 +100,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return app.exec();
     }
 
-    auto sql_client = TRY(SQL::SQLClient::launch_server_and_create_client("./SQLServer/SQLServer"sv));
+    auto sql_server_paths = TRY(get_paths_for_helper_process("SQLServer"sv));
+    auto sql_client = TRY(SQL::SQLClient::launch_server_and_create_client(move(sql_server_paths)));
     auto database = TRY(Browser::Database::create(move(sql_client)));
 
     auto cookie_jar = TRY(Browser::CookieJar::create(*database));

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -74,7 +74,6 @@ jobs:
           ninja -C tools-build install
           cmake -GNinja -B Build \
             -DBUILD_LAGOM=ON \
-            -DENABLE_LAGOM_LADYBIRD=ON \
             -DENABLE_LAGOM_CCACHE=ON \
             -DBUILD_SHARED_LIBS=OFF \
             -DANDROID_ABI=arm64-v8a \

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -465,10 +465,6 @@ if (BUILD_LAGOM)
 
     add_serenity_subdirectory(Userland/Shell)
 
-    if (ENABLE_LAGOM_LADYBIRD)
-        add_serenity_subdirectory(Ladybird)
-    endif()
-
     if (NOT ENABLE_FUZZERS AND NOT ENABLE_COMPILER_EXPLORER_BUILD AND NOT ANDROID)
         # Lagom Services
         add_serenity_subdirectory(Userland/Services)
@@ -492,6 +488,10 @@ if (BUILD_LAGOM)
         if (ENABLE_LAGOM_LIBWEB)
             add_executable(headless-browser ../../Userland/Utilities/headless-browser.cpp ../../Userland/Services/WebContent/WebDriverConnection.cpp)
             target_link_libraries(headless-browser LibWeb LibWebSocket LibCrypto LibGemini LibHTTP LibJS LibGfx LibMain LibTLS LibIPC LibJS)
+        endif()
+
+        if (ENABLE_LAGOM_LADYBIRD)
+            add_serenity_subdirectory(Ladybird)
         endif()
 
         add_executable(icc ../../Userland/Utilities/icc.cpp)

--- a/Userland/Libraries/LibSQL/SQLClient.h
+++ b/Userland/Libraries/LibSQL/SQLClient.h
@@ -22,7 +22,7 @@ class SQLClient
 
 public:
 #if !defined(AK_OS_SERENITY)
-    static ErrorOr<NonnullRefPtr<SQLClient>> launch_server_and_create_client(StringView server_path);
+    static ErrorOr<NonnullRefPtr<SQLClient>> launch_server_and_create_client(Vector<String> candidate_server_paths);
 #endif
 
     virtual ~SQLClient() = default;

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/DeprecatedString.h>
 #include <AK/Format.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
@@ -361,8 +362,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #if defined(AK_OS_SERENITY)
     auto sql_client = TRY(SQL::SQLClient::try_create());
 #else
-    VERIFY(sql_server_path != nullptr);
-    auto sql_client = TRY(SQL::SQLClient::launch_server_and_create_client(sql_server_path));
+    VERIFY(!sql_server_path.is_empty());
+    auto sql_client = TRY(SQL::SQLClient::launch_server_and_create_client({ TRY(String::from_utf8(sql_server_path)) }));
 #endif
 
     SQLRepl repl(loop, database_name, move(sql_client));


### PR DESCRIPTION
This will let us use the same path discovery methods for WebContent,
SQLServer, and any other helper processes we need to launch.

Fixes #17062