### PR TITLE
LibJS+LibLocale: Propagate all OOM errors from Vectors/Strings in Intl

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -2047,11 +2047,11 @@ static Optional<Calendar> keyword_to_calendar(KeywordCalendar keyword)
     }
 }
 
-Vector<HourCycle> get_regional_hour_cycles(StringView region)
+ErrorOr<Vector<HourCycle>> get_regional_hour_cycles(StringView region)
 {
     auto region_value = hour_cycle_region_from_string(region);
     if (!region_value.has_value())
-        return {};
+        return Vector<HourCycle> {};
 
     auto region_index = to_underlying(*region_value);
 
@@ -2059,7 +2059,7 @@ Vector<HourCycle> get_regional_hour_cycles(StringView region)
     auto const& regional_hour_cycles = s_hour_cycle_lists.at(regional_hour_cycles_index);
 
     Vector<HourCycle> hour_cycles;
-    hour_cycles.ensure_capacity(regional_hour_cycles.size());
+    TRY(hour_cycles.try_ensure_capacity(regional_hour_cycles.size()));
 
     for (auto hour_cycle : regional_hour_cycles)
         hour_cycles.unchecked_append(static_cast<HourCycle>(hour_cycle));

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -798,7 +798,7 @@ namespace Locale {
 
     generator.append(R"~~~(
 struct NumberFormatImpl {
-    NumberFormat to_unicode_number_format() const {
+    ErrorOr<NumberFormat> to_unicode_number_format() const {
         NumberFormat number_format {};
 
         number_format.magnitude = magnitude;
@@ -808,9 +808,9 @@ struct NumberFormatImpl {
         number_format.positive_format = decode_string(positive_format);
         number_format.negative_format = decode_string(negative_format);
 
-        number_format.identifiers.ensure_capacity(identifiers.size());
+        TRY(number_format.identifiers.try_ensure_capacity(identifiers.size()));
         for (@string_index_type@ identifier : identifiers)
-            number_format.identifiers.append(decode_string(identifier));
+            number_format.identifiers.unchecked_append(decode_string(identifier));
 
         return number_format;
     }
@@ -1017,7 +1017,7 @@ ErrorOr<Optional<NumberFormat>> get_standard_number_system_format(StringView loc
             break;
         }
 
-        return s_number_formats[format_index].to_unicode_number_format();
+        return TRY(s_number_formats[format_index].to_unicode_number_format());
     }
 
     return OptionalNone {};
@@ -1046,10 +1046,10 @@ ErrorOr<Vector<NumberFormat>> get_compact_number_system_formats(StringView local
         }
 
         auto number_formats = s_number_format_lists.at(number_format_list_index);
-        formats.ensure_capacity(number_formats.size());
+        TRY(formats.try_ensure_capacity(number_formats.size()));
 
         for (auto number_format : number_formats)
-            formats.append(s_number_formats[number_format].to_unicode_number_format());
+            formats.unchecked_append(TRY(s_number_formats[number_format].to_unicode_number_format()));
     }
 
     return formats;
@@ -1074,7 +1074,7 @@ static Unit const* find_units(StringView locale, StringView unit)
     return nullptr;
 }
 
-Vector<NumberFormat> get_unit_formats(StringView locale, StringView unit, Style style)
+ErrorOr<Vector<NumberFormat>> get_unit_formats(StringView locale, StringView unit, Style style)
 {
     Vector<NumberFormat> formats;
 
@@ -1096,10 +1096,10 @@ Vector<NumberFormat> get_unit_formats(StringView locale, StringView unit, Style 
         }
 
         auto number_formats = s_number_format_lists.at(number_format_list_index);
-        formats.ensure_capacity(number_formats.size());
+        TRY(formats.try_ensure_capacity(number_formats.size()));
 
         for (auto number_format : number_formats)
-            formats.append(s_number_formats[number_format].to_unicode_number_format());
+            formats.unchecked_append(TRY(s_number_formats[number_format].to_unicode_number_format()));
     }
 
     return formats;

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -247,7 +247,7 @@ static constexpr Array<@relative_time_format_index_type@, @size@> @name@ { {)~~~
     generate_mapping(generator, cldr.locales, cldr.unique_formats.type_that_fits(), "s_locale_relative_time_formats"sv, "s_number_systems_digits_{}"sv, nullptr, [&](auto const& name, auto const& value) { append_list(name, value.time_units); });
 
     generator.append(R"~~~(
-Vector<RelativeTimeFormat> get_relative_time_format_patterns(StringView locale, TimeUnit time_unit, StringView tense_or_number, Style style)
+ErrorOr<Vector<RelativeTimeFormat>> get_relative_time_format_patterns(StringView locale, TimeUnit time_unit, StringView tense_or_number, Style style)
 {
     Vector<RelativeTimeFormat> formats;
 
@@ -268,7 +268,7 @@ Vector<RelativeTimeFormat> get_relative_time_format_patterns(StringView locale, 
         if (decode_string(locale_format.tense_or_number) != tense_or_number)
             continue;
 
-        formats.append(locale_format.to_relative_time_format());
+        TRY(formats.try_append(locale_format.to_relative_time_format()));
     }
 
     return formats;

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -11,9 +11,11 @@
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Intl/DisplayNames.h>
 #include <LibJS/Runtime/Intl/SingleUnitIdentifiers.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
+#include <LibJS/Runtime/VM.h>
 #include <LibJS/Runtime/Value.h>
 #include <LibLocale/Forward.h>
 
@@ -54,16 +56,16 @@ struct PatternPartition {
 };
 
 struct PatternPartitionWithSource : public PatternPartition {
-    static Vector<PatternPartitionWithSource> create_from_parent_list(Vector<PatternPartition> partitions)
+    static ThrowCompletionOr<Vector<PatternPartitionWithSource>> create_from_parent_list(VM& vm, Vector<PatternPartition> partitions)
     {
         Vector<PatternPartitionWithSource> result;
-        result.ensure_capacity(partitions.size());
+        TRY_OR_THROW_OOM(vm, result.try_ensure_capacity(partitions.size()));
 
         for (auto& partition : partitions) {
             PatternPartitionWithSource partition_with_source {};
             partition_with_source.type = partition.type;
             partition_with_source.value = move(partition.value);
-            result.append(move(partition_with_source));
+            result.unchecked_append(move(partition_with_source));
         }
 
         return result;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -612,7 +612,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(VM& vm, Dat
         // b. If p is "literal", then
         if (part == "literal"sv) {
             // i. Append a new Record { [[Type]]: "literal", [[Value]]: patternPart.[[Value]] } as the last element of the list result.
-            result.append({ "literal"sv, move(pattern_part.value) });
+            TRY_OR_THROW_OOM(vm, result.try_append({ "literal"sv, move(pattern_part.value) }));
         }
 
         // c. Else if p is equal to "fractionalSecondDigits", then
@@ -627,7 +627,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(VM& vm, Dat
             auto formatted_value = MUST_OR_THROW_OOM(format_numeric(vm, *number_format3, Value(value)));
 
             // iv. Append a new Record { [[Type]]: "fractionalSecond", [[Value]]: fv } as the last element of result.
-            result.append({ "fractionalSecond"sv, move(formatted_value) });
+            TRY_OR_THROW_OOM(vm, result.try_append({ "fractionalSecond"sv, move(formatted_value) }));
         }
 
         // d. Else if p is equal to "dayPeriod", then
@@ -643,7 +643,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(VM& vm, Dat
                 formatted_value = TRY_OR_THROW_OOM(vm, String::from_utf8(*symbol));
 
             // iii. Append a new Record { [[Type]]: p, [[Value]]: fv } as the last element of the list result.
-            result.append({ "dayPeriod"sv, move(formatted_value) });
+            TRY_OR_THROW_OOM(vm, result.try_append({ "dayPeriod"sv, move(formatted_value) }));
         }
 
         // e. Else if p is equal to "timeZoneName", then
@@ -660,7 +660,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(VM& vm, Dat
             auto formatted_value = TRY_OR_THROW_OOM(vm, ::Locale::format_time_zone(data_locale, value, style, local_time.time_since_epoch()));
 
             // iv. Append a new Record { [[Type]]: p, [[Value]]: fv } as the last element of the list result.
-            result.append({ "timeZoneName"sv, move(formatted_value) });
+            TRY_OR_THROW_OOM(vm, result.try_append({ "timeZoneName"sv, move(formatted_value) }));
         }
 
         // f. Else if p matches a Property column of the row in Table 6, then
@@ -757,7 +757,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(VM& vm, Dat
             }
 
             // xi. Append a new Record { [[Type]]: p, [[Value]]: fv } as the last element of the list result.
-            result.append({ style_and_value->name, move(formatted_value) });
+            TRY_OR_THROW_OOM(vm, result.try_append({ style_and_value->name, move(formatted_value) }));
         }
 
         // g. Else if p is equal to "ampm", then
@@ -781,7 +781,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(VM& vm, Dat
             }
 
             // iv. Append a new Record { [[Type]]: "dayPeriod", [[Value]]: fv } as the last element of the list result.
-            result.append({ "dayPeriod"sv, move(formatted_value) });
+            TRY_OR_THROW_OOM(vm, result.try_append({ "dayPeriod"sv, move(formatted_value) }));
         }
 
         // h. Else if p is equal to "relatedYear", then
@@ -806,7 +806,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(VM& vm, Dat
         // to adhere to the selected locale. This depends on other generated data, so it is deferred to here.
         else if (part == "decimal"sv) {
             auto decimal_symbol = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(data_locale, date_time_format.numbering_system(), ::Locale::NumericSymbol::Decimal)).value_or("."sv);
-            result.append({ "literal"sv, TRY_OR_THROW_OOM(vm, String::from_utf8(decimal_symbol)) });
+            TRY_OR_THROW_OOM(vm, result.try_append({ "literal"sv, TRY_OR_THROW_OOM(vm, String::from_utf8(decimal_symbol)) }));
         }
 
         // j. Else,
@@ -1145,7 +1145,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_date_time_range_
         }
 
         // h. Add all elements in partResult to result in order.
-        result.extend(move(part_result));
+        TRY_OR_THROW_OOM(vm, result.try_extend(move(part_result)));
         return {};
     }));
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -1079,7 +1079,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_date_time_range_
 
         // c. Let result be ? FormatDateTimePattern(dateTimeFormat, patternParts, x, undefined).
         auto raw_result = TRY(format_date_time_pattern(vm, date_time_format, move(pattern_parts), start, nullptr));
-        auto result = PatternPartitionWithSource::create_from_parent_list(move(raw_result));
+        auto result = MUST_OR_THROW_OOM(PatternPartitionWithSource::create_from_parent_list(vm, move(raw_result)));
 
         // d. For each Record { [[Type]], [[Value]] } r in result, do
         for (auto& part : result) {
@@ -1136,7 +1136,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_date_time_range_
 
         // f. Let partResult be ? FormatDateTimePattern(dateTimeFormat, patternParts, z, rangePattern).
         auto raw_part_result = TRY(format_date_time_pattern(vm, date_time_format, move(pattern_parts), time, &range_pattern.value()));
-        auto part_result = PatternPartitionWithSource::create_from_parent_list(move(raw_part_result));
+        auto part_result = MUST_OR_THROW_OOM(PatternPartitionWithSource::create_from_parent_list(vm, move(raw_part_result)));
 
         // g. For each Record { [[Type]], [[Value]] } r in partResult, do
         for (auto& part : part_result) {

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -449,7 +449,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_duration_format_pattern(VM
                 auto number = MUST_OR_THROW_OOM(format_numeric(vm, *number_format, MathematicalValue(value)));
 
                 // 5. Append the new Record { [[Type]]: unit, [[Value]]: num} to the end of result.
-                result.append({ unit, move(number) });
+                TRY_OR_THROW_OOM(vm, result.try_append({ unit, move(number) }));
 
                 // 6. If unit is "hours" or "minutes", then
                 if (unit.is_one_of("hours"sv, "minutes"sv)) {
@@ -485,7 +485,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_duration_format_pattern(VM
                         auto separator = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(data_locale, duration_format.numbering_system(), ::Locale::NumericSymbol::TimeSeparator)).value_or(":"sv);
 
                         // ii. Append the new Record { [[Type]]: "literal", [[Value]]: separator} to the end of result.
-                        result.append({ "literal"sv, TRY_OR_THROW_OOM(vm, String::from_utf8(separator)) });
+                        TRY_OR_THROW_OOM(vm, result.try_append({ "literal"sv, TRY_OR_THROW_OOM(vm, String::from_utf8(separator)) }));
                     }
                 }
             }
@@ -517,7 +517,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_duration_format_pattern(VM
                 }
 
                 // 8. Append the new Record { [[Type]]: unit, [[Value]]: concat } to the end of result.
-                result.append({ unit, MUST_OR_THROW_OOM(concat.to_string()) });
+                TRY_OR_THROW_OOM(vm, result.try_append({ unit, MUST_OR_THROW_OOM(concat.to_string()) }));
             }
         }
     }
@@ -561,7 +561,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_duration_format_pattern(VM
             merge = false;
             continue;
         }
-        string_result.append(part.value);
+        TRY_OR_THROW_OOM(vm, string_result.try_append(part.value));
     }
 
     // 10. Set result to ! CreatePartsFromList(lf, result).

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -15,6 +15,7 @@
 #include <LibJS/Runtime/Intl/PluralRulesConstructor.h>
 #include <LibJS/Runtime/Intl/RelativeTimeFormat.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
+#include <LibJS/Runtime/ThrowableStringBuilder.h>
 
 namespace JS::Intl {
 
@@ -507,16 +508,16 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_duration_format_pattern(VM
                 auto parts = MUST_OR_THROW_OOM(partition_number_pattern(vm, *number_format, MathematicalValue(value)));
 
                 // 6. Let concat be an empty String.
-                StringBuilder concat;
+                ThrowableStringBuilder concat(vm);
 
                 // 7. For each Record { [[Type]], [[Value]], [[Unit]] } part in parts, do
                 for (auto const& part : parts) {
                     // a. Set concat to the string-concatenation of concat and part.[[Value]].
-                    concat.append(part.value);
+                    TRY(concat.append(part.value));
                 }
 
                 // 8. Append the new Record { [[Type]]: unit, [[Value]]: concat } to the end of result.
-                result.append({ unit, TRY_OR_THROW_OOM(vm, concat.to_string()) });
+                result.append({ unit, MUST_OR_THROW_OOM(concat.to_string()) });
             }
         }
     }

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
@@ -1,14 +1,14 @@
 /*
- * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/StringBuilder.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/ListFormat.h>
 #include <LibJS/Runtime/IteratorOperations.h>
+#include <LibJS/Runtime/ThrowableStringBuilder.h>
 
 namespace JS::Intl {
 
@@ -188,16 +188,16 @@ ThrowCompletionOr<String> format_list(VM& vm, ListFormat const& list_format, Vec
     auto parts = MUST_OR_THROW_OOM(create_parts_from_list(vm, list_format, list));
 
     // 2. Let result be an empty String.
-    StringBuilder result;
+    ThrowableStringBuilder result(vm);
 
     // 3. For each Record { [[Type]], [[Value]] } part in parts, do
     for (auto& part : parts) {
         // a. Set result to the string-concatenation of result and part.[[Value]].
-        result.append(part.value);
+        TRY(result.append(part.value));
     }
 
     // 4. Return result.
-    return TRY_OR_THROW_OOM(vm, result.to_string());
+    return result.to_string();
 }
 
 // 13.5.4 FormatListToParts ( listFormat, list ), https://tc39.es/ecma402/#sec-formatlisttoparts

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -188,7 +188,7 @@ static ThrowCompletionOr<LocaleAndKeys> apply_unicode_extension_to_tag(VM& vm, S
             // iv. Else,
             else {
                 // 1. Append the Record { [[Key]]: key, [[Value]]: value } to keywords.
-                keywords.append({ TRY_OR_THROW_OOM(vm, String::from_utf8(key)), *value });
+                TRY_OR_THROW_OOM(vm, keywords.try_append({ TRY_OR_THROW_OOM(vm, String::from_utf8(key)), *value }));
             }
         }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -1801,11 +1801,11 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_number_range_pat
 
     // 3. Let xResult be ? PartitionNumberPattern(numberFormat, x).
     auto raw_start_result = TRY(partition_number_pattern(vm, number_format, move(start)));
-    auto start_result = PatternPartitionWithSource::create_from_parent_list(move(raw_start_result));
+    auto start_result = MUST_OR_THROW_OOM(PatternPartitionWithSource::create_from_parent_list(vm, move(raw_start_result)));
 
     // 4. Let yResult be ? PartitionNumberPattern(numberFormat, y).
     auto raw_end_result = TRY(partition_number_pattern(vm, number_format, move(end)));
-    auto end_result = PatternPartitionWithSource::create_from_parent_list(move(raw_end_result));
+    auto end_result = MUST_OR_THROW_OOM(PatternPartitionWithSource::create_from_parent_list(vm, move(raw_end_result)));
 
     // 5. If xResult is equal to yResult, then
     if (start_result == end_result) {

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -1317,7 +1317,7 @@ ThrowCompletionOr<Optional<Variant<StringView, String>>> get_number_format_patte
         //     i. Let unit be "fallback".
         // e. Let patterns be patterns.[[<unit>]].
         // f. Let patterns be patterns.[[<unitDisplay>]].
-        auto formats = ::Locale::get_unit_formats(number_format.data_locale(), number_format.unit(), number_format.unit_display());
+        auto formats = TRY_OR_THROW_OOM(vm, ::Locale::get_unit_formats(number_format.data_locale(), number_format.unit(), number_format.unit_display()));
         auto plurality = MUST_OR_THROW_OOM(resolve_plural(vm, number_format, ::Locale::PluralForm::Cardinal, number.to_value(vm)));
 
         if (auto it = formats.find_if([&](auto& p) { return p.plurality == plurality.plural_category; }); it != formats.end())

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -151,7 +151,9 @@ ThrowCompletionOr<Vector<PatternPartitionWithUnit>> partition_relative_time_patt
             auto result = TRY_OR_THROW_OOM(vm, String::from_utf8(patterns[0].pattern));
 
             // ii. Return a List containing the Record { [[Type]]: "literal", [[Value]]: result }.
-            return Vector<PatternPartitionWithUnit> { { "literal"sv, move(result) } };
+            Vector<PatternPartitionWithUnit> result_list;
+            TRY_OR_THROW_OOM(vm, result_list.try_empend("literal"sv, move(result)));
+            return result_list;
         }
     }
 
@@ -202,7 +204,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithUnit>> make_parts_list(VM& vm, Stri
         // a. If patternPart.[[Type]] is "literal", then
         if (pattern_part.type == "literal"sv) {
             // i. Append Record { [[Type]]: "literal", [[Value]]: patternPart.[[Value]], [[Unit]]: empty } to result.
-            result.empend("literal"sv, move(pattern_part.value));
+            TRY_OR_THROW_OOM(vm, result.try_empend("literal"sv, move(pattern_part.value)));
         }
         // b. Else,
         else {
@@ -212,7 +214,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithUnit>> make_parts_list(VM& vm, Stri
             // ii. For each Record { [[Type]], [[Value]] } part in parts, do
             for (auto& part : parts) {
                 // 1. Append Record { [[Type]]: part.[[Type]], [[Value]]: part.[[Value]], [[Unit]]: unit } to result.
-                result.empend(part.type, move(part.value), unit);
+                TRY_OR_THROW_OOM(vm, result.try_empend(part.type, move(part.value), unit));
             }
         }
     }

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -117,20 +117,20 @@ ThrowCompletionOr<Vector<PatternPartitionWithUnit>> partition_relative_time_patt
     //       then filtering the large set of locale data down to the pattern we are looking for. Instead,
     //       LibUnicode expects the individual options as enumeration values, and returns the couple of
     //       patterns that match those options.
-    auto find_patterns_for_tense_or_number = [&](StringView tense_or_number) {
+    auto find_patterns_for_tense_or_number = [&](StringView tense_or_number) -> ThrowCompletionOr<Vector<::Locale::RelativeTimeFormat>> {
         // 10. If style is equal to "short", then
         //     a. Let entry be the string-concatenation of unit and "-short".
         // 11. Else if style is equal to "narrow", then
         //     a. Let entry be the string-concatenation of unit and "-narrow".
         // 12. Else,
         //     a. Let entry be unit.
-        auto patterns = ::Locale::get_relative_time_format_patterns(data_locale, time_unit, tense_or_number, style);
+        auto patterns = TRY_OR_THROW_OOM(vm, ::Locale::get_relative_time_format_patterns(data_locale, time_unit, tense_or_number, style));
 
         // 13. If fields doesn't have a field [[<entry>]], then
         if (patterns.is_empty()) {
             // a. Let entry be unit.
             // NOTE: In the CLDR, the lack of "short" or "narrow" in the key implies "long".
-            patterns = ::Locale::get_relative_time_format_patterns(data_locale, time_unit, tense_or_number, ::Locale::Style::Long);
+            patterns = TRY_OR_THROW_OOM(vm, ::Locale::get_relative_time_format_patterns(data_locale, time_unit, tense_or_number, ::Locale::Style::Long));
         }
 
         // 14. Let patterns be fields.[[<entry>]].
@@ -144,7 +144,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithUnit>> partition_relative_time_patt
         auto value_string = MUST(Value(value).to_string(vm));
 
         // b. If patterns has a field [[<valueString>]], then
-        if (auto patterns = find_patterns_for_tense_or_number(value_string); !patterns.is_empty()) {
+        if (auto patterns = MUST_OR_THROW_OOM(find_patterns_for_tense_or_number(value_string)); !patterns.is_empty()) {
             VERIFY(patterns.size() == 1);
 
             // i. Let result be patterns.[[<valueString>]].
@@ -173,7 +173,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithUnit>> partition_relative_time_patt
     }
 
     // 19. Let po be patterns.[[<tl>]].
-    auto patterns = find_patterns_for_tense_or_number(tense);
+    auto patterns = MUST_OR_THROW_OOM(find_patterns_for_tense_or_number(tense));
 
     // 20. Let fv be ! PartitionNumberPattern(relativeTimeFormat.[[NumberFormat]], value).
     auto value_partitions = MUST_OR_THROW_OOM(partition_number_pattern(vm, relative_time_format.number_format(), Value(value)));

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/StringBuilder.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>

--- a/Userland/Libraries/LibLocale/DateTimeFormat.h
+++ b/Userland/Libraries/LibLocale/DateTimeFormat.h
@@ -189,7 +189,7 @@ CalendarPatternStyle calendar_pattern_style_from_string(StringView style);
 StringView calendar_pattern_style_to_string(CalendarPatternStyle style);
 
 Optional<HourCycleRegion> hour_cycle_region_from_string(StringView hour_cycle_region);
-Vector<HourCycle> get_regional_hour_cycles(StringView region);
+ErrorOr<Vector<HourCycle>> get_regional_hour_cycles(StringView region);
 ErrorOr<Vector<HourCycle>> get_locale_hour_cycles(StringView locale);
 ErrorOr<Optional<HourCycle>> get_default_regional_hour_cycle(StringView locale);
 

--- a/Userland/Libraries/LibLocale/NumberFormat.cpp
+++ b/Userland/Libraries/LibLocale/NumberFormat.cpp
@@ -20,7 +20,7 @@ ErrorOr<Optional<StringView>> __attribute__((weak)) get_number_system_symbol(Str
 ErrorOr<Optional<NumberGroupings>> __attribute__((weak)) get_number_system_groupings(StringView, StringView) { return OptionalNone {}; }
 ErrorOr<Optional<NumberFormat>> __attribute__((weak)) get_standard_number_system_format(StringView, StringView, StandardNumberFormatType) { return OptionalNone {}; }
 ErrorOr<Vector<NumberFormat>> __attribute__((weak)) get_compact_number_system_formats(StringView, StringView, CompactNumberFormatType) { return Vector<NumberFormat> {}; }
-Vector<NumberFormat> __attribute__((weak)) get_unit_formats(StringView, StringView, Style) { return {}; }
+ErrorOr<Vector<NumberFormat>> __attribute__((weak)) get_unit_formats(StringView, StringView, Style) { return Vector<NumberFormat> {}; }
 
 Optional<Span<u32 const>> __attribute__((weak)) get_digits_for_number_system(StringView)
 {

--- a/Userland/Libraries/LibLocale/NumberFormat.h
+++ b/Userland/Libraries/LibLocale/NumberFormat.h
@@ -69,7 +69,7 @@ ErrorOr<String> replace_digits_for_number_system(StringView system, StringView n
 
 ErrorOr<Optional<NumberFormat>> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type);
 ErrorOr<Vector<NumberFormat>> get_compact_number_system_formats(StringView locale, StringView system, CompactNumberFormatType type);
-Vector<NumberFormat> get_unit_formats(StringView locale, StringView unit, Style style);
+ErrorOr<Vector<NumberFormat>> get_unit_formats(StringView locale, StringView unit, Style style);
 
 ErrorOr<Optional<String>> augment_currency_format_pattern(StringView currency_display, StringView base_pattern);
 ErrorOr<Optional<String>> augment_range_pattern(StringView range_separator, StringView lower, StringView upper);

--- a/Userland/Libraries/LibLocale/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibLocale/RelativeTimeFormat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -53,6 +53,6 @@ StringView time_unit_to_string(TimeUnit time_unit)
     }
 }
 
-Vector<RelativeTimeFormat> __attribute__((weak)) get_relative_time_format_patterns(StringView, TimeUnit, StringView, Style) { return {}; }
+ErrorOr<Vector<RelativeTimeFormat>> __attribute__((weak)) get_relative_time_format_patterns(StringView, TimeUnit, StringView, Style) { return Vector<RelativeTimeFormat> {}; }
 
 }

--- a/Userland/Libraries/LibLocale/RelativeTimeFormat.h
+++ b/Userland/Libraries/LibLocale/RelativeTimeFormat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -34,6 +34,6 @@ struct RelativeTimeFormat {
 Optional<TimeUnit> time_unit_from_string(StringView time_unit);
 StringView time_unit_to_string(TimeUnit time_unit);
 
-Vector<RelativeTimeFormat> get_relative_time_format_patterns(StringView locale, TimeUnit time_unit, StringView tense_or_number, Style style);
+ErrorOr<Vector<RelativeTimeFormat>> get_relative_time_format_patterns(StringView locale, TimeUnit time_unit, StringView tense_or_number, Style style);
 
 }


### PR DESCRIPTION
This *should* take care of all append, insert, emend, extend, etc. and construct-from-initializer-list operations. Not promising I didn't miss anything though :)