### PR TITLE
CMake: Set DWARF version before the debug information level

### DIFF
--- a/Meta/CMake/serenity_compile_options.cmake
+++ b/Meta/CMake/serenity_compile_options.cmake
@@ -27,10 +27,12 @@ add_compile_options(-fsized-deallocation)
 add_compile_options(-fstack-clash-protection)
 add_compile_options(-fstack-protector-strong)
 add_link_options(-fstack-protector-strong)
-add_compile_options(-g1)
 
 # FIXME: Remove this once DWARF revision 5 is supported
 add_compile_options(-gdwarf-4)
+
+# Note: This needs to be set _after_ setting the DWARF version, otherwise we end up generating more debug information than we need.
+add_compile_options(-g1)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wno-literal-suffix)


### PR DESCRIPTION
Setting the DWARF version after having selected which level of debug information to generate apparently undoes some settings again.

Doing the reverse apparently keeps both the version and the debug level setting, resulting in a significantly smaller disk image size.

This brings our image size down to 2.0G again, after being at 5.2G ever since fb0dee5a54dbfbec7e805805371198d5f5fc574f got merged.