### PR TITLE
LibGfx+icc: Read namedColor2Type

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -580,6 +580,8 @@ ErrorOr<NonnullRefPtr<TagData>> Profile::read_tag(ReadonlyBytes bytes, u32 offse
         return Lut8TagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case MultiLocalizedUnicodeTagData::Type:
         return MultiLocalizedUnicodeTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
+    case NamedColor2TagData::Type:
+        return NamedColor2TagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case ParametricCurveTagData::Type:
         return ParametricCurveTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case S15Fixed16ArrayTagData::Type:
@@ -1137,7 +1139,14 @@ ErrorOr<void> Profile::check_tag_types()
 
     // ICC v4, 9.2.37 namedColor2Tag
     // "Permitted tag types: namedColor2Type"
-    // FIXME
+    if (auto type = m_tag_table.get(namedColor2Tag); type.has_value()) {
+        if (type.value()->type() != NamedColor2TagData::Type)
+            return Error::from_string_literal("ICC::Profile: namedColor2Tag has unexpected type");
+        // ICC v4, 10.17 namedColor2Type
+        // "The device representation corresponds to the header’s “data colour space” field.
+        //  This representation should be consistent with the “number of device coordinates” field in the namedColor2Type."
+        // FIXME: check that
+    }
 
     // ICC v4, 9.2.38 outputResponseTag
     // "Permitted tag types: responseCurveSet16Type"

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -163,6 +163,26 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     record.iso_3166_1_country_code >> 8, record.iso_3166_1_country_code & 0xff,
                     record.text);
             }
+        } else if (tag_data->type() == Gfx::ICC::NamedColor2TagData::Type) {
+            auto& named_colors = static_cast<Gfx::ICC::NamedColor2TagData&>(*tag_data);
+            outln("    vendor specific flag: 0x{:08x}", named_colors.vendor_specific_flag());
+            outln("    common name prefix: \"{}\"", named_colors.prefix());
+            outln("    common name suffix: \"{}\"", named_colors.suffix());
+            outln("    {} colors:", named_colors.size());
+            for (size_t i = 0; i < min(named_colors.size(), 5u); ++i) {
+                const auto& pcs = named_colors.pcs_coordinates(i);
+
+                // FIXME: Display decoded values? (See ICC v4 6.3.4.2 and 10.8.)
+                out("        \"{}\", PCS coordinates: 0x{:04x} 0x{:04x} 0x{:04x}", MUST(named_colors.color_name(i)), pcs.xyz.x, pcs.xyz.y, pcs.xyz.z);
+                if (auto number_of_device_coordinates = named_colors.number_of_device_coordinates(); number_of_device_coordinates > 0) {
+                    out(", device coordinates:");
+                    for (size_t j = 0; j < number_of_device_coordinates; ++j)
+                        out(" 0x{:04x}", named_colors.device_coordinates(i)[j]);
+                }
+                outln();
+            }
+            if (named_colors.size() > 5u)
+                outln("        ...");
         } else if (tag_data->type() == Gfx::ICC::ParametricCurveTagData::Type) {
             auto& parametric_curve = static_cast<Gfx::ICC::ParametricCurveTagData&>(*tag_data);
             switch (parametric_curve.function_type()) {


### PR DESCRIPTION
This is the type of namedColor2Tag, which is a required tag in NamedColor profiles.

The implementation is pretty basic for now and only exposes the numbers stored in the file directly (after endian conversion).