### PR TITLE
LibSQL: Actually print an error message after failing to launch a server

### DIFF
--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -85,7 +85,7 @@ static ErrorOr<void> launch_server(DeprecatedString const& socket_path, Deprecat
                 "--pid-file"sv,
                 pid_path,
             };
-            auto result = Core::System::exec(arguments[0], arguments, Core::System::SearchInPath::Yes);
+            result = Core::System::exec(arguments[0], arguments, Core::System::SearchInPath::Yes);
             if (!result.is_error())
                 break;
         }


### PR DESCRIPTION
We were shadowing the 'result' variable, which made an exec error message along with the search paths never being printed.