### PR TITLE
Piano: Fix creation of PlayerWidget, drawing of wave form and removing of notes

### DIFF
--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -41,6 +41,7 @@ ErrorOr<void> MainWidget::initialize()
 
     m_wave_widget = TRY(try_add<WaveWidget>(m_track_manager));
     m_wave_widget->set_fixed_height(100);
+    TRY(m_wave_widget->set_sample_size(sample_count));
 
     m_tab_widget = TRY(try_add<GUI::TabWidget>());
     m_roll_widget = TRY(m_tab_widget->try_add_tab<RollWidget>(TRY("Piano Roll"_string), m_track_manager));

--- a/Userland/Applications/Piano/Music.h
+++ b/Userland/Applications/Piano/Music.h
@@ -19,11 +19,6 @@ namespace Music {
 // - 44,100 samples/sec
 // - 1,411.2 kbps
 
-struct Sample {
-    i16 left;
-    i16 right;
-};
-
 constexpr int sample_count = Audio::AUDIO_BUFFER_SIZE * 10;
 
 constexpr double sample_rate = 44100;

--- a/Userland/Applications/Piano/WaveWidget.cpp
+++ b/Userland/Applications/Piano/WaveWidget.cpp
@@ -36,20 +36,19 @@ void WaveWidget::paint_event(GUI::PaintEvent& event)
 
     Color left_wave_color = left_wave_colors[m_track_manager.current_track()->synth()->wave()];
     Color right_wave_color = right_wave_colors[m_track_manager.current_track()->synth()->wave()];
-    // FIXME: We can't get the last buffer from the track manager anymore
-    auto buffer = FixedArray<Audio::Sample>::must_create_but_fixme_should_propagate_errors(sample_count);
-    double width_scale = static_cast<double>(frame_inner_rect().width()) / buffer.size();
+    m_track_manager.current_track()->write_cached_signal_to(m_samples.span());
+    double width_scale = static_cast<double>(frame_inner_rect().width()) / m_samples.size();
 
-    auto const maximum = Audio::Sample::max_range(buffer.span());
+    auto const maximum = Audio::Sample::max_range(m_samples.span());
     int prev_x = 0;
-    int prev_y_left = sample_to_y(buffer[0].left, maximum.left);
-    int prev_y_right = sample_to_y(buffer[0].right, maximum.right);
+    int prev_y_left = sample_to_y(m_samples[0].left, maximum.left);
+    int prev_y_right = sample_to_y(m_samples[0].right, maximum.right);
     painter.set_pixel({ prev_x, prev_y_left }, left_wave_color);
     painter.set_pixel({ prev_x, prev_y_right }, right_wave_color);
 
-    for (size_t x = 1; x < buffer.size(); ++x) {
-        int y_left = sample_to_y(buffer[x].left, maximum.left);
-        int y_right = sample_to_y(buffer[x].right, maximum.right);
+    for (size_t x = 1; x < m_samples.size(); ++x) {
+        int y_left = sample_to_y(m_samples[x].left, maximum.left);
+        int y_right = sample_to_y(m_samples[x].right, maximum.right);
 
         Gfx::IntPoint point1_left(prev_x * width_scale, prev_y_left);
         Gfx::IntPoint point2_left(x * width_scale, y_left);

--- a/Userland/Applications/Piano/WaveWidget.cpp
+++ b/Userland/Applications/Piano/WaveWidget.cpp
@@ -9,6 +9,7 @@
 #include "WaveWidget.h"
 #include "TrackManager.h"
 #include <AK/NumericLimits.h>
+#include <AK/StdLibExtras.h>
 #include <LibGUI/Painter.h>
 
 WaveWidget::WaveWidget(TrackManager& track_manager)
@@ -16,12 +17,12 @@ WaveWidget::WaveWidget(TrackManager& track_manager)
 {
 }
 
-int WaveWidget::sample_to_y(int sample) const
+int WaveWidget::sample_to_y(float sample, float sample_max) const
 {
-    // Sample scaling that looks good, experimentally determined.
-    constexpr double nice_scale_factor = 1.0;
-    constexpr double sample_max = NumericLimits<i16>::max();
-    double percentage = sample / sample_max * nice_scale_factor;
+    if (sample_max < 1.0f)
+        sample_max = 1.0f;
+    sample_max *= rescale_factor;
+    double percentage = static_cast<double>(sample) / static_cast<double>(sample_max);
     double portion_of_half_height = percentage * ((frame_inner_rect().height() - 1) / 2.0);
     double y = (frame_inner_rect().height() / 2.0) + portion_of_half_height;
     return y;
@@ -36,18 +37,19 @@ void WaveWidget::paint_event(GUI::PaintEvent& event)
     Color left_wave_color = left_wave_colors[m_track_manager.current_track()->synth()->wave()];
     Color right_wave_color = right_wave_colors[m_track_manager.current_track()->synth()->wave()];
     // FIXME: We can't get the last buffer from the track manager anymore
-    auto buffer = FixedArray<Music::Sample>::must_create_but_fixme_should_propagate_errors(sample_count);
+    auto buffer = FixedArray<Audio::Sample>::must_create_but_fixme_should_propagate_errors(sample_count);
     double width_scale = static_cast<double>(frame_inner_rect().width()) / buffer.size();
 
+    auto const maximum = Audio::Sample::max_range(buffer.span());
     int prev_x = 0;
-    int prev_y_left = sample_to_y(buffer[0].left);
-    int prev_y_right = sample_to_y(buffer[0].right);
+    int prev_y_left = sample_to_y(buffer[0].left, maximum.left);
+    int prev_y_right = sample_to_y(buffer[0].right, maximum.right);
     painter.set_pixel({ prev_x, prev_y_left }, left_wave_color);
     painter.set_pixel({ prev_x, prev_y_right }, right_wave_color);
 
     for (size_t x = 1; x < buffer.size(); ++x) {
-        int y_left = sample_to_y(buffer[x].left);
-        int y_right = sample_to_y(buffer[x].right);
+        int y_left = sample_to_y(buffer[x].left, maximum.left);
+        int y_right = sample_to_y(buffer[x].right, maximum.right);
 
         Gfx::IntPoint point1_left(prev_x * width_scale, prev_y_left);
         Gfx::IntPoint point2_left(x * width_scale, y_left);

--- a/Userland/Applications/Piano/WaveWidget.h
+++ b/Userland/Applications/Piano/WaveWidget.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <LibAudio/Sample.h>
 #include <LibGUI/Frame.h>
 
 class TrackManager;
@@ -18,11 +19,14 @@ public:
     virtual ~WaveWidget() override = default;
 
 private:
+    // Scales the sample-y value down by a bit, so that it doesn't look like it is clipping.
+    static constexpr float rescale_factor = 1.2f;
+
     explicit WaveWidget(TrackManager&);
 
     virtual void paint_event(GUI::PaintEvent&) override;
 
-    int sample_to_y(int sample) const;
+    int sample_to_y(float sample, float sample_max) const;
 
     TrackManager& m_track_manager;
 };

--- a/Userland/Applications/Piano/WaveWidget.h
+++ b/Userland/Applications/Piano/WaveWidget.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AK/FixedArray.h>
 #include <LibAudio/Sample.h>
 #include <LibGUI/Frame.h>
 
@@ -17,6 +18,12 @@ class WaveWidget final : public GUI::Frame {
     C_OBJECT(WaveWidget)
 public:
     virtual ~WaveWidget() override = default;
+
+    ErrorOr<void> set_sample_size(size_t sample_size)
+    {
+        TRY(m_samples.try_resize(sample_size));
+        return {};
+    }
 
 private:
     // Scales the sample-y value down by a bit, so that it doesn't look like it is clipping.
@@ -29,4 +36,5 @@ private:
     int sample_to_y(float sample, float sample_max) const;
 
     TrackManager& m_track_manager;
+    Vector<Audio::Sample> m_samples;
 };

--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -38,6 +38,19 @@ struct Sample {
     {
     }
 
+    // Returns the absolute maximum range (separate per channel) of the given sample buffer.
+    // For example { 0.8, 0 } means that samples on the left channel occupy the range { -0.8, 0.8 },
+    // while all samples on the right channel are 0.
+    static Sample max_range(ReadonlySpan<Sample> span)
+    {
+        Sample result { NumericLimits<float>::min_normal(), NumericLimits<float>::min_normal() };
+        for (Sample sample : span) {
+            result.left = max(result.left, AK::fabs(sample.left));
+            result.right = max(result.right, AK::fabs(sample.right));
+        }
+        return result;
+    }
+
     void clip()
     {
         if (left > 1)

--- a/Userland/Libraries/LibDSP/Track.h
+++ b/Userland/Libraries/LibDSP/Track.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/DisjointChunks.h>
+#include <AK/FixedArray.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/Weakable.h>
@@ -30,6 +31,8 @@ public:
 
     // Creates the current signal of the track by processing current note or audio data through the processing chain.
     void current_signal(FixedArray<Sample>& output_signal);
+
+    void write_cached_signal_to(Span<Sample> output_signal);
 
     // We are informed of an audio buffer size change. This happens off-audio-thread so we can allocate.
     ErrorOr<void> resize_internal_buffers_to(size_t buffer_size);
@@ -66,6 +69,11 @@ protected:
     Signal m_secondary_sample_buffer { FixedArray<Sample> {} };
     // A note buffer possibly used by the processor chain.
     Signal m_secondary_note_buffer { RollNotes {} };
+
+private:
+    Atomic<bool> m_sample_lock;
+
+    FixedArray<Sample> m_cached_sample_buffer = {};
 };
 
 class NoteTrack final : public Track {


### PR DESCRIPTION
It did not call `PlayerWidget.initialize()` which caused a crash every time a new track was added. Additionally the wave form could not be drawn anymore since the logic was moved to LibDSP. And lastly it wasn't possible to remove any notes as the clicked mouse button is not available within `mousemove_event`.