### PR TITLE
Calculator: Treat constants and pasted numbers as input

### DIFF
--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -142,6 +142,12 @@ void CalculatorWidget::set_entry(Crypto::BigFraction value)
     update_display();
 }
 
+void CalculatorWidget::set_typed_entry(Crypto::BigFraction value)
+{
+    m_keypad.set_typed_value(move(value));
+    update_display();
+}
+
 void CalculatorWidget::update_display()
 {
     m_entry->set_text(m_keypad.to_deprecated_string());

--- a/Userland/Applications/Calculator/CalculatorWidget.h
+++ b/Userland/Applications/Calculator/CalculatorWidget.h
@@ -21,6 +21,7 @@ public:
     virtual ~CalculatorWidget() override = default;
     DeprecatedString get_entry();
     void set_entry(Crypto::BigFraction);
+    void set_typed_entry(Crypto::BigFraction);
 
     void shrink(unsigned);
     unsigned rounding_length() const;

--- a/Userland/Applications/Calculator/Keypad.h
+++ b/Userland/Applications/Calculator/Keypad.h
@@ -27,6 +27,7 @@ public:
 
     Crypto::BigFraction value() const;
     void set_value(Crypto::BigFraction);
+    void set_typed_value(Crypto::BigFraction);
     void set_to_0();
 
     void shrink(unsigned);
@@ -56,6 +57,7 @@ private:
 
     enum class State {
         External,
+        TypedExternal,
         TypingInteger,
         TypingDecimal
     };

--- a/Userland/Applications/Calculator/main.cpp
+++ b/Userland/Applications/Calculator/main.cpp
@@ -53,7 +53,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (clipboard.mime_type == "text/plain") {
             if (!clipboard.data.is_empty()) {
                 auto const number = StringView(clipboard.data);
-                widget->set_entry(Crypto::BigFraction(number));
+                widget->set_typed_entry(Crypto::BigFraction(number));
             }
         }
     }));
@@ -62,13 +62,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto const power = Crypto::NumberTheory::Power("10"_bigint, "10"_bigint);
 
     constants_menu.add_action(GUI::Action::create("&Pi", TRY(Gfx::Bitmap::load_from_file("/res/icons/calculator/pi.png"sv)), [&](auto&) {
-        widget->set_entry(Crypto::BigFraction { Crypto::SignedBigInteger(31415926535), power });
+        widget->set_typed_entry(Crypto::BigFraction { Crypto::SignedBigInteger(31415926535), power });
     }));
     constants_menu.add_action(GUI::Action::create("&Euler's Number", TRY(Gfx::Bitmap::load_from_file("/res/icons/calculator/eulers_number.png"sv)), [&](auto&) {
-        widget->set_entry(Crypto::BigFraction { Crypto::SignedBigInteger(27182818284), power });
+        widget->set_typed_entry(Crypto::BigFraction { Crypto::SignedBigInteger(27182818284), power });
     }));
     constants_menu.add_action(GUI::Action::create("&Phi", TRY(Gfx::Bitmap::load_from_file("/res/icons/calculator/phi.png"sv)), [&](auto&) {
-        widget->set_entry(Crypto::BigFraction { Crypto::SignedBigInteger(16180339887), power });
+        widget->set_typed_entry(Crypto::BigFraction { Crypto::SignedBigInteger(16180339887), power });
     }));
 
     auto& round_menu = window->add_menu("&Round");


### PR DESCRIPTION
Fixes #17284

Constants and pasted numbers leave Keypad in the External state which causes subsequent operations to be performed without an argument.

This PR adds a separate method to enable setting the value of the keypad externally which leaves the keypad in a new `TypedExternal` state. Ideally, we would use the `TypingDecimal` state, but the display logic depends on each digit (and decimal point) being entered individually.