### PR TITLE
PixelPaint: Treat zero width/height selections as if they were empty

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/LassoSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LassoSelectTool.cpp
@@ -131,7 +131,12 @@ void LassoSelectTool::flood_lasso_selection(Gfx::Bitmap& lasso_bitmap, Gfx::IntP
     lasso_bitmap.flood_visit_from_point({ 0, 0 }, 0, move(pixel_reached));
 
     selection_mask.shrink_to_fit();
-    selection_mask.bounding_rect().translate_by(m_editor->active_layer()->location());
+
+    if (selection_mask.bounding_rect().width() == 1 && selection_mask.bounding_rect().height() == 1)
+        selection_mask = {};
+    else
+        selection_mask.bounding_rect().translate_by(m_editor->active_layer()->location());
+
     m_editor->image().selection().merge(selection_mask, m_merge_mode);
 }
 

--- a/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.cpp
@@ -33,6 +33,9 @@ void PolygonalSelectTool::flood_polygon_selection(Gfx::Bitmap& polygon_bitmap, G
     polygon_bitmap.flood_visit_from_point({ polygon_bitmap.width() - 1, polygon_bitmap.height() - 1 }, 0, move(pixel_reached));
 
     selection_mask.shrink_to_fit();
+    if (selection_mask.bounding_rect().width() == 1 && selection_mask.bounding_rect().height() == 1)
+        selection_mask = {};
+
     m_editor->image().selection().merge(selection_mask, m_merge_mode);
 }
 


### PR DESCRIPTION
The lasso and polygonal select tools mow treat selections with zero width or height as if they were empty. This has the effect of clearing the current selection in the "Add" merge mode, while having no effect on the current selection in the other merge modes.

This change also makes the lasso tool behave more reasonably when single clicking :^)

I've also included a drive by commit to change the lasso tool icon to the crosshair. This matches all the other selection tools. 