### PR TITLE
AK: Always define ak_assertion_failed, even when NDEBUG is false

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -7,7 +7,7 @@
 #include <AK/Assertions.h>
 #include <AK/Format.h>
 
-#if !defined(KERNEL) && defined(NDEBUG)
+#if !defined(KERNEL)
 extern "C" {
 
 void ak_verification_failed(char const* message)

--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -10,12 +10,12 @@
 #    include <Kernel/Assertions.h>
 #else
 #    include <assert.h>
+extern "C" __attribute__((noreturn)) void ak_verification_failed(char const*);
 #    ifndef NDEBUG
 #        define VERIFY assert
 #    else
 #        define __stringify_helper(x) #x
 #        define __stringify(x) __stringify_helper(x)
-extern "C" __attribute__((noreturn)) void ak_verification_failed(char const*);
 #        define VERIFY(expr)                                                                \
             (__builtin_expect(!(expr), 0)                                                   \
                     ? ak_verification_failed(#expr "\n" __FILE__ ":" __stringify(__LINE__)) \


### PR DESCRIPTION
Just because we may compile serenity with or without NDEBUG doesn't mean that consuming projects or Ports will share the setting.

Always define the custom assertion function so that we don't have to keep the same debug settings between all projects.