### PR TITLE
Settings: Improve default window size

### DIFF
--- a/Userland/Applications/Settings/main.cpp
+++ b/Userland/Applications/Settings/main.cpp
@@ -91,7 +91,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::Window::try_create());
     window->set_title("Settings");
-    window->resize(324, 265);
+    window->resize(420, 210);
 
     auto file_menu = TRY(window->try_add_menu("&File"));
     file_menu->add_action(GUI::CommonActions::make_quit_action([&](auto&) {


### PR DESCRIPTION
Beforehand, one icon was hidden out of sight and there was a scrollbar.
This small fix displays two neat rows of five icons.

Before:
<img width="1136" alt="Settings Before" src="https://user-images.githubusercontent.com/7754483/217071560-fba43bc5-169e-4307-b17a-c3f91224b982.png">

After:
<img width="1136" alt="Settings After" src="https://user-images.githubusercontent.com/7754483/217071617-52ee3eef-8c1f-4a9a-91a5-88a819d0e097.png">