### PR TITLE
LibGUI: Add a simple "recently open files" feature

### DIFF
--- a/Userland/Applications/ImageViewer/CMakeLists.txt
+++ b/Userland/Applications/ImageViewer/CMakeLists.txt
@@ -12,4 +12,4 @@ set(SOURCES
 )
 
 serenity_app(ImageViewer ICON filetype-image)
-target_link_libraries(ImageViewer PRIVATE LibCore LibDesktop LibGUI LibGfx LibImageDecoderClient LibMain)
+target_link_libraries(ImageViewer PRIVATE LibCore LibDesktop LibGUI LibGfx LibConfig LibImageDecoderClient LibMain)

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -16,6 +16,7 @@
 #include <LibCore/MappedFile.h>
 #include <LibCore/MimeData.h>
 #include <LibCore/Timer.h>
+#include <LibGUI/Application.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Orientation.h>
@@ -196,6 +197,7 @@ void ViewWidget::load_from_file(DeprecatedString const& path)
     }
 
     m_path = Core::DeprecatedFile::real_path_for(path);
+    GUI::Application::the()->set_most_recently_open_file(String::from_utf8(path).release_value_but_fixme_should_propagate_errors());
     reset_view();
 }
 

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -24,6 +24,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("TextEditor");
 
+    app->set_config_domain(TRY(String::from_utf8("TextEditor"sv)));
+
     auto preview_mode = "auto"sv;
     char const* file_to_edit = nullptr;
     Core::ArgsParser parser;

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -9,6 +9,7 @@
 #include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
+#include <AK/String.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Object.h>
@@ -87,6 +88,14 @@ public:
 
     auto const& global_shortcut_actions(Badge<GUI::CommandPalette>) const { return m_global_shortcut_actions; }
 
+    static constexpr size_t max_recently_open_files() { return 4; }
+
+    void set_config_domain(String);
+    void update_recent_file_actions();
+    void set_most_recently_open_file(String path);
+
+    void register_recent_file_actions(Badge<GUI::Menu>, Vector<NonnullRefPtr<GUI::Action>>);
+
 private:
     Application(int argc, char** argv, Core::EventLoop::MakeInspectable = Core::EventLoop::MakeInspectable::No);
     Application(Main::Arguments const& arguments, Core::EventLoop::MakeInspectable inspectable = Core::EventLoop::MakeInspectable::No)
@@ -120,6 +129,9 @@ private:
     Vector<DeprecatedString> m_args;
     WeakPtr<Widget> m_drag_hovered_widget;
     WeakPtr<Widget> m_pending_drop_widget;
+
+    String m_config_domain;
+    Vector<NonnullRefPtr<GUI::Action>> m_recent_file_actions;
 };
 
 }

--- a/Userland/Libraries/LibGUI/Menu.h
+++ b/Userland/Libraries/LibGUI/Menu.h
@@ -48,6 +48,8 @@ public:
     Menu& add_submenu(DeprecatedString name);
     void remove_all_actions();
 
+    ErrorOr<void> add_recent_files_list(Function<void(Action&)>);
+
     void popup(Gfx::IntPoint screen_position, RefPtr<Action> const& default_action = nullptr, Gfx::IntRect const& button_rect = {});
     void dismiss();
 
@@ -78,6 +80,8 @@ private:
     NonnullOwnPtrVector<MenuItem> m_items;
     WeakPtr<Action> m_current_default_action;
     bool m_visible { false };
+
+    Function<void(Action&)> m_recent_files_callback;
 };
 
 }


### PR DESCRIPTION
This feature allows any application to easily install an automatically
updating list of recently open files in a GUI::Menu.

There are three main pieces to this mechanism:

- GUI::Application::set_config_domain(domain): This must be called
  before using the recent files feature. It informs the Application
  object about which config domain to find the relevant RecentFiles
  list under.

- GUI::Menu::add_recently_open_files(callback): This inserts the list
  in a menu. A callback must be provided to handle actually opening
  the recent file in some application-specific way.

- GUI::Application::set_most_recently_open_file(path): This updates
  the list of recently open files, both in the configuration files,
  and in the GUI menu.

The PR also adds "recently open files" sections to the TextEditor and ImageViewer applications.