### PR TITLE
Profiler: Standardize percentage formatting

### DIFF
--- a/Userland/DevTools/Profiler/DisassemblyModel.cpp
+++ b/Userland/DevTools/Profiler/DisassemblyModel.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, Jelle Raaijmakers <jelle@gmta.nl>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -7,6 +8,7 @@
 
 #include "DisassemblyModel.h"
 #include "Gradient.h"
+#include "PercentageFormatting.h"
 #include "Profile.h"
 #include <LibCore/MappedFile.h>
 #include <LibDebug/DebugInfo.h>
@@ -185,10 +187,15 @@ GUI::Variant DisassemblyModel::data(GUI::ModelIndex const& index, GUI::ModelRole
         return colors.value().foreground;
     }
 
+    if (role == GUI::ModelRole::TextAlignment) {
+        if (index.column() == Column::SampleCount)
+            return Gfx::TextAlignment::CenterRight;
+    }
+
     if (role == GUI::ModelRole::Display) {
         if (index.column() == Column::SampleCount) {
             if (m_profile.show_percentages())
-                return ((float)insn.event_count / (float)m_node.event_count()) * 100.0f;
+                return format_percentage(insn.event_count, m_node.event_count());
             return insn.event_count;
         }
 

--- a/Userland/DevTools/Profiler/PercentageFormatting.h
+++ b/Userland/DevTools/Profiler/PercentageFormatting.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, Jelle Raaijmakers <jelle@gmta.nl>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/DeprecatedString.h>
+#include <AK/IntegralMath.h>
+#include <AK/Math.h>
+
+namespace Profiler {
+
+// Number of digits after the decimal point for sample percentages.
+static constexpr int const number_of_percent_digits = 2;
+static constexpr int const percent_digits_rounding = AK::pow(10, number_of_percent_digits);
+
+DeprecatedString format_percentage(auto value, auto total)
+{
+    auto percentage_full_precision = round_to<u64>(value * 100.f / total * percent_digits_rounding);
+    return DeprecatedString::formatted(
+        "{}.{:02}",
+        percentage_full_precision / percent_digits_rounding,
+        percentage_full_precision % percent_digits_rounding);
+};
+
+}

--- a/Userland/DevTools/Profiler/ProfileModel.cpp
+++ b/Userland/DevTools/Profiler/ProfileModel.cpp
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, Jelle Raaijmakers <jelle@gmta.nl>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "ProfileModel.h"
+#include "PercentageFormatting.h"
 #include "Profile.h"
 #include <LibGUI/FileIconProvider.h>
 #include <LibSymbolication/Symbolication.h>
@@ -111,25 +113,14 @@ GUI::Variant ProfileModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
         return {};
     }
     if (role == GUI::ModelRole::Display) {
-        auto round_percentages = [this](auto value) {
-            auto percentage_full_precision = round_to<int>(
-                static_cast<float>(value)
-                * 100.f
-                / static_cast<float>(m_profile.filtered_event_indices().size())
-                * percent_digits_rounding);
-            return DeprecatedString::formatted(
-                "{}.{:02}",
-                percentage_full_precision / percent_digits_rounding,
-                percentage_full_precision % percent_digits_rounding);
-        };
         if (index.column() == Column::SampleCount) {
             if (m_profile.show_percentages())
-                return round_percentages(node->event_count());
+                return format_percentage(node->event_count(), m_profile.filtered_event_indices().size());
             return node->event_count();
         }
         if (index.column() == Column::SelfCount) {
             if (m_profile.show_percentages())
-                return round_percentages(node->self_count());
+                return format_percentage(node->self_count(), m_profile.filtered_event_indices().size());
             return node->self_count();
         }
         if (index.column() == Column::ObjectName)

--- a/Userland/DevTools/Profiler/ProfileModel.h
+++ b/Userland/DevTools/Profiler/ProfileModel.h
@@ -14,10 +14,6 @@ namespace Profiler {
 
 class Profile;
 
-// Number of digits after the decimal point for sample percentages.
-static constexpr int const number_of_percent_digits = 2;
-static constexpr int const percent_digits_rounding = AK::pow(10, number_of_percent_digits);
-
 class ProfileModel final : public GUI::Model {
 public:
     static NonnullRefPtr<ProfileModel> create(Profile& profile)

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Julius Heijmen <julius.heijmen@gmail.com>
+ * Copyright (c) 2023, Jelle Raaijmakers <jelle@gmta.nl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -223,10 +224,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     // FIXME: Make this constexpr once String is able to.
-    auto const sample_count_percent_format_string = DeprecatedString::formatted("{{:.{}f}}%", number_of_percent_digits);
-    auto const format_sample_count = [&profile, sample_count_percent_format_string](auto const sample_count) {
+    auto const format_sample_count = [&profile](auto const sample_count) {
         if (profile->show_percentages())
-            return DeprecatedString::formatted(sample_count_percent_format_string, sample_count.as_float_or(0.0));
+            return DeprecatedString::formatted("{}%", sample_count.as_string());
         return DeprecatedString::formatted("{} Samples", sample_count.to_i32());
     };
 


### PR DESCRIPTION
This implements the same percentage formatting for the disassembly and flamegraph views as we have for the profile model.

**Examples**

![Screenshot_20230202_125715](https://user-images.githubusercontent.com/3210731/216319447-77fd6819-6748-4809-9201-1503478c1193.png)

![Screenshot_20230202_125743](https://user-images.githubusercontent.com/3210731/216319484-9409081d-6405-40f3-9e49-63260f453b89.png)
