### PR TITLE
LibGfx+icc: Implement half of lutAToBType and lutBToAType

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -580,6 +580,10 @@ ErrorOr<NonnullRefPtr<TagData>> Profile::read_tag(ReadonlyBytes bytes, u32 offse
         return Lut16TagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case Lut8TagData::Type:
         return Lut8TagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
+    case LutAToBTagData::Type:
+        return LutAToBTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
+    case LutBToATagData::Type:
+        return LutBToATagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case MultiLocalizedUnicodeTagData::Type:
         return MultiLocalizedUnicodeTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case NamedColor2TagData::Type:

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
@@ -332,13 +332,13 @@ ErrorOr<NonnullRefPtr<NamedColor2TagData>> NamedColor2TagData::from_bytes(Readon
     TRY(pcs_coordinates.try_resize(header.count_of_named_colors));
     TRY(device_coordinates.try_resize(header.count_of_named_colors * header.number_of_device_coordinates_of_each_named_color));
 
-    for (unsigned i = 0; i < header.count_of_named_colors; ++i) {
+    for (size_t i = 0; i < header.count_of_named_colors; ++i) {
         u8 const* root_name = bytes.data() + 8 + sizeof(NamedColorHeader) + i * record_byte_size;
         auto* components = bit_cast<BigEndian<u16> const*>(root_name + 32);
 
         root_names[i] = TRY(buffer_to_string(root_name));
         pcs_coordinates[i] = { { { components[0], components[1], components[2] } } };
-        for (unsigned j = 0; j < header.number_of_device_coordinates_of_each_named_color; ++j)
+        for (size_t j = 0; j < header.number_of_device_coordinates_of_each_named_color; ++j)
             device_coordinates[i * header.number_of_device_coordinates_of_each_named_color + j] = components[3 + j];
     }
 
@@ -384,7 +384,7 @@ ErrorOr<NonnullRefPtr<ParametricCurveTagData>> ParametricCurveTagData::from_byte
     auto* raw_parameters = bit_cast<BigEndian<s15Fixed16Number> const*>(bytes.data() + 12);
     Array<S15Fixed16, 7> parameters;
     parameters.fill(0);
-    for (unsigned i = 0; i < count; ++i)
+    for (size_t i = 0; i < count; ++i)
         parameters[i] = S15Fixed16::create_raw(raw_parameters[i]);
 
     return adopt_ref(*new ParametricCurveTagData(offset, size, function_type, move(parameters)));

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -165,6 +165,52 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             outln("    e = [ {}, {}, {},", e[0], e[1], e[2]);
             outln("          {}, {}, {},", e[3], e[4], e[5]);
             outln("          {}, {}, {} ]", e[6], e[7], e[8]);
+        } else if (tag_data->type() == Gfx::ICC::LutAToBTagData::Type) {
+            auto& a_to_b = static_cast<Gfx::ICC::LutAToBTagData&>(*tag_data);
+            outln("    {} input channels, {} output channels", a_to_b.number_of_input_channels(), a_to_b.number_of_output_channels());
+
+            if (auto const& optional_clut = a_to_b.clut(); optional_clut.has_value()) {
+                auto const& clut = optional_clut.value();
+                outln("    color lookup table: {} grid points, {}",
+                    MUST(String::join(" x "sv, clut.number_of_grid_points_in_dimension)),
+                    MUST(clut.values.visit(
+                        [](Vector<u8> const& v) { return String::formatted("{} u8 entries", v.size()); },
+                        [](Vector<u16> const& v) { return String::formatted("{} u16 entries", v.size()); })));
+            } else {
+                outln("    color lookup table: (not set)");
+            }
+
+            if (auto const& optional_e = a_to_b.e_matrix(); optional_e.has_value()) {
+                auto const& e = optional_e.value();
+                outln("    e = [ {}, {}, {}, {},", e[0], e[1], e[2], e[9]);
+                outln("          {}, {}, {}, {},", e[3], e[4], e[5], e[10]);
+                outln("          {}, {}, {}, {} ]", e[6], e[7], e[8], e[11]);
+            } else {
+                outln("    e = (not set)");
+            }
+        } else if (tag_data->type() == Gfx::ICC::LutBToATagData::Type) {
+            auto& b_to_a = static_cast<Gfx::ICC::LutBToATagData&>(*tag_data);
+            outln("    {} input channels, {} output channels", b_to_a.number_of_input_channels(), b_to_a.number_of_output_channels());
+
+            if (auto const& optional_e = b_to_a.e_matrix(); optional_e.has_value()) {
+                auto const& e = optional_e.value();
+                outln("    e = [ {}, {}, {}, {},", e[0], e[1], e[2], e[9]);
+                outln("          {}, {}, {}, {},", e[3], e[4], e[5], e[10]);
+                outln("          {}, {}, {}, {} ]", e[6], e[7], e[8], e[11]);
+            } else {
+                outln("    e = (not set)");
+            }
+
+            if (auto const& optional_clut = b_to_a.clut(); optional_clut.has_value()) {
+                auto const& clut = optional_clut.value();
+                outln("    color lookup table: {} grid points, {}",
+                    MUST(String::join(" x "sv, clut.number_of_grid_points_in_dimension)),
+                    MUST(clut.values.visit(
+                        [](Vector<u8> const& v) { return String::formatted("{} u8 entries", v.size()); },
+                        [](Vector<u16> const& v) { return String::formatted("{} u16 entries", v.size()); })));
+            } else {
+                outln("    color lookup table: (not set)");
+            }
         } else if (tag_data->type() == Gfx::ICC::MultiLocalizedUnicodeTagData::Type) {
             auto& multi_localized_unicode = static_cast<Gfx::ICC::MultiLocalizedUnicodeTagData&>(*tag_data);
             for (auto& record : multi_localized_unicode.records()) {


### PR DESCRIPTION
These are among the permitted tag types of ATo0Tag and BToA0Tag, which are among the required tags of most profiles. They are the last permitted tag types for those profiles (the other are lut8Type or lut16Type, which are already implemented).

They are pretty chonky types though, so this only implements support for the E matrix and the CLUT. Support for the various curves will be in a future PR.