### PR TITLE
Implement Accessible Name and Description Calculation

### DIFF
--- a/Userland/Libraries/LibWeb/ARIA/Roles.cpp
+++ b/Userland/Libraries/LibWeb/ARIA/Roles.cpp
@@ -178,4 +178,29 @@ bool is_non_abstract_role(Role role)
         || is_windows_role(role);
 }
 
+// https://www.w3.org/TR/wai-aria-1.2/#namefromcontent
+bool allows_name_from_content(Role role)
+{
+    return first_is_one_of(role,
+        Role::button,
+        Role::cell,
+        Role::checkbox,
+        Role::columnheader,
+        Role::gridcell,
+        Role::heading,
+        Role::link,
+        Role::menuitem,
+        Role::menuitemcheckbox,
+        Role::menuitemradio,
+        Role::option,
+        Role::radio,
+        Role::row,
+        Role::rowheader,
+        Role::sectionhead,
+        Role::switch_,
+        Role::tab,
+        Role::tooltip,
+        Role::treeitem);
+}
+
 }

--- a/Userland/Libraries/LibWeb/ARIA/Roles.h
+++ b/Userland/Libraries/LibWeb/ARIA/Roles.h
@@ -124,5 +124,6 @@ bool is_live_region_role(Role);
 bool is_windows_role(Role);
 
 bool is_non_abstract_role(Role);
+bool allows_name_from_content(Role);
 
 }

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.h
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.h
@@ -25,7 +25,7 @@ public:
     Vector<AccessibilityTreeNode*> children() const { return m_children; }
     void append_child(AccessibilityTreeNode* child) { m_children.append(child); }
 
-    void serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) const;
+    void serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object, Document const&) const;
 
 protected:
     virtual void visit_edges(Visitor&) override;

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2359,7 +2359,7 @@ DeprecatedString Document::dump_accessibility_tree_as_json()
         MUST(json.add("type"sv, "element"sv));
         MUST(json.add("role"sv, "document"sv));
     } else {
-        accessibility_tree->serialize_tree_as_json(json);
+        accessibility_tree->serialize_tree_as_json(json, *this);
     }
 
     MUST(json.finish());

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -35,6 +35,11 @@ enum class NodeType : u16 {
     NOTATION_NODE = 12
 };
 
+enum class NameOrDescription {
+    Name,
+    Description
+};
+
 struct GetRootNodeOptions {
     bool composed { false };
 };
@@ -617,6 +622,9 @@ public:
         return false;
     }
 
+    ErrorOr<String> accessible_name(Document const&) const;
+    ErrorOr<String> accessible_description(Document const&) const;
+
 protected:
     Node(JS::Realm&, Document&, NodeType);
     Node(Document&, NodeType);
@@ -638,12 +646,20 @@ protected:
 
     void build_accessibility_tree(AccessibilityTreeNode& parent) const;
 
+    ErrorOr<String> name_or_description(NameOrDescription, Document const&, HashTable<i32>&) const;
+
 private:
     void queue_tree_mutation_record(JS::NonnullGCPtr<NodeList> added_nodes, JS::NonnullGCPtr<NodeList> removed_nodes, Node* previous_sibling, Node* next_sibling);
 
     void insert_before_impl(JS::NonnullGCPtr<Node>, JS::GCPtr<Node> child);
     void append_child_impl(JS::NonnullGCPtr<Node>);
     void remove_child_impl(JS::NonnullGCPtr<Node>);
+
+    static Optional<StringView> first_valid_id(DeprecatedString const&, Document const&);
+    static ErrorOr<void> append_without_space(StringBuilder, StringView const&);
+    static ErrorOr<void> append_with_space(StringBuilder, StringView const&);
+    static ErrorOr<void> prepend_without_space(StringBuilder, StringView const&);
+    static ErrorOr<void> prepend_with_space(StringBuilder, StringView const&);
 
     JS::GCPtr<Node> m_parent;
     JS::GCPtr<Node> m_first_child;

--- a/Userland/Libraries/LibWebView/AccessibilityTreeModel.cpp
+++ b/Userland/Libraries/LibWebView/AccessibilityTreeModel.cpp
@@ -93,8 +93,12 @@ GUI::Variant AccessibilityTreeModel::data(GUI::ModelIndex const& index, GUI::Mod
         if (type != "element")
             return node_role;
 
+        auto name = node.get_deprecated_string("name"sv).value();
+        auto description = node.get_deprecated_string("description"sv).value();
+
         StringBuilder builder;
         builder.append(node_role.to_lowercase());
+        builder.appendff(" name: \"{}\", description: \"{}\"", name, description);
         return builder.to_deprecated_string();
     }
     return {};


### PR DESCRIPTION
This provides an initial implementation of the ACCNAME standard, improving our WAI-ARIA support. The names and descriptions are displayed in the accessibility tab of the DOM inspector along with the roles already present.