### PR TITLE
SQLStudio: Display real column names in the results tab

### DIFF
--- a/Userland/Applications/Browser/Database.h
+++ b/Userland/Applications/Browser/Database.h
@@ -68,6 +68,12 @@ private:
     Database(NonnullRefPtr<SQL::SQLClient> sql_client, SQL::ConnectionID connection_id);
     void execute_statement(SQL::StatementID statement_id, Vector<SQL::Value> placeholder_values, PendingExecution pending_execution);
 
+    template<typename ResultData>
+    auto find_pending_execution(ResultData const& result_data)
+    {
+        return m_pending_executions.find({ result_data.statement_id, result_data.execution_id });
+    }
+
     NonnullRefPtr<SQL::SQLClient> m_sql_client;
     SQL::ConnectionID m_connection_id { 0 };
 

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -232,7 +232,7 @@ MainWidget::MainWidget()
     m_query_results_table_view = m_query_results_widget->add<GUI::TableView>();
 
     m_action_tab_widget->on_tab_close_click = [this](auto&) {
-        m_action_tab_widget->set_fixed_height(0);
+        m_action_tab_widget->set_visible(false);
     };
 
     m_statusbar = find_descendant_of_type_named<GUI::Statusbar>("statusbar"sv);
@@ -285,7 +285,7 @@ MainWidget::MainWidget()
                 individual_result_as_json.append(result_row_column);
             query_results_model->add(move(individual_result_as_json));
         }
-        m_action_tab_widget->set_fixed_height(200);
+        m_action_tab_widget->set_visible(true);
     };
 }
 

--- a/Userland/DevTools/SQLStudio/MainWidget.h
+++ b/Userland/DevTools/SQLStudio/MainWidget.h
@@ -64,6 +64,7 @@ private:
 
     RefPtr<SQL::SQLClient> m_sql_client;
     Optional<SQL::ConnectionID> m_connection_id;
+    Vector<DeprecatedString> m_result_column_names;
     Vector<Vector<DeprecatedString>> m_results;
 
     void read_next_sql_statement_of_editor();

--- a/Userland/DevTools/SQLStudio/SQLStudio.gml
+++ b/Userland/DevTools/SQLStudio/SQLStudio.gml
@@ -8,16 +8,18 @@
         }
     }
 
-    @GUI::TabWidget {
-        name: "script_tab_widget"
-        reorder_allowed: true
-        show_close_buttons: true
-    }
+    @GUI::VerticalSplitter {
+        @GUI::TabWidget {
+            name: "script_tab_widget"
+            reorder_allowed: true
+            show_close_buttons: true
+        }
 
-    @GUI::TabWidget {
-        name: "action_tab_widget"
-        show_close_buttons: true
-        fixed_height: 0
+        @GUI::TabWidget {
+            name: "action_tab_widget"
+            show_close_buttons: true
+            visible: false
+        }
     }
 
     @GUI::Statusbar {

--- a/Userland/Libraries/LibSQL/AST/Select.cpp
+++ b/Userland/Libraries/LibSQL/AST/Select.cpp
@@ -12,9 +12,35 @@
 
 namespace SQL::AST {
 
+static DeprecatedString result_column_name(ResultColumn const& column, size_t column_index)
+{
+    auto fallback_column_name = [column_index]() {
+        return DeprecatedString::formatted("Column{}", column_index);
+    };
+
+    if (auto const& alias = column.column_alias(); !alias.is_empty())
+        return alias;
+
+    if (column.select_from_expression()) {
+        if (is<ColumnNameExpression>(*column.expression())) {
+            auto const& column_name_expression = verify_cast<ColumnNameExpression>(*column.expression());
+            return column_name_expression.column_name();
+        }
+
+        // FIXME: Generate column names from other result column expressions.
+        return fallback_column_name();
+    }
+
+    VERIFY(column.select_from_table());
+
+    // FIXME: Generate column names from select-from-table result columns.
+    return fallback_column_name();
+}
+
 ResultOr<ResultSet> Select::execute(ExecutionContext& context) const
 {
     NonnullRefPtrVector<ResultColumn> columns;
+    Vector<DeprecatedString> column_names;
 
     auto const& result_column_list = this->result_column_list();
     VERIFY(!result_column_list.is_empty());
@@ -26,27 +52,38 @@ ResultOr<ResultSet> Select::execute(ExecutionContext& context) const
         auto table_def = TRY(context.database->get_table(table_descriptor.schema_name(), table_descriptor.table_name()));
 
         if (result_column_list.size() == 1 && result_column_list[0].type() == ResultType::All) {
+            TRY(columns.try_ensure_capacity(columns.size() + table_def->columns().size()));
+            TRY(column_names.try_ensure_capacity(column_names.size() + table_def->columns().size()));
+
             for (auto& col : table_def->columns()) {
-                columns.append(
+                columns.unchecked_append(
                     create_ast_node<ResultColumn>(
                         create_ast_node<ColumnNameExpression>(table_def->parent()->name(), table_def->name(), col.name()),
                         ""));
+
+                column_names.unchecked_append(col.name());
             }
         }
     }
 
     if (result_column_list.size() != 1 || result_column_list[0].type() != ResultType::All) {
-        for (auto& col : result_column_list) {
+        TRY(columns.try_ensure_capacity(result_column_list.size()));
+        TRY(column_names.try_ensure_capacity(result_column_list.size()));
+
+        for (size_t i = 0; i < result_column_list.size(); ++i) {
+            auto const& col = result_column_list[i];
+
             if (col.type() == ResultType::All) {
                 // FIXME can have '*' for example in conjunction with computed columns
                 return Result { SQLCommand::Select, SQLErrorCode::SyntaxError, "*"sv };
             }
 
-            columns.append(col);
+            columns.unchecked_append(col);
+            column_names.unchecked_append(result_column_name(col, i));
         }
     }
 
-    ResultSet result { SQLCommand::Select };
+    ResultSet result { SQLCommand::Select, move(column_names) };
 
     auto descriptor = adopt_ref(*new TupleDescriptor);
     Tuple tuple(descriptor);

--- a/Userland/Libraries/LibSQL/ResultSet.h
+++ b/Userland/Libraries/LibSQL/ResultSet.h
@@ -25,7 +25,14 @@ public:
     {
     }
 
+    ALWAYS_INLINE ResultSet(SQLCommand command, Vector<DeprecatedString> column_names)
+        : m_command(command)
+        , m_column_names(move(column_names))
+    {
+    }
+
     SQLCommand command() const { return m_command; }
+    Vector<DeprecatedString> const& column_names() const { return m_column_names; }
 
     void insert_row(Tuple const& row, Tuple const& sort_key);
     void limit(size_t offset, size_t limit);
@@ -34,6 +41,7 @@ private:
     size_t binary_search(Tuple const& sort_key, size_t low, size_t high);
 
     SQLCommand m_command { SQLCommand::Unknown };
+    Vector<DeprecatedString> m_column_names;
 };
 
 }

--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -154,7 +154,7 @@ ErrorOr<NonnullRefPtr<SQLClient>> SQLClient::launch_server_and_create_client(Vec
 
 #endif
 
-void SQLClient::execution_success(u64 statement_id, u64 execution_id, bool has_results, size_t created, size_t updated, size_t deleted)
+void SQLClient::execution_success(u64 statement_id, u64 execution_id, Vector<DeprecatedString> const& column_names, bool has_results, size_t created, size_t updated, size_t deleted)
 {
     if (!on_execution_success) {
         outln("{} row(s) created, {} updated, {} deleted", created, updated, deleted);
@@ -164,6 +164,7 @@ void SQLClient::execution_success(u64 statement_id, u64 execution_id, bool has_r
     ExecutionSuccess success {
         .statement_id = statement_id,
         .execution_id = execution_id,
+        .column_names = move(const_cast<Vector<DeprecatedString>&>(column_names)),
         .has_results = has_results,
         .rows_created = created,
         .rows_updated = updated,

--- a/Userland/Libraries/LibSQL/SQLClient.h
+++ b/Userland/Libraries/LibSQL/SQLClient.h
@@ -15,6 +15,38 @@
 
 namespace SQL {
 
+struct ExecutionSuccess {
+    u64 statement_id { 0 };
+    u64 execution_id { 0 };
+
+    bool has_results { false };
+    size_t rows_created { 0 };
+    size_t rows_updated { 0 };
+    size_t rows_deleted { 0 };
+};
+
+struct ExecutionError {
+    u64 statement_id { 0 };
+    u64 execution_id { 0 };
+
+    SQLErrorCode error_code;
+    DeprecatedString error_message;
+};
+
+struct ExecutionResult {
+    u64 statement_id { 0 };
+    u64 execution_id { 0 };
+
+    Vector<Value> values;
+};
+
+struct ExecutionComplete {
+    u64 statement_id { 0 };
+    u64 execution_id { 0 };
+
+    size_t total_rows { 0 };
+};
+
 class SQLClient
     : public IPC::ConnectionToServer<SQLClientEndpoint, SQLServerEndpoint>
     , public SQLClientEndpoint {
@@ -27,10 +59,10 @@ public:
 
     virtual ~SQLClient() = default;
 
-    Function<void(u64, u64, SQLErrorCode, DeprecatedString const&)> on_execution_error;
-    Function<void(u64, u64, bool, size_t, size_t, size_t)> on_execution_success;
-    Function<void(u64, u64, Span<SQL::Value const>)> on_next_result;
-    Function<void(u64, u64, size_t)> on_results_exhausted;
+    Function<void(ExecutionSuccess)> on_execution_success;
+    Function<void(ExecutionError)> on_execution_error;
+    Function<void(ExecutionResult)> on_next_result;
+    Function<void(ExecutionComplete)> on_results_exhausted;
 
 private:
     explicit SQLClient(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
@@ -39,9 +71,9 @@ private:
     }
 
     virtual void execution_success(u64 statement_id, u64 execution_id, bool has_results, size_t created, size_t updated, size_t deleted) override;
+    virtual void execution_error(u64 statement_id, u64 execution_id, SQLErrorCode const& code, DeprecatedString const& message) override;
     virtual void next_result(u64 statement_id, u64 execution_id, Vector<SQL::Value> const&) override;
     virtual void results_exhausted(u64 statement_id, u64 execution_id, size_t total_rows) override;
-    virtual void execution_error(u64 statement_id, u64 execution_id, SQLErrorCode const& code, DeprecatedString const& message) override;
 };
 
 }

--- a/Userland/Libraries/LibSQL/SQLClient.h
+++ b/Userland/Libraries/LibSQL/SQLClient.h
@@ -19,6 +19,7 @@ struct ExecutionSuccess {
     u64 statement_id { 0 };
     u64 execution_id { 0 };
 
+    Vector<DeprecatedString> column_names;
     bool has_results { false };
     size_t rows_created { 0 };
     size_t rows_updated { 0 };
@@ -70,7 +71,7 @@ private:
     {
     }
 
-    virtual void execution_success(u64 statement_id, u64 execution_id, bool has_results, size_t created, size_t updated, size_t deleted) override;
+    virtual void execution_success(u64 statement_id, u64 execution_id, Vector<DeprecatedString> const& column_names, bool has_results, size_t created, size_t updated, size_t deleted) override;
     virtual void execution_error(u64 statement_id, u64 execution_id, SQLErrorCode const& code, DeprecatedString const& message) override;
     virtual void next_result(u64 statement_id, u64 execution_id, Vector<SQL::Value> const&) override;
     virtual void results_exhausted(u64 statement_id, u64 execution_id, size_t total_rows) override;

--- a/Userland/Services/SQLServer/SQLClient.ipc
+++ b/Userland/Services/SQLServer/SQLClient.ipc
@@ -3,7 +3,7 @@
 
 endpoint SQLClient
 {
-    execution_success(u64 statement_id, u64 execution_id, bool has_results, size_t created, size_t updated, size_t deleted) =|
+    execution_success(u64 statement_id, u64 execution_id, Vector<DeprecatedString> column_names, bool has_results, size_t created, size_t updated, size_t deleted) =|
     next_result(u64 statement_id, u64 execution_id, Vector<SQL::Value> row) =|
     results_exhausted(u64 statement_id, u64 execution_id, size_t total_rows) =|
     execution_error(u64 statement_id, u64 execution_id, SQL::SQLErrorCode code, DeprecatedString message) =|

--- a/Userland/Services/SQLServer/SQLStatement.cpp
+++ b/Userland/Services/SQLServer/SQLStatement.cpp
@@ -89,19 +89,19 @@ Optional<SQL::ExecutionID> SQLStatement::execute(Vector<SQL::Value> placeholder_
         auto result = execution_result.release_value();
 
         if (should_send_result_rows(result)) {
-            client_connection->async_execution_success(statement_id(), execution_id, true, 0, 0, 0);
+            client_connection->async_execution_success(statement_id(), execution_id, result.column_names(), true, 0, 0, 0);
 
             auto result_size = result.size();
             next(execution_id, move(result), result_size);
         } else {
             if (result.command() == SQL::SQLCommand::Insert)
-                client_connection->async_execution_success(statement_id(), execution_id, false, result.size(), 0, 0);
+                client_connection->async_execution_success(statement_id(), execution_id, result.column_names(), false, result.size(), 0, 0);
             else if (result.command() == SQL::SQLCommand::Update)
-                client_connection->async_execution_success(statement_id(), execution_id, false, 0, result.size(), 0);
+                client_connection->async_execution_success(statement_id(), execution_id, result.column_names(), false, 0, result.size(), 0);
             else if (result.command() == SQL::SQLCommand::Delete)
-                client_connection->async_execution_success(statement_id(), execution_id, false, 0, 0, result.size());
+                client_connection->async_execution_success(statement_id(), execution_id, result.column_names(), false, 0, 0, result.size());
             else
-                client_connection->async_execution_success(statement_id(), execution_id, false, 0, 0, 0);
+                client_connection->async_execution_success(statement_id(), execution_id, result.column_names(), false, 0, 0, 0);
         }
     });
 

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -76,28 +76,26 @@ public:
             m_editor->set_prompt(prompt_for_level(open_indents));
         };
 
-        m_sql_client->on_execution_success = [this](auto, auto, auto has_results, auto created, auto updated, auto deleted) {
-            if (updated != 0 || created != 0 || deleted != 0) {
-                outln("{} row(s) created, {} updated, {} deleted", created, updated, deleted);
-            }
-            if (!has_results) {
+        m_sql_client->on_execution_success = [this](auto result) {
+            if (result.rows_updated != 0 || result.rows_created != 0 || result.rows_deleted != 0)
+                outln("{} row(s) created, {} updated, {} deleted", result.rows_created, result.rows_updated, result.rows_deleted);
+            if (!result.has_results)
                 read_sql();
-            }
         };
 
-        m_sql_client->on_next_result = [](auto, auto, auto row) {
+        m_sql_client->on_next_result = [](auto result) {
             StringBuilder builder;
-            builder.join(", "sv, row);
+            builder.join(", "sv, result.values);
             outln("{}", builder.to_deprecated_string());
         };
 
-        m_sql_client->on_results_exhausted = [this](auto, auto, auto total_rows) {
-            outln("{} row(s)", total_rows);
+        m_sql_client->on_results_exhausted = [this](auto result) {
+            outln("{} row(s)", result.total_rows);
             read_sql();
         };
 
-        m_sql_client->on_execution_error = [this](auto, auto, auto, auto const& message) {
-            outln("\033[33;1mExecution error:\033[0m {}", message);
+        m_sql_client->on_execution_error = [this](auto result) {
+            outln("\033[33;1mExecution error:\033[0m {}", result.error_message);
             read_sql();
         };
 


### PR DESCRIPTION
We currently display "column 1, column 2" which is not all that helpful :)

![Screenshot from 2023-02-03 10-49-52](https://user-images.githubusercontent.com/5600524/216647240-eb752f1d-ff9f-4873-94ae-69167530832c.png)
