### PR TITLE
js: Remove usage of DeprecatedString

### DIFF
--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -77,7 +77,7 @@ static bool s_print_last_result = false;
 static bool s_strip_ansi = false;
 static bool s_disable_source_location_hints = false;
 static RefPtr<Line::Editor> s_editor;
-static DeprecatedString s_history_path = DeprecatedString::formatted("{}/.js-history", Core::StandardPaths::home_directory());
+static String s_history_path = String {};
 static int s_repl_line_level = 0;
 static bool s_fail_repl = false;
 
@@ -614,6 +614,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     bool syntax_highlight = !disable_syntax_highlight;
 
+    s_history_path = TRY(String::formatted("{}/.js-history", Core::StandardPaths::home_directory()));
+
     g_vm = JS::VM::create();
     g_vm->enable_default_host_import_module_dynamically_hook();
 
@@ -648,12 +650,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto& global_environment = interpreter->realm().global_environment();
 
         s_editor = Line::Editor::construct();
-        s_editor->load_history(s_history_path);
+        s_editor->load_history(s_history_path.to_deprecated_string());
 
         signal(SIGINT, [](int) {
             if (!s_editor->is_editing())
                 sigint_handler();
-            s_editor->save_history(s_history_path);
+            s_editor->save_history(s_history_path.to_deprecated_string());
         });
 
         s_editor->on_display_refresh = [syntax_highlight](Line::Editor& editor) {
@@ -848,7 +850,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         };
         s_editor->on_tab_complete = move(complete);
         TRY(repl(*interpreter));
-        s_editor->save_history(s_history_path);
+        s_editor->save_history(s_history_path.to_deprecated_string());
     } else {
         interpreter = JS::Interpreter::create<ScriptObject>(*g_vm);
         auto& console_object = *interpreter->realm().intrinsics().console_object();

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -283,13 +283,13 @@ static ErrorOr<bool> parse_and_run(JS::Interpreter& interpreter, StringView sour
 
         if (!thrown_value.is_object() || !is<JS::Error>(thrown_value.as_object()))
             return {};
-        auto& traceback = static_cast<JS::Error const&>(thrown_value.as_object()).traceback();
+        auto const& traceback = static_cast<JS::Error const&>(thrown_value.as_object()).traceback();
         if (traceback.size() > 1) {
             unsigned repetitions = 0;
             for (size_t i = 0; i < traceback.size(); ++i) {
-                auto& traceback_frame = traceback[i];
+                auto const& traceback_frame = traceback[i];
                 if (i + 1 < traceback.size()) {
-                    auto& next_traceback_frame = traceback[i + 1];
+                    auto const& next_traceback_frame = traceback[i + 1];
                     if (next_traceback_frame.function_name == traceback_frame.function_name) {
                         repetitions++;
                         continue;

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -352,7 +352,7 @@ static JS::ThrowCompletionOr<JS::Value> load_ini_impl(JS::VM& vm)
 
 static JS::ThrowCompletionOr<JS::Value> load_json_impl(JS::VM& vm)
 {
-    auto filename = TRY(vm.argument(0).to_deprecated_string(vm));
+    auto filename = TRY(vm.argument(0).to_string(vm));
     auto file_or_error = Core::Stream::File::open(filename, Core::Stream::OpenMode::Read);
     if (file_or_error.is_error())
         return vm.throw_completion<JS::Error>(DeprecatedString::formatted("Failed to open '{}': {}", filename, file_or_error.error()));


### PR DESCRIPTION
This removes some usage of `DeprecatedString` throughout the `js` utility. I have also updated `write_to_file()` to use the newer `Core::Stream::File` API. 