### PR TITLE
PixelPaint: Use image coordinates for bucket tool bounds checking

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
@@ -50,7 +50,7 @@ void BucketTool::on_mousedown(Layer* layer, MouseEvent& event)
     if (!layer->rect().contains(layer_event.position()))
         return;
 
-    if (auto selection = layer->image().selection(); !selection.is_empty() && !selection.is_selected(layer_event.position()))
+    if (auto selection = layer->image().selection(); !selection.is_empty() && !selection.is_selected(event.image_event().position()))
         return;
 
     GUI::Painter painter(layer->get_scratch_edited_bitmap());


### PR DESCRIPTION
This is a fix for a bug I introduced in #16526. 

Layer coordinates were being used to check whether the bucket tool was within the bounds of the current selection, rather than image coordinates. This produces the wrong result when the active layer and the image are different sizes.

Sorry this took me so long to spot :^)