### PR TITLE
Kernel: Disallow string literals for error propagation mechanism

### DIFF
--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -4,6 +4,7 @@ set(AK_SOURCES
     CircularBuffer.cpp
     DeprecatedFlyString.cpp
     DeprecatedString.cpp
+    Error.cpp
     FloatingPointStringConversions.cpp
     FlyString.cpp
     Format.cpp

--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Error.h>
+
+#ifdef KERNEL
+#    include <AK/Format.h>
+#endif
+
+namespace AK {
+
+Error Error::from_string_view_or_print_error_and_return_errno(StringView string_literal, [[maybe_unused]] int code)
+{
+#ifdef KERNEL
+    dmesgln("{}", string_literal);
+    return Error::from_errno(code);
+#else
+    return Error::from_string_view(string_literal);
+#endif
+}
+
+}

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -22,6 +22,12 @@ namespace AK {
 class Error {
 public:
     [[nodiscard]] static Error from_errno(int code) { return Error(code); }
+
+    // NOTE: For calling this method from within kernel code, we will simply print
+    // the error message and return the errno code.
+    // For calling this method from userspace programs, we will simply return from
+    // the Error::from_string_view method!
+    [[nodiscard]] static Error from_string_view_or_print_error_and_return_errno(StringView string_literal, int code);
     [[nodiscard]] static Error from_syscall(StringView syscall_name, int rc) { return Error(syscall_name, rc); }
     [[nodiscard]] static Error from_string_view(StringView string_literal) { return Error(string_literal); }
 

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -28,7 +28,12 @@ public:
     // For calling this method from userspace programs, we will simply return from
     // the Error::from_string_view method!
     [[nodiscard]] static Error from_string_view_or_print_error_and_return_errno(StringView string_literal, int code);
-    [[nodiscard]] static Error from_syscall(StringView syscall_name, int rc) { return Error(syscall_name, rc); }
+
+#ifndef KERNEL
+    [[nodiscard]] static Error from_syscall(StringView syscall_name, int rc)
+    {
+        return Error(syscall_name, rc);
+    }
     [[nodiscard]] static Error from_string_view(StringView string_literal) { return Error(string_literal); }
 
     // NOTE: Prefer `from_string_literal` when directly typing out an error message:
@@ -49,17 +54,29 @@ public:
     {
         return from_string_view(string);
     }
+#endif
 
     bool operator==(Error const& other) const
     {
+#ifdef KERNEL
+        return m_code == other.m_code;
+#else
         return m_code == other.m_code && m_string_literal == other.m_string_literal && m_syscall == other.m_syscall;
+#endif
     }
 
-    bool is_errno() const { return m_code != 0; }
-    bool is_syscall() const { return m_syscall; }
-
     int code() const { return m_code; }
-    StringView string_literal() const { return m_string_literal; }
+#ifndef KERNEL
+    bool is_errno() const
+    {
+        return m_code != 0;
+    }
+    bool is_syscall() const { return m_syscall; }
+    StringView string_literal() const
+    {
+        return m_string_literal;
+    }
+#endif
 
 protected:
     Error(int code)
@@ -68,6 +85,7 @@ protected:
     }
 
 private:
+#ifndef KERNEL
     Error(StringView string_literal)
         : m_string_literal(string_literal)
     {
@@ -81,8 +99,13 @@ private:
     }
 
     StringView m_string_literal;
+#endif
+
     int m_code { 0 };
+
+#ifndef KERNEL
     bool m_syscall { false };
+#endif
 };
 
 template<typename T, typename E>

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -684,9 +684,7 @@ struct Formatter<Error> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Error const& error)
     {
 #if defined(AK_OS_SERENITY) && defined(KERNEL)
-        if (error.is_errno())
-            return Formatter<FormatString>::format(builder, "Error(errno={})"sv, error.code());
-        return Formatter<FormatString>::format(builder, "Error({})"sv, error.string_literal());
+        return Formatter<FormatString>::format(builder, "Error(errno={})"sv, error.code());
 #else
         if (error.is_syscall())
             return Formatter<FormatString>::format(builder, "{}: {} (errno={})"sv, error.string_literal(), strerror(error.code()), error.code());

--- a/AK/Hex.cpp
+++ b/AK/Hex.cpp
@@ -15,18 +15,18 @@ namespace AK {
 ErrorOr<ByteBuffer> decode_hex(StringView input)
 {
     if ((input.length() % 2) != 0)
-        return Error::from_string_literal("Hex string was not an even length");
+        return Error::from_string_view_or_print_error_and_return_errno("Hex string was not an even length"sv, EINVAL);
 
     auto output = TRY(ByteBuffer::create_zeroed(input.length() / 2));
 
     for (size_t i = 0; i < input.length() / 2; ++i) {
         auto const c1 = decode_hex_digit(input[i * 2]);
         if (c1 >= 16)
-            return Error::from_string_literal("Hex string contains invalid digit");
+            return Error::from_string_view_or_print_error_and_return_errno("Hex string contains invalid digit"sv, EINVAL);
 
         auto const c2 = decode_hex_digit(input[i * 2 + 1]);
         if (c2 >= 16)
-            return Error::from_string_literal("Hex string contains invalid digit");
+            return Error::from_string_view_or_print_error_and_return_errno("Hex string contains invalid digit"sv, EINVAL);
 
         output[i] = (c1 << 4) + c2;
     }

--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -59,19 +59,19 @@ ErrorOr<size_t> FixedMemoryStream::seek(i64 offset, SeekMode seek_mode)
     switch (seek_mode) {
     case SeekMode::SetPosition:
         if (offset > static_cast<i64>(m_bytes.size()))
-            return Error::from_string_literal("Offset past the end of the stream memory");
+            return Error::from_string_view_or_print_error_and_return_errno("Offset past the end of the stream memory"sv, EINVAL);
 
         m_offset = offset;
         break;
     case SeekMode::FromCurrentPosition:
         if (offset + static_cast<i64>(m_offset) > static_cast<i64>(m_bytes.size()))
-            return Error::from_string_literal("Offset past the end of the stream memory");
+            return Error::from_string_view_or_print_error_and_return_errno("Offset past the end of the stream memory"sv, EINVAL);
 
         m_offset += offset;
         break;
     case SeekMode::FromEndPosition:
         if (offset > static_cast<i64>(m_bytes.size()))
-            return Error::from_string_literal("Offset past the start of the stream memory");
+            return Error::from_string_view_or_print_error_and_return_errno("Offset past the start of the stream memory"sv, EINVAL);
 
         m_offset = m_bytes.size() - offset;
         break;
@@ -92,7 +92,7 @@ ErrorOr<size_t> FixedMemoryStream::write(ReadonlyBytes bytes)
 ErrorOr<void> FixedMemoryStream::write_entire_buffer(ReadonlyBytes bytes)
 {
     if (remaining() < bytes.size())
-        return Error::from_string_literal("Write of entire buffer ends past the memory area");
+        return Error::from_string_view_or_print_error_and_return_errno("Write of entire buffer ends past the memory area"sv, EINVAL);
 
     TRY(write(bytes));
     return {};
@@ -163,7 +163,7 @@ ErrorOr<void> AllocatingMemoryStream::discard(size_t count)
     VERIFY(m_write_offset >= m_read_offset);
 
     if (count > used_buffer_size())
-        return Error::from_string_literal("Number of discarded bytes is higher than the number of allocated bytes");
+        return Error::from_string_view_or_print_error_and_return_errno("Number of discarded bytes is higher than the number of allocated bytes"sv, EINVAL);
 
     m_read_offset += count;
 

--- a/AK/Stream.cpp
+++ b/AK/Stream.cpp
@@ -16,14 +16,19 @@ ErrorOr<void> Stream::read_entire_buffer(Bytes buffer)
     size_t nread = 0;
     while (nread < buffer.size()) {
         if (is_eof())
-            return Error::from_string_literal("Reached end-of-file before filling the entire buffer");
+            return Error::from_string_view_or_print_error_and_return_errno("Reached end-of-file before filling the entire buffer"sv, EIO);
 
         auto result = read(buffer.slice(nread));
         if (result.is_error()) {
+#ifdef KERNEL
+            if (result.error().code() == EINTR) {
+                continue;
+            }
+#else
             if (result.error().is_errno() && result.error().code() == EINTR) {
                 continue;
             }
-
+#endif
             return result.release_error();
         }
 
@@ -69,7 +74,7 @@ ErrorOr<void> Stream::discard(size_t discarded_bytes)
 
     while (discarded_bytes > 0) {
         if (is_eof())
-            return Error::from_string_literal("Reached end-of-file before reading all discarded bytes");
+            return Error::from_string_view_or_print_error_and_return_errno("Reached end-of-file before reading all discarded bytes"sv, EIO);
 
         auto slice = TRY(read(buffer.span().slice(0, min(discarded_bytes, continuous_read_size))));
         discarded_bytes -= slice.size();
@@ -84,10 +89,15 @@ ErrorOr<void> Stream::write_entire_buffer(ReadonlyBytes buffer)
     while (nwritten < buffer.size()) {
         auto result = write(buffer.slice(nwritten));
         if (result.is_error()) {
+#ifdef KERNEL
+            if (result.error().code() == EINTR) {
+                continue;
+            }
+#else
             if (result.error().is_errno() && result.error().code() == EINTR) {
                 continue;
             }
-
+#endif
             return result.release_error();
         }
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -489,6 +489,7 @@ set(AK_SOURCES
     ../AK/StringUtils.cpp
     ../AK/StringView.cpp
     ../AK/Time.cpp
+    ../AK/Error.cpp
     ../AK/Format.cpp
     ../AK/UUID.cpp
 )
@@ -626,6 +627,7 @@ if (ENABLE_KERNEL_COVERAGE_COLLECTION)
     set(KCOV_EXCLUDED_SOURCES
         # Make sure we don't instrument any code called from __sanitizer_cov_trace_pc
         # otherwise we'll end up with recursive calls to that function.
+        ../AK/Error.cpp
         ../AK/Format.cpp
         ../AK/StringBuilder.cpp
         ../Kernel/Arch/x86_64/Processor.cpp

--- a/Kernel/Net/NetworkingManagement.cpp
+++ b/Kernel/Net/NetworkingManagement.cpp
@@ -117,7 +117,8 @@ UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<NetworkAdapter>> NetworkingManagement
             return adapter;
         }
     }
-    return Error::from_string_literal("Unsupported network adapter");
+    dmesgln("Networking: Failed to initialize device {}, unsupported network adapter", device_identifier.address());
+    return Error::from_errno(ENODEV);
 }
 
 bool NetworkingManagement::initialize()


### PR DESCRIPTION
We should always assume that when an error happens, then we might need to propagate it back to userspace.
This fact is a sad one, but truthfully there's nothing we could do about it as literally (funny to say this, right?) this is how all Unix and Unix-like kernels behave since the establishment of what Unix is.
Luckily, we don't have many instances of using string literals for error propagation, so let's fix those and disallow further usage.