### PR TITLE
Chess+GamesSettings: Move chess appearance settings into GamesSettings, and fix some bugs

### DIFF
--- a/Userland/Applications/GamesSettings/CMakeLists.txt
+++ b/Userland/Applications/GamesSettings/CMakeLists.txt
@@ -1,19 +1,22 @@
 serenity_component(
-        GamesSettings
-        REQUIRED
-        TARGETS GamesSettings
+    GamesSettings
+    REQUIRED
+    TARGETS GamesSettings
 )
 
 compile_gml(CardSettingsWidget.gml CardSettingsWidgetGML.h card_settings_widget_gml)
+compile_gml(ChessSettingsWidget.gml ChessSettingsWidgetGML.h chess_settings_widget_gml)
 
 set(SOURCES
     main.cpp
     CardSettingsWidget.cpp
+    ChessSettingsWidget.cpp
 )
 
 set(GENERATED_SOURCES
     CardSettingsWidgetGML.h
+    ChessSettingsWidgetGML.h
 )
 
 serenity_app(GamesSettings ICON games)
-target_link_libraries(GamesSettings PRIVATE LibConfig LibCore LibGfx LibGUI LibMain LibCards)
+target_link_libraries(GamesSettings PRIVATE LibConfig LibCore LibGfx LibGUI LibMain LibCards LibChess)

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -67,9 +67,16 @@ private:
     }
 };
 
-CardSettingsWidget::CardSettingsWidget()
+ErrorOr<NonnullRefPtr<CardSettingsWidget>> CardSettingsWidget::try_create()
 {
-    load_from_gml(card_settings_widget_gml).release_value_but_fixme_should_propagate_errors();
+    auto card_settings_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) CardSettingsWidget));
+    TRY(card_settings_widget->initialize());
+    return card_settings_widget;
+}
+
+ErrorOr<void> CardSettingsWidget::initialize()
+{
+    TRY(load_from_gml(card_settings_widget_gml));
 
     auto background_color = Gfx::Color::from_string(Config::read_string("Games"sv, "Cards"sv, "BackgroundColor"sv)).value_or(Gfx::Color::from_rgb(0x008000));
 
@@ -99,6 +106,8 @@ CardSettingsWidget::CardSettingsWidget()
     };
 
     m_last_selected_card_back = m_card_back_image_view->selection().first();
+
+    return {};
 }
 
 void CardSettingsWidget::apply_settings()

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
@@ -18,13 +18,13 @@ namespace GamesSettings {
 
 static constexpr StringView default_card_back_image_path = "/res/icons/cards/buggie-deck.png"sv;
 
-class Preview final : public Cards::CardGame {
-    C_OBJECT_ABSTRACT(Preview)
+class CardGamePreview final : public Cards::CardGame {
+    C_OBJECT_ABSTRACT(CardGamePreview)
 
 public:
-    static ErrorOr<NonnullRefPtr<Preview>> try_create()
+    static ErrorOr<NonnullRefPtr<CardGamePreview>> try_create()
     {
-        auto preview = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Preview()));
+        auto preview = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) CardGamePreview()));
 
         Gfx::IntPoint point { 25, 30 };
         TRY(preview->add_stack(point, Cards::CardStack::Type::Stock));
@@ -51,7 +51,7 @@ public:
     }
 
 private:
-    Preview() = default;
+    CardGamePreview() = default;
 
     virtual void paint_event(GUI::PaintEvent& event) override
     {
@@ -73,7 +73,7 @@ CardSettingsWidget::CardSettingsWidget()
 
     auto background_color = Gfx::Color::from_string(Config::read_string("Games"sv, "Cards"sv, "BackgroundColor"sv)).value_or(Gfx::Color::from_rgb(0x008000));
 
-    m_preview_frame = find_descendant_of_type_named<Preview>("cards_preview");
+    m_preview_frame = find_descendant_of_type_named<CardGamePreview>("cards_preview");
     m_preview_frame->set_background_color(background_color);
 
     m_background_color_input = find_descendant_of_type_named<GUI::ColorInput>("cards_background_color");
@@ -136,4 +136,4 @@ DeprecatedString CardSettingsWidget::card_back_image_path() const
 
 }
 
-REGISTER_WIDGET(GamesSettings, Preview);
+REGISTER_WIDGET(GamesSettings, CardGamePreview);

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.gml
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.gml
@@ -4,7 +4,7 @@
         margins: [8]
     }
 
-    @GamesSettings::Preview {
+    @GamesSettings::CardGamePreview {
         name: "cards_preview"
         fill_with_background_color: true
         fixed_height: 160

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.h
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -18,15 +18,17 @@ namespace GamesSettings {
 class CardGamePreview;
 
 class CardSettingsWidget final : public GUI::SettingsWindow::Tab {
-    C_OBJECT(CardSettingsWidget)
+    C_OBJECT_ABSTRACT(CardSettingsWidget)
 public:
+    static ErrorOr<NonnullRefPtr<CardSettingsWidget>> try_create();
     virtual ~CardSettingsWidget() override = default;
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
-    CardSettingsWidget();
+    CardSettingsWidget() = default;
+    ErrorOr<void> initialize();
 
     bool set_card_back_image_path(DeprecatedString const&);
     DeprecatedString card_back_image_path() const;

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.h
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.h
@@ -15,7 +15,7 @@
 
 namespace GamesSettings {
 
-class Preview;
+class CardGamePreview;
 
 class CardSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT(CardSettingsWidget)
@@ -31,7 +31,7 @@ private:
     bool set_card_back_image_path(DeprecatedString const&);
     DeprecatedString card_back_image_path() const;
 
-    RefPtr<Preview> m_preview_frame;
+    RefPtr<CardGamePreview> m_preview_frame;
     RefPtr<GUI::ColorInput> m_background_color_input;
     RefPtr<GUI::IconView> m_card_back_image_view;
 

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ChessSettingsWidget.h"
+#include "AK/String.h"
+#include <Applications/GamesSettings/ChessSettingsWidgetGML.h>
+#include <LibChess/Chess.h>
+#include <LibConfig/Client.h>
+#include <LibCore/DirIterator.h>
+#include <LibGUI/CheckBox.h>
+#include <LibGUI/ComboBox.h>
+#include <LibGUI/Frame.h>
+#include <LibGUI/ItemListModel.h>
+#include <LibGUI/Painter.h>
+
+namespace GamesSettings {
+
+struct BoardTheme {
+    StringView name;
+    Color dark_square_color;
+    Color light_square_color;
+};
+
+// The following colors have been taken from lichess.org, but I'm pretty sure they took them from chess.com.
+Array<BoardTheme, 3> s_board_themes {
+    BoardTheme { "Beige"sv, Color::from_rgb(0xb58863), Color::from_rgb(0xf0d9b5) },
+    BoardTheme { "Blue"sv, Color::from_rgb(0x8ca2ad), Color::from_rgb(0xdee3e6) },
+    BoardTheme { "Green"sv, Color::from_rgb(0x86a666), Color::from_rgb(0xffffdd) },
+};
+
+static BoardTheme& get_board_theme(StringView name)
+{
+    for (size_t i = 0; i < s_board_themes.size(); ++i) {
+        if (s_board_themes[i].name == name)
+            return s_board_themes[i];
+    }
+    return s_board_themes[0];
+}
+
+class BoardThemeModel final : public GUI::Model {
+public:
+    static ErrorOr<NonnullRefPtr<BoardThemeModel>> create()
+    {
+        return adopt_nonnull_ref_or_enomem(new (nothrow) BoardThemeModel());
+    }
+
+    ~BoardThemeModel() = default;
+
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override
+    {
+        return s_board_themes.size();
+    }
+
+    virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override
+    {
+        return 1;
+    }
+
+    virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role = GUI::ModelRole::Display) const override
+    {
+        if (role != GUI::ModelRole::Display)
+            return {};
+        if (!is_within_range(index))
+            return {};
+
+        return s_board_themes.at(index.row()).name;
+    }
+
+private:
+    BoardThemeModel()
+    {
+    }
+};
+
+static ErrorOr<RefPtr<Gfx::Bitmap>> load_piece_image(StringView set, StringView image)
+{
+    auto path = TRY(String::formatted("/res/icons/chess/sets/{}/{}", set, image));
+    return Gfx::Bitmap::load_from_file(path.bytes_as_string_view());
+}
+
+class ChessGamePreview final : public GUI::Frame {
+    C_OBJECT_ABSTRACT(ChessGamePreview)
+
+public:
+    static ErrorOr<NonnullRefPtr<ChessGamePreview>> try_create()
+    {
+        auto preview = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ChessGamePreview()));
+        return preview;
+    }
+
+    virtual ~ChessGamePreview() = default;
+
+    ErrorOr<void> set_piece_set_name(DeprecatedString const& piece_set_name)
+    {
+        if (m_piece_set_name == piece_set_name.view())
+            return {};
+
+        m_piece_set_name = TRY(String::from_utf8(piece_set_name));
+        m_piece_images.clear();
+
+        m_piece_images.set({ Chess::Color::White, Chess::Type::Pawn }, TRY(load_piece_image(m_piece_set_name, "white-pawn.png"sv)));
+        m_piece_images.set({ Chess::Color::Black, Chess::Type::Pawn }, TRY(load_piece_image(m_piece_set_name, "black-pawn.png"sv)));
+        m_piece_images.set({ Chess::Color::White, Chess::Type::Knight }, TRY(load_piece_image(m_piece_set_name, "white-knight.png"sv)));
+        m_piece_images.set({ Chess::Color::Black, Chess::Type::Knight }, TRY(load_piece_image(m_piece_set_name, "black-knight.png"sv)));
+        m_piece_images.set({ Chess::Color::White, Chess::Type::Bishop }, TRY(load_piece_image(m_piece_set_name, "white-bishop.png"sv)));
+        m_piece_images.set({ Chess::Color::Black, Chess::Type::Bishop }, TRY(load_piece_image(m_piece_set_name, "black-bishop.png"sv)));
+        m_piece_images.set({ Chess::Color::White, Chess::Type::Rook }, TRY(load_piece_image(m_piece_set_name, "white-rook.png"sv)));
+        m_piece_images.set({ Chess::Color::Black, Chess::Type::Rook }, TRY(load_piece_image(m_piece_set_name, "black-rook.png"sv)));
+        m_piece_images.set({ Chess::Color::White, Chess::Type::Queen }, TRY(load_piece_image(m_piece_set_name, "white-queen.png"sv)));
+        m_piece_images.set({ Chess::Color::Black, Chess::Type::Queen }, TRY(load_piece_image(m_piece_set_name, "black-queen.png"sv)));
+        m_piece_images.set({ Chess::Color::White, Chess::Type::King }, TRY(load_piece_image(m_piece_set_name, "white-king.png"sv)));
+        m_piece_images.set({ Chess::Color::Black, Chess::Type::King }, TRY(load_piece_image(m_piece_set_name, "black-king.png"sv)));
+
+        update();
+
+        return {};
+    }
+
+    void set_dark_square_color(Gfx::Color dark_square_color)
+    {
+        if (m_dark_square_color == dark_square_color)
+            return;
+
+        m_dark_square_color = dark_square_color;
+        update();
+    }
+
+    void set_light_square_color(Gfx::Color light_square_color)
+    {
+        if (m_light_square_color == light_square_color)
+            return;
+
+        m_light_square_color = light_square_color;
+        update();
+    }
+
+    void set_show_coordinates(bool show_coordinates)
+    {
+        if (m_show_coordinates == show_coordinates)
+            return;
+
+        m_show_coordinates = show_coordinates;
+        update();
+    }
+
+private:
+    ChessGamePreview() = default;
+
+    virtual void paint_event(GUI::PaintEvent& event) override
+    {
+        GUI::Frame::paint_event(event);
+
+        GUI::Painter painter(*this);
+        painter.add_clip_rect(event.rect());
+        painter.add_clip_rect(frame_inner_rect());
+
+        auto& coordinate_font = Gfx::FontDatabase::default_font().bold_variant();
+
+        // To show all the piece graphics, we need at least 12 squares visible.
+        // With the same preview size as we use for card games, a nice fit is 2 ranks of 6.
+        // There are definitely better ways of doing this, but it'll do. ;^)
+        size_t tile_size = 61;
+
+        auto rect_for_square = [&](Chess::Square const& square) {
+            return Gfx::IntRect {
+                frame_inner_rect().left() + square.file * tile_size,
+                frame_inner_rect().bottom() + 1 - (square.rank + 1) * tile_size,
+                tile_size,
+                tile_size
+            };
+        };
+
+        for (int rank = 0; rank < 3; ++rank) {
+            for (int file = 0; file < 8; ++file) {
+                Chess::Square square { rank, file };
+                auto tile_rect = rect_for_square(square);
+                painter.fill_rect(tile_rect, square.is_light() ? m_light_square_color : m_dark_square_color);
+
+                if (m_show_coordinates) {
+                    auto coord = square.to_algebraic();
+                    auto text_color = square.is_light() ? m_dark_square_color : m_light_square_color;
+                    auto shrunken_rect = tile_rect.shrunken(4, 4);
+
+                    if (square.rank == 0)
+                        painter.draw_text(shrunken_rect, coord.substring_view(0, 1), coordinate_font, Gfx::TextAlignment::BottomRight, text_color);
+
+                    if (square.file == 0)
+                        painter.draw_text(shrunken_rect, coord.substring_view(1, 1), coordinate_font, Gfx::TextAlignment::TopLeft, text_color);
+                }
+            }
+        }
+
+        auto draw_piece = [&](Chess::Piece const& piece, Chess::Square const& square) {
+            auto& bitmap = *m_piece_images.get(piece).value();
+            painter.draw_scaled_bitmap(
+                rect_for_square(square),
+                bitmap,
+                bitmap.rect(),
+                1.0f,
+                Gfx::Painter::ScalingMode::BilinearBlend);
+        };
+
+        draw_piece({ Chess::Color::White, Chess::Type::King }, { 0, 0 });
+        draw_piece({ Chess::Color::Black, Chess::Type::King }, { 1, 0 });
+        draw_piece({ Chess::Color::White, Chess::Type::Queen }, { 0, 1 });
+        draw_piece({ Chess::Color::Black, Chess::Type::Queen }, { 1, 1 });
+        draw_piece({ Chess::Color::White, Chess::Type::Rook }, { 0, 2 });
+        draw_piece({ Chess::Color::Black, Chess::Type::Rook }, { 1, 2 });
+        draw_piece({ Chess::Color::White, Chess::Type::Bishop }, { 0, 3 });
+        draw_piece({ Chess::Color::Black, Chess::Type::Bishop }, { 1, 3 });
+        draw_piece({ Chess::Color::White, Chess::Type::Knight }, { 0, 4 });
+        draw_piece({ Chess::Color::Black, Chess::Type::Knight }, { 1, 4 });
+        draw_piece({ Chess::Color::White, Chess::Type::Pawn }, { 0, 5 });
+        draw_piece({ Chess::Color::Black, Chess::Type::Pawn }, { 1, 5 });
+    }
+
+    HashMap<Chess::Piece, RefPtr<Gfx::Bitmap>> m_piece_images;
+
+    Gfx::Color m_dark_square_color { s_board_themes[0].dark_square_color };
+    Gfx::Color m_light_square_color { s_board_themes[0].light_square_color };
+    bool m_show_coordinates { true };
+    String m_piece_set_name;
+};
+
+ErrorOr<NonnullRefPtr<ChessSettingsWidget>> ChessSettingsWidget::try_create()
+{
+    auto chess_settings_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ChessSettingsWidget));
+    TRY(chess_settings_widget->initialize());
+    return chess_settings_widget;
+}
+
+ErrorOr<void> ChessSettingsWidget::initialize()
+{
+    TRY(load_from_gml(chess_settings_widget_gml));
+
+    auto piece_set_name = Config::read_string("Games"sv, "Chess"sv, "PieceSet"sv, "stelar7"sv);
+    auto board_theme = get_board_theme(Config::read_string("Games"sv, "Chess"sv, "BoardTheme"sv, "Beige"sv));
+    auto show_coordinates = Config::read_bool("Games"sv, "Chess"sv, "ShowCoordinates"sv, true);
+
+    m_preview = find_descendant_of_type_named<ChessGamePreview>("chess_preview");
+
+    m_piece_set_combobox = find_descendant_of_type_named<GUI::ComboBox>("piece_set");
+    Core::DirIterator piece_set_iterator { "/res/icons/chess/sets/", Core::DirIterator::SkipParentAndBaseDir };
+    while (piece_set_iterator.has_next())
+        m_piece_sets.append(piece_set_iterator.next_path());
+    auto piece_set_model = GUI::ItemListModel<DeprecatedString>::create(m_piece_sets);
+    m_piece_set_combobox->set_model(piece_set_model);
+    m_piece_set_combobox->set_text(piece_set_name, GUI::AllowCallback::No);
+    m_piece_set_combobox->on_change = [&](auto& value, auto&) {
+        set_modified(true);
+        m_preview->set_piece_set_name(value).release_value_but_fixme_should_propagate_errors();
+    };
+
+    m_board_theme_combobox = find_descendant_of_type_named<GUI::ComboBox>("board_theme");
+    m_board_theme_combobox->set_model(TRY(BoardThemeModel::create()));
+    m_board_theme_combobox->set_text(board_theme.name, GUI::AllowCallback::No);
+    m_board_theme_combobox->on_change = [&](auto&, auto& index) {
+        set_modified(true);
+
+        auto& theme = s_board_themes[index.row()];
+        m_preview->set_dark_square_color(theme.dark_square_color);
+        m_preview->set_light_square_color(theme.light_square_color);
+    };
+
+    m_show_coordinates_checkbox = find_descendant_of_type_named<GUI::CheckBox>("show_coordinates");
+    m_show_coordinates_checkbox->set_checked(show_coordinates, GUI::AllowCallback::No);
+    m_show_coordinates_checkbox->on_checked = [&](bool checked) {
+        set_modified(true);
+        m_preview->set_show_coordinates(checked);
+    };
+
+    TRY(m_preview->set_piece_set_name(piece_set_name));
+    m_preview->set_dark_square_color(board_theme.dark_square_color);
+    m_preview->set_light_square_color(board_theme.light_square_color);
+    m_preview->set_show_coordinates(show_coordinates);
+
+    return {};
+}
+
+void ChessSettingsWidget::apply_settings()
+{
+    Config::write_string("Games"sv, "Chess"sv, "PieceSet"sv, m_piece_set_combobox->text());
+    Config::write_string("Games"sv, "Chess"sv, "BoardTheme"sv, m_board_theme_combobox->text());
+    Config::write_bool("Games"sv, "Chess"sv, "ShowCoordinates"sv, m_show_coordinates_checkbox->is_checked());
+}
+
+void ChessSettingsWidget::reset_default_values()
+{
+    // FIXME: `set_text()` on a combobox doesn't trigger the `on_change` callback, but it probably should!
+    //        Until then, we have to manually tell the preview to update.
+    m_piece_set_combobox->set_text("stelar7");
+    (void)m_preview->set_piece_set_name("stelar7");
+    auto& board_theme = get_board_theme("Beige"sv);
+    m_board_theme_combobox->set_text(board_theme.name);
+    m_preview->set_dark_square_color(board_theme.dark_square_color);
+    m_preview->set_light_square_color(board_theme.light_square_color);
+    m_show_coordinates_checkbox->set_checked(true);
+}
+
+}
+
+REGISTER_WIDGET(GamesSettings, ChessGamePreview);

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.gml
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.gml
@@ -1,0 +1,58 @@
+@GUI::Frame {
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {
+        margins: [8]
+    }
+
+    @GamesSettings::ChessGamePreview {
+        name: "chess_preview"
+        fill_with_background_color: true
+        fixed_height: 160
+    }
+
+    @GUI::GroupBox {
+        title: "Appearance"
+        max_height: "shrink"
+        layout: @GUI::VerticalBoxLayout {
+            margins: [8]
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 16
+            }
+
+            @GUI::Label {
+                text: "Piece Set:"
+                text_alignment: "CenterLeft"
+            }
+
+            @GUI::ComboBox {
+                name: "piece_set"
+                model_only: true
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 16
+            }
+
+            @GUI::Label {
+                text: "Board Theme:"
+                text_alignment: "CenterLeft"
+            }
+
+            @GUI::ComboBox {
+                name: "board_theme"
+                model_only: true
+            }
+        }
+
+        @GUI::CheckBox {
+            name: "show_coordinates"
+            text: "Show coordinates"
+            checkbox_position: "Right"
+        }
+    }
+}

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.h
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/StringView.h>
+#include <LibGUI/SettingsWindow.h>
+#include <LibGfx/Color.h>
+
+namespace GamesSettings {
+
+class ChessGamePreview;
+
+class ChessSettingsWidget final : public GUI::SettingsWindow::Tab {
+    C_OBJECT_ABSTRACT(ChessSettingsWidget)
+public:
+    static ErrorOr<NonnullRefPtr<ChessSettingsWidget>> try_create();
+    virtual ~ChessSettingsWidget() override = default;
+
+    virtual void apply_settings() override;
+    virtual void reset_default_values() override;
+
+private:
+    ChessSettingsWidget() = default;
+    ErrorOr<void> initialize();
+
+    Vector<DeprecatedString> m_piece_sets;
+
+    RefPtr<ChessGamePreview> m_preview;
+    RefPtr<GUI::ComboBox> m_piece_set_combobox;
+    RefPtr<GUI::ComboBox> m_board_theme_combobox;
+    RefPtr<GUI::CheckBox> m_show_coordinates_checkbox;
+};
+
+}

--- a/Userland/Applications/GamesSettings/main.cpp
+++ b/Userland/Applications/GamesSettings/main.cpp
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "CardSettingsWidget.h"
+#include "ChessSettingsWidget.h"
 #include <LibConfig/Client.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
@@ -21,10 +22,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     StringView selected_tab;
     Core::ArgsParser args_parser;
-    args_parser.add_option(selected_tab, "Tab, must be 'cards'", "open-tab", 't', "tab");
+    args_parser.add_option(selected_tab, "Tab, one of 'cards' or 'chess'", "open-tab", 't', "tab");
     args_parser.parse(arguments);
 
     TRY(Core::System::unveil("/res", "r"));
+    // Both of these are used by the GUI::FileSystemModel in CardSettingsWidget.
+    TRY(Core::System::unveil("/etc/passwd", "r"));
+    TRY(Core::System::unveil("/etc/group", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = GUI::Icon::default_icon("games"sv);
@@ -32,6 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::SettingsWindow::create("Games Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
     window->set_icon(app_icon.bitmap_for_size(16));
     (void)TRY(window->add_tab<GamesSettings::CardSettingsWidget>("Cards"sv, "cards"sv));
+    (void)TRY(window->add_tab<GamesSettings::ChessSettingsWidget>("Chess"sv, "chess"sv));
     window->set_active_tab(selected_tab);
 
     window->show();

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -35,7 +35,7 @@ void ChessWidget::paint_event(GUI::PaintEvent& event)
     GUI::Painter painter(*this);
     painter.add_clip_rect(event.rect());
 
-    painter.fill_rect({ 0, 0, width(), height() }, Color::Black);
+    painter.fill_rect(frame_inner_rect(), Color::Black);
 
     painter.translate(frame_thickness() + widget_offset_x, frame_thickness() + widget_offset_y);
 

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -699,3 +699,28 @@ int ChessWidget::resign()
 
     return 0;
 }
+
+void ChessWidget::config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value)
+{
+    if (domain != "Games"sv && group != "Chess"sv)
+        return;
+
+    if (key == "PieceSet"sv) {
+        set_piece_set(value);
+        update();
+    } else if (key == "BoardTheme"sv) {
+        set_board_theme(value);
+        update();
+    }
+}
+
+void ChessWidget::config_bool_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, bool value)
+{
+    if (domain != "Games"sv && group != "Chess"sv)
+        return;
+
+    if (key == "ShowCoordinates"sv) {
+        set_coordinates(value);
+        update();
+    }
+}

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -84,7 +84,7 @@ void ChessWidget::paint_event(GUI::PaintEvent& event)
         if (!(m_dragging_piece && sq == m_moving_square)) {
             auto bmp = m_pieces.get(active_board.get_piece(sq));
             if (bmp.has_value()) {
-                painter.draw_scaled_bitmap(tile_rect, *bmp.value(), bmp.value()->rect());
+                painter.draw_scaled_bitmap(tile_rect, *bmp.value(), bmp.value()->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
             }
         }
 
@@ -169,7 +169,7 @@ void ChessWidget::paint_event(GUI::PaintEvent& event)
         auto bmp = m_pieces.get(active_board.get_piece(m_moving_square));
         if (bmp.has_value()) {
             auto center = m_drag_point - Gfx::IntPoint(tile_width / 2, tile_height / 2);
-            painter.draw_scaled_bitmap({ center, { tile_width, tile_height } }, *bmp.value(), bmp.value()->rect());
+            painter.draw_scaled_bitmap({ center, { tile_width, tile_height } }, *bmp.value(), bmp.value()->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
         }
     }
 }

--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2022, the SerenityOS developers.
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,10 +12,13 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <LibChess/Chess.h>
+#include <LibConfig/Listener.h>
 #include <LibGUI/Frame.h>
 #include <LibGfx/Bitmap.h>
 
-class ChessWidget final : public GUI::Frame {
+class ChessWidget final
+    : public GUI::Frame
+    , public Config::Listener {
     C_OBJECT(ChessWidget);
 
 public:
@@ -106,6 +110,9 @@ public:
 
 private:
     ChessWidget();
+
+    virtual void config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value) override;
+    virtual void config_bool_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, bool value) override;
 
     Chess::Board m_board;
     Chess::Board m_board_playback;

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -26,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    Config::pledge_domain("Chess");
+    Config::pledge_domain("Games");
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/Chess.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
@@ -49,10 +49,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    widget->set_piece_set(Config::read_string("Chess"sv, "Style"sv, "PieceSet"sv, "stelar7"sv));
-    widget->set_board_theme(Config::read_string("Chess"sv, "Style"sv, "BoardTheme"sv, "Beige"sv));
-    widget->set_coordinates(Config::read_bool("Chess"sv, "Style"sv, "Coordinates"sv, true));
-    widget->set_show_available_moves(Config::read_bool("Chess"sv, "Style"sv, "ShowAvailableMoves"sv, true));
+    widget->set_piece_set(Config::read_string("Games"sv, "Chess"sv, "PieceSet"sv, "stelar7"sv));
+    widget->set_board_theme(Config::read_string("Games"sv, "Chess"sv, "BoardTheme"sv, "Beige"sv));
+    widget->set_coordinates(Config::read_bool("Games"sv, "Chess"sv, "ShowCoordinates"sv, true));
+    widget->set_show_available_moves(Config::read_bool("Games"sv, "Chess"sv, "ShowAvailableMoves"sv, true));
 
     auto game_menu = TRY(window->try_add_menu("&Game"));
 
@@ -114,7 +114,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto action = GUI::Action::create_checkable(set, [&](auto& action) {
             widget->set_piece_set(action.text());
             widget->update();
-            Config::write_string("Chess"sv, "Style"sv, "PieceSet"sv, action.text());
+            Config::write_string("Games"sv, "Chess"sv, "PieceSet"sv, action.text());
         });
 
         piece_set_action_group.add_action(*action);
@@ -132,7 +132,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto action = GUI::Action::create_checkable(theme, [&](auto& action) {
             widget->set_board_theme(action.text());
             widget->update();
-            Config::write_string("Chess"sv, "Style"sv, "BoardTheme"sv, action.text());
+            Config::write_string("Games"sv, "Chess"sv, "BoardTheme"sv, action.text());
         });
         board_theme_action_group.add_action(*action);
         if (widget->board_theme().name == theme)
@@ -143,7 +143,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto coordinates_action = GUI::Action::create_checkable("Coordinates", [&](auto& action) {
         widget->set_coordinates(action.is_checked());
         widget->update();
-        Config::write_bool("Chess"sv, "Style"sv, "Coordinates"sv, action.is_checked());
+        Config::write_bool("Games"sv, "Chess"sv, "ShowCoordinates"sv, action.is_checked());
     });
     coordinates_action->set_checked(widget->coordinates());
     TRY(style_menu->try_add_action(coordinates_action));
@@ -151,7 +151,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto show_available_moves_action = GUI::Action::create_checkable("Show Available Moves", [&](auto& action) {
         widget->set_show_available_moves(action.is_checked());
         widget->update();
-        Config::write_bool("Chess"sv, "Style"sv, "ShowAvailableMoves"sv, action.is_checked());
+        Config::write_bool("Games"sv, "Chess"sv, "ShowAvailableMoves"sv, action.is_checked());
     });
     show_available_moves_action->set_checked(widget->show_available_moves());
     TRY(style_menu->try_add_action(show_available_moves_action));

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -42,11 +42,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto size = Config::read_i32("Chess"sv, "Display"sv, "size"sv, 512);
     window->set_title("Chess");
     window->set_base_size({ 4, 4 });
     window->set_size_increment({ 8, 8 });
-    window->resize(size - 4, size - 4);
+    window->resize(508, 508);
 
     window->set_icon(app_icon.bitmap_for_size(16));
 

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -27,6 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
 
     Config::pledge_domain("Games");
+    Config::monitor_domain("Games");
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man6/Chess.md") }));
     TRY(Desktop::Launcher::seal_allowlist());


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/222642/216322934-cc5cc072-49f9-4514-8663-1a4579550a2b.png)

The preview is the same size as the Cards one, yay consistency!

When you apply the settings, any open Chess instances now auto-update to match.

The "Show available moves" option is now in Chess's "Game" menu. It feels like something you might want to turn on and off more often.

There are about 60 lines of code for the `ChessGamePreview` which are very similar to code in Chess's `ChessWidget`. Ideally they'd both inherit from a common parent (or just be one class) but `LibChess` doesn't link `LibGUI` or `LibGfx`, and is used by non-graphical applications. So, there's no good place to really put it. 60 lines doesn't seem too bad.