### PR TITLE
AK+Everywhere: Add ReadonlySpan<T> alias and use it everywhere 

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -31,7 +31,7 @@ struct Array {
 
     [[nodiscard]] constexpr size_t size() const { return Size; }
 
-    [[nodiscard]] constexpr Span<T const> span() const { return { __data, Size }; }
+    [[nodiscard]] constexpr ReadonlySpan<T> span() const { return { __data, Size }; }
     [[nodiscard]] constexpr Span<T> span() { return { __data, Size }; }
 
     [[nodiscard]] constexpr T const& at(size_t index) const
@@ -76,7 +76,7 @@ struct Array {
     [[nodiscard]] constexpr ConstIterator end() const { return ConstIterator::end(*this); }
     [[nodiscard]] constexpr Iterator end() { return Iterator::end(*this); }
 
-    [[nodiscard]] constexpr operator Span<T const>() const { return span(); }
+    [[nodiscard]] constexpr operator ReadonlySpan<T>() const { return span(); }
     [[nodiscard]] constexpr operator Span<T>() { return span(); }
 
     constexpr size_t fill(T const& value)

--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -123,8 +123,8 @@ public:
     [[nodiscard]] Bytes bytes() { return { data(), size() }; }
     [[nodiscard]] ReadonlyBytes bytes() const { return { data(), size() }; }
 
-    [[nodiscard]] AK::Span<u8> span() { return { data(), size() }; }
-    [[nodiscard]] AK::Span<u8 const> span() const { return { data(), size() }; }
+    [[nodiscard]] AK::Bytes span() { return { data(), size() }; }
+    [[nodiscard]] AK::ReadonlyBytes span() const { return { data(), size() }; }
 
     [[nodiscard]] u8* offset_pointer(size_t offset) { return data() + offset; }
     [[nodiscard]] u8 const* offset_pointer(size_t offset) const { return data() + offset; }

--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -163,7 +163,7 @@ public:
     ConstIterator end() const { return ConstIterator::end(*this); }
 
     Span<T> span() { return { data(), size() }; }
-    Span<T const> span() const { return { data(), size() }; }
+    ReadonlySpan<T> span() const { return { data(), size() }; }
 
 private:
     struct Storage {

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -264,13 +264,13 @@ private:
 
 class TypeErasedFormatParams {
 public:
-    Span<TypeErasedParameter const> parameters() const { return m_parameters; }
+    ReadonlySpan<TypeErasedParameter> parameters() const { return m_parameters; }
 
-    void set_parameters(Span<TypeErasedParameter const> parameters) { m_parameters = parameters; }
+    void set_parameters(ReadonlySpan<TypeErasedParameter> parameters) { m_parameters = parameters; }
     size_t take_next_index() { return m_next_index++; }
 
 private:
-    Span<TypeErasedParameter const> m_parameters;
+    ReadonlySpan<TypeErasedParameter> m_parameters;
     size_t m_next_index { 0 };
 };
 
@@ -359,14 +359,14 @@ struct Formatter<StringView> : StandardFormatter {
 
 template<typename T>
 requires(HasFormatter<T>)
-struct Formatter<Span<T const>> : StandardFormatter {
+struct Formatter<ReadonlySpan<T>> : StandardFormatter {
     Formatter() = default;
     explicit Formatter(StandardFormatter formatter)
         : StandardFormatter(move(formatter))
     {
     }
 
-    ErrorOr<void> format(FormatBuilder& builder, Span<T const> value)
+    ErrorOr<void> format(FormatBuilder& builder, ReadonlySpan<T> value)
     {
         if (m_mode == Mode::Pointer) {
             Formatter<FlatPtr> formatter { *this };
@@ -406,19 +406,19 @@ struct Formatter<Span<T const>> : StandardFormatter {
 
 template<typename T>
 requires(HasFormatter<T>)
-struct Formatter<Span<T>> : Formatter<Span<T const>> {
+struct Formatter<Span<T>> : Formatter<ReadonlySpan<T>> {
     ErrorOr<void> format(FormatBuilder& builder, Span<T> value)
     {
-        return Formatter<Span<T const>>::format(builder, value);
+        return Formatter<ReadonlySpan<T>>::format(builder, value);
     }
 };
 
 template<typename T, size_t inline_capacity>
 requires(HasFormatter<T>)
-struct Formatter<Vector<T, inline_capacity>> : Formatter<Span<T const>> {
+struct Formatter<Vector<T, inline_capacity>> : Formatter<ReadonlySpan<T>> {
     ErrorOr<void> format(FormatBuilder& builder, Vector<T, inline_capacity> const& value)
     {
-        return Formatter<Span<T const>>::format(builder, value.span());
+        return Formatter<ReadonlySpan<T>>::format(builder, value.span());
     }
 };
 

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -61,7 +61,10 @@ struct Array;
 template<typename Container, typename ValueType>
 class SimpleIterator;
 
-using ReadonlyBytes = Span<u8 const>;
+template<typename T>
+using ReadonlySpan = Span<T const>;
+
+using ReadonlyBytes = ReadonlySpan<u8>;
 using Bytes = Span<u8>;
 
 template<typename T, AK::MemoryOrder DefaultMemoryOrder>

--- a/AK/MemMem.h
+++ b/AK/MemMem.h
@@ -43,7 +43,7 @@ constexpr void const* bitap_bitwise(void const* haystack, size_t haystack_length
 }
 
 template<typename HaystackIterT>
-inline Optional<size_t> memmem(HaystackIterT const& haystack_begin, HaystackIterT const& haystack_end, Span<u8 const> needle)
+inline Optional<size_t> memmem(HaystackIterT const& haystack_begin, HaystackIterT const& haystack_end, ReadonlyBytes needle)
 requires(requires { (*haystack_begin).data(); (*haystack_begin).size(); })
 {
     auto prepare_kmp_partial_table = [&] {
@@ -123,7 +123,7 @@ inline Optional<size_t> memmem_optional(void const* haystack, size_t haystack_le
     }
 
     // Fallback to KMP.
-    Array<Span<u8 const>, 1> spans { Span<u8 const> { (u8 const*)haystack, haystack_length } };
+    Array<ReadonlyBytes, 1> spans { ReadonlyBytes { (u8 const*)haystack, haystack_length } };
     return memmem(spans.begin(), spans.end(), { (u8 const*)needle, needle_length });
 }
 

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -192,7 +192,7 @@ public:
         return false;
     }
 
-    [[nodiscard]] bool constexpr starts_with(Span<T const> other) const
+    [[nodiscard]] bool constexpr starts_with(ReadonlySpan<T> other) const
     {
         if (size() < other.size())
             return false;
@@ -250,7 +250,7 @@ public:
         return TypedTransfer<T>::compare(data(), other.data(), size());
     }
 
-    ALWAYS_INLINE constexpr operator Span<T const>() const
+    ALWAYS_INLINE constexpr operator ReadonlySpan<T>() const
     {
         return { data(), size() };
     }

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -271,7 +271,10 @@ struct Traits<Span<T>> : public GenericTraits<Span<T>> {
     constexpr static bool is_trivial() { return true; }
 };
 
-using ReadonlyBytes = Span<u8 const>;
+template<typename T>
+using ReadonlySpan = Span<T const>;
+
+using ReadonlyBytes = ReadonlySpan<u8>;
 using Bytes = Span<u8>;
 
 }
@@ -279,5 +282,6 @@ using Bytes = Span<u8>;
 #if USING_AK_GLOBALLY
 using AK::Bytes;
 using AK::ReadonlyBytes;
+using AK::ReadonlySpan;
 using AK::Span;
 #endif

--- a/AK/UFixedBigInt.h
+++ b/AK/UFixedBigInt.h
@@ -77,13 +77,13 @@ public:
         return m_high;
     }
 
-    Span<u8> bytes()
+    Bytes bytes()
     {
-        return Span<u8>(reinterpret_cast<u8*>(this), sizeof(R));
+        return Bytes { reinterpret_cast<u8*>(this), sizeof(R) };
     }
-    Span<u8 const> bytes() const
+    ReadonlyBytes bytes() const
     {
-        return Span<u8 const>(reinterpret_cast<u8 const*>(this), sizeof(R));
+        return ReadonlyBytes { reinterpret_cast<u8 const*>(this), sizeof(R) };
     }
 
     template<Unsigned U>

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -64,7 +64,7 @@ public:
     Utf16View() = default;
     ~Utf16View() = default;
 
-    explicit Utf16View(Span<u16 const> code_units)
+    explicit Utf16View(ReadonlySpan<u16> code_units)
         : m_code_units(code_units)
     {
     }
@@ -116,7 +116,7 @@ private:
 
     size_t calculate_length_in_code_points() const;
 
-    Span<u16 const> m_code_units;
+    ReadonlySpan<u16> m_code_units;
     mutable Optional<size_t> m_length_in_code_points;
 };
 

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -90,7 +90,7 @@ public:
         m_size = other.size();
     }
 
-    explicit Vector(Span<T const> other)
+    explicit Vector(ReadonlySpan<T> other)
     requires(!IsLvalueReference<T>)
     {
         ensure_capacity(other.size());
@@ -112,10 +112,10 @@ public:
     }
 
     Span<StorageType> span() { return { data(), size() }; }
-    Span<StorageType const> span() const { return { data(), size() }; }
+    ReadonlySpan<StorageType> span() const { return { data(), size() }; }
 
     operator Span<StorageType>() { return span(); }
-    operator Span<StorageType const>() const { return span(); }
+    operator ReadonlySpan<StorageType>() const { return span(); }
 
     bool is_empty() const { return size() == 0; }
     ALWAYS_INLINE size_t size() const { return m_size; }

--- a/Kernel/Credentials.cpp
+++ b/Kernel/Credentials.cpp
@@ -10,7 +10,7 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullRefPtr<Credentials>> Credentials::create(UserID uid, GroupID gid, UserID euid, GroupID egid, UserID suid, GroupID sgid, Span<GroupID const> extra_gids, SessionID sid, ProcessGroupID pgid)
+ErrorOr<NonnullRefPtr<Credentials>> Credentials::create(UserID uid, GroupID gid, UserID euid, GroupID egid, UserID suid, GroupID sgid, ReadonlySpan<GroupID> extra_gids, SessionID sid, ProcessGroupID pgid)
 {
     auto extra_gids_array = TRY(FixedArray<GroupID>::create(extra_gids));
     return adopt_nonnull_ref_or_enomem(new (nothrow) Credentials(uid, gid, euid, egid, suid, sgid, move(extra_gids_array), sid, pgid));

--- a/Kernel/Credentials.h
+++ b/Kernel/Credentials.h
@@ -14,7 +14,7 @@ namespace Kernel {
 
 class Credentials final : public AtomicRefCounted<Credentials> {
 public:
-    static ErrorOr<NonnullRefPtr<Credentials>> create(UserID uid, GroupID gid, UserID euid, GroupID egid, UserID suid, GroupID sgid, Span<GroupID const> extra_gids, SessionID sid, ProcessGroupID pgid);
+    static ErrorOr<NonnullRefPtr<Credentials>> create(UserID uid, GroupID gid, UserID euid, GroupID egid, UserID suid, GroupID sgid, ReadonlySpan<GroupID> extra_gids, SessionID sid, ProcessGroupID pgid);
     ~Credentials();
 
     bool is_superuser() const { return euid() == 0; }
@@ -25,7 +25,7 @@ public:
     GroupID gid() const { return m_gid; }
     UserID suid() const { return m_suid; }
     GroupID sgid() const { return m_sgid; }
-    Span<GroupID const> extra_gids() const { return m_extra_gids.span(); }
+    ReadonlySpan<GroupID> extra_gids() const { return m_extra_gids.span(); }
     SessionID sid() const { return m_sid; };
     ProcessGroupID pgid() const { return m_pgid; }
 

--- a/Kernel/FileSystem/InodeMetadata.h
+++ b/Kernel/FileSystem/InodeMetadata.h
@@ -48,7 +48,7 @@ struct InodeMetadata {
     bool may_write(Credentials const&, UseEffectiveIDs = UseEffectiveIDs::Yes) const;
     bool may_execute(Credentials const&, UseEffectiveIDs = UseEffectiveIDs::Yes) const;
 
-    bool may_read(UserID u, GroupID g, Span<GroupID const> eg) const
+    bool may_read(UserID u, GroupID g, ReadonlySpan<GroupID> eg) const
     {
         if (u == 0)
             return true;
@@ -59,7 +59,7 @@ struct InodeMetadata {
         return (mode & S_IROTH) == S_IROTH;
     }
 
-    bool may_write(UserID u, GroupID g, Span<GroupID const> eg) const
+    bool may_write(UserID u, GroupID g, ReadonlySpan<GroupID> eg) const
     {
         if (u == 0)
             return true;
@@ -70,7 +70,7 @@ struct InodeMetadata {
         return (mode & S_IWOTH) == S_IWOTH;
     }
 
-    bool may_execute(UserID u, GroupID g, Span<GroupID const> eg) const
+    bool may_execute(UserID u, GroupID g, ReadonlySpan<GroupID> eg) const
     {
         if (u == 0)
             return true;

--- a/Kernel/Interrupts/GenericInterruptHandler.cpp
+++ b/Kernel/Interrupts/GenericInterruptHandler.cpp
@@ -67,7 +67,7 @@ void GenericInterruptHandler::change_interrupt_number(u8 number)
     register_generic_interrupt_handler(InterruptManagement::acquire_mapped_interrupt_number(interrupt_number()), *this);
 }
 
-Span<u32 const> GenericInterruptHandler::per_cpu_call_counts() const
+ReadonlySpan<u32> GenericInterruptHandler::per_cpu_call_counts() const
 {
     return m_per_cpu_call_counts.span().slice(0, Processor::count());
 }

--- a/Kernel/Interrupts/GenericInterruptHandler.h
+++ b/Kernel/Interrupts/GenericInterruptHandler.h
@@ -37,7 +37,7 @@ public:
 
     u8 interrupt_number() const { return m_interrupt_number; }
 
-    Span<u32 const> per_cpu_call_counts() const;
+    ReadonlySpan<u32> per_cpu_call_counts() const;
 
     virtual size_t sharing_devices_count() const = 0;
     virtual bool is_shared_handler() const = 0;

--- a/Kernel/Memory/SharedFramebufferVMObject.cpp
+++ b/Kernel/Memory/SharedFramebufferVMObject.cpp
@@ -60,7 +60,7 @@ Span<RefPtr<PhysicalPage>> SharedFramebufferVMObject::real_framebuffer_physical_
 {
     return m_real_framebuffer_vmobject->physical_pages();
 }
-Span<RefPtr<PhysicalPage> const> SharedFramebufferVMObject::real_framebuffer_physical_pages() const
+ReadonlySpan<RefPtr<PhysicalPage>> SharedFramebufferVMObject::real_framebuffer_physical_pages() const
 {
     return m_real_framebuffer_vmobject->physical_pages();
 }
@@ -70,7 +70,7 @@ Span<RefPtr<PhysicalPage>> SharedFramebufferVMObject::fake_sink_framebuffer_phys
     return m_physical_pages.span();
 }
 
-Span<RefPtr<PhysicalPage> const> SharedFramebufferVMObject::fake_sink_framebuffer_physical_pages() const
+ReadonlySpan<RefPtr<PhysicalPage>> SharedFramebufferVMObject::fake_sink_framebuffer_physical_pages() const
 {
     return m_physical_pages.span();
 }
@@ -92,7 +92,7 @@ void SharedFramebufferVMObject::switch_to_real_framebuffer_writes(Badge<Kernel::
     });
 }
 
-Span<RefPtr<PhysicalPage> const> SharedFramebufferVMObject::physical_pages() const
+ReadonlySpan<RefPtr<PhysicalPage>> SharedFramebufferVMObject::physical_pages() const
 {
     SpinlockLocker locker(m_writes_state_lock);
     if (m_writes_are_faked)

--- a/Kernel/Memory/SharedFramebufferVMObject.h
+++ b/Kernel/Memory/SharedFramebufferVMObject.h
@@ -29,7 +29,7 @@ public:
         }
         virtual StringView class_name() const override { return "FakeWritesFramebufferVMObject"sv; }
         virtual ErrorOr<NonnullLockRefPtr<VMObject>> try_clone() override { return Error::from_errno(ENOTIMPL); }
-        virtual Span<RefPtr<PhysicalPage> const> physical_pages() const override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
+        virtual ReadonlySpan<RefPtr<PhysicalPage>> physical_pages() const override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
         virtual Span<RefPtr<PhysicalPage>> physical_pages() override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
         NonnullLockRefPtr<SharedFramebufferVMObject> m_parent_object;
     };
@@ -46,7 +46,7 @@ public:
         }
         virtual StringView class_name() const override { return "RealWritesFramebufferVMObject"sv; }
         virtual ErrorOr<NonnullLockRefPtr<VMObject>> try_clone() override { return Error::from_errno(ENOTIMPL); }
-        virtual Span<RefPtr<PhysicalPage> const> physical_pages() const override { return m_parent_object->real_framebuffer_physical_pages(); }
+        virtual ReadonlySpan<RefPtr<PhysicalPage>> physical_pages() const override { return m_parent_object->real_framebuffer_physical_pages(); }
         virtual Span<RefPtr<PhysicalPage>> physical_pages() override { return m_parent_object->real_framebuffer_physical_pages(); }
         NonnullLockRefPtr<SharedFramebufferVMObject> m_parent_object;
     };
@@ -60,14 +60,14 @@ public:
     void switch_to_fake_sink_framebuffer_writes(Badge<Kernel::DisplayConnector>);
     void switch_to_real_framebuffer_writes(Badge<Kernel::DisplayConnector>);
 
-    virtual Span<RefPtr<PhysicalPage> const> physical_pages() const override;
+    virtual ReadonlySpan<RefPtr<PhysicalPage>> physical_pages() const override;
     virtual Span<RefPtr<PhysicalPage>> physical_pages() override;
 
     Span<RefPtr<PhysicalPage>> fake_sink_framebuffer_physical_pages();
-    Span<RefPtr<PhysicalPage> const> fake_sink_framebuffer_physical_pages() const;
+    ReadonlySpan<RefPtr<PhysicalPage>> fake_sink_framebuffer_physical_pages() const;
 
     Span<RefPtr<PhysicalPage>> real_framebuffer_physical_pages();
-    Span<RefPtr<PhysicalPage> const> real_framebuffer_physical_pages() const;
+    ReadonlySpan<RefPtr<PhysicalPage>> real_framebuffer_physical_pages() const;
 
     FakeWritesFramebufferVMObject const& fake_writes_framebuffer_vmobject() const { return *m_fake_writes_framebuffer_vmobject; }
     FakeWritesFramebufferVMObject& fake_writes_framebuffer_vmobject() { return *m_fake_writes_framebuffer_vmobject; }

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -35,7 +35,7 @@ public:
 
     size_t page_count() const { return m_physical_pages.size(); }
 
-    virtual Span<RefPtr<PhysicalPage> const> physical_pages() const { return m_physical_pages.span(); }
+    virtual ReadonlySpan<RefPtr<PhysicalPage>> physical_pages() const { return m_physical_pages.span(); }
     virtual Span<RefPtr<PhysicalPage>> physical_pages() { return m_physical_pages.span(); }
 
     size_t size() const { return m_physical_pages.size() * PAGE_SIZE; }

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -9,7 +9,7 @@
 #include <AK/String.h>
 #include <QCoreApplication>
 
-ErrorOr<void> spawn_helper_process(StringView process_name, Span<StringView> arguments, Core::System::SearchInPath search_in_path, Optional<Span<StringView const>> environment)
+ErrorOr<void> spawn_helper_process(StringView process_name, ReadonlySpan<StringView> arguments, Core::System::SearchInPath search_in_path, Optional<ReadonlySpan<StringView>> environment)
 {
     auto paths = TRY(get_paths_for_helper_process(process_name));
     VERIFY(!paths.is_empty());

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -15,7 +15,6 @@ ErrorOr<void> spawn_helper_process(StringView process_name, Span<StringView> arg
     VERIFY(!paths.is_empty());
     ErrorOr<void> result;
     for (auto const& path : paths) {
-        arguments[0] = path.bytes_as_string_view();
         result = Core::System::exec(path, arguments, search_in_path, environment);
         if (!result.is_error())
             break;

--- a/Ladybird/HelperProcess.h
+++ b/Ladybird/HelperProcess.h
@@ -14,5 +14,5 @@
 #include <AK/StringView.h>
 #include <LibCore/System.h>
 
-ErrorOr<void> spawn_helper_process(StringView process_name, Span<StringView> arguments, Core::System::SearchInPath, Optional<Span<StringView const>> environment = {});
+ErrorOr<void> spawn_helper_process(StringView process_name, ReadonlySpan<StringView> arguments, Core::System::SearchInPath, Optional<ReadonlySpan<StringView>> environment = {});
 ErrorOr<Vector<String>> get_paths_for_helper_process(StringView process_name);

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -576,7 +576,7 @@ void WebContentView::create_client()
 
         auto webcontent_fd_passing_socket_string = DeprecatedString::number(wc_fd_passing_fd);
 
-        Vector<StringView> arguments {
+        Vector<StringView, 5> arguments {
             "WebContent"sv,
             "--webcontent-fd-passing-socket"sv,
             webcontent_fd_passing_socket_string

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
@@ -2215,7 +2215,7 @@ ErrorOr<Vector<CalendarRangePattern>> get_calendar_range12_formats(StringView lo
     return result;
 }
 
-static ErrorOr<Span<@string_index_type@ const>> find_calendar_symbols(StringView locale, StringView calendar, CalendarSymbol symbol, CalendarPatternStyle style)
+static ErrorOr<ReadonlySpan<@string_index_type@>> find_calendar_symbols(StringView locale, StringView calendar, CalendarSymbol symbol, CalendarPatternStyle style)
 {
     if (auto const* data = TRY(find_calendar_data(locale, calendar)); data != nullptr) {
         auto const& symbols_list = s_calendar_symbol_lists[data->symbols];
@@ -2243,7 +2243,7 @@ static ErrorOr<Span<@string_index_type@ const>> find_calendar_symbols(StringView
         return s_symbol_lists.at(symbol_list_index);
     }
 
-    return Span<@string_index_type@ const> {};
+    return ReadonlySpan<@string_index_type@> {};
 }
 
 ErrorOr<Optional<StringView>> get_calendar_era_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Era value)

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
@@ -1127,7 +1127,7 @@ struct TextLayout {
     generate_available_values(generator, "get_available_currencies"sv, cldr.currencies);
 
     generator.append(R"~~~(
-Span<StringView const> get_available_keyword_values(StringView key)
+ReadonlySpan<StringView> get_available_keyword_values(StringView key)
 {
     auto key_value = key_from_string(key);
     if (!key_value.has_value())
@@ -1521,7 +1521,7 @@ Optional<StringView> get_locale_@enum_snake@_mapping(StringView locale, StringVi
     generate_value_to_string(generator, "{}_to_string"sv, "CharacterOrder"sv, "character_order"sv, format_identifier, cldr.character_orders);
 
     generator.append(R"~~~(
-static Span<@string_index_type@ const> find_keyword_indices(StringView locale, StringView key)
+static ReadonlySpan<@string_index_type@> find_keyword_indices(StringView locale, StringView key)
 {
     auto locale_value = locale_from_string(locale);
     if (!locale_value.has_value())

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
@@ -915,7 +915,7 @@ static Optional<NumberSystem> keyword_to_number_system(KeywordNumbers keyword)
     }
 }
 
-Optional<Span<u32 const>> get_digits_for_number_system(StringView system)
+Optional<ReadonlySpan<u32>> get_digits_for_number_system(StringView system)
 {
     auto number_system_keyword = keyword_nu_from_string(system);
     if (!number_system_keyword.has_value())

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
@@ -622,7 +622,7 @@ PluralCategory determine_plural_category(StringView locale, PluralForm form, Plu
     return decider(move(operands));
 }
 
-Span<PluralCategory const> available_plural_categories(StringView locale, PluralForm form)
+ReadonlySpan<PluralCategory> available_plural_categories(StringView locale, PluralForm form)
 {
     auto locale_value = locale_from_string(locale);
     if (!locale_value.has_value())

--- a/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
@@ -151,7 +151,7 @@ struct AK::Formatter<TimeZone::Location> : Formatter<FormatString> {
     }
 };
 
-static Optional<DateTime> parse_date_time(Span<StringView const> segments)
+static Optional<DateTime> parse_date_time(ReadonlySpan<StringView> segments)
 {
     auto comment_index = find_index(segments.begin(), segments.end(), "#"sv);
     if (comment_index != segments.size())

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateEmojiData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateEmojiData.cpp
@@ -228,9 +228,9 @@ struct EmojiData {
         return emoji;
     }
 
-    constexpr Span<u32 const> code_points() const
+    constexpr ReadonlySpan<u32> code_points() const
     {
-        return Span<u32 const>(s_emoji_code_points.data() + code_point_start, code_point_count);
+        return ReadonlySpan<u32>(s_emoji_code_points.data() + code_point_start, code_point_count);
     }
 
     @string_index_type@ name { 0 };
@@ -259,7 +259,7 @@ static constexpr Array<EmojiData, @emojis_size@> s_emojis { {)~~~");
     generator.append(R"~~~(
 } };
 
-Optional<Emoji> find_emoji_for_code_points(Span<u32 const> code_points)
+Optional<Emoji> find_emoji_for_code_points(ReadonlySpan<u32> code_points)
 {
     for (auto& emoji : s_emojis) {
         if (emoji.code_points() == code_points)

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -856,13 +856,13 @@ struct CodePointDecompositionRaw {
 struct CodePointDecomposition {
     u32 code_point { 0 };
     CompatibilityFormattingTag tag { CompatibilityFormattingTag::Canonical };
-    Span<u32 const> decomposition;
+    ReadonlySpan<u32> decomposition;
 };
 
 Optional<Locale> locale_from_string(StringView locale);
 
-Span<SpecialCasing const* const> special_case_mapping(u32 code_point);
-Span<CaseFolding const* const> case_folding_mapping(u32 code_point);
+ReadonlySpan<SpecialCasing const*> special_case_mapping(u32 code_point);
+ReadonlySpan<CaseFolding const*> case_folding_mapping(u32 code_point);
 
 }
 )~~~");
@@ -1133,7 +1133,7 @@ static constexpr Array<CodePointRange, @size@> @name@ { {
         generator.set("name", collection_name);
         generator.set("size", DeprecatedString::number(property_names.size()));
         generator.append(R"~~~(
-static constexpr Array<Span<CodePointRange const>, @size@> @name@ { {)~~~");
+static constexpr Array<ReadonlySpan<CodePointRange>, @size@> @name@ { {)~~~");
 
         for (auto const& property_name : property_names) {
             generator.set("name", DeprecatedString::formatted(property_format, property_name));
@@ -1197,7 +1197,7 @@ Optional<StringView> code_point_block_display_name(u32 code_point)
     return {};
 }
 
-Span<BlockName const> block_display_names()
+ReadonlySpan<BlockName> block_display_names()
 {
     static auto display_names = []() {
         Array<BlockName, s_block_display_names.size()> display_names;
@@ -1247,7 +1247,7 @@ u32 @method@(u32 code_point)
     append_code_point_mapping_search("to_unicode_titlecase"sv, "s_titlecase_mappings"sv, "code_point"sv);
 
     generator.append(R"~~~(
-Span<SpecialCasing const* const> special_case_mapping(u32 code_point)
+ReadonlySpan<SpecialCasing const*> special_case_mapping(u32 code_point)
 {
     auto const* mapping = binary_search(s_special_case_mappings, code_point, nullptr, CodePointComparator<SpecialCaseMapping> {});
     if (mapping == nullptr)
@@ -1256,7 +1256,7 @@ Span<SpecialCasing const* const> special_case_mapping(u32 code_point)
     return mapping->special_casing.span().slice(0, mapping->special_casing_size);
 }
 
-Span<CaseFolding const* const> case_folding_mapping(u32 code_point)
+ReadonlySpan<CaseFolding const*> case_folding_mapping(u32 code_point)
 {
     auto const* mapping = binary_search(s_case_folding_mappings, code_point, nullptr, CodePointComparator<CaseFoldingMapping> {});
     if (mapping == nullptr)
@@ -1281,7 +1281,7 @@ Optional<CodePointDecomposition const> code_point_decomposition(u32 code_point)
     auto const* mapping = binary_search(s_decomposition_mappings, code_point, nullptr, CodePointComparator<CodePointDecompositionRaw> {});
     if (mapping == nullptr)
         return {};
-    return CodePointDecomposition { mapping->code_point, mapping->tag, Span<u32 const> { s_decomposition_mappings_data.data() + mapping->decomposition_index, mapping->decomposition_count } };
+    return CodePointDecomposition { mapping->code_point, mapping->tag, ReadonlySpan<u32> { s_decomposition_mappings_data.data() + mapping->decomposition_index, mapping->decomposition_count } };
 }
 
 Optional<CodePointDecomposition const> code_point_decomposition_by_index(size_t index)
@@ -1289,7 +1289,7 @@ Optional<CodePointDecomposition const> code_point_decomposition_by_index(size_t 
     if (index >= s_decomposition_mappings.size())
         return {};
     auto const& mapping = s_decomposition_mappings[index];
-    return CodePointDecomposition { mapping.code_point, mapping.tag, Span<u32 const> { s_decomposition_mappings_data.data() + mapping.decomposition_index, mapping.decomposition_count } };
+    return CodePointDecomposition { mapping.code_point, mapping.tag, ReadonlySpan<u32> { s_decomposition_mappings_data.data() + mapping.decomposition_index, mapping.decomposition_count } };
 }
 )~~~");
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -158,7 +158,7 @@ static constexpr Array<@type@, @size@> @name@@index@ { {)~~~");
 
         generator.append(R"~~~(
 
-static constexpr Array<Span<@type@ const>, @size@ + 1> @name@ { {
+static constexpr Array<ReadonlySpan<@type@>, @size@ + 1> @name@ { {
     {})~~~");
 
         constexpr size_t max_values_per_row = 10;
@@ -475,7 +475,7 @@ Optional<@return_type@> @method_name@(StringView key)
 }
 
 template<typename IdentifierFormatter>
-void generate_value_to_string(SourceGenerator& generator, StringView method_name_format, StringView value_type, StringView value_name, IdentifierFormatter&& format_identifier, Span<DeprecatedString const> values)
+void generate_value_to_string(SourceGenerator& generator, StringView method_name_format, StringView value_type, StringView value_name, IdentifierFormatter&& format_identifier, ReadonlySpan<DeprecatedString> values)
 {
     generator.set("method_name", DeprecatedString::formatted(method_name_format, value_name));
     generator.set("value_type", value_type);
@@ -576,7 +576,7 @@ void generate_mapping(SourceGenerator& generator, LocalesType const& locales, St
     generator.set("name", name);
     generator.set("size", DeprecatedString::number(locales.size()));
     generator.append(R"~~~(
-static constexpr Array<Span<@type@ const>, @size@> @name@ { {
+static constexpr Array<ReadonlySpan<@type@>, @size@> @name@ { {
     )~~~");
 
     constexpr size_t max_values_per_row = 10;
@@ -606,7 +606,7 @@ void generate_available_values(SourceGenerator& generator, StringView name, Vect
     generator.set("name", name);
 
     generator.append(R"~~~(
-Span<StringView const> @name@()
+ReadonlySpan<StringView> @name@()
 {
     static constexpr auto values = Array {)~~~");
 

--- a/Tests/AK/TestArray.cpp
+++ b/Tests/AK/TestArray.cpp
@@ -8,7 +8,7 @@
 
 #include <AK/Array.h>
 
-static constexpr int constexpr_sum(Span<int const> const span)
+static constexpr int constexpr_sum(ReadonlySpan<int> const span)
 {
     int sum = 0;
     for (auto value : span)

--- a/Tests/AK/TestSpan.cpp
+++ b/Tests/AK/TestSpan.cpp
@@ -102,7 +102,7 @@ TEST_CASE(can_subspan_as_intended)
 {
     static constexpr u16 buffer[8] { 1, 2, 3, 4, 5, 6, 7, 8 };
 
-    constexpr Span<u16 const> span { buffer, 8 };
+    constexpr ReadonlySpan<u16> span { buffer, 8 };
     constexpr auto slice = span.slice(3, 2);
 
     static_assert(slice.size() == 2u);

--- a/Userland/Applications/Browser/CookieJar.cpp
+++ b/Userland/Applications/Browser/CookieJar.cpp
@@ -420,7 +420,7 @@ Vector<Web::Cookie::Cookie> CookieJar::get_matching_cookies(const URL& url, Depr
     return cookie_list;
 }
 
-static ErrorOr<Web::Cookie::Cookie> parse_cookie(Span<SQL::Value const> row)
+static ErrorOr<Web::Cookie::Cookie> parse_cookie(ReadonlySpan<SQL::Value> row)
 {
     if (row.size() != 12)
         return Error::from_string_view("Incorrect number of columns to parse cookie"sv);

--- a/Userland/Applications/Browser/Database.h
+++ b/Userland/Applications/Browser/Database.h
@@ -21,7 +21,7 @@
 namespace Browser {
 
 class Database : public RefCounted<Database> {
-    using OnResult = Function<void(Span<SQL::Value const>)>;
+    using OnResult = Function<void(ReadonlySpan<SQL::Value>)>;
     using OnComplete = Function<void()>;
     using OnError = Function<void(StringView)>;
 

--- a/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
@@ -24,7 +24,7 @@
 #include <spawn.h>
 #include <unistd.h>
 
-using StringViewListModel = GUI::ItemListModel<StringView, Span<StringView const>>;
+using StringViewListModel = GUI::ItemListModel<StringView, ReadonlySpan<StringView>>;
 
 static constexpr auto PI_OVER_180 = M_PIf32 / 180.0f;
 static constexpr auto PI_OVER_4 = M_PIf32 / 4.0f;

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -366,7 +366,7 @@ void HexEditorWidget::update_inspector_values(size_t position)
         value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::UTF8, utf8_view.unicode_substring_view(0, 1).as_string());
 
     if (byte_read_count % 2 == 0) {
-        Utf16View utf16_view { Span<u16 const> { reinterpret_cast<u16 const*>(&unsigned_64_bit_int), 4 } };
+        Utf16View utf16_view { ReadonlySpan<u16> { reinterpret_cast<u16 const*>(&unsigned_64_bit_int), 4 } };
         size_t valid_code_units;
         utf16_view.validate(valid_code_units);
         if (valid_code_units == 0)

--- a/Userland/Games/2048/Game.cpp
+++ b/Userland/Games/2048/Game.cpp
@@ -141,7 +141,7 @@ static bool is_complete(Game::Board const& board, size_t target)
     return false;
 }
 
-static bool has_no_neighbors(Span<u32 const> const& row)
+static bool has_no_neighbors(ReadonlySpan<u32> const& row)
 {
     if (row.size() < 2)
         return true;

--- a/Userland/Libraries/LibAudio/MP3HuffmanTables.h
+++ b/Userland/Libraries/LibAudio/MP3HuffmanTables.h
@@ -106,7 +106,7 @@ struct HuffmanDecodeResult {
 };
 
 template<typename T>
-HuffmanDecodeResult<T> huffman_decode(BigEndianInputBitStream& bitstream, Span<HuffmanNode<T> const> tree, size_t max_bits_to_read)
+HuffmanDecodeResult<T> huffman_decode(BigEndianInputBitStream& bitstream, ReadonlySpan<HuffmanNode<T>> tree, size_t max_bits_to_read)
 {
     HuffmanNode<T> const* node = &tree[0];
     size_t bits_read = 0;
@@ -1681,7 +1681,7 @@ constexpr auto Tree30 = make_huffman_tree<Table30>();
 constexpr auto Tree31 = make_huffman_tree<Table31>();
 
 struct HuffmanTreeXY {
-    Span<HuffmanNode<HuffmanXY> const> nodes;
+    ReadonlySpan<HuffmanNode<HuffmanXY>> nodes;
     int linbits;
 };
 

--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -555,7 +555,7 @@ MaybeLoaderError MP3LoaderPlugin::read_huffman_data(MP3::MP3Frame& frame, BigEnd
         granule.samples[count + 1] = requantize(y, exponents[count + 1]);
     }
 
-    Span<MP3::Tables::Huffman::HuffmanNode<MP3::Tables::Huffman::HuffmanVWXY> const> count1table = granule.count1table_select ? MP3::Tables::Huffman::TreeB : MP3::Tables::Huffman::TreeA;
+    ReadonlySpan<MP3::Tables::Huffman::HuffmanNode<MP3::Tables::Huffman::HuffmanVWXY>> count1table = granule.count1table_select ? MP3::Tables::Huffman::TreeB : MP3::Tables::Huffman::TreeA;
 
     // count1 is not known. We have to read huffman encoded values
     // until we've exhausted the granule's bits. We know the size of
@@ -672,7 +672,7 @@ void MP3LoaderPlugin::process_stereo(MP3::MP3Frame& frame, size_t granule_index)
     auto& granule_left = frame.channels[0].granules[granule_index];
     auto& granule_right = frame.channels[1].granules[granule_index];
 
-    auto get_last_nonempty_band = [](Span<float> samples, Span<MP3::Tables::ScaleFactorBand const> bands) -> size_t {
+    auto get_last_nonempty_band = [](Span<float> samples, ReadonlySpan<MP3::Tables::ScaleFactorBand> bands) -> size_t {
         size_t last_nonempty_band = 0;
 
         for (size_t i = 0; i < bands.size(); i++) {
@@ -781,7 +781,7 @@ void MP3LoaderPlugin::transform_samples_to_time(Array<float, 576> const& input, 
             output[i] = 0;
 
     } else {
-        s_mdct_36.transform(Span<float const>(input).slice(input_offset, 18), output);
+        s_mdct_36.transform(ReadonlySpan<float>(input).slice(input_offset, 18), output);
         for (size_t i = 0; i < 36; i++) {
             switch (block_type) {
             case MP3::BlockType::Normal:
@@ -837,7 +837,7 @@ void MP3LoaderPlugin::synthesis(Array<float, 1024>& V, Array<float, 32>& samples
     }
 }
 
-Span<MP3::Tables::ScaleFactorBand const> MP3LoaderPlugin::get_scalefactor_bands(MP3::Granule const& granule, int samplerate)
+ReadonlySpan<MP3::Tables::ScaleFactorBand> MP3LoaderPlugin::get_scalefactor_bands(MP3::Granule const& granule, int samplerate)
 {
     switch (granule.block_type) {
     case MP3::BlockType::Short:

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -56,7 +56,7 @@ private:
     static void process_stereo(MP3::MP3Frame&, size_t granule_index);
     static void transform_samples_to_time(Array<float, 576> const& input, size_t input_offset, Array<float, 36>& output, MP3::BlockType block_type);
     static void synthesis(Array<float, 1024>& V, Array<float, 32>& samples, Array<float, 32>& result);
-    static Span<MP3::Tables::ScaleFactorBand const> get_scalefactor_bands(MP3::Granule const&, int samplerate);
+    static ReadonlySpan<MP3::Tables::ScaleFactorBand> get_scalefactor_bands(MP3::Granule const&, int samplerate);
 
     AK::Vector<AK::Tuple<size_t, int>> m_seek_table;
     AK::Array<AK::Array<AK::Array<float, 18>, 32>, 2> m_last_values {};

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -132,7 +132,7 @@ bool ArgsParser::parse(int argc, char* const* argv, FailureBehavior failure_beha
     }
 
     if (m_perform_autocomplete) {
-        autocomplete(stdout, { argv[0], strlen(argv[0]) }, Span<char const* const> { argv + optind, static_cast<size_t>(argc - optind) });
+        autocomplete(stdout, { argv[0], strlen(argv[0]) }, ReadonlySpan<char const*> { argv + optind, static_cast<size_t>(argc - optind) });
         if (failure_behavior == FailureBehavior::Exit || failure_behavior == FailureBehavior::PrintUsageAndExit)
             exit(0);
         return false;
@@ -731,7 +731,7 @@ void ArgsParser::add_positional_argument(Vector<StringView>& values, char const*
     add_positional_argument(move(arg));
 }
 
-void ArgsParser::autocomplete(FILE* file, StringView program_name, Span<char const* const> remaining_arguments)
+void ArgsParser::autocomplete(FILE* file, StringView program_name, ReadonlySpan<char const*> remaining_arguments)
 {
     // We expect the full invocation of the program to be available as positional args,
     // e.g. `foo --bar arg -b` (program invoked as `foo --complete -- foo --bar arg -b`)

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -112,7 +112,7 @@ public:
     void add_positional_argument(Vector<StringView>& value, char const* help_string, char const* name, Required required = Required::Yes);
 
 private:
-    void autocomplete(FILE*, StringView program_name, Span<char const* const> remaining_arguments);
+    void autocomplete(FILE*, StringView program_name, ReadonlySpan<char const*> remaining_arguments);
 
     Vector<Option> m_options;
     Vector<Arg> m_positional_args;

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -70,7 +70,7 @@ struct ArgvList {
     }
 };
 
-ErrorOr<pid_t> Process::spawn(StringView path, Span<DeprecatedString const> arguments, DeprecatedString working_directory)
+ErrorOr<pid_t> Process::spawn(StringView path, ReadonlySpan<DeprecatedString> arguments, DeprecatedString working_directory)
 {
     ArgvList argv { path, arguments.size() };
     for (auto const& arg : arguments)
@@ -79,7 +79,7 @@ ErrorOr<pid_t> Process::spawn(StringView path, Span<DeprecatedString const> argu
     return argv.spawn();
 }
 
-ErrorOr<pid_t> Process::spawn(StringView path, Span<StringView const> arguments, DeprecatedString working_directory)
+ErrorOr<pid_t> Process::spawn(StringView path, ReadonlySpan<StringView> arguments, DeprecatedString working_directory)
 {
     Vector<DeprecatedString> backing_strings;
     backing_strings.ensure_capacity(arguments.size());
@@ -92,7 +92,7 @@ ErrorOr<pid_t> Process::spawn(StringView path, Span<StringView const> arguments,
     return argv.spawn();
 }
 
-ErrorOr<pid_t> Process::spawn(StringView path, Span<char const* const> arguments, DeprecatedString working_directory)
+ErrorOr<pid_t> Process::spawn(StringView path, ReadonlySpan<char const*> arguments, DeprecatedString working_directory)
 {
     ArgvList argv { path, arguments.size() };
     for (auto arg : arguments)

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -15,9 +15,9 @@ namespace Core {
 
 class Process {
 public:
-    static ErrorOr<pid_t> spawn(StringView path, Span<DeprecatedString const> arguments, DeprecatedString working_directory = {});
-    static ErrorOr<pid_t> spawn(StringView path, Span<StringView const> arguments, DeprecatedString working_directory = {});
-    static ErrorOr<pid_t> spawn(StringView path, Span<char const* const> arguments = {}, DeprecatedString working_directory = {});
+    static ErrorOr<pid_t> spawn(StringView path, ReadonlySpan<DeprecatedString> arguments, DeprecatedString working_directory = {});
+    static ErrorOr<pid_t> spawn(StringView path, ReadonlySpan<StringView> arguments, DeprecatedString working_directory = {});
+    static ErrorOr<pid_t> spawn(StringView path, ReadonlySpan<char const*> arguments = {}, DeprecatedString working_directory = {});
 
     static ErrorOr<String> get_name();
     enum class SetThreadName {

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1113,7 +1113,7 @@ ErrorOr<u64> create_jail(StringView jail_name)
 }
 #endif
 
-ErrorOr<void> exec(StringView filename, Span<StringView const> arguments, SearchInPath search_in_path, Optional<Span<StringView const>> environment)
+ErrorOr<void> exec(StringView filename, ReadonlySpan<StringView> arguments, SearchInPath search_in_path, Optional<ReadonlySpan<StringView>> environment)
 {
 #ifdef AK_OS_SERENITY
     Syscall::SC_execve_params params;
@@ -1399,7 +1399,7 @@ ErrorOr<Vector<gid_t>> getgroups()
     return groups;
 }
 
-ErrorOr<void> setgroups(Span<gid_t const> gids)
+ErrorOr<void> setgroups(ReadonlySpan<gid_t> gids)
 {
     if (::setgroups(gids.size(), gids.data()) < 0)
         return Error::from_syscall("setgroups"sv, -errno);

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -178,7 +178,7 @@ enum class SearchInPath {
 ErrorOr<void> exec_command(Vector<StringView>& command, bool preserve_env);
 #endif
 
-ErrorOr<void> exec(StringView filename, Span<StringView const> arguments, SearchInPath, Optional<Span<StringView const>> environment = {});
+ErrorOr<void> exec(StringView filename, ReadonlySpan<StringView> arguments, SearchInPath, Optional<ReadonlySpan<StringView>> environment = {});
 
 #ifdef AK_OS_SERENITY
 ErrorOr<void> join_jail(u64 jail_index);
@@ -203,7 +203,7 @@ ErrorOr<void> getsockname(int sockfd, struct sockaddr*, socklen_t*);
 ErrorOr<void> getpeername(int sockfd, struct sockaddr*, socklen_t*);
 ErrorOr<void> socketpair(int domain, int type, int protocol, int sv[2]);
 ErrorOr<Vector<gid_t>> getgroups();
-ErrorOr<void> setgroups(Span<gid_t const>);
+ErrorOr<void> setgroups(ReadonlySpan<gid_t>);
 ErrorOr<void> mknod(StringView pathname, mode_t mode, dev_t dev);
 ErrorOr<void> mkfifo(StringView pathname, mode_t mode);
 ErrorOr<void> setenv(StringView, StringView, bool);
@@ -222,7 +222,7 @@ public:
     AddressInfoVector(AddressInfoVector&&) = default;
     ~AddressInfoVector() = default;
 
-    Span<struct addrinfo const> addresses() const { return m_addresses; }
+    ReadonlySpan<struct addrinfo> addresses() const { return m_addresses; }
 
 private:
     friend ErrorOr<AddressInfoVector> getaddrinfo(char const* nodename, char const* servname, struct addrinfo const& hints);

--- a/Userland/Libraries/LibDSP/Clip.h
+++ b/Userland/Libraries/LibDSP/Clip.h
@@ -54,7 +54,7 @@ public:
     // May do nothing; that's fine.
     void remove_note(RollNote note);
 
-    Span<RollNote const> notes() const { return m_notes.span(); }
+    ReadonlySpan<RollNote> notes() const { return m_notes.span(); }
 
     RollNote operator[](size_t index) const { return m_notes[index]; }
     RollNote operator[](size_t index) { return m_notes[index]; }

--- a/Userland/Libraries/LibDSP/MDCT.h
+++ b/Userland/Libraries/LibDSP/MDCT.h
@@ -24,7 +24,7 @@ public:
         }
     }
 
-    void transform(Span<float const> data, Span<float> output)
+    void transform(ReadonlySpan<float> data, Span<float> output)
     {
         assert(N == 2 * data.size());
         assert(N == output.size());

--- a/Userland/Libraries/LibDSP/Track.h
+++ b/Userland/Libraries/LibDSP/Track.h
@@ -78,7 +78,7 @@ public:
     }
 
     bool check_processor_chain_valid() const override;
-    Span<NonnullRefPtr<NoteClip> const> notes() const { return m_clips.span(); }
+    ReadonlySpan<NonnullRefPtr<NoteClip>> notes() const { return m_clips.span(); }
 
     void set_note(RollNote note);
     void remove_note(RollNote note);

--- a/Userland/Libraries/LibDesktop/AppFile.cpp
+++ b/Userland/Libraries/LibDesktop/AppFile.cpp
@@ -155,7 +155,7 @@ bool AppFile::spawn() const
     if (!is_valid())
         return false;
 
-    auto pid = Core::Process::spawn(executable(), Span<DeprecatedString const> {}, working_directory());
+    auto pid = Core::Process::spawn(executable(), ReadonlySpan<StringView> {}, working_directory());
     if (pid.is_error())
         return false;
 

--- a/Userland/Libraries/LibGUI/Process.cpp
+++ b/Userland/Libraries/LibGUI/Process.cpp
@@ -9,7 +9,7 @@
 #include <LibGUI/Process.h>
 
 template<typename StringType>
-void spawn_or_show_error(GUI::Window* parent_window, StringView path, Span<StringType const> arguments)
+void spawn_or_show_error(GUI::Window* parent_window, StringView path, ReadonlySpan<StringType> arguments)
 {
     auto spawn_result = Core::Process::spawn(path, arguments);
     if (spawn_result.is_error())
@@ -18,17 +18,17 @@ void spawn_or_show_error(GUI::Window* parent_window, StringView path, Span<Strin
 
 namespace GUI {
 
-void Process::spawn_or_show_error(Window* parent_window, StringView path, Span<DeprecatedString const> arguments)
+void Process::spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<DeprecatedString> arguments)
 {
     ::spawn_or_show_error<DeprecatedString>(parent_window, path, arguments);
 }
 
-void Process::spawn_or_show_error(Window* parent_window, StringView path, Span<StringView const> arguments)
+void Process::spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<StringView> arguments)
 {
     ::spawn_or_show_error<StringView>(parent_window, path, arguments);
 }
 
-void Process::spawn_or_show_error(Window* parent_window, StringView path, Span<char const* const> arguments)
+void Process::spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<char const*> arguments)
 {
     ::spawn_or_show_error<char const*>(parent_window, path, arguments);
 }

--- a/Userland/Libraries/LibGUI/Process.h
+++ b/Userland/Libraries/LibGUI/Process.h
@@ -12,9 +12,9 @@
 namespace GUI {
 
 struct Process {
-    static void spawn_or_show_error(Window* parent_window, StringView path, Span<DeprecatedString const> arguments);
-    static void spawn_or_show_error(Window* parent_window, StringView path, Span<StringView const> arguments);
-    static void spawn_or_show_error(Window* parent_window, StringView path, Span<char const* const> arguments = {});
+    static void spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<DeprecatedString> arguments);
+    static void spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<StringView> arguments);
+    static void spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<char const*> arguments = {});
 };
 
 }

--- a/Userland/Libraries/LibGfx/Font/Emoji.cpp
+++ b/Userland/Libraries/LibGfx/Font/Emoji.cpp
@@ -25,7 +25,7 @@ Bitmap const* Emoji::emoji_for_code_point(u32 code_point)
     return emoji_for_code_points(Array { code_point });
 }
 
-Bitmap const* Emoji::emoji_for_code_points(Span<u32 const> const& code_points)
+Bitmap const* Emoji::emoji_for_code_points(ReadonlySpan<u32> const& code_points)
 {
     // FIXME: This function is definitely not fast.
     auto basename = DeprecatedString::join('_', code_points, "U+{:X}"sv);

--- a/Userland/Libraries/LibGfx/Font/Emoji.h
+++ b/Userland/Libraries/LibGfx/Font/Emoji.h
@@ -17,7 +17,7 @@ class Bitmap;
 class Emoji {
 public:
     static Gfx::Bitmap const* emoji_for_code_point(u32 code_point);
-    static Gfx::Bitmap const* emoji_for_code_points(Span<u32 const> const&);
+    static Gfx::Bitmap const* emoji_for_code_points(ReadonlySpan<u32> const&);
     static Gfx::Bitmap const* emoji_for_code_point_iterator(Utf8CodePointIterator&);
 };
 

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -274,7 +274,7 @@ Optional<i16> Kern::read_glyph_kerning_format0(ReadonlyBytes slice, u16 left_gly
         return {};
 
     // FIXME: implement a possibly slightly more efficient binary search using the parameters above
-    Span<Format0Pair const> pairs { bit_cast<Format0Pair const*>(slice.slice(sizeof(Format0)).data()), number_of_pairs };
+    ReadonlySpan<Format0Pair> pairs { bit_cast<Format0Pair const*>(slice.slice(sizeof(Format0)).data()), number_of_pairs };
 
     // The left and right halves of the kerning pair make an unsigned 32-bit number, which is then used to order the kerning pairs numerically.
     auto needle = (static_cast<u32>(left_glyph_id) << 16u) | static_cast<u32>(right_glyph_id);

--- a/Userland/Libraries/LibGfx/GradientPainting.cpp
+++ b/Userland/Libraries/LibGfx/GradientPainting.cpp
@@ -52,7 +52,7 @@ enum class UsePremultipliedAlpha {
 
 class GradientLine {
 public:
-    GradientLine(int gradient_length, Span<ColorStop const> color_stops, Optional<float> repeat_length, UsePremultipliedAlpha use_premultiplied_alpha = UsePremultipliedAlpha::Yes)
+    GradientLine(int gradient_length, ReadonlySpan<ColorStop> color_stops, Optional<float> repeat_length, UsePremultipliedAlpha use_premultiplied_alpha = UsePremultipliedAlpha::Yes)
         : m_repeating(repeat_length.has_value())
         , m_start_offset(round_to<int>((m_repeating ? color_stops.first().position : 0.0f) * gradient_length))
         , m_color_stops(color_stops)
@@ -133,7 +133,7 @@ private:
     bool m_repeating { false };
     int m_start_offset { 0 };
     float m_sample_scale { 1 };
-    Span<ColorStop const> m_color_stops {};
+    ReadonlySpan<ColorStop> m_color_stops {};
     UsePremultipliedAlpha m_use_premultiplied_alpha { UsePremultipliedAlpha::Yes };
 
     Vector<Color, 1024> m_gradient_line_colors;
@@ -165,7 +165,7 @@ private:
     TransformFunction m_transform_function;
 };
 
-static auto create_linear_gradient(IntRect const& physical_rect, Span<ColorStop const> color_stops, float angle, Optional<float> repeat_length)
+static auto create_linear_gradient(IntRect const& physical_rect, ReadonlySpan<ColorStop> color_stops, float angle, Optional<float> repeat_length)
 {
     float normalized_angle = normalized_gradient_angle_radians(angle);
     float sin_angle, cos_angle;
@@ -188,7 +188,7 @@ static auto create_linear_gradient(IntRect const& physical_rect, Span<ColorStop 
     };
 }
 
-static auto create_conic_gradient(Span<ColorStop const> color_stops, FloatPoint center_point, float start_angle, Optional<float> repeat_length, UsePremultipliedAlpha use_premultiplied_alpha = UsePremultipliedAlpha::Yes)
+static auto create_conic_gradient(ReadonlySpan<ColorStop> color_stops, FloatPoint center_point, float start_angle, Optional<float> repeat_length, UsePremultipliedAlpha use_premultiplied_alpha = UsePremultipliedAlpha::Yes)
 {
     // FIXME: Do we need/want sub-degree accuracy for the gradient line?
     GradientLine gradient_line(360, color_stops, repeat_length, use_premultiplied_alpha);
@@ -213,7 +213,7 @@ static auto create_conic_gradient(Span<ColorStop const> color_stops, FloatPoint 
     };
 }
 
-static auto create_radial_gradient(IntRect const& physical_rect, Span<ColorStop const> color_stops, IntPoint center, IntSize size, Optional<float> repeat_length)
+static auto create_radial_gradient(IntRect const& physical_rect, ReadonlySpan<ColorStop> color_stops, IntPoint center, IntSize size, Optional<float> repeat_length)
 {
     // A conservative guesstimate on how many colors we need to generate:
     auto max_dimension = max(physical_rect.width(), physical_rect.height());
@@ -232,7 +232,7 @@ static auto create_radial_gradient(IntRect const& physical_rect, Span<ColorStop 
     };
 }
 
-void Painter::fill_rect_with_linear_gradient(IntRect const& rect, Span<ColorStop const> color_stops, float angle, Optional<float> repeat_length)
+void Painter::fill_rect_with_linear_gradient(IntRect const& rect, ReadonlySpan<ColorStop> color_stops, float angle, Optional<float> repeat_length)
 {
     auto a_rect = to_physical(rect);
     if (a_rect.intersected(clip_rect() * scale()).is_empty())
@@ -246,7 +246,7 @@ static FloatPoint pixel_center(IntPoint point)
     return point.to_type<float>().translated(0.5f, 0.5f);
 }
 
-void Painter::fill_rect_with_conic_gradient(IntRect const& rect, Span<ColorStop const> color_stops, IntPoint center, float start_angle, Optional<float> repeat_length)
+void Painter::fill_rect_with_conic_gradient(IntRect const& rect, ReadonlySpan<ColorStop> color_stops, IntPoint center, float start_angle, Optional<float> repeat_length)
 {
     auto a_rect = to_physical(rect);
     if (a_rect.intersected(clip_rect() * scale()).is_empty())
@@ -257,7 +257,7 @@ void Painter::fill_rect_with_conic_gradient(IntRect const& rect, Span<ColorStop 
     conic_gradient.paint(*this, a_rect);
 }
 
-void Painter::fill_rect_with_radial_gradient(IntRect const& rect, Span<ColorStop const> color_stops, IntPoint center, IntSize size, Optional<float> repeat_length)
+void Painter::fill_rect_with_radial_gradient(IntRect const& rect, ReadonlySpan<ColorStop> color_stops, IntPoint center, IntSize size, Optional<float> repeat_length)
 {
     auto a_rect = to_physical(rect);
     if (a_rect.intersected(clip_rect() * scale()).is_empty())

--- a/Userland/Libraries/LibGfx/PaintStyle.h
+++ b/Userland/Libraries/LibGfx/PaintStyle.h
@@ -78,7 +78,7 @@ public:
         m_repeat_length = repeat_length;
     }
 
-    Span<ColorStop const> color_stops() const { return m_color_stops; }
+    ReadonlySpan<ColorStop> color_stops() const { return m_color_stops; }
     Optional<float> repeat_length() const { return m_repeat_length; }
 
 private:

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -704,7 +704,7 @@ void Painter::draw_bitmap(IntPoint p, GlyphBitmap const& bitmap, Color color)
     }
 }
 
-void Painter::draw_triangle(IntPoint offset, Span<IntPoint const> control_points, Color color)
+void Painter::draw_triangle(IntPoint offset, ReadonlySpan<IntPoint> control_points, Color color)
 {
     VERIFY(control_points.size() == 3);
     draw_triangle(control_points[0] + offset, control_points[1] + offset, control_points[2] + offset, color);

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -53,9 +53,9 @@ public:
     void fill_rect_with_checkerboard(IntRect const&, IntSize, Color color_dark, Color color_light);
     void fill_rect_with_gradient(Orientation, IntRect const&, Color gradient_start, Color gradient_end);
     void fill_rect_with_gradient(IntRect const&, Color gradient_start, Color gradient_end);
-    void fill_rect_with_linear_gradient(IntRect const&, Span<ColorStop const>, float angle, Optional<float> repeat_length = {});
-    void fill_rect_with_conic_gradient(IntRect const&, Span<ColorStop const>, IntPoint center, float start_angle, Optional<float> repeat_length = {});
-    void fill_rect_with_radial_gradient(IntRect const&, Span<ColorStop const>, IntPoint center, IntSize size, Optional<float> repeat_length = {});
+    void fill_rect_with_linear_gradient(IntRect const&, ReadonlySpan<ColorStop>, float angle, Optional<float> repeat_length = {});
+    void fill_rect_with_conic_gradient(IntRect const&, ReadonlySpan<ColorStop>, IntPoint center, float start_angle, Optional<float> repeat_length = {});
+    void fill_rect_with_radial_gradient(IntRect const&, ReadonlySpan<ColorStop>, IntPoint center, IntSize size, Optional<float> repeat_length = {});
     void fill_rect_with_rounded_corners(IntRect const&, Color, int radius);
     void fill_rect_with_rounded_corners(IntRect const&, Color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius);
     void fill_ellipse(IntRect const&, Color);
@@ -68,7 +68,7 @@ public:
     void draw_scaled_bitmap(IntRect const& dst_rect, Gfx::Bitmap const&, FloatRect const& src_rect, float opacity = 1.0f, ScalingMode = ScalingMode::NearestNeighbor);
     void draw_scaled_bitmap_with_transform(IntRect const& dst_rect, Gfx::Bitmap const&, FloatRect const& src_rect, Gfx::AffineTransform const&, float opacity = 1.0f, ScalingMode = ScalingMode::NearestNeighbor);
     void draw_triangle(IntPoint, IntPoint, IntPoint, Color);
-    void draw_triangle(IntPoint offset, Span<IntPoint const>, Color);
+    void draw_triangle(IntPoint offset, ReadonlySpan<IntPoint>, Color);
     void draw_ellipse_intersecting(IntRect const&, Color, int thickness = 1);
     void set_pixel(IntPoint, Color, bool blend = false);
     void set_pixel(int x, int y, Color color, bool blend = false) { set_pixel({ x, y }, color, blend); }

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -376,7 +376,7 @@ ThrowCompletionOr<CallExpression::ThisAndCallee> CallExpression::compute_this_an
 }
 
 // 13.3.8.1 Runtime Semantics: ArgumentListEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-argumentlistevaluation
-static ThrowCompletionOr<void> argument_list_evaluation(Interpreter& interpreter, Span<CallExpression::Argument const> const arguments, MarkedVector<Value>& list)
+static ThrowCompletionOr<void> argument_list_evaluation(Interpreter& interpreter, ReadonlySpan<CallExpression::Argument> const arguments, MarkedVector<Value>& list)
 {
     auto& vm = interpreter.vm();
     list.ensure_capacity(arguments.size());
@@ -4967,12 +4967,12 @@ DeprecatedString SourceRange::filename() const
     return code->filename().to_deprecated_string();
 }
 
-NonnullRefPtr<CallExpression> CallExpression::create(SourceRange source_range, NonnullRefPtr<Expression> callee, Span<Argument const> arguments)
+NonnullRefPtr<CallExpression> CallExpression::create(SourceRange source_range, NonnullRefPtr<Expression> callee, ReadonlySpan<Argument> arguments)
 {
     return ASTNodeWithTailArray::create<CallExpression>(arguments.size(), move(source_range), move(callee), arguments);
 }
 
-NonnullRefPtr<NewExpression> NewExpression::create(SourceRange source_range, NonnullRefPtr<Expression> callee, Span<Argument const> arguments)
+NonnullRefPtr<NewExpression> NewExpression::create(SourceRange source_range, NonnullRefPtr<Expression> callee, ReadonlySpan<Argument> arguments)
 {
     return ASTNodeWithTailArray::create<NewExpression>(arguments.size(), move(source_range), move(callee), arguments);
 }

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -111,7 +111,7 @@ public:
             value.~T();
     }
 
-    Span<T const> tail_span() const { return { tail_data(), tail_size() }; }
+    ReadonlySpan<T> tail_span() const { return { tail_data(), tail_size() }; }
 
     T const* tail_data() const { return reinterpret_cast<T const*>(reinterpret_cast<uintptr_t>(this) + sizeof(Derived)); }
     size_t tail_size() const { return m_tail_size; }
@@ -126,7 +126,7 @@ protected:
         return adopt_ref(*::new (memory) ActualDerived(move(source_range), forward<Args>(args)...));
     }
 
-    ASTNodeWithTailArray(SourceRange source_range, Span<T const> values)
+    ASTNodeWithTailArray(SourceRange source_range, ReadonlySpan<T> values)
         : Base(move(source_range))
         , m_tail_size(values.size())
     {
@@ -1493,7 +1493,7 @@ class CallExpression : public ASTNodeWithTailArray<CallExpression, Expression, C
 public:
     using Argument = CallExpressionArgument;
 
-    static NonnullRefPtr<CallExpression> create(SourceRange, NonnullRefPtr<Expression> callee, Span<Argument const> arguments);
+    static NonnullRefPtr<CallExpression> create(SourceRange, NonnullRefPtr<Expression> callee, ReadonlySpan<Argument> arguments);
 
     virtual Completion execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
@@ -1501,10 +1501,10 @@ public:
 
     Expression const& callee() const { return m_callee; }
 
-    Span<Argument const> arguments() const { return tail_span(); }
+    ReadonlySpan<Argument> arguments() const { return tail_span(); }
 
 protected:
-    CallExpression(SourceRange source_range, NonnullRefPtr<Expression> callee, Span<Argument const> arguments)
+    CallExpression(SourceRange source_range, NonnullRefPtr<Expression> callee, ReadonlySpan<Argument> arguments)
         : ASTNodeWithTailArray(move(source_range), arguments)
         , m_callee(move(callee))
     {
@@ -1530,14 +1530,14 @@ class NewExpression final : public CallExpression {
     friend class ASTNodeWithTailArray;
 
 public:
-    static NonnullRefPtr<NewExpression> create(SourceRange, NonnullRefPtr<Expression> callee, Span<Argument const> arguments);
+    static NonnullRefPtr<NewExpression> create(SourceRange, NonnullRefPtr<Expression> callee, ReadonlySpan<Argument> arguments);
 
     virtual Completion execute(Interpreter&) const override;
 
     virtual bool is_new_expression() const override { return true; }
 
 private:
-    NewExpression(SourceRange source_range, NonnullRefPtr<Expression> callee, Span<Argument const> arguments)
+    NewExpression(SourceRange source_range, NonnullRefPtr<Expression> callee, ReadonlySpan<Argument> arguments)
         : CallExpression(move(source_range), move(callee), arguments)
     {
     }

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -534,7 +534,7 @@ Bytecode::CodeGenerationErrorOr<void> Identifier::generate_bytecode(Bytecode::Ge
     return {};
 }
 
-static Bytecode::CodeGenerationErrorOr<void> arguments_to_array_for_call(Bytecode::Generator& generator, Span<CallExpression::Argument const> arguments)
+static Bytecode::CodeGenerationErrorOr<void> arguments_to_array_for_call(Bytecode::Generator& generator, ReadonlySpan<CallExpression::Argument> arguments)
 {
 
     if (arguments.is_empty()) {

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -1111,7 +1111,7 @@ DeprecatedString CopyObjectExcludingProperties::to_deprecated_string_impl(Byteco
     builder.appendff("CopyObjectExcludingProperties from:{}", m_from_object);
     if (m_excluded_names_count != 0) {
         builder.append(" excluding:["sv);
-        builder.join(", "sv, Span<Register const>(m_excluded_names, m_excluded_names_count));
+        builder.join(", "sv, ReadonlySpan<Register>(m_excluded_names, m_excluded_names_count));
         builder.append(']');
     }
     return builder.to_deprecated_string();

--- a/Userland/Libraries/LibJS/Runtime/Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Array.h
@@ -28,7 +28,7 @@ public:
 
     // Non-standard but equivalent to CreateArrayFromList.
     template<typename T>
-    static NonnullGCPtr<Array> create_from(Realm& realm, Span<T const> elements, Function<Value(T const&)> map_fn)
+    static NonnullGCPtr<Array> create_from(Realm& realm, ReadonlySpan<T> elements, Function<Value(T const&)> map_fn)
     {
         auto values = MarkedVector<Value> { realm.heap() };
         values.ensure_capacity(elements.size());
@@ -40,7 +40,7 @@ public:
 
     // Non-standard but equivalent to CreateArrayFromList.
     template<typename T, FallibleFunction<T const&> Callback>
-    static ThrowCompletionOr<NonnullGCPtr<Array>> try_create_from(VM& vm, Realm& realm, Span<T const> elements, Callback map_fn)
+    static ThrowCompletionOr<NonnullGCPtr<Array>> try_create_from(VM& vm, Realm& realm, ReadonlySpan<T> elements, Callback map_fn)
     {
         auto values = MarkedVector<Value> { realm.heap() };
         TRY_OR_THROW_OOM(vm, values.try_ensure_capacity(elements.size()));

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -32,7 +32,7 @@ DeclarativeEnvironment::DeclarativeEnvironment(Environment* parent_environment)
 {
 }
 
-DeclarativeEnvironment::DeclarativeEnvironment(Environment* parent_environment, Span<Binding const> bindings)
+DeclarativeEnvironment::DeclarativeEnvironment(Environment* parent_environment, ReadonlySpan<Binding> bindings)
     : Environment(parent_environment)
     , m_bindings(bindings)
 {

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -70,7 +70,7 @@ private:
 protected:
     DeclarativeEnvironment();
     explicit DeclarativeEnvironment(Environment* parent_environment);
-    DeclarativeEnvironment(Environment* parent_environment, Span<Binding const> bindings);
+    DeclarativeEnvironment(Environment* parent_environment, ReadonlySpan<Binding> bindings);
 
     virtual void visit_edges(Visitor&) override;
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -378,7 +378,7 @@ static auto& find_key_in_value(T& value, StringView key)
 }
 
 // 9.2.7 ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData ), https://tc39.es/ecma402/#sec-resolvelocale
-ThrowCompletionOr<LocaleResult> resolve_locale(VM& vm, Vector<String> const& requested_locales, LocaleOptions const& options, Span<StringView const> relevant_extension_keys)
+ThrowCompletionOr<LocaleResult> resolve_locale(VM& vm, Vector<String> const& requested_locales, LocaleOptions const& options, ReadonlySpan<StringView> relevant_extension_keys)
 {
     // 1. Let matcher be options.[[localeMatcher]].
     auto const& matcher = options.locale_matcher;
@@ -609,7 +609,7 @@ ThrowCompletionOr<Object*> coerce_options_to_object(VM& vm, Value options)
 // NOTE: 9.2.13 GetOption has been removed and is being pulled in from ECMA-262 in the Temporal proposal.
 
 // 1.2.14 GetBooleanOrStringNumberFormatOption ( options, property, stringValues, fallback ), https://tc39.es/proposal-intl-numberformat-v3/out/negotiation/proposed.html#sec-getbooleanorstringnumberformatoption
-ThrowCompletionOr<StringOrBoolean> get_boolean_or_string_number_format_option(VM& vm, Object const& options, PropertyKey const& property, Span<StringView const> string_values, StringOrBoolean fallback)
+ThrowCompletionOr<StringOrBoolean> get_boolean_or_string_number_format_option(VM& vm, Object const& options, PropertyKey const& property, ReadonlySpan<StringView> string_values, StringOrBoolean fallback)
 {
     // 1. Let value be ? Get(options, property).
     auto value = TRY(options.get(property));

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -86,10 +86,10 @@ bool is_well_formed_unit_identifier(StringView unit_identifier);
 ThrowCompletionOr<Vector<String>> canonicalize_locale_list(VM&, Value locales);
 Optional<StringView> best_available_locale(StringView locale);
 ThrowCompletionOr<String> insert_unicode_extension_and_canonicalize(VM&, ::Locale::LocaleID locale_id, ::Locale::LocaleExtension extension);
-ThrowCompletionOr<LocaleResult> resolve_locale(VM&, Vector<String> const& requested_locales, LocaleOptions const& options, Span<StringView const> relevant_extension_keys);
+ThrowCompletionOr<LocaleResult> resolve_locale(VM&, Vector<String> const& requested_locales, LocaleOptions const& options, ReadonlySpan<StringView> relevant_extension_keys);
 ThrowCompletionOr<Array*> supported_locales(VM&, Vector<String> const& requested_locales, Value options);
 ThrowCompletionOr<Object*> coerce_options_to_object(VM&, Value options);
-ThrowCompletionOr<StringOrBoolean> get_boolean_or_string_number_format_option(VM& vm, Object const& options, PropertyKey const& property, Span<StringView const> string_values, StringOrBoolean fallback);
+ThrowCompletionOr<StringOrBoolean> get_boolean_or_string_number_format_option(VM& vm, Object const& options, PropertyKey const& property, ReadonlySpan<StringView> string_values, StringOrBoolean fallback);
 ThrowCompletionOr<Optional<int>> default_number_option(VM&, Value value, int minimum, int maximum, Optional<int> fallback);
 ThrowCompletionOr<Optional<int>> get_number_option(VM&, Object const& options, PropertyKey const& property, int minimum, int maximum, Optional<int> fallback);
 ThrowCompletionOr<Vector<PatternPartition>> partition_pattern(VM&, StringView pattern);
@@ -97,7 +97,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_pattern(VM&, StringView pa
 template<size_t Size>
 ThrowCompletionOr<StringOrBoolean> get_boolean_or_string_number_format_option(VM& vm, Object const& options, PropertyKey const& property, StringView const (&string_values)[Size], StringOrBoolean fallback)
 {
-    return get_boolean_or_string_number_format_option(vm, options, property, Span<StringView const> { string_values }, move(fallback));
+    return get_boolean_or_string_number_format_option(vm, options, property, ReadonlySpan<StringView> { string_values }, move(fallback));
 }
 
 // NOTE: ECMA-402's GetOption is being removed in favor of a shared ECMA-262 GetOption in the Temporal proposal.

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -510,7 +510,7 @@ static Optional<StyleAndValue> find_calendar_field(StringView name, ::Locale::Ca
     return {};
 }
 
-static ThrowCompletionOr<Optional<StringView>> resolve_day_period(VM& vm, StringView locale, StringView calendar, ::Locale::CalendarPatternStyle style, Span<PatternPartition const> pattern_parts, LocalTime local_time)
+static ThrowCompletionOr<Optional<StringView>> resolve_day_period(VM& vm, StringView locale, StringView calendar, ::Locale::CalendarPatternStyle style, ReadonlySpan<PatternPartition> pattern_parts, LocalTime local_time)
 {
     // Use the "noon" day period if the locale has it, but only if the time is either exactly 12:00.00 or would be displayed as such.
     if (local_time.hour == 12) {

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -77,7 +77,7 @@ public:
     String const& pattern() const { return Patterns::pattern; };
     void set_pattern(String pattern) { Patterns::pattern = move(pattern); }
 
-    Span<::Locale::CalendarRangePattern const> range_patterns() const { return m_range_patterns.span(); };
+    ReadonlySpan<::Locale::CalendarRangePattern> range_patterns() const { return m_range_patterns.span(); };
     void set_range_patterns(Vector<::Locale::CalendarRangePattern> range_patterns) { m_range_patterns = move(range_patterns); }
 
     bool has_era() const { return Patterns::era.has_value(); }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -268,7 +268,7 @@ bool is_valid_duration_record(Temporal::DurationRecord const& record)
 }
 
 // 1.1.6 GetDurationUnitOptions ( unit, options, baseStyle, stylesList, digitalBase, prevStyle ), https://tc39.es/proposal-intl-duration-format/#sec-getdurationunitoptions
-ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM& vm, String const& unit, Object const& options, StringView base_style, Span<StringView const> styles_list, StringView digital_base, StringView previous_style)
+ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM& vm, String const& unit, Object const& options, StringView base_style, ReadonlySpan<StringView> styles_list, StringView digital_base, StringView previous_style)
 {
     // 1. Let style be ? GetOption(options, unit, string, stylesList, undefined).
     auto style_value = TRY(get_option(vm, options, unit.to_deprecated_string(), OptionType::String, styles_list, Empty {}));

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -195,7 +195,7 @@ struct DurationInstanceComponent {
     void (DurationFormat::*set_display_slot)(StringView);
     StringView unit;
     StringView number_format_unit;
-    Span<StringView const> values;
+    ReadonlySpan<StringView> values;
     StringView digital_default;
 };
 
@@ -224,7 +224,7 @@ struct DurationUnitOptions {
 ThrowCompletionOr<Temporal::DurationRecord> to_duration_record(VM&, Value input);
 i8 duration_record_sign(Temporal::DurationRecord const&);
 bool is_valid_duration_record(Temporal::DurationRecord const&);
-ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM&, String const& unit, Object const& options, StringView base_style, Span<StringView const> styles_list, StringView digital_base, StringView previous_style);
+ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM&, String const& unit, Object const& options, StringView base_style, ReadonlySpan<StringView> styles_list, StringView digital_base, StringView previous_style);
 ThrowCompletionOr<Vector<PatternPartition>> partition_duration_format_pattern(VM&, DurationFormat const&, Temporal::DurationRecord const& duration);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
@@ -115,7 +115,7 @@ JS_DEFINE_NATIVE_FUNCTION(Intl::supported_values_of)
     // 1. Let key be ? ToString(key).
     auto key = TRY(vm.argument(0).to_string(vm));
 
-    Span<StringView const> list;
+    ReadonlySpan<StringView> list;
 
     // 2. If key is "calendar", then
     if (key == "calendar"sv) {

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -27,7 +27,7 @@ struct LocaleAndKeys {
 };
 
 // Note: This is not an AO in the spec. This just serves to abstract very similar steps in ApplyOptionsToTag and the Intl.Locale constructor.
-static ThrowCompletionOr<Optional<String>> get_string_option(VM& vm, Object const& options, PropertyKey const& property, Function<bool(StringView)> validator, Span<StringView const> values = {})
+static ThrowCompletionOr<Optional<String>> get_string_option(VM& vm, Object const& options, PropertyKey const& property, Function<bool(StringView)> validator, ReadonlySpan<StringView> values = {})
 {
     auto option = TRY(get_option(vm, options, property, OptionType::String, values, Empty {}));
     if (option.is_undefined())
@@ -105,7 +105,7 @@ static ThrowCompletionOr<String> apply_options_to_tag(VM& vm, StringView tag, Ob
 }
 
 // 14.1.3 ApplyUnicodeExtensionToTag ( tag, options, relevantExtensionKeys ), https://tc39.es/ecma402/#sec-apply-unicode-extension-to-tag
-static ThrowCompletionOr<LocaleAndKeys> apply_unicode_extension_to_tag(VM& vm, StringView tag, LocaleAndKeys options, Span<StringView const> relevant_extension_keys)
+static ThrowCompletionOr<LocaleAndKeys> apply_unicode_extension_to_tag(VM& vm, StringView tag, LocaleAndKeys options, ReadonlySpan<StringView> relevant_extension_keys)
 {
     // 1. Assert: Type(tag) is String.
     // 2. Assert: tag matches the unicode_locale_id production.

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -97,7 +97,7 @@ ThrowCompletionOr<Object*> get_options_object(VM& vm, Value options)
 }
 
 // 13.3 GetOption ( options, property, type, values, fallback ), https://tc39.es/proposal-temporal/#sec-getoption
-ThrowCompletionOr<Value> get_option(VM& vm, Object const& options, PropertyKey const& property, OptionType type, Span<StringView const> values, OptionDefault const& default_)
+ThrowCompletionOr<Value> get_option(VM& vm, Object const& options, PropertyKey const& property, OptionType type, ReadonlySpan<StringView> values, OptionDefault const& default_)
 {
     VERIFY(property.is_string());
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
@@ -134,7 +134,7 @@ using TemporalUnitDefault = Variant<TemporalUnitRequired, Optional<StringView>>;
 
 ThrowCompletionOr<MarkedVector<Value>> iterable_to_list_of_type(VM&, Value items, Vector<OptionType> const& element_types);
 ThrowCompletionOr<Object*> get_options_object(VM&, Value options);
-ThrowCompletionOr<Value> get_option(VM&, Object const& options, PropertyKey const& property, OptionType type, Span<StringView const> values, OptionDefault const&);
+ThrowCompletionOr<Value> get_option(VM&, Object const& options, PropertyKey const& property, OptionType type, ReadonlySpan<StringView> values, OptionDefault const&);
 ThrowCompletionOr<String> to_temporal_overflow(VM&, Object const* options);
 ThrowCompletionOr<String> to_temporal_disambiguation(VM&, Object const* options);
 ThrowCompletionOr<String> to_temporal_rounding_mode(VM&, Object const& normalized_options, StringView fallback);
@@ -181,7 +181,7 @@ ThrowCompletionOr<DifferenceSettings> get_difference_settings(VM&, DifferenceOpe
 template<size_t Size>
 ThrowCompletionOr<Value> get_option(VM& vm, Object const& options, PropertyKey const& property, OptionType type, StringView const (&values)[Size], OptionDefault const& default_)
 {
-    return get_option(vm, options, property, type, Span<StringView const> { values }, default_);
+    return get_option(vm, options, property, type, ReadonlySpan<StringView> { values }, default_);
 }
 
 // 13.40 ToIntegerWithTruncation ( argument ), https://tc39.es/proposal-temporal/#sec-tointegerwithtruncation

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -50,7 +50,7 @@ bool is_builtin_calendar(StringView identifier)
 }
 
 // 12.1.2 AvailableCalendars ( ), https://tc39.es/proposal-temporal/#sec-temporal-availablecalendars
-Span<StringView const> available_calendars()
+ReadonlySpan<StringView> available_calendars()
 {
     // 1. Let calendars be the List of String values representing calendar types supported by the implementation.
     // NOTE: This can be removed in favor of using `Unicode::get_available_calendars()` once everything is updated to handle non-iso8601 calendars.

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
@@ -38,7 +38,7 @@ struct YearWeekRecord {
 };
 
 bool is_builtin_calendar(StringView identifier);
-Span<StringView const> available_calendars();
+ReadonlySpan<StringView> available_calendars();
 ThrowCompletionOr<Calendar*> create_temporal_calendar(VM&, String const& identifier, FunctionObject const* new_target = nullptr);
 ThrowCompletionOr<Calendar*> get_builtin_calendar(VM&, String const& identifier);
 Calendar* get_iso8601_calendar(VM&);

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -414,7 +414,7 @@ public:
         return { move(keys) };
     }
 
-    Span<UnderlyingBufferDataType const> data() const
+    ReadonlySpan<UnderlyingBufferDataType> data() const
     {
         return { reinterpret_cast<UnderlyingBufferDataType const*>(m_viewed_array_buffer->buffer().data() + m_byte_offset), m_array_length };
     }

--- a/Userland/Libraries/LibLocale/Locale.cpp
+++ b/Userland/Libraries/LibLocale/Locale.cpp
@@ -786,14 +786,14 @@ StringView style_to_string(Style style)
     }
 }
 
-Span<StringView const> __attribute__((weak)) get_available_keyword_values(StringView) { return {}; }
-Span<StringView const> __attribute__((weak)) get_available_calendars() { return {}; }
-Span<StringView const> __attribute__((weak)) get_available_collation_case_orderings() { return {}; }
-Span<StringView const> __attribute__((weak)) get_available_collation_numeric_orderings() { return {}; }
-Span<StringView const> __attribute__((weak)) get_available_collation_types() { return {}; }
-Span<StringView const> __attribute__((weak)) get_available_currencies() { return {}; }
-Span<StringView const> __attribute__((weak)) get_available_hour_cycles() { return {}; }
-Span<StringView const> __attribute__((weak)) get_available_number_systems() { return {}; }
+ReadonlySpan<StringView> __attribute__((weak)) get_available_keyword_values(StringView) { return {}; }
+ReadonlySpan<StringView> __attribute__((weak)) get_available_calendars() { return {}; }
+ReadonlySpan<StringView> __attribute__((weak)) get_available_collation_case_orderings() { return {}; }
+ReadonlySpan<StringView> __attribute__((weak)) get_available_collation_numeric_orderings() { return {}; }
+ReadonlySpan<StringView> __attribute__((weak)) get_available_collation_types() { return {}; }
+ReadonlySpan<StringView> __attribute__((weak)) get_available_currencies() { return {}; }
+ReadonlySpan<StringView> __attribute__((weak)) get_available_hour_cycles() { return {}; }
+ReadonlySpan<StringView> __attribute__((weak)) get_available_number_systems() { return {}; }
 Optional<Locale> __attribute__((weak)) locale_from_string(StringView) { return {}; }
 Optional<Language> __attribute__((weak)) language_from_string(StringView) { return {}; }
 Optional<Territory> __attribute__((weak)) territory_from_string(StringView) { return {}; }

--- a/Userland/Libraries/LibLocale/Locale.h
+++ b/Userland/Libraries/LibLocale/Locale.h
@@ -146,14 +146,14 @@ ErrorOr<Optional<String>> canonicalize_unicode_locale_id(LocaleID&);
 StringView default_locale();
 bool is_locale_available(StringView locale);
 
-Span<StringView const> get_available_keyword_values(StringView key);
-Span<StringView const> get_available_calendars();
-Span<StringView const> get_available_collation_case_orderings();
-Span<StringView const> get_available_collation_numeric_orderings();
-Span<StringView const> get_available_collation_types();
-Span<StringView const> get_available_currencies();
-Span<StringView const> get_available_hour_cycles();
-Span<StringView const> get_available_number_systems();
+ReadonlySpan<StringView> get_available_keyword_values(StringView key);
+ReadonlySpan<StringView> get_available_calendars();
+ReadonlySpan<StringView> get_available_collation_case_orderings();
+ReadonlySpan<StringView> get_available_collation_numeric_orderings();
+ReadonlySpan<StringView> get_available_collation_types();
+ReadonlySpan<StringView> get_available_currencies();
+ReadonlySpan<StringView> get_available_hour_cycles();
+ReadonlySpan<StringView> get_available_number_systems();
 
 Style style_from_string(StringView style);
 StringView style_to_string(Style style);

--- a/Userland/Libraries/LibLocale/NumberFormat.cpp
+++ b/Userland/Libraries/LibLocale/NumberFormat.cpp
@@ -22,7 +22,7 @@ ErrorOr<Optional<NumberFormat>> __attribute__((weak)) get_standard_number_system
 ErrorOr<Vector<NumberFormat>> __attribute__((weak)) get_compact_number_system_formats(StringView, StringView, CompactNumberFormatType) { return Vector<NumberFormat> {}; }
 Vector<NumberFormat> __attribute__((weak)) get_unit_formats(StringView, StringView, Style) { return {}; }
 
-Optional<Span<u32 const>> __attribute__((weak)) get_digits_for_number_system(StringView)
+Optional<ReadonlySpan<u32>> __attribute__((weak)) get_digits_for_number_system(StringView)
 {
     // Fall back to "latn" digits when Unicode data generation is disabled.
     constexpr Array<u32, 10> digits { { 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39 } };

--- a/Userland/Libraries/LibLocale/NumberFormat.h
+++ b/Userland/Libraries/LibLocale/NumberFormat.h
@@ -64,7 +64,7 @@ enum class NumericSymbol : u8 {
 ErrorOr<Optional<StringView>> get_number_system_symbol(StringView locale, StringView system, NumericSymbol symbol);
 ErrorOr<Optional<NumberGroupings>> get_number_system_groupings(StringView locale, StringView system);
 
-Optional<Span<u32 const>> get_digits_for_number_system(StringView system);
+Optional<ReadonlySpan<u32>> get_digits_for_number_system(StringView system);
 ErrorOr<String> replace_digits_for_number_system(StringView system, StringView number);
 
 ErrorOr<Optional<NumberFormat>> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type);

--- a/Userland/Libraries/LibLocale/PluralRules.cpp
+++ b/Userland/Libraries/LibLocale/PluralRules.cpp
@@ -34,7 +34,7 @@ PluralCategory __attribute__((weak)) determine_plural_category(StringView, Plura
     return PluralCategory::Other;
 }
 
-Span<PluralCategory const> __attribute__((weak)) available_plural_categories(StringView, PluralForm)
+ReadonlySpan<PluralCategory> __attribute__((weak)) available_plural_categories(StringView, PluralForm)
 {
     static constexpr Array<PluralCategory, 1> categories { { PluralCategory::Other } };
     return categories.span();

--- a/Userland/Libraries/LibLocale/PluralRules.h
+++ b/Userland/Libraries/LibLocale/PluralRules.h
@@ -118,7 +118,7 @@ constexpr StringView plural_category_to_string(PluralCategory category)
 }
 
 PluralCategory determine_plural_category(StringView locale, PluralForm form, PluralOperands operands);
-Span<PluralCategory const> available_plural_categories(StringView locale, PluralForm form);
+ReadonlySpan<PluralCategory> available_plural_categories(StringView locale, PluralForm form);
 PluralCategory determine_plural_range(StringView locale, PluralCategory start, PluralCategory end);
 
 }

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -365,7 +365,7 @@ PDFErrorOr<NonnullRefPtr<XRefTable>> DocumentParser::parse_xref_stream()
     auto stream = TRY(parse_stream(dict));
     auto table = adopt_ref(*new XRefTable());
 
-    auto field_to_long = [](Span<u8 const> field) -> long {
+    auto field_to_long = [](ReadonlyBytes field) -> long {
         long value = 0;
         const u8 max = (field.size() - 1) * 8;
         for (size_t i = 0; i < field.size(); ++i) {

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -301,7 +301,7 @@ private:
 struct ExecutionContext {
     NonnullRefPtr<Database> database;
     Statement const* statement { nullptr };
-    Span<Value const> placeholder_values {};
+    ReadonlySpan<Value> placeholder_values {};
     Tuple* current_row { nullptr };
 };
 
@@ -760,7 +760,7 @@ private:
 
 class Statement : public ASTNode {
 public:
-    ResultOr<ResultSet> execute(AK::NonnullRefPtr<Database> database, Span<Value const> placeholder_values = {}) const;
+    ResultOr<ResultSet> execute(AK::NonnullRefPtr<Database> database, ReadonlySpan<Value> placeholder_values = {}) const;
 
     virtual ResultOr<ResultSet> execute(ExecutionContext&) const
     {

--- a/Userland/Libraries/LibSQL/AST/Statement.cpp
+++ b/Userland/Libraries/LibSQL/AST/Statement.cpp
@@ -11,7 +11,7 @@
 
 namespace SQL::AST {
 
-ResultOr<ResultSet> Statement::execute(AK::NonnullRefPtr<Database> database, Span<Value const> placeholder_values) const
+ResultOr<ResultSet> Statement::execute(AK::NonnullRefPtr<Database> database, ReadonlySpan<Value> placeholder_values) const
 {
     ExecutionContext context { move(database), this, placeholder_values, nullptr };
     auto result = TRY(execute(context));

--- a/Userland/Libraries/LibTimeZone/TimeZone.cpp
+++ b/Userland/Libraries/LibTimeZone/TimeZone.cpp
@@ -141,7 +141,7 @@ ErrorOr<void> change_time_zone([[maybe_unused]] StringView time_zone)
 #endif
 }
 
-Span<StringView const> __attribute__((weak)) all_time_zones()
+ReadonlySpan<StringView> __attribute__((weak)) all_time_zones()
 {
 #if !ENABLE_TIME_ZONE_DATA
     static constexpr auto utc = Array { "UTC"sv };

--- a/Userland/Libraries/LibTimeZone/TimeZone.h
+++ b/Userland/Libraries/LibTimeZone/TimeZone.h
@@ -51,7 +51,7 @@ struct Location {
 StringView system_time_zone();
 StringView current_time_zone();
 ErrorOr<void> change_time_zone(StringView time_zone);
-Span<StringView const> all_time_zones();
+ReadonlySpan<StringView> all_time_zones();
 
 Optional<TimeZone> time_zone_from_string(StringView time_zone);
 StringView time_zone_to_string(TimeZone time_zone);

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -23,7 +23,7 @@ Optional<DeprecatedString> __attribute__((weak)) code_point_display_name(u32) { 
 Optional<StringView> __attribute__((weak)) code_point_block_display_name(u32) { return {}; }
 Optional<StringView> __attribute__((weak)) code_point_abbreviation(u32) { return {}; }
 u32 __attribute__((weak)) canonical_combining_class(u32) { return {}; }
-Span<BlockName const> __attribute__((weak)) block_display_names() { return {}; }
+ReadonlySpan<BlockName> __attribute__((weak)) block_display_names() { return {}; }
 
 u32 __attribute__((weak)) to_unicode_lowercase(u32 code_point)
 {

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -31,7 +31,7 @@ Optional<DeprecatedString> code_point_display_name(u32 code_point);
 Optional<StringView> code_point_block_display_name(u32 code_point);
 Optional<StringView> code_point_abbreviation(u32 code_point);
 
-Span<BlockName const> block_display_names();
+ReadonlySpan<BlockName> block_display_names();
 
 u32 canonical_combining_class(u32 code_point);
 

--- a/Userland/Libraries/LibUnicode/Emoji.cpp
+++ b/Userland/Libraries/LibUnicode/Emoji.cpp
@@ -8,6 +8,6 @@
 
 namespace Unicode {
 
-Optional<Emoji> __attribute__((weak)) find_emoji_for_code_points(Span<u32 const>) { return {}; }
+Optional<Emoji> __attribute__((weak)) find_emoji_for_code_points(ReadonlySpan<u32>) { return {}; }
 
 }

--- a/Userland/Libraries/LibUnicode/Emoji.h
+++ b/Userland/Libraries/LibUnicode/Emoji.h
@@ -34,15 +34,15 @@ struct Emoji {
     StringView name;
     EmojiGroup group { EmojiGroup::Unknown };
     u32 display_order { 0 };
-    Span<u32 const> code_points;
+    ReadonlySpan<u32> code_points;
 };
 
-Optional<Emoji> find_emoji_for_code_points(Span<u32 const> code_points);
+Optional<Emoji> find_emoji_for_code_points(ReadonlySpan<u32> code_points);
 
 template<size_t Size>
 Optional<Emoji> find_emoji_for_code_points(u32 const (&code_points)[Size])
 {
-    return find_emoji_for_code_points(Span<u32 const> { code_points });
+    return find_emoji_for_code_points(ReadonlySpan<u32> { code_points });
 }
 
 constexpr StringView emoji_group_to_string(EmojiGroup group)

--- a/Userland/Libraries/LibVT/EscapeSequenceParser.h
+++ b/Userland/Libraries/LibVT/EscapeSequenceParser.h
@@ -19,10 +19,10 @@ class EscapeSequenceExecutor {
 public:
     virtual ~EscapeSequenceExecutor() = default;
 
-    using Parameters = Span<unsigned const>;
-    using Intermediates = Span<u8 const>;
-    using OscParameter = Span<u8 const>;
-    using OscParameters = Span<OscParameter const>;
+    using Parameters = ReadonlySpan<unsigned>;
+    using Intermediates = ReadonlyBytes;
+    using OscParameter = ReadonlyBytes;
+    using OscParameters = ReadonlySpan<OscParameter>;
 
     virtual void emit_code_point(u32) = 0;
     virtual void execute_control_code(u8) = 0;

--- a/Userland/Libraries/LibWeb/CSS/BackdropFilter.h
+++ b/Userland/Libraries/LibWeb/CSS/BackdropFilter.h
@@ -25,7 +25,7 @@ public:
     bool has_filters() const { return m_filter_value_list; }
     bool is_none() const { return !has_filters(); }
 
-    Span<FilterFunction const> filters() const
+    ReadonlySpan<FilterFunction> filters() const
     {
         VERIFY(has_filters());
         return m_filter_value_list->filter_value_list().span();

--- a/Userland/Libraries/LibWeb/Painting/FilterPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/FilterPainting.cpp
@@ -19,7 +19,7 @@
 
 namespace Web::Painting {
 
-void apply_filter_list(Gfx::Bitmap& target_bitmap, Layout::Node const& node, Span<CSS::FilterFunction const> filter_list)
+void apply_filter_list(Gfx::Bitmap& target_bitmap, Layout::Node const& node, ReadonlySpan<CSS::FilterFunction> filter_list)
 {
     auto apply_color_filter = [&](Gfx::ColorFilter const& filter) {
         const_cast<Gfx::ColorFilter&>(filter).apply(target_bitmap, target_bitmap.rect(), target_bitmap, target_bitmap.rect());

--- a/Userland/Libraries/LibWeb/Painting/FilterPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/FilterPainting.h
@@ -12,7 +12,7 @@
 
 namespace Web::Painting {
 
-void apply_filter_list(Gfx::Bitmap& target_bitmap, Layout::Node const& node, Span<CSS::FilterFunction const> filter_list);
+void apply_filter_list(Gfx::Bitmap& target_bitmap, Layout::Node const& node, ReadonlySpan<CSS::FilterFunction> filter_list);
 
 void apply_backdrop_filter(PaintContext&, Layout::Node const&, CSSPixelRect const&, BorderRadiiData const&, CSS::BackdropFilter const&);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -107,7 +107,7 @@ void SVGPathElement::parse_attribute(DeprecatedFlyString const& name, Deprecated
     }
 }
 
-Gfx::Path path_from_path_instructions(Span<PathInstruction const> instructions)
+Gfx::Path path_from_path_instructions(ReadonlySpan<PathInstruction> instructions)
 {
     Gfx::Path path;
     Optional<Gfx::FloatPoint> previous_control_point;

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -32,6 +32,6 @@ private:
     Optional<Gfx::Path> m_path;
 };
 
-Gfx::Path path_from_path_instructions(Span<PathInstruction const>);
+Gfx::Path path_from_path_instructions(ReadonlySpan<PathInstruction>);
 
 }

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -21,7 +21,7 @@
 
 namespace Web::WebDriver {
 
-using Parameters = Span<StringView const>;
+using Parameters = ReadonlySpan<StringView>;
 
 class Client : public Core::Object {
     C_OBJECT_ABSTRACT(Client);

--- a/Userland/Services/WindowServer/HardwareScreenBackend.cpp
+++ b/Userland/Services/WindowServer/HardwareScreenBackend.cpp
@@ -152,7 +152,7 @@ void HardwareScreenBackend::set_head_buffer(int head_index)
     VERIFY(rc == 0);
 }
 
-ErrorOr<void> HardwareScreenBackend::flush_framebuffer_rects(int buffer_index, Span<FBRect const> flush_rects)
+ErrorOr<void> HardwareScreenBackend::flush_framebuffer_rects(int buffer_index, ReadonlySpan<FBRect> flush_rects)
 {
     int rc = fb_flush_buffers(m_display_connector_fd, buffer_index, flush_rects.data(), (unsigned)flush_rects.size());
     if (rc == -ENOTSUP)

--- a/Userland/Services/WindowServer/HardwareScreenBackend.h
+++ b/Userland/Services/WindowServer/HardwareScreenBackend.h
@@ -24,7 +24,7 @@ public:
 
     virtual void set_head_buffer(int index) override;
 
-    virtual ErrorOr<void> flush_framebuffer_rects(int buffer_index, Span<FBRect const> rects) override;
+    virtual ErrorOr<void> flush_framebuffer_rects(int buffer_index, ReadonlySpan<FBRect> rects) override;
 
     virtual ErrorOr<void> flush_framebuffer() override;
 

--- a/Userland/Services/WindowServer/ScreenBackend.h
+++ b/Userland/Services/WindowServer/ScreenBackend.h
@@ -27,7 +27,7 @@ public:
 
     virtual void set_head_buffer(int index) = 0;
 
-    virtual ErrorOr<void> flush_framebuffer_rects(int buffer_index, Span<FBRect const> rects) = 0;
+    virtual ErrorOr<void> flush_framebuffer_rects(int buffer_index, ReadonlySpan<FBRect> rects) = 0;
 
     virtual ErrorOr<void> unmap_framebuffer() = 0;
     virtual ErrorOr<void> map_framebuffer() = 0;

--- a/Userland/Services/WindowServer/VirtualScreenBackend.h
+++ b/Userland/Services/WindowServer/VirtualScreenBackend.h
@@ -27,7 +27,7 @@ private:
 
     virtual void set_head_buffer(int index) override;
 
-    virtual ErrorOr<void> flush_framebuffer_rects(int, Span<FBRect const>) override { return {}; }
+    virtual ErrorOr<void> flush_framebuffer_rects(int, ReadonlySpan<FBRect>) override { return {}; }
 
     virtual ErrorOr<void> flush_framebuffer() override { return {}; }
 


### PR DESCRIPTION
This adds `ReadonlySpan<T>` as an alias for `Span<T const>`, this was something brought up in #17309. 

With `Span<T const>` it's a little less clear that means underlying array is read-only, and the syntax is a little more awkward (and can easily be forgotten, as it has in places before). 

(Almost no functional changes, one tiny removal of some unnecessary mutation)