### PR TITLE
WebContent: Remove pending file requests before invoking their callbacks

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -49,7 +49,7 @@ template<typename T, typename S>
 concept DerivedFrom = IsBaseOf<S, T>;
 
 template<typename T>
-concept AnyString = IsConstructible<StringView, T>;
+concept AnyString = IsConstructible<StringView, RemoveCVReference<T> const&>;
 
 template<typename T, typename U>
 concept HashCompatible = IsHashCompatible<Detail::Decay<T>, Detail::Decay<U>>;

--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -154,8 +154,7 @@ public:
     }
 
     template<Concepts::HashCompatible<K> Key>
-    requires(IsSame<KeyTraits, Traits<K>>) Optional<typename ValueTraits::PeekType> get(Key const& key)
-        const
+    requires(IsSame<KeyTraits, Traits<K>>) Optional<typename ValueTraits::ConstPeekType> get(Key const& key) const
     requires(!IsPointer<typename ValueTraits::PeekType>)
     {
         auto it = find(key);
@@ -165,8 +164,7 @@ public:
     }
 
     template<Concepts::HashCompatible<K> Key>
-    requires(IsSame<KeyTraits, Traits<K>>) Optional<typename ValueTraits::ConstPeekType> get(Key const& key)
-        const
+    requires(IsSame<KeyTraits, Traits<K>>) Optional<typename ValueTraits::ConstPeekType> get(Key const& key) const
     requires(IsPointer<typename ValueTraits::PeekType>)
     {
         auto it = find(key);

--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -199,6 +199,31 @@ public:
         m_table.remove(it);
     }
 
+    Optional<V> take(K const& key)
+    {
+        if (auto it = find(key); it != end()) {
+            auto value = move(it->value);
+            m_table.remove(it);
+
+            return value;
+        }
+
+        return {};
+    }
+
+    template<Concepts::HashCompatible<K> Key>
+    requires(IsSame<KeyTraits, Traits<K>>) Optional<V> take(Key const& key)
+    {
+        if (auto it = find(key); it != end()) {
+            auto value = move(it->value);
+            m_table.remove(it);
+
+            return value;
+        }
+
+        return {};
+    }
+
     V& ensure(K const& key)
     {
         auto it = find(key);

--- a/Tests/AK/TestHashMap.cpp
+++ b/Tests/AK/TestHashMap.cpp
@@ -9,6 +9,7 @@
 #include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
+#include <AK/String.h>
 
 TEST_CASE(construct)
 {
@@ -218,4 +219,35 @@ TEST_CASE(in_place_rehashing_ordered_loop_bug)
     map.remove("yt.innertube::nextId");
     map.set("yt.innertube::nextId", "");
     VERIFY(map.keys().size() == 2);
+}
+
+TEST_CASE(take)
+{
+    HashMap<String, int> map;
+
+    EXPECT(!map.take("foo"sv).has_value());
+    EXPECT(!map.take("bar"sv).has_value());
+    EXPECT(!map.take(String::from_utf8_short_string("baz"sv)).has_value());
+
+    map.set(String::from_utf8_short_string("foo"sv), 1);
+    map.set(String::from_utf8_short_string("bar"sv), 2);
+    map.set(String::from_utf8_short_string("baz"sv), 3);
+
+    auto foo = map.take("foo"sv);
+    EXPECT_EQ(foo, 1);
+
+    foo = map.take("foo"sv);
+    EXPECT(!foo.has_value());
+
+    auto bar = map.take("bar"sv);
+    EXPECT_EQ(bar, 2);
+
+    bar = map.take("bar"sv);
+    EXPECT(!bar.has_value());
+
+    auto baz = map.take(String::from_utf8_short_string("baz"sv));
+    EXPECT_EQ(baz, 3);
+
+    baz = map.take(String::from_utf8_short_string("baz"sv));
+    EXPECT(!baz.has_value());
 }

--- a/Tests/AK/TestStringUtils.cpp
+++ b/Tests/AK/TestStringUtils.cpp
@@ -6,8 +6,32 @@
 
 #include <LibTest/TestCase.h>
 
+#include <AK/ByteBuffer.h>
+#include <AK/Concepts.h>
+#include <AK/FlyString.h>
+#include <AK/String.h>
 #include <AK/StringUtils.h>
 #include <AK/Vector.h>
+
+TEST_CASE(hash_compatible)
+{
+    static_assert(AK::Concepts::HashCompatible<String, StringView>);
+    static_assert(AK::Concepts::HashCompatible<String, FlyString>);
+    static_assert(AK::Concepts::HashCompatible<StringView, String>);
+    static_assert(AK::Concepts::HashCompatible<StringView, FlyString>);
+    static_assert(AK::Concepts::HashCompatible<FlyString, String>);
+    static_assert(AK::Concepts::HashCompatible<FlyString, StringView>);
+
+    static_assert(AK::Concepts::HashCompatible<DeprecatedString, StringView>);
+    static_assert(AK::Concepts::HashCompatible<DeprecatedString, DeprecatedFlyString>);
+    static_assert(AK::Concepts::HashCompatible<StringView, DeprecatedString>);
+    static_assert(AK::Concepts::HashCompatible<StringView, DeprecatedFlyString>);
+    static_assert(AK::Concepts::HashCompatible<DeprecatedFlyString, DeprecatedString>);
+    static_assert(AK::Concepts::HashCompatible<DeprecatedFlyString, StringView>);
+
+    static_assert(AK::Concepts::HashCompatible<StringView, ByteBuffer>);
+    static_assert(AK::Concepts::HashCompatible<ByteBuffer, StringView>);
+}
 
 TEST_CASE(matches_null)
 {

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -562,13 +562,12 @@ Messages::WebContentServer::GetSessionStorageEntriesResponse ConnectionFromClien
 
 void ConnectionFromClient::handle_file_return(i32 error, Optional<IPC::File> const& file, i32 request_id)
 {
-    auto file_request = m_requested_files.get(request_id);
+    auto file_request = m_requested_files.take(request_id);
 
     VERIFY(file_request.has_value());
     VERIFY(file_request.value().on_file_request_finish);
 
     file_request.value().on_file_request_finish(error != 0 ? Error::from_errno(error) : ErrorOr<i32> { file->take_fd() });
-    m_requested_files.remove(request_id);
 }
 
 void ConnectionFromClient::request_file(Web::FileRequest file_request)


### PR DESCRIPTION
Note the first HashMap commit here is needed for the hash-compatible change to actually compile (because now the hash-compatible methods will actually be used).