### PR TITLE
Meta: Automatically select best apt mirror

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,6 +45,12 @@ jobs:
 
       # === OS SETUP ===
 
+      # An attempt to avoid the (fairly common) azure apt mirror downtime.
+      - name: "Select best APT mirror"
+        run: |
+          sudo gem install apt-spy2
+          sudo apt-spy2 fix --commit --launchpad --country=US
+
       # Do we need to update the package cache first?
       # sudo apt-get update -qq
       - name: "Install Ubuntu dependencies"

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -45,6 +45,11 @@ jobs:
           repository: tc39/test262-parser-tests
           path: test262-parser-tests
 
+      - name: "Select best APT mirror"
+        run: |
+          sudo gem install apt-spy2
+          sudo apt-spy2 fix --commit --launchpad --country=US
+
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/pvs-studio-static-analysis.yml
+++ b/.github/workflows/pvs-studio-static-analysis.yml
@@ -19,6 +19,11 @@ jobs:
           wget -q -O - https://files.pvs-studio.com/beta/etc/pubkey.txt | sudo apt-key add -
           sudo wget -O /etc/apt/sources.list.d/viva64.list https://files.pvs-studio.com/beta/etc/viva64.list
 
+      - name: "Select best APT mirror"
+        run: |
+          sudo gem install apt-spy2
+          sudo apt-spy2 fix --commit --launchpad --country=US
+
       - name: "Install Ubuntu dependencies"
         # These packages are already part of the ubuntu-22.04 image:
         # cmake libgmp-dev npm shellcheck

--- a/.github/workflows/serenity-js-artifacts.yml
+++ b/.github/workflows/serenity-js-artifacts.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Checkout SerenityOS/serenity
         uses: actions/checkout@v3
 
+      - name: "Select best APT mirror"
+        run: |
+          sudo gem install apt-spy2
+          sudo apt-spy2 fix --commit --launchpad --country=US
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
+
       - name: Install dependencies Ubuntu
         run: |
           sudo apt-get update

--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -53,6 +53,11 @@ jobs:
       # === OS SETUP ===
       # TODO: Is there someway to share these steps with the cmake.yml?
 
+      - name: "Select best APT mirror"
+        run: |
+          sudo gem install apt-spy2
+          sudo apt-spy2 fix --commit --launchpad --country=US
+
       - name: "Install Ubuntu dependencies"
         # These packages are already part of the ubuntu-22.04 image:
         # cmake libgmp-dev npm shellcheck

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -17,6 +17,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: "Select best APT mirror"
+        run: |
+          sudo gem install apt-spy2
+          sudo apt-spy2 fix --commit --launchpad --country=US
       - name: "Install Ubuntu dependencies"
         run: |
           sudo apt-get update

--- a/Meta/Azure/Setup.yml
+++ b/Meta/Azure/Setup.yml
@@ -5,6 +5,12 @@ steps:
   - checkout: self
     persistCredentials: true
 
+  - ${{ if in(parameters.os, 'Linux', 'Serenity', 'Android') }}:
+    - script: |
+        sudo gem install apt-spy2
+        sudo apt-spy2 fix --commit --launchpad --country=US
+      displayName: 'Select best APT mirror'
+
   - ${{ if eq(parameters.os, 'Serenity') }}:
     - script: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -


### PR DESCRIPTION
This is an attempt to avoid issues with the azure ubuntu apt mirror by using `apt-spy2` to select the best mirror before installing dependencies.
