### PR TITLE
SystemServer: Fix `HOME` environment propagation issues 

### DIFF
--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -9,7 +9,7 @@
 #include <AK/String.h>
 #include <QCoreApplication>
 
-ErrorOr<void> spawn_helper_process(StringView process_name, Span<StringView> arguments, Core::System::SearchInPath search_in_path, Optional<Span<StringView>> environment)
+ErrorOr<void> spawn_helper_process(StringView process_name, Span<StringView> arguments, Core::System::SearchInPath search_in_path, Optional<Span<StringView const>> environment)
 {
     auto paths = TRY(get_paths_for_helper_process(process_name));
     VERIFY(!paths.is_empty());

--- a/Ladybird/HelperProcess.h
+++ b/Ladybird/HelperProcess.h
@@ -14,5 +14,5 @@
 #include <AK/StringView.h>
 #include <LibCore/System.h>
 
-ErrorOr<void> spawn_helper_process(StringView process_name, Span<StringView> arguments, Core::System::SearchInPath, Optional<Span<StringView>> environment = {});
+ErrorOr<void> spawn_helper_process(StringView process_name, Span<StringView> arguments, Core::System::SearchInPath, Optional<Span<StringView const>> environment = {});
 ErrorOr<Vector<String>> get_paths_for_helper_process(StringView process_name);

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -472,14 +472,9 @@ int clearenv()
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/setenv.html
 int setenv(char const* name, char const* value, int overwrite)
 {
-    return serenity_setenv(name, strlen(name), value, strlen(value), overwrite);
-}
-
-int serenity_setenv(char const* name, ssize_t name_length, char const* value, ssize_t value_length, int overwrite)
-{
     if (!overwrite && getenv(name))
         return 0;
-    auto const total_length = name_length + value_length + 2;
+    auto const total_length = strlen(name) + strlen(value) + 2;
     auto* var = (char*)malloc(total_length);
     snprintf(var, total_length, "%s=%s", name, value);
     s_malloced_environment_variables.set((FlatPtr)var);

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -486,6 +486,14 @@ int serenity_setenv(char const* name, ssize_t name_length, char const* value, ss
     return putenv(var);
 }
 
+// A non-evil version of putenv that will strdup the env (and free it later)
+int serenity_putenv(char const* new_var, size_t length)
+{
+    auto* var = strndup(new_var, length);
+    s_malloced_environment_variables.set((FlatPtr)var);
+    return putenv(var);
+}
+
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/putenv.html
 int putenv(char* new_var)
 {

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -32,7 +32,6 @@ int serenity_putenv(char const* new_var, size_t length);
 int unsetenv(char const*);
 int clearenv(void);
 int setenv(char const* name, char const* value, int overwrite);
-int serenity_setenv(char const* name, ssize_t name_length, char const* value, ssize_t value_length, int overwrite);
 char const* getprogname(void);
 void setprogname(char const*);
 int atoi(char const*);

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -28,6 +28,7 @@ __attribute__((alloc_size(2))) void* realloc(void* ptr, size_t);
 char* getenv(char const* name);
 char* secure_getenv(char const* name);
 int putenv(char*);
+int serenity_putenv(char const* new_var, size_t length);
 int unsetenv(char const*);
 int clearenv(void);
 int setenv(char const* name, char const* value, int overwrite);

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1442,6 +1442,20 @@ ErrorOr<void> setenv(StringView name, StringView value, bool overwrite)
     return {};
 }
 
+ErrorOr<void> putenv(StringView env)
+{
+#ifdef AK_OS_SERENITY
+    auto rc = serenity_putenv(env.characters_without_null_termination(), env.length());
+#else
+    // Leak somewhat unavoidable here due to the putenv API.
+    auto leaked_new_env = strndup(env.characters_without_null_termination(), env.length());
+    auto rc = ::putenv(leaked_new_env);
+#endif
+    if (rc < 0)
+        return Error::from_errno(errno);
+    return {};
+}
+
 ErrorOr<int> posix_openpt(int flags)
 {
     int const rc = ::posix_openpt(flags);

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1113,7 +1113,7 @@ ErrorOr<u64> create_jail(StringView jail_name)
 }
 #endif
 
-ErrorOr<void> exec(StringView filename, Span<StringView> arguments, SearchInPath search_in_path, Optional<Span<StringView>> environment)
+ErrorOr<void> exec(StringView filename, Span<StringView const> arguments, SearchInPath search_in_path, Optional<Span<StringView const>> environment)
 {
 #ifdef AK_OS_SERENITY
     Syscall::SC_execve_params params;

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -207,6 +207,7 @@ ErrorOr<void> setgroups(Span<gid_t const>);
 ErrorOr<void> mknod(StringView pathname, mode_t mode, dev_t dev);
 ErrorOr<void> mkfifo(StringView pathname, mode_t mode);
 ErrorOr<void> setenv(StringView, StringView, bool);
+ErrorOr<void> putenv(StringView);
 ErrorOr<int> posix_openpt(int flags);
 ErrorOr<void> grantpt(int fildes);
 ErrorOr<void> unlockpt(int fildes);

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -178,7 +178,7 @@ enum class SearchInPath {
 ErrorOr<void> exec_command(Vector<StringView>& command, bool preserve_env);
 #endif
 
-ErrorOr<void> exec(StringView filename, Span<StringView> arguments, SearchInPath, Optional<Span<StringView>> environment = {});
+ErrorOr<void> exec(StringView filename, Span<StringView const> arguments, SearchInPath, Optional<Span<StringView const>> environment = {});
 
 #ifdef AK_OS_SERENITY
 ErrorOr<void> join_jail(u64 jail_index);

--- a/Userland/Services/ConfigServer/main.cpp
+++ b/Userland/Services/ConfigServer/main.cpp
@@ -13,7 +13,6 @@
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     TRY(Core::System::pledge("stdio accept rpath wpath cpath"));
-    TRY(Core::System::unveil("/etc/passwd"sv, "r"sv));
     TRY(Core::System::unveil(Core::StandardPaths::config_directory(), "rwc"sv));
     TRY(Core::System::unveil(Core::StandardPaths::home_directory(), "rwc"sv));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Services/SQLServer/main.cpp
+++ b/Userland/Services/SQLServer/main.cpp
@@ -19,7 +19,6 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto database_path = DeprecatedString::formatted("{}/sql", Core::StandardPaths::data_directory());
     TRY(Core::Directory::create(database_path, Core::Directory::CreateDirectories::Yes));
 
-    TRY(Core::System::unveil("/etc/passwd"sv, "r"sv));
     TRY(Core::System::unveil(database_path, "rwc"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -193,12 +193,9 @@ ErrorOr<void> Service::spawn(int socket_fd)
             }
         }
 
-        auto environment = TRY(StringBuilder::create());
-        TRY(environment.try_append(m_environment));
-
         if (!m_sockets.is_empty()) {
             // The new descriptor is !CLOEXEC here.
-            TRY(environment.try_appendff(" SOCKET_TAKEOVER={}", TRY(socket_takeover_builder.to_string())));
+            TRY(Core::System::setenv("SOCKET_TAKEOVER"sv, socket_takeover_builder.string_view(), true));
         }
 
         if (m_account.has_value() && m_account.value().uid() != getuid()) {
@@ -207,13 +204,20 @@ ErrorOr<void> Service::spawn(int socket_fd)
                 dbgln("Failed to drop privileges (GID={}, UID={})\n", account.gid(), account.uid());
                 exit(1);
             }
-            TRY(environment.try_appendff(" HOME={}", account.home_directory()));
+            TRY(Core::System::setenv("HOME"sv, account.home_directory(), true));
         }
 
-        auto arguments = TRY(StringBuilder::create());
-        TRY(arguments.try_appendff("{} {}", m_executable_path, m_extra_arguments));
+        TRY(m_environment.view().for_each_split_view(' ', SplitBehavior::Nothing, [&](auto env) {
+            return Core::System::putenv(env);
+        }));
 
-        TRY(Core::System::exec(m_executable_path, arguments.string_view().split_view(' '), Core::System::SearchInPath::No, environment.string_view().split_view(' ')));
+        Vector<StringView, 10> arguments;
+        TRY(arguments.try_append(m_executable_path));
+        TRY(m_extra_arguments.view().for_each_split_view(' ', SplitBehavior::Nothing, [&](auto arg) {
+            return arguments.try_append(arg);
+        }));
+
+        TRY(Core::System::exec(m_executable_path, arguments, Core::System::SearchInPath::No));
     } else if (!m_multi_instance) {
         // We are the parent.
         m_pid = pid;


### PR DESCRIPTION
This PR fixes the recent errors about `/etc/passwd` not being unveiled. This was happening due to `StandardPaths::home_directory()` falling back to use `getpwuid()` as the `HOME` env var was not set.

The `HOME` env was not set due to a change in SystemServer which meant it stopped propagating the environment from LoginServer, which was setting `HOME` correctly. 

This reverts the SystemServer logic back to how it used to be (yes it used `split(' ')`) but with a little more `TRY()s`. This PR then also reverts the unveil commits that were papering over this.   