### PR TITLE
LibGUI: Base write_to_file(StringView path) on the stream overload

### DIFF
--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -79,7 +79,7 @@ void EditorWrapper::save()
         });
         file_picker_action->activate();
     }
-    editor().write_to_file(filename());
+    editor().write_to_file(filename()).release_value_but_fixme_should_propagate_errors();
     update_diff();
     editor().update();
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1458,15 +1458,11 @@ void TextEditor::timer_event(Core::TimerEvent&)
         update_cursor();
 }
 
-bool TextEditor::write_to_file(DeprecatedString const& path)
+ErrorOr<void> TextEditor::write_to_file(StringView path)
 {
-    auto file = Core::File::construct(path);
-    if (!file->open(Core::OpenMode::WriteOnly | Core::OpenMode::Truncate)) {
-        warnln("Error opening {}: {}", path, strerror(file->error()));
-        return false;
-    }
-
-    return write_to_file(*file);
+    auto file = TRY(Core::Stream::File::open(path, Core::Stream::OpenMode::Write | Core::Stream::OpenMode::Truncate));
+    TRY(write_to_file(*file));
+    return {};
 }
 
 bool TextEditor::write_to_file(Core::File& file)

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -129,7 +129,7 @@ public:
 
     void insert_at_cursor_or_replace_selection(StringView);
     void replace_all_text_without_resetting_undo_stack(StringView text);
-    bool write_to_file(DeprecatedString const& path);
+    ErrorOr<void> write_to_file(StringView path);
     bool write_to_file(Core::File&);
     ErrorOr<void> write_to_file(Core::Stream::File&);
     bool has_selection() const { return m_selection.is_valid(); }

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -130,7 +130,6 @@ public:
     void insert_at_cursor_or_replace_selection(StringView);
     void replace_all_text_without_resetting_undo_stack(StringView text);
     ErrorOr<void> write_to_file(StringView path);
-    bool write_to_file(Core::File&);
     ErrorOr<void> write_to_file(Core::Stream::File&);
     bool has_selection() const { return m_selection.is_valid(); }
     DeprecatedString selected_text() const;


### PR DESCRIPTION
`write_to_file(StringView path)` was based on the `Core::File` overload. The return type also changed from `bool` to `ErrorOr<void>` to ease error propagation.

There is probably an error in the saving logic of HackStudio, and `EditorWrapper::save()` is called twice. That's why the error is left as a FIXME instead of being shown.